### PR TITLE
DM-9581:MSX image rotation not computed correctly.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/FitsRead.java
@@ -53,6 +53,9 @@ import java.util.Arrays;
  *  remove the mask testing codes since the mask is done in the mask branch.
  * 9/26/16
  *  DM-4127
+ *
+ *  3/1/17
+ *  DM-9581
  */
 public class FitsRead implements Serializable {
     //class variable
@@ -264,11 +267,11 @@ public class FitsRead implements Serializable {
                     return fitsReader;
                 }
                 else {
-                    return createFitsReadPositionAngle(fitsReader, -angleToRotate, CoordinateSys.EQ_J2000);
+                    return createFitsReadPositionAngle(fitsReader, -angleToRotate, inCoordinateSys);
                 }
             }
             else {
-                return createFitsReadPositionAngle(fitsReader, -positionAngle+ rotationAngle, CoordinateSys.EQ_J2000);
+                return createFitsReadPositionAngle(fitsReader, -positionAngle+ rotationAngle, inCoordinateSys);
             }
         } catch (ProjectionException pe) {
             if (SUTDebug.isDebug()) {


### PR DESCRIPTION
The reason that the rotation is wrong is that the incoming coordinate in m16 is galactic. But the out image created by rotation is in EQ_2000.  I think the rotation should be done in the same coordinate as the original image.  However, I maybe wrong since I don't know the reason why the EQ_2000 is hard coded there. 

But the bug is fixed after I changed the coordinate.  I also tried other rotation related function and seemed to me all are well.

Please review this and let me know if I am doing the wrong way.  Thanks!

To test the bug,
 1.  In image search, enter target "m16"
 2. Select MSX tab
 3. Search
 4. Click rotation icon and enter 180



