### PR TITLE
DM-7803: add time series launch capability to suit app.

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -295,6 +295,7 @@ function tableSearch(action) {
     return (dispatch) => {
         //dispatch(validate(FETCH_TABLE, action));
         if (!action.err) {
+            dispatch(action);
             var {request={}, options={}} = action.payload;
             const {tbl_ui_id} = options;
             const {tbl_id} = request;

--- a/src/firefly/js/tables/ui/ActiveTableButton.jsx
+++ b/src/firefly/js/tables/ui/ActiveTableButton.jsx
@@ -1,0 +1,78 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {Component,PropTypes} from 'react';
+import sCompare from 'react-addons-shallow-compare';
+
+import {flux} from '../../Firefly.js';
+import {getTblInfoById, getActiveTableId} from '../TableUtil.js';
+
+/**
+ * This button will track the highlighted row of the given tbl_id or of the active table of the given tbl_grp.
+ * There are 2 callbacks available as props.
+ * onClick: This function is called when a user click on this button.
+ * onChange({tbl_id, highlightedRow}): This function is called when highlightedRow changes.
+ *                                     The returned object of this function will be set into state.
+ *                                     Props like show or title can be changed via this function.
+ */
+export class ActiveTableButton extends Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {...props};
+        this.onClick = this.onClick.bind(this);
+    }
+
+    componentDidMount() {
+        this.removeListener= flux.addListener(() => this.storeUpdate());
+    }
+
+    componentWillUnmount() {
+        this.removeListener && this.removeListener();
+        this.isUnmounted = true;
+    }
+
+    storeUpdate() {
+        if (!this.isUnmounted) {
+            var {tbl_id, tbl_grp, onChange} = this.props;
+            tbl_id = tbl_id || getActiveTableId(tbl_grp);
+            const {highlightedRow} = getTblInfoById(tbl_id);
+
+            if (sCompare(this, this.props, Object.assign({}, this.state, {tbl_id, highlightedRow}))) {
+                this.setState({tbl_id, highlightedRow});
+                onChange && this.setState(onChange({tbl_id, highlightedRow}));
+            }
+        }
+    }
+
+    onClick() {
+        const {onClick} = this.props;
+        const {tbl_id, highlightedRow} = this.state;
+        onClick && onClick({tbl_id, highlightedRow});
+    }
+
+    render() {
+        const {show=true, title, style, type='standard'} = this.state;
+        const astyle = Object.assign({textOverflow: 'ellipsis', maxWidth: 200, overflow: 'hidden'}, style);
+        const className = type === 'standard' ? 'button std' : 'button std hl';
+        return show && (
+            <button type = 'button' className={className} onClick = {this.onClick}>
+                <div title={title} style={astyle}>{title}</div>
+            </button>
+        );
+    }
+}
+
+
+ActiveTableButton.propTypes = {
+    tbl_id      : PropTypes.string,
+    tbl_grp     : PropTypes.string,
+    show        : PropTypes.bool,
+    title       : PropTypes.string,
+    type        : PropTypes.oneOf(['standard', 'highlight']),
+    style       : PropTypes.object,
+    onChange    : PropTypes.func,
+    onClick     : PropTypes.func
+};
+

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -88,7 +88,7 @@ export class FireflyViewer extends Component {
 
     render() {
         var {isReady, menu={}, appTitle, appIcon, altAppIcon, dropDown,
-                dropdownPanels, views, footer, style, showViewsSwitch} = this.state;
+                dropdownPanels, views, footer, style, showViewsSwitch, leftButtons, centerButtons, rightButtons} = this.state;
         const {visible, view} = dropDown || {};
 
         if (!isReady) {
@@ -106,7 +106,7 @@ export class FireflyViewer extends Component {
                             {...{dropdownPanels} } />
                     </header>
                     <main>
-                        <DynamicResults {...{views, showViewsSwitch}}/>
+                        <DynamicResults {...{views, showViewsSwitch, leftButtons, centerButtons, rightButtons}}/>
                     </main>
                 </div>
             );
@@ -129,7 +129,10 @@ FireflyViewer.propTypes = {
     dropdownPanels: PropTypes.arrayOf(PropTypes.element),
     views: PropTypes.string,     // combination of LO_VIEW separated by ' | '.  ie. 'images | tables'.
     style: PropTypes.object,
-    showViewsSwitch: PropTypes.bool
+    showViewsSwitch: PropTypes.bool,
+    leftButtons: PropTypes.arrayOf( PropTypes.func ),
+    centerButtons: PropTypes.arrayOf( PropTypes.func ),
+    rightButtons: PropTypes.arrayOf( PropTypes.func )
 };
 
 FireflyViewer.defaultProps = {
@@ -167,16 +170,19 @@ function BannerSection(props) {
 
 
 function DynamicResults(props) {
-    var {views, showViewsSwitch} = props;
+    var {views, ...rest} = props;
     if (LO_VIEW.get(views)) {
-        return <TriViewPanel {...{showViewsSwitch}}/>;
+        return <TriViewPanel {...rest}/>;
     }
 }
 DynamicResults.propTypes = {
     views: PropTypes.oneOfType([
                     PropTypes.string,
                     PropTypes.object]),
-    showViewsSwitch: PropTypes.bool
+    showViewsSwitch: PropTypes.bool,
+    leftButtons: PropTypes.arrayOf( PropTypes.func ),
+    centerButtons: PropTypes.arrayOf( PropTypes.func ),
+    rightButtons: PropTypes.arrayOf( PropTypes.func )
 };
 DynamicResults.defaultProps = {
     showViewsSwitch: true

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {Component} from 'react';
+import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
 
 import {pick} from 'lodash';
@@ -40,7 +40,7 @@ export class TriViewPanel extends Component {
 
     render() {
         // eslint-disable-next-line
-        const {showViewsSwitch} = this.props;
+        const {showViewsSwitch, leftButtons, centerButtons, rightButtons} = this.props;
         const {title, mode, showTables, showImages, showXyPlots, images={}} = this.state;
         const {expanded, standard, closeable} = mode || {};
         const content = {};
@@ -63,27 +63,13 @@ export class TriViewPanel extends Component {
                                                closeable={closeable}
                                                expandedMode={expanded===LO_VIEW.tables}/>);
         }
-        const searchDesc = (showViewsSwitch && showImages && showXyPlots && showTables) ?
-            (<div>
-                <div style={ {display: 'inline-block', float: 'right'} }>
-                    <button type='button' className='button std'
-                            onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('tables | images | xyPlots'))}>tri-view</button>
-                    <button type='button' className='button std'
-                            onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('tables | images'))}>img-tbl</button>
-                    <button type='button' className='button std'
-                            onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('images | xyPlots'))}>img-xy</button>
-                    <button type='button' className='button std'
-                            onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('tables | xyPlots'))}>xy-tbl</button>
-                </div>
-            </div>)
-            : <div/>;
-
+        const viewSwitch = showViewsSwitch && showImages && showXyPlots && showTables;
 
         if (showImages || showXyPlots || showTables) {
             return (
                 <ResultsPanel key='results'
                               title={title}
-                              searchDesc ={searchDesc}
+                              searchDesc ={searchDesc({viewSwitch, leftButtons, centerButtons, rightButtons})}
                               expanded={expanded}
                               standard={standard}
                               visToolbar={visToolbar}
@@ -94,4 +80,55 @@ export class TriViewPanel extends Component {
             return <div/>;
         }
     }
+}
+
+
+TriViewPanel.propTypes = {
+    showViewsSwitch: PropTypes.bool,
+    leftButtons: PropTypes.arrayOf( PropTypes.func ),
+    centerButtons: PropTypes.arrayOf( PropTypes.func ),
+    rightButtons: PropTypes.arrayOf( PropTypes.func )
+};
+TriViewPanel.defaultProps = {
+    showViewsSwitch: true
+};
+
+
+// eslint-disable-next-line
+function searchDesc({viewSwitch, leftButtons, centerButtons, rightButtons}) {
+
+    const hasContent = viewSwitch || leftButtons || centerButtons || rightButtons;
+    return !hasContent ? <div/> :
+    (
+        <div style={{display: 'inline-flex', justifyContent: 'space-between'}}>
+            <div>
+                {leftButtons &&
+                    leftButtons.map( (el) => el())
+                }
+            </div>
+            <div>
+                {centerButtons &&
+                    centerButtons.map( (el) => el())
+                }
+            </div>
+            <div style={{display: 'inline-flex'}}>
+                {rightButtons &&
+                    rightButtons.map( (el) => el())
+                }
+                <div style={{width: 20}}/>
+                {viewSwitch &&
+                    <div style={ {display: 'inline-block', float: 'right'} }>
+                        <button type='button' className='button std'
+                                onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('tables | images | xyPlots'))}>tri-view</button>
+                        <button type='button' className='button std'
+                                onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('tables | images'))}>img-tbl</button>
+                        <button type='button' className='button std'
+                                onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('images | xyPlots'))}>img-xy</button>
+                        <button type='button' className='button std'
+                                onClick={() => dispatchSetLayoutMode(LO_MODE.standard, LO_VIEW.get('tables | xyPlots'))}>xy-tbl</button>
+                    </div>
+                }
+            </div>
+       </div>
+    );
 }

--- a/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
+++ b/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
@@ -48,7 +48,7 @@ for(var i= 1; (i<=LC.MAX_IMAGE_CNT); i+=2) {
 
 export function LcImageToolbarView({activePlotId, viewerId, viewerPlotIds, layoutType, dlAry, tableId, closeFunc=null}) {
     const converter = getConverterData();
-    if (!converter) { return; }
+    if (!converter) { return null; }
 
     const viewer= getViewer(getMultiViewRoot(), viewerId);
     const count= get(viewer, 'layoutDetail.count', converter.defaultImageCount);

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -1,13 +1,13 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {get, isEmpty, isNil, set} from 'lodash';
+import {get, has, isEmpty, isNil, set, cloneDeep} from 'lodash';
 import {take} from 'redux-saga/effects';
 import {SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo,
         dispatchUpdateLayoutInfo, dropDownHandler} from '../../core/LayoutCntlr.js';
-import {TBL_RESULTS_ADDED, TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_HIGHLIGHT,
-        dispatchTableRemove, dispatchTableHighlight} from '../../tables/TablesCntlr.js';
-import {getCellValue, getTblById, getTblIdsByGroup, findIndex, getActiveTableId} from '../../tables/TableUtil.js';
+import {TBL_RESULTS_ADDED, TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_HIGHLIGHT, TABLE_SEARCH,
+        dispatchTableRemove, dispatchTableHighlight, dispatchTableFetch} from '../../tables/TablesCntlr.js';
+import {getCellValue, getTblById, getTblIdsByGroup, getActiveTableId, smartMerge} from '../../tables/TableUtil.js';
 import {dispatchTableReplace} from '../../tables/TablesCntlr.js';
 import {updateSet, updateMerge, logError} from '../../util/WebUtil.js';
 import ImagePlotCntlr, {dispatchPlotImage, visRoot, dispatchDeletePlotView,
@@ -21,7 +21,10 @@ import {VALUE_CHANGE, dispatchValueChange, dispatchMultiValueChange} from '../..
 import {MetaConst} from '../../data/MetaConst.js';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {CHART_ADD, getChartDataElement} from '../../charts/ChartsCntlr.js';
-import {getConverter, UNKNOWN_MISSION} from './LcConverterFactory.js';
+import {getConverter} from './LcConverterFactory.js';
+import {sortInfoString} from '../../tables/SortInfo.js';
+import {makeMissionEntries, keepHighlightedRowSynced} from './LcUtil.jsx';
+import {dispatchMountFieldGroup} from '../../fieldGroup/FieldGroupCntlr.js';
 
 export const LC = {
     RAW_TABLE: 'raw_table',          // raw table id
@@ -156,7 +159,7 @@ export function* lcManager(params={}) {
 
     while (true) {
         const action = yield take([
-            TBL_RESULTS_ADDED, TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_HIGHLIGHT, SHOW_DROPDOWN, SET_LAYOUT_MODE,
+            TBL_RESULTS_ADDED, TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_HIGHLIGHT, TABLE_SEARCH, SHOW_DROPDOWN, SET_LAYOUT_MODE,
             CHANGE_VIEWER_LAYOUT, VALUE_CHANGE, ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW, CHART_ADD
         ]);
 
@@ -182,6 +185,9 @@ export function* lcManager(params={}) {
 
         newLayoutInfo = dropDownHandler(newLayoutInfo, action);
         switch (action.type) {
+            case TABLE_SEARCH:
+                newLayoutInfo = handleNewSearch(newLayoutInfo, action);
+                break;
             case TBL_RESULTS_ADDED:
             case TABLE_LOADED:
                 newLayoutInfo = handleTableLoad(newLayoutInfo, action);
@@ -196,10 +202,10 @@ export function* lcManager(params={}) {
                 newLayoutInfo = handleTableActive(newLayoutInfo, action);
                 break;
             case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
-                newLayoutInfo = handlePlotActive(newLayoutInfo, action.payload.plotId);
+                newLayoutInfo = handlePlotActive(newLayoutInfo, action);
                 break;
             case CHART_ADD:
-                 newLayoutInfo = handleAddChart(newLayoutInfo, action.payload.chartId);
+                 newLayoutInfo = handleAddChart(newLayoutInfo, action);
                 break;
             case VALUE_CHANGE:
                 newLayoutInfo = handleValueChange(newLayoutInfo, action);
@@ -250,7 +256,7 @@ function updatePhaseTableChart(flux) {
 function handleValueChange(layoutInfo, action) {
     var {fieldKey, value, valid} = action.payload;
 
-    if (!valid) { return; }
+    if (!valid) { return layoutInfo; }
 
     if (fieldKey === 'cutoutSize') { // cutoutsize changes
         if ((get(layoutInfo, [LC.GENERAL_DATA, fieldKey]) !== value) && (value > 0.0) ) {
@@ -268,7 +274,7 @@ function handleValueChange(layoutInfo, action) {
         }
     } else {
         const converterData = getConverterData(layoutInfo);
-        if (!converterData) {return;}
+        if (!converterData) {return layoutInfo;}
 
         const updates = converterData.onFieldUpdate(fieldKey, value);
         if (isEmpty(updates)) {
@@ -306,7 +312,8 @@ function handleValueChange(layoutInfo, action) {
     return layoutInfo;
 }
 
-function handleAddChart(layoutInfo, chartId) {
+function handleAddChart(layoutInfo, action) {
+    const chartId = action.payload.chartId;
     if (chartId === LC.PHASE_FOLDED) {
         if (get(layoutInfo, ['displaMode']) !== 'result') {
             layoutInfo = updateSet(layoutInfo, ['displayMode'], 'result');
@@ -321,13 +328,35 @@ function handleAddChart(layoutInfo, chartId) {
  * @param plotId
  * @returns {*}
  */
-function handlePlotActive(layoutInfo, plotId) {
+function handlePlotActive(layoutInfo, action) {
+    const plotId = action.payload.plotId;
     const tableId = get(layoutInfo, ['images', 'activeTableId']);
 
     var rowNum= Number(plotId.substring(plotIdRoot.length));
     dispatchTableHighlight(tableId, rowNum);
     return layoutInfo;
 }
+
+/**
+ * handle logic when a new search is initiated.
+ * @param {LayoutInfo} layoutInfo layoutInfo
+ * @param {string} action
+ * @returns {LayoutInfo} the new layoutInfo
+ */
+function handleNewSearch(layoutInfo, action) {
+    const tbl_id = get(action, 'payload.request.META_INFO.tbl_id');
+    if (tbl_id === LC.RAW_TABLE) {
+        removeTablesFromGroup();
+        removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
+
+        if (has(layoutInfo, [LC.MISSION_DATA])) {
+            dispatchMountFieldGroup(getViewerGroupKey(get(layoutInfo, LC.MISSION_DATA)), false, false,
+                                                      null, null, [], undefined, true);
+        }
+        return smartMerge(layoutInfo, {displayMode: LC.RESULT_PAGE, periodState: LC.PERIOD_PAGE, missionEntries: null, generalEntries: null, fullRawTable:null});
+    }
+}
+
 /*
  * field group, LC_VIEWER_FINDER, includes fieldKey from missionEntries & generalEntries
  * missionEntries & generalEntries is mission specific, more detail to be fixed after raw table metadata is defined. -- TO DO
@@ -336,21 +365,34 @@ function handleRawTableLoad(layoutInfo, tblId) {
     const rawTable = getTblById(tblId);
     if (rawTable.error) {
         logError('Table load error: ' + rawTable.error);
-        return;
+        return layoutInfo;
     }
 
-    const metaInfo = rawTable && rawTable.tableMeta;
-    const converterId = get(metaInfo, LC.META_MISSION, UNKNOWN_MISSION);
-    const converterData = converterId && getConverter(converterId);
+    const generalEntries = get(layoutInfo, LC.GENERAL_DATA) || getGeneralEntries();
+    const {converterData, missionEntries} = makeMissionEntries(rawTable.tableMeta);
+
     if (!converterData) {
         logError('Unknown mission or no converter');
         return;
     }
 
-    const generalEntries = get(layoutInfo, LC.GENERAL_DATA, getGeneralEntries());
-    const missionEntries = converterData.onNewRawTable(rawTable, converterData);
-    
-    return Object.assign(layoutInfo, {missionEntries, generalEntries});
+    const {newLayoutInfo, shouldContinue} = converterData.onNewRawTable(rawTable, missionEntries, generalEntries, layoutInfo);
+    if (shouldContinue) {
+        // additional changes to the loaded table
+        ensureValidRawTable(rawTable, missionEntries);
+    }
+    return newLayoutInfo;
+}
+
+function ensureValidRawTable(rawTable={}, missionEntries) {
+    const {request={}} = rawTable;
+    const {sortInfo} = request;
+    // check to ensure time column is sorted.
+    if (!sortInfo) {
+        const timeSortInfo = sortInfoString(missionEntries[LC.META_TIME_CNAME]);
+        const treq = Object.assign(cloneDeep(request), {sortInfo: timeSortInfo});
+        dispatchTableFetch(treq);
+    }
 }
 
 /**
@@ -365,18 +407,18 @@ function handleTableLoad(layoutInfo, action) {
     layoutInfo = Object.assign({}, layoutInfo, {showTables: true, showXyPlots: true});
     if (tbl_id === LC.RAW_TABLE) {         // a new raw table is loaded
         if (action.type === TABLE_LOADED) {
-            layoutInfo = Object.assign(layoutInfo, {displayMode: LC.RESULT_PAGE, periodState: LC.PERIOD_PAGE});
             layoutInfo = handleRawTableLoad(layoutInfo, tbl_id);
-            if (!layoutInfo) {
-                return;
-            }
+            layoutInfo = handleTableActive(layoutInfo, action);     // because table_active happened before loaded.. we'll handle it here.
         }
+    }
+    if([LC.RAW_TABLE, LC.PHASE_FOLDED].includes(tbl_id)) {
+        const {highlightedRow} = getTblById(tbl_id);
+        // this handles sorting and filtering cases.
+        keepHighlightedRowSynced(tbl_id, highlightedRow);
     }
     if (isImageEnabledTable(tbl_id)) {
         layoutInfo = updateSet(layoutInfo, 'showImages', true);
     }
-    dispatchUpdateLayoutInfo(layoutInfo);
-    layoutInfo = handleTableActive(layoutInfo, action);
 
     return layoutInfo;
 }
@@ -415,7 +457,6 @@ function handleTableActive(layoutInfo, action) {
     }
 
     return layoutInfo;
-    //return Object.assign({}, layoutInfo);
 }
 
 function handleTableHighlight(layoutInfo, action) {
@@ -443,25 +484,7 @@ function handleTableHighlight(layoutInfo, action) {
     }
 
     // ensure the highlighted row of the raw and phase-folded tables are in sync.
-    if ([LC.PHASE_FOLDED, LC.RAW_TABLE].includes(tbl_id)) {
-        let filterInfo, actOn, rowid;
-        const tableModel = getTblById(tbl_id);
-        if (tbl_id === LC.RAW_TABLE) {
-            actOn = LC.PHASE_FOLDED;
-            rowid = getCellValue(tableModel, highlightedRow, 'ROWID');
-            filterInfo = `RAW_ROWID = ${rowid}`;
-        } else {
-            rowid = getCellValue(tableModel, highlightedRow, 'RAW_ROWID');
-            actOn = LC.RAW_TABLE;
-            filterInfo = `ROWID = ${rowid}`;
-        }
-        findIndex(actOn, filterInfo)
-            .then( (index) => {
-                if (index >=0) {
-                    dispatchTableHighlight(actOn, index);
-                }
-            });
-    }
+    keepHighlightedRowSynced(tbl_id, highlightedRow);
 
     return layoutInfo;
     //return Object.assign({}, layoutInfo);

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -620,7 +620,7 @@ const  PeriodogramResult = ({expanded}) => {
         resultLayout = (<SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={565}>
                             <SplitContent>
                                 <div style={{margin: '0 0 5px 6px'}}><ChangePeriodogram/></div>
-                                <div style={{height: 'calc(100% - 28px'}}>{tables}</div>
+                                <div style={{height: 'calc(100% - 28px)'}}>{tables}</div>
                             </SplitContent>
                             <SplitContent>{xyPlot}</SplitContent>
                         </SplitPane>);

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -29,7 +29,6 @@ export function uploadPhaseTable(tbl, flux) {
         const tReq = makeFileRequest(title, cacheKey, null,
                                      {tbl_id,
                                       sortInfo:sortInfoString(LC.PHASE_CNAME),
-                                      tblType: 'notACatalog',
                                       pageSize: LC.TABLE_PAGESIZE
                                      });
 

--- a/src/firefly/js/templates/lightcurve/LcUtil.jsx
+++ b/src/firefly/js/templates/lightcurve/LcUtil.jsx
@@ -1,4 +1,9 @@
 import React, {PropTypes} from 'react';
+import {get} from 'lodash';
+import {LC} from './LcManager.js';
+import {getConverter} from './LcConverterFactory.js';
+import {getCellValue, getTblById, findIndex} from '../../tables/TableUtil.js';
+import {dispatchTableHighlight} from '../../tables/TablesCntlr.js';
 
 export function getTypeData(key, val='', tip = '', labelV='', labelW) {
     return {
@@ -25,3 +30,42 @@ ReadOnlyText.propTypes = {
     labelWidth: PropTypes.number,
     wrapperStyle: PropTypes.object
 };
+
+
+export function makeMissionEntries(tableMeta, layoutInfo={}) {
+    var converterData = getConverter(get(tableMeta, LC.META_MISSION)) || getConverter();
+    var missionEntries = layoutInfo.missionEntries || {};
+    Object.assign(missionEntries, {
+        [LC.META_MISSION]: converterData.converterId,
+        [LC.META_TIME_CNAME]: get(tableMeta, LC.META_TIME_CNAME, converterData.defaultTimeCName),
+        [LC.META_FLUX_CNAME]: get(tableMeta, LC.META_FLUX_CNAME, converterData.defaultYCname),
+        [LC.META_ERR_CNAME]: get(tableMeta, LC.META_ERR_CNAME, converterData.defaultYErrCname),
+        [LC.META_TIME_NAMES]: get(tableMeta, LC.META_TIME_NAMES, converterData.timeNames),
+        [LC.META_FLUX_NAMES]: get(tableMeta, LC.META_FLUX_NAMES, converterData.yNames),
+        [LC.META_ERR_NAMES]: get(tableMeta, LC.META_ERR_NAMES, converterData.yErrNames)
+    });
+    return {converterData, missionEntries};
+}
+
+export function keepHighlightedRowSynced(tbl_id, highlightedRow) {
+    // ensure the highlighted row of the raw and phase-folded tables are in sync.
+    if ([LC.PHASE_FOLDED, LC.RAW_TABLE].includes(tbl_id)) {
+        let filterInfo, actOn, rowid;
+        const tableModel = getTblById(tbl_id);
+        if (tbl_id === LC.RAW_TABLE) {
+            actOn = LC.PHASE_FOLDED;
+            rowid = getCellValue(tableModel, highlightedRow, 'ROWID');
+            filterInfo = `RAW_ROWID = ${rowid}`;
+        } else {
+            rowid = getCellValue(tableModel, highlightedRow, 'RAW_ROWID');
+            actOn = LC.RAW_TABLE;
+            filterInfo = `ROWID = ${rowid}`;
+        }
+        findIndex(actOn, filterInfo)
+            .then( (index) => {
+                if (index >=0) {
+                    dispatchTableHighlight(actOn, index);
+                }
+            });
+    }
+}

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -5,11 +5,11 @@
 
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {pickBy, get, capitalize, has} from 'lodash';
+import {pickBy, get, capitalize} from 'lodash';
 import {flux, firefly} from '../../Firefly.js';
 import {getMenu, isAppReady, dispatchSetMenu, dispatchOnAppReady} from '../../core/AppDataCntlr.js';
-import {dispatchHideDropDown, getLayouInfo, SHOW_DROPDOWN,  dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
-import {lcManager, LC, removeTablesFromGroup, getViewerGroupKey} from './LcManager.js';
+import {dispatchHideDropDown, getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
+import {lcManager, LC} from './LcManager.js';
 import {getAllConverterIds, getConverter, getMissionName} from './LcConverterFactory.js';
 import {LcResult} from './LcResult.jsx';
 import {LcPeriod} from './LcPeriod.jsx';
@@ -26,7 +26,6 @@ import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import {watchCatalogs} from '../../visualize/saga/CatalogWatcher.js';
-import {dispatchMountFieldGroup} from '../../fieldGroup/FieldGroupCntlr.js';
 
 
 const vFileKey = LC.FG_FILE_FINDER;
@@ -213,19 +212,7 @@ UploadPanel.defaultProps = {
 
 function onSearchSubmit(request) {
     if ( request.rawTblSource ){
-        removeTablesFromGroup();
-        removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
-
-        var layoutInfo = getLayouInfo();
-
-        /* remove current viewer field group,
-           it is better to put this part into lcManager's handleRawTableLoad when that works solely for raw table load */
-        if (has(layoutInfo, [LC.MISSION_DATA])) {
-            dispatchMountFieldGroup(getViewerGroupKey(get(layoutInfo, LC.MISSION_DATA)), false, false,
-                                                      null, null, [], undefined, true);
-        }
-
-        dispatchUpdateLayoutInfo(Object.assign({}, layoutInfo, {fullRawTable: null}));  // clear full raw table
+        const {mission} = request;
         const converter = getConverter(request.mission);
         if (!converter) return;
 

--- a/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
@@ -5,7 +5,7 @@ import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
 import {makeFileRequest} from '../../../tables/TableUtil.js';
-import {getColumnIdx, getTblById} from '../../../tables/TableUtil.js';
+import {getColumnIdx, getTblById, smartMerge} from '../../../tables/TableUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {ReadOnlyText, getTypeData} from '../LcUtil.jsx';
 import {LC, getViewerGroupKey} from '../LcManager.js';
@@ -221,25 +221,19 @@ const posColumnInfo = (posCoords) => {
 };
 
 
-export function defaultOnNewRawTable(rawTable, converterData) {
+export function defaultOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo={}) {
     const metaInfo = rawTable && rawTable.tableMeta;
     var posInfo = posColumnInfo(get(metaInfo, LC.META_POS_COORD));
 
-    const missionEntries = {
-        [LC.META_MISSION]: converterData.converterId,
-        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, converterData.defaultTimeCName),
-        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, converterData.defaultYCname),
-        [LC.META_ERR_CNAME]: get(metaInfo, LC.META_ERR_CNAME, converterData.defaultYErrCname),
-        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES),
-        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES),
-        [LC.META_ERR_NAMES]: get(metaInfo, LC.META_ERR_NAMES),
+    const addtlEntries = {
         [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, converterData.dataSource),
         [LC.META_COORD_XNAME]: get(posInfo, LC.META_COORD_XNAME),
         [LC.META_COORD_YNAME]: get(posInfo, LC.META_COORD_YNAME),
         [LC.META_COORD_SYS]: get(posInfo, LC.META_COORD_SYS),
         [coordSysOptions]: get(converterData, coordSysOptions)
     };
-    return missionEntries;
+    missionEntries = Object.assign({}, missionEntries, addtlEntries);
+    return {shouldContinue: false, newLayoutInfo: smartMerge(layoutInfo, {missionEntries, generalEntries})};
 }
 
 export function defaultRawTableRequest(converter, source) {

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
@@ -1,15 +1,13 @@
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {get, isEmpty, set, omit, pick, cloneDeep, defer} from 'lodash';
-import {getLayouInfo, dispatchUpdateLayoutInfo} from '../../../core/LayoutCntlr.js';
-import FieldGroupUtils from '../../../fieldGroup/FieldGroupUtils';
-import {dispatchMultiValueChange} from '../../../fieldGroup/FieldGroupCntlr.js';
+import {get, isEmpty, set, pick, cloneDeep, defer} from 'lodash';
+import {getLayouInfo} from '../../../core/LayoutCntlr.js';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
 import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 import {makeFileRequest, makeTblRequest, smartMerge} from '../../../tables/TableUtil.js';
-import {dispatchTableFetch, dispatchTableSearch} from '../../../tables/TablesCntlr.js';
+import {dispatchTableSearch} from '../../../tables/TablesCntlr.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {FilterInfo} from '../../../tables/FilterInfo.js';
 
@@ -136,25 +134,7 @@ export const lsstSdssReducer = (missionEntries, generalEntries) => {
 };
 
 
-/*
-function setFields(missionEntries, generalEntries) {
-    const groupKey = getViewerGroupKey(missionEntries);
-    const fields = FieldGroupUtils.getGroupFields(groupKey);
-    if (fields) {
-        const initState = Object.keys(fields).reduce((prev, fieldKey) => {
-            if (has(missionEntries, fieldKey)) {
-                prev.push({fieldKey, value: get(missionEntries, fieldKey)});
-            } else if (has(generalEntries,fieldKey)) {
-                prev.push({fieldKey, value: get(generalEntries, fieldKey)});
-            }
-            return prev;
-        }, []);
-        dispatchMultiValueChange(groupKey, initState);
-    }
-}
-*/
-
-export function lsstSdssOnNewRawTable(rawTable, missionEntries, generalEntries, layoutInfo={}) {
+export function lsstSdssOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo={}) {
     const {band, lsst_filtered_band} = get(rawTable, 'request.META_INFO');
     var {rawTableRequest} = layoutInfo;
 

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssPlotRequests.js
@@ -49,7 +49,8 @@ export function makeLsstSdssPlotRequest(table, rowIdx, cutoutSize) {
     const r  = WebPlotRequest.makeProcessorRequest(sr, plot_desc);
     const rangeValues= RangeValues.makeRV({which:SIGMA, lowerValue:-2, upperValue:10, algorithm:STRETCH_LINEAR});
     r.setInitialRangeValues(rangeValues);
-    r.setZoomType(ZoomType.TO_WIDTH);
+    // r.setZoomType(ZoomType.TO_WIDTH);  TODO:LLY
+    r.setMultiImageIdx(0);
 
     return addCommonReqParams(r, title, makeWorldPt(ra,decl,CoordinateSys.EQ_J2000));
 }

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -2,8 +2,6 @@ import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
 import {get, has, isEmpty, set} from 'lodash';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
-import FieldGroupUtils from '../../../fieldGroup/FieldGroupUtils';
-import {dispatchMultiValueChange} from '../../../fieldGroup/FieldGroupCntlr.js';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
 import {makeFileRequest, getTblById, smartMerge} from '../../../tables/TableUtil.js';
@@ -167,7 +165,7 @@ function getFieldValidators(missionEntries) {
     }, {});
 }
 
-export function wiseOnNewRawTable(rawTable, missionEntries, generalEntries, layoutInfo) {
+export function wiseOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo) {
     const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries});
     return {newLayoutInfo, shouldContinue: true};
 }


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-7803

On LSST PDAC, when searching for 'Deep Forced Source' data, there should be a button to view the time series data for the highlighted objectId.
If you upload a table with time series's metadata, there should be a button to view the table as time series.

To Test:
- Check out 'DM-7803_triview_timeseries' branch in both firefly and suit repo.
- Build suit and then goto http://localhost:8080/suit/
- Search for "Deep Forced Source", then click on 'View Time Series' button at upper right corner to view the data in a separate window.
- When uploading a table with time series metadata, i.e. 'timeCName', there should also be a 'View as Time Series' button at the same location
