### PR TITLE
DM-14018, DM-14016, IRSA-1663 : Fixed various small HiPS issues

### DIFF
--- a/src/firefly/html/demo/ffapi-coverage-test.html
+++ b/src/firefly/html/demo/ffapi-coverage-test.html
@@ -32,9 +32,6 @@
     {
 
         window.firefly= {};
-        window.firefly.options= {
-            hips : {useForImageSearch: true, hipsSources: 'all', defHipsSources: 'irsa'},
-        };
         onFireflyLoaded= function(firefly) {
 
             window.ffViewer= firefly.getViewer();
@@ -85,12 +82,12 @@
                         color: {aTable: 'blue', bTable: 'yellow'},
                         overlayPosition : '149.08;68.739;EQ_J2000',
 
-                        useHiPS: true,
+                        // useHiPS: true,
                         useAllSkyFitsForPlus180 : true,
                         // fovDegFallOver: .02,
-                        fovDegFallOver: .5, // 720 arcsec
-                         hipsSourceURL : 'AllWISE_COLOR',
-                        // hipsSourceURL : 'http://alasky.u-strasbg.fr/DSS/DSSColor', // url
+                        fovDegFallOver: .5, // 1800 arcsec
+                         // hipsSourceURL : 'AllWISE_COLOR',
+                        hipsSourceURL : 'http://alasky.u-strasbg.fr/DSS/DSSColor', // url
                         // hipsSourceURL : 'http://alasky.u-strasbg.fr/Planets/CDS_P_Earth_BlueMarble/', // url
                         imageSourceParams: {
                             Service : 'WISE',

--- a/src/firefly/html/demo/ffapi-hips-test.html
+++ b/src/firefly/html/demo/ffapi-hips-test.html
@@ -77,7 +77,8 @@
                     plotId: 'aHipsID1-1',
                     WorldPt : '148.892;69.0654;EQ_J2000',
                     title     : 'A HiPS',
-                    hipsRootUrl: 'http://alasky.u-strasbg.fr/DSS/DSSColor'
+                    // hipsRootUrl: 'http://alasky.u-strasbg.fr/DSS/DSSColor'
+                    hipsRootUrl: 'CDS/P/SDSS9/color'
                 }
             );
 
@@ -86,7 +87,8 @@
                     plotId: 'aHipsID1-2',
                     WorldPt : '148.892;69.0654;EQ_J2000',
                     title     : 'A HiPS',
-                    hipsRootUrl: 'http://alasky.u-strasbg.fr/DSS/DSS2Merged'
+                    // hipsRootUrl: 'http://alasky.u-strasbg.fr/DSS/DSS2Merged'
+                    hipsRootUrl: 'ivo://CDS/P/DSS2/color'
                 }
             );
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterListEntry.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterListEntry.java
@@ -31,7 +31,7 @@ public class HiPSMasterListEntry {
         FRAME("Frame", "Frame", String.class, "Coordinate frame reference"),
         URL("Url", "Url", String.class, "HiPS url"),
         ID("ID", "ID",  String.class, "HiPS id"),
-        IVOID("CreatorID", "CreatorID", String.class, "Unique id of HiPS"),
+        IVOID("CreatorID", "CreatorID", String.class, "Unique id of HiPS"), // note- don't change this unless you change the client also
         WAVELENGTH("Wavelength", "Wavelength", String.class, "General wavelength, Radio, Millimeter, Infared, Optical, " +
                 "UV, EUV, X-ray, Gamma-ray"),
         RELEASEDATE("Release_date", "Release_date", String.class, "Last HiPS update date, YYYY-mm-ddTHH:MMZ"),
@@ -73,7 +73,8 @@ public class HiPSMasterListEntry {
     // columns included in the HiPS list table, some column may be hidden, URL, SOURCE
     private static PARAMS[] orderCols = new PARAMS[]{PARAMS.TYPE, PARAMS.TITLE, PARAMS.WAVELENGTH,
                                             PARAMS.RELEASEDATE, PARAMS.FRAME, PARAMS.ORDER, PARAMS.PIXELSCALE,
-                                            PARAMS.FRACTION,  PARAMS.PROPERTIES, PARAMS.URL,PARAMS.SOURCE};
+                                            PARAMS.FRACTION,  PARAMS.PROPERTIES, PARAMS.URL,
+                                            PARAMS.SOURCE, PARAMS.IVOID};
     static {
         for (PARAMS param : orderCols) {
             DataType dt = new DataType(param.getKey(), param.getTitle(), param.getMetaClass()) ;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
@@ -94,8 +94,8 @@ public class ServiceRetriever implements FileRetriever {
         Circle circle = PlotServUtils.getRequestArea(request);
         // this is really size not radius, i am just using Circle to hold the params
         float sizeInArcSec = (float) MathUtil.convert(MathUtil.Units.DEGREE, MathUtil.Units.ARCSEC, circle.getRadius());
-        if (sizeInArcSec > 500) sizeInArcSec = 500;
-        if (sizeInArcSec < 50) sizeInArcSec = 50;
+//        if (sizeInArcSec > 500) sizeInArcSec = 500;
+//        if (sizeInArcSec < 50) sizeInArcSec = 50;
         circle = new Circle(circle.getCenter(), sizeInArcSec);
         List<RelatedData> rdList= IbeQueryArtifact.get2MassRelatedData(circle.getCenter(), circle.getRadius()+"");
         TwoMassImageParams params = new TwoMassImageParams();

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -74,7 +74,7 @@ const defConfigOptions = {
     imageMasterSources: ['ALL'],
     imageMasterSourcesOrder: '',
     workspace : { showOptions: false},
-    hips: {useForImageSearch: false}
+    hips : {useForCoverage: true, useForImageSearch: true, hipsSources: 'all', defHipsSources: 'irsa'},
 };
 
 
@@ -140,7 +140,7 @@ export const firefly = {
  * @param props     viewer's props used for rendering.
  * @returns {Promise.<boolean>}
  */
-function bootstrap(options, viewer, props) {
+function bootstrap(options={}, viewer, props) {
 
     return  new Promise((resolve) => {
 
@@ -148,11 +148,9 @@ function bootstrap(options, viewer, props) {
         flux.process( {type : APP_LOAD} );
         resolve && resolve();
 
-        if (options) {
-            dispatchAppOptions(Object.assign({},defConfigOptions, options));
-            if (options.disableDefaultDropDown) {
-                dispatchUpdateLayoutInfo({disableDefaultDropDown:true});
-            }
+        dispatchAppOptions(Object.assign({},defConfigOptions, options));
+        if (options.disableDefaultDropDown) {
+            dispatchUpdateLayoutInfo({disableDefaultDropDown:true});
         }
 
         if (viewer) {

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -217,8 +217,11 @@ export function getConnectionCount(channel) {
  * @param corners array of 4 WorldPts that represent the corners of a image
  */
 export const dispatchActiveTarget= function(wp,corners) {
-    var payload={};
+    const payload={};
     if (isValidPoint(wp) && wp.type===Point.W_PT) {
+        payload.worldPt= wp;
+    }
+    else if (!wp) {
         payload.worldPt= wp;
     }
     if (corners) {

--- a/src/firefly/js/core/AppDataReducers.js
+++ b/src/firefly/js/core/AppDataReducers.js
@@ -79,8 +79,7 @@ export function alertsReducer(state={}, action={}) {
 
 /*---------------------------- REDUCING FUNTIONS -----------------------------*/
 const updateActiveTarget= function(state,action) {
-    var {worldPt,corners}= action.payload;
-    if (!worldPt && !corners) return state;
+    const {worldPt,corners}= action.payload;
     return Object.assign({}, state, {activeTarget:{worldPt,corners}});
 };
 

--- a/src/firefly/js/drawingLayers/HiPSGrid.js
+++ b/src/firefly/js/drawingLayers/HiPSGrid.js
@@ -6,8 +6,8 @@
 import ImagePlotCntlr, {visRoot} from '../visualize/ImagePlotCntlr.js';
 import DrawLayerCntlr from '../visualize/DrawLayerCntlr.js';
 import {primePlot, isDrawLayerVisible} from '../visualize/PlotViewUtil.js';
-import {getBestHiPSlevel, getVisibleHiPSCells,
-       getPointMaxSide, getMaxDisplayableHiPSLevel} from '../visualize/HiPSUtil.js';
+import {getHiPSNorderlevel, getVisibleHiPSCells,
+       getPointMaxSide, getMaxDisplayableHiPSGridLevel} from '../visualize/HiPSUtil.js';
 import FootprintObj from '../visualize/draw/FootprintObj.js';
 import ShapeDataObj from '../visualize/draw/ShapeDataObj.js';
 import {makeDrawingDef} from '../visualize/draw/DrawingDef.js';
@@ -77,7 +77,7 @@ function getLayerChanges(drawLayer, action) {
 
 
 function getTitle() {
-    return 'HiPS Grid';
+    return 'HEALPix (HiPS) Grid';
 }
 
 
@@ -119,11 +119,11 @@ function computeDrawDataForId(plotId, gridType, gridLockLevel) {
 
     let norder;
     if (gridType==='lock') {
-        norder= Math.min(Number(gridLockLevel), getMaxDisplayableHiPSLevel(plot));
+        norder= Math.min(Number(gridLockLevel), getMaxDisplayableHiPSGridLevel(plot));
     }
     else {
         const limitByMax= gridType==='match';
-        const {norder:retNorder}= getBestHiPSlevel(plot, limitByMax);
+        const {norder:retNorder}= getHiPSNorderlevel(plot, limitByMax);
         norder= retNorder;
     }
 

--- a/src/firefly/js/drawingLayers/HiPSGridlUI.jsx
+++ b/src/firefly/js/drawingLayers/HiPSGridlUI.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import {RadioGroupInputFieldView} from '../ui/RadioGroupInputFieldView.jsx';
 import {ListBoxInputFieldView} from '../ui/ListBoxInputField.jsx';
 import {dispatchModifyCustomField} from '../visualize/DrawLayerCntlr.js';
-import {getMaxDisplayableHiPSLevel, getBestHiPSlevel} from '../visualize/HiPSUtil.js';
+import {getMaxDisplayableHiPSGridLevel, getHiPSNorderlevel} from '../visualize/HiPSUtil.js';
 import {primePlot} from '../visualize/PlotViewUtil.js';
 
 
@@ -53,11 +53,9 @@ function showLevelOp(drawLayer, pv) {
     const plot= primePlot(pv);
     if (!plot) return null;
 
-    const norder= getMaxDisplayableHiPSLevel(plot);
-
-    const {gridLockLevel=getBestHiPSlevel(plot).norder }= drawLayer;
+    const norder= getMaxDisplayableHiPSGridLevel(plot);
+    const {gridLockLevel}= drawLayer;
     const value= Math.min(norder, Number(gridLockLevel));
-    
     const lockOp= [];
     for(let i= 1; i<=norder;i++) lockOp.push({label:i+'', value:i});
 
@@ -70,17 +68,17 @@ function showLevelOp(drawLayer, pv) {
             onChange={(ev) => changeLockLevelPref(drawLayer,pv,ev.target.value)}
             labelWidth={10}
             label={' '}
-            tooltip={ 'Chooseh HiPS grid level'}
+            tooltip={ 'Choose HiPS grid level'}
             options={lockOp}
             multiple={false}
         />
-    )
+    );
 }
 
 
 function changeHipsPref(drawLayer,pv,value) {
     const plot= primePlot(pv);
-    const gridLockLevel= drawLayer.gridLockLevel || getBestHiPSlevel(plot).norder;
+    const gridLockLevel= drawLayer.gridLockLevel || getHiPSNorderlevel(plot).norder;
     dispatchModifyCustomField(drawLayer.drawLayerId, {gridType:value,gridLockLevel},pv.plotId);
 }
 

--- a/src/firefly/js/ui/PopupUtil.jsx
+++ b/src/firefly/js/ui/PopupUtil.jsx
@@ -87,7 +87,7 @@ export function showInfoPopup(content, title='Information') {
 function makeContent(content) {
     return (
         <div style={{padding:5}}>
-            <div style={{minWidth:190, maxWidth: 400, padding:10, fontSize:'120%'}}>
+            <div style={{minWidth:190, maxWidth: 400, padding:10, fontSize:'120%', overflow: 'hidden'}}>
                 {content}
             </div>
             <div style={{padding:'0 0 5px 10px'}}>

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -26,7 +26,7 @@ class TargetPanelView extends PureComponent {
 
     componentWillUnmount() {
         const {onUnmountCB, fieldKey, groupKey}= this.props;
-        if (onUnmountCB) onUnmountCB(fieldKey,groupKey);
+        if (onUnmountCB) onUnmountCB(fieldKey,groupKey, this.props);
     }
 
     render() {
@@ -85,11 +85,14 @@ TargetPanelView.propTypes = {
 };
 
 
-function didUnmount(fieldKey,groupKey) {
+function didUnmount(fieldKey,groupKey, props) {
     const wp= parseWorldPt(FieldGroupUtils.getFldValue(FieldGroupUtils.getGroupFields(groupKey),fieldKey));
 
-    if (isValidPoint(wp)) {
-        if (wp) dispatchActiveTarget(wp);
+    if (props.nullAllowed && !wp) {
+        dispatchActiveTarget(null);
+    }
+    else if (isValidPoint(wp)) {
+        dispatchActiveTarget(wp);
     }
 }
 
@@ -202,6 +205,7 @@ const connectorDefaultProps = {
 
 function replaceValue(v,props) {
     const t= getActiveTarget();
+    // if (props.nullAllowed && !v) return v;
     let retVal= v;
     if (t && t.worldPt) {
        if (get(t,'worldPt')) retVal= t.worldPt.toString();

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -301,13 +301,14 @@ export function dispatchApiToolsView(apiToolsView) {
 }
 /**
  *
- * @param plotId
- * @param message
- * @param done
- * @param requestKey
+ * @param {String} plotId -
+ * @param {String} message - the message if working or failure
+ * @param {boolean} done - true if completed, false if still working
+ * @param {String} requestKey
+ * @param {boolean} [callSuccess=true] - true if success, false otherwise, parameter ignored if done is false
  */
-export function dispatchPlotProgressUpdate(plotId, message, done, requestKey ) {
-    flux.process({ type: PLOT_PROGRESS_UPDATE, payload: { plotId, done, message, requestKey }});
+export function dispatchPlotProgressUpdate(plotId, message, done, requestKey, callSuccess= true ) {
+    flux.process({ type: PLOT_PROGRESS_UPDATE, payload: { plotId, done, message, requestKey, callSuccess }});
 }
 
 /**

--- a/src/firefly/js/visualize/ZoomUtil.js
+++ b/src/firefly/js/visualize/ZoomUtil.js
@@ -13,7 +13,7 @@ import VisUtil from './VisUtil.js';
 
 export const levels= [.03125, .0625, .125,.25,.5, .75, 1,2,3, 4,5, 6, 7,8, 9, 10, 11, 12, 13, 14, 15, 16, 32];
 
-const hiPSLevels= [0.00390625,  .0078125, .015625, .03125, .0625, .125,.25, .5, .75, 1,2, 4, 8, 10, 14, 16, 32, 64];
+const hiPSLevels= [0.00390625,  .0078125, .015625, .03125, .0625, .125,.25, .5, .75, 1,2, 4, 8, 10, 14, 16, 32, 64, 128, 256];
 
 const IMAGE_ZOOM_MAX= levels[levels.length-1];
 const HIPS_ZOOM_MAX= hiPSLevels[levels.length-1];

--- a/src/firefly/js/visualize/iv/HiPSTileDrawer.js
+++ b/src/firefly/js/visualize/iv/HiPSTileDrawer.js
@@ -5,7 +5,7 @@
 import Enum from 'enum';
 import {createImageUrl,initOffScreenCanvas, computeBounding, isQuadTileOnScreen} from './TileDrawHelper.jsx';
 import {primePlot} from '../PlotViewUtil.js';
-import {getVisibleHiPSCells, getPointMaxSide, getBestHiPSlevel, makeHiPSAllSkyUrlFromPlot} from '../HiPSUtil.js';
+import {getVisibleHiPSCells, getPointMaxSide, getHiPSNorderlevel, makeHiPSAllSkyUrlFromPlot} from '../HiPSUtil.js';
 import {loadImage} from '../../util/WebUtil.js';
 import {CysConverter} from '../CsysConverter.js';
 import {findAllSkyCachedImage, findTileCachedImage, addAllSkyCachedImage} from './HiPSTileCache.js';
@@ -36,7 +36,7 @@ export function createHiPSDrawer(targetCanvas) {
         const {viewDim}= plotView;
         let transitionNorder;
 
-        const {norder, useAllSky}= getBestHiPSlevel(plot, true);
+        const {norder, useAllSky}= getHiPSNorderlevel(plot, true);
         const {fov,centerWp}= getPointMaxSide(plot,viewDim);
         const tilesToLoad= findCellOnScreen(plot,viewDim,norder, fov, centerWp);
         let drawTiming= DrawTiming.ASYNC;

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -682,13 +682,15 @@ function addProcessedTileData(state,action) {
 }
 
 function updatePlotProgress(state,action) {
-    const {plotId, message:plottingStatus, done, requestKey}= action.payload;
+    const {plotId, message:plottingStatus, done, requestKey, callSuccess=true}= action.payload;
     //console.log(`updatePlotProgress: plotId;${plotId}, message:${plottingStatus}, done:${done}`);
     if (!plotId) return state;
     const plotView=  getPlotViewById(state,plotId);
     if (!plotView) return state;
     if (requestKey!==plotView.request.getRequestKey()) return state;
     if (plotView.plottingStatus===plottingStatus) return state;
-    const changes= {plottingStatus,serverCall:done ? 'success': 'working'};
-    return clone(state,{plotViewAry:clonePvAry(state,plotId, changes)});
+
+    const serverCall= done ? callSuccess ? 'success' : 'fail' : 'working';
+
+    return clone(state,{plotViewAry:clonePvAry(state,plotId, {plottingStatus,serverCall})});
 }

--- a/src/firefly/js/visualize/ui/ZoomButton.jsx
+++ b/src/firefly/js/visualize/ui/ZoomButton.jsx
@@ -5,13 +5,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
-import {UserZoomTypes} from '../ZoomUtil.js';
 import {dispatchZoom} from '../ImagePlotCntlr.js';
-import {getZoomMax, getNextZoomLevel} from '../ZoomUtil.js';
+import {getZoomMax, getNextZoomLevel, UserZoomTypes} from '../ZoomUtil.js';
 import {primePlot} from '../PlotViewUtil.js';
 import {showZoomOptionsPopup} from '../../ui/ZoomOptionsPopup.jsx';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 import {isImage} from '../WebPlot.js';
+import {MAX_SUPPORTED_HIPS_LEVEL} from '../HiPSUtil.js';
 
 import zoomDown from 'html/images/icons-2014/ZoomOut.png';
 import zoomUp from 'html/images/icons-2014/ZoomIn.png';
@@ -43,12 +43,16 @@ function getZoomer() {
 
         if (zType===ZoomType.UP) {
             if (isZoomMax(pv)) {
+                let msg;
                 if (isImage(plot)) {
-                    showInfoPopup('You may not zoom beyond ' + getZoomMax(plot) + 'x', 'Zoom Info');
+                    msg= 'You may not zoom beyond ' + getZoomMax(plot) + 'x';
                 }
                 else {
-                    showInfoPopup('You have reached the maximum zoom depth', 'Zoom Info');
+                    msg= `You may not zoom beyond HiPS Norder level ${MAX_SUPPORTED_HIPS_LEVEL}`;
                 }
+
+                const renderContent= <div style={{padding: '5px 0 5px 0',whiteSpace: 'nowrap'}}> {msg} </div> ;
+                showInfoPopup(renderContent, 'Zoom Info');
                 return;
             }
         }


### PR DESCRIPTION
Fixed various small HiPS issues

   - async ivo resolve and coverage tweeks (DM-14018)
   - allows and empty target after a valid target (DM-14018)
   - title issues fixed (DM-14018)
   - catch potential hips_initial_fov errors (DM-14018))
   - Layer control grid lock level maxes out at 14 (DM-14016)
   - HiPS zoom can go down to 14 (DM-14016)
   - HiPS grid is now `HEALPix (HiPS) Grid` (DM-14016)
   - Better error messages (see IRSA-1663)

_to test:_

Test #:
  1. in ffapi-hips-test.html set `hipsRootUrl` to a ivo id and see it if works.
  1. in the image query panel set a target, load a  hips, uncheck the lock, go back to the query panel, delete the target so it is empty, load another hips, they should load at the same place
  1. zoom way in to a hips.  It should go to level 14
  1. It is hard to test all the error messages. Goto image search and try to load a hips with a bad URL.
  
