### PR TITLE
Irsa 814 813 add ibe2 api and SEIP/MSX examples

### DIFF
--- a/config/app-test.prop
+++ b/config/app-test.prop
@@ -18,3 +18,5 @@ workspace.protocol.irsa.webdav=edu.caltech.ipac.firefly.server.WebDAVWorkspaceMa
 # Another Impl?-> See edu.caltech.ipac.firefly.server.ws.WebDAVWorkspaceHandler#withCredentials
 # workspace.protocol.irsa.webdav=edu.caltech.ipac.firefly.server.ws.WebdavImpl
 
+atlas.ibe.host=irsadev.ipac.caltech.edu
+

--- a/config/app.config
+++ b/config/app.config
@@ -61,14 +61,12 @@ environments {
         ehcache.multicast.port = 4015
         visualize.fits.Security= false
         ehcache.multicast.ttl = 0
-        atlas.ibe.host    = "irsadev.ipac.caltech.edu"
     }
     dev {
         BuildType = "Development"
         ehcache.multicast.port = "5015"
         lsst.dataAccess.uri = "http://localhost:8661/db/v0/query?"
         lsst.dataAccess.db = "smm_bremerton"
-	atlas.ibe.host    = "irsadev.ipac.caltech.edu"
     }
     test {
         BuildType = "Beta"

--- a/config/app.config
+++ b/config/app.config
@@ -61,12 +61,14 @@ environments {
         ehcache.multicast.port = 4015
         visualize.fits.Security= false
         ehcache.multicast.ttl = 0
+        atlas.ibe.host    = "irsadev.ipac.caltech.edu"
     }
     dev {
         BuildType = "Development"
         ehcache.multicast.port = "5015"
         lsst.dataAccess.uri = "http://localhost:8661/db/v0/query?"
         lsst.dataAccess.db = "smm_bremerton"
+	atlas.ibe.host    = "irsadev.ipac.caltech.edu"
     }
     test {
         BuildType = "Beta"

--- a/config/app.config
+++ b/config/app.config
@@ -48,6 +48,7 @@ irsa.gator.service.periodogram.url = "https://irsa.ipac.caltech.edu/cgi-bin/peri
 
 wise.ibe.host       = "irsa.ipac.caltech.edu/ibe"
 twomass.ibe.host    = "irsa.ipac.caltech.edu/ibe"
+atlas.ibe.host    = "irsa.ipac.caltech.edu"
 
 lsst.dataAccess.uri = ''
 lsst.dataAccess.db = ''

--- a/src/firefly/config/app.prop
+++ b/src/firefly/config/app.prop
@@ -5,6 +5,7 @@ visualize.fits.search.path=@visualize.fits.search.path@:@alerts.dir@:@work.direc
 irsa.gator.hostname=@irsa.gator.hostname@
 wise.ibe.host=@wise.ibe.host@
 twomass.ibe.host=@twomass.ibe.host@
+atlas.ibe.host=@atlas.ibe.host@
 
 FireflyTools.Advertise= @FireflyTools.Advertise@
 ignore.auth=true

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/BaseIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/BaseIbeDataSource.java
@@ -24,14 +24,6 @@ public class BaseIbeDataSource implements IbeDataSource {
     private String tableName;
     private boolean useFileSystem = false;
     private String baseFilesystemPath;
-    public static final String USER_TARGET_WORLD_PT = "UserTargetWorldPt";
-    public static final String POS = "POS";
-    public static final String REF_BY = "refby";
-    public static final String INTERSECT = "INTERSECT";
-    public static final String SIZE = "SIZE";
-    public static final String MCEN = "mcen";
-    public static final String COLUMNS = "columns";
-    public static final String WHERE = "where";
 
     public BaseIbeDataSource() {
     }

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
@@ -5,6 +5,7 @@ package edu.caltech.ipac.astro.ibe;
 
 import edu.caltech.ipac.astro.IpacTableException;
 import edu.caltech.ipac.astro.IpacTableReader;
+import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.PtfIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
 import edu.caltech.ipac.firefly.data.FileInfo;
@@ -29,6 +30,8 @@ import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
+import static edu.caltech.ipac.astro.ibe.BaseIbeDataSource.addUrlParam;
+
 /**
  * Date: 4/17/14
  *
@@ -36,20 +39,13 @@ import java.util.Map;
  * @version $Id: $
  */
 public class IBE {
-    public static final String USER_TARGET_WORLD_PT = "UserTargetWorldPt";
-    public static final String POS = "POS";
-    public static final String REF_BY = "refby";
-    public static final String INTERSECT = "INTERSECT";
-    public static final String SIZE = "SIZE";
-    public static final String MCEN = "mcen";
-    public static final String COLUMNS = "columns";
-    public static final String WHERE = "where";
+
     public static final String CUT_SIZE = "size";
     public static final String CUT_CENTER = "center";
+    public static final String POS = "POS";
 
     private IbeDataSource ibeDataSource;
     private IbeFileUploader fileUploader;
-
 
 
     public IBE(IbeDataSource ibeDataSource) {
@@ -66,16 +62,12 @@ public class IBE {
 
     public void getMetaData(File results) throws IOException {
 
-        String url = ibeDataSource.getIbeHost() + "/search/" +
-                ibeDataSource.getMission() + "/" + ibeDataSource.getDataset() +
-                "/" + ibeDataSource.getTableName()+ "?FORMAT=METADATA";
+        String url = ibeDataSource.getMetaDataUrl();
         downloadViaUrlToFile(new URL(url), results);
     }
 
     public void query(File results, IbeQueryParam param) throws IOException {
-        String url = ibeDataSource.getIbeHost() + "/search/" +
-                ibeDataSource.getMission() + "/" + ibeDataSource.getDataset() +
-                "/" + ibeDataSource.getTableName() + "?" + convertToUrl(param);
+        String url = ibeDataSource.getQueryUrl(param);
         downloadViaUrlToFile(new URL(url), results);
     }
 
@@ -88,11 +80,9 @@ public class IBE {
             }
         }
 
-        String url = ibeDataSource.getIbeHost() + "/search/" +
-                ibeDataSource.getMission() + "/" + ibeDataSource.getDataset() +
-                "/" + ibeDataSource.getTableName();
+        String url = ibeDataSource.getSearchUrl();
 
-        Map<String, String> paramMap = asMap(param);
+        Map<String, String> paramMap = ibeDataSource.getMulipleQueryParam(param);
         paramMap.remove(POS);
         try {
             fileUploader.post(results, POS, posFile, new URL(url), paramMap);
@@ -104,6 +94,7 @@ public class IBE {
 
     /**
      * this is used to return fits images as well as artifacts.
+     *
      * @param param param map
      * @return
      * @throws IOException
@@ -115,15 +106,16 @@ public class IBE {
 
     /**
      * this is used to return fits images as well as artifacts.
+     *
      * @param param param map
-     * @param dl Download listener
+     * @param dl    Download listener
      * @return
      * @throws IOException
      */
     public FileInfo getData(IbeDataParam param, Map<String, String> sourceParams, File dir, DownloadListener dl)
-                                  throws IOException {
+            throws IOException {
 
-        if (param.getFilePath() == null) {
+        if (ibeDataSource.useFileSystem() && param.getFilePath() == null) {
             throw new IOException("IbeDataParam does not contains the required filepath information.");
         }
 
@@ -151,35 +143,33 @@ public class IBE {
 
     public URL createDataUrl(IbeDataParam param) throws IOException {
 
-        String fpath = param.getFilePath();
+        String url = ibeDataSource.getDataUrl(param);
 
-        String url = ibeDataSource.getIbeHost() + "/data/" +
-                ibeDataSource.getMission() + "/" + ibeDataSource.getDataset() +
-                "/" + ibeDataSource.getTableName() + "/" + fpath;
         String qstr = "";
         if (param.isDoCutout()) {
-            qstr= addUrlParam(qstr, CUT_CENTER, param.getCenter());
-            qstr= addUrlParam(qstr, CUT_SIZE, param.getSize());
-            qstr= addUrlParam(qstr, "gzip", param.isDoZip());
+            qstr = addUrlParam(qstr, CUT_CENTER, param.getCenter());
+            qstr = addUrlParam(qstr, CUT_SIZE, param.getSize());
+            qstr = addUrlParam(qstr, "gzip", param.isDoZip());
         }
 
-        url = url + (qstr.length() > 0 ? "?" + qstr : "");
+        url += (qstr.length() > 0 ? "?" + qstr : "");
+
         return new URL(url);
     }
 
 
     private FileInfo downloadViaUrl(URL url, Map<String, String> sourceParams, File dir, DownloadListener dl)
-                                                         throws IOException {
-        String progressKey= null;
-        String plotId= null;
+            throws IOException {
+        String progressKey = null;
+        String plotId = null;
         try {
-            if (sourceParams!=null) {
-                progressKey= sourceParams.get("ProgressKey");
-                plotId= sourceParams.get("plotId");
+            if (sourceParams != null) {
+                progressKey = sourceParams.get("ProgressKey");
+                plotId = sourceParams.get("plotId");
             }
             Map<String, String> identityCookies = ServerContext.getRequestOwner().getIdentityCookies();
 
-            return URLFileInfoProcessor.retrieveViaURL(url,dir, progressKey, plotId, null, identityCookies);
+            return URLFileInfoProcessor.retrieveViaURL(url, dir, progressKey, plotId, null, identityCookies);
         } catch (DataAccessException e) {
             throw new IOException(e.getMessage(), e);
         }
@@ -187,7 +177,7 @@ public class IBE {
 
 
     private void downloadViaUrlToFile(URL url, File results) throws IOException {
-        downloadViaUrlToFile(url,results,null);
+        downloadViaUrlToFile(url, results, null);
     }
 
     private void downloadViaUrlToFile(URL url, File results, DownloadListener dl) throws IOException {
@@ -196,65 +186,8 @@ public class IBE {
             uc.setRequestProperty("Accept", "text/plain");
             URLDownload.getDataToFile(uc, results, dl);
         } catch (FailedRequestException e) {
-            throw new IOException(e.getUserMessage(),  e);
+            throw new IOException(e.getUserMessage(), e);
         }
-    }
-
-    private Map<String, String> asMap(IbeQueryParam param) {
-        HashMap<String, String> params = new HashMap<>();
-        String s = convertToUrl(param);
-        String[] pp = s.split("&");
-        for (String keyval : pp) {
-            if (!StringUtils.isEmpty(keyval)) {
-                String[] parts = keyval.split("=", 2);
-                if (!StringUtils.isEmpty(parts[0])) {
-                    String v = parts.length > 1 && !StringUtils.isEmpty(parts[1]) ? parts[1].trim() : "";
-                    params.put(parts[0], v);
-                }
-            }
-        }
-        return params;
-    }
-
-
-    private String convertToUrl(IbeQueryParam param) {
-        String s = "";
-        if (param == null) return "";
-
-        if (!StringUtils.isEmpty(param.getRefBy())) {
-            s =addUrlParam(s, REF_BY, param.getRefBy());
-        } else if (!StringUtils.isEmpty(param.getPos())) {
-            s = addUrlParam(s, POS, param.getPos());
-            s = addUrlParam(s, INTERSECT, param.getIntersect());
-            if (param.isMcen()) {
-                s = addUrlParam(s, null, MCEN);
-            } else {
-                s = addUrlParam(s, SIZE, param.getSize());
-            }
-        }
-
-        s = addUrlParam(s, COLUMNS, param.getColumns());
-        s = addUrlParam(s, WHERE, param.getWhere(), true);
-        return s;
-    }
-
-    public static String addUrlParam(String url, String key, Object value) {
-        return addUrlParam(url, key, value, false);
-    }
-
-    public static String addUrlParam(String url, String key, Object value, boolean doEncode) {
-        try {
-            if (!StringUtils.isEmpty(value)) {
-                if (!StringUtils.isEmpty(url)) {
-                    url = url + "&";
-                }
-                value = doEncode ? URLEncoder.encode(value.toString(), "UTF-8") : value;
-                key = StringUtils.isEmpty(key) ? "" : key + "=";
-                url = url + key + value;
-            }
-        } catch (UnsupportedEncodingException e) {
-        }
-        return url;
     }
 
 
@@ -274,6 +207,43 @@ public class IBE {
 
     public static void main(String[] args) {
 
+
+        if (true) {
+            AtlasIbeDataSource atlas = new AtlasIbeDataSource(AtlasIbeDataSource.DS.SEIP);
+            IBE ibe = new IBE(atlas);
+            try {
+                String basedir = "/hydra/ibetest/atlas";
+                // query the metadata
+                File results = new File(basedir, "meta.tbl");
+                ibe.getMetaData(results);
+
+                // query via position
+                results = new File(basedir, "ibe.tbl");
+                IbeQueryParam param = new IbeQueryParam("280,-8", ".45");    // m31
+//                atlas.makeQueryParam()
+                ibe.query(results, param);
+
+                // retrieve all data types with cutout options
+                DataGroup data = IpacTableReader.readIpacTable(results, "results");
+                for (int idx = 0; idx < data.size(); idx++) {
+                    DataObject row = data.get(idx);
+                    Map<String, String> dinfo = IpacTableUtil.asMap(row);
+                    IbeDataParam dparam = ibe.getIbeDataSource().makeDataParam(dinfo);
+                   // dparam.setCutout(true, "10.768479,41.26906", ".1");
+                    try {
+                        FileInfo fileInfo = ibe.getData(dparam, null, new File(basedir), null);
+                        assert fileInfo.getSizeInBytes()>0;
+                    } catch (IOException ex) {
+                        throw new IOException("Line " + idx + ": Unable to retrieve " + dinfo.get("file_type") + " data.",ex);
+                    }
+                }
+
+            } catch (IOException | IpacTableException e) {
+                e.printStackTrace();
+            }
+        }
+
+        /*
         // test WISE
         if (false) {
             IBE ibe = new IBE(new WiseIbeDataSource(WiseIbeDataSource.DataProduct.ALLSKY_4BAND_1B));
@@ -312,7 +282,7 @@ public class IBE {
         }
 
         // test ptf
-        if (true) {
+        if (false) {
             IBE ibe = new IBE(new PtfIbeDataSource(PtfIbeDataSource.DataProduct.LEVEL1));
             try {
                 String basedir = "/hydra/ibetest/ptf";
@@ -344,6 +314,7 @@ public class IBE {
                 e.printStackTrace();
             }
         }
+        */
 
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
@@ -6,8 +6,6 @@ package edu.caltech.ipac.astro.ibe;
 import edu.caltech.ipac.astro.IpacTableException;
 import edu.caltech.ipac.astro.IpacTableReader;
 import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
-import edu.caltech.ipac.astro.ibe.datasource.PtfIbeDataSource;
-import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
@@ -22,12 +20,9 @@ import edu.caltech.ipac.util.download.URLDownload;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.URLEncoder;
-import java.util.HashMap;
 import java.util.Map;
 
 import static edu.caltech.ipac.astro.ibe.BaseIbeDataSource.addUrlParam;

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IbeDataSource.java
@@ -16,6 +16,15 @@ import java.util.Map;
  */
 public interface IbeDataSource {
 
+    public static final String USER_TARGET_WORLD_PT = "UserTargetWorldPt";
+    public static final String POS = "POS";
+    public static final String REF_BY = "refby";
+    public static final String INTERSECT = "INTERSECT";
+    public static final String SIZE = "SIZE";
+    public static final String MCEN = "mcen";
+    public static final String COLUMNS = "columns";
+    public static final String WHERE = "where";
+
     String getIbeHost();
     String getMission();
     String getDataset();

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IbeDataSource.java
@@ -34,7 +34,19 @@ public interface IbeDataSource {
     String getBaseFilesystemPath();
 
 
+    String getDataUrl(IbeDataParam param);
 
+    String getMetaDataUrl();
 
+    String getQueryUrl(IbeQueryParam param);
 
+    Map<String,String> getMulipleQueryParam(IbeQueryParam param);
+
+    String getSearchUrl();
+
+    String getCorners();
+
+    String getCenterCols();
+
+    String[] getColsToHide();
 }

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
@@ -1,0 +1,352 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.astro.ibe.datasource;
+
+import edu.caltech.ipac.astro.ibe.BaseIbeDataSource;
+import edu.caltech.ipac.astro.ibe.IbeDataParam;
+import edu.caltech.ipac.astro.ibe.IbeQueryParam;
+import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.StringUtils;
+import edu.caltech.ipac.visualize.plot.CoordinateSys;
+import edu.caltech.ipac.visualize.plot.Plot;
+import edu.caltech.ipac.visualize.plot.WorldPt;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/**
+ * Generic Atlas (IBE2) source definition, api has the URL form of (see IRSA-750):
+ * https://irsadev.ipac.caltech.edu/IBE?table=@schema@.@table@&POS=@ra@,@dec@
+ * <p>
+ * See schemas(mission) / tables value available: https://irsadev.ipac.caltech.edu/ibe
+ * <br>and<p>
+ * https://irsadev.ipac.caltech.edu/TAP/sync?query=select+c.schema_name,+c.table_name+from+TAP_SCHEMA.columns+c+JOIN+TAP_SCHEMA.tables+t+ON+c.table_name=t.table_name+where+c.column_name='ra4'+AND+t.irsa_dbms='POSTGRES'
+ * </p>
+ * <br>
+ * Plus, the <i>where</i> clause still apply, i.e. SEIP:
+ * https://irsadev.ipac.caltech.edu/IBE?table=spitzer.seip_science&responseformat=votable&POS=280,-8&where=instrument_name%3d%27IRAC%27+and+band_name%3d%27IRAC4%27
+ * <br><p>
+ * Using cutout:
+ * http://irsadev.ipac.caltech.edu/ibe/data/@chema@/@table@/@fname?center=@ra@,@dec@&size=@n@px
+ * <p>
+ * Note for Spitzer:
+ * there are two types of image that are considered "science": *mosaic.fits and median_mosaic.fits.
+ * Filtering by file-type: science will remove the unc and cov files, but not the median_mosaic.fits files.
+ * need specific filter: <em>fname like '%.mosaic.fits'</em>
+ *
+ * @author ejoliet
+ */
+public class AtlasIbeDataSource extends BaseIbeDataSource {
+    public static final String ATLAS = "atlas";
+
+    //Keeping the logic
+    public static final String DS_KEY = "ds"; // example: seip
+    public static final String BAND_KEY = "band"; // example: IRAC1
+    public static final String INSTRUMENT_KEY = "instrument"; //example: IRAC or MIPS
+    public static final String FILE_TYPE_KEY = "file_type";// example: 'science' for seip (see princiapl column for prefered image to display = '1'
+    public static final String TABLE_KEY = "table";// example: seip_science
+    public static final String SCHEMA_KEY = "schema"; //Example:spitzer
+    public static final String XTRA_KEY = "filter"; //Example:fname like '%.mosaic.fits'
+    private static final String PRINCIPAL_KEY = "principal";
+
+    private DS ds;
+
+    public enum DS {
+        SEIP("SEIP", "spitzer", "seip_science", FILE_TYPE_KEY + "='science' and fname like \'%.mosaic.fits\'");
+        private final String extraFilter;
+        private String name;
+        private String schema;
+        private String table;
+
+
+        DS(String name, String schema, String table, String xtraFilter) {
+            this.name = name;
+            this.schema = schema;
+            this.table = table;
+            this.extraFilter = xtraFilter;
+        }
+
+        /**
+         * DataSet name
+         *
+         * @return
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Schema = Mission, see https://irsadev.ipac.caltech.edu/ibe
+         *
+         * @return schema name which is the mission in IBE2/ATLAS
+         */
+        public String getSchema() {
+            return schema;
+        }
+
+        /**
+         * Table name in IRSA archives, see https://irsadev.ipac.caltech.edu/TAP/sync?query=select+c.schema_name,+c.table_name+from+TAP_SCHEMA.columns+c+JOIN+TAP_SCHEMA.tables+t+ON+c.table_name=t.table_name+where+c.column_name='ra4'+AND+t.irsa_dbms='POSTGRES'
+         *
+         * @return
+         */
+        public String getTable() {
+            return table;
+        }
+
+        public String getSpecificFilter() {
+            return extraFilter;
+        }
+
+        public static DS getDS(String name) {
+            for (DS ds : values()) {
+                if (ds.getName().equalsIgnoreCase(name)) {
+                    return ds;
+                }
+            }
+            return null;
+        }
+    }
+
+    public AtlasIbeDataSource() {
+    }
+
+    /**
+     * Convenient constructor to build a datasource by using a combination of schema name and table names in more generic way than ENUM string
+     *
+     * @param schema schema name, i.e. 'spitzer'
+     * @param table  table name, i.e 'seip_science'
+     */
+    public AtlasIbeDataSource(String schema, String table) {
+        this(null, schema, table);
+    }
+
+    public AtlasIbeDataSource(DS ds) {
+        this(null, ds);
+    }
+
+
+    public AtlasIbeDataSource(String ibeHost, String schema1, String table1) {
+        setupDS(ibeHost, schema1, table1);
+    }
+
+    public AtlasIbeDataSource(String ibeHost, DS ds) {
+        setupDS(ibeHost, ds.getSchema(), ds.getTable());
+    }
+
+    @Override
+    public void initialize(Map<String, String> dsInfo) {
+
+        ds = DS.getDS(dsInfo.get(DS_KEY));
+        String schema = null, table = null;
+        if (ds != null) {
+            schema = ds.getSchema();
+            table = ds.getTable();
+        } else {
+            // When info comes from edu.caltech.ipac.visualize.net.BaseIrsaParams
+            schema = dsInfo.get(SCHEMA_KEY);
+            table = dsInfo.get(TABLE_KEY);
+        }
+        setupDS(null, schema, table);
+    }
+
+    private void setupDS(String ibeHost, String dataset, String table) {
+
+        if (StringUtils.isEmpty(ibeHost)) {
+            ibeHost = AppProperties.getProperty("atlas.ibe.host", "https://irsadev.ipac.caltech.edu");
+        }
+        setIbeHost(ibeHost);
+        setMission(ATLAS);
+        setDataset(dataset);
+        setTableName(table);
+    }
+
+    public DS getDS() {
+        return ds;
+    }
+
+    @Override
+    public IbeDataParam makeDataParam(Map<String, String> pathInfo) {
+        IbeDataParam dataParam = new IbeDataParam();
+
+        String fname = pathInfo.get("fname");
+
+        String root = getImageRoot();
+
+        dataParam.setFilePath(root + "/" + fname);
+
+        // check cutout params
+        // look for ra_obj first - moving object search
+        String subLon = pathInfo.get("ra_obj");
+        if (StringUtils.isEmpty(subLon)) {
+            // next look for in_ra (IBE returns this)
+            subLon = pathInfo.get("in_ra");
+            if (StringUtils.isEmpty(subLon)) {
+                // all else fails, try using crval1
+                subLon = pathInfo.get("crval1");
+            }
+        }
+
+        // look for dec_obj first - moving object search
+        String subLat = pathInfo.get("dec_obj");
+        if (StringUtils.isEmpty(subLat)) {
+            // next look for in_dec (IBE returns this)
+            subLat = pathInfo.get("in_dec");
+            if (StringUtils.isEmpty(subLat)) {
+                // all else fails, try using crval2
+                subLat = pathInfo.get("crval2");
+            }
+        }
+        String subSize = pathInfo.get("subsize");
+
+        if (!StringUtils.isEmpty(subLon) && !StringUtils.isEmpty(subLat) && !StringUtils.isEmpty(subSize)) {
+            dataParam.setCutout(true, subLon + "," + subLat, subSize);
+        }
+
+        if (dataParam.getFilePath() != null && dataParam.getFilePath().endsWith(".gz")) {
+            dataParam.setDoZip(true);
+        }
+
+        return dataParam;
+    }
+
+    @Override
+    public IbeQueryParam makeQueryParam(Map<String, String> queryInfo) {
+
+        // source search
+        IbeQueryParam queryParam = new IbeQueryParam();
+
+        // process POS - target search
+        String userTargetWorldPt = queryInfo.get("UserTargetWorldPt");
+        if (userTargetWorldPt != null) {
+            WorldPt pt = WorldPt.parse(userTargetWorldPt);
+            if (pt != null) {
+                pt = Plot.convert(pt, CoordinateSys.EQ_J2000);
+                queryParam.setPos(pt.getLon() + "," + pt.getLat());
+                if (!StringUtils.isEmpty(queryInfo.get("intersect"))) {
+                    queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
+                }
+                String mcen = queryInfo.get("mcenter");
+                if (mcen != null && (mcen.equalsIgnoreCase(MCEN) || Boolean.parseBoolean(mcen))) {
+                    queryParam.setMcen(true);
+
+                } else {
+                    // workaround:
+                    if (StringUtils.isEmpty(queryInfo.get("radius"))) {
+                        queryParam.setSize(queryInfo.get("size"));
+                    } else {
+                        queryParam.setSize(queryInfo.get("radius"));
+                    }
+                }
+            }
+        }
+        // process constraints
+        String constraints = processAtlasConstraints(queryInfo);
+        if (!StringUtils.isEmpty(constraints)) {
+            queryParam.setWhere(constraints);
+        }
+
+        return queryParam;
+    }
+
+    private String processAtlasConstraints(Map<String, String> queryInfo) {
+        // create constraint array
+        ArrayList<String> constraints = new ArrayList<String>();
+        String constrStr = "";
+
+        String bands = queryInfo.get(BAND_KEY);
+        // process BAND - ENUMSTRING
+        if (!StringUtils.isEmpty(bands)) {
+            constraints.add("band_name IN (" + bands + ")");
+        }
+        String inst = queryInfo.get(INSTRUMENT_KEY);
+        if (!StringUtils.isEmpty(inst)) {
+            constraints.add("instrument_name=\'" + inst + "\'");
+        }
+
+        // Some image datasets have many images for same file_type and band, so we need to distinguish which one to plot
+        // Atlas metadata search will have a column named 'principal' is added, the filter need to take car of 'file_type' and look for principal = 1 (prefered image to display)
+        String ftype = queryInfo.get(FILE_TYPE_KEY);
+        if (!StringUtils.isEmpty(ftype)) {
+            constraints.add(FILE_TYPE_KEY + "=\'" + ftype + "\'");
+        }
+        String pvalue = queryInfo.get(PRINCIPAL_KEY);
+        if (!StringUtils.isEmpty(pvalue)) {
+            constraints.add(PRINCIPAL_KEY + "=" + pvalue);
+        }
+
+        // TODO for now , extra filter is passed from the request client but
+        // TODO ultimatetly it should be passed above:
+        String xtraFilter = ds == null ? queryInfo.get(XTRA_KEY) : ds.getSpecificFilter();
+        if (xtraFilter != null) {
+            constraints.add(xtraFilter);
+        }
+        // compile all constraints
+        if (!constraints.isEmpty()) {
+
+            int i = 0;
+            for (String s : constraints) {
+                if (i > 0) {
+                    constrStr += " AND ";
+                }
+                constrStr += s;
+
+                i++;
+            }
+        }
+        //Overwrite if where key is set:
+        String where = queryInfo.get("where");
+        if (where != null) {
+            constrStr = where;
+        }
+        return constrStr;
+    }
+
+    @Override
+    public String getDataUrl(IbeDataParam param) {
+        return this.getIbeHost() + "/ibe/" + param.getFilePath();
+    }
+
+    @Override
+    public String getSearchUrl() {
+        return this.getIbeHost() + "/IBE?table=" +
+                this.getDataset() + "." + this.getTableName();
+    }
+
+    @Override
+    public String getQueryUrl(IbeQueryParam param) {
+        return getSearchUrl() + "&" + convertToUrl(param);
+    }
+
+    @Override
+    public String getMetaDataUrl() {
+        return this.getIbeHost() + "/IBE?table=" +
+                this.getDataset() +
+                "." + this.getTableName() + "&FORMAT=METADATA";
+    }
+
+    private String convertToUrl(IbeQueryParam param) {
+        String s = "";
+        if (param == null) return "";
+
+        if (!StringUtils.isEmpty(param.getRefBy())) {
+            s = addUrlParam(s, REF_BY, param.getRefBy());
+        } else if (!StringUtils.isEmpty(param.getPos())) {
+            s = addUrlParam(s, POS, param.getPos());
+            s = addUrlParam(s, INTERSECT, param.getIntersect());
+            if (param.isMcen()) {
+                s = addUrlParam(s, null, MCEN);
+            } else {
+                s = addUrlParam(s, SIZE, param.getSize());
+            }
+        }
+
+        s = addUrlParam(s, COLUMNS, param.getColumns()); // ATLAS IBE2 doesn't have the columns filter, might want to do TAP data source for that purpose?
+        s = addUrlParam(s, WHERE, param.getWhere(), true);
+        return s;
+    }
+
+    public String getImageRoot() {
+        return "/data/" + getDataset() + "/" + getTableName();
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
@@ -158,7 +158,7 @@ public class PtfIbeDataSource extends BaseIbeDataSource {
                     queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
                 }
                 String mcen = queryInfo.get("mcenter");
-                if (mcen != null && mcen.equalsIgnoreCase(IBE.MCEN)) {
+                if (mcen != null && mcen.equalsIgnoreCase(MCEN)) {
                     queryParam.setMcen(true);
 
                 } else {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
@@ -165,7 +165,7 @@ public class TwoMassIbeDataSource extends BaseIbeDataSource {
                     queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
                 }
                 String mcen = queryInfo.get("mcenter");
-                if (mcen != null && (mcen.equalsIgnoreCase(IBE.MCEN) || Boolean.parseBoolean(mcen))) {
+                if (mcen != null && (mcen.equalsIgnoreCase(MCEN) || Boolean.parseBoolean(mcen))) {
                     queryParam.setMcen(true);
 
                 } else {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/WiseIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/WiseIbeDataSource.java
@@ -230,7 +230,7 @@ public class WiseIbeDataSource extends BaseIbeDataSource {
         // source search
         IbeQueryParam queryParam = new IbeQueryParam();
 
-        String userTargetWorldPt = queryInfo.get(IBE.USER_TARGET_WORLD_PT);
+        String userTargetWorldPt = queryInfo.get(USER_TARGET_WORLD_PT);
         String refSourceId = queryInfo.get("refSourceId");
         String sourceId = queryInfo.get("sourceId");
 
@@ -244,7 +244,7 @@ public class WiseIbeDataSource extends BaseIbeDataSource {
                     queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
                 }
                 String mcen = queryInfo.get("mcenter");
-                if (mcen != null && mcen.equalsIgnoreCase(IBE.MCEN)) {
+                if (mcen != null && mcen.equalsIgnoreCase(MCEN)) {
                     queryParam.setMcen(true);
 
                 } else {

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/JossoUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/JossoUtil.java
@@ -55,6 +55,8 @@ public class JossoUtil {
     }
 
     public static String makeVerifyUrl(String backTo) {
+        if(contextPath==null)
+            return null;
         int idx = backTo.indexOf(contextPath);
         if (idx >= 0) {
             String base = backTo.substring(0, idx);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IBEUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IBEUtils.java
@@ -3,8 +3,10 @@
  */
 package edu.caltech.ipac.firefly.server.persistence;
 
+import edu.caltech.ipac.astro.ibe.BaseIbeDataSource;
 import edu.caltech.ipac.astro.ibe.IBE;
 import edu.caltech.ipac.astro.ibe.IbeDataSource;
+import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.PtfIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.TwoMassIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
@@ -12,6 +14,7 @@ import edu.caltech.ipac.firefly.data.Param;
 import edu.caltech.ipac.firefly.data.SortInfo;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.util.DataSetParser;
+import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
 
 import java.io.IOException;
@@ -36,7 +39,9 @@ public class IBEUtils {
             ibeDataSource = new PtfIbeDataSource();
         } else if (mission.equals(TwoMassIbeDataSource.TWOMASS)) {
             ibeDataSource = new TwoMassIbeDataSource();
-        } else {
+        } else if (mission.equals(AtlasIbeDataSource.ATLAS)){
+            ibeDataSource = new AtlasIbeDataSource();
+        }else{
             throw new DataAccessException("Unsupported mission: "+mission);
         }
         ibeDataSource.initialize(paramMap);
@@ -129,6 +134,14 @@ public class IBEUtils {
             }
 
 
+        } else if (source instanceof AtlasIbeDataSource) {
+
+                // TODO : explain to me what is used for:
+                sortByCols.put("facility_name", "facility_name, instrument_name, band_name, file_type");
+                //TODO what is 'relatedCols' meant for?
+                // relatedCols = "fname";
+                colsToHide = new String[]{"in_row_id", "in_ra", "in_dec","ra_1", "dec_1",
+                    "ra_2", "dec_2", "ra_3", "dec_3", "ra_4", "dec_4"};
         }
 
         for (String sortCol : sortByCols.keySet()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IBEUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IBEUtils.java
@@ -136,10 +136,7 @@ public class IBEUtils {
 
         } else if (source instanceof AtlasIbeDataSource) {
 
-                // TODO : explain to me what is used for:
-                sortByCols.put("facility_name", "facility_name, instrument_name, band_name, file_type");
-                //TODO what is 'relatedCols' meant for?
-                // relatedCols = "fname";
+                sortByCols.put("facility_name", "facility_name,instrument_name,band_name,file_type");
                 colsToHide = new String[]{"in_row_id", "in_ra", "in_dec","ra_1", "dec_1",
                     "ra_2", "dec_2", "ra_3", "dec_3", "ra_4", "dec_4"};
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryIBE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryIBE.java
@@ -12,6 +12,7 @@ import edu.caltech.ipac.astro.IpacTableReader;
 import edu.caltech.ipac.astro.ibe.IBE;
 import edu.caltech.ipac.astro.ibe.IbeDataSource;
 import edu.caltech.ipac.astro.ibe.IbeQueryParam;
+import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.SortInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryIBE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryIBE.java
@@ -124,16 +124,12 @@ public class QueryIBE extends IpacTablePartProcessor {
             meta.setAttribute("table", source.getTableName());
             meta.setAttribute("subsize", request.getParam("subsize"));
             meta.setAttribute(MetaConst.DATASET_CONVERTER, source.getMission());
-            meta.setAttribute("ALL_CORNERS", "ra1;dec1;EQ_J2000,ra2;dec2;EQ_J2000,ra3;dec3;EQ_J2000,ra4;dec4;EQ_J2000");
-            meta.setAttribute("CENTER_COLUMN", "crval1;crval2;EQ_J2000");
+            meta.setAttribute("ALL_CORNERS", source.getCorners());
+            meta.setAttribute("CENTER_COLUMN", source.getCenterCols());
             meta.setAttribute("PREVIEW_COLUMN", "download");
             meta.setAttribute("RESOURCE_TYPE", "URL");
 
-            String [] colsToHide = {"in_row_id", "in_ra", "in_dec",
-                        "crval1", "crval2",
-                        "ra1", "ra2", "ra3", "ra4",
-                        "dec1", "dec2", "dec3", "dec4"
-            };
+            String [] colsToHide = source.getColsToHide();
 
             for (String c : colsToHide) {
                 meta.setAttribute(DataSetParser.makeAttribKey(DataSetParser.VISI_TAG, c), DataSetParser.VISI_HIDE);
@@ -143,7 +139,9 @@ public class QueryIBE extends IpacTablePartProcessor {
             meta.setAttributes(IBEUtils.getMissionSpecificTableMeta(source));
 
         }
-        catch (Exception ignored) {}
+        catch (Exception ignored) {
+            LOGGER.error(ignored,"Error ignored");
+        }
     }
 
     private boolean exists(List<DataType> cols, String name) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ibe/IbeQueryArtifact.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ibe/IbeQueryArtifact.java
@@ -4,6 +4,7 @@
 
 package edu.caltech.ipac.firefly.server.query.ibe;
 
+import edu.caltech.ipac.astro.ibe.BaseIbeDataSource;
 import edu.caltech.ipac.astro.ibe.IBE;
 import edu.caltech.ipac.astro.ibe.datasource.TwoMassIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
@@ -170,7 +171,7 @@ public class IbeQueryArtifact extends IpacTablePartProcessor {
 
     private static DataObject queryIBE(TableServerRequest req) throws IOException, DataAccessException {
         req.setRequestId(QueryIBE.PROC_ID);
-        req.setParam(QueryIBE.MOST_CENTER, IBE.MCEN);
+        req.setParam(QueryIBE.MOST_CENTER, BaseIbeDataSource.MCEN);
         req.setPageSize(1);
 
         SearchManager sman= new SearchManager();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
@@ -232,10 +232,12 @@ public class JOSSOAdapter implements SsoAdapter {
     public Map<String, String> getIdentities() {
         HashMap<String, String> idCookies = new HashMap<String, String>();
         RequestAgent http = ServerContext.getRequestOwner().getRequestAgent();
-        for (String name : ID_COOKIE_NAMES) {
-            String value = http.getCookieVal(name);
-            if (!StringUtils.isEmpty(value)) {
-                idCookies.put(name, value);
+        if(http!=null){
+            for (String name : ID_COOKIE_NAMES) {
+                String value = http.getCookieVal(name);
+                if (!StringUtils.isEmpty(value)) {
+                    idCookies.put(name, value);
+                }
             }
         }
         return idCookies.size() == 0 ? null : idCookies;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
@@ -191,13 +191,13 @@ public class ServiceRetriever implements FileRetriever {
         params.setRaJ2000(wp.getLon());
         params.setDecJ2000(wp.getLat());
         params.setBand(r.getSurveyBand());
-        params.setSchema(r.getParam(AtlasIbeDataSource.SCHEMA_KEY));
+        params.setSchema(r.getParam(AtlasIbeDataSource.DATASET_KEY));
         params.setTable(r.getParam(AtlasIbeDataSource.TABLE_KEY));
         params.setInstrument(r.getParam(AtlasIbeDataSource.INSTRUMENT_KEY));
         params.setXtraFilter(r.getParam(AtlasIbeDataSource.XTRA_KEY));
         params.setSize((float)circle.getRadius());
         FileInfo fi= getNetworkPlot(params);
-        return fi.copyWithDesc(getAtlasDesc(r.getParam(AtlasIbeDataSource.SCHEMA_KEY),r.getParam(AtlasIbeDataSource.INSTRUMENT_KEY),r.getSurveyBand()));
+        return fi.copyWithDesc(getAtlasDesc(r.getParam(AtlasIbeDataSource.DATASET_KEY),r.getParam(AtlasIbeDataSource.TABLE_KEY),r.getSurveyBand()));
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class WebPlotRequest extends ServerRequest {
 
     public enum
-            ServiceType {IRIS, ISSA, DSS, SDSS, TWOMASS, MSX, DSS_OR_IRIS, WISE, NONE}
+            ServiceType {IRIS, ATLAS, ISSA, DSS, SDSS, TWOMASS, MSX, DSS_OR_IRIS, WISE, NONE}
     public enum TitleOptions {NONE,  // use what it in the title
                               PLOT_DESC, // use the plot description key
                               FILE_NAME, // use the file name or analyze the URL and make a title from that

--- a/src/firefly/java/edu/caltech/ipac/util/download/CacheHelper.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/CacheHelper.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheKey;
+import edu.caltech.ipac.util.cache.CacheManager;
 
 import java.io.File;
 /**
@@ -32,7 +33,7 @@ public class CacheHelper {
     public static void setCacheDir(File dir) { _cacheDir= dir; }
 
     public static Cache getFileCache() {
-        return _fileCache;
+        return _fileCache!=null?_fileCache: CacheManager.getCache();
     }
 
     public static void putFile(CacheKey key, Object value) {
@@ -117,6 +118,9 @@ public class CacheHelper {
 
     public static FileInfo getFileData(CacheKey key)   {
         Cache cache= getFileCache();
+        if(cache == null){
+           return null;
+        }
         Object cacheObj= cache.get(key);
         FileInfo fd;
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageGetter.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageGetter.java
@@ -52,7 +52,7 @@ public class AtlasImageGetter {
                 if(atlasParams.getDs()!=null){ // using AtlasIbeSource defined datasets
                     m.put(AtlasIbeDataSource.DS_KEY, atlasParams.getDs());
                 }else{
-                    m.put(AtlasIbeDataSource.SCHEMA_KEY, atlasParams.getSchema());
+                    m.put(AtlasIbeDataSource.DATASET_KEY, atlasParams.getSchema());
                     m.put(AtlasIbeDataSource.TABLE_KEY, atlasParams.getTable());
                     //Extra filter for querying images for now - see IRSA-
                     queryMap.put(AtlasIbeDataSource.XTRA_KEY, atlasParams.getXtraFilter());
@@ -95,21 +95,5 @@ public class AtlasImageGetter {
             throw new FailedRequestException("Could not parse results", "Details in exception", me);
         }
 
-    }
-
-
-    public static void main(String args[]) {
-//       WiseImageParams params= new WiseImageParams();
-//       params.setSize(.33F);
-//       params.setBand("1");
-//       params.setBand(WiseImageParams.WISE_3A);
-//       params.setRaJ2000(10.672);
-//       params.setDecJ2000(41.259);
-//       try {
-//           lowlevelGetIbeImage(params, new File("./a.fits.gz"), null);
-//       }
-//       catch (Exception e) {
-//           System.out.println(e);
-//       }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageGetter.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageGetter.java
@@ -1,0 +1,115 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.visualize.net;
+
+
+import edu.caltech.ipac.astro.IpacTableException;
+import edu.caltech.ipac.astro.IpacTableReader;
+import edu.caltech.ipac.astro.ibe.IBE;
+import edu.caltech.ipac.astro.ibe.IbeDataParam;
+import edu.caltech.ipac.astro.ibe.IbeDataSource;
+import edu.caltech.ipac.astro.ibe.IbeQueryParam;
+import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
+import edu.caltech.ipac.astro.ibe.datasource.TwoMassIbeDataSource;
+import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.util.Assert;
+import edu.caltech.ipac.util.DataGroup;
+import edu.caltech.ipac.util.DataObject;
+import edu.caltech.ipac.util.IpacTableUtil;
+import edu.caltech.ipac.util.download.CacheHelper;
+import edu.caltech.ipac.util.download.FailedRequestException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Trey Roby
+ * @version $Id: DssImageGetter.java,v 1.9 2012/08/21 21:30:41 roby Exp $
+ */
+public class AtlasImageGetter {
+
+
+    public static File lowlevelGetIbe2Image(BaseIrsaParams params)
+            throws FailedRequestException,
+            IOException {
+
+        try {
+            String sizeStr = null;
+            IbeDataSource ibeSource = null;
+            Map<String, String> queryMap = new HashMap<String, String>(11);
+            if (params instanceof AtlasImageParams) {
+                AtlasImageParams atlasParams = (AtlasImageParams) params;
+                sizeStr= atlasParams.getSize()+"";
+                ibeSource = new AtlasIbeDataSource();
+
+                Map<String, String> m = new HashMap<String, String>(1);
+                m.put(AtlasIbeDataSource.BAND_KEY, atlasParams.getBand());
+                m.put(AtlasIbeDataSource.INSTRUMENT_KEY, atlasParams.getInstrument());
+                if(atlasParams.getDs()!=null){ // using AtlasIbeSource defined datasets
+                    m.put(AtlasIbeDataSource.DS_KEY, atlasParams.getDs());
+                }else{
+                    m.put(AtlasIbeDataSource.SCHEMA_KEY, atlasParams.getSchema());
+                    m.put(AtlasIbeDataSource.TABLE_KEY, atlasParams.getTable());
+                    //Extra filter for querying images for now - see IRSA-
+                    queryMap.put(AtlasIbeDataSource.XTRA_KEY, atlasParams.getXtraFilter());
+                    queryMap.put(AtlasIbeDataSource.BAND_KEY, atlasParams.getBand());
+                    queryMap.put(AtlasIbeDataSource.INSTRUMENT_KEY, atlasParams.getInstrument());
+                }
+                ibeSource.initialize(m);
+
+            } else {
+                Assert.argTst(false, "unknown request type");
+            }
+            IBE ibe = new IBE(ibeSource);
+
+
+            File queryTbl = File.createTempFile("Ibe2Query-", ".tbl", CacheHelper.getDir());
+
+            IbeQueryParam queryParam = ibeSource.makeQueryParam(queryMap);
+            queryParam.setPos(params.getRaJ2000String() + "," + params.getDecJ2000());
+            queryParam.setMcen(true);
+            //queryParam.setIntersect(IbeQueryParam.Intersect.CENTER);
+            ibe.query(queryTbl, queryParam);
+
+            DataGroup data = IpacTableReader.readIpacTable(queryTbl, "results");
+
+
+            if (data.values().size() == 1) {
+                DataObject row = data.get(0);
+                Map<String, String> dataMap = IpacTableUtil.asMap(row);
+                IbeDataParam dataParam = ibeSource.makeDataParam(dataMap);
+
+                dataParam.setCutout(true, params.getRaJ2000String() + "," + params.getDecJ2000String(), sizeStr);
+                dataParam.setDoZip(true);
+                FileInfo result = ibe.getData(dataParam, null);
+                return new File(result.getInternalFilename());
+            } else {
+                throw new FailedRequestException("Area not covered, images #"+data.values().size());
+            }
+
+        } catch (IpacTableException me) {
+            throw new FailedRequestException("Could not parse results", "Details in exception", me);
+        }
+
+    }
+
+
+    public static void main(String args[]) {
+//       WiseImageParams params= new WiseImageParams();
+//       params.setSize(.33F);
+//       params.setBand("1");
+//       params.setBand(WiseImageParams.WISE_3A);
+//       params.setRaJ2000(10.672);
+//       params.setDecJ2000(41.259);
+//       try {
+//           lowlevelGetIbeImage(params, new File("./a.fits.gz"), null);
+//       }
+//       catch (Exception e) {
+//           System.out.println(e);
+//       }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageParams.java
@@ -1,0 +1,79 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.visualize.net;
+
+/**
+ * Should take care of Atlas IBE which metadata is relying on band_name, schema name, file_type and table name
+ * principal is a column that serves to distinguish between main image to display and otheres, among a file_type
+ */
+public class AtlasImageParams extends IrsaImageParams {
+
+    // This example is for SEIP
+    private String file_type = "science"; // i.e for spitzer but bare in mind that can change from schema to another
+    private String _instrument; //TODO NOT USED FOR NOW but
+    private String schema = "spitzer";
+    private String ds = null; //i.e. "seip" if using hard coded definition, see edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource.DS;
+    private String table = "seip_science";
+    private String xtraFilter = ""; // i.e fname like '%.mosaic.fits' or file_tye=science
+
+    public AtlasImageParams() {
+        setType(IrsaTypes.ATLAS);
+    }
+
+    public void setInstrument(String b) {
+        this._instrument = b;
+    }
+
+    public String getInstrument() {
+        return this._instrument;
+    }
+
+    public String getUniqueString() {
+        return super.getUniqueString() + "-" + getSchema() + "-" + getTable() + "-" + getBand() + getSize();
+    }
+
+    public String toString() {
+        return getUniqueString();
+    }
+
+    public void setSchema(String schem) {
+        this.schema = schem;
+    }
+
+    public String getSchema() {
+        return this.schema;
+    }
+
+    public String getTable() {
+        return this.table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    public String getXtraFilter() {
+        return this.xtraFilter;
+    }
+
+    public void setXtraFilter(String xtraFilter) {
+        this.xtraFilter = xtraFilter;
+    }
+
+    public String getDs() {
+        return this.ds;
+    }
+
+    public void setDs(String ds) {
+        this.ds = ds;
+    }
+
+    public String getFileType() {
+        return this.file_type;
+    }
+
+    public void setFileType(String file_type) {
+        this.file_type = file_type;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/IrsaImageParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/IrsaImageParams.java
@@ -7,7 +7,7 @@ import edu.caltech.ipac.util.Assert;
 
 public class IrsaImageParams extends BaseIrsaParams  {
 
-    public enum IrsaTypes { ISSA, TWOMASS, TWOMASS6, IRIS, MSX };
+    public enum IrsaTypes { ISSA, TWOMASS, TWOMASS6, IRIS, MSX, ATLAS };
 
     private String _band= "12";
     private float  _size= 5.0F;
@@ -37,6 +37,9 @@ public class IrsaImageParams extends BaseIrsaParams  {
              case IRIS :
                        retval= "iris-" + super.toString() + _band + _size;
                        break;
+             case ATLAS:
+                 retval = "atlas-"+ super.toString();
+                 break;
              default :
                  Assert.tst(false); break;
          }

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/VisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/VisNetwork.java
@@ -30,6 +30,8 @@ public class VisNetwork {
         File f;
         if (params.getType()== IrsaImageParams.IrsaTypes.TWOMASS) {
             f= getIbeImage(params);
+        }else if(params.getType()== IrsaImageParams.IrsaTypes.ATLAS){
+            f = getIbe2Image(params);
         }
         else {
             f= getTraditionIrsaImage(params);
@@ -54,7 +56,18 @@ public class VisNetwork {
 
         return f;
     }
-
+    private static File getIbe2Image(BaseIrsaParams params) throws FailedRequestException {
+        File f= CacheHelper.getFile(params);
+        if (f == null)  {          // if not in cache
+            try {
+                f= AtlasImageGetter.lowlevelGetIbe2Image(params);
+            } catch (IOException e) {
+                throw ResponseMessage.simplifyNetworkCallException(e);
+            }
+            CacheHelper.getFileCache().put(params,f);
+        }
+        return f;
+    }
 
     private static File getIbeImage(BaseIrsaParams params) throws FailedRequestException {
         File f= CacheHelper.getFile(params);

--- a/src/firefly/js/metaConvert/AtlasRequestList.js
+++ b/src/firefly/js/metaConvert/AtlasRequestList.js
@@ -1,0 +1,62 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+
+import {get} from 'lodash';
+import {makeServerRequestBuilder} from './converterUtils.js';
+import {RangeValues,STRETCH_LINEAR,PERCENTAGE} from '../visualize/RangeValues.js';
+import {getCellValue} from '../tables/TableUtil.js';
+
+const colToUse= [ 'facility_name', 'band_name', 'instrument_name', 'fname', 'wavelength',
+    'file_type', 'ra', 'dec', 'dataproduct_type'];
+const rangeValues= RangeValues.makeRV({which:PERCENTAGE, lowerValue:1, upperValue:99, algorithm:STRETCH_LINEAR});
+
+const bandIdx= {'IRAC1':0, 'IRAC2':1, 'MIPS24':2};
+
+/**
+ * make a list of plot request for atlas. This function works with ConverterFactory.
+ * @param table
+ * @param row
+ * @param includeSingle
+ * @param includeStandard
+ * @param threeColorOps
+ * @return {{}}
+ */
+export function makeAtlasPlotRequest(table, row, includeSingle, includeStandard, threeColorOps) {
+
+    const overlap= get(table, 'request.intersect', '').toUpperCase()==='OVERLAPS';
+    var headerParams= overlap ? ['mission', 'ds'] : ['mission', 'ds', 'band'];
+
+    const builder= makeServerRequestBuilder(table,colToUse,headerParams,rangeValues,1);
+    const band= getCellValue(table,row,'band_name');
+    const inst= getCellValue(table,row,'instrument_name');
+    const telescope= getCellValue(table,row,'facitlity_name');
+    const retval= {};
+    
+    if (includeSingle) {
+        retval.single= builder(`spitzer-${band}`,'ibe_file_retrieve', `${telescope} ${band}`, row, {band});
+    }
+
+    if (includeStandard) {
+
+        retval.standard= [
+            builder('spitzer-irac1','ibe_file_retrieve', 'IRAC 1', row, {band:'IRAC1'}),
+            builder('spitzer-irac2','ibe_file_retrieve', 'IRAC 2', row, {band:'IRAC2'}),
+            builder('spitzer-irac3','ibe_file_retrieve', 'IRAC 3', row, {band:'IRAC3'}),
+            builder('spitzer-irac4','ibe_file_retrieve', 'IRAC 4', row, {band:'IRAC4'}),
+            builder('spitzer-mips24','ibe_file_retrieve', 'MIPS 1', row, {band:'IRAC24'})
+        ];
+        retval.highlightPlotId= 0;
+    }
+
+    if (threeColorOps) {
+        retval.threeColor= threeColorOps
+            .filter( (op) => Boolean(op.color))
+            .map( (op) =>  {
+                const b= bandIdx[op.band];
+                return builder('spitzer-seip-three-IRAC','ibe_file_retrieve', 'SEIP 3 Color', row, {band:b});
+            } );
+    }
+    return retval;
+}

--- a/src/firefly/js/metaConvert/AtlasRequestList.js
+++ b/src/firefly/js/metaConvert/AtlasRequestList.js
@@ -7,9 +7,11 @@ import {get} from 'lodash';
 import {makeServerRequestBuilder} from './converterUtils.js';
 import {RangeValues,STRETCH_LINEAR,PERCENTAGE} from '../visualize/RangeValues.js';
 import {getCellValue} from '../tables/TableUtil.js';
+import {parseWorldPt} from '../visualize/Point.js';
+import {convertAngle} from '../visualize/VisUtil.js';
 
 const colToUse= [ 'facility_name', 'band_name', 'instrument_name', 'fname', 'wavelength',
-    'file_type', 'ra', 'dec', 'dataproduct_type'];
+    'file_type', 'in_ra', 'in_dec', 'dataproduct_type'];
 const rangeValues= RangeValues.makeRV({which:PERCENTAGE, lowerValue:1, upperValue:99, algorithm:STRETCH_LINEAR});
 
 const bandIdx= {'IRAC1':0, 'IRAC2':1, 'MIPS24':2};
@@ -25,13 +27,36 @@ const bandIdx= {'IRAC1':0, 'IRAC2':1, 'MIPS24':2};
  */
 export function makeAtlasPlotRequest(table, row, includeSingle, includeStandard, threeColorOps) {
 
-    const overlap= get(table, 'request.intersect', '').toUpperCase()==='OVERLAPS';
-    var headerParams= overlap ? ['mission', 'ds'] : ['mission', 'ds', 'band'];
+    var headerParams= ['mission', 'ds', 'band','dataset', 'table'];
 
-    const builder= makeServerRequestBuilder(table,colToUse,headerParams,rangeValues,1);
+    const svcBuilder= makeServerRequestBuilder(table,colToUse,headerParams,rangeValues,1);
+    const builder = (plotId, reqKey, title, rowNum, extraParams) => {
+        const req= svcBuilder(plotId, reqKey, title, rowNum, extraParams);
+        const subsize = get(table, 'request.subsize');
+        if (subsize && subsize>0) {
+            const {UserTargetWorldPt, sizeUnit} = get(table, 'request', {});
+            if (UserTargetWorldPt && sizeUnit) {
+                const wp = parseWorldPt(UserTargetWorldPt);
+                // cutout is requested when in_ra, in_dec, and subsize are set (see AtlasIbeDataSource)
+                req.setParam('center', `${wp.getLon()},${wp.getLat()}`); // degrees assumed if no unit
+                req.setParam('in_ra', `${wp.getLon()}`);
+                req.setParam('in_dec', `${wp.getLat()}`);
+                const newSize = convertAngle(sizeUnit, 'deg', subsize);
+                req.setParam('subsize', `${newSize}`);
+            }
+        }
+        return req;
+    };
+
+
     const band= getCellValue(table,row,'band_name');
     const inst= getCellValue(table,row,'instrument_name');
-    const telescope= getCellValue(table,row,'facitlity_name');
+    const telescope= getCellValue(table,row,'facility_name');
+    const fname = getCellValue(table,row,'fname');
+    const subsize = get(table, ['request', 'subsize']);
+    const in_ra = getCellValue(table,row, 'in_ra');
+    const in_dec = getCellValue(table,row, 'in_dec');
+
     const retval= {};
     
     if (includeSingle) {
@@ -41,11 +66,11 @@ export function makeAtlasPlotRequest(table, row, includeSingle, includeStandard,
     if (includeStandard) {
 
         retval.standard= [
-            builder('spitzer-irac1','ibe_file_retrieve', 'IRAC 1', row, {band:'IRAC1'}),
-            builder('spitzer-irac2','ibe_file_retrieve', 'IRAC 2', row, {band:'IRAC2'}),
-            builder('spitzer-irac3','ibe_file_retrieve', 'IRAC 3', row, {band:'IRAC3'}),
-            builder('spitzer-irac4','ibe_file_retrieve', 'IRAC 4', row, {band:'IRAC4'}),
-            builder('spitzer-mips24','ibe_file_retrieve', 'MIPS 1', row, {band:'IRAC24'})
+            builder('spitzer-irac1','ibe_file_retrieve', `${band}`, row, {band:`${band}`, fname, in_ra, in_dec}),
+            // builder('spitzer-irac2','ibe_file_retrieve', 'IRAC 2', row, {band:'IRAC2'}),
+            // builder('spitzer-irac3','ibe_file_retrieve', 'IRAC 3', row, {band:'IRAC3'}),
+            // builder('spitzer-irac4','ibe_file_retrieve', 'IRAC 4', row, {band:'IRAC4'}),
+            // builder('spitzer-mips24','ibe_file_retrieve', 'MIPS 1', row, {band:'MIPS24'})
         ];
         retval.highlightPlotId= 0;
     }

--- a/src/firefly/js/metaConvert/ConverterFactory.js
+++ b/src/firefly/js/metaConvert/ConverterFactory.js
@@ -6,6 +6,7 @@
 import {get, isEmpty} from 'lodash';
 import {makeWisePlotRequest} from './WiseRequestList.js';
 import {make2MassPlotRequest} from './TwoMassRequestList.js';
+import {makeAtlasPlotRequest} from './AtlasRequestList.js';
 import {makeLsstSdssPlotRequest, makeLsstWisePlotRequest} from './LsstSdssRequestList.js';
 import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
 import {ZoomType} from '../visualize/ZoomType.js';
@@ -37,6 +38,12 @@ export const converters = {
             b3 : {color : null, title: 'Band 3'},
             b4 : {color : Band.BLUE, title: 'Band 4'}
         }
+    },
+    'atlas' : {
+        hasRelatedBands : true,
+        canGrid : true,
+        maxPlots : 5,
+        makeRequest : makeAtlasPlotRequest
     },
     'twomass' : {
         threeColor : true,

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -90,6 +90,9 @@ export class TestQueriesPanel extends PureComponent {
                             <Tab name='2Mass Search' id='2massImage'>
                                 <div>{render2MassSearch(fields)}</div>
                             </Tab>
+                            <Tab name='Atlas Search' id='atlasImage'>
+                                <div>{renderAtlasSearch(fields)}</div>
+                            </Tab>
                             {
                             <Tab name='Periodogram' id='periodogram'>
                                 <div>{renderPeriodogram(fields)}</div>
@@ -342,6 +345,43 @@ function renderWiseSearch(fields) {
     );
 }
 
+function renderAtlasSearch(fields) {
+
+// See value of band and instruments here as SEIP example:
+// https://irsadev.ipac.caltech.edu/IBE?table=spitzer.seip_science&POS=56.86909,24.10531
+    return (
+        <div style={{padding:5, display:'flex', flexDirection:'column', flexWrap:'no-wrap', alignItems:'center' }}>
+            <RadioGroupInputField
+                fieldKey='ds'
+                alignment='vertical'
+                initialState={{
+                    tooltip: 'Spacial Type',
+                    value: 'Cone'
+                }}
+                options={[
+                    {label: 'SEIP', value: 'seip'},
+                ]}
+            />
+            <RadioGroupInputField
+                fieldKey='band'
+                alignment='horizontal'
+                initialState={{
+                    tooltip: 'Return Band',
+                    value: 'IRAC1'
+                }}
+                options={[
+                    {label : 'IRAC 2.4', value: 'IRAC1'},
+                    {label : 'IRAC 3.6', value: 'IRAC2'},
+                    {label : 'IRAC 5.8', value: 'IRAC3'},
+                    {label : 'IRAC 8', value: 'IRAC4'},
+                    {label : 'MIPS 24', value: 'MIPS24'},
+                ]}
+            />
+        </div>
+    );
+
+}
+
 
 function render2MassSearch(fields) {
 
@@ -450,6 +490,8 @@ function onSearchSubmit(request) {
     }
     else if (request.Tabs === '2massImage') {
         do2Mass(request);
+    }else if (request.Tabs === 'atlasImage') {
+        doAtlas(request);
     }
     else if (request.Tabs === 'loadRegion') {
         doRegionLoad(request);
@@ -589,6 +631,24 @@ function do2Mass(request) {
             mission: 'twomass',
             ds: request.ds,
             band: request.band
+        });
+    dispatchTableSearch(reqParams);
+}
+
+function doAtlas(request) {
+    console.log('atlas', request);
+    const reqParams = makeTblRequest('ibe_processor', 'ATLAS-' + request[ServerParams.USER_TARGET_WORLD_PT],
+        {
+            [ServerParams.USER_TARGET_WORLD_PT]: request[ServerParams.USER_TARGET_WORLD_PT],
+            mission: 'atlas',
+            ds: request.ds, // map the ENUM string key DS_KEY
+            mcenter:true,
+            /* TODO Atlas source has only seip ds defined, for all the ATLAS dataset, use instead:
+            schema:'spitzer',
+            table:'seip_science'
+            */
+            band: request.bands
+            // instrument: 'IRAC' // NOT USED YET
         });
     dispatchTableSearch(reqParams);
 }

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -351,23 +351,23 @@ function renderAtlasSearch(fields) {
 // https://irsadev.ipac.caltech.edu/IBE?table=spitzer.seip_science&POS=56.86909,24.10531
     return (
         <div style={{padding:5, display:'flex', flexDirection:'column', flexWrap:'no-wrap', alignItems:'center' }}>
-            <RadioGroupInputField
+            <CheckboxGroupInputField
                 fieldKey='ds'
                 alignment='vertical'
                 initialState={{
                     tooltip: 'Spacial Type',
-                    value: 'Cone'
+                    value: 'seip'
                 }}
                 options={[
                     {label: 'SEIP', value: 'seip'},
                 ]}
             />
-            <RadioGroupInputField
+            <CheckboxGroupInputField
                 fieldKey='band'
                 alignment='horizontal'
                 initialState={{
                     tooltip: 'Return Band',
-                    value: 'IRAC1'
+                    value: 'IRAC1,IRAC2,IRAC3,IRAC4,MIPS24'
                 }}
                 options={[
                     {label : 'IRAC 2.4', value: 'IRAC1'},
@@ -642,7 +642,7 @@ function doAtlas(request) {
             [ServerParams.USER_TARGET_WORLD_PT]: request[ServerParams.USER_TARGET_WORLD_PT],
             mission: 'atlas',
             ds: request.ds, // map the ENUM string key DS_KEY
-            mcenter:true,
+            //mcenter:true, returned 1 image
             /* TODO Atlas source has only seip ds defined, for all the ATLAS dataset, use instead:
             schema:'spitzer',
             table:'seip_science'

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -352,14 +352,15 @@ function renderAtlasSearch(fields) {
     return (
         <div style={{padding:5, display:'flex', flexDirection:'column', flexWrap:'no-wrap', alignItems:'center' }}>
             <CheckboxGroupInputField
-                fieldKey='ds'
+                fieldKey='ds1'
                 alignment='vertical'
                 initialState={{
                     tooltip: 'Spacial Type',
-                    value: 'seip'
+                    value: 'spitzer.seip_science'
                 }}
                 options={[
-                    {label: 'SEIP', value: 'seip'},
+                    {label: 'MSX', value: 'msx.msx_images'},
+                    {label: 'SEIP', value: 'spitzer.seip_science'}
                 ]}
             />
             <CheckboxGroupInputField
@@ -367,7 +368,7 @@ function renderAtlasSearch(fields) {
                 alignment='horizontal'
                 initialState={{
                     tooltip: 'Return Band',
-                    value: 'IRAC1,IRAC2,IRAC3,IRAC4,MIPS24'
+                    value: 'IRAC1'
                 }}
                 options={[
                     {label : 'IRAC 2.4', value: 'IRAC1'},
@@ -375,6 +376,10 @@ function renderAtlasSearch(fields) {
                     {label : 'IRAC 5.8', value: 'IRAC3'},
                     {label : 'IRAC 8', value: 'IRAC4'},
                     {label : 'MIPS 24', value: 'MIPS24'},
+                    {label : 'E', value: 'E'},
+                    {label : 'A', value: 'A'},
+                    {label : 'C', value: 'C'},
+                    {label : 'D', value: 'D'},
                 ]}
             />
         </div>
@@ -641,14 +646,14 @@ function doAtlas(request) {
         {
             [ServerParams.USER_TARGET_WORLD_PT]: request[ServerParams.USER_TARGET_WORLD_PT],
             mission: 'atlas',
-            ds: request.ds, // map the ENUM string key DS_KEY
             //mcenter:true, returned 1 image
-            /* TODO Atlas source has only seip ds defined, for all the ATLAS dataset, use instead:
-            schema:'spitzer',
-            table:'seip_science'
-            */
-            band: request.bands
-            // instrument: 'IRAC' // NOT USED YET
+            // TODO Not yet fully working, see AtlasRequestList
+            ds:request.ds1,
+            band: request.band,
+            subsize:0.05,
+            sizeUnit:'deg',
+            mcenter:true
+            // filter:''
         });
     dispatchTableSearch(reqParams);
 }

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -15,7 +15,7 @@ import {parseResolver} from '../astro/net/Resolver.js';
 import {RangeValues} from './RangeValues.js';
 
 
-export const ServiceType= new Enum(['IRIS', 'ISSA', 'DSS', 'SDSS', 'TWOMASS', 'MSX', 'DSS_OR_IRIS', 'WISE', 'NONE'],
+export const ServiceType= new Enum(['IRIS', 'ISSA', 'DSS', 'SDSS', 'TWOMASS', 'MSX', 'DSS_OR_IRIS', 'WISE', 'ATLAS', 'NONE'],
                                               { ignoreCase: true });
 export const TitleOptions= new Enum([
     'NONE',  // use what it in the title
@@ -425,6 +425,28 @@ export class WebPlotRequest extends ServerRequest {
         return req;
     }
 
+    //======================== Atlas =====================================
+    /**
+     *
+     * @param wp
+     * @param survey any atlas combination tables: schema.table, i.e. 'spitzer.seip_science'
+     * @param band any atlas 'band_name' column, i.e 'IRAC2' (which is 2.4 microns channel from IRAC instrument)
+     * @param filter extra filter for particular table, such as 'file_type = 'science' and fname like '%.mosaic.fits' or 'file_type = 'science' and principal=1'
+     * @param sizeInDeg  TODO: wee need to specify a default from the master table
+     * @return {WebPlotRequest}
+     */
+    static makeAtlasRequest(wp, survey, band, filter, sizeInDeg) {
+        const req = this.makePlotServiceReq(ServiceType.ATLAS, wp, survey, sizeInDeg);
+        req.setParam(C.SURVEY_KEY, 'ATLAS' + '.' + survey);
+        req.setParam("schema", survey.split(".")[0]);
+        req.setParam("table", survey.split(".")[1]);
+        req.setParam("filter", filter);
+        req.setParam(C.SURVEY_KEY_BAND, band + '');
+        req.setParam(C.SURVEY_KEY, survey);
+        req.setTitle(survey + "," + band);
+        req.setDrawingSubGroupId(survey); // 'spitzer.seip_science' TODO is it enough for subgroup identification?
+        return req;
+    }
     //======================== DSS or IRIS =====================================
 
     static makeDSSOrIRISRequest(wp, dssSurvey, IssaSurvey, sizeInDeg) {

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -444,7 +444,7 @@ export class WebPlotRequest extends ServerRequest {
         req.setParam(C.SURVEY_KEY_BAND, band + '');
         req.setParam(C.SURVEY_KEY, survey);
         req.setTitle(survey + "," + band);
-        req.setDrawingSubGroupId(survey); // 'spitzer.seip_science' TODO is it enough for subgroup identification?
+        req.setDrawingSubGroupId('seip'); // 'spitzer.seip_science' TODO is it enough for subgroup identification?
         return req;
     }
     //======================== DSS or IRIS =====================================

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -432,19 +432,19 @@ export class WebPlotRequest extends ServerRequest {
      * @param survey any atlas combination tables: schema.table, i.e. 'spitzer.seip_science'
      * @param band any atlas 'band_name' column, i.e 'IRAC2' (which is 2.4 microns channel from IRAC instrument)
      * @param filter extra filter for particular table, such as 'file_type = 'science' and fname like '%.mosaic.fits' or 'file_type = 'science' and principal=1'
-     * @param sizeInDeg  TODO: wee need to specify a default from the master table
+     * @param sizeInDeg
      * @return {WebPlotRequest}
      */
     static makeAtlasRequest(wp, survey, band, filter, sizeInDeg) {
         const req = this.makePlotServiceReq(ServiceType.ATLAS, wp, survey, sizeInDeg);
-        req.setParam(C.SURVEY_KEY, 'ATLAS' + '.' + survey);
-        req.setParam("schema", survey.split(".")[0]);
+        req.setParam(C.SURVEY_KEY, survey.split(".")[0]);
+        req.setParam("dataset", survey.split(".")[0]);
         req.setParam("table", survey.split(".")[1]);
-        req.setParam("filter", filter);
+        req.setParam("filter", filter); //Needed for the query but not for fetching the data (see QueryIBE metadata)
         req.setParam(C.SURVEY_KEY_BAND, band + '');
-        req.setParam(C.SURVEY_KEY, survey);
         req.setTitle(survey + "," + band);
-        req.setDrawingSubGroupId('seip'); // 'spitzer.seip_science' TODO is it enough for subgroup identification?
+        // TODO drawingSubGroupId TO BE SET OUTSIDE here! ATLAS has many dataset and it will depend on the app to group those images, example: See ImageSelectPanelResult.js, Finderrchart...
+        //req.setDrawingSubGroupId(survey.split(".")[1]); // 'spitzer.seip_science'
         return req;
     }
     //======================== DSS or IRIS =====================================

--- a/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
+++ b/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
@@ -44,6 +44,8 @@ export const keyMap = {
     'twomasstypes':'SELECTIMAGEPANEL_2MASS_types',
     'wisetypes': 'SELECTIMAGEPANEL_WISE_types',
     'wisebands': 'SELECTIMAGEPANEL_WISE_bands',
+    'atlastypes': 'SELECTIMAGEPANEL_ATLAS_types',
+    'atlasbands': 'SELECTIMAGEPANEL_ATLAS_bands',
     'msxtypes':    'SELECTIMAGEPANEL_MSX_types',
     'dsstypes':    'SELECTIMAGEPANEL_DSS_types',
     'sdsstypes':   'SELECTIMAGEPANEL_SDSS_types',
@@ -72,6 +74,7 @@ const findCatId = (ary, id) => get(ary.find( (p) => p.id===id), 'CatalogId',-1);
 export function getTabsIndexes() {
     const panelCatalogs= getPanelCatalogs();
     return {
+        ATLAS:findCatId(panelCatalogs,'atlas'),
         IRAS: findCatId(panelCatalogs,'iras'),
         TWOMASS: findCatId(panelCatalogs,'2mass'),
         WISE: findCatId(panelCatalogs,'wise'),

--- a/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
@@ -28,6 +28,35 @@ export const initPanelCatalogs = [
         'range': {'min': 1, 'max': 12.5, 'unit': 'deg'},
         'size': 5
     },
+    /*
+    {
+        'id':'atlas',
+        'Title':'Atlas',
+        'Symbol': 'ATLAS',
+        'CatalogId': 8,
+        'fields': ['types', 'bands'],
+        'types': {
+            'Title': 'Atlas:',
+            'Items': [
+                {'item':'spitzer.seip_science', 'id': 0, 'name': 'Spitzer SEIP'},
+                {'item':'spitzer.fls_irac', 'id': 1, 'name': 'Spitzer FLS'}
+                ],
+            'Default': 'spitzer.seip_science'
+        },
+        'bands': {
+            'Title': 'Choose Band:',
+            'Items': [
+                {'item':`'IRAC1'`, 'id': 0, 'name': 'IRAC 1'},
+                {'item':`'IRAC2'`, 'id': 1, 'name': 'IRAC 2'},
+                {'item':`'IRAC3'`, 'id': 2, 'name': 'IRAC 3'},
+                {'item':`'IRAC4'`, 'id': 3, 'name': 'IRAC 4'},
+                {'item':`'MIPS24'`, 'id': 4, 'name': 'MIPS 1'}],
+            'Default': `'IRAC1'`
+        },
+        'range': {'min':.008, 'max':5, 'unit': 'deg'},
+        'size':.5
+    },
+    */
     {
         'id':'2mass',
         'Title':'2MASS',
@@ -190,6 +219,7 @@ export const initPanelCatalogs = [
 
 
 const defaultOrder= [
+    'atlas',
     'iras',
     '2mass',
     'wise',

--- a/src/firefly/js/visualize/ui/ImageSelectPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelReducer.js
@@ -51,7 +51,7 @@ function getTypeData(keyMapId, key, id,value) {
 
 // tab fields initialization
 function initTabFields(crtCatalogId) {
-    const {IRAS, TWOMASS, WISE, MSX, DSS, SDSS, FITS, URL, NONE}= getTabsIndexes();
+    const {ATLAS, IRAS, TWOMASS, WISE, MSX, DSS, SDSS, FITS, URL, NONE}= getTabsIndexes();
     const panelCatalogs= getPanelCatalogs();
     return (
     {
@@ -62,7 +62,9 @@ function initTabFields(crtCatalogId) {
         [keyMap['irastypes']]: getTypeData('irastypes', 'types', IRAS),
         [keyMap['twomasstypes']]: getTypeData('twomasstypes', 'types', TWOMASS),
         [keyMap['wisetypes']]: getTypeData('wisetypes', 'types', WISE),
+        [keyMap['atlastypes']]: getTypeData('atlastypes', 'types', ATLAS),
         [keyMap['wisebands']]: getTypeData('wisebands', 'bands', WISE),
+        [keyMap['atlasbands']]: getTypeData('atlasbands', 'bands', ATLAS),
         [keyMap['msxtypes']]: getTypeData('msxtypes', 'types', MSX),
         [keyMap['dsstypes']]: getTypeData('dsstypes', 'types', DSS),
         [keyMap['sdsstypes']]: getTypeData('sdsstypes', 'types', SDSS),

--- a/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
@@ -80,7 +80,7 @@ function imagePlotOnBlank(request) {
 // image plot on IRAS, 2MASS, WISE, MSX, DSS, SDSS
 function imagePlotOnSurvey(crtCatalogId, request) {
 
-    const {IRAS, TWOMASS, WISE, MSX, DSS, SDSS}= getTabsIndexes();
+    const {ATLAS, IRAS, TWOMASS, WISE, MSX, DSS, SDSS}= getTabsIndexes();
     var wp = parseWorldPt(request.UserTargetWorldPt);
     var sym = getPanelCatalogs()[crtCatalogId].Symbol.toLowerCase();
 
@@ -89,7 +89,9 @@ function imagePlotOnSurvey(crtCatalogId, request) {
     var survey = get(request, keyMap[t]);
     var band = get(request, keyMap[b]);
     var sizeInDeg = parseFloat(request[keyMap['sizefield']]);
-
+    // TODO This should go soon by using 'principal' and file_type in IbeDataSource server side:
+    var filter = `file_type='science' and fname like '%.mosaic.fits'`; //extra filter?
+    var xtraFilter = getPanelCatalogs()[crtCatalogId].Symbol.toLowerCase();
     var wpr = null;
 
     switch(crtCatalogId) {
@@ -107,7 +109,9 @@ function imagePlotOnSurvey(crtCatalogId, request) {
         case TWOMASS:
             wpr = WebPlotRequest.make2MASSRequest(wp, survey, sizeInDeg);
             break;
-
+        case ATLAS:
+            wpr = WebPlotRequest.makeAtlasRequest(wp, survey, band,filter,sizeInDeg);
+            break;
         case WISE:
             if (band) {
                 wpr = WebPlotRequest.makeWiseRequest(wp, survey, band, sizeInDeg);

--- a/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
@@ -110,7 +110,10 @@ function imagePlotOnSurvey(crtCatalogId, request) {
             wpr = WebPlotRequest.make2MASSRequest(wp, survey, sizeInDeg);
             break;
         case ATLAS:
-            wpr = WebPlotRequest.makeAtlasRequest(wp, survey, band,filter,sizeInDeg);
+            //TODO: Not sure how to combine several dataset with different missions under same ATLAS service type
+            // TODO For now: survey = dataset.table, see edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource
+            wpr = WebPlotRequest.makeAtlasRequest(wp, survey, band,sizeInDeg);
+            wpr.setDrawingSubGroupId(survey.split('.')[1]);
             break;
         case WISE:
             if (band) {

--- a/src/firefly/test/edu/caltech/ipac/astro/ibe/TestAtlasIbe.java
+++ b/src/firefly/test/edu/caltech/ipac/astro/ibe/TestAtlasIbe.java
@@ -1,0 +1,81 @@
+package edu.caltech.ipac.astro.ibe;
+
+import edu.caltech.ipac.astro.IpacTableException;
+import edu.caltech.ipac.astro.IpacTableReader;
+import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.util.DataGroup;
+import edu.caltech.ipac.util.DataObject;
+import edu.caltech.ipac.util.IpacTableUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+public class TestAtlasIbe extends ConfigTest {
+
+    @Test
+    public void testIbe2Call() {
+
+        AtlasIbeDataSource atlas = new AtlasIbeDataSource(AtlasIbeDataSource.DS.SEIP);
+//        AtlasIbeDataSource atlas = new AtlasIbeDataSource(AtlasIbeDataSource.DS.MSX);
+        IBE ibe = new IBE(atlas);
+        try {
+            String basedir = ".";
+            // query the metadata
+            File results = new File(basedir, "meta.tbl");
+            results.deleteOnExit();
+            ibe.getMetaData(results);
+
+            // query via position
+            results = new File(basedir, "ibe.tbl");
+            results.deleteOnExit();
+            IbeQueryParam param = new IbeQueryParam("280,-8", ".45");    // m31
+//                atlas.makeQueryParam()
+            if (atlas.getDataset().startsWith("spitzer")) {
+                param.setWhere("band_name in ( 'IRAC2' ) and file_type='science' and fname like '%.mosaic.fits'"); //specific to SEIP
+            } else {
+                param.setWhere("band_name in (\'E\')"); //specific to SEIP
+            }
+            ibe.query(results, param);
+
+            // retrieve all data types with cutout options
+//            DataGroup datatmp[] = VoTableUtil.voToDataGroups(results.getAbsolutePath());
+
+//            Assert.assertTrue("no data found", datatmp.length > 0);
+
+//            if(datatmp.length>0) {
+            DataGroup data = IpacTableReader.readIpacTable(results, "result.tbl");
+            Assert.assertTrue("no data found", data.size() > 0);
+
+            for (int idx = 0; idx < data.size(); idx++) {
+                DataObject row = data.get(idx);
+                Map<String, String> dinfo = IpacTableUtil.asMap(row);
+                IbeDataParam dparam = ibe.getIbeDataSource().makeDataParam(dinfo);
+                // dparam.setCutout(true, "10.768479,41.26906", ".1");
+                try {
+                    File fileTmp = new File(basedir);
+                    fileTmp.deleteOnExit();
+                    FileInfo fileInfo = ibe.getData(dparam, null, fileTmp, null);
+                    new File(fileInfo.getInternalFilename()).deleteOnExit();
+                    Assert.assertTrue("file is empty", fileInfo.getSizeInBytes() > 0);
+                } catch (IOException ex) {
+                    throw new IOException("Line " + idx + ": Unable to retrieve " + dinfo.get("file_type") + " data.", ex);
+                }
+            }
+//            }
+
+        } catch (IOException e) {
+            LOG.error("problem ", e.getMessage());
+            e.printStackTrace();
+        } catch (IpacTableException e) {
+            LOG.error("problem ", e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}
+
+


### PR DESCRIPTION
This FF (branch) implementation is the one used by Finderchart to search and display SEIP. Those are the first steps o add more ATLAS dataset.

The code has a new Atlas ibe datasource and example in Test searches (localhost:8080/firefly/firefly-dev.html).

I've also added a test, under test/astro/ibe.

Checkout the branch and check that i didn't break any image fits viewer related features.

Caveats: The code still miss the 3-color implementation. And the part related to fits download dialog.

In order to test Finderchat, checkout the corresponding branch in IFE and build it. You should see SEIP checkbox added as dataset to be searched. (the code has also MSX but is not enabled, AKARI is coming soon but will do it in another ticket. it will follow the same logic as SEIP and ATLAS/IBE API, requiring to set 'dataset', 'table' and 'filter').

If you have any question, please let me know.

Thanks for testing and reviewing this.
