### PR TITLE
DM-14516 make ds9 region file parsing case insensitive

### DIFF
--- a/src/firefly/html/demo/ffapi-footprint-test.html
+++ b/src/firefly/html/demo/ffapi-footprint-test.html
@@ -1,0 +1,199 @@
+<!doctype html>
+
+<!--
+  ~ License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+  -->
+
+<html>
+
+<head>
+    <meta http-equiv="Cache-Control" content="no-cache">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Demo of Firefly Tools</title>
+</head>
+
+<body>
+
+
+<div style="width: 500px; padding: 10px 0 0 10px;">
+    This page demos footprint on image with target at (0;0; J2000)
+    <br>
+</div>
+
+<div id ="imageForRegion" style="border: 1px solid blue;width: 600px; height: 600px; margin: 10px;"></div>
+
+<div style="width:800px">
+
+    <p style="margin-top:3px">Add new footprint overlay on above image:  <p/>
+    <ul>
+    <li><span style="color: blue">Create Footprint Layer:</span> enter region ID or use the hint, compose footprint description in the editing area, then click to add the new layer</li>
+    <li><span style="color: blue">Select Footprint Layer:</span> select a layer from the list and click to select the layer, the description of the selected footprint is shown in the editing area and the
+                                  first region in the footprint is highlighted</li>
+    <li><span style="color: blue">Delete Footprint Layer:</span> select a layer from the list and click to delete the layer </li>
+    </ul>
+</div>
+
+<div>
+    <a title="create a new region layer" href='javascript:createRegionLayer()'>Create Footprint Layer</a>
+    <input type='text' placeholder='' list='regionCreated' id='createRegionId' name='createRegionLayer'>
+    <datalist id='regionCreated'>
+    </datalist>
+    &nbsp;
+    <a title="select a region layer" href='javascript:selectRegion()'>Select Footprint Layer:</a>
+    <select id='regionLayers'><option selected disabled>Region Layers:</option></select>
+    &nbsp;
+    <a title="delete a region layer" href='javascript:deleteRegionLayer()'>Delete Foorprint Layer</a>
+    <select id='regionList_delete'><option selected disabled>Region Layer:</option></select>
+    <div>
+        <textarea id="regionLayerContent" style="width: 800px; height: 300px; margin: 10px;"> </textarea>
+    </div>
+</div>
+
+<script type="text/javascript">
+    if (!window.firefly) window.firefly= {};
+    window.firefly.options= {charts: {}};
+</script>
+
+
+<script type="text/javascript">
+    {
+        onFireflyLoaded= function(firefly) {
+
+            window.ffViewer= firefly.getViewer();
+
+            firefly.setGlobalImageDef({
+                ZoomType  : 'TO_WIDTH'
+            } );
+
+            firefly.debug= true;
+
+            var util= firefly.util;
+            var ui= firefly.ui;
+
+            firefly.showImage('imageForRegion', {
+                Type      : 'SERVICE',
+                plotId:   'regiontest',
+                plotGroupId : 'myGroup',
+                Service  : 'WISE',
+                Title     : 'WISE W1 (3.4 microns)',
+                SurveyKey  : '3a',
+                SurveyKeyBand  : '1',
+                WorldPt    : '0.0;0.0;EQ_J2000',
+                SizeInDeg  : '1.5',
+                AllowImageSelection : true});
+
+            window.regionAry = [
+                'J2000',
+                'POLYGON -0.2D -0.2D -0.2D 0.2D 0.2D 0.2D 0.2D -0.2D # COLOR=ORANGE',
+                'POLYGON -0.18D -0.18D -0.18D 0.18D 0.18D 0.18D 0.18D -0.18D # COLOR=RED'
+            ];
+
+            window.emptyRegion = '';
+            window.regions = [];
+            window.regionsList = {};
+            window.regionId = 0;
+
+            document.getElementById('regionLayerContent').value = window.regionAry.join('\n');
+            document.getElementById('createRegionId').placeholder = "Region_Plot_" + (window.regionId+1);
+        };
+
+        createRegionLayer = function() {
+            var layerId = document.getElementById('createRegionId').value;
+
+            if (!layerId) {
+                window.regionId++;
+                layerId = "Region_Plot_" + window.regionId;
+                document.getElementById('createRegionId').value = layerId;
+            }
+            if (layerId) {
+                var regionAry = document.getElementById('regionLayerContent').value.split('\n').filter(function (r) {
+                    return (r.length !== 0);
+                });
+
+                if (window.regions.indexOf(layerId) < 0) {
+                    window.regions.push(layerId);
+                }
+                window.regionsList[layerId] = regionAry;  // add new or update existing region layer
+                updateRegionLayerList();
+
+                firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, 'regiontest');
+            }
+        };
+
+        updateDataList = function() {
+            var datalist = document.getElementById('regionCreated');
+            var options = '';
+
+            window.regions.forEach( function(r) {
+                options += '<option value="'+r+'" />';
+            });
+
+            datalist.innerHTML = options;
+            document.getElementById('createRegionId').value = '';
+            document.getElementById('createRegionId').placeholder = "Region_Plot_" + (window.regionId+1);
+        };
+
+        updateRegionLayerList = function() {
+            var selectListIds = ['regionLayers', 'regionList_delete'];
+
+            selectListIds.forEach( function(selectId) {
+                var selectBox = document.getElementById(selectId);
+
+                for (var i = selectBox.options.length - 1; i > 0; i--) {
+                     selectBox.remove(i);
+                }
+                window.regions.forEach(function (r) {
+                    var option = document.createElement('option');
+                    option.value = r;
+                    option.text = r;
+                    selectBox.appendChild(option);
+                });
+
+                selectBox.getElementsByTagName('option')[0].selected = 'selected';
+            });
+            updateDataList();
+
+        };
+
+        selectRegion = function() {
+            var selectBox=document.getElementById('regionLayers');
+            var selectedLayerId = selectBox.options[selectBox.selectedIndex].value;
+
+            if (window.regions.indexOf(selectedLayerId) >= 0) {
+                var regionAry = window.regionsList[selectedLayerId];
+                var regionArea = document.getElementById('regionLayerContent');
+
+                regionArea.value = regionAry.join('\n');
+
+                if (selectedLayerId) {
+                    firefly.action.dispatchSelectRegion(selectedLayerId, regionAry);
+                }
+            }
+        };
+
+        deleteRegionLayer = function() {
+            var selectBox = document.getElementById('regionList_delete');
+
+            if (selectBox.selectedIndex !== 0) {
+                var selectedLayerId = selectBox.options[selectBox.selectedIndex].value;
+
+                window.regions.splice(selectBox.selectedIndex - 1, 1);
+                delete window.regionsList[selectedLayerId];
+                updateRegionLayerList();
+
+                firefly.action.dispatchDeleteRegionLayer(selectedLayerId, 'regiontest');
+            }
+        };
+
+
+   }
+   
+</script>
+
+<!-- to try a container: <script  type="text/javascript" src="http://localhost:8090/firefly/firefly_loader.js"></script>-->
+
+<script  type="text/javascript" src="../firefly_loader.js"></script>
+
+

--- a/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
@@ -165,6 +165,7 @@ public class RegionFactory {
                     }
                 }
 
+                region_type = region_type.toLowerCase();
                 boolean isWorldCoord = isWorldCoords(coordSys);
                 if (st.hasMoreToken()) {
 
@@ -204,7 +205,7 @@ public class RegionFactory {
                     }
                     else if (isPointTypeTwo(virtualLineNoInclude)) {
                         if (st.hasMoreToken()) {
-                            if (st.nextToken().equals("point")) {
+                            if (st.nextToken().toLowerCase().equals("point")) {
                                 WorldPt wp= parseWorldPt(coordSys, st.nextToken(), st.nextToken());
                                 RegionPoint.PointType pointType = convertPointType(region_type);
                                 if (options!=null)  ops= parseRegionOption(options,globalOps,include);
@@ -568,15 +569,19 @@ public class RegionFactory {
                     unit= RegionValue.Unit.ARCMIN;
                     break;
                 case 'd':      // degrees
+                case 'D':
                     unit= RegionValue.Unit.DEGREE;
                     break;
                 case 'r':      // radians
+                case 'R':
                     unit= RegionValue.Unit.RADIANS;
                     break;
                 case 'p':      // physical
+                case 'P':
                     unit= RegionValue.Unit.SCREEN_PIXEL;
                     break;
                 case 'i':      // image
+                case 'I':
                     unit= RegionValue.Unit.IMAGE_PIXEL;
                     break;
                 default:
@@ -728,7 +733,7 @@ public class RegionFactory {
         else if (s.equalsIgnoreCase("cross"))     retval = RegionPoint.PointType.Cross;
         else if (s.equalsIgnoreCase("x"))         retval = RegionPoint.PointType.X;
         else if (s.equalsIgnoreCase("arrow"))     retval = RegionPoint.PointType.Arrow;
-        else if (s.equals("boxcircle")) retval = RegionPoint.PointType.BoxCircle;
+        else if (s.equalsIgnoreCase("boxcircle")) retval = RegionPoint.PointType.BoxCircle;
         return retval;
     }
 

--- a/src/firefly/js/visualize/region/Region.js
+++ b/src/firefly/js/visualize/region/Region.js
@@ -49,7 +49,7 @@ var cloneArg = (arg) => Object.keys(arg).reduce((prev, key) =>
  * @param {string} message parsing message
  * @function makeRegion
  */
-export var makeRegion = (
+export const makeRegion = (
             {
                 wpAry,       // for polygon, polygonCenter is added optionally based on VisUtil.computerCentralAndRadius
                 radiusAry,
@@ -100,7 +100,7 @@ export var makeRegion = (
  * @function makeRegionOptions
  */
 
-export var makeRegionOptions = (
+export const makeRegionOptions = (
             {
                 color = 'green',
                 text,
@@ -157,7 +157,7 @@ export const regionPropsList = {
         MSG:     'message'
 };
 
-export var defaultRegionProperty = {
+export const defaultRegionProperty = {
     color: 'green',
     text:  '',
     font:  {name: 'helvetica', point: '10', weight: 'normal', slant: 'normal'},
@@ -186,8 +186,8 @@ export var defaultRegionProperty = {
     message: ''
 };
 
-export var getRegionDefault = (prop) => (has(defaultRegionProperty, prop) ? defaultRegionProperty[prop] : null);
-export var setRegionPropDefault = (prop, value) => {
+export const getRegionDefault = (prop) => (has(defaultRegionProperty, prop) ? defaultRegionProperty[prop] : null);
+export const setRegionPropDefault = (prop, value) => {
             if (has(defaultRegionProperty, prop)) {
                 defaultRegionProperty[prop] = value;
             }
@@ -201,7 +201,7 @@ export var setRegionPropDefault = (prop, value) => {
  * @function RegionValue
  */
 
-export var RegionValue =
+export const RegionValue =
     (value = 0.0, unit = RegionValueUnit.CONTEXT) => ({value, unit});
 
 /**
@@ -210,7 +210,7 @@ export var RegionValue =
  * @param {Object} height RegionValue height of box or second radius of ellipse
  * @function RegionDimension
  */
-export var RegionDimension = (width, height) => ({width, height});
+export const RegionDimension = (width, height) => ({width, height});
 
 /**
  * regiopn parse exception
@@ -223,28 +223,28 @@ export class RegParseException extends Error {
     }
 }
 
-export var makeRegionMsg = (msg) => makeRegion({type: RegionType.message, message: msg});
+export const makeRegionMsg = (msg) => makeRegion({type: RegionType.message, message: msg});
 
 /**
  * @summary get region type
  * @param {string} rgTypeStr
  * @returns {Object} RegionType
  */
-export var getRegionType = (rgTypeStr) => (RegionType.get(rgTypeStr) || RegionType.undefined);
+export const getRegionType = (rgTypeStr) => (RegionType.get(rgTypeStr) || RegionType.undefined);
 
 /**
  * $summary get region point type
  * @param {string} typeStr
  * @returns {Object} RegionPointType
  */
-export var getRegionPointType = (typeStr) => (RegionPointType.get(typeStr) || RegionPointType.undefined);
+export const getRegionPointType = (typeStr) => (RegionPointType.get(typeStr) || RegionPointType.undefined);
 
 /**
  * @summary get coordinate system
  * @param {string} coordStr
  * @returns {Object} RegionCsys
  */
-export var getRegionCoordSys = (coordStr) => (RegionCsys.get(coordStr) || RegionCsys.UNDEFINED);
+export const getRegionCoordSys = (coordStr) => (RegionCsys.get(coordStr) || RegionCsys.UNDEFINED);
 
 /**
  * @summary get region font object
@@ -254,7 +254,7 @@ export var getRegionCoordSys = (coordStr) => (RegionCsys.get(coordStr) || Region
  * @param {string} slant ex: normal, italic
  * @returns {Object}
  */
-export var makeRegionFont = (name = 'helvetica', point = '10', weight = 'normal', slant = 'normal') => (
+export const makeRegionFont = (name = 'helvetica', point = '10', weight = 'normal', slant = 'normal') => (
         {name, point, weight, slant});
 
 /**

--- a/src/firefly/js/visualize/region/RegionDrawer.js
+++ b/src/firefly/js/visualize/region/RegionDrawer.js
@@ -11,7 +11,6 @@ import ShapeDataObj from '../draw/ShapeDataObj.js';
 import {DrawSymbol, make as makePoint } from '../draw/PointDataObj.js';
 import {union, isArray} from 'lodash';
 import {TextLocation} from '../draw/DrawingDef.js';
-import Point from '../Point.js';
 
 export const DEFAULT_TEXTLOC = {
     [RegionType.circle.key]: TextLocation.CIRCLE_SE,
@@ -207,7 +206,7 @@ function updateDrawobjProp(rgPropAry, rgOptions, dObj) {
                 if (dObj.text) {
                     var x = get(rgOptions, regionPropsList.OFFX, getRegionDefault(regionPropsList.OFFX));
                     var y = get(rgOptions, regionPropsList.OFFY, getRegionDefault(regionPropsList.OFFY));
-                    if (x != 0 || y != 0) {
+                    if (x !== 0 || y !== 0) {
                         dObj.textOffset = makeOffsetPt(x, y);
                     }
                 }
@@ -333,10 +332,10 @@ function drawRegionAnnulus(regionObj) {
  * make one drawobj for box with ratote angle, makeRectangleByCenter is used
  * @param w  width
  * @param h  height
+ * @param a rotation angle
  * @param wp center of box
  * @param options region properties
  * @param propChkAry property cheeck list
- * @param a rotation angle
  * @param isOnWorld
  * @returns {*}
  */
@@ -485,10 +484,10 @@ function drawRegionPolygon(regionObj) {
  * make one drawobj for ellipse with ratote angle, makeEllipse is used
  * @param r1  radius1
  * @param r2  radius2
+ * @param a rotation angle
  * @param wp center of ellipse
  * @param options region properties
  * @param propChkAry property cheeck list
- * @param a rotation angle
  * @param isOnWorld
  * @returns {*}
  */

--- a/src/firefly/js/visualize/region/RegionFactory.js
+++ b/src/firefly/js/visualize/region/RegionFactory.js
@@ -290,7 +290,8 @@ export class RegionFactory {
         var ptIdx;
 
         // region point with shape in description, ex. circle point x y
-        if ((regionType = getRegionType(regionParams[1])) === RegionType.point) {
+        regionType = getRegionType(regionParams[1]);
+        if (regionType === RegionType.point) {
             if ((pointType = getRegionPointType(regionParams[0])) === RegionPointType.undefined) {
                 return makeRegionMsg(`[${RegionParseError.InvalidType}] ${rgMsg}`);
             }
@@ -751,7 +752,7 @@ export class RegionFactory {
         var isTransformationChecked = false;
 
         if (!validator.isInt(unit_char) && (unit_char !== 's')) {
-            switch(unit_char) {
+            switch(unit_char.toLowerCase()) {
                 case '"':
                     unit = RegionValueUnit.ARCSEC;
                     break;
@@ -1042,7 +1043,7 @@ export class RegionFactory {
                 break;
             }
 
-            switch (opName) {
+            switch (opName.toLowerCase()) {
                 case 'color':
                     opValRes = getOptionValue(ops, getValueBeforeChar, ' ');
                     if (opValRes.valueStr) {


### PR DESCRIPTION
This development includes: 
- make the case-insensitive parsing on ds9 regions to be case insensitive on both server and front ends. 

test: 
- do image search on firefly on target (0,0, j2000) and upload footprint file from 'Load DS9 Region File' popup.   
- go to firefly/demo/ffapi-footprint-test.html, and add footprint layer from the footprint tool page. 
