### PR TITLE
DM-14046 Cache HiPS list and properties search result

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
@@ -50,7 +50,7 @@ public class AnyFileDownload extends BaseHttpServlet {
         File downloadFile;
 
         if (hips!=null) {
-            downloadFile= retrieveHiPSData(hips);
+            downloadFile= retrieveHiPSData(hips, null);
         }
         else {
             downloadFile= ServerContext.convertToFile(fname);
@@ -113,14 +113,14 @@ public class AnyFileDownload extends BaseHttpServlet {
 
     public static Cache getCache() { return UserCache.getInstance(); }
 
-    private static File retrieveHiPSData(String urlStr) throws Exception {
-
+    public static File retrieveHiPSData(String urlStr, String pathExt) throws Exception {
         URL url= new URL(urlStr);
 
-        File dir= new File(ServerContext.getHiPSDir(),new File(url.getHost()+"/"+url.getPath()).getParent());
+        String fPath = pathExt == null ? url.getPath() : (url.getPath() + "/" + pathExt);
+        File dir= new File(ServerContext.getHiPSDir(),new File(url.getHost() + fPath).getParent());
         if (!dir.exists()) dir.mkdirs();
-        File targetFile= new File(dir, new File(url.getFile()).getName());
-//        if (targetFile.canRead()) return targetFile;
+
+        File targetFile= new File(dir, new File((pathExt == null ? url.getFile() : pathExt)).getName());
         URLDownload.getDataToFile(url,targetFile);
         return targetFile;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/CDSHiPSListSource.java
@@ -2,8 +2,6 @@ package edu.caltech.ipac.firefly.server.visualize.hips;
 
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
-import edu.caltech.ipac.util.download.FailedRequestException;
-import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.visualize.hips.HiPSMasterListEntry.PARAMS;
 
 import java.util.HashMap;
@@ -64,6 +62,17 @@ public class CDSHiPSListSource implements HiPSMasterListSourceType {
         String url = HiPSCDSURL + dataProduct(dataTypes);
 
         // no call for HiPS properties
-        return IrsaHiPSListSource.createHiPSListFromUrl(url, source, paramsMap, false);
+        return IrsaHiPSListSource.createHiPSListFromUrl(url, source, paramsMap, false, joinStr(dataTypes));
+    }
+
+    private String joinStr(String[] strAry) {
+        String[] newAry = new String[strAry.length];
+
+        for (int i = 0; i < strAry.length; i++) {
+            newAry[i] = strAry[i].toLowerCase();
+        }
+        Arrays.sort(newAry);
+
+        return String.join("_", newAry);
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterList.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterList.java
@@ -7,7 +7,6 @@ package edu.caltech.ipac.firefly.server.visualize.hips;
 
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.util.DataGroup;
 import edu.caltech.ipac.util.DataObject;
 import edu.caltech.ipac.util.DataType;
@@ -131,17 +130,6 @@ public class HiPSMasterList extends EmbeddedDbProcessor {
         }
     }
 
-    private List<HiPSMasterListEntry> cleanHiPSList(List<HiPSMasterListEntry> listToClean, List<String> ids) {
-        List<HiPSMasterListEntry> cleanedList = new ArrayList<>();
-
-        for (HiPSMasterListEntry oneEntry : listToClean) {
-            if (!ids.contains(oneEntry.getMapInfo().get(PARAMS.ID.getKey()))) {
-                cleanedList.add(oneEntry);
-            }
-        }
-        return cleanedList;
-    }
-
     private void setupMeta(DataGroup dg, boolean bMulti) {
         int    sWidth = 30;
 
@@ -159,15 +147,6 @@ public class HiPSMasterList extends EmbeddedDbProcessor {
                 dg.addAttribute(makeAttribKey(VISI_TAG, colName), "hidden");
             }
         }
-    }
-
-
-    public static File createFile(String[] dataTypes, String fileExt, String hipsSource) throws IOException {
-        String filePrefix = hipsSource + "_" + String.join("_", dataTypes);
-        File file = null;
-
-        file = File.createTempFile(filePrefix, fileExt, ServerContext.getPermWorkDir());
-        return file;
     }
 
     private static DataGroup createTableDataFromListEntry(List<HiPSMasterListEntry> hipsMaps) {


### PR DESCRIPTION
The development includes:
- update the method to retrieveHiPSData in which the target file path is modified to contain the path portion plus some extra string in case the url contains query portion. 

test:
- clean the work area relevant to HiPS data 
- do HiPS search on IRSA, CDS, check the produced HiPS data produced 
- repeat firefly and HiPS search and the search is resulted faster than earlier search. 

