### PR TITLE
IRSA-595: set default axis format to exponential.

### DIFF
--- a/src/firefly/js/charts/ui/HistogramPlotly.jsx
+++ b/src/firefly/js/charts/ui/HistogramPlotly.jsx
@@ -170,8 +170,9 @@ export class HistogramPlotly extends Component {
                     side: get(xAxis, OPP) ? 'top' : 'bottom',
                     titlefont: {
                         size: FSIZE
-                    }
-                },
+                    },
+                     exponentformat:'e'
+                 },
                 yaxis: {
                     title: 'Number',
                     gridLineWidth: 1,
@@ -182,7 +183,8 @@ export class HistogramPlotly extends Component {
                     side: get(yAxis, OPP) ? 'right' : 'left',
                     titlefont: {
                         size: FSIZE
-                    }
+                    },
+                    exponentformat:'e'
                 },
                 margin: {
                     l: leftMargin,

--- a/src/firefly/js/charts/ui/XYPlotPlotly.jsx
+++ b/src/firefly/js/charts/ui/XYPlotPlotly.jsx
@@ -367,7 +367,8 @@ function getChartingInfo(props) {
             tickfont: {
                 size: FSIZE
             },
-            zeroline: false
+            zeroline: false,
+            exponentformat:'e'
         },
         yaxis: {
             autorange: false,
@@ -389,7 +390,9 @@ function getChartingInfo(props) {
             tickfont: {
                 size: FSIZE
             },
-            zeroline: false
+            zeroline: false,
+            exponentformat:'e'
+
         },
         margin: {
             l: yOpposite ? MIN_MARGIN_PX : Y_TICKLBL_PX,

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -345,7 +345,8 @@ class PhaseFoldingChart extends PureComponent {
                         },
                     tickfont: {
                         size: 12
-                    }
+                    },
+                    exponentformat:'e'
                 },
                 yaxis: {
                     title: `${flux} (mag)`,
@@ -357,7 +358,8 @@ class PhaseFoldingChart extends PureComponent {
                     autorange: 'reversed',
                     titlefont: {
                         size: 12
-                    }
+                    },
+                    exponentformat:'e'
                 },
                 margin: {
                     l: 50,


### PR DESCRIPTION
I've changed the default axis label format to be exponential instead of defualt k/M/B suffix notation.

To test:
Bring any plot and plot an axis either with high values or multiply by 1000 so you can see the difference. Before it was k/M/B format, now it should be raw or exponent notation. 