### PR TITLE
IRSA-257 (amended): added cookies when getting IBE url download

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
@@ -8,6 +8,7 @@ import edu.caltech.ipac.astro.IpacTableReader;
 import edu.caltech.ipac.astro.ibe.datasource.PtfIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
 import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.URLFileInfoProcessor;
 import edu.caltech.ipac.util.DataGroup;
@@ -176,7 +177,9 @@ public class IBE {
                 progressKey= sourceParams.get("ProgressKey");
                 plotId= sourceParams.get("plotId");
             }
-            return URLFileInfoProcessor.retrieveViaURL(url,dir, progressKey, plotId, null, null);
+            Map<String, String> identityCookies = ServerContext.getRequestOwner().getIdentityCookies();
+
+            return URLFileInfoProcessor.retrieveViaURL(url,dir, progressKey, plotId, null, identityCookies);
         } catch (DataAccessException e) {
             throw new IOException(e.getMessage(), e);
         }


### PR DESCRIPTION
Added the cookies to the download URL for IBE when a user is logged in via SSO for example.
This fixed the previous change https://github.com/Caltech-IPAC/firefly/pull/430 which was made on the FileInfo but the file was already fetched by then. The set of the cookie has to happen elsewhere. The issue was partially fixed in the PtfIbeResolver which was using the authentication cookies but the images were not.