### PR TITLE
DM-7765 Render the text defined as the 'text' property value of a region on PNG

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/RegionPng.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/RegionPng.java
@@ -45,6 +45,7 @@ import java.awt.geom.GeneralPath;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.Font;
 import java.util.List;
 
 /**
@@ -302,6 +303,19 @@ public class RegionPng {
         fo.setShowPoint(false);
         fo.setTargetName(rt.getOptions().getText());
         StringShape ss= fo.getDrawer().getStringShape();
+        int  fStyle = Font.PLAIN;
+        if (rt.getOptions().getFont().isBold()) {
+            if (rt.getOptions().getFont().isItalic()) {
+                fStyle = Font.BOLD + Font.ITALIC;
+            } else {
+                fStyle = Font.BOLD;
+            }
+        } else if (rt.getOptions().getFont().isItalic()) {
+            fStyle = Font.ITALIC;
+        }
+
+        ss.setFont(new Font(rt.getOptions().getFont().getName(),
+                            fStyle, (int)rt.getOptions().getFont().getPt()));
         ss.setDrawWithBackground(false);
         ss.setUseRegionCalc(true);
         ss.setOffsetDirection(StringShape.CENTER);

--- a/src/firefly/java/edu/caltech/ipac/visualize/draw/StringShape.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/draw/StringShape.java
@@ -75,6 +75,8 @@ public class StringShape {
    public void setOffsetDistance(int offsetDist) { _offsetDist= offsetDist; }
    public void  setColor(Color c)                 { _color= c; }
    public Color getColor()                        { return _color; }
+   public Font  getFont()                         { return _font; }
+   public void  setFont(Font f)                   { _font = f; }
 
     public void draw(Graphics2D   g2,
                     ImageWorkSpacePt      ipt,

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -342,10 +342,10 @@ function resultsSuccess(request, plot) {
         plotState.getWorkingFitsFileStr(band) :
         plotState.getOriginalFitsFileStr(band);
 
-    var getRegionsDes = () => {
+    var getRegionsDes = (bSeperateText) => {
         var regionDes;
 
-        regionDes = makeRegionsFromPlot(plot);
+        regionDes = makeRegionsFromPlot(plot, bSeperateText);
         return `[${regionDes.join(STRING_SPLIT_TOKEN)}]`;
     };
 
@@ -356,7 +356,7 @@ function resultsSuccess(request, plot) {
         download(url);
     } else if (ext && ext.toLowerCase() === 'png') {
 
-        getImagePng(plotState, getRegionsDes()).then((result) => {
+        getImagePng(plotState, getRegionsDes(true)).then((result) => {
             var imgFile = get(result, 'ImageFileName');
 
             if (imgFile) {
@@ -371,7 +371,7 @@ function resultsSuccess(request, plot) {
 
     } else if (ext && ext.toLowerCase() === 'reg') {
 
-        saveDS9RegionFile(getRegionsDes()).then( (result ) => {
+        saveDS9RegionFile(getRegionsDes(false)).then( (result ) => {
             var rgFile = get(result, 'RegionFileName');
 
             if (rgFile) {

--- a/src/firefly/js/visualize/draw/DirectionArrowDrawObj.js
+++ b/src/firefly/js/visualize/draw/DirectionArrowDrawObj.js
@@ -164,7 +164,7 @@ function toRegion(startPt,endPt,plot,drawParams,renderOptions) {
 
     if (text) {
         des += setRegionPropertyDes(regionPropsList.TEXT, text) +
-               setRegionPropertyDes(regionPropsList.FONT, {name: 'helvetica', size: 9, weight: 'normal', style: 'normal'} );
+               setRegionPropertyDes(regionPropsList.FONT, {name: 'helvetica', size: 9, weight: 'normal', slant: 'normal'} );
     }
     des = endRegionDes(des);
 

--- a/src/firefly/js/visualize/draw/PointDataObj.js
+++ b/src/firefly/js/visualize/draw/PointDataObj.js
@@ -273,7 +273,7 @@ function makeTextLocationPoint(drawObj, plot, textLoc, fontSize) {
     if (!area) return null;
 
     var {centerPt, width, height} = area;
-    var fHeight = fontHeight(fontSize) + 4;
+    var fHeight = fontHeight(fontSize);
     var opt;
 
     switch(textLoc) {
@@ -319,6 +319,7 @@ function drawXY(ctx, drawTextAry, pt, plot, drawObj, drawParams,renderOptions, o
     if (textOffset && (textOffset.x !== 0.0 || textOffset.y !== 0.0)) {
         drawText(drawObj, drawTextAry, plot, vpt, drawParams);
     } else {
+        drawObj.textWorldLoc = plot.getImageCoords(vpt);
         DrawUtil.drawText(drawTextAry, text, vpt.x, vpt.y, color, renderOptions,
                           fontName, fontSize, fontWeight, fontStyle);
     }

--- a/src/firefly/js/visualize/draw/ShapeToRegion.js
+++ b/src/firefly/js/visualize/draw/ShapeToRegion.js
@@ -160,7 +160,8 @@ export function addTextRelatedProps(drawObj, drawParams) {
 
 
 /**
- * create text region seperate from the region of any shape in case there exit non default textloc or textoffset
+ * create text region seperate from the region of any shape in case there exists non default textloc or textoffset or
+ * a seperate request.
  * @param drawObj
  * @param drawParams
  * @param regionType
@@ -169,7 +170,7 @@ export function addTextRelatedProps(drawObj, drawParams) {
  */
 export function createTextRegionFromShape(drawObj, drawParams, regionType, cc) {
     var {textLoc}= drawParams;
-    var {text, textOffset}= drawObj;
+    var {text, textOffset, bSeperateText = false}= drawObj;
 
     var des = '';
     var searchTextLoc = () => {
@@ -186,14 +187,20 @@ export function createTextRegionFromShape(drawObj, drawParams, regionType, cc) {
     if (!text) return des;
 
     // check if text location is default as defined and no offset involved
-    if ((!textLoc || textLoc === DEFAULT_TEXTLOC[regionType.key]) &&
+    if ((!bSeperateText) &&
+        (!textLoc || textLoc === DEFAULT_TEXTLOC[regionType.key]) &&
         (!textOffset || (textOffset.x === 0.0 && textOffset.y === 0.0)))  return des;
 
     // adapt the computed text location if there is or recompute the text location
     var textWorldLoc = get(drawObj, 'textWorldLoc', searchTextLoc());
     if (!textWorldLoc) return des;
 
-    return makeTextRegion(cc.getWorldCoords(textWorldLoc), cc, drawObj, drawParams);
+    var textReg = makeTextRegion(cc.getWorldCoords(textWorldLoc), cc, drawObj, drawParams);
+    if (isEmpty(textReg)) {
+        return des;
+    } else {
+        return textReg[0];
+    }
 }
 
 /**

--- a/src/firefly/js/visualize/region/Region.js
+++ b/src/firefly/js/visualize/region/Region.js
@@ -36,17 +36,17 @@ var cloneArg = (arg) => Object.keys(arg).reduce((prev, key) =>
                         }, {});
 
 /**
- *
- * @param wpAry WorldPt array, items contained: line, annulus, ellipse, box: 1, line: 2, polygon: >= 3
- * @param radiusAry RegionValue array, items contained: annulus: at least 2 radii.
- * @param dimensionAry RegionDimension array, each item contains w, h for box and box annulus
+ * @summary make region object
+ * @param {Object[]} wpAry WorldPt array, items contained: line, annulus, ellipse, box: 1, line: 2, polygon: >= 3
+ * @param {Object[]} radiusAry RegionValue array, items contained: annulus: at least 2 radii.
+ * @param {Object[]} dimensionAry RegionDimension array, each item contains w, h for box and box annulus
  *                                            or 2 radii for ellipse and ellipse annulus
- * @param angle RegionValue
- * @param type  RegionType
- * @param options   RegionOptions, properties of region
- * @param highlighted bool
- * @param message parsing message
- * @constructor
+ * @param {Object} angle RegionValue
+ * @param {Object} type  RegionType
+ * @param {Object} options   RegionOptions, properties of region
+ * @param {boolean} highlighted bool
+ * @param {string} message parsing message
+ * @function makeRegion
  */
 export var makeRegion = (
             {
@@ -74,30 +74,29 @@ export var makeRegion = (
 
 
 /**
- *
- * @param color         string, 'white', 'black', 'red', 'green', 'blue', 'cyan', 'magenta', 'yellow'
- *                      default: 'green'
- * @param text          string,  default: ''
- * @param font          makeRegionFont,  default: 'helvetica 10 normal normal'
- * @param pointType     RegionPointType, default:
- * @param pointSize     number   default: 5
- * @param editable      bool     default: 1
- * @param movable       bool     default: 1
- * @param rotatable     bool     default: 0
- * @param highlightable bool     default: 1
- * @param deletable     bool     default: 1
- * @param fixedSize     bool     default: 0
- * @param include       bool     default: 1
- * @param lineWidth     number   default: 0
- * @param dashlist      string   default: "8 3"
- * @param source        bool     default: 1
- * @param dashable      bool     default: 0
- * @param offsetX       number   default: 0
- * @param offsetY       number   default: 0
- * @param message       string,  default: '', containing parsing (error) message
- * @param tag           string,  default: ''
- * @param coordSys      string
- * @constructor
+ * @summary make object for region properties
+ * @param {string} color 'white', 'black', 'red', 'green' (default), 'blue', 'cyan', 'magenta', 'yellow'
+ * @param {string} text default: ''
+ * @param {Object} font from makeRegionFont, default is from 'helvetica 10 normal normal'
+ * @param {Object} pointType  RegionPointType,
+ * @param {number} pointSize  default: 5
+ * @param {boolean} editable  default: 1
+ * @param {boolean} movable   default: 1
+ * @param {boolean} rotatable default: 0
+ * @param {boolean} highlightable default: 1
+ * @param {boolean} deletable default: 1
+ * @param {boolean} fixedSize default: 0
+ * @param {boolean} include default: 1
+ * @param {number} lineWidth default: 0
+ * @param {string} dashlist default: "8 3"
+ * @param {boolean} source  default: 1
+ * @param {boolean} dashable default: 0
+ * @param {number} offsetX default: 0
+ * @param {number} offsetY default: 0
+ * @param {string} message default: '', containing parsing (error) message
+ * @param {string} tag default: ''
+ * @param {string} coordSys default: 'PHYSICAL'
+ * @function makeRegionOptions
  */
 
 export var makeRegionOptions = (
@@ -180,7 +179,7 @@ export var defaultRegionProperty = {
     source: 1,
     offsetX: 0,
     offsetY: 0,
-    coordSys: 'J2000',
+    coordSys: 'PHYSICAL',
     textLoc: 'DEFAULT',
 
     message: ''
@@ -195,20 +194,20 @@ export var setRegionPropDefault = (prop, value) => {
 
 
 /**
- *
- * @param value value for radius and dimension
- * @param unit  DEGREE, SCREEN_PIXEL and IMAGE_PIXEL
- * @constructor
+ * @summary region value object
+ * @param {number} value value for radius and dimension
+ * @param {Object} unit  DEGREE, SCREEN_PIXEL and IMAGE_PIXEL
+ * @function RegionValue
  */
 
 export var RegionValue =
     (value = 0.0, unit = RegionValueUnit.CONTEXT) => ({value, unit});
 
 /**
- *
- * @param width  RegionValue width of box or first radius of ellipse
- * @param height RegionValue height of box or second radius of ellipse
- * @constructor
+ * @summary region value object for dimension
+ * @param {Object} width  RegionValue width of box or first radius of ellipse
+ * @param {Object} height RegionValue height of box or second radius of ellipse
+ * @function RegionDimension
  */
 export var RegionDimension = (width, height) => ({width, height});
 
@@ -226,110 +225,117 @@ export class RegParseException extends Error {
 export var makeRegionMsg = (msg) => makeRegion({type: RegionType.message, message: msg});
 
 /**
- *
- * @param rgTypeStr
- * @returns {RegionType}
+ * @summary get region type
+ * @param {string} rgTypeStr
+ * @returns {Object} RegionType
  */
 export var getRegionType = (rgTypeStr) => (RegionType.get(rgTypeStr) || RegionType.undefined);
 
 /**
- *
- * @param typeStr
- * @returns {RegionPointType}
+ * $summary get region point type
+ * @param {string} typeStr
+ * @returns {Object} RegionPointType
  */
 export var getRegionPointType = (typeStr) => (RegionPointType.get(typeStr) || RegionPointType.undefined);
 
 /**
- * parse font string set in region property
- * @param coordStr
- * @returns {RegionCsys}
+ * @summary get coordinate system
+ * @param {string} coordStr
+ * @returns {Object} RegionCsys
  */
 export var getRegionCoordSys = (coordStr) => (RegionCsys.get(coordStr) || RegionCsys.UNDEFINED);
 
 /**
- *
- * @param name string - ex: Arieal, Courier, Ties, Helvetica, sans-serif, BRAGGADOCIO
- * @param point string (font size) ex: 10, 12, 14, 16
- * @param weight string ex: normal, bold
- * @param slant string ex: normal, italic
+ * @summary get region font object
+ * @param {string} name ex: Arieal, Courier, Ties, Helvetica, sans-serif, BRAGGADOCIO
+ * @param {string} point font size,  ex: 10, 12, 14, 16
+ * @param {string} weight ex: normal, bold
+ * @param {string} slant ex: normal, italic
+ * @returns {Object}
  */
 export var makeRegionFont = (name = 'helvetica', point = '10', weight = 'normal', slant = 'normal') => (
         {name, point, weight, slant});
 
 /**
- * create region on point
- * @param worldPoint
- * @param options
- * @param highlighted
+ * @summary create region on point
+ * @param {Object} worldPoint
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionPoint(worldPoint, options, highlighted) {
     return  makeRegion({type: RegionType.point, wpAry: [worldPoint],  options, highlighted});
 }
 
 /**
- * create region on text
- * @param worldPoint
- * @param options
- * @param highlighted
+ * @summary create region on text
+ * @param {Object} worldPoint
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionText(worldPoint, options, highlighted) {
     return makeRegion({type: RegionType.text, wpAry: [worldPoint], options, highlighted});
 }
 
 /**
- * create region on box
- * @param worldPoint
- * @param angle RegionValue
- * @param dim   ReginDimension
- * @param options
- * @param highlighted
+ * @summary create region on box
+ * @param {Object} worldPoint
+ * @param {Object} angle RegionValue
+ * @param {Object} dim   ReginDimension containing width and height
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionBox(worldPoint, dim, angle, options, highlighted) {
     return makeRegion({type: RegionType.box, wpAry: [worldPoint], dimensionAry: [dim], angle, options, highlighted});
 }
 
 /**
- * create region on boxannulus
- * @param worldPoint
- * @param angle  RegionValue
- * @param dimAry array of RegionDimension, [w, h]
- * @param options
- * @param highlighted
- *
+ * @summary create region on boxannulus
+ * @param {Object} worldPoint
+ * @param {Object} angle  RegionValue
+ * @param {Object[]} dimAry array of RegionDimension containing width and height
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionBoxAnnulus(worldPoint, dimAry,  angle, options, highlighted) {
     return makeRegion({type: RegionType.boxannulus, wpAry: [worldPoint], dimensionAry: dimAry, angle, options, highlighted});
 }
 
 /**
- * create region on annulus
- * @param worldPoint
- * @param radAry array of RegionValue (radius)
- * @param options
- * @param highlighted
+ * @summary create region on annulus
+ * @param {Object} worldPoint
+ * @param {Object[]} radAry array of RegionValue (radius)
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionAnnulus(worldPoint, radAry,  options, highlighted) {
     return makeRegion({type: RegionType.annulus, wpAry: [worldPoint], radiusAry: radAry, options, highlighted});
 }
 
 /**
- * create region on circle
- * @param worldPoint
- * @param radius  RegionValue
- * @param options
- * @param highlighted
+ * @summary create region on circle
+ * @param {Object} worldPoint
+ * @param {Object} radius  RegionValue
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionCircle(worldPoint, radius,  options, highlighted) {
     return makeRegion({type: RegionType.circle, wpAry: [worldPoint], radiusAry: [radius], options, highlighted});
 }
 
 /**
- * create region on ellipse
- * @param worldPoint
- * @param angle  RegionValue
- * @param dim    RegionDimension [radius1, radius2]
- * @param options
- * @param highlighted
+ * @summary create region on ellipse
+ * @param {Object} worldPoint
+ * @param {Object} angle  RegionValue
+ * @param {Object} dim    RegionDimension containing radius 1 and radius 2
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionEllipse(worldPoint, dim, angle, options, highlighted) {
     return makeRegion({type: RegionType.ellipse, wpAry: [worldPoint],
@@ -338,12 +344,13 @@ export function makeRegionEllipse(worldPoint, dim, angle, options, highlighted) 
 
 
 /**
- * create region on ellipseannulus
- * @param worldPoint
- * @param angle  RegionValue
- * @param dimAry array of RegionDimension [radius1, radius2]
- * @param options
- * @param highlighted
+ * @summary create region on ellipseannulus
+ * @param {Object} worldPoint
+ * @param {Object} angle  RegionValue
+ * @param {Object[]} dimAry array of RegionDimension containing radius 1 and radius  2
+ * @param {Object} options
+ * @param {boolean} highlighted
+ * @returns {Object}
  */
 export function makeRegionEllipseAnnulus(worldPoint, dimAry, angle, options, highlighted ) {
     return makeRegion({type: RegionType.ellipseannulus, wpAry: [worldPoint],
@@ -351,21 +358,23 @@ export function makeRegionEllipseAnnulus(worldPoint, dimAry, angle, options, hig
 }
 
 /**
- * create region on line
- * @param worldPoint1
- * @param worldPoint2
- * @param options
- * @param highlight
+ * @summary create region on line
+ * @param {Object} worldPoint1
+ * @param {Object} worldPoint2
+ * @param {Object} options
+ * @param {boolean} highlight
+ * @returns {Object}
  */
 export function makeRegionLine(worldPoint1, worldPoint2, options, highlight ) {
     return makeRegion({ type: RegionType.line, wpAry: [worldPoint1, worldPoint2], options, highlight});
 }
 
 /**
- * create region on polygon
- * @param wpAry array of WorldPt
- * @param options
- * @param highlight
+ * @summary create region on polygon
+ * @param {Object[]} wpAry array of WorldPt
+ * @param {Object} options
+ * @param {boolean} highlight
+ * @returns {Object}
  */
 export function makeRegionPolygon(wpAry, options, highlight) {
     return makeRegion({type: RegionType.polygon, wpAry, options, highlight});

--- a/src/firefly/js/visualize/region/Region.js
+++ b/src/firefly/js/visualize/region/Region.js
@@ -248,10 +248,10 @@ export var getRegionCoordSys = (coordStr) => (RegionCsys.get(coordStr) || Region
 
 /**
  *
- * @param name string
- * @param point string (font size)
- * @param weight string
- * @param slant string
+ * @param name string - ex: Arieal, Courier, Ties, Helvetica, sans-serif, BRAGGADOCIO
+ * @param point string (font size) ex: 10, 12, 14, 16
+ * @param weight string ex: normal, bold
+ * @param slant string ex: normal, italic
  */
 export var makeRegionFont = (name = 'helvetica', point = '10', weight = 'normal', slant = 'normal') => (
         {name, point, weight, slant});

--- a/src/firefly/js/visualize/region/RegionDescription.js
+++ b/src/firefly/js/visualize/region/RegionDescription.js
@@ -53,7 +53,7 @@ var fontObjToStr = (v) => (`"${v.name} ${v.point} ${v.weight} ${v.slant}"` );
  * make region descript array from plot DrawObj of all visible DrawLayer
  * @param plot
  */
-export function makeRegionsFromPlot(plot)
+export function makeRegionsFromPlot(plot, bSeperateText = false)
 {
     var plotId = plot? plot.plotId : get(visRoot(), 'avtivePlotId');
     var dlAry = getAllDrawLayersForPlot(getDlAry(), plotId, true );
@@ -85,10 +85,12 @@ export function makeRegionsFromPlot(plot)
 
 
         drawObjs.forEach( (dObj) => {
+            dObj.bSeperateText = bSeperateText;
             oneRegionDes = DrawOp.toRegion(dObj, plot, dl.drawingDef);
             if (!isEmpty(oneRegionDes)) {
                 rgDesAry.push(...oneRegionDes);
             }
+            dObj.bSeperateText = null;
          } );
     });
     return rgDesAry;
@@ -240,7 +242,7 @@ export function setRegionPropertyDes(prop, value) {
             pval =  `"${get(value, 'name', v.name).toLowerCase()} ` +
                     `${get(value, 'size', v.point)} ` +
                     `${get(value, 'weight', v.weight).toLowerCase()} ` +
-                    `${get(value, 'style', v.slant)}"`;
+                    `${get(value, 'slant', v.slant)}"`;
 
             if (pval !== fontstr) {
                 des = `${pname}${pval}`;


### PR DESCRIPTION
The rendering of the region associated text was missing in the PNG. 
This issue is fixed by creating a separate text region  with the location calculated at JS parts, the text value and font defined in the original region, and sending the created text regions as well as the original regions to the server for producing the PNG. 

 