### PR TITLE
DM-7192: Fixed:  image of the coverage is gone after expand mode

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
@@ -92,7 +92,7 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
                 }
                 throw new DataAccessException("Service Error");
             }
-            else if (retval.getResponseCode()>400) {
+            else if (retval.getResponseCode()>305) {
                 throw new DataAccessException(retval.getResponseCodeMsg());
             }
         } catch (FailedRequestException e) {

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -549,7 +549,7 @@ function handleTableActive(layoutInfo, action) {
 
     if (isImageEnabledTable(tbl_id)) {
         layoutInfo = updateSet(layoutInfo, 'images.activeTableId', tbl_id);
-        clearLcImages();
+        // clearLcImages();
         layoutInfo = setupImages(layoutInfo);
     }
 

--- a/src/firefly/js/visualize/iv/CanvasTileDrawer.js
+++ b/src/firefly/js/visualize/iv/CanvasTileDrawer.js
@@ -166,16 +166,6 @@ function makeDrawer(plotView, plot, targetCanvas, totalCnt, loadedImages,
             }
             else tileData=src;
 
-            if (!beginRender && opacity===1) {
-                beginRender= true;
-                const intervalId= setTimeout( () => {
-                    if (!abortRender && !renderComplete)  {
-                        clearTimeout(intervalId);
-                    }
-                }, 100);
-            }
-
-
             const p = retrieveAndProcessImage(tileData, tileAttributes, shouldProcess, processor);
             p.then((imageData) => {
                 loadedImages.cachedImageData[tileIdx] = clone(loadedImages.serverData[tileIdx],
@@ -202,7 +192,7 @@ function makeDrawer(plotView, plot, targetCanvas, totalCnt, loadedImages,
 
         abort()  {
             abortRender = true;
-            if (opacity===1) renderImage();
+            if (opacity===1 && !renderComplete) renderImage();
         }
     };
 }

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -75,7 +75,6 @@ export function reducer(state, action) {
             retState= endServerCallFail(state,action);
             break;
 
-        case Cntlr.ROTATE  :
         case Cntlr.CROP:
             retState= addPlot(state,action, false, false);
             break;


### PR DESCRIPTION
DM-7192: Fixed: User image of the coverage is gone after expand mode

Also includes:
 - Bug fix: if a zoom ends after a replot then abort the zoom, also apply to color and stretch change
 - A little code clean up and documentation

_Original Bug explanation:_

Do a catalog search, then do an image search to replace coverage image by another image (say WISE), then go in expand mode and back, the image is replaced back to the initial coverage image

_Fix:_

After expanded mode the user image should still be there.