### PR TITLE
DM-7273: Mouse readout cleanup and bug fixes

### DIFF
--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import {take,race,call} from 'redux-saga/effects';
+import {has} from 'lodash';
 import {MouseState} from '../visualize/VisMouseSync.js';
 import ImagePlotCntlr, {visRoot, ExpandType} from '../visualize/ImagePlotCntlr.js';
 import {primePlot} from '../visualize/PlotViewUtil.js';
@@ -59,8 +60,12 @@ export function getPrimePlot(plotId) {
     return primePlot(visRoot(), plotId);
 }
 
+
+
+var isInit= false;
 /**
- * @summary  initialize the auto readout. Must be call once at the begging to get the popup readout running.
+ * @summary  initialize the auto readout. Can only be called once at the begging to get the popup readout running.
+ * Called internally during first image plot.
  * @param {object} ReadoutComponent - either a PopupMouseReadoutMinimal or PopupMouseReadoutFull
  * @param {object} props - a list of the properties
  * @public
@@ -68,11 +73,10 @@ export function getPrimePlot(plotId) {
  * @memberof firefly.util.image
  */
 export function initAutoReadout(ReadoutComponent= DefaultApiReadout,
-         //   props={MouseReadoutComponent:PopupMouseReadoutMinimal, showThumb:false,showMag:false}){
       props={MouseReadoutComponent:PopupMouseReadoutFull, showThumb:true,showMag:true } ){
-
-
+    if (isInit) return;
     dispatchAddSaga(autoReadoutVisibility, {ReadoutComponent,props});
+    isInit= true;
 }
 
 
@@ -138,7 +142,7 @@ function *autoReadoutVisibility({ReadoutComponent,props}) {
                            mouse: call(mouseUpdatePromise),
                            timer: call(delay, 3000)
                          });
-            if ((!winner.expandedChange || !winner.mouse) && !inDialog && !isLockByClick(readoutRoot()) && !isAutoReadIsLocked(readoutRoot())) {
+            if ((has(winner,'timer')) && !inDialog && !isLockByClick(readoutRoot()) && !isAutoReadIsLocked(readoutRoot())) {
                 hideReadout();
             }
             else {

--- a/src/firefly/js/visualize/ui/DefaultApiReadout.jsx
+++ b/src/firefly/js/visualize/ui/DefaultApiReadout.jsx
@@ -14,10 +14,10 @@ import {ThumbnailView} from './ThumbnailView.jsx';
 import {MagnifiedView} from './MagnifiedView.jsx';
 
 var fullStyle= {
-    width: 680,
-    height: 70,
-    minWidth: 680,
-    minHeight:70,
+    // width: 680,
+    // height: 70,
+    // minWidth: 680,
+    // minHeight:70,
     display: 'inline-block',
     position: 'relative',
     verticalAlign: 'top',
@@ -27,10 +27,10 @@ var fullStyle= {
 };
 
 var minimalStyle= {
-    width: 360,
-    height: 70,
-    minWidth: 360,
-    minHeight:70,
+    // width: 360,
+    // height: 70,
+    // minWidth: 360,
+    // minHeight:70,
     display: 'inline-block',
     position: 'relative',
     verticalAlign: 'top',
@@ -86,9 +86,9 @@ export class DefaultApiReadout extends Component {
             const style = MouseReadoutComponent &&  MouseReadoutComponent.name==='PopupMouseReadoutMinimal'?minimalStyle:fullStyle;
             return (
 
-                <div style={{display:'inline-block', float:'right', whiteSpace:'nowrap'}}>
+                <div style={{display:'flex',flexWrap:'nowrap'}}>
                     <div style={style}>
-                        <div style={{position:'absolute', color:'black'}}>
+                        <div style={{position:'relative', color:'black', height:'100%'}}>
                             <MouseReadoutComponent readout={readout} showMag={ showMag} showThumb={showThumb}/>
                         </div>
                     </div>

--- a/src/firefly/js/visualize/ui/MouseReadout.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadout.jsx
@@ -30,7 +30,7 @@ const rS = {
     whiteSpace: 'nowrap',
     overflow: 'hidden'
 };
-const EMPTY = <div style={rS}></div>;
+const EMPTY = <div style={rS}/>;
 const EMPTY_READOUT = '';
 const coordinateMap = {
     galactic: CoordinateSys.GALACTIC,
@@ -194,15 +194,15 @@ export function getFluxInfo(sndReadout){
     }
     var fluxValueArrays=[];
     var fluxLabelArrays=[];
-    var fluxValue,  formatStr;
+    var fluxValue;
 
     for (let i = 0; i < fluxObj.length; i++) {
         if (!isNaN(fluxObj[i].value )) {
             fluxValue = (fluxObj[i].value < 1000) ? `${myFormat(fluxObj[i].value, fluxObj[i].precision)}` : fluxObj[i].value.toExponential(6).replace('e+', 'E');
             if (fluxObj[i].unit && !isNaN(fluxObj[i].value)) fluxValue+= ` ${fluxObj[i].unit}`;
             fluxValueArrays.push(fluxValue);
-            fluxLabelArrays.push(fluxObj[i].title);
         }
+        fluxLabelArrays.push(fluxObj[i].title);
      }
 
     if (fluxLabelArrays.length<3) { //fill with empty
@@ -231,7 +231,7 @@ export function  getMouseReadout(readoutItems, toCoordinateName) {
     var wpt = readoutItems.worldPt;
     if (!wpt.value) return;
 
-    var result,fStr, obj;
+    var result, obj;
     var {coordinate, type} = getCoordinateMap(toCoordinateName);
     if (coordinate) {
         var ptInCoord = VisUtil.convert(wpt.value, coordinate);

--- a/src/firefly/js/visualize/ui/PopupMouseReadoutFull.jsx
+++ b/src/firefly/js/visualize/ui/PopupMouseReadoutFull.jsx
@@ -8,6 +8,7 @@
  */
 import React, {PropTypes} from 'react';
 import {get} from 'lodash';
+import {clone} from '../../util/WebUtil.js';
 import {showMouseReadoutOptionDialog} from './MouseReadoutOptionPopups.jsx';
 import {dispatchChangePointSelection} from '../ImagePlotCntlr.js';
 import {STANDARD_READOUT, dispatchChangeLockByClick, dispatchChangeLockUnlockByClick} from '../../visualize/MouseReadoutCntlr.js';
@@ -17,17 +18,15 @@ import {getMouseReadout, labelMap, getFluxInfo} from './MouseReadout.jsx';
 import LOCKED from    'html/images/icons-2014/lock_20x20.png';
 import UNLOCKED from  'html/images/icons-2014/unlock_20x20.png';
 
-const rS = {
-    padding : 10,
-    cursor: 'pointer'
 
 
+const linkLook = {
+    textDecoration: 'underline',
+    fontStyle: 'italic',
 };
-const EMPTY = <div style={rS}></div>;
-
 
 const column1 = {
-    width: 60,
+    width: 80,
     paddingRight: 1,
     textAlign: 'right',
     color: 'DarkGray',
@@ -39,9 +38,7 @@ const column3 = {
     width: 80,
     paddingRight: 2,
     textAlign: 'right',
-    textDecoration: 'underline',
     color: 'DarkGray',
-    fontStyle: 'italic',
     display: 'inline-block'
 };
 const column3_r2 = {width: 80, paddingRight: 1, textAlign: 'right', color: 'DarkGray', display: 'inline-block'};
@@ -51,22 +48,30 @@ const column5 = {
     width: 74,
     paddingRight: 1,
     textAlign: 'right',
-    textDecoration: 'underline',
     color: 'DarkGray',
-    fontStyle: 'italic',
     display: 'inline-block'
 };
 
 const column6 = {width: 170,addingLeft: 2, textAlign: 'left', display: 'inline-block'};
-const column7 = {width: 109, paddingLeft: 6, display: 'inline-block'};
+const lockByClickStyle = {width: 100, display: 'inline-block', float: 'right', margin: '-10px 24px 0 0 '};
+
 
 export function PopupMouseReadoutFull({readout}){
 
 
     //get the standard readouts
     const sndReadout= readout[STANDARD_READOUT];
-    if (!get(sndReadout,'readoutItems')) return EMPTY;
+    const {threeColor}= readout.standardReadout;
 
+    const rS = {
+        cursor: 'pointer',
+        width: 485,
+        display: 'inline-block',
+        position: 'relative',
+    };
+
+
+    if (!get(sndReadout,'readoutItems')) return <div style={rS}/>;
 
     const lock = readout.isLocked ? LOCKED:UNLOCKED;
     var objList={};
@@ -74,7 +79,7 @@ export function PopupMouseReadoutFull({readout}){
         objList[key]=getMouseReadout(sndReadout.readoutItems,  readout.readoutPref[key] );
     });
 
-    if (!objList)return EMPTY;
+    if (!objList)return <div style={rS}/>;
 
     const {mouseReadout1, mouseReadout2, pixelSize} = objList;
 
@@ -83,41 +88,44 @@ export function PopupMouseReadoutFull({readout}){
 
     return (
 
-        <div style={ rS}>
-
-            {/*row1*/}
-            <div  >
-                <div style={ column1}>{fluxLabels[1]} </div>
-                <div style={ column2}>  {fluxValues[1]}  </div>
-                <div style={ column3} onClick={ () => showDialog('pixelSize', readout.readoutPref.pixelSize)}>
-                    {labelMap[readout.readoutPref.pixelSize] }
-                </div>
-                <div style={column4}>{pixelSize} </div>
-
-                <div style={ column5} onClick={ () => showDialog('mouseReadout1', readout.readoutPref.mouseReadout1)}>
-                    { labelMap[readout.readoutPref.mouseReadout1] }
-                </div>
-                <div style={column6}> {mouseReadout1} </div>
-
-
-                <div style={column7}>  < img  src= {lock}  onClick ={() =>{
+        <div style={{display:'flex', height: '100%', alignItems:'center'}}>
+            <div>
+                <img  src= {lock}  title= 'Lock the readout panel visible' onClick ={() =>{
                       dispatchChangeLockUnlockByClick(!readout.isLocked);
                    }}
                 />
-                </div>
             </div>
-            <div>{/* row2*/}
-                <div style={ column1}>{fluxLabels[2]} </div>
-                <div style={ column2}> { fluxValues[2]} </div>
+            <div style={ rS}>
 
-                <div style={ column3_r2}>{fluxLabels[0]}</div>
-                <div style={ column4}> {fluxValues[0]}</div>
+                {/*row1*/}
+                <div>
+                    <div style={ clone(column3,linkLook)} onClick={ () => showDialog('pixelSize', readout.readoutPref.pixelSize)}>
+                        {labelMap[readout.readoutPref.pixelSize] }
+                    </div>
+                    <div style={column4}>{pixelSize} </div>
 
-                <div style={ column5} onClick={ () => showDialog('mouseReadout2' ,readout.readoutPref.mouseReadout2 )}>
-                    {labelMap[readout.readoutPref.mouseReadout2] } </div>
+                    <div style={ clone(column5,linkLook)} onClick={ () => showDialog('mouseReadout1', readout.readoutPref.mouseReadout1)}>
+                        { labelMap[readout.readoutPref.mouseReadout1] }
+                    </div>
+                    <div style={column6}> {mouseReadout1} </div>
 
-                <div style={column6}>  {mouseReadout2}  </div>
-                <div style={column7} title='Click on an image to lock the display at that point.'>
+                </div>
+                <div style={{paddingTop: 3}}>{/* row2*/}
+                    <div style={ column3_r2}>{fluxLabels[0]}</div>
+                    <div style={ column4}> {fluxValues[0]}</div>
+
+                    <div style={ clone(column5,linkLook)} onClick={ () => showDialog('mouseReadout2' ,readout.readoutPref.mouseReadout2 )}>
+                        {labelMap[readout.readoutPref.mouseReadout2] } </div>
+
+                    <div style={column6}>  {mouseReadout2}  </div>
+                </div>
+                 <div style={{height: 13, width:'100%', paddingTop:3}}>{/* row3*/}
+                     {threeColor && <div style={ column3}>{fluxLabels[1]}</div>}
+                     {threeColor && <div style={ column4}>{fluxValues[1]}</div>}
+                     {threeColor && <div style={ column5}>{fluxLabels[2]}</div>}
+                     {threeColor && <div style={ column6}>{fluxValues[2]}</div>}
+                </div>
+                <div style={lockByClickStyle} title='Click on an image to lock the display at that point.'>
                     <input type='checkbox' name='aLock' value='lock'
                            onChange={() => {
                            dispatchChangePointSelection('mouseReadout', !readout.lockByClick);

--- a/src/firefly/js/visualize/ui/PopupMouseReadoutMinimal.jsx
+++ b/src/firefly/js/visualize/ui/PopupMouseReadoutMinimal.jsx
@@ -18,8 +18,10 @@ import LOCKED from    'html/images/icons-2014/lock_20x20.png';
 import UNLOCKED from  'html/images/icons-2014/unlock_20x20.png';
 
 const rS = {
-    padding : 10,
-    cursor: 'pointer'
+    // padding : 10,
+    cursor: 'pointer',
+    display: 'flex',
+    padding: '2px 0 2px 3px'
 };
 
 
@@ -65,41 +67,41 @@ export function PopupMouseReadoutMinimal({readout}){
     return (
         <div style={ rS}>
             {/*row1*/}
-            <div  >
-
-
-                <div style={ column1} onClick={ () => showDialog('mouseReadout1', readout.readoutPref.mouseReadout1)}>
-                    { labelMap[readout.readoutPref.mouseReadout1] }
-                </div>
-                <div style={column2}> {mouseReadout1} </div>
-
-                <div style={column3}>
-                    < img  src= {lock}  onClick ={() =>{
+            <img  src= {lock}  title= 'Lock the readout panel visible' onClick ={() =>{
                       dispatchChangeLockUnlockByClick(!readout.isLocked);
                    }}
-                    />
+            />
+            <div>
+                <div>
+
+
+                    <div style={ column1} onClick={ () => showDialog('mouseReadout1', readout.readoutPref.mouseReadout1)}>
+                        { labelMap[readout.readoutPref.mouseReadout1] }
+                    </div>
+                    <div style={column2}> {mouseReadout1} </div>
+
+
                 </div>
-
-            </div>
-            <div>{/* row2*/}
+                <div>{/* row2*/}
 
 
-                <div style={ column1} onClick={ () => showDialog('mouseReadout2' ,readout.readoutPref.mouseReadout2 )}>
-                    {labelMap[readout.readoutPref.mouseReadout2] } </div>
+                    <div style={ column1} onClick={ () => showDialog('mouseReadout2' ,readout.readoutPref.mouseReadout2 )}>
+                        {labelMap[readout.readoutPref.mouseReadout2] } </div>
 
-                <div style={column2}>  {mouseReadout2}  </div>
+                    <div style={column2}>  {mouseReadout2}  </div>
 
-                <div style={column3} title='Click on an image to lock the display at that point.'>
-                    <input type='checkbox' name='aLock' value='lock'
-                           onChange={() => {
+                    <div style={column3} title='Click on an image to lock the display at that point.'>
+                        <input type='checkbox' name='aLock' value='lock'
+                               onChange={() => {
                            dispatchChangePointSelection('mouseReadout', !readout.lockByClick);
                            dispatchChangeLockByClick(!readout.lockByClick);
                       }}
-                    />
-                    Lock by click
-                </div>
+                        />
+                        Lock by click
+                    </div>
 
-             </div>
+                </div>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
 - Mouse readout not longer will randomly switch to the bigger one.
 - The mouse readout will not blink as you go in and out of an image
 - Clean up flow of mouse readout saga
 - MouseReadoutWatch includes description of empty flux fields
 - Readout ui layout has been cleaned up: minimal is smaller, three color is tighter, standard api is cleaner
 - Readout now correctly shows empty flux display


_Test with_: gator, firefly viewer and ffapi-highlevel-test.html