### PR TITLE
DM-13382: In TablePanel, allow option to show data type

### DIFF
--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -124,14 +124,22 @@ function buildTablePart(llApi) {
      * @prop {boolean} removable    true if this table can be removed from view.  Defaults to true.
      * @prop {boolean} backgroundable    true if this search can be sent to background.  Defaults to false.
      * @prop {boolean} showUnits    defaults to false
+     * @prop {boolean} showTypes    defaults to false
      * @prop {boolean} showFilters  defaults to false
      * @prop {boolean} selectable   defaults to true
      * @prop {boolean} expandable   defaults to true
      * @prop {boolean} showToolbar  defaults to true
+     * @prop {boolean} showTitle    defaults to true
+     * @prop {boolean} showPaging   defaults to true
+     * @prop {boolean} showSave     defaults to true
+     * @prop {boolean} showOptionButton    defaults to true
+     * @prop {boolean} showFilterButton    defaults to true
      * @prop {boolean} border       defaults to true
+     * @prop {boolean} help_id      link to help if applicable
      * @prop {function[]}  leftButtons   an array of functions that returns a button-like component laid out on the left side of this table header.  Function will be called with table's state.
      * @prop {function[]}  rightButtons  an array of functions that returns a button-like component laid out on the left side of this table header.  Function will be called with table's state.
      */
+
 
     /**
      * @param {string|HTMLDivElement} targetDiv to put the table in.

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -9,14 +9,12 @@ import {SelectInfo} from './SelectInfo.js';
 
 export class TableConnector {
     
-    constructor(tbl_id, tbl_ui_id, tableModel, showUnits=true, showFilters=false, pageSize) {
+    constructor({tbl_id, tbl_ui_id, tableModel, showUnits=true, showTypes=false, showFilters=false, pageSize}) {
         this.tbl_id = tbl_id || tableModel.tbl_id;
         this.tbl_ui_id = tbl_ui_id;
         this.tableModel = tableModel;
 
-        this.origPageSize = pageSize;
-        this.origShowUnits = showUnits;
-        this.origShowFilters = showFilters;
+        this.orig = {showUnits, showTypes, showFilters, pageSize};
     }
 
     onMount() {
@@ -104,14 +102,14 @@ export class TableConnector {
         TblCntlr.dispatchTableUiUpdate(changes);
     }
 
-    onOptionUpdate({pageSize, columns, showUnits, showFilters, sortInfo, filterInfo}) {
+    onOptionUpdate({pageSize, columns, showUnits, showTypes, showFilters, sortInfo, filterInfo}) {
         if (pageSize) {
             this.onPageSizeChange(pageSize);
         }
         if (!isUndefined(filterInfo)) {
             this.onFilter(filterInfo);
         }
-        const changes = omitBy({columns, showUnits, showFilters, optSortInfo:sortInfo}, isUndefined);
+        const changes = omitBy({columns, showUnits, showTypes, showFilters, optSortInfo:sortInfo}, isUndefined);
         if (!isEmpty(changes)) {
             changes.tbl_ui_id = this.tbl_ui_id;
             TblCntlr.dispatchTableUiUpdate(changes);
@@ -122,15 +120,16 @@ export class TableConnector {
         const ctable = TblUtil.getTblById(this.tbl_id);
         var filterInfo = get(ctable, 'request.filters', '').trim();
         filterInfo = filterInfo !== '' ? '' : undefined;
-        const pageSize = get(ctable, 'request.pageSize') !== this.origPageSize ? this.origPageSize : undefined;
+        var {showUnits, showTypes, showFilters, pageSize} = this.orig || {};
+        
+        pageSize = get(ctable, 'request.pageSize') !== pageSize ? pageSize : undefined;
         this.onOptionUpdate({filterInfo, pageSize,
                         columns: cloneDeep(get(ctable, 'tableData.columns', [])),
-                        showUnits: this.origShowUnits,
-                        showFilters: this.origShowFilters});
+                        showUnits, showTypes, showFilters});
     }
 
-    static newInstance(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize) {
-        return new TableConnector(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize);
+    static newInstance({tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize}) {
+        return new TableConnector({tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize});
     }
 }
 

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -48,8 +48,8 @@
  * @prop {string} units     data units
  * @prop {string} nullString string used to represent null value
  * @prop {string} desc      description of the column
- * @prop {number} width     column display width
- * @prop {number} prefWidth     preferred width.  if width is not defined
+ * @prop {number} width     max width needed to display data.
+ * @prop {number} prefWidth     preferred width, regardless of the data.
  * @prop {boolean} sortable     true if undefined
  * @prop {boolean} filterable   true if undefined
  * @prop {string} visibility    show, hide, or hidden.  hidden columns are not viewable by users.

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -28,7 +28,7 @@ class BasicTableViewInternal extends PureComponent {
         this.state = {
             showMask: false,
             data: [],
-            columnWidths: makeColWidth(props.columns, props.data, props.showUnits)
+            columnWidths: makeColWidth(props.columns, props.showUnits, props.showTypes)
         };
 
         this.onColumnResizeEndCallback = this.onColumnResizeEndCallback.bind(this);
@@ -53,7 +53,7 @@ class BasicTableViewInternal extends PureComponent {
 
     componentWillReceiveProps(nProps) {
         if (isEmpty(this.state.columnWidths) && !isEmpty(nProps.columns)) {
-            this.setState({columnWidths: makeColWidth(nProps.columns, nProps.data, nProps.showUnits)});
+            this.setState({columnWidths: makeColWidth(nProps.columns, nProps.showUnits, nProps.showTypes)});
         }
     }
 
@@ -118,7 +118,7 @@ class BasicTableViewInternal extends PureComponent {
 
     render() {
         const {width, height}= this.props.size;
-        const {columns, data, hlRowIdx, showUnits, showFilters, filterInfo, renderers, bgColor,
+        const {columns, data, hlRowIdx, showUnits, showTypes, showFilters, filterInfo, renderers, bgColor,
             selectable, selectInfoCls, sortInfo, callbacks, textView, rowHeight, showMask, error, tbl_ui_id} = this.props;
         const {columnWidths} = this.state;
         const {onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected} = this;
@@ -130,10 +130,10 @@ class BasicTableViewInternal extends PureComponent {
         // const sortInfoCls = SortInfo.parse(sortInfo);
         //
         const makeColumnsProps = {columns, data, selectable, selectInfoCls, renderers, bgColor,
-                                  columnWidths, filterInfo, sortInfo, showUnits, showFilters,
+                                  columnWidths, filterInfo, sortInfo, showUnits, showTypes, showFilters,
                                   onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected, tbl_id};
 
-        const headerHeight = 22 + (showUnits && 8) + (showFilters && 22);
+        const headerHeight = 22 + (showUnits && 8) + (showTypes && 8) + (showFilters && 22);
 
         return (
             <div tabIndex='-1' onKeyDown={this.onKeyDown} className='TablePanel__frame' >
@@ -171,6 +171,7 @@ BasicTableViewInternal.propTypes = {
     sortInfo: PropTypes.string,
     selectable: PropTypes.bool,
     showUnits: PropTypes.bool,
+    showTypes: PropTypes.bool,
     showFilters: PropTypes.bool,
     textView: PropTypes.bool,
     rowHeight: PropTypes.number,
@@ -199,6 +200,7 @@ BasicTableViewInternal.propTypes = {
 BasicTableViewInternal.defaultProps = {
     selectable: false,
     showUnits: false,
+    showTypes: false,
     showFilters: false,
     showMask: false,
     rowHeight: 20,
@@ -218,20 +220,21 @@ const TextView = ({columns, data, showUnits, width, height}) => {
     );
 };
 
-function makeColWidth(columns, showUnits) {
+function makeColWidth(columns, showUnits, showTypes) {
     return !columns ? {} : columns.reduce((widths, col, idx) => {
         const label = col.name;
         let nchar = col.prefWidth;
         const unitLength = showUnits ? get(col, 'units.length', 0) : 0;
+        const typeLength = showTypes ? get(col, 'type.length', 0) : 0;
         if (!nchar) {
-            nchar = Math.max(label.length+2, unitLength+2, get(col,'width', 0)); // 2 is for padding and sort symbol
+            nchar = Math.max(label.length+2, unitLength+2, typeLength+2, get(col,'width', 0)); // 2 is for padding and sort symbol
         }
         widths[idx] = nchar * 7;
         return widths;
     }, {});
 }
 
-function makeColumns ({columns, columnWidths, data, selectable, showUnits, showFilters, renderers, bgColor='white',
+function makeColumns ({columns, columnWidths, data, selectable, showUnits, showTypes, showFilters, renderers, bgColor='white',
             selectInfoCls, filterInfo, sortInfo, onRowSelect, onSelectAll, onSort, onFilter, onFilterSelected, tbl_id}) {
     if (!columns) return false;
 
@@ -246,7 +249,7 @@ function makeColumns ({columns, columnWidths, data, selectable, showUnits, showF
             <Column
                 key={col.name}
                 columnKey={idx}
-                header={<HeadRenderer {...{col, showUnits, showFilters, filterInfo, sortInfo, onSort, onFilter, tbl_id}} />}
+                header={<HeadRenderer {...{col, showUnits, showTypes, showFilters, filterInfo, sortInfo, onSort, onFilter, tbl_id}} />}
                 cell={<CellRenderer style={style} data={data} colIdx={idx} />}
                 fixed={fixed}
                 width={columnWidths[idx]}
@@ -260,7 +263,7 @@ function makeColumns ({columns, columnWidths, data, selectable, showUnits, showF
         var cbox = (<Column
             key='selectable-checkbox'
             columnKey='selectable-checkbox'
-            header={<SelectableHeader {...{checked, onSelectAll, showUnits, showFilters, onFilterSelected}} />}
+            header={<SelectableHeader {...{checked, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected}} />}
             cell={<SelectableCell style={{backgroundColor: bgColor}} selectInfoCls={selectInfoCls} onRowSelect={onRowSelect} />}
             fixed={true}
             width={25}

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -52,7 +52,7 @@ export class TablePanel extends PureComponent {
 
 
     setupInitState(props) {
-        var {tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize} = props;
+        var {tbl_id, tbl_ui_id, tableModel, ...rest} = props;
 
         if (!tbl_id && tableModel) {
             if (!tableModel.tbl_id) {
@@ -61,7 +61,7 @@ export class TablePanel extends PureComponent {
             tbl_id = tableModel.tbl_id;
         }
         tbl_ui_id = tbl_ui_id || TblUtil.uniqueTblUiId();
-        this.tableConnector = TableConnector.newInstance(tbl_id, tbl_ui_id, tableModel, showUnits, showFilters, pageSize);
+        this.tableConnector = TableConnector.newInstance({tbl_id, tbl_ui_id, tableModel, ...rest});
         const uiState = TblUtil.getTableUiById(tbl_ui_id);
         return Object.assign({}, this.props, uiState);
     }
@@ -120,7 +120,7 @@ export class TablePanel extends PureComponent {
         const {tableConnector} = this;
         const { selectable, expandable, expandedMode, border, renderers, title, removable, rowHeight, help_id,
             showToolbar, showTitle, showOptionButton, showPaging, showSave, showFilterButton,
-            totalRows, showLoading, columns, showUnits, showFilters, textView,
+            totalRows, showLoading, columns, showUnits, showTypes, showFilters, textView,
             tbl_id, error, startIdx, hlRowIdx, currentPage, pageSize, selectInfo, showMask,
             filterInfo, filterCount, sortInfo, data, backgroundable} = this.state;
         var {leftButtons, rightButtons} =  this.state;
@@ -192,7 +192,7 @@ export class TablePanel extends PureComponent {
                         >
                             <BasicTableView
                                 callbacks={tableConnector}
-                                { ...{columns, data, hlRowIdx, rowHeight, selectable, showUnits, showFilters,
+                                { ...{columns, data, hlRowIdx, rowHeight, selectable, showUnits, showTypes, showFilters,
                                     selectInfoCls, filterInfo, sortInfo, textView, showMask, currentPage,
                                     tableConnector, renderers, tbl_ui_id} }
                             />
@@ -202,7 +202,7 @@ export class TablePanel extends PureComponent {
                                  title={TT_OPTIONS}
                                  onClick={showOptionsDialog}/>
                             }
-
+    
                         </div>
                     </div>
                 </div>
@@ -245,6 +245,7 @@ TablePanel.propTypes = {
     help_id: PropTypes.string,
     removable: PropTypes.bool,
     showUnits: PropTypes.bool,
+    showTypes: PropTypes.bool,
     showFilters: PropTypes.bool,
     showToolbar: PropTypes.bool,
     showTitle: PropTypes.bool,

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -27,7 +27,7 @@ export class TablePanelOptions extends SimpleComponent  {
 
     render() {
         const {onChange, onOptionReset, tbl_ui_id} = this.props;
-        const {columns, pageSize, showUnits=false, showFilters=false, showToolbar=true, optSortInfo, filterInfo} = this.state;
+        const {columns, pageSize, showUnits=false, showTypes=false, showFilters=false, showToolbar=true, optSortInfo, filterInfo} = this.state;
 
         if (isEmpty(columns)) return false;
 
@@ -49,22 +49,25 @@ export class TablePanelOptions extends SimpleComponent  {
                                    checked={showFilters}/>
                         </div>
                     </div>
-                    {showToolbar &&
-                        <div style={{display: 'inline-block'}}>
-                            <div style={{marginTop: 17}}>
-                                <InputField
-                                    validator={intValidator(1,10000)}
-                                    tooltip='Set page size'
-                                    label='Page Size:'
-                                    labelStyle={{...labelStyle, width: 60}}
-                                    size={3}
-                                    value={pageSize+''}
-                                    onChange={onPageSize}
-                                    actOn={['blur','enter']}
-                                />
-                            </div>
+                    <div style={{display: 'inline-block'}}>
+                        <div>
+                            <div style={labelStyle}>Show Types:</div>
+                            <input type='checkbox' onChange={(e) => onPropChanged(e.target.checked, 'showTypes')}
+                                   checked={showTypes}/>
                         </div>
-                    }
+                        {showToolbar &&
+                            <InputField
+                                validator={intValidator(1,10000)}
+                                tooltip='Set page size'
+                                label='Page Size:'
+                                labelStyle={{...labelStyle, width: 60}}
+                                size={3}
+                                value={pageSize+''}
+                                onChange={onPageSize}
+                                actOn={['blur','enter']}
+                            />
+                        }
+                    </div>
                     <span>
 
                         <button type='button' className='TablePanelOptions__button' onClick={onOptionReset}

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -12,7 +12,7 @@ import {intValidator} from '../../util/Validate.js';
 import * as TblUtil from '../TableUtil.js';
 
 
-const labelStyle = {display: 'inline-block', width: 50};
+const labelStyle = {display: 'inline-block', whiteSpace: 'nowrap', width: 50};
 
 
 export class TablePanelOptions extends SimpleComponent  {
@@ -54,9 +54,9 @@ export class TablePanelOptions extends SimpleComponent  {
                                                            onChange={(e) => onPropChanged(e.target.checked, 'showUnits')}
                                                            checked={showUnits}/>Units
                             </div>
-                            <div style={labelStyle}><input type='checkbox'
+                            <div style={{...labelStyle, width: 80}}><input type='checkbox'
                                                            onChange={(e) => onPropChanged(e.target.checked, 'showTypes')}
-                                                           checked={showTypes}/>Types
+                                                           checked={showTypes}/>Data Types
                             </div>
                             <div style={labelStyle}><input type='checkbox'
                                                            onChange={(e) => onPropChanged(e.target.checked, 'showFilters')}

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -5,16 +5,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty} from 'lodash';
-
 import {SimpleComponent} from '../../ui/SimpleComponent.jsx';
 import {FilterEditor} from './FilterEditor.jsx';
 import {InputField} from '../../ui/InputField.jsx';
 import {intValidator} from '../../util/Validate.js';
-
 import * as TblUtil from '../TableUtil.js';
 
 
-const labelStyle = {display: 'inline-block', width: 70};
+const labelStyle = {display: 'inline-block', width: 50};
 
 
 export class TablePanelOptions extends SimpleComponent  {
@@ -34,42 +32,39 @@ export class TablePanelOptions extends SimpleComponent  {
         const {onPageSize, onPropChanged} = makeCallbacks(onChange, columns);
         return (
 
-               <div className='TablePanelOptions'>
-                 <div
+            <div className='TablePanelOptions'>
+                <div
                     style={{flexGrow: 0, marginBottom: 32, display: 'flex', flexDirection: 'row', justifyContent: 'space-between'}}>
-                    <div style={{display: 'inline-block', whiteSpace: 'nowrap'}}>
-                        <div>
-                            <div style={labelStyle}>Show Units:</div>
-                            <input type='checkbox' onChange={(e) => onPropChanged(e.target.checked, 'showUnits')}
-                                   checked={showUnits}/>
-                        </div>
-                        <div>
-                            <div style={labelStyle}>Show Filters:</div>
-                            <input type='checkbox' onChange={(e) => onPropChanged(e.target.checked, 'showFilters')}
-                                   checked={showFilters}/>
-                        </div>
-                    </div>
-                    <div style={{display: 'inline-block'}}>
-                        <div>
-                            <div style={labelStyle}>Show Types:</div>
-                            <input type='checkbox' onChange={(e) => onPropChanged(e.target.checked, 'showTypes')}
-                                   checked={showTypes}/>
-                        </div>
+                    <div>
                         {showToolbar &&
-                            <InputField
-                                validator={intValidator(1,10000)}
-                                tooltip='Set page size'
-                                label='Page Size:'
-                                labelStyle={{...labelStyle, width: 60}}
-                                size={3}
-                                value={pageSize+''}
-                                onChange={onPageSize}
-                                actOn={['blur','enter']}
-                            />
+                        <InputField
+                            validator={intValidator(1,10000)}
+                            tooltip='Set page size'
+                            label='Page Size:'
+                            labelStyle={{...labelStyle, width: 60}}
+                            size={3}
+                            value={pageSize+''}
+                            onChange={onPageSize}
+                            actOn={['blur','enter']}
+                        />
                         }
+                        <div>
+                            <div style={{...labelStyle, width: 44, marginLeft: 19}}>Show:</div>
+                            <div style={labelStyle}><input type='checkbox'
+                                                           onChange={(e) => onPropChanged(e.target.checked, 'showUnits')}
+                                                           checked={showUnits}/>Units
+                            </div>
+                            <div style={labelStyle}><input type='checkbox'
+                                                           onChange={(e) => onPropChanged(e.target.checked, 'showTypes')}
+                                                           checked={showTypes}/>Types
+                            </div>
+                            <div style={labelStyle}><input type='checkbox'
+                                                           onChange={(e) => onPropChanged(e.target.checked, 'showFilters')}
+                                                           checked={showFilters}/>Filters
+                            </div>
+                        </div>
                     </div>
                     <span>
-
                         <button type='button' className='TablePanelOptions__button' onClick={onOptionReset}
                                 title='Reset all options to defaults'>Reset</button>
                     </span>
@@ -79,7 +74,7 @@ export class TablePanelOptions extends SimpleComponent  {
                         {...{tbl_ui_id, columns, filterInfo, onChange}}
                     />
                 </div>
-               </div>
+            </div>
 
      );
     };

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -65,8 +65,8 @@ export class HeaderCell extends PureComponent {
                         {label || name}
                         { sortDir !== UNSORTED && <SortSymbol sortDir={sortDir}/> }
                     </div>
-                    {showTypes && <div style={{height: 11, fontWeight: 'normal', fontStyle: 'italic', color: 'brown'}}>{typeVal}</div>}
                     {showUnits && <div style={{height: 11, fontWeight: 'normal'}}>{unitsVal}</div>}
+                    {showTypes && <div style={{height: 11, fontWeight: 'normal', fontStyle: 'italic'}}>{typeVal}</div>}
                 </div>
                 {showFilters && filter}
             </div>
@@ -98,8 +98,8 @@ export class SelectableHeader extends Component {
                        tabIndex={-1}
                        checked={checked}
                        onChange={(e) => onSelectAll(e.target.checked)}/>
-                {showTypes && <div/>}
                 {showUnits && <div/>}
+                {showTypes && <div/>}
                 {showFilters && <img className='clickable'
                                      style={{marginBottom: 3}}
                                      src={FILTER_SELECTED_ICO}

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -59,13 +59,15 @@ export class HeaderCell extends PureComponent {
 
         const onClick = toBoolean(sortable, true) && (() => onSort(sortCol));
         return (
-            <div style={style} title={cdesc} className='TablePanel__header clickable' onClick={onClick}>
-                <div>
-                    {label || name}
-                    { sortDir !== UNSORTED && <SortSymbol sortDir={sortDir}/> }
+            <div style={style} title={cdesc} className='TablePanel__header'>
+                <div style={{height: '100%'}} className='clickable' onClick={onClick}>
+                    <div>
+                        {label || name}
+                        { sortDir !== UNSORTED && <SortSymbol sortDir={sortDir}/> }
+                    </div>
+                    {showTypes && <div style={{height: 11, fontWeight: 'normal', fontStyle: 'italic', color: 'brown'}}>{typeVal}</div>}
+                    {showUnits && <div style={{height: 11, fontWeight: 'normal'}}>{unitsVal}</div>}
                 </div>
-                {showTypes && <div style={{height: 11, fontWeight: 'normal', fontStyle: 'italic', color: 'brown'}}>{typeVal}</div>}
-                {showUnits && <div style={{height: 11, fontWeight: 'normal'}}>{unitsVal}</div>}
                 {showFilters && filter}
             </div>
         );


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-13382

Add option to show/hide column's data type.  Option is added to option panel and exposed through API as well.  
I took the liberty of adding some style to the data type because it looks pretty bad without it.  
If you don't like it, I have not problem changing it to something people agree to.

A couple of things you should be aware of.
- Sorting is triggered by clicking anywhere on the column header, not just the column's label.
- Cursor's is change to a 'pointer' icon when hover over the column's header.

Deployed to k8s:
https://irsawebdev9.ipac.caltech.edu/dm-13382/firefly/
