### PR TITLE
DM-7665: fixed the region parsing issue regarding region used separators contained in some property values

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -332,6 +332,19 @@
                 'image; box 280 200 72 72 0 # color=cyan text={right syntax}'
             ];
 
+            /*
+            window.regionWithSpecialChars = [
+                'circle  202.4844693750341 47.23118060364845 13.9268922364868 # color=blue text={j2000 ; circle on ; J2000}',
+                'J2000;box 202.4844693750341 47.23118060364845 0.0069268922364 0.0069268922364  0 # color=red text={box on # J2000 with radius ## 0.00198268922364868}',
+                'circle  100.4844693750341 147.23118060364845 0.0239268922364868 # color=purple text="j2000 ; circle on # J2000"'
+            ];
+            */
+            window.regionWithSpecialChars = [
+                'circle  202.4844693750341 47.23118060364845 13.9268922364868 # color=cyan text={physical;circle ;; color=cyan}',
+                'J2000;box 202.4844693750341 47.23118060364845 0.0069268922364 0.0069268922364  0 # color=red text={box on # J2000 with size ## 0.0069268922364}',
+                'image;circle  100.4844693750341 147.23118060364845 10.0239268922364868 # color=#B8E986 text="image ; circle # color=#B8E986"'
+            ];
+
 
             window.moreRegionAry =  [
                 'image;ellipse 100 100 20p 40p 30p 60p 40p 80p 20 # color=green text={ellipseannulus 2}',
@@ -359,7 +372,8 @@
                 document.getElementById('createRegionId').value = layerId;
 
             }
-            document.getElementById('regionLayerContent').value = window.smallregion.join('\n');
+            document.getElementById('regionLayerContent').value = window.regionWithSpecialChars.join('\n');
+
 /*
             if (window.regionId === 0) {
                 document.getElementById('regionLayerContent').value = window.emptyRegion;

--- a/src/firefly/js/visualize/region/RegionFactory.js
+++ b/src/firefly/js/visualize/region/RegionFactory.js
@@ -681,7 +681,7 @@ export class RegionFactory {
                                     (c !== RegionCsys.DETECTOR) );
 
         var makePt = (vx, vy, cs) => {
-            if (vx.unit === RegionValueUnit.IMAGE_PIXEL || vx.unit === RegionValueUnit.P) {
+            if (vx.unit === RegionValueUnit.IMAGE_PIXEL || vx.unit === RegionValueUnit.SCREEN_PIXEL) {
                 return makeImagePt(vx.value, vy.value);
             } else {
                 return makeWorldPt(vx.value, vy.value, this.parse_coordinate(cs));


### PR DESCRIPTION
Fixed the parsing errors which happen when 
- semicolon, space, or '#' is contained in the values of text property.
- the text (or font) property is not properly quoted with " or ' or {}. 

Test sample, 
upload firefly_test_data/region-test-files/regionText.reg
or 
visit localhost:8080/demo/ffapi-highlevel-test.html by clicking 'test-open' and 'create_region_layer' 