### PR TITLE
DM-9080-LabelCutoff Fix label cutoff on the tab header and popup panel title

### DIFF
--- a/src/firefly/js/ui/PopupPanel.jsx
+++ b/src/firefly/js/ui/PopupPanel.jsx
@@ -146,20 +146,20 @@ export var PopupPanel= React.createClass(
                      onMouseLeave={this.onMouseLeave}
                 >
                     <div className={'standard-border'}>
-                        <div style={{position:'relative', height:'14px', width:'100%', cursor:'default'}}
+                        <div style={{position:'relative', height:'16px', width:'100%', cursor:'default'}}
                              className={'title-bar title-color popup-panel-title-background'}
                             onTouchStart={this.dialogMoveStart}
                             onTouchMove={this.dialogMove}
                             onTouchEnd={this.dialogMoveEnd}
                             onMouseDownCapture={this.dialogMoveStart}>
                             <div ref={(c) => this.titleBarRef=c}
-                                 style= {{position:'absolute', left:'0px', top:'0px',width:'100%', padding: '3px 0 3px 10px'}}
+                                 style= {{position:'absolute', left: 0, top: 0, bottom: 0, width:'100%', padding: '3px 0 3px 10px'}}
                                  onMouseDownCapture={this.dialogMoveStart}
                                  onTouchStart={this.dialogMoveStart}
                                  onTouchMove={this.dialogMove}
                                  onTouchEnd={this.dialogMoveEnd}
                                  className={'title-label'} >
-                                <div className={'text-ellipsis'} style={{width:'80%'}}>
+                                <div className={'text-ellipsis'} style={{width:'80%', height: '100%'}}>
                                     {title}
                                 </div>
                             </div>

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -195,8 +195,8 @@ export class Tab extends Component {
 
         return (
             <li className={tabClassName} onClick={() => onSelect(id,name)}>
-                <div>
-                    <div style={textStyle} className='text-ellipsis' title={name}>
+                <div style={{height: '100%'}}>
+                    <div style={{...textStyle, height: '100%'}} className='text-ellipsis' title={name}>
                          {name}
                     </div>
                     {removable &&

--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -22,7 +22,7 @@ const rgUploadGroupKey = 'RegionUploadGroup';
 const rgUploadFieldKey = 'regionFileUpload';
 const regionDrawLayerId = RegionPlot.TYPE_ID;
 
-export function showRegionFileUploadPanel(popTitle) {
+export function showRegionFileUploadPanel(popTitle='Load DS9 Region File') {
     var popup = (<PopupPanel title={popTitle}>
                     <RegionUpload />
                 </PopupPanel>);


### PR DESCRIPTION
The development fixes: 
- letter bottom cutoff on tab header and popup panel title
- add missing popup panel title 

test:
try the following entry to see tab group and popup panel
localhost:8080/firefly/
  enter a target and search, try click tool button for loading region file, fits download, or overlay editor+color picker to get various popup panel. 
  select 'catalogs' to get group of tabs
