### PR TITLE
DM-10477: wcs match reset images when it turns off

### DIFF
--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -170,7 +170,7 @@ export function computeCentralPointAndRadius(inPoints) {
  * @param {number} dec  the equatorial DEC in degrees of the second object
  * @return {number} position angle in degrees between the two objects
  */
-function getPositionAngle(ra0, dec0, ra, dec) {
+export function getPositionAngle(ra0, dec0, ra, dec) {
     let sind, sinpa, cospa;
 
     const alf = ra * DtoR;
@@ -200,7 +200,7 @@ function getPositionAngle(ra0, dec0, ra, dec) {
     if (dec0===-90) pa = 0.0;
 
     return pa;
-};
+}
 
 /**
  * Rotates the given input position and returns the result. The rotation
@@ -338,12 +338,42 @@ export const getRotationAngle= function(plot) {
     const iy = iHeight / 2;
     const cc= CysConverter.make(plot);
     const wptC = cc.getWorldCoords(makeImageWorkSpacePt(ix, iy));
-    const wpt2 = cc.getWorldCoords(makeImageWorkSpacePt(ix, iHeight/4));
+    const wpt2 = cc.getWorldCoords(makeImageWorkSpacePt(ix, iy+iHeight/4));
     if (wptC && wpt2) {
         retval = getPositionAngle(wptC.getLon(), wptC.getLat(), wpt2.getLon(), wpt2.getLat());
     }
     return retval;
 };
+
+
+/**
+ * Return true if the plot in both PlotViews are rotated the same
+ * @param {PlotView} pv1
+ * @param {PlotView} pv2
+ * @return {boolean}
+ */
+export function isRotationMatching(pv1, pv2) {
+    const p1= primePlot(pv1);
+    const p2= primePlot(pv2);
+
+    if (!p1 || !p2) return false;
+
+    if (isNorthCountingRotation(pv1) && isNorthCountingRotation(pv2)) {
+        return true;
+    }
+    else {
+        const r1= getRotationAngle(p1) + pv1.rotation;
+        const r2= getRotationAngle(p2) + pv2.rotation;
+        return Math.abs(r1-r2) < .9;
+    }
+}
+
+function isNorthCountingRotation(pv) {
+    const plot= primePlot(pv);
+    if (!plot) return false;
+    return (pv.plotViewCtx.rotateNorthLock || (isPlotNorth(plot) && !pv.rotation) );
+}
+
 
 /**
  * Is the image positioned so that north is up.

--- a/src/firefly/js/visualize/iv/CanvasTileDrawer.js
+++ b/src/firefly/js/visualize/iv/CanvasTileDrawer.js
@@ -83,6 +83,10 @@ function purgeLoadedImages(loadedImages) {
     }
 }
 
+
+const noOp= { drawerTile : () => undefined,
+              abort : () => undefined };
+
 /**
  *
  * @param {PlotView} plotView
@@ -102,7 +106,16 @@ function purgeLoadedImages(loadedImages) {
 function makeDrawer(plotView, plot, targetCanvas, totalCnt, loadedImages,
                     offsetX,offsetY, scale, opacity, tileAttributes, shouldProcess, processor) {
 
-    if (!targetCanvas) return;
+    if (!targetCanvas) return noOp;
+
+    if (!totalCnt) {
+        window.requestAnimationFrame(() => {
+            targetCanvas.getContext('2d').clearRect(0,0,targetCanvas.width, targetCanvas.height);
+        });
+        return noOp;
+    }
+
+
     const offscreenCanvas = document.createElement('canvas');
     const offscreenCtx = offscreenCanvas.getContext('2d');
 
@@ -130,6 +143,7 @@ function makeDrawer(plotView, plot, targetCanvas, totalCnt, loadedImages,
     offscreenCtx.strokeStyle='rgba(0,0,0,.2)';
     offscreenCtx.textAlign= 'center';
     offscreenCtx.lineWidth= 1;
+
 
     const renderImage= () => renderToScreen(plotView, targetCanvas, offscreenCanvas, opacity, offsetX, offsetY);
 

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -272,7 +272,7 @@ function rotatePv(pv, targetAngle, rotateNorthLock) {
 
 }
 
-function rotatePvToMatch(pv, matchToPv) {
+function rotatePvToMatch(pv, matchToPv, rotateNorthLock) {
     if (isRotationMatching(pv,matchToPv)) return pv;
     const plot= primePlot(pv);
     const matchToPlot= primePlot(matchToPv);
@@ -282,6 +282,7 @@ function rotatePvToMatch(pv, matchToPv) {
         (matchToPv.flipY ? 1 : -1);
     targetRotation= targetRotation ? 360- targetRotation : 0;
     pv= clone(pv);
+    pv.plotViewCtx= clone(pv.plotViewCtx, {rotateNorthLock});
     pv.rotation= (360 + targetRotation) % 360;
     return updateTransform(pv);
 }
@@ -320,10 +321,10 @@ function updateClientRotation(state,action) {
 
     const plotGroup= findPlotGroup(pv.plotGroupId,plotGroupAry);
     const masterPv= rotatePv(pv,targetAngle,rotateNorthLock);
-    if (state.wcsMatchType) {
+    if (state.wcsMatchType || rotateType===RotateType.NORTH) {
         plotViewAry= clonePvAryWithPv(plotViewAry, masterPv);
         if (actionScope===ActionScope.GROUP) {
-            plotViewAry= matchPlotView(masterPv,plotViewAry, plotGroup, (pv) => rotatePvToMatch(pv,masterPv));
+            plotViewAry= matchPlotView(masterPv,plotViewAry, plotGroup, (pv) => rotatePvToMatch(pv,masterPv, rotateNorthLock));
         }
     }
     else {

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -12,7 +12,7 @@ import {replacePlotView, replacePrimaryPlot, changePrimePlot,
 import {WebPlot, clonePlotWithZoom, PlotAttribute} from '../WebPlot.js';
 import {logError, updateSet} from '../../util/WebUtil.js';
 import {CCUtil, CysConverter} from '../CsysConverter.js';
-import {isPlotNorth, getRotationAngle} from '../VisUtil.js';
+import {isPlotNorth, getRotationAngle, isRotationMatching} from '../VisUtil.js';
 import {PlotPref} from './../PlotPref.js';
 import {primePlot,
         clonePvAry,
@@ -272,6 +272,20 @@ function rotatePv(pv, targetAngle, rotateNorthLock) {
 
 }
 
+function rotatePvToMatch(pv, matchToPv) {
+    if (isRotationMatching(pv,matchToPv)) return pv;
+    const plot= primePlot(pv);
+    const matchToPlot= primePlot(matchToPv);
+    if (!plot || !matchToPlot) return pv;
+    const masterRot= matchToPv.rotation * (matchToPv.flipY ? -1 : 1);
+    let targetRotation= ((getRotationAngle(matchToPlot)+  masterRot)  - (getRotationAngle(plot))) *
+        (matchToPv.flipY ? 1 : -1);
+    targetRotation= targetRotation ? 360- targetRotation : 0;
+    pv= clone(pv);
+    pv.rotation= (360 + targetRotation) % 360;
+    return updateTransform(pv);
+}
+
 
 function updateClientRotation(state,action) {
     const {plotId,angle, rotateType, actionScope}= action.payload;
@@ -305,10 +319,18 @@ function updateClientRotation(state,action) {
     // const realAngle= (360-targetAngle) % 360;
 
     const plotGroup= findPlotGroup(pv.plotGroupId,plotGroupAry);
-
-    plotViewAry= actionScope===ActionScope.GROUP ?
-               applyToOnePvOrGroup(plotViewAry,plotId,plotGroup, (pv) => rotatePv(pv,targetAngle, rotateNorthLock)) :
-               clonePvAryWithPv(plotViewAry, rotatePv(pv,targetAngle,rotateNorthLock));
+    const masterPv= rotatePv(pv,targetAngle,rotateNorthLock);
+    if (state.wcsMatchType) {
+        plotViewAry= clonePvAryWithPv(plotViewAry, masterPv);
+        if (actionScope===ActionScope.GROUP) {
+            plotViewAry= matchPlotView(masterPv,plotViewAry, plotGroup, (pv) => rotatePvToMatch(pv,masterPv));
+        }
+    }
+    else {
+        plotViewAry= actionScope===ActionScope.GROUP ?
+            applyToOnePvOrGroup(plotViewAry,plotId,plotGroup, (pv) => rotatePv(pv,targetAngle, rotateNorthLock)) :
+            clonePvAryWithPv(plotViewAry, masterPv);
+    }
 
     return clone(state,{plotViewAry});
 }


### PR DESCRIPTION
DM-10477: wcs match reset images when it turns off

Including bug fixes:

  - Fixed a rotation issue: clicking rotate north on north up images fliped them south
  - Fixed: when north is up, clicking north up makes the image rotate south.

_To test:_

 - load m81 - 2mass, wise 1a, dss, sdss
 - click on any image turn wcs-match on then turn off
 - click on another image and do the same things
 - image should rotation to match then unrotated
 - Also, while WCS matched, rotate an image, they should rotate together and stay matched

_To test North up bug:_

  - load 2mass click on rotate north - nothing should happen
