### PR TITLE
IRSA-504 workspace server api

### DIFF
--- a/config/app-test.prop
+++ b/config/app-test.prop
@@ -11,8 +11,6 @@ irsa.gator.service.periodogram.url=https://irsa.ipac.caltech.edu/cgi-bin/periodo
 irsa.gator.service.periodogram.keys=x y alg peaks
 
 workspace.host.url=https://irsa.ipac.caltech.edu
-# USE FOR SSO Test:
-#workspace.host.url=https://irsadev.ipac.caltech.edu
 workspace.root.dir=/work
 workspace.protocol.irsa=webdav
 workspace.protocol.irsa.webdav=edu.caltech.ipac.firefly.server.WebDAVWorkspaceManager

--- a/config/app-test.prop
+++ b/config/app-test.prop
@@ -9,3 +9,12 @@ irsa.gator.service.periodogram.url=https://irsa.ipac.caltech.edu/cgi-bin/periodo
 
 # Periodogram API request parameter list definition, separated by space
 irsa.gator.service.periodogram.keys=x y alg peaks
+
+workspace.host.url=https://zeus2.ipac.caltech.edu
+workspace.root.dir=.
+workspace.protocol.irsa=webdav
+workspace.protocol.irsa.webdav=edu.caltech.ipac.firefly.server.WebDAVWorkspaceManager
+
+# Another Impl?-> See edu.caltech.ipac.firefly.server.ws.WebDAVWorkspaceHandler#withCredentials
+# workspace.protocol.irsa.webdav=edu.caltech.ipac.firefly.server.ws.WebdavImpl
+

--- a/config/app-test.prop
+++ b/config/app-test.prop
@@ -10,8 +10,10 @@ irsa.gator.service.periodogram.url=https://irsa.ipac.caltech.edu/cgi-bin/periodo
 # Periodogram API request parameter list definition, separated by space
 irsa.gator.service.periodogram.keys=x y alg peaks
 
-workspace.host.url=https://zeus2.ipac.caltech.edu
-workspace.root.dir=.
+workspace.host.url=https://irsa.ipac.caltech.edu
+# USE FOR SSO Test:
+#workspace.host.url=https://irsadev.ipac.caltech.edu
+workspace.root.dir=/work
 workspace.protocol.irsa=webdav
 workspace.protocol.irsa.webdav=edu.caltech.ipac.firefly.server.WebDAVWorkspaceManager
 

--- a/config/log4j-test.properties
+++ b/config/log4j-test.properties
@@ -7,8 +7,8 @@ log4j.logger.test=WARN, A1
 log4j.additivity.test= false
 
 # turn off logs coming from our code
-log4j.logger.edu=OFF
-log4j.additivity.edu= false
+log4j.logger.edu=OFF,A1
+log4j.additivity.edu=false
 
 
 # A1 is set to be a ConsoleAppender.

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -169,5 +169,10 @@ public class ServerParams {
 
     public static final String INIT_APP = "CmdInitApp";
     public static final String LOGOUT = "CmdLogout";
+
+    //Workspaces
+    public static final String WS_LIST = "wsList";
+    public static final String WS_GET_FILE = "wsGet";
+    public static final String WS_PUT_FILE = "wsPut";
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/WspaceMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/WspaceMeta.java
@@ -26,12 +26,23 @@ public class WspaceMeta implements Serializable {
     public static final String DESC = "desc";
     public static final String TYPE = "type";
 
+    public void setUrl(String url) {
+        this.url = url;
+    }
 
-    public enum Includes {NONE(false,0), NONE_PROPS(true, 0), CHILDREN(false,1), CHILDREN_PROPS(true, 1), ALL(false), ALL_PROPS(true);
+    public String getUrl() {
+        return url;
+    }
+
+    public enum Includes {
+        NONE(false, 0), NONE_PROPS(true, 0), CHILDREN(false, 1), CHILDREN_PROPS(true, 1), ALL(false), ALL_PROPS(true);
         public boolean inclProps = false;
         public int depth = 0;
 
-        Includes(boolean b) {this(b, Integer.MAX_VALUE);}
+        Includes(boolean b) {
+            this(b, Integer.MAX_VALUE);
+        }
+
         Includes(boolean b, int d) {
             inclProps = b;
             depth = d;
@@ -45,8 +56,11 @@ public class WspaceMeta implements Serializable {
     private long size = -1;
     private String lastModified;
     private String contentType;
+    private String creationDate;
+    private String url;
 
-    public WspaceMeta() {}
+    public WspaceMeta() {
+    }
 
     public WspaceMeta(String relPath) {
         this(null, relPath, null);
@@ -88,16 +102,17 @@ public class WspaceMeta implements Serializable {
 
     /**
      * returns the name of the file, it's a file type, or "" otherwise.
+     *
      * @return
      */
     public String getFileName() {
         int idx = relPath.lastIndexOf("/");
         if (idx < 0) {
             return relPath;
-        } else if(idx == relPath.length() -1) {
+        } else if (idx == relPath.length() - 1) {
             return "";
         } else {
-            return relPath.substring(idx+1);
+            return relPath.substring(idx + 1);
         }
     }
 
@@ -106,13 +121,13 @@ public class WspaceMeta implements Serializable {
         if (s.equals("/")) return null;
 
         if (s.endsWith("/")) {
-            s.substring(0, s.length()-1);
+            s.substring(0, s.length() - 1);
         }
         int idx = relPath.lastIndexOf("/");
         if (idx <= 0) {
             return "/";
         } else {
-            return relPath.substring(0, idx+1);
+            return relPath.substring(0, idx + 1);
         }
     }
 
@@ -120,11 +135,13 @@ public class WspaceMeta implements Serializable {
     public String toString() {
         StringBuffer s = new StringBuffer("-----------------------------\n");
         s.append(wsHome).append(relPath).append("\n");
+        s.append("creationDate:").append(creationDate).append("\n");
         s.append("lastModified:").append(lastModified).append("\n");
         s.append("contentType:").append(contentType).append("\n");
         s.append("size:").append(size).append("\n");
+        s.append("url:").append(url).append("\n");
         if (getProperties() != null && getProperties().size() > 0) {
-            for(String key : getProperties().keySet()) {
+            for (String key : getProperties().keySet()) {
                 s.append("\t").append(key).append(": ").append(getProperty(key)).append("\n");
             }
         }
@@ -183,6 +200,14 @@ public class WspaceMeta implements Serializable {
         return contentType;
     }
 
+    public void setCreationDate(String val) {
+        this.creationDate = val;
+    }
+
+    public String getCreationDate() {
+        return this.creationDate;
+    }
+
     //====================================================================
 //  nodes graph
 //====================================================================
@@ -208,6 +233,7 @@ public class WspaceMeta implements Serializable {
 
     /**
      * return a list of all the nodes under this one in depth first order.
+     *
      * @return
      */
     public List<WspaceMeta> getAllNodes() {
@@ -237,6 +263,7 @@ public class WspaceMeta implements Serializable {
     /**
      * searches this node and all of its descendant to find the
      * first matching path given.
+     *
      * @param path
      * @return
      */
@@ -265,7 +292,7 @@ public class WspaceMeta implements Serializable {
             return "";
         }
         s = !s.startsWith("/") ? "/" + s : s;
-        s = s.endsWith("/") ? s.substring(0, s.length()-1): s;
+        s = s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
         return s;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
@@ -6,6 +6,7 @@ import edu.caltech.ipac.firefly.server.ws.WsCredentials;
 import edu.caltech.ipac.firefly.server.ws.WsException;
 import edu.caltech.ipac.firefly.server.ws.WsResponse;
 import edu.caltech.ipac.firefly.server.ws.WsUtil;
+import edu.caltech.ipac.util.AppProperties;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -21,6 +22,8 @@ import java.nio.file.Paths;
  * Created by ejoliet on 6/21/17.
  */
 public class LocalFSWorkspace implements WorkspaceManager {
+    //TODO We might need to change those properties if we need to deal with 2 or more workspaces at the same time
+    String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
 
 
     private final WsCredentials wscred;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Consumer;
 
 /**
  * LOCAL filesystem implementation of workspace- NOT FULLY IMPLEMENTED
@@ -75,6 +76,11 @@ public class LocalFSWorkspace implements WorkspaceManager {
 
     @Override
     public WsResponse getList(String parentUri, int depth) throws IOException {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public WsResponse getFile(String fileUri, Consumer consumer) throws WsException {
         throw new IllegalArgumentException("not implemented");
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
@@ -1,0 +1,163 @@
+package edu.caltech.ipac.firefly.server;
+
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
+import edu.caltech.ipac.firefly.server.ws.WsException;
+import edu.caltech.ipac.firefly.server.ws.WsResponse;
+import edu.caltech.ipac.firefly.server.ws.WsUtil;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * LOCAL filesystem implementation of workspace- NOT FULLY IMPLEMENTED
+ * For testing purposes so far
+ * Created by ejoliet on 6/21/17.
+ */
+public class LocalFSWorkspace implements WorkspaceManager {
+
+
+    private final WsCredentials wscred;
+
+    public LocalFSWorkspace() {
+        String userHome = System.getProperty("user.home");
+        String userKey = userHome;
+        if (userHome.lastIndexOf(File.separator) > 0) {
+            userKey = userHome.substring(userHome.lastIndexOf(File.separator) + 1, userHome.length());
+        }
+        wscred = new WsCredentials(userKey);
+    }
+
+    public LocalFSWorkspace(WsCredentials cred) {
+        wscred = cred;
+    }
+
+    public static final String WS_ROOT_DIR = ".";
+
+    private static final Logger.LoggerImpl LOG = Logger.getLogger();
+
+    private void createIfNotExist(String parent) {
+        new File(parent).mkdirs();
+    }
+
+
+    @Override
+    public String getProp(PROPS prop) {
+        PROPS propFound = null;
+        for (PROPS p : PROPS.values()) {
+            if (p.name().equalsIgnoreCase(prop.name())) {
+                propFound = p;
+            }
+        }
+        String propVal = prop + " doesn't exist";
+        if (propFound.equals(PROPS.ROOT_URL)) {
+            propVal = WS_HOST_URL;
+        } else if (propFound.equals(PROPS.ROOT_DIR)) {
+            propVal = WS_ROOT_DIR;
+        } else if (propFound.equals(PROPS.AUTH)) {
+            propVal = "NONE";
+        } else if (propFound.equals(PROPS.PROTOCOL)) {
+            propVal = PROTOCOL.WEBDAV.name();
+        }
+
+        return propVal;
+    }
+
+
+    @Override
+    public WsResponse getList(String parentUri, int depth) throws IOException {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public WsResponse getFile(String fileUri, File outputFile) throws WsException {
+        try {
+            byte[] bytes = Files.readAllBytes(Paths.get(getResourceUrl(fileUri)));
+            FileUtils.writeByteArrayToFile(outputFile, bytes);
+            return WsUtil.success(200, "Downloaded", outputFile.getAbsolutePath());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        WsResponse resp = WsUtil.error(500);
+        return resp;
+    }
+
+    String getResourceUrl(String res) {
+        return getWsHome() + "/" + res;
+    }
+
+    @Override
+    public WsResponse putFile(String relUri, File item, String contentType) throws WsException {
+
+        File parent = new File(getResourceUrl(relUri));
+        Path fileUpload = Paths.get("", item.getAbsolutePath());
+        if (!parent.exists()) {
+            createIfNotExist(relUri);
+        }
+        try {
+            String newFile = parent.getAbsolutePath() + File.separator + item.getName();
+            Files.copy(fileUpload, new FileOutputStream(newFile));
+            return WsUtil.success(200, "Created", newFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return WsUtil.error(500);
+    }
+
+    @Override
+    public File createWsLocalFile(String wspaceSaveDirectory, String filePrefix, String fileExt) {
+        return null;
+    }
+
+    @Override
+    public WsResponse delete(String uri) throws WsException {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public WsResponse createParent(String newParentRelUri) throws WsException {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public WsResponse renameFile(String originalFileRelPath, String fileName, boolean b) throws WsException {
+
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public WspaceMeta getMeta(String uri, WspaceMeta.Includes includes) {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public boolean setMeta(WspaceMeta... metas) {
+        return false;
+    }
+
+    @Override
+    public WspaceMeta newLocalWsMeta(File file, String propName, String value) {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public WsCredentials getCredentials() {
+        return wscred;
+    }
+
+    @Override
+    public String getWsHome() {
+        return WS_ROOT_DIR;
+    }
+
+    @Override
+    public PROTOCOL getProtocol() {
+        return PROTOCOL.LOCAL;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -9,6 +9,8 @@ import edu.caltech.ipac.firefly.server.events.FluxAction;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
 import edu.caltech.ipac.firefly.server.security.SsoAdapter;
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.ws.WorkspaceFactory;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.Cache;
@@ -83,9 +85,9 @@ public class RequestOwner implements Cloneable {
         if (wsManager == null) {
             getUserInfo();
             if (userInfo.isGuestUser()) {
-                wsManager = new WorkspaceManager(getUserKey());
+                wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(getUserKey()));
             } else {
-                wsManager = new WorkspaceManager(userInfo.getLoginName(), getIdentityCookies());
+                wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(userInfo.getLoginName(), getIdentityCookies()));
             }
         }
         return wsManager;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
@@ -17,6 +17,7 @@ import edu.caltech.ipac.firefly.server.rpc.ResourceServerCommands;
 import edu.caltech.ipac.firefly.server.rpc.VisServerCommands;
 import edu.caltech.ipac.firefly.server.servlets.HttpServCommands;
 import edu.caltech.ipac.firefly.server.query.SearchServerCommands;
+import edu.caltech.ipac.firefly.server.ws.WsServerCommands;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -66,6 +67,11 @@ public class ServerCommandAccess {
 
         _cmdMap.put(ServerParams.USER_KEY,   new ResourceServerCommands.UserKey());
         _cmdMap.put(ServerParams.VERSION,      new ResourceServerCommands.GetVersion());
+
+        //Workspaces
+        _cmdMap.put(ServerParams.WS_LIST,               new WsServerCommands.WsList());
+        _cmdMap.put(ServerParams.WS_GET_FILE,           new WsServerCommands.WsGetFile());
+        _cmdMap.put(ServerParams.WS_PUT_FILE,           new WsServerCommands.WsPutFile());
 
         _cmdMap.put(ServerParams.RAW_DATA_SET,           new SearchServerCommands.GetRawDataSet());
         _cmdMap.put(ServerParams.JSON_DATA,              new SearchServerCommands.GetJSONData());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * WebDAV implementation for IRSA
@@ -347,6 +348,11 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
         } catch (IOException e) {
             throw new WsException("Fail to get the file " + fileUri);
         }
+    }
+
+    @Override
+    public WsResponse getFile(String fileUri, Consumer consumer) throws WsException {
+        throw new IllegalArgumentException("not implemented");
     }
 
     @Override

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
@@ -1,0 +1,688 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server;
+
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.network.HttpServices;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
+import edu.caltech.ipac.firefly.server.ws.WsException;
+import edu.caltech.ipac.firefly.server.ws.WsResponse;
+import edu.caltech.ipac.firefly.server.ws.WsUtil;
+import edu.caltech.ipac.util.StringUtils;
+import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
+import org.apache.commons.httpclient.methods.RequestEntity;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.jackrabbit.webdav.DavConstants;
+import org.apache.jackrabbit.webdav.DavMethods;
+import org.apache.jackrabbit.webdav.MultiStatus;
+import org.apache.jackrabbit.webdav.MultiStatusResponse;
+import org.apache.jackrabbit.webdav.client.methods.*;
+import org.apache.jackrabbit.webdav.property.*;
+import org.apache.jackrabbit.webdav.xml.Namespace;
+
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * WebDAV implementation for IRSA
+ * Everything relative to ws home (as URI remote)
+ * Date: 6/12/14
+ *
+ * @author loi
+ * @version $Id: $
+ */
+public class WebDAVWorkspaceManager implements WorkspaceManager {
+
+    /**
+     * TODO is this used currently or should/will it be used in the future?
+     */
+    private static final Namespace IRSA_NS = Namespace.getNamespace("irsa", "https://irsa.ipac.caltech.edu/namespace/");
+
+    private static final Logger.LoggerImpl LOG = Logger.getLogger();
+    private WsCredentials creds;
+
+    @Override
+    public String getProp(PROPS prop) {
+        PROPS propFound = null;
+        for (PROPS p : PROPS.values()) {
+            if (p.name().equalsIgnoreCase(prop.name())) {
+                propFound = p;
+                break;
+            }
+        }
+        String propVal = prop + " doesn't exist";
+        if (propFound.equals(PROPS.ROOT_URL)) {
+            propVal = WS_HOST_URL;
+        } else if (propFound.equals(PROPS.ROOT_DIR)) {
+            propVal = WS_ROOT_DIR;
+        } else if (propFound.equals(PROPS.AUTH)) {
+            propVal = this.partition.name();
+        } else if (propFound.equals(PROPS.PROTOCOL)) {
+            propVal = PROTOCOL.WEBDAV.name();
+        }
+
+        return propVal;
+    }
+
+    public enum Partition {
+        PUBSPACE, SSOSPACE;
+
+        public String toString() {
+            return name().toLowerCase();
+        }
+    }
+
+    private Partition partition;
+    private String userHome;
+    private Map<String, String> cookies;
+
+    public WebDAVWorkspaceManager(WsCredentials cred) {
+        this(Partition.PUBSPACE, cred, true);
+    }
+
+    public WebDAVWorkspaceManager(String pubspaceId) {
+        this(Partition.PUBSPACE, new WsCredentials(pubspaceId), true);
+    }
+
+    public WebDAVWorkspaceManager(String ssospaceId, Map<String, String> cookies) {
+        this(Partition.SSOSPACE, new WsCredentials(ssospaceId, cookies), false);
+
+    }
+
+    public WebDAVWorkspaceManager(Partition partition, WsCredentials cred, boolean initialize) {
+        this(partition, cred.getWsId(), cred.getCookies(), initialize);
+        this.creds = cred;
+    }
+
+    public WebDAVWorkspaceManager(Partition partition, String wsId, Map<String, String> cookies, boolean initialize) {
+        this.creds = new WsCredentials(wsId, cookies);
+        this.partition = partition;
+        this.userHome = WspaceMeta.ensureWsHomePath(wsId);
+        this.cookies = cookies;
+        if (initialize) {
+            davMakeDir("");
+        }
+    }
+
+    /**
+     * returns the local filesystem path of the given relpath.
+     *
+     * @param relPath relative to the user's workspace and must starts with '/'
+     * @return
+     */
+    public String getLocalFsPath(String relPath) {
+        return WS_ROOT_DIR + getAbsPath(relPath);
+    }
+
+    /**
+     * returns the webdav's absolute path.  for IRSA, it's /partition/user_ws/relpath.
+     *
+     * @param relPath relative to the user's workspace and must starts with '/'
+     * @return
+     */
+    public String getAbsPath(String relPath) {
+        String s = WspaceMeta.ensureRelPath(relPath);
+        return getWsHome() + s;
+    }
+
+    /**
+     * returns the relative path given the file.  for IRSA, it's /partition/user_ws/relpath.
+     *
+     * @param file relative to the user's workspace and must starts with '/'
+     * @return
+     */
+    public String getRelPath(File file) {
+        String s = file.getAbsolutePath().replaceFirst(WS_ROOT_DIR, "");
+        s = s.replaceFirst(getWsHome(), "");
+        return s;
+    }
+
+    /**
+     * return the url of this resource.
+     *
+     * @param relPath
+     * @return
+     */
+    public String getResourceUrl(String relPath) {
+        return WS_HOST_URL + getAbsPath(relPath);
+    }
+
+    public String getWsHome() {
+        return "/" + partition + userHome;
+    }
+
+    public File createWsLocalFile(String parent, String fname, String fext) {
+        davMakeDir(parent);
+        return new File(new File(getLocalFsPath(parent)), fname + "-" + System.currentTimeMillis() % 1000000 + fext);
+    }
+
+
+//====================================================================
+//  WEBDAV functions
+//====================================================================
+
+    /**
+     * create a directory given by the relPath parameter.
+     *
+     * @param relPath relative to the user's workspace
+     * @return the absolute path to the directory on the filesystem.
+     */
+    public File davMakeDir(String relPath) {
+        try {
+            String[] parts = relPath.split("/");
+            String cdir = "/";
+            for (String s : parts) {
+                cdir += StringUtils.isEmpty(s) ? "" : s + "/";
+                WspaceMeta m = getMeta(cdir, WspaceMeta.Includes.NONE);
+                if (m == null) {
+                    DavMethod mkcol = new MkColMethod(getResourceUrl(cdir));
+                    if (!executeMethod(mkcol)) {
+                        // handle error
+                        LOG.error("Unable to create directory:" + relPath + " -- " + mkcol.getStatusText());
+                        return null;
+                    }
+                }
+            }
+            return new File(getLocalFsPath(relPath));
+        } catch (Exception e) {
+            LOG.error(e, "Error while makeCollection:" + relPath);
+        }
+        return null;
+    }
+
+    boolean exists(String relRemoteUri) {
+        return getMeta(relRemoteUri, WspaceMeta.Includes.NONE) != null;
+    }
+
+    /**
+     * @param upload
+     * @param relPath expecting uri folder a/b
+     * @return
+     */
+    public WsResponse davPut(File upload, String relPath, String contentType) {
+        try {
+            String parentPath = WsUtil.ensureUriFolderPath(relPath);
+            //if (!exists(parentPath)) {
+            WsResponse response = createParent(parentPath);
+            //}
+            // If parent and file name exists already, stop
+            if (!response.doContinue()) {
+                return WsUtil.error(Integer.parseInt(response.getStatusCode()), response.getStatusText(), parentPath);
+            }
+            String newUrl = getResourceUrl(parentPath) + upload.getName();
+            if (exists(parentPath + upload.getName())) {
+                return WsUtil.error(304, newUrl);// not modified, already exists
+            }
+            PutMethod put = new PutMethod(newUrl);
+
+            // TODO Content Type doesn't seems to be passed on
+            RequestEntity requestEntity = new InputStreamRequestEntity(new BufferedInputStream(
+                    new FileInputStream(upload), HttpServices.BUFFER_SIZE), upload.length(), contentType);
+            put.setRequestEntity(requestEntity);
+            /** is to allow a client that is sending a request message with a request body
+             *  to determine if the origin server is willing to accept the request
+             * (based on the request headers) before the client sends the request body.
+             * this require server supporting HTTP/1.1 protocol.
+             */
+            put.getParams().setBooleanParameter(
+                    HttpMethodParams.USE_EXPECT_CONTINUE, true);
+
+            if (!executeMethod(put)) {
+                // handle error
+                LOG.error("Unable to upload file:" + relPath + " -- " + put.getStatusText());
+                return WsUtil.error(put.getStatusCode(), put.getStatusText());
+            }
+
+            return WsUtil.success(put.getStatusCode(), put.getStatusText(), newUrl);
+        } catch (Exception e) {
+            LOG.error(e, "Error while uploading file:" + upload.getPath());
+        }
+        return WsUtil.error(500);
+    }
+
+    public WsResponse davGet(File outfile, String fromPath) throws IOException {
+        String url = getResourceUrl(fromPath);
+        WebDAVGetMethod get = new WebDAVGetMethod(url);
+        InputStream in = null;
+        try {
+            if (!executeMethod(get, false)) {
+                // handle error
+                LOG.error("Unable to download file:" + fromPath + " -- " + get.getStatusText());
+                return WsUtil.error(get.getStatusCode(), get.getStatusText());
+            }
+            if (get.getResponseContentLength() > 0) {
+                in = get.getResponseBodyAsStream();
+                FileUtils.copyInputStreamToFile(in, outfile);
+            }
+        } catch (Exception e) {
+            LOG.error(e, "Error while downloading remote file:" + url);
+        } finally {
+            get.releaseConnection();
+        }
+        return WsUtil.success(200, "File downloaded " + outfile.getAbsolutePath(), "");
+    }
+
+//====================================================================
+//  for firefly use
+//====================================================================
+
+
+    @Override
+    public WsCredentials getCredentials() {
+        return this.creds;
+    }
+
+    @Override
+    public PROTOCOL getProtocol() {
+        return PROTOCOL.WEBDAV;
+    }
+
+    @Override
+    public WsResponse getList(String parentUri, int depth) throws WsException {
+
+        WspaceMeta.Includes prop = WspaceMeta.Includes.CHILDREN_PROPS;
+
+        if (depth < 0) {
+            prop = WspaceMeta.Includes.ALL_PROPS;
+        } else if (depth == 0) {
+            prop = WspaceMeta.Includes.NONE_PROPS;
+        }
+
+        WsResponse resp = new WsResponse("200", "List", "");
+
+        WspaceMeta meta = getMeta(parentUri, prop);
+        if (meta == null) {
+            return WsUtil.error(304, "No resource", getResourceUrl(parentUri));
+        }
+        List<WspaceMeta> childNodes = new ArrayList<>();
+        childNodes.add(meta);
+
+        //If no child, set the (self) meta in response:
+        resp.setWspaceMeta(childNodes);
+
+        if (meta.getChildNodes() != null) {
+            // Childs replaced here:
+            childNodes = meta.getChildNodes();
+            resp.setWspaceMeta(childNodes);
+            String respString = "";
+            Iterator<WspaceMeta> it = childNodes.iterator();
+            int child = 0;
+            while (it.hasNext()) {
+                WspaceMeta next = it.next();
+                respString += next.getRelPath() + ", ";
+                child++;
+
+            }
+            resp.setResponse(respString);
+        }
+
+        return resp;
+    }
+
+    @Override
+    public WsResponse getFile(String fileUri, File outputFile) throws WsException {
+        try {
+            return davGet(outputFile, fileUri);
+        } catch (IOException e) {
+            throw new WsException("Fail to get the file " + fileUri);
+        }
+    }
+
+    @Override
+    public WsResponse putFile(String relPath, File item, String contentType) throws WsException {
+        String ct = contentType;
+        if (contentType == null) {
+            ct = ContentType.DEFAULT_BINARY.getMimeType();
+        }
+        return davPut(item, relPath, ct);
+    }
+
+    @Override
+    public WsResponse delete(String uri) throws WsException {
+        if (WspaceMeta.ensureWsHomePath(uri).equals("")) {
+            return WsUtil.error(304, "Attempt to delete home, skipping...");
+        }
+        String url = getResourceUrl(uri);
+        WebDAVDeleteMethod rm = new WebDAVDeleteMethod(url);
+        try {
+            if (!executeMethod(rm, true)) {
+                // handle error
+                LOG.error("Unable to delete file:" + uri + " -- " + rm.getStatusText());
+                return WsUtil.error(rm);
+            }
+        } catch (Exception e) {
+            LOG.error(e, "Error while deleting remote file:" + url);
+        }
+        return WsUtil.success(200, "Deleted " + uri, uri);
+    }
+
+    @Override
+    public WsResponse createParent(String newRelPath) throws WsException {
+        String[] parts = newRelPath.split("/");
+        String cdir = "/";
+        for (String s : parts) {
+            cdir += StringUtils.isEmpty(s) ? "" : s + "/";
+            WspaceMeta m = getMeta(cdir, WspaceMeta.Includes.NONE);
+            if (m == null) {
+                try {
+                    URI uri = new URI(getResourceUrl(cdir));
+                } catch (URISyntaxException e) {
+                    return WsUtil.error(e);
+                }
+                DavMethod mkcol = new MkColMethod(getResourceUrl(cdir));
+                if (!executeMethod(mkcol)) {
+                    // handle error
+                    LOG.error("Unable to create directory:" + newRelPath + " -- " + mkcol.getStatusText());
+                    return WsUtil.error(mkcol, "Resource already exist");
+                }
+            }
+        }
+        return WsUtil.success(200, "Created", getResourceUrl(newRelPath));
+    }
+
+    @Override
+    public WsResponse renameFile(String originalFileRelPath, String newfileName, boolean overwrite) throws WsException {
+        WspaceMeta meta = new WspaceMeta(originalFileRelPath);
+        String parent = meta.getParentPath();
+
+        String newUrl = getResourceUrl(parent) + newfileName;
+
+        MoveMethod move = new MoveMethod(getResourceUrl(originalFileRelPath), newUrl, overwrite);
+        if (!executeMethod(move)) {
+            // handle error
+            LOG.error("Unable to move:" + originalFileRelPath + " -- " + move.getStatusText());
+            return WsUtil.error(move.getStatusCode(), move.getStatusLine().getReasonPhrase());
+        }
+        return WsUtil.success(move.getStatusCode(), move.getStatusText(), newUrl);
+    }
+
+    public WspaceMeta getMeta(String relPath) {
+        return getMeta(relPath, WspaceMeta.Includes.ALL);
+    }
+
+    public WsResponse search(String relPath) throws IOException {
+        String query = "" +
+                "  " +
+                " SELECT *" +
+                "  " +
+                "";
+        query = "//element(*,rep:root)";
+
+        OptionsMethod options = new OptionsMethod(getResourceUrl(relPath));
+        executeMethod(options);
+        String okMethod = "SEARCH";
+        if (!options.isAllowed(okMethod)) {
+            String s = "";
+            String[] allowedMethods = options.getAllowedMethods();
+            for (String method : allowedMethods) {
+                s += method + "\n";
+            }
+            return WsUtil.error(options.getStatusCode(), options.getStatusText(), okMethod + " is not allowed - only:\n" + s);
+        }
+        SearchMethod m = new SearchMethod(getResourceUrl(relPath), query, "xpath");
+        if (!executeMethod(m)) {
+            // handle error
+            LOG.error("Unable to move:" + relPath + " -- " + m.getStatusText());
+            return WsUtil.error(m.getStatusCode(), m.getStatusLine().getReasonPhrase());
+        }
+        return WsUtil.success(m.getStatusCode(), m.getStatusText(), relPath);
+    }
+
+    public WspaceMeta getMeta(String relPath, WspaceMeta.Includes includes) {
+
+        // this can be optimized by retrieving only the props we care for.
+        DavMethod pFind = null;
+        try {
+            if (includes.inclProps) {
+                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_ALL_PROP, includes.depth);
+            } else {
+                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_BY_PROPERTY, includes.depth);
+            }
+
+            if (!executeMethod(pFind, false)) {
+                // handle error
+                if (pFind.getStatusCode() != 404) {
+                    LOG.error("Unable to find property:" + relPath + " -- " + pFind.getStatusText());
+                }
+                return null;
+            }
+
+            MultiStatus multiStatus = pFind.getResponseBodyAsMultiStatus();
+            MultiStatusResponse[] resps = multiStatus.getResponses();
+            if (resps == null || resps.length == 0) {
+                return null;
+            }
+            WspaceMeta root = new WspaceMeta(getWsHome(), relPath);
+
+            for (MultiStatusResponse res : resps) {
+                if (res.getHref().equals(root.getAbsPath())) {
+                    convertToWspaceMeta(root, res);
+                } else {
+                    addToRoot(root, res);
+                }
+            }
+            return root;
+        } catch (Exception e) {
+            LOG.error(e, "Error while getting meta for:" + relPath);
+        } finally {
+            if (pFind != null) {
+                pFind.releaseConnection();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * convenience method to create meta for a local file in the workspace
+     *
+     * @param file
+     * @param propName
+     * @param value
+     * @return
+     */
+    public WspaceMeta newLocalWsMeta(File file, String propName, String value) {
+        WspaceMeta meta = new WspaceMeta(getWsHome(), getRelPath(file));
+        meta.setProperty(propName, value);
+        return meta;
+    }
+
+    /**
+     * convenience method to set one property on a resource.
+     * if the property value is null, that property will be removed.
+     * otherwise, the property will be either added or updated.
+     *
+     * @param relPath
+     * @param propName
+     * @param value
+     * @return
+     */
+    public boolean setMeta(String relPath, String propName, String value) {
+        WspaceMeta meta = new WspaceMeta(null, relPath);
+        meta.setProperty(propName, value);
+        return setMeta(meta);
+    }
+
+    /**
+     * set meta information on this dav's resource.
+     * if the property value is null, that property will be removed.
+     * otherwise, the property will be either added or updated.
+     *
+     * @param metas
+     * @return
+     */
+    public boolean setMeta(WspaceMeta... metas) {
+        if (metas == null) return false;
+        for (WspaceMeta meta : metas) {
+
+            Map<String, String> props = meta.getProperties();
+            if (props != null && props.size() > 0) {
+                DavPropertySet newProps = new DavPropertySet();
+                DavPropertyNameSet removeProps = new DavPropertyNameSet();
+
+                for (String key : props.keySet()) {
+                    String v = props.get(key);
+                    if (v == null) {
+                        removeProps.add(DavPropertyName.create(key, IRSA_NS));
+                    } else {
+                        DavProperty p = new DefaultDavProperty(key, props.get(key), IRSA_NS);
+                        newProps.add(p);
+                    }
+                }
+                try {
+                    PropPatchMethod proPatch = new PropPatchMethod(getResourceUrl(meta.getRelPath()), newProps, removeProps);
+                    if (!executeMethod(proPatch)) {
+                        // handle error
+                        LOG.error("Unable to update property:" + newProps.toString() + " -- " + proPatch.getStatusText());
+                        return false;
+                    }
+                    return true;
+                } catch (IOException e) {
+                    LOG.error(e, "Error while setting property: " + meta);
+                    e.printStackTrace();
+                }
+
+            }
+
+        }
+        return false;
+    }
+
+//====================================================================
+//
+//====================================================================
+
+    private WspaceMeta convertToWspaceMeta(WspaceMeta meta, MultiStatusResponse res) {
+        if (meta == null) {
+            meta = new WspaceMeta(getWsHome(), res.getHref().replaceFirst(getWsHome(), ""));
+        }
+        if (res.getHref() != null) {
+            meta.setUrl(WS_HOST_URL + res.getHref());
+        }
+        DavPropertySet props = res.getProperties(200);
+        if (props != null) {
+            for (DavProperty p : props) {
+                String name = (p == null || p.getName() == null) ? null : p.getName().getName();
+                if (name != null) {
+                    String v = String.valueOf(p.getValue());
+                    if (name.equals(DavConstants.PROPERTY_GETLASTMODIFIED)) {
+                        meta.setLastModified(v);
+                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTLENGTH)) {
+                        meta.setSize(Long.parseLong(v));
+                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTTYPE)) {
+                        meta.setContentType(v);
+                    } else if (p.getName().getNamespace().equals(IRSA_NS)) {
+                        meta.setProperty(name, String.valueOf(p.getValue()));
+                    } else if (name.equals(DavConstants.PROPERTY_CREATIONDATE)) {
+                        meta.setCreationDate(v);
+                    }
+                }
+            }
+        }
+        return meta;
+    }
+
+    private void addToRoot(WspaceMeta root, MultiStatusResponse res) {
+        WspaceMeta meta = convertToWspaceMeta(null, res);
+        WspaceMeta p = root.find(meta.getParentPath());
+        if (p != null) {
+            p.addChild(meta);
+        } else {
+            root.addChild(meta);
+        }
+    }
+
+    private boolean executeMethod(DavMethod method) {
+        return executeMethod(method, true);
+    }
+
+    private boolean executeMethod(DavMethod method, boolean releaseConnection) {
+        try {
+            return partition.equals(Partition.PUBSPACE) ? HttpServices.executeMethod(method) :
+                    HttpServices.executeMethod(method, "xxx", "xx", cookies);
+        } finally {
+            if (releaseConnection && method != null) {
+                method.releaseConnection();
+            }
+        }
+
+
+    }
+
+    public static void main(String[] args) {
+        WebDAVWorkspaceManager man = null;
+//        man = (WebDAVWorkspaceManager) ServerContext.getRequestOwner().getWsManager();
+
+        man = new WebDAVWorkspaceManager("ejoliet-tmp2");
+
+        simpleTest(man);
+
+//        AppProperties.setProperty("sso.server.url", "http://irsa.ipac.caltech.edu/account/");
+//        String session = JOSSOAdapter.createSession("", "");
+//        Map<String, String> cookies = new HashMap<String, String>();
+//        cookies.put(WebAuthModule.AUTH_KEY, session);
+//        WorkspaceManager man = new WorkspaceManager("<someuser>@ipac.caltech.edu", cookies);
+//        simpleTest(man);
+    }
+
+    private static void simpleTest(WebDAVWorkspaceManager man) {
+        String relPath = "124/";
+        File f = man.davMakeDir(relPath);
+        System.out.println("new directory: " + String.valueOf(f));
+
+        WspaceMeta m = new WspaceMeta(null, relPath);
+        m.setProperty("test1", "an awesome idea");
+        m.setProperty("test", null);
+        man.setMeta(m);
+
+        String ufilePath = relPath + "gaia-binary.vot";
+        WsResponse wsResponse = man.davPut(new File("/Users/ejoliet/devspace/branch/dev/firefly_test_data/edu/caltech/ipac/firefly/ws/gaia-binary.vot"), ufilePath, null);
+
+        System.out.println(wsResponse);
+
+        WspaceMeta meta = new WspaceMeta(null, ufilePath);
+        meta.setProperty("added_by", man.userHome);
+        man.setMeta(meta);
+        man.setMeta(ufilePath, "added_by", man.userHome);
+
+        WspaceMeta meta2 = man.getMeta("/", WspaceMeta.Includes.ALL_PROPS);
+        System.out.println(meta2.getNodesAsString());
+    }
+
+
+    class WebDAVGetMethod extends DavMethodBase {
+        public WebDAVGetMethod(String uri) {
+            super(uri);
+        }
+
+        public String getName() {
+            return DavMethods.METHOD_GET;
+        }
+
+        public boolean isSuccess(int statusCode) {
+            return statusCode == 200;
+        }
+    }
+
+    class WebDAVDeleteMethod extends DavMethodBase {
+        public WebDAVDeleteMethod(String uri) {
+            super(uri);
+        }
+
+        public String getName() {
+            return DavMethods.METHOD_DELETE;
+        }
+
+        public boolean isSuccess(int statusCode) {
+            return statusCode == 200;
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
@@ -17,11 +17,6 @@ public interface WorkspaceManager extends Workspaces {
 
     String SEARCH_DIR = WspaceMeta.SEARCH_DIR;
 
-    //TODO We might need to change those properties if we need to deal with 2 or more workspaces at the same time
-    String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
-    String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
-
-
     WsCredentials getCredentials();
 
     String getWsHome();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
@@ -4,389 +4,57 @@
 package edu.caltech.ipac.firefly.server;
 
 import edu.caltech.ipac.firefly.data.WspaceMeta;
-import edu.caltech.ipac.firefly.server.network.HttpServices;
-import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.ws.Workspaces;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
 import edu.caltech.ipac.util.AppProperties;
-import edu.caltech.ipac.util.StringUtils;
-import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
-import org.apache.commons.httpclient.methods.RequestEntity;
-import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.apache.jackrabbit.webdav.DavConstants;
-import org.apache.jackrabbit.webdav.MultiStatus;
-import org.apache.jackrabbit.webdav.MultiStatusResponse;
-import org.apache.jackrabbit.webdav.client.methods.DavMethod;
-import org.apache.jackrabbit.webdav.client.methods.MkColMethod;
-import org.apache.jackrabbit.webdav.client.methods.PropFindMethod;
-import org.apache.jackrabbit.webdav.client.methods.PropPatchMethod;
-import org.apache.jackrabbit.webdav.client.methods.PutMethod;
-import org.apache.jackrabbit.webdav.property.DavProperty;
-import org.apache.jackrabbit.webdav.property.DavPropertyName;
-import org.apache.jackrabbit.webdav.property.DavPropertyNameSet;
-import org.apache.jackrabbit.webdav.property.DavPropertySet;
-import org.apache.jackrabbit.webdav.property.DefaultDavProperty;
-import org.apache.jackrabbit.webdav.xml.Namespace;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Map;
 
 /**
- * Date: 6/12/14
- *
- * @author loi
- * @version $Id: $
+ * Workspace manager interface
  */
-public class WorkspaceManager {
-    public static final String SEARCH_DIR = WspaceMeta.SEARCH_DIR;
-    public static final String STAGING_DIR = WspaceMeta.STAGING_DIR;
-    public static final String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
-    public static final String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
+public interface WorkspaceManager extends Workspaces {
 
-    private static final Namespace IRSA_NS = Namespace.getNamespace("irsa", "https://irsa.ipac.caltech.edu/namespace/");
-    private static final Logger.LoggerImpl LOG = Logger.getLogger();
+    String SEARCH_DIR = WspaceMeta.SEARCH_DIR;
 
-    public enum Partition { PUBSPACE, SSOSPACE;
-                    public String toString() {return name().toLowerCase();}
-                }
+    //TODO We might need to change those properties if we need to deal with 2 or more workspaces at the same time
+    String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
+    String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
 
-    private Partition partition;
-    private String userHome;
-    private Map<String,String> cookies;
 
-    public WorkspaceManager(String pubspaceId) {
-        this(Partition.PUBSPACE, pubspaceId, null);
-    }
+    WsCredentials getCredentials();
 
-    public WorkspaceManager(String ssospaceId, Map<String, String> cookies) {
-        this(Partition.SSOSPACE, ssospaceId, cookies);
+    String getWsHome();
 
-    }
+    public enum PROTOCOL {LOCAL, WEBDAV, VOSPACE}
 
-    public WorkspaceManager(Partition partition, String wsId, Map<String, String> cookies) {
-        this.partition = partition;
-        this.userHome = WspaceMeta.ensureWsHomePath(wsId);
-        this.cookies = cookies;
-        davMakeDir("");
-    }
+    enum PROPS {PROTOCOL, AUTH, ROOT_URL, ROOT_DIR}
+
+    public PROTOCOL getProtocol();
+
+    public String getProp(PROPS ps);
 
     /**
-     * returns the local filesystem path of the given relpath.
-     * @param relPath  relative to the user's workspace and must starts with '/'
-     * @return
+     * TODO kept this because somehow we used it elsewhere
+     * TODO but i think we should be using http and not local access
+     * Create file in ws relative path
+     *
+     * @param wspaceRelDir
+     * @param filePrefix
+     * @param fileExt
+     * @return File created
+     * @deprecated should be using {@link Workspaces#putFile(String, File, String)}
      */
-    public String getLocalFsPath(String relPath) {
-        return WS_ROOT_DIR  + getAbsPath(relPath);
-    }
+    File createWsLocalFile(String wspaceRelDir, String filePrefix, String fileExt);
 
     /**
-     * returns the webdav's absolute path.  for IRSA, it's /partition/user_ws/relpath.
-     * @param relPath  relative to the user's workspace and must starts with '/'
-     * @return
-     */
-    public String getAbsPath(String relPath) {
-        String s = WspaceMeta.ensureRelPath(relPath);
-        return getWsHome() + s;
-    }
-
-    /**
-     * returns the relative path given the file.  for IRSA, it's /partition/user_ws/relpath.
-     * @param file  relative to the user's workspace and must starts with '/'
-     * @return
-     */
-    public String getRelPath(File file) {
-        String s = file.getAbsolutePath().replaceFirst(WS_ROOT_DIR, "");
-        s = s.replaceFirst(getWsHome(), "");
-        return s;
-    }
-
-    /**
-     * return the url of this resource.
-     * @param relPath
-     * @return
-     */
-    public String getResourceUrl(String relPath) {
-        return WS_HOST_URL + getAbsPath(relPath);
-    }
-
-    public String getWsHome() {
-        return "/" + partition + userHome;
-    }
-
-    public File createFile(String parent, String fname, String fext) {
-        davMakeDir(parent);
-        return new File(new File(getLocalFsPath(parent)), fname + "-" + System.currentTimeMillis()%1000000 + fext);
-    }
-
-    /**
-     * convenience method to create meta for a local file in the workspace
-     * @param file
+     * build ws meta from local file in ws fs
+     *
+     * @param file     file located in ws fs
      * @param propName
      * @param value
-     * @return
+     * @return WspaceMeta
+     * ¬
      */
-    public WspaceMeta newMeta(File file, String propName, String value) {
-        WspaceMeta meta = new WspaceMeta(getWsHome(), getRelPath(file));
-        meta.setProperty(propName, value);
-        return meta;
-    }
-
-//====================================================================
-//  WEBDAV functions
-//====================================================================
-
-    /**
-     * create a directory given by the relPath parameter.
-     * @param relPath relative to the user's workspace
-     * @return  the absolute path to the directory on the filesystem.
-     */
-    public File davMakeDir(String relPath) {
-        try {
-            String[] parts = relPath.split("/");
-            String cdir = "/";
-            for (String s : parts) {
-                cdir += StringUtils.isEmpty(s) ? "" :  s + "/";
-                WspaceMeta m = getMeta(cdir, WspaceMeta.Includes.NONE);
-                if (m == null) {
-                    DavMethod mkcol = new MkColMethod(getResourceUrl(cdir));
-                    if ( !executeMethod(mkcol)) {
-                        // handle error
-                        System.out.println("Unable to create directory:" + relPath + " -- " + mkcol.getStatusText());
-                        return null;
-                    }
-                }
-            }
-            return new File(getLocalFsPath(relPath));
-        } catch (Exception e) {
-            LOG.error(e, "Error while makeCollection:" + relPath);
-        }
-        return null;
-    }
-
-    public boolean davPut(File upload, String toPath) {
-        try {
-            PutMethod put = new PutMethod(getResourceUrl(toPath));
-            RequestEntity requestEntity = new InputStreamRequestEntity(new BufferedInputStream(
-                                new FileInputStream(upload), HttpServices.BUFFER_SIZE), upload.length());
-            put.setRequestEntity(requestEntity);
-            /** is to allow a client that is sending a request message with a request body
-             *  to determine if the origin server is willing to accept the request
-             * (based on the request headers) before the client sends the request body.
-             * this require server supporting HTTP/1.1 protocol.
-             */
-            put.getParams().setBooleanParameter(
-                    HttpMethodParams.USE_EXPECT_CONTINUE, true);
-
-            if (!executeMethod(put)) {
-                // handle error
-                System.out.println("Unable to upload file:" + toPath + " -- " + put.getStatusText());
-                return false;
-            }
-
-            return true;
-        } catch (Exception e) {
-            LOG.error(e, "Error while uploading file:" + upload.getPath());
-        }
-        return false;
-    }
-
-
-//====================================================================
-//  for firefly use
-//====================================================================
-
-    public WspaceMeta getMeta(String relPath) {
-        return getMeta(relPath, WspaceMeta.Includes.ALL);
-    }
-
-
-    public WspaceMeta getMeta(String relPath, WspaceMeta.Includes includes) {
-
-        // this can be optimized by retrieving only the props we care for.
-        DavMethod pFind = null;
-        try {
-            if (includes.inclProps) {
-                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_ALL_PROP, includes.depth);
-            } else {
-                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_BY_PROPERTY, includes.depth);
-            }
-
-            if (!executeMethod(pFind, false)) {
-                // handle error
-                if (pFind.getStatusCode() != 404) {
-                    System.out.println("Unable to find property:" + relPath + " -- " + pFind.getStatusText());
-                }
-                return null;
-            }
-
-            MultiStatus multiStatus = pFind.getResponseBodyAsMultiStatus();
-            MultiStatusResponse[] resps = multiStatus.getResponses();
-            if (resps == null || resps.length == 0) {
-                return null;
-            }
-            WspaceMeta root = new WspaceMeta(getWsHome(), relPath);
-
-            for (MultiStatusResponse res : resps) {
-                if (res.getHref().equals(root.getAbsPath())) {
-                    convertToWspaceMeta(root, res);
-                } else {
-                    addToRoot(root, res);
-                }
-            }
-            return root;
-        } catch (Exception e) {
-            LOG.error(e, "Error while getting meta for:" + relPath);
-        } finally {
-            if (pFind != null) {
-                pFind.releaseConnection();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * convenience method to set one property on a resource.
-     * if the property value is null, that property will be removed.
-     * otherwise, the property will be either added or updated.
-     * @param relPath
-     * @param propName
-     * @param value
-     * @return
-     */
-    public boolean setMeta(String relPath, String propName, String value) {
-        WspaceMeta meta = new WspaceMeta(null, relPath);
-        meta.setProperty(propName, value);
-        return setMeta(meta);
-    }
-
-    /**
-     * set meta information on this dav's resource.
-     * if the property value is null, that property will be removed.
-     * otherwise, the property will be either added or updated.
-     * @param metas
-     * @return
-     */
-    public boolean setMeta(WspaceMeta ... metas) {
-        if (metas == null) return false;
-        for(WspaceMeta meta : metas) {
-
-            Map<String, String> props = meta.getProperties();
-            if (props != null && props.size() > 0) {
-                DavPropertySet newProps=new DavPropertySet();
-                DavPropertyNameSet removeProps=new DavPropertyNameSet();
-
-                for (String key : props.keySet()) {
-                    String v = props.get(key);
-                    if (v == null) {
-                        removeProps.add(DavPropertyName.create(key, IRSA_NS));
-                    } else {
-                        DavProperty p = new DefaultDavProperty(key, props.get(key), IRSA_NS);
-                        newProps.add(p);
-                    }
-                }
-                try {
-                    PropPatchMethod proPatch=new PropPatchMethod(getResourceUrl(meta.getRelPath()), newProps, removeProps);
-                    if ( !executeMethod(proPatch)) {
-                        // handle error
-                        System.out.println("Unable to update property:" + newProps.toString() +  " -- " + proPatch.getStatusText());
-                        return false;
-                    }
-                    return true;
-                } catch (IOException e) {
-                    LOG.error(e, "Error while setting property: " + meta);
-                    e.printStackTrace();
-                }
-
-            }
-
-        }
-        return false;
-    }
-
-//====================================================================
-//
-//====================================================================
-
-    private WspaceMeta convertToWspaceMeta(WspaceMeta meta, MultiStatusResponse res) {
-        if (meta == null) {
-            meta = new WspaceMeta(getWsHome(), res.getHref().replaceFirst(getWsHome(), ""));
-        }
-        DavPropertySet props = res.getProperties(200);
-        if (props != null) {
-            for (DavProperty p : props) {
-                String name = (p == null || p.getName() == null) ? null : p.getName().getName();
-                if (name != null) {
-                    String v = String.valueOf(p.getValue());
-                    if (name.equals(DavConstants.PROPERTY_GETLASTMODIFIED)) {
-                            meta.setLastModified(v);
-                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTLENGTH)) {
-                        try {
-                            meta.setSize(Long.parseLong(v));
-                        } catch (Exception e) {}
-                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTTYPE)) {
-                        meta.setContentType(v);
-                    } else if (p.getName().getNamespace().equals(IRSA_NS)) {
-                        meta.setProperty(name, String.valueOf(p.getValue()));
-                    }
-                }
-            }
-        }
-        return meta;
-    }
-
-    private void addToRoot(WspaceMeta root, MultiStatusResponse res) {
-        WspaceMeta meta = convertToWspaceMeta(null, res);
-        WspaceMeta p = root.find(meta.getParentPath());
-        if (p != null) {
-            p.addChild(meta);
-        } else {
-            root.addChild(meta);
-        }
-    }
-    private boolean executeMethod(DavMethod method) {
-        return executeMethod(method, true);
-    }
-
-    private boolean executeMethod(DavMethod method, boolean releaseConnection) {
-        try {
-            return partition.equals(Partition.PUBSPACE) ? HttpServices.executeMethod(method) :
-                    HttpServices.executeMethod(method, "xxx", "xx", cookies);
-        } finally {
-            if (releaseConnection && method != null) {
-                method.releaseConnection();
-            }
-        }
-
-
-
-    }
-
-    public static void main(String[] args) {
-        WorkspaceManager man = ServerContext.getRequestOwner().getWsManager();
-        simpleTest(man);
-
-//        AppProperties.setProperty("sso.server.url", "http://irsa.ipac.caltech.edu/account/");
-//        String session = JOSSOAdapter.createSession("", "");
-//        Map<String, String> cookies = new HashMap<String, String>();
-//        cookies.put(WebAuthModule.AUTH_KEY, session);
-//        WorkspaceManager man = new WorkspaceManager("<someuser>@ipac.caltech.edu", cookies);
-//        simpleTest(man);
-    }
-     private static void simpleTest(WorkspaceManager man) {
-         File f = man.davMakeDir("123/");
-         System.out.println("new directory: " + String.valueOf(f));
-
-         WspaceMeta m = new WspaceMeta(null, "123/");
-         m.setProperty("test1", "an awesome idea");
-         m.setProperty("test", null);
-         man.setMeta(m);
-
-         String ufilePath = "/123/uploaded" + System.currentTimeMillis()%1000 + ".tiff";
-         man.davPut(new File("/Users/loi/dia.tiff"), ufilePath);
-         man.setMeta(ufilePath, "added_by", man.userHome);
-
-         WspaceMeta meta = man.getMeta("/", WspaceMeta.Includes.ALL_PROPS);
-         System.out.println(meta.getNodesAsString());
-     }
+    WspaceMeta newLocalWsMeta(File file, String propName, String value);
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -43,8 +43,6 @@ import java.util.*;
  */
 abstract public class IpacTablePartProcessor implements SearchProcessor<DataGroupPart> {
 
-    public static final boolean useWorkspace = AppProperties.getBooleanProperty("useWorkspace", false);
-
     public static final Logger.LoggerImpl SEARCH_LOGGER = Logger.getLogger(Logger.SEARCH_LOGGER);
     public static final Logger.LoggerImpl LOGGER = Logger.getLogger();
     //public static long logCounter = 0;
@@ -288,8 +286,8 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
 
     private String createUniqueId(String reqId, List<Param> params) {
         String uid = reqId + "-";
-        if ( useWorkspace || (isSecurityAware() &&
-                ServerContext.getRequestOwner().isAuthUser()) ) {
+        if ( isSecurityAware() &&
+                ServerContext.getRequestOwner().isAuthUser() ) {
             uid = uid + ServerContext.getRequestOwner().getUserKey();
         }
 
@@ -525,12 +523,6 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
 
             if (doCache()) {
                 cache.put(key, cfile);
-                if (useWorkspace) {
-                    WorkspaceManager ws = ServerContext.getRequestOwner().getWsManager();
-                    WspaceMeta meta = ws.newLocalWsMeta(cfile, WspaceMeta.TYPE, request.getRequestId());
-                    meta.setProperty(WspaceMeta.DESC, getDescResolver().getDesc(request));
-                    ws.setMeta(meta);
-                }
             }
             isFromCache = false;
         }
@@ -596,23 +588,7 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
     protected File createFile(TableServerRequest request, String fileExt) throws IOException {
         File file = null;
         if (doCache()) {
-            if (useWorkspace) {
-                //TODO can we discuss if this is the right behaviour to put the temp file in ws?
-                //TODO The idea was to use maybe pubspace for temp but the user ws should be populated only if the user request it
-                //TODO Meaning that the UI needs to expose a control for that
-                // Put it in WS via local FS
-                ServerContext.getRequestOwner().getWsManager().createWsLocalFile(getWspaceSaveDirectory(), getFilePrefix(request), fileExt);
-//              try{
-//                // TODO Put it in WS via http?
-//                  file = File.createTempFile(getFilePrefix(request), fileExt, ServerContext.getTempWorkDir());
-//                  ServerContext.getRequestOwner().getWsManager().putFile(
-//                            getWspaceSaveDirectory(), file, ContentType.DEFAULT_BINARY.getMimeType()//**TODO is this the right mime-type?**/);
-//                } catch (WsException e) {
-//                  LOGGER.error("Couldn't upload file " + file.getAbsolutePath() + " to ws " + ServerContext.getRequestOwner().getWsManager().getProp(WorkspaceManager.PROPS.ROOT_URL));
-//                }
-            } else {
-                file = File.createTempFile(getFilePrefix(request), fileExt, ServerContext.getPermWorkDir());
-            }
+            file = File.createTempFile(getFilePrefix(request), fileExt, ServerContext.getPermWorkDir());
         } else {
             file = File.createTempFile(getFilePrefix(request), fileExt, ServerContext.getTempWorkDir());
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/JsonDataProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/JsonDataProcessor.java
@@ -23,8 +23,6 @@ import java.util.*;
  */
 abstract public class JsonDataProcessor implements SearchProcessor<String> {
 
-    public static final boolean useWorkspace = AppProperties.getBooleanProperty("useWorkspace", false);
-
     public static final Logger.LoggerImpl SEARCH_LOGGER = Logger.getLogger(Logger.SEARCH_LOGGER);
     public static final Logger.LoggerImpl LOGGER = Logger.getLogger();
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/LocalWorkspaceHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/LocalWorkspaceHandler.java
@@ -1,0 +1,41 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import edu.caltech.ipac.firefly.server.LocalFSWorkspace;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.util.AppProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * API WS for client
+ * Created by ejoliet on 6/15/17.
+ */
+public class LocalWorkspaceHandler implements WorkspaceHandler {
+
+    String p = AppProperties.getProperty("workspace.protocol.irsa.webdav", "edu.caltech.ipac.firefly.server.WebDAVWorkspaceManager");
+
+    /**
+     * map userKey and ws,
+     * TODO we don't want to create a new Wsmanager for every user access, do we?
+     */
+    Map<String, WorkspaceManager> wsPool;
+
+    public LocalWorkspaceHandler() {
+        wsPool = new HashMap<>();
+    }
+
+    public WorkspaceManager withCredentials(WsCredentials cred) {
+
+        synchronized (cred) {
+            String id = cred.getWsId();
+
+            if (wsPool.containsKey(id)) {
+                return wsPool.get(id);
+            }
+            WorkspaceManager ws = new LocalFSWorkspace();
+            wsPool.put(ws.getCredentials().getWsId(), ws);
+            return ws;
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WebDAVWorkspaceHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WebDAVWorkspaceHandler.java
@@ -1,0 +1,59 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.util.AppProperties;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * API manager/handler for webdav client
+ * Class implementation of manager passed as property¬
+ * Created by ejoliet on 6/15/17.
+ */
+public class WebDAVWorkspaceHandler implements WorkspaceHandler {
+
+    String managerClass = AppProperties.getProperty("workspace.protocol.irsa.webdav", "edu.caltech.ipac.firefly.server.WebDAVWorkspaceManager");
+
+    /**
+     * map userKey and ws,
+     * TODO we don't want to create a new Wsmanager for every user access, do we?
+     */
+    Map<String, WorkspaceManager> wsPool;
+
+    public WebDAVWorkspaceHandler() {
+        wsPool = new HashMap<>();
+    }
+
+    public WorkspaceManager withCredentials(WsCredentials cred) {
+
+        synchronized (cred) {
+            String id = cred.getWsId();
+
+            if (wsPool.containsKey(id)) {
+                return wsPool.get(id);
+            }
+            WorkspaceManager ws = null;//new WebDAVWorkspaceManager(cred.getWsId(), cred.getCookies());
+            try {
+                Class clazz = Class.forName(managerClass);
+                Constructor<?> ctor = clazz.getConstructor(WsCredentials.class);
+                ws = (WorkspaceManager) ctor.newInstance(new Object[]{cred});
+                wsPool.put(cred.getWsId(), ws);
+            } catch (InstantiationException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+            } catch (InvocationTargetException e) {
+                e.printStackTrace();
+            }
+
+            return ws;
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WorkspaceFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WorkspaceFactory.java
@@ -1,0 +1,50 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import edu.caltech.ipac.firefly.core.ResourceNotFoundException;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.util.AppProperties;
+
+/**
+ * Factories of ws handlers
+ * Created by ejoliet on 6/15/17.
+ */
+public class WorkspaceFactory {
+
+    static String protocolProp = AppProperties.getProperty("workspace.protocol.irsa", "webdav");
+
+    /**
+     * @return Handler based on protocol read from properties workspace.protocol.irsa
+     * @throws WsException
+     */
+    public static WorkspaceHandler getWorkspaceHandler() {
+        try {
+            return getWorkspaceHandler(get(protocolProp));
+        } catch (WsException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static WorkspaceHandler getWorkspaceHandler(WorkspaceManager.PROTOCOL p) {
+
+        switch (p) {
+            case LOCAL:
+                return new LocalWorkspaceHandler();
+            case WEBDAV:
+                return new WebDAVWorkspaceHandler();
+            case VOSPACE:
+                throw new ResourceNotFoundException(p.name() + " not implemented yet ");
+        }
+        throw new ResourceNotFoundException(p.name() + " not found ");
+    }
+
+    private static WorkspaceManager.PROTOCOL get(String name) throws WsException {
+        for (WorkspaceManager.PROTOCOL p : WorkspaceManager.PROTOCOL.values()) {
+            if (p.name().equalsIgnoreCase(name)) {
+                return p;
+            }
+        }
+        throw new WsException("Invalid protocol name loaded from properties: " + name);
+    }
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WorkspaceHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WorkspaceHandler.java
@@ -1,0 +1,19 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+
+/**
+ * API for WS handler that will handle every ws manager per user
+ * Created by ejoliet on 6/15/17.
+ */
+public interface WorkspaceHandler {
+
+    /**
+     * Return ws manager using credentials {@link WsCredentials}
+     *
+     * @param cred {@link WsCredentials}
+     * @return
+     */
+    WorkspaceManager withCredentials(WsCredentials cred);
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/Workspaces.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/Workspaces.java
@@ -1,0 +1,81 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Define workspaces API that will be used by UI client to connect to WS
+ * To ease the interaction between client and server, the interface is defined with relative path/uri to remote ws home
+ * home dir / root url <b>should/expected to</b> be defined in implementation (see {@link edu.caltech.ipac.firefly.server.WorkspaceManager.PROPS}
+ * <p>
+ * Created by ejoliet on 6/16/17.
+ */
+public interface Workspaces {
+
+    /**
+     * Gets files from relative path
+     *
+     * @param parentWspaceRelDir ws parent directory to get list of files
+     * @param depth              if -1, give all the folders/files below the parent, 0 return the parent, 1 return children only
+     * @return {@link WsResponse} - list of {@link WspaceMeta} can be found in response, see {@link WsResponse#getWspaceMeta()} resource list in response object}
+     * @throws IOException handle ws error
+     */
+    WsResponse getList(String parentWspaceRelDir, int depth) throws IOException;
+
+    /**
+     * Get file relative to ws home
+     *
+     * @param wspaceRelFile remote URI relative file path , i.e. "x/y/z/aaa.tbl" will be located under WS_HOME at WS_URL
+     * @param outputFile    local file downloaded
+     * @return {@link WsResponse} response string should contain the abs path of the file TODO could contain more metadata
+     * @throws WsException handle ws error
+     */
+    WsResponse getFile(String wspaceRelFile, File outputFile) throws WsException;
+
+    /**
+     * Put the file item in a relative remote location from home directory with same name as file item
+     *
+     * @param wspaceRelPath relative path location to ws home
+     * @param item
+     * @param contentType
+     * @return {@link WsResponse}
+     * @throws WsException handle ws error
+     */
+    WsResponse putFile(String wspaceRelPath, File item, String contentType) throws WsException;
+
+
+    /**
+     * Delete file/folder that is in relative path to ws home
+     *
+     * @param wspaceRelPath path uri relative to ws home
+     * @return {@link WsResponse}
+     * @throws WsException handle ws error
+     */
+    WsResponse delete(String wspaceRelPath) throws WsException;
+
+    /**
+     * Create parent folder relative to ws home under
+     *
+     * @param newRelativeFolderPath relative to ws home folder path
+     * @return {@link WsResponse}
+     * @throws WsException handle ws error
+     */
+    WsResponse createParent(String newRelativeFolderPath) throws WsException;
+
+    /**
+     * Rename file
+     *
+     * @param originalFileRelPath
+     * @param newfileName
+     * @param shouldOverwrite
+     * @return
+     * @throws WsException
+     */
+    WsResponse renameFile(String originalFileRelPath, String newfileName, boolean shouldOverwrite) throws WsException;
+
+    WspaceMeta getMeta(String uri, WspaceMeta.Includes includes);
+
+    boolean setMeta(WspaceMeta... metas);
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/Workspaces.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/Workspaces.java
@@ -4,6 +4,8 @@ import edu.caltech.ipac.firefly.data.WspaceMeta;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
 
 /**
  * Define workspaces API that will be used by UI client to connect to WS
@@ -35,6 +37,15 @@ public interface Workspaces {
     WsResponse getFile(String wspaceRelFile, File outputFile) throws WsException;
 
     /**
+     * Get file via a consumer
+     * @param wspaceRelFile remote URI relative file path , i.e. "x/y/z/aaa.tbl" will be located under WS_HOME at WS_URL
+     * @param consumer consumer should take care of the incoming result supplied
+     * @return {@link WsResponse} TODO could contain more metadata
+     * @throws WsException
+     */
+    WsResponse getFile(String wspaceRelFile, Consumer<?> consumer) throws WsException;
+
+    /**
      * Put the file item in a relative remote location from home directory with same name as file item
      *
      * @param wspaceRelPath relative path location to ws home
@@ -56,7 +67,7 @@ public interface Workspaces {
     WsResponse delete(String wspaceRelPath) throws WsException;
 
     /**
-     * Create parent folder relative to ws home under
+     * Create path to parent folder relative to ws home under, auto creating the necessary intermediate folders.
      *
      * @param newRelativeFolderPath relative to ws home folder path
      * @return {@link WsResponse}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsCredentials.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsCredentials.java
@@ -1,0 +1,44 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import java.util.Map;
+
+/**
+ * Created by ejoliet on 6/19/17.
+ */
+public class WsCredentials {
+
+    private String wsId;
+    private Map<String, String> cookies;
+    private String password;
+
+    public Map<String, String> getCookies() {
+        return cookies;
+    }
+
+    public String getWsId() {
+        return wsId;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    enum AUTH {NONE, TOKEN, DIGEST, BASIC}
+
+    public WsCredentials(String wsId, Map<String, String> cookies) {
+        this.wsId = wsId;
+
+        this.cookies = cookies;
+    }
+
+    public WsCredentials(String wsId, String pass) {
+        this.wsId = wsId;
+        this.password = pass;
+        this.cookies = null;
+    }
+
+    public WsCredentials(String userKey) {
+        this.wsId = userKey;
+        this.cookies = null;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsException.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsException.java
@@ -1,0 +1,12 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import java.io.IOException;
+
+/**
+ * Created by ejoliet on 6/19/17.
+ */
+public class WsException extends IOException {
+    public WsException(String s) {
+        super(s);
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsResponse.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsResponse.java
@@ -1,11 +1,13 @@
 package edu.caltech.ipac.firefly.server.ws;
 
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+
 import java.util.List;
 
 /**
  * Created by ejoliet on 6/16/17.
  */
-public class WsResponse<WspaceMeta>{
+public class WsResponse {
 
     private String statusCode = "";
     private String statusText = "";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsResponse.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsResponse.java
@@ -1,0 +1,66 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import java.util.List;
+
+/**
+ * Created by ejoliet on 6/16/17.
+ */
+public class WsResponse<WspaceMeta>{
+
+    private String statusCode = "";
+    private String statusText = "";
+    private String response = "";
+    private List<WspaceMeta> meta;
+    public WsResponse() {
+    }
+
+    public WsResponse(String code, String text, String responseString) {
+        statusCode = code;
+        statusText = text;
+        response = responseString;
+    }
+
+    public String getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(String statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getStatusText() {
+        return statusText;
+    }
+
+    public void setStatusText(String statusText) {
+        this.statusText = statusText;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String response) {
+        this.response = response;
+    }
+
+    public void setWspaceMeta(List<WspaceMeta> meta) {
+        this.meta = meta;
+    }
+
+    public List<WspaceMeta> getWspaceMeta() {
+        return this.meta;
+    }
+
+    public String toString() {
+        String result = "status code : " + statusCode + "\n" +
+                "status text : " + statusText + "\n" +
+                "   response : " + response;
+        return result;
+    }
+
+    public boolean doContinue(){
+        return true;
+    }
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerCommands.java
@@ -1,0 +1,40 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.ws;
+
+
+import edu.caltech.ipac.firefly.server.ServCommand;
+import edu.caltech.ipac.firefly.server.SrvParam;
+
+/**
+ * Handle the commands to manage ws
+ *
+ * @author ejoliet
+ */
+public class WsServerCommands {
+
+
+    public static class WsList extends ServCommand {
+
+        public String doCommand(SrvParam params) throws Exception {
+            throw new IllegalArgumentException("Not implemented yet");
+        }
+    }
+
+    public static class WsGetFile extends ServCommand {
+
+        public String doCommand(SrvParam params) throws Exception {
+            throw new IllegalArgumentException("Not implemented yet");
+        }
+    }
+
+    public static class WsPutFile extends ServCommand {
+
+        public String doCommand(SrvParam params) throws Exception {
+            throw new IllegalArgumentException("Not implemented yet");
+        }
+    }
+
+}
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsUtil.java
@@ -1,0 +1,89 @@
+package edu.caltech.ipac.firefly.server.ws;
+
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.util.StringUtils;
+import edu.caltech.ipac.util.download.ResponseMessage;
+import org.apache.commons.httpclient.HttpMethod;
+
+/**
+ * Created by ejoliet on 6/20/17.
+ */
+public class WsUtil {
+
+    public static WsResponse error(int code, String status) {
+
+        return new WsErrorResponse(code + "", status);
+    }
+
+    public static WsResponse error(HttpMethod meth) {
+
+        return new WsErrorResponse(meth.getStatusCode() + "", meth.getStatusText());
+    }
+
+    public static WsResponse error(HttpMethod meth, String extraMessage) {
+
+        WsResponse err = error(meth);
+        err.setResponse(extraMessage);
+
+        return err;
+    }
+
+    public static WsResponse error(int code, String status, String extraMessage) {
+
+        WsResponse err = error(code, status);
+        err.setResponse(extraMessage);
+
+        return err;
+    }
+
+    public static WsResponse error(int code) {
+
+        String httpResponseMessage = ResponseMessage.getHttpResponseMessage(code);
+
+        return new WsErrorResponse(code + "", httpResponseMessage);
+    }
+
+    public static WsResponse success(int code, String status, String bodyString) {
+
+        return new WsResponse(code + "", status, bodyString);
+    }
+
+    public static WsResponse error(Exception e) {
+        WsResponse err = error(-1, e.toString());
+        err.setResponse(e.getMessage());
+        return err;
+    }
+
+    private static class WsErrorResponse extends WsResponse {
+        public WsErrorResponse(String code, String status) {
+            super(code, status, null);
+        }
+
+        @Override
+        public boolean doContinue() {
+            return false;
+        }
+    }
+
+    public static String buildRemoteUri(WorkspaceManager m, String relFilePath) {
+        String wsUrl = m.getProp(WorkspaceManager.PROPS.ROOT_URL);
+        String wsHome = WspaceMeta.ensureWsHomePath(m.getWsHome());
+
+        return wsUrl + wsHome + WspaceMeta.ensureRelPath(relFilePath);
+    }
+
+    /**
+     * Adds "/" at the end if not present
+     *
+     * @param path
+     * @return always with "/" at the end
+     */
+    public static String ensureUriFolderPath(String path) {
+        String okUri = StringUtils.isEmpty(path) ? "" : path;
+        if (!path.endsWith("/")) {
+            okUri += "/";
+        }
+        return okUri;
+    }
+}

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -150,4 +150,10 @@ export const ServerParams = {
 
 
         USER_TARGET_WORLD_PT : 'UserTargetWorldPt',
+
+
+        WS_LIST : "wsList",
+        WS_GET_FILE : "wsGet",
+        WS_PUT_FILE : "wsPut"
+
 };

--- a/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
@@ -25,7 +25,7 @@ public class ConfigTest {
     public static String LOG4J_PROP_FILE = "./config/log4j-test.properties";
     public static String LOGGING_PROP_FILE = "./config/logging-test.properties";
     public static String TEST_PROP_FILE = "./config/app-test.prop";
-
+    public static String WS_USER_ID = "test-ws";
     /**
      * Use the logger in the test case that would extends this class.
      */

--- a/src/firefly/test/edu/caltech/ipac/firefly/util/FileLoader.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/util/FileLoader.java
@@ -15,6 +15,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Created by zhang on 10/19/16.
@@ -35,14 +37,13 @@ public class FileLoader {
      * @return
      * @throws ClassNotFoundException
      */
-    public static String getDataPath(Class cls) throws ClassNotFoundException {
+    public static String getDataPath(Class cls) {
 
-        String testTreePath =  cls.getProtectionDomain().getCodeSource().getLocation().getPath();
-        String  rootPath = testTreePath.split("firefly")[0];
+        String rootPath = Paths.get("").toAbsolutePath().getParent().toUri().getPath();
         String testDataPath = TEST_DATA_ROOT+cls.getCanonicalName().replaceAll("\\.", "/")
                 .replace(cls.getSimpleName(), "");
 
-        String dataPath = rootPath+ testDataPath;
+        String dataPath = rootPath + testDataPath;
         return dataPath;
     }
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/LocalWsGetTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/LocalWsGetTest.java
@@ -1,0 +1,115 @@
+package edu.caltech.ipac.firefly.ws;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.server.LocalFSWorkspace;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
+import edu.caltech.ipac.firefly.server.ws.WsException;
+import edu.caltech.ipac.firefly.server.ws.WsResponse;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.jackrabbit.webdav.DavMethods;
+import org.apache.jackrabbit.webdav.client.methods.DavMethodBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static edu.caltech.ipac.firefly.util.FileLoader.resolveFile;
+
+/**
+ * Created by ejoliet on 6/16/17.
+ */
+public class LocalWsGetTest extends ConfigTest {
+
+
+    private WsCredentials cred;
+    private WorkspaceManager wsm;
+    private String testUri;
+    private String testFileName;
+    private File testFile;
+    private long size;
+
+    @Before
+    public void putInit() throws WsException {
+        cred = new WsCredentials(WS_USER_ID);
+        testFileName = "gaia-binary.vot";
+        testFile = resolveFile(LocalWsGetTest.class, testFileName);
+        size = testFile.length();
+        testUri = "tmp1/";
+    }
+
+    @Test
+    public void testPutGet() throws WsException {
+
+
+        try {
+            //Test class impl
+            put(LocalFSWorkspace.class);
+            byte[] bytes = get(testUri + "/" + testFile.getName());
+            Assert.assertTrue("Size uploaded " + size + " not the same found " + bytes.length, bytes.length == size);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void put(Class cls) throws IOException {
+
+        wsm = new LocalFSWorkspace(cred);
+
+        LOG.info(wsm.getClass().getCanonicalName());
+
+
+        WsResponse wsResponse = wsm.putFile(testUri,
+                testFile,
+                ContentType.DEFAULT_BINARY.getMimeType());
+
+        Assert.assertTrue("Upload went wrong, status code <200 " + wsResponse.getStatusCode(), Integer.parseInt(wsResponse.getStatusCode()) >= 200);
+        Assert.assertTrue("Uploaded file name is wrong " + wsResponse.getResponse(), wsResponse.getResponse().endsWith(testFile.getName()));
+
+
+        File tmp = File.createTempFile("test", "vot");
+        tmp.deleteOnExit();
+        wsResponse = wsm.getFile(testUri + File.separator +
+                testFile.getName(), tmp);
+
+        Assert.assertTrue(tmp.length() == testFile.length());
+
+        Assert.assertTrue(tmp.getAbsolutePath().equals(wsResponse.getResponse()));
+
+
+    }
+
+
+    byte[] get(String uri) throws Exception {
+        return Files.readAllBytes(Paths.get("", uri));
+    }
+
+    @After
+    public void clean() {
+        try {
+            FileUtils.deleteDirectory(new File(wsm.getWsHome() + File.separator + testUri));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    class MyGetMethod extends DavMethodBase {
+        public MyGetMethod(String uri) {
+            super(uri);
+        }
+
+        public String getName() {
+            return DavMethods.METHOD_GET;
+        }
+
+        public boolean isSuccess(int statusCode) {
+            return statusCode == 200;
+        }
+    }
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsIrsaTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsIrsaTest.java
@@ -29,7 +29,7 @@ public class WsIrsaTest extends ConfigTest {
     private static WorkspaceManager workspaceManager;
 
     @Before
-    public void init() throws ClassNotFoundException {
+    public void init() throws Exception {
 
         //TESTING PUBSPACE
         WsCredentials cred = new WsCredentials(WS_USER_ID);
@@ -78,7 +78,7 @@ public class WsIrsaTest extends ConfigTest {
 
     }
 
-    private static File pickFile(int idx) throws ClassNotFoundException {
+    private static File pickFile(int idx) throws Exception {
         File testPath = new File(FileLoader.getDataPath(WsIrsaTest.class));
         File file = testPath.listFiles(new FilenameFilter() {
             @Override

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsIrsaTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsIrsaTest.java
@@ -35,14 +35,13 @@ public class WsIrsaTest extends ConfigTest {
         WsCredentials cred = new WsCredentials(WS_USER_ID);
         f = pickFile(0);
 
-        //TODO For TESTING SSOspace, uncomment 2 lines below and add proper password
-//      cred = new WsCredentials("ejoliet@ipac.caltech.edu", "xxx");
-//      f = FileLoader.resolveFile(WsIrsaTest.class, "wstest.fits"); // Test adding fits >1Mb (only SSO quota ok)
+        //For TESTING SSOspace, uncomment 2 lines below and add proper password
+      //cred = new WsCredentials("test@ipac.caltech.edu", "Ask irsa");
+      //f = FileLoader.resolveFile(WsIrsaTest.class, "wstest.fits"); // Test adding fits >1Mb (only SSO quota ok)
 
 
-        //SSOSPACE is only available in irsadev for now. - PUBSPACE will also work with same prop
-        //TODO this doesn't overwrite, use ./config/app-test.prop instead
-        AppProperties.setProperty("workspace.host.url", "https://irsadev.ipac.caltech.edu");
+        //TODO this doesn't overwrite, use ./config/app-test.prop if you need
+        //AppProperties.setProperty("workspace.host.url", "https://irsadev.ipac.caltech.edu");
 
         workspaceManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(cred);
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsIrsaTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsIrsaTest.java
@@ -1,0 +1,92 @@
+package edu.caltech.ipac.firefly.ws;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.firefly.server.ws.*;
+import edu.caltech.ipac.firefly.util.FileLoader;
+import edu.caltech.ipac.util.AppProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test SSO @ IRSA
+ * Created by ejoliet on 6/26/17.
+ */
+public class WsIrsaTest extends ConfigTest {
+
+
+    private static File f;
+    private static WorkspaceManager workspaceManager;
+
+    @Before
+    public void init() throws ClassNotFoundException {
+
+        //TESTING PUBSPACE
+        WsCredentials cred = new WsCredentials(WS_USER_ID);
+        f = pickFile(0);
+
+        //TODO For TESTING SSOspace, uncomment 2 lines below and add proper password
+//      cred = new WsCredentials("ejoliet@ipac.caltech.edu", "xxx");
+//      f = FileLoader.resolveFile(WsIrsaTest.class, "wstest.fits"); // Test adding fits >1Mb (only SSO quota ok)
+
+
+        //SSOSPACE is only available in irsadev for now. - PUBSPACE will also work with same prop
+        //TODO this doesn't overwrite, use ./config/app-test.prop instead
+        AppProperties.setProperty("workspace.host.url", "https://irsadev.ipac.caltech.edu");
+
+        workspaceManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(cred);
+
+    }
+
+    @Test
+    public void testSSOAuth() throws ClassNotFoundException, IOException {
+
+        LOG.info(workspaceManager.getWsHome());
+
+
+        workspaceManager.putFile("", f, null);
+        WsResponse r = workspaceManager.getList("", 1);
+        if (!r.getStatusCode().equals("200")) {
+            LOG.error(r.getStatusText());
+        }
+        List<WspaceMeta> wsmeta = r.getWspaceMeta();
+
+        if (wsmeta != null) {
+            for (WspaceMeta meta : wsmeta) {
+                LOG.info(meta.getNodesAsString());
+                if (meta.getRelPath().endsWith(f.getName())) {
+                    assertTrue(meta.getSize() == f.length());
+                }
+            }
+        }
+    }
+
+
+    @After
+    public void clean() throws WsException {
+        LOG.info("deleting " + f.getName());
+        workspaceManager.delete(f.getName());
+
+    }
+
+    private static File pickFile(int idx) throws ClassNotFoundException {
+        File testPath = new File(FileLoader.getDataPath(WsIrsaTest.class));
+        File file = testPath.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return !name.endsWith(".fits"); // Can't use fits in pubspace because > 1Mb irsa policy storage
+            }
+        })[idx];
+        return file;
+    }
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsListTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsListTest.java
@@ -1,5 +1,6 @@
 package edu.caltech.ipac.firefly.ws;
 
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.data.WspaceMeta;
 import edu.caltech.ipac.firefly.server.WorkspaceManager;
 import edu.caltech.ipac.firefly.server.ws.*;
@@ -15,14 +16,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static edu.caltech.ipac.firefly.ConfigTest.LOG;
-import static edu.caltech.ipac.firefly.ConfigTest.WS_USER_ID;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Created by ejoliet on 6/26/17.
  */
-public class WsListTest {
+public class WsListTest extends ConfigTest {
 
     private static WorkspaceManager m;
     private static File[] testFile = new File[2];
@@ -30,6 +29,8 @@ public class WsListTest {
     private static String[] relFolder = new String[2];
     private static ArrayList testFolders;
     private static ArrayList testFiles;
+    private static WorkspaceHandler handler;
+
 
     @Before
     public void init() throws WsException, ClassNotFoundException {
@@ -38,8 +39,8 @@ public class WsListTest {
         testFiles = new ArrayList<>();
         relFolder[0] = createFolder("/tmp1/");
         relFolder[1] = createFolder("/tmp2/");
-
-        m = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(key));
+        handler = WorkspaceFactory.getWorkspaceHandler();
+        m = handler.withCredentials(new WsCredentials(key));
 
         testFile[0] = pickFile(0);
         testFile[1] = pickFile(1);
@@ -135,12 +136,15 @@ public class WsListTest {
         // Gets children folder meta under user home ws.
         // Equivalent to WsResponse wsResponse = m.getList("/", 1);
         //
-        List<WspaceMeta> metas = m.getMeta("/", WspaceMeta.Includes.CHILDREN).getChildNodes();//wsResponse.getWspaceMeta();
+        WspaceMeta mMeta = m.getMeta("/", WspaceMeta.Includes.CHILDREN);
+        if (mMeta != null) {
+            List<WspaceMeta> metas = mMeta.getChildNodes();//wsResponse.getWspaceMeta();
 
-        for (WspaceMeta meta : metas) {
-            WsResponse response = m.delete(meta.getRelPath());
-            if (response.getStatusCode().equals("304")) { //Parent is home, try to delete file then
-                m.delete(meta.getRelPath());
+            for (WspaceMeta meta : metas) {
+                WsResponse response = m.delete(meta.getRelPath());
+                if (response.getStatusCode().equals("304")) { //Parent is home, try to delete file then
+                    m.delete(meta.getRelPath());
+                }
             }
         }
     }

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsListTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsListTest.java
@@ -1,0 +1,159 @@
+package edu.caltech.ipac.firefly.ws;
+
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.firefly.server.ws.*;
+import edu.caltech.ipac.firefly.util.FileLoader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static edu.caltech.ipac.firefly.ConfigTest.LOG;
+import static edu.caltech.ipac.firefly.ConfigTest.WS_USER_ID;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by ejoliet on 6/26/17.
+ */
+public class WsListTest {
+
+    private static WorkspaceManager m;
+    private static File[] testFile = new File[2];
+    private static String key = WS_USER_ID;
+    private static String[] relFolder = new String[2];
+    private static ArrayList testFolders;
+    private static ArrayList testFiles;
+
+    @Before
+    public void init() throws WsException, ClassNotFoundException {
+
+        testFolders = new ArrayList<>();
+        testFiles = new ArrayList<>();
+        relFolder[0] = createFolder("/tmp1/");
+        relFolder[1] = createFolder("/tmp2/");
+
+        m = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(key));
+
+        testFile[0] = pickFile(0);
+        testFile[1] = pickFile(1);
+
+        m.putFile(relFolder[0], testFile[0], null);
+
+        m.putFile(relFolder[1], testFile[0], null);
+        m.putFile(relFolder[1], testFile[1], null);
+    }
+
+    private String createFolder(String s) {
+        testFolders.add(s);
+        return s;
+    }
+
+    @Test
+    public void testGetListDepth() throws IOException {
+
+        //Get childs of user home
+        WsResponse r = m.getList("/", 1);
+
+        if (r.doContinue()) { //Success response
+            List<WspaceMeta> childNodes = r.getWspaceMeta();
+            printChildren(childNodes);
+
+            assertTrue(childNodes.size() == relFolder.length);
+            childNodes = r.getWspaceMeta();
+            if (childNodes != null) {
+                Iterator<WspaceMeta> it = childNodes.iterator();
+                int childs = 0;
+                while (it.hasNext()) {
+                    WspaceMeta next = it.next();
+                    assertTrue(testFolders.contains(next.getRelPath()));
+                    childs++;
+                }
+
+                assertTrue(childs == childNodes.size());
+            }
+        }
+
+        //Gets prop from file equivalent to get list of resource with depth = 0:
+        String testPath = WsUtil.ensureUriFolderPath(WspaceMeta.ensureRelPath(relFolder[0])) + testFile[0].getName();
+        WsResponse response = m.getList(testPath, 0);
+        if (response.doContinue()) {
+            List responseWspaceMeta = response.getWspaceMeta();
+            assertTrue(responseWspaceMeta.size() == 1);
+            WspaceMeta meta1 = (WspaceMeta) responseWspaceMeta.get(0);
+            assertTrue(meta1.getRelPath().equals(testPath));
+        }
+
+        //Get children of folder: should be one file
+        r = m.getList(WsUtil.ensureUriFolderPath(WspaceMeta.ensureRelPath(relFolder[0])), 1);
+        if (r.doContinue()) { //Success response
+            List<WspaceMeta> childNodes = r.getWspaceMeta();
+            assertTrue(childNodes.size() == 1);
+            WspaceMeta wspaceMeta = childNodes.get(0);
+            assertTrue(wspaceMeta.getRelPath().equals(testPath));
+        }
+
+        //Get children of folder: should be 2 files
+        r = m.getList(WsUtil.ensureUriFolderPath(WspaceMeta.ensureRelPath(relFolder[1])), 1);
+        if (r.doContinue()) { //Success response
+            List<WspaceMeta> childNodes = r.getWspaceMeta();
+            assertTrue(childNodes.size() == 2);
+            int i = 0;
+            for (WspaceMeta m : childNodes) {
+                WspaceMeta wspaceMeta = m;
+                File f = testFile[i++];
+                assertTrue(wspaceMeta.getSize() > 0);
+                assertTrue(testFiles.contains(f.getName()));
+            }
+            assertTrue(i == childNodes.size());
+        }
+
+    }
+
+    private void printChildren(List<WspaceMeta> childNodes) {
+        if (childNodes != null) {
+            Iterator<WspaceMeta> it = childNodes.iterator();
+            if (childNodes.size() > 0) {
+                while (it.hasNext()) {
+                    WspaceMeta next = it.next();
+                    LOG.info(next.getRelPath());
+                    printChildren(next.getChildNodes());
+                }
+            }
+        }
+    }
+
+    @After
+    public void tearDown() throws IOException {
+
+        // Gets children folder meta under user home ws.
+        // Equivalent to WsResponse wsResponse = m.getList("/", 1);
+        //
+        List<WspaceMeta> metas = m.getMeta("/", WspaceMeta.Includes.CHILDREN).getChildNodes();//wsResponse.getWspaceMeta();
+
+        for (WspaceMeta meta : metas) {
+            WsResponse response = m.delete(meta.getRelPath());
+            if (response.getStatusCode().equals("304")) { //Parent is home, try to delete file then
+                m.delete(meta.getRelPath());
+            }
+        }
+    }
+
+    private static File pickFile(int idx) throws ClassNotFoundException {
+        File testPath = new File(FileLoader.getDataPath(WsListTest.class));
+        File file = testPath.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return !name.endsWith(".fits"); // Can't use fits in pubspace because > 1Mb irsa policy storage
+            }
+        })[idx];
+        testFiles.add(file.getName());
+        return file;
+    }
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPropTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPropTest.java
@@ -1,0 +1,85 @@
+package edu.caltech.ipac.firefly.ws;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.core.ResourceNotFoundException;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.firefly.server.ws.WorkspaceFactory;
+import edu.caltech.ipac.firefly.server.ws.WorkspaceHandler;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
+import edu.caltech.ipac.firefly.server.ws.WsException;
+import edu.caltech.ipac.util.AppProperties;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by ejoliet on 6/16/17.
+ */
+public class WsPropTest extends ConfigTest {
+
+    private String urlHost;
+    private String prot;
+    private String userKey;
+    private WorkspaceHandler ws;
+
+    @Before
+    public void init() throws WsException {
+
+        urlHost = AppProperties.getProperty("workspace.host.url");
+        prot = AppProperties.getProperty("workspace.protocol.irsa");
+        userKey = WS_USER_ID;
+        ws = WorkspaceFactory.getWorkspaceHandler();
+    }
+
+    @Test
+    public void testProps() {
+        try {
+            WorkspaceManager.PROPS prop = WorkspaceManager.PROPS.ROOT_URL;
+            WorkspaceManager m = ws.withCredentials(new WsCredentials(userKey));
+            Assert.assertTrue(m.getProp(prop).equals(urlHost));
+            Assert.assertTrue(m.getProp(WorkspaceManager.PROPS.PROTOCOL).equalsIgnoreCase(prot));
+
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+
+    }
+
+    @Test
+    public void testPoolWsManager() {
+        try {
+
+            // get 2 times the workspace manager, the object should be the same if the user key is the same
+            WorkspaceManager ws1 = ws.withCredentials(new WsCredentials(userKey));
+
+            WorkspaceManager ws2 = ws.withCredentials(new WsCredentials(userKey));
+
+            Assert.assertTrue(ws1.getCredentials().getWsId().equals(ws2.getCredentials().getWsId()));
+            Assert.assertTrue(ws1.getClass().equals(ws2.getClass()));
+
+            // get 2 times the workspace manager for same user but different protocol, the object should be different
+            WorkspaceManager ws3 = ws.withCredentials(new WsCredentials(userKey));
+
+            WorkspaceManager ws4 = WorkspaceFactory.getWorkspaceHandler(WorkspaceManager.PROTOCOL.LOCAL).
+                    withCredentials(new WsCredentials(userKey));
+
+            Assert.assertFalse(ws3.getClass().equals(ws4.getClass()));
+
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+
+    }
+
+    @Test(expected = ResourceNotFoundException.class)
+    public void testNotImplementedVospace() {
+
+        WorkspaceFactory.getWorkspaceHandler(WorkspaceManager.PROTOCOL.VOSPACE).withCredentials(new WsCredentials(userKey));
+
+    }
+
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPutGetTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPutGetTest.java
@@ -1,0 +1,118 @@
+package edu.caltech.ipac.firefly.ws;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.firefly.server.ws.*;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.http.entity.ContentType;
+import org.apache.jackrabbit.webdav.DavMethods;
+import org.apache.jackrabbit.webdav.client.methods.DavMethodBase;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.UUID;
+
+import static edu.caltech.ipac.firefly.util.FileLoader.resolveFile;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by ejoliet on 6/16/17.
+ */
+public class WsPutGetTest extends ConfigTest {
+
+
+    private WsCredentials cred;
+    private WorkspaceManager wsm;
+    private String testUrl;
+    private String testRelPathFolder;
+    private String testFileName;
+    private File testFile;
+    private long size;
+
+    @Before
+    public void putInit() throws WsException {
+        cred = new WsCredentials(WS_USER_ID);
+        testFileName = "gaia-binary.vot";
+        testFile = resolveFile(WsPutGetTest.class, testFileName);
+        size = testFile.length();
+        testRelPathFolder = "tmp-" + UUID.randomUUID().toString() + "/tmp1/tmp2/tmp3";//
+        // TODO with special chars irt throws 301-move permanently status "/tmp1?/t2#$%^&*9"; ??
+        wsm = WorkspaceFactory.getWorkspaceHandler().withCredentials(cred);
+        LOG.info(wsm.getClass().getCanonicalName());
+
+    }
+
+    @After
+    public void delRelFolder() throws WsException {
+        wsm.delete(WsUtil.ensureUriFolderPath(testRelPathFolder.substring(0,testRelPathFolder.indexOf("/"))));
+    }
+
+    @Test
+    public void testPutGet() throws WsException {
+
+        WsResponse wsResponse = wsm.putFile(testRelPathFolder,
+                testFile,
+                ContentType.DEFAULT_BINARY.getMimeType());
+
+        assertTrue("Upload went wrong, status code <200 " + wsResponse.getStatusCode(), Integer.parseInt(wsResponse.getStatusCode()) == 201);
+        assertTrue("Uploaded file name is wrong " + wsResponse.getResponse(), wsResponse.getStatusText().equals("Created"));
+
+
+        testUrl = wsm.getMeta(WsUtil.ensureUriFolderPath(testRelPathFolder) + testFile.getName(), WspaceMeta.Includes.NONE).getUrl();
+        try {
+            byte[] bytes = jackrabbitGet(testUrl);
+            assertTrue("Size uploaded " + size + " not the same found " + bytes.length, bytes.length == size);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    byte[] jackrabbitGet(String uri) throws Exception {
+        org.apache.commons.httpclient.HttpClient client = new org.apache.commons.httpclient.HttpClient();
+        org.apache.commons.httpclient.Credentials creds = new org.apache.commons.httpclient.UsernamePasswordCredentials(cred.getWsId(), cred.getPassword());
+        client.getState().setCredentials(AuthScope.ANY, creds);
+        MyGetMethod method = new MyGetMethod(uri);
+        client.executeMethod(method);
+        if (method.isSuccess(method.getStatusCode())) {
+            byte[] resp = method.getResponseBody();
+            LOG.info("Got response: " + resp.length + " bytes");
+            return resp;
+        }
+        return new byte[0];
+    }
+
+    @Test
+    public void specialCharsUriException() throws WsException {
+
+        testRelPathFolder = "tmp-" + UUID.randomUUID().toString() + "/tmp1?/t2#$%^&*9";
+
+        WsResponse wsResponse = wsm.putFile(testRelPathFolder,
+                testFile,
+                ContentType.DEFAULT_BINARY.getMimeType());
+        if (wsResponse.getStatusCode().endsWith("301")) {
+            assertTrue(wsResponse.getStatusCode().equals("-1"));
+            assertTrue(wsResponse.getResponse().startsWith("java.net.URISyntaxException"));
+            assertTrue(wsResponse.getResponse().indexOf(testRelPathFolder) > 0);
+        }
+
+    }
+
+    class MyGetMethod extends DavMethodBase {
+        public MyGetMethod(String uri) {
+            super(uri);
+        }
+
+        public String getName() {
+            return DavMethods.METHOD_GET;
+        }
+
+        public boolean isSuccess(int statusCode) {
+            return statusCode == 200;
+        }
+    }
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsTest.java
@@ -1,0 +1,233 @@
+package edu.caltech.ipac.firefly.ws;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.WorkspaceManager;
+import edu.caltech.ipac.firefly.server.ws.*;
+import edu.caltech.ipac.firefly.util.FileLoader;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.entity.ContentType;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by ejoliet on 6/15/17.
+ */
+public class WsTest extends ConfigTest {
+
+
+    private static String relFolder = null;
+    private static WorkspaceManager man;
+    private static String userKey = WS_USER_ID;
+    private SimpleDateFormat df;
+    private static List<String> resourceList;
+
+    @BeforeClass
+    public static void init() {
+
+        relFolder = "123/321/";
+        resourceList = new ArrayList<>();
+    }
+
+    @Before
+    public void setUp() {
+        man = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(userKey));
+        df = new SimpleDateFormat("E, dd MMM yyyy HH:mm:ss Z");
+    }
+
+    @Test
+    public void testHandler() throws WsException, ParseException {
+
+
+//        UserInfo ui = UserInfo.newGuestUser();
+
+        //create folder under home (.)
+        WsResponse f = man.createParent(relFolder);
+        LOG.info("new directory: " + String.valueOf(f));
+
+        WspaceMeta m = new WspaceMeta(null, relFolder);
+        m.setProperty("test1", "an awesome idea");
+        m.setProperty("test", null);
+        man.setMeta(m);
+
+        WspaceMeta metaRetrieved = man.getMeta(WsUtil.ensureUriFolderPath(relFolder), WspaceMeta.Includes.ALL_PROPS);
+        LOG.info(metaRetrieved.getNodesAsString());
+        assertTrue("Doesn't contains meta ", metaRetrieved.getProperty("test1").equals("an awesome idea"));
+
+        String name1 = "gaia-binary2.vot";
+        File testFile = FileLoader.resolveFile(WsTest.class, name1);
+        String ufilePath = putFile(name1, man);
+
+        //  ufilePath = putFile("x.fits", man);// Fails for now: Request Entity Too Large in pubspace
+        WspaceMeta meta = new WspaceMeta(null, ufilePath);
+        meta.setProperty("added_by", userKey);
+        man.setMeta(meta);
+
+        metaRetrieved = man.getMeta(ufilePath, WspaceMeta.Includes.ALL_PROPS);
+        LOG.info(metaRetrieved.getNodesAsString());
+        assertTrue("Doesn't contains meta ", metaRetrieved.getProperty("added_by").equals(userKey));
+
+        String renamed = "gaia-binary2-renamed.vot";
+        man.renameFile(ufilePath, renamed, true);
+
+        resourceList.add(ufilePath.replaceAll(name1, renamed));
+
+        metaRetrieved = man.getMeta(WsUtil.ensureUriFolderPath(relFolder) + renamed, WspaceMeta.Includes.ALL_PROPS);
+        LOG.info(metaRetrieved.getNodesAsString());
+
+        //Date modDate = df.parse(metaRetrieved.getLastModified());
+
+        assertTrue("Doesn't contains meta ", metaRetrieved != null);
+
+        //Should remain unchanged
+        String renamedSame = renamed;
+        man.renameFile(ufilePath, renamedSame, false);
+//        Date modDateRenamedSame = df.parse(man.getMeta(ufilePath, WspaceMeta.Includes.ALL_PROPS).getLastModified());
+//        assertTrue(modDate.equals(modDateRenamedSame));
+        assertTrue(man.getMeta(WsUtil.ensureUriFolderPath(relFolder) + renamedSame, WspaceMeta.Includes.ALL_PROPS).getLastModified().equals(man.getMeta(WsUtil.ensureUriFolderPath(relFolder) + renamed, WspaceMeta.Includes.ALL_PROPS).getLastModified()));
+    }
+
+    @Test
+    public void testGet() throws WsException {
+
+        //Check what we put is what we get
+        File original = FileLoader.resolveFile(WsTest.class, "gaia-binary.vot");
+        String name2 = original.getName();
+
+        // Make sure is uploaded first to test to get it
+        String ufilePath = putFile(name2, man);
+
+        WspaceMeta meta = man.getMeta("/", WspaceMeta.Includes.ALL_PROPS);
+
+        // Change to INFO level in log4j-test.properties to see output.
+        // log4j.logger.test=INFO, A1
+
+        LOG.info(meta.getNodesAsString());
+
+        meta = man.getMeta(ufilePath, WspaceMeta.Includes.ALL_PROPS);
+
+        LOG.info(meta.toString());
+
+        try {
+
+            File gotFromWS = getFile(name2, man);
+
+            //test.deleteOnExit();
+
+            assertTrue("Empty!", gotFromWS.length() > 0);
+            assertTrue(gotFromWS.length() == original.length());
+            assertTrue(meta.getSize() == original.length());
+            assertTrue("Empty!", FileUtils.contentEquals(gotFromWS, original));
+            assertTrue("wrong name!", gotFromWS.getName().startsWith(name2));
+        } catch (WsException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+
+    }
+
+
+    @Test
+    public void delete() throws WsException {
+
+        //Check what we put is what we get
+        File original = FileLoader.resolveFile(WsTest.class, "gaia-binary.vot");
+        String name2 = original.getName();
+
+        // Make sure is uploaded first to test to get it
+        String ufilePath = putFile(name2, man);
+
+        WspaceMeta metaRetrieved = man.getMeta(ufilePath, WspaceMeta.Includes.ALL_PROPS);
+
+        assertTrue(metaRetrieved != null); //exists
+
+        man.delete(ufilePath);
+
+        metaRetrieved = man.getMeta(ufilePath, WspaceMeta.Includes.ALL_PROPS);
+
+        assertTrue(metaRetrieved == null); //removed
+
+    }
+
+    @AfterClass
+    public static void cleanUp() throws IOException {
+        LOG.info("Cleaning " + userKey);
+//
+////      Clean up using resource list
+//
+//          WorkspaceManager wsm = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(userKey));
+//        Iterator<String> iterator = resourceList.iterator();
+//        while (iterator.hasNext()) {
+//            String path = iterator.next();
+//            del(path);
+//        }
+//
+
+        // OR using getList from manager get children of root
+
+        WsResponse response = man.getList("/", 1);
+        List meta = response.getWspaceMeta();
+
+        Iterator iterator1 = meta.iterator();
+        while (iterator1.hasNext()) {
+            WspaceMeta next = (WspaceMeta) iterator1.next();
+
+            del(next.getRelPath());
+        }
+
+    }
+
+    private static void del(String path) throws WsException {
+        LOG.info("Deleting " + path);
+        WsResponse response = man.delete(path);
+        LOG.info(response.getStatusText());
+        if (!response.getStatusCode().equals("200")) {
+            return;
+        }
+//        int idx = path.lastIndexOf("/");
+//        if (idx > 0) {
+//            String parentPath = path.substring(0, idx+1);
+//            del(parentPath);
+//        }
+    }
+
+    private File getFile(String name, WorkspaceManager man) throws IOException, WsException {
+
+        String ufilePath = WsUtil.ensureUriFolderPath(relFolder) + name;
+
+        File tmpFile = File.createTempFile(name, "", new File("."));
+
+        tmpFile.deleteOnExit();
+
+        WsResponse responseFile = man.getFile(ufilePath, tmpFile);
+        assertTrue("Not good code " + responseFile.getStatusCode(), responseFile.getStatusCode().equals("200"));
+        return tmpFile;
+    }
+
+    private String putFile(String name, WorkspaceManager man) throws WsException {
+        File testFile = FileLoader.resolveFile(WsTest.class, name);
+
+        String ufilePath = WsUtil.ensureUriFolderPath(relFolder) + testFile.getName();
+
+        if (!resourceList.contains(ufilePath)) {
+            resourceList.add(ufilePath);
+        }
+        man.putFile(relFolder, testFile, ContentType.DEFAULT_BINARY.getMimeType());
+        return ufilePath;
+    }
+
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/client/WebDAVClient.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/client/WebDAVClient.java
@@ -1,0 +1,334 @@
+package edu.caltech.ipac.firefly.ws.client;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.httpclient.Credentials;
+import org.apache.commons.httpclient.HostConfiguration;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.SimpleHttpConnectionManager;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
+import org.apache.commons.httpclient.methods.RequestEntity;
+import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
+import org.apache.jackrabbit.webdav.MultiStatus;
+import org.apache.jackrabbit.webdav.MultiStatusResponse;
+import org.apache.jackrabbit.webdav.client.methods.CheckinMethod;
+import org.apache.jackrabbit.webdav.client.methods.CheckoutMethod;
+import org.apache.jackrabbit.webdav.client.methods.DeleteMethod;
+import org.apache.jackrabbit.webdav.client.methods.MkColMethod;
+import org.apache.jackrabbit.webdav.client.methods.PutMethod;
+import org.apache.jackrabbit.webdav.client.methods.ReportMethod;
+import org.apache.jackrabbit.webdav.client.methods.UncheckoutMethod;
+import org.apache.jackrabbit.webdav.client.methods.VersionControlMethod;
+import org.apache.jackrabbit.webdav.version.report.ReportInfo;
+import org.apache.jackrabbit.webdav.version.report.ReportType;
+
+
+/**
+ * Created by ejoliet on 6/16/17.
+ * Example of Webdav Client.
+ */
+public class WebDAVClient {
+
+
+    private static Logger LOGGER = Logger.getLogger(WebDAVClient.class.getName());
+
+    private HttpClient client = null;
+
+    public WebDAVClient(String host, int port, String username, String password) {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("WebDAVConnector {host=" + host + ", port=" + port + ", username=" + username + ", password=******}");
+        }
+
+        HostConfiguration hostConfig = new HostConfiguration();
+        hostConfig.setHost(host, port);
+
+        HttpConnectionManager connectionManager = new SimpleHttpConnectionManager();
+        HttpConnectionManagerParams params = new HttpConnectionManagerParams();
+        int maxHostConnections = 20;
+        params.setMaxConnectionsPerHost(hostConfig, maxHostConnections);
+        connectionManager.setParams(params);
+
+        client = new HttpClient(connectionManager);
+        Credentials creds = new UsernamePasswordCredentials(username, password);
+        client.getState().setCredentials(AuthScope.ANY, creds);
+        client.setHostConfiguration(hostConfig);
+    }
+
+    public WebDAVResponse listFolder(String uri) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("listFolder '" + uri + "'");
+        }
+
+        GetMethod httpMethod = new GetMethod(uri);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse createFolder(String parentUri, String newFoldersName) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("createFolder '" + newFoldersName + "' into '" + parentUri + "'");
+        }
+
+        MkColMethod httpMethod = new MkColMethod(parentUri + newFoldersName);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse downloadFile(String fileUri, String outputFileFolder, String outputFileName) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("downloadFile '" + fileUri + "' and save it to '" + outputFileFolder + outputFileName + "'");
+        }
+
+        GetMethod httpMethod = new GetMethod(fileUri);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, false);
+
+        // Save output file
+        if (httpMethod.getResponseContentLength() > 0) {
+            InputStream inputStream = httpMethod.getResponseBodyAsStream();
+            File responseFile = new File(outputFileFolder + outputFileName);
+            OutputStream outputStream = new FileOutputStream(responseFile);
+            byte buf[] = new byte[1024];
+            int len;
+            while ((len = inputStream.read(buf)) > 0) {
+                outputStream.write(buf, 0, len);
+            }
+            outputStream.close();
+            inputStream.close();
+        }
+
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse uploadFile(String destinationUri, String file, String contentType) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("uploadFile '" + file + "' with mimeType '" + contentType + "' to folder '" + destinationUri + "'");
+        }
+
+        PutMethod httpMethod = new PutMethod(destinationUri);
+
+        FileInputStream fis = new FileInputStream(file);
+        RequestEntity requestEntity = new InputStreamRequestEntity(fis, contentType);
+        httpMethod.setRequestEntity(requestEntity);
+
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    /**
+     * To delete either a folder or a file
+     *
+     * @param uri
+     * @throws Exception
+     */
+    public WebDAVResponse deleteItem(String uri) throws Exception {
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("deleteItem '" + uri + "'");
+        }
+
+        DeleteMethod httpMethod = new DeleteMethod(uri);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse checkout(String uri) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("checkout '" + uri + "'");
+        }
+
+        CheckoutMethod httpMethod = new CheckoutMethod(uri);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse checkin(String uri) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("checkin '" + uri + "'");
+        }
+
+        CheckinMethod httpMethod = new CheckinMethod(uri);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse cancelCheckout(String uri) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("cancelCheckout '" + uri + "'");
+        }
+
+        UncheckoutMethod httpMethod = new UncheckoutMethod(uri);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse report(String uri) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("report '" + uri + "'");
+        }
+
+        ReportInfo reportInfo = new ReportInfo(ReportType.VERSION_TREE);
+
+        ReportMethod httpMethod = new ReportMethod(uri, reportInfo);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, false);
+
+        MultiStatus multiStatus = httpMethod.getResponseBodyAsMultiStatus();
+        MultiStatusResponse responses[] = multiStatus.getResponses();
+
+        String responseAsString = "";
+        for (int i = 0; i < responses.length; i++) {
+            responseAsString += responses[i].getHref() + "\n";
+        }
+
+        objResponse.setResponse(responseAsString);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    public WebDAVResponse versionControl(String uri) throws Exception {
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("versionControl '" + uri + "'");
+        }
+
+        VersionControlMethod httpMethod = new VersionControlMethod(uri);
+        client.executeMethod(httpMethod);
+
+        WebDAVResponse objResponse = processResponse(httpMethod, true);
+        httpMethod.releaseConnection();
+        return objResponse;
+    }
+
+    private WebDAVResponse processResponse(HttpMethod httpMethod, boolean getResponseAsString) {
+
+        String statusCode = "-1";
+        if (httpMethod.getStatusCode() > 0) {
+            statusCode = String.valueOf(httpMethod.getStatusCode());
+        }
+        String statusText = httpMethod.getStatusText();
+
+        String responseString = "";
+        if (getResponseAsString) {
+            try {
+                responseString = httpMethod.getResponseBodyAsString();
+                if (responseString == null) {
+                    responseString = "";
+                }
+            } catch (IOException e) {
+                if (LOGGER.isLoggable(Level.WARNING)) {
+                    LOGGER.warning("IOException while getting responseAsString: " + e.getMessage());
+                }
+                e.printStackTrace();
+            }
+        }
+
+        if (LOGGER.isLoggable(Level.INFO)) {
+            LOGGER.info("status CODE: " + statusCode + ", status TEXT: " + statusText + "\n response string: " + responseString);
+        }
+
+        WebDAVResponse response = new WebDAVResponse(statusCode, statusText, responseString);
+        return response;
+    }
+
+    public static void main(String[] args) throws Exception {
+        WebDAVClient client = new WebDAVClient("http://test.cyberduck.ch/dav/anon/sardine/",80,"","");
+
+        WebDAVResponse webDAVResponse = client.listFolder("http://test.cyberduck.ch/dav/anon/sardine/");
+        LOGGER.info(webDAVResponse.getResponse());
+    }
+}
+
+
+class WebDAVResponse {
+
+    private String statusCode = "";
+    private String statusText = "";
+    private String response = "";
+
+    public WebDAVResponse() {
+
+    }
+
+    WebDAVResponse(String code, String text, String responseString) {
+        statusCode = code;
+        statusText = text;
+        response = responseString;
+    }
+
+    public String getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(String statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getStatusText() {
+        return statusText;
+    }
+
+    public void setStatusText(String statusText) {
+        this.statusText = statusText;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String response) {
+        this.response = response;
+    }
+
+    public String toString() {
+        String result = "status code : " + statusCode + "\n" +
+                "status text : " + statusText + "\n" +
+                "   response : " + response;
+        return result;
+    }
+}


### PR DESCRIPTION
I've checked in the manager for workspaces that should work for different implementation. Part of the code was already implemented few years ago so i needed to adjusted and add/fix webdav specific implementation.

**The idea** is to have a common interface that will be used from UI client to interact with workspaces back in the server. Right now the implementation is WebDAV and local FS (not fully implemented) for testing purposes. I've kept original method that was used in other places already (such as to get the ws directory or staging files directly from FF app) - _`I'm not sure if we want to stage files directly to workspace without the consent from the user first, such that the user has to deliberately set the default mechanism to save the result into workspaces`_

**The API** exposes `get, put, create parent, rename, delete and list files` from user workspace independently of the implementation in the workspace server. There is also a way to set and get metadata, which will help in particular to get/set custom properties in the future. 

I've added a bunch of tests that covers the implementation of the manager and aslo helps to understand how the api works. Typically a request to the server will give back a metadata object which contains the properties of the node(s). This object should be also generic to cover any workspace implementation in the future. 

**The tests** covers the authenticated user and public (anonymous) space as well. I've omitted the test to authenticate with cookies (with IRSA SSO server).

Finally, i've added some code to start the **skeleton of the server commands** but i feel that this will be part of the other ticket IRSA-474 (File picker to use server worskspace api). 

Couple of things need to be addressed and **can't be done at this stage**: 

- how the response json object would look like when used by the file picker to list the files for example.
- Should we create by default the workspace user home if not present? Right now the implementation is creating a parent (see constructor of the manager).
- Would the file picker only show files if logged in? Should we always use anonymous space?

**Need to discuss further also:** I'm not sure if we want to stage files directly to workspace without the consent from the user first, such that the user has to deliberalty set the default mechanism to save the result into workspaces

Part of the _**answer of many questions could be found in IRSA-457**_: workspace reqs and concepts, when ready.

> **To TEST**:
> 
> Checkout branches from firefly and firefly_test_data: `IRSA-504-workspace-server-api`.
> In order to see logs, you need to change level from WARN to INFO in `config/log4j-test.properties`.
> Then run tests `gradle test` or from your favorite IDE. Tests will take files from `test_data` here: `edu/caltech/ipac/firefly/ws/`. One fits file is used for SSO only because pubspace has limit to 1Mb. The tests use a common user id: `test-ws` with no password (anonymous).
> 
> Then go to some tests and see how you can call the manager via a handler that will keep the manager mapping the user id. Each handler belongs to a protocol: WEBDAV, LOCAL or VOSPACE. Manager can be of different implementation: webdav or local.
> 
> Another way to see in action is to comment out the tear down (@After in test) of the test and look for url:  https://irsa.ipac.caltech.edu/pubspace/test-ws/
> This area should be populated and clean up as long you run those tests.

Let me know if you have trouble or find problems.