### PR TITLE
IRSA-503:Migrated Finderchart needs a control button to switch from table view to chart view and vice-versa

### DIFF
--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -145,31 +145,32 @@ BannerSection.propTypes = {
 
 function ResultSection({layoutInfo}) {
     const {currentSearch, images} = layoutInfo;
-    const {expanded=LO_VIEW.none, closeable} = layoutInfo.mode || {};
+    const {expanded=LO_VIEW.none} = layoutInfo.mode || {};
 
     const {allSearchItems} = getSearchInfo();
     if (!allSearchItems) return <div/>;
     const {results} = allSearchItems[currentSearch] || {};
     const standard = results ? results(layoutInfo) : <div/>;
 
-    return expanded === LO_VIEW.none ? standard : <ExpandedView {...{expanded, closeable, images}}/>;
+    return expanded === LO_VIEW.none ? standard : <ExpandedView {...{expanded, images}}/>;
 }
 
-function ExpandedView ({expanded, closeable,  images}) {
+function ExpandedView ({expanded,  images}) {
+
     var view;
     if (expanded === LO_VIEW.tables) {
         view = (<TablesContainer mode='both'
-                         closeable={closeable}
+                         closeable={true}
                          expandedMode={expanded===LO_VIEW.tables}
                          tableOptions={{help_id:'main1TSV.table'}}/>
                 );
     } else if (expanded === LO_VIEW.xyPlots) {
-        view = (<ChartsContainer closeable={closeable}
+        view = (<ChartsContainer closeable={true}
                          expandedMode={expanded===LO_VIEW.xyPlots}/>
                 );
     } else {
         view = (<TriViewImageSection key='res-tri-img'
-                         closeable={closeable}
+                         closeable={true}
                          imageExpandedMode={expanded===LO_VIEW.images}
                          {...images}  />
                 );


### PR DESCRIPTION
Part of the branch implementation was about fixing a bug in HydraViewer.jsx.  The closable is not defined in the layout mode. Thus, the closable is always no defined.
  However it is used in all three contaniners as closable={closeable}.  Since the closeable is always undefined, it caused the
  the xyPlot's, imagePlots, the close button was gone.

The other part is done in IFE.