### PR TITLE
IRSA-331:  update default cutout size units in TST

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -76,7 +76,7 @@ export const LC = {
 const plotIdRoot= 'LC_FRAME-';
 
 
-var defaultCutout = '0.2';
+var defaultCutout = '5';
 //var defaultFlux = '';
 
 function getFluxBandName(layoutInfo) {
@@ -282,7 +282,7 @@ function updateRawTableChart(timeCName, fluxCName, converterId) {
 
     if (timeCName && fluxCName) {
 
-        const title =getConverter(converterId).showPlotTitle?getConverter(converterId).showPlotTitle(LC.RAW_TABLE):''
+        const title =getConverter(converterId).showPlotTitle?getConverter(converterId).showPlotTitle(LC.RAW_TABLE):'';
 
         const xyPlotParams = {x: {columnOrExpr: timeCName}, y: {columnOrExpr: fluxCName, options: 'grid,flip'}, plotTitle:title};
 

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -26,6 +26,8 @@ import {sortInfoString} from '../../tables/SortInfo.js';
 import {makeMissionEntries, keepHighlightedRowSynced} from './LcUtil.jsx';
 import {dispatchMountFieldGroup} from '../../fieldGroup/FieldGroupCntlr.js';
 import {ServerParams} from '../../data/ServerParams.js';
+import {convertAngle} from '../../visualize/VisUtil.js';
+
 
 
 export const LC = {
@@ -76,7 +78,7 @@ export const LC = {
 const plotIdRoot= 'LC_FRAME-';
 
 
-var defaultCutout = '5';
+var defaultCutout = '5';     //5 arcsec
 //var defaultFlux = '';
 
 function getFluxBandName(layoutInfo) {
@@ -679,6 +681,7 @@ export function setupImages(layoutInfo) {
     const newPlotIdAry = makePlotIds(tableModel.highlightedRow, tableModel.totalRows, count);
     const maxPlotIdAry = makePlotIds(tableModel.highlightedRow, tableModel.totalRows, LC.MAX_IMAGE_CNT);
     const cutoutSize = getCutoutSize(layoutInfo);
+
     try {
         newPlotIdAry.forEach((plotId) => {
             var pv = getPlotViewById(vr, plotId);

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -26,6 +26,7 @@ import {dispatchMultiValueChange, dispatchRestoreDefaults}  from '../../fieldGro
 import {logError} from '../../util/WebUtil.js';
 import {getConverter, getMissionName} from './LcConverterFactory.js';
 import {ERROR_MSG_KEY} from '../lightcurve/generic/errorMsg.js';
+import {convertAngle} from '../../visualize/VisUtil.js';
 
 const resultItems = ['title', 'mode', 'showTables', 'showImages', 'showXyPlots', 'searchDesc', 'images',
     LC.MISSION_DATA, LC.GENERAL_DATA, 'periodState'];
@@ -130,6 +131,9 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
     const mission = getMissionName(converterId) || 'Mission';
     const showImages = isEmpty(imagePlot);
 
+    // convert the default Cutout size in arcmin to deg for WebPlotRequest, expected to be string in download panel
+    var cutoutSizeInDeg = (convertAngle('arcmin','deg', cutoutSize)).toString();
+
     var tsView = (err) => {
 
         if (!err) {
@@ -174,7 +178,7 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
                 <div>
                     <DownloadButton>
                         <DownloadOptionPanel
-                            cutoutSize={cutoutSize}
+                            cutoutSize={cutoutSizeInDeg}
                             title={'Image Download Option'}
                             dlParams={{
                                     MaxBundleSize: 200*1024*1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -126,7 +126,7 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
 
     const converterId = get(settingBox, ['props', 'missionEntries', LC.META_MISSION]);
     const convertData = getConverter(converterId);
-    const cutoutSize = get(convertData, 'noImageCutout') ? undefined : get(settingBox, 'props.generalEntries.cutoutSize', '0.3');
+    const cutoutSize = get(convertData, 'noImageCutout') ? undefined : get(settingBox, 'props.generalEntries.cutoutSize', '5');
     const mission = getMissionName(converterId) || 'Mission';
     const showImages = isEmpty(imagePlot);
 

--- a/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/basic/BasicMissionOptions.js
@@ -167,7 +167,7 @@ export const basicOptionsReducer = (missionEntries, generalEntries, typeColumns)
                 {validator: null}),
             ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
                 'image cutout size',
-                'Cutout Size (deg):', 100)),
+                'Cutout Size (arcmin):', 100)),
             [LC.META_URL_CNAME]: Object.assign(getTypeData(LC.META_URL_CNAME, '',
                 'Image url column name',
                 'Source Column:', labelWidth))

--- a/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/generic/DefaultMissionOptions.js
@@ -167,7 +167,7 @@ export const defaultOptionsReducer = (missionEntries, generalEntries, typeColumn
                 {validator: null}),
             ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
                 'image cutout size',
-                'Cutout Size (deg):', 100)),
+                'Cutout Size (arcmin):', 100)),
             [LC.META_ERR_CNAME]: Object.assign(getTypeData(LC.META_ERR_CNAME, '',
                 'flux error column name',
                 'Error Column:', labelWidth)),

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
@@ -126,7 +126,7 @@ const lsstSdssReducer = (missionEntries, generalEntries) => {
                 {validator: fldValidator(LC.META_FLUX_NAMES)}),
             ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
                 'image cutout size',
-                'Cutout Size (deg):', labelWidth)),
+                'Cutout Size (arcmin):', labelWidth)),
             [LC.META_ERR_CNAME]: Object.assign(getTypeData(LC.META_ERR_CNAME, '',
                 'flux error column name',
                 'Error Column:', labelWidth))

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssPlotRequests.js
@@ -10,6 +10,8 @@ import {ZoomType} from '../../../visualize/ZoomType.js';
 import {ServerRequest} from '../../../data/ServerRequest.js';
 
 import {addCommonReqParams} from '../LcConverterFactory.js';
+import {convertAngle} from '../../../visualize/VisUtil.js';
+
 
 const bandMap= {u:0, g:1, r:2, i:3, z:4};
 
@@ -36,14 +38,18 @@ export function makeLsstSdssPlotRequest(table, rowIdx, cutoutSize) {
     const ra = getCellValue(table, rowIdx, 'coord_ra');
     const decl = getCellValue(table, rowIdx, 'coord_decl');
 
+    // convert the default Cutout size in arcmin to deg for WebPlotRequest
+    const cutoutSizeInDeg = convertAngle('arcmin','deg', cutoutSize);
+
+
     const sr= new ServerRequest('LSSTImageSearch');
     sr.setParam('imageType', 'calexp');
     sr.setParam('imageId', scienceCcdId);
     sr.setParam('ra', ra);
     sr.setParam('dec', decl);
-    sr.setParam('subsize', `${cutoutSize}`); // in degrees
+    sr.setParam('subsize', `${cutoutSizeInDeg}`); // in degrees
 
-    const title =scienceCcdId.substr(0, 4) + bandMap[filterName].toString() + scienceCcdId.substr(5, 10)+'-'+filterName+(cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+    const title =scienceCcdId.substr(0, 4) + bandMap[filterName].toString() + scienceCcdId.substr(5, 10)+'-'+filterName+(cutoutSize ? ` size: ${cutoutSize}(arcmin)` : '');
     const plot_desc = `lsst-sdss-${scienceCcdId}`;
 
     const r  = WebPlotRequest.makeProcessorRequest(sr, plot_desc);

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -185,7 +185,7 @@ export const wiseOptionsReducer = (missionEntries, generalEntries) => {
                 {validator: null}),
             ['cutoutSize']: Object.assign(getTypeData('cutoutSize', '',
                 'image cutout size',
-                'Cutout Size (deg):', 100)),
+                'Cutout Size (arcmin):', 100)),
             [LC.META_URL_CNAME]: Object.assign(getTypeData(LC.META_URL_CNAME, '',
                 'WISE Image identifier column name (frame_id)',
                 'Image Column:', labelWidth)),

--- a/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
@@ -10,6 +10,7 @@ import {isNil, isEmpty} from 'lodash';
 import {ERROR_MSG_KEY} from '../generic/errorMsg.js';
 
 import {addCommonReqParams} from '../LcConverterFactory.js';
+import {convertAngle} from '../../../visualize/VisUtil.js';
 
 export function makeWisePlotRequest(table, rowIdx, cutoutSize) {
     const ra = getCellValue(table, rowIdx, 'ra');
@@ -26,7 +27,7 @@ export function makeWisePlotRequest(table, rowIdx, cutoutSize) {
     /*the following should be from reading in the url column returned from LC search
      we are constructing the url for wise as the LC table does
      not have the url column yet
-     It is only for WISE, using default cutout size 0.3 deg
+     set default cutout size 5 arcmin
      const url = `http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w1-int-1b.fits`;
      */
     const serverinfo = 'http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/';
@@ -34,7 +35,7 @@ export function makeWisePlotRequest(table, rowIdx, cutoutSize) {
     const url = `${serverinfo}${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w${band}-int-1b.fits${centerandsize}`;
     const plot_desc = `WISE-${frameId}`;
     const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);
-    const title = 'WISE-' + frameId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+    const title = 'WISE-' + frameId + (cutoutSize ? ` size: ${cutoutSize}(arcmin)` : '');
     return addCommonReqParams(reqParams, title, makeWorldPt(ra, dec, CoordinateSys.EQ_J2000));
 }
 
@@ -61,6 +62,9 @@ export function getWebPlotRequestViaWISEIbe(tableModel, hlrow, cutoutSize, param
     const frameNum = getCellValue(tableModel, hlrow, 'frame_num');
     const scanId = getCellValue(tableModel, hlrow, 'scan_id');
     const sourceId = getCellValue(tableModel, hlrow, 'source_id');
+
+    // convert the default Cutout size in arcmin to deg for WebPlotRequest
+    const cutoutSizeInDeg = convertAngle('arcmin','deg', cutoutSize);
 
     try {
         var wise_sexp_ibe = /(\d+)([0-9][a-z])(\w+)/g;
@@ -108,9 +112,9 @@ export function getWebPlotRequestViaWISEIbe(tableModel, hlrow, cutoutSize, param
             sr.setParam('in_dec', `${dec}`);
             wp = makeWorldPt(ra, dec, CoordinateSys.EQ_J2000);
             sr.setParam('doCutout', 'true');
-            sr.setParam('size', `${cutoutSize}`);
-            sr.setParam('subsize', `${cutoutSize}`);
-            title = 'WISE-W' + band + '-' + tmpId + (cutoutSize ? ` size: ${cutoutSize}(deg)` : '');
+            sr.setParam('size', `${cutoutSizeInDeg}`);
+            sr.setParam('subsize', `${cutoutSizeInDeg}`);
+            title = 'WISE-W' + band + '-' + tmpId + (cutoutSize ? ` size: ${cutoutSize}(arcmin)` : '');
         }
 
         const reqParams = WebPlotRequest.makeProcessorRequest(sr, 'wise');

--- a/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
@@ -30,8 +30,12 @@ export function makeWisePlotRequest(table, rowIdx, cutoutSize) {
      set default cutout size 5 arcmin
      const url = `http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w1-int-1b.fits`;
      */
+
+    // convert the default Cutout size in arcmin to deg for WebPlotRequest
+    const cutoutSizeInDeg = convertAngle('arcmin','deg', cutoutSize);
+
     const serverinfo = 'http://irsa.ipac.caltech.edu/ibe/data/wise/merge/merge_p1bm_frm/';
-    const centerandsize = cutoutSize ? `?center=${ra},${dec}&size=${cutoutSize}&gzip=false` : '';
+    const centerandsize = cutoutSize ? `?center=${ra},${dec}&size=${cutoutSizeInDeg}&gzip=false` : '';
     const url = `${serverinfo}${scangrp}/${scan_id}/${frame_num}/${scan_id}${frame_num}-w${band}-int-1b.fits${centerandsize}`;
     const plot_desc = `WISE-${frameId}`;
     const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);


### PR DESCRIPTION
What changed:
1. the default cutout size is set to 5 arcmin for all missons
2. added  cutout size conversion from arcmin to deg before sending WebPlotRequest

To Test
* upload a WISE/LSST time series table, the upper left form panel should have the default 5arcmin cutout size, the lower image panel will show size in arcmin unit in title