### PR TITLE
DM-11603 Make column expression to work for all plotly charts 

### DIFF
--- a/src/firefly/html/demo/ffapi-slate-test3.html
+++ b/src/firefly/html/demo/ffapi-slate-test3.html
@@ -76,7 +76,7 @@ Some unsupported plotly charts:
 <ul>
 
     <li>
-        <a href='javascript:load3DChart(0,0,2,2)'>Show 3D Scatter </a> <span class='smallCoords'>at row: 0, col: 0, w:2 h: 2</span>
+        <a href='javascript:load2DScatter(0,0,2,2)'>Show Plotly Scatter </a> <span class='smallCoords'>at row: 0, col: 0, w:2 h: 2</span>
     </li>
     <li>
         <a href="javascript:loadSurface(0,2,2,2)">Show Surface </a><span class='smallCoords'>at row: 0, col: 2, w: 2, h: 2</span>
@@ -109,6 +109,34 @@ Some unsupported plotly charts:
 
         function getSTarget() {
             return document.getElementById('sTarget').value;
+        }
+
+        function load2DScatter(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'newChartContainer');
+
+            var trace1 = {
+                tbl_id: "wiseCatTbl",
+                x: "tables::w1mpro-w2mpro",
+                y: "tables::w2mpro-w3mpro",
+                mode: 'markers',
+                type: 'scatter',
+                error_x : {array: "tables::w3sigmpro"},
+                error_y : {array: "tables::w4sigmpro"},
+                marker: {size: 4, opacity: 0.5}
+            };
+
+            var layoutS = {
+                title: 'Color-Color',
+                xaxis: {title: 'w1mpro-w2mpro (mag)'},
+                yaxis: {title: 'w2mpro-w3mpro (mag)'}
+            };
+
+
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'newChart1', layout: layoutS, data: [trace1]},
+                    'newChartContainer');
+
         }
 
         function load3DChart(r,c,w,h) {

--- a/src/firefly/html/demo/ffapi-slate-test3.html
+++ b/src/firefly/html/demo/ffapi-slate-test3.html
@@ -76,22 +76,22 @@ Some unsupported plotly charts:
 <ul>
 
     <li>
-        <a href='javascript:loadHistogramCharts(0,0,2,2)'>Show Histogram</a> <span class='smallCoords'>at row: 0, col: 0, w:2 h: 2</span>
+        <a href='javascript:load3DChart(0,0,2,2)'>Show 3D Scatter </a> <span class='smallCoords'>at row: 0, col: 0, w:2 h: 2</span>
     </li>
     <li>
-        <a href="javascript:loadSurface(0,2,2,2)">Show Surface</a><span class='smallCoords'>at row: 0, col: 2, w: 2, h: 2</span>
+        <a href="javascript:loadSurface(0,2,2,2)">Show Surface </a><span class='smallCoords'>at row: 0, col: 2, w: 2, h: 2</span>
     </li>
     <li>
-        <a href="javascript:loadBar(2,0,3,3)">Show Bar chart</a><span class='smallCoords'>at row: 2, col: 0, w: 3, h: 3</span>
+        <a href="javascript:loadBar(2,0,3,3)">Show Bar chart </a><span class='smallCoords'>at row: 2, col: 0, w: 3, h: 3</span>
     </li>
     <li>
-        <a href="javascript:loadPie(2,3,3,3)">Show Pie Chart</a><span class='smallCoords'>at row: 2, col: 3, w: 3. h: 3</span>
+        <a href="javascript:loadPie(2,3,3,3)">Show Pie Chart </a><span class='smallCoords'>at row: 2, col: 3, w: 3. h: 3</span>
     </li>
     <li>
-        <a href="javascript:loadDensity(4,0,3,3)">Show Histogram2dContour</a><span class='smallCoords'>at row: 4, col: 0, w: 3, h: 3</span>
+        <a href="javascript:loadDensity(4,0,3,3)">Show Histogram2dContour </a><span class='smallCoords'>at row: 4, col: 0, w: 3, h: 3</span>
     </li>
     <li>
-        <a href="javascript:loadBox(4,3,3,3)">Show Box</a><span class='smallCoords'>at row: 4, col: 3, w: 3, h: 3</span>
+        <a href="javascript:loadBox(4,3,3,3)">Show Box </a><span class='smallCoords'>at row: 4, col: 3, w: 3, h: 3</span>
     </li>
 </ul>
 </body>
@@ -111,6 +111,53 @@ Some unsupported plotly charts:
             return document.getElementById('sTarget').value;
         }
 
+        function load3DChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', '3dChartContainer');
+
+
+            var data3d = [
+                {
+                    tbl_id: "wiseCatTbl",
+                    type: 'scatter3d',
+                    name: 'color-color-color',
+                    x: "tables::w1mpro-w2mpro",
+                    y: "tables::w2mpro-w3mpro",
+                    z: "tables::w3mpro-w4mpro",
+                    mode : 'markers',
+                    marker : {
+                        size: 3,
+                        line: {
+                            color: 'rgb(127, 127, 127, 0.14)',
+                            width: 1
+                        }
+                    },
+                    hoverinfo: 'x+y+z'
+                }
+            ];
+
+            var tfont = {size: 11};
+            var layout3d = {
+                title: 'color-color-color',
+                scene:{
+                    xaxis: {
+                        title: 'w1-w2 (mag)',
+                        titlefont: tfont
+                    },
+                    yaxis: {
+                        title: 'w2-w3 (mag)',
+                        titlefont: tfont
+                    },
+                    zaxis: {
+                        title: 'w3-w4 (mag)',
+                        titlefont: tfont
+                    }
+                }
+            };
+
+            firefly.getViewer().showPlot(
+                    {chartId: 'newChart3', layout: layout3d, data: data3d },
+                    '3dChartContainer');
+        }
 
         function loadHistogramCharts(r,c,w,h) {
             firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'histContainer');

--- a/src/firefly/html/demo/ffapi-slate-test3.html
+++ b/src/firefly/html/demo/ffapi-slate-test3.html
@@ -185,15 +185,15 @@ Some unsupported plotly charts:
             var dataPie = [
                 {
                     tbl_id: "wiseCatTbl",
-                    name: 'Area',
+                    name: 'Stats for (w1+w2)',
                     type: 'pie',
-                    values: "tables::w1mpro",
+                    values: "tables::w1mpro+w2mpro",
                     labels:  "tables::clon",
                     textinfo: 'none'
                 }];
 
             var layoutPie = {
-                title: 'pie: w1mpro vs. clon',
+                title: 'pie: w1+w2 vs. clon',
                 showlegend: true
             };
 
@@ -231,10 +231,10 @@ Some unsupported plotly charts:
             var dataSurface = [
                 {
                     type: 'surface',
-                    name: 'w1-ra-dec',
+                    name: 'w1-w2-w3',
                     tbl_id: "wiseCatTbl",
-                    x: "tables::ra",
-                    y: "tables::dec",
+                    x: "tables::w1mpro-w2mpro",
+                    y: "tables::w2mpro-w3mpro",
                     z: "tables::w1mpro",
                     hoverinfo: 'x+y+z'
                 }
@@ -242,14 +242,14 @@ Some unsupported plotly charts:
 
             var tfont = {size: 11};
             var layoutSurface = {
-                title: 'Surface on ra & dec',
+                title: 'Surface on w1-w2 & w2-w3',
                 scene:{
                     xaxis: {
-                        title: 'ra (deg)',
+                        title: 'w1-w2 (deg)',
                         titlefont: tfont
                     },
                     yaxis: {
-                        title: 'dec (deg)',
+                        title: 'w2-w3 (deg)',
                         titlefont: tfont
                     }
                 }
@@ -267,15 +267,15 @@ Some unsupported plotly charts:
             var dataBox = [
                 {
                     type: 'box',
-                    name: 'w1mpro',
+                    name: 'w1+w2',
                     tbl_id: "wiseCatTbl",
-                    y: "tables::w1mpro"
+                    y: "tables::w1mpro+w2mpro"
                 },
                 {
                     type: 'box',
-                    name: 'w2mpro',
+                    name: 'w2+w3',
                     tbl_id: "wiseCatTbl",
-                    y: "tables::w2mpro"
+                    y: "tables::w2mpro+w3mpro"
                 }
             ];
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYGenericProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYGenericProcessor.java
@@ -1,0 +1,210 @@
+/**
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupWriter;
+import edu.caltech.ipac.util.*;
+import edu.caltech.ipac.firefly.data.Param;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author tatianag
+ */
+@SearchProcessorImpl(id = "XYGeneric")
+public class XYGenericProcessor extends IpacTablePartProcessor {
+    private static final String SEARCH_REQUEST = "searchRequest";
+    private static final String ColExpKey = "ColOrExp";
+
+    @Override
+    protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
+        String searchRequestJson = request.getParam(SEARCH_REQUEST);
+        DataGroup dg = SearchRequestUtils.dataGroupFromSearchRequest(searchRequestJson);
+        List<Param> allParams = request.getParams();
+        ArrayList<XYWithErrorsProcessor.Col> colsLst = new ArrayList<>();
+        ArrayList<TextCol> txtcolsLst = new ArrayList<>();
+
+        // the output table columns with the names like x, y, z, r, t, values, labels, etc.
+        DataType[] dataTypes = dg.getDataDefinitions();
+        List<String> numericCols = DataObjectUtil.getNumericCols(dataTypes);
+
+        for (Param p: allParams) {
+            String name = p.getName();
+            String colName;
+            String val;
+            XYWithErrorsProcessor.Col  aCol;
+            TextCol tCol;
+
+            if (name.endsWith(ColExpKey)) {
+                colName = name.substring(0, name.length() - ColExpKey.length());
+                val = p.getValue();
+
+                if (stringContainsItemFrom(val, numericCols)) {
+                    aCol = XYWithErrorsProcessor.getCol(dataTypes, val, colName, false);
+                    colsLst.add(aCol);
+                } else {
+                    tCol = getTextCol(dataTypes, val, colName);
+                    txtcolsLst.add(tCol);
+                }
+            }
+        }
+
+        XYWithErrorsProcessor.Col[] cols = colsLst.toArray(new XYWithErrorsProcessor.Col[colsLst.size()]);
+        TextCol[] textcols = txtcolsLst.toArray(new TextCol[txtcolsLst.size()]);
+
+        // create the array of output columns
+        ArrayList<DataGroup.Attribute> colMeta = new ArrayList<>();
+        ArrayList<DataType> columnList = new ArrayList<>();
+
+        XYWithErrorsProcessor.createColumnsToList(columnList, dg, cols, colMeta);
+        createColumnsOnTextCol(columnList, dg, textcols, colMeta);
+        DataType columns [] = columnList.toArray(new DataType[columnList.size()]);
+
+        // create the return data group
+        DataGroup  retVal = new DataGroup("XY Generic", columns);
+        DataObject retRow;
+        String     formatted;
+        DataType   dt;
+        int        numCols = cols.length;
+
+        for (int rIdx = 0; rIdx < dg.size(); rIdx++) {
+            DataObject row = dg.get(rIdx);
+            retRow = new DataObject(retVal);
+
+            // render data from numeric columns
+            for (int c = 0; c < numCols ; c++) {
+                XYWithErrorsProcessor.Col col = cols[c];
+                double val;
+
+                val = col.getter.getValue(row);
+                if (Double.isNaN(val) && !col.canBeNaN) {
+                    retRow = null;
+                    break;
+                } else {
+                    dt = columns[c];
+                    formatted = col.getter.getFormattedValue(row);
+                    if (formatted == null) {
+                        retRow.setDataElement(dt, QueryUtil.convertData(dt.getDataType(), val));
+                    } else {
+                        retRow.setFormattedData(dt, formatted);
+                    }
+                }
+            }
+
+            // render data from text columns
+            if (retRow != null && textcols.length > 0) {
+                for (int c = 0; c < textcols.length; c++) {
+                    TextCol tcol = textcols[c];
+                    dt = columns[c + numCols];
+
+                    formatted = tcol.getFormattedValue(row);
+                    if (formatted == null) {
+                        retRow.setDataElement(dt, tcol.getValue(row));
+                    } else {
+                        retRow.setFormattedData(dt, formatted);
+                    }
+                }
+            }
+
+            if (retRow != null) {
+                retVal.add(retRow);
+            }
+        }
+
+        for (XYWithErrorsProcessor.Col c : cols) {
+            colMeta.add(new DataGroup.Attribute(c.exprColName, c.colOrExpr));
+        }
+        for (TextCol c : textcols) {
+            colMeta.add(new DataGroup.Attribute(c.colname, c.colOrExpr));
+        }
+        retVal.setAttributes(colMeta);
+        File outFile = createFile(request);
+        DataGroupWriter.write(outFile, retVal);
+        return outFile;
+    }
+
+
+    private boolean stringContainsItemFrom(String srcStr, List<String> strList) {
+        for (String colStr : strList) {
+            if (srcStr.contains(colStr)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private TextCol getTextCol(DataType[] dataTypes, String colOrExpr, String exprColName) throws DataAccessException {
+        TextCol tCol = new TextCol(dataTypes, colOrExpr, exprColName);
+        if (!tCol.isValid(dataTypes)) {
+            throw new DataAccessException("Invalid column or expression: "+colOrExpr);
+        }
+        return tCol;
+    }
+
+    private static class TextCol {
+        DataType col;
+        String colname;
+        String colOrExpr;
+
+        TextCol(DataType[] dataTypes, String colOrExpr, String exprColName) {
+            this.colOrExpr = colOrExpr;
+            this.colname = exprColName;
+            this.col = null;
+            for (DataType dt : dataTypes) {
+                if (dt.getKeyName().equals(colOrExpr)) {
+                    this.col = dt;
+                }
+            }
+        }
+
+        boolean isValid(DataType[] dataTypes) {
+            return (col != null);
+        }
+
+        String getValue(DataObject row) {
+            if (col == null) {
+                return "";
+            }
+
+            Object val = row.getDataElement(col);
+            if (val instanceof String) {
+                return (String) val;
+            } else {
+                try {
+                    return String.valueOf(val);
+                }
+                catch (Exception ex)
+                {
+                    return "";
+                }
+            }
+        }
+
+        String getFormattedValue(DataObject row){
+            return row.getFormatedData(col);
+        }
+    }
+
+    private static void createColumnsOnTextCol(ArrayList<DataType>columnList, DataGroup dg,
+                                                     TextCol[] textCols,
+                                                     ArrayList<DataGroup.Attribute> colMeta) {
+        DataType dt, dtDef;
+
+        for (TextCol col : textCols) {
+            dtDef = dg.getDataDefintion(col.colOrExpr);
+            dt = dtDef.copyWithNoColumnIdx(columnList.size());
+            dt.setMaxDataWidth(dtDef.getMaxDataWidth());
+            dt.setFormatInfo(dtDef.getFormatInfo());
+            columnList.add(dt);
+            colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), col.colOrExpr));
+        }
+    }
+
+}
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYGenericProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYGenericProcessor.java
@@ -46,7 +46,7 @@ public class XYGenericProcessor extends IpacTablePartProcessor {
                 val = p.getValue();
 
                 if (stringContainsItemFrom(val, numericCols)) {
-                    aCol = getCol(dataTypes, val, colName, false);
+                    aCol = getCol(dataTypes, val, colName, true);
                     colsLst.add(aCol);
                 } else {
                     tCol = getTextCol(dataTypes, val, colName);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
@@ -113,29 +113,14 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         Col[] cols = colsLst.toArray(new Col[colsLst.size()]);
 
         // create the array of output columns
-        DataType dt, dtSrc;
+        DataType dt;
         ArrayList<DataType> columnList = new ArrayList<>();
         dt = new DataType("rowIdx", Integer.class);
         dt.setFormatInfo(new DataType.FormatInfo(11)); // max num digits in integer, long - 20
         columnList.add(dt);
         ArrayList<DataGroup.Attribute> colMeta = new ArrayList<>();
 
-        for (Col col : cols) {
-            if (col.getter.isExpression()) {
-                dt = new DataType(col.colname, col.colname, Double.class, DataType.Importance.HIGH, "", false);
-                DataType.FormatInfo fi = dt.getFormatInfo();
-                fi.setDataFormat("%.14g");
-                dt.setFormatInfo(fi);
-                columnList.add(dt);
-            } else {
-                dtSrc = dg.getDataDefintion(col.colname);
-                dt = dtSrc.copyWithNoColumnIdx(columnList.size());
-                dt.setMaxDataWidth(dtSrc.getMaxDataWidth());
-                dt.setFormatInfo(dtSrc.getFormatInfo());
-                columnList.add(dt);
-                colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), col.colname));
-            }
-        }
+        createColumnsToList(columnList, dg, cols, colMeta);
         DataType columns [] = columnList.toArray(new DataType[columnList.size()]);
 
         // create the return data group
@@ -198,7 +183,29 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         return outFile;
     }
 
-    private Col getCol(DataType[] dataTypes, String colOrExpr, String exprColName, boolean canBeNaN) throws DataAccessException {
+    public static void createColumnsToList(ArrayList<DataType>columnList, DataGroup dg, Col[] cols,
+                                           ArrayList<DataGroup.Attribute> colMeta) {
+        DataType dt, dtSrc;
+
+        for (Col col : cols) {
+            if (col.getter.isExpression()) {
+                dt = new DataType(col.colname, col.colname, Double.class, DataType.Importance.HIGH, "", false);
+                DataType.FormatInfo fi = dt.getFormatInfo();
+                fi.setDataFormat("%.14g");
+                dt.setFormatInfo(fi);
+                columnList.add(dt);
+            } else {
+                dtSrc = dg.getDataDefintion(col.colname);
+                dt = dtSrc.copyWithNoColumnIdx(columnList.size());
+                dt.setMaxDataWidth(dtSrc.getMaxDataWidth());
+                dt.setFormatInfo(dtSrc.getFormatInfo());
+                columnList.add(dt);
+                colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), col.colname));
+            }
+        }
+    }
+
+    public static Col getCol(DataType[] dataTypes, String colOrExpr, String exprColName, boolean canBeNaN) throws DataAccessException {
         Col col = new Col(dataTypes, colOrExpr, exprColName, canBeNaN);
         if (!col.getter.isValid()) {
             throw new DataAccessException("Invalid column or expression: "+colOrExpr);
@@ -207,7 +214,7 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
     }
 
 
-    private static class Col {
+    public static class Col {
         DataObjectUtil.DoubleValueGetter getter;
         String colname;
         String exprColName;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/XYWithErrorsProcessor.java
@@ -67,50 +67,50 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         DataType[] dataTypes = dg.getDataDefinitions();
 
         // create the array of getters, which know how to get double values
-        ArrayList<Col> colsLst = new ArrayList<>();
-        Col xCol = getCol(dataTypes, xColOrExpr, "x", false);
+        ArrayList<XYGenericProcessor.Col> colsLst = new ArrayList<>();
+        XYGenericProcessor.Col xCol = XYGenericProcessor.getCol(dataTypes, xColOrExpr, "x", false);
         colsLst.add(xCol);
-        colsLst.add(getCol(dataTypes, yColOrExpr, "y", false));
+        colsLst.add(XYGenericProcessor.getCol(dataTypes, yColOrExpr, "y", false));
 
         // columns for color and size maps
         if (!StringUtils.isEmpty(colorColOrExpr)) {
-            colsLst.add(getCol(dataTypes, colorColOrExpr, "color", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, colorColOrExpr, "color", true));
         }
         if (!StringUtils.isEmpty(sizeColOrExpr)) {
-            colsLst.add(getCol(dataTypes, sizeColOrExpr, "size", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, sizeColOrExpr, "size", true));
         }
 
 
-        Col sortCol = null;
+        XYGenericProcessor.Col sortCol = null;
         if (hasSortCol) {
             if (sortColOrExpr.equals(xColOrExpr)) {
                 sortCol = xCol;
             } else {
-                sortCol = getCol(dataTypes, sortColOrExpr, "sortBy", true);
+                sortCol = XYGenericProcessor.getCol(dataTypes, sortColOrExpr, "sortBy", true);
                 colsLst.add(sortCol);
             }
         }
 
         if (hasXError) {
-            colsLst.add(getCol(dataTypes, xErrColOrExpr, "xErr", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, xErrColOrExpr, "xErr", true));
         }
         if (hasXLowError) {
-            colsLst.add(getCol(dataTypes, xErrLowColOrExpr, "xErrLow", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, xErrLowColOrExpr, "xErrLow", true));
         }
         if (hasXHighError) {
-            colsLst.add(getCol(dataTypes, xErrHighColOrExpr, "xErrHigh", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, xErrHighColOrExpr, "xErrHigh", true));
         }
         if (hasYError) {
-            colsLst.add(getCol(dataTypes, yErrColOrExpr, "yErr", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, yErrColOrExpr, "yErr", true));
         }
         if (hasYLowError) {
-            colsLst.add(getCol(dataTypes, yErrLowColOrExpr, "yErrLow", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, yErrLowColOrExpr, "yErrLow", true));
         }
         if (hasYHighError) {
-            colsLst.add(getCol(dataTypes, yErrHighColOrExpr, "yErrHigh", true));
+            colsLst.add(XYGenericProcessor.getCol(dataTypes, yErrHighColOrExpr, "yErrHigh", true));
         }
 
-        Col[] cols = colsLst.toArray(new Col[colsLst.size()]);
+        XYGenericProcessor.Col[] cols = colsLst.toArray(new XYGenericProcessor.Col[colsLst.size()]);
 
         // create the array of output columns
         DataType dt;
@@ -120,7 +120,7 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         columnList.add(dt);
         ArrayList<DataGroup.Attribute> colMeta = new ArrayList<>();
 
-        createColumnsToList(columnList, dg, cols, colMeta);
+        XYGenericProcessor.createColumnsToList(columnList, dg, cols, colMeta);
         DataType columns [] = columnList.toArray(new DataType[columnList.size()]);
 
         // create the return data group
@@ -128,7 +128,7 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
 
         DataObject retrow;
         int ncols = cols.length;
-        Col col;
+        XYGenericProcessor.Col col;
         double val;
         String formatted;
         DataType dtRowIdx = columns[0];
@@ -163,7 +163,7 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         }
 
 
-        for (Col c : cols) {
+        for (XYGenericProcessor.Col c : cols) {
             colMeta.add(new DataGroup.Attribute(c.exprColName, c.colOrExpr));
         }
         if (xCol == sortCol) {
@@ -183,55 +183,5 @@ public class XYWithErrorsProcessor extends IpacTablePartProcessor {
         return outFile;
     }
 
-    public static void createColumnsToList(ArrayList<DataType>columnList, DataGroup dg, Col[] cols,
-                                           ArrayList<DataGroup.Attribute> colMeta) {
-        DataType dt, dtSrc;
-
-        for (Col col : cols) {
-            if (col.getter.isExpression()) {
-                dt = new DataType(col.colname, col.colname, Double.class, DataType.Importance.HIGH, "", false);
-                DataType.FormatInfo fi = dt.getFormatInfo();
-                fi.setDataFormat("%.14g");
-                dt.setFormatInfo(fi);
-                columnList.add(dt);
-            } else {
-                dtSrc = dg.getDataDefintion(col.colname);
-                dt = dtSrc.copyWithNoColumnIdx(columnList.size());
-                dt.setMaxDataWidth(dtSrc.getMaxDataWidth());
-                dt.setFormatInfo(dtSrc.getFormatInfo());
-                columnList.add(dt);
-                colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), col.colname));
-            }
-        }
-    }
-
-    public static Col getCol(DataType[] dataTypes, String colOrExpr, String exprColName, boolean canBeNaN) throws DataAccessException {
-        Col col = new Col(dataTypes, colOrExpr, exprColName, canBeNaN);
-        if (!col.getter.isValid()) {
-            throw new DataAccessException("Invalid column or expression: "+colOrExpr);
-        }
-        return col;
-    }
-
-
-    public static class Col {
-        DataObjectUtil.DoubleValueGetter getter;
-        String colname;
-        String exprColName;
-        String colOrExpr;
-        boolean canBeNaN;
-
-        Col(DataType[] dataTypes, String colOrExpr, String exprColName, boolean canBeNaN) {
-            this.colOrExpr = colOrExpr;
-            this.exprColName = exprColName;
-            this.getter = new DataObjectUtil.DoubleValueGetter(dataTypes, colOrExpr);
-            if (getter.isExpression()) {
-                this.colname = exprColName;
-            } else {
-                this.colname = colOrExpr;
-            }
-            this.canBeNaN = canBeNaN;
-        }
-    }
 }
 

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -12,7 +12,7 @@ import shallowequal from 'shallowequal';
 
 import {flux} from '../Firefly.js';
 import {getAppOptions} from '../core/AppDataCntlr.js';
-import {getTblById, getColumnIdx, getCellValue, cloneRequest, doFetchTable, isFullyLoaded, watchTableChanges, MAX_ROW} from '../tables/TableUtil.js';
+import {getTblById, getColumnIdx, getCellValue, isFullyLoaded, watchTableChanges} from '../tables/TableUtil.js';
 import {TABLE_HIGHLIGHT, TABLE_LOADED, TABLE_SELECT, TABLE_REMOVE} from '../tables/TablesCntlr.js';
 import {dispatchChartUpdate, dispatchChartHighlighted, dispatchChartSelect, getChartData} from './ChartsCntlr.js';
 import {Expression} from '../util/expr/Expression.js';
@@ -325,6 +325,12 @@ export function newTraceFrom(data, selIndexes, newTraceProps) {
 
     const sdata = cloneDeep(pick(data, ['x', 'y', 'z', 'error_x', 'error_y', 'text', 'marker', 'hoverinfo', 'firefly' ]));
     Object.assign(sdata, {showlegend: false, type: get(data, 'type', 'scatter'), mode: 'markers'});
+
+    // the rowIdx doesn't exist for generic plotly chart case
+    if (!get(sdata, 'firefly.rowIdx') && get(sdata, 'x.length', 0) !== 0) {
+        const rowIdx = range(get(sdata, 'x.length')).map(String);
+        set(sdata, 'firefly.rowIdx', rowIdx);
+    }
 
     // walk through object and replace values where there's an array with only the selected indexes.
     function deepReplace(obj) {

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -28,7 +28,7 @@ import {SelectInfo} from '../tables/SelectInfo.js';
 import {getTraceTSEntries as scatterTSGetter} from './dataTypes/FireflyScatter.js';
 import {getTraceTSEntries as histogramTSGetter} from './dataTypes/FireflyHistogram.js';
 import {getTraceTSEntries as heatmapTSGetter} from './dataTypes/FireflyHeatmap.js';
-import {getTraceTSEntries as genericTSGatter} from './dataTypes/FireflyGenericData.js';
+import {getTraceTSEntries as genericTSGetter} from './dataTypes/FireflyGenericData.js';
 
 export const SCATTER = 'scatter';
 export const HEATMAP = 'heatmap';
@@ -277,7 +277,7 @@ export function getRowIdx(traceData, pointIdx) {
 export function getPointIdx(traceData, rowIdx) {
     const rowIdxArray = get(traceData, 'firefly.rowIdx');
     // use double equal in case we compare string to Number
-    return rowIdxArray ? rowIdxArray.findIndex((e) => e === rowIdx) : rowIdx;
+    return rowIdxArray ? rowIdxArray.findIndex((e) => e == rowIdx) : rowIdx;
 }
 
 export function isScatter2d(type) {
@@ -490,7 +490,7 @@ function getTraceTSEntries({chartDataType, traceTS, chartId, traceNum}) {
     } else if (chartDataType === 'fireflyHeatmap') {
         return heatmapTSGetter({traceTS, chartId, traceNum});
     } else {
-        return genericTSGatter({traceTS, chartId, traceNum});
+        return genericTSGetter({traceTS, chartId, traceNum});
     }
 }
 

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -395,9 +395,7 @@ function chartSelect(action) {
         // avoid updating chart twice
         // don't update before table select
         if (!chartTrigger) {
-            if (!isEmpty(selIndexes)) {
-                selected = newTraceFrom(data[activeTrace], selIndexes, SELECTED_PROPS);
-            }
+            selected = newTraceFrom(data[activeTrace], selIndexes, SELECTED_PROPS);
             dispatchChartUpdate({chartId, changes: {selected, selection: undefined}});
         }
     };

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -1,0 +1,74 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {get} from 'lodash';
+import {getTblById, cloneRequest, doFetchTable, makeTblRequest, MAX_ROW} from '../../tables/TableUtil.js';
+import {dispatchChartUpdate, dispatchChartHighlighted, getChartData} from '../ChartsCntlr.js';
+import {getDataChangesForMappings, getPointIdx, updateSelected} from '../ChartUtil.js';
+
+/**
+ * This function creates table source entries to get plotly chart data from the server
+ * (The search processor knows how to handle expressions and eliminates null mapping key)
+ *
+ */
+
+/**
+ * This function creates table source entries to get plotly chart data from the server
+ * (The search processor knows how to handle expressions and eliminates null mapping key)
+ * For the plotly chart which type is not recognized by Firefly
+ * @param traceTS
+ * @returns {{options: *, fetchData: fetchData}}
+ */
+export function getTraceTSEntries({traceTS}) {
+    const {mappings} = traceTS || {};
+    const options = {};
+
+    if (mappings) {
+        Object.keys(mappings).forEach((key) => {
+            options[`${key}ColOrExp`] = mappings[key];
+        });
+        return {options, fetchData};
+    } else {
+        return {};
+    }
+}
+
+function fetchData(chartId, traceNum, tablesource) {
+
+    const {tbl_id, options, mappings} = tablesource;
+    const originalTableModel = getTblById(tbl_id);
+    const {request, highlightedRow, selectInfo} = originalTableModel;
+    const sreq = cloneRequest(request, {startIdx: 0, pageSize: MAX_ROW});
+
+    const req = makeTblRequest('XYGeneric');
+    req.searchRequest = JSON.stringify(sreq);
+    req.startIdx = 0;
+    req.pageSize = MAX_ROW;
+    Object.entries(options).forEach(([k,v]) => v && (req[k]=v));
+
+    doFetchTable(req).then((tableModel) => {
+        if (tableModel.tableData && tableModel.tableData.data) {
+            const {tableMeta} = tableModel;
+            const validCols = Object.keys(mappings);
+
+            tableModel.tableData.columns.forEach((col) => {
+                const name = col.name;
+                if (validCols.includes(name) && tableMeta[name]) {
+                    col.name = tableMeta[name];
+                }
+            });
+
+            const changes = getDataChangesForMappings({tableModel, mappings, traceNum});
+
+            dispatchChartUpdate({chartId, changes});
+            const traceData = get(getChartData(chartId), `data.${traceNum}`);
+            dispatchChartHighlighted({chartId, highlighted: getPointIdx(traceData,highlightedRow)});   // update highlighted point in chart
+            updateSelected(chartId, selectInfo);
+        }
+    }).catch(
+        (reason) => {
+            console.error(`Failed to fetch data for ${chartId} trace ${traceNum}: ${reason}`);
+        }
+    );
+}
+

--- a/src/firefly/js/charts/dataTypes/FireflyScatter.js
+++ b/src/firefly/js/charts/dataTypes/FireflyScatter.js
@@ -104,9 +104,11 @@ function fetchData(chartId, traceNum, tablesource) {
             const yColumn = getColumn(tableModel, get(mappings, 'y'));
             const yUnit = get(yColumn, 'units', '');
 
+            const traceData = get(getChartData(chartId), `data.${traceNum}`);
+
             addOtherChanges({changes, xLabel, xTipLabel, xUnit, yLabel, yTipLabel, yUnit, chartId, traceNum});
             dispatchChartUpdate({chartId, changes});
-            dispatchChartHighlighted({chartId, highlighted: getPointIdx(highlightedRow)});   // update highlighted point in chart
+            dispatchChartHighlighted({chartId, highlighted: getPointIdx(traceData, highlightedRow)});   // update highlighted point in chart
             updateSelected(chartId, selectInfo);
         }
     }).catch(


### PR DESCRIPTION
This development includes
- a generic search processor to handle column expression which is  related to at least on numeric column or one 'text' column from the searched table.  
- a generic chart data handler to create table source entries to get plotly chart data from the server when the trace data is defined on table columns, like x: 'tables:w1mpro+w2mpro'. The data related keyword is not limited to be like 'x' or 'y' only in the JSON description. It varies based on the chart type, ex. pie chart has data defined on 'labels' and 'values'. 

Test: 
try  to run ffpai-slate-test3.html in which the data of some charts is defined in column expression style. 
