### PR TITLE
DM-13326 Fixed issues on circular selection per feedback from IRSA tester

### DIFF
--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -205,6 +205,7 @@ window.enableFireflyReduxLogging= false;
 //     if (type.startsWith('tblstats')) return false;
 //     if (type.startsWith('table_ui')) return false;
 //     if (type.startsWith('app_data')) return false;
+//     if (type.startsWith('ReadoutCntlr')) return false;
 //     return window.enableFireflyReduxLogging;
 // }
 

--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -28,6 +28,7 @@ import {getUIComponent} from './CatalogUI.jsx';
 import {FilterInfo} from '../tables/FilterInfo.js';
 import DrawUtil from '../visualize/draw/DrawUtil.js';
 import SelectArea, {SelectedShape} from './SelectArea.js';
+import {detachSelectArea} from '../visualize/ui/SelectAreaDropDownView.jsx';
 
 const TYPE_ID= 'CATALOG_TYPE';
 
@@ -331,6 +332,7 @@ export function selectCatalog(pv,dlAry) {
                     .forEach( (idx) => selectInfoCls.setRowSelect(idx, true));
                 dispatchTableSelect(dl.drawLayerId, selectInfoCls.data);
             });
+            detachSelectArea(pv);
         }
     }
 }
@@ -359,6 +361,7 @@ export function filterCatalog(pv,dlAry) {
 
     const selectedShape = getSelectedShape(pv, dlAry);
     catDlAry.forEach((dl) =>doFilter(dl,p,sel, selectedShape));
+    detachSelectArea(pv);
 }
 
 

--- a/src/firefly/js/drawingLayers/ImageOutline.js
+++ b/src/firefly/js/drawingLayers/ImageOutline.js
@@ -100,14 +100,18 @@ function computeDrawData(drawLayer, plotId) {
     return computeDrawobj(drawLayer, plot);
 }
 
-/*
-drawObj could be either statically set by dl.drawObj or dynamically updated in attribute
- PlotAttribute.OUTLINEIMAGE_DRAWOBJ or PlotAttribute.OUTLINEIMAGE_BOUNDS
 
- title could be either statically set by dl.text or dynamically updated in attribute PlotAttribute.OUTLINEIMAGE_TITLE
- text location could either statically set by dl.textLoc or dynamically updated in attribute PlotAttribute.OUTLINEIMAGE_TITLELOC
-
- statically set is one time set.
+/**
+ * create drawing object and title object based on the statical or dynamical settings.
+ * drawObj could be either statically set by dl.drawObj or dynamically set by plot attribute,
+ * i.e. PlotAttribute.OUTLINEIMAGE_DRAWOBJ or PlotAttribute.OUTLINEIMAGE_BOUNDS
+ * title could be either statically set by dl.text or dynamically set by attribute
+ * PlotAttribute.OUTLINEIMAGE_TITLE
+ * text location could be either statically set by dl.textLoc or dynamically set by attribute
+ * PlotAttribute.OUTLINEIMAGE_TITLELOC
+ * @param dl
+ * @param plot
+ * @returns {*}
  */
 function computeDrawobj(dl, plot) {
 

--- a/src/firefly/js/drawingLayers/ImageOutline.js
+++ b/src/firefly/js/drawingLayers/ImageOutline.js
@@ -7,47 +7,47 @@
  */
 
 
-import {isEmpty} from 'lodash';
+import {get, isArray} from 'lodash';
 import ImagePlotCntlr, {visRoot} from '../visualize/ImagePlotCntlr.js';
 import DrawLayerCntlr from '../visualize/DrawLayerCntlr.js';
 import {primePlot, isDrawLayerVisible} from '../visualize/PlotViewUtil.js';
 import {PlotAttribute} from '../visualize/WebPlot.js';
-import {getBestHiPSlevel, getVisibleHiPSCells,
-    getPointMaxSide, getMaxDisplayableHiPSLevel} from '../visualize/HiPSUtil.js';
 import FootprintObj from '../visualize/draw/FootprintObj.js';
 import ShapeDataObj from '../visualize/draw/ShapeDataObj.js';
 import {makeDrawingDef} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {DataTypes,ColorChangeType} from '../visualize/draw/DrawLayer.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
-import {makeImagePt} from '../visualize/Point.js';
+import {makeImagePt, makeDevicePt} from '../visualize/Point.js';
 import CysConverter from '../visualize/CsysConverter';
+import DrawOp from '../visualize/draw/DrawOp.js';
 
 const ID= 'IMAGE_OUTLINE';
 const TYPE_ID= 'IMAGE_OUTLINE_TYPE';
-
-
-
 const factoryDef= makeFactoryDef(TYPE_ID,creator,getDrawData,getLayerChanges,null,null);
 
 export default {factoryDef, TYPE_ID}; // every draw layer must default export with factoryDef and TYPE_ID
 
 let idCnt=0;
 
-
 function creator(initPayload, presetDefaults) {
 
-    let drawingDef= makeDrawingDef('blue', {lineWidth:1} );
+    let drawingDef= makeDrawingDef(get(initPayload, 'color', 'blue'), {lineWidth:1} );
     drawingDef= Object.assign(drawingDef,presetDefaults);
-
 
     idCnt++;
 
     const options= {
         hasPerPlotData:true,
         isPointData:false,
-        canUserChangeColor: ColorChangeType.DYNAMIC,
+        canUserChangeColor: ColorChangeType.DYNAMIC
     };
-    return DrawLayer.makeDrawLayer(`${ID}-${idCnt}`,TYPE_ID, {}, options, drawingDef);
+
+    const dl = DrawLayer.makeDrawLayer(`${ID}-${idCnt}`,TYPE_ID, get(initPayload, 'title', {}), options, drawingDef);
+
+    dl.drawObj = get(initPayload, 'drawObj');
+    dl.textLoc = get(initPayload, 'textLoc');
+    dl.text = get(initPayload, 'title');
+    return dl;
 }
 
 
@@ -67,9 +67,17 @@ function getLayerChanges(drawLayer, action) {
             let {plotIdAry}= action.payload;
             if (!plotIdAry && !plotId) return null;
             if (!plotIdAry) plotIdAry= [plotId];
-            const title= Object.assign({},drawLayer.title);
-            plotIdAry.forEach( (id) => title[id]= getTitle(id));
+
+            let title;
+
+            if (typeof drawLayer.title === 'string') {
+                title = drawLayer.title;
+            } else {
+                title = Object.assign({}, drawLayer.title);
+                plotIdAry.forEach((id) => title[id] = getTitle(id));
+            }
             return {title};
+
         case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
             break;
     }
@@ -79,7 +87,7 @@ function getLayerChanges(drawLayer, action) {
 
 function getTitle(plotId) {
     const plot= primePlot(visRoot(),plotId);
-    const lastTitle= plot.attributes[PlotAttribute.LAST_IMAGE_TITLE];
+    const lastTitle= plot.attributes[PlotAttribute.OUTLINEIMAGE_TITLE];
     return `${lastTitle?lastTitle:'Image'} outline`;
 }
 
@@ -88,23 +96,77 @@ function computeDrawData(drawLayer, plotId) {
     const plot= primePlot(visRoot(),plotId);
     if (!plot) return [];
 
-    const wpAry= plot.attributes[PlotAttribute.LAST_IMAGE_BOUNDS];
-    const lastTitle= plot.attributes[PlotAttribute.LAST_IMAGE_TITLE];
-
-    if (isEmpty(wpAry)) {
-        return [];
-    }
-    const cc= CysConverter.make(plot);
-    const s1= cc.getDeviceCoords(wpAry[0]);
-    const s2= cc.getDeviceCoords(wpAry[2]);
-    if (!s1 || !s2) return [];
-    const loc= cc.getWorldCoords(makeImagePt( (s1.x+s2.x)/2, (s1.y+s2.y)/2));
-    const retObj= [FootprintObj.make([wpAry])];
-    if (lastTitle && loc) {
-        const textObj= ShapeDataObj.makeTextWithOffset(makeImagePt(-10,-6), loc, lastTitle);
-        retObj.push(textObj);
-    }
-    return retObj;
+    return computeDrawobj(drawLayer, plot);
 }
 
+/*
+drawObj could be either statically set by dl.drawObj or dynamically updated in attribute
+ PlotAttribute.OUTLINEIMAGE_DRAWOBJ or PlotAttribute.OUTLINEIMAGE_BOUNDS
 
+ title could be either statically set by dl.text or dynamically updated in attribute PlotAttribute.OUTLINEIMAGE_TITLE
+ text location could either statically set by dl.textLoc or dynamically updated in attribute PlotAttribute.OUTLINEIMAGE_TITLELOC
+
+ statically set is one time set.
+ */
+function computeDrawobj(dl, plot) {
+
+    let   drawObj = dl.drawObj;
+    let   textLoc = dl.textLoc || plot.attributes[PlotAttribute.OUTLINEIMAGE_TITLELOC];
+    const text = dl.text || plot.attributes[PlotAttribute.OUTLINEIMAGE_TITLE];
+    const cc = CysConverter.make(plot);
+
+    const drawObjTextLoc = (dObj) => {
+        if (isArray(dObj)) {
+            textLoc = drawObj.map((oneObj) => DrawOp.getCenterPt(oneObj))
+                .reduce((prev, oneLoc) => {
+                    const loc = cc.getDeviceCoords(oneLoc);
+                    prev = [prev[0] + loc.x, prev[1] + loc.y];
+                    return prev;
+                }, [0, 0])
+                .map((loc) => loc/drawObj.length);
+
+            textLoc = cc.getWorldCoords(makeDevicePt(textLoc[0], textLoc[0]));
+        } else {
+            textLoc = DrawOp.getCenterPt(dObj);
+        }
+    };
+
+    if (drawObj) {
+        if (text && !textLoc) {
+            textLoc = drawObjTextLoc(drawObj);
+        }
+    } else {  // dynamic get data from attribute
+        if (plot.attributes[PlotAttribute.OUTLINEIMAGE_DRAWOBJ]) {
+            drawObj = plot.attributes[PlotAttribute.OUTLINEIMAGE_DRAWOBJ];
+
+            if (text && !textLoc && drawObj) {
+                textLoc = drawObjTextLoc(drawObj);
+            }
+
+        } else if (plot.attributes[PlotAttribute.OUTLINEIMAGE_BOUNDS]) {
+            const wpAry = plot.attributes[PlotAttribute.OUTLINEIMAGE_BOUNDS];
+
+            if (wpAry && wpAry.length > 2) {
+                drawObj = FootprintObj.make([wpAry]);
+                if (text && !textLoc) {
+                    const s1 = cc.getDeviceCoords(wpAry[0]);
+                    const s2 = cc.getDeviceCoords(wpAry[wpAry.length / 2]);
+
+                    if (s1 && s2) {
+                        textLoc = cc.getWorldCoords(makeDevicePt((s1.x + s2.x) / 2, (s1.y + s2.y) / 2));
+                    }
+                }
+            }
+        }
+    }
+
+    if (!drawObj) return [];
+
+    const retObj = isArray(drawObj) ? drawObj : [drawObj];
+    if (text && textLoc) {
+        const textObj = ShapeDataObj.makeTextWithOffset(makeImagePt(-10, -6), textLoc, text);
+        retObj.push(textObj);
+    }
+
+    return retObj;
+}

--- a/src/firefly/js/drawingLayers/ImageOutline.js
+++ b/src/firefly/js/drawingLayers/ImageOutline.js
@@ -39,7 +39,8 @@ function creator(initPayload, presetDefaults) {
     const options= {
         hasPerPlotData:true,
         isPointData:false,
-        canUserChangeColor: ColorChangeType.DYNAMIC
+        canUserChangeColor: ColorChangeType.DYNAMIC,
+        destroyWhenAllDetached: get(initPayload, 'destroyWhenAllDetached', false)
     };
 
     const dl = DrawLayer.makeDrawLayer(`${ID}-${idCnt}`,TYPE_ID, get(initPayload, 'title', {}), options, drawingDef);

--- a/src/firefly/js/drawingLayers/SelectArea.js
+++ b/src/firefly/js/drawingLayers/SelectArea.js
@@ -61,7 +61,7 @@ export function selectAreaEndActionCreator(rawAction) {
             dispatchAttributeChange(plotId,true,PlotAttribute.SELECTION,sel,true);
             // const imBoundSel= pv.rotation ? getImageBoundsSelection(sel,CsysConverter.make(plot)) : sel;
             const imBoundSel= getImageBoundsSelection(sel,CsysConverter.make(plot), drawLayer.selectedShape,
-                                                      pv.rotation, drawLayer.selectedShape === SelectedShape.circle.key);
+                                                      pv.rotation);
             dispatchAttributeChange(plotId,true,PlotAttribute.IMAGE_BOUNDS_SELECTION, imBoundSel,true);
         }
     };
@@ -365,7 +365,7 @@ function makeSelectObj(firstPt,currentPt,cc, rotation, title, dl) {
     return retAry;
 }
 
-function getImageBoundsSelection(sel,cc, shape, rotation, bPadding = false) {
+function getImageBoundsSelection(sel,cc, shape, rotation, bPadding = true) {
     const {x, y, w, h} = makeImageBoundingBox(sel,cc, shape, rotation);
 
     const padding = bPadding ? Math.ceil(cc.zoomFactor) : 0;

--- a/src/firefly/js/drawingLayers/SelectArea.js
+++ b/src/firefly/js/drawingLayers/SelectArea.js
@@ -138,7 +138,6 @@ function getCursor(plotView, screenPt) {
 }
 
 function getLayerChanges(drawLayer, action) {
-
     switch (action.type) {
         case DrawLayerCntlr.SELECT_AREA_START:
             return start(drawLayer,action);

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -197,6 +197,7 @@ export function dispatchCreateDrawLayer(drawLayerTypeId, params={}) {
     if (plotIdAry) {
         dispatchAttachLayerToPlot(drawLayerTypeId,plotIdAry);
     }
+    return drawLayer;
 }
 
 
@@ -316,6 +317,7 @@ export function dispatchDestroyDrawLayer(id) {
  * @param {boolean} attachAllPlot
  * @param {boolean|string} visible - Can have three values: true: layer is attach visible, false: attach not-visible,
  * value (string) 'inherit' layer is visible
+ * @param {boolean} plotTypeMustMatch
  * @memberof firefly.action
  * @public
  * @function  dispatchAttachLayerToPlot

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -60,10 +60,13 @@ export const PlotAttribute= {
 
     IMAGE_BOUNDS_SELECTION: 'IMAGE_BOUNDS_SELECTION',
 
-    LAST_IMAGE_BOUNDS: 'LAST_IMAGE_BOUNDS',
-
-    LAST_IMAGE_TITLE: 'LAST_IMAGE_TITLE',
-
+    /**
+     * setting for outline image, bounds (for FootprintObj) or drawObj, text, textLoc,
+     */
+    OUTLINEIMAGE_BOUNDS: 'OUTLINEIMAGE_BOUNDS',
+    OUTLINEIMAGE_TITLE: 'OUTLINEIMAGE_TITLE',
+    OUTLINEIMAGE_TITLELOC: 'OUTLINEIMAGE_TITLELOC',
+    OUTLINEIMAGE_DRAWOBJ: 'OUTLINE_OBJ',
     /**
      * This will probably an object to represent a line {pt0: point,pt1: point}
      * @See ./Point.js
@@ -124,6 +127,7 @@ export const PlotAttribute= {
 
 
     UNIQUE_KEY : 'UNIQUE_KEY'
+
 };
 
 

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -1339,8 +1339,8 @@ export class WebPlotRequest extends ServerRequest {
     getOverlayIds() {
         return this.containsParam(C.OVERLAY_IDS) ?
             this.getParam(C.OVERLAY_IDS).split(';') :
-            ['ACTIVE_TARGET_TYPE','POINT_SELECTION_TYPE', 'DISTANCE_TOOL_TYPE', 'NORTH_UP_COMPASS_TYPE',
-             'SELECT_AREA_TYPE', 'WEB_GRID_TYPE', 'OVERLAY_MARKER_TYPE', 'OVERLAY_FOOTPRINT_TYPE', 'REGION_PLOT_TYPE'];
+            ['ACTIVE_TARGET_TYPE','POINT_SELECTION_TYPE', 'NORTH_UP_COMPASS_TYPE',
+             'WEB_GRID_TYPE', 'OVERLAY_MARKER_TYPE', 'OVERLAY_FOOTPRINT_TYPE', 'REGION_PLOT_TYPE'];
             //[ActiveTarget.TYPE_ID,'OTHER'];
     }
 

--- a/src/firefly/js/visualize/draw/DrawUtil.js
+++ b/src/firefly/js/visualize/draw/DrawUtil.js
@@ -9,7 +9,7 @@ import {toRadians} from '../VisUtil.js';
 const FALLBACK_COLOR = 'red';
 
 export default {getColor, beginPath, stroke, strokeRec, drawLine, drawText, drawTextCanvas, drawPath, makeShadow,
-                drawHandledLine, drawInnerRecWithHandles, drawInnerCircleWithHandles, rotateAroundScreenPt,
+                drawHandledLine, drawInnerRecWithHandles, drawCircleWithHandles, rotateAroundScreenPt,
                 drawX, drawSquareX, drawSquare, drawEmpSquareX, drawCross, drawSymbol,
                 drawEmpCross, drawDiamond, drawDot, drawCircle, drawEllipse, drawBoxcircle,
                 drawArrow, drawRotate, clear,clearCanvas, fillRec, getDrawingSize,
@@ -87,13 +87,17 @@ function drawInnerRecWithHandles(ctx, color, lineWidth, inX1, inY1, inX2, inY2) 
     stroke(ctx);
 }
 
-function drawInnerCircleWithHandles(ctx, color, lineWidth, inX1, inY1, inX2, inY2) {
+function drawCircleWithHandles(ctx, color, lineWidth, inX1, inY1, inX2, inY2, outerThickness = 0) {
 
     const x0 = (inX1+inX2)/2;
     const y0 = (inY1+inY2)/2;
-    const r1 = Math.max((Math.abs(inX1-inX2)-(2*lineWidth))/2, 1);
-    const r2 = Math.max((Math.abs(inY1-inY2)-(2*lineWidth))/2, 1);
+    const rx = (inX2 - inX1)/2;
+    const ry = (inY2 - inY1)/2;
 
+    let r1 = Math.abs(rx);
+    let r2 = Math.abs(ry);
+    r1 = Math.max(r1 - outerThickness, 1);
+    r2 = Math.max(r2 - outerThickness, 1);
 
     drawEllipse(ctx, x0, y0, color, lineWidth, r1, r2, 0);
 }

--- a/src/firefly/js/visualize/draw/SelectBox.js
+++ b/src/firefly/js/visualize/draw/SelectBox.js
@@ -169,7 +169,6 @@ function crossesDisplay(plot, devPt1, devPt2) {
 
 
 /**
- *
  * @param ctx
  * @param {DevicePt} pt0
  * @param {DevicePt} pt2
@@ -182,21 +181,21 @@ function drawBox(ctx, pt0, pt2, drawParams,renderOptions) {
     const   {handleColor=color} = drawParams;
     const lineWidth= (style===Style.STANDARD) ? 2 : 1;
 
-    const sWidth= Math.abs(pt2.x-pt0.x);
-    const sHeight= Math.abs(pt2.y-pt0.y);
+    const sWidth= pt2.x-pt0.x;
+    const sHeight= pt2.y-pt0.y;
 
     if (selectedShape === SelectedShape.rect.key) {    // no rectangle for handle only case
         DrawUtil.strokeRec(ctx, color, lineWidth, pt0.x, pt0.y, sWidth, sHeight);
     } else if (selectedShape === SelectedShape.circle.key) {
-        DrawUtil.drawEllipse(ctx, (pt2.x + pt0.x)/2, (pt0.y+pt2.y)/2, color, lineWidth, sWidth/2, sHeight/2, 0);
+        DrawUtil.drawCircleWithHandles(ctx, color, lineWidth, pt0.x, pt0.y, pt2.x, pt2.y);
     }
 
     if (style === Style.HANDLED) {
 
         if (selectedShape === SelectedShape.rect.key) {    // no rectangle for handle only case
-            DrawUtil.drawInnerRecWithHandles(ctx, innerBoxColor, 2, pt0.x, pt0.y, pt2.x, pt2.y);
+            DrawUtil.drawInnerRecWithHandles(ctx, innerBoxColor, 2, pt0.x, pt0.y, pt2.x, pt2.y, lineWidth);
         } else {
-            DrawUtil.drawInnerCircleWithHandles(ctx, innerBoxColor, 2, pt0.x, pt0.y, pt2.x, pt2.y);
+            DrawUtil.drawCircleWithHandles(ctx, innerBoxColor, 2, pt0.x, pt0.y, pt2.x, pt2.y, lineWidth);
         }
 
         const pt1= makeDevicePt(pt0.x+sWidth,pt0.y);

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -137,9 +137,10 @@ function makeRectangleByCorners(pt1, pt2) {
  * @param isOnWorld if the rectangle have the width and height move along the east and north direction over the world domain
  * @returns {Object}
  */
-function makeRectangleByCenter(pt1, width, height, unitType=UnitType.PIXEL, angle = 0.0, angleUnit = UnitType.ARCSEC, isOnWorld = true) {
+function makeRectangleByCenter(pt1, width, height, unitType=UnitType.PIXEL, angle = 0.0, angleUnit = UnitType.ARCSEC,
+                               isOnWorld = true, centerInView = false) {
     const isCenter = true;
-    return Object.assign(make(ShapeType.Rectangle), {pts:[pt1], width, height, unitType, angle, angleUnit, isOnWorld, isCenter});
+    return Object.assign(make(ShapeType.Rectangle), {pts:[pt1], width, height, unitType, angle, angleUnit, isOnWorld, isCenter, centerInView});
 }
 
 /**
@@ -726,7 +727,7 @@ export function drawText(drawObj, ctx, plot, inPt, drawParams) {
  * @param onlyAddToPath
  */
 function drawRectangle(drawObj, ctx, plot, drawParams, onlyAddToPath) {
-    const {pts, text, width, height, angleUnit, isCenter = false, isOnWorld = false}= drawObj;
+    const {pts, text, width, height, angleUnit, isCenter = false, isOnWorld = false, centerInView=false}= drawObj;
     let {renderOptions}= drawObj;
     const {color, lineWidth, style, textLoc, unitType, fontSize}= drawParams;
     let {angle = 0.0}= drawObj;
@@ -746,10 +747,10 @@ function drawRectangle(drawObj, ctx, plot, drawParams, onlyAddToPath) {
         if (isCenter) {
             sRect = rectOnImage(pts[0], isCenter, plot, width, height, unitType, isOnWorld);
         }
-
         const devPt0 = plot ? plot.getDeviceCoords(pts[0]) : pts[0];
         if (!plot || (!isCenter && plot.pointOnDisplay(devPt0)) ||
-                     (isCenter && sRect && cornerInView(sRect.corners, plot))) {
+                     (isCenter && ((centerInView&&plot.pointOnDisplay(devPt0))||
+                                   (sRect && cornerInView(sRect.corners, plot))))) {
             inView = true;
 
             switch (unitType) {

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -915,7 +915,8 @@ function drawEllipse(drawObj, ctx, plot, drawParams, onlyAddToPath) {
 
         if (plot) {
             const sRect = rectOnImage(pts[0], true, plot, radius1*2, radius2*2, unitType, isOnWorld);
-            if (!plot.pointOnDisplay(pt0) || !sRect || !cornerInView(sRect.corners, plot)) {
+
+            if (!plot.pointOnDisplay(pt0) && !sRect && !cornerInView(sRect.corners, plot)) {
                 inView = false;
             } else {
                 w = sRect.width * plot.zoomFactor/2;

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -146,6 +146,22 @@ function contextToolbar(pv,dlAry,extensionList) {
                                showMultiImageController={showMulti}/>
         );
     }
+    else if (showUnselect(pv, dlAry)) {
+        return (
+            <VisCtxToolbarView {...{plotView:pv, dlAry,  extensionAry:EMPTY_ARRAY,
+                showCatUnSelect:true,
+                showMultiImageController:showMulti}}
+            />
+        );
+    }
+    else if (showClearFilter(pv,dlAry)) {
+        return (
+            <VisCtxToolbarView {...{plotView:pv, dlAry,  extensionAry:EMPTY_ARRAY,
+                showClearFilter:true,
+                showMultiImageController:showMulti}}
+            />
+        );
+    }
     else if (showMulti || isHiPS(plot)) {
         return (
             <VisCtxToolbarView plotView={pv} dlAry={dlAry} extensionAry={EMPTY_ARRAY}

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -191,7 +191,10 @@ function zoomStart(state, action) {
 
 
     // update zoom factor and scroll position
-    const centerImagePt= findCurrentCenterPoint(pv);
+    const centerImagePt= isFitFill(userZoomType) ?
+                          makeImagePt(plot.dataWidth/2, plot.dataHeight/2) :
+                          findCurrentCenterPoint(pv);
+
     pv= replacePrimaryPlot(pv,clonePlotWithZoom(plot,zoomLevel));
 
 
@@ -464,9 +467,8 @@ function updateViewSize(state,action) {
             pv= recenterPv(null, false)(pv);
         }
         else {
-            const centerImagePt= (pv.scrollX<0 || pv.scrollY<0) ?
-                makeImagePt(plot.dataWidth/2, plot.dataHeight/2) :
-                findCurrentCenterPoint(pv);
+            // const centerImagePt= (pv.scrollX<0 || pv.scrollY<0) ? makeImagePt(plot.dataWidth/2, plot.dataHeight/2) : findCurrentCenterPoint(pv);
+            const centerImagePt= (pv.scrollX===-1 && pv.scrollY===-1) ? makeImagePt(plot.dataWidth/2, plot.dataHeight/2) : findCurrentCenterPoint(pv);
             pv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt));
         }
 

--- a/src/firefly/js/visualize/task/PlotAdminTask.js
+++ b/src/firefly/js/visualize/task/PlotAdminTask.js
@@ -17,7 +17,7 @@ import { getPlotViewById, applyToOnePvOrGroup, findPlotGroup, isDrawLayerAttache
 import {isHiPS, isImage} from '../WebPlot.js';
 import {RotateType} from '../PlotState.js';
 import {clone} from '../../util/WebUtil.js';
-import {destroySelectAreaRelatedLayers} from '../ui/SelectAreaDropDownView.jsx';
+import {detachSelectAreaRelatedLayers} from '../ui/SelectAreaDropDownView.jsx';
 
 export function autoPlayActionCreator(rawAction) {
     return (dispatcher) => {
@@ -95,6 +95,8 @@ export function restoreDefaultsActionCreator(rawAction) {
         const {plotGroupAry,plotViewAry}= vr;
         const pv= getPlotViewById(vr,plotId);
         const plotGroup= findPlotGroup(pv.plotGroupId,plotGroupAry);
+
+        detachSelectAreaRelatedLayers(pv, true);
         applyToOnePvOrGroup( plotViewAry, plotId, plotGroup, false,
             (pv)=> {
                 if (vr.plotRequestDefaults[pv.plotId]) {
@@ -121,7 +123,6 @@ export function restoreDefaultsActionCreator(rawAction) {
 
                     }
                 }
-                destroySelectAreaRelatedLayers();
             });
     };
 }

--- a/src/firefly/js/visualize/task/PlotAdminTask.js
+++ b/src/firefly/js/visualize/task/PlotAdminTask.js
@@ -17,6 +17,7 @@ import { getPlotViewById, applyToOnePvOrGroup, findPlotGroup, isDrawLayerAttache
 import {isHiPS, isImage} from '../WebPlot.js';
 import {RotateType} from '../PlotState.js';
 import {clone} from '../../util/WebUtil.js';
+import {destroySelectAreaRelatedLayers} from '../ui/SelectAreaDropDownView.jsx';
 
 export function autoPlayActionCreator(rawAction) {
     return (dispatcher) => {
@@ -120,6 +121,7 @@ export function restoreDefaultsActionCreator(rawAction) {
 
                     }
                 }
+                destroySelectAreaRelatedLayers();
             });
     };
 }

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -281,8 +281,8 @@ function getCornersAttribute(pv) {
     const cAry= getCorners(plot);
     if (!cAry) return null;
     return {
-        [PlotAttribute.LAST_IMAGE_BOUNDS]: cAry,
-        [PlotAttribute.LAST_IMAGE_TITLE]: plot.title
+        [PlotAttribute.OUTLINEIMAGE_BOUNDS]: cAry,
+        [PlotAttribute.OUTLINEIMAGE_TITLE]: plot.title
     };
 }
 

--- a/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
@@ -172,7 +172,7 @@ export function drawOnCanvas(c,drawingDef, w, h) {
 function makeHelpLine(helpLine) {
     if (helpLine) {
         return (
-            <div style={{paddingTop:10,maxWidth:'30em',marginLeft:'2em'}}>{helpLine}</div>
+            <div style={{paddingTop:10,paddingBottom:5,maxWidth:'30em',marginLeft:'2em', whiteSpace: 'normal'}}>{helpLine}</div>
         );
     }
     else {

--- a/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
@@ -108,7 +108,7 @@ export function detachImageOutlineLayerForSelectArea(pv, allPlots = true) {
 }
 
 export function detachSelectAreaRelatedLayers(pv, allPlots = true, selectId = SelectArea.TYPE_ID) {
-    detachSelectArea(selectId, allPlots, selectId);
+    detachSelectArea(pv, allPlots, selectId);
     detachImageOutlineLayerForSelectArea(pv, allPlots);
 }
 

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -327,7 +327,8 @@ function zoomIntoSelection(pv, dlAry) {
     const sp0=  cc.getScreenCoords(sel.pt0);
     const sp2=  cc.getScreenCoords(sel.pt1);
 
-    const level= (viewDim.width / Math.abs(sp0.x-sp2.x)) * p.zoomFactor;
+    const level= Math.min((viewDim.width / Math.abs(sp0.x-sp2.x)),
+                          (viewDim.height/ Math.abs(sp0.y-sp2.y))) * p.zoomFactor;
     dispatchZoom({ plotId, userZoomType: UserZoomTypes.LEVEL, level});
 
 

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -236,7 +236,7 @@ function crop(pv, dlAry) {
 // attach image outline drawing layer on top of the cropped image, zoom-to-fit image and recenter image
 function attachImageOutline(pv, dlAry) {
     const selectedShape = getSelectedShape(pv, dlAry);
-    if (selectedShape === SelectedShape.rect.key) return;
+    //if (selectedShape === SelectedShape.rect.key) return;
 
     const outlineAry = getDrawLayersByType(dlAry, ImageOutline.TYPE_ID);
     let   dl = outlineAry.find((dl) => isOutlineImageForSelectArea(dl));
@@ -256,16 +256,19 @@ function attachImageOutline(pv, dlAry) {
             return Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
         };
 
-        const r1 = dist((imgPt[0].x - imgPt[1].x), (imgPt[0].y - imgPt[1].y))/2;
-        const r2 = dist((imgPt[1].x - imgPt[2].x), (imgPt[1].y - imgPt[2].y))/2;
+        const r1 = dist((imgPt[0].x - imgPt[1].x), (imgPt[0].y - imgPt[1].y));
+        const r2 = dist((imgPt[1].x - imgPt[2].x), (imgPt[1].y - imgPt[2].y));
         const center = cc.getWorldCoords(makeImagePt((imgPt[0].x + imgPt[2].x)/2, (imgPt[0].y + imgPt[2].y)/2));
         const rotArc = pv.rotation === 0.0 ? 0.0 : convertAngle('deg', 'arcsec', (360 - pv.rotation));
 
 
-        const ellipseObj = ShapeDataObj.makeEllipse(center, r1, r2, ShapeDataObj.UnitType.IMAGE_PIXEL, rotArc,
-                                                    ShapeDataObj.UnitType.ARCSEC, false);
+        const drawObj = selectedShape === SelectedShape.rect.key ?
+                        ShapeDataObj.makeRectangleByCenter(center, r1, r2, ShapeDataObj.UnitType.IMAGE_PIXEL,
+                                                           rotArc,  ShapeDataObj.UnitType.ARCSEC, false, true) :
+                        ShapeDataObj.makeEllipse(center, r1/2, r2/2, ShapeDataObj.UnitType.IMAGE_PIXEL,
+                                                            rotArc, ShapeDataObj.UnitType.ARCSEC, false);
         dl = dispatchCreateDrawLayer(ImageOutline.TYPE_ID,
-                                    {drawObj: ellipseObj, color: 'red', title, destroyWhenAllDetached: true});
+                                    {drawObj, color: 'red', title, destroyWhenAllDetached: true});
     }
 
     if (!isDrawLayerAttached(dl, pv.plotId)) {
@@ -327,8 +330,8 @@ function zoomIntoSelection(pv, dlAry) {
     const sp0=  cc.getScreenCoords(sel.pt0);
     const sp2=  cc.getScreenCoords(sel.pt1);
 
-    const level= Math.min((viewDim.width / Math.abs(sp0.x-sp2.x)),
-                          (viewDim.height/ Math.abs(sp0.y-sp2.y))) * p.zoomFactor;
+    const level= Math.min(viewDim.width/Math.abs(sp0.x-sp2.x),
+                          viewDim.height/Math.abs(sp0.y-sp2.y)) * p.zoomFactor;
     dispatchZoom({ plotId, userZoomType: UserZoomTypes.LEVEL, level});
 
 

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -16,7 +16,7 @@ import {logError} from '../../util/WebUtil.js';
 import {showImageAreaStatsPopup} from './ImageStatsPopup.jsx';
 import {getDrawLayersByType, isDrawLayerAttached } from '../PlotViewUtil.js';
 
-import {dispatchDetachLayerFromPlot, dispatchCreateDrawLayer,
+import {dispatchCreateDrawLayer,
         dispatchAttachLayerToPlot} from '../DrawLayerCntlr.js';
 import {dispatchCrop, dispatchChangeCenterOfProjection, dispatchChangePrimePlot,
         dispatchZoom, dispatchProcessScroll, dispatchChangeHiPS} from '../ImagePlotCntlr.js';
@@ -24,7 +24,7 @@ import {makePlotSelectionExtActivateData} from '../../core/ExternalAccessUtils.j
 import {dispatchExtensionActivate} from '../../core/ExternalAccessCntlr.js';
 import {selectCatalog,unselectCatalog,filterCatalog,clearFilterCatalog} from '../../drawingLayers/Catalog.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
-import SelectArea, {SelectedShape} from '../../drawingLayers/SelectArea.js';
+import {SelectedShape} from '../../drawingLayers/SelectArea.js';
 import {isImageOverlayLayersActive} from '../RelatedDataUtil.js';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 import CoordUtil from '../CoordUtil.js';
@@ -37,7 +37,7 @@ import {isLoadingHiPSSurverys} from '../HiPSCntlr.js';
 import {getSelectedShape} from '../../drawingLayers/Catalog.js';
 import ImageOutline from '../../drawingLayers/ImageOutline.js';
 import ShapeDataObj from '../draw/ShapeDataObj.js';
-import {isOutlineImageForSelectArea, SELECT_AREA_TITLE} from './SelectAreaDropDownView.jsx';
+import {isOutlineImageForSelectArea, detachSelectArea, SELECT_AREA_TITLE} from './SelectAreaDropDownView.jsx';
 import {convertAngle} from '../VisUtil.js';
 
 import CROP from 'html/images/icons-2014/24x24_Crop.png';
@@ -228,7 +228,7 @@ function crop(pv, dlAry) {
 
     dispatchCrop({plotId:pv.plotId, imagePt1:ip0, imagePt2:ip1, cropMultiAll});
     attachImageOutline(pv, dlAry);
-    dispatchDetachLayerFromPlot(SelectArea.TYPE_ID,pv.plotId,true);
+    detachSelectArea(pv, true);
 }
 
 
@@ -265,7 +265,7 @@ function attachImageOutline(pv, dlAry) {
         const ellipseObj = ShapeDataObj.makeEllipse(center, r1, r2, ShapeDataObj.UnitType.IMAGE_PIXEL, rotArc,
                                                     ShapeDataObj.UnitType.ARCSEC, false);
         dl = dispatchCreateDrawLayer(ImageOutline.TYPE_ID,
-                                    {drawObj: ellipseObj, color: 'red', title});
+                                    {drawObj: ellipseObj, color: 'red', title, destroyWhenAllDetached: true});
     }
 
     if (!isDrawLayerAttached(dl, pv.plotId)) {
@@ -344,7 +344,7 @@ function zoomIntoSelection(pv, dlAry) {
     }
 
     attachImageOutline(pv, dlAry);
-    dispatchDetachLayerFromPlot(SelectArea.TYPE_ID,pv.plotId,true);
+    detachSelectArea(pv, true);
 
 }
 


### PR DESCRIPTION
The development is made per ticket of 
https://jira.lsstcorp.org/browse/DM-13326

- remove the select area layer after the selected area is cropped or zoomed (to fit selected area)
- for circular selection, a circular region in red is shown on the top of cropped or zoomed (to fit selected area) image in order to indicate the selected (elliptical) area. This is done by using ImageOutline drawing layer, and ImageOutline drawing layer is updated to be generic to contain any Firefly defined drawing object. 
- the image is re-centered at the center of the selected area in case 'recenter image to selected area' is clicked after 'select an area'. 
- Fix the select area help text shown in overlay display menu. 

test:
do image search on Firefly, 
click 'select area' button and make 'Elliptical selection' and make a selection
try 'crop', 'zoom to fit selected area' or 'recenter image to select area' respectively. 
try 'restore to the defaults' to resume the image 
check the title and help line for select area in 'overlay display' menu. 

repeat the test on rotated image. 

