### PR TITLE
DM-8571: The current search result table tab should be shown immediately

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -341,8 +341,8 @@ function tblResultsAdded(action) {
             if (!TblUtil.getTableInGroup(tbl_id, options.tbl_group)) {
                 tbl_ui_id = tbl_ui_id || TblUtil.uniqueTblUiId();
                 dispatch({type: TBL_RESULTS_ADDED, payload: {tbl_id, title, tbl_ui_id, options}});
-                dispatchAddSaga(doOnTblLoaded, {tbl_id, callback:() => dispatchActiveTableChanged(tbl_id, options.tbl_group)});
             }
+            dispatchActiveTableChanged(tbl_id, options.tbl_group);
         }
     };
 }


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-8571

Switch to the search result tab immediately even though data have not returned.
Minor code change.  Please confirm it did not break anything else, i.e. external viewer, lightcurve, etc.