### PR TITLE
DM-7825: Use custom http headers to pass ws connection info

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/ClientEventQueue.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/ClientEventQueue.java
@@ -50,7 +50,6 @@ public class ClientEventQueue {
             if (name.equals(Name.EVT_CONN_EST)) {
                 JSONObject dataJ = JSONParser.parseStrict(sEvent.getData().toString()).isObject();
                 String sEventInfo = dataJ.get("connID").isString().stringValue() + "_" + dataJ.get("channel").isString().stringValue();
-                Cookies.setCookie("seinfo", sEventInfo);
                 GwtUtil.getClientLogger().log(Level.INFO, "Websocket connection established: " + sEventInfo );
             } else if (data instanceof BackgroundStatus) {
                 WebEvent<String> ev= new WebEvent<String>(ClientEventQueue.class,name,((BackgroundStatus)data).serialize());
@@ -84,10 +83,6 @@ public class ClientEventQueue {
         } catch(ex) {
             console.log("Exception sending message: " + msg);
         }
-    }-*/;
-
-    private native void closeConnection() /*-{
-        $wnd.firefly.ClientEventQueue.close();
     }-*/;
 
     public static native void start(String baseurl) /*-{
@@ -138,10 +133,6 @@ public class ClientEventQueue {
         doWSConnect();
     }-*/;
 
-//====================================================================
-//
-//====================================================================
-
     private static ServerEvent parseJsonEvent(String msg) {
         try {
             JSONObject eventJ = JSONParser.parseStrict(msg).isObject();
@@ -167,4 +158,12 @@ public class ClientEventQueue {
             return null;
         }
     }
+
+//====================================================================
+//
+//====================================================================
+
+    private native void closeConnection() /*-{
+        $wnd.firefly.ClientEventQueue.close();
+    }-*/;
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -32,11 +32,10 @@ import java.util.UUID;
  */
 public class RequestOwner implements Cloneable {
 
+    private static final Logger.LoggerImpl LOG = Logger.getLogger();
     public static String USER_KEY = "usrkey";
 //    private static final String[] ID_COOKIE_NAMES = new String[]{WebAuthModule.AUTH_KEY, "ISIS"};
     private static boolean ignoreAuth = AppProperties.getBooleanProperty("ignore.auth", false);
-    private static final Logger.LoggerImpl LOG = Logger.getLogger();
-
     private RequestAgent requestAgent;
     private Date startTime;
     private File workingDir;
@@ -67,15 +66,8 @@ public class RequestOwner implements Cloneable {
         if (requestAgent != null) {
             host = requestAgent.getHeader("host");
             referrer = requestAgent.getHeader("Referer");
-
-            String sei = requestAgent.getCookie("seinfo");
-            if (!StringUtils.isEmpty(sei)) {
-                String [] parts =  sei.split("_");
-                if (parts.length > 1) {
-                    eventConnID = parts[0];
-                    eventChannel = parts[1];
-                }
-            }
+            eventChannel = requestAgent.getHeader("FF-channel");
+            eventConnID = requestAgent.getHeader("FF-connID");
         }
     }
 
@@ -149,11 +141,6 @@ public class RequestOwner implements Cloneable {
         return !StringUtils.isEmpty(getAuthToken());
     }
 
-    // should only use this as a way to bypass the web-based access.
-    public void setUserInfo(UserInfo userInfo) {
-        this.userInfo = userInfo;
-    }
-
     public UserInfo getUserInfo() {
         if (userInfo == null) {
             if (isAuthUser() && !ignoreAuth) {
@@ -175,6 +162,11 @@ public class RequestOwner implements Cloneable {
             }
         }
         return userInfo;
+    }
+
+    // should only use this as a way to bypass the web-based access.
+    public void setUserInfo(UserInfo userInfo) {
+        this.userInfo = userInfo;
     }
 
     @Override

--- a/src/firefly/js/core/messaging/WebSocketClient.js
+++ b/src/firefly/js/core/messaging/WebSocketClient.js
@@ -3,7 +3,7 @@
  */
 
 import {get, pickBy} from 'lodash';
-import {setCookie, parseUrl} from '../../util/WebUtil.js';
+import {setCookie, parseUrl, getModuleName} from '../../util/WebUtil.js';
 import {getRootURL} from '../../util/BrowserUtil.js';
 import {dispatchUpdateAppData} from '../AppDataCntlr.js';
 
@@ -70,8 +70,6 @@ function addListener( {matches, onEvent} ) {
 }
 
 function onOpen() {
-    console.log('WS open: WebSocketClient started');
-
     if (pinger) clearInterval(pinger);
     pinger = setInterval(() => wsSend({}), 5000);
 }
@@ -97,8 +95,8 @@ function onMessage(event) {
         if (eventData.name === 'EVT_CONN_EST') {
             // connection established.. doing handshake.
             [connId, channel] = [eventData.data.connID, eventData.data.channel];
-            setCookie('seinfo', `${connId}_${channel}`);
             dispatchUpdateAppData({channel});
+            console.log(`WebSocket connected.  connId:${connId} channel:${channel}`); 
         } else {
             listenters.forEach( (l) => {
                 if (!l.matches || l.matches(eventData)) {

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -8,6 +8,7 @@ import Enum from 'enum';
 import update from 'react-addons-update';
 import {get, set, has, omit, isObject, union, isFunction, isEqual,  isNil, last} from 'lodash';
 import { getRootURL } from './BrowserUtil.js';
+import {getWsConnId, getWsChannel} from '../core/messaging/WebSocketClient.js';
 
 const  MEG          = 1048576;
 const GIG          = 1048576 * 1024;
@@ -143,7 +144,10 @@ export function fetchUrl(url, options, returnAllResponses= false) {
         };
     options = Object.assign(req, options);
 
-    const headers = {};
+    const headers = {
+        'FF-channel': getWsChannel(),
+        'FF-connID': getWsConnId()
+    };
     options.headers = Object.assign(headers, options.headers);
 
     if (options.params) {

--- a/src/firefly/python/display/firefly_client.py
+++ b/src/firefly/python/display/firefly_client.py
@@ -182,14 +182,11 @@ class FireflyClient(WebSocketClient):
                 conn_info = ev['data']
                 if self.channel is None:
                     self.channel = conn_info['channel']
-                conn_id = ''
-                if 'conn_id' in conn_info:
-                    conn_id = conn_info['conn_id']
-                seinfo = self.channel
-                if (len(conn_id)) > 0:
-                    seinfo = conn_id + '_' + seinfo
+                if 'connID' in conn_info:
+                    self.conn_id = conn_info['connID']
 
-                self.session.cookies['seinfo'] = seinfo
+                self.headers = {'FF_FF-channel': self.channel,
+                                'FF-connID': self.conn_id}
             except:
                 print('from callback exception: ')
                 print(m)
@@ -199,14 +196,14 @@ class FireflyClient(WebSocketClient):
     def _send_url_as_get(self, url):
         """Send URL in 'GET' request and return status."""
 
-        response = self.session.get(url)
+        response = self.session.get(url, headers=self.headers)
         status = json.loads(response.text)
         return status[0]
 
     def _send_url_as_post(self, data):
         """Send URL in 'POST' request and return status."""
 
-        response = self.session.post(self.url_root, data=data)
+        response = self.session.post(self.url_root, data=data, headers=self.headers)
         status = json.loads(response.text)
         return status[0]
 
@@ -367,7 +364,7 @@ class FireflyClient(WebSocketClient):
 
         url = 'http://' + self.this_host + '/firefly/sticky/Firefly_FileUpload?preload=%s' % pre_load
         files = {'file': open(path, 'rb')}
-        result = self.session.post(url, files=files)
+        result = self.session.post(url, files=files, headers=self.headers)
         index = result.text.find('$')
         return result.text[index:]
 
@@ -390,7 +387,7 @@ class FireflyClient(WebSocketClient):
 
         url = 'http://' + self.this_host + '/firefly/sticky/Firefly_FileUpload?preload=true'
         data_pack = {'data': stream}
-        result = self.session.post(url, files=data_pack)
+        result = self.session.post(url, files=data_pack, headers=self.headers)
         index = result.text.find('$')
         return result.text[index:]
 
@@ -434,7 +431,7 @@ class FireflyClient(WebSocketClient):
         url = 'http://' + self.this_host + '/firefly/sticky/Firefly_FileUpload?preload='
         url += 'true&type=FITS' if data_type.upper() == 'FITS' else 'false&type=UNKNOWN'
         data_pack = {'data': stream}
-        result = self.session.post(url, files=data_pack)
+        result = self.session.post(url, files=data_pack, headers=self.headers)
         index = result.text.find('$')
         return result.text[index:]
 


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-7825

We were using cookies to pass websocket connection info to the server.  This approach does not work in and embedded mode, ie. Gator.
I've converted to use custom http headers instead.  This also affects python api.  I've modified the code to reflect the changes.

The above url describe how to reproduce the problem.  This change fixed the above problem and should not have any regression issue.  Please confirm.