### PR TITLE
DM-7462: create dispatch function, rendering style and stored status  for region selection

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -81,6 +81,15 @@
     <input type='text' placeholder='' list='regionCreated' id='createRegionId' name='createRegionLayer' onChange='updateDatalist()'>
     <datalist id='regionCreated'>
     </datalist>
+    color: <input type='text' id='selectColor' value='#DAA520' style="width: 60px">
+    lineWidth: <input type='text' id='lineWidth' value='0' style="width: 30px">
+    <select id='selectStyle'>
+        <option value='UprightBox'>Upright box</option>
+        <option value='DottedOverlay'>Overlay with dotted border</option>
+        <option value='SolidOverlay'>Overlay with differet color</option>
+        <option value='DottedReplace'>Replace with dotted border</option>
+        <option value='SolidReplace'>Replace with differnt color</option>
+    </select>
     <a href='javascript:deleteRegionLayer()'>Delete Region Layer</a>
     <select id='regionList_delete'><option selected disabled>Region Layer:</option></select>
     <div>
@@ -94,6 +103,11 @@
     <select id='regionEntry_remove'><option selected disabled>Regiion Layers:</option></select>
     <div>
         <textarea id="moreRegionContent" style="width: 800px; height: 300px; margin: 10px;"> </textarea>
+    </div>
+    <a href='javascript:selectRegion()'>Select the following region(s):</a>
+    <select id='regionEntry_select'><option selected disabled>Region Layers:</option></select>
+    <div>
+        <textarea id='selectRegionContent' style='width: 800px; height: 300px; margin: 10px;'></textarea>
     </div>
 </div>
 
@@ -322,6 +336,7 @@
 
             document.getElementById('regionLayerContent').value = window.regionAry.join('\n');
             document.getElementById('moreRegionContent').value = window.moreRegionAry.join('\n');
+            document.getElementById('selectRegionContent').value = window.regionAry2[13];
             //document.getElementById('createRegionId').placeholder = "Region_Plot_" + (window.regionId+1);
             updateRegionLayerList();
         };
@@ -335,7 +350,8 @@
                 document.getElementById('createRegionId').value = layerId;
 
             }
-
+            document.getElementById('regionLayerContent').value = window.regionAry2.join('\n');
+/*
             if (window.regionId === 0) {
                 document.getElementById('regionLayerContent').value = window.emptyRegion;
             } else if (window.regionId === 3) {  // region with error
@@ -347,13 +363,19 @@
             } else if (window.regionId > 3) {    // longer region list
                 document.getElementById('regionLayerContent').value = window.regionAry2.join('\n');
             }
-
+*/
             var regionAry = document.getElementById('regionLayerContent').value.split('\n').filter(function(r) { return (r.length !== 0);});
             window.regions.push(layerId);
             updateRegionLayerList();
 
-            firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, 'regiontest');
-            firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, null, window.ffViewer.dispatch);
+            var st = document.getElementById('selectStyle').value;
+            var lw = parseInt(document.getElementById('lineWidth').value);
+            var sc = document.getElementById('selectColor').value;
+            var selectMode = {selectStyle: st, selectColor: sc, lineWidth: lw};
+            //var selectMode = {selectStyle: style};
+
+            firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, 'regiontest', selectMode);
+            firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, null, selectMode, dispatcher = window.ffViewer.dispatch);
         };
 
         updateDataList = function() {
@@ -370,7 +392,7 @@
         };
 
         updateRegionLayerList = function() {
-            var selectListIds = ['regionList_delete', 'regionEntry_add', 'regionEntry_remove'];
+            var selectListIds = ['regionList_delete', 'regionEntry_add', 'regionEntry_remove', 'regionEntry_select'];
 
             selectListIds.forEach( function(selectId) {
                 var selectBox = document.getElementById(selectId);
@@ -401,7 +423,7 @@
                 updateRegionLayerList();
 
                 firefly.action.dispatchDeleteRegionLayer(selectedLayerId, 'regiontest');
-                firefly.action.dispatchDeleteRegionLayer(selectedLayerId, null, window.ffViewer.dispatch);
+                firefly.action.dispatchDeleteRegionLayer(selectedLayerId, null, dispatcher = window.ffViewer.dispatch);
             }
         };
 
@@ -412,11 +434,22 @@
 
             selectBox.getElementsByTagName('option')[0].selected = 'selected';
 
-            firefly.action.dispatchAddRegionEntry(selectedLayerId, addRegions, 'regiontest');
+            firefly.action.dispatchAddRegionEntry(selectedLayerId, addRegions, 'regiontest', null, {});
             if (selectedLayerId === 'Region Layers:') {
-                firefly.action.dispatchAddRegionEntry(null, addRegions, null, null, dispatcher = window.ffViewer.dispatch);
+                firefly.action.dispatchAddRegionEntry(null, addRegions, null, null, {}, dispatcher = window.ffViewer.dispatch);
             } else {
-                firefly.action.dispatchAddRegionEntry(selectedLayerId, addRegions, null, null, dispatcher = window.ffViewer.dispatch);
+                firefly.action.dispatchAddRegionEntry(selectedLayerId, addRegions, null, null, {}, dispatcher = window.ffViewer.dispatch);
+            }
+        };
+
+        selectRegion = function() {
+            var selectBox=document.getElementById('regionEntry_select');
+            var selectedLayerId = selectBox.options[selectBox.selectedIndex].value;
+            var selRegions = document.getElementById('selectRegionContent').value.split('\n').filter(function(r) { return (r.length !== 0);});
+
+            if (selectedLayerId) {
+                firefly.action.dispatchSelectRegion(selectedLayerId, selRegions);
+                firefly.action.dispatchSelectRegion(selectedLayerId, selRegions, dispatcher = window.ffViewer.dispatch);
             }
         };
 

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -41,6 +41,7 @@ export {CysConverter} from '../visualize/CsysConverter.js';
 export {CCUtil} from '../visualize/CsysConverter.js';
 export {watchCoverage} from '../visualize/saga/CoverageWatcher.js';
 export {watchImageMetaData} from '../visualize/saga/ImageMetaDataWatcher.js';
+export {getSelectedRegion} from '../drawingLayers/RegionPlot.js';
 
 export {extensionAdd, extensionRemove} from '../core/ExternalAccessUtils.js';
 

--- a/src/firefly/js/drawingLayers/RegionPlot.js
+++ b/src/firefly/js/drawingLayers/RegionPlot.js
@@ -6,19 +6,25 @@ import {makeDrawingDef} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {DataTypes, ColorChangeType}  from '../visualize/draw/DrawLayer.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
 import {drawRegions} from '../visualize/region/RegionDrawer.js';
-import {addNewRegion, removeRegion} from '../visualize/region/RegionUtil.js';
+import {getRegionIndex, addNewRegion, removeRegion} from '../visualize/region/RegionUtil.js';
 import {RegionFactory} from '../visualize/region/RegionFactory.js';
 import {primePlot, getDrawLayerById} from '../visualize/PlotViewUtil.js';
 import ImagePlotCntlr, {visRoot} from '../visualize/ImagePlotCntlr.js';
 import {MouseState} from '../visualize/VisMouseSync.js';
 import DrawOp from '../visualize/draw/DrawOp.js';
 import DrawLayerCntlr, {DRAWING_LAYER_KEY,
+                        defaultRegionSelectColor,
+                        RegionSelectStyle,
+                        getRegionSelectStyle,
                         dispatchModifyCustomField,
                         dispatchAddRegionEntry,
                         dispatchDeleteRegionLayer,
-                        dispatchRemoveRegionEntry, dlRoot} from '../visualize/DrawLayerCntlr.js';
-import {get, set, isEmpty} from 'lodash';
+                        dispatchRemoveRegionEntry,
+                        dispatchSelectRegion,
+                        dlRoot} from '../visualize/DrawLayerCntlr.js';
+import {get, set, has, isEmpty, isString, isArray} from 'lodash';
 import {dispatchAddSaga} from '../core/MasterSaga.js';
+import {flux} from '../Firefly.js';
 
 const ID= 'REGION_PLOT';
 const TYPE_ID= 'REGION_PLOT_TYPE';
@@ -34,9 +40,10 @@ function* regionsRemoveSaga({id, plotId}, dispatch, getState) {
                                      DrawLayerCntlr.DETACH_LAYER_FROM_PLOT]);
 
             if (action.payload.drawLayerId === id) {
+                var dl;
                 switch (action.type) {
                     case  DrawLayerCntlr.REGION_REMOVE_ENTRY :
-                        var dl = getDrawLayerById(getState()[DRAWING_LAYER_KEY], id);
+                        dl = getDrawLayerById(getState()[DRAWING_LAYER_KEY], id);
                         if (dl && isEmpty(get(dl, 'drawObjAry'))) {
                             dispatchDeleteRegionLayer(id, plotId);
                         }
@@ -78,7 +85,8 @@ function creator(initPayload) {
     };
 
     var actionTypes = [DrawLayerCntlr.REGION_ADD_ENTRY,
-                       DrawLayerCntlr.REGION_REMOVE_ENTRY];
+                       DrawLayerCntlr.REGION_REMOVE_ENTRY,
+                       DrawLayerCntlr.REGION_SELECT];
 
     const id = get(initPayload, 'drawLayerId', `${ID}-${idCnt}`);
     var   dl = DrawLayer.makeDrawLayer( id, TYPE_ID, get(initPayload, 'title', 'Region Plot'),
@@ -87,6 +95,7 @@ function creator(initPayload) {
     dl.regionAry = get(initPayload, 'regionAry', null);
     dl.dataFrom = get(initPayload, 'dataFrom', 'ds9');
     dl.highlightedRegion = get(initPayload, 'highlightedRegion', null);
+    dl.selectMode = get(initPayload, 'selectMode');
 
     dispatchAddSaga(regionsRemoveSaga, {id, plotId: get(initPayload, 'plotId')});
     idCnt++;
@@ -127,9 +136,9 @@ function highlightChange(mouseStatePayload) {
 
             dlRoot().drawLayerAry.forEach( (dl) => {
                 if (dl.drawLayerId === drawLayer.drawLayerId) {
-                    dispatchModifyCustomField(dl.drawLayerId, {highlightedRegion: closestObj}, plotId, false);
+                    dispatchSelectRegion(dl.drawLayerId, closestObj);
                 } else if (closestObj) {
-                    dispatchModifyCustomField(dl.drawLayerId, {highlightedRegion: null}, plotId, false);
+                    dispatchSelectRegion(dl.drawLayerId, null);
                 }
             });
         }
@@ -163,27 +172,71 @@ function highlightChange(mouseStatePayload) {
  * @returns {*}
  */
 function getLayerChanges(drawLayer, action) {
-    const {changes, regionChanges, drawLayerId } = action.payload;
+    const {regionChanges, drawLayerId } = action.payload;
 
     if (drawLayerId && drawLayerId !== drawLayer.drawLayerId) return null;
     var dd = Object.assign({}, drawLayer.drawData);
 
-    switch (action.type) {
-        case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
-             if (changes) {
-                 dd[DataTypes.HIGHLIGHT_DATA] = null;
-                 if (!changes.highlightedRegion) {
-                     if (drawLayer.highlightedRegion) {
-                         drawLayer.highlightedRegion.highlight = 0; // un-highlight the last selected region
-                         drawLayer.highlightedRegion = null;
-                     }
-                 } else {
-                     if (drawLayer.highlightedRegion) drawLayer.highlightedRegion.highlight = 0;
-                     changes.highlightedRegion.highlight = 1;
+    var deHighlight = (obj) => {
+        //obj.highlight = 0;
+        obj.isRendered = 1;
+    };
 
-                 }
-             }
-             return Object.assign({}, changes, {drawData: dd});
+    //  re-render data in case  border 'replace' style is used for region selected
+    var reDrawData = (hiRegion) => {
+        if (has(drawLayer, 'selectMode.selectStyle') && drawLayer.selectMode.selectStyle.includes('Replace')) {
+            if (hiRegion) {
+                hiRegion.isRendered = 0;  // de-render the selected region
+            }
+
+            drawLayer.drawObjAry = drawLayer.drawObjAry.slice();
+            Object.keys(dd[DataTypes.DATA]).forEach((plotId) => {
+                set(dd[DataTypes.DATA], plotId, null);
+            });
+        }
+     };
+
+    switch (action.type) {
+        case DrawLayerCntlr.REGION_SELECT:
+            const {selectedRegion} = action.payload;
+
+            Object.keys(dd[DataTypes.HIGHLIGHT_DATA]).forEach((plotId) => {
+                set(dd[DataTypes.HIGHLIGHT_DATA], plotId, null)
+            });
+
+            var highlightedRegion = null;
+            var selectRegionDesc = null;
+
+            // no region is selected
+            if (isEmpty(selectedRegion)) {        // nothing is selected, empty string, empty array or null
+                if (drawLayer.highlightedRegion) {
+                    deHighlight(drawLayer.highlightedRegion); // de-highlight the highlighted region if there is
+                    drawLayer.highlightedRegion = null;
+                    reDrawData();
+                }
+            } else {
+                // test if selected region is string or array of string description
+                if (isString(selectedRegion) || isArray(selectedRegion)) {    // region description in string or array of string
+                    highlightedRegion = getSelectedRegionDrawObj(drawLayer, selectedRegion);
+                    highlightedRegion = isEmpty(highlightedRegion) ? null : highlightedRegion[0];
+                } else {    // a region drawObj
+                    highlightedRegion = selectedRegion;
+                }
+
+                // selected region is valid
+                if (highlightedRegion) {
+                    if (drawLayer.highlightedRegion) {
+                        deHighlight(drawLayer.highlightedRegion); // de-highlight the highlighted region if there is
+                    }
+
+                    reDrawData(highlightedRegion);
+
+                    //highlightedRegion.highlight = 1;
+                    selectRegionDesc = get(highlightedRegion, 'region.desc', null);
+                }
+            }
+            return Object.assign({}, {highlightedRegion}, {drawData: dd},
+                                     {selectRegionDesc});
 
         case DrawLayerCntlr.REGION_ADD_ENTRY:
             if (regionChanges) {
@@ -193,18 +246,22 @@ function getLayerChanges(drawLayer, action) {
                     drawLayer.title = layerTitle.slice();  // update title of the layer
                 }
                 addRegionsToData(drawLayer, regionChanges);
+
                 Object.keys(dd[DataTypes.DATA]).forEach((plotId) => {
                     set(dd[DataTypes.DATA], plotId, drawLayer.drawObjAry)
                 });
+
             }
             return {drawData: dd};
 
         case DrawLayerCntlr.REGION_REMOVE_ENTRY:
             if (regionChanges) {
                 removeRegionsFromData(drawLayer, regionChanges);
+
                 Object.keys(dd[DataTypes.DATA]).forEach((plotId) => {
                     set(dd[DataTypes.DATA], plotId, drawLayer.drawObjAry)
                 });
+
             }
 
             return {drawData: dd};
@@ -215,20 +272,22 @@ function getLayerChanges(drawLayer, action) {
 }
 
 function getDrawData(dataType, plotId, drawLayer, action, lastDataRet) {
-    const {highlightedRegion, drawObjAry} = drawLayer;
+    const {highlightedRegion, drawObjAry, selectMode} = drawLayer;
 
     switch (dataType) {
-        case DataTypes.DATA:
+        case DataTypes.DATA:    // based on the same drawObjAry to draw the region on each plot
             return isEmpty(lastDataRet) ? drawObjAry || plotAllRegions(drawLayer) : lastDataRet;
-        case DataTypes.HIGHLIGHT_DATA:
-            return isEmpty(lastDataRet) ? plotHighlightRegion(highlightedRegion, plotId) : lastDataRet;
+        case DataTypes.HIGHLIGHT_DATA:      // create the region drawObj based on the original region for upright case.
+            return isEmpty(lastDataRet) ?
+                   plotHighlightRegion(highlightedRegion, plotId, selectMode) : lastDataRet;
     }
     return null;
 }
 /**
- * create DrawingObj for all regions
- * @param dl    drawing layer
- * @returns {*}
+ * @summary create DrawingObj for all regions
+ * @param {Object} dl    drawing layer
+ * @returns {Object[]}
+ * @ignore
  */
 function plotAllRegions(dl) {
     var {dataFrom, regionAry} = dl; //regionAry: array of region strings
@@ -245,34 +304,45 @@ function plotAllRegions(dl) {
 }
 
 /**
- * create DrawingObj for highlighted region
- * @param highlightedObj
- * @param plotId
- * @returns {*}
+ * @summary create DrawingObj for highlighted region
+ * @param {Object} highlightedObj
+ * @param {string} plotId
+ * @param {Object} selectMode
+ * @returns {Object[]}
+ * @ignore
  */
-function plotHighlightRegion(highlightedObj, plotId) {
+function plotHighlightRegion(highlightedObj, plotId, selectMode) {
     if (!highlightedObj) {
         return [];
     }
 
     if (highlightedObj.region) highlightedObj.region.highlighted = 1;
-    return [DrawOp.makeHighlight(highlightedObj, primePlot(visRoot(), plotId))];
+    var hObj = [DrawOp.makeHighlight(highlightedObj, primePlot(visRoot(), plotId), selectMode)];
+
+    hObj.forEach((oneObj) => {
+        oneObj.highlight = 1;
+    });
+
+    return hObj;
 }
 
 /**
- * add new DrawingObj into originally displayed DrawingObj set
- * @param drawLayer
- * @param addedRegions
- * @returns {Array}
+ * @summary add new DrawingObj into originally displayed DrawingObj set
+ * @param {Object} drawLayer
+ * @param {string|string[]} addedRegions
+ * @returns {Object[]}
+ * @ignore
  */
 function addRegionsToData(drawLayer, addedRegions) {
     var {regions, drawObjAry: lastData} = drawLayer;
     var resultRegions = regions ? regions.slice() : [];
     var allDrawobjs = lastData ? lastData.slice() : [];
 
-    if (addedRegions) {
-        resultRegions = addedRegions.reduce ( (prev, aRegionDes) => {
-            var aRegion = RegionFactory.parsePart(aRegionDes);
+    if (!isEmpty(addedRegions)) {
+        var allRegions = isString(addedRegions) ? [addedRegions] : addedRegions;
+        var rgObj = RegionFactory.parseRegionDS9(allRegions);
+
+        resultRegions = rgObj.reduce ( (prev, aRegion) => {
             var newDrawobj = addNewRegion(prev, aRegion);
 
             if (newDrawobj) {
@@ -290,9 +360,10 @@ function addRegionsToData(drawLayer, addedRegions) {
 
 /**
  * remove DrawingObj from originally displayed DrawingObj set
- * @param drawLayer
- * @param removedRegions
- * @returns {Array}
+ * @param {Object} drawLayer
+ * @param {string|string[]} removedRegions
+ * @returns {Object[]}
+ * @ignore
  */
 function removeRegionsFromData(drawLayer, removedRegions) {
     var {regions, drawObjAry: lastData} = drawLayer;
@@ -303,9 +374,11 @@ function removeRegionsFromData(drawLayer, removedRegions) {
         return [];     // no region to be removed
     }
 
-    if (removedRegions) {
-        resultRegions = removedRegions.reduce((prev, aRegionDes) => {
-            var rmRegion = RegionFactory.parsePart(aRegionDes);
+    if (!isEmpty(removedRegions)) {
+        var allRegions = isString(removedRegions) ? [removedRegions] : removedRegions;
+        var rgObj = RegionFactory.parseRegionDS9(allRegions);
+
+        resultRegions = rgObj.reduce((prev, rmRegion) => {
             var {index, regions} = removeRegion( prev, rmRegion );
 
             if (index >= 0) {
@@ -319,4 +392,45 @@ function removeRegionsFromData(drawLayer, removedRegions) {
     drawLayer.regions = resultRegions;
     drawLayer.drawObjAry = allDrawObjs;
     return allDrawObjs;
+}
+
+/**
+ * @summary find the region drawObj based on region description
+ * @param {object} drawLayer
+ * @param {string|string[]} regionDes
+ * @param {int} stopIndex maximum number of regions to be selected
+ * @return {Object}
+ * @ignore
+ */
+function getSelectedRegionDrawObj(drawLayer, regionDes, stopIndex = 1) {
+    var {regions, drawObjAry} = drawLayer;
+
+    var regs = RegionFactory.parseRegionDS9((isString(regionDes) ? [regionDes] : regionDes),
+                                            true, stopIndex);
+    var selDrawObj = [];
+
+    if (!isEmpty(regs)) {
+        selDrawObj = regs.reduce((prev, aRegion, index) => {
+            if (index < stopIndex) {
+                var idx = getRegionIndex(regions, aRegion);
+
+                if (idx >= 0) {
+                    prev.push(drawObjAry[idx]);
+                }
+            }
+            return prev;
+        }, []);
+    }
+    return selDrawObj.slice(0, stopIndex);
+}
+
+/**
+ * @summary get the region description of the selected region from the specified region layer
+ * @param {string} drawLayerId id of the drawing layer
+ * @return {string}
+ */
+export function getSelectedRegion(drawLayerId) {
+    var drawLayer = getDrawLayerById(flux.getState()[DRAWING_LAYER_KEY], drawLayerId);
+
+    return get(drawLayer, 'selectRegionDesc', '');
 }

--- a/src/firefly/js/drawingLayers/RegionPlot.js
+++ b/src/firefly/js/drawingLayers/RegionPlot.js
@@ -66,6 +66,7 @@ function* regionsRemoveSaga({id, plotId}, dispatch, getState) {
  *                                 => regions and regionObjAry are updated as adding or removing regions occurs
  *                                 highlightedRegion: selected region
  * @return {Function}
+ * @ignore
  */
 function creator(initPayload) {
 
@@ -106,6 +107,7 @@ function creator(initPayload) {
  * find the drawObj which is selected for highlight
  * @param mouseStatePayload
  * @returns {Function}
+ * @ignore
  */
 function highlightChange(mouseStatePayload) {
     const {drawLayer,plotId,screenPt} = mouseStatePayload;
@@ -170,6 +172,7 @@ function highlightChange(mouseStatePayload) {
  * @param drawLayer
  * @param action
  * @returns {*}
+ * @ignore
  */
 function getLayerChanges(drawLayer, action) {
     const {regionChanges, drawLayerId } = action.payload;
@@ -399,7 +402,7 @@ function removeRegionsFromData(drawLayer, removedRegions) {
  * @param {object} drawLayer
  * @param {string|string[]} regionDes
  * @param {int} stopIndex maximum number of regions to be selected
- * @return {Object}
+ * @return {Object[]} if no region is found, an empty array is return.
  * @ignore
  */
 function getSelectedRegionDrawObj(drawLayer, regionDes, stopIndex = 1) {
@@ -425,9 +428,12 @@ function getSelectedRegionDrawObj(drawLayer, regionDes, stopIndex = 1) {
 }
 
 /**
- * @summary get the region description of the selected region from the specified region layer
+ * @summary get the region description of the selected region from the specified drawing layer
  * @param {string} drawLayerId id of the drawing layer
- * @return {string}
+ * @return {string} description of the selected region
+ * @public
+ * @function getSelectedRegion
+ * @memberof firefly.util.image
  */
 export function getSelectedRegion(drawLayerId) {
     var drawLayer = getDrawLayerById(flux.getState()[DRAWING_LAYER_KEY], drawLayerId);

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -8,6 +8,7 @@ import ImagePlotCntlr, {visRoot}  from './ImagePlotCntlr.js';
 import DrawLayerReducer from './reducer/DrawLayerReducer.js';
 import {without,union,omit,isEmpty,get} from 'lodash';
 import {clone} from '../util/WebUtil.js';
+import Enum from 'enum';
 
 
 export {selectAreaEndActionCreator} from '../drawingLayers/SelectArea.js';
@@ -59,6 +60,7 @@ const REGION_CREATE_LAYER = `${DRAWLAYER_PREFIX}.RegionPlot.createLayer`;
 const REGION_DELETE_LAYER = `${DRAWLAYER_PREFIX}.RegionPlot.deleteLayer`;
 const REGION_ADD_ENTRY = `${DRAWLAYER_PREFIX}.RegionPlot.addRegion`;
 const REGION_REMOVE_ENTRY = `${DRAWLAYER_PREFIX}.RegionPlot.removeRegion`;
+const REGION_SELECT = `${DRAWLAYER_PREFIX}.RegionPlot.selectRegion`;
 
 // marker and footprint
 const MARKER_START = `${DRAWLAYER_PREFIX}.MarkerTool.markerStart`;
@@ -71,9 +73,20 @@ const FOOTPRINT_END = `${DRAWLAYER_PREFIX}.FootprintTool.footprintEnd`;
 const FOOTPRINT_MOVE = `${DRAWLAYER_PREFIX}.FootprintTool.footprintMove`;
 
 export const DRAWING_LAYER_KEY= 'drawLayers';
-
 export function dlRoot() { return flux.getState()[DRAWING_LAYER_KEY]; }
 
+export const RegionSelectStyle = ['UprightBox', 'DottedOverlay', 'SolidOverlay',
+                                  'DottedReplace', 'SolidReplace'];
+export const  defaultRegionSelectColor = '#DAA520';   // golden
+export const  defaultRegionSelectStyle = RegionSelectStyle[0];
+
+export function getRegionSelectStyle(style = defaultRegionSelectStyle) {
+    var idx = RegionSelectStyle.findIndex((val) => {
+        return val.toLowerCase() === style.toLowerCase();
+    });
+
+    return (idx < 0) ? defaultRegionSelectStyle : RegionSelectStyle[idx];
+}
 
 /**
  * Return, from the store, the master array of all the drawing layers on all the plots
@@ -94,6 +107,7 @@ export default {
     FORCE_DRAW_LAYER_UPDATE,
     DT_START, DT_MOVE, DT_END,
     REGION_CREATE_LAYER, REGION_DELETE_LAYER,  REGION_ADD_ENTRY, REGION_REMOVE_ENTRY,
+    REGION_SELECT,
     MARKER_START, MARKER_MOVE, MARKER_END, MARKER_CREATE,
     FOOTPRINT_CREATE, FOOTPRINT_START, FOOTPRINT_END, FOOTPRINT_MOVE,
     makeReducer, dispatchRetrieveData, dispatchChangeVisibility,
@@ -287,27 +301,39 @@ export function dispatchDetachLayerFromPlot(id,plotId, detachPlotGroup=false,
 }
 
 /**
- * @summary Create plot layer containing the regions based on region file or region description
- * @param drawLayerId required
- * @param layerTitle  layerTitle is set based on drawLayerId or default setting it is unset
- * @param fileOnServer
- * @param regionAry
- * @param plotId The region layer is created on all plots of the active plot group in plotId is empty
- * @param dispatcher
+ * @summary Create drawing layer based on region file or region description
+ * @param {string} drawLayerId id of the drawing layer to be created, required
+ * @param {string} layerTitle  if it is empty, it will be created internally
+ * @param {string} fileOnServer region file name on server
+ * @param {string[]|string} regionAry  array or string of region description
+ * @param {string[]|string} plotId  array or string of plot id. If plotId is empty, all plots of the active group are applied.
+ * @param {function} dispatcher
+ * @param {Object} selectMode    redndering features for the selected region
+ * @param {string} selectMode.selectStyle   rendering style for the selected region including 'UprightBox', 'DottedOverlay',
+ * 'SolidOverlay', 'DottedReplace', and 'SolidReplace'
+ * @param {string} selectMode.selectColor   rendering color for the selected region, ex: 'red', '#DAA520'
+ * @param {int}    selectMode.lineWidth     rendering line width for the selected region. 0 or less means the line width
+ * is the same as that of the selected region
  * @public
- * @memberof firefly.action
  * @func dispatchCreateRegionLayer
+ * @memberof firefly.action
  */
-export function dispatchCreateRegionLayer(drawLayerId, layerTitle, fileOnServer='', regionAry=[], plotId=[],
-                                           dispatcher = flux.process ) {
-    dispatcher({type: REGION_CREATE_LAYER, payload: {drawLayerId, fileOnServer, plotId, layerTitle, regionAry}});
+export function dispatchCreateRegionLayer(drawLayerId, layerTitle, fileOnServer='', regionAry=[], plotId='',
+                                           {selectStyle = defaultRegionSelectStyle, selectColor = defaultRegionSelectColor,
+                                            lineWidth = 0  },     // lineWidth = 0, as original region
+                                            dispatcher = flux.process) {
+
+    dispatcher({type: REGION_CREATE_LAYER, payload: {drawLayerId, fileOnServer, plotId, layerTitle, regionAry,
+                                                     selectMode: {selectStyle: getRegionSelectStyle(selectStyle),
+                                                                  selectColor, lineWidth}}});
 }
 
 /**
- * delete drawing layer with regions
- * @param drawLayerId
- * @param plotId
- * @param dispatcher
+ * @summary Delete the region drawing layer
+ * @param {string} drawLayerId id of the drawing layer to be deleted, required
+ * @param {string[]|string} plotId  array or string of plot id. If plotId is empty, all plots of the active group are applied.
+ * @param {function} dispatcher
+ * @public
  * @func dispatchDeleteRegionLayer
  * @memberof firefly.action
  */
@@ -316,33 +342,64 @@ export function dispatchDeleteRegionLayer(drawLayerId, plotId, dispatcher = flux
 }
 
 /**
- * Add regions to plot layer, if the layer doesn't exist, a new one is created
- * the layer title is replaced if the layer exists
- * the layer id is created in the layer doesn't exist or id is not set, the creation of new id is
- * based on layerTitle which is set based on some reference or default setting if it is unset.
- * @param drawLayerId
- * @param regionChanges
- * @param plotId  The region layer is created on all plots of the active plot group in plotId is empty
- * @param layerTitle
- * @param dispatcher
+ * @summay Add regions to drawing layer,
+ * @param {string} drawLayerId   id of the drawing layer where the region(s) are added to.
+ * if the layer doesn't exist, a new drawing layer is created by either using the specified drawLayerId or
+ * creating a new id based on the setting of 'layerTitle' in case drawLayerId is undefined.
+ * @param {string[]|string} regionChanges  array or string of region description
+ * @param {string[]|string} plotId  array or string of plot id. If plotId is empty, all plots of the active group are applied.
+ * @param {string} layerTitle    will replace the original title if the drawing layer exists and layerTitle is non-empty.
+ * @param {Object} selectMode    redndering features for the selected region
+ * @param {string} selectMode.selectStyle   rendering style for the selected region including 'UprightBox', 'DottedOverlay',
+ * 'SolidOverlay', 'DottedReplace', and 'SolidReplace'
+ * @param {string} selectMode.selectColor   rendering color for the selected region, ex: 'red', '#DAA520'
+ * @param {int}    selectMode.lineWidth     rendering line width for the selected region. 0 or less means the line width
+ * is the same as that of the selected region
+ * @param {function} dispatcher
+ * @public
  * @func dispatchAddRegionEntry
  * @memberof firefly.action
  */
-export function dispatchAddRegionEntry(drawLayerId, regionChanges, plotId=[], layerTitle='', dispatcher = flux.process) {
-    dispatcher({type: REGION_ADD_ENTRY, payload: {drawLayerId, regionChanges, plotId, layerTitle}});
+export function dispatchAddRegionEntry(drawLayerId, regionChanges, plotId=[], layerTitle='',
+                                        {selectStyle = defaultRegionSelectStyle, selectColor = defaultRegionSelectColor,
+                                        lineWidth = 0 },     // lineWidth <= 0, as original region
+                                       dispatcher = flux.process) {
+    dispatcher({type: REGION_ADD_ENTRY, payload: {drawLayerId, regionChanges, plotId, layerTitle,
+                                                  selectMode: {selectStyle: getRegionSelectStyle(selectStyle),
+                                                               selectColor, lineWidth}}});
 }
 
 /**
- * remove the region entry from the plot layer with drawLayerId
- * @param drawLayerId
- * @param regionChanges
- * @param dispatcher
+ * @summary remove region(s) from the drawing layer
+ * @param {string} drawLayerId id of the drawing layer where the region(s) are removed from, required.
+ * @param {string[]|string} regionChanges array or string of region description.
+ * @param {function} dispatcher
+ * @public
  * @func dispatchRemoveRegionEntry
  * @memberof firefly.action
  */
 export function dispatchRemoveRegionEntry(drawLayerId, regionChanges, dispatcher = flux.process) {
     dispatcher({type: REGION_REMOVE_ENTRY, payload: {drawLayerId, regionChanges}});
 }
+
+
+/**
+ * @summary select region from a drawing layer containing regions
+ * @param {string} drawLayerId  id of drawing layer where the region is selected from, required.
+ * @param {string[]|string} selectedRegion array or string of region description, currently only single region is allowed
+ * to be selected if the array contains the description of multiple regions.
+ * @param {function} dispatcher
+ * @public
+ * @func dispatchSelectRegion
+ * @memberof firefly.action
+ */
+export function dispatchSelectRegion(drawLayerId, selectedRegion, dispatcher = flux.process) {
+    dispatcher({type: REGION_SELECT, payload: {drawLayerId, selectedRegion}});
+}
+
+/**
+ *
+ */
 /**
  *
  * @param markerId
@@ -589,24 +646,6 @@ function deletePlotView(state,action, dlReducer) {
     } );
 
     return Object.assign({},state, {drawLayerAry});
-}
-
-/**
- * destroy draw layer in case no region left after region removal
- * @param state
- * @param action
- * @param dlReducer
- * @memberof firefly.action
- * @returns {Object}
- */
-function destroyDrawLayerNoRegion(state, action, dlReducer) {
-    var retState = determineAndCallLayerReducer(state, action, dlReducer);
-    var dl = retState.drawLayerAry.find((dl) => dl.drawLayerId === action.payload.drawLayerId);
-
-    if (dl && isEmpty(get(dl, 'drawObjAry', null))) {
-        retState = destroyDrawLayer(retState, action);
-    }
-    return retState;
 }
 
 //function mouseStateChange(state,action) {

--- a/src/firefly/js/visualize/draw/DrawOp.js
+++ b/src/firefly/js/visualize/draw/DrawOp.js
@@ -9,6 +9,7 @@ import ShapeDataObj from './ShapeDataObj.js';
 import FootprintObj from './FootprintObj.js';
 import DirectionArrowDrawObj from './DirectionArrowDrawObj.js';
 import MarkerFootprintObj from './MarkerFootprintObj.js';
+import {has} from 'lodash';
 
 export var drawTypes= {
     [POINT_DATA_OBJ] : PointDataObj.draw,
@@ -57,7 +58,9 @@ class DrawOp {
      * @param onlyAddToPath
      */
     static draw(drawObj,ctx,drawTextAry,csysConv,def,vpPtM,onlyAddToPath) {
-        op(drawObj,'draw')(drawObj, ctx, drawTextAry, csysConv, def, vpPtM,onlyAddToPath);
+        if (!has(drawObj, 'isRendered') || drawObj.isRendered ) {
+            op(drawObj, 'draw')(drawObj, ctx, drawTextAry, csysConv, def, vpPtM, onlyAddToPath);
+        }
     }
 
     /**

--- a/src/firefly/js/visualize/draw/Drawer.js
+++ b/src/firefly/js/visualize/draw/Drawer.js
@@ -336,7 +336,7 @@ class Drawer {
 
         if (canDraw(ctx,highlightData)) {
             var vpPtM= makeViewPortPt(0,0);
-            highlightData.forEach( (pt) => drawObj(ctx, null, drawingDef, cc, pt, vpPtM, false) );
+            highlightData.forEach( (pt) => drawObj(ctx, [], drawingDef, cc, pt, vpPtM, false) );
         }
     }
 

--- a/src/firefly/js/visualize/draw/PointDataObj.js
+++ b/src/firefly/js/visualize/draw/PointDataObj.js
@@ -476,7 +476,7 @@ export function makeHighlightPointDataObj(drawObj, cc, def) {
     var rectObj = ShapeDataObj.makeRectangleByCenter(wCenter, w, h, ShapeDataObj.UnitType.PIXEL,
                                                      0.0, ShapeDataObj.UnitType.ARCSEC, false);
 
-    makeShapeHighlightRenderOptions( rectObj );
+    makeShapeHighlightRenderOptions( rectObj, color );
     return rectObj;
 }
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -19,7 +19,7 @@ import {has, isNil, get, set} from 'lodash';
 const FONT_FALLBACK= ',sans-serif';
 
 var UnitType= new Enum(['PIXEL','ARCSEC','IMAGE_PIXEL']);
-var ShapeType= new Enum(['Line', 'Text','Circle', 'Rectangle', 'Ellipse',
+export var ShapeType= new Enum(['Line', 'Text','Circle', 'Rectangle', 'Ellipse',
                          'Annulus', 'BoxAnnulus', 'EllipseAnnulus', 'Polygon']);
 const SHAPE_DATA_OBJ= 'ShapeDataObj';
 const DEF_WIDTH = 1;

--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -62,7 +62,8 @@ function uploadAndProcessRegion(request, rgComp, drawLayerId) {
                 if (isEmpty(drawLayerId)) {
                     drawLayerId = drawLayerIdGen.next().value;
                 }
-                dispatchCreateRegionLayer(drawLayerId, drawLayerId, file, regionAry);
+                dispatchCreateRegionLayer(drawLayerId, drawLayerId, file, regionAry, undefined,
+                    {selectStyle: 'UprightBox', lineWidth: 1});
                 dispatchHideDialog(popupId);
             }
     };

--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -62,8 +62,7 @@ function uploadAndProcessRegion(request, rgComp, drawLayerId) {
                 if (isEmpty(drawLayerId)) {
                     drawLayerId = drawLayerIdGen.next().value;
                 }
-                dispatchCreateRegionLayer(drawLayerId, drawLayerId, file, regionAry, undefined,
-                    {selectStyle: 'UprightBox', lineWidth: 1});
+                dispatchCreateRegionLayer(drawLayerId, drawLayerId, file, regionAry);
                 dispatchHideDialog(popupId);
             }
     };

--- a/src/firefly/js/visualize/region/RegionUtil.js
+++ b/src/firefly/js/visualize/region/RegionUtil.js
@@ -17,7 +17,7 @@ export function getRegionIndex(regions, aRegionObj) {
 }
 
 /**
- * create region DrawObj if not exist in Region array per Region object
+ * create region DrawObj if not exist in region object array
  * @param crtRegions
  * @param aRegionObj
  * @returns {null}
@@ -213,11 +213,30 @@ function mergeOptionProps(optionSet1, optionSet2) {
  * @returns {boolean}
  */
 function isSameOptions(region1, region2) {
+
+    var isEqualObject = (a, b) => {
+        var aProps = Object.keys(a);
+        var bProps = Object.keys(b);
+
+        if (aProps.length != bProps.length) {
+            return false;
+        }
+
+        var notSameIdx = aProps.findIndex((prop) => {
+            return (prop === '_options') ? false : ((!has(b, prop)) || (a[prop] !== b[prop]));
+        });
+
+        return (notSameIdx < 0);
+    };
+
     var keys = mergeOptionProps(Object.keys(region1.options), Object.keys(region2.options));
     var notSameProp =  keys.findIndex( (prop) => {
         var v1 = getOptionValue(region1.options, prop);
         var v2 = getOptionValue(region2.options, prop);
 
+        if (typeof(v1) === 'object' && typeof(v2) === 'object') {
+            return !isEqualObject(v1, v2);
+        }
         return (v1 !== v2);
     });
 

--- a/src/firefly/jsdoc_config.json
+++ b/src/firefly/jsdoc_config.json
@@ -12,6 +12,7 @@
            "./js/charts/ChartUtil.js",
            "./js//visualize/CsysConverter.js",
            "./js/visualize/DrawLayerCntlr.js",
+	   "./js/drawingLayers/RegionPlot.js",
            "../../docs/firefly-api-overview.md"
 
         ],


### PR DESCRIPTION
Implementation: 
- create region selection dispatch function, dispatchSelectRegion.
- create status to record the text description of selected region and provide function to access the status. 
- add selectMode parameter into dispatchCreateRegionLayer & dispatchAddRegionEntry functions which defines the rendering style, rendering color and line width for the selected region. 5 types of rendering styles are defined, 'UprightBox', 'DottedOverlay', 'SolidOverlay', 'DottedReplace' and 'SolidReplace'. 

Testing: 
- from localhost:8080/firefly/demo/ffapi-highlevel-test.html, 
   1. click 'test open'
   2. find color,  line width text boxes and rendering style dropdown list next to 'Create Region Layer' to set the display features for showing the selected region, then click 'Create Region Layer' to create region layer with the id shown on the box next to it. 
    3. go down to the bottom of the page to select the region (one region description is already put into the textarea box) 
        - select the region layer from the dropdown list, 
        - click 'Select the following region(s)'. (note: current version support single region selection)
    You may delete the region layer and create a new region layer to see the different rendering effect on the selected region. (set the style before clicking 'Create Region Layer') 

- from localhost:8080/firefly
       1. using image select panelt to select two images, m51 & wise, m51 & 2mass
       2. upload region file, test5.reg,  from firefly_test_file/region_test_files
       3. click any region to see the region is highlighted over all plots. 
    (the default rendering style for selected region is applied in here). 
 