### PR TITLE
DM-7155: Filtering from image is wrong on sorted tables.

### DIFF
--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -365,7 +365,9 @@ function doFilter(dl,p,sel) {
         console.log(idxs);
     }
     else {
-        const idxs= getSelectedPts(sel, p, dl.drawData.data);
+        const rowidIdx= findColIdx(dl.tableData.columns,'ROWID');
+        var idxs= getSelectedPts(sel, p, dl.drawData.data);
+        idxs = rowidIdx < 0 ? idxs : idxs.map( (idx) => get(dl,`tableData.data[${idx}][${rowidIdx}]`) );
         filter= `IN (${idxs.toString()})`;
         // filterInfoCls.setFilter(filter);
         filterInfoCls.setFilter('ROWID', filter);

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -102,7 +102,7 @@ function handleCatalogUpdate(tbl_id) {
     const params= {
         startIdx : 0,
         pageSize : 1000000,
-        inclCols : `${columns.lonCol},${columns.latCol}`
+        inclCols : `${columns.lonCol},${columns.latCol},ROWID`
     };
 
     var dataTooBigForSelection= false;


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-7155

from ticket:
> Sort a table first. Then using image selection tool, select an area, then filter: the filter fails. Points are outside the selected area.

PS.. Title of ticket mentioned that is was wrong for XyPlot as well.  That is NOT true.  XyPlot works fine.