### PR TITLE
DM-11341: exception creating firefly Jupyter widget

### DIFF
--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -164,17 +164,12 @@ task prepareWebapp (type:Copy, dependsOn: [gwt, loadConfig, createVersionTag]) {
     filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: project.appConfigProps)
   }
   doLast {
-    def plotlyFiles = fileTree(dir: "${buildDir}/war/", include: 'plotly*min.js')
-    plotlyFiles.each { File file ->
-      // plotly script load fails if loaded from amd environment
-      // with a script tag (as firefly loads it)
-      println ">> updating $file"
-      def resPlotly = exec {
-        commandLine "sed", '-i', '', 's/\\&\\&define\\.amd/\\&\\&false/', "$file"
-      }
-      if (resPlotly.getExitValue() != 0) {
-        throw new GradleException("Failed to update $file")
-      }
+    // plotly script load fails if loaded from amd environment
+    // with a script tag (as firefly loads it)
+    // see DM-11341 for details
+    println ">> updating plotly script"
+    ant.replaceregexp(match:'\\&\\&define\\.amd', replace:'\\&\\&false', flags:'g', byline:true) {
+      fileset(dir: "${buildDir}/war/", includes: 'plotly*min.js')
     }
   }
 }

--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -163,6 +163,20 @@ task prepareWebapp (type:Copy, dependsOn: [gwt, loadConfig, createVersionTag]) {
 
     filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: project.appConfigProps)
   }
+  doLast {
+    def plotlyFiles = fileTree(dir: "${buildDir}/war/", include: 'plotly*min.js')
+    plotlyFiles.each { File file ->
+      // plotly script load fails if loaded from amd environment
+      // with a script tag (as firefly loads it)
+      println ">> updating $file"
+      def resPlotly = exec {
+        commandLine "sed", '-i', '', 's/\\&\\&define\\.amd/\\&\\&false/', "$file"
+      }
+      if (resPlotly.getExitValue() != 0) {
+        throw new GradleException("Failed to update $file")
+      }
+    }
+  }
 }
 
 

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -57,6 +57,7 @@ export function loadScript(scriptName) {
             const head= document.getElementsByTagName('head')[0];
             const script= document.createElement('script');
             script.type= 'text/javascript';
+            script.charset= 'utf-8';
             script.src= scriptName;
             head.appendChild(script);
             script.onload= (ev) => resolve(ev);


### PR DESCRIPTION
Jira ticket: https://jira.lsstcorp.org/browse/DM-11341

This is the firefly part of DM-11341: exception when creating Jupyter widgets. The exception is caused by unsuccessful loading of the minified plotly script ([plotly-1.28.2.min.js](http://irsa.ipac.caltech.edu:80/irsaviewer/plotly-1.28.2.min.js))

Since jupyter widgets are defined as AMD modules, plotly assumes that we are loading it in AMD/RequireJS context: if("function"==typeof define&&define.amd)define([],t), which results in anonymous define error and Plotly not being loaded. According to webpack docs, the bundle with undefined library name, like this, "will not work as expected, or not work at all (in the case of the almond loader) if loaded directly with a <script> tag." (See Module Definition Systems [here](https://webpack.js.org/configuration/output/)) Please note, that firefly does load plotly with a <script> tag. 

The proposed solution is to modify the plotly script in the firefly-based project deployments to never load it as an AMD module.

Another modification is to avoid preloading plotly on application start. It will only be loaded when first requested.

The additional pull request for firefly_widgets is [here](https://github.com/Caltech-IPAC/firefly_widgets/pull/7)