### PR TITLE
DM-6617: fix parsing info link

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatMasterTableQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatMasterTableQuery.java
@@ -262,7 +262,7 @@ public class CatMasterTableQuery extends IpacTablePartProcessor {
                 int endAnchor= s.indexOf(">",start);
                 if (targetStr!=null && endAnchor>0 && url!=null &&
                         !s.substring(beginChar,endAnchor).contains("target=")) {
-                    String rStr= "\\Q" + beginChar+url+beginChar + "\\E";
+                    String rStr = beginChar + url + beginChar;
                     retval= retval.replaceFirst(rStr, rStr+ " target="+"\""+targetStr+"\" ");
                 }
             }


### PR DESCRIPTION
Fixed the URL parsing when relative URL is found in master catalog table. In order to test, you need to build FF and  redeploy the branch built. 
Then go to 'catalog' search and check that 'info' and inner link in description are ok. 