### PR TITLE
DM-8245 Add image tables into LSST catalog search panel.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
@@ -49,9 +49,6 @@ import edu.caltech.ipac.firefly.data.table.MetaConst;
  */
 @SearchProcessorImpl(id = "LSSTCataLogSearch")
 public class LSSTCataLogSearch extends IpacTablePartProcessor {
-    private static final String RA = "coord_ra";
-    private static final String DEC = "coord_decl";
-
     private static final Logger.LoggerImpl _log = Logger.getLogger();
     private static final String PORT = "5000";
     private static final String HOST = AppProperties.getProperty("lsst.dd.hostname","lsst-qserv-dax01.ncsa.illinois.edu");
@@ -81,7 +78,6 @@ public class LSSTCataLogSearch extends IpacTablePartProcessor {
 
 
     }
-
 
     /**
      * This method will return the search method string based on the method.  If the method is not supported, the exception
@@ -451,8 +447,29 @@ public class LSSTCataLogSearch extends IpacTablePartProcessor {
         }
 
     }
+
+    private String raName(String table_name) {
+        if (table_name.contains("RunDeep")) {
+            return "coord_ra";
+        } else if (table_name.contains("Ccd") || table_name.contains("Coadd")) {
+            return "ra";
+        }
+        return "";
+    }
+
+    private String decName(String table_name) {
+        if (table_name.contains("RunDeep")) {
+            return "coord_decl";
+        } else  {
+            return "decl";
+        }
+    }
+
     @Override
     public void prepareTableMeta(TableMeta meta, List<DataType> columns, ServerRequest request) {
+        String tableName = request.getParam("table_name");
+        String RA = raName(tableName);
+        String DEC = decName(tableName);
 
         TableMeta.LonLatColumns llc = new TableMeta.LonLatColumns(RA, DEC, CoordinateSys.EQ_J2000);
         meta.setCenterCoordColumns(llc);

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -148,7 +148,7 @@ export function makeLsstCatalogRequest(title, project, catalog, params={}, optio
     const tbl_id = options.tbl_id || uniqueTblId();
     const id = LSSTQueryPID;
     const UserTargetWorldPt = params.UserTargetWorldPt || params.position;  // may need to convert to worldpt.
-    const table_name = 'RunDeepForcedSource';//_limit100';    //catalog+'_queryresult';
+    const table_name = catalog;
     const meta_table = catalog;
     var META_INFO = Object.assign(options.META_INFO || {}, {title, tbl_id});
 

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -167,6 +167,8 @@ export class CatalogConstraintsPanel extends React.Component {
         const request = createDDRequest(); //Fetch DD master table
         const urlDef = get(FieldGroupUtils.getGroupFields(this.props.groupKey), 'cattable.coldef', 'null');
 
+        console.log('fetch DD: ' + JSON.stringify(request));
+
         fetchTable(request).then((tableModel) => {
             const tableModelFetched = tableModel;
             tableModelFetched.tbl_id = tblid;

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -174,7 +174,7 @@ function doCatalog(request) {
     } else {
         title += ` (${spatial}`;
         if (spatial === SpatialMethod.Box.value || spatial === SpatialMethod.Cone.value || spatial === SpatialMethod.Elliptical.value) {
-            title += ':' + conesize + '\'\'';
+            title += ':' + conesize + ((sizeUnit === 'deg') ? 'deg' : ((sizeUnit === 'arcsec') ? '\'\'' : '\''));
         }
         title += ')';
 
@@ -287,8 +287,17 @@ class LSSTCatalogSelectView extends Component {
                     label: 'Deep Forced Source',
                     value: 'RunDeepForcedSource',       //TODO: temporary hard code of catalog name
                     cat:[]
+                },
+                {
+                    label: 'Science CCD Exposure',
+                    value: 'Science_Ccd_Exposure',
+                    cat: []
+                },
+                {
+                    label: 'Deep Coadd',
+                    value: 'DeepCoadd',
+                    cat: []
                 }
-
         ];
 
         catmaster.push({  project, catalogs });


### PR DESCRIPTION
the development includes: 
- add image tables, Science_Ccd_Exposure, DeepCoadd into LSST catalog search panel. 
- search and display DD table for image tables on LSSTMetaSearch 
- show image tables on tri-view on LSSTCatalogSearch
- fix spatial data unit shown in catalog search title. 
- fix the bug in generating query parameters for LSSTMetaSearch.
 