### PR TITLE
DM-11374 Disable position search on catalogs/tables without position information

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatMasterTableQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatMasterTableQuery.java
@@ -64,7 +64,8 @@ public class CatMasterTableQuery extends IpacTablePartProcessor {
     private static File getMasterCatalogFile(TableServerRequest request) throws IOException, DataAccessException {
         File retval;
         try {
-            String colNames = "projectshort, subtitle, description, server, catname, cols, nrows, coneradius, infourl, ddlink";
+            // pos column is added to indicate if the catalog contains position information.
+            String colNames = "projectshort, subtitle, description, server, catname, cols, nrows, coneradius, infourl, ddlink, pos";
             File catOutFile = MASTER_CAT_FILE;
 
             // if hydra, check for additional catalogs

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -137,7 +137,7 @@ const spatialSelection = (withPos, polyIsDef, searchOption) => {
                 Method Search:
             </div>
             <div style={{paddingLeft: 4}}>
-                {'All Sky'}
+                All Sky
             </div>
         </div>
     );
@@ -344,7 +344,7 @@ function sizeArea(searchType, imageCornerCalc) {
         return (
 
             <div style={{border: '1px solid #a3aeb9', padding:'30px 30px', whiteSpace: 'pre-line'}}>
-                {'Search the catalog with no spatial constraints'}
+                Search the catalog with no spatial constraints
             </div>
         );
     }

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -142,7 +142,7 @@ function doCatalog(request) {
     const catPart= request[gkey];
     const spacPart= request[gkeySpacial];
     const {catalog, project, cattable}= catPart;
-    const {spatial}= spacPart;
+    const {spatial='AllSky'}= spacPart;  // if there is no 'spatial' field (catalog with no position information case)
 
     const conesize = convertAngle('deg', 'arcsec', spacPart.conesize);
     var title = `${catPart.project}-${catPart.cattable}`;
@@ -639,11 +639,13 @@ class CatalogDDList extends PureComponent {
         const optList = getSubProjectOptions(catmaster, selProj);
         const catTable = getCatalogOptions(catmaster, selProj, selCat).option;
 
+
         //HERE HERE HERE
         const currentIdx = get(fields, 'cattable.indexClicked', 0);
         const radius = parseFloat(catTable[currentIdx].cat[RADIUS_COL]);
         const coneMax= radius / 3600;
         const boxMax= coneMax*2;
+
         //HERE HERE HERE
 
         let catname0 = get(FieldGroupUtils.getGroupFields(gkey), 'cattable.value', catTable[0].value);
@@ -659,6 +661,13 @@ class CatalogDDList extends PureComponent {
 
         const polygonDefWhenPlot= get(getAppOptions(), 'catalogSpacialOp')==='polygonWhenPlotExist';
 
+        // for 'pos' column
+        const POS_COL = master.cols.findIndex((oneCol) => {
+            const colName = get(oneCol, 'name', '');
+            return (colName && (colName.toLowerCase() === 'pos'));
+        });
+        const posVal = POS_COL >= 0 ? get(catTable, [currentIdx, 'cat', POS_COL], 'n').toLowerCase() : 'n';
+        const withPos = posVal.includes('y');
 
         return (
             <div>
@@ -694,7 +703,8 @@ class CatalogDDList extends PureComponent {
                     </div>
                     <div className='spatialsearch' style={catPanelStyle}>
                         <CatalogSearchMethodType groupKey={gkeySpacial} polygonDefWhenPlot={polygonDefWhenPlot}
-                                                 coneMax={coneMax} boxMax={boxMax} />
+                                                 coneMax={coneMax} boxMax={boxMax} withPos={withPos}
+                        />
                     </div>
                 </div>
                 {/*

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -666,8 +666,8 @@ class CatalogDDList extends PureComponent {
             const colName = get(oneCol, 'name', '');
             return (colName && (colName.toLowerCase() === 'pos'));
         });
-        const posVal = POS_COL >= 0 ? get(catTable, [currentIdx, 'cat', POS_COL], 'n').toLowerCase() : 'n';
-        const withPos = posVal.includes('y');
+
+        const withPos = (get(catTable, [currentIdx, 'cat', POS_COL]) || 'y').includes('y');
 
         return (
             <div>

--- a/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
@@ -105,7 +105,7 @@ function imagePlotOnSurvey(crtCatalogId, request) {
     var band = get(request, keyMap[b]);
     var sizeInDeg = parseFloat(request[keyMap['sizefield']]);
     // TODO This should go soon by using 'principal' and file_type in IbeDataSource server side:
-    var filter = `file_type='science' and fname like '%.mosaic.fits'`; //extra filter?
+    var filter = 'file_type= \'science\' and fname like \'%.mosaic.fits\''; //extra filter?
     var xtraFilter = getPanelCatalogs()[crtCatalogId].Symbol.toLowerCase();
     var wpr = null;
 

--- a/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
@@ -105,7 +105,7 @@ function imagePlotOnSurvey(crtCatalogId, request) {
     var band = get(request, keyMap[b]);
     var sizeInDeg = parseFloat(request[keyMap['sizefield']]);
     // TODO This should go soon by using 'principal' and file_type in IbeDataSource server side:
-    var filter = 'file_type= \'science\' and fname like \'%.mosaic.fits\''; //extra filter?
+    var filter = "file_type='science' and fname like '%.mosaic.fits'"; //extra filter?
     var xtraFilter = getPanelCatalogs()[crtCatalogId].Symbol.toLowerCase();
     var wpr = null;
 


### PR DESCRIPTION
The development includes: 
- Include col 'pos' for catalog master table, only 'all sky' is searched in case the catalog/table has no position information. (value at column 'pos' is 'n' instead of 'y')
- replace the select/option tag for spatial search with 'All Sky' text at the spatial selection panel for the catalog/table without position information.  

test:
go to localhost:8080/firefly and do catalog search 
If a table with position information is selected,  the position search method option list is shown at position search area and ready for selection. 
If a table without position information is selected (i.e. Select Project: 'Gaia', Select Catalog: 'Gaia DR1 Database', table: 'Gaia G-band Time Series of Variable Sources'), the position search is disabled and only 'All sky' is searched in default. 

