### PR TITLE
DM-8668 lc period finder

### DIFF
--- a/src/firefly/html/lc.html
+++ b/src/firefly/html/lc.html
@@ -13,7 +13,6 @@
                 template: 'LightCurveViewer',
                 menu: [
                     {label:'Upload', action:'LCUpload'},
-                    {label:'Catalogs', action:'IrsaCatalogDropDown'},
                     {label:'Help', action:'app_data.helpLoad', type:'COMMAND'},
                     ]
             },

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -24,6 +24,7 @@ export const LO_MODE = new Enum(['expanded', 'standard']);
 export const SET_LAYOUT         = `${LAYOUT_PATH}.setLayout`;
 export const SET_LAYOUT_MODE    = `${LAYOUT_PATH}.setLayoutMode`;
 export const SHOW_DROPDOWN      = `${LAYOUT_PATH}.showDropDown`;
+export const SET_LAYOUT_DISPLAY = `${LAYOUT_PATH}.showPage`;
 
 /*---------------------------- Reducers ----------------------------*/
 
@@ -45,6 +46,10 @@ export function reducer(state={}, action={}) {
             var {visible = true} = action.payload;
             return smartMerge(state, {dropDown: {visible, view: getSelView(state, action.payload)}});
 
+        case SET_LAYOUT_DISPLAY :
+            var {displayMode} = action.payload;
+
+            return smartMerge(state, {displayMode});
         default:
             return state;
     }
@@ -85,6 +90,10 @@ export function dispatchHideDropDown() {
     flux.process({type: SHOW_DROPDOWN, payload: {visible: false}});
 }
 
+
+export function dispatchLayoutDisplayMode(mode) {
+    flux.process({type: SET_LAYOUT_DISPLAY, payload: {displayMode: mode}});
+}
 
 /*------------------------- Util functions -------------------------*/
 export function getExpandedMode() {

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -24,7 +24,6 @@ export const LO_MODE = new Enum(['expanded', 'standard']);
 export const SET_LAYOUT         = `${LAYOUT_PATH}.setLayout`;
 export const SET_LAYOUT_MODE    = `${LAYOUT_PATH}.setLayoutMode`;
 export const SHOW_DROPDOWN      = `${LAYOUT_PATH}.showDropDown`;
-export const SET_LAYOUT_DISPLAY = `${LAYOUT_PATH}.showPage`;
 
 /*---------------------------- Reducers ----------------------------*/
 
@@ -46,10 +45,6 @@ export function reducer(state={}, action={}) {
             var {visible = true} = action.payload;
             return smartMerge(state, {dropDown: {visible, view: getSelView(state, action.payload)}});
 
-        case SET_LAYOUT_DISPLAY :
-            var {displayMode} = action.payload;
-
-            return smartMerge(state, {displayMode});
         default:
             return state;
     }
@@ -90,10 +85,6 @@ export function dispatchHideDropDown() {
     flux.process({type: SHOW_DROPDOWN, payload: {visible: false}});
 }
 
-
-export function dispatchLayoutDisplayMode(mode) {
-    flux.process({type: SET_LAYOUT_DISPLAY, payload: {displayMode: mode}});
-}
 
 /*------------------------- Util functions -------------------------*/
 export function getExpandedMode() {
@@ -144,7 +135,7 @@ export function dropDownHandler(layoutInfo, action) {
         case REPLACE_VIEWER_ITEMS :
         case ImagePlotCntlr.PLOT_IMAGE :
         case ImagePlotCntlr.PLOT_IMAGE_START :
-            return updateSet(layoutInfo, 'dropDown.visible', false);
+            return smartMerge(layoutInfo, {dropDown: {visible: false}});
             break;
 
         case SHOW_DROPDOWN:
@@ -152,7 +143,7 @@ export function dropDownHandler(layoutInfo, action) {
         case ImagePlotCntlr.DELETE_PLOT_VIEW:
             if (!get(layoutInfo, 'dropDown.visible', false)) {
                 if (count===0) {
-                    return updateSet(layoutInfo, 'dropDown.visible', true);
+                    return smartMerge(layoutInfo, {dropDown: {visible: true}});
                 }
             }
             break;

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -55,7 +55,7 @@ export class TablesContainer extends Component {
     render() {
         const {closeable, tbl_group, expandedMode, tables, layout, active} = this.state;
         if (expandedMode) {
-            return <ExpandedView {...{active, tables, layout, expandedMode, closeable}} />;
+            return <ExpandedView {...{active, tables, layout, expandedMode, closeable, tbl_group}} />;
         } else {
             return isEmpty(tables) ? <div></div> : <StandardView {...{active, tables, expandedMode, tbl_group}} />;
         }

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -1,0 +1,879 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {Component, PropTypes} from 'react';
+
+import sCompare from 'react-addons-shallow-compare';
+import {cloneDeep, get, set, omit, slice, replace, pick} from 'lodash';
+import SplitPane from 'react-split-pane';
+import {flux} from '../../Firefly.js';
+import CompleteButton from '../../ui/CompleteButton.jsx';
+import {FormPanel} from './../../ui/FormPanel.jsx';
+import {DEC_PHASE} from '../../ui/RangeSliderView.jsx';
+import {InputGroup} from '../../ui/InputGroup.jsx';
+import {doUpload} from '../../ui/FileUpload.jsx';
+import {RangeSlider}  from '../../ui/RangeSlider.jsx';
+import {FieldGroup} from '../../ui/FieldGroup.jsx';
+import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
+import {ValidationField} from '../../ui/ValidationField.jsx';
+import {showInfoPopup} from '../../ui/PopupUtil.jsx';
+import {createContentWrapper} from '../../ui/panel/DockLayoutPanel.jsx';
+import Validate from '../../util/Validate.js';
+import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
+import {sortInfoString} from '../../tables/SortInfo.js';
+import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
+import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
+import {dispatchRestoreDefaults} from '../../fieldGroup/FieldGroupCntlr.js';
+import {makeTblRequest,getTblById, tableToText, makeFileRequest} from '../../tables/TableUtil.js';
+import {LC} from './LcManager.js';
+import {LcPeriodogram, pKeyDef} from './LcPeriodogram.jsx';
+import {dispatchLayoutDisplayMode, LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
+import ReactHighcharts from 'react-highcharts';
+
+const pfinderkey = LC.PERIOD_FINDER;
+
+
+
+export function getTypeData(key, val='', tip = '', labelV='', labelW) {
+    return {
+        fieldKey: key,
+        label: labelV,
+        value: val,
+        tooltip: tip,
+        labelWidth: labelW
+    };
+}
+
+const cPeriodKeyDef = {
+    time: {fkey: 'time', label: 'Time Column'},
+    flux: {fkey: 'flux', label: 'Flux Column'},
+    min: {fkey: 'periodMin', label: 'Period Min'},
+    max: {fkey: 'periodMax', label: 'Period Max'},
+    timecols: {fkey: 'timeCols', label: ''},
+    fluxcols: {fkey: 'fluxCols', label: ''}
+};
+
+const fKeyDef = Object.assign({}, cPeriodKeyDef,
+                                {tz: {fkey: 'tzero', label: 'Zero Point Time'},
+                                period: {fkey: 'period', label: 'Period (day)'},
+                                periodsteps: {fkey: 'periodSteps', label: ''},
+                                tzmax: {fkey: 'tzeroMax', label: ''}});
+
+const STEP = 1;     // step for slider
+export const validTimeSuggestions = ['mjd'];      // suggestive time column name
+export const validFluxSuggestions = ['w1mpro_ep', 'w2mpro_ep', 'w3mpro_ep', 'w4mpro_ep'];
+const Margin = 0.2;
+const DEC = 8;       // decimal digit
+
+const defValues= {
+    [fKeyDef.time.fkey]: Object.assign(getTypeData(fKeyDef.time.fkey, '',
+        'time column name',
+        `${fKeyDef.time.label}:`, 100),
+        {validator:  (val) => {
+            let retVal = {valid: true, message: ''};
+            if (!validTimeSuggestions.includes(val)) {
+                retVal = {valid: false, message: `${val} is not a valid time column`};
+            }
+            return retVal;
+        }}),
+    [fKeyDef.flux.fkey]: Object.assign(getTypeData(fKeyDef.flux.fkey, '',
+        'flux column name', `${fKeyDef.flux.label}:`, 100),
+        {validator:  (val) => {
+            let retVal = {valid: true, message: ''};
+            if (!validFluxSuggestions.includes(val)) {
+                retVal = {valid: false, message: `${val} is not a valid flux column`};
+            }
+            return retVal;
+        }}),
+    [fKeyDef.tz.fkey]: Object.assign(getTypeData(fKeyDef.tz.fkey, '', 'zero time', `${fKeyDef.tz.label}:`, 100),
+        {validator: null}),
+    [fKeyDef.tzmax.fkey]: Object.assign(getTypeData(fKeyDef.tzmax.fkey, '', 'maximum for zero time'),
+        {validator: null}),
+    [fKeyDef.min.fkey]: Object.assign(getTypeData(fKeyDef.min.fkey, '', 'minimum period', `${fKeyDef.min.label}:`, 50),
+        {validator: null}),
+    [fKeyDef.max.fkey]: Object.assign(getTypeData(fKeyDef.max.fkey, '', 'maximum period', `${fKeyDef.max.label}:`, 50),
+        {validator: null}),
+    [fKeyDef.period.fkey]: Object.assign(getTypeData(fKeyDef.period.fkey, '', '', `${fKeyDef.period.label}:`, 100),
+        {validator: null}),
+    [fKeyDef.timecols.fkey]: Object.assign(getTypeData(fKeyDef.timecols.fkey, [],  'time column suggestion'),
+        {validator: null}),
+    [fKeyDef.fluxcols.fkey]: Object.assign(getTypeData(fKeyDef.fluxcols.fkey, [],  'flux column suggestion'),
+        {validator: null}),
+    [fKeyDef.periodsteps.fkey]: Object.assign(getTypeData(fKeyDef.periodsteps.fkey, '3',  'total period steps'),
+        {validator: Validate.intRange.bind(null, 1, 2000, 'period total step')})
+};
+
+var currentPhaseFoldedTable;   // table with phase column
+var periodRange;
+var SliderMin = 0.0;
+var periodErr;       // error message for period setting
+var timeErr;         // error message for time zero setting
+
+
+const PanelResizableStyle = {
+    width: 550,
+    minWidth: 400,
+    height: 300,
+    minHeight: 300,
+    marginLeft: 15,
+    overflow: 'auto',
+    padding: '2px'
+};
+
+
+export class LcPeriod extends Component {
+
+    constructor(props) {
+        super(props);
+        this.state = pick(getLayouInfo(), ['mode']);
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+    componentDidMount() {
+        this.iAmMounted = true;
+        this.removeListener = flux.addListener(() => this.storeUpdate());
+    }
+
+    componentWillUnmount() {
+        this.removeListener && this.removeListener();
+    }
+
+    storeUpdate() {
+        if (this && this.iAmMounted) {
+            const nextState = pick(getLayouInfo(), ['mode']);
+            var stateMode = get(this.state, 'mode', null);
+            var nextMode = get(nextState, 'mode', null);
+
+            if (!stateMode && !nextMode && stateMode !== nextMode) {
+               this.setState(nextState);
+            }
+        }
+    }
+
+
+    render() {
+        const {display} = this.props;
+        const {mode} = this.state;
+        var {expanded, standard} = mode || {};
+
+        expanded = LO_VIEW.get(expanded) || LO_VIEW.none;
+        var standardProps = {...this.props};
+
+        return (
+            expanded === LO_VIEW.none
+                ? <PeriodStandardView key='res-std-view' {...standardProps} />
+                : <PeriodExpandedView key='res-exp-view' expanded={expanded} display={display}/>
+        );
+    }
+}
+
+
+LcPeriod.propTypes = {
+    timeColName: PropTypes.string,
+    fluxColName: PropTypes.string,
+    validTimeColumns: PropTypes.arrayOf(PropTypes.string),
+    validFluxColumns: PropTypes.arrayOf(PropTypes.string),
+    display: PropTypes.string
+};
+
+LcPeriod.defaultProps = {
+    timeColName: 'mjd',
+    fluxColName: validFluxSuggestions[0],
+    validTimeColumns: validTimeSuggestions,
+    validFluxColumns: validFluxSuggestions,
+    display: 'period'
+};
+
+const PeriodStandardView = (props) => {
+    const {display} = props;
+    var fields = FieldGroupUtils.getGroupFields(pfinderkey);
+    var initState = {};
+
+    if (!fields) {
+        var {timeColName:time, fluxColName:flux, validTimeColumns:timeCols, validFluxColumns:fluxCols} = props;
+        periodRange = computePeriodRange(LC.RAW_TABLE, time);
+        periodErr = `Period error: must be a float and not less than ${periodRange.min} (day)`;
+        timeErr = `time zero error: must be a float and within [0.0, ${periodRange.tzeroMax}]`;
+
+        initState = Object.assign({time, flux, timeCols, fluxCols}, {...periodRange});
+    }
+
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column', flexGrow: 1, position: 'relative'}}>
+            <div style={{flexGrow: 1, position: 'relative'}}>
+                <div style={{position: 'absolute', top: 0, right: 0, bottom: 0, left: 0}}>
+                    <FieldGroup groupKey={pfinderkey}
+                                reducerFunc={LcPFReducer(initState)}  keepState={true}>
+                    <SplitPane split='horizontal' minSize={100} defaultSize={'90%'}>
+                        <SplitPane split='vertical' minSize={20} defaultSize={PanelResizableStyle.width}>
+                            <SplitPane split='horizontal' minSize={20} defaultSize={'45%'}>
+                                {createContentWrapper(<LcPFOptionsBox />)}
+                                {createContentWrapper(<PhaseFoldingChart height={350}
+                                                                         width={PanelResizableStyle.width}/>)}
+                            </SplitPane>
+                            {createContentWrapper(<LcPeriodogram display={display} groupKey={pfinderkey}/>)}
+                        </SplitPane>
+                        <div style={{height: 20, marginTop: 5, marginBottom: 5, display: 'flex'}}>
+                            <CompleteButton
+                                groupKey={[pfinderkey]}
+                                onSuccess={setPFTableSuccess()}
+                                onFail={setPFTableFail()}
+                                text={'Phase Folded Table'}
+                            />
+                            <button type='button' className='button std hl' onClick={cancelPeriodSetting()}>
+                                Cancel
+                            </button>
+                        </div>
+                    </SplitPane>
+                    </FieldGroup>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const PeriodExpandedView = ({expanded, display}) => {
+    const expandedProps = {expanded, display, groupKey: pfinderkey};
+
+    return (
+        <div>
+            <LcPeriodogram  {...expandedProps} />
+        </div>
+    );
+};
+
+/**
+ * @summary 2D xyplot component on phase folding panel
+ */
+class PhaseFoldingChart extends Component {
+    constructor(props) {
+        super(props);
+
+        var fields = FieldGroupUtils.getGroupFields(pfinderkey);
+        var {width, height, showTooltip=true} = props;
+        var {data, minPhase = 0.0, period, flux} = getPhaseFlux(fields);
+
+        this.state = {
+            fields,
+            config: {
+                chart: {
+                    type: 'scatter',
+                    borderColor: '#a5a5a5',
+                    borderWidth: 1,
+                    borderRadius: 5,
+                    zoomType: 'xy',
+                    height,
+                    width
+                },
+                title: {
+                    fontSize: '16px',
+                    text: period ? `period=${period}(day)`:'period='
+                },
+                xAxis: {
+                    min: minPhase - Margin,
+                    max: minPhase + 2.0 + Margin,
+                    title: {text: `${LC.PHASE_CNAME}`},
+                    gridLineWidth: 1,
+                    gridLineColor: '#e9e9e9'
+                },
+                yAxis: {
+                    title: {text: `${flux}(mag)`},
+                    lineWidth: 1,
+                    tickWidth: 1,
+                    tickLength: 10,
+                    gridLineColor: '#e9e9e9'
+                },
+                tooltip: showTooltip ? {enabled: true,
+                    formatter() {
+                        return ('<span>' +
+                        `${LC.PHASE_CNAME} = ${this.x.toFixed(DEC_PHASE)} <br/>` +
+                        `${flux} = ${this.y} mag <br/>` +
+                        '</span>');
+                    }}
+                    : {enabled: false},
+                series: [{
+                    showInLegend: false,
+                    marker: {radius: 2},
+                    color: 'blue',
+                    data
+                }],
+                credits: {
+                    enabled: false // removes a reference to Highcharts.com from the chart
+                }
+            }
+        };
+    }
+
+    shouldComponentUpdate(np,ns) {
+        return (this.props !== np) || (this.state.fields !== ns.fields);
+    }
+
+    componentWillUnmount() {
+        this.iAmMounted = false;
+        if (this.unbinder) this.unbinder();
+    }
+
+    componentDidMount() {
+        var isPhaseChanged = (newFields) => {
+            var fieldsToCheck = ['time', 'flux', 'tz', 'period'];
+            var fieldsInfo = fieldsToCheck.map((f) => {
+                return [get(newFields, [fKeyDef[f].fkey, 'value'], ''),
+                    get(this.state.fields, [fKeyDef[f].fkey, 'value'], '')];
+            });
+
+            var idx = fieldsToCheck.findIndex((f, idx) => {
+                return !fieldsInfo[idx][0] || (fieldsInfo[idx][0] !== fieldsInfo[idx][1]);
+            });
+
+            return (idx !== -1);
+        };
+
+        this.iAmMounted = true;
+        var  chart = this.refs.chart.getChart();
+
+        this.unbinder= FieldGroupUtils.bindToStore(pfinderkey, (fields) => {
+            if (this && this.iAmMounted && isPhaseChanged(fields, this.state.fields)) {
+                this.setState({fields});
+
+                var {data, minPhase = 0.0, period, flux} = getPhaseFlux(fields);
+                chart.setTitle({text: period ? `period=${period}(day)`:'period='});
+                chart.series[0].setData(data);
+                chart.xAxis[0].update({min: minPhase - Margin,
+                    max: minPhase + 2.0 + Margin});
+                chart.yAxis[0].setTitle({text: `${flux}(mag)`});
+            }
+        });
+    }
+
+    render() {
+        //console.log('rerender hicharts');
+        return (
+            <div>
+                <ReactHighcharts config={this.state.config} isPureConfig={true} ref='chart'/>
+            </div>
+        );
+    }
+
+}
+
+
+/**
+ * @summary get flux series in terms of folded phase
+ * @param {Object} fields
+ * @returns {*}
+ */
+function getPhaseFlux(fields) {
+    var rawTable = getTblById(LC.RAW_TABLE);
+    var {columns, data} = rawTable.tableData;    // column names and data
+
+    var {time, period, tzero, flux} = fields;
+    const tc = time ? time.value : '';
+    const fc = flux ? flux.value: '';
+    const tIdx = tc ? columns.findIndex((c) => (c.name === tc)) : -1;  // find time column
+    const fIdx = fc ? columns.findIndex((c) => (c.name === fc)) : -1;  // find flux column
+
+    if (tIdx < 0 || fIdx < 0) return {};
+
+    var pd, tz;
+
+    if (period){
+        if (!period.valid) return {};    // invalid period
+        pd = parseFloat(period.value);
+    } else {
+        pd = periodRange.min;
+    }
+    if (tzero) {
+        if (!tzero.valid) return {};      // invalid period
+        tz = parseFloat(tzero.value);
+    } else {
+        tz = periodRange.tzero;
+    }
+
+    var phaseV = data.map((d) => {
+        return parseFloat(getPhase(d[tIdx], tz, pd));
+    });
+
+    var minPhase = Math.min(...phaseV);
+    var maxPhase = Math.max(...phaseV) + 1.0;
+
+    var xy = data.reduce((prev, d, idx) => {
+        var phase1, phase2, fluxV;
+
+        fluxV = parseFloat(d[fIdx]);
+        phase1 = phaseV[idx];
+        phase2 = phase1 + 1.0;
+        prev.push([phase1, fluxV], [phase2, fluxV]);
+
+        return prev;
+    }, []);
+
+    return Object.assign({data: xy}, {minPhase, maxPhase, period: pd.toFixed(DEC_PHASE), flux: fc});
+}
+
+
+/**
+ * @summary Phase folding panel component for setting parameters
+ */
+class LcPFOptionsBox extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {fields: FieldGroupUtils.getGroupFields(pfinderkey)};
+    }
+
+    componentWillUnmount() {
+        this.iAmMounted= false;
+        if (this.unbinder) this.unbinder();
+    }
+
+
+    componentDidMount() {
+        this.iAmMounted= true;
+        this.unbinder= FieldGroupUtils.bindToStore(pfinderkey, (fields) => {
+            if (this && this.iAmMounted && fields!==this.state.fields) {
+                this.setState({fields});
+            }
+        });
+    }
+
+    render() {
+        var {fields} = this.state;
+
+        return (
+            <div style={PanelResizableStyle}>
+                <LcPFOptions {...fields}/>
+            </div>
+        );
+
+    }
+}
+
+function LcPFOptions(fields) {
+
+    const {periodMax, periodMin, period} = fields || {};
+
+    if ((!periodMin || !periodMin || !period)) return <span />;
+    const step = STEP;
+    var min = parseFloat(parseFloat(periodMin.value).toFixed(DEC_PHASE)); // number
+    var max = parseFloat(periodMax.value);
+
+    max = adjustMax(max, SliderMin, step).max;    // number
+
+    function  markStyle(per, val) {
+        return {style: {left: `${per}%`, marginLeft: -16, width: 40}, label: `${val}`};
+    }
+
+    var getMarks = (sliderMin, sliderMax, noMarks) => {
+        const sliderSize = sliderMax - sliderMin;
+        const intMark = (sliderSize)/(noMarks - 1);
+
+        // min sits at the first mark, all other marks evenly spread on the slider
+        var marks = Object.assign({}, {[min]: markStyle(100*(min-sliderMin)/sliderSize, min)});
+
+        // make an array like [0, 1, 2, ...] and produce marks between two ends of sRange
+        marks = [...Array(noMarks).keys()].slice(1).reduce((prev, m) => {
+            var val = parseFloat((intMark * m + sliderMin).toFixed(DEC_PHASE));
+            var per = 100*(val - sliderMin)/sliderSize;
+
+            prev = Object.assign(prev, {[val]: markStyle(per, val)});
+            return prev;
+        }, marks);
+
+        return marks;
+    };
+
+    const NOMark = 5;
+    const sRange = [SliderMin, max];
+    var marks = getMarks(sRange[0], sRange[1], NOMark);
+
+
+    //var step = periodSteps ? (max - min)/periodSteps.value : (max-min)/periodRange.steps;
+
+    return (
+
+            <InputGroup labelWidth={110}>
+                <SuggestBoxInputField
+                    fieldKey={fKeyDef.time.fkey}
+                    getSuggestions = {(val)=>{
+                            const suggestions = validTimeSuggestions.filter((el)=>{return el.startsWith(val);});
+                            return suggestions.length > 0 ? suggestions : validTimeSuggestions;
+                        }}
+
+                />
+                <br/>
+                <SuggestBoxInputField
+                    fieldKey={fKeyDef.flux.fkey}
+                    getSuggestions = {(val)=>{
+                            const suggestions = validFluxSuggestions.filter((el)=>{return el.startsWith(val);});
+                            return suggestions.length > 0 ? suggestions : validFluxSuggestions;
+                        }}
+
+                />
+                <br/>
+                <ValidationField fieldKey={fKeyDef.tz.fkey} />
+                <br/>
+
+                <RangeSlider fieldKey={fKeyDef.period.fkey}
+                             min={sRange[0]}
+                             max={sRange[1]}
+                             minStop={min}
+                             maxStop={max}
+                             marks={marks}
+                             step={step}
+                             tooptip={'slide to set period value'}
+                             value={period.value}
+                             defaultValue={min}
+                             wrapperStyle={{marginBottom: 20, width: PanelResizableStyle.width*3/4}}
+                             sliderStyle={{marginLeft: 10, marginTop: 20}}
+                />
+                <br/>
+                <br/>
+                <div style={{display: 'flex'}}>
+                    <ValidationField fieldKey={fKeyDef.min.fkey} />
+                    <ValidationField fieldKey={fKeyDef.max.fkey} />
+                </div>
+                <br/>
+                <ValidationField fieldKey={fKeyDef.period.fkey} />
+                <br/>
+                <div style={{marginTop: 15}}>
+                    <button type='button' className='button std hl'  onClick={() => resetDefaults()}>
+                        <b>Reset</b>
+                    </button>
+                </div>
+                <br/>
+            </InputGroup>
+    );
+}
+
+LcPFOptions.propTypes = {
+    fields: PropTypes.object
+};
+
+/**
+ * @summary phase folding parameter reducer  // TODO: not sure how this works
+ * @param {object} initState
+ * @return {object}
+ */
+var LcPFReducer= (initState) => {
+        return (inFields, action) => {
+            if (!inFields) {
+                var defV = Object.assign({}, defValues);
+                            defV.periodSteps.value = periodRange.steps;
+                const {min, max, time, flux, timeCols, fluxCols, tzero, steps, tzeroMax} = initState || {};
+                set(defV, [fKeyDef.min.fkey, 'value'], `${min}`);
+                set(defV, [fKeyDef.max.fkey, 'value'], `${max}`);
+                set(defV, [fKeyDef.time.fkey, 'value'], time);
+                set(defV, [fKeyDef.flux.fkey, 'value'], flux);
+                set(defV, [fKeyDef.period.fkey, 'value'], `${min}`);
+                set(defV, [fKeyDef.tz.fkey, 'value'], `${tzero}`);
+                set(defV, [fKeyDef.timecols.fkey, 'value'], timeCols);
+                set(defV, [fKeyDef.fluxcols.fkey, 'value'], fluxCols);
+                set(defV, [fKeyDef.periodsteps.fkey, 'value'], `${steps}`);
+                set(defV, [fKeyDef.tzmax.fkey, 'value'], `${tzeroMax}`);
+
+                set(defV, [fKeyDef.period.fkey, 'tooltip'], `Period for phase folding, within [${min} (i.e. 1 sec), ${max}(suggestion)]`);
+                set(defV, [fKeyDef.tz.fkey, 'tooltip'], `time zero, within [0.0, ${tzeroMax}`);
+
+                set(defV, [fKeyDef.min.fkey, 'validator'], periodMinValidator('minimum period'));
+                set(defV, [fKeyDef.max.fkey, 'validator'], periodMaxValidator('maximum period'));
+                set(defV, [fKeyDef.tz.fkey, 'validator'], timezeroValidator(8, timeErr));
+                set(defV, [fKeyDef.period.fkey, 'validator'], periodValidator(8, periodErr));
+
+                set(defV, [fKeyDef.period.fkey, 'errMsg'], periodErr);
+                return defV;
+            }
+            return Object.assign({}, inFields);
+        };
+    };
+
+/**
+ * @summary validator for periopd value
+ * @param {number} precision
+ * @param {string} description
+ * @returns {function}
+ */
+function periodValidator(precision, description) {
+    return (valStr) => {
+        var max = get(FieldGroupUtils.getGroupFields(pfinderkey), [fKeyDef.max.fkey, 'value']);
+        max = max ? parseFloat(max) : periodRange.max;
+        var min = get(FieldGroupUtils.getGroupFields(pfinderkey), [fKeyDef.min.fkey, 'value']);
+        min = min ? parseFloat(min) : periodRange.min;
+
+        var retRes = Validate.floatRange(min, max, precision, description, valStr);
+        if (!valStr && retRes.valid) {
+            return {
+                valid: false,
+                message: description
+            };
+        }
+        return retRes;
+    };
+}
+
+
+function periodMinValidator(description) {
+    return (valStr) => {
+        var retRes = Validate.isFloat(description, valStr);
+
+        if (retRes.valid) {
+            var val = valStr && parseFloat(valStr);
+            var max = get(FieldGroupUtils.getGroupFields(pfinderkey), [fKeyDef.max.fkey, 'value']);
+            max = max ? parseFloat(max) : periodRange.max;
+
+            if (!valStr || (val < periodRange.min || val >= max)) {    // can not be less than the computed minimum
+                return {valid: false, message: 'invalid '+ description};
+            }
+        } else {
+            retRes.message = description;
+        }
+        return retRes;
+    };
+}
+
+function periodMaxValidator(description) {
+    return (valStr) => {
+        var retRes = Validate.isFloat(description, valStr);
+
+        if (retRes.valid) {
+            var val = valStr && parseFloat(valStr);
+            var min = get(FieldGroupUtils.getGroupFields(pfinderkey), [fKeyDef.min.fkey, 'value']);
+            min = min ? parseFloat(min) : periodRange.min;
+
+            if (!valStr || (val <= min || val > periodRange.max) ) {   // can not be greater than computed maximum
+                return {valid: false, message: 'invalid ' + description};
+            }
+        }
+        return retRes;
+    };
+}
+/**
+ * @summary time zero validator
+ * @param {number} precision
+ * @param {string} description
+ * @returns {function}
+ */
+function timezeroValidator(precision, description) {
+    return (valStr) => {
+        var retRes = Validate.floatRange(periodRange.tzero, periodRange.tzeroMax, precision, description, valStr);
+
+        if (retRes.valid) {
+            if (!valStr) {
+                return {
+                    valid: false,
+                    message: description
+                };
+            }
+         }
+        return retRes;
+    };
+}
+
+
+
+function setPFTableSuccess() {
+    return (request) => {
+        doPFCalculate();
+        var reqData = get(request, pfinderkey);
+        var timeName = get(reqData, fKeyDef.time.fkey);
+        var period = get(reqData, fKeyDef.period.fkey);
+        var flux = get(reqData, fKeyDef.flux.fkey);
+
+        repeatDataCycle(timeName, parseFloat(period), currentPhaseFoldedTable);
+
+        const {tableData, tbl_id, tableMeta, title} = currentPhaseFoldedTable;
+        const ipacTable = tableToText(tableData.columns, tableData.data, true, tableMeta);
+        const file = new File([new Blob([ipacTable])], `${tbl_id}.tbl`);
+
+        doUpload(file).then(({status, cacheKey}) => {
+            const tReq = makeFileRequest(title, cacheKey, null, {tbl_id, sortInfo:sortInfoString(LC.PHASE_CNAME)});
+            dispatchTableSearch(tReq, {removable: false});
+
+            let xyPlotParams = {
+                userSetBoundaries: {xMax: 2},
+                x: {columnOrExpr: LC.PHASE_CNAME, options: 'grid'},
+                y: {columnOrExpr: flux, options: 'grid,flip'}
+            };
+            loadXYPlot({chartId: LC.PHASE_FOLDED, tblId: LC.PHASE_FOLDED, xyPlotParams});
+        });
+
+        dispatchLayoutDisplayMode(LC.RESULT_PAGE);
+    };
+}
+
+function setPFTableFail() {
+    return (request) => {
+        return showInfoPopup('Phase folding parameter setting error');
+    };
+}
+
+/**
+ * @summary callback to add phase column to raw table on slider's change
+ */
+function doPFCalculate() {
+    let fields = FieldGroupUtils.getGroupFields(pfinderkey);
+    let rawTable = getTblById(LC.RAW_TABLE);
+
+    currentPhaseFoldedTable = rawTable && addPhaseToTable(rawTable, fields);
+}
+
+/**
+ * @summary create a table model with phase column
+ * @param {TableModel} tbl
+ * @param {Object} fields
+ * @returns {TableModel}
+ */
+function addPhaseToTable(tbl, fields) {
+    var {time, period, tzero} = fields;
+    var {columns} = tbl.tableData;
+    var tc = time ? time.value : 'mjd';
+    var tIdx = tc ? columns.findIndex((c) => (c.name === tc)) : -1;
+
+    if (tIdx < 0) return null;
+
+    var pd = period ? parseFloat(period.value) : periodRange.min;
+    var tz = tzero ? parseFloat(tzero.value) : periodRange.tzero;
+    var tPF = Object.assign(cloneDeep(tbl), {tbl_id: LC.PHASE_FOLDED, title: 'Phase Folded'},
+        {request: getPhaseFoldingRequest(fields, tbl)},
+        {highlightedRow: 0});
+    tPF = omit(tPF, ['hlRowIdx', 'isFetching']);
+
+    var phaseC = {desc: 'number of period elapsed since starting time.',
+        name: LC.PHASE_CNAME, type: 'double', width: 20 };
+
+    tPF.tableData.columns.push(phaseC);          // add phase column
+
+    tPF.tableData.data.forEach((d, index) => {   // add phase value (in string) to each data
+
+        tPF.tableData.data[index].push(getPhase(parseFloat(d[tIdx]), tz, pd));
+    });
+
+    return tPF;
+}
+
+/**
+ * @summary create table request object for phase folded table
+ * @param {Object} fields
+ * @param {TableModel} tbl
+ * @returns {TableRequest}
+ */
+function getPhaseFoldingRequest(fields, tbl) {
+    return makeTblRequest('PhaseFoldedProcessor', LC.PHASE_FOLDED, {
+        'period_days': fields&&get(fields, 'period.value'),
+        'table_name': 'folded_table',
+        'x': fields&&get(fields, 'time.value'),
+        'original_table': tbl.tableMeta.tblFilePath
+    },  {tbl_id:LC.PHASE_FOLDED});
+
+}
+
+/**
+ * @summary calculate phase and return as text
+ * @param {number} time
+ * @param {number} timeZero
+ * @param {number} period
+ * @param {number} dec
+ * @returns {string}  folded phase (positive or negative) with 'dec'  decimal digits
+ */
+function getPhase(time, timeZero, period,  dec=DEC_PHASE) {
+    var q = (time - timeZero)/period;
+    var p = q >= 0  ? (q - Math.floor(q)) : (q + Math.floor(-q));
+
+    return p.toFixed(dec);
+}
+
+/**
+ * @summary duplicate the phase cycle to the phase folded table
+ * @param {string} timeCol
+ * @param {number} period
+ * @param {TableModel} phaseTable
+ */
+function repeatDataCycle(timeCol, period, phaseTable) {
+    var tIdx = phaseTable.tableData.columns.findIndex((c) => (c.name === timeCol));
+    var fIdx = phaseTable.tableData.columns.findIndex((c) => (c.name === LC.PHASE_CNAME));
+    var {totalRows, tbl_id, title} = phaseTable;
+
+
+    slice(phaseTable.tableData.data, 0, totalRows).forEach((d) => {
+        var newRow = slice(d);
+
+        newRow[tIdx] = `${parseFloat(d[tIdx]) + period}`;
+        newRow[fIdx] = `${parseFloat(d[fIdx]) + 1}`;
+        phaseTable.tableData.data.push(newRow);
+    });
+
+    totalRows *= 2;
+
+    set(phaseTable, 'totalRows', totalRows);
+    set(phaseTable, ['tableMeta', 'RowsRetrieved'], `${totalRows}`);
+
+    set(phaseTable, ['tableMeta', 'tbl_id'], tbl_id);
+    set(phaseTable, ['tableMeta', 'title'], title);
+
+    var col = phaseTable.tableData.columns.length;
+    var sqlMeta = get(phaseTable, ['tableMeta', 'SQL']);
+    if (sqlMeta) {
+        set(phaseTable, ['tableMeta', 'SQL'], replace(sqlMeta, `${col-1}`, `${col}`));
+    }
+
+}
+
+/**
+ * @summary compute the period minimum and maximum based on table data
+ * @param {string} tbl_id
+ * @param {string} timeColName
+ * @returns {Object}
+ */
+function computePeriodRange(tbl_id, timeColName) {
+    var tbl = getTblById(tbl_id);
+    var {columns, data} = tbl.tableData;
+    var tIdx = columns.findIndex((col) => (col.name === timeColName));
+    var arr = data.reduce((prev, e)=> {
+        prev.push(parseFloat(e[tIdx]));
+        return prev;
+    }, []);
+    var factor = 1;
+
+    var timeZero = Math.min(...arr);
+    var timeMax = Math.max(...arr);
+
+    var max = parseFloat(((timeMax - timeZero)*factor).toFixed(DEC_PHASE));
+    var min = Math.pow(10, -DEC_PHASE);
+    var newMax = adjustMax(max, SliderMin, STEP);
+
+    return {min, max: newMax.max, steps: newMax.steps, tzero: timeZero, tzeroMax: timeMax};
+}
+
+/**
+ * @summary adjust the maximum to be the multiple of the step resolution if the maximum on the slider is updated
+ * @param {number} max
+ * @param {number} min
+ * @param {number} step
+ * @returns {{steps: number, max: number}}
+ */
+export function adjustMax(max, min, step) {
+    var newTotalSteps = Math.ceil((max - min) / step);
+    var newMax = parseFloat((newTotalSteps*step + min).toFixed(DEC_PHASE));
+    var res = (newMax - min)/newTotalSteps;
+
+    return {steps: newTotalSteps, max: newMax, res};
+}
+
+
+/**
+ * @summary reset the setting
+ */
+function resetDefaults() {
+    dispatchRestoreDefaults(pfinderkey);
+}
+
+
+function cancelPeriodSetting() {
+    return () => {
+        dispatchLayoutDisplayMode(LC.RESULT_PAGE);
+    };
+}
+

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -23,9 +23,9 @@ import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 import {dispatchRestoreDefaults, dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {makeTblRequest,getTblById, tableToText, makeFileRequest} from '../../tables/TableUtil.js';
-import {LC} from './LcManager.js';
+import {LC, updateLayoutDisplay} from './LcManager.js';
 import {LcPeriodogram, startPeriodogramPopup} from './LcPeriodogram.jsx';
-import {dispatchLayoutDisplayMode, LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
+import {LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
 import ReactHighcharts from 'react-highcharts';
 
 const pfinderkey = LC.PERIOD_FINDER;
@@ -848,7 +848,7 @@ function setPFTableSuccess() {
             loadXYPlot({chartId: LC.PHASE_FOLDED, tblId: LC.PHASE_FOLDED, xyPlotParams});
         });
 
-        dispatchLayoutDisplayMode(LC.RESULT_PAGE);
+        updateLayoutDisplay(LC.RESULT_PAGE);
     };
 }
 
@@ -1030,6 +1030,6 @@ function resetDefaults() {
  */
 function cancelPeriodSetting() {
     return () => {
-        dispatchLayoutDisplayMode(LC.RESULT_PAGE);
+        updateLayoutDisplay(LC.RESULT_PAGE);
     };
 }

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -3,11 +3,8 @@
  */
 
 import React, {Component, PropTypes} from 'react';
-
-import sCompare from 'react-addons-shallow-compare';
-import { get, set, isEmpty} from 'lodash';
+import { get, set} from 'lodash';
 import SplitPane from 'react-split-pane';
-import CompleteButton from '../../ui/CompleteButton.jsx';
 import {createContentWrapper} from '../../ui/panel/DockLayoutPanel.jsx';
 import {LC, periodPageMode, updateLayoutDisplay} from './LcManager.js';
 import {getTypeData} from './LcPeriod.jsx';
@@ -16,7 +13,7 @@ import {dispatchValueChange, dispatchMountComponent} from '../../fieldGroup/Fiel
 import Validate from '../../util/Validate.js';
 import {makeTblRequest, getTblById} from '../../tables/TableUtil.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
-import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
+import {dispatchTableSearch, dispatchActiveTableChanged} from '../../tables/TablesCntlr.js';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
@@ -162,7 +159,7 @@ function  PeriodogramButton(props) {
                     className='button std'
                     onClick={startPeriodogramPopup(groupKey)}>Find Periodogram</button>
         </div>
-    )
+    );
 }
 
 
@@ -170,7 +167,7 @@ PeriodogramButton.propTypes = {
     groupKey: PropTypes.string.isRequired
 };
 
-const popupId = 'periodogramPopup';
+export const popupId = 'periodogramPopup';
 
 /**
  * @summry periodogram popup
@@ -275,7 +272,6 @@ class PeriodogramOptionsBox extends Component {
                         <ListBoxInputField options={algorOptions}
                                            multiple={false}
                                            fieldKey={pKeyDef.algor.fkey}
-                                           multiple={false}
                         />
                         <br/>
                         <SuggestBoxInputField
@@ -356,13 +352,13 @@ function resetDefaults(groupKey) {
  * @param popupId
  * @returns {Function}
  */
-function cancelPeriodogram(groupKey, popupId) {
+export function cancelPeriodogram(groupKey, popupId) {
     return () => {
         resetDefaults(groupKey);
         if (popupId && isDialogVisible(popupId)) {
             dispatchHideDialog(popupId);
         }
-    }
+    };
 }
 
 /**
@@ -425,6 +421,7 @@ function periodogramSuccess(groupKey, popupId, hideDropDown = false) {
             loadXYPlot({chartId: LC.PERIODOGRAM, tblId: LC.PERIODOGRAM, markAsDefault: true, xyPlotParams});
         }
 
+        dispatchActiveTableChanged(LC.PERIODOGRAM, LC.PERIODOGRAM_GROUP);
         if (hideDropDown && popupId && isDialogVisible(popupId)) {
             dispatchHideDialog(popupId);
         }
@@ -454,14 +451,14 @@ const  PeriodogramResult = ({expanded}) => {
 
 
     if (!expanded || expanded === LO_VIEW.none) {
-        resultLayout = <SplitPane split='horizontal' minSize={20} defaultSize={'45%'}>
+        resultLayout = (<SplitPane split='horizontal' minSize={20} defaultSize={'45%'}>
                             {createContentWrapper(tables)}
                             {createContentWrapper(xyPlot)}
-                        </SplitPane>;
+                        </SplitPane>);
     } else {
-        resultLayout = <div style={{ flex: 'auto', display: 'flex', flexFlow: 'column', overflow: 'hidden', height: '100%'}}>
+        resultLayout = (<div style={{ flex: 'auto', display: 'flex', flexFlow: 'column', overflow: 'hidden', height: '100%'}}>
             {expanded === LO_VIEW.tables ? tables : xyPlot}
-        </div>;
+        </div>);
     }
     return resultLayout;
 };

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -9,7 +9,7 @@ import { get, set, isEmpty} from 'lodash';
 import SplitPane from 'react-split-pane';
 import CompleteButton from '../../ui/CompleteButton.jsx';
 import {createContentWrapper} from '../../ui/panel/DockLayoutPanel.jsx';
-import {LC, periodPageMode} from './LcManager.js';
+import {LC, periodPageMode, updateLayoutDisplay} from './LcManager.js';
 import {getTypeData} from './LcPeriod.jsx';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 import {dispatchValueChange, dispatchMountComponent} from '../../fieldGroup/FieldGroupCntlr.js';
@@ -20,7 +20,7 @@ import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
-import {dispatchLayoutDisplayMode, LO_VIEW} from '../../core/LayoutCntlr.js';
+import {LO_VIEW} from '../../core/LayoutCntlr.js';
 import {dispatchShowDialog, dispatchHideDialog, isDialogVisible} from '../../core/ComponentCntlr.js';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
@@ -429,7 +429,7 @@ function periodogramSuccess(groupKey, popupId, hideDropDown = false) {
             dispatchHideDialog(popupId);
         }
 
-        dispatchLayoutDisplayMode(LC.PERGRAM_PAGE);
+        updateLayoutDisplay(LC.PERGRAM_PAGE);
         periodPageMode(LC.PERGRAM_PAGE);
     };
 }

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -1,0 +1,391 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {Component, PropTypes} from 'react';
+
+import sCompare from 'react-addons-shallow-compare';
+import { get, set, isEmpty} from 'lodash';
+import SplitPane from 'react-split-pane';
+import CompleteButton from '../../ui/CompleteButton.jsx';
+import {createContentWrapper} from '../../ui/panel/DockLayoutPanel.jsx';
+import {LC, periodPageMode} from './LcManager.js';
+import {getTypeData} from './LcPeriod.jsx';
+import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
+import {dispatchValueChange, dispatchMountComponent} from '../../fieldGroup/FieldGroupCntlr.js';
+import Validate from '../../util/Validate.js';
+import {makeTblRequest, getTblById} from '../../tables/TableUtil.js';
+import {sortInfoString} from '../../tables/SortInfo.js';
+import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
+import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
+import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
+import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
+import {dispatchLayoutDisplayMode, LO_VIEW} from '../../core/LayoutCntlr.js';
+import {dispatchShowDialog, dispatchHideDialog, isDialogVisible} from '../../core/ComponentCntlr.js';
+import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
+import {PopupPanel} from '../../ui/PopupPanel.jsx';
+import {FieldGroup} from '../../ui/FieldGroup.jsx';
+import {InputGroup} from '../../ui/InputGroup.jsx';
+import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
+import {ValidationField} from '../../ui/ValidationField.jsx';
+import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
+
+var pgramkey = LC.PERIOD_FINDER;
+
+const algorOptions = [
+    {label: 'Lomb‑Scargle ', value: 'ls', proj: 'LCViewer'},
+    {label: 'Box-fitting Least Squares', value: 'bls', proj: 'LCViewer'},
+    {label: 'Plavchan 2008', value: 'plav', proj: 'LCViewer'}
+];
+
+const stepOptions = [
+    {label: 'Fixed Frequency', value: 'fixedf', proj: 'LCViewer'},
+    {label: 'Fixed Period', value: 'fixedp', proj: 'LCViewer'},
+    {label: 'Exponential', value: 'exp', proj: 'LCViewer'},
+    {label: 'Plavchan', value: 'plav', proj: 'LCViewer'}
+];
+
+const cPeriodKeyDef = {
+    time: {fkey: 'time', label: 'Time Column'},
+    flux: {fkey: 'flux', label: 'Flux Column'},
+    min: {fkey: 'periodMin', label: 'Period Min'},
+    max: {fkey: 'periodMax', label: 'Period Max'},
+    timecols: {fkey: 'timeCols', label: ''},
+    fluxcols: {fkey: 'fluxCols', label: ''}
+};
+
+const pKeyDef = Object.assign({}, cPeriodKeyDef,
+                    { algor: {fkey: 'periodAlgor', label: 'Periodogram Type'},
+                      stepmethod: {fkey: 'stepMethod', label: 'Period Step Method'},
+                      stepsize: {fkey: 'stepSize', label: 'Fixed Step Size'},
+                      peaks: {fkey: 'peaks', label:'Number of Peaks'} });
+
+
+function getDefaultStepSize(fields) {
+    //const fields = FieldGroupUtils.getGroupFields(gKey);
+    const min = get(fields, [pKeyDef.min.fkey]);
+    const max = get(fields, [pKeyDef.max.fkey]);
+    const {totalRows} = getTblById(LC.RAW_TABLE) || {};
+
+    const s = min&&max&&totalRows ? (parseFloat(max)-parseFloat(min))/(totalRows*10) : 1.0e-7;
+
+    return `${s}`;
+}
+
+
+var defValues = {
+    [pKeyDef.algor.fkey]: Object.assign(getTypeData(pKeyDef.algor.fkey,
+        algorOptions[0].value,
+        'periodogram algorithm',
+        `${pKeyDef.algor.label}:`, 150)),
+    [pKeyDef.stepmethod.fkey]: Object.assign(getTypeData(pKeyDef.stepmethod.fkey,
+        stepOptions[0].value,
+        'periodogram step method',
+        `${pKeyDef.stepmethod.label}:`, 150)),
+    [pKeyDef.stepsize.fkey]: Object.assign(getTypeData(pKeyDef.stepsize.fkey, '',
+        'period fixed step size',
+        `${pKeyDef.stepsize.label}:`, 150),
+        {validator: Validate.floatRange.bind(null, 1.0e-7, undefined, 'fixed step size field')}),
+    [pKeyDef.peaks.fkey]: Object.assign(getTypeData(pKeyDef.peaks.fkey, '50',
+        'number of peaks to return',
+        `${pKeyDef.peaks.label}:`, 50),
+        {validator: Validate.intRange.bind(null, 1, 500, 'peaks number field')})
+};
+
+var defPeriod = {
+    [pKeyDef.time.fkey]: {value: ''},
+    [pKeyDef.flux.fkey]: {value: ''},
+    [pKeyDef.min.fkey]: {value: ''},
+    [pKeyDef.max.fkey]: {value: ''}
+};
+
+var defPeriodogram = {
+    [pKeyDef.algor.fkey]: {value: ''},
+    [pKeyDef.stepmethod.fkey]: {value: ''},
+    [pKeyDef.stepsize.fkey]: {value: ''},
+    [pKeyDef.peaks.fkey]: {value: ''}
+};
+
+export function LcPeriodogram(props) {
+    const {display, groupKey=pgramkey, expanded} = props;
+    const content = {};
+
+    content.tables =  (<TablesContainer key='res-tables'
+                                        mode='both'
+                                        tbl_group={LC.PERIODOGRAM_GROUP}
+                                        closeable={true}
+                                        expandedMode={expanded===LO_VIEW.tables}/>);
+    content.xyPlot = (<ChartsContainer key='res-charts'
+                                       closeable={true}
+                                       expandedMode={expanded===LO_VIEW.xyPlots}/>);
+
+    const resultProps = {...content, expanded, display, groupKey};
+
+    return (
+        <div style={{height: '100%'}}>
+            {(display&&display==='period') ? <PeriodogramButton groupKey={groupKey} /> :
+                                             <PeriodogramResult {...resultProps} />}
+        </div>
+    );
+}
+
+
+LcPeriodogram.propTypes = {
+    display: PropTypes.string.isRequired,
+    expanded: PropTypes.object,
+    groupKey: PropTypes.string
+};
+
+LcPeriodogram.defaultProps = {
+    display: LC.PERIOD_PAGE
+};
+
+
+function  PeriodogramButton(props) {
+    const {groupKey} = props;
+    return (
+        <div style={{height: '100%',
+                     display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
+            <CompleteButton style={{maxWidth: '50%'}}
+                            groupKey={groupKey}
+                            text={'Find Periodogram'}
+                            onSuccess={startPeriodogramPopup(groupKey)}
+            />
+        </div>
+    )
+}
+
+
+
+PeriodogramButton.propTypes = {
+    groupKey: PropTypes.string.isRequired
+};
+
+const popupId = 'periodogramPopup';
+
+var startPeriodogramPopup = (groupKey) =>  {
+    return (request) => {
+
+        Object.keys(defPeriod).forEach((key) => {
+            set(defPeriod, [key, 'value'], get(request, [key]));     // init default time, flux value, period
+        });
+
+        updatePeriodGroup(groupKey, request);
+
+        var popup = (<PopupPanel title={'Periodogram'}>
+            {<PeriodogramOptionsBox groupKey={groupKey} />}
+            <div>
+                <CompleteButton
+                    dialogId={popupId}
+                    groupKey={groupKey}
+                    onSuccess={periodogramSuccess(true)}
+                    text={'Periodogram Calculation'}
+                />
+            </div>
+        </PopupPanel>);
+
+        DialogRootContainer.defineDialog(popupId, popup);
+        dispatchShowDialog(popupId);
+    };
+};
+
+
+function updatePeriodGroup(gkey, request) {
+
+    if (!Object.keys(request).includes(pKeyDef.algor.fkey)){
+        var defV = Object.assign({}, defValues);
+
+        set(defV, [pKeyDef.stepsize.fkey, 'value'], getDefaultStepSize(request));
+
+        Object.keys(defV).forEach((key) => {
+           var v = defV[key].value;
+
+           dispatchMountComponent(gkey, key, true, v, defV[key]);
+           set(defPeriodogram, [key, 'value'], v);
+        });
+    } else {
+
+        Object.keys(defPeriodogram).forEach((key) => {
+            set(defPeriodogram, [key, 'value'], get(request, [key]));     // init default time, flux value, period
+        });
+    }
+}
+
+class PeriodogramOptionsBox extends Component {
+    constructor(props) {
+        super(props);
+        var {groupKey} = props;
+
+        this.state = {fields: FieldGroupUtils.getGroupFields(groupKey)};
+    }
+
+    componentWillUnmount() {
+        this.iAmMounted = false;
+        if (this.unbinder) this.unbinder();
+    }
+
+    componentDidMount() {
+        var {groupKey} = this.props;
+
+        this.iAmMounted = true;
+        this.unbinder = FieldGroupUtils.bindToStore(groupKey, (fields) => {
+            if (fields !== this.state.fields && this.iAmMounted) {
+                this.setState({fields});
+            }
+        });
+    }
+
+    render() {
+        const {groupKey} = this.props;
+        const {timeCols, fluxCols } = this.state.fields || {};
+
+        return (
+            <div style={{padding:5}}>
+                <FieldGroup groupKey={groupKey} keepState={true}>
+                    <InputGroup labelWidth={150}>
+                        <ListBoxInputField options={algorOptions}
+                                           multiple={false}
+                                           fieldKey={pKeyDef.algor.fkey}
+                                           multiple={false}
+                        />
+                        <br/>
+                        <SuggestBoxInputField
+                            fieldKey={pKeyDef.time.fkey}
+                            getSuggestions = {(val)=>{
+                            const sList = timeCols&&get(timeCols, 'value');
+                            const suggestions =  sList && sList.filter((el)=>{return el.startsWith(val);});
+                            return suggestions && suggestions.length > 0 ? suggestions : [];
+                        }}
+
+                        />
+                        <br/>
+                        <SuggestBoxInputField
+                            fieldKey={pKeyDef.flux.fkey}
+                            getSuggestions = {(val)=>{
+                            const sList = fluxCols&&get(fluxCols, 'value');
+                            const suggestions = sList && sList.filter((el)=>{return el.startsWith(val);});
+                            return suggestions && suggestions.length > 0 ? suggestions : [];
+                        }}
+
+                        />
+                        <br/>
+                        <ListBoxInputField options={stepOptions}
+                                           multiple={false}
+                                           fieldKey={pKeyDef.stepmethod.fkey}
+                                           multiple={false}
+                        />
+                        <br/>
+                        <ValidationField fieldKey={pKeyDef.stepsize.fkey} />
+                        <br/>
+                        <ValidationField fieldKey={pKeyDef.min.fkey} />
+                        <br/>
+                        <ValidationField fieldKey={pKeyDef.max.fkey} />
+                        <br/>
+                        <ValidationField fieldKey={pKeyDef.peaks.fkey} />
+                        <br/>
+
+                        <button type='button' className='button std hl' onClick={() => resetDefaults(groupKey)}>
+                            <b>Reset</b>
+                        </button>
+
+                    </InputGroup>
+                </FieldGroup>
+                <br/>
+            </div>
+        );
+    }
+}
+
+
+PeriodogramOptionsBox.propTypes = {
+    groupKey: PropTypes.string.isRequired
+};
+
+function resetDefaults(groupKey) {
+    Object.keys(defPeriodogram).forEach((fieldKey) => {
+        dispatchValueChange({groupKey, fieldKey, value: defPeriodogram[fieldKey].value});
+    });
+
+    Object.keys(defPeriod).forEach((fieldKey) => {
+        dispatchValueChange({groupKey, fieldKey, value: defPeriod[fieldKey].value});
+    });
+}
+
+function periodogramSuccess(hideDropDown = false) {
+    return (request) => {
+        const tbl = getTblById(LC.RAW_TABLE);
+        const fields = FieldGroupUtils.getGroupFields(pgramkey);
+        const srcFile = tbl.request.source;
+
+        var tReq2 = makeTblRequest('LightCurveProcessor', LC.PEAK_TABLE, {
+            original_table: srcFile,
+            x: fields.time.value || 'mjd',
+            y: fields.flux.value || 'w1mpro_ep',
+            alg: fields.periodAlgor.value,
+            pmin: fields.periodMin.value,
+            pmax: fields.periodMax.value,
+            step_method: fields.stepMethod.value,
+            step_size: fields.stepSize.value,
+            peaks: fields.peaks.value,
+            table_name: LC.PEAK_TABLE,
+            sortInfo: sortInfoString('SDE')                 // sort peak table by column SDE
+        }, {tbl_id: LC.PEAK_TABLE});
+
+        if (tReq2 !== null) {
+            const xyPlotParams = {
+                x: {columnOrExpr: LC.PEAK_CNAME, options: 'grid'},
+                y: {columnOrExpr: LC.POWER_CNAME, options: 'grid'}
+            };
+            loadXYPlot({chartId: LC.PEAK_TABLE, tblId: LC.PEAK_TABLE, xyPlotParams});
+            dispatchTableSearch(tReq2, {removable: true, tbl_group: LC.PERIODOGRAM_GROUP});
+        }
+
+        var tReq = makeTblRequest('LightCurveProcessor', LC.PERIODOGRAM, {
+            original_table: srcFile,
+            x: fields.time.value || 'mjd',
+            y: fields.flux.value || 'w1mpro_ep',
+            alg: fields.periodAlgor.value,
+            pmin: fields.periodMin.value,
+            pmax: fields.periodMax.value,
+            step_method: fields.stepMethod.value,
+            step_size: fields.stepSize.value,
+            peaks: fields.peaks.value,
+            table_name: LC.PERIODOGRAM
+        }, {tbl_id: LC.PERIODOGRAM});
+
+
+        if (tReq !== null) {
+            dispatchTableSearch(tReq, {removable: true, tbl_group: LC.PERIODOGRAM_GROUP});
+            const xyPlotParams = {
+                userSetBoundaries: {yMin: 0},
+                x: {columnOrExpr: LC.PERIOD_CNAME, options: 'grid,log'},
+                y: {columnOrExpr: LC.POWER_CNAME, options: 'grid'}
+            };
+            loadXYPlot({chartId: LC.PERIODOGRAM, tblId: LC.PERIODOGRAM, markAsDefault: true, xyPlotParams});
+        }
+
+        if (hideDropDown && isDialogVisible(popupId)) {
+            dispatchHideDialog(popupId);
+        }
+
+        dispatchLayoutDisplayMode(LC.PERGRAM_PAGE);
+        periodPageMode(LC.PERGRAM_PAGE);
+    };
+}
+
+function  PeriodogramResult({expanded, groupKey, tables, xyPlot}) {
+
+    var resultLayout;
+
+    if (!expanded || expanded === LO_VIEW.none) {
+        resultLayout = <SplitPane split='horizontal' minSize={20} defaultSize={'45%'}>
+                            {createContentWrapper(tables)}
+                            {createContentWrapper(xyPlot)}
+                        </SplitPane>;
+    } else {
+        resultLayout = <div style={{ flex: 'auto', display: 'flex', flexFlow: 'column', overflow: 'hidden'}}>
+            {expanded === LO_VIEW.tables ? tables : xyPlot}
+        </div>;
+    }
+    return resultLayout;
+}

--- a/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPhaseFoldingPopup.jsx
@@ -703,7 +703,7 @@ function getPhaseFoldingRequest(fields, tbl) {
     return makeTblRequest('PhaseFoldedProcessor', LC.PHASE_FOLDED, {
         'period_days': fields&&get(fields, 'period.value'),
         'table_name': 'folded_table',
-        'x': fields&&get(fields, 'timeCol.value'),
+        'x': fields&&get(fields, 'time.value'),
         'original_table': tbl.tableMeta.tblFilePath
     },  {tbl_id:LC.PHASE_FOLDED});
 

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -24,12 +24,13 @@ import {LcPFOptionsPanel} from './LcPhaseFoldingPanel.jsx';
 import {LcPeriodFindingPanel} from './PeriodogramOptionsPanel.jsx';
 import {DownloadButton, DownloadOptionPanel} from '../../ui/DownloadDialog.jsx';
 
+const resultItems = ['title', 'mode', 'showTables', 'showImages', 'showXyPlots', 'showForm', 'images'];
 
 export class LcResult extends Component {
 
     constructor(props) {
         super(props);
-        this.state = {};
+        this.state = Object.assign({}, pick(getLayouInfo(), resultItems));
     }
 
     shouldComponentUpdate(np, ns) {
@@ -45,7 +46,7 @@ export class LcResult extends Component {
     }
 
     storeUpdate() {
-        const nextState = pick(getLayouInfo(), ['title', 'mode', 'showTables', 'showImages', 'showXyPlots', 'showForm', 'images']);
+        const nextState = pick(getLayouInfo(), resultItems);
         this.setState(nextState);
     }
 
@@ -145,7 +146,7 @@ const ExpandedView = ({expanded, imagePlot, xyPlot, tables}) => {
 
 
 // eslint-disable-next-line
-const StandardView = ({visToolbar, title, searchDesc, standard, imagePlot, xyPlot, tables, form}) => {
+const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables, form}) => {
 
     return (
         <div style={{display: 'flex', flexDirection: 'column', flexGrow: 1, position: 'relative'}}>

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -5,12 +5,12 @@
 
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {pickBy, startsWith} from 'lodash';
+import {pickBy} from 'lodash';
 
 import {flux, firefly} from '../../Firefly.js';
 import {getMenu, isAppReady, dispatchSetMenu, dispatchOnAppReady} from '../../core/AppDataCntlr.js';
 import {getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
-import {lcManager, LC} from './LcManager.js';
+import {lcManager, LC, removeTablesFromGroup} from './LcManager.js';
 import {listenerPanel} from './LcPhaseFoldingPanel.jsx';
 import {LcResult} from './LcResult.jsx';
 import {LcPeriod} from './LcPeriod.jsx';
@@ -32,9 +32,6 @@ import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import * as TblUtil from '../../tables/TableUtil.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
-import {menuHas} from './LcManager.js';
-
-// import {deepDiff} from '../util/WebUtil.js';
 
 /**
  * This is a light curve viewer.
@@ -85,7 +82,7 @@ export class LcViewer extends Component {
 
     render() {
         var {isReady, menu={}, appTitle, appIcon, altAppIcon, dropDown,
-                dropdownPanels=[], views, footer, style, displayMode} = this.state;
+                dropdownPanels=[], footer, style, displayMode} = this.state;
         const {visible, view} = dropDown || {};
 
         dropdownPanels.push(<UploadPanel/>);
@@ -105,7 +102,7 @@ export class LcViewer extends Component {
                             {...{dropdownPanels} } />
                     </header>
                     <main>
-                        {displayMode&&startsWith(displayMode, 'period') ? <LcPeriod displayMode={displayMode}/> : <LcResult/>}
+                        {displayMode&&displayMode.startsWith('period') ? <LcPeriod displayMode={displayMode}/> : <LcResult/>}
                     </main>
                 </div>
             );
@@ -199,7 +196,8 @@ export function UploadPanel(props) {
             </FormPanel>
         </div>
     );
-};
+}
+
 UploadPanel.propTypes = {
     name: PropTypes.oneOf(['LCUpload'])
 };
@@ -210,6 +208,9 @@ UploadPanel.defaultProps = {
 
 function onSearchSubmit(request) {
     if ( request.rawTblSource ){
+        removeTablesFromGroup();
+        removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
+
         const {timeCName= LC.DEF_TIME_CNAME, fluxCName= LC.DEF_FLUX_CNAME} = request;
         const options = {
             tbl_id: LC.RAW_TABLE,

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -105,7 +105,7 @@ export class LcViewer extends Component {
                             {...{dropdownPanels} } />
                     </header>
                     <main>
-                        {displayMode&&startsWith(displayMode, 'period') ? <LcPeriod display={displayMode}/> : <LcResult/>}
+                        {displayMode&&startsWith(displayMode, 'period') ? <LcPeriod displayMode={displayMode}/> : <LcResult/>}
                     </main>
                 </div>
             );

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -5,7 +5,7 @@
 
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {pickBy} from 'lodash';
+import {pickBy, startsWith} from 'lodash';
 
 import {flux, firefly} from '../../Firefly.js';
 import {getMenu, isAppReady, dispatchSetMenu, dispatchOnAppReady} from '../../core/AppDataCntlr.js';
@@ -13,6 +13,7 @@ import {getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
 import {lcManager, LC} from './LcManager.js';
 import {listenerPanel} from './LcPhaseFoldingPanel.jsx';
 import {LcResult} from './LcResult.jsx';
+import {LcPeriod} from './LcPeriod.jsx';
 import {Menu} from '../../ui/Menu.jsx';
 import {Banner} from '../../ui/Banner.jsx';
 import {DropDownContainer} from '../../ui/DropDownContainer.jsx';
@@ -31,6 +32,7 @@ import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import * as TblUtil from '../../tables/TableUtil.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
+import {menuHas} from './LcManager.js';
 
 // import {deepDiff} from '../util/WebUtil.js';
 
@@ -83,7 +85,7 @@ export class LcViewer extends Component {
 
     render() {
         var {isReady, menu={}, appTitle, appIcon, altAppIcon, dropDown,
-                dropdownPanels=[], views, footer, style} = this.state;
+                dropdownPanels=[], views, footer, style, displayMode} = this.state;
         const {visible, view} = dropDown || {};
 
         dropdownPanels.push(<UploadPanel/>);
@@ -103,7 +105,7 @@ export class LcViewer extends Component {
                             {...{dropdownPanels} } />
                     </header>
                     <main>
-                        <LcResult/>
+                        {displayMode&&startsWith(displayMode, 'period') ? <LcPeriod display={displayMode}/> : <LcResult/>}
                     </main>
                 </div>
             );

--- a/src/firefly/js/ui/FieldGroup.jsx
+++ b/src/firefly/js/ui/FieldGroup.jsx
@@ -39,7 +39,9 @@ export class FieldGroup extends Component {
     }
 
     componentWillUnmount() {
-        dispatchMountFieldGroup(this.props.groupKey, false);
+        if (!this.props.keepMounted) {
+            dispatchMountFieldGroup(this.props.groupKey, false);
+        }
     }
 
     render() {
@@ -59,7 +61,8 @@ FieldGroup.propTypes= {
     actionTypes: PropTypes.arrayOf(PropTypes.string),
     keepState : PropTypes.bool,
     initValues : PropTypes.object,
-    style : PropTypes.object
+    style : PropTypes.object,
+    keepMounted: PropTypes.bool
 };
 
 FieldGroup.childContextTypes= {
@@ -71,6 +74,7 @@ FieldGroup.contextTypes = { groupKey: PropTypes.string };
 FieldGroup.defaultProps=  {
     reducerFunc: null,
     validatorFunc: null,
-    keepState : false
+    keepState : false,
+    keepMounted : false
 };
 

--- a/src/firefly/js/ui/Menu.jsx
+++ b/src/firefly/js/ui/Menu.jsx
@@ -19,7 +19,8 @@ function handleAction (menuItem) {
 
     // set whether search menu should be shown
     if (menuItem.type === COMMAND) {
-        flux.process({type: menuItem.action, payload:{}});
+        flux.process({type: menuItem.action,
+                      payload: (menuItem.payload ? menuItem.payload : {})});
     } else {
         dispatchShowDropDown( {view: menuItem.action});
     }

--- a/src/firefly/js/ui/RangeSlider.jsx
+++ b/src/firefly/js/ui/RangeSlider.jsx
@@ -19,7 +19,7 @@ function getProps(params, fireValueChange) {
  * @param {function} fireValueChange
  */
 function handleOnChange(value, params, fireValueChange){
-     fireValueChange({
+     fireValueChange&&fireValueChange({
          value
      });
 
@@ -34,38 +34,11 @@ function handleOnChange(value, params, fireValueChange){
     }
 }
 
-
-/**
- * @summary callback to handle the slider value change  entered in the input field
- * @param {string} vText
- * @param {Object} params
- * @param {function} fireValueChange
- */
-/*
-function handleOnMaxChange(vText, params, fireValueChange) {
-    var value = vText;
-    var {steps, max} = adjustMax(parseFloat(vText), params.min, params.step);
-
-    fireValueChange({
-        value
-    });
-
-    var {groupKey} = params;
-    var payload = Object.assign({}, {value: max}, {groupKey, fieldKey: 'periodMax'});
-    dispatchValueChange(payload);
-    payload = Object.assign({}, {value: steps}, {groupKey, fieldKey: 'periodSteps'});
-    dispatchValueChange(payload);
-
-    if (has(params, 'onValueChange')) {
-        params.onValueChange(parseFloat(value));
-    }
-}
-
-*/
-
 const propTypes={
-    label:       PropTypes.string,                  // slider label
-    value:       PropTypes.string.required,         // slider value
+    associatedKey: PropTypes.string,
+    label:       PropTypes.string,             // slider label
+    slideValue:  PropTypes.string.required,    // slider value
+    value:       PropTypes.string,
     onValueChange: PropTypes.func,                  // callback on slider change
     min:         PropTypes.number,                  // minimum end of slider
     max:         PropTypes.number,                  // maximum end of slider

--- a/src/firefly/js/ui/RangeSlider.jsx
+++ b/src/firefly/js/ui/RangeSlider.jsx
@@ -9,7 +9,6 @@ function getProps(params, fireValueChange) {
     return Object.assign({}, params,
         {
             handleChange: (v) => handleOnChange(v, params, fireValueChange),
-            handleMaxChange: (v) => handleOnMaxChange(v, params, fireValueChange)
         });
 }
 
@@ -35,12 +34,14 @@ function handleOnChange(value, params, fireValueChange){
     }
 }
 
+
 /**
  * @summary callback to handle the slider value change  entered in the input field
  * @param {string} vText
  * @param {Object} params
  * @param {function} fireValueChange
  */
+/*
 function handleOnMaxChange(vText, params, fireValueChange) {
     var value = vText;
     var {steps, max} = adjustMax(parseFloat(vText), params.min, params.step);
@@ -60,6 +61,8 @@ function handleOnMaxChange(vText, params, fireValueChange) {
     }
 }
 
+*/
+
 const propTypes={
     label:       PropTypes.string,                  // slider label
     value:       PropTypes.string.required,         // slider value
@@ -78,7 +81,6 @@ const propTypes={
     tooltip:  PropTypes.string,                          // tooltip on label
     minStop:  PropTypes.number,                          // minimum value the slider can be changed to
     maxStop:  PropTypes.number,                          // maximum value the slider can be changed to
-    canEnterValue: PropTypes.bool,                       // if the slider value can be mannually entered
     errMsg: PropTypes.string                            // message for invalid value
 };
 

--- a/src/firefly/js/ui/RangeSliderView.jsx
+++ b/src/firefly/js/ui/RangeSliderView.jsx
@@ -1,12 +1,8 @@
 import React, {Component, PropTypes}  from 'react';
-import {get, has, isNumber, isString, isObject, isNil, isNaN} from 'lodash';
-import {InputFieldView}  from './InputFieldView.jsx';
+import {get, has, isNumber, isString, isObject, isNaN} from 'lodash';
 
 import Slider from 'rc-slider';
 import './rc-slider.css';
-
-export const DEC_PHASE = 3;
-
 
 /**
  * @summary slider component
@@ -15,13 +11,14 @@ export class RangeSliderView extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {value: parseFloat(props.value)};
-
+        this.state = {value: parseFloat(props.slideValue)};
         this.onSliderChange = this.onSliderChange.bind(this);
+        var d = get(props, 'decimalDig', 3);
+        this.decimalDig = (d < 0) ? 0 : (d > 20) ? 20 : d;
     }
 
     componentWillReceiveProps(nextProps) {
-        this.setState( {value: nextProps.value} );
+        this.setState( {value: nextProps.slideValue} );
     }
 
 
@@ -35,53 +32,12 @@ export class RangeSliderView extends Component {
         }
 
         this.setState({value: v});
-        v = parseFloat(v.toFixed(DEC_PHASE));
+        v = parseFloat(v.toFixed(this.decimalDig));
 
         if (handleChange) {
             handleChange(`${v}`);      //value could be any number of decimal
         }
     }
-
-    /*
-
-    onValueChange(e) {
-        var vText = get(e, 'target.value');
-        var {max, handleMaxChange, handleChange, min, step} = this.props;
-
-        if (!isNil(vText) && vText) {
-              var val = parseFloat(vText);
-
-              if (isNaN(val)) {
-
-                  if (handleChange) {
-                      handleChange(vText);
-                  } else {
-                      this.setState({displayValue: vText});
-                  }
-              } else if (val >  max) {     // value exceeds current max
-                  if (handleMaxChange) {
-                      handleMaxChange(vText);
-                  } else {
-                      var aMax = adjustMax(val, min, step );
-                      this.setState({displayValue: vText, max: aMax.max, step: aMax.res});
-                  }
-              } else {                    // value within the min and max range
-                  if (handleChange) {
-                      handleChange(vText);
-                  } else {
-                      this.setState({displayValue: vText});
-                  }
-              }
-        } else {
-            if (handleChange) {
-                handleChange('');
-            } else {
-                this.setState({displayValue: ''});
-            }
-        }
-    }
-
-    */
 
 
     render() {
@@ -96,44 +52,10 @@ export class RangeSliderView extends Component {
             val = maxStop;
         }
 
-
-/*
-        var labelValue = () => {
-            if (!label) return null;
-            var msg = valid ? '' : errMsg || `invalid value: must be within [${minStop}, ${maxStop}]`;
-
-            return (
-                <InputFieldView tooltip={tooltip}
-                                label={label}
-                                labelWidth={labelWidth}
-                                wrapperStyle={{marginBottom: 15}}
-                                value={displayValue}
-                                style={{width: 125}}
-                                onChange={this.onValueChange}
-                                type={'text'}
-                                valid={valid}
-                                message={msg}
-                />
-
-            );
-        };
-
-        var sliderValue = () => {
-            if (!label) return null;
-
-            return (
-                <div style={{display: 'flex'}}>
-                    <div title={tooltip}
-                         style={{width: labelWidth, marginBOttom: 15, marginRight: 4}}>{label}</div>
-                    <div>{displayValue}</div>
-                </div>
-            );
-        };
-*/
         return (
             <div style={wrapperStyle}>
                 <div style={sliderStyle} display='flex'>
-                    <div title={tooltip} style={{width: labelWidth}}>{label}</div>
+                    <div title={tooltip} style={{width: labelWidth, marginBottom: 5}}>{label}</div>
                     <Slider min={min}
                             max={max}
                             className={className}
@@ -162,13 +84,16 @@ RangeSliderView.propTypes = {
     step: PropTypes.number,
     vertical: PropTypes.bool,
     defaultValue: PropTypes.number,
-    value: PropTypes.string.isRequired,
+    slideValue: PropTypes.string.isRequired,
+    value: PropTypes.string,
     handle: PropTypes.element,
     wrapperStyle: PropTypes.object,
     sliderStyle: PropTypes.object,
     label: PropTypes.string,
     labelWidth: PropTypes.number,
-    tooltip:  PropTypes.string
+    tooltip:  PropTypes.string,
+    decimalDig: PropTypes.number,
+    handleChange: PropTypes.func           // callback on slider change
 };
 
 RangeSliderView.defaultProps = {
@@ -178,12 +103,14 @@ RangeSliderView.defaultProps = {
     vertical: false,
     defaultValue: 0,
     value: 0.0,
-    label: ''
+    label: '',
+    decimalDig: 3
 };
+
 
 export function checkMarksObject(props, propName, componentName) {
     if (isNumber(propName) ||
-        (isString(propName) && parseFloat(propName))) {
+        (isString(propName) && !isNaN(parseFloat(propName)))) {
         if (isString(props[propName]) || (isObject(props[propName]) &&
             has(props[propName], 'style') && has(props[propName], 'label'))) {
             return null;


### PR DESCRIPTION
The development includes:
- period finding layout before and after periodogram which contains the panels 
   (LcPeriods.jsx)
    . to enter values of period finding parameters
    . to show phase folding preview of xy plot
    . to show periodogram and peak tables and XT plots (after periodogram)
- Find periodogram dialog  which inherits some parameters from period finding panel
   (LcPeriodogram.jsx)
- Revamp LcManager to work with period finding and periodogram finding flow 
   (LcManager.js)
- add 'keepMounted' property to FieldGroup component which allows the parameters under the field group to be kept mounted while the component is unmounted. 
- update 'RangeSlider' component by removing the text input field attached to the slider. 
Test:
- localhost:8080/firefly/lc.html. 
- choose file - lc_raw.tbl ->search, 'Periof Finding' button is shown on the top menu after the search. 
- click button 'Period Finding' to get period finding layout
- enter values or move the slider in period finding panel to see the change of phase folding XY chart and the change of the buttons at the bottom ( 'Back to Period', 'Accept Period') 
- click button 'Find Periodogram' to get Periodogram popup dialog
   . 'reset' button restores the values to those as the popup is started. 
   . 'Periodogram Calculation' button exits the dialogs and calculates periodogram/peak tables and charts. 
  . 'cancel' button restores the field values and exits the dialog. 
- select the period from the periodogram/peak tables or charts to see the change of phase folding  plot. 