### PR TITLE
DM-10349 Chart expression logarithm to be the same as other languages

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/util/expr/Expr.java
+++ b/src/firefly/java/edu/caltech/ipac/util/expr/Expr.java
@@ -41,13 +41,15 @@ public abstract class Expr {
     /** Unary operator: cosine    */       public static final int COS   = 105;
     /** Unary operator: e to the x*/       public static final int EXP   = 106;
     /** Unary operator: floor     */       public static final int FLOOR = 107;
-    /** Unary operator: log 10*/           public static final int LOG   = 108;
+    /** Unary operator: natural log */     public static final int LOG   = 108;
     /** Unary operator: negation        */ public static final int NEG   = 109;
     /** Unary operator: rounding  */       public static final int ROUND = 110;
     /** Unary operator: sine      */       public static final int SIN   = 111;
     /** Unary operator: square root */     public static final int SQRT  = 112;
     /** Unary operator: tangent */         public static final int TAN   = 113;
-    /** Unary operator: natural log*/      public static final int LN   = 114;
+    /** Unary operator: natural log*/      public static final int LN    = 114;
+    /** Unary operator: log 10 */          public static final int LOG10 = 115;
+    /** Unary operator: log 10 */          public static final int LG    = 116;
 
     /** Make a literal expression.
      * @param v the constant value of the expression
@@ -126,8 +128,10 @@ class UnaryExpr extends Expr {
             case COS:   return Math.cos(arg);
             case EXP:   return Math.exp(arg);
             case FLOOR: return Math.floor(arg);
-            case LOG:   return Math.log10(arg);
-            case LN:   return Math.log(arg);
+            case LOG:   return Math.log(arg);
+            case LN:    return Math.log(arg);
+            case LOG10: return Math.log10(arg);
+            case LG:    return Math.log10(arg);
             case NEG:   return -arg;
             case ROUND: return Math.rint(arg);
             case SIN:   return Math.sin(arg);

--- a/src/firefly/java/edu/caltech/ipac/util/expr/Parser.java
+++ b/src/firefly/java/edu/caltech/ipac/util/expr/Parser.java
@@ -180,13 +180,13 @@ public class Parser {
     static private final String[] procs1 = {
             "abs", "acos", "asin", "atan",
             "ceil", "cos", "exp", "floor",
-            "log", "ln", "round", "sin", "sqrt",
+            "log", "ln", "lg", "log10", "round", "sin", "sqrt",
             "tan"
     };
     static private final int[] rators1 = {
             Expr.ABS, Expr.ACOS, Expr.ASIN, Expr.ATAN,
             Expr.CEIL, Expr.COS, Expr.EXP, Expr.FLOOR,
-            Expr.LOG, Expr.LN, Expr.ROUND, Expr.SIN, Expr.SQRT,
+            Expr.LOG, Expr.LN, Expr.LG, Expr.LOG10, Expr.ROUND, Expr.SIN, Expr.SQRT,
             Expr.TAN
     };
 

--- a/src/firefly/java/edu/caltech/ipac/util/expr/expressions.html
+++ b/src/firefly/java/edu/caltech/ipac/util/expr/expressions.html
@@ -1,0 +1,228 @@
+<!--
+Copyright 2002 by Darius Bacon <darius@wry.me>
+Altered
+-->
+<!DOCTYPE html>
+
+<html>
+<head><meta name="generator" content="Latte 2.1"><title>Expressing Formulas</title></head>
+   <body bgcolor="ivory"><p><h1>Expressing formulas</h1>
+
+<p>Here's how you can enter your formulas.  It's almost but not quite
+like ordinary math notation from the textbooks; there are differences
+because you have to type into input boxes instead of writing things
+out freehand.  For instance, to express <i>x<sup>2</sup></i>+1 you type in
+<code>x^2+1</code>.
+
+<p><h2>Basics</h2>
+
+<p>Adding and subtracting work as you'd expect: <code>x+5</code>, <code>1-x</code>.
+
+<p>To multiply, use <code>*</code>: <code>7*x</code> means 7 times <i>x</i>.
+
+<p>To divide, use <code>/</code>: <code>x/3</code> means <i>x</i> divided by 3.
+
+<p><i>x <sup>n</sup></i> is written <code>x^n</code>.
+
+<p>The square root of <i>x</i> is written <code>sqrt(x)</code>.
+
+<p>Putting all this together, here's a bigger example, a solution to the
+quadratic equation:<br><code>sqrt(b^2 - 4*a*c) / (2*a)</code>.
+
+<p><h2>Reference Manual</h2>
+
+<p><table align="center" width="95%" cellpadding="5" border="0">
+        <tr>
+             <td><b>Feature</b></td>
+             <td><b>Syntax</b></td>
+             <td><b>Examples</b></td>
+        </tr>
+        <tr>
+             <td>Numbers</td>
+             <td><code>1</code></td>
+             <td><dl><dt><code>42.5</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Variables</td>
+             <td><code>x</code></td>
+             <td><dl><dt><code>longvariablename</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td><i>x <sup>y</sup></i></td>
+             <td><code>x ^ y</code></td>
+             <td><dl><dt><code>3^2 = 9</code></dt><dt><code>2^2^3 = 2^8 = 256</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Multiply, divide</td>
+          <td><code>x * y</code></td>
+             <td><dl><dt><code>3*2 = 6</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td></td>
+             <td><code>x / y</code></td>
+             <td><dl><dt><code>3/2 = 1.5</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Add, subtract, negate</td>
+             <td><code>x + y</code></td>
+             <td><dl><dt><code>3+2 = 5</code></dt></dl></td>
+        </tr>
+        <tr><td></td>
+             <td><code>x - y</code></td>
+             <td><dl><dt><code>3-2 = 1</code></dt></dl></td>
+        </tr>
+        <tr><td></td>
+             <td><code>-x</code></td>
+             <td><dl><dt><code>-3 = 0-3</code></dt></dl></td>
+        </tr>
+        <tr><td>Comparison</td>
+             <td><code>x &lt; y</code></td>
+             <td><dl><dt><code>2&lt;3 = 1</code></dt><dt><code>2&lt;2 = 0</code></dt><dt><code>3&lt;2 = 0</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td></td>
+             <td><code>x &lt;= y</code></td>
+             <td><dl><dt><code>2&lt;=3 = 1</code></dt><dt><code>2&lt;=2 = 1</code></dt><dt><code>3&lt;=2 = 0</code></dt></dl></td>
+        </tr>
+        <tr><td></td>
+             <td><code>x = y</code></td>
+             <td><dl><dt><code>2=3 = 0</code></dt><dt><code>2=2 = 1</code></dt></dl></td></tr>
+        <tr><td></td>
+             <td><code>x &lt;&gt; y</code></td>
+             <td><dl><dt><code>2&lt;&gt;3 = 1</code></dt><dt><code>2&lt;&gt;2 = 0</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td></td>
+             <td><code>x &gt;= y</code></td>
+             <td><dl><dt>same as <code>y &lt;= x</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td></td>
+             <td><code>x &gt; y</code></td>
+             <td><dl><dt>same as <code>y &lt; x</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Conjunction</td>
+             <td><code>x and y</code></td>
+             <td><dl><dt><code>1 and 1 = 1</code></dt><dt><code>1 and 0 = 0</code></dt><dt><code>0 and 0 = 0</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Disjunction</td>
+             <td><code>x or y</code></td>
+             <td><dl><dt><code>1 or 1 = 1</code></dt><dt><code>1 or 0 = 1</code></dt><dt><code>0 or 0 = 0</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Absolute value</td>
+             <td><code>abs(x)</code></td>
+             <td><dl><dt><code>abs(-2) = 2</code></dt><dt><code>abs(2) = 2</code></dt></dl></td>
+        </tr>
+        <tr><td>Arc-cosine</td>
+             <td><code>acos(x)</code></td>
+             <td><dl><dt><code>acos(1) = 0</code></dt></dl></td>
+        </tr>
+        <tr><td>Arc-sine</td>
+             <td><code>asin(x)</code></td>
+             <td><dl><dt><code>asin(1) = pi/2</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Arc-tangent</td>
+             <td><code>atan(x)</code></td>
+             <td><dl><dt><code>atan(1) = pi/4</code></dt></dl></td>
+        </tr>
+        <tr><td></td>
+             <td><code>atan2(x, y)</code></td>
+             <td><dl><dt><code>atan(-1, -1) = -3 pi / 4</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Ceiling</td>
+             <td><code>ceil(x)</code></td>
+             <td><dl><dt><code>ceil(3.5) = 4</code></dt><dt><code>ceil(-3.5) = -3</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Cosine</td>
+             <td><code>cos(x)</code></td>
+             <td><dl><dt><code>cos(0) = 1</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td><i>e <sup>x</sup></i></td>
+             <td><code>exp(x)</code></td>
+             <td><dl><dt><code>exp(1) = 2.7182818284590451</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Floor</td>
+             <td><code>floor(x)</code></td>
+             <td><dl><dt><code>floor(3.5) = 3</code></dt><dt><code>floor(-3.5) = -4</code></dt></dl></td>
+        </tr>
+        <tr>
+             <td>Conditional</td>
+             <td><code>if(x, y, z)</code></td>
+             <td><dl><dt><code>if(1, 42, 137) = 42</code></dt><dt><code>if(0, 42, 137) = 137</code></dt></dl></td>
+        </tr>
+       <tr>
+           <td>Natural logarithm</td>
+           <td><code>log(x)</code> or <code>ln(x)</code></td>
+           <td><dl><dt><code>log(2.7182818284590451) = 1</code></dt><dt><code>ln(2.7182818284590451) = 1</code></dt></dl></td>
+       </tr>
+       <tr>
+           <td>Common logarithm</td>
+           <td><code>log10(x)</code> or <code>lg(x)</code></td>
+           <td><dl><dt><code>log10(10) = 1</code></dt><dt><code>lg(10) = 1</code></dt></dl></td>
+       </tr>
+       <tr>
+           <td>Maximum</td>
+           <td><code>max(x, y)</code></td>
+           <td><dl><dt><code>max(2, 3) = 3</code></dt></dl></td>
+       </tr>
+       <tr>
+           <td>Minimum</td>
+           <td><code>min(x, y)</code></td>
+           <td><dl><dt><code>min(2, 3) = 2</code></dt></dl></td>
+       </tr>
+       <tr>
+           <td>Rounding</td>
+           <td><code>round(x)</code></td>
+           <td><dl><dt><code>round(3.5) = 4</code></dt><dt><code>round(-3.5) = -4</code></dt></dl></td>
+       </tr>
+       <tr>
+           <td>Sine</td>
+           <td><code>sin(x)</code></td>
+           <td><dl><dt><code>sin(pi/2) = 1</code></dt></dl></td>
+       </tr>
+       <tr>
+           <td>Square root</td>
+           <td><code>sqrt(x)</code></td>
+           <td><dl><dt><code>sqrt(9) = 3</code></dt></dl></td>
+       </tr>
+       <tr>
+           <td>Tangent</td>
+           <td><code>tan(x)</code></td>
+           <td><dl><dt><code>tan(pi/4) = 1</code> (approximately)</dt></dl></td>
+       </tr>
+   </table>
+
+<p><h2>Pitfalls</h2>
+
+
+<p>Write <code>0 &lt; x and x &lt; 5</code>, rather than <code>0 &lt; x &lt; 5</code>.  The
+latter is interpreted as <code>(0 &lt; x) &lt; 5</code>, which first evaluates
+<code>0 &lt; x</code> yielding a truth value (1 or 0 for true or false), then
+compares that truth value to 5.  Don't do that!
+
+<p><code>a/b*c</code> is not <code>a/(b*c)</code>.  In handwritten math notation
+you could write that with <code>a</code> above the division line and <code>b*c</code> vertically below it, but we can't do that here: everything is
+horizontal and so the program can't tell if you meant <code>(a/b)*c</code>
+or <code>a/(b*c)</code>.  (It chooses the first, in fact.)  When in doubt,
+use parentheses.
+
+<p>The program does not understand <code>sin x</code>, but requires <code>sin(x)</code> instead.  This is because, if you said <code>sin x * y</code>, it'd
+be uncertain whether you meant <code>sin(x * y)</code> or <code>(sin(x)) *
+y</code>.  So all the functions need parentheses; the lessened ambiguity is
+worth the extra typing.
+
+<p>While you can refer to real numbers like pi and e and the square root
+of 2, this program can't represent them exactly; it only holds onto a
+fixed number of digits.  For example, computing <code>tan(pi/4)</code>
+doesn't give 1 exactly, but 0.99999999999999989.  You can get
+completely bogus answers if your formulas are too sensitive to these
+imprecisions; there isn't space here to treat this issue.</body>
+</html>

--- a/src/firefly/js/charts/dataTypes/FireflyHistogram.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHistogram.js
@@ -29,7 +29,7 @@ export function getTraceTSEntries({chartId, traceNum}) {
     const histogramParams = get(fireflyData, `${traceNum}.options`);
     options['columnExpression'] = histogramParams.columnOrExpr;
     if (get(layout, 'xaxis.type') === 'log') {
-        options.columnExpression = 'log('+histogramParams.columnOrExpr+')';
+        options.columnExpression = 'lg('+histogramParams.columnOrExpr+')';
     }
     if (histogramParams.fixedBinSizeSelection) { // fixed size bins
         options.fixedBinSizeSelection=histogramParams.fixedBinSizeSelection;

--- a/src/firefly/js/charts/dataTypes/HistogramCDT.js
+++ b/src/firefly/js/charts/dataTypes/HistogramCDT.js
@@ -106,7 +106,7 @@ function fetchColData(dispatch, chartId, chartDataElementId) {
     // histogram parameters
     req.columnExpression = histogramParams.columnOrExpr;
     if (histogramParams.x && histogramParams.x.includes('log')) {
-        req.columnExpression = 'log('+req.columnExpression+')';
+        req.columnExpression = 'lg('+req.columnExpression+')';
     }
     if (histogramParams.fixedBinSizeSelection) { // fixed size bins
         req.fixedBinSizeSelection=histogramParams.fixedBinSizeSelection;

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -11,6 +11,10 @@ import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
 import ColValuesStatistics from '../ColValuesStatistics.js';
 import {showColSelectPopup} from './ColSelectView.jsx';
 
+const EXPRESSION_TTIPS = `
+Supported operators: ^, *, /, +, -, <, <=, =, <>, >=, >, and, or.
+Supported functions: abs(x), acos(x), asin(x), atan(x), atan2(x,y), ceil(x), cos(x), exp(x), floor(x), if(x,y,z), lg(x), ln(x), log10(x), log(x), max(x,y), min(x,y), round(x), sin(x), sqrt(x), tan(x).
+Example: sqrt(b^2 - 4*a*c) / (2*a), where a, b, c are column names.`;
 
 /*
  * Split content into prior content and the last alphanumeric token in the text
@@ -55,6 +59,9 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
 
     const getSuggestions = (val)=>{
         const {token} = parseSuggestboxContent(val);
+        if (val && val.endsWith(')')) {
+            return [];
+        }
         const matches = allSuggestions.filter( (idx)=>{return colValStats[idx].name.startsWith(token);} );
         return matches.length ? matches : allSuggestions;
     };
@@ -91,7 +98,7 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
                     valid,
                     message,
                     validator: colValidator,
-                    tooltip: `Column or expression for ${tooltip ? tooltip : name}`,
+                    tooltip: `Column or expression for ${tooltip ? tooltip : name}.${EXPRESSION_TTIPS}`,
                     nullAllowed
                 }}
                 getSuggestions={getSuggestions}

--- a/src/firefly/js/ui/SuggestBoxInputField.jsx
+++ b/src/firefly/js/ui/SuggestBoxInputField.jsx
@@ -135,7 +135,7 @@ class SuggestBoxInputFieldView extends PureComponent {
         var displayValue = get(ev, 'target.value');
         var {valid,message} = this.props.validator(displayValue);
         const inputWidth = ev.target.offsetWidth ? ev.target.offsetWidth : this.state.inputWidth;
-        this.setState({displayValue, valid, message, isOpen: false, suggestions: [], inputWidth});
+        this.setState({displayValue, valid, message, inputWidth});
         this.updateSuggestions(displayValue);
         this.props.fireValueChange({ value : displayValue, message, valid});
     }
@@ -147,6 +147,8 @@ class SuggestBoxInputFieldView extends PureComponent {
             // make sure the suggestions are still relevant when promise returns
             if (arrayOrPromise === this.suggestionsPromise && isArray(suggestions) && suggestions.length > 0) {
                 this.setState({isOpen: true, suggestions});
+            } else {
+                this.setState({isOpen: false, suggestions: []});
             }
         }).catch((err) => logError(err));
     }

--- a/src/firefly/js/util/expr/Expr.js
+++ b/src/firefly/js/util/expr/Expr.js
@@ -27,21 +27,27 @@
 /** Unary operator: cosine    */       export const COS   = 105;
 /** Unary operator: e to the x*/       export const EXP   = 106;
 /** Unary operator: floor     */       export const FLOOR = 107;
-/** Unary operator: log 10 */          export const LOG   = 108;
+/** Unary operator: natural log */     export const LOG   = 108;
 /** Unary operator: negation  */       export const NEG   = 109;
 /** Unary operator: rounding  */       export const ROUND = 110;
 /** Unary operator: sine      */       export const SIN   = 111;
 /** Unary operator: square root */     export const SQRT  = 112;
 /** Unary operator: tangent */         export const TAN   = 113;
-/** Unary operator: natural log*/      export const LN    = 114;
+/** Unary operator: natural log */     export const LN    = 114;
+/** Unary operator: log 10 */          export const LOG10 = 115;
+/** Unary operator: log 10 */          export const LG    = 116;
 
-/** Make a literal expression.
+/**
+ * Make a literal expression.
  * @param {number} v the constant value of the expression
- * @return an expression whose value is always v */
+ * @return an expression whose value is always v
+ */
 export function makeLiteral(v) {
     return new LiteralExpr(v);
 }
-/** Make an expression that applies a unary operator to an operand.
+
+/**
+ * Make an expression that applies a unary operator to an operand.
  * @param {number} rator (int) a code for a unary operator
  * @param rand operand (Expr)
  * @return an expression meaning rator(rand)
@@ -52,10 +58,11 @@ export function makeApp1(rator, rand) {
             ? new LiteralExpr(app.value())
             : app;
 }
-/** Make an expression that applies a binary operator to two operands.
- * @param rator (int) a code for a binary operator
- * @param rand0 (Expr) left operand
- * @param rand1 (Expr) right operand
+/**
+ * Make an expression that applies a binary operator to two operands.
+ * @param {number} rator - a code for a binary operator
+ * @param {Expr} rand0 - left operand
+ * @param {Expr} rand1  right operand
  * @return an expression meaning rator(rand0, rand1)
  */
 export function makeApp2(rator, rand0, rand1) {
@@ -64,12 +71,12 @@ export function makeApp2(rator, rand0, rand1) {
             ? new LiteralExpr(app.value())
             : app;
 }
-/** Make a conditional expression.
+/**
+ * Make a conditional expression.
  * @param test (Expr) `if' part
  * @param consequent (Expr) `then' part
  * @param alternative (Expr) `else' part
- * @return an expression meaning `if test, then consequent, else
- *         alternative' 
+ * @return an expression meaning `if test, then consequent, else alternative'
  */
 export function makeIfThenElse(test,
                         consequent,
@@ -110,8 +117,10 @@ class UnaryExpr {
             case COS:   return Math.cos(arg);
             case EXP:   return Math.exp(arg);
             case FLOOR: return Math.floor(arg);
-            case LOG:   return Math.log10(arg);
-            case LN:   return Math.log(arg);
+            case LOG:   return Math.log(arg);
+            case LN:    return Math.log(arg);
+            case LOG10: return Math.log10(arg);
+            case LG:    return Math.log10(arg);
             case NEG:   return -arg;
             case ROUND: return Math.round(arg);
             case SIN:   return Math.sin(arg);
@@ -143,12 +152,12 @@ class BinaryExpr {
             case MIN:   return arg0 < arg1 ? arg0 : arg1;
             case LT:    return arg0 <  arg1 ? 1.0 : 0.0;
             case LE:    return arg0 <= arg1 ? 1.0 : 0.0;
-            case EQ:    return arg0 == arg1 ? 1.0 : 0.0;
-            case NE:    return arg0 != arg1 ? 1.0 : 0.0;
+            case EQ:    return arg0 === arg1 ? 1.0 : 0.0;
+            case NE:    return arg0 !== arg1 ? 1.0 : 0.0;
             case GE:    return arg0 >= arg1 ? 1.0 : 0.0;
             case GT:    return arg0  > arg1 ? 1.0 : 0.0;
-            case AND:   return arg0 != 0 && arg1 != 0 ? 1.0 : 0.0;
-            case OR:    return arg0 != 0 || arg1 != 0 ? 1.0 : 0.0;
+            case AND:   return arg0 !== 0 && arg1 !== 0 ? 1.0 : 0.0;
+            case OR:    return arg0 !== 0 || arg1 !== 0 ? 1.0 : 0.0;
             default: throw 'BUG: bad rator: '+this.rator;
         }
     }

--- a/src/firefly/js/util/expr/Parser.js
+++ b/src/firefly/js/util/expr/Parser.js
@@ -18,14 +18,14 @@ const operatorChars = '*/+-^<>=,()';
 const procs1 = [
         'abs', 'acos', 'asin', 'atan',
         'ceil', 'cos', 'exp', 'floor',
-        'log', 'ln', 'round', 'sin', 'sqrt',
+        'log', 'ln', 'lg', 'log10', 'round', 'sin', 'sqrt',
         'tan'
 ];
 
 const rators1 = [
         Expr.ABS, Expr.ACOS, Expr.ASIN, Expr.ATAN,
         Expr.CEIL, Expr.COS, Expr.EXP, Expr.FLOOR,
-        Expr.LOG, Expr.LN, Expr.ROUND, Expr.SIN, Expr.SQRT,
+        Expr.LOG, Expr.LN, Expr.LG, Expr.LOG10, Expr.ROUND, Expr.SIN, Expr.SQRT,
         Expr.TAN
 ];
 


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-10349

Use the following functions for logarithms in Firefly column expressions: 
   log, ln – for natural logarithm
   log10, lg – for common logarithm
 
(The meaning of 'log' has changed from lg to ln to match definitions in JS or Python.)

Added documentation for expressions to both code and tooltips.

Reduced the number of suggest box updates to avoid flickering.