### PR TITLE
IRSA-399 remove x-log options from histogram

### DIFF
--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -310,7 +310,7 @@ export class HistogramOptions extends React.Component {
                                             initialState= {{ value:'closed' }}
                                             fieldKey='plotoptions'>
                         <InputGroup labelWidth={20}>
-                            {/*<CheckboxGroupInputField
+                            <CheckboxGroupInputField
                                 initialState= {{
                                     value: get(histogramParams, 'x', '_none_'),
                                     tooltip: 'X axis options',
@@ -319,10 +319,10 @@ export class HistogramOptions extends React.Component {
                                 options={[
                                     {label: 'reverse', value: 'flip'},
                                     {label: 'top', value: 'opposite'},
-                                    {label: 'log', value: 'log'}
+                                    /*{label: 'log', value: 'log'}*/
                                 ]}
                                 fieldKey='x'
-                            />*/}
+                            />
                             <CheckboxGroupInputField
                                 initialState= {{
                                     value: get(histogramParams, 'y', '_none_'),

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -310,7 +310,7 @@ export class HistogramOptions extends React.Component {
                                             initialState= {{ value:'closed' }}
                                             fieldKey='plotoptions'>
                         <InputGroup labelWidth={20}>
-                            <CheckboxGroupInputField
+                            {/*<CheckboxGroupInputField
                                 initialState= {{
                                     value: get(histogramParams, 'x', '_none_'),
                                     tooltip: 'X axis options',
@@ -322,7 +322,7 @@ export class HistogramOptions extends React.Component {
                                     {label: 'log', value: 'log'}
                                 ]}
                                 fieldKey='x'
-                            />
+                            />*/}
                             <CheckboxGroupInputField
                                 initialState= {{
                                     value: get(histogramParams, 'y', '_none_'),


### PR DESCRIPTION
Option in histogram setting panel has been removed for now. See detail in the ticket.
I have kept the code for the (near) future.

Please, confirm that the option is no longer available.