### PR TITLE
DM-9578: warning message does not disappear

### DIFF
--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -33,6 +33,7 @@ const makeInfoPopup = (mess,x,y) => <PointerPopup x={x} y={y} message={makeMessa
 
 function computeWarningXY(warnIcon) {
     var bodyRect = document.body.getBoundingClientRect();
+    if (!warnIcon) return {};
     var elemRect = warnIcon.getBoundingClientRect();
     var warningOffsetX = (elemRect.left - bodyRect.left) + warnIcon.offsetWidth / 2;
     var warningOffsetY = elemRect.top - bodyRect.top;
@@ -59,16 +60,15 @@ export class InputFieldView extends Component {
 
     componentDidUpdate() {
         var {infoPopup}= this.state;
-        if (infoPopup) {
+        if (infoPopup && this.warnIcon) {
             var {warningOffsetX, warningOffsetY}= computeWarningXY(this.warnIcon);
             var {message}= this.props;
+            if (this.hider) this.hider();
             this.hider = DialogRootContainer.showTmpPopup(makeInfoPopup(message, warningOffsetX, warningOffsetY));
         }
-        else {
-            if (this.hider) {
-                this.hider();
-                this.hider = null;
-            }
+        else if (this.hider) {
+            this.hider();
+            this.hider = null;
         }
     }
 


### PR DESCRIPTION
 - even with valid data if the mouse is covering the warning icon

_to test:_

 - bring up firefly and go to a input field such as a target input field
 - enter an invalid target
 - place mouse over warning icon so that you see the message
 - with out moving the mouse, then enter a valid target (such as `m31`)
 - the warning icon and the popup message should go away. 