### PR TITLE
IRSA-264: Different instances of Atlas send images to same IRSA Viewe…

### DIFF
--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -328,7 +328,7 @@ function makePlotSimple(llApi, plotId) {
 function showImageInMultiViewer(llApi, targetDiv, request) {
     const {dispatchPlotImage, dispatchAddViewer, dispatchAddImages}= llApi.action;
     const {findInvalidWPRKeys,confirmPlotRequest}= llApi.util.image;
-    const {renderDOM,debug}= llApi.util;
+    const {renderDOM,debug, getWsConnId, getWsChannel}= llApi.util;
     const {MultiImageViewer, MultiViewStandardToolbar}= llApi.ui;
 
     highlevelImageInit(llApi);
@@ -337,7 +337,7 @@ function showImageInMultiViewer(llApi, targetDiv, request) {
         const badList= findInvalidWPRKeys(r);
         if (badList.length) debug(`plot request has the following bad keys: ${badList}`);
     });
-    request= confirmPlotRequest(request,globalImageViewDefParams,targetDiv,makePlotId);
+    request= confirmPlotRequest(request,globalImageViewDefParams,targetDiv,makePlotId(getWsConnId));
 
     const plotId= !Array.isArray(request) ? request.plotId : request.find( (r) => r.plotId).plotId;
     dispatchAddViewer(targetDiv,'create_replace');
@@ -359,7 +359,7 @@ function initCoverage(llApi, targetDiv,options= {}) {
 
     renderDOM(targetDiv, MultiImageViewer,
         {viewerId:targetDiv, canReceiveNewPlots, canDelete:false, Toolbar:MultiViewStandardToolbar });
-    options= Object.assign({},options, {viewerId:targetDiv})
+    options= Object.assign({},options, {viewerId:targetDiv});
     dispatchAddSaga(watchCoverage, options);
 }
 
@@ -377,9 +377,11 @@ function highlevelImageInit(llApi) {
 
 var plotCnt= 0;
 
-function makePlotId() {
-    plotCnt++;
-    return 'apiPlot-'+plotCnt;
+function makePlotId(wsConnIdGetter) {
+    return () => {
+        plotCnt++;
+        return `apiPlot-${wsConnIdGetter()}-${plotCnt}`;
+    };
 }
 
 //================================================================

--- a/src/firefly/js/api/ApiUtil.js
+++ b/src/firefly/js/api/ApiUtil.js
@@ -25,6 +25,7 @@ import {take,race,call} from 'redux-saga/effects';
 export {getBoolean} from '../util/WebUtil.js';
 export {toBoolean} from '../util/WebUtil.js';
 
+export {getWsConnId, getWsChannel} from '../core/messaging/WebSocketClient.js';
 
 /**
  * Is in debug mode

--- a/src/firefly/js/api/ApiViewer.js
+++ b/src/firefly/js/api/ApiViewer.js
@@ -24,7 +24,7 @@ import {DT_XYCOLS} from '../charts/dataTypes/XYColsCDT.js';
 import {DT_HISTOGRAM} from '../charts/dataTypes/HistogramCDT.js';
 import {makeFileRequest}  from '../tables/TableUtil.js';
 import {makeXYPlotParams, makeHistogramParams, uniqueChartId} from '../charts/ChartUtil.js';
-import {getWsChannel} from '../core/messaging/WebSocketClient.js';
+import {getWsChannel, getWsConnId} from '../core/messaging/WebSocketClient.js';
 import {getConnectionCount, WS_CONN_UPDATED, GRAB_WINDOW_FOCUS} from '../core/AppDataCntlr.js';
 import {dispatchAddSaga} from '../core/MasterSaga.js';
 import {DEFAULT_FITS_VIEWER_ID} from '../visualize/MultiViewCntlr.js';
@@ -324,5 +324,5 @@ var plotCnt= 0;
 
 function makePlotId() {
     plotCnt++;
-    return 'apiPlotRemote-'+plotCnt;
+    return `apiPlot-${getWsConnId()}-${plotCnt}`;
 }


### PR DESCRIPTION
https://caltech-ipac.atlassian.net/browse/IRSA-264

Fixed multiple instances of Alas causes IRSA Viewer image to overwrite each other.
I added websocket connection ID(WS ID) to the plot ID.  WS ID is unique for each connecting client.  This helps make plot ID unique as well as retaining traceability.

To test: 
- deploy irsaviewer built from this branch.
- reconfigure personal irsa instance to point to your deployment
- launch multiple Atlas pages and send images to IRSA Viewer.