### PR TITLE
DM-5792: Support artifacts on all images that have them (currently wise and 2mass)

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
@@ -93,9 +93,18 @@ public class FileInfo implements HasAccessInfo, Serializable {
     public int getResponseCode() { return StringUtils.getInt(attributes.get(RESPONSE_CODE), 200); }
     public String getResponseCodeMsg() { return attributes.get(RESPONSE_CODE_MSG); }
 
+
+    public void addRelatedDataList(List<RelatedData> rDataList) {
+        if (rDataList==null) return;
+        for(RelatedData rd : rDataList) addRelatedData(rd);
+    }
+
+
     public void addRelatedData(RelatedData rData) {
-        if (relatedData==null) relatedData= new ArrayList<>();
-        relatedData.add(rData);
+        if (rData!=null) {
+            if (relatedData==null) relatedData= new ArrayList<>();
+            relatedData.add(rData);
+        }
     }
 
     public List<RelatedData> getRelatedData() { return relatedData; }

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
@@ -2,16 +2,10 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-/*
- * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
- */
-
 package edu.caltech.ipac.firefly.data;
-
 
 import edu.caltech.ipac.firefly.visualize.RequestType;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
-
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,66 +20,100 @@ public class RelatedData implements Serializable {
 
     private String dataType= ""; // image or table
     private String desc;
+    /** related dataKey should be a unique string for a fits file */
+    private String dataKey;
     private Map<String,String> searchParams= new HashMap<>();
     private Map<String,String> availableMask= new HashMap<>();
 
 
     private RelatedData() {}
 
-    public static RelatedData makeMaskRelatedData(String fileName, Map<String,String> availableMask, int extensionNumber) {
+    /**
+     * Factory method to create mask related data
+     * @param fileName - fits file name on the server
+     * @param availableMask - a map with the key to be the bits number (as a string) and the value to be a description
+     * @param extensionNumber - extension number of the fits file
+     * @param dataKey - should be a unique string for a fits file
+     * @return RelatedData
+     */
+    public static RelatedData makeMaskRelatedData(String fileName, Map<String,String> availableMask, int extensionNumber, String dataKey) {
+        Map<String,String> searchParams= new HashMap<>();
+        searchParams.put(WebPlotRequest.FILE, fileName);
+        searchParams.put(WebPlotRequest.PLOT_AS_MASK, "true");
+        searchParams.put(WebPlotRequest.TYPE, RequestType.FILE+"");
+        searchParams.put(WebPlotRequest.MULTI_IMAGE_IDX, extensionNumber+"");
+        return makeMaskRelatedData(searchParams, availableMask, dataKey);
+    }
+
+    /**
+     * Factory method to create mask related data
+     * @param searchParams- parameters used to make a WebPlotRequest search
+     * @param availableMask - a map with the key to be the bits number (as a string) and the value to be a description
+     * @param dataKey - should be a unique string for a fits file
+     * @return RelatedData
+     */
+    public static RelatedData makeMaskRelatedData(Map<String,String> searchParams, Map<String,String> availableMask, String dataKey) {
         RelatedData d= new RelatedData();
         d.dataType= IMAGE_MASK;
         d.availableMask= availableMask;
 
         d.desc= "Mask";
-        d.searchParams.put(WebPlotRequest.FILE, fileName);
-        d.searchParams.put(WebPlotRequest.PLOT_AS_MASK, "true");
-        d.searchParams.put(WebPlotRequest.TYPE, RequestType.FILE+"");
-        d.searchParams.put(WebPlotRequest.MULTI_IMAGE_IDX, extensionNumber+"");
-
-        return d;
-    }
-
-
-    public static RelatedData makeMaskRelatedData(Map<String,String> searchParams, Map<String,String> availableMask) {
-        RelatedData d= new RelatedData();
-        d.dataType= IMAGE_MASK;
-        d.availableMask= availableMask;
-
-        d.desc= "Mask";
+        d.dataKey = dataKey;
         d.searchParams= searchParams;
         return d;
     }
 
-    public static RelatedData makeImageOverlayRelatedData(String fileName, String desc, int extensionNumber) {
-        RelatedData d= new RelatedData();
-        d.dataType= IMAGE_OVERLAY;
-        d.desc= desc;
-
-        d.searchParams.put(WebPlotRequest.FILE, fileName);
-        d.searchParams.put(WebPlotRequest.TYPE, RequestType.FILE+"");
-        d.searchParams.put(WebPlotRequest.MULTI_IMAGE_IDX, extensionNumber+"");
-        return d;
+    /**
+     * Factory method to create image overlay related data
+     * @param fileName - name of the fits file
+     * @param dataKey - should be a unique string for a fits file
+     * @param desc - description of the data
+     * @param extensionNumber - extenions number in the fits file
+     * @return RelatedData
+     */
+    public static RelatedData makeImageOverlayRelatedData(String fileName, String dataKey, String desc, int extensionNumber) {
+        Map<String,String> searchParams= new HashMap<>();
+        searchParams.put(WebPlotRequest.FILE, fileName);
+        searchParams.put(WebPlotRequest.TYPE, RequestType.FILE+"");
+        searchParams.put(WebPlotRequest.MULTI_IMAGE_IDX, extensionNumber+"");
+        return makeImageOverlayRelatedData(searchParams,dataKey,desc);
     }
 
-    public static RelatedData makeImageOverlayRelatedData(Map<String,String> searchParams, String desc) {
+    /**
+     * Factory method to create image overlay related data
+     * @param searchParams - parameters used to make a WebPlotRequest search
+     * @param dataKey - should be a unique string for a fits file
+     * @param desc - description of the data
+     * @return RelatedData
+     */
+    public static RelatedData makeImageOverlayRelatedData(Map<String,String> searchParams, String dataKey, String desc) {
         RelatedData d= new RelatedData();
         d.dataType= IMAGE_OVERLAY;
         d.desc= desc;
+        d.dataKey = dataKey;
         d.searchParams= searchParams;
         return d;
     }
 
-    public static RelatedData makeTabularRelatedData(Map<String,String> searchParams, String desc) {
+    /**
+     * Factory method to create tabular related data
+     * @param searchParams - parameters us to make a table file type server request
+     * @param dataKey - should be a unique string for a fits file
+     * @param desc - description of the data
+     * @return RelatedData
+     */
+    public static RelatedData makeTabularRelatedData(Map<String,String> searchParams, String dataKey, String desc) {
         RelatedData d= new RelatedData();
         d.dataType= TABLE;
         d.searchParams= searchParams;
+        d.dataKey = dataKey;
         d.desc= desc;
         return d;
     }
 
 
     public String getDataType() { return dataType;}
+    public String getDataKey() { return dataKey;}
     public Map<String,String> getAvailableMask() { return availableMask;}
     public String getDesc() { return desc;}
     public Map<String,String> getSearchParams() { return searchParams;}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ibe/IbeQueryArtifact.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ibe/IbeQueryArtifact.java
@@ -1,0 +1,252 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.firefly.server.query.ibe;
+
+import edu.caltech.ipac.astro.ibe.IBE;
+import edu.caltech.ipac.astro.ibe.datasource.TwoMassIbeDataSource;
+import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.RelatedData;
+import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.data.WiseRequest;
+import edu.caltech.ipac.firefly.data.table.MetaConst;
+import edu.caltech.ipac.firefly.data.table.TableMeta;
+import edu.caltech.ipac.firefly.server.persistence.IbeFileRetrieve;
+import edu.caltech.ipac.firefly.server.persistence.QueryIBE;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.query.IpacTablePartProcessor;
+import edu.caltech.ipac.firefly.server.query.ParamDoc;
+import edu.caltech.ipac.firefly.server.query.SearchManager;
+import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
+import edu.caltech.ipac.firefly.server.visualize.imageretrieve.ServiceRetriever;
+import edu.caltech.ipac.firefly.util.MathUtil;
+import edu.caltech.ipac.util.DataGroup;
+import edu.caltech.ipac.util.DataObject;
+import edu.caltech.ipac.util.DataType;
+import edu.caltech.ipac.util.IpacTableUtil;
+import edu.caltech.ipac.util.StringUtils;
+import edu.caltech.ipac.visualize.plot.CoordinateSys;
+import edu.caltech.ipac.visualize.plot.WorldPt;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Query the IBE for artifacts. Copied and renamed FinderChartQueryArtifact (which is now deprecated).
+ */
+@SearchProcessorImpl(id = "IbeQueryArtifact", params = {
+        @ParamDoc(name = "service", desc = "right now: wise or 2mass, might have more options later"),
+        @ParamDoc(name = "band", desc = "wise band: 1,2,3 or 4, only necessary for wise"),
+        @ParamDoc(name = "type", desc = "artifact type:  wise: P,O,H or D, 2mass: glint or pers"),
+        @ParamDoc(name = "UserTargetWorldPt", desc = "target string, example- 2.3;4.5;EQJ2000 or 6.7;8.9;GAL"),
+        @ParamDoc(name = "subsize", desc = "the radius in degrees"),
+
+        @ParamDoc(name = WiseRequest.HOST, desc = "todo add support for: (optional) the hostname, including port"),
+        @ParamDoc(name = WiseRequest.SCHEMA_GROUP, desc = "todo add support for: the name of the schema group"),
+        @ParamDoc(name = WiseRequest.SCHEMA, desc = "todo add support for: the name of the schema within the schema group")
+})
+public class IbeQueryArtifact extends IpacTablePartProcessor {
+    private static final Logger.LoggerImpl _log = Logger.getLogger();
+    private static final String RA = "ra";
+    private static final String DEC = "dec";
+    public static final String ID= "IbeQueryArtifact";
+
+
+
+    @Override
+    protected File loadDataFile(TableServerRequest req) throws IOException, DataAccessException {
+        return getFinderChartArtifact(req);
+    }
+
+    private File getFinderChartArtifact(TableServerRequest req) throws IOException, DataAccessException {
+        String service = req.getParam("service");
+
+        if (service==null) throw new IOException("Missing service param");
+
+        File retFile = null;
+        if (service.equalsIgnoreCase("wise")) {
+            retFile = getWiseArtifact(req);
+        } else if (service.equalsIgnoreCase("2mass")) {
+            retFile = get2MassArtifact(req);
+        } else {
+            _log.error("getFinderChartArtifact() unable to process TableServerRequest with service="+service);
+        }
+
+        return retFile;
+    }
+
+    @Override
+    public void prepareTableMeta(TableMeta meta, List<DataType> columns, ServerRequest request) {
+        TableMeta.LonLatColumns llc;
+
+        String lonCol = null, latCol = null;
+        for (DataType col : columns) {
+
+            if (col.getKeyName().equalsIgnoreCase(RA)) lonCol = col.getKeyName();
+            if (col.getKeyName().equalsIgnoreCase(DEC)) latCol = col.getKeyName();
+
+            if (!StringUtils.isEmpty(lonCol) && !StringUtils.isEmpty(latCol)) {
+                llc = new TableMeta.LonLatColumns(lonCol, latCol, CoordinateSys.EQ_J2000);
+                meta.setLonLatColumnAttr(MetaConst.CENTER_COLUMN, llc);
+                break;
+            }
+        }
+        super.prepareTableMeta(meta, columns, request);
+    }
+
+    private File getWiseArtifact(final TableServerRequest req) throws IOException, DataAccessException {
+
+        WiseRequest sreq= new WiseRequest();
+        sreq.setParam(QueryIBE.MISSION, WiseIbeDataSource.WISE);
+        sreq.setParam(ServerParams.USER_TARGET_WORLD_PT, req.getParam("UserTargetWorldPt"));
+        sreq.setParam("optLevel", "1b4,3a4");// todo, what is this?
+        sreq.setParam("band", req.getParam("band"));
+        sreq.setParam("subsize", req.getParam("subsize"));
+        sreq.setParam(WiseRequest.PRODUCT_LEVEL, ServiceRetriever.WISE_3A);
+        sreq.setSchema(WiseRequest.ALLWISE_MULTIBAND);
+
+        try {
+            DataObject row = queryIBE(sreq);
+            //Step 2: modify TableServerRequest
+            if (row != null) {
+                sreq.setParams(req.getParams());
+                sreq.setParams(IpacTableUtil.asMap(row));
+
+                return getIBEData(sreq);
+            }
+        } catch (Exception e) {
+            // some may not have artifacts
+        }
+        return null;
+    }
+
+    private File get2MassArtifact(final TableServerRequest req) throws IOException, DataAccessException {
+
+        try {
+            TableServerRequest sreq = new TableServerRequest();
+            sreq.setParam(QueryIBE.MISSION, TwoMassIbeDataSource.TWOMASS);
+            sreq.setParam(TwoMassIbeDataSource.DS_KEY, TwoMassIbeDataSource.DS.ASKY.getName());
+            sreq.setParam(QueryIBE.POS_WORLDPT, req.getParam("UserTargetWorldPt"));
+            sreq.setParam(QueryIBE.RADIUS, get2MassImageSize(req.getParam("subsize")));
+
+            DataObject row = queryIBE(sreq);
+
+            String fname = req.getParam("type").equals("glint") ? "glint.tbl" : "pers.tbl";
+            sreq.setParams(IpacTableUtil.asMap(row));
+            sreq.setParam("fname", fname);
+
+            return getIBEData(sreq);
+
+        } catch (SecurityException  e) {
+            throw new IOException(e.getMessage(), e.getCause());
+        }
+    }
+
+
+    private static double max2massSize = MathUtil.convert(MathUtil.Units.ARCSEC, MathUtil.Units.DEGREE, 500);
+    private static double min2massSize = MathUtil.convert(MathUtil.Units.ARCSEC, MathUtil.Units.DEGREE, 50);
+
+    private static String get2MassImageSize(String v) {
+        //use ServiceRetriever->get2MassPlot(...)
+        double sizeInArcSec = Double.parseDouble(v);
+        if (sizeInArcSec > max2massSize) {
+            return Double.toString(max2massSize);
+        } else if (sizeInArcSec < min2massSize) {
+            return Double.toString(min2massSize);
+        } else {
+            return v;
+        }
+    }
+
+    private static DataObject queryIBE(TableServerRequest req) throws IOException, DataAccessException {
+        req.setRequestId(QueryIBE.PROC_ID);
+        req.setParam(QueryIBE.MOST_CENTER, IBE.MCEN);
+        req.setPageSize(1);
+
+        SearchManager sman= new SearchManager();
+        DataGroupPart primaryData= sman.getDataGroup(req);
+        DataGroup resTable= primaryData.getData();
+
+        if (resTable.values().size() > 0) {
+            return resTable.get(0);
+        } else {
+            throw new DataAccessException("Cannot find IBE data:" + req.toString());
+        }
+    }
+
+    private static File getIBEData(TableServerRequest req) throws IOException, DataAccessException {
+        req.setRequestId(IbeFileRetrieve.PROC_ID);
+
+        SearchManager sman= new SearchManager();
+        FileInfo fileInfo= sman.getFileInfo(req);
+        if (fileInfo != null) {
+            File f = new File(fileInfo.getInternalFilename());
+            return f.canRead() ? f : null;
+        } else {
+            throw new DataAccessException("Cannot find IBE data:" + req.toString());
+        }
+    }
+
+
+    public static  List<RelatedData> getWiseRelatedData(WorldPt wp, String sizeInDeg, String band) {
+
+        List<RelatedData> rdList= new ArrayList<>();
+        rdList.add(makeWiseRelatedDataItem(wp,sizeInDeg,band,"P", "latents","WISE Latents"));
+        rdList.add(makeWiseRelatedDataItem(wp,sizeInDeg,band,"O", "ghost","WISE Optical Ghosts"));
+        rdList.add(makeWiseRelatedDataItem(wp,sizeInDeg,band,"H", "halos","WISE Halos"));
+        rdList.add(makeWiseRelatedDataItem(wp,sizeInDeg,band,"D", "diff_spikes","WISE Diffraction Spikes"));
+        return rdList;
+    }
+
+    public static  List<RelatedData> get2MassRelatedData(WorldPt wp, String sizeInDeg) {
+        List<RelatedData> rdList= new ArrayList<>();
+        rdList.add(get2MassRelatedDataItem(wp,sizeInDeg,"glint","glint_arti","2MASS Glints Artifacts"));
+        rdList.add(get2MassRelatedDataItem(wp,sizeInDeg,"pers","pers_arti","2MASS Persistence Artifacts"));
+        return rdList;
+    }
+
+
+    private static RelatedData makeWiseRelatedDataItem(WorldPt wp, String sizeInDeg, String band,
+                                                String type, String dataKey, String desc) {
+        Map<String,String> params= new HashMap<>();
+        params.put("id", IbeQueryArtifact.ID);
+        params.put("service", "wise");
+        params.put("band", band);
+        params.put("type", type);
+        params.put("subsize", sizeInDeg);
+        params.put(ServerParams.USER_TARGET_WORLD_PT, wp.toString());
+        params.put(WiseRequest.PRODUCT_LEVEL, ServiceRetriever.WISE_3A);
+        return RelatedData.makeTabularRelatedData(params, dataKey, desc);
+    }
+
+    private static RelatedData get2MassRelatedDataItem(WorldPt wp, String sizeInDeg,
+                                                String type, String dataKey, String desc) {
+        Map<String,String> params= new HashMap<>();
+        params.put("id", IbeQueryArtifact.ID);
+        params.put("service", "2mass");
+        params.put("type", type);
+        params.put("subsize", sizeInDeg);
+        params.put(ServerParams.USER_TARGET_WORLD_PT, wp.toString());
+        return RelatedData.makeTabularRelatedData(params, dataKey, desc);
+    }
+
+
+
+
+}
+
+
+
+
+
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -86,6 +86,7 @@ public class VisJsonSerializer {
         }
         retObj.put("searchParams", new JSONObject(rData.getSearchParams()));
         retObj.put("desc", rData.getDesc());
+        retObj.put("dataKey", rData.getDataKey());
         return retObj;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
@@ -159,7 +159,12 @@ public class WebPlotReader {
             else {
                 List<List<RelatedData>> relatedDataList= investigateRelations(fd.getFile(),frAry);
                 for (int i = 0; (i < frAry.length); i++) {
-                    List<RelatedData> rd= relatedDataList!=null ? relatedDataList.get(i) : null;
+                    List<RelatedData> rd= null;
+                    if (relatedDataList!=null || fd.getRelatedData()!=null) {
+                        rd= new ArrayList<>();
+                        if (relatedDataList!=null)  rd.addAll(relatedDataList.get(i));
+                        if (fd.getRelatedData()!=null) rd.addAll(fd.getRelatedData());
+                    }
                     retval[i]= new FileReadInfo(originalFile, frAry[i], band, i, fd.getDesc(), uploadedName, rd, null);
                 }
             }
@@ -442,13 +447,13 @@ public class WebPlotReader {
                         if (!extType.equalsIgnoreCase("IMAGE")) {
                             if (frAry[i].getExtType().equalsIgnoreCase("MASK")) {
                                 RelatedData d= RelatedData.makeMaskRelatedData(f.getAbsolutePath(),
-                                        frAry[i].getImageHeader().maskHeaders, i);
+                                        frAry[i].getImageHeader().maskHeaders, i, "mask");
                                 relatedList.add(d);
                             }
                         }
                         if (extType.equalsIgnoreCase("VARIANCE")) {
                             RelatedData d= RelatedData.makeImageOverlayRelatedData(f.getAbsolutePath(),
-                                    "Variance", i);
+                                    "variance", "Variance", i);
                             relatedList.add(d);
                         }
                     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ProcessorFileRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ProcessorFileRetriever.java
@@ -18,8 +18,6 @@ import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.util.download.ResponseMessage;
 import edu.caltech.ipac.visualize.plot.GeomException;
 
-import java.io.File;
-
 /**
  * @author tatianag
  *         $Id: ProcessorFileRetriever.java,v 1.8 2012/07/27 22:23:29 tatianag Exp $
@@ -46,8 +44,9 @@ public class ProcessorFileRetriever implements FileRetriever {
             if (responseCode>=305) {
                 throw new FailedRequestException(fi.getResponseCodeMsg());
             }
-            File f= new File(fi.getInternalFilename());
-            return new FileInfo(f, f.getName());
+//            File f= new File(fi.getInternalFilename());
+//            return new FileInfo(f, f.getName());
+            return fi;
         } catch (DataAccessException dae) {
             throw ResponseMessage.simplifyNetworkCallException(dae);
         } catch (FailedRequestException e) {

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -54,6 +54,7 @@ import PointSelection from '../drawingLayers/PointSelection.js';
 import StatsPoint from '../drawingLayers/StatsPoint.js';
 import NorthUpCompass from '../drawingLayers/NorthUpCompass.js';
 import Catalog from '../drawingLayers/Catalog.js';
+import Artifact from '../drawingLayers/Artifact.js';
 import WebGrid from '../drawingLayers/WebGrid.js';
 
 import RegionPlot from '../drawingLayers/RegionPlot.js';
@@ -107,7 +108,8 @@ const actionCreators = new Map();
 
 const drawLayerFactory= DrawLayerFactory.makeFactory(ActiveTarget,SelectArea,DistanceTool,
                                                      PointSelection, StatsPoint, NorthUpCompass,
-                                                     Catalog, WebGrid, RegionPlot, MarkerTool, FootprintTool);
+                                                     Catalog, Artifact, WebGrid, RegionPlot,
+                                                     MarkerTool, FootprintTool);
 
 const cdtFactory= chartDataTypeFactory([DATATYPE_XYCOLS, DATATYPE_HISTOGRAM]);
 const chartsFactory= chartTypeFactory([PLOTLY_CHART, SCATTER_TBLVIEW, HISTOGRAM_TBLVIEW]);

--- a/src/firefly/js/drawingLayers/Artifact.js
+++ b/src/firefly/js/drawingLayers/Artifact.js
@@ -32,7 +32,7 @@ const defSymbolMap= {
     diff_spikes: {color: 'orange', symbol: DrawSymbol.DOT, size: 1},
     halos : {color: 'yellow', symbol: DrawSymbol.SQUARE, size: 3},
     ghost : {color: 'pink', symbol: DrawSymbol.DIAMOND, size: 3},
-    latents : {color: 'green', symbol: DrawSymbol.X, size: 3},
+    latents : {color: 'cyan', symbol: DrawSymbol.X, size: 3},
     unknown  : {color: 'blue', symbol: DrawSymbol.X, size: 3},
 };
 

--- a/src/firefly/js/drawingLayers/Artifact.js
+++ b/src/firefly/js/drawingLayers/Artifact.js
@@ -1,0 +1,198 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+
+import {take} from 'redux-saga/effects';
+import {get} from 'lodash';
+import {isPlotIdInPvNewPlotInfoAry,
+         isDrawLayerVisible, getDrawLayerById, getPlotViewById} from '../visualize/PlotViewUtil.js';
+import {getRelatedDataById} from '../visualize/RelatedDataUtil.js';
+import {clone, logError} from '../util/WebUtil.js';
+import ImagePlotCntlr, {visRoot} from '../visualize/ImagePlotCntlr.js';
+import PointDataObj, {DrawSymbol} from '../visualize/draw/PointDataObj.js';
+import {makeDrawingDef, getNextColor} from '../visualize/draw/DrawingDef.js';
+import DrawLayer, {ColorChangeType} from '../visualize/draw/DrawLayer.js';
+import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
+import DrawLayerCntlr, {dlRoot, dispatchModifyCustomField} from '../visualize/DrawLayerCntlr.js';
+import {makeWorldPt} from '../visualize/Point.js';
+import {doFetchTable} from '../tables/TableUtil.js';
+import {getUIComponent} from './CatalogUI.jsx';
+import {dispatchAddSaga} from '../core/MasterSaga.js';
+import {getCenterColumns} from '../tables/TableInfoUtil.js';
+
+const TYPE_ID= 'ARTIFACT_TYPE';
+
+const factoryDef= makeFactoryDef(TYPE_ID,creator,null, getLayerChanges,null,getUIComponent);
+export default {factoryDef, TYPE_ID}; // every draw layer must default export with factoryDef and TYPE_ID
+
+const defSymbolMap= {
+    pers_arti  : {color: 'orange', symbol: DrawSymbol.CROSS, size: 3},
+    glint_arti : {color: 'purple', symbol: DrawSymbol.DIAMOND, size: 3},
+    diff_spikes: {color: 'orange', symbol: DrawSymbol.DOT, size: 1},
+    halos : {color: 'yellow', symbol: DrawSymbol.SQUARE, size: 3},
+    ghost : {color: 'pink', symbol: DrawSymbol.DIAMOND, size: 3},
+    latents : {color: 'green', symbol: DrawSymbol.X, size: 3},
+    unknown  : {color: 'blue', symbol: DrawSymbol.X, size: 3},
+};
+
+
+
+function* watchReplot({plotId, drawLayerId}) {
+    let keepChecking= true;
+    while (keepChecking) {
+        const action = yield take([ImagePlotCntlr.PLOT_IMAGE, ImagePlotCntlr.PLOT_IMAGE_FAIL,
+                                 ImagePlotCntlr.DELETE_PLOT_VIEW, DrawLayerCntlr.DESTROY_DRAWING_LAYER]);
+        const {payload}= action;
+        switch (action.type) {
+            case ImagePlotCntlr.PLOT_IMAGE:
+                if (isPlotIdInPvNewPlotInfoAry(payload.pvNewPlotInfoAry, plotId)) {
+                    updateArtifactTable(plotId, drawLayerId);
+                }
+                break;
+            case ImagePlotCntlr.PLOT_IMAGE_FAIL:
+                if (payload.plotId===plotId) {
+                    dispatchModifyCustomField(drawLayerId, {tableModel:null});
+                }
+                break;
+            case ImagePlotCntlr.DELETE_PLOT_VIEW:
+                keepChecking= (payload.plotId!==plotId);
+                break;
+            case DrawLayerCntlr.DESTROY_DRAWING_LAYER:
+                keepChecking= (payload.drawLayerId!==drawLayerId);
+                break;
+        }
+    }
+}
+
+
+
+
+function updateArtifactTable(plotId, drawLayerId) {
+    const dl= getDrawLayerById(dlRoot(), drawLayerId);
+    const pv= getPlotViewById(visRoot(), plotId);
+    if (!dl || !pv) return;
+    if (isDrawLayerVisible(dl,plotId)) {
+        retrieveArtifactsTable(dl);
+    }
+    else {
+        dispatchModifyCustomField(drawLayerId, {tableModel:null});
+    }
+}
+
+
+
+function retrieveArtifactsTable(drawLayer) {
+    const pv= getPlotViewById(visRoot(), drawLayer.plotId);
+    const rd= getRelatedDataById(pv, drawLayer.relatedDataId);
+
+    if (!rd) return;
+
+    const sendReq= clone(rd.searchParams,{ startIdx : 0, pageSize : 1000000 });
+
+    doFetchTable(sendReq).then(
+        (tableModel) => {
+            if (tableModel.tableData && tableModel.tableData.data) {
+                dispatchModifyCustomField(drawLayer.drawLayerId, {tableModel});
+            }
+        }
+    ).catch(
+        (reason) => {
+            logError(`Failed retried artifact data: ${reason}`, reason);
+        }
+    );
+}
+
+
+
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+//--- The following are functions are used to create and
+//--- operate the drawing layer
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+
+function creator(initPayload, presetDefaults) {
+    const {title, color, angleInRadian=false, relatedDataId, plotId, symbol, size}= initPayload;
+
+    const pv= getPlotViewById(visRoot(), plotId);
+    const rd= getRelatedDataById(pv, relatedDataId);
+
+    const dataKey=  get(rd, 'dataKey');
+
+    const symbolData= defSymbolMap[dataKey] || defSymbolMap['unknown'];
+
+    const drawingDef= Object.assign(makeDrawingDef(),
+        {
+            size: size || symbolData.size || 5,
+            symbol: DrawSymbol.get(symbol) || symbolData.symbol || DrawSymbol.SQUARE
+        },
+        presetDefaults);
+
+    const options= {
+        hasPerPlotData:false,
+        isPointData:true,
+        canUserDelete: true,
+        canUserChangeColor: ColorChangeType.DYNAMIC,
+        titleMatching: true,
+        destroyWhenAllDetached :true
+    };
+
+    drawingDef.color= (color || symbolData.color || getNextColor());
+
+    const dl= DrawLayer.makeDrawLayer(relatedDataId,TYPE_ID, title, options, drawingDef, null, null);
+    dl.tableModel= null;
+    dl.plotId= plotId;
+    dl.relatedDataId= relatedDataId;
+    dl.angleInRadian= angleInRadian;
+
+    dispatchAddSaga(watchReplot, {drawLayerId:dl.drawLayerId, plotId});
+
+    return dl;
+}
+
+
+function getLayerChanges(drawLayer, action) {
+
+    switch (action.type) {
+        case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
+            const {tableModel}= action.payload.changes;
+            return tableModel ? Object.assign({tableModel}, createDrawData(drawLayer, tableModel)) :
+                                {tableModel:null, drawData: null};
+            break;
+
+        case DrawLayerCntlr.ATTACH_LAYER_TO_PLOT:
+        case DrawLayerCntlr.CHANGE_VISIBILITY:
+            if (action.payload.visible && !drawLayer.tableModel) {
+                retrieveArtifactsTable(drawLayer); //start the server retrieve call
+            }
+            break;
+    }
+    return null;
+}
+
+
+
+function toAngle(d, radianToDegree)  {
+    const v= Number(d);
+    return (!isNaN(v) && radianToDegree) ? v*180/Math.PI : v;
+}
+
+function createDrawData(drawLayer, tableModel) {
+    if (!tableModel) return;
+
+    const {tableData}= tableModel;
+    if (!tableData.data.length) return;
+
+    const columns= getCenterColumns(tableModel);
+    if (columns.lonIdx<0 || columns.latIdx<0) return null;
+
+    const {angleInRadian:rad}= drawLayer;
+
+    const data= tableData.data.map( (d) => {
+        const wp= makeWorldPt( toAngle(d[columns.lonIdx],rad), toAngle(d[columns.latIdx],rad), columns.csys);
+        return PointDataObj.make(wp);
+    });
+    return {drawData: {data}};
+}

--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -11,7 +11,7 @@ import FootprintObj from '../visualize/draw/FootprintObj.js';
 import {makeDrawingDef, getNextColor} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {DataTypes,ColorChangeType} from '../visualize/draw/DrawLayer.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
-import DrawLayerCntlr, {SUBGROUP, GroupingScope} from '../visualize/DrawLayerCntlr.js';
+import DrawLayerCntlr, {SUBGROUP} from '../visualize/DrawLayerCntlr.js';
 import {MouseState} from '../visualize/VisMouseSync.js';
 import DrawOp from '../visualize/draw/DrawOp.js';
 import {makeWorldPt} from '../visualize/Point.js';
@@ -66,7 +66,7 @@ function creator(initPayload, presetDefaults) {
         [MouseState.DOWN.key]: highlightChange
     };
 
-    drawingDef.color= (color || tableMeta[MetaConst.DEFAULT_COLOR] || getNextColor());
+    drawingDef.color= (color || get(tableMeta,MetaConst.DEFAULT_COLOR) || getNextColor());
 
     const options= {
         hasPerPlotData:false,
@@ -79,11 +79,11 @@ function creator(initPayload, presetDefaults) {
         dataTooBigForSelection,
         helpLine : helpText,
         canUserChangeColor: ColorChangeType.DYNAMIC,
-        supportSubgroups: Boolean(tableMeta[SUBGROUP])
+        supportSubgroups: Boolean(tableMeta && tableMeta[SUBGROUP])
     };
-    // todo: get the real title
+
     const dl= DrawLayer.makeDrawLayer(catalogId,TYPE_ID, 
-                                      title || `Catalog: ${tableMeta.title || catalogId}`,
+                                      title || `Catalog: ${get(tableMeta,'title',catalogId)}`,
                                       options, drawingDef, null, pairs );
     dl.catalogId= catalogId;
     dl.tableData= tableData;
@@ -234,11 +234,6 @@ function computePointDrawLayer(drawLayer, tableData, columns) {
 }
 
 function computeBoxDrawLayer(drawLayer, tableData, columns) {
-
-    // const lonIdx= findColIdx(tableData.columns, columns.lonCol);
-    // const latIdx= findColIdx(tableData.columns, columns.latCol);
-    // if (lonIdx<0 || latIdx<0) return null;
-
     const {angleInRadian:rad}= drawLayer;
 
     return tableData.data.map( (d) => {

--- a/src/firefly/js/drawingLayers/CatalogUI.jsx
+++ b/src/firefly/js/drawingLayers/CatalogUI.jsx
@@ -2,10 +2,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-/*
- * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
- */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import {RadioGroupInputFieldView} from '../ui/RadioGroupInputFieldView.jsx';
@@ -18,12 +14,6 @@ export const getUIComponent = (drawLayer,pv) => <CatalogUI drawLayer={drawLayer}
 
 function CatalogUI({drawLayer,pv}) {
 
-    const tStyle= {
-        display:'inline-block',
-        whiteSpace: 'nowrap',
-        minWidth: '3em',
-        paddingLeft : 5
-    };
     const options= [ {label: 'All', value: 'GROUP'},
                    {label: 'Row', value: 'SUBGROUP'},
                    {label: 'Image', value: 'SINGLE'}
@@ -54,16 +44,16 @@ function changeVisibilityScope(drawLayer,pv,value) {
     dispatchModifyCustomField( drawLayerId, {groupingScope}, plotId );
     const visible= isDrawLayerVisible(drawLayer,plotId);
     switch (groupingScope) {
-        case GroupingScope.GROUP : //make sure all image match the visibility of the plotId
-            dispatchChangeVisibility(drawLayerId, visible,plotId);
+        case GroupingScope.GROUP : //make sure all images match the visibility of the plotId
+            dispatchChangeVisibility({id:drawLayerId, visible,plotId});
             break;
         case GroupingScope.SUBGROUP : // change all, then put only subgroup back
-            if (visible) dispatchChangeVisibility(drawLayerId, false,plotId);
-            dispatchChangeVisibility(drawLayerId, visible,plotId,true, drawingSubGroupId);
+            if (visible) dispatchChangeVisibility({id:drawLayerId, visible:false,plotId});
+            dispatchChangeVisibility({id:drawLayerId, visible,plotId,subGroupId:drawingSubGroupId});
             break;
         case GroupingScope.SINGLE : // change all, then put only image back
-            if (visible) dispatchChangeVisibility(drawLayerId, false, plotId);
-            dispatchChangeVisibility(drawLayerId, visible,plotId, false);
+            if (visible) dispatchChangeVisibility({id:drawLayerId, visible:false, plotId});
+            dispatchChangeVisibility({id:drawLayerId, visible,plotId, useGroup:false});
             break;
     }
 }

--- a/src/firefly/js/drawingLayers/NorthUpCompassUI.jsx
+++ b/src/firefly/js/drawingLayers/NorthUpCompassUI.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {RadioGroupInputFieldView} from '../ui/RadioGroupInputFieldView.jsx';
-import {dispatchModifyCustomField, dispatchForceDrawLayerUpdate} from '../visualize/DrawLayerCntlr.js';
 
 export const getUIComponent = (drawLayer,pv) => <NorthUpCompassUI drawLayer={drawLayer} pv={pv}/>;
 
@@ -16,14 +15,7 @@ export const getUIComponent = (drawLayer,pv) => <NorthUpCompassUI drawLayer={dra
 */
 function NorthUpCompassUI({drawLayer,pv}) {
 
-    const tStyle= {
-        display:'inline-block',
-        whiteSpace: 'nowrap',
-        minWidth: '3em',
-        paddingLeft : 5
-    };
-
-    var options= [ {label: 'all', value: 'all'},
+    const options= [ {label: 'all', value: 'all'},
                    {label: 'row', value: 'row'},
                    {label: 'image', value: 'image'},
     ];
@@ -52,4 +44,3 @@ NorthUpCompassUI.propTypes= {
     drawLayer     : PropTypes.object.isRequired,
     pv            : PropTypes.object.isRequired
 };
-

--- a/src/firefly/js/tables/TableInfoUtil.js
+++ b/src/firefly/js/tables/TableInfoUtil.js
@@ -1,0 +1,106 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {MetaConst} from '../data/MetaConst.js';
+import {CoordinateSys} from '../visualize/CoordSys.js';
+import {getColumnIdx} from './TableUtil.js';
+
+
+export const DEF_CORNER_COLS= ['ra1;dec1', 'ra2;dec2', 'ra3;dec3', 'ra4;dec4'];
+
+
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} CoordColsDescription
+ *
+ * @summary And object that describes a pairs of columns in a table that makes up a coordinate
+ *
+ * @prop {string} lonCol - name of the longitudinal column
+ * @prop {string} latCol - name of the latitudinal column
+ * @prop {number} lonIdx - column index for the longitudinal column
+ * @prop {number} latIdx - column index for the latitudinal column
+ * @prop {CoordinateSys} csys - the coordinate system to use
+ */
+
+
+
+
+const makeCoordColAry= (cAry, table) => cAry.map( (c) => makeCoordCol(c,table)).filter( (cCol) => cCol);
+
+/**
+ * Convert a meta data entry description the coordinate column to an CoordColsDescription object. The meta data entry is
+ * a string with two or three parts separated by a semicolon. examples- as 'ra;dec;J2000' or 'lon3;lat3;Gal'.
+ * The first element of the string is optional it could be 'ra;dec' and it will default to J2000.
+ *
+ * @param def
+ * @param {TableModel} table - used to look up column information
+ * @return {CoordColsDescription}
+ */
+function makeCoordCol(def, table) {
+    const s = def.split(';');
+    if (s.length!== 3 && s.length!==2) return null;
+    const s0Idx= getColumnIdx(table,s[0]);
+    const s1Idx= getColumnIdx(table,s[1]);
+    if (s0Idx===-1 || s1Idx=== -1) return null;
+    return {
+        lonCol: s[0],
+        latCol: s[1],
+        lonIdx: s0Idx,
+        latIdx: s1Idx,
+        csys : s[2] ? CoordinateSys.parse(s[2]) : CoordinateSys.EQ_J2000
+    };
+
+}
+
+
+/**
+ * Investigate table meta data a return a CoordColsDescription array for 4 pairs columns that represent
+ * the 4 corners of an object in the table
+ * @param {TableModel} table
+ * @return {Array.<CoordColsDescription>}
+ */
+export function getCornersColumns(table) {
+    if (!table) return [];
+    const {tableMeta}= table;
+    if (!tableMeta) return [];
+    if (tableMeta[MetaConst.ALL_CORNERS]) {
+        return makeCoordColAry(tableMeta[MetaConst.ALL_CORNERS].split(','),table);
+    }
+    return makeCoordColAry(DEF_CORNER_COLS,table);
+}
+
+/**
+ * Investigate table meta data a return a CoordColsDescription for two columns that represent and object in the row
+ * @param {TableModel} table
+ * @return {CoordColsDescription}
+ */
+export function getCenterColumns(table) {
+    if (!table) return [];
+    const {tableMeta:meta}= table;
+    if (!meta) return [];
+
+    if (meta[MetaConst.CENTER_COLUMN]) return makeCoordCol(meta[MetaConst.CENTER_COLUMN],table);
+    if (meta[MetaConst.CATALOG_COORD_COLS]) return makeCoordCol(meta[MetaConst.CATALOG_COORD_COLS],table);
+    const defCol= guessDefColumns(table);
+
+    return makeCoordCol(defCol,table);
+}
+
+
+/**
+ * if there are no default columns then try to guess.  try ra,dec or lon, lat.  More guesses could be added later.
+ * @param {TableModel} table
+ * @return {string}
+ *
+ */
+function guessDefColumns(table) {
+    const {columns}= table.tableData;
+    const colList= columns.map( (c) => c.name.toLowerCase());
+    if (colList.includes('ra') && colList.includes('dec')) return 'ra;dec;EQ_J2000';
+    if (colList.includes('lon') && colList.includes('lat')) return 'lon;lat;EQ_J2000';
+    return 'ra;dec;EQ_J2000';
+}
+

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -36,7 +36,7 @@ function getDialogBuilder() {
 const dialogBuilder = getDialogBuilder();
 
 export function showFitsRotationDialog() {
-    // if (isOverlayLayersActive(visRoot())) {
+    // if (isImageOverlayLayersActive(visRoot())) {
     //    showInfoPopup('Rotate not yet supported with mask layers');
     // }
     // else {

--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -116,7 +116,8 @@ class ShapePickerWrapper extends PureComponent {
         const newDD = (symbolSize === drawingDef.size) ? clone(drawingDef, {symbol}) :
                                                          clone(drawingDef, {symbol, size: symbolSize});
 
-        dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId);
+        const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
+        dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
         this.setState({drawingDef: newDD});
 
     }
@@ -141,7 +142,8 @@ class ShapePickerWrapper extends PureComponent {
             const newDD = clone(drawingDef, {size: symbolSize});
 
             this.setState({size, validSize, drawingDef: newDD});
-            dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId);
+            const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
+            dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
         }
     }
 
@@ -166,7 +168,8 @@ class ShapePickerWrapper extends PureComponent {
             const symbolSize = DrawUtil.getSymbolSize(isize, isize, drawingDef.symbol);
             const newDD = clone(drawingDef, {size: symbolSize});
 
-            dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId);
+            const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
+            dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
             this.setState({drawingDef: newDD});
         }
     }
@@ -180,8 +183,9 @@ class ShapePickerWrapper extends PureComponent {
         const isize = Math.floor(parseFloat(size));
         const symbolSize = DrawUtil.getSymbolSize(isize, isize, drawingDef.symbol);
 
-        dispatchChangeDrawingDef(this.displayGroupId, clone(drawingDef, {symbol: drawingDef.symbol,
-                                                                         size: symbolSize}), this.plotId);
+        const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
+        dispatchChangeDrawingDef(this.displayGroupId, clone(drawingDef, {symbol: drawingDef.symbol, size: symbolSize}),
+                                                             this.plotId, dl.titleMatching);
 
     }
 

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -551,3 +551,21 @@ export function isMultiImageFitsWithSameArea(pv) {
     });
 }
 
+/**
+ *
+ * @param {Array.<PvNewPlotInfo>} pvNewPlotInfoAry
+ * @return {Array.<String>}
+ */
+export function getPvNewPlotIdAry(pvNewPlotInfoAry) {
+    return pvNewPlotInfoAry.map( (npi) => npi.plotId);
+}
+
+/**
+ *
+ * @param {Array.<PvNewPlotInfo>} pvNewPlotInfoAry
+ * @param {String} plotId - plotId to test
+ * @return {boolean}
+ */
+export function isPlotIdInPvNewPlotInfoAry(pvNewPlotInfoAry, plotId) {
+    return pvNewPlotInfoAry.some( (npi) => npi.plotId===plotId);
+}

--- a/src/firefly/js/visualize/draw/CanvasWrapper.jsx
+++ b/src/firefly/js/visualize/draw/CanvasWrapper.jsx
@@ -11,9 +11,10 @@ import {makeDrawingDef} from './DrawingDef.js';
 
 
 function updateDrawer(drawer,plot, width, height, drawLayer,force=false) {
-    var data, highlightData, selectIdxs;
+    let data, highlightData, selectIdxs;
     if (!drawLayer) return;
-    var {drawData}= drawLayer;
+    const {drawData}= drawLayer;
+    if (!drawData) return;
     drawer.decimate= drawLayer.decimate;
     var plotId= plot? plot.plotId : null;
     if (Array.isArray(drawData)) {

--- a/src/firefly/js/visualize/draw/DrawLayer.js
+++ b/src/firefly/js/visualize/draw/DrawLayer.js
@@ -37,13 +37,11 @@ export const ColorChangeType= {DISABLE,DYNAMIC,STATIC};
  * @prop {DrawingDef} drawingDef
  *
  * @prop {Boolean} canHighlight default: false,  if the layer can highlight
- * @prop {Boolean} canSelect  default: false      // todo if true the the default reducer should  handle it. point data only?
+ * @prop {Boolean} canSelect  default: false
  * @prop {Boolean} dataTooBigForSelection   default: false
- * @prop {Boolean} canFilter  default: false      // todo if true the the default reducer should  handle it
+ * @prop {Boolean} canFilter  default: false
  * @prop {Boolean} canUseMouse  default: false, drawing layer has mouse interaction, must set up actionTypeAry
- * @prop {Boolean} canSubgroup  default: false, can be used with subgrouping   // todo
  * @prop {Boolean} hasPerPlotData  default: false,  drawing layer produces different data for each plot
- * @prop {Boolean} asyncData   default: false  //todo
  * @prop {Boolean} isPointData  default: false
  * @prop {ColorChangeType} canUserChangeColor  default: ColorChangeType.STATIC
  * @prop {Boolean} canUserDelete  default: true
@@ -87,6 +85,7 @@ export const ColorChangeType= {DISABLE,DYNAMIC,STATIC};
  *
  */
 
+
 /**
  *
  * @param {string} drawLayerId
@@ -100,9 +99,7 @@ export const ColorChangeType= {DISABLE,DYNAMIC,STATIC};
  * @param {boolean} [options.canFilter]    drawing layer can be used with the filter controls,
  *                               only used with canSelect and isPointData
  * @param {boolean} [options.canUseMouse]  drawing layer has mouse interaction, must set up actionTypeAry
- * @param {boolean} [options.canSubgroup]  can be used with subgrouping
  * @param {boolean} [options.hasPerPlotData] drawing layer produces different data for each plot
- * @param {boolean} [options.asyncData] drawing layer uses async operations to get the data
  * @param {boolean} [options.isPointData] drawing layer only uses point data, @see PointDataObj.js
  * @param {boolean|string} [options.canUserChangeColor] drawing layer color can be changed by the user,
  *                                   can be DISABLE,DYNAMIC, or STATIC, default: STATIC
@@ -113,7 +110,7 @@ export const ColorChangeType= {DISABLE,DYNAMIC,STATIC};
  * @param {object} drawingDef  the defaults that the drawer will use if not overridden by the object @see DrawingDef
  * @param {Array} actionTypeAry extra [actions] that are allow though to the drawing layer reducer
  * @param {object} mouseEventMap object literal with event to function mapping, see documentation below in object
- * @param {object} exclusive
+ * @param {object} exclusiveDef
  * @param {function} getCursor
  * @return {DrawLayer}
  */
@@ -126,7 +123,7 @@ function makeDrawLayer(drawLayerId,
                        mouseEventMap= {},
                        exclusiveDef= null,
                        getCursor= null) {
-    var drawLayer=  {
+    const drawLayer=  {
 
 
          // it section: The types of IDs
@@ -149,22 +146,18 @@ function makeDrawLayer(drawLayerId,
         plotIdAry: [],  // array of plotId that are layered
         visiblePlotIdAry: [], // array of plotId that are visible, only ids in this array are visible
         actionTypeAry,      // what actions that the reducer will allow through the drawing layer reducer
-        dataAvailable : true,  //todo
         drawingDef,
 
         groupingScope: GroupingScope.SUBGROUP, // only applies if a catalog has supportSubgroups
+        titleMatching: false,
 
 
            // The following are the options that the drawing layer supports.
            // should be set in the options parameter
         canHighlight: false,
-        canSelect: false,      // todo if true the the default reducer should  handle it. point data only?
         dataTooBigForSelection : false,
-        canFilter: false,      // todo if true the the default reducer should  handle it
         canUseMouse: false,
-        canSubgroup: false,    // todo
         hasPerPlotData: false,
-        asyncData : false,  //todo
         isPointData: false,
         canUserChangeColor: ColorChangeType.STATIC,
         canUserDelete: true,
@@ -206,7 +199,7 @@ function makeDrawLayer(drawLayerId,
 
 
            //
-           //     mouse type as the key and the function to call when activated @see mousestate
+           //     mouse type as the key and the function to call when activated @see MouseState
            //     if the value is an object the a it should define the properties: exclusive:boolean and func:function
            //     the function usually dispatch type functions, but can be anything
            //     value can be an action string. in that case flux.process is call to dispatch that action.
@@ -249,24 +242,4 @@ function makeDrawLayer(drawLayerId,
     };
 
     return Object.assign(drawLayer,options);
-}
-
-/**
- *
- * @param drawLayerId
- * @param plotId
- * @return if async and !dataAvailable return false otherwise return true
- */
-function isDataAvailable(drawLayerId, plotId) {
-
-}
-
-
-/**
- * may return null is !isDataAvailable()
- * @param drawLayerId
- * @param plotId
- */
-function getData(drawLayerId, plotId) {
-
 }

--- a/src/firefly/js/visualize/region/RegionTask.js
+++ b/src/firefly/js/visualize/region/RegionTask.js
@@ -126,7 +126,7 @@ export function regionDeleteLayerActionCreator(rawAction) {
         var dl = getDrawLayerById(getDlAry(), drawLayerId);
 
         if (dl && drawLayerId && pId) {
-            dispatchDetachLayerFromPlot(drawLayerId, pId, true, false, dl.destroyWhenAllDetached);
+            dispatchDetachLayerFromPlot(drawLayerId, pId, true, dl.destroyWhenAllDetached);
         } else {
             reportError(`${RegionIdErr} for deleting region layer`);
         }

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -73,6 +73,7 @@ export function* watchCatalogs() {
 
 const isCName = (name) => (c) => c.name===name;
 
+//todo - this fucntion should start using TableInfoUtil.getCenterColumns
 function handleCatalogUpdate(tbl_id) {
     const sourceTable= getTblById(tbl_id);
 
@@ -163,7 +164,8 @@ function updateDrawingLayer(tbl_id, title, tableData, tableMeta, tableRequest,
         if (dl.supportSubgroups  &&  dl.tableMeta[SUBGROUP]) {
             plotIdAry.map( (plotId) =>  getPlotViewById(visRoot(), plotId))
                 .filter( (pv) => dl.tableMeta[SUBGROUP]!==get(pv, 'drawingSubGroupId'))
-                .forEach( (pv) => pv && dispatchChangeVisibility(dl.drawLayerId, false, pv.plotId, false));
+                .forEach( (pv) => pv && dispatchChangeVisibility({id:dl.drawLayerId, visible:false,
+                                                                  plotId:pv.plotId, useGroup:false}));
         }
     }
 }
@@ -176,7 +178,7 @@ function attachToAllCatalogs(pvNewPlotInfoAry) {
                 dispatchAttachLayerToPlot(dl.drawLayerId, info.plotId);
                 const pv= getPlotViewById(visRoot(), info.plotId);
                 if (dl.tableMeta[SUBGROUP]!==get(pv, 'drawingSubGroupId')) {
-                    pv && dispatchChangeVisibility(dl.drawLayerId, false, pv.plotId, false);
+                    pv && dispatchChangeVisibility({id:dl.drawLayerId, visible:false, plotId:pv.plotId, useGroup:false});
                 }
             });
         }

--- a/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
@@ -39,7 +39,7 @@ function destroyDrawLayer(plotId)
     const dl = getDrawLayerByType(getDlAry(), typeId);
 
     if (isDrawLayerAttached(dl, plotId)) {
-        dispatchDetachLayerFromPlot(typeId, plotId, false, false);
+        dispatchDetachLayerFromPlot(typeId, plotId, false);
     }
     dispatchDestroyDrawLayer(typeId);
 }
@@ -272,7 +272,7 @@ class ImageAreaStatsTableRow extends PureComponent {
             dispatchAttachLayerToPlot(typeId, plotId);
         }
 
-        dispatchModifyCustomField(typeId, {worldPt}, plotId, false);
+        dispatchModifyCustomField(typeId, {worldPt}, plotId);
     }
 
     onMouseOut() {
@@ -286,7 +286,7 @@ class ImageAreaStatsTableRow extends PureComponent {
         const dl = getDrawLayerByType(getDlAry(), typeId);
 
         if (isDrawLayerAttached(dl, plotId)) {
-            dispatchModifyCustomField(typeId, {}, plotId, false);
+            dispatchModifyCustomField(typeId, {}, plotId);
         }
     }
 

--- a/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
+++ b/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
@@ -67,7 +67,7 @@ function onOff(pv,typeId,todo) {
         dispatchAttachLayerToPlot(typeId,pv.plotId,true);
     }
     else {
-        dispatchDetachLayerFromPlot(typeId,pv.plotId,true,true, dl.destroyWhenAllDetached);
+        dispatchDetachLayerFromPlot(typeId,pv.plotId,true,dl.destroyWhenAllDetached);
     }
 }
 

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -21,7 +21,7 @@ import {dispatchExtensionActivate} from '../../core/ExternalAccessCntlr.js';
 import {selectCatalog,unselectCatalog,filterCatalog,clearFilterCatalog} from '../../drawingLayers/Catalog.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import SelectArea from '../../drawingLayers/SelectArea.js';
-import {isOverlayLayersActive} from '../RelatedDataUtil.js';
+import {isImageOverlayLayersActive} from '../RelatedDataUtil.js';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 import CoordUtil from '../CoordUtil.js';
 import { parseImagePt } from '../Point.js';
@@ -53,14 +53,14 @@ const Metrics= {MAX:'MAX', MIN:'MIN', CENTROID:'CENTROID', FW_CENTROID:'FW_CENTR
 
 function formatNumber(num, fractionDigits=7)
 {
-    let numStr, thred;
+    let numStr;
     const SigDig = 7;
 
 
     if (num === null || num === undefined) {
         return '';
     }
-    thred = Math.min(Math.pow(10, SigDig - fractionDigits), 1.0);
+    const thred = Math.min(Math.pow(10, SigDig - fractionDigits), 1.0);
 
     if (Math.abs(num) >= thred) {
         numStr = num.toFixed(fractionDigits);
@@ -85,11 +85,11 @@ function tabulateStatics(wpResult, cc) {
     const bands  = wpResult.Band_Info;
     const noBand = 'NO_BAND';
 
-    var bandData = {};
+    const bandData = {};
 
     function getOneStatSet(b) {
 
-        let tblData = {};
+        const tblData = {};
 
         tblData[SSummary] = [
             [b.MEAN.desc, formatNumber(b.MEAN.value) + ' ' + b.MEAN.units],
@@ -106,18 +106,16 @@ function tabulateStatics(wpResult, cc) {
             }
 
             const item = b[ipMetrics[i]];
-            let ipt, wpt;
-            let hmsRA, hmsDec;
-            let statsRow = [];
+            const statsRow = [];
 
             // item title
             statsRow.push(item.desc);
 
             // item location
-            ipt = parseImagePt(item.ip);
-            wpt = cc.getWorldCoords(ipt);
-            hmsRA = CoordUtil.convertLonToString(wpt.getLon(), wpt.getCoordSys());
-            hmsDec = CoordUtil.convertLatToString(wpt.getLat(), wpt.getCoordSys());
+            const ipt = parseImagePt(item.ip);
+            const wpt = cc.getWorldCoords(ipt);
+            const hmsRA = CoordUtil.convertLonToString(wpt.getLon(), wpt.getCoordSys());
+            const hmsDec = CoordUtil.convertLatToString(wpt.getLat(), wpt.getCoordSys());
             statsRow.push(`RA: ${hmsRA}\nDEC: ${hmsDec}`);
 
             // item value
@@ -167,7 +165,7 @@ function stats(pv) {
     callGetAreaStatistics(p.plotState, ip0,ip1,ip2,ip3)
         .then( (wpResult) => {      // result of area stats
 
-            // tabaularize stats data
+            // tabularize stats data
             const tblData = tabulateStatics(wpResult, cc);
 
             //console.log(wpResult);
@@ -182,7 +180,7 @@ function stats(pv) {
 
 function crop(pv) {
 
-    if (isOverlayLayersActive(pv)) {
+    if (isImageOverlayLayersActive(pv)) {
         showInfoPopup('Crop not yet supported with mask layers');
         return;
     }
@@ -306,8 +304,8 @@ export class VisCtxToolbarView extends PureComponent {
 
         };
 
-        var showOptions= showSelectionTools|| showCatSelect|| showCatUnSelect ||
-            showFilter || showClearFilter || !isEmpty(extensionAry);
+        const showOptions= showSelectionTools|| showCatSelect|| showCatUnSelect ||
+                           showFilter || showClearFilter || !isEmpty(extensionAry);
 
         return (
             <div style={rS}>
@@ -426,7 +424,7 @@ export function MultiImageControllerView({plotView:pv}) {
     }
     const plot= primePlot(pv);
 
-    var cIdx= plots.findIndex( (p) => p.plotImageId===plot.plotImageId);
+    let cIdx= plots.findIndex( (p) => p.plotImageId===plot.plotImageId);
     if (cIdx<0) cIdx= 0;
 
     const nextIdx= cIdx===plots.length-1 ? 0 : cIdx+1;

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -9,7 +9,7 @@ import {getActivePlotView,
     hasGroupLock,
     findPlotGroup,
     getAllDrawLayersForPlot} from '../PlotViewUtil.js';
-import {findRelatedData} from '../RelatedDataUtil.js';
+import {findUnactivatedRelatedData} from '../RelatedDataUtil.js';
 import {dispatchRotate, dispatchFlip, dispatchRecenter,
         dispatchRestoreDefaults,dispatchGroupLocking} from '../ImagePlotCntlr.js';
 import {RotateType} from '../PlotState.js';
@@ -393,7 +393,7 @@ function showImagePopup() {
 
 export function LayerButton({pv,visible}) {
     const layerCnt=  pv ? (getAllDrawLayersForPlot(getDlAry(),pv.plotId).length + pv.overlayPlotViews.length) : 0;
-    const enabled= Boolean(layerCnt || findRelatedData(pv).length);
+    const enabled= Boolean(layerCnt || findUnactivatedRelatedData(pv).length);
     return (
         <ToolbarButton icon={LAYER_ICON}
                        tip='Manipulate overlay display: Control color, visibility, and advanced options'


### PR DESCRIPTION

 - Image FileRetrievers can add artifact to RelatedData
  - WISE and 2MASS supported
  - Artifact drawing layer uses lazy loading
  - added layer title matching for visibility, color, and symbol changing
  - firefly: IbeQueryArtifact replaces ife: FinderChartQueryArtifact
  - Also added support for getting adding RelatedData artifacts in IbeFileRetrieve

_The big concept:_

- When an image plot is request is sent to the server it not only returns the image data but also how to retrieve "related data". 
- Sometime this related data are image mask in other cases it is artifact data.
- What related data is return is query specific.  This way the client does not have to know the details of the project.
- A RelatedData object can be turned into a server search request to retrieve it when the user request to see it.
- There are so far 3 types of related data: mask, tabular (artifacts), and image (not yet implemented).
- The mask related data was implemented months ago.  This pull request implements the tabular related data.



_to test:_
 - bring up the firefly or irsa viewer, or finder chart, or time series.
 - when you have a wise or 2mass layer up you should see the artifact drawing layers on the dialog.  They are off by default.
  - if you have more than one image such as several wise or several 2mass images. Checking and unchecking artifact turn all of them of the same type on and off.

