### PR TITLE
DM-11601 showChart API changes

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-charttest.html
+++ b/src/firefly/html/demo/ffapi-highlevel-charttest.html
@@ -31,7 +31,7 @@
 <br/><br/>
 <div id="xyplotHere" style="width: 800px; height: 550px; border: solid 1px;"></div>
 <br/><br/>
-<div id="plotly" style="resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px; border: solid 1px gray;"></div>
+<div id="plotlyDiv" style="resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px; border: solid 1px gray;"></div>
 <br/><br/>
 <div id="table-1" style="width: 800px; height: 550px; border: solid 1px;"></div>
 <br/><br/>
@@ -97,33 +97,36 @@
 //            firefly.util.renderDOM('histogramHere', firefly.ui.Histogram, props);
 
             var dataH = [
-                {name: 'dec-0.02', marker: {color: 'rgba(153, 51, 153, 0.8)'}},
-                {name: 'dec+0.02', marker: {color: 'rgba(102,153,0, 0.7)'}}
-            ];
-
-            var fireflyDataH = [
                 {
-                    dataType: 'fireflyHistogram',
-                    tbl_id: 'test-tbl',
-                    options: {
-                        algorithm: 'fixedSizeBins',
-                        fixedBinSizeSelection: 'numBins',
-                        numBins: 30,
-                        columnOrExpr: 'dec-0.02'
-                    }
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'test-tbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 30,
+                            columnOrExpr: 'dec-0.02'
+                        }
+                    },
+                    name: 'dec-0.02',
+                    marker: {color: 'rgba(153, 51, 153, 0.8)'}
                 },
                 {
-                    dataType: 'fireflyHistogram',
-                    tbl_id: 'test-tbl',
-                    options: {
-                        algorithm: 'fixedSizeBins',
-                        fixedBinSizeSelection: 'numBins',
-                        numBins: 40,
-                        columnOrExpr: 'dec+0.02'   // same column but shifted
-                    }
-                }
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'test-tbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 40,
+                            columnOrExpr: 'dec+0.02'   // same column but shifted
+                        }
+                    },
+                    name: 'dec+0.02',
+                    marker: {color: 'rgba(102,153,0, 0.7)'}}
             ];
-            firefly.showPlot('histogramHere', {chartId: 'firefly-hist-tbl', chartType: 'plot.ly', data: dataH, fireflyData: fireflyDataH});
+
+            firefly.showChart('histogramHere', {data: dataH});
 
 
             // show scatter chart
@@ -151,7 +154,7 @@
             };
 
             var data = [trace1, trace2];
-            firefly.showPlot('plotly', {chartId: 'test', chartType: 'plot.ly', data: data});
+            firefly.showChart('plotlyDiv', {data: data});
 
 
             var tblReq =  firefly.util.table.makeIrsaCatalogRequest('allwise_p3as_psd', 'WISE', 'allwise_p3as_psd',
@@ -167,14 +170,14 @@
             firefly.showTable('table-1', tblReq);
 
             trace1 = {
-                tbl_id: "test-tbl",
-                x: "tables::ra",
-                y: "tables::dec",
-                mode: 'markers',
-                type: 'scatter'
+                type: 'fireflyScatter',
+                tbl_id: 'test-tbl',
+                x: 'tables::ra',
+                y: 'tables::dec',
+                mode: 'markers'
             };
 
-            firefly.showPlot('plotly', {chartId: 'plotly-tbl', chartType: 'plot.ly', data: [trace1], fireflyData: [{dataType: 'fireflyScatter'}]});
+            firefly.showChart('plotlyDiv', {data: [trace1]});
 
 
             var tblReqLg =  firefly.util.table.makeIrsaCatalogRequest('allwise_p3as_psd', 'WISE', 'allwise_p3as_psd',
@@ -187,38 +190,33 @@
 
             var dataHM = [
                 {
+                    type: 'fireflyHeatmap',
                     tbl_id: "test-tbl-lg",
-                    type: 'heatmap',
-                    name: 'w1-w2',
                     x: "tables::w1mpro",
                     y: "tables::w2mpro",
+                    name: 'w1-w2',
                     colorscale: 'Blues'
                 },
                 {
+                    type: 'fireflyHeatmap',
                     tbl_id: "test-tbl-lg",
-                    type: 'heatmap',
-                    name: 'w1-w3',
                     x: "tables::w1mpro",
                     y: "tables::w3mpro",
+                    name: 'w1-w3',
                     colorscale: 'Reds',
                     reversescale: true
                 },
                 {
+                    type: 'fireflyHeatmap',
                     tbl_id: "test-tbl-lg",
-                    type: 'heatmap',
-                    name: 'w1-w4',
                     x: "tables::w1mpro",
                     y: "tables::w4mpro",
+                    name: 'w1-w4',
                     colorscale: 'Greens'
                 }
             ];
-            var	fireflyDataHM = [
-                {dataType: 'fireflyHeatmap'},
-                {dataType: 'fireflyHeatmap'},
-                {dataType: 'fireflyHeatmap'}
-            ];
 
-            firefly.showPlot('heatmapHere', {chartId: 'plotly-tbl-lg', chartType: 'plot.ly', data: dataHM, fireflyData: fireflyDataHM});
+            firefly.showChart('heatmapHere', {data: dataHM});
 
         }
     }

--- a/src/firefly/html/demo/ffapi-slate-test2.html
+++ b/src/firefly/html/demo/ffapi-slate-test2.html
@@ -167,7 +167,7 @@ Images
                 x: "tables::w1mpro-w2mpro",
                 y: "tables::w2mpro-w3mpro",
                 mode: 'markers',
-                type: 'scatter',
+                type: 'fireflyScatter',
                 marker: {size: 4, opacity: 0.5}
             };
 
@@ -177,8 +177,8 @@ Images
                 yaxis: {title: 'w2mpro-w3mpro (mag)'}
             };
 
-            firefly.getViewer().showPlot(
-                    {chartId: 'newChart1', layout: layoutS, data: [trace1], fireflyData: [{dataType: 'fireflyScatter'}]},
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart1', layout: layoutS, data: [trace1]},
                     'newChartContainer');
         }
 
@@ -188,56 +188,49 @@ Images
 
             var dataHM = [
                 {
+                    type: 'fireflyHeatmap',
                     tbl_id: "wiseCatTbl",
-                    type: 'heatmap',
-                    name: 'w1-w2',
                     x: "tables::w1mpro",
                     y: "tables::w2mpro",
+                    name: 'w1-w2',
                     colorscale: 'Blues'
                 },
                 {
+                    type: 'fireflyHeatmap',
                     tbl_id: "wiseCatTbl",
-                    type: 'heatmap',
-                    name: 'w1-w3',
                     x: "tables::w1mpro",
                     y: "tables::w3mpro",
+                    name: 'w1-w3',
                     colorscale: 'Reds',
                     reversescale: true
                 },
                 {
+                    type: 'fireflyHeatmap',
                     tbl_id: "wiseCatTbl",
-                    type: 'heatmap',
-                    name: 'w1-w4',
                     x: "tables::w1mpro",
                     y: "tables::w4mpro",
+                    name: 'w1-w4',
                     colorscale: 'Greens'
                 }
-            ];
-            // use firefly algorithm to create heatmap data
-            var	fireflyDataHM = [
-                {dataType: 'fireflyHeatmap'},
-                {dataType: 'fireflyHeatmap'},
-                {dataType: 'fireflyHeatmap'}
             ];
             var layoutHM = {
                 title: 'Magnitude-magnitude densities',
                 xaxis: {title: 'w1 photometry (mag)'},
-                yaxis: {title: ''}
-            };
-            // user boundaries - so that heatmaps will be calculated in the same XY space
-            var fireflyLayoutHM = {
-                xaxis: {
-                    min: 5,
-                    max: 20
-                },
-                yaxis: {
-                    min: 4,
-                    max: 18
+                yaxis: {title: ''},
+                firefly: { // user boundaries - so that heatmaps will be calculated in the same XY space
+                    xaxis: {
+                        min: 5,
+                        max: 20
+                    },
+                    yaxis: {
+                        min: 4,
+                        max: 18
+                    }
                 }
             };
 
-            firefly.getViewer().showPlot(
-                    {chartId: 'newChart2', layout: layoutHM,  data: dataHM, fireflyData:fireflyDataHM, fireflyLayout:fireflyLayoutHM},
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart2', layout: layoutHM,  data: dataHM},
                     'heatMapContainer');
         }
 
@@ -245,31 +238,33 @@ Images
             firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'histContainer');
 
             var dataH = [
-                {name: 'w1mpro', marker: {color: 'rgba(153, 51, 153, 0.8)'}},
-                {name: 'w2mpro', marker: {color: 'rgba(102,153,0, 0.7)'}}
-            ];
-
-            var fireflyDataH = [
                 {
-                    dataType: 'fireflyHistogram',
-                    tbl_id: 'wiseCatTbl',
-                    options: {
-                        algorithm: 'fixedSizeBins',
-                        fixedBinSizeSelection: 'numBins',
-                        numBins: 30,
-                        columnOrExpr: 'w1mpro'
-                    }
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 30,
+                            columnOrExpr: 'w1mpro'
+                        }
+                    },
+                    name: 'w1mpro',
+                    marker: {color: 'rgba(153, 51, 153, 0.8)'}
                 },
                 {
-                    dataType: 'fireflyHistogram',
-                    tbl_id: 'wiseCatTbl',
-                    options: {
-                        algorithm: 'fixedSizeBins',
-                        fixedBinSizeSelection: 'numBins',
-                        numBins: 40,
-                        columnOrExpr: 'w2mpro'   // same column but shifted
-                    }
-                }
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 40,
+                            columnOrExpr: 'w2mpro'
+                        }
+                    },
+                    name: 'w2mpro',
+                    marker: {color: 'rgba(102,153,0, 0.7)'}}
             ];
 
             var layoutHist = {
@@ -278,8 +273,8 @@ Images
                 yaxis: {title: ''}
             };
 
-            firefly.getViewer().showPlot(
-                    {chartId: 'firefly-hist-tbl', layout: layoutHist, data: dataH, fireflyData: fireflyDataH},
+            firefly.getViewer().showChart(
+                    {chartId: 'firefly-hist-tbl', layout: layoutHist, data: dataH},
                     'histContainer');
         }
 
@@ -326,7 +321,7 @@ Images
                 }
             };
 
-            firefly.getViewer().showPlot(
+            firefly.getViewer().showChart(
                     {chartId: 'newChart3', layout: layout3d, data: data3d },
                     '3dChartContainer');
         }

--- a/src/firefly/html/demo/ffapi-slate-test3.html
+++ b/src/firefly/html/demo/ffapi-slate-test3.html
@@ -116,31 +116,33 @@ Some unsupported plotly charts:
             firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'histContainer');
 
             var dataH = [
-                {name: 'w1mpro', marker: {color: 'rgba(153, 51, 153, 0.8)'}},
-                {name: 'w2mpro', marker: {color: 'rgba(102,153,0, 0.7)'}}
-            ];
-
-            var fireflyDataH = [
                 {
-                    dataType: 'fireflyHistogram',
-                    tbl_id: 'wiseCatTbl',
-                    options: {
-                        algorithm: 'fixedSizeBins',
-                        fixedBinSizeSelection: 'numBins',
-                        numBins: 30,
-                        columnOrExpr: 'w1mpro'
-                    }
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 30,
+                            columnOrExpr: 'w1mpro'
+                        }
+                    },
+                    name: 'w1mpro',
+                    marker: {color: 'rgba(153, 51, 153, 0.8)'}
                 },
                 {
-                    dataType: 'fireflyHistogram',
-                    tbl_id: 'wiseCatTbl',
-                    options: {
-                        algorithm: 'fixedSizeBins',
-                        fixedBinSizeSelection: 'numBins',
-                        numBins: 40,
-                        columnOrExpr: 'w2mpro'   // same column but shifted
-                    }
-                }
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 40,
+                            columnOrExpr: 'w2mpro'
+                        }
+                    },
+                    name: 'w2mpro',
+                    marker: {color: 'rgba(102,153,0, 0.7)'}}
             ];
 
             var layoutHist = {
@@ -149,8 +151,8 @@ Some unsupported plotly charts:
                 yaxis: {title: ''}
             };
 
-            firefly.getViewer().showPlot(
-                    {chartId: 'firefly-hist-tbl', layout: layoutHist, data: dataH, fireflyData: fireflyDataH},
+            firefly.getViewer().showChart(
+                    {chartId: 'firefly-hist-tbl', layout: layoutHist, data: dataH},
                     'histContainer');
         }
 
@@ -175,7 +177,7 @@ Some unsupported plotly charts:
                 yaxis: {tickfont:{size: 11, family: 'PT Sans Narrow'}}
             };
 
-            firefly.getViewer().showPlot(
+            firefly.getViewer().showChart(
                     {chartId: 'newBar', data: dataBar, layout: layoutBar}, 'barContainer');
         }
 
@@ -197,7 +199,7 @@ Some unsupported plotly charts:
                 showlegend: true
             };
 
-            firefly.getViewer().showPlot(
+            firefly.getViewer().showChart(
                     {chartId: 'newPie', data: dataPie, layout: layoutPie}, 'pieContainer');
         }
 
@@ -220,7 +222,7 @@ Some unsupported plotly charts:
                 yaxis: {title: 'dec'}
             };
 
-            firefly.getViewer().showPlot(
+            firefly.getViewer().showChart(
                     {chartId: 'newhist2dcontour', data: dataContour, layout: layoutContour}, 'h2dcontourContainer');
         }
 
@@ -255,7 +257,7 @@ Some unsupported plotly charts:
                 }
             };
 
-            firefly.getViewer().showPlot(
+            firefly.getViewer().showChart(
                     {chartId: 'newSurface', layout: layoutSurface, data: dataSurface },
                     'surfaceContainer');
         }
@@ -285,7 +287,7 @@ Some unsupported plotly charts:
                 titlefont: tfont
             };
 
-            firefly.getViewer().showPlot(
+            firefly.getViewer().showChart(
                     {chartId: 'newBox', layout: layoutBox, data: dataBox},
                     'boxContainer');
         }

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -152,7 +152,14 @@ function buildTablePart(llApi) {
 
 function buildChartPart(llApi) {
 
-    const showPlot= (targetDiv, parameters)  => doShowPlot(llApi, targetDiv, parameters);
+    /**
+     * @summary The general function to plot a Plotly chart.
+     * @param {string|HTMLDivElement} targetDiv - div to put the chart in.
+     * @param {{data: array.object, layout: object}} parameters - plotly parameters (possibly with firefly extensions)
+     * @memberof firefly
+     * @public
+     */
+    const showChart = (targetDiv, parameters)  => doShowChart(llApi, targetDiv, parameters);
 
     /**
      * @summary The general plotting function to plot an XY Plot.
@@ -185,7 +192,7 @@ function buildChartPart(llApi) {
     const showHistogram= (targetDiv, parameters)  => doShowHistogram(llApi, targetDiv, parameters);
 
 
-    return {showPlot, showXYPlot, addXYPlot, showHistogram};
+    return {showChart, showXYPlot, addXYPlot, showHistogram};
 }
 
 function buildCommon(llApi) {
@@ -395,13 +402,13 @@ function makePlotId(wsConnIdGetter) {
 //---------- Private XYPlot or Histogram functions
 //================================================================
 
-function doShowPlot(llApi, targetDiv, params={}) {
+function doShowChart(llApi, targetDiv, params={}) {
     const {dispatchChartAdd}= llApi.action;
     const {uniqueChartId} = llApi.util.chart;
     const {renderDOM} = llApi.util;
     const {MultiChartViewer}= llApi.ui;
 
-    params = Object.assign({chartId: uniqueChartId, viewerId: targetDiv}, params);
+    params = Object.assign({chartId: uniqueChartId(`${targetDiv}`), viewerId: targetDiv, chartType: 'plot.ly'}, params);
     dispatchChartAdd(params);
 
     renderDOM(targetDiv, MultiChartViewer,

--- a/src/firefly/js/api/ApiViewer.js
+++ b/src/firefly/js/api/ApiViewer.js
@@ -36,7 +36,7 @@ import {REINIT_APP} from '../core/AppDataCntlr.js';
 
 export const ViewerType= new Enum([
     'TriView',  // use what it in the title
-    'Grid', // use the plot description key
+    'Grid' // use the plot description key
 ], { ignoreCase: true });
 
 
@@ -273,14 +273,14 @@ function buildChartPart(channel,file,dispatch) {
 
     /**
      * @summary Show a chart
-     * @param {XYPlotOptions} xyPlotOptions
+     * @param {{chartId: string, data: array.object, layout: object}} options
      * @param {string} viewerId
      * @memberof firefly.ApiViewer
      * @public
      */
-    const showPlot= (xyPlotOptions, viewerId) => {
+    const showChart= (options, viewerId) => {
         doViewerOperation(channel, file, () => {
-            plotRemotePlot(xyPlotOptions, viewerId, dispatch);
+            plotRemoteChart(options, viewerId, dispatch);
         });
     };
 
@@ -312,7 +312,7 @@ function buildChartPart(channel,file,dispatch) {
         });
     };
 
-    return {showPlot, showXYPlot, showHistogram};
+    return {showChart, showXYPlot, showHistogram};
 }
 
 
@@ -340,22 +340,22 @@ export function* doOnWindowConnected({channel, f}) {
         isLoaded = cnt > 0;
     }
     // Added a half second delay before ready to combat a race condition
-    // TODO: loi is going to look it it to determine if application it truely ready
+    // TODO: loi is going to look it it to determine if application it truly ready
     setTimeout(() => f && f(), 500);
 }
 
 
 //================================================================
-//---------- Private XYPlot functions
+//---------- Private Chart functions
 //================================================================
 
 
 /**
- * @param {XYPlotOptions} params - XY plot parameters
+ * @param {{chartId: string, data: array.object, layout: object}} params - chart parameters
  * @param {string} viewerId
  * @param {Function} dispatch - dispatch function
  */
-function plotRemotePlot(params, viewerId, dispatch) {
+function plotRemoteChart(params, viewerId, dispatch) {
 
     const dispatchParams= clone({
         groupId: viewerId || 'default',

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -288,7 +288,7 @@ export function getOptionsUI(chartId) {
     const {data, fireflyData, activeTrace=0} = getChartData(chartId);
     const type = get(data, [activeTrace, 'type'], 'scatter');
     const dataType = get(fireflyData, [activeTrace, 'dataType'], '');
-    if (isScatter2d(type)) {
+    if (dataType === 'fireflyScatter' || isScatter2d(type)) {
         return ScatterOptions;
     } else if (type === 'histogram') {
         return HistogramOptions;

--- a/src/firefly/js/charts/dataTypes/FireflyScatter.js
+++ b/src/firefly/js/charts/dataTypes/FireflyScatter.js
@@ -106,7 +106,8 @@ function fetchData(chartId, traceNum, tablesource) {
 
             addOtherChanges({changes, xLabel, xTipLabel, xUnit, yLabel, yTipLabel, yUnit, chartId, traceNum});
             dispatchChartUpdate({chartId, changes});
-            dispatchChartHighlighted({chartId, highlighted: getPointIdx(highlightedRow)});   // update highlighted point in chart
+            const traceData = get(getChartData(chartId), `data.${traceNum}`);
+            dispatchChartHighlighted({chartId, highlighted: getPointIdx(traceData, highlightedRow)});   // update highlighted point in chart
             updateSelected(chartId, selectInfo);
         }
     }).catch(

--- a/src/firefly/js/charts/dataTypes/FireflyScatter.js
+++ b/src/firefly/js/charts/dataTypes/FireflyScatter.js
@@ -118,6 +118,8 @@ function fetchData(chartId, traceNum, tablesource) {
 
 function addOtherChanges({changes, xLabel, xTipLabel, xUnit, yLabel, yTipLabel, yUnit, chartId, traceNum}) {
 
+    changes[`data.${traceNum}.type`] = 'scatter';
+
     // set default title if it's the first trace
     // and no title is set by the user
     const {layout, data} = getChartData(chartId) || {};

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -11,13 +11,14 @@ import {getColValidator} from './ColumnOrExpression.jsx';
 import {getColValStats} from '../TableStatsCntlr.js';
 
 function getToolbarStates(chartId) {
-    const {selection, selected, activeTrace=0, tablesources, layout, data={}} = getChartData(chartId);
+    const {selection, selected, activeTrace=0, tablesources, layout, data=[]} = getChartData(chartId);
     const {tbl_id} = get(tablesources, [activeTrace], {});
     const {columns} = get(getTblById(tbl_id), ['tableData']) || {};
     const hasFilter = tbl_id && !isEmpty(get(getTblById(tbl_id), 'request.filters'));
     const hasSelection = !isEmpty(selection);
     const traceNames = data.map((t) => t.name).toString();
-    return {hasSelection, hasFilter, activeTrace, tbl_id, hasSelected: !!selected,
+    const activeTraceType = get(data, `${activeTrace}.type`);
+    return {hasSelection, hasFilter, activeTrace, activeTraceType, tbl_id, hasSelected: !!selected,
             dragmode: get(layout, 'dragmode'), traceNames, columns};
 }
 

--- a/src/firefly/js/charts/ui/XYPlotPlotly.jsx
+++ b/src/firefly/js/charts/ui/XYPlotPlotly.jsx
@@ -14,6 +14,8 @@ import {getFormatString} from '../../util/MathUtil.js';
 import {plotParamsShape, plotDataShape} from './XYPlotPropTypes.js';
 import {calculateChartSize, getXAxisOptions, getYAxisOptions, getZoomSelection, formatError,
     isLinePlot, plotErrors, selFiniteMin, selFiniteMax} from './XYPlot.jsx';
+import BrowserInfo from  '../../util/BrowserInfo.js';
+
 
 const defaultShading = 'lin';
 
@@ -210,14 +212,18 @@ function makeSeries(props) {
                 xanchor: yOpposite ? 'right' : 'left',
                 x: yOpposite ? -0.02 : 1.02,
                 thickness: 10,
-                outlinewidth: 0,
-                title: 'pts'
+                outlinewidth: 0
             },
             x,
             y,
             z,
             text: generateTooltips(props, rows)
         };
+        // colorbar.title is causing hover text display issues in Firefox
+        // see https://github.com/plotly/plotly.js/issues/2003
+        if (!BrowserInfo.isFirefox()) {
+            heatmap.colorbar.title = 'pts';
+        }
 
         if (get(params, 'shading', defaultShading) === defaultShading) {
             heatmap.colorscale = [[0, 'rgb(240,240,240)'], [1, 'rgb(37,37,37)']];

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -187,6 +187,7 @@ export function TableSourcesOptions({tablesource={}, activeTrace, groupKey}) {
     // _tables.  is prefixed the fieldKey.  it will be replaced with 'tables::val' on submitChanges.
     const tbl_id = get(tablesource, 'tbl_id');
     const colValStats = getColValStats(tbl_id);
+    if (!colValStats) { return null; }
     const labelWidth = 30;
     const xProps = {fldPath:`_tables.data.${activeTrace}.x`, label: 'X:', name: 'X', nullAllowed: false, colValStats, groupKey, labelWidth};
     const yProps = {fldPath:`_tables.data.${activeTrace}.y`, label: 'Y:', name: 'Y', nullAllowed: false, colValStats, groupKey, labelWidth};


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-11601

- Renamed API function showPlot to showChart and removed fireflyData and fireflyLayout from its parameters.
- Firefly specific options are now under firefly property of data and layout, trace type can be fireflyScatter, fireflyHistogram, and fireflyHeatmap for Firefly extended charts.
- Updated addChart action creator to take care of this change and split plotly and firefly info on the fly.
- Added a workaround for hover text appearing without background in Firefox.