### PR TITLE
DM-7970: Image settings for Light curve

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
+++ b/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
@@ -51,11 +51,11 @@ export function LcImageToolbarView({activePlotId, viewerId, viewerPlotIds, layou
             <div style={{display:'inline-block'}}>
                 <input style={{margin: 0}}
                        type='checkbox'
-                       checked={vr.wcsMatchType===WcsMatchType.Standard}
-                       onChange={(ev) => wcsMatchStandard(ev.target.checked, vr.activePlotId) }
+                       checked={vr.wcsMatchType===WcsMatchType.Target}
+                       onChange={(ev) => wcsMatchTarget(ev.target.checked, vr.activePlotId) }
                 />
             </div>
-            <div style={tStyle}>WCS Match</div>
+            <div style={tStyle}>Target Match</div>
         </div>
     );
 
@@ -125,6 +125,6 @@ InlineRightToolbarWrapper.propTypes= {
     dlAry : PropTypes.array
 };
 
-function wcsMatchStandard(doWcsStandard, plotId) {
-    dispatchWcsMatch({matchType:doWcsStandard?WcsMatchType.Standard:false, plotId});
+function wcsMatchTarget(doWcsStandard, plotId) {
+    dispatchWcsMatch({matchType:doWcsStandard?WcsMatchType.Target:false, plotId});
 }

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -209,6 +209,7 @@ export function setupImages(tbl_id) {
         const tableModel = getTblById(tbl_id);
         if (!tableModel || isNil(tableModel.highlightedRow)) return;
         var vr= visRoot();
+        const hasPlots= vr.plotViewAry.length>0;
         const newPlotIdAry= makePlotIds(tableModel.highlightedRow, tableModel.totalRows,count);
         const maxPlotIdAry= makePlotIds(tableModel.highlightedRow, tableModel.totalRows,MAX_IMAGE_CNT);
 
@@ -232,7 +233,7 @@ export function setupImages(tbl_id) {
 
 
         vr= visRoot();
-        if (!vr.wcsMatchType) {
+        if (!vr.wcsMatchType && !hasPlots) {
             dispatchWcsMatch({matchType:WcsMatchType.Target, plotId:newActivePlotId});
         }
 

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -10,7 +10,8 @@ import {TBL_RESULTS_ADDED, TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_HIGHLIGHT} fr
 import {getCellValue, getTblById, makeTblRequest} from '../../tables/TableUtil.js';
 import {updateSet} from '../../util/WebUtil.js';
 import {dispatchPlotImage, visRoot, dispatchDeletePlotView,
-        dispatchChangeActivePlotView} from '../../visualize/ImagePlotCntlr.js';
+        dispatchChangeActivePlotView,
+        WcsMatchType, dispatchWcsMatch} from '../../visualize/ImagePlotCntlr.js';
 import {getPlotViewById} from '../../visualize/PlotViewUtil.js';
 import {getMultiViewRoot, dispatchReplaceViewerItems, getViewer} from '../../visualize/MultiViewCntlr.js';
 import {WebPlotRequest,TitleOptions} from '../../visualize/WebPlotRequest.js';
@@ -20,6 +21,8 @@ import {ServerRequest} from '../../data/ServerRequest.js';
 import {CHANGE_VIEWER_LAYOUT} from '../../visualize/MultiViewCntlr.js';
 import {LcPFOptionsPanel, grpkey} from './LcPhaseFoldingPanel.jsx';
 import FieldGroupUtils, {revalidateFields} from '../../fieldGroup/FieldGroupUtils';
+import {makeWorldPt} from '../../visualize/Point.js';
+import {CoordinateSys} from '../../visualize/CoordSys.js';
 
 export const RAW_TABLE = 'raw_table';
 export const PHASE_FOLDED = 'phase_folded';
@@ -160,14 +163,7 @@ function getWebPlotRequest(tableModel, hlrow) {
     sr.setParam('in_dec',`${dec}`);
 
     const reqParams = WebPlotRequest.makeProcessorRequest(sr, 'wise');
-    reqParams.setTitle('WISE-'+ frameId);
-    reqParams.setGroupLocked(true);
-    reqParams.setPlotGroupId('LightCurveGroup');
-    reqParams.setPreferenceColorKey('light-curve-color-pref');
-    return reqParams;
-
-
-
+    return addCommonReqParams(reqParams, title, makeWorldPt(ra,dec,CoordinateSys.EQ_J2000));
 }
 
 function getWebPlotRequestViaUrl(tableModel, hlrow, cutoutSize) {
@@ -191,15 +187,19 @@ function getWebPlotRequestViaUrl(tableModel, hlrow, cutoutSize) {
     const url = `${serverinfo}${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w1-int-1b.fits${centerandsize}`;
     const plot_desc = `WISE-${frameId}`;
     const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);
-    reqParams.setTitle('WISE-'+ frameId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : ''));
-    reqParams.setTitleOptions(TitleOptions.NONE);
-    reqParams.setGroupLocked(true);
-    reqParams.setPlotGroupId('LightCurveGroup');
-    reqParams.setPreferenceColorKey('light-curve-color-pref');
-    return reqParams;
+    const title= 'WISE-'+ frameId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+    return addCommonReqParams(reqParams, title, makeWorldPt(ra,dec,CoordinateSys.EQ_J2000));
+}
 
-
-
+function addCommonReqParams(inWpr,title,wp) {
+    const retWpr= inWpr.makeCopy();
+    retWpr.setTitle(title);
+    retWpr.setTitleOptions(TitleOptions.NONE);
+    retWpr.setGroupLocked(true);
+    retWpr.setPlotGroupId('LightCurveGroup');
+    retWpr.setPreferenceColorKey('light-curve-color-pref');
+    retWpr.setOverlayPosition(wp);
+    return retWpr;
 }
 
 export function setupImages(tbl_id) {
@@ -227,7 +227,14 @@ export function setupImages(tbl_id) {
 
 
         dispatchReplaceViewerItems(IMG_VIEWER_ID, newPlotIdAry);
-        dispatchChangeActivePlotView(plotIdRoot+tableModel.highlightedRow);
+        const newActivePlotId= plotIdRoot+tableModel.highlightedRow;
+        dispatchChangeActivePlotView(newActivePlotId);
+
+
+        vr= visRoot();
+        if (!vr.wcsMatchType) {
+            dispatchWcsMatch({matchType:WcsMatchType.Target, plotId:newActivePlotId});
+        }
 
         vr= visRoot();
 

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -90,16 +90,20 @@ export function expandedPlotViewAry(ref,activePlotId=null) {
  * @param visRoot - root of the visualization object in store
  * @param pvOrId this parameter will take the plotId string or a plotView object
  * @param onlyIfGroupLocked
+ * @param hasPlots
  * @returns {*}
  */
-export function getPlotViewIdListInGroup(visRoot,pvOrId,onlyIfGroupLocked=true) {
+export function getPlotViewIdListInGroup(visRoot,pvOrId,onlyIfGroupLocked=true, hasPlots=false) {
     if (!pvOrId) return [];
     var pv= (typeof pvOrId ==='string') ? getPlotViewById(visRoot,pvOrId) : pvOrId;
     var gid= pv.plotGroupId;
     var group= getPlotGroupById(visRoot,gid);
     var locked= hasGroupLock(pv,group);
     if (!locked && onlyIfGroupLocked) return [pv.plotId];
-    return visRoot.plotViewAry.filter( (pv) => pv.plotGroupId===gid).map( (pv) => pv.plotId);
+    const idList=  visRoot.plotViewAry.filter( (pv) => pv.plotGroupId===gid).map( (pv) => pv.plotId);
+    if (!hasPlots) return idList;
+
+    return idList.filter( (id) => get(getPlotViewById(visRoot,id),'plots.length') );
 }
 
 

--- a/src/firefly/js/visualize/Point.js
+++ b/src/firefly/js/visualize/Point.js
@@ -61,17 +61,6 @@ var Point = {  SPT, IM_PT, IM_WS_PT, VP_PT, PROJ_PT, W_PT, OFFSET_PT};
  * @global
  */
 
-var ptTypes= Object.values(Point);
-
-//var makePt = function (x, y) {
-//    var retval= {};
-//    retval.getX = function () { return x; };
-//    retval.getY = function () { return y; };
-//    retval.toString= function() {
-//        return x+";"+y;
-//    };
-//    return retval;
-//};
 
 
 export class SimplePt {
@@ -192,8 +181,8 @@ function stringAryToWorldPt(wpParts) {
 
 /**
  * @summary A point on the sky with a coordinate system
- * @param {number} lon - longitude in degrees
- * @param {number} lat - latitude in degrees
+ * @param {number|string} lon - longitude in degrees, strings are converted to numbers
+ * @param {number|string} lat - latitude in degrees, strings are converted to numbers
  * @param {CoordinateSys} coordSys - The coordinate system of this worldPt
  *
  * @param {String} [objName] -  object name used to create this worldPt
@@ -206,16 +195,14 @@ function stringAryToWorldPt(wpParts) {
  * @global
  */
 export const makeWorldPt= function (lon,lat,coordSys,objName,resolver) {
-    if (typeof lon === 'string') lon= Number(lon);
-    if (typeof lat === 'string') lat= Number(lat);
-    return new WorldPt(lon,lat,coordSys,objName,resolver) ;
+    return new WorldPt(Number(lon),Number(lat),coordSys,objName,resolver) ;
 };
 
 
 /**
  * @summary A point in the image file
- * @param {number} x - the x
- * @param {number} y - the y
+ * @param {number|string} x - the x, string is converted to number
+ * @param {number|string} y - the y, string is converted to number
  *
  * @return {ImagePt}
  *
@@ -224,31 +211,25 @@ export const makeWorldPt= function (lon,lat,coordSys,objName,resolver) {
  * @public
  * @global
  */
-export const makeImagePt= function(x,y) {
-    if (typeof x === 'string') x= Number(x);
-    if (typeof y === 'string') y= Number(y);
-    return Object.assign(new SimplePt(x,y), {type:IM_PT});
-};
+export const makeImagePt= (x,y) => Object.assign(new SimplePt(Number(x),Number(y)), {type:IM_PT});
+
 
 /**
  *
- * @param x
- * @param y
+ * @param {number|string} x - the x, string is converted to number
+ * @param {number|string} y - the y, string is converted to number
  * @memberof firefly.util.image
  * @return {Pt}
  */
-export const makeImageWorkSpacePt= function(x,y) {
-    if (typeof x === 'string') x= Number(x);
-    if (typeof y === 'string') y= Number(y);
-    return Object.assign(new SimplePt(x,y), {type:IM_WS_PT});
-};
+export const makeImageWorkSpacePt= (x,y) => Object.assign(new SimplePt(Number(x),Number(y)), {type:IM_WS_PT});
+
 
 
 
 /**
  * @summary A point of the display image
- * @param {number} x - the x
- * @param {number} y - the y
+ * @param {number|string} x - the x, string is converted to number
+ * @param {number|string} y - the y, string is converted to number
  *
  * @return {ScreenPt}
  *
@@ -257,27 +238,31 @@ export const makeImageWorkSpacePt= function(x,y) {
  * @public
  * @global
  */
-export const makeScreenPt= function(x,y) {
-    if (typeof x === 'string') x= Number(x);
-    if (typeof y === 'string') y= Number(y);
-    return Object.assign(new SimplePt(x,y), {type:SPT});
-};
-export const makeViewPortPt= function(x,y) {
-    if (typeof x === 'string') x= Number(x);
-    if (typeof y === 'string') y= Number(y);
-    return Object.assign(new SimplePt(x,y), {type:VP_PT});
-};
-export const makeProjectionPt= function(x,y) {
-    if (typeof x === 'string') x= Number(x);
-    if (typeof y === 'string') y= Number(y);
-    return Object.assign(new SimplePt(x,y), {type:PROJ_PT});
-};
-export const makeOffsetPt= function(x,y) {
-    if (typeof x === 'string') x= Number(x);
-    if (typeof y === 'string') y= Number(y);
-    return Object.assign(new SimplePt(x,y), {type:OFFSET_PT});
-};
+export const makeScreenPt= (x,y) => Object.assign(new SimplePt(Number(x),Number(y)), {type:SPT});
 
+export const makeViewPortPt= (x,y) => Object.assign(new SimplePt(Number(x),Number(y)), {type:VP_PT});
+
+export const makeProjectionPt= (x,y) => Object.assign(new SimplePt(Number(x),Number(y)), {type:PROJ_PT});
+
+export const makeOffsetPt= (x,y) => Object.assign(new SimplePt(Number(x),Number(y)), {type:OFFSET_PT});
+
+
+/**
+ * @summary Test if two points are equals.  They must be the same coordinate system and have the same values to be
+ * equal. Two points that are null or undefined are also considered equal.
+ * If both points are WorldPt and are equal in values and coordindate system but have a
+ * different resolver and object names, * they are still considered equal.
+ *
+ * @param {Point} p1 - the first point
+ * @param {Point} p2 - the second point
+ *
+ * @return  true if equals
+ *
+ * @function pointEquals
+ * @memberof firefly.util.image
+ * @public
+ * @global
+ */
 export const pointEquals= function(p1,p2)  {
     if (isNil(p1) && isNil(p2)) return true;
     else if (isNil(p1) || isNil(p2)) return false;
@@ -326,6 +311,8 @@ export const parseWorldPt = function (serializedWP) {
     }
     return stringAryToWorldPt(sAry);
 };
+
+const ptTypes= Object.values(Point);
 
 export const isValidPoint= (testPt) =>  (testPt && testPt.type && ptTypes.includes(testPt.type));
 

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -147,22 +147,34 @@ function updateForWcsMatching(visRoot, pv, mpwWcsPrimId) {
     const plot= primePlot(pv);
     if (!plot || !wcsMatchType ) return pv;
 
-    if (mpwWcsPrimId!==pv.plotId) {
-        const offPt= findWCSMatchOffset(visRoot, mpwWcsPrimId, primePlot(pv));
-        const masterPv=getPlotViewById(visRoot,mpwWcsPrimId);
-        if (masterPv) {
-            pv= updatePlotViewScrollXY(pv, makeScreenPt(masterPv.scrollX-offPt.x, masterPv.scrollY-offPt.y), false);
+    if (wcsMatchType===WcsMatchType.Standard) {
+        if (mpwWcsPrimId!==pv.plotId) {
+            const offPt= findWCSMatchOffset(visRoot, mpwWcsPrimId, primePlot(pv));
+            const masterPv=getPlotViewById(visRoot,mpwWcsPrimId);
+            if (masterPv) {
+                pv= updatePlotViewScrollXY(pv, makeScreenPt(masterPv.scrollX-offPt.x, masterPv.scrollY-offPt.y), false);
+            }
         }
     }
-    else if (wcsMatchType===WcsMatchType.Target && getPlotViewIdListInGroup(visRoot,pv.plotId).length<2) {
-        const ft=  plot.attributes[PlotAttribute.FIXED_TARGET];
-        if (ft) {
-            const centerImagePt = CCUtil.getImageCoords(plot, ft);
-            pv= updatePlotViewScrollXY(pv, PlotView.findScrollPtForImagePt(pv, centerImagePt, false));
+    else if (wcsMatchType===WcsMatchType.Target) {
+        if (getPlotViewIdListInGroup(visRoot,pv.plotId,true,true).length<2) {
+            const ft=  plot.attributes[PlotAttribute.FIXED_TARGET];
+            if (ft) {
+                const centerImagePt = CCUtil.getImageCoords(plot, ft);
+                pv= updatePlotViewScrollXY(pv, PlotView.findScrollPtForImagePt(pv, centerImagePt, false));
+            }
+        }
+        else {
+            const offPt= findWCSMatchOffset(visRoot, mpwWcsPrimId, primePlot(pv));
+            const masterPv=getPlotViewById(visRoot,mpwWcsPrimId);
+            if (masterPv) {
+                pv= updatePlotViewScrollXY(pv, makeScreenPt(masterPv.scrollX-offPt.x, masterPv.scrollY-offPt.y), false);
+            }
         }
     }
     return pv;
 }
+
 
 function newOverlayPrep(state, action) {
     const {plotId, imageOverlayId, imageNumber, maskValue, maskNumber, color, title, drawingDef}= action.payload;

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -472,7 +472,7 @@ function getNewAttributes(plot) {
 
     if (worldPt) {
         const cc= CysConverter.make(plot);
-        if (cc.pointInPlot(worldPt)) {
+        if (cc.pointInPlot(worldPt) || req.getOverlayPosition()) {
             attributes[PlotAttribute.FIXED_TARGET]= worldPt;
             if (circle) attributes[PlotAttribute.REQUESTED_SIZE]= circle.radius;  // says radius but really size
         }

--- a/src/firefly/js/visualize/task/WcsMatchTask.js
+++ b/src/firefly/js/visualize/task/WcsMatchTask.js
@@ -30,16 +30,20 @@ export function wcsMatchActionCreator(action) {
 
         var group= findPlotGroup(masterPv.plotGroupId, visRoot.plotGroupAry);
 
-        if (!matchType || matchType.Off || !width  || !height) {
+
+        if (!matchType || !width  || !height) {
             dispatcher({
                 type: ImagePlotCntlr.WCS_MATCH,
-                payload: {wcsMatchCenterWP:null,wcsMatchType:false,mpwWcsPrimId:null}
+                payload: {wcsMatchCenterWP:null,wcsMatchType:matchType,mpwWcsPrimId:plotId}
             });
             applyToOnePvOrGroup(visRoot.plotViewAry, masterPv.plotId, group,
                 (pv) => dispatchUpdateViewSize(pv.plotId));
             return;
         }
+
         const wcsMatchCenterWP= findWcsMatchPoint(masterPv, plotId, matchType);
+
+
 
         dispatcher({
             type: ImagePlotCntlr.WCS_MATCH,
@@ -174,6 +178,7 @@ function isRotationMatching(p1, p2) {
  */
 function findWcsMatchPoint(pv, plotId, matchType) {
     const p= primePlot(pv);
+    if (!p) return null;
     switch (matchType) {
         case WcsMatchType.Standard:
             return CCUtil.getWorldCoords(p, makeScreenPt(p.screenSize.width/2,p.screenSize.height/2));


### PR DESCRIPTION
 - WCS target match on by default.
 - The image stretch and color is saved as preference
 - object position should be centered in the display by default.
 - object is overlaid


To test: just read in the raw table.  The changes are visible.