### PR TITLE
DM-9248 Implement 'All Sky' mode in LSST catalog and image search catalogs

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMetaSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMetaSearch.java
@@ -53,7 +53,6 @@ public class LSSTMetaSearch  extends IpacTablePartProcessor{
         JSONParser parser = new JSONParser();
 
         JSONObject obj = ( JSONObject) parser.parse(new FileReader(file ));
-        //return  obj.get("message").toString();
         return  obj.get("error").toString();
     }
 
@@ -111,6 +110,13 @@ public class LSSTMetaSearch  extends IpacTablePartProcessor{
 
     }
 
+    /**
+     * This method processes the input JSONArray and then return a DataType array.
+     * Since there is no unit data,this method fakes the unit and description.
+     *
+     * @param metaData
+     * @return
+     */
     private DataType[] getDataType(JSONArray metaData){
         DataType[] dataTypes = new DataType[metaData.size()+2];//add unit and descriptions
         for (int i=0; i<metaData.size(); i++){

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
@@ -31,7 +31,9 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
-
+/**
+ * This is a base class for LSSTCatlogSearch and LSSTLightCurveQuery
+ */
 public abstract class LSSTQuery extends IpacTablePartProcessor {
     private static final Logger.LoggerImpl _log = Logger.getLogger();
     private static final String PORT = "5000";
@@ -147,7 +149,12 @@ public abstract class LSSTQuery extends IpacTablePartProcessor {
         return dg;
     }
 
-
+    /**
+     * This method add a number to a DataObject
+     * @param dataType
+     * @param nd
+     * @param row
+     */
     private void addNumberToRow(DataType dataType, Number nd,DataObject row ) {
         switch (dataType.getDataType().getSimpleName()){
             case "Byte":
@@ -172,6 +179,12 @@ public abstract class LSSTQuery extends IpacTablePartProcessor {
         }
     }
 
+    /**
+     * This method adds a String to a DataObject
+     * @param dataType
+     * @param sd
+     * @param row
+     */
     private void addStringToRow(DataType dataType, String sd,DataObject row){
         switch (dataType.getDataType().getSimpleName()) {
             case "Boolean":

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -163,6 +163,7 @@ export class CatalogConstraintsPanel extends React.Component {
      * @param {string} dd_short
      * @param {function} createDDRequest
      * @param {boolean} clearSelections
+     * @param {func} afterFetch
      */
     fetchDD(catName, dd_short, createDDRequest, clearSelections = false, afterFetch) {
 
@@ -460,7 +461,7 @@ function updateRowSelected(tbl_id, onTableChanged) {
         }
         TblCntlr.dispatchTableSelect(tbl_id, selectInfoCls.data);
         onTableChanged && onTableChanged();
-    }
+    };
 }
 
 /**

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -18,12 +18,11 @@ import {FilterInfo, FILTER_TTIPS} from '../../tables/FilterInfo.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {InputAreaFieldConnected} from '../../ui/InputAreaField.jsx';
 import {fieldGroupConnector} from '../../ui/FieldGroupConnector.jsx';
-import {LSSTDDPID} from './LSSTCatalogSelectViewPanel.jsx';
 const sqlConstraintsCol = {name: 'constraints', idx: 1, type: 'char', width: 10};
 
 import '../../tables/ui/TablePanel.css';
 
-/**
+/*
  * update short_dd to be one of ['short', 'long', ''] based on if 'showForm' is true or not
  */
 function makeFormType(showForm, short_dd) {

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -291,7 +291,6 @@ class CatalogSelectView extends Component {
      * from tableModel.tableData.columns
      * result is set in the state as 'master' object {catmaster, cols}
      * @see setMaster
-     * @returns {Void} fetch master table and once fetched, set state with it
      */
     loadMasterCatalogTable() {
 

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -8,7 +8,7 @@ import {FormPanel} from '../../ui/FormPanel.jsx';
 import { get, merge, isEmpty, isFunction} from 'lodash';
 import {updateMerge} from '../../util/WebUtil.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
-import {doFetchTable, makeTblRequest, makeIrsaCatalogRequest, makeVOCatalogRequest, getTblById} from '../../tables/TableUtil.js';
+import {doFetchTable, makeTblRequest, makeIrsaCatalogRequest, makeVOCatalogRequest} from '../../tables/TableUtil.js';
 import {CatalogTableListField} from './CatalogTableListField.jsx';
 import {CatalogConstraintsPanel} from './CatalogConstraintsPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
@@ -146,11 +146,11 @@ function doCatalog(request) {
     var title = `${catPart.project}-${catPart.cattable}`;
     var tReq = {};
     if (spatial === SpatialMethod.get('Multi-Object').value) {
-        var filename = catPart.fileUpload;
-        var radius = conesize;
+        var filename = get(catPart, 'fileUpload');
+
         tReq = makeIrsaCatalogRequest(title, catPart.project, catPart.cattable, {
             filename,
-            radius,
+            radius: conesize,
             SearchMethod: spacPart.spatial,
             RequestedDataSet: catalog
         });
@@ -222,10 +222,10 @@ export function validateSql(sqlTxt) {
     //const filterInfoCls = FilterInfo.parse(sql);
     //return filterInfoCls.serialize();//sql.replace(';',' AND ');
     // Check that text area sql doesn't starts with 'AND', if needed, update the value without
-    if (sqlTxt.toLowerCase().indexOf('and') == 0) { // text sql starts with and, but and will be added if constraints is added to any column already, so remove here if found
+    if (sqlTxt.toLowerCase().indexOf('and') === 0) { // text sql starts with and, but and will be added if constraints is added to any column already, so remove here if found
         sqlTxt = sqlTxt.substring(3, sqlTxt.length).trim();
     }
-    if (sqlTxt.toLowerCase().lastIndexOf('and') == sqlTxt.length - 3) {
+    if (sqlTxt.toLowerCase().lastIndexOf('and') === sqlTxt.length - 3) {
         sqlTxt = sqlTxt.substring(0, sqlTxt.length - 3).trim();
     }
     return sqlTxt;
@@ -329,8 +329,6 @@ class CatalogSelectView extends Component {
                     }
                 });
                 subprojects[projects[i]] = tmp;
-
-
             }
             var o = 0;
             for (i = 0; i < projects.length; i++) {
@@ -384,7 +382,6 @@ class CatalogSelectView extends Component {
      *      ["projectshort", "subtitle", "description", "server", "catname", "cols", "nrows", "coneradius", "infourl", "ddlink", "catSearchProcessor", "ddSearchProcessor"]
      * @see master table file from http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan?mode=ascii
      * @param {Object} master table model
-     * @returns {Void} set the state to include master table
      */
     setMaster(master = {}) {
         this.setState({master});
@@ -436,7 +433,7 @@ class CatalogSelectView extends Component {
         );
     }
 }
-const currentField = {};
+
 /**
  * Reducer from field group component, should return updated project and sub-project updated
  * @returns {Function} reducer to change fields when user interact with the dialog
@@ -513,7 +510,7 @@ var userChangeDispatch = function () {
 
                 const catname = get(inFields, 'cattable.value', '');
                 const formsel = get(inFields, 'ddform.value', 'true');
-                const shortdd = formsel == 'true' ? 'short' : 'long';
+                const shortdd = formsel === 'true' ? 'short' : 'long';
                 inFields = updateMerge(inFields, 'tableconstraints', {
                     tbl_id: `${catname}-${shortdd}-dd-table-constraint`
                 });
@@ -530,6 +527,7 @@ var userChangeDispatch = function () {
     };
 };
 
+/*
 function cleanFilterRestrictions(inFields) {
     //Object.keys(inFields).forEach((k) => {
     //
@@ -545,6 +543,7 @@ function cleanFilterRestrictions(inFields) {
     inFields = updateMerge(inFields, 'txtareasql', {value: ''});
     return inFields;
 }
+*/
 
 /**
  * Return the project elements such as label, value and project is present in each
@@ -601,7 +600,6 @@ class CatalogDDList extends Component {
         const selProject0 = catmaster[0].project;
         const selCat0 = catmaster[0].subproject[0].value;
 
-        let catTable, optProjects, optList;
         // User interact, coming from field group reducer function
         // @see userChangeDispatch
 
@@ -619,15 +617,13 @@ class CatalogDDList extends Component {
         //}
         // Build option list for project,  sub-project and catalog table based on the selected or initial value of project and sub-project
 
-
-
-
-        optProjects = getProjectOptions(this.props.master.catmaster);
-        optList = getSubProjectOptions(catmaster, selProj);
-        catTable = getCatalogOptions(catmaster, selProj, selCat).option;
+        const {master, fields} = this.props;
+        const optProjects = getProjectOptions(master.catmaster);
+        const optList = getSubProjectOptions(catmaster, selProj);
+        const catTable = getCatalogOptions(catmaster, selProj, selCat).option;
 
         //HERE HERE HERE
-        const currentIdx = get(this.props.fields, 'cattable.indexClicked', 0);
+        const currentIdx = get(fields, 'cattable.indexClicked', 0);
         const radius = parseFloat(catTable[currentIdx].cat[RADIUS_COL]);
         const coneMax= radius / 3600;
         const boxMax= coneMax*2;
@@ -638,10 +634,10 @@ class CatalogDDList extends Component {
             catname0 = catTable[0].value;
         }
         const ddform = get(FieldGroupUtils.getGroupFields(gkey), 'ddform.value', 'true');
-        const shortdd = ddform == 'true' ? 'short' : 'long';
+        const shortdd = ddform === 'true' ? 'short' : 'long';
         const tbl_id = `${catname0}-${shortdd}-dd-table-constraint`;
 
-        const {cols} = this.props.master;
+        const {cols} = master;
         const catPanelStyle = {height: 350};
 
         const polygonDefWhenPlot= get(getAppOptions(), 'catalogSpacialOp')==='polygonWhenPlotExist';
@@ -709,12 +705,13 @@ class CatalogDDList extends Component {
     }
 }
 
-CatalogSelectViewPanel.propTypes = {
+CatalogDDList.propTypes = {
     name: PropTypes.oneOf([dropdownName]),
-    fields: PropTypes.object
+    fields: PropTypes.object,
+    master: PropTypes.object
 };
 
-CatalogSelectViewPanel.defaultProps = {
+CatalogDDList.defaultProps = {
     name: dropdownName
 };
 

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -189,14 +189,14 @@ function onSearchSubmit(request) {
         } else if (cattype === IMAGETYPE) {
             const imageState = FieldGroupUtils.getGroupFields(gkeyImageSpatial);
             const wp = get(imageState, [ServerParams.USER_TARGET_WORLD_PT, 'value']);
-            if (!wp) {
+            const intersect = get(imageState, ['intersect', 'value']);
+
+            if (!wp && intersect !== 'ALLSKY') {
                 showInfoPopup('Target is required');
                 return;
             }
 
-            const intersect = get(imageState, ['intersect', 'value']);
-
-            if (intersect !== 'CENTER') {
+            if (intersect !== 'CENTER' && intersect !== 'ALLSKY') {
 
                 if (!get(imageState, ['size', 'valid'])) {
                     showInfoPopup('box size is required');
@@ -257,19 +257,21 @@ function addConstraintToQuery(tReq) {
 }
 
 function doImage(request, imgPart) {
+    const noSizeMethod = ['ALLSKY', 'CENTER'];
+    const noTargetMethod = ['ALLSKY'];
     const {cattable} = request[gkey] || {};
     const spatial =  get(imgPart, ['spatial', 'value']);
     const intersect = get(imgPart, ['intersect', 'value']);
-    const size = (intersect !== 'CENTER') ? get(imgPart, ['size', 'value']) : '';
+    const size = (!noSizeMethod.includes(intersect)) ? get(imgPart, ['size', 'value']) : '';
     const sizeUnit = 'deg';
-    const wp = get(imgPart, [ServerParams.USER_TARGET_WORLD_PT,'value']);
+    const wp = (!noTargetMethod.includes(intersect)) && get(imgPart, [ServerParams.USER_TARGET_WORLD_PT,'value']);
 
     var title = `${projectName}-${cattable}-${capitalize(intersect)}`;
-    var loc = wp.split(';').slice(0, 2).join();
+    var loc = wp && wp.split(';').slice(0, 2).join();
 
-    if (intersect !== 'CENTER') {
+    if (!noSizeMethod.includes(intersect)) {
         title += `([${loc}]:${formatNumberString(size)}deg)`;
-    } else {
+    } else if (!noTargetMethod.includes(intersect)) {
         title += `([${loc}])`;
     }
 

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -197,13 +197,14 @@ function onSearchSubmit(request) {
             }
 
             if (intersect !== 'CENTER' && intersect !== 'ALLSKY') {
-
                 if (!get(imageState, ['size', 'valid'])) {
                     showInfoPopup('box size is required');
                     return;
                 }
             }
-            doImage(request, imageState);
+            if (validateConstraints(gkey)) {
+                doImage(request, imageState);
+            }
         }
     }
     else if (request[gkey].Tabs === 'loadcatLsst') {

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
 import { get,set, merge, isEmpty, capitalize} from 'lodash';
 import {updateMerge} from '../../util/WebUtil.js';
@@ -93,7 +93,7 @@ const LSSTMaster = {
     catalogs: LSSTTables
 };
 
-export const LSSTDDPID = 'LSSTMetaSearch';
+const LSSTDDPID = 'LSSTMetaSearch';
 
 var catmaster = [];
 
@@ -227,7 +227,7 @@ function hideSearchPanel() {
  * @returns {string}
  */
 function formatNumberString(numstr, digits = DEC) {
-    var d = digits&digits >= 0 ?  digits : DEC;
+    var d = digits&&digits >= 0 ?  digits : DEC;
 
     return parseFloat(numstr).toFixed(d).replace(/(?:\.0+|(\.\d+?)0+)$/, '$1');
 }
@@ -345,8 +345,8 @@ function doCatalog(request, spatPart) {
     // plus change spatial name to cone
     if (spatial === SpatialMethod.Elliptical.value) {
 
-        const pa = get(spatPart, ['posangle', 'value'], 0);
-        const ar = get(spatPart, ['axialratio', 'value'], 0.26);
+        const pa = get(spatPart, ['posangle', 'value'], '0');
+        const ar = get(spatPart, ['axialratio', 'value'], '0.26');
 
         // see PA and RATIO string values in edu.caltech.ipac.firefly.server.catquery.GatorQuery
         merge(tReq, {'posang': pa, 'ratio': ar});
@@ -377,7 +377,7 @@ function doCatalog(request, spatPart) {
  */
 function doLoadTable(request) {
     var tReq = makeTblRequest('userCatalogFromFile', 'Lsst Table Upload', {
-        filePath: request.fileUpload
+        filePath: get(request, 'fileUpload')
     });
     dispatchTableSearch(tReq);
 }
@@ -468,8 +468,14 @@ class LSSTCatalogSelectView extends Component {
     }
 }
 
+LSSTCatalogSelectView.propsType = {
+    cattable: PropTypes.string,
+    cattype: PropTypes.string
+};
+
 /**
  * @summary Reducer from field group component, should return updated catalog selection
+ * @param {string} tblId
  * @returns {Function} reducer to change fields when user interact with the dialog
  */
 var userChangeLsstDispatch = function (tblId) {
@@ -644,11 +650,8 @@ class LsstCatalogDDList extends Component {
         const {catmaster} = this.state.master;
         if (!catmaster) return false;
 
-        var {cattable} = this.props;
-        if (!cattable) return false;
-
-        var {cattype} = this.props;
-        if (!cattype) return false;
+        var {cattable, cattype} = this.props;
+        if (!cattable || !cattype) return false;
 
         const spatialH = 300;
         const spatialPanelStyle = {height: spatialH, width: 550, paddingLeft: 2, paddingRight: 2};
@@ -688,7 +691,7 @@ class LsstCatalogDDList extends Component {
                             wrapperStyle={{marginLeft: 15, marginTop: 10}}
                         />
                      </div>
-                )
+                );
         };
 
         var searchMethod = () => {
@@ -700,10 +703,10 @@ class LsstCatalogDDList extends Component {
                 const boxMax = coneMax * 2;
                 const polygonDefWhenPlot = get(getAppOptions(), 'catalogSpacialOp') === 'polygonWhenPlotExist';
 
-                method = <CatalogSearchMethodType groupKey={gkeySpatial} polygonDefWhenPlot={polygonDefWhenPlot}
-                                                  coneMax={coneMax} boxMax={boxMax}/>;
+                method = (<CatalogSearchMethodType groupKey={gkeySpatial} polygonDefWhenPlot={polygonDefWhenPlot}
+                                                  coneMax={coneMax} boxMax={boxMax}/>);
             } else {
-                method = <LSSTImageSpatialType groupKey={gkeyImageSpatial} />
+                method = <LSSTImageSpatialType groupKey={gkeyImageSpatial} />;
             }
 
             return (<div className='spatialsearch' style={spatialPanelStyle}>
@@ -738,13 +741,18 @@ class LsstCatalogDDList extends Component {
     }
 }
 
+LsstCatalogDDList.propTypes = {
+    cattable: PropTypes.string,
+    cattype: PropTypes.string,
+    master: PropTypes.object
+};
+
 /**
  * @summary component for loading catalog file
  * @returns {XML}
  * @constructor
  */
-function CatalogLoad({}) {
-
+function CatalogLoad() {
     return (
         <div style={{padding: 5, width: '800px', height: '300px'}}>
             <FileUpload
@@ -769,10 +777,10 @@ CatalogLoad.propTypes = {};
  Define fields init and per action
  */
 function fieldInit(tblId) {
-    var constraintV = LSSTMaster.catalogs.map((t) =>  ({constraints: '', selcols: '', filters: undefined}));
+    var constraintV = LSSTMaster.catalogs.map(() =>  ({constraints: '', selcols: '', filters: undefined}));
     var catOptions = LSSTMaster.catalogs.map((t) => (t.value));
     var sqlValues = LSSTMaster.catalogs.map((t) => (''));
-    var coldefList = LSSTMaster.catalogs.map((t) => (get(t, ['cat', COLDEF1]) || get(t, ['cat', COLDEF2]) || ""));
+    var coldefList = LSSTMaster.catalogs.map((t) => (get(t, ['cat', COLDEF1]) || get(t, ['cat', COLDEF2]) || ''));
 
     return (
         {

--- a/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
+++ b/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
@@ -49,7 +49,7 @@ export class LSSTImageSpatialType extends Component {
                         keepState={true}
                         reducerFunc={imageSearchReducer}
                         style={{display:'flex', flexDirection:'column', alignItems:'center'}}>
-                {renderTargetPanel(groupKey)}
+                {renderTargetPanel(groupKey, searchType)}
                 <div style={{padding: 3}}>
                     <InputGroup labelWidth={270}>
                         <ListBoxInputField
@@ -63,13 +63,14 @@ export class LSSTImageSpatialType extends Component {
                                         {value: 'CENTER', label: 'Image contains target' },
                                         {value: 'COVERS', label: 'Image covers entire search region' },
                                         {value: 'ENCLOSED', label: 'Image is entirely enclosed by search region' },
-                                        {value: 'OVERLAPS', label: 'Any pixel overlaps search region', disabled: true}
-                                          ] }
+                                        {value: 'OVERLAPS', label: 'Any pixel overlaps search region', disabled: true},
+                                        {value: 'ALLSKY', label: 'All Sky'}] }
                             multiple={false}
                         />
-                        {renderSearchRegion(searchType!=='CENTER')}
-                        {renderImageSize(searchType==='CENTER' || searchType==='COVERS', true)}
-                        {renderMostCenter(searchType==='CENTER' || searchType==='COVERS', true)}
+                        {searchType === 'ALLSKY' && renderAllSkyNote()}
+                        {searchType !== 'ALLSKY' && renderSearchRegion(searchType !== 'CENTER')}
+                        {searchType !== 'ALLSKY' && renderImageSize(searchType === 'CENTER' || searchType === 'COVERS', true)}
+                        {searchType !== 'ALLSKY' && renderMostCenter(searchType ==='CENTER' || searchType === 'COVERS', true)}
                     </InputGroup>
                 </div>
             </FieldGroup>
@@ -77,11 +78,11 @@ export class LSSTImageSpatialType extends Component {
     }
 }
 
-function renderTargetPanel(groupKey) {
+function renderTargetPanel(groupKey, searchType) {
     return (
         <div className='intarget'>
-            <TargetPanel labelWidth={100} groupKey={groupKey}/>
-        </div>
+            {(searchType !== 'ALLSKY') && <TargetPanel labelWidth={100} groupKey={groupKey}/>}
+        </div> 
     );
 }
 
@@ -142,6 +143,16 @@ function renderMostCenter(visible, disable) {
                                       {label: 'No', value: 'all'}
                                       ]}
         />
+    );
+}
+
+function renderAllSkyNote() {
+    return (
+        <div style={{display:'flex', flexDirection:'column', alignItems:'center'}} >
+            <div style={{marginTop: 10,  border: '1px solid #a3aeb9', padding:'30px 30px'}}>
+                Search the catalog with no spatial constraints
+            </div>
+        </div>
     );
 }
 

--- a/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
+++ b/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
@@ -153,7 +153,7 @@ function imageSearchReducer(inFields, action) {
     if (!inFields) {
         return fieldInit();
     } else {
-        return inFields
+        return inFields;
     }
 }
 


### PR DESCRIPTION

Development includes
[CW DM-9248]
- the 'all sky' feature was built in the LSST spatial search component. 
- fixed some code syntax errors issued by IntelliJ. 
- fixed the setting of some spatial search parameters from float to string format prior to building the table search request. 

[LZ DM-9247]
- Add the AllSky search in Catalog search
- Add the allSky search in Image Catalog search
- Add the guard to prevent from allSky search without constraints.

test for 'AllSky': 
- localhost:8080/firefly/lsst-pdac-triview.html
- In catalog search, select "allSky"
Enter the constrains at the field:
For deep source at the id field enter
=3219370314566605
For forced deep source at the id field enter:
=225486482582800165

- in image search
for Deep coadd: 
deepCoaddId =1610612744
for ccd 
scienceCcdExposureId = 2649410121