### PR TITLE
DM-9359: Fixed: Restoring coverage image after cropping it shows an empty tab entitled 'FITS data

### DIFF
--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -27,8 +27,8 @@ import {dispatchAttachLayerToPlot,
         dispatchCreateDrawLayer,
         dispatchDetachLayerFromPlot,
         DRAWING_LAYER_KEY} from './DrawLayerCntlr.js';
-import {dispatchReplaceViewerItems, getExpandedViewerItemIds,
-         getMultiViewRoot, EXPANDED_MODE_RESERVED} from './MultiViewCntlr.js';
+import {dispatchReplaceViewerItems, getExpandedViewerItemIds, findViewerWithItemId,
+         getMultiViewRoot, EXPANDED_MODE_RESERVED, IMAGE} from './MultiViewCntlr.js';
 
 import {zoomActionCreator} from './ZoomUtil.js';
 import {plotImageMaskActionCreator,
@@ -854,15 +854,16 @@ function restoreDefaultsActionCreator(rawAction) {
             (pv)=> {
                 if (vr.plotRequestDefaults[pv.plotId]) {
                     const def= vr.plotRequestDefaults[pv.plotId];
+                    const viewerId= findViewerWithItemId(getMultiViewRoot(), pv.plotId, IMAGE);
                     if (def.threeColor) {
-                        dispatchPlotImage({plotId:pv.plotId, 
-                                           wpRequest:[def.redReq,def.greenReq,def.blueReq],
+                        dispatchPlotImage({plotId:pv.plotId,
+                                           viewerId, wpRequest:[def.redReq,def.greenReq,def.blueReq],
                                            threeColor:true,
                                            useContextModifications:false});
                     }
                     else {
                         dispatchPlotImage({plotId:pv.plotId, wpRequest:def.wpRequest,
-                                           useContextModifications:false});
+                                           viewerId, useContextModifications:false});
                     }
                 }
             });


### PR DESCRIPTION
_To test, just follow the ticket description._

When doing a catalog search, the result tri-view shows image, table and xy-plot.
The image is called 'Coverage'.  Using the selection tool and cropping part of the image, the result is a smaller image which is correct.

Then when trying to go back and restore to default image (click the "Restore" button on the toolbar), the result is 2 tabs, one with the coverage restored correctly and another one called 'FITS data' empty and active.