### PR TITLE
IRSA-1581: 2mass image request fix when survey was implicitly value asky

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
@@ -136,6 +136,11 @@ public class TwoMassIbeDataSource extends BaseIbeDataSource {
             }
         }
         String subSize = pathInfo.get("subsize");
+        if(!StringUtils.isEmpty(subSize)){
+            if(subSize.equals("null")){
+                subSize = null;
+            }
+        }
 
         if (!StringUtils.isEmpty(subLon) && !StringUtils.isEmpty(subLat) && !StringUtils.isEmpty(subSize)) {
             dataParam.setCutout(true, subLon + "," + subLat, subSize);

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FinderChartRequestUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FinderChartRequestUtil.java
@@ -165,7 +165,7 @@ public class FinderChartRequestUtil {
                 wpReq= WebPlotRequest.makeSloanDSSRequest(pt, getComboValue(key), radius);
                 break;
             case TWOMASS:
-                wpReq= WebPlotRequest.make2MASSRequest(pt, getComboValue(key),radius);
+                wpReq= WebPlotRequest.make2MASSRequest(pt, "asky", getComboValue(key),radius);
                 break;
             case AKARI:
             case SEIP:

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceDesc.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceDesc.java
@@ -77,9 +77,9 @@ public class ServiceDesc {
     }
 
     private static String get2MassDesc(WebPlotRequest request) {
-        String survey= request.getSurveyKey().toLowerCase();
+        String band= request.getSurveyBand().toLowerCase();
         String root = "2MASS ";
-        switch (survey) {
+        switch (band) {
             case "j": return root + "J";
             case "h": return root + "H";
             case "k": return root + "K";

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
@@ -335,8 +335,10 @@ public class WebPlotRequest extends ServerRequest {
 
     public static WebPlotRequest make2MASSRequest(WorldPt wp,
                                                   String survey,
+                                                  String band,
                                                   float sizeInDeg) {
         WebPlotRequest req= makePlotServiceReq(ServiceType.TWOMASS, wp, survey, sizeInDeg);
+        req.setParam(SURVEY_KEY_BAND, band + "");
         req.setTitle("2MASS: "+survey.toUpperCase());
         return req;
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/IbeImageGetter.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/IbeImageGetter.java
@@ -13,10 +13,7 @@ import edu.caltech.ipac.astro.ibe.IbeQueryParam;
 import edu.caltech.ipac.astro.ibe.datasource.TwoMassIbeDataSource;
 import edu.caltech.ipac.astro.ibe.datasource.WiseIbeDataSource;
 import edu.caltech.ipac.firefly.data.FileInfo;
-import edu.caltech.ipac.util.Assert;
-import edu.caltech.ipac.util.DataGroup;
-import edu.caltech.ipac.util.DataObject;
-import edu.caltech.ipac.util.IpacTableUtil;
+import edu.caltech.ipac.util.*;
 import edu.caltech.ipac.util.download.CacheHelper;
 import edu.caltech.ipac.util.download.FailedRequestException;
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/TwoMassImageParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/TwoMassImageParams.java
@@ -19,7 +19,7 @@ public class TwoMassImageParams extends ImageServiceParams {
     public float  getSize()             { return _size; }
 
     public String getUniqueString() {
-        return "2mass-" + super.toString()+ "-" + ds + "-" + _band + "-" +_size;
+        return "2mass-" + super.toString()+ "-" + this.ds + "-" + _band + "-" +_size;
     }
 
     public String toString() { return getUniqueString(); }

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -350,13 +350,15 @@ export class WebPlotRequest extends ServerRequest {
     /**
      *
      * @param wp
-     * @param {string} survey  must be one of 'j','h','k'
+     * @param {string} survey  must be one of 'asky', 'askyw', 'sx', 'sxw', 'cal'
+     * @param {string} band  must be one of 'j','h','k'
      * @param sizeInDeg less then .138 degrees (500 arcsec)
      * @return {WebPlotRequest}
      */
-    static make2MASSRequest(wp, survey, sizeInDeg) {
+    static make2MASSRequest(wp, survey, band, sizeInDeg) {
         const req= this.makePlotServiceReq(ServiceType.TWOMASS, wp, survey, sizeInDeg);
         req.setTitle('2MASS '+survey.toUpperCase());
+        req.setParam(C.SURVEY_KEY_BAND, band + '');
         req.setDrawingSubGroupId('2mass');
         return req;
     }

--- a/src/firefly/js/visualize/saga/CoverageChooser.js
+++ b/src/firefly/js/visualize/saga/CoverageChooser.js
@@ -31,7 +31,7 @@ export function getCoverageRequest(wp, size, baseTitle, blank= false, gridOn= Gr
         request.setTitle(baseTitle);
     }
     else if (radiusAS < 500) {
-        request = WebPlotRequest.make2MASSRequest(wp, 'k', size);
+        request = WebPlotRequest.make2MASSRequest(wp, 'asky', 'k', size);
         title = baseTitle + ' 2MASS k';
         request.setTitle(title);
     } else if (radiusAS < 1800) {

--- a/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
+++ b/src/firefly/js/visualize/ui/ImageSelectPanelResult.js
@@ -122,7 +122,7 @@ function imagePlotOnSurvey(crtCatalogId, request) {
             break;
 
         case TWOMASS:
-            wpr = WebPlotRequest.make2MASSRequest(wp, survey, sizeInDeg);
+            wpr = WebPlotRequest.make2MASSRequest(wp, survey, band, sizeInDeg);
             break;
         case ATLAS:
             //TODO: Not sure how to combine several dataset with different missions under same ATLAS service type


### PR DESCRIPTION
I've updated the function that make the 2mass request image from the client side. This was a change needed after IRSA-1447.
Please, check that 2mass image are back in Finder Chart (same branch name in IFE) and when coverage 2mass image is chosen.

I saw already a problem that i couldn't figure it out in Safari. Chrome is fine.