### PR TITLE
DM-13797 remove HiPS grid on and support to IRSA HiPS list

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -48,7 +48,7 @@ irsa.gator.service.periodogram.url = "https://irsa.ipac.caltech.edu/cgi-bin/peri
 // IRSA hips map access: from "file" or from "url" && hips url
 irsa.hips.list.source="url"
 irsa.hips.masterUrl="https://irsadev.ipac.caltech.edu/data/hips/list"
-irsa.hips.url.base="irsa.ipac.caltech.edu"
+
 /*  ----------------------------------------------------------------------- */
 
 wise.ibe.host       = "irsa.ipac.caltech.edu/ibe"
@@ -66,19 +66,16 @@ environments {
         ehcache.multicast.port = 4015
         visualize.fits.Security= false
         ehcache.multicast.ttl = 0
-        irsa.hips.url.base="irsadev.ipac.caltech.edu"
     }
     dev {
         BuildType = "Development"
         ehcache.multicast.port = "5015"
         lsst.dataAccess.uri = "http://localhost:8661/db/v0/query?"
         lsst.dataAccess.db = "smm_bremerton"
-        irsa.hips.url.base="irsadev.ipac.caltech.edu"
     }
     test {
         BuildType = "Beta"
         ehcache.multicast.port = "6015"
-        irsa.hips.url.base="irsadev.ipac.caltech.edu"
     }
     ops_int {
         ehcache.multicast.port = "7515"

--- a/config/app.config
+++ b/config/app.config
@@ -45,6 +45,10 @@ irsa.gator.hostname     = "https://irsa.ipac.caltech.edu"
 most.host = "https://irsasearchops.ipac.caltech.edu/cgi-bin/MOST/nph-most"
 // IRSA Periodogram API
 irsa.gator.service.periodogram.url = "https://irsa.ipac.caltech.edu/cgi-bin/periodogram/nph-periodogram_api"
+// IRSA hips map access: from "file" or from "url" && hips url
+irsa.hips.list.source="url"
+irsa.hips.masterUrl="https://irsadev.ipac.caltech.edu/data/hips/list"
+irsa.hips.url.base="irsa.ipac.caltech.edu"
 /*  ----------------------------------------------------------------------- */
 
 wise.ibe.host       = "irsa.ipac.caltech.edu/ibe"
@@ -62,16 +66,19 @@ environments {
         ehcache.multicast.port = 4015
         visualize.fits.Security= false
         ehcache.multicast.ttl = 0
+        irsa.hips.url.base="irsadev.ipac.caltech.edu"
     }
     dev {
         BuildType = "Development"
         ehcache.multicast.port = "5015"
         lsst.dataAccess.uri = "http://localhost:8661/db/v0/query?"
         lsst.dataAccess.db = "smm_bremerton"
+        irsa.hips.url.base="irsadev.ipac.caltech.edu"
     }
     test {
         BuildType = "Beta"
         ehcache.multicast.port = "6015"
+        irsa.hips.url.base="irsadev.ipac.caltech.edu"
     }
     ops_int {
         ehcache.multicast.port = "7515"

--- a/src/firefly/config/app.prop
+++ b/src/firefly/config/app.prop
@@ -31,3 +31,8 @@ irsa.gator.service.periodogram.url=@irsa.gator.service.periodogram.url@
 
 // Periodogram API request parameter list definition, separated by space
 irsa.gator.service.periodogram.keys=x y alg step_method pmin pmax step_size peaks
+
+# IRSA HiPS map service
+irsa.hips.list.source=@irsa.hips.list.source@
+irsa.hips.masterUrl=@irsa.hips.masterUrl@
+irsa.hips.url.base=@irsa.hips.url.base@

--- a/src/firefly/config/app.prop
+++ b/src/firefly/config/app.prop
@@ -35,4 +35,3 @@ irsa.gator.service.periodogram.keys=x y alg step_method pmin pmax step_size peak
 # IRSA HiPS map service
 irsa.hips.list.source=@irsa.hips.list.source@
 irsa.hips.masterUrl=@irsa.hips.masterUrl@
-irsa.hips.url.base=@irsa.hips.url.base@

--- a/src/firefly/java/edu/caltech/ipac/firefly/resources/irsa-hips-master-table.csv
+++ b/src/firefly/java/edu/caltech/ipac/firefly/resources/irsa-hips-master-table.csv
@@ -1,15 +1,21 @@
-url,label
-http://alasky.u-strasbg.fr/2MASS/Color,2MASS colored
-http://alasky.u-strasbg.fr/DSS/DSSColor,DSS colored
-http://alasky.u-strasbg.fr/DSS/DSS2Merged,DSS2 Red (F+R)
-http://alasky.u-strasbg.fr/Fermi/Color,Fermi color
-http://alasky.u-strasbg.fr/FinkbeinerHalpha,Halpha
-http://alasky.u-strasbg.fr/GALEX/GR6-02-Color,GALEX Allsky Imaging Survey colored
-http://alasky.u-strasbg.fr/IRISColor,IRIS colored
-http://alasky.u-strasbg.fr/MellingerRGB,Mellinger colored
-http://alasky.u-strasbg.fr/SDSS/DR9/color,SDSS9 colored
-http://alasky.u-strasbg.fr/SpitzerI1I2I4color,IRAC color I1,I2,I4 - (GLIMPSE, SAGE, SAGE-SMC, SINGS
-http://alasky.u-strasbg.fr/VTSS/Ha,VTSS-Ha
-http://saada.u-strasbg.fr/xmmallsky,XMM-Newton stacked EPIC images (no phot. normalization)
-http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1/,AllWISE color
-http://www.spitzer.caltech.edu/glimpse360/aladin/data,GLIMPSE360
+creator_did,hips_release_date,hips_service_url,hips_status
+ivo://ESAVO/P/HERSCHEL/PACS-color,2015-10-16T01:02Z,https://irsadev.ipac.caltech.edu/data/hips/ESAC/PACS-color,public mirror clonable
+ivo://CDS/P/2MASS/color,2016-04-22T14:40Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/2MASS/Color,public mirror unclonable
+ivo://CDS/P/2MASS/K,2016-04-22T14:23Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/2MASS/K,public mirror unclonable
+ivo://CDS/P/2MASS/H,2016-04-22T13:48Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/2MASS/H,public mirror unclonable
+ivo://CDS/P/2MASS/J,2016-04-22T14:03Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/2MASS/J,public mirror unclonable
+ivo://CDS/P/allWISE/W2,2016-06-03T14:58Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/AllWISE/W2,public mirror unclonable
+ivo://CDS/P/allWISE/color,2016-07-01T06:44Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/AllWISE/RGB-W4-W2-W1,public mirror unclonable
+ivo://CDS/P/allWISE/W1,2016-06-03T14:49Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/AllWISE/W1,public mirror unclonable
+ivo://CDS/P/allWISE/W3,2016-06-03T14:58Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/AllWISE/W3,public mirror unclonable
+ivo://CDS/P/allWISE/W4,2016-06-03T14:58Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/AllWISE/W4,public mirror unclonable
+ivo://CDS/P/SDSS9/color,2014-10-24T15:12Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/SDSS/DR9/color,public mirror unclonable
+ivo://CDS/P/SPITZER/IRAC1,2011-07-07T11:40Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/SPITZER/IRAC1,public mirror unclonable
+ivo://CDS/P/SPITZER/IRAC2,2011-07-06T15:52Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/SPITZER/IRAC2,public mirror unclonable
+ivo://CDS/P/SPITZER/IRAC3,2011-07-06T13:38Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/SPITZER/IRAC3,public mirror unclonable
+ivo://CDS/P/SPITZER/IRAC4,2011-07-06T08:46Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/SPITZER/IRAC4,public mirror unclonable
+ivo://CDS/P/IRIS/color,2010-06-09T06:33Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/IRIS/color,public mirror unclonable
+ivo://CDS/P/DSS2/color,2015-05-11T08:45Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/DSS2/color,public mirror unclonable
+ivo://CDS/P/DSS2/red,2014-10-24T14:57Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/DSS2/red,public mirror unclonable
+ivo://CDS/P/PLANCK/R2/LFI/color,2015-02-06T12:09Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/PLANCK/R2/LFI/color,public mirror unclonable
+ivo://CDS/P/PLANCK/R2/HFI/color,2015-02-06T13:38Z,https://irsadev.ipac.caltech.edu/data/hips/CDS/PLANCK/R2/HFI/color,public mirror unclonable

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
@@ -68,71 +68,8 @@ public class CDSHiPSListSource implements HiPSMasterListSourceType {
     }
 
     private List<HiPSMasterListEntry> createHiPSList(String[] dataTypes,
-                                                     String source) throws IOException, DataAccessException, FailedRequestException  {
+                                                     String source) throws IOException, DataAccessException, FailedRequestException {
         String url = HiPSCDSURL + dataProduct(dataTypes);
-
-        _log.briefDebug("executing CDS query: " + url);
-        File file = HiPSMasterList.createFile(dataTypes, ".txt", source);
-        Map<String, String> requestHeader=new HashMap<>();
-        requestHeader.put("Accept", "application/text");
-        long cTime = System.currentTimeMillis();
-        FileInfo listFile = URLDownload.getDataToFileUsingPost(new URL(url), null, null, requestHeader, file, null,
-                                                               TIMEOUT);
-        _log.briefDebug("get CDS HiPS took " + (System.currentTimeMillis() - cTime) + "ms");
-
-        if (listFile.getResponseCode() >= 400) {
-             String err = LSSTQuery.getErrorMessageFromFile(file);
-             throw new DataAccessException("[HiPS_CDS] " + (err == null ? listFile.getResponseCodeMsg() : err));
-        }
-
-        return getListData(file, paramsMap, source);
-    }
-
-    private List<HiPSMasterListEntry> getListData(File f, Map<String, String> keyMap, String source) throws IOException {
-        if (f == null) return null;
-
-        try{
-            // Open the file that is the first
-            // command line parameter
-            BufferedReader br = new BufferedReader(new FileReader(f));
-            String strLine;
-            HiPSMasterListEntry oneList = null;
-            List<HiPSMasterListEntry> lists = new ArrayList();
-            String sProp = HiPSMasterListEntry.getParamString(keyMap, PARAMS.ID);  // first property for each record
-
-            //Read File Line By Line
-            while ((strLine = br.readLine()) != null)   {
-                String tLine = strLine.trim();
-                if (tLine.startsWith("#")) continue;    // comment line
-
-                String[] oneKeyVal = tLine.split("=");
-                if (oneKeyVal.length != 2) continue;    // not legal key=value line
-
-                String k = oneKeyVal[0].trim();         // key
-                String v = oneKeyVal[1].trim();         // value
-
-
-                if (k.equalsIgnoreCase(sProp)) {        // key is 'ID'
-                    oneList = new HiPSMasterListEntry();
-                    lists.add(oneList);
-                    oneList.set(PARAMS.ID.getKey(), v);
-                    oneList.set(PARAMS.SOURCE.getKey(), source);
-                } else {
-                    if (oneList == null) continue;
-                    for (Map.Entry<String, String> entry : keyMap.entrySet()) {
-                        if (entry.getValue().equals(k)) {
-                            oneList.set(entry.getKey(), v);
-                            break;
-                        }
-                    }
-                }
-            }
-            //Close the input stream
-            br.close();
-            return lists;
-        }catch (Exception e){//Catch exception if any
-            e.printStackTrace();
-            throw new IOException("[HIPS_CDS]:" + e.getMessage());
-        }
+        return IrsaHiPSListSource.createHiPSListFromUrl(url, dataTypes, source, null);
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
@@ -28,11 +28,11 @@ public class CDSHiPSListSource implements HiPSMasterListSourceType {
     private static final String HiPSCDSURL = AppProperties.getProperty("HiPS.cds.hostname",
                                              "http://alasky.unistra.fr/MocServer/query?hips_service_url=*&get=record");
     //set default timeout to 30seconds
-    private static int TIMEOUT  = new Integer( AppProperties.getProperty("HiPS.cds.timeoutLimit" , "30")).intValue();
+    private static int TIMEOUT  = new Integer( AppProperties.getProperty("HiPS.timeoutLimit" , "30")).intValue();
     private static Map<String, String> paramsMap = new HashMap<>();
 
     static {
-        HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.ID, "ID");
+        HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.ID, "creator_did");
         HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TITLE, "obs_title");
         HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.ORDER, "hips_order");
         HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TYPE, "dataproduct_type");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
@@ -70,6 +70,6 @@ public class CDSHiPSListSource implements HiPSMasterListSourceType {
     private List<HiPSMasterListEntry> createHiPSList(String[] dataTypes,
                                                      String source) throws IOException, DataAccessException, FailedRequestException {
         String url = HiPSCDSURL + dataProduct(dataTypes);
-        return IrsaHiPSListSource.createHiPSListFromUrl(url, dataTypes, source, null);
+        return IrsaHiPSListSource.createHiPSListFromUrl(url, dataTypes, source);
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/IrsaHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/IrsaHiPSListSource.java
@@ -9,35 +9,68 @@ import edu.caltech.ipac.firefly.server.util.DsvToDataGroup;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.util.DataObject;
 import edu.caltech.ipac.util.DataType;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.util.download.URLDownload;
+import edu.caltech.ipac.firefly.server.query.lsst.LSSTQuery;
 import org.apache.commons.csv.CSVFormat;
 
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.File;
+import java.net.URL;
+import java.io.FileReader;
+import java.io.BufferedReader;
 
 /**
  * Created by cwang on 2/27/18.
  */
 public class IrsaHiPSListSource implements HiPSMasterListSourceType {
     private static final Logger.LoggerImpl _log = Logger.getLogger();
-    private final static String irsaHipsTable = "/edu/caltech/ipac/firefly/resources/irsa-hips-master-table.csv";
-    private static final String IRSA_HIPS_TABLE = AppProperties.getProperty("irsa.hipsmastertable.location",irsaHipsTable);
+    private static final String irsaHiPSSource = AppProperties.getProperty("irsa.hips.list.source", "file");
+    private static final String irsaHipsTable = "/edu/caltech/ipac/firefly/resources/irsa-hips-master-table.csv";
+    private static final String irsaHipsUrl = "https://irsadev.ipac.caltech.edu/data/hips/list";
+    private static final String irsaHiPSList = irsaHiPSSource.equals("file") ?
+                                                    AppProperties.getProperty("irsa.hips.masterFile",irsaHipsTable):
+                                                    AppProperties.getProperty("irsa.hips.masterUrl", irsaHipsUrl);
+    private static final String urlBase = AppProperties.getProperty("irsa.hips.url.base", "irsa.ipac.caltech.edu");
+    private static int TIMEOUT  = new Integer( AppProperties.getProperty("HiPS.timeoutLimit" , "30")).intValue();
+
 
 
     private static Map<String, String> paramsMap = new HashMap<>();
     static {
-        HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TITLE, "label");
-        HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.URL, "url");
+        if (irsaHiPSSource.equals("file")) {
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TITLE, "label");
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.URL, "url");
+        } else {
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.ID, "creator_did");
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.URL, "hips_service_url");
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TITLE, "obs_title");
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.ORDER, "hips_order");
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TYPE, "dataproduct_type");
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.FRACTION, "moc_sky_fraction");
+            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.FRAME, "hips_frame");
+        }
     }
 
     public List<HiPSMasterListEntry> getHiPSListData(String[] dataTypes, String source) {
         try {
-            return createHiPSList(IRSA_HIPS_TABLE, dataTypes, source);
+
+            if (!Arrays.asList(dataTypes).contains(ServerParams.IMAGE)) return null;
+
+            if (irsaHiPSSource.equals("file")) {
+                return createHiPSListFromFile(irsaHiPSList, dataTypes, source);
+            } else {
+                return createHiPSListFromUrl(irsaHiPSList, dataTypes, source);
+            }
         }
-        catch (FailedRequestException | IOException e) {
+        catch (FailedRequestException | IOException | DataAccessException e) {
             _log.warn("get Irsa HiPS failed");
             return null;
         } catch (Exception e) {
@@ -47,8 +80,117 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
 
     }
 
+    List<HiPSMasterListEntry> createHiPSListFromUrl(String url, String[] dataTypes, String source)
+                                                  throws IOException, DataAccessException, FailedRequestException  {
+        _log.briefDebug("executing Irsa url query: " + url);
+
+        File file = HiPSMasterList.createFile(dataTypes, ".txt", source);
+        Map<String, String> requestHeader=new HashMap<>();
+        requestHeader.put("Accept", "application/text");
+        long cTime = System.currentTimeMillis();
+        FileInfo listFile = URLDownload.getDataToFileUsingPost(new URL(url), null, null, requestHeader, file, null,
+                TIMEOUT);
+
+        _log.briefDebug("get IRSA HiPS took " + (System.currentTimeMillis() - cTime) + "ms");
+
+        if (listFile.getResponseCode() >= 400) {
+            String err = LSSTQuery.getErrorMessageFromFile(file);
+            throw new DataAccessException("[HiPS_CDS] " + (err == null ? listFile.getResponseCodeMsg() : err));
+        }
+
+        return getListDataFrom(file, paramsMap, source);
+
+    }
+
+    private List<HiPSMasterListEntry> getListDataFrom(File f, Map<String, String> keyMap, String source)
+                                                                                               throws IOException {
+        if (f == null) return null;
+
+        try{
+            // Open the file that is the first command line parameter
+            BufferedReader br = new BufferedReader(new FileReader(f));
+            String strLine;
+            HiPSMasterListEntry oneList = null;
+            List<HiPSMasterListEntry> lists = new ArrayList();
+            String sProp = HiPSMasterListEntry.getParamString(keyMap, PARAMS.ID);  // first property for each record
+
+            //Read File Line By Line
+            while ((strLine = br.readLine()) != null)   {
+                String tLine = strLine.trim();
+                if (tLine.startsWith("#")) continue;    // comment line
+
+                String[] oneKeyVal = tLine.split("=");
+                if (oneKeyVal.length != 2) continue;    // not legal key=value line
+
+                String k = oneKeyVal[0].trim();         // key
+                String v = oneKeyVal[1].trim();         // value
+
+
+                if (k.equalsIgnoreCase(sProp)) {        // key is 'creator_did'
+                    oneList = new HiPSMasterListEntry();
+                    lists.add(oneList);
+                    oneList.set(PARAMS.ID.getKey(), v);
+                    oneList.set(PARAMS.SOURCE.getKey(), source);
+                    oneList.set(PARAMS.TYPE.getKey(), ServerParams.IMAGE);
+                    oneList.set(PARAMS.TITLE.getKey(), getTitle(v));
+                } else {
+                    if (oneList == null) continue;
+                    for (Map.Entry<String, String> entry : keyMap.entrySet()) {
+                        if (entry.getValue().equals(k)) {
+                            if (entry.getKey().equals(PARAMS.URL.getKey())) {
+                                v = checkBaseUrl(v);
+                            }
+                            oneList.set(entry.getKey(), v);
+                            break;
+                        }
+                    }
+                }
+            }
+            //Close the input stream
+            br.close();
+            return lists;
+        } catch (Exception e){//Catch exception if any
+            e.printStackTrace();
+            throw new IOException("[HIPS_CDS]:" + e.getMessage());
+        }
+    }
+
+    private String getTitle(String titleStr) {
+         int insLoc = titleStr.indexOf("//");
+         if (insLoc < 0) return titleStr;
+
+         int divLoc = titleStr.indexOf('/', insLoc+2);
+         if (divLoc < 0) return titleStr;
+
+         int titleLoc = titleStr.indexOf('/', divLoc+1);
+         if (titleLoc < 0) return titleStr;
+
+         String newTitle = titleStr.substring(titleLoc+1).replaceAll("/", " ").trim();
+
+         return newTitle;
+    }
+
+    private String checkBaseUrl(String crtUrl) {
+        if (crtUrl.contains(urlBase)) {
+            return crtUrl;
+        } else {
+            int baseSLoc = crtUrl.indexOf("//");
+            if (baseSLoc < 0)
+                return crtUrl;
+
+            int baseELoc = crtUrl.indexOf("/", baseSLoc+2);
+            if (baseELoc < 0)
+                return crtUrl;
+
+            String newUrl = crtUrl.substring(0, baseSLoc+2) + urlBase + crtUrl.substring(baseELoc);
+
+            return newUrl;
+        }
+    }
+
+
     // a csv file is created to contain HiPS from IRSA
-    private List<HiPSMasterListEntry> createHiPSList(String hipsMaser,
+    private List<HiPSMasterListEntry> createHiPSListFromFile(String hipsMaser,
                                                      String[] dataTypes,
                                                      String source) throws IOException, FailedRequestException {
 
@@ -81,8 +223,8 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
         for (DataObject row : dataRows) {
             oneList = new HiPSMasterListEntry();
             lists.add(oneList);
-            oneList.set(PARAMS.TYPE.getKey(), ServerParams.IMAGE);
             oneList.set(PARAMS.SOURCE.getKey(), source);
+            oneList.set(PARAMS.TYPE.getKey(), ServerParams.IMAGE);
             for (int i = 0; i < dataCols.length; i++) {
                 Object obj = row.getDataElement(dataCols[i].getKeyName());
                 String val = obj != null ? obj.toString() : null;
@@ -90,6 +232,7 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
                 oneList.set(cols[i], val);
             }
         }
+
         
         return lists;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/IrsaHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/IrsaHiPSListSource.java
@@ -45,10 +45,6 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
 
     private static Map<String, String> paramsMap = new HashMap<>();
     static {
-        if (irsaHiPSSource.equals("file")) {
-            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TITLE, "label");
-            HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.URL, "url");
-        } else {
             HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.ID, "creator_did");
             HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.URL, "hips_service_url");
             HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TITLE, "obs_title");
@@ -56,7 +52,6 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
             HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.TYPE, "dataproduct_type");
             HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.FRACTION, "moc_sky_fraction");
             HiPSMasterListEntry.setParamsMap(paramsMap, PARAMS.FRAME, "hips_frame");
-        }
     }
 
     public List<HiPSMasterListEntry> getHiPSListData(String[] dataTypes, String source) {
@@ -171,7 +166,8 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
     }
 
     private String checkBaseUrl(String crtUrl) {
-        if (crtUrl.contains(urlBase)) {
+
+        if (crtUrl == null || crtUrl.contains(urlBase)) {
             return crtUrl;
         } else {
             int baseSLoc = crtUrl.indexOf("//");
@@ -190,11 +186,11 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
 
 
     // a csv file is created to contain HiPS from IRSA
-    private List<HiPSMasterListEntry> createHiPSListFromFile(String hipsMaser,
+    private List<HiPSMasterListEntry> createHiPSListFromFile(String hipsMaster,
                                                      String[] dataTypes,
                                                      String source) throws IOException, FailedRequestException {
 
-        InputStream inf= IrsaHiPSListSource.class.getResourceAsStream(hipsMaser);
+        InputStream inf= IrsaHiPSListSource.class.getResourceAsStream(hipsMaster);
         DataGroup dg = DsvToDataGroup.parse(inf, CSVFormat.DEFAULT);
 
         return getListData(dg, paramsMap, source);
@@ -229,7 +225,14 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
                 Object obj = row.getDataElement(dataCols[i].getKeyName());
                 String val = obj != null ? obj.toString() : null;
 
-                oneList.set(cols[i], val);
+                if (dataCols[i].getKeyName().equals(keyMap.get(PARAMS.URL.getKey()))) {
+                    oneList.set(cols[i], checkBaseUrl(val));
+                } else if (cols[i] != null) {
+                    oneList.set(cols[i], val);
+                }
+                if (dataCols[i].getKeyName().equals(keyMap.get(PARAMS.ID.getKey()))) {
+                    oneList.set(PARAMS.TITLE.getKey(), getTitle(val));
+                }
             }
         }
 

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -15,7 +15,7 @@ import {INFO_POPUP} from './PopupUtil.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
 import {onHiPSSurveys, isLoadingHiPSSurverys, HiPSPopular, HiPSId, HiPSData, HiPSSurveyTableColumn,
         getHiPSSurveys,  getHiPSLoadingMessage, getPopularHiPSTable,
-        isOnePopularSurvey, makeHiPSSurveysTableName, indexInHiPSSurveys,
+        makeHiPSSurveysTableName, indexInHiPSSurveys,
         updateHiPSTblHighlightOnUrl} from '../visualize/HiPSListUtil.js';
 import {FieldGroup} from './FieldGroup.jsx';
 import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
@@ -164,8 +164,8 @@ function getHiPSPopularSetting(hipsUrl) {
     let pSetting = getFieldVal(gKeyHiPSPanel, fKeyHiPSPopular);
 
     if (isUndefined(pSetting)) {
-        pSetting = (!hipsUrl || isOnePopularSurvey(hipsUrl)) ? HiPSPopular : '';
-        // pSetting = HiPSPopular;
+        //pSetting = (!hipsUrl || isOnePopularSurvey(hipsUrl)) ? HiPSPopular : '';
+        pSetting = HiPSPopular; // will be updated based on app options hips popular setting
     }
 
     return pSetting;

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -149,49 +149,6 @@ function hideSearchPanel() {
 }
 
 
-function renderHiPS(fields) {
-
-    //todo
-    //todo
-    //todo
-    //todo
-    //todo
-    const options= hipsSURVEYS.map( (s,idx) => ({label:s.label, value:idx+''}));
-    options.push({label:'Other', value:'other'});
-
-    return (
-        <div>
-            <div>
-                HiPS Plot
-            </div>
-
-            <RadioGroupInputField
-                fieldKey='hipsSurvey'
-                inline={true}
-                alignment='vertical'
-                initialState={{
-                    tooltip: 'Choose survey',
-                    value: options[0].value
-                }}
-                options={options}
-            />
-            <ValidationField fieldKey='otherUrl'
-                             initialState={{
-                                 fieldKey: 'otherUrl',
-                                 value: '',
-                                 tooltip: 'a url',
-                                 label : 'url:',
-                                 labelWidth : 100
-                             }}/>
-
-
-        </div>
-    );
-}
-
-
-
-
 function renderPeriodogram(fields) {
 
     /**

--- a/src/firefly/js/visualize/HiPSListUtil.js
+++ b/src/firefly/js/visualize/HiPSListUtil.js
@@ -76,12 +76,6 @@ export function getPopularHiPSTable(hipsId, hipsUrl) {
     return  (masterTbl && hFilter && hFilter.getPopularTable) ? hFilter.getPopularTable(masterTbl, hipsUrl) : null;
 }
 
-export function isOnePopularSurvey(url) {
-    const hFilter = getHiPSFilter();
-
-    return (hFilter && hFilter.isOnePopularSurvey) ? hFilter.isOnePopularSurvey(url) : false;
-}
-
 function getHiPSFilter() {
     const hFilter = defaultHiPSPopularFilter;  // hard code, hips filter will be configured later
 
@@ -101,12 +95,6 @@ function stripTrailingSlash(url) {
 
 
 function defaultHiPSPopularFilter() {
-    const isOnePopularSurvey = (url) => {
-        const defaultUrls =  hipsSURVEYS.map((oneSurvey) => stripTrailingSlash(oneSurvey.url).toLowerCase());
-
-        return defaultUrls.findIndex((dUrl) => dUrl === stripTrailingSlash(url).toLowerCase()) >= 0;
-    };
-
     const createPopularTable = (tableModel, popular_tblId, hipsUrl) => {
         const newTable = omit(cloneDeep(tableModel), ['request', 'origTableModel', 'selectInfo', 'tableMeta'] );
         newTable.tbl_id = popular_tblId;
@@ -140,7 +128,6 @@ function defaultHiPSPopularFilter() {
     };
 
     return {
-        isOnePopularSurvey,
         getPopularTable
     };
 }

--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -336,67 +336,6 @@ function filterAllSky(centerWp, cells) {
     });
 }
 
-
-export const hipsSURVEYS = [
-    {
-        url: 'http://alasky.u-strasbg.fr/2MASS/Color',
-        label: '2MASS colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/DSS/DSSColor',
-        label: 'DSS colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/DSS/DSS2Merged',
-        label: 'DSS2 Red (F+R)'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/Fermi/Color',
-        label: 'Fermi color'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/FinkbeinerHalpha',
-        label: 'Halpha'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/GALEX/GR6-02-Color',
-        label: 'GALEX Allsky Imaging Survey colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/IRISColor',
-        label: 'IRIS colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/MellingerRGB',
-        label: 'Mellinger colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/SDSS/DR9/color',
-        label: 'SDSS9 colored'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/SpitzerI1I2I4color',
-        label: 'IRAC color I1,I2,I4 - (GLIMPSE, SAGE, SAGE-SMC, SINGS)'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/VTSS/Ha',
-        label: 'VTSS-Ha'
-    },
-    {
-        url: 'http://saada.u-strasbg.fr/xmmallsky',
-        label: 'XMM-Newton stacked EPIC images (no phot. normalization)'
-    },
-    {
-        url: 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1/',
-        label: 'AllWISE color'
-    },
-    {
-        url: 'http://www.spitzer.caltech.edu/glimpse360/aladin/data',
-        label: 'GLIMPSE360'
-    }
-];
-
-
 export const API_HIPS_CONSTANTS= {
     TWO_MASS: 'http://alasky.u-strasbg.fr/2MASS/Color',
     DSS_COLORED: 'http://alasky.u-strasbg.fr/DSS/DSSColor',

--- a/src/firefly/js/visualize/MenuItemKeys.js
+++ b/src/firefly/js/visualize/MenuItemKeys.js
@@ -25,14 +25,13 @@ export const MenuItemKeys= {
     markerToolDD : 'markerToolDD',
     northArrow : 'northArrow',
     grid : 'grid',
-    hipsGrid: 'hipsGrid',
     ds9Region : 'ds9Region',
     maskOverlay : 'maskOverlay',
     layer : 'layer',
     irsaCatalog : 'irsaCatalog',
     restore : 'restore',
     lockRelated: 'lockRelated',
-    fitsHeader: 'fitsHeader',
+    fitsHeader: 'fitsHeader'
 };
 
 const defaultOff = [MenuItemKeys.lockImage, MenuItemKeys.irsaCatalog, MenuItemKeys.maskOverlay];

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -467,8 +467,15 @@ function getHiPSCoordSysFromProperties(hipsProperties) {
         case 'equatorial' : return CoordinateSys.EQ_J2000;
         case 'galactic' :   return CoordinateSys.GALACTIC;
         case 'ecliptic' :   return CoordinateSys.ECL_B1950;
-        default:            return CoordinateSys.GALACTIC;
     }
+    if (!hipsProperties.hips_frame) {
+        switch (hipsProperties.coordsys) { // fallback using old style
+            case 'C' : return CoordinateSys.EQ_J2000;
+            case 'G' : return CoordinateSys.GALACTIC;
+            case 'E' : return CoordinateSys.ECL_B1950;
+        }
+    }
+    return CoordinateSys.GALACTIC;
 }
 
 function makeHiPSProjectionUsingProperties(hipsProperties, lon=0, lat=0) {

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -1345,7 +1345,8 @@ export class WebPlotRequest extends ServerRequest {
         return this.containsParam(C.OVERLAY_IDS) ?
             this.getParam(C.OVERLAY_IDS).split(';') :
             ['ACTIVE_TARGET_TYPE','POINT_SELECTION_TYPE', 'NORTH_UP_COMPASS_TYPE',
-             'WEB_GRID_TYPE', 'OVERLAY_MARKER_TYPE', 'OVERLAY_FOOTPRINT_TYPE', 'REGION_PLOT_TYPE'];
+             'WEB_GRID_TYPE', 'OVERLAY_MARKER_TYPE', 'OVERLAY_FOOTPRINT_TYPE', 'REGION_PLOT_TYPE',
+             'HIPS_GRID_TYPE'];
             //[ActiveTarget.TYPE_ID,'OTHER'];
     }
 

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -25,7 +25,7 @@ import {ensureWPR, determineViewerId, getHipsImageConversion,
         initBuildInDrawLayers, addDrawLayers} from './PlotImageTask.js';
 import {dlRoot, dispatchAttachLayerToPlot,
         dispatchCreateDrawLayer, dispatchDetachLayerFromPlot,
-        getDlAry} from '../DrawLayerCntlr.js';
+        getDlAry, dispatchDestroyDrawLayer} from '../DrawLayerCntlr.js';
 import ImageOutline from '../../drawingLayers/ImageOutline.js';
 import Artifact from '../../drawingLayers/Artifact.js';
 import {isHiPS} from '../WebPlot';
@@ -175,7 +175,7 @@ export function makePlotHiPSAction(rawAction) {
             })
             .then( addAllSky)
             .then( (plot) => {
-                addHiPSGridLayer();
+                createHiPSGridLayer();
                 dispatchAddActionWatcher({
                     actions:[ImagePlotCntlr.PLOT_HIPS, ImagePlotCntlr.UPDATE_VIEW_SIZE],
                     callback:watchForHiPSViewDim,
@@ -191,7 +191,7 @@ export function makePlotHiPSAction(rawAction) {
     };
 }
 
-function addHiPSGridLayer() {
+function createHiPSGridLayer() {
     const dl= getDrawLayerByType(getDlAry(), HiPSGrid.TYPE_ID);
     if (!dl) {
         dispatchCreateDrawLayer(HiPSGrid.TYPE_ID);
@@ -295,6 +295,7 @@ export function convertToImage(pv, allSky= false) {
     const {plotId, plotGroupId,viewDim}= pv;
     const {allSkyRequest, imageRequestRoot}= pv.plotViewCtx.hipsImageConversion;
     dispatchDetachLayerFromPlot(ImageOutline.TYPE_ID, plotId);
+    dispatchDetachLayerFromPlot(HiPSGrid.TYPE_ID, plotId);
     const doingAllSky= allSky && allSkyRequest;
     const wpRequest= (doingAllSky) ? allSkyRequest.makeCopy() : imageRequestRoot.makeCopy();
     const hipsFov= getHiPSFoV(pv);

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -7,15 +7,15 @@ import ImagePlotCntlr, {visRoot, IMAGE_PLOT_KEY,
     dispatchChangeCenterOfProjection, dispatchZoom,
     dispatchAttributeChange,
     dispatchPlotProgressUpdate, dispatchPlotImage, dispatchPlotHiPS} from '../ImagePlotCntlr.js';
-import {getEstimatedFullZoomFactor, getArcSecPerPix, getZoomLevelForScale, UserZoomTypes} from '../ZoomUtil.js';
+import {getArcSecPerPix, getZoomLevelForScale, UserZoomTypes} from '../ZoomUtil.js';
 import {WebPlot, PlotAttribute} from '../WebPlot.js';
 import {fetchUrl, clone, loadImage} from '../../util/WebUtil.js';
 import {getPlotGroupById} from '../PlotGroup.js';
-import {primePlot, getPlotViewById, hasGroupLock} from '../PlotViewUtil.js';
+import {primePlot, getPlotViewById, hasGroupLock, isDrawLayerAttached} from '../PlotViewUtil.js';
 import {dispatchAddActionWatcher} from '../../core/MasterSaga.js';
 import {getHiPSZoomLevelToFit} from '../HiPSUtil.js';
 import {getCenterOfProjection, findCurrentCenterPoint, getCorners,
-    getDrawLayerByType, getDrawLayersByType} from '../PlotViewUtil.js';
+        getDrawLayerByType, getDrawLayersByType} from '../PlotViewUtil.js';
 import {findAllSkyCachedImage, addAllSkyCachedImage} from '../iv/HiPSTileCache.js';
 import {makeHiPSAllSkyUrl, makeHiPSAllSkyUrlFromPlot,
          makeHipsUrl, getHiPSFoV, resolveHiPSConstant} from '../HiPSUtil.js';
@@ -24,12 +24,14 @@ import {CCUtil} from '../CsysConverter.js';
 import {ensureWPR, determineViewerId, getHipsImageConversion,
         initBuildInDrawLayers, addDrawLayers} from './PlotImageTask.js';
 import {dlRoot, dispatchAttachLayerToPlot,
-    dispatchCreateDrawLayer, dispatchDetachLayerFromPlot} from '../DrawLayerCntlr.js';
+        dispatchCreateDrawLayer, dispatchDetachLayerFromPlot,
+        getDlAry} from '../DrawLayerCntlr.js';
 import ImageOutline from '../../drawingLayers/ImageOutline.js';
 import Artifact from '../../drawingLayers/Artifact.js';
-import CysConverter from '../CsysConverter';
 import {isHiPS} from '../WebPlot';
 import {dispatchChangeHiPS} from '../ImagePlotCntlr';
+import HiPSGrid from '../../drawingLayers/HiPSGrid.js';
+
 
 //const INIT_STATUS_UPDATE_DELAY= 7000;
 
@@ -173,6 +175,7 @@ export function makePlotHiPSAction(rawAction) {
             })
             .then( addAllSky)
             .then( (plot) => {
+                addHiPSGridLayer();
                 dispatchAddActionWatcher({
                     actions:[ImagePlotCntlr.PLOT_HIPS, ImagePlotCntlr.UPDATE_VIEW_SIZE],
                     callback:watchForHiPSViewDim,
@@ -186,6 +189,13 @@ export function makePlotHiPSAction(rawAction) {
                 hipsFail(dispatcher, plotId, wpRequest, 'Could not retrieve properties file');
             } );
     };
+}
+
+function addHiPSGridLayer() {
+    const dl= getDrawLayerByType(getDlAry(), HiPSGrid.TYPE_ID);
+    if (!dl) {
+        dispatchCreateDrawLayer(HiPSGrid.TYPE_ID);
+    }
 }
 
 

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -24,6 +24,7 @@ import {getPlotViewById, getDrawLayerByType, getDrawLayersByType, getDrawLayerBy
 import {enableMatchingRelatedData, enableRelatedDataLayer} from '../RelatedDataUtil.js';
 import {modifyRequestForWcsMatch} from './WcsMatchTask.js';
 import WebGrid from '../../drawingLayers/WebGrid.js';
+import HiPSGrid from '../../drawingLayers/HiPSGrid.js';
 
 //======================================== Exported Functions =============================
 //======================================== Exported Functions =============================
@@ -327,7 +328,8 @@ export function addDrawLayers(request, plot ) {
                     dispatchAttachLayerToPlot(dl.drawLayerId, plotId);
                 }
             } else if (dl.canAttachNewPlot) {
-                dispatchAttachLayerToPlot(dl.drawLayerId, plotId);
+                const visibility = dl.drawLayerTypeId === HiPSGrid.TYPE_ID ? false : true;
+                dispatchAttachLayerToPlot(dl.drawLayerId, plotId, false, visibility);
             }
         });
     });

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -31,7 +31,6 @@ import NorthUpCompass from '../../drawingLayers/NorthUpCompass.js';
 import { fitsHeaderView} from './FitsHeaderView.jsx';
 import { getDlAry } from '../DrawLayerCntlr.js';
 import WebGrid from '../../drawingLayers/WebGrid.js';
-import HiPSGrid from '../../drawingLayers/HiPSGrid.js';
 import {showRegionFileUploadPanel} from '../region/RegionFileUploadView.jsx';
 import {MarkerDropDownView} from './MarkerDropDownView.jsx';
 import {showImageSelPanel} from './ImageSearchPanelV2.jsx';
@@ -50,8 +49,6 @@ import DIST_ON from 'html/images/icons-2014/Measurement-ON.png';
 import DIST_OFF from 'html/images/icons-2014/Measurement.png';
 import GRID_OFF from 'html/images/icons-2014/GreenGrid.png';
 import GRID_ON from 'html/images/icons-2014/GreenGrid-ON.png';
-import HIPS_GRID_OFF from 'html/images/icons-2014/HiPSGrid.png';
-import HIPS_GRID_ON from 'html/images/icons-2014/HiPSGrid-ON.png';
 import COMPASS_OFF from 'html/images/icons-2014/28x28_Compass.png';
 import COMPASS_ON from 'html/images/icons-2014/28x28_CompassON.png';
 import ROTATE_NORTH_OFF from 'html/images/icons-2014/RotateToNorth.png';
@@ -283,18 +280,6 @@ export class VisToolbarView extends PureComponent {
                                         iconOff={GRID_OFF}
                                         visible={mi.grid}
                 />
-
-                <SimpleLayerOnOffButton plotView={pv}
-                                        typeId={HiPSGrid.TYPE_ID}
-                                        tip='Add HiPS grid layer to the HiPS display'
-                                        iconOn={HIPS_GRID_ON}
-                                        iconOff={HIPS_GRID_OFF}
-                                        allPlots={true}
-                                        plotTypeMustMatch={true}
-                                        visible={mi.hipsGrid && hips}
-                />
-
-
 
                 <ToolbarButton icon={DS9_REGION}
                                tip='Load a DS9 Region File'


### PR DESCRIPTION
The development includes:
- Remove HiPS grid icon from the toolbar, Add HiPS grid layer with the checkbox turned off (the layer is hidden by default) when a new HiPS is added. 
- Add support for calling IRSA hips list,
    . Update App config file by adding information related to IRSA HiPS map service 
    . Each item in the HiPS list has unique value for HiPS property creator_did. 
    . Extract title value from property creator_id for IRSA HiPS list

Note: please checkout ife with the same branch name 'DM-13797-rmHiPSGridIconIrsaHiPSList'. 
 
test:
do HiPS image search. 
For this PR, HiPS map list is formed by sending request to IRSA HiPS map service, 
https://irsadev.ipac.caltech.edu/data/hips/list


