### PR TITLE
DM-14694 fix pixel coordinate to be compatible with FITS convention

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -471,6 +471,11 @@ public class VisServerOps {
             Band bands[] = state.getBands();
             WebPlotRequest cropRequest[] = new WebPlotRequest[bands.length];
 
+            int c1_x = (int)Math.floor(c1.getX());
+            int c2_x = (int)Math.ceil(c2.getX());
+            int c1_y = (int)Math.ceil(c1.getY());
+            int c2_y = (int)Math.floor(c2.getY());
+
             for (int i = 0; (i < bands.length); i++) {
 
                 File workingFilsFile = PlotStateUtil.getWorkingFitsFile(state, bands[i]);
@@ -486,20 +491,24 @@ public class VisServerOps {
                     if (cropMultiAll) {
                         File originalFile = PlotStateUtil.getOriginalFile(state, bands[i]);
                         CropFile.crop_extensions(originalFile.getPath(), cropFile.getPath(),
-                                (int) c1.getX(), (int) c1.getY(),
-                                (int) c2.getX(), (int) c2.getY());
+                                c1_x, c1_y, c2_x, c2_y);
+                                //(int) c1.getX(), (int) c1.getY(),
+                                //(int) c2.getX(), (int) c2.getY());
                         cropFits = new Fits(cropFile);
                         saveCropFits = false;
                     } else {
                         Fits fits = new Fits(PlotStateUtil.getWorkingFitsFile(state, bands[i]));
                         cropFits = CropFile.do_crop(fits, state.getImageIdx(bands[i]) + 1,
-                                (int) c1.getX(), (int) c1.getY(),
-                                (int) c2.getX(), (int) c2.getY());
+                                c1_x, c1_y, c2_x, c2_y);
+                                //(int) c1.getX(), (int) c1.getY(),
+                                //(int) c2.getX(), (int) c2.getY());
                     }
                 } else {
                     Fits fits = new Fits(PlotStateUtil.getWorkingFitsFile(state, bands[i]));
-                    cropFits = CropFile.do_crop(fits, (int) c1.getX(), (int) c1.getY(),
-                            (int) c2.getX(), (int) c2.getY());
+                    cropFits = CropFile.do_crop(fits,
+                                                //(int) c1.getX(), (int) c1.getY(),
+                                                //(int) c2.getX(), (int) c2.getY());
+                                                c1_x, c1_y, c2_x, c2_y);
                 }
 
                 FitsRead fr[] = FitsCacher.loadFits(cropFits, cropFile);

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImagePlot.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImagePlot.java
@@ -393,7 +393,7 @@ public class ImagePlot extends Plot implements Serializable {
                 wpt= convert(wpt,_imageCoordSys);
             }
             ProjectionPt proj_pt= _projection.getImageCoords(wpt.getLon(),wpt.getLat());
-            retval= new ImageWorkSpacePt( proj_pt.getX() + 0.5F ,  proj_pt.getY() + 0.5F);
+            retval= new ImageWorkSpacePt( proj_pt.getX() + 1.0F,  proj_pt.getY() + 1.0F);
         }
         return retval;
     }

--- a/src/firefly/js/rpc/PlotServicesJson.js
+++ b/src/firefly/js/rpc/PlotServicesJson.js
@@ -10,7 +10,7 @@ import {isArray} from 'lodash';
 import {ServerParams} from '../data/ServerParams.js';
 import {doJsonRequest} from '../core/JsonUtils.js';
 import {SelectedShape} from '../drawingLayers/SelectArea.js';
-
+import {xy0Fitsll} from '../visualize/Point.js';
 
 
 /**
@@ -135,9 +135,15 @@ export function callRecomputeStretch(state, stretchDataAry) {
 }
 
 
-
 export function callCrop(stateAry, corner1ImagePt, corner2ImagePt, cropMultiAll) {
 
+    //console.log('corner1ImagePt: ' + corner1ImagePt.x + ';'+ corner1ImagePt.y);
+    //console.log('corner2ImagePt: ' + corner2ImagePt.x + ';'+ corner2ImagePt.y);
+
+    corner1ImagePt.x -= xy0Fitsll;
+    corner1ImagePt.y -= xy0Fitsll;
+    corner2ImagePt.x -= xy0Fitsll;
+    corner2ImagePt.y -= xy0Fitsll;
     var params= makeParamsWithStateAry(stateAry,false, [
         {name:ServerParams.PT1, value: corner1ImagePt.toString()},
         {name:ServerParams.PT2, value: corner2ImagePt.toString()},

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -24,7 +24,7 @@ import {FieldGroup} from './FieldGroup.jsx';
 
 import CsysConverter from '../visualize/CsysConverter.js';
 import {primePlot, getActivePlotView, getFoV} from '../visualize/PlotViewUtil.js';
-import { makeImagePt, makeWorldPt, makeScreenPt, makeDevicePt} from '../visualize/Point.js';
+import { makeImagePt, makeWorldPt, makeScreenPt, makeDevicePt, xy0Fitsll} from '../visualize/Point.js';
 import {visRoot} from '../visualize/ImagePlotCntlr.js';
 import {getValueInScreenPixel} from '../visualize/draw/ShapeDataObj.js';
 
@@ -164,10 +164,10 @@ function calcCornerString(pv, method) {
     const radiusSearch = getFoV(pv) > maxHipsRadiusSearch ? maxHipsRadiusSearch * 3600 : getFoV(pv) * 3600; // in arcsec
 
     if (method==='image' || (!sel && method==='area-selection') ) {
-        pt1 = cc.getWorldCoords(makeImagePt(0,0));
-        pt2 = cc.getWorldCoords(makeImagePt(w, 0));
-        pt3 = cc.getWorldCoords(makeImagePt(w, h));
-        pt4 = cc.getWorldCoords(makeImagePt(0, h));
+        pt1 = cc.getWorldCoords(makeImagePt(0+xy0Fitsll,0+xy0Fitsll));
+        pt2 = cc.getWorldCoords(makeImagePt(w+xy0Fitsll, 0+xy0Fitsll));
+        pt3 = cc.getWorldCoords(makeImagePt(w+xy0Fitsll, h+xy0Fitsll));
+        pt4 = cc.getWorldCoords(makeImagePt(0+xy0Fitsll, h+xy0Fitsll));
 
         if(isHiPS(plot)){
             const centerDevPt= makeDevicePt(plot.viewDim.width/2, plot.viewDim.height/2);

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -4,11 +4,10 @@
 import CoordinateSys from './CoordSys.js';
 import VisUtil from './VisUtil.js';
 import {makeRoughGuesser} from './ImageBoundsData.js';
-import Point, {makeImageWorkSpacePt, makeImagePt,
+import Point, {xy0Fits, xy0Fitsll, makeImageWorkSpacePt, makeImagePt,
                makeScreenPt, makeWorldPt, makeDevicePt, isValidPoint} from './Point.js';
 import {Matrix} from 'transformation-matrix-js';
 import {getPixScaleDeg} from './WebPlot.js';
-
 
 function convertToCorrect(wp) {
     if (!wp) return null;
@@ -90,7 +89,7 @@ export class CysConverter {
             const ipt= this.getImageCoords(iwPt);
             const x= ipt.x;
             const y= ipt.y;
-            retval= (x >= 0 && x <= this.dataWidth && y >= 0 && y <= this.dataHeight );
+            retval= (x >= 0+xy0Fitsll && x <= this.dataWidth+xy0Fitsll && y >= 0+xy0Fitsll && y <= this.dataHeight+xy0Fitsll);
         }
         return retval;
     }
@@ -133,7 +132,7 @@ export class CysConverter {
     imageWorkSpacePtInPlot(ipt) {
         if (!ipt) return false;
         const {x,y}= ipt;
-        return (x >= 0 && x <= this.dataWidth && y >= 0 && y <= this.dataHeight );
+        return (x >= 0+xy0Fitsll && x <= this.dataWidth+xy0Fitsll && y >= 0+xy0Fitsll && y <= this.dataHeight+xy0Fitsll );
     }
 
     /**
@@ -238,7 +237,8 @@ export class CysConverter {
     makeIWPtFromSPt(screenPt, altZoomLevel) {
         if (!screenPt) return null;
         const zoom= altZoomLevel || this.zoomFactor;
-        return makeImageWorkSpacePt(screenPt.x / zoom, this.dataHeight-screenPt.y/zoom);
+        //return makeImageWorkSpacePt(screenPt.x / zoom, this.dataHeight-screenPt.y/zoom);
+        return makeImageWorkSpacePt(screenPt.x / zoom + xy0Fitsll, this.dataHeight-(screenPt.y/zoom) + xy0Fitsll);
     }
 
 //========================================================================================
@@ -304,7 +304,8 @@ export class CysConverter {
                     wpt= VisUtil.convert(wpt,this.imageCoordSys);
                 }
                 const projPt= this.projection.getImageCoords(wpt.getLon(),wpt.getLat());
-                retval= projPt ? makeImagePt( projPt.x+ 0.5 ,  projPt.y+ 0.5) : null;
+                //retval= projPt ? makeImagePt( projPt.x+ 0.5 ,  projPt.y+ 0.5) : null;
+                retval= projPt ? makeImagePt( projPt.x + xy0Fits,  projPt.y + xy0Fits) : null;
                 this.putInConversionCache(originalWp,retval);
             }
         }
@@ -460,9 +461,11 @@ export class CysConverter {
 
                 const  proj_pt= this.projection.getImageCoords(wpt.getLon(),wpt.getLat());
                 if (proj_pt) {
-                    const imageX= proj_pt.x  + 0.5;
-                    const imageY= proj_pt.y  + 0.5;
+                    //const imageX= proj_pt.x  + 0.5;
+                    //const imageY= proj_pt.y  + 0.5;
 
+                    const imageX= proj_pt.x + xy0Fits;
+                    const imageY= proj_pt.y + xy0Fits;
                     imagePt= makeImagePt(imageX,imageY);
                     this.putInConversionCache(originalWp, imagePt);
 
@@ -483,8 +486,10 @@ export class CysConverter {
     makeScreenPtFromImPtOptimized(imagePt,retPt) {
         if (!imagePt) return null;
         // convert image to image workspace
-        const imageWorkspaceX= imagePt.x;
-        const imageWorkspaceY= imagePt.y;
+        //const imageWorkspaceX= imagePt.x;
+        //const imageWorkspaceY= imagePt.y;
+        const imageWorkspaceX= imagePt.x - xy0Fitsll;
+        const imageWorkspaceY= imagePt.y - xy0Fitsll;
 
         // convert image workspace to screen
         const zFact= this.zoomFactor;
@@ -502,8 +507,10 @@ export class CysConverter {
     makeSPtFromIWPt(iwpt, altZoomLevel) {
         if (!iwpt) return null;
         const zoom= altZoomLevel || this.zoomFactor;
-        return makeScreenPt(iwpt.x*zoom,
-                            (this.dataHeight - iwpt.y) *zoom );
+        //return makeScreenPt(iwpt.x*zoom,
+        //                  (this.dataHeight - iwpt.y) *zoom );
+        return makeScreenPt((iwpt.x-xy0Fitsll)*zoom,
+                            (this.dataHeight - (iwpt.y-xy0Fitsll)) *zoom );
     }
 
 
@@ -542,7 +549,8 @@ export class CysConverter {
 
     makeWorldPtFromIPt( ipt, outputCoordSys) {
         if (!ipt) return null;
-        let wpt = this.projection.getWorldCoords(ipt.x - .5 ,ipt.y - .5);
+        //let wpt = this.projection.getWorldCoords(ipt.x - .5 ,ipt.y - .5);
+        let wpt = this.projection.getWorldCoords(ipt.x - xy0Fits , ipt.y - xy0Fits);
         if (wpt && outputCoordSys!==wpt.getCoordSys()) {
             wpt= VisUtil.convert(wpt, outputCoordSys);
         }

--- a/src/firefly/js/visualize/ImageBoundsData.js
+++ b/src/firefly/js/visualize/ImageBoundsData.js
@@ -4,7 +4,7 @@
 
 import CoordinateSys from './CoordSys.js';
 import VisUtil from './VisUtil.js';
-import {makeImagePt} from './Point';
+import {makeImagePt, xy0Fits, xy0Fitsll} from './Point';
 import {getPixScaleDeg} from './WebPlot.js';
 
 
@@ -29,10 +29,10 @@ export const makeRoughGuesser= function(cc) {
 
 
     const {dataWidth, dataHeight}= cc;
-    const topLeft= cc.getWorldCoords(makeImagePt(0,0));
-    const topRight= cc.getWorldCoords(makeImagePt(dataWidth,0));
-    const bottomRight= cc.getWorldCoords(makeImagePt(dataWidth,dataHeight));
-    const bottomLeft= cc.getWorldCoords(makeImagePt(0,dataHeight));
+    const topLeft= cc.getWorldCoords(makeImagePt(0+xy0Fitsll,0+xy0Fitsll));
+    const topRight= cc.getWorldCoords(makeImagePt(dataWidth+xy0Fitsll,0+xy0Fitsll));
+    const bottomRight= cc.getWorldCoords(makeImagePt(dataWidth+xy0Fitsll,dataHeight+xy0Fitsll));
+    const bottomLeft= cc.getWorldCoords(makeImagePt(0+xy0Fitsll,dataHeight+xy0Fitsll));
     const scale= getPixScaleDeg(cc);
 
 

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -3,7 +3,7 @@
  */
 import {difference, flatten, get, has, isArray, isEmpty, isString, isUndefined} from 'lodash';
 import {getPlotGroupById} from './PlotGroup.js';
-import {makeDevicePt, makeImagePt, makeWorldPt, pointEquals} from './Point.js';
+import {makeDevicePt, makeImagePt, makeWorldPt, pointEquals, xy0Fitsll} from './Point.js';
 import {clone} from '../util/WebUtil.js';
 import {dispatchDestroyDrawLayer, getDlAry} from './DrawLayerCntlr.js';
 import {makeTransform} from './PlotTransformUtils.js';
@@ -546,10 +546,10 @@ export function isMultiImageFitsWithSameArea(pv) {
     const plot= primePlot(pv);
     const {dataWidth:w, dataHeight:h} = plot;
 
-    const ic1= makeImagePt(0,0);
-    const ic2= makeImagePt(w,0);
-    const ic3= makeImagePt(0,h);
-    const ic4= makeImagePt(w,h);
+    const ic1= makeImagePt(0+xy0Fitsll,0+xy0Fitsll);
+    const ic2= makeImagePt(w+xy0Fitsll,0+xy0Fitsll);
+    const ic3= makeImagePt(0+xy0Fitsll,h+xy0Fitsll);
+    const ic4= makeImagePt(w+xy0Fitsll,h+xy0Fitsll);
 
     const projName= plot.projection.getProjectionName();
     const cc= CysConverter.make(plot);
@@ -659,10 +659,10 @@ export function getCorners(plot) {
     const cc= CysConverter.make(plot);
     const {dataWidth:w, dataHeight:h} = plot;
 
-    const c1= cc.getWorldCoords(makeImagePt(0,0));
-    const c2= cc.getWorldCoords(makeImagePt(w,0));
-    const c3= cc.getWorldCoords(makeImagePt(w,h));
-    const c4= cc.getWorldCoords(makeImagePt(0,h));
+    const c1= cc.getWorldCoords(makeImagePt(0+xy0Fitsll,0+xy0Fitsll));
+    const c2= cc.getWorldCoords(makeImagePt(w+xy0Fitsll,0+xy0Fitsll));
+    const c3= cc.getWorldCoords(makeImagePt(w+xy0Fitsll,h+xy0Fitsll));
+    const c4= cc.getWorldCoords(makeImagePt(0+xy0Fitsll,h+xy0Fitsll));
     if (!c1 || !c2 || !c3 || !c4) return null;
     return [c1,c2,c3,c4];
 }
@@ -719,8 +719,8 @@ export function getFoV(pv, alternateZoomFactor) {
         return 360;
     }
     else { // not allsky image, but computation is outside of projection, use an alternate approach
-        const ip1=  cc.getWorldCoords(makeImagePt(0, 0));
-        const ip2=  cc.getWorldCoords(makeImagePt(plot.dataWidth, 0));
+        const ip1=  cc.getWorldCoords(makeImagePt(0+xy0Fitsll, 0+xy0Fitsll));
+        const ip2=  cc.getWorldCoords(makeImagePt(plot.dataWidth+xy0Fitsll, 0+xy0Fitsll));
         const idist= (ip1 && ip2) && computeDistance(ip1, ip2);
         if (!idist) return false;
         return (pv.viewDim.width/plot.screenSize.width) * idist;

--- a/src/firefly/js/visualize/Point.js
+++ b/src/firefly/js/visualize/Point.js
@@ -14,7 +14,8 @@ const OFFSET_PT= 'OffsetPt';
 
 const Point = {  SPT, IM_PT, IM_WS_PT, DEV_PT, PROJ_PT, W_PT, OFFSET_PT};
 
-
+export const xy0Fits = 1;
+export const xy0Fitsll = xy0Fits-0.5;
 
 /**
  * @typedef {Object} Point

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -16,7 +16,7 @@ import {CCUtil, CysConverter} from './CsysConverter.js';
 import DrawOp from './draw/DrawOp.js';
 import {primePlot} from './PlotViewUtil.js';
 import {doConv} from '../astro/conv/CoordConv.js';
-import Point, {makeImageWorkSpacePt, makeImagePt, makeScreenPt,
+import Point, {xy0Fitsll, makeImageWorkSpacePt, makeImagePt, makeScreenPt,
                makeWorldPt, makeDevicePt, isValidPoint, pointEquals} from './Point.js';
 import {Matrix} from 'transformation-matrix-js';
 import {getPixScaleDeg, getFluxUnits} from './WebPlot.js';
@@ -385,8 +385,8 @@ export const getRotationAngle= function(plot) {
     const ix = iWidth / 2;
     const iy = iHeight / 2;
     const cc= CysConverter.make(plot);
-    const wptC = cc.getWorldCoords(makeImageWorkSpacePt(ix, iy));
-    const wpt2 = cc.getWorldCoords(makeImageWorkSpacePt(ix, iy+iHeight/4));
+    const wptC = cc.getWorldCoords(makeImageWorkSpacePt(ix+xy0Fitsll, iy+xy0Fitsll));
+    const wpt2 = cc.getWorldCoords(makeImageWorkSpacePt(ix+xy0Fitsll, iy+xy0Fitsll+iHeight/4));
     if (wptC && wpt2) {
         retval = getPositionAngle(wptC.getLon(), wptC.getLat(), wpt2.getLon(), wpt2.getLat());
     }
@@ -712,7 +712,7 @@ function getSelectedPtsFromRect(selection, plot, objList) {
  */
 export function getCenterPtOfPlot(plot) {
     if (!plot) return null;
-    const ip= makeImagePt(plot.dataWidth/2,plot.dataHeight/2);
+    const ip= makeImagePt(plot.dataWidth/2+xy0Fitsll,plot.dataHeight/2+xy0Fitsll);
     return CCUtil.getWorldCoords(plot,ip);
 }
 
@@ -906,10 +906,10 @@ export function getTopmostVisiblePoint(pv,xOff, yOff) {
     const {viewDim} = pv;
 
     const lineSegs= [
-       {pt1: cc.getDeviceCoords(makeImagePt(0,0)), pt2: cc.getDeviceCoords(makeImagePt(dataWidth,0))},
-       {pt1: cc.getDeviceCoords(makeImagePt(dataWidth,0)), pt2: cc.getDeviceCoords(makeImagePt(dataWidth,dataHeight))},
-       {pt1: cc.getDeviceCoords(makeImagePt(dataWidth,dataHeight)), pt2: cc.getDeviceCoords(makeImagePt(0,dataHeight))},
-       {pt1: cc.getDeviceCoords(makeImagePt(0,dataHeight)), pt2: cc.getDeviceCoords(makeImagePt(0,0))}
+       {pt1: cc.getDeviceCoords(makeImagePt(0+xy0Fitsll,0+xy0Fitsll)), pt2: cc.getDeviceCoords(makeImagePt(dataWidth+xy0Fitsll,0+xy0Fitsll))},
+       {pt1: cc.getDeviceCoords(makeImagePt(dataWidth+xy0Fitsll,0+xy0Fitsll)), pt2: cc.getDeviceCoords(makeImagePt(dataWidth+xy0Fitsll,dataHeight+xy0Fitsll))},
+       {pt1: cc.getDeviceCoords(makeImagePt(dataWidth+xy0Fitsll,dataHeight+xy0Fitsll)), pt2: cc.getDeviceCoords(makeImagePt(0+xy0Fitsll,dataHeight+xy0Fitsll))},
+       {pt1: cc.getDeviceCoords(makeImagePt(0+xy0Fitsll,dataHeight+xy0Fitsll)), pt2: cc.getDeviceCoords(makeImagePt(0+xy0Fitsll,0+xy0Fitsll))}
     ];
 
     const foundSegs= lineSegs

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -11,7 +11,7 @@ import CoordinateSys from './CoordSys.js';
 import {makeProjection} from './projection/Projection.js';
 import PlotState from './PlotState.js';
 import BandState from './BandState.js';
-import {makeWorldPt, makeScreenPt} from './Point.js';
+import {makeWorldPt, makeScreenPt, xy0Fitsll} from './Point.js';
 import {changeProjectionCenter} from './HiPSUtil.js';
 import {CysConverter} from './CsysConverter.js';
 import {makeImagePt} from './Point';

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -32,7 +32,7 @@ import {primePlot,
 import {makeImagePt, makeWorldPt, makeDevicePt} from '../Point.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import {RotateType} from '../PlotState.js';
-import Point from '../Point.js';
+import Point, {xy0Fitsll} from '../Point.js';
 import {updateTransform} from '../PlotTransformUtils.js';
 import {WebPlotRequest} from '../WebPlotRequest.js';
 
@@ -196,7 +196,7 @@ function zoomStart(state, action) {
 
     // update zoom factor and scroll position
     const centerImagePt= isFitFill(userZoomType) ?
-                          makeImagePt(plot.dataWidth/2, plot.dataHeight/2) :
+                          makeImagePt(plot.dataWidth/2 + xy0Fitsll, plot.dataHeight/2 + xy0Fitsll) :
                           findCurrentCenterPoint(pv);
 
     pv= replacePrimaryPlot(pv,clonePlotWithZoom(plot,zoomLevel));
@@ -499,7 +499,7 @@ function updateViewSize(state,action) {
 
         if (plot) {
             centerImagePt= (pv.scrollX===-1 && pv.scrollY===-1) ?
-                makeImagePt(plot.dataWidth/2, plot.dataHeight/2) :
+                makeImagePt(plot.dataWidth/2 + xy0Fitsll, plot.dataHeight/2 + xy0Fitsll) :
                 findCurrentCenterPoint(pv);
         }
         const w= isUndefined(width) ? pv.viewDim.width : width;
@@ -511,7 +511,7 @@ function updateViewSize(state,action) {
         pv= updateTransform(pv);
 
         if (isHiPS(plot)) {
-            centerImagePt= makeImagePt( plot.dataWidth/2, plot.dataHeight/2);
+            centerImagePt= makeImagePt( plot.dataWidth/2 + xy0Fitsll, plot.dataHeight/2 + xy0Fitsll);
             pv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt));
         }
         else if (state.wcsMatchType===WcsMatchType.Standard && state.mpwWcsPrimId!==plotId) {
@@ -585,7 +585,7 @@ function recenterPv(centerPt,  centerOnImage) {
                 centerImagePt = CCUtil.getImageCoords(plot, wp);
             }
             else {
-                centerImagePt = makeImagePt(plot.dataWidth / 2, plot.dataHeight / 2);
+                centerImagePt = makeImagePt(plot.dataWidth / 2 + xy0Fitsll, plot.dataHeight / 2 + xy0Fitsll);
             }
         }
 

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -13,7 +13,7 @@ import {PlotAttribute} from '../WebPlot.js';
 import {CCUtil} from '../CsysConverter.js';
 import {getRotationAngle} from '../VisUtil.js';
 import {updateTransform} from '../PlotTransformUtils.js';
-import {makeImagePt} from '../Point.js';
+import {makeImagePt, xy0Fitsll} from '../Point.js';
 import {clone} from '../../util/WebUtil.js';
 
 
@@ -136,7 +136,7 @@ function addHiPS(state,action, setActive= true, newPlot= true) {
         pv.flipX= false;
 
         if (pv.viewDim) {
-            const centerImagePt= makeImagePt( plot.dataWidth/2, plot.dataHeight/2);
+            const centerImagePt= makeImagePt( plot.dataWidth/2 + xy0Fitsll, plot.dataHeight/2 + xy0Fitsll);
             pv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt));
         }
         return pv;

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -12,7 +12,7 @@ import {WebPlot,PlotAttribute, RDConst, isImage} from '../WebPlot.js';
 import CsysConverter from '../CsysConverter.js';
 import VisUtils from '../VisUtil.js';
 import {PlotState} from '../PlotState.js';
-import Point, {makeImagePt} from '../Point.js';
+import Point, {makeImagePt, xy0Fitsll} from '../Point.js';
 import {WPConst, DEFAULT_THUMBNAIL_SIZE} from '../WebPlotRequest.js';
 import {Band} from '../Band.js';
 import {PlotPref} from '../PlotPref.js';
@@ -428,10 +428,10 @@ function updateActiveTarget(plot) {
         const w= plot.dataWidth;
         const h= plot.dataHeight;
         const cc= CsysConverter.make(plot);
-        const pt1= cc.getWorldCoords(makeImagePt(0, 0));
-        const pt2= cc.getWorldCoords(makeImagePt(w, 0));
-        const pt3= cc.getWorldCoords(makeImagePt(w,h));
-        const pt4= cc.getWorldCoords(makeImagePt(0, h));
+        const pt1= cc.getWorldCoords(makeImagePt(0+xy0Fitsll, 0+xy0Fitsll));
+        const pt2= cc.getWorldCoords(makeImagePt(w+xy0Fitsll, 0+xy0Fitsll));
+        const pt3= cc.getWorldCoords(makeImagePt(w+xy0Fitsll, h+xy0Fitsll));
+        const pt4= cc.getWorldCoords(makeImagePt(0+xy0Fitsll, h+xy0Fitsll));
         if (pt1 && pt2 && pt3 && pt4) {
             corners= [pt1,pt2,pt3,pt4];
         }


### PR DESCRIPTION
This development fixes the image pixel coordinate per FITS convention and using WCSA,  i.e. the center of the lower-left pixel is (1, 1).   The updates include, 
- the coordinate conversion between image point and world point, image point and screen pixel. 
- the coordinate range of image pixel starting from [0.5, 0.5], (i.e. the lower-left corner of pixel xy0) and the center coordinate of image pixels. 
- adjustment on image coordinates for image crop request sent to the server

test: 
do image search, 
- check the image coordinate at the edge
- crop the image and check the image pixel coordinate starting from 0.5, 0.5
- upload a region file with content like the following for image case, target: m45, wise allwise w1, and check the image pixel of the regions, 
  
   image;polygon 119 25 140 195 120 150 #color=cyan
   image;circle 196 182 2i # color=orange 
