### PR TITLE
Dm-10241 Fix the rendering of east arrow in the North/East compass

### DIFF
--- a/src/firefly/js/drawingLayers/NorthUpCompass.js
+++ b/src/firefly/js/drawingLayers/NorthUpCompass.js
@@ -148,9 +148,8 @@ function makeCompass(plotId, action){
     var cdelt1 = cc.getImagePixelScaleInDeg();
     var zf= cc.zoomFactor || 1;
     var wpt2= makeWorldPt(wpStart.getLon(), wpStart.getLat() + (Math.abs(cdelt1)/zf)*(px));
-    var wptE2=  makeWorldPt(wpStart.getLon()+(Math.abs(cdelt1)/zf)*(px), wpStart.getLat());
     var spt2= cc.getScreenCoords(wpt2);
-    var sptE2= cc.getScreenCoords(wptE2);
+    var sptE2 = getEastFromNorthOnScreen(cc, sptStart, spt2, Math.PI/2);
 
     if (sptStart===null || spt2===null || sptE2===null) {
         return null;
@@ -160,4 +159,14 @@ function makeCompass(plotId, action){
     var dataE= makeDirectionArrowDrawObj(sptStart, sptE2,'E');
 
     return [dataE, dataN];
+}
+
+function getEastFromNorthOnScreen(cc, origin, nVec) {
+    var originSpt = cc.getScreenCoords(origin);
+    var vec1Spt = cc.getScreenCoords(nVec);
+
+    var x2 = (vec1Spt.y - originSpt.y) + originSpt.x;
+    var y2 = -(vec1Spt.x - originSpt.x) + originSpt.y;
+
+    return makeScreenPt(x2, y2);
 }

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -221,15 +221,20 @@ function makeDrawing(pv,width,height) {
     const thumbZoomFact= getThumbZoomFact(plot,width,height);
     const cdelt1 = cc.getImagePixelScaleInDeg();
     const wpt2= makeWorldPt(wptC.getLon(), wptC.getLat() + (Math.abs(cdelt1)/thumbZoomFact)*(arrowLength/1.6));
-    const wptE2= makeWorldPt(wptC.getLon()+(Math.abs(cdelt1)/thumbZoomFact)*(arrowLength/2), wptC.getLat());
+    //const wptE2= makeWorldPt(wptC.getLon()+(Math.abs(cdelt1)/thumbZoomFact)*(arrowLength/2), wptC.getLat());
     const wptE1= wptC;
     const wpt1= wptC;
 
+    const sptC = cc.getScreenCoords(wptC);
+    const sptN = cc.getScreenCoords(wpt2);
+    const [x, y] = [(sptN.y - sptC.y) + sptC.x, (-sptN.x + sptC.x)+sptC.y];
+    const wptE2 = cc.getWorldCoords(makeScreenPt(x, y));
 
     const spt1= cc.getDeviceCoords(wpt1, thumbZoomFact, thumbnailTrans);
     const spt2= cc.getDeviceCoords(wpt2, thumbZoomFact, thumbnailTrans);
     const sptE1= cc.getDeviceCoords(wptE1, thumbZoomFact, thumbnailTrans);
     const sptE2= cc.getDeviceCoords(wptE2, thumbZoomFact, thumbnailTrans);
+
 
     if (!spt1 || !spt2 || !sptE1 || !sptE2) return null;
 


### PR DESCRIPTION
This development fixes the rendering of the East arrow line in the North/East compass, making the direction of the East arrow perpendicular to the North arrow line.

test: 
please refer to the compass on DS9 for the following image search,. 
- from Firefly, get image by setting RA=45, DEC=89 and selecting IRAS with 5 degree cutout,
  add grid and the North/East Compass. 
- download the fits image, and open it from DS9.
- add grid and compasses at various locations  in DS9
- move the image in Firefly to see the compass shown on various locations and compared the compass to that shown on DS9. 