### PR TITLE
DM-9691: time series image problems fixed

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -262,6 +262,7 @@ function handleValueChange(layoutInfo, action) {
         if ((get(layoutInfo, [LC.GENERAL_DATA, fieldKey]) !== value) && (value > 0.0) ) {
             if (get(layoutInfo, ['displayMode']) === LC.RESULT_PAGE) {
                 layoutInfo = updateSet(layoutInfo, [LC.GENERAL_DATA, fieldKey], value);
+                clearLcImages();
                 setupImages(layoutInfo);
             }
         }
@@ -269,6 +270,7 @@ function handleValueChange(layoutInfo, action) {
         if (get(layoutInfo, [LC.MISSION_DATA, fieldKey]) !== value) {
             if (get(layoutInfo, ['displayMode']) === LC.RESULT_PAGE) {
                 layoutInfo = updateSet(layoutInfo, [LC.MISSION_DATA, fieldKey], value);
+                clearLcImages();
                 setupImages(layoutInfo);
             }
         }
@@ -295,6 +297,7 @@ function handleValueChange(layoutInfo, action) {
                 updatePhaseTableChart(fluxCol);
             }
 
+            clearLcImages();
             setupImages(newLayoutInfo);
 
             // update time or flux for period panel field group if it exists
@@ -304,6 +307,7 @@ function handleValueChange(layoutInfo, action) {
             }
         }
         if (didChange(LC.META_URL_CNAME)) {
+            clearLcImages();
             setupImages(newLayoutInfo);
         }
 
@@ -337,9 +341,17 @@ function handlePlotActive(layoutInfo, action) {
     return layoutInfo;
 }
 
+function clearLcImages() {
+    const vr= visRoot();
+    vr.plotViewAry.forEach( (pv) => dispatchDeletePlotView({plotId:pv.plotId}));
+    dispatchReplaceViewerItems(LC.IMG_VIEWER_ID, ['placeHolder']);
+}
+
 function clearResults(layoutInfo) {
     removeTablesFromGroup();
     removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
+    clearLcImages();
+
 
     if (has(layoutInfo, [LC.MISSION_DATA])) {
         dispatchMountFieldGroup(getViewerGroupKey(get(layoutInfo, LC.MISSION_DATA)), false, false,

--- a/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerLayout.jsx
@@ -39,10 +39,13 @@ const draggingOrReleasing = (ms) => ms==DRAG || ms===DRAG_COMPONENT || ms===UP |
 
 function updateZoom(pv, paging) {
     if (!primePlot(pv)) return;
-    const vr= visRoot();
     var doZoom= false;
     var actionScope= ActionScope.GROUP;
-    if (isImageViewerSingleLayout(getMultiViewRoot(), visRoot(), pv.plotId)) {
+    const vr= visRoot();
+    if (!paging && vr.wcsMatchType && pv.plotId!==vr.mpwWcsPrimId) {
+        doZoom= false;
+    }
+    else if (isImageViewerSingleLayout(getMultiViewRoot(), vr, pv.plotId)) {
         doZoom= true;
         actionScope= ActionScope.SINGLE;
     }
@@ -54,6 +57,7 @@ function updateZoom(pv, paging) {
         doZoom= (isActive || !inActive);
         actionScope= isActive ? ActionScope.GROUP : ActionScope.SINGLE;
     }
+
     if (doZoom) {
         dispatchZoom({
             plotId: pv.plotId,
@@ -95,6 +99,14 @@ export class ImageViewerLayout extends Component {
             const plot= primePlot(vr);
             const ft=  plot.attributes[PlotAttribute.FIXED_TARGET];
             if (ft) dispatchRecenter({plotId:plot.plotId, centerPt:ft});
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const {width,height}= nextProps;
+        const {viewDim}= nextProps.plotView;
+        if (width!==viewDim.width && height!==viewDim.height) {
+            dispatchUpdateViewSize(nextProps.plotView.plotId,width,height);
         }
     }
 

--- a/src/firefly/js/visualize/task/ImageOverlayTask.js
+++ b/src/firefly/js/visualize/task/ImageOverlayTask.js
@@ -44,11 +44,11 @@ const nextColor= () => colorChoose.next().value;
 export function* watchForCompletedPlot(options) {
 
 
-    var idMatch= false;
+    let idMatch= false;
     while (!idMatch) {
         const action = yield take([ImagePlotCntlr.PLOT_IMAGE, ImagePlotCntlr.PLOT_IMAGE_FAIL]);
         const {pvNewPlotInfoAry, plotId}= action.payload;
-        const idMatch = Boolean(pvNewPlotInfoAry && pvNewPlotInfoAry.find((i) => i.plotId === options.plotId)) ||
+        idMatch = Boolean(pvNewPlotInfoAry && pvNewPlotInfoAry.find((i) => i.plotId === options.plotId)) ||
                                plotId===options.plotId;
         if (idMatch) {
             if (action.type===ImagePlotCntlr.PLOT_IMAGE) {

--- a/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
@@ -10,7 +10,8 @@ const flexContainerStyle= {
     display:'flex',
     flexDirection:'column',
     flexWrap:'nowrap',
-    alignItems: 'stretch'
+    alignItems: 'stretch',
+    flexGrow: 1
 };
 
 const defDecStyle= {


### PR DESCRIPTION
 - expanded mode problem fixed (flex layout issue)
 - image zoom levels sizes stay correctly syncronized
 - images reset when new data is loaded
 - images reset when cutout size changes and stay synced
 - when rotation happens on images, target match is turned off. Therefore new
   images will not come in at the same rotation.  The target match
   must be turned back on. This is the expected behavior we can consider
   whether is is the desired behavior.