### PR TITLE
DM-7918 Constraint column render error and the state update error when column constraint changes 

### DIFF
--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -113,6 +113,16 @@ export class FilterInfo {
     }
 
     /**
+     * validator for column's filter.  it validates only the condition portion of the filter.
+     * @param conditions
+     * @returns {{valid: boolean, value: (string|*), message: string}}
+     */
+    static conditionValidatorNoAutoCorrect(conditions) {
+        const valid = FilterInfo.isConditionValid(conditions);
+        return {valid, value: conditions, message: FILTER_CONDITION_TTIPS};
+    }
+
+    /**
      * validate the filterInfo string
      * @param {string} filterInfo
      * @param {TableColumn[]} columns array of column definitions
@@ -145,7 +155,7 @@ export class FilterInfo {
     static validator(columns, filterInfo) {
         filterInfo = FilterInfo.autoCorrectFilter(filterInfo);
         const [valid, message] = FilterInfo.isValid(filterInfo, columns);
-        return {valid, value: filterInfo, message};
+        return  {valid, value: filterInfo, message};
     }
 
     /**

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -13,6 +13,7 @@ import {FILTER_CONDITION_TTIPS, FILTER_TTIPS, FilterInfo} from '../FilterInfo.js
 import {sortTableData, calcColumnWidths} from  '../TableUtil.js';
 import {InputAreaField} from '../../ui/InputAreaField.jsx';
 import {toBoolean} from '../../util/WebUtil.js';
+import {NOT_CELL_DATA} from './TableRenderer.js';
 
 const wrapperStyle = {display: 'block', flexGrow: 0};
 const style = {display: 'block', width: '100%', resize: 'none', boxSizing: 'border-box', backgroundColor: 'white'};
@@ -95,7 +96,7 @@ function prepareOptionData(columns, sortInfo, filterInfo, selectable) {
     const filterInfoCls = FilterInfo.parse(filterInfo);
     columns = columns.filter((c) => c.visibility !== 'hidden');
     var data = columns.map( (v) => {
-        const filter = toBoolean(v.filterable, true) ? filterInfoCls.getFilter(v.name) || '' : undefined;
+        const filter = toBoolean(v.filterable, true) ? filterInfoCls.getFilter(v.name) || '' : NOT_CELL_DATA;
         return [v.label||v.name||'', filter, v.units||'', v.desc||'', v.visibility !== 'hide'];
     } );
     sortTableData(data, cols, sortInfo);

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import FixedDataTable from 'fixed-data-table';
 import sCompare from 'react-addons-shallow-compare';
-import {set, get, isEmpty, isEqual, pick} from 'lodash';
+import {set, get, isEmpty, isEqual, isArray, pick} from 'lodash';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS} from '../FilterInfo.js';
 import {SortInfo} from '../SortInfo.js';
@@ -236,12 +236,21 @@ export const NOT_CELL_DATA = '__NOT_A_VALID_DATA___';
  */
 export const createInputCell = (tooltips, size = 10, validator, onChange, style) => {
     const changeHandler = (rowIndex, data, colIdx, v) => {
-        set(data, [rowIndex, colIdx], v.value);
+        set(data, [rowIndex, colIdx], [v.value, v.valid]);
         onChange && onChange();
     };
 
     return ({rowIndex, data, colIdx}) => {
-        const val = get(data, [rowIndex, colIdx]);
+        const dValue = get(data, [rowIndex, colIdx]);
+        var val, valid=true;
+
+        if (isArray(dValue)) {
+            val = dValue[0];
+            valid = get(dValue, ['1'], true);
+        } else {
+            val = dValue;
+        }
+
         if (val === NOT_CELL_DATA) {
             return null;
         } else {
@@ -255,6 +264,7 @@ export const createInputCell = (tooltips, size = 10, validator, onChange, style)
                         value={val}
                         onChange={(v) => changeHandler(rowIndex, data, colIdx, v) }
                         actOn={['blur','enter']}
+                        valid={valid}
                     />
                 </div>
             );

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import FixedDataTable from 'fixed-data-table';
 import sCompare from 'react-addons-shallow-compare';
-import {set, get, isEqual, pick} from 'lodash';
+import {set, get, isEmpty, isEqual, pick} from 'lodash';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS} from '../FilterInfo.js';
 import {SortInfo} from '../SortInfo.js';
@@ -224,6 +224,7 @@ export const createLinkCell = ({hrefColIdx, value}) => {
     };
 };
 
+export const NOT_CELL_DATA = '__NOT_A_VALID_DATA___';
 /**
  * creates an input field cell renderer.
  * @param tooltips
@@ -236,12 +237,12 @@ export const createLinkCell = ({hrefColIdx, value}) => {
 export const createInputCell = (tooltips, size = 10, validator, onChange, style) => {
     const changeHandler = (rowIndex, data, colIdx, v) => {
         set(data, [rowIndex, colIdx], v.value);
-        onChange && onChange(v);
+        onChange && onChange();
     };
 
     return ({rowIndex, data, colIdx}) => {
         const val = get(data, [rowIndex, colIdx]);
-        if (val === undefined) {
+        if (val === NOT_CELL_DATA) {
             return null;
         } else {
             return (

--- a/src/firefly/js/ui/InputField.jsx
+++ b/src/firefly/js/ui/InputField.jsx
@@ -1,7 +1,8 @@
 import React, {PropTypes} from 'react';
-import {has} from 'lodash';
+import {has, get} from 'lodash';
 
 import {InputFieldView} from './InputFieldView.jsx';
+import {NOT_CELL_DATA} from '../tables/ui/TableRenderer.js';
 
 
 function shouldAct(e, actOn) {
@@ -32,7 +33,11 @@ export class InputField extends React.Component {
         const nState = {fieldKey, value};
         if (shouldAct(e, actOn)) {
             var {valid, message, ...others} = validator ? validator(value) : {valid:true, message:''};
-            has(others, 'value') && (nState.value = others.value);    // allow the validator to modify the value.. useful in auto-correct.
+            var vadVal = get(others, 'value');  // vadVal has value as undefined in case no validator exists.
+            if (vadVal && vadVal !== NOT_CELL_DATA) {
+                nState.value = others.value;
+            }
+            //has(others, 'value') && (nState.value = others.value);    // allow the validator to modify the value.. useful in auto-correct.
             nState.valid = valid;
             nState.message = valid ? '' : (label + message).replace('::', ':');
             onChange && onChange(nState);

--- a/src/firefly/js/ui/InputField.jsx
+++ b/src/firefly/js/ui/InputField.jsx
@@ -46,7 +46,7 @@ export class InputField extends React.Component {
     }
 
     componentWillReceiveProps(nProps) {
-        this.setState(newState({value: nProps.value}));
+        this.setState(newState({value: nProps.value, valid: nProps.valid}));
     }
 
     render() {
@@ -93,6 +93,7 @@ InputField.propTypes = {
     wrapperStyle: PropTypes.object,
     labelStyle: PropTypes.object,
     value: PropTypes.string,
+    valid: PropTypes.bool,
     onChange: PropTypes.func,
     actOn: PropTypes.arrayOf(PropTypes.oneOf(['blur', 'enter', 'changes'])),
     showWarning : PropTypes.bool,

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -15,6 +15,7 @@ import {createLinkCell, createInputCell} from '../../tables/ui/TableRenderer.js'
 import * as TblCntlr from '../../tables/TablesCntlr.js';
 import {SelectInfo} from '../../tables/SelectInfo.js';
 import {FilterInfo, FILTER_TTIPS} from '../../tables/FilterInfo.js';
+import {isNil} from 'lodash';
 
 const sqlConstraintsCol = {name: 'constraints', idx: 1, type: 'char', width: 10};
 
@@ -37,13 +38,14 @@ export class CatalogConstraintsPanel extends React.Component {
     }
 
     componentDidMount() {
-        const {catname} = this.props;
-        this.fetchDD(catname, 'true'); //short form as default
+        const {catname, processId, dd_short} = this.props;
+        this.fetchDD(catname, dd_short, processId,   'true'); //short form as default
     }
 
     componentWillReceiveProps(np) {
-        if (np.catname != this.props.catname || np.dd_short != this.props.dd_short) {
-            this.fetchDD(np.catname, np.dd_short);
+        if (np.catname !== this.props.catname || np.dd_short !== this.props.dd_short ||
+            np.processId !== this.props.processId) {
+            this.fetchDD(np.catname,  np.dd_short, np.props.processId);
         } else if (this.state.tableModel) {
             if (np.tbl_id != this.state.tableModel.tbl_id) {
                 const tableModel = getTblById(np.tbl_id);
@@ -54,7 +56,31 @@ export class CatalogConstraintsPanel extends React.Component {
 
     render() {
         const {tableModel} = this.state;
-        const {catname, dd_short, fieldKey} = this.props;
+        const {catname, dd_short, fieldKey, showFormType=true, processId} = this.props;
+
+
+        var formTypeList = () => {
+                return (
+                    <div style={{display:'flex', flexDirection:'row', padding:'5px 5px 0'}}>
+                        <ListBoxInputField fieldKey={'ddform'} inline={true} labelWidth={0}
+                           initialState={{
+                                tooltip: 'Select form',
+                                value: 'false'
+                           }}
+                           options={[
+                                {label: 'Standard', value: 'true'},
+                                {label: 'Long form', value: 'false'}
+                           ]}
+                           labelWidth={75}
+                           label='Table Selection:'
+                           multiple={false}
+                        />
+                        <button style={{padding: '0 5px 0 5px', margin: showFormType ? '0 10px 0 10px' : '0'}}
+                                onClick={ () => this.fetchDD(catname, processId, dd_short, true)}>Reset
+                        </button>
+                    </div>
+                );
+        };
 
         if (isEmpty(tableModel) || !tableModel.tbl_id.startsWith(catname)) {
             return <div style={{top: 0}} className='loading-mask'/>;
@@ -66,25 +92,7 @@ export class CatalogConstraintsPanel extends React.Component {
                     style={{display:'flex', flexDirection:'column',
                             margin:'0px 10px 5px 5px', padding:'0 0 0 10px',
                             border:'1px solid #a3aeb9'}}>
-                    <div
-                        style={{display:'flex', flexDirection:'row', padding:'5px 5px 0'}}>
-
-                        <ListBoxInputField fieldKey={'ddform'} inline={true} labelWidth={0}
-                                           initialState={{
-                                          tooltip: 'Select form',
-                                          value: 'false'
-                                      }}
-                                           options={ [ {label: 'Standard', value: 'true'},
-                                                   {label: 'Long form', value: 'false'}
-                                                 ]}
-                                           labelWidth={75}
-                                           label='Table Selection:'
-                                           multiple={false}
-                        />
-                        <button style={{padding:'0 5px 0 5px', margin:'0 10px 0 10px'}}
-                                onClick={ () => this.fetchDD(catname, dd_short, true)}>Reset
-                        </button>
-                    </div>
+                    {showFormType && formTypeList()}
                     <div>
                         <TablePanelConnected {...{tableModel, fieldKey}} />
                         {renderSqlArea()}
@@ -100,8 +108,8 @@ export class CatalogConstraintsPanel extends React.Component {
      * @param dd_short
      * @param clearSelections
      */
-    fetchDD(catName, dd_short, clearSelections = false) {
-        const shortdd = (dd_short == 'true') ? 'short' : 'long';
+    fetchDD(catName, dd_short, processId, clearSelections = false) {
+        const shortdd = isNil(dd_short) ? '' : (dd_short == 'true') ? 'short' : 'long';
         const tblid = `${catName}-${shortdd}-dd-table-constraint`;
 
         //// Check if it exists already - fieldgroup has a keepState property but
@@ -113,8 +121,11 @@ export class CatalogConstraintsPanel extends React.Component {
         }
 
         //const catName = get(FieldGroupUtils.getGroupFields(gkey), 'cattable.value', '');
-        const request = {id: 'GatorDD', 'catalog': catName, 'short': dd_short}; //Fetch DD master table
+        const request = {id: processId, 'catalog': catName, short: dd_short}; //Fetch DD master table
         const urldef = get(FieldGroupUtils.getGroupFields(this.props.groupKey), 'cattable.coldef', 'null');
+        //if (dd_short) {
+        //    request['short'] = dd_short;
+        // }
 
         doFetchTable(request).then((tableModel) => {
             const tableModelFetched = tableModel;
@@ -208,22 +219,23 @@ CatalogConstraintsPanel.propTypes = {
     dd_short: PropTypes.string,
     constraintskey: PropTypes.string,
     fieldKey: PropTypes.string,
-    groupKey: PropTypes.string
+    groupKey: PropTypes.string,
+    showFormType: PropTypes.bool,
+    processId: PropTypes.string
 };
 
 CatalogConstraintsPanel.defaultProps = {
-    catname: ''
+    catname: '',
+    processId: 'GatorDD'
 };
 
 /**
  * display the data restrictions into a tabular format
- * @returns {XML}
- * @param onChange
- * @param ontablechanged
- * @param fieldKey
- * @param tableModel
+ * @param {func} ontTableChanged
+ * @param {Object} tableModel
+ * @returns {Object} constraint table
  */
-function ConstraintPanel({tableModel, fieldKey, onChange, ontablechanged}) {
+function ConstraintPanel({tableModel, onTableChanged}) {
     //define the table style only in the table div
     const tableStyle = {
         boxSizing: 'border-box',
@@ -249,15 +261,10 @@ function ConstraintPanel({tableModel, fieldKey, onChange, ontablechanged}) {
     const tbl_ui_id = tableModel.tbl_id + '-ui';
     return (
 
-        <div
-            style={{display:'inline-block',
-                    width: '97%', height: '170px', padding: '5px 5px'}}>
-            {
-                /*<div style={popupPanelResizableStyle}>
-                 <div style={tableStyle}>*/
-            }
+        <div style={{display:'inline-block',
+                     width: '97%', height: '170px', padding: '5px 5px'}}>
             <TablePanel
-                onTableChanged={ontablechanged}
+                onTableChanged={onTableChanged}
                 //onBlur={ (e) => {console.log('onChange called from table '+e.value);}}
                 showToolbar={false}
                 showMask={true}
@@ -266,26 +273,27 @@ function ConstraintPanel({tableModel, fieldKey, onChange, ontablechanged}) {
                 tbl_ui_id = {tbl_ui_id}
                 tableModel={tableModel}
                 renderers={
-                                        {
-                                            name:
-                                                { cellRenderer:
-                                                                createLinkCell(
-                                                                    {
-                                                                        hrefColIdx: tableModel.tableData.columns.length-1
-                                                                    }
-                                                                )
-                                                },
-                                            constraints:
-                                                { cellRenderer:
-                                                                createInputCell(
-                                                                         FILTER_TTIPS,
-                                                                         15,
-                                                                         FilterInfo.validator,
-                                                                         onChange
-                                                                )
-                                                }
-                                        }
-                               }
+                    {
+                        name:
+                            { cellRenderer:
+                                createLinkCell(
+                                    {
+                                        hrefColIdx: tableModel.tableData.columns.length-1
+                                    }
+                                )
+                            },
+                        constraints:
+                            { cellRenderer:
+                                createInputCell(
+                                         FILTER_TTIPS,
+                                         15,
+                                         //FilterInfo.conditionValidatorNoAutoCorrect,
+                                         null,
+                                         onTableChanged
+                                )
+                            }
+                    }
+                }
             />
         </div>
     );
@@ -293,25 +301,18 @@ function ConstraintPanel({tableModel, fieldKey, onChange, ontablechanged}) {
 
 export const TablePanelConnected = fieldGroupConnector(ConstraintPanel, getProps, null, null);
 
-const mypropTypes = {
-    onTableChanged: PropTypes.func,
-    fieldKey: PropTypes.string,
-    groupKey: PropTypes.string
-};
-
 function getProps(params, fireValueChange) {
 
     return Object.assign({}, params,
         {
-            //onBlur: (ev) => handleOnBlur(ev, params, fireValueChange)
-            ontablechanged: (ev) => handleOnTableChanged(ev, params, fireValueChange)
+            onTableChanged: () => handleOnTableChanged(params, fireValueChange)
         });
 }
 
-function handleOnTableChanged(ev, params, fireValueChange) {
+function handleOnTableChanged(params, fireValueChange) {
     //var {sql, selCol} = functionGetNewVal(params.tablemodel);
     //sql != params.sql;
-    const {tbl_id} = params;
+    const {tbl_id} = params.tableModel;
     const tbl = getTblById(tbl_id);
     let tbl_data = {};
     let sel_info = {};
@@ -323,25 +324,25 @@ function handleOnTableChanged(ev, params, fireValueChange) {
     }
 
     let sqlTxt = '';
+    let errors = '';
 
     tbl_data.forEach((d) => {
         if (d[1] && d[1].trim().length > 0) {
             const filterString = d[1].trim();
             const colName = d[0];
-            //const filterInfoCls = FilterInfo.parse(d[0] + d[1]);
-            //const val = filterInfoCls.serialize();
             const parts = filterString && filterString.split(';');
-            const nparts = parts.length;
+
             parts.forEach((v, idx) => {
                 // const parts = v.trim().match(extract_regex);
+                var {valid, value} = FilterInfo.conditionValidatorNoAutoCorrect(v);  // TODO: need more detail syntax check
 
-                sqlTxt += `${colName} ${v} `;
-
-                if (idx < nparts - 1) {
-                    sqlTxt += ' AND ';
+                if (!valid) {
+                    errors += (errors.length > 0 ? ` ${value}` : value);
+                } else {
+                    var oneSql = `${colName} ${v}`;
+                    sqlTxt += (sqlTxt.length > 0 ? ` AND ${oneSql}` : oneSql);
                 }
             });
-
         }
     });
 
@@ -352,7 +353,6 @@ function handleOnTableChanged(ev, params, fireValueChange) {
             selCols += tbl_data[colIdxSelected][0] + ',';
         }
     }
-
 
     // the value of this input field is a string
     const val = get(params, 'value', '');
@@ -365,16 +365,16 @@ function handleOnTableChanged(ev, params, fireValueChange) {
     // CAN BECOME AN ENDLESS LOOP IF IT FIRES AGAIN WITHOUT CHECKING
     // BASICALLY IMPLEMENTING HERE THE 'ONCHANGE' OF THE TABLEVIEW USED IN A FORM
 
-    if (val.constraints != sqlTxt || val.selcols != selCols) {
+    if (val.constraints !== sqlTxt || val.selcols !== selCols) {
         fireValueChange({
-            value: {constraints: sqlTxt, selcols: selCols}
+            value: {constraints: sqlTxt, selcols: selCols, errorConstraints: errors}
         });
     }
 }
 
 const extract_regex = new RegExp('(<|>|>=|<=|=|!=|like|in)(.+)', 'i');
 
-const inputFiledValidator = (filterString) => {
+const inputFieldValidator = (filterString) => {
     let retval = {valid: true, message: ''};
     if (filterString) {
         filterString && filterString.split(';').forEach((v) => {

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -15,7 +15,7 @@ import {createLinkCell, createInputCell} from '../../tables/ui/TableRenderer.js'
 import * as TblCntlr from '../../tables/TablesCntlr.js';
 import {SelectInfo} from '../../tables/SelectInfo.js';
 import {FilterInfo, FILTER_TTIPS} from '../../tables/FilterInfo.js';
-import {isNil} from 'lodash';
+import {isNil, isArray} from 'lodash';
 
 const sqlConstraintsCol = {name: 'constraints', idx: 1, type: 'char', width: 10};
 
@@ -305,8 +305,8 @@ function ConstraintPanel({tableModel, onTableChanged}) {
                                 createInputCell(
                                          FILTER_TTIPS,
                                          15,
-                                         //FilterInfo.conditionValidatorNoAutoCorrect,
-                                         null,
+                                         FilterInfo.conditionValidatorNoAutoCorrect,
+                                         //null,
                                          onTableChanged
                                 )
                             }
@@ -345,10 +345,18 @@ function handleOnTableChanged(params, fireValueChange) {
     let errors = '';
 
     tbl_data.forEach((d) => {
-        if (d[1] && d[1].trim().length > 0) {
-            const filterString = d[1].trim();
-            const colName = d[0];
-            const parts = filterString && filterString.split(';');
+        var filterStrings, valid = true;
+        const colName = d[0];
+
+        if (isArray(d[1])) {
+            filterStrings = d[1][0].trim();
+            valid = get(d[1], '1', true);
+        } else {
+            filterStrings = d[1].trim();
+        }
+
+        if (filterStrings && filterStrings.length > 0) {
+            const parts = filterStrings && filterStrings.split(';');
 
             parts.forEach((v, idx) => {
                 // const parts = v.trim().match(extract_regex);

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -43,9 +43,10 @@ export class CatalogConstraintsPanel extends React.Component {
     }
 
     componentWillReceiveProps(np) {
-        if (np.catname !== this.props.catname || np.dd_short !== this.props.dd_short ||
-            np.processId !== this.props.processId) {
-            this.fetchDD(np.catname,  np.dd_short, np.props.processId);
+        if (np.processId !== this.props.processId) {
+            this.fetchDD(np.catname,  np.dd_short, np.processId, true);
+        } else if (np.catname !== this.props.catname || np.dd_short !== this.props.dd_short) {
+            this.fetchDD(np.catname,  np.dd_short, np.processId);
         } else if (this.state.tableModel) {
             if (np.tbl_id != this.state.tableModel.tbl_id) {
                 const tableModel = getTblById(np.tbl_id);
@@ -58,27 +59,28 @@ export class CatalogConstraintsPanel extends React.Component {
         const {tableModel} = this.state;
         const {catname, dd_short, fieldKey, showFormType=true, processId} = this.props;
 
-
+        var resetButton = () => {
+            return (
+                <button style={{padding: '0 5px 0 5px', margin: showFormType ? '0 10px 0 10px' : '0'}}
+                        onClick={ () => this.fetchDD(catname,  dd_short, processId, true)}>Reset
+                </button>
+            );
+        };
         var formTypeList = () => {
                 return (
-                    <div style={{display:'flex', flexDirection:'row', padding:'5px 5px 0'}}>
-                        <ListBoxInputField fieldKey={'ddform'} inline={true} labelWidth={0}
-                           initialState={{
-                                tooltip: 'Select form',
-                                value: 'false'
-                           }}
-                           options={[
-                                {label: 'Standard', value: 'true'},
-                                {label: 'Long form', value: 'false'}
-                           ]}
-                           labelWidth={75}
-                           label='Table Selection:'
-                           multiple={false}
-                        />
-                        <button style={{padding: '0 5px 0 5px', margin: showFormType ? '0 10px 0 10px' : '0'}}
-                                onClick={ () => this.fetchDD(catname, processId, dd_short, true)}>Reset
-                        </button>
-                    </div>
+                   <ListBoxInputField fieldKey={'ddform'} inline={true} labelWidth={0}
+                       initialState={{
+                            tooltip: 'Select form',
+                            value: 'false'
+                       }}
+                       options={[
+                            {label: 'Standard', value: 'true'},
+                            {label: 'Long form', value: 'false'}
+                       ]}
+                       labelWidth={75}
+                       label='Table Selection:'
+                       multiple={false}
+                   />
                 );
         };
 
@@ -92,7 +94,10 @@ export class CatalogConstraintsPanel extends React.Component {
                     style={{display:'flex', flexDirection:'column',
                             margin:'0px 10px 5px 5px', padding:'0 0 0 10px',
                             border:'1px solid #a3aeb9'}}>
-                    {showFormType && formTypeList()}
+                    <div style={{display:'flex', flexDirection:'row', padding:'5px 5px 0'}}>
+                        {showFormType && formTypeList()}
+                        {resetButton()}
+                    </div>
                     <div>
                         <TablePanelConnected {...{tableModel, fieldKey}} />
                         {renderSqlArea()}
@@ -109,7 +114,7 @@ export class CatalogConstraintsPanel extends React.Component {
      * @param clearSelections
      */
     fetchDD(catName, dd_short, processId, clearSelections = false) {
-        const shortdd = isNil(dd_short) ? '' : (dd_short == 'true') ? 'short' : 'long';
+        const shortdd = isNil(dd_short) ? '' : (dd_short === 'true') ? 'short' : 'long';
         const tblid = `${catName}-${shortdd}-dd-table-constraint`;
 
         //// Check if it exists already - fieldgroup has a keepState property but
@@ -379,7 +384,7 @@ const inputFieldValidator = (filterString) => {
     if (filterString) {
         filterString && filterString.split(';').forEach((v) => {
             const parts = v.trim().match(extract_regex) || [];
-            if (parts.length == 0) {
+            if (parts.length === 0) {
                 retval = {valid: false, message: `${v} not valid: ${FILTER_TTIPS}`};
                 return retval;
             }

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -89,6 +89,18 @@ export class CatalogSelectViewPanel extends Component {
     }
 }
 
+function validConstraints(groupKey) {
+    const {tableconstraints} = FieldGroupUtils.getGroupFields(groupKey);
+
+    var errMsg = get(tableconstraints, ['value', 'errorConstraints']);
+
+    if (!isEmpty(errMsg)) {
+        showInfoPopup('Invalid constraints: ' + errMsg);
+        return false;
+    }
+    return true;
+}
+
 function onSearchSubmit(request) {
     console.log('original request <br />' + JSON.stringify(request));
 
@@ -100,7 +112,9 @@ function onSearchSubmit(request) {
             showInfoPopup('Target is required');
             return;
         }
-        doCatalog(request);
+        if (validConstraints(gkey)) {
+            doCatalog(request);
+        }
     }
     else if (request.Tabs === 'loadcat') {
         doLoadTable(request);
@@ -710,7 +724,7 @@ function fieldInit() {
         },
         'tableconstraints': {
             fieldKey: 'tableconstraints',
-            value: {constraints: '', selcols: ''},
+            value: {constraints: '', selcols: '', errorConstraints: ''},
             tbl_id: ''
         },
         'txtareasql': {


### PR DESCRIPTION
Fixed the bugs for catalog search constraints, the bugs are: 
- the constraint rendering became empty when 'enter' key is pressed or the focus on the cell is moved away. 
- the state regarding the search constraints is not updated when the constraint changes. 

Note:
If any entered column constraint is checked to be invalid, the error message will be shown in a popup box when the 'search' button is clicked and the search will stop. 