### PR TITLE
DM-8006 Add xy chart to phase folding parameter setting panel using Highcharts

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -360,7 +360,7 @@ function highlightRow(action) {
             }).catch( (error) => {
                 dispatch({type: TABLE_HIGHLIGHT, payload: TblUtil.createErrorTbl(tbl_id, `Fail to load table. \n   ${error}`)});
             });
-        }E
+        }
     };
 }
 

--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPanel.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPanel.jsx
@@ -28,6 +28,7 @@ import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {RAW_TABLE, PHASE_FOLDED} from '../../templates/lightcurve/LcManager.js';
+import {showPhaseFoldingPopup} from './LcPhaseFoldingPopup.jsx';
 
 import './LCPanels.css';
 
@@ -269,7 +270,10 @@ export function LcPFOptionsPanel ({fields}) {
                         <b>Reset</b>
                     </button>
 
-                    <br/>
+                    <br/> <br/>
+
+                   <button type='button' className='button std hl'
+                           onClick={() => showPhaseFoldingPopup('Phase Folding')}>Phase Folding Dialog</button>
                 </InputGroup>
             </FieldGroup>
 

--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
@@ -157,7 +157,6 @@ const defValues= {
                             {validator: null})
 };
 
-
 const RES = 10;      // factor for defining total steps for period
 const DEC = 3;       // decimal digit
 const validTimeSuggestions = ['mjd'];      // suggestive time column name
@@ -333,7 +332,8 @@ class PhaseFoldingChart extends Component {
                     width
                 },
                 title: {
-                    text: 'Flux vs. Phase'
+                    fontSize: '16px',
+                    text: period ? `period=${period}(day)`:'period='
                 },
                 xAxis: {
                     min: minPhase - Margin,
@@ -358,9 +358,9 @@ class PhaseFoldingChart extends Component {
                                         }}
                                      : {enabled: false},
                 series: [{
+                    showInLegend: false,
                     marker: {radius: 2},
                     color: 'blue',
-                    name: period ? `period=${period}(day)`:'period=',
                     data
                 }],
                 credits: {
@@ -402,8 +402,8 @@ class PhaseFoldingChart extends Component {
                 this.setState({fields});
 
                 var {data, minPhase = 0.0, period, flux} = getPhaseFlux(fields);
+                chart.setTitle({text: period ? `period=${period}(day)`:'period='});
                 chart.series[0].setData(data);
-                chart.series[0].update({name: period ? `period=${period}(day)`:'period='});
                 chart.xAxis[0].update({min: minPhase - Margin,
                                        max: minPhase + 2.0 + Margin});
                 chart.yAxis[0].setTitle({text: `${flux}(mag)`})
@@ -412,6 +412,7 @@ class PhaseFoldingChart extends Component {
     }
 
     render() {
+        //console.log('rerender hicharts');
         return (
             <div>
                 <ReactHighcharts config={this.state.config} isPureConfig={true} ref='chart'/>
@@ -460,7 +461,6 @@ function LcPFOptions({fields}) {
 
     const {periodMax, periodMin} = fields || {};
     const step = STEP;
-    const DECS = 2;
     var min = periodMin ? periodMin.value : periodRange.min;
     var max = periodMax ? periodMax.value : periodRange.max;
 
@@ -476,11 +476,11 @@ function LcPFOptions({fields}) {
         return {style: {left: `${per}%`, marginLeft: -16, width: 40}, label: `${val}`};
     }
 
-    var marks = Object.assign({}, {[min]: markStyle(parseFloat((100*(min-SliderMin)/sliderSize).toFixed(DECS)), min)});
+    var marks = Object.assign({}, {[min]: markStyle(100*(min-SliderMin)/sliderSize, min)});
 
     marks = [...Array(NOMark).keys()].slice(1).reduce((prev, m) => {
-                var val = parseFloat((INTMark * m + sRange[0]).toFixed(DECS));
-                var per = parseFloat((100*(val - SliderMin)/sliderSize).toFixed(DECS));
+                var val = parseFloat((INTMark * m + sRange[0]).toFixed(DEC));
+                var per = 100*(val - SliderMin)/sliderSize;
 
                 prev = Object.assign(prev, {[val]: markStyle(per, val)});
                 return prev;
@@ -824,7 +824,7 @@ function computePeriodRange(tbl_id, timeColName) {
     var max = parseFloat(((timeMax - timeZero)*factor).toFixed(DEC));
     var min = Math.pow(10, -DEC);
 
-    SliderMin = min;
+    SliderMin = 0.0;
     var newMax = adjustMax(max, SliderMin, STEP);
 
     return {min, max: newMax.max, steps: newMax.steps};

--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
@@ -352,7 +352,7 @@ class PhaseFoldingChart extends Component {
                 tooltip: showTooltip ? {enabled: true,
                                         formatter() {
                                             return ('<span>' +
-                                            `${phaseCol} = ${this.x} <br/>` +
+                                            `${phaseCol} = ${this.x.toFixed(DEC)} <br/>` +
                                             `${flux} = ${this.y} mag <br/>` +
                                             '</span>');
                                         }}

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -98,7 +98,7 @@ export class LcResult extends Component {
         }
         if (showForm) {
             const fields= this.state;
-/*
+
             content.form = (
                 <div>
                     <div>
@@ -116,13 +116,13 @@ export class LcResult extends Component {
                             </Tab>
                             <Tab name='Upload/Phase Folding'>
                                 <div>
-                                    <UploadPanel phaseButton={true}/>
+                                    <UploadPanel />
                                 </div>
                             </Tab>
                         </Tabs>
                     </div>
                 </div> );
- */
+ /*
             content.form = (
                 <div>
                     <div>
@@ -140,7 +140,7 @@ export class LcResult extends Component {
                         </Tabs>
                     </div>
                 </div> );
-
+*/
         }
 
         expanded = LO_VIEW.get(expanded) || LO_VIEW.none;

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -203,7 +203,7 @@ export const UploadPanel = ({phaseButton}) => {
                     />
 
                 </FieldGroup>
-                {phaseButton ? <button type='button' onClick={() => showPhaseFoldingPopup('Phase Folding', RAW_TABLE)}>Phase Folding</button> : null}
+                {phaseButton ? <button type='button' onClick={() => showPhaseFoldingPopup('Phase Folding')}>Phase Folding</button> : null}
             </FormPanel>
         </div>
     );

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -28,7 +28,6 @@ import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import * as TblUtil from '../../tables/TableUtil.js';
-import {showPhaseFoldingPopup} from './LcPhaseFoldingPopup.jsx';
 
 // import {deepDiff} from '../util/WebUtil.js';
 
@@ -155,7 +154,7 @@ function BannerSection(props) {
 /**
  *  A temporary upload panel for use during development phase.  This should be removed or replaced with something else.
  */
-export const UploadPanel = ({phaseButton}) => {
+export const UploadPanel = () => {
 
     return (
         <div style={{padding: 10}}>
@@ -203,7 +202,6 @@ export const UploadPanel = ({phaseButton}) => {
                     />
 
                 </FieldGroup>
-                {phaseButton ? <button type='button' onClick={() => showPhaseFoldingPopup('Phase Folding')}>Phase Folding</button> : null}
             </FormPanel>
         </div>
     );

--- a/src/firefly/js/ui/RangeSliderView.jsx
+++ b/src/firefly/js/ui/RangeSliderView.jsx
@@ -151,6 +151,7 @@ export class RangeSliderView extends Component {
                             value={v}
                             handle={handle}
                             tipFormatter={null}
+                            included={true}
                             onChange={this.onSliderChange} />
                 </div>
             </div>

--- a/src/firefly/js/ui/RangeSliderView.jsx
+++ b/src/firefly/js/ui/RangeSliderView.jsx
@@ -5,7 +5,7 @@ import {InputFieldView}  from './InputFieldView.jsx';
 import Slider from 'rc-slider';
 import './rc-slider.css';
 
-const DEC = 8;
+const DEC = 3;
 
 /**
  * @summary adjust the maximum to be the multiple of the step resolution if the maximum on the slider is updated

--- a/src/firefly/js/ui/rc-slider.css
+++ b/src/firefly/js/ui/rc-slider.css
@@ -1,9 +1,13 @@
 .rc-slider {
   position: relative;
-  height: 4px;
+  /* height: 4px; // original, edited by firefly*/
+  height: 8px;
   width: 100%;
   border-radius: 6px;
-  background-color: #e9e9e9;
+  /*background-color: #e9e9e9; // original, edited (2 lines below) by firefly */
+  background-color: #b8b8b8;
+  box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.6) inset;
+
   box-sizing: border-box;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
@@ -14,19 +18,29 @@
 .rc-slider-track {
   position: absolute;
   left: 0;
-  height: 4px;
+  /* height: 4px; */
+  height: 8px;
   border-radius: 6px;
-  background-color: #abe2fb;
+  /*background-color: #abe2fb; // original, edited (2 lines below) by firefly */
+  background-color: #b8b8b8;
+  box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.6) inset;
 }
 .rc-slider-handle {
   position: absolute;
-  margin-left: -7px;
-  margin-top: -5px;
+  margin-left: -4px;
+  /* margin-top: -5px; //original, edited by firefly */
+  margin-top: -2px;
+  /*
   width: 14px;
   height: 14px;
+  // original, edited (two lines below) by firefly*/
+  width: 9px;
+  height: 12px;
   cursor: pointer;
-  border-radius: 50%;
-  border: solid 2px #96dbfa;
+  /*border-radius: 50%; //original, edited by firefly */
+  border-radius:30%;
+  /*border: solid 2px #96dbfa; // original, edited by firefly */
+  border: solid 2px #646464;
   background-color: #fff;
 }
 .rc-slider-handle:hover {
@@ -38,7 +52,8 @@
 }
 .rc-slider-mark {
   position: absolute;
-  top: 10px;
+  /* top: 10px;// original, edited by firefly*/
+  top: 18px;
   left: 0;
   width: 100%;
   font-size: 12px;
@@ -52,13 +67,15 @@
   color: #999;
 }
 .rc-slider-mark-text-active {
-  color: #666;
+  /* color: #666; // original, edited by firefly */
+  color: #999;
 }
 .rc-slider-step {
   position: absolute;
   width: 100%;
   height: 4px;
-  margin: 5px 0;
+  /* margin: 5px 0; // original, edited by firefly */
+  margin: 12px 0;
   background: transparent;
 }
 .rc-slider-dot {
@@ -67,7 +84,8 @@
   margin-left: -4px;
   width: 8px;
   height: 8px;
-  border: 2px solid #e9e9e9;
+  /*border: 2px solid #e9e9e9; // original, edited by firefly */
+  border: 2px solid #c0c0c0;
   background-color: #fff;
   cursor: pointer;
   border-radius: 50%;
@@ -80,7 +98,8 @@
   margin-left: -4px;
 }
 .rc-slider-dot-active {
-  border-color: #96dbfa;
+  /*border-color: #96dbfa; // original, edited by  firefly */
+  border-color: #c0c0c0;
 }
 .rc-slider-disabled {
   background-color: #e9e9e9;


### PR DESCRIPTION
The implementation mainly, 
- add 2D chart on the client side phase folding dialog and the plot changes as any of the phase folding parameters (time column, flux column, zero time point, period) changes.
- update the parameter items in the parameter setting dialog. 

Test:
- localhost:8080/firefly/lc.html
- open 'lc_raw.tbl' from 'Raw Table', click 'search'
- select tab 'Upload/Phase folding' and click button 'Phase Folding'
- experiment the setting of all entries and move slider to set 'period', the plot will be updated as any of the parameter (except Flux error column)  changes 
- click button 'Phase Folded Table' to close the dialog and a table with phase column is created (or updated) based on current setting of period, time column and zero point time. 

Note:
- The time and flux column names are set in default for IRSA cases. Those column names are settable while the phase folding dialog component is used. 


