### PR TITLE
IRSA-572:Color stretch for three color does not work

### DIFF
--- a/src/firefly/js/visualize/RangeValues.js
+++ b/src/firefly/js/visualize/RangeValues.js
@@ -230,7 +230,7 @@ export class RangeValues {
             a= alStrToConst[algorithm.toLowerCase()];
         }
 
-        return new RangeValues.make( btValue, lowerValue, btValue, upperValue,1.0,0,1,2, a);
+        return new RangeValues.make( btValue, lowerValue, btValue, upperValue,NaN,2, a);
 
     }
 


### PR DESCRIPTION
  Fixed color stretch issue:

This pull request  implemented two tickets, IRSA-572 and IRSA-586.  

1. On the client side, when the specific color tab is selected for doing stretch, only this band's data is stored in the stretch data and dispatched to the server.
1. On the server side, when the recompute stretch is performed, its update the range values and the band index.  Thus, only the corresponding band's data is stretched with the new range values.

To test,
  Please check out this branch and search a color images with one, two and three bands.  And then do the color stretch at each band. 