### PR TITLE
DM-14230 Python API show_chart failure with FireflySlate template

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-test.html
+++ b/src/firefly/html/demo/ffapi-highlevel-test.html
@@ -71,7 +71,8 @@
     </div>
 </div>
 <div>XYPlot from API calls:
-    <a href='javascript:firefly.getViewer().showXYPlot(xyPlotOpsReq3)'>Show XY Plot</a>
+    <a href='javascript:firefly.getViewer().showXYPlot(xyPlotOpsReq3)'>Show XY Plot</a>&nbsp;&nbsp;&nbsp;
+    <a href='javascript:firefly.getViewer().showChart({data:[{x: [1,2,3], y: [1,2,3]}]})'>Show Chart</a>
 </div>
 <div>
     <div id="xyPlot1" style="display: inline-block; width: 550px; height: 300px; margin: 10px; background-color: white"></div>

--- a/src/firefly/html/slate.html
+++ b/src/firefly/html/slate.html
@@ -23,7 +23,7 @@
                 MenuItemKeys: {maskOverlay:true},
                 catalogSpacialOp: 'polygonWhenPlotExist',
                 disableDefaultDropDown: true,
-                charts: {multitrace: true}
+                charts: {maxRowsForScatter: 15000}
             }
         };
     </script>

--- a/src/firefly/html/slate.html
+++ b/src/firefly/html/slate.html
@@ -23,7 +23,7 @@
                 MenuItemKeys: {maskOverlay:true},
                 catalogSpacialOp: 'polygonWhenPlotExist',
                 disableDefaultDropDown: true,
-                charts: {maxRowsForScatter: 15000}
+                charts: {maxRowsForScatter: 15000, defaultDeletable: true}
             }
         };
     </script>

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -112,6 +112,7 @@ const defFireflyOptions = {
     workspace : { showOptions: false},
 
     charts: {
+        defaultDeletable: undefined, // by default if there are more than one chart in container, all charts are deletable
         maxRowsForScatter: 5000, // maximum table rows for scatter chart support
         multitrace: true,  // deprecated - by default we use multi-trace architecture
         singleTraceUI: false, // by default we support multi-trace in UI

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -49,8 +49,8 @@ function fetchData(chartId, traceNum, tablesource) {
         dispatchError(chartId, traceNum, `${totalRows} rows exceed scatter chart best performance limit of ${maxScatterRows}.`);
         return;
     }
-
-    const numericCols = getColumns(originalTableModel, COL_TYPE.NUMBER).map((c) => c.name);
+    
+    const colNames = getColumns(originalTableModel).map((c) => c.name);
 
     // default behavior
     const sreq = cloneRequest(request, {
@@ -60,7 +60,7 @@ function fetchData(chartId, traceNum, tablesource) {
             // we'd like expression columns to be named as the paths to trace data arrays, ex. data[0].x
             //const asStr = (numericCols.includes(v)) ? '' : k.startsWith('firefly') ? ` as "${k}"` :` as "data.${traceNum}.${k}"`;
             const asStr = k.startsWith('firefly') ? ` as "${k}"` :` as "data.${traceNum}.${k}"`;
-            return `${formatColExpr({colOrExpr: v, quoted: true, colNames: numericCols})}${asStr}`;
+            return `${formatColExpr({colOrExpr: v, quoted: true, colNames})}${asStr}`;
         }).join(', ')    // allows to use the same columns, ex. "w1" as "x", "w1" as "marker.color"
     });
 

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -136,7 +136,7 @@ export class ChartsContainer extends PureComponent {
                 <ChartPanel key={chartId} expandable={true} chartId={chartId}/>;
         } else {
             return (
-                <MultiChartViewer {...{closeable, viewerId, expandedMode}}/>
+                <MultiChartViewer {...{closeable, viewerId : viewerId, expandedMode}}/>
             );
         }
     }

--- a/src/firefly/js/charts/ui/HistogramPlotly.jsx
+++ b/src/firefly/js/charts/ui/HistogramPlotly.jsx
@@ -156,7 +156,7 @@ export class HistogramPlotly extends Component {
             plotlyLayout: {
                 height,
                 width,
-                hovermode: 'compare',
+                hovermode: 'x',
                  xaxis: {
                     title: `${desc} ` + (xUnit ? `(${xUnit})` : ''),
                     type: (logs && logs.includes('x') ? LOG : LINEAR),

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -27,7 +27,7 @@ export class MultiChartViewer extends PureComponent {
 
     constructor(props) {
         super(props);
-        this.state= {viewer : null};
+        this.state= {viewer : getViewer(getMultiViewRoot(), props.viewerId)};
     }
 
     componentWillReceiveProps(nextProps) {

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -76,7 +76,19 @@ export class MultiChartViewer extends PureComponent {
         const {viewerId, expandedMode, closeable} = this.props;
         const {viewer}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId);
-        if (!viewer || isEmpty(viewer.itemIdAry)) return false;
+        if (!viewer || isEmpty(viewer.itemIdAry)) {
+            if (expandedMode && closeable) {
+                return (
+                    <div className='ChartPanel__container'>
+                        <div style={{position: 'relative', flexGrow: 1}}>
+                        {expandedMode && closeable && <CloseButton style={{paddingLeft: 10, position: 'absolute', top: 0, left: 0}} onClick={() => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)}/>}
+                        </div>
+                    </div>
+                );
+            } else {
+                return false;
+            }
+        }
         let activeItemId = getActiveViewerItemId(viewerId);
         if (isUndefined(activeItemId) || !getChartData(activeItemId)) {
             activeItemId = viewer.itemIdAry[0];
@@ -140,7 +152,7 @@ const stopPropagation= (ev) => ev.stopPropagation();
 
 
 MultiChartViewer.propTypes= {
-    viewerId : PropTypes.string.isRequired,
+    viewerId : PropTypes.string,
     canReceiveNewItems : PropTypes.string,
     forceRowSize : PropTypes.number,
     forceColSize : PropTypes.number,

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -5,7 +5,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {pickBy, isEmpty} from 'lodash';
+import {get, pickBy, isEmpty} from 'lodash';
 
 import {flux, firefly} from '../../Firefly.js';
 import {getMenu, isAppReady, dispatchSetMenu, dispatchOnAppReady} from '../../core/AppDataCntlr.js';
@@ -131,8 +131,8 @@ function mainView({expanded,gridView, gridColumns, leftButtons, centerButtons, r
             return <ImageExpandedMode closeFunc={closeExpanded}/>;
             break;
         case LO_VIEW.xyPlots:
-            const obj= getExpandedChartProps();
-            const chartViewerId= obj ? findViewerWithItemId(getMultiViewRoot(), obj.chartId, PLOT2D) : null;
+            const chartId = get(getExpandedChartProps(), 'chartId');
+            const chartViewerId= chartId ? findViewerWithItemId(getMultiViewRoot(), chartId, PLOT2D) : null;
             return <ChartsContainer closeable={true} expandedMode={true} viewerId={chartViewerId}/>;
             break;
         case LO_VIEW.tables:

--- a/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
+++ b/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
@@ -7,7 +7,6 @@ import {filter, isEmpty, get, isArray, uniq} from 'lodash';
 
 import {startImageMetadataWatcher} from '../../visualize/saga/ImageMetaDataWatcher.js';
 import {startCoverageWatcher} from '../../visualize/saga/CoverageWatcher.js';
-import {dispatchAddSaga} from '../../core/MasterSaga.js';
 
 import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, ENABLE_SPECIAL_VIEWER, SPECIAL_VIEWER,
           getLayouInfo, dispatchUpdateLayoutInfo, dispatchAddCell, dispatchRemoveCell, getNextCell} from '../../core/LayoutCntlr.js';
@@ -17,9 +16,8 @@ import {dispatchLoadTblStats} from '../../charts/TableStatsCntlr';
 
 import {CHART_ADD, CHART_REMOVE} from '../../charts/ChartsCntlr.js';
 
-import ImagePlotCntlr, {visRoot} from '../../visualize/ImagePlotCntlr.js';
-import {REPLACE_VIEWER_ITEMS, DEFAULT_FITS_VIEWER_ID, IMAGE, PLOT2D, dispatchAddViewer, dispatchAddViewerItems,
-    getViewer, getViewerItemIds, getMultiViewRoot, findViewerWithItemId} from '../../visualize/MultiViewCntlr.js';
+import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
+import {REPLACE_VIEWER_ITEMS, IMAGE, getViewerItemIds, getMultiViewRoot, findViewerWithItemId} from '../../visualize/MultiViewCntlr.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
 
 /**
@@ -171,8 +169,6 @@ function handleChartDelete(layoutInfo, action) {
 
 
 function handleNewImage(layoutInfo, action) {
-
-
     const {payload}= action;
     const {gridView=[]}= layoutInfo;
     const mvRoot= getMultiViewRoot();
@@ -209,23 +205,14 @@ function handleNewImage(layoutInfo, action) {
 
 function handleNewChart(layoutInfo, action) {
 
-    const {chartId, viewerId}= action.payload;
+    const {viewerId}= action.payload;
     const {gridView=[]}= layoutInfo;
-
-    // viewer should be updated before cell adding
-    const viewer= getViewer(getMultiViewRoot(), viewerId);
-    if (!viewer) {
-        dispatchAddViewer(viewerId,true,PLOT2D,true);
-    }
-    dispatchAddViewerItems(viewerId, [chartId], PLOT2D);
 
     const item= gridView.find( (g) => g.cellId===viewerId);
     if (!item) {
-        const viewer= findViewerWithItemId(getMultiViewRoot(), chartId, PLOT2D);
         const cell= getNextCell(gridView,3,1);
-        dispatchAddCell({row:cell.row,col:cell.col,width:1,height:1,cellId:viewer,type:LO_VIEW.xyPlots});
+        dispatchAddCell({row:cell.row,col:cell.col,width:1,height:1,cellId:viewerId,type:LO_VIEW.xyPlots});
     }
-
 
     return layoutInfo;
 }

--- a/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
+++ b/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
@@ -151,7 +151,6 @@ function handleTableDelete(layoutInfo, action) {
     if (tbl_group && isEmpty(tblIdAry)) {
         dispatchRemoveCell({cellId:tbl_group});
     }
-
 }
 
 function handlePlotDelete(layoutInfo, action) {
@@ -163,8 +162,11 @@ function handlePlotDelete(layoutInfo, action) {
 }
 
 function handleChartDelete(layoutInfo, action) {
-    //todo: implement
-    console.log('implement chart delete');
+    const {viewerId}= action.payload;
+    const itemAry= getViewerItemIds(getMultiViewRoot(), viewerId);
+    if (isEmpty(itemAry)) {
+        dispatchRemoveCell({cellId:viewerId});
+    }
 }
 
 
@@ -207,25 +209,16 @@ function handleNewImage(layoutInfo, action) {
 
 function handleNewChart(layoutInfo, action) {
 
-    const {chartId, groupId, viewerId, chartType}= action.payload;
+    const {chartId, viewerId}= action.payload;
     const {gridView=[]}= layoutInfo;
 
-    if (chartType!=='plot.ly') {
-        if (groupId) {
-            let viewer= getViewer(getMultiViewRoot(), groupId);
-            if (!viewer) {
-                dispatchAddViewer(groupId,true,PLOT2D,true);
-            }
-            dispatchAddViewerItems(groupId, [chartId], PLOT2D);
-
-            const item= gridView.find( (g) => g.cellId===groupId);
-            if (!item) {
-                viewer= findViewerWithItemId(getMultiViewRoot(), chartId, PLOT2D);
-                const cell= getNextCell(gridView,3,1);
-                dispatchAddCell({row:cell.row,col:cell.col,width:3,height:1,cellId:viewer,type:LO_VIEW.xyPlots});
-            }
-        }
+    // viewer should be updated before cell adding
+    const viewer= getViewer(getMultiViewRoot(), viewerId);
+    if (!viewer) {
+        dispatchAddViewer(viewerId,true,PLOT2D,true);
     }
+    dispatchAddViewerItems(viewerId, [chartId], PLOT2D);
+
     const item= gridView.find( (g) => g.cellId===viewerId);
     if (!item) {
         const viewer= findViewerWithItemId(getMultiViewRoot(), chartId, PLOT2D);


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-14230

To test
- cd firefly_client/firefly_client
-  jupyter notebook ../examples/
- Use slate-demo-explicit2.ipynb, after creating FireflyClient (fc) and launching browser, add a cell `status = fc.show_chart(data=[dict(x=[1,2,3])])` - make sure the chart shows up and expand works. 

Also added code to remove cell on chart delete, fixed a bug preventing text columns in chart data, and a few other.