### PR TITLE
DM-9491 Add support for generic time series tables in the TS viewer

### DIFF
--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -19,5 +19,6 @@ export const MetaConst = {
     POSITION_COORD: 'positionCoord',
     DATASET_CONVERTER : 'datasetInfoConverterId',
     DEFAULT_COLOR : 'DEFAULT_COLOR',
-    DATA_SOURCE : 'DataSource'
+    DATA_SOURCE : 'DataSource',
+    TS_DATASET : 'TSDatasetId'
 };

--- a/src/firefly/js/fieldGroup/FieldGroupCntlr.js
+++ b/src/firefly/js/fieldGroup/FieldGroupCntlr.js
@@ -118,9 +118,9 @@ export function dispatchInitFieldGroup(groupKey,keepState=false,
  */
 export function dispatchMountFieldGroup(groupKey, mounted, keepState= false, 
                                         initValues=null, reducerFunc= null,
-                                        actionTypes=[], wrapperGroupKey) {
+                                        actionTypes=[], wrapperGroupKey, forceUnmount = false) {
     flux.process({type: MOUNT_FIELD_GROUP, payload: {groupKey, mounted, initValues, reducerFunc, 
-                                                     actionTypes, keepState, wrapperGroupKey} });
+                                                     actionTypes, keepState, wrapperGroupKey, forceUnmount} });
 }
 
 
@@ -340,7 +340,7 @@ function initFieldGroup(state,action) {
 }
 
 const updateFieldGroupMount= function(state,action) {
-    var {groupKey, mounted, initValues, wrapperGroupKey}= action.payload;
+    var {groupKey, mounted, initValues, wrapperGroupKey, forceUnmount}= action.payload;
     if (!groupKey) return state;
 
     var retState= state;
@@ -365,7 +365,7 @@ const updateFieldGroupMount= function(state,action) {
     else {
         if (isFieldGroupDefined(state,groupKey)) {
             var fg= findAndCloneFieldGroup(state, groupKey, {mounted:false});
-            if (!fg.keepState) fg.fields= null;
+            if (!fg.keepState || forceUnmount) fg.fields= null;
             retState= clone(state,{[groupKey]:fg});
         }
     }

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -5,14 +5,14 @@
 import {get} from 'lodash';
 import {TitleOptions} from '../../visualize/WebPlotRequest.js';
 import {logError} from '../../util/WebUtil.js';
-
-import {DefaultSettingBox, defaultOnNewRawTable, defaultOnFieldUpdate, defaultRawTableRequest} from './DefaultMissionOptions.js';
-import {getWebPlotRequestViaWISEIbe} from './wise/WisePlotRequests.js';  //WiseRequestList.js
-import {makeLsstSdssPlotRequest} from './lsst_sdss/LsstSdssPlotRequests.js'; //LsstSdssRequestList.js';
+import {getWebPlotRequestViaWISEIbe} from './wise/WisePlotRequests.js';
+import {makeLsstSdssPlotRequest} from './lsst_sdss/LsstSdssPlotRequests.js';
+import {makeURLPlotRequest} from './generic/DefaultPlotRequests.js';
 import {LsstSdssSettingBox, lsstSdssOnNewRawTable, lsstSdssOnFieldUpdate, lsstSdssRawTableRequest} from './lsst_sdss/LsstSdssMissionOptions.js';
+import {WiseSettingBox, wiseOnNewRawTable, wiseOnFieldUpdate, wiseRawTableRequest} from './wise/WiseMissionOptions.js';
+import {DefaultSettingBox, defaultOnNewRawTable, defaultOnFieldUpdate, defaultRawTableRequest} from './generic/DefaultMissionOptions.js';
 
-
-
+export const UNKNOWN_MISSION = 'generic';
 /**
  * A function to create a WebPlotRequest from the given parameters
  * @callback WebplotRequestCreator
@@ -73,10 +73,10 @@ const converters = {
         defaultYCname: 'w1mpro_ep',
         defaultYErrCname: '',
         missionName: 'WISE',
-        MissionOptions: DefaultSettingBox,
-        onNewRawTable: defaultOnNewRawTable,
-        onFieldUpdate: defaultOnFieldUpdate,
-        rawTableRequest: defaultRawTableRequest,
+        MissionOptions: WiseSettingBox,
+        onNewRawTable: wiseOnNewRawTable,
+        onFieldUpdate: wiseOnFieldUpdate,
+        rawTableRequest: wiseRawTableRequest,
         timeNames: ['mjd'],
         yNames: ['w1mpro_ep', 'w2mpro_ep', 'w3mpro_ep', 'w4mpro_ep'],
         yErrNames: ['w1sigmpro_ep', 'w2sigmpro_ep', 'w3sigmpro_ep', 'w4sigmpro_ep'],
@@ -97,6 +97,20 @@ const converters = {
         yNames: ['mag', 'tsv_flux'],
         yErrNames: ['magErr', 'tsv_fluxErr'],
         webplotRequestCreator: makeLsstSdssPlotRequest
+    },
+    [UNKNOWN_MISSION]: {
+        converterId: UNKNOWN_MISSION,
+        defaultImageCount: 3,
+        defaultTimeCName: 'mjd',
+        defaultYCname: 'value',
+        defaultYErrCname: '',
+        missionName: '',
+        MissionOptions: DefaultSettingBox,
+        onNewRawTable: defaultOnNewRawTable,
+        onFieldUpdate: defaultOnFieldUpdate,
+        rawTableRequest: defaultRawTableRequest,
+        dataSource: 'img_url',
+        webplotRequestCreator: makeURLPlotRequest
     }
 };
 
@@ -104,7 +118,7 @@ export function getAllConverterIds() {
     return Object.keys(converters);
 }
 
-export function getConverter(converterId) {
+export function getConverter(converterId = UNKNOWN_MISSION) {
     const converter = converterId && converters[converterId];
     if (!converter) {
         logError(`Unable to find dataset converter ${converterId}`);

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -13,6 +13,8 @@ import {WiseSettingBox, wiseOnNewRawTable, wiseOnFieldUpdate, wiseRawTableReques
 import {DefaultSettingBox, defaultOnNewRawTable, defaultOnFieldUpdate, defaultRawTableRequest} from './generic/DefaultMissionOptions.js';
 
 export const UNKNOWN_MISSION = 'generic';
+export const COORD_SYSTEM_OPTIONS = ['EQ_J2000', 'EQ_B1950', 'GALACTIC'];
+export const coordSysOptions = 'coordSysOptions';
 /**
  * A function to create a WebPlotRequest from the given parameters
  * @callback WebplotRequestCreator
@@ -101,15 +103,19 @@ const converters = {
     [UNKNOWN_MISSION]: {
         converterId: UNKNOWN_MISSION,
         defaultImageCount: 3,
-        defaultTimeCName: 'mjd',
-        defaultYCname: 'value',
+        defaultTimeCName: '',
+        defaultYCname: '',
         defaultYErrCname: '',
         missionName: '',
+        defaultCoordX: '',
+        defaultCoordY: '',
+        defaultCoordSys: '',
         MissionOptions: DefaultSettingBox,
         onNewRawTable: defaultOnNewRawTable,
         onFieldUpdate: defaultOnFieldUpdate,
         rawTableRequest: defaultRawTableRequest,
-        dataSource: 'img_url',
+        dataSource: '',
+        [coordSysOptions]: COORD_SYSTEM_OPTIONS,
         webplotRequestCreator: makeURLPlotRequest
     }
 };
@@ -119,7 +125,7 @@ export function getAllConverterIds() {
 }
 
 export function getConverter(converterId = UNKNOWN_MISSION) {
-    const converter = converterId && converters[converterId];
+    const converter = converters[converterId];
     if (!converter) {
         logError(`Unable to find dataset converter ${converterId}`);
         return;

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -13,7 +13,7 @@ import HelpIcon from '../../ui/HelpIcon.jsx';
 import {RangeSlider}  from '../../ui/RangeSlider.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {ValidationField} from '../../ui/ValidationField.jsx';
-import {showInfoPopup} from '../../ui/PopupUtil.jsx';
+import {showInfoPopup, INFO_POPUP} from '../../ui/PopupUtil.jsx';
 import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import Validate from '../../util/Validate.js';
 import {dispatchActiveTableChanged} from '../../tables/TablesCntlr.js';
@@ -25,7 +25,7 @@ import {doPFCalculate, getPhase} from './LcPhaseTable.js';
 import {LcPeriodogram, cancelPeriodogram, popupId} from './LcPeriodogram.jsx';
 import {ReadOnlyText, getTypeData} from './LcUtil.jsx';
 import {LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
-import {isDialogVisible} from '../../core/ComponentCntlr.js';
+import {isDialogVisible, dispatchHideDialog} from '../../core/ComponentCntlr.js';
 import {updateSet} from '../../util/WebUtil.js';
 import ReactHighcharts from 'react-highcharts';
 import Resizable from 'react-component-resizable';
@@ -187,7 +187,7 @@ LcPeriod.defaultProps = {
  */
 function cancelStandard() {
     if (isDialogVisible(popupId)) {
-        cancelPeriodogram(pfinderkey, popupId)();
+        cancelPeriodogram();
     }
 
     updateLayoutDisplay(LC.RESULT_PAGE);
@@ -911,7 +911,10 @@ function setPFTableSuccess() {
         doPFCalculate(flux, timeName, period, tzero);
 
         if (isDialogVisible(popupId)) {
-            cancelPeriodogram(pfinderkey, popupId)();
+            cancelPeriodogram();
+        }
+        if (isDialogVisible(INFO_POPUP)) {
+            dispatchHideDialog(INFO_POPUP);
         }
     };
 }

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -123,7 +123,7 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
 
     const cutoutSize = get(settingBox, 'props.generalEntries.cutoutSize', '0.3');
     const converterId = get(settingBox, ['props', 'missionEntries', LC.META_MISSION]);
-    const mission = get(getMissionName(converterId), 'mission', 'Mission');
+    const mission = getMissionName(converterId) || 'Mission';
 
     return (
         <div style={{display: 'flex', flexDirection: 'column', flexGrow: 1, position: 'relative'}}>

--- a/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
@@ -9,9 +9,10 @@ import {getColumnIdx, getTblById} from '../../../tables/TableUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {ReadOnlyText, getTypeData} from '../LcUtil.jsx';
 import {LC, getViewerGroupKey} from '../LcManager.js';
-import {getMissionName} from '../LcConverterFactory.js';
+import {getMissionName, coordSysOptions} from '../LcConverterFactory.js';
 
 const labelWidth = 90;
+
 
 export class DefaultSettingBox extends Component {
     constructor(props) {
@@ -28,12 +29,12 @@ export class DefaultSettingBox extends Component {
         if (isEmpty(generalEntries) || isEmpty(missionEntries)) return false;
 
         const wrapperStyle = {margin: '3px 0'};
-
+/*
         var allCommonEntries = Object.keys(generalEntries).map((key) =>
             <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
                              style={{width: 80}}/>
         );
-
+*/
         const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME];
         const missionOtherKeys = [ LC.META_URL_CNAME, LC.META_ERR_CNAME];
         const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
@@ -52,6 +53,19 @@ export class DefaultSettingBox extends Component {
             <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}/>
         );
 
+        var missionPosEntries = () => {
+            var sKey = LC.META_COORD_SYS;
+
+            var sysCol = (
+                <SuggestBoxInputField key={sKey} fieldKey={sKey} wrapperStyle={wrapperStyle}
+                                      getSuggestions={() =>get(missionEntries, coordSysOptions, [])} />
+            );
+            var xyCols = [LC.META_COORD_XNAME, LC.META_COORD_YNAME].map((key) =>
+                <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle} />
+            );
+
+            return [sysCol, xyCols];
+        };
 
         const groupKey = getViewerGroupKey(missionEntries);
         const converterId = get(missionEntries, LC.META_MISSION);
@@ -59,16 +73,17 @@ export class DefaultSettingBox extends Component {
         return (
             <FieldGroup groupKey={groupKey}
                         reducerFunc={defaultOptionsReducer(missionEntries, generalEntries)} keepState={true}>
-                <div style={{display: 'flex', alignItems: 'flex-end'}} >
-                    <div >
-                        <ReadOnlyText label='Mission:' content={getMissionName(converterId)}
-                                      labelWidth={labelWidth} wrapperStyle={{margin: '3px 0 6px 0'}}/>
-
-                        {missionInputs}
-                        {missionOthers}
-                    </div>
-                    <div>
-                        {allCommonEntries}
+                <div style={{display: 'flex', flexDirection: 'column'}} >
+                    <ReadOnlyText label='Mission:' content={getMissionName(converterId)}
+                                  labelWidth={labelWidth} wrapperStyle={{margin: '3px 0 6px 0'}}/>
+                    <div style={{display: 'flex'}}>
+                        <div>
+                            {missionInputs}
+                            {missionOthers}
+                        </div>
+                        <div>
+                            {missionPosEntries()}
+                        </div>
                     </div>
                 </div>
             </FieldGroup>
@@ -118,13 +133,23 @@ export const defaultOptionsReducer = (missionEntries, generalEntries) => {
                 'Error Column:', labelWidth)),
             [LC.META_URL_CNAME]: Object.assign(getTypeData(LC.META_URL_CNAME, '',
                 'Image url column name',
-                'Source Column:', labelWidth))
+                'Source Column:', labelWidth)),
+            [LC.META_COORD_XNAME]: Object.assign(getTypeData(LC.META_COORD_XNAME, '',
+                'Coordinate X column name',
+                'X Column:', labelWidth)),
+            [LC.META_COORD_YNAME]: Object.assign(getTypeData(LC.META_COORD_YNAME, '',
+                'Coordinate Y column name',
+                'Y Column:', labelWidth)),
+            [LC.META_COORD_SYS]: Object.assign(getTypeData(LC.META_COORD_SYS, '',
+                'Coordinate system',
+                'Coord System:', labelWidth))
         };
 
         var   defV = Object.assign({}, defValues);
         const validators = getFieldValidators(missionEntries, getTblById(LC.RAW_TABLE));
 
-        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_URL_CNAME, LC.META_ERR_CNAME];
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_URL_CNAME, LC.META_ERR_CNAME,
+                             LC.META_COORD_XNAME, LC.META_COORD_YNAME, LC.META_COORD_SYS];
         const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
 
         missionListKeys.forEach((key) => {
@@ -138,9 +163,12 @@ export const defaultOptionsReducer = (missionEntries, generalEntries) => {
                 set(defV, [key, 'validator'], validators[key]);
             }
         });
+
+        /*
         Object.keys(generalEntries).forEach((key) => {
             set(defV, [key, 'value'], get(generalEntries, key, ''));
         });
+        */
         return defV;
     };
 };
@@ -151,7 +179,10 @@ function getFieldValidators(missionEntries, rawTable) {
     const fldsWithValidators = [
         {key: LC.META_TIME_CNAME, vkey: LC.META_TIME_NAMES},
         {key: LC.META_FLUX_CNAME, vkey: LC.META_FLUX_NAMES},
-        {key: LC.META_URL_CNAME}
+        {key: LC.META_URL_CNAME},
+        {key: LC.META_COORD_XNAME},
+        {key: LC.META_COORD_YNAME},
+        {key: LC.META_COORD_SYS, vkey: coordSysOptions}
         //{key: LC.META_ERR_CNAME, vkey: LC.META_ERR_NAMES} // error can have no value
         ];
     return fldsWithValidators.reduce((all, fld) => {
@@ -172,28 +203,28 @@ function getFieldValidators(missionEntries, rawTable) {
     }, {});
 }
 
-/*
-function setFields(missionEntries, generalEntries, rawTable) {
-    const groupKey = getViewerGroupKey(missionEntries);
-    const fields = FieldGroupUtils.getGroupFields(groupKey);
-    const validators = getFieldValidators(missionEntries, rawTable);
-    if (fields) {
-        const initState = Object.keys(fields).reduce((prev, fieldKey) => {
-            if (has(missionEntries, fieldKey)) {
-                prev.push({fieldKey, value: get(missionEntries, fieldKey), validator: validators[fieldKey]});
-            } else if (has(generalEntries,fieldKey)) {
-                prev.push({fieldKey, value: get(generalEntries, fieldKey)});
-            }
-            return prev;
-        }, []);
-        dispatchMultiValueChange(groupKey, initState);
+const posColumnInfo = (posCoords) => {
+    const posElement = [LC.META_COORD_XNAME, LC.META_COORD_YNAME, LC.META_COORD_SYS];
+    var posInfo = posElement.reduce((prev, ele) => {
+        prev[ele] = '';
+        return prev;
+    }, {});
+
+    if (posCoords) {
+        var s = posCoords.split(';');
+        if (s && s.length === 3) {
+            s.forEach((ele, idx) => posInfo[posElement[idx]] = ele);
+        }
     }
-}
-*/
+
+    return posInfo;
+};
 
 
 export function defaultOnNewRawTable(rawTable, converterData) {
     const metaInfo = rawTable && rawTable.tableMeta;
+    var posInfo = posColumnInfo(get(metaInfo, LC.META_POS_COORD));
+
     const missionEntries = {
         [LC.META_MISSION]: converterData.converterId,
         [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, converterData.defaultTimeCName),
@@ -202,7 +233,11 @@ export function defaultOnNewRawTable(rawTable, converterData) {
         [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES),
         [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES),
         [LC.META_ERR_NAMES]: get(metaInfo, LC.META_ERR_NAMES),
-        [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, converterData.dataSource)
+        [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, converterData.dataSource),
+        [LC.META_COORD_XNAME]: get(posInfo, LC.META_COORD_XNAME),
+        [LC.META_COORD_YNAME]: get(posInfo, LC.META_COORD_YNAME),
+        [LC.META_COORD_SYS]: get(posInfo, LC.META_COORD_SYS),
+        [coordSysOptions]: get(converterData, coordSysOptions)
     };
     return missionEntries;
 }
@@ -219,7 +254,8 @@ export function defaultRawTableRequest(converter, source) {
 }
 
 export function defaultOnFieldUpdate(fieldKey, value) {
-    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME].includes(fieldKey)) {
+    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME,
+            LC.META_COORD_XNAME, LC.META_COORD_YNAME, LC.META_COORD_SYS].includes(fieldKey)) {
         return {[fieldKey] : value};
     }
 }

--- a/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
@@ -1,0 +1,225 @@
+import React, {Component, PropTypes} from 'react';
+import sCompare from 'react-addons-shallow-compare';
+import {get, has, isEmpty, set} from 'lodash';
+import {FieldGroup} from '../../../ui/FieldGroup.jsx';
+import {ValidationField} from '../../../ui/ValidationField.jsx';
+import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
+import {makeFileRequest} from '../../../tables/TableUtil.js';
+import {getColumnIdx, getTblById} from '../../../tables/TableUtil.js';
+import {sortInfoString} from '../../../tables/SortInfo.js';
+import {ReadOnlyText, getTypeData} from '../LcUtil.jsx';
+import {LC, getViewerGroupKey} from '../LcManager.js';
+import {getMissionName} from '../LcConverterFactory.js';
+
+const labelWidth = 90;
+
+export class DefaultSettingBox extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+    render() {
+        var {generalEntries, missionEntries} = this.props;
+
+        if (isEmpty(generalEntries) || isEmpty(missionEntries)) return false;
+
+        const wrapperStyle = {margin: '3px 0'};
+
+        var allCommonEntries = Object.keys(generalEntries).map((key) =>
+            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
+                             style={{width: 80}}/>
+        );
+
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME];
+        const missionOtherKeys = [ LC.META_URL_CNAME, LC.META_ERR_CNAME];
+        const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
+
+        var missionInputs = missionKeys.map((key, index) =>
+            <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
+                                  getSuggestions={(val) => {
+                                    const list = get(missionEntries, missionListKeys[index], []);
+                                    const suggestions =  list && list.filter((el) => {return el.startsWith(val);});
+                                    return suggestions.length > 0 ? suggestions : list;
+                                  }}
+            />
+        );
+
+        var missionOthers = missionOtherKeys.map((key) =>
+            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}/>
+        );
+
+
+        const groupKey = getViewerGroupKey(missionEntries);
+        const converterId = get(missionEntries, LC.META_MISSION);
+
+        return (
+            <FieldGroup groupKey={groupKey}
+                        reducerFunc={defaultOptionsReducer(missionEntries, generalEntries)} keepState={true}>
+                <div style={{display: 'flex', alignItems: 'flex-end'}} >
+                    <div >
+                        <ReadOnlyText label='Mission:' content={getMissionName(converterId)}
+                                      labelWidth={labelWidth} wrapperStyle={{margin: '3px 0 6px 0'}}/>
+
+                        {missionInputs}
+                        {missionOthers}
+                    </div>
+                    <div>
+                        {allCommonEntries}
+                    </div>
+                </div>
+            </FieldGroup>
+        );
+    }
+}
+
+DefaultSettingBox.propTypes = {
+    generalEntries: PropTypes.object,
+    missionEntries: PropTypes.object
+};
+
+
+export const defaultOptionsReducer = (missionEntries, generalEntries) => {
+    return (inFields, action) => {
+        if (inFields) {
+            return inFields;
+        }
+
+        // defValues used to keep the initial values for parameters in the field group of result page
+        // time: time column
+        // flux: flux column
+        // timecols:  time column candidates
+        // fluxcols:  flux column candidates
+        // errorcolumm: error column
+        // cutoutsize: image cutout size
+        const defValues = {
+            [LC.META_TIME_CNAME]: Object.assign(getTypeData(LC.META_TIME_CNAME, '',
+                'Time column name',
+                'Time Column:', labelWidth),
+                {validator: null}),
+            [LC.META_FLUX_CNAME]: Object.assign(getTypeData(LC.META_FLUX_CNAME, '',
+                'Value column name',
+                'Value Column:', labelWidth),
+                {validator: null}),
+            [LC.META_TIME_NAMES]: Object.assign(getTypeData(LC.META_TIME_NAMES, '',
+                'Value column suggestion'),
+                {validator: null}),
+            [LC.META_FLUX_NAMES]: Object.assign(getTypeData(LC.META_FLUX_NAMES, '',
+                'Value column suggestion'),
+                {validator: null}),
+            ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
+                'image cutout size',
+                'Cutout Size (deg):', 100)),
+            [LC.META_ERR_CNAME]: Object.assign(getTypeData(LC.META_ERR_CNAME, '',
+                'flux error column name',
+                'Error Column:', labelWidth)),
+            [LC.META_URL_CNAME]: Object.assign(getTypeData(LC.META_URL_CNAME, '',
+                'Image url column name',
+                'Source Column:', labelWidth))
+        };
+
+        var   defV = Object.assign({}, defValues);
+        const validators = getFieldValidators(missionEntries, getTblById(LC.RAW_TABLE));
+
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_URL_CNAME, LC.META_ERR_CNAME];
+        const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
+
+        missionListKeys.forEach((key) => {
+            set(defV, [key, 'value'], get(missionEntries, key, []));
+        });
+
+        // set value and validator
+        missionKeys.forEach((key) => {
+            set(defV, [key, 'value'], get(missionEntries, key, ''));
+            if (has(validators, key)) {
+                set(defV, [key, 'validator'], validators[key]);
+            }
+        });
+        Object.keys(generalEntries).forEach((key) => {
+            set(defV, [key, 'value'], get(generalEntries, key, ''));
+        });
+        return defV;
+    };
+};
+
+
+
+function getFieldValidators(missionEntries, rawTable) {
+    const fldsWithValidators = [
+        {key: LC.META_TIME_CNAME, vkey: LC.META_TIME_NAMES},
+        {key: LC.META_FLUX_CNAME, vkey: LC.META_FLUX_NAMES},
+        {key: LC.META_URL_CNAME}
+        //{key: LC.META_ERR_CNAME, vkey: LC.META_ERR_NAMES} // error can have no value
+        ];
+    return fldsWithValidators.reduce((all, fld) => {
+        all[fld.key] =
+            (val) => {
+                let retVal = {valid: true, message: ''};
+                const cols = get(missionEntries, fld.vkey, []);
+                if (cols.length === 0 && rawTable) {
+                    if (getColumnIdx(rawTable, val) < 0) {
+                        retVal = {valid: false, message: `${val} is not a valid column name`};
+                    }
+                } else if (!cols.includes(val)) {
+                    retVal = {valid: false, message: `${val} is not a valid column name`};
+                }
+                return retVal;
+            };
+        return all;
+    }, {});
+}
+
+/*
+function setFields(missionEntries, generalEntries, rawTable) {
+    const groupKey = getViewerGroupKey(missionEntries);
+    const fields = FieldGroupUtils.getGroupFields(groupKey);
+    const validators = getFieldValidators(missionEntries, rawTable);
+    if (fields) {
+        const initState = Object.keys(fields).reduce((prev, fieldKey) => {
+            if (has(missionEntries, fieldKey)) {
+                prev.push({fieldKey, value: get(missionEntries, fieldKey), validator: validators[fieldKey]});
+            } else if (has(generalEntries,fieldKey)) {
+                prev.push({fieldKey, value: get(generalEntries, fieldKey)});
+            }
+            return prev;
+        }, []);
+        dispatchMultiValueChange(groupKey, initState);
+    }
+}
+*/
+
+
+export function defaultOnNewRawTable(rawTable, converterData) {
+    const metaInfo = rawTable && rawTable.tableMeta;
+    const missionEntries = {
+        [LC.META_MISSION]: converterData.converterId,
+        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, converterData.defaultTimeCName),
+        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, converterData.defaultYCname),
+        [LC.META_ERR_CNAME]: get(metaInfo, LC.META_ERR_CNAME, converterData.defaultYErrCname),
+        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES),
+        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES),
+        [LC.META_ERR_NAMES]: get(metaInfo, LC.META_ERR_NAMES),
+        [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, converterData.dataSource)
+    };
+    return missionEntries;
+}
+
+export function defaultRawTableRequest(converter, source) {
+    const options = {
+        tbl_id: LC.RAW_TABLE,
+        sortInfo: sortInfoString('mjd'),   //TODO: tentative solution to get around 'ROWID' issue
+        tblType: 'notACatalog',
+        pageSize: LC.TABLE_PAGESIZE
+    };
+    return makeFileRequest('Input Data', source, null, options);
+
+}
+
+export function defaultOnFieldUpdate(fieldKey, value) {
+    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME].includes(fieldKey)) {
+        return {[fieldKey] : value};
+    }
+}

--- a/src/firefly/js/templates/lightcurve/generic/DefaultPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/generic/DefaultPlotRequests.js
@@ -1,0 +1,25 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {getCellValue, getColumnIdx} from '../../../tables/TableUtil.js';
+import {WebPlotRequest} from '../../../visualize/WebPlotRequest.js';
+import {makeWorldPt} from '../../../visualize/Point.js';
+import {CoordinateSys} from '../../../visualize/CoordSys.js';
+import {addCommonReqParams} from '../LcConverterFactory.js';
+
+export function makeURLPlotRequest(table, rowIdx, cutoutSize, params) {
+    const {dataSource, timeCol} = params;
+
+    // not change the current plots in case dataSource or time column does not exist
+    if (getColumnIdx(table, dataSource) < 0 || getColumnIdx(table, timeCol) < 0) return null;
+
+    const ra = getCellValue(table, rowIdx, 'ra');
+    const dec = getCellValue(table, rowIdx, 'dec');
+    const url = getCellValue(table, rowIdx, dataSource );
+    const time = getCellValue(table, rowIdx, timeCol);
+    const plot_desc = `Mission-${rowIdx}`;
+
+    const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);
+    const title= `Mission- ${time}`+ (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+    return addCommonReqParams(reqParams, title, makeWorldPt(ra,dec,CoordinateSys.EQ_J2000));
+}

--- a/src/firefly/js/templates/lightcurve/generic/DefaultPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/generic/DefaultPlotRequests.js
@@ -5,21 +5,22 @@ import {getCellValue, getColumnIdx} from '../../../tables/TableUtil.js';
 import {WebPlotRequest} from '../../../visualize/WebPlotRequest.js';
 import {makeWorldPt} from '../../../visualize/Point.js';
 import {CoordinateSys} from '../../../visualize/CoordSys.js';
-import {addCommonReqParams} from '../LcConverterFactory.js';
+import {addCommonReqParams, COORD_SYSTEM_OPTIONS} from '../LcConverterFactory.js';
 
 export function makeURLPlotRequest(table, rowIdx, cutoutSize, params) {
-    const {dataSource, timeCol} = params;
+    const {dataSource, timeCol, ra, dec, coordSys} = params;
 
-    // not change the current plots in case dataSource or time column does not exist
-    if (getColumnIdx(table, dataSource) < 0 || getColumnIdx(table, timeCol) < 0) return null;
-
-    const ra = getCellValue(table, rowIdx, 'ra');
-    const dec = getCellValue(table, rowIdx, 'dec');
+    // create plot request on either valid or invalid parameters
     const url = getCellValue(table, rowIdx, dataSource );
     const time = getCellValue(table, rowIdx, timeCol);
-    const plot_desc = `Mission-${rowIdx}`;
-
+    const plot_desc = `Mission-${time||'null'}-${dataSource||'null'}-${ra||'null'}-${dec||'null'}-${coordSys||'null'}`;
     const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);
-    const title= `Mission- ${time}`+ (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
-    return addCommonReqParams(reqParams, title, makeWorldPt(ra,dec,CoordinateSys.EQ_J2000));
+    const title= `Mission-${time||'null'}`;
+    const sys = COORD_SYSTEM_OPTIONS.includes(coordSys) ? CoordinateSys.parse(coordSys) : null;
+    const wpt = (getColumnIdx(table, ra) < 0 || getColumnIdx(table, dec) < 0 || !sys) ? undefined :
+                makeWorldPt(getCellValue(table, rowIdx, ra),
+                            getCellValue(table, rowIdx, dec),
+                            sys);
+
+    return addCommonReqParams(reqParams, title, wpt);
 }

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
@@ -1,9 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {get, has, isEmpty, set, omit} from 'lodash';
+import {get, isEmpty, set, omit} from 'lodash';
 import {getLayouInfo, dispatchUpdateLayoutInfo} from '../../../core/LayoutCntlr.js';
-import FieldGroupUtils from '../../../fieldGroup/FieldGroupUtils';
-import {dispatchMultiValueChange} from '../../../fieldGroup/FieldGroupCntlr.js';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
 import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
@@ -136,7 +134,7 @@ export const lsstSdssReducer = (missionEntries, generalEntries) => {
 };
 
 
-
+/*
 function setFields(missionEntries, generalEntries) {
     const groupKey = getViewerGroupKey(missionEntries);
     const fields = FieldGroupUtils.getGroupFields(groupKey);
@@ -152,10 +150,10 @@ function setFields(missionEntries, generalEntries) {
         dispatchMultiValueChange(groupKey, initState);
     }
 }
+*/
 
 
-
-export function lsstSdssOnNewRawTable(rawTable, converterData, generalEntries) {
+export function lsstSdssOnNewRawTable(rawTable, converterData) {
     const metaInfo = rawTable && rawTable.tableMeta;
     const missionEntries = {
         [LC.META_MISSION]: converterData.converterId,
@@ -168,7 +166,6 @@ export function lsstSdssOnNewRawTable(rawTable, converterData, generalEntries) {
         band: get(metaInfo, 'band', 'u'),
         rawTableSource: get(metaInfo, 'rawTableSource')
     };
-    setFields(missionEntries, generalEntries);
     return missionEntries;
 }
 
@@ -180,7 +177,6 @@ export function lsstSdssOnFieldUpdate(fieldKey, value) {
     if (fieldKey === 'band' || fieldKey === LC.META_TIME_CNAME) {
         removeTablesFromGroup();
         removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
-        var layoutInfo = getLayouInfo();
         dispatchUpdateLayoutInfo(Object.assign({}, layoutInfo, {showTables: false, showXyPlots: false, fullRawTable: null, missionEntries: {}}));  // clear full rawtable
         const treq = makeRawTableRequest(newMissionEntries);
         dispatchTableSearch(treq, {removable: true});

--- a/src/firefly/js/ui/PopupUtil.jsx
+++ b/src/firefly/js/ui/PopupUtil.jsx
@@ -8,7 +8,7 @@ import {PopupPanel} from './PopupPanel.jsx';
 import {dispatchShowDialog} from '../core/ComponentCntlr.js';
 import DialogRootContainer from './DialogRootContainer.jsx';
 
-const INFO_POPUP= 'InfoPopup';
+export const INFO_POPUP= 'InfoPopup';
 
 
 // ------------------------------------------------------------


### PR DESCRIPTION
The development includes:
- make UI for generic time series table, metadata tags for time column (ts_timeCName), flux column (ts_fluxCName) , image url(datasource)  and error column (ts_errorCName) can be specified in either table file or the UI. 
- add 'generic' category into the convert factory to cover the default setting for generic table in addition to WISE and LSST missions. 
- Create 'generic' directory to contain the development for generic table specific UI, table load query and plot query. Move 'WISE' relevant development to be under 'wise' directory.
- Fix periodogram table/peak table calculation error. (there was no periodogram table created for LSST). 
- clean the field values in the viewer group when a new raw table is uploaded. 
- period min/max on the periodogram calculation popup is set to be irrelevant to period min/max on the period finding panel. 

Test: 
- localhost:8080/firefly/ts.html, select 'Generic' from Mission and upload the test file, fout_ts.tbl as attached in https://jira.lsstcorp.org/browse/DM-9491.
