### PR TITLE
DM-6908 Add filter editor to the chart toolbar

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/HistogramProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/HistogramProcessor.java
@@ -134,51 +134,51 @@ public class HistogramProcessor extends IpacTablePartProcessor {
      */
     public DataGroup createHistogramTable(double[] columnData) throws DataAccessException {
 
-
-        /*if (!scale.equalsIgnoreCase(LINEAR_SCALE)){
-            columnData = scaleData(columnData);
-        }*/
-
-        //calculate three arrays, numInBin, binMix and binMax
-        Object[] obj;
-        if (algorithm != null && algorithm.equalsIgnoreCase(FIXED_SIZE_ALGORITHM)) {
-            obj = calculateFixedBinSizeDataArray(columnData);
-        } else {
-            obj = calculateVariableBinSizeDataArray(columnData);
-
-        }
-
-        int[] numPointsInBin = (int[]) obj[0];
-        double[] binMin = (double[]) obj[1];
-        double[] binMax = (double[]) obj[2];
-        int nPoints = numPointsInBin.length;
-
         DataType[] tblcolumns = columns;
+        DataGroup HistogramTable;
 
-        if (nPoints>1) {
-            double firstBinRange = binMax[0]-binMin[0];
-            int firstSigDigitPos = (int)Math.floor(Math.log10(Math.abs(firstBinRange)))+1;
-            if (firstSigDigitPos < -2) {
-                // increase precision
-                DataType.FormatInfo fi = DataType.FormatInfo.createFloatFormat(20, 3-firstSigDigitPos);
-                tblcolumns = new DataType[]{
+        if (columnData.length > 0) {
+            //calculate three arrays, numInBin, binMix and binMax
+            Object[] obj;
+            if (algorithm != null && algorithm.equalsIgnoreCase(FIXED_SIZE_ALGORITHM)) {
+                obj = calculateFixedBinSizeDataArray(columnData);
+            } else {
+                obj = calculateVariableBinSizeDataArray(columnData);
+
+            }
+
+            int[] numPointsInBin = (int[]) obj[0];
+            double[] binMin = (double[]) obj[1];
+            double[] binMax = (double[]) obj[2];
+            int nPoints = numPointsInBin.length;
+
+            if (nPoints > 1) {
+                double firstBinRange = binMax[0] - binMin[0];
+                int firstSigDigitPos = (int) Math.floor(Math.log10(Math.abs(firstBinRange))) + 1;
+                if (firstSigDigitPos < -2) {
+                    // increase precision
+                    DataType.FormatInfo fi = DataType.FormatInfo.createFloatFormat(20, 3 - firstSigDigitPos);
+                    tblcolumns = new DataType[]{
                             new DataType("numInBin", Integer.class),
                             new DataType("binMin", Double.class),
                             new DataType("binMax", Double.class)
-                        };
-                tblcolumns[1].setFormatInfo(fi);
-                tblcolumns[2].setFormatInfo(fi);
+                    };
+                    tblcolumns[1].setFormatInfo(fi);
+                    tblcolumns[2].setFormatInfo(fi);
+                }
             }
-        }
 
-        //add each row to the DataGroup
-        DataGroup HistogramTable = new DataGroup("histogramTable", tblcolumns);
-        for (int i = 0; i < nPoints; i++) {
-            DataObject row = new DataObject(HistogramTable);
-            row.setDataElement(tblcolumns[0], numPointsInBin[i]);
-            row.setDataElement(tblcolumns[1], binMin[i]);
-            row.setDataElement(tblcolumns[2], binMax[i]);
-            HistogramTable.add(row);
+            //add each row to the DataGroup
+            HistogramTable = new DataGroup("histogramTable", tblcolumns);
+            for (int i = 0; i < nPoints; i++) {
+                DataObject row = new DataObject(HistogramTable);
+                row.setDataElement(tblcolumns[0], numPointsInBin[i]);
+                row.setDataElement(tblcolumns[1], binMin[i]);
+                row.setDataElement(tblcolumns[2], binMax[i]);
+                HistogramTable.add(row);
+            }
+        } else {
+            HistogramTable = new DataGroup("histogramTable", tblcolumns);
         }
         return HistogramTable;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -660,10 +660,12 @@ public class QueryUtil {
             }
         }
 
-        retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".X-MAX", String.valueOf(xMax));
-        retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".X-MIN", String.valueOf(xMin));
-        retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".Y-MAX", String.valueOf(yMax));
-        retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".Y-MIN", String.valueOf(yMin));
+        if (Double.isFinite(xMax)) {
+            retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".X-MAX", String.valueOf(xMax));
+            retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".X-MIN", String.valueOf(xMin));
+            retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".Y-MAX", String.valueOf(yMax));
+            retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".Y-MIN", String.valueOf(yMin));
+        }
 
         if (doDecimation) {
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/DataGroupFilter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/DataGroupFilter.java
@@ -20,7 +20,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -121,15 +120,17 @@ public class DataGroupFilter {
                         rowIdx = row.getRowIdx();
                         rowIdx = rowIdx < 0 ? cRowNum : rowIdx;
                     }
+
+                    if (needToWriteHeader) {
+                        needToWriteHeader = false;
+                        DataGroupWriter.writeStatus(writer, DataGroupPart.State.INPROGRESS);
+                        IpacTableUtil.writeAttributes(writer, attributes, DataGroupPart.LOADING_STATUS);
+                        IpacTableUtil.writeHeader(writer, headers);
+                    }
+
                     if (CollectionUtil.matches(rowIdx, row, filters)) {
                         row.setRowIdx(rowIdx);
 
-                        if (needToWriteHeader) {
-                            needToWriteHeader = false;
-                            DataGroupWriter.writeStatus(writer, DataGroupPart.State.INPROGRESS);
-                            IpacTableUtil.writeAttributes(writer, attributes, DataGroupPart.LOADING_STATUS);
-                            IpacTableUtil.writeHeader(writer, headers);
-                        }
                         IpacTableUtil.writeRow(writer, headers, row);
                         if (++rowsFound == prefetchSize) {
                             processInBackground(dg);

--- a/src/firefly/js/charts/HistogramCntlr.js
+++ b/src/firefly/js/charts/HistogramCntlr.js
@@ -218,6 +218,7 @@ function fetchColData(dispatch, tblId, histogramParams, chartId) {
 
     doFetchTable(req).then(
         (tableModel) => {
+            let histogramData = [];
             if (tableModel.tableData && tableModel.tableData.data) {
                 // if logarithmic values were requested, convert the returned exponents back
                 var toNumber = histogramParams.x.includes('log') ?
@@ -229,20 +230,20 @@ function fetchColData(dispatch, tblId, histogramParams, chartId) {
                             return Math.pow(10,Number(val));
                         }
                     } : (val)=>Number(val);
-                const histogramData = tableModel.tableData.data.reduce((data, arow) => {
+                histogramData = tableModel.tableData.data.reduce((data, arow) => {
                     data.push(arow.map(toNumber));
                     return data;
                 }, []);
 
-                dispatch(updateColData(
-                    {
-                        chartId,
-                        isColDataReady : true,
-                        tblSource,
-                        histogramParams,
-                        histogramData
-                    }));
             }
+            dispatch(updateColData(
+                {
+                    chartId,
+                    isColDataReady : true,
+                    tblSource,
+                    histogramParams,
+                    histogramData
+                }));
         }
     ).catch(
         (reason) => {

--- a/src/firefly/js/charts/ui/Histogram.jsx
+++ b/src/firefly/js/charts/ui/Histogram.jsx
@@ -351,7 +351,9 @@ export class Histogram extends React.Component {
             }
         };
 
-        this.setChartConfig(config);
+        if (data.length > 0) {
+            this.setChartConfig(config);
+        }
 
         return (
             <div>

--- a/src/firefly/js/charts/ui/XYPlot.jsx
+++ b/src/firefly/js/charts/ui/XYPlot.jsx
@@ -9,6 +9,7 @@ import ReactHighcharts from 'react-highcharts/bundle/highcharts';
 import {SelectInfo} from '../../tables/SelectInfo.js';
 import {parseDecimateKey} from '../../tables/Decimate.js';
 
+const defaultShading = 'lin';
 
 export const axisParamsShape = PropTypes.shape({
     columnOrExpr : PropTypes.string,
@@ -66,7 +67,7 @@ const toNumber = (val)=>Number(val);
  @param {boolean} returnNum - if true return group number rather than group description
  @return {number|string} from 1 to 6, 1 for 1 pt series
  */
-const getWeightBasedGroup = function(weight, minWeight, maxWeight, logShading=true, returnNum=true) {
+const getWeightBasedGroup = function(weight, minWeight, maxWeight, logShading=false, returnNum=true) {
     if (weight == 1) return returnNum ? 1 : '1pt';
     else {
         if (logShading) {
@@ -216,7 +217,7 @@ export class XYPlot extends React.Component {
     shouldComponentUpdate(nextProps) {
         const {data, width, height, params, highlighted, selectInfo, desc} = this.props;
         // only rerender when plot data change
-        if (nextProps.data !== data) {
+        if (nextProps.data !== data || get(params, 'shading', defaultShading) !== get(nextProps.params, 'shading', defaultShading)) {
             return true;
         } else {
             const chart = this.refs.chart && this.refs.chart.getChart();

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -33,11 +33,11 @@ export class FilterEditor extends React.Component {
     // }
 
     render() {
-        const {columns, origColumns, onChange, sortInfo, filterInfo= ''} = this.props;
+        const {columns, selectable, onChange, sortInfo, filterInfo= ''} = this.props;
         if (isEmpty(columns)) return false;
 
         const {cols, data, selectInfoCls} = prepareOptionData(columns, sortInfo, filterInfo);
-        const callbacks = makeCallbacks(onChange, columns, origColumns, data, filterInfo);
+        const callbacks = makeCallbacks(onChange, columns, data, filterInfo);
         const renderers = makeRenderers(callbacks.onFilter);
         return (
             <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
@@ -47,7 +47,7 @@ export class FilterEditor extends React.Component {
                             bgColor='beige'
                             columns={cols}
                             rowHeight={24}
-                            selectable={true}
+                            selectable={selectable}
                             {...{data, selectInfoCls, sortInfo, callbacks, renderers}}
                         />
                     </div>
@@ -68,14 +68,18 @@ export class FilterEditor extends React.Component {
             </div>
         );
     }
-};
+}
 
 FilterEditor.propTypes = {
     columns: PropTypes.arrayOf(React.PropTypes.object),
-    origColumns: PropTypes.arrayOf(PropTypes.object),
+    selectable: PropTypes.bool,
     sortInfo: PropTypes.string,
     filterInfo: PropTypes.string,
     onChange: PropTypes.func
+};
+
+FilterEditor.defaultProps = {
+    selectable: true
 };
 
 function prepareOptionData(columns, sortInfo, filterInfo) {
@@ -85,7 +89,7 @@ function prepareOptionData(columns, sortInfo, filterInfo) {
         {name: 'Filter', visibility: 'show', prefWidth: 12},
         {name: 'Units', visibility: 'show', prefWidth: 6},
         {name: 'Description', visibility: 'show', prefWidth: 60},
-        {name: 'Selected', visibility: 'hidden'},
+        {name: 'Selected', visibility: 'hidden'}
     ];
 
     const filterInfoCls = FilterInfo.parse(filterInfo);
@@ -106,7 +110,7 @@ function prepareOptionData(columns, sortInfo, filterInfo) {
     return {cols, data, tableRowCount, selectInfoCls};
 }
 
-function makeCallbacks(onChange, columns, origColumns, data, orgFilterInfo='') {
+function makeCallbacks(onChange, columns, data, orgFilterInfo='') {
     var onSelectAll = (checked) => {
         const nColumns = cloneDeep(columns).filter((c) => c.visibility !== 'hidden');
         nColumns.forEach((v) => {

--- a/src/firefly/js/ui/ToolbarButton.css
+++ b/src/firefly/js/ui/ToolbarButton.css
@@ -20,7 +20,7 @@
 .ff-badge {
     position: absolute;
     right: -3px;
-    top: -4px;
+    top: -1px;
 
     font-size: 10px;
     font-weight: normal;

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -3,7 +3,7 @@
  */
 
 import {take} from 'redux-saga/effects';
-import {isEmpty, get} from 'lodash';
+import {isEmpty, get, omit} from 'lodash';
 import {TABLE_NEW_LOADED,TABLE_SORT, TABLE_SELECT,TABLE_HIGHLIGHT,TABLE_REMOVE,TABLE_UPDATE} from '../../tables/TablesCntlr.js';
 import {dispatchCreateDrawLayer,dispatchAttachLayerToPlot,dispatchDestroyDrawLayer, dispatchModifyCustomField} from '../DrawLayerCntlr.js';
 import ImagePlotCntlr, {visRoot} from '../ImagePlotCntlr.js';
@@ -112,8 +112,8 @@ function handleCatalogUpdate(tbl_id) {
         dataTooBigForSelection= true;
     }
 
-    const req = Object.assign({}, sourceTable.request, params);
-    req.tbl_id = tbl_id;
+    const req = Object.assign(omit(sourceTable.request, ['tbl_id', 'META_INFO']), params);
+    req.tbl_id = `cat-${tbl_id}`;
 
     doFetchTable(req).then(
         (tableModel) => {

--- a/src/firefly/js/visualize/saga/ChartsSync.js
+++ b/src/firefly/js/visualize/saga/ChartsSync.js
@@ -47,8 +47,6 @@ export function* syncCharts() {
             case TablesCntlr.TABLE_SORT:
             case TablesCntlr.TABLE_NEW_LOADED:
                 const {tbl_id} = action.payload;
-                console.log(TableUtil.getTblById(tblId));
-                //console.log(get(TableUtil.getTblById(tblId), 'request'));
 
                 // check if there are any mounted charts related to this table
                 if (ChartsCntlr.getNumRelatedCharts(tbl_id, true) > 0) {

--- a/src/firefly/js/visualize/saga/ChartsSync.js
+++ b/src/firefly/js/visualize/saga/ChartsSync.js
@@ -47,6 +47,8 @@ export function* syncCharts() {
             case TablesCntlr.TABLE_SORT:
             case TablesCntlr.TABLE_NEW_LOADED:
                 const {tbl_id} = action.payload;
+                console.log(TableUtil.getTblById(tblId));
+                //console.log(get(TableUtil.getTblById(tblId), 'request'));
 
                 // check if there are any mounted charts related to this table
                 if (ChartsCntlr.getNumRelatedCharts(tbl_id, true) > 0) {

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -4,7 +4,7 @@
 
 import {take} from 'redux-saga/effects';
 import Enum from 'enum';
-import {get,isEmpty,flattenDeep,values} from 'lodash';
+import {get,isEmpty,flattenDeep,values, omit} from 'lodash';
 import {MetaConst} from '../../data/MetaConst.js';
 import {TitleOptions} from '../WebPlotRequest.js';
 import {CoordinateSys} from '../CoordSys.js';
@@ -162,7 +162,6 @@ function removeCoverage(tbl_id, decimatedTables) {
     }
 }
 
-
 /**
  * 
  * @param tbl_id
@@ -186,8 +185,9 @@ function updateCoverage(tbl_id, viewerId, decimatedTables, options) {
         inclCols : getCovColumnsForQuery(options, table)
     };
 
-    const req = Object.assign({}, table.request, params);
-    req.tbl_id = tbl_id;
+
+    const req = Object.assign(omit(table.request, ['tbl_id', 'META_INFO']), params);
+    req.tbl_id = `cov-${tbl_id}`;
 
     if (decimatedTables[tbl_id] /*&& decimatedTables[tbl_id].tableMeta.tblFilePath===table.tableMeta.tblFilePath*/) { //todo support decimated data
         updateCoverageWithData(table, options, tbl_id, decimatedTables[tbl_id], decimatedTables);
@@ -367,7 +367,7 @@ function defaultCanDoCorners(table) {// eslint-disable-line no-unused-vars
 
 function getCovColumnsForQuery(options, table) {
     const cAry= [...options.getCornersColumns(table), options.getCenterColumns(table)];
-    return cAry.reduce( (s,c,idx)=> s+`${idx>0?',':''}${c.latCol},${c.lonCol}`,'');
+    return cAry.reduce( (s,c,idx)=> s+`${idx>0?',':''}${c.lonCol},${c.latCol}`,'');
 }
 
 function getCornersColumns(table) {


### PR DESCRIPTION
- Added filter editor to the charts toolbar
- When filtering returns empty data set, server side will return header. Before, it was returning  \Loading-Status = COMPLETED, and TablesCntlr:265 would never activate a new table callback.
- Charts are cleared when table data are being fetched. 
- Label and unit in XYPlotOptions will now get cleared whenever x or y changes
- removed tbl_id from CatalogWatcher and CoverageWatcher's server requests to prevent interference with the table
- changed the order of lat,lon->lon,lat in CoverageWatcher's server request (just for consistency: it was dec, ra before)