### PR TITLE
DM-13776: Add option to include firefly's onlinehelp when building firefly

### DIFF
--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -89,6 +89,23 @@ test {
   }
 }
 
+task onlinehelp (dependsOn: [loadConfig]) {
+  ext.onlinehelp_dir = "$rootDir/../ife-onlinehelp/"
+  doLast {
+    exec {
+      workingDir onlinehelp_dir
+      commandLine 'gradle', ":${project['app-name']}:build"
+    }
+
+    new File("${gwt.warDir}/onlinehelp").mkdirs()
+    copy {
+      from zipTree("$onlinehelp_dir/build/dist/${project['app-name']}_help.zip")
+      into "${gwt.warDir}/onlinehelp"
+    }
+  }
+}
+
+
 task prepareWebapp (type:Copy, dependsOn: [gwt, loadConfig, createVersionTag]) {
   description= 'Generates the configuration files needed by the webapp, ie. app.prop, web.xml, etc.'
   group = MISC_GROUP

--- a/config/app.config
+++ b/config/app.config
@@ -24,7 +24,7 @@ download.bundle.maxbytes = 304857600
 
 sso.server.url = "https://irsa.ipac.caltech.edu/account/"
 sso.user.profile.url = "https://irsa.ipac.caltech.edu/account/uman/uman.html//id=profile"
-__$help.base.url = "https://irsa.ipac.caltech.edu/onlinehelp/"
+__$help.base.url = "onlinehelp/"
 
 
 visualize.fits.MaxSizeInBytes= 10737418240


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-13776

Add option to build and deploy onlinehelp along with the application.
Changes were made directly in master branch of ife-onlinehelp as well.

To build onlinehelp along with firefly:
`gradle :firefly:onlinehelp :firefly:war`

Deployed to k8s: https://irsawebdev9.ipac.caltech.edu/dm-13776/firefly/
