### PR TITLE
DM-9349: filtering by ROWID is off by 1

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/FilterHanlder.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/FilterHanlder.java
@@ -28,7 +28,7 @@ public class FilterHanlder extends BgIpacTableHandler {
     private static Logger.LoggerImpl LOG = Logger.getLogger();
     private BufferedReader reader;
     private List<CollectionUtil.Filter<DataObject>> filters;
-    private int cRowNum;
+    private int cRowNum = -1;
     private boolean hasRowIdFilter = false;
     private int rowsFound;
     private List<DataGroup.Attribute> attributes;


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-9349

In Firfefly (+IRSAVIewer) development version, when the user select table rows and filter them out, the result table is not matching the selected rows before applying the filter.
OPS is fine though.

Steps to reproduce:
do a catalog search i.e., 2mass, 100". From the result table, select a row and apply filter. Then check that the resulting row is not the one you selected.

TG 02/10/2017 The row returned is actually the previous row. 
The related issue is filtering a point from an image. A previous row is returned as a result.