### PR TITLE
DM-12993 Add NEOWISE data

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/resources/LSSTMetaInfo.json
+++ b/src/firefly/java/edu/caltech/ipac/firefly/resources/LSSTMetaInfo.json
@@ -1,139 +1,227 @@
 {
-  "SDSS": {"catalog":
-                         [{"tables": ["RunDeepSource", "RunDeepForcedSource"],
-                           "meta": "db/v0/tap/sync",
-                           "database": "sdss_stripe82_01",
-                           "objectColumn": ["id", "objectId"],
-                           "filterColumn": ["coadd_filter_id"],
-                           "forcedSourceTable": ["RunDeepForcedSource", "RunDeepForcedSource"],
-                           "tableType":["source","forcedSource"],
-                           "datatype": "catalog",
-                           "datasetInfoConverterId": "lsst_sdss",
-                           "ra": "coord_ra",
-                           "dec": "coord_decl"}],
-           "imagemeta":
-                        [{"tables": ["DeepCoadd", "Science_Ccd_Exposure"],
-                          "meta": "db/v0/tap/sync",
-                          "database": "sdss_stripe82_01",
-                          "tableType":["coadd","ccdExposure"],
-                          "datatype": "imagemeta",
-                          "datasetInfoConverterId": "lsst_sdss",
-                          "ra": ["corner1Ra","corner2Ra", "corner3Ra", "corner4Ra"],
-                          "dec": ["corner1Decl","corner2Decl", "corner3Decl", "corner4Decl"]}]},
- "WISE": {"catalog":
-                    [{"tables": ["allwise_p3as_psd", "allwise_p3as_mep",
-                                 "allsky_4band_p1bs_psd", "allsky_3band_p1bs_psd", "allsky_2band_p1bs_psd"],
-                      "meta": "db/v0/tap/sync",
-                      "database": "wise_00",
-                      "objectColumn": ["cntr", "cntr_mf", "cntr", "cntr", "cntr"],
-                      "forcedSourceTable": ["allwise_p3as_mep", "allwise_p3as_mep"],
-                      "tableType": ["source","forcedSource", "singleExpSource", "singleExpSource", "singleExpSource"],
-                      "datatype": "catalog",
-                      "datasetInfoConverterId": "wise",
-                      "ra": "ra",
-                      "dec": "decl"},
-                     {"tables": ["allwise_p3as_psr"],
-                      "meta": "db/v0/tap/sync",
-                      "database": "wise_ext_00",
-                      "tabletype": ["source"],
-                      "datatype": "catalog",
-                      "datasetInfoConverterId": "wise",
-                      "ra": "ra",
-                      "dec": "decl"}],
-            "imagemeta":
-                    [
-                      {
-                        "tables": [
-                          "allwise_p3am_cdd",
-                          "allwise_p3as_cdd",
-                          "allsky_4band_p1bm_frm",
-                          "allsky_3band_p1bm_frm",
-                          "allsky_2band_p1bm_frm"
-                        ],
-                        "meta": "db/v0/tap/sync",
-                        "database": "wise_00",
-                        "tabletype": ["coadd", "coadd", "ccdExposure", "ccdExposure", "ccdExposure"],
-                        "datatype": "imagemeta",
-                        "datasetInfoConverterId": "wise",
-                        "ra": [
-                          "ra1",
-                          "ra2",
-                          "ra3",
-                          "ra4"
-                        ],
-                        "dec": [
-                          "dec1",
-                          "dec2",
-                          "dec3",
-                          "dec4"
-                        ],
-                        "schema": {
-                          "allwise-multiband": {
-                            "tables": [
-                              "allwise_p3am_cdd",
-                              "allwise_p3as_cdd"
-                            ],
-                            "params": {
-                              "ImageSet": "allwise-multiband",
-                              "ProductLevel": "3a",
-                              "title": "AllWISE"
-                            }
-                          },
-                          "allsky_4band-1b": {
-                            "tables": [
-                              "allsky_4band_p1bm_frm"
-                            ],
-                            "params": {
-                              "ImageSet": "allsky-4band",
-                              "ProductLevel": "1b",
-                              "title": "AllSky - Single"
-                            }
-                          },
-                          "allsky_4band-3a": {
-                            "tables": [],
-                            "params": {
-                              "ImageSet": "allsky-4band",
-                              "ProductLevel": "3a",
-                              "title": "AllSky - Atlas"
-                            }
-                          },
-                          "cryo_3band-1b": {
-                            "tables": [
-                              "allsky_3band_p1bm_frm"
-                            ],
-                            "params": {
-                              "ImageSet": "cryo_3band",
-                              "ProductLevel": "1b",
-                              "title": "3-Band Single"
-                            }
-                          },
-                          "cryo_3band-1b-3a": {
-                            "tables": [],
-                            "params": {
-                              "ImageSet": "cryo_3band",
-                              "ProductLevel": "3a",
-                              "title": "3-Band Atlas"
-                            }
-                          },
-                          "postcryo-1b": {
-                            "tables": [
-                              "allsky_2band_p1bm_frm"
-                            ],
-                            "params": {
-                              "ImageSet": "postcryo",
-                              "ProductLevel": "1b",
-                              "title": "Post-Cryo"
-                            }
-                          },
-                          "neowiser-1b": {
-                            "tables": [],
-                            "params": {
-                              "ImageSet": "neowiser",
-                              "ProductLevel": "1b",
-                              "title": "NeoWISER"
-                            }
-                          }
-                        }
-                      }]
+  "SDSS": {
+    "catalog": [
+      {
+        "tables": [
+          "RunDeepSource",
+          "RunDeepForcedSource"
+        ],
+        "meta": "db/v0/tap/sync",
+        "database": "sdss_stripe82_01",
+        "objectColumn": [
+          "id",
+          "objectId"
+        ],
+        "filterColumn": [
+          "coadd_filter_id"
+        ],
+        "forcedSourceTable": [
+          "RunDeepForcedSource",
+          "RunDeepForcedSource"
+        ],
+        "tableType": [
+          "source",
+          "forcedSource"
+        ],
+        "datatype": "catalog",
+        "datasetInfoConverterId": "lsst_sdss",
+        "ra": "coord_ra",
+        "dec": "coord_decl"
+      }
+    ],
+    "imagemeta": [
+      {
+        "tables": [
+          "DeepCoadd",
+          "Science_Ccd_Exposure"
+        ],
+        "meta": "db/v0/tap/sync",
+        "database": "sdss_stripe82_01",
+        "tableType": [
+          "coadd",
+          "ccdExposure"
+        ],
+        "datatype": "imagemeta",
+        "datasetInfoConverterId": "lsst_sdss",
+        "ra": [
+          "corner1Ra",
+          "corner2Ra",
+          "corner3Ra",
+          "corner4Ra"
+        ],
+        "dec": [
+          "corner1Decl",
+          "corner2Decl",
+          "corner3Decl",
+          "corner4Decl"
+        ]
+      }
+    ]
+  },
+  "WISE": {
+    "catalog": [
+      {
+        "tables": [
+          "allwise_p3as_psd",
+          "allwise_p3as_mep",
+          "allsky_4band_p1bs_psd",
+          "allsky_3band_p1bs_psd",
+          "allsky_2band_p1bs_psd"
+        ],
+        "meta": "db/v0/tap/sync",
+        "database": "wise_00",
+        "objectColumn": [
+          "cntr",
+          "cntr_mf",
+          "cntr",
+          "cntr",
+          "cntr"
+        ],
+        "forcedSourceTable": [
+          "allwise_p3as_mep",
+          "allwise_p3as_mep"
+        ],
+        "tableType": [
+          "source",
+          "forcedSource",
+          "singleExpSource",
+          "singleExpSource",
+          "singleExpSource"
+        ],
+        "datatype": "catalog",
+        "datasetInfoConverterId": "wise",
+        "ra": "ra",
+        "dec": "decl"
+      },
+      {
+        "tables": [
+          "allwise_p3as_psr"
+        ],
+        "meta": "db/v0/tap/sync",
+        "database": "wise_ext_00",
+        "tabletype": [
+          "source"
+        ],
+        "datatype": "catalog",
+        "datasetInfoConverterId": "wise",
+        "ra": "ra",
+        "dec": "decl"
+      },
+      {
+        "tables": [
+          "neowiser_yr1_p1bs_psd"
+        ],
+        "meta": "db/v0/tap/sync",
+        "database": "neowiser_yr1_00",
+        "tabletype": [
+          "source"
+        ],
+        "datatype": "catalog",
+        "datasetInfoConverterId": "wise",
+        "ra": "ra",
+        "dec": "decl"
+      }
+    ],
+    "imagemeta": [
+      {
+        "tables": [
+          "allwise_p3am_cdd",
+          "allwise_p3as_cdd",
+          "allsky_4band_p1bm_frm",
+          "allsky_3band_p1bm_frm",
+          "allsky_2band_p1bm_frm"
+        ],
+        "meta": "db/v0/tap/sync",
+        "database": "wise_00",
+        "tabletype": [
+          "coadd",
+          "coadd",
+          "ccdExposure",
+          "ccdExposure",
+          "ccdExposure"
+        ],
+        "datatype": "imagemeta",
+        "datasetInfoConverterId": "wise",
+        "ra": [
+          "ra1",
+          "ra2",
+          "ra3",
+          "ra4"
+        ],
+        "dec": [
+          "dec1",
+          "dec2",
+          "dec3",
+          "dec4"
+        ],
+        "schema": {
+          "allwise-multiband": {
+            "tables": [
+              "allwise_p3am_cdd",
+              "allwise_p3as_cdd"
+            ],
+            "params": {
+              "ImageSet": "allwise-multiband",
+              "ProductLevel": "3a",
+              "title": "AllWISE"
             }
+          },
+          "allsky_4band-1b": {
+            "tables": [
+              "allsky_4band_p1bm_frm"
+            ],
+            "params": {
+              "ImageSet": "allsky-4band",
+              "ProductLevel": "1b",
+              "title": "AllSky - Single"
+            }
+          },
+          "allsky_4band-3a": {
+            "tables": [],
+            "params": {
+              "ImageSet": "allsky-4band",
+              "ProductLevel": "3a",
+              "title": "AllSky - Atlas"
+            }
+          },
+          "cryo_3band-1b": {
+            "tables": [
+              "allsky_3band_p1bm_frm"
+            ],
+            "params": {
+              "ImageSet": "cryo_3band",
+              "ProductLevel": "1b",
+              "title": "3-Band Single"
+            }
+          },
+          "cryo_3band-1b-3a": {
+            "tables": [],
+            "params": {
+              "ImageSet": "cryo_3band",
+              "ProductLevel": "3a",
+              "title": "3-Band Atlas"
+            }
+          },
+          "postcryo-1b": {
+            "tables": [
+              "allsky_2band_p1bm_frm"
+            ],
+            "params": {
+              "ImageSet": "postcryo",
+              "ProductLevel": "1b",
+              "title": "Post-Cryo"
+            }
+          },
+          "neowiser-1b": {
+            "tables": [],
+            "params": {
+              "ImageSet": "neowiser",
+              "ProductLevel": "1b",
+              "title": "NeoWISER"
+            }
+          }
+        }
+      }
+    ]
+  }
 }

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -386,7 +386,13 @@ export function getDataChangesForMappings({tableModel, mappings, traceNum}) {
         tableModel.tableData.data.forEach((r) => {
             r.map((e, idx) => transposed[idx].push(e));
         });
-        getDataVal = (v) => transposed[cols.indexOf(v)];
+        // tableModel columns are named as the paths to the trace arrays
+        getDataVal = (v) => {
+            const idx = cols.indexOf(v);
+            if (idx >= 0) {
+                return transposed[cols.indexOf(v)];
+            }
+        };
     } else {
         // no tableModel case is for pre-fetch changes
         changes[`fireflyData.${traceNum}.error`] = undefined;
@@ -397,7 +403,7 @@ export function getDataChangesForMappings({tableModel, mappings, traceNum}) {
         Object.entries(mappings).forEach(([k,v]) => {
             // using plotly attribute path (key in the mappings object) as a column name
             // this makes it possible to use the same column as x and y, for example
-            changes[`data.${traceNum}.${k}`] = getDataVal(k);
+            changes[`data.${traceNum}.${k}`] = getDataVal(v) || getDataVal(`data[${traceNum}].${k}`);
         });
     }
 

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -45,7 +45,9 @@ function fetchData(chartId, traceNum, tablesource) {
         startIdx: 0,
         pageSize: MAX_ROW,
         inclCols: Object.entries(mappings).map(([k,v]) => {
-            return `${formatColExpr({colOrExpr: v, quoted: true, colNames: numericCols})} as "${k}"`;
+            // we'd like expression columns to be named as the paths to trace data arrays, ex. data[0].x
+            const asStr = (numericCols.includes(v)) ? '' : ` as "data[${traceNum}].${k}"`;
+            return `${formatColExpr({colOrExpr: v, quoted: true, colNames: numericCols})}${asStr}`;
         }).join(', ')    // allows to use the same columns, ex. "w1" as "x", "w1" as "marker.color"
     });
 

--- a/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/LSSTCatalogSelectViewPanel.jsx
@@ -99,96 +99,112 @@ const LSSTTables = [
     {
         project: 'WISE',
         label: 'WISE',
-        subproject: [{
-            database: 'wise_00',
-            label: 'wise 00',
-            project: 'WISE',
+        subproject: [
+            {
+                database: 'wise_00',
+                label: 'AllWISE',
+                project: 'WISE',
 
-            catalogs: [
-                {
-                    id: SOURCE,
-                    label: 'AllWISE Source Catalog',
-                    value: 'allwise_p3as_psd',
-                    type: CATTYPE
-                },
-                {
-                    id: FORCEDSOURCE,
-                    label: 'AllWISE Multiepoch Photometry Table',
-                    value: 'allwise_p3as_mep',
-                    type: CATTYPE
-                },
-                {
-                    id: SINGLEEXPSOURCE,
-                    label: 'WISE All-Sky Single Exposure (L1b) Source Table',
-                    value: 'allsky_4band_p1bs_psd',
-                    type: CATTYPE
-                },
-                {
-                    id: SINGLEEXPSOURCE,
-                    label: 'WISE 3-Band Cryo Single Exposure (L1b) Source Table',
-                    value: 'allsky_3band_p1bs_psd',
-                    type: CATTYPE
-                },
-                {
-                    id: SINGLEEXPSOURCE,
-                    label: 'WISE Post-Cryo Single Exposure (L1b) Source Table',
-                    value: 'allsky_2band_p1bs_psd',
-                    type: IMAGETYPE
-                }
-            ],
-            images: [
-                {
-                    id: COADD,
-                    label: ' AllWISE Atlas Image',
-                    value: 'allwise_p3am_cdd',
-                    type: IMAGETYPE,
-                    cat: {}
-                },
-                {
-                    id: CCDEXPOSURE,
-                    label: 'WISE All-Sky Single Exposure (L1b) Image',
-                    value: 'allsky_4band_p1bm_frm',
-                    type: IMAGETYPE,
-                    cat: {}
-                },
-                {
-                    id: CCDEXPOSURE,
-                    label: 'WISE 3-Band Cryo Single Exposure (L1b) Image',
-                    value: 'allsky_3band_p1bm_frm',
-                    type: IMAGETYPE,
-                    cat: {}
-                },
-                {
-                    id: CCDEXPOSURE,
-                    label: 'WISE Post-Cryo Single Exposure (L1b) Image',
-                    value: 'allsky_2band_p1bm_frm',
-                    type: IMAGETYPE,
-                    cat: {}
-                }
-            ]
-        },
-        {
-            database: 'wise_ext_00',
-            label: 'wise_ext_00',
-            project: 'WISE',
+                catalogs: [
+                    {
+                        id: SOURCE,
+                        label: 'AllWISE Source Catalog',
+                        value: 'allwise_p3as_psd',
+                        type: CATTYPE
+                    },
+                    {
+                        id: FORCEDSOURCE,
+                        label: 'AllWISE Multiepoch Photometry Table',
+                        value: 'allwise_p3as_mep',
+                        type: CATTYPE
+                    },
+                    {
+                        id: SINGLEEXPSOURCE,
+                        label: 'WISE All-Sky Single Exposure (L1b) Source Table',
+                        value: 'allsky_4band_p1bs_psd',
+                        type: CATTYPE
+                    },
+                    {
+                        id: SINGLEEXPSOURCE,
+                        label: 'WISE 3-Band Cryo Single Exposure (L1b) Source Table',
+                        value: 'allsky_3band_p1bs_psd',
+                        type: CATTYPE
+                    },
+                    {
+                        id: SINGLEEXPSOURCE,
+                        label: 'WISE Post-Cryo Single Exposure (L1b) Source Table',
+                        value: 'allsky_2band_p1bs_psd',
+                        type: IMAGETYPE
+                    }
+                ],
+                images: [
+                    {
+                        id: COADD,
+                        label: ' AllWISE Atlas Image',
+                        value: 'allwise_p3am_cdd',
+                        type: IMAGETYPE,
+                        cat: {}
+                    },
+                    {
+                        id: CCDEXPOSURE,
+                        label: 'WISE All-Sky Single Exposure (L1b) Image',
+                        value: 'allsky_4band_p1bm_frm',
+                        type: IMAGETYPE,
+                        cat: {}
+                    },
+                    {
+                        id: CCDEXPOSURE,
+                        label: 'WISE 3-Band Cryo Single Exposure (L1b) Image',
+                        value: 'allsky_3band_p1bm_frm',
+                        type: IMAGETYPE,
+                        cat: {}
+                    },
+                    {
+                        id: CCDEXPOSURE,
+                        label: 'WISE Post-Cryo Single Exposure (L1b) Image',
+                        value: 'allsky_2band_p1bm_frm',
+                        type: IMAGETYPE,
+                        cat: {}
+                    }
+                ]
+            },
+            {
+                database: 'wise_ext_00',
+                label: 'AllWISE (Ext)',
+                project: 'WISE',
 
-            catalogs: [
-                {
-                    id: SOURCE,
-                    label: 'AllWISE Reject Table',
-                    value: 'allwise_p3as_psr',
-                    type: CATTYPE
-                }
-            ],
-            images: []
-        }]
+                catalogs: [
+                    {
+                        id: SOURCE,
+                        label: 'AllWISE Reject Table',
+                        value: 'allwise_p3as_psr',
+                        type: CATTYPE
+                    }
+                ],
+                images: []
+            },
+            {
+                database: 'neowiser_yr1_00',
+                label: 'NeoWISE',
+                project: 'WISE',
+
+                catalogs: [
+                    {
+                        id: SOURCE,
+                        label: 'NEOWISE-R Year 1 Single Exposure (L1b) Source Table',
+                        value: 'neowiser_yr1_p1bs_psd',
+                        type: CATTYPE
+                    }
+                ],
+                images: []
+            }]
     }
 ];
 
 
 const LSSTTableTypes = {
-   [CATTYPE]: 'Catalogs',
-   [IMAGETYPE]: 'Images'
+    [CATTYPE]: 'Catalogs',
+    [IMAGETYPE]: 'Images'
 };
 
 const LSSTDDPID = 'LSSTMetaSearch';


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-12993

- added NEOWISE data to PDAC search panel, 
- suit is now using multitrace charts, 
- fixed chart display for columns of type 'long' (was getting error before)
- when columns are used to create scatter, tooltips should show the same data we see in table cells

Please, check out the corresponding branch in suit to test:

To test

1. Build both firefly and suit:
`cd ../firefly; gradle :firefly:clean; gradle :firefly:bAAD; cd ../suit; gradle :suit:bAAD`
2. Connect to ncsa vpn
3. http://localhost:8080/suit
Choose NeoWISE from project list (there is only a single catalog table)

Working samples from DM-12992:
```
curl -o neowy1.json -d 'query=SELECT+*+FROM+neowiser_yr1_00.neowiser_yr1_p1bs_psd+WHERE+qserv_areaspec_circle(9.469,-1.152,0.01);' http://lsst-qserv-dax01.ncsa.illinois.edu:5000/db/v0/tap/sync
curl -o neowPolygon.json -d 'query=SELECT+*+FROM+neowiser_yr1_00.neowiser_yr1_p1bs_psd+WHERE+qserv_areaspec_poly(9.4, -1.2, 9.6, -1.2, 9.4, -1.1);' http://lsst-qserv-dax01.ncsa.illinois.edu:5000/db/v0/tap/sync
```



