### PR TITLE
DM-7448: Table reset unset option 'Show unit' initially set

### DIFF
--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -113,6 +113,7 @@ function buildTablePart(llApi) {
     /**
      * @typedef {object} TblOptions    table options
      * @prop {string}  tbl_group    the group this table belongs to.  Defaults to 'main'.
+     * @prop {number}  pageSize     the starting page size.  Will use the request's pageSize if not given.
      * @prop {boolean} removable    true if this table can be removed from view.  Defaults to true.
      * @prop {boolean} showUnits    defaults to false
      * @prop {boolean} showFilters  defaults to false

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -12,15 +12,14 @@ import {fetchUrl} from '../util/WebUtil.js';
 
 export class TableConnector {
     
-    constructor(tbl_id, tbl_ui_id, tableModel, showUnits=true, showFilters=false) {
+    constructor(tbl_id, tbl_ui_id, tableModel, showUnits=true, showFilters=false, pageSize) {
         this.tbl_id = tbl_id;
         this.tbl_ui_id = tbl_ui_id;
         this.localTableModel = tableModel;
 
-        this.origPageSize = get(this.tableModel, 'request.pageSize', 100);
+        this.origPageSize = pageSize;
         this.origShowUnits = showUnits;
         this.origShowFilters = showFilters;
-        this.origColumns = cloneDeep(get(tableModel, 'tableData.columns', []));
     }
 
     onSort(sortInfoString) {
@@ -153,8 +152,8 @@ export class TableConnector {
                         showFilters: this.origShowFilters});
     }
 
-    static newInstance(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters) {
-        return new TableConnector(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters);
+    static newInstance(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize) {
+        return new TableConnector(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize);
     }
 }
 

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -201,9 +201,10 @@ export function tableSearch(action) {
     return (dispatch) => {
         //dispatch(validate(FETCH_TABLE, action));
         if (!action.err) {
-            var {request, options, tbl_group} = action.payload;
+            var {request={}, options={}, tbl_group} = action.payload;
             const {tbl_id} = request;
             const title = get(request, 'META_INFO.title');
+            request.pageSize = options.pageSize = options.pageSize || request.pageSize || 100;
 
             dispatchTableFetch(request);
             if (!TblUtil.getTableInGroup(tbl_id, tbl_group)) {

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -238,14 +238,14 @@ const TextView = ({columns, data, showUnits, widthPx, heightPx}) => {
 };
 
 function makeColWidth(columns, showUnits) {
-    return !columns ? {} : columns.reduce((widths, col) => {
+    return !columns ? {} : columns.reduce((widths, col, idx) => {
         const label = col.name;
         var nchar = col.prefWidth;
         const unitLength = showUnits ? get(col, 'units.length', 0) : 0;
         if (!nchar) {
             nchar = Math.max(label.length+2, unitLength+2, get(col,'width', 0)); // 2 is for padding and sort symbol
         }
-        widths[col.name] = nchar * 7;
+        widths[idx] = nchar * 7;
         return widths;
     }, {});
 }
@@ -268,7 +268,7 @@ function makeColumns ({columns, columnWidths, data, selectable, showUnits, showF
                 header={<HeadRenderer {...{col, showUnits, showFilters, filterInfo, sortInfo, onSort, onFilter}} />}
                 cell={<CellRenderer style={style} data={data} colIdx={idx} />}
                 fixed={fixed}
-                width={columnWidths[col.name]}
+                width={columnWidths[idx]}
                 isResizable={true}
                 allowCellsRecycling={true}
             />

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -32,13 +32,13 @@ const TT_EXPAND = 'Expand this panel to take up a larger area';
 export class TablePanel extends Component {
     constructor(props) {
         super(props);
-        var {tbl_id, tbl_ui_id, tableModel} = props;
+        var {tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize} = props;
 
         if (!tbl_id && tableModel) {
             tbl_id = get(tableModel, 'tbl_id', TblUtil.uniqueTblId());
         }
         tbl_ui_id = tbl_ui_id || TblUtil.uniqueTblUiId();
-        this.tableConnector = TableConnector.newInstance(tbl_id, tbl_ui_id, tableModel, this.props.showUnits, this.props.showFilters);
+        this.tableConnector = TableConnector.newInstance(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize);
         const uiState = TblUtil.getTableUiById(tbl_ui_id);
         this.state = Object.assign({}, this.props, uiState);
 

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -121,10 +121,10 @@ function StandardView(props) {
 
 // eslint-disable-next-line
 function SingleTable({table, expandedMode}) {
-    var {tbl_id, title, removable, tbl_ui_id} = table;
+    var {tbl_id, title, removable, tbl_ui_id, options={}} = table;
 
     return  (
-        <TablePanel key={tbl_id} border={true} {...{title, removable, tbl_id, tbl_ui_id, expandedMode}} />
+        <TablePanel key={tbl_id} border={true} {...{title, removable, tbl_id, tbl_ui_id, ...options, expandedMode}} />
     );
 }
 
@@ -132,13 +132,13 @@ function tablesAsTab(tables, expandedMode) {
 
     return tables &&
         Object.keys(tables).map( (key) => {
-            var {tbl_id, title, removable, tbl_ui_id} = tables[key];
+            var {tbl_id, title, removable, tbl_ui_id, options={}} = tables[key];
             const onTabRemove = () => {
                 dispatchTableRemove(tbl_id);
             };
             return  (
                 <Tab key={tbl_ui_id} name={title} removable={removable} onTabRemove={onTabRemove}>
-                    <TablePanel key={tbl_id} border={false} showTitle={false} {...{tbl_id, tbl_ui_id, expandedMode}} />
+                    <TablePanel key={tbl_id} border={false} showTitle={false} {...{tbl_id, tbl_ui_id, ...options, expandedMode}} />
                 </Tab>
             );
         } );


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-7448

Reset button does not work when options are set explicitly.

This the demo page below, the first table has showUnits and showFilters set to true.  It used to work reset properly.  
http://localhost:8080/firefly/demo/ffapi-highlevel-test.html
