### PR TITLE
DM-9165: fixing coverage issues

### DIFF
--- a/src/firefly/html/demo/ffapi-coverage-test.html
+++ b/src/firefly/html/demo/ffapi-coverage-test.html
@@ -1,0 +1,91 @@
+<!doctype html>
+
+<!--
+  ~ License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+  -->
+
+<html>
+
+<head>
+    <meta http-equiv="Cache-Control" content="no-cache">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Demo of Firefly Tools</title>
+</head>
+
+<body>
+
+
+<div style="width: 500px; padding: 50px 0 0 20px;">
+    <br>
+    This page demos new api
+    <br>
+</div>
+
+<div>
+    <div id="coverageHere" style="display: inline-block; width: 400px; height: 400px; margin: 10px;"></div>
+    <div id="tables-1" style="display: inline-block; width: 550px; height: 300px; margin: 10px; background-color: white;"></div>
+</div>
+
+<script type="text/javascript">
+    {
+        onFireflyLoaded= function(firefly) {
+
+            window.ffViewer= firefly.getViewer();
+
+            firefly.setGlobalImageDef({
+                ZoomType  : 'TO_WIDTH'
+            } );
+
+            firefly.debug= true;
+
+            var util= firefly.util;
+            var ui= firefly.ui;
+              util.image.initAutoReadout(ui.DefaultApiReadout,
+                     {MouseReadoutComponent:ui.PopupMouseReadoutMinimal, showThumb:false,showMag:false});
+
+
+
+
+
+
+            //-----------------  TABLE DEMO ------------------------//
+            tblReq1 = firefly.util.table.makeIrsaCatalogRequest('allwise_p3as_psd', 'WISE', 'allwise_p3as_psd',
+                    {   position: '148.9;68.8;EQ_J2000',
+                        SearchMethod: 'Cone',
+                        radius: 300,
+                    },
+                    {tbl_id: 'aTable'}
+                    );
+            tblReq2 = firefly.util.table.makeIrsaCatalogRequest('fp_psc', '2MASS', 'fp_psc',
+                    {   position: '148.9;68.8;EQ_J2000',
+                        SearchMethod: 'Cone',
+                        radius: 300,
+                    },
+                    {tbl_id: 'bTable'}
+            );
+
+            firefly.showTable('tables-1', tblReq1);
+            firefly.showTable('tables-1', tblReq2);
+
+            firefly.showCoverage('coverageHere',
+                    {
+                        gridOn:true,
+                        symbol: {aTable: 'X', bTable: 'arrow'},
+                        symbolSize: {aTable: 3, bTable: 12},
+                        color: {aTable: 'blue', bTable: 'yellow'},
+//                        overlayPosition : '149.9;68.8;EQ_J2000',
+                        overlayPosition : '149.08;68.739;EQ_J2000',
+                   });
+
+        };
+
+   }
+   
+</script>
+
+
+<script  type="text/javascript" src="../firefly_loader.js"></script>
+
+

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -356,7 +356,8 @@ function initCoverage(llApi, targetDiv,options= {}) {
 
     renderDOM(targetDiv, MultiImageViewer,
         {viewerId:targetDiv, canReceiveNewPlots, canDelete:false, Toolbar:MultiViewStandardToolbar });
-    dispatchAddSaga(watchCoverage, {viewerId:targetDiv, options});
+    options= Object.assign({},options, {viewerId:targetDiv})
+    dispatchAddSaga(watchCoverage, options);
 }
 
 

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -37,7 +37,6 @@ import {masterSaga} from './MasterSaga.js';
 
 
 //--- import Sagas
-import {watchCatalogs} from '../visualize/saga/CatalogWatcher.js';
 import {syncCharts} from '../visualize/saga/ChartsSync.js';
 import {imagePlotter} from '../visualize/saga/ImagePlotter.js';
 import {watchReadout} from '../visualize/saga/MouseReadoutWatch.js';
@@ -223,7 +222,6 @@ function createRedux() {
 }
 
 function startCoreSagas() {
-    dispatchAddSaga(watchCatalogs);
     dispatchAddSaga( imagePlotter);
     dispatchAddSaga( syncCharts);
     dispatchAddSaga( watchReadout);

--- a/src/firefly/js/drawingLayers/ActiveTarget.js
+++ b/src/firefly/js/drawingLayers/ActiveTarget.js
@@ -3,6 +3,7 @@
  */
 
 
+import {isEmpty} from 'lodash'
 import ImagePlotCntlr, {visRoot} from '../visualize/ImagePlotCntlr.js';
 import DrawLayerCntlr from '../visualize/DrawLayerCntlr.js';
 import {primePlot} from '../visualize/PlotViewUtil.js';
@@ -27,7 +28,8 @@ var idCnt=0;
 
 function creator(initPayload, presetDefaults) {
     var drawingDef= makeDrawingDef('blue');
-    drawingDef.symbol= DrawSymbol.SQUARE;
+    drawingDef.symbol= DrawSymbol.CIRCLE;
+    drawingDef.size= 6;
     drawingDef= Object.assign(drawingDef,presetDefaults);
 
     idCnt++;
@@ -42,8 +44,8 @@ function creator(initPayload, presetDefaults) {
 
 
 function getDrawData(dataType, plotId, drawLayer, action, lastDataRet) {
-    if (dataType!= DataTypes.DATA) return null;
-    return lastDataRet || computeDrawLayer(plotId);
+    if (dataType!==DataTypes.DATA) return null;
+    return isEmpty(lastDataRet) ? computeDrawData(plotId) : lastDataRet;
 }
 
 function getLayerChanges(drawLayer, action) {
@@ -72,7 +74,7 @@ function getTitle(plotId) {
     return retval;
 }
 
-function computeDrawLayer(plotId) {
+function computeDrawData(plotId) {
     if (!plotId) return null;
     var plot= primePlot(visRoot(),plotId);
     if (!plot) return [];

--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -52,10 +52,11 @@ var createCnt= 0;
 function creator(initPayload, presetDefaults) {
     const {catalogId, tableData, tableMeta, title,
            selectInfo, columns, tableRequest, highlightedRow, color, angleInRadian=false,
+           symbol, size,
            dataTooBigForSelection=false, catalog=true,boxData=false }= initPayload;
     var drawingDef= makeDrawingDef();
-    drawingDef.size= 5;
-    drawingDef.symbol= DrawSymbol.SQUARE;
+    drawingDef.size= size || 5;
+    drawingDef.symbol= DrawSymbol.get(symbol) || DrawSymbol.SQUARE;
     drawingDef= Object.assign(drawingDef,presetDefaults);
 
     var pairs= {
@@ -223,7 +224,6 @@ function computePointDrawLayer(drawLayer, tableData, columns) {
     const {angleInRadian:rad}= drawLayer;
     if (lonIdx<0 || latIdx<0) return null;
 
-    const {size,symbol}= drawLayer.drawingDef;
     return tableData.data.map( (d) => {
         const wp= makeWorldPt( toAngle(d[lonIdx],rad), toAngle(d[latIdx],rad), columns.csys);
         return PointDataObj.make(wp);

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -20,6 +20,7 @@ import {getActionFromUrl} from '../../core/History.js';
 import {launchImageMetaDataSega} from '../../visualize/ui/TriViewImageSection.jsx';
 import {syncChartViewer, addDefaultScatter} from '../../visualize/saga/ChartsSync.js';
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
+import {watchCatalogs} from '../../visualize/saga/CatalogWatcher.js';
 
 // import {deepDiff} from '../util/WebUtil.js';
 
@@ -43,6 +44,7 @@ export class FireflyViewer extends Component {
     constructor(props) {
         super(props);
         this.state = this.getNextState();
+        dispatchAddSaga(watchCatalogs);
         dispatchAddSaga(layoutManager,{views: props.views});
         dispatchAddSaga(syncChartViewer);
         dispatchAddSaga(addDefaultScatter);

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -181,7 +181,7 @@ function handleActiveTableChange (layoutInfo, action) {
         coverageLockedOn= anyHasCatalog || anyHasMeta;
     }
 
-    if (anyHasCatalog) {
+    if (anyHasCatalog || anyHasMeta) {
         showCoverage = coverageLockedOn;
         showImages = true;
     } else {
@@ -218,8 +218,7 @@ function handlePlotDelete(layoutInfo, action) {
 
 function handleNewImage(layoutInfo, action) {
     var {images={}} = layoutInfo;
-    var {selectedTab, showMeta, showFits} = images;
-    var coverageLockedOn = false;
+    var {selectedTab, showMeta, showFits, coverageLockedOn} = images;
 
     const {viewerId} = action.payload || {};
     if (viewerId === META_VIEWER_ID) {

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -28,6 +28,7 @@ import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import {makeFileRequest} from '../../tables/TableUtil.js';
+import {watchCatalogs} from '../../visualize/saga/CatalogWatcher.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 
 
@@ -40,6 +41,7 @@ export class LcViewer extends Component {
     constructor(props) {
         super(props);
         this.state = this.getNextState();
+        dispatchAddSaga(watchCatalogs);
         dispatchAddSaga(lcManager);
         dispatchAddSaga(listenerPanel);
         dispatchAddSaga(syncChartViewer);

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -98,7 +98,7 @@ export function getDlAry() { return flux.getState()[DRAWING_LAYER_KEY].drawLayer
 
 /**
  * Return the draw layer store
- * @returns {DrawLayerRoot[]}
+ * @returns {DrawLayerRoot}
  * @memberof firefly.action
  * @function  getDlRoot
  */

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -220,7 +220,7 @@ export function getConnectedPlotsIds(ref, drawLayerId) {
 
 /**
  *
- * @param ref - the root of the drawing layer controller or the master array of all drawing layers
+ * @param {DrawLayer[]|DrawLayerRoot} ref - the root of the drawing layer controller or the master array of all drawing layers
  * @param typeId
  * @return {object} the draw layer
  */
@@ -231,7 +231,7 @@ export function getDrawLayerByType(ref,typeId) {
 
 /**
  *
- * @param ref - the root of the drawing layer controller or the master array of all drawing layers
+ * @param {DrawLayer[]|DrawLayerRoot} ref - the root of the drawing layer controller or the master array of all drawing layers
  * @param id draw layer id
  * @returns {Array} the draw layer
  */
@@ -242,7 +242,7 @@ export function getDrawLayerById(ref,id) {
 
 /**
  * UNTESTED - I think I will need this eventually
- * @param {Object} ref - the root of the drawing layer controller or the master array of all drawing layers
+ * @param {DrawLayer[]|DrawLayerRoot} ref - the root of the drawing layer controller or the master array of all drawing layers
  * @param {string} displayGroupId
  * @return {Array} the draw layer
  */

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -534,7 +534,7 @@ export class WebPlotRequest extends ServerRequest {
 
     /**
      *
-     * @param {WorldPt} worldPt
+     * @param {WorldPt|String} worldPt - the world point object or a serialized version
      */
     setOverlayPosition(worldPt) {
         this.setParam(C.OVERLAY_POSITION, worldPt.toString());

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -19,7 +19,7 @@ const FONT_FALLBACK= ',sans-serif';
 
 var UnitType= new Enum(['PIXEL','ARCSEC','IMAGE_PIXEL']);
 export var ShapeType= new Enum(['Line', 'Text','Circle', 'Rectangle', 'Ellipse',
-                         'Annulus', 'BoxAnnulus', 'EllipseAnnulus', 'Polygon']);
+                         'Annulus', 'BoxAnnulus', 'EllipseAnnulus', 'Polygon'], { ignoreCase: true });
 const SHAPE_DATA_OBJ= 'ShapeDataObj';
 const DEF_WIDTH = 1;
 

--- a/src/firefly/js/visualize/saga/ImagePlotter.js
+++ b/src/firefly/js/visualize/saga/ImagePlotter.js
@@ -43,8 +43,8 @@ export function* imagePlotter(params, dispatch, getState) {
 
             case ImagePlotCntlr.UPDATE_VIEW_SIZE:
                 const {plotId}= action.payload;
-                const waitAction= waitingPlotActions.find( (a) => actionMatches(a,plotId));
-                if (waitAction) {
+                const waitActions= waitingPlotActions.filter( (a) => actionMatches(a,plotId));
+                waitActions.forEach( (waitAction) => {
                     const {requestKey}= waitAction.payload;
                     if (canContinue(waitAction)) {
                         continuePlotting(makeContinueAction(waitAction),dispatch);
@@ -52,7 +52,7 @@ export function* imagePlotter(params, dispatch, getState) {
                             .filter( (a) => a.payload.requestKey!==requestKey) // filter out this request
                             .filter( (a) => !actionMatches(a,plotId));         // filter out any duplicates
                     }
-                }
+                });
                 break;
         }
     }

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -93,7 +93,7 @@ function closeExpanded() {
 
 export function launchImageMetaDataSega() {
     dispatchAddSaga(watchImageMetaData,{viewerId: META_VIEWER_ID});
-    dispatchAddSaga(watchCoverage, {viewerId:'coverageImages'});
+    dispatchAddSaga(watchCoverage, {viewerId:'coverageImages', ignoreCatalogs:true});
 }
 
 TriViewImageSection.propTypes= {


### PR DESCRIPTION
 - Now can set overlay position
 - Symbol, symbol size and color can be set per table
 - Active Target bug fixed
 - Initlization of CoverageWatch sega moved to templates and api
 - triview: fixed coverage disappearing in a certain case

**To Test**

 - build and try http://localhost:8080/firefly/demo/ffapi-coverage-test.html
 - modify options on lines 72-80, then copy file to `/hydra/server/tomcatwebapps/firefly/demo/` and reload