### PR TITLE
DM-10831 Histogram multi-trace chart

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-charttest.html
+++ b/src/firefly/html/demo/ffapi-highlevel-charttest.html
@@ -91,32 +91,34 @@
 //             **/
 //            firefly.util.renderDOM('histogramHere', firefly.ui.Histogram, props);
 
-            var dataH = [{marker: {color: '#993399'},opacity: 0.8},
-                          {marker: {color: '#669900'},opacity: 0.7}];
+            var dataH = [
+                {name: 'dec-0.02', marker: {color: 'rgba(153, 51, 153, 0.8)'}},
+                {name: 'dec+0.02', marker: {color: 'rgba(102,153,0, 0.7)'}}
+            ];
 
-             var fireflyDataH = [
-                 {
-                     dataType: 'fireflyHistogram',
-                     tbl_id: 'test-tbl',
-                     options: {
-                         algorithm: 'fixedSizeBins',
-                         fixedBinSizeSelection: 'numBins',
-                         numBins: 30,
-                         columnOrExpr: 'dec'
-                     }
-                 },
-                 {
-                     dataType: 'fireflyHistogram',
-                     tbl_id: 'test-tbl',
-                     options: {
-                         algorithm: 'fixedSizeBins',
-                         fixedBinSizeSelection: 'numBins',
-                         numBins: 40,
-                         columnOrExpr: 'dec-0.05'   // same column but shifted
-                     }
-                 }
-             ];
-             firefly.showPlot('histogramHere', {chartId: 'firefly-hist-tbl', chartType: 'plot.ly', data: dataH, fireflyData: fireflyDataH});
+            var fireflyDataH = [
+                {
+                    dataType: 'fireflyHistogram',
+                    tbl_id: 'test-tbl',
+                    options: {
+                        algorithm: 'fixedSizeBins',
+                        fixedBinSizeSelection: 'numBins',
+                        numBins: 30,
+                        columnOrExpr: 'dec-0.02'
+                    }
+                },
+                {
+                    dataType: 'fireflyHistogram',
+                    tbl_id: 'test-tbl',
+                    options: {
+                        algorithm: 'fixedSizeBins',
+                        fixedBinSizeSelection: 'numBins',
+                        numBins: 40,
+                        columnOrExpr: 'dec+0.02'   // same column but shifted
+                    }
+                }
+            ];
+            firefly.showPlot('histogramHere', {chartId: 'firefly-hist-tbl', chartType: 'plot.ly', data: dataH, fireflyData: fireflyDataH});
 
 
             // show scatter chart

--- a/src/firefly/html/demo/ffapi-highlevel-charttest.html
+++ b/src/firefly/html/demo/ffapi-highlevel-charttest.html
@@ -40,56 +40,84 @@
     {
         onFireflyLoaded= function(firefly) {
 
-            // show histogram data  no options, no connection to the table)
-            // data is an array of rows,
-            // first col - nPoints or number of points in the bin, second col - binMin, third col - binMax
-            // (supports variable length bins)
-            // define overlapping histograms in series array
-            const props = {
-                series: [
-                    {data : [
-                        [1,1,10],
-                        [10,10,100],
-                        [100,100,1000],
-                        [1000,1000,10000],
-                        [100,10000,100000],
-                        [10,100000,1000000],
-                        [1,1000000,10000000]],
-                        binColor:'#336699',
-                        name:'sample1'},
-                    {data : [
-                        [6, 50,150],
-                        [80,150,1200],
-                        [15,1200,30400]],
-                        binColor:'#CB3515',
-                        name:'sample2'}
-                ],
-                width: 800,
-                height: 550,
-                logs: 'xy',
-                desc: 'Both X and Y are using log scale'
-            };
+//            // show histogram data  no options, no connection to the table)
+//            // data is an array of rows,
+//            // first col - nPoints or number of points in the bin, second col - binMin, third col - binMax
+//            // (supports variable length bins)
+//            // define overlapping histograms in series array
+//            const props = {
+//                series: [
+//                    {data : [
+//                        [1,1,10],
+//                        [10,10,100],
+//                        [100,100,1000],
+//                        [1000,1000,10000],
+//                        [100,10000,100000],
+//                        [10,100000,1000000],
+//                        [1,1000000,10000000]],
+//                        binColor:'#336699',
+//                        name:'sample1'},
+//                    {data : [
+//                        [6, 50,150],
+//                        [80,150,1200],
+//                        [15,1200,30400]],
+//                        binColor:'#CB3515',
+//                        name:'sample2'}
+//                ],
+//                width: 800,
+//                height: 550,
+//                logs: 'xy',
+//                desc: 'Both X and Y are using log scale'
+//            };
+//
+//            /**
+//             // one histogram
+//             const props = {
+//                data : [
+//                 [1,1,10],
+//                 [10,10,100],
+//                 [100,100,1000],
+//                 [1000,1000,10000],
+//                 [100,10000,100000],
+//                 [10,100000,1000000],
+//                 [1,1000000,10000000]
+//                 ],
+//                width: 800,
+//                height: 550,
+//                logs: 'xy',
+//                desc: 'Both X and Y are using log scale',
+//                binColor: '#336699'
+//             };
+//             **/
+//            firefly.util.renderDOM('histogramHere', firefly.ui.Histogram, props);
 
-            /**
-             // one histogram
-             const props = {
-                data : [
-                 [1,1,10],
-                 [10,10,100],
-                 [100,100,1000],
-                 [1000,1000,10000],
-                 [100,10000,100000],
-                 [10,100000,1000000],
-                 [1,1000000,10000000]
-                 ],
-                width: 800,
-                height: 550,
-                logs: 'xy',
-                desc: 'Both X and Y are using log scale',
-                binColor: '#336699'
-             };
-             **/
-            firefly.util.renderDOM('histogramHere', firefly.ui.Histogram, props);
+            var dataH = [{marker: {color: '#993399'},opacity: 0.8},
+                          {marker: {color: '#669900'},opacity: 0.7}];
+
+             var fireflyDataH = [
+                 {
+                     dataType: 'fireflyHistogram',
+                     tbl_id: 'test-tbl',
+                     options: {
+                         algorithm: 'fixedSizeBins',
+                         fixedBinSizeSelection: 'numBins',
+                         numBins: 30,
+                         columnOrExpr: 'dec'
+                     }
+                 },
+                 {
+                     dataType: 'fireflyHistogram',
+                     tbl_id: 'test-tbl',
+                     options: {
+                         algorithm: 'fixedSizeBins',
+                         fixedBinSizeSelection: 'numBins',
+                         numBins: 40,
+                         columnOrExpr: 'dec-0.05'   // same column but shifted
+                     }
+                 }
+             ];
+             firefly.showPlot('histogramHere', {chartId: 'firefly-hist-tbl', chartType: 'plot.ly', data: dataH, fireflyData: fireflyDataH});
+
 
             // show scatter chart
             firefly.debug= true;
@@ -135,11 +163,10 @@
                 x: "tables::test-tbl,ra",
                 y: "tables::test-tbl,dec",
                 mode: 'markers',
-                type: 'scatter',
-                firefly: {dataType: 'fireflyScatter'}
+                type: 'scatter'
             };
 
-            firefly.showPlot('plotly', {chartId: 'plotly-tbl', chartType: 'plot.ly', data: [trace1]});
+            firefly.showPlot('plotly', {chartId: 'plotly-tbl', chartType: 'plot.ly', data: [trace1], fireflyData: {dataType: 'fireflyScatter'}});
 
         }
     }

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -20,7 +20,7 @@ import {logError, flattenObject} from '../util/WebUtil.js';
 import {UI_PREFIX} from './ChartsCntlr.js';
 import {ScatterOptions} from './ui/options/ScatterOptions.jsx';
 import {FireflyHistogramOptions} from './ui/options/FireflyHistogramOptions.jsx';
-import {HistogramOptions} from './ui/options/HistogramOptions.jsx';
+import {HistogramOptions} from './ui/options/PlotlyHistogramOptions.jsx';
 import {BasicOptions} from './ui/options/BasicOptions.jsx';
 import {ScatterToolbar, BasicToolbar} from './ui/PlotlyToolbar';
 import {SelectInfo} from '../tables/SelectInfo.js';
@@ -516,7 +516,7 @@ export function applyDefaults(chartData={}) {
         },
         xaxis: {
             autorange:true,
-            gridLineWidth: 1,
+            showgrid: false,
             lineColor: '#e9e9e9',
             tickwidth: 1,
             ticklen: 5,
@@ -531,7 +531,7 @@ export function applyDefaults(chartData={}) {
         },
         yaxis: {
             autorange:true,
-            gridLineWidth: 1,
+            showgrid: true,
             lineColor: '#e9e9e9',
             tickwidth: 1,
             ticklen: 5,

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -19,10 +19,13 @@ import {Expression} from '../util/expr/Expression.js';
 import {logError, flattenObject} from '../util/WebUtil.js';
 import {UI_PREFIX} from './ChartsCntlr.js';
 import {ScatterOptions} from './ui/options/ScatterOptions.jsx';
+import {FireflyHistogramOptions} from './ui/options/FireflyHistogramOptions.jsx';
+import {HistogramOptions} from './ui/options/HistogramOptions.jsx';
 import {BasicOptions} from './ui/options/BasicOptions.jsx';
 import {ScatterToolbar, BasicToolbar} from './ui/PlotlyToolbar';
 import {SelectInfo} from '../tables/SelectInfo.js';
 import {getTraceTSEntries as scatterTSGetter} from './dataTypes/FireflyScatter.js';
+import {getTraceTSEntries as histogramTSGetter} from './dataTypes/FireflyHistogram.js';
 
 export const SCATTER = 'scatter';
 export const HISTOGRAM = 'histogram';
@@ -272,18 +275,22 @@ export function getPointIdx(traceData, rowIdx) {
 
 export function getOptionsUI(chartId) {
     // based on chartData, determine what options to display
-    const {data, activeTrace=0} = getChartData(chartId);
+    const {data, fireflyData, activeTrace=0} = getChartData(chartId);
     const type = get(data, [activeTrace, 'type'], 'scatter');
-    switch (type) {
-        case 'scatter':
-            return ScatterOptions;
-        default:
-            return BasicOptions;
+    const dataType = get(fireflyData, [activeTrace, 'dataType'], '');
+    if (type === 'scatter') {
+        return ScatterOptions;
+    } else if (type === 'histogram') {
+        return HistogramOptions;
+    } else if (dataType === 'fireflyHistogram') {
+            return FireflyHistogramOptions;
+    } else {
+        return BasicOptions;
     }
 }
 
 export function getToolbarUI(chartId, activeTrace=0) {
-    const {data} =  getChartData(chartId);
+    const {data, fireflyData} =  getChartData(chartId);
     const type = get(data, [activeTrace, 'type'], '');
     if (type === 'scatter') {
         return ScatterToolbar;
@@ -331,8 +338,8 @@ export function newTraceFrom(data, selIndexes, newTraceProps) {
  * @param {string} p.chartId
  * @param {object[]} p.data
  */
-export function handleTableSourceConnections({chartId, data}) {
-    var tablesources = makeTableSources(data);
+export function handleTableSourceConnections({chartId, data, fireflyData}) {
+    var tablesources = makeTableSources(chartId, data, fireflyData);
     var oldTablesources = get(getChartData(chartId), 'tablesources',[]);
 
     const hasTablesources = Array.isArray(tablesources) && tablesources.find((ts) => !isEmpty(ts));
@@ -345,11 +352,6 @@ export function handleTableSourceConnections({chartId, data}) {
         if (isEmpty(traceTS)) {
             tablesources[idx] = oldTraceTS;     // if no updates.. move the previous one into the new tablesources
         } else {
-
-            // setup trace table source object to be able to handle chart data
-            const traceSpecificEntries = getTraceTSEntries(traceTS, chartId, idx);
-            Object.assign(traceTS, traceSpecificEntries);
-
             if (!tablesourcesEqual(traceTS, oldTraceTS)) {
                 const {tbl_id} = traceTS;
 
@@ -407,7 +409,7 @@ function updateChartData(chartId, traceNum, tablesource, action={}) {
 
         // fetch data
         if (tablesource.fetchData) {
-            tablesource.fetchData();
+            tablesource.fetchData(chartId, traceNum, tablesource);
         } else {
             // default behavior
             const {request, highlightedRow, selectInfo={}} = tableModel || {};
@@ -455,7 +457,7 @@ export function getDataChangesForMappings({tableModel, mappings, traceNum}) {
     return changes;
 }
 
-function makeTableSources(data=[]) {
+function makeTableSources(chartId, data=[], fireflyData=[]) {
 
     const convertToDS = (flattenData) =>
                         Object.entries(flattenData)
@@ -467,32 +469,46 @@ function makeTableSources(data=[]) {
                                     return p;
                                 }, {});
 
-    return data.map((d) => {
-        const ds = convertToDS(flattenObject(d, isPlainObject)); //avoid flattening arrays
+
+    // for some firefly specific chart types the data are
+    const currentData = (data.length < fireflyData.length) ? fireflyData : data;
+
+    return currentData.map((d, traceNum) => {
+        const ds = data[traceNum] ? convertToDS(flattenObject(data[traceNum], isPlainObject)) : {}; //avoid flattening arrays
+        if (!ds.tbl_id) {
+            // table id can be a part of fireflyData
+            const tbl_id = get(fireflyData, `${traceNum}.tbl_id`);
+            if (tbl_id) ds.tbl_id = tbl_id;
+        }
+        // we use tblFilePath to see if the table has changed (sorted, filtered, etc.)
         if (ds.tbl_id) {
             const tableModel = getTblById(ds.tbl_id);
             ds.tblFilePath = get(tableModel, 'tableMeta.tblFilePath');
+        }
+        // set up table server request parameters (options) for firefly specific charts
+        const chartDataType = get(fireflyData[traceNum], 'dataType');
+        if (chartDataType) {
+            Object.assign(ds, getTraceTSEntries({chartDataType, traceTS: ds, chartId, traceNum}));
         }
         return ds;
     });
 }
 
-export function getTraceTSEntries(traceTS, chartId, traceNum) {
-    const {data} = getChartData(chartId) || {};
-    const chartDataType = get(data[traceNum], 'firefly.dataType');
-    if (!chartDataType) {
-        // default behavior
+function getTraceTSEntries({chartDataType, traceTS, chartId, traceNum}) {
+    if (chartDataType === 'fireflyScatter') {
+        return scatterTSGetter({traceTS, chartId, traceNum});
+    } else if (chartDataType === 'fireflyHistogram') {
+            return histogramTSGetter({traceTS, chartId, traceNum});
+    } else {
         return {};
-    } else if (chartDataType === 'fireflyScatter') {
-        return scatterTSGetter(traceTS, chartId, traceNum);
     }
 }
 
-
+// does the default depend on the chart type?
 export function applyDefaults(chartData={}) {
     const defaultLayout = {
         hovermode: 'closest',
-        dragmode: 'select',
+        dragmode: 'zoom',
         legend: {
             font: {size: FSIZE},
             orientation: 'v',

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -310,13 +310,13 @@ export function makeChartDataFetch (getChartDataType) {
 
 function chartAdd(action) {
     return (dispatch) => {
-        const {chartId, chartType, viewerId='main', data} = action.payload;
+        const {chartId, chartType, viewerId='main', data, fireflyData} = action.payload;
         clearChartConn({chartId});
         dispatch(action);
         if (chartType === 'plot.ly') {
             dispatchAddViewer(viewerId,true,'plot2d',true);
             dispatchAddViewerItems(viewerId, [chartId], 'plot2d');
-            handleTableSourceConnections({chartId, data});
+            handleTableSourceConnections({chartId, data, fireflyData});
         }
     };
 }
@@ -330,10 +330,10 @@ function chartUpdate(action) {
         dispatch(action);
 
 
-        const {data} = Object.entries(changes)
-                             .filter(([k,v]) => k.startsWith('data'))
+        const {data, fireflyData} = Object.entries(changes)
+                             .filter(([k,v]) => (k.startsWith('data') || k.startsWith('fireflyData')))
                              .reduce( (p, [k,v]) => set(p, k, v), {}); // take all of the data changes and create an object from it.
-        handleTableSourceConnections({chartId, data});
+        handleTableSourceConnections({chartId, data, fireflyData});
     };
 }
 
@@ -439,7 +439,10 @@ function setActiveTrace(action) {
             }
             highlighted = newTraceFrom(data[activeTrace], [getPointIdx(data[activeTrace], highlightedRow)], HIGHLIGHTED_PROPS);
         }
-        dispatchChartUpdate({chartId, changes:{activeTrace, selected, highlighted, selection: undefined}});
+        const changes = {activeTrace, selected, highlighted, selection: undefined};
+        // every chart supports zoom, only scatter has actions for selection
+        changes['layout.dragmode'] = 'zoom';
+        dispatchChartUpdate({chartId, changes});
     };
 }
 

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -440,8 +440,6 @@ function setActiveTrace(action) {
             highlighted = newTraceFrom(data[activeTrace], [getPointIdx(data[activeTrace], highlightedRow)], HIGHLIGHTED_PROPS);
         }
         const changes = {activeTrace, selected, highlighted, selection: undefined};
-        // every chart supports zoom, only scatter has actions for selection
-        changes['layout.dragmode'] = 'zoom';
         dispatchChartUpdate({chartId, changes});
     };
 }

--- a/src/firefly/js/charts/dataTypes/FireflyHistogram.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHistogram.js
@@ -1,0 +1,228 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {get, isArray} from 'lodash';
+import {logError} from '../../util/WebUtil.js';
+import {getTblById, cloneRequest, doFetchTable, makeTblRequest, MAX_ROW} from '../../tables/TableUtil.js';
+import {dispatchChartUpdate, getChartData} from '../ChartsCntlr.js';
+
+import {toMaxFixed} from '../../util/MathUtil.js';
+import Color from '../../util/Color.js';
+
+const HIST_DEC = 6;
+const A = 0.85;
+
+/**
+ * This function creates table source entries to get aggregated firefly histogram data from the server
+ * @param p
+ * @param p.traceTS
+ * @param p.chartId
+ * @param p.traceNum
+ * @returns {{options: {}, fetchData: fetchData}}
+ */
+export function getTraceTSEntries({chartId, traceNum}) {
+
+    const options = {};
+
+    // histogram parameters
+    const {fireflyData} = getChartData(chartId) || {};
+    const histogramParams = get(fireflyData, `${traceNum}.options`);
+    options['columnExpression'] = histogramParams.columnOrExpr;
+    if (histogramParams.x && histogramParams.x.includes('log')) {
+        options.columnExpression = 'log('+histogramParams.columnOrExpr+')';
+    }
+    if (histogramParams.fixedBinSizeSelection) { // fixed size bins
+        options.fixedBinSizeSelection=histogramParams.fixedBinSizeSelection;
+        if (histogramParams.fixedBinSizeSelection==='numBins'){
+            options.binSize =  histogramParams.numBins;
+        }else{
+            options.binSize =  histogramParams.binWidth;
+        }
+    }
+    if (histogramParams.falsePositiveRate) {  // variable size bins using Bayesian Blocks
+        options.falsePositiveRate = histogramParams.falsePositiveRate;
+    }
+    if (histogramParams.minCutoff) {
+        options.min = histogramParams.minCutoff;
+    }
+    if (histogramParams.maxCutoff) {
+        options.max = histogramParams.maxCutoff;
+    }
+
+    return {options, fetchData};
+}
+
+function fetchData(chartId, traceNum, tablesource) {
+    const {tbl_id, options} = tablesource;
+
+    const tableModel = getTblById(tbl_id);
+    const {request} = tableModel;
+    const sreq = cloneRequest(request, {'startIdx': 0, 'pageSize': MAX_ROW});
+
+    const req = makeTblRequest('HistogramProcessor');
+    req.searchRequest = JSON.stringify(sreq);
+    Object.entries(options).forEach(([k,v]) => req[k] = v);
+
+
+    doFetchTable(req).then(
+        (tableModel) => {
+
+            let histogramData = [];
+            if (tableModel.tableData && tableModel.tableData.data) {
+                // if logarithmic values were requested, convert the returned exponents back
+                var toNumber = get(options, 'x', '').includes('log') ?
+                    (val, i)=> {
+                        // first col is n, next two are the boundaries of the bin
+                        return (i === 0) ? Number(val) : Math.pow(10, Number(val));
+                    } : (val)=>Number(val);
+                var nrow, lastIdx;
+                histogramData = tableModel.tableData.data.reduce((data, arow, i) => {
+                    nrow = arow.map(toNumber);
+                    lastIdx = data.length - 1;
+                    if (i > 0 && data[lastIdx][1] === nrow[1]) {
+                        //collapse bins when two bins are the same because of precision loss
+                        // (ex. large long on server side truncated to float)
+                        data[lastIdx] = [data[lastIdx][0] + nrow[0], data[lastIdx][1], nrow[2]];
+                    } else {
+                        data.push(nrow);
+                    }
+                    return data;
+                }, []);
+
+            }
+            const {data} = getChartData(chartId);
+            let binColor = get(data, `${traceNum}.marker.color`);
+            if (isArray(binColor)) binColor = binColor[0];
+            const changes = getChanges({histogramData, binColor, traceNum});
+            dispatchChartUpdate({chartId, changes});
+        }
+    ).catch(
+        (reason) => {
+            console.error(`Failed to fetch histogram data for ${chartId} trace ${traceNum}: ${reason}`);
+        }
+    );
+}
+
+
+function getChanges({histogramData, binColor, traceNum}) {
+    var {x, y, binWidth, color, text, colorScale, borderColor} = createXY(histogramData, binColor);
+    const changes = {};
+    changes[`data.${traceNum}.type`] = 'bar'; // using bar chart to display firefly histogram
+    changes[`data.${traceNum}.x`] = x;
+    changes[`data.${traceNum}.y`] = y;
+    changes[`data.${traceNum}.width`] = binWidth;
+    changes[`data.${traceNum}.marker.color`] = color;
+    changes[`data.${traceNum}.marker.colorscale`] = colorScale;
+    changes[`data.${traceNum}.marker.line`] = {width: 1, color: borderColor};
+    changes[`data.${traceNum}.text`] = text;
+    changes[`data.${traceNum}.hoverinfo`] = 'text';
+    return changes;
+}
+
+/*
+ * Expecting an 2 dimensional array of numbers
+ * each row is an array of 3 values:
+ * [0] number of points in a bin,
+ * [1] minimum of a bin
+ * [2] maximum of a bin
+ */
+function validateData(histogramData, logScale) {
+    if (!histogramData) { return false; }
+    let valid = true;
+    try {
+        histogramData.sort(function(row1, row2){
+            // [1] is minimum bin edge
+            return row1[1]-row2[1];
+        });
+        if (histogramData) {
+            for (var i = 0; i < histogramData.length; i++) {
+                if (histogramData[i].length !== 3) {
+                    logError(`Invalid histogram data in row ${i} [${histogramData[i]}]`);
+                    valid = false;
+                } else if (histogramData[i][1]>histogramData[i][2]) {
+                    logError(`Histogram data row ${i}: minimum is more than maximum. [${histogramData[i]}]`);
+                    valid=false;
+                } else if (histogramData[i+1] && Math.abs(histogramData[i][2]-histogramData[i+1][1])>1000*Number.EPSILON &&
+                    histogramData[i][2]>histogramData[i+1][1]) {
+                    logError(`Histogram data row ${i}: bin range overlaps the following row. [${histogramData[i]}]`);
+                    valid=false;
+                } else if (histogramData[i][0] < 0) {
+                    logError(`Histogram data row ${i} count is less than zero, ${histogramData[i][0]}`);
+                    valid=false;
+                }
+            }
+            if (logScale && histogramData[0][1]<=0) {
+                logError('Unable to plot histogram: zero or subzero values on logarithmic scale');
+                valid = false;
+            }
+        }
+    } catch (e) {
+        logError(`Invalid data passed to Histogram: ${e}`);
+        valid = false;
+    }
+    return valid;
+}
+
+function createXY(data, binColor) { // removed '#d1d1d1' to use default colors
+    var  emptyData = {
+        x: [], y: [], text:[], borderColor: '',  binWidth: [], color: [], colorScale: []
+    };
+
+    if (!validateData(data)) {
+        emptyData.valid = false;
+        return emptyData;
+    } else {
+        emptyData.valid = true;
+    }
+
+    //const getRGBAStr = (rgbStr, a) => {
+    //    return Color.toRGBAString(Color.toRGBA(rgbStr.slice(1), a));
+    //};
+
+    //const lightColor = getRGBAStr(Color.shadeColor(binColor, 0.2), A);
+    emptyData.color = binColor; // for multiple traces changing alternating colors are confusing
+    emptyData.borderColor = binColor && binColor === '#000000' ? Color.shadeColor(binColor, 0.5) : 'black';
+    //emptyData.colorScale = [[0, getRGBAStr(binColor, A)], [1, lightColor]];
+
+    // compute bin width for the bin has the same xMin & xMan
+    var startW = data[data.length-1][2] - data[0][1];
+    if (startW === 0.0) startW = 1.0;
+
+    var   minWidth = data.find((row) => {return row[1]===row[2];}) ?
+                        data.reduce((prev, d) => {
+                            if (d[1] !== d[2]) {
+                                const dist = (d[2] - d[1])/2;
+
+                                if (dist < prev) {
+                                    prev = dist;
+                                }
+                            }
+                            return prev;
+                        }, startW*0.02) : 1.0;
+
+    var lastX = data[0][1]-1.0;
+    //var prevColor = 0;
+
+    var addBin = (xySeries, x1, x2, y) => {
+        const xVal = (x1 + x2) / 2;
+
+        xySeries.x.push(xVal);
+        xySeries.y.push(y);
+        xySeries.binWidth.push(x1 === x2 ? minWidth: x2-x1);
+
+        //prevColor = (x1 <= lastX) ? (prevColor+1)%2 : 0;  // when two bars are next to each other, color is changed
+        //xySeries.color.push(prevColor);
+
+        xySeries.text.push(
+            `<span> ${x1 !== x2 ? '<b>Bin center: </b>' + toMaxFixed(xVal, HIST_DEC) + '<br>' : ''}` +
+            `${x1 !== x2 ? '<b>Range: </b>' + toMaxFixed(x1, HIST_DEC) + ' to ' + toMaxFixed(x2, HIST_DEC) + '<br>' : ''}` +
+            `<b>Count:</b> ${y}</span>`);
+
+        lastX = x2;
+    };
+
+    return data.reduce((xy, oneData) => {
+        addBin(xy, oneData[1], oneData[2], oneData[0]);
+        return xy;
+    }, emptyData);
+}

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -238,11 +238,11 @@ export class ChartPanel extends PureComponent {
         const {chartId} = this.props;
         const chartData =  ChartsCntlr.getChartData(chartId) || {};
         if (chartData) {
-            const {chartType, showOptions, optionsKey} = chartData;
+            const {chartType, activeTrace, showOptions, optionsKey} = chartData;
             //if (chartType === 'plot.ly') return {};
             const {Chart,Options,Toolbar,getChartProperties,updateOnStoreChange} = reduxFlux.getChartType(chartType);
             return {
-                chartId, showOptions, optionsKey, ...getChartProperties(chartId),
+                chartId, activeTrace, showOptions, optionsKey, ...getChartProperties(chartId),
                 Chart,
                 Options,
                 Toolbar,

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -236,7 +236,7 @@ export class ChartPanel extends PureComponent {
 
     getNextState() {
         const {chartId} = this.props;
-        const chartData =  ChartsCntlr.getChartData(chartId) || {};
+        const chartData =  ChartsCntlr.getChartData(chartId);
         if (chartData) {
             const {chartType, activeTrace, showOptions, optionsKey} = chartData;
             //if (chartType === 'plot.ly') return {};
@@ -259,7 +259,7 @@ export class ChartPanel extends PureComponent {
             if (!updateOnStoreChange || updateOnStoreChange(this.state)) {
                     this.setState(this.getNextState());
             }  else {
-                const {showOptions, optionsKey} = ChartsCntlr.getChartData(this.props.chartId);
+                const {showOptions, optionsKey} = ChartsCntlr.getChartData(this.props.chartId) || {};
                 if (showOptions !== this.state.showOptions || optionsKey !== this.state.optionsKey) {
                     this.setState({showOptions, optionsKey});
                 }

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
-import {get, defer, isEmpty} from 'lodash';
+import {get, isEmpty} from 'lodash';
 import ColValuesStatistics from './../ColValuesStatistics.js';
 import {DATATYPE_HISTOGRAM} from '../dataTypes/HistogramCDT.js';
 import CompleteButton from '../../ui/CompleteButton.jsx';
@@ -214,9 +214,11 @@ export class HistogramOptions extends Component {
             }
             dispatchValueChange(payload);
             if (histogramParams) {
-                defer(setOptions, groupKey, histogramParams);
+                setOptions(groupKey, histogramParams);
+                //defer(setOptions, groupKey, histogramParams);
             }
         }
+
 
         this.iAmMounted= true;
     }
@@ -314,10 +316,9 @@ export class HistogramOptions extends Component {
                             <button type='button' className='button std' onClick={() => setOptions(groupKey, defaultParams)}>Reset</button>
                         </div>
                     </div>}
-                    {basicFields}
                     <ColumnOrExpression {...xProps}/>
 
-                    <FieldGroupCollapsible  header='Options'
+                    {!basicFields && <FieldGroupCollapsible  header='Options'
                                             initialState= {{ value:'closed' }}
                                             fieldKey='plotoptions'>
                         <InputGroup labelWidth={20}>
@@ -348,7 +349,7 @@ export class HistogramOptions extends Component {
                                 fieldKey='y'
                             />
                         </InputGroup>
-                    </FieldGroupCollapsible>
+                    </FieldGroupCollapsible>}
                     <br/>
                     <InputGroup labelWidth={60}>
                         <RadioGroupInputField
@@ -365,6 +366,8 @@ export class HistogramOptions extends Component {
                     <br/>
                     {this.renderAlgorithmParameters()}
                     <br/>
+                    {basicFields && <br/>}
+                    {basicFields}
                 </FieldGroup>
 
             </div>

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -33,8 +33,8 @@ export class PlotlyChartArea extends PureComponent {
 
     getNextState() {
         const {chartId} = this.props;
-        const {data, highlighted, layout, selected} = getChartData(chartId);
-        return  {data, highlighted, selected, layout};
+        const {data, highlighted, layout, selected, activeTrace} = getChartData(chartId);
+        return  {data, highlighted, selected, layout, activeTrace};
     }
 
     storeUpdate() {
@@ -54,13 +54,16 @@ export class PlotlyChartArea extends PureComponent {
 
     render() {
         const {widthPx, heightPx} = this.props;
-        const {data=[], highlighted, selected, layout={}} = this.state;
+        const {data=[], highlighted, selected, layout={}, activeTrace=0} = this.state;
         const doingResize= (layout && (layout.width!==widthPx || layout.height!==heightPx));
         const showlegend = data.length > 1;
         let pdata = data;
         // TODO: change highlight or selected without forcing new plot
-        pdata = selected ? pdata.concat([selected]) : pdata;
-        pdata = highlighted ? pdata.concat([highlighted]) : pdata;
+        if (!data[activeTrace] || get(data[activeTrace], 'type') === 'scatter') {
+            // highlight makes sence only for scatter at the moment
+            pdata = selected ? pdata.concat([selected]) : pdata;
+            pdata = highlighted ? pdata.concat([highlighted]) : pdata;
+        }
         const playout = Object.assign({showlegend}, layout, {width: widthPx, height: heightPx});
         return (
             <PlotlyWrapper newPlotCB={this.afterRedraw} data={pdata} layout={playout}

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -9,11 +9,12 @@ import {dispatchSetLayoutMode, LO_MODE, LO_VIEW} from '../../core/LayoutCntlr.js
 import {downloadChart} from './PlotlyWrapper.jsx';
 
 function getToolbarStates(chartId) {
-    const {selection, selected, activeTrace=0, tablesources, layout} = getChartData(chartId);
+    const {selection, selected, activeTrace=0, tablesources, layout, data={}} = getChartData(chartId);
     const {tbl_id} = get(tablesources, [activeTrace], {});
     const hasFilter = tbl_id && !isEmpty(get(getTblById(tbl_id), 'request.filters'));
     const hasSelection = !isEmpty(selection);
-    return {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected: !!selected, dragmode: get(layout, 'dragmode')};
+    const traceNames = data.map((t) => t.name).toString();
+    return {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected: !!selected, dragmode: get(layout, 'dragmode'), traceNames};
 }
 
 export class ScatterToolbar extends SimpleComponent {

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -175,7 +175,7 @@ function ExpandBtn({style={}, chartId}) {
 function ActiveTraceSelect({style={}, chartId, activeTrace}) {
     const {data} = getChartData(chartId) || [];
     const selected = get(data, [activeTrace, 'name']) || `trace ${activeTrace}`;
-    if (data.length < 2) return null;
+    if (!data || data.length < 2) return null;
 
     return (
         <div style={{width:100, height:20, ...style}} className='styled-select semi-square'>

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -7,7 +7,7 @@ import {ValidationField} from '../../../ui/ValidationField.jsx';
 import CompleteButton from '../../../ui/CompleteButton.jsx';
 import {NewTracePanelBtn} from './NewTracePanel.jsx';
 import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
-
+import Validate from '../../../util/Validate.js';
 
 const fieldProps = {labelWidth: 62, size: 15};
 
@@ -47,43 +47,51 @@ export function basicFieldReducer({data, layout, activeTrace, tablesources}) {
             value: get(layout, 'title'),
             tooltip: 'Plot title',
             label : 'Plot Title:',
-            ...fieldProps,
+            ...fieldProps
         },
         [`data.${activeTrace}.name`]: {
             fieldKey: `data.${activeTrace}.name`,
             value: get(data, `${activeTrace}.name`, 'trace ' + activeTrace),
             tooltip: 'The name of this new series',
             label : 'Series name:',
-            ...fieldProps,
+            ...fieldProps
         },
         [`data.${activeTrace}.marker.color`]: {
             fieldKey: `data.${activeTrace}.marker.color`,
             value: color,
             tooltip: 'Set series color',
             label : 'Color:',
-            ...fieldProps,
+            ...fieldProps
+        },
+        [`data.${activeTrace}.opacity`]: {
+            fieldKey: `data.${activeTrace}.opacity`,
+            value: get(data, `${activeTrace}.opacity`, ''),
+            validator: Validate.floatRange.bind(null, 0.1, 1.0, 2,'opacity'),
+            tooltip: 'Set trace opacity',
+            label : 'Opacity:',
+            ...fieldProps
         },
         ['layout.showlegend']: {
             fieldKey: 'layout.showlegend',
             value: get(layout, 'showlegend', ''),
             tooltip: 'Show legend',
             label : 'Legend:',
-            ...fieldProps,
+            ...fieldProps
         },
         ['layout.xaxis.title']: {
             fieldKey: 'layout.xaxis.title',
             value: get(layout, 'xaxis.title'),
             tooltip: 'X axis title',
             label : 'Xaxis Title:',
-            ...fieldProps,
+            ...fieldProps
         },
         ['layout.yaxis.title']: {
             fieldKey: 'layout.yaxis.title',
             value: get(layout, 'yaxis.title'),
             tooltip: 'Y axis title',
             label : 'Yaxis Title:',
-            ...fieldProps,
-        },
+            ...fieldProps
+        }
     };
 
     return (inFields, action) => {
@@ -97,16 +105,19 @@ export function basicFieldReducer({data, layout, activeTrace, tablesources}) {
 
 
 export function BasicOptionFields({activeTrace, align='vertical'}) {
+    // TODO: need color input field
     return (
         <div className={`FieldGroup__${align}`}>
             <ValidationField fieldKey={'layout.title'}/>
             <ValidationField fieldKey={`data.${activeTrace}.name`}/>
             <ValidationField fieldKey={`data.${activeTrace}.marker.color`}/>
+            <ValidationField fieldKey={`data.${activeTrace}.opacity`}/>
 {/* checkboxgroup is not working right when there's only 1 .. will add in later
             <CheckboxGroupInputField fieldKey={'layout.showlegend'}/>
 */}
             <ValidationField fieldKey={'layout.xaxis.title'}/>
             <ValidationField fieldKey={'layout.yaxis.title'}/>
+            <br/>
         </div>
     );
 }

--- a/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {get, isUndefined, set, reverse} from 'lodash';
+
+import {BasicOptionFields, OptionTopBar, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
+import {HistogramOptions} from '../HistogramOptions.jsx';
+import {getChartData} from '../../ChartsCntlr.js';
+
+import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
+import {getColValStats} from '../../TableStatsCntlr.js';
+
+export class FireflyHistogramOptions extends SimpleComponent {
+
+    getNextState() {
+        const {chartId} = this.props;
+        const {activeTrace:cActiveTrace} = getChartData(chartId);
+        // activeTrace is passed via property, when used from NewTracePanel
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
+        return {activeTrace};
+    }
+
+    render() {
+        const {chartId} = this.props;
+        const {tablesources, layout, data, activeTrace:cActiveTrace=0} = getChartData(chartId);
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
+        const groupKey = this.props.groupKey || `${chartId}-ffhist-${activeTrace}`;
+        const tablesource = get(tablesources, [cActiveTrace]);
+        const tbl_id = get(tablesource, 'tbl_id');
+        const colValStats = getColValStats(tbl_id);
+
+        const histogramParams = toHistogramOptions(chartId, activeTrace);
+
+        const basicFields = BasicOptionFields({layout, data, activeTrace});
+        const basicFieldsReducer = basicFieldReducer({data, layout, activeTrace, tablesources});
+        return (
+            <div style={{padding:'0 5px 7px'}}>
+                {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChangesFFHistogram}}/>}
+                <HistogramOptions {...{key: activeTrace, groupKey, histogramParams, colValStats, basicFields, basicFieldsReducer}}/>
+            </div>
+        );
+    }
+}
+
+export function submitChangesFFHistogram({chartId, activeTrace, fields, tbl_id}) {
+    const changes = histogramOptionsToChanges(chartId, activeTrace, fields, tbl_id);
+    submitChanges({chartId, fields: changes, tbl_id});
+}
+
+function histogramOptionsToChanges(chartId, activeTrace, fields, tbl_id) {
+    const {layout} = getChartData(chartId);
+    const changes = {};
+    changes[`fireflyData.${activeTrace}.dataType`] = 'fireflyHistogram';
+    changes[`fireflyData.${activeTrace}.tbl_id`] = tbl_id;
+    const options = {};
+    Object.entries(fields).forEach( ([k,v]) => {
+        if (k.startsWith('data') || k.startsWith('layout')) {
+            changes[k] = v;
+        } else {
+            options[`${k}`] = v;
+        }
+    });
+    changes[`fireflyData.${activeTrace}.options`] = options;
+
+    ['x', 'y'].forEach((a) => {
+        const opts = get(fields, a, '');
+        const range = get(layout, `${a}axis.range`);
+        if (opts.includes('flip')) {
+            if (range) {
+                if (range[0]<range[1]) changes[`layout.${a}axis.range`] = reverse(range);
+            } else {
+                changes[`layout.${a}axis.autorange`] = 'reversed';
+            }
+
+        } else {
+            if (range) {
+                if (range[1]<range[0]) changes[`layout.${a}axis.range`] = reverse(range);
+            } else {
+                changes[`layout.${a}axis.autorange`] = true;
+            }
+        }
+        if (opts.includes('opposite')) {
+            changes[`layout.${a}axis.side`] = (a==='x'?'top':'right');
+        } else {
+            changes[`layout.${a}axis.side`] = (a==='x'?'bottom':'left');
+        }
+        changes[`layout.${a}axis.type`]  = opts.includes('log') ? 'log' : 'linear';
+    });
+    changes['activeTrace'] = activeTrace;
+    return changes;
+}
+
+function toHistogramOptions(chartId, activeTrace=0) {
+    const {fireflyData, layout} = getChartData(chartId);
+    const options = get(fireflyData, `${activeTrace}.options`, {});
+    const histogramOptions = {};
+    Object.entries(options).forEach( ([k,v]) => {
+        set(histogramOptions, k, v);
+    });
+
+    ['x', 'y'].forEach((a) => {
+        const opts = [];
+        if (get(layout, `${a}axis.autorange`) === 'reversed' ||
+            (get(layout, `${a}axis.range.1`) < get(layout, `${a}axis.range.0`))) {
+            opts.push('flip');
+        }
+        if (get(layout, `${a}axis.side`) === (a==='x'?'top':'right')) {
+            opts.push('opposite');
+        }
+        if (get(layout, `${a}axis.type`) === 'log') {
+            opts.push('log');
+        }
+        set(histogramOptions, a, opts.toString());
+    });
+    return histogramOptions;
+}
+

--- a/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
@@ -29,7 +29,7 @@ export class FireflyHistogramOptions extends SimpleComponent {
 
         const histogramParams = toHistogramOptions(chartId, activeTrace);
 
-        const basicFields = BasicOptionFields({layout, data, activeTrace});
+        const basicFields = BasicOptionFields({layout, data, activeTrace, xNoLog: true});
         const basicFieldsReducer = basicFieldReducer({data, layout, activeTrace, tablesources});
         return (
             <div style={{padding:'0 5px 7px'}}>
@@ -46,13 +46,13 @@ export function submitChangesFFHistogram({chartId, activeTrace, fields, tbl_id})
 }
 
 function histogramOptionsToChanges(chartId, activeTrace, fields, tbl_id) {
-    const {layout} = getChartData(chartId);
+    const {layout={}} = getChartData(chartId);
     const changes = {};
     changes[`fireflyData.${activeTrace}.dataType`] = 'fireflyHistogram';
     changes[`fireflyData.${activeTrace}.tbl_id`] = tbl_id;
     const options = {};
     Object.entries(fields).forEach( ([k,v]) => {
-        if (k.startsWith('data') || k.startsWith('layout')) {
+        if (k.startsWith('data') || k.startsWith('layout') || k.startsWith('_')) {
             changes[k] = v;
         } else {
             options[`${k}`] = v;
@@ -60,36 +60,12 @@ function histogramOptionsToChanges(chartId, activeTrace, fields, tbl_id) {
     });
     changes[`fireflyData.${activeTrace}.options`] = options;
 
-    ['x', 'y'].forEach((a) => {
-        const opts = get(fields, a, '');
-        const range = get(layout, `${a}axis.range`);
-        if (opts.includes('flip')) {
-            if (range) {
-                if (range[0]<range[1]) changes[`layout.${a}axis.range`] = reverse(range);
-            } else {
-                changes[`layout.${a}axis.autorange`] = 'reversed';
-            }
-
-        } else {
-            if (range) {
-                if (range[1]<range[0]) changes[`layout.${a}axis.range`] = reverse(range);
-            } else {
-                changes[`layout.${a}axis.autorange`] = true;
-            }
-        }
-        if (opts.includes('opposite')) {
-            changes[`layout.${a}axis.side`] = (a==='x'?'top':'right');
-        } else {
-            changes[`layout.${a}axis.side`] = (a==='x'?'bottom':'left');
-        }
-        changes[`layout.${a}axis.type`]  = opts.includes('log') ? 'log' : 'linear';
-    });
     changes['activeTrace'] = activeTrace;
     return changes;
 }
 
 function toHistogramOptions(chartId, activeTrace=0) {
-    const {fireflyData, layout} = getChartData(chartId);
+    const {fireflyData, layout={}} = getChartData(chartId);
     const options = get(fireflyData, `${activeTrace}.options`, {});
     const histogramOptions = {};
     Object.entries(options).forEach( ([k,v]) => {

--- a/src/firefly/js/charts/ui/options/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/HistogramOptions.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {get, isUndefined} from 'lodash';
+
+import {FieldGroup} from '../../../ui/FieldGroup.jsx';
+import {ValidationField} from '../../../ui/ValidationField.jsx';
+import {ListBoxInputField} from '../../../ui/ListBoxInputField.jsx';
+import {ColumnOrExpression} from '../ColumnOrExpression.jsx';
+import {BasicOptionFields, OptionTopBar, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
+import {getChartData} from '../../ChartsCntlr.js';
+
+import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
+import {getColValStats} from '../../TableStatsCntlr.js';
+
+const fieldProps = {labelWidth: 62, size: 15};
+
+/**
+ * This are the options for Plotly histogram chart
+ * Plotly histogram does not display well with firefly histogram, which is using Plotly bar chart
+ * Known issues: shen shown with firefly histogram, Plotly histogram shows as lines or does not show at all
+ */
+export class HistogramOptions extends SimpleComponent {
+
+    getNextState() {
+        const {chartId} = this.props;
+        const {activeTrace:cActiveTrace} = getChartData(chartId);
+        // activeTrace is passed via property, when used from NewTracePanel
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
+        return {activeTrace};
+    }
+
+    render() {
+        const {chartId} = this.props;
+        const {tablesources, layout, data, activeTrace:cActiveTrace=0} = getChartData(chartId);
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
+        const groupKey = this.props.groupKey || `${chartId}-ffhist-${activeTrace}`;
+        const tablesource = get(tablesources, [cActiveTrace]);
+        const tbl_id = get(tablesource, 'tbl_id');
+        const colValStats = getColValStats(tbl_id);
+        const xProps = {fldPath:`_tables.data.${activeTrace}.x`, label: 'X:', name: 'X', nullAllowed: false, colValStats, groupKey, labelWidth: 62};
+        return (
+            <div style={{padding:'0 5px 7px'}}>
+                {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChanges}}/>}
+                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace, tablesources})}>
+                    <BasicOptionFields {...{layout, data, activeTrace}}/>
+                    <ColumnOrExpression {...xProps}/>
+                    <ListBoxInputField fieldKey={`data.${activeTrace}.histfunc`} options={[{value:'count'}, {value:'sum'}, {value:'avg'}, {value:'min'}, {value:'max'}]}/>
+                    <ValidationField fieldKey={`data.${activeTrace}.nbinsx`}/>
+                    <ValidationField fieldKey={`data.${activeTrace}.xbins.size`}/>
+                    <ValidationField fieldKey={`data.${activeTrace}.xbins.start`}/>
+                    <ValidationField fieldKey={`data.${activeTrace}.xbins.end`}/>
+                </FieldGroup>
+            </div>
+        );
+    }
+}
+
+export function fieldReducer({data, layout, activeTrace, tablesources={}}) {
+    const tablesourceMappings = get(tablesources[activeTrace], 'mappings');
+    const basicReducer = basicFieldReducer({data, layout, activeTrace, tablesources});
+    const fields = {
+        [`_tables.data.${activeTrace}.x`]: {
+            fieldKey: `_tables.data.${activeTrace}.x`,
+            value: get(tablesourceMappings, 'x', ''),
+            tooltip: 'X axis',
+            label: 'X:',
+            ...fieldProps
+        },
+        [`data.${activeTrace}.histfunc`]: {
+            fieldKey: `data.${activeTrace}.histfunc`,
+            value: get(data, `${activeTrace}.histfunc`),
+            tooltip: 'Binning function used for this histogram trace',
+            label: 'Function:',
+            ...fieldProps
+        },
+        [`data.${activeTrace}.nbinsx`]: {
+            fieldKey: `data.${activeTrace}.nbinsx`,
+            value: get(data, `${activeTrace}.nbinsx`),
+            tooltip: 'Maximum number of desired bins',
+            label: 'Num of bins:',
+            ...fieldProps
+        },
+        [`data.${activeTrace}.xbins.size`]: {
+            fieldKey: `data.${activeTrace}.xbins.size`,
+            value: get(data, `${activeTrace}.xbins.size`),
+            tooltip: 'Step in between value each x axis bin',
+            label: 'Bin width:',
+            ...fieldProps
+        },
+        [`data.${activeTrace}.xbins.start`]: {
+            fieldKey: `data.${activeTrace}.xbins.start`,
+            value: get(data, `${activeTrace}.xbins.start`),
+            tooltip: 'Sets the starting value for the x axis bins',
+            label: 'Min:',
+            ...fieldProps
+        },
+        [`data.${activeTrace}.xbins.end`]: {
+            fieldKey: `data.${activeTrace}.xbins.end`,
+            value: get(data, `${activeTrace}.xbins.end`),
+            tooltip: 'Sets the end value for the x axis bins.',
+            label: 'Max:',
+            ...fieldProps
+        },
+        ...basicReducer(null)
+    };
+    return (inFields, action) => {
+        if (!inFields) {
+            return fields;
+        } else {
+            return inFields;
+        }
+    };
+}

--- a/src/firefly/js/charts/ui/options/NewTracePanel.jsx
+++ b/src/firefly/js/charts/ui/options/NewTracePanel.jsx
@@ -1,23 +1,52 @@
 import React from 'react';
-import {get} from 'lodash';
 
 import {getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
-import {VALUE_CHANGE} from '../../../fieldGroup/FieldGroupCntlr.js';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {ListBoxInputField} from '../../../ui/ListBoxInputField.jsx';
 import CompleteButton from '../../../ui/CompleteButton.jsx';
 import DialogRootContainer from '../../../ui/DialogRootContainer.jsx';
 import {dispatchShowDialog, dispatchHideDialog} from '../../../core/ComponentCntlr.js';
 import {PopupPanel} from '../../../ui/PopupPanel.jsx';
-import {updateSet} from '../../../util/WebUtil.js';
 import {getFieldVal} from '../../../fieldGroup/FieldGroupUtils.js';
 import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
-import {TableSourcesOptions, submitChangesScatter} from './ScatterOptions.jsx';
-import {submitChanges} from './BasicOptions.jsx';
-import {errorFieldKey, errorMinusFieldKey} from './Errors.jsx';
+import {ScatterOptions, submitChangesScatter} from './ScatterOptions.jsx';
+import {HistogramOptions} from './HistogramOptions.jsx';
+import {FireflyHistogramOptions, submitChangesFFHistogram} from './FireflyHistogramOptions.jsx';
+import {BasicOptionFields, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
 
 const fieldProps = {labelWidth: 62, size: 15};
+
+function getSubmitChangesFunc(traceType) {
+    switch(traceType) {
+        case 'scatter':
+            return submitChangesScatter;
+        case 'fireflyHistogram':
+            return submitChangesFFHistogram;
+        default:
+            return submitChanges;
+    }
+}
+
+function getOptionsComponent({traceType, chartId, activeTrace, groupKey}) {
+    const {data, layout} = getChartData(chartId);
+    switch(traceType) {
+        case 'scatter':
+            return (<ScatterOptions {...{chartId, activeTrace, groupKey}}/>);
+        case 'fireflyHistogram':
+            return (<FireflyHistogramOptions {...{chartId, activeTrace, groupKey}}/>);
+        case 'histogram':
+            return (<HistogramOptions {...{chartId, activeTrace, groupKey}}/>);
+        default:
+            return (
+                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace})}>
+                    <BasicOptionFields {...{activeTrace}}/>
+                    <ValidationField fieldKey={`_tables.data.${activeTrace}.x`}/>
+                    <ValidationField fieldKey={`_tables.data.${activeTrace}.y`}/>
+                </FieldGroup>
+            );
+    }
+}
 
 export class NewTracePanel extends SimpleComponent {
 
@@ -25,48 +54,33 @@ export class NewTracePanel extends SimpleComponent {
         const {tbl_id, chartId} = this.props;
         const {data} = getChartData(chartId);
         const activeTrace = data.length;        //setting activeTrace to next available index.
-        const groupKey = `${chartId}-new-trace-${activeTrace}`;
-        const type = getFieldVal(groupKey, `data.${activeTrace-1}.type`);
+        const type = getFieldVal('new-trace', 'type') || 'scatter';
+        const groupKey = `${chartId}-new-trace-${type}`;
+        //const groupKey = `${chartId}-new-trace-${activeTrace}`;
+        //const type = getFieldVal(groupKey, `data.${activeTrace}.type`) || 'scatter';
         return {groupKey, activeTrace, type};
     }
 
     render() {
         const {tbl_id, chartId} = this.props;
         const {groupKey, activeTrace, type} = this.state;
-        const {data, layout, tablesources} = getChartData(chartId);
         const doAdd = (fields) => {
-            const traceType = get(fields, `data.${activeTrace}.type`);
-            const submitChangesFunc =  (traceType === 'scatter') ? submitChangesScatter : submitChanges;
+            const traceType = type;
+            const submitChangesFunc =  getSubmitChangesFunc(traceType);
 
             fields = Object.assign({activeTrace}, fields);  // make the newly added trace active
+            fields[`data.${activeTrace}.type`] = type; //make sure trace type is set
             // need to hide before the changes are submitted to avoid React Internal error too much recursion (mounting/unmouting fields)
             dispatchHideDialog('ScatterNewTracePanel');
             submitChangesFunc({chartId, activeTrace, fields, tbl_id});
-
         };
-
-        const ScatterOpt = () => (
-            <div className='FieldGroup__vertical'>
-                <ListBoxInputField fieldKey={`data.${activeTrace}.mode`} options={[{value:'markers'}, {value:'lines'}, {value:'lines+markers'}]}/>
-                <TableSourcesOptions tablesource={{tbl_id}} activeTrace={activeTrace} groupKey={groupKey}/>
-            </div>
-        );
-        const HistogramOpt = () => (
-            <div className='FieldGroup__vertical'>
-                <ValidationField fieldKey={`_tables.data.${activeTrace}.x`}/>
-                <ValidationField fieldKey={`_tables.data.${activeTrace}.y`}/>
-            </div>
-        );
-        const addtlParams = (type === 'histogram') ? HistogramOpt() : ScatterOpt();
 
         return (
             <div style={{padding: 10}}>
-                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace, tablesources})}>
-                    <ListBoxInputField fieldKey={`data.${activeTrace}.type`} options={[{value:'scatter'}, {value:'histogram'}]}/>
-                    <ValidationField fieldKey={`data.${activeTrace}.name`}/>
-                    <ValidationField fieldKey={`data.${activeTrace}.marker.color`}/>
-                    {addtlParams}
+                <FieldGroup className='FieldGroup__vertical' keepState={true} groupKey='new-trace'>
+                    <ListBoxInputField fieldKey='type' tooltip='Select plot type' label='Plot Type:' options={[{value:'scatter'}, {value:'fireflyHistogram'}, {value:'histogram'}]} {...fieldProps} />
                 </FieldGroup>
+                {getOptionsComponent({traceType:type, chartId, activeTrace, groupKey})}
                 <div style={{display: 'inline-flex', marginTop: 10, justifyContent: 'space-between'}}>
                     <CompleteButton groupKey={groupKey}
                                     onSuccess={doAdd}
@@ -97,103 +111,28 @@ export function NewTracePanelBtn({tbl_id, chartId}) {
     );
 }
 
-function fieldReducer({data, layout, activeTrace, tablesources={}}) {
-    const tablesourceMappings = get(tablesources[activeTrace], 'mappings');
-    let color = get(data, `${activeTrace}.marker.color`, '');
-    color = Array.isArray(color) ? '' : color;
+function fieldReducer({data, layout, activeTrace}) {
+    const basicReducer = basicFieldReducer({data, layout, activeTrace});
     const fields = {
-        [`data.${activeTrace}.type`]: {
-            fieldKey: `data.${activeTrace}.type`,
-            value: get(data, `${activeTrace}.type`),
-            tooltip: 'Select plot type',
-            label: 'Plot Type:',
-            ...fieldProps,
-        },
-        [`data.${activeTrace}.name`]: {
-            fieldKey: `data.${activeTrace}.name`,
-            value: get(data, `${activeTrace}.name`, 'trace ' + activeTrace),
-            tooltip: 'The name of this new series',
-            label : 'Series name:',
-            ...fieldProps,
-        },
-        [`data.${activeTrace}.marker.color`]: {
-            fieldKey: `data.${activeTrace}.marker.color`,
-            value: color,
-            tooltip: 'Set series color',
-            label : 'Color:',
-            ...fieldProps,
-        },
-        [`data.${activeTrace}.mode`]: {
-            fieldKey: `data.${activeTrace}.mode`,
-            value: get(data, `${activeTrace}.mode`),
-            tooltip: 'Select plot style',
-            label: 'Plot Style:',
-            ...fieldProps,
-        },
         [`_tables.data.${activeTrace}.x`]: {
-             fieldKey: `_tables.data.${activeTrace}.x`,
-             value: get(tablesourceMappings, 'x', ''),
-             //tooltip: 'X axis',
-             label: 'X:',
-             ...fieldProps
-         },
-         [`_tables.data.${activeTrace}.y`]: {
-             fieldKey: `_tables.data.${activeTrace}.y`,
-             value: get(tablesourceMappings, 'y', ''),
-             //tooltip: 'Y axis',
-             label: 'Y:',
-             ...fieldProps
-         },
-         [errorFieldKey(activeTrace, 'x')]: {
-             fieldKey: errorFieldKey(activeTrace, 'x'),
-             value: get(tablesourceMappings, ['error_x.array'], ''),
-             ...fieldProps
-         },
-         [errorMinusFieldKey(activeTrace, 'x')]: {
-             fieldKey: errorMinusFieldKey(activeTrace, 'x'),
-             value: get(tablesourceMappings, ['error_x.arrayminus'], ''),
-             ...fieldProps
-         },
-         [errorFieldKey(activeTrace, 'y')]: {
-             fieldKey: errorFieldKey(activeTrace, 'y'),
-             value: get(tablesourceMappings, ['error_y.array'], ''),
-             ...fieldProps
-         },
-         [errorMinusFieldKey(activeTrace, 'y')]: {
-             fieldKey: errorMinusFieldKey(activeTrace, 'x'),
-             value: get(tablesourceMappings, ['error_y.arrayminus'], ''),
-             ...fieldProps
-         },
-         [`_tables.data.${activeTrace}.marker.color`]: {
-             fieldKey: `_tables.data.${activeTrace}.marker.color`,
-             value: get(tablesourceMappings, 'marker.color', ''),
-             //tooltip: 'Use a column for color map',
-             label: 'Color Map:',
-             ...fieldProps
-         },
-         [`_tables.data.${activeTrace}.marker.size`]: {
-             fieldKey: `_tables.data.${activeTrace}.marker.size`,
-             value: get(tablesourceMappings, 'marker.size', ''),
-             //tooltip: 'Use a column for size map',
-             label: 'Size Map:',
-             ...fieldProps
-         }
+            fieldKey: `_tables.data.${activeTrace}.x`,
+            value: '',
+            tooltip: 'X axis',
+            label: 'X:',
+            ...fieldProps
+        },
+        [`_tables.data.${activeTrace}.y`]: {
+            fieldKey: `_tables.data.${activeTrace}.y`,
+            value: '',
+            tooltip: 'Y axis',
+            label: 'Y:',
+            ...fieldProps
+        },
+        ...basicReducer(null)
     };
     return (inFields, action) => {
         if (!inFields) {
             return fields;
-        }
-
-        const {payload:{fieldKey='', value=''}, type} = action;
-
-        if (fieldKey.endsWith('marker.color') && type === VALUE_CHANGE && value.length === 1) {
-            if (fieldKey.startsWith('_tables')) {
-                const colorKey = Object.keys(inFields).find((k) => k.match(/data.+.marker.color/)) || '';
-                if (colorKey) inFields = updateSet(inFields, [colorKey, 'value'], '');     // blanks out color when a color map is entered
-            } else {
-                const colorMapKey = Object.keys(inFields).find((k) => k.match(/_tables.+.marker.color/)) || '';
-                if (colorMapKey) inFields = updateSet(inFields, [colorMapKey, 'value'], '');   // blanks out color map when a color is entered
-            }
         }
         return inFields;
 

--- a/src/firefly/js/charts/ui/options/NewTracePanel.jsx
+++ b/src/firefly/js/charts/ui/options/NewTracePanel.jsx
@@ -11,7 +11,7 @@ import {PopupPanel} from '../../../ui/PopupPanel.jsx';
 import {getFieldVal} from '../../../fieldGroup/FieldGroupUtils.js';
 import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
 import {ScatterOptions, submitChangesScatter} from './ScatterOptions.jsx';
-import {HistogramOptions} from './HistogramOptions.jsx';
+import {HistogramOptions} from './PlotlyHistogramOptions.jsx';
 import {FireflyHistogramOptions, submitChangesFFHistogram} from './FireflyHistogramOptions.jsx';
 import {BasicOptionFields, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
 
@@ -40,9 +40,9 @@ function getOptionsComponent({traceType, chartId, activeTrace, groupKey}) {
         default:
             return (
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace})}>
-                    <BasicOptionFields {...{activeTrace}}/>
                     <ValidationField fieldKey={`_tables.data.${activeTrace}.x`}/>
                     <ValidationField fieldKey={`_tables.data.${activeTrace}.y`}/>
+                    <BasicOptionFields {...{activeTrace}}/>
                 </FieldGroup>
             );
     }
@@ -77,9 +77,10 @@ export class NewTracePanel extends SimpleComponent {
 
         return (
             <div style={{padding: 10}}>
-                <FieldGroup className='FieldGroup__vertical' keepState={true} groupKey='new-trace'>
+                <FieldGroup className='FieldGroup__vertical' style={{padding: 5}} keepState={true} groupKey='new-trace'>
                     <ListBoxInputField fieldKey='type' tooltip='Select plot type' label='Plot Type:' options={[{value:'scatter'}, {value:'fireflyHistogram'}, {value:'histogram'}]} {...fieldProps} />
                 </FieldGroup>
+                <br/>
                 {getOptionsComponent({traceType:type, chartId, activeTrace, groupKey})}
                 <div style={{display: 'inline-flex', marginTop: 10, justifyContent: 'space-between'}}>
                     <CompleteButton groupKey={groupKey}

--- a/src/firefly/js/charts/ui/options/PlotlyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/PlotlyHistogramOptions.jsx
@@ -41,13 +41,14 @@ export class HistogramOptions extends SimpleComponent {
             <div style={{padding:'0 5px 7px'}}>
                 {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChanges}}/>}
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace, tablesources})}>
-                    <BasicOptionFields {...{layout, data, activeTrace}}/>
                     <ColumnOrExpression {...xProps}/>
                     <ListBoxInputField fieldKey={`data.${activeTrace}.histfunc`} options={[{value:'count'}, {value:'sum'}, {value:'avg'}, {value:'min'}, {value:'max'}]}/>
                     <ValidationField fieldKey={`data.${activeTrace}.nbinsx`}/>
                     <ValidationField fieldKey={`data.${activeTrace}.xbins.size`}/>
                     <ValidationField fieldKey={`data.${activeTrace}.xbins.start`}/>
                     <ValidationField fieldKey={`data.${activeTrace}.xbins.end`}/>
+                    <br/>
+                    <BasicOptionFields {...{layout, data, activeTrace}}/>
                 </FieldGroup>
             </div>
         );

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -39,12 +39,13 @@ export class ScatterOptions extends SimpleComponent {
             <div style={{padding:'0 5px 7px'}}>
                 {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChangesScatter}}/>}
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace, tablesources})}>
-                    <BasicOptionFields {...{layout, data, activeTrace}}/>
                     <ListBoxInputField fieldKey={`data.${activeTrace}.mode`} options={[{value:'markers'}, {value:'lines'}, {value:'lines+markers'}]}/>
                     <ListBoxInputField fieldKey={`data.${activeTrace}.marker.symbol`}
                                        options={[{value:'circle'}, {value:'circle-open'}, {value:'square'}, {value:'square-open'}, {value:'diamond'}, {value:'diamond-open'},
                                                  {value:'cross'}, {value:'x'}, {value:'triangle-up'}, {value:'hexagon'}, {value:'star'}]}/>
                     {tablesource && <TableSourcesOptions {...{tablesource, activeTrace, groupKey}}/>}
+                    <br/>
+                    <BasicOptionFields {...{layout, data, activeTrace}}/>
                 </FieldGroup>
             </div>
         );

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {get} from 'lodash';
+import {get, isUndefined} from 'lodash';
 
 import {getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
@@ -20,21 +20,24 @@ export class ScatterOptions extends SimpleComponent {
 
     getNextState() {
         const {chartId} = this.props;
-        const {activeTrace} = getChartData(chartId);
+        const {activeTrace:cActiveTrace} = getChartData(chartId);
+        // activeTrace is passed via property, when used from NewTracePanel
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
         return {activeTrace};
     }
 
     render() {
         const {chartId} = this.props;
         //const {activeTrace=0} = this.state;
-        const {tablesources, data, layout, activeTrace=0} = getChartData(chartId);
-        const groupKey = `${chartId}-scatter-${activeTrace}`;
-        const tablesource = get(tablesources, [activeTrace]);
+        const {tablesources, data, layout, activeTrace:cActiveTrace=0} = getChartData(chartId);
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
+        const groupKey = this.props.groupKey || `${chartId}-scatter-${activeTrace}`;
+        const tablesource = get(tablesources, [cActiveTrace]);
         const tbl_id = get(tablesource, 'tbl_id');
 
         return (
             <div style={{padding:'0 5px 7px'}}>
-                <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChangesScatter}}/>
+                {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChangesScatter}}/>}
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace, tablesources})}>
                     <BasicOptionFields {...{layout, data, activeTrace}}/>
                     <ListBoxInputField fieldKey={`data.${activeTrace}.mode`} options={[{value:'markers'}, {value:'lines'}, {value:'lines+markers'}]}/>
@@ -68,11 +71,11 @@ export function fieldReducer({data, layout, activeTrace, tablesources={}}) {
         },
         [errorTypeFieldKey(activeTrace, 'x')]: {
             fieldKey: errorTypeFieldKey(activeTrace, 'x'),
-            value: get(data, `${activeTrace}.firefly.error_x.errorsType`, 'none')
+            value: get(data, `${activeTrace}.fireflyData.options.error_x.errorsType`, 'none')
         },
         [errorTypeFieldKey(activeTrace, 'y')]: {
             fieldKey: errorTypeFieldKey(activeTrace, 'y'),
-            value: get(data, `${activeTrace}.firefly.error_y.errorsType`, 'none')
+            value: get(data, `${activeTrace}.fireflyData.options.error_y.errorsType`, 'none')
         },
         ...basicReducer(null)
     };
@@ -193,7 +196,7 @@ export function submitChangesScatter({chartId, activeTrace, fields, tbl_id}) {
     const sizeMap = get(fields, `_tables.data.${activeTrace}.marker.size`);
 
     const dataType = (colorMap || sizeMap) ? 'scatter' : 'fireflyScatter';
-    const changes = {[`data.${activeTrace}.firefly.dataType`] : dataType};
+    const changes = {[`fireflyData.${activeTrace}.dataType`] : dataType};
     if (dataType === 'fireflyScatter') {
         // add a mapping for rowIdx
         changes[`_tables.data.${activeTrace}.firefly.rowIdx`] = 'rowIdx'; // rowIdx is mapping table rows to data points

--- a/src/firefly/js/ui/panel/CollapsiblePanel.jsx
+++ b/src/firefly/js/ui/panel/CollapsiblePanel.jsx
@@ -126,7 +126,7 @@ CollapsiblePanel.defaultProps= {
 function getProps(params, fireValueChange) {
     return Object.assign({}, params, {
         onToggle: (isOpen) => fireValueChange({value: isOpen?'open':'closed'}),
-        isOpen: (params.value && params.value==='open')
+        isOpen: Boolean(params.value && params.value==='open')
     });
 }
 


### PR DESCRIPTION
This PR is for supporting Firefly Histogram chart (with the column data aggregated into bins on the server) in multi-trace plotly chart. (Currently, multi-trace chart is only available in API.)

I've changed histograms to solid color to make multiple histograms look good together, and so that the trace color can be changed easily.
For comparison, I have added options for Plotly histogram (client side histogram calculation). Firefly histogram (backed by Plotly bar chart) and Plotly histogram do not work well together, but it's good to see what options are available and see if we can support both charts with one set of options.

Ticket:
https://jira.lsstcorp.org/browse/DM-10831

Test:
http://localhost:8080/firefly/demo/ffapi-highlevel-charttest.html
Check the first chart, try to change options, add new traces, reset. You can also add histogram trace to scatter plot just above the table. 