### PR TITLE
DM-7147: fix region bugs as listed in DM-7147.

### DIFF
--- a/src/firefly/html/demo/ffapi-2images.html
+++ b/src/firefly/html/demo/ffapi-2images.html
@@ -237,6 +237,9 @@
             };
             firefly.showImage('image2_div', req2);
 
+            firefly.action.dispatchCreateRegionLayer('region2', 'Region Layer 2', null, ['image; box 200 200 72 72 0 # color=red'], ['image1', 'image2']);
+
+
         }
     }
 </script>

--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -235,8 +235,8 @@
                  /*
                 'global color=green dashlist=8 3 width=1 font="helvetica 10 normal normal" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 rotate=0 source=1',
                 'J2000;point    202.41   47.262 # color=pink text="pt circle 1" point=circle',
-                'box (100p, 70p, 20p, 20p, 0) #color=red text={IMAGE coordinate - 1}',
-                'box (100i, 70i, 30i, 30i, 0) #color=orange text={PHYSICAL coordinate -2}',
+                'box (100p, 70p, 20p, 20p, 0) #color=red text={Physical coordinate - 1}',
+                'box (100i, 70i, 30i, 30i, 0) #color=orange text={Image coordinate -2}',
                 'line(202.414796 47.281999 202.423758 47.247072) # color=orange width=10 select=0 text={line 2}',
                 'text 30p 40p # color=pink text={text test 3} edit=0 highlite=0 font="BRAGGADOCIO 10 normal roman"',
                 'text 202.437691 47.234228{more text testing 4} # color=purple move=0',

--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -231,9 +231,12 @@
             firefly.addXYPlot({QUERY_ID: 'oldSelectable'}, 'oldXyPlot1');
             //-----< old xyplot api ------//
 
-            var regionAry = [
+            window.regionAry = [
+                 /*
                 'global color=green dashlist=8 3 width=1 font="helvetica 10 normal normal" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 rotate=0 source=1',
                 'J2000;point    202.41   47.262 # color=pink text="pt circle 1" point=circle',
+                'box (100p, 70p, 20p, 20p, 0) #color=red text={IMAGE coordinate - 1}',
+                'box (100i, 70i, 30i, 30i, 0) #color=orange text={PHYSICAL coordinate -2}',
                 'line(202.414796 47.281999 202.423758 47.247072) # color=orange width=10 select=0 text={line 2}',
                 'text 30p 40p # color=pink text={text test 3} edit=0 highlite=0 font="BRAGGADOCIO 10 normal roman"',
                 'text 202.437691 47.234228{more text testing 4} # color=purple move=0',
@@ -252,7 +255,38 @@
                 'j2000;box(47.247072i, 180.445347i, 50p, 20p, 0) # color=blue width=6 text="box 12-3"',
                 'physical;-box point 12 12 # text="pt box 13"',
                 'j2000;polygon(202.564796, 47.281999,202.553758, 47.247072, 202.445347, 47.244296, 202.479687, 47.264027, 202.492153, 47.290841) # color=blue text="polygon 14" offsety=10 width=10 font="helvetica 16 bold"',
-                'point    202.45   47.2879 # color=cyan text="pt arrow 15" delete=0 point=arrow 20'
+                'point    202.45   47.2879 # color=cyan text="pt arrow 15" delete=0 point=arrow 20',
+                'IMAGE;box (160, 70, 20, 20, 0) #color=red text={IMAGE test - 1}',
+                'PHYSICAL;box (160, 70, 30, 30, 0) #color=orange text={PHYSICAL test -2}'
+                */
+                'box (240, 220, 20, 20, 0) #color=red text={     ph1}',
+                'box (240i, 220i, 60i, 60i, 0) #color=orange text={ph2}',
+                'J2000;point    202.41   47.262 # color=pink text="pt circle 1" point=circle',
+                'IMAGE;box (360, 220, 20, 20, 0) #color=red text={     im1}',
+                'PHYSICAL;box (360, 220, 60, 60, 0) #color=orange text={ph3}'
+            ];
+
+            window.regionAry2 = [
+                'J2000',
+                'boxcircle point    202.45    47.262 # color=red text="pt boxcircle 6" delete=0',
+                'physical;circle   80 140  20       # color=red offsetx=25  offsety=2 width=5 edit=0 text="circle 7"',
+                'annulus   13h30m16.41s +47d14m43.9s  30p 40p 50p       # color=green text="hello" include=0 text="annulus 8"',
+                'physical;point 200 140 # color=yellow point=cross 20 text="pt cross 9" offsetx=10',
+                'physical;point 13h29m52.73s, +47d11m40.9s # color=purple point=diamond 15 text="pt diamond 10"',
+                '#circle(202.55556, 47.188286 , 20p)  # color=blue text="text 11"',
+                'box(202.55556, 47.188286 ,20p,40p, 30p, 50p, 0)  # color=red width=5 text="boxann 11"',
+                'box(202.52556,47.226286,0.0240,0.006,0)  # color=green width=5 text="box 11-2"',
+                'image;box(100, 150, 50p, 20p, 2r) # color=magenta width=6 text="slanted box 12"',
+                'image;box(190.564796, 47.281999, 50p, 20p, 0) # color=red width=6 offsety=-15 text="box 12-1"',
+                'j2000;box(47.247072i, 180.445347i, 50p, 20p, 0) # color=blue width=6 text="box 12-3"',
+                'physical;-box point 12 12 # text="pt box 13"',
+                'j2000;polygon(202.564796, 47.281999,202.553758, 47.247072, 202.445347, 47.244296, 202.479687, 47.264027, 202.492153, 47.290841) # color=blue text="polygon 14" offsety=10 width=10 font="helvetica 16 bold"',
+                'point    202.45   47.2879 # color=cyan text="pt arrow 15" delete=0 point=arrow 20',
+            ];
+
+            window.regionWithError = [
+                'image; box 280 200 72 72 # color=blue text={wrong syntax}',
+                'image; box 280 200 72 72 0 # color=cyan text={right syntax}'
             ];
 
             var moreRegionAry =  [
@@ -264,7 +298,7 @@
             window.regions = [];
             window.regionId = window.regions.length;
 
-            document.getElementById('regionLayerContent').value = regionAry.join('\n');
+            document.getElementById('regionLayerContent').value = window.regionAry.join('\n');
             document.getElementById('moreRegionContent').value = moreRegionAry.join('\n');
             //document.getElementById('createRegionId').placeholder = "Region_Plot_" + (window.regionId+1);
             updateRegionLayerList();
@@ -277,6 +311,14 @@
                 window.regionId++;
                 layerId = "Region_Plot_" + window.regionId;
                 document.getElementById('createRegionId').value = layerId;
+            }
+
+            if (window.regionId === 3) {
+                document.getElementById('regionLayerContent').value = window.regionWithError.join('\n');
+            } else if (window.regionId > 1) {
+                document.getElementById('regionLayerContent').value = window.regionAry2.join('\n');
+            } else {
+                document.getElementById('regionLayerContent').value = window.regionAry.join('\n');
             }
 
             var regionAry = document.getElementById('regionLayerContent').value.split('\n').filter(function(r) { return (r.length !== 0);});
@@ -355,7 +397,7 @@
             selectBox.getElementsByTagName('option')[0].selected = 'selected';
             firefly.action.dispatchRemoveRegionEntry(selectedLayerId, removeRegions);
             firefly.action.dispatchRemoveRegionEntry(selectedLayerId, removeRegions, window.ffViewer.dispatch);
-        }
+        };
 
         plotRemote= function() {
             firefly.getViewer().showImage({plotId: 'xxq',

--- a/src/firefly/js/visualize/draw/PointDataObj.js
+++ b/src/firefly/js/visualize/draw/PointDataObj.js
@@ -443,6 +443,7 @@ export function makeHighlightPointDataObj(drawObj, cc) {
                                                                     0.0, ShapeDataObj.UnitType.ARCSEC, false);
 
     makeShapeHighlightRenderOptions( rectObj );
+    rectObj.isAHighlight = { from: drawObj, plotImageId: cc.plotImageId};
     return rectObj;
 }
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -12,6 +12,7 @@ import {TextLocation, Style, DEFAULT_FONT_SIZE} from './DrawingDef.js';
 import Point, {makeScreenPt, makeViewPortPt, makeOffsetPt, makeWorldPt, makeImagePt} from '../Point.js';
 import {toRegion} from './ShapeToRegion.js';
 import {getDrawobjArea,  isScreenPtInRegion, makeHighlightShapeDataObj} from './ShapeHighlight.js';
+import {makeHighlightPointDataObj, POINT_DATA_OBJ} from './PointDataObj.js';
 import CsysConverter from '../CsysConverter.js';
 import {has, isNil, get, set} from 'lodash';
 
@@ -233,6 +234,14 @@ var draw=  {
     },
 
     draw(drawObj,ctx,drawTextAry,plot,def,vpPtM,onlyAddToPath) {
+        if (has(drawObj, 'isAHighlight') && drawObj.isAHighlight.plotImageId !== plot.plotImageId) {
+            var fromObj = get(drawObj.isAHighlight, 'from');
+
+            if (fromObj) {
+                drawObj = (fromObj.type === POINT_DATA_OBJ) ? makeHighlightPointDataObj(fromObj, plot):
+                          makeHighlightShapeDataObj(fromObj, plot, drawObj.isAHighlight.def);
+            }
+        }
         var drawParams= makeDrawParams(drawObj,def);
         drawShape(drawObj,ctx,drawTextAry,plot,drawParams,onlyAddToPath);
     },

--- a/src/firefly/js/visualize/draw/ShapeHighlight.js
+++ b/src/firefly/js/visualize/draw/ShapeHighlight.js
@@ -663,6 +663,8 @@ export function makeHighlightShapeDataObj(drawObj, cc, def = {}) {
     var rectObj = ShapeDataObj.makeRectangleByCenter(wcenter, w, h, ShapeDataObj.UnitType.PIXEL, 0.0, ShapeDataObj.UnitType.ARCSEC, false);
 
     makeShapeHighlightRenderOptions( rectObj );
+
+    rectObj.isAHighlight = { from: drawObj, plotImageId: cc.plotImageId, def};
     return rectObj;
 }
 

--- a/src/firefly/js/visualize/region/RegionDrawer.js
+++ b/src/firefly/js/visualize/region/RegionDrawer.js
@@ -337,9 +337,10 @@ function drawRegionAnnulus(regionObj) {
  * @param options region properties
  * @param propChkAry property cheeck list
  * @param a rotation angle
+ * @param isOnWorld
  * @returns {*}
  */
-function drawOneBox(w, h, a, wp, options, propChkAry) {
+function drawOneBox(w, h, a, wp, options, propChkAry, isOnWorld) {
     var unit = regionUnitToDrawObj(w.unit);
     var angleUnit = regionUnitToDrawObj(a.unit);
     var width, height, angle;
@@ -368,7 +369,7 @@ function drawOneBox(w, h, a, wp, options, propChkAry) {
         angleUnit = ShapeDataObj.UnitType.ARCSEC;
     }
 
-    var dObj = ShapeDataObj.makeRectangleByCenter(wp, width, height, unit, angle, angleUnit, wp.type === Point.W_PT);
+    var dObj = ShapeDataObj.makeRectangleByCenter(wp, width, height, unit, angle, angleUnit, isOnWorld);
 
     updateDrawobjProp(propChkAry, options, dObj);
     return dObj;
@@ -387,7 +388,7 @@ function drawRegionBox(regionObj) {
                           regionObj.angle,
                           regionObj.wpAry[0],
                           regionObj.options,
-                          allProps);
+                          allProps, regionObj.isOnWorld);
 
     dObj.textLoc = DEFAULT_TEXTLOC[RegionType.box.key];
     return [dObj];
@@ -406,7 +407,7 @@ function drawRegionBoxAnnulus(regionObj) {
                               regionObj.angle,
                               regionObj.wpAry[0],
                               regionObj.options,
-                              commonProps);
+                              commonProps, regionObj.isOnWorld);
     var boxannulusObj = ShapeDataObj.makeBoxAnnulus(regionObj.wpAry[0],
                                                     dimAry(regionObj.dimensionAry, firstObj.unitType),
                                                     firstObj.unitType,
@@ -419,7 +420,7 @@ function drawRegionBoxAnnulus(regionObj) {
     boxannulusObj = Object.assign(boxannulusObj, pick(firstObj, commonProps));
 
     var moreObj = regionObj.dimensionAry.reverse().slice(1).map((d) => {
-        var nextObj = drawOneBox(d.width, d.height, regionObj.angle, regionObj.wpAry[0], regionObj.options, []);
+        var nextObj = drawOneBox(d.width, d.height, regionObj.angle, regionObj.wpAry[0], regionObj.options, [], regionObj.isOnWorld);
 
         return Object.assign(nextObj, pick(firstObj, commonProps));
     });
@@ -488,9 +489,10 @@ function drawRegionPolygon(regionObj) {
  * @param options region properties
  * @param propChkAry property cheeck list
  * @param a rotation angle
+ * @param isOnWorld
  * @returns {*}
  */
-function drawOneEllipse(r1, r2, a, wp, options, propChkAry) {
+function drawOneEllipse(r1, r2, a, wp, options, propChkAry, isOnWorld) {
     var unit = regionUnitToDrawObj(r1.unit);
     var angleUnit = regionUnitToDrawObj(a.unit);
     var radius1, radius2, angle;
@@ -508,7 +510,6 @@ function drawOneEllipse(r1, r2, a, wp, options, propChkAry) {
     } else {
         radius1 = r1.value;
         radius2 = r2.value;
-//        angle = 0.0;
     }
 
     // DS9 angle is counterclockwise, canvas angle is clockwise
@@ -519,7 +520,7 @@ function drawOneEllipse(r1, r2, a, wp, options, propChkAry) {
         angleUnit = ShapeDataObj.UnitType.ARCSEC;
     }
 
-    var dObj = ShapeDataObj.makeEllipse(wp, radius1, radius2, unit, angle, angleUnit, wp.type === Point.W_PT);
+    var dObj = ShapeDataObj.makeEllipse(wp, radius1, radius2, unit, angle, angleUnit, isOnWorld);
 
     updateDrawobjProp(propChkAry, options, dObj);
     return dObj;
@@ -538,7 +539,7 @@ function drawRegionEllipse(regionObj) {
         regionObj.angle,
         regionObj.wpAry[0],
         regionObj.options,
-        allProps);
+        allProps, regionObj.isOnWorld);
 
     dObj.textLoc =  DEFAULT_TEXTLOC[RegionType.ellipse.key];
     return [dObj];
@@ -556,7 +557,7 @@ function drawRegionEllipseAnnulus(regionObj) {
                                   regionObj.angle,
                                   regionObj.wpAry[0],
                                   regionObj.options,
-                                  commonProps);
+                                  commonProps, regionObj.isOnWorld);
     var ellipseannObj = ShapeDataObj.makeEllipseAnnulus(regionObj.wpAry[0],
                                                         dimAry(regionObj.dimensionAry, firstObj.unitType),
                                                         firstObj.unitType,
@@ -569,7 +570,7 @@ function drawRegionEllipseAnnulus(regionObj) {
     ellipseannObj = Object.assign(ellipseannObj, pick(firstObj, commonProps));
 
     var moreObj = regionObj.dimensionAry.reverse().slice(1).map((d) => {
-        var nextObj = drawOneEllipse(d.width, d.height, regionObj.angle, regionObj.wpAry[0], regionObj.options, []);
+        var nextObj = drawOneEllipse(d.width, d.height, regionObj.angle, regionObj.wpAry[0], regionObj.options, [], regionObj.isOnWorld);
 
         return Object.assign(nextObj, pick(firstObj, commonProps));
     });

--- a/src/firefly/test/edu/caltech/ipac/visualize/test5.reg
+++ b/src/firefly/test/edu/caltech/ipac/visualize/test5.reg
@@ -1,0 +1,21 @@
+J2000
+point    202.58   47.262 # color=pink text="pt circle 1" point=circle 
+line(202.414796 47.281999 202.423758 47.247072) # color=orange width=10 select=1 text='line 2'
+text 30p 40p # color=pink text={text test 3} edit=0 highlite=0 font="BRAGGADOCIO 10 normal roman"
+text 202.437691 47.234228{more text testing 4} # color=purple move=0
+point    202.43    47.270 # point=x 15 color=green text="pt x 5" rotate=0
+point    202.45    47.262 # color=red text="pt boxcircle 6" delete=1 point=boxcircle 10
+physical;circle   80 140  20       # color=red offsetx=25  offsety=2 width=5 edit=0 text="circle 7"
+annulus   13h30m16.41s +47d14m43.9s  20p 30p 40p       # color=green text="hello" include=0 text="annulus 8"
+physical;point 180 140 # color=yellow point=cross 20 text="pt cross 9" offsetx=10
+physical;point 13h29m52.73s, +47d11m40.9s # color=purple point=diamond 15 text="pt diamond 10"
+#circle(202.55556, 47.188286 , 20p)  # color=blue text="text 11"
+physical;box(186.55556, 47.188286 ,20p,40p, 30p, 50p, 0)  # color=red width=5 text="boxann 11"
+physical;box(186.52556,47.226286,0.0240,0.006,0)  # color=green width=5 text="box 11-2"
+image;box(100, 150, 50p, 20p, 2r) # color=magenta width=6 text="slanted box 12"  
+image;box(190.564796, 47.281999, 50p, 20p, 0) # color=red width=6 offsety=-15 text="box 12-1"
+j2000;box(47.247072i, 180.445347i, 50p, 20p, 0) # color=blue width=6 text="box 12-3"
+physical;-box point 12 12 # text="pt box 13"
+J2000;polygon(202.564796, 47.281999,202.553758, 47.247072, 202.445347, 47.244296, 202.479687, 47.264027, 202.492153, 47.290841) # color=blue text="polygon 14" width=1 font="helvetica 16 bold" 
+point    202.45   47.2879 # color=cyan text="pt arrow 15" delete=1 point=arrow 20
+


### PR DESCRIPTION
fix the following region bugs, 
1. set the default coordinate system to be 'PHYSICAL' (fixed in DM-5192-PyAPI)
2. region defined with 'PHYSICAL' or  'IMAGE' is treated as 'IMAGE' coordinate
3 . create region layer after the image with plotId finishes loading  - changing the region description parsing which needs plotId info to be done after after the region layer is created (fixed in DM-7088)
4. select the region from any region layer
5. log region parsing error in the console. 

test: 
start firefly demo file, 
localhost:8080/firefly/demo/ffapi-highlevel-test.html

- click on 'test open' to get the Firefly app
- go to the page bottom for 'region test'
- test for bug 1, click on 'Create Region Layer' (for layer Region_Plot_1), the top two regions with no coordinate system specified  shown in the text box is displayed as with default coordinate system. 
- test for bug 2, as the display of 'Region_Plot_1', the first two boxes and the last two boxes are all treated as 'IMAGE' coordinates though some of the boxes are defined on 'PHYSICAL'. 
- test for bug 4, continue to click on 'Create Region Layer' (for layer Region_Plot_2), click any region from either layer 'Region_Plot_1' and 'Region_Plot_2 as shown on the Firefly app. 
- test for bug 5, continue to click on 'Create Region Layer' (for layer Region_Plot_3), the first box is defined with wrong syntax as the error logged in the console. 
