### PR TITLE
DM-13919 add arcminute-scale rage to HiPS image FOV display

### DIFF
--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -1019,7 +1019,7 @@ export default {
     isPlotNorth, getEstimatedFullZoomFactor,
     intersects, contains, containsRec,containsCircle,
     getArrowCoords, getSelectedPts, calculatePosition, getCorners,
-    makePt, getWorldPtRepresentation, getCenterPtOfPlot, toDegrees
+    makePt, getWorldPtRepresentation, getCenterPtOfPlot, toDegrees, convertAngle
 };
 
 

--- a/src/firefly/js/visualize/ZoomUtil.js
+++ b/src/firefly/js/visualize/ZoomUtil.js
@@ -138,26 +138,27 @@ export function getZoomDesc(pv) {
     const plot= primePlot(pv);
     if (!plot) return '';
     const zstr= convertZoomToString(plot.zoomFactor);
+
     if (isImage(plot)) {
         return zstr;
     }
     else {
         if (!plot.viewDim) return '';
         const zprefix= SHOW_ZOOM_PREFIX ? zstr+', ' : '';
-        // const degPerPix= getArcSecPerPix(plot,plot.zoomFactor)/3600;
-        // const fov= degPerPix * plot.viewDim.width;
         const fov= getHiPSFoV(pv);
-        if (fov>10) {
-            return `${zprefix}FOV: ${numeral(fov).format('0')}${String.fromCharCode(176)}`;
-        }
-        else if (fov>5) {
-            return `${zprefix}FOV: ${numeral(fov).format('0.0')}${String.fromCharCode(176)}`;
-        }
-        else if (fov>1) {
-            return `${zprefix}FOV: ${numeral(fov).format('0.00')}${String.fromCharCode(176)}`;
-        }
-        else {
-            return `${zprefix}FOV: ${numeral(fov*3600).format('0')}"`;
+        const zoomNumber = (charCode, fNum) => {
+            const nFormat = (fNum > 10.0) ? '0' : ((fNum >= 1.0) ? '0.0' : '0.00');
+
+            return `${zprefix}FOV: ${numeral(fNum).format(nFormat)}${charCode}`;
+        };
+
+        if (fov > 1.0) {
+            return zoomNumber(String.fromCharCode(176), fov);
+        } else {
+            const fovMin = VisUtil.convertAngle('deg', 'arcmin', fov);
+
+            return fovMin > 1.0 ? zoomNumber("'", fovMin) :
+                                  zoomNumber('"', VisUtil.convertAngle('arcmin', 'arcsec', fovMin));
         }
     }
 


### PR DESCRIPTION
This development:
Add arcminute-scale range to HiPS image FOV display in the image title. 
- The FOV display will be changed from degree to arcminute if the value in degree is less than 1.0, and changed from arcminute to arcsecond if the value in arcminute is less than 1.0. 
- The value is display in two significant digits. 

Test:
do HiPS image search by selecting a HiPS from the HiPS map list. 
zoom in the image to see that FOV number dropps and the unit changes from deg to arcminute and then to arcsecond if the zooming is not beyond the limit. 