### PR TITLE
DM-8706: catalog search mistakingly brings up an image tab

### DIFF
--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -135,7 +135,7 @@ export function dropDownHandler(layoutInfo, action) {
         case REPLACE_VIEWER_ITEMS :
         case ImagePlotCntlr.PLOT_IMAGE :
         case ImagePlotCntlr.PLOT_IMAGE_START :
-            return updateSet(layoutInfo, 'dropDown.visible', false);
+            return smartMerge(layoutInfo, {dropDown: {visible: false}});
             break;
 
         case SHOW_DROPDOWN:
@@ -143,7 +143,7 @@ export function dropDownHandler(layoutInfo, action) {
         case ImagePlotCntlr.DELETE_PLOT_VIEW:
             if (!get(layoutInfo, 'dropDown.visible', false)) {
                 if (count===0) {
-                    return updateSet(layoutInfo, 'dropDown.visible', true);
+                    return smartMerge(layoutInfo, {dropDown: {visible: true}});
                 }
             }
             break;

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -110,7 +110,7 @@ export function isMetaDataTable(tbl_id) {
     const tableMeta= get(table, 'tableMeta');
     if (!tableMeta) return false;
 
-    if (MetaConst.DATASET_CONVERTER) return true;
+    if (tableMeta[MetaConst.DATASET_CONVERTER]) return true;
     if (tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] || tableMeta[MetaConst.CATALOG_COORD_COLS])  return false;
     const converter= converterFactory(table);
     return Boolean(converter);

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -65,6 +65,7 @@ export function* layoutManager({title, views='tables | images | xyPlots'}) {
                 break;
             case ImagePlotCntlr.DELETE_PLOT_VIEW:
                 newLayoutInfo = handlePlotDelete(newLayoutInfo, action);
+                break;
             case TABLE_LOADED:
             case TBL_RESULTS_ADDED:
                 newLayoutInfo = handleNewTable(newLayoutInfo, action);
@@ -221,7 +222,7 @@ function handleNewImage(layoutInfo, action) {
     var {selectedTab, showMeta, showFits} = images;
     var coverageLockedOn = false;
 
-    const {viewerId, plotGroupId} = action.payload || {};
+    const {viewerId} = action.payload || {};
     if (viewerId === META_VIEWER_ID) {
         // select image meta tab when new images are added.
         selectedTab = 'meta';

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -3,11 +3,10 @@
  */
 
 import {take} from 'redux-saga/effects';
-import {get, filter, omitBy, isNil, isEmpty} from 'lodash';
+import {filter, isEmpty, get} from 'lodash';
 
-import {LO_VIEW, LO_MODE, SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo, dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
-import {clone} from '../../util/WebUtil.js';
-import {findGroupByTblId, getTblIdsByGroup,getActiveTableId} from '../../tables/TableUtil.js';
+import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo, dispatchUpdateLayoutInfo, dropDownHandler} from '../../core/LayoutCntlr.js';
+import {findGroupByTblId, getTblIdsByGroup, smartMerge} from '../../tables/TableUtil.js';
 import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
 import {CHART_ADD, CHART_REMOVE} from '../../charts/ChartsCntlr.js';
 
@@ -15,6 +14,7 @@ import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
 import {isMetaDataTable, isCatalogTable} from '../../metaConvert/converterUtils.js';
 import {META_VIEWER_ID} from '../../visualize/ui/TriViewImageSection.jsx';
 import {REPLACE_VIEWER_ITEMS, DEFAULT_FITS_VIEWER_ID, getViewerItemIds, getMultiViewRoot} from '../../visualize/MultiViewCntlr.js';
+import {visRoot} from '../../visualize/ImagePlotCntlr.js';
 
 /**
  * this manager manages what main components get display on the screen.
@@ -22,196 +22,181 @@ import {REPLACE_VIEWER_ITEMS, DEFAULT_FITS_VIEWER_ID, getViewerItemIds, getMulti
  * This manager implements the default firefly viewer's requirements.
  * Because it may differs between applications, it is okay to have a custom layout manager if needed.
  * @param {object} p
- * @param [p.title] title to display. p
- * @param p.views defaults to tri-view if not given.
+ * @param {string} [p.title] title to display
+ * @param {string} [p.views] defaults to tri-view if not given.
  */
 export function* layoutManager({title, views='tables | images | xyPlots'}) {
     views = LO_VIEW.get(views) || LO_VIEW.none;
-    var coverageLockedOn= false;
 
     while (true) {
         const action = yield take([
             ImagePlotCntlr.PLOT_IMAGE_START, ImagePlotCntlr.PLOT_IMAGE,
             ImagePlotCntlr.DELETE_PLOT_VIEW, REPLACE_VIEWER_ITEMS,
-            TBL_RESULTS_ADDED, TABLE_REMOVE, TABLE_LOADED, CHART_ADD, CHART_REMOVE,
-            SHOW_DROPDOWN, SET_LAYOUT_MODE,
-            TBL_RESULTS_ACTIVE
+            TABLE_REMOVE, TABLE_LOADED, TBL_RESULTS_ADDED, TBL_RESULTS_ACTIVE,
+            CHART_ADD, CHART_REMOVE,
+            SHOW_DROPDOWN, SET_LAYOUT_MODE
         ]);
 
-        var {hasImages, hasTables, hasXyPlots, mode, dropDown={}, ...others} = getLayouInfo();
-        // eslint-disable-next-line
-        var {images, tables, xyPlots} = others;     //images, tables, and xyPlots are additional states relevant only to them.
-        var {expanded, standard} = mode || {};
-        var searchDesc = '';
-        var closeable = true, ignore = false;
-        standard = standard || views;
+        /**
+         * This is the current state of the layout store.  Action handlers should return newLayoutInfo if state changes
+         * If state has changed, it will be dispacthed into the flux.
+         * @type {LayoutInfo} layoutInfo
+         * @prop {boolean}  layoutInfo.showTables  show tables panel
+         * @prop {boolean}  layoutInfo.showXyPlots show charts panel
+         * @prop {boolean}  layoutInfo.showImages  show images panel
+         * @prop {string}   layoutInfo.searchDesc  optional string describing search criteria used to generate this result.
+         * @prop {boolean}  layoutInfo.autoExpand  this is true when manager think it should be expanded, ie. single view
+         * @prop {Object}   layoutInfo.images      images specific states
+         * @prop {string}   layoutInfo.images.metaTableId  tbl_id of the image meta table
+         * @prop {string}   layoutInfo.images.selectedTab  selected tab of the images tabpanel
+         * @prop {string}   layoutInfo.images.showCoverage  show images coverage tab
+         * @prop {string}   layoutInfo.images.showFits  show images fits data tab
+         * @prop {string}   layoutInfo.images.showMeta  show images image metea tab
+         * @prop {string}   layoutInfo.images.coverageLockedOn
+         */
+        var layoutInfo = getLayouInfo();
+        var newLayoutInfo = layoutInfo;
 
-        var showImages = hasImages && views.has(LO_VIEW.images);
-        const showXyPlots = hasXyPlots && views.has(LO_VIEW.xyPlots);
-        const showTables = hasTables && views.has(LO_VIEW.tables);
-
-        const ids = getViewerItemIds(getMultiViewRoot(), DEFAULT_FITS_VIEWER_ID);
-        images = clone(images, {showFits: ids && ids.length > 0});
-
-        // special cases which could affect the layout..
         switch (action.type) {
-            case SHOW_DROPDOWN :
-            case SET_LAYOUT_MODE :
-                ignore = handleLayoutChanges(action);
-                break;
-
-            case TABLE_LOADED :
-                [showImages, images, coverageLockedOn] = handleNewTable(action, images, showImages, showTables, coverageLockedOn);
-                break;
-
-            case REPLACE_VIEWER_ITEMS :
+            case ImagePlotCntlr.PLOT_IMAGE_START:
             case ImagePlotCntlr.PLOT_IMAGE :
-            case ImagePlotCntlr.PLOT_IMAGE_START :
-                [showImages, images, ignore] = handleNewImage(action, images);
+            case REPLACE_VIEWER_ITEMS:
+                newLayoutInfo = handleNewImage(newLayoutInfo, action);
+                break;
+            case ImagePlotCntlr.DELETE_PLOT_VIEW:
+                newLayoutInfo = handlePlotDelete(newLayoutInfo, action);
+            case TABLE_LOADED:
+            case TBL_RESULTS_ADDED:
+                newLayoutInfo = handleNewTable(newLayoutInfo, action);
                 break;
             case TBL_RESULTS_ACTIVE:
-                [showImages, images, coverageLockedOn] = handleActiveTableChange(action.payload.tbl_id, images, coverageLockedOn);
+                newLayoutInfo = handleActiveTableChange(newLayoutInfo, action);
                 break;
-            case TABLE_REMOVE:
-                [showImages, images, coverageLockedOn] = handleActiveTableChange(getActiveTableId(findGroupByTblId(action.payload.tbl_id)), images, coverageLockedOn);
-                break;
-
         }
 
-        if (ignore) continue;  // ignores, don't update layout.
+        newLayoutInfo = onAnyAction(newLayoutInfo, action, views);
+        newLayoutInfo = dropDownHandler(newLayoutInfo, action);     // handles dropdown behaviors
 
-        const count = filter([showTables, showXyPlots, showImages]).length;
+        if (newLayoutInfo !== layoutInfo) {
+            dispatchUpdateLayoutInfo(newLayoutInfo);
 
-        // change mode when new UI elements are added or removed from results
-        switch (action.type) {
-            case CHART_ADD:
-            case TBL_RESULTS_ADDED:
-            case TABLE_LOADED:
-            case REPLACE_VIEWER_ITEMS :
-            case ImagePlotCntlr.PLOT_IMAGE :
-            case ImagePlotCntlr.PLOT_IMAGE_START :
-            case CHART_REMOVE:
-            case TABLE_REMOVE:
-            case ImagePlotCntlr.DELETE_PLOT_VIEW:
-                if (count === 1) {
-                    // set mode into expanded view when there is only 1 component visible.
-                    closeable = false;
-                    expanded =  showImages ? LO_VIEW.images :
-                        showXyPlots ? LO_VIEW.xyPlots :
-                            showTables ? LO_VIEW.tables :  expanded;
-                } else {
+        }
+    }
+}
+
+function onAnyAction(layoutInfo, action, views) {
+    var {mode, hasXyPlots, hasTables, showImages, showXyPlots, showTables, autoExpand} = layoutInfo;
+    var {expanded=LO_VIEW.none, standard=views} = mode || {};
+
+    console.log('showTables:' + showTables + '  hasTables:' + hasTables);
+    // enforce views settings
+    showImages =  showImages && views.has(LO_VIEW.images);
+    showXyPlots = hasXyPlots && views.has(LO_VIEW.xyPlots);
+    showTables =  hasTables && views.has(LO_VIEW.tables) && showTables;
+
+    const count = filter([showTables, showXyPlots, showImages]).length;
+    const closeable = count > 1;
+
+    switch (action.type) {
+        case TABLE_REMOVE:
+        case TBL_RESULTS_ADDED:
+        case REPLACE_VIEWER_ITEMS:
+        case ImagePlotCntlr.PLOT_IMAGE_START :
+        case ImagePlotCntlr.DELETE_PLOT_VIEW:
+        case CHART_ADD:
+        case CHART_REMOVE:
+        {
+            // handle autoExpand feature
+            if (autoExpand) {
+                if (count > 1) {
+                    autoExpand = false;
                     expanded = LO_VIEW.none;
                 }
-                mode = {expanded, standard, closeable};
-                break;
+            } else if (expanded === LO_VIEW.none && count === 1) {
+                // set mode into expanded view when there is only 1 component visible.
+                autoExpand = true;
+                autoExpand = true;
+                expanded =  showImages ? LO_VIEW.images :
+                    showXyPlots ? LO_VIEW.xyPlots :
+                        showTables ? LO_VIEW.tables :  expanded;
+            }
+            mode = {expanded, standard, closeable};
+            break;
         }
-
-
-        // calculate dropDown when new UI elements are added or removed from results
-        switch (action.type) {
-            case CHART_ADD:
-            case TBL_RESULTS_ADDED:
-            case TABLE_LOADED:
-            case REPLACE_VIEWER_ITEMS :
-            case ImagePlotCntlr.PLOT_IMAGE :
-            case ImagePlotCntlr.PLOT_IMAGE_START :
-                dropDown = {visible: count === 0};
-                break;
-            case SHOW_DROPDOWN:
-            case CHART_REMOVE:
-            case TABLE_REMOVE:
-            case ImagePlotCntlr.DELETE_PLOT_VIEW:
-                if (!get(dropDown, 'visible', false)) {
-                    dropDown = {visible: count === 0};
-                }
-                break;
-        }
-
-        dispatchUpdateLayoutInfo(omitBy({title, views, mode, searchDesc, dropDown, showTables, showImages, showXyPlots, images}, isNil));
     }
+    return smartMerge(layoutInfo, {showTables, showImages, showXyPlots, autoExpand, mode: {expanded, standard, closeable}});
 }
+    
 
-function handleLayoutChanges(action) {
-    if ((action.type === SHOW_DROPDOWN && get(action, 'payload.visible', true)) ||
-        (action.type === SET_LAYOUT_MODE && get(action, 'payload.mode') === LO_MODE.expanded)) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-function handleNewTable(action, images, showImages, showTables, coverageLockedOn) {
-
+function handleNewTable(layoutInfo, action) {
     const {tbl_id} = action.payload;
-
-    // check for catalog or meta images
-    if (!showTables) return [showImages, images, coverageLockedOn];        // ignores this if table is not visible
+    var {images, showImages} = layoutInfo;
+    var {coverageLockedOn, showFits, showMeta, showCoverage, selectedTab, metaDataTableId} = images || {};
 
     const isMeta = isMetaDataTable(tbl_id);
     if (isMeta || isCatalogTable(tbl_id)) {
-        if (!get(images, 'showFits')) {
-                          // only show coverage if there are not images or coverage is showing
-            const showFits= shouldShowFits();
+        if (!showFits) {
+            // only show coverage if there are not images or coverage is showing
+            showFits= shouldShowFits();
             coverageLockedOn= !showFits||coverageLockedOn;
-            images = clone(images, {selectedTab: 'coverage', showCoverage: coverageLockedOn});
+            selectedTab = 'coverage';
+            showCoverage = coverageLockedOn;
             showImages = true;
         }
     }
     if (isMeta) {
-        images = clone(images, {selectedTab: 'meta', showMeta: true, metaDataTableId: tbl_id});
         showImages = true;
+        selectedTab = 'meta';
+        showMeta = true;
+        metaDataTableId = tbl_id;
     }
-    return [showImages, images, coverageLockedOn];
+    return smartMerge(layoutInfo, {showTables: true, showImages, images: {coverageLockedOn, showFits, showMeta, showCoverage, selectedTab, metaDataTableId}});
 }
 
-function handleActiveTableChange (tbl_id, images, coverageLockedOn) {
-    // check for catalog or meta images
+
+function handleActiveTableChange (layoutInfo, action) {
+    const {tbl_id} = action.payload;
+    var {images, showImages} = layoutInfo;
+    var {coverageLockedOn, showCoverage, showMeta, metaDataTableId} = images;
 
     const showFits= shouldShowFits();
-
-    var showImages= showFits||coverageLockedOn;
+    showImages= showFits||coverageLockedOn;
 
     if (!tbl_id) {
-        images = clone(images, {showMeta: false, showCoverage: false, showFits, metaDataTableId: null});
-        return [showFits, images, false];
+        images = {showMeta: false, showCoverage: false, showFits, metaDataTableId: null};
+        return smartMerge(layoutInfo, {images, showImages:showFits, coverageLockedOn:false});
     }
 
     const tblGroup= findGroupByTblId(tbl_id);
-    if (!tblGroup) return [showImages, images, coverageLockedOn];
-    const tblList= getTblIdsByGroup(tblGroup);
-    if (isEmpty(tblList)) return [showImages, images, coverageLockedOn];
+    if (!tblGroup) return smartMerge(layoutInfo, {showImages});
 
+    const tblList= getTblIdsByGroup(tblGroup);
+    if (isEmpty(tblList)) return smartMerge(layoutInfo, {showImages});
+
+    // check for catalog or meta images
     const anyHasCatalog= hasCatalogTable(tblList);
     const anyHasMeta= hasMetaTable(tblList);
 
     if (coverageLockedOn) {
         coverageLockedOn= anyHasCatalog || anyHasMeta;
-        showImages= showFits || coverageLockedOn;
     }
 
-    if (!anyHasCatalog && !anyHasMeta) {
-        coverageLockedOn= false;
-        showImages= showFits || coverageLockedOn;
-        images = clone(images, {showMeta: false, showCoverage: false, showFits, metaDataTableId: null});
-        return [showFits, images, coverageLockedOn];
-    }
-
-
-
-    if (hasCatalogTable(tblList)) {
-        images = clone(images, {showCoverage: coverageLockedOn, showFits});
+    if (anyHasCatalog) {
+        showCoverage = coverageLockedOn;
         showImages = true;
+    } else {
+        showCoverage = false;
     }
 
-    if (hasMetaTable(tblList)) {
-        const metaTableId= isMetaDataTable(tbl_id) ? tbl_id : findFirstMetaTable(tblList);
-        images = clone(images, {showMeta: true, showFits, metaDataTableId:metaTableId});
+    if (anyHasMeta) {
+        metaDataTableId = isMetaDataTable(tbl_id) ? tbl_id : findFirstMetaTable(tblList);
+        showMeta = true;
         showImages = true;
+    } else {
+        metaDataTableId = null;
+        showMeta = false;
     }
-    else {
-        images = clone(images, {showMeta: false, showFits, metaTableId:null});
-    }
-    return [showImages, images, coverageLockedOn];
+    return smartMerge(layoutInfo, {images: {coverageLockedOn, showCoverage, showMeta, metaDataTableId}, showImages, coverageLockedOn});
 }
 
 const hasCatalogTable= (tblList) => tblList.some( (id) => isCatalogTable(id) );
@@ -220,19 +205,33 @@ const findFirstMetaTable= (tblList) => tblList.find( (id) => isMetaDataTable(id)
 const shouldShowFits= () => !isEmpty(getViewerItemIds(getMultiViewRoot(), DEFAULT_FITS_VIEWER_ID));
 
 
+function handlePlotDelete(layoutInfo, action) {
+    var {images, showImages} = layoutInfo;
+    var {coverageLockedOn} = images || {};
+    const showFits = shouldShowFits();
+    if (!get(visRoot(), 'plotViewAry.length', 0)) {
+        coverageLockedOn = false;
+        showImages = false;
+    }
+    return smartMerge(layoutInfo, {showImages, images:{coverageLockedOn, showFits}});
+}
 
-function handleNewImage(action, images) {
-    var ignore = false;
+function handleNewImage(layoutInfo, action) {
+    var {images} = layoutInfo;
+    var {selectedTab, showMeta, showFits} = images;
+    var coverageLockedOn = false;
+
     const {viewerId, plotGroupId} = action.payload || {};
     if (viewerId === META_VIEWER_ID) {
         // select image meta tab when new images are added.
-        images = clone(images, {selectedTab: 'meta', showMeta: true});
+        selectedTab = 'meta';
+        showMeta = true;
     } else if (viewerId === DEFAULT_FITS_VIEWER_ID) {
         // select image tab when new images are added.
-        images = clone(images, {selectedTab: 'fits', showFits: true});
+        selectedTab = 'fits';
+        showFits = true;
     } else {
-        ignore = true;
+        coverageLockedOn = true;
     }
-
-    return [true, images, ignore];
+    return smartMerge(layoutInfo, {showImages: true, images: {coverageLockedOn, selectedTab, showMeta, showFits}});
 }

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -71,12 +71,12 @@ export function* lcManager(params={}) {
         ]);
 
         /**
-         * This is the current state of the application.  Action handlers should return newLayoutInfo if state changes
+         * This is the current state of the layout store.  Action handlers should return newLayoutInfo if state changes
          * If state has changed, it will be dispacthed into the flux.
-         * @type {LayoutInfo}
+         * @type {LayoutInfo}   layoutInfo
          * @prop {boolean}  layoutInfo.showForm    show form panel
          * @prop {boolean}  layoutInfo.showTables  show tables panel
-         * @prop {boolean}  layoutInfo.showCharts  show charts panel
+         * @prop {boolean}  layoutInfo.showXyPlots show charts panel
          * @prop {boolean}  layoutInfo.showImages  show images panel
          * @prop {string}   layoutInfo.searchDesc  optional string describing search criteria used to generate this result.
          * @prop {Object}   layoutInfo.images      images specific states


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-8706

also fixed:
 - DM-8602: Cols link does not work when launched from "Charts" popup.
 - when no image available, remove fits data tabs
 - drop down menu when there’s nothing in the results after the last component has been removed.

Test:
use firefly-dev.html page for testing for additional functions, ie.  image meta search