### PR TITLE
DM-11604 Support showing the active chart trace

### DIFF
--- a/src/firefly/html/demo/ffapi-slate-test3.html
+++ b/src/firefly/html/demo/ffapi-slate-test3.html
@@ -28,7 +28,7 @@
 
 
 <div style="font-size: 16pt; padding:0 0 10px 10px;">
-    Test Firefly Blank Slate Viewer
+    Test Firefly Blank Slate Viewer (for generic column expression)
 </div>
 
 <pre>

--- a/src/firefly/html/demo/ffapi-slate-test4.html
+++ b/src/firefly/html/demo/ffapi-slate-test4.html
@@ -133,8 +133,9 @@ Some unsupported plotly charts:
 
             var trace2 = {
                 tbl_id: "wiseCatTbl",
-                x: "tables::w1mpro-w2mpro",
-                y: "tables::w2mpro-w3mpro",
+                x: "tables::w2mpro-w3mpro",
+                y: "tables::w3mpro-w4mpro",
+                name: 'w2-w3 vs. w3-w4',
                 mode: 'markers',
                 type: 'scatter',
                 error_x : {array: "tables::w3sigmpro"},

--- a/src/firefly/html/demo/ffapi-slate-test4.html
+++ b/src/firefly/html/demo/ffapi-slate-test4.html
@@ -28,7 +28,7 @@
 
 
 <div style="font-size: 16pt; padding:0 0 10px 10px;">
-    Test Firefly Blank Slate Viewer
+    Test Firefly Blank Slate Viewer (for Plotly chart with multi-traces of same type)
 </div>
 
 <pre>

--- a/src/firefly/html/demo/ffapi-slate-test4.html
+++ b/src/firefly/html/demo/ffapi-slate-test4.html
@@ -79,19 +79,25 @@ Some unsupported plotly charts:
         <a href='javascript:load2DScatter(0,0,2,2)'>Show Plotly Scatter </a> <span class='smallCoords'>at row: 0, col: 0, w:2 h: 2</span>
     </li>
     <li>
-        <a href="javascript:loadSurface(0,2,2,2)">Show Surface </a><span class='smallCoords'>at row: 0, col: 2, w: 2, h: 2</span>
+        <a href="javascript:loadSurface(0,2,2,2)">Show 3D </a><span class='smallCoords'>at row: 0, col: 2, w: 2, h: 2</span>
     </li>
     <li>
-        <a href="javascript:loadBar(2,0,3,3)">Show Bar chart </a><span class='smallCoords'>at row: 2, col: 0, w: 3, h: 3</span>
+        <a href="javascript:loadNewHeatmapCharts(2,0,2,3)">Show Heatmap chart </a><span class='smallCoords'>at row: 2, col: 0, w: 2, h: 3</span>
     </li>
     <li>
-        <a href="javascript:loadPie(2,3,3,3)">Show Pie Chart </a><span class='smallCoords'>at row: 2, col: 3, w: 3. h: 3</span>
+        <a href="javascript:loadHistogramCharts(2,2,2,3)">Show Histogram Chart </a><span class='smallCoords'>at row: 2, col: 2, w: 2. h: 3</span>
     </li>
     <li>
-        <a href="javascript:loadDensity(5,0,3,3)">Show Histogram2dContour </a><span class='smallCoords'>at row: 5, col: 0, w: 3, h: 3</span>
+        <a href="javascript:loadPie(2,4,2,3)">Show Pie Chart </a><span class='smallCoords'>at row: 2, col: 4, w: 2. h: 3</span>
     </li>
     <li>
-        <a href="javascript:loadBox(5,3,3,3)">Show Box </a><span class='smallCoords'>at row: 5, col: 3, w: 3, h: 3</span>
+        <a href="javascript:loadDensity(5,0,2,3)">Show Histogram2dContour </a><span class='smallCoords'>at row: 5, col: 0, w: 2, h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadHistogram2d(5,2,2,3)">Show Histogram2d </a><span class='smallCoords'>at row: 5, col: 2, w: 2, h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadBox(5,4,2,3)">Show Box </a><span class='smallCoords'>at row: 5, col: 4, w: 2, h: 3</span>
     </li>
 </ul>
 </body>
@@ -125,6 +131,28 @@ Some unsupported plotly charts:
                 marker: {size: 4, opacity: 0.5}
             };
 
+            var trace2 = {
+                tbl_id: "wiseCatTbl",
+                x: "tables::w1mpro-w2mpro",
+                y: "tables::w2mpro-w3mpro",
+                mode: 'markers',
+                type: 'scatter',
+                error_x : {array: "tables::w3sigmpro"},
+                error_y : {array: "tables::w4sigmpro"},
+                marker: {size: 4, opacity: 0.5}
+            };
+
+            var trace3 = {
+                tbl_id: "wiseCatTbl",
+                x: "tables::w1mpro-w2mpro",
+                y: "tables::w2mpro-w3mpro",
+                mode: 'markers',
+                type: 'scatter',
+                error_x : {array: "tables::w3sigmpro"},
+                error_y : {array: "tables::w4sigmpro"},
+                marker: {size: 4, opacity: 0.5}
+            };
+
             var layoutS = {
                 title: 'Color-Color',
                 xaxis: {title: 'w1mpro-w2mpro (mag)'},
@@ -134,7 +162,7 @@ Some unsupported plotly charts:
 
 
             firefly.getViewer().showChart(
-                    {chartId: 'newChart1', layout: layoutS, data: [trace1]},
+                    {chartId: 'newChart1', layout: layoutS, data: [trace1, trace2, trace3]},
                     'newChartContainer');
 
         }
@@ -147,21 +175,30 @@ Some unsupported plotly charts:
                 {
                     tbl_id: "wiseCatTbl",
                     type: 'scatter3d',
-                    name: 'color-color-color',
+                    name: 'color-1',
                     x: "tables::w1mpro-w2mpro",
                     y: "tables::w2mpro-w3mpro",
                     z: "tables::w3mpro-w4mpro",
                     mode : 'markers',
                     marker : {
-                        size: 3,
-                        line: {
-                            color: 'rgb(127, 127, 127, 0.14)',
-                            width: 1
-                        }
+                        size: 3
+                    },
+                    hoverinfo: 'x+y+z'
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    type: 'scatter3d',
+                    name: 'color-2',
+                    x: "tables::w1mpro-w2mpro",
+                    y: "tables::w2mpro-w3mpro",
+                    z: "tables::w3mpro-w4mpro",
+                    mode: 'markers',
+                    marker: {
+                        size: 3
                     },
                     hoverinfo: 'x+y+z'
                 }
-            ];
+           ];
 
             var tfont = {size: 11};
             var layout3d = {
@@ -187,8 +224,8 @@ Some unsupported plotly charts:
                     '3dChartContainer');
         }
 
-        function loadHistogramCharts(r,c,w,h) {
-            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'histContainer');
+        function loadFireflyHistogramCharts(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'fireflyHistContainer');
 
             var dataH = [
                 {
@@ -202,8 +239,7 @@ Some unsupported plotly charts:
                             columnOrExpr: 'w1mpro'
                         }
                     },
-                    name: 'w1mpro',
-                    marker: {color: 'rgba(153, 51, 153, 0.8)'}
+                    name: 'w1mpro'
                 },
                 {
                     type: 'fireflyHistogram',
@@ -216,8 +252,8 @@ Some unsupported plotly charts:
                             columnOrExpr: 'w2mpro'
                         }
                     },
-                    name: 'w2mpro',
-                    marker: {color: 'rgba(102,153,0, 0.7)'}}
+                    name: 'w2mpro'
+                }
             ];
 
             var layoutHist = {
@@ -228,8 +264,36 @@ Some unsupported plotly charts:
 
             firefly.getViewer().showChart(
                     {chartId: 'firefly-hist-tbl', layout: layoutHist, data: dataH},
+                    'fireflyHistContainer');
+        }
+
+        function loadHistogramCharts(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'histContainer');
+
+            var dataH = [
+                {
+                    type: 'histogram',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro"
+                },
+                {
+                    type: 'histogram',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro"
+                }
+            ];
+
+            var layoutHist = {
+                title: 'Photometry histogram',
+                xaxis: {title: 'photometry (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'hist-tbl', layout: layoutHist, data: dataH},
                     'histContainer');
         }
+
 
         function loadBar(r, c, w, h) {
             firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'barContainer');
@@ -239,10 +303,32 @@ Some unsupported plotly charts:
                 {
                     tbl_id: "wiseCatTbl",
                     type: 'bar',
-                    name: 'w1nm',
+                    name: 'w1nm_1',
                     orientation: 'h',
                     y: "tables::clon",
-                    x: "tables::w1nm"
+                    x: "tables::w1nm",
+                    error_x : {array: "tables::w3sigmpro"},
+                    error_y : {array: "tables::w4sigmpro"}
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    type: 'bar',
+                    name: 'w1nm_2',
+                    orientation: 'h',
+                    y: "tables::clon",
+                    x: "tables::w1nm",
+                    error_x : {array: "tables::w3sigmpro"},
+                    error_y : {array: "tables::w4sigmpro"}
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    type: 'bar',
+                    name: 'w1nm_3',
+                    orientation: 'h',
+                    y: "tables::clon",
+                    x: "tables::w1nm",
+                    error_x : {array: "tables::w3sigmpro"},
+                    error_y : {array: "tables::w4sigmpro"}
                 }
             ];
 
@@ -262,15 +348,24 @@ Some unsupported plotly charts:
             var dataPie = [
                 {
                     tbl_id: "wiseCatTbl",
-                    name: 'Stats for (w1+w2)',
+                    name: 'pie: (w1+w2)',
                     type: 'pie',
                     values: "tables::w1mpro+w2mpro",
                     labels:  "tables::clon",
                     textinfo: 'none'
-                }];
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'pie: (w3+w4)',
+                    type: 'pie',
+                    values: "tables::w3mpro+w4mpro",
+                    labels:  "tables::clon",
+                    textinfo: 'none'
+                }
+            ];
 
             var layoutPie = {
-                title: 'pie: w1+w2 vs. clon',
+                title: 'pie: (w1+w2)|(w3+w4) vs. clon',
                 showlegend: true
             };
 
@@ -284,12 +379,21 @@ Some unsupported plotly charts:
             var dataContour = [
                 {
                     tbl_id: "wiseCatTbl",
-                    name: 'contour',
+                    name: 'contour 1',
                     type: 'histogram2dcontour',
                     x: "tables::ra",
                     y: "tables::dec",
                     ncontours: 20
-                }];
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'contour 2',
+                    type: 'histogram2dcontour',
+                    x: "tables::ra",
+                    y: "tables::dec",
+                    ncontours: 30
+                }
+            ];
 
             var layoutContour = {
                 title: 'histogram2dcontour: ra vs. dec',
@@ -301,6 +405,61 @@ Some unsupported plotly charts:
                     {chartId: 'newhist2dcontour', data: dataContour, layout: layoutContour}, 'h2dcontourContainer');
         }
 
+        function loadHistogram2d(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'h2dContainer');
+
+            var dataContour = [
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'hist2d 1',
+                    type: 'histogram2d',
+                    x: "tables::ra",
+                    y: "tables::dec",
+                    z: "tables::w1snr"
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'hist2d 2',
+                    type: 'histogram2d',
+                    x: "tables::ra",
+                    y: "tables::dec",
+                    z: "tables::w1snr"
+                }
+            ];
+
+            // contour example
+            /*
+            var dataContour = [
+                {
+                    type: 'contour',
+                    name: 'contour 1',
+                    z: [[10, 10.625, 12.5, 15.625, 20],
+                        [5.625, 6.25, 8.125, 11.25, 15.625],
+                        [2.5, 3.125, 5., 8.125, 12.5],
+                        [0.625, 1.25, 3.125, 6.25, 10.625],
+                        [0, 0.625, 2.5, 5.625, 10]],
+                },
+                {
+                    type: 'contour',
+                    name: 'contour 2',
+                    z: [[10, 10.625, 12.5, 15.625, 20],
+                        [5.625, 6.25, 8.125, 11.25, 15.625],
+                        [2.5, 3.125, 5., 8.125, 12.5],
+                        [0.625, 1.25, 3.125, 6.25, 10.625],
+                        [0, 0.625, 2.5, 5.625, 10]],
+                }
+            ];
+            */
+            var layoutContour = {
+                title: 'histogram2d: ra vs. dec',
+                xaxis: {title: 'ra'},
+                yaxis: {title: 'dec'}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newhist2d', data: dataContour, layout: layoutContour}, 'h2dContainer');
+        }
+
         function loadSurface(r,c,w,h) {
             firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'surfaceContainer');
 
@@ -308,7 +467,16 @@ Some unsupported plotly charts:
             var dataSurface = [
                 {
                     type: 'surface',
-                    name: 'w1-w2-w3',
+                    name: 'surfcace 1',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro-w2mpro",
+                    y: "tables::w2mpro-w3mpro",
+                    z: "tables::w1mpro",
+                    hoverinfo: 'x+y+z'
+                },
+                {
+                    type: 'surface',
+                    name: 'surface 2',
                     tbl_id: "wiseCatTbl",
                     x: "tables::w1mpro-w2mpro",
                     y: "tables::w2mpro-w3mpro",
@@ -319,7 +487,7 @@ Some unsupported plotly charts:
 
             var tfont = {size: 11};
             var layoutSurface = {
-                title: 'Surface on w1-w2 & w2-w3',
+                title: 'Surface on (w1-w2) & (w2-w3)',
                 scene:{
                     xaxis: {
                         title: 'w1-w2 (deg)',
@@ -367,6 +535,54 @@ Some unsupported plotly charts:
                     'boxContainer');
         }
 
+        function loadNewHeatmapCharts(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'heatMapContainer');
+
+
+            var dataHM = [
+                {
+                    type: 'fireflyHeatmap',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    name: 'w1-w2'
+                },
+                {
+                    type: 'fireflyHeatmap',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro",
+                    y: "tables::w3mpro",
+                    name: 'w1-w3',
+                    reversescale: true
+                },
+                {
+                    type: 'fireflyHeatmap',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro",
+                    y: "tables::w4mpro",
+                    name: 'w1-w4'
+                }
+            ];
+            var layoutHM = {
+                title: 'Magnitude-magnitude densities',
+                xaxis: {title: 'w1 photometry (mag)'},
+                yaxis: {title: ''},
+                firefly: { // user boundaries - so that heatmaps will be calculated in the same XY space
+                    xaxis: {
+                        min: 5,
+                        max: 20
+                    },
+                    yaxis: {
+                        min: 4,
+                        max: 18
+                    }
+                }
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newHeatmapChart', layout: layoutHM,  data: dataHM},
+                    'heatMapContainer');
+        }
 
         function showATable(sTarget,r,c,w,h) {
             firefly.getViewer().addCell(r,c,w,h, 'tables');

--- a/src/firefly/html/demo/ffapi-slate-test5.html
+++ b/src/firefly/html/demo/ffapi-slate-test5.html
@@ -28,7 +28,7 @@
 
 
 <div style="font-size: 16pt; padding:0 0 10px 10px;">
-    Test Firefly Blank Slate Viewer
+    Test Firefly Blank Slate Viewer (for Plotly chart with multi-traces of mixed types)
 </div>
 
 <pre>

--- a/src/firefly/html/demo/ffapi-slate-test5.html
+++ b/src/firefly/html/demo/ffapi-slate-test5.html
@@ -1,0 +1,674 @@
+<!doctype html>
+
+<!--
+  ~ License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+  -->
+
+<html>
+
+<head>
+    <meta http-equiv="Cache-Control" content="no-cache">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Demo of Firefly Tools</title>
+        <style type="text/css">
+            .smallCoords {
+                font-size: 10pt;
+            }
+        </style>
+    </head>
+</head>
+
+<body>
+
+
+<div style="width: 500px; padding: 10px 0 0 20px;">
+</div>
+
+
+<div style="font-size: 16pt; padding:0 0 10px 10px;">
+    Test Firefly Blank Slate Viewer
+</div>
+
+<pre>
+    Slate function calls from firefly.getViewer()
+
+        v.addCell
+
+        v.showCoverage
+        v.showImageMetaDataViewer
+        v.showTable
+        v.showImage
+        v.showXYPlot
+        v.showHistogram
+
+    flow:
+       call v.addCell with position, type and cellId - type must be one of 'tables', 'images', 'xyPlots', 'tableImageMeta', 'coverageImage'
+       call v.showTable, v.showImage, v.showXYPlot, v.showHistogram, v.showCoverage, or v.showImageMetaDataViewer
+</pre>
+
+<div>
+    serialized target: <input type="text" name="fname" id="sTarget" style="width: 300px; margin: 10px;">
+</div>
+<pre>
+    try:
+    148.88822;69.06529;EQ_J2000 # Galaxy M81
+    202.48417;47.23056;EQ_J2000 # Galaxy M51
+    136.9316774;+1.1195886;galactic # W5 star-forming region
+    10.68479;41.26906;EQ_J2000 # Galaxy M31
+</pre>
+
+
+<div style='margin-bottom: 15px'>
+    <a href='javascript:firefly.getViewer().reinitViewer()'>Reinit App</a>
+</div>
+
+
+Load Tables for charts to use
+<ul>
+    <li>
+        <a href="javascript:showATable(getSTarget(),0,4,2,2)">Load the Table</a> <span class='smallCoords'>at row: 0, col: 4, w:2 h: 2</span>
+    </li>
+</ul>
+
+Some unsupported plotly charts:
+<ul>
+
+    <li>
+        <a href='javascript:loadMixedScatterChart(0,0,2,2)'>Show scatter & heatmap Scatter </a> <span class='smallCoords'>at row: 0, col: 0, w:2 h: 2</span>
+    </li>
+    <li>
+        <a href="javascript:loadMixedScatterHistChart(0,2,2,2)">Show heatmap & histogram </a><span class='smallCoords'>at row: 0, col: 2, w: 2, h: 2</span>
+    </li>
+    <li>
+        <a href="javascript:loadHistogramHeatChart(2,0,2,3)">Show heatmap & histogram chart </a><span class='smallCoords'>at row: 2, col: 0, w: 2, h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadPieScatterChart(2,2,2,3)">Show pie & scatter Chart </a><span class='smallCoords'>at row: 2, col: 2, w: 2. h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadScatterFireflyHistChart(2,4,2,3)">Show scatter & firefly histogram Chart </a><span class='smallCoords'>at row: 2, col: 4,  w: 2. h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadHeatmapHist2dChart(5,0,2,3)">Show heatmap & histogram2dcontour chart </a><span class='smallCoords'>at row: 5, col: 0, w: 2, h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadHistogram2dHistChart(5,2,2,3)">Show histogram2dcontour & histogram </a><span class='smallCoords'>at row: 5, col: 2, w: 2, h: 3</span>
+    </li>
+    <li>
+        <a href="javascript:loadFireflyHistogramCharts(5,4,2,3)">Show fireflyHistogram & heatmap </a><span class='smallCoords'>at row: 5, col: 4, w: 2, h: 3</span>
+    </li>
+</ul>
+</body>
+
+
+<script type="text/javascript">
+    if (!window.firefly) window.firefly= {};
+    window.firefly.options= {charts: {chartEngine: 'plotly'}};
+</script>
+
+
+
+<script type="text/javascript">
+    {
+
+        function getSTarget() {
+            return document.getElementById('sTarget').value;
+        }
+
+        function loadMixedScatterChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'newChartContainer');
+
+            var mixData =[
+                {
+                    type: 'heatmap',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro+7",
+                    y: "tables::w2mpro+8",
+                    z: "tables::w1snr",
+                    colorbar: {y:0.42},
+                    name: 'heatmap'
+                },
+                {
+                    name: "scatter 1",
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    mode: 'markers',
+                    type: 'scatter',
+                    error_x : {array: "tables::w1sigmpro"},
+                    error_y : {array: "tables::w2sigmpro"},
+                    marker: {size: 4, opacity: 0.15}
+                },
+                {
+                    name: "scatter 2",
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    mode: 'markers',
+                    type: 'scatter',
+                    error_x : {array: "tables::w1sigmpro"},
+                    error_y : {array: "tables::w2sigmpro"},
+                    marker: {size: 4, opacity: 0.15}
+                }];
+
+            var layoutS = {
+                title: 'Scatter and Heatmap',
+                xaxis: {title: 'w1mpro(mag)'},
+                yaxis: {title: 'w2mpro(mag)'}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart1', layout: layoutS, data: mixData},
+                    'newChartContainer');
+
+        }
+
+
+        function loadMixedScatterHistChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'newChartContainer2');
+
+            var mixData =[{
+                    tbl_id: "wiseCatTbl",
+                    name: "histogram",
+                    x: "tables::w1mpro",
+                    type: 'histogram'
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "scatter",
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    mode: 'markers',
+                    type: 'scatter',
+                    error_x : {array: "tables::w1sigmpro"},
+                    error_y : {array: "tables::w2sigmpro"},
+                    marker: {size: 4, opacity: 0.5}
+                }
+            ];
+
+            var layoutS = {
+                title: 'Scatter & histogram',
+                xaxis: {title: 'w1mpro(mag)'},
+                yaxis: {title: 'w2mpro(mag)'}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart2', layout: layoutS, data: mixData},
+                    'newChartContainer2');
+
+        }
+
+
+        function loadHistogramHeatChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'newChartContainer3');
+
+            var mixData =[
+                {
+                    type: 'heatmap',
+                    name: "heatmap: w1-w2",
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro+7",
+                    y: "tables::w2mpro+30",
+                    z: "tables::w2snr",
+                    colorscale: "Bluered",
+                    colorbar: {x:-0.3}
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "hist1",
+                    x: "tables::w1mpro",
+                    type: 'histogram'
+                },
+                {
+                    type: 'histogram',
+                    name: "hist2",
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w2mpro"
+                }
+            ];
+
+            var layoutS = {
+                title: 'Heatmap & Histogram',
+                xaxis: {title: 'photometry (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart3', layout: layoutS, data: mixData},
+                    'newChartContainer3');
+
+        }
+
+        function loadPieHeatChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'newChartContainer4');
+
+            var mixData =[
+                {
+                    type: 'heatmap',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro+7",
+                    y: "tables::w2mpro+30",
+                    z: "tables::w2snr",
+                    colorscale: "Bluered",
+                    colorbar: {x:-0.3},
+                    name: 'heat: w1-w2'
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'Pie: w1+w2',
+                    type: 'pie',
+                    values: "tables::w1mpro+w2mpro",
+                    labels:  "tables::clon",
+                    textinfo: 'none'
+                }
+            ];
+
+            var layoutS = {
+                title: 'Heatmap & Pie',
+                xaxis: {title: 'photometry (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart4', layout: layoutS, data: mixData},
+                    'newChartContainer4');
+
+        }
+
+
+        function loadBarPieChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'newChartContainer5');
+
+            var mixData =[
+                {
+                    tbl_id: "wiseCatTbl",
+                    type: 'bar',
+                    name: 'bar: w1nm',
+                    orientation: 'h',
+                    y: "tables::clon",
+                    x: "tables::w1nm",
+                    error_x : {array: "tables::w3sigmpro"},
+                    error_y : {array: "tables::w4sigmpro"}
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'pie:w1+w2',
+                    type: 'pie',
+                    values: "tables::w1mpro+w2mpro",
+                    labels:  "tables::clon",
+                    textinfo: 'none'
+                }
+            ];
+
+            var layoutS = {
+                title: 'Pie & Bar',
+                xaxis: {title: 'w1nm (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart5', layout: layoutS, data: mixData},
+                    'newChartContainer5');
+
+        }
+
+
+        function loadPieScatterChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'newChartContainer6');
+
+            var mixData =[
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "pie 1: w3+w4",
+                    type: "pie",
+                    values: "tables::w3mpro+w4mpro",
+                    labels:  "tables::clon",
+                    textinfo: 'none'
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "scatter: w1-w2",
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    mode: 'markers',
+                    type: 'scatter',
+                    error_x : {array: "tables::w1sigmpro"},
+                    error_y : {array: "tables::w2sigmpro"},
+                    marker: {size: 4, opacity: 0.15}
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "pie 2: w1+w2",
+                    type: "pie",
+                    values: "tables::w1mpro+w2mpro",
+                    labels:  "tables::clon",
+                    textinfo: 'none'
+                }
+            ];
+
+            var layoutS = {
+                title: 'Scatter & pie',
+                xaxis: {title: 'photometry (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newChart6', layout: layoutS, data: mixData},
+                    'newChartContainer6');
+
+        }
+
+        function loadScatterHist2dChart(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'h2dcontourContainer');
+
+            var dataContour = [
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'cont: ra-dec',
+                    type: 'histogram2dcontour',
+                    x: "tables::ra",
+                    y: "tables::dec",
+                    colorbar: {y:0.39},
+                    colorscale: "Blues",
+                    ncontours: 20
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "scatter",
+                    x: "tables::ra",
+                    y: "tables::dec",
+                    mode: 'markers',
+                    type: 'scatter',
+                    marker: {size: 4, opacity: 0.15, color: "#ffff00"}
+                }
+            ];
+
+            var layoutContour = {
+                title: "histogram2dcontour & scatter",
+                xaxis: {title: 'ra'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newhist2dcontour', data: dataContour, layout: layoutContour}, 'h2dcontourContainer');
+        }
+
+        function loadHeatmapHist2dChart(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'h2dcontourHeatContainer');
+
+            var dataContour = [
+                {
+                    type: 'heatmap',
+                    name: "heatmap: ra-dec",
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::ra-0.2",
+                    y: "tables::dec",
+                    z: "tables::w2snr",
+                    colorscale: "Reds",
+                    colorbar: {x:-0.5}
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'cont: ra-dec',
+                    type: 'histogram2dcontour',
+                    x: "tables::ra",
+                    y: "tables::dec",
+                    colorscale: "Blues",
+                    colorbar: {y:0.39},
+                    ncontours: 20
+                }
+            ];
+
+            var layoutContour = {
+                title: "histogram2dcontour & heatmap",
+                xaxis: {title: 'ra'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newhist2dConheat', data: dataContour, layout: layoutContour}, 'h2dcontourHeatContainer');
+        }
+
+        function loadHistogram2dHistChart(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'h2dcontourContainer_hist');
+
+            var dataContour = [
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'cont: w1-w2',
+                    type: 'histogram2dcontour',
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    colorbar: {y:0.25},
+                    ncontours: 20
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "hist1: w1",
+                    x: "tables::w1mpro",
+                    type: 'histogram'
+                },
+                {
+                    type: 'histogram',
+                    name: "hist2: w2",
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w2mpro"
+                }
+            ];
+
+            var layoutContour = {
+                title: "histogram2dcontour & histogram",
+                xaxis: {title: ''},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newhist2dcontour_hist', data: dataContour, layout: layoutContour}, 'h2dcontourContainer_hist');
+        }
+
+        function loadHistogram2dHeatmapChart(r, c, w, h) {
+            firefly.getViewer().addCell(r, c, w, h, 'xyPlots', 'h2dcontourContainer_heat');
+
+            var dataContour = [
+                {
+                    type: 'heatmap',
+                    tbl_id: "wiseCatTbl",
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    z: "tables::w1snr",
+                    name: 'heat: w1-w2'
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: 'cont: w1-w2',
+                    type: 'histogram2dcontour',
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    colorbar: {x:-0.3},
+                    reversescale: true,
+                    ncontours: 20
+                }
+            ];
+
+            var layoutContour = {
+                title: "histogram2dcontour & heatmap",
+                xaxis: {title: 'w1mpro'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'newhist2dcontour_heat', data: dataContour, layout: layoutContour}, 'h2dcontourContainer_heat');
+        }
+
+        function loadScatterFireflyHistChart(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'fireflyHistScatterContainer');
+
+            var dataH = [
+                {
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 30,
+                            columnOrExpr: 'w1mpro'
+                        }
+                    },
+                    name: 'w1: ffHist'
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "scatter: w1-w2",
+                    x: "tables::w1mpro",
+                    y: "tables::w2mpro",
+                    mode: 'markers',
+                    type: 'scatter',
+                    marker: {size: 4, opacity: 0.15}
+                },
+                {
+                    type: 'fireflyHistogram',
+
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 40,
+                            columnOrExpr: 'w2mpro'
+                        }
+                    },
+                    name: 'w2: ffHist'
+                }
+            ];
+
+            var layoutHist = {
+                title: 'firefly histogram vs. scatter ',
+                xaxis: {title: 'photometry (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'firefly-hist-scatter-tbl', layout: layoutHist, data: dataH},
+                    'fireflyHistScatterContainer');
+        }
+
+
+        function loadFireflyHistogramCharts(r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'xyPlots', 'fireflyHistContainer');
+
+            var dataH = [
+                {
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 30,
+                            columnOrExpr: 'w1mpro'
+                        }
+                    },
+                    name: 'w1: ffhist'
+                },
+                {
+                    tbl_id: "wiseCatTbl",
+                    name: "histogram",
+                    x: "tables::w1mpro",
+                    type: 'histogram'
+                },
+                {
+                    type: 'fireflyHistogram',
+                    firefly: {
+                        tbl_id: 'wiseCatTbl',
+                        options: {
+                            algorithm: 'fixedSizeBins',
+                            fixedBinSizeSelection: 'numBins',
+                            numBins: 40,
+                            columnOrExpr: 'w2mpro'
+                        }
+                    },
+                    name: 'w2: ffhist'
+                }
+            ];
+
+            var layoutHist = {
+                title: 'firefly histogram vs. histogram ',
+                xaxis: {title: 'photometry (mag)'},
+                yaxis: {title: ''}
+            };
+
+            firefly.getViewer().showChart(
+                    {chartId: 'firefly-hist-tbl', layout: layoutHist, data: dataH},
+                    'fireflyHistContainer');
+        }
+
+        function showATable(sTarget,r,c,w,h) {
+            firefly.getViewer().addCell(r,c,w,h, 'tables');
+            var req=  firefly.util.table.makeIrsaCatalogRequest('WISE catalog', 'WISE', 'allwise_p3as_psd',
+                {
+                    position: sTarget,
+                    SearchMethod: 'Cone',
+                    radius: 360
+                },
+                {
+                    tbl_id: "wiseCatTbl"
+                }
+            );
+            firefly.getViewer().showTable( req, {removable: true, showUnits: false, showFilters: true});
+        }
+    }
+</script>
+
+
+
+
+<script type="text/javascript">
+    {
+        onFireflyLoaded= function(firefly) {
+
+            document.getElementById('sTarget').value=  '10.68479;41.26906;EQ_J2000';
+
+            firefly.setViewerConfig(firefly.ViewerType.Grid);
+            window.ffViewer= firefly.getViewer();
+
+            firefly.setGlobalImageDef({
+                ZoomType  : 'TO_WIDTH'
+            } );
+
+            firefly.debug= true;
+
+            var util= firefly.util;
+            var ui= firefly.ui;
+
+            var req= {
+                plotId: 'xxq',
+                Type      : 'SERVICE',
+                plotGroupId : 'myGroup',
+                Service   : 'TWOMASS',
+                Title     : '2mass from service',
+                GridOn     : true,
+//                GridOn     : 'TRUE_LABELS_FALSE',
+                SurveyKey  : 'k',
+                WorldPt    : '10.68479;41.26906;EQ_J2000',
+                SizeInDeg  : '.12',
+                AllowImageSelection : true
+            };
+
+
+
+
+        };
+
+   }
+
+</script>
+
+<!-- to try a container: <script  type="text/javascript" src="http://localhost:8090/firefly/firefly_loader.js"></script>-->
+
+<script  type="text/javascript" src="../firefly_loader.js"></script>
+
+
+</html>

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -504,7 +504,12 @@ function getTraceTSEntries({chartDataType, traceTS, chartId, traceNum}) {
 }
 
 // does the default depend on the chart type?
-export function applyDefaults(chartData={}, resetColor = false) {
+/**
+ * set default value for layout and data
+ * @param chartData
+ * @param resetColor reset color generator for default color assignment of the chart
+ */
+export function applyDefaults(chartData={}, resetColor = true) {
     //const chartType = get(chartData, ['data', '0', 'type']);
     //const noXYAxis = chartType && (chartType === 'pie');
 
@@ -566,17 +571,19 @@ export function applyDefaults(chartData={}, resetColor = false) {
 }
 
 
-// color-blind friendly colors
-export const TRACE_COLORS = [  '#333333', '#ff3333', '#00ccff', '#336600',
-                        '#9900cc', '#ff9933', '#009999', '#66ff33',
-                        '#cc9999', '#b22424', '#008fb2', '#244700',
-                        '#6b008f', '#b26b24', '#006b6b', '#47b224', '8F6B6B'];
+// plotly default color (items 0-7) + color-blind friendly colors
+export const TRACE_COLORS = [  '#1f77b4', '#2ca02c', '#d62728', '#9467bd',
+                               '#8c564b', '#e377c2', '#7f7f7f', '#17becf',
+                               '#333333', '#ff3333', '#00ccff', '#336600',
+                               '#9900cc', '#ff9933', '#009999', '#66ff33',
+                               '#cc9999', '#b22424', '#008fb2', '#244700',
+                               '#6b008f', '#b26b24', '#006b6b', '#47b224', '8F6B6B'];
 export const TRACE_COLORSCALE = [  'Bluered', 'Blues', 'Earth', 'Electric', 'Greens',
                                 'Greys', 'Hot', 'Jet', 'Picnic', 'Portland', 'Rainbow',
                                 'RdBu', 'Reds', 'Viridis', 'YlGnBu', 'YlOrRd' ];
 
-export function *traceColorGenerator(colorList, init = 0) {
-    let nextIdx = init;
+export function *traceColorGenerator(colorList) {
+    let nextIdx = -1;
 
     while (true) {
         const result = yield (nextIdx === -1) ? '' : colorList[nextIdx%colorList.length];

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -697,7 +697,10 @@ function reduceData(state={}, action={}) {
                 rest['_original'] = cloneDeep(action.payload);
                 applyDefaults(rest);
                 useScatterGL && changeToScatterGL(rest);
-                set(rest, 'curveNumberMap', range(rest.data.length));
+
+                // the first trace is put as the last curve for plotly rendering
+                const curveNumberMap = range(1, rest.data.length).concat([0]);
+                Object.assign(rest, {curveNumberMap});
             }
             state = updateSet(state, chartId,
                 omitBy({

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {cloneDeep, has, get, isEmpty, isString, isUndefined, omit, omitBy, set} from 'lodash';
+import {cloneDeep, has, get, isEmpty, isString, isUndefined, omit, omitBy, set, range} from 'lodash';
 import shallowequal from 'shallowequal';
 
 import {flux} from '../Firefly.js';
@@ -438,10 +438,11 @@ function chartFilterSelection(action) {
 function setActiveTrace(action) {
     return (dispatch) => {
         const {chartId, activeTrace} = action.payload;
-        const {data, tablesources} = getChartData(chartId) || {};
+        const {data, tablesources, curveNumberMap} = getChartData(chartId) || {};
         const tbl_id = get(tablesources, [activeTrace, 'tbl_id']);
         let selected = undefined;
         let highlighted = undefined;
+        let curveMap = undefined;
         if (tbl_id) {
             const {selectInfo, highlightedRow} = getTblById(tbl_id) || {};
             if (selectInfo) {
@@ -452,8 +453,12 @@ function setActiveTrace(action) {
                 }
             }
             highlighted = newTraceFrom(data[activeTrace], [getPointIdx(data[activeTrace], highlightedRow)], HIGHLIGHTED_PROPS);
+            if (curveNumberMap) {
+                curveMap = range(curveNumberMap.length).filter((idx) => (idx !== activeTrace));
+                curveMap.push(activeTrace);
+            }
         }
-        const changes = {activeTrace, selected, highlighted, selection: undefined};
+        const changes = {activeTrace, selected, highlighted, selection: undefined, curveNumberMap: curveMap};
         dispatchChartUpdate({chartId, changes});
     };
 }
@@ -692,6 +697,7 @@ function reduceData(state={}, action={}) {
                 rest['_original'] = cloneDeep(action.payload);
                 applyDefaults(rest);
                 useScatterGL && changeToScatterGL(rest);
+                set(rest, 'curveNumberMap', range(rest.data.length));
             }
             state = updateSet(state, chartId,
                 omitBy({

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -699,8 +699,10 @@ function reduceData(state={}, action={}) {
                 useScatterGL && changeToScatterGL(rest);
 
                 // the first trace is put as the last curve for plotly rendering
-                const curveNumberMap = range(1, rest.data.length).concat([0]);
-                Object.assign(rest, {curveNumberMap});
+                const tData = get(rest, ['data', 'length']);
+                if (tData) {
+                    Object.assign(rest, {activeTrace: tData-1, curveNumberMap: range(tData)});
+                }
             }
             state = updateSet(state, chartId,
                 omitBy({

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -323,10 +323,10 @@ function chartAdd(action) {
             const newPayload = handleFireflyTraceTypes(action.payload);
             const actionToDispatch = (newPayload === action.payload) ? action : Object.assign({}, action, {payload: newPayload});
             dispatch(actionToDispatch);
-            const {viewerId='main', data, fireflyData, fireflyLayout} = actionToDispatch.payload;
+            const {viewerId='main', data, fireflyData} = actionToDispatch.payload;
             dispatchAddViewer(viewerId,true,'plot2d',true);
             dispatchAddViewerItems(viewerId, [chartId], 'plot2d');
-            handleTableSourceConnections({chartId, data, fireflyData, fireflyLayout});
+            handleTableSourceConnections({chartId, data, fireflyData});
         } else {
             dispatch(action);
         }

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -1,12 +1,14 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {flux} from '../../Firefly.js';
-import {get} from 'lodash';
+import {get, set} from 'lodash';
 import shallowequal from 'shallowequal';
 import {PlotlyWrapper} from './PlotlyWrapper.jsx';
 
 import {dispatchChartUpdate, dispatchChartHighlighted, getChartData} from '../ChartsCntlr.js';
 import {isScatter2d} from '../ChartUtil.js';
+
+
 
 export class PlotlyChartArea extends PureComponent {
 
@@ -63,7 +65,15 @@ export class PlotlyChartArea extends PureComponent {
             doingResize = true;
         }
         const showlegend = data.length > 1;
-        let pdata = data.map((e) => Object.assign({}, e)); // create shallow copy of data elements to avoid sharing x,y,z arrays
+
+        // put the active trace after all inactive traces
+        let pdata = data.reduce((rdata, e, idx) =>  {
+            (idx !== activeTrace) && rdata.push(e);
+            return rdata;
+        }, []);
+
+        pdata.push(data[activeTrace]);
+        //let pdata = data.map((e) => Object.assign({}, e)); // create shallow copy of data elements to avoid sharing x,y,z arrays
         if (!data[activeTrace] || isScatter2d(get(data[activeTrace], 'type', ''))) {
             // highlight makes sense only for scatter at the moment
             // 3d scatter highlight and selected appear in front - not good: disable for the moment

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -145,8 +145,7 @@ function onClick(chartId) {
         const highlighted = get(evData.points, `${0}.pointNumber`);
         const curveName = get(evData.points, `${0}.data.name`);
 
-        const traceNum = curveNumber >= curveNumberMap.length ? curveNumber :
-                         curveNumberMap.find((tNum, idx) => idx === curveNumber);
+        const traceNum = curveNumber >= curveNumberMap.length ? curveNumber : curveNumberMap[curveNumber];
 
         // traceNum is related to any of trace data or SELECTED trace or HIGHLIGHTED trace
         // if traceNUm is between [0, curveNumberMap.length-1], then curveNumber is mapped to one of the trace data

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -199,6 +199,8 @@ export class PlotlyWrapper extends Component {
 
             if (!useScatterGL) {
                 // when using SVG, it's actually faster to redraw then to do multiple updates
+                // if renderType is restyle, plotly render the inactive trace on top of the active trace
+                // for chart with type histogram2d or histogram2dcontour
                 if (renderType === RenderType.RESTYLE_AND_RELAYOUT || dataUpdate.length > 1 ||
                     (data.find((d) => get(d, 'type').includes('histogram2d')))) {
                     renderType = RenderType.NEW_PLOT;

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -199,7 +199,8 @@ export class PlotlyWrapper extends Component {
 
             if (!useScatterGL) {
                 // when using SVG, it's actually faster to redraw then to do multiple updates
-                if (renderType === RenderType.RESTYLE_AND_RELAYOUT || dataUpdate.length > 1) {
+                if (renderType === RenderType.RESTYLE_AND_RELAYOUT || dataUpdate.length > 1 ||
+                    (data.find((d) => get(d, 'type').includes('histogram2d')))) {
                     renderType = RenderType.NEW_PLOT;
                 }
             }


### PR DESCRIPTION
The development includes: 
- reorder the traces before plotly rendering such that the active chart is rendered on top of others. 
- assign the name and color relevant values to the trace in case those are not assigned initially. 
- create 2 demo apps, one is to render charts with multiple traces of the same type (ffapi-slate-test4.html) and the orher is to render charts with traces of mixed types (ffapi-slate-test5.html). 

test: 
run demo/ffapi-slate-test4.html to test the selection of active trace 
run  demo/ffapi-slate-test5.html to test the selection of active trace on the chart with mixed types. 
note: the chart rendering is based on the selection of active trace and the following rendering priority among different chart types (observation from the samples): 
pie -> scatter -> fireflyHistogram(bar) -> histogram -> histogram2dcontour/histogram2d -> heatmap

some issue: 
- the scatter chart in ffapi-slate-test4.html includes 3 trace with the same data, however, sometime the rendering of all traces is not overlapped, need some investigation about this issue. 
- the inactive trace for the chart with histogram2dcontour(or histogram2d) type is rendered above the active one (main chart part not the colorbar)  while using plotly 'restyle'. 