### PR TITLE
IRSA-748: Replace image search with new ImageSearchPanelV2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,7 @@
     "react/no-did-update-set-state": 1,
     "react/no-direct-mutation-state": 1,
     "react/no-unknown-property": 1,
-    "react/prop-types": [1, {"ignore": ["children"]}],
+    "react/prop-types": [1, {"ignore": ["children"], "skipUndeclared": true}],
     "react/react-in-jsx-scope": 1,
     "react/self-closing-comp": 1,
     "react/wrap-multilines": 1,

--- a/src/firefly/html/firefly-dev.html
+++ b/src/firefly/html/firefly-dev.html
@@ -15,7 +15,8 @@
                 template: 'FireflyViewer',
                 options : {
                     MenuItemKeys: {maskOverlay:true},
-                    workspace : {showOptions: true}
+                    workspace : {showOptions: true},
+                    imageMasterSourcesOrder: ['WISE', '2MASS', 'Spitzer']
                 }
             },
         };

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
@@ -126,7 +126,7 @@ public class VisServerCommands {
             }
 
 
-            data.put("success", true);
+//            data.put("success", true);
 
             JSONArray wrapperAry= new JSONArray();
             obj.put("data", data);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -111,6 +111,7 @@ public class ImagePlotCreator {
                 if (state.isThreeColor()) {
                     plot.setThreeColorBand(state.isBandVisible(band) ? readInfo.getFitsRead() :null,
                             band,frGroup);
+                    stretchBand(band,state,plot,frGroup);
                 }
                 if (readInfo.getModFileWriter()!=null) fileWriterMap.put(band,readInfo.getModFileWriter());
                 first= false;
@@ -209,13 +210,19 @@ public class ImagePlotCreator {
             FitsCacher.addFitsReadToCache(retval.getTargetFile(), new FitsRead[]{tmpFR});
         }
 
-        RangeValues rv= state.getRangeValues(readInfo.getBand());
+        stretchBand(band,state, plot,frGroup);;
+        return retval;
+    }
+
+    private static void stretchBand(Band band, PlotState state, ImagePlot plot, ActiveFitsReadGroup frGroup) {
+        RangeValues rv= state.getRangeValues(band);
+        HistogramOps histOps= plot.getHistogramOps(band,frGroup);
         if (rv==null) {
             rv= FitsRead.getDefaultFutureStretch();
-            state.setRangeValues(rv, readInfo.getBand());
+            state.setRangeValues(rv, band);
         }
         histOps.recomputeStretch(rv, true);
-        return retval;
+
     }
 
     private static void initPlotTitle(PlotState state,

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imagesources/ImageMasterData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imagesources/ImageMasterData.java
@@ -10,9 +10,14 @@ import edu.caltech.ipac.firefly.server.util.Logger;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static edu.caltech.ipac.firefly.server.visualize.imagesources.ImageMasterDataEntry.PARAMS.MISSION_ID;
 
 /**
  * @author Trey Roby
@@ -32,33 +37,43 @@ public class ImageMasterData {
     private static final Logger.LoggerImpl _log= Logger.getLogger();
 
     /**
-     *
      * @param imageSources - this list of sources of image data, A source string should be a memter of the sources map
-     * @param sortOrder the results should be sorted by project in the as the sortOrder any project not listed in
-     *                  the sortOrder array can just be put on bottom
+     * @param sortOrder    the results should be sorted by project in the as the sortOrder any project not listed in
+     *                     the sortOrder array can just be put on bottom
      * @return an array of JSONObject each is a image source
      */
     public static JSONArray getJson(String imageSources[], String sortOrder[]) {
 
-        // todo implement the sortOrder parameter
-
-
-        String workingSources[]= imageSources;
-        if (imageSources==null || imageSources.length==0 ||
-                 (imageSources.length==1 && imageSources[0].equalsIgnoreCase(ServerParams.ALL))) {
-            workingSources= sources.keySet().toArray(new String [10]);
+        String workingSources[] = imageSources;
+        if (imageSources == null || imageSources.length == 0 ||
+                (imageSources.length == 1 && imageSources[0].equalsIgnoreCase(ServerParams.ALL))) {
+            workingSources = sources.keySet().toArray(new String[10]);
         }
 
-
-        JSONArray jsonData= new JSONArray();
-        for(String source : workingSources) {
-            if (sources.get(source)!=null) {
-                List<ImageMasterDataEntry> sourceData= sources.get(source).getImageMasterData();
-                if (sourceData!=null) {
-                    for( ImageMasterDataEntry sd : sourceData) jsonData.add(makeJsonObj(sd.getDataMap()));
-                }
-
+        List<ImageMasterDataEntry> allSourceData = new ArrayList<>();
+        for (String source : workingSources) {
+            ImageMasterDataSourceType imds = sources.get(source);
+            if (imds != null) {
+                List<ImageMasterDataEntry> imd = imds.getImageMasterData();
+                if (imd != null) allSourceData.addAll(imds.getImageMasterData());
             }
+        }
+
+        // do sort if requested
+        if (sortOrder != null && sortOrder.length > 0) {
+            List<String> orders = Arrays.asList(sortOrder);
+            Collections.sort(allSourceData, (e1, e2) -> {
+                int e1Order = orders.indexOf(e1.getParamString(MISSION_ID));
+                e1Order = e1Order < 0 ? Integer.MAX_VALUE : e1Order;
+                int e2Order = orders.indexOf(e2.getParamString(MISSION_ID));
+                e2Order = e2Order < 0 ? Integer.MAX_VALUE : e2Order;
+                return Integer.compare(e1Order, e2Order);
+            });
+        }
+
+        JSONArray jsonData = new JSONArray();
+        for (ImageMasterDataEntry sd : allSourceData) {
+            jsonData.add(makeJsonObj(sd.getDataMap()));
         }
         return jsonData;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imagesources/ImageMasterDataEntry.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imagesources/ImageMasterDataEntry.java
@@ -52,8 +52,15 @@ public class ImageMasterDataEntry {
     public void setPlotRequestParams(Map<String,String> params) { map.put(PLOT_REQUEST_PARAMS, params);}
 
 
-    public void set(PARAMS key, String val){map.put(key.getKey(), val);}
+    public String getParamString(PARAMS key) {
+        if (key != null) {
+            Object v = map.get(key.getKey());
+            return  v == null ? null : v.toString();
+        }
+        return null;
+    }
 
+    public void set(PARAMS key, String val){map.put(key.getKey(), val);}
 
     public Map<String,Object> getDataMap() {
         return map;

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -334,7 +334,7 @@ function makePlotSimple(llApi, plotId) {
 
 function showImageInMultiViewer(llApi, targetDiv, request) {
     const {dispatchPlotImage, dispatchAddViewer, dispatchAddImages}= llApi.action;
-    const {findInvalidWPRKeys,confirmPlotRequest}= llApi.util.image;
+    const {findInvalidWPRKeys,confirmPlotRequest, IMAGE, NewPlotMode}= llApi.util.image;
     const {renderDOM,debug, getWsConnId, getWsChannel}= llApi.util;
     const {MultiImageViewer, MultiViewStandardToolbar}= llApi.ui;
 
@@ -347,10 +347,10 @@ function showImageInMultiViewer(llApi, targetDiv, request) {
     request= confirmPlotRequest(request,globalImageViewDefParams,targetDiv,makePlotId(getWsConnId));
 
     const plotId= !Array.isArray(request) ? request.plotId : request.find( (r) => r.plotId).plotId;
-    dispatchAddViewer(targetDiv,'create_replace');
+    dispatchAddViewer(targetDiv, NewPlotMode.create_replace.key, IMAGE);
     dispatchPlotImage({plotId, wpRequest:request, viewerId:targetDiv});
     renderDOM(targetDiv, MultiImageViewer,
-        {viewerId:targetDiv, canReceiveNewPlots:'create_replace', Toolbar:MultiViewStandardToolbar });
+        {viewerId:targetDiv, canReceiveNewPlots:NewPlotMode.create_replace.key, Toolbar:MultiViewStandardToolbar });
 
 }
 
@@ -358,10 +358,10 @@ function initCoverage(llApi, targetDiv,options= {}) {
     const {MultiImageViewer, MultiViewStandardToolbar}= llApi.ui;
     const {dispatchAddSaga}= llApi.action;
     const {renderDOM,debug}= llApi.util;
-    const {watchImageMetaData,watchCoverage}= llApi.util.image;
+    const {watchImageMetaData,watchCoverage,NewPlotMode}= llApi.util.image;
     highlevelImageInit(llApi);
 
-    const {canReceiveNewPlots='create_replace'}= options;
+    const {canReceiveNewPlots=NewPlotMode.replace_only.key}= options;
 
 
     renderDOM(targetDiv, MultiImageViewer,

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -50,6 +50,8 @@ export {getSelectedRegion} from '../drawingLayers/RegionPlot.js';
 export {extensionAdd, extensionRemove} from '../core/ExternalAccessUtils.js';
 export {makeWorldPt, makeScreenPt, makeImagePt, parsePt} from '../visualize/Point.js';
 
+export {IMAGE, NewPlotMode} from '../visualize/MultiViewCntlr';
+
 
 /**
  * Get plot object with the given plot id, when plotId is not included, active plot is returned.

--- a/src/firefly/js/core/background/BackgroundMonitor.jsx
+++ b/src/firefly/js/core/background/BackgroundMonitor.jsx
@@ -143,7 +143,6 @@ function SearchItem(bgStatus) {
     );
 }
 
-// eslint-disable-next-line
 function SearchStatus({ID, STATE, Title, SERVER_REQ}) {
     var progress;
     if (BG_STATE.WAITING.is(STATE)) {
@@ -185,7 +184,6 @@ function PackageStatus(bgStatus) {
     );
 }
 
-// eslint-disable-next-line
 function SinglePackage({ID, Title, STATE, ITEMS=[]}) {
     var progress;
     if (BG_STATE.WAITING.is(STATE)) {
@@ -203,7 +201,6 @@ function SinglePackage({ID, Title, STATE, ITEMS=[]}) {
     );
 }
 
-// eslint-disable-next-line
 function MultiPackage({ID, Title, STATE, ITEMS}) {
     var progress = BG_STATE.CANCELED.is(STATE) && <div>User aborted this request</div>;
     const packages = ITEMS.map( (pi, INDEX) => {
@@ -220,7 +217,6 @@ function MultiPackage({ID, Title, STATE, ITEMS}) {
     );
 }
 
-// eslint-disable-next-line
 function PackageHeader({ID, Title, progress, STATE}) {
     const removeBgStatus = () => {
         dispatchJobRemove(ID);

--- a/src/firefly/js/rpc/PlotServicesJson.js
+++ b/src/firefly/js/rpc/PlotServicesJson.js
@@ -185,9 +185,10 @@ export function callGetImageMasterData(imageSources, projectSortOrder='') {
     const sortOrderStr= isArray(projectSortOrder) ? projectSortOrder.join(',') : projectSortOrder.toString();
     const imageSourcesStr= isArray(imageSources) ? imageSources.join(',') : imageSources.toString();
     return doJsonRequest(ServerParams.GET_IMAGE_MASTER_DATA,
-        {[ServerParams.IMAGE_SOURCES] : imageSourcesStr},
-        {[ServerParams.SORT_ORDER] : sortOrderStr},
-        true);
+                {[ServerParams.IMAGE_SOURCES] : imageSourcesStr,
+                 [ServerParams.SORT_ORDER] : sortOrderStr
+                },
+                true);
 }
 
 export function getDS9Region(fileKey) {

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -221,8 +221,6 @@ BasicTableView.defaultProps = {
 };
 
 
-// components here on down are private.  not all props are defined.
-/* eslint-disable react/prop-types */
 const TextView = ({columns, data, showUnits, widthPx, heightPx}) => {
     const text = tableTextView(columns, data, showUnits);
     return (

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -263,7 +263,6 @@ TablePanel.defaultProps = {
     pageSize: 100
 };
 
-// eslint-disable-next-line
 function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons}) {
     const style = {display: 'flex'};
     if (leftButtons) {
@@ -277,7 +276,6 @@ function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons}) {
     );
 }
 
-// eslint-disable-next-line
 function Title({title, removable, tbl_id}) {
     return (
         <div className='TablePanel__title'>
@@ -292,7 +290,6 @@ function Title({title, removable, tbl_id}) {
     );
 }
 
-// eslint-disable-next-line
 function Loading({showTitle, tbl_id, title, removable, bgStatus}) {
     const toBg = () => {
         dispatchTblResultsRemove(tbl_id);

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -19,9 +19,6 @@ import FILTER_SELECTED_ICO from 'html/images/icons-2014/16x16_Filter.png';
 const {Cell} = FixedDataTable;
 const html_regex = /<.+>/;
 
-// the components here are small and used by table only.  not all props are defined.
-/* eslint-disable react/prop-types */
-
 /*---------------------------- COLUMN HEADER RENDERERS ----------------------------*/
 function Label({sortable, label, name, sortByCols, sortInfoCls, onSort}) {
     const sortDir = sortInfoCls.getDirection(name);

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -74,7 +74,6 @@ TablesContainer.defaultProps = {
 
 
 function ExpandedView(props) {
-    // eslint-disable-next-line
     const {tables, closeable} = props;
     return (
         <div style={{ display: 'flex', height: '100%', flexGrow: 1, flexDirection: 'column', overflow: 'hidden'}}>
@@ -95,7 +94,6 @@ function ExpandedView(props) {
 
 
 function StandardView(props) {
-    // eslint-disable-next-line
     const {tables, tableOptions, expandedMode, active, tbl_group} = props;
 
     var activeIdx = Object.keys(tables).findIndex( (tbl_ui_id) => get(tables,[tbl_ui_id,'tbl_id']) === active);
@@ -116,7 +114,6 @@ function StandardView(props) {
     }
 }
 
-// eslint-disable-next-line
 function SingleTable({table, tableOptions, expandedMode}) {
     var {tbl_id, title, removable, tbl_ui_id, options={}} = table;
 

--- a/src/firefly/js/templates/fireflyviewer/ResultsPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/ResultsPanel.jsx
@@ -50,7 +50,6 @@ ResultsPanel.propTypes = {
 };
 
 
-// eslint-disable-next-line
 const ExpandedView = ({expanded, imagePlot, xyPlot, tables}) => {
     const view = expanded === LO_VIEW.tables ? tables
                 : expanded === LO_VIEW.xyPlots ? xyPlot
@@ -63,7 +62,6 @@ const ExpandedView = ({expanded, imagePlot, xyPlot, tables}) => {
 };
 
 
-// eslint-disable-next-line
 const StandardView = ({visToolbar, title, searchDesc, standard, imagePlot, xyPlot, tables}) => {
     standard = LO_VIEW.get(standard) || LO_VIEW.none;
     const components = resolveComponents(standard, imagePlot, xyPlot, tables);

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -34,7 +34,6 @@ export class TriViewPanel extends PureComponent {
     }
 
     render() {
-        // eslint-disable-next-line
         const {showViewsSwitch, leftButtons, centerButtons, rightButtons} = this.props;
         const {title, mode, showTables, showImages, showXyPlots, images={}} = this.state;
         const {expanded, standard, closeable} = mode || {};
@@ -91,7 +90,6 @@ TriViewPanel.defaultProps = {
 };
 
 
-// eslint-disable-next-line
 function searchDesc({viewSwitch, leftButtons, centerButtons, rightButtons}) {
 
     const hasContent = viewSwitch || leftButtons || centerButtons || rightButtons;

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -106,7 +106,6 @@ export class LcResult extends PureComponent {
     }
 }
 
-// eslint-disable-next-line
 const ExpandedView = ({expanded, imagePlot, xyPlot, tables}) => {
     const view = expanded === LO_VIEW.tables ? tables
         : expanded === LO_VIEW.xyPlots ? xyPlot
@@ -118,7 +117,6 @@ const ExpandedView = ({expanded, imagePlot, xyPlot, tables}) => {
 
 const buttonW = 650;
 
-// eslint-disable-next-line
 const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables, settingBox}) => {
 
     const converterId = get(settingBox, ['props', 'missionEntries', LC.META_MISSION]);

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -10,7 +10,7 @@ import {get, pick} from 'lodash';
 import {getDropDownInfo} from '../core/LayoutCntlr.js';
 import {flux, getVersion} from '../Firefly.js';
 import {SearchPanel} from '../ui/SearchPanel.jsx';
-import {ImageSearchPanelV2} from '../visualize/ui/ImageSearchPanelV2.jsx';
+import {ImageSearchDropDown} from '../visualize/ui/ImageSearchPanelV2.jsx';
 import {TestSearchPanel} from '../ui/TestSearchPanel.jsx';
 import {TestQueriesPanel} from '../ui/TestQueriesPanel.jsx';
 import {ImageSelectDropdown} from '../ui/ImageSelectDropdown.jsx';
@@ -27,9 +27,9 @@ export const dropDownMap = {
     Search: <SearchPanel />,
     TestSearch: <TestSearchPanel />,
     TestSearches: <TestQueriesPanel />,
-    ImageSearchPanelV2: <ImageSearchPanelV2/>,
-    ImageSelectDropDownCmd: <ImageSelectDropdown />,
-    ImageSelectDropDownSlateCmd: <ImageSelectDropdown gridSupport={true}/>,
+    ImageSearchPanelV2: <ImageSearchDropDown/>,
+    ImageSelectDropDownCmd: <ImageSearchDropDown/>,
+    ImageSelectDropDownSlateCmd: <ImageSearchDropDown gridSupport={true}/>,
     ChartSelectDropDownCmd: <ChartSelectDropdown />,
     IrsaCatalogDropDown: <CatalogSelectViewPanel/>,
     LsstCatalogDropDown: <LSSTCatalogSelectViewPanel/>,

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -53,8 +53,9 @@ function createSuccessHandler(action, params={}, title, onSubmit) {
 }
 
 export const FormPanel = function (props) {
-    var {children, onSuccess, onSubmit, onCancel, onError, groupKey, action, params, title, style, inputStyle,
-        submitText='Search', help_id, changeMasking, includeUnmounted=false} = props;
+    const { children, onSuccess, onSubmit, onCancel=dispatchHideDropDown, onError, groupKey,
+            action, params, title, style, inputStyle, submitBarStyle,
+            submitText='Search', help_id, changeMasking, includeUnmounted=false} = props;
 
     const childrenStyle = Object.assign({
         backgroundColor: 'white',
@@ -64,15 +65,15 @@ export const FormPanel = function (props) {
         boxSizing: 'border-box',
         flexGrow: 1
     }, inputStyle);
-    onCancel = onCancel || dispatchHideDropDown;
     const mStyle = Object.assign({height: '100%', display:'flex', flexDirection: 'column', boxSizing: 'border-box'}, style);
-
+    const barStyle = Object.assign({flexGrow: 0, display: 'inline-flex', justifyContent: 'space-between', boxSizing: 'border-box',
+                                  width: '100%', alignItems: 'flex-end', padding:'2px 0px 3px'}, submitBarStyle);
     return (
         <div style={mStyle}>
             <div style={childrenStyle}>
                 {children}
             </div>
-            <div style={{flexGrow: 0, display: 'inline-flex', justifyContent: 'space-between', width: '100%', alignItems: 'flex-end', padding:'2px 0px 3px'}}>
+            <div style={barStyle}>
                 <div>
                     <CompleteButton style={{display: 'inline-block', marginRight: 10}}
                                     includeUnmounted={includeUnmounted}
@@ -101,6 +102,7 @@ FormPanel.propTypes = {
     title: PropTypes.string,
     style: PropTypes.object,
     inputStyle: PropTypes.object,
+    submitBarStyle: PropTypes.object,
     onSubmit: PropTypes.func, // onSubmit(request) - callback that accepts table request, use with action, params, and title props
     onSuccess: PropTypes.func, // onSuccess(fields) - callback that takes fields object, its keys are the field keys for fields in the given group
     onCancel: PropTypes.func,

--- a/src/firefly/js/ui/ImageSelect.css
+++ b/src/firefly/js/ui/ImageSelect.css
@@ -1,15 +1,41 @@
 .ImageSelect {
-    display: inline-flex;
+    display: flex;
+    flex-direction: column;
+    background-color: #f5f5f5;
 }
 
-.ImageSelect > * {
+.ImageSelect__panels {
+    display: flex;
     box-shadow: 0 1px 3px 0 rgba(0,0,0,0.16), 0 0 0 1px rgba(0,0,0,0.04);
     transition: box-shadow .3s ease-in-out;
     background-color: #fff;
-    border-radius: 2px;
-    margin: 2px;
+    border-bottom-right-radius: 2px;
+    border-bottom-left-radius: 2px;
     outline: none;
 }
+
+.ImageSelect__info {
+    color: saddlebrown;
+    font-style: italic;
+    font-size: smaller;
+    padding: 0 4px 2px;
+}
+
+.ImageSelect__title {
+    font-weight: bold;
+    padding: 4px;
+}
+
+.ImageSelect__toolbar {
+    flex-grow: 0;
+    background-color: #f5f5f5;
+    height: 15px;
+    min-height: 15px;
+    padding: 3px 6px;
+    display: inline-flex;
+    justify-content: space-between;
+}
+
 
 .FilterPanel {
     flex-grow: 0;
@@ -18,22 +44,8 @@
     flex-direction: column;
 }
 
-.FilterPanel__toolbar {
-    flex-grow: 0;
-    background-color: #f5f5f5;
-    border-bottom: solid 1px #f1f1f1;
-    height: 15px;
-    min-height: 15px;
-    color: #005da4;
-    font-size: larger;
-    font-weight: bold;
-    padding: 3px
-}
-
 .FilterPanel__view {
-    padding: 5px;
     flex-grow: 1;
-    overflow: auto;
     overflow: auto;
     margin-right: -2px;
 }
@@ -60,15 +72,6 @@
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-}
-
-.DataProductList__toolbar {
-    flex-grow: 0;
-    background-color: #f5f5f5;
-    border-bottom: solid 1px #f1f1f1;
-    height: 15px;
-    min-height: 15px;
-    padding: 3px
 }
 
 .DataProductList__view {

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -261,7 +261,7 @@ function DataProductList({filteredImageData, groupKey, multiSelect, onChange}) {
                                                   .map((o) => o.label).join() )                 // takes the label of the selected field
                             .join();
     let content;
-    if (projects.length > 1) {
+    if (projects.length > 0) {
         content = projects.map((p) => <DataProduct key={p} {...{groupKey, project:p, filteredImageData, multiSelect}}/>);
     } else {
         content = (

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -74,7 +74,7 @@ ImageSelect.propTypes = {
 const toFilterSelectAry = (groupKey, s) => getFieldVal(groupKey, `Filter_${s}`, '').split(',').map((d) => d.trim()).filter((d) => d);
 
 
-function doWhenValueChanged(fieldKey, inFields, value) {
+function doWhenValueChanged(fieldKey='', inFields, value) {
     if (fieldKey.startsWith('PROJ_ALL_')) {
         // a project checkbox is clicked
         const proj = fieldKey.replace('PROJ_ALL_', '');
@@ -114,7 +114,6 @@ function fieldsReducer(inFields, action) {
 }
 
 
-// eslint-disable-next-line
 function ToolBar({filteredImageData, groupKey, onChange}) {
     const projects= uniqBy(filteredImageData, 'project').map( (d) => d.project);
     const setDSListMode = (flg) => {
@@ -146,7 +145,6 @@ function ToolBar({filteredImageData, groupKey, onChange}) {
 }
 
 /*--------------------------- Filter Panel ---------------------------------------------*/
-// eslint-disable-next-line
 function FilterPanel({imageMasterData, groupKey, onChange}) {
     const allSelect = Object.values(FieldGroupUtils.getGroupFields(groupKey))
         .filter( (f) => get(f, 'fieldKey','').startsWith('Filter_'))
@@ -162,7 +160,6 @@ function FilterPanel({imageMasterData, groupKey, onChange}) {
     );
 }
 
-// eslint-disable-next-line
 function FilterPanelView({onChange, imageMasterData}) {
     const forSummary = uniqBy(imageMasterData, (t) => `${t.missionId};${t.project}`);
     const missions = toFilterSummary(forSummary, 'missionId', 'missionId');
@@ -203,7 +200,6 @@ class FilterSelect extends PureComponent {
     }
 
     render() {
-        // eslint-disable-next-line
         const {type, dataList, onChange, maxShown=3} = this.props;
         const {showExpanded} = this.state;
         const fieldKey= `Filter_${type}`;
@@ -239,7 +235,6 @@ class FilterSelect extends PureComponent {
 }
 
 // save in case we want to do it this way
-// eslint-disable-next-line
 function FilterSelectExpanded({selections, onClose}) {
     return (
         <div className='FilterPanel__item--exp'>
@@ -265,7 +260,6 @@ const toFilterSummary = (master, key, desc) => Object.entries(countBy(master, (d
 
 /*--------------------------- Data Product List ---------------------------------------*/
 
-// eslint-disable-next-line
 function DataProductList({filteredImageData, groupKey, multiSelect, onChange}) {
     const projects= uniqBy(filteredImageData, 'project').map( (d) => d.project);
 
@@ -295,7 +289,6 @@ function DataProductList({filteredImageData, groupKey, multiSelect, onChange}) {
     );
 }
 
-// eslint-disable-next-line
 function DataProduct({groupKey, project, filteredImageData, multiSelect}) {
 
     // filter projects ... projects is like dataproduct or dataset.. i.e SEIP
@@ -348,7 +341,6 @@ const hasImageSelection = (groupKey, proj) => {
 };
 
 
-// eslint-disable-next-line
 function BandSelect({groupKey, subProject, projectData, labelMaxWidth, multiSelect}) {
     subProject = isNil(subProject) ? '' : subProject;
     const fieldKey= `IMAGES_${get(projectData, [0, 'project'])}||${subProject}`;

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -74,7 +74,8 @@ ImageSelect.propTypes = {
 const toFilterSelectAry = (groupKey, s) => getFieldVal(groupKey, `Filter_${s}`, '').split(',').map((d) => d.trim()).filter((d) => d);
 
 
-function doWhenValueChanged(fieldKey='', inFields, value) {
+function fieldsReducer(inFields, action) {
+    const {fieldKey='', value=''} = action.payload;
     if (fieldKey.startsWith('PROJ_ALL_')) {
         // a project checkbox is clicked
         const proj = fieldKey.replace('PROJ_ALL_', '');
@@ -103,16 +104,6 @@ function doWhenValueChanged(fieldKey='', inFields, value) {
     return inFields;
 }
 
-function fieldsReducer(inFields, action) {
-    const {fieldKey='', fieldAry, value=''} = action.payload;
-    if (fieldKey) {
-        return (doWhenValueChanged(fieldKey, inFields, value));
-    } else if (get(fieldAry, 'length')) {
-        inFields = fieldAry.reduce( (p, f) => doWhenValueChanged(f.fieldKey, p, f.value), inFields);
-    };
-    return inFields;
-}
-
 
 function ToolBar({filteredImageData, groupKey, onChange}) {
     const projects= uniqBy(filteredImageData, 'project').map( (d) => d.project);
@@ -120,9 +111,9 @@ function ToolBar({filteredImageData, groupKey, onChange}) {
         projects.forEach((k) => dispatchComponentStateChange(k, {isOpen:flg}));
         onChange && onChange();
     };
-    const clearFields = (type) => {
+    const clearFields = (types) => {
         const fields = Object.values(FieldGroupUtils.getGroupFields(groupKey))
-                            .filter( (f) => get(f, 'fieldKey','').startsWith(type))
+                            .filter( (f) => types.some( (t) => get(f, 'fieldKey','').startsWith(t)))
                             .filter( (f) => get(f, 'value'));        // look for all selected filters
         if (fields.length > 0) {
             fields.forEach((f) => f.value = '');
@@ -133,10 +124,10 @@ function ToolBar({filteredImageData, groupKey, onChange}) {
     return (
         <div className='ImageSelect__toolbar'>
             <div>
-                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => clearFields('Filter_')}>Clear Filters</a>
+                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => clearFields(['Filter_'])}>Clear Filters</a>
             </div>
             <div>
-                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => clearFields('IMAGES_')}>Clear Selections</a>
+                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => clearFields(['IMAGES_', 'PROJ_ALL_'])}>Clear Selections</a>
                 &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => setDSListMode(true)}>Expand All</a>
                 &bull;<a className='ff-href' onClick={() => setDSListMode(false)}>Collapse All</a>
             </div>

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -4,13 +4,14 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {uniqBy, uniq, get, countBy, isNil, xor, sortBy} from 'lodash';
+import {uniqBy, uniq, get, countBy, isNil, xor} from 'lodash';
 
 
 import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
 import {RadioGroupInputField} from './RadioGroupInputField.jsx';
 import {CollapsiblePanel} from '../ui/panel/CollapsiblePanel.jsx';
 import FieldGroupUtils, {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
+import {dispatchMultiValueChange} from '../fieldGroup/FieldGroupCntlr.js';
 import {dispatchComponentStateChange} from '../core/ComponentCntlr.js';
 import {updateSet} from '../util/WebUtil.js';
 
@@ -22,11 +23,11 @@ export class ImageSelect extends PureComponent {
     constructor(props) {
         super(props);
         this.state= {lastMod:new Date().getTime()};
-        props.addChangeListener && props.addChangeListener('ImageSelect', fieldsReducer(props.imageMasterData));
+        props.addChangeListener && props.addChangeListener('ImageSelect', fieldsReducer);
     }
 
     render() {
-        const {style, imageMasterData, groupKey, title, multiSelect=true} = this.props;
+        const {style, imageMasterData, groupKey, multiSelect=true} = this.props;
         imageMasterData.forEach((d)=> {
             ['missionId', 'project', 'subProject'].forEach((k) => d[k] = d[k] || '');
         });
@@ -46,8 +47,15 @@ export class ImageSelect extends PureComponent {
 
         return (
             <div style={style} className='ImageSelect'>
-                <FilterPanel {...{imageMasterData, title}}/>
-                <DataProductList {...{filteredImageData, groupKey, multiSelect, onChange: () => this.setState({lastMod:new Date().getTime()})}}/>
+                <ToolBar className='ImageSelect__toolbar' {...{filteredImageData, groupKey, onChange: () => this.setState({lastMod:new Date().getTime()})}}/>
+                <div style={{flexGrow: 1, display: 'flex'}}>
+                    <div className='ImageSelect__panels' style={{marginRight: 3, flexGrow: 0}}>
+                        <FilterPanel {...{imageMasterData, groupKey}}/>
+                    </div>
+                    <div className='ImageSelect__panels' style={{flexGrow: 1}}>
+                        <DataProductList {...{filteredImageData, groupKey, multiSelect}}/>
+                    </div>
+                </div>
             </div>
         );
     }
@@ -60,56 +68,95 @@ ImageSelect.propTypes = {
     // a function so this component can handle field change event from reducing function.
     addChangeListener: PropTypes.func.isRequired,
     style: PropTypes.object,
-    title: PropTypes.string,
     multiSelect: PropTypes.bool
 };
 
 const toFilterSelectAry = (groupKey, s) => getFieldVal(groupKey, `Filter_${s}`, '').split(',').map((d) => d.trim()).filter((d) => d);
 
 
-function fieldsReducer(imageMasterData={}) {
-    return (inFields, action) => {
-        const {fieldKey='', options={}, value=''} = action.payload;
-
-        if (fieldKey.startsWith('PROJ_ALL_')) {
-            // a project checkbox is clicked
-            const proj = fieldKey.replace('PROJ_ALL_', '');
-            Object.entries(inFields).forEach( ([k, f]) => {
-                if (k.startsWith(`IMAGES_${proj}`)) {
-                    if (value === '_all_') {
-                        const allVals = f.options ? f.options.map((o) => o.value).join() : '';
-                        inFields = updateSet(inFields, [k, 'value'], allVals);
-                    } else {
-                        inFields = updateSet(inFields, [k, 'value'], '');
-                    }
+function doWhenValueChanged(fieldKey, inFields, value) {
+    if (fieldKey.startsWith('PROJ_ALL_')) {
+        // a project checkbox is clicked
+        const proj = fieldKey.replace('PROJ_ALL_', '');
+        Object.entries(inFields).forEach( ([k, f]) => {
+            if (k.startsWith(`IMAGES_${proj}`)) {
+                if (value === '_all_') {
+                    const allVals = f.options ? f.options.map((o) => o.value).join() : '';
+                    inFields = updateSet(inFields, [k, 'value'], allVals);
+                } else {
+                    inFields = updateSet(inFields, [k, 'value'], '');
                 }
-            });
-        } else if (fieldKey.startsWith('IMAGES_')) {
-            // one item changed, update project selectAll checkbox
-            const matcher = fieldKey.split('||')[0];
-            const cbGroups = Object.values(inFields).filter((f) => get(f, 'fieldKey', '').startsWith(matcher));  // array of subproject in this project
-            const allSelected = cbGroups.reduce((p, f) => {
-                            const selAry = get(f,'value','').split(',');
-                            const allAry = get(f,'options',[]).map((o) => o.value);
-                            return p && xor(selAry, allAry).length === 0;
-                        }, true);
-            const proj = matcher.substring(7);
-            inFields = updateSet(inFields, ['PROJ_ALL_' + proj, 'value'], (allSelected ? '_all_' : ''));
-        }
+            }
+        });
+    } else if (fieldKey.startsWith('IMAGES_')) {
+        // one item changed, update project selectAll checkbox
+        const matcher = fieldKey.split('||')[0];
+        const cbGroups = Object.values(inFields).filter((f) => get(f, 'fieldKey', '').startsWith(matcher));  // array of subproject in this project
+        const allSelected = cbGroups.reduce((p, f) => {
+            const selAry = get(f,'value','').split(',');
+            const allAry = get(f,'options',[]).map((o) => o.value);
+            return p && xor(selAry, allAry).length === 0;
+        }, true);
+        const proj = matcher.substring(7);
+        inFields = updateSet(inFields, ['PROJ_ALL_' + proj, 'value'], (allSelected ? '_all_' : ''));
+    }
+    return inFields;
+}
 
-        return inFields;
+function fieldsReducer(inFields, action) {
+    const {fieldKey='', fieldAry, value=''} = action.payload;
+    if (fieldKey) {
+        return (doWhenValueChanged(fieldKey, inFields, value));
+    } else if (get(fieldAry, 'length')) {
+        inFields = fieldAry.reduce( (p, f) => doWhenValueChanged(f.fieldKey, p, f.value), inFields);
     };
+    return inFields;
 }
 
 
+// eslint-disable-next-line
+function ToolBar({filteredImageData, groupKey, onChange}) {
+    const projects= uniqBy(filteredImageData, 'project').map( (d) => d.project);
+    const setDSListMode = (flg) => {
+        projects.forEach((k) => dispatchComponentStateChange(k, {isOpen:flg}));
+        onChange && onChange();
+    };
+    const clearFields = (type) => {
+        const fields = Object.values(FieldGroupUtils.getGroupFields(groupKey))
+                            .filter( (f) => get(f, 'fieldKey','').startsWith(type))
+                            .filter( (f) => get(f, 'value'));        // look for all selected filters
+        if (fields.length > 0) {
+            fields.forEach((f) => f.value = '');
+            dispatchMultiValueChange(groupKey, fields);
+        }
+    };
+
+    return (
+        <div className='ImageSelect__toolbar'>
+            <div>
+                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => clearFields('Filter_')}>Clear Filters</a>
+            </div>
+            <div>
+                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => clearFields('IMAGES_')}>Clear Selections</a>
+                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => setDSListMode(true)}>Expand All</a>
+                &bull;<a className='ff-href' onClick={() => setDSListMode(false)}>Collapse All</a>
+            </div>
+        </div>
+    );
+}
 
 /*--------------------------- Filter Panel ---------------------------------------------*/
-
 // eslint-disable-next-line
-function FilterPanel({imageMasterData, title='Select Data Set', onChange}) {
+function FilterPanel({imageMasterData, groupKey, onChange}) {
+    const allSelect = Object.values(FieldGroupUtils.getGroupFields(groupKey))
+        .filter( (f) => get(f, 'fieldKey','').startsWith('Filter_'))
+        .filter( (f) => get(f, 'value'))                                    // look for only selected fields
+        .map( (f) => f.value).join();                                       // get the value of the selected fields
+
     return(
         <div className='FilterPanel'>
-            <div className='FilterPanel__toolbar'>{title}</div>
+            <div className='ImageSelect__title'>Filter By:</div>
+            <div className='ImageSelect__info'>{pretty(allSelect, 25)}</div>
             <FilterPanelView {...{onChange, imageMasterData}}/>
         </div>
     );
@@ -170,10 +217,10 @@ class FilterSelect extends PureComponent {
                 <CheckboxGroupInputField
                     key={fieldKey}
                     fieldKey={fieldKey}
-                    initialState={{
-                                            value: '',   // workaround for _all_ for now
-                                            tooltip: 'Please select some boxes',
-                                            label : '' }}
+                    initialState={{ options: dispOptions,
+                                    value: '',   // workaround for _all_ for now
+                                    tooltip: 'Please select some boxes',
+                                    label : '' }}
                     options={dispOptions}
                     alignment='vertical'
                     labelWidth={35}
@@ -221,24 +268,29 @@ const toFilterSummary = (master, key, desc) => Object.entries(countBy(master, (d
 // eslint-disable-next-line
 function DataProductList({filteredImageData, groupKey, multiSelect, onChange}) {
     const projects= uniqBy(filteredImageData, 'project').map( (d) => d.project);
-    const setDSListMode = (flg) => {
-                                projects.forEach((k) => dispatchComponentStateChange(k, {isOpen:flg}));
-                                onChange && onChange();
-                            };
+
+    const allSelect = Object.values(FieldGroupUtils.getGroupFields(groupKey))
+                            .filter( (f) => get(f, 'fieldKey','').startsWith('IMAGES_'))
+                            .filter( (f) => get(f, 'value'))                                    // look for only selected fields
+                            .map( (f) => f.options.filter( (o) => f.value.includes(o.value))
+                                                  .map((o) => o.label).join() )                 // takes the label of the selected field
+                            .join();
+    let content;
+    if (projects.length > 1) {
+        content = projects.map((p) => <DataProduct key={p} {...{groupKey, project:p, filteredImageData, multiSelect}}/>);
+    } else {
+        content = (
+            <div style={{display:'flex', justifyContent:'center', marginTop: 40}}>
+                <div>No data match these criteria</div>
+            </div>
+        );
+    }
 
     return (
         <div className='DataProductList'>
-            <div className='DataProductList__toolbar'>
-                &bull;<a style={{marginRight: 7}} className='ff-href' onClick={() => setDSListMode(true)}>Expand All</a>
-                &bull;<a className='ff-href' onClick={() => setDSListMode(false)}>Collapse All</a>
-            </div>
-            <div className='DataProductList__view'>
-                {
-                    projects.map((p) =>
-                        <DataProduct key={p} {...{groupKey, project:p, filteredImageData, multiSelect}}/>
-                    )
-                }
-            </div>
+            <div className='ImageSelect__title'>Selection:</div>
+            <div className='ImageSelect__info'>{pretty(allSelect, 100)}</div>
+            <div className='DataProductList__view'>{content}</div>
         </div>
     );
 }
@@ -351,3 +403,16 @@ function BandSelect({groupKey, subProject, projectData, labelMaxWidth, multiSele
 }
 
 const toImageOptions= (a) => a.map ( (d) => ({label: d.title, value: d.imageId}));
+
+function pretty(str, max) {
+    const words = str.split(',');
+    let pretty = '';
+    for(var i=0; i< words.length; i++) {
+        if (pretty.length + words[i].length > max) {
+            pretty += ` (${words.length-i} more)`;
+            break;
+        }
+        pretty += words[i] + (i === words.length-1 ? '' : ',');
+    }
+    return pretty;
+}

--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -5,7 +5,7 @@
 //-----------------
 import PositionParser from '../util/PositionParser';
 import PositionFieldDef from '../data/form/PositionFieldDef';
-import Point from '../visualize/Point';
+import {getRootPath} from '../util/BrowserUtil.js';
 import {fetchUrl} from '../util/WebUtil.js';
 import {parseWorldPt} from '../visualize/Point';
 
@@ -55,7 +55,7 @@ var makeResolverPromise= function(objName, resolver) {
 
 function makeSearchPromise(objName, resolver= 'nedthensimbad') {
     var rejectFunc= null;
-    var url= `sticky/CmdSrv?objName=${objName}&resolver=${resolver}&cmd=CmdResolveName`;
+    var url= `${getRootPath()}sticky/CmdSrv?objName=${objName}&resolver=${resolver}&cmd=CmdResolveName`;
     var searchPromise= new Promise(
         function(resolve, reject) {
             fetchUrl(url).then( (response) => {

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -148,7 +148,7 @@ function initState() {
 /**
  *
  * @param {string} viewerId
- * @param {boolean} canReceiveNewPlots
+ * @param {string} canReceiveNewPlots   a string representation of one of NewPlotMode.
  * @param {string} containerType a string with container type, IMAGE and PLOT2D are predefined
  * @param {boolean} mounted
  */

--- a/src/firefly/js/visualize/reducer/PlotTitle.js
+++ b/src/firefly/js/visualize/reducer/PlotTitle.js
@@ -34,17 +34,20 @@ export function makePostPlotTitle(plot,r) {
 }
 
 function computeFileNameBaseTitle(r,state, band, preTitle) {
-    var retval= '';
-    var rt= r.getRequestType();
+    let retval= '';
+    const rt= r.getRequestType();
     if (rt===RequestType.WORKSPACE || rt===RequestType.FILE || rt===RequestType.TRY_FILE_THEN_URL) {
-        if (state.getUploadFileName(band)) {
+        if (r.getFileName()) {
+            retval= preTitle + computeTitleFromFile(r.getFileName());
+        }
+        else if (state.getUploadFileName(band)) {
             retval= preTitle + computeTitleFromFile(state.getUploadFileName(band));
         }
         else {
-            retval= preTitle + computeTitleFromFile(r.getFileName());
+            retval= 'FITS';
         }
     }
-    else if (r.getRequestType()== RequestType.URL) {
+    else if (rt===RequestType.URL) {
         retval= computeTitleFromURL(r.getURL(),r,preTitle);
     }
     return retval;

--- a/src/firefly/js/visualize/saga/MouseReadoutWatch.js
+++ b/src/firefly/js/visualize/saga/MouseReadoutWatch.js
@@ -42,11 +42,12 @@ export function* watchReadout() {
         let readout= undefined;
         plotView= getPlotViewById(visRoot(), plotId);
         const plot= primePlot(plotView);
+        threeColor= plot.plotState.threeColor;
         if (usePayload(mouseState,lockByClick)) {
 
             if (plot) {
                 if (isImage(plot)) {
-                    readout= makeReadoutWithFlux(makeReadout(plot,worldPt,screenPt,imagePt), plot, null, plot.plotState.threeColor);
+                    readout= makeReadoutWithFlux(makeReadout(plot,worldPt,screenPt,imagePt), plot, null, threeColor);
                     dispatchReadoutData(plotId,readout, plot.plotState.threeColor);
                 }
                 else {

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.css
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.css
@@ -9,7 +9,7 @@
 .ImageSearch__title {
     font-weight: bold;
     font-size: large;
-    margin: 4px;
+    margin: 6px 4px;
 }
 
 .ImageSearch__section {
@@ -17,10 +17,10 @@
     transition: box-shadow .3s ease-in-out;
     background-color: white;
     border-radius: 2px;
-    margin: 2px;
-    padding: 2px;
+    padding: 6px 2px 4px 2px;
+    margin: 2px 4px;
     outline: none;
-    width: calc(100% - 4px);
+    width: calc(100% - 8px);
     display: inline-flex;
     align-items: baseline;
     box-sizing: border-box;

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -29,6 +29,7 @@ import {dispatchShowDialog, dispatchHideDialog} from '../../core/ComponentCntlr.
 import {NewPlotMode, findViewerWithItemId, getMultiViewRoot, getViewer, getAViewFromMultiView, IMAGE} from '../MultiViewCntlr.js';
 import {getPlotViewById} from '../PlotViewUtil.js';
 import {WorkspaceUpload} from '../../ui/WorkspaceViewer.jsx';
+import {getWorkspaceConfig} from '../WorkspaceCntlr.js';
 
 import './ImageSearchPanelV2.css';
 
@@ -257,8 +258,10 @@ function ImageSource({groupKey, imageMasterData, multiSelect, archiveName='Archi
     const isThreeColor = getFieldVal(FG_KEYS.main, 'imageType') === 'threeColor';
     const options = [   {label: archiveName, value: 'archive'},
                         {label: 'Upload', value: 'upload'},
-                        {label: 'URL', value: 'url'},
-                        {label: 'Workspace', value: ServerParams.IS_WS}];
+                        {label: 'URL', value: 'url'}];
+    if (getWorkspaceConfig()) {
+        options.push({label: 'Workspace', value: ServerParams.IS_WS});
+    }
     isThreeColor && (options.push({label: 'None', value: 'none'}));
     const defaultValue = isThreeColor ? 'none' : 'archive';
     const imageSource = getFieldVal(groupKey, 'imageSource', defaultValue);

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -34,7 +34,7 @@ import WebGrid from '../../drawingLayers/WebGrid.js';
 import HiPSGrid from '../../drawingLayers/HiPSGrid.js';
 import {showRegionFileUploadPanel} from '../region/RegionFileUploadView.jsx';
 import {MarkerDropDownView} from './MarkerDropDownView.jsx';
-import {showImageSelPanel} from './ImageSelectPanel.jsx';
+import {showImageSelPanel} from './ImageSearchPanelV2.jsx';
 import {showMaskDialog} from './MaskAddPanel.jsx';
 import {isImage,isHiPS} from '../WebPlot.js';
 


### PR DESCRIPTION
https://caltech-ipac.atlassian.net/browse/IRSA-748

Also includes:
- https://caltech-ipac.atlassian.net/browse/IRSA-955
- https://caltech-ipac.atlassian.net/browse/IRSA-956
- fix TargetPanel resolution in API demo pages
- fix API showImage and showCoverage not setting the right viewer's option

Build firefly and irsaviewer on this branch
Anywhere image search/load is available, the new ImageSearchPanel will appears.
This includes API, Gator, and elsewhere in firefly.

When updating current image, then panel allow for only 1 image to be selected.
Otherwise, you can select more than one, and have them all loaded at once.

@cwang2016 , will you help check to see if any features missing in this new panel.
@robyww , will you do the same.  Also, you want to look over the small changes I made to image API.
