### PR TITLE
DM-7543: color backgrnd image viewer inline tool change

### DIFF
--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -158,7 +158,7 @@ function contextToolbar(pv,dlAry,extensionList) {
 
 
 const bgSlightGray= {background: 'rgba(255,255,255,.2)'};
-
+const bgFFGray= {background: '#e3e3e3'};
 
 function makeInlineRightToolbar(visRoot,pv,dlAry,mousePlotId, handleInlineTools, showDelete) {
     if (!pv) return false;
@@ -184,7 +184,7 @@ function makeInlineRightToolbar(visRoot,pv,dlAry,mousePlotId, handleInlineTools,
     var lVis= BrowserInfo.isTouchInput() || (visRoot.apiToolsView && mousePlotId===pv.plotId);
     var exVis= BrowserInfo.isTouchInput() || mousePlotId===pv.plotId;
     var tb= !isExpanded && visRoot.apiToolsView;
-    const style= (lVis || tb) && handleInlineTools ? bgSlightGray : {};
+    const style= (lVis || tb) && handleInlineTools ? bgFFGray : bgSlightGray;
     return (
         <div style={style} className='iv-decorate-inline-toolbar-container'>
             <VisInlineToolbarView

--- a/src/firefly/js/visualize/iv/PlotTitle.css
+++ b/src/firefly/js/visualize/iv/PlotTitle.css
@@ -8,10 +8,10 @@
     position : absolute;
     left : 0;
     top : 0;
-    padding : 2px 0 0 2px;
-    color : white;
-    background : rgba(0,0,255,.5);
-    whiteSpace : nowrap;
+    padding : 0 5px 0 2px;
+    /*color : white;*/
+    background : #e3e3e3;/*rgba(255,255,255,.2);*/
+    white-space : nowrap;
     font-size : 9pt;
     border-radius : 0 0 5px 0;
 }
@@ -22,7 +22,7 @@
     padding : 1px 0 0 2px;
     color : black;
     /*background : white;*/
-    whiteSpace : nowrap;
+    white-space : nowrap;
     font-size : 9pt;
 }
 


### PR DESCRIPTION
Please, have a look to this change. The ticket suppose to solve the consistency with the rest of the color to be more consistent and readable. Blue is not consistent with the rest (grey) and the zoom level is not readable. Sometimes the inline tool icons (top right-hand side) are not apparent enough.

This is step 1 change: making the background to be the same grey color on image viewer left and right, and plot title black, zoom level label red.

Another proposed solution is step 2:  black font on white background if step 1 doesn't solve the issue.

Thanks.