### PR TITLE
DM-12949 column expression issues in charts

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -223,7 +223,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         try {
             JdbcFactory.getSimpleTemplate(dbInstance).queryForInt(String.format("select count(*) from %s", resultSetID));
         } catch (Exception e) {
-            // does not exists.. create table from orignal 'data' table
+            // does not exists.. create table from original 'data' table
             List<String> cols = StringUtils.isEmpty(treq.getInclColumns()) ? getColumnNames(dbInstance, "DATA")
                     : StringUtils.asList(treq.getInclColumns(), ",");
             String wherePart = dbAdapter.wherePart(treq);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -255,6 +255,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         TableServerRequest nreq = (TableServerRequest) treq.cloneRequest();
         nreq.setFilters(null);
         nreq.setSortInfo(null);
+        nreq.setInclColumns(new String[0]);
 
         return execRequestQuery(nreq, dbFile, resultSetID);
     }

--- a/src/firefly/java/edu/caltech/ipac/util/expr/Parser.java
+++ b/src/firefly/java/edu/caltech/ipac/util/expr/Parser.java
@@ -191,10 +191,10 @@ public class Parser {
     };
 
     static private final String[] procs2 = {
-            "atan2", "max", "min"
+            "atan2", "max", "min", "power"
     };
     static private final int[] rators2 = {
-            Expr.ATAN2, Expr.MAX, Expr.MIN
+            Expr.ATAN2, Expr.MAX, Expr.MIN, Expr.POW
     };
 
     private Expr parseFactor() throws SyntaxException {

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {get, isArray, uniqueId} from 'lodash';
-import {getTblById, getColumn, doFetchTable} from '../../tables/TableUtil.js';
+import {COL_TYPE, getTblById, getColumns, getColumn, doFetchTable} from '../../tables/TableUtil.js';
 import {cloneRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {dispatchChartUpdate, dispatchError, getChartData} from '../ChartsCntlr.js';
 import {formatColExpr, getDataChangesForMappings, updateHighlighted, updateSelected, isScatter2d} from '../ChartUtil.js';
@@ -38,13 +38,14 @@ function fetchData(chartId, traceNum, tablesource) {
 
     const originalTableModel = getTblById(tbl_id);
     const {request, highlightedRow, selectInfo} = originalTableModel;
+    const numericCols = getColumns(originalTableModel, COL_TYPE.NUMBER).map((c) => c.name);
 
     // default behavior
     const sreq = cloneRequest(request, {
         startIdx: 0,
         pageSize: MAX_ROW,
         inclCols: Object.entries(mappings).map(([k,v]) => {
-            return `${formatColExpr(v)} as "${k}"`;
+            return `${formatColExpr({colOrExpr: v, quoted: true, colNames: numericCols})} as "${k}"`;
         }).join(', ')    // allows to use the same columns, ex. "w1" as "x", "w1" as "marker.color"
     });
 

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -14,9 +14,9 @@ import MAGNIFYING_GLASS from 'html/images/icons-2014/magnifyingGlass.png';
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
 
 const EXPRESSION_TTIPS = `
-Supported operators: ^, *, /, +, -, <, <=, =, <>, >=, >, and, or.
-Supported functions: abs(x), acos(x), asin(x), atan(x), atan2(x,y), ceil(x), cos(x), exp(x), floor(x), if(x,y,z), lg(x), ln(x), log10(x), log(x), max(x,y), min(x,y), round(x), sin(x), sqrt(x), tan(x).
-Example: sqrt(b^2 - 4*a*c) / (2*a), where a, b, c are column names.`;
+Supported operators: *, /, +, -.
+Supported functions: abs(x), acos(x), asin(x), atan(x), atan2(x,y), ceil(x), cos(x), exp(x), floor(x), lg(x), ln(x), log10(x), log(x), power(x,y), round(x), sin(x), sqrt(x), tan(x).
+Example: sqrt(power(b,4) - 4*a*c) / (2*a), where a, b, c are column names.`;
 
 /*
  * Split content into prior content and the last alphanumeric token in the text

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -228,7 +228,10 @@ function onSelect(chartId) {
             }
 
             if (points) {
-                if (points.length < 1) {
+                const {data, activeTrace=0} = getChartData(chartId);
+                const type = get(data, [activeTrace, 'type'], 'scatter');
+                // points are populated only for scatter2d, not for heatmap
+                if (isScatter2d(type) && points.length < 1) {
                     showInfoPopup((<div>No active trace points in the selection area.</div>), 'Warning');
                 } else {
                     dispatchChartUpdate({

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -47,7 +47,7 @@ export class FilterInfo {
         filterString && filterString.split(';').forEach( (v) => {
                 let [, cname, op, val] = v.trim().match(filter_regex) || [];
                 if (cname && op) {
-                    cname = cname.replace(/^"(.+)"$/, '$1');      // strip quotes if any
+                    cname = cname.replace(/"(.+?)"/g, '$1');      // strip quotes if any
                     filterInfo.addFilter(cname, `${op} ${val}`);
                 }
             });

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -3,6 +3,7 @@
  */
 
 import {getColumnIdx, getColumn} from './TableUtil.js';
+import {Expression} from '../util/expr/Expression.js';
 import {isUndefined, get} from 'lodash';
 
 const cond_regex = new RegExp('(!=|>=|<=|<|>|=|like|in)\\s*(.+)');
@@ -135,12 +136,16 @@ export class FilterInfo {
         const rval = [true, ''];
         const allowCols = columns.concat({name:'ROW_IDX'});
         if (filterInfo && filterInfo.trim().length > 0) {
+            filterInfo = filterInfo.replace(/"(.+?)"/g, '$1'); // remove quotes
             return filterInfo.split(';').reduce( ([isValid, msg], v) => {
                 const [, cname] = v.trim().match(filter_regex) || [];
                 if (!cname) {
                         msg += `\n"${v}" is not a valid filter.`;
                     } else if (!allowCols.some( (c) => c.name === cname)) {
-                        msg +=`\n"${v}" column not found.\n`;
+                        const expr = new Expression(cname, allowCols.map((s)=>s.name));
+                        if (!expr.isValid()) {
+                            msg += `\n"${v}" unrecognized column or expression.\n`;
+                        }
                     }
                     return [!msg, msg];
                 }, rval);
@@ -214,11 +219,17 @@ export class FilterInfo {
         };
     }
 
-    serialize() {
+
+
+    serialize(formatKey) {
+        if (!formatKey) {
+            // add quotes to key if it does not contains quotes
+            formatKey = (k) => k.includes('"') ? k : `"${k}"`;
+        }
         return Object.entries(this)
                     .map(([k,v]) => v.split(';')
                                     .filter((f) => f)
-                                    .map( (f) => k.includes('"') ? `${k} ${f}` : `"${k}" ${f}`)         // add quotes to key if it does not contains quotes
+                                    .map( (f) => `${formatKey(k)} ${f}`)
                                     .join(';'))
                     .join(';');
     }

--- a/src/firefly/js/util/expr/Parser.js
+++ b/src/firefly/js/util/expr/Parser.js
@@ -30,11 +30,11 @@ const rators1 = [
 ];
 
 const procs2 = [
-    'atan2', 'max', 'min'
+    'atan2', 'max', 'min', 'power'
 ];
 
 const rators2 = [
-        Expr.ATAN2, Expr.MAX, Expr.MIN
+    Expr.ATAN2, Expr.MAX, Expr.MIN, Expr.POW
 ];
 
 /**
@@ -86,21 +86,25 @@ const rators2 = [
         this.token = null;
     }
 
-    /** Return the expression denoted by the input string.
+    /**
+     * Return the expression denoted by the input string.
      *
      *  @param input the unparsed expression
-     *  @exception SyntaxException if the input is unparsable */
+     *  @exception SyntaxException if the input is unparsable
+     */
     static parse(input) {
         return new Parser().parseString(input);
     }
 
 
-    /** Adjust the set of allowed variables: create it (if not yet
+    /**
+     * Adjust the set of allowed variables: create it (if not yet
      * existent) and add optVariable (if it's nonnull).  If the
      * allowed-variable set exists, the parser will reject input
      * strings that use any other variables.
      *
-     * @param optVariable the variable to be allowed, or null */
+     * @param optVariable the variable to be allowed, or null
+     */
     allow(optVariable) {
         if (!optVariable) {
             this.allowedVariables = null;
@@ -128,10 +132,12 @@ const rators2 = [
 
 
 
-    /** Return the expression denoted by the input string.
+    /**
+     * Return the expression denoted by the input string.
      *  @param {string} input the unparsed expression
      *  @return expression
-     *  @exception SyntaxException if the input is unparsable */
+     *  @exception SyntaxException if the input is unparsable
+     */
     parseString(input) {
         this.tokens = new Scanner(input, operatorChars);
         return this.reparse();
@@ -143,7 +149,7 @@ const rators2 = [
         this.tokens.index = -1;
         this.nextToken();
         const expr = this.parseExpr(0);
-        if (this.token.ttype != Token.TT_EOF) {
+        if (this.token.ttype !== Token.TT_EOF) {
             throw this.error('Incomplete expression',
                 SyntaxException.INCOMPLETE);
         }
@@ -277,7 +283,7 @@ const rators2 = [
     }
 
     expect(ttype) {
-        if (this.token.ttype != ttype) {
+        if (this.token.ttype !== ttype) {
             throw this.error(ttype + ' expected',
                 SyntaxException.EXPECTED, '' + ttype);
         }


### PR DESCRIPTION
- fixed filter from chart when column expressions are used
- use db to calculate column expression values for general charts
- allow same columns to be used for x and y

What is not done:
- I might need to update DecimationProcessor and HistogramProcessor as a part of this PR.
- Expression validation is still done using old Expression parser. Column expression input field tooltip is updated with the operators and functions that are common for both java/js expressions and h2 db. A separate ticket will address column expression validation issues. 
- XYGenericProcessor and XYWithErrorProcessor can not be removed while we are using old single-trace chart architecture. After we finally switch to multi-trace charts, we should remove the code supporting old charts.