### PR TITLE
DM-11856: framework for client properties defined at build time

### DIFF
--- a/buildScript/depends.gincl
+++ b/buildScript/depends.gincl
@@ -300,7 +300,6 @@ ext.NODE = { ...cmd ->
   // this is a way send config info to JS code.
   def res = exec {
     environment '__$version_tag': tag
-    environment '__$help_base_url': project.appConfigProps['help.base.url']
     environment 'WP_BUILD_DIR': wpBuildDir
     environment 'NODE_ENV': (project.env == 'local' ? 'development' : 'production')
     commandLine cmd

--- a/buildScript/webpack.config.js
+++ b/buildScript/webpack.config.js
@@ -59,13 +59,16 @@ export default function makeWebpackConfig(config) {
     const globals = {
         'process.env'   : {NODE_ENV : JSON.stringify(config.env)},
         NODE_ENV        : config.env,
-        __SCRIPT_NAME__ : JSON.stringify(script_names),
-        __MODULE_NAME__ : JSON.stringify(config.name),
+        __PROPS__       : {
+            SCRIPT_NAME: JSON.stringify(script_names),
+            MODULE_NAME: JSON.stringify(config.name)
+        }
+
     };
 
-    // add all of the env that starts with '__' into globals
+    // add all of the env that starts with '__$' as global props
     Object.keys(process.env).filter((k) => k.startsWith('__$')).forEach((k) => {
-        globals[k] = JSON.stringify(process.env[k]);
+        globals.__PROPS__[k.substring(3)] = JSON.stringify(process.env[k]);
     });
 
     const DEBUG    = config.env === 'development' && process.env.DEBUG;

--- a/buildScript/webpack.config.js
+++ b/buildScript/webpack.config.js
@@ -60,8 +60,8 @@ export default function makeWebpackConfig(config) {
         'process.env'   : {NODE_ENV : JSON.stringify(config.env)},
         NODE_ENV        : config.env,
         __PROPS__       : {
-            SCRIPT_NAME: JSON.stringify(script_names),
-            MODULE_NAME: JSON.stringify(config.name)
+            SCRIPT_NAME : JSON.stringify(script_names),
+            MODULE_NAME : JSON.stringify(config.name)
         }
 
     };

--- a/config/app.config
+++ b/config/app.config
@@ -23,7 +23,7 @@ download.bundle.maxbytes = 304857600
 
 sso.server.url = "https://irsa.ipac.caltech.edu/account/"
 sso.user.profile.url = "https://irsa.ipac.caltech.edu/account/uman/uman.html//id=profile"
-help.base.url = "https://irsa.ipac.caltech.edu/onlinehelp/"
+__$help.base.url = "https://irsa.ipac.caltech.edu/onlinehelp/"
 
 
 visualize.fits.MaxSizeInBytes= 10737418240

--- a/config/common.prop
+++ b/config/common.prop
@@ -42,9 +42,6 @@ ArrayRenderer.padding=\
 sso.server.url=@sso.server.url@
 sso.user.profile.url=@sso.user.profile.url@
 
-help.base.url=@help.base.url@
-__$help.base.url=@help.base.url@
-
-
+help.base.url=@__$help.base.url@
 
 visualize.fits.MaxSizeInBytes= @visualize.fits.MaxSizeInBytes@

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -26,6 +26,7 @@ import {wsConnect} from './core/messaging/WebSocketClient.js';
 import {ActionEventHandler} from './core/messaging/MessageHandlers.js';
 import {dispatchAppOptions} from './core/AppDataCntlr.js';
 import {init} from './rpc/CoreServices.js';
+import {getProp} from './util/WebUtil.js';
 
 export const flux = reduxFlux;
 
@@ -109,7 +110,7 @@ function fireflyInit() {
 }
 
 export function getVersion() {
-  return typeof __$version_tag === 'undefined' ? 'unknown' : __$version_tag;
+  return getProp('version_tag', 'unknown');
 } 
 
 

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -11,6 +11,7 @@ import {appDataReducer, menuReducer, alertsReducer} from './AppDataReducers.js';
 import Point, {isValidPoint} from '../visualize/Point.js';
 import {getModuleName} from '../util/WebUtil.js';
 import {getWsChannel} from './messaging/WebSocketClient.js';
+import {getProp} from '../util/WebUtil.js';
 
 export const APP_DATA_PATH = 'app_data';
 export const COMMAND = 'COMMAND';
@@ -248,8 +249,7 @@ function grabWindowFocus() {
 function onlineHelpLoad( action )
 {
     return () => {
-        /*global __$help_base_url*/
-        var url = typeof __$help_base_url === 'undefined' ? 'unknown' : __$help_base_url;       // this is a global var.. ending with '/'
+        var url = getProp('help.base.url');
         var windowName = 'onlineHelp';
         var moduleName = getModuleName();
 

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -8,6 +8,7 @@ import {SimpleComponent} from './SimpleComponent.jsx';
 import {getUserInfo} from '../core/AppDataCntlr.js';
 import {logout} from '../rpc/CoreServices.js';
 import {getRootURL} from '../util/BrowserUtil.js';
+import {getProp} from '../util/WebUtil.js';
 import './Banner.css';
 
 
@@ -62,8 +63,7 @@ export class UserInfo extends SimpleComponent {
     }
 
     render() {
-        /*global __$sso_redirect_uri*/
-        var logoutUri = typeof __$sso_redirect_uri === 'undefined' ? undefined : __$sso_redirect_uri;
+        const logoutUri = getProp('sso_redirect_uri', '');
 
         const {loginName='Guest', firstName, lastName, login_url} = this.state || {};
         const isGuest = loginName === 'Guest';

--- a/src/firefly/js/util/BrowserUtil.js
+++ b/src/firefly/js/util/BrowserUtil.js
@@ -6,12 +6,12 @@
  * Created by roby on 4/3/15.
  */
 
-/*global __SCRIPT_NAME__*/
+import {getProp} from './WebUtil.js';
 
-
-const SCRIPT_NAME = (typeof __SCRIPT_NAME__ === 'undefined') ? undefined : __SCRIPT_NAME__;
+const SCRIPT_NAME = getProp('SCRIPT_NAME');
 
 var getScriptURL = (function() {
+    
     var scripts = document.getElementsByTagName('script');
     var myScript;
     for(var i=0; (i<scripts.length); i++) {

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -2,8 +2,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-/*global __MODULE_NAME__*/
-
 import Enum from 'enum';
 import shallowequal from 'shallowequal';
 import {get, set, has, omit, isObject, union, isFunction, isEqual,  isNil,
@@ -35,8 +33,22 @@ export const WS_CONNID_HD  = 'FF-connID';
 export const ParamType= new Enum(['POUND', 'QUESTION_MARK']);
 
 
+
+
+
+
+/*global __PROPS__*/
+
+
+const GLOBAL_PROPS = (typeof __PROPS__ === 'undefined') ? undefined : __PROPS__;
+
+export function getProp(key, def) {
+    if (!GLOBAL_PROPS) return def;
+    return get(GLOBAL_PROPS, [key], def);
+}
+
 export function getModuleName() {
-    return (typeof __MODULE_NAME__ === 'undefined') ? undefined : __MODULE_NAME__;
+    return getProp('MODULE_NAME');
 }
 
 
@@ -199,12 +211,12 @@ export function fetchUrl(url, options, doValidation= true) {
 
 
     // ?info=json&access_token_refresh_interval=<seconds>
-    /*global __$sso_redirect_uri*/
-    if (typeof __$sso_redirect_uri !== 'undefined') {
-        const refreshUrl =  `${getRootURL()}${__$sso_redirect_uri}?info=json&access_token_refresh_interval=0`;
+    const ssoRedirect = getProp('sso_redirect_uri');
+    if (ssoRedirect) {
+        const refreshUrl =  `${getRootURL()}${ssoRedirect}?info=json&access_token_refresh_interval=0`;
         fetch(refreshUrl).then( (resp) =>  {
             resp.text().then( (text) => {
-                console.log( text );
+                //console.log( text );
             });
         });
     }

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -33,16 +33,10 @@ export const WS_CONNID_HD  = 'FF-connID';
 export const ParamType= new Enum(['POUND', 'QUESTION_MARK']);
 
 
-
-
-
-
-/*global __PROPS__*/
-
-
-const GLOBAL_PROPS = (typeof __PROPS__ === 'undefined') ? undefined : __PROPS__;
-
+let GLOBAL_PROPS;
 export function getProp(key, def) {
+    /*global __PROPS__*/
+    GLOBAL_PROPS = GLOBAL_PROPS || (typeof __PROPS__ === 'undefined') ? undefined : __PROPS__;
     if (!GLOBAL_PROPS) return def;
     return get(GLOBAL_PROPS, [key], def);
 }

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -35,8 +35,8 @@ export const ParamType= new Enum(['POUND', 'QUESTION_MARK']);
 
 let GLOBAL_PROPS;
 export function getProp(key, def) {
-    /*global __PROPS__*/
-    GLOBAL_PROPS = GLOBAL_PROPS || (typeof __PROPS__ === 'undefined') ? undefined : __PROPS__;
+    /*global __PROPS__*/        // this is defined at build-time.
+    GLOBAL_PROPS = GLOBAL_PROPS || __PROPS__;
     if (!GLOBAL_PROPS) return def;
     return get(GLOBAL_PROPS, [key], def);
 }


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-11856

- define '__$' as a prefix to indicate client property
- added getProp() to WebUtil.js to access the property on the client
See `help.base.url` in config/app.config as an example.

Everything should work as before.  More changes under the sam branch in ife and suit as well.