### PR TITLE
IRSA-1373: IRSA Viewer: "null" mapped to whitespace for table downloa…

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -32,16 +32,17 @@ abstract public class BaseDbAdapter implements DbAdapter {
     private static Map<String, EmbeddedDbInstance> dbInstances = new HashMap<>();
     private static Logger.LoggerImpl LOGGER = Logger.getLogger();
 
-    private static final String DD_INSERT_SQL = "insert into %s_dd values (?,?,?,?,?,?,?,?,?,?)";
+    private static final String DD_INSERT_SQL = "insert into %s_dd values (?,?,?,?,?,?,?,?,?,?,?)";
     private static final String DD_CREATE_SQL = "create table %s_dd "+
             "(" +
-            "  cname    varchar(1024)" +
-            ", label    varchar(1024)" +
-            ", type     varchar(1024)" +
-            ", units    varchar(1024)" +
-            ", format   varchar(1024)" +
+            "  cname    varchar(1023)" +
+            ", label    varchar(1023)" +
+            ", type     varchar(255)" +
+            ", units    varchar(255)" +
+            ", null_str varchar(255)" +
+            ", format   varchar(255)" +
             ", width    int" +
-            ", visibility varchar(1024)" +
+            ", visibility varchar(255)" +
             ", sortable boolean" +
             ", filterable boolean" +
             ", desc     varchar(64000)" +

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -323,6 +323,7 @@ public class EmbeddedDbUtil {
                             getStrVal(meta, LABEL_TAG, dt, dt.getKeyName()),
                             dt.getTypeDesc(),
                             dt.getDataUnit(),
+                            dt.getNullString(),
                             format,
                             width,
                             visi,
@@ -357,6 +358,7 @@ public class EmbeddedDbUtil {
                 String cname = rs.getString("cname");
                 String label = rs.getString("label");
                 String units = rs.getString("units");
+                String nullStr = rs.getString("null_str");
                 String format = rs.getString("format");
                 int width = rs.getInt("width");
                 String visibility = rs.getString("visibility");
@@ -373,6 +375,9 @@ public class EmbeddedDbUtil {
                     }
                     if (!StringUtils.isEmpty(units)) {
                         dtype.setUnits(units);
+                    }
+                    if (!StringUtils.isEmpty(nullStr)) {
+                        dtype.setNullString(nullStr);
                     }
                     if (!StringUtils.isEmpty(format)) {
                         dtype.getFormatInfo().setDataFormat(format);


### PR DESCRIPTION
…ds via UI

null_string were not stored during the conversion from IPAC table to DB table.  
This causes table with null values to show up as empty string.

Build firefly and search any IRSA catalog.
I think all IRSA catalog are now returning tables with null_string set to 'null'.
You should see 'null' in place of empty string for null values.