### PR TITLE
DM-13489 Modify image dropdown to support HiPS and modify HiPS loading with a URL via API

### DIFF
--- a/src/firefly/html/firefly-dev.html
+++ b/src/firefly/html/firefly-dev.html
@@ -26,7 +26,7 @@
                     MenuItemKeys: {maskOverlay:true},
                     workspace : {showOptions: true},
                     imageMasterSourcesOrder: ['WISE', '2MASS', 'Spitzer'],
-                    hips : {useForCoverage: true},
+                    hips : {useForCoverage: true, useForImageSearch: true}
                 }
             },
         };

--- a/src/firefly/html/firefly.html
+++ b/src/firefly/html/firefly.html
@@ -24,7 +24,7 @@
                     MenuItemKeys: {maskOverlay:true},
                     catalogSpacialOp: 'polygonWhenPlotExist',
                     charts: {multitrace: true},
-                    hips : {useForCoverage: true},
+                    hips : {useForCoverage: true, useForImageSearch: true},
                     workspace : {showOptions: false},
                     imageMasterSourcesOrder: ['WISE', '2MASS', 'Spitzer']
                 }

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -72,7 +72,8 @@ const defConfigOptions = {
     catalogSpacialOp: undefined,
     imageMasterSources: ['ALL'],
     imageMasterSourcesOrder: '',
-    workspace : { showOptions: false}
+    workspace : { showOptions: false},
+    hips: {useForImageSearch: false}
 };
 
 

--- a/src/firefly/js/ui/CheckboxGroupInputField.jsx
+++ b/src/firefly/js/ui/CheckboxGroupInputField.jsx
@@ -83,9 +83,6 @@ function handleOnChange(ev, params, fireValueChange) {
 
     fireValueChange({ value: curValueArr.toString(), message, valid });
 
-    if (params.onChange) {
-        params.onChange(ev);
-    }
 }
 
 

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -56,8 +56,8 @@ HiPSImageSelect.propTypes = {
 
 function SelectUrl({style}) {
     return (
-        <div className='ImageSearch__section' style={style}>
-            <div className='ImageSearch__section--title'>URL</div>
+        <div className='ImageSearch__section' style={style} title={'enter url of HiPS image'}>
+            <div className='ImageSearch__section--title'>Enter URL</div>
             <ValidationField
                 labelWidth={150}
                 style={{width: 475}}

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -1,0 +1,100 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {get} from 'lodash';
+import {HiPSId} from '../visualize/HiPSCntlr.js';
+import {HiPSSurveyListSelection, makeHiPSSurveysTableName, HiPSPopupMsg} from './HiPSSurveyListDisplay.jsx';
+import {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
+import {ValidationField} from './ValidationField.jsx';
+import {getTblById, getCellValue} from '../tables/TableUtil.js';
+import {DEFAULT_FITS_VIEWER_ID} from '../visualize/MultiViewCntlr.js';
+import WebPlotRequest from '../visualize/WebPlotRequest.js';
+import {parseWorldPt} from '../visualize/Point.js';
+
+import './ImageSelect.css';
+
+
+export class HiPSImageSelect extends PureComponent {
+
+    constructor(props) {
+        super(props);
+        this.state= {lastMod:new Date().getTime(),
+                    imageSource: getFieldVal(props.groupKey, 'imageSource')};
+    }
+
+    render() {
+        const {style} = this.props;
+        const {imageSource} = this.state;
+        const wrapperStyle = imageSource === 'url' ?
+                            Object.assign({}, style, {width: 'calc(100% - 6pt)',
+                                                      height: 35,
+                                                      alignItems: 'center'}) :
+                            Object.assign({}, style, {display: 'flex',
+                                                       flexDirection:'column',
+                                                       alignItems: 'center'});
+
+        return (
+            <div style={style} className='ImageSelect'>
+                {imageSource === 'url' ? <SelectUrl style={wrapperStyle}/> :
+                                        <HiPSSurveyListSelection
+                                            surveysId={HiPSId}
+                                            wrapperStyle={ wrapperStyle }
+                                        />}
+            </div>
+        );
+    }
+}
+
+HiPSImageSelect.propTypes = {
+    groupKey: PropTypes.string.isRequired,
+    style: PropTypes.object
+};
+
+
+function SelectUrl({style}) {
+    return (
+        <div className='ImageSearch__section' style={style}>
+            <div className='ImageSearch__section--title'>URL</div>
+            <ValidationField
+                labelWidth={150}
+                style={{width: 475}}
+                fieldKey='txURL'
+            />
+        </div>
+    );
+}
+
+SelectUrl.propTypes = {
+    style: PropTypes.object
+};
+
+/**
+ * create webPlotRequest for HiPS image request
+ * @param request
+ * @param plotId
+ */
+export function makeHiPSWebPlotRequest(request, plotId) {
+    let url;
+    if (get(request, 'imageSource', 'archive') === 'url') {
+        url = get(request, 'txURL');
+    } else {
+        const tblId = makeHiPSSurveysTableName();
+        const tableModel = tblId ? getTblById(tblId) : null;
+        if (!tableModel) {
+            HiPSPopupMsg('No HiPS information found', 'HiPS search');
+            return null;
+        }
+        const {highlightedRow=0} = tableModel;
+        url = getCellValue(tableModel, highlightedRow, 'url');
+    }
+    const fov = get(request, 'sizeFov', 180);
+    const wp = parseWorldPt(request.UserTargetWorldPt) || null;
+    const wpRequest = WebPlotRequest.makeHiPSRequest(url, wp, fov);
+    wpRequest.setPlotGroupId(DEFAULT_FITS_VIEWER_ID);
+    wpRequest.setPlotId(plotId);
+    return wpRequest;
+}
+

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -208,6 +208,12 @@ export class HiPSSurveyListSelection extends PureComponent {
     constructor(props) {
         super(props);
 
+        const hipsSurveys = getHiPSSurveys(this.props.surveysId);
+        // no surveys in the store yet
+        if (!hipsSurveys) {
+            const {dataType=HiPSData} = props;
+            onHiPSSurveys(dataType, props.surveysId);
+        }
         this.state = {[fKeyHiPSPopular]: getHiPSPopularSetting(props.hipsUrl),
                       isUpdatingHips: isLoadingHiPSSurverys(props.surveysId)};
         //this.groupKey = props.groupKey || gKeyHiPSPanel;
@@ -229,12 +235,13 @@ export class HiPSSurveyListSelection extends PureComponent {
             const isUpdatingHips = isLoadingHiPSSurverys(surveysId);
             const pSetting = getFieldVal(gKeyHiPSPanel, fKeyHiPSPopular);
 
-            if (isUpdatingHips !== get(this.state, 'isUpdatingHips')) {
-                this.setState({isUpdatingHips});
-            }
             if (pSetting !== get(this.state, [fKeyHiPSPopular])) {
                 this.setState({[fKeyHiPSPopular]: pSetting});
             }
+            if (isUpdatingHips !== get(this.state, 'isUpdatingHips')) {
+                this.setState({isUpdatingHips});
+            }
+
         }
     }
 
@@ -263,7 +270,8 @@ export class HiPSSurveyListSelection extends PureComponent {
 HiPSSurveyListSelection.propTypes = {
     surveysId: PropTypes.string.isRequired,
     wrapperStyle: PropTypes.object,
-    hipsUrl: PropTypes.string
+    hipsUrl: PropTypes.string,
+    dataType: PropTypes.array
 };
 
 function fieldReducer(hipsUrl) {

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -2,7 +2,6 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {flux} from '../Firefly.js';
 import {isEmpty, get} from 'lodash';
-import {getHiPSSurveys,  getHiPSLoadingMessage, updateHiPSId, HiPSSurveyTableColumm} from '../visualize/HiPSCntlr.js';
 import {getTblById, getCellValue} from '../tables/TableUtil.js';
 import LOADING from 'html/images/gxt/loading.gif';
 import {TablePanel} from '../tables/ui/TablePanel.jsx';
@@ -14,34 +13,48 @@ import {HelpIcon} from './HelpIcon.jsx';
 import {CompleteButton} from './CompleteButton.jsx';
 import {INFO_POPUP} from './PopupUtil.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
-import {HiPSData}  from './TestQueriesPanel.jsx';
-import {onHiPSSurveys, isLoadingHiPSSurverys, HiPSPopular, _HiPSPopular} from '../visualize/HiPSCntlr.js';
+import {onHiPSSurveys, isLoadingHiPSSurverys,
+        HiPSPopular, HiPSId, HiPSData, HiPSSurveyTableColumm,
+        getHiPSSurveys,  getHiPSLoadingMessage, updateHiPSId,
+        indexInHiPSSurveys, isOnePopularSurvey} from '../visualize/HiPSCntlr.js';
 import {FieldGroup} from './FieldGroup.jsx';
 import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
-import {getFieldVal, getFieldGroupState} from '../fieldGroup/FieldGroupUtils.js';
+import {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
+import {primePlot} from '../visualize/PlotViewUtil.js';
+import {visRoot} from '../visualize/ImagePlotCntlr.js';
 
 //define the table style only in the table div
 const tableStyle = {boxSizing: 'border-box', padding:5, width: '100%', height: 'calc(100% - 20px)', overflow: 'hidden', display: 'flex', flexDirection: 'column'};
 const hipsSurveysPopupId = 'hipsSurveys';
-export const HiPSSurvey = 'HiPS_Surveys_';
+const HiPSSurvey = 'HiPS_Surveys_';
 
+
+export function makeHiPSSurveysTableName(hipsId) {
+    if (!hipsId) {
+        const popularHiPS = getFieldVal(gKeyHiPSPanel, fKeyHiPSPopular);
+        hipsId = updateHiPSId(HiPSId, (popularHiPS === HiPSPopular));
+    }
+
+    return HiPSSurvey + hipsId;
+}
 /**
  * table to contain HiPS survey info including url, data_product and title
  * @param id
  * @param surveys
  * @param isPopular
+ * @param hipsUrl
  * @param moreStyle
  * @returns {XML}
  */
-function renderHiPSSurveysTable(id, surveys, isPopular, moreStyle={}) {
+function renderHiPSSurveysTable(id, surveys, isPopular, hipsUrl, moreStyle={}) {
+    const hipsId = updateHiPSId(id, isPopular);
     if (!surveys) {
-        surveys = getHiPSSurveys(updateHiPSId(id, isPopular));
+        surveys = getHiPSSurveys(hipsId);
     }
     const surveyTableStyle = isEmpty(moreStyle) ? tableStyle : Object.assign(tableStyle, moreStyle);
-    const tableId = HiPSSurvey + updateHiPSId(id, isPopular);
+    const tableId = makeHiPSSurveysTableName(hipsId);
 
     let tableModel = getTblById(tableId);
-
 
     if (!tableModel && !isEmpty(surveys)) {
         const columns = [ {name: HiPSSurveyTableColumm.type.key, width: 8, type: 'char'},
@@ -59,11 +72,13 @@ function renderHiPSSurveysTable(id, surveys, isPopular, moreStyle={}) {
             return prev;
         }, []);
 
+        const highlightedRow = indexInHiPSSurveys(hipsId, hipsUrl);
+
         tableModel = {
             totalRows: data.length,
             tbl_id: tableId,
             tableData: {columns, data},
-            highlightedRow: 0
+            highlightedRow
         };
     }
 
@@ -89,9 +104,10 @@ function renderHiPSSurveysTable(id, surveys, isPopular, moreStyle={}) {
  * @param id
  * @param isUpdatingHips
  * @param popularHiPS
+ * @param hipsUrl
  * @returns {*}
  */
-function showHiPSSurveyList(id, isUpdatingHips, popularHiPS = '') {
+function showHiPSSurveyList(id, isUpdatingHips, popularHiPS, hipsUrl) {
     const isPopular =  (popularHiPS === HiPSPopular);
     const hipsSurveys = getHiPSSurveys(updateHiPSId(id, isPopular));
 
@@ -104,7 +120,7 @@ function showHiPSSurveyList(id, isUpdatingHips, popularHiPS = '') {
     };
 
     const showHiPSSurvey = () => {
-        return renderHiPSSurveysTable(id, hipsSurveys, isPopular);
+        return renderHiPSSurveysTable(id, hipsSurveys, isPopular, hipsUrl);
     };
 
     return (
@@ -115,12 +131,13 @@ function showHiPSSurveyList(id, isUpdatingHips, popularHiPS = '') {
 
 /**
  * show HiPS survey info table in popup panel
+ * @param hipsUrl
  * @param pv
+ * @param surveysId
  * @param dataType
  * @returns {*}
  */
-export function showHiPSSurverysPopup(pv, dataType=HiPSData) {
-    const surveysId =  get(pv, ['request', 'params', 'hipsSurveysId']);
+export function showHiPSSurverysPopup(hipsUrl,  pv, surveysId = HiPSId, dataType=HiPSData) {
     const popupPanelResizableStyle = {
         width: 550,
         height: 400,
@@ -130,12 +147,8 @@ export function showHiPSSurverysPopup(pv, dataType=HiPSData) {
         overflow: 'hidden'
     };
 
-    if (!surveysId ) {
-        HiPSPopupMsg('No HiPS Surveys Id found', 'HiPS Surverys search');
-        return;
-    }
-
     const hipsSurveys = getHiPSSurveys(surveysId);
+    // no surveys in the store yet
     if (!hipsSurveys) {
         onHiPSSurveys(dataType, surveysId);
     }
@@ -146,18 +159,18 @@ export function showHiPSSurverysPopup(pv, dataType=HiPSData) {
                 <div style={popupPanelResizableStyle}>
                     <HiPSSurveyListSelection
                         surveysId={surveysId}
-                        pv={pv}
                         wrapperStyle={{height: 'calc(100% - 60px)'}}
+                        hipsUrl={hipsUrl}
                     />
 
                     <div style={{display: 'flex', justifyContent: 'space-between', marginTop: 15, marginBottom: 15}}>
                         <div style={{display: 'flex', alignItems: 'flexStart', marginLeft: 10}}>
                             <div style={{marginRight: 10}}>
                                 <CompleteButton
-                                    onSuccess={onSelectPlot(surveysId, pv.plotId)}
+                                    onSuccess={onSelectPlot(surveysId, pv ? primePlot(pv) : primePlot(visRoot()))}
                                     text={'Search'}
                                     dialogId={hipsSurveysPopupId}
-                                    groupKey={gKeyHiPSPopup}
+                                    groupKey={gKeyHiPSPanel}
                                 />
                             </div>
                             <div>
@@ -181,15 +194,12 @@ export function showHiPSSurverysPopup(pv, dataType=HiPSData) {
     startHiPSPopup();
 }
 
-export const gKeyHiPSPopup = 'HIPSList_PANEL';
+export const gKeyHiPSPanel = 'HIPSList_PANEL';
 export const fKeyHiPSPopular = 'popularHiPS';
 
-const getHiPSPopularSetting = (pv) => {
-    const surveysId = get(pv, ['request', 'params', 'hipsSurveysId']);
-
-    return (surveysId&&surveysId.endsWith(_HiPSPopular)) ? HiPSPopular
-                                                         : getFieldVal( gKeyHiPSPopup, fKeyHiPSPopular, HiPSPopular);
-};
+function getHiPSPopularSetting(hipsUrl) {
+    return (!hipsUrl || isOnePopularSurvey(hipsUrl)) ? HiPSPopular : '';
+}
 
 /**
  * show HiPS survey info table plus check box for showing popular surveys in popup panel or form panel
@@ -198,9 +208,9 @@ export class HiPSSurveyListSelection extends PureComponent {
     constructor(props) {
         super(props);
 
-        const popularStr = getHiPSPopularSetting(props.pv);
-        const isUpdatingHips = isLoadingHiPSSurverys(props.surveysId);
-        this.state = {fields: {popularHiPS: {value: popularStr}}, isUpdatingHips};
+        this.state = {[fKeyHiPSPopular]: getHiPSPopularSetting(props.hipsUrl),
+                      isUpdatingHips: isLoadingHiPSSurverys(props.surveysId)};
+        //this.groupKey = props.groupKey || gKeyHiPSPanel;
     }
 
     componentWillUnmount() {
@@ -215,42 +225,35 @@ export class HiPSSurveyListSelection extends PureComponent {
 
     storeUpdate() {
         if (this.iAmMounted) {
-            const {fields} = getFieldGroupState(gKeyHiPSPopup) || {};
-
-            if (fields && (fields !== get(this.state, 'fields'))) {
-                this.setState({fields});
-            }
-
-            const isUpdatingHips = isLoadingHiPSSurverys(this.props.surveysId);
+            const {surveysId} = this.props;
+            const isUpdatingHips = isLoadingHiPSSurverys(surveysId);
+            const pSetting = getFieldVal(gKeyHiPSPanel, fKeyHiPSPopular);
 
             if (isUpdatingHips !== get(this.state, 'isUpdatingHips')) {
                 this.setState({isUpdatingHips});
             }
-
+            if (pSetting !== get(this.state, [fKeyHiPSPopular])) {
+                this.setState({[fKeyHiPSPopular]: pSetting});
+            }
         }
     }
 
     render() {
-        const {surveysId, wrapperStyle} = this.props;
-        const {fields, isUpdatingHips} = this.state;
-        const popularHiPS = get(fields, [fKeyHiPSPopular, 'value']);
-
+        const {surveysId, wrapperStyle, hipsUrl} = this.props;
+        const {isUpdatingHips, [fKeyHiPSPopular]: popularS} = this.state;
 
         return (
             <div style={wrapperStyle}>
-                <FieldGroup groupKey={gKeyHiPSPopup} validatorFunc={null} keepState={true}
+                <FieldGroup groupKey={gKeyHiPSPanel} validatorFunc={null} keepState={true}
+                            reducerFunc={fieldReducer(hipsUrl)}
                             style={{height: '100%', width: '100%'}}>
                     <CheckboxGroupInputField
                         fieldKey={fKeyHiPSPopular}
-                        initialState={{
-                                        value: popularHiPS,   // workaround for _all_ for now
-                                        tooltip: 'display popular HiPS'
-                                      }}
                         options={[{label: 'Popular HiPS', value: HiPSPopular}]}
                         alignment='horizontal'
                         wrapperStyle={{textAlign: 'center'}}
                     />
-                    {showHiPSSurveyList(surveysId, isUpdatingHips, popularHiPS)}
+                    {showHiPSSurveyList(surveysId, isUpdatingHips, popularS, hipsUrl)}
                 </FieldGroup>
             </div>
         );
@@ -258,21 +261,35 @@ export class HiPSSurveyListSelection extends PureComponent {
 }
 
 HiPSSurveyListSelection.propTypes = {
-    pv: PropTypes.object,
     surveysId: PropTypes.string.isRequired,
-    wrapperStyle: PropTypes.object
+    wrapperStyle: PropTypes.object,
+    hipsUrl: PropTypes.string
 };
 
-function onSelectPlot(surveysId, plotId) {
+function fieldReducer(hipsUrl) {
+    return (inFields, action ) => {
+        if (!inFields) {
+            const pSetting = getHiPSPopularSetting(hipsUrl);
+            return {[fKeyHiPSPopular]: {
+                fieldKey: fKeyHiPSPopular,
+                value: pSetting,
+                tooltip: 'display popular HiPS'
+            }};
+        }
+        return inFields;
+    };
+}
+
+function onSelectPlot(surveysId, plot) {
     return (request) => {
-        const tblId = HiPSSurvey + updateHiPSId(surveysId, (get(request, fKeyHiPSPopular) === HiPSPopular));
+        const tblId = makeHiPSSurveysTableName(updateHiPSId(surveysId, (get(request, fKeyHiPSPopular) === HiPSPopular)));
         const tableModel = getTblById(tblId);
         if (!tableModel) {
             return;
         }
 
         const rootUrl = getCellValue(tableModel, get(tableModel, 'highlightedRow', 0), 'url');
-        dispatchChangeHiPS({plotId, hipsUrlRoot: rootUrl});
+        dispatchChangeHiPS({plotId: plot.plotId, hipsUrlRoot: rootUrl});
     };
 }
 

--- a/src/firefly/js/ui/RadioGroupInputField.jsx
+++ b/src/firefly/js/ui/RadioGroupInputField.jsx
@@ -31,9 +31,6 @@ function handleOnChange(ev, params, fireValueChange) {
 
     if (checked) {
         fireValueChange({ value: val, valid: true});
-        if (params.onChange) {
-            params.onChange(val);
-        }
     }
 }
 

--- a/src/firefly/js/ui/RadioGroupInputField.jsx
+++ b/src/firefly/js/ui/RadioGroupInputField.jsx
@@ -31,6 +31,9 @@ function handleOnChange(ev, params, fireValueChange) {
 
     if (checked) {
         fireValueChange({ value: val, valid: true});
+        if (params.onChange) {
+            params.onChange(val);
+        }
     }
 }
 

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -29,7 +29,7 @@ import {showInfoPopup} from './PopupUtil.jsx';
 import Validate from '../util/Validate.js';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
 
-import FieldGroupUtils, {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
+import FieldGroupUtils  from '../fieldGroup/FieldGroupUtils.js';
 import {dispatchTableSearch} from '../tables/TablesCntlr.js';
 import {FieldGroupTabs, Tab} from './panel/TabPanel.jsx';
 import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
@@ -41,13 +41,12 @@ import {makeTblRequest, makeIrsaCatalogRequest} from '../tables/TableRequestUtil
 import {dispatchAddViewerItems,getAViewFromMultiView,getMultiViewRoot, DEFAULT_FITS_VIEWER_ID, IMAGE} from '../visualize/MultiViewCntlr.js';
 import WebPlotRequest from '../visualize/WebPlotRequest.js';
 import {dispatchPlotImage, dispatchPlotHiPS} from '../visualize/ImagePlotCntlr.js';
+import {hipsSURVEYS} from '../visualize/HiPSUtil.js';
 import {getDS9Region} from '../rpc/PlotServicesJson.js';
 import {RegionFactory} from '../visualize/region/RegionFactory.js';
-import {onHiPSSurveys, HiPSDataType, HiPSPopular, updateHiPSId} from '../visualize/HiPSCntlr.js';
-import {HiPSSurvey,  HiPSPopupMsg, HiPSSurveyListSelection, gKeyHiPSPopup, fKeyHiPSPopular} from './HiPSSurveyListDisplay.jsx';
+import {onHiPSSurveys, HiPSId, HiPSData} from '../visualize/HiPSCntlr.js';
+import {makeHiPSSurveysTableName, HiPSPopupMsg, HiPSSurveyListSelection} from './HiPSSurveyListDisplay.jsx';
 import {getTblById, getCellValue} from '../tables/TableUtil.js';
-import {visRoot } from '../visualize/ImagePlotCntlr.js';
-import {getActivePlotView} from '../visualize/PlotViewUtil.js';
 
 const options = [
     {label: 'AllWISE Source Catalog', value: 'allwise_p3as_psd', proj: 'WISE'},
@@ -55,74 +54,6 @@ const options = [
     {label: 'IRAS Point Source Catalog v2.1 (PSC)', value: 'iraspsc', proj: 'IRAS'}
 ];
 
-
-
-const hipsSURVEYS = [
-    {
-        url: 'http://alasky.u-strasbg.fr/2MASS/Color',
-        label: '2MASS colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/DSS/DSSColor',
-        label: 'DSS colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/DSS/DSS2Merged',
-        label: 'DSS2 Red (F+R)'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/Fermi/Color',
-        label: 'Fermi color'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/FinkbeinerHalpha',
-        label: 'Halpha'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/GALEX/GR6-02-Color',
-        label: 'GALEX Allsky Imaging Survey colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/IRISColor',
-        label: 'IRIS colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/MellingerRGB',
-        label: 'Mellinger colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/SDSS/DR9/color',
-        label: 'SDSS9 colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/SpitzerI1I2I4color',
-        label: 'IRAC color I1,I2,I4 - (GLIMPSE, SAGE, SAGE-SMC, SINGS)'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/VTSS/Ha',
-        label: 'VTSS-Ha'
-    },
-    {
-        url: 'http://saada.u-strasbg.fr/xmmallsky',
-        label: 'XMM-Newton stacked EPIC images (no phot. normalization)'
-    },
-    {
-        url: 'http://saada.u-strasbg.fr/xmmallsky/',
-        label: 'XMM PN colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1/',
-        label: 'AllWISE color'
-    },
-    {
-        url: 'http://www.spitzer.caltech.edu/glimpse360/aladin/data',
-        label: 'GLIMPSE360'
-    }
-];
-
-
-export const HiPSData = [HiPSDataType.image, HiPSDataType.cube];
-const HiPSId = 'hips';
 
 export class TestQueriesPanel extends PureComponent {
 
@@ -146,7 +77,7 @@ export class TestQueriesPanel extends PureComponent {
         //const fields = this.state;
         const {fields}=this.state || {};
 
-        const onTabSelect = (idx, id, name) => {
+        const onTabSelect = (idx, id) => {
             if (id === HiPSId) {
                 onHiPSSurveys(HiPSData, id);
             }
@@ -178,7 +109,6 @@ export class TestQueriesPanel extends PureComponent {
                             <Tab name='HiPS' id={HiPSId}>
                                 <HiPSSurveyListSelection
                                     surveysId={HiPSId}
-                                    pv={getActivePlotView(visRoot())}
                                     wrapperStyle={{width: 550, height: 400, display: 'flex',
                                                    flexDirection:'column',
                                                    alignItems: 'center'}}
@@ -212,15 +142,12 @@ export class TestQueriesPanel extends PureComponent {
 
 
 
-
-
-
 TestQueriesPanel.propTypes = {
-    name: PropTypes.oneOf(['TestSearches']),
+    name: PropTypes.oneOf(['TestSearches'])
 };
 
 TestQueriesPanel.defaultProps = {
-    name: 'TestSearches',
+    name: 'TestSearches'
 };
 
 
@@ -288,7 +215,7 @@ function renderPeriodogram(fields) {
                 'original_table':'http://web.ipac.caltech.edu/staff/ejoliet/demo/OneTarget-27-AllWISE-MEP-m82-2targets-10arsecs.tbl',
                 'x':'mjd',
                 'y':'w1mpro_ep',
-                'table_name': 'periodogram',
+                'table_name': 'periodogram'
                 // The following are optional
                 //'pmin':0,
                 //'pmax':200,
@@ -648,10 +575,7 @@ function doHiPSLoad(request) {
 
     dispatchHideDropDown();
 
-
-    const popularHiPS = getFieldVal(gKeyHiPSPopup, fKeyHiPSPopular);
-    const hipsId = updateHiPSId(HiPSId, (popularHiPS === HiPSPopular));
-    const tblId = HiPSSurvey + hipsId;
+    const tblId = makeHiPSSurveysTableName();
     const tableModel = getTblById(tblId);
     if (!tableModel) {
         return HiPSPopupMsg('No HiPS information found', 'HiPS search');
@@ -663,7 +587,6 @@ function doHiPSLoad(request) {
     const wpRequest= WebPlotRequest.makeHiPSRequest(rootUrl, null);
     wpRequest.setPlotGroupId(DEFAULT_FITS_VIEWER_ID);
     wpRequest.setPlotId('aHiPSid');
-    wpRequest.setHipsSurveysId(hipsId);
 
     const wp = parseWorldPt(request.UserTargetWorldPt);
     if (wp) wpRequest.setWorldPt(wp);

--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -80,9 +80,9 @@ export function makeHiPSTileUrl(plot, nOrder, tileNumber) {
 }
 
 /**
- *
  * @param urlRoot
  * @param exts
+ * @param cubeIdx
  * @param proxy
  * @return {*}
  */

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -1323,8 +1323,6 @@ export class WebPlotRequest extends ServerRequest {
     setHipsRootUrl(url) { this.setParam(C.HIPS_ROOT_URL, url);}
     getHipsRootUrl() { return this.getParam(C.HIPS_ROOT_URL);}
 
-    setHipsSurveysId(id) { this.setParam(C.HIPS_SURVEYS_ID, id);}
-    getHipsSurveysId() { return this.getParam(C.HIPS_SURVEYS_ID);}
     /**
      *
      * @param overlayIdList

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -18,7 +18,8 @@ import {findAllSkyCachedImage, addAllSkyCachedImage} from '../iv/HiPSTileCache.j
 import {makeHiPSAllSkyUrl, makeHiPSAllSkyUrlFromPlot, makeHipsUrl, getHiPSFoV} from '../HiPSUtil.js';
 import {ZoomType} from '../ZoomType.js';
 import {CCUtil} from '../CsysConverter.js';
-import {ensureWPR, determineViewerId, getHipsImageConversion} from './PlotImageTask.js';
+import {ensureWPR, determineViewerId, getHipsImageConversion,
+        initBuildInDrawLayers, addDrawLayers} from './PlotImageTask.js';
 import {dlRoot, dispatchAttachLayerToPlot,
     dispatchCreateDrawLayer, dispatchDetachLayerFromPlot} from '../DrawLayerCntlr.js';
 import ImageOutline from '../../drawingLayers/ImageOutline.js';
@@ -30,6 +31,7 @@ import Artifact from '../../drawingLayers/Artifact.js';
 //======================================== Exported Functions =============================
 //======================================== Exported Functions =============================
 
+let firstTime = true;
 
 
 function hipsFail(dispatcher, plotId, wpRequest, reason) {
@@ -76,6 +78,9 @@ function watchForHiPSViewDim(action, cancelSelf, params) {
 
         const wp= pv.request && pv.request.getWorldPt();
         if (wp) dispatchChangeCenterOfProjection({plotId,centerProjPt:wp});
+
+        addDrawLayers(pv.request, plot);
+
         cancelSelf();
     }
 }
@@ -123,6 +128,12 @@ export function makePlotHiPSAction(rawAction) {
             hipsFail(dispatcher, plotId, wpRequest, 'No Root URL');
             return;
         }
+
+        if (firstTime) {
+            initBuildInDrawLayers();
+            firstTime= false;
+        }
+
         dispatcher( { type: ImagePlotCntlr.PLOT_IMAGE_START,payload:newPayload} );
         dispatchPlotProgressUpdate(plotId, 'Retrieving Info', false, null);
 

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -314,7 +314,7 @@ export function processPlotImageSuccessResponse(dispatcher, payload, result) {
 }
 
 
-function addDrawLayers(request, plot ) {
+export function addDrawLayers(request, plot ) {
     const {plotId}= plot;
     request.getOverlayIds().forEach((drawLayerTypeId)=> {
         const dls = getDrawLayersByType(dlRoot(), drawLayerTypeId);
@@ -431,7 +431,7 @@ function updateActiveTarget(plot) {
     if (activeTarget || corners) dispatchActiveTarget(activeTarget,corners);
 }
 
-function initBuildInDrawLayers() {
+export function initBuildInDrawLayers() {
     dispatchCreateDrawLayer(ActiveTarget.TYPE_ID);
 }
 

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -34,7 +34,7 @@ import { parseImagePt } from '../Point.js';
 import {getDefaultHiPSSurveys} from '../HiPSUtil.js';
 import {ListBoxInputFieldView} from '../../ui/ListBoxInputField';
 import {showHiPSSurverysPopup} from '../../ui/HiPSSurveyListDisplay.jsx';
-import {isLoadingHiPSSurverys} from '../HiPSCntlr.js';
+import {isLoadingHiPSSurverys, HiPS} from '../HiPSCntlr.js';
 import {getSelectedShape} from '../../drawingLayers/Catalog.js';
 import ImageOutline from '../../drawingLayers/ImageOutline.js';
 import ShapeDataObj from '../draw/ShapeDataObj.js';
@@ -389,7 +389,7 @@ function makeHiPSImageSelect(pv) {
         );
 }
 
-function makeHiPSImageTable(pv, isUpdatingHips) {
+function makeHiPSImageTable(pv, surveysId, isUpdatingHips) {
     const plot= primePlot(pv);
     if (!plot) return null;
 
@@ -398,7 +398,8 @@ function makeHiPSImageTable(pv, isUpdatingHips) {
             <div style={{marginLeft: 10, marginRight: 5}}>
                 <input  type='button'
                         value='Find HiPS Plot'
-                        onClick={()=>showHiPSSurverysPopup(pv)} />
+                        onClick={()=>showHiPSSurverysPopup(get(pv, ['request', 'params', 'hipsRootUrl']),
+                                                           pv, surveysId)} />
             </div>
         );
     };
@@ -471,11 +472,9 @@ export class VisCtxToolbarView extends PureComponent {
     constructor(props) {
         super(props);
 
-        const {plotView} = props;
-
-        const hipsId = get(plotView ['request', 'params', 'hipsSurveysId']);
-        if (hipsId) {
-            const isUpdatingHips = isLoadingHiPSSurverys(hipsId);
+        this.hipsId = HiPS;
+        if (this.hipsId) {
+            const isUpdatingHips = isLoadingHiPSSurverys(this.hipsId);
 
             this.state = {isUpdatingHips};
         }
@@ -494,14 +493,10 @@ export class VisCtxToolbarView extends PureComponent {
     storeUpdate() {
 
         if (this.iAmMounted) {
-            const hipsId = get(this.props, ['plotView', 'request', 'params', 'hipsSurveysId']);
+            const isUpdatingHips = isLoadingHiPSSurverys(this.hipsId);
 
-            if (hipsId) {
-                const isUpdatingHips = isLoadingHiPSSurverys(hipsId);
-
-                if (isUpdatingHips !== get(this.state, 'isUpdatingHips', false)) {
-                    this.setState({isUpdatingHips});
-                }
+            if (isUpdatingHips !== get(this.state, 'isUpdatingHips', false)) {
+                this.setState({isUpdatingHips});
             }
         }
     }
@@ -575,7 +570,7 @@ export class VisCtxToolbarView extends PureComponent {
 
                 {makeExtensionButtons(extensionAry,pv,dlAry)}
 
-                {isHiPS(plot) && makeHiPSImageTable(pv, isUpdatingHips)}
+                {isHiPS(plot) && makeHiPSImageTable(pv, this.hipsId, isUpdatingHips)}
                 {isHiPS(plot) && makeHiPSCoordSelect(pv)}
 
             </div>


### PR DESCRIPTION
This development is for 
https://jira.lsstcorp.org/browse/DM-13489
- add app option to turn on or off HiPS image from the image search panel. 
- add HiPS selection to the search panel:
   section 1: add HiPS button
   section 2: image sources includes 'search' and 'url'
   section 3: entries for target and field of view
   section 4: entries for url in case image source is from url, or a table showing list of HiPS surveys for HiPS search in the image source is from 'search'
- Support HiPS loading with a URL via API as described in 
   https://jira.lsstcorp.org/browse/DM-13286

test:
do HiPS image search by choosing the following items on Image Search panel, 
- section 1, image type, HiPS, 
- section 2, image source, 'Search' or 'URL',
- section 3, target (optional) and field of view (default is 180 degree)
- section 4, select one survey from the table of all public surveys or popular surveys or by entering URL in case URL is selected in section 2. 
click 'Search' 
