### PR TITLE
DM-7798: Add remote launch capabilities to the Time Series viewer

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -166,7 +166,7 @@
         function launchLC(req) {
             var req = firefly.util.table.makeFileRequest(null, 'http://web.ipac.caltech.edu/staff/ejoliet/demo/WISE-mep-2764p772_ac51-010204.tbl',null,
                     { tbl_id: 'raw_table',
-                      META_INFO: {mission: 'WISE'} });
+                      META_INFO: {datasetInfoConverterId: 'wise'} });
             firefly.getViewer(null, "lc.html").showTable(req);
         }
 

--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -51,7 +51,7 @@
     <a href='javascript:firefly.getViewer().showTable(tblReq3)'>Open a table</a>
     <a href='javascript:firefly.getViewer().showTable(tblReq1)'>Open allwise</a>
     <a href='javascript:tblReq1.sortInfo="ASC,ra"; firefly.getViewer().fetchTable(tblReq1)'>Sort allwise by ra</a>
-</div>
+    <a href='javascript:launchLC()'>Launch WISE LcViewer</a></div>
 <div>
     <div id="tables-2" style="display: inline-block; width: 550px; height: 300px; margin: 10px; background-color: white"></div>
     <div id="tables-1" style="display: inline-block; width: 550px; height: 300px; margin: 10px; background-color: white; position: absolute"></div>
@@ -163,6 +163,13 @@
 
 <script type="text/javascript">
     {
+        function launchLC(req) {
+            var req = firefly.util.table.makeFileRequest(null, 'http://web.ipac.caltech.edu/staff/ejoliet/demo/WISE-mep-2764p772_ac51-010204.tbl',null,
+                    { tbl_id: 'raw_table',
+                      META_INFO: {mission: 'WISE'} });
+            firefly.getViewer(null, "lc.html").showTable(req);
+        }
+
         function loadMovingTable() {
             var req = firefly.util.table.makeFileRequest('A moving object table',
                     'http://web.ipac.caltech.edu/staff/roby/demo/moving/MOST_results-sample.tbl',null,

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -129,7 +129,8 @@ function buildTablePart(llApi) {
      * @prop {boolean} expandable   defaults to true
      * @prop {boolean} showToolbar  defaults to true
      * @prop {boolean} border       defaults to true
-     * @prop {object}  downloadButton   a download button component for this table
+     * @prop {function[]}  leftButtons   an array of functions that returns a button-like component laid out on the left side of this table header.  Function will be called with table's state.
+     * @prop {function[]}  rightButtons  an array of functions that returns a button-like component laid out on the left side of this table header.  Function will be called with table's state.
      */
 
     /**

--- a/src/firefly/js/api/ApiViewer.js
+++ b/src/firefly/js/api/ApiViewer.js
@@ -49,7 +49,7 @@ export function buildViewerApi() {
  * @memberof firefly
  *
  */
-function getViewer(channel= getWsChannel(),file='') {
+export function getViewer(channel= getWsChannel(),file='') {
     channel += VIEWER_ID;
     const dispatch= (action) => dispatchRemoteAction(channel,action);
 

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -25,7 +25,6 @@ import {FileUpload} from '../../ui/FileUpload.jsx';
 import {ValidationField} from '../../ui/ValidationField.jsx';
 import {dispatchHideDropDown} from '../../core/LayoutCntlr.js';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
-import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import {makeFileRequest} from '../../tables/TableUtil.js';
 import {sortInfoString} from '../../tables/SortInfo.js';

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -20,7 +20,7 @@ import {dispatchHideDropDown} from '../../core/LayoutCntlr.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
 import {ServerParams} from '../../data/ServerParams.js';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
-import {makeTblRequest, makeLsstCatalogRequest} from '../../tables/TableUtil.js';
+import {makeTblRequest, makeLsstCatalogRequest, makeFileRequest, getCellValue} from '../../tables/TableUtil.js';
 import {CatalogConstraintsPanel, getTblId} from './CatalogConstraintsPanel.jsx';
 import {validateSql, validateConstraints} from './CatalogSelectViewPanel.jsx';
 import {LSSTImageSpatialType} from './LSSTImageSpatialType.jsx';
@@ -283,21 +283,23 @@ function doImage(request, imgPart) {
 
 
     tReq = addConstraintToQuery(tReq);
-    const downloadButton = (
-            <DownloadButton>
-                <DownloadOptionPanel
-                    cutoutSize = {size}
-                    dlParams = {{
-                            Title: title,
-                            FilePrefix: cattable,
-                            BaseFileName: cattable,
-                            DataSource: cattable,
-                            FileGroupProcessor: 'LSSTFileGroupProcessor'     // insert FileGroupProcessor's ID here.
-                        }}/>
-            </DownloadButton>
+    const downloadButton = ({tbl_id}) => {
+                return (
+                    <DownloadButton tbl_id = {tbl_id}>
+                        <DownloadOptionPanel
+                            cutoutSize = {size}
+                            dlParams = {{
+                                    Title: title,
+                                    FilePrefix: cattable,
+                                    BaseFileName: cattable,
+                                    DataSource: cattable,
+                                    FileGroupProcessor: 'LSSTFileGroupProcessor'     // insert FileGroupProcessor's ID here.
+                                }}/>
+                    </DownloadButton>
 
-        );
-    dispatchTableSearch(tReq, {downloadButton});
+                );
+            };
+    dispatchTableSearch(tReq, {leftButtons: [downloadButton]});
 }
 
 /**


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-7798

Added 'Launch WISE LcViewer'  link into demo page to demonstrate how to launch an external viewer to display time series data.

To test:
goto http://localhost:8080/firefly/demo/ffapi-highlevel-test.html
In Tables from API calls section, click on 'Launch WISE LcViewer' to launch an external viewer showing wise light curve data.