### PR TITLE
DM-7239: Table reset does not reset to original settings.

### DIFF
--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -12,16 +12,21 @@ import {fetchUrl} from '../util/WebUtil.js';
 
 export class TableConnector {
     
-    constructor(tbl_id, tbl_ui_id, tableModel) {
+    constructor(tbl_id, tbl_ui_id, tableModel, showUnits=true, showFilters=false) {
         this.tbl_id = tbl_id;
         this.tbl_ui_id = tbl_ui_id;
-        this.origTableModel = tableModel;
+        this.localTableModel = tableModel;
+
+        this.origPageSize = get(this.tableModel, 'request.pageSize', 100);
+        this.origShowUnits = showUnits;
+        this.origShowFilters = showFilters;
+        this.origColumns = cloneDeep(get(tableModel, 'tableData.columns', []));
     }
 
     onSort(sortInfoString) {
         var {tableModel, request} = TblUtil.getTblInfoById(this.tbl_id);
-        if (this.origTableModel) {
-            tableModel = TblUtil.sortTable(this.origTableModel, sortInfoString);
+        if (this.localTableModel) {
+            tableModel = TblUtil.sortTable(this.localTableModel, sortInfoString);
             TblCntlr.dispatchTableReplace(tableModel);
         } else {
             request = Object.assign({}, request, {sortInfo: sortInfoString});
@@ -31,8 +36,8 @@ export class TableConnector {
 
     onFilter(filterIntoString) {
         var {tableModel, request} = TblUtil.getTblInfoById(this.tbl_id);
-        if (this.origTableModel) {
-            tableModel = filterIntoString ? TblUtil.filterTable(this.origTableModel, filterIntoString) : this.origTableModel;
+        if (this.localTableModel) {
+            tableModel = filterIntoString ? TblUtil.filterTable(this.localTableModel, filterIntoString) : this.localTableModel;
             TblCntlr.dispatchTableReplace(tableModel);
         } else {
             request = Object.assign({}, request, {filters: filterIntoString});
@@ -48,7 +53,7 @@ export class TableConnector {
         if (isEmpty(selected)) return;
 
         var {tableModel, request} = TblUtil.getTblInfoById(this.tbl_id);
-        if (this.origTableModel) {
+        if (this.localTableModel) {
             // not implemented yet
         } else {
             const filterInfoCls = FilterInfo.parse(request.filters);
@@ -88,7 +93,7 @@ export class TableConnector {
         const {hlRowIdx, startIdx} = TblUtil.getTblInfoById(this.tbl_id);
         if (rowIdx !== hlRowIdx) {
             const highlightedRow = startIdx + rowIdx;
-            if (this.origTableModel) {
+            if (this.localTableModel) {
                 const tableModel = {tbl_id: this.tbl_id, highlightedRow};
                 flux.process({type: TblCntlr.TABLE_UPDATE, payload: tableModel});
             } else {
@@ -113,6 +118,16 @@ export class TableConnector {
         TblCntlr.dispatchTableSelect(this.tbl_id, selectInfoCls.data);
     }
 
+    onToggleTextView(textView) {
+        const changes = {tbl_ui_id:this.tbl_ui_id, textView};
+        TblCntlr.dispatchTableUiUpdate(changes);
+    }
+
+    onToggleOptions(showOptions) {
+        const changes = {tbl_ui_id:this.tbl_ui_id, showOptions};
+        TblCntlr.dispatchTableUiUpdate(changes);
+    }
+
     onOptionUpdate({pageSize, columns, showUnits, showFilters, sortInfo, filterInfo}) {
         if (pageSize) {
             this.onPageSizeChange(pageSize);
@@ -127,18 +142,19 @@ export class TableConnector {
         }
     }
 
-    onToggleTextView(textView) {
-        const changes = {tbl_ui_id:this.tbl_ui_id, textView};
-        TblCntlr.dispatchTableUiUpdate(changes);
+    onOptionReset() {
+        const ctable = this.localTableModel || TblUtil.getTblById(this.tbl_id);
+        var filterInfo = get(ctable, 'request.filters', '').trim();
+        filterInfo = filterInfo !== '' ? '' : undefined;
+        const pageSize = get(ctable, 'request.pageSize') !== this.origPageSize ? this.origPageSize : undefined;
+        this.onOptionUpdate({filterInfo, pageSize,
+                        columns: cloneDeep(get(ctable, 'tableData.columns', [])),
+                        showUnits: this.origShowUnits,
+                        showFilters: this.origShowFilters});
     }
 
-    onToggleOptions(showOptions) {
-        const changes = {tbl_ui_id:this.tbl_ui_id, showOptions};
-        TblCntlr.dispatchTableUiUpdate(changes);
-    }
-
-    static newInstance(tbl_id, tbl_ui_id, tableModel) {
-        return new TableConnector(tbl_id, tbl_ui_id, tableModel);
+    static newInstance(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters) {
+        return new TableConnector(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters);
     }
 }
 

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -38,7 +38,7 @@ export class TablePanel extends Component {
             tbl_id = get(tableModel, 'tbl_id', TblUtil.uniqueTblId());
         }
         tbl_ui_id = tbl_ui_id || TblUtil.uniqueTblUiId();
-        this.tableConnector = TableConnector.newInstance(tbl_id, tbl_ui_id, tableModel);
+        this.tableConnector = TableConnector.newInstance(tbl_id, tbl_ui_id, tableModel, this.props.showUnits, this.props.showFilters);
         const uiState = TblUtil.getTableUiById(tbl_ui_id);
         this.state = Object.assign({}, this.props, uiState);
 
@@ -49,6 +49,7 @@ export class TablePanel extends Component {
         this.toggleOptions = this.toggleOptions.bind(this);
         this.expandTable = this.expandTable.bind(this);
         this.onOptionUpdate = this.onOptionUpdate.bind(this);
+        this.onOptionReset = this.onOptionReset.bind(this);
     }
 
     componentDidMount() {
@@ -104,6 +105,9 @@ export class TablePanel extends Component {
     onOptionUpdate(value) {
         this.tableConnector.onOptionUpdate(value);
     }
+    onOptionReset() {
+        this.tableConnector.onOptionReset();
+    }
 
     render() {
         const {selectable, expandable, expandedMode, border, renderers, title, removable, rowHeight, help_id,
@@ -120,7 +124,6 @@ export class TablePanel extends Component {
 
         const selectInfoCls = SelectInfo.newInstance(selectInfo, startIdx);
         const viewIcoStyle = 'tablepanel ' + (textView ? 'tableView' : 'textView');
-        const origColumns = get(TblUtil.getTblById(this.tableConnector.tbl_id), 'tableData.columns');
         const tableTopPos = showToolbar ? 29 : 0;
         const TT_VIEW = textView ? TT_TABLE_VIEW : TT_TEXT_VIEW;
 
@@ -180,8 +183,9 @@ export class TablePanel extends Component {
                         {showOptions &&
                             <TablePanelOptions
                                 onChange={this.onOptionUpdate}
+                                onOptionReset={this.onOptionReset}
                                 toggleOptions={this.toggleOptions}
-                                { ...{columns, origColumns, optSortInfo, filterInfo, pageSize, showUnits, showFilters, showToolbar}}
+                                { ...{columns, optSortInfo, filterInfo, pageSize, showUnits, showFilters, showToolbar}}
                             /> }
                     </div>
                 </div>

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {isEmpty, cloneDeep} from 'lodash';
+import {isEmpty} from 'lodash';
 
 import {FilterEditor} from './FilterEditor.jsx';
 import {InputField} from '../../ui/InputField.jsx';
@@ -29,10 +29,10 @@ export class TablePanelOptions extends React.Component {
     // }
 
     render() {
-        const {columns, origColumns, pageSize, showUnits, showFilters, showToolbar=true, onChange, optSortInfo, filterInfo, toggleOptions} = this.props;
+        const {columns, pageSize, showUnits, showFilters, showToolbar=true, onChange, onOptionReset, optSortInfo, filterInfo, toggleOptions} = this.props;
         if (isEmpty(columns)) return false;
 
-        const {onPageSize, onPropChanged, onReset} = makeCallbacks(onChange, columns, origColumns);
+        const {onPageSize, onPropChanged} = makeCallbacks(onChange, columns);
         return (
             <div className='TablePanelOptions'>
                 <div
@@ -75,7 +75,7 @@ export class TablePanelOptions extends React.Component {
                              title='Remove Tab'
                              onClick={() => toggleOptions()}/>
 
-                        <button className='TablePanelOptions__button' onClick={onReset}
+                        <button className='TablePanelOptions__button' onClick={onOptionReset}
                                 title='Reset all options to defaults'>Reset</button>
                     </span>
                 </div>
@@ -94,7 +94,6 @@ export class TablePanelOptions extends React.Component {
 
 TablePanelOptions.propTypes = {
     columns: React.PropTypes.arrayOf(React.PropTypes.object),
-    origColumns: React.PropTypes.arrayOf(React.PropTypes.object),
     optSortInfo: React.PropTypes.string,
     filterInfo: React.PropTypes.string,
     pageSize: React.PropTypes.number,
@@ -102,10 +101,11 @@ TablePanelOptions.propTypes = {
     showFilters: React.PropTypes.bool,
     showToolbar: React.PropTypes.bool,
     onChange: React.PropTypes.func,
+    onOptionReset: React.PropTypes.func,
     toggleOptions: React.PropTypes.func
 };
 
-function makeCallbacks(onChange, columns, origColumns, data) {
+function makeCallbacks(onChange) {
     var onPageSize = (pageSize) => {
         if (pageSize.valid) {
             onChange && onChange({pageSize: pageSize.value});
@@ -116,9 +116,5 @@ function makeCallbacks(onChange, columns, origColumns, data) {
         onChange && onChange({[prop]: v});
     };
 
-    var onReset = () => {
-        onChange && onChange({pageSize: 100, showUnits: false, showFilters: false, filterInfo: '', columns: cloneDeep(origColumns)});
-    };
-
-    return {onPageSize, onPropChanged, onReset};
+    return {onPageSize, onPropChanged};
 }

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -118,8 +118,8 @@ export function* watchCoverage({viewerId, options= {}}) {
                     // no need to update coverage on table sort.. data have not changed.
                     decimatedTables[tbl_id]= null;
                     displayedTableId = updateCoverage(tbl_id, viewerId, decimatedTables, options);
-                    break;
                 }
+                break;
 
             case TBL_RESULTS_ACTIVE:
                 if (!getTableInGroup(tbl_id)) continue;


### PR DESCRIPTION
 - reset options based on original settings.
 - do not reload document unless it is needed.
 - do not redraw coverage with table is sorted

Reset should work like it did before.
Show units, show filters, column selections, and filters will be reset to what it was originally when table was loaded.  On table sort, coverage image will not reset.  However, it will be reset on filters changed.  This is how it is in production as well.