### PR TITLE
IRSA-810: Replace left hand options links to top left hand tabs (FinderChart)

### DIFF
--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -122,11 +122,13 @@ export function dispatchSetMenu(menu) {
 
 /**
  * Load search info into the application
- * @param groups
+ * @param p                     parameter object
+ * @param {object[]}  p.groups  an array of search groups
  * @param {string}   [activeSearch] the current selected search.  defaults to the first search.
+ * @param {string}   [flow]     'horizontal' or 'vertical'.  defaults to 'vertical'.
  */
-export function dispatchLoadSearches(groups, activeSearch) {
-    flux.process({ type : LOAD_SEARCHES, payload: {groups, activeSearch} });
+export function dispatchLoadSearches({groups, activeSearch, flow}) {
+    flux.process({ type : LOAD_SEARCHES, payload: {groups, activeSearch, flow} });
 }
 
 /**
@@ -272,14 +274,14 @@ function onlineHelpLoad( action )
 
 function loadSearches(action) {
     return function (dispatch) {
-        var {groups=[], activeSearch} = action.payload;
+        var {groups=[], activeSearch, flow} = action.payload;
         groups.forEach( (g) => {
             Object.entries(get(g, 'searchItems',{}))
                   .forEach(([k,v]) => v.name = k);      // insert key as name into the search object.
         });
         activeSearch = activeSearch || get(Object.values(get(groups, [0, 'searchItems'], {})), [0, 'name']);    // defaults to first searchItem
         const allSearchItems = Object.assign({}, ...map(groups, 'searchItems'));
-        Object.assign(searchInfo, {allSearchItems, groups});
+        Object.assign(searchInfo, {allSearchItems, groups, flow});
         dispatch({ type : APP_UPDATE, payload: {searches: {activeSearch}}});
     };
 }

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -26,8 +26,6 @@ export class SearchPanel extends SimpleComponent {
         const sideBar = Object.keys(allSearchItems).length > 1 ? <SideBar {...{activeSearch, groups}}/> : null;
         const searchItem = allSearchItems[activeSearch];
 
-        const onTabSelect = () => undefined;
-
         if (flow === 'vertical') {
             return (
                 <div className='SearchPanel' style={style}>
@@ -41,10 +39,12 @@ export class SearchPanel extends SimpleComponent {
             );
         } else {
             const title = get(groups, [0, 'title']);
+            const onTabSelect = (index,id,name) => dispatchUpdateAppData(set({}, ['searches', 'activeSearch'], name));
+
             return (
                 <div>
                     {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
-                    <Tabs onTabSelect={onTabSelect} resizable={true} useFlex={true} borderless={true} contentStyle={{backgroundColor: 'transparent'}}>
+                    <Tabs componentKey={`SearchPanel_${title}`} onTabSelect={onTabSelect} resizable={true} useFlex={true} borderless={true} contentStyle={{backgroundColor: 'transparent'}}>
                         {searchesAsTabs(allSearchItems)}
                     </Tabs>
                 </div>

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -4,11 +4,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {set} from 'lodash';
+import {set, get} from 'lodash';
 import {dispatchUpdateAppData} from '../core/AppDataCntlr.js';
 import {getSearchInfo} from '../core/AppDataCntlr.js';
 import {FormPanel} from './FormPanel.jsx';
 import {SimpleComponent} from './SimpleComponent.jsx';
+import {Tabs, Tab} from './panel/TabPanel.jsx';
 
 export class SearchPanel extends SimpleComponent {
 
@@ -18,29 +19,60 @@ export class SearchPanel extends SimpleComponent {
 
     render() {
         const {style={}} = this.props;
-        const {activeSearch, groups} = this.state;
+        const {activeSearch, groups, flow='vertical'} = this.state;
         if (!groups) return null;
         const {allSearchItems} = getSearchInfo();
 
         const sideBar = Object.keys(allSearchItems).length > 1 ? <SideBar {...{activeSearch, groups}}/> : null;
         const searchItem = allSearchItems[activeSearch];
 
-        return (
-            <div className='SearchPanel' style={style}>
-                {sideBar}
-                {searchItem &&
+        const onTabSelect = () => undefined;
+
+        if (flow === 'vertical') {
+            return (
+                <div className='SearchPanel' style={style}>
+                    {sideBar}
+                    {searchItem &&
                     <div className='SearchPanel__form'>
                         <SearchForm searchItem={searchItem} />
                     </div>
-                }
-            </div>
-        );
+                    }
+                </div>
+            );
+        } else {
+            const title = get(groups, [0, 'title']);
+            return (
+                <div>
+                    {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
+                    <Tabs onTabSelect={onTabSelect} resizable={true} useFlex={true} borderless={true} contentStyle={{backgroundColor: 'transparent'}}>
+                        {searchesAsTabs(allSearchItems)}
+                    </Tabs>
+                </div>
+            );
+        }
     }
 }
 
 SearchPanel.propTypes = {
-    style:      PropTypes.object
+    style:  PropTypes.object
 };
+
+
+function searchesAsTabs(allSearchItems) {
+
+    return allSearchItems &&
+        Object.values(allSearchItems).map( (searchItem) => {
+            const label = searchItem.title || searchItem.name;
+            return  (
+                <Tab key={label} name={label}>
+                    <div className='SearchPanel__form'>
+                        <SearchForm searchItem={searchItem} />
+                    </div>
+                </Tab>
+            );
+        } );
+}
+
 
 
 function SearchForm({searchItem}) {

--- a/src/firefly/js/ui/panel/TabPanel.css
+++ b/src/firefly/js/ui/panel/TabPanel.css
@@ -13,7 +13,7 @@
     outline: none;
     color:black; /*CVAL-BLACK*/
     cursor:pointer;
-    height: 18px;
+    height: 20px;
     margin-left:6px;
     padding:2px 6px;
     font-weight: normal;
@@ -21,6 +21,7 @@
     border-top-left-radius: 5px;
     white-space: nowrap;
     overflow: hidden;
+    box-sizing: border-box;
 }
 
 .TabPanel__Tab--selected {
@@ -46,3 +47,8 @@
     position: relative;
 }
 
+.TabPanel__Content.borderless {
+    border: none;
+    border-top: 1px solid #c8c8c8;
+    border-radius: 0;
+}

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -59,7 +59,7 @@ class TabsHeader extends PureComponent {
             });
         }
         return (
-            <div style={{flexGrow: 0, height: 18}}>
+            <div style={{flexGrow: 0, height: 20}}>
                 {(widthPx||!resizable) ? <ul className='TabPanel__Tabs'>
                     {sizedChildren}
                 </ul> : <div/>}
@@ -107,7 +107,7 @@ export class Tabs extends PureComponent {
 
     render () {
         var { selectedIdx}= this.state;
-        const {children, useFlex, resizable} = this.props;
+        const {children, useFlex, resizable, borderless, contentStyle={}} = this.props;
         const numTabs = React.Children.count(children);
 
         var content;
@@ -128,11 +128,11 @@ export class Tabs extends PureComponent {
                     {content}
                 </div>
             );
-
+        const contentClsName = borderless ? 'TabPanel__Content borderless' : 'TabPanel__Content';
         return (
             <div style={{display: 'flex', height: '100%', flexDirection: 'column', flexGrow: 1, overflow: 'hidden'}}>
                 <TabsHeader {...{resizable}}>{newChildren}</TabsHeader>
-                <div ref='contentRef' className='TabPanel__Content'>
+                <div ref='contentRef' style={contentStyle} className={contentClsName}>
                     {(content)?contentDiv:''}
                 </div>
             </div>
@@ -147,13 +147,16 @@ Tabs.propTypes= {
     defaultSelected:  PropTypes.any,
     onTabSelect: PropTypes.func,
     useFlex: PropTypes.bool,
-    resizable: PropTypes.bool
+    resizable: PropTypes.bool,
+    contentStyle: PropTypes.object,
+    borderless: PropTypes.bool
 };
 
 Tabs.defaultProps= {
     defaultSelected: 0,
     useFlex: false,
-    resizable: false
+    resizable: false,
+    borderless: false
 };
 
 


### PR DESCRIPTION
https://caltech-ipac.atlassian.net/browse/IRSA-810

Also:
- added flow:horizontal option to SearchPanel to display search items horizontally on top
- clean up FinderChart's form layout

More changes are in ife under the same branch
To Test:
- build finderchart in ife
- goto http://localhost:8080/applications/finderchart/

You should see that the left navigation panel is now replaced by a top tab-style navigation.
I've also removed borders, margin and padding to have a cleaner look.
Let me know what you think. 