### PR TITLE
DM-10149 fix the phase value range of phase folded chart

### DIFF
--- a/src/firefly/html/firefly.html
+++ b/src/firefly/html/firefly.html
@@ -21,7 +21,7 @@
                 options : {
                     MenuItemKeys: {maskOverlay:true},
                     catalogSpacialOp: 'polygonWhenPlotExist',
-                    charts: {chartEngine: ''}
+                    charts: {chartEngine: 'plotly'}
                 }
             }
         };

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -340,8 +340,8 @@ class PhaseFoldingChart extends Component {
                     //color: 'blue',
                     color: 'rgba(63, 127, 191, 0.5)'
                 },
-                x: data.map((d) => d[0]),
-                y: data.map((d) => d[1]),
+                x: data&&data.map((d) => d[0]),
+                y: data&&data.map((d) => d[1]),
                 hoverinfo: 'text'
             }],
             plotlyLayout: {

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -75,7 +75,7 @@ export function doPFCalculate(flux, time, period, tzero) {
  */
 export function getPhase(time, timeZero, period,  dec=DEC_PHASE) {
     var q = (time - timeZero)/period;
-    var p = q >= 0  ? (q - Math.floor(q)) : (q + Math.floor(-q));
+    var p = q >= 0  ? (q - Math.floor(q)) : (q + Math.floor(-q) + 1.0);
 
     return p.toFixed(dec);
 }


### PR DESCRIPTION
the development includes:
- fixes the phase value range on the phase folded curve to be [0, 2)
- plotly based phase folded chart doesn't react properly as the periodogram table is highlighted on a row with invalid period value. 

test:
- start time series upload page, i.e. localhost:8080/firefly/ts.html
- load a time series file
- select 'find period' in the result page, go to period page
- make the zero point time value bigger by adding a couple of digit '0' before the decimal point
- slide the slider to see if the phase falls between 0 and 2
- click 'calculate periodogram'
- select some period value which is either valid or invalid
- check if the period entry and the phase folded chart react correctly. 
(valid period shows a phase folded chart, invalid period shows no chart). 