### PR TITLE
DM-12705: cache replication not working in kubernetes

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -17,10 +17,9 @@ RUN apt-get update && apt-get install -y \
         && rm -rf /var/lib/apt/lists/*
 
 
-# These environment varibles are not really make to be overridden
+# These environment varibles are not really made to be overridden
 # they can be but are mostly for setup
 ENV JPDA_ADDRESS=5050
-ENV JMX_ADDRESS=9050
 ENV CATALINA_PID=${CATALINA_BASE}/bin/catalina.pid
 
 # work dir and config dir might be overridden if they were used in a mounted volume
@@ -62,8 +61,7 @@ COPY setenv.sh /usr/local/tomcat/bin/
 
 # 8080 - http
 # 5050 - debug
-# 9050 - jmx (jconsole)
-EXPOSE 8080 5050 9050 7011
+EXPOSE 8080 5050
 
 
 # ----------------------------------------------------------

--- a/docker/base/launchTomcat.sh
+++ b/docker/base/launchTomcat.sh
@@ -32,7 +32,7 @@ echo
 echo "Properties: "
 echo "          Description                  Property             Value"
 echo "          -----------                  --------             -----"
-echo "          Min JVM size                 MIN_JVM_SIZE         ${MIN_JVM_SIZE}"
+echo "          Min JVM size                 MIN_JVM_SIZE        ${MIN_JVM_SIZE}"
 echo "          Min JVM size                 MAX_JVM_SIZE         ${MAX_JVM_SIZE}"
 echo "          Multi node sticky routing    jvmRoute             ${JVM_ROUTE}"
 echo "          Admin username               ADMIN_USER           ${ADMIN_USER}"
@@ -46,7 +46,6 @@ echo
 echo "Ports: "
 echo "        8080 - http"
 echo "        5050 - debug"
-echo "        9050 - jmx (jconsole)"
 echo
 echo "Volume Mount Points: "
 echo "        Log directory : /usr/local/tomcat/logs : Directory for logs files"

--- a/docker/base/setenv.sh
+++ b/docker/base/setenv.sh
@@ -3,11 +3,12 @@ CATALINA_OPTS="\
         -Xms${MIN_JVM_SIZE} \
         -Xmx${MAX_JVM_SIZE} \
         -DjvmRoute=${JVM_ROUTE}
-        -Djava.net.preferIPv4Stack=true \
-        -Dcom.sun.management.jmxremote.port=${JMX_ADDRESS} \
-        -Dcom.sun.management.jmxremote.rmi.port=${JMX_ADDRESS} \
-        -Dcom.sun.management.jmxremote.ssl=false \
-        -Dcom.sun.management.jmxremote.authenticate=false"
+        -Djava.net.preferIPv4Stack=true"
+
+#        -Dcom.sun.management.jmxremote.port=${JMX_ADDRESS} \
+#        -Dcom.sun.management.jmxremote.rmi.port=${JMX_ADDRESS} \
+#        -Dcom.sun.management.jmxremote.ssl=false \
+#        -Dcom.sun.management.jmxremote.authenticate=false"
 
 JAVA_OPTS="-Dnet.sf.ehcache.enableShutdownHook=true \
            -Dserver_config_dir=${SERVER_CONFIG_DIR} \

--- a/docker/base/setenv.sh
+++ b/docker/base/setenv.sh
@@ -3,7 +3,6 @@ CATALINA_OPTS="\
         -Xms${MIN_JVM_SIZE} \
         -Xmx${MAX_JVM_SIZE} \
         -DjvmRoute=${JVM_ROUTE}
-        -Djava.rmi.server.hostname= \
         -Djava.net.preferIPv4Stack=true \
         -Dcom.sun.management.jmxremote.port=${JMX_ADDRESS} \
         -Dcom.sun.management.jmxremote.rmi.port=${JMX_ADDRESS} \


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-12705

It turns out to be a trivial fix.  Firefly's docker template was passing `-Djava.rmi.server.hostname=` property to the jvm, setting RMI host name to blank.  This causes ehcache's RMI replication code to fail during lookup.  
As part of this PR, I was able to confirm that replication is working in k8s environment.
I added some println into CacheEventWorker to monitor replicated cache's event and was able to confirm that data did get replicated between 2 instances of Firefly in a k8s deployment.

For testing purposes, I have a deployment of 2 firefly instances under the url:  https://irsawebdev9.ipac.caltech.edu/loi/firefly/

If you have kubectl installed, you can do the following to see that event messages are replicated between the pods.

`$ kubectl get pod`

> firefly--loi-6c558f4657-skmfc             1/1       Running   0          55m
> firefly--loi-6c558f4657-vvpml             1/1       Running   0          55m

In separate terminal, type command:
`$ kubectl log -f firefly--loi-6c558f4657-skmfc`  and 
`$ kubectl log -f firefly--loi-6c558f4657-vvpml`  

Then, goto https://irsawebdev9.ipac.caltech.edu/loi/firefly/
This creates a new `client` info event that get replicated to both pods.
You should see 2 `put` notifications; one for the new cleint, another for the full list of clients updated.
