### PR TITLE
DM-8310: search Target match

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -35,9 +35,18 @@
     <a href='../../firefly/;a=ImagePlotCntlr.PlotImage?wpRequest={%20%22File%22:%20%22http://ned.ipac.caltech.edu/img/1988MNRAS.230..345N/ARP_220:I:6cm:n1988.fits.gz%22,%20%22URL%22:%20%22http://ned.ipac.caltech.edu/img/1988MNRAS.230..345N/ARP_220:I:6cm:n1988.fits.gz%22,%20%22RangeValues%22:%20%2292,-2,92,8,1,0,1,2,44,25,600,120%22,%20%22PostTitle%22:%20%22ARP%20220%22,%20%22TitleFilenameModePfx%22:%20%22cutout%22,%20%22ColorTable%22:%201,%20%22TitleOptions%22:%20%22FILE_NAME%22,%20%22Type%22:%20%22TRY_FILE_THEN_URL%22%20}'>Show Fits by URL</a>
 </div>
 <div>
+    <a href="javascript:loadMoving()">load Moving Images</a>
+</div>
+<div>
+    <a href="javascript:loadMovingTable()">load Moving Table</a>
+</div>
+<div>
     <div id="imageViewHere" style="display: inline-block; width: 550px; height: 550px; margin: 10px;"></div>
     <div id="coverageHere" style="display: inline-block; width: 400px; height: 400px; margin: 10px;"></div>
 </div>
+<!--<div>-->
+    <!--<div id="movingDiv" style="display: inline-block; width: 400px; height: 400px; margin: 10px;"></div>-->
+<!--</div>-->
 <div>Tables from API calls:
     <a href='javascript:firefly.getViewer().showTable(tblReq3)'>Open a table</a>
     <a href='javascript:firefly.getViewer().showTable(tblReq1)'>Open allwise</a>
@@ -102,6 +111,74 @@
         <textarea id='selectRegionContent' style='width: 800px; height: 300px; margin: 10px;'></textarea>
     </div>
 </div>
+
+<script type="text/javascript">
+    {
+        function loadMoving() {
+            var m49025b_143_2= {
+                url: 'http://web.ipac.caltech.edu/staff/roby/demo/moving/49025b143-w2-int-1b.fits',
+                plotId: 'm49025b_143_2',
+                OverlayPosition : '330.347003;-2.774482;EQ_J2000',
+                ZoomType : 'TO_WIDTH_HEIGHT',
+                Title: '49025b143-w2',
+                plotGroupId : 'movingGroup',
+            };
+            var m49273b_134_2= {
+                url: 'http://web.ipac.caltech.edu/staff/roby/demo/moving/49273b134-w2-int-1b.fits',
+                plotId: 'm49273b_134_2',
+                OverlayPosition : '333.539702;-0.779310;EQ_J2000',
+                ZoomType : 'TO_WIDTH_HEIGHT',
+                Title: '49273b134-w2',
+                plotGroupId : 'movingGroup',
+            };
+            var m49277b_135_1= {
+                url: 'http://web.ipac.caltech.edu/staff/roby/demo/moving/49277b135-w1-int-1b.fits',
+                plotId: 'm49277b_135_1',
+                OverlayPosition : '333.589054;-0.747251;EQ_J2000',
+                ZoomType : 'TO_WIDTH_HEIGHT',
+                Title: '49277b135-w1',
+                plotGroupId : 'movingGroup',
+            };
+            var m49289b_134_2= {
+                url: 'http://web.ipac.caltech.edu/staff/roby/demo/moving/49289b134-w2-int-1b.fits',
+                plotId: 'm49289b_134_2',
+                OverlayPosition : '333.736578;-0.651222;EQ_J2000',
+                ZoomType : 'TO_WIDTH_HEIGHT',
+                Title: '49289b134-w2',
+                plotGroupId : 'movingGroup',
+            };
+
+//            firefly.showImage('movingDiv', m49025b_143_2);
+//            firefly.showImage('movingDiv', m49273b_134_2);
+//            firefly.showImage('movingDiv', m49277b_135_1);
+//            firefly.showImage('movingDiv', m49289b_134_2);
+
+            firefly.getViewer().showImage( m49025b_143_2);
+            firefly.getViewer().showImage( m49273b_134_2);
+            firefly.getViewer().showImage( m49277b_135_1);
+            firefly.getViewer().showImage( m49289b_134_2);
+        }
+    }
+</script>
+
+<script type="text/javascript">
+    {
+        function loadMovingTable() {
+            var req = firefly.util.table.makeFileRequest('A moving object table',
+                    'http://web.ipac.caltech.edu/staff/roby/demo/moving/MOST_results-sample.tbl',null,
+                    { pageSize: 15,
+                        META_INFO: {
+                            datasetInfoConverterId : 'SimpleMoving',
+                            MovingObjCoordColumns: 'ra_obj;dec_obj;EQ_J2000',
+                            urlColumn : 'image_url'
+                        }
+                    });
+            firefly.getViewer().showTable( req, {removable: true, showUnits: false, showFilters: true});
+        }
+    }
+</script>
+
+
 
 
 <script type="text/javascript">

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
@@ -26,6 +26,7 @@ public class MetaConst {
 
     public final static String CATALOG_TARGET_COL_NAME = "CatalogTargetColName";
     public final static String CATALOG_COORD_COLS = "CatalogCoordColumns";
+    public final static String MOVING_COORD_COLS = "MovingObjCoordColumns";
     public final static String DATASET_CONVERTER = "datasetInfoConverterId";
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -289,7 +289,7 @@ public class ImagePlotCreator {
                 if (retval>zoomChoice.getMaxZoomLevel()) retval=zoomChoice.getMaxZoomLevel();
             }
         }
-        else if (zoomChoice.getZoomType()== ZoomType.FULL_SCREEN) {
+        else if (zoomChoice.getZoomType()== ZoomType.FULL_SCREEN || zoomChoice.getZoomType()== ZoomType.TO_WIDTH_HEIGHT) {
             retval= VisUtil.getEstimatedFullZoomFactor(VisUtil.FullType.WIDTH_HEIGHT,width, height,
                                                        zoomChoice.getWidth(), zoomChoice.getHeight());
             if (zoomChoice.hasMaxZoomLevel()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/ZoomType.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/ZoomType.java
@@ -18,6 +18,7 @@ public enum ZoomType {
                       SMART,         // use smart zoom - this is deprecated, don't use anymore
                       FULL_SCREEN,       // requires width & height specified
                       TO_WIDTH,          // requires width
+                      TO_WIDTH_HEIGHT,   // requires width
                       TO_HEIGHT,         // requires height, not yet implemented
                       ARCSEC_PER_SCREEN_PIX // arcsec
                       }

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -175,7 +175,7 @@ var collapsedLogging= [
     ExternalAccessCntlr.EXTENSION_ACTIVATE
 ];
 
-window.enableFireflyReduxLogging= true;
+window.enableFireflyReduxLogging= false;
 
 
 /**
@@ -184,7 +184,7 @@ window.enableFireflyReduxLogging= true;
  * @param action
  * @return {boolean}
  */
-function logFilter(getState,action) { 
+function logFilter(getState,action) {
     const {type}= action;
     if (!type) return false;
     if (type.startsWith('VisMouseCntlr')) return false;
@@ -195,8 +195,12 @@ function logFilter(getState,action) {
     if (type.startsWith('tblstats')) return false;
     if (type.startsWith('table_ui')) return false;
     if (type.startsWith('app_data')) return false;
-    return true;
+    return window.enableFireflyReduxLogging;;
 }
+
+// function logFilter(getState,action) {
+//     return window.enableFireflyReduxLogging;
+// }
 
 
 function collapsedFilter(getState,action) {
@@ -212,7 +216,7 @@ function createRedux() {
     // create a rootReducer from all of the registered reducers
     const rootReducer = combineReducers(reducers);
     const sagaMiddleware = createSagaMiddleware();
-    const middleWare=  applyMiddleware(thunkMiddleware, /*logger,*/ sagaMiddleware);
+    const middleWare=  applyMiddleware(thunkMiddleware, logger, sagaMiddleware); //todo: turn off action logging
     const store = createStore(rootReducer, middleWare);
     sagaMiddleware.run(masterSaga);
     return store;

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -15,6 +15,7 @@ export const MetaConst = {
     DATA_PRIMARY : 'DataPrimary',
     CATALOG_TARGET_COL_NAME : 'CatalogTargetColName',
     CATALOG_COORD_COLS : 'CatalogCoordColumns',
+    MOVING_COORD_COLS : 'MovingObjCoordColumns',
     DATASET_CONVERTER : 'datasetInfoConverterId',
     DEFAULT_COLOR : 'DEFAULT_COLOR'
 };

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -110,6 +110,7 @@ export function isMetaDataTable(tbl_id) {
     const tableMeta= get(table, 'tableMeta');
     if (!tableMeta) return false;
 
+    if (MetaConst.DATASET_CONVERTER) return true;
     if (tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] || tableMeta[MetaConst.CATALOG_COORD_COLS])  return false;
     const converter= converterFactory(table);
     return Boolean(converter);

--- a/src/firefly/js/util/SimpleMemCache.js
+++ b/src/firefly/js/util/SimpleMemCache.js
@@ -23,7 +23,7 @@ var SimpleMemCache= {
 
 
     deleteCache(name) {
-        cacheContainer[name] = undefined;
+        Reflect.defineProperty(cacheContainer,name);
     },
 
 

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -3,7 +3,6 @@
  */
 import CoordinateSys from './CoordSys.js';
 import VisUtil from './VisUtil.js';
-import SimpleMemCache from '../util/SimpleMemCache.js';
 import {makeRoughGuesser} from './ImageBoundsData.js';
 import Point, {makeImageWorkSpacePt, makeViewPortPt, makeImagePt,
                makeScreenPt, makeWorldPt, isValidPoint} from './Point.js';
@@ -54,6 +53,7 @@ export class CysConverter {
         this.zoomFactor= plot.zoomFactor;
         this.imageCoordSys= plot.imageCoordSys;
         this.inPlotRoughGuess= null;
+        this.conversionCache= plot.conversionCache;
     }
 
 
@@ -63,8 +63,8 @@ export class CysConverter {
      * @param {ImagePt} imp Image Point
      */
     putInConversionCache(wp, imp) {
-        if (SimpleMemCache.size(this.plotImageId)<MAX_CACHE_ENTRIES) {
-            SimpleMemCache.set(this.plotImageId, wp.toString(), imp);
+        if (this.conversionCache.size<MAX_CACHE_ENTRIES) {
+            this.conversionCache.set(wp.toString(), imp);
         }
     }
 
@@ -291,7 +291,7 @@ export class CysConverter {
         var checkedPt= convertToCorrect(wpt);
         if (checkedPt.type===Point.W_PT) {
             var originalWp= wpt;
-            retval= SimpleMemCache.get(this.plotImageId, checkedPt.toString() );
+            retval= this.conversionCache.get(checkedPt.toString() );
             if (!retval) {
                 if (this.imageCoordSys!==wpt.getCoordSys()) {
                     wpt= VisUtil.convert(wpt,this.imageCoordSys);
@@ -365,7 +365,7 @@ export class CysConverter {
     getViewPortCoordsOptimize(wpt, retPt) {
         var success= false;
 
-        var  imagePt= SimpleMemCache.get(this.plotImageId, wpt.toString);
+        var  imagePt= this.conversionCache.get(wpt.toString());
 
         if (!imagePt) {
             const csys= wpt.getCoordSys();
@@ -665,6 +665,4 @@ export const CCUtil = {
 
 
 export default CysConverter;
-
-
 

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -42,8 +42,8 @@ import {wcsMatchActionCreator} from './task/WcsMatchTask.js';
 /** can the 'COLLAPSE', 'GRID', 'SINGLE' */
 export const ExpandType= new Enum(['COLLAPSE', 'GRID', 'SINGLE']);
 
-/** can the 'NorthCenOnPt', 'NorthCenOnMoving', 'Standard', 'Off' */
-export const WcsMatchType= new Enum(['NorthCenOnPt', 'NorthCenOnMoving', 'StandCenOnPt', 'StandCenOnMoving', 'Standard']);
+/** can the 'Standard', 'Target' */
+export const WcsMatchType= new Enum(['Standard', 'Target']);
 
 
 
@@ -395,7 +395,7 @@ export function dispatchStretchChange({plotId, stretchData,
  * Enable / Disable WCS Match
  * @param {Object}  p
  * @param {string} p.plotId
- * @param {Enum|string} p.matchType one of 'NorthCenOnPt', 'NorthCenOnMoving', 'Standard', 'Off'
+ * @param {Enum|string} p.matchType one of 'Standard', 'Off'
  * @param {Function} p.dispatcher
  */
 export function dispatchWcsMatch({plotId, matchType, dispatcher= flux.process} ) {
@@ -486,15 +486,18 @@ export function dispatchProcessScroll({plotId,scrollPt, disableBoundCheck=false,
  * Note - function parameter is a single object
  * @param {Object}  p
  * @param {string} p.plotId
- * @param {Point} p.centerPt
+ * @param {Point} p.centerPt Point to center on
+ * @param {boolean} p.centerOnImage only used if centerPt is not defined.  If true then the centering will be
+ *                                  the center of the image.  If false, then the center point will be the
+ *                                  FIXED_TARGET attribute, if defined. Otherwise it will be the center of the image.
  * @param {Function} [p.dispatcher] only for special dispatching uses such as remote
  *
  * @public
  * @function dispatchRecenter
  * @memberof firefly.action
  */
-export function dispatchRecenter({plotId, centerPt, dispatcher= flux.process}) {
-    dispatcher({type: RECENTER, payload: {plotId, centerPt} });
+export function dispatchRecenter({plotId, centerPt, centerOnImage, dispatcher= flux.process}) {
+    dispatcher({type: RECENTER, payload: {plotId, centerPt, centerOnImage} });
 }
 
 /**
@@ -557,12 +560,13 @@ export function dispatchPlotImage({plotId,wpRequest, threeColor=isArray(wpReques
  * @param {string} p.viewerId
  * @param {Object} p.pvOptions PlotView init Options
  * @param {boolean} [p.setNewPlotAsActive] the last completed plot will be active
+ * @param {boolean} [p.holdWcsMatch= false] if wcs match is on, then modify the request to hold the wcs match
  * @param {Function} p.dispatcher only for special dispatching uses such as remote
  */
 export function dispatchPlotGroup({wpRequestAry, viewerId, pvOptions= {},
-                                   setNewPlotAsActive= true,
+                                   setNewPlotAsActive= true, holdWcsMatch= false,
                                    dispatcher= flux.process}) {
-    dispatcher( { type: PLOT_IMAGE, payload: { wpRequestAry, pvOptions, setNewPlotAsActive, viewerId} });
+    dispatcher( { type: PLOT_IMAGE, payload: { wpRequestAry, pvOptions, setNewPlotAsActive, holdWcsMatch, viewerId} });
 }
 
 

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -24,47 +24,48 @@ export const PlotAttribute= {
      * This will probably be a WebMouseReadoutHandler class
      * @see WebMouseReadoutHandler
      */
-    READOUT_ATTR:             'READOUT_ATTR',
+    READOUT_ATTR: 'READOUT_ATTR',
 
-    READOUT_ROW_PARAMS:             'READOUT_ROW_PARAMS',
+    READOUT_ROW_PARAMS: 'READOUT_ROW_PARAMS',
 
     /**
      * This will probably be a WorldPt
+     * Used to overlay a target associated with this image
      */
-    FIXED_TARGET:             'FIXED_TARGET',
+    FIXED_TARGET: 'FIXED_TARGET',
 
     /**
      * This will probably be a double with the requested size of the plot
      */
-    REQUESTED_SIZE:             'REQUESTED_SIZE',
+    REQUESTED_SIZE: 'REQUESTED_SIZE',
 
 
     /**
      * This will probably an object represent a rectangle {pt0: point,pt1: point}
      * @See ./Point.js
      */
-    SELECTION:                'SELECTION',
+    SELECTION: 'SELECTION',
 
     /**
      * This will probably an object to represent a line {pt0: point,pt1: point}
      * @See ./Point.js
      */
-    ACTIVE_DISTANCE:          'ACTIVE_DISTANCE',
+    ACTIVE_DISTANCE: 'ACTIVE_DISTANCE',
 
-    SHOW_COMPASS:          'SHOW_COMPASS',
+    SHOW_COMPASS: 'SHOW_COMPASS',
 
     /**
      * This will probably an object {pt: point}
      * @See ./Point.js
      */
-    ACTIVE_POINT:          'ACTIVE_POINT',
+    ACTIVE_POINT: 'ACTIVE_POINT',
 
 
     /**
      * This is a String describing why this plot can't be rotated.  If it is defined then
      * rotating is disabled.
      */
-    DISABLE_ROTATE_REASON:          'DISABLE_ROTATE_HINT',
+    DISABLE_ROTATE_REASON: 'DISABLE_ROTATE_HINT',
 
     /**
      * what should happen when multi-fits images are changed.  If set the zoom is set to the same level
@@ -150,7 +151,7 @@ export const PlotAttribute= {
  * @prop {number} zoomFactor - the zoom factor
  * @prop {string} title - title of the plot
  * @prop {object} webFitsData -  needs documentation
- * @prop {ImageTileData} serverImages -  object contains the image tile information (todo: needs typedef)
+ * @prop {ImageTileData} serverImages -  object contains the image tile information
  * @prop {ViewPort} viewPort -  needs documentation
  * @prop {CoordinateSys} imageCoordSys - the image coordinate system
  * @prop {Dimension} screenSize - width/height in screen pixels
@@ -224,14 +225,11 @@ export const WebPlot= {
         var plotState= PlotState.makePlotStateWithJson(wpInit.plotState);
         var zf= plotState.getZoomLevel();
 
-        var csys= CoordinateSys.parse(wpInit.imageCoordSys);
-
-
         var webPlot= {
             plotId,
             plotImageId     : plotId+'---NEEDS___INIT',
             serverImages    : wpInit.initImages,
-            imageCoordSys   : csys,
+            imageCoordSys   : CoordinateSys.parse(wpInit.imageCoordSys),
             plotState,
             projection,
             dataWidth       : wpInit.dataWidth,
@@ -245,10 +243,14 @@ export const WebPlot= {
             //=== Mutable =====================
             screenSize: {width:wpInit.dataWidth*zf, height:wpInit.dataHeight*zf},
             zoomFactor: zf,
-            // percentOpaque   : 1.0,
             alive    : true,
             attributes,
             viewPort: WebPlot.makeViewPort(0,0,0,0),
+
+                 // a note about conversionCache - the caches (using a map) calls to convert WorldPt to ImagePt
+                 // have this here breaks the redux paradigm, however it still seems to be the best place. The cache
+                 // is completely transient. If we start serializing the store there should not be much of an issue.
+            conversionCache: new Map(),
             //=== End Mutable =====================
             asOverlay
         };

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -631,20 +631,6 @@ export class WebPlotRequest extends ServerRequest {
     }
 
     /**
-     * @deprecated
-     * Check if the zoom type is a smart type, the parameter is optional. if not passed the
-     * function will look at the object for the value
-     * @param testType optional, ZoomType
-     * @return boolean, true is the type is smart
-     */
-    isSmartZoom(testType) {
-        var type= testType||this.getZoomType();
-        return (ZoomType.SMART.is(type) ||
-                ZoomType.SMART_SMALL.is(type) ||
-                ZoomType.SMART_LARGE.is(type));
-    }
-
-    /**
      *
      * @param {boolean} hasMax
      */

--- a/src/firefly/js/visualize/ZoomType.js
+++ b/src/firefly/js/visualize/ZoomType.js
@@ -10,17 +10,15 @@
 import Enum from 'enum';
 export const ZoomType= new Enum([
                       'STANDARD',       // use normal zoom, zoom to given zoom level or 1x if not specified
-                      'SMART',         // use smart zoom
-                      'SMART_SMALL',   // with smart zoom use sizing algorithm that produces larger size
-                      'SMART_LARGE',   // with smart zoom use sizing algorithm that produces smaller size
-                      'SMART_FOR_SMALL_FILE', // when smart zoom is not set, use it anyway for smaller files
-                      'FULL_SCREEN',       // requires width & height specified
+                      'FULL_SCREEN',       // requires width & height specified. deprecated, same as TO_WIDTH_HEIGHT
+                      'TO_WIDTH_HEIGHT',   // requires width & height specified
                       'TO_WIDTH',          // requires width
                       'TO_HEIGHT',         // requires height, not yet implemented
                       'ARCSEC_PER_SCREEN_PIX' // arcsec
                       ]);
 
-const whArray= [ZoomType.TO_WIDTH, ZoomType.TO_HEIGHT, ZoomType.FULL_SCREEN, ZoomType.ARCSEC_PER_SCREEN_PIX];
+const whArray= [ZoomType.TO_WIDTH, ZoomType.TO_HEIGHT, ZoomType.FULL_SCREEN,
+                ZoomType.TO_WIDTH_HEIGHT, ZoomType.ARCSEC_PER_SCREEN_PIX];
 
 /**
  * Return true if zoom type requires width and height

--- a/src/firefly/js/visualize/iv/ExpandedTools.jsx
+++ b/src/firefly/js/visualize/iv/ExpandedTools.jsx
@@ -14,6 +14,7 @@ import {showExpandedOptionsPopup} from '../ui/ExpandedOptionsPopup.jsx';
 import { dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {VisToolbar} from '../ui/VisToolbar.jsx';
 import {getMultiViewRoot, getExpandedViewerItemIds} from '../MultiViewCntlr.js';
+import {WcsMatchOptions} from '../ui/WcsMatchOptions.jsx';
 
 import './ExpandedTools.css';
 
@@ -41,9 +42,7 @@ function createOptions(expandedMode, singleAutoPlay, visRoot, plotIdAry) {
         autoPlay= (
             <div>
                 <div style={{display:'inline-block'}}>
-                    <input style={{margin: 0}}
-                           type='checkbox'
-                          checked={singleAutoPlay}
+                    <input style={{margin: 0}} type='checkbox' checked={singleAutoPlay}
                            onChange={() => dispatchExpandedAutoPlay(!singleAutoPlay) }
                     />
                 </div>
@@ -54,16 +53,7 @@ function createOptions(expandedMode, singleAutoPlay, visRoot, plotIdAry) {
 
     if (plotIdAry.length>1) {
         wcsMatch= (
-            <div>
-                <div style={{display:'inline-block'}}>
-                    <input style={{margin: 0}}
-                           type='checkbox'
-                           checked={visRoot.wcsMatchType===WcsMatchType.Standard}
-                           onChange={(ev) => wcsMatchStandard(ev.target.checked, visRoot.activePlotId) }
-                    />
-                </div>
-                <div style={tStyle}>WCS Match</div>
-            </div>
+                <WcsMatchOptions activePlotId={visRoot.activePlotId} wcsMatchType={visRoot.wcsMatchType} />
         );
     }
 
@@ -74,29 +64,6 @@ function createOptions(expandedMode, singleAutoPlay, visRoot, plotIdAry) {
             {autoPlay}
         </div>
     );
-}
-
-
-// wcsSTMatch= (
-//     <div>
-//         <div style={{display:'inline-block'}}>
-//             <input style={{margin: 0}}
-//                    type='checkbox'
-//                    checked={visRoot.wcsMatchType===WcsMatchType.NorthCenOnPt}
-//                    onChange={(ev) =>  wcsMatchNorth(ev.target.checked, visRoot.activePlotId) }
-//             />
-//         </div>
-//         <div style={tStyle}>WCS Search Target Match</div>
-//     </div>
-// );
-
-// function wcsMatchNorth(doWcsNorth, plotId) {
-//     dispatchWcsMatch({matchType:doWcsNorth?WcsMatchType.NorthCenOnPt:false, plotId});
-//     // console.log(`doWcsNorth: ${doWcsNorth}`);
-// }
-
-function wcsMatchStandard(doWcsStandard, plotId) {
-    dispatchWcsMatch({matchType:doWcsStandard?WcsMatchType.Standard:false, plotId});
 }
 
 

--- a/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
@@ -18,9 +18,11 @@ import {isImageViewerSingleLayout, getMultiViewRoot} from '../MultiViewCntlr.js'
 import {contains} from '../VisUtil.js';
 import {
     visRoot,
+    WcsMatchType,
     ActionScope,
     dispatchPlotProgressUpdate,
     dispatchZoom,
+    dispatchRecenter,
     dispatchProcessScroll,
     dispatchChangeActivePlotView,
     dispatchUpdateViewSize} from '../ImagePlotCntlr.js';
@@ -161,16 +163,12 @@ export class ImageViewerLayout extends Component {
 
     renderInside() {
         var {plotView,drawLayersAry}= this.props;
-        var {plotId,scrollX,scrollY, viewDim}= plotView;
-        var plot= primePlot(plotView);
-        const vr= visRoot();
+        const plot= primePlot(plotView);
+        const {plotId}= plotView;
+        var {width:viewPortWidth,height:viewPortHeight}= plot.viewPort.dim;
+        const {left,top,scrollViewWidth, scrollViewHeight, scrollX,scrollY, viewDim}=  getPositionInfo(plotView);
 
-        var {dim:{width:viewPortWidth,height:viewPortHeight},x:vpX,y:vpY}= plot.viewPort;
-        var {width:sw,height:sh}= plot.screenSize;
-        var scrollViewWidth= Math.min(viewPortWidth,sw);
-        var scrollViewHeight= Math.min(viewPortHeight,sh);
-        var left= vpX-scrollX; //+offPt.x;
-        var top= vpY-scrollY; //+offPt.y;
+
         var rootStyle= {left, top,
                         position:'relative',
                         width:scrollViewWidth,
@@ -178,17 +176,6 @@ export class ImageViewerLayout extends Component {
                         marginRight: 'auto',
                         marginLeft: 0
         };
-
-        if (vr.wcsMatchType) {
-            rootStyle.marginLeft = 0; // todo: could I do some sort of center computation so the active wcs was centered
-        }
-        else {
-            if (viewDim.width>plot.screenSize.width) {
-                rootStyle.marginLeft = (viewDim.width-plot.screenSize.width)/2;
-            }
-         }
-
-
 
         const drawLayersIdAry= drawLayersAry ? drawLayersAry.map( (dl) => dl.drawLayerId) : null;
 
@@ -200,7 +187,10 @@ export class ImageViewerLayout extends Component {
                 <div className='plot-view-master-panel'
                      style={{width:viewPortWidth,height:viewPortHeight,
                                  left:0,right:0,position:'absolute', cursor}}>
-                    {makeTileDrawers(plotView,viewPortWidth,viewPortHeight,scrollX,scrollY)}
+                    {makeTileDrawers(plotView,
+                                     Math.max(viewPortWidth,viewDim.width),
+                                     Math.max(viewPortHeight,viewDim.height),
+                                     scrollX,scrollY)}
                     <DrawingLayers
                         key={'DrawingLayers:'+plotId}
                         plot={plot} drawLayersIdAry={drawLayersIdAry} />
@@ -220,9 +210,12 @@ export class ImageViewerLayout extends Component {
         var {viewDim:{width,height}}= pv;
         var insideStuff;
         var plotShowing= Boolean(width && height && primePlot(this.props.plotView));
+        var onScreen= true;
 
-        if (plotShowing) {
+        if (plotShowing ) {
+            onScreen= isImageOnScreen(this.props.plotView);
             insideStuff= this.renderInside();
+
         }
 
         var style= {
@@ -235,7 +228,7 @@ export class ImageViewerLayout extends Component {
         return (
             <div className='web-plot-view-scr' style={style}>
                 {insideStuff}
-                {makeMessageArea(pv,plotShowing)}
+                {makeMessageArea(pv,plotShowing,onScreen)}
             </div>
         );
     }
@@ -253,6 +246,27 @@ ImageViewerLayout.propTypes= {
     externalHeight: PropTypes.number.isRequired
 };
 
+
+function isImageOnScreen(plotView) {
+
+    const {left,top,scrollViewWidth, scrollViewHeight, viewDim}=  getPositionInfo(plotView);
+    const visible= (left+scrollViewWidth>=0 && left<=viewDim.width && top+scrollViewHeight>=0 && top<=viewDim.height);
+    return visible;
+}
+
+
+function getPositionInfo(plotView) {
+    var plot= primePlot(plotView);
+    var {dim:{width:viewPortWidth,height:viewPortHeight},x:vpX,y:vpY}= plot.viewPort;
+    var {width:sw,height:sh}= plot.screenSize;
+    var scrollViewWidth= Math.min(viewPortWidth,sw);
+    var scrollViewHeight= Math.min(viewPortHeight,sh);
+    var {scrollX,scrollY, viewDim}= plotView;
+    var left= vpX-scrollX;
+    var top= vpY-scrollY;
+
+    return {left,top,scrollViewWidth, scrollViewHeight, scrollX,scrollY, viewDim};
+}
 
 
 // eslint-disable-next-line valid-jsdoc
@@ -323,15 +337,30 @@ function plotMover(screenX,screenY, originalScrollX, originalScrollY) {
         var newX= originalScrollX -xdiff;
         var newY= originalScrollY -ydiff;
 
-        if (newX<0) newX= 0;
-        if (newY<0) newY= 0;
+        // if (newX<0) newX= 0; //todo: reenable
+        // if (newY<0) newY= 0; //todo: reenable
 
         return makeScreenPt(newX, newY);
     };
 }
 
-function makeMessageArea(pv,plotShowing) {
-    if (pv.serverCall==='success') return false;
+function makeMessageArea(pv,plotShowing,onScreen) {
+    if (pv.serverCall==='success') {
+        if (onScreen) {
+            return false;
+        }
+        else {
+            return (
+                <ImageViewerStatus message={'Center Plot'} working={false}
+                                   useMessageAlpha={false}
+                                   useButton={true}
+                                   buttonText='Recenter'
+                                   buttonCB={() => dispatchRecenter({plotId:pv.plotId}) }
+
+                />
+            );
+        }
+    }
 
     if (pv.serverCall==='working') {
         return (
@@ -344,8 +373,9 @@ function makeMessageArea(pv,plotShowing) {
     else if (pv.plottingStatus) {
         return (
             <ImageViewerStatus message={pv.plottingStatus} working={false}
-                               useMessageAlpha={true} canClear={plotShowing}
-                               clearCB={() => dispatchPlotProgressUpdate(pv.plotId,'',true)}
+                               useMessageAlpha={true} useButton={plotShowing}
+                               buttonText='OK'
+                               buttonCB={() => dispatchPlotProgressUpdate(pv.plotId,'',true)}
                                />
         );
     }

--- a/src/firefly/js/visualize/iv/ImageViewerStatus.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerStatus.jsx
@@ -88,13 +88,13 @@ export class ImageViewerStatus extends Component {
     }
 
     render() {
-        const {message='',working,useMessageAlpha=false, canClear=false, clearCB} = this.props;
+        const {message='',working,useMessageAlpha=false, useButton=false, buttonCB, buttonText='OK'} = this.props;
         const {messageShowing, maskShowing}= this.state;
 
         var workingStatusText= useMessageAlpha ? statusTextAlpha : statusText;
-        const workingStatusTextCell= canClear ? statusTextCellWithClear : statusTextCell;
+        const workingStatusTextCell= useButton ? statusTextCellWithClear : statusTextCell;
 
-        if (!working && !canClear) workingStatusText= omit(workingStatusText,'zIndex');
+        if (!working && !useButton) workingStatusText= omit(workingStatusText,'zIndex');
 
         return (
             <div style={statusContainer}>
@@ -106,7 +106,8 @@ export class ImageViewerStatus extends Component {
                 { messageShowing &&
                      <div style={workingStatusText} >
                          <div style={workingStatusTextCell}>{message}</div>
-                         { canClear && <CompleteButton style={{flex: '2 2 auto'}} onSuccess={clearCB}/> }
+                         { useButton && <CompleteButton text= {buttonText}
+                                                        style={{flex: '2 2 auto'}} onSuccess={buttonCB}/> }
                      </div>
                 }
             </div>
@@ -120,6 +121,7 @@ ImageViewerStatus.propTypes= {
     messageWaitTimeMS : PropTypes.number,
     maskWaitTimeMS : PropTypes.number,
     useMessageAlpha : PropTypes.bool,
-    canClear : PropTypes.bool,
-    clearCB : PropTypes.func
+    useButton : PropTypes.bool,
+    buttonCB : PropTypes.func,
+    buttonText : PropTypes.string
 };

--- a/src/firefly/js/visualize/reducer/OverlayPlotView.js
+++ b/src/firefly/js/visualize/reducer/OverlayPlotView.js
@@ -3,7 +3,6 @@
  */
 
 import {clone} from '../../util/WebUtil.js'
-import SimpleMemCache from '../../util/SimpleMemCache.js';
 
 /**
  * @typedef {Object} OverlayPlotView
@@ -58,8 +57,6 @@ export function makeOverlayPlotView(imageOverlayId, plotId, title, imageNumber, 
 export function replaceOverlayPlots(opv, plot) {
 
     opv= clone(opv, {plot});
-    SimpleMemCache.clearCache(plot.plotImageId);
-    SimpleMemCache.clearCache(plot.plotImageId);
     plot.plotImageId= `${opv.imageOverlayId}--${opv.plotCounter}`;
     opv.plotCounter++;
 

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -10,7 +10,7 @@
 
 import update from 'react-addons-update';
 import {WebPlot, PlotAttribute} from './../WebPlot.js';
-import {get, isString} from 'lodash';
+import {get, isString, isUndefined} from 'lodash';
 import {clone} from '../../util/WebUtil.js';
 import {WPConst} from './../WebPlotRequest.js';
 import {RotateType} from './../PlotState.js';
@@ -24,7 +24,7 @@ import {DEFAULT_THUMBNAIL_SIZE} from '../WebPlotRequest.js';
 import SimpleMemCache from '../../util/SimpleMemCache.js';
 import {CCUtil, CysConverter} from './../CsysConverter.js';
 import {getDefMenuItemKeys} from '../MenuItemKeys.js';
-import {ExpandType} from '../ImagePlotCntlr.js';
+import {ExpandType, WcsMatchType} from '../ImagePlotCntlr.js';
 
 const DEF_WORKING_MSG= 'Plotting ';
 
@@ -116,7 +116,7 @@ export function makePlotView(plotId, req, pvOptions= {}) {
         scrollY : -1,
         viewDim : {width:0, height:0}, // size of viewable area  (div size: offsetWidth & offsetHeight)
         overlayPlotViews: [],
-        menuItemKeys: makeMenuItemKeys(req,pvOptions,getDefMenuItemKeys()), // normally wil not change
+        menuItemKeys: makeMenuItemKeys(req,pvOptions,getDefMenuItemKeys()), // normally will not change
         plotViewCtx: createPlotViewContextData(req, pvOptions),
 
 
@@ -212,14 +212,6 @@ function replacePlots(pv, plotAry, overlayPlotViews, expandedMode, keepPrimeIdx=
     pv= clone(pv);
     pv.plotViewCtx= clone(pv.plotViewCtx);
 
-    if (pv.plots && pv.plots.length) {
-        pv.plots.forEach( (plot) => {
-            SimpleMemCache.clearCache(plot.plotImageId);
-            // todo- clean up before resetting the array - go through old array call server to delete plot
-            //todo -- somewhere need to call the server with a delete plot - probably needs to be an action or side effect
-        });
-    }
-
 
     if (overlayPlotViews) {
         const oPlotAry= overlayPlotViews.map( (opv) => opv.plot);
@@ -281,7 +273,7 @@ export function updatePlotViewScrollXY(plotView,newScrollPt, useBoundChecking= t
     newScrollPt= cc.getScreenCoords(newScrollPt);
     var {x:newSx,y:newSy}= newScrollPt;
 
-    if (useBoundChecking) {
+    if (useBoundChecking && false) { // todo: reenable
         newSx= checkBounds(newSx,plot.screenSize.width,scrollWidth);
         newSy= checkBounds(newSy,plot.screenSize.height,scrollHeight);
     }
@@ -331,7 +323,7 @@ export function replacePrimaryPlot(plotView,primePlot) {
  * @param {boolean} useBoundChecking
  * @return {Array}
  */
-function updatePlotGroupScrollXY(visRoot, plotId,plotViewAry, plotGroupAry, newScrollPt, useBoundChecking=true) {
+export function updatePlotGroupScrollXY(visRoot, plotId,plotViewAry, plotGroupAry, newScrollPt, useBoundChecking=true) {
     var plotView= updatePlotViewScrollXY(getPlotViewById(plotViewAry, plotId), newScrollPt, useBoundChecking);
     plotViewAry= replacePlotView(plotViewAry, plotView);
     var plotGroup= findPlotGroup(plotView.plotGroupId,plotGroupAry);
@@ -353,15 +345,34 @@ export function findWCSMatchOffset(vr, masterPlotOrId, matchPlotOrToId) {
 
     const masterP=  isString(masterPlotOrId) ? primePlot(vr, masterPlotOrId) : masterPlotOrId;
     const matchToP = isString(matchPlotOrToId) ? primePlot(vr, matchPlotOrToId) : matchPlotOrToId;
-
     if (!masterP || !matchToP) return makeScreenPt(0,0);
     if (masterP.plotId===matchToP.plotId) return makeScreenPt(0,0);
 
-    const masterPt = CCUtil.getScreenCoords(masterP, vr.wcsMatchCenterWP);
-    const matchToPt = CCUtil.getScreenCoords(matchToP, vr.wcsMatchCenterWP);
+    if (vr.wcsMatchType===WcsMatchType.Standard) {
 
-    return (matchToPt && masterPt) ? makeScreenPt(masterPt.x - matchToPt.x, masterPt.y - matchToPt.y) :
-                                     makeScreenPt(-matchToP.screenSize.width,-matchToP.screenSize.width);
+        const masterPt = CCUtil.getScreenCoords(masterP, vr.wcsMatchCenterWP);
+        const matchToPt = CCUtil.getScreenCoords(matchToP, vr.wcsMatchCenterWP);
+
+        return (matchToPt && masterPt) ?
+                    makeScreenPt(masterPt.x - matchToPt.x, masterPt.y - matchToPt.y) :
+                    makeScreenPt(-matchToP.screenSize.width,-matchToP.screenSize.width);
+    }
+    else if (vr.wcsMatchType===WcsMatchType.Target) {
+
+        if (!matchToP.attributes[PlotAttribute.FIXED_TARGET] || !masterP.attributes[PlotAttribute.FIXED_TARGET] ) {
+            return makeScreenPt(0,0);
+        }
+
+        const matchToFT= CCUtil.getScreenCoords(matchToP,matchToP.attributes[PlotAttribute.FIXED_TARGET]);
+        const masterFT= CCUtil.getScreenCoords(masterP,masterP.attributes[PlotAttribute.FIXED_TARGET]);
+
+        const offsetPt= makeScreenPt(masterFT.x-matchToFT.x, masterFT.y-matchToFT.y);
+        return offsetPt;
+    }
+    else {
+        return makeScreenPt(0,0);
+    }
+
 }
 
 
@@ -392,7 +403,12 @@ function makeScrollPosMatcher(sourcePV, visRoot, useBoundsChecking) {
         var retPV= pv;
         var plot= primePlot(pv);
         if (plot) {
-            if (visRoot.wcsMatchType) {
+            if (visRoot.wcsMatchType===WcsMatchType.Standard) {
+                const offPt = findWCSMatchOffset(visRoot, sourcePV.plotId, plot.plotId);
+                retPV= updatePlotViewScrollXY(pv,makeScreenPt(srcSx-offPt.x,srcSy-offPt.y), false);
+            }
+            else if (visRoot.wcsMatchType===WcsMatchType.Target) {
+                // TODO: need compute offset of the active target from the center and match it
                 const offPt = findWCSMatchOffset(visRoot, sourcePV.plotId, plot.plotId);
                 retPV= updatePlotViewScrollXY(pv,makeScreenPt(srcSx-offPt.x,srcSy-offPt.y), false);
             }
@@ -488,12 +504,13 @@ function findCurrentCenterPoint(plotView,scrollX,scrollY) {
     var plot= primePlot(plotView);
     if (!plot) return null;
     var {scrollWidth,scrollHeight}= getScrollSize(plotView);
-    var sx= (typeof scrollX !== 'undefined') ? scrollX : plotView.scrollX;
-    var sy= (typeof scrollY !== 'undefined') ? scrollY : plotView.scrollY;
+    var {viewDim}= plotView;
+    var sx= (isUndefined(scrollX)) ? plotView.scrollX : scrollX;
+    var sy= (isUndefined(scrollY)) ? plotView.scrollY : scrollY ;
 
     var {width:screenW, height:screenH}= plot.screenSize;
-    var cX=  (screenW<scrollWidth) ? screenW/2 : sx+scrollWidth/2;
-    var cY= (screenH<scrollHeight) ? screenH/2 : sy+scrollHeight/2;
+    var cX=  (screenW<viewDim.width) ? screenW/2 : sx+scrollWidth/2;
+    var cY= (screenH<viewDim.height) ? screenH/2 : sy+scrollHeight/2;
     var pt= makeScreenPt(cX,cY);
     return CCUtil.getImageCoords(plot,pt);
 }
@@ -612,8 +629,10 @@ function checkBounds(pos,screenSize,scrollSize) {
 function findScrollPtForCenter(plotView) {
     var {width,height}= plotView.viewDim;
     var {width:scrW,height:scrH}= primePlot(plotView).screenSize;
-    var x= (scrW>width) ? scrW/2- width/2 : 0;
-    var y= (scrH>height) ? scrH/2- height/2 : 0;
+    // var x= (scrW>width) ? scrW/2- width/2 : (width-scrW)/2;
+    // var y= (scrH>height) ? scrH/2- height/2 : (height/scrH)/2;
+    var x= scrW/2- width/2;
+    var y= scrH/2- height/2;
     return makeScreenPt(x,y);
 }
 
@@ -630,7 +649,23 @@ function findScrollPtForImagePt(plotView, ipt, useBoundChecking= true) {
     var center= CCUtil.getScreenCoords(plot, ipt);
     var x= center.x- Math.min(width,scrW)/2;
     var y= center.y- Math.min(height,scrH)/2;
-    if (useBoundChecking) {
+
+    if (scrW>width) {
+        x= center.x - width/2;
+    }
+    else {
+        x=  center.x - width/2;
+    }
+
+    if (scrH>height) {
+        y= center.y - height/2;
+    }
+    else {
+        y=  center.y - height/2;
+    }
+
+
+    if (useBoundChecking && false) { // todo: reenable
         x= checkBounds(x,scrW,width);
         y= checkBounds(y,scrH,height);
     }

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -408,7 +408,6 @@ function makeScrollPosMatcher(sourcePV, visRoot, useBoundsChecking) {
                 retPV= updatePlotViewScrollXY(pv,makeScreenPt(srcSx-offPt.x,srcSy-offPt.y), false);
             }
             else if (visRoot.wcsMatchType===WcsMatchType.Target) {
-                // TODO: need compute offset of the active target from the center and match it
                 const offPt = findWCSMatchOffset(visRoot, sourcePV.plotId, plot.plotId);
                 retPV= updatePlotViewScrollXY(pv,makeScreenPt(srcSx-offPt.x,srcSy-offPt.y), false);
             }

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -63,7 +63,7 @@ export function* watchCatalogs() {
                 break;
 
             case ImagePlotCntlr.PLOT_IMAGE:
-                attachToAllCatalogs(action.payload.plotId);
+                attachToAllCatalogs(action.payload.pvNewPlotInfoAry);
                 break;
         }
     }
@@ -162,10 +162,10 @@ function updateDrawingLayer(tbl_id, title, tableData, tableMeta, tableRequest,
 }
 
 
-function attachToAllCatalogs(plotId) {
+function attachToAllCatalogs(pvNewPlotInfoAry) {
     dlRoot().drawLayerAry.forEach( (dl) => {
         if (dl.drawLayerTypeId===Catalog.TYPE_ID && dl.catalog) {
-            dispatchAttachLayerToPlot(dl.drawLayerId, plotId);
+            pvNewPlotInfoAry.forEach( (info) => dispatchAttachLayerToPlot(dl.drawLayerId, info.plotId));
         }
     });
 }

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -130,6 +130,10 @@ function makePlotImageAction(rawAction) {
                 useContextModifications:true,
                 groupLocked:true
             };
+            if (vr.wcsMatchType && vr.mpwWcsPrimId && rawAction.payload.holdWcsMatch) {
+                const wcsPrim= getPlotViewById(vr,vr.mpwWcsPrimId);
+                payload.wpRequestAry= payload.wpRequestAry.map( (wpr) => modifyRequestForWcsMatch(wcsPrim, wpr));
+            }
         }
 
         if (firstTime) {

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
@@ -25,7 +25,8 @@ export class ImageMetaDataToolbar extends Component {
         var update= !shallowequal(omit(props,om), omit(np,om)) || !shallowequal(ns,state);
         if (update) return true;
 
-        return (np.layoutType===SINGLE && props.visRoot.activePlotId!==np.visRoot.activePlotId);
+        return ((np.layoutType===SINGLE && props.visRoot.activePlotId!==np.visRoot.activePlotId) ||
+                props.visRoot.wcsMatchType!==np.visRoot.wcsMatchType);
     }
 
 
@@ -54,6 +55,7 @@ export class ImageMetaDataToolbar extends Component {
         const {visRoot, viewerId, viewerPlotIds, layoutType, dlAry, tableId}= this.props;
         return (
             <ImageMetaDataToolbarView activePlotId={visRoot.activePlotId} viewerId={viewerId}
+                                      wcsMatchType={visRoot.wcsMatchType}
                                       viewerPlotIds={viewerPlotIds} layoutType={layoutType} dlAry={dlAry}
                                       activeTable={activeTable} converterFactory={converterFactory}
                                         /> 

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
@@ -12,6 +12,7 @@ import {dispatchChangeViewerLayout, getViewer, getMultiViewRoot,
         GRID, GRID_FULL, GRID_RELATED, SINGLE} from '../MultiViewCntlr.js';
 import {showColorBandChooserPopup} from './ColorBandChooserPopup.jsx';
 import {ImagePager} from './ImagePager.jsx';
+import {WcsMatchOptions} from './WcsMatchOptions.jsx';
 
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
 import ONE from 'html/images/icons-2014/Images-One.png';
@@ -34,12 +35,13 @@ const toolsStyle= {
 };
 
 
-
-export function ImageMetaDataToolbarView({activePlotId, viewerId, viewerPlotIds, layoutType, dlAry,
+export function ImageMetaDataToolbarView({activePlotId, viewerId, viewerPlotIds, layoutType, dlAry, wcsMatchType,
                                           activeTable, converterFactory, handleInlineTools=true }) {
 
     const {dataId,converter}= converterFactory(activeTable) || {};
-    if (!converter) return <div/>;
+    if (!converter) {
+        return <div/>;
+    }
     var nextIdx, prevIdx, leftImageStyle;
     const viewer= getViewer(getMultiViewRoot(), viewerId);
     const vr= visRoot();
@@ -62,6 +64,7 @@ export function ImageMetaDataToolbarView({activePlotId, viewerId, viewerPlotIds,
     }
     const showThreeColorButton= converter.threeColor && viewer.layout===GRID && viewer.layoutDetail!==GRID_FULL;
     const showPager= activeTable && viewer.layoutDetail===GRID_FULL;
+
 
 
     return (
@@ -98,7 +101,8 @@ export function ImageMetaDataToolbarView({activePlotId, viewerId, viewerPlotIds,
                                  onClick={() => dispatchChangeActivePlotView(viewerPlotIds[nextIdx])} />
                 }
             </div>
-            {showPager && <ImagePager pageSize={10} tbl_id={activeTable.tbl_id} />}
+            <WcsMatchOptions activePlotId={activePlotId} wcsMatchType={wcsMatchType} />
+            {showPager && <ImagePager pageSize={converter.maxPlots} tbl_id={activeTable.tbl_id} />}
             {handleInlineTools && <InlineRightToolbarWrapper visRoot={vr} pv={pv} dlAry={pvDlAry} />}
         </div>
     );

--- a/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
+++ b/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
@@ -5,10 +5,10 @@
 
 import React, {PropTypes} from 'react';
 import {dispatchChangeViewerLayout} from '../MultiViewCntlr.js';
-import {dispatchChangeActivePlotView, WcsMatchType, dispatchWcsMatch} from '../ImagePlotCntlr.js';
+import {dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {VisInlineToolbarView} from './VisInlineToolbarView.jsx';
 import {getPlotViewById, getAllDrawLayersForPlot} from '../PlotViewUtil.js';
-import {getDlAry} from '../DrawLayerCntlr.js';
+import {WcsMatchOptions} from './WcsMatchOptions.jsx';
 
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
 import BrowserInfo from '../../util/BrowserInfo.js';
@@ -30,13 +30,6 @@ const toolsStyle= {
     justifyContent: 'space-between'
 };
 
-const tStyle= {
-    display:'inline-block',
-    whiteSpace: 'nowrap',
-    minWidth: '3em',
-    paddingLeft : 5
-};
-
 
 export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, layoutType= 'grid', dlAry, handleInlineTools=true }) {
     
@@ -47,7 +40,7 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, layo
     if (cIdx<0) cIdx= 0;
 
     if (viewerPlotIds.length===1) {
-        return <div></div>;
+        return <div/>;
     }
 
     // single mode stuff
@@ -77,16 +70,7 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, layo
 
     if (viewerPlotIds.length>1) {
         wcsMatch= (
-            <div style={{alignSelf:'center', paddingLeft:25}}>
-                <div style={{display:'inline-block'}}>
-                    <input style={{margin: 0}}
-                           type='checkbox'
-                           checked={visRoot.wcsMatchType===WcsMatchType.Standard}
-                           onChange={(ev) => wcsMatchStandard(ev.target.checked, visRoot.activePlotId) }
-                    />
-                </div>
-                <div style={tStyle}>WCS Match</div>
-            </div>
+            <WcsMatchOptions activePlotId={visRoot.activePlotId} wcsMatchType={visRoot.wcsMatchType} />
         );
     }
 
@@ -119,10 +103,6 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, layo
             {handleInlineTools && makeInlineRightToolbar(visRoot,pv,pvDlAry)}
         </div>
     );
-}
-
-function wcsMatchStandard(doWcsStandard, plotId) {
-    dispatchWcsMatch({matchType:doWcsStandard?WcsMatchType.Standard:false, plotId});
 }
 
 function makeInlineRightToolbar(visRoot,pv,dlAry){

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -171,13 +171,14 @@ function getThumbZoomFact(plot, thumbW, thumbH) {
 function getScrollBoxInfo(pv, thumbW, thumbH) {
     var plot= primePlot(pv);
     var fact= getThumbZoomFact(plot,thumbW,thumbH)/ plot.zoomFactor;
-    var ss= getScrollSize(pv);
+    const {viewDim}= pv;
+    // var ss= getScrollSize(pv);
 
     return {
         tsX: (pv.scrollX)*fact,
         tsY: (pv.scrollY)*fact,
-        tsWidth: ss.scrollWidth*fact,
-        tsHeight: ss.scrollHeight*fact
+        tsWidth: viewDim.width*fact,
+        tsHeight: viewDim.height*fact
     };
 
 }

--- a/src/firefly/js/visualize/ui/WcsMatchOptions.jsx
+++ b/src/firefly/js/visualize/ui/WcsMatchOptions.jsx
@@ -1,0 +1,55 @@
+
+import React, {PropTypes}  from 'react';
+import {WcsMatchType, dispatchWcsMatch} from '../ImagePlotCntlr.js';
+
+
+const tStyle= {
+    display:'inline-block',
+    whiteSpace: 'nowrap',
+    minWidth: '3em',
+    paddingLeft : 5
+};
+
+export function WcsMatchOptions({wcsMatchType, activePlotId}) {
+
+    return (
+        <div style={{alignSelf:'center', paddingLeft:25}}>
+            <div>
+                <div style={{display:'inline-block'}}>
+                    <input style={{margin: 0}}
+                           type='checkbox'
+                           checked={wcsMatchType===WcsMatchType.Standard}
+                           onChange={(ev) => wcsMatchStandard(ev.target.checked, activePlotId) }
+                    />
+                </div>
+                <div style={tStyle}>WCS Match</div>
+            </div>
+
+            <div>
+                <div style={{display:'inline-block'}}>
+                    <input style={{margin: 0}}
+                           type='checkbox'
+                           checked={wcsMatchType===WcsMatchType.Target}
+                           onChange={(ev) => wcsMatchTarget(ev.target.checked, activePlotId) }
+                    />
+                </div>
+                <div style={tStyle}>Target Match</div>
+            </div>
+        </div>
+
+    );
+}
+
+WcsMatchOptions.propTypes= {
+    wcsMatchType : PropTypes.any,
+    activePlotId: PropTypes.string,
+};
+
+function wcsMatchStandard(doWcsStandard, plotId) {
+    dispatchWcsMatch({matchType:doWcsStandard?WcsMatchType.Standard:false, plotId});
+}
+
+
+function wcsMatchTarget(doWcsTarget, plotId) {
+    dispatchWcsMatch({matchType:doWcsTarget?WcsMatchType.Target:false, plotId});
+}


### PR DESCRIPTION
Search Target match includes:
    - search target match will show search target in center
    - now more scroll bounds checking.  Can put the image anywhere
    - redoing scrolling
    - recenter feature
    - wcs match now puts images in center
    - can load a table of moving objects
    - found bugs in coordinate conversion caching, cache object moved to WebPlot

To Test:

1. *To Test a set of images with moving tagets defined*
    - use ffapi-highlevel-test.html, 
    - click on `load Moving Images`
    - look for the new tab
    - click on `search target match`

1. *To Test loading a moving target table*
   - use ffapi-highlevel-test.html
   - click on `load Moving Table`
   - look for the new tab
   - click on `search target match`


