### PR TITLE
IRSA-820: Add Akari

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
@@ -12,6 +12,8 @@ import edu.caltech.ipac.visualize.plot.CoordinateSys;
 import edu.caltech.ipac.visualize.plot.Plot;
 import edu.caltech.ipac.visualize.plot.WorldPt;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -184,11 +186,27 @@ public class AtlasIbeDataSource extends BaseIbeDataSource {
         return ds;
     }
 
+    //this method encode the file name in case it has + or some other sign
+    private String getEncodedFileName(String fname){
+
+            String[] fpArray =fname.split("/");
+
+            try {
+                String str=new String();
+                for (int i=0; i<fpArray.length; i++){
+                    str += URLEncoder.encode(fpArray[i], "UTF-8") + "/";
+                }
+                return str;
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+            return null;
+    }
     @Override
     public IbeDataParam makeDataParam(Map<String, String> pathInfo) {
         IbeDataParam dataParam = new IbeDataParam();
 
-        String fname = pathInfo.get("fname");
+        String fname = getEncodedFileName( pathInfo.get("fname") );
 
         String root = getImageRoot();
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FinderChartRequestUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FinderChartRequestUtil.java
@@ -94,12 +94,11 @@ public class FinderChartRequestUtil {
      * Expected format :  metadata expected to be as "schema.table-band;title"
      */
     private final static String akariCombo[]={
-            "akari.images_tbl:N60;FIS N60 (65 micron)",
-            "akari.images_tbl:WideS;FIS WideS (90 micron)",
-            "akari.images_tbl:WideL;FIS WideL (140 micron)",
-            "akari.images_tbl:N160;FIS N160 (160 micron)"
+            "akari.akari_images:N60;FIS N60 (65 micron);file_type='science'",
+            "akari.akari_images:WideS;FIS WideS (90 micron);file_type='science'",
+            "akari.akari_images:WideL;FIS WideL (140 micron);file_type='science'",
+            "akari.akari_images:N160;FIS N160 (160 micron);file_type='science'"
     };
-
     private final static String sDssCombo[]={
             "u;u","g;g","r;r","i;i","z;z"
     };


### PR DESCRIPTION
1. This is the Firefly branch.   The changes are:
- Encoded  fileName that is used for form the  url to fetch the image
- Corrected definition of the akariCombo array in te FinderchartRequstUtil to make the download FITS, PNG, HTML and PDF work

2. The same branch in IFE, please find it in the server. The changes are:
- Add Akari
- Solved the merge conflict with IRSA-810

  

To test it, 
http://localhost:8080/applications/finderchart/
using m81 for target