### PR TITLE
DM-12940 Fix the error while adding marker or footprint to the plot without image

### DIFF
--- a/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
+++ b/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
@@ -4,8 +4,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {isEmpty} from 'lodash';
-import {getDrawLayerByType, isDrawLayerAttached } from '../PlotViewUtil.js';
+import {getDrawLayerByType, isDrawLayerAttached, primePlot } from '../PlotViewUtil.js';
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
 import {dispatchCreateDrawLayer,
      getDlAry,
@@ -15,7 +14,7 @@ import {dispatchCreateDrawLayer,
 
 export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,visible,
                                             todo, isIconOn, onClick,allPlots= true }) {
-    var enabled= pv ? true : false;
+    var enabled= primePlot(pv) ? true : false;
     var isOn= isIconOn;
     if (typeId && pv) {
         const distLayer= getDrawLayerByType(getDlAry(),typeId);

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -169,13 +169,13 @@ export class VisToolbarView extends PureComponent {
 
         const pv= getActivePlotView(visRoot);
         const plot= primePlot(pv);
-        const image= isImage(plot);
+        const image= !isHiPS(plot);
         const hips= isHiPS(plot);
         const plotGroupAry= visRoot.plotGroupAry;
 
         const mi= pv ? pv.menuItemKeys : getDefMenuItemKeys();
 
-        const enabled= Boolean(pv);
+        const enabled= Boolean(plot);
 
         return (
             <div style={rS}>
@@ -409,7 +409,7 @@ function showImagePopup() {
 //==================================================================================
 
 export function LayerButton({pv,visible}) {
-    const layerCnt=  pv ? (getAllDrawLayersForPlot(getDlAry(),pv.plotId).length + pv.overlayPlotViews.length) : 0;
+    const layerCnt=  primePlot(pv) ? (getAllDrawLayersForPlot(getDlAry(),pv.plotId).length + pv.overlayPlotViews.length) : 0;
     const enabled= Boolean(layerCnt || findUnactivatedRelatedData(pv).length);
     return (
         <ToolbarButton icon={LAYER_ICON}


### PR DESCRIPTION
The development fixes the error when adding marker or footprint to the drawing layer containing the plot without image, 
- skip adding the marker or footprint to the plot that is attached to the marker/footprint drawing layer and has no image. 
- disable the buttons on the toolbar in case the selected plot containing no image. 

test case 1:
go to firefly do image search, 
target: m31, 
select all images under  'SDSS' and 'WISE All-Sky Altas'

result: No image found for SDSS, and  buttons on the tool bar for those plots are disabled. 

test case 2:
go to finderchart do multiple positions search. 
upload file 'forirsa_ref1.tbl' as attached in https://jira.lsstcorp.org/browse/DM-12940
Marker tool can be added to all plots with images with no error. 


 