### PR TITLE
DM-11299 Coadded images displayed ignoring cutout size

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTImageSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTImageSearch.java
@@ -79,14 +79,20 @@ public class LSSTImageSearch extends URLFileInfoProcessor {
             }
         }
 
-        String imageType = request.getParam("imageType"); // calexp
-        if (!imageType.equals("calexp")) {
-            throw new DataAccessException("Only calexp cutouts are supported at the moment");
-        }
-        String imageId = request.getParam("imageId");
-
+        String imageType = request.getParam("imageType"); // calexp or coadd
         double subsizeArcSec = MathUtil.convert(MathUtil.Units.DEGREE, MathUtil.Units.ARCSEC, request.getDoubleParam("subsize"));
-        return new URL(DAX_URL+imageType+"/"+imageId+"/cutout?ra="+ra+"&dec="+dec+"&widthAng="+subsizeArcSec+"&heightAng="+subsizeArcSec);
+        if (imageType.equals("calexp")) {
+            String imageId = request.getParam("imageId");
+            // width and height in arcseconds
+            return new URL(DAX_URL+imageType+"/"+imageId+"/cutout?ra="+ra+"&dec="+dec+"&widthAng="+subsizeArcSec+"&heightAng="+subsizeArcSec);
+        } else {
+            // coadd
+            String filterName = request.getParam("filterName");
+            // width and height in arcseconds, for pixels use cutoutPixel instead of cutout
+            return new URL(DAX_URL+imageType+"/cutout?ra="+ra+"&dec="+dec+"&filter="+filterName+"&width="+subsizeArcSec+"&height="+subsizeArcSec);
+        }
+
+
     }
 
     private void validateRequiredParams(ServerRequest request, String [] requiredParams) throws DataAccessException {

--- a/src/firefly/js/metaConvert/LsstSdssRequestList.js
+++ b/src/firefly/js/metaConvert/LsstSdssRequestList.js
@@ -51,7 +51,7 @@ function makeCcdReqBuilder(table, rowIdx) {
     sr.setParam('run', `${run}`);
     sr.setParam('camcol', `${camcol}`);
     sr.setParam('field', `${field}`);
-    if (subsize) {
+    if (subsize && subsize>0) {
         sr.setParam('subsize', `${subsize}`);
         sr.setParam([ServerParams.USER_TARGET_WORLD_PT], get(table, ['request', [ServerParams.USER_TARGET_WORLD_PT]]));
         sr.setParam('imageId', getCellValue(table, rowIdx, 'scienceCcdExposureId'));
@@ -83,7 +83,7 @@ function makeCoaddReqBuilder(table, rowIdx) {
     const sr= new ServerRequest('LSSTImageSearch');
     sr.setParam('tract', `${tract}`);
     sr.setParam('patch', `${patch}`);
-    if (subsize) {
+    if (subsize && subsize>0) {
         sr.setParam('subsize', `${subsize}`);
         sr.setParam([ServerParams.USER_TARGET_WORLD_PT], get(table, ['request', [ServerParams.USER_TARGET_WORLD_PT]]));
         sr.setParam('imageId', getCellValue(table, rowIdx, 'deepCoaddId'));

--- a/src/firefly/js/metaConvert/LsstSdssRequestList.js
+++ b/src/firefly/js/metaConvert/LsstSdssRequestList.js
@@ -74,7 +74,7 @@ function makeCcdReqBuilder(table, rowIdx) {
  * @param rowIdx - {int}
  * @returns {Function}
  */
-function makeCoadReqBuilder(table, rowIdx) {
+function makeCoaddReqBuilder(table, rowIdx) {
 
     const tract= getCellValue(table, rowIdx, 'tract');
     const patch= getCellValue(table, rowIdx, 'patch');
@@ -117,7 +117,7 @@ export function makeLsstSdssPlotRequest(table, row, includeSingle, includeStanda
         id= Number(getCellValue(table, row, 'scienceCcdExposureId'));
     }
     else {
-        builder= makeCoadReqBuilder(table, row);
+        builder= makeCoaddReqBuilder(table, row);
         const deepCoaddId= Number(getCellValue(table, row, 'deepCoaddId'));
         id = deepCoaddId - deepCoaddId%8;
 

--- a/src/firefly/js/metaConvert/WiseRequestList.js
+++ b/src/firefly/js/metaConvert/WiseRequestList.js
@@ -35,7 +35,7 @@ export function makeWisePlotRequest(table, row, includeSingle, includeStandard, 
         const req= svcBuilder(plotId, reqKey, title, rowNum, extraParams);
         req.setPreferenceColorKey('wise-color-pref');
         const subsize = get(table, 'request.subsize');
-        if (subsize) {
+        if (subsize && subsize>0) {
             const {UserTargetWorldPt, sizeUnit} = get(table, 'request', {});
             if (UserTargetWorldPt && sizeUnit) {
                 const wp = parseWorldPt(UserTargetWorldPt);

--- a/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
@@ -57,7 +57,8 @@ export function getWebPlotRequestViaWISEIbe(tableModel, hlrow, cutoutSize, param
     dataSource: 'frame_id'
 }) {
     const ra = getCellValue(tableModel, hlrow, 'ra');
-    const dec = getCellValue(tableModel, hlrow, 'dec');
+    const dec = getCellValue(tableModel, hlrow, 'dec') || getCellValue(tableModel, hlrow, 'decl'); // LSST WISE convention is 'decl'
+
 
     //For images from AllWise:
     const frameId = getCellValue(tableModel, hlrow, 'frame_id');

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -200,7 +200,8 @@ function radiusInField({label = 'Radius:'}) {
                          wrapperStyle={{padding:5, margin: '5px 0 5px 0'}}
                          initialState={{
                                                unit: 'arcsec',
-                                               labelWidth : 100
+                                               labelWidth : 100,
+                                               nullAllowed: false
                                            }}
                          label={label}/>
     );

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -399,11 +399,6 @@ function doImage(request, imgPart) {
         title += `([${loc}])`;
     }
 
-    //TODO: remove when cutouts are supported for deepCoadd
-    if (subsize && cattable === 'DeepCooad') {
-        subsize = undefined;
-    }
-
     var tReq = makeLsstCatalogRequest(title, projectName, database, cattable,
                                       {[ServerParams.USER_TARGET_WORLD_PT]: wp,
                                        intersect,

--- a/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
+++ b/src/firefly/js/visualize/ui/LSSTImageSpatialType.jsx
@@ -98,7 +98,8 @@ function renderSearchRegion(visible) {
                                            tooltip: 'Please select an option',
                                            unit: 'arcsec',
                                            min:  1/3600,
-                                           max:  43200/3600
+                                           max:  43200/3600,
+                                           nullAllowed: false
                                  }}
                          label='Search Region (Square) Size:' />
     );
@@ -118,7 +119,8 @@ function renderImageSize(visible, disable) {
                                            tooltip: 'Please select an option',
                                            unit: 'arcsec',
                                            min:  1/3600,
-                                           max:  7200/3600
+                                           max:  7200/3600,
+                                           nullAllowed: true
                                         }}
                         label='Return Image Size (leave blank for full images):'
                         />


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-11299

This is continuation of Cindy's work on WISE cutouts
- when subsize is present in request, we assume that the image is cutout for both WISE and LSST.
- When cutouts are requested for LSST deepCoadd images, I_16 of [ImageServ API](https://confluence.lsstcorp.org/pages/viewpage.action?pageId=54854064) is called.
Unfortunately, the code should be fixed on DAX side. At the moment we get HTTP 404 Not Found for band 'r' and HTTP 502 Bad Gateway fro other bands. Test target 9.6 -1.1 

Known issues:
- I_16 of [ImageServ API](https://confluence.lsstcorp.org/pages/viewpage.action?pageId=54854064) produces error (LDSS SDSS deepCoadd image cutouts)
- Spinning wheel on table fetch error (addressed in another [pr-422](https://github.com/Caltech-IPAC/firefly/pull/422))
- Invalid cutout size (while being visually distinct) does not stop search. The issues with SizeInputField validation are addressed by DM-11386
- When searching WISE Images for cryo (only 3 bands available) or post-cryo (only 2 bands available), we still show 4 image widgets, unavailable images with 'Failed- Not Found' message. Example: WISE Images 3-band cryo for 'm1'.

More details about the first item:

The call for LSST SDSS cutouts produces an error on the DAX side. To test try

`curl -v -o band_i 'http://lsst-qserv-dax01.ncsa.illinois.edu:5000/image/v0/deepCoadd/cutout?ra=9.6&dec=-1.1&filter=i&width=5.0&height=5.0'`

`curl -v -o band_r 'http://lsst-qserv-dax01.ncsa.illinois.edu:5000/image/v0/deepCoadd/cutout?ra=9.6&dec=-1.1&filter=r&width=5.0&height=5.0'`

The content of band_i and band_r is different. The last one contains 'Image Not Found'. Also, I can see `HTTP/1.1 502 Bad Gateway` in the headers of the first request and `HTTP/1.1 404 NOT FOUND` in the headers of the second.

DM team is working to find a resolution of this issue