### PR TITLE
IRSA-641 Extend the saving/uploading feature to include the choice of…

### DIFF
--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -60,7 +60,8 @@ const defaults = {
         {label:'Images', action:'ImageSelectDropDownCmd'},
         {label:'Charts', action:'ChartSelectDropDownCmd'},
         {label:'Help', action:HELP_LOAD, type:'COMMAND'},
-        {label:'Example Js Dialog', action:'exampleDialog', type:'COMMAND'}
+        {label:'Example Js Dialog', action:'exampleDialog', type:'COMMAND'},
+        {label:'File Upload Dialog', action:'fileuploadDialog', type:'COMMAND'}
     ]
 };
 

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -61,6 +61,9 @@ import RegionPlot from '../drawingLayers/RegionPlot.js';
 import MarkerTool from '../drawingLayers/MarkerTool.js';
 import FootprintTool from '../drawingLayers/FootprintTool.js';
 import {showExampleDialog} from '../ui/ExampleDialog.jsx';
+import {showFileUploadDialog} from '../ui/FileUploadDialog.jsx';
+import {DownloadOptionPanel} from '../ui/DownloadDialog.jsx';
+
 
 //==============
 // import Perf from 'react-addons-perf';
@@ -157,6 +160,16 @@ actionCreators.set(ChartsCntlr.CHART_OPTIONS_UPDATE, ChartsCntlr.makeChartOption
 
 actionCreators.set('exampleDialog', (rawAction) => {
     showExampleDialog();
+    return rawAction;
+});
+
+actionCreators.set('fileuploadDialog', (rawAction) => {
+    showFileUploadDialog();
+    return rawAction;
+});
+
+actionCreators.set('downloadDialog', (rawAction) => {
+    DownloadOptionPanel();
     return rawAction;
 });
 

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -22,6 +22,7 @@ import {dispatchAddSaga} from '../../core/MasterSaga.js';
 import {FormPanel} from './../../ui/FormPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {FileUpload} from '../../ui/FileUpload.jsx';
+import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
@@ -210,6 +211,24 @@ export function UploadPanel(props) {
     const options = missionOptions.map((id) => {
         return {label: getMissionName(id) || capitalize(id), value: id};
     });
+    var showUploadLocation = () => {
+        var options = [
+            {'id': 0, label: 'Local File', 'value': 'isLocal'},
+            {'id': 1, label: 'Workspace', 'value': 'isWs'}
+        ];
+        return (
+            <div>
+                <RadioGroupInputField
+                    initialState={{value: options[0].value,
+                                      fieldKey: 'uploadContainer' }}
+                    alignment={'horizontal'}
+                    options={options}
+                />
+            </div>
+        );
+
+    };
+
 
     return (
         <div style={{padding: 10}}>
@@ -222,7 +241,16 @@ export function UploadPanel(props) {
                 help_id={'loadingTSV'}>
                 <FieldGroup groupKey={vFileKey} validatorFunc={null} keepState={true}>
                     <div
-                        style={{padding:5 }}>
+                        style={{padding:5}}>
+                        <div
+                            style={{padding:5,display:'flex', flexDirection:'row', alignItems:'center' }}>
+                            <div
+                                style={{display:'flex', flexDirection:'column', alignItems: 'flex-end', margin:'0px 10px'}}>
+                                <div>{'Choose Upload from: '}</div>
+                            </div>
+
+                            {showUploadLocation()}
+                        </div>
                         <div
                             style={{padding:5, display:'flex', flexDirection:'row', alignItems:'center' }}>
                             <div
@@ -230,14 +258,16 @@ export function UploadPanel(props) {
                                 <div> {'Upload time series table:'} </div>
                                 <HelpText helpId={'loadingTSV'} linkText={'(See requirements)'} />
                                 </div>
-                            <FileUpload
-                                wrapperStyle={wrapperStyle}
-                                fieldKey='rawTblSource'
-                                initialState={{
-                            tooltip: 'Select a Time Series Table file to upload',
-                            label: ''
-                        }}
-                            />
+                            <div>
+                                <FileUpload
+                                    wrapperStyle={wrapperStyle}
+                                    fieldKey='rawTblSource'
+                                    initialState={{
+                                tooltip: 'Select a Time Series Table file to upload',
+                                label: ''
+                                }}
+                                />
+                            </div>
                         </div>
                         <div
                             style={{padding:5,display:'flex', flexDirection:'row', alignItems:'center' }}>

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -13,9 +13,9 @@ const UL_URL = `${getRootURL()}sticky/CmdSrv?${ServerParams.COMMAND}=${ServerPar
 
 
 function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  message, onChange, value, labelWidth,
-                         innerStyle, isFromURL, onUrlAnalysis, fileNameStyle}) {
-    var style = !isFromURL ? Object.assign({color: 'transparent', border: 'none', background: 'none'}, innerStyle) : (innerStyle || {});
-    var fileName = (!isFromURL && value) ?  value.split(/(\\|\/)/g).pop() : 'No file chosen';
+                         innerStyle, isFromURL, isFromWsURL, isFromFile, uploadSrc, onUrlAnalysis, fileNameStyle}) {
+    var style = (!isFromURL && !isFromWsURL) ? Object.assign({color: 'transparent', border: 'none', background: 'none'}, innerStyle) : (innerStyle || {});
+    var fileName = ((!isFromURL && !isFromWsURL) && value) ?  value.split(/(\\|\/)/g).pop() : 'No file chosen';
 
     const inputEntry = () => {
         const labelW = isNil(labelWidth) ? 0 : labelWidth;
@@ -26,7 +26,7 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                 visible={true}
                 message={message}
                 onChange={onChange}
-                type={isFromURL ? 'text' : 'file'}
+                type={(isFromURL || isFromWsURL) ? 'text' : 'file'}
                 label={label}
                 value={value}
                 tooltip={value}
@@ -46,7 +46,18 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                             onClick={() =>  onUrlAnalysis(value)}>{'Upload'}</button>
                 </div>
             );
-        } else {
+        } else if (isFromWsURL) {
+            return (
+                <div>
+                    <div style={{display:'inline-block', whiteSpace:'nowrap'}}>
+                        <button type='button' className='button std hl' disabled
+                                onClick={() =>  onUrlAnalysis(value)}>{'Upload from WS'}</button>
+                    </div>
+                    <div style={{padding:20, fontSize:'150%'}}>The WS file pick panel should be here.</div>
+                </div>
+
+            );
+        } else if (isFromFile) {
             let fPos = {marginLeft: -150};
 
             if (!isNil(fileNameStyle)) fPos = Object.assign(fPos, fileNameStyle);
@@ -77,7 +88,9 @@ FileUploadView.propTypes = {
     labelWidth: PropTypes.number,
     valid: PropTypes.bool,
     wrapperStyle: PropTypes.object,
-    isFromURL: PropTypes.bool.isRequired,
+    isFromURL: PropTypes.bool,
+    isFromWsURL: PropTypes.bool,
+    isFromFile: PropTypes.bool,
     onUrlAnalysis: PropTypes.func,
     fileNameStyle: PropTypes.object
 };
@@ -85,7 +98,9 @@ FileUploadView.propTypes = {
 FileUploadView.defaultProps = {
     fileType: 'TABLE',
     isLoading: false,
+    isFromFile: true,
     isFromURL: false,
+    isFromWsURL: false,
     labelWidth: 0
 };
 
@@ -114,7 +129,16 @@ function getProps(params, fireValueChange) {
                                                                                 params.fileAnalysis)
             }
         );
-    } else {
+    } else if (has(params, 'isFromWsURL') && params.isFromWsURL) {
+        return Object.assign({}, params,
+            {
+                onChange: (ev) => onUrlChange(ev, params, fireValueChange),
+                value: params.displayValue,
+                onUrlAnalysis: (value) => doUrlAnalysis(value, fireValueChange, params.fileType,
+                    params.fileAnalysis)
+            }
+        );
+    } else if (has(params, 'isFromFile') && params.isFromFile) {
         return Object.assign({}, params,
             {
                 value: params.displayValue,
@@ -171,6 +195,8 @@ export function doUpload(file, params={}) {
     if (!file) return Promise.reject('Required file parameter not given');
 
     if (has(params, 'isFromURL') && params.isFromURL) {
+        params = Object.assign(params, {URL: file});
+    } else if (has(params, 'isFromWsURL') && params.isFromWsURL) {
         params = Object.assign(params, {URL: file});
     } else {
         params = Object.assign(params, {file});   // file should be the last param due to AnyFileUpload limitation

--- a/src/firefly/js/ui/FileUploadDialog.jsx
+++ b/src/firefly/js/ui/FileUploadDialog.jsx
@@ -1,0 +1,53 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {TargetPanel} from './TargetPanel.jsx';
+import {InputGroup} from './InputGroup.jsx';
+import Validate from '../util/Validate.js';
+import {ValidationField} from './ValidationField.jsx';
+import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
+import {RadioGroupInputField} from './RadioGroupInputField.jsx';
+import {ListBoxInputField} from './ListBoxInputField.jsx';
+import {SuggestBoxInputField} from './SuggestBoxInputField.jsx';
+import {Histogram} from '../charts/ui/Histogram.jsx';
+import CompleteButton from './CompleteButton.jsx';
+import {FieldGroup} from './FieldGroup.jsx';
+import {dispatchMultiValueChange, dispatchRestoreDefaults} from '../fieldGroup/FieldGroupCntlr.js';
+import DialogRootContainer from './DialogRootContainer.jsx';
+import {PopupPanel} from './PopupPanel.jsx';
+import FieldGroupUtils, {revalidateFields} from '../fieldGroup/FieldGroupUtils';
+import {FileUpload} from './FileUpload.jsx';
+import {FileUploadViewPanel} from '../visualize/ui/FileUploadViewPanel.jsx';
+import {FileUploadDropdown} from '../ui/FileUploadDropdown.jsx';
+
+import {CollapsiblePanel} from './panel/CollapsiblePanel.jsx';
+import {Tabs, Tab,FieldGroupTabs} from './panel/TabPanel.jsx';
+import {dispatchShowDialog} from '../core/ComponentCntlr.js';
+
+
+
+function getDialogBuilder() {
+    var popup= null;
+    return () => {
+        if (!popup) {
+            const popup= (
+                <PopupPanel title={'File Upload Dialog'} >
+                    <FileUploadDropdown  groupKey={'FILEUPLOAD_FORM'} />
+                </PopupPanel>
+            );
+            DialogRootContainer.defineDialog('FileUploadDialog', popup);
+        }
+        return popup;
+    };
+}
+
+const dialogBuilder= getDialogBuilder();
+
+export function showFileUploadDialog() {
+    dialogBuilder();
+    dispatchShowDialog('FileUploadDialog');
+}
+

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -28,7 +28,7 @@ import {FileUpload} from '../../ui/FileUpload.jsx';
 import {convertAngle} from '../VisUtil.js';
 import {masterTableFilter} from './IrsaMasterTableFilters.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
-
+import {FileUploadViewPanel} from './FileUploadViewPanel.jsx';
 
 import './CatalogTableListField.css';
 import './CatalogSelectViewPanel.css';
@@ -418,21 +418,9 @@ class CatalogSelectView extends PureComponent {
                         <CatalogDDList {...this.props} {...this.state} />
                     </Tab>
                     <Tab name='Load Catalog' id='loadcat'>
-                        <div
-                            style={{padding:5, width:'800px', height:'300px'}}>
-                            <FileUpload
-                                wrapperStyle={{margin: '5px 0'}}
-                                fieldKey='fileUpload'
-                                initialState={{
-                                            tooltip: 'Select an IPAC catalog table file to upload',
-                                            label: 'File:'}}
-                            />
-                            <div>
-                                <em style={{color:'gray'}}>Custom catalog in IPAC table format</em>
-                                <HelpIcon
-                                    helpId={'basics.loadcatalog'}/>
-                            </div>
-                        </div>
+
+                        <FileUploadViewPanel fieldKey='loadcatpanel' />
+
                     </Tab>
                     <Tab name='VO Catalog' id='vosearch'>
 

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -26,6 +26,7 @@ import './ImageSelectPanel.css';
 
 export const panelKey = 'FileUploadAnalysis';
 const  fileId = 'fileUpload';
+const  wsurlId = 'wsurlUpload';
 const  urlId = 'urlUpload';
 
 const SUMMARY_INDEX_COL = 0;
@@ -435,6 +436,7 @@ export class FileUploadViewPanel extends PureComponent {
 
         const uploadStyle = {marginTop: 12, marginBottom: 20};
         const uploadMethod = [{value: fileId, label: 'Upload file'},
+                              {value: wsurlId, label: 'Upload from WorkSpace'},
                               {value: urlId, label: 'Upload from URL'}];
         const {uploadSrc} = this.state;
         const lineH = 16;
@@ -447,22 +449,38 @@ export class FileUploadViewPanel extends PureComponent {
                             fileNameStyle={{marginLeft: 0, fontSize: 12}}
                             fieldKey={fileId}
                             fileAnalysis={this.onLoading}
+                            isFromFile={true}
+                            uploadSrc={uploadSrc}
                             innerStyle={{width: 80}}
                             initialState={{tooltip: 'Select a file with FITS, VOTABLE, CSV, TSV, or IPAC format',
                                            label: ''
                                            }}/>
                 );
-            } else if (uploadSrc === urlId) {
+            } else if (uploadSrc === wsurlId) {
                 return (
                         <FileUpload
                             wrapperStyle={{...uploadStyle, marginRight: 32, width: '50%'}}
-                            fieldKey={urlId}
+                            fieldKey={wsurlId}
                             fileAnalysis={this.onLoading}
-                            isFromURL={true}
-                            innerStyle={{width: '70%'}}
-                            initialState={{tooltip: 'Select a URL with file in FITS, VOTABLE, CSV, TSV, or IPAC format',
-                                           label: 'Enter URL of a file:'
+                            isFromWsURL={true}
+                            uploadSrc={uploadSrc}
+                            innerStyle={{width: '60%'}}
+                            initialState={{tooltip: 'Select a file from WorkSpace',
+                                           label: 'file URL from Workspace:', value: 'https://sample/urlupload'
                                          }}/>
+                );
+            } else if (uploadSrc === urlId) {
+                return (
+                    <FileUpload
+                        wrapperStyle={{...uploadStyle, marginRight: 32, width: '50%'}}
+                        fieldKey={urlId}
+                        fileAnalysis={this.onLoading}
+                        isFromURL={true}
+                        uploadSrc={uploadSrc}
+                        innerStyle={{width: '70%'}}
+                        initialState={{tooltip: 'Select a URL with file in FITS, VOTABLE, CSV, TSV, or IPAC format',
+                                                       label: 'Enter URL of a file:'
+                                                     }}/>
                 );
             }
         };
@@ -485,8 +503,8 @@ export class FileUploadViewPanel extends PureComponent {
             <FieldGroup groupKey={panelKey}
                         reducerFunc={fieldReducer()}
                         keepState={true}>
-                <div style={{width:988, height:'calc(100% - 20px)'}}>
-                    <div style={{display:'flex',  flexDirection: 'column', marginTop: 10, paddingLeft: '30%'}}>
+                <div style={{width:800, height:'calc(100% - 20px)'}}>
+                    <div style={{display:'flex',  flexDirection: 'column', marginTop: 10, paddingLeft: 20,paddingBottom: 20}}>
                         <RadioGroupInputField
                             initialState={{value: uploadMethod[0].value}}
                             fieldKey='uploadTabs'
@@ -872,6 +890,10 @@ function fieldInit() {
             },
             [fileId]: {
                 fieldKey: fileId,
+                value: ''
+            },
+            [wsurlId]: {
+                fieldKey: wsurlId,
                 value: ''
             },
             [urlId]: {

--- a/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
+++ b/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
@@ -29,7 +29,7 @@ import {getActivePlotView, primePlot} from '../PlotViewUtil.js';
 import {FieldGroupCollapsible, CollapseBorder, CollapseHeaderCorner} from '../../ui/panel/CollapsiblePanel.jsx';
 import {ImageSelPanelChangeOneColor, ImageSelPanelChange} from './ImageSelectPanelReducer.js';
 import {CheckboxGroupInputField} from '../../ui/CheckboxGroupInputField.jsx';
-
+import {FileUploadViewPanel} from '../ui/FileUploadViewPanel.jsx';
 import './ImageSelectPanel.css';
 
 const popupId = 'ImageSelectPopup';
@@ -54,6 +54,7 @@ export const keyMap = {
     'fitslist':    'SELECTIMAGEPANEL_FITS_list',
     'fitsextinput':'SELECTIMAGEPANEL_FITS_extinput',
     'fitsupload':  'SELECTIMAGEPANEL_FITS_upload',
+    'fitslocation': 'SELECTIMAGEPANEL_FITS_filelocation',
     'sizefield': 'SELECTIMAGEPANEL_ImgFeature_radius',
     'plotmode':    'SELECTIMAGEPANEL_targetplot',
     'createNewCell':    'createNewCell'
@@ -699,7 +700,7 @@ function CatalogTabView({catalog, fields}) {
         if (fieldname.includes('types') || fieldname.includes('bands') ||
             fieldname.includes('list')) {
             return listfield(fieldname, index);
-        }  else if (fieldname.includes('input')) {
+        } else if (fieldname.includes('input')) {
             var dkey = 'dependon';
 
             if (catalog[fieldname].hasOwnProperty(dkey)) {
@@ -715,27 +716,61 @@ function CatalogTabView({catalog, fields}) {
             }
 
             return inputfield(fieldname, index);
-        } else if ( fieldname.includes('upload')) {
-            return (
-                <div key={index} >
-                    <FileUpload
-                        wrapperStyle={{margin: '15px 10px 21px 10px'}}
-                        fieldKey={keyMap['fitsupload']}
-                        initialState= {{
-                        tooltip: 'Select a file to upload' }}
-                    />
-                </div>
-            );
-        } else {
-            return undefined;
-        }
-    };
+        } else if (fieldname.includes('upload')) {
 
-    return (
-        <div className={'tabview'}>
-            {(catalog.fields).map((oneField, index) =>  fieldrequest(oneField, index))}
-        </div>
-    );
+            var showUploadLocation = () => {
+                var options = [
+                    {'id': 0, label: 'Local File', 'value': 'isLocal'},
+                    {'id': 1, label: 'Workspace', 'value': 'isWs'}
+                ];
+
+
+                return (
+                    <div>
+                        <RadioGroupInputField
+                            initialState={{value: options[0].value,
+                                              fieldKey: keyMap['filelocation'] }}
+                            alignment={'horizontal'}
+                            fieldKey={keyMap['filelocation']}
+                            options={options}
+                        />
+                    </div>
+                );
+
+            };
+
+
+                return (
+                    <div key={index} style={{padding:5}}>
+                        <div
+                            style={{padding:5,display:'flex', flexDirection:'row', alignItems:'center' }}>
+                            <div
+                                style={{display:'flex', flexDirection:'column', alignItems: 'flex-end', margin:'0px 10px'}}>
+                                <div>{'Choose Upload from: '}</div>
+                            </div>
+
+                            {showUploadLocation()}
+                        </div>
+
+                        <FileUpload 
+                            wrapperStyle={{margin: '15px 10px 21px 10px'}} 
+                            fieldKey={keyMap['fitsupload']} 
+                            initialState={{     tooltip: 'Select a file to upload' }}     /> 
+
+                   </div>
+                );
+
+            } else {
+                    return undefined;
+            }
+        };
+
+        return (
+            <div className={'tabview'}>
+                {(catalog.fields).map((oneField, index) => fieldrequest(oneField, index))}
+            </div>
+        );
+
 }
 
 CatalogTabView.propTypes={

--- a/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
@@ -138,12 +138,23 @@ export const initPanelCatalogs = [
         'Title': 'FITS File',
         'Symbol': 'FITS',
         'CatalogId': 6,
-        'fields': ['upload', 'list', 'extinput'],
+        'fields': ['upload', 'list', 'extinput','filelocation'],
+        'types': {
+                 'Title': 'Upload File Container:',
+                 'Items': [
+                     {'item': 'isLocal', 'id': 0, 'name': 'Upload Local File'},
+                     {'item': 'isWs', 'id': 1, 'name': 'Upload from Workspace'}
+                ],
+                 'Default':'isLocal'
+        },
         'button': {
             'Title': 'Enter URL of a FITS File:',
             'nullallowed': false
         },
         'upload': {
+            'Title': ''
+        },
+        'filelocation': {
             'Title': ''
         },
         'list': {

--- a/src/firefly/js/visualize/ui/ImageSelectPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelReducer.js
@@ -67,6 +67,7 @@ function initTabFields(crtCatalogId) {
         [keyMap['dsstypes']]: getTypeData('dsstypes', 'types', DSS),
         [keyMap['sdsstypes']]: getTypeData('sdsstypes', 'types', SDSS),
         [keyMap['fitslist']]: getTypeData('fitslist', 'list', FITS),
+        [keyMap['fitslocation']]: getTypeData('fitslocation', 'filelocation', FITS, 'isLocal'),
         [keyMap['fitsextinput']]: getTypeData('fitsextinput', 'extinput', FITS, '0'),
         /*
         [keyMap['blankinput']]: {


### PR DESCRIPTION
… the container.

Note for the image select upload and time series viewer upload panel, the upload workspace needs to be connected to the file picker. There is no selection logic applied for now. 
To view the extended save/upload panel:
1. from image toolbar, click save icon
2. in firefly/image search panel
3. in firefly/catalog search load catalog panel
4. in firefly/Upload panel
5. time series viewer 
6. added a File Upload dialog in firefly-dev.html page, for testing development of file pick only  