### PR TITLE
DM-13866: Optimize server memory usage

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -4,8 +4,7 @@
 package edu.caltech.ipac.firefly.server;
 
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
-import edu.caltech.ipac.firefly.server.db.BaseDbAdapter;
-import edu.caltech.ipac.firefly.server.filters.CommonFilter;
+import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorFactory;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.visualize.VisContext;
@@ -765,13 +764,13 @@ public class ServerContext {
             System.out.println("contextInitialized...");
             ServletContext cntx = servletContextEvent.getServletContext();
             ServerContext.init(cntx.getContextPath(), cntx.getServletContextName(), cntx.getRealPath(WEBAPP_CONFIG_LOC));
-            Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> BaseDbAdapter.cleanup(), 1, 1, TimeUnit.MINUTES);   // check every minute
-
+            Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> DbAdapter.getAdapter().cleanup(false),
+                        DbAdapter.CLEANUP_INTVL, DbAdapter.CLEANUP_INTVL, TimeUnit.MILLISECONDS);
         }
 
         public void contextDestroyed(ServletContextEvent servletContextEvent) {
             System.out.println("contextDestroyed...");
-            BaseDbAdapter.cleanup(true);
+            DbAdapter.getAdapter().cleanup(true);
             ((EhcacheProvider)CacheManager.getCacheProvider()).shutdown();
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -5,6 +5,7 @@ package edu.caltech.ipac.firefly.server.db;
 
 import edu.caltech.ipac.firefly.data.SortInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.db.spring.JdbcFactory;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.DataType;
 import edu.caltech.ipac.util.StringUtils;
@@ -12,13 +13,11 @@ import edu.caltech.ipac.util.StringUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.data.TableServerRequest.INCL_COLUMNS;
@@ -28,8 +27,8 @@ import static edu.caltech.ipac.firefly.data.TableServerRequest.INCL_COLUMNS;
  * @version $Id: DbInstance.java,v 1.3 2012/03/15 20:35:40 loi Exp $
  */
 abstract public class BaseDbAdapter implements DbAdapter {
-    private static long MAX_IDLE_TIME = 1000 * 60 * 15;      // will be purged up if idle more than 15 minutes.
     private static Map<String, EmbeddedDbInstance> dbInstances = new HashMap<>();
+    private static long LAST_CHECK = System.currentTimeMillis();
     private static Logger.LoggerImpl LOGGER = Logger.getLogger();
 
     private static final String DD_INSERT_SQL = "insert into %s_dd values (?,?,?,?,?,?,?,?,?,?,?)";
@@ -184,61 +183,107 @@ abstract public class BaseDbAdapter implements DbAdapter {
     }
 
     public void close(File dbFile, boolean deleteFile) {}          // subclass should override this to properly closes the database and cleanup resources.
+    public Map<String, EmbeddedDbInstance> getDbInstances() { return dbInstances; }
 
     protected abstract EmbeddedDbInstance createDbInstance(File dbFile);
 
-    public static Map<String, EmbeddedDbInstance> getDbInstances() { return dbInstances; }
 
-    public static void cleanup() {
+//====================================================================
+//  cleanup related functions
+//====================================================================
+    public void cleanup() {
         cleanup(false);
     }
 
-    public static void cleanup(boolean force) {
-        List<EmbeddedDbInstance> toBeRemove = dbInstances.values().stream()
-                                                    .filter((db) -> db.hasExpired() || force).collect(Collectors.toList());
-        if (toBeRemove.size() > 0) {
-            LOGGER.info(String.format("There are currently %d databases open.  Of which, %d will be closed.", dbInstances.size(), toBeRemove.size()));
-            toBeRemove.forEach((db) -> {
-                DbAdapter.getAdapter(db.name).close(db.dbFile, false);
-                dbInstances.remove(db.dbFile.getPath());
-            });
+    public void cleanup(boolean force) {
+
+        try {
+            // remove expired search results
+            List<EmbeddedDbInstance> toBeRemove = dbInstances.values().stream()
+                    .filter((db) -> db.hasExpired() || force).collect(Collectors.toList());
+            if (toBeRemove.size() > 0) {
+                LOGGER.info(String.format("There are currently %d databases open.  Of which, %d will be closed.", dbInstances.size(), toBeRemove.size()));
+                toBeRemove.forEach((db) -> closeDb(db));
+            }
+
+            // remove search results based on LRU when count is greater than the high-water mark
+            long totalRows = dbInstances.values().stream().mapToInt((db) -> db.getRowCount()).sum();
+            if (totalRows > MAX_MEMORY_ROWS) {
+                long cRows = 0, highWaterMark = (long) (MAX_MEMORY_ROWS * .8);      // bring max down to 80% capacity
+                List<EmbeddedDbInstance> active = new ArrayList<>(dbInstances.values());
+                Collections.sort(active, (db1, db2) -> Long.compare(db2.getLastAccessed(), db1.getLastAccessed()));  // sorted descending..
+                for(EmbeddedDbInstance db : active) {
+                    cRows += db.getRowCount();
+                    if (cRows > highWaterMark) {
+                        closeDb(db);
+                    }
+                }
+            }
+
+            // compact long active databases - should only check if it's been recently accessed and that it was not just created.
+            List<EmbeddedDbInstance> toCompact = dbInstances.values().stream()
+                    .filter((db) -> !db.isCompact() && db.getRowCount() > 0 && db.getLastAccessed() < LAST_CHECK)
+                    .collect(Collectors.toList());
+            if (toCompact.size() > 0) {
+                toCompact.forEach((db) -> compact(db));
+            }
+
+            // record stats if needed
+            for(EmbeddedDbInstance db : dbInstances.values()) {
+                if (db.getRowCount() < 0) {
+                    db.setRowCount(getRowCount(db));
+                }
+                if (db.getLastAccessed() > LAST_CHECK) {
+                    db.setTblCount(getTempTables(db).size()+1);
+                }
+            }
+
+        }catch (Exception e) {
+            LOGGER.error(e);
+        }
+        LAST_CHECK = System.currentTimeMillis();
+    }
+
+    private static void closeDb(EmbeddedDbInstance db) {
+        DbAdapter.getAdapter(db.name).close(db.dbFile, false);
+        dbInstances.remove(db.dbFile.getPath());
+    }
+
+    private static void compact(EmbeddedDbInstance db) {
+        List<String> tables = getTempTables(db);
+        if (tables.size() > 0) {
+            // do compact.. remove all temporary tables
+            for (String tblName : tables) {
+                String dataSql = String.format("drop table %s if exists", tblName);
+                String metaSql = String.format("drop table %s if exists", tblName + "_meta");
+                String ddSql = String.format("drop table %s if exists", tblName + "_dd");
+                Arrays.asList(dataSql, metaSql, ddSql).stream().forEach(
+                        (sql) -> JdbcFactory.getSimpleTemplate(db).update(sql));
+            }
+        }
+        db.setCompact(true);
+        db.setTblCount(1);
+    }
+
+
+    private static int getRowCount(EmbeddedDbInstance db) {
+        try {
+            String sql = "SELECT CARDINALITY FROM INFORMATION_SCHEMA.SYSTEM_TABLESTATS \n" +
+                    "where table_schema = 'PUBLIC' and TABLE_NAME = 'DATA'";
+            return JdbcFactory.getSimpleTemplate(db).queryForInt(sql);
+        } catch (Exception e) {
+            return 0;
         }
     }
 
-    public static class EmbeddedDbInstance extends DbInstance {
-        long lastAccessed;
-        File dbFile;
+    private static List<String> getTempTables(EmbeddedDbInstance db) {
+        String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.SYSTEM_TABLESTATS \n" +
+                "where table_schema = 'PUBLIC' \n" +
+                "and TABLE_NAME != 'DATA'\n" +
+                "and TABLE_NAME not like '%_META'\n" +
+                "and TABLE_NAME not like '%_DD'\n";
 
-        public EmbeddedDbInstance(String type, File dbFile, String dbUrl, String driver) {
-            super(false, null, dbUrl, null, null, driver, type);
-            lastAccessed = System.currentTimeMillis();
-            this.dbFile = dbFile;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return StringUtils.areEqual(this.dbUrl,((EmbeddedDbInstance)obj).dbUrl);
-        }
-
-        @Override
-        public int hashCode() {
-            return this.dbUrl.hashCode();
-        }
-
-        public long getLastAccessed() {
-            return lastAccessed;
-        }
-
-        public boolean hasExpired() {
-            return System.currentTimeMillis() - lastAccessed > MAX_IDLE_TIME;
-        }
-
-        public File getDbFile() {
-            return dbFile;
-        }
-
-        public void touch() {
-            lastAccessed = System.currentTimeMillis();
-        }
+        return JdbcFactory.getSimpleTemplate(db).query(sql, (rs, i) -> rs.getString(1));
     }
+
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.util.StringUtils;
 
 import java.io.File;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_FILE_TYPE;
 
@@ -129,6 +130,7 @@ public interface DbAdapter {
     }
 
     class EmbeddedDbInstance extends DbInstance {
+        ReentrantLock lock = new ReentrantLock();
         long lastAccessed;
         long created;
         File dbFile;
@@ -177,6 +179,9 @@ public interface DbAdapter {
             isCompact = false;
         }
 
+        public ReentrantLock getLock() {
+            return lock;
+        }
         public void setCompact(boolean compact) { isCompact = compact;}
         public boolean isCompact() { return isCompact; }
         public int getTblCount() { return tblCount; }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
@@ -39,7 +39,7 @@ public interface DbAdapter {
     long MAX_IDLE_TIME  = 1000 * 60 * 15;   // will shutdown database if idle more than 15 minutes.
     int  CLEANUP_INTVL  = 1000 * 60;        // check every 1 minutes
     static long maxMemRows() {
-        long availMem = Runtime.getRuntime().maxMemory() - Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        long availMem = Runtime.getRuntime().maxMemory() - (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory());
         return Math.min(10000000, Math.max(1000000, availMem/1024/1024/1024 * 250000));
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/H2DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/H2DbAdapter.java
@@ -3,8 +3,6 @@
  */
 package edu.caltech.ipac.firefly.server.db;
 
-import edu.caltech.ipac.firefly.data.TableServerRequest;
-
 import java.io.File;
 
 /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
@@ -27,18 +27,17 @@ public class HsqlDbAdapter extends BaseDbAdapter{
         return String.format("CREATE TABLE %s AS (%s) WITH DATA", tblName, selectSql);
     }
 
-    public void close(File dbFile, boolean deleteFile) {
-        DbInstance db = getDbInstance(dbFile, false);
-        if (db != null) {
-            JdbcFactory.getTemplate(db).execute("SHUTDOWN");
-            File f = new File(dbFile + ".lck");
+    protected void shutdown(EmbeddedDbInstance db) {
+        JdbcFactory.getTemplate(db).execute("SHUTDOWN");
+        File f = new File(db.getDbFile() + ".lck");
+        if (f.exists()) f.delete();
+    }
+
+    protected void removeDbFiles(File dbFile) {
+        if (dbFile.exists()) dbFile.delete();
+        for(String fname : DB_FILES) {
+            File f = new File(dbFile + fname);
             if (f.exists()) f.delete();
-        }
-        if (deleteFile) {
-            for(String fname : DB_FILES) {
-                File f = new File(dbFile + fname);
-                if (f.exists()) f.delete();
-            }
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
@@ -16,7 +16,7 @@ public class HsqlDbAdapter extends BaseDbAdapter{
     public String getName() {
         return HSQL;
     }
-    private static final String[] DB_FILES = new String[]{".properties",".script",".log",".data",".backup"};
+    private static final String[] DB_FILES = new String[]{".properties",".script",".log",".data",".lck",".backup"};
 
     protected EmbeddedDbInstance createDbInstance(File dbFile) {
         String dbUrl = String.format("jdbc:hsqldb:file:%s;hsqldb.log_size=1024;sql.syntax_ora=true;sql.ignore_case=true", dbFile.getPath());
@@ -31,6 +31,8 @@ public class HsqlDbAdapter extends BaseDbAdapter{
         DbInstance db = getDbInstance(dbFile, false);
         if (db != null) {
             JdbcFactory.getTemplate(db).execute("SHUTDOWN");
+            File f = new File(dbFile + ".lck");
+            if (f.exists()) f.delete();
         }
         if (deleteFile) {
             for(String fname : DB_FILES) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -148,7 +148,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         try {
             boolean dbFileCreated = false;
             File dbFile = getDbFile(treq);
-            if (!dbFile.exists() || !EmbeddedDbUtil.hasTable(treq, dbFile, "DATA")) {
+            if (!dbFile.exists()) {
                 StopWatch.getInstance().start("createDbFile: " + treq.getRequestId());
                 dbFile = populateDataTable(treq);
                 dbFileCreated = true;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -10,11 +10,13 @@ import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.data.table.SelectionInfo;
 import edu.caltech.ipac.firefly.data.table.TableMeta;
+import edu.caltech.ipac.firefly.server.ServCommand;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbInstance;
 import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.db.spring.JdbcFactory;
+import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.firefly.server.util.ipactable.DataGroupPart;
@@ -22,6 +24,7 @@ import edu.caltech.ipac.firefly.server.util.ipactable.JsonTableUtil;
 import edu.caltech.ipac.util.CollectionUtil;
 import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.DataType;
+import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.core.NestedRuntimeException;
@@ -72,6 +75,7 @@ import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.execRequestQuery
 abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPart>, CanGetDataFile {
     private static final Map<String, ReentrantLock> activeRequests = new HashMap<>();
     private static final ReentrantLock lockChecker = new ReentrantLock();
+    private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
 
 
     /**
@@ -94,7 +98,14 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
      */
     public File getDbFile(TableServerRequest treq) {
         String fname = String.format("%s_%s.%s", treq.getRequestId(), DigestUtils.md5Hex(getUniqueID(treq)), DbAdapter.getAdapter(treq).getName());
-        return new File(ServerContext.getTempWorkDir(), fname);
+        return new File(getTempDir(), fname);
+    }
+
+    protected File getTempDir() {
+        String sessId = ServerContext.getRequestOwner().getRequestAgent().getSessId();
+        File tempDir = new File(ServerContext.getTempWorkDir(), sessId.substring(0, 3));
+        if (!tempDir.exists()) tempDir.mkdirs();
+        return tempDir;
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
@@ -36,7 +36,7 @@ public abstract class SharedDbProcessor extends EmbeddedDbProcessor {
     public File getDbFile(TableServerRequest treq) {
         DbAdapter dbAdapter = DbAdapter.getAdapter(treq);
         String fname = String.format("%s_%s.%s", treq.getRequestId(), ServerContext.getRequestOwner().getRequestAgent().getSessId(), dbAdapter.getName());
-        return new File(ServerContext.getTempWorkDir(), fname);
+        return new File(getTempDir(), fname);
     }
 
     public FileInfo ingestDataIntoDb(TableServerRequest treq, File dbFile) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -393,8 +393,8 @@ public class QueryUtil {
      */
     public static int getInt(Object val) {
         if (val != null) {
-            if (val instanceof Integer) {
-                return (Integer)val;
+            if (val instanceof Number) {
+                return ((Number)val).intValue();
             } else {
                 try {
                     return Integer.parseInt(String.valueOf(val));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/DataGroupReader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/ipactable/DataGroupReader.java
@@ -35,7 +35,7 @@ public class DataGroupReader {
     public static DataGroup readAnyFormat(File inf, int tableIndex) throws IOException {
         Format format = guessFormat(inf);
         if (format == Format.IPACTABLE) {
-            return read(inf, false, false);
+            return read(inf, false, false, true);
         } else if (format == Format.VO_TABLE) {
             DataGroup[] tables = VoTableUtil.voToDataGroups(inf.getAbsolutePath());
             if (tables.length > tableIndex) {

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -86,6 +86,9 @@
  * @prop {object} META_INFO meta information passed as key/value pair to server then returned as tableMeta.
  * @prop {string} use       one of 'catalog_overlay', 'catalog_primary', 'data_primary'.
  * @prop {string} tbl_id    a unique id of a table. auto-create if not given.
+ *
+ * @global
+ * @public
  */
 
 /**
@@ -127,4 +130,7 @@
  * @prop {object} DataSource
  * @prop {TableRequest} tableRequest 
  * @prop {string} selectionInfo
+ *
+ * @global
+ * @public
  */


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-13866

Update status page to include more details on EmbeddedDB.
http://localhost:8080/firefly/admin/status

Add cache eviction strategy for VIS_SHARE_MEM
        
        - cached data expires after 60 minute of inactivity
        - force eviction check once every 1 minute.


Add cleanup strategy for EmbeddedDB

        There are two stages of clean-up; compact(remove all temp tables), then shutdown(remove from memory)
        - Compact DB once it has idled longer than CLEANUP_INTVL
        - Shutdown DB once it has expired; idle longer than MAX_IDLE_TIME
        - Shutdown DB based on LRU(Least Recently Used) once the total rows have exceeded MAX_MEMORY_ROWS

        Current settings:
          - CLEANUP_INTVL:  1 minutes
          - MAX_IDLE_TIME: 15 minutes
          - MAX_MEMORY_ROWS:  250k rows for every 1GB of max heap, between the range of 1-10 millions.
 