### PR TITLE
DM-7116: change the title of drawing layer dialog based on the title of the active image

### DIFF
--- a/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
@@ -21,16 +21,12 @@ export const DRAW_LAYER_POPUP= 'DrawLayerPopup';
 
 function getDialogBuilder() {
     var popup= null;
+    const defaultTitle = 'Drawing Layers';
     return () => {
         if (!popup) {
-            var title = 'Drawing Layers';
-            //try {
-            //    if(visRoot()){
-            //        title += ': '+getActivePlotView(visRoot()).plots[0].title;
-            //    }
-            //}catch (E){
-            //    //
-            //}
+            var title = get( getActivePlotView(visRoot()), ['plots', '0', 'title']);
+            title = title ? `Layers- ${title}` : defaultTitle;
+
             const popup= (
                 <PopupPanel title={title} >
                     <DrawLayerPanel/>


### PR DESCRIPTION
Make the tile on the drawing layer dialog to be the same as the image title from either image or catalog search. 

