### PR TITLE
DM-6947: fixing word typos and help links

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -101,6 +101,7 @@
     font-family: tahoma,arial,helvetica,sans-serif;
     font-style: italic;
     cursor: pointer;
+    text-decoration: underline;
 }
 
 .ff-href:hover {

--- a/src/firefly/js/charts/ui/ColSelectView.jsx
+++ b/src/firefly/js/charts/ui/ColSelectView.jsx
@@ -115,7 +115,7 @@ function renderCloseAndHelpButtons(tblId,onColSelected,buttonText,popupId) {
         </div>
         {/* comment out the help button for now
             <div style={helpIdStyle}>
-                <HelpIcon helpid={'visualization.setxyplot'}/>
+                <HelpIcon helpId={'catalogs.xyplots'}/>
             </div>
          */}
     </div>

--- a/src/firefly/js/charts/ui/XYPlotOptions.jsx
+++ b/src/firefly/js/charts/ui/XYPlotOptions.jsx
@@ -350,7 +350,7 @@ export class XYPlotOptions extends React.Component {
                             }}
                             options={[
                                 {label: 'grid', value: 'grid'},
-                                {label: 'flip', value: 'flip'},
+                                {label: 'reverse', value: 'flip'},
                                 {label: 'log', value: 'log'}
                             ]}
                             fieldKey='x.options'
@@ -419,7 +419,7 @@ export class XYPlotOptions extends React.Component {
                             }}
                             options={[
                                 {label: 'grid', value: 'grid'},
-                                {label: 'flip', value: 'flip'},
+                                {label: 'reverse', value: 'flip'},
                                 {label: 'log', value: 'log'}
                             ]}
                             fieldKey='y.options'

--- a/src/firefly/js/drawingLayers/DistanceToolUI.jsx
+++ b/src/firefly/js/drawingLayers/DistanceToolUI.jsx
@@ -23,9 +23,9 @@ function DistanceToolUI({drawLayer,pv}) {
 
 
 
-    var options= [ {label: 'Deg', value: 'deg'},
-                   {label: 'Arc Min', value: 'arcmin'},
-                   {label: 'Arc Sec', value: 'arcsec'},
+    var options= [ {label: 'Degree', value: 'deg'},
+                   {label: 'Arcminute', value: 'arcmin'},
+                   {label: 'Arcsecond', value: 'arcsec'}
     ];
 
 

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -74,7 +74,7 @@ export class TablePanelOptions extends React.Component {
                              onClick={() => toggleOptions()}/>
 
                         <button className='TablePanelOptions__button' onClick={onReset}
-                                title='Reset all options to defauls'>Reset</button>
+                                title='Reset all options to defaults'>Reset</button>
                     </span>
                 </div>
                 <div style={{height: 'calc(100% - 40px)'}}>

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -287,7 +287,7 @@ function FitsDownloadDialogForm() {
                         </td>
                         <td>
                             <div style={{ textAlign:'center', marginBottom: 20}}>
-                               <HelpIcon helpid={'visualization.fitsDownloadOptions'} />
+                               <HelpIcon helpId={'visualization.fitsViewer'} />
                             </div>
                         </td>
                     </tr>

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -246,7 +246,7 @@ function FitsRotationDialogForm() {
                             </td>
                             <td>
                                 <div style={{ textAlign:'center', marginBottom: 20}}>
-                                    <HelpIcon helpid={'visualization.Rotate'} />
+                                    <HelpIcon helpId={'visualization.imageoptions'} />
                                 </div>
                             </td>
                          </tr>

--- a/src/firefly/js/ui/VoSearchPanel.jsx
+++ b/src/firefly/js/ui/VoSearchPanel.jsx
@@ -9,6 +9,8 @@ import {ValidationField} from './ValidationField.jsx';
 import FieldGroupUtils from '../fieldGroup/FieldGroupUtils.js';
 import {ListBoxInputField} from './ListBoxInputField.jsx';
 import {gkey} from '../visualize/ui/CatalogSelectViewPanel.jsx';
+import {HelpIcon} from '../ui/HelpIcon.jsx';
+
 import './VoSearchPanel.css';
 
 export class VoSearchPanel extends React.Component {
@@ -32,19 +34,25 @@ export class VoSearchPanel extends React.Component {
     render() {
         const fields = this.state;
         return (
-            <div className={'vopanel'}>
-                <div className={'section'}>
-                    {targetPanelArea()}
-                </div>
-                <div className={'size'}>
-                    { sizeArea()}
-                </div>
-                <div className={'voarea'}>
-                    { voSearchArea() }
-                    <div style={{padding:'20px 0 20px 0'}}>
-                        <a target='_blank' href='http://nvo.stsci.edu/vor10/index.aspx'>Find Astronomical Data
-                            Resources </a>
+            <div>
+                <div className={'vopanel'}>
+                    <div className={'section'}>
+                        {targetPanelArea()}
                     </div>
+                    <div className={'size'}>
+                        { sizeArea()}
+                    </div>
+                    <div className={'voarea'}>
+                        { voSearchArea() }
+                        <div style={{padding:'20px 0 20px 0'}}>
+                            <a target='_blank' href='http://nvo.stsci.edu/vor10/index.aspx'>Find Astronomical Data
+                                Resources </a>
+                        </div>
+                    </div>
+                </div>
+                <div style={{display:'flex',flexDirection:'column', alignItems:'flex-end'}}>
+                    <HelpIcon
+                        helpId={'catalogs.vo'}/>
                 </div>
             </div>
         );

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -35,9 +35,6 @@ import './CatalogSelectViewPanel.css';
  */
 export const gkey = 'CATALOG_PANEL';
 
-/**define the helpButton*/
-const helpIdStyle = {'textAlign': 'center', display: 'inline-block', height: 40, marginRight: 20};
-
 const dropdownName = 'IrsaCatalogDropDown';
 
 const initRadiusArcSec = (10 / 3600) + '';
@@ -78,7 +75,7 @@ export class CatalogSelectViewPanel extends Component {
     render() {
         var {fields}= this.state;
         return (
-            <div style={{padding: 10}}>
+            <div>
                 <FormPanel
                     width='auto' height='auto'
                     groupKey={gkey}
@@ -87,6 +84,7 @@ export class CatalogSelectViewPanel extends Component {
                     <CatalogSelectView fields={fields}/>
                 </FormPanel>
             </div>
+
         );
     }
 }
@@ -401,10 +399,10 @@ class CatalogSelectView extends Component {
                                             tooltip: 'Select an IPAC catalog table file to upload',
                                             label: 'File:'}}
                             />
-                            <div style={helpIdStyle}>
+                            <div>
                                 <em style={{color:'gray'}}>Custom catalog in IPAC table format</em>
                                 <HelpIcon
-                                    helpid={'basics.loadcatalog'}/>
+                                    helpId={'basics.loadcatalog'}/>
                             </div>
                         </div>
                     </Tab>
@@ -660,6 +658,10 @@ class CatalogDDList extends Component {
                     />
                 </div>
                 {/*</div>*/}
+                <div style={{display:'flex',flexDirection:'column', alignItems:'flex-end'}}>
+                    <HelpIcon
+                        helpId={'basics.catalogs'}/>
+                </div>
             </div>
         );
     }

--- a/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
@@ -21,8 +21,16 @@ function getDialogBuilder() {
     var popup= null;
     return () => {
         if (!popup) {
+            var title = 'Drawing Layers';
+            //try {
+            //    if(visRoot()){
+            //        title += ': '+getActivePlotView(visRoot()).plots[0].title;
+            //    }
+            //}catch (E){
+            //    //
+            //}
             const popup= (
-                <PopupPanel title={'Drawing Layers'} >
+                <PopupPanel title={title} >
                     <DrawLayerPanel/>
                 </PopupPanel>
             );

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -161,7 +161,7 @@ function renderCloseAndHelpButtons(popupId){
             />
         </div>
         <div style={helpIdStyle}>
-            <HelpIcon helpid={'visualization.fitsDownloadOptions'}/>
+            <HelpIcon helpId={'visualization.fitsViewer'}/>
         </div>
     </div>
 );

--- a/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
+++ b/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
@@ -473,6 +473,9 @@ class ImageSelectionView extends Component {
                     </div>
                     { loadButtonArea() }
                 </div>
+                <div style={{display:'flex', flexDirection:'column', alignItems:'flex-end'}}>
+                    <HelpIcon helpId={'basics.searching'}/>
+                </div>
             </FieldGroup>
         );
     }

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -47,7 +47,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
         return (
             <Tabs onTabSelect={onTabSelect} defaultSelected={selectedTab} useFlex={true}>
                 { showFits &&
-                    <Tab name='Fits Data' removable={false} id='fits'>
+                    <Tab name='FITS Data' removable={false} id='fits'>
                         <MultiImageViewer viewerId= {DEFAULT_FITS_VIEWER_ID}
                                           insideFlex={true}
                                           canReceiveNewPlots={true}
@@ -56,7 +56,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
                     </Tab>
                 }
                 { showMeta &&
-                    <Tab name='Image Meta Data' removable={false} id='meta'>
+                    <Tab name='Images' removable={false} id='meta'>
                         <MultiImageViewer viewerId= {META_VIEWER_ID}
                                           insideFlex={true}
                                           canReceiveNewPlots={false}

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -23,6 +23,7 @@ import {ColorTableDropDownView} from './ColorTableDropDownView.jsx';
 
 import {showFitsDownloadDialog} from '../../ui/FitsDownloadDialog.jsx';
 import {showFitsRotationDialog} from '../../ui/FitsRotationDialog.jsx';
+import {HelpIcon} from '../../ui/HelpIcon.jsx';
 import DistanceTool from '../../drawingLayers/DistanceTool.js';
 import SelectArea from '../../drawingLayers/SelectArea.js';
 import NorthUpCompass from '../../drawingLayers/NorthUpCompass.js';
@@ -166,7 +167,7 @@ export class VisToolbarView extends Component {
         return (
             <div style={rS}>
                 <ToolbarButton icon={SAVE}
-                               tip='Save the Fits file, PNG file, or save the overlays as a region'
+                               tip='Save the FITS file, PNG file, or save the overlays as a region'
                                enabled={enabled}
                                horizontal={true}
                                visible={mi.fitsDownload}
@@ -194,6 +195,23 @@ export class VisToolbarView extends Component {
                                        visible={mi.stretchQuick}
                                        dropDown={<StretchDropDownView plotView={pv}/>} />
 
+
+                <ToolbarHorizontalSeparator/>
+                
+                <ToolbarButton icon={ROTATE}
+                               tip='Rotate the image to any angle'
+                               enabled={enabled}
+                               horizontal={true}
+                               visible={mi.rotate}
+                               onClick={showFitsRotationDialog}/>
+                <SimpleLayerOnOffButton plotView={pv}
+                                        isIconOn={pv&&plot ? pv.plotViewCtx.rotateNorthLock : false }
+                                        tip='Rotate this image so that North is up'
+                                        iconOn={ROTATE_NORTH_ON}
+                                        iconOff={ROTATE_NORTH_OFF}
+                                        visible={mi.rotateNorth}
+                                        onClick={doRotateNorth}
+                />
                 <ToolbarButton icon={FLIP_Y} tip='Flip the image on the Y Axis'
                                enabled={enabled} horizontal={true}
                                visible={mi.flipImageY}
@@ -203,27 +221,6 @@ export class VisToolbarView extends Component {
                                enabled={enabled} horizontal={true}
                                visible={mi.recenter}
                                onClick={() => recenter(pv)}/>
-
-
-                <ToolbarHorizontalSeparator/>
-
-                <SimpleLayerOnOffButton plotView={pv}
-                                        isIconOn={pv&&plot ? pv.plotViewCtx.rotateNorthLock : false }
-                                        tip='Rotate this image so that North is up'
-                                        iconOn={ROTATE_NORTH_ON}
-                                        iconOff={ROTATE_NORTH_OFF}
-                                        visible={mi.rotateNorth}
-                                        onClick={doRotateNorth}
-                />
-
-                <ToolbarButton icon={ROTATE}
-                               tip='Rotate the image to any angle'
-                               enabled={enabled}
-                               horizontal={true}
-                               visible={mi.rotate}
-                               onClick={showFitsRotationDialog}/>
-
-
 
                 <ToolbarHorizontalSeparator/>
 
@@ -323,6 +320,10 @@ export class VisToolbarView extends Component {
 
 
 
+                <div style={{display:'inline-block', height:'100%', flex:'0 0 auto', marginLeft:'10px'}}>
+                    <HelpIcon
+                        helpId={'visualization.fitsViewer'}/>
+                </div>
 
             </div>
         );


### PR DESCRIPTION
This PR contains the following fix:
- words/label fixed
- links to online-help fixed and icon added.
- order of the icon in the image toolbar to be as before migration

Let me know if you find any inconsistency.