### PR TITLE
DM-11122: create gradle tasks for docker related functions

### DIFF
--- a/buildScript/depends.gincl
+++ b/buildScript/depends.gincl
@@ -111,7 +111,7 @@ task buildClient (dependsOn: loadConfig) {
   description= 'Build JavaScript portion of the application.'
   group = MISC_GROUP
 
-  outputs.dir "${buildDir}/gwt/${project['app-name']}"
+  outputs.dir "${buildDir}/war"
   inputs.dir "${projectDir}/js"
   inputs.dir "${fireflyPath}/src/firefly/js"
 
@@ -131,7 +131,7 @@ task buildJsDoc (dependsOn: loadConfig) {
   description= 'Build JSDoc.'
   group = MISC_GROUP
 
-  def outdir = "${buildDir}/gwt/${project['app-name']}"
+  def outdir = "${buildDir}/war"
 
   outputs.dir outdir
   inputs.dir "${projectDir}"
@@ -154,7 +154,7 @@ task publishJsDocs (dependsOn: loadConfig) {
   description = 'Publish js docs to firefly.lsst.io'
   group = MISC_GROUP
 
-  def docsDir = "${buildDir}/gwt/${project['app-name']}/docs/js"
+  def docsDir = "${buildDir}/war/docs/js"
   doLast {
     def res = project.ext.publishDocs docsDir, 'firefly'
     if (res.getExitValue() != 0) {
@@ -167,7 +167,7 @@ task publishPythonDocs (dependsOn: loadConfig) {
   description = 'Publish python docs to firefly_client.lsst.io'
   group = MISC_GROUP
 
-  def docsDir = "${buildDir}/gwt/${project['app-name']}/docs/python"
+  def docsDir = "${buildDir}/war/docs/python"
   doLast {
     def res = project.ext.publishDocs docsDir, 'firefly_client'
     if (res.getExitValue() != 0) {
@@ -176,11 +176,91 @@ task publishPythonDocs (dependsOn: loadConfig) {
   }
 }
 
+
+task dockerImage (dependsOn: loadConfig) {
+  description = 'Create a docker image'
+  group = MISC_GROUP
+
+  ext.docker_repo = "ipac/firefly"
+  ext.docker_registry = ''
+  ext.docker_tag = 'latest'
+
+  doLast {
+    // copy artifacts to staging directory
+    copy {
+      from ("${project.distDir}") { include '*.war' }
+      from ("${fireflyPath}/docker/base") { include '*' }
+      into "${buildDir}/docker"
+    }
+
+    try {
+      "docker --version".execute()
+    } catch (Exception e) {
+      println ">> docker is not installed.  This task required docker"
+      throw new GradleException("docker is not installed.  This task required docker", e)
+    }
+
+    if (!file("${buildDir}/docker/Dockerfile").exists()) {
+      println ">> Dockerfile not found. Fail to create docker image"
+      throw new GradleException("Dockerfile not found. Fail to create docker image")
+    }
+
+    docker_repo = project.appConfigProps.docker_repo ?: docker_repo
+    docker_tag = project.appConfigProps.docker_tag ?: docker_tag
+    docker_registry = project.appConfigProps.docker_registry ?: docker_registry
+    docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
+
+    def res = exec {
+      workingDir "${buildDir}/docker"
+      commandLine "docker build -t ${docker_registry}${docker_repo}:${docker_tag} --build-arg IMAGE_NAME=${docker_registry}${docker_repo} .".split(' ')
+    }
+    if (res.getExitValue() != 0) {
+      throw new GradleException("Fail to create docker image")
+    }
+    return res;
+  }
+}
+
+task dockerPublish (dependsOn: dockerImage) {
+  description = 'Create a docker image'
+  group = MISC_GROUP
+
+  doLast {
+
+    try {
+      "docker --version".execute()
+    } catch (Exception e) {
+      println ">> docker is not installed.  This task required docker"
+      throw new GradleException("docker is not installed.  This task required docker", e)
+    }
+
+    if (project.appConfigProps.docker_user != '') {
+      def proc = "docker login --username ${project.appConfigProps.docker_user} --password ${project.appConfigProps.docker_passwd}".execute()
+      proc.waitForOrKill(10000)
+      println ">> docker login as ${project.appConfigProps.docker_user} with exit status ${proc.exitValue()}"
+    }
+
+    def docker_repo = project.appConfigProps.docker_repo ?: dockerImage.docker_repo
+    def docker_tag = project.appConfigProps.docker_tag ?: dockerImage.docker_tag
+    def docker_registry = project.appConfigProps.docker_registry ?: dockerImage.docker_registry
+    docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
+
+    def res = exec {
+      workingDir "${buildDir}/docker"
+      commandLine "docker push ${docker_registry}${docker_repo}:${docker_tag}".split(' ')
+    }
+    if (res.getExitValue() != 0) {
+      throw new GradleException("Fail to push docker image")
+    }
+    return res;
+  }
+}
+
 /**
  * this function setup node.js environment then run the given command.
  */
 ext.NODE = { ...cmd ->
-  def wpBuildDir = "${buildDir}/gwt/${project['app-name']}"
+  def wpBuildDir = "${buildDir}/war"
   def tag = "v" + getVersionTag() + ' Built On:' + build_time;
 
   try {

--- a/buildScript/gwt.gincl
+++ b/buildScript/gwt.gincl
@@ -2,8 +2,8 @@
 task gwt {
   outputs.upToDateWhen { false }
 
-  ext.buildDir = "${project.buildDir}/gwt"
-  ext.warDir = "$buildDir/${project['app-name']}"
+  ext.buildDir = "${project.buildDir}"
+  ext.warDir = "$buildDir/war"
   ext.modules = "<UNDEFINED>"
   ext.module_name = project.projectDir.name
   ext.startupUrl = "${project['app-name']}.html"

--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -166,7 +166,7 @@ war {
   outputs.dir gwt.warDir
   classpath = configurations.webappLib
   from gwt.warDir
-  destinationDir = file("${rootDir}/build/libs")
+  destinationDir = file(project.distDir)
 
   doFirst {
     archiveName = "${webapp.baseWarName}.war"

--- a/buildScript/init.gincl
+++ b/buildScript/init.gincl
@@ -4,6 +4,7 @@ ext.MISC_GROUP = "~ Misc"
 
 project.ext["app-name"] = name
 project.ext.buildRoot = "$rootDir/build"
+project.ext.distDir = "${rootDir}/build/dist"
 buildDir = "$buildRoot/${project.ext["app-name"]}"
 
 

--- a/buildScript/utils.gincl
+++ b/buildScript/utils.gincl
@@ -35,7 +35,7 @@ task deployAllWars(dependsOn: loadConfig) {
       execCmd(rhost, true, ["rm", "-r", "$tomcat_home/temp/ehcache"])
 
       // copy all of the war files
-      def wars = fileTree(dir: "${project.buildRoot}/libs", include: '*.war')
+      def wars = fileTree(dir: "${project.distDir}", include: '*.war')
       wars.each { File file ->
         copyWar(file, rhost)
       }

--- a/buildScript/webpack.config.js
+++ b/buildScript/webpack.config.js
@@ -31,7 +31,7 @@ export default function makeWebpackConfig(config) {
 
     var def_config = {
         env         : process.env.NODE_ENV || 'development',
-        dist        : process.env.WP_BUILD_DIR || path.resolve(config.project, `build/${config.name}/gwt/${config.name}`),
+        dist        : process.env.WP_BUILD_DIR || path.resolve(config.project, `build/${config.name}/war`),
         do_lint     : process.env.DO_LINT || process.env.DO_LINT_STRICT || false,
         html_dir    : 'html',
         use_loader  : true,


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-11122

DM-11122: gradle task for docker

2 tasks created: dockerImage, dockerPublish
dockerImage is a prerequisite for dockerPublish
they will accept these params:
```
docker_repo = "ipac/firefly”
docker_registry = ''
docker_tag = ‘latest’
```
`docker_user, docker_passwd` may be passed as parameter.  This is used to log into docker hub.

`docker_registry `may be set to a local registry.  You can test it by running a local registry and setting `docker_registry` as parameter or via personal build.config file.
`docker_tag` will be set to branch name during auto-build setup.  This will be useful for ‘dev’ as well as PR’s instances.

To test:
- install docker
- checkout this branch
- gradle :firefly:dockerImage
- in terminal type: docker images
   - ipac/firefly should appears in listing

In you ~/.gradle/build.config, add
```
docker_user = “irsadev”
docker_passwd = <contact me for password>
```
- gradle :firefly:dockerPublish
- goto https://hub.docker.com/r/ipac/firefly/tags/
- you should see an updated ‘latest’


Other changes:
- build/libs is now build/dist
- content of war file used to be in build/firefly/gwt/firefly is now in build/firefly/war