### PR TITLE
DM-6289 Chart options - reset to default

### DIFF
--- a/src/firefly/js/api/ApiUtilChart.jsx
+++ b/src/firefly/js/api/ApiUtilChart.jsx
@@ -9,5 +9,5 @@ import * as XYPlotCntlr from '../charts/XYPlotCntlr.js';
 export {uniqueChartId} from '../charts/ChartUtil.js';
 
 export function loadPlotDataForTbl(tblId, chartId, xyPlotParams) {
-    XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tblId);
+    XYPlotCntlr.dispatchLoadPlotData({chartId, xyPlotParams, markAsDefault:true, tblId});
 }

--- a/src/firefly/js/charts/ui/ChartsTableViewPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartsTableViewPanel.jsx
@@ -608,16 +608,18 @@ export class OptionsWrapper extends React.Component {
                 options = (<XYPlotOptions key={formName} groupKey={formName}
                                    colValStats={tblStatsData.colStats}
                                    xyPlotParams={get(tblPlotData, 'xyPlotParams')}
+                                   defaultParams={get(tblPlotData, 'defaultParams')}
                                    onOptionsSelected={(xyPlotParams) => {
-                                                XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tableModel.tbl_id);
+                                                XYPlotCntlr.dispatchLoadPlotData({chartId, xyPlotParams, tblId: tableModel.tbl_id});
                                             }
                                           }/>);
             } else {
                 options = (<HistogramOptions key={formName} groupKey={formName}
                                       colValStats={tblStatsData.colStats}
                                       histogramParams={get(tblHistogramData, 'histogramParams')}
+                                      defaultParams={get(tblHistogramData, 'defaultParams')}
                                       onOptionsSelected={(histogramParams) => {
-                                                HistogramCntlr.dispatchLoadColData(chartId, histogramParams, tableModel.tbl_id);
+                                                HistogramCntlr.dispatchLoadColData({chartId, histogramParams, tblId: tableModel.tbl_id});
                                             }
                                           }/>);
             }

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -122,7 +122,7 @@ export class HistogramOptions extends React.Component {
     }
 
     render() {
-        const { colValStats, groupKey, histogramParams, onOptionsSelected}= this.props;
+        const { colValStats, groupKey, histogramParams, defaultParams, onOptionsSelected}= this.props;
         return (
             <div style={{padding:'0 5px'}}>
                 <FieldGroup groupKey={groupKey} validatorFunc={null} keepState={true}>
@@ -137,7 +137,7 @@ export class HistogramOptions extends React.Component {
                         <div style={{flexGrow: 1}}/>
                         <div style={{flexGrow: 0}}>
                             <button type='button' className='button std' onClick={() => setOptions(groupKey, {})}>Clear</button>
-                            <button type='button' className='button std' onClick={() => setOptions(groupKey, histogramParams)}>Reset</button>
+                            <button type='button' className='button std' onClick={() => setOptions(groupKey, defaultParams)}>Reset</button>
                         </div>
                     </div>}
 
@@ -220,5 +220,6 @@ HistogramOptions.propTypes = {
     groupKey: PropTypes.string.isRequired,
     colValStats: PropTypes.arrayOf(PropTypes.instanceOf(ColValuesStatistics)).isRequired,
     onOptionsSelected: PropTypes.func,
-    histogramParams: histogramParamsShape
+    histogramParams: histogramParamsShape,
+    defaultParams: histogramParamsShape
 };

--- a/src/firefly/js/charts/ui/XYPlotOptions.jsx
+++ b/src/firefly/js/charts/ui/XYPlotOptions.jsx
@@ -422,7 +422,7 @@ export class XYPlotOptions extends React.Component {
     }
 
     render() {
-        const { colValStats, groupKey, xyPlotParams, onOptionsSelected}= this.props;
+        const { colValStats, groupKey, xyPlotParams, defaultParams, onOptionsSelected}= this.props;
 
         // the suggestions are indexes in the colValStats array - it makes it easier to render then with labels
         const allSuggestions = colValStats.map((colVal,idx)=>{return idx;});
@@ -471,7 +471,7 @@ export class XYPlotOptions extends React.Component {
                         <div style={{flexGrow: 1}}/>
                         <div style={{flexGrow: 0}}>
                             <button type='button' className='button std' onClick={() => setOptions(groupKey, {})}>Clear</button>
-                            <button type='button' className='button std' onClick={() => setOptions(groupKey, xyPlotParams)}>Reset</button>
+                            <button type='button' className='button std' onClick={() => setOptions(groupKey, defaultParams)}>Reset</button>
                         </div>
                     </div>}
 
@@ -622,5 +622,6 @@ XYPlotOptions.propTypes = {
     groupKey: PropTypes.string.isRequired,
     colValStats: PropTypes.arrayOf(PropTypes.instanceOf(ColValuesStatistics)).isRequired,
     onOptionsSelected: PropTypes.func,
-    xyPlotParams: plotParamsShape
+    xyPlotParams: plotParamsShape,
+    defaultParams: plotParamsShape
 };

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -95,12 +95,12 @@ class ChartSelect extends Component {
             switch (chartType) {
                 case SCATTER:
                     onXYPlotOptsSelected((xyPlotParams) => {
-                        XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tblId);
+                        XYPlotCntlr.dispatchLoadPlotData({chartId, xyPlotParams, markAsDefault: true, tblId});
                     }, flds);
                     break;
                 case HISTOGRAM:
                     onHistogramOptsSelected((histogramParams) => {
-                        HistogramCntlr.dispatchLoadColData(chartId, histogramParams, tblId);
+                        HistogramCntlr.dispatchLoadColData({chartId, histogramParams, markAsDefault: true, tblId});
                     }, flds);
                     break;
             }
@@ -108,7 +108,7 @@ class ChartSelect extends Component {
         };
 
         return (
-            <div style={{padding:10, overflow:'auto', maxWidth:350, maxheight:500}}>
+            <div style={{padding:10, overflow:'auto', maxWidth:600, maxHeight:600}}>
                 <FormPanel
                     groupKey={formName}
                     onSubmit={resultSuccess}

--- a/src/firefly/js/visualize/saga/ChartsSync.js
+++ b/src/firefly/js/visualize/saga/ChartsSync.js
@@ -36,7 +36,7 @@ export function* syncCharts() {
                             // default chart is xy plot of coordinate columns or first two numeric columns
                             const defaultParams = getDefaultXYPlotParams(tblId);
                             if (defaultParams) {
-                                XYPlotCntlr.dispatchLoadPlotData(tblId, defaultParams, tblId);
+                                XYPlotCntlr.dispatchLoadPlotData({chartId, xyPlotParams: defaultParams, markAsDefault: true, tblId});
                             }
                         }
                     }
@@ -56,7 +56,7 @@ export function* syncCharts() {
                             hasRelated = true;
                             if (ChartsCntlr.isChartMounted(tbl_id, cid, SCATTER)) {
                                 const xyPlotParams = xyPlotState[cid].xyPlotParams;
-                                XYPlotCntlr.dispatchLoadPlotData(cid, xyPlotParams, tbl_id);
+                                XYPlotCntlr.dispatchLoadPlotData({chartId: cid, xyPlotParams, tblId: tbl_id});
                             }
                         }
                     });
@@ -70,7 +70,7 @@ export function* syncCharts() {
                                 hasRelated = true;
                                 if (ChartsCntlr.isChartMounted(tbl_id, cid, 'histogram')) {
                                     const histogramParams = histogramState[cid].histogramParams;
-                                    HistogramCntlr.dispatchLoadColData(cid, histogramParams, tbl_id);
+                                    HistogramCntlr.dispatchLoadColData({chartId: cid, histogramParams, tblId: tbl_id});
                                 }
                             }
                         });
@@ -80,7 +80,7 @@ export function* syncCharts() {
                             // default chart is xy plot of coordinate columns or first two numeric columns
                             const defaultParams = getDefaultXYPlotParams(tbl_id);
                             if (defaultParams) {
-                                XYPlotCntlr.dispatchLoadPlotData(tbl_id, defaultParams, tbl_id);
+                                XYPlotCntlr.dispatchLoadPlotData({chartId: tbl_id, xyPlotParams: defaultParams, markAsDefault: true, tblId: tbl_id});
                             }
                         }
                     }
@@ -101,13 +101,13 @@ function updateChartDataIfNeeded(tblId, chartId, chartType) {
             case SCATTER:
                 const xyPlotParams = get(chartSpace, [chartId, 'xyPlotParams']);
                 if (xyPlotParams) {
-                    XYPlotCntlr.dispatchLoadPlotData(chartId, xyPlotParams, tblId);
+                    XYPlotCntlr.dispatchLoadPlotData({chartId, xyPlotParams, tblId});
                 }
                 break;
             case HISTOGRAM:
                 const histogramParams = get(chartSpace, [chartId, 'histogramParams']);
                 if (histogramParams) {
-                    HistogramCntlr.dispatchLoadColData(chartId, histogramParams, tblId);
+                    HistogramCntlr.dispatchLoadColData({chartId, histogramParams, tblId});
                 }
                 break;
             default:


### PR DESCRIPTION
- Fixed truncated columns in table statistics processor (when col name is long)
- Fixed NaN related issues in histogram processor
- Reset in xyplot or histogram options resets options to the default.

How do we know the options are the default?

- Chart is created from the menu drop down, options selected there are "the default"
- Default chart, created with the default parameters
- Chart is created via API, options passed via the API function are "the default"