### PR TITLE
DM-12864 Coverage and chart rendering on Tri-View when a catalog without position information is searched

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -12,9 +12,9 @@ import shallowequal from 'shallowequal';
 
 import {getAppOptions} from '../core/AppDataCntlr.js';
 import {getTblById, getColumnIdx, getCellValue, isFullyLoaded, watchTableChanges} from '../tables/TableUtil.js';
-import {TABLE_HIGHLIGHT, TABLE_LOADED, TABLE_SELECT, TABLE_REMOVE} from '../tables/TablesCntlr.js';
+import {TABLE_HIGHLIGHT, TABLE_LOADED, TABLE_SELECT} from '../tables/TablesCntlr.js';
 import {dispatchLoadTblStats} from './TableStatsCntlr.js';
-import {dispatchChartUpdate, dispatchChartHighlighted, dispatchChartSelect, dispatchChartRemove, removeTrace, getChartData} from './ChartsCntlr.js';
+import {dispatchChartUpdate, dispatchChartHighlighted, dispatchChartSelect, getChartData} from './ChartsCntlr.js';
 import {Expression} from '../util/expr/Expression.js';
 import {logError, flattenObject} from '../util/WebUtil.js';
 import {ScatterOptions} from './ui/options/ScatterOptions.jsx';
@@ -104,7 +104,7 @@ export function getHighlighted(xyPlotParams, tblId) {
  */
 export function getColOrExprValue(tableModel, rowIdx, colOrExpr) {
     if (tableModel) {
-        var val;
+        let val;
         if (getColumnIdx(tableModel, colOrExpr) >= 0) {
             val = getCellValue(tableModel, rowIdx, colOrExpr);
             val = isFinite(parseFloat(val)) ? Number(val) : Number.NaN;
@@ -465,7 +465,7 @@ export function handleTableSourceConnections({chartId, data, fireflyData}) {
                 }
             }
             traceTS._cancel = watchTableChanges(traceTS.tbl_id,
-                [TABLE_LOADED, TABLE_HIGHLIGHT, TABLE_SELECT, TABLE_REMOVE],
+                [TABLE_LOADED, TABLE_HIGHLIGHT, TABLE_SELECT],
                 (action) => updateChartData(chartId, idx, traceTS, action));
 
         }
@@ -511,16 +511,6 @@ function updateChartData(chartId, traceNum, tablesource, action={}) {
         if (traceNum !== activeTrace) return;
         const {selectInfo={}} = action.payload;
         updateSelected(chartId, selectInfo);
-    } else if (action.type === TABLE_REMOVE) {
-        // remove trace or remove chart if the last trace
-        tablesource._cancel && tablesource._cancel();
-        const {data} = getChartData(chartId, 'data', []);
-        if (data.length === 1) {
-            dispatchChartRemove(chartId);
-        } else {
-            removeTrace(chartId, traceNum);
-        }
-
     } else {
         if (!isFullyLoaded(tbl_id)) return;
         const tableModel = getTblById(tbl_id);

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -52,6 +52,7 @@ const isDebug = () => get(window, 'firefly.debug', false);
 function actionCreators() {
     return {
         [CHART_ADD]:     chartAdd,
+        [CHART_REMOVE]:  chartRemove,
         [CHART_UPDATE]:  chartUpdate,
         [CHART_HIGHLIGHT]: chartHighlight,
         [CHART_FILTER_SELECTION]: chartFilterSelection,
@@ -341,6 +342,14 @@ function chartAdd(action) {
         } else {
             dispatch(action);
         }
+    };
+}
+
+function chartRemove(action) {
+    return (dispatch) => {
+        const {chartId} = action.payload;
+        clearChartConn({chartId});
+        dispatch(action);
     };
 }
 
@@ -764,7 +773,6 @@ function reduceData(state={}, action={}) {
         {
             const {chartId} = action.payload;
             isDebug() && console.log('REMOVE '+chartId);
-            clearChartConn(chartId);
             return omit(state, chartId);
         }
         case (CHART_DATA_FETCH)  :

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -4,22 +4,20 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {isEqual, isEmpty, get} from 'lodash';
+import {isEqual, isEmpty} from 'lodash';
 
-import {getAppOptions} from '../../core/AppDataCntlr.js';
 import {LO_VIEW, LO_MODE, dispatchSetLayoutMode} from '../../core/LayoutCntlr.js';
 import {PLOT2D, DEFAULT_PLOT2D_VIEWER_ID, dispatchAddViewerItems, dispatchRemoveViewerItems, dispatchUpdateCustom, getViewerItemIds, getMultiViewRoot} from '../../visualize/MultiViewCntlr.js';
-import {monitorChanges, findGroupByTblId, getActiveTableId, getTblById, isFullyLoaded} from '../../tables/TableUtil.js';
+import {monitorChanges, findGroupByTblId, getActiveTableId, isFullyLoaded} from '../../tables/TableUtil.js';
 import {TBL_RESULTS_ACTIVE, TABLE_LOADED} from '../../tables/TablesCntlr';
 import {CHART_ADD, CHART_REMOVE, getChartIdsInGroup, getChartData, dispatchChartAdd} from '../ChartsCntlr.js';
-import {colWithName, getNumericCols, DEFAULT_ALPHA} from '../ChartUtil.js';
-import {MetaConst} from '../../data/MetaConst.js';
+import {getDefaultChartProps} from '../ChartUtil.js';
 
 import {CloseButton} from '../../ui/CloseButton.jsx';
 import {ChartPanel} from './ChartPanel.jsx';
 import {MultiChartViewer, getActiveViewerItemId} from './MultiChartViewer.jsx';
 
-const DATAPOINTS_COLOR = `rgba(63, 127, 191, ${DEFAULT_ALPHA})`;
+
 
 // DEFAULT_PLOT2D_VIEWER_ID, 'main'
 function watchTblGroup(viewerId, tblGroup, addDefaultChart) {
@@ -89,96 +87,6 @@ function doUpdateViewer(viewerId, tblGroup, chartId) {
     }
 }
 
-function getDefaultChartProps(tbl_id) {
-
-    if (!isFullyLoaded(tbl_id)) { return; }
-
-    const {tableMeta, tableData, totalRows}= getTblById(tbl_id);
-
-    if (!totalRows) {
-        return;
-    }
-
-    // default chart props can be set in a table attribute
-    const defaultChartDef = tableMeta[MetaConst.DEFAULT_CHART_DEF];
-    const defaultChartProps = defaultChartDef && JSON.parse(defaultChartDef);
-    if (defaultChartProps && defaultChartProps.data) {
-        defaultChartProps.data.forEach((e) => e['tbl_id'] = tbl_id);
-        return defaultChartProps;
-    }
-
-    // for catalogs use lon and lat columns
-    let isCatalog = Boolean(tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] && tableMeta[MetaConst.CATALOG_COORD_COLS]);
-    let xCol = undefined, yCol = undefined;
-
-    if (isCatalog) {
-        const s = tableMeta[MetaConst.CATALOG_COORD_COLS].split(';');
-        if (s.length !== 3) return;
-        xCol = colWithName(tableData.columns, s[0]); // longtitude
-        yCol = colWithName(tableData.columns, s[1]); // latitude
-
-        if (!xCol || !yCol) {
-            isCatalog = false;
-        }
-    }
-
-    //otherwise use the first one-two numeric columns
-    if (!isCatalog) {
-        const numericCols = getNumericCols(tableData.columns);
-        if (numericCols.length > 1) {
-            xCol = numericCols[0];
-            yCol = numericCols[1];
-        } else if (numericCols.length > 0) {
-            xCol = numericCols[0];
-            yCol = numericCols[0];
-        }
-    }
-
-    if (xCol && yCol)  {
-        if (xCol === yCol) {
-            // if only one numeric column is available, do histogram
-            const chartData = {
-                data: [{
-                    type: 'fireflyHistogram',
-                    firefly: {
-                        tbl_id,
-                        options: {
-                            algorithm: 'fixedSizeBins',
-                            fixedBinSizeSelection: 'numBins',
-                            numBins: 20,
-                            columnOrExpr: `${xCol.name}`
-                        }
-                    },
-                    name: xCol.name
-                }]
-            };
-            return chartData;
-        } else {
-            const chartData = {
-                data: [{
-                    tbl_id,
-                    x: xCol && `tables::${xCol.name}`,
-                    y: yCol && `tables::${yCol.name}`
-                }],
-                layout: {
-                    xaxis: {
-                        autorange: isCatalog ? 'reversed' : 'true'
-                    },
-                    yaxis: {showgrid: false}
-                }
-            };
-            const maxRowsForScatter = get(getAppOptions(), 'charts.maxRowsForScatter', 5000);
-            if (totalRows > maxRowsForScatter) {
-                Object.assign(chartData.data[0], {type: 'fireflyHeatmap', colorscale: 'Greys', reversescale: true});
-            } else {
-                Object.assign(chartData.data[0], {mode: 'markers', marker: {color: DATAPOINTS_COLOR}});
-            }
-            return chartData;
-        }
-    } else {
-        return {};
-    }
-}
 
 /**
  * Default viewer

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -61,7 +61,7 @@ const binSizeOptions = [  {label: 'Number of bins:', value: 'numBins'},
 
 
 function isSingleColumn(colName, colValStats) {
-    for (var i = 0; i < colValStats.length; i++) {
+    for (let i = 0; i < colValStats.length; i++) {
         if (colName === colValStats[i].name) {
             return true;
         }
@@ -69,7 +69,7 @@ function isSingleColumn(colName, colValStats) {
     }
     return false;
 }
-var columnNameReducer= (colValStats, basicFieldsReducer) => {
+function columnNameReducer(colValStats, basicFieldsReducer) {
     return (inFields, action) => {
 
         if (!inFields) {
@@ -79,17 +79,20 @@ var columnNameReducer= (colValStats, basicFieldsReducer) => {
         if (!isEmpty(colValStats) && action.type === VALUE_CHANGE) {
             fieldKey = get(action.payload, 'fieldKey');
             switch (fieldKey) {
-                // when column name changes, update the min/max input
+                // when column name changes, update the min/max input and clear x title
                 case 'columnOrExpr': {
                       const numBins = get(inFields, ['numBins', 'value'], 50);
                       const colName = action.payload.value;
                        if (colName) {
+                           if (inFields['layout.xaxis.title']) {
+                               inFields = updateSet(inFields, ['layout.xaxis.title', 'value'], undefined);
+                           }
                            if (isSingleColumn(colName, colValStats)) {
-                               for (var i = 0; i < colValStats.length; i++) {
+                               for (let i = 0; i < colValStats.length; i++) {
                                    if (colName === colValStats[i].name) {
                                        const dataMin = colValStats[i].min;
                                        const dataMax = colValStats[i].max;
-                                       var binWidth = ((dataMax - dataMin) / numBins).toFixed(6);
+                                       const binWidth = ((dataMax - dataMin) / numBins).toFixed(6);
                                        inFields = updateSet(inFields, ['minCutoff', 'value'], `${dataMin}`);
                                        inFields = updateSet(inFields, ['maxCutoff', 'value'], `${dataMax}`);
                                        inFields = updateSet(inFields, ['binWidth', 'value'], `${binWidth}`);
@@ -129,7 +132,7 @@ var columnNameReducer= (colValStats, basicFieldsReducer) => {
                 case 'maxCutoff':   {
 
                     const fixedBinSizeSelection = get(inFields, ['fixedBinSizeSelection', 'value']);
-                    var numBins, min, max, binWidth;
+                    let numBins, min, max, binWidth;
                     if (fixedBinSizeSelection==='numBins'){
                         numBins = get(inFields, ['numBins', 'value'], 50);
                         min = get(inFields, ['minCutoff', 'value'], '');
@@ -161,7 +164,8 @@ var columnNameReducer= (colValStats, basicFieldsReducer) => {
         }
 
     };
-};
+}
+
 export class HistogramOptions extends Component {
 
     constructor(props) {
@@ -206,10 +210,10 @@ export class HistogramOptions extends Component {
         const {colValStats, groupKey, histogramParams} = this.props;
         if (colValStats) {
             const colValidator = getColValidator(colValStats);
-            var payload = {groupKey, fieldKey: 'columnOrExpr', validator: colValidator};
+            let payload = {groupKey, fieldKey: 'columnOrExpr', validator: colValidator};
             const value = get(histogramParams, 'columnOrExpr');
             if (value) {
-                var {valid, message} = colValidator(value);
+                const {valid, message} = colValidator(value);
                 payload = Object.assign(payload, {value, valid, message});
             }
             dispatchValueChange(payload);
@@ -228,7 +232,7 @@ export class HistogramOptions extends Component {
         const {groupKey, histogramParams} = this.props;
         const {fields} = this.state;
 
-        var algorithm =  FieldGroupUtils.getFldValue(fields, 'algorithm', 'fixedSizeBins');
+        const algorithm =  FieldGroupUtils.getFldValue(fields, 'algorithm', 'fixedSizeBins');
 
         if (algorithm === 'bayesianBlocks') {
             // if label is in initialState, it does not show when first time displayed
@@ -249,7 +253,7 @@ export class HistogramOptions extends Component {
         } else { // fixedSizeBins
 
 
-         var disabled = FieldGroupUtils.getFldValue(this.state.fields, 'fixedBinSizeSelection') ?
+         const disabled = FieldGroupUtils.getFldValue(this.state.fields, 'fixedBinSizeSelection') ?
              FieldGroupUtils.getFldValue(this.state.fields, 'fixedBinSizeSelection')!=='numBins':false;
 
          return (

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -8,13 +8,14 @@ import {get, isEqual, isEmpty, filter, pick, uniqBy} from 'lodash';
 import Enum from 'enum';
 import {flux} from '../Firefly.js';
 import {clone} from '../util/WebUtil.js';
-import {smartMerge} from '../tables/TableUtil.js';
+import {smartMerge, getActiveTableId} from '../tables/TableUtil.js';
 import {getDropDownNames} from '../ui/Menu.jsx';
 import ImagePlotCntlr from '../visualize/ImagePlotCntlr.js';
 import {TBL_RESULTS_ADDED, TBL_RESULTS_REMOVE, TABLE_REMOVE} from '../tables/TablesCntlr.js';
-import {CHART_ADD, CHART_REMOVE} from '../charts/ChartsCntlr.js';
+import {CHART_ADD, CHART_REMOVE, getChartIdsInGroup} from '../charts/ChartsCntlr.js';
 import {REPLACE_VIEWER_ITEMS} from '../visualize/MultiViewCntlr.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
+import {getDefaultChartProps} from '../charts/ChartUtil.js';
 
 export const LAYOUT_PATH = 'layout';
 
@@ -217,7 +218,8 @@ export function getLayouInfo() {
     const layout = get(flux.getState(), 'layout', {});
     const hasImages = get(flux.getState(), 'allPlots.plotViewAry.length') > 0;
     const hasTables = !isEmpty(get(flux.getState(), 'table_space.results.main.tables', {}));
-    const hasXyPlots = hasTables || !isEmpty(get(flux.getState(), 'charts.data', {}));
+    //const hasXyPlots = !isEmpty(get(flux.getState(), 'charts.data', {})) || (hasTables && !isEmpty(getDefaultChartProps(getActiveTableId())));
+    const hasXyPlots = getChartIdsInGroup(getActiveTableId()).push(getChartIdsInGroup('default')).length > 0 || (hasTables && !isEmpty(getDefaultChartProps(getActiveTableId())));
     return clone(layout, {hasImages, hasTables, hasXyPlots});
 }
 
@@ -249,7 +251,7 @@ export function dropDownHandler(layoutInfo, action) {
         case ImagePlotCntlr.PLOT_IMAGE_START :
             return smartMerge(layoutInfo, {dropDown: {visible: false}});
             break;
-
+        case CHART_REMOVE:
         case SHOW_DROPDOWN:
         case TABLE_REMOVE:
         case TBL_RESULTS_REMOVE:

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -12,7 +12,7 @@ import {smartMerge, getActiveTableId} from '../tables/TableUtil.js';
 import {getDropDownNames} from '../ui/Menu.jsx';
 import ImagePlotCntlr from '../visualize/ImagePlotCntlr.js';
 import {TBL_RESULTS_ADDED, TBL_RESULTS_REMOVE, TABLE_REMOVE} from '../tables/TablesCntlr.js';
-import {CHART_ADD, CHART_REMOVE, getChartIdsInGroup} from '../charts/ChartsCntlr.js';
+import {CHART_ADD, CHART_REMOVE} from '../charts/ChartsCntlr.js';
 import {REPLACE_VIEWER_ITEMS} from '../visualize/MultiViewCntlr.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
 import {getDefaultChartProps} from '../charts/ChartUtil.js';
@@ -218,8 +218,15 @@ export function getLayouInfo() {
     const layout = get(flux.getState(), 'layout', {});
     const hasImages = get(flux.getState(), 'allPlots.plotViewAry.length') > 0;
     const hasTables = !isEmpty(get(flux.getState(), 'table_space.results.main.tables', {}));
-    //const hasXyPlots = !isEmpty(get(flux.getState(), 'charts.data', {})) || (hasTables && !isEmpty(getDefaultChartProps(getActiveTableId())));
-    const hasXyPlots = getChartIdsInGroup(getActiveTableId()).push(getChartIdsInGroup('default')).length > 0 || (hasTables && !isEmpty(getDefaultChartProps(getActiveTableId())));
+    /*
+      to make plot area disappear if it's not possible to create a plot use
+         hasXyPlots = getChartIdsInGroup(getActiveTableId()).length > 0 ||
+                      getChartIdsInGroup('default').length > 0 ||
+                      (hasTables && !isEmpty(getDefaultChartProps(getActiveTableId())));
+      the drawback is that the layout changes for tables with no numeric data or no data
+    */
+    // keep plot area in place if any table has a related chart
+    const hasXyPlots = !isEmpty(get(flux.getState(), 'charts.data', {})) || (hasTables && !isEmpty(getDefaultChartProps(getActiveTableId())));
     return clone(layout, {hasImages, hasTables, hasXyPlots});
 }
 

--- a/src/firefly/js/drawingLayers/Artifact.js
+++ b/src/firefly/js/drawingLayers/Artifact.js
@@ -4,7 +4,7 @@
 
 
 import {take} from 'redux-saga/effects';
-import {get} from 'lodash';
+import {get, isEmpty} from 'lodash';
 import {isPlotIdInPvNewPlotInfoAry,
          isDrawLayerVisible, getDrawLayerById, getPlotViewById} from '../visualize/PlotViewUtil.js';
 import {getRelatedDataById} from '../visualize/RelatedDataUtil.js';
@@ -186,7 +186,7 @@ function createDrawData(drawLayer, tableModel) {
     if (!tableData.data.length) return;
 
     const columns= getCenterColumns(tableModel);
-    if (columns.lonIdx<0 || columns.latIdx<0) return null;
+    if (isEmpty(columns) || columns.lonIdx<0 || columns.latIdx<0) return null;
 
     const {angleInRadian:rad}= drawLayer;
 

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -110,8 +110,9 @@ export function findGridTableRows(table,maxRows, plotIdRoot) {
  */
 export function isMetaDataTable(tbl_id) {
     const table= getTblById(tbl_id);
-    const tableMeta= get(table, 'tableMeta');
-    if (!tableMeta) return false;
+    if (isEmpty(table)) return false;
+    const {tableMeta, totalRows} = table;
+    if (!tableMeta || !totalRows) return false;
 
     const hasDsCol= Boolean(Object.keys(tableMeta).find( (key) => key.toUpperCase()===dataSourceUpper));
 
@@ -125,6 +126,6 @@ export function isMetaDataTable(tbl_id) {
  */
 export function isCatalogTable(tbl_id) {
     const table= getTblById(tbl_id);
-    return !isEmpty(getCenterColumns(table));
+    return get(table, 'totalRows') && !isEmpty(getCenterColumns(table));
 }
 

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -7,6 +7,7 @@ import {ServerRequest} from '../data/ServerRequest.js';
 import {WebPlotRequest} from '../visualize/WebPlotRequest.js';
 import {ZoomType} from '../visualize/ZoomType.js';
 import {getTblById,getTblInfo, getCellValue} from '../tables/TableUtil.js';
+import {getCenterColumns} from '../tables/TableInfoUtil.js';
 import {converterFactory} from './ConverterFactory.js';
 import {MetaConst} from '../data/MetaConst.js';
 
@@ -92,10 +93,10 @@ export function findGridTableRows(table,maxRows, plotIdRoot) {
 
     const {startIdx, endIdx, highlightedRow}= getTblInfo(table, maxRows);
 
-    var j= 0;
+    let j= 0;
     const retval= [];
 
-    for(var i=startIdx; (i<endIdx );i++) {
+    for(let i=startIdx; (i<endIdx );i++) {
         retval[j++] = {plotId: computePlotId(plotIdRoot, i), row: i, highlight: i === highlightedRow};
     }
     return retval;
@@ -124,9 +125,6 @@ export function isMetaDataTable(tbl_id) {
  */
 export function isCatalogTable(tbl_id) {
     const table= getTblById(tbl_id);
-    const tableMeta= get(table, 'tableMeta');
-    if (!tableMeta) return false;
-
-    return Boolean(tableMeta[MetaConst.CATALOG_OVERLAY_TYPE] || tableMeta[MetaConst.CATALOG_COORD_COLS]);
+    return !isEmpty(getCenterColumns(table));
 }
 

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -12,13 +12,12 @@ import shallowequal from 'shallowequal';
 import {dataReducer} from './reducer/TableDataReducer.js';
 import {uiReducer} from './reducer/TableUiReducer.js';
 import {resultsReducer} from './reducer/TableResultsReducer.js';
-import {updateMerge} from '../util/WebUtil.js';
+import {updateMerge, logError} from '../util/WebUtil.js';
 import {FilterInfo} from './FilterInfo.js';
 import {selectedValues} from '../rpc/SearchServicesJson.js';
 import {BG_STATUS, BG_JOB_ADD} from '../core/background/BackgroundCntlr.js';
 import {isSuccess, isDone, getErrMsg} from '../core/background/BackgroundUtil.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
-import {ServerParams} from '../data/ServerParams.js';
 
 export const TABLE_SPACE_PATH = 'table_space';
 export const TABLE_RESULTS_PATH = 'table_space.results.tables';
@@ -540,7 +539,11 @@ function syncFetch(request, hlRowIdx, invokedBy, dispatch) {
     unset(request, 'META_INFO.backgroundable');
     TblUtil.doFetchTable(request, hlRowIdx).then ( (tableModel) => {
         const type = tableModel.origTableModel ? TABLE_REPLACE : TABLE_UPDATE;
-        dispatch( {type, payload: tableModel} );
+        try {
+            dispatch({type, payload: tableModel});
+        } catch (e) {
+            logError(e.stack);
+        }
     }).catch( (error) => {
         dispatch({type: TABLE_UPDATE, payload: TblUtil.createErrorTbl(request.tbl_id, `Failed to load table. \n   ${error}`)});
     });

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -88,6 +88,7 @@ function onAnyAction(layoutInfo, action, views) {
         case TABLE_REMOVE:
         case TBL_RESULTS_ADDED:
         case TBL_RESULTS_REMOVE:
+        case TABLE_LOADED:
         case REPLACE_VIEWER_ITEMS:
         case ImagePlotCntlr.PLOT_IMAGE_START :
         case ImagePlotCntlr.DELETE_PLOT_VIEW:
@@ -97,13 +98,12 @@ function onAnyAction(layoutInfo, action, views) {
         {
             // handle autoExpand feature
             if (autoExpand) {
-                if (count > 1) {
+                if (count !== 1) {
                     autoExpand = false;
                     expanded = LO_VIEW.none;
                 }
             } else if (expanded === LO_VIEW.none && count === 1) {
                 // set mode into expanded view when there is only 1 component visible.
-                autoExpand = true;
                 autoExpand = true;
                 expanded =  showImages ? LO_VIEW.images :
                     showXyPlots ? LO_VIEW.xyPlots :

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -232,7 +232,7 @@ export class ChartSelectDropdown extends PureComponent {
             if (!totalRows) {
                 noChartReason = 'empty table';
             } else if (getNumericCols(tableData.columns).length < 1) {
-                noChartReason = 'tha table has no numeric columns';
+                noChartReason = 'the table has no numeric columns';
             }
         } else {
             noChartReason = 'no active table';

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {get, isEmpty, isUndefined} from 'lodash';
+import {get, isEmpty} from 'lodash';
 import {take} from 'redux-saga/effects';
 
 import {ImageExpandedMode} from '../iv/ImageExpandedMode.jsx';
@@ -234,6 +234,7 @@ function onActiveTable (layoutInfo, action) {
         showImages = true;
     } else {
         showCoverage = false;
+        showImages= showFits||coverageLockedOn;
     }
 
     if (anyHasMeta) {


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-12864

If the table with no positional info is the first rendered in firefly, no coverage or chart area will show.
If other tables are added, the coverage and chart areas will not disappear, when changing the active table. This is intentional behavior to avoid confusing layout changes.

An example of a table with no position info WISE -> AllWISE Inventory Table 

Other bugs fixed:
- non-returning search
- removed chart hanging in the store
- empty result area with no drop down, when all tables are deleted
- missing layout updates