### PR TITLE
DM-3612 scatter plot errorbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-addons-perf" : "15.3.1",
     "react-component-resizable": "1.0.1",
     "react-grid-layout": "0.13.3",
-    "react-highcharts": "10.0.0",
+    "react-highcharts": "11.0.0",
     "react-split-pane": "0.1.44",
     "redux": "3.5.2",
     "redux-thunk": "2.1.0",

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchRequestUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchRequestUtils.java
@@ -1,0 +1,56 @@
+/**
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.packagedata.FileInfo;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupReader;
+import edu.caltech.ipac.util.DataGroup;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * We have a few search processors, which are accepting the search request as a parameter
+ * This class contains the shared code
+ * @author tatianag
+ */
+public class SearchRequestUtils {
+
+    /**
+     * Get data group created by the search request
+     * @param searchRequestJson search request in JSON format
+     * @return DataGroup data group
+     * @throws IOException
+     * @throws DataAccessException
+     */
+    static DataGroup dataGroupFromSearchRequest(String searchRequestJson) throws IOException, DataAccessException {
+        if (searchRequestJson == null) {
+            throw new DataAccessException("Missing search request");
+        }
+        JSONObject searchRequestJSON = (JSONObject) JSONValue.parse(searchRequestJson);
+        String searchId = (String) searchRequestJSON.get(ServerParams.ID);
+        if (searchId == null) {
+            throw new DataAccessException("Search request must contain " + ServerParams.ID);
+        }
+        TableServerRequest sReq = QueryUtil.convertToServerRequest(searchRequestJson);
+
+        FileInfo fi = new SearchManager().getFileInfo(sReq);
+        if (fi == null) {
+            throw new DataAccessException("Unable to get file location info");
+        }
+        if (fi.getInternalFilename() == null) {
+            throw new DataAccessException("File not available");
+        }
+        if (!fi.hasAccess()) {
+            throw new SecurityException("Access is not permitted.");
+        }
+
+       return DataGroupReader.readAnyFormat(new File(fi.getInternalFilename()));
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
@@ -1,0 +1,192 @@
+/**
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupWriter;
+import edu.caltech.ipac.util.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+
+
+/**
+ * @author tatianag
+ */
+@SearchProcessorImpl(id = "XYWithErrors")
+public class XYWithErrorsProcessor extends IpacTablePartProcessor {
+    private static final String SEARCH_REQUEST = "searchRequest";
+    private static final String X_COL_EXPR = "xColOrExpr";
+    private static final String Y_COL_EXPR = "yColOrExpr"    ;
+    private static final String XERR_LOW_COL_EXPR = "xErrLowColOrExpr";
+    private static final String XERR_HIGH_COL_EXPR = "xErrHighColOrExpr";
+    private static final String YERR_LOW_COL_EXPR = "yErrLowColOrExpr";
+    private static final String YERR_HIGH_COL_EXPR = "yErrHighColOrExpr";
+
+    private static final Col NO_COL = new Col();
+
+    @Override
+    protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
+        String searchRequestJson = request.getParam(SEARCH_REQUEST);
+        DataGroup dg = SearchRequestUtils.dataGroupFromSearchRequest(searchRequestJson);
+        String xColOrExpr = request.getParam(X_COL_EXPR);
+        String yColOrExpr = request.getParam(Y_COL_EXPR);
+        String xErrLowColOrExpr = request.getParam(XERR_LOW_COL_EXPR);
+        String xErrHighColOrExpr = request.getParam(XERR_HIGH_COL_EXPR);
+        String yErrLowColOrExpr = request.getParam(YERR_LOW_COL_EXPR);
+        String yErrHighColOrExpr = request.getParam(YERR_HIGH_COL_EXPR);
+
+        boolean hasXLowError = !StringUtils.isEmpty(xErrLowColOrExpr);
+        boolean hasXHighError = !StringUtils.isEmpty(xErrHighColOrExpr) ;
+        boolean hasYLowError = !StringUtils.isEmpty(yErrLowColOrExpr);
+        boolean hasYHighError = !StringUtils.isEmpty(yErrHighColOrExpr);
+        if ((hasXLowError || hasXHighError || hasYLowError || hasYHighError) && dg.size()>=QueryUtil.DECI_ENABLE_SIZE) {
+            throw new DataAccessException("Errors for more than "+QueryUtil.DECI_ENABLE_SIZE+" are not supported");
+        }
+
+        // the output table columns: rowIdx, x, y, [[left, right], [low, high]]
+        DataType[] dataTypes = dg.getDataDefinitions();
+        Col xCol = getCol(dataTypes, xColOrExpr,"x", false);
+        Col yCol = getCol(dataTypes, yColOrExpr, "y", false);
+        Col xLowCol = NO_COL;
+        Col xHighCol = NO_COL;
+        Col yLowCol = NO_COL;
+        Col yHighCol = NO_COL;
+        if (hasXLowError || hasXHighError) {
+            String xLowColOrExpr = hasXLowError ? xColOrExpr+"-"+xErrLowColOrExpr : xColOrExpr;
+            xLowCol = getCol(dataTypes, xLowColOrExpr, "left", true);
+            String xHighColOrExpr = hasXHighError ? xColOrExpr+"+"+xErrHighColOrExpr : xColOrExpr;
+            xHighCol = getCol(dataTypes, xHighColOrExpr, "right", true);
+        }
+        if (hasYLowError || hasYHighError) {
+            String yLowColOrExpr = hasYLowError ? yColOrExpr+"-"+yErrLowColOrExpr : yColOrExpr;
+            yLowCol = getCol(dataTypes, yLowColOrExpr, "low", true);
+            String yHighColOrExpr = hasYHighError ? yColOrExpr+"+"+yErrHighColOrExpr : yColOrExpr;
+            yHighCol = getCol(dataTypes, yHighColOrExpr, "high", true);
+        }
+
+        // create the array of getters, which know how to get double values
+        ArrayList<Col> colsLst = new ArrayList<>();
+        colsLst.add(xCol);
+        colsLst.add(yCol);
+        if (hasXLowError || hasXHighError) {
+            colsLst.add(xLowCol);
+            colsLst.add(xHighCol);
+        }
+        if (hasYLowError || hasYHighError) {
+            colsLst.add(yLowCol);
+            colsLst.add(yHighCol);
+        }
+        Col[] cols = colsLst.toArray(new Col[colsLst.size()]);
+
+        // create the array of output columns
+        ArrayList<DataType> columnList = new ArrayList<>();
+        ArrayList<DataGroup.Attribute> colMeta = new ArrayList<>();
+        columnList.add(new DataType("rowIdx", Integer.class));
+        for (Col col : cols) {
+            if (col.getter.isExpression()) {
+                columnList.add(new DataType(col.colname, col.colname, Double.class, DataType.Importance.HIGH, "", false));
+            } else {
+                columnList.add(dg.getDataDefintion(col.colname).copyWithNoColumnIdx(columnList.size()));
+                colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), col.colname));
+            }
+        }
+        DataType columns [] = columnList.toArray(new DataType[columnList.size()]);
+
+        // create the return data group
+        DataGroup retval = new DataGroup("XY with Errors", columns);
+        retval.setAttributes(colMeta);
+
+        DataObject retrow;
+        int ncols = cols.length;
+        Col col;
+        DataType dt;
+        double val;
+        String formatted;
+        DataType dtRowIdx = columns[0];
+
+        for (int rIdx = 0; rIdx < dg.size(); rIdx++) {
+            DataObject row = dg.get(rIdx);
+            retrow = new DataObject(retval);
+            for (int c = 0; c < ncols ; c++) {
+                col = cols[c];
+                val = col.getter.getValue(row);
+                if (Double.isNaN(val) && !col.canBeNaN) {
+                    retrow = null;
+                    break;
+                } else {
+                    dt = columns[c+1];
+                    formatted = col.getter.getFormattedValue(row);
+                    if (formatted == null) {
+                        retrow.setDataElement(dt, QueryUtil.convertData(dt.getDataType(), val));
+                    } else {
+                        retrow.setFormattedData(dt, formatted);
+                    }
+                    col.updateMinMax(val);
+                }
+            }
+            if (retrow != null) {
+                retrow.setDataElement(dtRowIdx, rIdx);
+                retval.add(retrow);
+            }
+        }
+
+        if (retval.size() > 0) {
+            double xMin = Math.min(xCol.minVal, xLowCol.minVal);
+            retval.addAttribute("X-MIN", String.valueOf(xMin));
+            double xMax = Math.max(xCol.maxVal, xHighCol.maxVal);
+            retval.addAttribute("X-MAX", String.valueOf(xMax));
+
+            double yMin = Math.min(yCol.minVal, yLowCol.minVal);
+            retval.addAttribute("Y-MIN", String.valueOf(yMin));
+            double yMax = Math.max(yCol.maxVal, yHighCol.maxVal);
+            retval.addAttribute("Y-MAX", String.valueOf(yMax));
+        }
+
+        retval.shrinkToFitData();
+        File outFile = createFile(request);
+        DataGroupWriter.write(outFile, retval);
+        return outFile;
+    }
+
+    private Col getCol(DataType[] dataTypes, String colOrExpr, String exprColName, boolean canBeNaN) throws DataAccessException {
+        Col col = new Col(dataTypes, colOrExpr, exprColName, canBeNaN);
+        if (!col.getter.isValid()) {
+            throw new DataAccessException("Invalid column or expression: "+colOrExpr);
+        }
+        return col;
+    }
+
+
+    private static class Col {
+        DataObjectUtil.DoubleValueGetter getter;
+        String colname;
+        boolean canBeNaN;
+        double minVal = Double.MAX_VALUE;
+        double maxVal = Double.MIN_VALUE;
+
+        Col() {
+            this.canBeNaN = true;
+        }
+
+        Col(DataType[] dataTypes, String colOrExpr, String exprColName, boolean canBeNaN) {
+            this.getter = new DataObjectUtil.DoubleValueGetter(dataTypes, colOrExpr);
+            if (getter.isExpression()) {
+                this.colname = exprColName;
+            } else {
+                this.colname = colOrExpr;
+            }
+            this.canBeNaN = canBeNaN;
+        }
+
+
+        public void updateMinMax(double val) {
+            if (val > maxVal) { maxVal = val; }
+            if (val < minVal) { minVal = val; }
+        }
+    }
+}
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -54,7 +54,7 @@ public class QueryUtil {
     public static final Logger.LoggerImpl LOGGER = Logger.getLogger();
 
     private static final int DECI_DEF_MAX_POINTS = AppProperties.getIntProperty("decimation.def.max.points", 100000);
-    private static final int DECI_ENABLE_SIZE = AppProperties.getIntProperty("decimation.enable.size", 5000);
+    public static final int DECI_ENABLE_SIZE = AppProperties.getIntProperty("decimation.enable.size", 5000);
 
     public static String makeUrlBase(String url) {
 
@@ -915,7 +915,7 @@ public class QueryUtil {
         return "%."+needSigDigits+"g";
     }
 
-    private static Object convertData(Class dataType, double x) {
+    public static Object convertData(Class dataType, double x) {
         if (dataType.isAssignableFrom(Double.class)) {
             return x;
         } else if (dataType.isAssignableFrom(Float.class)) {

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -29,23 +29,21 @@ export const getHighlighted = function(xyPlotParams, tblId) {
     const tableModel = getTblById(tblId);
     if (tableModel && xyPlotParams) {
         const rowIdx = tableModel.highlightedRow;
-        const xIn = xyPlotParams.x.columnOrExpr;
-        const yIn = xyPlotParams.y.columnOrExpr;
-        const xErr= xyPlotParams.x.error;
-        const yErr= xyPlotParams.y.error;
-
-        const x = getColOrExprValue(tableModel, rowIdx, xIn);
-        const y = getColOrExprValue(tableModel, rowIdx, yIn);
-        const highlighted = {x, y, rowIdx};
-        if (xErr) {
-            highlighted['left'] = getColOrExprValue(tableModel, rowIdx, `${xIn}-${xErr}`);
-            highlighted['right'] = getColOrExprValue(tableModel, rowIdx, `${xIn}+${xErr}`);
-        }
-        if (yErr) {
-            highlighted['low'] = getColOrExprValue(tableModel, rowIdx, `${yIn}-${yErr}`);
-            highlighted['high'] = getColOrExprValue(tableModel, rowIdx, `${yIn}+${yErr}`);
-
-        }
+        const highlighted = {rowIdx};
+        [
+            {n:'x',v:xyPlotParams.x.columnOrExpr},
+            {n:'y',v:xyPlotParams.y.columnOrExpr},
+            {n:'xErr', v:xyPlotParams.x.error},
+            {n:'xErrLow', v:xyPlotParams.x.errorLow},
+            {n:'xErrHigh', v:xyPlotParams.x.errorHigh},
+            {n:'yErr', v:xyPlotParams.y.error},
+            {n:'yErrLow', v:xyPlotParams.y.errorLow},
+            {n:'yErrHigh', v:xyPlotParams.y.errorHigh}
+        ].map((entry) => {
+            if (entry.v) {
+                highlighted[entry.n] = getColOrExprValue(tableModel, rowIdx, entry.v);
+            }
+        });
         return highlighted;
     }
 };

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -31,24 +31,47 @@ export const getHighlighted = function(xyPlotParams, tblId) {
         const rowIdx = tableModel.highlightedRow;
         const xIn = xyPlotParams.x.columnOrExpr;
         const yIn = xyPlotParams.y.columnOrExpr;
+        const xErr= xyPlotParams.x.error;
+        const yErr= xyPlotParams.y.error;
 
-        var x, y;
-        if (getColumnIdx(tableModel, xIn) >= 0) {
-            x = getCellValue(tableModel, rowIdx, xIn);
-        } else {
-            x = getExpressionValue(xIn, tableModel, rowIdx);
+        const x = getColOrExprValue(tableModel, rowIdx, xIn);
+        const y = getColOrExprValue(tableModel, rowIdx, yIn);
+        const highlighted = {x, y, rowIdx};
+        if (xErr) {
+            highlighted['left'] = getColOrExprValue(tableModel, rowIdx, `${xIn}-${xErr}`);
+            highlighted['right'] = getColOrExprValue(tableModel, rowIdx, `${xIn}+${xErr}`);
         }
+        if (yErr) {
+            highlighted['low'] = getColOrExprValue(tableModel, rowIdx, `${yIn}-${yErr}`);
+            highlighted['high'] = getColOrExprValue(tableModel, rowIdx, `${yIn}+${yErr}`);
 
-        if (getColumnIdx(tableModel, yIn) >= 0) {
-            y = getCellValue(tableModel, rowIdx, yIn);
-        } else {
-            y = getExpressionValue(yIn, tableModel, rowIdx);
         }
-        return {x:Number(x), y:Number(y), rowIdx};
+        return highlighted;
     }
 };
 
-function getExpressionValue(strExpr, tableModel, rowIdx) {
+/**
+ * This method returns the value of the column cell or an expression from multiple column cells in a given row
+ *
+ * @param {TableModel} tableModel - table model
+ * @param {number} rowIdx - row index in the table
+ * @param {string} colOrExpr - column name or expression
+ * @returns {number} value of the column or expression in the given row
+ */
+export function getColOrExprValue(tableModel, rowIdx, colOrExpr) {
+    if (tableModel) {
+        var val;
+        if (getColumnIdx(tableModel, colOrExpr) >= 0) {
+            val = getCellValue(tableModel, rowIdx, colOrExpr);
+            val = isFinite(parseFloat(val)) ? Number(val) : Number.NaN;
+        } else {
+            val = getExpressionValue(tableModel, rowIdx, colOrExpr);
+        }
+        return val;
+    }
+}
+
+function getExpressionValue(tableModel, rowIdx, strExpr) {
 
     const expr = new Expression(strExpr); // no check for allowed variables, already validated
     if (expr.isValid()) {

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -243,7 +243,25 @@ function doChartDataFetch(dispatch, payload, getChartDataType) {
     let newMeta = meta;
 
     if (tblId) {
-        const tblSource = get(getTblById(tblId), 'tableMeta.tblFilePath');
+        const tblModel = getTblById(tblId);
+
+        // if table load produced an error, we can not get chart data
+        const error = get(tblModel, error);
+        if (error) {
+            const message = 'Failed to fetch chart data';
+            logError(`${message}: ${error}`);
+            dispatch(chartDataUpdate(
+                {
+                    chartId,
+                    chartDataElementId,
+                    isDataReady: true,
+                    error: {message, error},
+                    data: undefined
+                }));
+            return;
+        }
+
+        const tblSource = get(tblModel, 'tableMeta.tblFilePath');
         const tblSourceChart = get(meta, 'tblSource');
 
         if (tblSourceChart !== tblSource) {

--- a/src/firefly/js/charts/chartTypes/ScatterTblView.jsx
+++ b/src/firefly/js/charts/chartTypes/ScatterTblView.jsx
@@ -288,12 +288,10 @@ function addSelection(chartId, tblId, tableModel) {
             const {xMin, xMax, yMin, yMax} = selection;
             const selectInfoCls = SelectInfo.newInstance({rowCount: tableModel.totalRows});
             // add all rows which fall into selection
-            const xIdx = 0, yIdx = 1, rowIdx = 2;
             rows.forEach((arow) => {
-                const x = Number(arow[xIdx]);
-                const y = Number(arow[yIdx]);
+                const {x, y, rowIdx} = arow;
                 if (x >= xMin && x <= xMax && y >= yMin && y <= yMax) {
-                    selectInfoCls.setRowSelect(Number(arow[rowIdx]), true);
+                    selectInfoCls.setRowSelect(rowIdx, true);
                 }
             });
             const selectInfo = selectInfoCls.data;
@@ -309,10 +307,8 @@ function selectionNotEmpty(chartId, selection) {
     if (rows) {
         if (selection) {
             const {xMin, xMax, yMin, yMax} = selection;
-            const xIdx = 0, yIdx = 1;
             const aPt = rows.find((arow) => {
-                const x = Number(arow[xIdx]);
-                const y = Number(arow[yIdx]);
+                const {x, y} = arow;
                 return (x >= xMin && x <= xMax && y >= yMin && y <= yMax);
             });
             return Boolean(aPt);

--- a/src/firefly/js/charts/highcharts/XYErrorBars.js
+++ b/src/firefly/js/charts/highcharts/XYErrorBars.js
@@ -1,0 +1,306 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+
+/**
+ * loosely based on http://www.highcharts.com/plugin-registry/single/38/error_bar
+ * (using highcharts 5 source)
+ * @param Highcharts
+ */
+export function xyErrorBarExtension(Highcharts) {
+    (function (H) {
+        'use strict';
+        var each = H.each,
+            noop = H.noop,
+            pick = H.pick,
+            seriesType = H.seriesType,
+            seriesTypes = H.seriesTypes;
+
+        /**
+         * The boxplot series type.
+         *
+         * @constructor seriesTypes.boxplot
+         * @augments seriesTypes.column
+         */
+        seriesType('error_bar', 'column', {
+            threshold: null,
+            tooltip: {
+                pointFormat: '<span style="color:{point.color}">\u25CF</span>' + // eslint-disable-line no-dupe-keys
+                    '<b>{point.left}</b> - <b>{point.right}</b><br/>' +
+                    '<b>{point.low}</b> - <b>{point.high}</b><br/>'
+            },
+            grouping: false,
+            color: '#000000',
+            fillColor: '#ffffff',
+            lineWidth: 1,
+            medianWidth: 2,
+            states: {
+                hover: {
+                    brightness: -0.3
+                }
+            },
+            //stemColor: null,
+            //stemDashStyle: 'solid'
+            //stemWidth: null,
+
+            //whiskerColor: null,
+            whiskerLength: '3',
+            whiskerWidth: 2,
+            format: 'xy'
+
+
+        }, /** @lends seriesTypes.boxplot */ {
+            pointArrayMap: ['x','y', 'left', 'right', 'low', 'high'], // array point configs are mapped to this
+            xpointArrayMap: ['x', 'left', 'right'],
+            ypointArrayMap: ['y', 'low', 'high'],
+            toYData(point) { // return a plain array for speedy calculation
+                return [point.low, point.high];
+            },
+            pointValKey: 'y', // defines the top of the tracker
+
+
+            /**
+             * Get presentational attributes
+             * @param point
+             */
+            pointAttribs(point) {
+                var options = this.options,
+                    color = (point && point.color) || this.color;
+
+                return {
+                    'fill': point.fillColor || options.fillColor || color,
+                    'stroke': options.lineColor || color,
+                    'stroke-width': options.lineWidth || 0
+                };
+            },
+
+
+            /**
+             * Disable data labels for box plot
+             */
+            drawDataLabels: noop,
+
+            /**
+             * Translate data points from raw values x and y to plotX and plotY
+             */
+            translate() {
+                var series = this,
+                    xAxis = series.xAxis,
+                    yAxis = series.yAxis,
+                    xpointArrayMap = series.xpointArrayMap,
+                    ypointArrayMap = series.ypointArrayMap;
+
+                seriesTypes.column.prototype.translate.apply(series);
+
+                // do the translation on each point dimension
+                each(series.points, function(point) {
+                    each(xpointArrayMap, function(key) {
+                        if (point[key] !== null) {
+                            point[key + 'Plot'] = xAxis.translate(point[key], 0, 0, 0, 1);
+                        }
+                    });
+                    each(ypointArrayMap, function(key) {
+                        if (point[key] !== null) {
+                            point[key + 'Plot'] = yAxis.translate(point[key], 0, 1, 0, 1);
+                        }
+                    });
+                });
+            },
+
+            /**
+             * Draw the data points
+             */
+            drawPoints() {
+                var series = this, //state = series.state,
+                    points = series.points,
+                    options = series.options,
+                    chart = series.chart,
+                    renderer = chart.renderer,
+                    xPlot,
+                    yPlot,
+                    leftPlot,
+                    rightPlot,
+                    highPlot,
+                    lowPlot,
+                    xWhiskerLow,
+                    xWhiskerHigh,
+                    yWhiskerLeft,
+                    yWhiskerRight,
+                    whiskerLength = series.options.whiskerLength,
+                    format = series.options.format;
+
+
+                each(points, function(point) {
+
+                    var graphic = point.graphic,
+                        verb = graphic ? 'animate' : 'attr';
+
+
+                    var stemAttr = {},
+                        whiskersAttr = {},
+                        color = point.color || series.color;
+
+                    if (point.plotY !== undefined) {
+
+                        xPlot  = Math.floor(point.xPlot);
+                        yPlot =  Math.floor(point.yPlot);
+                        leftPlot = Math.floor(point.leftPlot);
+                        rightPlot = Math.floor(point.rightPlot);
+
+                        highPlot = Math.floor(point.highPlot);
+                        lowPlot = Math.floor(point.lowPlot);
+
+                        xWhiskerLow = Math.floor(yPlot - whiskerLength);
+                        xWhiskerHigh = Math.floor(yPlot + whiskerLength);
+
+                        yWhiskerLeft = Math.floor(xPlot - whiskerLength);
+                        yWhiskerRight = Math.floor(xPlot + whiskerLength);
+
+                        if (!graphic) {
+                            point.graphic = graphic = renderer.g('point')
+                                .add(series.group);
+
+                            point.stem = renderer.path()
+                                .addClass('highcharts-boxplot-stem')
+                                .add(graphic);
+
+                            if (whiskerLength) {
+                                point.whiskers = renderer.path()
+                                    .addClass('highcharts-boxplot-whisker')
+                                    .add(graphic);
+                            }
+
+                            // Stem attributes
+                            stemAttr.stroke = point.stemColor || options.stemColor || color;
+                            stemAttr['stroke-width'] = pick(point.stemWidth, options.stemWidth, options.lineWidth);
+                            stemAttr.dashstyle = point.stemDashStyle || options.stemDashStyle;
+                            point.stem.attr(stemAttr);
+
+                            // Whiskers attributes
+                            if (whiskerLength) {
+                                whiskersAttr.stroke = point.whiskerColor || options.whiskerColor || color;
+                                whiskersAttr['stroke-width'] = pick(point.whiskerWidth, options.whiskerWidth, options.lineWidth);
+                                point.whiskers.attr(whiskersAttr);
+                            }
+                        }
+
+                        switch (format) {
+                            case 'x':
+                                point.stem[verb]({
+                                    d: [
+                                        'M',
+                                        leftPlot, yPlot,
+                                        'L',
+                                        rightPlot, yPlot,
+                                        'z'
+                                    ]});
+
+                                if (whiskerLength) {
+                                    point.whiskers[verb]({
+                                        d: [
+                                            'M',
+                                            leftPlot, xWhiskerLow,
+                                            'L',
+                                            leftPlot, xWhiskerHigh,
+
+                                            'M',
+                                            rightPlot, xWhiskerLow,
+                                            'L',
+                                            rightPlot, xWhiskerHigh,
+
+                                            'z'
+                                        ]
+                                    });
+                                }
+                                break;
+
+                            case 'y':
+                                point.stem[verb]({
+                                    d: [
+                                        'M',
+                                        xPlot, lowPlot,
+                                        'L',
+                                        xPlot, highPlot,
+                                        'z'
+                                    ]});
+
+                                if (whiskerLength) {
+                                    point.whiskers[verb]({
+                                        d: [
+                                            'M',
+                                            yWhiskerLeft, lowPlot,
+                                            'L',
+                                            yWhiskerRight, lowPlot,
+
+                                            'M',
+                                            yWhiskerLeft, highPlot,
+                                            'L',
+                                            yWhiskerRight, highPlot,
+
+                                            'z'
+                                        ]
+                                    });
+                                }
+                                break;
+
+                            case 'xy':
+                            default:
+                                point.stem[verb]({
+                                    d: [
+                                        'M',
+                                        leftPlot, yPlot,
+                                        'L',
+                                        rightPlot, yPlot,
+                                        'M',
+                                        xPlot, lowPlot,
+                                        'L',
+                                        xPlot, highPlot,
+                                        'z'
+                                    ]});
+
+                                if (whiskerLength) {
+                                    point.whiskers[verb]({
+                                        d: [
+                                            'M',
+                                            leftPlot, xWhiskerLow,
+                                            'L',
+                                            leftPlot, xWhiskerHigh,
+
+                                            'M',
+                                            rightPlot, xWhiskerLow,
+                                            'L',
+                                            rightPlot, xWhiskerHigh,
+
+                                            'M',
+                                            yWhiskerLeft, lowPlot,
+                                            'L',
+                                            yWhiskerRight, lowPlot,
+
+                                            'M',
+                                            yWhiskerLeft, highPlot,
+                                            'L',
+                                            yWhiskerRight, highPlot,
+
+                                            'z'
+                                        ]
+                                    });
+                                }
+                                break;
+                        }
+                    }
+                });
+
+            },
+            setStackedPoints: noop // #3890
+
+
+        });
+
+        /* ****************************************************************************
+         * End error_bars series code												*
+         *****************************************************************************/
+
+    }(Highcharts));
+}
+

--- a/src/firefly/js/charts/ui/XYPlot.jsx
+++ b/src/firefly/js/charts/ui/XYPlot.jsx
@@ -243,18 +243,21 @@ const calculateChartSize = function(widthPx, heightPx, props) {
     return {chartWidth, chartHeight};
 };
 
-const formatError = function(val, low, high) {
-    if (Number.isFinite(low) && Number.isFinite(high) && Number.isFinite(val)) {
-        const lowErr = Math.abs(val - low);
-        const highErr = Math.abs(high - val);
-        const fmtLow = getFormatString(lowErr, 4);
-        const symmetricError = Math.abs(highErr-lowErr) < Math.abs(Math.min(lowErr, highErr))/1000;
+const formatError = function(val, err, errLow, errHigh) {
+    if (Number.isFinite(err) || (Number.isFinite(errLow) && Number.isFinite(errHigh))) {
+        const symmetricError = Number.isFinite(err);
+        const lowErr = symmetricError ? err : errLow;
+        const highErr = symmetricError ? err : errHigh;
+        // we might want to use format for expressions in future - still hard to tell how many places to save
+        //const fmtLow = getFormatString(lowErr, 4);
         if (symmetricError) {
-            return ' \u00B1 '+numeral(lowErr).format(fmtLow); //Unicode U+00B1 is plusmn
+            //return ' \u00B1 '+numeral(lowErr).format(fmtLow); //Unicode U+00B1 is plusmn
+            return ' \u00B1 '+lowErr; //Unicode U+00B1 is plusmn
         } else {
-            const fmtHigh = getFormatString(highErr, 4);
+            //const fmtHigh = getFormatString(highErr, 4);
+            //return `\u002B${numeral(highErr).format(fmtHigh)} / \u2212${numeral(lowErr).format(fmtLow)}`;
             // asymmetric errors format: 8 +4/-2
-            return `\u002B${numeral(highErr).format(fmtHigh)} / \u2212${numeral(lowErr).format(fmtLow)}`;
+            return `\u002B${highErr} / \u2212${lowErr}`;
         }
     } else {
         return '';
@@ -745,9 +748,9 @@ export class XYPlot extends React.Component {
                 formatter() {
                     const weight = this.point.weight ? `represents ${this.point.weight} points <br/>` : '';
                     const xval = xFormat ? numeral(this.point.x).format(xFormat) : this.point.x;
-                    const xerr = formatError(this.point.x, this.point.left, this.point.right);
+                    const xerr = formatError(this.point.x, this.point.xErr, this.point.xErrLow, this.point.xErrHigh);
                     const yval = yFormat ? numeral(this.point.y).format(yFormat) : this.point.y;
-                    const yerr = formatError(this.point.y, this.point.low, this.point.high);
+                    const yerr = formatError(this.point.y, this.point.yErr, this.point.yErrLow, this.point.yErrHigh);
                     return '<span> ' + `${params.x.label} = ${xval} ${xerr} ${params.x.unit} <br/>` +
                         `${params.y.label} = ${yval} ${yerr} ${params.y.unit} <br/> ` +
                         `${weight}</span>`;


### PR DESCRIPTION
In this ticket, the option is provided to enter a symmetric error  for X and Y column. Asymmetric errors will be handled by a separate ticket.

A column or an expression can be entered next to X and Y field in plot options.
Good test is WISE color-color plots: use w[1,2,3,4]sigmpro as an uncertainty for w[1,2,3,4]mpro. 

If less than 20 points are displayed, the error bar will have whiskers, otherwise no whiskers.

To test, bring up a catalog search in Firefly, choose WISE. After the default chart comes up, open the options, choose w1mpro for X, w1sigmpro for X Err, w2mpro for Y, w2sigmpro for Y Err. Do the search, zoom to see error bars, check tooltip to see the uncertainty, when available. (If not available, the corresponding cell in the table should show null.)
