### PR TITLE
DM-13780: fixed image recenter problem

### DIFF
--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -486,17 +486,23 @@ function updateViewSize(state,action) {
     const plotViewAry= state.plotViewAry.map( (pv) => {
         if (pv.plotId!==plotId ) return pv;
         const plot= primePlot(pv);
+        let centerImagePt;
 
-
+        if (plot) {
+            centerImagePt= (pv.scrollX===-1 && pv.scrollY===-1) ?
+                makeImagePt(plot.dataWidth/2, plot.dataHeight/2) :
+                findCurrentCenterPoint(pv);
+        }
         const w= isUndefined(width) ? pv.viewDim.width : width;
         const h= isUndefined(height) ? pv.viewDim.height : height;
         pv= Object.assign({}, pv, {viewDim: {width:w, height:h}});
         if (!plot) return pv;
 
         const masterPv= getPlotViewById(state, state.mpwWcsPrimId);
+        pv= updateTransform(pv);
 
         if (isHiPS(plot)) {
-            const centerImagePt= makeImagePt( plot.dataWidth/2, plot.dataHeight/2);
+            centerImagePt= makeImagePt( plot.dataWidth/2, plot.dataHeight/2);
             pv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt));
         }
         else if (state.wcsMatchType===WcsMatchType.Standard && state.mpwWcsPrimId!==plotId) {
@@ -509,9 +515,7 @@ function updateViewSize(state,action) {
             pv= recenterPv(null, false)(pv);
         }
         else {
-            // const centerImagePt= (pv.scrollX<0 || pv.scrollY<0) ? makeImagePt(plot.dataWidth/2, plot.dataHeight/2) : findCurrentCenterPoint(pv);
-            const centerImagePt= (pv.scrollX===-1 && pv.scrollY===-1) ? makeImagePt(plot.dataWidth/2, plot.dataHeight/2) : findCurrentCenterPoint(pv);
-            pv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt));
+            pv= centerImagePt ? updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt)) : recenter((null,false)(pv));
         }
 
         pv= updateTransform(pv);

--- a/src/firefly/js/visualize/ui/ZoomButton.jsx
+++ b/src/firefly/js/visualize/ui/ZoomButton.jsx
@@ -43,8 +43,12 @@ function getZoomer() {
 
         if (zType===ZoomType.UP) {
             if (isZoomMax(pv)) {
-                console.log('show max zoom info popup ');
-                showInfoPopup('You may not zoom beyond ' + getZoomMax(plot) + 'x', 'Zoom Info');
+                if (isImage(plot)) {
+                    showInfoPopup('You may not zoom beyond ' + getZoomMax(plot) + 'x', 'Zoom Info');
+                }
+                else {
+                    showInfoPopup('You have reached the maximum zoom depth', 'Zoom Info');
+                }
                 return;
             }
         }


### PR DESCRIPTION
  -  fixed image recenter problem
  - also fixed the max zoom message show zoom level with HiPS


_to test:_

 - recenter: bring in 4 images, then bring image a hips.  The image should stay centered.
 - zoom: bring in a HiPS and zoom it all the way.  The message should not show a zoom level.