### PR TITLE
Dm 4484 marker tool - create drawing layer for marker tool

### DIFF
--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -35,7 +35,11 @@ import DrawLayerCntlr, {makeDetachLayerActionCreator,
                         distanceToolEndActionCreator,
                         regionCreateLayerActionCreator,
                         regionDeleteLayerActionCreator,
-                        regionUpdateEntryActionCreator} from '../visualize/DrawLayerCntlr.js';
+                        regionUpdateEntryActionCreator,
+                        markerToolAttachActionCreator,
+                        markerToolStartActionCreator,
+                        markerToolMoveActionCreator,
+                        markerToolEndActionCreator} from '../visualize/DrawLayerCntlr.js';
 import MultiViewCntlr, {IMAGE_MULTI_VIEW_KEY} from '../visualize/MultiViewCntlr.js';
 import ComponentCntlr, {DIALOG_OR_COMPONENT_KEY} from '../core/ComponentCntlr.js';
 import {masterSaga} from './MasterSaga.js';
@@ -51,7 +55,7 @@ import Catalog from '../drawingLayers/Catalog.js';
 import WebGrid from '../drawingLayers/WebGrid.js';
 
 import RegionPlot from '../drawingLayers/RegionPlot.js';
-
+import MarkerTool from '../drawingLayers/MarkerTool.js';
 import {showExampleDialog} from '../ui/ExampleDialog.jsx';
 
 //==============
@@ -75,7 +79,7 @@ const actionCreators = new Map();
 
 const drawLayerFactory= DrawLayerFactory.makeFactory(ActiveTarget,SelectArea,DistanceTool,
                                                      PointSelection, StatsPoint, NorthUpCompass,
-                                                     Catalog, WebGrid, RegionPlot);
+                                                     Catalog, WebGrid, RegionPlot, MarkerTool);
 
 
 
@@ -133,7 +137,10 @@ actionCreators.set(XYPlotCntlr.LOAD_PLOT_DATA, XYPlotCntlr.loadPlotData);
 
 actionCreators.set(DrawLayerCntlr.SELECT_AREA_END, selectAreaEndActionCreator);
 actionCreators.set(DrawLayerCntlr.DT_END, distanceToolEndActionCreator);
-
+actionCreators.set(DrawLayerCntlr.MARKER_ATTACH, markerToolAttachActionCreator);
+actionCreators.set(DrawLayerCntlr.MARKER_START, markerToolStartActionCreator);
+actionCreators.set(DrawLayerCntlr.MARKER_MOVE, markerToolMoveActionCreator);
+actionCreators.set(DrawLayerCntlr.MARKER_END, markerToolEndActionCreator);
 
 actionCreators.set(DrawLayerCntlr.REGION_CREATE_LAYER, regionCreateLayerActionCreator);
 actionCreators.set(DrawLayerCntlr.REGION_DELETE_LAYER, regionDeleteLayerActionCreator);

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -36,10 +36,10 @@ import DrawLayerCntlr, {makeDetachLayerActionCreator,
                         regionCreateLayerActionCreator,
                         regionDeleteLayerActionCreator,
                         regionUpdateEntryActionCreator,
-                        markerToolAttachActionCreator,
                         markerToolStartActionCreator,
                         markerToolMoveActionCreator,
-                        markerToolEndActionCreator} from '../visualize/DrawLayerCntlr.js';
+                        markerToolEndActionCreator,
+                        markerToolCreateLayerActionCreator} from '../visualize/DrawLayerCntlr.js';
 import MultiViewCntlr, {IMAGE_MULTI_VIEW_KEY} from '../visualize/MultiViewCntlr.js';
 import ComponentCntlr, {DIALOG_OR_COMPONENT_KEY} from '../core/ComponentCntlr.js';
 import {masterSaga} from './MasterSaga.js';
@@ -137,10 +137,10 @@ actionCreators.set(XYPlotCntlr.LOAD_PLOT_DATA, XYPlotCntlr.loadPlotData);
 
 actionCreators.set(DrawLayerCntlr.SELECT_AREA_END, selectAreaEndActionCreator);
 actionCreators.set(DrawLayerCntlr.DT_END, distanceToolEndActionCreator);
-actionCreators.set(DrawLayerCntlr.MARKER_ATTACH, markerToolAttachActionCreator);
 actionCreators.set(DrawLayerCntlr.MARKER_START, markerToolStartActionCreator);
 actionCreators.set(DrawLayerCntlr.MARKER_MOVE, markerToolMoveActionCreator);
 actionCreators.set(DrawLayerCntlr.MARKER_END, markerToolEndActionCreator);
+actionCreators.set(DrawLayerCntlr.MARKER_CREATE, markerToolCreateLayerActionCreator);
 
 actionCreators.set(DrawLayerCntlr.REGION_CREATE_LAYER, regionCreateLayerActionCreator);
 actionCreators.set(DrawLayerCntlr.REGION_DELETE_LAYER, regionDeleteLayerActionCreator);

--- a/src/firefly/js/drawingLayers/MarkerTool.js
+++ b/src/firefly/js/drawingLayers/MarkerTool.js
@@ -1,0 +1,324 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {isEmpty, get, set, isArray} from 'lodash';
+import DrawLayerCntlr, {DRAWING_LAYER_KEY, dispatchAttachLayerToPlot} from '../visualize/DrawLayerCntlr.js';
+import {visRoot,dispatchAttributeChange} from '../visualize/ImagePlotCntlr.js';
+import {makeDrawingDef} from '../visualize/draw/DrawingDef.js';
+import DrawLayer, {ColorChangeType}  from '../visualize/draw/DrawLayer.js';
+import {MouseState} from '../visualize/VisMouseSync.js';
+import {PlotAttribute} from '../visualize/WebPlot.js';
+import CsysConverter from '../visualize/CsysConverter.js';
+import BrowserInfo from '../util/BrowserInfo.js';
+import VisUtil from '../visualize/VisUtil.js';
+import SelectBox from '../visualize/draw/SelectBox.js';
+import {getPlotViewById, primePlot, getDrawLayerById} from '../visualize/PlotViewUtil.js';
+import {Style} from '../visualize/draw/DrawingDef.js';
+//import DrawLayerFactory from '../visualize/draw/DrawLayerFactory.js';
+import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
+import ShapeDataObj from '../visualize/draw/ShapeDataObj.js';
+import {makeImagePt, makeScreenPt} from '../visualize/point.js';
+import {flux} from '../Firefly.js';
+import Enum from 'enum';
+
+
+const editHelpText=
+'Click center and drage to move, click corner and drage to resize';
+
+const EDIT_DISTANCE= BrowserInfo.isTouchInput() ? 18 : 10;
+const MARKER_SIZE = 40;      // marker original size in screen coordinate (radius of a circle)
+const HANDLER_BOX = 4;        // handler size (square size in screen coordinate)
+const markerInterval = 3000; // time interval for showing marker with handlers and no handlerss
+
+
+const ID= 'OVERLAY_MARKER';
+const TYPE_ID= 'OVERLAY_MARKER_TYPE';
+
+const factoryDef= makeFactoryDef(TYPE_ID,creator,null,getLayerChanges,onDetach,null);
+
+export default {factoryDef, TYPE_ID}; // every draw layer must default export with factoryDef and TYPE_ID
+const MarkerStatus = new Enum(['attached', 'select', 'relocate', 'resize']);
+
+var getCC = (plotId) => {
+    var plot = primePlot(visRoot(), plotId);
+    return CsysConverter.make(plot);
+};
+
+var idCnt=0;
+
+/**
+ *
+ * @return {Function}
+ */
+function creator(initPayload) {
+
+    var drawingDef= makeDrawingDef('red');
+    var pairs= {
+        [MouseState.DRAG.key]: DrawLayerCntlr.MARKER_MOVE,
+        [MouseState.DOWN.key]: DrawLayerCntlr.MARKER_START,
+        [MouseState.UP.key]: DrawLayerCntlr.MARKER_END
+    };
+
+    var actionTypes= [DrawLayerCntlr.MARKER_MOVE,
+                      DrawLayerCntlr.MARKER_START,
+                      DrawLayerCntlr.MARKER_END,
+                      DrawLayerCntlr.MARKER_ATTACH];
+    
+    var exclusiveDef= { exclusiveOnDown: true, type : 'anywhere' };
+
+
+    idCnt++;
+    var options= {
+        canUseMouse:true,
+        canUserChangeColor: ColorChangeType.DYNAMIC,
+        canUserDelete: true,
+        destroyWhenAllDetached: true
+    };
+    return  DrawLayer.makeDrawLayer( get(initPayload, 'drawLayerId', `${ID}-${idCnt}`),
+                                    TYPE_ID, get(initPayload, 'Title', 'Marker Tool'),
+                                    options, drawingDef, actionTypes, pairs, exclusiveDef);
+}
+
+function onDetach(drawLayer,action) {
+    var {plotIdAry}= action.payload;
+    plotIdAry.forEach( (plotId) => dispatchAttributeChange(plotId,false,PlotAttribute.SELECTION,null,true));
+}
+
+function getLayerChanges(drawLayer, action) {
+    //var dd = Object.assign({}, drawLayer.drawData);
+
+    switch (action.type) {
+        case DrawLayerCntlr.MARKER_START:
+            console.log(action.type);
+            var dl = makeMarker(action);
+            console.log('next marker status: ' +(get(dl, 'markerStatus') ? dl.markerStatus.key : 'null'));
+            return dl;
+        case DrawLayerCntlr.MARKER_MOVE:
+        case DrawLayerCntlr.MARKER_END:
+        case DrawLayerCntlr.MARKER_ATTACH:
+            console.log(action.type);
+            var dl = makeMarker(action);
+            console.log('next marker status: ' + (get(dl, 'markerStatus') ? dl.markerStatus.key : 'null'));
+            return dl;
+    }
+
+}
+
+var evenSize = (size) => {
+    var s;
+    if (size) {
+        s = (isArray(size) && size.length > 1) ? Math.min(size[0], size[1]): size;
+    } else {
+        s = MARKER_SIZE;
+    }
+    return [s, s];
+};
+
+export function markerToolAttachActionCreator(rawAction) {
+    return (dispatcher) => {
+        var {plotId= get(visRoot(), 'activePlotId'), drawLayerId, attachPlotGroup } = rawAction.payload;
+
+        if (plotId) {
+            dispatchAttachLayerToPlot(drawLayerId, plotId, attachPlotGroup);
+
+            var plot = primePlot(visRoot(), plotId);
+            if (plot) {
+                var wpt = plot.attributes[PlotAttribute.FIXED_TARGET];
+
+                showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_ATTACH, evenSize(), wpt, plotId,
+                                   MarkerStatus.attached, markerInterval);
+
+            }
+        }
+    };
+}
+
+
+export function markerToolStartActionCreator(rawAction) {
+    return (dispatcher) => {
+        var {plotId, imagePt, screenPt, drawLayer} = rawAction.payload;
+        var cc = getCC(plotId);
+
+        var wpt;
+        var {markerStatus, currentSize, currentPt, timeoutProcess} = drawLayer;
+
+        console.log('start: status = ' + (markerStatus? markerStatus.key: 'null') + ' timeout: ' + (timeoutProcess ? timeoutProcess : 'null'));
+        if (timeoutProcess) clearTimeout(timeoutProcess);
+
+        if (markerStatus === MarkerStatus.attached)  {             // marker moves to the mouse down position
+            wpt = cc.getWorldCoords(imagePt);
+            showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_START, evenSize(currentSize), wpt, plotId,
+                               MarkerStatus.relocate, markerInterval, timeoutProcess);
+        } else if (markerStatus === MarkerStatus.select) {        // check the position of mouse down: on circle, on handler, or none
+             var idx = findClosestIndex(drawLayer.drawData.data, screenPt, cc);
+
+
+             if (idx >= 0) {
+                 var nextStatus = idx === 0 ? MarkerStatus.relocate : MarkerStatus.resize;
+                 wpt = cc.getWorldCoords(currentPt);
+
+                 // makrer stays at current position
+                 showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_START, evenSize(currentSize), wpt, plotId,
+                                    nextStatus, markerInterval);
+             }
+        }
+    };
+}
+
+export function markerToolEndActionCreator(rawAction) {
+    return (dispatcher) => {
+        var {plotId, drawLayer} = rawAction.payload;
+        var cc = getCC(plotId);
+        var {markerStatus, currentSize, currentPt, timeoutProcess} = drawLayer;
+
+        if (timeoutProcess) clearTimeout(timeoutProcess);
+console.log('end: status = ' + (markerStatus? rawAction.payload.drawLayer.markerStatus.key: 'null') + ' timeout: ' + (timeoutProcess ? timeoutProcess : 'null'));
+        // mouse stay at current position and size
+        if (markerStatus === MarkerStatus.relocate || markerStatus === MarkerStatus.resize) {
+            var wpt = cc.getWorldCoords(currentPt);
+            showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_END, evenSize(currentSize), wpt, plotId,
+                               timeoutProcess, MarkerStatus.select, markerInterval);
+        }
+    };
+}
+
+export function markerToolMoveActionCreator(rawAction) {
+    return (dispatcher) => {
+        var {plotId, imagePt, screenPt, drawLayer} = rawAction.payload;
+        var cc = getCC(plotId);
+        var {markerStatus, currentSize: newSize, currentPt: wpt, timeoutProcess} = drawLayer;
+
+        if (timeoutProcess) clearTimeout(timeoutProcess);
+        console.log('move: status = ' + (markerStatus? markerStatus.key: 'null') + ' timeout: ' + (timeoutProcess ? timeoutProcess : 'null'));
+
+        if (markerStatus === MarkerStatus.resize)  {               // mmarker stay at current point, and change size
+            var screenCenter = cc.getScreenCoords(wpt);
+            newSize = [Math.abs(screenPt.x - screenCenter.x)*2, Math.abs(screenPt.y - screenCenter.y)*2];
+        } else if (markerStatus === MarkerStatus.relocate) {      // marker move to new mouse down positon
+            wpt = cc.getWorldCoords(imagePt);
+        }
+        showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_MOVE, newSize, wpt, plotId,
+                           markerStatus, markerInterval);
+    };
+}
+
+const screenDistance= (pt1,pt2) => VisUtil.computeScreenDistance(pt1.x,pt1.y,pt2.x,pt2.y);
+
+function findClosestIndex(drawObjAry, screenPt, cc) {
+    var distance = EDIT_DISTANCE;
+
+    return  drawObjAry.reduce( (prev, drawObj, index) => {
+        var dist;
+        var centerPt = cc.getScreenCoords(drawObj.pts);
+
+        if (drawObj.type === ShapeDataObj.UnitType.Circle) {
+            dist = screenDistance(screenPt, centerPt) - drawObj.radius;
+            if (dist < 0) {
+                dist = 0;
+            }
+        } else if (drawObj.type === ShapeDataObj.UnitType.Rectangle) {
+            var x1, x2, y1, y2;
+
+            x1 = centerPt.x - drawObj.width/2;
+            x2 = centerPt.x + drawObj.width/2;
+            y1 = centerPt.y - drawObj.height/2;
+            y2 = centerPt.y + drawObj.height/2;
+
+            var bx = (screenPt.x >= x1 && screenPt.x <= x2) ? screenPt.x :
+                     ((screenPt.x < x1) ? x1 : x2);
+            var by = (screenPt.y >= y1 && screenPt.y <= y2) ? screenPt.y :
+                     ((screenPt.y < y1) ? y1 : y2);
+
+            dist = screenDistance(screenPt, makeScreenPt(bx, by));
+        }
+
+        if (dist < distance) {
+            distance = dist;
+            prev = index;
+        }
+        return prev;
+    }, -1);
+}
+
+
+/**
+ * dispatch action to locate marker with corners and no corner by timer interval on the draw layer
+ * @param dispatcher
+ * @param size   in screen coordinate
+ * @param wpt    marker location world coordinate
+ * @param plotId
+ * @param timer  milliseconds
+ */
+function showMarkersByTimer(dispatcher, actionType, size, wpt, plotId,  doneStatus, timer) {
+    var setAction = (isHandler) => ({
+        type: actionType,
+        payload: {isHandler, size, wpt, plotId, markerStatus: doneStatus}
+    });
+
+    var timeoutProcess = setTimeout(() => dispatcher(setAction(false)), timer);
+    console.log('new timeout ' + timeoutProcess);
+    var crtAction = set(setAction(true), 'payload.timeoutProcess', timeoutProcess);
+    dispatcher(crtAction);
+}
+
+function makeMarker(action) {
+     var {plotId, isHandler, wpt, size, markerStatus, timeoutProcess} = action.payload;
+
+     if (!plotId || !wpt) return null;
+
+     const plot = primePlot(visRoot(), plotId);
+     var [markerW, markerH] = isArray(size) && size.length > 1 ?  [size[0], size[1]] : [size, size];
+     var markObjs = makeMarkDrawObj(plot, wpt, markerW, markerH, isHandler);
+     var exclusiveDef, vertexDef; // cursor point
+     var dlObj =  {
+        helpLine: editHelpText,
+        drawData: {data:markObjs},
+        currentPt: wpt,                    // center
+        currentSize: [markerW, markerH],
+     };
+     if (timeoutProcess) {
+         dlObj.timeoutProcess = timeoutProcess;
+     }
+
+     if (markerStatus) {
+         var cc = CsysConverter.make(plot);
+         const imgPt = cc.getImageCoords(wpt);
+
+         if (markerStatus === MarkerStatus.attached) {
+             exclusiveDef = { exclusiveOnDown: true, type : 'anywhere' };
+             vertexDef = {points:null, pointDist:EDIT_DISTANCE};
+         } else {
+             exclusiveDef = { exclusiveOnDown: true, type : 'vertexThenAnywhere' };
+             vertexDef = {points:[imgPt], pointDist: Math.sqrt(Math.pow(markerW/2, 2) + Math.pow(markerH/2, 2))};
+         }
+         return Object.assign(dlObj, {markerStatus, vertexDef, exclusiveDef});
+     } else {
+         return dlObj;
+     }
+}
+
+function makeMarkDrawObj(plot, centerPt, width, height, includeHandler) {
+    var retval;
+    var radius = Math.min(width, height)/2;
+
+    retval = [ShapeDataObj.makeCircleWithRadius(centerPt, radius)];
+
+    if (includeHandler) {
+        var cc = CsysConverter.make(plot);
+        var corners = [[-1, 1], [1, 1], [-1, -1], [1, -1]];
+        var imgPt = cc.getImageCoords(centerPt);
+
+        retval = corners.reduce((prev, coord) => {
+            var x = imgPt.x + coord[0] * width/(2*cc.zoomFactor);
+            var y = imgPt.y + coord[1] * height/(2*cc.zoomFactor);
+
+            var handlerCenter = cc.getWorldCoords(makeImagePt(x, y));
+            var handlerBox = ShapeDataObj.makeRectangleByCenter(handlerCenter, HANDLER_BOX, HANDLER_BOX,
+                            ShapeDataObj.UnitType.PIXEL, 0.0, ShapeDataObj.UnitType.ARCSEC, false);
+            prev.push(handlerBox);
+            return prev;
+        }, retval);
+    }
+    return retval;
+}
+

--- a/src/firefly/js/drawingLayers/MarkerToolUI.jsx
+++ b/src/firefly/js/drawingLayers/MarkerToolUI.jsx
@@ -64,7 +64,7 @@ class MarkerToolUI extends React.Component {
                                                   onChange={this.changeMarkerText}/>
                 </div>
                 <div style={tStyle}> Corners:
-                    <select defaultValue={TextLocation.CIRCLE_SE.key} onChange={ this.changeMarkerTextLocation }>
+                    <select value={this.state.markerTextLoc} onChange={ this.changeMarkerTextLocation }>
                         <option value={TextLocation.CIRCLE_NE.key}> NE </option>
                         <option value={TextLocation.CIRCLE_NW.key}> NW </option>
                         <option value={TextLocation.CIRCLE_SE.key}> SE </option>
@@ -88,5 +88,5 @@ MarkerToolUI.propTypes= {
 };
 
 MarkerToolUI.defaultProps={
-    markerType    : 'marker'
+    markerType    : 'marker'      // could be set for marker or other footprint cases
 };

--- a/src/firefly/js/drawingLayers/MarkerToolUI.jsx
+++ b/src/firefly/js/drawingLayers/MarkerToolUI.jsx
@@ -1,0 +1,92 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React from 'react';
+import sCompare from 'react-addons-shallow-compare';
+import {TextLocation} from '../visualize/draw/DrawingDef.js';
+import {dispatchModifyCustomField} from '../visualize/DrawLayerCntlr.js';
+import {addNewDrawLayer} from '../visualize/ui/MarkerDropDownView.jsx';
+import {isNil, get} from 'lodash';
+
+export const getMarkerToolUIComponent = (drawLayer,pv) => <MarkerToolUI drawLayer={drawLayer} pv={pv}/>;
+export const defaultMarkerTextLoc = TextLocation.CIRCLE_SE;
+
+
+class MarkerToolUI extends React.Component {
+    constructor(props) {
+        super(props);
+
+        var markerText = get(this.props.drawLayer, ['drawData', 'data', '0', 'text'], '');
+        var markerTextLoc = get(this.props.drawLayer, ['drawData', 'data', '0', 'textLoc'], defaultMarkerTextLoc);
+
+        this.state = {markerText,  markerTextLoc: markerTextLoc.key};
+        this.changeMarkerText = this.changeMarkerText.bind(this);
+        this.changeMarkerTextLocation = this.changeMarkerTextLocation.bind(this);
+    }
+
+    shouldComponentUpdate(np, ns) {return sCompare(this, np, ns); }
+
+    changeMarkerText(ev) {
+        var markerText = get(ev, 'target.value');
+
+        if (isNil(markerText)) markerText = '';
+        this.setState({markerText});
+
+        dispatchModifyCustomField( this.props.drawLayer.drawLayerId,
+                    {markerText, markerTextLoc: TextLocation.get(this.state.markerTextLoc)}, this.props.pv.plotId);
+    }
+
+    changeMarkerTextLocation(ev) {
+        var markerTextLoc = get(ev, 'target.value');
+
+        this.setState({markerTextLoc});
+        dispatchModifyCustomField( this.props.drawLayer.drawLayerId,
+                    {markerText: this.state.markerText, markerTextLoc: TextLocation.get(markerTextLoc)}, this.props.pv.plotId);
+    }
+
+    render() {
+        const tStyle= {
+            display:'inline-block',
+            whiteSpace: 'nowrap',
+            minWidth: '3em',
+            paddingLeft : 5
+        };
+
+        var textOnLink = `Add ${this.props.markerType}`;
+        var tipOnLink = `Add a ${this.props.markerType}`;
+
+        return (
+            <div style={{ padding:'5px 0 9px 0'}}>
+                <div style={tStyle}> Label:<input style={{width: 60}}
+                                                  type='text'
+                                                  value={this.state.markerText}
+                                                  onChange={this.changeMarkerText}/>
+                </div>
+                <div style={tStyle}> Corners:
+                    <select defaultValue={TextLocation.CIRCLE_SE.key} onChange={ this.changeMarkerTextLocation }>
+                        <option value={TextLocation.CIRCLE_NE.key}> NE </option>
+                        <option value={TextLocation.CIRCLE_NW.key}> NW </option>
+                        <option value={TextLocation.CIRCLE_SE.key}> SE </option>
+                        <option value={TextLocation.CIRCLE_SW.key}> SW </option>
+                    </select>
+                </div>
+                <div style={tStyle}  title={tipOnLink}>
+                    <a className='ff-href' style={{textDecoration: 'underline'}}
+                       onClick={()=>addNewDrawLayer(this.props.pv, this.props.markerType)}>{textOnLink}</a>
+                </div>
+            </div>
+        );
+    }
+}
+
+
+MarkerToolUI.propTypes= {
+    drawLayer     : React.PropTypes.object.isRequired,
+    pv            : React.PropTypes.object.isRequired,
+    markerType    : React.PropTypes.string
+};
+
+MarkerToolUI.defaultProps={
+    markerType    : 'marker'
+};

--- a/src/firefly/js/drawingLayers/MarkerToolUI.jsx
+++ b/src/firefly/js/drawingLayers/MarkerToolUI.jsx
@@ -17,7 +17,7 @@ class MarkerToolUI extends React.Component {
     constructor(props) {
         super(props);
 
-        var markerText = get(this.props.drawLayer, 'title');
+        var markerText = get(this.props.drawLayer, ['drawData', 'data', '0', 'text'], '');
         var markerTextLoc = get(this.props.drawLayer, ['drawData', 'data', '0', 'textLoc'], defaultMarkerTextLoc);
 
         this.state = {markerText,  markerTextLoc: markerTextLoc.key};

--- a/src/firefly/js/drawingLayers/MarkerToolUI.jsx
+++ b/src/firefly/js/drawingLayers/MarkerToolUI.jsx
@@ -17,7 +17,7 @@ class MarkerToolUI extends React.Component {
     constructor(props) {
         super(props);
 
-        var markerText = get(this.props.drawLayer, ['drawData', 'data', '0', 'text'], '');
+        var markerText = get(this.props.drawLayer, 'title');
         var markerTextLoc = get(this.props.drawLayer, ['drawData', 'data', '0', 'textLoc'], defaultMarkerTextLoc);
 
         this.state = {markerText,  markerTextLoc: markerTextLoc.key};
@@ -33,6 +33,7 @@ class MarkerToolUI extends React.Component {
         if (isNil(markerText)) markerText = '';
         this.setState({markerText});
 
+        this.props.drawLayer.title = markerText;
         dispatchModifyCustomField( this.props.drawLayer.drawLayerId,
                     {markerText, markerTextLoc: TextLocation.get(this.state.markerTextLoc)}, this.props.pv.plotId);
     }

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -7,6 +7,7 @@ import {getPlotViewIdListInGroup, getDrawLayerById, getConnectedPlotsIds} from '
 import ImagePlotCntlr, {visRoot}  from './ImagePlotCntlr.js';
 import DrawLayerReducer from './reducer/DrawLayerReducer.js';
 import {without,union,omit,isEmpty} from 'lodash';
+import {clone} from '../util/WebUtil.js';
 
 
 export {selectAreaEndActionCreator} from '../drawingLayers/SelectArea.js';
@@ -54,16 +55,13 @@ const REGION_DELETE_LAYER = `${DRAWLAYER_PREFIX}.RegionPlot.deleteLayer`;
 const REGION_ADD_ENTRY = `${DRAWLAYER_PREFIX}.RegionPlot.addRegion`;
 const REGION_REMOVE_ENTRY = `${DRAWLAYER_PREFIX}.RegionPlot.removeRegion`;
 
-// makler and footprint
+// marker and footprint
 const MARKER_START = `${DRAWLAYER_PREFIX}.MarkerTool.markerStart`;
 const MARKER_MOVE = `${DRAWLAYER_PREFIX}.MarkerTool.markerMove`;
 const MARKER_END = `${DRAWLAYER_PREFIX}.MarkerTool.markerEnd`;
 const MARKER_CREATE= `${DRAWLAYER_PREFIX}.MarkerTool.markerCreate`;
 
 export const DRAWING_LAYER_KEY= 'drawLayers';
-
-const clone = (obj,params={}) => Object.assign({},obj,params);
-
 
 export function dlRoot() { return flux.getState()[DRAWING_LAYER_KEY]; }
 

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -11,10 +11,10 @@ import {without,union,omit,isEmpty} from 'lodash';
 
 export {selectAreaEndActionCreator} from '../drawingLayers/SelectArea.js';
 export {distanceToolEndActionCreator} from '../drawingLayers/DistanceTool.js';
-export {markerToolAttachActionCreator,
-        markerToolStartActionCreator,
+export {markerToolStartActionCreator,
         markerToolMoveActionCreator,
-        markerToolEndActionCreator} from '../drawingLayers/MarkerTool.js';
+        markerToolEndActionCreator,
+        markerToolCreateLayerActionCreator} from '../drawingLayers/MarkerTool.js';
 
 export {regionCreateLayerActionCreator,
         regionDeleteLayerActionCreator,
@@ -58,8 +58,7 @@ const REGION_REMOVE_ENTRY = `${DRAWLAYER_PREFIX}.RegionPlot.removeRegion`;
 const MARKER_START = `${DRAWLAYER_PREFIX}.MarkerTool.markerStart`;
 const MARKER_MOVE = `${DRAWLAYER_PREFIX}.MarkerTool.markerMove`;
 const MARKER_END = `${DRAWLAYER_PREFIX}.MarkerTool.markerEnd`;
-const MARKER_ATTACH = `${DRAWLAYER_PREFIX}.MarkerTool.markerAttach`;
-const MARKER_LOC = `${DRAWLAYER_PREFIX}.MarkerTool.markerLocate`;
+const MARKER_CREATE= `${DRAWLAYER_PREFIX}.MarkerTool.markerCreate`;
 
 export const DRAWING_LAYER_KEY= 'drawLayers';
 
@@ -84,13 +83,13 @@ export default {
     FORCE_DRAW_LAYER_UPDATE,
     DT_START, DT_MOVE, DT_END,
     REGION_CREATE_LAYER, REGION_DELETE_LAYER,  REGION_ADD_ENTRY, REGION_REMOVE_ENTRY,
-    MARKER_START, MARKER_MOVE, MARKER_END, MARKER_ATTACH, MARKER_LOC,
+    MARKER_START, MARKER_MOVE, MARKER_END, MARKER_CREATE,
     makeReducer, dispatchRetrieveData, dispatchChangeVisibility,
     dispatchCreateDrawLayer, dispatchDestroyDrawLayer,
     dispatchAttachLayerToPlot, dispatchDetachLayerFromPlot,
     dispatchCreateRegionLayer, dispatchDeleteRegionLayer,
     dispatchAddRegionEntry, dispatchRemoveRegionEntry,
-    dispatchAttachMarkerLayerToPlot
+    dispatchCreateMarkerLayer
 };
 
 /**
@@ -259,9 +258,10 @@ export function dispatchRemoveRegionEntry(regionId, regionChanges, dispatcher = 
     dispatcher({type: REGION_REMOVE_ENTRY, payload: {regionId, regionChanges}});
 }
 
-export function dispatchAttachMarkerLayerToPlot(drawLayerId, plotId, attachPlotGroup=true, dispatcher = flux.process) {
-    dispatcher({type: MARKER_ATTACH, payload: {plotId, drawLayerId, attachPlotGroup}});
+export function dispatchCreateMarkerLayer(markerId, layerTitle, plotId = [], attachPlotGroup=true, dispatcher = flux.process) {
+    dispatcher({type: MARKER_CREATE, payload: {plotId, markerId, layerTitle, attachPlotGroup}});
 }
+
 
 function getDrawLayerId(dlRoot,id) {
     var drawLayer= dlRoot.drawLayerAry.find( (dl) => id===dl.drawLayerId);

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -11,6 +11,10 @@ import {without,union,omit,isEmpty} from 'lodash';
 
 export {selectAreaEndActionCreator} from '../drawingLayers/SelectArea.js';
 export {distanceToolEndActionCreator} from '../drawingLayers/DistanceTool.js';
+export {markerToolAttachActionCreator,
+        markerToolStartActionCreator,
+        markerToolMoveActionCreator,
+        markerToolEndActionCreator} from '../drawingLayers/MarkerTool.js';
 
 export {regionCreateLayerActionCreator,
         regionDeleteLayerActionCreator,
@@ -50,6 +54,13 @@ const REGION_DELETE_LAYER = `${DRAWLAYER_PREFIX}.RegionPlot.deleteLayer`;
 const REGION_ADD_ENTRY = `${DRAWLAYER_PREFIX}.RegionPlot.addRegion`;
 const REGION_REMOVE_ENTRY = `${DRAWLAYER_PREFIX}.RegionPlot.removeRegion`;
 
+// makler and footprint
+const MARKER_START = `${DRAWLAYER_PREFIX}.MarkerTool.markerStart`;
+const MARKER_MOVE = `${DRAWLAYER_PREFIX}.MarkerTool.markerMove`;
+const MARKER_END = `${DRAWLAYER_PREFIX}.MarkerTool.markerEnd`;
+const MARKER_ATTACH = `${DRAWLAYER_PREFIX}.MarkerTool.markerAttach`;
+const MARKER_LOC = `${DRAWLAYER_PREFIX}.MarkerTool.markerLocate`;
+
 export const DRAWING_LAYER_KEY= 'drawLayers';
 
 const clone = (obj,params={}) => Object.assign({},obj,params);
@@ -73,11 +84,13 @@ export default {
     FORCE_DRAW_LAYER_UPDATE,
     DT_START, DT_MOVE, DT_END,
     REGION_CREATE_LAYER, REGION_DELETE_LAYER,  REGION_ADD_ENTRY, REGION_REMOVE_ENTRY,
+    MARKER_START, MARKER_MOVE, MARKER_END, MARKER_ATTACH, MARKER_LOC,
     makeReducer, dispatchRetrieveData, dispatchChangeVisibility,
     dispatchCreateDrawLayer, dispatchDestroyDrawLayer,
     dispatchAttachLayerToPlot, dispatchDetachLayerFromPlot,
     dispatchCreateRegionLayer, dispatchDeleteRegionLayer,
-    dispatchAddRegionEntry, dispatchRemoveRegionEntry
+    dispatchAddRegionEntry, dispatchRemoveRegionEntry,
+    dispatchAttachMarkerLayerToPlot
 };
 
 /**
@@ -246,6 +259,9 @@ export function dispatchRemoveRegionEntry(regionId, regionChanges, dispatcher = 
     dispatcher({type: REGION_REMOVE_ENTRY, payload: {regionId, regionChanges}});
 }
 
+export function dispatchAttachMarkerLayerToPlot(drawLayerId, plotId, attachPlotGroup=true, dispatcher = flux.process) {
+    dispatcher({type: MARKER_ATTACH, payload: {plotId, drawLayerId, attachPlotGroup}});
+}
 
 function getDrawLayerId(dlRoot,id) {
     var drawLayer= dlRoot.drawLayerAry.find( (dl) => id===dl.drawLayerId);

--- a/src/firefly/js/visualize/draw/DrawOp.js
+++ b/src/firefly/js/visualize/draw/DrawOp.js
@@ -8,16 +8,15 @@ import SelectBox from './SelectBox.js';
 import ShapeDataObj from './ShapeDataObj.js';
 import FootprintObj from './FootprintObj.js';
 import DirectionArrowDrawObj from './DirectionArrowDrawObj.js';
-
-
-
+import MarkerObj from './MarkerObj.js';
 
 export var drawTypes= {
     [POINT_DATA_OBJ] : PointDataObj.draw,
     [SelectBox.SELECT_BOX] : SelectBox.draw,
     [FootprintObj.FOOTPRINT_OBJ] : FootprintObj.draw,
     [DirectionArrowDrawObj.DIR_ARROW_DRAW_OBJ] : DirectionArrowDrawObj.draw,
-    [ShapeDataObj.SHAPE_DATA_OBJ] : ShapeDataObj.draw
+    [ShapeDataObj.SHAPE_DATA_OBJ] : ShapeDataObj.draw,
+    [MarkerObj.MARKER_DATA_OBJ] : MarkerObj.draw
 };
 
 class DrawOp {

--- a/src/firefly/js/visualize/draw/MarkerObj.js
+++ b/src/firefly/js/visualize/draw/MarkerObj.js
@@ -8,18 +8,21 @@ import DrawObj from './DrawObj';
 import DrawUtil from './DrawUtil';
 import {TextLocation, Style, DEFAULT_FONT_SIZE} from './DrawingDef.js';
 import {makeImagePt, makeOffsetPt} from '../Point.js';
-import ShapeDataObj from './ShapeDataObj.js';
+import ShapeDataObj, {lengthToImagePixel, lengthToScreenPixel, lengthToArcsec} from './ShapeDataObj.js';
 import DrawOp from './DrawOp.js';
 import CsysConverter from '../CsysConverter.js';
 import {has, isNil, get, isEmpty} from 'lodash';
 import {defaultMarkerTextLoc} from '../../drawingLayers/MarkerToolUI.jsx';
 import BrowserInfo from '../../util/BrowserInfo.js';
+import {clone} from '../../util/WebUtil.js';
 
-const HANDLER_BOX = 4;        // handler size (square size in screen coordinate)
+const HANDLER_BOX = 6;        // handler size (square size in image coordinate)
 const MarkerType= new Enum(['Marker', 'HST_FT']); // TODO: more footprint styles to be defined.
 const MARKER_DATA_OBJ= 'MarkerDataObj';
 const DEF_WIDTH = 1;
 export const MARKER_DISTANCE= BrowserInfo.isTouchInput() ? 18 : 10;
+
+var boxInArcsec = (cc) => lengthToArcsec(HANDLER_BOX, cc, ShapeDataObj.UnitType.SCREEN_PIXEL);
 
 function make(sType) {
     const obj= DrawObj.makeDrawObj();
@@ -50,7 +53,7 @@ var getWorldOrImage = (pt, cc) => (cc.projection.isSpecified() ? cc.getWorldCoor
 /**
  * make drawObj for Marker with handlers or not. Marker is defined as a circle with 4 handlers at the corners
  * @param centerPt
- * @param width
+ * @param width  image coordinate
  * @param height
  * @param isHandler
  * @param plot
@@ -59,40 +62,47 @@ var getWorldOrImage = (pt, cc) => (cc.projection.isSpecified() ? cc.getWorldCoor
  * @param unitType
  * @returns {*}
  */
-export function makeMarker(centerPt, width, height, isHandler, plot, text, textLoc, unitType = ShapeDataObj.UnitType.PIXEL) {
-    var dObj = Object.assign(make(MarkerType.Marker), {pts: [centerPt], width, height, unitType});
+export function makeMarker(centerPt, width, height, isHandler, plot, text, textLoc, unitType = ShapeDataObj.UnitType.IMAGE_PIXEL) {
+    var cc = CsysConverter.make(plot);
+    var w = lengthToArcsec(width, cc, unitType);
+    var h = lengthToArcsec(height, cc, unitType);
+    var worldUnit = ShapeDataObj.UnitType.ARCSEC;
+    var markerC = getWorldOrImage(centerPt, cc);
+    var dObj = clone(make(MarkerType.Marker), {pts: [markerC], width: w, height: h, unitType: worldUnit});
     var retval;
-    var radius = Math.min(width, height)/2;
-    var mainCircle = ShapeDataObj.makeCircleWithRadius(centerPt, radius, unitType);
+    var radius = lengthToArcsec(Math.min(width, height)/2, cc, unitType);
+
+    var mainCircle = ShapeDataObj.makeCircleWithRadius(markerC, radius, worldUnit);
     var textProps = {text: (isNil(text) ? '' : text),
                      textLoc: (isNil(textLoc) ? defaultMarkerTextLoc : textLoc)};
 
-    dObj = Object.assign(dObj, textProps);
-    mainCircle = Object.assign(mainCircle, textProps);
+    dObj = clone(dObj, textProps);
+    mainCircle = clone(mainCircle, textProps);
     retval = [mainCircle];    // circle is the first element in the marker's drawobj array
 
     dObj.includeHandler = isHandler; // start index of handler object
     dObj.handlerIndex = 1;
 
-    var cc = CsysConverter.make(plot);
+
     var corners = [[-1, 1], [1, 1], [1, -1], [-1, -1]];
     var imgPt = cc.getImageCoords(centerPt);
-    var nW = (width)/(2 * cc.zoomFactor);
-    var nH = (height)/(2 * cc.zoomFactor);
+    var nW = lengthToImagePixel(width/2, cc, unitType);
+    var nH = lengthToImagePixel(height/2, cc, unitType);
 
     retval = corners.reduce((prev, coord) => {
         var x = imgPt.x + coord[0] * nW;
         var y = imgPt.y + coord[1] * nH;
 
         var handlerCenter = getWorldOrImage(makeImagePt(x, y), cc);
-        var handlerBox = ShapeDataObj.makeRectangleByCenter(handlerCenter, HANDLER_BOX, HANDLER_BOX,
-                             ShapeDataObj.UnitType.PIXEL, 0.0, ShapeDataObj.UnitType.ARCSEC, false);
+        //var s = lengthToArcsec(HANDLER_BOX, cc, ShapeDataObj.UnitType.IMAGE_PIXEL);
+        var s = boxInArcsec(cc);
+        var handlerBox = ShapeDataObj.makeRectangleByCenter(handlerCenter, s, s, worldUnit,
+                                                            0.0, ShapeDataObj.UnitType.ARCSEC, false);
         prev.push(handlerBox);
         return prev;
     }, retval);
 
     dObj.drawObjAry = retval;
-    markerTextOffset(dObj);
     return dObj;
 }
 
@@ -132,6 +142,7 @@ var draw=  {
         return drawObj.pts[0];
     },
 
+    //pt in screen coordinate
     getScreenDist(drawObj,plot, pt) {
         var dist = -1;
         var testPt = plot.getScreenCoords(drawObj.pts[0]);
@@ -143,18 +154,22 @@ var draw=  {
 
         if (testPt) {
             if (drawObj.sType === ShapeDataObj.ShapeType.Rectangle) {
-                var x1 = testPt.x - drawObj.width / 2;
-                var x2 = testPt.x + drawObj.width / 2;
-                var y1 = testPt.y - drawObj.height / 2;
-                var y2 = testPt.y + drawObj.height / 2;
+                var w = lengthToScreenPixel(drawObj.width/2, plot, drawObj.unitType);
+                var h = lengthToScreenPixel(drawObj.height/2, plot, drawObj.unitType);
+                var x1 = testPt.x - w;
+                var x2 = testPt.x + w;
+                var y1 = testPt.y - h;
+                var y2 = testPt.y + h;
 
                 var bx = (pt.x >= x1 && pt.x <= x2) ? pt.x : ((pt.x < x1) ? x1 : x2);
                 var by = (pt.y >= y1 && pt.y <= y2) ? pt.y : ((pt.y < y1) ? y1 : y2);
 
                 dist = distToPt(bx, by);
             } else if (drawObj.sType === ShapeDataObj.ShapeType.Circle) {
+                var r = lengthToScreenPixel(drawObj.radius, plot, drawObj.unitType);
+
                 dist = distToPt(testPt.x, testPt.y);
-                dist = dist > drawObj.radius ? dist - drawObj.radius : 0;
+                dist = dist > r ? dist - r : 0;
             }
         }
         return dist;
@@ -188,6 +203,32 @@ var draw=  {
 export default {
     make,draw, makeMarker, MARKER_DATA_OBJ
 };
+
+
+/**
+ * horizontal distance between the screentPt and the path connecting the handle center and the marker center
+ * @param handlePt handle center
+ * @param centerPt marker center
+ * @param screenPt screen pt
+ * @param cc
+ * @returns {number}
+ */
+function distToPathToCenter(handlePt, centerPt, screenPt, cc) {
+    var markerC = cc.getScreenCoords(centerPt);
+    var handleC = cc.getScreenCoords(handlePt);
+    var slopeY = markerC.y - handleC.y;
+    var slopeX = markerC.x - handleC.x;
+    var dx = screenPt.x - handleC.x;
+    var dist = MARKER_DISTANCE;
+
+    if ((screenPt.y > markerC.y && screenPt.y <= handleC.y) ||
+        (screenPt.y < markerC.y && screenPt.y >= handleC.y)) {
+        var targetY = (slopeY * (dx) / slopeX) + handleC.y;
+
+        dist = Math.abs(targetY - screenPt.y);
+    }
+    return dist;
+}
 
 /**
  * find the drawObj inside the marker which is closest to the given screenPt
@@ -226,6 +267,9 @@ export function findClosestIndex(screenPt, drawObj, cc) {
  */
 function drawMarkerObject(drawObj, ctx, drawTextAry, plot, def, vpPtM, onlyAddToPath) {
     var {drawObjAry}= drawObj;
+    if (!drawObjAry) return;
+
+    markerTextOffset(drawObj, plot);
     var dObjs = (drawObj.includeHandler) ? drawObjAry : drawObjAry.slice(0, drawObj.handlerIndex);
 
     // draw the child drawObj
@@ -268,7 +312,7 @@ function translateMarker(plot,drawObj,apt) {
  * rotate a marker around worldPt by angle on image coordinate
  * @param plot
  * @param drawObj
- * @param angle
+ * @param angle, in arcsec unit
  * @param worldPt
  * @returns {*} a array of rotated objects contained in drawObj
  */
@@ -290,7 +334,7 @@ function rotateMakerAround(plot,drawObj,angle,worldPt) {
     // regenerate 4 handlers on the corners of the rectangular coverage after rotation
     var handlers = drawObj.drawObjAry.slice(drawObj.handlerIndex);
     var rotatedCorners = handlers.map( (oneCorner) => {    // corners after rotation
-          return rotateAroundPt(plot.getImageCoords(oneCorner.pts));
+          return rotateAroundPt(plot.getImageCoords(oneCorner.pts[0]));
     });
 
     // rectangular coverage after rotation in image coordinate
@@ -311,10 +355,11 @@ function rotateMakerAround(plot,drawObj,angle,worldPt) {
     }, {});
 
     // create new handlers at the new corners
-    var corners = [[min_x, max_y], [max_x, max_y], [max_x, min_y], [min_x, min_y]];   // corners of rectangular coverage
+    var corners = [[min_x, max_y], [max_x, max_y], [max_x, min_y], [min_x, min_y]];   // corners of rectangular coverage'
+    var s = boxInArcsec(plot);
     handlers = corners.map( (corner) => {
         return ShapeDataObj.makeRectangleByCenter(getWorldOrImage(makeImagePt(corner[0], corner[1]), plot),
-                HANDLER_BOX, HANDLER_BOX, ShapeDataObj.UnitType.PIXEL, 0.0, ShapeDataObj.UnitType.ARCSEC, false);
+                                                s, s, ShapeDataObj.UnitType.ARCSEC, 0.0, ShapeDataObj.UnitType.ARCSEC, false);
     });
 
     drawObj.pts = [newPt];
@@ -365,7 +410,6 @@ export function updateMarkerDrawObjText(drawObj, text, textLoc) {
         var newDrawObj = Object.assign({}, drawObj, textInfo);
 
         newDrawObj.drawObjAry[mainIndex] = newMain;
-        markerTextOffset(newDrawObj);
 
         return newDrawObj;
     }
@@ -375,17 +419,19 @@ export function updateMarkerDrawObjText(drawObj, text, textLoc) {
 /**
  * add text offset to marker object
  * @param drawObj
+ * @param cc
  */
-function markerTextOffset(drawObj) {
+function markerTextOffset(drawObj, cc) {
     var {textLoc = TextLocation.DEFAULT, drawObjAry} = drawObj;
     var mainObj = (drawObjAry) ? drawObjAry[0] : null;
     var dy = 0;
+    var off = lengthToScreenPixel(HANDLER_BOX/2, cc, ShapeDataObj.UnitType.PIXEL);
 
     if (mainObj) {
         if (textLoc === TextLocation.CIRCLE_NE || textLoc === TextLocation.CIRCLE_NW) {
-            dy = -HANDLER_BOX/2;
+            dy = -off;
         } else if (textLoc === TextLocation.CIRCLE_SE || textLoc === TextLocation.CIRCLE_SW) {
-            dy = +HANDLER_BOX/2;
+            dy = +off;
         }
         var textOff = makeOffsetPt(0, dy);
 
@@ -405,7 +451,9 @@ function markerTextOffset(drawObj) {
 function toMarkerRegion(drawObj,plot, def) {
     if (!has(drawObj, 'drawObjAry')) return [];
 
-    return drawObj.drawObjAry.reduce( (prev, dObj) => {
+    var dObjs = (drawObj.includeHandler) ? drawObj.drawObjAry : drawObj.drawObjAry.slice(0, drawObj.handlerIndex);
+
+    return dObjs.reduce( (prev, dObj) => {
         var regList = DrawOp.toRegion(dObj, plot, def);
 
         if (!isEmpty(regList)) {

--- a/src/firefly/js/visualize/draw/MarkerObj.js
+++ b/src/firefly/js/visualize/draw/MarkerObj.js
@@ -46,6 +46,18 @@ function make(sType) {
 
 var getWorldOrImage = (pt, cc) => (cc.projection.isSpecified() ? cc.getWorldCoords(pt) : cc.getImageCoords(pt));
 
+/**
+ * make drawObj for Marker with handlers or not. Marker is defined as a circle with 4 handlers at the corners
+ * @param centerPt
+ * @param width
+ * @param height
+ * @param isHandler
+ * @param plot
+ * @param text
+ * @param textLoc
+ * @param unitType
+ * @returns {*}
+ */
 export function makeMarker(centerPt, width, height, isHandler, plot, text, textLoc, unitType = ShapeDataObj.UnitType.PIXEL) {
     var dObj = Object.assign(make(MarkerType.Marker), {pts: [centerPt], width, height, unitType});
     var retval;

--- a/src/firefly/js/visualize/draw/MarkerObj.js
+++ b/src/firefly/js/visualize/draw/MarkerObj.js
@@ -1,0 +1,411 @@
+
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import Enum from 'enum';
+import DrawObj from './DrawObj';
+import DrawUtil from './DrawUtil';
+import {TextLocation, Style, DEFAULT_FONT_SIZE} from './DrawingDef.js';
+import {makeImagePt, makeOffsetPt} from '../Point.js';
+import ShapeDataObj from './ShapeDataObj.js';
+import DrawOp from './DrawOp.js';
+import CsysConverter from '../CsysConverter.js';
+import {has, isNil, get, isEmpty} from 'lodash';
+import {defaultMarkerTextLoc} from '../../drawingLayers/MarkerToolUI.jsx';
+import BrowserInfo from '../../util/BrowserInfo.js';
+
+const HANDLER_BOX = 4;        // handler size (square size in screen coordinate)
+const MarkerType= new Enum(['Marker', 'HST_FT']); // TODO: more footprint styles to be defined.
+const MARKER_DATA_OBJ= 'MarkerDataObj';
+const DEF_WIDTH = 1;
+export const MARKER_DISTANCE= BrowserInfo.isTouchInput() ? 18 : 10;
+
+function make(sType) {
+    const obj= DrawObj.makeDrawObj();
+    obj.pts= [];
+    obj.sType= sType;   // default: MarkerType.Marker
+    obj.type= MARKER_DATA_OBJ;
+    // may contain the following:
+        //obj.text= null;
+        //obj.fontName = 'helvetica';
+        //obj.fontSize = DEFAULT_FONT_SIZE;
+        //obj.fontWeight = 'normal';
+        //obj.fontStyle = 'normal';
+        //obj.width= null;
+        //obj.height= null;
+        //obj.style=Style.STANDARD;
+        //obj.sType = MarkerType.Marker
+        //obj.unitType = UnitType.PIXEL;
+        //obj.includeHandler = true|false
+        //obj.textLoc= TextLocation.CIRCLE_SE
+        //obj.textOffset= null;   // offsetScreenPt
+        //obj.drawObjAry= array of ShapeDataObj
+    return obj;
+}
+
+var getWorldOrImage = (pt, cc) => (cc.projection.isSpecified() ? cc.getWorldCoords(pt) : cc.getImageCoords(pt));
+
+export function makeMarker(centerPt, width, height, isHandler, plot, text, textLoc, unitType = ShapeDataObj.UnitType.PIXEL) {
+    var dObj = Object.assign(make(MarkerType.Marker), {pts: [centerPt], width, height, unitType});
+    var retval;
+    var radius = Math.min(width, height)/2;
+    var mainCircle = ShapeDataObj.makeCircleWithRadius(centerPt, radius, unitType);
+    var textProps = {text: (isNil(text) ? '' : text),
+                     textLoc: (isNil(textLoc) ? defaultMarkerTextLoc : textLoc)};
+
+    dObj = Object.assign(dObj, textProps);
+    mainCircle = Object.assign(mainCircle, textProps);
+    retval = [mainCircle];    // circle is the first element in the marker's drawobj array
+
+    dObj.includeHandler = isHandler ? 1 : 0; // start index of handler object
+
+
+    if (isHandler) {
+        var cc = CsysConverter.make(plot);
+        var corners = [[-1, 1], [1, 1], [-1, -1], [1, -1]];
+        var imgPt = cc.getImageCoords(centerPt);
+        var nW = (width)/(2 * cc.zoomFactor);
+        var nH = (height)/(2 * cc.zoomFactor);
+
+        retval = corners.reduce((prev, coord) => {
+            var x = imgPt.x + coord[0] * nW;
+            var y = imgPt.y + coord[1] * nH;
+
+            var handlerCenter = getWorldOrImage(makeImagePt(x, y), cc);
+            var handlerBox = ShapeDataObj.makeRectangleByCenter(handlerCenter, HANDLER_BOX, HANDLER_BOX,
+                                 ShapeDataObj.UnitType.PIXEL, 0.0, ShapeDataObj.UnitType.ARCSEC, false);
+            prev.push(handlerBox);
+            return prev;
+        }, retval);
+    }
+
+    dObj.drawObjAry = retval;
+    markerTextOffset(dObj);
+    return dObj;
+}
+
+
+function makeDrawParams(drawObj,def={}) {
+    var color= DrawUtil.getColor(drawObj.color,def.color);
+    var style= drawObj.style || def.style || Style.STANDARD;
+    var lineWidth= drawObj.lineWidth || def.lineWidth || DEF_WIDTH;
+    var textLoc= drawObj.textLoc || def.textLoc || TextLocation.DEFAULT;
+    var unitType= drawObj.unitType || def.unitType || ShapeDataObj.UnitType.PIXEL;
+    var fontName= drawObj.fontName || def.fontName || 'helvetica';
+    var fontSize= drawObj.fontSize || def.fontSize || DEFAULT_FONT_SIZE;
+    var fontWeight= drawObj.fontWeight || def.fontWeight || 'normal';
+    var fontStyle= drawObj.fontStyle || def.fontStyle || 'normal';
+    return {
+        color,
+        style,
+        lineWidth,
+        textLoc,
+        unitType,
+        fontName,
+        fontSize,
+        fontWeight,
+        fontStyle
+    };
+}
+
+
+var draw=  {
+
+    usePathOptimization(drawObj,def) {
+        var dp= makeDrawParams(drawObj,def);
+        return dp==Style.STANDARD && (drawObj.sType==MarkerType.Marker);
+    },
+
+    getCenterPt(drawObj) {
+        return drawObj.pts[0];
+    },
+
+    getScreenDist(drawObj,plot, pt) {
+        var dist = -1;
+        var testPt = plot.getScreenCoords(drawObj.pts[0]);
+        var distToPt = (x1, y1) => {
+            var dx = x1-pt.x;
+            var dy = y1-pt.y;
+            return Math.sqrt((dx * dx) + (dy * dy));
+        };
+
+        if (testPt) {
+            if (drawObj.sType === ShapeDataObj.ShapeType.Rectangle) {
+                var x1 = testPt.x - drawObj.width / 2;
+                var x2 = testPt.x + drawObj.width / 2;
+                var y1 = testPt.y - drawObj.height / 2;
+                var y2 = testPt.y + drawObj.height / 2;
+
+                var bx = (pt.x >= x1 && pt.x <= x2) ? pt.x : ((pt.x < x1) ? x1 : x2);
+                var by = (pt.y >= y1 && pt.y <= y2) ? pt.y : ((pt.y < y1) ? y1 : y2);
+
+                dist = distToPt(bx, by);
+            } else if (drawObj.sType === ShapeDataObj.ShapeType.Circle) {
+                dist = distToPt(testPt.x, testPt.y);
+                dist = dist > drawObj.radius ? dist - drawObj.radius : 0;
+            }
+        }
+        return dist;
+    },
+
+    draw(drawObj,ctx,drawTextAry,plot,def,vpPtM,onlyAddToPath) {
+        drawMarkerObject(drawObj,ctx,drawTextAry,plot,def,vpPtM, onlyAddToPath);
+    },
+
+    toRegion(drawObj,plot, def) {
+        return toMarkerRegion(drawObj,plot,def);
+    },
+
+    translateTo(drawObj, plot, apt) {
+        return translateMarker(plot,drawObj,apt);
+    },
+
+    rotateAround(drawObj, plot, angle, worldPt) {
+        return rotateMakerAround(plot,drawObj,angle,worldPt);
+    },
+
+    makeHighlight(drawObj, plot, def) {
+        return null;
+    },
+
+    isScreenPointInside(screenPt, drawObj, plot, def) {
+        return findClosestIndex(screenPt, get(drawObj, 'drawObjAry'), plot);  // >=0, if inside <0: not inside
+    }
+};
+
+export default {
+    make,draw, makeMarker, MARKER_DATA_OBJ
+};
+
+/**
+ * find the drawObj inside the marker which is closest to the given screenPt
+ * @param screenPt
+ * @param drawObj
+ * @param cc
+ * @returns {*}
+ */
+export function findClosestIndex(screenPt, drawObj, cc) {
+    var distance = MARKER_DISTANCE;
+    if (!has(drawObj, 'drawObjAry')) {
+        return -1;
+    }
+
+    return drawObj.drawObjAry.reduce((prev, oneObj, index) => {
+        var dist = draw.getScreenDist(oneObj, cc, screenPt);
+
+        if (dist >= 0 && dist < distance) {
+            distance = dist;
+            prev = index;
+        }
+        return prev;
+    }, -1);
+}
+
+
+/**
+ * draw the object which contains drawObj array
+ * @param drawObj
+ * @param ctx
+ * @param drawTextAry
+ * @param plot
+ * @param def
+ * @param vpPtM
+ * @param onlyAddToPath
+ */
+function drawMarkerObject(drawObj, ctx, drawTextAry, plot, def, vpPtM, onlyAddToPath) {
+    var {drawObjAry}= drawObj;
+
+    // draw the child drawObj
+    if (drawObjAry) {
+        drawObjAry.forEach( (oneDrawObj) => DrawOp.draw(oneDrawObj, ctx, drawTextAry, plot, def, vpPtM, onlyAddToPath));
+    }
+}
+
+/**
+ * translate the marker to location apt
+ * @param plot
+ * @param drawObj
+ * @param apt
+ * @returns {*} an array of translated objects contained in drawObj
+ */
+function translateMarker(plot,drawObj,apt) {
+    var centerPt = plot.getImageCoords(drawObj.pts[0]);
+    var pt = plot.getImageCoords(apt);
+    var dx = pt.x - centerPt.x;
+    var dy = pt.y - centerPt.y;
+
+    drawObj.pts = getWorldOrImage(apt, plot);
+
+    if (has(drawObj, 'drawObjAry')) {
+        var dAry =  drawObj.drawObjAry.map((oneObj) => {
+            var {pts} = oneObj;
+            var newPts = pts&&pts.map( (onePt) => {
+                var ptImg = plot.getImageCoords(onePt);
+                return getWorldOrImage(makeImagePt(ptImg.x + dx, ptImg.y + dy), plot);
+            });
+            return Object.assign({}, oneObj, {pts: newPts});
+        });
+        drawObj.drawObjAry = dAry;
+        return dAry;
+    }
+    return null;
+}
+
+/**
+ * rotate a marker around worldPt by angle on image coordinate
+ * @param plot
+ * @param drawObj
+ * @param angle
+ * @param worldPt
+ * @returns {*} a array of rotated objects contained in drawObj
+ */
+function rotateMakerAround(plot,drawObj,angle,worldPt) {
+    var worldImg = plot.getImageCoords(worldPt);
+    var drawObjPt = plot.getImageCoords(drawObj.pts[0]);
+
+    var rotateAroundPt = (imgPt) => {   // rotate around given worldPt on immage coordinate
+        var x1 = imgPt.x - worldImg.x;
+        var y1 = imgPt.y - worldImg.y;
+        var x2 = x1 * Math.cos(angle) - y1 * Math.sin(angle) + worldImg.x;
+        var y2 = x1 * Math.sin(angle) + y1 * Math.cos(angle) + worldImg.y;
+
+        return getWorldOrImage(makeImagePt(x2, y2), plot);
+    };
+
+    var newPt = rotateAroundPt(drawObjPt);
+    var handlers = null;
+
+    // regenerate 4 handlers on the corners of the rectangular coverage after rotation
+    if (drawObj.includeHandler > 0) {
+        var w = drawObj.width/(2*plot.zoomFactor);    // half of width in image coordinate
+        var h = drawObj.height/(2*plot.zoomFactor);   // half of height in image coordinate
+        var corners = [[-1, 1], [1, 1], [1, -1], [-1, -1]];
+        var rotatedCorners = corners.map( (oneCorner) => {    // corners after rotation
+            var x = oneCorner[0] * w + drawObjPt.x;   // 4 corners before rotation on image coordinate
+            var y = oneCorner[1] * h + drawObjPt.y;
+
+            return rotateAroundPt(makeImagePt(x, y));
+        });
+
+        // rectangular coverage after rotation in image coordinate
+        var {min_x, min_y, max_x, max_y} = rotatedCorners.reduce((prev, corner) => {
+            if (!has(prev, 'min_x') || corner.x < prev.min_x ) {
+                prev.min_x = corner.x;
+            }
+            if (!has(prev, 'max_x') || corner.x > prev.max_x ) {
+                prev.max_x = corner.x;
+            }
+            if (!has(prev, 'min_y') || corner.y < prev.min_y ) {
+                prev.min_y = corner.y;
+            }
+            if (!has(prev, 'max_y') || corner.y > prev.max_y ) {
+                prev.max_y = corner.y;
+            }
+            return prev;
+        }, {});
+
+        corners = [[min_x, max_y], [max_y, max_y], [max_x, min_y], [min_x, min_y]];   // corners of rectangular coverage
+        handlers = corners.map( (corner) => {
+            return ShapeDataObj.makeRectangleByCenter(getWorldOrImage(makeImagePt(corner[0], corner[1]), plot),
+                HANDLER_BOX, HANDLER_BOX, ShapeDataObj.UnitType.PIXEL, 0.0, ShapeDataObj.UnitType.ARCSEC, false);
+        });
+    }
+
+    drawObj.pts = [newPt];
+
+    // rotate each shape drawObj contained inside
+    if (has(drawObj, 'drawObjAry')) {
+        var dAry = drawObj.includeHandler > 0 ? drawObj.drawObjAry.slice(drawObj.includeHandler): drawObj.drawObjAry;
+
+        dAry = dAry.map((oneObj) => {
+            var {pts} = oneObj;                             // rotate pts around worldPt
+            var newPts = pts && pts.map((onePt) => {
+                    var ptImg = plot.getImageCoords(onePt);
+                    return rotateAroundPt(ptImg);
+                });
+            var newObj = Object.assign({}, oneObj, {pts: newPts});
+            updateShapeAngle(newObj, angle);               // update angle for the shape which has angle property
+            return newObj;
+        });
+
+        drawObj.drawObjAry = handlers ? [...dAry,...handlers] : dAry;
+        return drawObj.drawObjAry;
+    }
+    return null;
+}
+
+function updateShapeAngle(drawObj, angle) {
+    if (drawObj.sType === ShapeDataObj.ShapeType.Rectangle ||
+        drawObj.sType === ShapeDataObj.ShapeType.Ellipse) {
+        drawObj.angle = angle;
+    }
+}
+
+/**
+ * update the text attached to the marker object
+ * @param drawObj
+ * @param text
+ * @param textLoc
+ * @returns {*}
+ */
+export function updateMarkerDrawObjText(drawObj, text, textLoc) {
+    if (!has(drawObj, 'drawObjAry')) return null;
+
+    var mainIndex = drawObj.drawObjAry.findIndex( (dObj) => (dObj.sType === ShapeDataObj.ShapeType.Circle));
+    var textInfo = Object.assign({}, (!isNil(text))&&{text}, textLoc&&{textLoc});
+
+    if ( mainIndex >= 0 && (text || textLoc )) {
+        var newMain = Object.assign({}, drawObj.drawObjAry[mainIndex], textInfo);
+        var newDrawObj = Object.assign({}, drawObj, textInfo);
+
+        newDrawObj.drawObjAry[mainIndex] = newMain;
+        markerTextOffset(newDrawObj);
+
+        return newDrawObj;
+    }
+    return null;
+}
+
+/**
+ * add text offset to marker object
+ * @param drawObj
+ */
+function markerTextOffset(drawObj) {
+    var {textLoc = TextLocation.DEFAULT, drawObjAry} = drawObj;
+    var mainObj = (drawObjAry) ? drawObjAry[0] : null;
+    var dy = 0;
+
+    if (mainObj) {
+        if (textLoc === TextLocation.CIRCLE_NE || textLoc === TextLocation.CIRCLE_NW) {
+            dy = -HANDLER_BOX/2;
+        } else if (textLoc === TextLocation.CIRCLE_SE || textLoc === TextLocation.CIRCLE_SW) {
+            dy = +HANDLER_BOX/2;
+        }
+        var textOff = makeOffsetPt(0, dy);
+
+        mainObj.textOffset = textOff;
+        drawObj.textOffset = textOff;
+    }
+}
+
+
+/**
+ * generate region description for marker
+ * @param drawObj
+ * @param plot
+ * @param def
+ * @returns {*}
+ */
+function toMarkerRegion(drawObj,plot, def) {
+    if (!has(drawObj, 'drawObjAry')) return [];
+
+    return drawObj.drawObjAry.reduce( (prev, dObj) => {
+        var regList = DrawOp.toRegion(dObj, plot, def);
+
+        if (!isEmpty(regList)) {
+            prev.push(...regList);
+        }
+        return prev;
+    }, []);
+}

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -529,7 +529,7 @@ function drawLine(drawObj, ctx, drawTextAry, plot, drawParams, onlyAddToPath) {
  */
 function drawCircle(drawObj, ctx, drawTextAry, plot, drawParams) {
     var {pts, text, radius, renderOptions}= drawObj;
-    var {color, lineWidth, fontSize, textLoc, unitType,}= drawParams;
+    var {color, lineWidth, fontSize, textLoc, unitType}= drawParams;
 
 
     var inView= false;
@@ -916,6 +916,7 @@ function drawCompositeObject(drawObj, ctx, drawTextAry, plot, drawParams, onlyAd
  * locate text for circle, return the location in screen coordinate
  * @param plot
  * @param textLoc
+ * @param fontSize
  * @param centerPt
  * @param screenRadius
  * @return {null}

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -1212,6 +1212,60 @@ export function lengthToImagePixel(r, plot, unitType) {
 }
 
 /**
+ * calculate the length in screen coordinate
+ * @param r
+ * @param plot
+ * @param unitType
+ * @returns {*}
+ */
+export function lengthToScreenPixel(r, plot, unitType) {
+    var screenRadius;
+
+    switch (unitType) {
+        case UnitType.PIXEL:
+            screenRadius = r;
+            break;
+        case UnitType.IMAGE_PIXEL:
+            screenRadius = r * plot.zoomFactor;
+            break;
+        case UnitType.ARCSEC:
+            screenRadius = r * plot.zoomFactor/(plot.projection.getPixelScaleArcSec());
+            break;
+        default:
+            screenRadius = r;
+    }
+    return screenRadius;
+}
+
+
+/**
+ * calculate the length in world coordinate
+ * @param r
+ * @param plot
+ * @param unitType
+ * @returns {*}
+ */
+export function lengthToArcsec(r, plot, unitType) {
+    var arcsecRadius;
+
+    switch (unitType) {
+        case UnitType.PIXEL:
+            arcsecRadius = screenPixelToArcsec(r, plot);
+            break;
+        case UnitType.IMAGE_PIXEL:
+            arcsecRadius = imagePixelToArcsec(r, plot);
+            break;
+        case UnitType.ARCSEC:
+            arcsecRadius = r;
+            break;
+        default:
+            arcsecRadius = r;
+    }
+    return arcsecRadius;
+}
+
+
+/**
  * calcuate the horizontal and vertical coverage after rotating a rectagle with width and height
  * @param width
  * @param height

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -622,7 +622,7 @@ export function drawText(drawObj, drawTextAry, plot, inPt, drawParams) {
         var color = has(drawObj, 'color') ? drawObj.color : 'black';
         DrawUtil.drawText(drawTextAry, text, x, y, color, renderOptions,
                 fontName+FONT_FALLBACK, fontSize, fontWeight, fontStyle);
-        drawObj.textImgLoc = plot.getImageCoords(makeViewPortPt(x, y));
+        drawObj.textWorldLoc = plot.getImageCoords(makeViewPortPt(x, y));
     }
 }
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -454,7 +454,7 @@ export function getValueInScreenPixel(plot, arcsecValue) {
  * @param drawParams
  * @param onlyAddToPath
  */
-function drawShape(drawObj, ctx, drawTextAry, plot, drawParams, onlyAddToPath) {
+export function drawShape(drawObj, ctx, drawTextAry, plot, drawParams, onlyAddToPath) {
 
     switch (drawObj.sType) {
         case ShapeType.Text:
@@ -507,7 +507,7 @@ function drawLine(drawObj, ctx, drawTextAry, plot, drawParams, onlyAddToPath) {
         if (!onlyAddToPath || style===Style.HANDLED) DrawUtil.stroke(ctx);
     }
 
-    if (text && inView) {
+    if (!isNil(text) && inView) {
         const textLocPt= makeTextLocationLine(plot, textLoc, fontSize,pts[0], pts[1]);
         drawText(drawObj, drawTextAry, plot, plot.getViewPortCoords(textLocPt),
                 drawParams);
@@ -529,7 +529,7 @@ function drawLine(drawObj, ctx, drawTextAry, plot, drawParams, onlyAddToPath) {
  */
 function drawCircle(drawObj, ctx, drawTextAry, plot, drawParams) {
     var {pts, text, radius, renderOptions}= drawObj;
-    var {color, lineWidth, textLoc, unitType,}= drawParams;
+    var {color, lineWidth, fontSize, textLoc, unitType,}= drawParams;
 
 
     var inView= false;
@@ -571,8 +571,8 @@ function drawCircle(drawObj, ctx, drawTextAry, plot, drawParams) {
         }
     }
 
-    if (text && inView && centerPt) {
-        var textPt= makeTextLocationCircle(plot,textLoc,centerPt,screenRadius);
+    if (!isNil(text) && inView && centerPt) {
+        var textPt= makeTextLocationCircle(plot,textLoc, fontSize, centerPt, (screenRadius+lineWidth));
         drawText(drawObj, drawTextAry, plot,textPt, drawParams);
     }
 }
@@ -771,7 +771,7 @@ function drawRectangle(drawObj, ctx, drawTextAry,  plot, drawParams, onlyAddToPa
         }
     }
 
-    if (text && inView) {
+    if (!isNil(text) && inView) {
         var textPt= makeTextLocationRectangle(plot, textLoc, fontSize, centerPt, w, h, angle, lineWidth);
         drawText(drawObj, drawTextAry, plot, textPt, drawParams);
     }
@@ -868,7 +868,7 @@ function drawEllipse(drawObj, ctx, drawTextAry,  plot, drawParams, onlyAddToPath
 
     }
 
-    if (text && inView) {
+    if (!isNil(text) && inView) {
         var textPt= makeTextLocationEllipse(plot, textLoc, fontSize, centerPt, w, h, angle, lineWidth);
         drawText(drawObj, drawTextAry, plot, textPt, drawParams);
     }
@@ -896,7 +896,7 @@ function drawCompositeObject(drawObj, ctx, drawTextAry, plot, drawParams, onlyAd
     }
 
     // draw the text asscociated with the shape, find the overal covered area first
-    if (text) {
+    if (!isNil(text)) {
         var objArea = getDrawobjArea(drawObj, plot);
 
         if (objArea && isAreaInView(objArea, plot)) {
@@ -920,19 +920,21 @@ function drawCompositeObject(drawObj, ctx, drawTextAry, plot, drawParams, onlyAd
  * @param screenRadius
  * @return {null}
  */
-function makeTextLocationCircle(plot, textLoc, centerPt, screenRadius) {
+function makeTextLocationCircle(plot, textLoc, fontSize, centerPt, screenRadius) {
     var scrCenPt= plot.getScreenCoords(centerPt);
     if (!scrCenPt || screenRadius<1) return null;
     var opt;
+    var fHeight = fontHeight(fontSize);
+
     switch (textLoc) {
         case TextLocation.CIRCLE_NE:
-            opt= makeOffsetPt(-1*screenRadius, -1*(screenRadius+10));
+            opt= makeOffsetPt(-1*screenRadius, -1*(screenRadius+fHeight));
             break;
         case TextLocation.CIRCLE_NW:
-            opt= makeOffsetPt(screenRadius, -1*(screenRadius));
+            opt= makeOffsetPt(screenRadius, -1*(screenRadius+fHeight) );
             break;
         case TextLocation.CIRCLE_SE:
-            opt= makeOffsetPt(-1*screenRadius, screenRadius+5);
+            opt= makeOffsetPt(-1*screenRadius, screenRadius);
             break;
         case TextLocation.CIRCLE_SW:
             opt= makeOffsetPt(screenRadius, screenRadius);

--- a/src/firefly/js/visualize/draw/ShapeToRegion.js
+++ b/src/firefly/js/visualize/draw/ShapeToRegion.js
@@ -177,10 +177,10 @@ export function createTextRegionFromShape(drawObj, drawParams, regionType, cc) {
         var doChild = null;
 
         if (has(drawObj, 'drawObjAry')) {
-            doChild = drawObj.drawObjAry.find( ( childDrawObj ) =>  has(childDrawObj, 'textImgLoc') );
+            doChild = drawObj.drawObjAry.find( ( childDrawObj ) =>  has(childDrawObj, 'textWorldLoc') );
         }
 
-        return doChild ? doChild.textImgLoc : null;
+        return doChild ? doChild.textWorldLoc : null;
     };
 
     // check if no text
@@ -191,10 +191,10 @@ export function createTextRegionFromShape(drawObj, drawParams, regionType, cc) {
         (!textOffset || (textOffset.x === 0.0 && textOffset.y === 0.0)))  return des;
 
     // adapt the computed text location if there is or recompute the text location
-    var textImgLoc = get(drawObj, 'textImgLoc', searchTextLoc());
-    if (!textImgLoc) return des;
+    var textWorldLoc = get(drawObj, 'textWorldLoc', searchTextLoc());
+    if (!textWorldLoc) return des;
 
-    return makeTextRegion(cc.getImageCoords(textImgLoc), cc, drawObj, drawParams);
+    return makeTextRegion(cc.getWorldCoords(textWorldLoc), cc, drawObj, drawParams);
 }
 
 /**

--- a/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
@@ -99,7 +99,7 @@ export class ImageViewerLayout extends Component {
                 this.scroll(plotId,mouseState,screenX,screenY);
                 var cursor = DEFAULT_CURSOR;
                 const cursorCandidate= ownerCandidate || findMouseOwner(drawLayersAry,primePlot(plotView),screenPt);
-                if (MOVE.is(mouseState) && has(cursorCandidate, 'getCursor') ) {
+                if (MOVE.is(mouseState) && get(cursorCandidate, 'getCursor') ) {
                     cursor = cursorCandidate.getCursor(plotView, screenPt) || DEFAULT_CURSOR;
                 }
                 if (cursor !== this.state.cursor) this.setState({cursor});

--- a/src/firefly/js/visualize/region/RegionTask.js
+++ b/src/firefly/js/visualize/region/RegionTask.js
@@ -11,7 +11,7 @@ import {getDrawLayerById} from '../PlotViewUtil.js';
 import RegionPlot from '../../drawingLayers/RegionPlot.js';
 import {getPlotViewAry} from '../PlotViewUtil.js';
 import {visRoot } from '../ImagePlotCntlr.js';
-import {has, isArray} from 'lodash';
+import {has, isArray, get} from 'lodash';
 
 const regionDrawLayerId = RegionPlot.TYPE_ID;
 
@@ -22,16 +22,9 @@ var [RegionIdErr, RegionErr, DrawObjErr, JSONErr] = [
     'create drawing object error',
     'get region json error'];
 
-var getPlotIdAry = (plotId) => {
-    if (plotId) {
-        if (isArray(plotId)) {
-            if (plotId.length > 0) return plotId;
-        } else {
-            return [plotId];
-        }
-    }
+var getPlotId = (plotId) => {
+    return (!plotId || (isArray(plotId)&&plotId.length === 0)) ? get(visRoot(), 'activePlotId') : plotId;
 
-    return getPlotViewAry(visRoot()).map((pv) => pv.plotId);
 };
 
 /**
@@ -84,11 +77,13 @@ function createRegionLayer(regionAry, title, regionId, plotId, dataFrom = 'ds9')
             var dl = getDrawLayerById(getDlAry(), regionId);
 
             if (!dl) {
-                 dispatchCreateDrawLayer(regionDrawLayerId, {title, drawLayerId: regionId, regions: rgAry});
+                dispatchCreateDrawLayer(regionDrawLayerId, {title, drawLayerId: regionId, regions: rgAry});
             }
 
-            var plotIdAry = getPlotIdAry(plotId);
-            dispatchAttachLayerToPlot(regionId, plotIdAry, !plotIdAry);
+            var pId = getPlotId(plotId);
+            if (pId) {
+                dispatchAttachLayerToPlot(regionId, pId, true);
+            }
         } else {
             reportError(DrawObjErr);
         }
@@ -107,10 +102,10 @@ export function regionDeleteLayerActionCreator(rawAction) {
     return (dispatcher) => {
         var {plotId, regionId} = rawAction.payload;
 
-        var plotIdAry = getPlotIdAry(plotId);
+        var pId = getPlotId(plotId);
 
-        if (regionId) {
-            dispatchDetachLayerFromPlot(regionId, plotIdAry, !plotIdAry, false);
+        if (regionId && pId) {
+            dispatchDetachLayerFromPlot(regionId, pId, true);
         } else {
             reportError(`${RegionIdErr} for deleting region layer`);
         }

--- a/src/firefly/js/visualize/region/RegionTask.js
+++ b/src/firefly/js/visualize/region/RegionTask.js
@@ -105,7 +105,7 @@ export function regionDeleteLayerActionCreator(rawAction) {
         var pId = getPlotId(plotId);
 
         if (regionId && pId) {
-            dispatchDetachLayerFromPlot(regionId, pId, true);
+            dispatchDetachLayerFromPlot(regionId, pId, true, false);
         } else {
             reportError(`${RegionIdErr} for deleting region layer`);
         }

--- a/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
@@ -13,7 +13,7 @@ import {has, get} from 'lodash';
 var idCnt=0;
 
 const markerItem = {
-    marker: {label: 'Marker'}
+    marker: {label: 'Marker'}     // TODO: add more items for footprint cases
 };
 
 function displayItemText(itemName) {

--- a/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
@@ -4,18 +4,16 @@
 
 import React, {PropTypes} from 'react';
 import {SingleColumnMenu} from '../../ui/DropDownMenu.jsx';
-import MarkerTool from '../../drawingLayers/MarkerTool.js';
 import {ToolbarButton,
         DropDownVerticalSeparator} from '../../ui/ToolbarButton.jsx';
-import {dispatchCreateDrawLayer,
-    dispatchAttachMarkerLayerToPlot} from '../DrawLayerCntlr.js';
+import { dispatchCreateMarkerLayer } from '../DrawLayerCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {has, get} from 'lodash';
 
 var idCnt=0;
 
 const markerItem = {
-    marker: {label: 'Marker', drawLayerType: MarkerTool.TYPE_ID}
+    marker: {label: 'Marker'}
 };
 
 function displayItemText(itemName) {
@@ -24,17 +22,13 @@ function displayItemText(itemName) {
     }
 }
 
-function addNewDrawLayer(pv, itemName) {
+export function addNewDrawLayer(pv, itemName) {
     if (!has(markerItem, itemName)) return;
-
-    var plotId = pv ? pv.plotId : get(visRoot(), 'activePlotId');  // pv should be true, otherwise marker is disabled.
     var drawLayerId = `${markerItem[itemName].label}-${idCnt++}`;
+    var plotId = pv ? pv.plotId : get(visRoot(), 'activePlotId');  // pv should be true, otherwise marker is disabled.
 
-    if (plotId) {
-        dispatchCreateDrawLayer(markerItem[itemName].drawLayerType, {Title: drawLayerId, drawLayerId});
-        dispatchAttachMarkerLayerToPlot(drawLayerId, plotId, true);
-    }
- }
+    dispatchCreateMarkerLayer(drawLayerId, drawLayerId, plotId, true);
+}
 
 export function MarkerDropDownView({plotView:pv}) {
     var enabled = !!pv;

--- a/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
@@ -1,0 +1,54 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {PropTypes} from 'react';
+import {SingleColumnMenu} from '../../ui/DropDownMenu.jsx';
+import MarkerTool from '../../drawingLayers/MarkerTool.js';
+import {ToolbarButton,
+        DropDownVerticalSeparator} from '../../ui/ToolbarButton.jsx';
+import {dispatchCreateDrawLayer,
+    dispatchAttachMarkerLayerToPlot} from '../DrawLayerCntlr.js';
+import {visRoot} from '../ImagePlotCntlr.js';
+import {has, get} from 'lodash';
+
+var idCnt=0;
+
+const markerItem = {
+    marker: {label: 'Marker', drawLayerType: MarkerTool.TYPE_ID}
+};
+
+function displayItemText(itemName) {
+    if (has(markerItem, itemName)) {
+        return `Add ${markerItem[itemName].label}`;
+    }
+}
+
+function addNewDrawLayer(pv, itemName) {
+    if (!has(markerItem, itemName)) return;
+
+    var plotId = pv ? pv.plotId : get(visRoot(), 'activePlotId');  // pv should be true, otherwise marker is disabled.
+    var drawLayerId = `${markerItem[itemName].label}-${idCnt++}`;
+
+    if (plotId) {
+        dispatchCreateDrawLayer(markerItem[itemName].drawLayerType, {Title: drawLayerId, drawLayerId});
+        dispatchAttachMarkerLayerToPlot(drawLayerId, plotId, true);
+    }
+ }
+
+export function MarkerDropDownView({plotView:pv}) {
+    var enabled = !!pv;
+
+    return (
+        <SingleColumnMenu>
+            <ToolbarButton text={displayItemText('marker')}
+                           enabled={enabled} horizontal={false}
+                           onClick={()=> addNewDrawLayer(pv, 'marker')}/>
+            <DropDownVerticalSeparator/>
+        </SingleColumnMenu>
+    );
+}
+
+MarkerDropDownView.propTypes= {
+    plotView : PropTypes.object
+};

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -31,7 +31,7 @@ import sCompare from 'react-addons-shallow-compare';
 import { getDlAry } from '../DrawLayerCntlr.js';
 import WebGrid from '../../drawingLayers/WebGrid.js';
 import {showRegionFileUploadPanel} from '../region/RegionFileUploadView.jsx';
-
+import {MarkerDropDownView} from './MarkerDropDownView.jsx';
 
 
 //===================================================
@@ -64,7 +64,7 @@ import UNLOCKED from 'html/images/icons-2014/BkgUnlocked.png';
 
 import COLOR from 'html/images/icons-2014/28x28_ColorPalette.png';
 import STRETCH from 'html/images/icons-2014/28x28_Log.png';
-// import MARKER from 'html/images/icons-2014/MarkerCirclesIcon_28x28.png';
+import MARKER from 'html/images/icons-2014/MarkerCirclesIcon_28x28.png';
 
 
 export const VIS_TOOLBAR_HEIGHT=34;
@@ -239,6 +239,12 @@ export class VisToolbarView extends Component {
                                         iconOn={DIST_ON}
                                         iconOff={DIST_OFF}
                                         visible={mi.distanceTool} />
+
+                <DropDownToolbarButton icon={MARKER}
+                                       tip='Overlay Markers and Instrument Footprints'
+                                       enabled={enabled} horizontal={true}
+                                       visible={mi.markerToolDD}
+                                       dropDown={<MarkerDropDownView plotView={pv}/>} />
 
                 <SimpleLayerOnOffButton plotView={pv}
                                         typeId={NorthUpCompass.TYPE_ID}


### PR DESCRIPTION
The implementation includes:
- DrawObj for marker
- Marker dropdown list under the marker icon to show the marker and footprint items (will be added later). 
- Marker drawing layer rendering and operation including action creator and action dispatch functions.
- Marker UI component shown in Drawing Layers popup. 
The implementation set up some work which can be similarly expanded to footprints in the future. 
 
Maker drawing layer operation:
- select 'Add Marker' from dropdown list to add a  new drawing layer
- click anywhere to locate the newly added marker
- click and drag the mouse  to relocate or resize the marker: 
  for relocation: click and drag inside the circle, then drag the mouse.
  for resize: click inside the circle, then click and drag the handler to resize 
- label and its location are set from Marker tool UI