### PR TITLE
DM 8916: Junit Test on IPACTableReader.

### DIFF
--- a/config/log4j-test.properties
+++ b/config/log4j-test.properties
@@ -3,11 +3,15 @@ log4j.rootLogger=ERROR, A1
 
 # Use to output logs from tests, change to DEBUG or INFO to get locally more logs.
 # Should stay in WARN level for more quiter environment in general.
-log4j.logger.test=ERROR, A1
+log4j.logger.test=WARN, A1
+log4j.additivity.test= false
+
+# turn off logs coming from our code
+log4j.logger.edu=OFF
+log4j.additivity.edu= false
+
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
-
-# A1 uses PatternLayout.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
+++ b/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
@@ -1,0 +1,801 @@
+package edu.caltech.ipac.astro;
+
+
+import edu.caltech.ipac.firefly.util.FileLoader;
+import edu.caltech.ipac.util.DataGroup;
+import edu.caltech.ipac.util.DataObject;
+import edu.caltech.ipac.util.DataType;
+import edu.caltech.ipac.util.StringUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.Reader;
+import java.util.*;
+
+/**
+ * Created by ymei on 1/26/17.
+ *
+ * DM-8916-JUnitTestIPACTableRead
+ *
+ * This test is mainly test if IPACTableReader.java reads the IPAC table correctly. The IRSA IPAC table reader requirements are in
+ *      http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html
+ *
+ * An IPAC table is composed by three parts: Attributes which includes keywords and comments; header which includes column names,
+ *      data types, data units, and null values; and data rows.
+ *
+ * The test cases below test if the reader can parse all parts in a table correctly and also if the reader can throw exceptions correctly
+ *      when a table violate the requirements.
+ *
+ */
+public class IpacTableReaderTest {
+
+    //Input parameters:
+    private static final String catName = "catName";
+    String[] onlyColumns = null;
+    private boolean useFloatsForDoubles = false;
+    private boolean isHeadersOnlyAllow = false;
+    private boolean noAttributes = false;
+    private int estFileSize = 0;
+
+    //Expected parameters in the data group:
+    private String[] attributeKeys = null;
+    private String[] attributeValues = null;
+    private String[] attributeComments = null;
+    private String[] colTitles = null;
+    private String[] colKeyNames = null;
+    private String[] colDataTypeDesc = null;
+    private String[] colDataTypes = null;
+    private String[] colDataUnits = null;
+    private String[] colNullStrings = null;
+    private String[][] dataValues = null;
+
+    //The IPAC table reader store the table content in the dataGroup:
+    private DataGroup dataGroup;
+
+    @Before
+    /**
+     *
+     */
+    public void setUp() throws IpacTableException, ClassNotFoundException, java.io.FileNotFoundException {
+        //Read different tables in each test case below.
+    }
+
+    @After
+    /**
+     * Release the memories
+     */
+    public void tearDown() {
+        dataGroup = null;
+    }
+
+
+    @Test
+    /**
+     * This test calls the methods IpacTableReader.readIpacTable to read all the columns from a valid input IPAC table, IPACTableSample1.tbl,
+     * and verify if the produced dataGroup contains the correct information from the table.
+     *
+     * The input parameters to call IpacTableReader.readIpacTable:
+     * File
+     * onlyColumns
+     * useFloatsForDoubles
+     * catName = "catName"
+     * isHeadersonlyAllow
+     */
+    public void testValidIpacTable1() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        //Read all the columns, other parameters are "false".
+
+        /* IPACTableSample1.tbl:
+
+        \catalog1 = 'Sample Catalog1'
+        \catalog2 = 'Sample Catalog2'
+        \ Comment1
+        \ Comment2
+        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+          165.466279  -34.704730      5       11.27       K6Ve
+          123.4       5.67            9       8.9         K6Ve-1
+
+        */
+
+        //Inputs:
+        String tableName = "IPACTableSample1.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        //onlyColumns = null;
+
+        //Set the expected values:
+        setExpectedValues_Input1_full();
+
+        //Read the table and generate the dataGroup:
+        dataGroup = IpacTableReader.readIpacTable(inFile, catName);
+
+        //Check the result:
+        checkResult(dataGroup);
+
+        //Test result: This IPAC table is read correctly.
+        // Passed.
+        // Known issue: The data type "real" is currently not supported. It is treated as a String. See the ticket https://jira.lsstcorp.org/browse/DM-9026
+
+    }
+
+    @Test
+    /**
+     * This test calls the methods IpacTableReader.readIpacTable to read all the columns from a valid input IPAC table, IPACTableSample1.tbl,
+     * and verify if the produced dataGroup contains the correct information from the table.
+     *         useFloatsForDoubles = true; isHeadersOnlyAllow = true;
+     *
+     */
+    public void testValidIpacTable2() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException
+
+    {
+
+        //Read all the columns but useFloatsForDoubles = true; isHeadersOnlyAllow = true;
+
+        /* IPACTableSample1.tbl:
+
+        \catalog1 = 'Sample Catalog1'
+        \catalog2 = 'Sample Catalog2'
+        \ Comment1
+        \ Comment2
+        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+          165.466279  -34.704730      5       11.27       K6Ve
+          123.4       5.67            9       8.9         K6Ve-1
+
+        */
+
+        //Inputs:
+        String tableName = "IPACTableSample1.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        //onlyColumns = null;
+        useFloatsForDoubles = true;
+        isHeadersOnlyAllow = true;
+
+        //Reset the expected values:
+        setExpectedValues_Input1_full();
+
+        //Read the table and generate the dataGroup:
+        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+
+        //Check the result:
+        checkResult(dataGroup);
+
+        //Test result: No effects from  useFloatsForDoubles = true; isHeadersOnlyAllow = true;
+        // useFloatsForDoubles is not used. isHeadersOnlyAllow = true is not used.
+        // Passed.
+        //Action: Do we need to use those two parameters and for what?
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read only two columns from a valid input IPAC table, IPACTableSample1.tbl,
+     * and verify if the produced dataGroup contains the correct information from the table.
+     *
+     */
+    public void testOnlyColumns() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException
+
+    {
+
+        /* IPACTableSample1.tbl:
+
+        \catalog1 = 'Sample Catalog1'
+        \catalog2 = 'Sample Catalog2'
+        \ Comment1
+        \ Comment2
+        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+          165.466279  -34.704730      5       11.27       K6Ve
+          123.4       5.67            9       8.9         K6Ve-1
+
+        */
+
+
+        //Inputs:
+        String tableName = "IPACTableSample1.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        //The same input file but only read two columns:
+        onlyColumns = new String[]{"ra", "dec"};
+        useFloatsForDoubles = false;
+        isHeadersOnlyAllow = false;
+
+        //Reset the expected values:
+        setExpectedValues_Input1_radecOnly();
+
+        //Read the table and generate the dataGroup:
+        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+
+        //Check the result:
+        checkResult(dataGroup);
+
+        //Test result: "onlyColumns" works fine. Only those two columns are read.
+        // Passed.
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read a valid input IPAC table, IPACTableSample2_NoAttributes.tbl, which has no attributes.
+     * More data types are tested.
+     * Verify if the produced dataGroup contains the correct information from the table.
+     *
+     */
+    public void testNoAttributes() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        /* IPACTableSample2_NoAttributes.tbl:
+
+        |id                            |f_x                           |f_y                           |i_x                           |i_y                           |peakValue                     |
+        |long                          |float                         |float                         |int                           |int                           |float                         |
+        |                              |pixels                        |pixels                        |pixels                        |pixels                        |dn                            |
+        |                              |                              |                              |                              |                              |                              |
+         1                              1309.0000                      8.0000                         1309                           8                              149.5896
+         18422                          389.0000                       4.0000                         389                            4                              11.4204
+         18423                          287.0000                       9.0000                         287                            9                              31.1756
+
+        */
+
+        String tableName = "IPACTableSample2_NoAttributes.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        noAttributes = true;
+        onlyColumns = null;
+        setExpectedValues_Input2();
+        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        checkResult(dataGroup);
+
+        //Test result: It is okay for an IPAC table not having any attributes. The table is read correctly.
+        // Passed.
+        // Known issues: The trailing zeros to the right of the decimal point is truncated, eg. 1309.0000 to 1309.0.
+
+    }
+
+    @Test
+    /** This test calls the method IpacTableReader.readIpacTable to read a IPAC table, IPACTable3_wrongAttributes.tbl,
+     * which has some wrong keywords and wrong comments.
+     * Need to see how our table reader handle it.
+     *
+     */
+    public void testWrongAttributes1() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        /* IPACTable3_wrongAttributes.tbl:
+
+        \ catalog1 = 'A space makes this line as a comment'
+        \catalog2 = 'This is a valid keyword.'
+        \key:3  'missing the equal sign and no leading space, so this line will be ignored'
+        \Missing the leading space so this line will be ignored
+        \ Comment2
+        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+          165.466279  -34.704730      5       11.27       K6Ve
+          123.4       5.67            9       8.9         K6Ve-1
+
+         */
+
+
+        String tableName = "IPACTable3_wrongAttributes.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        noAttributes = false;
+        onlyColumns = null;
+        setExpectedValues_Input3_wrongAttributes();
+        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        checkResult(dataGroup);
+
+        /*Test result:
+
+        If a "keyword" has a space after the "\", it will be treated as a comment. Nothing can be done in the table reader about this.
+        If a keyword has no "=" , it will be ignored. Nothing can be done in the table reader.
+        If a comment has no space after "\", it will be ignored. Nothing can be done in the table reader.
+
+        */
+
+        // Passed.
+
+        // Action: How to improve the way to test those issues?
+
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read IPACTable4_wrongAttributes.tbl
+     * which some attributes missing the first "\".
+     */
+    public void testWrongAttributes2() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        /* IPACTable4_wrongAttributes.tbl:
+
+          Comment1 missing the back slash! This line will be ignored.
+          catalog1 = missing the back slash but with a space; this line will be ignored.
+         catalog2 = missing the back slash and no space
+         \ Comment2 Valid comment
+         |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+         |   double  |    double |   int    |   real   |   char     |
+         |   deg     |    deg    |          |   mag    |            |
+         |   null    |    null   |   null   |   null   |   null     |
+           165.466279  -34.704730      5       11.27       K6Ve
+           123.4       5.67            9       8.9         K6Ve-1
+
+         */
+
+        String tableName = "IPACTable4_wrongAttributes.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+
+        try{
+            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        } catch (IpacTableException e){
+            System.out.println("IpacTableException from the table " + tableName + ": " + e.getMessage());
+        }
+
+        //Test result:
+        //If an attribute starts with a space, it will be ignored.
+        //If an attribute has no "\" nor space at beginning, it will trigger IpacTableException: "Data row must start with a space." and no dataGroup is generated.
+
+        //Action item: Anything we can do better in the table reader?
+
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read IPACTable5_duplicatedCol.tbl
+     * which has duplicate column names.
+     */
+    public void testDuplicateColumn() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        /*
+        \catalog1 = 'Sample Catalog1'
+        \catalog2 = 'Sample Catalog2'
+        \ Comment1
+        \ Comment2
+        |   ra      |    ra     |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+          165.466279  -34.704730      5       11.27       K6Ve
+          123.4       5.67            9       8.9         K6Ve-1
+         */
+
+        //Read a table with duplicated column names
+        String tableName = "IPACTable5_duplicatedCol.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+
+        try{
+            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        } catch (IpacTableException e){
+            System.out.println("IpacTableException from the table " + tableName + ":" + e.getMessage());
+        }
+
+        DataType[] dataTypes = dataGroup.getDataDefinitions();
+        List<String> colTitle = new ArrayList<String>();
+        for (int i = 0; i < dataTypes.length; i++) {
+            colTitle.add(dataTypes[i].getDefaultTitle().toString());
+        }
+
+        System.out.println("NO IpacTableException from the table " + tableName + " which has duplicate column names: " + colTitle);
+
+        //Test result:
+        //The duplicate columns are not detected. A dataGroup is generated with those duplicate columns!
+        //Action item: Issue a ticket!
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read IPACTable6_nodata.tbl which has no data.
+     */
+    public void testNoData() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        /*
+        \catalog1 = 'Sample Catalog1'
+        \catalog2 = 'Sample Catalog2'
+        \ Comment1
+        \ Comment2
+        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+         */
+
+        //Read a table without data
+        String tableName = "IPACTable6_nodata.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+
+        try{
+            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        } catch (IpacTableException e){
+            System.out.println("IpacTableException from the table " + tableName + ": "  + e.getMessage());
+        }
+
+        //Test result: IpacTableException is thrown.
+        //Passed.
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read IPACTable7_dataUnderBar.tbl which has one datum under "|".
+     */
+    public void testDataUnderBar() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        /*
+        \catalog1 = 'Sample Catalog1'
+        \catalog2 = 'Sample Catalog2'
+        \ Comment1
+        \ Comment2
+        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+           165.466279 -34.704730      5       11.27       K6Ve
+          123.4       5.67            9       8.9         K6Ve-1
+         */
+
+        // Read a table with some data under "|"
+        String tableName = "IPACTable7_dataUnderBar.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+
+        //setExpectedValues_Input7_full();
+
+        try{
+            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        } catch (IpacTableException e){
+            System.out.println("IpacTableException from the table " + tableName + ": "  + e.getMessage());
+        }
+
+        System.out.println("NO IpacTableException from the table " + tableName + " which has data under \"|\". A dataGroup is generated but the content is wrong.");
+
+        //checkResult(dataGroup);
+
+        //Test result: No exception. A dataGroup is generated but with wrong content! 165.466279 is truncated to 165.46627; -34.704730 is missing.
+        //Action item: Issue a ticket.
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read IPACTable8_noHeader.tbl which has no header.
+     */
+    public void testNoHeader() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+
+        /* IPACTable8_noHeader.tbl:
+
+        \catalog1 = 'Sample Catalog1'
+        \catalog2 = 'Sample Catalog2'
+        \ Comment1
+        \ Comment2
+          165.466279  -34.704730      5       11.27       K6Ve
+          123.4       5.67            9       8.9         K6Ve-1
+         */
+
+        // Read a table without header.
+        String tableName = "IPACTable8_noHeader.tbl";
+        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+
+        //setExpectedValues_Input7_full();
+
+        try{
+            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        } catch (IpacTableException e){
+            System.out.println("IpacTableException from the table " + tableName + ": "  + e.getMessage());
+        }
+
+        DataType[] dataTypes = dataGroup.getDataDefinitions();
+
+        System.out.println("NO IpacTableException from the table " + tableName + " which has no header. The dataGroup is generated but the dataTypes length is " + dataTypes.length);
+        //checkResult(dataGroup);
+
+        //Test result: The dataGroup is genearated but no dataTypes.
+        //Action item: Issue a ticket: at least the column name is required.
+
+    }
+
+
+    @Test
+    /**
+     *
+     * This test calls the methods IpacTableReader.readIpacTable(inReader, catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow) which take the input Reader
+     * The input parameters:
+     * FileReader
+     * catName = "catName"
+     * onlyColumns
+     * useFloatsForDoubles
+     * estFileSize
+     * isHeaderOnlyAllow
+     */
+    public void testValidIpacTable_Reader() throws IpacTableException, ClassNotFoundException, FileNotFoundException, java.lang.NullPointerException {
+
+
+        String tableName = "IPACTableSample1.tbl";
+        Reader inReader = new FileReader(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        //onlyColumns = null;
+        //useFloatsForDoubles = false;
+        //estFileSize = 0;
+        //isHeadersOnlyAllow = false;
+        //noAttributes = false;
+
+        setExpectedValues_Input1_full();
+        dataGroup = IpacTableReader.readIpacTable(inReader, catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
+        checkResult(dataGroup);
+
+        //Test result: Passed.
+    }
+
+    private void setExpectedValues_Input1_full() {
+
+               /*
+                \catalog1 = 'Sample Catalog1'
+                \catalog2 = 'Sample Catalog2'
+                \ Comment1
+                \ Comment2
+                |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+                |   double  |    double |   int    |   real   |   char     |
+                |   deg     |    deg    |          |   mag    |            |
+                |   null    |    null   |   null   |   null   |   null     |
+                  165.466279  -34.704730      5       11.27       K6Ve
+                  123.4       5.67            9       8.9         K6Ve-1
+
+                  */
+
+        //Set the attributes:
+        attributeKeys = new String[]{"catalog1", "catalog2", "source"};
+        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTableSample1.tbl"};
+        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
+
+        //Set the header:
+
+        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //The 4th one is "readl" in the table but currently the IPAC table treat it as "char". DM-9026.
+        //colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //After DM-9026.
+        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
+                "class java.lang.Integer", "class java.lang.String", "class java.lang.String"}; //The 4h one is "real" in the table but currently the IPAC table treats it as String. DM-9026.
+        //colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
+        //"class java.lang.Integer", "class java.lang.Double", "class java.lang.String"}; //After DM-9026.
+        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
+        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
+
+        //Set the data:
+        dataValues = new String[][]{{"165.466279", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
+
+    }
+
+    private void setExpectedValues_Input1_radecOnly() {
+
+               /*
+                \catalog1 = 'Sample Catalog1'
+                \catalog2 = 'Sample Catalog2'
+                \ Comment1
+                \ Comment2
+                |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+                |   double  |    double |   int    |   real   |   char     |
+                |   deg     |    deg    |          |   mag    |            |
+                |   null    |    null   |   null   |   null   |   null     |
+                  165.466279  -34.704730      5       11.27       K6Ve
+                  123.4       5.67            9       8.9         K6Ve-1
+
+                  */
+
+        //Only read two columns: ra and dec.
+
+        //Set the attributes:
+        attributeKeys = new String[]{"catalog1", "catalog2", "source"};
+        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTableSample1.tbl"};
+        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
+
+        //Set the header:
+        colTitles = new String[]{"ra", "dec"};
+        colKeyNames = new String[]{"ra", "dec"};
+        colDataTypeDesc = new String[]{"double", "double"};
+        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double"};
+        colDataUnits = new String[]{"deg", "deg"};
+        colNullStrings = new String[]{"null", "null"};
+
+        //Set the data:
+        dataValues = new String[][]{{"165.466279", "-34.70473"}, {"123.4", "5.67"}};
+
+    }
+
+
+
+    private void setExpectedValues_Input2(){
+
+        /*
+        |id                            |f_x                           |f_y                           |i_x                           |i_y                           |peakValue                     |
+        |long                          |float                         |float                         |int                           |int                           |float                         |
+        |                              |pixels                        |pixels                        |pixels                        |pixels                        |dn                            |
+        |                              |                              |                              |                              |                              |                              |
+        1                              1309.0000                      8.0000                         1309                           8                              149.5896
+        18422                          389.0000                       4.0000                         389                            4                              11.4204
+        18423                          287.0000                       9.0000                         287                            9                              31.1756
+        */
+
+
+        //Set the attributes:
+        attributeKeys = new String[]{"source"};
+        attributeValues = new String[]{"/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTableSample2_NoAttributes.tbl"};
+        attributeComments = null;
+
+        //Set the header:
+        colTitles = new String[]{"id", "f_x", "f_y", "i_x", "i_y", "peakValue"};
+        colKeyNames = new String[]{"id", "f_x", "f_y", "i_x", "i_y", "peakValue"};
+        colDataTypeDesc = new String[]{"long", "float", "float", "int", "int", "float"};
+        colDataTypes = new String[]{"class java.lang.Long", "class java.lang.Float",
+                "class java.lang.Float", "class java.lang.Integer", "class java.lang.Integer", "class java.lang.Float"};
+        colDataUnits = new String[]{"", "pixels", "pixels", "pixels", "pixels", "dn"};
+        colNullStrings = new String[]{"", "", "", "", "", ""};
+
+        //Set the data:
+        dataValues = new String[][]{{"1", "1309.0", "8.0", "1309", "8", "149.5896"},
+                                        {"18422", "389.0", "4.0", "389", "4", "11.4204"},
+                                        {"18423", "287.0", "9.0", "287", "9", "31.1756"}};
+    }
+
+    private void setExpectedValues_Input3_wrongAttributes() {
+
+        /*
+        \ catalog1 = 'A space makes this line as a comment'
+        \catalog2 = 'This is a valid keyword.'
+        \key:3  'missing the equal sign and no leading space, so this line will be ignored'
+        \Missing the leading space so this line will be ignored
+        \ Comment2
+        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+        |   double  |    double |   int    |   real   |   char     |
+        |   deg     |    deg    |          |   mag    |            |
+        |   null    |    null   |   null   |   null   |   null     |
+        165.466279  -34.704730      5       11.27       K6Ve
+        123.4       5.67            9       8.9         K6Ve-1
+
+         */
+
+        //Set the attributes:
+        attributeKeys = new String[]{"catalog2", "source"};
+        attributeValues = new String[]{"\'This is a valid keyword.\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTable3_wrongAttributes.tbl"};
+        attributeComments = new String[]{"\\ catalog1 = 'A space makes this line as a comment'", "\\ Comment2"};
+
+        //Set the header:
+        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //The 4th one is "readl" in the table but currently the IPAC table treat it as "char". DM-9026.
+        //colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //After DM-9026.
+        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
+                "class java.lang.Integer", "class java.lang.String", "class java.lang.String"}; //The 4h one is "real" in the table but currently the IPAC table treats it as String. DM-9026.
+        //colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
+        //"class java.lang.Integer", "class java.lang.Double", "class java.lang.String"}; //After DM-9026.
+        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
+        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
+
+        //Set the data:
+        dataValues = new String[][]{{"165.466279", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
+
+    }
+
+    private void setExpectedValues_Input7_full() {
+
+               /*
+                \catalog1 = 'Sample Catalog1'
+                \catalog2 = 'Sample Catalog2'
+                \ Comment1
+                \ Comment2
+                |   ra      |    dec    |   n_obs  |    V     |   SpType   |
+                |   double  |    double |   int    |   real   |   char     |
+                |   deg     |    deg    |          |   mag    |            |
+                |   null    |    null   |   null   |   null   |   null     |
+                  165.466279  -34.704730      5       11.27       K6Ve
+                  123.4       5.67            9       8.9         K6Ve-1
+
+                  */
+
+        //Set the attributes:
+        attributeKeys = new String[]{"catalog1", "catalog2", "source"};
+        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTable7_dataUnderBar.tbl"};
+        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
+
+        //Set the header:
+
+        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //The 4th one is "readl" in the table but currently the IPAC table treat it as "char". DM-9026.
+        //colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //After DM-9026.
+        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
+                "class java.lang.Integer", "class java.lang.String", "class java.lang.String"}; //The 4h one is "real" in the table but currently the IPAC table treats it as String. DM-9026.
+        //colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
+        //"class java.lang.Integer", "class java.lang.Double", "class java.lang.String"}; //After DM-9026.
+        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
+        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
+
+        //Set the data:
+        dataValues = new String[][]{{"165.46627", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
+
+    }
+    
+    /**
+     *
+     * @param dataGroup
+     */
+
+    private void checkResult(DataGroup dataGroup) {
+
+        //Check data definitions:
+        DataType[] dataTypes = dataGroup.getDataDefinitions();
+        for (int i = 0; i < dataTypes.length; i++) {
+            Assert.assertEquals("check column title", dataTypes[i].getDefaultTitle().toString(), colTitles[i]);
+            Assert.assertEquals("check column key name", dataTypes[i].getKeyName().toString(), colKeyNames[i]);
+            Assert.assertEquals("check column data type short description", dataTypes[i].getTypeDesc().toString(), colDataTypeDesc[i]);
+            Assert.assertEquals("check column data type class", dataTypes[i].getDataType().toString(), colDataTypes[i]);
+            Assert.assertEquals("check the column unit", dataTypes[i].getDataUnit().toString(), colDataUnits[i]);
+            Assert.assertEquals("check column null string", dataTypes[i].getNullString().toString(), colNullStrings[i]);
+        }
+
+        //Not test the followings:
+        //dt0.getMayBeNull(); //false!!???
+        //dt0.getFormatInfo().toString(); //"edu.caltech.ipac.util.DataType$FormatInfo@...."??
+        //dt0.getImportance().toString(); //"HIGH" (who assigned this?)
+        //dt0.getMaxDataWidth(); //10
+
+        //Check the Attributes (comments):
+        List<DataGroup.Attribute> attributes = dataGroup.getKeywords();
+        if (attributes.size() == 0){
+            //System.out.println("No attributes detected.");
+            //Assert.assertTrue("No attributes", noAttributes);
+            Assert.assertFalse("No attributes found", !noAttributes);
+        }
+        else {
+            int commentNum = 0;
+            for (DataGroup.Attribute att : attributes) {
+                if (att.isComment()) {
+                    //System.out.println(att.toString());
+                    Assert.assertEquals("check the comments:", att.toString(), attributeComments[commentNum]);
+                    commentNum++;
+                }
+            }
+        }
+
+        //Check the attributes (key, value):
+        Map<String, DataGroup.Attribute> attributeMap = dataGroup.getAttributes();
+        //attributeMap.size();
+        int j = 0;
+        String value;
+        for (Map.Entry entry : attributeMap.entrySet()) {
+            Assert.assertEquals("check the key", entry.getKey(), attributeKeys[j]);
+            value = ((DataGroup.Attribute) entry.getValue()).getValue().toString();
+            //System.out.println(value + " " + attributeValues[j] + " " + j);
+            Assert.assertEquals("check the value", value, attributeValues[j]);
+            j++;
+        }
+
+        //Check the data content/values:
+        List<DataObject> objList = dataGroup.values(); //
+        for (int row = 0; row < objList.size(); row++) {
+            for (int col = 0; col < dataTypes.length; col++) {
+                String dataExpected = objList.get(row).getDataElement(dataTypes[col]).toString();
+                Assert.assertEquals("check the 0th data value in the row", dataExpected, dataValues[row][col]);
+            }
+        }
+    }
+
+
+    // All the methods:
+
+    //public static DataGroup readIpacTable(File f, String catName)
+    //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName)
+    //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName, boolean isHeadersOnlyAllow)
+
+    //public static DataGroup readIpacTable(Reader fr, String catName)
+    //public static DataGroup readIpacTable(Reader fr, String catName, long estFileSize)
+    //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize)
+    //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize, boolean isHeadersOnlyAllow)
+
+
+}

--- a/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
+++ b/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
@@ -10,6 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.StringReader;
 import java.util.*;
 
@@ -56,7 +57,7 @@ public class IpacTableReaderTest extends ConfigTest{
             Keep onlyColumns = null to read all the columns.
      */
 
-    public void testValidIpacTable() {
+    public void testValidIpacTable() throws IpacTableException, IOException {
 
         //Input table:
         String input =
@@ -88,48 +89,44 @@ public class IpacTableReaderTest extends ConfigTest{
         dataValues = new String[][]{{"165.466279", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
 
 
-        try {
-            //public static DataGroup readIpacTable(Reader fr, String catName)
-            //public static DataGroup readIpacTable(Reader fr, String catName, long estFileSize)
-            //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize)
-            //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize, boolean isHeadersOnlyAllow)
+        //Test the following methods:
+        //public static DataGroup readIpacTable(Reader fr, String catName)
+        //public static DataGroup readIpacTable(Reader fr, String catName, long estFileSize)
+        //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize)
+        //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize, boolean isHeadersOnlyAllow)
 
-            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
-            checkResult(dataGroup);
+        DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+        checkResult(dataGroup);
 
-            estFileSize = 100;
-            dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, estFileSize);
-            checkResult(dataGroup); //estFileSize is never used.
+        estFileSize = 100;
+        dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, estFileSize);
+        checkResult(dataGroup); //estFileSize is never used.
 
-            useFloatsForDoubles = true;
-            dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize);
-            checkResult(dataGroup); //useFloatForDoubles is never used.
+        useFloatsForDoubles = true;
+        dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize);
+        checkResult(dataGroup); //useFloatForDoubles is never used.
 
-            isHeadersOnlyAllow = true;
-            dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
-            checkResult(dataGroup); //isHeadersOnlyAllow = true is never use.
+        isHeadersOnlyAllow = true;
+        dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
+        checkResult(dataGroup); //isHeadersOnlyAllow = true is never use.
 
-            //Test the following methods:
-            //public static DataGroup readIpacTable(File f, String catName)
-            //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName)
-            //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName, boolean isHeadersOnlyAllow)
+        //Test the following methods:
+        //public static DataGroup readIpacTable(File f, String catName)
+        //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName)
+        //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName, boolean isHeadersOnlyAllow)
 
-            File tempFile = new File("./temp.tbl");
-            IpacTableWriter.save(tempFile, dataGroup);
-            dataGroup = IpacTableReader.readIpacTable(tempFile, catName);
-            checkResult(dataGroup);
-            useFloatsForDoubles = true;
-            dataGroup = IpacTableReader.readIpacTable(tempFile, onlyColumns, useFloatsForDoubles, catName);
-            checkResult(dataGroup); //useFloatsForDoubles has never be used!
-            isHeadersOnlyAllow = true;
-            dataGroup = IpacTableReader.readIpacTable(tempFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
-            checkResult(dataGroup); //isHeadersOnlyAllow=true has never be used!
+        File tempFile = new File("./temp.tbl");
+        tempFile.deleteOnExit();
 
-            tempFile.delete();
-
-        }catch (Exception e){
-            //?
-        }
+        IpacTableWriter.save(tempFile, dataGroup);
+        dataGroup = IpacTableReader.readIpacTable(tempFile, catName);
+        checkResult(dataGroup);
+        useFloatsForDoubles = true;
+        dataGroup = IpacTableReader.readIpacTable(tempFile, onlyColumns, useFloatsForDoubles, catName);
+        checkResult(dataGroup); //useFloatsForDoubles has never be used!
+        isHeadersOnlyAllow = true;
+        dataGroup = IpacTableReader.readIpacTable(tempFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        checkResult(dataGroup); //isHeadersOnlyAllow=true has never be used!
 
         //Test result: This IPAC table is read correctly.
         // Passed.
@@ -142,7 +139,7 @@ public class IpacTableReaderTest extends ConfigTest{
      * and verify if the produced dataGroup contains the correct information from the table.
      */
 
-    public void testOnlyColumns() {
+    public void testOnlyColumns() throws IpacTableException {
 
         //Input table:
         String input =
@@ -176,15 +173,11 @@ public class IpacTableReaderTest extends ConfigTest{
         //Set the data:
         dataValues = new String[][]{{"165.466279", "-34.70473"}, {"123.4", "5.67"}};
 
-        try {
-            //Read the table and generate the dataGroup:
-            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
+        //Read the table and generate the dataGroup:
+        DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
 
-            //Check the result:
-            checkResult(dataGroup);
-        }catch(IpacTableException e){
-
-        }
+        //Check the result:
+        checkResult(dataGroup);
 
         //Test result: "onlyColumns" works fine. Only those two selected columns are read.
         // Passed.
@@ -198,7 +191,7 @@ public class IpacTableReaderTest extends ConfigTest{
      * Verify if the produced dataGroup contains the correct information from the table.
      *
      */
-    public void testNoAttributes() {
+    public void testNoAttributes() throws IpacTableException {
 
 
         String input =
@@ -211,19 +204,14 @@ public class IpacTableReaderTest extends ConfigTest{
 
         noAttributes = true;
 
-        try {
-            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
+        DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
 
-            List<DataGroup.Attribute> comments = dataGroup.getKeywords();
-            Assert.assertEquals("There should be 0 comments", 0, comments.size());
-            Map<String, DataGroup.Attribute> keywordsMap = dataGroup.getAttributes();
-            Assert.assertEquals("There should be 0 keywords", 0, keywordsMap.size());
+        List<DataGroup.Attribute> comments = dataGroup.getKeywords();
+        Assert.assertEquals("There should be 0 comments", 0, comments.size());
+        Map<String, DataGroup.Attribute> keywordsMap = dataGroup.getAttributes();
+        Assert.assertEquals("There should be 0 keywords", 0, keywordsMap.size());
 
-            Assert.assertEquals("ra for row 1", 165.466279, (Double) dataGroup.get(0).getDataElement("ra"), 0.001);
-        }catch(IpacTableException e){
-
-        }
-
+        Assert.assertEquals("ra for row 1", 165.466279, (Double) dataGroup.get(0).getDataElement("ra"), 0.000001);
 
         //Test result: It is okay for an IPAC table not having any attributes. The table is read correctly.
         // Passed.
@@ -235,7 +223,7 @@ public class IpacTableReaderTest extends ConfigTest{
      * Need to see how our table reader handle it.
      *
      */
-    public void testWrongAttributes1() {
+    public void testWrongAttributes1() throws IpacTableException {
 
         String input =
         "\\ catalog1 = 'A space makes this line as a comment'\n" +
@@ -248,20 +236,15 @@ public class IpacTableReaderTest extends ConfigTest{
         "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
         "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-        try {
-            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+        DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
 
-            //Check the Attributes (comments):
-            List<DataGroup.Attribute> attributes = dataGroup.getKeywords();
-            Assert.assertTrue(attributes.get(0).isComment());
-            Assert.assertEquals("The first attribute has a space so it is parsed as a comment.",
-                    attributes.get(0).toString(), "\\ catalog1 = 'A space makes this line as a comment'");
+        //Check the Attributes (comments):
+        List<DataGroup.Attribute> attributes = dataGroup.getKeywords();
+        Assert.assertTrue(attributes.get(0).isComment());
+        Assert.assertEquals("The first attribute has a space so it is parsed as a comment.",
+                attributes.get(0).toString(), "\\ catalog1 = 'A space makes this line as a comment'");
 
-            Assert.assertEquals("The last two lines will be ignored as they have no leading space nor '=' ", 1, attributes.size());
-
-        }catch(IpacTableException e){
-
-        }
+        Assert.assertEquals("The last two lines will be ignored as they have no leading space nor '=' ", 1, attributes.size());
 
         /*Test result:
 
@@ -285,7 +268,6 @@ public class IpacTableReaderTest extends ConfigTest{
 
         String input =
                 "catalog2 = missing the back slash and no space\n" +
-                "\\ Comment2 Valid comment\n" +
                 "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
                 "|   double  |    double |   int    |   real   |   char     |\n" +
                 "|   deg     |    deg    |          |   mag    |            |\n" +
@@ -294,15 +276,14 @@ public class IpacTableReaderTest extends ConfigTest{
                 "  123.4       5.67            9       8.9         K6Ve-1    ";
 
 
-        try{
+        try {
             DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
             Assert.fail("No exception thrown.");
-        } catch (Exception e){
+        } catch (IpacTableException e) {
 
         }
 
         //Test result:
-        //If an attribute starts with a space, it will be ignored.
         //If an attribute has no "\" nor space at beginning, it will trigger IpacTableException: "Data row must start with a space." and no dataGroup is generated.
 
         //Passed
@@ -332,8 +313,10 @@ public class IpacTableReaderTest extends ConfigTest{
 
         try{
             DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
-            // After DM-9332 is implemented uncomment this:
+            //After DM-9332 is implemented uncomment this:
             //Assert.fail("No exception thrown out");
+            //After DM-9332, the LOG.WARN should be deleted:
+            LOG.warn("This test should trigger IpacTableException but it doesn't. After DM-9332 fixes it, the test needs to be updated.");
 
         } catch (IpacTableException e){
 
@@ -362,6 +345,7 @@ public class IpacTableReaderTest extends ConfigTest{
      * Test if it can be handled correctly.
      */
     public void testDatatype_real() {
+
         String input =
                 "\\catalog1 = 'Sample Catalog1'\n" +
                 "\\catalog2 = 'Sample Catalog2'\n" +
@@ -397,6 +381,7 @@ public class IpacTableReaderTest extends ConfigTest{
 
         //Test result:
         //The 4th one is "real" in the table but currently the IPAC table treat it as "char". DM-9026.
+        LOG.warn("The data type \'real\' is parsed as a char. DM-9026 will parse real as double and then the test needs some updates.");
 
     }
 
@@ -454,8 +439,9 @@ public class IpacTableReaderTest extends ConfigTest{
 
         try{
             DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
-            //After https://jira.lsstcorp.org/browse/DM-9333 is implemented, use this:
+            //After https://jira.lsstcorp.org/browse/DM-9333 is implemented, use this Assert.fail and delete the LOG.warn below:
             //Assert.fail("No exception is thrown out");
+            LOG.warn("When some data are under \'|\' in an IPAC table, the reader doesn't throw out IpacTableException. DM-9333 will fix it and then this test needs some mods.");
         }catch(IpacTableException e){
 
         }
@@ -490,8 +476,9 @@ public class IpacTableReaderTest extends ConfigTest{
 
         try{
             DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
-            //After https://jira.lsstcorp.org/browse/DM-9335 is implemented, use this:
+            //After https://jira.lsstcorp.org/browse/DM-9335 is implemented, use the Assert.fail and delete the LOG.warn below:
             //Assert.fail("No exception is thrown out.");
+            LOG.warn("IPAC table reader doesn't catch the no header problem. DM-9335 will fix it and then the test needs some mods.");
         }catch(IpacTableException e) {
 
         }

--- a/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
+++ b/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
@@ -1,20 +1,16 @@
 package edu.caltech.ipac.astro;
 
 
-import edu.caltech.ipac.firefly.util.FileLoader;
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.DataObject;
 import edu.caltech.ipac.util.DataType;
-import edu.caltech.ipac.util.StringUtils;
-import org.junit.After;
+
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.Reader;
+import java.io.StringReader;
 import java.util.*;
 
 /**
@@ -32,10 +28,10 @@ import java.util.*;
  *      when a table violate the requirements.
  *
  */
-public class IpacTableReaderTest {
+public class IpacTableReaderTest extends ConfigTest{
 
     //Input parameters:
-    private static final String catName = "catName";
+    private static final String catName = "catalogName";
     String[] onlyColumns = null;
     private boolean useFloatsForDoubles = false;
     private boolean isHeadersOnlyAllow = false;
@@ -54,172 +50,143 @@ public class IpacTableReaderTest {
     private String[] colNullStrings = null;
     private String[][] dataValues = null;
 
-    //The IPAC table reader store the table content in the dataGroup:
-    private DataGroup dataGroup;
-
-    @Before
-    /**
-     *
-     */
-    public void setUp() throws IpacTableException, ClassNotFoundException, java.io.FileNotFoundException {
-        //Read different tables in each test case below.
-    }
-
-    @After
-    /**
-     * Release the memories
-     */
-    public void tearDown() {
-        dataGroup = null;
-    }
-
-
     @Test
     /**
-     * This test calls the methods IpacTableReader.readIpacTable to read all the columns from a valid input IPAC table, IPACTableSample1.tbl,
-     * and verify if the produced dataGroup contains the correct information from the table.
-     *
-     * The input parameters to call IpacTableReader.readIpacTable:
-     * File
-     * onlyColumns
-     * useFloatsForDoubles
-     * catName = "catName"
-     * isHeadersonlyAllow
+     * This test calls the methods in IpacTableReader and verify if the produced dataGroup contains the correct information from the table.
+            Keep onlyColumns = null to read all the columns.
      */
-    public void testValidIpacTable1() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
 
-        //Read all the columns, other parameters are "false".
+    public void testValidIpacTable() {
 
-        /* IPACTableSample1.tbl:
-
-        \catalog1 = 'Sample Catalog1'
-        \catalog2 = 'Sample Catalog2'
-        \ Comment1
-        \ Comment2
-        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-          165.466279  -34.704730      5       11.27       K6Ve
-          123.4       5.67            9       8.9         K6Ve-1
-
-        */
-
-        //Inputs:
-        String tableName = "IPACTableSample1.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
-        //onlyColumns = null;
+        //Input table:
+        String input =
+                "\\catalog1 = 'Sample Catalog1'\n" +
+                "\\catalog2 = 'Sample Catalog2'\n" +
+                "\\ Comment1\n" +
+                "\\ Comment2\n" +
+                "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+                "|   double  |    double |   int    |   float  |   char     |\n" +
+                "|   deg     |    deg    |          |   mag    |            |\n" +
+                "|   null    |    null   |   null   |   null   |   null     |\n" +
+                "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
+                "  123.4       5.67            9       8.9         K6Ve-1    ";
 
         //Set the expected values:
-        setExpectedValues_Input1_full();
 
-        //Read the table and generate the dataGroup:
-        dataGroup = IpacTableReader.readIpacTable(inFile, catName);
+        //The attributes:
+        attributeKeys = new String[]{"catalog1", "catalog2"};
+        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'"};
+        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
+        //The header:
+        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colDataTypeDesc = new String[]{"double", "double", "int", "float", "char"};
+        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double", "class java.lang.Integer", "class java.lang.Float", "class java.lang.String"};
+        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
+        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
+        //The data:
+        dataValues = new String[][]{{"165.466279", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
 
-        //Check the result:
-        checkResult(dataGroup);
+
+        try {
+            //public static DataGroup readIpacTable(Reader fr, String catName)
+            //public static DataGroup readIpacTable(Reader fr, String catName, long estFileSize)
+            //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize)
+            //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize, boolean isHeadersOnlyAllow)
+
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+            checkResult(dataGroup);
+
+            estFileSize = 100;
+            dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, estFileSize);
+            checkResult(dataGroup); //estFileSize is never used.
+
+            useFloatsForDoubles = true;
+            dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize);
+            checkResult(dataGroup); //useFloatForDoubles is never used.
+
+            isHeadersOnlyAllow = true;
+            dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
+            checkResult(dataGroup); //isHeadersOnlyAllow = true is never use.
+
+            //Test the following methods:
+            //public static DataGroup readIpacTable(File f, String catName)
+            //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName)
+            //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName, boolean isHeadersOnlyAllow)
+
+            File tempFile = new File("./temp.tbl");
+            IpacTableWriter.save(tempFile, dataGroup);
+            dataGroup = IpacTableReader.readIpacTable(tempFile, catName);
+            checkResult(dataGroup);
+            useFloatsForDoubles = true;
+            dataGroup = IpacTableReader.readIpacTable(tempFile, onlyColumns, useFloatsForDoubles, catName);
+            checkResult(dataGroup); //useFloatsForDoubles has never be used!
+            isHeadersOnlyAllow = true;
+            dataGroup = IpacTableReader.readIpacTable(tempFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+            checkResult(dataGroup); //isHeadersOnlyAllow=true has never be used!
+
+            tempFile.delete();
+
+        }catch (Exception e){
+            //?
+        }
 
         //Test result: This IPAC table is read correctly.
         // Passed.
-        // Known issue: The data type "real" is currently not supported. It is treated as a String. See the ticket https://jira.lsstcorp.org/browse/DM-9026
-
     }
+
 
     @Test
     /**
-     * This test calls the methods IpacTableReader.readIpacTable to read all the columns from a valid input IPAC table, IPACTableSample1.tbl,
+     * This test calls the method IpacTableReader.readIpacTable(StringReader fr, String catName) to read only two columns from a valid input IPAC table as a String,
      * and verify if the produced dataGroup contains the correct information from the table.
-     *         useFloatsForDoubles = true; isHeadersOnlyAllow = true;
-     *
      */
-    public void testValidIpacTable2() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException
 
-    {
+    public void testOnlyColumns() {
 
-        //Read all the columns but useFloatsForDoubles = true; isHeadersOnlyAllow = true;
+        //Input table:
+        String input =
+                "\\catalog1 = 'Sample Catalog1'\n" +
+                "\\catalog2 = 'Sample Catalog2'\n" +
+                "\\ Comment1\n" +
+                "\\ Comment2\n" +
+                "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+                "|   double  |    double |   int    |   float  |   char     |\n" +
+                "|   deg     |    deg    |          |   mag    |            |\n" +
+                "|   null    |    null   |   null   |   null   |   null     |\n" +
+                "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
+                "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-        /* IPACTableSample1.tbl:
+        //Set the expected values:
 
-        \catalog1 = 'Sample Catalog1'
-        \catalog2 = 'Sample Catalog2'
-        \ Comment1
-        \ Comment2
-        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-          165.466279  -34.704730      5       11.27       K6Ve
-          123.4       5.67            9       8.9         K6Ve-1
-
-        */
-
-        //Inputs:
-        String tableName = "IPACTableSample1.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
-        //onlyColumns = null;
-        useFloatsForDoubles = true;
-        isHeadersOnlyAllow = true;
-
-        //Reset the expected values:
-        setExpectedValues_Input1_full();
-
-        //Read the table and generate the dataGroup:
-        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
-
-        //Check the result:
-        checkResult(dataGroup);
-
-        //Test result: No effects from  useFloatsForDoubles = true; isHeadersOnlyAllow = true;
-        // useFloatsForDoubles is not used. isHeadersOnlyAllow = true is not used.
-        // Passed.
-        //Action: Do we need to use those two parameters and for what?
-
-    }
-
-    @Test
-    /**
-     * This test calls the method IpacTableReader.readIpacTable to read only two columns from a valid input IPAC table, IPACTableSample1.tbl,
-     * and verify if the produced dataGroup contains the correct information from the table.
-     *
-     */
-    public void testOnlyColumns() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException
-
-    {
-
-        /* IPACTableSample1.tbl:
-
-        \catalog1 = 'Sample Catalog1'
-        \catalog2 = 'Sample Catalog2'
-        \ Comment1
-        \ Comment2
-        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-          165.466279  -34.704730      5       11.27       K6Ve
-          123.4       5.67            9       8.9         K6Ve-1
-
-        */
-
-
-        //Inputs:
-        String tableName = "IPACTableSample1.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
-        //The same input file but only read two columns:
         onlyColumns = new String[]{"ra", "dec"};
-        useFloatsForDoubles = false;
-        isHeadersOnlyAllow = false;
 
         //Reset the expected values:
-        setExpectedValues_Input1_radecOnly();
+        //Set the attributes:
+        attributeKeys = new String[]{"catalog1", "catalog2"};
+        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'"};
+        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
+        //Set the header:
+        colTitles = new String[]{"ra", "dec"};
+        colKeyNames = new String[]{"ra", "dec"};
+        colDataTypeDesc = new String[]{"double", "double"};
+        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double"};
+        colDataUnits = new String[]{"deg", "deg"};
+        colNullStrings = new String[]{"null", "null"};
+        //Set the data:
+        dataValues = new String[][]{{"165.466279", "-34.70473"}, {"123.4", "5.67"}};
 
-        //Read the table and generate the dataGroup:
-        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+        try {
+            //Read the table and generate the dataGroup:
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
 
-        //Check the result:
-        checkResult(dataGroup);
+            //Check the result:
+            checkResult(dataGroup);
+        }catch(IpacTableException e){
 
-        //Test result: "onlyColumns" works fine. Only those two columns are read.
+        }
+
+        //Test result: "onlyColumns" works fine. Only those two selected columns are read.
         // Passed.
 
     }
@@ -231,66 +198,70 @@ public class IpacTableReaderTest {
      * Verify if the produced dataGroup contains the correct information from the table.
      *
      */
-    public void testNoAttributes() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+    public void testNoAttributes() {
 
-        /* IPACTableSample2_NoAttributes.tbl:
 
-        |id                            |f_x                           |f_y                           |i_x                           |i_y                           |peakValue                     |
-        |long                          |float                         |float                         |int                           |int                           |float                         |
-        |                              |pixels                        |pixels                        |pixels                        |pixels                        |dn                            |
-        |                              |                              |                              |                              |                              |                              |
-         1                              1309.0000                      8.0000                         1309                           8                              149.5896
-         18422                          389.0000                       4.0000                         389                            4                              11.4204
-         18423                          287.0000                       9.0000                         287                            9                              31.1756
+        String input =
+                "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+                "|   double  |    double |   int    |   real   |   char     |\n" +
+                "|   deg     |    deg    |          |   mag    |            |\n" +
+                "|   null    |    null   |   null   |   null   |   null     |\n" +
+                "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
+                "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-        */
-
-        String tableName = "IPACTableSample2_NoAttributes.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
         noAttributes = true;
-        onlyColumns = null;
-        setExpectedValues_Input2();
-        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
-        checkResult(dataGroup);
+
+        try {
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
+
+            List<DataGroup.Attribute> comments = dataGroup.getKeywords();
+            Assert.assertEquals("There should be 0 comments", 0, comments.size());
+            Map<String, DataGroup.Attribute> keywordsMap = dataGroup.getAttributes();
+            Assert.assertEquals("There should be 0 keywords", 0, keywordsMap.size());
+
+            Assert.assertEquals("ra for row 1", 165.466279, (Double) dataGroup.get(0).getDataElement("ra"), 0.001);
+        }catch(IpacTableException e){
+
+        }
+
 
         //Test result: It is okay for an IPAC table not having any attributes. The table is read correctly.
         // Passed.
-        // Known issues: The trailing zeros to the right of the decimal point is truncated, eg. 1309.0000 to 1309.0.
 
     }
 
     @Test
-    /** This test calls the method IpacTableReader.readIpacTable to read a IPAC table, IPACTable3_wrongAttributes.tbl,
-     * which has some wrong keywords and wrong comments.
+    /** This test calls the method IpacTableReader.readIpacTable to read a table, which has some wrong keywords and wrong comments.
      * Need to see how our table reader handle it.
      *
      */
-    public void testWrongAttributes1() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+    public void testWrongAttributes1() {
 
-        /* IPACTable3_wrongAttributes.tbl:
+        String input =
+        "\\ catalog1 = 'A space makes this line as a comment'\n" +
+        "\\key:3\n" +
+        "\\Missing the leading space so this line will be ignored\n" +
+        "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+        "|   double  |    double |   int    |   real   |   char     |\n" +
+        "|   deg     |    deg    |          |   mag    |            |\n" +
+        "|   null    |    null   |   null   |   null   |   null     |\n" +
+        "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
+        "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-        \ catalog1 = 'A space makes this line as a comment'
-        \catalog2 = 'This is a valid keyword.'
-        \key:3  'missing the equal sign and no leading space, so this line will be ignored'
-        \Missing the leading space so this line will be ignored
-        \ Comment2
-        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-          165.466279  -34.704730      5       11.27       K6Ve
-          123.4       5.67            9       8.9         K6Ve-1
+        try {
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
 
-         */
+            //Check the Attributes (comments):
+            List<DataGroup.Attribute> attributes = dataGroup.getKeywords();
+            Assert.assertTrue(attributes.get(0).isComment());
+            Assert.assertEquals("The first attribute has a space so it is parsed as a comment.",
+                    attributes.get(0).toString(), "\\ catalog1 = 'A space makes this line as a comment'");
 
+            Assert.assertEquals("The last two lines will be ignored as they have no leading space nor '=' ", 1, attributes.size());
 
-        String tableName = "IPACTable3_wrongAttributes.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
-        noAttributes = false;
-        onlyColumns = null;
-        setExpectedValues_Input3_wrongAttributes();
-        dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
-        checkResult(dataGroup);
+        }catch(IpacTableException e){
+
+        }
 
         /*Test result:
 
@@ -302,120 +273,157 @@ public class IpacTableReaderTest {
 
         // Passed.
 
-        // Action: How to improve the way to test those issues?
-
-
     }
 
     @Test
     /**
-     * This test calls the method IpacTableReader.readIpacTable to read IPACTable4_wrongAttributes.tbl
-     * which some attributes missing the first "\".
+     * This test calls the method IpacTableReader.readIpacTable to read a table with some wrong attributes missing the first "\".
+     * Test if an exception will be thrown out.
      */
-    public void testWrongAttributes2() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+    public void testWrongAttributes2() {
 
-        /* IPACTable4_wrongAttributes.tbl:
 
-          Comment1 missing the back slash! This line will be ignored.
-          catalog1 = missing the back slash but with a space; this line will be ignored.
-         catalog2 = missing the back slash and no space
-         \ Comment2 Valid comment
-         |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-         |   double  |    double |   int    |   real   |   char     |
-         |   deg     |    deg    |          |   mag    |            |
-         |   null    |    null   |   null   |   null   |   null     |
-           165.466279  -34.704730      5       11.27       K6Ve
-           123.4       5.67            9       8.9         K6Ve-1
+        String input =
+                "catalog2 = missing the back slash and no space\n" +
+                "\\ Comment2 Valid comment\n" +
+                "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+                "|   double  |    double |   int    |   real   |   char     |\n" +
+                "|   deg     |    deg    |          |   mag    |            |\n" +
+                "|   null    |    null   |   null   |   null   |   null     |\n" +
+                "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
+                "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-         */
-
-        String tableName = "IPACTable4_wrongAttributes.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
 
         try{
-            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
-        } catch (IpacTableException e){
-            System.out.println("IpacTableException from the table " + tableName + ": " + e.getMessage());
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+            Assert.fail("No exception thrown.");
+        } catch (Exception e){
+
         }
 
         //Test result:
         //If an attribute starts with a space, it will be ignored.
         //If an attribute has no "\" nor space at beginning, it will trigger IpacTableException: "Data row must start with a space." and no dataGroup is generated.
 
-        //Action item: Anything we can do better in the table reader?
-
+        //Passed
 
     }
 
     @Test
     /**
-     * This test calls the method IpacTableReader.readIpacTable to read IPACTable5_duplicatedCol.tbl
-     * which has duplicate column names.
+     * This test calls the method IpacTableReader.readIpacTable to read a table which has duplicate column names.
+     * Test if an exception will be thrown out.
      */
-    public void testDuplicateColumn() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+    public void testDuplicateColumn(){
 
-        /*
-        \catalog1 = 'Sample Catalog1'
-        \catalog2 = 'Sample Catalog2'
-        \ Comment1
-        \ Comment2
-        |   ra      |    ra     |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-          165.466279  -34.704730      5       11.27       K6Ve
-          123.4       5.67            9       8.9         K6Ve-1
-         */
+    String input =
+            "\\catalog1 = 'Sample Catalog1'\n" +
+            "\\catalog2 = 'Sample Catalog2'\n" +
+            "\\ Comment1\n" +
+            "\\ Comment2\n" +
+            "|   ra      |    ra     |   n_obs  |    V     |   SpType   |\n" +
+            "|   double  |    double |   int    |   float  |   char     |\n" +
+            "|   deg     |    deg    |          |   mag    |            |\n" +
+            "|   null    |    null   |   null   |   null   |   null     |\n" +
+            "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
+            "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-        //Read a table with duplicated column names
-        String tableName = "IPACTable5_duplicatedCol.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+
 
         try{
-            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+            // After DM-9332 is implemented uncomment this:
+            //Assert.fail("No exception thrown out");
+
         } catch (IpacTableException e){
-            System.out.println("IpacTableException from the table " + tableName + ":" + e.getMessage());
+
         }
 
+
+        /* How to find the problem:
+        DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
         DataType[] dataTypes = dataGroup.getDataDefinitions();
         List<String> colTitle = new ArrayList<String>();
         for (int i = 0; i < dataTypes.length; i++) {
             colTitle.add(dataTypes[i].getDefaultTitle().toString());
         }
-
-        System.out.println("NO IpacTableException from the table " + tableName + " which has duplicate column names: " + colTitle);
+        LOG.warn("The duplicate columns should not be allowed: " + colTitle);
+        */
 
         //Test result:
         //The duplicate columns are not detected. A dataGroup is generated with those duplicate columns!
-        //Action item: Issue a ticket!
+        //Action item: Issue a ticket: https://jira.lsstcorp.org/browse/DM-9332
 
     }
 
     @Test
     /**
-     * This test calls the method IpacTableReader.readIpacTable to read IPACTable6_nodata.tbl which has no data.
+     * This test calls the method IpacTableReader.readIpacTable(StringReader fr, String catName) to read a table with data type as "real".
+     * Test if it can be handled correctly.
      */
-    public void testNoData() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+    public void testDatatype_real() {
+        String input =
+                "\\catalog1 = 'Sample Catalog1'\n" +
+                "\\catalog2 = 'Sample Catalog2'\n" +
+                "\\ Comment1\n" +
+                "\\ Comment2\n" +
+                "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+                "|   double  |    double |   int    |   real   |   char     |\n" +
+                "|   deg     |    deg    |          |   mag    |            |\n" +
+                "|   null    |    null   |   null   |   null   |   null     |\n" +
+                "  165.466279  -34.704730      5       11.27       K6Ve      \n" +
+                "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-        /*
-        \catalog1 = 'Sample Catalog1'
-        \catalog2 = 'Sample Catalog2'
-        \ Comment1
-        \ Comment2
-        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-         */
 
-        //Read a table without data
-        String tableName = "IPACTable6_nodata.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        /* After the DM-9026 is implemented, use this:
+        //The attributes:
+        attributeKeys = new String[]{"catalog1", "catalog2"};
+        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'"};
+        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
+        //The header:
+        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
+        colDataTypeDesc = new String[]{"double", "float", "int", "real", "char"};
+        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double", "class java.lang.Integer", "class java.lang.Double", "class java.lang.String"}; //real -> Double!
+        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
+        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
+        //The data:
+        dataValues = new String[][]{{"165.466279", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
+
+        //Get the dataGroup and check:
+        DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+        checkResult(dataGroup);
+        */
+
+        //Test result:
+        //The 4th one is "real" in the table but currently the IPAC table treat it as "char". DM-9026.
+
+    }
+
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read a table which has no data.
+     * Test if an exception is thrown out.
+     */
+    public void testNoData() {
+
+
+        String input =
+                "\\catalog1 = 'Sample Catalog1'\n" +
+                "\\catalog2 = 'Sample Catalog2'\n" +
+                "\\ Comment1\n" +
+                "\\ Comment2\n" +
+                "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+                "|   double  |    double |   int    |   real   |   char     |\n" +
+                "|   deg     |    deg    |          |   mag    |            |\n" +
+                "|   null    |    null   |   null   |   null   |   null     |";
+
 
         try{
-            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+            Assert.fail("No exception thrown out.");
         } catch (IpacTableException e){
-            System.out.println("IpacTableException from the table " + tableName + ": "  + e.getMessage());
+
         }
 
         //Test result: IpacTableException is thrown.
@@ -425,300 +433,74 @@ public class IpacTableReaderTest {
 
     @Test
     /**
-     * This test calls the method IpacTableReader.readIpacTable to read IPACTable7_dataUnderBar.tbl which has one datum under "|".
+     * This test calls the method IpacTableReader.readIpacTable to read a table which has one datum under "|".
+     * Test if an exception is thrown out.
      */
-    public void testDataUnderBar() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
+    public void testDataUnderBar() {
 
-        /*
-        \catalog1 = 'Sample Catalog1'
-        \catalog2 = 'Sample Catalog2'
-        \ Comment1
-        \ Comment2
-        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-           165.466279 -34.704730      5       11.27       K6Ve
-          123.4       5.67            9       8.9         K6Ve-1
-         */
 
-        // Read a table with some data under "|"
-        String tableName = "IPACTable7_dataUnderBar.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
+        String input =
+                "\\catalog1 = 'Sample Catalog1'\n" +
+                "\\catalog2 = 'Sample Catalog2'\n" +
+                "\\ Comment1\n" +
+                "\\ Comment2\n" +
+                "|   ra      |    dec    |   n_obs  |    V     |   SpType   |\n" +
+                "|   double  |    double |   int    |   float  |   char     |\n" +
+                "|   deg     |    deg    |          |   mag    |            |\n" +
+                "|   null    |    null   |   null   |   null   |   null     |\n" +
+                "   165.466279 -34.704730      5       11.27       K6Ve      \n" +
+                "  123.4       5.67            9       8.9         K6Ve-1    ";
 
-        //setExpectedValues_Input7_full();
 
         try{
-            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
-        } catch (IpacTableException e){
-            System.out.println("IpacTableException from the table " + tableName + ": "  + e.getMessage());
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+            //After https://jira.lsstcorp.org/browse/DM-9333 is implemented, use this:
+            //Assert.fail("No exception is thrown out");
+        }catch(IpacTableException e){
+
         }
 
-        System.out.println("NO IpacTableException from the table " + tableName + " which has data under \"|\". A dataGroup is generated but the content is wrong.");
-
-        //checkResult(dataGroup);
-
-        //Test result: No exception. A dataGroup is generated but with wrong content! 165.466279 is truncated to 165.46627; -34.704730 is missing.
-        //Action item: Issue a ticket.
-
-    }
-
-    @Test
-    /**
-     * This test calls the method IpacTableReader.readIpacTable to read IPACTable8_noHeader.tbl which has no header.
-     */
-    public void testNoHeader() throws IpacTableException, ClassNotFoundException, java.lang.NullPointerException {
-
-        /* IPACTable8_noHeader.tbl:
-
-        \catalog1 = 'Sample Catalog1'
-        \catalog2 = 'Sample Catalog2'
-        \ Comment1
-        \ Comment2
-          165.466279  -34.704730      5       11.27       K6Ve
-          123.4       5.67            9       8.9         K6Ve-1
-         */
-
-        // Read a table without header.
-        String tableName = "IPACTable8_noHeader.tbl";
-        File inFile = new File(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
-
-        //setExpectedValues_Input7_full();
-
-        try{
-            dataGroup = IpacTableReader.readIpacTable(inFile, onlyColumns, useFloatsForDoubles, catName, isHeadersOnlyAllow);
-        } catch (IpacTableException e){
-            System.out.println("IpacTableException from the table " + tableName + ": "  + e.getMessage());
-        }
-
-        DataType[] dataTypes = dataGroup.getDataDefinitions();
-
-        System.out.println("NO IpacTableException from the table " + tableName + " which has no header. The dataGroup is generated but the dataTypes length is " + dataTypes.length);
-        //checkResult(dataGroup);
-
-        //Test result: The dataGroup is genearated but no dataTypes.
-        //Action item: Issue a ticket: at least the column name is required.
-
-    }
-
-
-    @Test
-    /**
-     *
-     * This test calls the methods IpacTableReader.readIpacTable(inReader, catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow) which take the input Reader
-     * The input parameters:
-     * FileReader
-     * catName = "catName"
-     * onlyColumns
-     * useFloatsForDoubles
-     * estFileSize
-     * isHeaderOnlyAllow
-     */
-    public void testValidIpacTable_Reader() throws IpacTableException, ClassNotFoundException, FileNotFoundException, java.lang.NullPointerException {
-
-
-        String tableName = "IPACTableSample1.tbl";
-        Reader inReader = new FileReader(FileLoader.getDataPath(IpacTableReaderTest.class) + tableName);
-        //onlyColumns = null;
-        //useFloatsForDoubles = false;
-        //estFileSize = 0;
-        //isHeadersOnlyAllow = false;
-        //noAttributes = false;
-
-        setExpectedValues_Input1_full();
-        dataGroup = IpacTableReader.readIpacTable(inReader, catName, onlyColumns, useFloatsForDoubles, estFileSize, isHeadersOnlyAllow);
-        checkResult(dataGroup);
-
-        //Test result: Passed.
-    }
-
-    private void setExpectedValues_Input1_full() {
-
-               /*
-                \catalog1 = 'Sample Catalog1'
-                \catalog2 = 'Sample Catalog2'
-                \ Comment1
-                \ Comment2
-                |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-                |   double  |    double |   int    |   real   |   char     |
-                |   deg     |    deg    |          |   mag    |            |
-                |   null    |    null   |   null   |   null   |   null     |
-                  165.466279  -34.704730      5       11.27       K6Ve
-                  123.4       5.67            9       8.9         K6Ve-1
-
-                  */
-
-        //Set the attributes:
-        attributeKeys = new String[]{"catalog1", "catalog2", "source"};
-        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTableSample1.tbl"};
-        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
-
-        //Set the header:
-
-        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
-        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
-        colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //The 4th one is "readl" in the table but currently the IPAC table treat it as "char". DM-9026.
-        //colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //After DM-9026.
-        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
-                "class java.lang.Integer", "class java.lang.String", "class java.lang.String"}; //The 4h one is "real" in the table but currently the IPAC table treats it as String. DM-9026.
-        //colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
-        //"class java.lang.Integer", "class java.lang.Double", "class java.lang.String"}; //After DM-9026.
-        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
-        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
-
-        //Set the data:
-        dataValues = new String[][]{{"165.466279", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
-
-    }
-
-    private void setExpectedValues_Input1_radecOnly() {
-
-               /*
-                \catalog1 = 'Sample Catalog1'
-                \catalog2 = 'Sample Catalog2'
-                \ Comment1
-                \ Comment2
-                |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-                |   double  |    double |   int    |   real   |   char     |
-                |   deg     |    deg    |          |   mag    |            |
-                |   null    |    null   |   null   |   null   |   null     |
-                  165.466279  -34.704730      5       11.27       K6Ve
-                  123.4       5.67            9       8.9         K6Ve-1
-
-                  */
-
-        //Only read two columns: ra and dec.
-
-        //Set the attributes:
-        attributeKeys = new String[]{"catalog1", "catalog2", "source"};
-        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTableSample1.tbl"};
-        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
-
-        //Set the header:
-        colTitles = new String[]{"ra", "dec"};
-        colKeyNames = new String[]{"ra", "dec"};
-        colDataTypeDesc = new String[]{"double", "double"};
-        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double"};
-        colDataUnits = new String[]{"deg", "deg"};
-        colNullStrings = new String[]{"null", "null"};
-
-        //Set the data:
-        dataValues = new String[][]{{"165.466279", "-34.70473"}, {"123.4", "5.67"}};
-
-    }
-
-
-
-    private void setExpectedValues_Input2(){
-
-        /*
-        |id                            |f_x                           |f_y                           |i_x                           |i_y                           |peakValue                     |
-        |long                          |float                         |float                         |int                           |int                           |float                         |
-        |                              |pixels                        |pixels                        |pixels                        |pixels                        |dn                            |
-        |                              |                              |                              |                              |                              |                              |
-        1                              1309.0000                      8.0000                         1309                           8                              149.5896
-        18422                          389.0000                       4.0000                         389                            4                              11.4204
-        18423                          287.0000                       9.0000                         287                            9                              31.1756
+        /* How to find the problem:
+        DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+        Assert.assertNotEquals(165.466279, (Double)dataGroup.get(0).getDataElement("ra"));
+        Assert.assertNotEquals(-34.704730, (Double)dataGroup.get(0).getDataElement("dec"));
         */
 
-
-        //Set the attributes:
-        attributeKeys = new String[]{"source"};
-        attributeValues = new String[]{"/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTableSample2_NoAttributes.tbl"};
-        attributeComments = null;
-
-        //Set the header:
-        colTitles = new String[]{"id", "f_x", "f_y", "i_x", "i_y", "peakValue"};
-        colKeyNames = new String[]{"id", "f_x", "f_y", "i_x", "i_y", "peakValue"};
-        colDataTypeDesc = new String[]{"long", "float", "float", "int", "int", "float"};
-        colDataTypes = new String[]{"class java.lang.Long", "class java.lang.Float",
-                "class java.lang.Float", "class java.lang.Integer", "class java.lang.Integer", "class java.lang.Float"};
-        colDataUnits = new String[]{"", "pixels", "pixels", "pixels", "pixels", "dn"};
-        colNullStrings = new String[]{"", "", "", "", "", ""};
-
-        //Set the data:
-        dataValues = new String[][]{{"1", "1309.0", "8.0", "1309", "8", "149.5896"},
-                                        {"18422", "389.0", "4.0", "389", "4", "11.4204"},
-                                        {"18423", "287.0", "9.0", "287", "9", "31.1756"}};
-    }
-
-    private void setExpectedValues_Input3_wrongAttributes() {
-
-        /*
-        \ catalog1 = 'A space makes this line as a comment'
-        \catalog2 = 'This is a valid keyword.'
-        \key:3  'missing the equal sign and no leading space, so this line will be ignored'
-        \Missing the leading space so this line will be ignored
-        \ Comment2
-        |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-        |   double  |    double |   int    |   real   |   char     |
-        |   deg     |    deg    |          |   mag    |            |
-        |   null    |    null   |   null   |   null   |   null     |
-        165.466279  -34.704730      5       11.27       K6Ve
-        123.4       5.67            9       8.9         K6Ve-1
-
-         */
-
-        //Set the attributes:
-        attributeKeys = new String[]{"catalog2", "source"};
-        attributeValues = new String[]{"\'This is a valid keyword.\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTable3_wrongAttributes.tbl"};
-        attributeComments = new String[]{"\\ catalog1 = 'A space makes this line as a comment'", "\\ Comment2"};
-
-        //Set the header:
-        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
-        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
-        colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //The 4th one is "readl" in the table but currently the IPAC table treat it as "char". DM-9026.
-        //colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //After DM-9026.
-        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
-                "class java.lang.Integer", "class java.lang.String", "class java.lang.String"}; //The 4h one is "real" in the table but currently the IPAC table treats it as String. DM-9026.
-        //colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
-        //"class java.lang.Integer", "class java.lang.Double", "class java.lang.String"}; //After DM-9026.
-        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
-        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
-
-        //Set the data:
-        dataValues = new String[][]{{"165.466279", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
+        //Test result: No exception. A dataGroup is generated but with wrong content! 165.466279 is truncated to 165.46627; -34.704730 is missing.
+        //Action item: Issue a ticket https://jira.lsstcorp.org/browse/DM-9333
 
     }
 
-    private void setExpectedValues_Input7_full() {
+    @Test
+    /**
+     * This test calls the method IpacTableReader.readIpacTable to read a table which has no header.
+     * Test if an exception is thrown out.
+     */
+    public void testNoHeader() {
 
-               /*
-                \catalog1 = 'Sample Catalog1'
-                \catalog2 = 'Sample Catalog2'
-                \ Comment1
-                \ Comment2
-                |   ra      |    dec    |   n_obs  |    V     |   SpType   |
-                |   double  |    double |   int    |   real   |   char     |
-                |   deg     |    deg    |          |   mag    |            |
-                |   null    |    null   |   null   |   null   |   null     |
-                  165.466279  -34.704730      5       11.27       K6Ve
-                  123.4       5.67            9       8.9         K6Ve-1
 
-                  */
+        String input =
+                "\\catalog1 = 'Sample Catalog1'\n" +
+                "\\catalog2 = 'Sample Catalog2'\n" +
+                "\\ Comment1\n" +
+                "\\ Comment2\n" +
+                "  165.466279  -34.704730      5       11.27       K6Ve\n" +
+                "  123.4       5.67            9       8.9         K6Ve-1";
 
-        //Set the attributes:
-        attributeKeys = new String[]{"catalog1", "catalog2", "source"};
-        attributeValues = new String[]{"\'Sample Catalog1\'", "\'Sample Catalog2\'", "/hydra/cm/firefly_test_data/edu/caltech/ipac/astro/IPACTable7_dataUnderBar.tbl"};
-        attributeComments = new String[]{"\\ Comment1", "\\ Comment2"};
 
-        //Set the header:
+        try{
+            DataGroup dataGroup = IpacTableReader.readIpacTable(new StringReader(input), catName);
+            //After https://jira.lsstcorp.org/browse/DM-9335 is implemented, use this:
+            //Assert.fail("No exception is thrown out.");
+        }catch(IpacTableException e) {
 
-        colTitles = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
-        colKeyNames = new String[]{"ra", "dec", "n_obs", "V", "SpType"};
-        colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //The 4th one is "readl" in the table but currently the IPAC table treat it as "char". DM-9026.
-        //colDataTypeDesc = new String[]{"double", "double", "int", "char", "char"}; //After DM-9026.
-        colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
-                "class java.lang.Integer", "class java.lang.String", "class java.lang.String"}; //The 4h one is "real" in the table but currently the IPAC table treats it as String. DM-9026.
-        //colDataTypes = new String[]{"class java.lang.Double", "class java.lang.Double",
-        //"class java.lang.Integer", "class java.lang.Double", "class java.lang.String"}; //After DM-9026.
-        colDataUnits = new String[]{"deg", "deg", "", "mag", ""};
-        colNullStrings = new String[]{"null", "null", "null", "null", "null"};
+        }
 
-        //Set the data:
-        dataValues = new String[][]{{"165.46627", "-34.70473", "5", "11.27", "K6Ve"}, {"123.4", "5.67", "9", "8.9", "K6Ve-1"}};
+        //Test result: The dataGroup is genearated but no dataTypes and data. When try to use the data, java.lang.IllegalArgumentException is thrown.
+        //Action item: Issue a ticket: https://jira.lsstcorp.org/browse/DM-9335
 
     }
+
     
     /**
      *
@@ -729,6 +511,7 @@ public class IpacTableReaderTest {
 
         //Check data definitions:
         DataType[] dataTypes = dataGroup.getDataDefinitions();
+
         for (int i = 0; i < dataTypes.length; i++) {
             Assert.assertEquals("check column title", dataTypes[i].getDefaultTitle().toString(), colTitles[i]);
             Assert.assertEquals("check column key name", dataTypes[i].getKeyName().toString(), colKeyNames[i]);
@@ -737,12 +520,6 @@ public class IpacTableReaderTest {
             Assert.assertEquals("check the column unit", dataTypes[i].getDataUnit().toString(), colDataUnits[i]);
             Assert.assertEquals("check column null string", dataTypes[i].getNullString().toString(), colNullStrings[i]);
         }
-
-        //Not test the followings:
-        //dt0.getMayBeNull(); //false!!???
-        //dt0.getFormatInfo().toString(); //"edu.caltech.ipac.util.DataType$FormatInfo@...."??
-        //dt0.getImportance().toString(); //"HIGH" (who assigned this?)
-        //dt0.getMaxDataWidth(); //10
 
         //Check the Attributes (comments):
         List<DataGroup.Attribute> attributes = dataGroup.getKeywords();
@@ -768,10 +545,13 @@ public class IpacTableReaderTest {
         int j = 0;
         String value;
         for (Map.Entry entry : attributeMap.entrySet()) {
-            Assert.assertEquals("check the key", entry.getKey(), attributeKeys[j]);
-            value = ((DataGroup.Attribute) entry.getValue()).getValue().toString();
-            //System.out.println(value + " " + attributeValues[j] + " " + j);
-            Assert.assertEquals("check the value", value, attributeValues[j]);
+            //Not check the input file source:
+            if (j < (attributeMap.size() - 1)) {
+                Assert.assertEquals("check the key", entry.getKey(), attributeKeys[j]);
+                value = ((DataGroup.Attribute) entry.getValue()).getValue().toString();
+                //System.out.println(value + " " + attributeValues[j] + " " + j);
+                Assert.assertEquals("check the value", value, attributeValues[j]);
+            }
             j++;
         }
 
@@ -780,22 +560,9 @@ public class IpacTableReaderTest {
         for (int row = 0; row < objList.size(); row++) {
             for (int col = 0; col < dataTypes.length; col++) {
                 String dataExpected = objList.get(row).getDataElement(dataTypes[col]).toString();
-                Assert.assertEquals("check the 0th data value in the row", dataExpected, dataValues[row][col]);
+                Assert.assertEquals("check the data value", dataExpected, dataValues[row][col]);
             }
         }
     }
-
-
-    // All the methods:
-
-    //public static DataGroup readIpacTable(File f, String catName)
-    //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName)
-    //public static DataGroup readIpacTable(File f, String onlyColumns[], boolean useFloatsForDoubles, String catName, boolean isHeadersOnlyAllow)
-
-    //public static DataGroup readIpacTable(Reader fr, String catName)
-    //public static DataGroup readIpacTable(Reader fr, String catName, long estFileSize)
-    //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize)
-    //public static DataGroup readIpacTable(Reader fr, String catName, String onlyColumns[],boolean useFloatsForDoubles,long estFileSize, boolean isHeadersOnlyAllow)
-
 
 }


### PR DESCRIPTION
Please review the Junit test for IPACTableRead.

Need to use the branch, DM-8916-JUnitTestForIPACTableRead, on firefly_test_data.

 This test is mainly to test if IPACTableReader.java reads the IPAC table correctly. The IRSA IPAC table reader requirements are in
       http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html
 
 An IPAC table is composed by three parts: Attributes which includes keywords and comments; header which includes column names, data types, data units, and null values; and data rows.
 
The test cases below test if the reader can parse all parts in a table correctly and also if the reader can throw exceptions correctly when a table violate the requirements.


In this version, there are several known issues:
1) So far all the data comparison is done to compare strings (.toString() )  Will improve this.
2) Need to finalize the rules to validate an IPAC table. Or how strict we should accept/reject a table. Then we can update the test cases.

