### PR TITLE
IRSA-689: Time Series Viewer Prepare Download doesn’t send to Background Monitor

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -85,9 +85,10 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
             if (pidstr != null) {
                 try {
                     pfilename = new PtfIbeResolver().getListPfilenames(new long[]{pid})[0];
-                } catch (InterruptedException e) {
-                    //PID didn't work
-                    throw new DataAccessException("PID " + pid + " didn't give any result ", e);
+                } catch (Exception e) {
+                    //PID didn't work, swallow it
+                    logger.briefInfo("PID " + pid + " didn't give any result ");
+                    continue;
                 }
             } else {
                 pfilename = (String) dgData.get(rowIdx, "pfilename");

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -8,6 +8,7 @@ import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fi
 import {LC} from '../LcManager.js';
 import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
 import {ValidationField} from '../../../ui/ValidationField.jsx';
+import {DL_DATA_TAG} from '../LcConverterFactory.js';
 
 
 const labelWidth = 80;
@@ -158,6 +159,7 @@ export function ptfDownloaderOptPanel (mission, cutoutSizeInDeg) {
     return (
         <DownloadButton>
             <DownloadOptionPanel
+                dataTag = {DL_DATA_TAG}
                 cutoutSize={cutoutSizeInDeg}
                 title={'Image Download Option'}
                 dlParams={{

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -6,6 +6,7 @@ import {makeFileRequest, getCellValue, getTblById, getColumnIdx, smartMerge, get
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
+import {DL_DATA_TAG} from '../LcConverterFactory.js';
 
 
 const labelWidth = 80;
@@ -164,6 +165,7 @@ export function wiseOnFieldUpdate(fieldKey, value) {
 export function wiseDowloadOptionPanel (mission, cutoutSizeInDeg){
     return (
         <DownloadOptionPanel
+            dataTag = {DL_DATA_TAG}
             cutoutSize={cutoutSizeInDeg}
             title={'Image Download Option'}
             dlParams={{


### PR DESCRIPTION
https://caltech-ipac.atlassian.net/browse/IRSA-689

To test:
- build irsaviewer then goto http://localhost:8080/irsaviewer/timeseries
- use a wise time series file or the ptf file in the ticket.
- select all then download.

wise should work.  ptf fail for me.  I got an unhandled exception.
But, both were added to background monitor as it should be.
@ejoliet, you should have someone look at the exception below.  It should not happen.

```
java.lang.ArrayIndexOutOfBoundsException: 0
	at edu.caltech.ipac.firefly.server.query.lc.PtfFileGroupsProcessor.computeFileGroup(PtfFileGroupsProcessor.java:87)
	at edu.caltech.ipac.firefly.server.query.lc.PtfFileGroupsProcessor.loadData(PtfFileGroupsProcessor.java:41)
	at edu.caltech.ipac.firefly.server.query.FileGroupsProcessor.getData(FileGroupsProcessor.java:48)
	at edu.caltech.ipac.firefly.server.query.FileGroupsProcessor.getData(FileGroupsProcessor.java:33)
	at edu.caltech.ipac.firefly.server.packagedata.PackageMaster$PackagingWorker.work(PackageMaster.java:229)
	at edu.caltech.ipac.firefly.server.query.BackgroundEnv$BackgroundProcessor.run(BackgroundEnv.java:532)
	at java.lang.Thread.run(Thread.java:745)

```