### PR TITLE
IRSA-611:Period value isn't display anymore in result view

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -24,7 +24,7 @@ import {LC, updateLayoutDisplay, getValidValueFrom, getFullRawTable} from './LcM
 import {doPFCalculate, getPhase} from './LcPhaseTable.js';
 import {LcPeriodogram, cancelPeriodogram, popupId} from './LcPeriodogram.jsx';
 import {ReadOnlyText, getTypeData} from './LcUtil.jsx';
-import {LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
+import {LO_VIEW, getLayouInfo,dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
 import {isDialogVisible, dispatchHideDialog} from '../../core/ComponentCntlr.js';
 import {updateSet} from '../../util/WebUtil.js';
 import {PlotlyWrapper} from '../../charts/ui/PlotlyWrapper.jsx';
@@ -959,6 +959,16 @@ function setPFTableSuccess() {
         const tzero = get(reqData, fKeyDef.tz.fkey);
 
         doPFCalculate(flux, timeName, period, tzero);
+
+        const min = get(reqData, fKeyDef.min.fkey,defPeriod.min );
+        const max = get(reqData, fKeyDef.max.fkey, defPeriod.max);
+        const tzeroMax = get(reqData, fKeyDef.tzmax.fkey.fkey, defPeriod.tzeroMax);
+
+        const layoutInfo = getLayouInfo();
+        dispatchUpdateLayoutInfo(Object.assign({}, layoutInfo, {
+
+            periodRange: {min, max, tzero, tzeroMax, period}
+        }));
 
         if (isDialogVisible(popupId)) {
             cancelPeriodogram();


### PR DESCRIPTION
  After using plotly, the period is no longer displayed.
  Thie reason is that  LcPeriodPlotly failed to save the period value to the store.

To test:
1. check out this branch and build firefly
2. There is no change in ife.  In ife, check out dev and build irsaviewer.
3. run localhost:8080/irsaviewer/ts.html and then changes period, press "Accept".