### PR TITLE
DM-6022 Lazy load related chart data on table data update

### DIFF
--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -357,12 +357,12 @@ function makePlotId() {
 //================================================================
 
 function showXYPlot(llApi, targetDiv, params={}) {
-    const {dispatchSetupTblTracking, dispatchTableFetch}= llApi.action;
+    const {dispatchTableFetch}= llApi.action;
     const {TBL_RESULTS_ACTIVE} = llApi.action.type;
     const {renderDOM} = llApi.util;
     const {makeFileRequest, getActiveTableId, uniqueTblId} = llApi.util.table;
     const {uniqueChartId, loadPlotDataForTbl} = llApi.util.chart;
-    const {ChartsContainer, ChartsTableViewPanel}= llApi.ui;
+    const {ChartsTableViewPanel}= llApi.ui;
     const {addActionListener} = llApi.util;
 
     if ((typeof targetDiv).match(/string|HTMLDivElement/) === null) {
@@ -397,7 +397,6 @@ function showXYPlot(llApi, targetDiv, params={}) {
         );
         tblId = searchRequest.tbl_id;
         dispatchTableFetch(searchRequest);
-        dispatchSetupTblTracking(tblId);
     }
 
     const chartId = uniqueChartId(tblId||tblGroup);

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -10,7 +10,6 @@ import shallowequal from 'shallowequal';
 import {dataReducer} from './reducer/TableDataReducer.js';
 import {uiReducer} from './reducer/TableUiReducer.js';
 import {resultsReducer} from './reducer/TableResultsReducer.js';
-import {dispatchSetupTblTracking} from '../visualize/TableStatsCntlr.js';
 import {dispatchAddSaga} from '../core/MasterSaga.js';
 
 export const TABLE_SPACE_PATH = 'table_space';
@@ -48,8 +47,7 @@ export function tableSearch(action) {
             var {request, options, tbl_group} = action.payload;
             const {tbl_id} = request;
             const title = get(request, 'META_INFO.title');
-            
-            dispatchSetupTblTracking(tbl_id);
+
             dispatchTableFetch(request);
             if (!TblUtil.getTableInGroup(tbl_id, tbl_group)) {
                 const {tbl_group, removable} = options || {};

--- a/src/firefly/js/visualize/ChartsCntlr.js
+++ b/src/firefly/js/visualize/ChartsCntlr.js
@@ -2,13 +2,20 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
+import {has, get, isUndefined, omit} from 'lodash';
+
 import {flux} from '../Firefly.js';
-import {updateSet} from '../util/WebUtil.js';
+import {updateSet, updateMerge} from '../util/WebUtil.js';
+
+import * as TablesCntlr from '../tables/TablesCntlr.js';
 
 export const CHART_SPACE_PATH = 'charts';
 export const UI_PREFIX = `${CHART_SPACE_PATH}.ui`;
 
 export const CHART_UI_EXPANDED      = `${UI_PREFIX}.expanded`;
+export const CHART_MOUNTED = `${UI_PREFIX}/mounted`;
+export const CHART_UNMOUNTED = `${UI_PREFIX}/unmounted`;
+export const DELETE = `${UI_PREFIX}/delete`;
 
 /**
  * request to put a chart into an expanded mode.
@@ -21,15 +28,132 @@ export function dispatchChartExpanded(chartId, tblId, chartType, optionsPopup) {
     flux.process( {type: CHART_UI_EXPANDED, payload: {chartId, tblId, chartType, optionsPopup}});
 }
 
+/*
+ *  Dispatched when chart becomes visible (is rendered for the first time after being invisible)
+ *  When chart is mounted, its data need to be in sync with the related table
+ *  @param {string} tblId - table id (table data for this chart)
+ *  @param {string} chartId - chart id
+ *  @param {string} chartType - chart type, ex. scatter, histogram
+ */
+export function dispatchChartMounted(tblId, chartId, chartType, dispatcher= flux.process) {
+    dispatcher({type: CHART_MOUNTED, payload: {tblId, chartId, chartType}});
+}
+
+/*
+ *  Dispatched when chart becomes invisible
+ *  When chart is unmounted, its data synced with the related table only when it becomes mounted again
+ *  @param {string} tblId - table id (table data for this chart)
+ *  @param {string} chartId - chart id
+ *  @param {string} chartType - chart type, ex. scatter, histogram
+ */
+export function dispatchChartUnmounted(tblId, chartId, chartType, dispatcher= flux.process) {
+    dispatcher({type: CHART_UNMOUNTED, payload: {tblId, chartId, chartType}});
+}
+
+/*
+ * Delete chart and related data
+ *  @param {string} tblId - table id (table data for this chart)
+ *  @param {string} chartId - chart id
+ *  @param {string} chartType - chart type, ex. scatter, histogram
+ */
+export function dispatchDelete(tblId, chartId, chartType, dispatcher= flux.process) {
+    dispatcher({type: DELETE, payload: {tblId, chartId, chartType}});
+}
+
+const uniqueId = (chartId, chartType) => { return `${chartType}|${chartId}`; };
+const isChartType = (uChartId, chartType) => { return uChartId.startsWith(chartType); };
+
+const chartActions = [CHART_UI_EXPANDED,CHART_MOUNTED,CHART_UNMOUNTED,DELETE];
+
 export function reducer(state={ui:{}}, action={}) {
-    //var root = state.ui;
-    switch (action.type) {
-        case (CHART_UI_EXPANDED) :
-            const {chartId, tblId, chartType, optionsPopup} = action.payload;
-            //return updateSet(root, 'expanded', {chartId, tblId});
-            return updateSet(state, 'ui.expanded', {chartId, tblId, chartType, optionsPopup});
-        default:
-            //return root;
-            return state;
+    if (action.type === TablesCntlr.TABLE_REMOVE) {
+        const {tbl_id} = action.payload;
+        if (has(state, tbl_id)) {
+            return Object.assign({}, omit(state, [tbl_id]));
+        }
+        return state;
+    } else if (chartActions.indexOf(action.type) > -1) {
+        const {chartId, tblId, chartType}  = action.payload;
+        const uChartId = uniqueId(chartId, chartType);
+        switch (action.type) {
+
+            case (CHART_UI_EXPANDED) :
+                const {optionsPopup} = action.payload;
+                //return updateSet(root, 'expanded', {chartId, tblId});
+                return updateSet(state, 'ui.expanded', {chartId, tblId, chartType, optionsPopup});
+            case (CHART_MOUNTED) :
+
+                if (!has(state, ['tbl', tblId])) {
+                    return updateSet(state, ['tbl',tblId], {[uChartId]: {mounted: true}});
+                } else {
+                    if (get(state, ['tbl', tblId, uChartId, 'mounted'])) {
+                        //other version of the same chart is mounted
+                        let n = get(state, ['tbl', tblId, uChartId, 'n']);
+                        n = n ? Number(n) : 1;
+                        return updateMerge(state, ['tbl', tblId, uChartId], {upToDate: true, n: n + 1});
+                    } else {
+                        return updateSet(state, ['tbl', tblId, uChartId], {mounted: true});
+                    }
+                }
+            case (CHART_UNMOUNTED) :
+                if (has(state, ['tbl', tblId])) {
+                    if (get(state, ['tbl', tblId, uChartId, 'mounted'])) {
+                        let n = get(state, ['tbl', tblId, uChartId, 'n']);
+                        n = n ? Number(n) : 1;
+                        if (n > 1) {
+                            //multiple versions of the same chart are mounted
+                            return updateMerge(state, ['tbl', tblId, uChartId], {n: n - 1});
+                        }
+                    } else {
+                        return updateSet(state, ['tbl', tblId, uChartId], {mounted: false});
+                    }
+                }
+                return state;
+            case (DELETE) :
+                if (has(state, ['tbl', tblId, uChartId])) {
+                    if (Object.keys(state['tbl'][tblId]).length > 1) {
+                        return updateSet(state, ['tbl', tblId], omit(state['tbl'][tblId], [uChartId]));
+                    } else {
+                        return updateSet(state, 'tbl', omit(state['tbl'], [tblId]));
+                    }
+                }
+                return state;
+            default:
+                return state;
+        }
+    } else {
+        return state;
     }
+}
+
+
+export function getExpandedChartProps() {
+    return get(flux.getState(), [CHART_SPACE_PATH, 'ui', 'expanded']);
+}
+
+
+export function getNumRelatedCharts(tblId, mounted, chartType) {
+    let numRelated = 0;
+    const byTblSpace = get(flux.getState(), [CHART_SPACE_PATH, 'tbl']);
+    if (byTblSpace) {
+        if (isUndefined(tblId)) {
+            Object.keys(byTblSpace).forEach((tblId)=>{
+                numRelated += getNumRelatedCharts(tblId, mounted);
+            });
+        } else if (byTblSpace[tblId]) {
+            Object.keys(byTblSpace[tblId]).forEach((uChartId) => {
+                if (isUndefined(mounted)||byTblSpace[tblId][uChartId].mounted===mounted) {
+                    if (isUndefined(chartType) || isChartType(uChartId, chartType)) {
+                        numRelated++;
+                    }
+                }
+            });
+        }
+    }
+    return numRelated;
+}
+
+export function isChartMounted(tblId, chartId, chartType) {
+    const uChartId = uniqueId(chartId, chartType);
+    return Boolean(get(flux.getState(), [CHART_SPACE_PATH, 'tbl', tblId, uChartId, 'mounted']));
 }

--- a/src/firefly/js/visualize/ChartsContainer.jsx
+++ b/src/firefly/js/visualize/ChartsContainer.jsx
@@ -8,17 +8,13 @@ import shallowequal from 'shallowequal';
 
 
 import {flux} from '../Firefly.js';
-import {get} from 'lodash';
 
 import {LO_VIEW, LO_MODE, dispatchSetLayoutMode, getExpandedMode} from '../core/LayoutCntlr.js';
 import {CloseButton} from '../ui/CloseButton.jsx';
 
 import {ChartsTableViewPanel} from '../visualize/ChartsTableViewPanel.jsx';
-import {CHART_SPACE_PATH} from '../visualize/ChartsCntlr.js';
+import {getExpandedChartProps} from '../visualize/ChartsCntlr.js';
 
-export function getExpandedChartProps() {
-    return get(flux.getState(),[CHART_SPACE_PATH, 'ui', 'expanded']);
-}
 
 function nextState(props) {
     const {closeable, chartId, tblId, chartType, optionsPopup} = props;
@@ -34,16 +30,18 @@ export class ChartsContainer extends Component {
     }
 
     componentWillReceiveProps(np) {
-        if (!this.isUnmounted && !shallowequal(this.props, np)) {
+        if (this.iAmMounted && !shallowequal(this.props, np)) {
             this.setState(nextState(np));
         }
     }
 
     componentDidMount() {
         this.removeListener= flux.addListener(() => this.storeUpdate());
+        this.iAmMounted = true;
     }
 
     componentWillUnmount() {
+        this.iAmMounted = false;
         this.removeListener && this.removeListener();
     }
 
@@ -53,7 +51,7 @@ export class ChartsContainer extends Component {
 
 
     storeUpdate() {
-        if (!this.isUnmounted) {
+        if (this.iAmMounted) {
             const expandedMode = this.props.expandedMode && getExpandedMode() === LO_VIEW.xyPlots;
             if (expandedMode !== this.state.expandedMode) {
                 this.setState(nextState(this.props));

--- a/src/firefly/js/visualize/ChartsTableViewPanel.jsx
+++ b/src/firefly/js/visualize/ChartsTableViewPanel.jsx
@@ -67,7 +67,7 @@ class ChartsPanel extends React.Component {
                 var widthPx = size.width;
                 var heightPx = size.height;
                 //console.log('width: '+widthPx+', height: '+heightPx);
-                if (widthPx !== this.state.widthPx || heightPx != this.state.heightPx) {
+                if (widthPx !== this.state.widthPx || heightPx !== this.state.heightPx) {
                     this.setState({widthPx, heightPx, immediateResize: false});
                 }
             }
@@ -136,7 +136,7 @@ class ChartsPanel extends React.Component {
     componentWillReceiveProps(nextProps) {
         const {tblId, chartId, chartType} = nextProps;
         if (!tblId || !chartId) { return; }
-        if (chartId != this.props.chartId || chartType != this.props.chartType || !this.props.tblId) {
+        if (chartId !== this.props.chartId || chartType !== this.props.chartType || !this.props.tblId) {
             dispatchChartUnmounted(this.props.tblId, this.props.chartId, this.props.chartType);
             dispatchChartMounted(tblId,chartId,chartType);
         }
@@ -628,12 +628,12 @@ export class OptionsWrapper extends React.Component {
     }
 
     shouldComponentUpdate(nProps) {
-        return nProps.chartId != this.props.chartId ||
+        return nProps.chartId !== this.props.chartId ||
         get(nProps, 'tblPlotData.xyPlotParams') !== get(this.props, 'tblPlotData.xyPlotParams') ||
         get(nProps, 'tblHistogramData.histogramParams') !== get(this.props, 'tblHistogramData.histogramParams') ||
         get(nProps, 'tableModel.tbl_id') !== get(this.props, 'tableModel.tbl_id') ||
             get(nProps, 'tblStatsData.isColStatsReady') !== get(this.props, 'tblStatsData.isColStatsReady') ||
-            nProps.chartType != this.props.chartType;
+            nProps.chartType !== this.props.chartType;
     }
 
     // componentDidUpdate(prevProps, prevState) {

--- a/src/firefly/js/visualize/TableStatsCntlr.js
+++ b/src/firefly/js/visualize/TableStatsCntlr.js
@@ -21,18 +21,10 @@ import * as TablesCntlr from '../tables/TablesCntlr.js';
 
 
 export const TBLSTATS_DATA_KEY = 'tblstats';
-export const SETUP_TBL_TRACKING = `${TBLSTATS_DATA_KEY}/SETUP_TBL_TRACKING`;
+
 export const LOAD_TBL_STATS = `${TBLSTATS_DATA_KEY}/LOAD_TBL_STATS`;
 export const UPDATE_TBL_STATS = `${TBLSTATS_DATA_KEY}/UPDATE_TBL_STATS`;
 
-/*
- * Set up store, which will reflect the data relevant to the given table
- * @param {string} tblId - table id
- * @param {function} dispatcher only for special dispatching uses such as remote
- */
-export function dispatchSetupTblTracking(tblId, dispatcher= flux.process) {
-    dispatcher({type: SETUP_TBL_TRACKING, payload: {tblId}});
-}
 
 /*
  * Get the number of points, min and max values, units and description for each table column
@@ -74,14 +66,6 @@ function getInitState() {
 
 export function reducer(state=getInitState(), action={}) {
     switch (action.type) {
-        case (SETUP_TBL_TRACKING) :
-        {
-            const {tblId} = action.payload;
-            if (!state[tblId]) {
-                return updateSet(state, tblId, {isColStatsReady: false});
-            }
-            return state;
-        }
         case (TablesCntlr.TABLE_REMOVE)  :
         {
             const {tbl_id} = action.payload;

--- a/src/firefly/js/visualize/saga/ChartsSync.js
+++ b/src/firefly/js/visualize/saga/ChartsSync.js
@@ -3,17 +3,19 @@
  */
 import {take} from 'redux-saga/effects';
 
-import {has} from 'lodash';
+import {get} from 'lodash';
 
 import {flux} from '../../Firefly.js';
+import {logError} from '../../util/WebUtil.js';
 
 import * as TablesCntlr from '../../tables/TablesCntlr.js';
 import * as TableStatsCntlr from '../TableStatsCntlr.js';
 import * as TableUtil from '../../tables/TableUtil.js';
 
 import * as XYPlotCntlr from '../XYPlotCntlr.js';
+import * as ChartsCntlr from '../ChartsCntlr.js';
 import * as HistogramCntlr from '../HistogramCntlr.js';
-import {hasRelatedCharts, getDefaultXYPlotParams} from '../ChartUtil.js';
+import {SCATTER, HISTOGRAM, getChartSpace, hasRelatedCharts, getDefaultXYPlotParams} from '../ChartUtil.js';
 
 /**
  * this saga handles chart related side effects
@@ -22,49 +24,59 @@ export function* syncCharts() {
     var tableStatsState, xyPlotState, histogramState;
 
     while (true) {
-        const action= yield take([TableStatsCntlr.SETUP_TBL_TRACKING, TablesCntlr.TABLE_NEW_LOADED, TablesCntlr.TABLE_SORT]);
+        const action= yield take([ChartsCntlr.CHART_MOUNTED, TablesCntlr.TABLE_NEW_LOADED, TablesCntlr.TABLE_SORT]);
+        if (!ChartsCntlr.getNumRelatedCharts()) { continue; }
         const request= action.payload.request;
         switch (action.type) {
-            case TableStatsCntlr.SETUP_TBL_TRACKING:
-                const {tblId} = action.payload;
+            case ChartsCntlr.CHART_MOUNTED:
+                const {tblId, chartId, chartType} = action.payload;
                 if (TableUtil.isFullyLoaded(tblId)) {
-                    TableStatsCntlr.dispatchLoadTblStats(TableUtil.getTblById(tblId)['request']);
-                    if (!hasRelatedCharts(tblId)) {
-                        // default chart is xy plot of coordinate columns or first two numeric columns
-                        const defaultParams = getDefaultXYPlotParams(tblId);
-                        if (defaultParams) {
-                            XYPlotCntlr.dispatchLoadPlotData(tblId, defaultParams, tblId);
+                    if (ChartsCntlr.getNumRelatedCharts(tblId)===1) {
+                        TableStatsCntlr.dispatchLoadTblStats(TableUtil.getTblById(tblId)['request']);
+                        if (!hasRelatedCharts(tblId)) {
+                            // default chart is xy plot of coordinate columns or first two numeric columns
+                            const defaultParams = getDefaultXYPlotParams(tblId);
+                            if (defaultParams) {
+                                XYPlotCntlr.dispatchLoadPlotData(tblId, defaultParams, tblId);
+                            }
                         }
                     }
+                    updateChartDataIfNeeded(tblId, chartId, chartType);
                 }
+
                 break;
             case TablesCntlr.TABLE_SORT:
             case TablesCntlr.TABLE_NEW_LOADED:
                 const {tbl_id} = action.payload;
-                let hasRelated = false;
 
-                xyPlotState = flux.getState()[XYPlotCntlr.XYPLOT_DATA_KEY];
-                Object.keys(xyPlotState).forEach((cid) => {
-                    if (xyPlotState[cid].tblId === tbl_id) {
-                        const xyPlotParams = xyPlotState[cid].xyPlotParams;
-                        XYPlotCntlr.dispatchLoadPlotData(cid, xyPlotParams, tbl_id);
-                        hasRelated = true;
-                    }
-                });
-
-                // table statistics and histogram data do not change on table sort
-                if (action.type !== TablesCntlr.TABLE_SORT) {
-                    histogramState = flux.getState()[HistogramCntlr.HISTOGRAM_DATA_KEY];
-                    Object.keys(histogramState).forEach((cid) => {
-                        if (histogramState[cid].tblId === tbl_id) {
-                            const histogramParams = histogramState[cid].histogramParams;
-                            HistogramCntlr.dispatchLoadColData(cid, histogramParams, tbl_id);
+                // check if there are any mounted charts related to this table
+                if (ChartsCntlr.getNumRelatedCharts(tbl_id, true) > 0) {
+                    let hasRelated = false;
+                    xyPlotState = getChartSpace(SCATTER);
+                    Object.keys(xyPlotState).forEach((cid) => {
+                        if (xyPlotState[cid].tblId === tbl_id) {
                             hasRelated = true;
+                            if (ChartsCntlr.isChartMounted(tbl_id, cid, SCATTER)) {
+                                const xyPlotParams = xyPlotState[cid].xyPlotParams;
+                                XYPlotCntlr.dispatchLoadPlotData(cid, xyPlotParams, tbl_id);
+                            }
                         }
                     });
 
-                    tableStatsState = flux.getState()[TableStatsCntlr.TBLSTATS_DATA_KEY];
-                    if (has(tableStatsState, tbl_id)) {
+                    // table statistics and histogram data do not change on table sort
+                    if (action.type !== TablesCntlr.TABLE_SORT) {
+                        histogramState = getChartSpace(HISTOGRAM);
+                        Object.keys(histogramState).forEach((cid) => {
+                            if (histogramState[cid].tblId === tbl_id) {
+                                hasRelated = true;
+                                if (ChartsCntlr.isChartMounted(tbl_id, cid, 'histogram')) {
+                                    const histogramParams = histogramState[cid].histogramParams;
+                                    HistogramCntlr.dispatchLoadColData(cid, histogramParams, tbl_id);
+                                }
+                            }
+                        });
+
+                        tableStatsState = flux.getState()[TableStatsCntlr.TBLSTATS_DATA_KEY];
                         TableStatsCntlr.dispatchLoadTblStats(request);
                         if (!hasRelated) {
                             // default chart is xy plot of coordinate columns or first two numeric columns
@@ -75,7 +87,6 @@ export function* syncCharts() {
                         }
                     }
                 }
-
                 break;
         }
     }
@@ -83,3 +94,26 @@ export function* syncCharts() {
 
 
 
+function updateChartDataIfNeeded(tblId, chartId, chartType) {
+    const tblSource = get(TableUtil.getTblById(tblId), 'tableMeta.source');
+    const chartSpace = getChartSpace(chartType);
+    const chartTblSource = get(chartSpace,[chartId,'tblSource']);
+    if (tblSource && (!chartTblSource || chartTblSource !== tblSource)) {
+        switch(chartType) {
+            case SCATTER:
+                const xyPlotParams = get(chartSpace, [chartId, 'xyPlotParams']);
+                if (xyPlotParams) {
+                    XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tblId);
+                }
+                break;
+            case HISTOGRAM:
+                const histogramParams = get(chartSpace, [chartId, 'histogramParams']);
+                if (histogramParams) {
+                    HistogramCntlr.dispatchLoadColData(chartId, histogramParams, tblId);
+                }
+                break;
+            default:
+                logError(`Unknown chart type ${chartType}`);
+        }
+    }
+}


### PR DESCRIPTION
- Introduced CHART_MOUNTED/CHART_UNMOUNTED actions, deleted SETUP_TBL_TRACKING.
- Reworked the logic for chart related controllers. Chart data are updated only if a chart is mounted, no updates on unmounted charts.
- Now checking if connected table or server parameters have changed before placing server request for data
- Fixed setState calls on unmounted component in ChartContainer.
- Fixed delete button being shown in expanded mode.