### PR TITLE
DM-6473: Fixes mostly related to image view of the meta data via table

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -1632,7 +1632,9 @@ public class VisServerOps {
         WebPlotResult retval;
         boolean userAbort = false;
         String progressKey = "";
-        if (reqAry != null) {
+        String plotId= null;
+        if (reqAry != null && reqAry.length>0) {
+            plotId= reqAry[0].getPlotId();
             for (int i = 0; (i < reqAry.length); i++) {
                 if (reqAry[i] != null) {
                     progressKey = reqAry[i].getProgressKey();
@@ -1643,17 +1645,17 @@ public class VisServerOps {
 
         if (e instanceof FileRetrieveException) {
             FileRetrieveException fe = (FileRetrieveException) e;
-            retval = WebPlotResult.makeFail("Retrieve failed", "Could not retrieve fits file", fe.getDetailMessage(), progressKey);
+            retval = WebPlotResult.makeFail("Retrieve failed", "Could not retrieve fits file", fe.getDetailMessage(), progressKey, plotId);
             fe.setSimpleToString(true);
         } else if (e instanceof FailedRequestException) {
             FailedRequestException fe = (FailedRequestException) e;
-            retval = WebPlotResult.makeFail(fe.getUserMessage(), fe.getUserMessage(), fe.getDetailMessage(), progressKey);
+            retval = WebPlotResult.makeFail(fe.getUserMessage(), fe.getUserMessage(), fe.getDetailMessage(), progressKey, plotId);
             fe.setSimpleToString(true);
             userAbort = VisContext.PLOT_ABORTED.equals(fe.getDetailMessage());
         } else if (e instanceof SecurityException) {
-            retval = WebPlotResult.makeFail("No Access", "You do not have access to this data,", e.getMessage(), progressKey);
+            retval = WebPlotResult.makeFail("No Access", "You do not have access to this data,", e.getMessage(), progressKey, plotId);
         } else {
-            retval = WebPlotResult.makeFail("Server Error, Please Report", e.getMessage(), null, progressKey);
+            retval = WebPlotResult.makeFail("Server Error, Please Report", e.getMessage(), null, progressKey, plotId);
         }
         List<String> messages = new ArrayList<String>(8);
         messages.add(logMsg);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotResultSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotResultSerializer.java
@@ -163,6 +163,7 @@ public class WebPlotResultSerializer {
             map.put( "userFailReason", res.getUserFailReason());
             map.put( "detailFailReason", res.getDetailFailReason());
             map.put( "progressKey", pKey);
+            map.put( "plotId", res.getPlotId());
         }
 
         JSONObject wraperObj= new JSONObject();

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResult.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResult.java
@@ -49,32 +49,35 @@ public class WebPlotResult implements Serializable, DataEntry, Iterable<Map.Entr
     private String _userFailReason;
     private String _detailFailReason;
     private String _progressKey;
+    private String _plotId;
     private HashMap<String, DataEntry> _map= new HashMap<String, DataEntry>(3);
 
 //======================================================================
 //----------------------- Constructors ---------------------------------
 //======================================================================
     
-    public WebPlotResult()  { this(null, true,"", "","",""); }
-    public WebPlotResult(String ctxStr)  { this(ctxStr, true,"", "","",""); }
+    public WebPlotResult()  { this(null, true,"", "","","",null); }
+    public WebPlotResult(String ctxStr)  { this(ctxStr, true,"", "","","",null); }
     protected WebPlotResult(String briefFailReason,
                             String userFailReason,
                             String detailFailReason,
-                            String progressKey)  {
-        this(null, false, briefFailReason, userFailReason, detailFailReason,progressKey);
+                            String progressKey,
+                            String plotId)  {
+        this(null, false, briefFailReason, userFailReason, detailFailReason,progressKey,plotId);
     }
 
     public static WebPlotResult makeFail(String briefFailReason,
                                          String userFailReason,
                                          String detailFailReason)  {
-        return new WebPlotResult(briefFailReason, userFailReason,detailFailReason,"");
+        return new WebPlotResult(briefFailReason, userFailReason,detailFailReason,"",null);
     }
 
     public static WebPlotResult makeFail(String briefFailReason,
                                          String userFailReason,
                                          String detailFailReason,
-                                         String progressKey)  {
-        return new WebPlotResult(briefFailReason, userFailReason,detailFailReason,progressKey);
+                                         String progressKey,
+                                         String plotId)  {
+        return new WebPlotResult(briefFailReason, userFailReason,detailFailReason,progressKey, plotId);
     }
 
     private WebPlotResult(String ctxStr,
@@ -82,13 +85,15 @@ public class WebPlotResult implements Serializable, DataEntry, Iterable<Map.Entr
                           String briefFailReason,
                           String userFailReason,
                           String detailFailReason,
-                          String progressKey)  {
+                          String progressKey,
+                          String plotId)  {
         _ctxStr= ctxStr;
         _success= success;
         _briefFailReason= briefFailReason;
         _userFailReason= userFailReason;
         _detailFailReason= detailFailReason;
         _progressKey= progressKey;
+        _plotId= plotId;
     }
 //======================================================================
 //----------------------- Public Methods -------------------------------
@@ -116,6 +121,7 @@ public class WebPlotResult implements Serializable, DataEntry, Iterable<Map.Entr
     public String getUserFailReason() { return _userFailReason; }
     public String getDetailFailReason() { return _detailFailReason; }
     public String getProgressKey() { return _progressKey; }
+    public String getPlotId() { return _plotId; }
     public String getContextStr() { return _ctxStr; }
 
     public Iterator<Map.Entry<String,DataEntry>> iterator() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResultParser.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResultParser.java
@@ -103,7 +103,7 @@ public class WebPlotResultParser {
             retval= WebPlotResult.makeFail(res.getBriefFailReason(),
                                            res.getUserFailReason(),
                                            res.getDetailFailReason(),
-                                           res.getProgressKey());
+                                           res.getProgressKey(),null);
 
         }
         return retval;

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -214,7 +214,7 @@ var logger= loggerMiddleware({duration:true, predicate:logFilter, collapsed:coll
 function createRedux() {
     // create a rootReducer from all of the registered reducers
     const rootReducer = combineReducers(reducers);
-    const middleWare=  applyMiddleware(thunkMiddleware, createSagaMiddleware(masterSaga));
+    const middleWare=  applyMiddleware(thunkMiddleware, /*logger,*/ createSagaMiddleware(masterSaga));
     
     return createStore(rootReducer, middleWare);
 }

--- a/src/firefly/js/core/layout/FireflyLayoutManager.js
+++ b/src/firefly/js/core/layout/FireflyLayoutManager.js
@@ -3,11 +3,12 @@
  */
 
 import {take} from 'redux-saga/effects';
-import {get, filter, omitBy, isNil} from 'lodash';
+import {get, filter, omitBy, isNil, isEmpty} from 'lodash';
 
 import {LO_VIEW, LO_MODE, SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo, dispatchUpdateLayoutInfo} from '../LayoutCntlr.js';
 import {clone} from '../../util/WebUtil.js';
-import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE} from '../../tables/TablesCntlr.js';
+import {findGroupByTblId, getTblIdsByGroup,getActiveTableId} from '../../tables/TableUtil.js';
+import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
 import {isMetaDataTable, isCatalogTable} from '../../metaConvert/converterUtils.js';
 import {META_VIEWER_ID} from '../../visualize/ui/TriViewImageSection.jsx';
@@ -30,7 +31,8 @@ export function* layoutManager({title, views='tables | images | xyPlots'}) {
             ImagePlotCntlr.PLOT_IMAGE_START, ImagePlotCntlr.PLOT_IMAGE,
             ImagePlotCntlr.DELETE_PLOT_VIEW, REPLACE_IMAGES,
             TBL_RESULTS_ADDED, TABLE_REMOVE, TABLE_LOADED,
-            SHOW_DROPDOWN, SET_LAYOUT_MODE
+            SHOW_DROPDOWN, SET_LAYOUT_MODE,
+            TBL_RESULTS_ACTIVE
         ]);
 
         var {hasImages, hasTables, hasXyPlots, mode, dropDown={}, ...others} = getLayouInfo();
@@ -64,6 +66,13 @@ export function* layoutManager({title, views='tables | images | xyPlots'}) {
             case ImagePlotCntlr.PLOT_IMAGE_START :
                 [showImages, images, ignore] = handleNewImage(action, images);
                 break;
+            case TBL_RESULTS_ACTIVE:
+                [showImages, images] = handleActiveTableChange(action.payload.tbl_id, images);
+                break;
+            case TABLE_REMOVE:
+                [showImages, images] = handleActiveTableChange(getActiveTableId(findGroupByTblId(action.payload.tbl_id)), images);
+                break;
+
         }
 
         if (ignore) continue;  // ignores, don't update layout.
@@ -88,7 +97,9 @@ export function* layoutManager({title, views='tables | images | xyPlots'}) {
                     expanded = LO_VIEW.none;
                 }
                 mode = {expanded, standard, closeable};
+                break;
         }
+
 
         // calculate dropDown when new UI elements are added or removed from results
         switch (action.type) {
@@ -131,11 +142,61 @@ function handleNewTable(action, images, showImages) {
         }
     }
     if (isMeta) {
-        images = clone(images, {selectedTab: 'meta', showMeta: true});
+        images = clone(images, {selectedTab: 'meta', showMeta: true, metaDataTableId: tbl_id});
         showImages = true;
     }
     return [showImages, images];
 }
+
+function handleActiveTableChange (tbl_id, images) {
+    // check for catalog or meta images
+
+    const showFits= shouldShowFits();
+    var showImages= showFits;
+
+    if (!tbl_id) {
+        images = clone(images, {showMeta: false, showCoverage: false, showFits, metaDataTableId: null});
+        return [showFits, images];
+    }
+
+    const tblGroup= findGroupByTblId(tbl_id);
+    if (!tblGroup) return [showImages, images];
+    const tblList= getTblIdsByGroup(tblGroup);
+    if (isEmpty(tblList)) return [showImages, images];
+
+    const anyHasCatalog= hasCatalogTable(tblList);
+    const anyHasMeta= hasMetaTable(tblList);
+
+
+    if (!anyHasCatalog && !anyHasMeta) {
+        images = clone(images, {showMeta: false, showCoverage: false, showFits, metaDataTableId: null});
+        return [showFits, images];
+    }
+
+
+
+    if (hasCatalogTable(tblList)) {
+        images = clone(images, {showCoverage: true, showFits});
+        showImages = true;
+    }
+
+    if (hasMetaTable(tblList)) {
+        const metaTableId= isMetaDataTable(tbl_id) ? tbl_id : findFirstMetaTable(tblList);
+        images = clone(images, {showMeta: true, showFits, metaDataTableId:metaTableId});
+        showImages = true;
+    }
+    else {
+        images = clone(images, {showMeta: false, showFits, metaTableId:null});
+    }
+    return [showImages, images];
+}
+
+const hasCatalogTable= (tblList) => tblList.some( (id) => isCatalogTable(id) );
+const hasMetaTable= (tblList) => tblList.some( (id) => isMetaDataTable(id) );
+const findFirstMetaTable= (tblList) => tblList.find( (id) => isMetaDataTable(id) );
+const shouldShowFits= () => !isEmpty(getViewerPlotIds(getMultiViewRoot(), DEFAULT_FITS_VIEWER_ID));
+
+
 
 function handleNewImage(action, images) {
     var ignore = false;

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -432,8 +432,8 @@ export function dispatchPlotImage({plotId,wpRequest, threeColor=isArray(wpReques
  * @param wpRequestAry
  * @param {function} dispatcher only for special dispatching uses such as remote
  */
-export function dispatchPlotGroup({wpRequestAry, pvOptions= {}, dispatcher= flux.process}) {
-    dispatcher( { type: PLOT_IMAGE, payload: { wpRequestAry} });
+export function dispatchPlotGroup({wpRequestAry, viewerId, pvOptions= {}, dispatcher= flux.process}) {
+    dispatcher( { type: PLOT_IMAGE, payload: { wpRequestAry, pvOptions, viewerId} });
 }
 
 

--- a/src/firefly/js/visualize/PlotImageTask.js
+++ b/src/firefly/js/visualize/PlotImageTask.js
@@ -107,7 +107,7 @@ function makePlotImageAction(rawAction) {
                 wpRequestAry:ensureWPR(wpRequestAry),
                 viewerId:rawAction.payload.viewerId,
                 attributes:rawAction.payload.attributes,
-                pvOptions: rawAction.pvOptions,
+                pvOptions: rawAction.payload.pvOptions,
                 threeColor:false,
                 addToHistory:false,
                 useContextModifications:true,
@@ -203,8 +203,8 @@ export function processPlotImageSuccessResponse(dispatcher, payload, result) {
     var failAry= [];
 
     if (result.success && Array.isArray(result.data)) {
-        successAry= result.data.filter( (d) => d.success);
-        failAry= result.data.filter( (d) => !d.success);
+        successAry= result.data.filter( (d) => d.data.success);
+        failAry= result.data.filter( (d) => !d.data.success);
     }
     else {
         if (result.success) successAry= [{data:result}];
@@ -248,6 +248,7 @@ export function processPlotImageSuccessResponse(dispatcher, payload, result) {
         resultPayload.briefDescription= data.briefFailReason;
         resultPayload.description= 'Plot Failed- ' + data.userFailReason;
         resultPayload.detailFailReason= data.detailFailReason;
+        resultPayload.plotId= data.plotId;
         dispatcher( { type: ImagePlotCntlr.PLOT_IMAGE_FAIL, payload:resultPayload} );
     });
 

--- a/src/firefly/js/visualize/iv/ExpandedModeDisplay.jsx
+++ b/src/firefly/js/visualize/iv/ExpandedModeDisplay.jsx
@@ -63,7 +63,6 @@ export class ExpandedModeDisplay extends Component {
                                   additionalStyle={{flex:'1 1 auto'}}
                                   closeFunc={closeFunc}
                                   defaultDecoration={false} 
-                                  canDelete={true}
                                   showWhenExpanded={true}
                                   insideFlex={insideFlex}
             />

--- a/src/firefly/js/visualize/iv/ImageViewer.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewer.jsx
@@ -92,7 +92,7 @@ export class ImageViewer extends Component {
 
     render() {
         var {plotView,allPlots,drawLayersAry,mousePlotId}= this.state;
-        var {showWhenExpanded, plotId, handleInlineTools, showDelete}= this.props;
+        var {showWhenExpanded, plotId, handleInlineTools}= this.props;
         if (!showWhenExpanded  && allPlots.expandedMode!==ExpandType.COLLAPSE) return false;
         if (!plotView) return false;
 
@@ -109,7 +109,6 @@ export class ImageViewer extends Component {
                              visRoot={allPlots}
                              mousePlotId={mousePlotId}
                              handleInlineTools={handleInlineTools}
-                             showDelete={showDelete}
                              extensionList={getExtensionList(plotId)} />
         );
     }
@@ -119,13 +118,11 @@ ImageViewer.propTypes= {
     plotId : PropTypes.string.isRequired,
     showWhenExpanded : PropTypes.bool,
     handleInlineTools : PropTypes.bool,
-    showDelete : PropTypes.bool 
 };
 
 ImageViewer.defaultProps = {
     handleInlineTools : true,
     showWhenExpanded : false,
-    showDelete : false
 };
 
 

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -273,10 +273,11 @@ export class ImageViewerDecorate extends Component {
 
     render() {
         const {plotView:pv,drawLayersAry,extensionList,visRoot,mousePlotId,
-               handleInlineTools,showDelete,width,height}= this.props;
+               handleInlineTools,width,height}= this.props;
 
         if (!width || !height) return false;
 
+        const showDelete= pv.plotViewCtx.userCanDeletePlots;
         const ctxToolbar= contextToolbar(pv,drawLayersAry,extensionList);
         const top= ctxToolbar?32:0;
         var title, zoomFactor;
@@ -360,7 +361,6 @@ ImageViewerDecorate.propTypes= {
     width : PropTypes.number.isRequired,
     height : PropTypes.number.isRequired,
     handleInlineTools : PropTypes.bool,
-    showDelete : PropTypes.bool 
 };
 
 

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -127,6 +127,29 @@ function plotFail(state,action) {
     return clone(state,  {plotViewAry:clonePvAry(plotViewAry,plotId,changes)});
 }
 
+
+// function plotFail(state,action) {
+//     const {description, plotId, wpRequestAry}= action.payload;
+//     var {plotViewAry}= state;
+//     if (plotId) {
+//         const plotView=  getPlotViewById(state,plotId);
+//         if (!plotView) return state;
+//         const changes= {plottingStatus:description,serverCall:'fail' };
+//         return clone(state,  {plotViewAry:clonePvAry(plotViewAry,plotId,changes)});
+//     }
+//     else if (wpRequestAry) {
+//         const pvChangeAry= wpRequestAry.map( (r) => {
+//             const pv=  getPlotViewById(state,plotId);
+//             if (!pv) return null;
+//             return clone(pv,{plottingStatus:description,serverCall:'fail' } );
+//         });
+//         const newPlotViewAry= unionBy(pvChangeAry,plotViewAry, 'plotId');
+//         return clone(state,  {plotViewAry:newPlotViewAry});
+//     }
+// }
+
+
+
 /**
  /**
  *

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -9,7 +9,7 @@
  */
 
 import update from 'react-addons-update';
-import {isEqual,unionBy} from 'lodash';
+import {isEqual,unionBy, get} from 'lodash';
 import {WebPlot, PlotAttribute} from './../WebPlot.js';
 import {WPConst} from './../WebPlotRequest.js';
 import {RotateType} from './../PlotState.js';
@@ -101,7 +101,7 @@ export function makePlotView(plotId, req, pvOptions= {}) {
         overlayPlotViews: [], //todo
         attributes: {}, //todo, i hope to remove this an only hold attributes on web plot
         menuItemKeys: makeMenuItemKeys(req,pvOptions,defMenuItemKeys), // normally wil not change
-        plotViewCtx: createPlotViewContextData(req),
+        plotViewCtx: createPlotViewContextData(req, pvOptions),
 
 
         options : {
@@ -133,8 +133,9 @@ export function makePlotView(plotId, req, pvOptions= {}) {
 
 
 
-function createPlotViewContextData(req) {
+function createPlotViewContextData(req, pvOptions) {
     return {
+        userCanDeletePlots: get(pvOptions, 'userCanDeletePlots', true),
         rotateNorthLock : false,// todo MAYBE!!! // rotate this plot north when plotting,
         userModifiedRotate: false, // the user modified the rotate status, todo
         zoomLockingEnabled : false,
@@ -466,9 +467,12 @@ function findCurrentCenterPoint(plotView,scrollX,scrollY) {
  */
 function isRecomputeViewPortNecessary(scrollX,scrollY,scrollWidth,scrollHeight, viewPort) {
     var {x,y,dim} = viewPort;
-    var contains= VisUtil.containsRec(x,y, dim.width,dim.height,
+    var needsRecompute= !VisUtil.containsRec(x,y, dim.width,dim.height,
                                       scrollX,scrollY,scrollWidth-1,scrollHeight-1);
-    return !contains;
+    if (!needsRecompute) {
+        needsRecompute= (!x && !scrollX && dim.width>scrollWidth) || (!y && !scrollY && dim.width>scrollHeight);
+    }
+    return needsRecompute;
 }
 
 

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -245,7 +245,8 @@ function updateCoverageWithData(table, options, tbl_id, allRowsTable, decimatedT
                     [COVERAGE_TARGET]: centralPoint,
                     [COVERAGE_RADIUS]: maxRadius,
                     [COVERAGE_TABLE]: tbl_id
-                }
+                },
+                pvOptions: { userCanDeletePlots: false}
             }
         );
     }

--- a/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
+++ b/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
@@ -50,6 +50,7 @@ export function* watchImageMetaData({viewerId}) {
 
         if (action.type===TABLE_REMOVE) {
             tbl_id= getActiveTableId();
+            if (!tbl_id) removeAllPlotsInViewer(viewerId);
         }
         else if (payload.tbl_id) {
             if (!isMetaDataTable(payload.tbl_id)) continue;
@@ -112,15 +113,17 @@ const getKey= (threeOp, band) => Object.keys(threeOp).find( (k) => threeOp[k].co
  */
 function updateImagePlots(tbl_id, viewerId, layoutChange=false) {
 
-    if (!tbl_id) return [];
-    var reqRet;
+    const viewer= getViewer(getMultiViewRoot(),viewerId);
     const table= getTblById(tbl_id);
     // check to see if tableData is available in this range.
-    if (!isTblDataAvail(table.highlightedRow, table.highlightedRow+1, table)) return [];
-    const viewer= getViewer(getMultiViewRoot(),viewerId);
-    if (!table) return [];
+    if (!table || !isTblDataAvail(table.highlightedRow, table.highlightedRow+1, table)) {
+        removeAllPlotsInViewer(viewerId);
+        return [];
+    }
 
+    var reqRet;
     const converterData= converterFactory(table);
+    if (!converterData) return [];
     const {dataId,converter}= converterData;
     var highlightPlotId;
     var threeColorOps;
@@ -174,6 +177,13 @@ function updateImagePlots(tbl_id, viewerId, layoutChange=false) {
 }
 
 
+function removeAllPlotsInViewer(viewerId) {
+    if (!viewerId) return;
+    const inViewerIds= getViewerPlotIds(getMultiViewRoot(), viewerId);
+    dispatchReplaceImages(viewerId,[]);
+    inViewerIds.forEach( (plotId) => dispatchDeletePlotView({plotId}));
+}
+
 function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
     const groupId= `${viewerId}-${dataId}-standard`;
     var plottingIds= reqAry.map( (r) =>  r.getPlotId());
@@ -206,7 +216,11 @@ function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
 
     // prepare stand plot
     const wpRequestAry= makePlottingList(reqAry);
-    if (!isEmpty(wpRequestAry)) dispatchPlotGroup({wpRequestAry, pvOptions: {menuItemKeys:{imageSelect : false}}});
+    if (!isEmpty(wpRequestAry)) {
+        dispatchPlotGroup({wpRequestAry, viewerId,
+                           pvOptions: { userCanDeletePlots: false, menuItemKeys:{imageSelect : false} }
+        });
+    }
     if (activeId) dispatchChangeActivePlotView(activeId);
 
 
@@ -217,7 +231,7 @@ function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
             dispatchPlotImage(
                 {
                     plotId:threeCPlotId, wpRequest:plotThreeReqAry, threeColor:true,
-                               pvOptions: {menuItemKeys:{imageSelect : false}}
+                               pvOptions: {userCanDeletePlots: true, menuItemKeys:{imageSelect : false}}
                 });
         }
     }

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
@@ -16,7 +16,7 @@ export class ImageMetaDataToolbar extends Component {
 
     constructor(props) {
         super(props);
-        this.state= {activeTable : null};
+        this.state= {activeTable : getTblById(this.props.tableId)};
     }
 
     shouldComponentUpdate(np,ns) {
@@ -41,8 +41,9 @@ export class ImageMetaDataToolbar extends Component {
 
     storeUpdate() {
         if (!this.iAmMounted) return;
-        const activeTable= getTblById(getActiveTableId());
-        if (isMetaDataTable(getActiveTableId()) && activeTable!==this.state.activeTable) {
+        const {tableId}= this.props;
+        const activeTable= getTblById(tableId);
+        if (activeTable!==this.state.activeTable) {
             this.setState({activeTable});
         }
     }
@@ -50,7 +51,7 @@ export class ImageMetaDataToolbar extends Component {
     render() {
         const {activeTable}= this.state;
         
-        const {visRoot, viewerId, viewerPlotIds, layoutType, dlAry}= this.props;
+        const {visRoot, viewerId, viewerPlotIds, layoutType, dlAry, tableId}= this.props;
         return (
             <ImageMetaDataToolbarView activePlotId={visRoot.activePlotId} viewerId={viewerId}
                                       viewerPlotIds={viewerPlotIds} layoutType={layoutType} dlAry={dlAry}
@@ -65,5 +66,6 @@ ImageMetaDataToolbar.propTypes= {
     visRoot : PropTypes.object,
     viewerId : PropTypes.string.isRequired,
     layoutType : PropTypes.string.isRequired,
-    viewerPlotIds : PropTypes.arrayOf(PropTypes.string).isRequired
+    viewerPlotIds : PropTypes.arrayOf(PropTypes.string).isRequired,
+    tableId: PropTypes.string
 };

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -3,7 +3,7 @@
  */
 
 import React, {Component,PropTypes} from 'react';
-import {isEmpty} from 'lodash';
+import {isEmpty,omit} from 'lodash';
 import sCompare from 'react-addons-shallow-compare';
 import {flux} from '../../Firefly.js';
 import {dispatchAddViewer, dispatchViewerMounted, dispatchViewerUnmounted, 
@@ -52,24 +52,18 @@ export class MultiImageViewer extends Component {
     }
 
     render() {
-        const {forceRowSize, forceColSize, gridDefFunc,Toolbar,viewerId, insideFlex, closeFunc, canDelete}= this.props;
+        const {viewerId}= this.props;
         const {viewer,visRoot,dlAry}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId);
         if (!viewer || isEmpty(viewer.plotIdAry)) return false;
+        const newProps= omit(this.props, ['viewerPlotIds', 'showWhenExpanded']);
         return (
-            <MultiImageViewerView viewerPlotIds={viewer.plotIdAry}
-                                  forceRowSize={forceRowSize}
-                                  forceColSize={forceColSize}
-                                  gridDefFunc={gridDefFunc}
+            <MultiImageViewerView {...newProps}
+                                  viewerPlotIds={viewer.plotIdAry}
                                   layoutType={layoutType}
-                                  Toolbar={Toolbar}
-                                  viewerId={viewerId}
+                                  showWhenExpanded={false}
                                   visRoot={visRoot}
                                   dlAry={dlAry}
-                                  showWhenExpanded={false}
-                                  insideFlex={insideFlex}
-                                  closeFunc={closeFunc}
-                                  canDelete={canDelete}
             />
         );
     }
@@ -84,7 +78,6 @@ MultiImageViewer.propTypes= {
     gridDefFunc : PropTypes.func,
     insideFlex : PropTypes.bool,
     closeFunc : PropTypes.func,
-    canDelete :  PropTypes.bool
 };
 
 // function gridDefFunc(plotIdAry) : [ {title :string, [plotId:string]}]
@@ -100,5 +93,4 @@ MultiImageViewer.propTypes= {
 
 MultiImageViewer.defaultProps= {
     canReceiveNewPlots : false,
-    canDelete : true
 };

--- a/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
@@ -34,7 +34,7 @@ export function MultiImageViewerView(props) {
     const {Toolbar, layoutType, visRoot,
            viewerPlotIds, forceRowSize, forceColSize, gridDefFunc,
            showWhenExpanded=false, additionalStyle,
-           defaultDecoration=true, insideFlex=false, canDelete=true}= props;
+           defaultDecoration=true, insideFlex=false}= props;
     var wrapperStyle; 
     if (insideFlex) {
         wrapperStyle= Object.assign({}, flexContainerStyle, {flex:'1 1 auto'});
@@ -48,22 +48,22 @@ export function MultiImageViewerView(props) {
     }
     else if (layoutType==='single' || viewerPlotIds.length===1) {  // SINGLE VIEW
         var id= viewerPlotIds.includes(visRoot.activePlotId) ? visRoot.activePlotId : viewerPlotIds[0];
-        container= makeImageViewerFull(id,showWhenExpanded,canDelete, viewerPlotIds.length===1);
+        container= makeImageViewerFull(id,showWhenExpanded,viewerPlotIds.length===1);
     }
     else if (gridDefFunc) {  // GRID computed by a function
-        container= makeSparseGrid(viewerPlotIds, gridDefFunc(viewerPlotIds),showWhenExpanded,canDelete);
+        container= makeSparseGrid(viewerPlotIds, gridDefFunc(viewerPlotIds),showWhenExpanded);
     }
     else if (forceRowSize) {  // GRID with row size
         var col = viewerPlotIds.length / forceRowSize + (viewerPlotIds.length % forceRowSize);
-        container= makePackedGrid(viewerPlotIds,forceRowSize,col,false,showWhenExpanded,canDelete);
+        container= makePackedGrid(viewerPlotIds,forceRowSize,col,false,showWhenExpanded);
     }
     else if (forceColSize) { // GRID with column size
         var rows = viewerPlotIds.length / forceColSize + (viewerPlotIds.length % forceColSize);
-        container= makePackedGrid(viewerPlotIds,rows,forceColSize,true,showWhenExpanded,canDelete);
+        container= makePackedGrid(viewerPlotIds,rows,forceColSize,true,showWhenExpanded);
     }
     else {                   // GRID automatic
         const dim= findAutoGridDim(viewerPlotIds.length);
-        container= makePackedGrid(viewerPlotIds,dim.rows,dim.cols,true,showWhenExpanded,canDelete);
+        container= makePackedGrid(viewerPlotIds,dim.rows,dim.cols,true,showWhenExpanded);
     }
     
     var s= Object.assign({}, additionalStyle, wrapperStyle, defaultDecoration? defDecStyle: {});
@@ -96,13 +96,12 @@ MultiImageViewerView.propTypes= {
     gridDefFunc : PropTypes.func,  // optional - a function to return the grid definition
     gridComponent : PropTypes.object,  // a react element to define the grid - not implemented, just an idea
     showWhenExpanded : PropTypes.bool,
-    canDelete :  PropTypes.bool,
     insideFlex :  PropTypes.bool
 };
 
 
 
-function makePackedGrid(viewerPlotIds,rows,cols, columnBased,showWhenExpanded,canDelete) {
+function makePackedGrid(viewerPlotIds,rows,cols, columnBased,showWhenExpanded) {
     const percentWidth= 100/cols;
     const percentHeight= 100/rows;
 
@@ -110,12 +109,12 @@ function makePackedGrid(viewerPlotIds,rows,cols, columnBased,showWhenExpanded,ca
     const height= `calc(${percentHeight}% - 2px)`;
 
     return columnBased ?
-        columnBasedIvAry(viewerPlotIds,cols,percentWidth,percentHeight,width,height, showWhenExpanded,canDelete)  :
-        rowBasedIvAry(viewerPlotIds,rows,percentWidth,percentHeight,width,height,showWhenExpanded,canDelete);
+        columnBasedIvAry(viewerPlotIds,cols,percentWidth,percentHeight,width,height, showWhenExpanded)  :
+        rowBasedIvAry(viewerPlotIds,rows,percentWidth,percentHeight,width,height,showWhenExpanded);
 }
 
 
-function rowBasedIvAry(viewerPlotIds,rows,percentWidth,percentHeight,width,height,showWhenExpanded,canDelete) {
+function rowBasedIvAry(viewerPlotIds,rows,percentWidth,percentHeight,width,height,showWhenExpanded) {
     var col = 0;
     var row = 0;
     return viewerPlotIds.map( (plotId) => {
@@ -123,13 +122,13 @@ function rowBasedIvAry(viewerPlotIds,rows,percentWidth,percentHeight,width,heigh
         var top= `calc(${row*percentHeight}% + 1px)`;
         row = (row < rows - 1) ? row + 1 : 0;
         if (row===0) col++;
-        return makeImageViewer(plotId,top,left,width,height, showWhenExpanded,canDelete);
+        return makeImageViewer(plotId,top,left,width,height, showWhenExpanded);
     });
 
 }
 
 
-function columnBasedIvAry(viewerPlotIds,cols,percentWidth,percentHeight,width,height,showWhenExpanded,canDelete) {
+function columnBasedIvAry(viewerPlotIds,cols,percentWidth,percentHeight,width,height,showWhenExpanded) {
     var col = 0;
     var row = 0;
     return viewerPlotIds.map( (plotId) => {
@@ -137,15 +136,15 @@ function columnBasedIvAry(viewerPlotIds,cols,percentWidth,percentHeight,width,he
         var top= `calc(${row*percentHeight}% + 1px)`;
         col = (col < cols - 1) ? col + 1 : 0;
         if (col===0) row++;
-        return makeImageViewer(plotId,top,left,width,height, showWhenExpanded,canDelete);
+        return makeImageViewer(plotId,top,left,width,height, showWhenExpanded);
     });
 }
 
 
-const makeImageViewer = (plotId,top,left,width,height,showWhenExpanded,canDelete) => (
+const makeImageViewer = (plotId,top,left,width,height,showWhenExpanded) => (
                       <div style={{position:'absolute', top,left,width,height}} key={plotId}>
                           <ImageViewer plotId={plotId} key={plotId} 
-                                       showWhenExpanded={showWhenExpanded} showDelete={canDelete}
+                                       showWhenExpanded={showWhenExpanded}
                                        handleInlineTools={false}/>
                       </div>
                                         );
@@ -154,13 +153,12 @@ const makeImageViewer = (plotId,top,left,width,height,showWhenExpanded,canDelete
  * 
  * @param plotId
  * @param showWhenExpanded
- * @param canDelete
  * @param handleInlineTools
  */
-const makeImageViewerFull = (plotId, showWhenExpanded, canDelete, handleInlineTools) => (
+const makeImageViewerFull = (plotId, showWhenExpanded, handleInlineTools) => (
     <div style={{position:'absolute', top:0,left:0,bottom:0,right:0}} key={plotId}>
         <ImageViewer plotId={plotId} key={plotId}  showWhenExpanded={showWhenExpanded}
-                      showDelete={canDelete} handleInlineTools={handleInlineTools} />
+                      handleInlineTools={handleInlineTools} />
     </div>
 );
 

--- a/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
+++ b/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
@@ -32,7 +32,7 @@ const toolsStyle= {
 
 
 
-export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, layoutType, dlAry, handleInlineTools=true }) {
+export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, layoutType= 'grid', dlAry, handleInlineTools=true }) {
     
     var cIdx= viewerPlotIds.findIndex( (plotId) => plotId===visRoot.activePlotId);
     const pv= getPlotViewById(visRoot, visRoot.activePlotId);
@@ -111,7 +111,7 @@ MultiViewStandardToolbar.propTypes= {
     dlAry : PropTypes.arrayOf(React.PropTypes.object),
     visRoot : PropTypes.object,
     viewerId : PropTypes.string.isRequired,
-    layoutType : PropTypes.string.isRequired,
+    layoutType : PropTypes.string,
     viewerPlotIds : PropTypes.arrayOf(PropTypes.string).isRequired,
     handleInlineTools : PropTypes.bool
 };

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -3,6 +3,7 @@
  */
 
 import React, {PropTypes} from 'react';
+import {get} from 'lodash';
 import {ExpandedModeDisplay} from '../iv/ExpandedModeDisplay.jsx';
 import {Tab, Tabs} from '../../ui/panel/TabPanel.jsx';
 import {MultiViewStandardToolbar} from './MultiViewStandardToolbar.jsx';
@@ -11,6 +12,7 @@ import {MultiImageViewer} from './MultiImageViewer.jsx';
 import {watchImageMetaData} from '../saga/ImageMetaDataWatcher.js';
 import {watchCoverage} from '../saga/CoverageWatcher.js';
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
+import {getTblById} from '../../tables/TableUtil.js';
 import {DEFAULT_FITS_VIEWER_ID} from '../MultiViewCntlr.js';
 import {LO_MODE, LO_VIEW, dispatchSetLayoutMode, dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
 
@@ -25,11 +27,13 @@ export const COVERAGE_VIEWER_ID = 'TBD';
  * @param showMeta
  * @param imageExpandedMode if true, then imageExpandedMode overrides everything else
  * @param closeable expanded mode should have a close button
+ * @param metaDataTableId
  * @return {XML}
  * @constructor
  */
 export function TriViewImageSection({showCoverage=false, showFits=false, selectedTab='fits',
-                                     showMeta=false, imageExpandedMode=false, closeable=true}) {
+                                     showMeta=false, imageExpandedMode=false, closeable=true,
+                                     metaDataTableId}) {
     
     if (imageExpandedMode) {
         return  ( <ExpandedModeDisplay
@@ -39,6 +43,8 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
                 );
     }
     const onTabSelect = (idx, id) => dispatchUpdateLayoutInfo({images:{selectedTab:id}});
+    const table= getTblById(metaDataTableId);
+    const metaTitle= get(table,'tableMeta.title')  || 'Image Meta Data';
 
 
     // showCoverage= true; // todo - let the application control is coverage is visible
@@ -51,16 +57,15 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
                         <MultiImageViewer viewerId= {DEFAULT_FITS_VIEWER_ID}
                                           insideFlex={true}
                                           canReceiveNewPlots={true}
-                                          canDelete={true}
                                           Toolbar={MultiViewStandardToolbar}/>
                     </Tab>
                 }
                 { showMeta &&
-                    <Tab name='Images' removable={false} id='meta'>
+                    <Tab name={metaTitle} removable={false} id='meta'>
                         <MultiImageViewer viewerId= {META_VIEWER_ID}
                                           insideFlex={true}
                                           canReceiveNewPlots={false}
-                                          canDelete={false}
+                                          tableId={metaDataTableId}
                                           Toolbar={ImageMetaDataToolbar}/>
                     </Tab>
                 }
@@ -69,7 +74,6 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
                         <MultiImageViewer viewerId='coverageImages'
                                           insideFlex={true}
                                           canReceiveNewPlots={false}
-                                          canDelete={false}
                                           Toolbar={MultiViewStandardToolbar}/>
                     </Tab>
                 }


### PR DESCRIPTION

 - images cannot be remove, but in expanded mode, it can.
 - plot group fails are not failing correctly, no message shown
 - When a non-meta table is selected, images are shown, but not the toolbar.
 - After table is removed, images are still there and other problem with removing tables.
 - Firefly viewer uses 'triViewImages’ viewer_id while api has no viewer_id. as a result, images loaded by api will be lost once table or other searched data are returned. (I think this is fixed, but I may not understand it)
 - Catalog or Grid overlay are drawn outside of the images.