### PR TITLE
DM-9395 Showing histogram on external viewer 

### DIFF
--- a/src/firefly/html/firefly.html
+++ b/src/firefly/html/firefly.html
@@ -21,9 +21,9 @@
                 options : {
                     MenuItemKeys: {maskOverlay:true},
                     catalogSpacialOp: 'polygonWhenPlotExist',
-                    charts: {chartEngine: 'plotly'}
+                    charts: {chartEngine: ''}
                 }
-            },
+            }
         };
     </script>
     <script  type="text/javascript" src="firefly_loader.js"></script>

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -129,12 +129,11 @@ function onAnyAction(layoutInfo, action, views) {
 
 function handleNewTable(layoutInfo, action) {
     const {tbl_id} = action.payload;
-    var {images={}, showImages, showTables, hasTables} = layoutInfo;
+    var {images={}, showImages, showTables} = layoutInfo;
     var {coverageLockedOn, showFits, showMeta, showCoverage, selectedTab, metaDataTableId} = images;
     const isMeta = isMetaDataTable(tbl_id);
-    const isDisplayTable = (hasTables && showTables);
 
-    if ((isMeta || isCatalogTable(tbl_id)) && isDisplayTable  ) {
+    if ((isMeta || isCatalogTable(tbl_id)) && showTables ) {
         if (!showFits) {
             // only show coverage if there are not images or coverage is showing
             showFits= shouldShowFits();
@@ -144,7 +143,7 @@ function handleNewTable(layoutInfo, action) {
             showImages = true;
         }
     }
-    if (isMeta && isDisplayTable) {
+    if (isMeta && showTables) {
         showImages = true;
         selectedTab = 'meta';
         showMeta = true;

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -129,11 +129,12 @@ function onAnyAction(layoutInfo, action, views) {
 
 function handleNewTable(layoutInfo, action) {
     const {tbl_id} = action.payload;
-    var {images={}, showImages} = layoutInfo;
+    var {images={}, showImages, showTables, hasTables} = layoutInfo;
     var {coverageLockedOn, showFits, showMeta, showCoverage, selectedTab, metaDataTableId} = images;
-
     const isMeta = isMetaDataTable(tbl_id);
-    if (isMeta || isCatalogTable(tbl_id)) {
+    const isDisplayTable = (hasTables && showTables);
+
+    if ((isMeta || isCatalogTable(tbl_id)) && isDisplayTable  ) {
         if (!showFits) {
             // only show coverage if there are not images or coverage is showing
             showFits= shouldShowFits();
@@ -143,7 +144,7 @@ function handleNewTable(layoutInfo, action) {
             showImages = true;
         }
     }
-    if (isMeta) {
+    if (isMeta && isDisplayTable) {
         showImages = true;
         selectedTab = 'meta';
         showMeta = true;

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -21,6 +21,7 @@ import {resultsSuccess as onHistogramOptsSelected} from '../charts/ui/HistogramO
 //import {uniqueChartId} from '../charts/ChartUtil.js';
 
 import {FormPanel} from './FormPanel.jsx';
+import CompleteButton from './CompleteButton.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
 
 import LOADING from 'html/images/gxt/loading.gif';
@@ -232,10 +233,17 @@ export class ChartSelectDropdown extends Component {
 
     render() {
         const {tblId, tblStatsData} = this.state;
+        
         return tblId ? (
             <ChartSelect {...{tblId, tblStatsData}} {...this.props}/>
         ) : (
-            <div style={{padding:20, fontSize:'150%'}}>Charts are not available: no active table.</div>
+            <div>
+                <div style={{padding:20, fontSize:'150%'}}>Charts are not available: no active table.</div>
+                <CompleteButton style={{paddingLeft: 20, paddingBottom: 20}}
+                    onSuccess={hideSearchPanel}
+                    text = {'OK'}
+                />
+            </div>
         );
     }
 }

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -233,7 +233,7 @@ export class ChartSelectDropdown extends Component {
 
     render() {
         const {tblId, tblStatsData} = this.state;
-        
+
         return tblId ? (
             <ChartSelect {...{tblId, tblStatsData}} {...this.props}/>
         ) : (


### PR DESCRIPTION
This development fixes the following: 
- If the external viewer shows charts only, 'Charts' drop-down button is not working to make another histogram since there is no active table from the viewer. 
- the 'close' button is removed from the external viewer if only charts are on the external viewer. 
  the 'close' button exists when the chart is expanded from an external viewer with table, image and charts. Clicking the 'close' button, the page will go back to the original external viewer. 

test:
go to the demo page: 
http://localhost:8080/firefly/demo/ffapi-highlevel-test.html

click on 'show histogram'. an external viewer opens a new tab with a histogram chart on the page. 



