### PR TITLE
DM-7593: use phase folded code in processor and update test

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PhaseFoldedCurveProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PhaseFoldedCurveProcessor.java
@@ -73,12 +73,8 @@ public class PhaseFoldedCurveProcessor extends IpacTablePartProcessor {
     }
 
     protected File phaseFoldedTable(PeriodogramAPIRequest req) throws InterruptedException {
-        //Fake building phase folded
-        Thread.sleep(5000);
 
-
-        File phaseFoldedTable = irsaLcHandler.toPhaseFoldedTable(getSourceFile(req.getLcSource(), req), req.getPeriod());
-
+        File phaseFoldedTable = irsaLcHandler.toPhaseFoldedTable(getSourceFile(req.getLcSource(), req), req.getPeriod(), req.getTimeColName());
 
         return phaseFoldedTable;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PhaseFoldedLightCurve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PhaseFoldedLightCurve.java
@@ -1,11 +1,12 @@
-package edu.caltech.ipac.firefly.server.query;
+package edu.caltech.ipac.firefly.server.query.lc;
 
 import edu.caltech.ipac.astro.IpacTableException;
+import edu.caltech.ipac.astro.IpacTableWriter;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupReader;
 import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.DataObject;
 import edu.caltech.ipac.util.DataType;
-import edu.caltech.ipac.astro.IpacTableWriter;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -32,10 +33,17 @@ public class PhaseFoldedLightCurve {
         if (!dg.containsKey(timeColName)) {
             throw new IpacTableException("The data does not contain the column: " + timeColName);
         }
+        if (period<=0) {
+            throw new IpacTableException("Period should be positive, but value passed = " + period);
+        }
 
         //Add a new data type and colunm: phase
         DataType phaseType = new DataType("phase", "phase", Double.class, DataType.Importance.HIGH, null, false);
         //DataType phaseType = new DataType("phase", Double.class);
+
+        // TODO DM-7594 / DM-7595:
+        // phaseType.setFormatInfo... and attribute to appear as description in ipac table header.
+
         dg.addDataDefinition(phaseType);
 
         //Find the minimum time:

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -95,7 +95,7 @@ export class TestQueriesPanel extends Component {
                                 <div>{renderLoadRegion(fields)}</div>
                             </Tab>
                             <Tab name='Compute Periodogram' id='periodogram'>
-                                <div>{renderPeriodogram()}</div>
+                                <div>{renderPeriodogram(fields)}</div>
                             </Tab>
                         </FieldGroupTabs>
 
@@ -122,7 +122,7 @@ function hideSearchPanel() {
     dispatchHideDropDown();
 }
 
-function renderPeriodogram() {
+function renderPeriodogram(fields) {
 
     /**
      *
@@ -131,6 +131,7 @@ function renderPeriodogram() {
     function lightCurveSubmit(isPeriodogram) {
         console.log('periodogram...');
         let tReq;
+        const ds = get(fields, 'period.value', 1);
         //var tReq = makeTblRequest('PhaseFoldedProcessor', 'Phase folded', { period: '1', 'table_name':'folded_table','original_table':});
         if (isPeriodogram) {
             tReq = makeTblRequest('LightCurveProcessor', 'Periodogram', {
@@ -139,13 +140,15 @@ function renderPeriodogram() {
             });
         } else {
             tReq = makeTblRequest('PhaseFoldedProcessor', 'Phase folded', {
-                'period_days': '1',
+                'period_days': ds,
                 'table_name': 'folded_table',
+                'time_col_name':'mjd',
                 //'original_table': 'file:///Users/ejoliet/Documents/IPAC/ipac_samples/AllWISE-MEP-m82-2targets-10arsecs.tbl'
-                'original_table': 'http://web.ipac.caltech.edu/staff/ejoliet/demo/AllWISE-MEP-m82-2targets-10arsecs.tbl'
+                'original_table': 'http://web.ipac.caltech.edu/staff/ejoliet/demo/OneTarget-27-AllWISE-MEP-m82-2targets-10arsecs.tbl'
             });
         }
-
+        console.log(ds);
+        console.log('tReq ' +tReq);
         dispatchTableSearch(tReq);
     }
 
@@ -163,7 +166,7 @@ function renderPeriodogram() {
             <ValidationField fieldKey='period'
                              initialState={{
                                           fieldKey: 'period',
-                                          value: '0.0',
+                                          value: '1.0',
                                           tooltip: 'period',
                                           label : 'period:',
                                           labelWidth : 100

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/PhaseFoldedLightCurveTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/PhaseFoldedLightCurveTest.java
@@ -1,11 +1,9 @@
 package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.astro.IpacTableException;
-import edu.caltech.ipac.firefly.server.query.PhaseFoldedLightCurve;
+import edu.caltech.ipac.firefly.server.query.lc.PhaseFoldedLightCurve;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupReader;
 import edu.caltech.ipac.util.DataGroup;
-import edu.caltech.ipac.util.DataObject;
-import edu.caltech.ipac.util.DataType;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Please review this PR which make use of the phase folded code, updating phase folded processor and tests.
To see in action, go to 

http://localhost:8080/firefly/firefly-dev.html

And click 'compute periodogram' tab.
Change period and phase fold.

The phase folded request built can be seen here: js/ui/TestQueriesPanel.jsx:142

The phase column displays '0.0' which is not enough (see ticket [DM-7593])
