### PR TITLE
DM-7460 No help link/anchor option for XY-Plot

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -205,7 +205,7 @@
             firefly.showTable('tables-2', tblReq2, {removable: false, showUnits: true, showFilters: true});
             //-----------------  CHART DEMO ------------------------//
             //--- using QUERY_ID: 'upload' does not work getActiveTableId('upload') returns undefined ---//
-            firefly.addXYPlot('xyPlot1', {tbl_id: tblReq2.tbl_id, xCol: 'ra', yCol: 'dec'});
+            firefly.addXYPlot('xyPlot1', {tbl_id: tblReq2.tbl_id, xCol: 'ra', yCol: 'dec', help_id: 'visualization.xyplotViewer'});
             firefly.addXYPlot('xyPlot2', {tbl_id: tblReq2.tbl_id, xCol: 'w1mpro+w4mpro', yCol: 'w2mpro'});
 
             //-----< old table api ------//

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -374,7 +374,7 @@ function doShowXYPlot(llApi, targetDiv, params={}) {
         params = oldApiParams;
     }
 
-    const {xCol, yCol, xyRatio, stretch, xLabel, yLabel, xUnit, yUnit, xOptions, yOptions} = params;
+    const {xCol, yCol, xyRatio, stretch, xLabel, yLabel, xUnit, yUnit, xOptions, yOptions, help_id} = params;
     const xyPlotParams = xCol && yCol ?
     {
         xyRatio,
@@ -423,7 +423,8 @@ function doShowXYPlot(llApi, targetDiv, params={}) {
             closeable: false,
             expandedMode: false,
             chartType: 'scatter',
-            deletable: false
+            deletable: false,
+            help_id
         }
     );
 }

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {has, get, isUndefined, omit} from 'lodash';
+import {has, get, isUndefined, omit, omitBy} from 'lodash';
 import shallowequal from 'shallowequal';
 
 import {flux} from '../Firefly.js';
@@ -24,10 +24,11 @@ export const DELETE = `${UI_PREFIX}/delete`;
  * request to put a chart into an expanded mode.
  * @param {string} chartId - chart id
  * @param {string} tblId - table id, to which this chart is related. Acts as a group id
- * @param {string} chartType (ex. scatter, histogram)
+ * @param {string} chartType - chart type (ex. scatter, histogram)
+ * @param {string} [help_id] - help anchor string
  */
-export function dispatchChartExpanded(chartId, tblId, chartType) {
-    flux.process( {type: CHART_UI_EXPANDED, payload: {chartId, tblId, chartType}});
+export function dispatchChartExpanded(chartId, tblId, chartType, help_id) {
+    flux.process( {type: CHART_UI_EXPANDED, payload: {chartId, tblId, chartType, help_id}});
 }
 
 /*
@@ -120,10 +121,10 @@ const chartActions = [CHART_UI_EXPANDED,CHART_MOUNTED,CHART_UNMOUNTED,DELETE];
  */
 function reduceUI(state={}, action={}) {
     if (chartActions.indexOf(action.type) > -1) {
-        const {chartId, tblId, chartType}  = action.payload;
+        const {chartId, tblId, chartType, help_id}  = action.payload;
         switch (action.type) {
             case (CHART_UI_EXPANDED) :
-                return updateSet(state, 'expanded', {chartId, tblId, chartType});
+                return updateSet(state, 'expanded', omitBy({chartId, tblId, chartType, help_id}, isUndefined));
             default:
                 return state;
         }

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -17,9 +17,9 @@ import {getExpandedChartProps} from '../ChartsCntlr.js';
 
 
 function nextState(props) {
-    const {closeable, chartId, tblId, chartType, optionsPopup} = props;
+    const {closeable, chartId, tblId, chartType, help_id} = props;
     const expandedMode = props.expandedMode && getExpandedMode() === LO_VIEW.xyPlots;
-    const chartProps = expandedMode ? getExpandedChartProps() : {chartId, tblId, chartType, optionsPopup};
+    const chartProps = expandedMode ? getExpandedChartProps() : {chartId, tblId, chartType, help_id};
     return Object.assign({expandedMode,closeable}, chartProps);
 }
 

--- a/src/firefly/js/charts/ui/ChartsTableViewPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartsTableViewPanel.jsx
@@ -20,6 +20,7 @@ import * as HistogramCntlr from '../HistogramCntlr.js';
 import * as XYPlotCntlr from '../XYPlotCntlr.js';
 import {dispatchChartExpanded, dispatchDelete, dispatchChartMounted, dispatchChartUnmounted} from '../ChartsCntlr.js';
 import {LO_MODE, LO_VIEW, dispatchSetLayoutMode} from '../../core/LayoutCntlr.js';
+import {HelpIcon} from '../../ui/HelpIcon.jsx';
 import {SCATTER, HISTOGRAM, getChartSpace, getHighlighted, getTblIdForChartId, numRelatedCharts} from '../ChartUtil.js';
 import {XYPlotOptions} from './XYPlotOptions.jsx';
 import {XYPlot} from './XYPlot.jsx';
@@ -394,7 +395,7 @@ class ChartsPanel extends React.Component {
     }
 
     renderToolbar() {
-        const {expandable, expandedMode, tblId, chartId, chartType, deletable} = this.props;
+        const {expandable, expandedMode, tblId, chartId, chartType, deletable, help_id} = this.props;
         return (
             <div role='toolbar' className='ChartPanel__toolbar'>
                 <div className='group'>
@@ -431,10 +432,11 @@ class ChartsPanel extends React.Component {
                          title='Expand this panel to take up a larger area'
                          src={OUTLINE_EXPAND}
                          onClick={() => {
-                            dispatchChartExpanded(chartId, tblId, chartType);
+                            dispatchChartExpanded(chartId, tblId, chartType, help_id);
                             dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.xyPlots);
                          }}
                     />}
+                    { help_id && <div style={{paddingLeft: 4, marginTop: -10}}> <HelpIcon helpId={help_id} /> </div>}
                     { expandable && !expandedMode &&
                     (isBoolean(deletable) ? deletable : numRelatedCharts(tblId) > 1) &&  // when deletable is undefined, use related charts criterion
                     <img style={{alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}
@@ -499,6 +501,7 @@ ChartsPanel.propTypes = {
     expandedMode: PropTypes.bool,
     expandable: PropTypes.bool,
     deletable : PropTypes.bool,
+    help_id: PropTypes.string, // anchor to the documentation
     tblId : PropTypes.string,
     tableModel : PropTypes.object,
     tblStatsData : PropTypes.object,


### PR DESCRIPTION
Provide help_id option to define help anchor string.
If firefly is built locally, an example can be found in the first chart at
  http://localhost:8080/firefly/demo/ffapi-highlevel-test.html 