### PR TITLE
DM-6026: distinguish table sort from filter.

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -185,7 +185,7 @@
 
             firefly.showTable('tables-1', tblReq1);
             firefly.showTable('tables-1', tblReq2);
-            firefly.showTable('tables-2', tblReq3, {tbl_group: 'upload', removable: false, showUnits: true, showFilters: true});
+            firefly.showTable('tables-2', tblReq3, {removable: false, showUnits: true, showFilters: true});
             //-----------------  CHART DEMO ------------------------//
             //--- using QUERY_ID: 'upload' does not work getActiveTableId('upload') returns undefined ---//
             firefly.addXYPlot('xyPlot1', {tbl_id: tblReq3.tbl_id, xCol: 'ra1+ra2', yCol: 'dec1+dec2'});

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -197,9 +197,10 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
                 page = new DataGroupPart(def, new DataGroup("No result found", new DataType[0]), 0, 0);
             } else {
                 try {
-                    postProcessData(dgFile, request);
+                    dgFile = postProcessData(dgFile, request);
                     page = IpacTableParser.getData(dgFile, request.getStartIndex(), request.getPageSize());
                     page.getTableDef().ensureStatus();      // make sure there's a status line so
+                    page.getTableDef().setSource(ServerContext.replaceWithPrefix(dgFile));  // set table meta source to file it came from.
                 } catch (Exception e) {
                     LOGGER.error(e, "Fail to parse ipac table file: " + dgFile);
                     throw e;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/JsonTableUtil.java
@@ -38,9 +38,12 @@ public class JsonTableUtil {
     public static JSONObject toJsonTableModel(DataGroupPart page, TableMeta meta, TableServerRequest request) throws IOException {
 
         if (meta == null) {
-            meta = new TableMeta("unknown");
+            meta = new TableMeta();
         }
         if (page.getTableDef()!=null && page.getTableDef().getAttributes() != null) {
+            if (StringUtils.isEmpty(meta.getSource())) {
+                meta.setSource(page.getTableDef().getSource());
+            }
             // merge tableDef's attributes with tablemeta's.
             for (DataGroup.Attribute attr : page.getTableDef().getAttributes()) {
                 // meta override tabledef's.

--- a/src/firefly/js/api/ApiBuild.js
+++ b/src/firefly/js/api/ApiBuild.js
@@ -59,6 +59,7 @@ export function initApi() {
         window.onFireflyLoaded && window.onFireflyLoaded(firefly);
     });
     initExpandedView();
+    window.firefly.ignoreHistory = true;
 }
 
 

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -44,6 +44,15 @@ function build(llApi) {
 
 /*----------------------------< TABLE PART ----------------------------*/
 
+var divToGrp = (() => {
+    // workaround to support mapping first targetDiv to 'main'
+    var main;
+    return (div) => {
+        if (!main) main = div;
+        return div === main ? 'main' : div;
+    }
+})();
+
 function oldApi(llApi, params, options) {
     const {getBoolean} = llApi.util;
     const {makeFileRequest} = llApi.util.table;
@@ -75,16 +84,17 @@ function doShowTable(llApi, targetDiv, request, options={}) {
     const {dispatchTableSearch}= llApi.action;
     const {renderDOM}= llApi.util;
     const {TablesContainer}= llApi.ui;
-    var contProps = options && options.tbl_group ? {tbl_group: options.tbl_group} : {};
+    var contProps = {};
 
     if ((typeof targetDiv).match(/string|HTMLDivElement/) === null) {
         // old api.. need to setup request and options before continue.
         const params = targetDiv;
         targetDiv = request;
         request = oldApi(llApi, params, options);
-        contProps.tbl_group = targetDiv;
-        options.tbl_group = targetDiv;
     }
+
+    options.tbl_group = options.tbl_group || divToGrp(targetDiv);
+    contProps.tbl_group = options.tbl_group;
 
     Object.keys(options).forEach( (k) => {
         if (options[k] === undefined) {

--- a/src/firefly/js/core/History.js
+++ b/src/firefly/js/core/History.js
@@ -34,6 +34,7 @@ const historyAware = [  TABLE_SEARCH, SHOW_DROPDOWN
 var isHistoryEvent = false;
 
 window.onpopstate = function(event) {
+    if (get(window, 'firefly.ignoreHistory', false)) return;
     isHistoryEvent = true;
     try {
         if (event.state) {
@@ -49,6 +50,7 @@ window.onpopstate = function(event) {
 };
 
 export function getActionFromUrl() {
+    if (get(window, 'firefly.ignoreHistory', false)) return;
     const urlInfo = parseUrl(document.location);
     if (urlInfo.searchObject) {
         const type = get(urlInfo, 'pathAry.0.a');
@@ -60,7 +62,7 @@ export function getActionFromUrl() {
 }
 
 export function recordHistory(action={}) {
-    if (isHistoryEvent) return;
+    if (get(window, 'firefly.ignoreHistory', false) || isHistoryEvent) return;
 
     const handler = historyAware[action.type];
     if (get(handler, 'actionToUrl')) {

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -124,7 +124,7 @@ actionCreators.set(DrawLayerCntlr.DETACH_LAYER_FROM_PLOT, makeDetachLayerActionC
 
 actionCreators.set(TablesCntlr.TABLE_SEARCH, TablesCntlr.tableSearch);
 actionCreators.set(TablesCntlr.TABLE_FETCH, TablesCntlr.tableFetch);
-actionCreators.set(TablesCntlr.TABLE_FETCH_UPDATE, TablesCntlr.tableFetch);
+actionCreators.set(TablesCntlr.TABLE_SORT, TablesCntlr.tableFetch);
 actionCreators.set(TablesCntlr.TABLE_HIGHLIGHT, TablesCntlr.highlightRow);
 
 actionCreators.set(TableStatsCntlr.LOAD_TBL_STATS, TableStatsCntlr.loadTblStats);

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -23,7 +23,7 @@ export class TableConnector {
             flux.process({type: TblCntlr.TABLE_REPLACE, payload: tableModel});
         } else {
             request = Object.assign({}, request, {sortInfo: sortInfoString});
-            TblCntlr.dispatchTableFetch(request);
+            TblCntlr.dispatchTableSort(request);
         }
     }
 

--- a/src/firefly/js/tables/reducer/TableResultsReducer.js
+++ b/src/firefly/js/tables/reducer/TableResultsReducer.js
@@ -41,8 +41,7 @@ function removeTable(root, action) {
 
             if (tbl_id === get(root, [tbl_group,'active'])) {
                 // active table have been remove. set it to the first available table
-                const first = findKey(tbl_group.tables);
-                const newActiveId = first && first.tbl_id;
+                const newActiveId = findKey(root[tbl_group].tables);
                 root = updateSet(root, [tbl_group,'active'], newActiveId);
             }
         }

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -86,8 +86,7 @@ function uiStateReducer(ui, tableModel) {
 
 function updateAllUi(ui, tbl_id, tbl_ui_id, payload) {
     if (tbl_ui_id) {
-        const changes = set({}, [tbl_ui_id], payload);
-        return TblUtil.smartMerge(ui, changes);
+        return updateMerge(ui, tbl_ui_id, payload);
     } else {
         Object.keys(ui).filter( (ui_id) => {
             return get(ui, [ui_id, 'tbl_id']) === tbl_id;

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -69,7 +69,7 @@ TablePanelOptions.propTypes = {
 };
 
 function prepareOptionData(columns, colSortDir) {
-
+    columns = columns.filter((c) => c.visibility != 'hidden');
     if (colSortDir) {
         // sort the columns according to colSortDir
         const multiplier = colSortDir === SORT_ASC ? 1 : -1;
@@ -100,7 +100,7 @@ function prepareOptionData(columns, colSortDir) {
 
 function makeCallbacks(onChange, columns, origColumns, data) {
     var onSelectAll = (checked) => {
-        const nColumns = cloneDeep(columns);
+        const nColumns = cloneDeep(columns).filter((c) => c.visibility != 'hidden');
         nColumns.forEach((v) => {
             v.visibility = checked ? 'show' : 'hide';
         });

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -383,7 +383,7 @@ export function updateSet(object, path, value) {
  */
 export function updateMerge(object, path, value) {
     if (!has(object, path)) {
-        set(object, path, undefined);
+        set(object, path, {});
     }
     const o = set({}, path, {$merge: value});
     return update(object, o);


### PR DESCRIPTION
created TABLE_SORT action to distinguish sorting from filtering.  sorting should not reload xyplot nor catalog overlay.

Also:
- disable history when in api mode.
- ensure tableMeta.source reflects the file on the server.
- fix TablePanelOptions not resetting columns selection.
- remove 'Fits Data' tab when no images available.
- fix 'Coverage' appearing when it should.