### PR TITLE
IRSA_672: improve image lable for plot title inline

### DIFF
--- a/src/firefly/js/visualize/iv/PlotTitle.css
+++ b/src/firefly/js/visualize/iv/PlotTitle.css
@@ -11,10 +11,13 @@
     padding : 0 5px 0 2px;
     /*color : white;*/
     background : #e3e3e3;/*rgba(255,255,255,.2);*/
-    /*white-space : nowrap;*/
+    white-space : nowrap;
     font-size : 9pt;
     border-radius : 0 0 5px 0;
     line-height: normal;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
 }
 
 

--- a/src/firefly/js/visualize/iv/PlotTitle.css
+++ b/src/firefly/js/visualize/iv/PlotTitle.css
@@ -11,9 +11,10 @@
     padding : 0 5px 0 2px;
     /*color : white;*/
     background : #e3e3e3;/*rgba(255,255,255,.2);*/
-    white-space : nowrap;
+    /*white-space : nowrap;*/
     font-size : 9pt;
     border-radius : 0 0 5px 0;
+    line-height: normal;
 }
 
 


### PR DESCRIPTION
Improve image title label by changing the line height (css). 
This is also solving the problem that in smaller screen, the zoom level wasn't shown. 

Check that it doesn't break anything.