### PR TITLE
DM-7029: fixed some api bugs

### DIFF
--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -33,6 +33,8 @@ export {RequestType} from '../visualize/RequestType';
 export {ExpandType, dispatchApiToolsView} from '../visualize/ImagePlotCntlr.js';
 export {CsysConverter} from '../visualize/CsysConverter.js';
 export {CCUtil} from '../visualize/CsysConverter.js';
+export {primePlot} from '../visualize/PlotViewUtil.js';
+export {visRoot} from '../visualize/ImagePlotCntlr.js';
 export {watchCoverage} from '../visualize/saga/CoverageWatcher.js';
 import {watchImageMetaData} from '../visualize/saga/ImageMetaDataWatcher.js';
 

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -31,6 +31,8 @@ export {RangeValues} from '../visualize/RangeValues.js';
 export {WPConst, WebPlotRequest, findInvalidWPRKeys, confirmPlotRequest} from '../visualize/WebPlotRequest.js';
 export {RequestType} from '../visualize/RequestType';
 export {ExpandType, dispatchApiToolsView} from '../visualize/ImagePlotCntlr.js';
+export {CsysConverter} from '../visualize/CsysConverter.js';
+export {CCUtil} from '../visualize/CsysConverter.js';
 export {watchCoverage} from '../visualize/saga/CoverageWatcher.js';
 import {watchImageMetaData} from '../visualize/saga/ImageMetaDataWatcher.js';
 

--- a/src/firefly/js/drawingLayers/SelectArea.js
+++ b/src/firefly/js/drawingLayers/SelectArea.js
@@ -93,7 +93,7 @@ function creator() {
     var options= {
         canUseMouse:true,
         canUserChangeColor: ColorChangeType.DISABLE,
-        canUserDelete: false,
+        canUserDelete: true,
         destroyWhenAllDetached: true
     };
     return DrawLayer.makeDrawLayer( `${ID}-${idCnt}`, TYPE_ID, 'Selection Tool',

--- a/src/firefly/js/drawingLayers/SelectArea.js
+++ b/src/firefly/js/drawingLayers/SelectArea.js
@@ -84,7 +84,7 @@ function creator() {
                       DrawLayerCntlr.SELECT_AREA_MOVE,
                       DrawLayerCntlr.SELECT_AREA_END,
                       DrawLayerCntlr.SELECT_MOUSE_LOC];
-    
+
     var exclusiveDef= { exclusiveOnDown: true, type : 'anywhere' };
 
 
@@ -259,7 +259,7 @@ function drag(drawLayer,action) {
     var plot= primePlot(visRoot(),plotId);
     if (!plot) return;
     var drawSel= makeSelectObj(drawLayer.firstPt, imagePt, CsysConverter.make(plot));
-    var exclusiveDef= { exclusiveOnDown: true, type : 'vertexOnly' };
+    var exclusiveDef= { exclusiveOnDown: true, type : 'vertexThenAnywhere' };
     return {currentPt:imagePt,
             drawData:{data:drawSel},
             exclusiveDef,

--- a/src/firefly/js/visualize/PlotImageTask.js
+++ b/src/firefly/js/visualize/PlotImageTask.js
@@ -12,7 +12,7 @@ import CsysConverter from './CsysConverter.js';
 import {dispatchActiveTarget, getActiveTarget} from '../core/AppDataCntlr.js';
 import VisUtils from './VisUtil.js';
 import {PlotState} from './PlotState.js';
-import {makeImagePt} from './Point.js';
+import Point, {makeImagePt} from './Point.js';
 import {WPConst, DEFAULT_THUMBNAIL_SIZE} from './WebPlotRequest.js';
 import {Band} from './Band.js';
 import {PlotPref} from './PlotPref.js';
@@ -230,7 +230,7 @@ export function processPlotImageSuccessResponse(dispatcher, payload, result) {
 
         pvNewPlotInfoAry
             .forEach((info) => info.plotAry
-                .forEach( (p)  => addDrawLayers(p.plotState.getWebPlotRequest(), p.plotId) ));
+                .forEach( (p)  => addDrawLayers(p.plotState.getWebPlotRequest(), p) ));
 
 
 
@@ -253,10 +253,21 @@ export function processPlotImageSuccessResponse(dispatcher, payload, result) {
 }
 
 
-function addDrawLayers(request, plotId ) {
+function addDrawLayers(request, plot ) {
+    const {plotId}= plot;
     request.getOverlayIds().forEach((drawLayerTypeId)=> {
         const dl = getDrawLayerByType(dlRoot(), drawLayerTypeId);
-        if (dl) DrawLayerCntlr.dispatchAttachLayerToPlot(dl.drawLayerId, plotId);
+        if (dl) {
+            if (dl.drawLayerTypeId===ActiveTarget.TYPE_ID) {
+                const pt= plot.attributes[PlotAttribute.FIXED_TARGET];
+                if (pt && pt.type===Point.W_PT) {
+                    DrawLayerCntlr.dispatchAttachLayerToPlot(dl.drawLayerId, plotId);
+                }
+            }
+            else {
+                DrawLayerCntlr.dispatchAttachLayerToPlot(dl.drawLayerId, plotId);
+            }
+        }
     });
 
     if (request.getGridOn()!==GridOnStatus.FALSE) {

--- a/src/firefly/js/visualize/draw/DrawerComponent.jsx
+++ b/src/firefly/js/visualize/draw/DrawerComponent.jsx
@@ -3,8 +3,7 @@
  */
 
 import React from 'react';
-import difference from 'lodash/difference';
-import isEqual from 'lodash/isEqual';
+import {xor,isEqual} from 'lodash';
 import sCompare from 'react-addons-shallow-compare';
 import CanvasWrapper from './CanvasWrapper.jsx';
 import TextDrawer from './TextDrawer.jsx';
@@ -80,7 +79,8 @@ export class DrawerComponent extends React.Component {
     textUpdateCallback(textDrawAry) {
         var {textDrawAry:old}= this.state;
         //if ((!textDrawAry && !old)  || !textDrawAry.length && !old.length) return;
-        if (!difference(textDrawAry,old).length) return;
+        // if (!difference(textDrawAry,old).length && !difference(old,textDrawAry).length) return;
+        if (!xor(textDrawAry,old).length) return;
 
         var doUpdate=
             old.length!=textDrawAry.length ||

--- a/src/firefly/js/visualize/iv/EventLayer.jsx
+++ b/src/firefly/js/visualize/iv/EventLayer.jsx
@@ -39,7 +39,6 @@ export var EventLayer= React.createClass(
         var {screenX, screenY, offsetX, offsetY}= ev.nativeEvent;
         if (ev.clientX && ev.clientY && offsetX && offsetY) {
             spt= makeScreenPt( viewPortX+offsetX, viewPortY+offsetY);
-            console.log(`fireEvent: ${spt.toString()}`);
         }
         this.props.eventCallback(plotId,mouseState,spt,screenX,screenY);
     },
@@ -56,7 +55,6 @@ export var EventLayer= React.createClass(
         var compOffX= x-getAbsoluteLeft(e);
         var compOffY= y-getAbsoluteTop(e);
         spt= makeScreenPt( viewPortX+compOffX, viewPortY+compOffY);
-        console.log(`fireDocEvent: ${spt.toString()}`);
         this.props.eventCallback(plotId,mouseState,spt,screenX,screenY);
     },
 

--- a/src/firefly/js/visualize/iv/EventLayer.jsx
+++ b/src/firefly/js/visualize/iv/EventLayer.jsx
@@ -39,6 +39,7 @@ export var EventLayer= React.createClass(
         var {screenX, screenY, offsetX, offsetY}= ev.nativeEvent;
         if (ev.clientX && ev.clientY && offsetX && offsetY) {
             spt= makeScreenPt( viewPortX+offsetX, viewPortY+offsetY);
+            console.log(`fireEvent: ${spt.toString()}`);
         }
         this.props.eventCallback(plotId,mouseState,spt,screenX,screenY);
     },
@@ -50,9 +51,12 @@ export var EventLayer= React.createClass(
         var {x:viewPortX,y:viewPortY} = viewPort;
         var {screenX, screenY, pageX:x, pageY:y}= nativeEv;
         var e= ReactDOM.findDOMNode(this);
-        var compOffX= x-getAbsoluteLeft(e)+window.scrollX-1;
-        var compOffY= y-getAbsoluteTop(e)+window.scrollY-1;
+        // var compOffX= x-getAbsoluteLeft(e)+window.scrollX-1;
+        // var compOffY= y-getAbsoluteTop(e)+window.scrollY-1;
+        var compOffX= x-getAbsoluteLeft(e);
+        var compOffY= y-getAbsoluteTop(e);
         spt= makeScreenPt( viewPortX+compOffX, viewPortY+compOffY);
+        console.log(`fireDocEvent: ${spt.toString()}`);
         this.props.eventCallback(plotId,mouseState,spt,screenX,screenY);
     },
 
@@ -96,6 +100,14 @@ export var EventLayer= React.createClass(
 
     },
 
+
+    onMouseMove(ev) {
+        if (!this.mouseDown) {
+            var {viewPort,plotId}= this.props;
+            this.fireEvent(ev,plotId,viewPort,this.mouseDown?MouseState.DRAG_COMPONENT : MouseState.MOVE);
+        }
+    },
+
     onDocumentMouseMove(nativeEv) {
         if (this.mouseDown) {
             var {viewPort,plotId}= this.props;
@@ -123,11 +135,6 @@ export var EventLayer= React.createClass(
         this.fireEvent(ev,plotId,viewPort,MouseState.ENTER);
     },
 
-
-    onMouseMove(ev) {
-        var {viewPort,plotId}= this.props;
-        this.fireEvent(ev,plotId,viewPort,this.mouseDown?MouseState.DRAG_COMPONENT : MouseState.MOVE);
-    },
 
 
     onTouchCancel(ev) {

--- a/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
@@ -309,9 +309,9 @@ function findMouseOwner(dlList, plot, screenPt) {
             const y= screenPt.y- dist;
             const w= dist*2;
             const h= dist*2;
-            return vertexDef.points.find( (p) => {
-                const spt= cc.getScreenCoords(p);
-                return contains(x,y,w,h,spt.x,spt.y);
+            return vertexDef.points.find( (pt) => {
+                const spt= cc.getScreenCoords(pt);
+                return spt && contains(x,y,w,h,spt.x,spt.y);
             } );
         });
 

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -403,14 +403,19 @@ function getNewAttributes(plot) {
         worldPt= circle.center;
     }
     else if (getActiveTarget()) {
-        worldPt= getActiveTarget();
+        worldPt= getActiveTarget().worldPt;
     }
     else {
         worldPt= VisUtil.getCenterPtOfPlot(plot);
     }
 
-    if (worldPt) attributes[PlotAttribute.FIXED_TARGET]= worldPt;
-    if (circle) attributes[PlotAttribute.REQUESTED_SIZE]= circle.radius;  // says radius but really size
+    if (worldPt) {
+        const cc= CysConverter.make(plot);
+        if (cc.pointInPlot(worldPt)) {
+            attributes[PlotAttribute.FIXED_TARGET]= worldPt;
+            if (circle) attributes[PlotAttribute.REQUESTED_SIZE]= circle.radius;  // says radius but really size
+        }
+    }
     if (req.getUniqueKey())     attributes[PlotAttribute.UNIQUE_KEY]= req.getUniqueKey();
     if (req.isMinimalReadout()) attributes[PlotAttribute.MINIMAL_READOUT]=true;
 

--- a/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
@@ -4,9 +4,9 @@
 
 
 import React from 'react';
-import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
+import {dispatchShowDialog, dispatchHideDialog} from '../../core/ComponentCntlr.js';
 import sCompare from 'react-addons-shallow-compare';
-import {getActivePlotView} from '../PlotViewUtil.js';
+import {getActivePlotView, getAllDrawLayersForPlot} from '../PlotViewUtil.js';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import {getDlAry} from '../DrawLayerCntlr.js';
@@ -39,6 +39,9 @@ export function showDrawingLayerPopup() {
     dispatchShowDialog(DRAW_LAYER_POPUP);
 }
 
+export function hideDrawingLayerPopup() {
+    dispatchHideDialog(DRAW_LAYER_POPUP);
+}
 
 
 class DrawLayerPanel extends React.Component {
@@ -65,7 +68,14 @@ class DrawLayerPanel extends React.Component {
         var activePv= getActivePlotView(visRoot());
 
         if (activePv!==state.activePv  || getDlAry()!==state.dlAry) {
-            this.setState({dlAry:getDlAry(),activePv});
+            const dlAry= getDlAry();
+            var layers= getAllDrawLayersForPlot(dlAry,activePv.plotId);
+            if (layers.length) {
+                this.setState({dlAry,activePv});
+            }
+            else {
+                setTimeout(() => hideDrawingLayerPopup(),0)
+            }
         }
     }
 


### PR DESCRIPTION
 - Image is coming with one draw layer. (I can delete this draw layer and nothing changes on the image)
 - When draw layer is deleted, and no more layers are present, the layers dialog should be closed. (It stays with nothing to
  display, you have to click x to close it.)
 - After selecting an area in one viewer, I select an area in another viewer, then move the mouse to the first one: 147
  ImageViewerLayout.jsx:314 Uncaught TypeError: Cannot read property 'x' of null at ImageViewerLayout.jsx:314 Nothing works after
that. I have to reload.
 - Selection appears with an offset, if the page, which contains the viewer is scrolled. (Load the attached script, press
  'Start selection tracking' click to select a point, then scroll page a bit down, then click to select another point - it shows
down from where it should be.)
 - I have 2 image viewers in separate divs. Selected line in one, then selected line in the other. The line from the first one
  disappeared, but its label is still there. (See attached image.)
 - Selection is working differently from distance. To select in another plot, I need to press selection again. I don't need to press ruler again to select new distance in another plot.
 - The payload.attValue of CHANGE_PLOT_ATTRIBUTE action is using WorldPt for area and point selections (when payload.attKey is  'SELECTION' or 'ACTIVE_POINT'), but ImagePt for line selection (when payload.attKey is 'ACTIVE_DISTANCE') How can I make them
all use image coordinates? Now exporting the coordinage system conversion code.

`var imagePt= firefly.util.image.CCUtil.getImageCoords(plot,pt);`