### PR TITLE
IRSA-641 Extend the saving/uploading feature to include the choice of…

### DIFF
--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -59,8 +59,9 @@ const defaults = {
         {label:'Image Concept', action:'NewImageSearchPanel'},
         {label:'Images', action:'ImageSelectDropDownCmd'},
         {label:'Charts', action:'ChartSelectDropDownCmd'},
-        {label:'Help', action:HELP_LOAD, type:'COMMAND'},
-        {label:'Example Js Dialog', action:'exampleDialog', type:'COMMAND'}
+        {label:'Example Js Dialog', action:'exampleDialog', type:'COMMAND'},
+        {label:'File Upload', action:'fileuploadDialog', type:'COMMAND'},
+        {label:'Help', action:HELP_LOAD, type:'COMMAND'}
     ]
 };
 

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -61,6 +61,9 @@ import RegionPlot from '../drawingLayers/RegionPlot.js';
 import MarkerTool from '../drawingLayers/MarkerTool.js';
 import FootprintTool from '../drawingLayers/FootprintTool.js';
 import {showExampleDialog} from '../ui/ExampleDialog.jsx';
+import {showFileUploadDialog} from '../ui/FileUploadDialog.jsx';
+import {DownloadOptionPanel} from '../ui/DownloadDialog.jsx';
+
 
 //==============
 // import Perf from 'react-addons-perf';
@@ -157,6 +160,16 @@ actionCreators.set(ChartsCntlr.CHART_OPTIONS_UPDATE, ChartsCntlr.makeChartOption
 
 actionCreators.set('exampleDialog', (rawAction) => {
     showExampleDialog();
+    return rawAction;
+});
+
+actionCreators.set('fileuploadDialog', (rawAction) => {
+    showFileUploadDialog();
+    return rawAction;
+});
+
+actionCreators.set('downloadDialog', (rawAction) => {
+    DownloadOptionPanel();
     return rawAction;
 });
 

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -22,6 +22,7 @@ import {dispatchAddSaga} from '../../core/MasterSaga.js';
 import {FormPanel} from './../../ui/FormPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {FileUpload} from '../../ui/FileUpload.jsx';
+import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {syncChartViewer} from '../../visualize/saga/ChartsSync.js';
@@ -210,6 +211,24 @@ export function UploadPanel(props) {
     const options = missionOptions.map((id) => {
         return {label: getMissionName(id) || capitalize(id), value: id};
     });
+    var showUploadLocation = () => {
+        var options = [
+            {'id': 0, label: 'Local File', 'value': 'isLocal'},
+            {'id': 1, label: 'Workspace', 'value': 'isWs'}
+        ];
+        return (
+            <div>
+                <RadioGroupInputField
+                    initialState={{value: options[0].value,
+                                      fieldKey: 'uploadContainer' }}
+                    alignment={'horizontal'}
+                    options={options}
+                />
+            </div>
+        );
+
+    };
+
 
     return (
         <div style={{padding: 10}}>
@@ -222,7 +241,16 @@ export function UploadPanel(props) {
                 help_id={'loadingTSV'}>
                 <FieldGroup groupKey={vFileKey} validatorFunc={null} keepState={true}>
                     <div
-                        style={{padding:5 }}>
+                        style={{padding:5}}>
+                        <div
+                            style={{padding:5,display:'flex', flexDirection:'row', alignItems:'center' }}>
+                            <div
+                                style={{display:'flex', flexDirection:'column', alignItems: 'flex-end', margin:'0px 10px'}}>
+                                <div>{'Choose Upload from: '}</div>
+                            </div>
+
+                            {showUploadLocation()}
+                        </div>
                         <div
                             style={{padding:5, display:'flex', flexDirection:'row', alignItems:'center' }}>
                             <div
@@ -230,14 +258,16 @@ export function UploadPanel(props) {
                                 <div> {'Upload time series table:'} </div>
                                 <HelpText helpId={'loadingTSV'} linkText={'(See requirements)'} />
                                 </div>
-                            <FileUpload
-                                wrapperStyle={wrapperStyle}
-                                fieldKey='rawTblSource'
-                                initialState={{
-                            tooltip: 'Select a Time Series Table file to upload',
-                            label: ''
-                        }}
-                            />
+                            <div>
+                                <FileUpload
+                                    wrapperStyle={wrapperStyle}
+                                    fieldKey='rawTblSource'
+                                    initialState={{
+                                tooltip: 'Select a Time Series Table file to upload',
+                                label: ''
+                                }}
+                                />
+                            </div>
                         </div>
                         <div
                             style={{padding:5,display:'flex', flexDirection:'row', alignItems:'center' }}>

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -13,7 +13,7 @@ const UL_URL = `${getRootURL()}sticky/CmdSrv?${ServerParams.COMMAND}=${ServerPar
 
 
 function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  message, onChange, value, labelWidth,
-                         innerStyle, isFromURL, isFromWsURL, isFromFile, uploadSrc, onUrlAnalysis, fileNameStyle}) {
+                         innerStyle, isFromURL, isFromWsURL, uploadSrc, onUrlAnalysis, fileNameStyle}) {
     var style = (!isFromURL && !isFromWsURL) ? Object.assign({color: 'transparent', border: 'none', background: 'none'}, innerStyle) : (innerStyle || {});
     var fileName = ((!isFromURL && !isFromWsURL) && value) ?  value.split(/(\\|\/)/g).pop() : 'No file chosen';
 
@@ -57,7 +57,7 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                 </div>
 
             );
-        } else if (isFromFile) {
+        } else {
             let fPos = {marginLeft: -150};
 
             if (!isNil(fileNameStyle)) fPos = Object.assign(fPos, fileNameStyle);
@@ -88,9 +88,8 @@ FileUploadView.propTypes = {
     labelWidth: PropTypes.number,
     valid: PropTypes.bool,
     wrapperStyle: PropTypes.object,
-    isFromURL: PropTypes.bool,
-    isFromWsURL: PropTypes.bool,
-    isFromFile: PropTypes.bool,
+    isFromURL: PropTypes.bool.isRequired,
+    isFromWsURL: PropTypes.bool.isRequired,
     onUrlAnalysis: PropTypes.func,
     fileNameStyle: PropTypes.object
 };
@@ -98,7 +97,6 @@ FileUploadView.propTypes = {
 FileUploadView.defaultProps = {
     fileType: 'TABLE',
     isLoading: false,
-    isFromFile: true,
     isFromURL: false,
     isFromWsURL: false,
     labelWidth: 0
@@ -138,7 +136,7 @@ function getProps(params, fireValueChange) {
                     params.fileAnalysis)
             }
         );
-    } else if (has(params, 'isFromFile') && params.isFromFile) {
+    } else {
         return Object.assign({}, params,
             {
                 value: params.displayValue,
@@ -165,7 +163,7 @@ function handleChange(ev, fireValueChange, type, fileAnalysis) {
 
 function makeDoUpload(file, type, isFromURL, isFromWsURL, fileAnalysis) {
     return () => {
-        return doUpload(file, {type, isFromURL, fileAnalysis}).then(({status, message, cacheKey, fileFormat, analysisResult}) => {
+        return doUpload(file, {type, isFromURL, isFromWsURL, fileAnalysis}).then(({status, message, cacheKey, fileFormat, analysisResult}) => {
             let valid = status === '200';
             if (valid) {        // json file is not supported currently
                 if (!isNil(fileFormat)) {

--- a/src/firefly/js/ui/FileUploadDialog.jsx
+++ b/src/firefly/js/ui/FileUploadDialog.jsx
@@ -1,0 +1,34 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {PureComponent} from 'react';
+import DialogRootContainer from './DialogRootContainer.jsx';
+import {PopupPanel} from './PopupPanel.jsx';
+import {FileUploadSelectPanel} from '../visualize/ui/FileUploadSelectPanel.jsx';
+import {dispatchShowDialog} from '../core/ComponentCntlr.js';
+
+
+
+function getDialogBuilder() {
+    var popup= null;
+    return () => {
+        if (!popup) {
+            const popup= (
+                <PopupPanel title={'File Upload Dialog'} >
+                    <FileUploadSelectPanel  groupKey={'FileUploadSelect'} />
+                </PopupPanel>
+            );
+            DialogRootContainer.defineDialog('FileUploadDialog', popup);
+        }
+        return popup;
+    };
+}
+
+const dialogBuilder= getDialogBuilder();
+
+export function showFileUploadDialog() {
+    dialogBuilder();
+    dispatchShowDialog('FileUploadDialog');
+}
+

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -8,13 +8,14 @@ import {FormPanel} from '../../ui/FormPanel.jsx';
 import { get, merge, isEmpty, isFunction, set} from 'lodash';
 import {updateMerge} from '../../util/WebUtil.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
-import {doFetchTable, makeTblRequest, makeIrsaCatalogRequest, makeVOCatalogRequest, DataTagMeta} from '../../tables/TableUtil.js';
+import {doFetchTable, makeTblRequest, makeFileRequest,makeIrsaCatalogRequest, makeVOCatalogRequest, DataTagMeta} from '../../tables/TableUtil.js';
 import {CatalogTableListField} from './CatalogTableListField.jsx';
 import {CatalogConstraintsPanel} from './CatalogConstraintsPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import FieldGroupCntlr from '../../fieldGroup/FieldGroupCntlr.js';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 import {FieldGroupTabs, Tab} from '../../ui/panel/TabPanel.jsx';
+import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
 import {dispatchHideDropDown} from '../../core/LayoutCntlr.js';
 import {ServerParams} from '../../data/ServerParams.js';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
@@ -782,6 +783,10 @@ function fieldInit() {
         },
         'vourl': {
             fieldKey: 'vourl',
+            value: ''
+        },
+        'catupload':{
+            fieldKey: 'fileUpload',
             value: ''
         }
 

--- a/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
+++ b/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
@@ -29,7 +29,7 @@ import {getActivePlotView, primePlot} from '../PlotViewUtil.js';
 import {FieldGroupCollapsible, CollapseBorder, CollapseHeaderCorner} from '../../ui/panel/CollapsiblePanel.jsx';
 import {ImageSelPanelChangeOneColor, ImageSelPanelChange} from './ImageSelectPanelReducer.js';
 import {CheckboxGroupInputField} from '../../ui/CheckboxGroupInputField.jsx';
-
+import {FileUploadViewPanel} from '../ui/FileUploadViewPanel.jsx';
 import './ImageSelectPanel.css';
 
 const popupId = 'ImageSelectPopup';
@@ -56,6 +56,7 @@ export const keyMap = {
     'fitslist':    'SELECTIMAGEPANEL_FITS_list',
     'fitsextinput':'SELECTIMAGEPANEL_FITS_extinput',
     'fitsupload':  'SELECTIMAGEPANEL_FITS_upload',
+    'fitslocation': 'SELECTIMAGEPANEL_FITS_filelocation',
     'sizefield': 'SELECTIMAGEPANEL_ImgFeature_radius',
     'plotmode':    'SELECTIMAGEPANEL_targetplot',
     'createNewCell':    'createNewCell'
@@ -702,7 +703,7 @@ function CatalogTabView({catalog, fields}) {
         if (fieldname.includes('types') || fieldname.includes('bands') ||
             fieldname.includes('list')) {
             return listfield(fieldname, index);
-        }  else if (fieldname.includes('input')) {
+        } else if (fieldname.includes('input')) {
             var dkey = 'dependon';
 
             if (catalog[fieldname].hasOwnProperty(dkey)) {
@@ -718,27 +719,61 @@ function CatalogTabView({catalog, fields}) {
             }
 
             return inputfield(fieldname, index);
-        } else if ( fieldname.includes('upload')) {
-            return (
-                <div key={index} >
-                    <FileUpload
-                        wrapperStyle={{margin: '15px 10px 21px 10px'}}
-                        fieldKey={keyMap['fitsupload']}
-                        initialState= {{
-                        tooltip: 'Select a file to upload' }}
-                    />
-                </div>
-            );
-        } else {
-            return undefined;
-        }
-    };
+        } else if (fieldname.includes('upload')) {
 
-    return (
-        <div className={'tabview'}>
-            {(catalog.fields).map((oneField, index) =>  fieldrequest(oneField, index))}
-        </div>
-    );
+            var showUploadLocation = () => {
+                var options = [
+                    {'id': 0, label: 'Local File', 'value': 'isLocal'},
+                    {'id': 1, label: 'Workspace', 'value': 'isWs'}
+                ];
+
+
+                return (
+                    <div>
+                        <RadioGroupInputField
+                            initialState={{value: options[0].value,
+                                              fieldKey: keyMap['filelocation'] }}
+                            alignment={'horizontal'}
+                            fieldKey={keyMap['filelocation']}
+                            options={options}
+                        />
+                    </div>
+                );
+
+            };
+
+
+                return (
+                    <div key={index} style={{padding:5}}>
+                        <div
+                            style={{padding:5,display:'flex', flexDirection:'row', alignItems:'center' }}>
+                            <div
+                                style={{display:'flex', flexDirection:'column', alignItems: 'flex-end', margin:'0px 10px'}}>
+                                <div>{'Choose Upload from: '}</div>
+                            </div>
+
+                            {showUploadLocation()}
+                        </div>
+
+                        <FileUpload 
+                            wrapperStyle={{margin: '15px 10px 21px 10px'}} 
+                            fieldKey={keyMap['fitsupload']} 
+                            initialState={{     tooltip: 'Select a file to upload' }}     /> 
+
+                   </div>
+                );
+
+            } else {
+                    return undefined;
+            }
+        };
+
+        return (
+            <div className={'tabview'}>
+                {(catalog.fields).map((oneField, index) => fieldrequest(oneField, index))}
+            </div>
+        );
+
 }
 
 CatalogTabView.propTypes={

--- a/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelProp.js
@@ -167,12 +167,23 @@ export const initPanelCatalogs = [
         'Title': 'FITS File',
         'Symbol': 'FITS',
         'CatalogId': 6,
-        'fields': ['upload', 'list', 'extinput'],
+        'fields': ['upload', 'list', 'extinput','filelocation'],
+        'types': {
+                 'Title': 'Upload File Container:',
+                 'Items': [
+                     {'item': 'isLocal', 'id': 0, 'name': 'Upload Local File'},
+                     {'item': 'isWs', 'id': 1, 'name': 'Upload from Workspace'}
+                ],
+                 'Default':'isLocal'
+        },
         'button': {
             'Title': 'Enter URL of a FITS File:',
             'nullallowed': false
         },
         'upload': {
+            'Title': ''
+        },
+        'filelocation': {
             'Title': ''
         },
         'list': {

--- a/src/firefly/js/visualize/ui/ImageSelectPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelReducer.js
@@ -69,6 +69,7 @@ function initTabFields(crtCatalogId) {
         [keyMap['dsstypes']]: getTypeData('dsstypes', 'types', DSS),
         [keyMap['sdsstypes']]: getTypeData('sdsstypes', 'types', SDSS),
         [keyMap['fitslist']]: getTypeData('fitslist', 'list', FITS),
+        [keyMap['fitslocation']]: getTypeData('fitslocation', 'filelocation', FITS, 'isLocal'),
         [keyMap['fitsextinput']]: getTypeData('fitsextinput', 'extinput', FITS, '0'),
         /*
         [keyMap['blankinput']]: {


### PR DESCRIPTION
I have reverted most of the changes in FileUpload and FileUploadViewPanel (these were written for the current image search specifically). So it seems to be incomplete.
for the image select upload and time series viewer upload panel, the upload workspace needs to be connected to the file picker. There is no selection logic applied for now.
To view the extended save/upload panel:
1. run an image search,  from image toolbar, click save icon
2.    in firefly/image search panel
3.    in firefly/catalog search load catalog panel
4.   in firefly/Upload panel
5.   time series viewer
6.   added a File Upload dialog in firefly-dev.html page, for testing development of file pick only

