### PR TITLE
DM-6950: improve overlay labels

### DIFF
--- a/src/firefly/js/drawingLayers/NorthUpCompass.js
+++ b/src/firefly/js/drawingLayers/NorthUpCompass.js
@@ -96,11 +96,5 @@ function makeCompass(plotId, action){
 
     //return Arrays.asList(new DrawObj[]{dataN, dataE});
     //
-    var arrows = VisUtil.getArrowCoords();
-
-    var pt = makeWorldPt(10.68479, 41.26906);//cc.getWorldCoords(makeImagePt(0, 0));
-    var obj = ShapeDataObj.makeCircleWithRadius(pt,50);
-    var txt = ShapeDataObj.makeText(pt,"Text");
-    obj.color = 'yellow';
     return [dataE, dataN];
 }

--- a/src/firefly/js/visualize/draw/DirectionArrowDrawObj.js
+++ b/src/firefly/js/visualize/draw/DirectionArrowDrawObj.js
@@ -127,7 +127,8 @@ function drawDirectionArrow(ctx,drawTextAry,startPt,endPt,drawParams,renderOptio
 
     //FIXME:color text black on white background - yellow on white background is not readable
     //TODO: better solution would be to adapt text color with background
-    DrawUtil.drawText(drawTextAry, text, ret.textX, ret.textY,'black', renderOptions);
+    // DM-6950
+    DrawUtil.drawText(drawTextAry, text, ret.textX, ret.textY, color, renderOptions);
 }
 
 function toRegion(startPt,endPt,plot,drawParams,renderOptions) {

--- a/src/firefly/js/visualize/draw/DirectionArrowDrawObj.js
+++ b/src/firefly/js/visualize/draw/DirectionArrowDrawObj.js
@@ -123,11 +123,6 @@ function drawDirectionArrow(ctx,drawTextAry,startPt,endPt,drawParams,renderOptio
 
     DrawUtil.drawPath(ctx, color,2,drawList,false, renderOptions);
 
-    //DrawUtil.drawText(ctx,ret.textX, ret.textY, color, '9px serif',  text, renderOptions);
-
-    //FIXME:color text black on white background - yellow on white background is not readable
-    //TODO: better solution would be to adapt text color with background
-    // DM-6950
     DrawUtil.drawText(drawTextAry, text, ret.textX, ret.textY, color, renderOptions);
 }
 

--- a/src/firefly/js/visualize/draw/DrawUtil.js
+++ b/src/firefly/js/visualize/draw/DrawUtil.js
@@ -116,14 +116,15 @@ function drawText(drawTextAry,text, x,y,color,
         color,
         left:x,
         top:y,
+        //padding:'1px 3px 1px 3px',
         fontFamily,
         'fontSize': size,
         fontWeight,
         fontStyle,
-        'backgroundColor': 'white',
-        'MozBorderRadius': '5px',
-        'borderRadius': '5px',
-        'WebkitBorderRadius': '5px'
+        //'backgroundColor': 'white',
+        'MozBorderRadius': '1px',
+        'borderRadius': '1px',
+        'WebkitBorderRadius': '1px'
     };
     drawTextAry.push({text,style});
 }

--- a/src/firefly/js/visualize/draw/DrawUtil.js
+++ b/src/firefly/js/visualize/draw/DrawUtil.js
@@ -96,11 +96,14 @@ function drawInnerRecWithHandles(ctx, color, lineWidth, inX1, inY1, inX2, inY2) 
  * @param size
  * @param fontWeight
  * @param fontStyle
+ * @param backGroundColor
+ * @param padDing
  */
 function drawText(drawTextAry,text, x,y,color,
                   renderOptions,
                   fontFamily='helvetica', size='9px',
-                  fontWeight='normal', fontStyle='normal') {
+                  fontWeight='normal', fontStyle='normal',
+                  backGroundColor, padDing) {
 
 
     //todo
@@ -116,16 +119,18 @@ function drawText(drawTextAry,text, x,y,color,
         color,
         left:x,
         top:y,
-        //padding:'1px 3px 1px 3px',
         fontFamily,
         'fontSize': size,
         fontWeight,
         fontStyle,
-        //'backgroundColor': 'white',
         'MozBorderRadius': '1px',
         'borderRadius': '1px',
         'WebkitBorderRadius': '1px'
     };
+
+    if (backGroundColor) style.backgroundColor = backGroundColor;
+    if (padDing) style.padding = padDing;
+
     drawTextAry.push({text,style});
 }
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -629,12 +629,7 @@ export function drawText(drawObj, drawTextAry, plot, inPt, drawParams) {
         if (y > south)y = south;
         else if (y<height) y= height;
 
-        //FIXME:color text black on white background - yellow on white background is not readable
-        //TODO: better solution would be to adapt text color with background
-
-        // in case shape 'text' defines the color of its own
-        // DM-6950: remove background white and update color with same used for the object itself (grid, distance tool, marker label,etc)
-        var color = drawParams.color || drawObj.color || 'black';//has(drawObj, 'color') ? drawObj.color : 'black';
+        var color = drawParams.color || drawObj.color || 'black';
         DrawUtil.drawText(drawTextAry, text, x, y, color, renderOptions,
                 fontName+FONT_FALLBACK, fontSize, fontWeight, fontStyle);
         drawObj.textWorldLoc = plot.getImageCoords(makeViewPortPt(x, y));

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -633,7 +633,8 @@ export function drawText(drawObj, drawTextAry, plot, inPt, drawParams) {
         //TODO: better solution would be to adapt text color with background
 
         // in case shape 'text' defines the color of its own
-        var color = has(drawObj, 'color') ? drawObj.color : 'black';
+        // DM-6950: remove background white and update color with same used for the object itself (grid, distance tool, marker label,etc)
+        var color = drawParams.color || drawObj.color || 'black';//has(drawObj, 'color') ? drawObj.color : 'black';
         DrawUtil.drawText(drawTextAry, text, x, y, color, renderOptions,
                 fontName+FONT_FALLBACK, fontSize, fontWeight, fontStyle);
         drawObj.textWorldLoc = plot.getImageCoords(makeViewPortPt(x, y));


### PR DESCRIPTION
I've removed white background on the text labels and and made color the same as the overlay itself.
Please check that it is the case for the overlays in general (grid, markers, distance tool, compass).
Thanks!