### PR TITLE
DM-10370: Optimize server memory usage for fits images

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -103,7 +103,7 @@ public class ServerParams {
     public static final String CREATE_PLOT_GROUP = "CmdCreatePlotGroup";
     public static final String ZOOM = "CmdZoom";
     public static final String STRETCH = "CmdStretch";
-    public static final String ADD_BAND = "CmdAddBand";
+    public static final String GET_BETA = "CmdGetBeta";
     public static final String REMOVE_BAND = "CmdRemoveBand";
     public static final String CHANGE_COLOR = "CmdChangeColor";
     public static final String ROTATE_NORTH = "CmdRotateNorth";

--- a/src/firefly/java/edu/caltech/ipac/firefly/rpc/PlotServiceJson.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/rpc/PlotServiceJson.java
@@ -117,9 +117,6 @@ public class PlotServiceJson implements PlotServiceAsync {
     }
 
     public void addColorBand(PlotState state, WebPlotRequest bandRequest, Band band, AsyncCallback<WebPlotResult> async) {
-        doPlotService(ServerParams.ADD_BAND, async, state,
-                      new Param(ServerParams.BAND, band.toString()),
-                      new Param(ServerParams.REQUEST, bandRequest.toString()));
     }
 
     public void getFileFlux(FileAndHeaderInfo[] fileAndHeader, ImagePt inIpt, final AsyncCallback<String[]> async) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
@@ -46,7 +46,7 @@ public class ServerCommandAccess {
         _cmdMap.put(ServerParams.CREATE_PLOT_GROUP,  new VisServerCommands.GetWebPlotGroupCmd());
         _cmdMap.put(ServerParams.ZOOM,         new VisServerCommands.ZoomCmd());
         _cmdMap.put(ServerParams.STRETCH,      new VisServerCommands.StretchCmd());
-        _cmdMap.put(ServerParams.ADD_BAND,     new VisServerCommands.AddBandCmd());
+        _cmdMap.put(ServerParams.GET_BETA,     new VisServerCommands.GetBetaCmd());
         _cmdMap.put(ServerParams.REMOVE_BAND,  new VisServerCommands.RemoveBandCmd());
         _cmdMap.put(ServerParams.CHANGE_COLOR, new VisServerCommands.ChangeColor());
         _cmdMap.put(ServerParams.DELETE,       new VisServerCommands.DeletePlot());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
@@ -40,6 +40,7 @@ public class EhcacheProvider implements Cache.Provider {
     private static long curConfModTime = 0;
 
     static {
+
         URL url = null;
         File f = getConfFile("ehcache.xml");
         if (f != null && f.canRead()) {
@@ -65,7 +66,14 @@ public class EhcacheProvider implements Cache.Provider {
             File ignoreSizeOf = getConfFile("ignore_sizeof.txt");
             System.setProperty("net.sf.ehcache.sizeof.filter", ignoreSizeOf.getAbsolutePath());
 
-            sharedManager = CacheManager.create(sharedConfig.getAbsolutePath());
+            try {
+                System.setProperty("net.sf.ehcache.sizeofengine.shared.VIS_SHARED_MEM",
+                                   "edu.caltech.ipac.firefly.server.cache.ObjectSizeEngineWrapper");
+                sharedManager = CacheManager.create(sharedConfig.getAbsolutePath());
+            } catch (RuntimeException e) {
+                System.clearProperty("net.sf.ehcache.sizeofengine.shared.VIS_SHARED_MEM");
+                sharedManager = CacheManager.create(sharedConfig.getAbsolutePath());
+            }
             float pctVisSharedMemSize = AppProperties.getFloatProperty("pct.vis.shared.mem.size", 0F);
 
             // check to see if vis.shared.mem.size is setup in the environment or setup for auto-config.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
@@ -66,9 +66,17 @@ public class EhcacheProvider implements Cache.Provider {
             File ignoreSizeOf = getConfFile("ignore_sizeof.txt");
             System.setProperty("net.sf.ehcache.sizeof.filter", ignoreSizeOf.getAbsolutePath());
 
+            // Two 2 tries to start cache manager:
+            //   1. The first time will only work in the single app deployment such the firefly standalone version.
+            //      Ehcahce is not deployed in the tomcat lib directory.
+            //
+            //   2. In the typical multi app production case there will be an exception, because ehcache is in the tomcat lib
+            //      directory and has a different class loader. Then the cache manager will start without
+            //      the sizeofEngine override. To use the sizeofEngine wrapper in multi app production case it would need to
+            //      be a jar that is placed in the tomcat lib directory alone with EHcache.
             try {
-                System.setProperty("net.sf.ehcache.sizeofengine.shared.VIS_SHARED_MEM",
-                                   "edu.caltech.ipac.firefly.server.cache.ObjectSizeEngineWrapper");
+                String sizeEngName= ObjectSizeEngineWrapper.class.getName();
+                System.setProperty("net.sf.ehcache.sizeofengine.shared.VIS_SHARED_MEM", sizeEngName);
                 sharedManager = CacheManager.create(sharedConfig.getAbsolutePath());
             } catch (RuntimeException e) {
                 System.clearProperty("net.sf.ehcache.sizeofengine.shared.VIS_SHARED_MEM");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/ObjectSizeEngineWrapper.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/ObjectSizeEngineWrapper.java
@@ -1,0 +1,47 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.firefly.server.cache;
+
+
+import net.sf.ehcache.pool.Size;
+import net.sf.ehcache.pool.SizeOfEngine;
+import net.sf.ehcache.pool.impl.DefaultSizeOfEngine;
+
+/**
+ * @author Trey Roby
+ */
+public class ObjectSizeEngineWrapper extends DefaultSizeOfEngine {
+
+    public ObjectSizeEngineWrapper() {
+        super(1000, false);
+    }
+    public ObjectSizeEngineWrapper(int maxDepth, boolean abortWhenMaxDepthExceeded) {
+        super(maxDepth, abortWhenMaxDepthExceeded);
+    }
+
+    public ObjectSizeEngineWrapper(int maxDepth, boolean abortWhenMaxDepthExceeded, boolean silent) {
+        super(maxDepth, abortWhenMaxDepthExceeded, silent);
+    }
+
+    @Override
+    public SizeOfEngine copyWith(int maxDepth, boolean abortWhenMaxDepthExceeded) {
+//        return super.copyWith(maxDepth, abortWhenMaxDepthExceeded);
+        return new ObjectSizeEngineWrapper(maxDepth, abortWhenMaxDepthExceeded);
+    }
+
+    @Override
+    public Size sizeOf(Object key, Object value, Object container) {
+        return (value instanceof BluffSize) ?
+                 new Size(((BluffSize)value).getSize(), true) :
+                 super.sizeOf(key,value,container);
+    }
+
+    static public class BluffSize {
+        private long size;
+        public BluffSize(long size) {this.size= size;}
+        public long getSize() { return size; }
+    }
+}
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/PlotServiceImpl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/PlotServiceImpl.java
@@ -160,7 +160,7 @@ public class PlotServiceImpl extends BaseRemoteService implements PlotService {
     public WebPlotResult addColorBand(PlotState      state,
                                       WebPlotRequest bandRequest,
                                       Band band) {
-        return VisServerOps.addColorBand(state, bandRequest, band);
+        return null; // no longer used
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
@@ -200,6 +200,32 @@ public class VisServerCommands {
         }
     }
 
+
+    public static class GetBetaCmd extends ServCommand {
+
+        public String doCommand(Map<String, String[]> paramMap) throws IllegalArgumentException {
+
+            SrvParam sp= new SrvParam(paramMap);
+            PlotState state= sp.getState();
+            double resultAry[]= VisServerOps.getBeta(state);
+
+            JSONObject obj= new JSONObject();
+            obj.put("success", true);
+
+            JSONArray data= new JSONArray();
+            for(double r : resultAry) data.add(r);
+
+            JSONArray wrapperAry= new JSONArray();
+            obj.put("data", data);
+            wrapperAry.add(obj);
+
+            return wrapperAry.toJSONString();
+        }
+    }
+
+
+
+
     public static class StretchCmd extends ServCommand {
 
         public String doCommand(Map<String, String[]> paramMap) throws IllegalArgumentException {
@@ -228,19 +254,6 @@ public class VisServerCommands {
             }
 
             WebPlotResult result = VisServerOps.recomputeStretch(state, sdAry);
-            return WebPlotResultSerializer.createJson(result, sp.isJsonDeep());
-        }
-    }
-
-    public static class AddBandCmd extends ServCommand {
-
-        public String doCommand(Map<String, String[]> paramMap) throws IllegalArgumentException {
-
-            SrvParam sp= new SrvParam(paramMap);
-            PlotState state= sp.getState();
-            Band band = Band.parse(sp.getRequired(ServerParams.BAND));
-            WebPlotRequest req= WebPlotRequest.parse(sp.getRequired(ServerParams.REQUEST));
-            WebPlotResult result = VisServerOps.addColorBand(state, req, band);
             return WebPlotResultSerializer.createJson(result, sp.isJsonDeep());
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/CtxControl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/CtxControl.java
@@ -112,7 +112,6 @@ public class CtxControl {
                                                                   state.getColorTableId(), rv);
                                 plot.getPlotGroup().setZoomTo(state.getZoomLevel());
                                 if (state.isThreeColor()) plot.setThreeColorBand(fr[imageIdx],band,frGroup);
-                                ctx.setPlot(plot);
                                 first= false;
                             }
                             else {
@@ -217,7 +216,10 @@ public class CtxControl {
         return (PlotClientCtx) getCache().get(new StringKey(ctxStr));
     }
 
-    public static boolean isCtxAvailable(String ctxStr) { return getPlotCtx(ctxStr)!=null; }
+    public static boolean isCtxAvailable(String ctxStr) {
+        PlotClientCtx ctx= getPlotCtx(ctxStr);
+        return (ctx!=null && ctx.getCachedPlot()!=null);
+    }
 
     public static void putPlotCtx(PlotClientCtx ctx) {
         if (ctx!=null && ctx.getKey()!=null) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -197,6 +197,7 @@ public class ImagePlotCreator {
         Band band= readInfo.getBand();
 
 
+        FitsCacher.clearCachedHDU(readInfo.getOriginalFile());
         plot.setThreeColorBand(state.isBandVisible(readInfo.getBand()) ? readInfo.getFitsRead() :null,
                                readInfo.getBand(),frGroup);
         HistogramOps histOps= plot.getHistogramOps(band,frGroup);
@@ -320,7 +321,8 @@ public class ImagePlotCreator {
         long fileLength= (f!=null && f.canRead()) ? f.length() : 0;
         HistogramOps ops= plot.getHistogramOps(band,frGroup);
         Histogram hist= ops.getDataHistogram();
-        return new WebFitsData( ops.getDataMin(hist), ops.getDataMax(hist),ops.getBeta(),
+        return new WebFitsData( ops.getDataMin(hist), ops.getDataMax(hist),
+                                Double.NaN /*no longer pass beta by default*/,
                                 fileLength, plot.getFluxUnits(band,frGroup));
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ModFileWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ModFileWriter.java
@@ -38,18 +38,15 @@ abstract class ModFileWriter {
     protected boolean doTask() { return true; }
 
     /**
-     * Start the file writing in separate thread.  This method also update the working fits file to the name that is about
-     * to be created.
+     * Write the fits file and update data structures
      * @param state the PlotState to update
      */
-    public void go(PlotState state) {
+    public void writeFile(PlotState state) {
         PlotStateUtil.setWorkingFitsFile(state, _targetFile, _band);
         if (_markAsOriginal) {
             PlotStateUtil.setOriginalFitsFile(state, _targetFile, _band);
         }
-        if (doTask()) {
-            write();
-        }
+        if (doTask()) write();
     }
 
     public boolean getCreatesOnlyOneImage() { return true; }
@@ -117,6 +114,7 @@ abstract class ModFileWriter {
                 OutputStream os= new BufferedOutputStream(new FileOutputStream(f), 1024*16);
                 _fr.writeSimpleFitsFile(os);
                 FileUtil.silentClose(os);
+                _fr.clearHDU();
             } catch (Exception e) {
                 _log.warn(e,"geom write failed", "geom file: "+f.getPath());
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -17,7 +17,6 @@ import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.firefly.visualize.ClientFitsHeader;
 import edu.caltech.ipac.firefly.visualize.CreatorResults;
 import edu.caltech.ipac.firefly.visualize.FileAndHeaderInfo;
-import edu.caltech.ipac.firefly.visualize.InsertBandInitializer;
 import edu.caltech.ipac.firefly.visualize.PlotImages;
 import edu.caltech.ipac.firefly.visualize.PlotState;
 import edu.caltech.ipac.firefly.visualize.RequestType;
@@ -228,6 +227,20 @@ public class VisServerOps {
         return true;
     }
 
+    public static double[] getBeta(PlotState state) {
+        double[] resultsAry= new double[] {Double.NaN,Double.NaN,Double.NaN};
+        try {
+            ActiveCallCtx ctx = CtxControl.prepare(state);
+            FitsRead frAry[]= ctx.getFitsReadGroup().getFitsReadAry();
+            for(int i= 0; (i<frAry.length);i++) {
+                if (frAry[i]!=null) resultsAry[i]= frAry[i].getDefaultBeta();
+            }
+            return resultsAry;
+
+        } catch (Exception e) {
+            return resultsAry;
+        }
+    }
 
     public static String[] getFileFlux(FileAndHeaderInfo fileAndHeader[], ImagePt ipt) {
         try {
@@ -282,24 +295,6 @@ public class VisServerOps {
             return createError("on getFlux", state, e);
         }
     }
-
-
-    public static WebPlotResult addColorBand(PlotState state, WebPlotRequest bandRequest, Band band) {
-        try {
-            ActiveCallCtx ctx = CtxControl.prepare(state);
-            InsertBandInitializer init;
-            init = WebPlotFactory.addBand(ctx.getPlot(), state, bandRequest, band, ctx.getFitsReadGroup());
-            CtxControl.updateCachedPlot(ctx);
-            WebPlotResult retval = new WebPlotResult(ctx.getKey());
-            retval.putResult(WebPlotResult.INSERT_BAND_INIT, init);
-            counters.incrementVis("3 Color Band");
-            return retval;
-        } catch (Exception e) {
-            return createError("on addColorBand", state, e);
-        }
-
-    }
-
 
     public static WebPlotResult deleteColorBand(PlotState state, Band band) {
         try {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.server.visualize;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.firefly.visualize.VisUtil;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
@@ -42,6 +43,8 @@ import java.util.Map;
  * The Crop class is deprecated. The same function is added to CropAndCenter.
  */
 public class WebPlotReader {
+
+    private static final Logger.LoggerImpl _log = Logger.getLogger();
 
     public static Map<Band, FileReadInfo[]> readFiles(Map<Band, FileInfo> fitsFiles, WebPlotRequest req)
             throws IOException,
@@ -136,7 +139,8 @@ public class WebPlotReader {
                 uploadedName= fd.getDesc();
             }
 
-            FitsRead frAry[]= FitsCacher.readFits(originalFile);
+            boolean usePipeline= needsPipeline(req);
+            FitsRead frAry[]= FitsCacher.readFits(originalFile, !usePipeline, !usePipeline); // turn caching off if I have to use pipeline
             retval = new FileReadInfo[frAry.length];
 
             if (needsPipeline(req)) { // if we need to use the pipeline make sure we create a new array
@@ -205,6 +209,10 @@ public class WebPlotReader {
 
     private static ModFileWriter checkUnzip(int i, Band band, File originalFile, ModFileWriter modFileWriter)  {
         if (i == 0 &&  modFileWriter == null && isUnzipNecessary(originalFile) ) {
+
+            _log.warn("Setting up unzip ModFileWriter, this procedure is deprecated.",
+                      "We should not just unzip the fits files up front.",
+                       originalFile.getAbsolutePath());
             modFileWriter = new ModFileWriter.UnzipFileWriter(band, originalFile);
         }
         return modFileWriter;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
@@ -43,7 +43,7 @@ public class HistogramOps {
     public FitsRead getFitsRead() { return fitsReadAry[band.getIdx()]; }
 
     //5/13/16 LZ added this method so the beta can be passed to the client side
-    public double getBeta(){ return fitsReadAry[band.getIdx()].getBeta();}
+    public double getBeta(){ return fitsReadAry[band.getIdx()].getDefaultBeta();}
 
     public Histogram getDataHistogram() {
         return fitsReadAry[band.getIdx()].getHistogram();

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
@@ -27,6 +27,7 @@ public class ImageDataGroup implements Iterable<ImageData> {
 
     private final int _width;
     private final int _height;
+    private double betaValue= Double.NaN;
 
 
 //======================================================================
@@ -52,6 +53,8 @@ public class ImageDataGroup implements Iterable<ImageData> {
         _width = hdr.naxis1;
         _height = hdr.naxis2;
 
+        rangeValues= ensureBetaValues(rangeValues, fitsReadAry);
+
         int totWidth= hdr.naxis1;
         int totHeight= hdr.naxis2;
 
@@ -76,6 +79,8 @@ public class ImageDataGroup implements Iterable<ImageData> {
             }
         }
     }
+
+
 
     /**
      * LZ 07/20/15
@@ -112,6 +117,8 @@ public class ImageDataGroup implements Iterable<ImageData> {
 
         _imageDataAry= new ImageData[xPanels * yPanels];
 
+
+
         int width;
         int height;
         for(int i= 0; i<xPanels; i++) {
@@ -129,6 +136,24 @@ public class ImageDataGroup implements Iterable<ImageData> {
 //======================================================================
 //----------------------- Public Methods -------------------------------
 //======================================================================
+
+    private RangeValues ensureBetaValues(RangeValues rv, FitsRead fitsReadAry[]) {
+        if (rv.getStretchAlgorithm()==RangeValues.STRETCH_ASINH && Double.isNaN(rv.getBetaValue())) {
+                               //if asinH and the default beta then compute the beta
+            if (Double.isNaN(this.betaValue)) {
+                for(FitsRead testFr : fitsReadAry) {
+                    if (testFr!=null) {
+                        this.betaValue= testFr.getDefaultBeta();
+                        break;
+                    }
+                }
+            }
+            return new RangeValues(rv.getLowerWhich(), rv.getLowerValue(), rv.getUpperWhich(), rv.getUpperValue(),
+                    this.betaValue, rv.getGammaValue(), rv.getStretchAlgorithm(),
+                    rv.getZscaleContrast(), rv.getZscaleSamples(), rv.getZscaleSamplesPerLine());
+        }
+        return rv;
+    }
 
     public Iterator<ImageData> iterator() {
         return Arrays.asList(_imageDataAry).iterator();
@@ -181,6 +206,8 @@ public class ImageDataGroup implements Iterable<ImageData> {
                                  int idx,
                                  RangeValues rangeValues,
                                  boolean force) {
+
+        rangeValues= ensureBetaValues(rangeValues, fitsReadAry);
         for(ImageData id : _imageDataAry) {
             id.recomputeStretch(fitsReadAry,idx,rangeValues, force);
         }
@@ -208,4 +235,3 @@ public class ImageDataGroup implements Iterable<ImageData> {
 // =====================================================================
 
 }
-

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
@@ -30,7 +30,7 @@ public class RangeValues implements Cloneable, Serializable {
     public static final int ZSCALE     = 91;
     public static final int SIGMA      = 92;
 
-    public static final double BETA =0.2;
+    public static final double BETA =Double.NaN;
     public static final double GAMMA=2.0;
 
     public static final String LINEAR_STR= "Linear";

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -88,7 +88,7 @@ export const ServerParams = {
         CREATE_PLOT_GROUP : 'CmdCreatePlotGroup',
         ZOOM : 'CmdZoom',
         STRETCH : 'CmdStretch',
-        ADD_BAND : 'CmdAddBand',
+        GET_BETA : 'CmdGetBeta',
         REMOVE_BAND : 'CmdRemoveBand',
         CHANGE_COLOR : 'CmdChangeColor',
         ROTATE_NORTH : 'CmdRotateNorth',

--- a/src/firefly/js/fieldGroup/FieldGroupCntlr.js
+++ b/src/firefly/js/fieldGroup/FieldGroupCntlr.js
@@ -145,7 +145,7 @@ export function dispatchMountComponent(groupKey,fieldKey,mounted,value,initField
  * @param {String} payload.fieldKey the field Key
  * @param {String} payload.groupKey group key
  * @param {String} payload.value value can be anything including a promise or function
- * @param {String} payload.valid - true if valid, default to true
+ * @param {boolean} payload.valid - true if valid, default to true
  */
 export function dispatchValueChange(payload) {
     flux.process({type: VALUE_CHANGE, payload});

--- a/src/firefly/js/rpc/PlotServicesJson.js
+++ b/src/firefly/js/rpc/PlotServicesJson.js
@@ -117,6 +117,13 @@ export function callChangeColor(state, colorTableId) {
     return doJsonRequest(ServerParams.CHANGE_COLOR, params, true);
 }
 
+export function callGetBeta(state) {
+    const params= [
+        {name:ServerParams.STATE, value: state.toJson()},
+    ];
+    return doJsonRequest(ServerParams.GET_BETA, params, true);
+}
+
 export function callRecomputeStretch(state, stretchDataAry) {
     var params= {
         [ServerParams.STATE]: state.toJson(),

--- a/src/firefly/js/ui/CompleteButton.jsx
+++ b/src/firefly/js/ui/CompleteButton.jsx
@@ -28,10 +28,14 @@ function validUpdate(valid,onSuccess,onFail,closeOnValid,groupKey,dialogId, incl
     if (valid && dialogId && closeOnValid) dispatchHideDialog(dialogId);
 }
 
-function onClick(onSuccess,onFail,closeOnValid,groupKey,dialogId,includeUnmounted) {
+function onClick(onSuccess,onFail,closeOnValid,groupKey,dialogId,includeUnmounted, changeMasking) {
     if (groupKey) {
+        if (changeMasking) changeMasking(true);
         validateFieldGroup(groupKey, includeUnmounted)
-            .then( (valid)=> validUpdate(valid,onSuccess,onFail,closeOnValid,groupKey,dialogId, includeUnmounted));
+            .then( (valid)=> {
+                if (changeMasking) changeMasking(false);
+                validUpdate(valid,onSuccess,onFail,closeOnValid,groupKey,dialogId, includeUnmounted);
+            });
     }
     else {
         if (onSuccess) onSuccess();
@@ -43,9 +47,9 @@ function onClick(onSuccess,onFail,closeOnValid,groupKey,dialogId,includeUnmounte
 
 export function CompleteButton ({onFail, onSuccess, groupKey=null, text='OK',
                           closeOnValid=true, dialogId,includeUnmounted= false,
-                          style={}}, context) {
+                          style={}, changeMasking}, context) {
     if (!groupKey && context) groupKey= context.groupKey;
-    const onComplete = () => onClick(onSuccess,onFail,closeOnValid,groupKey,dialogId,includeUnmounted);
+    const onComplete = () => onClick(onSuccess,onFail,closeOnValid,groupKey,dialogId,includeUnmounted,changeMasking);
     return (
         <div style={style}>
             <button type='button' className='button std hl'  onClick={onComplete}>{text}</button>
@@ -62,7 +66,8 @@ CompleteButton.propTypes= {
     closeOnValid: PropTypes.bool,
     dialogId: PropTypes.string,
     style: PropTypes.object,
-    includeUnmounted : PropTypes.bool
+    includeUnmounted : PropTypes.bool,
+    changeMasking: PropTypes.func,
 };
 
 CompleteButton.contextTypes= {

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React from 'react';
+import React, {PropTypes} from 'react';
 
 import CompleteButton from './CompleteButton.jsx';
 import * as TablesCntlr from '../tables/TablesCntlr.js';
@@ -29,7 +29,8 @@ function createSuccessHandler(action, params, onSubmit) {
 }
 
 export const FormPanel = function (props) {
-    var {children, onSubmit, onCancel, onError, groupKey, action, params, width='100%', height='100%', submitText='Search', help_id} = props;
+    var {children, onSubmit, onCancel, onError, groupKey, action, params,
+        width='100%', height='100%', submitText='Search', help_id, changeMasking} = props;
 
     const style = { width, height,
         backgroundColor: 'white',
@@ -49,7 +50,7 @@ export const FormPanel = function (props) {
                                     groupKey={groupKey}
                                     onSuccess={createSuccessHandler(action, params, onSubmit)}
                                     onFail={onError || handleFailfure}
-                                    text = {submitText}
+                                    text = {submitText} changeMasking={changeMasking}
                     />
                     <button style={{display: 'inline-block'}} type='button' className='button std' onClick={onCancel}>Cancel</button>
 
@@ -64,16 +65,17 @@ export const FormPanel = function (props) {
 
 
 FormPanel.propTypes = {
-    submitText: React.PropTypes.string,
-    width: React.PropTypes.string,
-    height: React.PropTypes.string,
-    onSubmit: React.PropTypes.func,
-    onCancel: React.PropTypes.func,
-    onError: React.PropTypes.func,
-    groupKey: React.PropTypes.any,
-    action: React.PropTypes.string,
-    params: React.PropTypes.object,
-    help_id: React.PropTypes.string
+    submitText: PropTypes.string,
+    width: PropTypes.string,
+    height: PropTypes.string,
+    onSubmit: PropTypes.func,
+    onCancel: PropTypes.func,
+    onError: PropTypes.func,
+    groupKey: PropTypes.any,
+    action: PropTypes.string,
+    params: PropTypes.object,
+    help_id: PropTypes.string,
+    changeMasking: PropTypes.func,
 };
 
 

--- a/src/firefly/js/ui/ImageSelectDropdown.jsx
+++ b/src/firefly/js/ui/ImageSelectDropdown.jsx
@@ -24,6 +24,17 @@ import {ImageSelection, getPlotInfo, panelKey, isCreatePlot, PLOT_NO,
 import {resultSuccess, resultFail} from '../visualize/ui/ImageSelectPanelResult.js';
 
 const dropdownName = 'ImageSelectDropDownCmd';
+
+
+const maskWrapper= {
+    position:'absolute',
+    left:0,
+    top:0,
+    width:'100%',
+    height:'100%'
+};
+
+
 /**
  *
  * @param props
@@ -36,8 +47,10 @@ export class ImageSelectDropdown extends Component {
 
         this.state = {
             fields: FieldGroupUtils.getGroupFields(panelKey),
-            visroot: visRoot()
+            visroot: visRoot(),
+            doMask : false
         };
+        this.changeMasking= (doMask) => this.setState(() => ({doMask}));
     }
 
 
@@ -77,9 +90,11 @@ export class ImageSelectDropdown extends Component {
                     groupKey={completeButtonKey(isThreeColor)}
                     onSubmit={resultSuccess(plotInfo, true)}
                     onError={resultFail()}
-                    onCancel={hideSearchPanel}>
+                    onCancel={hideSearchPanel}
+                    changeMasking={this.changeMasking}>
                     <ImageSelection loadButton={false} />
                 </FormPanel>
+                {this.state.doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
             </div>);
     }
 }

--- a/src/firefly/js/visualize/ImageBoundsData.js
+++ b/src/firefly/js/visualize/ImageBoundsData.js
@@ -28,22 +28,21 @@ function getJ2XY(wp) {
 export const makeRoughGuesser= function(cc) {
 
 
-    var dataWidth= cc.dataWidth;
-    var dataHeight= cc.dataHeight;
-    var topLeft= cc.getWorldCoords(makeImagePt(0,0));
-    var topRight= cc.getWorldCoords(makeImagePt(0,dataWidth));
-    var bottomLeft= cc.getWorldCoords(makeImagePt(dataHeight,0));
-    var bottomRight= cc.getWorldCoords(makeImagePt(dataHeight,dataWidth));
-    var scale= cc.getImagePixelScaleInDeg();
+    const {dataWidth, dataHeight}= cc;
+    const topLeft= cc.getWorldCoords(makeImagePt(0,0));
+    const topRight= cc.getWorldCoords(makeImagePt(dataWidth,0));
+    const bottomRight= cc.getWorldCoords(makeImagePt(dataWidth,dataHeight));
+    const bottomLeft= cc.getWorldCoords(makeImagePt(0,dataHeight));
+    const scale= cc.getImagePixelScaleInDeg();
 
 
-    var wPad= 25;
-    var hPad= 25;
+    const wPad= 25;
+    const hPad= 25;
 
-    var minRa= 5000;
-    var maxRa= -5000;
-    var minDec=5000;
-    var maxDec= -5000;
+    let minRa= 5000;
+    let maxRa= -5000;
+    let minDec=5000;
+    let maxDec= -5000;
 
                     // if I can find the corners then rough guess will not work
     if (!topLeft ||  !topRight || !bottomLeft || !bottomRight) return () => true;
@@ -61,13 +60,13 @@ export const makeRoughGuesser= function(cc) {
     maxDec+= (hPad*scale);
     maxRa+= (wPad*scale);
 
-    var imageSize= scale * Math.max(dataHeight,dataWidth);
-    var checkDeltaTop=    90-(2*imageSize);
-    var checkDeltaBottom= -90 + (2*imageSize);
+    const imageSize= scale * Math.max(dataHeight,dataWidth);
+    const checkDeltaTop=    90-(2*imageSize);
+    const checkDeltaBottom= -90 + (2*imageSize);
 
-    var wrapsRa= (maxRa-minRa) > 90;
-    var northPole= minDec>checkDeltaTop;
-    var southPole= maxDec<checkDeltaBottom;
+    const wrapsRa= (maxRa-minRa) > 90;
+    const northPole= minDec>checkDeltaTop;
+    const southPole= maxDec<checkDeltaBottom;
 
 
     if (northPole) { //if near the j2000 "north pole" then ignore ra check
@@ -78,15 +77,15 @@ export const makeRoughGuesser= function(cc) {
     }
     else if (wrapsRa) { // if image wraps around 0 ra
         return (wp) => {
-            var {x,y}= getJ2XY(wp);
-            var retval= y> minDec && y< maxDec;
+            const {x,y}= getJ2XY(wp);
+            let retval= y> minDec && y< maxDec;
             if (retval) retval= x> maxRa || x< minRa;
             return retval;
         };
     }
     else { // normal case
         return (wp) => {
-            var {x,y}= getJ2XY(wp);
+            const {x,y}= getJ2XY(wp);
             return (x> minRa && y> minDec && x< maxRa && y< maxDec);
         };
     }

--- a/src/firefly/js/visualize/RangeValues.js
+++ b/src/firefly/js/visualize/RangeValues.js
@@ -63,7 +63,7 @@ export class RangeValues {
                  lowerValue= 1.0,
                  upperWhich= PERCENTAGE,
                  upperValue= 99.0,
-                 betaValue=0.2,
+                 betaValue=NaN,
                  gammaValue=2.0,
                  algorithm= STRETCH_LINEAR,
                  zscaleContrast= 25,
@@ -157,7 +157,7 @@ export class RangeValues {
                    lowerValue= 1.0,
                    upperWhich,
                    upperValue= 99.0,
-                   betaValue=0.1,
+                   betaValue=NaN,
                    gammaValue=2.0,
                    algorithm= STRETCH_LINEAR,
                    zscaleContrast= 25,
@@ -193,7 +193,7 @@ export class RangeValues {
                 lowerValue= 1.0,
                 upperWhich= PERCENTAGE,
                 upperValue= 99.0,
-                betaValue=0.1,
+                betaValue=NaN,
                 gammaValue=2.0,
                 algorithm= STRETCH_LINEAR,
                 zscaleContrast= 25,
@@ -259,7 +259,7 @@ export class RangeValues {
 
 
         var params= sIn.split(',').map( (v) => validator.toFloat(v) );
-        var valid= params.every( (v)=> typeof v !== 'undefined' && !isNaN(v) );
+        var valid= params.every( (v)=> typeof v !== 'undefined');
 
         return valid ? new RangeValues(...params) : null;
     }

--- a/src/firefly/js/visualize/ui/ColorPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ColorPanelReducer.js
@@ -204,7 +204,7 @@ const updateFieldsFromRangeValues= function(fields,rv, fitsData) {
     fields.upperWhich= cloneWithValue(fields.upperWhich, rv.lowerWhich===ZSCALE ? PERCENTAGE : rv.upperWhich);
     fields.upperRange= cloneWithValue(fields.upperRange, rv.upperValue);
     // fields.beta= cloneWithValue(fields.beta,fitsData.beta.toFixed(2) );//rv.betaValue); //
-    fields.beta= cloneWithValue(fields.beta, rv.algorithm===STRETCH_ASINH ? rv.betaValue : fitsData.beta.toFixed(2));
+    fields.beta= cloneWithValue(fields.beta, rv.betaValue);
     fields.gamma= cloneWithValue(fields.gamma, rv.gammaValue);
     fields.algorithm= cloneWithValue(fields.algorithm, rv.algorithm);
     fields.zscaleContrast= cloneWithValue(fields.zscaleContrast, rv.zscaleContrast);
@@ -260,7 +260,7 @@ var getFieldInit= function() {
 
         beta: {
             fieldKey: 'beta',
-            value: '0.1',
+            value: NaN,
             validator: Validate.isPositiveFiniteNumber.bind(null, 'Beta'),
             tooltip: 'an arbitrary "softness"',
             label: 'Beta:'

--- a/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
+++ b/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
@@ -56,6 +56,14 @@ export const keyMap = {
     'plotmode':    'SELECTIMAGEPANEL_targetplot'
 };
 
+const maskWrapper= {
+    position:'absolute',
+    left:0,
+    top:0,
+    width:'100%',
+    height:'100%'
+};
+
 const findCatId = (ary, id) => get(ary.find( (p) => p.id===id), 'CatalogId',-1);
 
 export function getTabsIndexes() {
@@ -349,8 +357,10 @@ class ImageSelectionView extends Component {
                             [props[rgbFieldGroup[RED]], props[rgbFieldGroup[GREEN]], props[rgbFieldGroup[BLUE]]],
                             props.initCatalogId),
             addPlot:  isCreatePlot(props.plotMode, props.fields),
-            isThreeColor: isOnThreeColorSetting(props.plotMode, props.fields)
+            isThreeColor: isOnThreeColorSetting(props.plotMode, props.fields),
+            doMask : false
         };
+        this.changeMasking= (doMask) => this.setState(() => ({doMask}));
     }
 
     componentWillReceiveProps(nextProps) {
@@ -470,7 +480,9 @@ class ImageSelectionView extends Component {
                                 groupKey={completeButtonKey(this.state.isThreeColor)}
                                 onSuccess={resultSuccess(plotInfo)}
                                 onFail={resultFail()}
-                                text={'Load'} />
+                                text={'Load'}
+                                changeMasking={this.changeMasking}
+                            />
                         </div>
                         <div className={'padding'}>
                             <HelpIcon helpId={'visualizationCST'}/>
@@ -516,6 +528,7 @@ class ImageSelectionView extends Component {
                     { loadButtonArea() }
                 </div>
                 { panelHelpIcon() }
+                {this.state.doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
             </FieldGroup>
         );
     }


### PR DESCRIPTION
DM-10370: Optimize server memory usage for fits images

 - Server memory size cut in half
 - Optimized drawing so that user sees working message
 - Optimized scrolling so the it does not block when loading images
 - beta value (used for asinh strech) now only computed when required
 - added a getBetaValue service call
 - Uploading fits files now show masking while uploading
 - removed addColorBand call from server (not used)
 - Added way to push out memory in cache before large data is read in
 - Fixed bug in computing in CsysConvert.pointInPlot with rectangular images


This is a very difficult test it requires jconsole to monitor the memory with large fits images. It could take awhile just to get set up.  Mostly the review should just look over the code.

_Target code to look at:_
 
 - FitsCacher.java - _@lznakano this is the key file to check closely_
 - VisServerOps.java
 - FitsRead.java
 - ImageDataGroup.java


@loitly _would you look at:_
  - EhcacheProvider.java
  - ObjectSizeEngineWrapper.java
