### PR TITLE
IRSA-629 and IRSA-630: add generic way to get downloader in time series tool

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
@@ -52,7 +52,7 @@ public class PtfIbeDataSource extends BaseIbeDataSource {
         public String getTable() { return table;}
     }
 
-    public PtfIbeDataSource() { ptfResolver = new PtfIbeResolver();}
+    public PtfIbeDataSource() {}
 
     public PtfIbeDataSource(DataProduct ds) {
         this(null, ds);
@@ -188,6 +188,8 @@ public class PtfIbeDataSource extends BaseIbeDataSource {
         setMission(PTF);
         setDataset(dataset);
         setTableName(table);
+
+        ptfResolver = new PtfIbeResolver();
     }
 
     private String processConstraints(Map<String, String> queryInfo) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/BackgroundStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/BackgroundStatus.java
@@ -37,7 +37,7 @@ public class BackgroundStatus implements Serializable {
     public static final String DATA_SOURCE = "DATA_SOURCE";
     public static final String MESSAGE_BASE = "MESSAGE_";
     public static final String MESSAGE_CNT = "MESSAGE_CNT";
-    public static final String PACKAGE_PROGRESS_BASE = "PACKAGE_PROGRESS_";
+    public static final String ITEMS = "ITEMS_";
     public static final String PACKAGE_CNT = "PACKAGE_CNT";
     public static final String CLIENT_REQ = "CLIENT_REQ";
     public static final String SERVER_REQ = "SERVER_REQ";
@@ -361,7 +361,7 @@ public class BackgroundStatus implements Serializable {
     }
 
     public PackageProgress getPartProgress(int i) {
-        String s= getParam(PACKAGE_PROGRESS_BASE+i);
+        String s= getParam(ITEMS +i);
         PackageProgress retval= PackageProgress.parse(s);
         if (retval==null) retval= new PackageProgress();
         return retval;
@@ -397,7 +397,7 @@ public class BackgroundStatus implements Serializable {
     }
 
     public void setPartProgress(PackageProgress progress, int i) {
-        setParam(PACKAGE_PROGRESS_BASE+i,progress.serialize());
+        setParam(ITEMS +i,progress.serialize());
     }
 
     public Request getClientRequest() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
@@ -137,16 +137,16 @@ public class RequestAgent {
             this.response = response;
 
             String remoteIP = getHeader("X-Forwarded-For", request.getRemoteAddr());
-            String protocol = getHeader("X-Forwarded-Proto", request.getProtocol());
+            String scheme = getHeader("X-Forwarded-Proto", request.getScheme());
             String serverName = request.getServerName();
             int serverPort = request.getServerPort();
             String serverPortDesc = serverPort == 80 || serverPort == 443 ? "" : ":" + serverPort;
 
-            String baseUrl = String.format("%s://%s%s%s/", protocol, serverName, serverPortDesc, request.getContextPath());
-            String requestUrl = String.format("%s://%s%s%s", protocol, serverName, serverPortDesc, request.getRequestURI());
+            String baseUrl = String.format("%s://%s%s%s/", scheme, serverName, serverPortDesc, request.getContextPath());
+            String requestUrl = String.format("%s://%s%s%s", scheme, serverName, serverPortDesc, request.getRequestURI());
 
             setRemoteIP(remoteIP);
-            setProtocol(protocol);
+            setProtocol(scheme);
             setRequestUrl(requestUrl);
             setBaseUrl(baseUrl);
             setSessId(request.getSession(true).getId());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -1,0 +1,204 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query.lc;
+
+import edu.caltech.ipac.astro.IpacTableException;
+import edu.caltech.ipac.firefly.data.DownloadRequest;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.query.FileGroupsProcessor;
+import edu.caltech.ipac.firefly.server.query.SearchManager;
+import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
+import edu.caltech.ipac.firefly.server.query.ptf.PtfFileRetrieve;
+import edu.caltech.ipac.firefly.server.query.ptf.PtfIbeResolver;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
+import edu.caltech.ipac.firefly.server.util.ipactable.IpacTableParser;
+import edu.caltech.ipac.util.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.*;
+
+/**
+ * Created with IntelliJ IDEA. User: wmi Date: 10/8/13 Time: 4:30 PM To change this template use File | Settings | File
+ * Templates.
+ */
+
+@SearchProcessorImpl(id = "PtfLcDownload")
+public class PtfFileGroupsProcessor extends FileGroupsProcessor {
+
+    private static final Logger.LoggerImpl logger = Logger.getLogger();
+    private final int L2_FITS_SIZE = 33586560;
+    private final int L2_ANSI_SIZE = 16781760;
+
+    public List<FileGroup> loadData(ServerRequest request) throws IOException, DataAccessException {
+        assert (request instanceof DownloadRequest);
+        try {
+            return computeFileGroup((DownloadRequest) request);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new DataAccessException(e.getMessage());
+        }
+    }
+
+    private List<FileGroup> computeFileGroup(DownloadRequest request) throws IOException, IpacTableException, DataAccessException {
+        // create unique list of filesystem-based and url-based files
+        Set<String> zipFiles = new HashSet<String>();
+
+        Collection<Integer> selectedRows = request.getSelectedRows();
+        DataGroupPart dgp = new SearchManager().getDataGroup(request.getSearchRequest());
+
+        ArrayList<FileInfo> fiArr = new ArrayList<FileInfo>();
+        long fgSize = 0;
+
+        // values = cut or orig
+        String dlCutouts = request.getParam("dlCutouts");
+        boolean doCutout = dlCutouts != null && dlCutouts.equalsIgnoreCase("cut");
+
+        // values = folder or flat
+        String zipType = request.getParam("zipType");
+        boolean doFolders = zipType != null && zipType.equalsIgnoreCase("folder");
+
+        List<String> types = new ArrayList<String>();
+
+        IpacTableParser.MappedData dgData = IpacTableParser.getData(new File(dgp.getTableDef().getSource()),
+                selectedRows, "oid", "pfilename", "fid", "pid", "ccdid", "ra", "dec");
+
+        if (request.getParam("ProductLevel") == null) {
+            request.setParam("ProductLevel", "l1");
+        }
+        String subSize = request.getSafeParam("cutoutSize");
+        double sizeD = StringUtils.isEmpty(subSize) ? 0 : Double.parseDouble(subSize);
+        String sizeAsecStr = String.valueOf((int) (sizeD * 3600));
+
+        Map<String, String> cookies = ServerContext.getRequestOwner().getIdentityCookies();
+        for (int rowIdx : selectedRows) {
+            FileInfo fi = null;
+            String pidstr = dgData.get(rowIdx, "pid").toString();
+            long pid = Long.parseLong(pidstr);
+
+            String pfilename = null;
+            if (pidstr != null) {
+                try {
+                    pfilename = new PtfIbeResolver().getListPfilenames(new long[]{pid})[0];
+                } catch (InterruptedException e) {
+                    //PID didn't work
+                    throw new DataAccessException("PID " + pid + " didn't give any result ", e);
+                }
+            } else {
+                pfilename = (String) dgData.get(rowIdx, "pfilename");
+            }
+
+            String baseUrl = getBaseURL(request);
+
+            String fileName = pfilename;//createBaseFileString_l2(fieldDir, fieldId, fId, ccdId);
+
+            logger.briefInfo("filename=" + fileName);
+
+            File f = new File(fileName);
+            String extName = doFolders ? fileName : f.getName();
+            if (doCutout) {
+                // look for in_ra and in_dec returned by IBE
+                String subLon = dgData.get(rowIdx, "in_ra") != null ? String.format("%.4f", (Double) dgData.get(rowIdx, "in_ra")) : null;
+                if (StringUtils.isEmpty(subLon)) {
+                    subLon = String.format("%.4f", (Double) dgData.get(rowIdx, "ra"));
+                }
+
+                // look for in_ra and in_dec returned by IBE
+                String subLat = dgData.get(rowIdx, "in_dec") != null ? String.format("%.4f", (Double) dgData.get(rowIdx, "in_dec")) : null;
+                if (StringUtils.isEmpty(subLat)) {
+                    // if it fails, try using crval2
+                    subLat = String.format("%.4f", (Double) dgData.get(rowIdx, "dec"));
+                }
+                String cutoutInfo = "_ra" + subLon + "_dec" + subLat + "_asec" + sizeAsecStr;
+
+                extName = extName.replace(".fits",cutoutInfo+".fits");
+                String url = createCutoutURLString_l2(baseUrl, pfilename, subLon, subLat, subSize);
+                logger.briefInfo("cutout url: " + url);
+
+
+//                // strip out filename when using file resolver
+//                if (doFolders) {
+//                    int idx = extName.lastIndexOf("/");
+//                    idx = idx < 0 ? 0 : idx;
+//                    extName = extName.substring(0, idx) + "/";
+//                } else {
+//                    extName = null;
+//                }
+
+                fi = new FileInfo(url, extName, 100000);
+            } else {
+                String url = baseUrl + fileName;
+                fi = new FileInfo(url, extName, 100000);
+            }
+            if (fi != null) {
+                fi.setCookies(cookies);
+                fiArr.add(fi);
+                fgSize += fi.getSizeInBytes();
+            }
+        }
+
+        FileGroup fg = new FileGroup(fiArr, null, fgSize, "PTF Download Files");
+        ArrayList<FileGroup> fgArr = new ArrayList<FileGroup>();
+        fgArr.add(fg);
+        return fgArr;
+    }
+
+    static String createCutoutURLString_l2(String baseUrl, String baseFile, String lon, String lat, String size) {
+
+        //http://irsa.ipac.caltech.edu/ibe/data/ptf/images/level1/{$pfilename}?center=${ra},${dec}&size=${cutoutSizeInDeg}&gzip=false
+
+        String url = baseUrl + baseFile;
+        url += "?center=" + lon + "," + lat;
+        if (!StringUtils.isEmpty(size)) {
+            url += "&size=" + size;
+        }
+        url += "&gzip=" + false;
+
+        return url;
+    }
+
+//    static String getBaseURL(ServerRequest sr) {
+//
+//        String host = sr.getSafeParam("host") != null ? sr.getSafeParam("host") : PtfIbeResolver.PTF_IBE_HOST;
+//
+//        return QueryUtil.makeUrlBase(host) + "/data/ptf/images/level1/";
+//    }
+
+    private static String getBaseURL(ServerRequest sr) throws MalformedURLException {
+        // build service
+        return new PtfFileRetrieve().getBaseURL(sr);
+
+    }
+}
+
+
+/*
+ * THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE CALIFORNIA
+ * INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S. GOVERNMENT CONTRACT WITH
+ * THE NATIONAL AERONAUTICS AND SPACE ADMINISTRATION (NASA). THE SOFTWARE
+ * IS TECHNOLOGY AND SOFTWARE PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS
+ * AND IS PROVIDED AS-IS TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND,
+ * INCLUDING ANY WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR
+ * A PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC 2312- 2313)
+ * OR FOR ANY PURPOSE WHATSOEVER, FOR THE SOFTWARE AND RELATED MATERIALS,
+ * HOWEVER USED.
+ *
+ * IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA BE LIABLE
+ * FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT LIMITED TO, INCIDENTAL
+ * OR CONSEQUENTIAL DAMAGES OF ANY KIND, INCLUDING ECONOMIC DAMAGE OR INJURY TO
+ * PROPERTY AND LOST PROFITS, REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE
+ * ADVISED, HAVE REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+ *
+ * RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF THE SOFTWARE
+ * AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY CALTECH AND NASA FOR
+ * ALL THIRD-PARTY CLAIMS RESULTING FROM THE ACTIONS OF RECIPIENT IN THE USE
+ * OF THE SOFTWARE.
+ */
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -34,8 +34,6 @@ import java.util.*;
 public class PtfFileGroupsProcessor extends FileGroupsProcessor {
 
     private static final Logger.LoggerImpl logger = Logger.getLogger();
-    private final int L2_FITS_SIZE = 33586560;
-    private final int L2_ANSI_SIZE = 16781760;
 
     public List<FileGroup> loadData(ServerRequest request) throws IOException, DataAccessException {
         assert (request instanceof DownloadRequest);
@@ -132,10 +130,10 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
 //                    extName = null;
 //                }
 
-                fi = new FileInfo(url, extName, 100000);
+                fi = new FileInfo(url, extName, 0);
             } else {
                 String url = baseUrl + fileName;
-                fi = new FileInfo(url, extName, 100000);
+                fi = new FileInfo(url, extName, 0);
             }
             if (fi != null) {
                 fi.setCookies(cookies);
@@ -164,41 +162,9 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
         return url;
     }
 
-//    static String getBaseURL(ServerRequest sr) {
-//
-//        String host = sr.getSafeParam("host") != null ? sr.getSafeParam("host") : PtfIbeResolver.PTF_IBE_HOST;
-//
-//        return QueryUtil.makeUrlBase(host) + "/data/ptf/images/level1/";
-//    }
-
     private static String getBaseURL(ServerRequest sr) throws MalformedURLException {
         // build service
-        return new PtfFileRetrieve().getBaseURL(sr);
+        return PtfFileRetrieve.getBaseURL(sr);
 
     }
 }
-
-
-/*
- * THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE CALIFORNIA
- * INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S. GOVERNMENT CONTRACT WITH
- * THE NATIONAL AERONAUTICS AND SPACE ADMINISTRATION (NASA). THE SOFTWARE
- * IS TECHNOLOGY AND SOFTWARE PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS
- * AND IS PROVIDED AS-IS TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND,
- * INCLUDING ANY WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR
- * A PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC 2312- 2313)
- * OR FOR ANY PURPOSE WHATSOEVER, FOR THE SOFTWARE AND RELATED MATERIALS,
- * HOWEVER USED.
- *
- * IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA BE LIABLE
- * FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT LIMITED TO, INCIDENTAL
- * OR CONSEQUENTIAL DAMAGES OF ANY KIND, INCLUDING ECONOMIC DAMAGE OR INJURY TO
- * PROPERTY AND LOST PROFITS, REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE
- * ADVISED, HAVE REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
- *
- * RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF THE SOFTWARE
- * AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY CALTECH AND NASA FOR
- * ALL THIRD-PARTY CLAIMS RESULTING FROM THE ACTIONS OF RECIPIENT IN THE USE
- * OF THE SOFTWARE.
- */
-

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/WiseLightCurveFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/WiseLightCurveFileGroupsProcessor.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  * WARNING / TODO Dealing only with WISE download for now, client should use the downalod based on the mission name
  */
 @SearchProcessorImpl(id = "LightCurveFileGroupsProcessor")
-public class LightCurveFileGroupsProcessor extends FileGroupsProcessor {
+public class WiseLightCurveFileGroupsProcessor extends FileGroupsProcessor {
     private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
     private final int L1B_FITS_SIZE = 4167360;
     private final int L1B_FITS_SIZE_W4 = 1071360;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfFileRetrieve.java
@@ -1,0 +1,58 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query.ptf;
+
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
+import edu.caltech.ipac.firefly.server.query.URLFileInfoProcessor;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.util.AppProperties;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Created by IntelliJ IDEA. User: wmi
+ */
+
+
+@SearchProcessorImpl(id = "PtfFileRetrieve")
+public class PtfFileRetrieve extends URLFileInfoProcessor {
+    static final String IBE_HOST = AppProperties.getProperty("ptf.ibe.host", "https://irsa.ipac.caltech.edu/ibe");
+
+    public URL getURL(ServerRequest sr) throws MalformedURLException {
+        String productLevel = sr.getSafeParam("ProductLevel");
+
+        if (productLevel.equalsIgnoreCase("l2")) {
+            PtfRefimsFileRetrieve l2FileRetrieve = new PtfRefimsFileRetrieve();
+
+            return l2FileRetrieve.getURL(sr);
+        } else if (productLevel.equalsIgnoreCase("l1")) {
+            PtfProcimsFileRetrieve l1FileRetrieve = new PtfProcimsFileRetrieve();
+
+            return l1FileRetrieve.getURL(sr);
+        } else {
+            Logger.warn("cannot find param: productLevel or the param returns null");
+            throw new MalformedURLException("Can not find the file");
+        }
+
+    }
+    public String getBaseURL(ServerRequest sr) throws MalformedURLException {
+        String productLevel = sr.getSafeParam("ProductLevel");
+
+        if (productLevel.equalsIgnoreCase("l2")) {
+           return PtfRefimsFileRetrieve.getBaseURL(sr);
+        } else if (productLevel.equalsIgnoreCase("l1")) {
+            return PtfProcimsFileRetrieve.getBaseURL(sr);
+        } else {
+            Logger.warn("cannot find param: productLevel or the param returns null");
+            throw new MalformedURLException("Can not find the file");
+        }
+
+    }
+    @Override
+    protected boolean identityAware() {
+        return true;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfFileRetrieve.java
@@ -38,7 +38,7 @@ public class PtfFileRetrieve extends URLFileInfoProcessor {
         }
 
     }
-    public String getBaseURL(ServerRequest sr) throws MalformedURLException {
+    public static String getBaseURL(ServerRequest sr) throws MalformedURLException {
         String productLevel = sr.getSafeParam("ProductLevel");
 
         if (productLevel.equalsIgnoreCase("l2")) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
@@ -68,7 +68,7 @@ public class PtfIbeResolver {
         }
 
 
-        DataGroup dataObjects = DataGroupReader.readAnyFormat(tempFile);
+        DataGroup dataObjects = DataGroupReader.read(tempFile);
         Iterator<DataObject> iterator = dataObjects.iterator();
         int size = dataObjects.size();
         List<String> lstFiles = new ArrayList<String>();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
@@ -1,0 +1,109 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query.ptf;
+
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupReader;
+import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.DataGroup;
+import edu.caltech.ipac.util.DataObject;
+import edu.caltech.ipac.util.download.URLDownload;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Utility class to get metadata from PTF pids using IBE API.
+ * Created by ejoliet on 7/19/17.
+ */
+public class PtfIbeResolver {
+
+    private static final Logger.LoggerImpl log = Logger.getLogger();
+
+    public final static String PTF_IBE_HOST = AppProperties.getProperty("ptf.ibe.host", "https://irsa.ipac.caltech.edu/ibe");
+    public static boolean isTestMode = false;
+
+    public PtfIbeResolver() {
+    }
+
+    /**
+     * Get list of filenames out of the table from PIDs
+     *
+     * @param pid pids
+     * @return string array of file names, column pfilename
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public String[] getListPfilenames(long[] pid) throws IOException, InterruptedException {
+        return getValuesFromColumn(pid, "pfilename");
+    }
+
+
+    /**
+     * Gets value of the column from PTF PIDs
+     *
+     * @param pid     pids
+     * @param colName string name
+     * @return string array values of the column
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public String[] getValuesFromColumn(long pid[], String colName) throws IOException {
+        File tempFile = getTempFile();
+        try {
+            URLConnection aconn = URLDownload.makeConnection(createURL(pid));
+            aconn.setRequestProperty("Accept", "*/*");
+            URLDownload.getDataToFile(aconn, tempFile);
+        } catch (Exception e) {
+            log.error(e);
+        }
+
+
+        DataGroup dataObjects = DataGroupReader.readAnyFormat(tempFile);
+        Iterator<DataObject> iterator = dataObjects.iterator();
+        int size = dataObjects.size();
+        List<String> lstFiles = new ArrayList<String>();
+        int total = 0;
+        while (iterator.hasNext()) {
+            DataObject next = iterator.next();
+            Object pfilenam1 = next.getDataElement(colName);
+            if (pfilenam1 != null) {
+                lstFiles.add(pfilenam1.toString());
+                total++;
+            }
+        }
+
+        return lstFiles.toArray(new String[total]);
+    }
+
+    private static URL createURL(long[] pid) throws MalformedURLException {
+        String url = QueryUtil.makeUrlBase(PTF_IBE_HOST) + "/search/ptf/images/level1?where=pid%20in%20(";
+        StringBuilder sb = new StringBuilder();
+        sb.append(url);
+        for (int i = 0; i < pid.length; i++) {
+            sb.append(pid[i]);
+            if (i < pid.length - 1) {
+                sb.append(",");
+            }
+        }
+        sb.append(")");
+        return new URL(sb.toString());
+    }
+
+    protected File getTempFile() throws IOException {
+        File f = File.createTempFile("ptfFiles-", ".tbl", (isTestMode ? new File(".") : ServerContext.getTempWorkDir()));
+        if (isTestMode) {
+            f.deleteOnExit();
+        }
+        return f;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfProcimsFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfProcimsFileRetrieve.java
@@ -1,0 +1,103 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query.ptf;
+
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
+import edu.caltech.ipac.firefly.server.query.URLFileInfoProcessor;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.util.StringUtils;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static edu.caltech.ipac.firefly.server.query.ptf.PtfFileRetrieve.IBE_HOST;
+
+/**
+ * Created by IntelliJ IDEA. User: wmi Date: Feb 15, 2011 Time: 1:40:11 PM To change this template use File | Settings |
+ * File Templates.
+ */
+
+
+@SearchProcessorImpl(id = "PtfProcimsFileRetrieve")
+public class PtfProcimsFileRetrieve extends URLFileInfoProcessor {
+
+    // example: http://irsadev.ipac.caltech.edu:9006/data/ptf/dev/process/{pfilename}?lon={center lon}&lat={center lat}&size={subsize}
+    public static String createCutoutURLString_l1(String baseUrl, String baseFile, String lon, String lat, String size) {
+        String url = baseUrl + baseFile;
+        url += "?center=" + lon + "," + lat + "&size=" + size;
+        url += "&gzip=" + baseFile.endsWith("gz");
+
+        return url;
+    }
+
+    public static String getBaseURL(ServerRequest sr) {
+        String host = sr.getSafeParam("host") != null ? sr.getSafeParam("host") : IBE_HOST;
+        String schema = sr.getSafeParam("schema");
+        String table = sr.getSafeParam("table");
+
+        return QueryUtil.makeUrlBase(host) + "/data/ptf/" + schema + "/" + table + "/";
+    }
+
+    private static URL getIbeURL(ServerRequest sr, boolean doCutOut) throws MalformedURLException {
+        // build service
+        String baseUrl = getBaseURL(sr);
+
+        String pidStr = sr.getSafeParam("pid");
+        long pid = Long.parseLong(pidStr);
+
+        String baseFile = sr.getSafeParam("pfilename");
+        if (baseFile == null) {
+            try {
+                baseFile = new PtfIbeResolver().getListPfilenames(new long[]{pid})[0];
+            } catch (IOException | InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        if (doCutOut) {
+            // look for ra_obj returned by moving object search
+            String subLon = sr.getSafeParam("ra_obj");
+            if (StringUtils.isEmpty(subLon)) {
+                // next look for in_ra returned IBE
+                subLon = sr.getSafeParam("in_ra");
+                if (StringUtils.isEmpty(subLon)) {
+                    // all else fails, try using crval1
+                    subLon = sr.getSafeParam("crval1");
+                }
+            }
+
+            // look for dec_obj returned by moving object search
+            String subLat = sr.getSafeParam("dec_obj");
+            if (StringUtils.isEmpty(subLat)) {
+                // next look for in_dec retuened by IBE
+                subLat = sr.getSafeParam("in_dec");
+                if (StringUtils.isEmpty(subLat)) {
+                    // all else fails, try using crval2
+                    subLat = sr.getSafeParam("crval2");
+                }
+            }
+
+            String subSize = sr.getSafeParam("subsize");
+
+            return new URL(createCutoutURLString_l1(baseUrl, baseFile, subLon, subLat, subSize));
+        } else {
+            return new URL(baseUrl + baseFile);
+        }
+
+    }
+
+    public URL getURL(ServerRequest sr) throws MalformedURLException {
+        if (sr.containsParam("subsize")) {
+            return getIbeURL(sr, true);
+        } else {
+            return getIbeURL(sr, false);
+        }
+    }
+
+    @Override
+    protected boolean identityAware() {
+        return true;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfProcimsFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfProcimsFileRetrieve.java
@@ -21,7 +21,7 @@ import static edu.caltech.ipac.firefly.server.query.ptf.PtfFileRetrieve.IBE_HOST
  */
 
 
-@SearchProcessorImpl(id = "PtfProcimsFileRetrieve")
+@SearchProcessorImpl(id = "PtfProcImagesFileRetrieve")
 public class PtfProcimsFileRetrieve extends URLFileInfoProcessor {
 
     // example: http://irsadev.ipac.caltech.edu:9006/data/ptf/dev/process/{pfilename}?lon={center lon}&lat={center lat}&size={subsize}
@@ -35,10 +35,11 @@ public class PtfProcimsFileRetrieve extends URLFileInfoProcessor {
 
     public static String getBaseURL(ServerRequest sr) {
         String host = sr.getSafeParam("host") != null ? sr.getSafeParam("host") : IBE_HOST;
+        String schemaGroup = sr.getSafeParam("schemaGroup")!= null ? sr.getSafeParam("schemaGroup"):"ptf";
         String schema = sr.getSafeParam("schema");
         String table = sr.getSafeParam("table");
 
-        return QueryUtil.makeUrlBase(host) + "/data/ptf/" + schema + "/" + table + "/";
+        return QueryUtil.makeUrlBase(host) + "/data/" + schemaGroup + "/" + schema + "/" + table + "/";
     }
 
     private static URL getIbeURL(ServerRequest sr, boolean doCutOut) throws MalformedURLException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfRefimsFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfRefimsFileRetrieve.java
@@ -1,0 +1,106 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query.ptf;
+
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
+import edu.caltech.ipac.firefly.server.query.URLFileInfoProcessor;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.util.StringUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static edu.caltech.ipac.firefly.server.query.ptf.PtfFileRetrieve.IBE_HOST;
+
+/**
+ * Created by IntelliJ IDEA. User: wmi Date: OCT.4,2013
+ * <p/>
+ * To change this template use File | Settings | File Templates.
+ */
+
+
+@SearchProcessorImpl(id = "PtfRefimsFileRetrieve")
+public class PtfRefimsFileRetrieve extends URLFileInfoProcessor {
+
+    // example: http://irsadev.ipac.caltech.edu:6001/data/ptf/dev_refims/ptf_ref_img/ptffiled/f#/c#/filename?lon={center lon}&lat={center lat}&size={subsize}
+    public static String createCutoutURLString_l2(String baseUrl, String baseFile, String lon, String lat, String size) {
+        String url = baseUrl + baseFile;
+        url += "?center=" + lon + "," + lat;
+        if (!StringUtils.isEmpty(size)) {
+            url += "&size=" + size;
+        }
+        url += "&gzip=" + baseFile.endsWith("gz");
+
+        return url;
+    }
+
+    // example: http://irsadev:6001/search/ptf/dev_refims/ptf_ref_img?
+    public static String getBaseURL(ServerRequest sr) {
+        String host = sr.getSafeParam("host") != null ? sr.getSafeParam("host") : IBE_HOST;
+        String schemaGroup = sr.getSafeParam("schemaGroup");
+        String schema = sr.getSafeParam("schema");
+        String table = sr.getSafeParam("table");
+
+        return QueryUtil.makeUrlBase(host) + "/data/" + schemaGroup + "/" + schema + "/" + table + "/";
+    }
+
+
+    private static URL getIbeURL(ServerRequest sr, boolean doCutOut) throws MalformedURLException {
+        // build service
+        String baseUrl = getBaseURL(sr);
+        String filename = sr.getSafeParam("filename");
+        //String fieldId = sr.getSafeParam("ptffield");
+        String fieldId = filename.split("_")[1];
+        String fieldDir = fieldId.substring(0, 4);
+        String filterId = sr.getSafeParam("fid");
+        String ccdId = sr.getSafeParam("ccdid");
+
+        String baseFile = fieldDir + "/" + fieldId + "/f" + filterId + "/c" + ccdId + "/" + filename;
+
+        if (doCutOut) {
+            // look for ra_obj returned by moving object search
+            String subLon = sr.getSafeParam("ra_obj");
+            if (StringUtils.isEmpty(subLon)) {
+                // next look for in_ra returned IBE
+                subLon = sr.getSafeParam("in_ra");
+                if (StringUtils.isEmpty(subLon)) {
+                    // all else fails, try using crval1
+                    subLon = sr.getSafeParam("ra");
+                }
+            }
+
+            // look for dec_obj returned by moving object search
+            String subLat = sr.getSafeParam("dec_obj");
+            if (StringUtils.isEmpty(subLat)) {
+                // next look for in_dec retuened by IBE
+                subLat = sr.getSafeParam("in_dec");
+                if (StringUtils.isEmpty(subLat)) {
+                    // all else fails, try using crval2
+                    subLat = sr.getSafeParam("dec");
+                }
+            }
+
+            String subSize = sr.getSafeParam("subsize");
+
+            return new URL(createCutoutURLString_l2(baseUrl, baseFile, subLon, subLat, subSize));
+        } else {
+            return new URL(baseUrl + baseFile);
+        }
+
+    }
+
+    public URL getURL(ServerRequest sr) throws MalformedURLException {
+        if (sr.containsParam("subsize")) {
+            return getIbeURL(sr, true);
+        } else {
+            return getIbeURL(sr, false);
+        }
+    }
+
+    @Override
+    protected boolean identityAware() {
+        return true;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfRefimsFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfRefimsFileRetrieve.java
@@ -21,7 +21,7 @@ import static edu.caltech.ipac.firefly.server.query.ptf.PtfFileRetrieve.IBE_HOST
  */
 
 
-@SearchProcessorImpl(id = "PtfRefimsFileRetrieve")
+@SearchProcessorImpl(id = "PtfRefImagesFileRetrieve")
 public class PtfRefimsFileRetrieve extends URLFileInfoProcessor {
 
     // example: http://irsadev.ipac.caltech.edu:6001/data/ptf/dev_refims/ptf_ref_img/ptffiled/f#/c#/filename?lon={center lon}&lat={center lat}&size={subsize}

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -248,13 +248,13 @@ function handleBgJobRemove(state, action) {
  */
 function transform(bgstats) {
     const ITEMS = Object.keys(bgstats)
-        .filter( (k) => k.startsWith('PACKAGE_PROGRESS_') )
+        .filter( (k) => k.startsWith('ITEMS_') )
         .map( (k) => {
-            const [,,index] = k.split('_');
+            const [,index] = k.split('_');
             const INDEX = Number(index);
             return {INDEX, ...bgstats[k]};
         }).sort((a, b) => a.INDEX - b.INDEX);
-    const REST = pick(bgstats,  Object.keys(bgstats).filter( (k) => !k.startsWith('PACKAGE_PROGRESS_')));
+    const REST = pick(bgstats,  Object.keys(bgstats).filter( (k) => !k.startsWith('ITEMS_')));
 
     return {ITEMS, ...REST};
 }

--- a/src/firefly/js/core/background/BackgroundStatus.js
+++ b/src/firefly/js/core/background/BackgroundStatus.js
@@ -33,7 +33,7 @@ const Keys= {
     DATA_SOURCE: 'DATA_SOURCE',
     MESSAGE_BASE: 'MESSAGE_',
     MESSAGE_CNT: 'MESSAGE_CNT',
-    PACKAGE_PROGRESS_BASE: 'PACKAGE_PROGRESS_',
+    ITEMS: 'ITEMS_',
     PACKAGE_CNT: 'PACKAGE_CNT',
     CLIENT_REQ: 'CLIENT_REQ',
     SERVER_REQ: 'SERVER_REQ',
@@ -372,7 +372,7 @@ export class BackgroundStatus {
      * @return {PackageProgress}
      */
     getPartProgress(i) {
-        var s= this.getParam(Keys.PACKAGE_PROGRESS_BASE+i);
+        var s= this.getParam(Keys.ITEMS+i);
         var retval= PackageProgress.parse(s);
         if (!retval) retval= new PackageProgress();
         return retval;
@@ -423,7 +423,7 @@ export class BackgroundStatus {
      * @param i
      */
     setPartProgress(progress, i) {
-        this.setParam(Keys.PACKAGE_PROGRESS_BASE+i,progress.serialize());
+        this.setParam(Keys.ITEMS+i,progress.serialize());
     }
 
 

--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -82,7 +82,7 @@
  */
 
 /**
- * Background status of one job.  Packages info for this job are stored as PACKAGE_PROGRESS_n,
+ * Background status of one job.  Packages info for this job are stored as ITEMS_n,
  * where n is a sequential integer.
  * @typedef {Object.<string, PackageStatus>} BgStatus
  * @prop {string} TYPE  type of job.  ie. 'PACKAGE'
@@ -96,7 +96,7 @@
  */
 
 /**
- * Background status of one job.  Packages info for this job are stored as PACKAGE_PROGRESS_n,
+ * Background status of one job.  Packages info for this job are stored as ITEMS_n,
  * where n is a sequential integer.
  * @typedef {Object} PackageStatus
  * @prop {number} processedBytes  type of job.  ie. 'PACKAGE'

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -542,7 +542,7 @@ export function isTableLoaded(tableModel) {
 export function smartMerge(target, source) {
     if (!target) return source;
 
-    if (isPlainObject(source)) {
+    if (isPlainObject(source) && isPlainObject(target)) {
         const objChanges = {};
         Object.keys(source).forEach((k) => {
             const nval = smartMerge(target[k], source[k]);
@@ -551,7 +551,7 @@ export function smartMerge(target, source) {
             }
         });
         return (isEmpty(objChanges)) ? target : Object.assign({}, target, objChanges);
-    } else if (isArray(source)){
+    } else if (isArray(source) && isArray(target)){
         const aryChanges = [];
         source.forEach((v, idx) => {
             const nval = smartMerge(target[idx], source[idx]);

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -14,7 +14,7 @@ import {LsstSdssSettingBox, lsstSdssOnNewRawTable, lsstSdssOnFieldUpdate, lsstSd
 import {DefaultSettingBox, defaultOnNewRawTable, defaultOnFieldUpdate, defaultRawTableRequest} from './generic/DefaultMissionOptions.js';
 import {BasicSettingBox, basicOnNewRawTable, basicOnFieldUpdate, basicRawTableRequest, imagesShouldBeDisplayed} from './basic/BasicMissionOptions.js';
 import {WiseSettingBox, wiseOnNewRawTable, wiseOnFieldUpdate, wiseRawTableRequest,isValidWiseTable} from './wise/WiseMissionOptions.js';
-import {PTFSettingBox, ptfOnNewRawTable, ptfOnFieldUpdate, ptfRawTableRequest,isValidPTFTable} from './ptf/PTFMissionOptions.js';
+import {PTFSettingBox, ptfOnNewRawTable, ptfOnFieldUpdate, ptfRawTableRequest, isValidPTFTable, ptfDownloaderOptPanel} from './PTF/PTFMissionOptions.js';
 
 import {LC} from './LcManager.js';
 
@@ -70,6 +70,7 @@ export const coordSysOptions = 'coordSysOptions';
  * @prop {boolean} shouldImagesBeDisplayed a function that return true if user inputs make sense to the mission
  *                  to show images
  * @prop {function} isTableUploadValid - check table on upload if make sens with mission selected
+ * @prop {function} downloadOptions - return the option panel for download dialog
  */
 
 /**
@@ -132,6 +133,7 @@ const converters = {
         webplotRequestCreator: getWebPlotRequestViaPTFIbe,
         shouldImagesBeDisplayed: () => {return true;},
         isTableUploadValid:isValidPTFTable,
+        downloadOptions: ptfDownloaderOptPanel,
         yNamesChangeImage: [],
         showPlotTitle:getPlotTitle
     },

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -130,9 +130,9 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
     const cutoutSizeInDeg = (convertAngle('arcmin','deg', cutoutSize)).toString();
 
 
-    let downloaderOptPanel = (m, c) => {
-        return convertData.downloadOptions(m, c)
-    };
+    // let downloaderOptPanel = (m, c) => {
+    //     return convertData.downloadOptions(m, c)
+    // };
 
     const defaultOptPanel = (m, c) => {
         return (
@@ -159,9 +159,10 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
         )
     };
 
-    if(!convertData.downloadOptions){
-        downloaderOptPanel = defaultOptPanel;
-    }
+    const downloaderOptPanel = convertData.downloadOptions || defaultOptPanel;
+    // if(!convertData.downloadOptions){
+    //     downloaderOptPanel = defaultOptPanel;
+    // }
 
     let tsView = (err) => {
 

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -129,11 +129,6 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
     // convert the default Cutout size in arcmin to deg for WebPlotRequest, expected to be string in download panel
     const cutoutSizeInDeg = (convertAngle('arcmin','deg', cutoutSize)).toString();
 
-
-    // let downloaderOptPanel = (m, c) => {
-    //     return convertData.downloadOptions(m, c)
-    // };
-
     const defaultOptPanel = (m, c) => {
         return (
             <DownloadButton>
@@ -160,9 +155,6 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
     };
 
     const downloaderOptPanel = convertData.downloadOptions || defaultOptPanel;
-    // if(!convertData.downloadOptions){
-    //     downloaderOptPanel = defaultOptPanel;
-    // }
 
     let tsView = (err) => {
 

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -6,6 +6,8 @@ import {makeFileRequest, getCellValue, getTblById, getColumnIdx, smartMerge, get
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
+import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
+import {ValidationField} from '../../../ui/ValidationField.jsx';
 
 
 const labelWidth = 80;
@@ -151,3 +153,38 @@ export function ptfOnFieldUpdate(fieldKey, value) {
 
 }
 
+/**
+ *
+ * Gets the download option panel for PTF with specific file processor id 'PtfDownload'
+ * @param mission
+ * @param cutoutSizeInDeg
+ * @returns {XML}
+ */
+export function ptfDownloaderOptPanel (mission, cutoutSizeInDeg) {
+
+    return (
+        <DownloadButton>
+            <DownloadOptionPanel
+                cutoutSize={cutoutSizeInDeg}
+                title={'Image Download Option'}
+                dlParams={{
+                    MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
+                    FilePrefix: `${mission}_Files`,
+                    BaseFileName: `${mission}_Files`,
+                    DataSource: `${mission} images`,
+                    FileGroupProcessor: 'PtfLcDownload',
+                    ProductLevel:'l1',
+                    schema:'images',
+                    table:'level1'
+                }}>
+                <ValidationField
+                    initialState={{
+                        value: 'A sample download',
+                        label: 'Title for this download:'
+                    }}
+                    fieldKey='Title'
+                    labelWidth={110}/>
+            </DownloadOptionPanel>
+        </DownloadButton>
+    );
+}

--- a/src/firefly/js/templates/lightcurve/ptf/PTFPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFPlotRequests.js
@@ -12,30 +12,6 @@ import {ERROR_MSG_KEY} from '../generic/errorMsg.js';
 import {addCommonReqParams} from '../LcConverterFactory.js';
 import {convertAngle} from '../../../visualize/VisUtil.js';
 
-export function makePTFPlotRequest(table, rowIdx, cutoutSize) {
-    const ra = getCellValue(table, rowIdx, 'ra');
-    const dec = getCellValue(table, rowIdx, 'dec');
-    const pid = getCellValue(table, rowIdx, 'pid');
-    const band = 'g';
-
-    // convert the default Cutout size in arcmin to deg for WebPlotRequest
-    const cutoutSizeInDeg = convertAngle('arcmin','deg', cutoutSize);
-
-    //http://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1?where=pid=16406820
-
-    const ibeserverinfo = 'http://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1?';
-
-    const dataserverinfo = 'http://irsatest.ipac.caltech.edu/ibe/data/ptf/images/level1/';
-    const pfilename = 'proc/2013/06/16/f2/c4/p5/v1/PTF_201306163445_i_p_scie_t081605_u016406820_f02_p005137_c04.fits';
-    const centerandsize = cutoutSize ? `?center=${ra},${dec}&size=${cutoutSizeInDeg}&gzip=false` : '';
-    const url = `${dataserverinfo}${pfilename}/${centerandsize}`;
-    const plot_desc = `PTF-${pid}`;
-    const reqParams = WebPlotRequest.makeURLPlotRequest(url, plot_desc);
-    const title = 'PTF-' + pid + (cutoutSize ? ` size: ${cutoutSize}(arcmin)` : '');
-    return addCommonReqParams(reqParams, title, makeWorldPt(ra, dec, CoordinateSys.EQ_J2000));
-}
-
-//TODO to be implemented
 /**
  *
  * @param tableModel
@@ -58,28 +34,22 @@ export function getWebPlotRequestViaPTFIbe(tableModel, hlrow, cutoutSize, params
     // convert the default Cutout size in arcmin to deg for WebPlotRequest
     const cutoutSizeInDeg = convertAngle('arcmin','deg', cutoutSize);
 
-    // pfilename should be resolved using PtfibeResolver by ej
-    // PtfIbeResolver res = new PtfIbeResolver();
-    // String fs = res.getValuesFromColumn(pids, "pfilename");
-
-    const pfilename = 'proc/2013/06/16/f2/c4/p5/v1/PTF_201306163445_i_p_scie_t081605_u016406820_f02_p005137_c04.fits';
     try {
 
         // flux/value column control this | unless UI has radio button band enabled, put bandName back here to match band
         const band = `${params.bandName}`;
-        var tmpId = pid;
 
-        let title = 'PTF-W' + band + '-' + tmpId;
+        let title = 'PTF-W' + band + '-' + pid;
 
         const sr = new ServerRequest('ibe_file_retrieve');
         sr.setParam('mission', 'ptf');
         sr.setParam('PROC_ID', 'ibe_file_retrieve');
-        sr.setParam('schema', 'images');
+        sr.setParam('ProductLevel', 'l1');
         sr.setParam('table', 'level1');
-        sr.setParam('pfilename', `${pfilename}`);
-        //  sr.setParam('pfilename', `${fs}`);
+        sr.setParam('schema', 'images');
+        sr.setParam('pid', pid);
 
-        var wp = null;
+        let wp = null;
         sr.setParam('doCutout', 'false');
         if (!isNil(ra) && !isNil(dec)) {
             sr.setParam('center', `${ra},${dec}`);

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -160,3 +160,26 @@ export function wiseOnFieldUpdate(fieldKey, value) {
         return {[fieldKey]: value};
     }
 }
+
+export function wiseDowloadOptionPanel (mission, cutoutSizeInDeg){
+    return (
+        <DownloadOptionPanel
+            cutoutSize={cutoutSizeInDeg}
+            title={'Image Download Option'}
+            dlParams={{
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'LightCurveFileGroupsProcessor'
+            }}>
+            <ValidationField
+                initialState={{
+                    value: 'A sample download',
+                    label: 'Title for this download:'
+                }}
+                fieldKey='Title'
+                labelWidth={110}/>
+        </DownloadOptionPanel>
+    );
+}

--- a/src/firefly/js/ui/ScriptDownloadDialog.jsx
+++ b/src/firefly/js/ui/ScriptDownloadDialog.jsx
@@ -15,6 +15,7 @@ import {FieldGroup} from './FieldGroup.jsx';
 import {ListBoxInputField} from './ListBoxInputField.jsx';
 import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
 import FieldGroupUtils from '../fieldGroup/FieldGroupUtils.js';
+import {SCRIPT_ATTRIB} from '../core/background/BackgroundUtil.js';
 
 
 const SCRIPT_DOWNLOAD_ID = 'Download Retrieval Script';
@@ -62,7 +63,7 @@ class ScripDownloadPanel extends PureComponent {
 
     onSubmit(request) {
         const {ID, Title, DATA_SOURCE} = this.props;
-        const attributes = Object.values(request).filter((v) => v && v !== '-');
+        const attributes = Object.values(request).filter((v) => SCRIPT_ATTRIB.get(String(v)));
         createDownloadScript(ID, Title.replace(/\s/g, '_'), DATA_SOURCE, attributes)
             .then((url) => {
                 download(url);

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/PtfIbeTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/PtfIbeTest.java
@@ -1,0 +1,76 @@
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.query.ptf.PtfFileRetrieve;
+import edu.caltech.ipac.firefly.server.query.ptf.PtfIbeResolver;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Created by ejoliet on 7/20/17.
+ */
+public class PtfIbeTest extends ConfigTest {
+
+    @Before
+    public void setUp() {
+
+        PtfIbeResolver.isTestMode = true;
+    }
+
+    @Test
+    public void testPid2FilenameResolver() throws IOException, InterruptedException {
+
+        long[] pids = new long[]{16406820, 16406821};
+        File f = File.createTempFile("tmp", ".tbl", new File("."));
+        f.deleteOnExit();
+        PtfIbeResolver res = new PtfIbeResolver() {
+            /**
+             * @return
+             * @throws IOException
+             */
+            protected File getTempFile() throws IOException {
+                return f;
+            }
+        };
+        String[] fs = res.getValuesFromColumn(pids, "pfilename");
+
+        Assert.assertTrue(fs.length == pids.length);
+
+    }
+
+
+    @Test
+    public void testPtfFileRetrive() throws IOException, DataAccessException {
+
+        ServerRequest sr = new ServerRequest("PtfFileRetrieve");
+        sr.setParam("mission", "ptf");
+        sr.setParam("pid", "16406820");
+        sr.setParam("schema", "images");
+        sr.setParam("table", "level1");
+        sr.setParam("ProductLevel", "l1");
+        sr.setParam("ra_obj", "341.9706450");
+        sr.setParam("dec_obj", "65.0620120");
+
+        URL res = new PtfFileRetrieve().getURL(sr);
+
+        LOG.debug(res.toString());
+        Assert.assertTrue(new URL("https://irsa.ipac.caltech.edu/ibe/data/ptf/images/level1/proc/2013/06/16/f2/c4/p5/v1/PTF_201306163445_i_p_scie_t081605_u016406820_f02_p005137_c04.fits").
+                equals(res));
+
+
+        sr.setParam("doCutout", "cut");
+        sr.setParam("subsize", "0.083333");
+
+        res = new PtfFileRetrieve().getURL(sr);
+
+        LOG.debug(res.toString());
+        Assert.assertTrue(new URL("https://irsa.ipac.caltech.edu/ibe/data/ptf/images/level1/proc/2013/06/16/f2/c4/p5/v1/PTF_201306163445_i_p_scie_t081605_u016406820_f02_p005137_c04.fits?center=341.9706450,65.0620120&size=0.083333&gzip=false").
+                equals(res));
+    }
+}


### PR DESCRIPTION
This pull request combined 2 tickets IRSA-629 and 630.

One (IRSA-629) causes other one (IRSA-630): in order to get a different download processor (other than the current fixed one for WISE), i have introduced a function to deal with it in the UI form the converter factory.
Then i have added a specific server-side processor to package the files to be downloaded with the help of Wei's ticket (IRSA-514). Firefly has IBE for PTF included now. 

There is a current issue with the background monitor (@loi will fix it soon), once is fixed, the test should be going to the Timeseries tool and upload a LC for PTF, then select any row of the table and download the file(s) to test.