### PR TITLE
DM-7966: Default table sorting in LC viewer

### DIFF
--- a/src/firefly/js/tables/SortInfo.js
+++ b/src/firefly/js/tables/SortInfo.js
@@ -5,6 +5,17 @@ export const SORT_ASC = 'ASC';
 export const SORT_DESC = 'DESC';
 export const UNSORTED = '';
 
+
+/**
+ * convenience function to create the serialized string representation of SortInfo
+ * @param {string} colName column's name
+ * @param {boolean} [isAscending=true] false for descending order, otherwise it's default to ascending.
+ */
+export function sortInfoString(colName, isAscending=true) {
+    if (!colName) return '';
+    return SortInfo.newInstance( (isAscending ? SORT_ASC : SORT_DESC), colName).serialize();
+}
+
 /**
  * convenience class to handle the table's sort information.
  * data is stored as a string of '(ASC|DESC),col1[,col2]*.  ie.  'ASC,id,band'

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -299,7 +299,10 @@ function tableSearch(action) {
             const {tbl_id} = request;
             const title = get(request, 'META_INFO.title');
             request.pageSize = options.pageSize = options.pageSize || request.pageSize || 100;
-
+            if (TblUtil.getTblById(tbl_id)) {
+                // table exists... this is a new search.  old data should be removed.
+                dispatchTableRemove(tbl_id);
+            }
             dispatchTableFetch(request);
             dispatchTblResultsAdded(tbl_id, title, options, tbl_ui_id);
         }
@@ -345,8 +348,10 @@ function tblResultsAdded(action) {
 
 function highlightRow(action) {
     return (dispatch) => {
-        const {tbl_id} = action.payload;
+        const {tbl_id, highlightedRow} = action.payload;
         var tableModel = TblUtil.getTblById(tbl_id);
+        if (highlightedRow < 0 || highlightedRow >= tableModel.totalRows) return;   // out of bound.. ignore.
+
         var tmpModel = TblUtil.smartMerge(tableModel, action.payload);
         const {hlRowIdx, startIdx, endIdx, pageSize} = TblUtil.getTblInfo(tmpModel);
         if (TblUtil.isTblDataAvail(startIdx, endIdx, tableModel)) {

--- a/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
+++ b/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
@@ -11,7 +11,7 @@ import {WcsMatchType, visRoot, dispatchWcsMatch} from '../../visualize/ImagePlot
 import {VisInlineToolbarView} from '../../visualize/ui/VisInlineToolbarView.jsx';
 import {RadioGroupInputFieldView} from '../../ui/RadioGroupInputFieldView.jsx';
 import {dispatchChangeViewerLayout, getViewer, getMultiViewRoot, GRID, SINGLE} from '../../visualize/MultiViewCntlr.js';
-import {DEF_IMAGE_CNT, MAX_IMAGE_CNT} from './LcManager.js';
+import {LC} from './LcManager.js';
 
 
 
@@ -33,7 +33,7 @@ const tStyle= {
 
 var options= [];
 
-for(var i= 1; (i<=MAX_IMAGE_CNT); i+=2) {
+for(var i= 1; (i<=LC.MAX_IMAGE_CNT); i+=2) {
     options.push({label: String(i), value: String(i)});
 }
 
@@ -41,7 +41,7 @@ for(var i= 1; (i<=MAX_IMAGE_CNT); i+=2) {
 export function LcImageToolbarView({activePlotId, viewerId, viewerPlotIds, layoutType, dlAry, tableId}) {
 
     const viewer= getViewer(getMultiViewRoot(), viewerId);
-    const count= get(viewer, 'layoutDetail.count',DEF_IMAGE_CNT);
+    const count= get(viewer, 'layoutDetail.count',LC.DEF_IMAGE_CNT);
     const vr= visRoot();
     const pv= getPlotViewById(vr, activePlotId);
     const pvDlAry= getAllDrawLayersForPlot(dlAry,activePlotId,true);

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -21,13 +21,26 @@ import {CHANGE_VIEWER_LAYOUT} from '../../visualize/MultiViewCntlr.js';
 import {LcPFOptionsPanel, grpkey} from './LcPhaseFoldingPanel.jsx';
 import FieldGroupUtils, {revalidateFields} from '../../fieldGroup/FieldGroupUtils';
 
-export const RAW_TABLE = 'raw_table';
-export const PHASE_FOLDED = 'phase_folded';
-export const PERIODOGRAM = 'periodogram';
-export const PEAK_TABLE = 'peak_table';
-export const IMG_VIEWER_ID = 'lc_image_viewer';
-export const DEF_IMAGE_CNT= 5;
-export const MAX_IMAGE_CNT= 7;
+export const LC = {
+    RAW_TABLE: 'raw_table',
+    PHASE_FOLDED: 'phase_folded',
+    PERIODOGRAM: 'periodogram',
+    PEAK_TABLE: 'peak_table',
+    PERIOD_CNAME: 'Period',
+    POWER_CNAME: 'Power',
+    PEAK_CNAME: 'Peak',
+    PHASE_CNAME: 'phase',
+
+    IMG_VIEWER_ID: 'lc_image_viewer',
+    MAX_IMAGE_CNT: 7,
+    DEF_IMAGE_CNT: 5,
+
+    META_TIME_CNAME: 'timeCName',
+    META_FLUX_CNAME: 'fluxCName',
+    DEF_TIME_CNAME: 'mjd',
+    DEF_FLUX_CNAME: 'w1mpro_ep',
+};
+
 const plotIdRoot= 'LC_FRAME-';
 
 
@@ -124,7 +137,7 @@ function handleTableHighlight(layoutInfo, action) {
 }
 
 function isImageEnabledTable(tbl_id) {
-    return [PHASE_FOLDED, RAW_TABLE].includes(tbl_id);
+    return [LC.PHASE_FOLDED, LC.RAW_TABLE].includes(tbl_id);
 }
 
 function handleChangeMultiViewLayout(layoutInfo, action) {
@@ -204,13 +217,13 @@ function getWebPlotRequestViaUrl(tableModel, hlrow, cutoutSize) {
 
 export function setupImages(tbl_id) {
     try {
-        const viewer=  getViewer(getMultiViewRoot(),IMG_VIEWER_ID);
-        const count= get(viewer, 'layoutDetail.count',DEF_IMAGE_CNT);
+        const viewer=  getViewer(getMultiViewRoot(),LC.IMG_VIEWER_ID);
+        const count= get(viewer, 'layoutDetail.count',LC.DEF_IMAGE_CNT);
         const tableModel = getTblById(tbl_id);
         if (!tableModel || isNil(tableModel.highlightedRow)) return;
         var vr= visRoot();
         const newPlotIdAry= makePlotIds(tableModel.highlightedRow, tableModel.totalRows,count);
-        const maxPlotIdAry= makePlotIds(tableModel.highlightedRow, tableModel.totalRows,MAX_IMAGE_CNT);
+        const maxPlotIdAry= makePlotIds(tableModel.highlightedRow, tableModel.totalRows,LC.MAX_IMAGE_CNT);
 
         const cutoutSize = get(FieldGroupUtils.getGroupFields(grpkey), ['cutoutSize', 'value'], null);
 
@@ -226,7 +239,7 @@ export function setupImages(tbl_id) {
         });
 
 
-        dispatchReplaceViewerItems(IMG_VIEWER_ID, newPlotIdAry);
+        dispatchReplaceViewerItems(LC.IMG_VIEWER_ID, newPlotIdAry);
         dispatchChangeActivePlotView(plotIdRoot+tableModel.highlightedRow);
 
         vr= visRoot();

--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPanel.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPanel.jsx
@@ -4,33 +4,29 @@
 
 
 import React, {Component, PropTypes} from 'react';
-import {TargetPanel} from '../../ui/TargetPanel.jsx';
+import {isNil} from 'lodash';
+
 import {InputGroup} from '../../ui/InputGroup.jsx';
 import Validate from '../../util/Validate.js';
 import {ValidationField} from '../../ui/ValidationField.jsx';
-import {CheckboxGroupInputField} from '../../ui/CheckboxGroupInputField.jsx';
-import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
-import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
-import Histogram from '../../charts/ui/Histogram.jsx';
 import CompleteButton from '../../ui/CompleteButton.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {dispatchValueChange, dispatchRestoreDefaults} from '../../fieldGroup/FieldGroupCntlr.js';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
-import FieldGroupUtils, {revalidateFields} from '../../fieldGroup/FieldGroupUtils';
+import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 import {makeTblRequest,getTblById,getCellValue} from '../../tables/TableUtil.js';
 
-import {CollapsiblePanel} from '../../ui/panel/CollapsiblePanel.jsx';
-import {Tabs, Tab,FieldGroupTabs} from '../../ui/panel/TabPanel.jsx';
+import {Tabs, Tab} from '../../ui/panel/TabPanel.jsx';
 import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
 import {dispatchTableSearch, TABLE_HIGHLIGHT} from '../../tables/TablesCntlr.js';
 
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
-import {RAW_TABLE, PHASE_FOLDED, PERIODOGRAM, PEAK_TABLE, setupImages} from '../../templates/lightcurve/LcManager.js';
+import {LC} from '../../templates/lightcurve/LcManager.js';
 import {showPhaseFoldingPopup} from './LcPhaseFoldingPopup.jsx';
+import {sortInfoString} from '../../tables/SortInfo.js';
 
-import {isUndefined, get,set,isNil} from 'lodash';
 import {take} from 'redux-saga/effects';
 import './LCPanels.css';
 
@@ -80,55 +76,6 @@ const Header = {
     fontSize: 'large'
     };
 
-
-const defValues= {
-    fieldInt: {
-        fieldKey: 'fieldInt',
-        value: '3',
-        validator: Validate.intRange.bind(null, 1, 10, 'test field'),
-        tooltip: 'this is a tip for field 1',
-        label: 'Int Value:'
-    },
-    FluxColumn: {
-        fieldKey: 'fluxcolumn',
-        value: '',
-        validator: Validate.floatRange.bind(null, 0.2, 20.5, 2, 'Flux Column'),
-        tooltip: 'Flux Column',
-        label: 'Flux Column:',
-        nullAllowed : true,
-        labelWidth: 100
-    },
-    field1: {
-        fieldKey: 'field1',
-        value: '3',
-        validator: Validate.intRange.bind(null, 1, 10, 'test field'),
-        tooltip: 'this is a tip for field 1',
-        label: 'Int Value:'
-    },
-    field2: {
-        fieldKey: 'field2',
-        value: '',
-        validator: Validate.floatRange.bind(null, 1.5, 50.5, 2, 'a float field'),
-        tooltip: 'field 2 tool tip',
-        label: 'Float Value:',
-        nullAllowed : true,
-        labelWidth: 100
-    },
-    low: {
-        fieldKey: 'low',
-        value: '1',
-        validator: Validate.intRange.bind(null, 1, 100, 'low field'),
-        tooltip: 'this is a tip for low field',
-        label: 'Low Field:'
-    },
-    high: {
-        fieldKey: 'high',
-        value: '3',
-        validator: Validate.intRange.bind(null, 1, 100, 'high field'),
-        tooltip: 'this is a tip for high field',
-        label: 'High Field:'
-    }
-};
 
 
 var LcPhaseFoldingDialog = React.createClass({
@@ -188,8 +135,6 @@ export function LcPFOptionsPanel ({fields}) {
         const {radioGrpFld}= fields;
         hide= (radioGrpFld && radioGrpFld.value==='opt2');
     }
-    var fieldInt= makeField1(hide);
-
     //Todo: get valication Suggestion from table
 
     const validSuggestions = ['mjd','col1','col2'];
@@ -197,8 +142,7 @@ export function LcPFOptionsPanel ({fields}) {
 
     return (
 
-            <FieldGroup style= {PanelResizableStyle} groupKey={grpkey} initValues={{timeCol:'mjd',field1:'4'}}
-                              reducerFunc={DialogReducer} keepState={true}>
+            <FieldGroup style= {PanelResizableStyle} groupKey={grpkey} initValues={{timeCol:LC.DEF_TIME_CNAME}} keepState={true}>
                 <InputGroup labelWidth={110}>
 
                     <span style={Header}>Phase Folding</span>
@@ -229,24 +173,12 @@ export function LcPFOptionsPanel ({fields}) {
                     <ValidationField fieldKey='flux'
                          initialState= {{
                                 fieldKey: 'flux',
-                                value: '2.0',
-                                validator: Validate.floatRange.bind(null, 2.0, 5.5, 3,'Flux Column'),
-                                tooltip: 'Flux Column, value between 2.0 to 5.5',
+                                value: LC.DEF_FLUX_CNAME,
+                                tooltip: 'Flux column name',
                                 label : 'Flux Column:',
                                 labelWidth : 100
                           }} />
 
-                    <br/>
-
-                    <ValidationField fieldKey='fluxerror'
-                         initialState= {{
-                                fieldKey: 'fluxerror',
-                                value: '0.02',
-                                validator: Validate.floatRange.bind(null, 0.01, 0.5, 3,'Flux Error'),
-                                tooltip: 'Flux Error, value is between 0.01 to 0.5',
-                                label : 'Flux Error:',
-                                labelWidth : 100
-                         }} />
                     <br/>
 
                     <ValidationField fieldKey='period'
@@ -294,36 +226,6 @@ export function LcPFOptionsPanel ({fields}) {
 LcPFOptionsPanel.propTypes= {
     fields: PropTypes.object
 };
-
-/**
- *
- * @param {object} inFields
- * @param {object} action
- * @return {object}
- */
-var DialogReducer= function(inFields, action) {
-    if (!inFields)  {
-        return defValues;
-    }
-    else {
-        var {low,high}= inFields;
-        // inFields= revalidateFields(inFields);
-        if (!low.valid || !high.valid) {
-            return inFields;
-        }
-        if (parseFloat(low.value)> parseFloat(high.value)) {
-            low= Object.assign({},low, {valid:false, message:'must be lower than high'});
-            high= Object.assign({},high, {valid:false, message:'must be higher than low'});
-            return Object.assign({},inFields,{low,high});
-        }
-        else {
-            low= Object.assign({},low, low.validator(low.value));
-            high= Object.assign({},high, high.validator(high.value));
-            return Object.assign({},inFields,{low,high});
-        }
-    }
-};
-
 
 function resetDefaults() {
     dispatchRestoreDefaults(grpkey);
@@ -380,44 +282,28 @@ function resultsSuccess(request) {
 }
 
 function onSearchSubmit(request) {
-    let fieldState = FieldGroupUtils.getGroupFields(grpkey);
-
-    // TODO Fix: request doesn't contain 'Tabs'...
-    //if (request.Tabs==='LC Param') {
-        doPhaseFolding(fieldState);
-    //}
-    //else {
-    //    console.log('request no supported');
-    //}
+    const fieldState = FieldGroupUtils.getGroupFields(grpkey);
+    doPhaseFolding(fieldState);
 }
 
 //here to plug in the phase folding processor
 function doPhaseFolding(fields) {
-    let tbl = getTblById(RAW_TABLE);
+    let tbl = getTblById(LC.RAW_TABLE);
 
-    console.log(fields);
+    // console.log(fields);
 
-    var tReq = makeTblRequest('PhaseFoldedProcessor', PHASE_FOLDED, {
-        'period_days': fields.period.value,
-        'cutout_size': fields.cutoutSize.value,
-        'flux': fields.flux.value,
-        'table_name': 'folded_table',
-        'x':fields.timeCol.value,
-        'original_table': tbl.tableMeta.tblFilePath
-    },  {tbl_id:PHASE_FOLDED});
-    if (tReq !== null) {
-        dispatchTableSearch(tReq, {removable: false});
-        let xyPlotParams = {x: {columnOrExpr: 'phase', options: 'grid'}, y: {columnOrExpr: 'w1mpro_ep', options:'grid,flip'}};
-        loadXYPlot({chartId:PHASE_FOLDED, tblId:PHASE_FOLDED, xyPlotParams});
-    }
-}
+    var tReq = makeTblRequest('PhaseFoldedProcessor', LC.PHASE_FOLDED, {
+        period_days: fields.period.value,
+        cutout_size: fields.cutoutSize.value,
+        flux: fields.flux.value,
+        table_name: 'folded_table',
+        x:fields.timeCol.value,
+        original_table: tbl.tableMeta.tblFilePath
+    },  {tbl_id:LC.PHASE_FOLDED, sortInfo:sortInfoString(LC.PHASE_CNAME)});
 
-function makeField1(hide) {
-    var f1= (
-        <ValidationField fieldKey={'field1'} />
-    );
-    var hidden= <div style={{paddingLeft:30}}>field is hidden</div>;
-    return hide ? hidden : f1;
+    dispatchTableSearch(tReq, {removable: false});
+    const xyPlotParams = {x: {columnOrExpr: LC.PHASE_CNAME, options: 'grid'}, y: {columnOrExpr: tReq.flux, options:'grid,flip'}};
+    loadXYPlot({chartId:LC.PHASE_FOLDED, tblId:LC.PHASE_FOLDED, xyPlotParams});
 }
 
 export function* listenerPanel() {
@@ -452,9 +338,9 @@ function handleTableHighlight(action) {
 function getPeriodFromTable(tbl_id) {
     const tableModel = getTblById(tbl_id);
     if (!tableModel || isNil(tableModel.highlightedRow)) return;
-    if (tbl_id === PERIODOGRAM) {
-        return getCellValue(tableModel, tableModel.highlightedRow, 'Period');
-    } else if (tbl_id === PEAK_TABLE) {
-        return getCellValue(tableModel, tableModel.highlightedRow, 'Period');
+    if (tbl_id === LC.PERIODOGRAM) {
+        return getCellValue(tableModel, tableModel.highlightedRow, LC.PERIOD_CNAME);
+    } else if (tbl_id === LC.PEAK_TABLE) {
+        return getCellValue(tableModel, tableModel.highlightedRow, LC.PERIOD_CNAME);
     }
 }

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -4,10 +4,9 @@
 
 import React, {Component} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {pick,get} from 'lodash';
+import {pick} from 'lodash';
 import SplitPane from 'react-split-pane';
 
-import ColValuesStatistics from '../../charts/ColValuesStatistics.js';
 
 import {flux} from '../../Firefly.js';
 import {LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
@@ -16,34 +15,17 @@ import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {VisToolbar} from '../../visualize/ui/VisToolbar.jsx';
 import {MultiImageViewerContainer} from '../../visualize/ui/MultiImageViewerContainer.jsx';
 import {createContentWrapper} from '../../ui/panel/DockLayoutPanel.jsx';
-import {IMG_VIEWER_ID} from './LcManager.js';
+import {LC} from './LcManager.js';
 import {FormPanel} from '../../ui/FormPanel.jsx';
-import {Tabs, Tab,FieldGroupTabs} from '../../ui/panel/TabPanel.jsx';
-import {CollapsiblePanel} from '../../ui/panel/CollapsiblePanel.jsx';
-import {CheckboxGroupInputField} from '../../ui/CheckboxGroupInputField.jsx';
+import {Tabs, Tab} from '../../ui/panel/TabPanel.jsx';
 import {ValidationField} from '../../ui/ValidationField.jsx';
 import Validate from '../../util/Validate.js';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
-import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {InputGroup} from '../../ui/InputGroup.jsx';
 import {UploadPanel} from './LcViewer.jsx';
-import {LcPlotOptionsPanel} from './LcPlotOptions.jsx';
 import {LcImageToolbar} from './LcImageToolbar.jsx';
-import {ImageMetaDataToolbar} from '../../visualize/ui/ImageMetaDataToolbar.jsx';
 import {LcPFOptionsPanel} from './LcPhaseFoldingPanel.jsx';
 import {LcPeriodFindingPanel} from './PeriodogramOptionsPanel.jsx';
-
-
-const PanelResizableStyle = {
-    width: 400,
-    minWidth: 450,
-    height: 300,
-    minHeight: 760,
-    resize: 'both',
-    position: 'relative',
-    backgroundColor: '#e6ffff',
-    overflow: 'auto'
-};
 
 
 export class LcResult extends Component {
@@ -78,7 +60,7 @@ export class LcResult extends Component {
         if (showImages) {
             visToolbar = <VisToolbar key='res-vis-tb'/>;
             content.imagePlot = (<MultiImageViewerContainer key='res-images'
-                                        viewerId={IMG_VIEWER_ID}
+                                        viewerId={LC.IMG_VIEWER_ID}
                                         closeable={true}
                                         forceRowSize={1}
                                         imageExpandedMode={expanded===LO_VIEW.images}
@@ -103,12 +85,12 @@ export class LcResult extends Component {
                     <div style={{height:'100%'}}>
                         <Tabs componentKey='OuterTabs' defaultSelected={0} useFlex={true}>
 
-                            <Tab name="Phase Folding">
+                            <Tab name='Phase Folding'>
                                 <div>
                                     {LcPFOptionsPanel(fields)}
                                 </div>
                             </Tab>
-                            <Tab name="Periodogram">
+                            <Tab name='Periodogram'>
                                 <div>
                                     <LcPeriodFindingPanel />
                                 </div>
@@ -125,7 +107,7 @@ export class LcResult extends Component {
                 <div>
                     <div>
                         <Tabs componentKey='OuterTabs' defaultSelected={0} useFlex={true}>
-                            <Tab name="Periodogram">
+                            <Tab name='Periodogram'>
                                 <div>
                                     <LcPeriodFindingPanel />
                                 </div>
@@ -181,7 +163,7 @@ const StandardView = ({visToolbar, title, searchDesc, standard, imagePlot, xyPlo
             <div style={{flexGrow: 1, position: 'relative'}}>
             <div style={{position: 'absolute', top: 0, right: 0, bottom: 0, left: 0}}>
                 <SplitPane split='vertical' minSize={20}  defaultSize={435}>
-                    <SplitPane split='horizontal' minSize={20} defaultSize={300}>
+                    <SplitPane split='horizontal' minSize={20} defaultSize={435}>
                         {createContentWrapper(form)}
                         {createContentWrapper(tables)}
                     </SplitPane>

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -5,12 +5,12 @@
 
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {get, pickBy} from 'lodash';
+import {pickBy} from 'lodash';
 
 import {flux, firefly} from '../../Firefly.js';
 import {getMenu, isAppReady, dispatchSetMenu, dispatchOnAppReady} from '../../core/AppDataCntlr.js';
-import {LO_VIEW, getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
-import {lcManager, PERIODOGRAM, PHASE_FOLDED, RAW_TABLE, PEAK_TABLE} from './LcManager.js';
+import {getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
+import {lcManager, LC} from './LcManager.js';
 import {listenerPanel} from './LcPhaseFoldingPanel.jsx';
 import {LcResult} from './LcResult.jsx';
 import {Menu} from '../../ui/Menu.jsx';
@@ -24,11 +24,13 @@ import {FormPanel} from './../../ui/FormPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {dispatchInitFieldGroup} from '../../fieldGroup/FieldGroupCntlr.js';
 import {FileUpload} from '../../ui/FileUpload.jsx';
+import {ValidationField} from '../../ui/ValidationField.jsx';
 import {dispatchHideDropDown} from '../../core/LayoutCntlr.js';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import * as TblUtil from '../../tables/TableUtil.js';
+import {sortInfoString} from '../../tables/SortInfo.js';
 
 // import {deepDiff} from '../util/WebUtil.js';
 
@@ -154,54 +156,42 @@ function BannerSection(props) {
 
 
 /**
- *  A temporary upload panel for use during development phase.  This should be removed or replaced with something else.
+ *  A generic upload panel.
+ * @param {Object} props react component's props
  */
-export const UploadPanel = () => {
-
+export function UploadPanel(props) {
+    const wrapperStyle = {margin: '5px 0'};
     return (
         <div style={{padding: 10}}>
             <FormPanel
-                width='640px' height='200px'
-                groupKey='LC_FORM'
+                groupKey='LC_UPLOAD_FORM'
                 onSubmit={(request) => onSearchSubmit(request)}
                 onCancel={dispatchHideDropDown}>
-                <FieldGroup groupKey='LC_FORM' validatorFunc={null} keepState={true}>
+                <FieldGroup groupKey='LC_UPLOAD_FORM' validatorFunc={null} keepState={true}>
                     <FileUpload
-                        wrapperStyle = {{margin: '5px 0'}}
-                        fieldKey = {RAW_TABLE}
-                        groupKey='LC_FORM'
+                        wrapperStyle = {wrapperStyle}
+                        fieldKey = 'rawTblSource'
                         initialState= {{
-                                tooltip: 'Select a file to upload',
-                                label: 'Raw Table:'
+                                tooltip: 'Select a Light Curves Table file to upload',
+                                label: 'Raw Light Curves Table:'
                             }}
                     />
-                    <FileUpload
-                        wrapperStyle = {{margin: '5px 0'}}
-                        fieldKey = {PEAK_TABLE}
-                        groupKey='LC_FORM'
-                        initialState= {{
-                                tooltip: 'Select a file to upload',
-                                label: 'Peak Table:'
-                            }}
-                    />
-                    <FileUpload
-                        wrapperStyle = {{margin: '5px 0'}}
-                        fieldKey = {PHASE_FOLDED}
-                        groupKey='LC_FORM'
-                        initialState= {{
-                                tooltip: 'Select a file to upload',
-                                label: 'Phase Folded:'
-                            }}
-                    />
-                    <FileUpload
-                        wrapperStyle = {{margin: '5px 0'}}
-                        fieldKey = {PERIODOGRAM}
-                        groupKey='LC_FORM'
-                        initialState= {{
-                                tooltip: 'Select a file to upload',
-                                label: 'Periodogram:'
-                            }}
-                    />
+                    <ValidationField fieldKey='timeCName'
+                                     wrapperStyle = {wrapperStyle}
+                                     placeholder = 'mjd'
+                                     initialState= {{
+                                          tooltip: 'Enter the name of the time column',
+                                          label : 'Time Column Name:',
+                                          labelWidth : 120
+                                      }} />
+                    <ValidationField fieldKey='fluxCName'
+                                     wrapperStyle = {wrapperStyle}
+                                     placeholder = 'w1mpro_ep'
+                                     initialState= {{
+                                          tooltip: 'Enter the name of the flux column',
+                                          label : 'Flux Column Name:',
+                                          labelWidth : 120
+                                      }} />
 
                 </FieldGroup>
             </FormPanel>
@@ -216,37 +206,22 @@ UploadPanel.defaultProps = {
     name: 'LCUpload'
 };
 
-const plotConfig = {
-    periodogram: {x: 'Period', y: 'Power'},
-    peaks: {x: 'Power', y: 'Peak'}
-}
-
 function onSearchSubmit(request) {
-    var treq, xyPlotParams;
-    const {periodogram, peaks} = plotConfig;
-    if ( get(request, RAW_TABLE) ){
-        treq = TblUtil.makeFileRequest('Raw Table', request[RAW_TABLE], null, {tbl_id:RAW_TABLE});
-        treq.tblType='notACatalog';
-        xyPlotParams = {x: {columnOrExpr: 'mjd'}, y: {columnOrExpr: 'w1mpro_ep', options:'grid,flip'}};
-    } else if ( get(request, PHASE_FOLDED) ) {
-        treq = TblUtil.makeFileRequest('Phase Folded', request[PHASE_FOLDED], null, {tbl_id:PHASE_FOLDED});
-        treq.tblType='notACatalog';
-        xyPlotParams = {x: {columnOrExpr: 'phase'}, y: {columnOrExpr: 'w1mpro_ep',  options:'grid,flip'}};
-    } else if ( get(request, PERIODOGRAM) ) {
-        treq = TblUtil.makeFileRequest('Periodogram', request[PERIODOGRAM], null, {tbl_id:PERIODOGRAM});
-        treq.tblType='notACatalog';
-        xyPlotParams = {x: {columnOrExpr: periodogram.x.name, options: 'log'}, y: {columnOrExpr: periodogram.y.name}};
-    } else if ( get(request, PEAK_TABLE) ) {
-        treq = TblUtil.makeFileRequest('Peak Table', request[PEAK_TABLE], null, {tbl_id:PEAK_TABLE});
-        treq.tblType='notACatalog';
-        xyPlotParams = {x: {columnOrExpr: peaks.x.name, options: 'log'}, y: {columnOrExpr: peaks.y.name}};
-    }
-    if (treq !== null) {
+    if ( request.rawTblSource ){
+        const {timeCName= LC.DEF_TIME_CNAME, fluxCName= LC.DEF_FLUX_CNAME} = request;
+        const options = {
+            tbl_id: LC.RAW_TABLE,
+            tblType: 'notACatalog',
+            sortInfo: sortInfoString(timeCName),
+            META_INFO: {timeCName, fluxCName}
+        };
+        const treq = TblUtil.makeFileRequest('Raw Table', request.rawTblSource, null, options);
         dispatchTableSearch(treq, {removable: false});
-        dispatchHideDropDown();
-        dispatchInitFieldGroup('LC_FORM');
-    }
-    if (xyPlotParams) {
+
+        const xyPlotParams = {x: {columnOrExpr: timeCName}, y: {columnOrExpr: fluxCName, options:'grid,flip'}};
         loadXYPlot({chartId:treq.tbl_id, tblId:treq.tbl_id, xyPlotParams});
-    }
+
+        dispatchHideDropDown();
+        dispatchInitFieldGroup('LC_UPLOAD_FORM');
+    } 
 }


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-7966 

- set default sorting on raw, phase, and peak tables
 also:
 - allow for raw table upload only, but added option to specify time and flux column
 - code cleanup
 - fix table index out-of-bound when navigate via arrow keys
 - change popup phase folded values from 3 decimal places to 8 to match the server-side version

Use /firefly/lc.html to test.