### PR TITLE
Heatmap (density) plot in multitrace chart

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-charttest.html
+++ b/src/firefly/html/demo/ffapi-highlevel-charttest.html
@@ -23,6 +23,10 @@
     </h2>
 </div>
 
+<div id="table-lg" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<br/><br/>
+<div id="heatmapHere" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<br/><br/>
 <div id="histogramHere" style="width: 800px; height: 550px; border: solid 1px"></div>
 <br/><br/>
 <div id="xyplotHere" style="width: 800px; height: 550px; border: solid 1px;"></div>
@@ -30,6 +34,7 @@
 <div id="plotly" style="resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px; border: solid 1px gray;"></div>
 <br/><br/>
 <div id="table-1" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<br/><br/>
 
 <script type="text/javascript">
     if (!window.firefly) window.firefly= {};
@@ -169,6 +174,47 @@
             };
 
             firefly.showPlot('plotly', {chartId: 'plotly-tbl', chartType: 'plot.ly', data: [trace1], fireflyData: [{dataType: 'fireflyScatter'}]});
+
+
+            var tblReqLg =  firefly.util.table.makeIrsaCatalogRequest('allwise_p3as_psd', 'WISE', 'allwise_p3as_psd',
+                    {   position: '10.68479;41.26906;EQ_J2000',
+                        SearchMethod: 'Cone',
+                        radius: 1200
+                    },
+                    {tbl_id: 'test-tbl-lg'});
+            firefly.showTable('table-lg', tblReqLg);
+
+            var dataHM = [
+                {
+                    type: 'heatmap',
+                    name: 'w1-w2',
+                    x: "tables::test-tbl-lg,w1mpro",
+                    y: "tables::test-tbl-lg,w2mpro",
+                    colorscale: 'Blues'
+                },
+                {
+                    type: 'heatmap',
+                    name: 'w1-w3',
+                    x: "tables::test-tbl-lg,w1mpro",
+                    y: "tables::test-tbl-lg,w3mpro",
+                    colorscale: 'Reds',
+                    reversescale: true
+                },
+                {
+                    type: 'heatmap',
+                    name: 'w1-w4',
+                    x: "tables::test-tbl-lg,w1mpro",
+                    y: "tables::test-tbl-lg,w4mpro",
+                    colorscale: 'Greens'
+                }
+            ];
+            var	fireflyDataHM = [
+                {dataType: 'fireflyHeatmap'},
+                {dataType: 'fireflyHeatmap'},
+                {dataType: 'fireflyHeatmap'}
+            ];
+
+            firefly.showPlot('heatmapHere', {chartId: 'plotly-tbl-lg', chartType: 'plot.ly', data: dataHM, fireflyData: fireflyDataHM});
 
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/DecimateInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/DecimateInfo.java
@@ -26,6 +26,8 @@ public class DecimateInfo implements Serializable, Comparable {
     private double yMin = Double.NaN;
     private double yMax = Double.NaN;
 
+    private int deciEnableSize = -1;
+
     public DecimateInfo() {
     }
 
@@ -104,6 +106,10 @@ public class DecimateInfo implements Serializable, Comparable {
         this.yMax = yMax;
     }
 
+    public int getDeciEnableSize() { return this.deciEnableSize; }
+
+    public void setDeciEnableSize(int deciEnableSize) { this.deciEnableSize = deciEnableSize; }
+
     public boolean isValid() {
         return !StringUtils.isEmpty(xColumnName) && !StringUtils.isEmpty(yColumnName);
     }
@@ -137,6 +143,9 @@ public class DecimateInfo implements Serializable, Comparable {
             if (values.length > 7 && !StringUtils.isEmpty(values[7])) {
                 dinfo.setYMax(StringUtils.getDouble(values[7]));
             }
+            if (values.length > 8 && !StringUtils.isEmpty(values[8])) {
+                dinfo.setDeciEnableSize(StringUtils.getInt(values[8], -1));
+            }
 
             return dinfo.isValid() ? dinfo : null;
         }
@@ -152,6 +161,7 @@ public class DecimateInfo implements Serializable, Comparable {
         s += "," + (Double.isNaN(xMax) ? "" : xMax);
         s += "," + (Double.isNaN(yMin) ? "" : yMin);
         s += "," + (Double.isNaN(yMax) ? "" : yMax);
+        s += "," + (deciEnableSize > -1 ? "" : deciEnableSize);
         return s;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -638,7 +638,8 @@ public class QueryUtil {
 
         int maxPoints = decimateInfo.getMaxPoints() == 0 ? DECI_DEF_MAX_POINTS : decimateInfo.getMaxPoints();
 
-        boolean doDecimation = dg.size() >= DECI_ENABLE_SIZE;
+        int deciEnableSize = decimateInfo.getDeciEnableSize() > -1 ? decimateInfo.getDeciEnableSize() : DECI_ENABLE_SIZE;
+        boolean doDecimation = dg.size() >= deciEnableSize;
 
         DataType[] columns = new DataType[doDecimation ? 5 : 3];
         Class xColClass = Double.class;
@@ -739,7 +740,7 @@ public class QueryUtil {
                 if (yDeciMax < yMax) { yMax = yDeciMax; checkLimits = true; }
             }
 
-            if (outRows < DECI_ENABLE_SIZE) {
+            if (outRows < deciEnableSize) {
                 // no decimation needed
                 // because the number of rows in the output
                 // is less than decimation limit

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -575,9 +575,6 @@ export function getNewTraceDefaults(type='', traceNum=0) {
         };
     } else if (type.includes(HEATMAP)) {
         return {
-            [`data.${traceNum}.colorbar.thickness`]: 10,
-            [`data.${traceNum}.colorbar.outlinewidth`]: 0,
-            [`data.${traceNum}.colorbar.title`]: 'pts',
             [`data.${traceNum}.showlegend`]: true,
             ['layout.xaxis.range']: undefined, //clear out fixed range
             ['layout.yaxis.range']: undefined //clear out fixed range

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -19,6 +19,7 @@ import {Expression} from '../util/expr/Expression.js';
 import {logError, flattenObject} from '../util/WebUtil.js';
 import {UI_PREFIX} from './ChartsCntlr.js';
 import {ScatterOptions} from './ui/options/ScatterOptions.jsx';
+import {HeatmapOptions} from './ui/options/HeatmapOptions.jsx';
 import {FireflyHistogramOptions} from './ui/options/FireflyHistogramOptions.jsx';
 import {HistogramOptions} from './ui/options/PlotlyHistogramOptions.jsx';
 import {BasicOptions} from './ui/options/BasicOptions.jsx';
@@ -26,8 +27,10 @@ import {ScatterToolbar, BasicToolbar} from './ui/PlotlyToolbar';
 import {SelectInfo} from '../tables/SelectInfo.js';
 import {getTraceTSEntries as scatterTSGetter} from './dataTypes/FireflyScatter.js';
 import {getTraceTSEntries as histogramTSGetter} from './dataTypes/FireflyHistogram.js';
+import {getTraceTSEntries as heatmapTSGetter} from './dataTypes/FireflyHeatmap.js';
 
 export const SCATTER = 'scatter';
+export const HEATMAP = 'heatmap';
 export const HISTOGRAM = 'histogram';
 
 export const SELECTED_COLOR = '#ffc800';
@@ -272,6 +275,7 @@ export function getRowIdx(traceData, pointIdx) {
  */
 export function getPointIdx(traceData, rowIdx) {
     const rowIdxArray = get(traceData, 'firefly.rowIdx');
+    // use double equal in case we compare string to Number
     return rowIdxArray ? rowIdxArray.findIndex((e) => e == rowIdx) : rowIdx;
 }
 
@@ -286,13 +290,15 @@ export function getOptionsUI(chartId) {
         return HistogramOptions;
     } else if (dataType === 'fireflyHistogram') {
             return FireflyHistogramOptions;
+    } else if (dataType === 'fireflyHeatmap') {
+            return HeatmapOptions;
     } else {
         return BasicOptions;
     }
 }
 
 export function getToolbarUI(chartId, activeTrace=0) {
-    const {data, fireflyData} =  getChartData(chartId);
+    const {data} =  getChartData(chartId);
     const type = get(data, [activeTrace, 'type'], '');
     if (type.includes('scatter')) {
         return ScatterToolbar;
@@ -501,6 +507,8 @@ function getTraceTSEntries({chartDataType, traceTS, chartId, traceNum}) {
         return scatterTSGetter({traceTS, chartId, traceNum});
     } else if (chartDataType === 'fireflyHistogram') {
             return histogramTSGetter({traceTS, chartId, traceNum});
+    } else if (chartDataType === 'fireflyHeatmap') {
+                return heatmapTSGetter({traceTS, chartId, traceNum});
     } else {
         return {};
     }
@@ -558,12 +566,21 @@ const TRACE_COLORS = [  '#333333', '#ff3333', '#00ccff','#336600',
 export function getNewTraceDefaults(type='', traceNum=0) {
     if (type.includes(SCATTER)) {
         return {
-            [`data.${traceNum}.type`] : type, //make sure trace type is set
+            [`data.${traceNum}.type`]: type, //make sure trace type is set
             [`data.${traceNum}.marker.color`]: TRACE_COLORS[traceNum] || undefined,
             [`data.${traceNum}.marker.line`]: 'none',
             [`data.${traceNum}.showlegend`]: true,
-            ['layout.xaxis.range'] : undefined, //clear out fixed range
-            ['layout.yaxis.range'] : undefined, //clear out fixed range
+            ['layout.xaxis.range']: undefined, //clear out fixed range
+            ['layout.yaxis.range']: undefined //clear out fixed range
+        };
+    } else if (type.includes(HEATMAP)) {
+        return {
+            [`data.${traceNum}.colorbar.thickness`]: 10,
+            [`data.${traceNum}.colorbar.outlinewidth`]: 0,
+            [`data.${traceNum}.colorbar.title`]: 'pts',
+            [`data.${traceNum}.showlegend`]: true,
+            ['layout.xaxis.range']: undefined, //clear out fixed range
+            ['layout.yaxis.range']: undefined //clear out fixed range
         };
     } else {
         return {

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -438,7 +438,7 @@ function setActiveTrace(action) {
             const {selectInfo, highlightedRow} = getTblById(tbl_id) || {};
             if (selectInfo) {
                 const selectInfoCls = SelectInfo.newInstance(selectInfo);
-                const selIndexes = Array.from(selectInfoCls.getSelected()).map((e)=>getPointIdx(data[activeTrace], e));;
+                const selIndexes = Array.from(selectInfoCls.getSelected()).map((e)=>getPointIdx(data[activeTrace], e));
                 if (selIndexes.length > 0) {
                     selected = newTraceFrom(data[activeTrace], selIndexes, SELECTED_PROPS);
                 }

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -1,0 +1,185 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {get, isUndefined} from 'lodash';
+import {getTblById, getColumn, cloneRequest, doFetchTable, MAX_ROW} from '../../tables/TableUtil.js';
+import {dispatchChartUpdate, dispatchChartHighlighted, getChartData} from '../ChartsCntlr.js';
+import {getPointIdx, updateSelected} from '../ChartUtil.js';
+import {serializeDecimateInfo, parseDecimateKey} from '../../tables/Decimate.js';
+
+/**
+ * This function creates table source entries to get firefly scatter and error data from the server
+ * (The search processor knows how to handle expressions and eliminates null x or y)
+ *
+ * @param p
+ * @param p.traceTS
+ * @param p.chartId
+ * @param p.traceNum
+ */
+export function getTraceTSEntries({traceTS, chartId, traceNum}) {
+    const {mappings} = traceTS;
+    const {fireflyData, fireflyLayout} = getChartData(chartId) || {};
+    // server call parameters
+    const xbins = get(fireflyData, `${traceNum}.nbins.x`);
+    const ybins = get(fireflyData, `${traceNum}.nbins.y`);
+    let maxbins = 10000;
+    let xyratio = get(fireflyLayout, 'xyratio', 1.0);
+    if (xbins && ybins) {
+        maxbins = xbins * ybins;
+        xyratio = xbins/ybins;
+    }
+
+    //TODO: take into account zoom? and boundaries
+    const {xmin, xmax, ymin, ymax} = {};
+
+    const options = {
+        xColOrExpr: get(mappings, 'x'),
+        yColOrExpr: get(mappings, 'y'),
+        maxbins, xyratio, xmin, xmax, ymin, ymax
+    };
+
+    return {options, fetchData};
+}
+
+function fetchData(chartId, traceNum, tablesource) {
+
+    const {tbl_id, options, mappings} = tablesource;
+    const tableModel = getTblById(tbl_id);
+    const {request, highlightedRow, selectInfo} = tableModel;
+
+    const {xColOrExpr, yColOrExpr, maxbins, xyratio, xmin, xmax, ymin, ymax} = options;
+    // min rows for decimation is 0
+    const req = cloneRequest(request, {startIdx: 0, pageSize: MAX_ROW,
+        'decimate' : serializeDecimateInfo(xColOrExpr, yColOrExpr, maxbins, xyratio, xmin, xmax, ymin, ymax, 0)});
+
+    doFetchTable(req).then((tableModel) => {
+        if (tableModel.tableData && tableModel.tableData.data) {
+
+            const changes = getChanges({tableModel, mappings, chartId, traceNum});
+            dispatchChartUpdate({chartId, changes});
+
+            // TODO: what should happen on table highlight or cell click?
+        }
+    }).catch(
+        (reason) => {
+            console.error(`Failed to fetch heatmap data for ${chartId} trace ${traceNum}: ${reason}`);
+        }
+    );
+}
+
+function getChanges({tableModel, mappings, chartId, traceNum}) {
+
+    const {tableMeta} = tableModel;
+    const decimateKey = tableMeta['decimate_key'];
+
+    if (!decimateKey) {
+        // ERROR - table is not decimated
+        console.error(`Failed to get heatmap data for ${chartId} trace ${traceNum}: decimateKey not found in returned data`);
+        return {};
+    }
+
+    const xLabel = get(mappings, 'x'); // default axis label for the first trace
+    const yLabel = get(mappings, 'y'); // default axis label for the first trace
+    const xTipLabel = xLabel.length > 20 ? 'x' : xLabel;
+    const yTipLabel = yLabel.length > 20 ? 'y' : yLabel;
+
+    const xColumn = getColumn(tableModel, get(mappings, 'x'));
+    const xUnit = get(xColumn, 'units', '');
+    const yColumn = getColumn(tableModel, get(mappings, 'y'));
+    const yUnit = get(yColumn, 'units', '');
+
+    const {xMin:x0, xUnit:dx, nX, yMin:y0, yUnit:dy, nY} = parseDecimateKey(decimateKey);
+
+    // function to get center point of the bin
+    const getCenter = (xval,yval) => {
+        return {
+            // bitwise operators convert operands to 32-bit integer
+            // hence they can be used as a fast way to truncate a float to an integer
+            x: x0+(~~((xval-x0)/dx)+0.5)*dx,
+            y: y0+(~~((yval-y0)/dy)+0.5)*dy
+        };
+    };
+
+    const x = [];
+    const y = [];
+    const z = [];
+    const text = []; // tooltips
+    const toRowIdx = new Map(); // maps decimate key (bin identifier in the form 'x:y') to rowIdx
+
+    tableModel.tableData.data.forEach((r) => {
+        // colNames = ['x', 'y', 'rowIdx', 'weight', 'decimate_key'];
+        const [xval, yval, rowIdx, weight, decimateKey] = r;
+        const centerPt = getCenter(xval, yval);
+        x.push(centerPt.x);
+        y.push(centerPt.y);
+        z.push(weight);
+        text.push(`<span> ${xTipLabel} = ${xval} ${xUnit} <br>` +
+                    ` ${yTipLabel} = ${yval} ${yUnit} <br>` +
+                    ` represents ${weight} points</span>`);
+        toRowIdx.set(decimateKey, rowIdx);
+    });
+
+    //to avoid showing variable cell heatmap,
+    //make sure the x and y values are populated for the empty bins
+    for (let i=0; i<nX; i++ ) {
+        for (let j = 0; j < nY; j++) {
+            if (!toRowIdx.has(`${i}:${j}`)) {
+                x.push(x0+(i+0.5)*dx);
+                y.push(y0+(j+0.5)*dy);
+                z.push(null); // if undefined, downloadImage might show heatmap with variable bins
+            }
+        }
+    }
+
+    const changes = {
+        // it's not clear how to provide the tooltips
+        // if alternative coordinate space is used
+        //[`data.${traceNum}.x0`]: x0,
+        //[`data.${traceNum}.y0`]: y0,
+        //[`data.${traceNum}.dx`]: dx,
+        //[`data.${traceNum}.dy`]: dy,
+        [`data.${traceNum}.x`]: x,
+        [`data.${traceNum}.y`]: y,
+        [`data.${traceNum}.z`]: z,
+        [`data.${traceNum}.text`]: text,
+        [`data.${traceNum}.hoverinfo`]: 'text',
+        [`fireflyData.${traceNum}.toRowIdx`]: toRowIdx
+    };
+
+    const {layout, data} = getChartData(chartId) || {};
+
+    if (data && data.length===1) {
+        // set default title if it's the first trace
+        // and no title is set by the user
+        const xAxisLabel = get(layout, 'xaxis.title');
+        if (!xAxisLabel) {
+            changes['layout.xaxis.title'] = xLabel + (xUnit ? ` (${xUnit})` : '');
+        }
+        const yAxisLabel = get(layout, 'yaxis.title');
+        if (!yAxisLabel) {
+            changes['layout.yaxis.title'] = yLabel + (yUnit ? ` (${yUnit})` : '');
+        }
+    }
+
+    // color bar
+    if (!get(data, `${traceNum}.colorbar`)) {
+        changes[`data.${traceNum}.colorbar.thickness`] = 10;
+        changes[`data.${traceNum}.colorbar.outlinewidth`] = 0;
+        changes[`data.${traceNum}.colorbar.title`] = 'pts'; //`(${traceNum})`;
+    }
+
+    if (!get(data, `${traceNum}.colorbar.x`)) {
+        const yside = get(layout, 'yaxis.side');
+        const yOpposite = (yside === 'right');
+        const colorBarIdx = data.filter((d) => get(d, 'colorbar') && get(d, 'showscale', true)).length;
+        addColorbarChanges(changes, yOpposite, traceNum, colorBarIdx);
+    }
+
+    return changes;
+}
+
+export function addColorbarChanges(changes, yOpposite, traceNum, idx) {
+    const f = 0.08; // colorbar shift in plot fractions
+    changes[`data.${traceNum}.colorbar.xanchor`] = yOpposite ? 'right' : 'left';
+    changes[`data.${traceNum}.colorbar.x`]  = yOpposite ? -0.02-idx*f : (1.02+idx*f);
+}

--- a/src/firefly/js/charts/dataTypes/FireflyScatter.js
+++ b/src/firefly/js/charts/dataTypes/FireflyScatter.js
@@ -120,8 +120,8 @@ function addOtherChanges({changes, xLabel, xTipLabel, xUnit, yLabel, yTipLabel, 
 
     // set default title if it's the first trace
     // and no title is set by the user
-    if (traceNum === 0) {
-        const {layout} = getChartData(chartId) || {};
+    const {layout, data} = getChartData(chartId) || {};
+    if (data && data.length===1) {
         const xAxisLabel = get(layout, 'xaxis.title');
         if (!xAxisLabel) {
             changes['layout.xaxis.title'] = xLabel + (xUnit ? ` (${xUnit})` : '');

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -62,7 +62,7 @@ export class PlotlyChartArea extends PureComponent {
             doingResize = true;
         }
         const showlegend = data.length > 1;
-        let pdata = [].concat(data);
+        let pdata = data.map((e) => Object.assign({}, e)); // create shallow copy of data elements to avoid sharing x,y,z arrays
         if (!data[activeTrace] || get(data[activeTrace], 'type', '').includes('scatter')) {
             // highlight makes sense only for scatter at the moment
             pdata = selected ? pdata.concat([selected]) : pdata;

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -54,11 +54,18 @@ export class BasicToolbar extends SimpleComponent {
     render() {
         const {chartId, expandable, toggleOptions} = this.props;
         //const {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected, dragmode} = this.state;
-        const {activeTrace, tbl_id, dragmode} = this.state;
+        const {activeTrace, hasFilter, hasSelection, tbl_id, dragmode} = this.state;
+
+        const showSelectionPart = get(getChartData(chartId), `data.${activeTrace}.type`, '').includes('heatmap');
+
         return (
             <div className='ChartToolbar'>
                 <ActiveTraceSelect style={{marginRight: 20}} {...{chartId, activeTrace}}/>
                 <DragModePart {...{chartId, tbl_id, dragmode}}/>
+                {showSelectionPart && <div className='ChartToolbar__buttons' style={{margin: '0 5px'}}>
+                    {hasFilter    && <ClearFilter {...{tbl_id}} />}
+                    {hasSelection && <FilterSelection {...{chartId}} />}
+                </div>}
                 <div className='ChartToolbar__buttons'>
                     <ResetZoomBtn style={{marginLeft: 10}} {...{chartId}} />
                     <SaveBtn {...{chartId}} />

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -258,7 +258,7 @@ const now = Date.now();
                         break;
                 }
                 set(getChartData(chartId), 'lastUpdated', Date.now());
-isDebug() && console.log(`${renderType.toString()} elapsed: ${Date.now() - now}`);
+isDebug() && console.log(`${renderType.toString()} ${dataUpdateTraces} elapsed: ${Date.now() - now}`);
             }
         } ).catch( (e) => {
             console.log('Plotly not loaded',e);

--- a/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
+++ b/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
@@ -4,15 +4,16 @@ import {get, isUndefined} from 'lodash';
 import {getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 
+import {toBoolean} from '../../../util/WebUtil.js';
 import {intValidator} from '../../../util/Validate.js';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {ListBoxInputField} from '../../../ui/ListBoxInputField.jsx';
 import {CheckboxGroupInputField} from '../../../ui/CheckboxGroupInputField.jsx';
 import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
 import {BasicOptionFields, OptionTopBar, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
-import {addColorbarChanges} from '../../dataTypes/FireflyHeatmap.js';
 import {getColValStats} from '../../TableStatsCntlr.js';
 import {ColumnOrExpression} from '../ColumnOrExpression.jsx';
+
 
 
 const fieldProps = {labelWidth: 62, size: 15};
@@ -41,7 +42,7 @@ export class HeatmapOptions extends SimpleComponent {
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({chartId, activeTrace})}>
                     {tablesource && <TableSourcesOptions {...{tablesource, activeTrace, groupKey}}/>}
                     <br/>
-                    <BasicOptionFields {...{activeTrace, groupKey}}/>
+                    <BasicOptionFields {...{activeTrace, groupKey, noColor: true}}/>
                 </FieldGroup>
             </div>
         );
@@ -158,7 +159,7 @@ export function submitChangesHeatmap({chartId, activeTrace, fields, tbl_id}) {
     Object.assign(changes, fields);
 
     // reversescale is boolean
-    changes[`data.${activeTrace}.reversescale`] = get(fields, `data.${activeTrace}.reversescale`, '').includes('true');
+    changes[`data.${activeTrace}.reversescale`] = toBoolean(get(fields, `data.${activeTrace}.reversescale`));
 
     submitChanges({chartId, fields: changes, tbl_id});
 }

--- a/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
+++ b/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import {get, isUndefined} from 'lodash';
+
+import {getChartData} from '../../ChartsCntlr.js';
+import {FieldGroup} from '../../../ui/FieldGroup.jsx';
+
+import {intValidator} from '../../../util/Validate.js';
+import {ValidationField} from '../../../ui/ValidationField.jsx';
+import {ListBoxInputField} from '../../../ui/ListBoxInputField.jsx';
+import {CheckboxGroupInputField} from '../../../ui/CheckboxGroupInputField.jsx';
+import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
+import {BasicOptionFields, OptionTopBar, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
+import {addColorbarChanges} from '../../dataTypes/FireflyHeatmap.js';
+import {getColValStats} from '../../TableStatsCntlr.js';
+import {ColumnOrExpression} from '../ColumnOrExpression.jsx';
+
+
+const fieldProps = {labelWidth: 62, size: 15};
+
+export class HeatmapOptions extends SimpleComponent {
+
+    getNextState() {
+        const {chartId} = this.props;
+        const {activeTrace:cActiveTrace} = getChartData(chartId);
+        // activeTrace is passed via property, when used from NewTracePanel
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
+        return {activeTrace};
+    }
+
+    render() {
+        const {chartId} = this.props;
+        const {tablesources, activeTrace:cActiveTrace=0} = getChartData(chartId);
+        const activeTrace = isUndefined(this.props.activeTrace) ? cActiveTrace : this.props.activeTrace;
+        const groupKey = this.props.groupKey || `${chartId}-heatmap-${activeTrace}`;
+        const tablesource = get(tablesources, [cActiveTrace]);
+        const tbl_id = get(tablesource, 'tbl_id');
+
+        return (
+            <div style={{padding:'0 5px 7px'}}>
+                {isUndefined(this.props.activeTrace) && <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id, submitChangesFunc: submitChangesHeatmap}}/>}
+                <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({chartId, activeTrace})}>
+                    {tablesource && <TableSourcesOptions {...{tablesource, activeTrace, groupKey}}/>}
+                    <br/>
+                    <BasicOptionFields {...{activeTrace, groupKey}}/>
+                </FieldGroup>
+            </div>
+        );
+    }
+}
+
+export function fieldReducer({chartId, activeTrace}) {
+    const {data, fireflyData, tablesources={}} = getChartData(chartId);
+    const tablesourceMappings = get(tablesources[activeTrace], 'mappings');
+    const basicReducer = basicFieldReducer({chartId, activeTrace, tablesources});
+    const fields = {
+
+        [`fireflyData.${activeTrace}.nbins.x`]: {
+            fieldKey: `fireflyData.${activeTrace}.nbins.x`,
+            value: get(fireflyData, `${activeTrace}.nbins.x`),
+            validator: intValidator(2, 300, 'Number of X-Bins'), // need at least 2 bins to display dx correctly
+            tooltip: 'Number of bins along X axis',
+            label: 'Number of X-Bins:',
+            labelWidth: 95,
+            size: 5
+        },
+        [`fireflyData.${activeTrace}.nbins.y`]: {
+            fieldKey: `fireflyData.${activeTrace}.nbins.y`,
+            value: get(fireflyData, `${activeTrace}.nbins.y`),
+            validator: intValidator(2, 300, 'Number of Y-Bins'), // need at least 2 bins to display dy correctly
+            tooltip: 'Number of bins along Y axis',
+            label: 'Number of Y-Bins:',
+            labelWidth: 95,
+            size: 5
+        },
+        [`data.${activeTrace}.colorscale`]: {
+            fieldKey: `data.${activeTrace}.colorscale`,
+            value: get(data, `${activeTrace}.colorscale`),
+            tooltip: 'Select colorscale for color map',
+            label: 'Color Scale:',
+            ...fieldProps
+        },
+        [`data.${activeTrace}.reversescale`]: {
+            fieldKey: `data.${activeTrace}.reversescale`,
+            value: String(get(data, `${activeTrace}.reversescale`, '')),
+            tooltip: 'Reverse colorscale for color map',
+            label: ' ',
+            labelWidth: 10
+        },
+        ...basicReducer(null)
+    };
+    const tblRelFields = {
+        [`_tables.data.${activeTrace}.x`]: {
+            fieldKey: `_tables.data.${activeTrace}.x`,
+            value: get(tablesourceMappings, 'x', ''),
+            //tooltip: 'X axis',
+            label: 'X:',
+            ...fieldProps
+        },
+        [`_tables.data.${activeTrace}.y`]: {
+            fieldKey: `_tables.data.${activeTrace}.y`,
+            value: get(tablesourceMappings, 'y', ''),
+            //tooltip: 'Y axis',
+            label: 'Y:',
+            ...fieldProps
+        }
+    };
+    return (inFields, action) => {
+        if (!inFields) {
+            return tablesourceMappings? Object.assign({}, fields, tblRelFields) : fields;
+        }
+
+        inFields = basicReducer(inFields, action);
+        return inFields;
+
+    };
+}
+
+export function TableSourcesOptions({tablesource={}, activeTrace, groupKey}) {
+    // _tables.  is prefixed the fieldKey.  it will be replaced with 'tables::tbl_id,val' on submitChanges.
+    const tbl_id = get(tablesource, 'tbl_id');
+    const colValStats = getColValStats(tbl_id);
+    const labelWidth = 30;
+    const xProps = {fldPath:`_tables.data.${activeTrace}.x`, label: 'X:', name: 'X', nullAllowed: false, colValStats, groupKey, labelWidth};
+    const yProps = {fldPath:`_tables.data.${activeTrace}.y`, label: 'Y:', name: 'Y', nullAllowed: false, colValStats, groupKey, labelWidth};
+
+    return (
+        <div className='FieldGroup__vertical'>
+            <br/>
+            <ColumnOrExpression {...xProps}/>
+            <ColumnOrExpression {...yProps}/>
+            <div style={{whiteSpace: 'nowrap'}}>
+                <ListBoxInputField fieldKey={`data.${activeTrace}.colorscale`}
+                                   inline={true}
+                                   options={[{label:'Default', value:undefined}, {value:'Bluered'}, {value:'Blues'}, {value:'Earth'}, {value:'Electric'}, {value:'Greens'},
+                                         {value:'Greys'}, {value:'Hot'}, {value:'Jet'}, {value:'Picnic'}, {value:'Portland'}, {value:'Rainbow'},
+                                         {value:'RdBu'}, {value:'Reds'}, {value:'Viridis'}, {value:'YlGnBu'}, {value:'YlOrRd'}]}/>
+                <CheckboxGroupInputField
+                    fieldKey={`data.${activeTrace}.reversescale`}
+                    wrapperStyle={{display: 'inline-block'}}
+                    options={[
+                            {label: 'reverse', value: 'true'}
+                        ]}
+                />
+            </div>
+            <ValidationField fieldKey={`fireflyData.${activeTrace}.nbins.x`}/>
+            <ValidationField fieldKey={`fireflyData.${activeTrace}.nbins.y`}/>
+        </div>
+    );
+}
+
+export function submitChangesHeatmap({chartId, activeTrace, fields, tbl_id}) {
+    const dataType = (!tbl_id) ? 'heatmap' : 'fireflyHeatmap';
+    const changes = {
+        [`fireflyData.${activeTrace}.type`] : 'heatmap',
+        [`fireflyData.${activeTrace}.dataType`] : dataType
+    };
+
+    Object.assign(changes, fields);
+
+    // reversescale is boolean
+    changes[`data.${activeTrace}.reversescale`] = get(fields, `data.${activeTrace}.reversescale`, '').includes('true');
+
+    submitChanges({chartId, fields: changes, tbl_id});
+}
+

--- a/src/firefly/js/charts/ui/options/NewTracePanel.jsx
+++ b/src/firefly/js/charts/ui/options/NewTracePanel.jsx
@@ -12,17 +12,21 @@ import {PopupPanel} from '../../../ui/PopupPanel.jsx';
 import {getFieldVal} from '../../../fieldGroup/FieldGroupUtils.js';
 import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
 import {ScatterOptions, submitChangesScatter} from './ScatterOptions.jsx';
+import {HeatmapOptions, submitChangesHeatmap} from './HeatmapOptions.jsx';
 import {HistogramOptions} from './PlotlyHistogramOptions.jsx';
 import {FireflyHistogramOptions, submitChangesFFHistogram} from './FireflyHistogramOptions.jsx';
 import {BasicOptionFields, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
 
 const fieldProps = {labelWidth: 62, size: 15};
+const dialogNameNewTrace = 'NewTracePanel';
 
 function getSubmitChangesFunc(traceType) {
     switch(traceType) {
         case 'scatter':
         case 'scattergl':
             return submitChangesScatter;
+        case 'heatmap':
+            return submitChangesHeatmap;
         case 'fireflyHistogram':
             return submitChangesFFHistogram;
         default:
@@ -35,6 +39,8 @@ function getOptionsComponent({traceType, chartId, activeTrace, groupKey}) {
         case 'scatter':
         case 'scattergl':
             return (<ScatterOptions {...{chartId, activeTrace, groupKey}}/>);
+        case 'heatmap':
+            return (<HeatmapOptions {...{chartId, activeTrace, groupKey}}/>);
         case 'fireflyHistogram':
             return (<FireflyHistogramOptions {...{chartId, activeTrace, groupKey}}/>);
         case 'histogram':
@@ -58,8 +64,6 @@ export class NewTracePanel extends SimpleComponent {
         const activeTrace = data.length;        //setting activeTrace to next available index.
         const type = getFieldVal('new-trace', 'type') || 'scatter';
         const groupKey = `${chartId}-new-trace-${type}`;
-        //const groupKey = `${chartId}-new-trace-${activeTrace}`;
-        //const type = getFieldVal(groupKey, `data.${activeTrace}.type`) || 'scatter';
         return {groupKey, activeTrace, type};
     }
 
@@ -71,21 +75,28 @@ export class NewTracePanel extends SimpleComponent {
             const submitChangesFunc =  getSubmitChangesFunc(traceType);
 
             fields = Object.assign({activeTrace}, fields);  // make the newly added trace active
-            fields[`data.${activeTrace}.type`] = type; //make sure trace type is set
+            fields[`data.${activeTrace}.type`] = type; // make sure trace type is set
 
             // apply defaults settings
             Object.entries(getNewTraceDefaults(type, activeTrace))
                     .forEach(([k,v]) => !fields[k] && (fields[k] = v));
             
             // need to hide before the changes are submitted to avoid React Internal error too much recursion (mounting/unmouting fields)
-            dispatchHideDialog('ScatterNewTracePanel');
+            dispatchHideDialog(dialogNameNewTrace);
             submitChangesFunc({chartId, activeTrace, fields, tbl_id});
         };
 
         return (
             <div style={{padding: 10}}>
                 <FieldGroup className='FieldGroup__vertical' style={{padding: 5}} keepState={true} groupKey='new-trace'>
-                    <ListBoxInputField fieldKey='type' tooltip='Select plot type' label='Plot Type:' options={[{value:'scatter'}, {value:'fireflyHistogram'}, {value:'histogram'}]} {...fieldProps} />
+                    <ListBoxInputField fieldKey='type' tooltip='Select plot type' label='Plot Type:'
+                        options={[
+                            {label: 'Scatter', value: 'scatter'},
+                            {label: 'Heatmap', value: 'heatmap'},
+                            {label: 'Firefly histogram', value: 'fireflyHistogram'},
+                            {label: 'Plotly histogram', value: 'histogram'}
+                        ]}
+                        {...fieldProps} />
                 </FieldGroup>
                 <br/>
                 {getOptionsComponent({traceType:type, chartId, activeTrace, groupKey})}
@@ -96,7 +107,7 @@ export class NewTracePanel extends SimpleComponent {
                                     text='ADD'
                     />
                     <button type='button' className='button std'
-                            onClick={() => dispatchHideDialog('ScatterNewTracePanel')}>Cancel
+                            onClick={() => dispatchHideDialog(dialogNameNewTrace)}>Cancel
                     </button>
                 </div>
             </div>
@@ -111,8 +122,8 @@ export function NewTracePanelBtn({tbl_id, chartId}) {
                 <NewTracePanel {...{tbl_id, chartId}}/>
             </PopupPanel>
         );
-        DialogRootContainer.defineDialog('ScatterNewTracePanel', content);
-        dispatchShowDialog('ScatterNewTracePanel');
+        DialogRootContainer.defineDialog(dialogNameNewTrace, content);
+        dispatchShowDialog(dialogNameNewTrace);
     }
     return (
         <button type='button' className='button std' onClick={showNewTracePanel}>Add Series</button>

--- a/src/firefly/js/charts/ui/options/NewTracePanel.jsx
+++ b/src/firefly/js/charts/ui/options/NewTracePanel.jsx
@@ -15,7 +15,7 @@ import {ScatterOptions, submitChangesScatter} from './ScatterOptions.jsx';
 import {HeatmapOptions, submitChangesHeatmap} from './HeatmapOptions.jsx';
 import {HistogramOptions} from './PlotlyHistogramOptions.jsx';
 import {FireflyHistogramOptions, submitChangesFFHistogram} from './FireflyHistogramOptions.jsx';
-import {BasicOptionFields, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
+import {BasicOptionFields, basicFieldReducer, submitChanges, hasMarkerColor} from './BasicOptions.jsx';
 
 const fieldProps = {labelWidth: 62, size: 15};
 const dialogNameNewTrace = 'NewTracePanel';
@@ -35,6 +35,7 @@ function getSubmitChangesFunc(traceType) {
 }
 
 function getOptionsComponent({traceType, chartId, activeTrace, groupKey}) {
+    const noColor = !hasMarkerColor(traceType);
     switch(traceType) {
         case 'scatter':
         case 'scattergl':
@@ -50,7 +51,7 @@ function getOptionsComponent({traceType, chartId, activeTrace, groupKey}) {
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey} reducerFunc={fieldReducer({chartId, activeTrace})}>
                     <ValidationField fieldKey={`_tables.data.${activeTrace}.x`}/>
                     <ValidationField fieldKey={`_tables.data.${activeTrace}.y`}/>
-                    <BasicOptionFields {...{activeTrace, groupKey}}/>
+                    <BasicOptionFields {...{activeTrace, groupKey, noColor}}/>
                 </FieldGroup>
             );
     }

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -6,7 +6,6 @@ import {getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 import {VALUE_CHANGE} from '../../../fieldGroup/FieldGroupCntlr.js';
 
-//import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {ListBoxInputField} from '../../../ui/ListBoxInputField.jsx';
 import {BasicOptionFields, OptionTopBar, basicFieldReducer, submitChanges} from './BasicOptions.jsx';
 import {updateSet} from '../../../util/WebUtil.js';

--- a/src/firefly/js/tables/Decimate.js
+++ b/src/firefly/js/tables/Decimate.js
@@ -22,10 +22,11 @@ const DECIMATE_TAG='decimate';
  * @param {number} optional max x limit
  * @param {number} optional min y limit
  * @param {number} optional max y limit
+ * @param {number} optional minimum number of points to enable decimation
  * @returns {string}
  */
-export const serializeDecimateInfo = function(xColumnName, yColumnName, maxPoints=10000, xyRatio=1, xMin, xMax, yMin, yMax) {
-    const orderedNumericProps = [maxPoints, xyRatio, xMin, xMax, yMin, yMax];
+export const serializeDecimateInfo = function(xColumnName, yColumnName, maxPoints=10000, xyRatio=1, xMin, xMax, yMin, yMax, deciEnableLimit=Number.NaN) {
+    const orderedNumericProps = [maxPoints, xyRatio, xMin, xMax, yMin, yMax, deciEnableLimit];
     const deciStrStart = `${DECIMATE_TAG}=${xColumnName},${yColumnName}`;
     return orderedNumericProps.reduce((sres, val)=>{
         return sres + ',' + (Number.isFinite(val) ? val : '');
@@ -42,7 +43,7 @@ export const parseDecimateInfo = function(str) {
 
     const kv = str.split('=', 2);
     if (kv && kv.length === 2 && kv[0]===DECIMATE_TAG) {
-        const [xColumnName,yColumnName,maxPoints,xyRatio,xMin,xMax,yMin,yMax] = kv[1].split(',');
+        const [xColumnName,yColumnName,maxPoints,xyRatio,xMin,xMax,yMin,yMax,deciEnableLimit='-1'] = kv[1].split(',');
         if (xColumnName && yColumnName) {
             return {
                 xColumnName,
@@ -52,7 +53,8 @@ export const parseDecimateInfo = function(str) {
                 xMin: Number.parseFloat(xMin),
                 xMax: Number.parseFloat(xMax),
                 yMin: Number.parseFloat(yMin),
-                yMax: Number.parseFloat(yMax)
+                yMax: Number.parseFloat(yMax),
+                deciEnableLimit: Number.parseInt(deciEnableLimit)
             };
         }
     }
@@ -73,7 +75,7 @@ export const parseDecimateKey = function(str) {
     if (v.length < 3) return null;
     v = v.substring(1,v.length-1); // remove outer braces
     const parts = v.split(',');
-    if (parts.length == 8) {
+    if (parts.length === 8) {
         const xColNameOrExpr= parts[0];
         const yColNameOrExpr = parts[1];
         const xMin = Number(parts[2]);

--- a/src/firefly/js/ui/ListBoxInputField.jsx
+++ b/src/firefly/js/ui/ListBoxInputField.jsx
@@ -36,7 +36,7 @@ export function ListBoxInputFieldView({inline, value, onChange, fieldKey, option
                     const optLabel = option.label || option.value;
                     return (
                         <option value={option.value}
-                                key={option.value}
+                                key={option.value||0}
                                 style={{paddingLeft: 5, paddingRight: 3}}
                                 title={option.tooltip}
                                 disabled={option.disabled ? 'disabled' : false}>


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-10832

Added heatmap trace type to multitrace chart with options and server side connection.

Known limitations:
- The only way to recalculate  heatmap is to change table, filter from the plot, or change heatmap parameters. The map is not recalculated on zoom or when axis limits change
- Table highlight is not shown - it's not clear if we should support this connection
colorbar can overlap.
- It's not possible to set from UI which heatmap trace is on top. (Usually the last trace in the data array is the one on top.) We might need a separate ticket for placing active trace (of the same type) on top of the others.
- Colorbar can overlap with the legend, other colorbar ticks. It's not easy to position it perfectly in generic case, when multiple colorbars (and legend) are present, but it is possible to set its length and location in the data array, when you know what exactly will be present on the chart.