### PR TITLE
DM-8985: server now finding image with mask extension, mask UI implemented

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -537,6 +537,8 @@
             firefly.getViewer().showImage({plotId: 'xxq',
                 Service: 'TWOMASS',
                 Title  : '2mass from service',
+                ZoomType : 'LEVEL',
+                initZoomLevel : 2,
                 SurveyKey  : 'k',
                 WorldPt    : '10.68479;41.26906;EQ_J2000',
                 RangeValues : firefly.util.image.serializeSimpleRangeValues("Sigma",-1,2,"Linear"),

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
@@ -37,7 +37,7 @@ public class RelatedData implements Serializable {
         d.dataType= IMAGE_MASK;
         d.availableMask= availableMask;
 
-        d.desc= null;
+        d.desc= "Mask";
         d.searchParams.put(WebPlotRequest.FILE, fileName);
         d.searchParams.put(WebPlotRequest.PLOT_AS_MASK, "true");
         d.searchParams.put(WebPlotRequest.TYPE, RequestType.FILE+"");
@@ -52,7 +52,7 @@ public class RelatedData implements Serializable {
         d.dataType= IMAGE_MASK;
         d.availableMask= availableMask;
 
-        d.desc= null;
+        d.desc= "Mask";
         d.searchParams= searchParams;
         return d;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/FileReadInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/FileReadInfo.java
@@ -3,10 +3,12 @@
  */
 package edu.caltech.ipac.firefly.server.visualize;
 
+import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.visualize.plot.FitsRead;
 
 import java.io.File;
+import java.util.List;
 
 /**
 * @author Trey Roby
@@ -20,6 +22,7 @@ class FileReadInfo {
     private final FitsRead fr;
     private final String dataDesc;
     private final ModFileWriter modFileWriter;
+    private final List<RelatedData> relatedData;
     private final String uploadedName;
 
     FileReadInfo(File originalFile,
@@ -28,6 +31,7 @@ class FileReadInfo {
                  int imageIdx,
                  String dataDesc,
                  String uploadedName,
+                 List<RelatedData> relatedData,
                  ModFileWriter modFileWriter) {
         this.originalFile= originalFile;
         this.workingFile = originalFile;
@@ -36,6 +40,7 @@ class FileReadInfo {
         this.fr= fr;
         this.modFileWriter= modFileWriter;
         this.dataDesc= dataDesc;
+        this.relatedData= relatedData;
         this.uploadedName= uploadedName;
     }
 
@@ -47,4 +52,5 @@ class FileReadInfo {
     public String getDataDesc() { return dataDesc; }
     public ModFileWriter getModFileWriter() { return modFileWriter; }
     public String getUploadedName() {return uploadedName;}
+    public List<RelatedData> getRelatedData() {return relatedData;}
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotInfo.java
@@ -9,12 +9,14 @@ package edu.caltech.ipac.firefly.server.visualize;
  */
 
 
+import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.firefly.visualize.PlotState;
 import edu.caltech.ipac.firefly.visualize.WebFitsData;
 import edu.caltech.ipac.visualize.plot.ActiveFitsReadGroup;
 import edu.caltech.ipac.visualize.plot.ImagePlot;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,18 +28,21 @@ public class ImagePlotInfo {
     private final ActiveFitsReadGroup frGroup;
     private final Map<Band,WebFitsData> wfDataMap;
     private final Map<Band,ModFileWriter> fileWriterMap;
+    private final List<RelatedData> relatedData;
     private final String dataDesc;
 
     public ImagePlotInfo(PlotState state,
                          ImagePlot plot,
                          ActiveFitsReadGroup frGroup,
                          String    dataDesc,
+                         List<RelatedData> relatedData,
                          Map<Band, WebFitsData> wfDataMap,
                          Map<Band, ModFileWriter> fileWriterMap) {
         this.state = state;
         this.plot = plot;
         this.frGroup = frGroup;
         this.wfDataMap = wfDataMap;
+        this.relatedData= relatedData;
         this.fileWriterMap = fileWriterMap;
         this.dataDesc = dataDesc;
     }
@@ -48,5 +53,6 @@ public class ImagePlotInfo {
     public Map<Band, ModFileWriter> getFileWriterMap() { return fileWriterMap; }
     public String getDataDesc() { return dataDesc; }
     public ActiveFitsReadGroup getFrGroup() { return frGroup; }
+    public List<RelatedData> getRelatedData() {return relatedData;}
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/PlotServUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/PlotServUtils.java
@@ -188,6 +188,21 @@ public class PlotServUtils {
 
 
 
+    public static File createRotatedFile(FitsRead originalFR,
+                                         String originalFileStr,
+                                         String workingFileStr,
+                                         PlotState.RotateType rotateType,
+                                         double angle,
+                                         CoordinateSys rotNorthType) throws FitsException, IOException, GeomException {
+
+        String fStr = originalFileStr != null ? originalFileStr : workingFileStr;
+        File originalFile = ServerContext.convertToFile(fStr);
+        boolean rotateNorth = (rotateType == PlotState.RotateType.NORTH);
+        File f = rotateNorth ? createRotateNorthFile(originalFile, originalFR, rotNorthType) :
+                               createRotatedAngleFile(originalFile, originalFR, angle);
+        return f;
+    }
+
     public static File createRotateNorthFile(File originalFile,
                                              FitsRead originalFR,
                                              CoordinateSys rotateNorthType) throws FitsException,
@@ -215,7 +230,7 @@ public class PlotServUtils {
     }
 
 
-    public static File createRotatedFile(File originalFile, FitsRead originalFR, double angle) throws FitsException,
+    public static File createRotatedAngleFile(File originalFile, FitsRead originalFR, double angle) throws FitsException,
                                                                                                       IOException,
                                                                                                       GeomException {
         FitsRead rotateFR= FitsRead.createFitsReadRotated(originalFR, angle, false);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/PlotStateUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/PlotStateUtil.java
@@ -59,6 +59,9 @@ public class PlotStateUtil {
         state.setMultiImageAction(threeC ? PlotState.MultiImageAction.USE_FIRST : PlotState.MultiImageAction.USE_ALL);
 
         state.setContextString(CtxControl.makeCachedCtx());
+        for(PlotState.Operation op : initializerState.getOperations()) {
+            state.addOperation(op);
+        }
         initState(state, req, initializerState);
         CtxControl.getPlotCtx(state.getContextString()).setPlotState(state);
         for(Band band : initializerState.getBands()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -10,6 +10,7 @@ package edu.caltech.ipac.firefly.server.visualize;
  */
 
 
+import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.firefly.visualize.BandState;
 import edu.caltech.ipac.firefly.visualize.ClientFitsHeader;
@@ -31,6 +32,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -51,6 +53,7 @@ public class VisJsonSerializer {
 
         map.put("imageCoordSys", wpInit.getCoordinatesOfPlot().toString());
         map.put("projectionJson", serializeProjection(wpInit));
+        map.put("relatedData", serializeRelatedDataArray(wpInit.getRelatedData()));
         map.put("dataWidth", wpInit.getDataWidth());
         map.put("dataHeight", wpInit.getDataHeight());
         map.put("imageScaleFactor", wpInit.getImageScaleFactor());
@@ -65,7 +68,25 @@ public class VisJsonSerializer {
         map.put("fitsData", ary);
 
         return map;
+    }
 
+    public static JSONArray serializeRelatedDataArray(List<RelatedData> relatedData) {
+        if (relatedData==null || relatedData.size()==0) return null;
+        JSONArray relatedArray= new JSONArray();
+        for(RelatedData r : relatedData) relatedArray.add(serializeRelated(r));
+        return relatedArray;
+    }
+
+    public static JSONObject serializeRelated(RelatedData rData) {
+        if (rData==null) return null;
+        JSONObject retObj= new JSONObject();
+        retObj.put("dataType", rData.getDataType());
+        if (rData.getAvailableMask().size()>0) {
+            retObj.put("availableMask", new JSONObject(rData.getAvailableMask()));
+        }
+        retObj.put("searchParams", new JSONObject(rData.getSearchParams()));
+        retObj.put("desc", rData.getDesc());
+        return retObj;
     }
 
     public static JSONObject serializeProjection(WebPlotInitializer wpInit) {
@@ -131,7 +152,7 @@ public class VisJsonSerializer {
         map.put("map_distortion", p.map_distortion);
         map.put("keyword", p.keyword);
 
-        for(Map.Entry<String,String> e : p.additionalHeaders.entrySet() ) {
+        for(Map.Entry<String,String> e : p.sendToClientHeaders.entrySet() ) {
             map.put(e.getKey(),e.getValue());
         }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
@@ -113,7 +113,7 @@ public class WebPlotFactory {
         Map<Band, WebPlotRequest> requestMap = new LinkedHashMap<Band, WebPlotRequest>(5);
         for (Band band : state.getBands()) requestMap.put(band, state.getWebPlotRequest(band));
         for(WebPlotRequest req : requestMap.values()) {
-            req.setZoomType(ZoomType.STANDARD);
+            req.setZoomType(ZoomType.LEVEL);
             req.setInitialZoomLevel(state.getZoomLevel());
         }
         WebPlotInitializer wpAry[] = create(requestMap, null, state, state.isThreeColor());
@@ -331,7 +331,8 @@ public class WebPlotFactory {
                                       pInfo.getFrGroup().getFitsRead(state.firstBand()).getImageScaleFactor(),
                                       wfDataAry,
                                       plot.getPlotDesc(),
-                                      pInfo.getDataDesc());
+                                      pInfo.getDataDesc(),
+                                      pInfo.getRelatedData());
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
@@ -406,6 +406,15 @@ public class WebPlotReader {
         }
     }
 
+    /**
+     * This method attempts to find how data might be related in a multi-extension fits file. I expect it will grow
+     * and become more advanced over time.
+     * Currently it looks of the extension type marked 'IMAGE' and makes that the based. Any extensions marked 'MASK' or
+     * 'VARIANCE' are related data.
+     * @param f the fits file name
+     * @param frAry the array of FitsRead objects that came from the file.
+     * @return the data relations
+     */
     private static List<List<RelatedData>> investigateRelations(File f, FitsRead frAry[]) {
         if (frAry.length>1) {
             int imageIdx= -1;

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
@@ -4,6 +4,7 @@
 package edu.caltech.ipac.firefly.visualize;
 
 import edu.caltech.ipac.firefly.data.DataEntry;
+import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.visualize.plot.CoordinateSys;
 import edu.caltech.ipac.visualize.plot.projection.Projection;
 
@@ -34,6 +35,7 @@ public class WebPlotInitializer implements Serializable, DataEntry {
     private WebFitsData   _fitsData[];
     private String        _desc;
     private String        _dataDesc;
+    private transient List<RelatedData> relatedData;
     private transient Projection _projection;
 
 
@@ -50,7 +52,8 @@ public class WebPlotInitializer implements Serializable, DataEntry {
                              int imageScaleFactor,
                              WebFitsData  fitsData[],
                              String desc,
-                             String dataDesc) {
+                             String dataDesc,
+                             List<RelatedData> relatedData ) {
 
         _plotState= plotState;
         _initImages= images;
@@ -63,6 +66,7 @@ public class WebPlotInitializer implements Serializable, DataEntry {
         _fitsData= fitsData;
         _desc= desc;
         _dataDesc= dataDesc;
+        this.relatedData= relatedData;
     }
 
 //======================================================================
@@ -79,6 +83,7 @@ public class WebPlotInitializer implements Serializable, DataEntry {
     }
 
     public String getProjectionSerialized() { return _projectionSerialized; }
+    public List<RelatedData> getRelatedData() { return  relatedData; }
 
     public int getDataWidth() { return _dataWidth; }
     public int getDataHeight() { return _dataHeight; }
@@ -125,13 +130,13 @@ public class WebPlotInitializer implements Serializable, DataEntry {
                 PlotState     plotState= PlotState.parse(sAry[i++]);
                 String        desc= getString(sAry[i++]);
                 String        dataDesc= getString(sAry[i++]);
-                List<WebFitsData> fdList= new ArrayList<WebFitsData>(3);
+                List<WebFitsData> fdList= new ArrayList<>(3);
                 while (i<sAry.length) {
                    fdList.add(WebFitsData.parse(sAry[i++]));
                 }
                 WebFitsData fitsData[]= fdList.toArray(new WebFitsData[fdList.size()]);
                 retval= new WebPlotInitializer(plotState,initImages,imageCoordSys,projection,dataWidth,dataHeight,
-                                               imageScaleFactor,fitsData,desc,dataDesc);
+                                               imageScaleFactor,fitsData,desc,dataDesc, null);
 
             } catch (NumberFormatException e) {
                 retval= null;

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
@@ -67,6 +67,7 @@ public class WebPlotRequest extends ServerRequest {
     public static final String ROTATE_NORTH = "RotateNorth";
     public static final String ROTATE_NORTH_TYPE = "RotateNorthType";
     public static final String ROTATE = "Rotate";
+    public static final String ROTATE_FROM_NORTH= "RotateFromNorth";
     public static final String ROTATION_ANGLE = "RotationAngle";
     public static final String HEADER_KEY_FOR_TITLE = "HeaderKeyForTitle";
     public static final String INIT_RANGE_VALUES = "RangeValues";
@@ -152,7 +153,7 @@ public class WebPlotRequest extends ServerRequest {
                                               GRID_ON, TITLE_OPTIONS, EXPANDED_TITLE_OPTIONS,
                                               POST_TITLE, PRE_TITLE, OVERLAY_POSITION,
                                               TITLE_FILENAME_MODE_PFX, MINIMAL_READOUT, DRAWING_SUB_GROUP_ID, GRID_ID,
-                                              DOWNLOAD_FILENAME_ROOT, PLOT_ID
+                                              DOWNLOAD_FILENAME_ROOT, PLOT_ID, ROTATE_FROM_NORTH
 
     };
 
@@ -609,9 +610,14 @@ public class WebPlotRequest extends ServerRequest {
     }
 
     public ZoomType getZoomType() {
-        ZoomType retval = ZoomType.STANDARD;
+        ZoomType retval = ZoomType.LEVEL;
+        int w= getZoomToWidth();
+        int h= getZoomToHeight();
         if (this.containsParam(ZOOM_TYPE)) {
             retval = Enum.valueOf(ZoomType.class, getParam(ZOOM_TYPE));
+        }
+        else if (w>0 && h>0){
+            retval = ZoomType.TO_WIDTH_HEIGHT;
         }
         return retval;
     }
@@ -691,6 +697,9 @@ public class WebPlotRequest extends ServerRequest {
         return getBooleanParam(ROTATE);
     }
 
+    public void setRotateFromNorth(boolean fromNorth) { this.setParam(ROTATE_FROM_NORTH, fromNorth+ ""); }
+
+    public boolean getRotateFromNorth() { return getBooleanParam(ROTATE_FROM_NORTH,true); }
 
     /**
      * set the angle to rotate to

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/ZoomType.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/ZoomType.java
@@ -14,6 +14,7 @@ package edu.caltech.ipac.firefly.visualize;
 */
 public enum ZoomType {
                       STANDARD,       // use normal zoom, zoom to given zoom level or 1x if not specified
+                      LEVEL,       // use normal zoom, zoom to given zoom level or 1x if not specified
                       FORCE_STANDARD, // Like standard, however even expanded mode does not override
                       SMART,         // use smart zoom - this is deprecated, don't use anymore
                       FULL_SCREEN,       // requires width & height specified

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -364,7 +364,6 @@ public class URLDownload {
                                          String postData) throws FailedRequestException, IOException {
         try {
             FileInfo outFileData;
-            FileInfo retval;
             int responseCode= 200;
             Map<String,List<String>> sendHeaders= null;
             try {
@@ -423,23 +422,22 @@ public class URLDownload {
 
                 in = makeDataInStream(conn);
             }
-            outFileData = new FileInfo(f, suggested, responseCode);
             out = makeOutStream(f);
-            retval = outFileData;
 
 
             long start = System.currentTimeMillis();
             netCopy(in, out, conn, maxFileSize, dl);
 
             long elapse = System.currentTimeMillis() - start;
-            logDownload(retval, conn.getURL().toString(), elapse );
+            outFileData = new FileInfo(f, suggested, responseCode);
+            logDownload(outFileData, conn.getURL().toString(), elapse );
 
             if (responseCode>=300 && responseCode<400) {
                 DException de= new DException(outFileData, responseCode, null);
                 throw new FailedRequestException("Network request failed", "Error: "+responseCode, de);
             }
 
-            return retval;
+            return outFileData;
         } catch (IOException e) {
             logError(conn.getURL(), e);
             throw e;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
@@ -77,7 +77,8 @@ public class ImageHeader implements Serializable
     public double bp[][] = new double[ProjectionParams.MAX_SIP_LENGTH][ProjectionParams.MAX_SIP_LENGTH];
     public boolean map_distortion = false;
     public String keyword;
-	public Map<String,String> additionalHeaders= new HashMap<>(77);
+	public Map<String,String> maskHeaders= new HashMap<>(23);
+	public Map<String,String> sendToClientHeaders = new HashMap<>(23);
 
 
     public ImageHeader()
@@ -112,11 +113,12 @@ public class ImageHeader implements Serializable
 	for(;extraIter.hasNext();) {
 		hc= (HeaderCard)extraIter.next();
 		if (hc.getKey().startsWith("MP") || hc.getKey().startsWith("HIERARCH.MP")) {
-			additionalHeaders.put(hc.getKey(), hc.getValue());
+			maskHeaders.put(hc.getKey(), hc.getValue());
+			sendToClientHeaders.put(hc.getKey(), hc.getValue());
 		}
 	}
 	hc= header.findCard("EXTTYPE");
-	if (hc!=null) additionalHeaders.put(hc.getKey(), hc.getValue());
+	if (hc!=null) sendToClientHeaders.put(hc.getKey(), hc.getValue());
 
 
 
@@ -729,7 +731,7 @@ public class ImageHeader implements Serializable
     public static ProjectionParams createProjectionParams(ImageHeader hdr) {
         ProjectionParams params= new ProjectionParams();
 
-		params.additionalHeaders= hdr.additionalHeaders;
+		params.sendToClientHeaders= hdr.sendToClientHeaders;
         params.bitpix= hdr.bitpix;
         params.naxis = hdr.naxis;
         params.naxis1= hdr.naxis1;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/ProjectionParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/ProjectionParams.java
@@ -48,7 +48,7 @@ public class ProjectionParams implements Serializable {
     public double bp[][] = new double[MAX_SIP_LENGTH][MAX_SIP_LENGTH];
     public boolean map_distortion = false;
     public String keyword;
-    public Map<String,String> additionalHeaders= new HashMap<>();
+    public Map<String,String> sendToClientHeaders= new HashMap<>();
 
     public ProjectionParams() {}
 }

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -12,10 +12,12 @@ import CompleteButton from './CompleteButton.jsx';
 import {FieldGroup} from './FieldGroup.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
 import {PopupPanel} from './PopupPanel.jsx';
+import {showInfoPopup} from './PopupUtil.jsx';
 import FieldGroupUtils from '../fieldGroup/FieldGroupUtils.js';
 import {primePlot} from '../visualize/PlotViewUtil.js';
 import {visRoot, dispatchRotate, ActionScope} from '../visualize/ImagePlotCntlr.js';
 import {RotateType} from '../visualize/PlotState.js';
+import {isOverlayLayersActive} from '../visualize/RelatedDataUtil.js';
 
 import HelpIcon from './HelpIcon.jsx';
 
@@ -37,8 +39,13 @@ function getDialogBuilder() {
 const dialogBuilder = getDialogBuilder();
 
 export function showFitsRotationDialog() {
-    dialogBuilder();
-    dispatchShowDialog('fitsRotationDialog');
+    if (isOverlayLayersActive(visRoot())) {
+       showInfoPopup('Rotate not yet supported with mask layers');
+    }
+    else {
+        dialogBuilder();
+        dispatchShowDialog('fitsRotationDialog');
+    }
 }
 
 

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -302,9 +302,10 @@ export function dispatchApiToolsView(apiToolsView) {
  * @param plotId
  * @param message
  * @param done
+ * @param requestKey
  */
-export function dispatchPlotProgressUpdate(plotId, message, done ) {
-    flux.process({ type: PLOT_PROGRESS_UPDATE, payload: { plotId, done, message }});
+export function dispatchPlotProgressUpdate(plotId, message, done, requestKey ) {
+    flux.process({ type: PLOT_PROGRESS_UPDATE, payload: { plotId, done, message, requestKey }});
 }
 
 /**
@@ -428,9 +429,10 @@ export function dispatchWcsMatch({plotId, matchType, dispatcher= flux.process} )
 export function dispatchRotate({plotId, rotateType, angle=-1, newZoomLevel=0,
                                 keepWcsLock= false,
                                 actionScope=ActionScope.GROUP,
+                                onlyRotateBase= false,
                                 dispatcher= flux.process} ) {
     dispatcher({ type: ROTATE,
-        payload: { plotId, angle, rotateType, actionScope, newZoomLevel, keepWcsLock}});
+        payload: { plotId, angle, rotateType, actionScope, newZoomLevel, onlyRotateBase, keepWcsLock}});
 }
 
 

--- a/src/firefly/js/visualize/RelatedDataUtil.js
+++ b/src/firefly/js/visualize/RelatedDataUtil.js
@@ -1,0 +1,190 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {difference,get, flatten, values, uniq, isEmpty} from 'lodash';
+import {getPlotViewIdListInGroup, getPlotViewById, operateOnOthersInGroup} from './PlotViewUtil.js';
+import {WPConst} from './WebPlotRequest.js';
+import {RDConst} from './WebPlot.js';
+import {visRoot, dispatchPlotMask, dispatchOverlayPlotChangeAttributes, dispatchPlotMaskLazyLoad} from './ImagePlotCntlr.js';
+
+
+
+
+//--------------------------------------------------------------
+//--------------------------------------------------------------
+//--------- related data and OverlayPlotView functions
+//--------------------------------------------------------------
+//--------------------------------------------------------------
+
+export function findRelatedData(pv) {
+    if (!get(pv,'plots')) return [];
+
+    const relatedData= flatten(pv.plots.map( (p) =>  p.relatedData))
+        .filter( (r,idx) => dataTypeMatches(r,idx,pv));
+    return relatedData;
+}
+
+function dataTypeMatches(r,idx, pv) {
+    const dataType= get(r,'dataType');
+    if (!RDConst.SUPPORTED_DATATYPES.includes(dataType)) return false;
+
+    if (dataType===RDConst.IMAGE_MASK) {
+        const opvAry= pv.overlayPlotViews.filter((opv) => opv.relatedDataId===r.relatedDataId);
+        if (!opvAry.length) return true;
+        const maskNumberAry= values(r.availableMask);
+        if (maskNumberAry.length!==opvAry.length) return true;
+    }
+    else {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * apply a function to all OverlayPlotView that match the passed, match is determined by same group and title
+ * @param {VisRoot}  vr
+ * @param {OverlayPlotView} opv
+ * @param {Function} func  an OverlayPlotView is passed as parameter
+ */
+export function operateOnOverlayPlotViewsThatMatch(vr, opv, func) {
+    const opvList= flatten(getPlotViewIdListInGroup(vr, opv.plotId)
+        .map( (id) => getPlotViewById(vr,id).overlayPlotViews))
+        .filter( (aOpv) => get(aOpv,'title')===opv.title);
+
+    opvList.forEach( (aOpv) => func(aOpv));
+}
+
+export function setMaskVisible(opv, visible) {
+    if (!visible || opv.plot) {
+        dispatchOverlayPlotChangeAttributes({plotId:opv.plotId, imageOverlayId:opv.imageOverlayId, attributes:{visible}});
+    }
+    else if (visible && opv.lazyLoadPayload) {
+        dispatchPlotMaskLazyLoad(opv.lazyLoadPayload);
+    }
+}
+
+
+
+
+//===========  Note the following set of related data functions might should go in another file.
+//===========  maybe even an action creator, not sure so for now I am going to keep it like this.
+
+/**
+ * Do processing to turn this related data into a drawing layer
+ * @param {VisRoot}  vr
+ * @param {PlotView} pv
+ * @param {RelatedData} relatedData
+ */
+export function enableRelatedDataLayer(vr, pv, relatedData) {
+    if (!relatedData) return;
+    switch (relatedData.dataType) {
+        case RDConst.IMAGE_MASK:
+            enableRelatedDataLayerMaskInGroup(vr, pv,relatedData);
+            break;
+        case RDConst.IMAGE_OVERLAY:
+            break;
+        case RDConst.TABLE:
+            break;
+    }
+}
+
+
+
+function enableRelatedDataLayerMaskInGroup(vr, pv,relatedData) {
+    enableRelatedDataLayerMask(pv,relatedData);
+
+    operateOnOthersInGroup(vr, pv, (aPv) => {
+        const rd= findRelatedData(aPv).filter( (aRd) => aRd.dataType===RDConst.IMAGE_MASK);
+        if (rd[0]) enableRelatedDataLayerMask(aPv,rd[0]);
+    } );
+}
+
+
+function enableRelatedDataLayerMask(pv, relatedData) {
+    const hdu= relatedData.searchParams[WPConst.MULTI_IMAGE_IDX];
+    const fileKey= relatedData.searchParams[WPConst.FILE];
+
+
+    const availMaskValues= values(relatedData.availableMask).map( (v) => Number(v));
+    const activeMaskValues= pv.overlayPlotViews.map( (opv) => Number(opv.maskNumber));
+
+    difference(availMaskValues,activeMaskValues)
+        .sort( (v1,v2) => v1-v2)
+        .forEach(  (v) =>
+            {
+                addMaskLayer(pv, v, hdu, fileKey, relatedData);
+            }
+        );
+
+
+}
+
+const maskIdRoot= 'AUTO_LOADED_MASK';
+var maskCnt= 0;
+
+function addMaskLayer(pv, maskNumber, hdu, fileKey, relatedData) {
+
+    const {relatedDataId}= relatedData;
+
+    const title= makeMaskTitle(maskNumber, relatedData.availableMask);
+
+    dispatchPlotMask({plotId:pv.plotId,
+        imageOverlayId:`${maskIdRoot}_#${maskNumber}_${maskCnt}`,
+        fileKey, maskNumber, maskValue:Math.pow(2,Number(maskNumber)),
+        uiCanAugmentTitle:false, imageNumber:hdu, title,
+        relatedDataId, lazyLoad:true});
+    maskCnt++;
+}
+
+function makeMaskTitle(maskNumber, availableMask) {
+    const titleRoot= 'bit # '+maskNumber;
+    var maskDesc= Object.keys(availableMask)
+        .filter( (k) => k.includes('MP'))
+        .find( (k) => parseInt(availableMask[k])===maskNumber);
+    if (maskDesc) {
+        if (maskDesc.startsWith('HIERARCH')) maskDesc= maskDesc.substring(9);
+        return `${titleRoot} - ${maskDesc}`;
+    }
+    else {
+        return titleRoot;
+    }
+}
+
+function enableRelatedDataLayerImageOverlay(pv, relatedData) {
+    //todo
+    console.log('todo: ImageOverlay');
+}
+
+function enableRelatedDataLayerTableOverlay(pv, relatedData) {
+    //todo
+    console.log('todo: artifact overlay');
+}
+
+
+/**
+ * search matchOverlayPlotViews array and find any related data in the passed PlotView. Enable the layers
+ * that match.
+ * This function has side effect of dispatching actions
+ * @param {PlotView} pv the plot view the contains the related data
+ * @param {OverlayPlotView[]} matchOverlayPlotViews array of OverlayPlotView that must be matched
+ */
+export function enableMatchingRelatedData(pv, matchOverlayPlotViews) {
+    const overTypes= uniq(matchOverlayPlotViews.map( (opv) => opv.opvType));
+    const relatedData= findRelatedData(pv).filter( (rd) => overTypes.includes(rd.dataType));
+    if (!relatedData.length) return;
+    relatedData.forEach( (r) => enableRelatedDataLayer(visRoot(), pv, r));
+
+    pv= getPlotViewById(visRoot(), pv.plotId);
+
+    //NOTE - only handles mask so far, other types of image overlay still need to be implemented
+    matchOverlayPlotViews
+        .filter( (moPv) => moPv.visible)
+        .forEach( (moPv) => {
+            const matchOpv= pv.overlayPlotViews.find( (opv) => moPv.opvType===RDConst.IMAGE_MASK &&
+            opv.opvType===RDConst.IMAGE_MASK &&
+            moPv.maskNumber === opv.maskNumber );
+            if (matchOpv) setMaskVisible(matchOpv,true);
+        });
+}
+

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -12,6 +12,14 @@ import PlotState from './PlotState.js';
 
 
 
+export const RDConst= {
+    IMAGE_OVERLAY: 'IMAGE_OVERLAY',
+    IMAGE_MASK: 'IMAGE_MASK',
+    TABLE: 'TABLE',
+    SUPPORTED_DATATYPES: ['IMAGE_MASK']
+   // SUPPORTED_DATATYPES: ['IMAGE_MASK', 'IMAGE_OVERLAY']
+
+};
 
 export const PlotAttribute= {
 
@@ -204,6 +212,8 @@ export const PlotAttribute= {
  */
 
 
+const relatedIdRoot= 'RelatedId-';
+var relatedId= 0;
 
 
 /**
@@ -230,6 +240,7 @@ export const WebPlot= {
             plotImageId     : plotId+'---NEEDS___INIT',
             serverImages    : wpInit.initImages,
             imageCoordSys   : CoordinateSys.parse(wpInit.imageCoordSys),
+            relatedData     : wpInit.relatedData,
             plotState,
             projection,
             dataWidth       : wpInit.dataWidth,
@@ -254,6 +265,13 @@ export const WebPlot= {
             //=== End Mutable =====================
             asOverlay
         };
+
+        if (webPlot.relatedData) {
+            webPlot.relatedData.forEach( (d) => {
+                d.relatedDataId= relatedIdRoot+relatedId;
+                relatedId++;
+            } );
+        }
 
         return webPlot;
     },
@@ -312,13 +330,14 @@ export function isBlankImage(plot) {
 
 /**
  *
- * @param {WebPlot} wpData
+ * @param {WebPlot} plot
  * @param {number} zoomFactor
  * @return {WebPlot}
  */
-export function clonePlotWithZoom(wpData,zoomFactor) {
-    var screenSize= {width:wpData.dataWidth*zoomFactor, height:wpData.dataHeight*zoomFactor};
-    return Object.assign({},wpData,{zoomFactor,screenSize});
+export function clonePlotWithZoom(plot,zoomFactor) {
+    if (!plot) return null;
+    var screenSize= {width:plot.dataWidth*zoomFactor, height:plot.dataHeight*zoomFactor};
+    return Object.assign({},plot,{zoomFactor,screenSize});
 }
 
 

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -169,6 +169,22 @@ export const PlotAttribute= {
  */
 
 
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} RelatedData
+ * @summary overlay data that is associated with the image data
+ *
+ * @prop {string} dataType one of 'IMAGE_OVERLAY', 'IMAGE_MASK', 'TABLE'
+ * @prop {string} desc user description of the data
+ * @prop {Object.<string, string>} searchParams map of search parameters to get the related data
+ * @prop {Object.<string, string>} availableMask only used for makes key it sh bit number value is the description
+ *
+ */
+
+
+
 /**
  * @global
  * @public

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -68,6 +68,7 @@ const C= {
     ROTATE_NORTH : 'RotateNorth',
     ROTATE_NORTH_TYPE : 'RotateNorthType',
     ROTATE : 'Rotate',
+    ROTATE_FROM_NORTH : 'RotateFromNorth',
     ROTATION_ANGLE : 'RotationAngle',
     HEADER_KEY_FOR_TITLE : 'HeaderKeyForTitle',
     INIT_RANGE_VALUES : 'RangeValues',
@@ -618,7 +619,7 @@ export class WebPlotRequest extends ServerRequest {
 
 
     /**
-     * set the initialize zoom level, this is used with ZoomType.STANDARD
+     * set the initialize zoom level, this is used with ZoomType.LEVEL
      *
      * @param {number} zl the zoom level, float
      * @see {ZoomType}
@@ -651,7 +652,7 @@ export class WebPlotRequest extends ServerRequest {
      * sets the zoom type, based on the ZoomType other zoom set methods may be required
      * Notes for ZoomType:
      * <ul>
-     * <li>ZoomType.STANDARD is the default, when set you may optionally call
+     * <li>ZoomType.LEVEL is the default when there is not width and height, when set you may optionally call
      * setInitialZoomLevel the zoom will default to be 1x</li>
      * <li>if ZoomType.TO_WIDTH then you must call setZoomToWidth and set a width </li>
      * <li>if ZoomType.FULL_SCREEN then you must call setZoomToWidth with a width and
@@ -667,7 +668,10 @@ export class WebPlotRequest extends ServerRequest {
     }
 
     getZoomType() {
-        return ZoomType.get(this.getParam(C.ZOOM_TYPE)) ||ZoomType.STANDARD;
+        const w= this.getZoomToWidth();
+        const h= this.getZoomToHeight();
+        const defaultType= (w && h) ?  ZoomType.TO_WIDTH_HEIGHT : ZoomType.LEVEL;
+        return ZoomType.get(this.getParam(C.ZOOM_TYPE)) || defaultType;
     }
 
     /**
@@ -766,6 +770,10 @@ export class WebPlotRequest extends ServerRequest {
      * @return number, the angle
      */
     getRotationAngle() { return this.getFloatParam(C.ROTATION_ANGLE); }
+
+    setRotateFromNorth(fromNorth) { this.setParam(C.ROTATE_FROM_NORTH, fromNorth+ ''); }
+
+    getRotateFromNorth() { this.getBooleanParam(C.ROTATE_FROM_NORTH,true); }
 
     /**
      * set if this image should be flipped on the Y axis

--- a/src/firefly/js/visualize/ZoomType.js
+++ b/src/firefly/js/visualize/ZoomType.js
@@ -10,6 +10,7 @@
 import Enum from 'enum';
 export const ZoomType= new Enum([
                       'STANDARD',       // use normal zoom, zoom to given zoom level or 1x if not specified
+                      'LEVEL',       // use normal zoom, zoom to given zoom level or 1x if not specified
                       'FULL_SCREEN',       // requires width & height specified. deprecated, same as TO_WIDTH_HEIGHT
                       'TO_WIDTH_HEIGHT',   // requires width & height specified
                       'TO_WIDTH',          // requires width

--- a/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
@@ -384,7 +384,7 @@ function makeMessageArea(pv,plotShowing,onScreen) {
             <ImageViewerStatus message={pv.plottingStatus} working={false}
                                useMessageAlpha={true} useButton={plotShowing}
                                buttonText='OK'
-                               buttonCB={() => dispatchPlotProgressUpdate(pv.plotId,'',true)}
+                               buttonCB={() => dispatchPlotProgressUpdate(pv.plotId,'',true, pv.request.getRequestKey())}
                                />
         );
     }

--- a/src/firefly/js/visualize/reducer/OverlayPlotView.js
+++ b/src/firefly/js/visualize/reducer/OverlayPlotView.js
@@ -2,7 +2,8 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {clone} from '../../util/WebUtil.js'
+import {clone} from '../../util/WebUtil.js';
+import {RDConst} from '../WebPlot.js';
 
 /**
  * @typedef {Object} OverlayPlotView
@@ -29,24 +30,30 @@ import {clone} from '../../util/WebUtil.js'
  * @param maskValue
  * @param {string} color the color, if overlay is a mask
  * @param drawingDef
+ * @param {string} [relatedDataId] a related data id if one exist
  * @return {OverlayPlotView}
  */
-export function makeOverlayPlotView(imageOverlayId, plotId, title, imageNumber, maskNumber, maskValue, color, drawingDef) {
+export function makeOverlayPlotView(imageOverlayId, plotId, title, imageNumber, maskNumber,
+                                    maskValue, color, drawingDef, relatedDataId, fileKey) {
 
     var opv= {
         imageOverlayId,
+        opvType: RDConst.IMAGE_MASK,
         plotId,
         title,
         plot: null,
         drawingDef,
         makeOverlay : true,
         visible: true,
+        wasVisibleWhenReplace: false,
         maskNumber,
         maskValue,
         imageNumber,
         color,
+        relatedDataId,
         opacity: .58,
         plotCounter:0, // index of how many plots, used for making next ID
+        fileKey,
         plottingStatus:'',
         serverCall:'success'
     };
@@ -59,6 +66,7 @@ export function replaceOverlayPlots(opv, plot) {
     opv= clone(opv, {plot});
     plot.plotImageId= `${opv.imageOverlayId}--${opv.plotCounter}`;
     opv.plotCounter++;
+    opv.visible= true;
 
     opv.plottingStatus='';
     opv.serverCall='success';

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -16,7 +16,6 @@ import {primePlot, getPlotViewById} from '../PlotViewUtil.js';
 import {REINIT_RESULT_VIEW} from '../../core/AppDataCntlr.js';
 import {doFetchTable, getTblById, getActiveTableId, getColumnIdx, getTableInGroup, isTableUsingRadians} from '../../tables/TableUtil.js';
 import MultiViewCntlr, {getViewerItemIds, dispatchAddViewerItems, getMultiViewRoot, getViewer, IMAGE} from '../MultiViewCntlr.js';
-// import {serializeDecimateInfo} from '../../tables/Decimate.js'; //todo need to support
 import {DrawSymbol} from '../draw/PointDataObj.js';
 import {computeCentralPointAndRadius} from '../VisUtil.js';
 import {makeWorldPt, pointEquals} from '../Point.js';
@@ -318,7 +317,7 @@ function makeOverlayCoverageDrawing() {
         const tbl_id=  plot.attributes[COVERAGE_TABLE];
         if (!tbl_id || !decimatedTables[tbl_id] || !getTblById(tbl_id)) return;
         const table= getTblById(tbl_id);
-        
+
         if (table.tableMeta[MetaConst.CATALOG_OVERLAY_TYPE]) return; // let the catalog just handle the drawing overlays
 
         const allRowsTable= decimatedTables[tbl_id];

--- a/src/firefly/js/visualize/saga/ImagePlotter.js
+++ b/src/firefly/js/visualize/saga/ImagePlotter.js
@@ -97,8 +97,8 @@ function canContinue(rawAction) {
  */
 function canContinueRequest(req, pv) {
     if (!pv) return false;
-    var requiresWH= requiresWidthHeight(req.getZoomType());
-    if (!requiresWH) return true;
+    // var requiresWH= requiresWidthHeight(req.getZoomType());
+    // if (!requiresWH) return true;
     var {viewDim:{width,height}}= pv;
     return width && height;
 }

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -329,10 +329,11 @@ function processPlotReplace(dispatcher, result, pv, makeSuccessAction, makeFailA
                 plotAry= pv.plots.map( (p,idx) => idx===pv.primeIdx ? newP : p);
             }
 
+            const existingOverlayPlotViews = pv.overlayPlotViews.filter((opv) => opv.plot);
             var overlayPlotViews = [];
             resultAry.forEach((r, i) => {
                 if (i === 0) return;
-                const {imageOverlayId}= pv.overlayPlotViews[i-1];
+                const {imageOverlayId}= existingOverlayPlotViews[i-1];
                 var plot = WebPlot.makeWebPlotData(imageOverlayId, r.data[WebPlotResult.PLOT_CREATE][0], {}, true);
                 overlayPlotViews[i - 1] = {plot};
             });

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -6,11 +6,12 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {isArray, uniqueId} from 'lodash';
+import {flatten, isArray, uniqueId, uniq, uniqBy, get, isEmpty} from 'lodash';
 import {WebPlotRequest, GridOnStatus} from '../WebPlotRequest.js';
-import ImagePlotCntlr, {makeUniqueRequestKey, IMAGE_PLOT_KEY} from '../ImagePlotCntlr.js';
+import ImagePlotCntlr, {visRoot, makeUniqueRequestKey,
+                        IMAGE_PLOT_KEY, dispatchDeleteOverlayPlot} from '../ImagePlotCntlr.js';
 import {dlRoot, dispatchCreateDrawLayer, dispatchAttachLayerToPlot} from '../DrawLayerCntlr.js';
-import {WebPlot,PlotAttribute} from '../WebPlot.js';
+import {WebPlot,PlotAttribute, RDConst} from '../WebPlot.js';
 import CsysConverter from '../CsysConverter.js';
 import {dispatchActiveTarget, getActiveTarget} from '../../core/AppDataCntlr.js';
 import VisUtils from '../VisUtil.js';
@@ -23,7 +24,8 @@ import ActiveTarget  from '../../drawingLayers/ActiveTarget.js';
 import * as DrawLayerCntlr from '../DrawLayerCntlr.js';
 import {makePostPlotTitle} from '../reducer/PlotTitle.js';
 import {dispatchAddViewerItems, EXPANDED_MODE_RESERVED, IMAGE, DEFAULT_FITS_VIEWER_ID} from '../MultiViewCntlr.js';
-import {getDrawLayerByType, getPlotViewById} from '../PlotViewUtil.js';
+import {getPlotViewById, getDrawLayerByType, getPlotViewIdListInGroup} from '../PlotViewUtil.js';
+import {enableMatchingRelatedData} from '../RelatedDataUtil.js';
 import {modifyRequestForWcsMatch} from './WcsMatchTask.js';
 import WebGrid from '../../drawingLayers/WebGrid.js';
 
@@ -86,6 +88,11 @@ function makeSinglePlotPayload(vr, rawPayload, requestKey) {
                      requestKey, attributes, viewerId, pvOptions, addToHistory,
                      useContextModifications, threeColor, setNewPlotAsActive};
 
+    const existingPv= getPlotViewById(vr,plotId);
+    if (existingPv) {
+        payload.oldOverlayPlotViews= {[plotId] :existingPv.overlayPlotViews};
+    }
+
     if (threeColor) {
         if (isArray(wpRequest)) {
             payload.redReq= addRequestKey(wpRequest[Band.RED.value], requestKey);
@@ -132,8 +139,18 @@ function makePlotImageAction(rawAction) {
                 groupLocked:true,
                 requestKey
             };
+
             payload.wpRequestAry= payload.wpRequestAry.map( (req) =>
                             addRequestKey(req,makeUniqueRequestKey('groupItemReqKey-'+req.getPlotId())));
+
+
+            payload.oldOverlayPlotViews= wpRequestAry
+                .map( (wpr) => getPlotViewById(vr,wpr.getPlotId()))
+                .filter( (pv) => get(pv, 'overlayPlotViews'))
+                .reduce( (obj, pv) => {
+                    obj[pv.plotId]= pv.overlayPlotViews;
+                    return obj;
+            },{});
 
             if (vr.wcsMatchType && vr.mpwWcsPrimId && rawAction.payload.holdWcsMatch) {
                 const wcsPrim= getPlotViewById(vr,vr.mpwWcsPrimId);
@@ -157,9 +174,9 @@ function makePlotImageAction(rawAction) {
 
 
         dispatcher( { type: ImagePlotCntlr.PLOT_IMAGE_START,payload});
-        // NOTE - sega ImagePlotter handles next step
-        // NOTE - sega ImagePlotter handles next step
-        // NOTE - sega ImagePlotter handles next step
+        // NOTE - saga ImagePlotter handles next step
+        // NOTE - saga ImagePlotter handles next step
+        // NOTE - saga ImagePlotter handles next step
     };
 }
 
@@ -202,10 +219,6 @@ export function modifyRequest(pvCtx, r, band) {
     //}
 
 
-    //if (pv.options.rememberZoom && primePlot(pv)) {
-    //    retval.setZoomType(ZoomType.STANDARD);
-    //    retval.setInitialZoomLevel(plot.zoomFac);
-    //}
 
     if (pvCtx.defThumbnailSize!==DEFAULT_THUMBNAIL_SIZE && !r.containsParam(WPConst.THUMBNAIL_SIZE)) {
         retval.setThumbnailSize(pvCtx.defThumbnailSize);
@@ -260,6 +273,12 @@ export function processPlotImageSuccessResponse(dispatcher, payload, result) {
         const plotIdAry = pvNewPlotInfoAry.map((info) => info.plotId);
         dispatcher({type: ImagePlotCntlr.ANY_REPLOT, payload: {plotIdAry}});
 
+        if (isEmpty(payload.oldOverlayPlotViews)) {
+            matchAndActivateOverlayPlotViewsByGroup(plotIdAry);
+        }
+        else {
+            matchAndActivateOverlayPlotViews(plotIdAry, payload.oldOverlayPlotViews);
+        }
 
         // pvNewPlotInfoAry.forEach((info) => {
         //     info.plotAry.map((p) => ({r: p.plotState.getWebPlotRequest(), plotId: p.plotId}))
@@ -336,6 +355,13 @@ function getRequest(payload) {
 }
 
 
+/**
+ *
+ * @param plotCreate
+ * @param payload
+ * @param requestKey
+ * @return {{plotId: *, requestKey: *, plotAry: *, overlayPlotViews: null}}
+ */
 const handleSuccess= function(plotCreate, payload, requestKey) {
     const plotState= PlotState.makePlotStateWithJson(plotCreate[0].plotState);
     const plotId= plotState.getWebPlotRequest().getPlotId();
@@ -370,9 +396,7 @@ function updateActiveTarget(plot) {
 
 
     if (!getActiveTarget()) {
-        var circle = req.getRequestArea();
-
-        if (req.getOverlayPosition())     activeTarget= req.getOverlayPosition();
+        var circle = req.getRequestArea(); if (req.getOverlayPosition())     activeTarget= req.getOverlayPosition();
         else if (circle && circle.center) activeTarget= circle.center;
         else                              activeTarget= VisUtils.getCenterPtOfPlot(plot);
 
@@ -398,3 +422,37 @@ function initBuildInDrawLayers() {
     DrawLayerCntlr.dispatchCreateDrawLayer(ActiveTarget.TYPE_ID);
 }
 
+/**
+ *
+ * @param {String[]} plotIdAry
+ * @param {Object.<string, OverlayPlotView>} oldOverlayPlotViews
+ */
+function matchAndActivateOverlayPlotViews(plotIdAry, oldOverlayPlotViews) {
+    plotIdAry.forEach( (plotId) => dispatchDeleteOverlayPlot({plotId, deleteAll:true}));
+
+    plotIdAry
+        .map( (plotId) => getPlotViewById(visRoot(), plotId))
+        .filter( (pv) => pv)
+        .forEach( (pv) => enableMatchingRelatedData(pv,oldOverlayPlotViews[pv.plotId]));
+}
+
+
+
+/**
+ *
+ * @param {String[]} plotIdAry
+ */
+function matchAndActivateOverlayPlotViewsByGroup(plotIdAry) {
+    const vr= visRoot();
+    plotIdAry
+        .map( (plotId) => getPlotViewById(visRoot(), plotId))
+        .filter( (pv) => pv)
+        .forEach( (pv) => {
+            const opvMatchArray= uniqBy(flatten(getPlotViewIdListInGroup(vr, pv.plotId)
+                                                       .filter( (id) => id!== pv.plotId)
+                                                       .map( (id) => getPlotViewById(vr,id))
+                                                       .map( (gpv) => gpv.overlayPlotViews)),
+                                   'maskNumber' );
+            enableMatchingRelatedData(pv,opvMatchArray);
+        });
+}

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -425,7 +425,7 @@ function initBuildInDrawLayers() {
 /**
  *
  * @param {String[]} plotIdAry
- * @param {Object.<string, OverlayPlotView>} oldOverlayPlotViews
+ * @param {Object.<string, OverlayPlotView[]>} oldOverlayPlotViews
  */
 function matchAndActivateOverlayPlotViews(plotIdAry, oldOverlayPlotViews) {
     plotIdAry.forEach( (plotId) => dispatchDeleteOverlayPlot({plotId, deleteAll:true}));

--- a/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
@@ -121,19 +121,20 @@ function makeColorChange(color, canUserChangeColor, modifyColor) {
 }
 
 function makeShape(isPointData, drawingDef, modifyShape) {
-    var [w, h] = [symbolSize, symbolSize];
-    var size = DrawUtil.getSymbolSize(w, h, drawingDef.symbol);
-    var df = Object.assign({}, drawingDef, {size});
-    var {width, height} = DrawUtil.getDrawingSize(size, drawingDef.symbol);
-
-    const feedBackStyle= {
-        width:width,
-        height:height,
-        display:'inline-block',
-        marginLeft:5
-    };
 
     if (isPointData) {
+        var [w, h] = [symbolSize, symbolSize];
+        var size = DrawUtil.getSymbolSize(w, h, drawingDef.symbol);
+        var df = Object.assign({}, drawingDef, {size});
+        var {width, height} = DrawUtil.getDrawingSize(size, drawingDef.symbol);
+
+        const feedBackStyle= {
+            width:width,
+            height:height,
+            display:'inline-block',
+            marginLeft:5
+        };
+
         return (
             <div style={bSty} >
                 <div style={feedBackStyle} onClick={() => modifyShape()}>

--- a/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
@@ -12,7 +12,7 @@ import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import {getDlAry} from '../DrawLayerCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
-import DrawLayerPanelView from './DrawLayerPanelView.jsx';
+import {DrawLayerPanelView} from './DrawLayerPanelView.jsx';
 import {flux} from '../../Firefly.js';
 import {readoutRoot} from '../../visualize/MouseReadoutCntlr.js';
 

--- a/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
@@ -265,7 +265,7 @@ export function resultSuccess(plotInfo, hideDropdown = false) {
                 default:
                     wpr = imagePlotOnSurvey(cId, rq);
             }
-            wpr.setZoomType(ZoomType.TO_WIDTH);
+            wpr.setZoomType(ZoomType.TO_WIDTH_HEIGHT);
             return wpr;
         };
 

--- a/src/firefly/js/visualize/ui/MaskAddPanel.jsx
+++ b/src/firefly/js/visualize/ui/MaskAddPanel.jsx
@@ -77,7 +77,7 @@ export function MaskAddPanel({vr}) {
 
 }
 
-const maskIdRoot= 'MASK_';
+const maskIdRoot= 'USER_LOADED_MASK_';
 var maskCnt= 0;
 
 function resultsSuccess(request,vr) {
@@ -86,8 +86,9 @@ function resultsSuccess(request,vr) {
     const maskV= Number(request.maskIdx);
     const hdu= Number(request.hduIdx);
     const fileKey= request.maskFile;
-    dispatchPlotMask({plotId:pv.plotId,imageOverlayId:maskIdRoot+maskCnt, fileKey, maskNumber:maskV, maskValue:Math.pow(2,maskV),
-                      imageNumber:hdu, title:'bit # '+maskV});
+    dispatchPlotMask({plotId:pv.plotId,imageOverlayId:maskIdRoot+maskCnt, fileKey,
+                      maskNumber:maskV, maskValue:Math.pow(2,maskV),
+                      uiCanAugmentTitle:true, imageNumber:hdu, title:'bit # '+maskV});
     maskCnt++;
 }
 

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -21,6 +21,10 @@ import {dispatchExtensionActivate} from '../../core/ExternalAccessCntlr.js';
 import {selectCatalog,unselectCatalog,filterCatalog,clearFilterCatalog} from '../../drawingLayers/Catalog.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import SelectArea from '../../drawingLayers/SelectArea.js';
+import {isOverlayLayersActive} from '../RelatedDataUtil.js';
+import {showInfoPopup} from '../../ui/PopupUtil.jsx';
+import CoordUtil from '../CoordUtil.js';
+import { parseImagePt } from '../Point.js';
 
 import CROP from 'html/images/icons-2014/24x24_Crop.png';
 import STATISTICS from 'html/images/icons-2014/24x24_Statistics.png';
@@ -33,8 +37,6 @@ import PAGE_LEFT from 'html/images/icons-2014/20x20_PageLeft.png';
 import SELECTED_ZOOM from 'html/images/icons-2014/ZoomFitToSelectedSpace.png';
 import SELECTED_RECENTER from 'html/images/icons-2014/RecenterImage-selection.png';
 
-import CoordUtil from '../CoordUtil.js';
-import { parseImagePt } from '../Point.js';
 
 
 //todo move the statistics constants to where they are needed
@@ -179,6 +181,13 @@ function stats(pv) {
 
 
 function crop(pv) {
+
+    if (isOverlayLayersActive(pv)) {
+        showInfoPopup('Crop not yet supported with mask layers');
+        return;
+    }
+
+
     var p= primePlot(pv);
     var cc= CysConverter.make(p);
     var sel= p.attributes[PlotAttribute.SELECTION];

--- a/src/firefly/js/visualize/ui/VisInlineToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisInlineToolbarView.jsx
@@ -40,7 +40,6 @@ function expand(plotId) {
 
 const rS= {
     width: '100% - 2px',
-    height: 34,
     position: 'relative',
     verticalAlign: 'top',
     whiteSpace: 'nowrap',

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -35,7 +35,9 @@ import {showRegionFileUploadPanel} from '../region/RegionFileUploadView.jsx';
 import {MarkerDropDownView} from './MarkerDropDownView.jsx';
 import {dispatchShowDropDown} from '../../core/LayoutCntlr.js';
 import {showImageSelPanel} from './ImageSelectPanel.jsx';
-import {showMaskDialog} from './MaskAddPanel.jsx';
+import {showMaskDialog} from './MaskAddPanel.jsx'
+import {isOverlayLayersActive} from '../RelatedDataUtil.js';
+import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 
 
 //===================================================
@@ -360,7 +362,12 @@ function doRotateNorth(pv,rotate) {
 function recenter(pv) { dispatchRecenter({plotId:pv.plotId}); }
 
 function flipY(pv) {
-    dispatchFlip({plotId:pv.plotId});
+    if (isOverlayLayersActive(pv)) {
+        showInfoPopup('Flip not yet supported with mask layers');
+    }
+    else {
+        dispatchFlip({plotId:pv.plotId});
+    }
 }
 
 

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -8,7 +8,8 @@ import {getActivePlotView,
     hasGroupLock,
     findPlotGroup,
     getAllDrawLayersForPlot} from '../PlotViewUtil.js';
-import {dispatchRotate, dispatchFlip, dispatchRecenter, 
+import {findRelatedData} from '../RelatedDataUtil.js';
+import {dispatchRotate, dispatchFlip, dispatchRecenter,
         dispatchRestoreDefaults,dispatchGroupLocking, ActionScope} from '../ImagePlotCntlr.js';
 import {RotateType} from '../PlotState.js';
 import {ToolbarButton, ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
@@ -92,10 +93,11 @@ const tipStyle= {
 
 /**
  * Vis Toolbar
- * @param visRoot visualization store root
- * @param toolTip tool tip to show
- * @param dlCount drawing layer count
- * @param messageUnder put the help message under
+ * @param p
+ * @param p.visRoot visualization store root
+ * @param p.toolTip tool tip to show
+ * @param p.dlCount drawing layer count
+ * @param p.messageUnder put the help message under
  * @return {XML}
  */
 export function VisToolbarViewWrapper({visRoot,toolTip,dlCount, messageUnder}) {
@@ -389,10 +391,11 @@ function showImagePopup() {
 
 export function LayerButton({pv,visible}) {
     const layerCnt=  pv ? (getAllDrawLayersForPlot(getDlAry(),pv.plotId).length + pv.overlayPlotViews.length) : 0;
+    const enabled= Boolean(layerCnt || findRelatedData(pv).length);
     return (
         <ToolbarButton icon={LAYER_ICON}
                        tip='Manipulate overlay display: Control color, visibility, and advanced options'
-                       enabled={Boolean(layerCnt)}
+                       enabled={enabled}
                        badgeCount={layerCnt}
                        horizontal={true}
                        visible={visible}


### PR DESCRIPTION
DM-8985: server now finding image with mask extension

 - server discovers mask layers in fits file
 - mask and other overlay information returned as addtional data for image load
 - give user options to load mask in drawing layers panel
 - add show all and hide all buttons
 - improvement in consistent color choosing of mask layers
 - mask can be lazy loaded
 - enable all mask in group, on/off in group,
 - fixed FileInfo null retured bug in last pull request
 - rotate ui: matching group, matching last plot
 - fixed zoom locking now consistently working, added LEVEL as plot zoom options to disable locking
 - made the default ZoomType TO_WIDTH_HEIGHT
 - fixed small toolbar layout background size issue

**To Test**:
 - use validation_data_hsc repository:
 - look in directory validation_data_hsc/DATA/00533/HSC-R/corr
 - load any CORR*.fits
    interesting mask:
           - bit number 4, 5,  and 11 are interesting to turn on.
           - CORR-0903342-100.fits has bad pixels so try bit number 1 as well
 - bring up layer control
 - enable the mask layers, the layers should appear
 - turn any on and off 
- try the show all or hide all buttons
- try zoom
- try rotate and flip though they are a little flaky

**known bugs**:
 - flip does not work if you flip before you turn on a mask bit
 - flip and rotate are a fragile in general, might need to look into it more deeply in another ticket
