### PR TITLE
DM-7967: reverse axis for magnitude

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPanel.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPanel.jsx
@@ -395,7 +395,7 @@ function doPhaseFolding(fields) {
     },  {tbl_id:PHASE_FOLDED});
     if (tReq !== null) {
         dispatchTableSearch(tReq, {removable: false});
-        let xyPlotParams = {x: {columnOrExpr: 'phase', options: 'grid'}, y: {columnOrExpr: 'w1mpro_ep', options:'grid'}};
+        let xyPlotParams = {x: {columnOrExpr: 'phase', options: 'grid'}, y: {columnOrExpr: 'w1mpro_ep', options:'grid,flip'}};
         loadXYPlot({chartId:PHASE_FOLDED, tblId:PHASE_FOLDED, xyPlotParams});
     }
 }

--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
@@ -721,7 +721,7 @@ function setPFTableSuccess(hideDropDown = false) {
             let xyPlotParams = {
                 userSetBoundaries: {xMax: 2},
                 x: {columnOrExpr: phaseCol, options: 'grid'},
-                y: {columnOrExpr: flux, options: 'grid'}
+                y: {columnOrExpr: flux, options: 'grid,flip'}
             };
             loadXYPlot({chartId: PHASE_FOLDED, tblId: PHASE_FOLDED, xyPlotParams});
         });

--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
@@ -347,7 +347,8 @@ class PhaseFoldingChart extends Component {
                     lineWidth: 1,
                     tickWidth: 1,
                     tickLength: 10,
-                    gridLineColor: '#e9e9e9'
+                    gridLineColor: '#e9e9e9',
+                    reversed: true
                 },
                 tooltip: showTooltip ? {enabled: true,
                                         formatter() {

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -220,11 +220,11 @@ function onSearchSubmit(request) {
     if ( get(request, RAW_TABLE) ){
         treq = TblUtil.makeFileRequest('Raw Table', request[RAW_TABLE], null, {tbl_id:RAW_TABLE});
         treq.tblType='notACatalog';
-        xyPlotParams = {x: {columnOrExpr: 'mjd'}, y: {columnOrExpr: 'w1mpro_ep'}};
+        xyPlotParams = {x: {columnOrExpr: 'mjd'}, y: {columnOrExpr: 'w1mpro_ep', options:'grid,flip'}};
     } else if ( get(request, PHASE_FOLDED) ) {
         treq = TblUtil.makeFileRequest('Phase Folded', request[PHASE_FOLDED], null, {tbl_id:PHASE_FOLDED});
         treq.tblType='notACatalog';
-        xyPlotParams = {x: {columnOrExpr: 'phase'}, y: {columnOrExpr: 'w1mpro_ep'}};
+        xyPlotParams = {x: {columnOrExpr: 'phase'}, y: {columnOrExpr: 'w1mpro_ep',  options:'grid,flip'}};
     } else if ( get(request, PERIODOGRAM) ) {
         treq = TblUtil.makeFileRequest('Periodogram', request[PERIODOGRAM], null, {tbl_id:PERIODOGRAM});
         treq.tblType='notACatalog';

--- a/src/firefly/js/templates/lightcurve/PeriodogramOptionsPanel.jsx
+++ b/src/firefly/js/templates/lightcurve/PeriodogramOptionsPanel.jsx
@@ -217,7 +217,7 @@ function doPeriodFinding(request) {
         dispatchTableSearch(tReq, {removable: true});
         let xyPlotParams = {
             userSetBoundaries: {yMin: 0},
-            x: {columnOrExpr: 'PERIOD', options: 'grid, log'},
+            x: {columnOrExpr: 'PERIOD', options: 'grid,log'},
             y: {columnOrExpr: 'POWER', options: 'grid'}
         };
         loadXYPlot({chartId:PERIODOGRAM, tblId:PERIODOGRAM, markAsDefault:true, xyPlotParams});


### PR DESCRIPTION
In LC viewer application, magnitudes should look flipped automatically when they get plotted. Please, check that when raw and phase folded table are displayed, the fluxes are in reverse order Y-axis. thanks. 