### PR TITLE
DM-8707: scatter options in multi-trace charts

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
@@ -28,6 +28,8 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
     private static final String YERR_COL_EXPR = "yErrColOrExpr";
     private static final String YERR_LOW_COL_EXPR = "yErrLowColOrExpr";
     private static final String YERR_HIGH_COL_EXPR = "yErrHighColOrExpr";
+    private static final String COLOR_COL_EXPR = "colorColOrExpr";
+    private static final String SIZE_COL_EXPR = "sizeColOrExpr";
     private static final String SORT_COL_OR_EXPR = "sortColOrExpr";
 
 
@@ -43,6 +45,8 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         String yErrColOrExpr = request.getParam(YERR_COL_EXPR);
         String yErrLowColOrExpr = request.getParam(YERR_LOW_COL_EXPR);
         String yErrHighColOrExpr = request.getParam(YERR_HIGH_COL_EXPR);
+        String colorColOrExpr = request.getParam(COLOR_COL_EXPR);
+        String sizeColOrExpr = request.getParam(SIZE_COL_EXPR);
         String sortColOrExpr = request.getParam(SORT_COL_OR_EXPR);
 
         boolean hasXError = !StringUtils.isEmpty(xErrColOrExpr);
@@ -64,9 +68,18 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
 
         // create the array of getters, which know how to get double values
         ArrayList<Col> colsLst = new ArrayList<>();
-        Col xCol = getCol(dataTypes, xColOrExpr,"x", false);
+        Col xCol = getCol(dataTypes, xColOrExpr, "x", false);
         colsLst.add(xCol);
         colsLst.add(getCol(dataTypes, yColOrExpr, "y", false));
+
+        // columns for color and size maps
+        if (!StringUtils.isEmpty(colorColOrExpr)) {
+            colsLst.add(getCol(dataTypes, colorColOrExpr, "color", true));
+        }
+        if (!StringUtils.isEmpty(sizeColOrExpr)) {
+            colsLst.add(getCol(dataTypes, sizeColOrExpr, "size", true));
+        }
+
 
         Col sortCol = null;
         if (hasSortCol) {

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -33,8 +33,8 @@ export class PlotlyChartArea extends PureComponent {
 
     getNextState() {
         const {chartId} = this.props;
-        const {data, highlighted, layout, selected, activeTrace} = getChartData(chartId);
-        return  {data, highlighted, selected, layout, activeTrace};
+        const {data, highlighted, layout, fireflyLayout={}, selected, activeTrace} = getChartData(chartId);
+        return  {data, highlighted, selected, layout, activeTrace, xyratio: fireflyLayout.xyratio, stretch: fireflyLayout.stretch};
     }
 
     storeUpdate() {
@@ -53,9 +53,9 @@ export class PlotlyChartArea extends PureComponent {
     }
 
     render() {
-        const {widthPx, heightPx} = this.props;
-        const {data=[], highlighted, selected, layout={}, activeTrace=0} = this.state;
-        const doingResize= (layout && (layout.width!==widthPx || layout.height!==heightPx));
+        var {widthPx, heightPx} = this.props;
+        const {data=[], highlighted, selected, layout={}, activeTrace=0, xyratio, stretch} = this.state;
+
         const showlegend = data.length > 1;
         let pdata = data;
         // TODO: change highlight or selected without forcing new plot
@@ -64,12 +64,22 @@ export class PlotlyChartArea extends PureComponent {
             pdata = selected ? pdata.concat([selected]) : pdata;
             pdata = highlighted ? pdata.concat([highlighted]) : pdata;
         }
-        const playout = Object.assign({showlegend}, layout, {width: widthPx, height: heightPx});
+        const {chartWidth, chartHeight} = calculateChartSize(widthPx, heightPx, xyratio, stretch);
+        const doingResize= (layout && (layout.width!==chartWidth || layout.height!==chartHeight));
+        const playout = Object.assign({showlegend}, layout, {width: chartWidth, height: chartHeight});
+
+        const style = {float: 'left'};
+        if (chartWidth > widthPx || chartHeight > heightPx) {
+            Object.assign(style, {overflow: 'auto', width: widthPx, height: heightPx});
+        }
+
         return (
-            <PlotlyWrapper newPlotCB={this.afterRedraw} data={pdata} layout={playout}
-                           chartId={this.props.chartId}
-                           autoDetectResizing={false}
-                           doingResize={doingResize}/>
+            <div style={style}>
+                <PlotlyWrapper newPlotCB={this.afterRedraw} data={pdata} layout={playout}
+                               chartId={this.props.chartId}
+                               autoDetectResizing={false}
+                               doingResize={doingResize}/>
+            </div>
         );
     }
 }
@@ -79,6 +89,30 @@ PlotlyChartArea.propTypes = {
     widthPx: PropTypes.number,
     heightPx: PropTypes.number
 };
+
+function calculateChartSize(widthPx, heightPx, xyratio, stretch) {
+
+    let chartWidth = undefined, chartHeight = undefined;
+    if (xyratio) {
+        if (stretch === 'fit') {
+            chartHeight = Number(heightPx);
+            chartWidth = Number(xyratio) * Number(chartHeight);
+            if (chartWidth > Number(widthPx)) {
+                chartHeight -= 15; // to accommodate scroll bar
+            }
+        } else {
+            chartWidth = Number(widthPx);
+            chartHeight = Number(widthPx) / Number(xyratio);
+            if (chartHeight > Number(heightPx)) {
+                chartWidth -= 15; // to accommodate scroll bar
+            }
+        }
+    } else {
+        chartWidth = Number(widthPx);
+        chartHeight = Number(heightPx);
+    }
+    return {chartWidth, chartHeight};
+}
 
 function onClick(chartId) {
     return (evData) => {

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -1,15 +1,26 @@
-import React from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {get, isUndefined, reverse} from 'lodash';
 
 import {dispatchChartUpdate, dispatchChartAdd, getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
+import FieldGroupUtils, {getFieldVal} from '../../../fieldGroup/FieldGroupUtils.js';
+import {dispatchValueChange, VALUE_CHANGE, MULTI_VALUE_CHANGE} from '../../../fieldGroup/FieldGroupCntlr.js';
+import {showColorPickerDialog} from '../../../ui/ColorPicker.jsx';
+import Validate from '../../../util/Validate.js';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
+import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
 import {CheckboxGroupInputField} from '../../../ui/CheckboxGroupInputField.jsx';
 import CompleteButton from '../../../ui/CompleteButton.jsx';
 import {NewTracePanelBtn} from './NewTracePanel.jsx';
 import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
+import {updateSet} from '../../../util/WebUtil.js';
+import {hideColSelectPopup} from '../ColSelectView.jsx';
 
 const fieldProps = {labelWidth: 50, size: 25};
+const boundariesFieldProps = {labelWidth: 35, size: 10};
+const helpStyle = {fontStyle: 'italic', color: '#808080', paddingBottom: 10};
+const xyratioFldName = 'fireflyLayout.xyratio';
 
 const X_AXIS_OPTIONS = [
     {label: 'grid', value: 'grid'},
@@ -57,7 +68,7 @@ export class BasicOptions extends SimpleComponent {
     render() {
         const {chartId} = this.props;
         const {activeTrace=0} = this.state;
-        const {tablesources, data, layout} = getChartData(chartId);
+        const {tablesources} = getChartData(chartId);
         const groupKey = `${chartId}-basic-${activeTrace}`;
         const tablesource = get(tablesources, [activeTrace]);
         const tbl_id = get(tablesource, 'tbl_id');
@@ -65,15 +76,16 @@ export class BasicOptions extends SimpleComponent {
             <div style={{minWidth: 250, padding:'0 5px 7px'}}>
                 <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id}}/>
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey}
-                            reducerFunc={basicFieldReducer({data, layout, activeTrace, tablesources})}>
-                    <BasicOptionFields {...{layout, data, activeTrace}}/>
+                            reducerFunc={basicFieldReducer({chartId, activeTrace})}>
+                    <BasicOptionFields {...{activeTrace, groupKey}}/>
                 </FieldGroup>
             </div>
         );
     }
 }
 
-export function basicFieldReducer({data, layout, activeTrace, tablesources}) {
+export function basicFieldReducer({chartId, activeTrace}) {
+    const {data, layout, fireflyLayout={}} = getChartData(chartId);
     let color = get(data, `${activeTrace}.marker.color`, '');
     color = Array.isArray(color) ? '' : color;
     const fields = {
@@ -112,11 +124,11 @@ export function basicFieldReducer({data, layout, activeTrace, tablesources}) {
             label : 'X Label:',
             ...fieldProps
         },
-        ['_xoptions']: {
-            fieldKey: '_xoptions',
+        ['__xoptions']: {
+            fieldKey: '__xoptions',
             value: getOptions('x', layout),
             tooltip: 'X axis options',
-            label : 'X Options:',
+            label : 'Options:',
             ...fieldProps
         },
         ['layout.yaxis.title']: {
@@ -126,50 +138,226 @@ export function basicFieldReducer({data, layout, activeTrace, tablesources}) {
             label : 'Y Label:',
             ...fieldProps
         },
-        ['_yoptions']: {
-            fieldKey: '_yoptions',
+        ['__yoptions']: {
+            fieldKey: '__yoptions',
             value: getOptions('y', layout),
             tooltip: 'Y axis options',
-            label : 'Y Options:',
+            label : 'Options:',
             ...fieldProps
         },
-
+        ['fireflyLayout.xaxis.min']: {
+            fieldKey: 'fireflyLayout.xaxis.min',
+            value: get(fireflyLayout, 'xaxis.min'),
+            validator: (val)=>Validate.isFloat('X Min', val),
+            tooltip: 'Minimum X value',
+            label: 'X Min:',
+            ...boundariesFieldProps
+        },
+        ['fireflyLayout.xaxis.max']: {
+            fieldKey: 'fireflyLayout.xaxis.max',
+            value: get(fireflyLayout, 'xaxis.max'),
+            validator: (val)=>Validate.isFloat('X Max', val),
+            tooltip: 'Maximum X value',
+            label : 'X Max:',
+            ...boundariesFieldProps
+        },
+        ['fireflyLayout.yaxis.min']: {
+            fieldKey: 'fireflyLayout.yaxis.min',
+            value: get(fireflyLayout, 'yaxis.min'),
+            validator: (val)=>Validate.isFloat('Y Min', val),
+            tooltip: 'Minimum Y value',
+            label: 'Y Min:',
+            ...boundariesFieldProps
+        },
+        ['fireflyLayout.yaxis.max']: {
+            fieldKey: 'fireflyLayout.yaxis.max',
+            value: get(fireflyLayout, 'yaxis.max'),
+            validator: (val)=>Validate.isFloat('Y Max', val),
+            tooltip: 'Maximum Y value',
+            label : 'Y Max:',
+            ...boundariesFieldProps
+        },
+        [xyratioFldName]: {
+            fieldKey: xyratioFldName,
+            value: get(fireflyLayout, 'xyratio'),
+            validator: Validate.floatRange.bind(null, 1, 10, 1, 'X/Y ratio'),
+            tooltip: 'X/Y ratio',
+            label : 'X/Y ratio:',
+            labelWidth: 50
+        },
+        ['fireflyLayout.stretch']: {
+            fieldKey: 'fireflyLayout.stretch',
+            value: get(fireflyLayout, 'stretch', 'fit'),
+            tooltip: 'Should the plot fit into the available space or fill the available width?',
+            label : 'Stretch to:',
+            labelWidth: 50
+        }
     };
 
     return (inFields, action) => {
         if (!inFields) {
             return fields;
         } else {
+            let fieldKey = undefined;
+            if (action.type === VALUE_CHANGE) {
+                // when field changes, clear the label and unit
+                fieldKey = get(action.payload, 'fieldKey');
+                ['x','y'].forEach((a) => {
+                    if (fieldKey === `_tables.data.${activeTrace}.${a}`) {
+                        inFields = updateSet(inFields, [`layout.${a}axis.title`, 'value'], undefined);
+                        inFields = updateSet(inFields, [`fireflyLayout.${a}axis.min`, 'value'], undefined);
+                        inFields = updateSet(inFields, [`fireflyLayout.${a}axis.max`, 'value'], undefined);
+                        const optFldName = `__${a}options`;
+                        const currOptions = get(inFields, [optFldName, 'value']);
+                        // do not reset grid selection
+                        inFields = updateSet(inFields, [optFldName, 'value'], getOption(currOptions, 'grid'));
+                    }
+                });
+            }
+            if (action.type === MULTI_VALUE_CHANGE || action.type === VALUE_CHANGE) {
+                // validate min/max/log relationship
+                const fldsets = [
+                    {min: 'fireflyLayout.xaxis.min', max: 'fireflyLayout.xaxis.max', options: '__xoptions'},
+                    {min: 'fireflyLayout.yaxis.min', max: 'fireflyLayout.yaxis.max', options: '__yoptions'}
+                ];
+                fldsets.forEach(
+                    (v) => {
+                        if (!fieldKey || fieldKey === v.min || fieldKey === v.max || fieldKey === v.options) {
+                            const valMin = Number.parseFloat(get(inFields, [v.min, 'value']));
+                            const options = get(inFields, [v.options, 'value']);
+                            const logVal = Boolean(options && options.includes('log'));
+                            if (Number.isFinite(valMin)) {
+                                if (logVal && valMin <= 0) {
+                                    inFields = updateSet(inFields, [v.min, 'valid'], false);
+                                    inFields = updateSet(inFields, [v.min, 'message'], 'The minimum of a log axis can not be 0 or less');
+                                } else {
+                                    const valMax = Number.parseFloat(get(inFields, [v.max, 'value']));
+                                    if (Number.isFinite(valMax) && valMin > valMax) {
+                                        inFields = updateSet(inFields, [fieldKey || v.min, 'valid'], false);
+                                        inFields = updateSet(inFields, [fieldKey || v.min, 'message'], 'Min value greater than max');
+                                    }
+                                }
+                            }
+                        }
+                    });
+            }
             return inFields;
         }
     };
 }
 
 
-export function BasicOptionFields({activeTrace, align='vertical', xNoLog}) {
-    // TODO: need color input field
-    return (
-        <div className={`FieldGroup__${align}`} style={{padding: 5, border: '2px solid #a5a5a5', borderRadius: 10}}>
-            <ValidationField fieldKey={`data.${activeTrace}.name`}/>
-            <ValidationField fieldKey={`data.${activeTrace}.marker.color`}/>
+//export function BasicOptionFields({activeTrace, groupKey, align='vertical', xNoLog}) {
+export class BasicOptionFields extends Component {
 
-            {/* checkboxgroup is not working right when there's only 1 .. will add in later
-             <CheckboxGroupInputField fieldKey={'layout.showlegend'}/>
-             */}
+    constructor(props) {
+        super(props);
+        this.state = {
+            displayStretchOptions : Boolean(getFieldVal(props.groupKey, xyratioFldName))
+        };
+        this.setStretchOptionsVisibility = this.setStretchOptionsVisibility.bind(this);
+    }
 
-            <br/>
-            <ValidationField fieldKey={'layout.xaxis.title'}/>
-            <CheckboxGroupInputField fieldKey='_xoptions'
-                                     options={xNoLog ? X_AXIS_OPTIONS_NOLOG : X_AXIS_OPTIONS}/>
-            <br/>
-            <ValidationField fieldKey={'layout.yaxis.title'}/>
-            <CheckboxGroupInputField fieldKey='_yoptions' options={Y_AXIS_OPTIONS}/>
-            <br/>
-            <ValidationField fieldKey={'layout.title'}/>
+    setStretchOptionsVisibility(displayStretchOptions) {
+        if (this.iAmMounted && displayStretchOptions  !== this.state.displayStretchOptions) {
+            this.setState({displayStretchOptions});
+        }
+    }
 
-        </div>
-    );
+    componentWillUnmount() {
+        this.iAmMounted= false;
+        if (this.unbinder) this.unbinder();
+        hideColSelectPopup();
+    }
+
+    componentDidMount() {
+        this.unbinder = FieldGroupUtils.bindToStore(this.props.groupKey,
+            (fields) => {
+                this.setStretchOptionsVisibility(Boolean(get(fields, [xyratioFldName, 'value']) && get(fields, [xyratioFldName, 'valid'])));
+            });
+        this.iAmMounted= true;
+    }
+
+    render() {
+        const {activeTrace, groupKey, align='vertical', xNoLog} = this.props;
+
+        // TODO: need color input field
+        const colorFldPath = `data.${activeTrace}.marker.color`;
+
+        return (
+            <div className={`FieldGroup__${align}`}
+                 style={{padding: '15px 10px 0', border: '2px solid #a5a5a5', borderRadius: 10}}>
+                <ValidationField fieldKey={`data.${activeTrace}.name`}/>
+                <div style={{whiteSpace: 'nowrap'}}>
+                    <ValidationField inline={true} fieldKey={colorFldPath}/>
+                    <div
+                        style={{display: 'inline-block', cursor:'pointer', paddingLeft: 3, verticalAlign: 'middle', fontSize: 'larger'}}
+                        title='Select trace color'
+                        onClick={() => showColorPickerDialog(getFieldVal(groupKey, colorFldPath), true, false,
+                             (ev) => {
+                                 const {r,g,b,a}= ev.rgb;
+                                 const rgbStr= `rgba(${r},${g},${b},${a})`;
+                                 dispatchValueChange({fieldKey: colorFldPath, groupKey, value: rgbStr, valid: true});
+                             }, groupKey)}>
+                        {'\ud83d\udd0e'}
+                    </div>
+                </div>
+                <br/>
+                <ValidationField fieldKey={'layout.title'}/>
+                <br/>
+                {/* checkboxgroup is not working right when there's only 1 .. will add in later
+                 <CheckboxGroupInputField fieldKey={'layout.showlegend'}/>
+                 */}
+                <ValidationField fieldKey={'layout.xaxis.title'}/>
+                <CheckboxGroupInputField fieldKey='__xoptions'
+                                         options={xNoLog ? X_AXIS_OPTIONS_NOLOG : X_AXIS_OPTIONS}/>
+                <br/>
+                <ValidationField fieldKey={'layout.yaxis.title'}/>
+                <CheckboxGroupInputField fieldKey='__yoptions' options={Y_AXIS_OPTIONS}/>
+                <br/>
+                <div style={helpStyle}>
+                    Set plot boundaries if different from data range.
+                </div>
+                <div style={{display: 'flex', flexDirection: 'row', padding: '5px 15px 15px'}}>
+                    <div style={{paddingRight: 5}}>
+                        <ValidationField fieldKey={'fireflyLayout.xaxis.min'}/>
+                        <ValidationField fieldKey={'fireflyLayout.yaxis.min'}/>
+                    </div>
+                    <div style={{paddingRight: 5}}>
+                        <ValidationField fieldKey={'fireflyLayout.xaxis.max'}/>
+                        <ValidationField fieldKey={'fireflyLayout.yaxis.max'}/>
+                    </div>
+                </div>
+                <div style={helpStyle}>
+                    Enter display aspect ratio below.<br/>
+                    Leave it blank to use all available space.<br/>
+                </div>
+                <div style={{display: 'flex', flexDirection: 'row', padding: '5px 5px 5px 0'}}>
+                    <div style={{paddingRight: 5}}>
+                        <ValidationField style={{width:15}} fieldKey={xyratioFldName}/>
+                    </div>
+                    {this.state.displayStretchOptions && <div style={{paddingRight: 5}}>
+                        <RadioGroupInputField fieldKey={'fireflyLayout.stretch'}
+                                              alignment='horizontal'
+                                              options={[
+                                          {label: 'height', value: 'fit'},
+                                          {label: 'width', value: 'fill'}
+                                      ]}/>
+                    </div>}
+                </div>
+            </div>
+        );
+    }
 }
+
+BasicOptionFields.propTypes = {
+    groupKey: PropTypes.string.isRequired,
+    activeTrace: PropTypes.number.isRequired,
+    align: PropTypes.oneOf(['vertical', 'horizontal']),
+    xNoLog: PropTypes.bool
+};
+
+
 
 export function OptionTopBar({groupKey, activeTrace, chartId, tbl_id, submitChangesFunc=submitChanges}) {
     return (
@@ -190,6 +378,14 @@ export function OptionTopBar({groupKey, activeTrace, chartId, tbl_id, submitChan
     );
 }
 
+OptionTopBar.propTypes = {
+    groupKey: PropTypes.string.isRequired,
+    activeTrace: PropTypes.number.isRequired,
+    chartId: PropTypes.string,
+    tbl_id: PropTypes.string,
+    submitChangesFunc: PropTypes.func
+};
+
 /**
  * This is a default implementation of an option pane's apply changes function.
  * It assume the fieldId is the 'path' to the chart data and the value of the field is the value you want to change.
@@ -208,12 +404,13 @@ export function submitChanges({chartId, fields, tbl_id}) {
         if (tbl_id && k.startsWith('_tables.')) {
             k = k.replace('_tables.', '');
             v = v ? `tables::${tbl_id},${v}` : undefined;
-        } else if (k.startsWith('_')) {
-            // handling _xoptions and _yoptions
+        } else if (k.startsWith('__')) {
+            // handling __xoptions and __yoptions
             ['x','y'].forEach((a) => {
-                if (k === `_${a}options`) {
+                if (k === `__${a}options`) {
                     const opts = v || '';
                     const range = get(layout, `${a}axis.range`);
+
                     if (opts.includes('flip')) {
                         if (range) {
                             if (range[0]<range[1]) changes[`layout.${a}axis.range`] = reverse(range);
@@ -239,12 +436,57 @@ export function submitChanges({chartId, fields, tbl_id}) {
                 }
             });
         }
-        if (!changes[k]) {
+        // omit fields, that start with '__'
+        if (!k.startsWith('__') && !changes[k]) {
             changes[k] = v;
         }
-
     });
+    adjustAxesRange(layout, changes);
     dispatchChartUpdate({chartId, changes});
+}
+
+function adjustAxesRange(layout, changes) {
+    ['x', 'y'].forEach((a) => {
+        var minUser = parseFloat(get(changes, `fireflyLayout.${a}axis.min`));
+        var maxUser = parseFloat(get(changes, `fireflyLayout.${a}axis.max`));
+        if (!Number.isNaN(minUser) || !Number.isNaN(maxUser)) {
+            if (Number.isNaN(minUser) || Number.isNaN(maxUser)) {
+                // range values of a log axis are logs - convert them back
+                const range = get(layout, `${a}axis.range`, {}).map(get(layout, `${a}axis.type`) === 'log' ? (e)=>Math.pow(10, e) : (e)=>e);
+                if (Number.isNaN(minUser)) {
+                    minUser = Math.min(range[0], range[1]);
+                } else if (Number.isNaN(maxUser)) {
+                    maxUser = Math.max(range[0], range[1]);
+                }
+            }
+            const range = changes[`layout.${a}axis.range`] || [];
+            const reversed = (changes[`layout.${a}axis.autorange`] === 'reversed') || (range[1] < range[0]);
+            changes[`layout.${a}axis.range`] = getRange(minUser, maxUser, changes[`layout.${a}axis.type`] === 'log', reversed);
+            changes[`layout.${a}axis.autorange`] = false;
+        } else {
+            changes[`layout.${a}axis.autorange`] = true;
+        }
+    });
+}
+
+/**
+ * Get range for a plotly axis
+ * Plotly requires range to be reversed if the axis is reversed,
+ * and limits to be log if axis scale is log
+ * @param min - minimum value
+ * @param max - maximum value
+ * @param isLog - true, if an axis uses log scale
+ * @param isReversed - true, if the axis should be reversed
+ * @returns {Array<number>} an array for axis range property in plotly layout
+ */
+function getRange(min, max, isLog, isReversed) {
+    const [r1, r2] = isReversed ? [max, min] : [min, max];
+    return isLog ? [Math.log10(r1), Math.log10(r2)] : [r1, r2];
+}
+
+function getOption(options, opt) {
+    // returns opt if it's included into options
+    return (options && (options.includes(opt)||options.includes('_all_'))) ? opt : undefined;
 }
 
 function resetChart(chartId) {

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -180,7 +180,7 @@ export function basicFieldReducer({chartId, activeTrace}) {
         [xyratioFldName]: {
             fieldKey: xyratioFldName,
             value: get(fireflyLayout, 'xyratio'),
-            validator: Validate.floatRange.bind(null, 1, 10, 1, 'X/Y ratio'),
+            validator: Validate.floatRange.bind(null, 0.1, 10, 1, 'X/Y ratio'),
             tooltip: 'X/Y ratio',
             label : 'X/Y ratio:',
             labelWidth: 50
@@ -318,13 +318,19 @@ export class BasicOptionFields extends Component {
                 <div style={helpStyle}>
                     Set plot boundaries if different from data range.
                 </div>
-                <div style={{display: 'flex', flexDirection: 'row', padding: '5px 15px 15px'}}>
+                <div style={{display: 'flex', flexDirection: 'row', padding: '5px 15px 0'}}>
                     <div style={{paddingRight: 5}}>
                         <ValidationField fieldKey={'fireflyLayout.xaxis.min'}/>
-                        <ValidationField fieldKey={'fireflyLayout.yaxis.min'}/>
                     </div>
                     <div style={{paddingRight: 5}}>
                         <ValidationField fieldKey={'fireflyLayout.xaxis.max'}/>
+                    </div>
+                </div>
+                <div style={{display: 'flex', flexDirection: 'row', padding: '0px 15px 15px'}}>
+                    <div style={{paddingRight: 5}}>
+                        <ValidationField fieldKey={'fireflyLayout.yaxis.min'}/>
+                    </div>
+                    <div style={{paddingRight: 5}}>
                         <ValidationField fieldKey={'fireflyLayout.yaxis.max'}/>
                     </div>
                 </div>

--- a/src/firefly/js/charts/ui/options/Errors.jsx
+++ b/src/firefly/js/charts/ui/options/Errors.jsx
@@ -15,7 +15,7 @@ const ERR_TYPE_OPTIONS = [
 
 ];
 
-export function errorTypeFieldKey(activeTrace, axis) { return `data.${activeTrace}.firefly.error_${axis}.errorsType`; }
+export function errorTypeFieldKey(activeTrace, axis) { return `data.${activeTrace}.fireflyData.error_${axis}.errorsType`; }
 export function errorFieldKey(activeTrace, axis) { return `_tables.data.${activeTrace}.error_${axis}.array`; }
 export function errorMinusFieldKey(activeTrace, axis) { return `_tables.data.${activeTrace}.error_${axis}.arrayminus`; }
 

--- a/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
@@ -20,7 +20,7 @@ export class FireflyHistogramOptions extends SimpleComponent {
 
     render() {
         const {chartId} = this.props;
-        const {tablesources, layout, data, activeTrace:cActiveTrace=0} = getChartData(chartId);
+        const {tablesources, activeTrace:cActiveTrace=0} = getChartData(chartId);
         const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
         const groupKey = this.props.groupKey || `${chartId}-ffhist-${activeTrace}`;
         const tablesource = get(tablesources, [cActiveTrace]);
@@ -29,8 +29,8 @@ export class FireflyHistogramOptions extends SimpleComponent {
 
         const histogramParams = toHistogramOptions(chartId, activeTrace);
 
-        const basicFields = BasicOptionFields({layout, data, activeTrace, xNoLog: true});
-        const basicFieldsReducer = basicFieldReducer({data, layout, activeTrace, tablesources});
+        const basicFields = BasicOptionFields({activeTrace, groupKey, xNoLog: true});
+        const basicFieldsReducer = basicFieldReducer({chartId, activeTrace});
         return (
             <div style={{padding:'0 5px 7px'}}>
                 {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChangesFFHistogram}}/>}

--- a/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {get, isUndefined, set, reverse} from 'lodash';
+import {get, isUndefined, set} from 'lodash';
 
 import {BasicOptionFields, OptionTopBar, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
 import {HistogramOptions} from '../HistogramOptions.jsx';
@@ -29,7 +29,7 @@ export class FireflyHistogramOptions extends SimpleComponent {
 
         const histogramParams = toHistogramOptions(chartId, activeTrace);
 
-        const basicFields = BasicOptionFields({activeTrace, groupKey, xNoLog: true});
+        const basicFields = <BasicOptionFields {...{activeTrace, groupKey, xNoLog: true}}/>;
         const basicFieldsReducer = basicFieldReducer({chartId, activeTrace});
         return (
             <div style={{padding:'0 5px 7px'}}>

--- a/src/firefly/js/charts/ui/options/NewTracePanel.jsx
+++ b/src/firefly/js/charts/ui/options/NewTracePanel.jsx
@@ -29,7 +29,6 @@ function getSubmitChangesFunc(traceType) {
 }
 
 function getOptionsComponent({traceType, chartId, activeTrace, groupKey}) {
-    const {data, layout} = getChartData(chartId);
     switch(traceType) {
         case 'scatter':
             return (<ScatterOptions {...{chartId, activeTrace, groupKey}}/>);
@@ -39,10 +38,10 @@ function getOptionsComponent({traceType, chartId, activeTrace, groupKey}) {
             return (<HistogramOptions {...{chartId, activeTrace, groupKey}}/>);
         default:
             return (
-                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace})}>
+                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({chartId, activeTrace})}>
                     <ValidationField fieldKey={`_tables.data.${activeTrace}.x`}/>
                     <ValidationField fieldKey={`_tables.data.${activeTrace}.y`}/>
-                    <BasicOptionFields {...{activeTrace}}/>
+                    <BasicOptionFields {...{activeTrace, groupKey}}/>
                 </FieldGroup>
             );
     }
@@ -112,8 +111,8 @@ export function NewTracePanelBtn({tbl_id, chartId}) {
     );
 }
 
-function fieldReducer({data, layout, activeTrace}) {
-    const basicReducer = basicFieldReducer({data, layout, activeTrace});
+function fieldReducer({chartId, activeTrace}) {
+    const basicReducer = basicFieldReducer({chartId, activeTrace});
     const fields = {
         [`_tables.data.${activeTrace}.x`]: {
             fieldKey: `_tables.data.${activeTrace}.x`,

--- a/src/firefly/js/charts/ui/options/PlotlyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/PlotlyHistogramOptions.jsx
@@ -30,7 +30,7 @@ export class HistogramOptions extends SimpleComponent {
 
     render() {
         const {chartId} = this.props;
-        const {tablesources, layout, data, activeTrace:cActiveTrace=0} = getChartData(chartId);
+        const {tablesources, activeTrace:cActiveTrace=0} = getChartData(chartId);
         const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
         const groupKey = this.props.groupKey || `${chartId}-ffhist-${activeTrace}`;
         const tablesource = get(tablesources, [cActiveTrace]);
@@ -40,7 +40,7 @@ export class HistogramOptions extends SimpleComponent {
         return (
             <div style={{padding:'0 5px 7px'}}>
                 {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChanges}}/>}
-                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({data, layout, activeTrace, tablesources})}>
+                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({chartId, activeTrace})}>
                     <ColumnOrExpression {...xProps}/>
                     <ListBoxInputField fieldKey={`data.${activeTrace}.histfunc`} options={[{value:'count'}, {value:'sum'}, {value:'avg'}, {value:'min'}, {value:'max'}]}/>
                     <ValidationField fieldKey={`data.${activeTrace}.nbinsx`}/>
@@ -48,16 +48,17 @@ export class HistogramOptions extends SimpleComponent {
                     <ValidationField fieldKey={`data.${activeTrace}.xbins.start`}/>
                     <ValidationField fieldKey={`data.${activeTrace}.xbins.end`}/>
                     <br/>
-                    <BasicOptionFields {...{layout, data, activeTrace}}/>
+                    <BasicOptionFields {...{activeTrace, groupKey}}/>
                 </FieldGroup>
             </div>
         );
     }
 }
 
-export function fieldReducer({data, layout, activeTrace, tablesources={}}) {
+export function fieldReducer({chartId, activeTrace}) {
+    const {data, tablesources={}} = getChartData(chartId);
     const tablesourceMappings = get(tablesources[activeTrace], 'mappings');
-    const basicReducer = basicFieldReducer({data, layout, activeTrace, tablesources});
+    const basicReducer = basicFieldReducer({chartId, activeTrace, tablesources});
     const fields = {
         [`_tables.data.${activeTrace}.x`]: {
             fieldKey: `_tables.data.${activeTrace}.x`,


### PR DESCRIPTION
- Added options for plot boundaries, color map, and xyratio/stretch (for all chart types) 
- Added color picker to Color field. (Later we should have color input field.)
- Added field validation for boundary fields and logic to clear the fields on x and y changes.
- Color map and Size map can be column expressions. 
  (If Size map evaluates to a constant, it won't be connected to the table.) 

The issues that need to be resolved in the future tickets:
- Color input field
- Color bar display when color map is specified. (There is a number of issues with display: two tick sets, no update when color scale changes. We also need to make sure it's on the opposite side of yaxis.)
- Size map scaling: to make sure all points are visible, we might need to scale point size in pixels so that it falls into the valid range (4px and up), otherwise the points will be invisible.

Known issues to be resolved in future:

Currently it is possible to set boundaries from the options, but not when the chart is added. The reason is that as of now Plotly does not support setting upper or lower boundary for an axis, but it is likely that it [will be added in the future](https://github.com/plotly/plotly.js/issues/400).

You can still set the axis range in layout, but it's not that convenient, because it has to follow plotly limitations: both values in range need to be there, if the axis is reversed, the values need to be reversed, if the axis type is "log", the values need to be logs.  

https://jira.lsstcorp.org/browse/DM-8707
