### PR TITLE
DM-9340: raise size limit to 100 and use radio buttons instead of checkboxes

### DIFF
--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -65,6 +65,7 @@ class ShapePickerWrapper extends Component {
         this.displayGroupId = props.displayGroupId;
         this.plotId = props.plotId;
         this.updateSymbol = this.updateSymbol.bind(this);
+        this.drawSymbol = this.drawSymbol.bind(this);
         this.updateSize = this.updateSize.bind(this);
         this.updateShape = this.updateShape.bind(this);
         this.onArrowDown = this.onArrowDown.bind(this);
@@ -186,13 +187,45 @@ class ShapePickerWrapper extends Component {
 
     }
 
+    drawSymbol(df, validSize, size){
+        const {drawingDef} = this.state;
+
+        const maxSize = 20;
+        var canvasSize = validSize && (Math.floor(parseFloat(size)) + 2);
+        const bkColor = getBackgroundColor(df.color);
+        if (size > maxSize) {
+            canvasSize = validSize && Math.floor(parseFloat(maxSize)) + 2;
+            const symbolSize = DrawUtil.getSymbolSize(maxSize, maxSize, drawingDef.symbol);
+            df = clone(drawingDef, {size: symbolSize})
+        }
+
+        if (validSize) {
+
+            if (size > maxSize) {
+
+                return (
+                    <div style={{display:'flex', width: canvasSize, height: canvasSize}}>
+                        <SimpleCanvas width={canvasSize} height={canvasSize} backgroundColor={bkColor}
+                                      drawIt={(c)=>drawOnCanvas(c, df, canvasSize, canvasSize)}/>
+                        <text style={{fontSize:`${10.5+parseInt(size/10)}px`}}>+</text>
+                    </div>);
+            } else {
+                return (
+
+                    <div style={{display:'flex', width: canvasSize, height: canvasSize}}>
+
+                        <SimpleCanvas width={canvasSize} height={canvasSize} backgroundColor={bkColor}
+                                      drawIt={(c)=>drawOnCanvas(c, df, canvasSize, canvasSize)}/>
+                    </div>);
+            }
+        }
+    }
 
     render() {
         const {drawingDef, size, validSize} = this.state;
+        const df = validSize&&drawingDef;
         const labelW = 70;
         const mLeft = 10;
-        const df = validSize&&drawingDef;
-        const canvasSize = validSize && (Math.floor(parseFloat(size)) + 2);
         const bkColor = getBackgroundColor(drawingDef.color);
         const textColor = '#000000';
         const options = PointOptions.map((p) => {
@@ -228,11 +261,7 @@ class ShapePickerWrapper extends Component {
                                          placeholder={`size 3 < ${MAXSIZE}`}
                                          size={16}
                                          message={`invalid data entry, size is within 3 & ${MAXSIZE}`}/>
-                        {/*<div style={{width: canvasSize, height: canvasSize}}>
-                            {validSize && <SimpleCanvas width={canvasSize} height={canvasSize} backgroundColor={bkColor}
-                                                        drawIt={(c)=>drawOnCanvas(c, df, canvasSize, canvasSize)}/>}
-                        </div>
-                        */}
+                        {validSize && this.drawSymbol(df, validSize, size)}
                     </div>
                     <div style={{marginLeft: mLeft, marginTop: mLeft, color: textColor}}>
                         <i>enter the number or use the arrow up/down key to increase/decrease the size number </i>

--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -13,7 +13,7 @@ import {drawOnCanvas} from '../visualize/ui/DrawLayerItemView.jsx';
 import {dispatchChangeDrawingDef, getDlAry} from '../visualize/DrawLayerCntlr.js';
 import CompleteButton from './CompleteButton.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
-import {CheckboxGroupInputFieldView} from './CheckboxGroupInputField.jsx';
+import {RadioGroupInputFieldView} from './RadioGroupInputFieldView.jsx';
 import {InputFieldView} from './InputFieldView.jsx';
 import {showInfoPopup} from './PopupUtil.jsx';
 import {SimpleCanvas} from '../visualize/draw/SimpleCanvas.jsx';
@@ -22,6 +22,7 @@ import {get, isNaN} from 'lodash';
 import {clone} from '../util/WebUtil.js';
 import Color from '../util/Color.js';
 import validator from 'validator';
+import {HelpIcon} from '../ui/HelpIcon.jsx';
 
 
 const PointOptions = [ DrawSymbol.CIRCLE, DrawSymbol.SQUARE, DrawSymbol.DIAMOND,
@@ -29,7 +30,7 @@ const PointOptions = [ DrawSymbol.CIRCLE, DrawSymbol.SQUARE, DrawSymbol.DIAMOND,
                        DrawSymbol.BOXCIRCLE, DrawSymbol.DOT];
 
 const MINSIZE = 3;
-const MAXSIZE = 20;
+const MAXSIZE = 100;
 const popupIdBase = 'ShapePickerDialog';
 const ARROW_UP = 38;
 const ARROW_DOWN = 40;
@@ -197,7 +198,6 @@ class ShapePickerWrapper extends Component {
         const options = PointOptions.map((p) => {
                             return {value: p.key, label: drawShapeWithLabel(p, drawingDef, bkColor, textColor)}
                         });
-
         return (
             <div style={{width: 300}}>
                 <div style={{margin: mLeft,
@@ -207,17 +207,17 @@ class ShapePickerWrapper extends Component {
                              }}>
                     <div style={{display: 'flex', marginLeft: mLeft}} >
                         <div style={{width: labelW, color: textColor}} title={'pick a symbol'}>Symbols:</div>
-                        {CheckboxGroupInputFieldView({fieldKey: 'pointoptions',
-                                                  onChange: this.updateSymbol,
-                                                  tooltip: 'available symbol shapes',
-                                                  options,
-                                                  value: drawingDef.symbol.key,
-                                                  alignment: 'vertical'})}
+                        <RadioGroupInputFieldView fieldKey='pointoptions'
+                                                  onChange={this.updateSymbol}
+                                                  tooltip='available symbol shapes'
+                                                  options={options}
+                                                  value={drawingDef.symbol.key}
+                                                  alignment='vertical'/>
                     </div>
                     <div style={{marginLeft: mLeft, marginTop: mLeft, height: 26, display: 'flex', alignItems: 'center'}}>
-                        <InputFieldView  label={'Symbol Size:'}
+                        <InputFieldView  label={'Symbol Size (px):'}
                                          labelStyle={{color: textColor}}
-                                         labelWidth={labelW}
+                                         labelWidth={labelW+30}
                                          valid={validSize}
                                          onChange={this.updateSize}
                                          onKeyDown={this.onArrowDown}
@@ -225,16 +225,21 @@ class ShapePickerWrapper extends Component {
                                          value={size}
                                          tooltip={'enter the symbol size or use the arrow up (or down) key in the field to increase (or decrease) the size number '}
                                          type={'text'}
-                                         placeholder={'size is between 3 and 20'}
+                                         placeholder={`size 3 < ${MAXSIZE}`}
                                          size={16}
-                                         message={'invalid data entry, size is within 3 & 20'}/>
-                        <div style={{width: canvasSize, height: canvasSize}}>
+                                         message={`invalid data entry, size is within 3 & ${MAXSIZE}`}/>
+                        {/*<div style={{width: canvasSize, height: canvasSize}}>
                             {validSize && <SimpleCanvas width={canvasSize} height={canvasSize} backgroundColor={bkColor}
                                                         drawIt={(c)=>drawOnCanvas(c, df, canvasSize, canvasSize)}/>}
                         </div>
+                        */}
                     </div>
                     <div style={{marginLeft: mLeft, marginTop: mLeft, color: textColor}}>
                         <i>enter the number or use the arrow up/down key to increase/decrease the size number </i>
+                    </div>
+                    <div style={{display:'flex'}}>
+                        <HelpIcon
+                            helpId={'catalogs'}/>
                     </div>
                 </div>
                 <div style={{marginBottom: 10, marginLeft: mLeft}} >

--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -190,7 +190,7 @@ class ShapePickerWrapper extends Component {
     drawSymbol(df, validSize, size){
         const {drawingDef} = this.state;
 
-        const maxSize = 20;
+        const maxSize = 30;
         var canvasSize = validSize && (Math.floor(parseFloat(size)) + 2);
         const bkColor = getBackgroundColor(df.color);
         if (size > maxSize) {
@@ -204,10 +204,10 @@ class ShapePickerWrapper extends Component {
             if (size > maxSize) {
 
                 return (
-                    <div style={{display:'flex', width: canvasSize, height: canvasSize}}>
+                    <div style={{display:'flex', alignItems:'center', width: canvasSize, height: canvasSize}}>
                         <SimpleCanvas width={canvasSize} height={canvasSize} backgroundColor={bkColor}
                                       drawIt={(c)=>drawOnCanvas(c, df, canvasSize, canvasSize)}/>
-                        <text style={{fontSize:`${10.5+parseInt(size/10)}px`}}>+</text>
+                        {/*<text style={{fontSize:`${10.5+parseInt(size/10)}px`}}>+</text>*/}
                     </div>);
             } else {
                 return (
@@ -232,7 +232,7 @@ class ShapePickerWrapper extends Component {
                             return {value: p.key, label: drawShapeWithLabel(p, drawingDef, bkColor, textColor)}
                         });
         return (
-            <div style={{width: 300}}>
+            <div style={{width: 320}}>
                 <div style={{margin: mLeft,
                              border: '1px solid rgba(0, 0, 0, 0.298039)',
                              borderRadius: 5,
@@ -264,7 +264,7 @@ class ShapePickerWrapper extends Component {
                         {validSize && this.drawSymbol(df, validSize, size)}
                     </div>
                     <div style={{marginLeft: mLeft, marginTop: mLeft, color: textColor}}>
-                        <i>enter the number or use the arrow up/down key to increase/decrease the size number </i>
+                        <i>Try up/down arrow keys  </i>
                     </div>
                     <div style={{display:'flex'}}>
                         <HelpIcon


### PR DESCRIPTION
The ticket request was to raise the shape size limit to 100 pixels and change checkboxes to radio buttons for the choice selection.

By raising the size, i had to take out the current canvas. If you find a better way to adjust the window with the canvas, let me know, i couldn't.

Fixing the window width or any other style/css approach is not worth the effort because it could change again if the max size is not yet enough for future cases.

Maybe @robyww or @Caltech-IPAC/firefly developers might have a better solution. Come to me to discuss it if you want or feel free to commit directly to my branch. 

Thanks.
