### PR TITLE
DM-10345: provide management for long running searches

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -67,6 +67,7 @@
     -webkit-order: 1;
     -ms-flex-order: 1;
     order: 1;
+    height: 75px;
 }
 
 #App > footer {

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -129,6 +129,7 @@ public class ServerParams {
     public static final String PROGRESS = "CmdProgress";
     public static final String SUB_BACKGROUND_SEARCH= "subBackgroundSearch";
     public static final String GET_STATUS= "status";
+    public static final String ADD_JOB = "addBgJob";
     public static final String REMOVE_JOB = "removeBgJob";
     public static final String CANCEL= "cancel";
     public static final String ADD_ID_TO_CRITERIA= "addIDToCriteria";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
@@ -79,6 +79,7 @@ public class ServerCommandAccess {
         _cmdMap.put(ServerParams.GET_ENUM_VALUES,        new SearchServerCommands.GetEnumValues());
         _cmdMap.put(ServerParams.SUB_BACKGROUND_SEARCH,  new SearchServerCommands.SubmitBackgroundSearch());
         _cmdMap.put(ServerParams.GET_STATUS,             new SearchServerCommands.GetStatus());
+        _cmdMap.put(ServerParams.ADD_JOB,                new SearchServerCommands.AddBgJob());
         _cmdMap.put(ServerParams.REMOVE_JOB,             new SearchServerCommands.RemoveBgJob());
         _cmdMap.put(ServerParams.CANCEL,                 new SearchServerCommands.Cancel());
         _cmdMap.put(ServerParams.ADD_ID_TO_CRITERIA,     new SearchServerCommands.AddIDToPushCriteria());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
@@ -245,9 +245,12 @@ public class SrvParam {
 //  Table related convenience methods
 //====================================================================
     public TableServerRequest getTableServerRequest() {
-        String reqString = getRequired(ServerParams.REQUEST);
-        return QueryUtil.convertToServerRequest(reqString);
+        return getTableServerRequest(ServerParams.REQUEST);
     }
 
+    public TableServerRequest getTableServerRequest(String key) {
+        String reqString = getRequired(key);
+        return QueryUtil.convertToServerRequest(reqString);
+    }
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/BackgroundInfoCacher.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/BackgroundInfoCacher.java
@@ -50,8 +50,10 @@ public class BackgroundInfoCacher {
     }
 
     public static void fireBackgroundJobAdd(BackgroundStatus bgStat) {
-        FluxAction addAction = new FluxAction("background.bgJobAdd", QueryUtil.convertToJsonObject(bgStat));
-        ServerEventManager.fireAction(addAction, ServerEvent.Scope.USER);
+        if (bgStat != null) {
+            FluxAction addAction = new FluxAction("background.bgJobAdd", QueryUtil.convertToJsonObject(bgStat));
+            ServerEventManager.fireAction(addAction, ServerEvent.Scope.USER);
+        }
     }
 
     //======================================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackageMaster.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackageMaster.java
@@ -168,7 +168,7 @@ public class PackageMaster  {
                                                        req.getTitle(),req.getEmail(),
                                                        req.getDataSource(),
                                                        ServerContext.getRequestOwner());
-        BackgroundStatus bgStat= BackgroundEnv.backgroundProcess(WAIT_MILLS,backProcess);
+        BackgroundStatus bgStat= BackgroundEnv.backgroundProcess(WAIT_MILLS,backProcess, BgType.PACKAGE);
         checkForLongQueue(bgStat);
         return bgStat;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/BackgroundEnv.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/BackgroundEnv.java
@@ -290,21 +290,22 @@ public class BackgroundEnv {
         }
         return retval;
     }
-
-
     public static BackgroundStatus backgroundProcess(int waitMills, BackgroundProcessor processor) {
+        return backgroundProcess(waitMills, processor, null);
+    }
+
+    public static BackgroundStatus backgroundProcess(int waitMills, BackgroundProcessor processor, BackgroundStatus.BgType type) {
         String bid= processor.getBID();
         runBackgroundThread(waitMills, processor);
         Logger.briefDebug("Background thread returned");
         BackgroundStatus bgStat= processor.getBackgroundStatus();
         if (bgStat==null) {
             bgStat = processor.getPiCacher().getStatus();
-            bgStat = bgStat == null ? new BackgroundStatus(bid, BackgroundState.WAITING) : bgStat;
+            bgStat = bgStat == null ? new BackgroundStatus(bid, BackgroundState.WAITING, type) : bgStat;
         }
         if (!bgStat.isDone()) {
             // it's not done within the same request.. add it to background and enable email notification.
             bgStat.addAttribute(JobAttributes.CanSendEmail);
-            BackgroundEnv.addUserBackgroundInfo(bgStat);
         }
         processor.getPiCacher().setStatus(bgStat);
         Logger.briefDebug("Background report returned");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
@@ -19,6 +19,7 @@ import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupReader;
 import edu.caltech.ipac.firefly.server.util.ipactable.IpacTableParser;
+import edu.caltech.ipac.firefly.server.util.ipactable.JsonTableUtil;
 import edu.caltech.ipac.firefly.server.util.ipactable.TableDef;
 import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.util.IpacTableUtil;
@@ -31,6 +32,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
+
+import static edu.caltech.ipac.firefly.core.background.BackgroundStatus.CLIENT_REQ;
+import static edu.caltech.ipac.firefly.core.background.BackgroundStatus.SERVER_REQ;
 
 
 /**
@@ -198,14 +202,15 @@ public class SearchManager {
     public BackgroundStatus getRawDataSetBackground(TableServerRequest request, Request clientRequest, int waitMillis) throws RPCException {
 
         Logger.briefDebug("Backgrounded search started:" + waitMillis + " wait, req:" + request);
-        String email= request.containsParam(ServerParams.EMAIL)? request.getParam(ServerParams.EMAIL) : "";
+        String email= request.getMeta(ServerParams.EMAIL) == null ? "" : request.getMeta(ServerParams.EMAIL);
         SearchWorker worker= new SearchWorker(request, clientRequest);
+        String title = request.getTblTitle() == null ? request.getRequestId() : request.getTblTitle();
         BackgroundEnv.BackgroundProcessor processor=
                               new BackgroundEnv.BackgroundProcessor(worker,  null,
-                                                                    request.getRequestId(),
+                                                                    title,
                                                                     email, request.getRequestId(),
                                                                     ServerContext.getRequestOwner() );
-        return BackgroundEnv.backgroundProcess(waitMillis, processor);
+        return BackgroundEnv.backgroundProcess(waitMillis, processor, BackgroundStatus.BgType.SEARCH);
     }
 
     public RawDataSet getEnumValues(File file) throws IOException {
@@ -233,8 +238,12 @@ public class SearchManager {
         public BackgroundStatus work(BackgroundEnv.BackgroundProcessor p)  throws Exception {
             RawDataSet data= getRawDataSet(request);
             BackgroundStatus bgStat= new BackgroundStatus(p.getBID(), BackgroundState.SUCCESS, BackgroundStatus.BgType.SEARCH);
-            bgStat.setServerRequest(request);
-            bgStat.setClientRequest(clientRequest);
+            if (request != null) {
+                bgStat.setParam(SERVER_REQ, JsonTableUtil.toJsonTableRequest(request).toJSONString());
+            }
+            if (clientRequest != null) {
+                bgStat.setParam(CLIENT_REQ, JsonTableUtil.toJsonTableRequest(clientRequest).toJSONString());
+            }
             if (data.getTotalRows() > 0)  bgStat.setFilePath(data.getMeta().getSource());
             return bgStat;
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
@@ -149,18 +149,12 @@ public class SearchServerCommands {
     public static class SubmitBackgroundSearch extends ServCommand {
 
         public String doCommand(SrvParam params) throws Exception {
-            String servReqStr = params.getRequired(ServerParams.REQUEST);
+            TableServerRequest serverRequest = params.getTableServerRequest();
             int waitMil = params.getRequiredInt(ServerParams.WAIT_MILS);
 
-            TableServerRequest serverRequest= ServerRequest.parse(servReqStr, new TableServerRequest());
-            Request clientRequest= null;
-            if (params.contains(ServerParams.CLIENT_REQUEST))  {
-                clientRequest= ServerRequest.parse(params.getOptional(ServerParams.CLIENT_REQUEST),
-                        new Request());
-            }
             BackgroundStatus bgStat= new SearchServicesImpl().submitBackgroundSearch(
-                    serverRequest,clientRequest,waitMil);
-            return bgStat.serialize();
+                    serverRequest, null,waitMil);
+            return QueryUtil.convertToJsonObject(bgStat).toJSONString();
         }
     }
 
@@ -169,7 +163,7 @@ public class SearchServerCommands {
         public String doCommand(SrvParam params) throws Exception {
             BackgroundStatus bgStat= new SearchServicesImpl().getStatus(params.getID(),
                     params.getRequiredBoolean(ServerParams.POLLING));
-            return bgStat.serialize();
+            return QueryUtil.convertToJsonObject(bgStat).toJSONString();
         }
     }
 
@@ -177,6 +171,15 @@ public class SearchServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             new SearchServicesImpl().addIDToPushCriteria(params.getID());
+            return "true";
+        }
+    }
+
+    public static class AddBgJob extends ServCommand {
+
+        public String doCommand(SrvParam params) throws Exception {
+            BackgroundStatus bgStatus = QueryUtil.convertToBackgroundStatus(params.getRequired("bgStats"));
+            BackgroundEnv.addUserBackgroundInfo(bgStatus);
             return "true";
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -110,6 +110,23 @@ public class QueryUtil {
         return retval;
     }
 
+    public static BackgroundStatus convertToBackgroundStatus(String jsonBgStatus) {
+        BackgroundStatus retval = new BackgroundStatus();
+        if (!StringUtils.isEmpty(jsonBgStatus)) {
+            try {
+                JSONObject jsonReq = (JSONObject) new JSONParser().parse(jsonBgStatus);
+                for (Object key : jsonReq.keySet()) {
+                    String skey = String.valueOf(key);
+                    Object val = jsonReq.get(key);
+                    retval.setParam(skey, String.valueOf(val));
+                }
+            } catch (ParseException e) {
+                LOGGER.error(e);
+            }
+        }
+        return retval;
+    }
+
     public static JSONObject convertToJsonObject(BackgroundStatus bgStat) {
         List<String> intParams = Arrays.asList(MESSAGE_CNT, PACKAGE_CNT, TOTAL_BYTES, RESPONSE_CNT, ACTIVE_REQUEST_CNT);
 

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -123,6 +123,7 @@ function buildTablePart(llApi) {
      * @prop {string}  tbl_group    the group this table belongs to.  Defaults to 'main'.
      * @prop {number}  pageSize     the starting page size.  Will use the request's pageSize if not given.
      * @prop {boolean} removable    true if this table can be removed from view.  Defaults to true.
+     * @prop {boolean} backgroundable    true if this search can be sent to background.  Defaults to false.
      * @prop {boolean} showUnits    defaults to false
      * @prop {boolean} showFilters  defaults to false
      * @prop {boolean} selectable   defaults to true

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -123,7 +123,7 @@ function buildTablePart(llApi) {
      * @prop {string}  tbl_group    the group this table belongs to.  Defaults to 'main'.
      * @prop {number}  pageSize     the starting page size.  Will use the request's pageSize if not given.
      * @prop {boolean} removable    true if this table can be removed from view.  Defaults to true.
-     * @prop {boolean} backgroundable    true if this search can be sent to background.  Defaults to false.
+     * @prop {boolean} backgroundable    true if this search can be sent to background.  Defaults to true.
      * @prop {boolean} showUnits    defaults to false
      * @prop {boolean} showFilters  defaults to false
      * @prop {boolean} selectable   defaults to true

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -11,7 +11,7 @@ import {clone} from '../util/WebUtil.js';
 import {smartMerge} from '../tables/TableUtil.js';
 import {getDropDownNames} from '../ui/Menu.jsx';
 import ImagePlotCntlr from '../visualize/ImagePlotCntlr.js';
-import {TBL_RESULTS_ADDED, TABLE_REMOVE} from '../tables/TablesCntlr.js';
+import {TBL_RESULTS_ADDED, TBL_RESULTS_REMOVE, TABLE_REMOVE} from '../tables/TablesCntlr.js';
 import {CHART_ADD, CHART_REMOVE} from '../charts/ChartsCntlr.js';
 import {REPLACE_VIEWER_ITEMS} from '../visualize/MultiViewCntlr.js';
 
@@ -239,6 +239,7 @@ export function dropDownHandler(layoutInfo, action) {
 
         case SHOW_DROPDOWN:
         case TABLE_REMOVE:
+        case TBL_RESULTS_REMOVE:
         case ImagePlotCntlr.DELETE_PLOT_VIEW:
             if (!get(layoutInfo, 'dropDown.visible', false)) {
                 if (count===0) {
@@ -262,7 +263,7 @@ export function* dropDownManager() {
         const action = yield take([
             ImagePlotCntlr.PLOT_IMAGE_START, ImagePlotCntlr.PLOT_IMAGE,
             REPLACE_VIEWER_ITEMS,
-            TABLE_REMOVE, TBL_RESULTS_ADDED,
+            TABLE_REMOVE, TBL_RESULTS_ADDED, TBL_RESULTS_REMOVE,
             CHART_ADD, CHART_REMOVE,
             SHOW_DROPDOWN, SET_LAYOUT_MODE
         ]);

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -32,6 +32,7 @@ function actionCreators() {
         [BG_MONITOR_SHOW]: bgMonitorShow,
         [BG_SET_EMAIL]: bgSetEmail,
         [BG_Package]: bgPackage,
+        [BG_JOB_ADD]: bgJobAdd,
         [BG_JOB_REMOVE]: bgJobRemove,
         [BG_JOB_CANCEL]: bgJobCancel
     };
@@ -133,6 +134,16 @@ function bgMonitorShow(action) {
     };
 }
 
+function bgJobAdd(action) {
+    return (dispatch) => {
+        const bgStatus = action.payload;
+        if (bgStatus) {
+            SearchServices.addBgJob(bgStatus);
+            dispatch(action);
+        }
+    };
+}
+
 function bgJobRemove(action) {
     return (dispatch) => {
         const {id} = action.payload;
@@ -174,6 +185,8 @@ function bgPackage(action) {
                     if (url && isSuccess(get(bgStatus, 'STATE'))) {
                         download(url);
                         dispatch({type: BG_JOB_IMMEDIATE, payload: bgStatus});       // allow saga to catch flow.
+                    } else {
+                        dispatchJobAdd(bgStatus);
                     }
                 }
             });

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -27,6 +27,14 @@ export function getBackgroundJobs() {
 }
 
 /**
+ * returns background status for the given id.
+ * @returns {BgStatus}
+ */
+export function getBgStatusById(id) {
+    return get(flux.getState(), [BACKGROUND_PATH, 'jobs', id]);
+}
+
+/**
  * returns the email used for background status notification.
  * @returns {string}
  */
@@ -57,6 +65,12 @@ export function isSuccess(state) {
 
 export function isActive(state) {
     return BG_STATE.get('WAITING | WORKING | STARTING').has(state);
+}
+
+export function getErrMsg(bgStatus) {
+    return Object.entries(bgStatus).filter( ([k,v]) => k.startsWith('MESSAGE_'))
+                            .map(([k,v]) => v)
+                            .join('; ');
 }
 
 

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -113,6 +113,7 @@ export const ServerParams = {
         SUB_BACKGROUND_SEARCH: 'subBackgroundSearch',
         GET_STATUS: 'status',
         REMOVE_JOB: 'removeBgJob',
+        ADD_JOB: 'addBgJob',
         CANCEL: 'cancel',
         ADD_ID_TO_CRITERIA: 'addIDToCriteria',
         CLEAN_UP: 'cleanup',
@@ -140,7 +141,6 @@ export const ServerParams = {
         SELECTED_VALUES: 'selectedValues',
         TABLE_SAVE: 'tableSave',
         UPLOAD: 'upload',
-        JSON_SEARCH: 'jsonSearch',
         LOG_OUT: 'CmdLogout',
         INIT_APP: 'CmdInitApp',
 
@@ -152,8 +152,8 @@ export const ServerParams = {
         USER_TARGET_WORLD_PT : 'UserTargetWorldPt',
 
 
-        WS_LIST : "wsList",
-        WS_GET_FILE : "wsGet",
-        WS_PUT_FILE : "wsPut"
+        WS_LIST : 'wsList',
+        WS_GET_FILE : 'wsGet',
+        WS_PUT_FILE : 'wsPut'
 
 };

--- a/src/firefly/js/tables/reducer/TableResultsReducer.js
+++ b/src/firefly/js/tables/reducer/TableResultsReducer.js
@@ -31,7 +31,8 @@ export function resultsReducer(state={results:{}}, action={}) {
             const {tbl_id, tbl_group} = action.payload;
             return updateSet(root, [tbl_group,'active'], tbl_id);
         }
-        case (Cntlr.TABLE_REMOVE)    :
+        case Cntlr.TABLE_REMOVE    :
+        case Cntlr.TBL_RESULTS_REMOVE    :
             return removeTable(root, action);
         
         default:

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -20,6 +20,7 @@ export function uiReducer(state={ui:{}}, action={}) {
             return updateAllUi(root, tbl_id, tbl_ui_id, action.payload);
         }
         case (Cntlr.TABLE_REMOVE)    :
+        case (Cntlr.TBL_RESULTS_REMOVE)    :
             return removeTable(root, action);
 
         case (Cntlr.TBL_RESULTS_ADDED) :

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -191,6 +191,23 @@
     cursor: pointer;
 }
 
+.TablePanel__mask {
+    box-sizing: content-box;
+    background-color: rgba(255,255,255,.8);
+    display: flex;
+    position: relative;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+}
+
+.TablePanel__mask--button {
+    z-index: 1;
+    margin-top: 80px;
+    border: 1px solid rgba(0, 0, 0, 0.4);
+    box-sizing: content-box;
+    background-color: rgba(255,255,255,.8);
+}
 
 /** below are taken from FixedDataTable with some modifications */
 

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -7,7 +7,7 @@ import {filter} from 'lodash';
 
 import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo, dispatchUpdateLayoutInfo, dropDownManager} from '../../core/LayoutCntlr.js';
 import {smartMerge} from '../../tables/TableUtil.js';
-import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
+import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE, TBL_RESULTS_REMOVE} from '../../tables/TablesCntlr.js';
 import {CHART_ADD, CHART_REMOVE} from '../../charts/ChartsCntlr.js';
 
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
@@ -31,7 +31,7 @@ export function* layoutManager({title, views='tables | images | xyPlots'}) {
         const action = yield take([
             ImagePlotCntlr.PLOT_IMAGE_START, ImagePlotCntlr.PLOT_IMAGE,
             ImagePlotCntlr.DELETE_PLOT_VIEW, REPLACE_VIEWER_ITEMS,
-            TABLE_REMOVE, TABLE_LOADED, TBL_RESULTS_ADDED, TBL_RESULTS_ACTIVE,
+            TABLE_REMOVE, TABLE_LOADED, TBL_RESULTS_ADDED, TBL_RESULTS_ACTIVE, TBL_RESULTS_REMOVE,
             CHART_ADD, CHART_REMOVE,
             SHOW_DROPDOWN, SET_LAYOUT_MODE
         ]);
@@ -87,6 +87,7 @@ function onAnyAction(layoutInfo, action, views) {
     switch (action.type) {
         case TABLE_REMOVE:
         case TBL_RESULTS_ADDED:
+        case TBL_RESULTS_REMOVE:
         case REPLACE_VIEWER_ITEMS:
         case ImagePlotCntlr.PLOT_IMAGE_START :
         case ImagePlotCntlr.DELETE_PLOT_VIEW:

--- a/src/firefly/js/ui/DropDownContainer.css
+++ b/src/firefly/js/ui/DropDownContainer.css
@@ -8,6 +8,7 @@
     align-items: center;
     justify-content: space-between;
     height: calc(100% - 75px);
+    top: 75px;
 }
 
 .DD-ToolBar__content {

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -47,9 +47,9 @@ function createSuccessHandler(action, params={}, title, onSubmit) {
 
 export const FormPanel = function (props) {
     var {children, onSubmit, onCancel, onError, groupKey, action, params, title,
-        width='100%', height='100%', submitText='Search', help_id, changeMasking} = props;
+        submitText='Search', help_id, changeMasking} = props;
 
-    const style = { width, height,
+    const style = {
         backgroundColor: 'white',
         border: '1px solid rgba(0,0,0,0.2)',
         padding: 5,


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-10345

Normally, when a search is submitted, a table will appears masked with a loading icon.
The masked panel will be replaced with table data when the search results returned.
With this PR, when a search is backgroundable, a 'send to background' button will be added to the bottom of the loading icon.    If pressed, it will close the masked table and send the search to the background.  The job will appear in the Background Monitor. 
Per Xiuqin request, backgroundable is set to true by default.
This feature will be available to all Firefly's derived projects, ie /irsaviewr, /suit.

To test:
http://localhost:8080/firefly/
- Catalogs search with a larger radius
- While loading, click 'send to background'
- If button is not clicked, it will load when results returned.

Also:  this PR also fixes https://jira.lsstcorp.org/browse/DM-11252
