### PR TITLE
DM-6656: give options to set the color, symbol and size of some draw layers thorough the api

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -195,6 +195,8 @@
                 }
             ];
 
+            //util.image.setDrawLayerDefaults('ACTIVE_TARGET_TYPE', {symbol:'x', color:'pINk'});
+            //util.image.setDrawLayerDefaults('CATALOG_TYPE', {symbol:'ARROW', color:'pink', size:10});
 
             firefly.showImage('imageViewHere', req);
             firefly.showImage('imageViewHere', req2);

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -9,6 +9,7 @@ import ImagePlotCntlr, {visRoot, ExpandType} from '../visualize/ImagePlotCntlr.j
 import {primePlot} from '../visualize/PlotViewUtil.js';
 import {dispatchAddSaga} from '../core/MasterSaga.js';
 import  {DefaultApiReadout} from '../visualize/ui/DefaultApiReadout.jsx';
+import  {reduxFlux} from '../core/ReduxFlux.js';
 //import  {PopupMouseReadoutMinimal} from '../visualize/ui/PopupMouseReadoutMinimal.jsx';
 import  {PopupMouseReadoutFull} from '../visualize/ui/PopupMouseReadoutFull.jsx';
 import DialogRootContainer from '../ui/DialogRootContainer.jsx';
@@ -47,7 +48,7 @@ export {extensionAdd, extensionRemove} from '../core/ExternalAccessUtils.js';
 
 
 /**
- * @summary  Get plot object with the given plot id, when plotId is not included, active plot is returned.
+ * Get plot object with the given plot id, when plotId is not included, active plot is returned.
  * @param {string} [plotId] the plotId, optional
  * @returns {WebPlot}
  * @public
@@ -57,6 +58,27 @@ export {extensionAdd, extensionRemove} from '../core/ExternalAccessUtils.js';
  */
 export function getPrimePlot(plotId) {
     return primePlot(visRoot(), plotId);
+}
+
+/**
+ * Set a defaults object on for a draw layer type.
+ * The following draw layers are supported: 'ACTIVE_TARGET_TYPE', 'CATALOG_TYPE'
+ * @param {string} drawLayerTypeId
+ * @param {DrawingDef} defaults
+ * @public
+ * @function setDrawLayerDefaults
+ * @memberof firefly.util.image
+ *
+ * @example
+ * firefly.util.image.setDrawLayerDefaults('ACTIVE_TARGET_TYPE', {symbol:'x', color:'pink', size:15});
+ * or
+ * firefly util.image.setDrawLayerDefaults('CATALOG_TYPE', {symbol:'cross', color:'red'});
+ *
+ * @see DrawingDef
+ * @see DrawSymbol
+ */
+export function setDrawLayerDefaults(drawLayerTypeId, defaults) {
+    reduxFlux.setDrawLayerDefaults(drawLayerTypeId, defaults);
 }
 
 /**

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -314,6 +314,10 @@ function registerDrawLayer(factoryDef) {
     drawLayerFactory.register(factoryDef);
 }
 
+function setDrawLayerDefaults(typeId,defaults) {
+    drawLayerFactory.setDrawLayerDefaults(typeId,defaults);
+}
+
 function createDrawLayer(drawLayerTypeId, params) {
     return drawLayerFactory.create(drawLayerTypeId,params);
 }
@@ -329,6 +333,7 @@ export var reduxFlux = {
     registerDrawLayer,
     createDrawLayer,
     getDrawLayerFactory,
+    setDrawLayerDefaults,
     getRedux
 };
 

--- a/src/firefly/js/drawingLayers/ActiveTarget.js
+++ b/src/firefly/js/drawingLayers/ActiveTarget.js
@@ -25,9 +25,11 @@ export default {factoryDef, TYPE_ID}; // every draw layer must default export wi
 var idCnt=0;
 
 
-function creator(initPayload) {
+function creator(initPayload, presetDefaults) {
     var drawingDef= makeDrawingDef('blue');
     drawingDef.symbol= DrawSymbol.SQUARE;
+    drawingDef= Object.assign(drawingDef,presetDefaults);
+
     idCnt++;
 
     var options= {

--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -48,12 +48,14 @@ var createCnt= 0;
 //---------------------------------------------------------------------
 
 
-function creator(initPayload) {
+function creator(initPayload, presetDefaults) {
     const {catalogId, tableData, tableMeta, title,
            selectInfo, columns, tableRequest, highlightedRow, color, angleInRadian=false,
            dataTooBigForSelection=false, catalog=true,boxData=false }= initPayload;
     var drawingDef= makeDrawingDef();
+    drawingDef.size= 5;
     drawingDef.symbol= DrawSymbol.SQUARE;
+    drawingDef= Object.assign(drawingDef,presetDefaults);
 
     var pairs= {
         [MouseState.DOWN.key]: highlightChange
@@ -220,9 +222,10 @@ function computePointDrawLayer(drawLayer, tableData, columns) {
     const {angleInRadian:rad}= drawLayer;
     if (lonIdx<0 || latIdx<0) return null;
 
+    const {size,symbol}= drawLayer.drawingDef;
     return tableData.data.map( (d) => {
         const wp= makeWorldPt( toAngle(d[lonIdx],rad), toAngle(d[latIdx],rad), columns.csys);
-        return PointDataObj.make(wp, 5, DrawSymbol.SQUARE);
+        return PointDataObj.make(wp, size, symbol);
     });
 }
 
@@ -266,7 +269,7 @@ function computePointHighlightLayer(drawLayer, columns) {
     if (!raStr || !decStr) return null;
 
     const wp= makeWorldPt( raStr, decStr, columns.csys);
-    const obj= PointDataObj.make(wp, 5, DrawSymbol.SQUARE);
+    const obj= PointDataObj.make(wp, 5, drawLayer.drawingDef.symbol);
     const obj2= PointDataObj.make(wp, 5, DrawSymbol.X);
     obj.color= COLOR_HIGHLIGHTED_PT;
     obj2.color= COLOR_HIGHLIGHTED_PT;

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -269,13 +269,11 @@ export class WebPlotRequest extends ServerRequest {
         return req;
     }
 
-    static makeProcessorRequest(serverRequest, desc) {
+    static makeProcessorRequest(obj, desc) {
         var req = new WebPlotRequest(RequestType.PROCESSOR, desc);
-        // req.setParams(serverRequest.getParams());
-        req.setParams(serverRequest.getParams());
+        req.setParams(obj);
         return req;
     }
-
 
     static makeURLPlotRequest(url, userDesc) {
         var req = new WebPlotRequest(RequestType.URL, userDesc||'Fits from URL: ' + url);

--- a/src/firefly/js/visualize/draw/DrawLayerFactory.js
+++ b/src/firefly/js/visualize/draw/DrawLayerFactory.js
@@ -89,6 +89,7 @@ class DrawLayerFactory {
 
     constructor(factoryDefsAry) {
         this.registry=  {};
+        this.defaults= {};
         factoryDefsAry.forEach( (fd) => {
             if (fd.create && fd.drawLayerTypeId) {
                 this.register(fd);
@@ -111,7 +112,7 @@ class DrawLayerFactory {
             console.warn(`DrawingLayerType: ${drawLayerTypeId} does not exist in the registry, did you forget to add it?`);
             return null;
         }
-        return this.registry[drawLayerTypeId].create(initPayload);
+        return this.registry[drawLayerTypeId].create(initPayload, this.defaults[drawLayerTypeId]);
     }
 
     hasGetDrawData(drawLayer) {
@@ -148,6 +149,11 @@ class DrawLayerFactory {
         return this.registry[drawLayer.drawLayerTypeId].getUIComponent;
     }
 
+    setDrawLayerDefaults(drawLayerTypeId, def) {
+        if (this.defaults[drawLayerTypeId]) {
+            this.defaults[drawLayerTypeId]= Object.assign(this.defaults[drawLayerTypeId], def);
+        }
+    }
 
 
     /**
@@ -156,6 +162,7 @@ class DrawLayerFactory {
      */
     register(factoryDef) {
         this.registry[factoryDef.drawLayerTypeId]= factoryDef;
+        this.defaults[factoryDef.drawLayerTypeId]= {};
     }
 
     static makeFactory(...factoryDefs) {

--- a/src/firefly/js/visualize/draw/DrawingDef.js
+++ b/src/firefly/js/visualize/draw/DrawingDef.js
@@ -54,6 +54,9 @@ export const DEFAULT_FONT_SIZE = '9pt';
 /**
  * @typedef {Object} DrawingDef
  *
+ * The defaults that a drawing layer might use. Note that all the properties of this object are optional.
+ * It can be created with any subset.
+ *
  * @prop {String} color color css style
  * @prop {DrawSymbol} symbol default: DrawSymbol.X,
  * @prop {Number} lineWidth default:1,
@@ -77,12 +80,12 @@ export const DEFAULT_FONT_SIZE = '9pt';
  * @param pointData
  * @return {DrawingDef}
  */
-export function makeDrawingDef(color= 'red') {
+export function makeDrawingDef(color= 'red', presetDefaults= {}) {
 
 	// FIXME: those are not DS9 colors, hence problem when saved in DS9 regions format file
 
 
-    return {
+    const def= {
         color,
         symbol: DrawSymbol.X,
         lineWidth:1,
@@ -95,6 +98,7 @@ export function makeDrawingDef(color= 'red') {
         fontStyle: 'normal',
         selectedColor: COLOR_SELECTED_PT
     };
+    return Object.assign({}, def, presetDefaults);
 }
 
 

--- a/src/firefly/js/visualize/draw/PointDataObj.js
+++ b/src/firefly/js/visualize/draw/PointDataObj.js
@@ -21,13 +21,12 @@ import {defaultRegionSelectColor, defaultRegionSelectStyle} from '../DrawLayerCn
 
 /**
  *  enum
- *  ROTATE is the symbol mainly used as an indication for rotation in drawing layer
  *  one of 'X','SQUARE','CROSS','DIAMOND','DOT','CIRCLE', 'SQUARE_X', 'EMP_CROSS','EMP_SQUARE_X', 'BOXCIRCLE', 'ARROW'
  * */
 export const DrawSymbol = new Enum([
     'X','SQUARE','CROSS','DIAMOND','DOT','CIRCLE', 'SQUARE_X', 'EMP_CROSS','EMP_SQUARE_X',
     'BOXCIRCLE', 'ARROW', 'ROTATE'
-]);
+], { ignoreCase: true });
 
 export const POINT_DATA_OBJ= 'PointDataObj';
 const DEFAULT_SIZE= 4;
@@ -70,7 +69,8 @@ var draw=  {
 
     usePathOptimization(drawObj) {
         if (!drawObj.symbol) return true;
-        return drawObj.symbol!=DrawSymbol.EMP_CROSS && drawObj.symbol!=DrawSymbol.EMP_SQUARE_X;
+        const s= DrawSymbol.get(drawObj.symbol);
+        return s!==DrawSymbol.EMP_CROSS && s!==DrawSymbol.EMP_SQUARE_X;
     },
 
     getCenterPt(drawObj) {return drawObj.pt; },
@@ -125,7 +125,7 @@ export default {make,draw};
 
 /**
  * translate the point symbol
- * @param plot
+ * @param {WebPlot} plot
  * @param drawObj
  * @param apt
  * @returns {{pt: *}}
@@ -139,10 +139,10 @@ function translatePtTo(plot, drawObj, apt) {
 /**
  * rotate the point symbol (rotate the point defined for the point, not the entire symbol)
  * if the entire symbol needs to be rotated, set the angle to renderOptions.rotAngle externally
- * @param plot
+ * @param {WebPlot} plot
  * @param drawObj
- * @param angle in screen coodinate direction, radian
- * @param worldPt
+ * @param {number} angle in screen coodinate direction, radian
+ * @param {WorldPt} worldPt
  * @returns {{pt: *}}
  */
 function rotatePtAround(plot, drawObj, angle, worldPt) {
@@ -153,14 +153,14 @@ function rotatePtAround(plot, drawObj, angle, worldPt) {
 
 
 function makeDrawParams(pointDataObj,def) {
-    var symbol= pointDataObj.symbol || def.symbol || DEFAULT_SYMBOL;
-    var size= (symbol===DrawSymbol.DOT) ? pointDataObj.size || def.size || DOT_DEFAULT_SIZE :
+    const symbol= DrawSymbol.get(pointDataObj.symbol || def.symbol || DEFAULT_SYMBOL);
+    const size= (symbol===DrawSymbol.DOT) ? pointDataObj.size || def.size || DOT_DEFAULT_SIZE :
                                           pointDataObj.size || def.size || DEFAULT_SIZE;
-    var fontName= pointDataObj.fontName || def.fontName || 'helvetica';
-    var fontSize= pointDataObj.fontSize || def.fontSize || DEFAULT_FONT_SIZE;
-    var fontWeight= pointDataObj.fontWeight || def.fontWeight || 'normal';
-    var fontStyle= pointDataObj.fontStyle || def.fontStyle || 'normal';
-    var textLoc= pointDataObj.textLoc || def.textLoc || TextLocation.DEFAULT;
+    const fontName= pointDataObj.fontName || def.fontName || 'helvetica';
+    const fontSize= pointDataObj.fontSize || def.fontSize || DEFAULT_FONT_SIZE;
+    const fontWeight= pointDataObj.fontWeight || def.fontWeight || 'normal';
+    const fontStyle= pointDataObj.fontStyle || def.fontStyle || 'normal';
+    const textLoc= pointDataObj.textLoc || def.textLoc || TextLocation.DEFAULT;
 
     return {
         color: DrawUtil.getColor(pointDataObj.color,def.color),
@@ -179,7 +179,7 @@ function makeDrawParams(pointDataObj,def) {
  * @param ctx
  * @param drawTextAry
  * @param pt
- * @param plot
+ * @param {WebPlot} plot
  * @param drawObj
  * @param drawParams
  * @param renderOptions


### PR DESCRIPTION
Now the api should be able to set the size, color, shape of the active target and catalog via api.

 - only CATALOG_TYPE and ACTIVE_TARGET_TYPE are currently supported.
 - jsdocs in ApiUtilImage.jsx, line 63
 - framework can be used to add more options, just have to be supported by the drawing layer.

To test uncomment `ffapi-highlevel-test.html`, line 198 and 199.
