### PR TITLE
DM-6726 Default chart and other optimizations

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -196,8 +196,8 @@
             firefly.showTable('tables-2', tblReq2, {removable: false, showUnits: true, showFilters: true});
             //-----------------  CHART DEMO ------------------------//
             //--- using QUERY_ID: 'upload' does not work getActiveTableId('upload') returns undefined ---//
-            firefly.addXYPlot('xyPlot1', {tbl_id: tblReq2.tbl_id, xCol: 'ra1+ra2', yCol: 'dec1+dec2'});
-            firefly.addXYPlot('xyPlot2', {tbl_id: tblReq2.tbl_id, xCol: 'dtanneal', yCol: 'febgain'});
+            firefly.addXYPlot('xyPlot1', {tbl_id: tblReq2.tbl_id, xCol: 'w1mpro+w4mpro', yCol: 'w2mpro'});
+            firefly.addXYPlot('xyPlot2', {tbl_id: tblReq2.tbl_id, xCol: 'ra', yCol: 'dec'});
 
             //-----< old table api ------//
             var tblParams = {

--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -196,8 +196,8 @@
             firefly.showTable('tables-2', tblReq2, {removable: false, showUnits: true, showFilters: true});
             //-----------------  CHART DEMO ------------------------//
             //--- using QUERY_ID: 'upload' does not work getActiveTableId('upload') returns undefined ---//
-            firefly.addXYPlot('xyPlot1', {tbl_id: tblReq2.tbl_id, xCol: 'w1mpro+w4mpro', yCol: 'w2mpro'});
-            firefly.addXYPlot('xyPlot2', {tbl_id: tblReq2.tbl_id, xCol: 'ra', yCol: 'dec'});
+            firefly.addXYPlot('xyPlot1', {tbl_id: tblReq2.tbl_id, xCol: 'ra', yCol: 'dec'});
+            firefly.addXYPlot('xyPlot2', {tbl_id: tblReq2.tbl_id, xCol: 'w1mpro+w4mpro', yCol: 'w2mpro'});
 
             //-----< old table api ------//
             var tblParams = {
@@ -220,7 +220,7 @@
 
             //-----< old xyplot api ------//
             //--- using QUERY_ID: 'oldSelectable' does not work getActiveTableId('upload') returns undefined ---//
-            firefly.addXYPlot({QUERY_ID: 'oldSelectable', xCol: 'crval1', yCol: 'crval2'}, 'oldXyPlot1');
+            firefly.addXYPlot({QUERY_ID: 'oldSelectable'}, 'oldXyPlot1');
             //-----< old xyplot api ------//
 
             var regionAry = [

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -650,7 +650,7 @@ public class QueryUtil {
             if (!doDecimation) {
                 DataObject retrow = new DataObject(retval);
                 retrow.setDataElement(columns[0], convertData(xColClass,xval));
-                retrow.setDataElement(columns[1], convertData(xColClass,yval));
+                retrow.setDataElement(columns[1], convertData(yColClass,yval));
                 retrow.setDataElement(columns[2], rIdx); // natural index
                 retval.add(retrow);
             } else if (checkDeciLimits) {

--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -46,6 +46,7 @@ if (app) {
                 {label:'Catalogs CLASSIC', action:'IrsaCatalogDropDown'},
                 {label:'Test Searches', action:'TestSearches'},
                 {label:'Images', action:'ImageSelectDropDownCmd'},
+                {label:'Charts', action:'ChartSelectDropDownCmd'},
                 {label:'Help', action:HELP_LOAD, type:'COMMAND'},
                 {label:'Example Js Dialog', action:'exampleDialog', type:'COMMAND'}
         ]

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -407,14 +407,14 @@ function showXYPlot(llApi, targetDiv, params={}) {
             const new_tblId = getActiveTableId(tblGroup);
             if (new_tblId !== tblId) {
                 tblId = new_tblId;
-                dispatchSetupTblTracking(tblId);
                 loadPlotDataForTbl(tblId, chartId, xyPlotParams);
+                dispatchSetupTblTracking(tblId);
             }
         });
     }
     if (tblId) {
-        dispatchSetupTblTracking(tblId);
         loadPlotDataForTbl(tblId, chartId, xyPlotParams);
+        dispatchSetupTblTracking(tblId);
     }
 
 
@@ -424,7 +424,8 @@ function showXYPlot(llApi, targetDiv, params={}) {
             tblId,
             chartId,
             closeable: false,
-            expandedMode: false
+            expandedMode: false,
+            deletable: false
         }
     );
 }

--- a/src/firefly/js/api/ApiUtilChart.jsx
+++ b/src/firefly/js/api/ApiUtilChart.jsx
@@ -1,11 +1,6 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {take} from 'redux-saga/effects';
-
-import {dispatchAddSaga} from '../core/MasterSaga.js';
-import * as TablesCntlr from '../tables/TablesCntlr.js';
-import * as TableUtil from '../tables/TableUtil.js';
 
 import * as XYPlotCntlr from '../visualize/XYPlotCntlr.js';
 //import * as HistogramCntlr from '../visualize/HistogramCntlr.js';
@@ -14,22 +9,5 @@ import * as XYPlotCntlr from '../visualize/XYPlotCntlr.js';
 export {uniqueChartId} from '../visualize/ChartUtil.js';
 
 export function loadPlotDataForTbl(tblId, chartId, xyPlotParams) {
-    dispatchAddSaga(getChart, {tblId, chartId, xyPlotParams});
-}
-
-export function* getChart({tblId, chartId, xyPlotParams}) {
-
-    if (TableUtil.isFullyLoaded(tblId)) {
-        XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, TableUtil.getTblById(tblId)['request']);
-        return;
-    }
-
-    while (true) {
-        const action = yield take([TablesCntlr.TABLE_NEW_LOADED]);
-        const {tbl_id, request} = action.payload;
-        if (tbl_id === tblId) {
-            XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, request);
-            return;
-        }
-    }
+    XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tblId);
 }

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -1,0 +1,242 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, { Component, PropTypes} from 'react';
+import sCompare from 'react-addons-shallow-compare';
+import {get} from 'lodash';
+// import {deepDiff} from '../util/WebUtil.js';
+
+import {flux} from '../Firefly.js';
+import * as TblUtil from '../tables/TableUtil.js';
+import * as TableStatsCntlr from '../visualize/TableStatsCntlr.js';
+import * as XYPlotCntlr from '../visualize/XYPlotCntlr.js';
+import * as HistogramCntlr from '../visualize/HistogramCntlr.js';
+import XYPlotOptions from '../visualize/XYPlotOptions.jsx';
+import {resultsSuccess as onXYPlotOptsSelected} from '../visualize/XYPlotOptions.jsx';
+import HistogramOptions from '../visualize/HistogramOptions.jsx';
+import {resultsSuccess as onHistogramOptsSelected} from '../visualize/HistogramOptions.jsx';
+//import {uniqueChartId} from '../visualize/ChartUtil.js';
+
+import FormPanel from './FormPanel.jsx';
+import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
+
+import LOADING from 'html/images/gxt/loading.gif';
+
+const dropdownName = 'ChartSelectDropDownCmd';
+
+const SCATTER = 'scatter';
+const HISTOGRAM = 'histogram';
+const PREF_CHART_TYPE = 'pref.chartType';
+
+function getFormName(chartType) {
+    return chartType+'ChartOpts';
+}
+
+/**
+ *
+ * @param props
+ * @return {XML}
+ * @constructor
+ */
+class ChartSelect extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            chartType: localStorage.getItem(PREF_CHART_TYPE) || SCATTER
+        };
+
+        this.onChartTypeChange = this.onChartTypeChange.bind(this);
+    }
+
+    onChartTypeChange(ev) {
+        // the value of the group is the value of the selected option
+        var val = ev.target.value;
+        var checked = ev.target.checked;
+
+        if (checked) {
+            if (val !== this.state.chartType) {
+                localStorage.setItem(PREF_CHART_TYPE, val);
+                this.setState({chartType : val});
+            }
+        }
+    }
+
+    renderChartSelection() {
+        const {chartType} = this.state;
+        const fieldKey = 'chartType';
+        return (
+            <div style={{display:'block', whiteSpace: 'nowrap'}}>
+                <input type='radio'
+                       name={fieldKey}
+                       value={SCATTER}
+                       defaultChecked={chartType===SCATTER}
+                       onChange={this.onChartTypeChange}
+                /> Scatter Plot&nbsp;&nbsp;
+                <input type='radio'
+                       name={fieldKey}
+                       value={HISTOGRAM}
+                       defaultChecked={chartType===HISTOGRAM}
+                       onChange={this.onChartTypeChange}
+                /> Histogram&nbsp;&nbsp;
+            </div>
+        );
+    }
+
+    render() {
+        const {tblId, tblStatsData} = this.props;
+        const {chartType} = this.state;
+        const formName = getFormName(chartType);
+
+        const resultSuccess = (flds) => {
+            //const chartId = uniqueChartId(chartType);
+            const chartId = tblId; // before chart container is available we support one chart per table
+            switch (chartType) {
+                case SCATTER:
+                    onXYPlotOptsSelected((xyPlotParams) => {
+                        XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tblId);
+                    }, flds);
+                    break;
+                case HISTOGRAM:
+                    onHistogramOptsSelected((histogramParams) => {
+                        HistogramCntlr.dispatchLoadColData(chartId, histogramParams, tblId);
+                    }, flds);
+                    break;
+            }
+            hideSearchPanel();
+        };
+
+        return (
+            <div style={{padding:10, overflow:'auto', maxWidth:350, maxheight:500}}>
+                <FormPanel
+                    groupKey={formName}
+                    onSubmit={resultSuccess}
+                    onCancel={hideSearchPanel}>
+                    {this.renderChartSelection()}
+                    <OptionsWrapper  {...{tblStatsData, chartType}}/>
+                </FormPanel>
+
+            </div>);
+    }
+}
+
+ChartSelect.propTypes = {
+    tblId: PropTypes.string,
+    tblStatsData : PropTypes.object
+};
+
+
+function hideSearchPanel() {
+    dispatchHideDropDown();
+}
+
+export class OptionsWrapper extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+    // componentDidUpdate(prevProps, prevState) {
+    //     deepDiff({props: prevProps, state: prevState},
+    //         {props: this.props, state: this.state},
+    //         this.constructor.name);
+    // }
+
+    render() {
+        const {tblStatsData, chartType} = this.props;
+
+        if (get(tblStatsData,'isColStatsReady')) {
+            const formName = getFormName(chartType);
+            if (chartType === SCATTER) {
+                return (
+                    <XYPlotOptions key={formName} groupKey={formName}
+                                   colValStats={tblStatsData.colStats}/>
+                );
+            } else {
+                return (
+                    <HistogramOptions key={formName} groupKey = {formName}
+                                      colValStats={tblStatsData.colStats}/>
+                );
+            }
+        } else {
+            return (<img style={{verticalAlign:'top', height: 16, padding: 10, float: 'left'}}
+                         title='Loading Options...'
+                         src={LOADING}
+            />);
+        }
+    }
+}
+
+OptionsWrapper.propTypes = {
+    tblStatsData : PropTypes.object,
+    chartType: PropTypes.string
+};
+
+
+
+
+export class ChartSelectDropdown extends Component {
+
+    constructor(props) {
+        super(props);
+        this.state = this.getNextState();
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+    // componentDidUpdate(prevProps, prevState) {
+    //     deepDiff({props: prevProps, state: prevState},
+    //         {props: this.props, state: this.state},
+    //         this.constructor.name);
+    // }
+
+    componentDidMount() {
+        this.removeListener = flux.addListener(() => this.storeUpdate());
+        this.iAmMounted= true;
+    }
+
+    componentWillUnmount() {
+        this.iAmMounted= false;
+        this.removeListener && this.removeListener();
+    }
+
+    getNextState() {
+        const tblId = TblUtil.getActiveTableId(this.props.tblGroup);
+        const tblStatsData = tblId && flux.getState()[TableStatsCntlr.TBLSTATS_DATA_KEY][tblId];
+        return {tblId, tblStatsData};
+    }
+
+    storeUpdate() {
+        if (this.iAmMounted) {
+            const {tblId, tblStatsData} = this.getNextState();
+            if (tblId !== this.state.tblId || tblStatsData !== this.state.tblStatsData) {
+                this.setState(this.getNextState());
+            }
+        }
+    }
+
+    render() {
+        const {tblId, tblStatsData} = this.state;
+        return tblId ? (
+            <ChartSelect {...{tblId, tblStatsData}} {...this.props}/>
+        ) : (
+            <div style={{padding:20, fontSize:'150%'}}>Charts are not available: no active table.</div>
+        );
+    }
+}
+
+ChartSelectDropdown.propTypes = {
+    tblGroup: PropTypes.string, // if not present, default table group is used
+    name: PropTypes.oneOf([dropdownName])
+};
+
+
+ChartSelectDropdown.defaultProps = {
+    name: dropdownName
+};

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -12,6 +12,7 @@ import {flux, getVersion} from '../Firefly.js';
 import {SearchPanel} from '../ui/SearchPanel.jsx';
 import {TestQueriesPanel} from '../ui/TestQueriesPanel.jsx';
 import {ImageSelectDropdown} from '../ui/ImageSelectDropdown.jsx';
+import {ChartSelectDropdown} from '../ui/ChartSelectDropdown.jsx';
 import {CatalogSelectViewPanel} from '../visualize/ui/CatalogSelectViewPanel.jsx';
 import {getAlerts} from '../core/AppDataCntlr.js';
 
@@ -23,6 +24,7 @@ const dropDownMap = {
     AnyDataSetSearch: <SearchPanel />,
     TestSearches: <TestQueriesPanel />,
     ImageSelectDropDownCmd: <ImageSelectDropdown />,
+    ChartSelectDropDownCmd: <ChartSelectDropdown />,
     IrsaCatalogDropDown: <CatalogSelectViewPanel/>
 };
 
@@ -61,9 +63,11 @@ export class DropDownContainer extends Component {
 
     componentDidMount() {
         this.removeListener= flux.addListener(() => this.storeUpdate());
+        this.iAmMounted = true;
     }
 
     componentWillUnmount() {
+        this.iAmMounted = false;
         this.removeListener && this.removeListener();
     }
     
@@ -79,9 +83,11 @@ export class DropDownContainer extends Component {
     // }
 
     storeUpdate() {
-        const {visible, view} = getDropDownInfo();
-        if (visible!==this.state.visible || view!==this.state.selected) {
-            this.setState({visible, selected: view});
+        if (this.iAmMounted) {
+            const {visible, view} = getDropDownInfo();
+            if (visible !== this.state.visible || view !== this.state.selected) {
+                this.setState({visible, selected: view});
+            }
         }
     }
 
@@ -133,9 +139,11 @@ export class Alerts extends Component {
 
     componentDidMount() {
         this.removeListener= flux.addListener(() => this.storeUpdate());
+        this.iAmMounted = true;
     }
 
     componentWillUnmount() {
+        this.iAmMounted = false;
         this.removeListener && this.removeListener();
     }
 
@@ -144,7 +152,9 @@ export class Alerts extends Component {
     }
 
     storeUpdate() {
-        this.setState(getAlerts());
+        if (this.iAmMounted) {
+            this.setState(getAlerts());
+        }
     }
 
     render() {
@@ -158,7 +168,7 @@ export class Alerts extends Component {
             );
         } else return <div/>;
     }
-};
+}
 
 Alerts.propTypes = {
     msg: PropTypes.string,

--- a/src/firefly/js/ui/Menu.jsx
+++ b/src/firefly/js/ui/Menu.jsx
@@ -4,7 +4,7 @@
 
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {isEmpty, get} from 'lodash';
+import {get} from 'lodash';
 import {COMMAND, getMenu} from '../core/AppDataCntlr.js';
 import {flux} from '../Firefly.js';
 import {dispatchShowDropDown} from '../core/LayoutCntlr.js';
@@ -28,7 +28,7 @@ function handleAction (menuItem) {
  * @param isSelected
  * @returns {XML}
  */
-function makeMenuItem(menuItem, isSelected) {
+function  makeMenuItem(menuItem, isSelected) {
     var clsname = 'menu__item' + (isSelected ? ' menu__item-selected' : '');
     return (
         <td key={menuItem.action} align='left' style={{verticalAlign: 'bottom'}} onClick={handleAction.bind(this, menuItem)}>
@@ -96,7 +96,7 @@ export class Menu extends Component {
 }
 
 Menu.propTypes = {
-    menu   : React.PropTypes.object.isRequired
+    menu   : PropTypes.object.isRequired
 };
 
 /**

--- a/src/firefly/js/visualize/ChartUtil.js
+++ b/src/firefly/js/visualize/ChartUtil.js
@@ -62,9 +62,35 @@ function getExpressionValue(strExpr, tableModel, rowIdx) {
     }
 }
 
+export function hasRelatedCharts(tblId, space) {
+    if (space) {
+        return Boolean(Object.keys(space).find((chartId) => {
+            return space[chartId].tblId === tblId;
+        }));
+    } else {
+        return hasRelatedCharts(tblId, flux.getState()[XYPLOT_DATA_KEY]) ||
+            hasRelatedCharts(tblId, flux.getState()[HISTOGRAM_DATA_KEY]);
+    }
+}
+
 export function getTblIdForChartId(chartId) {
     return  get(flux.getState()[XYPLOT_DATA_KEY], [chartId, 'tblId']) ||
             get(flux.getState()[HISTOGRAM_DATA_KEY], [chartId, 'tblId']);
+}
+
+export function numRelatedCharts(tblId) {
+    let numRelated = 0;
+    let c;
+    const keys = [XYPLOT_DATA_KEY, HISTOGRAM_DATA_KEY];
+    keys.forEach( (key) => {
+        const space = flux.getState()[key];
+        for (c in space) {
+            if (space[c].tblId === tblId) {
+                numRelated++;
+            }
+        }
+    });
+    return numRelated;
 }
 
 export function uniqueChartId(prefix) {

--- a/src/firefly/js/visualize/ChartsCntlr.js
+++ b/src/firefly/js/visualize/ChartsCntlr.js
@@ -14,19 +14,20 @@ export const CHART_UI_EXPANDED      = `${UI_PREFIX}.expanded`;
  * request to put a chart into an expanded mode.
  * @param {string} chartId - chart id
  * @param {string} tblId - table id, to which this chart is related. Acts as a group id
+ * @param {string} chartType (ex. scatter, histogram)
  * @param {boolean} optionsPopup - true,  if options should be displayed as a popup
  */
-export function dispatchChartExpanded(chartId, tblId, optionsPopup) {
-    flux.process( {type: CHART_UI_EXPANDED, payload: {chartId, tblId, optionsPopup}});
+export function dispatchChartExpanded(chartId, tblId, chartType, optionsPopup) {
+    flux.process( {type: CHART_UI_EXPANDED, payload: {chartId, tblId, chartType, optionsPopup}});
 }
 
 export function reducer(state={ui:{}}, action={}) {
     //var root = state.ui;
     switch (action.type) {
         case (CHART_UI_EXPANDED) :
-            const {chartId, tblId, optionsPopup} = action.payload;
+            const {chartId, tblId, chartType, optionsPopup} = action.payload;
             //return updateSet(root, 'expanded', {chartId, tblId});
-            return updateSet(state, 'ui.expanded', {chartId, tblId, optionsPopup});
+            return updateSet(state, 'ui.expanded', {chartId, tblId, chartType, optionsPopup});
         default:
             //return root;
             return state;

--- a/src/firefly/js/visualize/ChartsContainer.jsx
+++ b/src/firefly/js/visualize/ChartsContainer.jsx
@@ -63,7 +63,13 @@ export class ChartsContainer extends Component {
 
     render() {
         const {expandedMode, closeable} = this.state;
-        return expandedMode ? <ExpandedView key='chart-expanded' closeable={closeable} {...this.props} {...this.state}/> : <ChartsTableViewPanel {...this.props} {...this.state}/>;
+        return expandedMode ? <ExpandedView key='chart-expanded' closeable={closeable} {...this.props} {...this.state}/> :
+            (
+                <div style={{ display: 'flex',  height: '100%', flexGrow: 1, flexDirection: 'row', overflow: 'hidden'}}>
+                    <ChartsTableViewPanel key='xyplot' {...this.props} {...this.state} chartType='scatter'/>
+                    <ChartsTableViewPanel key='histogram' {...this.props} {...this.state} chartType='histogram'/>
+                </div>
+            );
     }
 }
 

--- a/src/firefly/js/visualize/ChartsContainer.jsx
+++ b/src/firefly/js/visualize/ChartsContainer.jsx
@@ -21,9 +21,9 @@ export function getExpandedChartProps() {
 }
 
 function nextState(props) {
-    const {closeable, chartId, tblId, optionsPopup} = props;
+    const {closeable, chartId, tblId, chartType, optionsPopup} = props;
     const expandedMode = props.expandedMode && getExpandedMode() === LO_VIEW.xyPlots;
-    const chartProps = expandedMode ? getExpandedChartProps() : {chartId, tblId, optionsPopup};
+    const chartProps = expandedMode ? getExpandedChartProps() : {chartId, tblId, chartType, optionsPopup};
     return Object.assign({expandedMode,closeable}, chartProps);
 }
 

--- a/src/firefly/js/visualize/ChartsTableViewPanel.jsx
+++ b/src/firefly/js/visualize/ChartsTableViewPanel.jsx
@@ -479,7 +479,7 @@ class ChartsPanel extends React.Component {
                          title='Expand this panel to take up a larger area'
                          src={OUTLINE_EXPAND}
                          onClick={() => {
-                            dispatchChartExpanded(chartId, tblId, optionsPopup);
+                            dispatchChartExpanded(chartId, tblId, chartType, optionsPopup);
                             dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.xyPlots);
                          }}
                     />}

--- a/src/firefly/js/visualize/ChartsTableViewPanel.jsx
+++ b/src/firefly/js/visualize/ChartsTableViewPanel.jsx
@@ -6,7 +6,7 @@ import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
 // import {deepDiff} from '../util/WebUtil.js';
 
-import {get, debounce, defer} from 'lodash';
+import {get, debounce, defer, isBoolean} from 'lodash';
 import Resizable from 'react-component-resizable';
 
 
@@ -23,7 +23,7 @@ import {dispatchChartExpanded} from '../visualize/ChartsCntlr.js';
 
 import {LO_MODE, LO_VIEW, dispatchSetLayoutMode} from '../core/LayoutCntlr.js';
 
-import {getHighlighted, getTblIdForChartId} from './ChartUtil.js';
+import {getHighlighted, getTblIdForChartId, numRelatedCharts} from './ChartUtil.js';
 import XYPlotOptions from '../visualize/XYPlotOptions.jsx';
 import {XYPlot} from '../visualize/XYPlot.jsx';
 
@@ -36,6 +36,7 @@ import {dispatchShowDialog, dispatchHideDialog, isDialogVisible} from '../core/C
 
 import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
+import DELETE from 'html/images/blue_delete_10x10.png';
 import OUTLINE_EXPAND from 'html/images/icons-2014/24x24_ExpandArrowsWhiteOutline.png';
 import SETTINGS from 'html/images/icons-2014/24x24_GearsNEW.png';
 import ZOOM_IN from 'html/images/icons-2014/24x24_ZoomIn.png';
@@ -59,8 +60,10 @@ function getChartType(props) {
     if (props.chartId !== props.tblId) {
          if (props.tblPlotData) { return SCATTER; }
          if (props.tblHistogramData) { return HISTOGRAM; }
+    } else {
+        return props.chartType;
     }
-    return (localStorage.getItem(PREF_CHART_TYPE) || SCATTER);
+    //return (localStorage.getItem(PREF_CHART_TYPE) || SCATTER);
 }
 
 class ChartsPanel extends React.Component {
@@ -74,8 +77,8 @@ class ChartsPanel extends React.Component {
         };
 
         const normal = (size) => {
-            if (size && !this.isUnmounted) {
-                var widthPx = size.width - 10;
+            if (size && this.iAmMounted) {
+                var widthPx = size.width;
                 var heightPx = size.height;
                 //console.log('width: '+widthPx+', height: '+heightPx);
                 if (widthPx !== this.state.widthPx || heightPx != this.state.heightPx) {
@@ -107,7 +110,6 @@ class ChartsPanel extends React.Component {
         this.selectionNotEmpty = this.selectionNotEmpty.bind(this);
         this.renderSelectionButtons = this.renderSelectionButtons.bind(this);
         this.renderToolbar = this.renderToolbar.bind(this);
-        this.renderChartSelection = this.renderChartSelection.bind(this);
         this.onChartTypeChange = this.onChartTypeChange.bind(this);
         this.renderOptions = this.renderOptions.bind(this);
     }
@@ -116,7 +118,8 @@ class ChartsPanel extends React.Component {
         let doUpdate = nextState !== this.state ||
             nextProps.chartId !== this.props.chartId ||
             nextProps.tblStatsData !== this.props.tblStatsData ||
-            nextProps.expandedMode !== this.props.expandedMode;
+            nextProps.expandedMode !== this.props.expandedMode ||
+            nextProps.deletable !== this.props.deletable;
         if (!doUpdate) {
             const chartType = getChartType(nextProps);
             if (chartType === SCATTER) {
@@ -136,6 +139,7 @@ class ChartsPanel extends React.Component {
 
     componentDidMount() {
         this.handlePopups();
+        this.iAmMounted = true;
     }
 
     componentDidUpdate() {
@@ -147,17 +151,17 @@ class ChartsPanel extends React.Component {
     }
 
     componentWillUnmount() {
+        this.iAmMounted = false;
         if (isDialogVisible(popupId)) {
             hideChartOptionsPopup();
         }
-        this.isUnmounted = true;
     }
 
     handlePopups() {
         if (this.props.optionsPopup) {
             const {optionsShown, chartType} = this.state;
             if (optionsShown) {
-                const {tableModel, tblStatsData, tblPlotData, tblHistogramData, tblId, chartId} = this.props;
+                const {tableModel, tblStatsData, tblPlotData, tblHistogramData, chartId} = this.props;
                 // show options popup
                 let popupTitle = 'Chart Options';
 
@@ -168,7 +172,6 @@ class ChartsPanel extends React.Component {
                     <PopupPanel title={popupTitle} closeCallback={()=>{this.toggleOptions();}}>
                         <div
                             style={{overflow:'auto',width:OPTIONS_WIDTH,height:300,paddingTop:10,paddingLeft:10,verticalAlign:'top'}}>
-                            {chartId===tblId ? this.renderChartSelection() : false}
                             <OptionsWrapper {...{chartId, tableModel, tblStatsData, tblPlotData, tblHistogramData, chartType}}/>
                         </div>
                     </PopupPanel>
@@ -460,7 +463,8 @@ class ChartsPanel extends React.Component {
     }
 
     renderToolbar() {
-        const {expandable, expandedMode, tblId, chartId, optionsPopup} = this.props;
+        const {expandable, expandedMode, tblId, chartId, optionsPopup, deletable} = this.props;
+        const chartType = this.state.chartType;
         return (
             <div style={{height: 30, position: 'absolute', top: 0, left: 0, right: 0}}>
                 <img style={{verticalAlign:'top', float: 'left', cursor: 'pointer'}}
@@ -478,34 +482,25 @@ class ChartsPanel extends React.Component {
                             dispatchChartExpanded(chartId, tblId, optionsPopup);
                             dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.xyPlots);
                          }}
-                    />
-                    }
+                    />}
+                    { expandable && !expandedMode &&
+                    isBoolean(deletable) ? deletable : numRelatedCharts(tblId) > 1 &&  // when deletable is undefined, use related charts criterion
+                    <img style={{verticalAlign: 'top', paddingLeft: 2, paddingRight:5, cursor: 'pointer'}}
+                         title='Delete this chart'
+                         src={DELETE}
+                         onClick={() => {
+                            if (chartType === SCATTER) {
+                                XYPlotCntlr.dispatchDelete(chartId);
+                            } else if (chartType === HISTOGRAM) {
+                                HistogramCntlr.dispatchDelete(chartId);
+                            }
+                         }}
+                    />}
                 </div>
             </div>
         );
     }
 
-    renderChartSelection() {
-        const {tblId} = this.props;
-        const {chartType} = this.state;
-        const fieldKey = 'chartType_'+tblId;
-        return (
-            <div style={{display:'block', whiteSpace: 'nowrap'}}>
-                <input type='radio'
-                       name={fieldKey}
-                       value={SCATTER}
-                       defaultChecked={chartType===SCATTER}
-                       onChange={this.onChartTypeChange}
-                /> Scatter Plot&nbsp;&nbsp;
-                <input type='radio'
-                       name={fieldKey}
-                       value={HISTOGRAM}
-                       defaultChecked={chartType===HISTOGRAM}
-                       onChange={this.onChartTypeChange}
-                /> Histogram&nbsp;&nbsp;
-            </div>
-        );
-    }
 
     onChartTypeChange(ev) {
         // the value of the group is the value of the selected option
@@ -522,11 +517,10 @@ class ChartsPanel extends React.Component {
 
     renderOptions() {
         const {optionsShown, chartType, heightPx} = this.state;
-        const { tblId, tableModel, tblStatsData, tblPlotData, tblHistogramData, optionsPopup, chartId} = this.props;
+        const { tableModel, tblStatsData, tblPlotData, tblHistogramData, optionsPopup, chartId} = this.props;
         if (optionsShown && !optionsPopup) {
             return (
                 <div style={{flex: '0 0 auto',overflow:'auto',width:OPTIONS_WIDTH,height:heightPx,paddingLeft:10,verticalAlign:'top'}}>
-                    {chartId===tblId ? this.renderChartSelection() : false}
                     <OptionsWrapper  {...{chartId, tableModel, tblStatsData, tblPlotData, tblHistogramData, chartType}}/>
                 </div>
             );
@@ -548,6 +542,11 @@ class ChartsPanel extends React.Component {
             var {widthPx, heightPx, chartType} = this.state;
             const knownSize = widthPx && heightPx;
 
+            if (chartType === SCATTER && !this.props.tblPlotData ||
+                    chartType === HISTOGRAM && !this.props.tblHistogramData) {
+                return null;
+            }
+
             return (
                 <div style={{ display: 'flex', flex: 'auto', flexDirection: 'column', height: '100%', overflow: 'hidden'}}>
                     <div style={{ position: 'relative', flexGrow: 1}}>
@@ -555,7 +554,7 @@ class ChartsPanel extends React.Component {
                         <div style={{display: 'flex', flexDirection: 'row', position: 'absolute', top: 30, bottom: 0, left: 0, right: 0}}>
                             {this.renderOptions()}
                             <Resizable id='chart-resizer' onResize={this.onResize} style={{flexGrow: 1, position: 'relative', width: '100%', height: '100%', overflow: 'hidden'}}>
-                                <div style={{overflow:'auto',width:widthPx,height:heightPx,paddingLeft:10}}>
+                                <div style={{overflow:'auto',width:widthPx,height:heightPx}}>
                                     {knownSize ? chartType === SCATTER ? this.renderXYPlot() : this.renderHistogram() : <div/>}
                                 </div>
                             </Resizable>
@@ -571,6 +570,7 @@ ChartsPanel.propTypes = {
     expandedMode: PropTypes.bool,
     optionsPopup: PropTypes.bool,
     expandable: PropTypes.bool,
+    deletable : PropTypes.bool,
     tblId : PropTypes.string,
     tableModel : PropTypes.object,
     tblStatsData : PropTypes.object,
@@ -607,25 +607,30 @@ export class ChartsTableViewPanel extends Component {
 
     componentDidMount() {
         this.removeListener = flux.addListener(() => this.storeUpdate());
+        this.iAmMounted = true;
     }
 
     componentWillUnmount() {
+        this.iAmMounted=false;
         this.removeListener && this.removeListener();
     }
 
     getNextState() {
-        var {tblId, chartId} = this.props;
+        var {tblId, chartId, deletable} = this.props;
         tblId = tblId || chartId ? getTblIdForChartId(chartId) : TblUtil.getActiveTableId();
         chartId = this.props.chartId || tblId;
         const tableModel = TblUtil.getTblById(tblId);
         const tblStatsData = flux.getState()[TableStatsCntlr.TBLSTATS_DATA_KEY][tblId];
         const tblHistogramData = chartId ? flux.getState()[HistogramCntlr.HISTOGRAM_DATA_KEY][chartId] : undefined;
         const tblPlotData = chartId ? flux.getState()[XYPlotCntlr.XYPLOT_DATA_KEY][chartId] : undefined;
-        return {chartId, tblId, tableModel, tblStatsData, tblHistogramData, tblPlotData};
+        deletable = isBoolean(deletable) ? deletable : numRelatedCharts(tblId) > 1;
+        return {chartId, tblId, tableModel, tblStatsData, tblHistogramData, tblPlotData, deletable};
     }
 
     storeUpdate() {
-        this.setState(this.getNextState());
+        if (this.iAmMounted) {
+            this.setState(this.getNextState());
+        }
     }
 
     render() {
@@ -638,7 +643,8 @@ export class ChartsTableViewPanel extends Component {
 
 ChartsTableViewPanel.propTypes = {
     tblId: PropTypes.string, // if not present, active table id is used
-    chartId: PropTypes.string // if not present table id is used as a chart id
+    chartId: PropTypes.string, // if not present table id is used as a chart id
+    deletable: PropTypes.bool // should the chart be deletable?
 };
 
 export class OptionsWrapper extends React.Component {
@@ -649,6 +655,7 @@ export class OptionsWrapper extends React.Component {
     shouldComponentUpdate(nProps) {
         return nProps.chartId != this.props.chartId ||
         get(nProps, 'tblPlotData.xyPlotParams') !== get(this.props, 'tblPlotData.xyPlotParams') ||
+        get(nProps, 'tblHistogramData.histogramParams') !== get(this.props, 'tblHistogramData.histogramParams') ||
         get(nProps, 'tableModel.tbl_id') !== get(this.props, 'tableModel.tbl_id') ||
             get(nProps, 'tblStatsData.isColStatsReady') !== get(this.props, 'tblStatsData.isColStatsReady') ||
             nProps.chartType != this.props.chartType;
@@ -664,14 +671,14 @@ export class OptionsWrapper extends React.Component {
         const { chartId, tableModel, tblStatsData, chartType, tblPlotData, tblHistogramData} = this.props;
 
         if (get(tblStatsData,'isColStatsReady')) {
-            const formName = 'ChartOpt_' + chartId;
+            const formName = 'ChartOpt_' + chartType + chartId;
             if (chartType === SCATTER) {
                 return (
                     <XYPlotOptions key={formName} groupKey={formName}
                                    colValStats={tblStatsData.colStats}
                                    xyPlotParams={get(tblPlotData, 'xyPlotParams')}
                                    onOptionsSelected={(xyPlotParams) => {
-                                                XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tableModel.request);
+                                                XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tableModel.tbl_id);
                                             }
                                           }/>
                 );
@@ -681,7 +688,7 @@ export class OptionsWrapper extends React.Component {
                                       colValStats={tblStatsData.colStats}
                                       histogramParams={get(tblHistogramData, 'histogramParams')}
                                       onOptionsSelected={(histogramParams) => {
-                                                HistogramCntlr.dispatchLoadColData(chartId, histogramParams, tableModel.request);
+                                                HistogramCntlr.dispatchLoadColData(chartId, histogramParams, tableModel.tbl_id);
                                             }
                                           }/>
                 );
@@ -690,7 +697,7 @@ export class OptionsWrapper extends React.Component {
             return (<img style={{verticalAlign:'top', height: 16, padding: 10, float: 'left'}}
                          title='Loading Options...'
                          src={LOADING}
-            />);
+             />);
         }
     }
 }

--- a/src/firefly/js/visualize/saga/ChartsSync.js
+++ b/src/firefly/js/visualize/saga/ChartsSync.js
@@ -6,7 +6,6 @@ import {take} from 'redux-saga/effects';
 import {has} from 'lodash';
 
 import {flux} from '../../Firefly.js';
-import {MetaConst} from '../../data/MetaConst.js';
 
 import * as TablesCntlr from '../../tables/TablesCntlr.js';
 import * as TableStatsCntlr from '../TableStatsCntlr.js';
@@ -14,9 +13,7 @@ import * as TableUtil from '../../tables/TableUtil.js';
 
 import * as XYPlotCntlr from '../XYPlotCntlr.js';
 import * as HistogramCntlr from '../HistogramCntlr.js';
-import {hasRelatedCharts} from '../ChartUtil.js';
-
-
+import {hasRelatedCharts, getDefaultXYPlotParams} from '../ChartUtil.js';
 
 /**
  * this saga handles chart related side effects
@@ -84,58 +81,5 @@ export function* syncCharts() {
     }
 }
 
-function colWithName(cols, name) {
-    return cols.find((c) => { return c.name===name; });
-}
 
-function getNumericCols(cols) {
-    const ncols = [];
-    cols.forEach((c) => {
-        if (c.type !== 'char') {
-            ncols.push(c);
-        }
-    });
-    return ncols;
-}
 
-function getDefaultXYPlotParams(tbl_id) {
-
-    const {tableMeta, tableData, totalRows}= TableUtil.getTblById(tbl_id);
-
-    if (!totalRows) {
-        return;
-    }
-
-    // for catalogs use lon and lat columns
-    let isCatalog = Boolean(tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] && tableMeta[MetaConst.CATALOG_COORD_COLS]);
-    let xCol = undefined, yCol = undefined;
-
-    if (isCatalog) {
-        const s = tableMeta[MetaConst.CATALOG_COORD_COLS].split(';');
-        if (s.length !== 3) return;
-        xCol = colWithName(tableData.columns, s[0]); // longtitude
-        yCol = colWithName(tableData.columns, s[1]); // latitude
-
-        if (!xCol || !yCol) {
-            isCatalog = false;
-        }
-    }
-
-    // otherwise use the first one-two numeric columns
-    if (!isCatalog) {
-        const numericCols = getNumericCols(tableData.columns);
-        if (numericCols.length > 2) {
-            xCol = numericCols[0];
-            yCol = numericCols[1];
-        } else if (numericCols.length > 1) {
-            xCol = numericCols[0];
-            yCol = numericCols[0];
-        }
-    }
-
-    return (xCol && yCol) ?
-    {
-        x: {columnOrExpr: xCol.name, label: xCol.name, unit: xCol.units?xCol.units:''},
-        y: {columnOrExpr: yCol.name, label: yCol.name, unit: yCol.units?yCol.units:''}
-    } : undefined;
-}

--- a/src/firefly/js/visualize/saga/ChartsSync.js
+++ b/src/firefly/js/visualize/saga/ChartsSync.js
@@ -6,12 +6,15 @@ import {take} from 'redux-saga/effects';
 import {has} from 'lodash';
 
 import {flux} from '../../Firefly.js';
+import {MetaConst} from '../../data/MetaConst.js';
+
 import * as TablesCntlr from '../../tables/TablesCntlr.js';
 import * as TableStatsCntlr from '../TableStatsCntlr.js';
 import * as TableUtil from '../../tables/TableUtil.js';
 
 import * as XYPlotCntlr from '../XYPlotCntlr.js';
 import * as HistogramCntlr from '../HistogramCntlr.js';
+import {hasRelatedCharts} from '../ChartUtil.js';
 
 
 
@@ -29,38 +32,110 @@ export function* syncCharts() {
                 const {tblId} = action.payload;
                 if (TableUtil.isFullyLoaded(tblId)) {
                     TableStatsCntlr.dispatchLoadTblStats(TableUtil.getTblById(tblId)['request']);
+                    if (!hasRelatedCharts(tblId)) {
+                        // default chart is xy plot of coordinate columns or first two numeric columns
+                        const defaultParams = getDefaultXYPlotParams(tblId);
+                        if (defaultParams) {
+                            XYPlotCntlr.dispatchLoadPlotData(tblId, defaultParams, tblId);
+                        }
+                    }
                 }
                 break;
             case TablesCntlr.TABLE_SORT:
             case TablesCntlr.TABLE_NEW_LOADED:
                 const {tbl_id} = action.payload;
-
-                // table statistics and histogram data do not change on table sort
-                if (action.type !== TablesCntlr.TABLE_SORT) {
-                    tableStatsState = flux.getState()[TableStatsCntlr.TBLSTATS_DATA_KEY];
-                    if (has(tableStatsState, tbl_id)) {
-                        TableStatsCntlr.dispatchLoadTblStats(request);
-                    }
-
-                    histogramState = flux.getState()[HistogramCntlr.HISTOGRAM_DATA_KEY];
-                    Object.keys(histogramState).forEach((cid) => {
-                        if (histogramState[cid].tblId === tbl_id) {
-                            const histogramParams = histogramState[cid].histogramParams;
-                            HistogramCntlr.dispatchLoadColData(cid, histogramParams, request);
-                        }
-                    });
-                }
+                let hasRelated = false;
 
                 xyPlotState = flux.getState()[XYPlotCntlr.XYPLOT_DATA_KEY];
                 Object.keys(xyPlotState).forEach((cid) => {
                     if (xyPlotState[cid].tblId === tbl_id) {
                         const xyPlotParams = xyPlotState[cid].xyPlotParams;
-                        XYPlotCntlr.dispatchLoadPlotData(cid, xyPlotParams, request);
+                        XYPlotCntlr.dispatchLoadPlotData(cid, xyPlotParams, tbl_id);
+                        hasRelated = true;
                     }
                 });
+
+                // table statistics and histogram data do not change on table sort
+                if (action.type !== TablesCntlr.TABLE_SORT) {
+                    histogramState = flux.getState()[HistogramCntlr.HISTOGRAM_DATA_KEY];
+                    Object.keys(histogramState).forEach((cid) => {
+                        if (histogramState[cid].tblId === tbl_id) {
+                            const histogramParams = histogramState[cid].histogramParams;
+                            HistogramCntlr.dispatchLoadColData(cid, histogramParams, tbl_id);
+                            hasRelated = true;
+                        }
+                    });
+
+                    tableStatsState = flux.getState()[TableStatsCntlr.TBLSTATS_DATA_KEY];
+                    if (has(tableStatsState, tbl_id)) {
+                        TableStatsCntlr.dispatchLoadTblStats(request);
+                        if (!hasRelated) {
+                            // default chart is xy plot of coordinate columns or first two numeric columns
+                            const defaultParams = getDefaultXYPlotParams(tbl_id);
+                            if (defaultParams) {
+                                XYPlotCntlr.dispatchLoadPlotData(tbl_id, defaultParams, tbl_id);
+                            }
+                        }
+                    }
+                }
 
                 break;
         }
     }
 }
 
+function colWithName(cols, name) {
+    return cols.find((c) => { return c.name===name; });
+}
+
+function getNumericCols(cols) {
+    const ncols = [];
+    cols.forEach((c) => {
+        if (c.type !== 'char') {
+            ncols.push(c);
+        }
+    });
+    return ncols;
+}
+
+function getDefaultXYPlotParams(tbl_id) {
+
+    const {tableMeta, tableData, totalRows}= TableUtil.getTblById(tbl_id);
+
+    if (!totalRows) {
+        return;
+    }
+
+    // for catalogs use lon and lat columns
+    let isCatalog = Boolean(tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] && tableMeta[MetaConst.CATALOG_COORD_COLS]);
+    let xCol = undefined, yCol = undefined;
+
+    if (isCatalog) {
+        const s = tableMeta[MetaConst.CATALOG_COORD_COLS].split(';');
+        if (s.length !== 3) return;
+        xCol = colWithName(tableData.columns, s[0]); // longtitude
+        yCol = colWithName(tableData.columns, s[1]); // latitude
+
+        if (!xCol || !yCol) {
+            isCatalog = false;
+        }
+    }
+
+    // otherwise use the first one-two numeric columns
+    if (!isCatalog) {
+        const numericCols = getNumericCols(tableData.columns);
+        if (numericCols.length > 2) {
+            xCol = numericCols[0];
+            yCol = numericCols[1];
+        } else if (numericCols.length > 1) {
+            xCol = numericCols[0];
+            yCol = numericCols[0];
+        }
+    }
+
+    return (xCol && yCol) ?
+    {
+        x: {columnOrExpr: xCol.name, label: xCol.name, unit: xCol.units?xCol.units:''},
+        y: {columnOrExpr: yCol.name, label: yCol.name, unit: yCol.units?yCol.units:''}
+    } : undefined;
+}


### PR DESCRIPTION
- Removed chart selection from chart area
- Dropdown for chart selection (can be omitted if single chart type is used)
- Populate current values in chart options
- Support Clear and Reset in chart options
- For tables, connected to charts, if no default parameters are specified, default chart id XY plot with center columns for catalogs or two first numeric columns for other tables.
- Label, matching column expression, and unit, matching table model, are default parameters for both app and api now.
- Cleaned chart API a bit