### PR TITLE
IRSA-964: TimeSeries tool: downloading images from selected rows is broken

### DIFF
--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -47,6 +47,7 @@ clean {
   group = DEV_GROUP
 }
 
+
 test {
   description= 'Run Java and JavaScript unit test'
   group = DEV_GROUP
@@ -75,6 +76,16 @@ test {
   // listen to standard out and standard error of the test JVM(s)
   onOutput { descriptor, event ->
     logger.lifecycle("Test: " + descriptor + " produced standard out/err: " + event.message )
+  }
+
+  doFirst {
+    // things needed before test run
+    copy {
+      from("$rootDir/config/log4j-test.properties")
+      into "${gwt.warDir}/WEB-INF/config"
+      rename("log4j-test.properties", "log4j.properties")
+      filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: project.appConfigProps)
+    }
   }
 }
 

--- a/config/app-test.prop
+++ b/config/app-test.prop
@@ -18,4 +18,5 @@ workspace.protocol.webdav=edu.caltech.ipac.firefly.server.WebDAVWorkspaceManager
 # workspace.protocol.webdav=edu.caltech.ipac.firefly.server.ws.WebdavImpl
 
 atlas.ibe.host=irsadev.ipac.caltech.edu
+visualize.fits.Security=false
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -36,7 +36,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
     public static final List<String> SYS_PARAMS = Arrays.asList(REQUEST_CLASS,INCL_COLUMNS,SORT_INFO,FILTERS,PAGE_SIZE,START_IDX,FIXED_LENGTH,META_INFO,TBL_ID,SQL_FROM);
     public static final String TBL_INDEX = "tbl_index";     // the table to show if it's a multi-table file.
 
-    private int pageSize;
+    private int pageSize = -1;
     private int startIdx;
     private ArrayList<String> filters;
     private Map<String, String> metaInfo;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
@@ -32,6 +32,17 @@ public class RequestAgent {
     private String remoteIP;
     private String sessId;
 
+    public RequestAgent() {}
+
+    public RequestAgent(Map<String, Cookie> cookies, String protocol, String requestUrl, String baseUrl, String remoteIP, String sessId) {
+        this.cookies = cookies;
+        this.protocol = protocol;
+        this.requestUrl = requestUrl;
+        this.baseUrl = baseUrl;
+        this.remoteIP = remoteIP;
+        this.sessId = sessId;
+    }
+
     public void setCookies(Map<String, Cookie> cookies) {
         this.cookies = cookies;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -122,7 +122,10 @@ abstract public class BaseDbAdapter implements DbAdapter {
     public String orderByPart(TableServerRequest treq) {
         if (treq.getSortInfo() != null) {
             String dir = treq.getSortInfo().getDirection() == SortInfo.Direction.DESC ? " desc" : "";
-            return  "order by " + treq.getSortInfo().getPrimarySortColumn() + dir;
+            String cols = treq.getSortInfo().getSortColumns().stream()
+                    .map(c -> c.contains("\"") ? c : "\"" + c + "\"")
+                    .collect(Collectors.joining(","));
+            return  "order by " + cols + dir;
         }
         return "";
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/download/DynFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/download/DynFileGroupsProcessor.java
@@ -5,6 +5,7 @@ package edu.caltech.ipac.firefly.server.download;
 
 
 import edu.caltech.ipac.astro.IpacTableException;
+import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.util.download.URLDownload;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.ServerRequest;
@@ -57,8 +58,7 @@ public class DynFileGroupsProcessor extends FileGroupsProcessor {
     }
 
     private List<FileGroup> computeFileGroup(DownloadRequest request) throws IOException, IpacTableException, DataAccessException {
-        Collection<Integer> selectedRows = request.getSelectedRows();
-        DataGroupPart dgp = new SearchManager().getDataGroup(request.getSearchRequest());
+        ArrayList<Integer> selectedRows = new ArrayList<>(request.getSelectedRows());
 
         String urlDownloadColumn = request.getParam("URL_DOWNLOAD_COLUMN");
         if (urlDownloadColumn == null) {
@@ -70,7 +70,7 @@ public class DynFileGroupsProcessor extends FileGroupsProcessor {
             urlParamFilename = "name";
         }
 
-        IpacTableParser.MappedData dgData = IpacTableParser.getData(new File(dgp.getTableDef().getSource()),
+        IpacTableParser.MappedData dgData = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(),
                 selectedRows, urlDownloadColumn);
 
         Logger.LoggerImpl logger = Logger.getLogger();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
@@ -28,9 +28,11 @@ public class DecimationProcessor extends TableFunctionProcessor {
 
     protected DataGroup fetchData(TableServerRequest treq, File dbFile, DbAdapter dbAdapter) throws DataAccessException {
 
+        treq.setPageSize(Integer.MAX_VALUE);
+
         DecimateInfo decimateInfo = getDecimateInfo(treq);
         TableServerRequest sreq = getSearchRequest(treq);
-        sreq.setPageSize(Integer.MAX_VALUE);
+        sreq.setPageSize(Integer.MAX_VALUE);        // we want all of the data.  no paging
 
         // only read in the required columns
         Expression xColExpr = new Expression(decimateInfo.getxColumnName(), null);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
@@ -145,6 +145,8 @@ public class SearchManager {
         }
     }
 
+    // use edu.caltech.ipac.firefly.server.query.SearchServerCommands.SelectedValues instead
+    @Deprecated
     public List<String> getDataFileValues(File file, List<Integer> rows, String colName) throws DataAccessException, IOException {
 
         if (!file.canRead() ||

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
@@ -23,7 +23,6 @@ import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
 import edu.caltech.ipac.firefly.server.util.ipactable.JsonTableUtil;
 import edu.caltech.ipac.firefly.server.SrvParam;
-import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.StringUtils;
 import org.json.simple.JSONObject;
 
@@ -71,19 +70,11 @@ public class SearchServerCommands {
         public String doCommand(SrvParam params) throws Exception {
             String requestJson = params.getRequired(ServerParams.REQUEST);
             TableServerRequest treq = QueryUtil.convertToServerRequest(requestJson);
-            EmbeddedDbProcessor proc = (EmbeddedDbProcessor) new SearchManager().getProcessor(treq.getRequestId());
-            treq.setPageSize(Integer.MAX_VALUE);
             try {
                 List<String> cols = StringUtils.asList(params.getRequired("columnNames"), ",");
+                String[] colsAry = cols == null ? null : cols.toArray(new String[cols.size()]);
                 List<Integer> rows = StringUtils.convertToListInteger(params.getRequired("selectedRows"), ",");
-                // hitting the database directly.
-                String selCols = cols.size() > 0 ? StringUtils.toString(cols) : "*";
-                String tblName = proc.getResultSetID(treq) ;
-                String inRows = rows.size() > 0 ? StringUtils.toString(rows) : "-1";
-
-                String sql = String.format("select %s from %s where %s in (%s)", selCols, tblName, DataGroup.ROW_NUM, inRows);
-                DataGroupPart page = EmbeddedDbUtil.getResults(treq, sql , proc.getDbFile(treq), tblName);
-
+                DataGroupPart page = EmbeddedDbUtil.getSelectedDataAsDGPart(treq, rows, colsAry);
                 return JsonTableUtil.toJsonTableModel(page, treq).toJSONString();
             } catch (IOException e) {
                 throw new DataAccessException("Unable to resolve a search processor for this request.  SelectedValues aborted.");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
@@ -60,7 +60,7 @@ public abstract class SharedDbProcessor extends EmbeddedDbProcessor {
             DataGroup data = fetchData(treq);
             EmbeddedDbUtil.ingestDataGroup(dbFile, data, dbAdapter, tblName);
         }
-        return EmbeddedDbUtil.getResultForTable(treq, dbFile, tblName);
+        return EmbeddedDbUtil.execRequestQuery(treq, dbFile, tblName);
     }
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/StatisticsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/StatisticsProcessor.java
@@ -54,7 +54,7 @@ public class StatisticsProcessor extends TableFunctionProcessor {
         }
 
         // get all cols from dd table
-        DataGroup dd = EmbeddedDbUtil.runQuery(dbAdapter, dbFile, String.format("select * from data_dd"), null);
+        DataGroup dd = EmbeddedDbUtil.execQuery(dbAdapter, dbFile, String.format("select * from data_dd"), null);
 
         //generate one sql for all the columns.  each as cname_min, cname_max, cname_count
         DataGroup stats = new DataGroup("stats", columns);
@@ -79,7 +79,7 @@ public class StatisticsProcessor extends TableFunctionProcessor {
 
         }
         if (sqlCols.size() > 0) {
-            DataObject data = EmbeddedDbUtil.runQuery(dbAdapter, dbFile, String.format("select %s from %s",StringUtils.toString(sqlCols), origDataTblName), null).get(0);
+            DataObject data = EmbeddedDbUtil.execQuery(dbAdapter, dbFile, String.format("select %s from %s",StringUtils.toString(sqlCols), origDataTblName), null).get(0);
             for (int i = 0; i < stats.size(); i++) {
                 DataObject col = stats.get(i);
                 String cname = col.getStringData("columnName");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/TableFunctionProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/TableFunctionProcessor.java
@@ -16,7 +16,6 @@ import edu.caltech.ipac.util.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 
 import java.io.File;
-import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static edu.caltech.ipac.firefly.data.TableServerRequest.FILTERS;
@@ -88,14 +87,7 @@ public abstract class TableFunctionProcessor extends EmbeddedDbProcessor {
             EmbeddedDbUtil.createDDTbl(dbFile, data, dbAdapter, resTblName);
             EmbeddedDbUtil.createMetaTbl(dbFile, data, dbAdapter, resTblName);
         }
-        treq.setParam(TableServerRequest.SQL_FROM, resTblName);
-        String sql = String.format("%s from %s %s", dbAdapter.selectPart(treq), resTblName, dbAdapter.wherePart(treq));
-        sql = dbAdapter.translateSql(sql);
-
-        DataGroup dg = EmbeddedDbUtil.runQuery(dbAdapter, dbFile, sql, resTblName);
-        TableDef tm = new TableDef();
-        tm.setStatus(DataGroupPart.State.COMPLETED);
-        return new DataGroupPart(tm, dg, treq.getStartIndex(), dg.size());
+        return EmbeddedDbUtil.execRequestQuery(treq, dbFile, resTblName);
     }
 
     protected TableServerRequest getSearchRequest(TableServerRequest treq) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -8,6 +8,7 @@ import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.FileGroupsProcessor;
@@ -49,8 +50,7 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
         // create unique list of filesystem-based and url-based files
         Set<String> zipFiles = new HashSet<String>();
 
-        Collection<Integer> selectedRows = request.getSelectedRows();
-        DataGroupPart dgp = new SearchManager().getDataGroup(request.getSearchRequest());
+        ArrayList<Integer> selectedRows = new ArrayList<>(request.getSelectedRows());
 
         ArrayList<FileInfo> fiArr = new ArrayList<FileInfo>();
         long fgSize = 0;
@@ -65,7 +65,7 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
 
         List<String> types = new ArrayList<String>();
 
-        IpacTableParser.MappedData dgData = IpacTableParser.getData(new File(dgp.getTableDef().getSource()),
+        IpacTableParser.MappedData dgData = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(),
                 selectedRows, "oid", "pfilename", "fid", "pid", "ccdid", "ra", "dec");
 
         if (request.getParam("ProductLevel") == null) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -65,8 +65,9 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
 
         List<String> types = new ArrayList<String>();
 
-        IpacTableParser.MappedData dgData = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(),
-                selectedRows, "oid", "pfilename", "fid", "pid", "ccdid", "ra", "dec");
+        IpacTableParser.MappedData dgData = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(), selectedRows);
+// because some columns below may not be in the resultset, we will select all(*) then determine if they exists.
+//                selectedRows, "oid", "pfilename", "fid", "pid", "ccdid", "ra", "dec");
 
         if (request.getParam("ProductLevel") == null) {
             request.setParam("ProductLevel", "l1");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/WiseLightCurveFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/WiseLightCurveFileGroupsProcessor.java
@@ -5,6 +5,7 @@ import edu.caltech.ipac.astro.IpacTableException;
 import edu.caltech.ipac.astro.ibe.IBE;
 import edu.caltech.ipac.firefly.data.*;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.FileGroupsProcessor;
@@ -57,8 +58,7 @@ public class WiseLightCurveFileGroupsProcessor extends FileGroupsProcessor {
         // create unique list of filesystem-based and url-based files
         Set<String> zipFiles = new HashSet<String>();
 
-        Collection<Integer> selectedRows = request.getSelectedRows();
-        DataGroupPart dgp = new SearchManager().getDataGroup(request.getSearchRequest());
+        ArrayList<Integer> selectedRows = new ArrayList<>(request.getSelectedRows());
 
         ArrayList<FileGroup> fgArr = new ArrayList<FileGroup>();
         ArrayList<FileInfo> fiArr = new ArrayList<FileInfo>();
@@ -106,8 +106,10 @@ public class WiseLightCurveFileGroupsProcessor extends FileGroupsProcessor {
         // For LC viewer we only want single exposure - product level = 1b
         String pl = request.getSafeParam("ProductLevel");
         String productLevel = pl != null ? pl : "1b";
-        IpacTableParser.MappedData dgData = IpacTableParser.getData(new File(dgp.getTableDef().getSource()),
-                selectedRows, "source_id_mf", "source_id", "frame_id", "scan_id", "frame_num", "ra", "dec");
+        IpacTableParser.MappedData dgData = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(), selectedRows);
+        // some of these columns may not exists depending on the data type and therefore cannot be queried.
+        // in this case, we select all columns.
+        //"source_id_mf", "source_id", "frame_id", "scan_id", "frame_num", "ra", "dec"
 
 
         String frameidRegex = "(\\d+)([0-9][a-z])(\\w+)";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTFileGroupProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTFileGroupProcessor.java
@@ -4,6 +4,7 @@ import edu.caltech.ipac.astro.IpacTableException;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.query.*;
@@ -49,8 +50,7 @@ public class LSSTFileGroupProcessor  extends FileGroupsProcessor {
 
     private List<FileGroup> computeFileGroup(DownloadRequest request) throws IOException, IpacTableException, DataAccessException {
 
-        Collection<Integer> selectedRows = request.getSelectedRows();
-        DataGroupPart dgp = new SearchManager().getDataGroup(request.getSearchRequest());
+        ArrayList<Integer> selectedRows = new ArrayList<>(request.getSelectedRows());
 
         ArrayList<FileGroup> fgArr = new ArrayList<>();
 
@@ -71,8 +71,9 @@ public class LSSTFileGroupProcessor  extends FileGroupsProcessor {
         String[] deeoCoaddCols={"deepCoaddId","tract", "patch", "filterName"};
         String[] columns= isDeepCoadd?deeoCoaddCols:sccdCols;
 
-        IpacTableParser.MappedData dgData = IpacTableParser.getData(new File(dgp.getTableDef().getSource()),
+        IpacTableParser.MappedData dgData = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(),
                 selectedRows, columns);
+
         ArrayList<FileInfo> fiArr = new ArrayList<>();
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -24,9 +24,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 
+import static edu.caltech.ipac.firefly.server.query.tables.IpacTableFromSource.PROC_ID;
 
-@SearchProcessorImpl(id = "IpacTableFromSource")
+
+@SearchProcessorImpl(id = PROC_ID)
 public class IpacTableFromSource extends IpacTablePartProcessor {
+    public static final String PROC_ID = "IpacTableFromSource";
     public static final String TBL_TYPE = "tblType";
     public static final String TYPE_CATALOG = "catalog";
     public static final String URL_CHECK_FOR_NEWER = WebPlotRequest.URL_CHECK_FOR_NEWER;

--- a/src/firefly/java/edu/caltech/ipac/util/DataObject.java
+++ b/src/firefly/java/edu/caltech/ipac/util/DataObject.java
@@ -3,6 +3,8 @@
  */
 package edu.caltech.ipac.util;
 
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+
 import java.io.Serializable;
 
 /**
@@ -175,7 +177,11 @@ public class DataObject implements Serializable, Cloneable {
         return v == null ? def : v.toString();
     }
 
-
+    public int getIntData(String name) { return QueryUtil.getInt(getDataElement(name)); }
+    public int getIntData(String name, int def) {
+        int v = getIntData(name);
+        return v == Integer.MIN_VALUE ? def : v;
+    }
 
 
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
@@ -1,5 +1,7 @@
 package edu.caltech.ipac.firefly;
 
+import edu.caltech.ipac.firefly.server.RequestAgent;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.ws.WsCredentials;
 import edu.caltech.ipac.util.AppProperties;
@@ -12,6 +14,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.logging.LogManager;
 
 /**
@@ -118,4 +121,15 @@ public class ConfigTest {
             props.load(configUrl.openStream());
         }
     }
+
+    protected static void setupServerContext() {
+        setupServerContext("build/firefly/war/WEB-INF/config/", "/", "localhost:8080/");
+    }
+    protected static void setupServerContext(String webappConfigPath, String reqUrl, String baseUrl) {
+        System.setProperty("stats.log.dir", System.getProperty("java.io.tmpdir"));
+        ServerContext.getRequestOwner().setRequestAgent(new RequestAgent(null, "HTTP", reqUrl, baseUrl, "unknow", UUID.randomUUID().toString()));
+        ServerContext.init("/firefly", "firefly", webappConfigPath);
+
+    }
+
 }

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/EmbeddedDbUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/EmbeddedDbUtilTest.java
@@ -1,0 +1,150 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.astro.IpacTableException;
+import edu.caltech.ipac.astro.IpacTableReader;
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.data.SortInfo;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
+import edu.caltech.ipac.firefly.server.db.HsqlDbAdapter;
+import edu.caltech.ipac.firefly.server.query.tables.IpacTableFromSource;
+import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
+import edu.caltech.ipac.firefly.server.util.ipactable.IpacTableParser;
+import edu.caltech.ipac.firefly.util.FileLoader;
+import edu.caltech.ipac.util.DataGroup;
+import edu.caltech.ipac.util.DataType;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class EmbeddedDbUtilTest extends ConfigTest {
+
+	public static File dbFile;
+	public static File testFile;
+
+	@BeforeClass
+	public static void setUp() {
+		try {
+			// needed by test testGetSelectedData because it's dealing with code running in a server's context, ie  SearchProcessor, RequestOwner, etc.
+			setupServerContext();
+
+			dbFile = File.createTempFile("TestDb_", ".hsql");
+			dbFile.deleteOnExit();
+
+			HsqlDbAdapter dbAdapter = new HsqlDbAdapter();
+			testFile = FileLoader.resolveFile(EmbeddedDbUtilTest.class, "/embedded_db_test.tbl");
+			DataGroup data = IpacTableReader.readIpacTable(testFile, "test");
+			EmbeddedDbUtil.createDbFile(dbFile,dbAdapter);
+			EmbeddedDbUtil.ingestDataGroup(dbFile, data, dbAdapter, "data");
+		} catch (IpacTableException | IOException e) {
+			Assert.fail("Unable to ingest data into the database");
+		}
+	}
+
+	/**
+	 * test results based on the constructed TableServerRequest
+	 */
+	@Test
+	public void testExecRequestQuery() {
+		try {
+			TableServerRequest req = new TableServerRequest("n/a (id not used)");
+			req.setPageSize(9);
+			req.setInclColumns("\"designation\", \"dec\", \"sigdec\"");
+			DataGroupPart res = EmbeddedDbUtil.execRequestQuery(req, dbFile, "data");
+			DataGroup data = res.getData();
+
+			// test total rows, returned rows, and cols
+			Assert.assertEquals(res.getRowCount(), 10);
+			Assert.assertEquals(data.size(), 9);
+			Assert.assertEquals(data.getDataDefinitions().length, 3);
+
+			// random tests of returned values
+			Assert.assertEquals("J132955.35+471336.8", data.get(0).getDataElement("designation"));
+			Assert.assertEquals(0.0476, data.get(8).getDataElement("sigdec"));
+
+			// make sure meta information is passed back
+			testMeta(data);
+
+			// test sort;  reset request object
+			req = new TableServerRequest("n/a (id not used)");
+			req.setSortInfo(new SortInfo(SortInfo.Direction.DESC, "sigra"));
+			res = EmbeddedDbUtil.execRequestQuery(req, dbFile, "data");
+			data = res.getData();
+			Assert.assertEquals(0.0744, data.get(0).getDataElement("sigra"));
+			Assert.assertEquals(0.0413, data.get(9).getDataElement("sigra"));
+
+			// make sure meta information is still good after sorting
+			testMeta(data);
+
+			// test filter;  reset request object
+			req = new TableServerRequest("n/a (id not used)");
+			req.setSortInfo(new SortInfo(SortInfo.Direction.DESC, "sigra"));
+			req.setFilters(Arrays.asList(String.format("\"%s\" in (%f, %f, %f)", "sigra", 0.0413, 0.0744, 12345.6)));
+			res = EmbeddedDbUtil.execRequestQuery(req, dbFile, "data");
+			data = res.getData();
+			Assert.assertEquals(2, data.size());		// the 3rd values(12345.6) is not in the table
+			Assert.assertEquals(0.0755, data.get(0).getDataElement("sigdec"));
+			Assert.assertEquals(0.0394, data.get(1).getDataElement("sigdec"));
+
+			// make sure meta information is still good after sorting
+			testMeta(data);
+
+
+		} catch (Exception e) {
+			Assert.fail("testExecRequestQuery failed with exception: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * a lower level access based on a SQL statement
+	 */
+	@Test
+	public void testExecQuery() {
+		HsqlDbAdapter dbAdapter = new HsqlDbAdapter();
+		String sql = "select d.* from (select \"designation\", \"RA(deg)\"+1 as ABC from data where \"sigdec\" > 0.0750) as d order by d.ABC";
+		DataGroup data = EmbeddedDbUtil.execQuery(dbAdapter, dbFile, sql, "data");
+
+		Assert.assertEquals(203.4851848, data.get(0).getDataElement("ABC"));
+		Assert.assertEquals(203.4874371, data.get(1).getDataElement("ABC"));
+
+	}
+
+	/**
+	 * test data retrieval based on selected rows
+	 */
+	@Test
+	public void testGetSelectedData() {
+		TableServerRequest treq = new TableServerRequest(IpacTableFromSource.PROC_ID);
+		treq.setParam(ServerParams.SOURCE, testFile.toString());
+		treq.setPageSize(Integer.MAX_VALUE);
+		treq.setSortInfo(new SortInfo("sigra"));
+		treq.setFilters(Arrays.asList("\"sigra\" < 0.06"));
+
+		IpacTableParser.MappedData selVals = EmbeddedDbUtil.getSelectedMappedData(treq, Arrays.asList(1, 3, 5), "dec", "clon+1", "RA(deg)");
+
+		Assert.assertEquals("13h29m56.55s", selVals.get(1, "clon+1"));
+		Assert.assertEquals(47.2321996, selVals.get(3, "dec"));
+		Assert.assertEquals(202.4680189, selVals.get(5, "RA(deg)"));
+	}
+
+	private void testMeta(DataGroup data) {
+		// test meta
+		Assert.assertEquals("'ORIGIN value'", data.getAttribute("ORIGIN").getValue());
+		Assert.assertEquals("'SQL value'", data.getAttribute("SQL").getValue());
+		Assert.assertEquals("%.6g", data.getAttribute("col.dec.FmtDisp").getValue());
+
+		// test column meta
+		DataType dt = data.getDataDefintion("dec");
+		Assert.assertEquals("deg", dt.getDataUnit());
+		Assert.assertEquals(Double.class, dt.getDataType());
+	}
+
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/ipactable/IpacTableTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/ipactable/IpacTableTest.java
@@ -64,8 +64,8 @@ public class IpacTableTest {
 
         JSONObject json = JsonTableUtil.toJsonTableModel(page, request);
         Assert.assertNotNull(json);
-        String jsonStr = json.toJSONString();
-        String expected = FileUtil.readFile(jsonResults);
+        String jsonStr = json.toJSONString().trim();
+        String expected = FileUtil.readFile(jsonResults).trim();
         Assert.assertEquals(expected, jsonStr);
 
 


### PR DESCRIPTION
- Converted code relying on an ipac table file as source of the table data.
- Added unit testing for EmbeddedDbUtil
https://caltech-ipac.atlassian.net/browse/IRSA-964

Additional changes are in ife and firefly_test_data under the same branch.

To test:
http://localhost:8080/firefly/ts.html
- upload a file to view its time series data.
- select multiple rows then select "Prepare Download"
- the images from the selected rows should be downloaded.
This was not working prior to this PR.