### PR TITLE
DM-7223: Python API using reStructured and numpydoc format.

### DIFF
--- a/src/firefly/python/display/FireflyClient.py
+++ b/src/firefly/python/display/FireflyClient.py
@@ -1,3 +1,12 @@
+"""
+Module of FireflyClient.py
+--------------------------
+This module defines class 'FireflyClient' and methods to remotely communicate to Firefly viewer
+by dispatching remote actions.
+"""
+
+__docformat__ = 'restructuredtext'
+
 from ws4py.client.threadedclient import WebSocketClient
 import requests
 import webbrowser
@@ -6,21 +15,82 @@ import time
 import socket
 import urlparse
 import math
-
-__author__ = 'zhang' + ' Cindy Wang'
+import mimetypes
 
 
 class FireflyClient(WebSocketClient):
-    # class variables
-    # serverEvents = {
-    #       'name': ['EVT_CONN_EST', 'SvrBackgroundReport', 'WindowResize'],
-    #       'scope': ['SELF', 'CHANNEL'],
-    #       'dataType': ['STRING', 'JSON', 'BG_STATUS'],
-    #       'data': ['channel']
-    # }
+    """
+    For Firefly client to build interface to remotely communicate to the Firefly viewer.
 
-    fftools_cmd = '/firefly/sticky/CmdSrv'
-    my_localhost = 'localhost:8080'
+    methods
+    -------
+    add_listener(callback, name)
+        Add listener to events on Firefly client.
+    remove_listener(callback, name)
+        Remove event name from callback listener.
+    launch_browser()
+        Launch a browsers with the Firefly Tools viewer and the channel set.
+    wait_for_events()
+        Wait over events from the server.
+    get_firefly_url(mode, channel)
+        Get URL to Firefly Tools viewer and the channel set.
+    stay_connected()
+        Keep WebSocket connected.
+    disconnect()
+        Disconnect the WebSocket.
+    upload_file(path, pre_load)
+        Upload a file to the Firefly Server.
+    upload_fits_data(stream)
+        Upload fits file like object to the Firefly server.
+    upload_text_data(stream)
+        Upload a text file like object to the Firefly server.
+    upload_data(stream, data_type)
+        Upload a file like object to the Firefly server
+    create_image_url(image_source)
+        Create image url or data uri.
+    dispatch_remote_action(channel, action_type, payload)
+        Dispatch the action to the server by sending 'GET' request.
+    dispatch_remote_action_by_post(channel, action_type, payload)
+        Dispatch the action to the server by sending 'POST' request.
+    show_fits(file_on_server, plot_id, **additional_params)
+        Show a fits image.
+    show_table(file_on_server, tbl_id, title, page_size, is_catalog)
+        Show a table.
+    show_xyplot(file_on_server, **additional_params)
+        Show a XY plot.
+    add_extension(ext_type, plot_id, title, tool_tip, extension_id, image_src)
+        Add extension to the plot.
+    set_zoom(plot_id, factor)
+        Zoom the image.
+    set_pan(plot_id, x, y, coord)
+        Relocate the center of the image.
+    set_stretch(plot_id, type, algorithm, **additional_params)
+        Change the stretch of the image (no band case).
+    overlay_region_layer(file_on_server, region_data, title, region_layer_id, plot_id)
+        Overlay a region layer on the image plot.
+    delete_region_layer(region_layer_id, plot_id)
+        Delete region layer from the image plot.
+    add_region_data(region_data, region_layer_id, title, plot_id)
+        Add region entries to the region layer.
+    remove_region_data(region_data, region_layer_id)
+        Remove region entries from the region layer.
+    add_mask(bit_number, image_number, plot_id, mask_id, color, title, file_on_server)
+        Add a mask layer to the image plot.
+    remove_mask(plot_id, mask_id)
+         Remove a mask layer from the image plot.
+
+    Attributes
+    ----------
+    STRETCH_TYPE_DICT, STRETCH_ALGORITHM_DICT : dict
+        Definition of stretch type and algorithm.
+    ACTION_DICT : dict
+        Definition of FIrefly action.
+    EXTENSION_TYPE : list of str
+        Type of plot where the extension is added to.
+    """
+
+    _fftools_cmd = '/firefly/sticky/CmdSrv'
+    _my_localhost = 'localhost:8080'
     ALL = 'ALL_EVENTS_ENABLED'
 
     # for serializing the RangeValues object
@@ -49,36 +119,56 @@ class FireflyClient(WebSocketClient):
     # id for table, region layer, extension
     _item_id = {'Table': 0, 'RegionLayer': 0, 'Extension': 0, 'MaskLayer': 0}
 
-    # the constructor, define instance variables for the object
-    def __init__(self, host=my_localhost, channel=None):
+    # urls:
+    # launch browser:  http://<host>/firefly/firefly.html;wsch=<channel id> or (mode == 'full')
+    #                  http://<host>/firefly/firefly.html;id=Loader&channelID=<channel id>
+    # dispatch action: http://<host>/firefly/sticky/CmdSrv?channelID=<channel id>
+    #                  &cmd=pushAction&Action=<ACTION_DICT>
+    # open websocket:  ws://<host>/firefly/sticky/firefly/events?channdleID=<channel id>
+
+    def __init__(self, host=_my_localhost, channel=None):
+        """initialize a 'FireflyClient' object and build websocket.
+
+        Parameters
+        ----------
+        host : str
+            Firefly host.
+        channel : str
+            WebSocket channel id.
+        """
+
         if host.startswith('http://'):
             host = host[7:]
+
         self.this_host = host
+
         url = 'ws://%s/firefly/sticky/firefly/events' % host  # web socket url
         if channel:
             url += '?channelID=%s' % channel
         WebSocketClient.__init__(self, url)
-        self.url_root = 'http://' + host + self.fftools_cmd
+
+        self.url_root = 'http://' + host + self._fftools_cmd
         self.url_bw = 'http://' + self.this_host + '/firefly/firefly.html;wsch='
+
         self.listeners = {}
         self.channel = channel
         self.session = requests.Session()
-
         # print 'websocket url:%s' % url
         self.connect()
-
-    # def opened(self):
-    #     print ("Opening websocket connection to fftools")
-
-    # def closed(self, code, reason=None):
-    #     print ("Closed down", code, reason)
 
     def _handle_event(self, ev):
         for callback, eventIDList in self.listeners.items():
             if ev['name'] in eventIDList or FireflyClient.ALL in eventIDList:
                 callback(ev)
 
-    # overridde the superclass's method
+    # override the superclass's method
+    # serverEvents (message)
+    # {
+    #    'name': ['EVT_CONN_EST', 'SvrBackgroundReport', 'WindowResize'],
+    #    'scope': ['SELF', 'CHANNEL'],
+    #    'dataType': ['STRING', 'JSON', 'BG_STATUS'],
+    #    'data': {'channel': , 'connID': }
+    # }
     def received_message(self, m):
         ev = json.loads(m.data.decode('utf8'))
         event_name = ev['name']
@@ -103,39 +193,31 @@ class FireflyClient(WebSocketClient):
             self._handle_event(ev)
 
     def _send_url_as_get(self, url):
-        """
-        send URL in 'GET' request
-        :param url:
-        :return:
-        """
+        """Send URL in 'GET' request and return status."""
+
         response = self.session.get(url)
         # print response.text
         status = json.loads(response.text)
         return status[0]
 
     def _send_url_as_post(self, data):
-        """
-        send URL in 'POST' request
-        :param data
-        :return:
-        """
+        """Send URL in 'POST' request and return status."""
+
         response = self.session.post(self.url_root, data=data)
         status = json.loads(response.text)
         return status[0]
 
     def _is_page_connected(self):
+        """Check if the page is connected."""
+
         ip = socket.gethostbyname(socket.gethostname())
         url = self.url_root + '?cmd=pushAliveCheck&ipAddress=%s' % ip
         retval = self._send_url_as_get(url)
+
         return retval['active']
 
-    # def onConnected(self, channel):
-    #     #open the browser
-    #     url = 'http://' + self.this_host + '/fftools/app.html?id=Loader&channelID=' + channel
-    #     webbrowser.open('http://localhost:8080/fftools/app.html?id=Loader&channelID=' + channel)
-    #     webbrowser.open(url)
-
-    def _make_pid_param(self, plot_id):
+    @staticmethod
+    def _make_pid_param(plot_id):
         return ','.join(plot_id) if isinstance(plot_id, list) else plot_id
 
 # -----------------------------------------------------------------
@@ -146,11 +228,17 @@ class FireflyClient(WebSocketClient):
 
     def add_listener(self, callback, name=ALL):
         """
-        Add a function to listen for events on the firefly client
-        :param callback: set the function to be called when a event happens on the firefly client
-        :param name: set the name of the events, default to all events
-        :return:
+        Add a function to listen for events on the Firefly client.
+
+        Parameters
+        ----------
+        callback : function
+            The function to be called when a event happens on the Firefly client.
+        name : str, optional
+            The name of the events (the default is ALL, all events).
+
         """
+
         if callback not in self.listeners.keys():
             self.listeners[callback] = []
         if name not in self.listeners[callback]:
@@ -158,11 +246,22 @@ class FireflyClient(WebSocketClient):
 
     def remove_listener(self, callback, name=ALL):
         """
-        remove a callback
-        :param callback: a previous set function that is to be removed
-        :param name: set the name of the event, default to all events
-        :return:
+        Remove a event name from the callback listener.
+
+        Parameters
+        ----------
+        callback : function
+            A previously set callback function.
+        name : str, optional
+            The name of the event to be removed from the callback listener
+            (the default is ALL, all events).
+
+
+        Notes
+        -----
+        The callback listener is removed if all events are removed from the callback.
         """
+
         if callback in self.listeners.keys():
             if name in self.listeners[callback]:
                 self.listeners[callback].remove(name)
@@ -175,32 +274,56 @@ class FireflyClient(WebSocketClient):
         This is optional. You should not use this method in ipython notebook
         Event will get called anyway.
         """
+
         WebSocketClient.run_forever(self)
 
-    def get_firefly_url(self, mode=None, channel=None):
+    def get_firefly_url(self, mode='minimal', channel=None):
         """
         Get URL to Firefly Tools viewer and the channel set. Normally this method
-        will be call without any parameters.
-        :param mode: mode maybe one of 'full', or 'minimal'.  Defaults to minimal.
-        :param channel: a different channel string than the default
-        :return: the full url string
+        will be called without any parameters.
+
+        Parameters
+        -------------
+        mode : {'full', 'minimal'}, optional
+            Url mode (the default is 'minimal').
+        channel : str, optional
+            A different channel string than the default.
+
+        Returns
+        -------
+        out : str
+            url string.
         """
+
         if not channel:
             channel = self.channel
 
         url = 'http://' + self.this_host + '/firefly/firefly.html?id=Loader&channelID='
-        if mode == "full":
+        if mode.lower() == "full":
             url = self.url_bw
         return url + channel
 
     def launch_browser(self, url=None, channel=None, force=False):
         """
-        Launch a browsers with the Firefly Tools viewer and the channel set. Normally this method
-        will be call without any parameters.
-        :param url: the url, overriding the default
-        :param channel: a different channel than the default
-        :return: the channel
+        Launch a browser with the Firefly Tools viewer and the channel set.
+        The page is launched when `force` is true or the page is not opened yet.
+        Normally this method will be called without any parameters.
+
+        Parameters
+        ----------
+        url : str, optional
+            An url overriding the default (the default is set as self.url_bw).
+        channel : str, optional
+            A different channel than the default (the default is set as self.channel).
+        force : bool, optional
+            If the browser page is forced to be opened (the default is false).
+
+        Returns
+        -------
+        out : str
+            The channel ID.
         """
+
         if not channel:
             channel = self.channel
         if not url:
@@ -208,19 +331,38 @@ class FireflyClient(WebSocketClient):
         do_open = True if force else not self._is_page_connected()
         if do_open:
             webbrowser.open(self.get_firefly_url(url, channel))
+
         time.sleep(5)  # todo: find something better to do than sleeping
         return channel
 
     def stay_connected(self):
-        self.ws.run()
+        """Keep WebSocket connected."""
+        self.run()
 
     def disconnect(self):
+        """Disconnect the WebSocket."""
         self.close()
 
     def upload_file(self, path, pre_load=True):
-        """ Upload a file to the Firefly Server
-        :param path: uploaded file can be fits, region, and various types of table files
         """
+        Upload a file to the Firefly Server.
+
+        Parameters
+        ----------
+        path : str
+            Path of uploaded file. It can be fits, region, and various types of table files.
+        pre_load : bool
+            This parameter is not used.
+
+        Notes
+        -----
+        'pre_load' is not implemented in the server (will be removed later).
+
+        Returns
+        -------
+            Path of file after the upload.
+        """
+
         url = 'http://' + self.this_host + '/firefly/sticky/Firefly_FileUpload?preload=%s' % pre_load
         files = {'file': open(path, 'rb')}
         result = self.session.post(url, files=files)
@@ -229,11 +371,21 @@ class FireflyClient(WebSocketClient):
 
     def upload_fits_data(self, stream):
         """
-        Upload a FITS file like object to the Firefly server. The method should allows file like data
+        Upload a FITS file like object to the Firefly server. The method should allow file like data
         to be streamed without using a actual file.
-        :param stream: a file like object
-        :return: status
+
+        Parameters
+        ----------
+        stream: file-like object
+            An file like object containing fits data,
+            such as if *f = open(<a_fits_path>)*, *f* is a file object.
+
+        Returns
+        -------
+        out : dict
+            Status, like {'success': true}.
         """
+
         url = 'http://' + self.this_host + '/firefly/sticky/Firefly_FileUpload?preload=true'
         data_pack = {'data': stream}
         result = self.session.post(url, files=data_pack)
@@ -242,27 +394,91 @@ class FireflyClient(WebSocketClient):
 
     def upload_text_data(self, stream):
         """
-        Upload a Text file like object to the Firefly server. The method should allows file like data
+        Upload a Text file like object to the Firefly server. The method should allow text file like data
         to be streamed without using a actual file.
-        :param stream: a file like object
-        :return: status
+
+        Parameters
+        ----------
+        stream : file-like object
+            An file like object containing text data,
+            such as if *f = open(<a_textfile_path>)*, *f* is a file object.
+
+
+        Returns
+        -------
+        out : dict
+            Status, like {'success': true}.
         """
         return self.upload_data(stream, 'UNKNOWN')
 
     def upload_data(self, stream, data_type):
+        """
+        Upload a file like object to the Firefly server. The method should allow either fits or
+        non-fits file like data to be streamed without using a actual file.
+
+        Parameters
+        ----------
+        stream : file-like object
+            An file like object containing fits data or others.
+        data_type : {'FITS', 'UNKNOWN'}
+            Data type, fits or others.
+
+        Returns
+        -------
+        out : dict
+            Status, like {'success': true}.
+        """
+
         url = 'http://' + self.this_host + '/firefly/sticky/Firefly_FileUpload?preload='
-        url += 'true&type=FITS' if data_type == 'FITS' else 'false&type=UNKNOWN'
+        url += 'true&type=FITS' if data_type.upper() == 'FITS' else 'false&type=UNKNOWN'
         data_pack = {'data': stream}
         result = self.session.post(url, files=data_pack)
         index = result.text.find('$')
         return result.text[index:]
 
+    @staticmethod
+    def create_image_url(image_source):
+        """
+        Create image url or data uri according to the image source.
+
+        Parameters
+        ----------
+        image_source : str
+            An image path or image url.
+
+        Returns
+        -------
+         out : str
+            Data URI or image url.
+        """
+
+        def is_url(url):
+            return urlparse.urlparse(url).scheme != ''
+
+        if not image_source.startswith('data:image') and not is_url(image_source):
+            mime, _ = mimetypes.guess_type(image_source)
+            data_uri = open(image_source, 'rb').read().encode('base64').replace('\n', '')
+            return 'data:%s;base64,%s' % (mime, data_uri)
+
+        return image_source
+
     def dispatch_remote_action(self, channel, action_type, payload):
         """
-        dispatch the action to the server by using 'GET' request
-        :param: channel
-        :param: actionType
-        :param: payload: payload for the action
+        Dispatch the action to the server by using 'GET' request.
+
+        Parameters
+        ----------
+        channel : str
+            WebSocket channel id.
+        action_type : str
+            Action type,  one of actions from FireflyClient's attribute,  ACTION_DICT.
+        payload : dict
+            Payload, the content varies among action types.
+
+        Returns
+        -------
+        out : dict
+            Status of remote dispatch, like {'success': true}.
         """
 
         action = {'type': action_type, 'payload': payload}
@@ -272,11 +488,23 @@ class FireflyClient(WebSocketClient):
 
     def dispatch_remote_action_by_post(self, channel, action_type, payload):
         """
-        dispatch the action to the server by using 'POST' request
-        :param: channel
-        :param: actionType
-        :param: payload: payload for the action
+        Dispatch the action to the server by using 'POST' request.
+
+        Parameters
+        ----------
+        channel : str
+            Websocket channel id.
+        action_type : str
+            Action type, one of actions from FireflyClient's attribute, ACTION_DICT.
+        payload : dict
+            Payload, the content varies among action types.
+
+        Returns
+        -------
+        out : dict
+            Status of remotely dispatch, like {'success': true}.
         """
+
         action = {'type': action_type, 'payload': payload}
         data = {'channelID': channel, 'cmd': 'pushAction', 'action': json.dumps(action)}
 
@@ -286,21 +514,33 @@ class FireflyClient(WebSocketClient):
     # dispatch actions
     # -------------------------
 
-    # ----------------------------------------------------------------
-    # action on showing fits, tables, XYPlot and adding extension
-    # ----------------------------------------------------------------
+    # --------------------------------------------------------------------------
+    # action on showing fits, tables, XYPlot, adding extension, and adding mask
+    # -------------------------------------------------------------------------
 
     def show_fits(self, file_on_server=None, plot_id=None, **additional_params):
         """
-        Show a fits image
-        :param: file_on_server: the is the name of the file on the server.  If you used upload_file()
-                          then it is the return value of the method. Otherwise it is a file that
-                          firefly has direct read access to.
-        :param: plot_id: the id you assigned to the plot. This is necessary to further control the plot
-        :param: additionalParam: dictionary of any valid fits viewer plotting parameters,
-                          see firefly/docs/fits-plotting-parameters.md
-        :return: status of call
+        Show a fits image.
+
+        Parameters
+        ----------
+        file_on_server : str, optional
+            The is the name of the file on the server.  If you use upload_file()
+            then it is the return value of the method. Otherwise it is a file that
+            Firefly has direct access to.
+        plot_id : str or list of str, optional
+            The id you assign to the image plot. This is necessary to further control the plot.
+
+        additional_params : dict, optional
+            Dictionary of any valid fits viewer plotting parameters,
+            see `fits plotting parameters<https://github.com/Caltech-IPAC/firefly/blob/dev/docs/fits-plotting-parameters.md>`_.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
+
         wp_request = {'plotGroupId': 'groupFromPython',
                       'GroupLocked': False}
         payload = {'wpRequest': wp_request,
@@ -316,15 +556,27 @@ class FireflyClient(WebSocketClient):
 
     def show_table(self, file_on_server, tbl_id=None, title=None, page_size=100, is_catalog=True):
         """
-        Show a table in Firefly
-        :param file_on_server: the is the name of the file on the server.  If you used upload_file()
-                       then it is the return value of the method. Otherwise it is a file that
-                       firefly has direct read access to.
-        :param tbl_id: table Id
-        :param title: title on table
-        :param page_size: how many rows are shown.
-        :param is_catalog: catalog or table
-        :return: status of call
+        Show a table.
+
+        Parameters
+        ----------
+        file_on_server : str, optional
+            The is the name of the file on the server.  If you use upload_file()
+            then it is the return value of the method. Otherwise it is a file that
+            Firefly has direct access to.
+        tbl_id : str, optional
+            A table ID. It will be created automatically if not specified.
+        title : str, optional
+            Title associated with the table.
+        page_size : int, optional
+            The number of rows that are shown in the table page (the default is 100).
+        is_catalog : bool, optional
+            If the table file is a catalog (the default is true) or not.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
 
         if not tbl_id:
@@ -343,14 +595,57 @@ class FireflyClient(WebSocketClient):
 
     def show_xyplot(self, file_on_server, **additional_params):
         """
-        TODO
-        Show a table in Firefly
-        :param file_on_server: the is the name of the file on the server.  If you used upload_file()
-                       then it is the return value of the method. Otherwise it is a file that
-                       firefly has direct read access to.
-        :param additional_params: XY Plot Viewer parameters
-        :return: status of call
+        Show a XY plot
+
+        Parameters
+        ----------
+        file_on_server : str, optional
+            The is the name of the file on the server.  If you use upload_file()
+            then it is the return value of the method. Otherwise it is a file that
+            Firefly has direct access to.
+        **additional_params
+            Additional parameters for XY Plot, please see the details in 'Other Parameters'.
+
+        Other Parameters
+        ----------------
+        source: str
+            location of the ipac table, url or file path; ignored when XY plot view is added to table.
+        chartTitle : str
+            title of the chart.
+        xCol: str
+            column or expression to use for x values, can contain multiple column names,
+            ex. log(col) or (col1-col2)/col3.
+        yCol: str
+            column or expression to use for y values, can contain multiple column names,
+            ex. sin(col) or (col1-col2)/col3.
+        xyRatio : numeric types
+            Aspect ratio (must be between 1 and 10).
+        stretch : {'fit', 'fill'}
+            Stretch method.
+        xLabel : str
+            label to use with x axis.
+        yLabel : str
+            label to use with y axis.
+        xUnit : str
+            unit for x axis.
+        yUnit : str
+            unit for y axis.
+        xOptions : str
+            Comma separated list of x axis options: grid,flip,log.
+        yOptions : str
+            Comma separated list of y axis options: grid,flip,log.
+
+        Notes
+        -----
+            For the additional parameters, xCol and yCol are required, then all other
+            parameters are valid.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
+
         url = self.url_root + "?cmd=pushXYPlot"
         if additional_params:
             url += '&' + '&'.join(['%s=%s' % (k, v) for k, v in additional_params.items()])
@@ -360,15 +655,35 @@ class FireflyClient(WebSocketClient):
     def add_extension(self, ext_type, plot_id=None, title='', tool_tip='',
                       extension_id=None, image_src=None):
         """
-        TODO: callback
-        Add an extension to the plot.  Extensions are context menus that allows you to extend
-        what firefly can so when certain actions happen
-        :param ext_type: May be 'AREA_SELECT', 'LINE_SELECT', or 'POINT'. todo: 'CIRCLE_SELECT'
-        :param title: The title that the user sees
-        :param plot_id: The it of the plot to put the extension on
-        :param extension_id: The id of the extension
-        :param image_src: image source of an icon to display the toolbar instead of title
-        :return: status of call
+        Add an extension to the plot. Extensions are context menus that allows you to extend
+        what Firefly can do when certain actions happen.
+
+        Parameters
+        ----------
+        ext_type : {'AREA_SELECT', 'LINE_SELECT', or 'POINT'}
+            Extension type. It can be one of the values in the list,
+            or it will be reset to be 'NONE'.
+        plot_id : str, optional
+            Plot ID of the plot which the extension is added to, if not specified, then this request
+            applied to all plots in the same group of the active plot.
+        title : str, optional
+            The title for the extension.
+        tool_tip : str, optional
+            Tooltip for the extension.
+        extension_id : str, optional
+            Extension ID. It will be created automatically if not specifed.
+        image_src : str, optional
+            Image source of an icon to be displayed on the toolbar instead of the title.
+            Image source could be an image path or an image url.
+
+        Notes
+        -----
+        If image_src is not specified, then no extension is added.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
 
         if ext_type not in FireflyClient.EXTENSION_TYPE:
@@ -391,14 +706,24 @@ class FireflyClient(WebSocketClient):
 
     def set_zoom(self, plot_id, factor=1.0):
         """
-        Zoom the image
-        :param plot_id: plotId to which the region is added, parameter may be string or a list of strings.
-        :param factor: number, zoom factor for the image
-        :return:
+        Zoom the image.
+
+        Parameters
+        ----------
+        plot_id : str or a list of str
+            ID of the plot to be zoomed. If plot_id is a list or tuple, then each plot in the list
+            or the tuple is zoomed in order.
+        factor : numeric type
+            Zoom factor for the image.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
 
-        def zoom_oneplot(plot_id, factor):
-            payload = {'plotId': plot_id, 'userZoomType': 'LEVEL', 'level': factor, 'actionScope': 'SINGLE'}
+        def zoom_oneplot(one_plot_id, f):
+            payload = {'plotId': one_plot_id, 'userZoomType': 'LEVEL', 'level': f, 'actionScope': 'SINGLE'}
             return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['ZoomImage'], payload)
 
         if isinstance(plot_id, tuple) or isinstance(plot_id, list):
@@ -408,14 +733,23 @@ class FireflyClient(WebSocketClient):
 
     def set_pan(self, plot_id, x=None, y=None, coord='image'):
         """
-        Pan or scroll the image to center on the image coordinates passed
-        if no (x, y) is given, the image is recentered at the center of the image
-        :param plot_id: plot_id to which the region is added, parameter may be string or a list of strings.
-        :param x: number, new center x position to scroll to
-        :param y: number, new center y position to scroll to
-        :param coord: coordinate system, if coord == 'image', then x, y is for image pixel,
-        :                                if coord == 'J2000', then x, y is ra, dec on EQ_J2000.
-        :return:
+        Relocate the image to center on the given image coordinate or EQ_J2000 coordinate.
+        If no (x, y) is given, the image is recentered at the center of the image.
+
+        Parameters
+        ----------
+        plot_id : str or a list of str
+            ID of the plot to be panned. If plot_id is a list or tuple, then each plot in the list
+            or the tuple is panned in order.
+        x, y : numeric type
+            New center of x and y position to scroll to.
+        coord: {'image', 'J2000'}, optional
+            Coordinate system (the default is 'image').
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
 
         payload = {'plotId': plot_id}
@@ -427,22 +761,51 @@ class FireflyClient(WebSocketClient):
 
         return self.dispatch_remote_action(self.channel, FireflyClient.ACTION_DICT['PanImage'], payload)
 
-    def set_stretch(self, plot_id, type=None, algorithm=None, **additional_params):
+    def set_stretch(self, plot_id, stype=None, algorithm=None, **additional_params):
         """
-        Change the stretch of the image (no band case)
-        :param type: 'percent','maxmin','absolute','zscale', or 'sigma'
-        :param algorithm: 'linear', 'log','loglog','equal', 'squared', 'sqrt', 'asinh', 'powerlaw_gamma'
-        :param plot_id: plotId to which the range is added, parameter may be string or a list of strings.
-        :param additional_params:
-                for type is 'zscale', kwargs: zscale_contrast, zscale_samples, zscale_samples_perline
-                for type is others,   kwargs: lower_value, upper_value
-        :return: status of call
+        Change the stretch of the image (no band case).
+
+        Parameters
+        ----------
+        plot_id : str or a list of str
+            ID of the plot to be panned. If plot_id is a list or tuple, then each plot in the list
+            or the tuple is stretched in order.
+        stype : {'percent','maxmin','absolute','zscale', 'sigma'}, optional
+            Stretch method (the default is 'percent').
+        algorithm : {'linear', 'log','loglog','equal', 'squared', 'sqrt', 'asinh', 'powerlaw_gamma'}, optional
+            Stretch algorithm (the default is 'linear').
+        **additional_params
+            Additional parameters for image stretch. Please see the details in 'Other Parameters'.
+
+        Other Parameters
+        ----------------
+        zscale_contrast : numeric type
+            zscale contrast (the default is 25).
+        zscale_samples : int
+            zscale samples, int (the default is 600).
+        zscale_samples_perline : int
+            zscale samples per line (the default is 120).
+
+        lower_value : numeric type
+            Lower end of stretch (the default is 1).
+        uppler_value : numeric type
+            Upper end of stretch (the default is 90).
+
+        Notes
+        -----
+            `zscale_contrast`, `zscale_samples`, and `zscale_samples_perline` are for `stype = 'zscale'` case, and
+            `lower_value`, and `upper_value` are for other type cases.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
 
-        if type and type.lower() == 'zscale':
+        if stype and stype.lower() == 'zscale':
             serialized_rv = self._create_rangevalues_zscale(algorithm, **additional_params)
         else:
-            serialized_rv = self._create_rangevalues_standard(algorithm, type, **additional_params)
+            serialized_rv = self._create_rangevalues_standard(algorithm, stype, **additional_params)
 
         st_data = [{'band': 'NO_BAND', 'rv': serialized_rv, 'bandVisible': True}]
         payload = {'stretchData': st_data, 'plotId': plot_id}
@@ -456,17 +819,35 @@ class FireflyClient(WebSocketClient):
     def overlay_region_layer(self, file_on_server=None, region_data=None, title=None,
                              region_layer_id=None, plot_id=None):
         """
-        Overlay a region layer on the loaded FITS images, the regions are defiend either by a file or
-        by some text description
-        :param file_on_server: the is the name of the file on the server.  If you used upload_file()
-                                            then it is the return value of the method. Otherwise it
-                                            is a file that firefly has direct read access to.
-        :param region_data: region description, either a list of strings or a string
-        :param title: title of the region file
-        :param region_layer_id: id of layer to add
-        :param plot_id: plotId to which this region should be added, parameter may be string or
-                        a list of strings. If None then overlay region on all plots
-        :return: status of call
+        Overlay a region layer on the loaded FITS images. The regions are defined either by a file or
+        by text region description.
+
+        Parameters
+        ----------
+        file_on_server : str, optional
+            This is the name of the file on the server.  If you used upload_file()
+            then it is the return value of the method. Otherwise it
+            is a file that Firefly has direct read access to.
+        region_data: str or list of str, optional
+            Region description, either a list of strings or a string.
+        title : str, optional
+            Title of the region layer.
+        region_layer_id : str, optional
+            ID of the layer to be created. It is automatically created if not specified.
+        plot_id : str or a list of str, optional
+            ID of the plot that the region layer is created on.
+            If None,  then overlay region(s) on all plots in the same group of the active plot.
+
+        Notes
+        -----
+        file_on_server and region_data are exclusively required.
+        If both are specified, file_on_server takes the priority.
+        If none is specified, no region layer is created.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
 
         if not region_layer_id:
@@ -488,11 +869,20 @@ class FireflyClient(WebSocketClient):
 
     def delete_region_layer(self, region_layer_id, plot_id=None):
         """
-        Delete region layer on the loaded FITS images
-        :param region_layer_id: regionLayer to remove
-        :param plot_id: plotId to which the region layer should be removed, if None,
-                        then remove region layer from all plots
-        :return: status of call
+        Delete region layer from the loaded FITS images.
+
+        Parameters
+        ----------
+        region_layer_id : str
+            Region layer with the region_layer_id to be removed.
+        plot_id : str or a list of str
+            Plot ID. The region layer is removed from the plot with the plot id.
+            If not specified, then remove region layer from all plots in the same group of the active plot.
+
+        Returns
+        -------
+         out : dict
+            Status of the request, like {'success': true}.
         """
 
         payload = {'drawLayerId': region_layer_id}
@@ -504,11 +894,32 @@ class FireflyClient(WebSocketClient):
 
     def add_region_data(self, region_data, region_layer_id, title=None, plot_id=None):
         """
-        Add the specified region entries
-        :param region_data: a list of region entries
-        :param region_layer_id: id of region to remove entries from
-        :return: status of call
+        Add region entries to a region layer with the given ID.
+
+        Parameters
+        ----------
+        region_data : str or a list of str
+            Region entries to be added.
+        region_layer_id : str
+            ID of region layer where the entries are added to.
+        title : str, optional
+            Title of the region layer. If the layer exists, the original title is replaced.
+            If the layer doesn't exist, a new layer with the given title is created.
+        plot_id : str or a list of str, optional
+            Plot ID. This is for the case that the region layer doesn't exist.
+            If the region layer exists, this request applies to all plots attached to the layer.
+
+        Notes
+        -----
+            If no region layer with the given ID exists, a new region layer will be created
+            automatically just like how function 'overlay_region_layer' works.
+
+        Returns
+        -------
+        out : dict
+            Status of the request, like {'success': true}.
         """
+
         payload = {'regionChanges': region_data, 'drawLayerId': region_layer_id}
         if plot_id:
             payload.update({'plotId': plot_id})
@@ -520,10 +931,19 @@ class FireflyClient(WebSocketClient):
 
     def remove_region_data(self, region_data, region_layer_id):
         """
-        Remove the specified region entries
-        :param region_data: a list of region entries
-        :param region_layer_id: id of region to remove entries from
-        :return: status of call
+        Remove region entries from a region layer with the give ID.
+
+        Parameters
+        ----------
+        region_data : str or a list of str
+            Region entries to be removed.
+        region_layer_id : str
+            ID of the region layer where the region entries are removed from.
+
+        Returns
+        --------
+        out : dict
+            Status of the request, like {'success': true}.
         """
         payload = {'regionChanges': region_data, 'drawLayerId': region_layer_id}
 
@@ -533,16 +953,30 @@ class FireflyClient(WebSocketClient):
     def add_mask(self,  bit_number, image_number, plot_id, mask_id=None, color=None, title=None,
                  file_on_server=None):
         """
-        Add a mask layer
-        :param image_number: imageNumber of the mask layer
-        :param bit_number: bitNumber of the mask to overlay
-        :param plot_id: plot id to overlay the mask on
-        :param mask_id: id of mask
-        :param color: color as an html color (eg. #FF0000 (red) #00FF00 (green)
-        :param title: title of the mask layer
-        :param file_on_server: (optional) file to get the mask from,
-                                if None then get it from the original file
-        :return: status of call
+        Add a mask layer.
+
+        Parameters
+        ----------
+        image_number : int
+            Image number of the mask layer, HDU extension in fits.
+        bit_number : int
+            Bit number of the mask to overlay.
+        plot_id : str
+            ID of the plot to overlay the mask on.
+        mask_id : str, optional
+            Mask ID. It will be created automatically if not specified.
+        color : str, optional
+            Color as an html color (eg. #FF0000 (red) #00FF00 (green). A color will be
+            created in default if not specified.
+        title : str, optional
+            Title of the mask layer.
+        file_on_server : str, optional
+            File to get the mask from. The mask will be taken from the original file if not specified.
+
+        Returns
+        --------
+        out : dict
+            Status of the request, like {'success': true}.
         """
 
         if not mask_id:
@@ -562,10 +996,19 @@ class FireflyClient(WebSocketClient):
 
     def remove_mask(self, plot_id, mask_id):
         """
-        Remove a mask layer
-        :param plot_id: plot id of the overlay the mask is on
-        :param mask_id: id of mask
-        :return: status of call
+        Remove a mask layer from the plot with the given plot ID.
+
+        Parameters
+        ----------
+        plot_id : str
+            ID of the plot where the mask layer to be removed from.
+        mask_id: str
+            ID of the mask layer to be removed.
+
+        Returns
+        --------
+        out : dict
+            Status of the request, like {'success': true}
         """
 
         payload = {'plotId': plot_id, 'imageOverlayId': mask_id}
@@ -576,7 +1019,8 @@ class FireflyClient(WebSocketClient):
     # Range Values
     # -----------------------------------------------------------------
 
-    def _create_rv(self, stretch_type, lower_value, upper_value, algorithm,
+    @staticmethod
+    def _create_rv(stretch_type, lower_value, upper_value, algorithm,
                    zscale_contrast=25, zscale_samples=600, zscale_samples_perline=120,
                    beta_value=0.1, gamma_value=2.0):
         retval = None
@@ -593,11 +1037,23 @@ class FireflyClient(WebSocketClient):
 
     def _create_rangevalues_standard(self, algorithm, stretch_type='Percent', lower_value=1, upper_value=99):
         """
-        :param algorithm: must be 'Linear', 'Log','LogLog','Equal','Squared', 'Sqrt'
-        :param stretch_type: must be 'Percent','Absolute','Sigma'
-        :param lower_value: number, lower end of stretch
-        :param upper_value: number, upper end of stretch
-        :return: a serialized range values string
+        Create range values for non-zscale cases.
+
+        Parameters
+        -----------
+        algorithm : {'Linear', 'Log','LogLog','Equal','Squared', 'Sqrt'}
+            Stretch algorithm.
+        stretch_type : {'Percent','Absolute','Sigma'}
+            Stretch type.
+        lower_value: numeric type
+            Lower end of stretch.
+        upper_value: numeric type
+            Upper end of stretch
+
+        Returns
+        -------
+        out : str
+            a serialized range values string
         """
 
         retval = self._create_rv(stretch_type, lower_value, upper_value, algorithm)
@@ -610,12 +1066,25 @@ class FireflyClient(WebSocketClient):
     def _create_rangevalues_zscale(self, algorithm, zscale_contrast=25,
                                    zscale_samples=600, zscale_samples_perline=120):
         """
-        :param algorithm: must be 'Linear', 'Log','LogLog','Equal','Squared', 'Sqrt'
-        :param zscale_contrast: zscale contrast
-        :param zscale_samples: zscale samples
-        :param zscale_samples_perline: zscale sample per line
-        :return: a serialized range values string
+        Create range values for zscale case.
+
+        Parameters
+        ----------
+        algorithm: {'Linear', 'Log','LogLog','Equal','Squared', 'Sqrt'}
+            Stretch algorithm.
+        zscale_contrast: numeric type
+            Zscale contrast.
+        zscale_samples: int
+            Zscale samples
+        zscale_samples_perline: int
+            Zscale samples per line
+
+        Returns
+        -------
+        out : str
+            a serialized range values string
         """
+
         retval = self._create_rv('zscale', 1, 1, algorithm,
                                  zscale_contrast, zscale_samples, zscale_samples_perline)
         if not retval:
@@ -626,9 +1095,17 @@ class FireflyClient(WebSocketClient):
     @classmethod
     def _gen_item_id(cls, item):
         """
-        generate an ID for some entity like 'Table', 'RegionLayer', 'Extension'
-        :param item: entity type
-        :return: an ID string
+        Generate an ID for table, region layer, or extension entity.
+
+        Parameters
+        ----------
+        item : {'Table', 'RegionLayer', 'Extension'}
+            Entity type.
+
+        Returns
+        -------
+        out : str
+            ID string.
         """
 
         if item in cls._item_id:
@@ -637,19 +1114,3 @@ class FireflyClient(WebSocketClient):
         else:
             return None
 
-    @staticmethod
-    def create_image_url(image_source):
-        """
-        create image url according to image source
-        :param image_source: an image path or image url
-        :return:
-        """
-
-        def is_url(url):
-            return urlparse.urlparse(url).scheme != ''
-
-        if not image_source.startswith('data:image') and not is_url(image_source):
-            data_uri = open(image_source, 'rb').read().encode('base64').replace('\n', '')
-            return 'data:image/png;base64,%s' % data_uri
-
-        return image_source


### PR DESCRIPTION
Document Python API in 'docstrings' by following 'LSST DM Developer Guide' for documenting Python code. 
A simple Sphinx setup has been used to convert the implementation to HTML page. More detail format verification will be made after LSST documentation tool for Python is released. 