### PR TITLE
DM-14157: hips/fits/aitoff switching

### DIFF
--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -38,12 +38,6 @@ var options = {
         mergedListPriority: 'Irsa'
     },
     coverage : { // example of using DSS and wise combination for coverage (not that anyone would want to combination)
-        hipsSourceURL : 'http://alasky.u-strasbg.fr/DSS/DSSColor', // url
-            imageSourceParams: {
-            Service : 'WISE',
-                SurveyKey: '1b',
-                SurveyKeyBand: '4'
-        }
     }
 };
 

--- a/src/firefly/js/ui/ButtonGroup.css
+++ b/src/firefly/js/ui/ButtonGroup.css
@@ -1,0 +1,35 @@
+
+.buttonGroupButton {
+    background-color: #aaa;
+    border: 1px solid #ccc;
+    border-left: 0;
+    cursor: pointer;
+    margin: 0;
+    /*padding: 5px 10px;*/
+    position: relative;
+}
+
+.buttonGroupButton.Off {
+    background-color: white;
+}
+
+.buttonGroupButton.On {
+    background-color: #aaa;
+}
+
+
+
+.buttonGroupButton.On:focus {
+    outline-width: 0;
+}
+
+.buttonGroupButton.Off:focus {
+    outline-width: 0;
+}
+
+.buttonGroupButton.Off:hover {
+    background-color: #999;
+}
+.buttonGroupButton.On:hover {
+    background-color: #999;
+}

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -23,13 +23,13 @@ import {FileUpload} from '../ui/FileUpload.jsx';
 import {FieldGroup} from './FieldGroup.jsx';
 
 import CsysConverter from '../visualize/CsysConverter.js';
-import {primePlot, getActivePlotView} from '../visualize/PlotViewUtil.js';
+import {primePlot, getActivePlotView, getFoV} from '../visualize/PlotViewUtil.js';
 import { makeImagePt, makeWorldPt, makeScreenPt, makeDevicePt} from '../visualize/Point.js';
 import {visRoot} from '../visualize/ImagePlotCntlr.js';
-
 import {getValueInScreenPixel} from '../visualize/draw/ShapeDataObj.js';
+
 import './CatalogSearchMethodType.css';
-import {getHiPSFoV} from "../visualize/HiPSUtil";
+
 /*
  Component which suppose to handle the catalog method search such as cone, elliptical,etc.
  each of the option has different option panel associated
@@ -161,7 +161,7 @@ function calcCornerString(pv, method) {
     var w = plot.dataWidth;
     var h = plot.dataHeight;
     var cc = CsysConverter.make(plot);
-    const radiusSearch = getHiPSFoV(pv) > maxHipsRadiusSearch ? maxHipsRadiusSearch * 3600 : getHiPSFoV(pv) * 3600; // in arcsec
+    const radiusSearch = getFoV(pv) > maxHipsRadiusSearch ? maxHipsRadiusSearch * 3600 : getFoV(pv) * 3600; // in arcsec
 
     if (method==='image' || (!sel && method==='area-selection') ) {
         pt1 = cc.getWorldCoords(makeImagePt(0,0));

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -231,9 +231,9 @@ export class HiPSSurveyListSelection extends PureComponent {
 
     componentWillMount() {
         const sources = sourcesPerChecked();
-        const {dataType, surveysId} = this.props;
+        const {dataType, surveysId, hipsUrl} = this.props;
 
-        loadHiPSSurverysWithHighlight({dataTypes: dataType, id: surveysId, sources});
+        loadHiPSSurverysWithHighlight({dataTypes: dataType, id: surveysId, sources, ivoOrUrl: hipsUrl, columnName: URL_COL});
         this.setState({isUpdatingHips: isLoadingHiPSSurverys(makeHiPSSurveysTableName(surveysId, sources))});
     }
 

--- a/src/firefly/js/ui/RadioGroupInputFieldView.jsx
+++ b/src/firefly/js/ui/RadioGroupInputFieldView.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {uniqueId} from 'lodash';
 import InputFieldLabel from './InputFieldLabel.jsx';
+
+import './ButtonGroup.css';
 
 const vStyle={paddingLeft: 3, paddingRight: 8};
 const hStyle={paddingLeft: 0, paddingRight: 12};
 
 
-function makeOptions(options,alignment ,value,onChange,tooltip, labelStyle) {
+function makeRadioGroup(options,alignment ,value,onChange,tooltip, labelStyle) {
 
     const style = labelStyle?labelStyle:(alignment==='vertical' ? vStyle : hStyle);
     return options.map((option) => (
@@ -25,18 +26,43 @@ function makeOptions(options,alignment ,value,onChange,tooltip, labelStyle) {
     ));
 }
 
+function makeButtonGroup(options,value,onChange,tooltip, labelStyle) {
+
+    return options.map((option,idx) => (
+        <button type='button'   key={'' + idx} title={option.tooltip}
+                className={value===option.value ? 'buttonGroupButton On' : 'buttonGroupButton Off'}
+                value={option.value}
+                onClick={(ev) => ev.target.value!==value && onChange(ev)}>
+            {option.label}
+        </button>
+    ));
+}
+
+
+
+
 export function RadioGroupInputFieldView({options,alignment,value,
                                           onChange,label,inline,tooltip,
+                                          buttonGroup= false,
                                           labelWidth, wrapperStyle={}, labelStyle=undefined}) {
+
     const style= Object.assign({whiteSpace:'nowrap',display: inline?'inline-block':'block'},wrapperStyle);
-    const radioStyle = (alignment && alignment==='vertical') ? {display: 'block', marginTop: (label ? 10 : 0)}
-                                                             : {display: 'inline-block'};
+    let innerStyle;
+    if (buttonGroup) {
+        innerStyle= {display: 'flex'};
+    }
+    else {
+        innerStyle = (alignment==='vertical') ? {display: 'block', marginTop: (label ? 10 : 0)}
+            : {display: 'inline-block'};
+    }
 
     return (
         <div style={style}>
             {label && <InputFieldLabel label={label} tooltip={tooltip} labelWidth={labelWidth} /> }
-            <div style={radioStyle} >
-                {makeOptions(options,alignment,value,onChange,tooltip,labelStyle)}
+            <div style={innerStyle} >
+                {buttonGroup ?
+                     makeButtonGroup(options,value,onChange,tooltip,labelStyle) :
+                     makeRadioGroup(options,alignment,value,onChange,tooltip,labelStyle)}
             </div>
         </div>
     );
@@ -52,6 +78,7 @@ RadioGroupInputFieldView.propTypes= {
     inline : PropTypes.bool,
     labelWidth : PropTypes.number,
     wrapperStyle: PropTypes.object,
-    labelStyle: PropTypes.object
+    labelStyle: PropTypes.object,
+    buttonGroup : PropTypes.bool,
 };
 

--- a/src/firefly/js/ui/ZoomOptionsPopup.jsx
+++ b/src/firefly/js/ui/ZoomOptionsPopup.jsx
@@ -7,9 +7,9 @@ import {flux} from '../Firefly.js';
 import {dispatchShowDialog, dispatchHideDialog} from '../core/ComponentCntlr.js';
 import DialogRootContainer from './DialogRootContainer.jsx';
 import {PopupPanel} from './PopupPanel.jsx';
-import {getActivePlotView, primePlot} from '../visualize/PlotViewUtil.js';
+import {getActivePlotView, primePlot, getFoV} from '../visualize/PlotViewUtil.js';
 import {visRoot, dispatchZoom} from '../visualize/ImagePlotCntlr.js';
-import {levels, UserZoomTypes, convertZoomToString} from '../visualize/ZoomUtil';
+import {levels, UserZoomTypes, convertZoomToString, makeFoVString} from '../visualize/ZoomUtil';
 import {ToolbarButton} from './ToolbarButton.jsx';
 
 const _levels = levels;
@@ -19,7 +19,7 @@ function getDialogBuilder() {
     return () => {
         if (!popup) {
             const popup = (
-                <PopupPanel title={'Zoom Level'}>
+                <PopupPanel title={'Choose Field of View'}>
                     <ZoomOptionsPopup groupKey={'ZOOM_OPTIONS_FORM'}/>
                 </PopupPanel>
             );
@@ -64,7 +64,9 @@ class ZoomOptionsPopup extends PureComponent {
 
     constructor(props)  {
         super(props);
-        this.state = {plot:primePlot(visRoot()),initcurrLevel:primePlot(visRoot()).zoomFactor};
+        this.state = {plot:primePlot(visRoot()),
+            initcurrLevel:primePlot(visRoot()).zoomFactor,
+            plotView:getActivePlotView(visRoot())};
     }
 
     componentWillUnmount() {
@@ -89,17 +91,21 @@ class ZoomOptionsPopup extends PureComponent {
 
 
     render() {
-        const { plot, initcurrLevel} = this.state;
-        return <ZoomOptionsPopupForm  plot={plot} initcurrLevel={initcurrLevel}/>;
+        const { plot, initcurrLevel, plotView} = this.state;
+        return <ZoomOptionsPopupForm  plotView={plotView} plot={plot} initcurrLevel={initcurrLevel}/>;
     }
 
 }
 
+function makeZoomLabel(pv, zfactor) {
+    return makeFoVString(getFoV(pv,zfactor));
+}
+
 function ZoomOptionsPopupForm() {
 
-   const {plot, initcurrLevel} = getInitialPlotState();
+   const {plot, pv, initcurrLevel} = getInitialPlotState();
 
-    var verticalColumn = {display: 'inline-block', paddingLeft: 10, paddingBottom: 20, paddingRight: 10};
+    var verticalColumn = {display: 'inline-block', padding: '10px 10px 20px 25px'};
     var zoom_levels = _levels;
 
     var initcurrZoomLevelStr = convertZoomToString(initcurrLevel);
@@ -107,11 +113,12 @@ function ZoomOptionsPopupForm() {
 
     var optionArray = [];
     for (var i = 0; i < zoom_levels.length; i++) {
-        optionArray[i] = {label: convertZoomToString(zoom_levels[i]), value: zoom_levels[i]};
+        // optionArray[i] = {label: convertZoomToString(zoom_levels[i]), value: zoom_levels[i]};
+        optionArray[i] = {label: makeZoomLabel(pv,zoom_levels[i]), value: zoom_levels[i]};
     }
 
     return (
-            <div style={{ minWidth:100, minHeight: 300} }>
+            <div style={{ minWidth:150, minHeight: 300} }>
 
                 <div style={verticalColumn}>
                     {makezoomItems(plot, optionArray)}

--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -245,7 +245,8 @@ export function getHiPSZoomLevelToFit(pv,size) {
     const cc= CysConverter.make(tmpPlot);
     const pt1= cc.getImageCoords( makeWorldPt(0,0, plot.imageCoordSys));
     const pt2= cc.getImageCoords( makeWorldPt(size,0, plot.imageCoordSys));
-    return Math.min(width, height)/Math.abs(pt2.x-pt1.x);
+    // return Math.min(width, height)/Math.abs(pt2.x-pt1.x);
+    return width/Math.abs(pt2.x-pt1.x);
 }
 
 

--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -13,17 +13,15 @@
 
 
 import {get, isUndefined} from 'lodash';
-import {clone} from '../util/WebUtil.js';
+import {clone, encodeServerUrl} from '../util/WebUtil.js';
 import {CysConverter} from './CsysConverter.js';
-import {makeWorldPt, makeDevicePt} from './Point.js';
-import {SpatialVector, HealpixIndex} from '../externalSource/aladinProj/HealpixIndex.js';
-import {convert, computeDistance} from './VisUtil.js';
-import {replaceHeader, getScreenPixScaleArcSec} from './WebPlot.js';
+import {makeDevicePt, makeWorldPt} from './Point.js';
+import {HealpixIndex, SpatialVector} from '../externalSource/aladinProj/HealpixIndex.js';
+import {computeDistance, convert, toDegrees} from './VisUtil.js';
+import {getScreenPixScaleArcSec, replaceHeader} from './WebPlot.js';
 import {primePlot} from './PlotViewUtil.js';
 import CoordinateSys from './CoordSys';
-import {encodeServerUrl} from '../util/WebUtil.js';
 import {getRootURL} from '../util/BrowserUtil.js';
-import {toDegrees} from './VisUtil.js';
 
 
 export const MAX_SUPPORTED_HIPS_LEVEL= 14;
@@ -248,21 +246,6 @@ export function getHiPSZoomLevelToFit(pv,size) {
     const pt1= cc.getImageCoords( makeWorldPt(0,0, plot.imageCoordSys));
     const pt2= cc.getImageCoords( makeWorldPt(size,0, plot.imageCoordSys));
     return Math.min(width, height)/Math.abs(pt2.x-pt1.x);
-}
-
-/**
- *
- * @param {PlotView} pv
- * @return {number} fov in degrees
- */
-export function getHiPSFoV(pv) {
-    const cc= CysConverter.make(primePlot(pv));
-    const {width,height}=pv.viewDim;
-    if (!cc || !width || !height) return;
-
-    const pt1= cc.getWorldCoords( makeDevicePt(1,height/2));
-    const pt2= cc.getWorldCoords( makeDevicePt(width-1,height/2));
-    return (pt1 && pt2) ? computeDistance(pt1,pt2) : 180;
 }
 
 

--- a/src/firefly/js/visualize/PlotTransformUtils.js
+++ b/src/firefly/js/visualize/PlotTransformUtils.js
@@ -10,13 +10,12 @@ import {get, isNil} from 'lodash';
 import {Matrix} from 'transformation-matrix-js';
 import {primePlot} from './PlotViewUtil.js';
 import {clone, updateSet} from '../util/WebUtil.js';
-import {getCenterOfProjection} from './PlotViewUtil.js';
+import {getCenterOfProjection, getFoV} from './PlotViewUtil.js';
 
 import {toRadians} from './VisUtil.js';
 import {CysConverter}  from './CsysConverter.js';
 import {makeScreenPt, makeDevicePt} from './Point.js';
 import {isImage} from './WebPlot.js';
-import {getHiPSFoV} from './HiPSUtil.js';
 
 /**
  *
@@ -152,7 +151,7 @@ export function plotMover(originalDeviceX ,originalDeviceY , originalScrollPt, m
             }
 
 
-            if (lastWorldPt && Math.abs(lastWorldPt.y)>88 && getHiPSFoV(pv)>30) {
+            if (lastWorldPt && Math.abs(lastWorldPt.y)>88 && getFoV(pv)>30) {
                 // xdiff/=8;
                 ydiff/=8;
                 xdiff/=8;

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -9,7 +9,7 @@ import shallowequal from 'shallowequal';
 import {get,isEmpty,omit} from 'lodash';
 import {getPlotGroupById}  from '../PlotGroup.js';
 import {ExpandType, dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
-import {VisCtxToolbarView, canConvertHipsAndAllSky} from './../ui/VisCtxToolbarView.jsx';
+import {VisCtxToolbarView, canConvertHipsAndFits} from './../ui/VisCtxToolbarView.jsx';
 import {VisInlineToolbarView} from './../ui/VisInlineToolbarView.jsx';
 import {primePlot, isActivePlotView, getAllDrawLayersForPlot} from '../PlotViewUtil.js';
 import {ImageViewerLayout}  from '../ImageViewerLayout.jsx';
@@ -100,13 +100,12 @@ function showUnselect(pv,dlAry) {
 
 
 function contextToolbar(pv,dlAry,extensionList) {
-    if (!pv) return;
     const plot= primePlot(pv);
     if (!plot) return;
 
     const showMulti= isImage(plot) ? pv.plots.length>1 : plot.cubeDepth>1;
+    const hipsFits= canConvertHipsAndFits(pv);
 
-    // todo
 
     if (plot.attributes[PlotAttribute.SELECTION]) {
         const select= showSelect(pv,dlAry);
@@ -126,7 +125,7 @@ function contextToolbar(pv,dlAry,extensionList) {
     }
     else if (plot.attributes[PlotAttribute.ACTIVE_DISTANCE]) {
         const distAry= extensionList.filter( (ext) => ext.extType===LINE_SELECT);
-        if (!distAry.length && !showMulti && isImage(plot)) return false;
+        if (!distAry.length && !showMulti && !hipsFits) return false;
         return (
             <VisCtxToolbarView plotView={pv} dlAry={dlAry} extensionAry={isEmpty(distAry)?EMPTY_ARRAY:distAry}
                                showMultiImageController={showMulti}/>
@@ -134,7 +133,7 @@ function contextToolbar(pv,dlAry,extensionList) {
     }
     else if (plot.attributes[PlotAttribute.ACTIVE_POINT]) {
         const ptAry= extensionList.filter( (ext) => ext.extType===POINT);
-        if (!ptAry.length && !showMulti && isImage(plot)) return false;
+        if (!ptAry.length && !showMulti && !hipsFits) return false;
         return (
             <VisCtxToolbarView plotView={pv} dlAry={dlAry} extensionAry={isEmpty(ptAry)?EMPTY_ARRAY:ptAry}
                                showMultiImageController={showMulti}/>
@@ -156,13 +155,7 @@ function contextToolbar(pv,dlAry,extensionList) {
             />
         );
     }
-    else if (showMulti || isHiPS(plot)) {
-        return (
-            <VisCtxToolbarView plotView={pv} dlAry={dlAry} extensionAry={EMPTY_ARRAY}
-                               showMultiImageController={showMulti}/>
-        );
-    }
-    else if (isImage(plot) && canConvertHipsAndAllSky(pv)) {
+    else if (showMulti || hipsFits || isHiPS(plot)) {
         return (
             <VisCtxToolbarView plotView={pv} dlAry={dlAry} extensionAry={EMPTY_ARRAY}
                                showMultiImageController={showMulti}/>

--- a/src/firefly/js/visualize/iv/PlotTitle.css
+++ b/src/firefly/js/visualize/iv/PlotTitle.css
@@ -4,13 +4,11 @@
 
 
 .plot-title-inline-title-container {
-    pointer-events: none;
     position : absolute;
     left : 0;
     top : 0;
     padding : 0 5px 0 2px;
-    /*color : white;*/
-    background : #e3e3e3;/*rgba(255,255,255,.2);*/
+    background : #e3e3e3;
     white-space : nowrap;
     font-size : 9pt;
     border-radius : 0 0 5px 0;
@@ -22,19 +20,15 @@
 
 
 .plot-title-header-title-container {
-    pointer-events: none;
     padding : 1px 0 0 2px;
     color : black;
-    /*background : white;*/
     white-space : nowrap;
     font-size : 9pt;
 }
 
 .plot-title-expanded-title-container {
-    pointer-events: none;
     padding : 1px 0 0 2px;
     color : black;
-    /*background : white;*/
     white-space : nowrap;
     font-size : 10pt;
     font-weight : bold;

--- a/src/firefly/js/visualize/iv/PlotTitle.jsx
+++ b/src/firefly/js/visualize/iv/PlotTitle.jsx
@@ -12,6 +12,7 @@ import {primePlot} from '../PlotViewUtil.js';
 
 import './PlotTitle.css';
 import LOADING from 'html/images/gxt/loading.gif';
+import {isImage} from '../WebPlot.js';
 
 export const TitleType= new Enum(['INLINE', 'HEAD', 'EXPANDED']);
 
@@ -30,7 +31,10 @@ export function PlotTitle({plotView:pv, titleType, brief, working}) {
             break;
 
     }
-    let zlStr= getZoomDesc(pv);
+    const zlRet= getZoomDesc(pv);
+    let zlStr= `FOV: ${zlRet.fovFormatted}`;
+    let tooltip= `${plot.title}\nHorizontal field of view: ${zlRet.fovFormatted}`;
+    if (isImage(plot)) tooltip+= `\nZoom Level: ${zlRet.zoomLevelFormatted}`;
     let rotString= null;
     if (pv.rotation) {
         if (pv.plotViewCtx.rotateNorthLock) {
@@ -40,13 +44,14 @@ export function PlotTitle({plotView:pv, titleType, brief, working}) {
             rotString= angleStr + String.fromCharCode(176);
         }
         zlStr+=',';
+        tooltip+= `, ${rotString}`;
     }
 
     return (
-        <div className={styleName} title={plot.title}>
+        <div className={styleName} title={tooltip}>
             <div className='plot-title-title'>{plot.title}</div>
-            {!brief ? <div className='plot-title-zoom'><div dangerouslySetInnerHTML={{__html:zlStr}}/> </div> : ''}
-            {!brief && rotString ? <div className='plot-title-rotation'>{rotString}</div> : ''}
+            {!brief ? <div className='plot-title-zoom'><div title={tooltip} dangerouslySetInnerHTML={{__html:zlStr}}/> </div> : ''}
+            {!brief && rotString ? <div title={tooltip} className='plot-title-rotation'>{rotString}</div> : ''}
             {working ?<img style={{width:14,height:14,padding:'0 3px 0 5px'}} src={LOADING}/> : ''}
         </div>
     );

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -297,15 +297,15 @@ function processProjectionChange(state,action) {
 }
 
 function changeHiPS(state,action) {
-    const {plotId,hipsProperties, hipsUrlRoot, coordSys, cubeIdx, applyToGroup}= action.payload;
+    const {plotId,hipsProperties, coordSys, hipsUrlRoot, cubeIdx, applyToGroup}= action.payload;
     let {centerProjPt}= action.payload;
     let {plotViewAry}= state;
 
     let pv= getPlotViewById(state, plotId);
-    let plot= primePlot(pv);
-    if (!plot) return state;
+    const originalPlot= primePlot(pv);
+    if (!originalPlot) return state;
 
-    plot= clone(plot);
+    let plot= clone(originalPlot);
 
 
     // single plot stuff
@@ -317,6 +317,9 @@ function changeHiPS(state,action) {
         plot.cubeDepth= Number(get(hipsProperties, 'hips_cube_depth')) || 1;
         plot.cubeIdx= Number(get(hipsProperties, 'hips_cube_firstframe')) || 0;
         plot= replaceHiPSProjectionUsingProperties(plot, hipsProperties, getCenterOfProjection(plot) );
+        if (!centerProjPt && originalPlot.dataCoordSys!==plot.dataCoordSys) {
+            centerProjPt= convert(getCenterOfProjection(originalPlot), plot.dataCoordSys);
+        }
     }
 
     if (!isUndefined(cubeIdx) && plot.cubeDepth>1 && cubeIdx<plot.cubeDepth) {
@@ -333,7 +336,7 @@ function changeHiPS(state,action) {
 
     if (coordSys) {
         plotViewAry= changeHipsCoordinateSys(plotViewAry, state.plotGroupAry,pv, coordSys, applyToGroup);
-        if (!centerProjPt) centerProjPt= convert(getCenterOfProjection(plot), coordSys);
+        if (!centerProjPt) centerProjPt= convert(getCenterOfProjection(originalPlot), coordSys);
     }
 
     if (centerProjPt) {

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -34,6 +34,7 @@ import {UserZoomTypes} from '../ZoomUtil.js';
 import {RotateType} from '../PlotState.js';
 import Point from '../Point.js';
 import {updateTransform} from '../PlotTransformUtils.js';
+import {WebPlotRequest} from '../WebPlotRequest.js';
 
 
 //============ EXPORTS ===========
@@ -130,6 +131,9 @@ export function reducer(state, action) {
             retState= changeOverlayPlotAttributes(state,action);
             break;
 
+        case Cntlr.CHANGE_HIPS_IMAGE_CONVERSION :
+            retState= changeHipsImageConversionSettings(state,action);
+            break;
 
 
         case Cntlr.ADD_PROCESSED_TILES:
@@ -650,6 +654,26 @@ function changeOverlayPlotAttributes(state,action) {
         });
     return clone(state,{plotViewAry});
 }
+
+function changeHipsImageConversionSettings(state,action) {
+    const {plotId, hipsImageConversionChanges}= action.payload;
+    const changes= {...hipsImageConversionChanges};
+    const plotViewAry= state.plotViewAry
+        .map( (pv) => {
+            if (pv.plotId!==plotId || !pv.plotViewCtx.hipsImageConversion) return pv;
+            if (changes.hipsRequestRoot) changes.hipsRequestRoot= WebPlotRequest.makeFromObj(changes.hipsRequestRoot);
+            if (changes.imageRequestRoot) changes.imageRequestRoot= WebPlotRequest.makeFromObj(changes.imageRequestRoot);
+            if (changes.allSkyRequest) changes.allSkyRequest= WebPlotRequest.makeFromObj(changes.allSkyRequest);
+            pv= {...pv};
+            pv.plotViewCtx= {...pv.plotViewCtx};
+            pv.plotViewCtx.hipsImageConversion= {...pv.plotViewCtx.hipsImageConversion, ...changes};
+            return pv;
+        });
+    return clone(state,{plotViewAry});
+
+}
+
+
 
 function addProcessedTileData(state,action) {
     const {plotId, plotImageId, imageOverlayId, zoomFactor}= action.payload;

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {uniqBy,unionBy, isEmpty} from 'lodash';
+import {uniqBy,unionBy, differenceBy, isEmpty} from 'lodash';
 import Cntlr, {WcsMatchType} from '../ImagePlotCntlr.js';
 import {replacePlots, makePlotView, updatePlotViewScrollXY,
         findScrollPtToCenterImagePt, updateScrollToWcsMatch} from './PlotView.js';
@@ -341,8 +341,12 @@ function preNewPlotPrep(plotViewAry,action) {
         return pv;
     });
 
-    return unionBy(pvChangeAry,plotViewAry, 'plotId');
+    // return unionBy(pvChangeAry,plotViewAry, 'plotId');
+    const toAdd= differenceBy(pvChangeAry, plotViewAry, 'plotId');
+    const originalAndReplaced= plotViewAry.map( (pv) => pvChangeAry.find( (tPv) => tPv.plotId===pv.plotId) || pv);
+    return [...originalAndReplaced, ...toAdd];
 }
+
 
 export function endServerCallFail(state,action) {
     const {plotId,message}= action.payload;

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -83,7 +83,9 @@ export const ServerCallStatus= new Enum(['success', 'working', 'fail'], { ignore
  *
  * @prop {WebPlotRequest} hipsRequestRoot a WebPlotRequest that contains the base parameter to display a HiPS
  * @prop {WebPlotRequest} imageRequestRoot a WebPlotRequest that contains the base parameter to display an image. It must be a service type.
- * @prop {fovDegFallOver} The field of view size to determine when to move between and HiPS and an image
+ * @prop {number} fovDegFallOver The field of view size to determine when to move between and HiPS and an image
+ * @prop {number} fovMaxFitsSize how big this fits image can be
+ * @prop {boolean} autoConvertOnZoom do auto convert on zoom
  */
 
 /**
@@ -156,7 +158,9 @@ function createPlotViewContextData(req, pvOptions={}) {
 
     const {hipsImageConversion:hi}= pvOptions;
     if (hi && hi.hipsRequestRoot && hi.imageRequestRoot && hi.fovDegFallOver) {  // confirm all three parameters are there
-        plotViewCtx.hipsImageConversion= hi;
+        const defaults= {autoConvertOnZoom: false};
+        plotViewCtx.hipsImageConversion= {...defaults, ...hi};
+        if (!hi.fovMaxFitsSize ) hi.fovMaxFitsSize= hi.fovDegFallOver;
     }
     return plotViewCtx;
 }

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -60,7 +60,7 @@ const PLOT_ID= 'CoveragePlot';
 
 
 const defOptions= {
-    title: 'Coverage',
+    title: '2MASS k',
     tip: 'Coverage',
     getCoverageBaseTitle : (table) => '',   // eslint-disable-line no-unused-vars
     coverageType : CoverageType.BOTH,
@@ -81,10 +81,13 @@ const defOptions= {
         Service : 'TWOMASS',
         SurveyKey: 'asky',
         SurveyKeyBand: 'k',
+        title : '2MASS k'
     },
 
     useAllSkyFitsForPlus180 : true,
-    fovDegFallOver: .4,
+    fovDegFallOver: .13,
+    fovMaxFitsSize: .2,
+    autoConvertOnZoom: false,
 
 
     canDoCorners : defaultCanDoCorners,
@@ -316,7 +319,7 @@ function updateCoverageWithData(viewerId, table, options, tbl_id, allRowsTable, 
     const {overlayPosition= avgOfCenters }=  options;
 
     if (!avgOfCenters || maxRadius<=0) return;
-    const {fovDegFallOver, hipsSourceURL, imageSourceParams, useHiPS}= options;
+    const {fovDegFallOver, fovMaxFitsSize, autoConvertOnZoom, hipsSourceURL, imageSourceParams, useHiPS}= options;
 
     if (useHiPS) {
         // const baseTitle= options.getCoverageBaseTitle(allRowsTable);
@@ -340,11 +343,6 @@ function updateCoverageWithData(viewerId, table, options, tbl_id, allRowsTable, 
             hipsRequest= initRequest(hipsRequest, viewerId, PLOT_ID, overlayPosition, avgOfCenters);
             hipsRequest.setSizeInDeg(size);
 
-            if (options.title) {
-                imageRequest.setTitleOptions(TitleOptions.NONE);
-                imageRequest.setTitle(options.title);
-            }
-
             //todo: fixed this like the else to change isPlotted , also add if for overlayCoverageDrawing
 
 
@@ -361,6 +359,8 @@ function updateCoverageWithData(viewerId, table, options, tbl_id, allRowsTable, 
                     imageRequest,
                     allSkyRequest,
                     fovDegFallOver,
+                    fovMaxFitsSize,
+                    autoConvertOnZoom,
                     viewerId,
                     plotAllSkyFirst,
                     attributes: {

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -15,10 +15,10 @@ import {primePlot, getPlotViewById, hasGroupLock} from '../PlotViewUtil.js';
 import {dispatchAddActionWatcher} from '../../core/MasterSaga.js';
 import {getHiPSZoomLevelToFit} from '../HiPSUtil.js';
 import {getCenterOfProjection, findCurrentCenterPoint, getCorners,
-        getDrawLayerByType, getDrawLayersByType, getOnePvOrGroup} from '../PlotViewUtil.js';
+        getDrawLayerByType, getDrawLayersByType, getOnePvOrGroup, getFoV} from '../PlotViewUtil.js';
 import {findAllSkyCachedImage, addAllSkyCachedImage} from '../iv/HiPSTileCache.js';
 import {makeHiPSAllSkyUrl, makeHiPSAllSkyUrlFromPlot,
-         makeHipsUrl, getHiPSFoV, resolveHiPSConstant, getPointMaxSide} from '../HiPSUtil.js';
+         makeHipsUrl, resolveHiPSConstant, getPointMaxSide} from '../HiPSUtil.js';
 import {ZoomType} from '../ZoomType.js';
 import {CCUtil} from '../CsysConverter.js';
 import {ensureWPR, determineViewerId, getHipsImageConversion,
@@ -27,11 +27,12 @@ import {dlRoot, dispatchAttachLayerToPlot,
         dispatchCreateDrawLayer, dispatchDetachLayerFromPlot, getDlAry} from '../DrawLayerCntlr.js';
 import ImageOutline from '../../drawingLayers/ImageOutline.js';
 import Artifact from '../../drawingLayers/Artifact.js';
-import {isHiPS} from '../WebPlot';
+import {isHiPS, isImage} from '../WebPlot';
 import {dispatchChangeHiPS} from '../ImagePlotCntlr';
 import HiPSGrid from '../../drawingLayers/HiPSGrid.js';
 import ActiveTarget from '../../drawingLayers/ActiveTarget.js';
 import {resolveHiPSIvoURL} from '../HiPSListUtil.js';
+import {makeDevicePt, makeWorldPt} from '../Point.js';
 
 
 //const INIT_STATUS_UPDATE_DELAY= 7000;
@@ -320,7 +321,8 @@ export function makeImageOrHiPSAction(rawAction) {
         if (!validateHipsAndImage(imageRequest, hipsRequest, payload.fovDegFallOver)) return;
 
 
-        const {plotId, fovDegFallOver, pvOptions, attributes, plotAllSkyFirst=false}= payload;
+        const {plotId, fovDegFallOver, fovMaxFitsSize, autoConvertOnZoom,
+                pvOptions, attributes, plotAllSkyFirst=false}= payload;
         const viewerId= determineViewerId(payload.viewerId, plotId);
         const size= getSizeInDeg(imageRequest, hipsRequest);
         const groupId= getPlotGroupId(imageRequest, hipsRequest);
@@ -335,8 +337,8 @@ export function makeImageOrHiPSAction(rawAction) {
             wpRequest= hipsRequest.makeCopy();
         }
 
-        const hipsImageConversion= {hipsRequestRoot:hipsRequest, imageRequestRoot:imageRequest,
-                                    allSkyRequest, fovDegFallOver, plotAllSkyFirst};
+        const hipsImageConversion= {hipsRequestRoot:hipsRequest, imageRequestRoot:imageRequest, fovMaxFitsSize,
+                                    autoConvertOnZoom, allSkyRequest, fovDegFallOver, plotAllSkyFirst};
 
 
         wpRequest.setSizeInDeg(size);
@@ -353,31 +355,51 @@ export function makeImageOrHiPSAction(rawAction) {
 }
 
 
-
+/**
+ * convert to a image defined in  hipsImageConversion
+ * @param {PlotView} pv
+ * @param {boolean} allSky if true, convert to the allsky image defined in hipsImageConversion
+ */
 export function convertToImage(pv, allSky= false) {
     const {plotId, plotGroupId,viewDim}= pv;
-    const {allSkyRequest, imageRequestRoot}= pv.plotViewCtx.hipsImageConversion;
+    const {allSkyRequest, imageRequestRoot, fovMaxFitsSize}= pv.plotViewCtx.hipsImageConversion;
     dispatchDetachLayerFromPlot(ImageOutline.TYPE_ID, plotId);
     dispatchDetachLayerFromPlot(HiPSGrid.TYPE_ID, plotId);
-    const doingAllSky= allSky && allSkyRequest;
-    const wpRequest= (doingAllSky) ? allSkyRequest.makeCopy() : imageRequestRoot.makeCopy();
-    const hipsFov= getHiPSFoV(pv);
+    const convertToAllSky= allSky && allSkyRequest;
+    const wpRequest= (convertToAllSky) ? allSkyRequest.makeCopy() : imageRequestRoot.makeCopy();
+    const currentFoV= getFoV(pv);
     wpRequest.setPlotId(plotId);
     wpRequest.setPlotGroupId(plotGroupId);
     const plot= primePlot(pv);
     const attributes= clone(plot.attributes, getCornersAttribute(pv) || {});
-    if (doingAllSky) {
-        wpRequest.setZoomType(ZoomType.TO_WIDTH);
+    const fromImage= isImage(plot) && !plot.projection.isWrappingProjection();
+    if (convertToAllSky) {
+        if (fromImage) {
+            prepFromImageConversion(pv,wpRequest);
+            // wpRequest.setZoomType(ZoomType.ARCSEC_PER_SCREEN_PIX);
+            // wpRequest.setZoomArcsecPerScreenPix((currentFoV/viewDim.width) * 3600);
+            wpRequest.setZoomType(ZoomType.TO_WIDTH);
+        }
+        else {
+            wpRequest.setZoomType(ZoomType.TO_WIDTH);
+        }
     }
     else {
-        wpRequest.setWorldPt(getCenterOfProjection(primePlot(pv)));
-        wpRequest.setSizeInDeg(hipsFov);
-        wpRequest.setZoomType(ZoomType.ARCSEC_PER_SCREEN_PIX);
-        wpRequest.setZoomArcsecPerScreenPix((hipsFov/viewDim.width) * 3600);
+        wpRequest.setWorldPt(getCenterPt(pv));
+        wpRequest.setSizeInDeg(currentFoV> fovMaxFitsSize ? fovMaxFitsSize : currentFoV);
+        if (currentFoV > 5) {
+            wpRequest.setZoomType(ZoomType.TO_WIDTH_HEIGHT);
+        }
+        else {
+            wpRequest.setZoomType(ZoomType.ARCSEC_PER_SCREEN_PIX);
+            wpRequest.setZoomArcsecPerScreenPix((currentFoV/viewDim.width) * 3600);
+        }
     }
 
     dispatchPlotImage({plotId, wpRequest, attributes, enableRestore:false});
 }
+
+
 
 export function convertToHiPS(pv, fromAllSky= false) {
     const {plotId, plotGroupId}= pv;
@@ -388,22 +410,45 @@ export function convertToHiPS(pv, fromAllSky= false) {
 
 
     const attributes= clone(plot.attributes, getCornersAttribute(pv) || {});
+    wpRequest.setWorldPt(getCenterPt(pv));
     if (!fromAllSky) {
-        const cenPt= CCUtil.getWorldCoords(primePlot(pv), findCurrentCenterPoint(pv));
-        wpRequest.setWorldPt(cenPt);
-        wpRequest.setSizeInDeg(pv.plotViewCtx.hipsImageConversion.fovDegFallOver);
-        const dl = getDrawLayerByType(dlRoot(), ImageOutline.TYPE_ID);
-        if (!dl) dispatchCreateDrawLayer(ImageOutline.TYPE_ID);
-        dispatchAttachLayerToPlot(ImageOutline.TYPE_ID, plotId);
-
-        const artAry= getDrawLayersByType(dlRoot(), Artifact.TYPE_ID);
-        artAry.forEach( (a) => dispatchDetachLayerFromPlot(a.drawLayerId,plotId));
-
-
+        prepFromImageConversion(pv,wpRequest);
     }
 
     dispatchPlotHiPS({plotId, wpRequest, attributes, enableRestore:false});
 }
+
+function getCenterPt(pv) {
+    const plot= primePlot(pv);
+    if (isHiPS(plot)) {
+        return getCenterOfProjection(plot);
+    }
+    else {
+        return CCUtil.getWorldCoords(plot,findCurrentCenterPoint(pv));
+    }
+}
+
+
+/**
+ * This function has a lot of side effects, it modified wpRequest and dispatch drawing
+ * @param pv
+ * @param wpRequest
+ */
+function prepFromImageConversion(pv, wpRequest) {
+    const {plotId}= pv;
+    wpRequest.setWorldPt(getCenterPt(pv));
+    // wpRequest.setSizeInDeg(pv.plotViewCtx.hipsImageConversion.fovDegFallOver);
+    wpRequest.setSizeInDeg(getFoV(pv));
+    const dl = getDrawLayerByType(dlRoot(), ImageOutline.TYPE_ID);
+    if (!dl) dispatchCreateDrawLayer(ImageOutline.TYPE_ID);
+    dispatchAttachLayerToPlot(ImageOutline.TYPE_ID, plotId);
+    const artAry= getDrawLayersByType(dlRoot(), Artifact.TYPE_ID);
+    artAry.forEach( (a) => dispatchDetachLayerFromPlot(a.drawLayerId,plotId));
+}
+
+
+
+
 
 /**
  * Add add a image outline to some HiPS display and attempts to zoom to the same scale.
@@ -448,6 +493,55 @@ function getCornersAttribute(pv) {
         [PlotAttribute.OUTLINEIMAGE_TITLE]: plot.title
     };
 }
+
+
+/**
+ * This function will convert between HiPS and FITS or FITS and Hips depend on hipsImageConversion settings and zoom
+ * direction.
+ * @param {PlotView} pv
+ * @param {number} [prevZoomLevel] - previous zoom level
+ * @param {number} [nextZoomLevel] - next zoom level
+ * @return {boolean}
+ */
+export function doHiPSImageConversionIfNecessary(pv, prevZoomLevel, nextZoomLevel) {
+    if (!pv.plotViewCtx.hipsImageConversion) return false;
+    const plot= primePlot(pv);
+    const {fovDegFallOver, allSkyRequest}=  pv.plotViewCtx.hipsImageConversion;
+    const {width,height}= pv.viewDim;
+    const fov= getFoV(pv);
+    if (!nextZoomLevel || !prevZoomLevel) {
+        nextZoomLevel = plot.zoomFactor;
+        prevZoomLevel = plot.zoomFactor;
+    }
+
+    if (isHiPS(plot) ) {
+        const {screenSize}= plot;
+        if (fovDegFallOver && prevZoomLevel<=nextZoomLevel && fov < fovDegFallOver) { // zooming in hips FOV passes fovDegFallOver
+            convertToImage(pv, false);
+            return true;
+        }
+        else if (fov>179 &&  prevZoomLevel>=nextZoomLevel &&   // zooming out, hips image getting small
+            screenSize.width<width-10 && screenSize.height<height-10 && screenSize.width>50 &&
+            allSkyRequest){
+            convertToImage(pv, true);
+            return true;
+        }
+    }
+    else if (isImage(plot)) {
+        if (plot.projection.isWrappingProjection() && prevZoomLevel<=nextZoomLevel && fov < 200) {// zooming in, all sky FOV less than 180
+            convertToHiPS(pv);
+            return true;
+        }
+        else if (prevZoomLevel>=nextZoomLevel &&
+            (width-10)>plot.dataWidth*nextZoomLevel && (height-10) >plot.dataHeight*nextZoomLevel ) { //zoom out image getting small
+            convertToHiPS(pv);
+            return true;
+        }
+    }
+    return false;
+}
+
+
 
 
 

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -406,6 +406,7 @@ export function convertToHiPS(pv, fromAllSky= false) {
     const wpRequest= pv.plotViewCtx.hipsImageConversion.hipsRequestRoot.makeCopy();
     wpRequest.setPlotId(plotId);
     wpRequest.setPlotGroupId(plotGroupId);
+    wpRequest.setSizeInDeg(getFoV(pv));
     const plot= primePlot(pv);
 
 

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -56,7 +56,9 @@ export function getHipsImageConversion(hipsImageConversion ) {
         imageRequestRoot:ensureWPR(hipsImageConversion.imageRequestRoot),
         allSkyRequest: ensureWPR(hipsImageConversion.allSkyRequest),
         fovDegFallOver: hipsImageConversion.fovDegFallOver,
-        plotAllSkyFirst: hipsImageConversion.plotAllSkyFirst
+        fovMaxFitsSize: hipsImageConversion.fovMaxFitsSize,
+        plotAllSkyFirst: hipsImageConversion.plotAllSkyFirst,
+        autoConvertOnZoom: hipsImageConversion.autoConvertOnZoom
     };
 
 }

--- a/src/firefly/js/visualize/ui/ZoomButton.jsx
+++ b/src/firefly/js/visualize/ui/ZoomButton.jsx
@@ -34,7 +34,7 @@ const isFitFill= (userZoomType) =>  (userZoomType===UserZoomTypes.FIT || userZoo
 
 
 function getZoomer() {
-    var lastClick= Date.now();
+    let lastClick= Date.now();
     return (pv,zType) => {
         const time= Date.now();
         const deltaClick= time-lastClick;
@@ -57,16 +57,12 @@ function getZoomer() {
             }
         }
 
-        if (deltaClick < CLICK_TIME   && isImage(plot)) {
+        if (deltaClick < CLICK_TIME   && isImage(plot) && !plot.projection.isWrappingProjection()) {
             showZoomOptionsPopup();
             return;
         }
 
-        dispatchZoom({
-            plotId:pv.plotId,
-            userZoomType:zType.utilZt,
-            forceDelay:!isFitFill(zType.utilZt)
-        });
+        dispatchZoom({ plotId:pv.plotId, userZoomType:zType.utilZt, forceDelay:!isFitFill(zType.utilZt) });
     };
 }
 
@@ -84,10 +80,9 @@ export function isZoomMax(pv) {
 }
 
 export function ZoomButton({plotView:pv,zoomType,visible}) {
-    var enable= primePlot(pv) ? true : false;
     return (
         <ToolbarButton icon={zoomType.icon} tip={zoomType.tip}
-                       enabled={enable} visible={visible}
+                       enabled={Boolean(primePlot(pv))} visible={visible}
                        horizontal={true} onClick={() => zoom(pv,zoomType)}/>
     );
 }


### PR DESCRIPTION
  - buttons to move between hips/fits/aitoff
  - zoom switching now includes allsky in algorithm
  - auto check box to switch on zoom
  - zoom level switch to field of view
  - fixed: FOV when image zoomed level is really small
  - fixed: order of buttons
  - fixed: context toolbar going away when in different context modes
  - ButtonGroup option for RadioGroupInputFieldView

_to test:_

 - do catalog search, then switch between hips and fits
 - try the auto button and zoom
 - do a catalog search with m4, then m1
 - switch between hips, fits, aitoff
 - try auto button and zoom
 - try tooltip over field of view for both hips and fits
 - notice that there is only field of view, not zoom level
