### PR TITLE
Irsa 320 disable period change on table active

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -527,16 +527,16 @@ function handleTableActive(layoutInfo, action) {
         layoutInfo = setupImages(layoutInfo);
     }
 
-    if (tbl_id === LC.PERIODOGRAM_TABLE || tbl_id === LC.PEAK_TABLE) {
-        const per = getPeriodFromTable(tbl_id);
-        if (per) {
-            dispatchValueChange({
-                fieldKey: (LC.PERIOD_CNAME).toLowerCase(),
-                groupKey: LC.FG_PERIOD_FINDER,
-                value: `${parseFloat(per)}`
-            });
-        }
-    } else {
+    //if (tbl_id === LC.PERIODOGRAM_TABLE || tbl_id === LC.PEAK_TABLE) {
+    //    const per = getPeriodFromTable(tbl_id);
+    //    if (per) {
+    //        dispatchValueChange({
+    //            fieldKey: (LC.PERIOD_CNAME).toLowerCase(),
+    //            groupKey: LC.FG_PERIOD_FINDER,
+    //            value: `${parseFloat(per)}`
+    //        });
+    //    }
+    //} else {
         const fluxCol = get(layoutInfo, [LC.MISSION_DATA, LC.META_FLUX_CNAME]);
 
         if (tbl_id === LC.PHASE_FOLDED) {
@@ -545,7 +545,7 @@ function handleTableActive(layoutInfo, action) {
             const timeCol = get(layoutInfo, [LC.MISSION_DATA, LC.META_TIME_CNAME]);
             updateRawTableChart(timeCol, fluxCol);
         }
-    }
+    //}
 
     return layoutInfo;
 }
@@ -600,13 +600,14 @@ function getPeriodFromTable(tbl_id) {
         return '';
     }
 
+    //// KEEP IT JUST IN CASE WE WANT IT BACK FOR ANY REASON I CAN'T THINK OF NOW!
     // not update the period if 'noPeriodUpdate' is set to be true
-    // (for the case when both periodogram and peak tables are recalculated and only reset the period per the active one)
-    if (get(tableModel, ['request', 'noPeriodUpdate'])) {
-        set(tableModel, ['request', 'noPeriodUpdate'], undefined);
-        dispatchTableReplace(tableModel);
-        return '';
-    }
+    //// (for the case when both periodogram and peak tables are recalculated and only reset the period per the active one)
+    //if (get(tableModel, ['request', 'noPeriodUpdate'])) {
+    //    set(tableModel, ['request', 'noPeriodUpdate'], undefined);
+    //    dispatchTableReplace(tableModel);
+    //    return '';
+    //}
 
     return getCellValue(tableModel, tableModel.highlightedRow, LC.PERIOD_CNAME);
 }

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -226,7 +226,7 @@ const PeriodStandardView = (props) => {
                     <SplitContent>
                         <div className='phaseFolded'>
                             <div className='phaseFolded__options'>
-                                <LcPFOptionsBox/>
+                                <LcPFOptionsBox />
                             </div>
                             <PhaseFoldingChart/>
                         </div>
@@ -238,17 +238,6 @@ const PeriodStandardView = (props) => {
                 <div style={{marginTop:7, marginRight:10}}>
                     <HelpIcon helpId={'findpTSV.acceptp'}/>
                 </div>
-                <div style={{margin: 5}}>
-                    <button type='button' className='button std hl' onClick={()=>cancelStandard()}>Cancel</button>
-                </div>
-                <CompleteButton
-                    style={aroundButton}
-                    groupKey={[pfinderkey]}
-                    onSuccess={setPFTableSuccess()}
-                    onFail={setPFTableFail()}
-                    text={acceptPeriodTxt}
-                    includeUnmounted={true}
-                />
             </div>
         </FieldGroup>
     );
@@ -608,25 +597,44 @@ function LcPFOptions({fields, lastPeriod, periodList=[]}) {
     var marks = getSliderMarks(minPerN, maxPerN, sliderMin, sliderMax, NOMark);
     var offset = 16;
     var highlightW = PanelResizableStyle.width-panelSpace - offset;
-    var pSize = panelSpace/2 - 5;
-
+    var pSize = panelSpace / 2 - 5;
+    let styleItem = {display: 'list-item', marginLeft: '10px', paddingBottom:'20px'};
+    let innerItem = {display: 'inline-flex', maxWidth: '100%', alignItems: 'center'};
     return (<div style={{width: PanelResizableStyle.width - offset}}>
-                <div style={{display:'flex', flexDirection:'row-reverse', justifyContent:'space-between'}}>
-                    <HelpIcon helpId={'findpTSV.settings'}/>
+            <div style={{display:'flex', flexDirection:'row-reverse', justifyContent:'space-between'}}>
+                <HelpIcon helpId={'findpTSV.settings'}/>
+            </div>
+            {'Vary period and time offset while visualizing phase folded plot. ' +
+            'Optionally calculate periodogram and click to choose period. ' +
+            'When satisfied, click Accept to return to Time Series Viewer with phase folded table.'}
+            <br/>
+            <br/>
+            <br/>
+            {ReadOnlyText({
+                label: get(defValues, [fKeyDef.time.fkey, 'label']),
+                labelWidth: get(defValues, [fKeyDef.time.fkey, 'labelWidth']),
+                content: get(fields, [fKeyDef.time.fkey, 'value'])
+            })}
+            <br/>
+            {ReadOnlyText({
+                label: get(defValues, [fKeyDef.flux.fkey, 'label']),
+                labelWidth: get(defValues, [fKeyDef.flux.fkey, 'labelWidth']),
+                content: get(fields, [fKeyDef.flux.fkey, 'value'])
+            })}
+            <br/>
+            <h3>{'Set Period'}</h3>
+            <div style={styleItem}>
+                <div style={innerItem}>
+                    <ValidationField fieldKey={fKeyDef.period.fkey} label='Enter manually:'/>
+                    <button type='button' className='button std hl'
+                            onClick={() => resetPeriodDefaults(defPeriod)}>
+                        <b>Reset</b>
+                    </button>
                 </div>
-                <br/>
-                {ReadOnlyText({label: get(defValues, [fKeyDef.time.fkey, 'label']),
-                               labelWidth: get(defValues, [fKeyDef.time.fkey, 'labelWidth']),
-                               content: get(fields, [fKeyDef.time.fkey, 'value'])})}
-                <br/>
-                {ReadOnlyText({label: get(defValues, [fKeyDef.flux.fkey, 'label']),
-                               labelWidth: get(defValues, [fKeyDef.flux.fkey, 'labelWidth']),
-                               content: get(fields, [fKeyDef.flux.fkey, 'value'])})}
-                <br/>
-                <ValidationField fieldKey={fKeyDef.tz.fkey} />
-                <br/>
-                <br/>
-                <div style={{display: 'flex', alignItems: 'center'}}>
+            </div>
+            <div style={styleItem}>
+                <div>{'Slide to select:'}</div>
+                <div style={innerItem}>
                     <ValidationField fieldKey={fKeyDef.min.fkey} style={{width: pSize}}/>
                     <RangeSlider fieldKey={fKeyDef.period.fkey}
                                  min={sliderMin}
@@ -643,25 +651,29 @@ function LcPFOptions({fields, lastPeriod, periodList=[]}) {
                     />
                     <ValidationField fieldKey={fKeyDef.max.fkey} style={{width: pSize}}/>
                 </div>
-                <br/>
-                <div style={{display: 'flex', alignItems: 'center', marginTop: 20 }}>
-                    <div style={{padding: 10, width: highlightW - 10,
-                                 display: 'flex', justifyContent: 'space-between',
-                                 border: highlightBorder}}>
-                        <ValidationField fieldKey={fKeyDef.period.fkey} />
-                        <div>
-                            {/*<button type='button' className='button std hl' onClick={revertPeriod}>
-                                {revertPeriodTxt}
-                            </button>*/}
-                        </div>
-                    </div>
-                    <div style={{marginLeft: 30}} >
-                        <button type='button' className='button std hl'  onClick={() => resetPeriodDefaults(defPeriod)}>
-                            <b>Reset</b>
-                        </button>
-                    </div>
+            </div>
+            <div style={styleItem}>
+                <div style={innerItem}>
+                    {'Calculate periodogram (below) and click to select period'}
                 </div>
             </div>
+            <div style={{display:'flex', alignItems:'center'}}>
+                <h3>{'Set Time Offset:'}</h3><ValidationField style={{marginLeft:'20px'}} fieldKey={fKeyDef.tz.fkey} label=''/>
+            </div>
+            <br/>
+            <div style={{display: 'flex', alignItems:'center'}}>
+                <CompleteButton
+                    groupKey={[pfinderkey]}
+                    onSuccess={setPFTableSuccess()}
+                    onFail={setPFTableFail()}
+                    text={'Accept'}
+                    includeUnmounted={true}
+                />
+                <div style={{margin: 5}}>
+                    <button type='button' className='button std hl' onClick={()=>cancelStandard()}>Cancel</button>
+                </div>
+            </div>
+        </div>
     );
 }
 

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -704,7 +704,7 @@ var LcPFReducer= (initState) => {
                 set(defV, [fKeyDef.max.fkey, 'value'], `${max}`);
                 set(defV, [fKeyDef.time.fkey, 'value'], time);
                 set(defV, [fKeyDef.flux.fkey, 'value'], flux);
-                set(defV, [fKeyDef.period.fkey, 'value'], `${min}`);
+                //set(defV, [fKeyDef.period.fkey, 'value'], `${min}`);
                 set(defV, [fKeyDef.tz.fkey, 'value'], `${tzero}`);
                 set(defV, [fKeyDef.tzmax.fkey, 'value'], `${tzeroMax}`);
 

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -527,7 +527,7 @@ function periodogramSuccess(popupId, hideDropDown = false) {
             peaks: get(request, [pKeyDef.peaks.fkey]),
             table_name: LC.PEAK_TABLE,
             sortInfo: sortInfoString('SDE', false)                 // sort peak table by column SDE, descending
-        }, {tbl_id: LC.PEAK_TABLE, pageSize: parseInt(peak), noPeriodUpdate: true});
+        }, {tbl_id: LC.PEAK_TABLE, pageSize: parseInt(peak)}); //, noPeriodUpdate: true //see LcManager#getPeriodFromTable
 
         var tReq = makeTblRequest('LightCurveProcessor', LC.PERIODOGRAM_TABLE, {
             original_table: srcFile,

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -170,9 +170,12 @@ PeriodogramButton.propTypes = {
 
 function ChangePeriodogram() {
     return (
-        <button type='button' className='button std hl'
-                 onClick={startPeriodogramPopup(LC.FG_PERIODOGRAM_FINDER)}>Recalculate Periodogram
-        </button>
+        <div style = {{display:'flex', justifyContent:'space-between', alignItems:'center', marginRight:'10px'}}>
+            <button type='button' className='button std hl'
+                    onClick={startPeriodogramPopup(LC.FG_PERIODOGRAM_FINDER)}>Recalculate Periodogram
+            </button>
+            {'Click on plot or table to choose period'}
+        </div>
     );
 }
 
@@ -548,7 +551,9 @@ function periodogramSuccess(popupId, hideDropDown = false) {
                 userSetBoundaries: {yMin: 0},
                 x: {columnOrExpr: LC.PERIOD_CNAME, options: 'grid,log'},
                 y: {columnOrExpr: LC.POWER_CNAME, options: 'grid'},
-                plotStyle: 'linepoints'
+                plotStyle: 'linepoints',
+                plotTitle: 'Periodogram'
+
             };
             loadXYPlot({
                 chartId: LC.PERIODOGRAM_TABLE,
@@ -563,7 +568,8 @@ function periodogramSuccess(popupId, hideDropDown = false) {
             const xyPlotParams = {
                 x: {columnOrExpr: LC.PEAK_CNAME, options: 'grid'},
                 y: {columnOrExpr: LC.POWER_CNAME, options: 'grid'},
-                plotStyle: 'linepoints'
+                plotStyle: 'linepoints',
+                plotTitle: `First ${get(request, [pKeyDef.peaks.fkey])} Peaks`
 
             };
             loadXYPlot({chartId: LC.PEAK_TABLE, tblId: LC.PEAK_TABLE, xyPlotParams, help_id: 'findpTSV.pgramresults'});


### PR DESCRIPTION
This PR is removing the constraint of updating the period value every time the user switch from one active table to another. Plus, it also set no default value for the period.

Check that when you go to calculate periodogram in LC viewer, switching from one table to another back and forth doesn't change the value of the period, only if you click on the plot or the table.
Also noticed that no value is pre-filled in the period input field.

Let me know if you find any problem.