### PR TITLE
DM-8548 fixed the wrong deepCoaddId in the image title

### DIFF
--- a/src/firefly/js/metaConvert/LsstSdssRequestList.js
+++ b/src/firefly/js/metaConvert/LsstSdssRequestList.js
@@ -14,7 +14,7 @@ import {ServerRequest} from '../data/ServerRequest.js';
  * @param title - {String}
  * @returns {WebPlotRequest} a web plot request
  */
-
+const bandMap= {u:0, g:1,r:2,i:3, z:4};
 function makeWebRequest(sr,  plotId, title) {
     const r  = WebPlotRequest.makeProcessorRequest(sr, 'lsst-sdss');
     const rangeValues= RangeValues.makeRV({which:SIGMA, lowerValue:-2, upperValue:10, algorithm:STRETCH_LINEAR});
@@ -38,6 +38,7 @@ function makeCcdReqBuilder(table, rowIdx) {
     const run= getCellValue(table, rowIdx, 'run');
     const field= getCellValue(table, rowIdx, 'field');
     const camcol= getCellValue(table, rowIdx, 'camcol');
+
     const sr= new ServerRequest('LSSTImageSearch');
     sr.setParam('run', `${run}`);
     sr.setParam('camcol', `${camcol}`);
@@ -45,7 +46,8 @@ function makeCcdReqBuilder(table, rowIdx) {
 
     return (plotId, id, filterName) => {
         sr.setParam('filterName', `${filterName}`);
-        const title = id+'-'+filterName;
+        const scienceCCCdId = id.toString();
+        const title =scienceCCCdId.substr(0, 4) + bandMap[filterName].toString() + scienceCCCdId.substr(5, 10)+'-'+filterName;
         return makeWebRequest(sr, plotId,  title);
     };
 }
@@ -59,7 +61,7 @@ function makeCcdReqBuilder(table, rowIdx) {
  */
 function makeCoadReqBuilder(table, rowIdx) {
 
-    const bandMap= {u:0, g:1,r:2,i:3, z:4};
+
     const tract= getCellValue(table, rowIdx, 'tract');
     const patch= getCellValue(table, rowIdx, 'patch');
 


### PR DESCRIPTION

For ScienceCCD, its scienceCCDExposureId is the base id which does not contain the filterId, but for DeepCoaddId, it is the baseId + filterId.    For both, I used 
title = id +'_'+filterName.

To test it, please
  1. check it out and build
  2. connect vpn 
  3. start tomcat and then open this the http://localhost:8080/firefly/lsst-pdac-triview.htm
  4. select image, then table name
  5 enter 9.469,-1.152 at the Name or Position text box 

Thanks,