### PR TITLE
DM-13265 Saga error handling

### DIFF
--- a/src/firefly/js/api/ApiBuild.js
+++ b/src/firefly/js/api/ApiBuild.js
@@ -16,7 +16,7 @@ import * as AppDataCntlr from '../core/AppDataCntlr.js';
 import * as DrawLayerCntlr from '../visualize/DrawLayerCntlr.js';
 import {ApiExpandedView} from './ApiExpandedView.jsx';
 import {dispatchAddCell, dispatchRemoveCell, dispatchEnableSpecialViewer} from '../core/LayoutCntlr.js';
-import {dispatchAddSaga} from '../core/MasterSaga.js';
+import {dispatchAddSaga, dispatchAddActionWatcher} from '../core/MasterSaga.js';
 
 // Parts of the lowlevel api
 import * as ApiUtil from './ApiUtil.js';
@@ -174,7 +174,7 @@ export function buildLowlevelAPI() {
         findDispatch(AppDataCntlr),
         findDispatch(DrawLayerCntlr),
         {dispatchAddCell, dispatchRemoveCell, dispatchEnableSpecialViewer},
-        {dispatchAddSaga}
+        {dispatchAddSaga, dispatchAddActionWatcher, }
     );
 
     const ui= {

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -378,9 +378,8 @@ function showImageInMultiViewer(llApi, targetDiv, request, isHiPS, hipsImageConv
 
 function initCoverage(llApi, targetDiv,options= {}) {
     const {MultiImageViewer, MultiViewStandardToolbar}= llApi.ui;
-    const {dispatchAddSaga}= llApi.action;
     const {renderDOM,debug}= llApi.util;
-    const {watchImageMetaData,watchCoverage,NewPlotMode}= llApi.util.image;
+    const {startCoverageWatcher,NewPlotMode}= llApi.util.image;
     highlevelImageInit(llApi);
 
     const {canReceiveNewPlots=NewPlotMode.replace_only.key}= options;
@@ -389,7 +388,7 @@ function initCoverage(llApi, targetDiv,options= {}) {
     renderDOM(targetDiv, MultiImageViewer,
         {viewerId:targetDiv, canReceiveNewPlots, canDelete:false, Toolbar:MultiViewStandardToolbar });
     options= Object.assign({},options, {viewerId:targetDiv});
-    dispatchAddSaga(watchCoverage, options);
+    startCoverageWatcher(options);
 }
 
 

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -43,8 +43,8 @@ export {ExpandType, dispatchApiToolsView} from '../visualize/ImagePlotCntlr.js';
 
 export {CysConverter} from '../visualize/CsysConverter.js';
 export {CCUtil} from '../visualize/CsysConverter.js';
-export {watchCoverage} from '../visualize/saga/CoverageWatcher.js';
-export {watchImageMetaData} from '../visualize/saga/ImageMetaDataWatcher.js';
+export {startCoverageWatcher} from '../visualize/saga/CoverageWatcher.js';
+export {startImageMetadataWatcher} from '../visualize/saga/ImageMetaDataWatcher.js';
 export {getSelectedRegion} from '../drawingLayers/RegionPlot.js';
 
 export {extensionAdd, extensionRemove} from '../core/ExternalAccessUtils.js';

--- a/src/firefly/js/api/ApiViewer.js
+++ b/src/firefly/js/api/ApiViewer.js
@@ -24,7 +24,7 @@ import {dispatchChartAdd} from '../charts/ChartsCntlr.js';
 import {SCATTER, HISTOGRAM} from '../charts/ChartUtil.js';
 import {DT_XYCOLS} from '../charts/dataTypes/XYColsCDT.js';
 import {DT_HISTOGRAM} from '../charts/dataTypes/HistogramCDT.js';
-import {makeFileRequest}  from '../tables/TableUtil.js';
+import {makeFileRequest}  from '../tables/TableRequestUtil.js';
 import {makeXYPlotParams, makeHistogramParams, uniqueChartId} from '../charts/ChartUtil.js';
 import {getWsChannel, getWsConnId} from '../core/messaging/WebSocketClient.js';
 import {getConnectionCount, WS_CONN_UPDATED, GRAB_WINDOW_FOCUS} from '../core/AppDataCntlr.js';

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -466,7 +466,8 @@ export function handleTableSourceConnections({chartId, data, fireflyData}) {
             }
             traceTS._cancel = watchTableChanges(traceTS.tbl_id,
                 [TABLE_LOADED, TABLE_HIGHLIGHT, TABLE_SELECT],
-                (action) => updateChartData(chartId, idx, traceTS, action));
+                (action) => updateChartData(chartId, idx, traceTS, action),
+                uniqueId(`ucd-${traceTS.tbl_id}-trace`)); // watcher id for debugging
 
         }
         tablesources[idx] = traceTS;

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -534,7 +534,7 @@ function isFireflyType(type) {
 
 /**
  * Move firefly attributes from data and layout objects to fireflyData and fireflyLayout
- * @param payload – original action payload
+ * @param payload - original action payload
  * @return updated action payload
  */
 function handleFireflyTraceTypes(payload) {

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -29,7 +29,7 @@ function watchTblGroup(viewerId, tblGroup, addDefaultChart) {
         };
         const actions = [CHART_ADD, CHART_REMOVE, TBL_RESULTS_ACTIVE];
         if (addDefaultChart) actions.push(TABLE_LOADED);
-        return monitorChanges(actions, accept, updateViewer(viewerId, tblGroup));
+        return monitorChanges(actions, accept, updateViewer(viewerId, tblGroup), `wtg-${viewerId}-${tblGroup}`);
     };
 }
 

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -2,11 +2,10 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {take} from 'redux-saga/effects';
-import {get, map} from 'lodash';
+import {get, map, uniqueId} from 'lodash';
 
 import {flux} from '../Firefly.js';
-import {dispatchAddSaga} from '../core/MasterSaga.js';
+import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
 import {appDataReducer, menuReducer, alertsReducer} from './AppDataReducers.js';
 import Point, {isValidPoint} from '../visualize/Point.js';
 import {getModuleName} from '../util/WebUtil.js';
@@ -28,7 +27,6 @@ export const APP_OPTIONS = `${APP_DATA_PATH}.appOptions`;
 
 export const ADD_PREF = `${APP_DATA_PATH}.addPreference`;
 export const REMOVE_PREF = `${APP_DATA_PATH}.removePreference`;
-export const REINIT_RESULT_VIEW = `${APP_DATA_PATH}.reinitResultView`;
 export const ROOT_URL_PATH = `${APP_DATA_PATH}.rootUrlPath`;
 export const SET_ALERTS = `${APP_DATA_PATH}.setAlerts`;
 export const SET_USER_INFO = `${APP_DATA_PATH}.setUserInfo`;
@@ -83,6 +81,7 @@ export function dispatchAppOptions(appOptions) {
 /**
  * @param componentId the id or array of ids of the component to record the task count
  * @param taskId id of task, you create with makeTaskId()
+ * @param replace
  */
 export function dispatchAddTaskCount(componentId,taskId, replace= false) {
     flux.process({type: ADD_TASK_COUNT, payload: {componentId,taskId, replace}});
@@ -132,8 +131,8 @@ export function dispatchSetMenu(menu) {
  * Load search info into the application
  * @param p                     parameter object
  * @param {object[]}  p.groups  an array of search groups
- * @param {string}   [activeSearch] the current selected search.  defaults to the first search.
- * @param {string}   [flow]     'horizontal' or 'vertical'.  defaults to 'vertical'.
+ * @param {string}   [p.activeSearch] the current selected search.  defaults to the first search.
+ * @param {string}   [p.flow]     'horizontal' or 'vertical'.  defaults to 'vertical'.
  */
 export function dispatchLoadSearches({groups, activeSearch, flow}) {
     flux.process({ type : LOAD_SEARCHES, payload: {groups, activeSearch, flow} });
@@ -156,12 +155,13 @@ export function dispatchOnAppReady(callback) {
     if (isAppReady()) {
         callback && callback(flux.getState());
     } else {
-        dispatchAddSaga(doOnAppReady, callback);
+        dispatchAddActionWatcher({id: uniqueId('appReady'), actions: [APP_UPDATE, APP_LOAD],
+            callback: doOnAppReady, params: {callback}});
     }
 }
 
 
-/*---------------------------- EXPORTED FUNTIONS -----------------------------*/
+/*---------------------------- EXPORTED FUNCTIONS -----------------------------*/
 export function isAppReady() {
     const gwtReady = !get(window, 'firefly.use_gwt', false) ||
         get(flux.getState(), [APP_DATA_PATH, 'gwtLoaded']);
@@ -305,20 +305,21 @@ function updateAppData(appData) {
 }
 
 /**
- * This saga watches for app_data.isReady.  
- * When that happens, it will execute the given callback with the current state. 
- * @param {function} callback
+ * Action watcher callback. Watches for app_data.isReady.
+ * When app data are loaded, it will execute the callback passed with params with the current state.
+ * @callback actionWatcherCallback
+ * @param action
+ * @param cancelSelf
+ * @param params
+ * @param {function} params.callback function to execute on completion
  * @param {function} dispatch
  * @param {function} getState
  */
-function* doOnAppReady(callback, dispatch, getState) {
-
-    var isReady = isAppReady();
-    while (!isReady) {
-        yield take([APP_UPDATE, APP_LOAD]);
-        isReady = isAppReady();
+function doOnAppReady(action, cancelSelf, params={}, dispatch, getState) {
+    if (isAppReady()) {
+        params.callback && params.callback(getState());
+        cancelSelf();
     }
-    callback && callback(getState());
 }
 
 /**

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, map, uniqueId} from 'lodash';
+import {get, map} from 'lodash';
 
 import {flux} from '../Firefly.js';
 import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
@@ -155,8 +155,7 @@ export function dispatchOnAppReady(callback) {
     if (isAppReady()) {
         callback && callback(flux.getState());
     } else {
-        dispatchAddActionWatcher({id: uniqueId('appReady'), actions: [APP_UPDATE, APP_LOAD],
-            callback: doOnAppReady, params: {callback}});
+        dispatchAddActionWatcher({actions: [APP_UPDATE, APP_LOAD], callback: doOnAppReady, params: {callback}});
     }
 }
 

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -40,7 +40,6 @@ import ComponentCntlr, {DIALOG_OR_COMPONENT_KEY} from '../core/ComponentCntlr.js
 
 
 //--- import Sagas
-import {syncCharts} from '../visualize/saga/ChartsSync.js';
 import {imagePlotter} from '../visualize/saga/ImagePlotter.js';
 import {watchReadout} from '../visualize/saga/MouseReadoutWatch.js';
 import {watchForRelatedActions} from '../fieldGroup/FieldGroupCntlr.js';
@@ -235,7 +234,6 @@ function createRedux() {
 
 function startCoreSagas() {
     dispatchAddSaga( imagePlotter);
-    dispatchAddSaga( syncCharts);
     dispatchAddSaga( watchReadout);
     dispatchAddSaga( watchForRelatedActions);
     dispatchAddSaga( watchExtensionActions);

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -171,6 +171,12 @@ export function bgDownload({dlRequest, searchRequest, selectInfo}, {key, onCompl
         });
 }
 
+/**
+ * @callback actionWatcherCallback
+ * @param action
+ * @param cancelSelf
+ * @param params
+ */
 function bgTracker(action, cancelSelf, params={}) {
     const {bgID, key, onComplete, sentToBg} = params;
     const bgStatus = bgStatusTransform(action.payload || {});

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -827,11 +827,12 @@ export function createErrorTbl(tbl_id, error) {
  * @param {string}   tbl_id  table id to watch
  * @param {Object}   actions  an array of table actions to watch
  * @param {function} callback  callback to execute when table is loaded.
+ * @param {string} [watcherId] action watcher id to be used
  * @return {function} returns a function used to cancel
  */
-export function watchTableChanges(tbl_id, actions, callback) {
+export function watchTableChanges(tbl_id, actions, callback, watcherId) {
     const accept = (a) => tbl_id === (get(a, 'payload.tbl_id') || get(a, 'payload.request.tbl_id'));
-    return monitorChanges(actions, accept, callback);
+    return monitorChanges(actions, accept, callback, watcherId);
 }
 
 /**
@@ -839,12 +840,13 @@ export function watchTableChanges(tbl_id, actions, callback) {
  * @param {Object}   actions  an array of actions to watch
  * @param {function} accept  a function used to filter incoming actions.  if not given, it will accept all.
  * @param {function} callback  callback to execute when action occurs.
+ * @param {string} [watcherId] action watcher id to be used
  * @return {function} returns a function used to cancel
  */
-export function monitorChanges(actions, accept, callback) {
+export function monitorChanges(actions, accept, callback, watcherId) {
     if (!Array.isArray(actions) || actions.length === 0 || !callback) return;
 
-    const id = uniqueID();
+    const id = watcherId || uniqueID();
     const mCallback = (action) => {
         if (accept(action)) {
             callback(action);
@@ -891,13 +893,14 @@ export function isTextType(col={}) {
 
 /*-------------------------------------private------------------------------------------------*/
 /**
- * this saga watches for table update and invoke the given callback when
+ * Action watcher callback for table update, which is invoked when
  * the table given by tbl_id is fully loaded.
- * @param {Object}   action  action that triggered this watcher
- * @param {function} cancelSelf  function to cancel this watcher
- * @param {Object}   p  parameters object
- * @param {string}   p.tbl_id  table id to watch
- * @param {function} p.resolve  callback to execute when table is loaded.
+ * @callback actionWatcherCallback
+ * @param action  action that triggered this watcher
+ * @param cancelSelf  function to cancel this watcher
+ * @param params  parameters object
+ * @param {string}   params.tbl_id  table id to watch
+ * @param {function} params.resolve  callback to execute when table is loaded.
  */
 function doOnTblLoaded(action, cancelSelf, {tbl_id, resolve}) {
     if (!resolve) cancelSelf();

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -600,6 +600,17 @@ function asyncFetch(request, hlRowIdx, dispatch, tbl_id) {
     });
 }
 
+/**
+ * @callback actionWatcherCallback
+ * @param action
+ * @param cancelSelf
+ * @param params
+ * @param params.bgID
+ * @param params.request
+ * @param params.hlRowIdx
+ * @param params.dispatch
+ * @param params.tbl_id
+ */
 function bgTracker(action, cancelSelf, {bgID, request, hlRowIdx, dispatch, tbl_id}) {
     const {type} = action;
     const {ID, STATE} = action.payload || {};

--- a/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
+++ b/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
@@ -5,8 +5,8 @@
 import {take} from 'redux-saga/effects';
 import {filter, isEmpty, get, isArray, uniq} from 'lodash';
 
-import {watchImageMetaData} from '../../visualize/saga/ImageMetaDataWatcher.js';
-import {watchCoverage} from '../../visualize/saga/CoverageWatcher.js';
+import {startImageMetadataWatcher} from '../../visualize/saga/ImageMetaDataWatcher.js';
+import {startCoverageWatcher} from '../../visualize/saga/CoverageWatcher.js';
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
 
 import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, ENABLE_SPECIAL_VIEWER, SPECIAL_VIEWER,
@@ -112,11 +112,11 @@ function startSpecialViewerSaga(action, alreadyStarted) {
     switch (viewerType) {
 
         case SPECIAL_VIEWER.tableImageMeta:
-            dispatchAddSaga(watchImageMetaData,{viewerId: cellId, paused:false});
+            startImageMetadataWatcher({viewerId: cellId, paused:false});
             break;
         case SPECIAL_VIEWER.coverageImage:
             const useHiPS= get(getAppOptions(), 'hips.useForCoverage',false);
-            dispatchAddSaga(watchCoverage, {viewerId:cellId, ignoreCatalogs:true, paused:false, useHiPS});
+            startCoverageWatcher({viewerId:cellId, ignoreCatalogs:true, paused:false, useHiPS});
             break;
 
     }

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -27,7 +27,7 @@ import {logError} from '../../util/WebUtil.js';
  *     <li>Then loops:
  *     <ul>
  *         <li>waits for a table new table, update, highlight or select change and then updates the drawing layer
- *         <li>waits fora new plot and adds any catalog
+ *         <li>waits for a new plot and adds any catalog
  *     </ul>
  * </ul>
  */

--- a/src/firefly/js/visualize/saga/ChartsSync.js
+++ b/src/firefly/js/visualize/saga/ChartsSync.js
@@ -15,51 +15,47 @@ import {SCATTER, multitraceDesign} from '../../charts/ChartUtil.js';
 import {PLOT2D, DEFAULT_PLOT2D_VIEWER_ID, dispatchAddViewerItems, dispatchRemoveViewerItems, dispatchUpdateCustom, getViewerItemIds, getMultiViewRoot} from '../../visualize/MultiViewCntlr.js';
 
 /**
- * this saga handles chart related side effects
+ * Action watcher callback for handling pre-multitrace chart related side effects
+ * @callback actionWatcherCallback
+ * @param {Action} action
  */
-export function* syncCharts() {
-    while (true) {
-        const action= yield take([ChartsCntlr.CHART_ADD, ChartsCntlr.CHART_MOUNTED, ChartsCntlr.CHART_REMOVE, TablesCntlr.TABLE_LOADED]);
-        if (multitraceDesign()) {
-            return;
-        }
-        switch (action.type) {
-            case ChartsCntlr.CHART_ADD:
-            case ChartsCntlr.CHART_MOUNTED:
-            {
-                const {chartId} = action.payload;
-                ChartsCntlr.getRelatedTblIds(chartId).forEach((tblId) => {
-                    if (TableUtil.isFullyLoaded(tblId)) {
-                        if (!TableStatsCntlr.getColValStats(tblId) && ChartsCntlr.getNumCharts(tblId) === 1) {
-                            TableStatsCntlr.dispatchLoadTblStats(TableUtil.getTblById(tblId)['request']);
-                        }
-                        ChartsCntlr.updateChartData(chartId, tblId);
+export function syncCharts(action) {
+    switch (action.type) {
+        case ChartsCntlr.CHART_ADD:
+        case ChartsCntlr.CHART_MOUNTED:
+        {
+            const {chartId} = action.payload;
+            ChartsCntlr.getRelatedTblIds(chartId).forEach((tblId) => {
+                if (TableUtil.isFullyLoaded(tblId)) {
+                    if (!TableStatsCntlr.getColValStats(tblId) && ChartsCntlr.getNumCharts(tblId) === 1) {
+                        TableStatsCntlr.dispatchLoadTblStats(TableUtil.getTblById(tblId)['request']);
                     }
-                });
-                break;
-            }
-            case ChartsCntlr.CHART_REMOVE:
-            {
-                const {chartId} = action.payload;
-                dispatchRemoveViewerItems(DEFAULT_PLOT2D_VIEWER_ID, [chartId]);
-                break;
-            }
-            case TablesCntlr.TABLE_LOADED:
-                const {tbl_id} = action.payload;
-                if (ChartsCntlr.getNumCharts(tbl_id, true)>0) {  // has related mounted charts
-                    const {invokedBy} = action.payload;
-                    if (invokedBy !== TablesCntlr.TABLE_SORT) {
-                        TableStatsCntlr.dispatchLoadTblStats(TableUtil.getTblById(tbl_id)['request']);
-                    }
-                    ChartsCntlr.updateRelatedData(tbl_id, invokedBy);
+                    ChartsCntlr.updateChartData(chartId, tblId);
                 }
-                break;
+            });
+            break;
         }
+        case ChartsCntlr.CHART_REMOVE:
+        {
+            const {chartId} = action.payload;
+            dispatchRemoveViewerItems(DEFAULT_PLOT2D_VIEWER_ID, [chartId]);
+            break;
+        }
+        case TablesCntlr.TABLE_LOADED:
+            const {tbl_id} = action.payload;
+            if (ChartsCntlr.getNumCharts(tbl_id, true)>0) {  // has related mounted charts
+                const {invokedBy} = action.payload;
+                if (invokedBy !== TablesCntlr.TABLE_SORT) {
+                    TableStatsCntlr.dispatchLoadTblStats(TableUtil.getTblById(tbl_id)['request']);
+                }
+                ChartsCntlr.updateRelatedData(tbl_id, invokedBy);
+            }
+            break;
     }
 }
 
 /**
- * This saga makes synchronizes the default chart viewer with the active table
+ * This saga makes synchronizes the default chart viewer with the active table in pre-multitrace design
  */
 export function* syncChartViewer() {
     while (true) {
@@ -78,7 +74,7 @@ export function* syncChartViewer() {
 }
 
 /**
- * This saga adds a default chart
+ * This saga adds a default chart in pre-multitrace design
  */
 export function* addDefaultScatter() {
     while (true) {


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-13265

- Use spawn when using dispatchAddSaga. This prevents the unhandled exceptions in one saga to cancel all the siblings.
- Use fork with dispatchAddActionWatcher, because we are catching the unhandled exceptions. If an exception occurs in the callback, it won't cancel the saga.
- Added documentation for actionWatcherCallback
- Fixed a bug preventing remote charts on the test page 
- converted some dispatchAddSaga to dispatchAddActionWatcher, including coverage and image metadata watchers and firfely.utl.addActionListener API method. 

Test case:  http://localhost:8080/firefly/demo/ffapi-highlevel-test.html  Open console to view the output, "Start selection extensions", "Track mouth readout". Before, you would get an error when switching readout from one image to the other, which would cancel both listeners. Now, a single error in user defined readout listener does not prevent the following calls to succeed. 