### PR TITLE
DM-9382 Fix phase folded table content

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -210,7 +210,6 @@ export function cloneRequest(request, params = {}) {
  * @public
  * @func doFetchTable
  * @memberof firefly.util.table
- * @deprecated  use firefly.util.table.fetchTable instead
  */
 export function doFetchTable(tableRequest, hlRowIdx) {
     const {tbl_id} = tableRequest;

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -59,7 +59,7 @@ export const LC = {
     MISSION_DATA: 'missionEntries',
     GENERAL_DATA:'generalEntries',
 
-    TABLE_PAGESIZE: 50
+    TABLE_PAGESIZE: 100
 };
 
 const plotIdRoot= 'LC_FRAME-';
@@ -438,7 +438,7 @@ function handleTableActive(layoutInfo, action) {
 function handleTableHighlight(layoutInfo, action) {
     const {tbl_id, highlightedRow} = action.payload;
     const {displayMode} = layoutInfo;
-    const activeTableContainer = displayMode && displayMode.startsWith('period') ? LC.PERIODOGRAM_GROUP : 'main';
+    const activeTableContainer = displayMode && displayMode.startsWith('period') ? LC.PERIODOGRAM_GROUP : undefined;
 
     // only respond to active table highlight
     if (tbl_id !== getActiveTableId(activeTableContainer)) return layoutInfo;

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -402,7 +402,7 @@ class PhaseFoldingChart extends Component {
 
     componentDidMount() {
         var isPhaseChanged = (newFields) => {
-            var fieldsToCheck = ['time', 'flux', 'tz', 'period'];
+            var fieldsToCheck = ['tz', 'period'];
             var fieldsInfo = fieldsToCheck.map((f) => {
                 return [get(newFields, [fKeyDef[f].fkey, 'value'], ''),
                     get(this.state.fields, [fKeyDef[f].fkey, 'value'], '')];
@@ -831,7 +831,7 @@ var isPeriodMinValid = (valStr, description) => {
     var retval;
 
     retval = Validate.isFloat(description, valStr);
-    if (!retval.valid || !valStr) return {retval: false, message: `${description}: must be a float`};
+    if (!retval.valid || !valStr) return {valid: false, message: `${description}: must be a float`};
 
     var val = parseFloat(valStr);
     var max = getValidValueFrom(FieldGroupUtils.getGroupFields(pfinderkey), fKeyDef.max.fkey);
@@ -852,7 +852,7 @@ var isPeriodMaxValid = (valStr, description) => {
     var retval;
 
     retval = Validate.isFloat(description, valStr);
-    if (!retval.valid || !valStr) return {retval: false, message: `${description}: must be a float`};
+    if (!retval.valid || !valStr) return {valid: false, message: `${description}: must be a float`};
 
     var val = parseFloat(valStr);
     var min = getValidValueFrom(FieldGroupUtils.getGroupFields(pfinderkey), fKeyDef.min.fkey);

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -18,9 +18,9 @@ import Validate from '../../util/Validate.js';
 import {dispatchActiveTableChanged} from '../../tables/TablesCntlr.js';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 import FieldGroupCntlr, {dispatchValueChange, dispatchMultiValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
-import {makeTblRequest, getTblById, tableToIpac, makeFileRequest, getActiveTableId, getColumnIdx, getCellValue} from '../../tables/TableUtil.js';
-import {LC, updateLayoutDisplay, getValidValueFrom} from './LcManager.js';
-import {uploadPhaseTable, doPFCalculate, getPhase} from './LcPhaseTable.js';
+import {getActiveTableId, getColumnIdx} from '../../tables/TableUtil.js';
+import {LC, updateLayoutDisplay, getValidValueFrom, getFullRawTable} from './LcManager.js';
+import {doPFCalculate, getPhase} from './LcPhaseTable.js';
 import {LcPeriodogram, startPeriodogramPopup, cancelPeriodogram, popupId} from './LcPeriodogram.jsx';
 import {LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
 import {isDialogVisible} from '../../core/ComponentCntlr.js';
@@ -463,12 +463,15 @@ PhaseFoldingChart.propTypes = {
  * @returns {*}
  */
 function getPhaseFlux(fields) {
-    var rawTable = getTblById(LC.RAW_TABLE);
-    var {data} = rawTable.tableData;    // column names and data
+    const fc = get(fields, ['flux', 'value'], '');
+    var rawTable = getFullRawTable();
+    var {data} = get(rawTable, ['tableData'], {});
 
-    var {time, period, tzero, flux} = fields;
+    if (!data) return {flux: fc};
+
+    var {time, period, tzero} = fields;
     const tc = time ? time.value : '';
-    const fc = flux ? flux.value: '';
+
     const tIdx = tc ? getColumnIdx(rawTable, tc) : -1;  // find time column
     const fIdx = fc ? getColumnIdx(rawTable, fc) : -1;  // find flux column
 
@@ -483,7 +486,7 @@ function getPhaseFlux(fields) {
         pd = periodRange.min;
     }
     if (tzero) {
-        if (!tzero.valid) return {flux: fc};      // invalid period
+        if (!tzero.valid) return {flux: fc};      // invalid tzero
         tz = parseFloat(tzero.value);
     } else {
         tz = periodRange.tzero;
@@ -929,14 +932,13 @@ function timezeroValidator(description) {
  */
 function setPFTableSuccess() {
     return (request) => {
-        var reqData = get(request, pfinderkey);
-        var timeName = get(reqData, fKeyDef.time.fkey);
-        var period = get(reqData, fKeyDef.period.fkey);
-        var flux = get(reqData, fKeyDef.flux.fkey);
-        var tzero = get(reqData, fKeyDef.tz.fkey);
+        const reqData = get(request, pfinderkey);
+        const timeName = get(reqData, fKeyDef.time.fkey);
+        const period = get(reqData, fKeyDef.period.fkey);
+        const flux = get(reqData, fKeyDef.flux.fkey);
+        const tzero = get(reqData, fKeyDef.tz.fkey);
 
-        var phaseFoldedTable = doPFCalculate(flux, timeName, period, tzero);
-        phaseFoldedTable&&uploadPhaseTable(phaseFoldedTable,  flux);
+        doPFCalculate(flux, timeName, period, tzero);
 
         if (isDialogVisible(popupId)) {
             cancelPeriodogram(pfinderkey, popupId)();

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -533,7 +533,7 @@ function periodogramSuccess(popupId, hideDropDown = false) {
             step_size: ssize ? ssize : undefined,
             peaks: get(request, [pKeyDef.peaks.fkey]),
             table_name: LC.PERIODOGRAM_TABLE
-        }, {tbl_id: LC.PERIODOGRAM_TABLE, pageSize: LC.FULL_TABLE_SIZE});
+        }, {tbl_id: LC.PERIODOGRAM_TABLE});
 
 
         if (tReq !== null) {

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -213,10 +213,13 @@ function repeatDataCycle(phaseTable) {
     });
 
     var totalRows = tableData.data.length;
+    /* TODO: investigate to pick the needed properties under tableMeta */
+    /*
     var newTableMeta = pick(tableMeta, ['fixlen', 'QueryTime', 'ORIGIN',
                                         'DATETIME', 'DataTag','DATABASE',
                                         'EQUINOX', 'SKYAREA', 'StatusFile', 'SQL']);
-    set(phaseTable, ['tableMeta'], newTableMeta);
+    */
+    set(phaseTable, ['tableMeta'], tableMeta);
 
     set(phaseTable, ['tableMeta', 'RowsRetrieved'], `${totalRows}`);
     set(phaseTable, ['tableMeta', 'tbl_id'], tbl_id);

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -2,15 +2,14 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, set, omit, slice, replace, isArray, isString, cloneDeep} from 'lodash';
+import {get, set, slice, isArray, isString, cloneDeep, pick, omit} from 'lodash';
 import {doUpload} from '../../ui/FileUpload.jsx';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
-import {makeTblRequest,getTblById, tableToIpac, makeFileRequest, getColumnIdx} from '../../tables/TableUtil.js';
-import {LC, getValidValueFrom} from './LcManager.js';
+import {tableToIpac, makeFileRequest, getColumnIdx} from '../../tables/TableUtil.js';
+import {LC, getFullRawTable} from './LcManager.js';
 import {getLayouInfo} from '../../core/LayoutCntlr.js';
-import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 
 
 const DEC_PHASE = 3;       // decimal digit
@@ -22,15 +21,16 @@ const DEC_PHASE = 3;       // decimal digit
  */
 export function uploadPhaseTable(tbl, flux) {
     const {tbl_id, title} = tbl;
-
     const ipacTable = tableToIpac(tbl);
     const blob = new Blob([ipacTable]);
     //const file = new File([new Blob([ipacTable])], `${tbl_id}.tbl`);
 
     doUpload(blob).then(({status, cacheKey}) => {
         const tReq = makeFileRequest(title, cacheKey, null,
-                                     {tbl_id, sortInfo:sortInfoString(LC.PHASE_CNAME),
-                                      pageSize: LC.FULL_TABLE_SIZE
+                                     {tbl_id,
+                                      sortInfo:sortInfoString(LC.PHASE_CNAME),
+                                      tblType: 'notACatalog',
+                                      pageSize: LC.TABLE_PAGESIZE
                                      });
 
         dispatchTableSearch(tReq, {removable: true});
@@ -43,6 +43,8 @@ export function uploadPhaseTable(tbl, flux) {
         loadXYPlot({chartId: tbl_id, tblId: tbl_id, xyPlotParams});
     });
 
+
+
 }
 
 /**
@@ -54,14 +56,15 @@ export function uploadPhaseTable(tbl, flux) {
  * @return {TableModel} phase table
  */
 export function doPFCalculate(flux, time, period, tzero) {
-    const rawTable = getTblById(LC.RAW_TABLE);
+    const fullRawTable = getFullRawTable();
 
-    var phaseFoldedTable = rawTable && addPhaseToTable(rawTable, time, flux, tzero, period);
-    phaseFoldedTable&&repeatDataCycle(time, parseFloat(period), phaseFoldedTable);
+    var phaseFoldedTable = fullRawTable && addPhaseToTable(fullRawTable, time, tzero, period);
 
-    return phaseFoldedTable;
+     if (phaseFoldedTable) {
+         phaseFoldedTable = repeatDataCycle(phaseFoldedTable);
+         uploadPhaseTable(phaseFoldedTable, flux);
+    }
 }
-
 
 /**
  * @summary calculate phase and return as text
@@ -82,20 +85,21 @@ export function getPhase(time, timeZero, period,  dec=DEC_PHASE) {
  * @summary create a table model with phase column
  * @param {TableModel} tbl
  * @param {string} timeName
- * @param {string} fluxName
  * @param {string} tzero
  * @param {string} period
  * @returns {TableModel}
  */
-function addPhaseToTable(tbl, timeName, fluxName, tzero, period) {
+function addPhaseToTable(tbl, timeName, tzero, period) {
     var tIdx = timeName ? getColumnIdx(tbl, timeName) : -1;
 
     if (tIdx < 0) return null;
 
-    var tPF = Object.assign(cloneDeep(tbl), {tbl_id: LC.PHASE_FOLDED, title: 'Phase Folded'},
-                                            {request: getPhaseFoldingRequest(period, timeName, fluxName, tbl)},
-                                            {highlightedRow: 0});
-    tPF = omit(tPF, ['hlRowIdx', 'isFetching']);
+    const tbl_id =  LC.PHASE_FOLDED;
+    const title = 'Phase Folded';
+
+    var tPF = {tableData: cloneDeep(tbl.tableData),
+               tableMeta: cloneDeep(tbl.tableMeta),
+               tbl_id, title};
     tPF.tableMeta = omit(tPF.tableMeta, ['source', 'tblFilePath', 'sortInfo', 'isFullyLoaded']);
 
     var phaseC = {desc: 'number of period elapsed since starting time.',
@@ -194,57 +198,29 @@ function locateTableColumns(tbl, srcCols, targetCol, position = 1) {
 }
 
 /**
- * @summary create table request object for phase folded table
- * @param {string} period period in string
- * @param {string} time  time column
- * @param {string} flux flux name
- * @param {TableModel} tbl
- * @returns {TableRequest}
- */
-function getPhaseFoldingRequest(period, time, flux, tbl) {
-    const cutoutSize = getValidValueFrom(FieldGroupUtils.getGroupFields(LC.FG_VIEWER_FINDER), 'cutoutSize');
-
-    return makeTblRequest('PhaseFoldedProcessor', LC.PHASE_FOLDED, {
-        period_days: period,
-        table_name: 'folded_table',
-        cutout_size: cutoutSize ? cutoutSize : undefined,
-        flux,
-        x: time,
-        original_table: tbl.tableMeta.tblFilePath
-    },  {tbl_id:LC.PHASE_FOLDED, pageSize: LC.FULL_TABLE_SIZE});
-
-}
-
-/**
  * @summary duplicate the phase cycle to the phase folded table
- * @param {string} timeCol
- * @param {number} period
  * @param {TableModel} phaseTable
  */
-function repeatDataCycle(timeCol, period, phaseTable) {
-    var {totalRows, tbl_id, title, tableData} = phaseTable;
-    var tIdx = getColumnIdx(phaseTable, timeCol);
+function repeatDataCycle(phaseTable) {
+    var {tableData, tbl_id, title, tableMeta} = phaseTable;
     var fIdx = getColumnIdx(phaseTable, LC.PHASE_CNAME);
 
-    slice(tableData.data, 0, totalRows).forEach((d) => {
+    slice(tableData.data, 0).forEach((d) => {
         var newRow = slice(d);
 
-        newRow[tIdx] = `${parseFloat(d[tIdx]) + period}`;
         newRow[fIdx] = `${parseFloat(d[fIdx]) + 1}`;
         tableData.data.push(newRow);
     });
 
-    totalRows *= 2;
+    var totalRows = tableData.data.length;
+    var newTableMeta = pick(tableMeta, ['fixlen', 'QueryTime', 'ORIGIN',
+                                        'DATETIME', 'DataTag','DATABASE',
+                                        'EQUINOX', 'SKYAREA', 'StatusFile', 'SQL']);
+    set(phaseTable, ['tableMeta'], newTableMeta);
 
-    set(phaseTable, 'totalRows', totalRows);
     set(phaseTable, ['tableMeta', 'RowsRetrieved'], `${totalRows}`);
-
     set(phaseTable, ['tableMeta', 'tbl_id'], tbl_id);
     set(phaseTable, ['tableMeta', 'title'], title);
-
-    var col = tableData.columns.length;
-    var sqlMeta = get(phaseTable, ['tableMeta', 'SQL']);
-    if (sqlMeta) {
-        set(phaseTable, ['tableMeta', 'SQL'], replace(sqlMeta, `${col-1}`, `${col}`));
-    }
+    set(phaseTable, ['tableMeta', 'SQL'],`SELECT (${tableData.columns.length} column names follow in next row.)`);
+    return phaseTable;
 }

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -219,8 +219,6 @@ function repeatDataCycle(phaseTable) {
                                         'DATETIME', 'DataTag','DATABASE',
                                         'EQUINOX', 'SKYAREA', 'StatusFile', 'SQL']);
     */
-    set(phaseTable, ['tableMeta'], tableMeta);
-
     set(phaseTable, ['tableMeta', 'RowsRetrieved'], `${totalRows}`);
     set(phaseTable, ['tableMeta', 'tbl_id'], tbl_id);
     set(phaseTable, ['tableMeta', 'title'], title);

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -401,7 +401,7 @@ function updateFullRawTable(callback) {
 
         var [tzero, tzeroMax] = arr.length > 0 ? [Math.min(...arr), Math.max(...arr)] : [0.0, 0.0];
         var max = 365;
-        var min = Math.pow(10, -3);   // 0.0001
+        var min = Math.pow(10, -3);   // 0.001
 
         var fields = FieldGroupUtils.getGroupFields(LC.FG_PERIOD_FINDER);
         var initState;

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -8,7 +8,7 @@ import sCompare from 'react-addons-shallow-compare';
 import {pickBy, get} from 'lodash';
 import {flux, firefly} from '../../Firefly.js';
 import {getMenu, isAppReady, dispatchSetMenu, dispatchOnAppReady} from '../../core/AppDataCntlr.js';
-import {getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
+import {dispatchHideDropDown, getLayouInfo, SHOW_DROPDOWN,  dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
 import {MetaConst} from '../../data/MetaConst.js';
 import {lcManager, LC, removeTablesFromGroup, } from './LcManager.js';
 import {getAllConverterIds, getConverter} from './LcConverterFactory.js';
@@ -24,7 +24,6 @@ import {FormPanel} from './../../ui/FormPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {FileUpload} from '../../ui/FileUpload.jsx';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
-import {dispatchHideDropDown} from '../../core/LayoutCntlr.js';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import {makeFileRequest} from '../../tables/TableUtil.js';
@@ -219,7 +218,9 @@ function onSearchSubmit(request) {
     if ( request.rawTblSource ){
         removeTablesFromGroup();
         removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
+        var layoutInfo = getLayouInfo();
 
+        dispatchUpdateLayoutInfo(Object.assign({}, layoutInfo, {fullRawTable: null}));  // clear full rawtable
         const {mission} = request;
         const converter = getConverter(mission);
         if (!converter) return;
@@ -230,7 +231,7 @@ function onSearchSubmit(request) {
             tblType: 'notACatalog',
             sortInfo: sortInfoString(timeCName),
             META_INFO: {[MetaConst.DATASET_CONVERTER]: mission, timeCName},
-            pageSize: LC.FULL_TABLE_SIZE
+            pageSize: LC.TABLE_PAGESIZE
         };
         const treq = makeFileRequest('Raw Table', request.rawTblSource, null, options);
         dispatchTableSearch(treq, {removable: true});


### PR DESCRIPTION
fix the following phase folded table creation issues:
- derive the phase folded table from raw table with full data set by adding a phase column and doubling the row numbers of the raw table. 
- update the time column ('mjd')  value of the added rows to be the same as that in the raw table. 
- update and validate the period value (text field and the period slider)  when the selection of periodogram table and peak table or the highlight on those tables changes. 
