### PR TITLE
DM-12973 add showImageOrHiPS to API and update demo app

### DIFF
--- a/src/firefly/html/demo/ffapi-hips-test.html
+++ b/src/firefly/html/demo/ffapi-hips-test.html
@@ -28,18 +28,33 @@
     <div id="hipsDIV2" style="display: inline-block; width: 500px; height: 500px; margin: 10px;"></div>
 </div>
 
+<div>
+    <div style="display: inline-block">
+        <div style="width: 500px; padding: 50px 0 0 20px;">
+            <br> Show Image or HiPS (image request has no world point) <br>
+        </div>
+        <div id="hipsDiv3" style="width: 500px; height: 400px; margin: 10px;"></div>
+    </div>
+    <div style="display: inline-block">
+        <div style="width: 500px; padding: 50px 0 0 20px;">
+            <br> Show Image or HiPS (image request has world point) <br>
+        </div>
+        <div id="hipsDiv4" style="width: 500px; height: 400px; margin: 10px;"></div>
+    </div>
+</div>
+
 <script type="text/javascript">
     {
         onFireflyLoaded= function(firefly) {
 
             window.ffViewer= firefly.getViewer();
 
-            firefly.debug= true;
+            firefly.debug = true;
 
             var util= firefly.util;
             var ui= firefly.ui;
-              // util.image.initAutoReadout(ui.DefaultApiReadout,
-              //        {MouseReadoutComponent:ui.PopupMouseReadoutMinimal, showThumb:false,showMag:false});
+            // util.image.initAutoReadout(ui.DefaultApiReadout,
+            //        {MouseReadoutComponent:ui.PopupMouseReadoutMinimal, showThumb:false,showMag:false});
 
             firefly.showHiPS('hipsDIV1',
                 {
@@ -82,8 +97,50 @@
                 },
                 hiConvert
             );
-        };
 
+
+            var imageRequestNoWpt = {
+                    Service: 'WISE',
+                    Title: 'Wise',
+                    SurveyKey: '3a',
+                    SurveyKeyBand: '2'
+                };
+
+            var imageRequestWPt = {
+                Service: 'WISE',
+                Title: 'Wise',
+                SurveyKey: '3a',
+                SurveyKeyBand: '2',
+                WorldPt: '148.892;69.0654;EQ_J2000'
+            };
+
+            var fovDegFallOver=.5;
+
+            firefly.showImageOrHiPS(
+                'hipsDiv3',
+                {
+                    plotId: 'aHipsID3',
+                    title     : 'A HiPS - 0.1',
+                    hipsRootUrl: 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1',
+                    SizeInDeg:.1
+                },
+
+                imageRequestNoWpt, fovDegFallOver
+            );
+
+            firefly.showImageOrHiPS(
+                'hipsDiv4',
+                {
+                    plotId: 'aHipsID4',
+                    title     : 'A HiPS - 0.2',
+                    hipsRootUrl: 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1',
+                    SizeInDeg:.2
+                },
+
+                imageRequestWPt, fovDegFallOver
+            );
+
+        };
    }
    
 </script>

--- a/src/firefly/html/demo/ffapi-hips-test.html
+++ b/src/firefly/html/demo/ffapi-hips-test.html
@@ -43,6 +43,22 @@
     </div>
 </div>
 
+<div>
+    <div style="display: inline-block">
+        <div style="width: 500px; padding: 50px 0 0 20px;">
+            <br> Show Image or HiPS (no size defined) <br>
+        </div>
+        <div id="hipsDiv5" style="width: 500px; height: 400px; margin: 10px;"></div>
+    </div>
+    <div style="display: inline-block">
+        <div style="width: 500px; padding: 50px 0 0 20px;">
+            <br> Show Image or HiPS (size is defined) <br>
+        </div>
+        <div id="hipsDiv6" style="width: 500px; height: 400px; margin: 10px;"></div>
+    </div>
+</div>
+
+
 <script type="text/javascript">
     {
         onFireflyLoaded= function(firefly) {
@@ -116,6 +132,7 @@
 
             var fovDegFallOver=.5;
 
+            // world point in image request
             firefly.showImageOrHiPS(
                 'hipsDiv3',
                 {
@@ -137,6 +154,29 @@
                     SizeInDeg:.2
                 },
 
+                imageRequestWPt, fovDegFallOver
+            );
+
+            // no size in both requests
+            firefly.showImageOrHiPS(
+                 'hipsDiv5',
+                 {
+                    plotId: 'aHipsID5',
+                    title     : 'A HiPS - no size',
+                    hipsRootUrl: 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1',
+                 },
+                 imageRequestWPt, fovDegFallOver
+            );
+
+            // size defined in at least one request
+            firefly.showImageOrHiPS(
+                'hipsDiv6',
+                {
+                   plotId: 'aHipsID6',
+                   title     : 'A HiPS - 0.2',
+                   hipsRootUrl: 'http://alasky.u-strasbg.fr/AllWISE/RGB-W4-W2-W1',
+                   SizeInDeg:.2
+                },
                 imageRequestWPt, fovDegFallOver
             );
 

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -389,6 +389,7 @@ function showImageOrHiPSInMultiViewer(llApi, targetDiv, hipsRequest, imageReques
 }
 
 
+
 function showImageInMultiViewer(llApi, targetDiv, request, isHiPS, hipsImageConversion) {
     const {dispatchPlotImage, dispatchPlotHiPS, dispatchAddViewer}= llApi.action;
     const {IMAGE, NewPlotMode}= llApi.util.image;

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -254,6 +254,7 @@ export function makeImageOrHiPSAction(rawAction) {
         const hipsRequest= ensureWPR(payload.hipsRequest);
         const imageRequest= ensureWPR(payload.imageRequest);
         const allSkyRequest= ensureWPR(payload.allSkyRequest);
+
         if (!validateHipsAndImage(imageRequest, hipsRequest, payload.fovDegFallOver)) return;
 
 
@@ -261,7 +262,7 @@ export function makeImageOrHiPSAction(rawAction) {
         const viewerId= determineViewerId(payload.viewerId, plotId);
         const size= getSizeInDeg(imageRequest, hipsRequest);
         const groupId= getPlotGroupId(imageRequest, hipsRequest);
-        const useImage= (plotAllSkyFirst && allSkyRequest) || size<fovDegFallOver;
+        const useImage= (plotAllSkyFirst && allSkyRequest) || (imageRequest.getWorldPt() && (size<fovDegFallOver));
 
         let wpRequest= useImage ? imageRequest.makeCopy() : hipsRequest.makeCopy();
 

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -262,8 +262,8 @@ export function makeImageOrHiPSAction(rawAction) {
         const viewerId= determineViewerId(payload.viewerId, plotId);
         const size= getSizeInDeg(imageRequest, hipsRequest);
         const groupId= getPlotGroupId(imageRequest, hipsRequest);
-        const useImage= (plotAllSkyFirst && allSkyRequest) || (imageRequest.getWorldPt() && (size<fovDegFallOver));
-
+        const useImage= (plotAllSkyFirst && allSkyRequest) || (imageRequest.getWorldPt() &&
+                                                              (size !== 0) && (size < fovDegFallOver));
         let wpRequest= useImage ? imageRequest.makeCopy() : hipsRequest.makeCopy();
 
         if (useImage) {
@@ -398,10 +398,12 @@ function validateHipsAndImage(imageRequest, hipsRequest, fovDegFallOver) {
         console.log('You must define both hipsRequest and imageRequest');
         return false;
     }
+    /*
     if (!getSizeInDeg(imageRequest, hipsRequest)) {
         console.log('You must call setSizeInDeg in either the hipsRequest or the imageRequest');
         return false;
     }
+    */
     if (!getPlotGroupId(imageRequest, hipsRequest)) {
         console.log('You must call setPlotGroupId in either the hipsRequest or the imageRequest');
         return false;


### PR DESCRIPTION
The development 
- adds 'showImageOrHiPS' into Firefly API. 
- for showImageOrHiPS, either HiPS or regular image will be rendered based on certain criteria including that HiPS request will take the priority in case image request doesn't have target position specified. 

test: 
start firefly/demo/ffapi-hips-test.html

