### PR TITLE
DM-9206 - XY Plot: set precision for expression columns

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
@@ -103,9 +103,14 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         ArrayList<DataType> columnList = new ArrayList<>();
         columnList.add(new DataType("rowIdx", Integer.class));
         ArrayList<DataGroup.Attribute> colMeta = new ArrayList<>();
+        DataType dt;
         for (Col col : cols) {
             if (col.getter.isExpression()) {
-                columnList.add(new DataType(col.colname, col.colname, Double.class, DataType.Importance.HIGH, "", false));
+                dt = new DataType(col.colname, col.colname, Double.class, DataType.Importance.HIGH, "", false);
+                DataType.FormatInfo fi = dt.getFormatInfo();
+                fi.setDataFormat("%.14g");
+                dt.setFormatInfo(fi);
+                columnList.add(dt);
             } else {
                 columnList.add(dg.getDataDefintion(col.colname).copyWithNoColumnIdx(columnList.size()));
                 colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), col.colname));
@@ -119,7 +124,6 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         DataObject retrow;
         int ncols = cols.length;
         Col col;
-        DataType dt;
         double val;
         String formatted;
         DataType dtRowIdx = columns[0];

--- a/src/firefly/js/charts/dataTypes/XYColsCDT.js
+++ b/src/firefly/js/charts/dataTypes/XYColsCDT.js
@@ -510,9 +510,9 @@ function fetchXYWithErrorsOrSort(dispatch, chartId, chartDataElementId) {
 
                 // make sure all fields are numeric and change row data from [ [val] ] to [ {cname:val} ]
                 let xMin = Number.MAX_VALUE;
-                let xMax = Number.MIN_VALUE;
+                let xMax = -Number.MAX_VALUE;
                 let yMin = Number.MAX_VALUE;
-                let yMax = Number.MIN_VALUE;
+                let yMax = -Number.MAX_VALUE;
                 const rows = tableModel.tableData.data.map((row) => {
                     const nrow =  colNames.reduce( (nrow, name, cidx) => {
                         nrow[name] = parseFloat(row[cidx]);

--- a/src/firefly/js/charts/ui/XYPlot.jsx
+++ b/src/firefly/js/charts/ui/XYPlot.jsx
@@ -695,10 +695,10 @@ export class XYPlot extends React.Component {
         const {xTitle, xGrid, xReversed, xOpposite, xLog} = getXAxisOptions(params);
         const {yTitle, yGrid, yReversed, yOpposite, yLog} = getYAxisOptions(params);
         const {xMin, xMax, yMin, yMax} = getZoomSelection(params);
-        const {decimateKey} = data;
+        const {decimateKey, x, y} = data;
         const {xMin:xDataMin, xMax:xDataMax, yMin:yDataMin, yMax:yDataMax} = get(params, 'boundaries', {});
-        const xFormat = decimateKey ? getFormatString(Math.abs(xDataMax-xDataMin), 4) : undefined;
-        const yFormat = decimateKey ? getFormatString(Math.abs(yDataMax-yDataMin), 4) : undefined;
+        const xFormat = (decimateKey || x) ? getFormatString(Math.abs(xDataMax-xDataMin), 4) : undefined;
+        const yFormat = (decimateKey || y) ? getFormatString(Math.abs(yDataMax-yDataMin), 4) : undefined;
 
         const makeSeries = this.makeSeries;
 

--- a/src/firefly/js/charts/ui/XYPlot.jsx
+++ b/src/firefly/js/charts/ui/XYPlot.jsx
@@ -697,8 +697,9 @@ export class XYPlot extends React.Component {
         const {xMin, xMax, yMin, yMax} = getZoomSelection(params);
         const {decimateKey, x, y} = data;
         const {xMin:xDataMin, xMax:xDataMax, yMin:yDataMin, yMax:yDataMax} = get(params, 'boundaries', {});
-        const xFormat = (decimateKey || x) ? getFormatString(Math.abs(xDataMax-xDataMin), 4) : undefined;
-        const yFormat = (decimateKey || y) ? getFormatString(Math.abs(yDataMax-yDataMin), 4) : undefined;
+        // bin center and expression values need to be formatted
+        const xFormat = (decimateKey || (x && x.match(/\W/))) ? getFormatString(Math.abs(xDataMax-xDataMin), 4) : undefined;
+        const yFormat = (decimateKey || (y && y.match(/\W/))) ? getFormatString(Math.abs(yDataMax-yDataMin), 4) : undefined;
 
         const makeSeries = this.makeSeries;
 


### PR DESCRIPTION
This is a fix for a bug described in https://jira.lsstcorp.org/browse/DM-9206

Test procedure and test table are in the ticket.

Set precision for expression columns to 14 seg digits. 
Tooltip will include 4 sig digits in the difference between min and max of the plot.

