### PR TITLE
DM-10461: Fixed: wcs match a little off for almost north plots

### DIFF
--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -485,8 +485,8 @@ export class CysConverter {
 
         // convert image workspace to screen
         const zFact= this.zoomFactor;
-        retPt.x= Math.floor(imageWorkspaceX*zFact);
-        retPt.y= Math.floor((this.dataHeight - imageWorkspaceY) *zFact);
+        retPt.x= imageWorkspaceX*zFact;
+        retPt.y= (this.dataHeight - imageWorkspaceY) *zFact;
     }
 
 
@@ -499,8 +499,8 @@ export class CysConverter {
     makeSPtFromIWPt(iwpt, altZoomLevel) {
         if (!iwpt) return null;
         const zoom= altZoomLevel || this.zoomFactor;
-        return makeScreenPt(Math.floor(iwpt.x*zoom),
-                            Math.floor((this.dataHeight - iwpt.y) *zoom) );
+        return makeScreenPt(iwpt.x*zoom,
+                            (this.dataHeight - iwpt.y) *zoom );
     }
 
 

--- a/src/firefly/js/visualize/task/WcsMatchTask.js
+++ b/src/firefly/js/visualize/task/WcsMatchTask.js
@@ -187,8 +187,9 @@ function rotateToMatch(pv, masterPv, flipY) {
     const masterPlot= primePlot(masterPv);
     if (!plot) return;
     const masterRot= masterPv.rotation * (flipY ? -1 : 1);
-    const targetRotation= ((getRotationAngle(masterPlot)+  masterRot)  -
+    var targetRotation= ((getRotationAngle(masterPlot)+  masterRot)  -
                            (getRotationAngle(plot))) * (flipY ? 1 : -1);
+    if (targetRotation<0) targetRotation+= 360;
     dispatchRotate({
         plotId: plot.plotId,
         rotateType: RotateType.ANGLE,


### PR DESCRIPTION
_To Test_

- keep you browser window fairly small
- read in m81: 2mass, wise, dss, sdss
- do wcs match.
- put up grid
- grid should look parallel 