### PR TITLE
DM-8010: Add LSSTMetaSearch and LSSTCatalogSearch processors

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
@@ -1,4 +1,5 @@
 package edu.caltech.ipac.firefly.server.query.lsst;
+
 import edu.caltech.ipac.firefly.data.CatalogRequest;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
@@ -10,21 +11,40 @@ import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupWriter;
-import edu.caltech.ipac.firefly.server.util.ipactable.TableDef;
 import edu.caltech.ipac.firefly.util.DataSetParser;
+import edu.caltech.ipac.firefly.visualize.VisUtil;
 import edu.caltech.ipac.util.*;
+import edu.caltech.ipac.util.download.URLDownload;
+import edu.caltech.ipac.visualize.plot.WorldPt;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import java.io.*;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.lang.Exception;
+
 import edu.caltech.ipac.visualize.plot.CoordinateSys;
 import edu.caltech.ipac.firefly.data.table.MetaConst;
 
 
 /**
  * Created by zhang on 10/10/16.
+ * This is the Catalog search processor.  For any given target (ra and dec, except in polygon), it searches based
+ * the search method.  It supports four search methods:
+ *   1.  cone
+ *   2.  box
+ *   3.  Elliptical
+ *   4.  Polygon
+ *
+ *   For cone, box and polygon searches, all input have to be in degree unit
+ *   For Elliptical, ra and dec are in degree and the semi axis are in arcsec.
+ *
  */
 @SearchProcessorImpl(id = "LSSTCataLogSearch")
 public class LSSTCataLogSearch extends IpacTablePartProcessor {
@@ -32,35 +52,19 @@ public class LSSTCataLogSearch extends IpacTablePartProcessor {
     private static final String DEC = "coord_decl";
 
     private static final Logger.LoggerImpl _log = Logger.getLogger();
-
-    private static String DATA_ACCESS_URI = AppProperties.getProperty("lsst.dataAccess.uri", "lsst.dataAccess.uri");
+    private static final String PORT = "5000";
+    private static final String HOST = AppProperties.getProperty("lsst.dd.hostname","lsst-qserv-dax01.ncsa.illinois.edu");
+    private static final String DATABASE_NAME =AppProperties.getProperty("lsst.database" , "gapon_sdss_stripe92_patch366_0");
 
 
     @Override
     protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
 
+        try {
 
-
-        File dataFile = new File(request.getParam("table_path")+request.getParam("table_name")+".csv");
-       // File dataFile = new File(request.getParam("table_path")+request.getParam("table_name")+".json");
-
-        TableServerRequest metaRequest = new TableServerRequest("LSSTMetaSearch");
-        metaRequest.setParam("table_path",request.getParam("table_path") );
-        metaRequest.setParam("table_name",request.getParam("meta_table") );
-        metaRequest.setPageSize(Integer.MAX_VALUE);
-
-         try {
-             File outFile = createFile(request, ".tbl");
-             DataType[] dataTypes=getMeta(metaRequest);
-             DataGroup dg = getTableDataFromCsv(dataFile,dataTypes);
-
-             //add the short description to the table
-             for (int i=0; i<dataTypes.length; i++){
-                 dg.addAttribute(DataSetParser.makeAttribKey(DataSetParser.DESC_TAG, dataTypes[i].getKeyName()),
-                         dataTypes[i].getShortDesc());
-             }
+             DataGroup dg = getDataFromURL(request);
              dg.shrinkToFitData();
-
+             File outFile = createFile(request, ".tbl");
              DataGroupWriter.write(outFile, dg,0);
              _log.info("table loaded");
              return  outFile;
@@ -69,102 +73,162 @@ public class LSSTCataLogSearch extends IpacTablePartProcessor {
              e.printStackTrace();
          }
          return null;
-   }
+    }
 
 
-    private DataType getDataType(String colName, DataType[] dataType){
-        for (int i=0; i<dataType.length; i++){
-            if (dataType[i].getKeyName().equalsIgnoreCase(colName)){
-                return dataType[i];
+
+    protected String getSearchMethod(TableServerRequest req) throws Exception {
+
+        if (req.getParam("SearchMethod").equalsIgnoreCase("polygon")) {
+            String radecList = req.getParam(CatalogRequest.POLYGON);
+            String[] sArray = radecList.split(",");
+            String polygoneStr = "scisql_s2PtInCPoly(coord_ra,coord_decl,";
+            for (int i=0; i<sArray.length; i++){
+                String[] radecPair = sArray[i].trim().split("\\s+");
+                if (radecPair.length!=2){
+                    throw new Exception("wrong data entered");
+                }
+                if (i==sArray.length-1) {
+                    polygoneStr = polygoneStr + radecPair[0] + "," + radecPair[1] + ")=1;";
+                }
+                else {
+                    polygoneStr = polygoneStr + radecPair[0] + "," + radecPair[1] + ",";
+                }
+            }
+            return polygoneStr;
+        }
+        else{
+            String[]  radec = req.getParam("UserTargetWorldPt").split(";");
+            String ra = radec[0];
+            String dec = radec[1];
+            if (req.getParam("SearchMethod").equalsIgnoreCase("box")) {
+                String side = req.getParam(CatalogRequest.SIZE);
+                WorldPt wpt = new WorldPt(new Double(ra).doubleValue(), new Double(dec).doubleValue());
+                VisUtil.Corners corners  = VisUtil. getCorners(wpt, new Double(side).doubleValue());
+                String upperLeft = String.format(Locale.US, "%8.6f,%8.6f", corners.getUpperLeft().getLon(), corners.getUpperLeft().getLat());
+                String lowerRight = String.format(Locale.US, "%8.6f,%8.6f", corners.getLowerRight().getLon(), corners.getLowerRight().getLat());
+                return "scisql_s2PtInBox(coord_ra,coord_decl," +  lowerRight + "," +upperLeft + ")=1;";
+
+            }
+            else if (req.getParam("SearchMethod").equalsIgnoreCase("cone")) {
+                String radius = req.getParam(CatalogRequest.RADIUS);
+                //TODO remove it after the unit is degree
+                if (!radius.equalsIgnoreCase("0.01")){
+                    radius="0.01";
+                }
+                return "scisql_s2PtInCircle(coord_ra,coord_decl,"+ra +","+dec+","+radius +")=1;";
+
+            } else if (req.getParam("SearchMethod").equalsIgnoreCase("Eliptical")) {
+                double semiMajorAxis = new Double( req.getParam("radius")).doubleValue();
+                double ratio = new Double(req.getParam(CatalogRequest.RATIO)).doubleValue();
+                Double semiMinorAxis = semiMajorAxis*ratio;
+                String positionAngle = req.getParam("posang");
+                return  "scisql_s2PtInEllipse(coord_ra,coord_decl," + ra + "," + dec + "," + semiMajorAxis + "," +
+                        semiMinorAxis + "," + positionAngle + ")=1;";
             }
         }
         return null;
-    }
-    private DataObject getRow(DataType[] dataType, String[] cols,  String csvLine, DataGroup dg ) throws Exception {
-
-        String[] strVaues = csvLine.split(",");
-        if (strVaues.length!=cols.length){
-            throw new Exception("data length does not match");
-        }
-        DataObject row = new DataObject(dg);
-        for (int i=0; i<strVaues.length; i++){
-            DataType type = getDataType(cols[i], dataType);
-            if (type==null){
-                System.out.println("****name="+cols[i]);
-                throw new Exception("no data type define");
-            }
-
-
-            if (strVaues[i].equalsIgnoreCase("null")) {
-                type.setMayBeNull(true);
-                row.setDataElement(type, null);
-            }
-            else{
-                row.setDataElement(type, type.convertStringToData(strVaues[i]));
-            }
-
-        }
-
-        return row;
 
     }
-    private DataGroup getTableDataFromCsv(File  csvFile, DataType[] dataType ) throws Exception {
 
-        DataGroup dg = new DataGroup("result", dataType);
-        BufferedReader reader = new BufferedReader(new FileReader(csvFile));
-        try {
-            //get the first line and then convert to column names
-            String line = reader.readLine();
-            String[] cols = line.split(",");
-            while ((line = reader.readLine()) != null) {
+    String buildSqlQueryString(TableServerRequest request) throws Exception {
 
-                DataObject row = getRow(dataType, cols, line, dg);
-                dg.add(row);
-
-            }
-        }
-        finally {
-            // Free up file descriptor resources
-            reader.close();
+        String tableName = request.getParam("table_name");
+        String catTable = request.getParam(CatalogRequest.CATALOG);
+        if (catTable == null) {
+            //throw new RuntimeException(CatalogRequest.CATALOG + " parameter is required");
+            catTable = DATABASE_NAME+"."+ tableName;
         }
 
-        return dg;
+        String sql = "SELECT "+request.getParam(CatalogRequest.SELECTED_COLUMNS) + " FROM " + catTable +
+                " WHERE " + getSearchMethod( request);
+        return sql;
     }
+
+    private DataGroup  getDataFromURL(TableServerRequest request) throws Exception {
+
+        String sql = "query=" + URLEncoder.encode(buildSqlQueryString(request),"UTF-8");
+
+        try{
+            long cTime = System.currentTimeMillis();
+            _log.briefDebug("Executing SQL query: " + sql);
+            String url = "http://"+HOST +":"+PORT+"/db/v0/tap/sync";
+
+            File file = createFile(request, ".json");
+            Map<String, String> requestHeader=new HashMap<>();
+            requestHeader.put("Accept", "application/json");
+
+             URLDownload.getDataToFileUsingPost(new URL(url),sql,null,  requestHeader, file, null);
+             DataGroup dg =  getTableDataFromJson( request,file);
+            _log.briefDebug("SHOW COLUMNS took " + (System.currentTimeMillis() - cTime) + "ms");
+
+            return dg;
+
+        }
+        catch (Exception e) {
+            _log.error(e);
+            throw new DataAccessException("Query failed: " + e.getMessage());
+
+        }
+
+    }
+
 
     /**
      * This method convert the json data file to data group
      * @param jsonFile
-     * @param tableDef
      * @return
      * @throws IOException
      * @throws ParseException
      */
-    private DataGroup getTableDataFromJson(File jsonFile, TableDef tableDef) throws IOException, ParseException {
+    private DataGroup getTableDataFromJson(TableServerRequest request,  File jsonFile) throws IOException, ParseException {
 
+        JSONParser parser = new JSONParser();
+        JSONObject obj = (JSONObject) parser.parse(new FileReader(jsonFile));
+        JSONArray data =  (JSONArray) ((JSONObject) ((JSONObject) obj.get("result")).get("table")).get("data");
 
-         JSONArray tableData = getArrayData( jsonFile);
-         DataType[]  dataType =  tableDef.getCols().toArray(new DataType[0]);
+        JSONArray columns = (JSONArray) ( (JSONObject) ( (JSONObject)( (JSONObject) obj.get("result")).get("table")).get("metadata")).get("elements");
+        DataType[] dataType = getTypeDef(request, columns);
 
         DataGroup dg = new DataGroup("result", dataType  );
 
-        for (int i=0; i<tableData.size(); i++){
-            JSONObject rowTblData = (JSONObject) tableData.get(i);
+        for (int i=0; i<dataType.length; i++){
+            dg.addAttribute(DataSetParser.makeAttribKey(DataSetParser.DESC_TAG, dataType[i].getKeyName()),
+                    dataType[i].getShortDesc());
+        }
+
+        if (data.size()==0) return dg; //empty dataGroup
+        for (int i=0; i<data.size(); i++){
+            JSONArray  rowTblData = (JSONArray) data.get(i);
             DataObject row = new DataObject(dg);
             for (int j=0; j<dataType.length; j++){
-                Object value = getValue(dataType[j].getKeyName(), rowTblData);
-                 if (value==null){
-                        dataType[j].setMayBeNull(true);
-                        row.setDataElement(dataType[j], null);
-                 }
-                 else {
-                       //data stored in the cell should be the correct type as defined
-                       row.setDataElement(dataType[j], value);
-                  }
+
+                Object d = rowTblData.get(j);
+                if (d==null){
+                    dataType[j].setMayBeNull(true);
+                    row.setDataElement(dataType[j], null);
+                }
+                else  {
+
+                    //if it is a boolean, convert the "text" to boolean
+                    if (dataType[j].getDataType().getTypeName().equalsIgnoreCase("java.lang.Boolean")){
+                        char c = d.toString().toCharArray()[0];
+                        if (c=='\u0000'){
+                            System.out.println(c);
+                        }
+                        if (d.toString().equalsIgnoreCase(new String("\u0000"))  || d.toString().length()==0) {//\u0000 is "", an empty string
+                            d=new Boolean(false);
+                        }
+                        else {
+                            d=new Boolean(true);
+                        }
+                    }
+                   row.setDataElement(dataType[j],d );
+                }
 
             }
             dg.add(row);
         }
-
 
         return dg;
     }
@@ -207,50 +271,52 @@ public class LSSTCataLogSearch extends IpacTablePartProcessor {
         return null;
 
     }
-    private  DataType[] getMetaFromMetatable(DataGroup dataGroup){
+    private  DataType[] getTypeDef(TableServerRequest request, JSONArray columns){
 
-        DataType[] dataTypes = new DataType[dataGroup.size()];
-        DataObject[] dataObjects=dataGroup.values().toArray(new DataObject[0]);
-        for (int i=0; i<dataObjects.length; i++){
-            boolean maybeNull = dataObjects[i].getDataElement("Null").toString().equalsIgnoreCase("yes")?true:false;
-            String keyName = (String) dataObjects[i].getDataElement("Field");
-            dataTypes[i] = new DataType(keyName ,keyName,
-                    getDataClass( (String) dataObjects[i].getDataElement("Type")),
-                    DataType.Importance.HIGH,
-                    (String) dataObjects[i].getDataElement("Unit"),
-                    maybeNull
-            );
 
-            dataTypes[i].setShortDesc((String) dataObjects[i].getDataElement("Description"));
+        TableServerRequest metaRequest = new TableServerRequest("LSSTMetaSearch");
+        metaRequest.setParam("table_name",request.getParam("meta_table") );
+        metaRequest.setPageSize(Integer.MAX_VALUE);
+        //call LSSTMetaSearch processor to get the meta data as a DataGroup
+        DataGroup metaData = getMeta(metaRequest);
 
+        DataType[] dataTypes = new DataType[columns.size()];
+        DataObject[] dataObjects=metaData.values().toArray(new DataObject[0]);
+        for (int k=0; k<columns.size(); k++) {
+            JSONObject col = (JSONObject) columns.get(k);
+            for (int i = 0; i < dataObjects.length; i++) {
+                 String keyName = ((String) dataObjects[i].getDataElement("Field")).trim();
+                 if (keyName.equalsIgnoreCase( col.get("name").toString().trim() ) ){
+                      boolean maybeNull = dataObjects[i].getDataElement("Null").toString().equalsIgnoreCase("yes") ? true : false;
+                      dataTypes[k] = new DataType(keyName, keyName,
+                            getDataClass((String) dataObjects[i].getDataElement("Type")),
+                            DataType.Importance.HIGH,
+                            (String) dataObjects[i].getDataElement("Unit"),
+                            maybeNull
+                    );
+                    dataTypes[k].setShortDesc((String) dataObjects[i].getDataElement("Description"));
+                    break;
+                }
+            }
         }
-
         return dataTypes;
     }
-    private DataType[] getMeta(TableServerRequest request){
-       SearchManager sm = new SearchManager();
 
+    private DataGroup getMeta(TableServerRequest request){
+
+
+        SearchManager sm = new SearchManager();
         try {
             DataGroupPart dgp = sm.getDataGroup(request);
 
-            DataGroup metaData = dgp.getData();
-            return  getMetaFromMetatable(metaData );
+           return dgp.getData();
+
         } catch (Exception e) {
             e.getStackTrace();
         }
         return null;
     }
 
-
-    private  JSONArray getArrayData(File jsonFile) throws IOException, ParseException {
-
-
-        JSONParser parser = new JSONParser();
-
-        Object obj = parser.parse(new FileReader(jsonFile)); //meta json file
-        return (JSONArray)obj;
-
-    }
 
     @Override
     protected String getFilePrefix(TableServerRequest request) {
@@ -264,67 +330,11 @@ public class LSSTCataLogSearch extends IpacTablePartProcessor {
     }
     @Override
     public void prepareTableMeta(TableMeta meta, List<DataType> columns, ServerRequest request) {
-        TableMeta.LonLatColumns llc = null;
 
-        llc = new TableMeta.LonLatColumns(RA, DEC, CoordinateSys.EQ_J2000);
+        TableMeta.LonLatColumns llc = new TableMeta.LonLatColumns(RA, DEC, CoordinateSys.EQ_J2000);
         meta.setCenterCoordColumns(llc);
         meta.setAttribute(MetaConst.CATALOG_OVERLAY_TYPE, "LSST");
         super.prepareTableMeta(meta, columns, request);
     }
 
-    private  Object getValue(String colName,JSONObject rowTblData){
-
-        for (Object key : rowTblData.keySet()) {
-            //based on you key types
-            String keyStr = (String)key;
-            if (keyStr.equalsIgnoreCase(colName) ) {
-                return rowTblData.get(keyStr);
-
-            }
-        }
-        return null;
-    }
-
-  /*  private File loadDataFileDummy(TableServerRequest request) throws IOException, DataAccessException {
-        //File file = createFile(request, ".json");
-        File dataFile = new File(request.getParam("table_path")+request.getParam("table_name")+".csv");
-        // File dataFile = new File(request.getParam("table_path")+request.getParam("table_name")+".json");
-        File metaFile = new File(request.getParam("table_path")+request.getParam("meta_table")+".tbl");
-
-
-
-        TableDef tableDef= IpacTableUtil.getMetaInfo(metaFile);// getMeta(request);
-        // DataGroup dg = getTableDataFromJson(dataFile,tableDef);
-        DataGroup dg = null;
-        try {
-            dg = getTableDataFromCsv(dataFile,tableDef);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        // File outFile = createFile(request, ".tbl");
-        File outFile = new File(request.getParam("table_path")+ "out_"+request.getParam("table_name")+".json");
-        dg.shrinkToFitData();
-        DataGroupWriter.write(outFile, dg, 0);
-        return  outFile;
-    }
-
-    public static void main(String[] args) throws IOException, ParseException, DataAccessException {
-
-        String jsonFileName = "RunDeepSource_ra_btw";
-
-        TableServerRequest request = new TableServerRequest("DummyTable");
-        request.setParam("table_name","RunDeepSource_ra_btw");
-        request.setParam("table_path", "/hydra/cm/firefly_test_data/DAXTestData/");
-        request.setParam("meta_table","output_RunDeepSourceDD");
-        request.setParam("inFileName",dataPath +jsonFileName );
-        request.setParam(ServerRequest.ID_KEY, "RunDeepSource_ra_btw");
-
-        LSSTCataLogSearch lssCat = new LSSTCataLogSearch();
-        File file = lssCat.loadDataFileDummy(request);
-
-       System.out.println("done" + file.getAbsolutePath());
-
-
-
-    }*/
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMetaSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMetaSearch.java
@@ -1,81 +1,118 @@
 package edu.caltech.ipac.firefly.server.query.lsst;
 
-
 import edu.caltech.ipac.firefly.data.CatalogRequest;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.data.table.TableMeta;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.IpacTablePartProcessor;
+import edu.caltech.ipac.firefly.server.query.ParamDoc;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupWriter;
+import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.DataObject;
 import edu.caltech.ipac.util.DataType;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.URLDownload;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import java.io.*;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by zhang on 10/12/16.
  * This search processor is searching the MetaData (or Data Definition from DAX database, then save to a
  * IpacTable file.
  */
-@SearchProcessorImpl(id = "LSSTMetaSearch")
+@SearchProcessorImpl(id = "LSSTMetaSearch",
+        params =
+                {@ParamDoc(name=CatalogRequest.CATALOG, desc="catalog table to query")})
+
 public class LSSTMetaSearch  extends IpacTablePartProcessor{
      private static final Logger.LoggerImpl _log = Logger.getLogger();
+     private static final String PORT = "5000";
+     private static final String HOST = AppProperties.getProperty("lsst.dd.hostname","lsst-qserv-dax01.ncsa.illinois.edu");
+     //private static final String TABLE_NAME = AppProperties.getProperty("lsst.dd.tableName", "RunDeepForcedSource")        ;
+     private static final String DATABASE_NAME =AppProperties.getProperty("lsst.database" , "gapon_sdss_stripe92_patch366_0");
+
+    private DataGroup  getDataFromURL(TableServerRequest request) throws IOException, FailedRequestException, DataAccessException {
 
 
-    /* private  static TableMeta getMeta(TableServerRequest request) throws IOException, ParseException {
-        //TODO return the search data and then process it to a TableMeta data
-         return null;
-     }*/
+
+        String tableName = request.getParam("table_name");
+        String catTable = request.getParam(CatalogRequest.CATALOG);
+        if (catTable == null) {
+            //throw new RuntimeException(CatalogRequest.CATALOG + " parameter is required");
+            catTable = DATABASE_NAME+"."+ tableName;
+        }
+
+
+         String sql =  "query=" + URLEncoder.encode("SHOW COLUMNS FROM " + catTable+ ";", "UTF-8");
+
+        try{
+            long cTime = System.currentTimeMillis();
+            _log.briefDebug("Executing SQL query: " + sql);
+            String url = "http://"+HOST +":"+PORT+"/db/v0/tap/sync";
+
+            File file = createFile(request, ".json");
+            Map<String, String> requestHeader=new HashMap<>();
+            requestHeader.put("Accept", "application/json");
+
+            URLDownload.getDataToFileUsingPost(new URL(url),sql,null,  requestHeader, file, null);
+            DataGroup dg =  getMetaData(file);
+            _log.briefDebug("SHOW COLUMNS took " + (System.currentTimeMillis() - cTime) + "ms");
+            return dg;
+
+        }
+        catch (Exception e) {
+            _log.error(e);
+            throw new DataAccessException("Query failed: " + e.getMessage());
+
+        }
+
+    }
+
 
     @Override
     protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
 
-/*
-        String ddTable = request.getParam(CatalogRequest.CATALOG);
-         output file will be in json format
-        File file = createFile(request, ".json");*/
-
-
-        File file = new File(request.getParam("table_path")+request.getParam("table_name")+".json");
         try {
-            DataGroup dg = getMetaData(file);
+            DataGroup dg = getDataFromURL(request);
+
             File outFile = createFile(request, ".tbl");
             dg.shrinkToFitData();
             DataGroupWriter.write(outFile, dg, 0);
             return outFile;
 
-        }
-        catch (ParseException e){
-            _log.error("load table failed");
-            e.getStackTrace();
+        } catch (FailedRequestException e) {
+            e.printStackTrace();
         }
         return null;
 
     }
 
 
-     private DataType[] getDataType(JSONObject firstRow){
-         String[] colNames = (String[]) firstRow.keySet().toArray(new String[0]);
-         DataType[] dataTypes = new DataType[colNames.length+2];//add unit and descriptions
-         for (int i=0; i<colNames.length; i++){
-             dataTypes[i] = new DataType(colNames[i],  (new String()).getClass());
+    private DataType[] getDataType(JSONArray metaData){
+        DataType[] dataTypes = new DataType[metaData.size()+2];//add unit and descriptions
+        for (int i=0; i<metaData.size(); i++){
+            JSONObject element = (JSONObject) metaData.get(i);
+            dataTypes[i] = new DataType(element.get("name").toString(),  element.get("datatype").getClass());
+        }
+        dataTypes[metaData.size()] =new DataType("Unit",  (new String()).getClass());
+        dataTypes[metaData.size()+1] =new DataType("Description",  (new String()).getClass());
+        return dataTypes;
 
-         }
+    }
 
-         dataTypes[colNames.length] =new DataType("Unit",  (new String()).getClass());
-         dataTypes[colNames.length+1] =new DataType("Description",  (new String()).getClass());
-         return dataTypes;
-
-     }
     /**
      * This method reads the json file from DAX and process it. The output is a DataGroup of the Meta data
      * @param file
@@ -88,21 +125,23 @@ public class LSSTMetaSearch  extends IpacTablePartProcessor{
 
         JSONParser parser = new JSONParser();
 
-        Object obj = parser.parse(new FileReader(file ));
-        JSONArray metaData = (JSONArray) obj;
+        JSONObject obj = ( JSONObject) parser.parse(new FileReader(file ));
 
+        JSONArray metaData = (JSONArray) ( (JSONObject) ( (JSONObject)( (JSONObject) obj.get("result")).get("table")).get("metadata")).get("elements");
 
-        DataType[] dataTypes = getDataType( (JSONObject) metaData.get(0) );
+        DataType[] dataTypes = getDataType( metaData );
+        JSONArray  data = (JSONArray) ( (JSONObject)( (JSONObject) obj.get("result")).get("table")).get("data");
+
         DataGroup dg = new DataGroup(file.getName(), dataTypes);
 
-        for (int i=0; i<metaData.size(); i++){
-            JSONObject value = (JSONObject) metaData.get(i);
+        for (int i=0; i<data.size(); i++){
+
             DataObject row = new DataObject(dg);
             for (int j=0; j<dataTypes.length-2; j++){
-                row.setDataElement(dataTypes[j], value.get(dataTypes[j].getKeyName()));
+                row.setDataElement(dataTypes[j], ( (JSONArray)data.get(i)).get(j));
             }
             row.setDataElement(dataTypes[dataTypes.length-2], "dummyUnit1");
-            row.setDataElement(dataTypes[dataTypes.length-1], "description of "+value.get(dataTypes[0].getKeyName() ) );
+            row.setDataElement(dataTypes[dataTypes.length-1], "description of "+  ( (JSONArray)data.get(i)).get(0).toString()  );
             dg.add(row);
         }
 
@@ -127,43 +166,4 @@ public class LSSTMetaSearch  extends IpacTablePartProcessor{
 
     }
 
-   File loadDataFileDummy(TableServerRequest request) throws IOException, DataAccessException {
-
-
-           try {
-               File file = new File(request.getParam("inFileName"));
-               DataGroup dg = getMetaData(file);
-              // File outFile = createFile(request, ".json");
-               File oFile = new File(request.getParam("outFileName"));
-               dg.shrinkToFitData();
-               DataGroupWriter.write(oFile, dg, 0);
-               return oFile;
-           }
-           catch (ParseException e){
-               e.getStackTrace();
-           }
-
-           return null;
-   }
-
-
-    public static void main(String[] args) throws IOException, ParseException, DataAccessException {
-
-        String jsonFileName = "RunDeepSourceDD";
-
-        String dataPath = "/hydra/cm/firefly_test_data/DAXTestData/";
-
-        TableServerRequest request = new TableServerRequest("DummyDD");
-        request.setParam("inFileName",dataPath +jsonFileName+".json" );
-        String outFileName = dataPath + "output_" + jsonFileName+".tbl";
-        request.setParam("outFileName", outFileName);
-        LSSTMetaSearch lsstMeta = new LSSTMetaSearch();
-
-
-        File file = lsstMeta.loadDataFileDummy(request);
-        System.out.println("done" + file.getAbsolutePath());
-
-
-
-    }
 }

--- a/src/firefly/java/edu/caltech/ipac/util/download/FileData.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/FileData.java
@@ -17,14 +17,19 @@ public class FileData implements FileHolder, Serializable, Cloneable {
     private final File file;
     private final String suggestedExternalName;
     private final boolean fileDownloaded;
+    private final int responseCode;
 
     public FileData(File file, String suggestedExternalName) {
-        this(file,suggestedExternalName, true);
+        this(file,suggestedExternalName, true, 200);
     }
+
+
     public FileData(File file,
                     String suggestedExternalName,
-                    boolean fileDownloaded) {
+                    boolean fileDownloaded,
+                    int responseCode) {
         this.file = file;
+        this.responseCode = responseCode;
         this.suggestedExternalName = suggestedExternalName;
         this.fileDownloaded = fileDownloaded;
     }
@@ -36,8 +41,9 @@ public class FileData implements FileHolder, Serializable, Cloneable {
     public File getFile() {  return file; }
     public String getSuggestedExternalName()  { return suggestedExternalName;}
     public boolean isDownloaded() { return fileDownloaded; }
+    public int getResponseCode() { return responseCode; }
 
-    public Object clone() { return new FileData(file, suggestedExternalName); }
+    public Object clone() { return new FileData(file, suggestedExternalName, fileDownloaded, responseCode); }
 
 }
 

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -74,21 +74,27 @@ public class URLDownload {
      */
     public static FileData getDataToFileUsingPost(URL url,
                                                   String postData,
+                                                  Map<String, String> cookies,
+                                                  Map<String, String> requestHeader,
                                                   File outfile,
                                                   DownloadListener dl)
             throws FailedRequestException, IOException {
         try {
-            URLConnection c = makeConnection(url);
+            URLConnection c = makeConnection(url, cookies, requestHeader, false);
+
             if (c instanceof HttpURLConnection) {
                 HttpURLConnection conn = (HttpURLConnection) c;
-                conn.addRequestProperty("QQQ", "B");
-                conn.setDoOutput(true);
                 conn.setRequestMethod("POST");
-                OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream());
+                conn.setRequestProperty( "Content-Type", "application/x-www-form-urlencoded" );
+                conn.setRequestProperty( "Content-Length", String.valueOf(postData.length()));
+
+                conn.setDoOutput(true);
+                OutputStream os = conn.getOutputStream();
+                OutputStreamWriter wr = new OutputStreamWriter(os);
                 wr.write(postData);
                 wr.flush();
                 wr.close();
-                return getDataToFile(conn, outfile, dl);
+                return getDataToFile(conn, outfile, dl);//, false, false, false, 0L);
             } else {
                 FailedRequestException fe = new FailedRequestException("Can only do post with http: " + url.toString());
                 logError(url, postData, fe);

--- a/src/firefly/js/core/MasterSaga.js
+++ b/src/firefly/js/core/MasterSaga.js
@@ -4,12 +4,6 @@
 
 import {flux} from '../Firefly.js';
 import {fork, take} from 'redux-saga/effects';
-import {watchCatalogs} from '../visualize/saga/CatalogWatcher.js';
-import {syncCharts} from '../visualize/saga/ChartsSync.js';
-import {imagePlotter} from '../visualize/saga/ImagePlotter.js';
-import {watchReadout} from '../visualize/saga/MouseReadoutWatch.js';
-import {watchForRelatedActions} from '../fieldGroup/FieldGroupCntlr.js';
-
 export const ADD_SAGA= 'MasterSaga.addSaga';
 
 
@@ -28,18 +22,11 @@ export function dispatchAddSaga(saga, params) {
  */
 export function* masterSaga() {
 
-    yield take();
-    const {getState, dispatch}= flux.getRedux();
-    // This section starts any predefined Sagas
-    yield fork( watchCatalogs, null, dispatch, getState);
-    yield fork( imagePlotter, null, dispatch, getState);
-    yield fork( syncCharts, null, dispatch, getState);
-    yield fork( watchReadout, null, dispatch, getState);
-    yield fork( watchForRelatedActions, null, dispatch, getState);
 
     // Start a saga from any action
     while (true) {
         var action= yield take(ADD_SAGA);
+        const {getState, dispatch}= flux.getRedux();
         const {saga,params}= action.payload;
         if (typeof saga === 'function') yield fork( saga, params, dispatch, getState);
     }

--- a/src/firefly/js/fieldGroup/FieldGroupCntlr.js
+++ b/src/firefly/js/fieldGroup/FieldGroupCntlr.js
@@ -180,7 +180,7 @@ export function dispatchRestoreDefaults(groupKey) {
  * @param {Action} rawAction
  * @return {Function}
  */
-export function valueChangeActionCreator(rawAction) {
+function valueChangeActionCreator(rawAction) {
     return (dispatcher) => {
         const {value}= rawAction.payload;
         dispatcher(rawAction);
@@ -203,7 +203,7 @@ export function valueChangeActionCreator(rawAction) {
  * @param {Action} rawAction
  * @return {Function}
  */
-export function multiValueChangeActionCreator(rawAction) {
+function multiValueChangeActionCreator(rawAction) {
     return (dispatcher) => {
         const {groupKey, fieldAry}= rawAction.payload;
         dispatcher(rawAction);

--- a/src/firefly/js/fieldGroup/FieldGroupCntlr.js
+++ b/src/firefly/js/fieldGroup/FieldGroupCntlr.js
@@ -55,7 +55,6 @@ import {smartMerge} from '../tables/TableUtil.js';
 
 
 
-
 export const INIT_FIELD_GROUP= 'FieldGroupCntlr/initFieldGroup';
 export const MOUNT_COMPONENT= 'FieldGroupCntlr/mountComponent';
 export const MOUNT_FIELD_GROUP= 'FieldGroupCntlr/mountFieldGroup';
@@ -66,7 +65,19 @@ export const CHILD_GROUP_CHANGE= 'FieldGroupCntlr/childGroupChange';
 export const RELATED_ACTION= 'FieldGroupCntlr/relatedAction';
 
 
-const FIELD_GROUP_KEY= 'fieldGroup';
+export const FIELD_GROUP_KEY= 'fieldGroup';
+
+export default {
+    reducers () {return {[FIELD_GROUP_KEY]: reducer};},
+
+    actionCreators() {
+        return {
+            [VALUE_CHANGE] : valueChangeActionCreator,
+            [MULTI_VALUE_CHANGE]: multiValueChangeActionCreator
+        };
+    },
+    VALUE_CHANGE, CHILD_GROUP_CHANGE,
+};
 
 
 //======================================== Dispatch Functions =============================
@@ -95,14 +106,14 @@ export function dispatchInitFieldGroup(groupKey,keepState=false,
 
 
 /**
- * 
+ *
  * @param groupKey
  * @param mounted
  * @param keepState
  * @param initValues
  * @param reducerFunc
- * @param wrapperGroupKey
  * @param actionTypes any action types (beyond the FieldGroup action types) that the reducer should allow though
+ * @param wrapperGroupKey
  */
 export function dispatchMountFieldGroup(groupKey, mounted, keepState= false, 
                                         initValues=null, reducerFunc= null,
@@ -129,6 +140,7 @@ export function dispatchMountComponent(groupKey,fieldKey,mounted,value,initField
 /**
  * the required parameter are below, anything else passed is put in the field group as well
  *
+ * @param {Object} payload
  * @param {String} payload.fieldKey the field Key
  * @param {String} payload.groupKey group key
  * @param {String} payload.value value can be anything including a promise or function
@@ -141,8 +153,8 @@ export function dispatchValueChange(payload) {
 
 /**
  * Update mutiliple fields
- * @param {FieldGroupField[]} fieldAry
  * @param {String} groupKey
+ * @param {FieldGroupField[]} fieldAry
  */
 export function dispatchMultiValueChange(groupKey, fieldAry) {
     flux.process({type: MULTI_VALUE_CHANGE, payload:{groupKey, fieldAry}});
@@ -168,7 +180,7 @@ export function dispatchRestoreDefaults(groupKey) {
  * @param {Action} rawAction
  * @return {Function}
  */
-export const valueChangeActionCreator= function(rawAction) {
+export function valueChangeActionCreator(rawAction) {
     return (dispatcher) => {
         const {value}= rawAction.payload;
         dispatcher(rawAction);
@@ -191,7 +203,7 @@ export const valueChangeActionCreator= function(rawAction) {
  * @param {Action} rawAction
  * @return {Function}
  */
-export const multiValueChangeActionCreator= function(rawAction) {
+export function multiValueChangeActionCreator(rawAction) {
     return (dispatcher) => {
         const {groupKey, fieldAry}= rawAction.payload;
         dispatcher(rawAction);
@@ -565,12 +577,6 @@ function constructFieldGroup(groupKey,fields, reducerFunc, actionTypes, keepStat
 //============ EXPORTS ===========
 //============ EXPORTS ===========
 
-var FieldGroupCntlr = {reducer, FIELD_GROUP_KEY,
-                       INIT_FIELD_GROUP, MOUNT_COMPONENT,
-                       MOUNT_FIELD_GROUP, VALUE_CHANGE,
-                       CHILD_GROUP_CHANGE, MULTI_VALUE_CHANGE,
-                       valueChangeActionCreator};
-export default FieldGroupCntlr;
 
 //============ EXPORTS ===========
 //============ EXPORTS ===========

--- a/src/firefly/js/fieldGroup/FieldGroupUtils.js
+++ b/src/firefly/js/fieldGroup/FieldGroupUtils.js
@@ -6,7 +6,7 @@ import {get,isFunction,hasIn,isBoolean} from 'lodash';
 import {flux} from '../Firefly.js';
 import {logError,clone} from '../util/WebUtil.js';
 import {smartMerge} from '../tables/TableUtil.js';
-import FieldGroupCntlr, {dispatchValueChange,dispatchMultiValueChange} from './FieldGroupCntlr.js';
+import {FIELD_GROUP_KEY,dispatchValueChange,dispatchMultiValueChange} from './FieldGroupCntlr.js';
 
 
 const includeForValidation= (f,includeUnmounted) => f.valid !== undefined && (f.mounted||includeUnmounted);
@@ -129,7 +129,7 @@ export function getFieldGroupResults(groupKey,includeUnmounted=false) {
  * @return {object}
  */
 export const getFieldGroupState= function(groupKey) {
-    var fieldGroupMap= flux.getState()[FieldGroupCntlr.FIELD_GROUP_KEY];
+    var fieldGroupMap= flux.getState()[FIELD_GROUP_KEY];
     return fieldGroupMap[groupKey] ? fieldGroupMap[groupKey] : null;
 };
 

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -146,7 +146,7 @@ export function makeLsstCatalogRequest(title, project, catalog, params={}, optio
     const tbl_id = options.tbl_id || uniqueTblId();
     const id = LSSTQueryPID;
     const UserTargetWorldPt = params.UserTargetWorldPt || params.position;  // may need to convert to worldpt.
-    const table_name = 'RunDeepForcedSource_limit100';    //catalog+'_queryresult';
+    const table_name = 'RunDeepForcedSource';//_limit100';    //catalog+'_queryresult';
     const meta_table = catalog;
     var META_INFO = Object.assign(options.META_INFO || {}, {title, tbl_id});
 

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -201,15 +201,16 @@ function lsstSearchSubmit(isDD) {
 
     var tReq;
     if (isDD) { //Meta Search
-        tReq = makeTblRequest('LSSTMetaSearch', 'RunDeepForcedSourceDD', {
-            'table_name':  'RunDeepForcedSourceDD',//'RunDeepSourceDD',
-            'table_path': '/hydra/cm/firefly_test_data/DAXTestData/'
-        });
+        tReq = makeTblRequest('LSSTMetaSearch', 'RunDeepForcedSource', {
+          'table_name':  'RunDeepForcedSource',
+
+       });
     } else {//Catalog Search
-        tReq = makeTblRequest('LSSTCataLogSearch', 'RunDeepForcedSource_limit100', {
-            'table_name': 'RunDeepForcedSource_limit100',//'RunDeepSource_ra_btw',
+        tReq = makeTblRequest('LSSTCataLogSearch', 'RunDeepForcedSource', {
+            'table_name': 'RunDeepForcedSource',
             'table_path': '/hydra/cm/firefly_test_data/DAXTestData/',
-            'meta_table':  'RunDeepForcedSourceDD'//'RunDeepSourceDD'
+            'meta_table':  'RunDeepForcedSource',
+            'SearchMethod':'cone'
         });
     }
 

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -9,18 +9,18 @@ import DrawLayerReducer from './reducer/DrawLayerReducer.js';
 import {without,union,isEmpty} from 'lodash';
 import {clone} from '../util/WebUtil.js';
 
-export {selectAreaEndActionCreator} from '../drawingLayers/SelectArea.js';
-export {distanceToolEndActionCreator} from '../drawingLayers/DistanceTool.js';
-export {markerToolStartActionCreator,
+import {selectAreaEndActionCreator} from '../drawingLayers/SelectArea.js';
+import {distanceToolEndActionCreator} from '../drawingLayers/DistanceTool.js';
+import {markerToolStartActionCreator,
         markerToolMoveActionCreator,
         markerToolEndActionCreator,
         markerToolCreateLayerActionCreator} from '../drawingLayers/MarkerTool.js';
 
-export {regionCreateLayerActionCreator,
+import {regionCreateLayerActionCreator,
         regionDeleteLayerActionCreator,
         regionUpdateEntryActionCreator} from './region/RegionTask.js';
 
-export {footprintCreateLayerActionCreator,
+import {footprintCreateLayerActionCreator,
         footprintStartActionCreator,
         footprintMoveActionCreator,
         footprintEndActionCreator
@@ -105,7 +105,39 @@ export function getDlAry() { return flux.getState()[DRAWING_LAYER_KEY].drawLayer
 export function getDlRoot() { return flux.getState()[DRAWING_LAYER_KEY]; }
 
 
+
+
+
+export function getDrawLayerCntlrDef(drawLayerFactory) {
+    return {
+        reducers() {return {[DRAWING_LAYER_KEY]: makeReducer(drawLayerFactory)}; },
+
+        actionCreators() {
+            return {
+                [DETACH_LAYER_FROM_PLOT] :  makeDetachLayerActionCreator(drawLayerFactory),
+                [SELECT_AREA_END] :  selectAreaEndActionCreator,
+                [DT_END] :  distanceToolEndActionCreator,
+                [MARKER_START] :  markerToolStartActionCreator,
+                [MARKER_MOVE] :  markerToolMoveActionCreator,
+                [MARKER_END] :  markerToolEndActionCreator,
+                [MARKER_CREATE] :  markerToolCreateLayerActionCreator,
+                [FOOTPRINT_CREATE] :  footprintCreateLayerActionCreator,
+                [FOOTPRINT_START] :  footprintStartActionCreator,
+                [FOOTPRINT_END] :  footprintEndActionCreator,
+                [FOOTPRINT_MOVE] :  footprintMoveActionCreator,
+
+                [REGION_CREATE_LAYER] :  regionCreateLayerActionCreator,
+                [REGION_DELETE_LAYER] :  regionDeleteLayerActionCreator,
+                [REGION_ADD_ENTRY] :  regionUpdateEntryActionCreator,
+                [REGION_REMOVE_ENTRY] :  regionUpdateEntryActionCreator
+            };
+        },
+    };
+}
+
+
 export default {
+    getDrawLayerCntlrDef,
     CHANGE_VISIBILITY, RETRIEVE_DATA,
     ATTACH_LAYER_TO_PLOT, DETACH_LAYER_FROM_PLOT,CHANGE_DRAWING_DEF,
     CREATE_DRAWING_LAYER,DESTROY_DRAWING_LAYER, MODIFY_CUSTOM_FIELD,
@@ -124,6 +156,8 @@ export default {
     dispatchAddRegionEntry, dispatchRemoveRegionEntry,
     dispatchCreateMarkerLayer, dispatchCreateFootprintLayer
 };
+
+
 
 /**
  *

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -518,7 +518,7 @@ function getDrawLayerIdAry(dlRoot,id,useGroup) {
 //=============================================
 //=============================================
 
-export function makeDetachLayerActionCreator(factory) {
+function makeDetachLayerActionCreator(factory) {
     return (action) => {
         return (dispatcher) => {
             var {drawLayerId}= action.payload;

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -28,16 +28,16 @@ import {dispatchAttachLayerToPlot,
 import {dispatchReplaceViewerItems, getExpandedViewerItemIds,
          getMultiViewRoot, EXPANDED_MODE_RESERVED} from './MultiViewCntlr.js';
 
-export {zoomActionCreator} from './ZoomUtil.js';
-export {plotImageMaskActionCreator, overlayPlotChangeAttributeActionCreator} from './ImageOverlayTask.js';
+import {zoomActionCreator} from './ZoomUtil.js';
+import {plotImageMaskActionCreator, overlayPlotChangeAttributeActionCreator} from './ImageOverlayTask.js';
 
-export {colorChangeActionCreator,
+import {colorChangeActionCreator,
         stretchChangeActionCreator,
         flipActionCreator,
         cropActionCreator,
         rotateActionCreator} from './task/PlotChangeTask.js';
 
-export {wcsMatchActionCreator} from './task/WcsMatchTask.js';
+import {wcsMatchActionCreator} from './task/WcsMatchTask.js';
 
 /** can the 'COLLAPSE', 'GRID', 'SINGLE' */
 export const ExpandType= new Enum(['COLLAPSE', 'GRID', 'SINGLE']);
@@ -218,8 +218,40 @@ const initState= function() {
 //============ EXPORTS ===========
 //============ EXPORTS ===========
 
+
+
+/*---------------------------- REDUCERS -----------------------------*/
+
+function reducers() {
+    return {
+        [IMAGE_PLOT_KEY]: reducer,
+    };
+}
+
+function actionCreators() {
+    return {
+        [PLOT_IMAGE]: plotImageActionCreator,
+        [PLOT_MASK]: plotImageMaskActionCreator,
+        [OVERLAY_PLOT_CHANGE_ATTRIBUTES]: overlayPlotChangeAttributeActionCreator,
+        [ZOOM_IMAGE]: zoomActionCreator,
+        [COLOR_CHANGE]: colorChangeActionCreator,
+        [STRETCH_CHANGE]: stretchChangeActionCreator,
+        [ROTATE]: rotateActionCreator,
+        [FLIP]: flipActionCreator,
+        [CROP]: cropActionCreator,
+        [CHANGE_PRIME_PLOT] : changePrimeActionCreator,
+        [CHANGE_POINT_SELECTION]: changePointSelectionActionCreator,
+        [RESTORE_DEFAULTS]: restoreDefaultsActionCreator,
+        [EXPANDED_AUTO_PLAY]: autoPlayActionCreator,
+        [WCS_MATCH]: wcsMatchActionCreator,
+        [DELETE_PLOT_VIEW]: deletePlotViewActionCreator,
+    };
+}
+
+
 export default {
     reducer,
+    reducers, actionCreators,
     ANY_CHANGE,  // todo remove soon- only for interface with GWT
     ANY_REPLOT,
     PLOT_IMAGE_START, PLOT_IMAGE_FAIL, PLOT_IMAGE,

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -56,8 +56,6 @@ export const ActionScope= new Enum(['GROUP','SINGLE', 'LIST']);
 
 export const PLOTS_PREFIX= 'ImagePlotCntlr';
 
-const ANY_CHANGE= '${PLOT_PREFIX}.AnyChange';
-
 /** Action Type: plot of new image started */
 const PLOT_IMAGE_START= `${PLOTS_PREFIX}.PlotImageStart`;
 /** Action Type: plot of new image failed */
@@ -250,9 +248,7 @@ function actionCreators() {
 
 
 export default {
-    reducer,
     reducers, actionCreators,
-    ANY_CHANGE,  // todo remove soon- only for interface with GWT
     ANY_REPLOT,
     PLOT_IMAGE_START, PLOT_IMAGE_FAIL, PLOT_IMAGE,
     ZOOM_IMAGE_START, ZOOM_IMAGE_FAIL, ZOOM_IMAGE,ZOOM_LOCKING,
@@ -787,7 +783,7 @@ export function dispatchExpandedAutoPlay(autoPlayOn) {
  * @param {Action} rawAction
  * @returns {Function}
  */
-export function changePrimeActionCreator(rawAction) {
+function changePrimeActionCreator(rawAction) {
     return (dispatcher, getState) => changePrime(rawAction,dispatcher,getState);
 }
 
@@ -795,7 +791,7 @@ export function changePrimeActionCreator(rawAction) {
  * @param {Action} rawAction
  * @returns {Function}
  */
-export function deletePlotViewActionCreator(rawAction) {
+function deletePlotViewActionCreator(rawAction) {
     return (dispatcher, getState) => {
         const vr= getState()[IMAGE_PLOT_KEY];
         if (vr.wcsMatchType && !rawAction.payload.holdWcsMatch) {
@@ -809,7 +805,7 @@ export function deletePlotViewActionCreator(rawAction) {
  * @param {Action} rawAction
  * @returns {Function}
  */
-export function plotImageActionCreator(rawAction) {
+function plotImageActionCreator(rawAction) {
     return PlotImageTask.makePlotImageAction(rawAction);
 }
 
@@ -818,7 +814,7 @@ export function plotImageActionCreator(rawAction) {
  * @param {Action} rawAction
  * @returns {Function}
  */
-export function restoreDefaultsActionCreator(rawAction) {
+function restoreDefaultsActionCreator(rawAction) {
     return (dispatcher, getState) => {
         const vr= getState()[IMAGE_PLOT_KEY];
         const {plotId}= rawAction.payload;
@@ -845,7 +841,7 @@ export function restoreDefaultsActionCreator(rawAction) {
 }
 
 
-export function autoPlayActionCreator(rawAction) {
+function autoPlayActionCreator(rawAction) {
     return (dispatcher) => {
         var {autoPlayOn}= rawAction.payload;
         if (autoPlayOn) {
@@ -886,7 +882,7 @@ const detachAll= (plotViewAry,dl) => plotViewAry.forEach( (pv) => {
 });
 
 
-export function changePointSelectionActionCreator(rawAction) {
+function changePointSelectionActionCreator(rawAction) {
     return (dispatcher,getState) => {
         var store= getState();
         var wasEnabled= store[IMAGE_PLOT_KEY].pointSelEnableAry.length ? true : false;

--- a/src/firefly/js/visualize/MouseReadoutCntlr.js
+++ b/src/firefly/js/visualize/MouseReadoutCntlr.js
@@ -112,7 +112,7 @@ export function makeDescriptionItem(title) {
 //--------------------------------------------------------------------
 
 
-export function reducer(state=initState(), action={}) {
+function reducer(state=initState(), action={}) {
 
     if (!action.payload || !action.type) return state;
 

--- a/src/firefly/js/visualize/MouseReadoutCntlr.js
+++ b/src/firefly/js/visualize/MouseReadoutCntlr.js
@@ -21,6 +21,13 @@ export const DESC_VAL= 'desc';
 
 export function readoutRoot() { return flux.getState()[READOUT_KEY]; }
 
+
+export default {
+    reducers () {return {[READOUT_KEY]: reducer};},
+};
+
+
+
 //======================================== Dispatch Functions =============================
 //======================================== Dispatch Functions =============================
 //======================================== Dispatch Functions =============================

--- a/src/firefly/js/visualize/ZoomUtil.js
+++ b/src/firefly/js/visualize/ZoomUtil.js
@@ -28,7 +28,7 @@ const zoomMax= levels[levels.length-1];
  */
 export const UserZoomTypes= new Enum(['UP','DOWN', 'FIT', 'FILL', 'ONE', 'LEVEL', 'WCS_MATCH_PREV'], { ignoreCase: true });
 
-const ZOOM_WAIT_MS= 2000; // 2 seconds
+const ZOOM_WAIT_MS= 1500; // 1.5 seconds
 
 var zoomTimers= []; // todo: should I use a map? should it be in the redux store?
 

--- a/src/firefly/js/visualize/iv/TileDrawer.jsx
+++ b/src/firefly/js/visualize/iv/TileDrawer.jsx
@@ -50,7 +50,7 @@ export class TileDrawer extends Component {
 
         const scale= zoomFactor / tileZoomFactor;
         const style=Object.assign({},containerStyle, {width,height});
-        if (scale < .5 && tileData.images.length>5) {
+        if (scale < .3 && tileData.images.length>7) {
             return <div></div>;
         }
         else {

--- a/src/firefly/js/visualize/ui/ColorPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ColorPanelReducer.js
@@ -3,7 +3,7 @@
  */
 
 import Validate from '../../util/Validate.js';
-import FieldGroupCntlr from '../../fieldGroup/FieldGroupCntlr.js';
+import FieldGroupCntlr, {INIT_FIELD_GROUP} from '../../fieldGroup/FieldGroupCntlr.js';
 import ImagePlotCntlr from '../ImagePlotCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {primePlot} from '../PlotViewUtil.js';
@@ -67,7 +67,7 @@ const computeColorPanelState= function(fields, plottedRV, fitsData, band, action
             break;
 
         case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
-        case FieldGroupCntlr.INIT_FIELD_GROUP:
+        case INIT_FIELD_GROUP:
         case ImagePlotCntlr.ANY_REPLOT:
             if (!plottedRV && !fitsData) return fields;
             var newFields = updateFieldsFromRangeValues(fields,plottedRV,fitsData);

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -165,7 +165,7 @@ function doCatalog(request) {
         var filename = catPart.fileUpload;
 
         tReq = makeLsstCatalogRequest(title, project, cattable, {
-            table_path: '/hydra/cm/firefly_test_data/DAXTestData/',  // TODO: to remove later
+            //table_path: '/hydra/cm/firefly_test_data/DAXTestData/',  // TODO: to remove later
             filename,
             radius: conesize,
             SearchMethod: spatial
@@ -179,7 +179,7 @@ function doCatalog(request) {
 
         tReq = makeLsstCatalogRequest(title, project, cattable, {
             SearchMethod: spatial,
-            table_path: '/hydra/cm/firefly_test_data/DAXTestData/'  //TODO: to remove later
+            //table_path: '/hydra/cm/firefly_test_data/DAXTestData/'  //TODO: to remove later
         });
     }
 
@@ -280,12 +280,12 @@ class LSSTCatalogSelectView extends Component {
         var catalogs = [
                 {
                     label: 'Deep Forced Source',
-                    value: 'RunDeepForcedSourceDD',       //TODO: temporary hard code of catalog name
+                    value: 'RunDeepForcedSource',       //TODO: temporary hard code of catalog name
                     cat:[]
                 },
                 {
                     label: 'Deep Source',
-                    value: 'RunDeepSourceDD',
+                    value: 'RunDeepSource',
                     cat: []
                 }
         ];

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -155,9 +155,9 @@ function doCatalog(request) {
     const catPart = request[gkey];
     const spatPart = request[gkeySpatial];
     const {project, cattable} = catPart;
-    const {spatial} = spatPart;
+    const {spatial, conesize} = spatPart;
+    const sizeUnit = 'deg';
 
-    const conesize = convertAngle('deg', 'arcsec', spatPart.conesize);
     var title = `${projectName}-${catPart.cattable}`;
     var tReq = {};
 
@@ -165,9 +165,9 @@ function doCatalog(request) {
         var filename = catPart.fileUpload;
 
         tReq = makeLsstCatalogRequest(title, project, cattable, {
-            //table_path: '/hydra/cm/firefly_test_data/DAXTestData/',  // TODO: to remove later
             filename,
             radius: conesize,
+            sizeUnit,
             SearchMethod: spatial
         });
     } else {
@@ -178,14 +178,12 @@ function doCatalog(request) {
         title += ')';
 
         tReq = makeLsstCatalogRequest(title, project, cattable, {
-            SearchMethod: spatial,
-            //table_path: '/hydra/cm/firefly_test_data/DAXTestData/'  //TODO: to remove later
+            SearchMethod: spatial
         });
     }
 
     // change and merge others parameters in request if elliptical
     // plus change spatial name to cone
-    // TODO: (assume search method for elliptical is cone)
     if (spatial === SpatialMethod.Elliptical.value) {
 
         const pa = get(spatPart, 'posangle', 0);
@@ -204,6 +202,7 @@ function doCatalog(request) {
         } else {
             tReq.radius = conesize;
         }
+        tReq.sizeUnit = sizeUnit;
     } else if (spatial === SpatialMethod.Polygon.value) {
         tReq.polygon = spatPart.polygoncoords;
     }

--- a/src/firefly/js/visualize/ui/ZoomButton.jsx
+++ b/src/firefly/js/visualize/ui/ZoomButton.jsx
@@ -55,7 +55,7 @@ function getZoomer() {
         dispatchZoom({
             plotId:pv.plotId,
             userZoomType:zType.utilZt,
-            forceDelay:isFitFill(zType.utilZt)
+            forceDelay:!isFitFill(zType.utilZt)
         });
     };
 }


### PR DESCRIPTION
To test it,

Check it out and build. 
Start firefly view, then enter the following info based on the method:
  Cone search:  
     UserTargetPt: 9.49,-1.24
     Radius: 0.01 degree
 Box Search:
     UserTargetPt: 9.49,-1.24
     Radius: 0.01 degree
 Elliptical Search:
    9.49, -1.24
   Radius: 0.01 degree
Polygon Search:
    9.5  -1.2, 9.6 -1.24, 9.4 -1.24

Known issue:
  When the degree unit is selected, it still passed as arcsec 
  When all columns are selected by default, it passed null

Suggest:
  UI passes the unit, the server side handles the conversion based on the search methods.

Thanks for reviewing it.

[11/1/16 at 5:37PM]
After discussing with Cindy and after her changes, the following changes are made:
   1.  If the UI sends a null for selcol, all columns are selected.
   2.  For radius UI, he "degree" unit is used  The server side converts the unit based on the 
       search methods.
   3.  Datatypes inconsistence (for the same column):
        meta search (LSSTMetaSearch): select SHOW COLUMNS 
               return double, boolean
       catalog search (LSSTCatalogSearch): select * (select id, parent, ...)
               return float for double 
               return null for boolean

        When the DataType is created, if the type is no null, the type in catalog search is always
       used.  If it is null, the type in meta search is used.
   4. Add throw Exception for  LSSTCatalogSearch.  LSSTMetaSearch had the exception handled. 


 