### PR TITLE
IRSA-685 img tile reorder

### DIFF
--- a/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
@@ -35,7 +35,7 @@ function ExpandedOptionsPanel ({plotViewAry}) {
     const expandedIds= getExpandedViewerItemIds(getMultiViewRoot());
     var enabledStr= loadedPv.reduce( (s,pv) => {
         if (!expandedIds.includes(pv.plotId)) return s;
-        return s ? `${s},${pv.plotId}` : pv.plotId;
+        return s ? `${pv.plotId},${s}` : pv.plotId;
     },'');
 
     return (


### PR DESCRIPTION
Tile reordered fixed. See IRSA-685. This is a fix in RC.

Please, have a look by testing demo/ffapi-highlevel-test.html to open a couple of images in tri-view and see that when bringing the list of images, the order doesn't change. 
Thanks!