### PR TITLE
DM-10543: improved plotly performance during resize and add masking

### DIFF
--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -34,7 +34,7 @@ class ChartPanelView extends PureComponent {
 
         this.onResize = (size) => {
             if (this.state.widthPx === 0 || isPlotly()) {
-                defer(normal, size);
+            defer(normal, size);
             } else {
                 debounced(size);
             }
@@ -110,13 +110,11 @@ class ChartPanelView extends PureComponent {
                                 </div>}
                                 <Resizable id='chart-resizer' onResize={this.onResize}
                                            className='ChartPanel__chartresizer'>
-                                    <div style={{overflow:'auto',width:widthPx,height:heightPx}}>
-                                        {knownSize ?
-                                            errors.length > 0 ?
-                                                <ErrorPanel errors={errors}/> :
-                                                <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
-                                            <div/>}
-                                    </div>
+                                    {knownSize ?
+                                        errors.length > 0 ?
+                                            <ErrorPanel errors={errors}/> :
+                                            <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
+                                        <div/>}
                                 </Resizable>
                                 { !optionsShown && deletable &&
                                 <img style={{display: 'inline-block', position: 'absolute', top: 29, right: 0, alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}
@@ -135,14 +133,12 @@ class ChartPanelView extends PureComponent {
                         <div className='ChartPanel__chartarea'>
                             <Resizable id='chart-resizer' onResize={this.onResize}
                                        className='ChartPanel__chartresizer'>
-                                <div style={{overflow:'auto',width:widthPx,height:heightPx}}>
-                                    {knownSize ?
-                                        errors.length > 0 ?
-                                            <ErrorPanel errors={errors}/> :
-                                            <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
+                                {knownSize ?
+                                    errors.length > 0 ?
+                                        <ErrorPanel errors={errors}/> :
+                                        <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
 
-                                        <div/>}
-                                </div>
+                                    <div/>}
                             </Resizable>
                             {deletable &&
                             <img style={{display: 'inline-block', position: 'absolute', top: 0, right: 0, alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -5,6 +5,7 @@ import Resizable from 'react-component-resizable';
 import {flux} from '../../Firefly.js';
 import {get, debounce, defer} from 'lodash';
 import {reduxFlux} from '../../core/ReduxFlux.js';
+import {isPlotly} from '../ChartUtil.js';
 
 import * as ChartsCntlr from '../ChartsCntlr.js';
 
@@ -30,8 +31,9 @@ class ChartPanelView extends PureComponent {
             }
         };
         const debounced = debounce(normal, 100);
+
         this.onResize = (size) => {
-            if (this.state.widthPx === 0) {
+            if (this.state.widthPx === 0 || isPlotly()) {
                 defer(normal, size);
             } else {
                 debounced(size);

--- a/src/firefly/js/charts/ui/HistogramPlotly.jsx
+++ b/src/firefly/js/charts/ui/HistogramPlotly.jsx
@@ -290,6 +290,7 @@ export class HistogramPlotly extends Component {
                            layoutUpdate={layoutUpdate}
                            divUpdateCB={(div) => this.chart= div}
                            config={config}
+                           autoDetectResizing={true}
                            newPlotCB={this.afterRedraw}
             />
         );

--- a/src/firefly/js/charts/ui/PlotlyChartPanel.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartPanel.jsx
@@ -99,15 +99,9 @@ export class ChartArea extends PureComponent {
 
     render() {
         const {chartId} = this.props;
-        const {data=[], highlighted, selected, layout, showOptions, widthPx, heightPx} = this.state;
-        const layoutDim=  {width: widthPx, height: heightPx};
-
-
-        // if (layout && (!layout.width || !layout.height)) Object.assign(layout, layoutDim);
-        const handleAsResize= (layout && (layout.width!==widthPx || layout.height!==heightPx));
-        Object.assign(layout,layoutDim);
-
-
+        const {data=[], highlighted, selected, layout={}, showOptions, widthPx, heightPx} = this.state;
+        const doingResize= (layout && (layout.width!==widthPx || layout.height!==heightPx));
+        Object.assign(layout, {width: widthPx, height: heightPx});
         const OptionsUI = getOptionsUI(chartId);
         const showlegend = data.length > 1;
         let pdata = data;
@@ -118,7 +112,8 @@ export class ChartArea extends PureComponent {
         return (
             <Resizable className='ChartPanel__chartresizer' onResize={this.onResize}>
                 <PlotlyWrapper newPlotCB={this.afterRedraw} data={pdata} layout={playout}
-                               handleRenderAsResize={handleAsResize}/>
+                               autoDetectResizing={false}
+                               doingResize={doingResize}/>
                 {showOptions && <OptionsUI {...{chartId}}/>}
             </Resizable>
         );

--- a/src/firefly/js/charts/ui/PlotlyChartPanel.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartPanel.jsx
@@ -65,13 +65,8 @@ export class ChartArea extends PureComponent {
                 }
             }
         };
-        const debounced = debounce(normal, 100);
         this.onResize = (size) => {
-            if (this.state.widthPx === 0) {
-                defer(normal, size);
-            } else {
-                debounced(size);
-            }
+            defer(normal, size);
         };
     }
 
@@ -104,8 +99,15 @@ export class ChartArea extends PureComponent {
 
     render() {
         const {chartId} = this.props;
-        const {data=[], highlighted, selected, layout={}, showOptions, widthPx, heightPx} = this.state;
-        Object.assign(layout, {width: widthPx, height: heightPx});
+        const {data=[], highlighted, selected, layout, showOptions, widthPx, heightPx} = this.state;
+        const layoutDim=  {width: widthPx, height: heightPx};
+
+
+        // if (layout && (!layout.width || !layout.height)) Object.assign(layout, layoutDim);
+        const handleAsResize= (layout && (layout.width!==widthPx || layout.height!==heightPx));
+        Object.assign(layout,layoutDim);
+
+
         const OptionsUI = getOptionsUI(chartId);
         const showlegend = data.length > 1;
         let pdata = data;
@@ -115,7 +117,8 @@ export class ChartArea extends PureComponent {
 
         return (
             <Resizable className='ChartPanel__chartresizer' onResize={this.onResize}>
-                <PlotlyWrapper newPlotCB={this.afterRedraw} data={pdata} layout={playout}/>
+                <PlotlyWrapper newPlotCB={this.afterRedraw} data={pdata} layout={playout}
+                               handleRenderAsResize={handleAsResize}/>
                 {showOptions && <OptionsUI {...{chartId}}/>}
             </Resizable>
         );

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -4,15 +4,16 @@
 
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {get} from 'lodash';
+import {get,isEmpty,xor,debounce} from 'lodash';
 import {getPlotLy} from '../PlotlyConfig.js';
 import {logError} from '../../util/WebUtil.js';
+import BrowserInfo from '../../util/BrowserInfo.js';
 import Enum from 'enum';
 
 const PLOTLY_BASE_ID= 'plotly-plot';
 var counter= 0;
 
-export const RenderType= new Enum([ 'RESIZE', 'UPDATE', 'RESTYLE', 'RELAYOUT', 'RESTYLE_AND_RELAYOUT', 'NEW_PLOT'],
+export const RenderType= new Enum([ 'RESIZE', 'UPDATE', 'RESTYLE', 'RELAYOUT', 'RESTYLE_AND_RELAYOUT', 'NEW_PLOT', 'PAUSE_DRAWING' ],
              { ignoreCase: true });
 
 
@@ -25,6 +26,18 @@ const defaultConfig= {
         'hoverCompareCartesian'
     ]
 };
+
+const maskWrapper= {
+    position:'absolute',
+    left:0,
+    top:0,
+    width:'100%',
+    height:'100%'
+};
+
+function isSlowResize() {
+    return BrowserInfo.isFirefox();
+}
 
 export function downloadChart(chartId) {
     getPlotLy().then( (Plotly) => {
@@ -50,34 +63,86 @@ export class PlotlyWrapper extends Component {
         this.div= null;
         this.refUpdate= this.refUpdate.bind(this);
         this.renderType= RenderType.NEW_PLOT;
+        this.state= {showMask:false};
+
+
+        this.resizeUpdate= (postResizeRenderType) => {
+            this.renderType= postResizeRenderType;
+            this.forceUpdate();
+        };
+
+        this.resizeUpdateDebouncedLong= debounce(this.resizeUpdate,800);
+        this.resizeUpdateDebouncedShort= debounce(this.resizeUpdate,100);
+
+
+    }
+
+    showMask(show) {
+        setTimeout( () => {
+            if (show!==this.state.showMask) {
+                this.setState(() => ({showMask:show}));
+            }
+        },0);
+    }
+
+    /**
+     *
+     * @param useMask
+     * @param treatAsResize
+     * @param renderType
+     */
+    updateRenderType(useMask, treatAsResize, renderType) {
+        if (treatAsResize) {
+            this.renderType= RenderType.PAUSE_DRAWING;
+            isSlowResize() ? this.resizeUpdateDebouncedLong(renderType) : this.resizeUpdateDebouncedShort(renderType);
+        }
+        else {
+            this.renderType= renderType;
+        }
+        if (useMask || treatAsResize) this.showMask(true);
     }
 
     shouldComponentUpdate(np, ns) {
+
         const {data,layout, config, dataUpdate, layoutUpdate}= this.props;
-        if (data===np.data && layout===np.layout && config===np.config) {
+        const { maskOnLayout, maskOnRestyle, maskOnResize, maskOnNewPlot, autoResize, handleRenderAsResize}= np;
+
+        if (this.state.showMask!==ns.showMask) { //special case: detect when only masking is changing
+            this.renderType = RenderType.PAUSE_DRAWING;
+        }
+        else if (data===np.data && layout===np.layout && config===np.config) {  // these are the update cases
 
             const doRestyle= np.dataUpdate && dataUpdate!==np.dataUpdate;
             const doRelayout=np.layoutUpdate && layoutUpdate!==np.layoutUpdate;
 
-            if (doRestyle && doRelayout) this.renderType= RenderType.RESTYLE_AND_RELAYOUT;
-            else if (doRestyle)          this.renderType= RenderType.RESTYLE;
-            else if (doRelayout)         this.renderType= RenderType.RELAYOUT;
-            else                         this.renderType= RenderType.RESIZE;
+            if (doRestyle && doRelayout) {
+                this.updateRenderType(maskOnRestyle, handleRenderAsResize, RenderType.RESTYLE_AND_RELAYOUT);
+            }
+            else if (doRestyle) {
+                this.updateRenderType(maskOnRestyle, handleRenderAsResize, RenderType.RESTYLE);
+            }
+            else if (doRelayout) {
+                this.updateRenderType(maskOnLayout, handleRenderAsResize, RenderType.RELAYOUT);
+            }
+            else { // we must just be resized
+                if (autoResize) this.updateRenderType(maskOnResize, true, RenderType.RESIZE);
+                else            this.updateRenderType(maskOnResize, handleRenderAsResize, RenderType.RESIZE);
+            }
         }
-        else if (data!==np.data || layout!==np.layout && config===np.config) {
-            // this.renderType= RenderType.UPDATE;
-            this.renderType= RenderType.NEW_PLOT;
-        }
-        else {
-            this.renderType= RenderType.NEW_PLOT;
+        else { // fallthrough new plot case
+            this.updateRenderType(maskOnNewPlot, handleRenderAsResize, RenderType.NEW_PLOT);
         }
         return true;
     }
 
     draw() {
-        const {data,layout, config= defaultConfig, newPlotCB, dataUpdate, layoutUpdate, dataUpdateTraces}= this.props;
         const renderType = this.renderType;
+        if (renderType===RenderType.PAUSE_DRAWING) return;
+
+        const {data,layout, config= defaultConfig, newPlotCB, dataUpdate, layoutUpdate, dataUpdateTraces}= this.props;
+
         getPlotLy().then( (Plotly) => {
+
             if (this.div) { // make sure the div is still there
                 switch (renderType) {
                     case RenderType.RESTYLE:
@@ -101,10 +166,14 @@ export class PlotlyWrapper extends Component {
                         if (this.div.on) {
                             const chart = this.div;
                             chart.on('plotly_click', () => chart.parentElement.click());
+                            chart.on('plotly_afterplot', () => this.showMask(false));
+                            chart.on('plotly_autosize', () => this.showMask(false));
                         }
-                        if (newPlotCB) {
-                            newPlotCB(this.div, Plotly);
+                        else {
+                            this.showMask(false)
                         }
+                        if (newPlotCB) newPlotCB(this.div, Plotly);
+
                         break;
                 }
             }
@@ -124,23 +193,21 @@ export class PlotlyWrapper extends Component {
         }
     }
 
-    componentDidMount() {
-        this.draw();
-    }
+    componentDidMount() { this.draw(); }
 
-    componentDidUpdate() {
-        this.draw();
-    }
+    componentDidUpdate() { this.draw(); }
 
     render() {
         const {chartId, style}= this.props;
+        const {showMask}= this.state;
         // note: wrapper div is the target for the simulated click event
         // when the original click event is lost and plotly_click is emitted instead
         // chart image download relies on div id matching chartId
-        const nstyle = Object.assign({height: '100%', width: '100%'}, style);
+        const nstyle = Object.assign({position:'relative', height: '100%', width: '100%'}, style);
         return (
-            <div>
-                <div id={chartId || this.id} style={nstyle} ref={this.refUpdate}/>
+            <div style={nstyle}>
+                <div id={chartId || this.id} style={{height: '100%', width: '100%'}} ref={this.refUpdate}/>
+                {showMask && <div style={maskWrapper}> <div className='loading-mask'/> </div>}
             </div>
         );
     }
@@ -158,5 +225,20 @@ PlotlyWrapper.propTypes = {
     dataUpdateTraces: PropTypes.number,
     layoutUpdate: PropTypes.object,
     divUpdateCB: PropTypes.func,
-    newPlotCB: PropTypes.func
+    newPlotCB: PropTypes.func,
+    maskOnRelayout :PropTypes.bool,
+    maskOnRestyle :PropTypes.bool,
+    maskOnResize : PropTypes.bool,
+    maskOnNewPlot : PropTypes.bool,
+    autoResize : PropTypes.bool,
+    handleRenderAsResize: PropTypes.bool
+};
+
+PlotlyWrapper.defaultProps = {
+    maskOnLayout : true,
+    maskOnRestyle : false,
+    maskOnResize : true,
+    maskOnNewPlot : true,
+    autoResize : false,
+    handleRenderAsResize: false
 };

--- a/src/firefly/js/charts/ui/XYPlot.jsx
+++ b/src/firefly/js/charts/ui/XYPlot.jsx
@@ -205,7 +205,7 @@ export class XYPlot extends Component {
 
     render() {
 
-        const {data, params} = this.props;
+        const {data, params, width, height} = this.props;
 
         // validate parameters for the given data
         const errors = validate(params, data);
@@ -222,8 +222,15 @@ export class XYPlot extends Component {
                 </div>
             );
         } else {
-            const XYPlotInstance=  isPlotly() ? XYPlotPlotly : XYPlotHighcharts;
-            return (<XYPlotInstance {...this.props}/>);
+            if (isPlotly()) {
+                return <XYPlotPlotly {...this.props}/>;
+            } else {
+                return (
+                    <div style={{overflow:'auto',width,height}}>
+                        <XYPlotHighcharts {...this.props}/>
+                    </div>
+                );
+            }
         }
     }
 }

--- a/src/firefly/js/charts/ui/XYPlotPlotly.jsx
+++ b/src/firefly/js/charts/ui/XYPlotPlotly.jsx
@@ -426,7 +426,8 @@ export class XYPlotPlotly extends PureComponent {
         this.state = {
             dataUpdateTraces: undefined,
             dataUpdate: undefined,
-            layoutUpdate: undefined
+            layoutUpdate: undefined,
+            doingResize: false
         };
 
         this.afterRedraw = this.afterRedraw.bind(this);
@@ -446,8 +447,13 @@ export class XYPlotPlotly extends PureComponent {
 
         const {data, width, height, params, highlighted, selectInfo, desc} = this.props;
 
+
+        const doingResize= (width!==nextProps.width || height!==nextProps.height);
+        if (doingResize!==this.state.doingResize) this.setState({doingResize});
+
         // re-calculate charting info when the plot data change or an error occurs
         // shading change for density plot changes series
+
         if (nextProps.data !== data ||
             get(params, 'plotStyle') !== get(nextProps.params, 'plotStyle') ||
             plotErrors(params, 'x') !== plotErrors(nextProps.params, 'x') ||
@@ -781,7 +787,7 @@ export class XYPlotPlotly extends PureComponent {
             this.chartingInfo = getChartingInfo(this.props);
         }
         const {plotlyData, plotlyLayout, plotlyDivStyle} = this.chartingInfo;
-        const {dataUpdateTraces, dataUpdate, layoutUpdate} = this.state;
+        const {dataUpdateTraces, dataUpdate, layoutUpdate, doingResize} = this.state;
 
         return (
             <div style={{float: 'left'}}>
@@ -790,6 +796,7 @@ export class XYPlotPlotly extends PureComponent {
                                dataUpdate={dataUpdate}
                                layoutUpdate={layoutUpdate}
                                config={PLOTLY_CONFIG}
+                               handleRenderAsResize={doingResize}
                                newPlotCB={this.afterRedraw}
                 />
             </div>

--- a/src/firefly/js/charts/ui/XYPlotPlotly.jsx
+++ b/src/firefly/js/charts/ui/XYPlotPlotly.jsx
@@ -333,9 +333,7 @@ function getChartingInfo(props) {
 
     const plotlyDivStyle = {
         border: '1px solid a5a5a5',
-        borderRadius: 5,
-        width: '100%',
-        height: '100%'
+        borderRadius: 5
     };
 
     const {plotlyData, selectedRows, toRowIdx} = makeSeries(props);
@@ -447,9 +445,7 @@ export class XYPlotPlotly extends PureComponent {
 
         const {data, width, height, params, highlighted, selectInfo, desc} = this.props;
 
-
-        const doingResize= (width!==nextProps.width || height!==nextProps.height);
-        if (doingResize!==this.state.doingResize) this.setState({doingResize});
+        let doingResize= false;
 
         // re-calculate charting info when the plot data change or an error occurs
         // shading change for density plot changes series
@@ -605,11 +601,15 @@ export class XYPlotPlotly extends PureComponent {
                 if (newWidth !== width || newHeight !== height ||
                     newParams.xyRatio !== params.xyRatio || newParams.stretch !== params.stretch) {
                     const {chartWidth, chartHeight} = calculateChartSize(newWidth, newHeight, nextProps);
-                    this.setState({layoutUpdate: {height: chartHeight, width: chartWidth }});
+                    const {chartWidth:oldWidth, chartHeight:oldHeight} =  calculateChartSize(width, height, this.props);
+                    if (oldWidth !== chartWidth || oldHeight !== chartHeight) {
+                        this.setState({layoutUpdate: {height: chartHeight, width: chartWidth}});
+                        doingResize = true;
+                    }
                 }
             }
         }
-        return true;
+        if (doingResize!==this.state.doingResize) this.setState({doingResize});
     }
 
     /**
@@ -789,8 +789,14 @@ export class XYPlotPlotly extends PureComponent {
         const {plotlyData, plotlyLayout, plotlyDivStyle} = this.chartingInfo;
         const {dataUpdateTraces, dataUpdate, layoutUpdate, doingResize} = this.state;
 
+        const style = {float: 'left'};
+        const chartWidth = get(layoutUpdate, 'width') || plotlyLayout.width;
+        const chartHeight = get(layoutUpdate, 'height') || plotlyLayout.height;
+        if (chartWidth > this.props.width || chartHeight > this.props.height) {
+            Object.assign(style, {overflow:'auto',width:this.props.width,height:this.props.height});
+        }
         return (
-            <div style={{float: 'left'}}>
+            <div style={style}>
                 <PlotlyWrapper chartId={this.props.chartId} data={plotlyData} layout={plotlyLayout}  style={plotlyDivStyle}
                                dataUpdateTraces={dataUpdateTraces}
                                dataUpdate={dataUpdate}

--- a/src/firefly/js/charts/ui/XYPlotPlotly.jsx
+++ b/src/firefly/js/charts/ui/XYPlotPlotly.jsx
@@ -796,7 +796,8 @@ export class XYPlotPlotly extends PureComponent {
                                dataUpdate={dataUpdate}
                                layoutUpdate={layoutUpdate}
                                config={PLOTLY_CONFIG}
-                               handleRenderAsResize={doingResize}
+                               doingResize={doingResize}
+                               autoDetectResizing={false}
                                newPlotCB={this.afterRedraw}
                 />
             </div>

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -271,7 +271,7 @@ class PhaseFoldingChart extends PureComponent {
                 var heightPx = size.height;
 
                 if (widthPx !== this.state.widthPx || heightPx !== this.state.heightPx) {
-                    this.setState({widthPx, heightPx, doingResize:true});
+                    this.setState({widthPx, heightPx});
                 }
             }
         };
@@ -288,7 +288,7 @@ class PhaseFoldingChart extends PureComponent {
 
         this.doRegenData= (fields) => {
             this.chartingInfo= this.regenData(fields);
-            this.setState(() => ({fields, doingResize:false}));
+            this.setState(() => ({fields}));
         };
         this.doRegenData= this.doRegenData.bind(this);
         this.doRegenDataDebounced= debounce(this.doRegenData,250);
@@ -418,14 +418,14 @@ class PhaseFoldingChart extends PureComponent {
             `${this.lastFluxCol} = ${lastData[pointNumber][1]} mag <br>` +
             '</span>';
 
-            this.setState( { dataUpdate: { text : str }, doingResize:false } );
+            this.setState( { dataUpdate: { text : str }} );
         });
 
     }
 
 
     render() {
-        const {dataUpdate, doingResize} = this.state;
+        const {dataUpdate} = this.state;
         const {plotlyData, plotlyDivStyle, plotlyLayout}= this.chartingInfo;
 
         return (
@@ -433,7 +433,8 @@ class PhaseFoldingChart extends PureComponent {
                        onResize={this.onResize}>
                 <PlotlyWrapper data={plotlyData} layout={plotlyLayout}  style={plotlyDivStyle}
                                dataUpdate={dataUpdate}
-                               handleRenderAsResize={doingResize}
+                               autoSizePlot={true}
+                               autoDetectResizing={true}
                                divUpdateCB={(div) => this.chart= div}
                                newPlotCB={this.afterRedraw}
                 />


### PR DESCRIPTION
DM-10543: improved plotly performance during resize and add masking 

   - react component not has properties to control how it renders during resize
   - react component will now mask during slower work
   - moved all the resize debouncing to the PlotlyWrapper, Firefox is debounced more
   - LcPeriodPlotly will debounce the regen data for Firefox