### PR TITLE
IRSA-401: Add ops internal environment to IFE apps

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -62,7 +62,6 @@ environments {
     dev {
         BuildType = "Development"
         ehcache.multicast.port = "5015"
-        irsa.gator.service.periodogram.url = "https://irsadev.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api"
         lsst.dataAccess.uri = "http://localhost:8661/db/v0/query?"
         lsst.dataAccess.db = "smm_bremerton"
     }

--- a/config/app.config
+++ b/config/app.config
@@ -4,8 +4,8 @@
 BuildMajor = 1
 BuildMinor = 0
 BuildRev = 0
-BuildType = "Development"
 BuildNumber = 0
+BuildType = "Final"
 
 config.dir = "/hydra/server/config"
 work.directory = "/hydra/workarea"
@@ -21,15 +21,30 @@ ehcache.multicast.ttl = 1
 
 download.bundle.maxbytes = 304857600
 
-sso.server.url = "http://irsa.ipac.caltech.edu/account/"
-sso.user.profile.url = "http://irsa.ipac.caltech.edu/account/uman/uman.html//id=profile"
-help.base.url = "http://irsa.ipac.caltech.edu/onlinehelp/"
+sso.server.url = "https://irsa.ipac.caltech.edu/account/"
+sso.user.profile.url = "https://irsa.ipac.caltech.edu/account/uman/uman.html//id=profile"
+help.base.url = "https://irsa.ipac.caltech.edu/onlinehelp/"
 
 
 visualize.fits.MaxSizeInBytes= 10737418240
 visualize.fits.search.path = "/irsadata"
+visualize.fits.Security= true
 
-irsa.gator.hostname = "irsa.ipac.caltech.edu"
+// ehcache.xml env sensitive properties
+// ehcahe replication port; suggest 4015-local, 5015-dev, 6015-test, 7015-ops, 7515-ops_int
+ehcache.multicast.port = "7015"
+
+
+/* ------------------------ IRSA services --------------------------------- */
+GatorHost     = "https://irsa.ipac.caltech.edu"
+irsa.base.url           = "https://irsa.ipac.caltech.edu"
+irsa.gator.dd.hostname  = "https://irsa.ipac.caltech.edu"
+irsa.gator.hostname     = "https://irsa.ipac.caltech.edu"
+//MOST (moving object - precovery - search) host
+most.host = "https://irsasearchops.ipac.caltech.edu/cgi-bin/MOST/nph-most"
+// IRSA Periodogram API
+irsa.gator.service.periodogram.url = "https://irsa.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api"
+/*  ----------------------------------------------------------------------- */
 
 wise.ibe.host       = "irsa.ipac.caltech.edu/ibe"
 twomass.ibe.host    = "irsa.ipac.caltech.edu/ibe"
@@ -37,46 +52,25 @@ twomass.ibe.host    = "irsa.ipac.caltech.edu/ibe"
 lsst.dataAccess.uri = ''
 lsst.dataAccess.db = ''
 
-// not used at the moment - since Aug. 2015 - may come back (check Git history on QueryLSSTCatalog)
-// lsst.qserv.uri = ''
-// lsst.qserv.user = ''
-// lsst.qserv.pass = ''
-
-// not used at the moment - since Aug. 2015 - may come back (check Git history on QueryLSSTCatalogDD)
-// lsst.schema.uri = ''
-// lsst.schema.user = ''
-// lsst.schema.pass = ''
-
-
-// ehcache.xml env sensitive properties
-// ehcahe replication port; suggest 4016-developer, 5016-dev, 6016-I&T, 7016-Prod, 8016-Public
-ehcache.multicast.port = 4016
-visualize.fits.Security= true
-
-// IRSA Periodogram API
-irsa.gator.service.periodogram.url = "http://irsatest.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api"
-
-environments{
+environments {
     local {
-        visualize.fits.search.path = "/Library/WebServer/Documents:/irsadata:/hydra"
+        BuildType = "Development"
+        ehcache.multicast.port = 4015
         visualize.fits.Security= false
-        visualize.fits.MaxSizeInBytes= 10737418240
         ehcache.multicast.ttl = 0
     }
-
     dev {
+        BuildType = "Development"
         ehcache.multicast.port = "5015"
+        irsa.gator.service.periodogram.url = "https://irsadev.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api"
         lsst.dataAccess.uri = "http://localhost:8661/db/v0/query?"
         lsst.dataAccess.db = "smm_bremerton"
     }
-
     test {
-      BuildType = "Beta"
-      ehcache.multicast.port = "6015"
+        BuildType = "Beta"
+        ehcache.multicast.port = "6015"
     }
-
-    ops {
-      BuildType = "Final"
-      ehcache.multicast.port = "7015"
+    ops_int {
+        ehcache.multicast.port = "7515"
     }
 }

--- a/src/fftools/build.gradle
+++ b/src/fftools/build.gradle
@@ -20,24 +20,24 @@ ext.appConfig = {
   BuildMajor  = "2"
   BuildMinor  = "4"
   BuildRev    = "1"
-  ehcache.replicate = false
 
   FireflyTools.Advertise = ""
-  ehcache.multicast.port = "4016"
+  ehcache.multicast.port = "7016"
+  ehcache.replicate = true
+
   environments {
+    local {
+      ehcache.multicast.port = "4016"
+      ehcache.replicate = false
+    }
     dev {
       ehcache.multicast.port = "5016"
-      ehcache.replicate = true
     }
-
     test {
       ehcache.multicast.port = "6016"
-      ehcache.replicate = true
     }
-
-    ops {
-      ehcache.multicast.port = "7016"
-      ehcache.replicate = true
+    ops_int {
+      ehcache.multicast.port = "7516"
     }
   }
 }

--- a/src/fftools/config/configurable/spitzer.xml
+++ b/src/fftools/config/configurable/spitzer.xml
@@ -10,7 +10,7 @@
         <Title>SEIP Super Mosaics</Title>
         <Desc>Spitzer Enhances Imaging Products: Super Mosaics</Desc>
         <DataSource searchProcId="RTreeInventory">
-            <Param key="serviceurl" value="http://irsa.ipac.caltech.edu/cgi-bin/SSCDemo/nph-sscdemo"/>
+            <Param key="serviceurl" value="https://irsa.ipac.caltech.edu/cgi-bin/SSCDemo/nph-sscdemo"/>
             <Param key="dataset" value="ivo://irsa.ipac/spitzer.enhancedImages"/>
         </DataSource>
         <Form>

--- a/src/firefly/build.gradle
+++ b/src/firefly/build.gradle
@@ -26,24 +26,27 @@ ext.appConfig = {
   BuildMajor  = "1"
   BuildMinor  = "0"
   BuildRev    = "0"
-  ehcache.replicate = false
 
   FireflyTools.Advertise = ""
-  ehcache.multicast.port = "4011"
+  ehcache.multicast.port = "7011"
+  ehcache.replicate = true
+
   environments {
+    local {
+      ehcache.multicast.port = "4011"
+      ehcache.replicate = false
+    }
+
     dev {
       ehcache.multicast.port = "5011"
-      ehcache.replicate = true
     }
 
     test {
       ehcache.multicast.port = "6011"
-      ehcache.replicate = true
     }
 
-    ops {
-      ehcache.multicast.port = "7011"
-      ehcache.replicate = true
+    ops_int {
+      ehcache.multicast.port = "7511"
     }
   }
 }

--- a/src/firefly/config/app-test.prop
+++ b/src/firefly/config/app-test.prop
@@ -4,8 +4,8 @@
 # Property used in Light-curve API periodogram - use a result sample as basis to extract periodogram/peaks
 #irsa.gator.service.periodogram.url=http://web.ipac.caltech.edu/staff/ejoliet/demo/irsa-lc-sample-result-test.xml
 
-# In case the dev API (bacchus) is avialble, test with the follwoing (uncomment!) and comment the above prop
-irsa.gator.service.periodogram.url=http://bacchus.ipac.caltech.edu:9027/cgi-bin/periodogram/nph-periodogram_api
+# In case the dev API is avialble, test with the follwoing (uncomment!) and comment the above prop
+irsa.gator.service.periodogram.url=https://irsa/cgi-bin/periodogram/nph-periodogram_api
 
 # Periodogram API request parameter list definition, separated by space
 irsa.gator.service.periodogram.keys=x y alg peaks

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
@@ -169,7 +169,7 @@ public class PtfIbeDataSource extends BaseIbeDataSource {
     private void setupDS(String ibeHost, String dataset, String table) {
 
         if (StringUtils.isEmpty(ibeHost)) {
-            ibeHost = AppProperties.getProperty("ptf.ibe.host", "http://irsa.ipac.caltech.edu/ibe");
+            ibeHost = AppProperties.getProperty("ptf.ibe.host", "https://irsa.ipac.caltech.edu/ibe");
         }
         setIbeHost(ibeHost);
         setMission(PTF);

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
@@ -78,7 +78,7 @@ public class TwoMassIbeDataSource extends BaseIbeDataSource {
     private void setupDS(String ibeHost, String dataset, String table) {
 
         if (StringUtils.isEmpty(ibeHost)) {
-            ibeHost = AppProperties.getProperty("twomass.ibe.host", "http://irsa.ipac.caltech.edu/ibe");
+            ibeHost = AppProperties.getProperty("twomass.ibe.host", "https://irsa.ipac.caltech.edu/ibe");
         }
         setIbeHost(ibeHost);
         setMission(TWOMASS);

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/WiseIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/WiseIbeDataSource.java
@@ -346,7 +346,7 @@ public class WiseIbeDataSource extends BaseIbeDataSource {
     private void setupDS(String ibeHost, String baseFsPath, DataProduct ds) {
 
         if (StringUtils.isEmpty(ibeHost)) {
-            ibeHost = AppProperties.getProperty("wise.ibe.host", "http://irsa.ipac.caltech.edu/ibe");
+            ibeHost = AppProperties.getProperty("wise.ibe.host", "https://irsa.ipac.caltech.edu/ibe");
         }
 
         setIbeHost(ibeHost);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
@@ -44,7 +44,7 @@ public class WorkspaceManager {
     public static final String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
     public static final String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
 
-    private static final Namespace IRSA_NS = Namespace.getNamespace("irsa", "http://irsa.ipac.caltech.edu/namespace/");
+    private static final Namespace IRSA_NS = Namespace.getNamespace("irsa", "https://irsa.ipac.caltech.edu/namespace/");
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
 
     public enum Partition { PUBSPACE, SSOSPACE;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatScanQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatScanQuery.java
@@ -35,8 +35,8 @@ import static edu.caltech.ipac.firefly.util.DataSetParser.makeAttribKey;
  */
 @SearchProcessorImpl(id ="catScan")
 public class CatScanQuery extends DynQueryProcessor {
-    private static final String DEF_HOST    = AppProperties.getProperty("irsa.gator.hostname", "irsa.ipac.caltech.edu");
-    private static final String URL_FORMAT  = "http://%s/cgi-bin/Gator/nph-scan?%smode=ascii";
+    private static final String DEF_HOST    = AppProperties.getProperty("irsa.gator.hostname", "https://irsa.ipac.caltech.edu");
+    private static final String URL_FORMAT  = "%s/cgi-bin/Gator/nph-scan?%smode=ascii";
     private static final String PROJ_PARAM = "projshort=%s&";
 
     protected File loadDynDataFile(TableServerRequest req) throws IOException, DataAccessException {
@@ -58,13 +58,13 @@ public class CatScanQuery extends DynQueryProcessor {
     public void onComplete(ServerRequest request, DataGroupPart results) throws DataAccessException {
 
         if (results != null && results.getData() != null) {
-            // prepend http://irsa to the description link
+            // prepend https://irsa to the description link
             DataGroup data = results.getData();
             for (int i = 0; i <data.size(); i++) {
                 DataObject row = data.get(i);
                 String desc = String.valueOf(row.getDataElement("description"));
                 if (desc.indexOf("href='/data/") >= 0){
-                    desc = desc.replaceAll("href='/data/", "href='http://irsa.ipac.caltech.edu/data/");
+                    desc = desc.replaceAll("href='/data/", "href='https://irsa.ipac.caltech.edu/data/");
                     row.setDataElement(data.getDataDefintion("description"), desc);
                 }
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatSummaryQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatSummaryQuery.java
@@ -42,7 +42,7 @@ public class CatSummaryQuery  extends DynQueryProcessor {
 
 
     private static final String DEF_HOST    = AppProperties.getProperty("irsa.catSummary.hostname", "");
-    private static final String URL_FORMAT  = "http://%s/%s?%s";
+    private static final String URL_FORMAT  = "%s/%s?%s";
 
 
     protected File loadDynDataFile(TableServerRequest req) throws IOException, DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/Query2MassSIA.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/Query2MassSIA.java
@@ -53,7 +53,7 @@ public class Query2MassSIA extends QueryVOTABLE  {
     public static final String SCAN_KEY = "scan";
 
     private static final String TM_URL = AppProperties.getProperty("2mass.url.catquery",
-                                                      "http://irsa.ipac.caltech.edu/cgi-bin/2MASS/IM/nph-im_sia?FORMAT=image/fits");
+                                                      "https://irsa.ipac.caltech.edu/cgi-bin/2MASS/IM/nph-im_sia?FORMAT=image/fits");
     @Override
     protected String getWspaceSaveDirectory() {
         return "/" + WorkspaceManager.SEARCH_DIR + "/" + WspaceMeta.IMAGESET;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/inventory/InventorySearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/inventory/InventorySearch.java
@@ -41,8 +41,8 @@ import static edu.caltech.ipac.firefly.util.DataSetParser.makeAttribKey;
  */
 @SearchProcessorImpl(id ="inventorySearch")
 public class InventorySearch extends DynQueryProcessor {
-    private static final String DEF_HOST    = AppProperties.getProperty("irsa.inventory.hostname","irsa.ipac.caltech.edu" );
-    private static final String URL_FORMAT  = "http://%s/cgi-bin/SSCDemo/nph-sscdemo?dataset=%s&region=cone+%+.6f+%+.6f+%+.6f";
+    private static final String DEF_HOST    = AppProperties.getProperty("irsa.inventory.hostname","https://irsa.ipac.caltech.edu" );
+    private static final String URL_FORMAT  = "%s/cgi-bin/SSCDemo/nph-sscdemo?dataset=%s&region=cone+%+.6f+%+.6f+%+.6f";
     private static final ClassProperties COL_META = new ClassProperties("IS", InventorySearch.class);
 
     protected File loadDynDataFile(TableServerRequest req) throws IOException, DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/inventory/InventorySummary.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/inventory/InventorySummary.java
@@ -45,8 +45,8 @@ import static edu.caltech.ipac.firefly.util.DataSetParser.makeAttribKey;
  */
 @SearchProcessorImpl(id ="inventorySummary")
 public class InventorySummary extends DynQueryProcessor {
-    private static final String DEF_HOST    = AppProperties.getProperty("irsa.inventory.hostname","irsa.ipac.caltech.edu" );
-    private static final String URL_FORMAT  = "http://%s/cgi-bin/SSCDemo/nph-sscdemo?action=list&region=cone+%+.6f+%+.6f+%+.6f";
+    private static final String DEF_HOST    = AppProperties.getProperty("irsa.inventory.hostname","https://irsa.ipac.caltech.edu" );
+    private static final String URL_FORMAT  = "%s/cgi-bin/SSCDemo/nph-sscdemo?action=list&region=cone+%+.6f+%+.6f+%+.6f";
 
     protected File loadDynDataFile(TableServerRequest req) throws IOException, DataAccessException {
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
@@ -28,7 +28,7 @@ import java.net.URLConnection;
  * .
  * Should handle the LC transformations to get files out of the API result VOtable xml
  * Dev API can be found here:
- * http://irsadev.ipac.caltech.edu/applications/periodogram/Periodogram.html
+ * http://irsa.ipac.caltech.edu/applications/periodogram/Periodogram.html
  * <p>
  * TODO update api url and doc.
  *
@@ -46,7 +46,7 @@ public class IrsaLightCurveHandler implements LightCurveHandler {
      */
     public IrsaLightCurveHandler() {
 
-        rootApiUrl = AppProperties.getProperty("irsa.gator.service.periodogram.url", "https://irsadev.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api");
+        rootApiUrl = AppProperties.getProperty("irsa.gator.service.periodogram.url", "https://irsa.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api");
         apiKey = AppProperties.getArrayProperties("irsa.gator.service.periodogram.keys", "\\s+", "x y");// At least x,y , rest are optional
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
@@ -28,7 +28,7 @@ import java.net.URLConnection;
  * .
  * Should handle the LC transformations to get files out of the API result VOtable xml
  * Dev API can be found here:
- * http://bacchus.ipac.caltech.edu:9027/applications/periodogram/Periodogram.html
+ * http://irsadev.ipac.caltech.edu/applications/periodogram/Periodogram.html
  * <p>
  * TODO update api url and doc.
  *
@@ -46,7 +46,7 @@ public class IrsaLightCurveHandler implements LightCurveHandler {
      */
     public IrsaLightCurveHandler() {
 
-        rootApiUrl = AppProperties.getProperty("irsa.gator.service.periodogram.url", "http://bacchus.ipac.caltech.edu:9027/cgi-bin/periodogram/nph-periodogram_api");
+        rootApiUrl = AppProperties.getProperty("irsa.gator.service.periodogram.url", "https://irsadev.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api");
         apiKey = AppProperties.getArrayProperties("irsa.gator.service.periodogram.keys", "\\s+", "x y");// At least x,y , rest are optional
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
@@ -47,7 +47,7 @@ import java.rmi.RemoteException;
  */
 public class JOSSOAdapter {
     private static final String SSO_SERVICES_URL = AppProperties.getProperty("sso.server.url",
-                                                    "http://irsa.ipac.caltech.edu/account/");
+                                                    "https://irsa.ipac.caltech.edu/account/");
     private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
     private static final String REQUESTER = "JOSSOAdapter";
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/ui/table/TablePanel.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/ui/table/TablePanel.java
@@ -361,7 +361,7 @@ public class TablePanel extends Component implements StatefulWidget, FilterToggl
         String eMsg = caught != null ? caught.getMessage() : "unknown";
 
         String msgExtra = "<span class=\"faded-text\">" +
-                "<br><br>If you still continue to receive this message, contact IRSA for <a href='http://irsa.ipac.caltech.edu/applications/Helpdesk' target='_blank'>help</a>.  " +
+                "<br><br>If you still continue to receive this message, contact IRSA for <a href='https://irsa.ipac.caltech.edu/applications/Helpdesk' target='_blank'>help</a>.  " +
                 "<span>";
         String msg = "<b> Unable to load table.</b><br>";
 

--- a/src/firefly/java/edu/caltech/ipac/util/download/NetworkManager.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/NetworkManager.java
@@ -51,7 +51,7 @@ public class NetworkManager {
        addServerWithProp(SKYVIEW_SERVER,       "skys.gsfc.nasa.gov",       80);
        addServerWithProp(HEASARC_SERVER,       "heasarc.gsfc.nasa.gov",    80);
        addServerWithProp(VIZIER_SERVER,        "vizier.u-strasbg.fr",      80);
-       addServerWithProp(IRSA,                 "irsa.ipac.caltech.edu",    80);
+       addServerWithProp(IRSA,                 "irsa.ipac.caltech.edu",    443);
        addServerWithProp(AUTO_UPDATE_SERVER,   "soas.ipac.caltech.edu",    80);
        addServerWithProp(SPITZER_ARCHIVE,     "archive.spitzer.caltech.edu",80);
        addServerWithProp(SPIZTER_POPULAR,      "data.spitzer.caltech.edu",80);

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/IrsaImageGetter.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/IrsaImageGetter.java
@@ -73,7 +73,7 @@ public class IrsaImageGetter {
         File                  file= new File(fileName);
         String                req;
 
-        req = "http://" + hp.getHost() + ":" + hp.getPort() + app;
+        req = "https://" + hp.getHost() + ":" + hp.getPort() + app;
 
         if(parms.getLength() > 0)
         {

--- a/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
@@ -29,7 +29,7 @@ export function makeWisePlotRequest(table, rowIdx, cutoutSize) {
      It is only for WISE, using default cutout size 0.3 deg
      const url = `http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w1-int-1b.fits`;
      */
-    const serverinfo = 'http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/';
+    const serverinfo = 'https://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/';
     const centerandsize = cutoutSize ? `?center=${ra},${dec}&size=${cutoutSize}&gzip=false` : '';
     const url = `${serverinfo}${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w${band}-int-1b.fits${centerandsize}`;
     const plot_desc = `WISE-${frameId}`;

--- a/src/firefly/js/ui/IrsaFooter.jsx
+++ b/src/firefly/js/ui/IrsaFooter.jsx
@@ -17,8 +17,8 @@ export function IrsaFooter() {
             <div className='DD-ToolBar__footer--links'>
                 <ul>
                     <li><a href='https://irsasupport.ipac.caltech.edu/' target='helpdesk'>Contact</a></li>
-                    <li><a href='http://irsa.ipac.caltech.edu/privacy.html' target='privacy'>Privacy Policy</a></li>
-                    <li><a href='http://irsa.ipac.caltech.edu/ack.html' target='ack'>Acknowledge IRSA</a></li>
+                    <li><a href='https://irsa.ipac.caltech.edu/privacy.html' target='privacy'>Privacy Policy</a></li>
+                    <li><a href='https://irsa.ipac.caltech.edu/ack.html' target='ack'>Acknowledge IRSA</a></li>
                 </ul>
             </div>
             <div className='DD-ToolBar__footer--icons'>

--- a/src/firefly/js/ui/VoSearchPanel.jsx
+++ b/src/firefly/js/ui/VoSearchPanel.jsx
@@ -98,7 +98,7 @@ var voSearchArea = () => {
                               /*validator: {urlValidator}*/
                           }}
             size={60}
-            placeholder='Ex. http://irsa.ipac.caltech.edu/SCS?table=allwise_p3as_psd&'
+            placeholder='Ex. https://irsa.ipac.caltech.edu/SCS?table=allwise_p3as_psd&'
             actOn={['blur','enter']}
             wrapperStyle={{margin: '5px 0'}}
         />

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -572,7 +572,7 @@ function getSubProjectOptions(catmaster, project) {
  * @param catmaster master table data
  * @param project project name
  * @param subproject name of the category under project
- * @example cat object example: ["WISE", "AllWISE Database", "AllWISE Source Catalog", "WISE_AllWISE", "allwise_p3as_psd", "334", "747634026", "3600", "<a href='http://irsa.ipac.caltech.edu/Missions/wise.html' target='info'>info</a>", "<a href='http://wise2.ipac.caltech.edu/docs/release/allwise/expsup/sec2_1a.html' target='Column Def'>Column Def</a>", "GatorQuery", "GatorDD"]
+ * @example cat object example: ["WISE", "AllWISE Database", "AllWISE Source Catalog", "WISE_AllWISE", "allwise_p3as_psd", "334", "747634026", "3600", "<a href='https://irsa.ipac.caltech.edu/Missions/wise.html' target='info'>info</a>", "<a href='https://wise2.ipac.caltech.edu/docs/release/allwise/expsup/sec2_1a.html' target='Column Def'>Column Def</a>", "GatorQuery", "GatorDD"]
  * @returns {Object} array with ith element is an object which option values and an object with n attribute which ith attribute is corresponding
  * to ith columns in cols of master table and its value, i.e. ith = 0, 0:'WISE', where cols[0]=projectshort
  */

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -454,7 +454,7 @@ class LSSTCatalogSelectView extends Component {
      * an Object {project, catalogs} where'progject' is the progject name and 'catalogs' is array of catalog tables.
      * Each element in catalogs is with 'value' for catalog name value, 'label' for text shown on UI, and 'cat' for an
      * array containing column name of the catalog.
-     * @see master table file from http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan?mode=ascii
+     * @see master table file from https://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan?mode=ascii
      * @param {Object} master table model
      * @returns {XML} set the state to include master table
      */

--- a/src/firefly/test/edu/caltech/ipac/firefly/util/PostDownloadTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/util/PostDownloadTest.java
@@ -47,7 +47,7 @@ public class PostDownloadTest extends ConfigTest {
     public void testMultipart() {
         //"curl -F upload=@/hydra/workarea/firefly/temp_files/upload_7350632974912517382.tbl -F x=mjd -F y=w1mpro_ep http://bacchus.ipac.caltech.edu:9027/cgi-bin/periodogram/nph-periodogram_api -o pepe.xml"
         try {
-            URL url = new URL("http://bacchus.ipac.caltech.edu:9027/cgi-bin/periodogram/nph-periodogram_api");
+            URL url = new URL("https://irsadev.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api");
             check(url);
             MultiPartPostBuilder posBuilder = new MultiPartPostBuilder(url.toString());
             String src = tmpRawTable.getAbsolutePath();

--- a/src/firefly/test/edu/caltech/ipac/firefly/util/PostDownloadTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/util/PostDownloadTest.java
@@ -9,6 +9,7 @@ import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.util.download.URLDownload;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.*;
@@ -43,11 +44,12 @@ public class PostDownloadTest extends ConfigTest {
 
     }
 
+    @Ignore
     @Test
     public void testMultipart() {
         //"curl -F upload=@/hydra/workarea/firefly/temp_files/upload_7350632974912517382.tbl -F x=mjd -F y=w1mpro_ep http://bacchus.ipac.caltech.edu:9027/cgi-bin/periodogram/nph-periodogram_api -o pepe.xml"
         try {
-            URL url = new URL("https://irsadev.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api");
+            URL url = new URL("https://irsa.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api");
             check(url);
             MultiPartPostBuilder posBuilder = new MultiPartPostBuilder(url.toString());
             String src = tmpRawTable.getAbsolutePath();


### PR DESCRIPTION
https://caltech-ipac.atlassian.net/browse/IRSA-401
- add new env: ops_int
- ops to use default config
- switch IRSA’s service URLs to https
- map IRSA’s services based on deployment mapped out here: https://ipacwiki.ipac.caltech.edu/Projects/IRSA/IRSA_Systems/IRSA_Server_Info/IRSA_Software_Deployment_map
- remove all custom ports, i.e. 5001, 9200, etc
- apply changes to both rc and gwt branches

Changes are in firefly and ife under branch 'IRSA-401_add_ops-int_env'.
Checkout branch from both repositories to test different build combinations.
Notice added ops_int env settings.
To build config files without a full build, use  `gradle clean jar prepareWebapp`
  - inspect build/<app_name>/../*{.prop,.xml}  for generated prop files

One exception:  all heritage's services are pointed to ops.  dev version of those services are no longer maintained.