### PR TITLE
DM-8367: Line chart

### DIFF
--- a/src/firefly/js/charts/ChartDataType.js
+++ b/src/firefly/js/charts/ChartDataType.js
@@ -11,7 +11,7 @@ import {logError} from '../util/WebUtil.js';
  * @typedef {Object} ChartDataType - an object which specifies how to get chart data
  * @prop {string} id - unique chart data type id
  * @prop {Function} fetchData - function to load chart data element data: fetchData(dispatch, chartId, chartDataElementId)
- * @prop {Function} fetchParamsChanged - function to determine if fetch is necessary: fetchParamsChanged(oldOptions, newOptions)
+ * @prop {Function} fetchParamsChanged - function to determine if fetch is necessary: fetchParamsChanged(oldOptions, newOptions, chartDataElement)
  * @prop {Function} [getUpdatedOptions=undefined] - function to resolve the options, which depend on table or chart data getUpdatedOptions(options, tblId, data, meta)
  * @prop {boolean} [fetchOnTblSort=true] - if false, don't re-fetch data on tbl sort
  */

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -7,7 +7,7 @@
  * Utilities related to charts
  * Created by tatianag on 3/17/16.
  */
-import {uniqueId} from 'lodash';
+import {uniqueId, isUndefined, omitBy} from 'lodash';
 
 import {getTblById, getColumnIdx, getCellValue} from '../tables/TableUtil.js';
 import {Expression} from '../util/expr/Expression.js';
@@ -123,6 +123,8 @@ export function getNumericCols(cols) {
  * @prop {string}  [chartTitle] title of the chart
  * @prop {string}  xCol         column or expression to use for x values, can contain multiple column names ex. log(col) or (col1-col2)/col3
  * @prop {string}  yCol         column or expression to use for y values, can contain multiple column names ex. sin(col) or (col1-col2)/col3
+ * @prop {string}  [plotStyle]  points, linepoints, line
+ * @prop {string}  [sortColOrExpr] sort column or expression (when line plot is requested
  * @prop {number}  [xyRatio]    aspect ratio (must be between 1 and 10), if not defined the chart will fill all available space
  * @prop {string}  [stretch]    'fit' to fit plot into available space or 'fill' to fill the available width (applied when xyPlotRatio is defined)
  * @prop {string}  [xLabel]     label to use with x axis
@@ -131,6 +133,8 @@ export function getNumericCols(cols) {
  * @prop {string}  [yUnit]      unit for y axis
  * @prop {string}  [xOptions]   comma separated list of x axis options: grid,flip,log
  * @prop {string}  [yOptions]   comma separated list of y axis options: grid,flip,log
+ * @prop {string}  [xError]     column or expression for X error
+ * @prop {string}  [yError]     column or expression for Y error
  */
 
 /**
@@ -142,14 +146,16 @@ export function getNumericCols(cols) {
  * @memberof firefly.util.chart
  */
 export function makeXYPlotParams(params) {
-    const {xCol, yCol, xyRatio, stretch, xLabel, yLabel, xUnit, yUnit, xOptions, yOptions} = params;
+    const {xCol, yCol, xError, yError, xLabel, yLabel, xUnit, yUnit, xOptions, yOptions, plotStyle, sortColOrExpr, xyRatio, stretch} = params;
     const xyPlotParams = xCol && yCol ?
-    {
+    omitBy({
+        plotStyle,
+        sortColOrExpr,
         xyRatio,
         stretch,
-        x : { columnOrExpr : xCol, label : xLabel, unit : xUnit, options : xOptions},
-        y : { columnOrExpr : yCol, label : yLabel, unit : yUnit, options : yOptions}
-    } : undefined;
+        x : omitBy({ columnOrExpr : xCol, error: xError, label : xLabel, unit : xUnit, options : xOptions}, isUndefined),
+        y : omitBy({ columnOrExpr : yCol, error: yError, label : yLabel, unit : yUnit, options : yOptions}, isUndefined)
+    }, isUndefined) : undefined;
     return xyPlotParams;
 }
 

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -295,7 +295,7 @@ function doChartDataFetch(dispatch, payload, getChartDataType) {
         const fetchParamsChanged = chartDataElement.fetchParamsChanged  || cdt.fetchParamsChanged || (() => !isUndefined(fetchData));
 
         // need to fetch data if fetch parameters have changed
-        dataFetchNeeded = dataFetchNeeded || !oldOptions || fetchParamsChanged(oldOptions, newOptions);
+        dataFetchNeeded = dataFetchNeeded || !oldOptions ||  fetchParamsChanged(oldOptions, newOptions, chartDataElement);
 
         if (!dataFetchNeeded) {
             // when server call (fetch) parameters do not change but chart options change,

--- a/src/firefly/js/charts/dataTypes/XYColsCDT.js
+++ b/src/firefly/js/charts/dataTypes/XYColsCDT.js
@@ -16,6 +16,7 @@ import {colWithName, getNumericCols, SCATTER} from './../ChartUtil.js';
 import {serializeDecimateInfo} from '../../tables/Decimate.js';
 
 export const DT_XYCOLS = 'xycols';
+const DECI_ENABLE_SIZE = 5000; // matching QueryUtil.DECI_ENABLE_SIZE
 
 /**
  * Chart data type for XY columns
@@ -231,7 +232,7 @@ function serverParamsChanged(oldParams, newParams, chartDataElement) {
 
 function isLargeTable(tblId) {
     const {totalRows}= getTblById(tblId);
-    return (totalRows >= 5000);
+    return (totalRows >= DECI_ENABLE_SIZE);
 }
 
 //function errorsOrSortRequested(xyPlotParams) {

--- a/src/firefly/js/charts/dataTypes/XYColsCDT.js
+++ b/src/firefly/js/charts/dataTypes/XYColsCDT.js
@@ -197,31 +197,53 @@ export function setZoom(chartId, chartDataElementId, selection=undefined) {
     }
 }
 
-function serverParamsChanged(oldParams, newParams) {
+function serverParamsChanged(oldParams, newParams, chartDataElement) {
     if (oldParams === newParams) { return false; }
     if (!oldParams || !newParams) { return true; }
 
-    const newServerParams = getServerCallParameters(newParams);
-    const oldServerParams = getServerCallParameters(oldParams);
-    return newServerParams.some((p, i) => {
-        return p !== oldServerParams[i];
-    });
+    const {tblId, data} = chartDataElement;
+
+    if (isLargeTable(tblId)) {
+        const newServerParams = getServerCallParameters(newParams);
+        const oldServerParams = getServerCallParameters(oldParams);
+        return newServerParams.some((p, i) => {
+            return p !== oldServerParams[i];
+        });
+    } else {
+        // 'x', 'y', 'sortBy', 'xErr', 'xErrLow', 'xErrHigh', 'yErr', 'yErrLow', 'yErrHigh'
+        // server call parameters are present in the data
+        const newOpts = omitBy({
+            sortBy: newParams.sortColOrExpr,
+            x: newParams.x.columnOrExpr,
+            xErr: newParams.x.error,
+            xErrLow: newParams.x.errorLow,
+            xErrHigh: newParams.x.errorHigh,
+            y: newParams.y.columnOrExpr,
+            yErr: newParams.y.error,
+            yErrLow: newParams.y.errorLow,
+            yErrHigh: newParams.y.errorHigh
+        }, isUndefined);
+        return Object.keys(newOpts).some((o) => {
+            return newOpts[o] !== data[o];
+        });
+    }
 }
 
-function errorsRequested(xyPlotParams) {
-    return xyPlotParams &&
-        (xyPlotParams.x.error || xyPlotParams.y.error ||
-        xyPlotParams.x.errorLow || xyPlotParams.y.errorLow ||
-        xyPlotParams.x.errorHigh || xyPlotParams.y.errorHigh);
+function isLargeTable(tblId) {
+    const {totalRows}= getTblById(tblId);
+    return (totalRows >= 5000);
 }
+
+//function errorsOrSortRequested(xyPlotParams) {
+//    return xyPlotParams &&
+//        (xyPlotParams.sortColOrExpr ||
+//        xyPlotParams.x.error || xyPlotParams.y.error ||
+//        xyPlotParams.x.errorLow || xyPlotParams.y.errorLow ||
+//        xyPlotParams.x.errorHigh || xyPlotParams.y.errorHigh);
+//}
 
 function getServerCallParameters(xyPlotParams) {
     if (!xyPlotParams) { return []; }
-
-    if (errorsRequested(xyPlotParams)) {
-        return [xyPlotParams.x.columnOrExpr, xyPlotParams.x.error, xyPlotParams.x.errorLow, xyPlotParams.x.errorHigh,
-            xyPlotParams.y.columnOrExpr, xyPlotParams.y.error];
-    }
 
     if (xyPlotParams.zoom) {
         var {xMin, xMax, yMin, yMax}  = xyPlotParams.zoom;
@@ -315,17 +337,17 @@ function fetchPlotData(dispatch, chartId, chartDataElementId) {
     const chartDataElement = getChartDataElement(chartId, chartDataElementId);
     if (!chartDataElement) { logError(`[XYPlot] Chart data element is not found: ${chartId}, ${chartDataElementId}` ); return; }
 
-    const {tblId, options:xyPlotParams} = chartDataElement;
+    const {tblId} = chartDataElement;
     if (!tblId || !isFullyLoaded(tblId)) {return; }
 
-    if (errorsRequested(xyPlotParams)) {
-        fetchXYWithErrors(dispatch, chartId, chartDataElementId);
+    if (isLargeTable(tblId)) {
+        fetchXYLargeTable(dispatch, chartId, chartDataElementId);
     } else {
-        fetchXYNoErrors(dispatch, chartId, chartDataElementId);
+        fetchXYWithErrorsOrSort(dispatch, chartId, chartDataElementId);
     }
 }
 
-function fetchXYNoErrors(dispatch, chartId, chartDataElementId) {
+function fetchXYLargeTable(dispatch, chartId, chartDataElementId) {
     const chartDataElement = getChartDataElement(chartId, chartDataElementId);
 
     // tblId - table search request to obtain source table
@@ -415,7 +437,7 @@ function fetchXYNoErrors(dispatch, chartId, chartDataElementId) {
 }
 
 
-function fetchXYWithErrors(dispatch, chartId, chartDataElementId) {
+function fetchXYWithErrorsOrSort(dispatch, chartId, chartDataElementId) {
     const chartDataElement = getChartDataElement(chartId, chartDataElementId);
 
     // tblId - table search request to obtain source table
@@ -435,11 +457,13 @@ function fetchXYWithErrors(dispatch, chartId, chartDataElementId) {
     req.searchRequest = JSON.stringify(sreq);
     req.xColOrExpr = get(xyPlotParams, 'x.columnOrExpr');
     req.yColOrExpr = get(xyPlotParams, 'y.columnOrExpr');
+    req.sortColOrExpr = get(xyPlotParams, 'sortColOrExpr', req.xColOrExpr);
 
     if (!req.xColOrExpr || !req.yColOrExpr) {
         dispatchError(dispatch, chartId, chartDataElementId, 'Unknown X/Y column or expression');
     }
 
+    req.sortColOrExpr = get(xyPlotParams, 'sortColOrExpr'); // sort column for line plot
     req.xErrColOrExpr = get(xyPlotParams, 'x.error');
     req.xErrLowColOrExpr = get(xyPlotParams, 'x.errorLow');
     req.xErrHighColOrExpr = get(xyPlotParams, 'x.errorHigh');
@@ -466,7 +490,7 @@ function fetchXYWithErrors(dispatch, chartId, chartDataElementId) {
             if (tableModel.tableData.data.length>0) {
 
                 // create an array of column names that we recognize
-                const validCols = ['rowIdx', 'x', 'y', 'xErr', 'xErrLow', 'xErrHigh', 'yErr', 'yErrLow', 'yErrHigh'];
+                const validCols = ['rowIdx', 'x', 'y', 'sortBy', 'xErr', 'xErrLow', 'xErrHigh', 'yErr', 'yErrLow', 'yErrHigh'];
                 const colNames = tableModel.tableData.columns.map((col) => {
                     const name = col.name;
                     if (validCols.includes(name)) {
@@ -510,13 +534,19 @@ function fetchXYWithErrors(dispatch, chartId, chartDataElementId) {
                     } else if (x > xMax) {xMax = x; }
                     if (Number.isFinite(low)) {
                         if (low < yMin) { yMin = low; }
-                    } else if (y < yMin) { yMin = x; }
+                    } else if (y < yMin) { yMin = y; }
                     if (Number.isFinite(high)) {
                         if (high > yMax) { yMax = high; }
                     } else if (y > yMax) { yMax = y; }
                     return Object.assign(nrow, {left, right, low, high});
                 });
                 Object.assign(xyPlotData, {rows, xMin, xMax, yMin, yMax});
+                // save server call parameters, which were used to obtain the data
+                ['x', 'y', 'sortBy', 'xErr', 'xErrLow', 'xErrHigh', 'yErr', 'yErrLow', 'yErrHigh'].forEach((c) => {
+                    if (tableMeta[c]) {
+                        xyPlotData[c] = tableMeta[c];
+                    }
+                });
             }
         }
 
@@ -594,6 +624,13 @@ function getUpdatedParams(xyPlotParams, tblId, data) {
         }
     } else if (!isEmpty(boundaries)) {
         newParams = updateSet(newParams, 'boundaries', boundaries);
+    }
+
+    // if sortBy is set in the data, save sorting order in parameters
+    // needed to avoid server call, when data are already sorted as needed
+    const sortColOrExpr =  data['sortBy'];
+    if (sortColOrExpr && sortColOrExpr !== xyPlotParams.sortColOrExpr) {
+        newParams = updateSet(newParams, 'sortColOrExpr', sortColOrExpr);
     }
 
     return newParams;

--- a/src/firefly/js/charts/ui/XYPlot.jsx
+++ b/src/firefly/js/charts/ui/XYPlot.jsx
@@ -19,6 +19,9 @@ const defaultShading = 'lin';
 
 export const axisParamsShape = PropTypes.shape({
     columnOrExpr : PropTypes.string,
+    error : PropTypes.string, // for symmetric errors
+    errorLow : PropTypes.string, // for asymmetric errors
+    errorHigh : PropTypes.string, // for asymmetric errors
     label : PropTypes.string,
     unit : PropTypes.string,
     error: PropTypes.string,
@@ -33,6 +36,8 @@ export const selectionShape = PropTypes.shape({
 });
 
 export const plotParamsShape = PropTypes.shape({
+    plotStyle: PropTypes.oneOf(['points', 'line', 'linepoints']),
+    sortColOrExpr: PropTypes.string,
     xyRatio : PropTypes.number,
     stretch : PropTypes.oneOf(['fit','fill']),
     selection : selectionShape,
@@ -72,6 +77,10 @@ const selectedColor = 'rgba(255, 200, 0, 1)';
 const highlightedColor = 'rgba(255, 165, 0, 1)';
 const selectionRectColor = 'rgba(255, 209, 128, 0.5)';
 const selectionRectColorGray = 'rgba(165, 165, 165, 0.5)';
+
+const isLinePlot = function(plotStyle) {
+    return plotStyle === 'line' || plotStyle === 'linepoints';
+};
 
 /*
  @param {number} weight for a given point
@@ -580,7 +589,7 @@ export class XYPlot extends React.Component {
                 allSeries.push({
                     id: DATAPOINTS,
                     name: DATAPOINTS,
-                    type: params.plotStyle === 'line' ? 'line' : 'scatter',
+                    type: isLinePlot(params.plotStyle) ? 'line' : 'scatter',
                     color: hasErrorBars? datapointsColorWithErrors : datapointsColor,
                     data: rows,
                     marker,
@@ -753,6 +762,9 @@ export class XYPlot extends React.Component {
                     stickyTracking: false
                 },
                 line: {
+                    marker: {
+                        enabled: params.plotStyle === 'linepoints'
+                    },
                     states: {
                         hover: {
                             lineWidthPlus: 0 // do not increase line width when hovering over the series, default is 1

--- a/src/firefly/js/charts/ui/XYPlot.jsx
+++ b/src/firefly/js/charts/ui/XYPlot.jsx
@@ -293,7 +293,9 @@ export class XYPlot extends React.Component {
 
         // only re-render when the plot data change or an error occurs
         // shading change for density plot changes series
-        if (nextProps.data !== data || get(params, 'shading', defaultShading) !== get(nextProps.params, 'shading', defaultShading)) {
+        if (nextProps.data !== data ||
+            get(params, 'plotStyle') !== get(nextProps.params, 'plotStyle') ||
+            get(params, 'shading', defaultShading) !== get(nextProps.params, 'shading', defaultShading)) {
             return true;
         } else {
             const chart = this.refs.chart && this.refs.chart.getChart();
@@ -576,25 +578,26 @@ export class XYPlot extends React.Component {
                     });
                 }
                 allSeries.push({
-                        id: DATAPOINTS,
-                        name: DATAPOINTS,
-                        color: hasErrorBars? datapointsColorWithErrors : datapointsColor,
-                        data: rows,
-                        marker,
-                        turboThreshold: 0,
-                        showInLegend: false,
-                        point
-                    });
+                    id: DATAPOINTS,
+                    name: DATAPOINTS,
+                    type: params.plotStyle === 'line' ? 'line' : 'scatter',
+                    color: hasErrorBars? datapointsColorWithErrors : datapointsColor,
+                    data: rows,
+                    marker,
+                    turboThreshold: 0,
+                    showInLegend: false,
+                    point
+                });
                 allSeries.push({
-                        id: SELECTED,
-                        name: SELECTED,
-                        color: hasErrorBars? selectedColorWithErrors : selectedColor,
-                        data: selectedRows,
-                        marker,
-                        turboThreshold: 0,
-                        showInLegend: false,
-                        point
-                    });
+                    id: SELECTED,
+                    name: SELECTED,
+                    color: hasErrorBars? selectedColorWithErrors : selectedColor,
+                    data: selectedRows,
+                    marker,
+                    turboThreshold: 0,
+                    showInLegend: false,
+                    point
+                });
             } else {
                 const {xUnitPx, yUnitPx} = getDeciSymbolSize(chart, decimateKey);
                 marker = {symbol: 'rectangle', radius: xUnitPx/2.0, hD: (xUnitPx-yUnitPx)/2.0};
@@ -743,11 +746,25 @@ export class XYPlot extends React.Component {
                 symbolWidth: 12,
                 symbolRadius: 6
             },
+            plotOptions: {
+                series: {
+                    animation: false,
+                    cursor: 'pointer',
+                    stickyTracking: false
+                },
+                line: {
+                    states: {
+                        hover: {
+                            lineWidthPlus: 0 // do not increase line width when hovering over the series, default is 1
+                        }
+                    }
+                }
+            },
             title: {
                 text: desc
             },
             tooltip: {
-
+                snap: 10,
                 borderWidth: 1,
                 formatter() {
                     const weight = this.point.weight ? `represents ${this.point.weight} points <br/>` : '';
@@ -761,14 +778,6 @@ export class XYPlot extends React.Component {
                 },
                 shadow: !(decimateKey),
                 useHTML: Boolean((decimateKey))
-            },
-            plotOptions: {
-                scatter: {
-                    animation: false,
-                    cursor: 'pointer',
-                    snap: 10, // proximity to the point for mouse events
-                    stickyTracking: false
-                }
             },
             xAxis: {
                 min: selFinite(xMin, xDataMin),

--- a/src/firefly/js/charts/ui/XYPlotOptions.jsx
+++ b/src/firefly/js/charts/ui/XYPlotOptions.jsx
@@ -59,7 +59,7 @@ export function resultsSuccess(callback, flds, tblId) {
     const yErr = get(flds, ['y.error']);
 
     const plotStyle = get(flds, ['plotStyle']);
-    const sortColOrExpr = (plotStyle === 'line') ? xName : undefined;
+    const sortColOrExpr = plotStyle.startsWith('line') ? xName : undefined;
 
     const xOptions = get(flds, ['x.options']);
     const xLabel = get(flds, ['x.label']);
@@ -485,10 +485,11 @@ export class XYPlotOptions extends React.Component {
                         initialState= {{
                             value: get(xyPlotParams, 'plotStyle', 'points'),
                             tooltip: 'Select plot style',
-                            label : 'Plot style:'
+                            label : 'Plot Style:'
                         }}
                         options={[
                             {label: 'Points', value: 'points'},
+                            {label: 'Connected Points', value: 'linepoints'},
                             {label: 'Line', value: 'line'}
                         ]}
                         fieldKey='plotStyle'

--- a/src/firefly/js/charts/ui/XYPlotOptions.jsx
+++ b/src/firefly/js/charts/ui/XYPlotOptions.jsx
@@ -58,6 +58,9 @@ export function resultsSuccess(callback, flds, tblId) {
     const xErr = get(flds, ['x.error']);
     const yErr = get(flds, ['y.error']);
 
+    const plotStyle = get(flds, ['plotStyle']);
+    const sortColOrExpr = (plotStyle === 'line') ? xName : undefined;
+
     const xOptions = get(flds, ['x.options']);
     const xLabel = get(flds, ['x.label']);
     const xUnit = get(flds, ['x.unit']);
@@ -95,6 +98,8 @@ export function resultsSuccess(callback, flds, tblId) {
       */
 
     const xyPlotParams = omitBy({
+        plotStyle,
+        sortColOrExpr,
         userSetBoundaries,
         xyRatio : Number.isFinite(xyRatio) ? xyRatio : undefined,
         stretch : flds.stretch,
@@ -120,6 +125,7 @@ export function resultsFail() {
 
 export function setOptions(groupKey, xyPlotParams) {
     const flds = [
+        {fieldKey: 'plotStyle', value: get(xyPlotParams, 'plotStyle', 'points')},
         {fieldKey: 'x.columnOrExpr', value: get(xyPlotParams, 'x.columnOrExpr')},
         {fieldKey: 'x.error', value: get(xyPlotParams, 'x.error')},
         {fieldKey: 'x.label', value: get(xyPlotParams, 'x.label')},
@@ -449,7 +455,7 @@ export class XYPlotOptions extends React.Component {
     render() {
         const { colValStats, groupKey, xyPlotParams, defaultParams, onOptionsSelected}= this.props;
 
-        const noLogOption = possibleDecimatedTable(colValStats);
+        const largeTable = possibleDecimatedTable(colValStats);
 
         const xProps = {colValStats,params:xyPlotParams,groupKey,fldPath:'x.columnOrExpr',label:'X',tooltip:'X Axis',nullAllowed:false};
         const yProps = {colValStats,params:xyPlotParams,groupKey,fldPath:'y.columnOrExpr',label:'Y',tooltip:'Y Axis',nullAllowed:false};
@@ -474,12 +480,28 @@ export class XYPlotOptions extends React.Component {
                         </div>
                     </div>}
 
+                    {!largeTable && <RadioGroupInputField
+                        alignment='horizontal'
+                        initialState= {{
+                            value: get(xyPlotParams, 'plotStyle', 'points'),
+                            tooltip: 'Select plot style',
+                            label : 'Plot style:'
+                        }}
+                        options={[
+                            {label: 'Points', value: 'points'},
+                            {label: 'Line', value: 'line'}
+                        ]}
+                        fieldKey='plotStyle'
+                        groupKey={groupKey}
+                        labelWidth={50}
+                    />}
+                    {!largeTable && <br/>}
                     <div style={helpStyle}>
                         For X and Y, enter a column or an expression<br/>
                         ex. log(col); 100*col1/col2; col1-col2
                     </div>
                     <ColumnOrExpression {...xProps}/>
-                    <ColumnOrExpression {...xErrProps}/>
+                    {!largeTable && <ColumnOrExpression {...xErrProps}/>}
 
                     <FieldGroupCollapsible  header='X Label/Unit/Options'
                                             initialState= {{ value:'closed' }}
@@ -512,7 +534,7 @@ export class XYPlotOptions extends React.Component {
                                 tooltip: 'Check if you would like to plot grid',
                                 label : 'Options:'
                             }}
-                            options={noLogOption ? X_AXIS_OPTIONS_NOLOG : X_AXIS_OPTIONS}
+                            options={largeTable ? X_AXIS_OPTIONS_NOLOG : X_AXIS_OPTIONS}
                             fieldKey='x.options'
                             groupKey={groupKey}
                             labelWidth={50}
@@ -521,7 +543,7 @@ export class XYPlotOptions extends React.Component {
                     <br/>
 
                     <ColumnOrExpression {...yProps}/>
-                    <ColumnOrExpression {...yErrProps}/>
+                    {!largeTable && <ColumnOrExpression {...yErrProps}/>}
 
                     <FieldGroupCollapsible  header='Y Label/Unit/Options'
                                             initialState= {{ value:'closed' }}
@@ -555,7 +577,7 @@ export class XYPlotOptions extends React.Component {
                                 label : 'Options:'
 
                             }}
-                            options={noLogOption ? Y_AXIS_OPTIONS_NOLOG : Y_AXIS_OPTIONS}
+                            options={largeTable ? Y_AXIS_OPTIONS_NOLOG : Y_AXIS_OPTIONS}
                             fieldKey='y.options'
                             groupKey={groupKey}
                             labelWidth={50}

--- a/src/firefly/js/ui/RadioGroupInputFieldView.jsx
+++ b/src/firefly/js/ui/RadioGroupInputFieldView.jsx
@@ -1,4 +1,5 @@
 import React, {PropTypes}  from 'react';
+import {uniqueId} from 'lodash';
 import InputFieldLabel from './InputFieldLabel.jsx';
 
 const vStyle={paddingLeft: 3, paddingRight: 8};
@@ -8,12 +9,13 @@ const hStyle={paddingLeft: 0, paddingRight: 12};
 function makeOptions(options,alignment,fieldKey,value,onChange,tooltip) {
 
     const labelStyle= alignment==='vertical' ? vStyle : hStyle;
+    const uniqueName = uniqueId(fieldKey);
     return options.map((option) => (
         <span key={option.value}>
             <div style={{display:'inline-block'}} title={tooltip}>
                 <input type='radio'
                        title={tooltip}
-                       name={fieldKey}
+                       name={uniqueName}
                        value={option.value}
                        checked={value===option.value}
                        onChange={onChange}


### PR DESCRIPTION
Added support for line plot
- added plotStyle ('points' and 'line', defaults to 'points') and sortColOrExpr (defaults to x.colOrExpr) to XY plot parameters. For smaller (<5000 rows) tables, plotStyle shows in options; 
- added support for sortColOrExpr to XYWithErrorsProcessor;
- improved the logic to see if server fetch is needed, the function now has access to the server call parameters, with which the data were obtained 

To test, load a catalog less then 5000. Open options and select 'Line' as a plot style.

https://jira.lsstcorp.org/browse/DM-8367