### PR TITLE
DM-7991: handling upper limits

### DIFF
--- a/docs/firefly-api-overview.md
+++ b/docs/firefly-api-overview.md
@@ -94,7 +94,7 @@ Firefly React components can be found in `firefly.ui` module.
 | ---------- | ---- | ----------- |
 | div | string or Object | a div element or a string id of the div element |
 
-<br>
+
 *Example:* 
 ```js
 const props = {
@@ -188,8 +188,8 @@ The FITS viewer can take many, many possible parameters.  Some parameters contro
 
 For the details of FITS plotting parameters see: [fits-plotting-parameters.md](fits-plotting-parameters.md)
  
-<br>
-*Examples:* 
+
+*Examples:*
 ```js
 firefly.setGlobalImageDef({
     ZoomType  : 'TO_WIDTH'

--- a/src/firefly/html/demo/ffapi-sed.html
+++ b/src/firefly/html/demo/ffapi-sed.html
@@ -20,13 +20,18 @@
 
 <div style="width: 500px; padding: 50px 0 0 20px;">
     <h2>
-    Sample SED Plot: ARP 220
+    Sample SED Charts
     </h2>
 </div>
 
 <div id="table" style="width: 800px; height: 550px; border: solid 1px;"></div>
 <br/><br/>
-<div id="plotly" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<div id="sedchart" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<br/><br/>
+
+<div id="table2" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<br/><br/>
+<div id="sedchart2" style="width: 800px; height: 550px; border: solid 1px;"></div>
 <br/><br/>
 
 <script type="text/javascript">
@@ -39,53 +44,89 @@
         onFireflyLoaded= function(firefly) {
 
             var tblReq = firefly.util.table.makeFileRequest(
-                'SED: ARP-220', // title
-                'http://ned.ipac.caltech.edu/cgi-bin/datasearch?ebars_spec=ebars&label_spec=no&x_spec=freq&y_spec=Fnu_jy&xr=-2&objname=ARP+220&objid=58863&search_type=Photo_id&meas_type=bot&of=xml_main&objname=ARP+220&objid=58863&search_type=Photo_id&meas_type=bot',  // source
+                'SED: ARP-220 raw', // title
+                'http://ned.ipac.caltech.edu/cgi-bin/datasearch?ebars_spec=ebars&label_spec=no&x_spec=freq&y_spec=Fnu_jy&xr=-2&objname=ARP+220&objid=58863&search_type=Photo_id&meas_type=bot&of=xml_main&objname=ARP+220&objid\
+=58863&search_type=Photo_id&meas_type=bot',  // source
                 null,  // alt_source
-                //{filters: '"NED Photometry Measurement" is null or "NED Photometry Measurement" < 6.76E-09'}
-                {pageSize: 50, filters: '"NED Units" like \'Jy\''} // options
+                {filters: '"NED Units" like \'Jy\''} // options
             );
-            var tblId = tblReq.tbl_id;
 
-            // set data format for chart data (default '%.6f is not suitable to display numbers like 1.3e-9)
-            tblReq.META_INFO['col.data.0.x.FmtDisp']= '%g';
-            tblReq.META_INFO['col.data.0.y.FmtDisp']= '%g';
-            tblReq.META_INFO['col.fireflyData.0.yMax.FmtDisp']= '%g';
-            firefly.showTable('table', tblReq);
+            // while waiting for NED to provide us a numeric column for upper limit and uncertainty
+            // using the db expression to generate upper limit column:
+            tblReq.inclCols = '"No.","Frequency","NED Photometry Measurement","NED Uncertainty",CASEWHEN(IFNULL("NED Photometry Measurement", 0) > 0, NULL, 10) as "NED Limit"'
 
-            var data = [{
-                name: 'sed',
-                tbl_id: tblId,
-                //text: 'tables::"No."', // does not display - probably not needed, if chart and table are connected
-                x: 'tables::log(Frequency)',
-                y: 'tables::log("NED Photometry Measurement")',
-                firefly: {
-                    // waiting for NED to provide us a numeric column
-                    // the expression is for illustration purposes only: only a limited set of DB expressions is supported in chart options
-                    yMax: 'tables::log(CASEWHEN(IFNULL("NED Photometry Measurement", 0) > 0, NULL, 10))'
-                },
-                mode: 'markers'
-            }];
+            var wrapperReq = firefly.util.table.makeTblRequest('IpacTableFromSource', 'SED: ARP-220',
+                {searchRequest: tblReq}, {pageSize: 50});
+            var tblId = wrapperReq.tbl_id;
 
-            var fireflyData = [{
-                // waiting for NED to provide us a numeric column
-                // the expression is for illustration purposes only:
-                // only a limited set of DB expressions is supported in chart options
-                // with this expression, user can not modify apply new chart options
-                yMax: 'tables::log(CASEWHEN(IFNULL("NED Photometry Measurement", 0) > 0, NULL, 10))'
+            firefly.showTable('table', wrapperReq);
 
-            }];
-
-            var layout = {
-                xaxis: {
-                    title: 'log(<em>v</em> [Hz])',
-                },
-                yaxis: {
-                    title: 'log(F<sub><em>v</em></sub> [Jy])',
+            firefly.showChart('sedchart', {
+                data: [{
+                    name: 'sed',
+                    tbl_id: tblId,
+                    //text: 'tables::"No."', // does not display - probably not needed, if chart and table are connected
+                    x: 'tables::log(Frequency)',
+                    // error_x: {
+                    //     // assuming error is a fifth of the Frequency
+                    //     array_minus: 'tables::log("Frequency")-log("Frequency"-"Frequency"/5)', // error bar (minus)
+                    //     array: 'tables::log("Frequency"+"Frequency"/5)-log("Frequency")', // error bar (plus)
+                    // },
+                    y: 'tables::log("NED Photometry Measurement")',
+                    firefly: {
+                        yMax: 'tables::log("NED Limit")'
+                    },
+                    mode: 'markers'
+                }],
+                layout: {
+                    xaxis: {
+                        title: 'log(<em>v</em> [Hz])',
+                    },
+                    yaxis: {
+                        title: 'log(F<sub><em>v</em></sub> [Jy])',
+                    }
                 }
-            };
+            });
 
-            firefly.showChart('plotly', {data: data, fireflyData: fireflyData, layout: layout});
+
+            // Another example: the table has numeric columns
+
+            var tblReq2 = firefly.util.table.makeFileRequest(
+                'SED: M31', // title
+                'http://localhost:8080/firefly/demo/sedSample.xml',  // source
+                null,  // alt_source
+                {} // options
+            );
+            var tblId1 = tblReq2.tbl_id;
+
+            firefly.showTable('table2', tblReq2);
+
+            firefly.showChart('sedchart2', {
+                data: [{
+                    name: 'sed',
+                    tbl_id: tblId1,
+                    x: 'tables::Frequency',
+                    y: 'tables::NEDPhotometryMeasurement',
+                    error_y: {
+                        array: 'tables::NEDUncertainty', // error bar (symmetrical or plus)
+                    },
+                    firefly: {
+                        yMax: 'tables::NEDUpperLimit'
+                    },
+                    mode: 'markers'
+                }],
+                layout: {
+                    xaxis: {
+                        title: 'v [Hz]',
+                        type: 'log'
+                    },
+                    yaxis: {
+                        title: 'F(v) [Jy]',
+                        type: 'log'
+                    }
+                }
+            });
+
         }
     }
 

--- a/src/firefly/html/demo/ffapi-sed.html
+++ b/src/firefly/html/demo/ffapi-sed.html
@@ -1,0 +1,100 @@
+<!doctype html>
+
+<!--
+  ~ License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+  -->
+
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>Upper Limits - Firefly</title>
+    <meta http-equiv="Cache-Control" content="no-cache">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+
+<body>
+
+
+<div style="width: 500px; padding: 50px 0 0 20px;">
+    <h2>
+    Sample SED Plot: ARP 220
+    </h2>
+</div>
+
+<div id="table" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<br/><br/>
+<div id="plotly" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<br/><br/>
+
+<script type="text/javascript">
+    if (!window.firefly) window.firefly= {};
+    window.firefly.options= {charts: {singleTraceUI: true, upperLimitUI: true}};
+</script>
+
+<script type="text/javascript">
+    {
+        onFireflyLoaded= function(firefly) {
+
+            var tblReq = firefly.util.table.makeFileRequest(
+                'SED: ARP-220', // title
+                'http://ned.ipac.caltech.edu/cgi-bin/datasearch?ebars_spec=ebars&label_spec=no&x_spec=freq&y_spec=Fnu_jy&xr=-2&objname=ARP+220&objid=58863&search_type=Photo_id&meas_type=bot&of=xml_main&objname=ARP+220&objid=58863&search_type=Photo_id&meas_type=bot',  // source
+                null,  // alt_source
+                //{filters: '"NED Photometry Measurement" is null or "NED Photometry Measurement" < 6.76E-09'}
+                {pageSize: 50, filters: '"NED Units" like \'Jy\''} // options
+            );
+            var tblId = tblReq.tbl_id;
+
+            // set data format for chart data (default '%.6f is not suitable to display numbers like 1.3e-9)
+            tblReq.META_INFO['col.data.0.x.FmtDisp']= '%g';
+            tblReq.META_INFO['col.data.0.y.FmtDisp']= '%g';
+            tblReq.META_INFO['col.fireflyData.0.yMax.FmtDisp']= '%g';
+            firefly.showTable('table', tblReq);
+
+            var data = [{
+                name: 'sed',
+                tbl_id: tblId,
+                //text: 'tables::"No."', // does not display - probably not needed, if chart and table are connected
+                x: 'tables::log(Frequency)',
+                y: 'tables::log("NED Photometry Measurement")',
+                firefly: {
+                    // waiting for NED to provide us a numeric column
+                    // the expression is for illustration purposes only: only a limited set of DB expressions is supported in chart options
+                    yMax: 'tables::log(CASEWHEN(IFNULL("NED Photometry Measurement", 0) > 0, NULL, 10))'
+                },
+                mode: 'markers'
+            }];
+
+            var fireflyData = [{
+                // waiting for NED to provide us a numeric column
+                // the expression is for illustration purposes only:
+                // only a limited set of DB expressions is supported in chart options
+                // with this expression, user can not modify apply new chart options
+                yMax: 'tables::log(CASEWHEN(IFNULL("NED Photometry Measurement", 0) > 0, NULL, 10))'
+
+            }];
+
+            var layout = {
+                xaxis: {
+                    title: 'log(<em>v</em> [Hz])',
+                },
+                yaxis: {
+                    title: 'log(F<sub><em>v</em></sub> [Jy])',
+                }
+            };
+
+            firefly.showChart('plotly', {data: data, fireflyData: fireflyData, layout: layout});
+        }
+    }
+
+
+</script>
+
+
+<script  type="text/javascript" src="../firefly_loader.js"></script>
+
+
+</body>
+</html>

--- a/src/firefly/html/demo/sedSample.xml
+++ b/src/firefly/html/demo/sedSample.xml
@@ -1,0 +1,2882 @@
+<?xml version="1.0"?>
+<VOTABLE version="1.1">
+<DEFINITIONS>
+<COOSYS ID="J2000" equinox="2000." epoch="2000." system="eq_FK5" />
+</DEFINITIONS>
+<RESOURCE type="results">
+<DESCRIPTION>
+Results from query to  NASA/IPAC Extragalactic Database (NED),
+which is operated by the Jet Propulsion Laboratory, California Institute of
+Technology, under contract with the National Aeronautics and Space Administration.
+This work was (partially) supported by the US National Virtual Observatory
+development project, which is funded by the National Science Foundation
+under cooperative agreement AST0122449 with The Johns Hopkins University.
+</DESCRIPTION>
+<INFO name="QUERY_STATUS" value="OK"/>
+<PARAM name="queryDateTime"  ucd="time.creation" datatype="char" arraysize="*" value="2018-03-12T16:47:18PDT"/>
+<LINK content-role="query" content-type="text/xml" 
+href="http://ned.ipac.caltech.edu/cgi-bin/datasearch?search_type=Photometry&amp;objname=MESSIER 031&amp;of=xml_main"/>
+<TABLE ID="NED_PhotometricData" name="Photometric Data for MESSIER 031">
+<DESCRIPTION> Published and Homogenized [Frequency, Flux Density] Units </DESCRIPTION>
+
+<FIELD ID="photo_col1" name="No." ucd="meta.number;phot.mag" datatype="int">
+<DESCRIPTION> A sequential number of Photometry Measurement for this object, applicable to this list only. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col2" name="Observed Passband" ucd="instr.bandpass" datatype="char" arraysize="*">
+<DESCRIPTION> Colloquial descriptions of the frequency or wavelength at which the data were collected, identifying the bandpass by name e.g., "V","1.4GHz", "6 cm", "HI", etc. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col3" name="Photometry Measurement" ucd="phot" datatype="double" >
+<DESCRIPTION> The published photometry or fluxes  for this point. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col4" name="Uncertainty" ucd="stat.error;phot" datatype="char" arraysize="*">
+<DESCRIPTION> The published uncertainty for photometric data. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col5" name="Units" ucd="meta.unit;phot" datatype="char" arraysize="*">
+<DESCRIPTION> Units of photometry measurement for this point. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col6" name="Frequency" ucd="em.freq" datatype="double" unit="um">
+<DESCRIPTION> The frequency, wavelength, or photometric passband, in absolute units as calculated by NED </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col7" name="NEDPhotometryMeasurement" ucd="phot" datatype="double" unit="Jy">
+<DESCRIPTION> Flux/Photometric data for this point as transformed and stored by NED. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col8" name="NEDUncertainty" ucd="stat.error;phot" datatype="double" unit="Jy">
+<DESCRIPTION> Photometric/Flux uncertainty as transformed and stored by NED. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col_e1" name="NEDUpperLimit" ucd="stat.max;phot" datatype="double" unit="Jy">
+<DESCRIPTION> Flux/Photometric data for this point as transformed and stored by NED. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col9" name="NEDUnits" ucd="meta.unit;phot" datatype="char" arraysize="*">
+<DESCRIPTION> Absolute units of photometry measurement for this point. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col10" name="Refcode" ucd="meta.bib.bibcode" datatype="char" arraysize="*">
+<DESCRIPTION> The NED 19-digit Bibliographic Reference code. </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col11" name="Significance" ucd="meta.code.error" datatype="char" arraysize="*">
+<DESCRIPTION>Type of uncertainty reported in the original publication</DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col12" name="Published frequency" ucd="meta.ref;em.freq" datatype="char" arraysize="*">
+<DESCRIPTION>Wavelength or frequency  of observation as given in the original publication  </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col13" name="Frequency Mode" ucd="meta.ref;em.freq;instr.setup" datatype="char" arraysize="*">
+<DESCRIPTION>The method(s) by which the data were collected, reduced, or derived, regarding the frequency or wavelength; </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col14" name="Coordinates Targeted" ucd="pos" datatype="char" arraysize="*">
+<DESCRIPTION>The position at which the measurements were taken, followed by the coordinate reference frame (e.g.,  013350.90 +303935.8 (J2000) in format HHMMSS.ss +DDMMSS.s (EQUINOX),  etc.). </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col15" name="Spatial Mode" ucd="phot.flux;instr.setup" datatype="char" arraysize="*">
+<DESCRIPTION>The method(s) by which the data were collected, reduced, or derived, regarding the spatially integrated flux</DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col16" name="Qualifiers" ucd="meta.note;instr.setup" datatype="char" arraysize="*">
+<DESCRIPTION>Self-explanatory notes pertaining to the history of the data or adjustments to the data or hanges introduced by NED  </DESCRIPTION>
+</FIELD>
+<FIELD ID="photo_col17" name="Comments" ucd="meta.note;comment" datatype="char" arraysize="*">
+<DESCRIPTION>Other information from the published source or from NED that may be helpful in interpreting or qualifying the data. </DESCRIPTION>
+</FIELD>
+<DATA>
+<TABLEDATA>
+<TR>
+<TD>1</TD>
+<TD>0.1-100 GeV (Fermi) </TD>
+<TD> 6.5E-12   </TD>
+<TD>+/-1.3E-12</TD>
+<TD>erg/cm^2^/s         </TD>
+<TD>1.21E+25</TD>
+<TD>  5.37E-14</TD>
+<TD>1.07E-14</TD>
+<TD></TD>
+<TD>Jy</TD>
+<TD>2012ApJS..199...31N</TD>
+<TD>1 sigma</TD>
+<TD>     50.05 GeV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>010.633 +41.245 (J2000)</TD>
+<TD> Modelled datum</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data; NED frequency assigned to mid-point ofband in keV]]></TD>
+</TR>
+<TR>
+<TD>2</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 4.2E-13   </TD>
+<TD>+/-3E-15</TD>
+<TD>milliW/m^2^         </TD>
+<TD>5.68E+17</TD>
+<TD>  7.39E-08</TD>
+<TD>5.28E-10</TD>
+<TD></TD>
+<TD>Jy</TD>
+<TD>2005A&amp;A...434..483P</TD>
+<TD>uncertainty</TD>
+<TD>    2.35   keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.19 +41 16 07.9 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[instrument:EPIC PN+MOS1+MOS2            ]]></TD>
+<TD><![CDATA[Averaged new and previously published data;Extinction-corrected for Milky Way; NED frequency assigned tomid-point of band in keV]]></TD>
+</TR>
+<TR>
+<TD>3</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 3.9E-13   </TD>
+<TD>+/-4E-15</TD>
+<TD>milliW/m^2^         </TD>
+<TD>5.68E+17</TD>
+<TD>  6.87E-08</TD>
+<TD>7.04E-10</TD>
+<TD></TD>
+<TD>Jy</TD>
+<TD>2005A&amp;A...434..483P</TD>
+<TD>uncertainty</TD>
+<TD>    2.35   keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.19 +41 16 07.9 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[instrument: EPIC PN                     ]]></TD>
+<TD><![CDATA[Averaged new and previously published data;Extinction-corrected for Milky Way; NED frequency assigned tomid-point of band in keV]]></TD>
+</TR>
+<TR>
+<TD>4</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 4.8E-13   </TD>
+<TD>+/-8E-15</TD>
+<TD>milliW/m^2^         </TD>
+<TD>5.68E+17</TD>
+<TD>  8.45E-08</TD>
+<TD>1.41E-09</TD>
+<TD></TD>
+<TD>Jy</TD>
+<TD>2005A&amp;A...434..483P</TD>
+<TD>uncertainty</TD>
+<TD>    2.35   keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.19 +41 16 07.9 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[instrument:EPIC MOS1                    ]]></TD>
+<TD><![CDATA[Averaged new and previously published data;Extinction-corrected for Milky Way; NED frequency assigned tomid-point of band in keV]]></TD>
+</TR>
+<TR>
+<TD>5</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 4.6E-13   </TD>
+<TD>+/-8E-15</TD>
+<TD>milliW/m^2^         </TD>
+<TD>5.68E+17</TD>
+<TD>  8.10E-08</TD>
+<TD>1.41E-09</TD>
+<TD></TD>
+<TD>Jy</TD>
+<TD>2005A&amp;A...434..483P</TD>
+<TD>uncertainty</TD>
+<TD>    2.35   keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.19 +41 16 07.9 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[instrument: EPIC MOS2                   ]]></TD>
+<TD><![CDATA[Averaged new and previously published data;Extinction-corrected for Milky Way; NED frequency assigned tomid-point of band in keV]]></TD>
+</TR>
+<TR>
+<TD>6</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 4.18e-13  </TD>
+<TD>+/-3.2e-15</TD>
+<TD> erg/s/cm^2^        </TD>
+<TD>5.68E+17</TD>
+<TD>  7.36E-08</TD>
+<TD>5.63E-10</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>2008A&amp;A...480..599S</TD>
+<TD>uncertainty</TD>
+<TD>      2.35 keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.1 +411607 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data; NED frequency assigned tomid-point of band in keV]]></TD>
+</TR>
+<TR>
+<TD>7</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 1.34E-13  </TD>
+<TD>+/-9E-15</TD>
+<TD>erg/cm^2^/s         </TD>
+<TD>5.68E+17</TD>
+<TD>  2.36E-08</TD>
+<TD>1.58E-09</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2011A&amp;A...534A..55S</TD>
+<TD>uncertainty</TD>
+<TD>      2.35 keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.48 +41 16 08.4 (J2000)</TD>
+<TD> Modelled datum</TD>
+<TD><![CDATA[EPIC MOS2 flux                          ]]></TD>
+<TD><![CDATA[From new raw data; NED frequency assigned to mid-point ofband in keV]]></TD>
+</TR>
+<TR>
+<TD>8</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 1.06E-13  </TD>
+<TD>9E-15</TD>
+<TD>erg/cm^2^/s         </TD>
+<TD>5.68E+17</TD>
+<TD>  1.87E-08</TD>
+<TD>1.58E-09</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2011A&amp;A...534A..55S</TD>
+<TD>uncertainty</TD>
+<TD>      2.35 keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.48 +41 16 08.4 (J2000)</TD>
+<TD> Modelled datum</TD>
+<TD><![CDATA[EPIC MOS1 flux                          ]]></TD>
+<TD><![CDATA[From new raw data; NED frequency assigned to mid-point ofband in keV]]></TD>
+</TR>
+<TR>
+<TD>9</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 1.07E-13  </TD>
+<TD>4E-15</TD>
+<TD>erg/cm^2^/s         </TD>
+<TD>5.68E+17</TD>
+<TD>  1.88E-08</TD>
+<TD>7.04E-10</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2011A&amp;A...534A..55S</TD>
+<TD>uncertainty</TD>
+<TD>      2.35 keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.48 +41 16 08.4 (J2000)</TD>
+<TD> Modelled datum</TD>
+<TD><![CDATA[Combined EPIC flux                      ]]></TD>
+<TD><![CDATA[From new raw data; NED frequency assigned to mid-point ofband in keV]]></TD>
+</TR>
+<TR>
+<TD>10</TD>
+<TD>0.2-4.5 keV (XMM)   </TD>
+<TD> 9.56E-14  </TD>
+<TD>6E-15</TD>
+<TD>erg/cm^2^/s         </TD>
+<TD>5.68E+17</TD>
+<TD>  1.68E-08</TD>
+<TD>1.06E-09</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2011A&amp;A...534A..55S</TD>
+<TD>uncertainty</TD>
+<TD>      2.35 keV       </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.48 +41 16 08.4 (J2000)</TD>
+<TD> Modelled datum</TD>
+<TD><![CDATA[EPIC pn flux                            ]]></TD>
+<TD><![CDATA[From new raw data; NED frequency assigned to mid-point ofband in keV]]></TD>
+</TR>
+<TR>
+<TD>11</TD>
+<TD>1482A (IUE)         </TD>
+<TD> 0.83E-14  </TD>
+<TD>0.14E-14</TD>
+<TD>ergs cm^-2 s^-1 A^-1</TD>
+<TD>2.02E+15</TD>
+<TD>  6.09E-04</TD>
+<TD>1.03E-04</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1993ApJS...86....5K</TD>
+<TD>uncertainty</TD>
+<TD>    1482   A         </TD>
+<TD> Broad-band measurement; flux integrated over line</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[20"x10" aperture                        ]]></TD>
+<TD><![CDATA[Averaged from new and transformed previously published data]]></TD>
+</TR>
+<TR>
+<TD>12</TD>
+<TD>FUV (GALEX) AB      </TD>
+<TD> 8.83      </TD>
+<TD>0.01 </TD>
+<TD> mag                </TD>
+<TD>1.98E+15</TD>
+<TD>  1.07E+00</TD>
+<TD>9.82E-03</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2007ApJS..173..185G</TD>
+<TD>uncertainty</TD>
+<TD>      1516 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.3 +41 16 08.5 (J2000)</TD>
+<TD> Total flux</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>13</TD>
+<TD>1913A (IUE)         </TD>
+<TD> 0.61E-14  </TD>
+<TD>0.07E-14</TD>
+<TD>ergs cm^-2 s^-1 A^-1</TD>
+<TD>1.57E+15</TD>
+<TD>  7.46E-04</TD>
+<TD>8.56E-05</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1993ApJS...86....5K</TD>
+<TD>uncertainty</TD>
+<TD>    1913   A         </TD>
+<TD> Broad-band measurement; flux integrated over line</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[20"x10" aperture                        ]]></TD>
+<TD><![CDATA[Averaged from new and transformed previously published data]]></TD>
+</TR>
+<TR>
+<TD>14</TD>
+<TD>NUV (GALEX) AB      </TD>
+<TD> 8.00      </TD>
+<TD>0.01 </TD>
+<TD> mag                </TD>
+<TD>1.32E+15</TD>
+<TD>  2.29E+00</TD>
+<TD>2.11E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2007ApJS..173..185G</TD>
+<TD>uncertainty</TD>
+<TD>      2267 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>00 42 44.3 +41 16 08.5 (J2000)</TD>
+<TD> Total flux</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>15</TD>
+<TD>2373A (IUE)         </TD>
+<TD> 0.45E-14  </TD>
+<TD>0.17E-14</TD>
+<TD>ergs cm^-2 s^-1 A^-1</TD>
+<TD>1.26E+15</TD>
+<TD>  8.46E-04</TD>
+<TD>3.20E-04</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1993ApJS...86....5K</TD>
+<TD>uncertainty</TD>
+<TD>    2373   A         </TD>
+<TD> Broad-band measurement; flux integrated over line</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[20"x10" aperture                        ]]></TD>
+<TD><![CDATA[Averaged from new and transformed previously published data]]></TD>
+</TR>
+<TR>
+<TD>16</TD>
+<TD>2700A (IUE)         </TD>
+<TD> 1.09E-14  </TD>
+<TD>0.14E-14</TD>
+<TD>ergs cm^-2 s^-1 A^-1</TD>
+<TD>1.11E+15</TD>
+<TD>  2.65E-03</TD>
+<TD>3.41E-04</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1993ApJS...86....5K</TD>
+<TD>uncertainty</TD>
+<TD>    2700   A         </TD>
+<TD> Broad-band measurement; flux integrated over line</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[20"x10" aperture                        ]]></TD>
+<TD><![CDATA[Averaged from new and transformed previously published data]]></TD>
+</TR>
+<TR>
+<TD>17</TD>
+<TD>U (U_T^0)           </TD>
+<TD> 3.67      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>8.19E+14</TD>
+<TD>  6.16E+01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>no uncertainty reported</TD>
+<TD>3660       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data;Extinction-corrected for internal and Milky Way andK-correction applied; Standard Johnson UBVRI filtersassumed]]></TD>
+</TR>
+<TR>
+<TD>18</TD>
+<TD>U (U_T)             </TD>
+<TD> 4.86      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>8.19E+14</TD>
+<TD>  2.06E+01</TD>
+<TD>5.43E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>rms uncertainty</TD>
+<TD>3660       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data; StandardJohnson UBVRI filters assumed]]></TD>
+</TR>
+<TR>
+<TD>19</TD>
+<TD>B (B_T)             </TD>
+<TD> 4.36      </TD>
+<TD>0.02 </TD>
+<TD>mag                 </TD>
+<TD>6.81E+14</TD>
+<TD>  7.68E+01</TD>
+<TD>1.43E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>rms uncertainty</TD>
+<TD>4400       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data; StandardJohnson UBVRI filters assumed]]></TD>
+</TR>
+<TR>
+<TD>20</TD>
+<TD>m_p                 </TD>
+<TD> 4.3       </TD>
+<TD>0.4  </TD>
+<TD>mag                 </TD>
+<TD>6.81E+14</TD>
+<TD>  8.12E+01</TD>
+<TD>3.62E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1968CGCG6.C...0000Z</TD>
+<TD>rms noise</TD>
+<TD>4400       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.0 +410000. (B1950)</TD>
+<TD> Estimated by eye</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>21</TD>
+<TD>B (B_T^0)           </TD>
+<TD> 3.36      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>6.81E+14</TD>
+<TD>  1.93E+02</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>no uncertainty reported</TD>
+<TD>4400       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data;Extinction-corrected for internal and Milky Way andK-correction applied; Standard Johnson UBVRI filtersassumed]]></TD>
+</TR>
+<TR>
+<TD>22</TD>
+<TD>B (m_B)             </TD>
+<TD> 4.16      </TD>
+<TD>0.19 </TD>
+<TD>mag                 </TD>
+<TD>6.81E+14</TD>
+<TD>  9.23E+01</TD>
+<TD>1.77E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>rms uncertainty</TD>
+<TD>4400       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data; StandardJohnson UBVRI filters assumed]]></TD>
+</TR>
+<TR>
+<TD>23</TD>
+<TD>V (Johnson)         </TD>
+<TD> 7.96      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  2.38E+00</TD>
+<TD>6.68E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1961AJ.....66..390T</TD>
+<TD>uncertainty</TD>
+<TD>      5530 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[64.3" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>24</TD>
+<TD>V (Johnson)         </TD>
+<TD> 8.86      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  1.04E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1966ApJ...143..187J</TD>
+<TD>no uncertainty reported</TD>
+<TD>      5530 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[35" aperture; low quality data          ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>25</TD>
+<TD>V (Johnson)         </TD>
+<TD> 11.34     </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  1.06E-01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>no uncertainty reported</TD>
+<TD>      5530 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[7.62" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>26</TD>
+<TD>V (Johnson)         </TD>
+<TD> 12.05     </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  5.51E-02</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>no uncertainty reported</TD>
+<TD>      5530 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[4.86" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>27</TD>
+<TD>V (Johnson)         </TD>
+<TD> 9.68      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  4.89E-01</TD>
+<TD>1.37E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1961AJ.....66..390T</TD>
+<TD>uncertainty</TD>
+<TD>      5530 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[20.8" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>28</TD>
+<TD>V (Johnson)         </TD>
+<TD> 8.86      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  1.04E+00</TD>
+<TD>2.91E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1961AJ.....66..390T</TD>
+<TD>uncertainty</TD>
+<TD>      5530 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[36.2" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>29</TD>
+<TD>V (V_T^0)           </TD>
+<TD> 2.68      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  3.08E+02</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>no uncertainty reported</TD>
+<TD>5530       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data;Extinction-corrected for internal and Milky Way andK-correction applied; Standard Johnson UBVRI filtersassumed]]></TD>
+</TR>
+<TR>
+<TD>30</TD>
+<TD>V (V_T)             </TD>
+<TD> 3.44      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>5.42E+14</TD>
+<TD>  1.53E+02</TD>
+<TD>4.04E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>rms uncertainty</TD>
+<TD>5530       A         </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data; StandardJohnson UBVRI filters assumed]]></TD>
+</TR>
+<TR>
+<TD>31</TD>
+<TD>H{alpha}+[NII]      </TD>
+<TD> -9.3      </TD>
+<TD>0.12 </TD>
+<TD> log(ergs/cm^2^/s)  </TD>
+<TD>4.56E+14</TD>
+<TD>  5.01E+13</TD>
+<TD>1.38E+13</TD>
+<TD>Jy-Hz</TD>
+<TD>2008ApJS..178..247K</TD>
+<TD>1 sigma</TD>
+<TD>    6573.5 A         </TD>
+<TD> Line measurement; flux integrated over line; lines measured in emission</TD>
+<TD>00 42 44.3 +41 16 09 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>32</TD>
+<TD>R (Johnson)         </TD>
+<TD> 11.14     </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>4.28E+14</TD>
+<TD>  9.73E-02</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>no uncertainty reported</TD>
+<TD>      7000 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[4.86" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>33</TD>
+<TD>R (Johnson)         </TD>
+<TD> 10.42     </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>4.28E+14</TD>
+<TD>  1.89E-01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>no uncertainty reported</TD>
+<TD>      7000 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[7.62" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>34</TD>
+<TD>I (Johnson)         </TD>
+<TD> 6.98      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>3.33E+14</TD>
+<TD>  3.62E+00</TD>
+<TD>1.01E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1961AJ.....66..390T</TD>
+<TD>uncertainty</TD>
+<TD>      9000 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[36.2" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>35</TD>
+<TD>I (Johnson)         </TD>
+<TD> 7.88      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>3.33E+14</TD>
+<TD>  1.58E+00</TD>
+<TD>4.42E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1961AJ.....66..390T</TD>
+<TD>uncertainty</TD>
+<TD>      9000 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[20.8" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>36</TD>
+<TD>I (Johnson)         </TD>
+<TD> 10.1      </TD>
+<TD>0.10 </TD>
+<TD>mag                 </TD>
+<TD>3.33E+14</TD>
+<TD>  2.04E-01</TD>
+<TD>1.97E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>      9000 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[5.0" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>37</TD>
+<TD>I (Johnson)         </TD>
+<TD> 6.01      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>3.33E+14</TD>
+<TD>  8.84E+00</TD>
+<TD>2.48E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1961AJ.....66..390T</TD>
+<TD>uncertainty</TD>
+<TD>      9000 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[64.3" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>38</TD>
+<TD>I (Johnson)         </TD>
+<TD> 7.18      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>3.33E+14</TD>
+<TD>  3.01E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1966ApJ...143..187J</TD>
+<TD>no uncertainty reported</TD>
+<TD>      9000 A         </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[35" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>39</TD>
+<TD>J (Johnson)         </TD>
+<TD> 5.85      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>2.42E+14</TD>
+<TD>  7.33E+00</TD>
+<TD>4.16E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.24    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[47.5" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; Corrected for flux in reference beam;derived from a flux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>40</TD>
+<TD>J (Johnson)         </TD>
+<TD> 6.80      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.42E+14</TD>
+<TD>  3.05E+00</TD>
+<TD>8.56E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.24    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[27.4" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>41</TD>
+<TD>J (Johnson)         </TD>
+<TD> 4.72      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.42E+14</TD>
+<TD>  2.08E+01</TD>
+<TD>5.81E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.24    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[105" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>42</TD>
+<TD>J (Johnson)         </TD>
+<TD> 5.70      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.42E+14</TD>
+<TD>  8.41E+00</TD>
+<TD>2.36E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.24    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[53.3" aperture                          ]]></TD>
+<TD><![CDATA[Averaged new and previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>43</TD>
+<TD>J (Johnson)         </TD>
+<TD> 7.97      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>2.42E+14</TD>
+<TD>  1.04E+00</TD>
+<TD>5.91E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.24    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[13.7" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>44</TD>
+<TD>J_20 (2MASS LGA)    </TD>
+<TD> 2.149     </TD>
+<TD>0.015</TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  2.20E+02</TD>
+<TD>3.06E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.25      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[3229.4 x 1811.7 arcsec integration area.]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>45</TD>
+<TD>J_Kron (2MASS LGA)  </TD>
+<TD> 2.191     </TD>
+<TD>0.015</TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  2.12E+02</TD>
+<TD>2.94E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.25      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[2680.4 x 1503.7 arcsec integration area.]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>46</TD>
+<TD>J_tot (2MASS LGA)   </TD>
+<TD> 2.094     </TD>
+<TD>0.016</TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  2.31E+02</TD>
+<TD>3.44E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.25      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Total flux</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>47</TD>
+<TD>J_14arcsec (2MASS)  </TD>
+<TD> 8.009     </TD>
+<TD>0.015</TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  9.96E-01</TD>
+<TD>1.39E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>20032MASX.C.......:</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.25      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[14.0 x 14.0 arcsec aperture             ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>48</TD>
+<TD>1.25 microns        </TD>
+<TD> 1.9       </TD>
+<TD>0.1  </TD>
+<TD>Jy                  </TD>
+<TD>2.40E+14</TD>
+<TD>  1.90E+00</TD>
+<TD>1.00E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1970ApJ...159L.165K</TD>
+<TD>no uncertainty reported</TD>
+<TD>      1.25 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>49</TD>
+<TD>J (CIT)             </TD>
+<TD> 6.76      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  3.01E+00</TD>
+<TD>8.42E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.25    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[27.4" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>50</TD>
+<TD>J (CIT)             </TD>
+<TD> 5.80      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  7.28E+00</TD>
+<TD>2.04E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.25    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[47.5" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>51</TD>
+<TD>J (CIT)             </TD>
+<TD> 5.66      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  8.28E+00</TD>
+<TD>2.32E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.25    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[53.3" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>52</TD>
+<TD>J (CIT)             </TD>
+<TD> 4.68      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  2.04E+01</TD>
+<TD>5.72E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.25    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[107.1" aperture                         ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>53</TD>
+<TD>J (CIT)             </TD>
+<TD> 7.93      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>2.40E+14</TD>
+<TD>  1.02E+00</TD>
+<TD>2.87E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.25    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[13.7" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>54</TD>
+<TD>J (Johnson)         </TD>
+<TD> 8.4       </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>2.38E+14</TD>
+<TD>  7.00E-01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988VIrPh.C...0000d</TD>
+<TD>no uncertainty reported</TD>
+<TD>    1.26   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[16" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>55</TD>
+<TD>J (Johnson)         </TD>
+<TD> 6.57      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>2.38E+14</TD>
+<TD>  3.78E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1966ApJ...143..187J</TD>
+<TD>no uncertainty reported</TD>
+<TD>      1.26 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[35" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>56</TD>
+<TD>H (Johnson)         </TD>
+<TD> 7.6       </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>1.87E+14</TD>
+<TD>  9.80E-01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988VIrPh.C...0000d</TD>
+<TD>no uncertainty reported</TD>
+<TD>     1.6   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[16" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>57</TD>
+<TD>H_20 (2MASS LGA)    </TD>
+<TD> 1.331     </TD>
+<TD>0.016</TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  3.01E+02</TD>
+<TD>4.46E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.65      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[3229.4 x 1811.7 arcsec integration area.]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>58</TD>
+<TD>H_Kron (2MASS LGA)  </TD>
+<TD> 1.374     </TD>
+<TD>0.015</TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  2.89E+02</TD>
+<TD>4.02E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.65      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[2680.4 x 1503.7 arcsec integration area.]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>59</TD>
+<TD>H_tot (2MASS LGA)   </TD>
+<TD> 1.283     </TD>
+<TD>0.017</TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  3.14E+02</TD>
+<TD>4.96E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.65      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Total flux</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>60</TD>
+<TD>H_14arcsec (2MASS)  </TD>
+<TD> 7.054     </TD>
+<TD>0.015</TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.54E+00</TD>
+<TD>2.15E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>20032MASX.C.......:</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 1.65      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[14.0 x 14.0 arcsec aperture             ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>61</TD>
+<TD>H (Johnson)         </TD>
+<TD> 7.19      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.43E+00</TD>
+<TD>8.13E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[13.7" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>62</TD>
+<TD>H (Johnson)         </TD>
+<TD> 4.93      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.15E+01</TD>
+<TD>3.21E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[53.3" aperture                          ]]></TD>
+<TD><![CDATA[Averaged new and previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>63</TD>
+<TD>H (Johnson)         </TD>
+<TD> 5.06      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.02E+01</TD>
+<TD>5.78E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[47.5" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; Corrected for flux in reference beam;derived from a flux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>64</TD>
+<TD>H (Johnson)         </TD>
+<TD> 3.94      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  2.85E+01</TD>
+<TD>7.99E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[105" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>65</TD>
+<TD>H (Johnson)         </TD>
+<TD> 6.04      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  4.12E+00</TD>
+<TD>1.16E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[27.4" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>66</TD>
+<TD>H (HCO)             </TD>
+<TD> 1.89      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.77E+02</TD>
+<TD>4.96E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[798" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>67</TD>
+<TD>H (HCO)             </TD>
+<TD> 1.60      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  2.31E+02</TD>
+<TD>6.48E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[1207" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>68</TD>
+<TD>H (HCO)             </TD>
+<TD> 3.06      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  6.03E+01</TD>
+<TD>1.69E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[212.8" aperture                         ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>69</TD>
+<TD>H (HCO)             </TD>
+<TD> 2.56      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  9.56E+01</TD>
+<TD>2.68E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[368" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>70</TD>
+<TD>H (HCO)             </TD>
+<TD> 2.38      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.13E+02</TD>
+<TD>3.16E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[409.6" aperture                         ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>71</TD>
+<TD>H (HCO)             </TD>
+<TD> 3.44      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  4.25E+01</TD>
+<TD>1.19E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[154.3" aperture                         ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>72</TD>
+<TD>H (HCO)             </TD>
+<TD> 1.42      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  2.73E+02</TD>
+<TD>7.65E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[1554" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>73</TD>
+<TD>H (HCO)             </TD>
+<TD> 2.63      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  8.96E+01</TD>
+<TD>2.51E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[316.5" aperture                         ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>74</TD>
+<TD>H (HCO)             </TD>
+<TD> 4.10      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  2.31E+01</TD>
+<TD>6.48E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...237..655A</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[101.1" aperture                         ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>75</TD>
+<TD>H (CIT)             </TD>
+<TD> 6.06      </TD>
+<TD>0.02 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  3.69E+00</TD>
+<TD>6.86E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[27.4" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>76</TD>
+<TD>H (CIT)             </TD>
+<TD> 7.21      </TD>
+<TD>0.02 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.28E+00</TD>
+<TD>2.38E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[13.7" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>77</TD>
+<TD>H (CIT)             </TD>
+<TD> 3.96      </TD>
+<TD>0.02 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  2.55E+01</TD>
+<TD>4.75E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[107.1" aperture                         ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>78</TD>
+<TD>H (CIT)             </TD>
+<TD> 4.95      </TD>
+<TD>0.02 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.03E+01</TD>
+<TD>1.91E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[53.3" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>79</TD>
+<TD>H (CIT)             </TD>
+<TD> 5.07      </TD>
+<TD>0.02 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  9.19E+00</TD>
+<TD>1.71E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   1.65    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[47.5" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data; derived from aflux in a different band and a color]]></TD>
+</TR>
+<TR>
+<TD>80</TD>
+<TD>H (CIT)             </TD>
+<TD> 6.96      </TD>
+<TD>0.12 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  1.81E+00</TD>
+<TD>2.11E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>      1.65 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[15" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>81</TD>
+<TD>H (CIT)             </TD>
+<TD> 8.22      </TD>
+<TD>0.10 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  5.67E-01</TD>
+<TD>5.47E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>      1.65 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[7.5" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>82</TD>
+<TD>H (CIT)             </TD>
+<TD> 8.88      </TD>
+<TD>0.15 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  3.09E-01</TD>
+<TD>4.57E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>      1.65 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[5.0" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>83</TD>
+<TD>H (CIT)             </TD>
+<TD> 5.85      </TD>
+<TD>0.10 </TD>
+<TD>mag                 </TD>
+<TD>1.82E+14</TD>
+<TD>  5.03E+00</TD>
+<TD>4.85E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>      1.65 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[30" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>84</TD>
+<TD>K_20 (2MASS LGA)    </TD>
+<TD> 1.038     </TD>
+<TD>0.016</TD>
+<TD>mag                 </TD>
+<TD>1.38E+14</TD>
+<TD>  2.56E+02</TD>
+<TD>3.81E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 2.17      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[3229.4 x 1811.7 arcsec integration area.]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>85</TD>
+<TD>K_Kron (2MASS LGA)  </TD>
+<TD> 1.087     </TD>
+<TD>0.015</TD>
+<TD>mag                 </TD>
+<TD>1.38E+14</TD>
+<TD>  2.45E+02</TD>
+<TD>3.41E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 2.17      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[2680.4 x 1503.7 arcsec integration area.]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>86</TD>
+<TD>K_tot (2MASS LGA)   </TD>
+<TD> 0.984     </TD>
+<TD>0.017</TD>
+<TD>mag                 </TD>
+<TD>1.38E+14</TD>
+<TD>  2.69E+02</TD>
+<TD>4.25E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2003AJ....125..525J</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 2.17      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Total flux</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>87</TD>
+<TD>K_s_14arcsec (2MASS)</TD>
+<TD> 6.793     </TD>
+<TD>0.015</TD>
+<TD>mag                 </TD>
+<TD>1.38E+14</TD>
+<TD>  1.28E+00</TD>
+<TD>1.78E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>20032MASX.C.......:</TD>
+<TD>1 sigma uncert.</TD>
+<TD> 2.17      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004244.33 +411607.5 (J2000)</TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[14.0 x 14.0 arcsec aperture             ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>88</TD>
+<TD>K (CIT)             </TD>
+<TD> 6.93      </TD>
+<TD>0.15 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  1.06E+00</TD>
+<TD>1.58E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[15" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>89</TD>
+<TD>K (CIT)             </TD>
+<TD> 8.57      </TD>
+<TD>0.12 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  2.35E-01</TD>
+<TD>2.75E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[5.0" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>90</TD>
+<TD>K (CIT)             </TD>
+<TD> 5.69      </TD>
+<TD>0.10 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  3.34E+00</TD>
+<TD>3.22E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[30" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>91</TD>
+<TD>K (CIT)             </TD>
+<TD> 8.05      </TD>
+<TD>0.07 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  3.80E-01</TD>
+<TD>2.53E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[7.5" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>92</TD>
+<TD>K (CIT)             </TD>
+<TD> 6.82      </TD>
+<TD>0.12 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  1.18E+00</TD>
+<TD>1.38E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[15" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>93</TD>
+<TD>K (CIT)             </TD>
+<TD> 4.96      </TD>
+<TD>0.08 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  6.54E+00</TD>
+<TD>5.00E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[47" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>94</TD>
+<TD>K (CIT)             </TD>
+<TD> 3.72      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  2.02E+01</TD>
+<TD>5.65E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[107.1" aperture                         ]]></TD>
+<TD><![CDATA[Transformed from previously published data]]></TD>
+</TR>
+<TR>
+<TD>95</TD>
+<TD>K (CIT)             </TD>
+<TD> 6.29      </TD>
+<TD>0.05 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  1.89E+00</TD>
+<TD>8.91E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[20.0" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>96</TD>
+<TD>K (CIT)             </TD>
+<TD> 6.95      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  1.03E+00</TD>
+<TD>5.85E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[13.7" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data]]></TD>
+</TR>
+<TR>
+<TD>97</TD>
+<TD>K (CIT)             </TD>
+<TD> 4.71      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  8.10E+00</TD>
+<TD>2.27E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[53.3" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data]]></TD>
+</TR>
+<TR>
+<TD>98</TD>
+<TD>K (CIT)             </TD>
+<TD> 8.24      </TD>
+<TD>0.07 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  3.14E-01</TD>
+<TD>2.09E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[5.0" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>99</TD>
+<TD>K (CIT)             </TD>
+<TD> 9.11      </TD>
+<TD>0.12 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  1.41E-01</TD>
+<TD>1.64E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[2.5" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>100</TD>
+<TD>K (CIT)             </TD>
+<TD> 4.83      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  7.25E+00</TD>
+<TD>4.12E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[47.5" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data]]></TD>
+</TR>
+<TR>
+<TD>101</TD>
+<TD>K (CIT)             </TD>
+<TD> 7.36      </TD>
+<TD>0.07 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  7.05E-01</TD>
+<TD>4.70E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[10.0" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>102</TD>
+<TD>K (CIT)             </TD>
+<TD> 5.81      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.36E+14</TD>
+<TD>  2.94E+00</TD>
+<TD>8.24E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1980ApJ...240..779P</TD>
+<TD>uncertainty</TD>
+<TD>   2.20    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[27.4" aperture                          ]]></TD>
+<TD><![CDATA[Transformed from previously published data]]></TD>
+</TR>
+<TR>
+<TD>103</TD>
+<TD>2.2 microns         </TD>
+<TD> 1.4       </TD>
+<TD>0.1  </TD>
+<TD>Jy                  </TD>
+<TD>1.36E+14</TD>
+<TD>  1.40E+00</TD>
+<TD>1.00E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1970ApJ...159L.165K</TD>
+<TD>no uncertainty reported</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>104</TD>
+<TD>2.2 microns         </TD>
+<TD> 2         </TD>
+<TD>0.1  </TD>
+<TD>Jy                  </TD>
+<TD>1.36E+14</TD>
+<TD>  2.00E+00</TD>
+<TD>1.00E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1970ApJ...159L.165K</TD>
+<TD>no uncertainty reported</TD>
+<TD>       2.2 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>105</TD>
+<TD>K (Johnson)         </TD>
+<TD> 4.83      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>1.35E+14</TD>
+<TD>  7.80E+00</TD>
+<TD>4.43E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   2.22    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[47.5" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data; Corrected for flux in reference beam]]></TD>
+</TR>
+<TR>
+<TD>106</TD>
+<TD>K (Johnson)         </TD>
+<TD> 6.95      </TD>
+<TD>0.06 </TD>
+<TD>mag                 </TD>
+<TD>1.35E+14</TD>
+<TD>  1.11E+00</TD>
+<TD>6.29E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   2.22    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[13.7" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>107</TD>
+<TD>K (Johnson)         </TD>
+<TD> 3.72      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.35E+14</TD>
+<TD>  2.17E+01</TD>
+<TD>6.08E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   2.22    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[105" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>108</TD>
+<TD>K (Johnson)         </TD>
+<TD> 5.81      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.35E+14</TD>
+<TD>  3.16E+00</TD>
+<TD>8.86E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   2.22    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[27.4" aperture                          ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>109</TD>
+<TD>K (Johnson)         </TD>
+<TD> 7.2       </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>1.35E+14</TD>
+<TD>  8.79E-01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988VIrPh.C...0000d</TD>
+<TD>no uncertainty reported</TD>
+<TD>    2.22   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[16" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>110</TD>
+<TD>K (Johnson)         </TD>
+<TD> 4.71      </TD>
+<TD>0.03 </TD>
+<TD>mag                 </TD>
+<TD>1.35E+14</TD>
+<TD>  8.71E+00</TD>
+<TD>2.44E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1977HarvU.T00M....A</TD>
+<TD>uncertainty</TD>
+<TD>   2.22    microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[53.3" aperture                          ]]></TD>
+<TD><![CDATA[Averaged new and previously published data]]></TD>
+</TR>
+<TR>
+<TD>111</TD>
+<TD>K (Johnson)         </TD>
+<TD> 5.64      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>1.35E+14</TD>
+<TD>  3.70E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1966ApJ...143..187J</TD>
+<TD>no uncertainty reported</TD>
+<TD>      2.22 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[35" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>112</TD>
+<TD>3.4 microns         </TD>
+<TD> 0.65      </TD>
+<TD>.07  </TD>
+<TD>Jy                  </TD>
+<TD>8.82E+13</TD>
+<TD>  6.50E-01</TD>
+<TD>7.00E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1970ApJ...159L.165K</TD>
+<TD>no uncertainty reported</TD>
+<TD>       3.4 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>113</TD>
+<TD>3.4 microns         </TD>
+<TD> 1         </TD>
+<TD>0.05 </TD>
+<TD>Jy                  </TD>
+<TD>8.82E+13</TD>
+<TD>  1.00E+00</TD>
+<TD>5.00E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1970ApJ...159L.165K</TD>
+<TD>no uncertainty reported</TD>
+<TD>       3.4 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>114</TD>
+<TD>L (CIT)             </TD>
+<TD> 6.54      </TD>
+<TD>0.20 </TD>
+<TD>mag                 </TD>
+<TD>8.82E+13</TD>
+<TD>  7.51E-01</TD>
+<TD>1.52E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       3.4 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[15" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>115</TD>
+<TD>L (CIT)             </TD>
+<TD> 5.3       </TD>
+<TD>0.17 </TD>
+<TD>mag                 </TD>
+<TD>8.82E+13</TD>
+<TD>  2.35E+00</TD>
+<TD>3.99E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1969ApJ...157...55S</TD>
+<TD>uncertainty</TD>
+<TD>       3.4 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[30" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>116</TD>
+<TD>L (Johnson)         </TD>
+<TD> 7.2       </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>8.47E+13</TD>
+<TD>  3.80E-01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988VIrPh.C...0000d</TD>
+<TD>no uncertainty reported</TD>
+<TD>    3.54   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[16" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>117</TD>
+<TD>L (Johnson)         </TD>
+<TD> 5.68      </TD>
+<TD></TD>
+<TD>mag                 </TD>
+<TD>8.47E+13</TD>
+<TD>  1.54E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1966ApJ...143..187J</TD>
+<TD>no uncertainty reported</TD>
+<TD>      3.54 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[35" aperture                            ]]></TD>
+<TD><![CDATA[From new raw data; derived from a flux in a different bandand a color]]></TD>
+</TR>
+<TR>
+<TD>118</TD>
+<TD>3.55 microns (IRAC) </TD>
+<TD> 239       </TD>
+<TD>29   </TD>
+<TD>Jy                  </TD>
+<TD>8.44E+13</TD>
+<TD>  2.39E+02</TD>
+<TD>2.90E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2009A&amp;A...507..283M</TD>
+<TD>uncertainty</TD>
+<TD>      3.55 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>119</TD>
+<TD>5 microns           </TD>
+<TD> 0.059     </TD>
+<TD>0.016</TD>
+<TD>Jy                  </TD>
+<TD>6.25E+13</TD>
+<TD>  5.90E-02</TD>
+<TD>1.60E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1978ApJ...220L..37R</TD>
+<TD>uncertainty</TD>
+<TD>   4.8     microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[5.9" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>120</TD>
+<TD>7.87 microns (IRAC) </TD>
+<TD> 149       </TD>
+<TD>27   </TD>
+<TD>Jy                  </TD>
+<TD>3.81E+13</TD>
+<TD>  1.49E+02</TD>
+<TD>2.70E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2009A&amp;A...507..283M</TD>
+<TD>uncertainty</TD>
+<TD>      7.87 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>121</TD>
+<TD>10 microns          </TD>
+<TD> 0.025     </TD>
+<TD>0.008</TD>
+<TD>Jy                  </TD>
+<TD>3.00E+13</TD>
+<TD>  2.50E-02</TD>
+<TD>8.00E-03</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1978ApJ...220L..37R</TD>
+<TD>uncertainty</TD>
+<TD>   10      microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[5.7" aperture                           ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>122</TD>
+<TD>12 microns (IRAS)   </TD>
+<TD> 163.23    </TD>
+<TD>15  %</TD>
+<TD>Jy                  </TD>
+<TD>2.50E+13</TD>
+<TD>  1.63E+02</TD>
+<TD>2.45E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988ApJS...68...91R</TD>
+<TD>uncertainty</TD>
+<TD>      12   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>123</TD>
+<TD>12 microns (IRAS)   </TD>
+<TD> 1.698E+00 </TD>
+<TD>13  %</TD>
+<TD>Jy                  </TD>
+<TD>2.50E+13</TD>
+<TD>  1.70E+00</TD>
+<TD>2.21E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1990IRASF.C...0000M</TD>
+<TD>uncertainty</TD>
+<TD> 12        microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.6 +405947 (B1950)</TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[IRAS quality flag = 2                   ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>124</TD>
+<TD>24 microns (MIPS)   </TD>
+<TD> 94        </TD>
+<TD></TD>
+<TD>Jy                  </TD>
+<TD>1.27E+13</TD>
+<TD>  9.40E+01</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>2005ApJ...628L..29E</TD>
+<TD>no uncertainty reported</TD>
+<TD>   23.68   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[Transformed from previously published data]]></TD>
+</TR>
+<TR>
+<TD>125</TD>
+<TD>24 microns (MIPS)   </TD>
+<TD> 119       </TD>
+<TD>7    </TD>
+<TD>Jy                  </TD>
+<TD>1.27E+13</TD>
+<TD>  1.19E+02</TD>
+<TD>7.00E+00</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2010A&amp;A...509A..91T</TD>
+<TD>uncertainty</TD>
+<TD>    23.68  microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>126</TD>
+<TD>23.7 microns (MIPS) </TD>
+<TD> 118       </TD>
+<TD>17   </TD>
+<TD>Jy                  </TD>
+<TD>1.26E+13</TD>
+<TD>  1.18E+02</TD>
+<TD>1.70E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2009A&amp;A...507..283M</TD>
+<TD>uncertainty</TD>
+<TD>      23.7 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>127</TD>
+<TD>25 microns (IRAS)   </TD>
+<TD> 1.020E+00 </TD>
+<TD>6   %</TD>
+<TD>Jy                  </TD>
+<TD>1.20E+13</TD>
+<TD>  1.02E+00</TD>
+<TD>1.02E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1990IRASF.C...0000M</TD>
+<TD>uncertainty</TD>
+<TD> 25        microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.6 +405947 (B1950)</TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[IRAS quality flag = 3                   ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>128</TD>
+<TD>25 microns (IRAS)   </TD>
+<TD> 107.71    </TD>
+<TD>15  %</TD>
+<TD>Jy                  </TD>
+<TD>1.20E+13</TD>
+<TD>  1.08E+02</TD>
+<TD>1.62E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988ApJS...68...91R</TD>
+<TD>uncertainty</TD>
+<TD>      25   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>129</TD>
+<TD>60 microns (IRAS)   </TD>
+<TD> 1.079E+01 </TD>
+<TD>6   %</TD>
+<TD>Jy                  </TD>
+<TD>5.00E+12</TD>
+<TD>  1.08E+01</TD>
+<TD>6.47E-01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1990IRASF.C...0000M</TD>
+<TD>uncertainty</TD>
+<TD> 60        microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.6 +405947 (B1950)</TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[IRAS quality flag = 2                   ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>130</TD>
+<TD>60 microns (IRAS)   </TD>
+<TD> 536.18    </TD>
+<TD>15  %</TD>
+<TD>Jy                  </TD>
+<TD>5.00E+12</TD>
+<TD>  5.36E+02</TD>
+<TD>8.04E+01</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988ApJS...68...91R</TD>
+<TD>uncertainty</TD>
+<TD>      60   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>131</TD>
+<TD>71.4 microns (MIPS) </TD>
+<TD> 1086      </TD>
+<TD>256  </TD>
+<TD>Jy                  </TD>
+<TD>4.20E+12</TD>
+<TD>  1.09E+03</TD>
+<TD>2.56E+02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2009A&amp;A...507..283M</TD>
+<TD>uncertainty</TD>
+<TD>      71.4 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>132</TD>
+<TD>70 microns (MIPS)   </TD>
+<TD> 1200      </TD>
+<TD>110  </TD>
+<TD>Jy                  </TD>
+<TD>4.20E+12</TD>
+<TD>  1.20E+03</TD>
+<TD>1.10E+02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2010A&amp;A...509A..91T</TD>
+<TD>uncertainty</TD>
+<TD>    71.42  microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>133</TD>
+<TD>FIR (IRAS)          </TD>
+<TD> 5.43E-11  </TD>
+<TD></TD>
+<TD>W m^-2^             </TD>
+<TD>3.63E+12</TD>
+<TD>  1.49E+03</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988ApJS...68...91R</TD>
+<TD>no uncertainty reported</TD>
+<TD>      82.5 microns   </TD>
+<TD> Broad-band measurement; synthetic band</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>134</TD>
+<TD>100 microns (IRAS)  </TD>
+<TD> 2928.40   </TD>
+<TD>15  %</TD>
+<TD>Jy                  </TD>
+<TD>3.00E+12</TD>
+<TD>  2.93E+03</TD>
+<TD>4.39E+02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1988ApJS...68...91R</TD>
+<TD>uncertainty</TD>
+<TD>     100   microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>135</TD>
+<TD>100 microns (IRAS)  </TD>
+<TD></TD>
+<TD>&lt;1.409E+02 </TD>
+<TD>Jy                  </TD>
+<TD>3.00E+12</TD>
+<TD></TD>
+<TD></TD>
+<TD>1.41E+02</TD><TD>Jy</TD>
+<TD>1990IRASF.C...0000M</TD>
+<TD>90% confidence</TD>
+<TD> 100       microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.6 +405947 (B1950)</TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>136</TD>
+<TD>155.9 microns (MIPS)</TD>
+<TD> 7315      </TD>
+<TD>1632 </TD>
+<TD>Jy                  </TD>
+<TD>1.92E+12</TD>
+<TD>  7.32E+03</TD>
+<TD>1.63E+03</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2009A&amp;A...507..283M</TD>
+<TD>uncertainty</TD>
+<TD>     155.9 microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>137</TD>
+<TD>160 microns (MIPS)  </TD>
+<TD> 7800      </TD>
+<TD>1000 </TD>
+<TD>Jy                  </TD>
+<TD>1.92E+12</TD>
+<TD>  7.80E+03</TD>
+<TD>1.00E+03</TD>
+<TD></TD><TD>Jy</TD>
+<TD>2010A&amp;A...509A..91T</TD>
+<TD>uncertainty</TD>
+<TD>    155.9  microns   </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux in fixed aperture</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>138</TD>
+<TD>4.85 GHz            </TD>
+<TD> 36        </TD>
+<TD>15  %</TD>
+<TD>milliJy             </TD>
+<TD>4.85E+09</TD>
+<TD>  3.60E-02</TD>
+<TD>5.40E-03</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991ApJS...75....1B</TD>
+<TD>uncertainty</TD>
+<TD>4.85       GHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD>004002.1 +405959 (B1950)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>139</TD>
+<TD>4.85 GHz            </TD>
+<TD> 32        </TD>
+<TD>6    </TD>
+<TD>milliJy             </TD>
+<TD>4.85E+09</TD>
+<TD>  3.20E-02</TD>
+<TD>6.00E-03</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1991ApJS...75.1011G</TD>
+<TD>rms noise</TD>
+<TD>4.85       GHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD>004002.2 +405940 (B1950)</TD>
+<TD> Modelled datum</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data; Corrected for contaminating sources]]></TD>
+</TR>
+<TR>
+<TD>140</TD>
+<TD>4.8 GHz (Effelsberg)</TD>
+<TD> 1863      </TD>
+<TD></TD>
+<TD>milliJy             </TD>
+<TD>4.80E+09</TD>
+<TD>  1.86E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>2009ApJ...693.1392S</TD>
+<TD>no uncertainty reported</TD>
+<TD>       4.8 GHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From reprocessed raw data]]></TD>
+</TR>
+<TR>
+<TD>141</TD>
+<TD>1.49 GHz (VLA)      </TD>
+<TD> 8400.0    </TD>
+<TD></TD>
+<TD>milliJy             </TD>
+<TD>1.49E+09</TD>
+<TD>  8.40E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1996ApJS..103...81C</TD>
+<TD>no uncertainty reported</TD>
+<TD>   1.490   GHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD>004000.0 +405942 (B1950)</TD>
+<TD> Total flux</TD>
+<TD><![CDATA[Extended source; beamwidth = 48"        ]]></TD>
+<TD><![CDATA[Averaged from previously published data]]></TD>
+</TR>
+<TR>
+<TD>142</TD>
+<TD>1.49 GHz (VLA)      </TD>
+<TD> 14.5      </TD>
+<TD></TD>
+<TD>milliJy             </TD>
+<TD>1.49E+09</TD>
+<TD>  1.45E-02</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>1996ApJS..103...81C</TD>
+<TD>no uncertainty reported</TD>
+<TD>    1.49   GHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD>004001.1 +405950 (B1950)</TD>
+<TD> Peak flux</TD>
+<TD><![CDATA[Beamwidth = 48"                         ]]></TD>
+<TD><![CDATA[Averaged from previously published data]]></TD>
+</TR>
+<TR>
+<TD>143</TD>
+<TD>HI (21 cm line)     </TD>
+<TD> 6.15      </TD>
+<TD>0.10 </TD>
+<TD>m_21 mag            </TD>
+<TD>1.42E+09</TD>
+<TD>  1.51E+08</TD>
+<TD>1.46E+07</TD>
+<TD>Jy-Hz</TD>
+<TD>1991RC3.9.C...0000d</TD>
+<TD>rms uncertainty</TD>
+<TD>21         cm        </TD>
+<TD> Line measurement; flux integrated over line; lines measured in emission</TD>
+<TD>004000.2 +405943 (B1950)</TD>
+<TD> Multiple methods</TD>
+<TD><![CDATA[m_21 equiv. to S(HI) = 1.514E-18 W m^-2 ]]></TD>
+<TD><![CDATA[Homogenized from new and previously published data]]></TD>
+</TR>
+<TR>
+<TD>144</TD>
+<TD>HI (21cm line) DRAO </TD>
+<TD> 29221.4   </TD>
+<TD></TD>
+<TD>Jy km/s             </TD>
+<TD>1.42E+09</TD>
+<TD>  1.39E+08</TD>
+<TD></TD>
+<TD>Jy-Hz</TD>
+<TD>2009ApJ...705.1395C</TD>
+<TD>no uncertainty reported</TD>
+<TD>      21   cm        </TD>
+<TD> Line measurement; flux integrated over line; lines measured in emission</TD>
+<TD>00 42 44.4 +41 16 08 (J2000)</TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>145</TD>
+<TD>1.4 GHz (VLA)       </TD>
+<TD> 8600.0    </TD>
+<TD></TD>
+<TD>milliJy             </TD>
+<TD>1.40E+09</TD>
+<TD>  8.60E+00</TD>
+<TD></TD>
+<TD></TD><TD>Jy</TD>
+<TD>2002AJ....124..675C</TD>
+<TD>no uncertainty reported</TD>
+<TD>     1.4   GHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD></TD>
+<TD> Flux integrated from map</TD>
+<TD><![CDATA[From 1975PASP...87...83D                ]]></TD>
+<TD><![CDATA[Averaged from previously published data]]></TD>
+</TR>
+<TR>
+<TD>146</TD>
+<TD>408 MHz             </TD>
+<TD> 0.22      </TD>
+<TD>0.02 </TD>
+<TD>Jy                  </TD>
+<TD>4.08E+08</TD>
+<TD>  2.20E-01</TD>
+<TD>2.05E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1985A&amp;AS...59..255F</TD>
+<TD>rms uncertainty</TD>
+<TD>408        MHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD>0 40  3.1 40 59 39 (B1950)</TD>
+<TD> Total flux</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+<TR>
+<TD>147</TD>
+<TD>151 MHz (6C)        </TD>
+<TD> 0.75      </TD>
+<TD>0.075</TD>
+<TD>Jy                  </TD>
+<TD>1.52E+08</TD>
+<TD>  7.50E-01</TD>
+<TD>7.50E-02</TD>
+<TD></TD><TD>Jy</TD>
+<TD>1993MNRAS.263...25H</TD>
+<TD>typical accuracy</TD>
+<TD>151.5      MHz       </TD>
+<TD> Broad-band measurement</TD>
+<TD>004001.6 410004. (B1950)</TD>
+<TD> Peak flux</TD>
+<TD><![CDATA[                                        ]]></TD>
+<TD><![CDATA[From new raw data]]></TD>
+</TR>
+</TABLEDATA>
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/mapper/DataGroupUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/mapper/DataGroupUtil.java
@@ -137,8 +137,8 @@ public class DataGroupUtil {
             // format info - for numeric types only
             if (!(columnClass==String.class)) {
                 if (columnClass == Double.class || columnClass == Float.class) {
-                    int scale = Math.max(rsmd.getScale(i), 6);
-                    fi.setDataFormat("%." + scale + "f"); // double or float
+                    int scale = Math.max(rsmd.getScale(i), columnClass == Double.class ? 10 : 7);
+                    fi.setDataFormat("%." + scale + "e"); // double or float
                 } else if (Date.class.isAssignableFrom(columnClass)) {
                     fi.setDataFormat("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS"); // date
                 }

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {cloneDeep, has, get, isEmpty, isString, isUndefined, omit, omitBy, set, range} from 'lodash';
+import {cloneDeep, has, get, isArray, isEmpty, isString, isUndefined, omit, omitBy, set, range} from 'lodash';
 import shallowequal from 'shallowequal';
 
 import {flux} from '../Firefly.js';
@@ -45,7 +45,9 @@ export const CHART_UNMOUNTED = `${UI_PREFIX}/unmounted`;
 
 const FIRST_CDEL_ID = '0'; // first data element id (if missing)
 
-const FIREFLY_TRACE_TYPES = ['fireflyHistogram', 'fireflyHeatmap'];
+const FIREFLY_TRACE_TYPES = ['scatter', 'fireflyHistogram', 'fireflyHeatmap'];
+
+const EMPTY_ARRAY = [];
 
 export default {actionCreators, reducers};
 
@@ -395,7 +397,7 @@ function chartHighlight(action) {
     return (dispatch) => {
         const {chartId, highlighted=0, chartTrigger=false} = action.payload;
         // TODO: activeTrace is not implemented.  switch to trace.. then highlight(?)
-        const {data, tablesources, activeTrace:activeDataTrace=0, selected} = getChartData(chartId);
+        const {data, fireflyData, tablesources, activeTrace:activeDataTrace=0, selected} = getChartData(chartId);
 
         const {traceNum=activeDataTrace, traceName} = action.payload; // highlighted trace can be selected or highlighted trace of the data trace
 
@@ -412,7 +414,8 @@ function chartHighlight(action) {
             // avoid updating chart twice
             // update only as a response to table highlight change
             if (!chartTrigger) {
-                const hlTrace = newTraceFrom(data[traceNum], [highlighted], HIGHLIGHTED_PROPS);
+                const traceAnnotations = get(fireflyData, `${traceNum}.annotations`);
+                const hlTrace = newTraceFrom(data[traceNum], [highlighted], HIGHLIGHTED_PROPS, traceAnnotations);
                 dispatchChartUpdate({chartId, changes: {highlighted: hlTrace}});
             }
             let traceData = data[traceNum];
@@ -437,7 +440,7 @@ function chartHighlight(action) {
 function chartSelect(action) {
     return (dispatch) => {
         const {chartId, selIndexes=[], chartTrigger=false} = action.payload;
-        const {activeTrace=0, data, tablesources} = getChartData(chartId);
+        const {activeTrace=0, data, fireflyData, tablesources} = getChartData(chartId);
 
         // when skipping hover, selecting chart points does not work
         // disable chart select in this case
@@ -458,7 +461,8 @@ function chartSelect(action) {
         // don't update before table select
         if (!chartTrigger) {
             const hasSelected = !isEmpty(selIndexes);
-            selected = newTraceFrom(data[activeTrace], selIndexes, SELECTED_PROPS);
+            const traceAnnotations = get(fireflyData, `${activeTrace}.annotations`);
+            selected = newTraceFrom(data[activeTrace], selIndexes, SELECTED_PROPS, traceAnnotations);
             dispatchChartUpdate({chartId, changes: {hasSelected, selected, selection: undefined}});
         }
     };
@@ -499,27 +503,28 @@ function chartFilterSelection(action) {
 function setActiveTrace(action) {
     return (dispatch) => {
         const {chartId, activeTrace} = action.payload;
-        const {data, tablesources, curveNumberMap} = getChartData(chartId);
-        const changes = getActiveTraceChanges({activeTrace, data, tablesources, curveNumberMap});
+        const {data, fireflyData, tablesources, curveNumberMap} = getChartData(chartId);
+        const changes = getActiveTraceChanges({activeTrace, data, fireflyData, tablesources, curveNumberMap});
         dispatchChartUpdate({chartId, changes});
     };
 }
 
-function getActiveTraceChanges({activeTrace, data, tablesources, curveNumberMap}) {
+function getActiveTraceChanges({activeTrace, data, fireflyData, tablesources, curveNumberMap}) {
     const tbl_id = get(tablesources, [activeTrace, 'tbl_id']);
     let selected = undefined;
     let highlighted = undefined;
     let curveMap = undefined;
     if (tbl_id) {
         const {selectInfo, highlightedRow} = getTblById(tbl_id) || {};
+        const traceAnnotations = get(fireflyData, `${activeTrace}.annotations`);
         if (selectInfo) {
             const selectInfoCls = SelectInfo.newInstance(selectInfo);
             const selIndexes = Array.from(selectInfoCls.getSelected()).map((e)=>getPointIdx(data[activeTrace], e));
             if (selIndexes.length > 0) {
-                selected = newTraceFrom(data[activeTrace], selIndexes, SELECTED_PROPS);
+                selected = newTraceFrom(data[activeTrace], selIndexes, SELECTED_PROPS, traceAnnotations);
             }
         }
-        highlighted = newTraceFrom(data[activeTrace], [getPointIdx(data[activeTrace], highlightedRow)], HIGHLIGHTED_PROPS);
+        highlighted = newTraceFrom(data[activeTrace], [getPointIdx(data[activeTrace], highlightedRow)], HIGHLIGHTED_PROPS, traceAnnotations);
         if (curveNumberMap) {
             curveMap = range(curveNumberMap.length).filter((idx) => (idx !== activeTrace));
             curveMap.push(activeTrace);
@@ -529,7 +534,7 @@ function getActiveTraceChanges({activeTrace, data, tablesources, curveNumberMap}
 }
 
 function isFireflyType(type) {
-    return  FIREFLY_TRACE_TYPES.includes(type);
+    return  !type || FIREFLY_TRACE_TYPES.includes(type);
 }
 
 /**
@@ -557,9 +562,17 @@ function handleFireflyTraceTypes(payload) {
         });
         newPayload = Object.assign({}, newPayload, {data: plotlyData, fireflyData});
     }
-    if (layout.firefly) {
+    if (layout.firefly || isArray(layout.annotations)) {
         const fireflyLayout = layout.firefly;
         const plotlyLayout = omit(layout, 'firefly');
+
+        if (isArray(layout.annotations)) {
+            // save annotations array into fireflyLayout
+            if (!fireflyLayout.annotations) { fireflyLayout.annotations = []; }
+            fireflyLayout.annotations.push(plotlyLayout.annotations);
+        }
+
+
         newPayload = Object.assign({}, newPayload, {layout: plotlyLayout, fireflyLayout});
     }
     return newPayload;
@@ -891,6 +904,22 @@ function reduceData(state={}, action={}) {
     }
 }
 
+export function getAnnotations(chartId) {
+    const chartData = getChartData(chartId);
+    let annotations = get(chartData, 'fireflyLayout.annotations', EMPTY_ARRAY);
+    get(chartData, 'fireflyData', []).forEach((d) => {
+        if (isArray(d.annotations)) {
+            const filtered = d.annotations.filter((e) => !isUndefined(e));
+            if (filtered.length > 0) {
+                annotations = annotations.concat(d.annotations);
+            }
+        }
+    });
+    return annotations;
+}
+
+
+
 function chartDataElementsToObj(chartDataElementsArr) {
     if (!chartDataElementsArr) return;
     const obj = {};
@@ -950,6 +979,16 @@ function cleanupRelatedChartData(action) {
     });
 }
 
+export function hasUpperLimits(chartId, traceNum) {
+    const yMax = get(getChartData(chartId), `fireflyData.${traceNum}.yMax`);
+    return !isUndefined(yMax);
+}
+
+export function dataLoadedUpdate(changes) {
+    // when the chart data finished loading, fireflyData.traceNum.isLoading is switched to false
+    return Object.keys(changes).find((k)=>(k.match(/isLoading$/) && !changes[k]));
+}
+
 /**
  * Reset chart to the original
  * @param chartId
@@ -982,6 +1021,7 @@ export function removeTrace({chartId, traceNum}) {
                 Object.assign(changes,
                     getActiveTraceChanges({activeTrace: newActiveTrace,
                         data: changes['data'],
+                        fireflyData: changes['fireflyData'],
                         tablesources: changes['tablesources'],
                         curveNumberMap: newCurveMap})
                 );

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -152,7 +152,7 @@ function getChanges({tableModel, mappings, chartId, traceNum}) {
         [`data.${traceNum}.x`]: x,
         [`data.${traceNum}.y`]: y,
         [`data.${traceNum}.z`]: z,
-        [`data.${traceNum}.text`]: text,
+        [`data.${traceNum}.hovertext`]: text,
         [`data.${traceNum}.hoverinfo`]: 'text',
         [`fireflyData.${traceNum}.toRowIdx`]: toRowIdx
     };

--- a/src/firefly/js/charts/dataTypes/FireflyHistogram.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHistogram.js
@@ -153,7 +153,7 @@ function getChanges({histogramData, binColor, traceNum}) {
     changes[`data.${traceNum}.marker.color`] = color;
     changes[`data.${traceNum}.marker.colorscale`] = colorScale;
     changes[`data.${traceNum}.marker.line`] = {width: 1, color: borderColor};
-    changes[`data.${traceNum}.text`] = text;
+    changes[`data.${traceNum}.hovertext`] = text;
     changes[`data.${traceNum}.hoverinfo`] = 'text';
     return changes;
 }

--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -10,7 +10,7 @@ import {getFieldVal, getReducerFunc} from '../../fieldGroup/FieldGroupUtils.js';
 
 import {RadioGroupInputField} from './../../ui/RadioGroupInputField.jsx';
 import {SimpleComponent} from './../../ui/SimpleComponent.jsx';
-import {CHART_UPDATE, getChartData, removeTrace} from '../ChartsCntlr.js';
+import {CHART_UPDATE, dataLoadedUpdate, getChartData, removeTrace} from '../ChartsCntlr.js';
 import {getOptionsUI} from '../ChartUtil.js';
 import {NewTracePanel, getNewTraceType, getSubmitChangesFunc, addNewTrace} from './options/NewTracePanel.jsx';
 
@@ -126,7 +126,7 @@ export class ChartSelectPanel extends SimpleComponent {
 
         const chartActions = getChartActions({chartId, tbl_id});
         const {chartAction} = this.state;
-        const groupKey = getGroupKey(chartId, CHART_TRACE_MODIFY);
+        const groupKey = getGroupKey(chartId, chartAction);
 
         return (
 
@@ -204,6 +204,7 @@ ChartAction.propTypes = {
 function ChartActionOptions(props) {
     const {chartAction, tbl_id, chartId:chartIdProp, groupKey, hideDialog, showMultiTrace} = props;
 
+
     const chartId = chartAction === CHART_ADDNEW ? undefined : chartIdProp;
 
     if (chartAction === CHART_ADDNEW || chartAction === CHART_TRACE_ADDNEW) {
@@ -251,7 +252,7 @@ function watchChartDataChange(action, cancelSelf, params) {
     const {chartId:actionChartId, changes={}} = action.payload;
     const {chartId, groupKey} = params;
     //options should be synced when data are received: fireflyData.traceNum.isLoading is switched to false
-    if (actionChartId === chartId && Object.keys(changes).find((k)=>(k.match(/isLoading$/) && !changes[k]))) {
+    if (actionChartId === chartId && dataLoadedUpdate(changes)) {
         const reducerFunc = getReducerFunc(params.groupKey);
         const flds = reducerFunc && reducerFunc(null);
         if (flds) {

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -25,6 +25,7 @@ export const RenderType= new Enum([ 'RESIZE', 'UPDATE', 'RESTYLE', 'RELAYOUT',
 
 
 const defaultConfig= {
+    scrollZoom: true,
     displaylogo: false,
     displayModeBar: false,
     modeBarButtonsToRemove :[
@@ -244,7 +245,10 @@ const now = Date.now();
                         Plotly.Plots.resize(this.div);
                         break;
                     case RenderType.UPDATE:
-                        Plotly.update(this.div, data, layout);
+                        // can use UPDATE for single trace plus layout updates
+                        // otherwise it will not work - data will not be updated
+                        // dataUpdate should be an object
+                        Plotly.update(this.div, dataUpdate[0], layoutUpdate, dataUpdateTraces);
                         break;
                     case RenderType.NEW_PLOT:
                         Plotly.newPlot(this.div, data, layout, config);

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {get, isUndefined, isEmpty, reverse, set} from 'lodash';
+import {isArray, get, isUndefined, isEmpty, reverse, set} from 'lodash';
 
 import {dispatchChartUpdate, dispatchChartAdd, getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
@@ -473,7 +473,7 @@ BasicOptionFields.propTypes = {
 export function submitChanges({chartId, fields, tbl_id}) {
     if (!fields) return;                // fields failed validations..  quick/dirty.. may need to separate the logic later.
     if (!chartId) chartId = uniqueChartId();
-    const {layout={}, data=[], activeTrace:traceNum=0} = getChartData(chartId, {});
+    const {layout={}, data=[], fireflyData, activeTrace:traceNum=0} = getChartData(chartId, {});
     const changes = {showOptions: false};
     Object.entries(fields).forEach( ([k,v]) => {
         if (tbl_id && k.startsWith('_tables.')) {
@@ -540,6 +540,15 @@ export function submitChanges({chartId, fields, tbl_id}) {
                         // when changing color, change all color attributes
                         colorsOnTypes[type][0].filter((att) => att.endsWith('color')).
                         forEach((att) => changes[`data.${traceNum}.${att}`] = v);
+                        // change annotation color
+                        const annotations = get(fireflyData, `${traceNum}.annotations`);
+                        if (isArray(annotations)) {
+                            annotations.forEach((a, i) => {
+                                if (a) {
+                                    changes[`fireflyData.${traceNum}.annotations.${i}.arrowcolor`] = v;
+                                }
+                            });
+                        }
                     }
                 }
             }

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {get, isUndefined, omit} from 'lodash';
+import {isArray, get, isUndefined, omit} from 'lodash';
 
 import {Expression} from '../../../util/expr/Expression.js';
-import {getChartData, hasUpperLimits} from '../../ChartsCntlr.js';
+import {getChartData, getTraceSymbol, hasUpperLimits} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
 import {VALUE_CHANGE} from '../../../fieldGroup/FieldGroupCntlr.js';
 
@@ -74,8 +74,12 @@ export function fieldReducer({chartId, activeTrace}) {
     const basicReducer = basicFieldReducer({chartId, activeTrace});
 
     const getFields = () => {
-        const {data, tablesources={}} = getChartData(chartId);
+        const {data, fireflyData, tablesources={}} = getChartData(chartId);
         const tablesourceMappings = get(tablesources[activeTrace], 'mappings');
+
+        // when a symbol is substituted with an array,
+        // the selected symbol is saved in fireflyData
+        const symbol = getTraceSymbol(data, fireflyData, activeTrace);
 
         const fields = {
             [`data.${activeTrace}.mode`]: {
@@ -87,7 +91,7 @@ export function fieldReducer({chartId, activeTrace}) {
             },
             [`data.${activeTrace}.marker.symbol`]: {
                 fieldKey: `data.${activeTrace}.marker.symbol`,
-                value: get(data, `${activeTrace}.marker.symbol`),
+                value: symbol,
                 tooltip: 'Select marker symbol',
                 label: 'Symbol:',
                 ...fieldProps

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -714,11 +714,12 @@ export const cancelIdleCallback = window.cancelIdleCallback || ((id) => clearTim
 /**
  *
  * @param object
+ * @param prefix - prefix to use for all object properties
  * @param testFunc - test function to decide which entries should be flattened.  defaults to isPlainObject
  * @returns {*}
  */
-export function flattenObject(object, testFunc=isPlainObject) {
-    return Object.assign( {}, ...function _flatten( objectBit, path = '' ) {  //spread the result into our return object
+export function flattenObject(object, prefix='', testFunc=isPlainObject) {
+    return Object.assign( {}, ...function _flatten( objectBit, path=prefix) {  //spread the result into our return object
         return [].concat(                                                     //concat everything into one level
             ...Object.keys( objectBit ).map(                                  //iterate over object
                 (key) => {

--- a/src/firefly/js/util/expr/Expr.js
+++ b/src/firefly/js/util/expr/Expr.js
@@ -18,6 +18,7 @@
 /** Binary operator: greater than    */  export const GT  = 13;
 /** Binary operator: logical and     */  export const AND = 14;
 /** Binary operator: logical or      */  export const OR  = 15;
+/** Binary operator: if null         */  export const IFNULL  = 16;
 
 /** Unary operator: absolute value*/   export const ABS   = 100;
 /** Unary operator: arccosine */       export const ACOS  = 101;
@@ -148,6 +149,7 @@ class BinaryExpr {
             case DIV:   return arg0 / arg1; // division by 0 has IEEE 754 behavior
             case POW:   return Math.pow(arg0, arg1);
             case ATAN2: return Math.atan2(arg0, arg1);
+            case IFNULL: return (arg0 === undefined || arg0 === null) ? arg1 : arg0;
             case MAX:   return arg0 < arg1 ? arg1 : arg0;
             case MIN:   return arg0 < arg1 ? arg0 : arg1;
             case LT:    return arg0 <  arg1 ? 1.0 : 0.0;

--- a/src/firefly/js/util/expr/Parser.js
+++ b/src/firefly/js/util/expr/Parser.js
@@ -30,11 +30,11 @@ const rators1 = [
 ];
 
 const procs2 = [
-    'atan2', 'max', 'min', 'power'
+    'atan2', 'max', 'min', 'power', 'ifnull'
 ];
 
 const rators2 = [
-    Expr.ATAN2, Expr.MAX, Expr.MIN, Expr.POW
+    Expr.ATAN2, Expr.MAX, Expr.MIN, Expr.POW, Expr.IFNULL
 ];
 
 /**


### PR DESCRIPTION
https://irsawebdev9.ipac.caltech.edu/dm-7991/firefly/

https://jira.lsstcorp.org/browse/DM-7991

To test, use firefly/demo/ffapi-sed.html 

(Note the use of chart options there: `{singleTraceUI: true, upperLimitUI: true}` - the default values for both options are false.)

- Upper limit column or expression is stored in fireflyData[traceNum].yMax, using the same notation as for other mapped columns.
- Upper Limits are represented by annotations (arrows pointing down).
- Since Plotly stores annotations in the layout, trace annotations needed to be implemented.

Per trace annotations are stored in fireflyData, and are constructed when the data arrive. 

The annotations in plotly layout are constructed from the original annotations (moved to fireflyLayout.annotations) and trace annotations before chart is rendered. The assumption is that we won't have trace annotations when the number of points in the trace is large.

When upper limit annotations are present, reversing y axis or changing its type to 'log' requires reloading data and recreating annotations. Currently the data are reloaded only for the active trace (when the options are modified).  