### PR TITLE
DM-13241 Fix client table filtering issues on 'LIKE' and 'IN' conditions

### DIFF
--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -4,7 +4,8 @@
 
 import {getColumnIdx, getColumn, isNumericType, getTblById} from './TableUtil.js';
 import {Expression} from '../util/expr/Expression.js';
-import {isUndefined, get} from 'lodash';
+import {isUndefined, get, isArray} from 'lodash';
+import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 const cond_regex = new RegExp('(!=|>=|<=|<|>|=|like|in|is|is not)?\\s*(.+)');
 const cond_only_regex = new RegExp('^' + cond_regex.source, 'i');
@@ -176,17 +177,26 @@ export class FilterInfo {
         const cidx = getColumnIdx(tableModel, cname);
         const noROWID = cname === 'ROW_IDX' && cidx < 0;
         const colType = noROWID ? 'int' : get(getColumn(tableModel, cname), 'type', 'char');
+        const convertStrToNumber = (str, bRemoveQuote=true) => {
+            const numStr = bRemoveQuote ? removeQuoteAroundString(str) : str;
 
-        val = op === 'in' ? val.replace(/[()]/g, '').split(',').map((s) => s.trim()) : val;
+            return colType.match(/^[i]/) ? parseInt(numStr) : parseFloat(numStr);
+        };
 
-        if (colType.match(/^[sc]/)) {
-            if (op === 'in') {
-                val = val.map((s) => {
-                    return removeQuoteAroundString(s);
-                });
-            } else {
-                val = removeQuoteAroundString(val);
+
+        // update val of operator 'in' into an array of value
+        if (op === 'in') {
+            if (val.match(/^\(.*\)$/)) {
+                val = val.substring(1, val.length-1);
             }
+            val = val.split(',').map((s) => s.trim());
+        }
+
+        // remove single quote enclosing the string for the value of operater 'like' or char type column
+        if (op === 'like' || colType.match(/^[sc]/)) {
+            val = isArray(val) ? val.map((s) => removeQuoteAroundString(s)) : removeQuoteAroundString(val);
+        } else if (colType.match(/^[dfil]/)) {    // convert to number by removing single quote except 'in'
+            val =  isArray(val) ? val.map((s) => convertStrToNumber(s, false)) : convertStrToNumber(val);
         }
 
         return (row, idx) => {
@@ -194,8 +204,7 @@ export class FilterInfo {
             var compareTo = noROWID ? idx : row[cidx];
             if (isUndefined(compareTo)) return false;
 
-            if (!['in','like'].includes(op) && colType.match(/^[dfil]/)) {      // int, float, double, long .. or their short form.
-                val = Number(val);
+            if (op !== 'like' && colType.match(/^[dfil]/)) {      // int, float, double, long .. or their short form.
                 compareTo = Number(compareTo);
             } else {
                 compareTo = compareTo.toLowerCase();
@@ -204,7 +213,6 @@ export class FilterInfo {
             switch (op) {
                 case 'like' :
                     const reg = likeToRegexp(val);
-
                     return reg.test(compareTo);
                 case '>'  :
                     return compareTo > val;
@@ -277,31 +285,58 @@ export class FilterInfo {
 }
 
 /**
- * convert sql like condition to RegExp, usage of wildcard, % & _, escape wildcard, \% and \_ are considered
+ * convert sql like condition to RegExp, the following character cases in like condition are changed
+ * - usage of special characters for regular expression
+ * - usage of wildcard, % & _, escape wildcard, \% and \_,
+ * - usage of \\ is kept same in regular expression
  * @param text
  * @returns {RegExp}
  */
 function likeToRegexp(text) {
-    const specials = ['/', '.', '*', '+', '?', '|', ':', '!',
-        '(', ')', '[', ']', '{', '}', '\\', '^', '$', '-', '='
+    const specials = ['/', '.', '*', '+', '?', ':', '!',
+        '(', ')', '[', ']', '{', '}', '^', '$', '-', '='
     ];
 
     const sRE = new RegExp('(\\' + specials.join('|\\') + ')', 'g');
-    const wildcardSqlRegexp = (w) => {
-        return new RegExp('(?<!\\\\)'+ w, 'g');
-    };
-    const escapeWildcardSqlRegexp = (w) => {
-        return new RegExp('\\\\\\\\'+w, 'g');
-    };
 
-    const  newText = text.replace(sRE, '\\$1')
-                       .replace(wildcardSqlRegexp('%'), '.*')
-                       .replace(wildcardSqlRegexp('_'), '.')
-                       .replace(escapeWildcardSqlRegexp('%'), '%')
-                       .replace(escapeWildcardSqlRegexp('_'), '_');
+    // r1 is the replacement for w, r2 is the replacement for \w
+    function replaceWildCard(str, w, r1, r2, sIdx = 0) {
 
+        const idx = str.indexOf(w, sIdx);
 
-    return new RegExp(newText);
+        if (idx < 0) return str;
+
+        const escape = '\\';
+        let newStr;
+        let totalEscape = 0;
+
+        for (let i = idx-1; i >= sIdx; i--) {
+            if (str.charAt(i) !== escape) break;
+            totalEscape++;
+        }
+
+        if (totalEscape%2 === 0) {    // _=>. %=>.*
+            newStr = str.substring(0, idx) + r1 + str.substring(idx+1);
+            sIdx = idx + r1.length;
+        } else {                      // \_ => _, \% => %
+            newStr = str.substring(0, idx-1) + r2 + str.substring(idx+1);
+            sIdx = idx - 1 + r2.length;
+        }
+        return replaceWildCard(newStr, w, r1, r2, sIdx);
+    }
+
+    let  newText = text.replace(sRE, '\\$1');
+
+    newText = replaceWildCard(newText, '%', '.*', '%');
+    newText = replaceWildCard(newText, '_', '.', '_');
+
+    try {
+        return new RegExp('^' + newText + '$');
+    }
+    catch (e) {
+        showInfoPopup('invalid filtering condition: ' + text, 'table filtering');
+        return new RegExp();
+    }
 }
 
 /*-----------------------------------------------------------------------------------------*/
@@ -322,29 +357,73 @@ function autoCorrectConditions(conditions, tbl_id, cname) {
     }
 }
 
+/**
+ * auto correction on filter string in case it is not a valid sql statement.
+ * the correction following the rules as follows
+ * op : case 1: not specified or 'like' (for both numeric and text column)
+ *              if the value part is not enclosed by single quotes:
+ *                  convert %, _, | to be \%, \_ or \\. (escape the wildcard and escape character)
+ *                  enclose the string by '%' and then by single quotes.
+ *                  ex: abc% => '%abc\%%' after auto-correction.
+ *      case 2: 'in',
+ *              enclose each value in signle quotes in case they are missing (for text column only)
+ *              enclose the entire value string in braces, (), if they area missing (for all kinds of columns)
+ *              ex: in a, b  => in ('a', 'b') after auto=correction for text column
+ *              ex: in a, b  => in (a, b) after auto-correction for numeric column
+ *     case 3: other operaters, >, <, >=, <=, =, !=
+ *              enclose value in single quotes if they are missing (for text Column only)
+ *              ex: =abc => ='abc' after auto-correction for text column
+ *                  =abc => =abc   after auto-correction for numeric column
+ *
+ * @param v
+ * @param isNumeric
+ * @returns {*}
+ */
 function autoCorrectCondition(v, isNumeric=false) {
-    let [, op, val=''] = v.trim().replace(/[()]/g, '').match(cond_only_regex) || [];
-    if (!op && !val) return v;
 
-    op = op ? op.toLowerCase() : isNumeric ? '=' : 'like';      // apply default operator if one is not given.
+    const encloseByQuote = (txt, quote="'") => {
+        return `${quote}${txt}${quote}`;
+    };
+
+    const encloseString = (txt) => {
+        return (txt.match(/^'.*'$/) ? txt : encloseByQuote(txt));
+    };
+
+    let [, op, val=''] = v.trim().match(cond_only_regex) || [];
+
+    // empty string or string with no value
+    if (!op && !val) return v.trim();
+
+    op = op ? op.toLowerCase() : 'like';      // no operator is treated as 'like'
+
     switch (op) {
         case 'like':
-            val = !val.includes('%') ? `%${val}%` : val;
-            val = !val.match("^'.+'$") ? `'${val}'` : val;
+            if (!val.match(/^'.*'$/)) {
+                val = val.replace(/([_|%|\\])/g, '\\$1');
+
+                val = encloseByQuote(encloseByQuote(val, '%'));
+            }
             break;
         case 'in':
-            if (!isNumeric) {
-                val = val.split(',').map((s) => `'${s.trim()}'`).join();
-            }
-            val = `(${val})`;
+            let valList = val.match(/^\((.*)\)$/) ? val.substring(1, val.length-1) : val;
+
+            valList = valList.split(',').map((s) => {
+                return isNumeric ? s : encloseString(s.trim());
+            }).join(', ');
+
+            val = `(${valList})`;
             break;
         case '=':
         case '!=':
-            val = !isNumeric && !val.match("^'.+'$") ? `'${val}'` : val;
-            if (isNumeric && ["''", 'null', '""'].includes(val.toLowerCase())) {
-                op = op === '!=' ? 'is not' : 'is';
-                val = 'null';
-            }
+        case '>':
+        case '<':
+        case '>=':
+        case '<=':
+            val = isNumeric ? val : encloseString(val);
+            break;
+
+        default:
+            return '';
     }
     return `${op} ${val}`;
 }

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -42,14 +42,19 @@ function renderHiPSSurveysTable(id, surveys, isPopular, moreStyle={}) {
 
     let tableModel = getTblById(tableId);
 
+
     if (!tableModel && !isEmpty(surveys)) {
         const columns = [ {name: HiPSSurveyTableColumm.type.key, width: 8, type: 'char'},
             {name: HiPSSurveyTableColumm.title.key, width: 35, type: 'char'},
+            {name: HiPSSurveyTableColumm.order.key, width: 6, type: 'int'},
+            {name: HiPSSurveyTableColumm.sky_fraction.key, width: 12, type: 'float'},
             {name: HiPSSurveyTableColumm.url.key, width: 22, type: 'char'}];
 
         const data = surveys.reduce((prev, oneSurvey) => {
             prev.push([oneSurvey[HiPSSurveyTableColumm.type.key],
                 oneSurvey[HiPSSurveyTableColumm.title.key],
+                oneSurvey[HiPSSurveyTableColumm.order.key],
+                oneSurvey[HiPSSurveyTableColumm.sky_fraction.key],
                 oneSurvey[HiPSSurveyTableColumm.url.key]]);
             return prev;
         }, []);
@@ -117,7 +122,7 @@ function showHiPSSurveyList(id, isUpdatingHips, popularHiPS = '') {
 export function showHiPSSurverysPopup(pv, dataType=HiPSData) {
     const surveysId =  get(pv, ['request', 'params', 'hipsSurveysId']);
     const popupPanelResizableStyle = {
-        width: 480,
+        width: 550,
         height: 400,
         minWidth: 400,
         minHeight: 350,

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -179,7 +179,7 @@ export class TestQueriesPanel extends PureComponent {
                                 <HiPSSurveyListSelection
                                     surveysId={HiPSId}
                                     pv={getActivePlotView(visRoot())}
-                                    wrapperStyle={{width: '100%', height: 400, display: 'flex',
+                                    wrapperStyle={{width: 550, height: 400, display: 'flex',
                                                    flexDirection:'column',
                                                    alignItems: 'center'}}
                                 />

--- a/src/firefly/js/visualize/HiPSCntlr.js
+++ b/src/firefly/js/visualize/HiPSCntlr.js
@@ -8,7 +8,7 @@ export const HIPSSURVEY_PREFIX = 'HIPSCntlr';
 export const HIPSSURVEY_PATH = 'hipssurveys';
 export const HIPSSURVEY_CREATE_PATH = `${HIPSSURVEY_PREFIX}.createPath`;
 export const HIPSSURVEY_IN_LOADING = `${HIPSSURVEY_PREFIX}.inLoading`;
-export const HiPSSurveyTableColumm = new Enum(['url', 'title', 'type']);
+export const HiPSSurveyTableColumm = new Enum(['url', 'title', 'type', 'order', 'sky_fraction']);
 export const HiPSSurveysURL = 'http://alasky.unistra.fr/MocServer/query?hips_service_url=*&get=record';
 export const HiPSPopular = 'popular';
 export const _HiPSPopular = '_popular';
@@ -130,7 +130,17 @@ function parseHiPSList(str) {
     let currentRec = {};
     const hipsColumnMap = {obs_title:        HiPSSurveyTableColumm.title.key,
                            hips_service_url: HiPSSurveyTableColumm.url.key,
-                           dataproduct_type: HiPSSurveyTableColumm.type.key};
+                           dataproduct_type: HiPSSurveyTableColumm.type.key,
+                           hips_order:       HiPSSurveyTableColumm.order.key,
+                           moc_sky_fraction: HiPSSurveyTableColumm.sky_fraction.key};
+    const testRow = {
+        ID: 'test/row',
+        [HiPSSurveyTableColumm.title.key]: 'test_record\\(%for test only%)',
+        [HiPSSurveyTableColumm.url.key]: 'http:\\\\www.caltech.edu\\ipac',
+        [HiPSSurveyTableColumm.type.key]: 'test.1',
+        [HiPSSurveyTableColumm.order.key]: '3',
+        [HiPSSurveyTableColumm.sky_fraction.key]: '0.5'
+    };
 
     return str.split('\n')
                     .map( (s) => s.trim())
@@ -148,7 +158,7 @@ function parseHiPSList(str) {
                             }
                         }
                         return preHiPS;
-                    }, [])
+                    }, [testRow])
                     .reduce( (preHiPS, row) => {
                         if (row[HiPSSurveyTableColumm.type.key]) {    // remove the item with undefined type
                             preHiPS.push(row);


### PR DESCRIPTION
this development includes, 
- fix client table filtering by using 'like' and 'in' expression styles. 
- convert 'like' condition into regular expression match for client table filtering. 

test:
use firefly-dev.html
select tab 'Test Searches' and then tab 'HiPS'
uncheck 'Popular HiPS' to get more table content, this is a client table. 
try filtering examples: 
type: in (cube), in ('cube') or in ("cube")
         like cube, like 'cube' or like "cube"
title: like 2mass
url: like spit%.caltech or spit\%.caltech

