### PR TITLE
DM-9348 LSST - time series viewer results (part 2)

### DIFF
--- a/src/firefly/js/fieldGroup/FieldGroupUtils.js
+++ b/src/firefly/js/fieldGroup/FieldGroupUtils.js
@@ -165,7 +165,7 @@ const bindToStore= function(groupKey, stateUpdaterFunc) {
 
 
 /**
- *
+ * @param fields
  */
 export function revalidateFields(fields) {
     const newfields= clone(fields);

--- a/src/firefly/js/templates/lightcurve/DefaultMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/DefaultMissionOptions.js
@@ -1,0 +1,228 @@
+import React, {Component, PropTypes} from 'react';
+import sCompare from 'react-addons-shallow-compare';
+import {get, has, isEmpty, set} from 'lodash';
+import {FieldGroup} from '../../ui/FieldGroup.jsx';
+import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
+import {dispatchMultiValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
+import {ValidationField} from '../../ui/ValidationField.jsx';
+import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
+import {makeFileRequest} from '../../tables/TableUtil.js';
+import {sortInfoString} from '../../tables/SortInfo.js';
+import {ReadOnlyText, getTypeData} from './LcUtil.jsx';
+import {LC, getViewerGroupKey} from './LcManager.js';
+import {getMissionName} from './LcConverterFactory.js';
+
+
+const labelWidth = 80;
+
+export class DefaultSettingBox extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+    render() {
+        var {generalEntries, missionEntries} = this.props;
+
+        if (isEmpty(generalEntries) || isEmpty(missionEntries)) return false;
+
+        const wrapperStyle = {margin: '3px 0'};
+
+        var allCommonEntries = Object.keys(generalEntries).map((key) =>
+            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
+                             style={{width: 80}}/>
+        );
+
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME];
+        const missionOtherKeys = [LC.META_ERR_CNAME];
+        const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
+
+        var missionInputs = missionKeys.map((key, index) =>
+            <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
+                                  getSuggestions={(val) => {
+                                    const list = get(missionEntries, missionListKeys[index], []);
+                                    const suggestions =  list && list.filter((el) => {return el.startsWith(val);});
+                                    return suggestions.length > 0 ? suggestions : list;
+                                  }}
+            />
+        );
+
+        var missionOthers = missionOtherKeys.map((key) =>
+            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}/>
+        );
+
+
+        const groupKey = getViewerGroupKey(missionEntries);
+        const converterId = get(missionEntries, LC.META_MISSION);
+        const missionName = getMissionName(converterId);
+
+        return (
+            <FieldGroup groupKey={groupKey}
+                        reducerFunc={defaultOptionsReducer(missionEntries, generalEntries)} keepState={true}>
+                <div style={{display: 'flex', alignItems: 'flex-end'}} >
+                    <div >
+                        <ReadOnlyText label='Mission:' content={missionName}
+                                      labelWidth={labelWidth} wrapperStyle={{margin: '3px 0 6px 0'}}/>
+
+                        {missionInputs}
+                        {missionOthers}
+                    </div>
+                    <div>
+                        {allCommonEntries}
+                    </div>
+                </div>
+            </FieldGroup>
+        );
+    }
+}
+
+DefaultSettingBox.propTypes = {
+    generalEntries: PropTypes.object,
+    missionEntries: PropTypes.object
+};
+
+
+export const defaultOptionsReducer = (missionEntries, generalEntries) => {
+    return (inFields, action) => {
+        if (inFields) {
+            return inFields;
+        }
+
+        // defValues used to keep the initial values for parameters in the field group of result page
+        // time: time column
+        // flux: flux column
+        // timecols:  time column candidates
+        // fluxcols:  flux column candidates
+        // errorcolumm: error column
+        // cutoutsize: image cutout size
+        const defValues = {
+            [LC.META_TIME_CNAME]: Object.assign(getTypeData(LC.META_TIME_CNAME, '',
+                'time column name',
+                'Time Column:', labelWidth),
+                {validator: null}),
+            [LC.META_FLUX_CNAME]: Object.assign(getTypeData(LC.META_FLUX_CNAME, '',
+                'flux column name',
+                'Flux Column:', labelWidth),
+                {validator: null}),
+            [LC.META_TIME_NAMES]: Object.assign(getTypeData(LC.META_TIME_NAMES, '',
+                'time column suggestion'),
+                {validator: null}),
+            [LC.META_FLUX_NAMES]: Object.assign(getTypeData(LC.META_FLUX_NAMES, '',
+                'flux column suggestion'),
+                {validator: null}),
+            ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
+                'image cutout size',
+                'Cutout Size (deg):', 100)),
+            [LC.META_ERR_CNAME]: Object.assign(getTypeData(LC.META_ERR_CNAME, '',
+                'flux error column name',
+                'Error Column:', labelWidth))
+        };
+
+        var   defV = Object.assign({}, defValues);
+
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME];
+        const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
+
+        missionListKeys.forEach((key) => {
+            set(defV, [key, 'value'], get(missionEntries, key, []));
+        });
+
+        // set value and validator
+        missionKeys.forEach((key, idx) => {
+            set(defV, [key, 'value'], get(missionEntries, key, ''));
+            set(defV, [key, 'validator'], (val) => {
+                let retVal = {valid: true, message: ''};
+                        const cols = get(missionEntries, missionListKeys[idx], []);
+
+                if (cols.length !== 0 && !cols.includes(val)) {
+                    retVal = {valid: false, message: `${val} is not a valid column name`};
+                }
+
+                return retVal;
+            });
+        });
+        Object.keys(generalEntries).forEach((key) => {
+            set(defV, [key, 'value'], get(generalEntries, key, ''));
+        });
+        return defV;
+    };
+};
+
+
+
+function getFieldValidators(missionEntries) {
+    const fldsWithValidators = [
+        {key: LC.META_TIME_CNAME, vkey: LC.META_TIME_NAMES},
+        {key: LC.META_FLUX_CNAME, vkey: LC.META_FLUX_NAMES}
+        //{key: LC.META_ERR_CNAME, vkey: LC.META_ERR_NAMES} // error can have no value
+        ];
+    return fldsWithValidators.reduce((all, fld) => {
+        all[fld.key] =
+            (val) => {
+                let retVal = {valid: true, message: ''};
+                const cols = get(missionEntries, fld.vkey, []);
+                if (cols.length !== 0 && !cols.includes(val)) {
+                    retVal = {valid: false, message: `${val} is not a valid column name`};
+                }
+                return retVal;
+            };
+        return all;
+    }, {});
+}
+
+function setFields(missionEntries, generalEntries) {
+    const groupKey = getViewerGroupKey(missionEntries);
+    const fields = FieldGroupUtils.getGroupFields(groupKey);
+    const validators = getFieldValidators(missionEntries);
+    if (fields) {
+        const initState = Object.keys(fields).reduce((prev, fieldKey) => {
+            if (has(missionEntries, fieldKey)) {
+                prev.push({fieldKey, value: get(missionEntries, fieldKey), validator: validators[fieldKey]});
+            } else if (has(generalEntries,fieldKey)) {
+                prev.push({fieldKey, value: get(generalEntries, fieldKey)});
+            }
+            return prev;
+        }, []);
+        dispatchMultiValueChange(groupKey, initState);
+    }
+}
+
+
+
+export function defaultOnNewRawTable(rawTable, converterData, generalEntries) {
+    const metaInfo = rawTable && rawTable.tableMeta;
+    const missionEntries = {
+        [LC.META_MISSION]: converterData.converterId,
+        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, converterData.defaultTimeCName),
+        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, converterData.defaultYCname),
+        [LC.META_ERR_CNAME]: get(metaInfo, LC.META_ERR_CNAME, converterData.defaultYErrCname),
+        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES, converterData.timeNames),
+        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES, converterData.yNames),
+        [LC.META_ERR_NAMES]: get(metaInfo, LC.META_ERR_NAMES, converterData.yErrNames)
+    };
+    setFields(missionEntries, generalEntries);
+    return missionEntries;
+}
+
+export function defaultRawTableRequest(converter, source) {
+    const timeCName = converter.defaultTimeCName;
+    const mission = converter.converterId;
+    const options = {
+        tbl_id: LC.RAW_TABLE,
+        tblType: 'notACatalog',
+        sortInfo: sortInfoString(timeCName),
+        META_INFO: {[LC.META_MISSION]: mission, timeCName},
+        pageSize: LC.TABLE_PAGESIZE
+    };
+    return makeFileRequest('Raw Table', source, null, options);
+
+}
+
+export function defaultOnFieldUpdate(fieldKey, value) {
+    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_ERR_CNAME].includes(fieldKey)) {
+        return {[fieldKey] : value};
+    }
+}

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -2,11 +2,14 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
+import {get} from 'lodash';
 import {TitleOptions} from '../../visualize/WebPlotRequest.js';
 import {logError} from '../../util/WebUtil.js';
 
+import {DefaultSettingBox, defaultOnNewRawTable, defaultOnFieldUpdate, defaultRawTableRequest} from './DefaultMissionOptions.js';
 import {getWebPlotRequestViaWISEIbe} from './wise/WisePlotRequests.js';  //WiseRequestList.js
 import {makeLsstSdssPlotRequest} from './lsst_sdss/LsstSdssPlotRequests.js'; //LsstSdssRequestList.js';
+import {LsstSdssSettingBox, lsstSdssOnNewRawTable, lsstSdssOnFieldUpdate, lsstSdssRawTableRequest} from './lsst_sdss/LsstSdssMissionOptions.js';
 
 
 
@@ -19,36 +22,77 @@ import {makeLsstSdssPlotRequest} from './lsst_sdss/LsstSdssPlotRequests.js'; //L
  * @param {Object} params - mission specific parameters
  */
 
+/**
+ * @callback onNewRawTable
+ * @param {object} rawTable
+ * @param {LCMissionConverter} converterData
+ * @param {Object} generalEntries
+ * @return {Object} new missionEntries object
+ */
+
+/**
+ * @callback onFieldUpdate
+ * @param {string} fieldKey
+ * @param {string} newValue
+ * @return {Object} object with the mission entries keys that should update as a result of this change
+ */
+
+/**
+ * @callback rawTableRequest
+ * @param {LCMissionConverter} converterData
+ * @param {string} uploaded file location
+ * @return {TableRequest} table request object
+ */
 
 /**
  * @typedef {Object} LCMissionConverter - defines how to get LC data frm a mission specific table
+ * @prop {string}  converterId - unique identifier for this object
  * @prop {number}  defaultImageCount - default number of images connected to a ResultView row
  * @prop {string}  defaultTimeCName - default time column in ResultView table
  * @prop {string}  defaultYCName - default Y column in ResultView table
- * @prop {string[]}  timeNames - valid column names for time axis
- * @prop {string[]}  yNames - valid column names for y axis
+ * @prop {string}  defaultYErrCName - default Y error column in ResultView table
+ * @prop {string}  missionName - displayable mission name
+ * @prop {Component} MissionOptions - React component for result page options
+ * @prop {function} onNewRawTable - function called when new raw table is loaded, returns new mission entries object
+ * @prop {function} onFieldUpdate - function that is called when a value of a field changes
+ * @prop {function} rawTableRequest - function that creates raw table request
+ * @prop {function} setFields
+ * @prop {string[]} timeNames - valid column names for time axis
+ * @prop {string[]} yNames - valid column names for y axis
  * @prop {WebplotRequestCreator}  webplotRequestCreator a function to create a WebplotRequest
  */
 
 /**
  * @type {{wise: LCMissionConverter, lsst_sdss: LCMissionConverter}}
  **/
-export const converters = {
+const converters = {
     'wise': {
+        converterId: 'wise',
         defaultImageCount: 5,
         defaultTimeCName: 'mjd',
         defaultYCname: 'w1mpro_ep',
         defaultYErrCname: '',
+        missionName: 'WISE',
+        MissionOptions: DefaultSettingBox,
+        onNewRawTable: defaultOnNewRawTable,
+        onFieldUpdate: defaultOnFieldUpdate,
+        rawTableRequest: defaultRawTableRequest,
         timeNames: ['mjd'],
         yNames: ['w1mpro_ep', 'w2mpro_ep', 'w3mpro_ep', 'w4mpro_ep'],
         yErrNames: ['w1sigmpro_ep', 'w2sigmpro_ep', 'w3sigmpro_ep', 'w4sigmpro_ep'],
         webplotRequestCreator: getWebPlotRequestViaWISEIbe
     },
     'lsst_sdss': {
+        converterId: 'lsst_sdss',
         defaultImageCount: 1,
         defaultTimeCName: 'exposure_time_mid',
         defaultYCname: 'mag',
         defaultYErrCname: '',
+        missionName: 'LSST SDSS',
+        MissionOptions: LsstSdssSettingBox,
+        onNewRawTable: lsstSdssOnNewRawTable,
+        onFieldUpdate: lsstSdssOnFieldUpdate,
+        rawTableRequest: lsstSdssRawTableRequest,
         timeNames: ['exposure_time_mid'],
         yNames: ['mag', 'tsv_flux'],
         yErrNames: ['magErr', 'tsv_fluxErr'],
@@ -60,15 +104,19 @@ export function getAllConverterIds() {
     return Object.keys(converters);
 }
 
-export function getConverter(datasetConverterId) {
-    const converter = datasetConverterId && converters[datasetConverterId];
+export function getConverter(converterId) {
+    const converter = converterId && converters[converterId];
     if (!converter) {
-        logError(`Unable to find dataset converter ${datasetConverterId}`);
+        logError(`Unable to find dataset converter ${converterId}`);
         return;
     }
     return converter;
 }
 
+export function getMissionName(converterId) {
+    const converterData = converterId && converters[converterId];
+    return get(converterData, 'missionName', converterId);
+}
 
 /**
  * @param {WebPlotRequest} inWpr

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -22,6 +22,7 @@ import {getActiveTableId, getColumnIdx} from '../../tables/TableUtil.js';
 import {LC, updateLayoutDisplay, getValidValueFrom, getFullRawTable} from './LcManager.js';
 import {doPFCalculate, getPhase} from './LcPhaseTable.js';
 import {LcPeriodogram, cancelPeriodogram, popupId} from './LcPeriodogram.jsx';
+import {ReadOnlyText, getTypeData} from './LcUtil.jsx';
 import {LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
 import {isDialogVisible} from '../../core/ComponentCntlr.js';
 import {updateSet} from '../../util/WebUtil.js';
@@ -33,15 +34,7 @@ const pfinderkey = LC.FG_PERIOD_FINDER;
 const labelWidth = 100;
 
 export const highlightBorder = '1px solid #a3aeb9';
-export function getTypeData(key, val='', tip = '', labelV='', labelW) {
-    return {
-        fieldKey: key,
-        label: labelV,
-        value: val,
-        tooltip: tip,
-        labelWidth: labelW
-    };
-}
+
 
 export var isBetween = (a, b, c) => (c >= a && c <= b);
 
@@ -106,22 +99,6 @@ var defPeriod = {
 
 var periodRange;        // prediod range based on raw table, set based on the row table, and unchangable
 var periodErr;          // error message for period setting
-
-export var ReadOnlyText = ({label, content, labelWidth, wrapperStyle}) => {
-    return (
-        <div style={{display: 'flex',...wrapperStyle}}>
-            <div style={{width: labelWidth, paddingRight: 4}}> {label} </div>
-            <div> {content} </div>
-        </div>
-    );
-};
-
-ReadOnlyText.propTypes = {
-    label: PropTypes.string,
-    content: PropTypes.string,
-    labelWidth: PropTypes.number,
-    wrapperStyle: PropTypes.object
-};
 
 
 function lastFrom(strAry) {

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -8,7 +8,7 @@ import { get, set, has} from 'lodash';
 import SplitPane from 'react-split-pane';
 import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import {LC, getValidValueFrom, updateLayoutDisplay} from './LcManager.js';
-import {getTypeData} from './LcPeriod.jsx';
+import {getTypeData} from './LcUtil.jsx';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 import FieldGroupCntlr, {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import Validate from '../../util/Validate.js';

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -112,7 +112,8 @@ function addPhaseToTable(tbl, timeName, tzero, period) {
         tPF.tableData.data[index].push(getPhase(parseFloat(d[tIdx]), parseFloat(tzero), parseFloat(period)));
     });
 
-    const fluxCols = get(getLayouInfo(), [LC.MISSION_DATA, LC.META_FLUX_NAMES]);
+    const fluxCol = get(getLayouInfo(), [LC.MISSION_DATA, LC.META_FLUX_CNAME]);
+    const fluxCols = get(getLayouInfo(), [LC.MISSION_DATA, LC.META_FLUX_NAMES], [fluxCol]);
 
     locateTableColumns(tPF, [timeName, LC.PHASE_CNAME,...fluxCols], 0);
 

--- a/src/firefly/js/templates/lightcurve/LcUtil.jsx
+++ b/src/firefly/js/templates/lightcurve/LcUtil.jsx
@@ -1,0 +1,27 @@
+import React, {PropTypes} from 'react';
+
+export function getTypeData(key, val='', tip = '', labelV='', labelW) {
+    return {
+        fieldKey: key,
+        label: labelV,
+        value: val,
+        tooltip: tip,
+        labelWidth: labelW
+    };
+}
+
+export var ReadOnlyText = ({label, content, labelWidth, wrapperStyle}) => {
+    return (
+        <div style={{display: 'flex',...wrapperStyle}}>
+            <div style={{width: labelWidth, paddingRight: 4}}> {label} </div>
+            <div> {content} </div>
+        </div>
+    );
+};
+
+ReadOnlyText.propTypes = {
+    label: PropTypes.string,
+    content: PropTypes.string,
+    labelWidth: PropTypes.number,
+    wrapperStyle: PropTypes.object
+};

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
@@ -1,0 +1,219 @@
+import React, {Component, PropTypes} from 'react';
+import sCompare from 'react-addons-shallow-compare';
+import {get, has, isEmpty, set, omit} from 'lodash';
+import {getLayouInfo, dispatchUpdateLayoutInfo} from '../../../core/LayoutCntlr.js';
+import FieldGroupUtils from '../../../fieldGroup/FieldGroupUtils';
+import {dispatchMultiValueChange} from '../../../fieldGroup/FieldGroupCntlr.js';
+import {ValidationField} from '../../../ui/ValidationField.jsx';
+import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
+import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
+import {FieldGroup} from '../../../ui/FieldGroup.jsx';
+import {makeFileRequest} from '../../../tables/TableUtil.js';
+import {dispatchTableSearch} from '../../../tables/TablesCntlr.js';
+import {sortInfoString} from '../../../tables/SortInfo.js';
+import {FilterInfo} from '../../../tables/FilterInfo.js';
+
+import {LC, getViewerGroupKey, removeTablesFromGroup} from '../LcManager.js';
+import {getTypeData} from './../LcUtil.jsx';
+
+const labelWidth = 90;
+
+export class LsstSdssSettingBox extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+
+    render() {
+        const {generalEntries, missionEntries} = this.props;
+
+
+        if (isEmpty(generalEntries) || isEmpty(missionEntries)) return false;
+        const wrapperStyle = {margin: '3px 0'};
+
+        var rightEntries = Object.keys(generalEntries).map((key) =>
+            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}/>
+        );
+
+        const validFluxVals = get(missionEntries, LC.META_FLUX_NAMES, []);
+        rightEntries.unshift(
+            <SuggestBoxInputField key={LC.META_FLUX_CNAME}
+                fieldKey={LC.META_FLUX_CNAME} wrapperStyle={Object.assign(wrapperStyle)}
+                getSuggestions={(val) => {
+                    const suggestions =  validFluxVals && validFluxVals.filter((el) => {return el.startsWith(val);});
+                    return suggestions.length > 0 ? suggestions : validFluxVals;
+                }}
+            />
+        );
+
+        var leftEntries = [
+            <RadioGroupInputField key='band' fieldKey='band' wrapperStyle={wrapperStyle}
+                alignment='horizontal'
+                options={[
+                    {label: 'u', value: 'u'},
+                    {label: 'g', value: 'g'},
+                    {label: 'r', value: 'r'},
+                    {label: 'i', value: 'i'},
+                    {label: 'z', value: 'z'}
+                ]}
+            />
+        ];
+
+        const groupKey = getViewerGroupKey(missionEntries);
+
+        return (
+            <FieldGroup groupKey={groupKey}
+                        reducerFunc={lsstSdssReducer(missionEntries, generalEntries)} keepState={true}>
+                <div style={{display: 'flex', alignItems: 'flex-start'}} >
+                    <div >
+                        {leftEntries}
+                    </div>
+                    <div>
+                        {rightEntries}
+                    </div>
+                </div>
+            </FieldGroup>
+        );
+    }
+}
+
+LsstSdssSettingBox.propTypes = {
+    generalEntries: PropTypes.object,
+    missionEntries: PropTypes.object
+};
+
+export const lsstSdssReducer = (missionEntries, generalEntries) => {
+    return (inFields, action) => {
+        if (inFields) {
+            return inFields;
+        }
+
+        const validFluxVals = get(missionEntries, LC.META_FLUX_NAMES, []);
+        const fluxFldValidator = (val) => {
+            let retVal = {valid: true, message: ''};
+            if (validFluxVals.length !== 0 && !validFluxVals.includes(val)) {
+                retVal = {valid: false, message: `${val} is not a valid column name`};
+            }
+            return retVal;
+        };
+
+        // defValues used to keep the initial values for parameters in the field group of result page
+        // band: lsst sdss band name
+        // flux: flux column
+        // cutoutsize: image cutout size
+
+        const defValues = {
+            band: Object.assign(getTypeData('band', '',
+                'LSST SDSS band',
+                'LSST Band:', 60)),
+            [LC.META_FLUX_CNAME]: Object.assign(getTypeData(LC.META_FLUX_CNAME, '',
+                'Y column name',
+                'Periodic Column:', labelWidth),
+                {validator: fluxFldValidator}),
+            ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
+                'image cutout size',
+                'Cutout Size (deg):', labelWidth)),
+            [LC.META_ERR_CNAME]: Object.assign(getTypeData(LC.META_ERR_CNAME, '',
+                'flux error column name',
+                'Error Column:', labelWidth))
+        };
+
+        var   defV = Object.assign({}, defValues);
+
+        const missionKeys = ['band', LC.META_FLUX_CNAME];
+
+        // set value
+        missionKeys.forEach((key) => {
+            set(defV, [key, 'value'], get(missionEntries, key, ''));
+        });
+        Object.keys(generalEntries).forEach((key) => {
+            set(defV, [key, 'value'], get(generalEntries, key, ''));
+        });
+        return defV;
+    };
+};
+
+
+
+function setFields(missionEntries, generalEntries) {
+    const groupKey = getViewerGroupKey(missionEntries);
+    const fields = FieldGroupUtils.getGroupFields(groupKey);
+    if (fields) {
+        const initState = Object.keys(fields).reduce((prev, fieldKey) => {
+            if (has(missionEntries, fieldKey)) {
+                prev.push({fieldKey, value: get(missionEntries, fieldKey)});
+            } else if (has(generalEntries,fieldKey)) {
+                prev.push({fieldKey, value: get(generalEntries, fieldKey)});
+            }
+            return prev;
+        }, []);
+        dispatchMultiValueChange(groupKey, initState);
+    }
+}
+
+
+
+export function lsstSdssOnNewRawTable(rawTable, converterData, generalEntries) {
+    const metaInfo = rawTable && rawTable.tableMeta;
+    const missionEntries = {
+        [LC.META_MISSION]: converterData.converterId,
+        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, converterData.defaultTimeCName),
+        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, converterData.defaultYCname),
+        [LC.META_ERR_CNAME]: get(metaInfo, LC.META_ERR_CNAME, converterData.defaultYErrCname),
+        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES, converterData.timeNames),
+        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES, converterData.yNames),
+        [LC.META_ERR_NAMES]: get(metaInfo, LC.META_ERR_NAMES, converterData.yErrNames),
+        band: get(metaInfo, 'band', 'u'),
+        rawTableSource: get(metaInfo, 'rawTableSource')
+    };
+    setFields(missionEntries, generalEntries);
+    return missionEntries;
+}
+
+export function lsstSdssOnFieldUpdate(fieldKey, value) {
+    var layoutInfo = getLayouInfo();
+    const missionEntries = get(layoutInfo, LC.MISSION_DATA);
+    if (!missionEntries) return;
+    const newMissionEntries = Object.assign(omit(missionEntries,[LC.META_TIME_NAMES, LC.META_FLUX_NAMES,LC.META_ERR_NAMES]), {[fieldKey]: value});
+    if (fieldKey === 'band' || fieldKey === LC.META_TIME_CNAME) {
+        removeTablesFromGroup();
+        removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
+        var layoutInfo = getLayouInfo();
+        dispatchUpdateLayoutInfo(Object.assign({}, layoutInfo, {showTables: false, showXyPlots: false, fullRawTable: null, missionEntries: {}}));  // clear full rawtable
+        const treq = makeRawTableRequest(newMissionEntries);
+        dispatchTableSearch(treq, {removable: true});
+        return {};
+    } else if ([LC.META_FLUX_CNAME, LC.META_ERR_CNAME].includes(fieldKey)) {
+        return {[fieldKey]: value};
+    }
+}
+
+export function lsstSdssRawTableRequest(converter, source) {
+    const missionEntries = {
+        band: 'u',
+        [LC.META_TIME_CNAME]: converter.defaultTimeCName,
+        [LC.META_MISSION]: converter.converterId,
+        rawTableSource: source
+    };
+    return makeRawTableRequest(missionEntries);
+
+}
+
+function makeRawTableRequest(missionEntries) {
+    const filterInfo = new FilterInfo;
+    filterInfo.addFilter('filterName', `LIKE ${missionEntries['band']}`);
+    const options = {
+        tbl_id: LC.RAW_TABLE,
+        tblType: 'notACatalog',
+        sortInfo: sortInfoString(missionEntries[LC.META_TIME_CNAME]),
+        filters: filterInfo.serialize(),
+        META_INFO: missionEntries,
+        pageSize: LC.TABLE_PAGESIZE
+    };
+    return makeFileRequest('Raw Table', missionEntries['rawTableSource'], null, options);
+
+}

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
@@ -16,7 +16,7 @@ import {FilterInfo} from '../../../tables/FilterInfo.js';
 import {LC, getViewerGroupKey, removeTablesFromGroup} from '../LcManager.js';
 import {getTypeData} from './../LcUtil.jsx';
 
-const labelWidth = 90;
+const labelWidth = 100;
 
 export class LsstSdssSettingBox extends Component {
     constructor(props) {
@@ -36,19 +36,10 @@ export class LsstSdssSettingBox extends Component {
         const wrapperStyle = {margin: '3px 0'};
 
         var rightEntries = Object.keys(generalEntries).map((key) =>
-            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}/>
+            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle} style={{width: 80}}/>
         );
 
         const validFluxVals = get(missionEntries, LC.META_FLUX_NAMES, []);
-        rightEntries.unshift(
-            <SuggestBoxInputField key={LC.META_FLUX_CNAME}
-                fieldKey={LC.META_FLUX_CNAME} wrapperStyle={Object.assign(wrapperStyle)}
-                getSuggestions={(val) => {
-                    const suggestions =  validFluxVals && validFluxVals.filter((el) => {return el.startsWith(val);});
-                    return suggestions.length > 0 ? suggestions : validFluxVals;
-                }}
-            />
-        );
 
         var leftEntries = [
             <RadioGroupInputField key='band' fieldKey='band' wrapperStyle={wrapperStyle}
@@ -60,6 +51,13 @@ export class LsstSdssSettingBox extends Component {
                     {label: 'i', value: 'i'},
                     {label: 'z', value: 'z'}
                 ]}
+            />,
+            <SuggestBoxInputField key={LC.META_FLUX_CNAME}
+                fieldKey={LC.META_FLUX_CNAME} wrapperStyle={wrapperStyle}
+                getSuggestions={(val) => {
+                    const suggestions =  validFluxVals && validFluxVals.filter((el) => {return el.startsWith(val);});
+                    return suggestions.length > 0 ? suggestions : validFluxVals;
+                }}
             />
         ];
 
@@ -68,7 +66,7 @@ export class LsstSdssSettingBox extends Component {
         return (
             <FieldGroup groupKey={groupKey}
                         reducerFunc={lsstSdssReducer(missionEntries, generalEntries)} keepState={true}>
-                <div style={{display: 'flex', alignItems: 'flex-start'}} >
+                <div style={{display: 'flex', alignItems: 'flex-end'}} >
                     <div >
                         {leftEntries}
                     </div>
@@ -109,7 +107,7 @@ export const lsstSdssReducer = (missionEntries, generalEntries) => {
         const defValues = {
             band: Object.assign(getTypeData('band', '',
                 'LSST SDSS band',
-                'LSST Band:', 60)),
+                'LSST SDSS Band:', labelWidth)),
             [LC.META_FLUX_CNAME]: Object.assign(getTypeData(LC.META_FLUX_CNAME, '',
                 'Y column name',
                 'Periodic Column:', labelWidth),

--- a/src/firefly/js/ui/RadioGroupInputField.jsx
+++ b/src/firefly/js/ui/RadioGroupInputField.jsx
@@ -23,7 +23,7 @@ function handleOnChange(ev, params, fireValueChange) {
     var checked = ev.target.checked;
 
     if (checked) {
-        fireValueChange({ value: val });
+        fireValueChange({ value: val, valid: true});
     }
 }
 


### PR DESCRIPTION
The related ticket: [https://jira.lsstcorp.org/browse/DM-9348](https://jira.lsstcorp.org/browse/DM-9348)
Sample raw table for LSST_SDSS is attached to the ticket.

Refactored the code to support multiple missions (currently WISE and LSST SDSS)
- LcConverterFactory.js defines properties storing mission specific information
- It is assumed that each raw table contains time and at least one periodic column (we call it flux, but it can be anything)
- Each mission can have different UI to define those columns (upper part of result view)
- For LSST SDSS, the uploaded table contains all the bands, raw table is always filtered: band selection triggers table filter. It would be nice to have hidden filter for this case, which user can not remove. Currently, user can remove the filter, and band selection will not match the content of the table. 

