### PR TITLE
DM-8543 Activate the image inside the multi-image viewer without clicking the image iteself

### DIFF
--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -565,15 +565,15 @@ function changeActivePlot(state, payload, containerType) {
     return state.map((viewer) => {
         var isView = false;
 
+        if (!has(viewer, 'lastActivePlotId')) return viewer;
+
         if (viewerId) {         // plot image action case
             if ((viewerId === viewer.viewerId) && viewer.itemIdAry.includes(plotId)) {
                 isView = true;
             }
-        } else {                // change active plot action case
-            if (has(viewer, 'lastActivePlotId') &&
-                (viewer.containerType === containerType) &&
-                (viewer.itemIdAry.includes(plotId))) {
-                isView = true;
+        } else {               // change active plot action case
+            if ((viewer.containerType === containerType) && (viewer.itemIdAry.includes(plotId))) {
+              isView = true;
             }
         }
 

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -96,7 +96,7 @@ function initState() {
             containerType : IMAGE,
             layoutDetail : 'none',
             customData: {},
-            lastActivePlotId: ''
+            lastActiveItemId: ''
         },
         {
             viewerId:DEFAULT_PLOT2D_VIEWER_ID,
@@ -108,7 +108,8 @@ function initState() {
             mounted: false,
             containerType : PLOT2D,
             layoutDetail : 'none',
-            customData: {}
+            customData: {},
+            lastActiveItemId: ''
         }
     ];
 }
@@ -128,7 +129,7 @@ function initState() {
  * @param {boolean} mounted
  */
 export function dispatchAddViewer(viewerId, canReceiveNewPlots, containerType, mounted=false) {
-    flux.process({type: ADD_VIEWER , payload: {viewerId, canReceiveNewPlots, containerType, mounted, lastActivePlotId:''} });
+    flux.process({type: ADD_VIEWER , payload: {viewerId, canReceiveNewPlots, containerType, mounted, lastActiveItemId:''} });
 }
 
 /**
@@ -381,7 +382,7 @@ function reducer(state=initState(), action={}) {
             break;
         case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
         case ImagePlotCntlr.PLOT_IMAGE:
-            retState = changeActivePlot(state, payload, IMAGE);
+            retState = changeActiveItem(state, payload, IMAGE);
             break;
         default:
             break;
@@ -405,20 +406,20 @@ function imageViewerCanAdd(state, viewerId, plotId) {
 function addViewer(state,payload) {
 
     const {viewerId,containerType, layout=GRID,canReceiveNewPlots=NewPlotMode.replace_only.key, mounted=false}= payload;
-    var   {lastActivePlotId} = payload;
+    var   {lastActiveItemId} = payload;
     var entryInState = hasViewerId(state,viewerId);
 
     if (entryInState) {
         entryInState = Object.assign(entryInState, {canReceiveNewPlots, mounted, containerType});
 
-        if (has(entryInState, 'lastActivePlotId')) {
-            lastActivePlotId = entryInState.lastActivePlotId ? entryInState.lastActivePlotId : get(entryInState, ['itemIdAry', '0'], '');
-            entryInState = Object.assign(entryInState, {lastActivePlotId});
+        if (has(entryInState, 'lastActiveItemId')) {
+            lastActiveItemId = entryInState.lastActiveItemId ? entryInState.lastActiveItemId : get(entryInState, ['itemIdAry', '0'], '');
+            entryInState = Object.assign(entryInState, {lastActiveItemId});
         }
         return [...state];
     } else {
         const entry = {viewerId, containerType, canReceiveNewPlots, layout, mounted, itemIdAry: [], customData: {},
-                       lastActivePlotId};
+                       lastActiveItemId};
         return [...state, entry];
     }
 }
@@ -478,8 +479,8 @@ function replaceImages(state,viewerId,itemIdAry,containerType) {
     }
 
     var updateViewer = (entry) => {
-        if (has(entry, 'lastActivePlotId')) {
-            return {itemIdAry, lastActivePlotId: get(itemIdAry, '0', '')};
+        if (has(entry, 'lastActiveItemId')) {
+            return {itemIdAry, lastActiveItemId: get(itemIdAry, '0', '')};
         } else {
             return {itemIdAry};
         }
@@ -506,8 +507,8 @@ function removeItems(state,action) {
 
     var updateViewer = (entry) => {
 
-        if (has(entry, 'lastActivePlotId')&&rmIdAry.includes(entry.lastActivePlotId)) {
-            return {itemIdAry, lastActivePlotId: get(itemIdAry, '0', '')};
+        if (has(entry, 'lastActiveItemId')&&rmIdAry.includes(entry.lastActiveItemId)) {
+            return {itemIdAry, lastActiveItemId: get(itemIdAry, '0', '')};
         } else {
             return {itemIdAry}
         }
@@ -529,8 +530,8 @@ function deleteSingleItem(state,itemId, containerType) {
         if (viewer.containerType!==containerType || !viewer.itemIdAry.includes( itemId)) return viewer;
         const v = clone(viewer, {itemIdAry: without(viewer.itemIdAry, itemId)});
 
-        if (has(v, 'lastActivePlotId') && (v.lastActivePlotId === itemId)) {
-            return clone(v, {lastActivePlotId:  get(v, 'itemIdAry.0', '')});
+        if (has(v, 'lastActiveItemId') && (v.lastActiveItemId === itemId)) {
+            return clone(v, {lastActiveItemId:  get(v, 'itemIdAry.0', '')});
         } else {
             return v;
         }
@@ -559,13 +560,13 @@ function updateCustomData(state,action) {
     return state.map( (entry) => entry.viewerId===viewerId ? clone(entry, {customData}) : entry);
 }
 
-function changeActivePlot(state, payload, containerType) {
+function changeActiveItem(state, payload, containerType) {
     var {plotId, viewerId} = payload;
 
     return state.map((viewer) => {
         var isView = false;
 
-        if (!has(viewer, 'lastActivePlotId')) return viewer;
+        if (!has(viewer, 'lastActiveItemId')) return viewer;
 
         if (viewerId) {         // plot image action case
             if ((viewerId === viewer.viewerId) && viewer.itemIdAry.includes(plotId)) {
@@ -578,7 +579,7 @@ function changeActivePlot(state, payload, containerType) {
         }
 
         if (isView) {
-            return clone(viewer, {lastActivePlotId: plotId});
+            return clone(viewer, {lastActiveItemId: plotId});
         } else {
             return viewer;
         }

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -27,8 +27,8 @@ export class MultiImageViewer extends Component {
             dispatchViewerUnmounted(this.props.viewerId);
 
             var viewer = getViewer(getMultiViewRoot(), nextProps.viewerId);
-            if (viewer && viewer.lastActivePlotId) {
-                dispatchChangeActivePlotView(viewer.lastActivePlotId);
+            if (viewer && viewer.lastActiveItemId) {
+                dispatchChangeActivePlotView(viewer.lastActiveItemId);
             }
         }
         this.storeUpdate(nextProps);

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -9,7 +9,7 @@ import {flux} from '../../Firefly.js';
 import {NewPlotMode, dispatchAddViewer, dispatchViewerMounted, dispatchViewerUnmounted,
         getMultiViewRoot, getViewer, getLayoutType, IMAGE} from '../MultiViewCntlr.js';
 import {MultiImageViewerView} from './MultiImageViewerView.jsx';
-import {visRoot} from '../ImagePlotCntlr.js';
+import {visRoot, dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {getDlAry} from '../DrawLayerCntlr.js';
 
 export class MultiImageViewer extends Component {
@@ -23,8 +23,13 @@ export class MultiImageViewer extends Component {
 
     componentWillReceiveProps(nextProps) {
         if (this.props.viewerId!==nextProps.viewerId) {
-            dispatchAddViewer(nextProps.viewerId,nextProps.canReceiveNewPlots,IMAGE, true);
+            dispatchAddViewer(nextProps.viewerId, nextProps.canReceiveNewPlots, IMAGE,true);
             dispatchViewerUnmounted(this.props.viewerId);
+
+            var viewer = getViewer(getMultiViewRoot(), nextProps.viewerId);
+            if (viewer && viewer.lastActivePlotId) {
+                dispatchChangeActivePlotView(viewer.lastActivePlotId);
+            }
         }
         this.storeUpdate(nextProps);
     }


### PR DESCRIPTION
This development intends to solve the issue that no image is highlighted on the coverage map and FITS data panel while clicking back and forth among the image tabs on the triview. The image handling toolbar is  shown properly based on the selected image tab and its associated active image. 

test: 
localhost:8080/firefly/lsst-pdac-triview.html
image->deep source->target: 0, -1, search type: enclosed, search region size: 3600 arcsec

click 'External images' on top of the triview to get two images rendered in FITS Data panel, 
external images -> wise, create new plot, target: m31, search, 
external images ->wise, create new plot, target:  m51, search

click among all three image tabs, and test. 


