### PR TITLE
IRSA-1283: Fixed string column filtering

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
@@ -19,7 +19,7 @@ public class HsqlDbAdapter extends BaseDbAdapter{
     }
 
     protected EmbeddedDbInstance createDbInstance(File dbFile) {
-        String dbUrl = String.format("jdbc:hsqldb:file:%s;hsqldb.log_size=1024;sql.syntax_ora=true", dbFile.getPath());
+        String dbUrl = String.format("jdbc:hsqldb:file:%s;hsqldb.log_size=1024;sql.syntax_ora=true;sql.ignore_case=true", dbFile.getPath());
         return new EmbeddedDbInstance(getName(), dbFile, dbUrl, "org.hsqldb.jdbc.JDBCDriver");
     }
 

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -2,16 +2,16 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {getColumnIdx, getColumn} from './TableUtil.js';
+import {getColumnIdx, getColumn, isNumericType, getTblById} from './TableUtil.js';
 import {Expression} from '../util/expr/Expression.js';
 import {isUndefined, get} from 'lodash';
 
-const cond_regex = new RegExp('(!=|>=|<=|<|>|=|like|in)\\s*(.+)');
+const cond_regex = new RegExp('(!=|>=|<=|<|>|=|like|in|is|is not)?\\s*(.+)');
 const cond_only_regex = new RegExp('^' + cond_regex.source, 'i');
 const filter_regex = new RegExp('(\\S+)\\s*' + cond_regex.source, 'i');
 
 export const FILTER_CONDITION_TTIPS =
-`Valid values are one of (=, >, <, !=, >=, <=, LIKE) followed by a value separated by a space.
+`Valid values are one of (=, >, <, !=, >=, <=, LIKE, IS, IS NOT) followed by a value separated by a space.
 Or 'IN', followed by a list of values separated by commas. 
 Examples:  > 12345; != 3000; IN a,b,c,d`;
 
@@ -31,11 +31,11 @@ ${FILTER_CONDITION_TTIPS}`;
  * in this context:
  * filter is column_name = conditions
  * condition is operator + value(s)
- * multiple conditions are separated by comma.
  * multiple filters are separated by semicolon.
  */
 export class FilterInfo {
     constructor() {
+        this.filters={};
     }
 
     /**
@@ -56,26 +56,6 @@ export class FilterInfo {
     }
 
     /**
-     * given a list of conditions separated by semicolon,
-     * transform them into valid conditions if they are not already so.
-     * @param conditions
-     * @returns {string}
-     */
-    static autoCorrect(conditions) {
-        if (conditions) {
-            const parts = conditions.split(';').map( (v) => {
-                var [, op, val] = v.trim().replace(/[()]/g, '').match(cond_only_regex) || [];
-                [op, val] = op ? [op, val] : [ 'like', v.trim() ];  // defualt to 'like' if no operators found
-                val = op.toLowerCase() === 'in' ? `(${val})` : val;     // add parentheses when 'in' is used.
-                return `${op} ${val}`;
-           });
-            return parts.join(';');
-        } else {
-            return conditions;
-        }
-    }
-
-    /**
      * given a list of filters separated by semicolon,
      * transform them into valid filters if they are not already so.
      * @param filterInfo
@@ -86,7 +66,7 @@ export class FilterInfo {
             const filters = filterInfo.split(';').map( (v) => {
                 const [, cname, op, val] = v.trim().match(filter_regex) || [];
                 if (!cname) return v;
-                return `${cname} ${FilterInfo.autoCorrect(op + ' ' + val)}`;
+                return `${cname} ${FilterInfo.autoCorrectCondition(op + ' ' + val)}`;
             });
             return filters.join(';');
         } else {
@@ -108,10 +88,12 @@ export class FilterInfo {
     /**
      * validator for column's filter.  it validates only the condition portion of the filter.
      * @param conditions
+     * @param tbl_id
+     * @param cname
      * @returns {{valid: boolean, value: (string|*), message: string}}
      */
-    static conditionValidator(conditions) {
-        conditions = FilterInfo.autoCorrect(conditions);
+    static conditionValidator(conditions, tbl_id, cname) {
+        conditions = autoCorrectConditions(conditions, tbl_id, cname);
         const valid = FilterInfo.isConditionValid(conditions);
         return {valid, value: conditions, message: FILTER_CONDITION_TTIPS};
     }
@@ -226,7 +208,7 @@ export class FilterInfo {
             // add quotes to key if it does not contains quotes
             formatKey = (k) => k.includes('"') ? k : `"${k}"`;
         }
-        return Object.entries(this)
+        return Object.entries(this.filters)
                     .map(([k,v]) => v.split(';')
                                     .filter((f) => f)
                                     .map( (f) => `${formatKey(k)} ${f}`)
@@ -240,11 +222,11 @@ export class FilterInfo {
      * @param conditions
      */
     addFilter(colName, conditions) {
-        this[colName] = !this[colName] ? conditions : `${this[colName]}; ${conditions}`;
+        this.filters[colName] = !this.filters[colName] ? conditions : `${this.filters[colName]}; ${conditions}`;
     }
 
     setFilter(colName, conditions) {
-        Reflect.deleteProperty(this, colName);
+        Reflect.deleteProperty(this.filters, colName);
         if (conditions) {
             conditions.split(';').forEach( (v) => {
                 const [, op, val] = v.trim().match(cond_only_regex) || [];
@@ -260,11 +242,57 @@ export class FilterInfo {
      * @returns {string}
      */
     getFilter(colName) {
-        return this[colName] && this[colName].toString();
+        return this.filters[colName] && this.filters[colName].toString();
     }
 
     isEqual(colName, value) {
         const oldVal = this.getFilter(colName);
         return (!oldVal && !value) || oldVal === value;
     }
+}
+
+
+/*-----------------------------------------------------------------------------------------*/
+
+/**
+ * Attempt to auto-correct the given condition(s).
+ * @param {string} conditions  one or more conditions, separated by ';'
+ * @param {string} tbl_id   table ID.
+ * @param {string} cname    column name.
+ * @returns {string}
+ */
+function autoCorrectConditions(conditions, tbl_id, cname) {
+    const isNumeric = isNumericType(getColumn(getTblById(tbl_id), cname));
+    if (conditions) {
+        return conditions.split(';')                                // separate them into parts
+            .map( (v) => autoCorrectCondition(v, isNumeric))      // auto correct if needed
+            .join(';');                                // put them back
+    }
+}
+
+function autoCorrectCondition(v, isNumeric=false) {
+    let [, op, val=''] = v.trim().replace(/[()]/g, '').match(cond_only_regex) || [];
+    if (!op && !val) return v;
+
+    op = op ? op.toLowerCase() : isNumeric ? '=' : 'like';      // apply default operator if one is not given.
+
+    switch (op) {
+        case 'like':
+            val = !val.includes('%') ? `%${val}%` : val;
+            val = !val.match("^'.+'$") ? `'${val}'` : val;
+            break;
+        case 'in':
+            if (!isNumeric) {
+                val = val.split(',').map((s) => `'${s.trim}'`).join();
+            }
+            val = `(${val})`;
+            break;
+        case '=':
+        case '!=':
+            if (isNumeric && ["''", 'null', '""'].includes(val.toLowerCase())) {
+                op = op === '!=' ? 'is not' : 'is';
+                val = 'null';
+            }
+    }
+    return `${op} ${val}`;
 }

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -21,6 +21,8 @@ import {dispatchAddSaga, dispatchAddActionWatcher, dispatchCancelActionWatcher} 
 import {getWsConnId} from '../core/messaging/WebSocketClient.js';
 
 export const COL_TYPE = new Enum(['ALL', 'NUMBER', 'TEXT']);
+const char_types = ['char', 'c', 's', 'str'];
+const num_types = ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'];
 
 
 /**
@@ -188,10 +190,7 @@ export function getTableUiById(tbl_ui_id) {
  */
 export function getTableUiByTblId(tbl_id) {
     const uiRoot = get(flux.getState(), [TblCntlr.TABLE_SPACE_PATH, 'ui'], {});
-    const tbl_ui_id = Object.keys(uiRoot).find( (ui_id) => {
-        return get(uiRoot, [ui_id, 'tbl_id']) === tbl_id;
-    });
-    return tbl_ui_id || uiRoot[tbl_ui_id];
+    return Object.keys(uiRoot).find( (ui_id) => get(uiRoot, [ui_id, 'tbl_id']) === tbl_id);
 }
 
 /**
@@ -848,14 +847,18 @@ export function getColumns(tableModel, type=COL_TYPE.ALL) {
  * @returns {Array<TableColumn>}
  */
 export function getColsByType(tblColumns=[], type=COL_TYPE.ALL) {
-    const charTypes = ['char', 'c', 's', 'str'];
-    const numTypes = ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'];
-    const matcher = type === COL_TYPE.TEXT ? charTypes : numTypes;
+    const matcher = type === COL_TYPE.TEXT ? isTextType : isNumericType;
     return tblColumns.filter((col) => get(col, 'visibility') !== 'hidden'
-                        && (type === COL_TYPE.ALL || matcher.includes(col.type)));
+                        && (type === COL_TYPE.ALL || matcher(col)));
 }
 
+export function isNumericType(col={}) {
+    return num_types.includes(col.type);
+}
 
+export function isTextType(col={}) {
+    return char_types.includes(col.type);
+}
 
 /*-------------------------------------private------------------------------------------------*/
 /**

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -8,7 +8,7 @@ import FixedDataTable from 'fixed-data-table-2';
 import Resizable from 'react-component-resizable';
 import {debounce, defer, get, isEmpty} from 'lodash';
 
-import {tableTextView} from '../TableUtil.js';
+import {tableTextView, getTableUiById} from '../TableUtil.js';
 import {SelectInfo} from '../SelectInfo.js';
 import {FilterInfo} from '../FilterInfo.js';
 import {SortInfo} from '../SortInfo.js';
@@ -136,9 +136,10 @@ export class BasicTableView extends PureComponent {
 
     render() {
         const {columns, data, hlRowIdx, showUnits, showFilters, filterInfo, renderers, bgColor,
-            selectable, selectInfoCls, sortInfo, callbacks, textView, rowHeight, showMask, error} = this.props;
+            selectable, selectInfoCls, sortInfo, callbacks, textView, rowHeight, showMask, error, tbl_ui_id} = this.props;
         const {widthPx, heightPx, columnWidths} = this.state;
         const {onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected} = this;
+        const {tbl_id} = getTableUiById(tbl_ui_id) || {};
 
         if (!error && isEmpty(columns)) return (<div style={{top: 0}} className='loading-mask'/>);
 
@@ -147,7 +148,7 @@ export class BasicTableView extends PureComponent {
         //
         const makeColumnsProps = {columns, data, selectable, selectInfoCls, renderers, bgColor,
                                   columnWidths, filterInfo, sortInfo, showUnits, showFilters,
-                                  onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected};
+                                  onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected, tbl_id};
 
         const headerHeight = 22 + (showUnits && 8) + (showFilters && 22);
 
@@ -246,7 +247,7 @@ function makeColWidth(columns, showUnits) {
 }
 
 function makeColumns ({columns, columnWidths, data, selectable, showUnits, showFilters, renderers, bgColor='white',
-            selectInfoCls, filterInfo, sortInfo, onRowSelect, onSelectAll, onSort, onFilter, onFilterSelected}) {
+            selectInfoCls, filterInfo, sortInfo, onRowSelect, onSelectAll, onSort, onFilter, onFilterSelected, tbl_id}) {
     if (!columns) return false;
 
     var colsEl = columns.map((col, idx) => {
@@ -260,7 +261,7 @@ function makeColumns ({columns, columnWidths, data, selectable, showUnits, showF
             <Column
                 key={col.name}
                 columnKey={idx}
-                header={<HeadRenderer {...{col, showUnits, showFilters, filterInfo, sortInfo, onSort, onFilter}} />}
+                header={<HeadRenderer {...{col, showUnits, showFilters, filterInfo, sortInfo, onSort, onFilter, tbl_id}} />}
                 cell={<CellRenderer style={style} data={data} colIdx={idx} />}
                 fixed={fixed}
                 width={columnWidths[idx]}

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -191,7 +191,7 @@ export class TablePanel extends PureComponent {
                                 callbacks={tableConnector}
                                 { ...{columns, data, hlRowIdx, rowHeight, selectable, showUnits, showFilters,
                                     selectInfoCls, filterInfo, sortInfo, textView, showMask, currentPage,
-                                    tableConnector, renderers} }
+                                    tableConnector, renderers, tbl_ui_id} }
                             />
                             {showOptionButton && !showToolbar &&
                             <img className='TablePanel__options--small'
@@ -205,7 +205,7 @@ export class TablePanel extends PureComponent {
                                 onChange={this.onOptionUpdate}
                                 onOptionReset={this.onOptionReset}
                                 toggleOptions={this.toggleOptions}
-                                { ...{columns, optSortInfo, filterInfo, pageSize, showUnits, showFilters, showToolbar}}
+                                { ...{columns, optSortInfo, filterInfo, pageSize, showUnits, showFilters, showToolbar, tbl_ui_id}}
                             /> }
                     </div>
                 </div>

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -18,7 +18,7 @@ export class TablePanelOptions extends PureComponent {
     }
 
     render() {
-        const {columns, pageSize, showUnits, showFilters, showToolbar=true, onChange, onOptionReset, optSortInfo, filterInfo, toggleOptions} = this.props;
+        const {columns, pageSize, showUnits, showFilters, showToolbar=true, onChange, onOptionReset, optSortInfo, filterInfo, toggleOptions, tbl_ui_id} = this.props;
         if (isEmpty(columns)) return false;
 
         const {onPageSize, onPropChanged} = makeCallbacks(onChange, columns);
@@ -68,11 +68,8 @@ export class TablePanelOptions extends PureComponent {
                     </span>
                 </div>
                 <div style={{height: 'calc(100% - 40px)'}}>
-                    <FilterEditor
-                        columns={columns}
-                        filterInfo={filterInfo}
-                        sortInfo={optSortInfo}
-                        onChange={onChange}
+                    <FilterEditor sortInfo={optSortInfo}
+                        {...{tbl_ui_id, columns, filterInfo, onChange}}
                     />
                 </div>
             </div>
@@ -81,6 +78,7 @@ export class TablePanelOptions extends PureComponent {
 }
 
 TablePanelOptions.propTypes = {
+    tbl_ui_id: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.object),
     optSortInfo: PropTypes.string,
     filterInfo: PropTypes.string,

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -7,6 +7,7 @@ import FixedDataTable from 'fixed-data-table-2';
 import {set, get, isEqual, pick} from 'lodash';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS} from '../FilterInfo.js';
+import {getColumns} from '../TableUtil.js';
 import {SortInfo} from '../SortInfo.js';
 import {InputField} from '../../ui/InputField.jsx';
 import {SORT_ASC, UNSORTED} from '../SortInfo';
@@ -45,12 +46,14 @@ export class HeaderCell extends PureComponent {
     }
 
     render() {
-        const {col, showUnits, showFilters, filterInfo, sortInfo, onSort, onFilter, style} = this.props;
+        const {col, showUnits, showFilters, filterInfo, sortInfo, onSort, onFilter, style, tbl_id} = this.props;
         const cname = col.name;
         const cdesc = col.desc || col.label || cname;
         const filterStyle = {width: '100%', boxSizing: 'border-box'};
         const filterInfoCls = FilterInfo.parse(filterInfo);
         const sortInfoCls = SortInfo.parse(sortInfo);
+        const validator = (cond) => FilterInfo.conditionValidator(cond, tbl_id, cname);
+        
         return (
             <div style={style} title={cdesc} className='TablePanel__header'>
                 <Label {...{sortInfoCls, onSort}} {...col}/>
@@ -59,7 +62,7 @@ export class HeaderCell extends PureComponent {
                 }
                 {showFilters && get(col, 'filterable', true) &&
                 <InputField
-                    validator={FilterInfo.conditionValidator}
+                    validator={validator}
                     fieldKey={cname}
                     tooltip={FILTER_CONDITION_TTIPS}
                     value={filterInfoCls.getFilter(cname)}
@@ -236,7 +239,7 @@ export const createInputCell = (tooltips, size = 10, validator, onChange, style)
             return (
                 <div style={{margin: 2}}>
                     <InputField
-                        validator={validator}
+                        validator={(v) => validator(v, data, rowIndex, colIdx)}
                         tooltip={tooltips}
                         size={size}
                         style={style}

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -174,7 +174,7 @@ function updateDrawingLayer(tbl_id, title, tableData, tableMeta, tableRequest,
 }
 
 
-function attachToAllCatalogs(pvNewPlotInfoAry) {
+function attachToAllCatalogs(pvNewPlotInfoAry=[]) {
     dlRoot().drawLayerAry.forEach( (dl) => {
         if (dl.drawLayerTypeId===Catalog.TYPE_ID && dl.catalog) {
             pvNewPlotInfoAry.forEach( (info) => {


### PR DESCRIPTION
https://caltech-ipac.atlassian.net/browse/IRSA-1283
also:
- allow more robust string filtering using '%' wildcard
- string comparison is set to case-insensitive
- added filter for null in both numeric and text columns
- numeric column defaults to '=' when not entered

sample filters:
```
like 'j%425%.1'
is null
is not null

```

can be tested in any table.


