### PR TITLE
DM-7511: add JSDoc generation into build system.

### DIFF
--- a/buildScript/depends.gincl
+++ b/buildScript/depends.gincl
@@ -109,17 +109,42 @@ task buildClient (dependsOn: loadConfig) {
   inputs.dir "${fireflyPath}/src/firefly/js"
 
   doLast {
-    def res = project.ext.NPM 'run', 'build'
+    if (!file("webpack.config.js").exists()) {
+      println ">> webpack.config.js not found.  Skipping buildClient."
+      throw new StopExecutionException("webpack.config.js not found.  Skipping buildClient.")
+    }
+    def res = project.ext.NODE 'npm', 'run', 'build'
     if (res.getExitValue() != 0) {
       throw new GradleException("Fail to build Client")
     }
   }
 }
 
+task buildJsDoc (dependsOn: loadConfig) {
+  def outdir = "${buildDir}/gwt/${project['app-name']}"
+
+  outputs.dir outdir
+  inputs.dir "${projectDir}"
+  inputs.dir "${fireflyPath}/docs"
+  inputs.dir "${fireflyPath}/src/firefly"
+
+  doLast {
+    if (!file("jsdoc_config.json").exists()) {
+      println ">> jsdoc_config.json not found.  Skipping buildJsDoc."
+      throw new StopExecutionException("jsdoc_config.json not found.  Skipping buildJsDoc.")
+    }
+    def res = project.ext.NODE "${fireflyPath}/node_modules/.bin/jsdoc", '-c', 'jsdoc_config.json', '-d', "${outdir}/jsdoc"
+    if (res.getExitValue() != 0) {
+      throw new GradleException("Fail to build Client")
+    }
+  }
+}
+
+
 /**
- * this function setup npm environment then run the given command.
+ * this function setup node.js environment then run the given command.
  */
-ext.NPM = { ...cmd ->
+ext.NODE = { ...cmd ->
   def wpBuildDir = "${buildDir}/gwt/${project['app-name']}"
   def tag = "v" + getVersionTag() + ' Built On:' + build_time;
 
@@ -128,11 +153,6 @@ ext.NPM = { ...cmd ->
   } catch (Exception e) {
     println ">> Task failed due to missing npm package manager which comes bundled with node.js"
     throw new GradleException("Task failed due to missing npm package manager which comes bundled with node.js", e)
-  }
-
-  if (!file("webpack.config.js").exists()) {
-    println ">> webpack.config.js not found.  Skipping buildClient."
-    throw new StopExecutionException("webpack.config.js not found.  Skipping buildClient.")
   }
 
   if (file("${rootDir}/package.json").exists()) {
@@ -150,8 +170,7 @@ ext.NPM = { ...cmd ->
     environment '__$help_base_url': project.appConfigProps['help.base.url']
     environment 'WP_BUILD_DIR': wpBuildDir
     environment 'NODE_ENV': (project.env == 'local' ? 'development' : 'production')
-    executable "npm"
-    args cmd
+    commandLine cmd
   }
   return res;
 }

--- a/buildScript/gwt.gincl
+++ b/buildScript/gwt.gincl
@@ -168,7 +168,7 @@ task devMode (dependsOn: loadConfig) {
   outputs.upToDateWhen { false }
 
   doLast {
-    def res = project.ext.NPM 'run', 'dev'
+    def res = project.ext.NODE 'npm', 'run', 'dev'
     if (res.getExitValue() == 0) {
       throw new GradleException("Fail to run dev mode")
     }

--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -167,7 +167,7 @@ task deploy (dependsOn: [loadConfig, webapp]) << {
 }
 
 task buildAndDeploy( dependsOn:[war, deploy] )
-
+task buildAllAndDeploy( dependsOn:[war, buildJsDoc, deploy] )
 
 task buildAndPublish( dependsOn: war ) << {
   description= 'Build the war file and then publish it to a remote host. Property ${publish_host} is required'
@@ -248,6 +248,7 @@ task publishToGithub (dependsOn: loadConfig) {
 //-------------------------
 loadConfig.mustRunAfter gwt
 buildClient.mustRunAfter prepareWebapp
+buildJsDoc.mustRunAfter prepareWebapp
 prepareWebapp.mustRunAfter gwtCompile
 gwtCompile.mustRunAfter jar
 deploy.mustRunAfter war

--- a/src/firefly/config/web.xml
+++ b/src/firefly/config/web.xml
@@ -207,6 +207,7 @@
     </mime-mapping>
 
     <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
         <welcome-file>@launch.page@</welcome-file>
     </welcome-file-list>
 

--- a/src/firefly/jsdoc_config.json
+++ b/src/firefly/jsdoc_config.json
@@ -5,12 +5,12 @@
     },
     "source": {
         "include": [
-           "src/firefly/js/api/",
-           "src/firefly/js/tables/TableUtil.js",
-           "src/firefly/js/charts/XYPlotCntlr.js",
-           "src/firefly/js//visualize/CsysConverter.js",
-           "src/firefly/js/visualize/DrawLayerCntlr.js",
-           "docs/firefly-api-overview.md"
+           "./js/api/",
+           "./js/tables/TableUtil.js",
+           "./js/charts/XYPlotCntlr.js",
+           "./js//visualize/CsysConverter.js",
+           "./js/visualize/DrawLayerCntlr.js",
+           "../../docs/firefly-api-overview.md"
 
         ],
       "exclude": [
@@ -33,8 +33,8 @@
         "extensions": ["js", "jsx"]
     },
    "staticFiles": {
-        "include": ["./docs"],
-        "exclude": ["./docs/firefly-api-code-examples.md"],
+        "include": ["../../docs"],
+        "exclude": ["../../docs/firefly-api-code-examples.md"],
         "includePattern": ".+\\.md?$",
         "recursive": true
 
@@ -42,27 +42,26 @@
 
 
     "opts": {
-        "template": "node_modules/ink-docstrap/template", //use the minami template insetad of the default
+        "template": "../../node_modules/ink-docstrap/template", //use the docstrap template insetad of the default
         "encoding": "utf8",                               // same as -e utf8
-        "destination": "src/firefly/jsdoc/",              // same as -d ./out/
         "recurse": true ,                                 // same as -r
-        "tutorials": "./tutorial/",                      // same as -u path/to/tutorials
+        "tutorials": "../../tutorial/",                      // same as -u path/to/tutorials
         "access": "all"                                  //same as -a  <value>, values are all, public, private etc
 
     },
     "templates": {
-        "cleverLinks": false,
-        "monospaceLinks": false,
-        "useLongnameInNav": true,
-        "include": ["./docs/"],
-        "exclude": ["./docs/firefly-api-code-examples.md"],
-        "recursive": true,
-        "outputSourceFiles":true,
-        "includeDate":true,
-        "navType"               : "vertical",
-        "linenums":true,
-        "collapseSymbols": true,
-        "systemName" : "Firefly"
+        "cleverLinks" : false,
+        "monospaceLinks" : false,
+        "useLongnameInNav" : true,
+        "recursive" : true,
+        "outputSourceFiles" :true,
+        "includeDate" :true,
+        "navType" : "vertical",
+        "inverseNav" : true,
+        "linenums" :true,
+        "collapseSymbols" : false,
+        "systemName" : "Firefly",
+        "theme" : "spacelab"
     }
 
 }


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-7511

- Added buildJsDoc task to gradle build system to generate JS docs.
- Changed theme to match firefly's L&F.
   - This is open for discussion.  I am not adamant about this.

To build war plus JS docs and deploy it, use
`gradle :firefly:buildAllAndDeploy`  or `gradle :fi:bAA`

To see deployed JS docs, http://localhost:8080/firefly/jsdoc/