### PR TITLE
DM-11457: Selected table rows should be kept after sorting

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -21,6 +21,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
     public static final String TBL_FILE_PATH = "tblFilePath";       // this meta if exists contains source of the data
     public static final String TBL_FILE_TYPE = "tblFileType";       // this meta if exists contains storage type, ipac, h2, sqlite, etc
     public static final String RESULTSET_ID = "resultSetID";        // this meta if exists contains the ID of the resultset returned.
+    public static final String RESULTSET_REQ = "resultSetRequest";      // this meta if exists contains the Request used to create this of the resultset.
 
     public static final String TBL_ID = "tbl_id";
     public static final String TITLE = "title";
@@ -38,7 +39,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
     private int pageSize = -1;
     private int startIdx;
     private ArrayList<String> filters;
-    private SelectionInfo selectionInfo;
+    private SelectionInfo selectInfo;
     private Map<String, String> metaInfo;
 
     public TableServerRequest() {
@@ -148,12 +149,12 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
         }
     }
 
-    public SelectionInfo getSelectionInfo() {
-        return selectionInfo;
+    public SelectionInfo getSelectInfo() {
+        return selectInfo;
     }
 
-    public void setSelectionInfo(SelectionInfo selectionInfo) {
-        this.selectionInfo = selectionInfo;
+    public void setSelectInfo(SelectionInfo selectInfo) {
+        this.selectInfo = selectInfo;
     }
 
     /**
@@ -290,7 +291,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
     @Override
     public ServerRequest cloneRequest() {
         TableServerRequest tsr = (TableServerRequest) super.cloneRequest();
-        tsr.setSelectionInfo(getSelectionInfo());
+        tsr.setSelectInfo(getSelectInfo());
         return tsr;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.data;
 
+import edu.caltech.ipac.firefly.data.table.SelectionInfo;
 import edu.caltech.ipac.util.StringUtils;
 
 import javax.validation.constraints.NotNull;
@@ -21,9 +22,6 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
     public static final String TBL_FILE_TYPE = "tblFileType";       // this meta if exists contains storage type, ipac, h2, sqlite, etc
     public static final String RESULTSET_ID = "resultSetID";        // this meta if exists contains the ID of the resultset returned.
 
-    public static final String DECIMATE_INFO = "decimate";
-    public static final String SQL_FROM = "sqlFrom";
-
     public static final String TBL_ID = "tbl_id";
     public static final String TITLE = "title";
     public static final String FILTERS = "filters";
@@ -33,12 +31,14 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
     public static final String INCL_COLUMNS = "inclCols";
     public static final String FIXED_LENGTH = "fixedLength";
     public static final String META_INFO = "META_INFO";
-    public static final List<String> SYS_PARAMS = Arrays.asList(REQUEST_CLASS,INCL_COLUMNS,SORT_INFO,FILTERS,PAGE_SIZE,START_IDX,FIXED_LENGTH,META_INFO,TBL_ID,SQL_FROM);
+    public static final List<String> SYS_PARAMS = Arrays.asList(REQUEST_CLASS,INCL_COLUMNS,SORT_INFO,FILTERS,PAGE_SIZE,START_IDX,FIXED_LENGTH,META_INFO,TBL_ID);
     public static final String TBL_INDEX = "tbl_index";     // the table to show if it's a multi-table file.
+    public static final String SELECT_INFO = "selectInfo";  // a property of META_INFO.  deserialize into SelectionInfo.java
 
     private int pageSize = -1;
     private int startIdx;
     private ArrayList<String> filters;
+    private SelectionInfo selectionInfo;
     private Map<String, String> metaInfo;
 
     public TableServerRequest() {
@@ -146,6 +146,14 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
         } else {
             this.filters = null;
         }
+    }
+
+    public SelectionInfo getSelectionInfo() {
+        return selectionInfo;
+    }
+
+    public void setSelectionInfo(SelectionInfo selectionInfo) {
+        this.selectionInfo = selectionInfo;
     }
 
     /**
@@ -278,6 +286,14 @@ public class TableServerRequest extends ServerRequest implements Serializable, D
         }
         return params;
     }
+
+    @Override
+    public ServerRequest cloneRequest() {
+        TableServerRequest tsr = (TableServerRequest) super.cloneRequest();
+        tsr.setSelectionInfo(getSelectionInfo());
+        return tsr;
+    }
+
 
 //====================================================================
 //

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/table/SelectionInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/table/SelectionInfo.java
@@ -7,22 +7,34 @@ import edu.caltech.ipac.util.StringUtils;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**
  * Date: Jun 19, 2009
-*
-* @author loi
-* @version $Id: SelectionInfo.java,v 1.5 2012/02/14 01:32:21 loi Exp $
-*/
+ * Serialized form:  selectAll-idx1,idx2[,idxn]-rowCount
+ *  selectAll is a boolean
+ *  rowCount is an integer
+ *
+ * @author loi
+ * @version $Id: SelectionInfo.java,v 1.5 2012/02/14 01:32:21 loi Exp $
+ */
 public class SelectionInfo implements Serializable {
     private boolean selectAll;
     private Set<Integer> exceptions = new HashSet<Integer>();
     private int rowCount;
 
     public SelectionInfo() {
+    }
+
+    public SelectionInfo(boolean selectAll, List<Integer> exceptions, int rowCount) {
+        this.selectAll = selectAll;
+        this.rowCount = rowCount;
+        if (exceptions != null) {
+            this.exceptions = new HashSet<>(exceptions);
+        }
     }
 
     public void setRowCount(int rowCount) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -126,7 +126,8 @@ abstract public class BaseDbAdapter implements DbAdapter {
             String cols = treq.getSortInfo().getSortColumns().stream()
                     .map(c -> c.contains("\"") ? c : "\"" + c + "\"")
                     .collect(Collectors.joining(","));
-            return  "order by " + cols + dir;
+            String nullsOrder = dir.equals("") ? " NULLS FIRST" : " NULLS LAST";     // this may be HSQL specific.  move it to subclass if when it becomes a problem.
+            return  "order by " + cols + dir + nullsOrder;
         }
         return "";
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -8,23 +8,28 @@ import edu.caltech.ipac.astro.IpacTableWriter;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.data.table.SelectionInfo;
 import edu.caltech.ipac.firefly.data.table.TableMeta;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbInstance;
 import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.db.spring.JdbcFactory;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
+import edu.caltech.ipac.firefly.server.util.ipactable.JsonTableUtil;
 import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.DataType;
 import edu.caltech.ipac.util.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
 
 import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -265,7 +270,20 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         nreq.setSortInfo(null);
         nreq.setInclColumns(new String[0]);
 
-        return execRequestQuery(nreq, dbFile, resultSetID);
+        DataGroupPart page = execRequestQuery(nreq, dbFile, resultSetID);
+
+        // save information needed to recreated this resultset
+        page.getTableDef().setAttribute(TableServerRequest.RESULTSET_REQ, JsonTableUtil.toJsonTableRequest(treq).toString());
+        page.getTableDef().setAttribute(TableServerRequest.RESULTSET_ID, resultSetID);
+
+        // handle selectInfo
+        // selectInfo is sent to the server as Request.META_INFO.selectInfo
+        // it will be moved into TableModel.selectInfo
+        SelectionInfo selectInfo = getSelectInfoForThisResultSet(treq, dbAdapter, dbFile, resultSetID, page.getRowCount());
+        page.getTableDef().setSelectInfo(selectInfo);
+        treq.setSelectInfo(null);
+
+        return page;
     }
 
     public boolean isSecurityAware() { return false; }
@@ -279,5 +297,60 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         return cols;
     }
 
+    private String ensurePrevResultSetIfExists(TableServerRequest treq, File dbFile) {
+
+        String prevResultSetID = treq.getMeta().get(TableServerRequest.RESULTSET_ID);
+        if (!StringUtils.isEmpty(prevResultSetID)) {
+            try {
+                DbInstance dbInstance = DbAdapter.getAdapter(treq).getDbInstance(dbFile);
+                JdbcFactory.getSimpleTemplate(dbInstance).queryForInt(String.format("select count(*) from %s", prevResultSetID));
+            } catch (Exception e) {
+                // does not exists.. create table from original 'data' table
+                String resultSetRequest = treq.getMeta().get(TableServerRequest.RESULTSET_REQ);
+                if (!StringUtils.isEmpty(resultSetRequest)) {
+                    try {
+                        TableServerRequest req = QueryUtil.convertToServerRequest(resultSetRequest);
+                        DataGroupPart page = getResultSet(req, dbFile);
+                        prevResultSetID = page.getTableDef().getAttribute(TableServerRequest.RESULTSET_ID).getValue();
+                    } catch (DataAccessException e1) {
+                        // can ignore for now.
+                    }
+                    return prevResultSetID;
+                }
+            }
+        }
+        return prevResultSetID;
+    }
+
+    private SelectionInfo getSelectInfoForThisResultSet(TableServerRequest treq, DbAdapter dbAdapter, File dbFile, String forTable, int rowCnt) {
+
+        SelectionInfo selectInfo = treq.getSelectInfo();
+        if (selectInfo == null) {
+            selectInfo = new SelectionInfo(false, null, rowCnt);
+        } else {
+            selectInfo.setRowCount(rowCnt);
+        }
+
+        String prevResultSetID = treq.getMeta(TableServerRequest.RESULTSET_ID);             // the previous resultset ID
+        prevResultSetID = StringUtils.isEmpty(prevResultSetID) ? "data" : prevResultSetID;
+
+        if ( selectInfo.getSelectedCount() > 0 && !String.valueOf(prevResultSetID).equals(String.valueOf(forTable)) ) {
+            // there were row(s) selected from previous resultset.. make sure selectInfo is remapped to new resultset
+            prevResultSetID = ensurePrevResultSetIfExists(treq, dbFile);
+
+            String rowNums = StringUtils.toString(selectInfo.getSelected());
+            SimpleJdbcTemplate jdbc = JdbcFactory.getSimpleTemplate(dbAdapter.getDbInstance(dbFile));
+            String origRowIds = String.format("Select ROW_IDX from %s where ROW_NUM in (%s)", prevResultSetID, rowNums);
+
+            List<Integer> newRowNums = new ArrayList<>();
+            try {
+                newRowNums = jdbc.query(String.format("Select ROW_NUM from %s where ROW_IDX in (%s)", forTable, origRowIds), (rs, idx) -> rs.getInt(1));
+            } catch (Exception ex) {
+                // unable to collect previous select info.  we'll treat it
+            }
+            selectInfo = newRowNums.size() == rowCnt ? new SelectionInfo(true, null, rowCnt) : new SelectionInfo(false, newRowNums, rowCnt);
+        }
+        return selectInfo;
+    }
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -327,8 +327,6 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         SelectionInfo selectInfo = treq.getSelectInfo();
         if (selectInfo == null) {
             selectInfo = new SelectionInfo(false, null, rowCnt);
-        } else {
-            selectInfo.setRowCount(rowCnt);
         }
 
         String prevResultSetID = treq.getMeta(TableServerRequest.RESULTSET_ID);             // the previous resultset ID
@@ -350,6 +348,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             }
             selectInfo = newRowNums.size() == rowCnt ? new SelectionInfo(true, null, rowCnt) : new SelectionInfo(false, newRowNums, rowCnt);
         }
+        selectInfo.setRowCount(rowCnt);
         return selectInfo;
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -23,6 +23,7 @@ import edu.caltech.ipac.firefly.data.table.*;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupReader;
+import edu.caltech.ipac.firefly.server.util.ipactable.JsonTableUtil;
 import edu.caltech.ipac.firefly.server.util.ipactable.TableDef;
 import edu.caltech.ipac.util.*;
 import edu.caltech.ipac.util.decimate.DecimateKey;
@@ -86,6 +87,12 @@ public class QueryUtil {
         return retval;
     }
 
+    /**
+     * convert a json request to a TableServerRequest
+     * @see JsonTableUtil#toJsonTableRequest for the reverse
+     * @param searchReqStr
+     * @return
+     */
     public static TableServerRequest convertToServerRequest(String searchReqStr) {
         TableServerRequest retval = new TableServerRequest();
         if (!StringUtils.isEmpty(searchReqStr)) {
@@ -97,7 +104,12 @@ public class QueryUtil {
                     if (skey.equals(TableServerRequest.META_INFO)) {
                         Map meta = (Map) val;
                         for (Object mk : meta.keySet()) {
-                            retval.setMeta(String.valueOf(mk), String.valueOf(meta.get(mk)));
+                            String mkey = String.valueOf(mk);
+                            if (mkey.equals(TableServerRequest.SELECT_INFO)) {
+                                retval.setSelectionInfo(SelectionInfo.parse(String.valueOf(meta.get(mkey))));
+                            } else {
+                                retval.setMeta(mkey, String.valueOf(meta.get(mk)));
+                            }
                         }
                     } else {
                         retval.setTrueParam(skey, String.valueOf(val));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -106,7 +106,7 @@ public class QueryUtil {
                         for (Object mk : meta.keySet()) {
                             String mkey = String.valueOf(mk);
                             if (mkey.equals(TableServerRequest.SELECT_INFO)) {
-                                retval.setSelectionInfo(SelectionInfo.parse(String.valueOf(meta.get(mkey))));
+                                retval.setSelectInfo(SelectionInfo.parse(String.valueOf(meta.get(mkey))));
                             } else {
                                 retval.setMeta(mkey, String.valueOf(meta.get(mk)));
                             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/JsonTableUtil.java
@@ -40,7 +40,9 @@ public class JsonTableUtil {
 
         if (request != null && request.getMeta() != null) {
             for (String key : request.getMeta().keySet()) {
-                meta.setAttribute(key, request.getMeta(key));
+                if (!meta.contains(key)) {
+                    meta.setAttribute(key, request.getMeta(key));
+                }
             }
         }
 
@@ -59,11 +61,14 @@ public class JsonTableUtil {
 
         if (meta != null) {
             tableModel.put("tableMeta", toJsonTableMeta(meta));
+
+            if (meta.getSelectInfo() != null ){
+                tableModel.put("selectInfo", meta.getSelectInfo().toString());
+            }
         }
         if (request != null ){
             tableModel.put("request", toJsonTableRequest(request));
         }
-
         return tableModel;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/TableDef.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/TableDef.java
@@ -1,5 +1,6 @@
 package edu.caltech.ipac.firefly.server.util.ipactable;
 
+import edu.caltech.ipac.firefly.data.table.SelectionInfo;
 import edu.caltech.ipac.firefly.data.table.TableMeta;
 import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.DataType;
@@ -25,6 +26,7 @@ public class TableDef {
     private int rowCount;
     private int rowStartOffset;
     private int lineSepLength;
+    private SelectionInfo selectInfo;
     private transient Pair<Integer, String> extras;     // used by IpacTableUtil to store extras data while parsing an ipac table via input stream
 
     public void addAttributes(DataGroup.Attribute... attributes) {
@@ -62,6 +64,14 @@ public class TableDef {
     }
 
     public void setCols(List<DataType> cols) { this.cols = cols; }
+
+    public SelectionInfo getSelectInfo() {
+        return selectInfo;
+    }
+
+    public void setSelectInfo(SelectionInfo selectInfo) {
+        this.selectInfo = selectInfo;
+    }
 
     /**
      * returns all of the attributes including comments.  This function returns the attributes

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -6,7 +6,7 @@
  * Date: 3/5/12
  */
 
-import {get, set, omitBy} from 'lodash';
+import {get, set, omitBy, cloneDeep} from 'lodash';
 
 import {ServerParams} from '../data/ServerParams.js';
 import {doJsonRequest, DEF_BASE_URL} from '../core/JsonUtils.js';
@@ -14,8 +14,8 @@ import {getBgEmail} from '../core/background/BackgroundUtil.js';
 import {encodeUrl, download, getModuleName} from '../util/WebUtil.js';
 
 import Enum from 'enum';
-import {getTblById, getResultSetID} from '../tables/TableUtil.js';
-import {MAX_ROW, DataTagMeta, getTblId, setResultSetID, setSelectInfo} from '../tables/TableRequestUtil.js';
+import {getTblById, getResultSetID, getResultSetRequest} from '../tables/TableUtil.js';
+import {MAX_ROW, DataTagMeta, getTblId, setResultSetID, setResultSetRequest, setSelectInfo} from '../tables/TableRequestUtil.js';
 import {SelectInfo} from '../tables/SelectInfo.js';
 import {getBackgroundJobs} from '../core/background/BackgroundUtil.js';
 
@@ -44,16 +44,9 @@ export function fetchTable(tableRequest, hlRowIdx) {
         startIdx: 0,
         pageSize : MAX_ROW
     };
-    const tableModel = getTblById(getTblId(tableRequest));
-    if (tableModel) {
-        // pass along its resultSetID
-        const resultSetID = getResultSetID(tableModel.tbl_id);
-        resultSetID && setResultSetID(tableRequest, resultSetID);
-        // pass along selectInfo
-        tableModel.selectInfo && setSelectInfo(tableRequest, tableModel.selectInfo);
-    }
+    
+    tableRequest = setupNewRequest(tableRequest, def);
 
-    tableRequest = Object.assign(def, tableRequest);
     const params = {
         [ServerParams.REQUEST]: JSON.stringify(tableRequest),
     };
@@ -328,3 +321,25 @@ export function getDownloadScript({packageID, type, fname, dataSource}) {
     if (url) download(url);
 }
 
+/**
+ * This function add some important meta info needed by the server to process this request.
+ * These meta are system-only info and should not need to be known outside of this app.
+ * @param {TableRequest} tableRequest
+ * @param {object} defaults
+ */
+function setupNewRequest(tableRequest, defaults) {
+    const newRequest = Object.assign(cloneDeep(tableRequest), defaults);
+
+    const tableModel = getTblById(getTblId(newRequest));
+    if (tableModel) {
+        // pass along its resultSetID
+        const resultSetID = getResultSetID(tableModel.tbl_id);
+        resultSetID && setResultSetID(newRequest, resultSetID);
+        // pass along its resultSetRequest
+        const resultSetRequest = getResultSetRequest(tableModel.tbl_id);
+        resultSetRequest && setResultSetRequest(newRequest, resultSetRequest);
+        // pass along selectInfo
+        tableModel.selectInfo && setSelectInfo(newRequest, tableModel.selectInfo);
+    }
+    return newRequest;
+}

--- a/src/firefly/js/tables/SelectInfo.js
+++ b/src/firefly/js/tables/SelectInfo.js
@@ -5,8 +5,13 @@
 import {isEmpty} from 'lodash';
 
 import {getTblById} from './TableUtil.js';
+import {toBoolean} from '../util/WebUtil.js';
 
-
+/**
+ *  Serialized form:  selectAll-idx1,idx2[,idxn]-rowCount
+ *      selectAll is a boolean
+ *      rowCount is an integer
+ */
 export class SelectInfo {
     constructor(selectInfo) {
         this.data = selectInfo;
@@ -88,13 +93,14 @@ export class SelectInfo {
         return this.data.selectAll + '-' + Array.from(this.data.exceptions).join(',') + '-' + this.data.rowCount;
     }
 
-    parse(s) {
+    static parse(s) {
         var selecInfo = {};
         var parts = s.split('-');
         if (parts.length === 3) {
-            selecInfo.selectAll = Boolean(parts[0]);
+            selecInfo.selectAll = toBoolean(parts[0]);
             if (!isEmpty(parts[1])) {
-                selecInfo.exceptions =  parts[1].reduce( (res, cval) => {
+                const indices = parts[1].split(',');
+                selecInfo.exceptions =  indices.reduce( (res, cval) => {
                         return res.add(parseInt(cval));
                     }, new Set());
             }
@@ -112,7 +118,7 @@ export class SelectInfo {
      * @param {number} offset     All indices passed into this class's funtion will be offsetted by this given value.
      * @returns {SelectInfo}
      */
-    static newInstance({selectAll=false, exceptions=(new Set()), rowCount=0}, offset) {
+    static newInstance({selectAll=false, exceptions=(new Set()), rowCount=0}={}, offset) {
         var si = new SelectInfo({selectAll, exceptions, rowCount});
         if (offset) si.offset = offset;
         return si;

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -27,7 +27,7 @@ export class TableConnector {
                 set(tableModel, 'request.tbl_id', tbl_id);
                 const workingTableModel = cloneDeep(tableModel);
                 workingTableModel.origTableModel = tableModel;
-                TblCntlr.dispatchTableInsert(workingTableModel, undefined, false);
+                TblCntlr.dispatchTableAddLocal(workingTableModel, undefined, false);
             }
         }
     }

--- a/src/firefly/js/tables/TableRequestUtil.js
+++ b/src/firefly/js/tables/TableRequestUtil.js
@@ -2,11 +2,11 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, unset, cloneDeep, omit, omitBy, isNil} from 'lodash';
+import {get, set, unset, cloneDeep, omit, omitBy, isNil} from 'lodash';
 
-import {ServerParams} from '../data/ServerParams.js';
 import {uniqueTblId} from './TableUtil.js';
 import {Keys} from '../core/background/BackgroundStatus.js';
+import {SelectInfo} from './SelectInfo.js';
 
 export const MAX_ROW = Math.pow(2,31) - 1;
 export const DataTagMeta = ['META_INFO', Keys.DATA_TAG]; // a tag describing the content of this table.  ie. 'catalog', 'imagemeta'
@@ -208,3 +208,31 @@ export function makeTableFunctionRequest(searchRequest, id, title, params={}, op
     return req;
 }
 
+/**
+ * return the tbl_id from the request object
+ * @param {TableRequest} request
+ * @returns {string}
+ */
+export function getTblId(request) {
+    return get(request, 'META_INFO.tbl_id') || get(request, 'tbl_id'); 
+}
+
+/**
+ * set the resultSetID into the request object
+ * @param {TableRequest} request
+ * @param {string} resultSetID
+ */
+export function setResultSetID(request, resultSetID) {
+    set(request, 'META_INFO.resultSetID', resultSetID);
+}
+
+/**
+ * set selectInfo
+ * @param {TableRequest} request
+ * @param {object} selectInfo
+ */
+export function setSelectInfo(request, selectInfo) {
+    if (selectInfo) {
+        set(request, 'META_INFO.selectInfo', SelectInfo.newInstance(selectInfo).toString());
+    }
+}

--- a/src/firefly/js/tables/TableRequestUtil.js
+++ b/src/firefly/js/tables/TableRequestUtil.js
@@ -227,6 +227,15 @@ export function setResultSetID(request, resultSetID) {
 }
 
 /**
+ * set the resultSetRequest into the request object
+ * @param {TableRequest} request
+ * @param {string} resultSetRequest
+ */
+export function setResultSetRequest(request, resultSetRequest) {
+    set(request, 'META_INFO.resultSetRequest', resultSetRequest);
+}
+
+/**
  * set selectInfo
  * @param {TableRequest} request
  * @param {object} selectInfo

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -218,6 +218,17 @@ export function isFullyLoaded(tbl_id) {
 }
 
 /**
+ * return the resultSetID of this table.
+ * This is a unique ID used to identify the resultset on the server used to populate this table.
+ * @see TableRequestUtil.setResultSetID for the reverse
+ * @param {string} tbl_id
+ * @returns {string}
+ */
+export function getResultSetID(tbl_id) {
+    return get(getTblById(tbl_id), 'tableMeta.resultSetID', '');
+}
+
+/**
  * Returns the first index of the found row.  It will search the table on the client first.
  * If none is found and the table is partially loaded, it will search the server-side as well.
  * @param {string} tbl_id the tbl_id of the table to search on.

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -229,6 +229,17 @@ export function getResultSetID(tbl_id) {
 }
 
 /**
+ * return the resultSetRequest of this table.
+ * This is a JSON string of the request used to created this table
+ * @see TableRequestUtil.setResultSetRequest for the reverse
+ * @param {string} tbl_id
+ * @returns {string}
+ */
+export function getResultSetRequest(tbl_id) {
+    return get(getTblById(tbl_id), 'tableMeta.resultSetRequest', '');
+}
+
+/**
  * Returns the first index of the found row.  It will search the table on the client first.
  * If none is found and the table is partially loaded, it will search the server-side as well.
  * @param {string} tbl_id the tbl_id of the table to search on.

--- a/src/firefly/js/tables/reducer/TableDataReducer.js
+++ b/src/firefly/js/tables/reducer/TableDataReducer.js
@@ -32,13 +32,8 @@ export function dataReducer(state={data:{}}, action={}) {
         case (Cntlr.TABLE_HIGHLIGHT)  :
         case (Cntlr.TABLE_UPDATE)  :
         {
-            var {tbl_id, totalRows} = action.payload;
+            var {tbl_id} = action.payload;
             const updates = {[tbl_id] : {isFetching:false, ...action.payload}};
-            if (totalRows) {     // update selectInfo.rowCount
-                var selectInfo = get(TblUtil.getTblById(tbl_id), 'selectInfo');
-                selectInfo = selectInfo ? {...selectInfo, rowCount: totalRows} : SelectInfo.newInstance({rowCount: totalRows}).data;
-                updates[tbl_id].selectInfo = selectInfo;
-            }
             return TblUtil.smartMerge(root, updates);
         }
         case (Cntlr.TABLE_FETCH)      :

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -312,7 +312,7 @@ function Loading({showTitle, tbl_id, title, removable, bgStatus}) {
     );
 }
 
-function TableError({error, tbl_id, message}) {
+function TableError({tbl_id, message}) {
     const {request} = TblUtil.getTblById(tbl_id);
     const canReset = get(request, 'filters') || get(request, 'sortInfo');
     const reloadTable = () => {


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-11457

As described in the ticket, selection info should be kept after sorting and filtering.
In the case of filtering, when a selected row is removed due to a filter, it will be removed from selection info as well.  This is to ensure that the selection info is valid for the current view.

For example:
- select all, apply a filter.
- all rows are still selected.
- clear filters
- only the previously selected rows are selected.

Also in this ticket, `null` values are sorted to top for ascending and to the bottom on descending.

This ticket can be tested on any table.

