### PR TITLE
DM-6953: fixed mutliple image issues

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -26,7 +26,7 @@
 <div>
     <!--<a href='javascript:firefly.getViewer("testChannel").showImage({url:"http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits"})'>test open</a>-->
     <a href='javascript:firefly.getViewer().plotURL("http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits")'>test open</a>
-    <a href="javascript:firefly.getViewer().showImage({plotId: 'xxq', Service: 'TWOMASS', Title     : '2mass from service', SurveyKey  : 'k', WorldPt    : '10.68479;41.26906;EQ_J2000', SizeInDeg  : '.12', })">test again</a>
+    <a href="javascript:plotRemote()">test again</a>
     <a href="javascript:firefly.getViewer().showImage(window.threeC)">3 C</a>
     <a href="javascript:firefly.action.dispatchZoom({plotId: 'xxq',userZoomType:'UP' ,dispatcher:window.ffViewer.dispatch})">up</a>
     <a href="javascript:firefly.action.dispatchZoom({plotId: 'xxq',userZoomType:'DOWN' ,dispatcher:window.ffViewer.dispatch})">down</a>
@@ -98,6 +98,12 @@
 
             firefly.debug= true;
 
+            var util= firefly.util;
+            var ui= firefly.ui;
+            // ----------------- to use minimal readout, do the following
+            //  util.image.initAutoReadout(ui.DefaultApiReadout,
+            //         {MouseReadoutComponent:ui.PopupMouseReadoutMinimal, showThumb:false,showMag:false});
+            // -----------------
 
             var req= {
                 plotId: 'xxq',
@@ -106,6 +112,7 @@
                 Service   : 'TWOMASS',
                 Title     : '2mass from service',
                 GridOn     : true,
+//                GridOn     : 'TRUE_LABELS_FALSE',
                 SurveyKey  : 'k',
                 WorldPt    : '10.68479;41.26906;EQ_J2000',
                 SizeInDeg  : '.12',
@@ -118,6 +125,7 @@
                 Service  : 'WISE',
                 Title     : 'Wise',
                 GridOn     : true,
+//                GridOn     : 'TRUE_LABELS_FALSE',
                 SurveyKey  : 'Atlas',
                 bad1  : 'hello',
                 bad2  : 'bye',
@@ -347,6 +355,17 @@
             selectBox.getElementsByTagName('option')[0].selected = 'selected';
             firefly.action.dispatchRemoveRegionEntry(selectedLayerId, removeRegions);
             firefly.action.dispatchRemoveRegionEntry(selectedLayerId, removeRegions, window.ffViewer.dispatch);
+        }
+
+        plotRemote= function() {
+            firefly.getViewer().showImage({plotId: 'xxq',
+                Service: 'TWOMASS',
+                Title  : '2mass from service',
+                SurveyKey  : 'k',
+                WorldPt    : '10.68479;41.26906;EQ_J2000',
+                RangeValues : firefly.util.image.serializeSimpleRangeValues("Sigma",-1,2,"Linear"),
+                SizeInDeg  : '.12'
+            })
         }
    }
    

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -42,7 +42,7 @@ import {watchImageMetaData} from '../visualize/saga/ImageMetaDataWatcher.js';
  */
 export function initAutoReadout(ReadoutComponent= DefaultApiReadout,
          //   props={MouseReadoutComponent:PopupMouseReadoutMinimal, showThumb:false,showMag:false}){
-      props={MouseReadoutComponent:PopupMouseReadoutFull, showThumb:false,showMag:false } ){
+      props={MouseReadoutComponent:PopupMouseReadoutFull, showThumb:true,showMag:true } ){
 
 
     dispatchAddSaga(autoReadoutVisibility, {ReadoutComponent,props});
@@ -58,7 +58,7 @@ export function initAutoReadout(ReadoutComponent= DefaultApiReadout,
  */
 export function serializeSimpleRangeValues(stretchType,lowerValue,upperValue,algorithm) {
     const rv= RangeValues.makeSimple(stretchType,lowerValue,upperValue,algorithm);
-    return rv.serialize();
+    return rv.toJSON();
 }
 
 

--- a/src/firefly/js/api/ApiViewer.js
+++ b/src/firefly/js/api/ApiViewer.js
@@ -15,6 +15,7 @@ import {dispatchTableSearch, dispatchTableFetch}  from '../tables/TablesCntlr.js
 import {getWsChannel} from '../core/messaging/WebSocketClient.js';
 import {getConnectionCount, WS_CONN_UPDATED, GRAB_WINDOW_FOCUS} from '../core/AppDataCntlr.js';
 import {dispatchAddSaga} from '../core/MasterSaga.js';
+import {DEFAULT_FITS_VIEWER_ID} from '../visualize/MultiViewCntlr.js'
 
 const VIEWER_ID = '__viewer';
 var viewerWindow;
@@ -186,7 +187,7 @@ function plotRemoteImage(request, dispatch) {
     });
 
     request= confirmPlotRequest(request,{},'remoteGroup',makePlotId);
-    dispatchPlotImage({wpRequest:request, dispatcher:dispatch});
+    dispatchPlotImage({wpRequest:request, viewerId:DEFAULT_FITS_VIEWER_ID, dispatcher:dispatch});
 }
 
 

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -322,8 +322,8 @@ function fetchAppData(dispatch) {
 
 /*---------------------------- REDUCING FUNTIONS -----------------------------*/
 const updateActiveTarget= function(state,action) {
-    var {worldPt,corners}= action;
-    if (!worldPt || !corners) return state;
+    var {worldPt,corners}= action.payload;
+    if (!worldPt && !corners) return state;
     return Object.assign({}, state, {activeTarget:{worldPt,corners}});
 };
 

--- a/src/firefly/js/core/FireflyViewer.js
+++ b/src/firefly/js/core/FireflyViewer.js
@@ -17,7 +17,7 @@ import {DropDownContainer} from '../ui/DropDownContainer.jsx';
 import {TriViewPanel} from '../ui/TriViewPanel.jsx';
 import {VisHeader} from '../visualize/ui/VisHeader.jsx';
 import {getActionFromUrl} from '../core/History.js';
-import {launchImageMetaDataSega, FITS_VIEWER_ID} from '../visualize/ui/TriViewImageSection.jsx';
+import {launchImageMetaDataSega} from '../visualize/ui/TriViewImageSection.jsx';
 import {dispatchAddViewer} from '../visualize/MultiViewCntlr.js';
 import {dispatchAddSaga} from '../core/MasterSaga.js';
 
@@ -137,7 +137,6 @@ function onReady({menu, views}) {
         dispatchSetMenu({menuItems: menu});
     }
     if (views.has(LO_VIEW.images) ) {
-        dispatchAddViewer(FITS_VIEWER_ID, true, true);
         launchImageMetaDataSega();
     }
     const {hasImages, hasTables, hasXyPlots} = getLayouInfo();

--- a/src/firefly/js/core/layout/FireflyLayoutManager.js
+++ b/src/firefly/js/core/layout/FireflyLayoutManager.js
@@ -10,8 +10,8 @@ import {clone} from '../../util/WebUtil.js';
 import {TBL_RESULTS_ADDED, TABLE_NEW, TABLE_REMOVE} from '../../tables/TablesCntlr.js';
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
 import {isMetaDataTable, isCatalogTable} from '../../metaConvert/converterUtils.js';
-import {META_VIEWER_ID, FITS_VIEWER_ID} from '../../visualize/ui/TriViewImageSection.jsx';
-import {REPLACE_IMAGES, getViewerPlotIds, getMultiViewRoot} from '../../visualize/MultiViewCntlr.js';
+import {META_VIEWER_ID} from '../../visualize/ui/TriViewImageSection.jsx';
+import {REPLACE_IMAGES, DEFAULT_FITS_VIEWER_ID, getViewerPlotIds, getMultiViewRoot} from '../../visualize/MultiViewCntlr.js';
 
 /**
  * this manager manages what main components get display on the screen.
@@ -44,7 +44,7 @@ export function* layoutManager({title, views='tables | images | xyPlots'}) {
         const showXyPlots = hasXyPlots && views.has(LO_VIEW.xyPlots);
         const showTables = hasTables && views.has(LO_VIEW.tables);
 
-        const ids = getViewerPlotIds(getMultiViewRoot(), FITS_VIEWER_ID);
+        const ids = getViewerPlotIds(getMultiViewRoot(), DEFAULT_FITS_VIEWER_ID);
         images = clone(images, {showFits: ids && ids.length > 0});
 
         // special cases which could affect the layout..
@@ -138,8 +138,7 @@ function handleNewImage(action, images) {
     if (viewerId === META_VIEWER_ID) {
         // select image meta tab when new images are added.
         images = clone(images, {selectedTab: 'meta', showMeta: true});
-    } else if (viewerId === FITS_VIEWER_ID ||
-        (!viewerId && plotGroupId === 'remoteGroup') ) {    // only way to pick up external viewer api images
+    } else if (viewerId === DEFAULT_FITS_VIEWER_ID) {
         // select image tab when new images are added.
         images = clone(images, {selectedTab: 'fits', showFits: true});
     } else {

--- a/src/firefly/js/drawingLayers/ComputeWebGridData.js
+++ b/src/firefly/js/drawingLayers/ComputeWebGridData.js
@@ -19,7 +19,7 @@ const RANGE_THRESHOLD = 1.02;
 const minUserDistance= 0.25;   // user defined max dist. (deg)
 const maxUserDistance= 3.00;   // user defined min dist. (deg)
 
-var useLabels= true;
+// var useLabels= true;
 var userDefinedDistance = false;
 
 
@@ -27,9 +27,10 @@ var userDefinedDistance = false;
  * This method does the calculation for drawing data array
  * @param plot - primePlot object
  * @param cc - the CoordinateSys object
+ * @param useLabels - use Labels
  * @return a DrawData object
  */
-export function makeGridDrawData (plot,  cc){
+export function makeGridDrawData (plot,  cc, useLabels){
 
     const {width, height, screenWidth, csys,labelFormat} = getDrawLayerParameters(plot);
     if (width > 0 && height >0) {
@@ -42,7 +43,8 @@ export function makeGridDrawData (plot,  cc){
         var {xLines, yLines} = computeLines(cc, csys, range, levels, screenWidth);
         var wpt = cc.getWorldCoords(makeImageWorkSpacePt(1, 1), csys);
         var aitoff = (!wpt);
-        return  drawLines(csys, bounds, labels, xLines, yLines, levels[0].length, levels[1].length, aitoff, screenWidth);
+        return  drawLines(csys, bounds, labels, xLines, yLines, levels[0].length, levels[1].length, 
+                          aitoff, screenWidth, useLabels);
     }
 }
 
@@ -726,7 +728,7 @@ function getLabelPoints(bounds, csys, xLines, yLines, nLevel0, nLevel1) {
 }
 
 
-function drawLabeledPolyLine (drawData, bounds, nLevel0,  label, labelLocations, x, y, count, aitoff,screenWidth){
+function drawLabeledPolyLine (drawData, bounds, nLevel0,  label, labelLocations, x, y, count, aitoff,screenWidth, useLabels){
 
 
     //add the  draw line data to the drawData
@@ -762,7 +764,7 @@ function drawLabeledPolyLine (drawData, bounds, nLevel0,  label, labelLocations,
     }
 }
 
-function drawLines(csys,bounds, labels, xLines,yLines, nLevel0, nLevel1, aitoff,screenWidth) {
+function drawLines(csys,bounds, labels, xLines,yLines, nLevel0, nLevel1, aitoff,screenWidth, useLabels) {
     // Draw the lines previously computed.
     //get the locations where to put the labels
     var labelLocations =getLabelPoints(bounds, csys, xLines, yLines, nLevel0, nLevel1);
@@ -770,7 +772,7 @@ function drawLines(csys,bounds, labels, xLines,yLines, nLevel0, nLevel1, aitoff,
     var  lineCount = xLines.length;
     for (let i=0; i<lineCount; i+=1) {
         drawLabeledPolyLine(drawData, bounds,nLevel0, labels[i],labelLocations ,
-            xLines[i], yLines[i], i, aitoff,screenWidth);
+            xLines[i], yLines[i], i, aitoff,screenWidth, useLabels);
     }
     return drawData;
 

--- a/src/firefly/js/drawingLayers/WebGrid.js
+++ b/src/firefly/js/drawingLayers/WebGrid.js
@@ -4,6 +4,8 @@
  * 4/14/16
  */
 
+
+import  {isBoolean} from 'lodash';
 import  {visRoot} from '../visualize/ImagePlotCntlr.js';
 import {makeDrawingDef} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {ColorChangeType}  from '../visualize/draw/DrawLayer.js';
@@ -15,7 +17,7 @@ import { makeGridDrawData } from './ComputeWebGridData.js';
 import DrawLayerCntlr from '../visualize/DrawLayerCntlr.js';
 import {getPreference} from '../core/AppDataCntlr.js';
 import CoordinateSys from '../visualize/CoordSys.js';
- import ImagePlotCntlr from '../visualize/ImagePlotCntlr.js';
+import ImagePlotCntlr from '../visualize/ImagePlotCntlr.js';
 
  import {get} from 'lodash';
 
@@ -49,16 +51,19 @@ var idCnt=0;
  *
  * @return {Function}
  */
-function creator() {
+function creator(params) {
 
     var drawingDef= makeDrawingDef( DEF_GRID_COLOR);
+    const useLabels= isBoolean(params.useLabels) ? params.useLabels : true;
+    const id= params.drawLayerId || `${ID}-${idCnt}`;
     var options= {
         hasPerPlotData:true,
         isPointData:false,
+        useLabels,
         canUserChangeColor: ColorChangeType.DYNAMIC
     };
     
-    return DrawLayer.makeDrawLayer( `${ID}-${idCnt}`, TYPE_ID, 'grid', options , drawingDef);
+    return DrawLayer.makeDrawLayer( id, TYPE_ID, 'grid', options , drawingDef);
 }
 
  /**
@@ -80,7 +85,7 @@ function getDrawData(dataType, plotId, drawLayer, action, lastDataRet){
      var cc= CsysConverter.make(plot);
      if (!cc) return null;
 
-     return lastDataRet ||makeGridDrawData(plot, cc) ;
+     return lastDataRet ||makeGridDrawData(plot, cc, drawLayer.useLabels) ;
 
  }
 

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -10,7 +10,7 @@ import FFTOOLS_ICO from 'html/images/fftools-logo-offset-small-75x75.png';
 function menu(menuComp) {
     if (menuComp) {
         return (
-            <div id='menu-bar' style={{height: '30px', width: '100%', whiteSpace: 'nowrap', position:'relative'}}>
+            <div id='menu-bar' style={{height: '30px', display: 'inline-block', whiteSpace: 'nowrap', position:'relative'}}>
                 {menuComp}
             </div>
         );

--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -10,6 +10,7 @@ import {fetchUrl} from '../util/WebUtil.js';
 import {parseWorldPt} from '../visualize/Point';
 
 
+export {formatPosForTextField} from '../data/form/PositionFieldDef.js';
 
 
 // return an object with:
@@ -120,6 +121,11 @@ export var parseTarget= function(inStr, lastResults) {
             valid, resolvePromise, wpt, aborter  };
 };
 
+
+export function getFeedback(wpt) {
+    var posFieldDef= PositionFieldDef.makePositionFieldDef();
+    return posFieldDef.formatTargetForHelp(wpt);
+}
 
 var resolveObject = function(posFieldDef) {
     var objName= posFieldDef.getObjectName();

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -37,8 +37,11 @@ export {colorChangeActionCreator,
         rotateActionCreator} from './PlotChangeTask.js';
 
 
-
+/** can the 'COLLAPSE', 'GRID', 'SINGLE' */
 export const ExpandType= new Enum(['COLLAPSE', 'GRID', 'SINGLE']);
+
+
+/** can the 'NorthAndCenter', 'ByUserPositionAndZoom' */
 const WcsMatchMode= new Enum (['NorthAndCenter', 'ByUserPositionAndZoom']);
 
 
@@ -128,22 +131,42 @@ const API_TOOLS_VIEW= `${PLOTS_PREFIX}.apiToolsView`;
 export const IMAGE_PLOT_KEY= 'allPlots';
 
 export const ActionScope= new Enum(['GROUP','SINGLE', 'LIST']);
+
+/** @return {VisRoot} */
 export function visRoot() { return flux.getState()[IMAGE_PLOT_KEY]; }
 
+
+
+
 /**
- * The state is best thought of at the following:
- * The state contains an array of PlotView each have a plotId and tie to an Image Viewer,
- * one might be active (PlotView.js)
- * A PlotView has an array of WebPlots, one is primary (WebPlot.js)
- * An ImageViewer shows the primary plot of a plotView. (ImageView.js)
+ *
+ * @return {VisRoot}
  */
 const initState= function() {
 
+    /**
+     * @typedef {Object} VisRoot
+     *
+     * The state of the Image visualization
+     * The state contains an array of PlotView each have a plotId and tie to an Image Viewer,
+     * one might be active (PlotView.js)
+     * A PlotView has an array of WebPlots, one is primary (WebPlot.js)
+     * An ImageViewer shows the primary plot of a plotView. (ImageView.js)
+     *
+     * @prop {String} activePlotId the id of the active plot
+     * @prop {PlotView[]} plotViewAry view array
+     * @prop {PlotGroupAry[]} plotGroupAry view array
+     * @prop {object} plotRequestDefaults - can have multiple values
+     * @prop {ExpandType} expandedMode status of expand mode
+     * @prop {ExpandType} previousExpandedMode the value last time it was expanded
+     * @prop {boolean} singleAutoPlay true if auto play on in expanded mode
+     * @prop {boolean} apiToolsView true if working in api mode
+     */
     return {
+        activePlotId: null,
         plotViewAry : [],  //there is one plot view for every ImageViewer, a plotView will have a plotId
         plotGroupAry : [], // there is one for each group, a plot group may have multiple plotViews
-        plotHistoryRequest: [], //todo
-        activePlotId: null,
+        // plotHistoryRequest: [], //todo
 
         plotRequestDefaults : {}, // object: if normal request;
         //                                         {plotId : {threeColor:boolean, wpRequest : object, }
@@ -167,13 +190,6 @@ const initState= function() {
         wcsMatchCenterWP: null, //todo
         wcsMatchMode: WcsMatchMode.ByUserPositionAndZoom, //todo
         mpwWcsPrimId: null,//todo
-
-        //-- mouse readout settings - todo move to MouseReadoutCntlr
-        mouseReadout1:'eqj2000hms',
-        mouseReadout2: 'fitsIP',
-        pixelSize: 'pixelSize'
-
-
     };
 
 };
@@ -686,6 +702,12 @@ export function changePointSelectionActionCreator(rawAction) {
 //======================================== Reducer =============================
 //======================================== Reducer =============================
 
+/**
+ *
+ * @param state
+ * @param action
+ * @return {VisRoot}
+ */
 function reducer(state=initState(), action={}) {
 
     if (!action.payload || !action.type) return state;

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -36,6 +36,7 @@ export default {
 
 export const SINGLE='single';
 export const GRID='grid';
+export const DEFAULT_FITS_VIEWER_ID= 'DEFAULT_FITS_VIEWER_ID';
 export const EXPANDED_MODE_RESERVED= 'EXPANDED_MODE_RESERVED';
 export const ANY_VIEWER_RESERVED= 'ANY_VIEWER_RESERVED';
 
@@ -45,11 +46,21 @@ export const GRID_FULL='gridFull';
 function initState() {
 
     return [
-        { viewerId:EXPANDED_MODE_RESERVED,  
+        {
+            viewerId:EXPANDED_MODE_RESERVED,
             plotIdAry:[], 
-            viewType:'single', 
+            viewType:SINGLE,
             canReceiveNewPlots: true,
             reservedContainer:true,
+            customData: {}
+        },
+        {
+            viewerId:DEFAULT_FITS_VIEWER_ID,
+            plotIdAry:[],
+            viewType:GRID,
+            canReceiveNewPlots: true,
+            reservedContainer:true,
+            mounted: false,
             customData: {}
         }
     ];

--- a/src/firefly/js/visualize/PlotImageTask.js
+++ b/src/firefly/js/visualize/PlotImageTask.js
@@ -261,7 +261,8 @@ function addDrawLayers(request, plotId ) {
 
     if (request.getGridOn()!==GridOnStatus.FALSE) {
         const dl = getDrawLayerByType(dlRoot(), WebGrid.TYPE_ID);
-        if (!dl) dispatchCreateDrawLayer(WebGrid.TYPE_ID);
+        const useLabels= request.getGridOn()===GridOnStatus.TRUE;
+        if (!dl) dispatchCreateDrawLayer(WebGrid.TYPE_ID, {useLabels});
         dispatchAttachLayerToPlot(WebGrid.TYPE_ID, plotId, true);
     }
 }

--- a/src/firefly/js/visualize/Point.js
+++ b/src/firefly/js/visualize/Point.js
@@ -1,4 +1,5 @@
 
+import {isString} from 'lodash';
 import CoordinateSys from './CoordSys.js';
 import Resolver, {parseResolver} from '../astro/net/Resolver.js';
 import validator from 'validator';
@@ -225,7 +226,7 @@ export const parseScreenPt= (inStr) => parsePt(SPT,inStr);
  * @return {WorldPt}
  */
 export const parseWorldPt = function (serializedWP) {
-    if (!serializedWP) return null;
+    if (!serializedWP || !isString(serializedWP)) return null;
 
     var sAry= serializedWP.split(';');
     if (sAry.length<2 || sAry.length>5) {

--- a/src/firefly/js/visualize/ui/ApiExpandedDisplay.jsx
+++ b/src/firefly/js/visualize/ui/ApiExpandedDisplay.jsx
@@ -10,13 +10,14 @@ import {VisHeaderView} from './VisHeaderView.jsx';
 import {ExpandedModeDisplay} from '../iv/ExpandedModeDisplay.jsx';
 // import {currMouseState} from '../VisMouseCntlr.js';
 import {addMouseListener, lastMouseCtx} from '../VisMouseSync.js';
+import {readoutRoot} from '../../visualize/MouseReadoutCntlr.js';
 
 
 
 export class ApiExpandedDisplay extends Component {
     constructor(props) {
         super(props);
-        this.state= {visRoot:visRoot(), currMouseState:lastMouseCtx()};
+        this.state= {visRoot:visRoot(), currMouseState:lastMouseCtx(), readout:readoutRoot()};
     }
 
     shouldComponentUpdate(np,ns) { return sCompare(this,np,ns); }
@@ -33,8 +34,10 @@ export class ApiExpandedDisplay extends Component {
     }
 
     storeUpdate() {
-        if (visRoot()!==this.state.visRoot || lastMouseCtx() !==this.state.currMouseState) {
-            this.setState({visRoot:visRoot(), currMouseState:lastMouseCtx()});
+        if (visRoot()!==this.state.visRoot || 
+            lastMouseCtx() !==this.state.currMouseState || 
+            readoutRoot()!==this.state.readout) {
+            this.setState({visRoot:visRoot(), currMouseState:lastMouseCtx(), readout:readoutRoot()});
         }
     }
 
@@ -44,12 +47,12 @@ export class ApiExpandedDisplay extends Component {
      */
     render() {
         const {closeFunc}= this.props;
-        var {visRoot,currMouseState}= this.state;
+        var {visRoot,currMouseState, readout}= this.state;
         return (
             <div style={{width:'100%', height:'100%', display:'flex', flexWrap:'nowrap',
                          alignItems:'stretch', flexDirection:'column'}}>
                 <div style={{position: 'relative', marginBottom:'6px'}} className='banner-background'>
-                    <VisHeaderView visRoot={visRoot} currMouseState={currMouseState}/>
+                    <VisHeaderView visRoot={visRoot} currMouseState={currMouseState} readout={readout}/>
                 </div>
                 <div style={{flex: '1 1 auto', display:'flex'}}>
                     <ExpandedModeDisplay   {...{key:'results-plots-expanded', closeFunc, insideFlex:true}}/>

--- a/src/firefly/js/visualize/ui/MouseReadout.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadout.jsx
@@ -55,7 +55,12 @@ const column1 = {
     color: 'DarkGray',
     display: 'inline-block'
 };
-const column2 = {width: 90, display: 'inline-block'};
+const column2 = {
+    width: 90,
+    display: 'inline-block',
+    overflow:'hidden',
+    textOverflow: 'ellipsis'
+};
 
 const column3 = {
     width: 80,
@@ -68,7 +73,7 @@ const column3 = {
 };
 const column3_r2 = {width: 80, paddingRight: 1, textAlign: 'right', color: 'DarkGray', display: 'inline-block'};
 
-const column4 = {width: 88, paddingLeft:4, display: 'inline-block'};
+const column4 = {width: 88, paddingLeft:4, display: 'inline-block', textOverflow: 'ellipsis', overflow:'hidden'};
 const column5 = {
     width: 74,
     paddingRight: 1,
@@ -87,15 +92,16 @@ const column7_r2 = {width: 90, paddingLeft: 3, display: 'inline-block'};
 const precision7Digit = '0.0000000';
 const precision1Digit = '0.0';
 
-const myFormat= (v,precision) => numeral(v).format(padEnd('0.',precision+1,'0') );
+const myFormat= (v,precision) => !isNaN(v) ? numeral(v).format(padEnd('0.',precision+1,'0')) : '';
 export function MouseReadout({readout}){
 
 
    //get the standard readouts
-    const sndReadout= readout[STANDARD_READOUT];
-    if (!get(sndReadout,'readoutItems')) return EMPTY;
+   //  const sndReadout= readout[STANDARD_READOUT];
+    if (!get(readout,[STANDARD_READOUT, 'readoutItems'])) return EMPTY;
 
-
+    const sndReadout= get(readout, STANDARD_READOUT);
+    
     const title = sndReadout.readoutItems.title?sndReadout.readoutItems.title.value:'';
 
     var objList={};
@@ -191,10 +197,12 @@ export function getFluxInfo(sndReadout){
     var fluxValue,  formatStr;
 
     for (let i = 0; i < fluxObj.length; i++) {
-
+        if (!isNaN(fluxObj[i].value )) {
             fluxValue = (fluxObj[i].value < 1000) ? `${myFormat(fluxObj[i].value, fluxObj[i].precision)}` : fluxObj[i].value.toExponential(6).replace('e+', 'E');
+            if (fluxObj[i].unit && !isNaN(fluxObj[i].value)) fluxValue+= ` ${fluxObj[i].unit}`;
             fluxValueArrays.push(fluxValue);
             fluxLabelArrays.push(fluxObj[i].title);
+        }
      }
 
     if (fluxLabelArrays.length<3) { //fill with empty

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -19,6 +19,7 @@ import {WebPlot} from '../WebPlot.js';
 import {EventLayer} from './../iv/EventLayer.jsx';
 import {MouseState} from '../VisMouseSync.js';
 import {dispatchProcessScroll} from '../ImagePlotCntlr.js';
+import {makeMouseStatePayload,fireMouseCtxChange} from '../VisMouseSync.js';
 
 
 
@@ -101,11 +102,25 @@ function eventCB(mouseState,pt,pv,width,height) {
             case MouseState.DOWN :
             case MouseState.DRAG :
                 scrollPlot(pt,pv,width,height);
-                //console.log(`sx:${pt.x}, sy:${pt.y}`);
                 break;
+            default:
+                updateMove(mouseState,pt,pv,width,height);
         }
     }
 }
+
+
+function updateMove(mouseState, pt,pv,width,height) {
+    var plot= primePlot(pv);
+    var fact= getThumbZoomFact(plot,width,height);
+    var cc= CysConverter.make(plot);
+    var ipt= cc.getImageWorkSpaceCoords(pt,fact);
+    var spt= cc.getScreenCoords(ipt);
+    const payload= makeMouseStatePayload(pv.plotId, mouseState,spt,spt.x,spt.y);
+    fireMouseCtxChange(payload);
+}
+
+
 
 function scrollPlot(pt,pv,width,height) {
 

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -11,9 +11,9 @@ import {MultiImageViewer} from './MultiImageViewer.jsx';
 import {watchImageMetaData} from '../saga/ImageMetaDataWatcher.js';
 import {watchCoverage} from '../saga/CoverageWatcher.js';
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
+import {DEFAULT_FITS_VIEWER_ID} from '../MultiViewCntlr.js';
 import {LO_MODE, LO_VIEW, dispatchSetLayoutMode, dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
 
-export const FITS_VIEWER_ID = 'triViewImages';
 export const META_VIEWER_ID = 'triViewImageMetaData';
 export const COVERAGE_VIEWER_ID = 'TBD';
 
@@ -48,7 +48,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
             <Tabs onTabSelect={onTabSelect} defaultSelected={selectedTab} useFlex={true}>
                 { showFits &&
                     <Tab name='Fits Data' removable={false} id='fits'>
-                        <MultiImageViewer viewerId= {FITS_VIEWER_ID}
+                        <MultiImageViewer viewerId= {DEFAULT_FITS_VIEWER_ID}
                                           insideFlex={true}
                                           canReceiveNewPlots={true}
                                           canDelete={true}

--- a/src/firefly/js/visualize/ui/VisHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/VisHeaderView.jsx
@@ -38,7 +38,7 @@ export function VisHeaderView({visRoot,currMouseState, readout}) {
         <div style={{display:'inline-block', float:'right', whiteSpace:'nowrap'}}>
             <div style={rS}>
                 <div style={{position:'absolute', color:'white'}}>
-                    <MouseReadout  readout={readout}/>
+                    <MouseReadout readout={readout}/>
                 </div>
             </div>
 


### PR DESCRIPTION
 - There is no panner for the image (is it missing from the API or is it a bug in calling it?)
 - No readout value from thumbnail image
 - The top bar readout doesn't include units for the pixel flux
 - Clicking on the expand icon deletes the image (in API only)
 - Clicking on the expand icon diabled the expand mode of table and xy plot (in API only)
 - Image button ask you for a position and displays that, wiping out whatever image brought you to IRSA Viewer in the first place. It should give another tile of the same field, drawn from the selected data set. (IRSAVIewer only)
 - grid with label off
 - Made loading images from remote consistent
 - Started conversion of python API
 - fixed range values serialization issue