### PR TITLE
DM-5638: file upload should display feedback while it's busy uploading.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
@@ -316,15 +316,19 @@ public class FileUtil
 
 
     public static String readFile(File file) throws IOException {
-        DataInputStream in=null;
-        DataOutputStream out=null;
         if (!file.canRead()) {
             throw new IOException("Cannot read file");
         }
-        ByteArrayOutputStream byteAry= new ByteArrayOutputStream( (int)file.length()+200);
+        return readFile(new FileInputStream(file));
+    }
+
+    public static String readFile(InputStream inStream) throws IOException {
+        DataInputStream in=null;
+        DataOutputStream out=null;
+        ByteArrayOutputStream byteAry= new ByteArrayOutputStream();
 
         try {
-            in=new DataInputStream(new BufferedInputStream( new FileInputStream(file), BUFFER_SIZE));
+            in=new DataInputStream(new BufferedInputStream( inStream, BUFFER_SIZE));
             out=new DataOutputStream(byteAry);
 
             byte[] buffer = new byte[BUFFER_SIZE];
@@ -340,7 +344,6 @@ public class FileUtil
         }
         return byteAry.toString();
     }
-
 
 
     public static boolean writeStringToFile(File f, String s) {

--- a/src/firefly/js/fieldGroup/FieldGroupUtils.js
+++ b/src/firefly/js/fieldGroup/FieldGroupUtils.js
@@ -35,7 +35,7 @@ var validateSingle= function(groupKey, includeUnmounted) {
             if (typeof newValue=== 'object' && // check to see if return is an object that includes {value: any} and not a promise
                 !newValue.then &&
                 newValue.hasOwnProperty('value') ) {
-                dispatchValueChange(Object.assign({fieldKey:key,groupKey},newValue));
+                dispatchValueChange(Object.assign({valid:true,fieldKey:key,groupKey},newValue));
             }
             else {
                 dispatchValueChange({fieldKey:key,groupKey,valid:true,value:newValue});

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -1,4 +1,5 @@
 // import React, {PropTypes} from 'react';
+import React, {PropTypes} from 'react';
 import {get} from 'lodash';
 
 import {InputFieldView} from './InputFieldView.jsx';
@@ -6,51 +7,91 @@ import {fieldGroupConnector} from './FieldGroupConnector.jsx';
 import {fetchUrl} from '../util/WebUtil.js';
 import {getRootPath} from '../util/BrowserUtil.js';
 
+import LOADING from 'html/images/gxt/loading.gif';
 const UL_URL = getRootPath() + 'sticky/Firefly_FileUpload';
+
+
+function FileUploadView({fileType, isLoading, label, valid, wrapperStyle, message, onChange, value}) {
+    return (
+        <div>
+            <InputFieldView
+                valid = {valid}
+                visible = {true}
+                message = {message}
+                onChange = {onChange}
+                type = 'file'
+                label = {label}
+                value = {value}
+                tooltip = {value}
+                labelWidth = {0}
+                inline={true}
+                style = {{border: 'none', background: 'none'}}
+                wrapperStyle = {wrapperStyle}
+            />
+            {isLoading && <img style={{position: 'inline-block', width:14,height:14}} src={LOADING}/> }
+        </div>
+    );
+}
+
+
+FileUploadView.propTypes = {
+    fileType   : PropTypes.string.isRequired,
+    isLoading: PropTypes.bool.isRequired,
+    message: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    value : PropTypes.string.isRequired
+};
+
+FileUploadView.defaultProps = {
+    fileType: 'TABLE',
+    isLoading: false
+};
+
+export const FileUpload = fieldGroupConnector(FileUploadView, getProps);
+
+
+
+
+/*---------------------------- private ----------------------------*/
 
 function getProps(params, fireValueChange) {
     return Object.assign({}, params,
         {
-            message: params.message,
             value: params.displayValue,
-            type: 'file',
-            style: {border: 'none', background: 'none'},
-            labelWidth: 0,
-            onChange: (ev) => handleChange(ev, fireValueChange)
+            onChange: (ev) => handleChange(ev, fireValueChange, params.fileType)
         });
 }
 
-function handleChange(ev, fireValueChange) {
+function handleChange(ev, fireValueChange, type) {
     var file = get(ev, 'target.files.0');
     var displayValue = get(ev, 'target.value');
 
     fireValueChange({
         displayValue,
-        value: makeDoUpload(file, displayValue)
+        value: makeDoUpload(file, type)
     });
 }
 
-function makeDoUpload(file) {
+function makeDoUpload(file, type) {
     const options = {
         method: 'post',
-        params: {file}
+        params: {type, file}     // file should be the last param due to AnyFileUpload limitation
     };
     return () => {
-        return fetchUrl(UL_URL, options).then( (response) => {
-            return response.text().then( (text) => {
-                // text is in format ${status}::${message}::${cacheKey}
-                const resp =  text.split('::');
-                const valid = get(resp, [0]) === '200';
-                const message = get(resp, [1]);
-                const value = get(resp, [2]);
-                return {valid, message, value};
-            });
-        }).catch(function(err) {
-            return { valid: false, message: `Unable to upload file: ${get(file, 'name')}`};
-        });
+        return {
+            isLoading: true,
+            value : fetchUrl(UL_URL, options).then( (response) => {
+                return response.text().then( (text) => {
+                    // text is in format ${status}::${message}::${cacheKey}
+                    const resp =  text.split('::');
+                    const valid = get(resp, [0]) === '200';
+                    const message = get(resp, [1]);
+                    const value = get(resp, [2]);
+                    return {isLoading: false, valid, message, value};
+                });
+            }).catch(function(err) {
+                return { isLoading: false, valid: false, message: `Unable to upload file: ${get(file, 'name')}`};
+            })
+        };
     };
 }
-
-
-export const FileUpload = fieldGroupConnector(InputFieldView, getProps);
-

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -54,9 +54,8 @@ export const SearchPanel = (props) => {
                     />
 
                     <FileUpload
-                        wrapperStyle={{margin: '5px 0'}}
-                        fieldKey='fileUpload'
-                        upload_url='sdlfjslf'
+                        wrapperStyle = {{margin: '5px 0'}}
+                        fieldKey = 'fileUpload'
                         initialState= {{
                         tooltip: 'Select a file to upload',
                         label: 'Upload File:'}}

--- a/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
@@ -134,7 +134,6 @@ export const panelCatalogs = [
         },
         'upload': {
             'Title': '',
-            'url': 'sdlfjslf'
         },
         'list': {
             'Title': 'If file contains multiple extensions:',


### PR DESCRIPTION
While file is being uploaded, a spinning icon will appears on the right end of the file to indicate it is busy uploading.  This should happen right after you submit the form.

This pull request also fixes the problem where fits file are different once uploaded onto the server.
The upload files will be stored at: /hydra/workarea/fftools/visualize/fits-cache/upload_*