### PR TITLE
DM-7149: Add more support for FITS table display

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/IpacTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/IpacTableReader.java
@@ -44,6 +44,7 @@ public final class IpacTableReader {
                                                  "r", "float", "f"};
     private static final String INT_TYPE[]= { "int.*", "i"} ;
     private static final String LONG_TYPE[]= { "long", "l"} ;
+    private static final String BOOL_TYPE[]= { "bool", "b"} ;
     private static final String STRING_TYPE[]= {"cha.*", "str.*", "s", "c"};
 
     private String      _line;      // to keep the line read from file
@@ -513,6 +514,10 @@ public final class IpacTableReader {
                      ServerStringUtil.matchesRegExpList(itc._type, LONG_TYPE, true)) {
                    itc._foundType= Long.class;
                }
+               else  if (itc._type!=null &&
+                       ServerStringUtil.matchesRegExpList(itc._type, BOOL_TYPE, true)) {
+                   itc._foundType= Boolean.class;
+               }
                else {
                    itc._foundType= String.class;
                }
@@ -665,6 +670,7 @@ public final class IpacTableReader {
         return ServerStringUtil.matchesRegExpList(type, DOUBLE_TYPE, true) ||
                 ServerStringUtil.matchesRegExpList(type, INT_TYPE, true) ||
                 ServerStringUtil.matchesRegExpList(type, LONG_TYPE, true) ||
+                ServerStringUtil.matchesRegExpList(type, BOOL_TYPE, true) ||
                 ServerStringUtil.matchesRegExpList(type, STRING_TYPE, true);
     }
 
@@ -675,6 +681,8 @@ public final class IpacTableReader {
             return Integer.class;
         } else if ( ServerStringUtil.matchesRegExpList(type, LONG_TYPE, true) ) {
             return Long.class;
+        } else if ( ServerStringUtil.matchesRegExpList(type, BOOL_TYPE, true) ) {
+            return Boolean.class;
         }
         return String.class;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -27,6 +27,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
     public static final String META_INFO = "META_INFO";
     public static final String SYS_PARAMS = "|" + StringUtils.toString(new String[]{FILTERS,SORT_INFO,PAGE_SIZE,START_IDX,INCL_COLUMNS,FIXED_LENGTH,META_INFO,TBL_ID,DECIMATE_INFO}, "|") + "|";
 
+    public static final String TBL_INDEX = "tbl_index";     // the table to show if it's a multi-table file.
 
     private int pageSize;
     private int startIdx;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -619,6 +619,7 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
     protected static File convertToIpacTable(File tblFile, TableServerRequest request) throws IOException, DataAccessException{
         // if the file is not in IPAC table format - convert
         DataGroupReader.Format format = DataGroupReader.guessFormat(tblFile);
+        int tblIdx = request.getIntParam(TableServerRequest.TBL_INDEX, 0);
         boolean isFixedLength = request.getBooleanParam(TableServerRequest.FIXED_LENGTH, true);
         if (format == DataGroupReader.Format.IPACTABLE && isFixedLength) {
             // file is already in ipac table format
@@ -626,7 +627,7 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
         } else {
             if ( format != DataGroupReader.Format.UNKNOWN) {
                 // format is unknown.. convert it into ipac table format
-                DataGroup dg = DataGroupReader.readAnyFormat(tblFile);
+                DataGroup dg = DataGroupReader.readAnyFormat(tblFile, tblIdx);
                 File convertedFile; //= createFile(request, ".tbl");
                 if (format == DataGroupReader.Format.IPACTABLE) {
                     convertedFile = FileUtil.createUniqueFileFromFile(tblFile);
@@ -636,7 +637,7 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
                         convertedFile = FileUtil.createUniqueFileFromFile(convertedFile);
                 }
 
-                DataGroupWriter.write(convertedFile, dg, 0);
+                DataGroupWriter.write(convertedFile, dg, 0, request.getMeta());
                 return convertedFile;
             } else {
                 throw new DataAccessException("Source file has an unknown format:" + ServerContext.replaceWithPrefix(tblFile));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class IpacTableFromSource extends IpacTablePartProcessor {
     public static final String TBL_TYPE = "tblType";
     public static final String TYPE_CATALOG = "catalog";
+    public static final String TBL_INDEX = TableServerRequest.TBL_INDEX;     // the table to show if it's a multi-table file.
 
     protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/DataGroupReader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/DataGroupReader.java
@@ -34,6 +34,10 @@ public class DataGroupReader {
     }
 
     public static DataGroup readAnyFormat(File inf) throws IOException {
+        return readAnyFormat(inf, 0);
+    }
+
+    public static DataGroup readAnyFormat(File inf, int tableIndex) throws IOException {
         Format format = guessFormat(inf);
         if (format == Format.IPACTABLE) {
             return read(inf, false, false);
@@ -42,10 +46,9 @@ public class DataGroupReader {
         } else if (format == Format.FITS ) {
             try {
                 // Switch to the new function:
-                //List<DataGroup> retval = FITSTableReader.convertFITSToDataGroup(inf.getAbsolutePath(), null);
-                List<DataGroup> retval = FITSTableReader.convertFitsToDataGroup(inf.getAbsolutePath(), null, null, "TOP_MOST");
+                List<DataGroup> retval = FITSTableReader.convertFitsToDataGroup(inf.getAbsolutePath(), null, null, FITSTableReader.DEFAULT);
                 if (retval != null && retval.size() > 0) {
-                    return retval.get(0);
+                    return retval.get(tableIndex);
                 } else {
                     return null;
                 }

--- a/src/firefly/java/edu/caltech/ipac/util/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/util/DataGroup.java
@@ -140,7 +140,12 @@ public class DataGroup implements Serializable,
             int maxDataWidth = dt.getMaxDataWidth();
             if (force || maxDataWidth == 0) {
                 for (DataObject row : this) {
-                    int vlength = Number.class.isAssignableFrom(dt.getDataType()) ? row.getFormatedData(dt).length() : String.valueOf(row.getDataElement(dt)).length();
+                    int vlength = 0;
+                    if (Number.class.isAssignableFrom(dt.getDataType())) {
+                        vlength = dt.getFormatInfo().formatDataOnly(row.getDataElement(dt)).length();
+                    } else {
+                        vlength = String.valueOf(row.getDataElement(dt)).length();
+                    }
                     maxDataWidth = Math.max(maxDataWidth, vlength);
                 }
             }

--- a/src/firefly/java/edu/caltech/ipac/util/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/util/DataType.java
@@ -17,11 +17,13 @@ public class DataType implements Serializable, Cloneable {
     private static final String INTEGER = "int";
     private static final String LONG = "long";
     private static final String CHAR = "char";
+    private static final String BOOL = "bool";
     private static final String S_DOUBLE = "d";
     private static final String S_FLOAT = "f";
     private static final String S_INTEGER = "i";
     private static final String S_LONG = "l";
     private static final String S_CHAR = "c";
+    private static final String S_BOOL = "b";
 
     private       Class      _type;
     private       String     _units;
@@ -221,6 +223,8 @@ public class DataType implements Serializable, Cloneable {
                 _typeDesc = useShortType ? S_INTEGER : INTEGER;
             else if (dt.equals(Long.class))
                 _typeDesc = useShortType ? S_LONG : LONG;
+            else if (dt.equals(Boolean.class))
+                _typeDesc = useShortType ? S_BOOL : BOOL;
             else
                 _typeDesc = useShortType ? S_CHAR : CHAR;
         }

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -120,7 +120,7 @@ function colWithName(cols, name) {
 function getNumericCols(cols) {
     const ncols = [];
     cols.forEach((c) => {
-        if (c.type !== 'char') {
+        if (c.type.match(/^[dfil]/) != null) {      // int, float, double, long .. or their short form.
             ncols.push(c);
         }
     });

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -295,9 +295,15 @@ function tableToText(columns, dataAry, showUnits=false) {
 
     const colWidths = calcColumnWidths(columns, dataAry);
 
+    // column's name
     var textHead = columns.reduce( (pval, col, idx) => {
         return pval + (get(columns, [idx,'visibility'], 'show') === 'show' ? `${padEnd(col.name, colWidths[idx])}|` : '');
     }, '|');
+
+    // column's type
+    textHead += '\n' + columns.reduce( (pval, col, idx) => {
+            return pval + (get(columns, [idx,'visibility'], 'show') === 'show' ? `${padEnd(col.type || '', colWidths[idx])}|` : '');
+        }, '|');
 
     if (showUnits) {
         textHead += '\n' + columns.reduce( (pval, col, idx) => {

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -54,9 +54,21 @@ export const SearchPanel = (props) => {
                     <FileUpload
                         wrapperStyle = {{margin: '5px 0'}}
                         fieldKey = 'fileUpload'
+                        groupKey='TBL_BY_URL_PANEL'
                         initialState= {{
-                        tooltip: 'Select a file to upload',
-                        label: 'Upload File:'}}
+                                tooltip: 'Select a file to upload',
+                                label: 'Upload File:'
+                            }}
+                    />
+                    <ValidationField fieldKey='tbl_index'
+                                     groupKey='TBL_BY_URL_PANEL'
+                                     initialState= {{
+                                            value: 0,
+                                            size: 4,
+                                            validator: Validate.intRange.bind(null, 0, 100000),
+                                            label : 'Table Index:',
+                                            labelWidth : 60
+                                         }}
                     />
                 </FieldGroup>
             </FormPanel>
@@ -83,7 +95,7 @@ function hideSearchPanel() {
 
 function onSearchSubmit(request) {
     if (request.fileUpload) {
-        const treq = TblUtil.makeFileRequest(null, request.fileUpload, null, {filters: request.filters});
+        const treq = TblUtil.makeFileRequest(null, request.fileUpload, null, {...request});
         dispatchTableSearch(treq);
     } else if (request.srcTable) {
         const treq = TblUtil.makeFileRequest(null, request.srcTable, null, {filters: request.filters});


### PR DESCRIPTION
 - Add tbl_index to table request indicate which table to display if it's a multi-table file.
 - Add default behavior for column with array type to display the array's data-type and length.

https://jira.lsstcorp.org/browse/DM-7149

To test:
Follow above link to download table.fits file.
Using Firefly's "Data Sets..." sample dialog, upload the sample file to view fits table data.
Use the Table Index field to select which table to view.  There should be 4 tables in this file.
