### PR TITLE
IRSA-1790: Download for irsaviewer and finderchart stopped working.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
@@ -32,6 +32,7 @@ public class RequestAgent {
     private String requestUrl;
     private String baseUrl;
     private String remoteIP;
+    private String contextPath;
 
     public void setCookies(Map<String, String> cookies) {
         this.cookies = cookies;
@@ -47,6 +48,9 @@ public class RequestAgent {
     public String getProtocol() {
         return protocol;
     }
+
+    public String getContextPath() { return contextPath; }
+    public void setContextPath(String contextPath) { this.contextPath = contextPath; };
 
     public void setProtocol(String protocol) {
         this.protocol = protocol;
@@ -136,10 +140,12 @@ public class RequestAgent {
             String serverName = request.getServerName();
             int serverPort = request.getServerPort();
             String serverPortDesc = serverPort == 80 || serverPort == 443 ? "" : ":" + serverPort;
+            String contextPath = getPath(request);
 
-            String baseUrl = String.format("%s://%s%s%s/", scheme, serverName, serverPortDesc, request.getContextPath());
+            String baseUrl = String.format("%s://%s%s%s/", scheme, serverName, serverPortDesc, contextPath);
             String requestUrl = String.format("%s://%s%s%s", scheme, serverName, serverPortDesc, request.getRequestURI());
 
+            setContextPath(contextPath);
             setRemoteIP(remoteIP);
             setProtocol(scheme);
             setRequestUrl(requestUrl);
@@ -173,9 +179,29 @@ public class RequestAgent {
 
         @Override
         public String getHeader(String name, String def) {
-            String retval = request != null ? request.getHeader(name) : null;
+            if (request != null) {
+                String retval = request.getHeader(name);
+                retval = retval == null ? request.getHeader(name.toLowerCase()) : retval;
             return StringUtils.isEmpty(retval) ? def : retval;
+            } else {
+                return def;
+            }
         }
+
+        private String getPath(HttpServletRequest request) {
+            String path = request.getHeader("X-Forwarded-Path");
+            if (path == null) {
+                path = request.getHeader("x-original-uri");
+                if (path != null) {
+                    path = path.substring(0, path.indexOf(request.getContextPath()) + request.getContextPath().length());
+                }
+            }
+            if (path == null) {
+                path = request.getContextPath();
+            }
+            return path;
+        }
+
 
         @Override
         public void sendRedirect(String url) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -184,6 +184,10 @@ public class RequestOwner implements Cloneable {
         ro.referrer = referrer;
         ro.host = host;
         ro.wsManager = wsManager;
+        ro.userKey = userKey;
+        ro.eventChannel = eventChannel;
+        ro.eventConnID = eventConnID;
+
         return ro;
     }
 
@@ -237,7 +241,7 @@ public class RequestOwner implements Cloneable {
         if (!nVal.equals(String.valueOf(cVal))) {
             Cookie cookie = new Cookie(USER_KEY, userKey + "/" + userName);
             cookie.setMaxAge(3600 * 24 * 7 * 2);      // to live for two weeks
-            cookie.setPath("/"); // to make it available to all subpasses within base URL
+            cookie.setPath(requestAgent.getContextPath());
             requestAgent.sendCookie(cookie);
         }
     }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-1790

Download stopped working for irsaviewer and finderchart.  This is because finderchart created usrkey cookie with path '/'.  When frontpage and finderchart or irsaviewer are running on the same page, usrkey for frontpage was also sent to finderchart causing confusion.

The fix is made to FrontPage.  usrkey for frontpage will have a path of '/frontpage'.
I will deploy the changes to frontpage on irsabannertest1&2.  This should fix the download problem on irsadev.