### PR TITLE
DM-10188 Fix drawing related issues on markers and footprints with new rotation scheme

### DIFF
--- a/src/firefly/js/drawingLayers/FootprintTool.js
+++ b/src/firefly/js/drawingLayers/FootprintTool.js
@@ -289,7 +289,7 @@ function getLayerChanges(drawLayer, action) {
                 const plot = primePlot(visRoot(), pId);
                 const cc = CsysConverter.make(plot);
 
-                retV = createFootprintObjs(action, drawLayer, pId, initMarkerPos(plot, cc));
+                retV = createFootprintObjs(action, drawLayer, pId, initMarkerPos(plot, cc), retV);
             });
 
             return retV;
@@ -303,7 +303,7 @@ function getLayerChanges(drawLayer, action) {
             plotIdAry = getPlotViewIdListInGroup(visRoot(), plotId);
             plotIdAry.forEach((pId) => {
                 wptObj = (pId === plotId) ? wpt : get(dd, ['data', pId, 'pts', '0']);
-                retV = createFootprintObjs(action, drawLayer, pId, wptObj);
+                retV = createFootprintObjs(action, drawLayer, pId, wptObj, retV);
             });
             return retV;
 
@@ -416,9 +416,10 @@ function showFootprintByTimer(dispatcher, actionType, regions, plotId, doneStatu
  * @param dl
  * @param plotId
  * @param wpt
+ * @param prevRet previous return object
  * @returns {*}
  */
-function createFootprintObjs(action, dl, plotId, wpt) {
+function createFootprintObjs(action, dl, plotId, wpt, prevRet) {
     if (!plotId || !wpt) return null;
 
     const {isHandle, footprintStatus, regions, timeoutProcess, refPt, move} = action.payload;
@@ -470,7 +471,7 @@ function createFootprintObjs(action, dl, plotId, wpt) {
      var dlObj = {drawData: dl.drawData, helpLine: editHelpText};
 
      if (footprintStatus) {
-         var {exclusiveDef, vertexDef} = updateVertexInfo(footprintObj, plotId);
+         var {exclusiveDef, vertexDef} = updateVertexInfo(footprintObj, plotId, dl, prevRet);
 
          if (exclusiveDef && vertexDef) {
              return clone(dlObj, {footprintStatus, vertexDef, exclusiveDef});

--- a/src/firefly/js/drawingLayers/FootprintTool.js
+++ b/src/firefly/js/drawingLayers/FootprintTool.js
@@ -7,21 +7,20 @@ import {visRoot} from '../visualize/ImagePlotCntlr.js';
 import {makeDrawingDef, TextLocation} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {DataTypes, ColorChangeType}  from '../visualize/draw/DrawLayer.js';
 import {MouseState} from '../visualize/VisMouseSync.js';
-import {PlotAttribute} from '../visualize/WebPlot.js';
 import CsysConverter from '../visualize/CsysConverter.js';
-import {primePlot, getDrawLayerById} from '../visualize/PlotViewUtil.js';
+import {primePlot, getDrawLayerById, getPlotViewIdListInGroup} from '../visualize/PlotViewUtil.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
-import {MARKER_DISTANCE, ANGLE_UNIT, ROTATE_BOX, OutlineType, getWorldOrImage, findClosestIndex, makeFootprint,
-        lengthSizeUnit, updateFootprintDrawobjAngle, updateFootprintDrawobjText,
+import {ANGLE_UNIT, OutlineType, getWorldOrImage, findClosestIndex, makeFootprint,
+        lengthSizeUnit, updateFootprintDrawobjAngle,
         updateFootprintTranslate, updateFootprintOutline} from '../visualize/draw/MarkerFootprintObj.js';
-import {markerInterval, getCC, cancelTimeoutProcess, initMarkerPos} from './MarkerTool.js';
+import {markerInterval, getCC, cancelTimeoutProcess, initMarkerPos,
+        updateVertexInfo, updateMarkerText} from './MarkerTool.js';
 import {getFootprintToolUIComponent} from './FootprintToolUI.jsx';
-import ShapeDataObj, {lengthToScreenPixel} from '../visualize/draw/ShapeDataObj.js';
-import {getDrawobjArea} from '../visualize/draw/ShapeHighlight.js';
+import ShapeDataObj from '../visualize/draw/ShapeDataObj.js';
 import {clone} from '../util/WebUtil.js';
 import {getDS9Region} from '../rpc/PlotServicesJson.js';
 import {FootprintFactory} from '../visualize/draw/FootprintFactory.js';
-import {makeImagePt, makeDevicePt} from '../visualize/Point.js';
+import {makeImagePt} from '../visualize/Point.js';
 import {get, set, isArray, has, isNil} from 'lodash';
 import Enum from 'enum';
 
@@ -74,9 +73,9 @@ export function footprintCreateLayerActionCreator(rawAction) {
                             if (plot) {
                                 var wpt = initMarkerPos(plot);
 
-                                showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_CREATE, wpt, regions, pId,
+                                showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_CREATE, regions, pId,
                                     FootprintStatus.attached, footprintInterval, drawLayerId,
-                                    {isOutline: true, isRotate: true}, fpInfo);
+                                    {isOutline: true, isRotate: true}, fpInfo, wpt);
 
                             }
                         }
@@ -96,17 +95,15 @@ export function footprintCreateLayerActionCreator(rawAction) {
 */
 export function footprintStartActionCreator(rawAction) {
     return (dispatcher) => {
-        var {plotId, imagePt, screenPt, drawLayer} = rawAction.payload;
-        var cc = getCC(plotId);
-        var wpt;
-        var {footprintStatus, currentPt, timeoutProcess, drawLayerId, regions, fpInfo} = drawLayer;
-        var nextStatus = null;
-        var idx;
-        var refPt;
+        const {plotId, imagePt, screenPt, drawLayer} = rawAction.payload;
+        const cc = getCC(plotId);
+        const {drawLayerId, regions, fpInfo} = drawLayer;
+        const footprintObj = get(drawLayer, ['drawData', DataTypes.DATA, plotId], {});
+        const {footprintStatus, currentPt, timeoutProcess} = get(footprintObj, 'actionInfo', {});
+        var   wpt, idx, refPt;
+        var   nextStatus = null;
 
         cancelTimeoutProcess(timeoutProcess);
-        var footprintObj = get(drawLayer, ['drawData', 'data', '0']);
-
         // marker can move to anywhere the mouse click at while in 'attached' state
         if (footprintStatus === FootprintStatus.attached) {
             if (footprintObj) {
@@ -134,12 +131,11 @@ export function footprintStartActionCreator(rawAction) {
             refPt = imagePt;                   // refPt is used for calculating the relocated offset of next time
         }
         if (nextStatus) {
-            showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_START, wpt, regions, plotId,
-                nextStatus, footprintInterval, drawLayerId, {isOutline: true, isRotate:true}, fpInfo, refPt);
+            showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_START, regions, plotId,
+                nextStatus, footprintInterval, drawLayerId, {isOutline: true, isRotate:true}, fpInfo, wpt, refPt);
         }
     };
 }
-
 
 /**
  * action creator for FOOTPRINT_END
@@ -148,19 +144,19 @@ export function footprintStartActionCreator(rawAction) {
  */
 export function footprintEndActionCreator(rawAction) {
     return (dispatcher) => {
-        var {plotId, drawLayer} = rawAction.payload;
-        var cc = getCC(plotId);
-        var {footprintStatus, currentPt, timeoutProcess, drawLayerId, regions, fpInfo} = drawLayer;
-        var {includeOutline: isOutline, includeRotate: isRotate } = get(drawLayer, ['drawData', DataTypes.DATA, '0'], {});
+        const {plotId, drawLayer} = rawAction.payload;
+        const cc = getCC(plotId);
+        const {drawLayerId, regions, fpInfo} = drawLayer;
+        const footprintObj = get(drawLayer, ['drawData', DataTypes.DATA, plotId], {});
+        const {footprintStatus, currentPt, timeoutProcess} = get(footprintObj, 'actionInfo', {});
+        var   {includeOutline: isOutline, includeRotate: isRotate } = footprintObj;
 
         cancelTimeoutProcess(timeoutProcess);
-
         // marker stays at current position and size
         if ([FootprintStatus.relocate, FootprintStatus.attached_relocate, FootprintStatus.rotate].includes(footprintStatus)) {
-            var wpt = getWorldOrImage(currentPt, cc);
-
-            showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_END, wpt, regions, plotId,
-                            FootprintStatus.select, footprintInterval, drawLayerId, {isOutline, isRotate}, fpInfo);
+            const wpt = getWorldOrImage(currentPt, cc);
+            showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_END, regions, plotId,
+                            FootprintStatus.select, footprintInterval, drawLayerId, {isOutline, isRotate}, fpInfo, wpt);
         }
     };
 }
@@ -184,17 +180,17 @@ export function footprintMoveActionCreator(rawAction) {
     };
 
     return (dispatcher) => {
-        var {plotId, imagePt, drawLayer} = rawAction.payload;
-        var cc = getCC(plotId);
-        var {footprintStatus, currentPt: wpt, timeoutProcess, drawLayerId, refPt, regions, fpInfo} = drawLayer;
+        const {plotId, imagePt, drawLayer} = rawAction.payload;
+        const cc = getCC(plotId);
+        const {drawLayerId, regions, fpInfo} = drawLayer;
+        const footprintObj = get(drawLayer, ['drawData', DataTypes.DATA, plotId], {});
+        var   {footprintStatus, currentPt: wpt, timeoutProcess, refPt} = get(footprintObj, 'actionInfo', {});
         var move = {};
         var isHandle;
 
         cancelTimeoutProcess(timeoutProcess);
-
         // refPt: in image coordinate
-        if (footprintStatus === FootprintStatus.rotate)  {    // footprint rotate by angle on screenangle
-            var footprintObj = get(drawLayer, ['drawData', 'data', '0']);
+        if (footprintStatus === FootprintStatus.rotate)  {    // footprint rotate by angle on screen angle
             var center = centerForRotation(footprintObj, wpt);
 
             move.angle = -angleBetween(cc.getImageCoords(center), cc.getImageCoords(refPt), imagePt); // angle on screen
@@ -221,14 +217,16 @@ export function footprintMoveActionCreator(rawAction) {
 
         if (move) {
             // rotate (newDize) or relocate (wpt),  status remains the same
-            showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_MOVE, wpt, regions, plotId,
-                footprintStatus, 0, drawLayerId, isHandle, fpInfo, refPt, move);
+            showFootprintByTimer(dispatcher, DrawLayerCntlr.FOOTPRINT_MOVE, regions, plotId,
+                                 footprintStatus, 0, drawLayerId, isHandle, fpInfo, wpt, refPt, move);
         }
     };
 }
 
+
 /**
  * create drawing layer for a new marker
+ * @param {object} initPayload
  * @return {Function}
  */
 function creator(initPayload) {
@@ -240,8 +238,6 @@ function creator(initPayload) {
         [MouseState.DOWN.key]: DrawLayerCntlr.FOOTPRINT_START,
         [MouseState.UP.key]: DrawLayerCntlr.FOOTPRINT_END
     };
-
-    //var actionTypes=[DrawLayerCntlr.MARKER_LOC];
 
     var actionTypes= [DrawLayerCntlr.FOOTPRINT_MOVE,
                       DrawLayerCntlr.FOOTPRINT_START,
@@ -256,6 +252,7 @@ function creator(initPayload) {
         canUseMouse:true,
         canUserChangeColor: ColorChangeType.DYNAMIC,
         canUserDelete: true,
+        hasPerPlotData: true,
         destroyWhenAllDetached: true
     };
     var title = get(initPayload, 'Title', 'Footprint Tool');
@@ -276,42 +273,56 @@ function creator(initPayload) {
  * @returns {*}
  */
 function getLayerChanges(drawLayer, action) {
-    var {drawLayerId} = action.payload;
+    const {drawLayerId, plotId} = action.payload;
 
     if (!drawLayerId || drawLayerId !== drawLayer.drawLayerId) return null;
-    var dd = Object.assign({}, drawLayer.drawData);
+
+    const dd = Object.assign({}, drawLayer.drawData);
+    var  plotIdAry;
+    var  retV = null;
 
     switch (action.type) {
 
         case DrawLayerCntlr.FOOTPRINT_CREATE:
+            plotIdAry = getPlotViewIdListInGroup(visRoot(), plotId);
+            plotIdAry.forEach((pId) => {
+                const plot = primePlot(visRoot(), pId);
+                const cc = CsysConverter.make(plot);
+
+                retV = createFootprintObjs(action, drawLayer, pId, initMarkerPos(plot, cc));
+            });
+
+            return retV;
+
         case DrawLayerCntlr.FOOTPRINT_START:
         case DrawLayerCntlr.FOOTPRINT_MOVE:
         case DrawLayerCntlr.FOOTPRINT_END:
-            var data = get(dd, [DataTypes.DATA, '0']);
-            var {text = '', textLoc = TextLocation.REGION_SE} = data || {};
-            var crtFpObj = data || null;
-            var {footprintStatus} = action.payload;
+            var wptObj;
+            const {wpt} = action.payload;
 
-            if (footprintStatus === FootprintStatus.attached ||
-                footprintStatus === FootprintStatus.attached_relocate) {
-                text = get(drawLayer, 'title', '');    // title is the default text by the footprint
-            }
-
-            return createFootprintObjs(action, text, textLoc, crtFpObj);
+            plotIdAry = getPlotViewIdListInGroup(visRoot(), plotId);
+            plotIdAry.forEach((pId) => {
+                wptObj = (pId === plotId) ? wpt : get(dd, ['data', pId, 'pts', '0']);
+                retV = createFootprintObjs(action, drawLayer, pId, wptObj);
+            });
+            return retV;
 
         case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
-            var obj = get(dd, [DataTypes.DATA, '0']);
-            if (!obj) return null;
-            var {fpText, fpTextLoc, angleDeg} = action.payload.changes;
-            var {plotIdAry} = action.payload;
+            const {fpText, fpTextLoc, angleDeg, activePlotId} = action.payload.changes;
 
-
-            if (!isNil(angleDeg)) {
-                return updateFootprintAngle(angleDeg, obj, plotIdAry[0]);
-            } else {
-                return updateFootprintText(fpText, fpTextLoc, obj);
+            plotIdAry = getPlotViewIdListInGroup(visRoot(), activePlotId);
+            if (plotIdAry) {
+                if (!isNil(angleDeg)) {
+                    return updateFootprintAngle(angleDeg, dd[DataTypes.DATA], plotIdAry);
+                } else {
+                    return updateMarkerText(fpText, fpTextLoc, dd[DataTypes.DATA], plotIdAry);
+                }
             }
+            break;
+        default:
+            return null;
     }
+    return retV;
 }
 
 function getCursor(plotView, screenPt) {
@@ -324,11 +335,10 @@ function getCursor(plotView, screenPt) {
         //alert('null screenpt');
         return cursor;
     }
-    const plot= primePlot(plotView);
-    var   cc= CsysConverter.make(plot);
+    const  cc= CsysConverter.make(primePlot(plotView));
 
     dlAry.find( (dl) => {
-        var drawObj = get(dl, ['drawData', 'data', '0']);
+        var drawObj = get(dl, ['drawData', 'data', plotView.plotId]);
         var idx = findClosestIndex(screenPt, drawObj, cc).index;
 
         if (idx >= 0 && idx <= drawObj.outlineIndex) {
@@ -345,42 +355,31 @@ function getCursor(plotView, screenPt) {
 }
 
 /**
- * update text in marker object
- * @param text
- * @param textLoc
- * @param footprintDrawObj
- * @returns {*}
- */
-function updateFootprintText(text, textLoc, footprintDrawObj) {
-    var textUpdatedObj = updateFootprintDrawobjText(footprintDrawObj, text, textLoc);
-
-    return textUpdatedObj? {drawData: {data: [textUpdatedObj]}} : {};
-}
-
-/**
  * set footprint rotate angle
  * @param angleDegStr
  * @param footprintDrawObj
- * @param plotId
+ * @param plotIdAry
  * @returns {*}
  */
-function updateFootprintAngle(angleDegStr, footprintDrawObj, plotId) {
-    const plot = primePlot(visRoot(), plotId);
-    var cc = CsysConverter.make(plot);
+function updateFootprintAngle(angleDegStr, footprintDrawObj, plotIdAry) {
     var angleDeg;
-
     angleDeg = angleDegStr ? parseFloat(angleDegStr) : 0.0;
-
     while (angleDeg > 180.0 || angleDeg < -180.0) {
         angleDeg = angleDeg < 0 ? angleDeg + 360 : angleDeg - 360;
     }
 
-    var angleUpdatedObj = updateFootprintDrawobjAngle(footprintDrawObj, cc, footprintDrawObj.pts[0], angleDeg, ANGLE_UNIT.degree, true);
-    if (angleUpdatedObj) {
-        angleUpdatedObj.angleFromUI = true;
-    }
+    plotIdAry.forEach((plotId) => {
+        var cc = getCC(plotId);
 
-    return angleUpdatedObj ? {drawData: {data: [angleUpdatedObj]}} : {};
+        var angleUpdatedObj = updateFootprintDrawobjAngle(footprintDrawObj[plotId], cc,
+            footprintDrawObj[plotId].pts[0], angleDeg, ANGLE_UNIT.degree, true);
+        if (angleUpdatedObj) {
+            angleUpdatedObj.angleFromUI = true;
+            footprintDrawObj[plotId] = angleUpdatedObj;
+        }
+    });
+
+    return {drawData: {data: footprintDrawObj}};
 }
 
 
@@ -389,7 +388,6 @@ function updateFootprintAngle(angleDegStr, footprintDrawObj, plotId) {
  * dispatch action to locate marker with corners and no corner by timer interval on the drawing layer
  * @param dispatcher
  * @param actionType
- * @param wpt    marker location world coordinate
  * @param regions regions contained in footprint drawObj
  * @param plotId
  * @param doneStatus
@@ -397,16 +395,16 @@ function updateFootprintAngle(angleDegStr, footprintDrawObj, plotId) {
  * @param drawLayerId
  * @param isHandle
  * @param fpInfo
+ * @param wpt    marker location world coordinate
  * @param refPt
  * @param move
  */
-function showFootprintByTimer(dispatcher, actionType, wpt,  regions, plotId, doneStatus, timer, drawLayerId, isHandle,
-                              fpInfo, refPt, move) {
+function showFootprintByTimer(dispatcher, actionType, regions, plotId, doneStatus, timer, drawLayerId, isHandle,
+                              fpInfo, wpt, refPt, move) {
     var setAction = (isHandle) => ({
         type: actionType,
         payload: {isHandle, regions, wpt, plotId, footprintStatus: doneStatus, drawLayerId, fpInfo, refPt, move}
     });
-
     var timeoutProcess = (timer !== 0) && (setTimeout(() => dispatcher(setAction({})), timer));
     var crtAction = set(setAction(isHandle), 'payload.timeoutProcess', timeoutProcess);
     dispatcher(crtAction);
@@ -415,33 +413,41 @@ function showFootprintByTimer(dispatcher, actionType, wpt,  regions, plotId, don
 /**
  * create drawlayer object containing only the properties which has updated value
  * @param action
- * @param text
- * @param textLoc
- * @param crtFpObj current footprint drawobj
+ * @param dl
+ * @param plotId
+ * @param wpt
  * @returns {*}
  */
-function createFootprintObjs(action, text, textLoc, crtFpObj) {
-     var {plotId, isHandle, wpt, regions, footprintStatus, timeoutProcess, refPt, move} = action.payload;
+function createFootprintObjs(action, dl, plotId, wpt) {
+    if (!plotId || !wpt) return null;
 
-     if (!plotId || !wpt) return null;
+    const {isHandle, footprintStatus, regions, timeoutProcess, refPt, move} = action.payload;
+    const crtFpObj = get(dl, ['drawData', DataTypes.DATA, plotId], {});
+    var  {text = ''} = crtFpObj;
+    const {textLoc = TextLocation.REGION_SE} = crtFpObj;
 
-     const plot = primePlot(visRoot(), plotId);
-     var cc = CsysConverter.make(plot);
+    if (footprintStatus === FootprintStatus.attached ||
+        footprintStatus === FootprintStatus.attached_relocate) {
+        text = get(dl, 'title', '');    // title is the default text by the footprint
+    }
+
+     var cc = getCC(plotId);
      var footprintObj;
 
      if (footprintStatus === FootprintStatus.attached ||
-         footprintStatus === FootprintStatus.attached_relocate) {  // position is reloacated after the layer is attached
+         footprintStatus === FootprintStatus.attached_relocate) {  // position is relocated after the layer is attached
+
          footprintObj = makeFootprint(regions, wpt, isHandle, cc, text, textLoc);
      } else if (crtFpObj) {
          if ((footprintStatus === FootprintStatus.rotate || footprintStatus === FootprintStatus.relocate) && move) {
-             var {apt, angle, angleUnit} = move;    // move to relocate or rotate
+             var {apt} = move;    // move to relocate or rotate
 
              if (apt) {      // translate
                  footprintObj = updateFootprintTranslate(crtFpObj, cc, apt);
                  resetRotateSide(footprintObj);
+                 wpt = get(footprintObj, ['pts', '0']);
              } else {
-                 footprintObj = updateFootprintDrawobjAngle(crtFpObj, cc, wpt,
-                                                            angle, angleUnit);
+                 footprintObj = updateFootprintDrawobjAngle(crtFpObj, cc, wpt, move.angle, move.angleUnit);
                  footprintObj.angleFromUI = false;
              }
          } else {       // start to move or rotate (mouse down) or end the operation (mouse up)
@@ -455,29 +461,23 @@ function createFootprintObjs(action, text, textLoc, crtFpObj) {
          updateHandle(isHandle, footprintObj);
      }
 
-     var exclusiveDef, vertexDef; // cursor point
-     var dlObj =  {
-        helpLine: editHelpText,
-        drawData: {data: [footprintObj]},
-        currentPt: wpt                    // marker center, world or image coordinate
-     };
-     dlObj = clone(dlObj, {timeoutProcess: timeoutProcess ? timeoutProcess : null,
-                           refPt: refPt ? refPt : null});     // reference pt for next action (relocation or rotation)
+     footprintObj.plotId = plotId;
+     const actionInfo = {currentPt: wpt,       // marker center, world or image coordinate
+                         timeoutProcess: timeoutProcess ? timeoutProcess : null,
+                         refPt: refPt ? refPt : null,
+                         footprintStatus};
+     set(dl.drawData, [DataTypes.DATA, plotId],  Object.assign(footprintObj, {actionInfo}));
+     var dlObj = {drawData: dl.drawData, helpLine: editHelpText};
 
      if (footprintStatus) {
-         if (footprintStatus === FootprintStatus.attached) {
-             exclusiveDef = { exclusiveOnDown: true, type : 'anywhere' };
-             vertexDef = {points:null, pointDist:MARKER_DISTANCE};
-         } else {
-             var {dist, centerPt} = getVertexDistance( footprintObj, cc);
+         var {exclusiveDef, vertexDef} = updateVertexInfo(footprintObj, plotId);
 
-             exclusiveDef = { exclusiveOnDown: true, type : 'vertexOnly' };
-             vertexDef = {points:[centerPt], pointDist: dist};
+         if (exclusiveDef && vertexDef) {
+             return clone(dlObj, {footprintStatus, vertexDef, exclusiveDef});
          }
-         return clone(dlObj, {footprintStatus, vertexDef, exclusiveDef});
-     } else {
-         return dlObj;
      }
+     return dlObj;
+
 }
 
 /**
@@ -492,35 +492,6 @@ function centerForRotation(drawObj, wpt) {
 
     //return outlineBox.pts[0];
     return (outlineBox && outlineBox.outlineType === OutlineType.plotcenter) ? outlineBox.pts[0] : wpt;
-}
-/**
- * compute the radius distance of the footprint in terms of screen pixel for vertex search
- * @param footprintObj
- * @param cc
- * @returns {{dist: *, centerPt: *}}
- */
-function getVertexDistance( footprintObj, cc) {
-    var {drawObjAry, outlineIndex} = footprintObj;
-    var dist, w, h, centerPt;
-
-    if (outlineIndex && drawObjAry.length > outlineIndex &&
-        drawObjAry[outlineIndex].outlineType === OutlineType.original) {
-        var outlineObj = Object.assign({}, drawObjAry[outlineIndex]);
-        var {width, height, center} = getDrawobjArea(outlineObj, cc);
-
-        w = lengthToScreenPixel(width, cc, ShapeDataObj.UnitType.IMAGE_PIXEL) / 2;
-        h = lengthToScreenPixel(height, cc, ShapeDataObj.UnitType.IMAGE_PIXEL) / 2;
-        dist = ROTATE_BOX;
-        centerPt = getWorldOrImage(center, cc);
-    } else {
-        w = cc.viewDim.width/2;
-        h = cc.viewDim.height/2;
-        centerPt = getWorldOrImage(makeDevicePt(w, h), cc);
-        dist = 0;
-    }
-    dist += Math.sqrt(Math.pow(w, 2) + Math.pow(h, 2));
-
-    return {dist, centerPt};
 }
 
 /**

--- a/src/firefly/js/drawingLayers/FootprintToolUI.jsx
+++ b/src/firefly/js/drawingLayers/FootprintToolUI.jsx
@@ -148,48 +148,51 @@ class FootprintToolUI extends React.Component {
         var {isValidAngle, angleDeg, fpText, fpTextLoc} = this.state;
 
         return (
-            <div style={{display:'flex', justifyContent:'flex-start', padding:'5px 0 9px 0'}}>
-                <div style={tStyle}>
-                    <div title={'Add a lable to this footprint'}> Label:<input style={{width: 60}}
-                                       type='text'
-                                       value={fpText}
-                                       onChange={this.changeFootprintText}/>
-                    </div>
-                    <div style={mStyle} title={'Choose a corner'}> Corners:
-                        <select value={fpTextLoc} onChange={ this.changeFootprintTextLocation }>
-                            <option value={TextLocation.REGION_NE.key}> NE </option>
-                            <option value={TextLocation.REGION_NW.key}> NW </option>
-                            <option value={TextLocation.REGION_SE.key}> SE </option>
-                            <option value={TextLocation.REGION_SW.key}> SW </option>
-                        </select>
-                    </div>
-                </div>
-                <div style={tStyle}>
-                    <InputFieldView
-                                valid={isValidAngle}
-                                onChange={this.changeFootprintAngle}
-                                value={angleDeg}
-                                message={'invalid angle value'}
-                                label={'Angle:'}
-                                labelWidth={30}
-                                style={{width: 50}}
-                                tooltip={'Enter the angle in degree you want the footprint rotated'}
-
-                    />
-                    <div style={mStyle} title={textOnLink}>
-                        <a className='ff-href' style={{textDecoration: 'underline'}}
-                           onClick={()=>addFootprintDrawLayer(this.props.pv, this.state.fpInfo)}>{textOnLink}</a>
-                    </div>
-                </div>
-                <div style={{display:'flex', justifyContent: 'flex-start', paddingLeft:10}}>
+            <div style={{display:'flex', justifyContent:'flex-start', flexDirection: 'column', padding:'5px 0 9px 0'}}>
+                <div style={{display:'flex', justifyContent: 'flex-start', paddingLeft:10, paddingBottom:8}}>
                     <div> Center:</div>
                     <div style={tStyle}>
                         {convertWorldLonToString(this.state.currentPt, this.csys) + ', ' +
-                         convertWorldLatToString(this.state.currentPt, this.csys)}
+                        convertWorldLatToString(this.state.currentPt, this.csys)}
                         {convertWorldToString(this.state.currentPt, this.csys)}
                     </div>
                 </div>
 
+                <div style={{display:'flex', justifyContent:'flex-start'}}>
+
+                    <div style={tStyle}>
+                        <div title={'Add a lable to this footprint'}> Label:<input style={{width: 60}}
+                                           type='text'
+                                           value={fpText}
+                                           onChange={this.changeFootprintText}/>
+                        </div>
+                        <div style={mStyle} title={'Choose a corner'}> Corners:
+                            <select value={fpTextLoc} onChange={ this.changeFootprintTextLocation }>
+                                <option value={TextLocation.REGION_NE.key}> NE </option>
+                                <option value={TextLocation.REGION_NW.key}> NW </option>
+                                <option value={TextLocation.REGION_SE.key}> SE </option>
+                                <option value={TextLocation.REGION_SW.key}> SW </option>
+                            </select>
+                        </div>
+                    </div>
+                    <div style={tStyle}>
+                        <InputFieldView
+                                    valid={isValidAngle}
+                                    onChange={this.changeFootprintAngle}
+                                    value={angleDeg}
+                                    message={'invalid angle value'}
+                                    label={'Angle:'}
+                                    labelWidth={30}
+                                    style={{width: 50}}
+                                    tooltip={'Enter the angle in degree you want the footprint rotated'}
+
+                        />
+                        <div style={mStyle} title={textOnLink}>
+                            <a className='ff-href' style={{textDecoration: 'underline'}}
+                               onClick={()=>addFootprintDrawLayer(this.props.pv, this.state.fpInfo)}>{textOnLink}</a>
+                        </div>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/src/firefly/js/drawingLayers/MarkerTool.js
+++ b/src/firefly/js/drawingLayers/MarkerTool.js
@@ -9,11 +9,11 @@ import DrawLayer, {DataTypes,ColorChangeType}  from '../visualize/draw/DrawLayer
 import {MouseState} from '../visualize/VisMouseSync.js';
 import {PlotAttribute} from '../visualize/WebPlot.js';
 import CsysConverter from '../visualize/CsysConverter.js';
-import {primePlot, getDrawLayerById} from '../visualize/PlotViewUtil.js';
+import {primePlot, getDrawLayerById, getPlotViewIdListInGroup} from '../visualize/PlotViewUtil.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
 import {getWorldOrImage, makeMarker, findClosestIndex,  updateFootprintTranslate, updateMarkerSize,
         updateFootprintDrawobjText, updateFootprintOutline,  lengthSizeUnit,
-        MARKER_DISTANCE, OutlineType} from '../visualize/draw/MarkerFootprintObj.js';
+        MARKER_DISTANCE, OutlineType, MarkerType, ROTATE_BOX} from '../visualize/draw/MarkerFootprintObj.js';
 import {getMarkerToolUIComponent} from './MarkerToolUI.jsx';
 import {getDrawobjArea} from '../visualize/draw/ShapeHighlight.js';
 import ShapeDataObj, {lengthToScreenPixel, lengthToArcsec} from '../visualize/draw/ShapeDataObj.js';
@@ -27,7 +27,7 @@ const MARKER_SIZE = 40;      // marker original size in image coordinate (radius
 
 const ID= 'OVERLAY_MARKER';
 const TYPE_ID= 'OVERLAY_MARKER_TYPE';
-const factoryDef= makeFactoryDef(TYPE_ID,creator,null,getLayerChanges,null,getMarkerToolUIComponent);
+const factoryDef= makeFactoryDef(TYPE_ID,creator, null, getLayerChanges,null,getMarkerToolUIComponent);
 const MarkerStatus = new Enum(['attached', 'select', 'attached_relocate', 'relocate', 'resize']);
 
 export const markerInterval = 3000; // time interval for showing marker with handlers and no handlers
@@ -71,16 +71,8 @@ export function markerToolCreateLayerActionCreator(rawAction) {
         if (pId) {
             dispatchAttachLayerToPlot(drawLayerId, pId, attachPlotGroup);
 
-            var plot = primePlot(visRoot(), pId);
-            if (plot) {
-                var cc = CsysConverter.make(plot);
-                var wpt = initMarkerPos(plot, cc);
-                var size = lengthToArcsec(MARKER_SIZE, cc, ShapeDataObj.UnitType.PIXEL);
-
-                showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_CREATE, [size, size], wpt, pId,
-                                MarkerStatus.attached, markerInterval,  drawLayerId, {isOutline: true, isResize:true});
-
-            }
+            showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_CREATE, pId,
+                               MarkerStatus.attached, markerInterval,  drawLayerId, {isOutline: true, isResize:true});
         }
     };
 }
@@ -93,16 +85,16 @@ export function markerToolCreateLayerActionCreator(rawAction) {
  */
 export function markerToolStartActionCreator(rawAction) {
     return (dispatcher) => {
-        var {plotId, imagePt, screenPt, drawLayer} = rawAction.payload;
-        var cc = getCC(plotId);
-        var wpt;
-        var {markerStatus, currentSize, currentPt, timeoutProcess, drawLayerId} = drawLayer;
+        const {plotId, imagePt, screenPt, drawLayer} = rawAction.payload;
+        const markerObj = get(drawLayer, ['drawData', DataTypes.DATA, plotId]);
+        const {currentSize, currentPt, timeoutProcess, markerStatus} = markerObj.actionInfo || {};
+        const {drawLayerId} = drawLayer;
+        const cc = getCC(plotId);
+        var wpt;                         // center for re-render
         var nextStatus = null, idx;
-        var refPt;
+        var refPt;                       // reference for relocate
 
         cancelTimeoutProcess(timeoutProcess);
-        var markerObj = get(drawLayer, ['drawData', 'data', '0']);
-
         // marker can move to anywhere the mouse is clicked at while in 'attached' state
         if (markerStatus === MarkerStatus.attached) {
             if (markerObj) {
@@ -128,12 +120,14 @@ export function markerToolStartActionCreator(rawAction) {
                 wpt = getWorldOrImage(currentPt, cc);
             }
         }
-        if ([MarkerStatus.relocate, MarkerStatus.attached_relocate].includes(nextStatus)) {
+
+        if ([MarkerStatus.relocate, MarkerStatus.attached_relocate, MarkerStatus.resize].includes(nextStatus)) {
             refPt = imagePt;                   // refPt is used as the reference point for next relocation
         }
+
         if (nextStatus) {
-            showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_START, evenSize(currentSize), wpt, plotId,
-                                nextStatus, markerInterval, drawLayerId, {isOutline: true, isResize:true}, refPt);
+            showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_START, plotId, nextStatus, markerInterval,
+                               drawLayerId, {isOutline: true, isResize:true}, wpt, evenSize(currentSize), refPt);
         }
     };
 }
@@ -145,19 +139,20 @@ export function markerToolStartActionCreator(rawAction) {
  */
 export function markerToolEndActionCreator(rawAction) {
     return (dispatcher) => {
-        var {plotId, drawLayer} = rawAction.payload;
-        var cc = getCC(plotId);
-        var {markerStatus, currentSize, currentPt, timeoutProcess, drawLayerId} = drawLayer;
-        var {includeOutline: isOutline, includeResize: isResize } = get(drawLayer, ['drawData', DataTypes.DATA, '0'], {});
+        const {plotId, drawLayer} = rawAction.payload;
+        const markerObj = get(drawLayer, ['drawData', DataTypes.DATA, plotId], {});
+        const {currentSize, currentPt, timeoutProcess, markerStatus} = get(markerObj, 'actionInfo', {});
+        const {includeOutline: isOutline, includeResize: isResize} = markerObj;
+        const {drawLayerId} = drawLayer;
 
         cancelTimeoutProcess(timeoutProcess);
 
         // marker stays at current position and size
         if ([MarkerStatus.relocate, MarkerStatus.attached_relocate, MarkerStatus.resize].includes(markerStatus)) {
-            var wpt = getWorldOrImage(currentPt, cc);
+            var wpt = getWorldOrImage(currentPt, getCC(plotId));
 
-            showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_END, evenSize(currentSize), wpt, plotId,
-                               MarkerStatus.select, markerInterval, drawLayerId, {isOutline, isResize});
+            showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_END, plotId,
+                               MarkerStatus.select, markerInterval, drawLayerId, {isOutline, isResize}, wpt, evenSize(currentSize));
         }
     };
 }
@@ -169,9 +164,11 @@ export function markerToolEndActionCreator(rawAction) {
  */
 export function markerToolMoveActionCreator(rawAction) {
     return (dispatcher) => {
-        var {plotId, imagePt, drawLayer} = rawAction.payload;
-        var cc = getCC(plotId);
-        var {markerStatus, currentSize: newSize, currentPt: wpt, timeoutProcess, drawLayerId, refPt} = drawLayer;
+        const {plotId, imagePt, drawLayer} = rawAction.payload;
+        const markerObj = get(drawLayer, ['drawData', DataTypes.DATA, plotId], {});
+        const {drawLayerId} = drawLayer;
+        const cc = getCC(plotId);
+        var {markerStatus, currentSize: newSize, currentPt: wpt, timeoutProcess, refPt} = get(markerObj, 'actionInfo', {});
         var imageCenter = cc.getImageCoords(wpt);
         var move = {};
         var isHandle;
@@ -185,8 +182,8 @@ export function markerToolMoveActionCreator(rawAction) {
                        lengthToArcsec(Math.abs(imagePt.y - imageCenter.y)*2, cc, imgUnit)];
             move.newSize = {size: newSize, unitType: ShapeDataObj.UnitType.ARCSEC};   // in world size
             isHandle = { isOutline: true, isResize: true};
-
-        } else if (markerStatus === MarkerStatus.relocate) {      // marker move to new mouse down positon
+        } else if (markerStatus === MarkerStatus.relocate || markerStatus === MarkerStatus.attached_relocate) {
+            // marker move to new mouse down positon
             var dx, dy;
 
             if (refPt) {
@@ -203,9 +200,10 @@ export function markerToolMoveActionCreator(rawAction) {
                 isHandle = {isOutline: true, isResize: true};
             }
         }
+
         // resize (newDize) or relocate (wpt),  status remains the same
-        showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_MOVE, newSize, wpt, plotId,
-                           markerStatus, 0, drawLayerId, isHandle, refPt, move);
+        showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_MOVE, plotId,
+                           markerStatus, 0, drawLayerId, isHandle, wpt, newSize, refPt, move);
     };
 }
 
@@ -239,6 +237,7 @@ function creator(initPayload) {
         canUseMouse:true,
         canUserChangeColor: ColorChangeType.DYNAMIC,
         canUserDelete: true,
+        hasPerPlotData: true,
         destroyWhenAllDetached: true
     };
 
@@ -258,47 +257,68 @@ function creator(initPayload) {
  * @returns {*}
  */
 function getLayerChanges(drawLayer, action) {
-    var {drawLayerId} = action.payload;
-
+    const {drawLayerId, plotId} = action.payload;
     if (!drawLayerId || drawLayerId !== drawLayer.drawLayerId) return null;
-    var dd = Object.assign({}, drawLayer.drawData);
+
+    const dd = Object.assign({}, drawLayer.drawData);
+    var   plotIdAry;
+    var   {wpt, size} = action.payload;
+    var   retV = null;
 
     switch (action.type) {
         case DrawLayerCntlr.MARKER_CREATE:
+            plotIdAry = getPlotViewIdListInGroup(visRoot(), plotId);
+            var ccPlotId = CsysConverter.make(primePlot(visRoot(), plotId));
+            var sizePlot = lengthToArcsec(MARKER_SIZE, ccPlotId, ShapeDataObj.UnitType.PIXEL);
+
+            plotIdAry.forEach((pId) => {
+                const plot = primePlot(visRoot(), pId);
+                const cc = CsysConverter.make(plot);
+                wpt = initMarkerPos(plot, cc);
+
+                retV = createMarkerObjs(action, drawLayer, pId, wpt, sizePlot);
+            });
+
+            return retV;
+
         case DrawLayerCntlr.MARKER_START:
         case DrawLayerCntlr.MARKER_MOVE:
         case DrawLayerCntlr.MARKER_END:
-            var data = get(dd, [DataTypes.DATA, '0']);
-            var {text = '', textLoc = TextLocation.REGION_SE} = data || {};
-            var crtMarkerObj = data || null;
-            var {markerStatus} = action.payload;
+            var wptObj;
+            plotIdAry = getPlotViewIdListInGroup(visRoot(), plotId);
+            plotIdAry.forEach((pId) => {
+                wptObj = (pId === plotId) ? wpt : get(dd, ['data', pId, 'pts', '0']);
+                retV = createMarkerObjs(action, drawLayer, pId, wptObj, size);
+            });
 
-            if (markerStatus === MarkerStatus.attached ||
-                markerStatus === MarkerStatus.attached_relocate) {
-                text = get(drawLayer, 'title', '');    // title is the default text by the footprint
-            }
-
-            return createMarkerObjs(action, text, textLoc, crtMarkerObj);
+            return retV;
 
         case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
-            var {markerText, markerTextLoc} = action.payload.changes;
+            const {markerText, markerTextLoc, activePlotId} = action.payload.changes;
+            plotIdAry = getPlotViewIdListInGroup(visRoot(), activePlotId);
+            if (plotIdAry) {
+                return updateMarkerText(markerText, markerTextLoc, dd[DataTypes.DATA], plotIdAry);
+            }
+            break;
+        default:
+            return retV;
 
-            return updateMarkerText(markerText, markerTextLoc, dd[DataTypes.DATA]);
     }
+    return retV;
 }
 
 const cornerCursor = ['pointer', 'pointer', 'nwse-resize', 'nesw-resize', 'nwse-resize', 'nesw-resize'];
+
 
 function getCursor(plotView, screenPt) {
     var dlAry = dlRoot().drawLayerAry.filter( (dl) => {
         return (dl.drawLayerTypeId === TYPE_ID) && (get(dl, 'visiblePlotIdAry').includes(plotView.plotId));
     });
-    const plot= primePlot(plotView);
     var   cursor = '';
-    var   cc= CsysConverter.make(plot);
+    const cc= CsysConverter.make(primePlot(plotView));
 
     dlAry.find( (dl) => {
-        var drawObj = get(dl, ['drawData', 'data', '0']);
+        var drawObj = get(dl, ['drawData', 'data', plotView.plotId]);
         var idx = findClosestIndex(screenPt, drawObj, cc).index;
 
         if (idx >= 0 && idx < cornerCursor.length) {
@@ -316,13 +336,20 @@ function getCursor(plotView, screenPt) {
  * @param text
  * @param textLoc
  * @param markerDrawObj
+ * @param plotIdAry
  * @returns {*}
  */
-function updateMarkerText(text, textLoc, markerDrawObj) {
-    //var textUpdatedObj = updateMarkerDrawObjText(markerDrawObj[0], text, textLoc);
-    var textUpdatedObj = updateFootprintDrawobjText(markerDrawObj[0], text, textLoc);
+export function updateMarkerText(text, textLoc, markerDrawObj, plotIdAry) {
 
-    return textUpdatedObj? {drawData: {data: [textUpdatedObj]}} : {};
+    plotIdAry.forEach((pId) => {
+        var textUpdatedObj = updateFootprintDrawobjText(markerDrawObj[pId], text, textLoc);
+
+        if (textUpdatedObj) {
+            markerDrawObj[pId] = textUpdatedObj;
+        }
+    });
+
+    return {drawData: {data: markerDrawObj}};
 }
 
 /**
@@ -341,21 +368,22 @@ function evenSize(size = 0) {
  * dispatch action to locate marker with corners and no corner by timer interval on the drawing layer
  * @param dispatcher
  * @param actionType
- * @param size   in screen coordinate
- * @param wpt    marker location world coordinate
  * @param plotId
  * @param doneStatus
  * @param timer  milliseconds
  * @param drawLayerId
  * @param isHandle
+ * @param wpt    marker location world coordinatee
+ * @param size   in screen coordinate
  * @param refPt
  * @param move
  */
-function showMarkersByTimer(dispatcher, actionType, size, wpt, plotId,  doneStatus, timer, drawLayerId, isHandle,
-                            refPt, move) {
+function showMarkersByTimer(dispatcher, actionType, plotId, doneStatus, timer, drawLayerId, isHandle,
+                            wpt, size, refPt, move) {
+
     var setAction = (isHandle) => ({
         type: actionType,
-        payload: {isHandle, size, wpt, plotId, markerStatus: doneStatus, drawLayerId, refPt, move}
+        payload: {isHandle, plotId, markerStatus: doneStatus, drawLayerId, refPt, move, wpt, size}
     });
 
     var timeoutProcess = (timer !== 0) && (setTimeout(() => dispatcher(setAction({})), timer));
@@ -364,23 +392,58 @@ function showMarkersByTimer(dispatcher, actionType, size, wpt, plotId,  doneStat
 }
 
 /**
+ * calculate vertex distance for catching the marker
+ * @param markObj
+ * @param plotId
+ * @returns {{vertexDef: *, exclusiveDef: *}}
+ */
+export function updateVertexInfo(markObj, plotId) {
+    var markerStatus = markObj.sType === MarkerType.Marker ? get(markObj, ['actionInfo', 'markerStatus']) :
+                                                             get(markObj, ['actionInfo', 'footprintStatus']);
+    var exclusiveDef, vertexDef;
+
+    if (markerStatus) {
+        if (markerStatus === MarkerStatus.attached) {
+            exclusiveDef = {exclusiveOnDown: true, type: 'anywhere'};
+            vertexDef = {points: null, pointDist: MARKER_DISTANCE};
+        } else {
+            var cc = CsysConverter.make(primePlot(visRoot(), plotId));
+            const {dist, centerPt} = getVertexDistance(markObj, cc);
+
+            exclusiveDef = {exclusiveOnDown: true, type: 'vertexOnly'};
+            vertexDef = {points: [centerPt], pointDist: dist};
+        }
+        return {vertexDef, exclusiveDef};
+    }
+    return {};
+}
+
+/**
  * create drawlayer object containing only the properties which has updated value
  * @param action
- * @param text
- * @param textLoc
- * @param crtMarkerObj current marker drawObj
+ * @param dl
+ * @param plotId
+ * @param wpt
+ * @param size
  * @returns {*}
  */
-function createMarkerObjs(action, text, textLoc, crtMarkerObj) {
-     var {plotId, isHandle, wpt, size, markerStatus, timeoutProcess, refPt, move} = action.payload;
+function createMarkerObjs(action, dl, plotId, wpt, size) {
+    if (!plotId || !wpt) return null;
 
-     if (!plotId || !wpt) return null;
+    const {isHandle, markerStatus, timeoutProcess, move, refPt} = action.payload;
+    const crtMarkerObj = get(dl, ['drawData', DataTypes.DATA, plotId], {});
+    var   {text = ''} = crtMarkerObj;
+    const {textLoc = TextLocation.REGION_SE} = crtMarkerObj;
 
-     const plot = primePlot(visRoot(), plotId);
-     const cc = CsysConverter.make(plot);
-     var [markerW, markerH] = isArray(size) && size.length > 1 ?  [size[0], size[1]] : [size, size];
-     var unitT = ShapeDataObj.UnitType.ARCSEC;
-     var markObj;
+    if (markerStatus === MarkerStatus.attached ||
+        markerStatus === MarkerStatus.attached_relocate) {
+        text = get(dl, 'title', '');    // title is the default text by the footprint
+    }
+
+    const cc = CsysConverter.make(primePlot(visRoot(), plotId));
+    var [markerW, markerH] = isArray(size) && size.length > 1 ?  [size[0], size[1]] : [size, size];
+    var unitT = ShapeDataObj.UnitType.ARCSEC;
+    var markObj;
 
     if (markerStatus === MarkerStatus.attached ||
         markerStatus === MarkerStatus.attached_relocate) {  // position is reloacated after the layer is attached
@@ -388,9 +451,9 @@ function createMarkerObjs(action, text, textLoc, crtMarkerObj) {
     } else if (crtMarkerObj) {
         if ((markerStatus === MarkerStatus.resize || markerStatus === MarkerStatus.relocate) && move) {
             var {apt, newSize} = move;    // move to relocate or resize
-
             if (apt) {      // translate
                 markObj = updateFootprintTranslate(crtMarkerObj, cc, apt);
+                wpt = get(markObj, ['pts', '0']);
             } else if (newSize) {
                 markObj = updateMarkerSize(crtMarkerObj, cc, newSize);
             } else {
@@ -407,32 +470,24 @@ function createMarkerObjs(action, text, textLoc, crtMarkerObj) {
         updateHandle(isHandle, markObj); // handle display changes - resize handle disappears during translation
     }
 
-    var exclusiveDef, vertexDef; // cursor point
-    var dlObj =  {
-        helpLine: editHelpText,
-        drawData: {data: [markObj]},
-        currentPt: wpt,                    // marker center, world or image coordinate
-        currentSize: [markerW, markerH]
-    };
-    dlObj = clone(dlObj, {timeoutProcess: timeoutProcess ? timeoutProcess : null,
-                           refPt: refPt ? refPt : null});    // reference pt for next action
+    const actionInfo = {currentPt: wpt,       // marker center, world or image coordinate
+                        currentSize: [markerW, markerH],
+                        timeoutProcess: timeoutProcess ? timeoutProcess : null,
+                        refPt: refPt ? refPt : null,
+                        markerStatus};
+
+    set(dl.drawData, [DataTypes.DATA, plotId], Object.assign(markObj, {actionInfo}));
+    var dlObj = {drawData: dl.drawData, helpLine: editHelpText};
 
     if (markerStatus) {
-         if (markerStatus === MarkerStatus.attached) {
-             exclusiveDef = { exclusiveOnDown: true, type : 'anywhere' };
-             vertexDef = {points:null, pointDist:MARKER_DISTANCE};
-         } else {
+        var {exclusiveDef, vertexDef} = updateVertexInfo(markObj, plotId);
 
-             var {dist, centerPt} = getVertexDistance( markObj, cc);
+        if (exclusiveDef && vertexDef) {
+            return clone(dlObj, {markerStatus, vertexDef, exclusiveDef});
+        }
+    }
 
-             exclusiveDef = { exclusiveOnDown: true, type : 'vertexOnly' };
-             vertexDef = {points:[centerPt],
-                          pointDist: dist};
-         }
-         return clone(dlObj, {markerStatus, vertexDef, exclusiveDef});
-     } else {
-         return dlObj;
-     }
+    return dlObj;
 }
 
 /**
@@ -441,7 +496,7 @@ function createMarkerObjs(action, text, textLoc, crtMarkerObj) {
  * @param cc
  * @returns {{dist: (number|*), centerPt: *}}
  */
-function getVertexDistance( markObj, cc) {
+export function getVertexDistance( markObj, cc) {
     var {drawObjAry, outlineIndex} = markObj;
     var dist, w, h, centerPt;
 
@@ -453,12 +508,14 @@ function getVertexDistance( markObj, cc) {
         w = lengthToScreenPixel(width, cc, ShapeDataObj.UnitType.IMAGE_PIXEL) / 2;
         h = lengthToScreenPixel(height, cc, ShapeDataObj.UnitType.IMAGE_PIXEL) / 2;
         centerPt = getWorldOrImage(center, cc);
+        dist = markObj.sType === MarkerType.Marker ? 0 : ROTATE_BOX;
     } else {
         w = cc.viewDim.width/2;
         h = cc.viewDim.height/2;
         centerPt = getWorldOrImage(makeDevicePt(w, h), cc);
+        dist = 0;
     }
-    dist = Math.sqrt(Math.pow(w, 2) + Math.pow(h, 2));
+    dist += Math.sqrt(Math.pow(w, 2) + Math.pow(h, 2));
 
     return {dist, centerPt};
 }

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -46,6 +46,7 @@ export class CysConverter {
      */
     constructor(plot, altAffTrans)  {
         this.plotImageId= plot.plotImageId;
+        this.plotId = plot.plotId;
         this.plotState= plot.plotState;
         this.dataWidth= plot.dataWidth;
         this.dataHeight= plot.dataHeight;

--- a/src/firefly/js/visualize/draw/MarkerFootprintObj.js
+++ b/src/firefly/js/visualize/draw/MarkerFootprintObj.js
@@ -6,7 +6,7 @@
 import Point, {makeImagePt, makeScreenPt, makeDevicePt, makeWorldPt, SimplePt} from '../Point.js';
 import {CoordinateSys} from '../CoordSys.js';
 import ShapeDataObj, {lengthToImagePixel, lengthToScreenPixel,
-       lengthToArcsec, makePoint, drawText, makeTextLocationComposite} from './ShapeDataObj.js';
+       lengthToArcsec, makePoint, drawText, makeTextLocationComposite, flipTextLocAroundY} from './ShapeDataObj.js';
 import {POINT_DATA_OBJ, getPointDataobjArea, makePointDataObj, DrawSymbol} from './PointDataObj.js';
 import {getDrawobjArea, isWithinPolygon} from './ShapeHighlight.js';
 import {defaultMarkerTextLoc} from '../../drawingLayers/MarkerToolUI.jsx';
@@ -18,6 +18,8 @@ import DrawObj from './DrawObj.js';
 import DrawOp from './DrawOp.js';
 import BrowserInfo from '../../util/BrowserInfo.js';
 import {clone} from '../../util/WebUtil.js';
+import {getPlotViewById} from '../PlotViewUtil.js';
+import {visRoot} from '../ImagePlotCntlr.js';
 import Enum from 'enum';
 import {has, isNil, get, isEmpty, isArray, set} from 'lodash';
 
@@ -763,7 +765,6 @@ function createRotateHandle(outlineBox, cc, rotAngle) {
     const handleCenter = [[0, -0.5], [0.5, 0], [0, 0.5], [-0.5, 0]];  // handle center relative to the end of handle bar
     const handleAngle = [Math.PI * 3/2, 0, Math.PI*0.5, Math.PI];
     const [x1, x2, y1, y2] = [0, cc.screenSize.width, 0, cc.screenSize.height];
-
     var rotateObj = null;
     var corners =  getRectCorners(outlineBox.pts[0], outlineBox.width, outlineBox.height, outlineBox.unitType, cc);
     var side = 4;
@@ -1016,6 +1017,8 @@ function drawFootprintText(drawObj, plot, def, drawTextAry) {
     var objArea  = getObjArea(outlineObj, plot); // in image coordinate
 
     if (objArea) {
+        textLoc = flipTextLocAroundY(plot, textLoc);
+
         var textPt = makeTextLocationComposite(plot, textLoc, fontSize,
                         objArea.width * plot.zoomFactor,
                         objArea.height * plot.zoomFactor,

--- a/src/firefly/js/visualize/draw/PointDataObj.js
+++ b/src/firefly/js/visualize/draw/PointDataObj.js
@@ -369,11 +369,11 @@ function drawSymbolOnPlot(ctx, x, y, drawParams, renderOptions, onlyAddToPath, p
             DrawUtil.drawArrow(ctx, x, y, color, size, renderOptions, onlyAddToPath);
             break;
         case DrawSymbol.ROTATE:
-            const rAngle = getPVRotateAngle(plot);
+            var rotAngle = get(renderOptions, 'rotAngle', 0.0);
+            rotAngle = getPVRotateAngle(plot, rotAngle);
 
-            if (rAngle !== 0.0) {
-                renderOptions = Object.assign({}, renderOptions, {rotAngle: get(renderOptions, 'rotAngle', 0.0) + rAngle});
-            }
+            renderOptions = Object.assign({}, renderOptions, {rotAngle});
+
             DrawUtil.drawRotate(ctx, x, y, color, size, renderOptions, onlyAddToPath);
             break;
         default :

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -13,6 +13,8 @@ import {toRegion} from './ShapeToRegion.js';
 import {getDrawobjArea,  isScreenPtInRegion, makeHighlightShapeDataObj} from './ShapeHighlight.js';
 import CsysConverter from '../CsysConverter.js';
 import {has, isNil, get, set} from 'lodash';
+import {getPlotViewById} from '../PlotViewUtil.js';
+import {visRoot} from '../ImagePlotCntlr.js';
 
 const FONT_FALLBACK= ',sans-serif';
 
@@ -34,6 +36,13 @@ export function makePoint(pt, plot, toType) {
     } else {
         return plot.getWorldCoords(pt);
     }
+}
+
+export function getPVRotateAngle(plot) {
+     const plotId = plot.plotImageId.substring(0, plot.plotImageId.indexOf('-'));
+     const pv = getPlotViewById(visRoot(), plotId);
+
+     return pv.rotation ? convertAngle('deg', 'radian', pv.rotation) : 0.0;
 }
 
 function make(sType) {
@@ -744,10 +753,8 @@ function drawRectangle(drawObj, ctx, drawTextAry,  plot, drawParams, onlyAddToPa
                     angle =  plot.zoomFactor * angle;
                 }
 
-                angle += rectAngle;
-                if (has(renderOptions, 'rotAngle')) {
-                    angle += renderOptions.rotAngle;
-                }
+                angle += rectAngle + getPVRotateAngle(plot) + get(renderOptions, 'rotAngle', 0.0);
+
                 if (has(renderOptions, 'translation')) {
                     x += renderOptions.translation.x;
                     y += renderOptions.translation.y;
@@ -890,7 +897,7 @@ function drawEllipse(drawObj, ctx, drawTextAry,  plot, drawParams, onlyAddToPath
                 angle = plot.zoomFactor * angle;
             }
 
-            angle += eAngle;
+            angle += eAngle + getPVRotateAngle(plot);
 
             if (!onlyAddToPath || style === Style.HANDLED) {
                 DrawUtil.beginPath(ctx, color, lineWidth, renderOptions);


### PR DESCRIPTION
The development includes 
- fixing the bug regarding footprint rotation handles off while rotating
- fixing the bug regarding marker resize handles off while resizing
- rendering the footprints, markers and regions based on the rotation angle of the image. 
- updating footprint and marker rendering on multiple plots. 

test:
do image search 
add footprint or marker onto the image
operate the footprint or marker (rotate/move the footprint or resize/move the marker)
rotate the image before or while operating on the footprint/marker
