### PR TITLE
DM-9254 Make Firefly to work on Windows browser IE11

### DIFF
--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -4,7 +4,6 @@
 
 
 import {get} from 'lodash';
-
 import {firefly, Templates} from './Firefly.js';
 import {HELP_LOAD} from './core/AppDataCntlr.js';
 

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -3,8 +3,7 @@
  */
 /*global __$version_tag*/
 
-
-// import 'babel-polyfill';
+import 'babel-polyfill';
 import 'isomorphic-fetch';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/firefly/js/util/BrowserInfo.js
+++ b/src/firefly/js/util/BrowserInfo.js
@@ -188,7 +188,7 @@ function evaluateBrowser(ua,p) {
             retValue.majorV= 6;
         }
     }
-    else if (ua.includes('trident') && !ua.contains('edge')) {
+    else if (ua.includes('trident') && !ua.includes('edge')) {
         retValue= parseVersion(ua,IE_11_KEY);
         retValue.browser= Browser.IE;
     }else if (ua.includes('edge')) {


### PR DESCRIPTION
This development: 
-  import 'babel-polyfill' in Firefly.js to fix the fallback of some string functions on IE11. 

Test, 
you may install Windows on your Mac using VirtualBox to run IE11. You need, 
- Oracle VirtualBox(with extensions), 
   https://www.virtualbox.org/
- Windows 10 ISO 
   https://www.microsoft.com/en-us/software-download/windows10ISO

To do:
- download VirtualBox (and extensions), and create virtual machine with Windows 10. 
   (if you need more detail about installation, please let me know). 
- Starts IE11 from the created virtual machine and launch Firefly by using "http://10.0.2.2/firefly" (this is relevant to Firefly from your local machine, localhost:8080/firefly)

