### PR TITLE
DM-11398: fixes some time series display issues

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
+++ b/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import {get} from 'lodash';
 import BrowserInfo from '../../util/BrowserInfo.js';
 import {getPlotViewById, getAllDrawLayersForPlot} from '../../visualize/PlotViewUtil.js';
-import {WcsMatchType, visRoot, dispatchWcsMatch} from '../../visualize/ImagePlotCntlr.js';
+import {WcsMatchType, visRoot, dispatchWcsMatch, dispatchRecenter} from '../../visualize/ImagePlotCntlr.js';
 import {VisInlineToolbarView} from '../../visualize/ui/VisInlineToolbarView.jsx';
 import {RadioGroupInputFieldView} from '../../ui/RadioGroupInputFieldView.jsx';
 import {dispatchChangeViewerLayout, getViewer, getMultiViewRoot, GRID, SINGLE} from '../../visualize/MultiViewCntlr.js';
@@ -116,9 +116,12 @@ export function LcImageToolbarView({activePlotId, viewerId, viewerPlotIds, layou
 
 
 function changeSize(viewerId, value) {
-    value= Number(value);
-    dispatchChangeViewerLayout(viewerId, value === 1 ? SINGLE : GRID, {count:value});
+    value = Number(value);
+    dispatchChangeViewerLayout(viewerId, value === 1 ? SINGLE : GRID, {count: value});
+    const vr = visRoot();
+    return setTimeout(() => dispatchRecenter({plotId: vr.activePlotId}), 1000);
 }
+
 
 // <ImagePager pageSize={10} tbl_id={tableId} />
 // <ToolbarButton icon={ONE} tip={'Show single image at full size'}

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -667,7 +667,14 @@ export function setupImages(layoutInfo) {
     const viewer = getViewer(getMultiViewRoot(), LC.IMG_VIEWER_ID);
     const count = get(viewer, 'layoutDetail.count', converterData.defaultImageCount);
 
+
     var vr = visRoot();
+
+    if (plotIdRoot+tableModel.highlightedRow===vr.activePlotId && count===get(viewer,'itemIdAry', []).length) {
+        return;
+    }
+
+
     const hasPlots = vr.plotViewAry.length > 0;
     const newPlotIdAry = makePlotIds(tableModel.highlightedRow, tableModel.totalRows, count);
     const maxPlotIdAry = makePlotIds(tableModel.highlightedRow, tableModel.totalRows, LC.MAX_IMAGE_CNT);

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -512,7 +512,7 @@ export function dispatchProcessScroll({plotId,scrollPt, disableBoundCheck=false,
  * Note - function parameter is a single object
  * @param {Object}  p
  * @param {string} p.plotId
- * @param {Point} p.centerPt Point to center on
+ * @param {Point} [p.centerPt] Point to center on
  * @param {boolean} p.centerOnImage only used if centerPt is not defined.  If true then the centering will be
  *                                  the center of the image.  If false, then the center point will be the
  *                                  FIXED_TARGET attribute, if defined. Otherwise it will be the center of the image.
@@ -522,7 +522,7 @@ export function dispatchProcessScroll({plotId,scrollPt, disableBoundCheck=false,
  * @function dispatchRecenter
  * @memberof firefly.action
  */
-export function dispatchRecenter({plotId, centerPt, centerOnImage, dispatcher= flux.process}) {
+export function dispatchRecenter({plotId, centerPt= undefined, centerOnImage=false, dispatcher= flux.process}) {
     dispatcher({type: RECENTER, payload: {plotId, centerPt, centerOnImage} });
 }
 


### PR DESCRIPTION
    - when a image is clicked on, it will not longer jump to the center
    - when the number of images are changeed then the images will
      recenter

_to test:_

 - bring a time series up and change the number of images, they should recenter.
 - click on an image, it should not jump to the center. However, everything else should work as before.