### PR TITLE
DM-9425: several python interface issues

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -177,7 +177,7 @@
                         META_INFO: {
                             datasetInfoConverterId : 'SimpleMoving',
                             MovingObjCoordColumns: 'ra_obj;dec_obj;EQ_J2000',
-                            urlColumn : 'image_url'
+                            datasource: 'image_url'
                         }
                     });
             firefly.getViewer().showTable( req, {removable: true, showUnits: false, showFilters: true});

--- a/src/firefly/js/core/ExternalAccessCntlr.js
+++ b/src/firefly/js/core/ExternalAccessCntlr.js
@@ -2,6 +2,8 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import ExternalAccessUtils from './ExternalAccessUtils.js';
+import {POINT} from '../visualize/PlotCmdExtension.js';
+import {dispatchChangePointSelection} from '../visualize/ImagePlotCntlr.js';
 
 const EXTENSION_ADD= 'ExternalAccessCntlr/extensionAdd';
 const EXTENSION_REMOVE= 'ExternalAccessCntlr/extensionRemove';
@@ -53,7 +55,33 @@ const extensionActivateActionCreator= function(rawAction) {
 };
 
 
+function extensionAddActionCreator(rawAction) {
+    return (dispatcher) => {
 
+        if (rawAction.payload) {
+            var {payload : {extension}}= rawAction;
+            if (extension.extType===POINT) {
+                dispatchChangePointSelection('ExtensionSystem', true);
+            }
+        }
+        dispatcher(rawAction);
+    };
+};
+
+
+function reducers() {
+    return {
+        [EXTERNAL_ACCESS_KEY]: reducer,
+    };
+}
+
+
+function actionCreators() {
+    return {
+        [EXTENSION_ACTIVATE]: extensionActivateActionCreator,
+        [EXTENSION_ADD]: extensionAddActionCreator
+    };
+}
 
 function reducer(state=initState, action={}) {
     if (!action.payload || !action.type) return state;
@@ -80,7 +108,14 @@ function reducer(state=initState, action={}) {
 
 const addExtension= function(state, action) {
     var {extension}= action.payload;
-    var newAry= [...state.extensionList, extension];
+    const {extensionList}= state;
+    var newAry;
+    if (extensionList.find( (e) => e.id===extension.id)) {
+        newAry= extensionList.map( (e) => e.id===extension.id ? extension : e);
+    }
+    else {
+        newAry= [...state.extensionList, extension];
+    }
     return Object.assign({}, state, {extensionList:newAry});
 };
 
@@ -101,7 +136,7 @@ const updateChannel= function(state, action) {
 //============ EXPORTS ===========
 
 var ExternalAccessCntlr = {
-    reducer, extensionActivateActionCreator, EXTENSION_ADD, EXTENSION_REMOVE,
+    reducers, actionCreators, extensionActivateActionCreator, EXTENSION_ADD, EXTENSION_REMOVE,
     EXTENSION_ACTIVATE, CHANNEL_ACTIVATE, EXTERNAL_ACCESS_KEY,
     ALL_MPW
     };

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -135,6 +135,7 @@ registerCntlr(BackgroundCntlr);
 registerCntlr(ImagePlotCntlr);
 registerCntlr(FieldGroupCntlr);
 registerCntlr(MouseReadoutCntlr);
+registerCntlr(ExternalAccessCntlr);
 registerCntlr(TablesCntlr);
 registerCntlr(DrawLayerCntlr.getDrawLayerCntlrDef(drawLayerFactory));
 
@@ -142,7 +143,6 @@ registerCntlr(DrawLayerCntlr.getDrawLayerCntlrDef(drawLayerFactory));
 let redux = null;
 
 // pre-map a set of action => creator prior to bootstrapping.
-actionCreators.set(ExternalAccessCntlr.EXTENSION_ACTIVATE, ExternalAccessCntlr.extensionActivateActionCreator);
 
 actionCreators.set(TableStatsCntlr.LOAD_TBL_STATS, TableStatsCntlr.loadTblStats);
 actionCreators.set(ChartsCntlr.CHART_DATA_FETCH, ChartsCntlr.makeChartDataFetch(cdtFactory.getChartDataType));

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -17,5 +17,6 @@ export const MetaConst = {
     CATALOG_COORD_COLS : 'CatalogCoordColumns',
     MOVING_COORD_COLS : 'MovingObjCoordColumns',
     DATASET_CONVERTER : 'datasetInfoConverterId',
-    DEFAULT_COLOR : 'DEFAULT_COLOR'
+    DEFAULT_COLOR : 'DEFAULT_COLOR',
+    DATA_SOURCE : 'DataSource'
 };

--- a/src/firefly/js/drawingLayers/PointSelection.js
+++ b/src/firefly/js/drawingLayers/PointSelection.js
@@ -14,6 +14,7 @@ import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
 import CsysConverter from '../visualize/CsysConverter.js';
 import {MouseState} from '../visualize/VisMouseSync.js';
 import {flux} from '../Firefly.js';
+import {clone} from '../util/WebUtil.js';
 
 const ID= 'POINT_SELECTION';
 const TYPE_ID= 'POINT_SELECTION_TYPE';
@@ -43,9 +44,11 @@ function onDetach(drawLayer,action) {
 
 
 
-function creator(initPayload) {
+function creator(initPayload, presetDefaults) {
     var drawingDef= makeDrawingDef('pink');
-    drawingDef.symbol= DrawSymbol.CIRCLE;
+    drawingDef.symbol= DrawSymbol.SQUARE;
+    drawingDef.size= 6;
+    drawingDef= Object.assign(drawingDef,presetDefaults);
     idCnt++;
 
     var pairs= {
@@ -75,7 +78,9 @@ function getDrawData(dataType, plotId, drawLayer, action, lastDataRet) {
 
 
 function getLayerChanges(drawLayer, action) {
-    return null;
+    if  (action.type===DrawLayerCntlr.CHANGE_DRAWING_DEF) {
+        return {drawingDef: clone(drawLayer.drawingDef,action.payload.drawingDef)}
+    }
 }
 
 function makeSelectedPt(screenPt,plotId) {
@@ -96,12 +101,11 @@ function selectAPoint(drawLayer, action, active) {
     var drawAry;
     if (active) {
         drawAry= [
-            PointDataObj.make(selPt,5,DrawSymbol.CIRCLE),
-            PointDataObj.make(selPt,5,DrawSymbol.SQUARE)
+            PointDataObj.make(selPt),
         ];
     }
     else {
-        drawAry= [PointDataObj.make(selPt,5,DrawSymbol.CIRCLE)];
+        drawAry= [PointDataObj.make(selPt)]
     }
     return  drawAry;
 }

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -10,6 +10,7 @@ import {getTblById,getTblInfo, getCellValue} from '../tables/TableUtil.js';
 import {converterFactory} from './ConverterFactory.js';
 import {MetaConst} from '../data/MetaConst.js';
 
+const dataSourceUpper= 'DATASOURCE';
 
 const getSetInSrByRow= (table,sr,rowNum) => (col) => {
     sr.setSafeParam(col.name, getCellValue(table,rowNum,col.name));
@@ -100,6 +101,7 @@ export function findGridTableRows(table,maxRows, plotIdRoot) {
     return retval;
 }
 
+
 /**
  * Guess if this table contains image meta data
  * @param tbl_id
@@ -110,7 +112,9 @@ export function isMetaDataTable(tbl_id) {
     const tableMeta= get(table, 'tableMeta');
     if (!tableMeta) return false;
 
-    if (tableMeta[MetaConst.DATASET_CONVERTER]) return true;
+    const hasDsCol= Boolean(Object.keys(tableMeta).find( (key) => key.toUpperCase()===dataSourceUpper));
+
+    if (tableMeta[MetaConst.DATASET_CONVERTER] || hasDsCol) return true;
     if (tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] || tableMeta[MetaConst.CATALOG_COORD_COLS])  return false;
     const converter= converterFactory(table);
     return Boolean(converter);

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -654,22 +654,23 @@ export function getTblInfo(tableModel, aPageSize) {
 
 
 /**
- *
+ * Return the row data as an object keyed by the column name
  * @param {TableModel} tableModel
  * @param {Number} [rowIdx] = the index of the row to return, default to highlighted row
+ * @return {Object<String,String>} the values of the row keyed by the column name
  */
 export function getTblRowAsObj(tableModel, rowIdx= undefined) {
     if (!tableModel) return {};
-    if (isUndefined(rowIdx)) rowIdx= tableModel.highlightedRow;
-    if (rowIdx<0) return {};
-    const {data, columns}= tableModel.tableData;
+    const {highlightedRow, tableData} = tableModel;
+    const {data, columns}= tableData;
+    if (isUndefined(rowIdx)) rowIdx= highlightedRow;
+    if (rowIdx<0 && rowIdx< get(tableData, 'data.length',0)) return {};
     const row= data[rowIdx];
     if (!row) return {};
     return row.reduce( (obj,v, idx)  => {
            obj[columns[idx].name]= v;
            return obj;
           }, {});
-
 }
 
 

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, unset, has, isEmpty, uniqueId, cloneDeep, omit, omitBy, isNil, isPlainObject, isArray, padEnd} from 'lodash';
+import {get, unset, has, isEmpty, isUndefined, uniqueId, cloneDeep, omit, omitBy, isNil, isPlainObject, isArray, padEnd} from 'lodash';
 import * as TblCntlr from './TablesCntlr.js';
 import {SortInfo, SORT_ASC, UNSORTED} from './SortInfo.js';
 import {FilterInfo} from './FilterInfo.js';
@@ -651,6 +651,28 @@ export function getTblInfo(tableModel, aPageSize) {
     var totalPages = Math.ceil((totalRows || 0)/pageSize);
     return { tableModel, tbl_id, title, totalRows, request, startIdx, endIdx, hlRowIdx, currentPage, pageSize,totalPages, highlightedRow, selectInfo, error};
 }
+
+
+/**
+ *
+ * @param {TableModel} tableModel
+ * @param {Number} [rowIdx] = the index of the row to return, default to highlighted row
+ */
+export function getTblRowAsObj(tableModel, rowIdx= undefined) {
+    if (!tableModel) return {};
+    if (isUndefined(rowIdx)) rowIdx= tableModel.highlightedRow;
+    if (rowIdx<0) return {};
+    const {data, columns}= tableModel.tableData;
+    const row= data[rowIdx];
+    if (!row) return {};
+    return row.reduce( (obj,v, idx)  => {
+           obj[columns[idx].name]= v;
+           return obj;
+          }, {});
+
+}
+
+
 
 /**
  * returns the url to download a snapshot of the current table data.

--- a/src/firefly/js/visualize/PlotCmdExtension.js
+++ b/src/firefly/js/visualize/PlotCmdExtension.js
@@ -10,6 +10,7 @@ import {CysConverter} from './CsysConverter.js';
 import {PlotState} from './PlotState.js';
 import {PlotAttribute} from './WebPlot.js';
 import {primePlot} from './PlotViewUtil.js';
+import {getTblById, getTblRowAsObj} from '../tables/TableUtil.js';
 
 export const AREA_SELECT= 'AREA_SELECT';
 export const LINE_SELECT= 'LINE_SELECT';
@@ -29,6 +30,15 @@ export function makeExtActivateData(ext,pv,dlAry) {
         type: ext.extType,
         plotState: PlotState.convertToJSON(plot.plotState)
     };
+
+    if (plot.attributes.tbl_id) {
+        const table = getTblById(plot.attributes.tbl_id);
+        data.table= {
+            highlightedRow: table.highlightedRow,
+            row : getTblRowAsObj(table)
+        };
+    }
+
 
     switch (ext.extType) {
         case AREA_SELECT:

--- a/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
+++ b/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
@@ -160,6 +160,7 @@ function updateImagePlots(tbl_id, viewerId, layoutChange=false) {
 
     if (viewer.layout===SINGLE) {
         const {single}= converter.makeRequest(table,highlightedRow,true);
+        if (!single) return [];
         reqAry= [single];
         single.setPlotId(`${dataId}-singleview`,0);
         single.setRelatedTableRow(highlightedRow);
@@ -169,6 +170,7 @@ function updateImagePlots(tbl_id, viewerId, layoutChange=false) {
         const plotRows= findGridTableRows(table,Math.min(converter.maxPlots,MAX_GRID_SIZE),`${dataId}-gridfull`);
         var reqAry= plotRows.map( (pR) => {
             const {single}= converter.makeRequest(table,pR.row,true);
+            if (!single) return [];
             single.setRelatedTableRow(pR.row);
             single.setPlotId(pR.plotId);
             return single;
@@ -180,10 +182,11 @@ function updateImagePlots(tbl_id, viewerId, layoutChange=false) {
         reqRet= converter.makeRequest(table,highlightedRow,false,true,threeColorOps);
         highlightPlotId= reqRet.highlightPlotId;
         reqAry= reqRet.standard;
+        if (isEmpty(reqAry)) return [];
         threeReqAry= reqRet.threeColor;
     }
 
-    replot(reqAry, threeReqAry, highlightPlotId, viewerId, dataId);
+    replot(reqAry, threeReqAry, highlightPlotId, viewerId, dataId, tbl_id);
 }
 
 
@@ -194,7 +197,7 @@ function removeAllPlotsInViewer(viewerId) {
     inViewerIds.forEach( (plotId) => dispatchDeletePlotView({plotId}));
 }
 
-function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
+function replot(reqAry, threeReqAry, activeId, viewerId, dataId, tbl_id)  {
     const groupId= `${viewerId}-${dataId}-standard`;
     var plottingIds= reqAry.map( (r) =>  r.getPlotId());
     var threeCPlotId;
@@ -228,7 +231,8 @@ function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
     const wpRequestAry= makePlottingList(reqAry);
     if (!isEmpty(wpRequestAry)) {
         dispatchPlotGroup({wpRequestAry, viewerId, holdWcsMatch:true,
-                           pvOptions: { userCanDeletePlots: false, menuItemKeys:{imageSelect : false} }
+                           pvOptions: { userCanDeletePlots: false, menuItemKeys:{imageSelect : false} },
+                           attributes: { tbl_id },
         });
     }
     if (activeId) dispatchChangeActivePlotView(activeId);
@@ -241,7 +245,8 @@ function replot(reqAry, threeReqAry, activeId, viewerId, dataId)  {
             dispatchPlotImage(
                 {
                     plotId:threeCPlotId, viewerId, wpRequest:plotThreeReqAry, threeColor:true,
-                               pvOptions: {userCanDeletePlots: true, menuItemKeys:{imageSelect : false}}
+                               pvOptions: {userCanDeletePlots: true, menuItemKeys:{imageSelect : false}},
+                    attributes: { tbl_id },
                 });
         }
     }

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -57,7 +57,7 @@ const getFirstReq= (wpRAry) => isArray(wpRAry) ? wpRAry.find( (r) => r?true:fals
 
 function makeSinglePlotPayload(vr, rawPayload, requestKey) {
 
-   var {wpRequest, plotId, threeColor, viewerId=DEFAULT_FITS_VIEWER_ID, attributes, setNewPlotAsActive,
+   var {wpRequest, plotId, threeColor, viewerId=DEFAULT_FITS_VIEWER_ID, attributes, setNewPlotAsActive= true,
          holdWcsMatch= false, pvOptions= {}, addToHistory= false,useContextModifications= true}= rawPayload;
 
     wpRequest= ensureWPR(wpRequest);

--- a/src/firefly/test/python/demo-notebook.ipynb
+++ b/src/firefly/test/python/demo-notebook.ipynb
@@ -2,11 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "version: 2.7.11 |Anaconda 4.0.0 (x86_64)| (default, Dec  6 2015, 18:57:58) \n",
+      "[GCC 4.2.1 (Apple Inc. build 5577)]\n",
+      "HELLO HELLO HELLO\n",
+      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\"]}}\n"
+     ]
+    }
+   ],
    "source": [
     "from __future__ import print_function\n",
     "from builtins import range\n",
@@ -20,7 +31,7 @@
     "def myCallback(event):\n",
     "    print(\"Event Received: \"+json.dumps(event['data']))\n",
     "    if 'type' in event['data']:\n",
-    "        if event['data']['type']=='AREA_SELECT':\n",
+    "        if event['data']['type']=='POINT':\n",
     "            print('*************area select')\n",
     "            #pParams= { 'URL' : 'http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits','ColorTable' : '9'}\n",
     "            status= fc.show_fits(fileOnServer=None, plotId='p4', \n",
@@ -38,11 +49,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\", \"1\"]}}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'tt'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\"]}}\n",
+      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\", \"2\"]}}\n"
+     ]
+    }
+   ],
    "source": [
     "fc.launch_browser()"
    ]
@@ -74,11 +111,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"plotId\": \"p1\", \"plotGroupId\": \"groupFromPython\", \"GroupLocked\": false, \"file\": \"${cache-dir}/upload_981251362737094624.fits\", \"Title\": \"Hello\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "file= fc.upload_file('./data/wise-1b-1.fits')\n",
@@ -88,17 +133,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Event Received: {\"type\": \"ExternalAccessCntlr/extensionAdd\", \"payload\": {\"extension\": {\"title\": \"crop\", \"imageUrl\": null, \"toolTip\": \"second crop\", \"plotId\": null, \"id\": \"abc\", \"extType\": \"POINT\"}}}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{u'success': True}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Event Received: {\"wpt\": \"145.0377124381455;70.08332026729803;EQ_J2000\", \"plotState\": {\"multiImage\": \"USE_ALL\", \"ops\": [], \"rotaNorthType\": \"EQ_J2000\", \"flippedY\": false, \"rotationAngle\": null, \"rotationType\": \"UNROTATE\", \"zoomLevel\": 0.38681102, \"JSON\": true, \"newPlot\": false, \"bandStateAry\": [{\"originalImageIdx\": 0, \"originalFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--309328989-ibedatawiseallsky4band_p1bm_frm8a03558a23203558a232-w1-int-1b.fits\", \"imageIdx\": 0, \"rangeValuesSerialize\": \"92,-2.0,92,10.0,0.1,2.0,44,25,600,120\", \"multiImageFile\": false, \"fitsHeader\": {\"blankValue\": \"NaN\", \"naxis1\": \"1016\", \"bzero\": \"0.0\", \"naxis3\": \"1\", \"naxis2\": \"1016\", \"naxis\": \"2\", \"dataOffset\": \"37440\", \"bitpix\": \"-32\", \"bscale\": \"1.0\", \"cdelt2\": \"7.615957633896761E-4\", \"planeNumber\": \"0\"}, \"cubePlaneNumber\": 0, \"uploadFileNameStr\": null, \"plotRequestSerialize\": \"id=ibe_file_retrieve&RequestClass=ServerRequest&ColorTable=1&ImageSet=ALLSKY_4BAND&PreferenceColorKey=wise-color-pref&ProductLevel=1B&ProgressKey=groupItemReqKey-wise-1-1-1487186156431&RangeValues=92,-2,92,10,0.1,2,44,25,600,120&Title=Wise band 1&Type=PROCESSOR&UserDesc=Wise band 1&ZoomToHeight=170&ZoomToWidth=393&ZoomType=TO_WIDTH&band=1&frame_num=232&in_dec=69.06529&in_ra=148.88822&mission=wise&plotGroupId=triViewImageMetaData-wise-standard&plotId=wise-1&scan_id=03558a\", \"cubeCnt\": 0, \"workingFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--309328989-ibedatawiseallsky4band_p1bm_frm8a03558a23203558a232-w1-int-1b.fits\", \"bandVisible\": true}, null, null], \"colorTableId\": 1, \"ctxStr\": \"WebPlot-firefly--134.4.28.224--15\", \"threeColor\": false}, \"plotId\": \"wise-1\", \"ipt\": \"542.900933031422;455.00251218327463\", \"table\": {\"highlightedRow\": 0, \"row\": {\"mjd_obs\": \"55297.28265630\", \"debgain\": \"3.750\", \"in_dec\": \"69.06529\", \"scangrp\": \"8a\", \"scan_id\": \"03558a\", \"utanneal\": \"2010-04-11 02:00:13.731\", \"febgain\": \"5.7400\", \"dec1\": \"70.597611642470\", \"frame_num\": \"232\", \"qa_status\": \"Final\", \"crval2\": \"70.063156920632\", \"crval1\": \"144.907460830672\", \"magzpunc\": \"0.006000\", \"dtanneal\": \"17207.77328699830\", \"band\": \"1\", \"ra4\": \"143.344025911761\", \"ra2\": \"146.479944953800\", \"in_row_id\": \"1\", \"ra1\": \"144.513849930087\", \"dec4\": \"69.930739877343\", \"exptime\": \"7.7\", \"dec2\": \"70.183049485671\", \"dec3\": \"69.530673216485\", \"moon_sep\": \"111.959\", \"date_obs\": \"2010-04-11 06:47:01.504\", \"qual_frame\": \"10\", \"qual_scan\": \"5\", \"in_ra\": \"148.88822\", \"modeint\": \"12.774\", \"ROWID\": \"1007\", \"magzp\": \"20.75200\", \"saa_sep\": \"113.004\", \"ra3\": \"145.277216699680\"}}, \"type\": \"POINT\", \"id\": \"abc\"}\n",
+      "*************area select\n",
+      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"fileOnServer\": null, \"plotGroupId\": \"groupFromPython\", \"URL\": \"http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits\", \"plotId\": \"p4\", \"GroupLocked\": false, \"ColorTable\": \"9\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n",
+      "Event Received: {\"wpt\": \"146.12035620056662;70.34237390278766;EQ_J2000\", \"plotState\": {\"multiImage\": \"USE_ALL\", \"ops\": [], \"rotaNorthType\": \"EQ_J2000\", \"flippedY\": false, \"rotationAngle\": null, \"rotationType\": \"UNROTATE\", \"zoomLevel\": 0.38681102, \"JSON\": true, \"newPlot\": false, \"bandStateAry\": [{\"originalImageIdx\": 0, \"originalFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--1349936197-ibedatawiseallsky4band_p1bm_frm0a03570a23303570a233-w1-int-1b.fits\", \"imageIdx\": 0, \"rangeValuesSerialize\": \"92,-2.0,92,10.0,0.1,2.0,44,25,600,120\", \"multiImageFile\": false, \"fitsHeader\": {\"blankValue\": \"NaN\", \"naxis1\": \"1016\", \"bzero\": \"0.0\", \"naxis3\": \"1\", \"naxis2\": \"1016\", \"naxis\": \"2\", \"dataOffset\": \"40320\", \"bitpix\": \"-32\", \"bscale\": \"1.0\", \"cdelt2\": \"7.615962419435527E-4\", \"planeNumber\": \"0\"}, \"cubePlaneNumber\": 0, \"uploadFileNameStr\": null, \"plotRequestSerialize\": \"id=ibe_file_retrieve&RequestClass=ServerRequest&ColorTable=1&ImageSet=ALLSKY_4BAND&PreferenceColorKey=wise-color-pref&ProductLevel=1B&ProgressKey=groupItemReqKey-wise-1-7-1487186253454&RangeValues=92,-2,92,10,0.1,2,44,25,600,120&Title=Wise band 1&Type=PROCESSOR&UserDesc=Wise band 1&ZoomToHeight=138&ZoomToWidth=393&ZoomType=TO_WIDTH&band=1&frame_num=233&in_dec=69.06529&in_ra=148.88822&mission=wise&plotGroupId=triViewImageMetaData-wise-standard&plotId=wise-1&scan_id=03570a\", \"cubeCnt\": 0, \"workingFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--1349936197-ibedatawiseallsky4band_p1bm_frm0a03570a23303570a233-w1-int-1b.fits\", \"bandVisible\": true}, null, null], \"colorTableId\": 1, \"ctxStr\": \"WebPlot-firefly--134.4.28.224--20\", \"threeColor\": false}, \"plotId\": \"wise-1\", \"ipt\": \"434.32060432700126;571.3384652007221\", \"table\": {\"highlightedRow\": 31, \"row\": {\"mjd_obs\": \"55297.67969601\", \"debgain\": \"4.730\", \"in_dec\": \"69.06529\", \"scangrp\": \"0a\", \"scan_id\": \"03570a\", \"utanneal\": \"2010-04-11 13:55:02.155\", \"febgain\": \"8.8600\", \"dec1\": \"70.894552543557\", \"frame_num\": \"233\", \"qa_status\": \"Final\", \"crval2\": \"70.352595647878\", \"crval1\": \"146.339270492492\", \"magzpunc\": \"0.012000\", \"dtanneal\": \"8623.58000218868\", \"band\": \"4\", \"ra4\": \"144.738620659925\", \"ra2\": \"147.949545065907\", \"in_row_id\": \"1\", \"ra1\": \"145.974075044258\", \"dec4\": \"70.226456105075\", \"exptime\": \"8.8\", \"dec2\": \"70.466418976048\", \"dec3\": \"69.814334929990\", \"moon_sep\": \"109.314\", \"date_obs\": \"2010-04-11 16:18:45.735\", \"qual_frame\": \"10\", \"qual_scan\": \"5\", \"in_ra\": \"148.88822\", \"modeint\": \"405.685\", \"ROWID\": \"1034\", \"magzp\": \"12.94500\", \"saa_sep\": \"80.305\", \"ra3\": \"146.679937421195\"}}, \"type\": \"POINT\", \"id\": \"abc\"}\n",
+      "*************area select\n",
+      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"fileOnServer\": null, \"plotGroupId\": \"groupFromPython\", \"URL\": \"http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits\", \"plotId\": \"p4\", \"GroupLocked\": false, \"ColorTable\": \"9\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n",
+      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\"]}}\n",
+      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\", \"4\"]}}\n"
+     ]
+    }
+   ],
    "source": [
-    "fc.add_extension(\"AREA_SELECT\", 'p1', 'crop2', 'second crop', image_src='../../html/images/icons-2014/16x16_Filter.png')\n",
+    "#fc.add_extension(\"AREA_SELECT\", 'p1', 'crop2', 'second crop', image_src='../../html/images/icons-2014/16x16_Filter.png')\n",
     "\n",
     "#fc.add_extension(\"LINE_SELECT\", 'p1', 'crop2', 'second crop', imageSrc='/hydra/cm/firefly/src/firefly/html/images/icons-2014/16x16_Filter.png')\n",
     "\n",
-    "#fc.add_extension(\"POINT\", 'p1', 'crop2', 'second crop', imageSrc='/hydra/cm/firefly/src/firefly/html/images/icons-2014/16x16_Filter.png')"
+    "#fc.add_extension(\"POINT\", 'p1', 'crop2', 'second crop', imageSrc='/hydra/cm/firefly/src/firefly/html/images/icons-2014/16x16_Filter.png')\n",
+    "fc.add_extension(\"POINT\",  title='crop', tool_tip='second crop', extension_id='abc')"
    ]
   },
   {
@@ -458,21 +537,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [ana35]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "Python [ana35]"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/src/firefly/test/python/demo-notebook.ipynb
+++ b/src/firefly/test/python/demo-notebook.ipynb
@@ -70,14 +70,6 @@
      "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\"]}}\n",
-      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\", \"2\"]}}\n"
-     ]
     }
    ],
    "source": [
@@ -111,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -120,7 +112,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"plotId\": \"p1\", \"plotGroupId\": \"groupFromPython\", \"GroupLocked\": false, \"file\": \"${cache-dir}/upload_981251362737094624.fits\", \"Title\": \"Hello\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n"
+      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"plotId\": \"p1\", \"plotGroupId\": \"groupFromPython\", \"GroupLocked\": false, \"file\": \"${cache-dir}/upload_4005543556766116604.fits\", \"Title\": \"Hello\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n"
      ]
     }
    ],
@@ -133,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -152,7 +144,7 @@
        "{u'success': True}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -160,14 +152,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Event Received: {\"wpt\": \"145.0377124381455;70.08332026729803;EQ_J2000\", \"plotState\": {\"multiImage\": \"USE_ALL\", \"ops\": [], \"rotaNorthType\": \"EQ_J2000\", \"flippedY\": false, \"rotationAngle\": null, \"rotationType\": \"UNROTATE\", \"zoomLevel\": 0.38681102, \"JSON\": true, \"newPlot\": false, \"bandStateAry\": [{\"originalImageIdx\": 0, \"originalFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--309328989-ibedatawiseallsky4band_p1bm_frm8a03558a23203558a232-w1-int-1b.fits\", \"imageIdx\": 0, \"rangeValuesSerialize\": \"92,-2.0,92,10.0,0.1,2.0,44,25,600,120\", \"multiImageFile\": false, \"fitsHeader\": {\"blankValue\": \"NaN\", \"naxis1\": \"1016\", \"bzero\": \"0.0\", \"naxis3\": \"1\", \"naxis2\": \"1016\", \"naxis\": \"2\", \"dataOffset\": \"37440\", \"bitpix\": \"-32\", \"bscale\": \"1.0\", \"cdelt2\": \"7.615957633896761E-4\", \"planeNumber\": \"0\"}, \"cubePlaneNumber\": 0, \"uploadFileNameStr\": null, \"plotRequestSerialize\": \"id=ibe_file_retrieve&RequestClass=ServerRequest&ColorTable=1&ImageSet=ALLSKY_4BAND&PreferenceColorKey=wise-color-pref&ProductLevel=1B&ProgressKey=groupItemReqKey-wise-1-1-1487186156431&RangeValues=92,-2,92,10,0.1,2,44,25,600,120&Title=Wise band 1&Type=PROCESSOR&UserDesc=Wise band 1&ZoomToHeight=170&ZoomToWidth=393&ZoomType=TO_WIDTH&band=1&frame_num=232&in_dec=69.06529&in_ra=148.88822&mission=wise&plotGroupId=triViewImageMetaData-wise-standard&plotId=wise-1&scan_id=03558a\", \"cubeCnt\": 0, \"workingFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--309328989-ibedatawiseallsky4band_p1bm_frm8a03558a23203558a232-w1-int-1b.fits\", \"bandVisible\": true}, null, null], \"colorTableId\": 1, \"ctxStr\": \"WebPlot-firefly--134.4.28.224--15\", \"threeColor\": false}, \"plotId\": \"wise-1\", \"ipt\": \"542.900933031422;455.00251218327463\", \"table\": {\"highlightedRow\": 0, \"row\": {\"mjd_obs\": \"55297.28265630\", \"debgain\": \"3.750\", \"in_dec\": \"69.06529\", \"scangrp\": \"8a\", \"scan_id\": \"03558a\", \"utanneal\": \"2010-04-11 02:00:13.731\", \"febgain\": \"5.7400\", \"dec1\": \"70.597611642470\", \"frame_num\": \"232\", \"qa_status\": \"Final\", \"crval2\": \"70.063156920632\", \"crval1\": \"144.907460830672\", \"magzpunc\": \"0.006000\", \"dtanneal\": \"17207.77328699830\", \"band\": \"1\", \"ra4\": \"143.344025911761\", \"ra2\": \"146.479944953800\", \"in_row_id\": \"1\", \"ra1\": \"144.513849930087\", \"dec4\": \"69.930739877343\", \"exptime\": \"7.7\", \"dec2\": \"70.183049485671\", \"dec3\": \"69.530673216485\", \"moon_sep\": \"111.959\", \"date_obs\": \"2010-04-11 06:47:01.504\", \"qual_frame\": \"10\", \"qual_scan\": \"5\", \"in_ra\": \"148.88822\", \"modeint\": \"12.774\", \"ROWID\": \"1007\", \"magzp\": \"20.75200\", \"saa_sep\": \"113.004\", \"ra3\": \"145.277216699680\"}}, \"type\": \"POINT\", \"id\": \"abc\"}\n",
+      "Event Received: {\"wpt\": \"6.992208730035259;39.43483936262465;EQ_J2000\", \"plotState\": {\"multiImage\": \"USE_ALL\", \"ops\": [], \"rotaNorthType\": \"EQ_J2000\", \"flippedY\": false, \"rotationAngle\": null, \"rotationType\": \"UNROTATE\", \"zoomLevel\": 0.0959707, \"JSON\": true, \"newPlot\": false, \"bandStateAry\": [{\"originalImageIdx\": 0, \"originalFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu-251880181-ibedatawiseallsky4band_p3am_cdd0000770077p393_ab410077p393_ab41-w1-int-3.fits\", \"imageIdx\": 0, \"rangeValuesSerialize\": \"92,-2.0,92,10.0,0.1,2.0,44,25,600,120\", \"multiImageFile\": false, \"fitsHeader\": {\"blankValue\": \"NaN\", \"naxis1\": \"4095\", \"bzero\": \"0.0\", \"naxis3\": \"1\", \"naxis2\": \"4095\", \"naxis\": \"2\", \"dataOffset\": \"5760\", \"bitpix\": \"-32\", \"bscale\": \"1.0\", \"cdelt2\": \"3.819444391411E-4\", \"planeNumber\": \"0\"}, \"cubePlaneNumber\": 0, \"uploadFileNameStr\": null, \"plotRequestSerialize\": \"id=ibe_file_retrieve&RequestClass=ServerRequest&ColorTable=1&ImageSet=ALLSKY_4BAND&PreferenceColorKey=wise-color-pref&ProductLevel=3A&ProgressKey=groupItemReqKey-wise-1-1-1487263168031&RangeValues=92,-2,92,10,0.1,2,44,25,600,120&Title=Wise band 1&Type=PROCESSOR&UserDesc=Wise band 1&ZoomToHeight=170&ZoomToWidth=393&ZoomType=TO_WIDTH&band=1&coadd_id=0077p393_ab41&in_dec=41.26906&in_ra=10.68479&mission=wise&plotGroupId=triViewImageMetaData-wise-standard&plotId=wise-1\", \"cubeCnt\": 0, \"workingFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu-251880181-ibedatawiseallsky4band_p3am_cdd0000770077p393_ab410077p393_ab41-w1-int-3.fits\", \"bandVisible\": true}, null, null], \"colorTableId\": 1, \"ctxStr\": \"WebPlot-firefly--gabriel--6\", \"threeColor\": false}, \"plotId\": \"wise-1\", \"ipt\": \"3563.5876366432694;2209.0077127706745\", \"table\": {\"highlightedRow\": 0, \"row\": {\"numfrms\": \"208\", \"in_dec\": \"41.26906\", \"qa_status\": \"Prelim\", \"date_obs1\": \"2010-01-10 12:02:27.261\", \"date_obs2\": \"2010-07-19 03:06:27.235\", \"coadd_id\": \"0077p393_ab41\", \"mid_obs\": \"2010-07-17 00:18:32.483\", \"crval2\": \"39.375556000000\", \"crval1\": \"7.741972000000\", \"magzpunc\": \"0.006000\", \"band\": \"1\", \"in_ra\": \"10.68479\", \"ra2\": \"6.741423891405\", \"in_row_id\": \"1\", \"ra1\": \"8.743008767476\", \"dec4\": \"40.153176649367\", \"dec1\": \"38.588781900498\", \"dec2\": \"38.588786133458\", \"dec3\": \"40.153180978244\", \"ra4\": \"8.765694370424\", \"ROWID\": \"0\", \"magzp\": \"20.50000\", \"ra3\": \"6.718749359926\"}}, \"type\": \"POINT\", \"id\": \"abc\"}\n",
       "*************area select\n",
-      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"fileOnServer\": null, \"plotGroupId\": \"groupFromPython\", \"URL\": \"http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits\", \"plotId\": \"p4\", \"GroupLocked\": false, \"ColorTable\": \"9\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n",
-      "Event Received: {\"wpt\": \"146.12035620056662;70.34237390278766;EQ_J2000\", \"plotState\": {\"multiImage\": \"USE_ALL\", \"ops\": [], \"rotaNorthType\": \"EQ_J2000\", \"flippedY\": false, \"rotationAngle\": null, \"rotationType\": \"UNROTATE\", \"zoomLevel\": 0.38681102, \"JSON\": true, \"newPlot\": false, \"bandStateAry\": [{\"originalImageIdx\": 0, \"originalFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--1349936197-ibedatawiseallsky4band_p1bm_frm0a03570a23303570a233-w1-int-1b.fits\", \"imageIdx\": 0, \"rangeValuesSerialize\": \"92,-2.0,92,10.0,0.1,2.0,44,25,600,120\", \"multiImageFile\": false, \"fitsHeader\": {\"blankValue\": \"NaN\", \"naxis1\": \"1016\", \"bzero\": \"0.0\", \"naxis3\": \"1\", \"naxis2\": \"1016\", \"naxis\": \"2\", \"dataOffset\": \"40320\", \"bitpix\": \"-32\", \"bscale\": \"1.0\", \"cdelt2\": \"7.615962419435527E-4\", \"planeNumber\": \"0\"}, \"cubePlaneNumber\": 0, \"uploadFileNameStr\": null, \"plotRequestSerialize\": \"id=ibe_file_retrieve&RequestClass=ServerRequest&ColorTable=1&ImageSet=ALLSKY_4BAND&PreferenceColorKey=wise-color-pref&ProductLevel=1B&ProgressKey=groupItemReqKey-wise-1-7-1487186253454&RangeValues=92,-2,92,10,0.1,2,44,25,600,120&Title=Wise band 1&Type=PROCESSOR&UserDesc=Wise band 1&ZoomToHeight=138&ZoomToWidth=393&ZoomType=TO_WIDTH&band=1&frame_num=233&in_dec=69.06529&in_ra=148.88822&mission=wise&plotGroupId=triViewImageMetaData-wise-standard&plotId=wise-1&scan_id=03570a\", \"cubeCnt\": 0, \"workingFitsFileStr\": \"${cache-dir}/URL--irsa.ipac.caltech.edu--1349936197-ibedatawiseallsky4band_p1bm_frm0a03570a23303570a233-w1-int-1b.fits\", \"bandVisible\": true}, null, null], \"colorTableId\": 1, \"ctxStr\": \"WebPlot-firefly--134.4.28.224--20\", \"threeColor\": false}, \"plotId\": \"wise-1\", \"ipt\": \"434.32060432700126;571.3384652007221\", \"table\": {\"highlightedRow\": 31, \"row\": {\"mjd_obs\": \"55297.67969601\", \"debgain\": \"4.730\", \"in_dec\": \"69.06529\", \"scangrp\": \"0a\", \"scan_id\": \"03570a\", \"utanneal\": \"2010-04-11 13:55:02.155\", \"febgain\": \"8.8600\", \"dec1\": \"70.894552543557\", \"frame_num\": \"233\", \"qa_status\": \"Final\", \"crval2\": \"70.352595647878\", \"crval1\": \"146.339270492492\", \"magzpunc\": \"0.012000\", \"dtanneal\": \"8623.58000218868\", \"band\": \"4\", \"ra4\": \"144.738620659925\", \"ra2\": \"147.949545065907\", \"in_row_id\": \"1\", \"ra1\": \"145.974075044258\", \"dec4\": \"70.226456105075\", \"exptime\": \"8.8\", \"dec2\": \"70.466418976048\", \"dec3\": \"69.814334929990\", \"moon_sep\": \"109.314\", \"date_obs\": \"2010-04-11 16:18:45.735\", \"qual_frame\": \"10\", \"qual_scan\": \"5\", \"in_ra\": \"148.88822\", \"modeint\": \"405.685\", \"ROWID\": \"1034\", \"magzp\": \"12.94500\", \"saa_sep\": \"80.305\", \"ra3\": \"146.679937421195\"}}, \"type\": \"POINT\", \"id\": \"abc\"}\n",
-      "*************area select\n",
-      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"fileOnServer\": null, \"plotGroupId\": \"groupFromPython\", \"URL\": \"http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits\", \"plotId\": \"p4\", \"GroupLocked\": false, \"ColorTable\": \"9\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n",
-      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\"]}}\n",
-      "Event Received: {\"type\": \"app_data.wsConnUpdated\", \"payload\": {\"tt\": [\"0\", \"4\"]}}\n"
+      "Event Received: {\"type\": \"ImagePlotCntlr.PlotImage\", \"payload\": {\"wpRequest\": {\"fileOnServer\": null, \"plotGroupId\": \"groupFromPython\", \"URL\": \"http://web.ipac.caltech.edu/staff/roby/demo/wise-m51-band2.fits\", \"plotId\": \"p4\", \"GroupLocked\": false, \"ColorTable\": \"9\"}, \"viewerId\": \"DEFAULT_FITS_VIEWER_ID\", \"useContextModifications\": true}}\n"
      ]
     }
    ],
@@ -469,69 +456,6 @@
    "source": [
     "print(imageFileName)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/src/firefly/test/python/lsst2015-demo.ipynb
+++ b/src/firefly/test/python/lsst2015-demo.ipynb
@@ -190,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 - cleaned up ExternalAccessCntlr
 - fixed point selection improperly turning on and off
 - fixed extension added.  It will now update if the extension id already exist
 - extension response data sent to server now contains selected table row information
    if a table is associated with an image.
 - new plots are active by default, it was not defaulting correctly with remote actions
 - improve image meta data table uploads a little, made DataSource work correctly

Notes:
- this is really going to be hard to test until we get it on  the pdac.  I would sugest that the code review just look over the code the David S. and I will test it with his python code.
- ignore the python notebook file in the review