### PR TITLE
DM-8989: SQL constraint encoded

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/GatorQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/GatorQuery.java
@@ -387,7 +387,7 @@ public class GatorQuery extends BaseGator {
 
     private String encodeParams(String params) {
         if (!StringUtils.isEmpty(params)) {
-            params = params.replace(" ", "+");
+            return urlEncode(params);
         }
         return params;
     }


### PR DESCRIPTION
Please, check that it doesn't break anything else (Gator queries). Need to encode the constraint parameter passed in the request so it can cope with for example:
all-sky search with SQL constraint such as: `objid like '%Themis'`

Test: do a catalog search in NEOWISER Reactivation db, with the text search sql `objid like '%Themis'` in the SQL constraint text area on bottom of the catalog search panel.
Result should come back with 75 result same as if you are doing it from Gator page.