### PR TITLE
DM-7068: bug list

### DIFF
--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -114,15 +114,17 @@ function makeHighlightDeferred(drawLayer,plotId,screenPt) {
     var done= false;
     var idx= 0;
     const maxChunk= 1000;
-    var minDist = Number.MAX_SAFE_INTEGER;
+    var minDist = 20;
     const {data}= drawLayer.drawData;
     const {tableRequest}= drawLayer;
-    var closestIdx;
+    var closestIdx= -1;
     const plot= primePlot(visRoot(),plotId);
     const id= window.setInterval( () => {
         if (done) {
             window.clearInterval(id);
-            dispatchTableHighlight(drawLayer.drawLayerId,closestIdx,tableRequest);
+            if (closestIdx > -1) {
+                dispatchTableHighlight(drawLayer.drawLayerId,closestIdx,tableRequest);
+            }
         }
 
         var dist;

--- a/src/firefly/js/ui/DropDownMenu.jsx
+++ b/src/firefly/js/ui/DropDownMenu.jsx
@@ -10,15 +10,14 @@ import './DropDownMenu.css';
 const computePosition= (tgtX,tgtY)  => ({x:tgtX,y:tgtY+18});
 
 function placeDropDown(e,x,y) {
-    var {scrollX,scrollY}= window;
     var pos= computePosition(x,y);
 
-    var left= pos.x - 10 - scrollX;
+    var left= pos.x - 10;
     if (left<5) {
         left= 5;
     }
     e.style.left= left +'px';
-    e.style.top= (pos.y + 10  - scrollY)+'px';
+    e.style.top= (pos.y + 10)+'px';
     e.style.visibility='visible';
 }
 

--- a/src/firefly/js/ui/PopupPanelHelper.js
+++ b/src/firefly/js/ui/PopupPanelHelper.js
@@ -33,10 +33,10 @@ const inRangeCheck = function(x, y, xIncrease, yIncrease) {
 
 var getAbsoluteX= function(ev) {
     if (ev.type===MOUSE_EV) {
-        return  ev.clientX+document.scrollLeft;
+        return  ev.clientX+window.scrollX;
     }
     if (ev.type===TOUCH_EV) {
-        return  ev.targetTouches[0].clientX+document.scrollLeft;
+        return  ev.targetTouches[0].clientX+window.scrollX;
     }
     return 0;
 };
@@ -44,10 +44,10 @@ var getAbsoluteX= function(ev) {
 
 var getAbsoluteY= function(ev) {
     if (ev.type===MOUSE_EV) {
-        return  ev.clientY+document.scrollLeft;
+        return  ev.clientY+window.scrollY;
     }
     if (ev.type===TOUCH_EV) {
-        return  ev.targetTouches[0].clientY+window.scrollLeft;
+        return  ev.targetTouches[0].clientY+window.scrollY;
     }
     return 0;
 };
@@ -74,12 +74,12 @@ const doMove= function(ctx, x, y) {
         var yDiff= y-ctx.originalMouseY;
         var newX=ctx.originalX+xDiff;
         var newY=ctx.originalY+yDiff;
-        if (newX+ctx.popup.offsetWidth>window.innerWidth ) {
-            newX= window.innerWidth-ctx.popup.offsetWidth;
+        if (newX+ctx.popup.offsetWidth>window.innerWidth+ window.scrollX ) {
+            newX= window.innerWidth+window.scrollX-ctx.popup.offsetWidth;
         }
         if (newX<2) newX=2;
-        if (newY+ctx.popup.offsetHeight>window.innerHeight ) {
-            newY= window.innerHeight-ctx.popup.offsetHeight;
+        if (newY+ctx.popup.offsetHeight>window.innerHeight + window.scrollY ) {
+            newY= window.innerHeight+window.scrollY-ctx.popup.offsetHeight;
         }
         if (newY<2) newY=2;
 
@@ -117,7 +117,7 @@ export const getPopupPosition= function(e,layoutType) {
             break;
         case 'TOP_LEFT' :
             left= 2 + window.scrollX;
-            top= document.scrollY+ 3;
+            top= window.scrollY+ 3;
             break;
 
         case 'TOP_EDGE_CENTER' :
@@ -340,6 +340,8 @@ function findRegion(popup,titleBar,mx, my) {
 
     var retval= PopupRegion.NONE;
 
+    mx+= window.scrollX;
+    my+= window.scrollY;
     var x= getAbsoluteLeft(popup);
     var y= getAbsoluteTop(popup);
     var w= popup.offsetWidth;

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -409,6 +409,7 @@ export function dispatchRestoreDefaults({plotId, dispatcher= flux.process}) {
  * @param {boolean} useContextModifications it true the request will be modified to use preferences, rotation, etc
  *                                 should only be false when it is doing a 'restore to defaults' type plot
  * @param {boolean} attributes the are added to the plot
+ * @param {object} pvOptions parameter specific to the  plotView, only read the first time per plot id
  * @param {function} dispatcher only for special dispatching uses such as remote
  * @param viewerId
  */
@@ -417,10 +418,11 @@ export function dispatchPlotImage({plotId,wpRequest, threeColor=isArray(wpReques
                                   useContextModifications= true,
                                   dispatcher= flux.process,
                                   attributes={},
+                                  pvOptions= {},
                                   viewerId} ) {
 
     dispatcher({ type: PLOT_IMAGE,
-                   payload: {plotId,wpRequest, threeColor, addToHistory, 
+                   payload: {plotId,wpRequest, threeColor, addToHistory, pvOptions,
                              attributes, useContextModifications,viewerId}});
 }
 
@@ -430,7 +432,7 @@ export function dispatchPlotImage({plotId,wpRequest, threeColor=isArray(wpReques
  * @param wpRequestAry
  * @param {function} dispatcher only for special dispatching uses such as remote
  */
-export function dispatchPlotGroup({wpRequestAry, dispatcher= flux.process}) {
+export function dispatchPlotGroup({wpRequestAry, pvOptions= {}, dispatcher= flux.process}) {
     dispatcher( { type: PLOT_IMAGE, payload: { wpRequestAry} });
 }
 

--- a/src/firefly/js/visualize/PlotImageTask.js
+++ b/src/firefly/js/visualize/PlotImageTask.js
@@ -49,7 +49,7 @@ function ensureWPR(inVal) {
 const getFirstReq= (wpRAry) => isArray(wpRAry) ? wpRAry.find( (r) => r?true:false) : wpRAry;
 
 
-function makeSinglePlotPayload({wpRequest,plotId, threeColor, viewerId, attributes,
+function makeSinglePlotPayload({wpRequest,plotId, threeColor, viewerId, attributes, pvOptions= {},
                                 addToHistory= false,useContextModifications= true}  ) {
     wpRequest= ensureWPR(wpRequest);
 
@@ -68,7 +68,7 @@ function makeSinglePlotPayload({wpRequest,plotId, threeColor, viewerId, attribut
     const payload= { plotId:req.getPlotId(),
                      plotGroupId:req.getPlotGroupId(),
                      groupLocked:req.isGroupLocked(),
-                     attributes, viewerId, addToHistory, useContextModifications, threeColor};
+                     attributes, viewerId, pvOptions, addToHistory, useContextModifications, threeColor};
 
     if (threeColor) {
         if (isArray(wpRequest)) {
@@ -107,6 +107,7 @@ function makePlotImageAction(rawAction) {
                 wpRequestAry:ensureWPR(wpRequestAry),
                 viewerId:rawAction.payload.viewerId,
                 attributes:rawAction.payload.attributes,
+                pvOptions: rawAction.pvOptions,
                 threeColor:false,
                 addToHistory:false,
                 useContextModifications:true,

--- a/src/firefly/js/visualize/draw/DrawOp.js
+++ b/src/firefly/js/visualize/draw/DrawOp.js
@@ -6,12 +6,14 @@
 import PointDataObj, {POINT_DATA_OBJ} from './PointDataObj.js';
 import SelectBox from './SelectBox.js';
 import ShapeDataObj from './ShapeDataObj.js';
+import FootprintObj from './FootprintObj.js';
 import DirectionArrowDrawObj from './DirectionArrowDrawObj.js';
 import MarkerFootprintObj from './MarkerFootprintObj.js';
 
 export var drawTypes= {
     [POINT_DATA_OBJ] : PointDataObj.draw,
     [SelectBox.SELECT_BOX] : SelectBox.draw,
+    [FootprintObj.FOOTPRINT_OBJ] : FootprintObj.draw,
     [DirectionArrowDrawObj.DIR_ARROW_DRAW_OBJ] : DirectionArrowDrawObj.draw,
     [ShapeDataObj.SHAPE_DATA_OBJ] : ShapeDataObj.draw,
     [MarkerFootprintObj.MARKER_DATA_OBJ] : MarkerFootprintObj.draw

--- a/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
@@ -92,6 +92,7 @@ export class ImageViewerLayout extends Component {
             const ownerCandidate= findMouseOwner(list,primePlot(plotView),screenPt);         // see if anyone can own that mouse
             this.mouseOwnerLayerId = DOWN.is(mouseState) && ownerCandidate ? ownerCandidate.drawLayerId : null;   // can only happen on mouseDown
             if (this.mouseOwnerLayerId) {
+                if (DOWN.is(mouseState)) dispatchChangeActivePlotView(plotId);
                 const dl= getLayer(drawLayersAry,this.mouseOwnerLayerId);
                 fireMouseEvent(dl,mouseState,mouseStatePayload);
             }

--- a/src/firefly/js/visualize/projection/Projection.js
+++ b/src/firefly/js/visualize/projection/Projection.js
@@ -121,10 +121,13 @@ const projTypes= {
 	}
 };
 
+const getProjTypeInfo= (header) => projTypes[get(header,'maptype', UNRECOGNIZED)];
 
-const translateProjectionName= (maptype) => get(projTypes, [maptype,'name'],'UNRECOGNIZED');
-const isImplemented= (header) => get(header, ['maptype.implemented'],false);
-const isWrappingProjection= (header) => get(header, ['maptype.wrapping'],false);
+
+const translateProjectionName= (header) => getProjTypeInfo(header).name;
+const isImplemented= (header) => getProjTypeInfo(header).implemented;
+const isWrappingProjection= (header) => getProjTypeInfo(header).wrapping;
+
 
 
 

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -143,7 +143,7 @@ function preNewPlotPrep(plotViewAry,action) {
         return pv ? clone(pv, { plottingStatus:'Plotting...', 
                                 plots:[],  
                                 primeIdx:-1
-                              }) : makePlotView(plotId, req,null);
+                              }) : makePlotView(plotId, req,action.payload.pvOptions);
     });
 
     return unionBy(pvChangeAry,plotViewAry, 'plotId');

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -84,7 +84,7 @@ export default {replacePlots,
  * @param {object} pvOptions options for this plot view todo- define what pvOptions is, somewhere
  * @return  {PlotView} 
  */
-export function makePlotView(plotId, req, pvOptions) {
+export function makePlotView(plotId, req, pvOptions= {}) {
     var pv= {
         plotId, // should never change
         plotGroupId: req.getPlotGroupId(), //should never change
@@ -155,7 +155,7 @@ function createPlotViewContextData(req) {
 //todo - this function should determine which menuItem are visible and which are hidden
 // for now just return the default
 function makeMenuItemKeys(req,pvOptions,defMenuItemKeys) {
-    return defMenuItemKeys;
+    return Object.assign({},defMenuItemKeys, pvOptions.menuItemKeys);
 }
 
 export const initScrollCenterPoint= (pv) => updatePlotViewScrollXY(pv,findScrollPtForCenter(pv));

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -236,12 +236,13 @@ function updateCoverageWithData(table, options, tbl_id, allRowsTable, decimatedT
     }
     else {
         dispatchPlotImage({
-            wpRequest,
-            attributes:{
-                [COVERAGE_TARGET]: centralPoint,
-                [COVERAGE_RADIUS]: maxRadius,
-                [COVERAGE_TABLE]:  tbl_id
-            }}
+                wpRequest,
+                attributes: {
+                    [COVERAGE_TARGET]: centralPoint,
+                    [COVERAGE_RADIUS]: maxRadius,
+                    [COVERAGE_TABLE]: tbl_id
+                }
+            }
         );
     }
 }

--- a/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
+++ b/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
@@ -207,7 +207,7 @@ function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
 
     // prepare stand plot
     const wpRequestAry= makePlottingList(reqAry);
-    if (!isEmpty(wpRequestAry)) dispatchPlotGroup({wpRequestAry});
+    if (!isEmpty(wpRequestAry)) dispatchPlotGroup({wpRequestAry, pvOptions: {menuItemKeys:{imageSelect : false}}});
     if (activeId) dispatchChangeActivePlotView(activeId);
 
 
@@ -215,7 +215,11 @@ function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
     if (plottingThree)  {
         const plotThreeReqAry= make3ColorPlottingList(threeReqAry);
         if (!isEmpty(plotThreeReqAry)) {
-            dispatchPlotImage({plotId:threeCPlotId, wpRequest:plotThreeReqAry, threeColor:true});
+            dispatchPlotImage(
+                {
+                    plotId:threeCPlotId, wpRequest:plotThreeReqAry, threeColor:true,
+                               pvOptions: {menuItemKeys:{imageSelect : false}}
+                });
         }
     }
     

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -32,6 +32,8 @@ import { getDlAry } from '../DrawLayerCntlr.js';
 import WebGrid from '../../drawingLayers/WebGrid.js';
 import {showRegionFileUploadPanel} from '../region/RegionFileUploadView.jsx';
 import {MarkerDropDownView} from './MarkerDropDownView.jsx';
+import {dispatchShowDropDown} from '../../core/LayoutCntlr.js';
+import {showImageSelPanel} from './ImageSelectPanel.jsx';
 
 
 //===================================================
@@ -61,6 +63,7 @@ import FLIP_Y from 'html/images/icons-2014/Mirror.png';
 import RECENTER from 'html/images/icons-2014/RecenterImage.png';
 import LOCKED from 'html/images/icons-2014/BkgLocked.png';
 import UNLOCKED from 'html/images/icons-2014/BkgUnlocked.png';
+import NEW_IMAGE from 'html/images/icons-2014/28x28_FITS_NewImage.png';
 
 import COLOR from 'html/images/icons-2014/28x28_ColorPalette.png';
 import STRETCH from 'html/images/icons-2014/28x28_Log.png';
@@ -121,6 +124,10 @@ export function VisToolbarViewWrapper({visRoot,toolTip,dlCount, messageUnder}) {
 
 }
 
+
+
+//onClick={dispatchShowDropDown.bind(null, {view: 'ImageSelectDropDownCmd'})}/>}
+
 VisToolbarViewWrapper.propTypes= {
     visRoot : PropTypes.object.isRequired,
     toolTip : PropTypes.string,
@@ -154,6 +161,7 @@ export class VisToolbarView extends Component {
             verticalAlign: 'top',
             whiteSpace: 'nowrap'
         };
+        const {apiToolsView}= visRoot;
 
         var pv= getActivePlotView(visRoot);
         var plot= primePlot(pv);
@@ -171,6 +179,16 @@ export class VisToolbarView extends Component {
                                horizontal={true}
                                visible={mi.fitsDownload}
                                onClick={showFitsDownloadDialog.bind(null, 'Load Region')}/>
+
+
+                {apiToolsView && <ToolbarButton icon={NEW_IMAGE}
+                                             tip='Select a new image'
+                                             enabled={enabled}
+                                             horizontal={true}
+                                             visible={mi.imageSelect}
+                                             onClick={showImagePopup}/>}
+
+
 
                 <ToolbarHorizontalSeparator/>
 
@@ -361,6 +379,10 @@ function isGroupLocked(pv,plotGroupAry){
 function toggleLockRelated(pv,plotGroupAry){
     var plotGroup= findPlotGroup(pv.plotGroupId,plotGroupAry);
     dispatchGroupLocking(pv.plotId,!hasGroupLock(pv,plotGroup));
+}
+
+function showImagePopup() {
+    showImageSelPanel('Images');
 }
 
 //==================================================================================


### PR DESCRIPTION
 - image select now comes up a dialog in API mode, coverage update not yet working, see DM-7088
 - readded FooprintObj into DrawOp.js
 - fixed Multi-table coverage issues: projection not working in utility routines
 - dialogs position and mouse move bugs - (In API, it is not possible to drag dialogs)
 - The highlight should of catalog or coverage overlay should just change if you are close to the point. For now I am setting it to 20 pixels
 -  if marker/footprint overlay is clicked, that doesn't activate the image viewer and doesn't update the layer dialog either.  Fixed problem of Large drawing layers kept plot from becomming active on click