### PR TITLE
IRSA-396 period finder panel resized

### DIFF
--- a/src/firefly/js/templates/lightcurve/LCPanels.css
+++ b/src/firefly/js/templates/lightcurve/LCPanels.css
@@ -46,6 +46,9 @@
     border: 1px solid #cccccc;
     margin-right: 2px;
     padding: 10px;
+    width: 100%;
+    max-width: 525px;
+    overflow: auto;
 }
 
 .settingBox {

--- a/src/firefly/js/templates/lightcurve/LCPanels.css
+++ b/src/firefly/js/templates/lightcurve/LCPanels.css
@@ -47,7 +47,7 @@
     margin-right: 2px;
     padding: 10px;
     width: 100%;
-    max-width: 525px;
+    max-width: 540px;
     overflow: auto;
 }
 

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -222,7 +222,7 @@ const PeriodStandardView = (props) => {
         <FieldGroup groupKey={pfinderkey} style={{display: 'flex', flexDirection: 'column', position: 'relative', flexGrow: 1, minHeight: 500}}
                     reducerFunc={LcPFReducer(initState)}  keepState={true}>
             <div style={{flexGrow: 1, position: 'relative'}}>
-                <SplitPane split='horizontal' primary='second' maxSize={-100} minSize={100} defaultSize={400}>
+                <SplitPane split='horizontal' primary='second' maxSize={-100} minSize={100} defaultSize={500}>
                     <SplitContent>
                         <div className='phaseFolded'>
                             <div className='phaseFolded__options'>

--- a/src/firefly/js/templates/lightcurve/LcPeriod.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriod.jsx
@@ -222,7 +222,7 @@ const PeriodStandardView = (props) => {
         <FieldGroup groupKey={pfinderkey} style={{display: 'flex', flexDirection: 'column', position: 'relative', flexGrow: 1, minHeight: 500}}
                     reducerFunc={LcPFReducer(initState)}  keepState={true}>
             <div style={{flexGrow: 1, position: 'relative'}}>
-                <SplitPane split='horizontal' primary='second' maxSize={-100} minSize={100} defaultSize={500}>
+                <SplitPane split='horizontal' primary='second' maxSize={-100} minSize={100} defaultSize={200}>
                     <SplitContent>
                         <div className='phaseFolded'>
                             <div className='phaseFolded__options'>


### PR DESCRIPTION
I have added an overflow property and change couple of CSS property in order to make visible the scroll bar when the form panel is shrink. 

Please, check that is ok in different browser and device screens.