### PR TITLE
IRSA-359: renamed accept button label in periodogram form

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -204,7 +204,7 @@ export var startPeriodogramPopup = (groupKey) =>  {
                                 groupKey={groupKey}
                                 onSuccess={periodogramSuccess(popupId, true)}
                                 onFail={periodogramFail(popupId, true)}
-                                text={'Periodogram Calculation'} />
+                                text={'Calculate'} />
                     </div>
                     <div style={{marginTop:17}}>
                         <HelpIcon helpId={'findpTSV.pgramresults'}/>


### PR DESCRIPTION
As requested, accept button in periodogram form has been renamed to 'Calculate'.

Build and check that it is the case.