### PR TITLE
DM-8214 - handling server errors in charts

### DIFF
--- a/src/firefly/js/charts/ChartDataType.js
+++ b/src/firefly/js/charts/ChartDataType.js
@@ -12,7 +12,7 @@ import {logError} from '../util/WebUtil.js';
  * @prop {string} id - unique chart data type id
  * @prop {Function} fetchData - function to load chart data element data: fetchData(dispatch, chartId, chartDataElementId)
  * @prop {Function} fetchParamsChanged - function to determine if fetch is necessary: fetchParamsChanged(oldOptions, newOptions)
- * @prop {Function} getUpdatedOptions - function to resolve the options, which depend on table or chart data getUpdatedOptions(options, tblId, data, meta)
+ * @prop {Function} [getUpdatedOptions=undefined] - function to resolve the options, which depend on table or chart data getUpdatedOptions(options, tblId, data, meta)
  * @prop {boolean} [fetchOnTblSort=true] - if false, don't re-fetch data on tbl sort
  */
 

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -311,6 +311,9 @@ function doChartDataFetch(dispatch, payload, getChartDataType) {
  * @param payload.chartId
  * @param payload.chartDataElementId
  * @param payload.isDataReady
+ * @param payload.error
+ * @param payload.error.message
+ * @param payload.error.reason
  * @param payload.data
  * @param [payload.options]
  * @param [payload.meta]
@@ -520,6 +523,25 @@ export function getChartData(chartId) {
 
 export function getChartDataElement(chartId, chartDataElementId=FIRST_CDEL_ID) {
     return get(flux.getState(), [CHART_SPACE_PATH, 'data', chartId, 'chartDataElements', chartDataElementId]);
+}
+
+/**
+ * Get error object associated with the given chart data element
+ * @param chartId
+ * @returns {Array<{message:string, reason:object}>} an array of error objects
+ */
+export function getErrors(chartId) {
+    const chartDataElements = get(flux.getState(), [CHART_SPACE_PATH, 'data', chartId, 'chartDataElements']);
+    const errors = [];
+    if (chartDataElements) {
+        Object.keys(chartDataElements).forEach((id) => {
+            const error = chartDataElements[id].error;
+            if (error) {
+                errors.push(error);
+            }
+        });
+    }
+    return errors;
 }
 
 export function getExpandedChartProps() {

--- a/src/firefly/js/charts/dataTypes/HistogramCDT.js
+++ b/src/firefly/js/charts/dataTypes/HistogramCDT.js
@@ -161,6 +161,7 @@ function fetchColData(dispatch, chartId, chartDataElementId) {
                     chartId,
                     chartDataElementId,
                     isDataReady: true,
+                    error: undefined,
                     options : histogramParams,
                     data: histogramData,
                     meta: {tblSource}
@@ -168,7 +169,16 @@ function fetchColData(dispatch, chartId, chartDataElementId) {
         }
     ).catch(
         (reason) => {
-            console.error(`Failed to fetch histogram data: ${reason}`);
+            const message = 'Failed to fetch histogram data';
+            logError(`${message}: ${reason}`);
+            dispatch(chartDataUpdate(
+                {
+                    chartId,
+                    chartDataElementId,
+                    isDataReady: true,
+                    error: {message, reason},
+                    data: undefined
+                }));
         }
     );
 }

--- a/src/firefly/js/charts/dataTypes/XYColsCDT.js
+++ b/src/firefly/js/charts/dataTypes/XYColsCDT.js
@@ -8,7 +8,8 @@ import {updateSet, logError} from '../../util/WebUtil.js';
 import {get, omitBy, isEmpty, isString, isUndefined} from 'lodash';
 
 import {MetaConst} from '../../data/MetaConst.js';
-import {doFetchTable, getColumn, getTblById, isFullyLoaded, cloneRequest} from '../../tables/TableUtil.js';
+import {fetchTable} from '../../rpc/SearchServicesJson.js';
+import {getColumn, getTblById, isFullyLoaded, cloneRequest} from '../../tables/TableUtil.js';
 
 import {getChartDataElement, dispatchChartAdd, dispatchChartOptionsUpdate, chartDataUpdate} from './../ChartsCntlr.js';
 import {colWithName, getNumericCols, SCATTER} from './../ChartUtil.js';
@@ -325,7 +326,7 @@ function fetchPlotData(dispatch, chartId, chartDataElementId) {
         });
     req.tbl_id = `xy-${chartId}`;
 
-    doFetchTable(req).then(
+    fetchTable(req).then(
         (tableModel) => {
 
             // make sure we only save the data from the latest fetch
@@ -369,6 +370,7 @@ function fetchPlotData(dispatch, chartId, chartDataElementId) {
                     chartId,
                     chartDataElementId,
                     isDataReady: true,
+                    error: undefined,
                     options: getUpdatedParams(xyPlotParams, tblId, xyPlotData),
                     data: xyPlotData,
                     meta: {tblSource, decimatedUnzoomed}
@@ -376,7 +378,16 @@ function fetchPlotData(dispatch, chartId, chartDataElementId) {
         }
     ).catch(
         (reason) => {
-            logError(`Failed to fetch XY plot data: ${reason}`);
+            const message = 'Failed to fetch XY plot data';
+            logError(`${message}: ${reason}`);
+            dispatch(chartDataUpdate(
+                {
+                    chartId,
+                    chartDataElementId,
+                    isDataReady: true,
+                    error: {message, reason},
+                    data: undefined
+                }));
         }
     );
 

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -90,7 +90,7 @@ class ChartPanelView extends Component {
 
         var {widthPx, heightPx, componentKey, optionsShown} = this.state;
         const knownSize = widthPx && heightPx;
-
+        const errors  = ChartsCntlr.getErrors(chartId);
 
         if (showChart) {
             // chart with toolbar and options
@@ -113,7 +113,10 @@ class ChartPanelView extends Component {
                                 <Resizable id='chart-resizer' onResize={this.onResize}
                                            className='ChartPanel__chartresizer'>
                                     <div style={{overflow:'auto',width:widthPx,height:heightPx}}>
-                                        {knownSize ? <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
+                                        {knownSize ?
+                                            errors.length > 0 ?
+                                                <ErrorPanel errors={errors}/> :
+                                                <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
                                             <div/>}
                                     </div>
                                 </Resizable>
@@ -135,7 +138,11 @@ class ChartPanelView extends Component {
                             <Resizable id='chart-resizer' onResize={this.onResize}
                                        className='ChartPanel__chartresizer'>
                                 <div style={{overflow:'auto',width:widthPx,height:heightPx}}>
-                                    {knownSize ? <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
+                                    {knownSize ?
+                                        errors.length > 0 ?
+                                            <ErrorPanel errors={errors}/> :
+                                            <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
+
                                         <div/>}
                                 </div>
                             </Resizable>
@@ -189,6 +196,30 @@ ChartPanelView.propTypes = {
 ChartPanelView.defaultProps = {
     showToolbar: true,
     showChart: true
+};
+
+function ErrorPanel({errors}) {
+    return (
+      <div style={{position: 'relative', width: '100%', height: '100%'}}>
+          {errors.map((error, i) => {
+              const {message='Error', reason=''} = error;
+                    return (
+                        <div key={i} style={{padding: 20, textAlign: 'center', overflowWrap: 'normal'}}>
+                            <h3>{message}</h3>
+                            {`${reason}`}
+                        </div>
+                    );
+              })}
+      </div>
+    );
+}
+
+ErrorPanel.propTypes = {
+    errors: PropTypes.arrayOf(
+        PropTypes.shape({
+            message: PropTypes.string,
+            reason: PropTypes.oneOfType([PropTypes.object,PropTypes.string]) // reason can be an Error object
+        }))
 };
 
 export class ChartPanel extends Component {


### PR DESCRIPTION
This pull request is for handling server error in a chart. Prior to it, loading message would not disappear when an error occurred.

The test relies on a bug in 'Clear' options behavior for histogram. When 'Clear' is pressed, all fields histogram options are cleared, including 'Column or expression value'. If options are applied at this point, an empty column is sent to the server, resulting in an error. 