### PR TITLE
DM-10115 Reset the column select dropdown and column stats on new catalog search

### DIFF
--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -70,9 +70,11 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
     };
 
     var val = get(params, fldPath);
-    const onColSelected = (colName) => {
-        val = colName;
-        dispatchValueChange({fieldKey: fldPath, groupKey, value: colName, valid: true});
+    const onColSelected = (colValStats) => {
+        return (colName) => {
+            val = colName;
+            dispatchValueChange({fieldKey: fldPath, groupKey, value: colName, valid: true, colValStats});
+        };
     };
     const colValidator = getColValidator(colValStats,!nullAllowed);
     const value = get(params, fldPath);
@@ -102,7 +104,7 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
             />
             <div style={{display: 'inline-block', cursor:'pointer', paddingLeft: 3, verticalAlign: 'middle', fontSize: 'larger'}}
                  title={`Select ${name} column`}
-                 onClick={() => showColSelectPopup(colValStats, onColSelected,`Choose ${name}`,'OK',val)}>
+                 onClick={() => showColSelectPopup(colValStats, onColSelected(colValStats),`Choose ${name}`,'OK',val)}>
                 {cols}
             </div>
         </div>

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -69,11 +69,9 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
     };
 
     var val = get(params, fldPath);
-    const onColSelected = (colValStats) => {
-        return (colName) => {
-            val = colName;
-            dispatchValueChange({fieldKey: fldPath, groupKey, value: colName, valid: true, colValStats});
-        };
+    const onColSelected = (colName) => {
+        val = colName;
+        dispatchValueChange({fieldKey: fldPath, groupKey, value: colName, valid: true});
     };
     const colValidator = getColValidator(colValStats,!nullAllowed);
     const value = get(params, fldPath);
@@ -103,7 +101,7 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
             />
             <div style={{display: 'inline-block', cursor:'pointer', paddingLeft: 3, verticalAlign: 'middle', fontSize: 'larger'}}
                  title={`Select ${name} column`}
-                 onClick={() => showColSelectPopup(colValStats, onColSelected(colValStats),`Choose ${name}`,'OK',val)}>
+                 onClick={() => showColSelectPopup(colValStats, onColSelected,`Choose ${name}`,'OK',val)}>
                 {cols}
             </div>
         </div>

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -6,7 +6,6 @@ import React, {PropTypes} from 'react';
 import {get} from 'lodash';
 import {Expression} from '../../util/expr/Expression.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
-import {TextButton} from '../../ui/TextButton.jsx';
 import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
 import ColValuesStatistics from '../ColValuesStatistics.js';
 import {showColSelectPopup} from './ColSelectView.jsx';

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 
-import {get, defer} from 'lodash';
+import {get, defer, has} from 'lodash';
 import ColValuesStatistics from './../ColValuesStatistics.js';
 import {DATATYPE_HISTOGRAM} from '../dataTypes/HistogramCDT.js';
 import CompleteButton from '../../ui/CompleteButton.jsx';
@@ -49,8 +49,6 @@ export function setOptions(groupKey, histogramParams) {
         {fieldKey: 'binWidth', value: get(histogramParams, 'binWidth','')},
         {fieldKey: 'minCutoff', value: get(histogramParams, 'minCutoff','')},
         {fieldKey: 'maxCutoff', value: get(histogramParams, 'maxCutoff','')}
-
-
     ];
     dispatchMultiValueChange(groupKey, flds);
 }
@@ -79,6 +77,10 @@ var columnNameReducer= (colValStats) => {
         if (!inFields) {
             return {};
         }
+        if (has(action.payload, 'colValStats')) {
+            colValStats = get(action.payload, 'colValStats'); // reset column stats
+        }
+
         let fieldKey = undefined;
         if (action.type === VALUE_CHANGE) {
             // when column name changes, update the min/max input
@@ -87,6 +89,7 @@ var columnNameReducer= (colValStats) => {
                 case 'columnOrExpr':
                     const colName = action.payload.value;
                     if (colName ) {
+
                         if (isSingleColumn(colName, colValStats)) {
                             for (var i=0; i<colValStats.length; i++){
                                 if (colName=== colValStats[i].name) {
@@ -159,13 +162,13 @@ var columnNameReducer= (colValStats) => {
 };
 export class HistogramOptions extends React.Component {
 
-        constructor(props) {
-            super(props);
-            this.state = {
-                fields : FieldGroupUtils.getGroupFields(this.props.groupKey),
-                fixedAlgorithm: get(getAppOptions(), 'charts.ui.HistogramOptions.fixedAlgorithm') || props.fixedAlgorithm
-            };
-        }
+    constructor(props) {
+        super(props);
+        this.state = {
+            fields : FieldGroupUtils.getGroupFields(this.props.groupKey),
+            fixedAlgorithm: get(getAppOptions(), 'charts.ui.HistogramOptions.fixedAlgorithm') || props.fixedAlgorithm
+        };
+    }
 
 
     shouldComponentUpdate(np, ns) {

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 
-import {get, defer, has} from 'lodash';
+import {get, defer, isEmpty} from 'lodash';
 import ColValuesStatistics from './../ColValuesStatistics.js';
 import {DATATYPE_HISTOGRAM} from '../dataTypes/HistogramCDT.js';
 import CompleteButton from '../../ui/CompleteButton.jsx';
@@ -68,21 +68,16 @@ function isSingleColumn(colName, colValStats) {
     }
     return false;
 }
-var columnNameReducer= (colValStats) => {
-    if (!colValStats) {
-        return {};
-    }
+var columnNameReducer = () => {
     return (inFields, action) => {
 
         if (!inFields) {
             return {};
         }
-        if (has(action.payload, 'colValStats')) {
-            colValStats = get(action.payload, 'colValStats'); // reset column stats
-        }
+        const colValStats = get(action.payload, 'colValStats');
 
         let fieldKey = undefined;
-        if (action.type === VALUE_CHANGE) {
+        if (!isEmpty(colValStats) && action.type === VALUE_CHANGE) {
             // when column name changes, update the min/max input
             fieldKey = get(action.payload, 'fieldKey');
             switch (fieldKey){
@@ -297,7 +292,7 @@ export class HistogramOptions extends React.Component {
         return (
             <div style={{padding:'0 5px', minHeight: 250}}>
                 <FieldGroup groupKey={groupKey} validatorFunc={null} keepState={true}
-                            reducerFunc={columnNameReducer(colValStats)}>
+                            reducerFunc={columnNameReducer()}>
 
                     {onOptionsSelected &&
                     <div style={{display: 'flex', flexDirection: 'row', padding: '5px 0 15px'}}>
@@ -377,7 +372,7 @@ function renderFixedBinSizeOptions(groupKey, histogramParams, disabled){
          <RadioGroupInputField
             initialState= {{
                                 value: get(histogramParams, 'fixedBinSizeSelection', 'numBins'),
-                                tooltip: 'Please select number of bins or bin width',
+                                tooltip: 'Please select number of bins or bin width'
                                 //label: 'BinSize:'
                             }}
             options={binSizeOptions}
@@ -390,7 +385,7 @@ function renderFixedBinSizeOptions(groupKey, histogramParams, disabled){
                  initialState= {{
                                   value: get(histogramParams, 'numBins', '50'),
                                   validator:Validate.intRange.bind(null, 1, 500, 'numBins'),
-                                  tooltip: 'Number of bins',
+                                  tooltip: 'Number of bins'
 
                              }}
                  disabled = {disabled}
@@ -403,7 +398,7 @@ function renderFixedBinSizeOptions(groupKey, histogramParams, disabled){
                  initialState= {{
                                   value: get(histogramParams, 'binWidth', ''),
                                   validator:Validate.isFloat.bind(null,  'binWidth'),
-                                  tooltip: 'Bin width',
+                                  tooltip: 'Bin width'
 
                              }}
                  disabled = {!disabled}

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -68,14 +68,12 @@ function isSingleColumn(colName, colValStats) {
     }
     return false;
 }
-var columnNameReducer = () => {
+var columnNameReducer= (colValStats) => {
     return (inFields, action) => {
 
         if (!inFields) {
             return {};
         }
-        const colValStats = get(action.payload, 'colValStats');
-
         let fieldKey = undefined;
         if (!isEmpty(colValStats) && action.type === VALUE_CHANGE) {
             // when column name changes, update the min/max input
@@ -84,7 +82,6 @@ var columnNameReducer = () => {
                 case 'columnOrExpr':
                     const colName = action.payload.value;
                     if (colName ) {
-
                         if (isSingleColumn(colName, colValStats)) {
                             for (var i=0; i<colValStats.length; i++){
                                 if (colName=== colValStats[i].name) {
@@ -292,7 +289,7 @@ export class HistogramOptions extends React.Component {
         return (
             <div style={{padding:'0 5px', minHeight: 250}}>
                 <FieldGroup groupKey={groupKey} validatorFunc={null} keepState={true}
-                            reducerFunc={columnNameReducer()}>
+                            reducerFunc={columnNameReducer(colValStats)}>
 
                     {onOptionsSelected &&
                     <div style={{display: 'flex', flexDirection: 'row', padding: '5px 0 15px'}}>

--- a/src/firefly/js/fieldGroup/FieldGroupCntlr.js
+++ b/src/firefly/js/fieldGroup/FieldGroupCntlr.js
@@ -107,7 +107,6 @@ export function dispatchInitFieldGroup(groupKey,keepState=false,
 
 
 /**
- *
  * @param groupKey
  * @param mounted
  * @param keepState
@@ -115,6 +114,7 @@ export function dispatchInitFieldGroup(groupKey,keepState=false,
  * @param reducerFunc
  * @param actionTypes any action types (beyond the FieldGroup action types) that the reducer should allow though
  * @param wrapperGroupKey
+ * @param forceUnmount
  */
 export function dispatchMountFieldGroup(groupKey, mounted, keepState= false, 
                                         initValues=null, reducerFunc= null,

--- a/src/firefly/js/fieldGroup/FieldGroupCntlr.js
+++ b/src/firefly/js/fieldGroup/FieldGroupCntlr.js
@@ -340,7 +340,7 @@ function initFieldGroup(state,action) {
 }
 
 const updateFieldGroupMount= function(state,action) {
-    var {groupKey, mounted, initValues, wrapperGroupKey, forceUnmount}= action.payload;
+    var {groupKey, mounted, initValues, reducerFunc, wrapperGroupKey, forceUnmount}= action.payload;
     if (!groupKey) return state;
 
     var retState= state;
@@ -349,6 +349,7 @@ const updateFieldGroupMount= function(state,action) {
         if (isFieldGroupDefined(state,groupKey)) {
             fg= findAndCloneFieldGroup(state, groupKey, {mounted:true});
             if (wrapperGroupKey) fg.wrapperGroupKey= wrapperGroupKey;
+            if (reducerFunc) fg.reducerFunc= reducerFunc;
 
             if (initValues) {
                 fg.fields= addInitValues(fg.fields,initValues);

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -15,6 +15,7 @@ import {isMetaDataTable, isCatalogTable} from '../../metaConvert/converterUtils.
 import {META_VIEWER_ID} from '../../visualize/ui/TriViewImageSection.jsx';
 import {REPLACE_VIEWER_ITEMS, DEFAULT_FITS_VIEWER_ID, getViewerItemIds, getMultiViewRoot} from '../../visualize/MultiViewCntlr.js';
 import {visRoot} from '../../visualize/ImagePlotCntlr.js';
+import {resetChartSelectOptions} from '../../ui/ChartSelectDropdown.jsx';
 
 /**
  * this manager manages what main components get display on the screen.
@@ -157,6 +158,8 @@ function handleActiveTableChange (layoutInfo, action) {
     const {tbl_id} = action.payload;
     var {images={}, showImages} = layoutInfo;
     var {coverageLockedOn, showCoverage, showMeta, metaDataTableId} = images;
+
+    resetChartSelectOptions();
 
     const showFits= shouldShowFits();
     showImages= showFits||coverageLockedOn;

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -12,17 +12,20 @@ import * as TblUtil from '../tables/TableUtil.js';
 import * as TableStatsCntlr from '../charts/TableStatsCntlr.js';
 import * as ChartsCntlr from '../charts/ChartsCntlr.js';
 import {uniqueChartId} from '../charts/ChartUtil.js';
-import {XYPlotOptions} from '../charts/ui/XYPlotOptions.jsx';
 import {DT_XYCOLS} from '../charts/dataTypes/XYColsCDT.js';
-import {resultsSuccess as onXYPlotOptsSelected} from '../charts/ui/XYPlotOptions.jsx';
-import {HistogramOptions} from '../charts/ui/HistogramOptions.jsx';
+import {XYPlotOptions, resultsSuccess as onXYPlotOptsSelected,
+                       setOptions as XYPlotSetOptions} from '../charts/ui/XYPlotOptions.jsx';
 import {DT_HISTOGRAM} from '../charts/dataTypes/HistogramCDT.js';
-import {resultsSuccess as onHistogramOptsSelected} from '../charts/ui/HistogramOptions.jsx';
+import {HistogramOptions, resultsSuccess as onHistogramOptsSelected,
+                          setOptions as HistogramSetOptions} from '../charts/ui/HistogramOptions.jsx';
+
 //import {uniqueChartId} from '../charts/ChartUtil.js';
 
 import {FormPanel} from './FormPanel.jsx';
 import CompleteButton from './CompleteButton.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
+import FieldGroupUtils from '../fieldGroup/FieldGroupUtils';
+import {isEmpty} from 'lodash';
 
 import LOADING from 'html/images/gxt/loading.gif';
 
@@ -257,3 +260,22 @@ ChartSelectDropdown.propTypes = {
 ChartSelectDropdown.defaultProps = {
     name: dropdownName
 };
+
+
+/**
+ * @summary reset chart column select dropdown value if the relevant field group exists
+ */
+export function resetChartSelectOptions() {
+    const chartHandler = {
+        [SCATTER]: XYPlotSetOptions,
+        [HISTOGRAM]: HistogramSetOptions
+    };
+
+    Object.keys(chartHandler).forEach((chartType) => {
+        const formGroupName = getFormName(chartType);
+
+        if (!isEmpty(FieldGroupUtils.getGroupFields(formGroupName))) {
+            chartHandler[chartType](formGroupName);
+        }
+    });
+}

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -28,11 +28,11 @@ import LOADING from 'html/images/gxt/loading.gif';
 
 const dropdownName = 'ChartSelectDropDownCmd';
 
-const SCATTER = 'scatter';
-const HISTOGRAM = 'histogram';
+export const SCATTER = 'scatter';
+export const HISTOGRAM = 'histogram';
 const PREF_CHART_TYPE = 'pref.chartType';
 
-function getFormName(chartType) {
+export function getFormName(chartType) {
     return chartType+'ChartOpts';
 }
 

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -27,10 +27,11 @@ import {FileUpload} from '../../ui/FileUpload.jsx';
 import {convertAngle} from '../VisUtil.js';
 import {masterTableFilter} from './IrsaMasterTableFilters.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
+/*
 import {SCATTER, HISTOGRAM, getFormName} from '../../ui/ChartSelectDropdown.jsx';
 import {setOptions as HistogramSetOptions} from '../../charts/ui/HistogramOptions.jsx';
 import {setOptions as XYPlotSetOptions} from '../../charts/ui/XYPlotOptions.jsx';
-
+*/
 
 import './CatalogTableListField.css';
 import './CatalogSelectViewPanel.css';
@@ -215,19 +216,8 @@ function doCatalog(request) {
     if (colsSearched.length > 0) {
         tReq.selcols = colsSearched;
     }
-
     //console.log('final request: ' + JSON.stringify(tReq));
-    //reset column select dropdown value if there is the field group
-    const chartHandler = {[SCATTER]: XYPlotSetOptions,
-                          [HISTOGRAM]: HistogramSetOptions};
 
-    Object.keys(chartHandler).forEach((chartType) => {
-        const formGroupName = getFormName(chartType);
-
-        if (!isEmpty(FieldGroupUtils.getGroupFields(formGroupName))) {
-            chartHandler[chartType](formGroupName);
-        }
-    });
     dispatchTableSearch(tReq);
 }
 

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -27,11 +27,7 @@ import {FileUpload} from '../../ui/FileUpload.jsx';
 import {convertAngle} from '../VisUtil.js';
 import {masterTableFilter} from './IrsaMasterTableFilters.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
-/*
-import {SCATTER, HISTOGRAM, getFormName} from '../../ui/ChartSelectDropdown.jsx';
-import {setOptions as HistogramSetOptions} from '../../charts/ui/HistogramOptions.jsx';
-import {setOptions as XYPlotSetOptions} from '../../charts/ui/XYPlotOptions.jsx';
-*/
+
 
 import './CatalogTableListField.css';
 import './CatalogSelectViewPanel.css';

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -8,7 +8,7 @@ import {FormPanel} from '../../ui/FormPanel.jsx';
 import { get, merge, isEmpty, isFunction} from 'lodash';
 import {updateMerge} from '../../util/WebUtil.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
-import {doFetchTable, makeTblRequest, makeIrsaCatalogRequest, makeVOCatalogRequest} from '../../tables/TableUtil.js';
+import {doFetchTable, makeTblRequest, makeIrsaCatalogRequest, makeVOCatalogRequest, getTblIdsByGroup} from '../../tables/TableUtil.js';
 import {CatalogTableListField} from './CatalogTableListField.jsx';
 import {CatalogConstraintsPanel} from './CatalogConstraintsPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
@@ -27,6 +27,9 @@ import {FileUpload} from '../../ui/FileUpload.jsx';
 import {convertAngle} from '../VisUtil.js';
 import {masterTableFilter} from './IrsaMasterTableFilters.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
+import {SCATTER, HISTOGRAM, getFormName} from '../../ui/ChartSelectDropdown.jsx';
+import {setOptions as HistogramSetOptions} from '../../charts/ui/HistogramOptions.jsx';
+import {setOptions as XYPlotSetOptions} from '../../charts/ui/XYPlotOptions.jsx';
 
 
 import './CatalogTableListField.css';
@@ -213,7 +216,19 @@ function doCatalog(request) {
         tReq.selcols = colsSearched;
     }
 
-    console.log('final request: ' + JSON.stringify(tReq));
+    //console.log('final request: ' + JSON.stringify(tReq));
+    if (!isEmpty(getTblIdsByGroup())) {     // triview has table already, reset the chart column select form values
+        const chartHandler = {[SCATTER]: XYPlotSetOptions,
+                              [HISTOGRAM]: HistogramSetOptions};
+
+        Object.keys(chartHandler).forEach((chartType) => {
+            const formGroupName = getFormName(chartType);
+
+            if (!isEmpty(FieldGroupUtils.getGroupFields(formGroupName))) {
+                chartHandler[chartType](formGroupName);
+            }
+        });
+    }
     dispatchTableSearch(tReq);
 }
 

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -8,7 +8,7 @@ import {FormPanel} from '../../ui/FormPanel.jsx';
 import { get, merge, isEmpty, isFunction} from 'lodash';
 import {updateMerge} from '../../util/WebUtil.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
-import {doFetchTable, makeTblRequest, makeIrsaCatalogRequest, makeVOCatalogRequest, getTblIdsByGroup} from '../../tables/TableUtil.js';
+import {doFetchTable, makeTblRequest, makeIrsaCatalogRequest, makeVOCatalogRequest} from '../../tables/TableUtil.js';
 import {CatalogTableListField} from './CatalogTableListField.jsx';
 import {CatalogConstraintsPanel} from './CatalogConstraintsPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
@@ -217,18 +217,17 @@ function doCatalog(request) {
     }
 
     //console.log('final request: ' + JSON.stringify(tReq));
-    if (!isEmpty(getTblIdsByGroup())) {     // triview has table already, reset the chart column select form values
-        const chartHandler = {[SCATTER]: XYPlotSetOptions,
-                              [HISTOGRAM]: HistogramSetOptions};
+    //reset column select dropdown value if there is the field group
+    const chartHandler = {[SCATTER]: XYPlotSetOptions,
+                          [HISTOGRAM]: HistogramSetOptions};
 
-        Object.keys(chartHandler).forEach((chartType) => {
-            const formGroupName = getFormName(chartType);
+    Object.keys(chartHandler).forEach((chartType) => {
+        const formGroupName = getFormName(chartType);
 
-            if (!isEmpty(FieldGroupUtils.getGroupFields(formGroupName))) {
-                chartHandler[chartType](formGroupName);
-            }
-        });
-    }
+        if (!isEmpty(FieldGroupUtils.getGroupFields(formGroupName))) {
+            chartHandler[chartType](formGroupName);
+        }
+    });
     dispatchTableSearch(tReq);
 }
 


### PR DESCRIPTION
This development fixes the following issues after starting a new catalog search: 
- The column selection dropdown shows column stats of previous active table
- the added chart shows the content relevant to the previous active table, not current active table. 

test: 
- start a catalog search
- add a chart by clicking 'Charts' button, selecting chart type (Histogram or scatter) and selecting the column name from column select form.
- check if the added chart reflects the selected column and its stats.
- start another catalog search
- repeat the column selection steps to add the chart
- check if the added chart reflects the selected column and its stats from the second catalog search

