### PR TITLE
 DM-9247: Implement search processor(s) to support All Sky mode

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
@@ -101,7 +101,7 @@ public class LSSTCataLogSearch extends IpacTablePartProcessor {
 
         boolean isRunDeep = (catalog != null && catalog.contains("RunDeep"));
         switch (method.toUpperCase()) {
-            case "ALL_SKY":
+            case "ALLSKY":
                 return "";
             case "BOX":
                 //The unit is degree for all the input


### PR DESCRIPTION
To test it,

   1.  In catalog search, select "allSky"
   2. Enter the constrains at the field:

      For deep source at the id field enter
          =3219370314566605

      For forced deep source at the id field enter:
         =225486482582800165

Each search returns only one finding.

Thanks!
        