### PR TITLE
DM-9638 Remove unexpected image tab after a column for histogram is selected

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -182,8 +182,7 @@
                     { pageSize: 15,
                         META_INFO: {
                             datasetInfoConverterId : 'SimpleMoving',
-                            //positionCoordColumns: 'ra_obj;dec_obj;EQ_J2000',
-                            positionCoord: '10.68479;41.26906;EQ_J2000',
+                            positionCoordColumns: 'ra_obj;dec_obj;EQ_J2000',
                             datasource: 'image_url'
                         }
                     });

--- a/src/firefly/js/charts/ui/ColSelectView.jsx
+++ b/src/firefly/js/charts/ui/ColSelectView.jsx
@@ -68,7 +68,7 @@ export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonTe
         columns[3] = {name: 'Description', prefWidth: widths[3], visibility: 'show'};
     }
 
-    var tableModel = {totalRows: data.length, tbl_id:TBL_ID, tableData: {columns,  data }, highlightedRow: hlRowNum};
+    var tableModel = {totalRows: data.length, tbl_id:TBL_ID, tableData: {columns,  data }, highlightedRow: hlRowNum, onlyData: true};
 
     // 360 is the width of table options
     const minWidth = Math.max(columns.reduce((rval, c) => isFinite(c.prefWidth) ? rval+c.prefWidth : rval, 0), 360);

--- a/src/firefly/js/charts/ui/ColSelectView.jsx
+++ b/src/firefly/js/charts/ui/ColSelectView.jsx
@@ -68,7 +68,7 @@ export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonTe
         columns[3] = {name: 'Description', prefWidth: widths[3], visibility: 'show'};
     }
 
-    var tableModel = {totalRows: data.length, tbl_id:TBL_ID, tableData: {columns,  data }, highlightedRow: hlRowNum, onlyData: true};
+    var tableModel = {totalRows: data.length, tbl_id:TBL_ID, tableData: {columns,  data }, highlightedRow: hlRowNum};
 
     // 360 is the width of table options
     const minWidth = Math.max(columns.reduce((rval, c) => isFinite(c.prefWidth) ? rval+c.prefWidth : rval, 0), 360);

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -114,11 +114,7 @@ export function isMetaDataTable(tbl_id) {
 
     const hasDsCol= Boolean(Object.keys(tableMeta).find( (key) => key.toUpperCase()===dataSourceUpper));
 
-    if (tableMeta[MetaConst.DATASET_CONVERTER] || hasDsCol) return true;
-    if (tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] || tableMeta[MetaConst.CATALOG_COORD_COLS])  return false;
-    const converter= converterFactory(table);
-    return Boolean(converter);
-
+    return Boolean(tableMeta[MetaConst.DATASET_CONVERTER] || hasDsCol);
 }
 
 /**

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -6,7 +6,7 @@ import {take} from 'redux-saga/effects';
 import {filter, isEmpty, get} from 'lodash';
 
 import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo, dispatchUpdateLayoutInfo, dropDownHandler} from '../../core/LayoutCntlr.js';
-import {findGroupByTblId, getTblIdsByGroup, smartMerge} from '../../tables/TableUtil.js';
+import {findGroupByTblId, getTblIdsByGroup, smartMerge, getTblById} from '../../tables/TableUtil.js';
 import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
 import {CHART_ADD, CHART_REMOVE} from '../../charts/ChartsCntlr.js';
 
@@ -126,10 +126,13 @@ function onAnyAction(layoutInfo, action, views) {
     }
     return smartMerge(layoutInfo, {showTables, showImages, showXyPlots, autoExpand, mode: {expanded, standard, closeable}});
 }
-    
+
+var isOnlyTableData = (id) => (get(getTblById(id), 'onlyData'));
 
 function handleNewTable(layoutInfo, action) {
     const {tbl_id} = action.payload;
+
+    if (isOnlyTableData(tbl_id)) return layoutInfo;
     var {images={}, showImages} = layoutInfo;
     var {coverageLockedOn, showFits, showMeta, showCoverage, selectedTab, metaDataTableId} = images;
 

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -6,7 +6,7 @@ import {take} from 'redux-saga/effects';
 import {filter, isEmpty, get} from 'lodash';
 
 import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo, dispatchUpdateLayoutInfo, dropDownHandler} from '../../core/LayoutCntlr.js';
-import {findGroupByTblId, getTblIdsByGroup, smartMerge, getTblById} from '../../tables/TableUtil.js';
+import {findGroupByTblId, getTblIdsByGroup, smartMerge} from '../../tables/TableUtil.js';
 import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
 import {CHART_ADD, CHART_REMOVE} from '../../charts/ChartsCntlr.js';
 
@@ -127,12 +127,8 @@ function onAnyAction(layoutInfo, action, views) {
     return smartMerge(layoutInfo, {showTables, showImages, showXyPlots, autoExpand, mode: {expanded, standard, closeable}});
 }
 
-var isOnlyTableData = (id) => (get(getTblById(id), 'onlyData'));
-
 function handleNewTable(layoutInfo, action) {
     const {tbl_id} = action.payload;
-
-    if (isOnlyTableData(tbl_id)) return layoutInfo;
     var {images={}, showImages} = layoutInfo;
     var {coverageLockedOn, showFits, showMeta, showCoverage, selectedTab, metaDataTableId} = images;
 


### PR DESCRIPTION
This development is to
- Remove unexpected image tab and not unmount the column select ion popup after a column for Histogram is selected.
- skip to check if the table used for selecting the column is a catalog table or an image meta table after the table is loaded.

test: 
- start a catalog search (or lsst catalog search from lsst-pdac-triview.html)
- click 'Charts' (or 'Add Charts' for lsst)
- click 'Histogram' or 'Scattered plot' radio button.  click 'Cols' and select a column from the popup table. 
- the select column name is shown in the field for columns in chart select panel. 
