### PR TITLE
DM-5800 Tab titles need to shrink to accommodate long names

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -107,9 +107,8 @@ img, html {
 
 .disable-select {
     -moz-user-select : none;
-    -khtml-user-select : none;
+    -ms-user-select : none;
     -webkit-user-select : none;
-    -o-user-select :  none;
     user-select :  none;
 }
 
@@ -308,6 +307,14 @@ img, html {
     animation-duration: 2s;
     animation-iteration-count: infinite;
     animation-timing-function: linear;
-    filter: drop-shadow(0 0 2 rgba(0, 0, 0, 0.33));
+    filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.33));
 }
 /*------------------- loading mask ---------------------*/
+
+
+.text-ellipsis {
+    display: inline-block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}

--- a/src/firefly/js/ui/panel/TabPanel.css
+++ b/src/firefly/js/ui/panel/TabPanel.css
@@ -20,6 +20,8 @@
     \-moz-border-radius-topleft: 5px;
     \-webkit-border-top-left-radius: 5px;
     border-top-left-radius: 5px;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .TabPanel__Tab--selected {
@@ -45,3 +47,9 @@
     display: flex;
 }
 
+.ellipsis {
+    display: inline-block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}

--- a/src/firefly/js/ui/panel/TabPanel.css
+++ b/src/firefly/js/ui/panel/TabPanel.css
@@ -47,9 +47,3 @@
     display: flex;
 }
 
-.ellipsis {
-    display: inline-block;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-}

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -100,7 +100,7 @@ export class Tabs extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        this.state= Object.assign(tabsStateFromProps(nextProps));
+        this.state= tabsStateFromProps(nextProps);
     }
     
     shouldComponentUpdate(np, ns) {
@@ -188,7 +188,7 @@ export class Tab extends Component {
 
         return (
             <li className={tabClassName}>
-                <div className='ellipsis' title={name} onClick={() => onSelect(id,name)}>
+                <div className='text-ellipsis' title={name} onClick={() => onSelect(id,name)}>
                      {name}
                 </div>
                 {removable &&

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -4,6 +4,7 @@
 
 import './TabPanel.css';
 import React, {Component, PropTypes} from 'react';
+import ReactDOM from 'react-dom';
 import sCompare from 'react-addons-shallow-compare';
 import Resizable from 'react-component-resizable';
 import {debounce} from 'lodash';
@@ -27,27 +28,84 @@ function tabsStateFromProps(props) {
     return {selectedIdx};
 }
 
+
+function adjustTabsWidth(c) {
+    const el = ReactDOM.findDOMNode(c); //DOMElement
+    // el is <ul>, it's children are <li> for tabs, gradchildren <div> for name and <div> for close button
+    if (el && el.childNodes && el.childNodes.length>0) {
+        var i;
+        const numTabs = el.childNodes.length;
+
+        // 2*5px - border, 6px - left margin
+        const availableWidth = el.offsetWidth-10-6*numTabs;
+
+        let totalNameLengthPx = 0;
+        for (i=0; i<el.childNodes.length; i++) {
+            // name div is el.childNodes[i].childNodes[0] or el.childNodes[i].querySelector('.ellipsis')
+            totalNameLengthPx += el.childNodes[i].childNodes[0].scrollWidth;
+        }
+        for (i=0; i<el.childNodes.length; i++) {
+            const nameDivEl = el.childNodes[i].childNodes[0];
+            const nameLengthPx = nameDivEl.scrollWidth;
+            const maxTabWidth = availableWidth*nameLengthPx/totalNameLengthPx;
+            const maxNameWidth = maxTabWidth - (el.childNodes[i].offsetWidth-nameDivEl.offsetWidth);
+            // set the width of the tab
+            el.childNodes[i].style.maxWidth = Math.trunc(maxTabWidth)+'px';
+            // set the width of the name div
+            nameDivEl.style.maxWidth = Math.trunc(maxNameWidth)+'px';
+        }
+    }
+}
+
+class TabsHeader extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+        this.onResize = debounce((size) => {
+            if (size && size.width !== this.state.widthPx) {
+                this.setState({widthPx: size.width});
+            }
+        }, 100);
+
+        this.adjustTabsWidth = ((c) => {
+            // update only when size is available
+            this.state.widthPx && adjustTabsWidth(c);
+        }).bind(this);
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+    render() {
+        return (
+            <div style={{flexGrow: 0, height: 18}}>
+                <Resizable id='tabs-resizer' style={{position: 'relative', width: '100%', height: '100%', overflow: 'hidden'}} onResize={this.onResize}>
+                    <ul className='TabPanel__Tabs'
+                        ref={(c)=>{this.adjustTabsWidth(c);}}>
+                        {this.props.children}
+                    </ul>
+                </Resizable>
+            </div>
+        );
+    }
+}
+
 export class Tabs extends Component {
 
 
     constructor(props) {
         super(props);
         this.state= tabsStateFromProps(props);
-        this.onResize = debounce((size) => {
-            if (size) {
-                this.setState({widthPx: size.width});
-            }
-        }, 100);
     }
 
     componentWillReceiveProps(nextProps) {
-        this.state= Object.assign({widthPx:this.state.widthPx}, tabsStateFromProps(nextProps));
+        this.state= Object.assign(tabsStateFromProps(nextProps));
     }
     
     shouldComponentUpdate(np, ns) {
         return sCompare(this, np, ns);
     }
-
 
     onSelect(index,id,name) {
         const {onTabSelect, componentKey} = this.props;
@@ -65,33 +123,26 @@ export class Tabs extends Component {
     }
 
     render () {
-        var { selectedIdx, widthPx}= this.state;
-        const numTabs = this.props.children.length;
-        const maxTabWidth = widthPx && numTabs && Math.trunc(widthPx/numTabs-20);
+        var { selectedIdx}= this.state;
+        const origChildren = this.props.children;
+        const numTabs = React.Children.count(origChildren);
 
         var content;
         selectedIdx = Math.min(selectedIdx, numTabs-1);
-        var children = React.Children.map(this.props.children, (child, index) => {
+        var children = React.Children.map(origChildren, (child, index) => {
                 if (index === selectedIdx) {
                     content = React.Children.only(child.props.children);
                 }
 
                 return React.cloneElement(child, {
-                    maxTabWidth,
                     selected: (index == selectedIdx),
                     onSelect: this.onSelect.bind(this, index),
-                    ref: 'tab-' + (index++)
+                    ref: 'tab-' + (index)
                 });
             });
         return (
             <div style={{display: 'flex', flexDirection: 'column', flexGrow: 1, overflow: 'hidden'}}>
-                <div style={{flexGrow: 0, height: 18}}>
-                    <Resizable id='tabs-resizer' style={{position: 'relative', width: '100%', height: '100%', overflow: 'hidden'}} onResize={this.onResize}>
-                        <ul className='TabPanel__Tabs'>
-                            {children}
-                        </ul>
-                    </Resizable>
-                </div>
+                <TabsHeader>{children}</TabsHeader>
                 <div ref='contentRef' className='TabPanel__Content'>{(content)?content:''}</div>
             </div>
         );
@@ -128,26 +179,16 @@ export class Tab extends Component {
     }
 
     render () {
-        if (!this.props.maxTabWidth) {return null;} // will render when width is available
-
-        const {name, maxTabWidth, selected, onSelect, removable, onTabRemove, id} = this.props;
+        const {name, selected, onSelect, removable, onTabRemove, id} = this.props;
 
         var tabClassName = 'TabPanel__Tab' ;
         if (selected) {
             tabClassName += ' TabPanel__Tab--selected';
         }
 
-        const nameDivProps = {
-            className: 'ellipsis',
-            title: name,
-            onClick: () => onSelect(id,name)
-        };
-        // 2*6px - padding, 2*1px - border, 12px - btn
-        if (maxTabWidth) { nameDivProps.style = {maxWidth: (maxTabWidth-25)+'px'}; }
-
         return (
             <li className={tabClassName}>
-                <div {...nameDivProps}>
+                <div className='ellipsis' title={name} onClick={() => onSelect(id,name)}>
                      {name}
                 </div>
                 {removable &&
@@ -167,7 +208,6 @@ Tab.propTypes= {
     id: PropTypes.string,
     selected:  PropTypes.bool.isRequired, // private - true is the tab is currently selected
     onSelect: PropTypes.func, // private - called whenever the tab is clicked
-    maxTabWidth: PropTypes.number, // private - set in parent
     removable: PropTypes.bool,
     onTabRemove: PropTypes.func
 };


### PR DESCRIPTION
Tabs are now resizable.
If not enough space is available ellipsis character will be added at the end.
The tooltip with full name will come up when pointing to the tab.

I have experimented with making Mac style mid string truncation, as discussed [here](http://stackoverflow.com/questions/831552/ellipsis-in-the-middle-of-a-text-mac-style). Unfortunately, the most promising [solution](http://jsfiddle.net/r96vB/1/)  breaks in Firefox (resulting in overlap). It looks like purely CSS solution will ether have partial characters or uneven sizing due to truncated characters. To look good, the original string needs to be manipulated, which requires iterating on it because we can not tell in advance many pixels a string it will take. 