### PR TITLE
DM-9371 Display cutouts in LSST timeseries viewer

### DIFF
--- a/src/firefly/js/metaConvert/LsstSdssRequestList.js
+++ b/src/firefly/js/metaConvert/LsstSdssRequestList.js
@@ -8,6 +8,7 @@ import {ZoomType} from '../visualize/ZoomType.js';
 import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
 import {ServerRequest} from '../data/ServerRequest.js';
 import {ServerParams} from '../data/ServerParams.js';
+import {toMaxFixed} from '../util/MathUtil.js';
 
 /**
  * This method returns a WebRequest object
@@ -17,6 +18,9 @@ import {ServerParams} from '../data/ServerParams.js';
  * @returns {WebPlotRequest} a web plot request
  */
 const bandMap= {u:0, g:1,r:2,i:3, z:4};
+
+const DECDIGIT = 4;
+
 function makeWebRequest(sr,  plotId, title) {
     const r  = WebPlotRequest.makeProcessorRequest(sr, 'lsst-sdss');
     const rangeValues= RangeValues.makeRV({which:SIGMA, lowerValue:-2, upperValue:10, algorithm:STRETCH_LINEAR});
@@ -56,7 +60,8 @@ function makeCcdReqBuilder(table, rowIdx) {
     return (plotId, id, filterName) => {
         sr.setParam('filterName', `${filterName}`);
         const scienceCCCdId = id.toString();
-        const title =scienceCCCdId.substr(0, 4) + bandMap[filterName].toString() + scienceCCCdId.substr(5, 10)+'-'+filterName+(subsize ? ` size: ${subsize}(deg)` : '');
+        const title =scienceCCCdId.substr(0, 4) + bandMap[filterName].toString() + scienceCCCdId.substr(5, 10)+
+            '-'+filterName+(subsize ? ` size: ${toMaxFixed(subsize,DECDIGIT)}(deg)` : '');
         return makeWebRequest(sr, plotId,  title);
     };
 }
@@ -87,7 +92,7 @@ function makeCoadReqBuilder(table, rowIdx) {
     return (plotId, id, filterName) => {
         sr.setParam('filterName', `${filterName}`);
         const deepCoaddId = id + bandMap[filterName];
-        const title = deepCoaddId+'-'+filterName+(subsize ? ` size: ${subsize}(deg)` : '');
+        const title = deepCoaddId+'-'+filterName+(subsize ? ` size: ${toMaxFixed(subsize,DECDIGIT)}(deg)` : '');
         return makeWebRequest(sr, plotId,  title);
     };
 }

--- a/src/firefly/js/metaConvert/LsstSdssRequestList.js
+++ b/src/firefly/js/metaConvert/LsstSdssRequestList.js
@@ -1,11 +1,13 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
+import {get} from 'lodash';
 import {getCellValue} from '../tables/TableUtil.js';
 import {RangeValues,STRETCH_LINEAR,SIGMA} from '../visualize/RangeValues.js';
 import {ZoomType} from '../visualize/ZoomType.js';
 import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
 import {ServerRequest} from '../data/ServerRequest.js';
+import {ServerParams} from '../data/ServerParams.js';
 
 /**
  * This method returns a WebRequest object
@@ -38,16 +40,23 @@ function makeCcdReqBuilder(table, rowIdx) {
     const run= getCellValue(table, rowIdx, 'run');
     const field= getCellValue(table, rowIdx, 'field');
     const camcol= getCellValue(table, rowIdx, 'camcol');
+    const subsize = get(table, ['request', 'subsize']);
 
     const sr= new ServerRequest('LSSTImageSearch');
     sr.setParam('run', `${run}`);
     sr.setParam('camcol', `${camcol}`);
     sr.setParam('field', `${field}`);
+    if (subsize) {
+        sr.setParam('subsize', `${subsize}`);
+        sr.setParam([ServerParams.USER_TARGET_WORLD_PT], get(table, ['request', [ServerParams.USER_TARGET_WORLD_PT]]));
+        sr.setParam('imageId', getCellValue(table, rowIdx, 'scienceCcdExposureId'));
+        sr.setParam('imageType', 'calexp');
+    }
 
     return (plotId, id, filterName) => {
         sr.setParam('filterName', `${filterName}`);
         const scienceCCCdId = id.toString();
-        const title =scienceCCCdId.substr(0, 4) + bandMap[filterName].toString() + scienceCCCdId.substr(5, 10)+'-'+filterName;
+        const title =scienceCCCdId.substr(0, 4) + bandMap[filterName].toString() + scienceCCCdId.substr(5, 10)+'-'+filterName+(subsize ? ` size: ${subsize}(deg)` : '');
         return makeWebRequest(sr, plotId,  title);
     };
 }
@@ -61,18 +70,24 @@ function makeCcdReqBuilder(table, rowIdx) {
  */
 function makeCoadReqBuilder(table, rowIdx) {
 
-
     const tract= getCellValue(table, rowIdx, 'tract');
     const patch= getCellValue(table, rowIdx, 'patch');
+    const subsize = get(table, ['request', 'subsize']);
 
     const sr= new ServerRequest('LSSTImageSearch');
     sr.setParam('tract', `${tract}`);
     sr.setParam('patch', `${patch}`);
+    if (subsize) {
+        sr.setParam('subsize', `${subsize}`);
+        sr.setParam([ServerParams.USER_TARGET_WORLD_PT], get(table, ['request', [ServerParams.USER_TARGET_WORLD_PT]]));
+        sr.setParam('imageId', getCellValue(table, rowIdx, 'deepCoaddId'));
+        sr.setParam('imageType', 'deepCoadd');
+    }
 
     return (plotId, id, filterName) => {
         sr.setParam('filterName', `${filterName}`);
         const deepCoaddId = id + bandMap[filterName];
-        const title = deepCoaddId+'-'+filterName;
+        const title = deepCoaddId+'-'+filterName+(subsize ? ` size: ${subsize}(deg)` : '');
         return makeWebRequest(sr, plotId,  title);
     };
 }
@@ -92,8 +107,8 @@ export function makeLsstSdssPlotRequest(table, row, includeSingle, includeStanda
     var builder;
     var id;
     if (getCellValue(table, row, 'scienceCcdExposureId')) {
-          builder= makeCcdReqBuilder(table,row);
-         id= Number(getCellValue(table, row, 'scienceCcdExposureId'));
+        builder= makeCcdReqBuilder(table,row);
+        id= Number(getCellValue(table, row, 'scienceCcdExposureId'));
     }
     else {
         builder= makeCoadReqBuilder(table, row);
@@ -114,7 +129,7 @@ export function makeLsstSdssPlotRequest(table, row, includeSingle, includeStanda
             builder('lsst-sdss-g', id, 'g'),
             builder('lsst-sdss-r', id, 'r'),
             builder('lsst-sdss-i', id, 'i'),
-            builder('lsst-sdss-z', id, 'z'),
+            builder('lsst-sdss-z', id, 'z')
         ];
         if (retval.standard[filterId]) retval.highlightPlotId= retval.standard[filterId].getPlotId();
     }

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -84,7 +84,7 @@ const converters = {
     },
     'lsst_sdss': {
         converterId: 'lsst_sdss',
-        defaultImageCount: 1,
+        defaultImageCount: 3,
         defaultTimeCName: 'exposure_time_mid',
         defaultYCname: 'mag',
         defaultYErrCname: '',

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -221,8 +221,8 @@ function handleValueChange(layoutInfo, action) {
     if (fieldKey === 'cutoutSize') { // cutoutsize changes
         if ((get(layoutInfo, [LC.GENERAL_DATA, fieldKey]) !== value) && (value > 0.0) ) {
             if (get(layoutInfo, ['displayMode']) === LC.RESULT_PAGE) {
-                setupImages(layoutInfo);
                 layoutInfo = updateSet(layoutInfo, [LC.GENERAL_DATA, fieldKey], value);
+                setupImages(layoutInfo);
             }
         }
     } else {
@@ -298,7 +298,7 @@ function handleRawTableLoad(layoutInfo, tblId) {
         return;
     }
 
-    const generalEntries = getGeneralEntries();
+    const generalEntries = get(layoutInfo, LC.GENERAL_DATA, getGeneralEntries());
     const missionEntries = converterData.onNewRawTable(rawTable, converterData, generalEntries);
 
     defaultFlux = get(missionEntries, LC.META_FLUX_CNAME);

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssPlotRequests.js
@@ -6,6 +6,7 @@ import {RangeValues,STRETCH_LINEAR,SIGMA} from '../../../visualize/RangeValues.j
 import {WebPlotRequest} from '../../../visualize/WebPlotRequest.js';
 import {makeWorldPt} from '../../../visualize/Point.js';
 import {CoordinateSys} from '../../../visualize/CoordSys.js';
+import {ZoomType} from '../../../visualize/ZoomType.js';
 import {ServerRequest} from '../../../data/ServerRequest.js';
 
 import {addCommonReqParams} from '../LcConverterFactory.js';
@@ -25,31 +26,30 @@ export function makeLsstSdssPlotRequest(table, rowIdx, cutoutSize) {
     if (!id) {
         return; // error
     }
-    const run= getCellValue(table, rowIdx, 'run');
-    const field= getCellValue(table, rowIdx, 'field');
-    const camcol= getCellValue(table, rowIdx, 'camcol');
-
-    //const filterId= Number(getCellValue(table, rowIdx, 'filterId'));
+    const scienceCcdId = id.toString();
+    //const run= getCellValue(table, rowIdx, 'run');
+    //const field= getCellValue(table, rowIdx, 'field');
+    //const camcol= getCellValue(table, rowIdx, 'camcol');
     const filterName= getCellValue(table, rowIdx, 'filterName');
 
     // cutout center
     const ra = getCellValue(table, rowIdx, 'coord_ra');
     const decl = getCellValue(table, rowIdx, 'coord_decl');
 
-    // TODO: add support for cutouts
     const sr= new ServerRequest('LSSTImageSearch');
-    sr.setParam('run', `${run}`);
-    sr.setParam('camcol', `${camcol}`);
-    sr.setParam('field', `${field}`);
-    sr.setParam('filterName', `${filterName}`);
+    sr.setParam('imageType', 'calexp');
+    sr.setParam('imageId', scienceCcdId);
+    sr.setParam('ra', ra);
+    sr.setParam('dec', decl);
+    sr.setParam('subsize', `${cutoutSize}`); // in degrees
 
-    const scienceCcdId = id.toString();
     const title =scienceCcdId.substr(0, 4) + bandMap[filterName].toString() + scienceCcdId.substr(5, 10)+'-'+filterName+(cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
-    const plot_desc = `lsst-sdss-${run}`;
+    const plot_desc = `lsst-sdss-${scienceCcdId}`;
 
     const r  = WebPlotRequest.makeProcessorRequest(sr, plot_desc);
     const rangeValues= RangeValues.makeRV({which:SIGMA, lowerValue:-2, upperValue:10, algorithm:STRETCH_LINEAR});
     r.setInitialRangeValues(rangeValues);
+    r.setZoomType(ZoomType.TO_WIDTH);
 
     return addCommonReqParams(r, title, makeWorldPt(ra,decl,CoordinateSys.EQ_J2000));
 }

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -6,6 +6,7 @@ import {convertAngle} from '../visualize/VisUtil.js';
 import {InputFieldView} from './InputFieldView.jsx';
 import {ListBoxInputFieldView} from './ListBoxInputField.jsx';
 import Validate from '../util/Validate.js';
+import {toMaxFixed} from '../util/MathUtil.js';
 import validator from 'validator';
 
 const invalidSizeMsg = 'size is not set properly or size is out of range';
@@ -16,20 +17,13 @@ function getUnit(unit) {
     return unitSign[unit];
 }
 
-/*
- * remove trailing zero from toFixed result
- */
-function toMaxFixed(floatNum, digits) {
-    return parseFloat(floatNum.toFixed(digits));
-}
-
 // input: string format,
 // output: size in degree (string foramt, no decimal digit limit), '': invalid input
 export const sizeToDeg = (sizestr, unit) => {
     if (sizestr && !validator.isFloat(sizestr)) {
         return sizestr;
     }
-    return (sizestr) ? toMaxFixed(convertAngle(((unit) ? unit : 'deg'), 'deg', sizestr), DECDIGIT).toString() : '';
+    return (sizestr) ? convertAngle(((unit) ? unit : 'deg'), 'deg', sizestr).toString() : '';
 };
 
 // input: size in degree string format

--- a/src/firefly/js/util/MathUtil.js
+++ b/src/firefly/js/util/MathUtil.js
@@ -1,13 +1,10 @@
-/**
- * @author tatianag
- */
 /*
  Get the format string for a number, given an interval between the adjacent numbers
  and the number of significant digits you'd like to preserve in this interval
  */
 export const getFormatString = function(range, numSigDigits) {
 
-    if (range==0) { return '0'; }
+    if (range===0) { return '0'; }
 
     var format; // string format
 
@@ -32,3 +29,9 @@ export const getFormatString = function(range, numSigDigits) {
     return format;
 };
 
+/*
+ * remove trailing zero from toFixed result
+ */
+export function toMaxFixed(floatNum, digits) {
+    return parseFloat(Number(floatNum).toFixed(digits));
+}

--- a/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
+++ b/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
@@ -69,7 +69,7 @@ export class LSSTImageSpatialType extends Component {
                         />
                         {searchType === 'ALLSKY' && renderAllSkyNote()}
                         {searchType !== 'ALLSKY' && renderSearchRegion(searchType !== 'CENTER')}
-                        {searchType !== 'ALLSKY' && renderImageSize(searchType === 'CENTER' || searchType === 'COVERS', true)}
+                        {searchType !== 'ALLSKY' && renderImageSize(searchType === 'CENTER' || searchType === 'COVERS', false)}
                         {searchType !== 'ALLSKY' && renderMostCenter(searchType ==='CENTER' || searchType === 'COVERS', true)}
                     </InputGroup>
                 </div>
@@ -113,7 +113,7 @@ function renderImageSize(visible, disable) {
        <SizeInputFields fieldKey='subsize'
                         wrapperStyle={wrapper}
                         initialState= {{
-                                           value: '.1',
+                                           value: '', // default 0.1?
                                            tooltip: 'Please select an option',
                                            unit: 'arcsec',
                                            min:  1/3600,


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-9371

- Display image cutouts in LSST TS viewer 
To test, http://localhost:8080/firefly/ts.html, use LSST_SDSS and raw file attached to DM-9348

- Enable option to return cutouts on image search (at the moment, DAX supports cutouts image cutouts only Science CCD Exposure table, not yet for Deep Coadd) 
To test, http://localhost:8080/firefly/lsst-pdac-triview.html, select Images, set Return Image Size or leave it blank for full image.

- Updated SizeInputField to allow empty values.
