### PR TITLE
DM-9743 Time column name handling for Time Series Viewer

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -852,3 +852,32 @@ export function isTableUsingRadians(tableOrMeta) {
 export function createErrorTbl(tbl_id, error) {
     return {tbl_id, error};
 }
+
+
+/**
+ * @summary get column names from the column of numeric type
+ * @param {Array} tblColumns
+ * @returns {Array}
+ */
+export function getNumericColNames(tblColumns) {
+    const NumTypes = ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'];
+
+    return isEmpty(tblColumns) ? [] :
+                tblColumns.filter((tblCol) => (get(tblCol, 'visibility', '') !== 'hidden'))
+                    .filter((tblCol) => (NumTypes.includes(tblCol.type)))
+                    .map((tblCol) => (tblCol.name));
+}
+
+/**
+ * @summary get column names from the column of string or char type
+ * @param {Array} tblColumns
+ * @returns {Array}
+ */
+export function getStringColNames(tblColumns) {
+    const CharTypes = ['char', 'c', 's', 'str'];
+
+    return isEmpty(tblColumns) ? [] :
+                tblColumns.filter((tblCol) => (get(tblCol, 'visibility', '') !== 'hidden'))
+                    .filter((tblCol) => (CharTypes.includes(tblCol.type)))
+                    .map((tblCol) => (tblCol.name));
+}

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -90,7 +90,8 @@ const converters = {
         dataSource: 'frame_id',
         webplotRequestCreator: getWebPlotRequestViaWISEIbe,
         shouldImagesBeDisplayed: () => {return true;},
-        isTableUploadValid: isBasicTableUploadValid
+        isTableUploadValid: isBasicTableUploadValid,
+        yNamesChangeImage: []
     },
     'lsst_sdss': {
         converterId: 'lsst_sdss',
@@ -108,7 +109,8 @@ const converters = {
         yErrNames: ['magErr', 'tsv_fluxErr'],
         webplotRequestCreator: makeLsstSdssPlotRequest,
         shouldImagesBeDisplayed: () => {return true;},
-        isTableUploadValid: () => {return true;}
+        isTableUploadValid: () => {return true;},
+        yNamesChangeImage: []
     },
     [UNKNOWN_MISSION]: {
         converterId: UNKNOWN_MISSION,
@@ -128,7 +130,9 @@ const converters = {
         [coordSysOptions]: COORD_SYSTEM_OPTIONS,
         webplotRequestCreator: makeURLPlotRequest,
         shouldImagesBeDisplayed: () => {return true;},
-        isTableUploadValid: () => {return true;}
+        isTableUploadValid: () => {return true;},
+        yNamesChangeImage: [],     // TODO: y columns which will affect the image display
+        noImageCutout: true        // no image cutout is used
     },
     // Case which should handle any ipac table and image column, X,Y, coord system not shown (Generic/Advanced case)
     'basic': {
@@ -149,7 +153,8 @@ const converters = {
         [coordSysOptions]: COORD_SYSTEM_OPTIONS,
         webplotRequestCreator: basicURLPlotRequest,
         shouldImagesBeDisplayed: imagesShouldBeDisplayed,
-        isTableUploadValid: () => {return true;}
+        isTableUploadValid: () => {return true;},
+        yNamesChangeImage: []
     }
 };
 

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -1,7 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {get, has, isEmpty, isNil, set, cloneDeep} from 'lodash';
+import {get, has, isEmpty, isNil, set, cloneDeep, defer} from 'lodash';
 import {take} from 'redux-saga/effects';
 import {SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo,
         dispatchUpdateLayoutInfo, dropDownHandler} from '../../core/LayoutCntlr.js';
@@ -167,11 +167,17 @@ export var getValidValueFrom = (fields, valKey) => {
     return val ? val : '';
 };
 
+
+export function onTimeColumnChange(preTimeColumn, crtTimeColumn) {
+    if (preTimeColumn !== crtTimeColumn) {
+        return defer(() => handleTimeColumnChange(crtTimeColumn));
+    }
+}
 /**
  * @summary construct table fetch request based on exist request and new column sort info.
  * @param colToSort
  */
-export function makeRawTableRequestByColumnChange(colToSort) {
+export function handleTimeColumnChange(colToSort) {
     const sortInfo = sortInfoString(colToSort);
     const tReq = Object.assign(cloneDeep(get(getTblById(LC.RAW_TABLE), 'request')), {sortInfo, timeCName: colToSort});
 

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -5,9 +5,9 @@ import {get, has, isEmpty, isNil, set, cloneDeep} from 'lodash';
 import {take} from 'redux-saga/effects';
 import {SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo,
         dispatchUpdateLayoutInfo, dropDownHandler} from '../../core/LayoutCntlr.js';
-import {TBL_RESULTS_ADDED, TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_HIGHLIGHT, TABLE_SEARCH, TABLE_FETCH, TABLE_FILTER,
-        dispatchTableRemove, dispatchTableHighlight, dispatchTableFetch} from '../../tables/TablesCntlr.js';
-import {getCellValue, getTblById, getTblIdsByGroup, getActiveTableId, smartMerge} from '../../tables/TableUtil.js';
+import {TBL_RESULTS_ADDED, TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_HIGHLIGHT, TABLE_SEARCH, TABLE_FETCH,
+        dispatchTableRemove, dispatchTableHighlight, dispatchTableFetch, dispatchTableSort} from '../../tables/TablesCntlr.js';
+import {getCellValue, getTblById, getTblIdsByGroup, getActiveTableId, smartMerge, getColumnIdx} from '../../tables/TableUtil.js';
 import {dispatchTableReplace} from '../../tables/TablesCntlr.js';
 import {updateSet, updateMerge, logError} from '../../util/WebUtil.js';
 import ImagePlotCntlr, {dispatchPlotImage, visRoot, dispatchDeletePlotView,
@@ -17,7 +17,7 @@ import {getPlotViewById} from '../../visualize/PlotViewUtil.js';
 import {getMultiViewRoot, dispatchReplaceViewerItems, getViewer} from '../../visualize/MultiViewCntlr.js';
 import {CHANGE_VIEWER_LAYOUT} from '../../visualize/MultiViewCntlr.js';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
-import {VALUE_CHANGE, dispatchValueChange, dispatchMultiValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
+import {VALUE_CHANGE, dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {MetaConst} from '../../data/MetaConst.js';
 import {loadXYPlot} from '../../charts/dataTypes/XYColsCDT.js';
 import {CHART_ADD, getChartDataElement} from '../../charts/ChartsCntlr.js';
@@ -25,7 +25,6 @@ import {getConverter} from './LcConverterFactory.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {makeMissionEntries, keepHighlightedRowSynced} from './LcUtil.jsx';
 import {dispatchMountFieldGroup} from '../../fieldGroup/FieldGroupCntlr.js';
-import {ERROR_MSG_KEY} from '../lightcurve/generic/errorMsg.js';
 
 export const LC = {
     RAW_TABLE: 'raw_table',          // raw table id
@@ -169,6 +168,28 @@ export var getValidValueFrom = (fields, valKey) => {
 };
 
 /**
+ * @summary construct table fetch request based on exist request and new column sort info.
+ * @param colToSort
+ */
+export function makeRawTableRequestByColumnChange(colToSort) {
+    const sortInfo = sortInfoString(colToSort);
+    const tReq = Object.assign(cloneDeep(get(getTblById(LC.RAW_TABLE), 'request')), {sortInfo, timeCName: colToSort});
+
+    removeTablesFromGroup(LC.PERIODOGRAM_GROUP);
+
+    // remove phase folded table
+    const tblAry = getTblIdsByGroup();
+
+    tblAry && tblAry.forEach((tblId) => {
+                if (tblId !== LC.RAW_TABLE) {
+                    dispatchTableRemove(tblId);
+                }
+              });
+
+    dispatchTableSort(tReq);
+}
+
+/**
  * This event manager is custom made for light curve viewer.
  * @param {LCMissionConverter} params
  */
@@ -191,11 +212,13 @@ export function* lcManager(params={}) {
          * @prop {string}   layoutInfo.searchDesc  optional string describing search criteria used to generate this result.
          * @prop {Object}   layoutInfo.images      images specific states
          * @prop {string}   layoutInfo.images.activeTableId  last active table id that images responded to
-         * @prop {string}   layoutInfo.displayMode:'result' (result page), 'period' (period finding page), 'periodogram' or neither
+         * @prop {string}   layoutInfo.displayMode: 'result' (result page), 'period' (period finding page), 'periodogram' or neither
          * @prop {Object}   layoutInfo.missionEntries mission specific entries on result layout panel
          * @prop {Object}   layoutInfo.generalEntries general entries for result layout panel
          * @prop {string}   layoutInfo.periodState  // period or periodogram
-         * @prop {Object}   layoutInfo.fullRawTable
+         * @prop {Object}   layoutInfo.fullRawTable    // full raw table
+         * @prop {Object}   layoutInfo.rawTableRequest // raw table request
+         * @prop {Object}   layoutInfo.rawTableColumns // raw table columns
          */
         var layoutInfo = getLayouInfo();
         var newLayoutInfo = layoutInfo;
@@ -272,6 +295,11 @@ function updatePhaseTableChart(flux) {
  */
 function handleValueChange(layoutInfo, action) {
     var {fieldKey, value, valid} = action.payload;
+    var bUpdateImage = false;
+    var updateImages = (layout) => {
+        clearLcImages();
+        setupImages(layout);
+    };
 
     if (!valid) { return layoutInfo; }
 
@@ -279,16 +307,14 @@ function handleValueChange(layoutInfo, action) {
         if ((get(layoutInfo, [LC.GENERAL_DATA, fieldKey]) !== value) && (value > 0.0) ) {
             if (get(layoutInfo, ['displayMode']) === LC.RESULT_PAGE) {
                 layoutInfo = updateSet(layoutInfo, [LC.GENERAL_DATA, fieldKey], value);
-                clearLcImages();
-                layoutInfo = setupImages(layoutInfo);
+                updateImages(layoutInfo);
             }
         }
     } else if ([LC.META_COORD_XNAME, LC.META_COORD_YNAME, LC.META_COORD_SYS].includes(fieldKey)) {
         if (get(layoutInfo, [LC.MISSION_DATA, fieldKey]) !== value) {
             if (get(layoutInfo, ['displayMode']) === LC.RESULT_PAGE) {
                 layoutInfo = updateSet(layoutInfo, [LC.MISSION_DATA, fieldKey], value);
-                clearLcImages();
-                layoutInfo = setupImages(layoutInfo);
+                updateImages(layoutInfo);
             }
         }
     } else {
@@ -300,38 +326,43 @@ function handleValueChange(layoutInfo, action) {
             return layoutInfo;
         }
 
-        const didChange = (el) => Object.keys(updates).includes(el) && updates[el] !== get(layoutInfo, [LC.MISSION_DATA, fieldKey]);
-
         let newLayoutInfo = updateMerge(layoutInfo, LC.MISSION_DATA, updates);
 
-        if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME].some(didChange)) {
+        const didChange = (el) => Object.keys(updates).includes(el) && updates[el] !== get(layoutInfo, [LC.MISSION_DATA, fieldKey]);
+
+        if (didChange(LC.META_TIME_CNAME)) {
+            newLayoutInfo = smartMerge(newLayoutInfo, {fullRawTable: null, periodState: LC.PERIOD_PAGE});
+        } else if (didChange(LC.META_FLUX_CNAME)) {
             const timeCol = get(newLayoutInfo, [LC.MISSION_DATA, LC.META_TIME_CNAME]);
             const fluxCol = get(newLayoutInfo, [LC.MISSION_DATA, LC.META_FLUX_CNAME]);
             const activeTbl = getActiveTableId();
+
+            // refresh chart in case flux or time
             if (activeTbl === LC.RAW_TABLE) {
                 updateRawTableChart(timeCol, fluxCol);
             } else if (activeTbl === LC.PHASE_FOLDED) {
                 updatePhaseTableChart(fluxCol);
             }
 
-            clearLcImages();
-            newLayoutInfo = setupImages(newLayoutInfo);
-
+            // if (converterData.yNamesChangeImage.includes(value))
+            updateImages(newLayoutInfo);    //TODO: need more investigation, some change may not affect the images
             // update time or flux for period panel field group if it exists
             if (FieldGroupUtils.getGroupFields(LC.FG_PERIOD_FINDER)) {
-                dispatchMultiValueChange(LC.FG_PERIOD_FINDER,
-                [{fieldKey: 'time', value: timeCol}, {fieldKey: 'flux', value: fluxCol}]);
+                dispatchValueChange({groupKey: LC.FG_PERIOD_FINDER, fieldKey: 'flux', value: fluxCol});
             }
-        }
-        if ([LC.META_URL_CNAME, LC.META_FLUX_BAND].some(didChange)) {
-            clearLcImages();
-            newLayoutInfo = setupImages(newLayoutInfo);
+        } else if ([LC.META_URL_CNAME, LC.META_FLUX_BAND].some(didChange)) {
+            updateImages(newLayoutInfo);
         }
 
         layoutInfo = newLayoutInfo;
     }
+    if (bUpdateImage) {
+        updateImages(layoutInfo);
+    }
+
     return layoutInfo;
 }
+
 
 function handleAddChart(layoutInfo, action) {
     const chartId = action.payload.chartId;
@@ -346,7 +377,7 @@ function handleAddChart(layoutInfo, action) {
 /**
  * @summary highlight the table row & chart after change the active plot view
  * @param layoutInfo
- * @param plotId
+ * @param action
  * @returns {*}
  */
 function handlePlotActive(layoutInfo, action) {
@@ -355,6 +386,7 @@ function handlePlotActive(layoutInfo, action) {
 
     var rowNum= Number(plotId.substring(plotIdRoot.length));
     dispatchTableHighlight(tableId, rowNum);
+    keepHighlightedRowSynced(tableId, rowNum);
     return layoutInfo;
 }
 
@@ -386,9 +418,9 @@ function clearResults(layoutInfo) {
 
 /**
  * handle logic when a new search is initiated.
- * @param {LayoutInfo} layoutInfo layoutInfo
+ * @param {object} layoutInfo layoutInfo
  * @param {string} action
- * @returns {LayoutInfo} the new layoutInfo
+ * @returns {Object} the new layoutInfo
  */
 function handleNewSearch(layoutInfo, action) {
     const tbl_id = get(action, 'payload.request.META_INFO.tbl_id');
@@ -416,13 +448,14 @@ function handleRawTableLoad(layoutInfo, tblId) {
         return;
     }
 
-    const {newLayoutInfo, shouldContinue, validTable} = converterData.onNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo);
-    let newMissionEntries = get(newLayoutInfo, ['missionEntries']); // missionEntries could have changed after calling specific mission onRaw
+    let {newLayoutInfo, shouldContinue, validTable} = converterData.onNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo);
+    const newMissionEntries = get(newLayoutInfo, ['missionEntries']); // missionEntries could have changed after calling specific mission onRaw
+    newLayoutInfo = updateSet(newLayoutInfo, 'rawTableColumns', get(rawTable, ['tableData', 'columns']));
+
     if (shouldContinue) {
         // additional changes to the loaded table
         ensureValidRawTable(rawTable, newMissionEntries);
     }
-
 
     return newLayoutInfo;
 }
@@ -430,11 +463,17 @@ function handleRawTableLoad(layoutInfo, tblId) {
 function ensureValidRawTable(rawTable={}, missionEntries) {
     const {request={}} = rawTable;
     const {sortInfo} = request;
+
     // check to ensure time column is sorted.
     if (!sortInfo) {
-        const timeSortInfo = sortInfoString(missionEntries[LC.META_TIME_CNAME]);
-        const treq = Object.assign(cloneDeep(request), {sortInfo: timeSortInfo});
-        dispatchTableFetch(treq);
+        const timeCol = missionEntries[LC.META_TIME_CNAME];
+
+        if (timeCol && (getColumnIdx(rawTable, timeCol) >= 0)) {
+            const timeSortInfo = sortInfoString(timeCol);
+            const treq = Object.assign(cloneDeep(request), {sortInfo: timeSortInfo});
+
+            dispatchTableFetch(treq);
+        }
     }
 }
 
@@ -591,12 +630,12 @@ export function setupImages(layoutInfo) {
     const activeTableId = get(layoutInfo, 'images.activeTableId');
 
     const tableModel = getTblById(activeTableId);
-    if (!tableModel || isNil(tableModel.highlightedRow) || get(tableModel, 'totalRows', 0) < 1) return;
+    if (!tableModel || isNil(tableModel.highlightedRow) || get(tableModel, 'totalRows', 0) < 1) return layoutInfo;
 
     const converterId = get(layoutInfo, [LC.MISSION_DATA, LC.META_MISSION]);
     const converterData = converterId && getConverter(converterId);
     if (!converterId || !converterData) {
-        return;
+        return layoutInfo;
     }
 
     const viewer = getViewer(getMultiViewRoot(), LC.IMG_VIEWER_ID);

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -91,8 +91,11 @@ export class LcResult extends Component {
                                                tableOptions={{help_id:'main1TSV.table'}}/>);
         }
 
-        content.settingBox = (<SettingBox generalEntries={generalEntries} missionEntries={missionEntries}
-                                          periodState={periodState}/>);
+
+        content.settingBox = (<SettingBox generalEntries={generalEntries}
+                                          missionEntries={missionEntries}
+                                          periodState={periodState} />);
+
 
         expanded = LO_VIEW.get(expanded) || LO_VIEW.none;
         const expandedProps = {expanded, ...content};
@@ -121,8 +124,9 @@ const buttonW = 650;
 // eslint-disable-next-line
 const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables, settingBox}) => {
 
-    const cutoutSize = get(settingBox, 'props.generalEntries.cutoutSize', '0.3');
     const converterId = get(settingBox, ['props', 'missionEntries', LC.META_MISSION]);
+    const convertData = getConverter(converterId);
+    const cutoutSize = get(convertData, 'noImageCutout') ? undefined : get(settingBox, 'props.generalEntries.cutoutSize', '0.3');
     const mission = getMissionName(converterId) || 'Mission';
     const showImages = isEmpty(imagePlot);
 
@@ -337,6 +341,6 @@ function updateFullRawTable(callback) {
                     logError(`Failed to get full raw table: ${reason}`, reason);
                 }
             );
-        }
+       }
     }
 }

--- a/src/firefly/js/templates/lightcurve/LcUtil.jsx
+++ b/src/firefly/js/templates/lightcurve/LcUtil.jsx
@@ -48,17 +48,17 @@ export function makeMissionEntries(tableMeta, layoutInfo={}) {
     return {converterData, missionEntries};
 }
 
-export function keepHighlightedRowSynced(tbl_id, highlightedRow) {
+export function keepHighlightedRowSynced(tbl_id, highlightedRow=0) {
     // ensure the highlighted row of the raw and phase-folded tables are in sync.
     if ([LC.PHASE_FOLDED, LC.RAW_TABLE].includes(tbl_id)) {
         let filterInfo, actOn, rowid;
         const tableModel = getTblById(tbl_id);
         if (tbl_id === LC.RAW_TABLE) {
             actOn = LC.PHASE_FOLDED;
-            rowid = getCellValue(tableModel, highlightedRow, 'ROWID');
+            rowid = getCellValue(tableModel, highlightedRow, 'ROWID') || highlightedRow;
             filterInfo = `RAW_ROWID = ${rowid}`;
         } else {
-            rowid = getCellValue(tableModel, highlightedRow, 'RAW_ROWID');
+            rowid = getCellValue(tableModel, highlightedRow, 'RAW_ROWID') || highlightedRow;
             actOn = LC.RAW_TABLE;
             filterInfo = `ROWID = ${rowid}`;
         }

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -90,7 +90,6 @@ export class LcViewer extends Component {
             fluxColName: get(missionEntries, [LC.META_FLUX_CNAME])
         };
 
-        const missionName = get(missionEntries, 'missionName', '');
         dropdownPanels.push(<UploadPanel/>);
 
         var mainView = (err,converterId) => {

--- a/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
@@ -325,7 +325,6 @@ export function basicOnNewRawTable(rawTable, missionEntries, generalEntries, con
 export function basicRawTableRequest(converter, source) {
     const options = {
         tbl_id: LC.RAW_TABLE,
-        sortInfo: sortInfoString('mjd'),   //TODO: tentative solution to get around 'ROWID' issue
         tblType: 'notACatalog',
         META_INFO: {[LC.META_MISSION]: converter.converterId},
         pageSize: LC.TABLE_PAGESIZE

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
@@ -11,7 +11,7 @@ import {dispatchTableSearch} from '../../../tables/TablesCntlr.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {FilterInfo} from '../../../tables/FilterInfo.js';
 
-import {LC, getViewerGroupKey, makeRawTableRequestByColumnChange} from '../LcManager.js';
+import {LC, getViewerGroupKey, onTimeColumnChange} from '../LcManager.js';
 import {getTypeData} from './../LcUtil.jsx';
 
 const labelWidth = 100;
@@ -173,9 +173,7 @@ export function lsstSdssOnFieldUpdate(fieldKey, value) {
     if (!missionEntries) return;
 
     if (fieldKey === LC.META_TIME_CNAME) {
-        if (missionEntries[fieldKey] !== value) {
-            defer(() => makeRawTableRequestByColumnChange(value));
-        }
+        onTimeColumnChange(missionEntries[fieldKey], value);
 
         return {[fieldKey]: value};
     } else if (fieldKey === 'band') {

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -1,18 +1,16 @@
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {get, has, isEmpty, set, pick, cloneDeep} from 'lodash';
+import {get, has, isEmpty, set, defer, isNil} from 'lodash';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
 import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
 import {getLayouInfo} from '../../../core/LayoutCntlr.js';
 import {makeFileRequest, getCellValue, getTblById, getColumnIdx, smartMerge} from '../../../tables/TableUtil.js';
-import {updateMerge} from '../../../util/WebUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {ReadOnlyText, getTypeData} from '../LcUtil.jsx';
-import {LC, getViewerGroupKey} from '../LcManager.js';
+import {LC, getViewerGroupKey, makeRawTableRequestByColumnChange} from '../LcManager.js';
 import {getMissionName} from '../LcConverterFactory.js';
-import {isNil} from 'lodash';
 
 const labelWidth = 80;
 
@@ -85,7 +83,7 @@ export class WiseSettingBox extends Component {
         //        return <div><em>frame_id</em> column is missing, no images will be displayed </div>;
         //    }
         //};
-        var missionOthers = <RadioGroupInputField key='band'
+        var missionOthers = (<RadioGroupInputField key='band'
                                                   fieldKey={LC.META_FLUX_BAND} wrapperStyle={wrapperStyle}
                                                   alignment='horizontal'
                                                   options={[
@@ -93,7 +91,7 @@ export class WiseSettingBox extends Component {
                     {label: 'W2', value: 'w2'},
                     {label: 'W3', value: 'w3'},
                     {label: 'W4', value: 'w4'}
-                ]}/>;
+                ]}/>);
         const groupKey = getViewerGroupKey(missionEntries);
         const converterId = get(missionEntries, LC.META_MISSION);
         var missionName = getMissionName(converterId) || 'Mission';
@@ -171,7 +169,7 @@ export const wiseOptionsReducer = (missionEntries, generalEntries) => {
 
         const missionKeys = [LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_URL_CNAME];
         const missionListKeys = [LC.META_TIME_NAMES, LC.META_FLUX_NAMES];
-        const validators = getFieldValidators(missionEntries, getTblById(LC.RAW_TABLE));
+        const validators = getFieldValidators(missionEntries);
 
         missionListKeys.forEach((key) => {
             set(defV, [key, 'value'], get(missionEntries, key, []));
@@ -233,7 +231,8 @@ function getFieldValidators(missionEntries) {
 
 /**
  * Returns only numerical column names form raw lc table
- * @returns {[TableColumn]} - array of table columns objects
+ * @param {Object} rawTbl
+ * @returns {array} - array of table columns objects
  */
 function getOnlyNumericalCol(rawTbl) {
     //let cols = get(rawTbl, 'tableData.columns');
@@ -370,9 +369,16 @@ export function wiseRawTableRequest(converter, source) {
 }
 
 export function wiseOnFieldUpdate(fieldKey, value) {
-
     // images are controlled by radio button -> band w1,w2,w3,w4.
-    if ([LC.META_TIME_CNAME, LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME, LC.META_FLUX_BAND].includes(fieldKey)) {
+    if (fieldKey === LC.META_TIME_CNAME) {
+        const {missionEntries} = getLayouInfo() || {};
+        if (!missionEntries) return;
+
+        if (missionEntries[fieldKey] !== value) {
+            defer(() => makeRawTableRequestByColumnChange(value));
+        }
+        return {[fieldKey]: value};
+    } else if ([LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME, LC.META_FLUX_BAND].includes(fieldKey)) {
         return {[fieldKey]: value};
     }
 }

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -1,6 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import sCompare from 'react-addons-shallow-compare';
-import {get, has, isEmpty, set, defer, isNil} from 'lodash';
+import {get, has, isEmpty, set, isNil} from 'lodash';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {SuggestBoxInputField} from '../../../ui/SuggestBoxInputField.jsx';
@@ -9,7 +9,7 @@ import {getLayouInfo} from '../../../core/LayoutCntlr.js';
 import {makeFileRequest, getCellValue, getTblById, getColumnIdx, smartMerge} from '../../../tables/TableUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {ReadOnlyText, getTypeData} from '../LcUtil.jsx';
-import {LC, getViewerGroupKey, makeRawTableRequestByColumnChange} from '../LcManager.js';
+import {LC, getViewerGroupKey, onTimeColumnChange} from '../LcManager.js';
 import {getMissionName} from '../LcConverterFactory.js';
 
 const labelWidth = 80;
@@ -374,9 +374,7 @@ export function wiseOnFieldUpdate(fieldKey, value) {
         const {missionEntries} = getLayouInfo() || {};
         if (!missionEntries) return;
 
-        if (missionEntries[fieldKey] !== value) {
-            defer(() => makeRawTableRequestByColumnChange(value));
-        }
+        onTimeColumnChange(missionEntries[fieldKey], value);
         return {[fieldKey]: value};
     } else if ([LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME, LC.META_FLUX_BAND].includes(fieldKey)) {
         return {[fieldKey]: value};


### PR DESCRIPTION
The development includes:
- add time column name field to LSST setting box. 
-update the response when the user change the time column name. This update is applied to all table cases (wise, last, generic and basic tables) including
  . update raw table  
  . remove phase folded table if there is
  . update the chart and the images accordingly
  . restart phase folded table calculation.

- fix the following bugs: 
  . table highlight sync between raw table, phase folded table and the images => Loi contributed and updated code regarding highlight sync. 
  . field validation for generic (and basic) tables
   . ensure the table reloaded with sort information for generic table which has no time column name info when the table is uploaded at first time.
  . remove cutout option for generic table on image download (note: the image download for generic table is not working yet)

Test:
start time series viewer upload panel (ts.html), upload a generic table (example fout_ts.tbl is attached in the ticket) as either 'generic' or 'basic'
try: 
- find period, and change the time column, and check the changes to the chart, table, and image. 
- highlight row sync among tables, chart and images. 