### PR TITLE
DM-11547: dockerize apache https proxy.

### DIFF
--- a/buildScript/depends.gincl
+++ b/buildScript/depends.gincl
@@ -184,13 +184,16 @@ task dockerImage (dependsOn: loadConfig) {
   ext.docker_repo = "ipac/firefly"
   ext.docker_registry = ''
   ext.docker_tag = 'latest'
+  ext.copy_res = true
 
   doLast {
     // copy artifacts to staging directory
-    copy {
-      from ("${project.distDir}") { include '*.war' }
-      from ("${fireflyPath}/docker/base") { include '*' }
-      into "${buildDir}/docker"
+    if (copy_res) {
+      copy {
+        from ("${project.distDir}") { include '*.war' }
+        from ("${fireflyPath}/docker/base") { include '*' }
+        into "${buildDir}/docker"
+      }
     }
 
     try {
@@ -286,6 +289,13 @@ ext.NODE = { ...cmd ->
     environment 'WP_BUILD_DIR': wpBuildDir
     environment 'NODE_ENV': (project.env == 'local' ? 'development' : 'production')
     commandLine cmd
+    for (String key : project.appConfigProps.keySet()) {
+      if (key.startsWith('__$')) {
+        environment (key, project.appConfigProps[key])
+        println ">>   " + key + " = " + project.appConfigProps[key]
+      }
+    }
+
   }
   return res;
 }

--- a/buildScript/gwt.gincl
+++ b/buildScript/gwt.gincl
@@ -25,7 +25,7 @@ task gwtCompile (type: JavaExec, dependsOn: [gwt, loadConfig]) {
   group = "Build"
 
   outputs.upToDateWhen { false }
-  inputs.source sourceSets.main.java.srcDirs
+  inputs.file sourceSets.main.java.srcDirs
   inputs.dir sourceSets.main.output.resourcesDir
   outputs.dir gwt.buildDir
 
@@ -90,7 +90,7 @@ task gwtRun (type: JavaExec, dependsOn: [gwt, loadConfig]) {
   description= 'GWT DevMode'
   group = MISC_GROUP
 
-  inputs.source sourceSets.main.java.srcDirs
+  inputs.file sourceSets.main.java.srcDirs
   inputs.dir sourceSets.main.output.resourcesDir
 
   main = 'com.google.gwt.dev.DevMode'
@@ -134,7 +134,7 @@ task gwtSuperDev (type: JavaExec, dependsOn: [gwt, loadConfig]) {
   description= 'GWT SuperDev Mode'
   group = MISC_GROUP
 
-  inputs.source sourceSets.main.java.srcDirs
+  inputs.file sourceSets.main.java.srcDirs
   inputs.dir sourceSets.main.output.resourcesDir
 
   main = 'com.google.gwt.dev.codeserver.CodeServer'

--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -30,12 +30,14 @@ configurations {
   }
 }
 
-task jsTest (dependsOn: [loadConfig]) << {
-  if (file("package.json").exists()) {
-    println ">> running JavaScript test..."
-    def res = project.ext.NODE 'yarn', 'run', 'test-unit'
-    if (res.getExitValue() != 0) {
-      throw new GradleException("JavaScript test fail.")
+task jsTest (dependsOn: [loadConfig]) {
+  doLast {
+    if (file("package.json").exists()) {
+      println ">> running JavaScript test..."
+      def res = project.ext.NODE 'yarn', 'run', 'test-unit'
+      if (res.getExitValue() != 0) {
+        throw new GradleException("JavaScript test fail.")
+      }
     }
   }
 }
@@ -177,23 +179,25 @@ clean {
   delete "${war.destinationDir}/${webapp.baseWarName}.war"
 }
 
-task deploy (dependsOn: [loadConfig, webapp]) << {
+task deploy (dependsOn: [loadConfig, webapp]) {
   description= 'Deploy webapp(war file) to Tomcat.  Require ${tomcat_home} property'
   group = MAIN_GROUP
 
-  if (!project.hasProperty("tomcat_home")) {
-    throw ProjectConfigurationException("tomcat_home property is not found.")
-  }
-  if (!file("$war.destinationDir/${webapp.baseWarName}.war").exists()) {
-    println ">> ${webapp.baseWarName}.war not found.  Skipping deploy."
-    throw new StopExecutionException("${webapp.baseWarName}.war not found.  Skipping deploy.")
-  }
+  doLast {
+    if (!project.hasProperty("tomcat_home")) {
+      throw ProjectConfigurationException("tomcat_home property is not found.")
+    }
+    if (!file("$war.destinationDir/${webapp.baseWarName}.war").exists()) {
+      println ">> ${webapp.baseWarName}.war not found.  Skipping deploy."
+      throw new StopExecutionException("${webapp.baseWarName}.war not found.  Skipping deploy.")
+    }
 
-  copy {
-    println ">> deploying file:$war.destinationDir/${webapp.baseWarName}.war"
-    delete("$tomcat_home/webapps/${webapp.baseWarName}")
-    from("$war.destinationDir/${webapp.baseWarName}.war")
-    into "$tomcat_home/webapps/"
+    copy {
+      println ">> deploying file:$war.destinationDir/${webapp.baseWarName}.war"
+      delete("$tomcat_home/webapps/${webapp.baseWarName}")
+      from("$war.destinationDir/${webapp.baseWarName}.war")
+      into "$tomcat_home/webapps/"
+    }
   }
 }
 

--- a/config/common.prop
+++ b/config/common.prop
@@ -42,6 +42,7 @@ sso.server.url=@sso.server.url@
 sso.user.profile.url=@sso.user.profile.url@
 
 help.base.url=@help.base.url@
+__$help.base.url=@help.base.url@
 
 
 

--- a/docker/proxy-dev/Dockerfile
+++ b/docker/proxy-dev/Dockerfile
@@ -1,0 +1,26 @@
+FROM birgerk/apache-letsencrypt
+
+RUN apt-get update && \
+    apt-get -f --assume-yes install libapache2-mod-auth-openidc && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ./others/*.conf /etc/apache2/conf-enabled/
+
+RUN   a2enmod proxy; \
+      a2enmod proxy_http; \
+      a2enmod proxy_wstunnel; \
+      a2enmod auth_openidc
+
+RUN   mkdir /etc/apache2/certs; \
+      openssl req \
+            -new \
+            -newkey rsa:4096 \
+            -days 365 \
+            -nodes \
+            -x509 \
+            -subj "/C=US/ST=CA/L=dev/O=dev/CN=localhost" \
+            -keyout /etc/apache2/certs/localhost.key \
+            -out /etc/apache2/certs/localhost.cert
+
+
+EXPOSE 80 443

--- a/docker/proxy-dev/Dockerfile
+++ b/docker/proxy-dev/Dockerfile
@@ -2,6 +2,8 @@ FROM birgerk/apache-letsencrypt
 
 RUN apt-get update && \
     apt-get -f --assume-yes install libapache2-mod-auth-openidc && \
+    apt-get install wget && \
+    apt-get install telnet && \
     rm -rf /var/lib/apt/lists/*
 
 COPY ./others/*.conf /etc/apache2/conf-enabled/
@@ -24,3 +26,7 @@ RUN   mkdir /etc/apache2/certs; \
 
 
 EXPOSE 80 443
+
+# Default environment varibles.
+ENV docker_host=localhost
+ENV firefly_port=8080

--- a/docker/proxy-dev/build.gradle
+++ b/docker/proxy-dev/build.gradle
@@ -15,3 +15,10 @@ dockerImage {
     }
   }
 }
+
+// define some dummy values so that if you do not have them, apache would still start up.
+ext.appConfig = {
+  oidc_client_id = "dummy"
+  oidc_client_secret = "dummy"
+  oidc_redirect_uri = "https://dummy/"
+}

--- a/docker/proxy-dev/build.gradle
+++ b/docker/proxy-dev/build.gradle
@@ -1,0 +1,17 @@
+
+dockerImage {
+
+  docker_repo = "ipac/proxy-dev"
+  docker_registry = ''
+  docker_tag = 'latest'
+  copy_res = false
+
+  doFirst {
+    // copy artifacts to staging directory
+    copy {
+      from (projectDir) include '**/*'
+      into "${buildDir}/docker"
+      filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: project.appConfigProps)
+    }
+  }
+}

--- a/docker/proxy-dev/others/openid.conf
+++ b/docker/proxy-dev/others/openid.conf
@@ -1,0 +1,14 @@
+OIDCProviderMetadataURL https://test.cilogon.org/.well-known/openid-configuration
+OIDCClientID @oidc_client_id@
+OIDCClientSecret @oidc_client_secret@
+
+OIDCRedirectURI @oidc_redirect_uri@
+OIDCCryptoPassphrase pass357code
+
+OIDCScope "openid profile email org.cilogon.userinfo edu.uiuc.ncsa.myproxy.getcert"
+OIDCAuthNHeader X-Forwarded-User
+
+<Location /suit/>
+   AuthType openid-connect
+   Require claim "isMemberOf~.cn=lsst_users|cn=lsst_pdac"
+</Location>

--- a/docker/proxy-dev/others/proxy.conf
+++ b/docker/proxy-dev/others/proxy.conf
@@ -19,14 +19,14 @@ ProxyStatus On
 
 
 ## Hydra app for firefly
-ProxyPass         /firefly/sticky/firefly/events  ws://${docker_host}:8080/firefly/sticky/firefly/events
-ProxyPass         /firefly http://${docker_host}:8080/firefly
-ProxyPassReverse  /firefly http://${docker_host}:8080/firefly
+ProxyPass         /firefly/sticky/firefly/events  ws://${docker_host}:${firefly_port}/firefly/sticky/firefly/events
+ProxyPass         /firefly http://${docker_host}:${firefly_port}/firefly
+ProxyPassReverse  /firefly http://${docker_host}:${firefly_port}/firefly
 
 ## Hydra app for suit
-ProxyPass         /suit/sticky/firefly/events  ws://${docker_host}:8080/suit/sticky/firefly/events
-ProxyPass         /suit http://${docker_host}:8080/suit
-ProxyPassReverse  /suit http://${docker_host}:8080/suit
+ProxyPass         /suit/sticky/firefly/events  ws://${docker_host}:${firefly_port}/suit/sticky/firefly/events
+ProxyPass         /suit http://${docker_host}:${firefly_port}/suit
+ProxyPassReverse  /suit http://${docker_host}:${firefly_port}/suit
 
 
 ## end proxy config for Hydra support

--- a/docker/proxy-dev/others/proxy.conf
+++ b/docker/proxy-dev/others/proxy.conf
@@ -1,0 +1,35 @@
+# Load these modules if not already loaded
+<IfModule !proxy_module>
+    LoadModule proxy_module modules/mod_proxy.so
+</IfModule>
+<IfModule !proxy_http_module>
+    LoadModule proxy_http_module modules/mod_proxy_http.so
+</IfModule>
+<IfModule !proxy_wstunnel_module>
+    LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+</IfModule>
+<IfModule !rewrite_module>
+    LoadModule rewrite_module modules/mod_rewrite.so
+</IfModule>
+
+
+ProxyRequests Off
+ProxyPreserveHost On
+ProxyStatus On
+
+
+## Hydra app for firefly
+ProxyPass         /firefly/sticky/firefly/events  ws://${docker_host}:8080/firefly/sticky/firefly/events
+ProxyPass         /firefly http://${docker_host}:8080/firefly
+ProxyPassReverse  /firefly http://${docker_host}:8080/firefly
+
+## Hydra app for suit
+ProxyPass         /suit/sticky/firefly/events  ws://${docker_host}:8080/suit/sticky/firefly/events
+ProxyPass         /suit http://${docker_host}:8080/suit
+ProxyPassReverse  /suit http://${docker_host}:8080/suit
+
+
+## end proxy config for Hydra support
+
+
+

--- a/docker/proxy-dev/others/site.conf
+++ b/docker/proxy-dev/others/site.conf
@@ -1,0 +1,20 @@
+<VirtualHost *:80>
+  ServerName localhost
+
+</VirtualHost>
+
+<VirtualHost *:443>
+  ServerName localhost
+
+  SSLEngine on
+
+  SSLCertificateFile /etc/apache2/certs/localhost.cert
+  SSLCertificateKeyFile /etc/apache2/certs/localhost.key
+
+  RequestHeader set X-Forwarded-Proto "https"
+  RequestHeader set X-Forwarded-Port "443"
+  <FilesMatch "\.(cgi|shtml|phtml|php)$">
+     SSLOptions +StdEnvVars
+  </FilesMatch>
+
+</VirtualHost>

--- a/docker/proxy-dev/proxyctl.sh
+++ b/docker/proxy-dev/proxyctl.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+case "$1" in
+  start)
+        docker start proxy-dev
+        ;;
+  stop)
+        docker stop proxy-dev
+        ;;
+  shell)
+        docker exec -it proxy-dev /bin/bash
+        ;;
+  clean)
+        docker rmi $(docker images --filter "dangling=true" -q --no-trunc)
+        ;;
+  update)
+        cd /hydra/cm/firefly
+        gradle proxyDev:dockerImage
+        docker stop proxy-dev
+        docker container rm proxy-dev
+
+        docker run -d \
+                   -p 80:80 \
+                   -p 443:443 \
+                   -e "docker_host=`ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'  | tail -1`" \
+                   --name proxy-dev ipac/proxy-dev
+
+#           -e "DOMAINS=`hostname`" \
+#           -e "WEBMASTER_MAIL=loi@ipac.caltech.edu" \
+#           -e "STAGING=proxy" \
+
+        ;;
+  *)
+        echo $"Usage: proxyctl.sh [start|stop|shell|clean|update]"
+        exit
+esac
+

--- a/docker/proxy-dev/proxyctl.sh
+++ b/docker/proxy-dev/proxyctl.sh
@@ -1,4 +1,41 @@
-#!/bin/sh
+#!/bin/bash
+
+
+http_port="80"
+https_port="443"
+docker_host="`ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'  | tail -1`"
+firefly_port="8080"
+
+
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    -http|--http_port)
+    http_port="$2"
+    shift # past argument
+    ;;
+    -https|--https_port)
+    https_port="$2"
+    shift # past argument
+    ;;
+    -host|--docker_host)
+    docker_host="$2"
+    shift # past argument
+    ;;
+    -firefly|--firefly_port)
+    firefly_port="$2"
+    shift # past argument
+    ;;
+    *)
+            # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+
 case "$1" in
   start)
         docker start proxy-dev
@@ -13,15 +50,25 @@ case "$1" in
         docker rmi $(docker images --filter "dangling=true" -q --no-trunc)
         ;;
   update)
-        cd /hydra/cm/firefly
+        echo ----------------------------------------
+        echo http_port  = "${http_port}"
+        echo https_port  = "${https_port}"
+        echo docker_host  = "${docker_host}"
+        echo firefly_port  = "${firefly_port}"
+        echo ----------------------------------------
+
+        DIR=$(dirname "${0}")
+        cd $DIR/../../../firefly
         gradle proxyDev:dockerImage
         docker stop proxy-dev
         docker container rm proxy-dev
 
         docker run -d \
-                   -p 80:80 \
-                   -p 443:443 \
-                   -e "docker_host=`ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'  | tail -1`" \
+                   -p ${http_port}:80 \
+                   -p ${https_port}:443 \
+                   -e docker_host=${docker_host} \
+                   -e firefly_port=${firefly_port} \
+                   -e docker_host=`ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk '{print $2}'  | tail -1` \
                    --name proxy-dev ipac/proxy-dev
 
 #           -e "DOMAINS=`hostname`" \
@@ -30,7 +77,14 @@ case "$1" in
 
         ;;
   *)
-        echo $"Usage: proxyctl.sh [start|stop|shell|clean|update]"
-        exit
+        echo
+        echo "Usage: proxyctl.sh [start|stop|shell|clean|update]"
+        echo "  optional parameters for update only:"
+        echo "    -http|--http_port <number>"
+        echo "    -https|--https_port <number>"
+        echo "    -host|--docker_host <x.x.x.x>  : ip address of the host running firefly"
+        echo "    -firefly|--firefly_port <number>"
+        echo
+        exit 1
 esac
 

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -1,0 +1,17 @@
+FROM birgerk/apache-letsencrypt
+
+
+#RUN apt-get update && \
+#    apt-get -f stretch install libapache2-mod-auth-openidc && \
+#    rm -rf /var/lib/apt/lists/*
+
+#RUN ln -s /usr/lib/apache2/modules/mod_auth_openidc.so modules/mod_auth_openidc.so
+COPY ./others/*.conf /etc/apache2/conf-enabled/
+
+RUN   a2enmod proxy; \
+      a2enmod proxy_http; \
+      a2enmod proxy_wstunnel
+
+EXPOSE 80 443
+
+ENTRYPOINT ["httpd-foreground"]

--- a/docker/proxy/build.gradle
+++ b/docker/proxy/build.gradle
@@ -1,0 +1,16 @@
+
+dockerImage {
+
+  docker_repo = "ipac/proxy"
+  docker_registry = ''
+  docker_tag = 'latest'
+  copy_res = false
+
+  doFirst {
+    // copy artifacts to staging directory
+    copy {
+      from (projectDir) include '**/*'
+      into "${buildDir}/docker"
+    }
+  }
+}

--- a/docker/proxy/others/proxy.conf
+++ b/docker/proxy/others/proxy.conf
@@ -1,0 +1,35 @@
+# Load these modules if not already loaded
+<IfModule !proxy_module>
+    LoadModule proxy_module modules/mod_proxy.so
+</IfModule>
+<IfModule !proxy_http_module>
+    LoadModule proxy_http_module modules/mod_proxy_http.so
+</IfModule>
+<IfModule !proxy_wstunnel_module>
+    LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
+</IfModule>
+<IfModule !rewrite_module>
+    LoadModule rewrite_module modules/mod_rewrite.so
+</IfModule>
+
+
+ProxyRequests Off
+ProxyPreserveHost On
+ProxyStatus On
+
+
+## Hydra app for firefly
+ProxyPass         /firefly/sticky/firefly/events  ws://firefly:8080/firefly/sticky/firefly/events
+ProxyPass         /firefly http://firefly:8080/firefly
+ProxyPassReverse  /firefly http://firefly:8080/firefly
+
+## Hydra app for suit
+ProxyPass         /suit/sticky/firefly/events  ws://firefly:8080/suit/sticky/firefly/events
+ProxyPass         /suit http://firefly:8080/suit
+ProxyPassReverse  /suit http://firefly:8080/suit
+
+
+## end proxy config for Hydra support
+
+
+

--- a/docker/proxy/proxyctl.sh
+++ b/docker/proxy/proxyctl.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+case "$1" in
+  start)
+        docker start proxy
+        ;;
+  stop)
+        docker stop proxy
+        ;;
+  shell)
+        docker exec -it proxy /bin/bash
+        ;;
+  update)
+        docker stop proxy
+        docker container rm proxy
+
+        docker pull ipac/proxy
+        docker run -d \
+                   -p 80:80 \
+                   -p 443:443 \
+                   -e "DOMAINS=`hostname`" \
+                   -e "WEBMASTER_MAIL=loi@ipac.caltech.edu" \
+                   --network=local_nw \
+                   --restart=unless-stopped \
+                   --name proxy ipac/proxy
+
+#               -e "DOMAINS=`hostname`" \
+#               -e "STAGING=proxy" \
+        ;;
+  *)
+        echo $"Usage: proxyctl.sh [start|stop|shell|update]"
+        exit
+esac
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,12 @@
 rootProject.name = 'firefly_root'
 
-include 'simbad', 'xstream', 'firefly', 'fftools', 'firefly_data'
+include 'simbad', 'xstream', 'firefly', 'fftools', 'firefly_data', 'proxy', 'proxyDev'
 
 project(":simbad").projectDir   = file('src/external/simbad')
 project(":xstream").projectDir  = file('src/external/xstream')
 project(":firefly").projectDir  = file('src/firefly')
 project(":fftools").projectDir  = file('src/fftools')
 project(":firefly_data").projectDir = file('src/firefly_data')
+project(":proxy").projectDir = file('docker/proxy')
+project(":proxyDev").projectDir = file('docker/proxy-dev')
 

--- a/src/fftools/build.gradle
+++ b/src/fftools/build.gradle
@@ -36,6 +36,7 @@ ext.appConfig = {
     test {
       ehcache.multicast.port = "6016"
     }
+
     ops_int {
       ehcache.multicast.port = "7516"
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
@@ -1,0 +1,203 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.security;
+
+import edu.caltech.ipac.firefly.data.userdata.RoleList;
+import edu.caltech.ipac.firefly.data.userdata.UserInfo;
+import edu.caltech.ipac.firefly.server.RequestAgent;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class support authentication in which mod_auth_openidc is used
+ * at the proxy level.
+ *
+ * @author loi
+ * @version $Id: JOSSOAdapter.java,v 1.14 2012/10/10 21:54:45 loi Exp $
+ */
+public class AuthOpenidcMod implements SsoAdapter {
+
+    private static final String REMOTE_USER = "x-forwarded-user";
+    private static final String ACCESS_TOKEN = "oidc_access_token";
+    private static final String EXPIRES_IN = "oidc_access_token_expires";
+
+    private static final String IDP_NAME = "oidc_claim_idp_name";
+    private static final String IDP = "oidc_claim_idp";
+    private static final String AFFILIATION = "oidc_claim_affiliation";
+    private static final String FIRST_NAME = "oidc_claim_given_name";
+    private static final String LAST_NAME = "oidc_claim_family_name";
+    private static final String EMAIL = "oidc_claim_email";
+
+    private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
+
+    private static final String ROLE_CLAIM = "oidc_claim_ismemberof";
+
+
+    /**
+     * returns the number of seconds before this session expires.  0 if session is not valid, or it's already expires.
+     * @param tokenId
+     * @return
+     */
+    public long checkSession(String tokenId) {
+        return 0;
+    }
+
+    /**
+     * return all of the roles for a user authenticated with this token.
+     * @param token
+     * @return
+     */
+    public RoleList getRoles(String token) {
+        return getRoleList();
+    }
+
+    public Token resolveAuthToken(String assertionKey) {
+        return null;
+    }
+
+    public Token refreshAuthToken(Token old) {
+        return null;
+    }
+
+    public boolean logout(String token) {
+        clearAuthInfo();
+        return true;
+    }
+
+    public UserInfo login(String name, String passwd) {
+        return null;
+    }
+
+    public String createSession(String name, String passwd) {
+        return null;
+    }
+
+    public String getAssertKey() {
+        return null;
+    }
+
+    public Token getAuthToken() {
+        return getToken();
+    }
+
+    public String getAuthTokenId() {
+        Token token = getAuthToken();
+        return token == null ? null : token.getId();
+    }
+
+    public UserInfo getUserInfo() {
+        RequestAgent ra = ServerContext.getRequestOwner().getRequestAgent();
+        try {
+            String email = getString(ra, EMAIL, "");
+
+            UserInfo userInfo = new UserInfo(email, null);
+            userInfo.setEmail(email);
+            userInfo.setLastName(getString(ra, LAST_NAME, ""));
+            userInfo.setFirstName(getString(ra, FIRST_NAME, ""));
+            userInfo.setInstitute(getString(ra, AFFILIATION, ""));
+            userInfo.setProperty(IDP_NAME, getString(ra, IDP_NAME, ""));
+            userInfo.setProperty(IDP, getString(ra, IDP, ""));
+            userInfo.setRoles(getRoleList());
+            return userInfo;
+        } catch (Exception e) {
+            LOGGER.error(e);
+            return null;
+        }
+    }
+
+    public void clearAuthInfo() {
+    }
+
+    @NotNull
+    public Map<String, String> getIdentities() {
+        HashMap<String, String> identities = new HashMap<>();
+        String remoteUser = ServerContext.getRequestOwner().getRequestAgent().getHeader(REMOTE_USER);
+        if (!StringUtils.isEmpty(remoteUser)) {
+            identities.put(REMOTE_USER, remoteUser);
+        }
+        return identities;
+    }
+
+    public String getRequestedUrl(HttpServletRequest req) {
+        return null;
+    }
+
+    public String makeAuthCheckUrl(String requestedUrl) {
+        return null;
+    }
+
+
+//====================================================================
+//  private methods
+//====================================================================
+
+    private Token getToken() {
+        Token token = null;
+        try {
+            RequestAgent ra = ServerContext.getRequestOwner().getRequestAgent();
+            String remoteUser = getString(ra, REMOTE_USER, "");
+            int expiresIn = getInt(ra, EXPIRES_IN, 0);
+            token = new Token(remoteUser);
+            token.set(EXPIRES_IN, String.valueOf(expiresIn));
+            token.setExpiresOn(expiresIn);
+        } catch (Exception e) {
+            LOGGER.error(e);
+        }
+        return token;
+    }
+
+    private static String getString(RequestAgent ra, String key, String def) {
+        return ra.getHeader(key, def);
+    }
+
+    private static int getInt(RequestAgent ra, String key, int def) {
+        String val = ra.getHeader(key);
+        if (val == null) {
+            return def;
+        } else {
+            try {
+                return Integer.parseInt(String.valueOf(val));
+            } catch (NumberFormatException ex) {
+                return def;
+            }
+        }
+    }
+
+    /**
+     * Convert the isMemberOf string to a RoleList.  This is specific to CILogon.
+     * The values look like it came from an LDAP service. ["cn=val,ou=val,dc=val1,dc=val2,dc=val3","cn=val,ou=val,dc=val1,dc=val2,dc=val3"]
+     * @return
+     */
+    @NotNull
+    private static RoleList getRoleList() {
+        RequestAgent ra = ServerContext.getRequestOwner().getRequestAgent();
+        String[] isMemberOf = getString(ra, ROLE_CLAIM, "").split(",");
+
+        RoleList roleList = new RoleList();
+        String cuser = "";
+        for (String r : isMemberOf) {
+            String[] keyval = r.split("=", 2);
+            String cn=null, dc="";
+
+            if (keyval[0].equals("cn")) {
+                cn = keyval.length > 1 ? keyval[1] : "";
+            } else if (keyval[0].equals("dc")) {
+                dc = keyval.length > 1 ? keyval[1] : "";
+            }
+            if (!StringUtils.isEmpty(cn) && !cn.equals(cuser)) {
+                cuser = cn;
+                roleList.add(new RoleList.RoleEntry(dc, dc.hashCode(), cn, cn.hashCode(), ""));
+            }
+        }
+
+        return roleList;
+    }
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/OidcAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/OidcAdapter.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,11 +66,11 @@ public class OidcAdapter implements SsoAdapter {
     private static String ssoProfileUrl = AppProperties.getProperty("sso.user.profile.url");
     private static String oidcClientId = AppProperties.getProperty("oidc_client_id");
     private static String oidcClientSecret = AppProperties.getProperty("oidc_client_secret");
+    private static final String REDIRECT_URI = AppProperties.getProperty("oidc_redirect_uri", "oidc/verify");
 
     private static final String LOGIN_URL = ssoServerUrl + "/authorize";
     private static final String TOKEN_URL = ssoServerUrl + "/oauth2/token";
     private static final String USER_INFO_URL = ssoServerUrl + "/oauth2/userinfo";
-    private static final String VERIFY_URL = "oidc/verify";
     private static final String SCOPE = "openid profile email org.cilogon.userinfo edu.uiuc.ncsa.myproxy.getcert";
     private static final String ROLE_CLAIM = "isMemberOf";
 
@@ -252,7 +251,7 @@ public class OidcAdapter implements SsoAdapter {
     }
 
     private static String makeVerifyUrl() {
-        return   ServerContext.getRequestOwner().getRequestAgent().getBaseUrl() + VERIFY_URL;
+        return   ServerContext.getRequestOwner().getRequestAgent().getBaseUrl() + REDIRECT_URI;
     }
 
     @NotNull

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
@@ -27,6 +27,7 @@ public interface SsoAdapter {
     String SSO_FRAMEWORK_NAME = "sso.framework.name";
     String JOSSO = "josso";
     String OPENID_CONNECT = "oidc";
+    String MOD_AUTH_OPENIDC = "mod_auth_openidc";
 
     /**
      * returns the number of seconds before this session expires.  0 if session is not valid, or it's already expires.
@@ -79,16 +80,19 @@ public interface SsoAdapter {
                 return new JOSSOAdapter();
             case OPENID_CONNECT:
                 return new OidcAdapter();
+            case MOD_AUTH_OPENIDC:
+                return new AuthOpenidcMod();
             default:
                 return new JOSSOAdapter();
         }
     }
 
-    public static class Token implements Serializable {
+    class Token implements Serializable {
         private String id;
         private long expiresOn = Long.MAX_VALUE;
         private Map<String, String> others = new HashMap<>();
         private Map<String, String> claims;
+
 
         public Token(String id) {
             this.id = id;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoCheckFilter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoCheckFilter.java
@@ -15,6 +15,7 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -62,6 +63,19 @@ public class SsoCheckFilter implements Filter {
         if (request instanceof HttpServletRequest) {
             HttpServletRequest req = (HttpServletRequest) request;
             HttpServletResponse res = (HttpServletResponse) response;
+
+            System.out.println("REMOTE_USER: " + req.getRemoteUser());
+            Enumeration<String> headers = req.getHeaderNames();
+            while (headers.hasMoreElements()) {
+                String k = headers.nextElement();
+                String v = req.getHeader(k);
+                System.out.println("HEADER " + k + ":" + v);
+            }
+
+            for (String k : req.getParameterMap().keySet()) {
+                String v = req.getParameter(k);
+                System.out.println("PARAM " + k + ":" + v);
+            }
 
             if (!isExcluded(req)) {
                 SsoAdapter.Token authToken = SsoAdapter.getAdapter().getAuthToken();

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import {SimpleComponent} from './SimpleComponent.jsx';
 import {getUserInfo} from '../core/AppDataCntlr.js';
 import {logout} from '../rpc/CoreServices.js';
+import {getRootURL} from '../util/BrowserUtil.js';
 import './Banner.css';
 
 
@@ -61,14 +62,24 @@ export class UserInfo extends SimpleComponent {
     }
 
     render() {
+        /*global __$sso_redirect_uri*/
+        var logoutUri = typeof __$sso_redirect_uri === 'undefined' ? undefined : __$sso_redirect_uri;
+
         const {loginName='Guest', firstName, lastName, login_url} = this.state || {};
         const isGuest = loginName === 'Guest';
         const onLogin = () => login_url && (window.location = login_url);
+        const onLogout = () => {
+            if (logoutUri) {
+                window.location = `${getRootURL()}${logoutUri}?logout=${getRootURL()}`;
+            } else {
+                logout();
+            }
+        };
 
         return (
             <div className='banner__user-info'>
                 <span>{loginName}</span>
-                {!isGuest && <div className='banner__user-info--links' onClick={logout}>Logout</div>}
+                {!isGuest && <div className='banner__user-info--links' onClick={onLogout}>Logout</div>}
                 {isGuest && <div className='banner__user-info--links' onClick={onLogin}>Login</div>}
             </div>
         );

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -197,6 +197,20 @@ export function fetchUrl(url, options, doValidation= true) {
 
     if (!url) return;
 
+
+    // ?info=json&access_token_refresh_interval=<seconds>
+    /*global __$sso_redirect_uri*/
+    if (typeof __$sso_redirect_uri !== 'undefined') {
+        const refreshUrl =  `${getRootURL()}${__$sso_redirect_uri}?info=json&access_token_refresh_interval=0`;
+        fetch(refreshUrl).then( (resp) =>  {
+            resp.text().then( (text) => {
+                console.log( text );
+            });
+        });
+    }
+
+
+
     // define defaults request options
     options = options || {};
     const req = { method: 'get',


### PR DESCRIPTION
- use letsencrypt for public site, and self-signed for development
- add support for authentication via mod_auth_openidc
- expand build script to exposes configurable global variables to javascript

**self-signed https proxy locally.**
cd ./firefly; docker/proxy-dev/proxyctl.sh update
this will create and run the apache proxy in docker.  access it on port 80 or 443.  i.e.  http://localhost/

**javascript global variables**
to make any configuration property a javascript global variable, append '__$' to it.  i.e.  __$help.base.url
