### PR TITLE
DM-10465 Fix position input parsing bugs or better position input error messages

### DIFF
--- a/src/firefly/js/data/form/PositionFieldDef.js
+++ b/src/firefly/js/data/form/PositionFieldDef.js
@@ -53,34 +53,37 @@ var makePositionFieldDef= function(properties) {
 
                 // check coordinate system
                 if (_parser.getCoordSys() === CoordinateSys.UNDEFINED) {
-                    throw getErrMsg() + 'invalid coordinate system.';
+                    throw getErrMsg() + 'Invalid coordinate system';
                 }
 
                 // validate RA
                 var ra = _parser.getRa();
                 if (isNaN(ra)) {
-                    const errRA = _parser.getRAParseError();
+                    const errRA = _parser.getRAParseError() || 'Unable to parse RA';
                     if (errRA) {
                         throw `${getErrMsg()}${errRA}`;
                     }
+                    /*
                     var raStr = _parser.getRaString();
 
                     if (hard || (raStr !==null && !(raStr.length === 1 && raStr.charAt(0) === '.'))) {
-                        throw getErrMsg() + 'unable to parse RA.';
+                        throw getErrMsg() + 'Unable to parse RA.';
                     }
+                    */
                 }
                 // validate DEC
                 var dec = _parser.getDec();
                 if (isNaN(dec)) {
-                    const errDec = _parser.getDECParseError();
-
+                    const errDec = _parser.getDECParseError() || 'Unable to parse DEC';
                     if (errDec) {
                         throw `${getErrMsg()}${errDec}`;
                     }
+                    /*
                     var decStr = _parser.getDecString();
                     if (hard || (decStr !== null && !(decStr.length === 1 && (decStr.charAt(0) === '+' || decStr.charAt(0) === '-' || decStr.charAt(0) === '.')))) {
-                        throw getErrMsg() + 'unable to parse DEC.';
+                        throw getErrMsg() + 'Unable to parse DEC.';
                     }
+                    */
                 }
             }
         }
@@ -94,13 +97,14 @@ var makePositionFieldDef= function(properties) {
     }
 
     function getErrMsg() {
-        return 'error: ';
+        return 'Error: ';
     }
 
     // -------------------- public methods --------------------
-     /**
+
+    /**
      *
-     * @returns WorldPt
+     * @return {object} world position
      */
     var getPosition= function() {
         return _parser.getPosition();

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -180,7 +180,7 @@ function makePayloadAndUpdateActive(displayValue, parseResults, resolvePromise, 
     const wpStr= parseResults && wpt ? wpt.toString() : null;
 
     const payload= {
-        message : 'Could not resolve object: Enter valid object',
+        message : parseResults.parseError || 'Could not resolve object: Enter valid object',
         displayValue,
         wpt,
         value : resolvePromise ? resolvePromise  : wpStr,

--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -86,13 +86,17 @@ export var parseTarget= function(inStr, lastResults, resolver) {
     var resolveData;
     var resolvePromise= null;
     var aborter= null;
+    let errMsg = null;
+
     if (targetInput) {
         if (lastResults && lastResults.aborter) lastResults.aborter();
         try {
             valid= posFieldDef.validateSoft(targetInput);
         } catch (e) {
             valid= false;
+            errMsg = e;
         }
+
         if (valid) {
             wpt= posFieldDef.getPosition();
             if (posFieldDef.getInputType()===PositionParser.PositionParsedInput.Position) {
@@ -116,7 +120,7 @@ export var parseTarget= function(inStr, lastResults, resolver) {
         aborter= resolveData.aborter;
     }
 
-    return {showHelp, feedback,
+    return {showHelp, feedback, parseError: errMsg,
             inputType: posFieldDef.getInputType(),
             valid, resolvePromise, wpt, aborter  };
 };

--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -80,7 +80,6 @@ export var parseTarget= function(inStr, lastResults, resolver) {
     var valid= false;
     var targetInput= inStr;
     var feedback= 'valid: false';
-    //var update= true;
     var showHelp= true;
     var posFieldDef= PositionFieldDef.makePositionFieldDef();
     var resolveData;
@@ -173,7 +172,6 @@ var resolveObject = function(posFieldDef, resolver) {
             }
         }
     ).catch(function(e) {
-            // console.log(`aborted: ${objName}`);
             if (e) console.error(e);
         });
 

--- a/src/firefly/js/util/PositionParser.js
+++ b/src/firefly/js/util/PositionParser.js
@@ -83,6 +83,14 @@ var makePositionParser = function(helper) {
         return helper.convertStringToLat(v, _coordSys);
     };
 
+    retPP.getRAParseError = function() {
+        return helper.getRAError();
+    };
+
+    retPP.getDECParseError = function () {
+        return helper.getDECError();
+    };
+
     retPP.getRaString= function() {
         return _ra;
     };
@@ -177,10 +185,10 @@ var makePositionParser = function(helper) {
                 }
                 if (numericList.length>0) {
                     for (i=0; (i<numericList.length); i++) {
-                        dec += (item+' ');
+                        dec += (numericList[i] + ' ');
                     }
                     for (i=0; (i<alphabetList.length); i++) {
-                        coordSys += (item+' ');
+                        coordSys += (alphabetList[i]+' ');
                     }
                 } else {
                     if (alphabetList.length===1) {
@@ -440,30 +448,6 @@ var makePositionParser = function(helper) {
         return retval;
     }
 
-
-
-    function coordToString(csys) {
-        var retval= '';
-
-        if (csys===CoordinateSys.EQ_J2000) {
-            retval= 'Equ J2000';
-        }
-        else if (csys===CoordinateSys.EQ_B1950) {
-            retval= 'Equ B1950';
-        }
-        else if (csys===CoordinateSys.GALACTIC) {
-            retval= 'Gal';
-        }
-        else if (csys===CoordinateSys.ECL_J2000) {
-            retval= 'Ecl J2000';
-        }
-        else if (csys===CoordinateSys.ECL_B1950) {
-            retval= 'Ecl B1950';
-        }
-
-        return retval;
-
-    }
 
     function matches(s, regExp) {
         return helper.matchesIgnoreCase(s, regExp);

--- a/src/firefly/js/visualize/CoordUtil.js
+++ b/src/firefly/js/visualize/CoordUtil.js
@@ -21,7 +21,6 @@ const FORM_DMS = 1;             // 12d34m23.4s
 const FORM_HMS = 2;             // 12h34m23.4s
 
 const LAT_OUT_RANGE = 'Latitude is out of range [-90.0, +90.0]';
-//var LON_OUT_RANGE = 'Longitude is out of range [0.0, 360.0)';
 const LON_TOO_BIG = 'Longitude is too big (>=360.0)';
 const LON_NEGATIVE = 'Longitude can not be negative';
 const RA_TOO_BIG = 'RA is too big (>=24 hours)';

--- a/src/firefly/js/visualize/CoordUtil.js
+++ b/src/firefly/js/visualize/CoordUtil.js
@@ -32,7 +32,7 @@ const MIN_SEC_TOO_BIG = 'Greater than 60 minutes or seconds';
 const INVALID_SEPARATOR = 'Invalid input';
 
 
-
+const isDigit = (c) => (!!c.trim() && (c > -1));
 
 
 /**
@@ -100,7 +100,7 @@ var sex2dd = function (coordstr, islat, isequ) {
                     }  //Mark this place - number starts here
                 }
             }
-            else if (!isNaN(p.charAt(0))) {
+            else if (isDigit(p.charAt(0))) {
                 if (pointseen===0) {
                     cntdigits++;
                 }
@@ -242,7 +242,7 @@ var sex2dd = function (coordstr, islat, isequ) {
 
         } else if (sep[0] ===' ') {
 
-            isdec= (isequ && !islat);
+            isdec= !(isequ && !islat);  // per CoordUtil.java
 
         } else if (sep[0] ==='m') {
             isdec = false;


### PR DESCRIPTION
This development includes:
- Better error messages for position input in more specific description by creating the method to show the existing parsing error messages already in the codes, such as (-34, 23) or (123, -91) in which ra or dec is out of range. 
- fix the position input parsing bug for the following input style
    <ra>, <dec> <coordinate system>  (ex. '12.3, 23.4 gal' or '18.0, -23.0 Equ J2000’)
- fix the interpretation bug for the position input in HMS format, like ’12 34 56.89 -23 45 16.56’

Test:
Start Firefly image search
Enter the position input examples as follows, read the position description or the error message if there is, 
     (-34, 23)
      12.3, 23.4 gal
      '18.0, -23.0 Equ J2000’
     ’12 34 56.89 -23 45 16.56’
  