### PR TITLE
IRSA-870: added PDF, HTML, PNG and FITS files download for seip and akari

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/fuse/provider/FinderChartDataSetInfoConverter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/fuse/provider/FinderChartDataSetInfoConverter.java
@@ -334,10 +334,14 @@ public class FinderChartDataSetInfoConverter extends AbstractDataSetInfoConverte
                 else if (band.endsWith("3")) retID= ID.WISE_3.name();
                 else if (band.endsWith("4")) retID= ID.WISE_4.name();
                 break;
+            case SEIP:
+            case AKARI:
+            case ATLAS: retID= ID.WISE_1.name();
+                break;
             case MSX:
             case NONE:
             default:
-                retID= ID.TWOMASS_J.name();
+                retID= service.name()+"-"+band;
                 break;
         }
         return retID;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/Packager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/Packager.java
@@ -70,7 +70,6 @@ public class Packager {
         backgroundInfoCacher = packageInfo;
         _fgList = fgList;
         _maxBundleBytes = maxBundleBytes;
-        resolveUrlData();
         computeEstimate();
     }
 
@@ -271,33 +270,25 @@ public class Packager {
         return _packageID;
     }
 
-    private void resolveUrlData() {
-
-        for (FileGroup fg : _fgList) {
-            for (FileInfo f : fg) {
-                String urlStr = f.getInternalFilename();
-                if (urlStr.contains("://")) {
-                    long size = f.getSizeInBytes();
-                    if (size == 0) {
-                        size = DEFAULT_DATA_BYTES;
-                        f.setSizeInBytes(size);
-                        fg.setSizeInBytes(fg.getSizeInBytes() + size);
-                    }
-                }
-            }
-        }
-    }
-
     private void computeEstimate() {
         long totalSize = 0;
         int totalFiles = 0;
 
         // use dynamically created bundles
         for (FileGroup fg : _fgList) {
-            totalSize += fg.getSizeInBytes();
-            for (FileInfo f : fg) {
-                totalFiles++;
+            if(fg.getSizeInBytes()==0) {
+                long size = 0;
+                for (FileInfo f : fg) {
+                    size = f.getSizeInBytes();
+                    if (size == 0) {
+                        size = DEFAULT_DATA_BYTES;
+                        f.setSizeInBytes(size);
+                    }
+                    fg.setSizeInBytes(fg.getSizeInBytes() + size);
+                }
             }
+            totalSize += fg.getSizeInBytes();
+            totalFiles +=fg.getSize();
         }
         PackagedBundle bundle= new PackagedBundle(0, 0, totalFiles, totalSize);
         bundleList.add(bundle);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceDesc.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceDesc.java
@@ -23,6 +23,8 @@ public class ServiceDesc {
             case DSS: return getDssDesc(r);
             case SDSS: return getSloanDssDesc(r);
             case WISE: return getWiseDesc(r);
+            case AKARI:
+            case SEIP:
             case ATLAS: return getAtlasDesc(r);
             default: return r.getServiceType()+"";
         }
@@ -32,9 +34,9 @@ public class ServiceDesc {
     private static String getAtlasDesc(WebPlotRequest r) {
 
         String schema= r.getParam(AtlasIbeDataSource.DATASET_KEY);
-        String instrument=r.getParam(AtlasIbeDataSource.TABLE_KEY);
+        String table=r.getParam(AtlasIbeDataSource.TABLE_KEY);
         String band= r.getSurveyBand();
-        return schema + " "+instrument+ " " + band;
+        return schema + " "+table+ " " + band;
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
@@ -36,6 +36,8 @@ public class ServiceRetriever implements FileRetriever {
             case DSS: return getDssPlot(r);
             case SDSS: return getSloanDSSPlot(r);
             case WISE: return getWisePlot(r);
+            case AKARI:
+            case SEIP:
             case ATLAS: return getAtlasPlot(r);
             case DSS_OR_IRIS: return getDSSorIris(r);
             default: throw new FailedRequestException("Unsupported Service");
@@ -126,8 +128,18 @@ public class ServiceRetriever implements FileRetriever {
         AtlasImageParams params = new AtlasImageParams();
         params.setWorldPt(circle.getCenter());
         params.setBand(r.getSurveyBand());
-        params.setSchema(r.getParam(AtlasIbeDataSource.DATASET_KEY));
-        params.setTable(r.getParam(AtlasIbeDataSource.TABLE_KEY));
+        // New image search deals with atlas surveyKey formatted such as 'schema.table'
+        String datasetAtlas = r.getSurveyKey();
+        String schema, table;
+        if(datasetAtlas!=null && datasetAtlas.split("\\.").length==2){
+            schema = datasetAtlas.split("\\.")[0];
+            table = datasetAtlas.split("\\.")[1];
+        }else{
+            schema = r.getParam(AtlasIbeDataSource.DATASET_KEY);
+            table = r.getParam(AtlasIbeDataSource.TABLE_KEY);
+        }
+        params.setSchema(schema);
+        params.setTable(table);
         params.setInstrument(r.getParam(AtlasIbeDataSource.INSTRUMENT_KEY));
         params.setXtraFilter(r.getParam(AtlasIbeDataSource.XTRA_KEY));
         params.setSize((float)circle.getRadius());

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
@@ -30,8 +30,9 @@ import java.util.List;
  */
 public class WebPlotRequest extends ServerRequest {
 
+    // TODO this is actually coupled with edu.caltech.ipac.firefly.data.FinderChartRequestUtil.ImageSet.ImageSet and so we need to add imageset here although SEIP, AKARI are using ATLAS services.
     public enum
-            ServiceType {IRIS, ATLAS, ISSA, DSS, SDSS, TWOMASS, MSX, DSS_OR_IRIS, WISE, NONE}
+            ServiceType {IRIS, SEIP, AKARI, ATLAS, ISSA, DSS, SDSS, TWOMASS, MSX, DSS_OR_IRIS, WISE, NONE}
     public enum TitleOptions {NONE,  // use what it in the title
                               PLOT_DESC, // use the plot description key
                               FILE_NAME, // use the file name or analyze the URL and make a title from that
@@ -377,6 +378,29 @@ public class WebPlotRequest extends ServerRequest {
         return req;
     }
 
+    /**
+     * @param wp
+     * @param survey for atlas, survey is in form of 'schema.table'
+     * @param band SEIP exmaple 'irac1'
+     * @param filter for SEIP, it should loo like type=science and fname like %.mosaic.fits
+     * @param sizeInDeg
+     * @return
+     */
+    public static WebPlotRequest makeAtlasRequest(WorldPt wp,
+                                   String survey,
+                                   String band, String filter,
+                                   float sizeInDeg) {
+        WebPlotRequest req = makePlotServiceReq(ServiceType.ATLAS, wp, survey, sizeInDeg);
+        req.setParam(SURVEY_KEY, survey.split("\\.")[0]);
+        req.setParam("dataset", survey.split("\\.")[0]);
+        req.setParam("table", survey.split("\\.")[1]);
+        req.setParam("filter", filter); //Needed for the query but not for fetching the data (see QueryIBE metadata)
+        req.setParam(SURVEY_KEY_BAND, band + "");
+        req.setTitle(survey + "," + band);
+        // TODO drawingSubGroupId TO BE SET OUTSIDE here! ATLAS has many dataset and it will depend on the app to group those images, example: See ImageSelectPanelResult.js, Finderrchart...
+        //req.setDrawingSubGroupId(survey.split(".")[1]); // 'spitzer.seip_science'
+        return req;
+    }
     //======================== DSS or IRIS =====================================
 
     public static WebPlotRequest makeDSSOrIRISRequest(WorldPt wp,

--- a/src/firefly/js/core/background/BackgroundMonitor.jsx
+++ b/src/firefly/js/core/background/BackgroundMonitor.jsx
@@ -266,9 +266,9 @@ function PackageItem(progress) {
     var pct= BY_SIZE ? (processedBytes / totalBytes) :
                          (processedFiles / totalFiles);
     pct = Math.round(100 * pct);
-    const pctOf = BY_SIZE ? Math.round(totalBytes/1024/1024) + ' MB' :
+    const pctOf = BY_SIZE ? Math.round(Math.max(totalBytes/1024/1024,1)) + ' MB' :
                     totalFiles + ' files';
-    const finalSize = Math.round(finalCompressedBytes/1024/1024, -1);
+    const finalSize = Math.round(Math.max(finalCompressedBytes/1024/1024,1));
     const dlmsg = SINGLE ? 'Download Now' : `Download Part #${INDEX+1}`;
 
     if (isSuccess(STATE) || pct === 100) {      // because when there is only 1 item, state is set to success but pct does not calculate to 100%

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -485,6 +485,9 @@ function  makeServiceFileName(req,plot, band) {
         case ServiceType.WISE:
             retval= 'wise-'+req.getSurveyKey()+'-'+req.getSurveyBand()+'.fits';
             break;
+        case ServiceType.ATLAS:
+            retval= 'atlas-'+req.getSurveyKey()+'-'+req.getSurveyBand()+'.fits';
+            break;
         case ServiceType.NONE:
             retval= makeTitleFileName(plot, band);
             break;


### PR DESCRIPTION
I've added the files download for SEIP (and AKARI when IRSA-820 is done on client side) on server for Finderchart. There is same branch name in IFE.

Build from there Finderchart, and test searching for SEIP/WISE, try to download pdf, html png and fits.

I've also fixed a rounding problem for small size (<1MB) displayed in background monitor status.

Let me know.