### PR TITLE
DM-13192 ImageServAPI v1

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -132,8 +132,16 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                 StopWatch.getInstance().start("createDbFile: " + request.getRequestId());
                 DbAdapter dbAdapter = DbAdapter.getAdapter(treq);
                 dbFile = createDbFile(treq);
-                FileInfo dbFileInfo = ingestDataIntoDb(treq, dbFile);
-                dbFile = dbFileInfo.getFile();
+                try {
+                    FileInfo dbFileInfo = ingestDataIntoDb(treq, dbFile);
+                    dbFile = dbFileInfo.getFile();
+                } catch (DataAccessException e) {
+                    dbFile.delete();
+                    throw e;
+                } catch (Exception e) {
+                    dbFile.delete();
+                    throw new DataAccessException(e);
+                }
                 EmbeddedDbUtil.setDbMetaInfo(treq, dbAdapter, dbFile);
                 dbFileCreated = true;
                 StopWatch.getInstance().stop("createDbFile: " + request.getRequestId()).printLog("createDbFile: " + request.getRequestId());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessorWrapper.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessorWrapper.java
@@ -51,7 +51,9 @@ public class EmbeddedDbProcessorWrapper extends EmbeddedDbProcessor {
 
             FileInfo finfo = EmbeddedDbUtil.ingestDataGroup(dbFile, dg, dbAdapter, "data");
             return finfo;
-        } catch (IpacTableException | IOException | DataAccessException ex) {
+        } catch (DataAccessException ex) {
+            throw ex;
+        } catch (IpacTableException | IOException ex) {
             throw new DataAccessException(ex);
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
@@ -12,10 +12,11 @@ import edu.caltech.ipac.util.DataType;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.visualize.plot.CoordinateSys;
 import edu.caltech.ipac.visualize.plot.WorldPt;
-import java.util.List;
-import java.util.Locale;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+
+import java.util.List;
+import java.util.Locale;
 
 
 /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCataLogSearch.java
@@ -313,11 +313,14 @@ public class LSSTCataLogSearch extends LSSTQuery {
         String database = request.getParam("database");
 
         if (LSSTQuery.isCatalogTable(database, catTable)) {
-            Object RA = LSSTQuery.getRA(database, catTable);
-            Object DEC = LSSTQuery.getDEC(database, catTable);
+            Object lon = LSSTQuery.getRA(database, catTable);
+            Object lat = LSSTQuery.getDEC(database, catTable);
 
-            TableMeta.LonLatColumns llc = new TableMeta.LonLatColumns((String) RA, (String) DEC, CoordinateSys.EQ_J2000);
-            meta.setCenterCoordColumns(llc);
+            if (lon != null && lat != null) {
+                TableMeta.LonLatColumns llc = new TableMeta.LonLatColumns((String) lon, (String) lat, CoordinateSys.EQ_J2000);
+                meta.setCenterCoordColumns(llc);
+                meta.setLonLatColumnAttr(MetaConst.CATALOG_COORD_COLS, llc);
+            }
             meta.setAttribute(MetaConst.CATALOG_OVERLAY_TYPE, "LSST");
             String col = LSSTQuery.getTableColumn(database, catTable, "objectColumn");
             if (col != null) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTFileGroupProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTFileGroupProcessor.java
@@ -2,19 +2,23 @@ package edu.caltech.ipac.firefly.server.query.lsst;
 
 import edu.caltech.ipac.astro.IpacTableException;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
+import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
-import edu.caltech.ipac.firefly.data.FileInfo;
-import edu.caltech.ipac.firefly.server.query.*;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.query.FileGroupsProcessor;
+import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
 import edu.caltech.ipac.firefly.server.util.ipactable.IpacTableParser;
-import java.io.File;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static edu.caltech.ipac.firefly.server.util.Logger.getLogger;
 
@@ -119,19 +123,19 @@ public class LSSTFileGroupProcessor  extends FileGroupsProcessor {
 
 
         if (isDeepCoadd){
-            Long tract = (Long) dgData.get(rowIdx,"tract");
+            String tract = dgData.get(rowIdx,"tract").toString();
             String patch = (String) dgData.get(rowIdx,"patch");
             String filterName =(String) dgData.get(rowIdx,"filterName");
 
-            return LSSTImageSearch.createURLForDeepCoadd(tract.toString(), patch, filterName);
+            return LSSTImageSearch.createURLForDeepCoadd(tract, patch, filterName);
         }
         else{
-            Long run =  (Long) dgData.get(rowIdx,"run");
-            Integer camcol =  (Integer)dgData.get(rowIdx,"camcol");
-            Long field =  (Long) dgData.get(rowIdx,"field");
+            String run = dgData.get(rowIdx,"run").toString();
+            String camcol =  dgData.get(rowIdx,"camcol").toString();
+            String field =  dgData.get(rowIdx,"field").toString();
             String filterName =  (String) dgData.get(rowIdx,"filterName");
 
-            return LSSTImageSearch.createURLForScienceCCD(run.toString(), camcol.toString(),field.toString(), filterName);
+            return LSSTImageSearch.createURLForScienceCCD(run, camcol, field, filterName);
         }
 
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTImageSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTImageSearch.java
@@ -24,7 +24,11 @@ import java.util.ArrayList;
 @SearchProcessorImpl(id = "LSSTImageSearch")
 public class LSSTImageSearch extends URLFileInfoProcessor {
     private static final Logger.LoggerImpl logger = Logger.getLogger();
-    private static String DAX_URL="http://lsst-qserv-dax01.ncsa.illinois.edu:5000/image/v0/";
+    // using ImageServ API v1: https://confluence.lsstcorp.org/display/DM/ImageServ+API+-+v1
+    // image repository (DC_W13_Stripe82) is a part of the URL, but it is not clear where it comes from
+    // and how we should get it: via metaserv or image/v1/capabilities
+    // I am hardcoding it here for now
+    public static String DAX_URL="http://lsst-qserv-dax01.ncsa.illinois.edu:5000/image/v1/DC_W13_Stripe82";
 
     /**
      * Implement the abstract method, "getURL"
@@ -84,12 +88,16 @@ public class LSSTImageSearch extends URLFileInfoProcessor {
         if (imageType.equals("calexp")) {
             String imageId = request.getParam("imageId");
             // width and height in arcseconds
-            return new URL(DAX_URL+imageType+"/"+imageId+"/cutout?ra="+ra+"&dec="+dec+"&widthAng="+subsizeArcSec+"&heightAng="+subsizeArcSec);
+            // ImageServAPI-I11
+            return new URL(DAX_URL+"?ds="+imageType+"&sid="+imageId+
+                    "&ra="+ra+"&dec="+dec+"&width="+subsizeArcSec+"&height="+subsizeArcSec+"&unit=arcsec");
         } else {
             // coadd
             String filterName = request.getParam("filterName");
             // width and height in arcseconds, for pixels use cutoutPixel instead of cutout
-            return new URL(DAX_URL+imageType+"/cutout?ra="+ra+"&dec="+dec+"&filter="+filterName+"&width="+subsizeArcSec+"&height="+subsizeArcSec);
+            // ImageServAPI-I9
+            return new URL(DAX_URL+"?ds="+imageType+
+                    "&ra="+ra+"&dec="+dec+"&filter="+filterName+"&width="+subsizeArcSec+"&height="+subsizeArcSec+"&unit=arcsec");
         }
 
 
@@ -151,11 +159,13 @@ public class LSSTImageSearch extends URLFileInfoProcessor {
 
     private static  String getBaseURL(boolean isDeepCoadd){
         if (isDeepCoadd) {
-            return DAX_URL+"deepCoadd/ids?";
+            // ImageServAPI-I14
+            return DAX_URL+"?ds=deepCoadd&";
 
         }
         else {
-            return DAX_URL+"calexp/ids?";
+            // ImageServAPI-I7
+            return DAX_URL+"?ds=calexp&";
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMultiObjectSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMultiObjectSearch.java
@@ -2,21 +2,19 @@ package edu.caltech.ipac.firefly.server.query.lsst;
 
 import edu.caltech.ipac.firefly.core.EndUserException;
 import edu.caltech.ipac.firefly.data.CatalogRequest;
-import edu.caltech.ipac.firefly.server.ServerContext;
-import edu.caltech.ipac.firefly.server.query.*;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
 import edu.caltech.ipac.firefly.server.util.ConcurrentSearchUtil;
-import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupReader;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupWriter;
-import edu.caltech.ipac.firefly.visualize.VisUtil;
-import edu.caltech.ipac.util.*;
-import edu.caltech.ipac.visualize.plot.WorldPt;
+import edu.caltech.ipac.util.DataGroup;
+import edu.caltech.ipac.util.DataObject;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 
 
@@ -95,7 +93,7 @@ public class LSSTMultiObjectSearch extends LSSTCataLogSearch{
             columnNames = request.getParam(CatalogRequest.SELECTED_COLUMNS);
             catTable = request.getParam(CatalogRequest.CATALOG);
             /*If the major is in the input file, use the major/2 as the radius.  Since the major is in
-              archsec convert the major to degree
+              arcsec convert the major to degree
             */
             radius = dataObject.containsKey("major") && dataObject.getDataElement("major")!=null?
                   String.valueOf(Double.parseDouble(dataObject.getDataElement("major").toString())/3600.0)
@@ -112,7 +110,7 @@ public class LSSTMultiObjectSearch extends LSSTCataLogSearch{
                 return "CONE";
             }
             //Search an elliptical area around each of two positions.
-            if ( major.length()!=0  && ratio.length()!=0){
+            else if (major.length()!=0){
                 return "ELIPTICAL";
             }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
@@ -41,7 +41,7 @@ import java.util.Map;
  */
 public abstract class LSSTQuery extends IpacTablePartProcessor {
     private static final Logger.LoggerImpl _log = Logger.getLogger();
-    public static final String PORT = "5000";
+    public static final String PORT = "5003";
     public static final String HOST = AppProperties.getProperty("lsst.dd.hostname","lsst-qserv-dax01.ncsa.illinois.edu");
 
     //set default timeout to 180 seconds

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
@@ -41,7 +41,7 @@ import java.util.Map;
  */
 public abstract class LSSTQuery extends IpacTablePartProcessor {
     private static final Logger.LoggerImpl _log = Logger.getLogger();
-    public static final String PORT = "5003";
+    public static final String PORT = "5000";
     public static final String HOST = AppProperties.getProperty("lsst.dd.hostname","lsst-qserv-dax01.ncsa.illinois.edu");
 
     //set default timeout to 180 seconds

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -22,7 +22,7 @@ import {syncChartViewer, addDefaultScatter} from '../../visualize/saga/ChartsSyn
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
 import {watchCatalogs} from '../../visualize/saga/CatalogWatcher.js';
 import {getImageMasterData} from '../../visualize/ui/AllImageSearchConfig.js';
-import {initWorkspace} from '../../visualize/WorkspaceCntlr.js';
+import {getWorkspaceConfig, initWorkspace} from '../../visualize/WorkspaceCntlr.js';
 
 import FFTOOLS_ICO from 'html/images/fftools-logo-offset-small-75x75.png';
 
@@ -56,7 +56,7 @@ export class FireflyViewer extends PureComponent {
         dispatchAddSaga(layoutManager,{views: props.views});
         dispatchAddSaga(syncChartViewer);
         dispatchAddSaga(addDefaultScatter);
-        initWorkspace();
+        if (getWorkspaceConfig()) { initWorkspace(); }
     }
 
     getNextState() {

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -35,7 +35,7 @@ import {HelpText} from './../../ui/HelpText.jsx';
 import {dispatchAllowDataTag} from '../../core/background/BackgroundCntlr.js';
 import {WorkspaceUpload} from '../../ui/WorkspaceViewer.jsx';
 import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
-import {initWorkspace} from '../../visualize/WorkspaceCntlr.js';
+import {getWorkspaceConfig, initWorkspace} from '../../visualize/WorkspaceCntlr.js';
 import {ServerParams} from '../../data/ServerParams.js';
 
 const vFileKey = LC.FG_FILE_FINDER;
@@ -51,7 +51,7 @@ export class LcViewer extends PureComponent {
         dispatchAddSaga(watchCatalogs);
         dispatchAddSaga(lcManager);
         dispatchAddSaga(syncChartViewer);
-        initWorkspace();
+        if (getWorkspaceConfig()) { initWorkspace();}
     }
 
     getNextState() {

--- a/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/lsst_sdss/LsstSdssMissionOptions.js
@@ -197,8 +197,8 @@ export function lsstSdssRawTableRequest(converter, source) {
 function makeRawTableRequest(missionEntries, rawTableRequest) {
     const band = missionEntries['band'];
     const filterInfo = new FilterInfo;
-    filterInfo.addFilter('filterName', `LIKE ${band}`);
-    var searchRequest = cloneDeep(rawTableRequest);
+    filterInfo.addFilter('filterName', `LIKE '${band}'`);
+    let searchRequest = cloneDeep(rawTableRequest);
     searchRequest.filters = filterInfo.serialize();
     searchRequest = JSON.stringify(searchRequest);
     const options = {

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -550,7 +550,7 @@ function defaultCanDoCorners(table) {// eslint-disable-line no-unused-vars
 
 function getCovColumnsForQuery(options, table) {
     const cAry= [...options.getCornersColumns(table), options.getCenterColumns(table)];
-    const base = cAry.map( (c)=> `"${c.lonCol}","${c.latCol}"`).join();     // column names should be in quotes
+    const base = cAry.filter((c)=>Boolean(c)).map( (c)=> `"${c.lonCol}","${c.latCol}"`).join();     // column names should be in quotes
     return base+',"ROW_IDX"';
 }
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTDbServTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTDbServTest.java
@@ -9,7 +9,6 @@ import edu.caltech.ipac.firefly.server.query.lsst.LSSTQuery;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.util.download.URLDownload;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -21,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Test that we can get catalogs and image metadata from DAX dbserv, when it's available
+ * Test that we can get catalogs and image metadata from DAX dbserv, when it's available 
  */
 public class LSSTDbServTest extends ConfigTest {
 
@@ -58,11 +57,7 @@ public class LSSTDbServTest extends ConfigTest {
             "SELECT count(*) FROM sdss_stripe82_01.RunDeepForcedSource WHERE objectId=3448068867358968;"
             
 	};
-
-
-	@BeforeClass
-	public static void setUp() {
-	}
+	
 
 	/**
 	 * test that we can obtain the data for all catalog queries
@@ -75,7 +70,7 @@ public class LSSTDbServTest extends ConfigTest {
                 boolean passed;
                 for (String query : queries) {
                     passed = getJsonData(query);
-                    Assert.assertTrue(passed);
+                    Assert.assertTrue("FAILED: "+query, passed);
                 }
             }
 		} catch (Exception e) {
@@ -96,20 +91,19 @@ public class LSSTDbServTest extends ConfigTest {
 
 			long cTime = System.currentTimeMillis();
 			FileInfo fileData = URLDownload.getDataToFileUsingPost(new URL(url), sql, null, requestHeader, file, null, 180);
-			System.out.println("SQL query took " + (System.currentTimeMillis() - cTime) + "ms");
-			System.out.println(query);
-			System.out.println();
+			LOG.info("SQL query took " + (System.currentTimeMillis() - cTime) + "ms");
+			LOG.info(query);
 
 			if (fileData.getResponseCode() >= 400) {
 				String err = LSSTQuery.getErrorMessageFromFile(file);
 				err = "[DAX] " + (err == null ? fileData.getResponseCodeMsg() : err);
-				System.out.println(err);
+				LOG.error(err, query);
 				return false;
 			} else {
 				return true;
 			}
 		} catch (FailedRequestException | IOException e) {
-			e.printStackTrace();
+			LOG.error(e, query);
 			return false;
 		}
 	}
@@ -127,7 +121,7 @@ public class LSSTDbServTest extends ConfigTest {
 			urlConn.connect();
 			return urlConn.getResponseCode() == 200;
 		} catch (IOException e) {
-		    System.out.println("dbserv is not available "+e.getMessage());
+		    LOG.info("dbserv is not available "+e.getMessage());
 			return false;
 		}
 	}
@@ -144,7 +138,7 @@ public class LSSTDbServTest extends ConfigTest {
 			urlConn.connect();
 			return urlConn.getResponseCode() == 200;
 		} catch (IOException e) {
-            System.out.println("DAX is not available "+e.getMessage());
+            LOG.info("DAX is not available "+e.getMessage());
 			return false;
 		}
 	}

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTDbServTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTDbServTest.java
@@ -30,7 +30,7 @@ public class LSSTDbServTest extends ConfigTest {
 			"SELECT * FROM sdss_stripe82_01.RunDeepSource WHERE qserv_areaspec_circle(9.469,-1.152,0.01);",
 			"SELECT * FROM wise_00.allwise_p3as_mep WHERE qserv_areaspec_circle(9.469,-1.152,0.01);",
 			"SELECT * FROM sdss_stripe82_01.RunDeepSource WHERE qserv_areaspec_box(9.5,-1.23,9.6,-1.22);",
-			"SELECT * FROM sdss_stripe82_01.RunDeepSource1 WHERE qserv_areaspec_ellipse(9.469,-1.152,58,36,0);",
+			"SELECT * FROM sdss_stripe82_01.RunDeepSource WHERE qserv_areaspec_ellipse(9.469,-1.152,58,36,0);",
 			"SELECT * FROM sdss_stripe82_01.RunDeepForcedSource WHERE qserv_areaspec_poly(9.4,-1.2,9.6,-1.2,9.4,-1.1);",
 			// image metadata searches
 			"SELECT * FROM sdss_stripe82_01.DeepCoadd WHERE scisql_s2PtInCPoly(9.462, -1.152, corner1Ra, corner1Decl, corner2Ra, corner2Decl, corner3Ra, corner3Decl, corner4Ra, corner4Decl)=1;",
@@ -44,7 +44,7 @@ public class LSSTDbServTest extends ConfigTest {
 					"(scisql_s2PtInCPoly(9.5, -1.23, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1) AND " +
 					"(scisql_s2PtInCPoly(9.5, -1.22, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1) AND " +
 					"(scisql_s2PtInCPoly(9.6, -1.23, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1) AND " +
-					"(scisql_s2PtInCPoly(9.6, -1.22, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1);'",
+					"(scisql_s2PtInCPoly(9.6, -1.22, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1);",
             "SELECT * FROM sdss_stripe82_01.Science_Ccd_Exposure WHERE " +
                     "(scisql_s2PtInBox(corner1Ra, corner1Decl, 0, -1, 5, 1)=1) AND " +
                     "(scisql_s2PtInBox(corner2Ra, corner2Decl,0, -1, 5, 1) =1) AND " +

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTDbServTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTDbServTest.java
@@ -1,0 +1,151 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.query.lsst.LSSTQuery;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.URLDownload;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test that we can get catalogs and image metadata from DAX dbserv, when it's available
+ */
+public class LSSTDbServTest extends ConfigTest {
+
+	private static String [] queries = {
+			//catalog searches
+			"SELECT * FROM sdss_stripe82_01.RunDeepSource WHERE qserv_areaspec_circle(9.469,-1.152,0.01);",
+			"SELECT * FROM wise_00.allwise_p3as_mep WHERE qserv_areaspec_circle(9.469,-1.152,0.01);",
+			"SELECT * FROM sdss_stripe82_01.RunDeepSource WHERE qserv_areaspec_box(9.5,-1.23,9.6,-1.22);",
+			"SELECT * FROM sdss_stripe82_01.RunDeepSource1 WHERE qserv_areaspec_ellipse(9.469,-1.152,58,36,0);",
+			"SELECT * FROM sdss_stripe82_01.RunDeepForcedSource WHERE qserv_areaspec_poly(9.4,-1.2,9.6,-1.2,9.4,-1.1);",
+			// image metadata searches
+			"SELECT * FROM sdss_stripe82_01.DeepCoadd WHERE scisql_s2PtInCPoly(9.462, -1.152, corner1Ra, corner1Decl, corner2Ra, corner2Decl, corner3Ra, corner3Decl, corner4Ra, corner4Decl)=1;",
+			"SELECT * FROM wise_00.allwise_p3am_cdd WHERE scisql_s2PtInCPoly(9.462, -1.152, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1;",
+			"SELECT * FROM sdss_stripe82_01.Science_Ccd_Exposure WHERE " +
+					"(scisql_s2PtInCPoly(9.5, -1.23, corner1Ra, corner1Decl, corner2Ra, corner2Decl, corner3Ra, corner3Decl, corner4Ra, corner4Decl)=1) AND " +
+					"(scisql_s2PtInCPoly(9.5, -1.22, corner1Ra, corner1Decl, corner2Ra, corner2Decl, corner3Ra, corner3Decl, corner4Ra, corner4Decl)=1) AND " +
+					"(scisql_s2PtInCPoly(9.6, -1.23, corner1Ra, corner1Decl, corner2Ra, corner2Decl, corner3Ra, corner3Decl, corner4Ra, corner4Decl)=1) AND " +
+					"(scisql_s2PtInCPoly(9.6, -1.22, corner1Ra, corner1Decl, corner2Ra, corner2Decl, corner3Ra, corner3Decl, corner4Ra, corner4Decl)=1);",
+			"SELECT * FROM wise_00.allsky_2band_p1bm_frm WHERE " +
+					"(scisql_s2PtInCPoly(9.5, -1.23, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1) AND " +
+					"(scisql_s2PtInCPoly(9.5, -1.22, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1) AND " +
+					"(scisql_s2PtInCPoly(9.6, -1.23, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1) AND " +
+					"(scisql_s2PtInCPoly(9.6, -1.22, ra1, dec1, ra2, dec2, ra3, dec3, ra4, dec4)=1);'",
+            "SELECT * FROM sdss_stripe82_01.Science_Ccd_Exposure WHERE " +
+                    "(scisql_s2PtInBox(corner1Ra, corner1Decl, 0, -1, 5, 1)=1) AND " +
+                    "(scisql_s2PtInBox(corner2Ra, corner2Decl,0, -1, 5, 1) =1) AND " +
+                    "(scisql_s2PtInBox(corner3Ra, corner3Decl, 0, -1, 5, 1)=1) AND " +
+                    "(scisql_s2PtInBox(corner4Ra, corner4Decl, 0, -1, 5, 1)=1);",
+            "SELECT * FROM wise_00.allwise_p3am_cdd WHERE " +
+                    "(scisql_s2PtInBox(ra1, dec1, 0, -1, 5, 1)=1) AND " +
+                    "(scisql_s2PtInBox(ra2, dec2,0, -1, 5, 1) =1) AND " +
+                    "(scisql_s2PtInBox(ra3, dec3, 0, -1, 5, 1)=1) AND " +
+                    "(scisql_s2PtInBox(ra4, dec4, 0, -1, 5, 1)=1);",
+            "SELECT count(*) FROM sdss_stripe82_01.RunDeepForcedSource WHERE objectId=3448068867358968;"
+            
+	};
+
+
+	@BeforeClass
+	public static void setUp() {
+	}
+
+	/**
+	 * test that we can obtain the data for all catalog queries
+	 */
+	@Test
+	public void testCatalogQueries() {
+		try {
+
+		    if (daxAvailable() && dbservAvailable()) {
+                boolean passed;
+                for (String query : queries) {
+                    passed = getJsonData(query);
+                    Assert.assertTrue(passed);
+                }
+            }
+		} catch (Exception e) {
+			Assert.fail("testCatalogQueries failed with exception: " + e.getMessage());
+		}
+	}
+
+
+	private static boolean getJsonData(String query) {
+		try {
+			String sql = "query=" + URLEncoder.encode(query, "UTF-8");
+
+			String url = "http://" + LSSTQuery.HOST + ":" + LSSTQuery.PORT + "/db/v0/tap/sync";
+			File file = File.createTempFile("lssttest", "json");
+			file.deleteOnExit();
+			Map<String, String> requestHeader = new HashMap<>();
+			requestHeader.put("Accept", "application/json");
+
+			long cTime = System.currentTimeMillis();
+			FileInfo fileData = URLDownload.getDataToFileUsingPost(new URL(url), sql, null, requestHeader, file, null, 180);
+			System.out.println("SQL query took " + (System.currentTimeMillis() - cTime) + "ms");
+			System.out.println(query);
+			System.out.println();
+
+			if (fileData.getResponseCode() >= 400) {
+				String err = LSSTQuery.getErrorMessageFromFile(file);
+				err = "[DAX] " + (err == null ? fileData.getResponseCodeMsg() : err);
+				System.out.println(err);
+				return false;
+			} else {
+				return true;
+			}
+		} catch (FailedRequestException | IOException e) {
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+
+	/**
+	 * Is dbserv running?
+	 * @return true if dbserv is accessible and running
+	 */
+	private static boolean dbservAvailable() {
+		try {
+			URL urlServer = new URL("http://"+ LSSTQuery.HOST +":"+LSSTQuery.PORT+"/db/v0/tap/");
+			HttpURLConnection urlConn = (HttpURLConnection) urlServer.openConnection();
+			urlConn.setConnectTimeout(3000); // 3 seconds timeout
+			urlConn.connect();
+			return urlConn.getResponseCode() == 200;
+		} catch (IOException e) {
+		    System.out.println("dbserv is not available "+e.getMessage());
+			return false;
+		}
+	}
+
+	/**
+	 * Is DAX running?
+	 * @return true if DAX is accessible and running
+	 */
+	public static boolean daxAvailable() {
+		try {
+			URL urlServer = new URL("http://"+ LSSTQuery.HOST +":"+LSSTQuery.PORT+"/");
+			HttpURLConnection urlConn = (HttpURLConnection) urlServer.openConnection();
+			urlConn.setConnectTimeout(3000); // 3 seconds timeout
+			urlConn.connect();
+			return urlConn.getResponseCode() == 200;
+		} catch (IOException e) {
+            System.out.println("DAX is not available "+e.getMessage());
+			return false;
+		}
+	}
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTImgServTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTImgServTest.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.query;
 
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.query.lsst.LSSTImageSearch;
 import edu.caltech.ipac.firefly.server.query.lsst.LSSTQuery;
@@ -17,9 +18,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 /**
- * Test getting images from DAX ImageServ, when it's available
+ * Test getting images from DAX ImageServ, when it's available 
  */
-public class LSSTImgServTest {
+public class LSSTImgServTest extends ConfigTest {
 
     @Test
    	public void testDaxImages() {
@@ -38,7 +39,7 @@ public class LSSTImgServTest {
                 boolean passed;
                 for (String url : urls) {
                     passed = getImage(url);
-                    Assert.assertTrue(passed);
+                    Assert.assertTrue("FAILED: "+url, passed);
                 }
             }
    		} catch (Exception e) {
@@ -53,19 +54,18 @@ public class LSSTImgServTest {
 
             long cTime = System.currentTimeMillis();
             FileInfo fileData = URLDownload.getDataToFile(new URL(url), file);
-            System.out.println("Image retrieval took " + (System.currentTimeMillis() - cTime) + "ms");
-            System.out.println(url);
-            System.out.println();
+            LOG.info("Image retrieval took " + (System.currentTimeMillis() - cTime) + "ms");
+            LOG.info(url);
 
             if (fileData.getResponseCode() >= 400) {
                 String err = fileData.getResponseCode()+" "+fileData.getResponseCodeMsg();
-                System.out.println(err);
+                LOG.error(err);
                 return false;
             } else {
                 return true;
             }
         } catch (FailedRequestException | IOException e) {
-            e.printStackTrace();
+            LOG.error(e, url);
             return false;
         }
     }
@@ -78,7 +78,7 @@ public class LSSTImgServTest {
       			urlConn.connect();
       			return urlConn.getResponseCode() == 200;
       		} catch (IOException e) {
-      		    System.out.println("imgserv is not available "+e.getMessage());
+                LOG.info("imgserv is not available "+e.getMessage());
       			return false;
       		}
     }

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTImgServTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/LSSTImgServTest.java
@@ -1,0 +1,85 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.query.lsst.LSSTImageSearch;
+import edu.caltech.ipac.firefly.server.query.lsst.LSSTQuery;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.URLDownload;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Test getting images from DAX ImageServ, when it's available
+ */
+public class LSSTImgServTest {
+
+    @Test
+   	public void testDaxImages() {
+   		try {
+            if (LSSTDbServTest.daxAvailable() && imgservAvailable()) {
+                // calexp exposure
+                String ccdUrl = LSSTImageSearch.createURLForScienceCCD("5646", "4", "694", "g");
+                // deep coadd image
+                String deepCoaddUrl = LSSTImageSearch.createURLForDeepCoadd("0", "225,1", "r");
+                // calexp cutout
+                String ccdCutoutUrl = LSSTImageSearch.DAX_URL+"?ds=calexp&sid=5646240694&ra=37.6292&dec=0.104625&width=300.0&height=450.0&unit=arcsec";
+                // deep coadd cutout
+                String deepCoaddCutoutUrl = LSSTImageSearch.DAX_URL+"?ds=deepcoadd&ra=19.36995&dec=-0.3147&filter=r&width=300&height=400&unit=arcsec";
+
+                String[] urls = {ccdUrl, deepCoaddUrl, ccdCutoutUrl, deepCoaddCutoutUrl};
+                boolean passed;
+                for (String url : urls) {
+                    passed = getImage(url);
+                    Assert.assertTrue(passed);
+                }
+            }
+   		} catch (Exception e) {
+   			Assert.fail("testDaxImages failed with exception: " + e.getMessage());
+   		}
+   	}
+
+    private boolean getImage(String url) {
+        try {
+            File file = File.createTempFile("lssttest", "json");
+            file.deleteOnExit();
+
+            long cTime = System.currentTimeMillis();
+            FileInfo fileData = URLDownload.getDataToFile(new URL(url), file);
+            System.out.println("Image retrieval took " + (System.currentTimeMillis() - cTime) + "ms");
+            System.out.println(url);
+            System.out.println();
+
+            if (fileData.getResponseCode() >= 400) {
+                String err = fileData.getResponseCode()+" "+fileData.getResponseCodeMsg();
+                System.out.println(err);
+                return false;
+            } else {
+                return true;
+            }
+        } catch (FailedRequestException | IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+   	private static boolean imgservAvailable() {
+        try {
+      			URL urlServer = new URL("http://"+ LSSTQuery.HOST +":"+LSSTQuery.PORT+"/image/v1");
+      			HttpURLConnection urlConn = (HttpURLConnection) urlServer.openConnection();
+      			urlConn.setConnectTimeout(3000); // 3 seconds timeout
+      			urlConn.connect();
+      			return urlConn.getResponseCode() == 200;
+      		} catch (IOException e) {
+      		    System.out.println("imgserv is not available "+e.getMessage());
+      			return false;
+      		}
+    }
+}


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-13192

The purpose of this PR is to convert from [DAX ImageServ v0](https://confluence.lsstcorp.org/display/DM/Update+for+ImageServ+API+-+v0) to [DAX ImageServ v1](https://confluence.lsstcorp.org/display/DM/ImageServ+API+-+v1)

- converted URLs to work with ImageServ v1
- added unit tests to check for successful HTTP status when retrieving table and images from DAX (when DAX services are available)
- bug fix: applications with no workspace, should not initialize it
- bug fix: catalog watcher should not throw exception when center cols are missing and only corner cols are present
- bug fix: filter syntax should be `"filterName" LIKE 'u'`
- avoid unnecessary wrapping of DataAccessException

To run tests:
gradle -Dtest.single=LSSTDbServ :firefly:test
gradle -Dtest.single=LSSTImgServ :firefly:test

This PR can not be verified before QServ and DAX services are restored to normal state.
