### PR TITLE
DM-9162: magnitude should be plotted in reversed order Yaxis

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -367,7 +367,8 @@ class PhaseFoldingChart extends Component {
                     lineWidth: 1,
                     tickWidth: 1,
                     tickLength: 10,
-                    gridLineColor: '#e9e9e9'
+                    gridLineColor: '#e9e9e9',
+                    reversed: true
                 },
                 tooltip: showTooltip ? {enabled: true,
                     borderColor: '#a3aeb9',


### PR DESCRIPTION
Phase folded chart preview had the magnitude Yaxis shown in increasing order, astronomers wants to see the magnitude value in reversed. This fix the issue for that component in the "Period finding" layout.
