### PR TITLE
DM-9589: Fixed WISE case and add basic case with no images

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -379,7 +379,8 @@ function clearResults(layoutInfo) {
         periodState: LC.PERIOD_PAGE,
         missionEntries: null,
         generalEntries: null,
-        fullRawTable: null
+        fullRawTable: null,
+        error:''
     });
 }
 

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -25,6 +25,7 @@ import {getConverter} from './LcConverterFactory.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {makeMissionEntries, keepHighlightedRowSynced} from './LcUtil.jsx';
 import {dispatchMountFieldGroup} from '../../fieldGroup/FieldGroupCntlr.js';
+import {ERROR_MSG_KEY} from '../lightcurve/generic/errorMsg.js';
 
 export const LC = {
     RAW_TABLE: 'raw_table',          // raw table id
@@ -41,6 +42,7 @@ export const LC = {
 
     META_TIME_CNAME: 'ts_timeCName',
     META_FLUX_CNAME: 'ts_fluxCName',
+    META_FLUX_BAND: 'ts_bandName',
     META_ERR_CNAME: 'ts_errorCName',
     META_COORD_XNAME: 'ts_coordXName',
     META_COORD_YNAME: 'ts_coordYName',
@@ -60,10 +62,10 @@ export const LC = {
 
     META_TIME_NAMES: 'ts_timeNames',
     META_FLUX_NAMES: 'ts_fluxNames',
+    META_URL_NAMES: 'ts_datasources',
     META_ERR_NAMES: 'ts_errorNames',
 
     META_MISSION: MetaConst.TS_DATASET,
-
     MISSION_DATA: 'missionEntries',
     GENERAL_DATA:'generalEntries',
 
@@ -75,6 +77,10 @@ const plotIdRoot= 'LC_FRAME-';
 
 var defaultCutout = '0.2';
 //var defaultFlux = '';
+
+function getFluxBandName(layoutInfo) {
+    return get(layoutInfo, ['missionEntries', LC.META_FLUX_BAND]);
+}
 
 function getFluxColumn(layoutInfo) {
     return get(layoutInfo, ['missionEntries', LC.META_FLUX_CNAME]);
@@ -107,10 +113,21 @@ function getDataSource(layoutInfo) {
 function getImagePlotParams(layoutInfo) {
     return {timeCol: getTimeColumn(layoutInfo),
             fluxCol: getFluxColumn(layoutInfo),
+            bandName: getFluxBandName(layoutInfo),
             dataSource: getDataSource(layoutInfo),
             ra: getRA(layoutInfo),
             dec: getDEC(layoutInfo),
             coordSys: getCoordSys(layoutInfo)};
+}
+
+function getUserInputParams(layoutInfo) {
+    return {timeCol: getTimeColumn(layoutInfo),
+        fluxCol: getFluxColumn(layoutInfo),
+        bandName: getFluxBandName(layoutInfo),
+        dataSource: getDataSource(layoutInfo),
+        ra: getRA(layoutInfo),
+        dec: getDEC(layoutInfo),
+        coordSys: getCoordSys(layoutInfo)};
 }
 
 export function getConverterData(layoutInfo=getLayouInfo()) {
@@ -263,7 +280,7 @@ function handleValueChange(layoutInfo, action) {
             if (get(layoutInfo, ['displayMode']) === LC.RESULT_PAGE) {
                 layoutInfo = updateSet(layoutInfo, [LC.GENERAL_DATA, fieldKey], value);
                 clearLcImages();
-                setupImages(layoutInfo);
+                layoutInfo = setupImages(layoutInfo);
             }
         }
     } else if ([LC.META_COORD_XNAME, LC.META_COORD_YNAME, LC.META_COORD_SYS].includes(fieldKey)) {
@@ -271,7 +288,7 @@ function handleValueChange(layoutInfo, action) {
             if (get(layoutInfo, ['displayMode']) === LC.RESULT_PAGE) {
                 layoutInfo = updateSet(layoutInfo, [LC.MISSION_DATA, fieldKey], value);
                 clearLcImages();
-                setupImages(layoutInfo);
+                layoutInfo = setupImages(layoutInfo);
             }
         }
     } else {
@@ -285,7 +302,7 @@ function handleValueChange(layoutInfo, action) {
 
         const didChange = (el) => Object.keys(updates).includes(el) && updates[el] !== get(layoutInfo, [LC.MISSION_DATA, fieldKey]);
 
-        const newLayoutInfo = updateMerge(layoutInfo, LC.MISSION_DATA, updates);
+        let newLayoutInfo = updateMerge(layoutInfo, LC.MISSION_DATA, updates);
 
         if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME].some(didChange)) {
             const timeCol = get(newLayoutInfo, [LC.MISSION_DATA, LC.META_TIME_CNAME]);
@@ -298,7 +315,7 @@ function handleValueChange(layoutInfo, action) {
             }
 
             clearLcImages();
-            setupImages(newLayoutInfo);
+            newLayoutInfo = setupImages(newLayoutInfo);
 
             // update time or flux for period panel field group if it exists
             if (FieldGroupUtils.getGroupFields(LC.FG_PERIOD_FINDER)) {
@@ -306,9 +323,9 @@ function handleValueChange(layoutInfo, action) {
                 [{fieldKey: 'time', value: timeCol}, {fieldKey: 'flux', value: fluxCol}]);
             }
         }
-        if (didChange(LC.META_URL_CNAME)) {
+        if ([LC.META_URL_CNAME, LC.META_FLUX_BAND].some(didChange)) {
             clearLcImages();
-            setupImages(newLayoutInfo);
+            newLayoutInfo = setupImages(newLayoutInfo);
         }
 
         layoutInfo = newLayoutInfo;
@@ -352,12 +369,18 @@ function clearResults(layoutInfo) {
     removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
     clearLcImages();
 
-
     if (has(layoutInfo, [LC.MISSION_DATA])) {
         dispatchMountFieldGroup(getViewerGroupKey(get(layoutInfo, LC.MISSION_DATA)), false, false,
             null, null, [], undefined, true);
     }
-    return smartMerge(layoutInfo, {displayMode: LC.RESULT_PAGE, periodState: LC.PERIOD_PAGE, missionEntries: null, generalEntries: null, fullRawTable:null});
+    return smartMerge(layoutInfo, {
+        showImages: false,
+        displayMode: LC.RESULT_PAGE,
+        periodState: LC.PERIOD_PAGE,
+        missionEntries: null,
+        generalEntries: null,
+        fullRawTable: null
+    });
 }
 
 /**
@@ -392,11 +415,14 @@ function handleRawTableLoad(layoutInfo, tblId) {
         return;
     }
 
-    const {newLayoutInfo, shouldContinue} = converterData.onNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo);
+    const {newLayoutInfo, shouldContinue, validTable} = converterData.onNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo);
+    let newMissionEntries = get(newLayoutInfo, ['missionEntries']); // missionEntries could have changed after calling specific mission onRaw
     if (shouldContinue) {
         // additional changes to the loaded table
-        ensureValidRawTable(rawTable, missionEntries);
+        ensureValidRawTable(rawTable, newMissionEntries);
     }
+
+
     return newLayoutInfo;
 }
 
@@ -435,7 +461,7 @@ function handleTableLoad(layoutInfo, action) {
         keepHighlightedRowSynced(tbl_id, highlightedRow);
     }
     if (isImageEnabledTable(tbl_id)) {
-        layoutInfo = updateSet(layoutInfo, 'showImages', true);
+        layoutInfo = updateSet(layoutInfo, 'showImages', shouldImagesBeLayout(layoutInfo));
     }
 
     return layoutInfo;
@@ -451,7 +477,7 @@ function handleTableActive(layoutInfo, action) {
     const {tbl_id} = action.payload;
     if (isImageEnabledTable(tbl_id)) {
         layoutInfo = updateSet(layoutInfo, 'images.activeTableId', tbl_id);
-        setupImages(layoutInfo);
+        layoutInfo = setupImages(layoutInfo);
     }
 
     if (tbl_id === LC.PERIODOGRAM_TABLE || tbl_id === LC.PEAK_TABLE) {
@@ -486,7 +512,9 @@ function handleTableHighlight(layoutInfo, action) {
     if (tbl_id !== getActiveTableId(activeTableContainer)) return layoutInfo;
 
     if (isImageEnabledTable(tbl_id)) {
-        setupImages(layoutInfo);
+        layoutInfo = setupImages(layoutInfo);
+    }else{
+        //TODO Shouldn't show the layout at all if images can't be seen:
     }
 
     // update period field when it's selected from a table with period.
@@ -541,39 +569,52 @@ function isImageEnabledTable(tbl_id) {
     return [LC.PHASE_FOLDED, LC.RAW_TABLE].includes(tbl_id);
 }
 
+function shouldImagesBeLayout(layoutInfo){
+
+    const converterId = get(layoutInfo, [LC.MISSION_DATA, LC.META_MISSION]);
+    const converterData = converterId && getConverter(converterId);
+    if (!converterId || !converterData) {
+        return false;
+    }
+
+    return converterData.shouldImagesBeDisplayed(getUserInputParams(layoutInfo));
+}
+
 function handleChangeMultiViewLayout(layoutInfo) {
-    setupImages(layoutInfo);
+    layoutInfo = setupImages(layoutInfo);
     return layoutInfo;
 }
 
 export function setupImages(layoutInfo) {
+
+    const activeTableId = get(layoutInfo, 'images.activeTableId');
+
+    const tableModel = getTblById(activeTableId);
+    if (!tableModel || isNil(tableModel.highlightedRow) || get(tableModel, 'totalRows', 0) < 1) return;
+
+    const converterId = get(layoutInfo, [LC.MISSION_DATA, LC.META_MISSION]);
+    const converterData = converterId && getConverter(converterId);
+    if (!converterId || !converterData) {
+        return;
+    }
+
+    const viewer = getViewer(getMultiViewRoot(), LC.IMG_VIEWER_ID);
+    const count = get(viewer, 'layoutDetail.count', converterData.defaultImageCount);
+
+    var vr = visRoot();
+    const hasPlots = vr.plotViewAry.length > 0;
+    const newPlotIdAry = makePlotIds(tableModel.highlightedRow, tableModel.totalRows, count);
+    const maxPlotIdAry = makePlotIds(tableModel.highlightedRow, tableModel.totalRows, LC.MAX_IMAGE_CNT);
+    const cutoutSize = getCutoutSize(layoutInfo);
     try {
-        const activeTableId = get(layoutInfo, 'images.activeTableId');
-
-        const tableModel = getTblById(activeTableId);
-        if (!tableModel || isNil(tableModel.highlightedRow) || get(tableModel, 'totalRows',0) < 1) return;
-
-        const converterId = get(layoutInfo, [LC.MISSION_DATA,LC.META_MISSION]);
-        const converterData = converterId && getConverter(converterId);
-        if (!converterId || !converterData) {return;}
-
-        const viewer=  getViewer(getMultiViewRoot(),LC.IMG_VIEWER_ID);
-        const count= get(viewer, 'layoutDetail.count', converterData.defaultImageCount);
-
-        var vr= visRoot();
-        const hasPlots= vr.plotViewAry.length>0;
-        const newPlotIdAry= makePlotIds(tableModel.highlightedRow, tableModel.totalRows,count);
-        const maxPlotIdAry= makePlotIds(tableModel.highlightedRow, tableModel.totalRows,LC.MAX_IMAGE_CNT);
-        const cutoutSize = getCutoutSize(layoutInfo);
-
-        newPlotIdAry.forEach( (plotId) => {
-            var pv = getPlotViewById(vr,plotId);
-            const rowNum= Number(plotId.substring(plotIdRoot.length));
-            const webPlotReq = converterData.webplotRequestCreator(tableModel,rowNum, cutoutSize,
-                                                                   getImagePlotParams(layoutInfo));
+        newPlotIdAry.forEach((plotId) => {
+            var pv = getPlotViewById(vr, plotId);
+            const rowNum = Number(plotId.substring(plotIdRoot.length));
+            const webPlotReq = converterData.webplotRequestCreator(tableModel, rowNum, cutoutSize,
+                getImagePlotParams(layoutInfo));
 
             if (webPlotReq && (!pv || get(pv, ['request', 'params', 'Title']) !== webPlotReq.getTitle() ||
-                                      get(pv, ['request', 'params', 'UserDesc']) !== webPlotReq.getUserDesc()))  {
+                get(pv, ['request', 'params', 'UserDesc']) !== webPlotReq.getUserDesc())) {
                 dispatchPlotImage({
                     plotId, wpRequest: webPlotReq,
                     setNewPlotAsActive: false,
@@ -585,24 +626,32 @@ export function setupImages(layoutInfo) {
 
 
         dispatchReplaceViewerItems(LC.IMG_VIEWER_ID, newPlotIdAry);
-        const newActivePlotId= plotIdRoot+tableModel.highlightedRow;
+        const newActivePlotId = plotIdRoot + tableModel.highlightedRow;
         dispatchChangeActivePlotView(newActivePlotId);
 
-        vr= visRoot();
+        vr = visRoot();
 
         if (!vr.wcsMatchType && !hasPlots) {
-            dispatchWcsMatch({matchType:WcsMatchType.Target, plotId:newActivePlotId});
+            dispatchWcsMatch({matchType: WcsMatchType.Target, plotId: newActivePlotId});
         }
 
-        vr= visRoot();
+        vr = visRoot();
 
         vr.plotViewAry
-            .filter( (pv) => pv.plotId.startsWith(plotIdRoot))
-            .filter( (pv) => pv.plotId!==vr.mpwWcsPrimId)
-            .filter( (pv) => !maxPlotIdAry.includes(pv.plotId))
-            .forEach( (pv) => dispatchDeletePlotView({plotId:pv.plotId, holdWcsMatch:true}));
-    } catch (E){
-        console.log(E.toString());
+            .filter((pv) => pv.plotId.startsWith(plotIdRoot))
+            .filter((pv) => pv.plotId !== vr.mpwWcsPrimId)
+            .filter((pv) => !maxPlotIdAry.includes(pv.plotId))
+            .forEach((pv) => dispatchDeletePlotView({plotId: pv.plotId, holdWcsMatch: true}));
+
+        // Decide whether or not to show images, mission specific:
+        const imagesShown = converterData.shouldImagesBeDisplayed(layoutInfo);
+        layoutInfo = updateSet(layoutInfo, 'showImages', imagesShown);
+
+        return layoutInfo;
+    } catch (E) {
+        console.log(E.stack.split('\n')[0] + E.stack.split('\n')[1]);
+        layoutInfo = updateSet(layoutInfo, 'showImages', false);
+        return layoutInfo;
     }
 }
 

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -649,9 +649,9 @@ function LcPFOptions({fields, lastPeriod, periodList=[]}) {
                                  border: highlightBorder}}>
                         <ValidationField fieldKey={fKeyDef.period.fkey} />
                         <div>
-                            <button type='button' className='button std hl' onClick={revertPeriod}>
+                            {/*<button type='button' className='button std hl' onClick={revertPeriod}>
                                 {revertPeriodTxt}
-                            </button>
+                            </button>*/}
                         </div>
                     </div>
                     <div style={{marginLeft: 30}} >

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -97,31 +97,13 @@ export class LcResult extends Component {
         expanded = LO_VIEW.get(expanded) || LO_VIEW.none;
         const expandedProps = {expanded, ...content};
         const standardProps = {visToolbar, title, searchDesc, standard, ...content};
-        const converterId = get(missionEntries, LC.META_MISSION);
-        if (!isValidTable(converterId)) {
-            return (
-                <div style={{display:'flex', position:'absolute', border: '1px solid #a3aeb9', padding:20, fontSize:'150%'}}>
-                    {`Table uploaded is not ${getMissionName(converterId)} valid, missing image identifier columns.
-                      Please, select option 'Basic' for general table upload.`}
-                    <div>
-                        <HelpIcon helpId={'loadingTSV'}/>
-                    </div>
-                </div>
-            );
-        } else {
-            return (
-                expanded === LO_VIEW.none
-                    ? <StandardView key='res-std-view' {...standardProps} />
-                    : <ExpandedView key='res-exp-view' {...expandedProps} />
-            );
-        }
+
+        return (
+            expanded === LO_VIEW.none
+                ? <StandardView key='res-std-view' {...standardProps} />
+                : <ExpandedView key='res-exp-view' {...expandedProps} />
+        );
     }
-}
-
-function isValidTable(converterId) {
-    const converterData = converterId && getConverter(converterId);
-
-    return converterData && converterData.isTableUploadValid();
 }
 
 // eslint-disable-next-line

--- a/src/firefly/js/templates/lightcurve/LcUtil.jsx
+++ b/src/firefly/js/templates/lightcurve/LcUtil.jsx
@@ -43,7 +43,7 @@ export function makeMissionEntries(tableMeta, layoutInfo={}) {
         [LC.META_TIME_NAMES]: get(tableMeta, LC.META_TIME_NAMES, converterData.timeNames),
         [LC.META_FLUX_NAMES]: get(tableMeta, LC.META_FLUX_NAMES, converterData.yNames),
         [LC.META_ERR_NAMES]: get(tableMeta, LC.META_ERR_NAMES, converterData.yErrNames),
-        [LC.META_FLUX_BAND]: get(tableMeta, LC.META_ERR_NAMES, converterData.bandName)
+        [LC.META_FLUX_BAND]: get(tableMeta, LC.META_FLUX_BAND, converterData.bandName)
     });
     return {converterData, missionEntries};
 }

--- a/src/firefly/js/templates/lightcurve/LcUtil.jsx
+++ b/src/firefly/js/templates/lightcurve/LcUtil.jsx
@@ -42,7 +42,8 @@ export function makeMissionEntries(tableMeta, layoutInfo={}) {
         [LC.META_ERR_CNAME]: get(tableMeta, LC.META_ERR_CNAME, converterData.defaultYErrCname),
         [LC.META_TIME_NAMES]: get(tableMeta, LC.META_TIME_NAMES, converterData.timeNames),
         [LC.META_FLUX_NAMES]: get(tableMeta, LC.META_FLUX_NAMES, converterData.yNames),
-        [LC.META_ERR_NAMES]: get(tableMeta, LC.META_ERR_NAMES, converterData.yErrNames)
+        [LC.META_ERR_NAMES]: get(tableMeta, LC.META_ERR_NAMES, converterData.yErrNames),
+        [LC.META_FLUX_BAND]: get(tableMeta, LC.META_ERR_NAMES, converterData.bandName)
     });
     return {converterData, missionEntries};
 }

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -26,6 +26,7 @@ import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
 import {watchCatalogs} from '../../visualize/saga/CatalogWatcher.js';
+import {HelpIcon} from './../../ui/HelpIcon.jsx';
 
 
 const vFileKey = LC.FG_FILE_FINDER;
@@ -82,11 +83,14 @@ export class LcViewer extends Component {
 
     render() {
         var {isReady, menu={}, appTitle, appIcon, altAppIcon, dropDown,
-                dropdownPanels=[], footer, style, displayMode, missionEntries} = this.state;
+            dropdownPanels=[], footer, style, displayMode, missionEntries} = this.state;
         const {visible, view} = dropDown || {};
-        const periodProps = {displayMode, timeColName: get(missionEntries, [LC.META_TIME_CNAME]),
-                                          fluxColName: get(missionEntries, [LC.META_FLUX_CNAME])};
+        const periodProps = {
+            displayMode, timeColName: get(missionEntries, [LC.META_TIME_CNAME]),
+            fluxColName: get(missionEntries, [LC.META_FLUX_CNAME])
+        };
 
+        const missionName = get(missionEntries, 'missionName', '');
         dropdownPanels.push(<UploadPanel/>);
 
         if (!isReady) {
@@ -104,7 +108,8 @@ export class LcViewer extends Component {
                             {...{dropdownPanels} } />
                     </header>
                     <main>
-                        {displayMode&&displayMode.startsWith('period') ? <LcPeriod {...periodProps}/> : <LcResult/>}
+                        {displayMode && displayMode.startsWith('period') ? <LcPeriod {...periodProps}/> :
+                            <LcResult/>}
                     </main>
                 </div>
             );
@@ -148,9 +153,9 @@ function BannerSection(props) {
     const {menu, ...rest} = pickBy(props);
     return (
         <Banner key='banner'
-            menu={<Menu menu={menu} /> }
-            visPreview={<VisHeader showHeader={false}/> }
-            readout={<VisHeader showPreview={false}/> }
+                menu={<Menu menu={menu} /> }
+                visPreview={<VisHeader showHeader={false}/> }
+                readout={<VisHeader showPreview={false}/> }
             {...rest}
         />
     );
@@ -168,7 +173,9 @@ BannerSection.propTypes = {
 export function UploadPanel(props) {
     const wrapperStyle = {margin: '5px 0'};
 
-    const options = getAllConverterIds().map((id) => { return {label: getMissionName(id)||capitalize(id), value: id}; });
+    const options = getAllConverterIds().map((id) => {
+        return {label: getMissionName(id) || capitalize(id), value: id};
+    });
     return (
         <div style={{padding: 10}}>
             <FormPanel
@@ -179,22 +186,22 @@ export function UploadPanel(props) {
                 help_id={'loadingTSV'}>
                 <FieldGroup groupKey={vFileKey} validatorFunc={null} keepState={true}>
                     <FileUpload
-                        wrapperStyle = {wrapperStyle}
-                        fieldKey = 'rawTblSource'
-                        initialState= {{
+                        wrapperStyle={wrapperStyle}
+                        fieldKey='rawTblSource'
+                        initialState={{
                             tooltip: 'Select a Time Series Table file to upload',
                             label: 'Time Series Table:'
                         }}
                     />
                     <ListBoxInputField fieldKey='mission'
-                        wrapperStyle = {wrapperStyle}
-                        initialState= {{
+                                       wrapperStyle={wrapperStyle}
+                                       initialState={{
                             value: 'wise',
                             tooltip: 'Enter the name of the mission',
                             label : 'Mission:',
                             labelWidth : 45
                         }}
-                        options={options}
+                                       options={options}
                     />
                 </FieldGroup>
             </FormPanel>
@@ -211,7 +218,7 @@ UploadPanel.defaultProps = {
 };
 
 function onSearchSubmit(request) {
-    if ( request.rawTblSource ){
+    if (request.rawTblSource) {
         const {mission} = request;
         const converter = getConverter(request.mission);
         if (!converter) return;
@@ -219,7 +226,7 @@ function onSearchSubmit(request) {
         const treq = converter.rawTableRequest(converter, request.rawTblSource);
         dispatchTableSearch(treq, {removable: true});
         dispatchHideDropDown();
-    } 
+    }
 }
 
 

--- a/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
@@ -1,0 +1,297 @@
+import React, {Component, PropTypes} from 'react';
+import sCompare from 'react-addons-shallow-compare';
+import {get, has, isEmpty, set} from 'lodash';
+import {FieldGroup} from '../../../ui/FieldGroup.jsx';
+import {ValidationField} from '../../../ui/ValidationField.jsx';
+import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
+import {makeFileRequest} from '../../../tables/TableUtil.js';
+import {getColumnIdx, getTblById, smartMerge} from '../../../tables/TableUtil.js';
+import {sortInfoString} from '../../../tables/SortInfo.js';
+import {ReadOnlyText, getTypeData} from '../LcUtil.jsx';
+import {LC, getViewerGroupKey} from '../LcManager.js';
+import {getMissionName, coordSysOptions} from '../LcConverterFactory.js';
+
+const labelWidth = 90;
+
+
+export class BasicSettingBox extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    shouldComponentUpdate(np, ns) {
+        return sCompare(this, np, ns);
+    }
+
+    render() {
+        var {generalEntries, missionEntries} = this.props;
+
+        if (isEmpty(generalEntries) || isEmpty(missionEntries)) return false;
+
+        const wrapperStyle = {margin: '3px 0'};
+        /*
+         var allCommonEntries = Object.keys(generalEntries).map((key) =>
+         <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
+         style={{width: 80}}/>
+         );
+         */
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME];
+        const missionUrl = [LC.META_URL_CNAME];
+        const missionOtherKeys = [LC.META_ERR_CNAME];
+        const tblModel = getTblById(LC.RAW_TABLE);
+        const topZ = 9999;
+
+        var getList = (val, type, valDefault) => {
+            var colType = (!type || (type === 'numeric')) ?
+                ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'] : ['char', 'c', 's', 'str'];
+
+            return get(tblModel, ['tableData', 'columns']).reduce((prev, col) => {
+                if ((colType.includes(col.type)) &&
+                    (!has(col, 'visibility') || get(col, 'visibility') !== 'hidden') &&
+                    (col.name.startsWith(val) || val === valDefault)) {
+                    prev.push(col.name);
+                }
+                return prev;
+            }, []);
+        };
+
+        var missionInputs = missionKeys.map((key) =>
+            <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle} popupIndex={topZ}
+                                  getSuggestions={(val) => getList(val)}/>
+        );
+
+        var missionData = missionUrl.map((key) =>
+            <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle} popupIndex={topZ}
+                                  getSuggestions={(val) => getList(val, 'char', '')}/>
+        );
+
+        var missionOthers = missionOtherKeys.map((key) =>
+            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}/>
+        );
+
+        const groupKey = getViewerGroupKey(missionEntries);
+        const converterId = get(missionEntries, LC.META_MISSION);
+
+        return (
+            <FieldGroup groupKey={groupKey}
+                        reducerFunc={basicOptionsReducer(missionEntries, generalEntries)} keepState={true}>
+                <div style={{display: 'flex', flexDirection: 'column'}}>
+                    {getMissionName(converterId) !== '' &&
+                    <ReadOnlyText label='Mission:' content={getMissionName(converterId)}
+                                  labelWidth={labelWidth} wrapperStyle={{margin: '3px 0 6px 0'}}/>}
+                    <div style={{display: 'flex'}}>
+                        <div>
+                            {missionInputs}
+                            {/*missionData*/}
+                        </div>
+                    </div>
+                </div>
+            </FieldGroup>
+        );
+    }
+}
+
+BasicSettingBox.propTypes = {
+    generalEntries: PropTypes.object,
+    missionEntries: PropTypes.object
+};
+
+function getStringCol(rawTbl) {
+    var colType = ['char', 'c', 's', 'str'];
+    let cols = get(rawTbl, 'tableData.columns');
+    let charCols = cols.filter((c) => {
+        return colType.includes(c.type)
+    });
+    let c = [];
+    charCols.forEach((el) => {
+        c.push(el.name);
+    });
+    return c;
+}
+
+function getNumCols(rawTbl) {
+    var colType = ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'];
+    let cols = get(rawTbl, 'tableData.columns');
+    let charCols = cols.filter((c) => {
+        return colType.includes(c.type)
+    });
+    let c = [];
+    charCols.forEach((el) => {
+        c.push(el.name);
+    });
+    return c;
+}
+
+export const basicOptionsReducer = (missionEntries, generalEntries) => {
+    return (inFields, action) => {
+        if (inFields) {
+            return inFields;
+        }
+
+        // defValues used to keep the initial values for parameters in the field group of result page
+        // time: time column
+        // flux: flux column
+        // timecols:  time column candidates
+        // fluxcols:  flux column candidates
+        // errorcolumm: error column
+        // cutoutsize: image cutout size
+        const defValues = {
+            [LC.META_TIME_CNAME]: Object.assign(getTypeData(LC.META_TIME_CNAME, '',
+                'Time column name',
+                'Time Column:', labelWidth),
+                {validator: null}),
+            [LC.META_FLUX_CNAME]: Object.assign(getTypeData(LC.META_FLUX_CNAME, '',
+                'Value column name',
+                'Value Column:', labelWidth),
+                {validator: null}),
+            [LC.META_TIME_NAMES]: Object.assign(getTypeData(LC.META_TIME_NAMES, '',
+                'Value column suggestion'),
+                {validator: null}),
+            [LC.META_FLUX_NAMES]: Object.assign(getTypeData(LC.META_FLUX_NAMES, '',
+                'Value column suggestion'),
+                {validator: null}),
+            ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
+                'image cutout size',
+                'Cutout Size (deg):', 100)),
+            [LC.META_URL_CNAME]: Object.assign(getTypeData(LC.META_URL_CNAME, '',
+                'Image url column name',
+                'Source Column:', labelWidth))
+        };
+
+        var defV = Object.assign({}, defValues);
+        const validators = getFieldValidators(missionEntries, getTblById(LC.RAW_TABLE));
+
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_URL_CNAME, LC.META_ERR_CNAME,
+            LC.META_COORD_XNAME, LC.META_COORD_YNAME, LC.META_COORD_SYS];
+        const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
+
+        missionListKeys.forEach((key) => {
+            set(defV, [key, 'value'], get(missionEntries, key, []));
+        });
+
+        // set value and validator
+        missionKeys.forEach((key) => {
+            set(defV, [key, 'value'], get(missionEntries, key, ''));
+            if (has(validators, key)) {
+                set(defV, [key, 'validator'], validators[key]);
+            }
+        });
+
+        /*
+         Object.keys(generalEntries).forEach((key) => {
+         set(defV, [key, 'value'], get(generalEntries, key, ''));
+         });
+         */
+        return defV;
+    };
+};
+
+
+function getFieldValidators(missionEntries, rawTable) {
+
+    const fldsWithValidators = [
+        {key: LC.META_TIME_CNAME, vkey: LC.META_TIME_NAMES},
+        {key: LC.META_FLUX_CNAME, vkey: LC.META_FLUX_NAMES},
+        {key: LC.META_URL_CNAME, vkey: LC.META_URL_NAMES}
+    ];
+    return fldsWithValidators.reduce((all, fld) => {
+        all[fld.key] =
+            (val) => {
+                let retVal = {valid: true, message: ''};
+                const cols = get(missionEntries, fld.vkey, []);
+                if (cols.length === 0 && rawTable) {
+                    if (getColumnIdx(rawTable, val) < 0) {
+                        retVal = {valid: false, message: `${val} is not a valid column name`};
+                    }
+                } else if (!cols.includes(val)) {
+                    retVal = {valid: false, message: `${val} is not a valid column name`};
+                }
+                return retVal;
+            };
+        return all;
+    }, {});
+}
+
+const posColumnInfo = (posCoords) => {
+    const posElement = [LC.META_COORD_XNAME, LC.META_COORD_YNAME, LC.META_COORD_SYS];
+    var posInfo = posElement.reduce((prev, ele) => {
+        prev[ele] = '';
+        return prev;
+    }, {});
+
+    if (posCoords) {
+        var s = posCoords.split(';');
+        if (s && s.length === 3) {
+            s.forEach((ele, idx) => posInfo[posElement[idx]] = ele);
+        }
+    }
+
+    return posInfo;
+};
+
+/**
+ * Return true if the user inputs make sense to show images in result layout
+ */
+export function imagesShouldBeDisplayed(layoutInfo) {
+
+    //Control image display by lookig at data source input field:
+    // if (isEmpty(get(layoutInfo, [LC.MISSION_DATA, LC.META_URL_CNAME]))) {
+    //    return false;
+    //}
+    //return get(layoutInfo, [LC.MISSION_DATA, LC.META_URL_CNAME]).length > 0;
+    //
+    return false;
+}
+
+/**
+ * Pregex pattern for wise, at least to find mjd and w1mpro if present
+ * @type {string[]}
+ */
+const xyColPattern = ['\\w*jd\\w*'];
+
+export function basicOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo = {}) {
+
+    // Update default values AND sortInfo and
+    const metaInfo = rawTable && rawTable.tableMeta;
+
+    let numericalCols = getNumCols(rawTable);
+
+    //let strCols = getStringCol(rawTable);
+    //strCols.push('');// Empty means no images
+    let defaultCTimeName = (getColumnIdx(rawTable, converterData.defaultTimeCName) > 0) ? converterData.defaultTimeCName : numericalCols[0];
+    let defaultYColName = (getColumnIdx(rawTable, converterData.defaultYCname) > 0) ? converterData.defaultYCname : numericalCols[1];
+
+    defaultCTimeName = numericalCols.filter((el) => {
+            if (el.toLocaleLowerCase().match(xyColPattern[0]) != null) {
+                return el;
+            }
+        })[0] || defaultCTimeName;
+    const defaultValues = {
+        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, defaultCTimeName),
+        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, defaultYColName)
+        //[LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, converterData.dataSource),
+        //[LC.META_URL_NAMES]: get(metaInfo, LC.META_URL_NAMES, strCols)
+    };
+
+    missionEntries = Object.assign({}, missionEntries, defaultValues);
+    const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries});
+    return {newLayoutInfo, shouldContinue: false};
+}
+
+export function basicRawTableRequest(converter, source) {
+    const options = {
+        tbl_id: LC.RAW_TABLE,
+        sortInfo: sortInfoString('mjd'),   //TODO: tentative solution to get around 'ROWID' issue
+        tblType: 'notACatalog',
+        META_INFO: {[LC.META_MISSION]: converter.converterId},
+        pageSize: LC.TABLE_PAGESIZE
+    };
+    return makeFileRequest('Input Data', source, null, options);
+
+}
+
+export function basicOnFieldUpdate(fieldKey, value) {
+    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME].includes(fieldKey)) {
+        return {[fieldKey]: value};
+    }
+}

--- a/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
@@ -39,7 +39,7 @@ export class BasicSettingBox extends Component {
         const missionUrl = [LC.META_URL_CNAME];
         const missionOtherKeys = [LC.META_ERR_CNAME];
         const tblModel = getTblById(LC.RAW_TABLE);
-        const topZ = 9999;
+        const topZ = 3;
 
         var getList = (val, type, valDefault) => {
             var colType = (!type || (type === 'numeric')) ?

--- a/src/firefly/js/templates/lightcurve/basic/BasicPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/basic/BasicPlotRequests.js
@@ -1,0 +1,28 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {getCellValue, getColumnIdx} from '../../../tables/TableUtil.js';
+import {WebPlotRequest} from '../../../visualize/WebPlotRequest.js';
+import {makeWorldPt} from '../../../visualize/Point.js';
+import {CoordinateSys} from '../../../visualize/CoordSys.js';
+import {addCommonReqParams, COORD_SYSTEM_OPTIONS} from '../LcConverterFactory.js';
+
+export function basicURLPlotRequest(table, rowIdx, cutoutSize, params = {}) {
+
+
+    const {dataSource, timeCol} = params;
+    try {
+        // create plot request on either valid or invalid parameters
+        const url = getCellValue(table, rowIdx, dataSource);
+        const time = getCellValue(table, rowIdx, timeCol);
+        const plot_desc = `Table-${time || 'null'}-${dataSource || 'null'}`;
+
+
+        const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);
+        const title = `Table-${time || 'null'}`;
+
+        return addCommonReqParams(reqParams, title, null);
+    } catch (E) {
+        throw new Error('Datasource field is empty, don\'t show images');
+    }
+}

--- a/src/firefly/js/templates/lightcurve/generic/errorMsg.js
+++ b/src/firefly/js/templates/lightcurve/generic/errorMsg.js
@@ -1,0 +1,3 @@
+export const ERROR_MSG_KEY = {
+    IMAGE_FETCH: 'imageFetchedError'
+}

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -1,15 +1,18 @@
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {get, has, isEmpty, set} from 'lodash';
+import {get, has, isEmpty, set, pick, cloneDeep} from 'lodash';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
-import {makeFileRequest, getTblById, smartMerge} from '../../../tables/TableUtil.js';
+import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
+import {getLayouInfo} from '../../../core/LayoutCntlr.js';
+import {makeFileRequest, getCellValue, getTblById, getColumnIdx, smartMerge} from '../../../tables/TableUtil.js';
+import {updateMerge} from '../../../util/WebUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {ReadOnlyText, getTypeData} from '../LcUtil.jsx';
 import {LC, getViewerGroupKey} from '../LcManager.js';
 import {getMissionName} from '../LcConverterFactory.js';
-
+import {isNil} from 'lodash';
 
 const labelWidth = 80;
 
@@ -29,6 +32,23 @@ export class WiseSettingBox extends Component {
 
         const wrapperStyle = {margin: '3px 0'};
 
+        const tblModel = getTblById(LC.RAW_TABLE);
+        //const validTimes = get(missionEntries, LC.META_FLUX_NAMES, []);
+        //const validValues = get(missionEntries, LC.META_FLUX_NAMES, []);
+
+        var getList = (val, type) => {
+            var colType = (!type || type === 'numeric') ?
+                ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'] : ['char', 'c', 's', 'str', 'double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'];
+
+            return get(tblModel, ['tableData', 'columns']).reduce((prev, col) => {
+                if ((colType.includes(col.type)) &&
+                    (!has(col, 'visibility') || get(col, 'visibility') !== 'hidden') &&
+                    (col.name.startsWith(val))) {
+                    prev.push(col.name);
+                }
+                return prev;
+            }, []);
+        };
         var allCommonEntries = Object.keys(generalEntries).map((key) =>
             <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
                              style={{width: 80}}/>
@@ -36,39 +56,61 @@ export class WiseSettingBox extends Component {
 
         const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME];
         const missionOtherKeys = [LC.META_ERR_CNAME];
+        const imageDataSource = [LC.META_URL_CNAME]; // use meta_url from generic case, see LcManager.js:320 for why
         const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
-
+        const topZ = 9999;
         var missionInputs = missionKeys.map((key, index) =>
-            <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle}
-                                  getSuggestions={(val) => {
-                                    const list = get(missionEntries, missionListKeys[index], []);
-                                    const suggestions =  list && list.filter((el) => {return el.startsWith(val);});
-                                    return suggestions.length > 0 ? suggestions : list;
-                                  }}
-            />
+            <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle} popupIndex={topZ}
+                                  getSuggestions={(val) => getList(val, 'numeric')}/>
         );
 
-        var missionOthers = missionOtherKeys.map((key) =>
-            <ValidationField key={key} fieldKey={key} wrapperStyle={wrapperStyle}/>
+        var missionData = imageDataSource.map((key) =>
+            <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle} popupIndex={topZ}
+                                  getSuggestions={(val) => getList(val)}/>
         );
 
-
+        //const frameId = getColumnIdx(tblModel, 'frame_id');
+        //var missionOthers = (frameId) => {
+        //    if (frameId > -1) {
+        //        return <RadioGroupInputField key='band'
+        //                                     fieldKey='band' wrapperStyle={wrapperStyle}
+        //                                     alignment='horizontal'
+        //                                     options={[
+        //            {label: 'W1', value: 'w1'},
+        //            {label: 'W2', value: 'w2'},
+        //            {label: 'W3', value: 'w3'},
+        //            {label: 'W4', value: 'w4'}
+        //        ]}/>;
+        //    } else {
+        //        return <div><em>frame_id</em> column is missing, no images will be displayed </div>;
+        //    }
+        //};
+        var missionOthers = <RadioGroupInputField key='band'
+                                                  fieldKey={LC.META_FLUX_BAND} wrapperStyle={wrapperStyle}
+                                                  alignment='horizontal'
+                                                  options={[
+                    {label: 'W1', value: 'w1'},
+                    {label: 'W2', value: 'w2'},
+                    {label: 'W3', value: 'w3'},
+                    {label: 'W4', value: 'w4'}
+                ]}/>;
         const groupKey = getViewerGroupKey(missionEntries);
         const converterId = get(missionEntries, LC.META_MISSION);
-        var   missionName = getMissionName(converterId) || 'Mission';
+        var missionName = getMissionName(converterId) || 'Mission';
 
         return (
             <FieldGroup groupKey={groupKey}
                         reducerFunc={wiseOptionsReducer(missionEntries, generalEntries)} keepState={true}>
-                <div style={{display: 'flex', alignItems: 'flex-end'}} >
+                <div style={{display: 'flex', alignItems: 'flex-end'}}>
                     <div >
                         <ReadOnlyText label='Mission:' content={missionName}
                                       labelWidth={labelWidth} wrapperStyle={{margin: '3px 0 6px 0'}}/>
 
                         {missionInputs}
-                        {/* missionOthers */}
+                        {/*missionData*/}
                     </div>
-                    <div>
+                    <div style={{padding: '0 6px 0 6px', border: '1px solid #a3aeb9'}}>
+                        {missionOthers}
                         {allCommonEntries}
                     </div>
                 </div>
@@ -97,31 +139,37 @@ export const wiseOptionsReducer = (missionEntries, generalEntries) => {
         // errorcolumm: error column
         // cutoutsize: image cutout size
         const defValues = {
+            [LC.META_FLUX_BAND]: Object.assign(getTypeData(LC.META_FLUX_BAND, '',
+                'Select WISE band for images to be displayed',
+                'Image display:', 70)),
             [LC.META_TIME_CNAME]: Object.assign(getTypeData(LC.META_TIME_CNAME, '',
                 'time column name',
                 'Time Column:', labelWidth),
                 {validator: null}),
             [LC.META_FLUX_CNAME]: Object.assign(getTypeData(LC.META_FLUX_CNAME, '',
-                'flux column name',
-                'Flux Column:', labelWidth),
+                'value column name',
+                'Value Column:', labelWidth),
                 {validator: null}),
             [LC.META_TIME_NAMES]: Object.assign(getTypeData(LC.META_TIME_NAMES, '',
                 'time column suggestion'),
                 {validator: null}),
             [LC.META_FLUX_NAMES]: Object.assign(getTypeData(LC.META_FLUX_NAMES, '',
-                'flux column suggestion'),
+                'value column suggestion'),
                 {validator: null}),
             ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
                 'image cutout size',
                 'Cutout Size (deg):', 100)),
+            [LC.META_URL_CNAME]: Object.assign(getTypeData(LC.META_URL_CNAME, '',
+                'WISE Image identifier column name (frame_id)',
+                'Image Column:', labelWidth)),
             [LC.META_ERR_CNAME]: Object.assign(getTypeData(LC.META_ERR_CNAME, '',
-                'flux error column name',
+                'value error column name',
                 'Error Column:', labelWidth))
         };
 
-        var   defV = Object.assign({}, defValues);
+        var defV = Object.assign({}, defValues);
 
-        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME];
+        const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_URL_CNAME];
         const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
         const validators = getFieldValidators(missionEntries, getTblById(LC.RAW_TABLE));
 
@@ -144,13 +192,13 @@ export const wiseOptionsReducer = (missionEntries, generalEntries) => {
 };
 
 
-
 function getFieldValidators(missionEntries) {
     const fldsWithValidators = [
         {key: LC.META_TIME_CNAME, vkey: LC.META_TIME_NAMES},
-        {key: LC.META_FLUX_CNAME, vkey: LC.META_FLUX_NAMES}
+        {key: LC.META_FLUX_CNAME, vkey: LC.META_FLUX_NAMES},
+        {key: LC.META_URL_CNAME}
         //{key: LC.META_ERR_CNAME, vkey: LC.META_ERR_NAMES} // error can have no value
-        ];
+    ];
     return fldsWithValidators.reduce((all, fld) => {
         all[fld.key] =
             (val) => {
@@ -164,10 +212,129 @@ function getFieldValidators(missionEntries) {
         return all;
     }, {});
 }
+/*
+ function setFields(missionEntries, generalEntries) {
+ const groupKey = getViewerGroupKey(missionEntries);
+ const fields = FieldGroupUtils.getGroupFields(groupKey);
+ const validators = getFieldValidators(missionEntries);
+ if (fields) {
+ const initState = Object.keys(fields).reduce((prev, fieldKey) => {
+ if (has(missionEntries, fieldKey)) {
+ prev.push({fieldKey, value: get(missionEntries, fieldKey), validator: validators[fieldKey]});
+ } else if (has(generalEntries,fieldKey)) {
+ prev.push({fieldKey, value: get(generalEntries, fieldKey)});
+ }
+ return prev;
+ }, []);
+ dispatchMultiValueChange(groupKey, initState);
+ }
+ }
+ */
 
+/**
+ * Returns only numerical column names form raw lc table
+ * @returns {[TableColumn]} - array of table columns objects
+ */
+function getOnlyNumericalCol(rawTbl) {
+    //let cols = get(rawTbl, 'tableData.columns');
+    //let cnum = cols.filter((c) => c.type != 'char');
+    //let c = [];
+    //cnum.forEach((el) => {
+    //    c.push(el.name);
+    //});
+    //return c;
+
+    var colType = ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'];
+    return get(rawTbl, ['tableData', 'columns']).reduce((prev, col) => {
+        if ((colType.includes(col.type)) &&
+            (!has(col, 'visibility') || get(col, 'visibility') !== 'hidden')) {
+            prev.push(col.name);
+        }
+        return prev;
+    }, []);
+}
+
+/**
+ * Check if this is WISE MEP table on upload, otherise bailout
+ * @returns {boolean} error message to be picked up by UI
+ */
+export function isBasicTableUploadValid() {
+
+    const tableModel = getTblById(LC.RAW_TABLE);
+    // For wcs target match and overlay
+    const ra = getCellValue(tableModel, 0, 'ra');
+    const dec = getCellValue(tableModel, 0, 'dec');
+
+    // For images from AllWise:
+    const frameId = getCellValue(tableModel, 0, 'frame_id');
+
+    // For other single exposure tables (NEOWISE, etc)
+    const frameNum = getCellValue(tableModel, 0, 'frame_num');
+    const scanId = getCellValue(tableModel, 0, 'scan_id');
+    const sourceId = getCellValue(tableModel, 0, 'source_id');
+
+    // For now, bailout when images fetched will fail:
+    if(isNil(frameId)){
+        if(isNil(sourceId)){
+           return (!isNil(scanId) && !isNil(frameNum));
+        }else{
+            return true;
+        }
+    }else{
+        return true;
+    }
+}
+
+/**
+ * Pregex pattern for wise, at least to find mjd and w1mpro if present
+ * @type {string[]}
+ */
+const xyColPattern = ['\\w*jd\\w*', 'w[1-4]mpro\\w*'];
 export function wiseOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo) {
+
+    // Update default values AND sortInfo and
+    const metaInfo = rawTable && rawTable.tableMeta;
+
+    let numericalCols = getOnlyNumericalCol(rawTable);
+
+    //Find column based on a pattern, if not, just get the constant value from the converter (=mjd, =w1mpro_ep)
+
+    let defaultCTimeName = (getColumnIdx(rawTable, converterData.defaultTimeCName) > 0) ? converterData.defaultTimeCName : numericalCols[0];
+    let defaultYColName = (getColumnIdx(rawTable, converterData.defaultYCname) > 0) ? converterData.defaultYCname : numericalCols[1];
+    let defaultDataSource = (getColumnIdx(rawTable, converterData.dataSource) > 0) ? converterData.dataSource : numericalCols[3];
+
+    defaultYColName = numericalCols.filter((el) => {
+            if (el.toLocaleLowerCase().match(xyColPattern[1]) != null) {
+                return el;
+            }
+        })[0] || defaultYColName;
+    defaultCTimeName = numericalCols.filter((el) => {
+            if (el.toLocaleLowerCase().match(xyColPattern[0]) != null) {
+                return el;
+            }
+        })[0] || defaultCTimeName;
+    const defaultValues = {
+        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, defaultCTimeName),
+        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, defaultYColName),
+        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES, numericalCols),
+        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES, numericalCols),
+        [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, defaultDataSource),
+        [LC.META_FLUX_BAND]: get(metaInfo, LC.META_FLUX_BAND, 'w1')
+    };
+
+    missionEntries = Object.assign({}, missionEntries, defaultValues);
+    //
+    //
+    //var {rawTableRequest} = layoutInfo;
+    //rawTableRequest = cloneDeep(rawTable.request);
+    //const options = {
+    //    sortInfo: sortInfoString(defaultCTimeName),
+    //    META_INFO: {...pick(missionEntries, [LC.META_MISSION, LC.META_TIME_CNAME, LC.META_FLUX_CNAME])}
+    //};
+
+
     const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries});
-    return {newLayoutInfo, shouldContinue: true};
+    return {newLayoutInfo, shouldContinue: false};
 }
 
 export function wiseRawTableRequest(converter, source) {
@@ -175,16 +342,18 @@ export function wiseRawTableRequest(converter, source) {
     const mission = converter.converterId;
     const options = {
         tbl_id: LC.RAW_TABLE,
-        sortInfo: sortInfoString(timeCName),
+        sortInfo: sortInfoString(timeCName), // if present, it will skip LcManager.js#ensureValidRawTable
         META_INFO: {[LC.META_MISSION]: mission, timeCName},
         pageSize: LC.TABLE_PAGESIZE
     };
-    return makeFileRequest('Raw Table', source, null, options);
+    return makeFileRequest('Input Data', source, null, options);
 
 }
 
 export function wiseOnFieldUpdate(fieldKey, value) {
-    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_ERR_CNAME].includes(fieldKey)) {
-        return {[fieldKey] : value};
+
+    // images are controlled by radio button -> band w1,w2,w3,w4.
+    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME, LC.META_FLUX_BAND].includes(fieldKey)) {
+        return {[fieldKey]: value};
     }
 }

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -58,7 +58,7 @@ export class WiseSettingBox extends Component {
         const missionOtherKeys = [LC.META_ERR_CNAME];
         const imageDataSource = [LC.META_URL_CNAME]; // use meta_url from generic case, see LcManager.js:320 for why
         const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
-        const topZ = 9999;
+        const topZ = 3;
         var missionInputs = missionKeys.map((key, index) =>
             <SuggestBoxInputField key={key} fieldKey={key} wrapperStyle={wrapperStyle} popupIndex={topZ}
                                   getSuggestions={(val) => getList(val, 'numeric')}/>
@@ -295,6 +295,25 @@ export function wiseOnNewRawTable(rawTable, missionEntries, generalEntries, conv
     // Update default values AND sortInfo and
     const metaInfo = rawTable && rawTable.tableMeta;
 
+    let error = '';
+    if(!isBasicTableUploadValid()){
+        const frameId = getCellValue(rawTable, 0, 'frame_id');
+        const sourceId = getCellValue(rawTable, 0, 'source_id');
+        const frameNum = getCellValue(rawTable, 0, 'frame_num');
+        const scanId = getCellValue(rawTable, 0, 'scan_id');
+        var a = [];
+        isNil(frameId) ? a.push('frame_id') :'';
+        isNil(sourceId) ? a.push('source_id'):'';
+        isNil(scanId) ? a.push('scan_id') : '';
+        isNil(frameNum) ? a.push('frame_num'):'';
+
+        for (let i=0; i< a.length-1;i++){
+            error+= a[i]+', ';
+        }
+        error+= a[a.length-1];
+    }
+
+
     let numericalCols = getOnlyNumericalCol(rawTable);
 
     //Find column based on a pattern, if not, just get the constant value from the converter (=mjd, =w1mpro_ep)
@@ -333,7 +352,7 @@ export function wiseOnNewRawTable(rawTable, missionEntries, generalEntries, conv
     //};
 
 
-    const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries});
+    const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries, error});
     return {newLayoutInfo, shouldContinue: false};
 }
 

--- a/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
@@ -6,6 +6,8 @@ import {WebPlotRequest} from '../../../visualize/WebPlotRequest.js';
 import {makeWorldPt} from '../../../visualize/Point.js';
 import {CoordinateSys} from '../../../visualize/CoordSys.js';
 import {ServerRequest} from '../../../data/ServerRequest.js';
+import {isNil, isEmpty} from 'lodash';
+import {ERROR_MSG_KEY} from '../generic/errorMsg.js';
 
 import {addCommonReqParams} from '../LcConverterFactory.js';
 
@@ -13,55 +15,107 @@ export function makeWisePlotRequest(table, rowIdx, cutoutSize) {
     const ra = getCellValue(table, rowIdx, 'ra');
     const dec = getCellValue(table, rowIdx, 'dec');
     const frameId = getCellValue(table, rowIdx, 'frame_id');
-    var   wise_sexp_ibe = /(\d+)([0-9][a-z])(\w+)/g;
-    var   res = wise_sexp_ibe.exec(frameId);
+
+    var wise_sexp_ibe = /(\d+)([0-9][a-z])(\w+)/g;
+    var res = wise_sexp_ibe.exec(frameId);
     const scan_id = res[1] + res[2];
     const scangrp = res[2];
     const frame_num = res[3];
-
+    //const band=`${params.fluxCol}`.match(/\d/g);
+    const band = 1;
     /*the following should be from reading in the url column returned from LC search
      we are constructing the url for wise as the LC table does
      not have the url column yet
      It is only for WISE, using default cutout size 0.3 deg
-    const url = `http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w1-int-1b.fits`;
-    */
+     const url = `http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w1-int-1b.fits`;
+     */
     const serverinfo = 'http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/';
     const centerandsize = cutoutSize ? `?center=${ra},${dec}&size=${cutoutSize}&gzip=false` : '';
-    const url = `${serverinfo}${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w1-int-1b.fits${centerandsize}`;
+    const url = `${serverinfo}${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w${band}-int-1b.fits${centerandsize}`;
     const plot_desc = `WISE-${frameId}`;
     const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);
-    const title= 'WISE-'+ frameId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
-    return addCommonReqParams(reqParams, title, makeWorldPt(ra,dec,CoordinateSys.EQ_J2000));
+    const title = 'WISE-' + frameId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+    return addCommonReqParams(reqParams, title, makeWorldPt(ra, dec, CoordinateSys.EQ_J2000));
 }
 
 
-export function getWebPlotRequestViaWISEIbe(tableModel, hlrow, cutoutSize, params={fluxCol:'w1mpro_ep'}) {
+/**
+ *
+ * @param tableModel
+ * @param hlrow
+ * @param cutoutSize
+ * @param params object attribute match the LcManager#getImagePlotParams()
+ * @returns {WebPlotRequest}
+ */
+export function getWebPlotRequestViaWISEIbe(tableModel, hlrow, cutoutSize, params = {
+    bandName: 'w1',
+    fluxCol: 'w1mpro_ep',
+    dataSource: 'frame_id'
+}) {
     const ra = getCellValue(tableModel, hlrow, 'ra');
     const dec = getCellValue(tableModel, hlrow, 'dec');
+
+    //For images from AllWise:
     const frameId = getCellValue(tableModel, hlrow, 'frame_id');
-    var   wise_sexp_ibe = /(\d+)([0-9][a-z])(\w+)/g;
-    var   res = wise_sexp_ibe.exec(frameId);
-    const scan_id = res[1] + res[2];
-    const scangrp = res[2];
-    const frame_num = res[3];
-    const band=`${params.fluxCol}`.match(/\d/g);
-    const title= 'WISE-W'+ band + '-'+ frameId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+    // For other single exposure tables (NEOWISE, etc)
+    const frameNum = getCellValue(tableModel, hlrow, 'frame_num');
+    const scanId = getCellValue(tableModel, hlrow, 'scan_id');
+    const sourceId = getCellValue(tableModel, hlrow, 'source_id');
 
-    const sr= new ServerRequest('ibe_file_retrieve');
-    sr.setParam('mission', 'wise');
-    sr.setParam('PROC_ID', 'ibe_file_retrieve');
-    sr.setParam('ProductLevel',  '1b');
-    sr.setParam('ImageSet', 'merge');
-    sr.setParam('band', `${band}`);
-    sr.setParam('scangrp', `${scangrp}`);
-    sr.setParam('scan_id', `${scan_id}`);
-    sr.setParam('frame_num', `${frame_num}`);
-    sr.setParam('center', `${ra},${dec}`);
-    sr.setParam('size', `${cutoutSize}`);
-    sr.setParam('subsize', `${cutoutSize}`);
-    sr.setParam('in_ra',`${ra}`);
-    sr.setParam('in_dec',`${dec}`);
+    try {
+        var wise_sexp_ibe = /(\d+)([0-9][a-z])(\w+)/g;
+        var tmpId = '';
+        var res;
+        if (!isNil(frameId)) {
+            res = wise_sexp_ibe.exec(frameId);
+            tmpId = frameId;
+        } else if (!isNil(sourceId)) {
+            res = wise_sexp_ibe.exec(sourceId.substring(0, sourceId.indexOf('-')));
+            tmpId = sourceId;
+        } else {
+            tmpId = `${scanId}${frameNum}`;
+            res = wise_sexp_ibe.exec(tmpId);
+        }
 
-    const reqParams = WebPlotRequest.makeProcessorRequest(sr, 'wise');
-    return addCommonReqParams(reqParams, title, makeWorldPt(ra,dec,CoordinateSys.EQ_J2000));
+        const scan_id = res[1] + res[2];
+        const scangrp = res[2];
+        const frame_num = res[3];
+
+        // flux/value column control this | unless UI has radio button band enabled, put bandName back here to match band
+        const band = `${params.bandName}`.match(/[1-4]/i);// `${params.fluxCol}`.match(/w[1-4]/i); //check if name has wW[1-4] in name
+
+
+        let title = 'WISE-W' + band + '-' + tmpId;
+
+        const sr = new ServerRequest('ibe_file_retrieve');
+        sr.setParam('mission', 'wise');
+        sr.setParam('PROC_ID', 'ibe_file_retrieve');
+        sr.setParam('ProductLevel', '1b');
+
+        // TODO the value ImageSet should be collected in the server or passed in here from properties,
+        // specially to handle WISE internal case
+        sr.setParam('ImageSet', 'merge');
+
+        sr.setParam('band', `${band}`);
+        sr.setParam('scangrp', `${scangrp}`);
+        sr.setParam('scan_id', `${scan_id}`);
+        sr.setParam('frame_num', `${frame_num}`);
+        var wp = null;
+        sr.setParam('doCutout', 'false');
+        if (!isNil(ra) && !isNil(dec)) {
+            sr.setParam('center', `${ra},${dec}`);
+            sr.setParam('in_ra', `${ra}`);
+            sr.setParam('in_dec', `${dec}`);
+            wp = makeWorldPt(ra, dec, CoordinateSys.EQ_J2000);
+            sr.setParam('doCutout', 'true');
+            sr.setParam('size', `${cutoutSize}`);
+            sr.setParam('subsize', `${cutoutSize}`);
+            title = 'WISE-W' + band + '-' + tmpId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+        }
+
+        const reqParams = WebPlotRequest.makeProcessorRequest(sr, 'wise');
+        return addCommonReqParams(reqParams, title, wp);
+    } catch (E) {
+        throw new Error(E.message + ': as a consequence, images will fail', ERROR_MSG_KEY.IMAGE_FETCH);
+    }
 }


### PR DESCRIPTION
This is a fix for the basic case and neowise tables.

I've introduced a basic case which suppose to handle all numerical column of a general table uploaded in order to allow user to find the period and phase fold, with no images to be displayed.

I have added to the converter cases, 2 new functions, one about the images layout and another one to validate the table uploaded.

The case for WISE is trickier because we need to support tables that contains either frame_id or source_id or scanId and frame_num to be able to display WISE single exposure images. I've changed the WISE plot request and add specific function to validate the table. If the table doesn't have those column, the viewer will bailout in a message (the current message will be reviewed and is not definitive) to let the user know that although the table upload is not valid for WISE/NEOWISE, it can still upload by selecting the basic option.

On table load has changed in order to get the layoutInfo object updated which is acting as changing state to for layout result display, where showImages control the final layout.

To test, please, upload table for different cases and see if the above make sense, otherwise, come to me and let me know your questions.

WISE and Basic case are those that should go for release next week or so.
Generic case has more advanced options and should be reviewed to be included in future releases.
