### PR TITLE
IRSA-327: fix rounding problem

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/util/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/IpacTableUtil.java
@@ -174,11 +174,15 @@ public class IpacTableUtil {
         }
     }
     public static void guessFormatInfo(DataType dataType, String value) {
+       guessFormatInfo(dataType, value, 0);
+    }
 
-        String formatStr = guessFormatStr(dataType, value.trim());
+    public static void guessFormatInfo(DataType dataType, String value, int precision) {
+
+        String formatStr = guessFormatStr(dataType, value.trim(), precision);
         if (formatStr != null) {
             DataType.FormatInfo.Align align = value.startsWith(" ") ? DataType.FormatInfo.Align.RIGHT
-                                                : DataType.FormatInfo.Align.LEFT;
+                    : DataType.FormatInfo.Align.LEFT;
             DataType.FormatInfo fi = dataType.getFormatInfo();
             fi.setDataFormat(formatStr);
             fi.setDataAlign(align);
@@ -405,16 +409,16 @@ public class IpacTableUtil {
         return meta;
     }
 
-    public static String guessFormatStr(DataType type, String val) {
+    public static String guessFormatStr(DataType type, String val, int precision) {
         if (type.getTypeDesc() != null &&
                 ServerStringUtil.matchesRegExpList(type.getTypeDesc(), STRING_TYPE, true)) {
             return "%s";
         } else {
-            return guessFormatStr(val, type.getDataType());
+            return guessFormatStr(val, type.getDataType(), precision);
         }
     }
 
-    private static String guessFormatStr(String val, Class cls) {
+    private static String guessFormatStr(String val, Class cls, int minPrecision) {
 
         String formatStr = null;
         try {
@@ -436,7 +440,7 @@ public class IpacTableUtil {
                     // decimal format
                     int idx = val.indexOf(".");
                     int prec = val.length() - idx - 1;
-                    return "%." + prec + "f";
+                    return "%." + Math.max(prec,minPrecision) + "f";
                 } else {
                     boolean isFloat= (cls==Float.class || cls==Double.class);
                     formatStr = isFloat ?  "%.0f" : "%d";


### PR DESCRIPTION
I've set a default min precision for VOTable converter to data group, plus added the reading of a precision attribute from VOTable if it exists.
The guessing part of the format is only made in the first row. We need to improve that also for the IPAC table reader which is related to ticket raised during GOODS data-set release ([IRSA-128](https://caltech-ipac.atlassian.net/browse/IRSA-128)).

Please check that this make sense and doesn't affect other things.

To test: do a periodogram calculation with period min=1, period max=2, rest as default for example, the first value of the VOTAble from the API is `1`, the second is 1.000... 
This value should appear  in the table/xy plot view with at least `8` digit which is the default minimum precision.