### PR TITLE
DM-11477 Make plot.ly plotting API to handle Firefly unrecognized charts types cleanly

### DIFF
--- a/src/firefly/html/demo/ffapi-slate-test3.html
+++ b/src/firefly/html/demo/ffapi-slate-test3.html
@@ -1,0 +1,354 @@
+<!doctype html>
+
+<!--
+  ~ License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+  -->
+
+<html>
+
+<head>
+    <meta http-equiv="Cache-Control" content="no-cache">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Demo of Firefly Tools</title>
+        <style type="text/css">
+            .smallCoords {
+                font-size: 10pt;
+            }
+        </style>
+    </head>
+</head>
+
+<body>
+
+
+<div style="width: 500px; padding: 10px 0 0 20px;">
+</div>
+
+
+<div style="font-size: 16pt; padding:0 0 10px 10px;">
+    Test Firefly Blank Slate Viewer
+</div>
+
+<pre>
+    Slate function calls from firefly.getViewer()
+
+        v.addCell
+
+        v.showCoverage
+        v.showImageMetaDataViewer
+        v.showTable
+        v.showImage
+        v.showXYPlot
+        v.showHistogram
+
+    flow:
+       call v.addCell with position, type and cellId - type must be one of 'tables', 'images', 'xyPlots', 'tableImageMeta', 'coverageImage'
+       call v.showTable, v.showImage, v.showXYPlot, v.showHistogram, v.showCoverage, or v.showImageMetaDataViewer
+</pre>
+
+<div>
+    serialized target: <input type="text" name="fname" id="sTarget" style="width: 300px; margin: 10px;">
+</div>
+<pre>
+    try:
+    148.88822;69.06529;EQ_J2000 # Galaxy M81
+    202.48417;47.23056;EQ_J2000 # Galaxy M51
+    136.9316774;+1.1195886;galactic # W5 star-forming region
+    10.68479;41.26906;EQ_J2000 # Galaxy M31
+</pre>
+
+
+<div style='margin-bottom: 15px'>
+    <a href='javascript:firefly.getViewer().reinitViewer()'>Reinit App</a>
+</div>
+
+
+Load Tables for charts to use
+<ul>
+    <li>
+        <a href="javascript:showATable(getSTarget(),0,4,2,2)">Load the Table</a> <span class='smallCoords'>at row: 0, col: 4, w:2 h: 2</span>
+    </li>
+</ul>
+
+Some unsupported plotly charts:
+<ul>
+
+    <li>
+        <a href='javascript:loadHistogramCharts(0,0,2,2)'>Show Histogram</a> <span class='smallCoords'>at row: 0, col: 0, w:2 h: 2</span>
+    </li>
+    <li>
+        <a href="javascript:loadSurface(0,2,2,2)">Show Surface</a><span class='smallCoords'>at row: 0, col: 2, w: 2, h: 2</span>
+    </li>
+    <li>
+        <a href="javascript:loadBar(2,0,3,3)">Show Bar chart</a><span class='smallCoords'>at row: 2, col: 0, w: 3, h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadPie(2,3,3,3)">Show Pie Chart</a><span class='smallCoords'>at row: 2, col: 3, w: 3. h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadDensity(4,0,3,3)">Show Histogram2dContour</a><span class='smallCoords'>at row: 4, col: 0, w: 3, h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadBox(4,3,3,3)">Show Box</a><span class='smallCoords'>at row: 4, col: 3, w: 3, h: 3</span>
+    </li>
+</ul>
+</body>
+
+
+<script type="text/javascript">
+    if (!window.firefly) window.firefly= {};
+    window.firefly.options= {charts: {chartEngine: 'plotly'}};
+</script>
+
+
+
+<script type="text/javascript">
+    {
+
+        function getSTarget() {
+            return document.getElementById('sTarget').value;
+        }
+
+
+        function loadHistogramCharts(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'histContainer');
+
+            var dataH = [
+                {name: 'w1mpro', marker: {color: 'rgba(153, 51, 153, 0.8)'}},
+                {name: 'w2mpro', marker: {color: 'rgba(102,153,0, 0.7)'}}
+            ];
+
+            var fireflyDataH = [
+                {
+                    dataType: 'fireflyHistogram',
+                    tbl_id: 'wiseCatTbl',
+                    options: {
+                        algorithm: 'fixedSizeBins',
+                        fixedBinSizeSelection: 'numBins',
+                        numBins: 30,
+                        columnOrExpr: 'w1mpro'
+                    }
+                },
+                {
+                    dataType: 'fireflyHistogram',
+                    tbl_id: 'wiseCatTbl',
+                    options: {
+                        algorithm: 'fixedSizeBins',
+                        fixedBinSizeSelection: 'numBins',
+                        numBins: 40,
+                        columnOrExpr: 'w2mpro'   // same column but shifted
+                    }
+                }
+            ];
+
+            var layoutHist = {
+                title: 'Photometry histogram',
+                xaxis: {title: 'photometry (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'firefly-hist-tbl', layout: layoutHist, data: dataH, fireflyData: fireflyDataH},
+                    'histContainer');
+        }
+
+        function loadBar(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'barContainer');
+
+
+            var dataBar = [
+                {
+                    type: 'bar',
+                    name: 'w1nm',
+                    orientation: 'h',
+                    y: "tables::wiseCatTbl,clon",
+                    x: "tables::wiseCatTbl,w1nm"
+                }
+            ];
+
+            var layoutBar = {
+                title: 'Bar: w1nm vs. clon',
+                xaxis: {title: 'w1nm'},
+                yaxis: {tickfont:{size: 11, family: 'PT Sans Narrow'}}
+            };
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'newBar', data: dataBar, layout: layoutBar}, 'barContainer');
+        }
+
+        function loadPie(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'pieContainer');
+
+            var dataPie = [
+                {
+                    name: 'Area',
+                    type: 'pie',
+                    values: "tables::wiseCatTbl,w1mpro",
+                    labels:  "tables::wiseCatTbl,clon",
+                    textinfo: 'none'
+                }];
+
+            var layoutPie = {
+                title: 'pie: w1mpro vs. clon',
+                showlegend: true
+            };
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'newPie', data: dataPie, layout: layoutPie}, 'pieContainer');
+        }
+
+        function loadDensity(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'h2dcontourContainer');
+
+            var dataContour = [
+                {
+                    name: 'contour',
+                    type: 'histogram2dcontour',
+                    x: "tables::wiseCatTbl,ra",
+                    y:  "tables::wiseCatTbl,dec",
+                    ncontours: 20
+                }];
+
+            var layoutContour = {
+                title: 'histogram2dcontour: ra vs. dec',
+                xaxis: {title: 'ra'},
+                yaxis: {title: 'dec'}
+            };
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'newhist2dcontour', data: dataContour, layout: layoutContour}, 'h2dcontourContainer');
+        }
+
+        function loadSurface(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'surfaceContainer');
+
+
+            var dataSurface = [
+                {
+                    type: 'surface',
+                    name: 'w1-ra-dec',
+                    x: "tables::wiseCatTbl,ra",
+                    y: "tables::wiseCatTbl,dec",
+                    z: "tables::wiseCatTbl,w1mpro",
+                    hoverinfo: 'x+y+z'
+                }
+            ];
+
+            var tfont = {size: 11};
+            var layoutSurface = {
+                title: 'Surface on ra & dec',
+                scene:{
+                    xaxis: {
+                        title: 'ra (deg)',
+                        titlefont: tfont
+                    },
+                    yaxis: {
+                        title: 'dec (deg)',
+                        titlefont: tfont
+                    }
+                }
+            };
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'newSurface', layout: layoutSurface, data: dataSurface },
+                    'surfaceContainer');
+        }
+
+        function loadBox(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'boxContainer');
+
+
+            var dataBox = [
+                {
+                    type: 'box',
+                    name: 'w1mpro',
+                    y: "tables::wiseCatTbl,w1mpro"
+                },
+                {
+                    type: 'box',
+                    name: 'w2mpro',
+                    y: "tables::wiseCatTbl,w2mpro"
+                }
+            ];
+
+            var tfont = {size: 11};
+            var layoutBox = {
+                title: 'Box on photometry',
+                titlefont: tfont
+            };
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'newBox', layout: layoutBox, data: dataBox},
+                    'boxContainer');
+        }
+
+
+        function showATable(sTarget,r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'tables');
+            var req=  firefly.util.table.makeIrsaCatalogRequest('WISE catalog', 'WISE', 'allwise_p3as_psd',
+                {
+                    position: sTarget,
+                    SearchMethod: 'Cone',
+                    radius: 360
+                },
+                {
+                    tbl_id: "wiseCatTbl"
+                }
+            );
+            firefly.getViewer().showTable( req, {removable: true, showUnits: false, showFilters: true});
+        }
+    }
+</script>
+
+
+
+
+<script type="text/javascript">
+    {
+        onFireflyLoaded= function(firefly) {
+
+            document.getElementById('sTarget').value=  '10.68479;41.26906;EQ_J2000';
+
+            firefly.setViewerConfig(firefly.ViewerType.Grid);
+            window.ffViewer= firefly.getViewer();
+
+            firefly.setGlobalImageDef({
+                ZoomType  : 'TO_WIDTH'
+            } );
+
+            firefly.debug= true;
+
+            var util= firefly.util;
+            var ui= firefly.ui;
+
+            var req= {
+                plotId: 'xxq',
+                Type      : 'SERVICE',
+                plotGroupId : 'myGroup',
+                Service   : 'TWOMASS',
+                Title     : '2mass from service',
+                GridOn     : true,
+//                GridOn     : 'TRUE_LABELS_FALSE',
+                SurveyKey  : 'k',
+                WorldPt    : '10.68479;41.26906;EQ_J2000',
+                SizeInDeg  : '.12',
+                AllowImageSelection : true
+            };
+
+
+
+
+        };
+
+   }
+
+</script>
+
+<!-- to try a container: <script  type="text/javascript" src="http://localhost:8090/firefly/firefly_loader.js"></script>-->
+
+<script  type="text/javascript" src="../firefly_loader.js"></script>
+
+
+</html>

--- a/src/firefly/html/demo/ffapi-slate-test3.html
+++ b/src/firefly/html/demo/ffapi-slate-test3.html
@@ -207,7 +207,7 @@ Some unsupported plotly charts:
                     name: 'contour',
                     type: 'histogram2dcontour',
                     x: "tables::wiseCatTbl,ra",
-                    y:  "tables::wiseCatTbl,dec",
+                    y: "tables::wiseCatTbl,dec",
                     ncontours: 20
                 }];
 

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -520,6 +520,9 @@ function getTraceTSEntries({chartDataType, traceTS, chartId, traceNum}) {
 
 // does the default depend on the chart type?
 export function applyDefaults(chartData={}) {
+    const chartType = get(chartData, ['data', '0', 'type']);
+    const noXYAxis = chartType && (chartType === 'pie');
+
     const defaultLayout = {
         hovermode: 'closest',
         dragmode: 'zoom',
@@ -537,29 +540,29 @@ export function applyDefaults(chartData={}) {
             titlefont: {
                 size: FSIZE
             },
-            tickfont: {
-                size: FSIZE
-            },
-            showline: true,
+            ticks: noXYAxis ? '' : 'outside',
+            showline: !noXYAxis,
+            showticklabels: !noXYAxis,
             zeroline: false
         },
         yaxis: {
             autorange:true,
-            showgrid: true,
+            showgrid: !noXYAxis,
             lineColor: '#e9e9e9',
             tickwidth: 1,
             ticklen: 5,
             titlefont: {
                 size: FSIZE
             },
-            tickfont: {
-                size: FSIZE
-            },
-            showline: true,
+            ticks: noXYAxis ? '' : 'outside',
+            showline: !noXYAxis,
+            showticklabels: !noXYAxis,
             zeroline: false
         }
     };
+
     chartData.layout = merge(defaultLayout, chartData.layout);
+
 }
 
 // color-blind friendly colors

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -579,6 +579,13 @@ export function chartDataUpdate(payload) {
     return { type : CHART_DATA_UPDATE, payload };
 }
 
+function findNewBar() {
+    const newChart = getChartData('newBar');
+    const l = get(newChart, ['layout', 'xaxis', 'range']);
+    if (l) {
+        console.log(l);
+    }
+}
 
 /*
  Possible structure of store:

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -11,6 +11,7 @@ import * as ChartsCntlr from '../ChartsCntlr.js';
 
 import DELETE from 'html/images/blue_delete_10x10.png';
 
+
 class ChartPanelView extends PureComponent {
 
     constructor(props) {
@@ -155,7 +156,10 @@ class ChartPanelView extends PureComponent {
                     <Toolbar {...{chartId, expandable, expandedMode, toggleOptions: this.toggleOptions}}/>
                     <div className='ChartPanel__chartarea--withToolbar'>
                         {showOptions &&
-                        <div className='ChartPanelOptions'>
+                        <div className='ChartPanelOptions'
+                             onClick={stopPropagation}
+                             onTouchStart={stopPropagation}
+                             onMouseDown={stopPropagation}>
                             <div style={{height: 14}}>
                                 <div style={{ right: -6, float: 'right'}}
                                      className='btn-close'
@@ -191,6 +195,8 @@ ChartPanelView.defaultProps = {
     showToolbar: true,
     showChart: true
 };
+
+const stopPropagation= (ev) => ev.stopPropagation();
 
 function ErrorPanel({errors}) {
     return (

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -73,20 +73,29 @@ export class MultiChartViewer extends PureComponent {
             activeItemId = viewer.itemIdAry[0];
         }
 
-        const onChartSelect = (chartId) => {
+        const onChartSelect = (ev,chartId) => {
             if (chartId !== activeItemId) {
                 dispatchUpdateCustom(viewerId, {activeItemId: chartId});
             }
+            stopPropagation(ev);
         };
 
+
         const makeItemViewer = (chartId) => (
-            <div className={chartId === activeItemId ? 'ChartPanel ChartPanel--active' : 'ChartPanel'} onClick={()=>onChartSelect(chartId)}>
+            <div className={chartId === activeItemId ? 'ChartPanel ChartPanel--active' : 'ChartPanel'}
+                 onClick={(ev)=>onChartSelect(ev,chartId)}
+                 onTouchStart={stopPropagation}
+                 onMouseDown={stopPropagation}>
                 <ChartPanel key={chartId} showToolbar={false} chartId={chartId}/>
             </div>
         );
 
         const makeItemViewerFull = (chartId) => (
-            <ChartPanel key={chartId} showToolbar={false} chartId={chartId}/>
+            <div onClick={stopPropagation}
+                 onTouchStart={stopPropagation}
+                 onMouseDown={stopPropagation}>
+                <ChartPanel key={chartId} showToolbar={false} chartId={chartId}/>
+            </div>
         );
 
         const newProps = {
@@ -114,6 +123,10 @@ export class MultiChartViewer extends PureComponent {
         );
     }
 }
+
+
+const stopPropagation= (ev) => ev.stopPropagation();
+
 
 MultiChartViewer.propTypes= {
     viewerId : PropTypes.string.isRequired,

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -1,5 +1,5 @@
 import './ChartPanel.css';
-import React, {PureComponent} from 'react';
+import React from 'react';
 import {get, isEmpty} from 'lodash';
 
 import {dispatchChartUpdate, dispatchChartFilterSelection, dispatchChartSelect, getChartData, dispatchSetActiveTrace, dispatchChartExpanded} from '../ChartsCntlr.js';

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -7,6 +7,8 @@ import {SimpleComponent} from '../../ui/SimpleComponent.jsx';
 import {getTblById, clearFilters, getColumnIdx, getColumnType} from '../../tables/TableUtil.js';
 import {dispatchSetLayoutMode, LO_MODE, LO_VIEW} from '../../core/LayoutCntlr.js';
 import {downloadChart} from './PlotlyWrapper.jsx';
+import {getColValidator} from './ColumnOrExpression.jsx';
+import {getColValStats} from '../TableStatsCntlr.js';
 
 function getToolbarStates(chartId) {
     const {selection, selected, activeTrace=0, tablesources, layout, data={}} = getChartData(chartId);
@@ -69,8 +71,14 @@ function isSelectable(tbl_id, chartId, type) {
               if (!checkItem) return false;      // ignore
 
               if (dataExp[idx]) {
-                  return getColumnIdx(tableModel, dataExp[idx]) < 0 ||
-                         strCol.includes(getColumnType(tableModel, dataExp[idx]));
+                  if (getColumnIdx(tableModel, dataExp[idx]) >= 0) {
+                      return strCol.includes(getColumnType(tableModel, dataExp[idx]));
+                  } else {
+                      const colValidator = getColValidator(getColValStats(tbl_id));
+                      const {valid} = colValidator(dataExp[idx]);
+
+                      return !valid;
+                  }
               } else {
                   return true;   // not qualified to have selection box
               }

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -4,7 +4,7 @@ import {get, isEmpty} from 'lodash';
 
 import {dispatchChartUpdate, dispatchChartFilterSelection, dispatchChartSelect, getChartData, dispatchSetActiveTrace, dispatchChartExpanded} from '../ChartsCntlr.js';
 import {SimpleComponent} from '../../ui/SimpleComponent.jsx';
-import {getTblById, clearFilters} from '../../tables/TableUtil.js';
+import {getTblById, clearFilters, getColumnIdx} from '../../tables/TableUtil.js';
 import {dispatchSetLayoutMode, LO_MODE, LO_VIEW} from '../../core/LayoutCntlr.js';
 import {downloadChart} from './PlotlyWrapper.jsx';
 
@@ -27,6 +27,7 @@ export class ScatterToolbar extends SimpleComponent {
     render() {
         const {chartId, expandable, toggleOptions} = this.props;
         const {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected, dragmode} = this.state;
+
         return (
             <div className='ChartToolbar'>
                 <ActiveTraceSelect style={{marginRight: 20}} {...{chartId, activeTrace}}/>
@@ -44,6 +45,31 @@ export class ScatterToolbar extends SimpleComponent {
     }
 }
 
+function isSelectable(tbl_id, chartId, type, activeTrace) {
+    const typeWithX = ['heatmap', 'histogram2dcontour', 'histogram2d'];
+    const typeWithY = ['heatmap', 'histogram2dcontour', 'histogram2d'];
+
+    if (!tbl_id) return false;
+    const checkX = typeWithX.includes(type);
+    const checkY = typeWithY.includes(type);
+
+    if (!checkX&&!checkY) return false;     // chart type has no selection box in tool bar
+
+    const {x, y} = get(getChartData(chartId), `tablesources.${activeTrace}.mappings`) || {};
+    const tableModel = getTblById(tbl_id);
+    const dataExp = [x, y];
+
+    const noSelectionIdx = [checkX, checkY].findIndex((checkItem, idx) => {
+        if (!checkItem) return false;      // ignore
+        if (dataExp[idx]) {
+            return getColumnIdx(tableModel, dataExp[idx]) < 0;
+        } else {
+            return true;   // not qualified to have selection box
+        }
+    });
+    return (noSelectionIdx < 0);
+}
+
 export class BasicToolbar extends SimpleComponent {
 
     getNextState(np) {
@@ -57,19 +83,21 @@ export class BasicToolbar extends SimpleComponent {
         const {activeTrace, hasFilter, hasSelection, tbl_id, dragmode} = this.state;
 
         const type = get(getChartData(chartId), `data.${activeTrace}.type`, '');
-        const showSelectionPart = type.includes('heatmap');
-        const is3d = type.endsWith('3d') || type === 'surface';
+        const showSelectionPart = isSelectable(tbl_id, chartId, type, activeTrace);
+        const showDragPart = !type.includes('pie');
+        const is3d = type.endsWith('3d') || type === 'surface'; // scatter3d, mesh3d, surface
 
         return (
             <div className='ChartToolbar'>
                 <ActiveTraceSelect style={{marginRight: 20}} {...{chartId, activeTrace}}/>
-                <DragModePart {...{chartId, tbl_id, dragmode, hasSelectionMode: showSelectionPart, is3d}}/>
+                {showDragPart &&
+                    <DragModePart {...{chartId, tbl_id, dragmode, hasSelectionMode: showSelectionPart, is3d}}/>}
                 {showSelectionPart && <div className='ChartToolbar__buttons' style={{margin: '0 5px'}}>
-                    {hasFilter    && <ClearFilter {...{tbl_id}} />}
+                    {hasFilter && <ClearFilter {...{tbl_id}} />}
                     {hasSelection && <FilterSelection {...{chartId}} />}
-                </div>}
+                    </div>}
                 <div className='ChartToolbar__buttons'>
-                    <ResetZoomBtn style={{marginLeft: 10}} {...{chartId}} />
+                    {showDragPart && <ResetZoomBtn style={{marginLeft: 10}} {...{chartId}} />}
                     <SaveBtn {...{chartId}} />
                     {tbl_id && <FiltersBtn {...{chartId, toggleOptions}} />}
                     <OptionsBtn {...{chartId, toggleOptions}} />

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -1,5 +1,5 @@
 import './ChartPanel.css';
-import React from 'react';
+import React, {PureComponent} from 'react';
 import {get, isEmpty} from 'lodash';
 
 import {dispatchChartUpdate, dispatchChartFilterSelection, dispatchChartSelect, getChartData, dispatchSetActiveTrace, dispatchChartExpanded} from '../ChartsCntlr.js';
@@ -11,10 +11,12 @@ import {downloadChart} from './PlotlyWrapper.jsx';
 function getToolbarStates(chartId) {
     const {selection, selected, activeTrace=0, tablesources, layout, data={}} = getChartData(chartId);
     const {tbl_id} = get(tablesources, [activeTrace], {});
+    const {columns} = get(getTblById(tbl_id), ['tableData']) || {};
     const hasFilter = tbl_id && !isEmpty(get(getTblById(tbl_id), 'request.filters'));
     const hasSelection = !isEmpty(selection);
     const traceNames = data.map((t) => t.name).toString();
-    return {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected: !!selected, dragmode: get(layout, 'dragmode'), traceNames};
+    return {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected: !!selected,
+            dragmode: get(layout, 'dragmode'), traceNames, columns};
 }
 
 export class ScatterToolbar extends SimpleComponent {

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -29,12 +29,13 @@ export class ScatterToolbar extends SimpleComponent {
     render() {
         const {chartId, expandable, toggleOptions} = this.props;
         const {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected, dragmode} = this.state;
+        const hasSelectionMode = Boolean(tbl_id);
 
         return (
             <div className='ChartToolbar'>
                 <ActiveTraceSelect style={{marginRight: 20}} {...{chartId, activeTrace}}/>
                 <SelectionPart {...{chartId, hasFilter, activeTrace, hasSelection, hasSelected, tbl_id}}/>
-                <DragModePart {...{chartId, tbl_id, dragmode}}/>
+                <DragModePart {...{chartId, tbl_id, dragmode, hasSelectionMode}}/>
                 <div className='ChartToolbar__buttons'>
                     <ResetZoomBtn style={{marginLeft: 10}} {...{chartId}} />
                     <SaveBtn {...{chartId}} />

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -6,7 +6,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
 
-import {get, debounce, isEmpty, set, omit} from 'lodash';
+import {get, debounce, isEmpty, set, omit, cloneDeep} from 'lodash';
 import {getPlotLy} from '../PlotlyConfig.js';
 import {getChartData, useChartRedraw, useScatterGL} from '../ChartsCntlr.js';
 import {logError, deltas, flattenObject} from '../../util/WebUtil.js';
@@ -46,6 +46,13 @@ function isSlowResize() {
     return BrowserInfo.isFirefox();
 }
 
+function findNewBar() {
+    const newChart = getChartData('newBar');
+    const l = get(newChart, ['layout', 'xaxis', 'range']);
+    if (l) {
+        console.log(l);
+    }
+}
 
 export function downloadChart(chartId) {
     getPlotLy().then( (Plotly) => {
@@ -236,10 +243,10 @@ const now = Date.now();
                         Plotly.Plots.resize(this.div);
                         break;
                     case RenderType.UPDATE:
-                        Plotly.update(this.div, data, layout);
+                        Plotly.update(this.div, data, cloneDeep(layout));
                         break;
                     case RenderType.NEW_PLOT:
-                        Plotly.newPlot(this.div, data, layout, config);
+                        Plotly.newPlot(this.div, data, cloneDeep(layout), config);
                         if (this.div.on) {
                             const chart = this.div;
                             chart.on('plotly_click', () => chart.parentElement.click());

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -243,10 +243,10 @@ const now = Date.now();
                         Plotly.Plots.resize(this.div);
                         break;
                     case RenderType.UPDATE:
-                        Plotly.update(this.div, data, cloneDeep(layout));
+                        Plotly.update(this.div, data, layout);
                         break;
                     case RenderType.NEW_PLOT:
-                        Plotly.newPlot(this.div, data, cloneDeep(layout), config);
+                        Plotly.newPlot(this.div, data, layout, config);
                         if (this.div.on) {
                             const chart = this.div;
                             chart.on('plotly_click', () => chart.parentElement.click());

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -341,19 +341,13 @@ isDebug() && console.log(`${renderType.toString()} ${dataUpdateTraces} elapsed: 
         // chart image download relies on div id matching chartId
         const nstyle = Object.assign({position:'relative', height: '100%', width: '100%'}, style);
         return (
-            <div style={nstyle}
-                 onClick={stopPropagation}
-                 onTouchStart={stopPropagation}
-                 onMouseDown={stopPropagation} >
+            <div style={nstyle} >
                 <div id={chartId || this.id} style={{height: '100%', width: '100%'}} ref={this.refUpdate}/>
                 {showMask && <div style={maskWrapper}> <div className='loading-mask'/> </div>}
             </div>
         );
     }
 }
-
-
-const stopPropagation= (ev) => ev.stopPropagation();
 
 PlotlyWrapper.propTypes = {
     chartId: PropTypes.string,

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -6,7 +6,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
 
-import {get, debounce, isEmpty, set, omit, cloneDeep} from 'lodash';
+import {get, debounce, isEmpty, set, omit} from 'lodash';
 import {getPlotLy} from '../PlotlyConfig.js';
 import {getChartData, useChartRedraw, useScatterGL} from '../ChartsCntlr.js';
 import {logError, deltas, flattenObject} from '../../util/WebUtil.js';
@@ -46,13 +46,6 @@ function isSlowResize() {
     return BrowserInfo.isFirefox();
 }
 
-function findNewBar() {
-    const newChart = getChartData('newBar');
-    const l = get(newChart, ['layout', 'xaxis', 'range']);
-    if (l) {
-        console.log(l);
-    }
-}
 
 export function downloadChart(chartId) {
     getPlotLy().then( (Plotly) => {

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -17,6 +17,7 @@ import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
 import {updateSet} from '../../../util/WebUtil.js';
 import {hideColSelectPopup} from '../ColSelectView.jsx';
 import {addColorbarChanges} from '../../dataTypes/FireflyHeatmap.js';
+import {getColumnType, getTblById} from '../../../tables/TableUtil.js';
 
 const fieldProps = {labelWidth: 50, size: 25};
 const boundariesFieldProps = {labelWidth: 35, size: 10};
@@ -29,8 +30,8 @@ const X_AXIS_OPTIONS = [
     {label: 'top', value: 'opposite'},
     {label: 'log', value: 'log'}
 ];
-
 const X_AXIS_OPTIONS_NOLOG = X_AXIS_OPTIONS.filter((el) => {return el.label !== 'log';});
+
 
 const Y_AXIS_OPTIONS = [
     {label: 'grid', value: 'grid'},
@@ -38,6 +39,7 @@ const Y_AXIS_OPTIONS = [
     {label: 'right', value: 'opposite'},
     {label: 'log', value: 'log'}
 ];
+const Y_AXIS_OPTIONS_NOLOG = Y_AXIS_OPTIONS.filter((el) => {return el.label !== 'log';});
 
 function getOptions(a, layout) {
     const opts = [];
@@ -62,11 +64,17 @@ function getOptions(a, layout) {
  * @param type - Plotly chart type
  */
 export function hasMarkerColor(type) {
-    return type.startsWith('scatter') || type.startsWith('histogram') || type === 'box' || type === 'bar' || type === 'area' || type === 'pointcloud';
+    return type.startsWith('scatter') || ['histogram', 'box', 'bar', 'area', 'plotcloud'].includes(type);
 }
 
-function hasNoXY(type) {
-    return type.endsWith('3d') || ['pie','surface'].includes(type);
+function hasNoXY(type, tablesources) {
+    if (type.endsWith('3d') || ['pie', 'surface'].includes(type)) return true;
+
+    const noXYtrace = tablesources.findIndex((trace) => {
+        return (!get(trace, ['mappings', 'x']) || !get(trace, ['mappings', 'y']));
+    });
+
+    return noXYtrace >= 0;
 }
 
 export class BasicOptions extends SimpleComponent {
@@ -86,13 +94,18 @@ export class BasicOptions extends SimpleComponent {
         const tbl_id = get(tablesource, 'tbl_id');
         const type = get(data, `${activeTrace}.type`, 'scatter');
         const noColor = !hasMarkerColor(type);
-        const noXY = hasNoXY(type);
+        const noXY = hasNoXY(type, tablesources);
+        const xColType = noXY ? '' : getColumnType(getTblById(tbl_id), get(tablesource, ['mappings', 'x'], ''));
+        const yColType = noXY ? '' : getColumnType(getTblById(tbl_id), get(tablesource, ['mappings', 'y'], ''));
+        const xNoLog = type.includes('histogram') ? true : undefined;          // histogram2d or histogram2dcontour
+        const yNoLog = type.includes('histogram') ? true : undefined;
+
         return (
             <div style={{minWidth: 250, padding:'0 5px 7px'}}>
                 <OptionTopBar {...{groupKey, activeTrace, chartId, tbl_id}}/>
                 <FieldGroup className='FieldGroup__vertical' keepState={false} groupKey={groupKey}
                             reducerFunc={basicFieldReducer({chartId, activeTrace})}>
-                    <BasicOptionFields {...{activeTrace, groupKey, noColor, noXY}}/>
+                    <BasicOptionFields {...{activeTrace, groupKey, noColor, noXY, xColType, yColType, xNoLog, yNoLog}}/>
                 </FieldGroup>
             </div>
         );
@@ -293,7 +306,8 @@ export class BasicOptionFields extends Component {
     }
 
     render() {
-        const {activeTrace, groupKey, align='vertical', noColor, noXY, xNoLog} = this.props;
+        const {activeTrace, groupKey, align='vertical', noColor, noXY, xNoLog, yNoLog, xColType, yColType} = this.props;
+        const strT = ['str', 'char', 's', 'c'];
 
         // TODO: need color input field
         const colorFldPath = `data.${activeTrace}.marker.color`;
@@ -325,30 +339,34 @@ export class BasicOptionFields extends Component {
                 {!noXY && <div>
                     <ValidationField fieldKey={'layout.xaxis.title'}/>
                     <CheckboxGroupInputField fieldKey='__xoptions'
-                                             options={xNoLog ? X_AXIS_OPTIONS_NOLOG : X_AXIS_OPTIONS}/>
+                                             options={xNoLog || strT.includes(xColType) ? X_AXIS_OPTIONS_NOLOG : X_AXIS_OPTIONS}/>
                     <br/>
                     <ValidationField fieldKey={'layout.yaxis.title'}/>
-                    <CheckboxGroupInputField fieldKey='__yoptions' options={Y_AXIS_OPTIONS}/>
+                    <CheckboxGroupInputField fieldKey='__yoptions'
+                                             options={yNoLog || strT.includes(yColType) ? Y_AXIS_OPTIONS_NOLOG : Y_AXIS_OPTIONS}/>
                     <br/>
                     <div style={helpStyle}>
                         Set plot boundaries if different from data range.
                     </div>
-                    <div style={{display: 'flex', flexDirection: 'row', padding: '5px 15px 0'}}>
-                        <div style={{paddingRight: 5}}>
-                            <ValidationField fieldKey={'fireflyLayout.xaxis.min'}/>
+                    {strT.includes(xColType) ? false :
+                        <div style={{display: 'flex', flexDirection: 'row', padding: '5px 15px 0'}}>
+                            <div style={{paddingRight: 5}}>
+                                <ValidationField fieldKey={'fireflyLayout.xaxis.min'}/>
+                            </div>
+                            <div style={{paddingRight: 5}}>
+                                <ValidationField fieldKey={'fireflyLayout.xaxis.max'}/>
+                            </div>
+                        </div>}
+                    {strT.includes(yColType) ? false :
+                        <div style={{display: 'flex', flexDirection: 'row', padding: '0px 15px 15px'}}>
+                            <div style={{paddingRight: 5}}>
+                                <ValidationField fieldKey={'fireflyLayout.yaxis.min'}/>
+                            </div>
+                            <div style={{paddingRight: 5}}>
+                                <ValidationField fieldKey={'fireflyLayout.yaxis.max'}/>
+                            </div>
                         </div>
-                        <div style={{paddingRight: 5}}>
-                            <ValidationField fieldKey={'fireflyLayout.xaxis.max'}/>
-                        </div>
-                    </div>
-                    <div style={{display: 'flex', flexDirection: 'row', padding: '0px 15px 15px'}}>
-                        <div style={{paddingRight: 5}}>
-                            <ValidationField fieldKey={'fireflyLayout.yaxis.min'}/>
-                        </div>
-                        <div style={{paddingRight: 5}}>
-                            <ValidationField fieldKey={'fireflyLayout.yaxis.max'}/>
-                        </div>
-                    </div>
+                    }
                 </div>}
                 <div style={helpStyle}>
                     Enter display aspect ratio below.<br/>
@@ -378,7 +396,10 @@ BasicOptionFields.propTypes = {
     align: PropTypes.oneOf(['vertical', 'horizontal']),
     noColor: PropTypes.bool,
     xNoLog: PropTypes.bool,
-    noXY: PropTypes.bool
+    yNoLog: PropTypes.bool,
+    noXY: PropTypes.bool,
+    xColType: PropTypes.string,
+    yColType: PropTypes.string
 };
 
 
@@ -436,12 +457,11 @@ export function submitChanges({chartId, fields, tbl_id}) {
                     const range = get(layout, `${a}axis.range`);
 
                     if (opts.includes('flip')) {
-                        if (range) {
+                        if (range) {  
                             if (range[0]<range[1]) changes[`layout.${a}axis.range`] = reverse(range);
                         } else {
                             changes[`layout.${a}axis.autorange`] = 'reversed';
                         }
-
                     } else {
                         if (range) {
                             if (range[1]<range[0]) changes[`layout.${a}axis.range`] = reverse(range);
@@ -456,7 +476,11 @@ export function submitChanges({chartId, fields, tbl_id}) {
                     }
 
                     changes[`layout.${a}axis.showgrid`] = opts.includes('grid');
-                    changes[`layout.${a}axis.type`]  = opts.includes('log') ? 'log' : 'linear';
+                    if (opts.includes('log')) {
+                        changes[`layout.${a}axis.type`] = 'log';
+                    } else if (get(layout, `${a}axis.type`, '') === 'log') {
+                        changes[`layout.${a}axis.type`] = 'linear';
+                    }
                 }
             });
         }
@@ -498,7 +522,7 @@ function adjustAxesRange(layout, changes) {
             changes[`layout.${a}axis.range`] = getRange(minUser, maxUser, changes[`layout.${a}axis.type`] === 'log', reversed);
             changes[`layout.${a}axis.autorange`] = false;
         } else {
-            changes[`layout.${a}axis.autorange`] = true;
+            //changes[`layout.${a}axis.autorange`] = true;
         }
     });
 }

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -32,7 +32,6 @@ const X_AXIS_OPTIONS = [
 ];
 const X_AXIS_OPTIONS_NOLOG = X_AXIS_OPTIONS.filter((el) => {return el.label !== 'log';});
 
-
 const Y_AXIS_OPTIONS = [
     {label: 'grid', value: 'grid'},
     {label: 'reverse', value: 'flip'},
@@ -64,14 +63,14 @@ function getOptions(a, layout) {
  * @param type - Plotly chart type
  */
 export function hasMarkerColor(type) {
-    return type.startsWith('scatter') || ['histogram', 'box', 'bar', 'area', 'plotcloud'].includes(type);
+    return type.startsWith('scatter') || ['histogram', 'box', 'bar', 'plotcloud'].includes(type);
 }
 
 /*
  * check if the trace is not 3d-like chart or pie and has x and y defined
 */
 function hasNoXY(type, tablesource) {
-    if (type.endsWith('3d') || ['pie', 'surface'].includes(type)) return true;
+    if (type.endsWith('3d') || ['pie', 'surface', 'bar', 'area'].includes(type)) return true;
 
     return (!get(tablesource, ['mappings', 'x']) || !get(tablesource, ['mappings', 'y']));
 }

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -67,14 +67,13 @@ export function hasMarkerColor(type) {
     return type.startsWith('scatter') || ['histogram', 'box', 'bar', 'area', 'plotcloud'].includes(type);
 }
 
-function hasNoXY(type, tablesources) {
+/*
+ * check if the trace is not 3d-like chart or pie and has x and y defined
+*/
+function hasNoXY(type, tablesource) {
     if (type.endsWith('3d') || ['pie', 'surface'].includes(type)) return true;
 
-    const noXYtrace = tablesources.findIndex((trace) => {
-        return (!get(trace, ['mappings', 'x']) || !get(trace, ['mappings', 'y']));
-    });
-
-    return noXYtrace >= 0;
+    return (!get(tablesource, ['mappings', 'x']) || !get(tablesource, ['mappings', 'y']));
 }
 
 export class BasicOptions extends SimpleComponent {
@@ -94,7 +93,7 @@ export class BasicOptions extends SimpleComponent {
         const tbl_id = get(tablesource, 'tbl_id');
         const type = get(data, `${activeTrace}.type`, 'scatter');
         const noColor = !hasMarkerColor(type);
-        const noXY = hasNoXY(type, tablesources);
+        const noXY = hasNoXY(type, tablesource);
         const xColType = noXY ? '' : getColumnType(getTblById(tbl_id), get(tablesource, ['mappings', 'x'], ''));
         const yColType = noXY ? '' : getColumnType(getTblById(tbl_id), get(tablesource, ['mappings', 'y'], ''));
         const xNoLog = type.includes('histogram') ? true : undefined;          // histogram2d or histogram2dcontour

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -444,6 +444,20 @@ export function getColumnIdx(tableModel, colName) {
 }
 
 /**
+ * Returns the column data type with the given name
+ * @param {TableModel} tableModel
+ * @param {string} colName
+ * @returns {string}
+ * @public getColumnType
+ */
+export function getColumnType(tableModel, colName) {
+    const cols = get(tableModel, 'tableData.columns', []);
+
+    return get(cols.find((col)=> col.name === colName), 'type', '');
+}
+
+
+/**
  * returns column information for the given name.
  * @param {TableModel} tableModel
  * @param {string} colName


### PR DESCRIPTION
This development includes:
- render plotly charts by giving any plotly data and layout JSON description. 
- put Firefly like tool bar for each plotly chart either recognized or unrecognized by Firefly. The tool bar rendering is classified into the following groups, 
1. basic tool bar with buttons for 
   download chart as PNG + show/edit filter + chart options and tools + Expand panel (for Pie) 
2.  1 + buttons for 
     Zoom to the original range + Zoom + Pan (for Histogram, bar, box)
3.  2 + buttons for  select (for each trace with x, y data directly mapped to table  numerical columns, like scatter, histogram2d, histogram2dcontour, heatmap)
4.  2 + buttons for orbital rotation + turntable rotation
     (for 3D-like charts, such as scatter3d, surface, mesh3d) 

- update the chart options and tools side bar content for Firefly unrecognized charts. 
   update the logic for XY options, XY range, marker color, etc. 
- fixed the issue that the mouse actions on the side bar may inaccurately move the entire grid unit of that chart. 

Test:
run demo/ffapi-slate-test3.html to get the following chart samples: 
histogram, surface, bar, pie, histogram2dcontour and box. 
The chart samples are made for showing purpose with no significant meanings. 
 