### PR TITLE
dm-14758 fixed text display error for region text

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
@@ -191,9 +191,10 @@ public class RegionFactory {
                             coordStr= st.nextToken();
                             String textPart= st.nextToken();
                             String end=  (textStart.equals("{")) ? "}" : textStart;
-                            int endIdx= textPart.indexOf(end);
+                            int sIdx = textInput.indexOf(textStart);
+                            int endIdx= textInput.indexOf(end, sIdx+1);
                             if (endIdx>-1) {
-                                String textString= textPart.substring(0,endIdx);
+                                String textString= textInput.substring(sIdx+1,endIdx);
                                 ops.setText(textString);
                             }
                         }

--- a/src/firefly/js/visualize/region/RegionFactory.js
+++ b/src/firefly/js/visualize/region/RegionFactory.js
@@ -417,7 +417,7 @@ export class RegionFactory {
                     return prev;
                 }, []);
             } else {
-                pAry = desWithnoText.split(/\s+/);   // blank string is ignored
+                pAry = desWithnoText.trim().split(/\s+/);   // blank string is ignored
             }
 
             if (textRes.text) {
@@ -428,7 +428,7 @@ export class RegionFactory {
 
 
         if ( rIdx >= 0 && lIdx >= 0 && rIdx > lIdx ) {    // with ()
-            newdes = regionDes.slice(0, rIdx).replace('(', ' ').trim();
+            newdes = regionDes.slice(0, rIdx).replace('(', ' ').trim() + regionDes.slice(rIdx+1);
             return getParams(newdes);
         } else if (rIdx < 0 && lIdx < 0) {               // with no ()
             return getParams(regionDes);


### PR DESCRIPTION
Per ds9 documentation, the 'text' region could be defined like

text x y {Your Text Here}
text x y # text={Your Text Here}
text (x,y) {Your Text Here}
text (x y) {Your Text Here}
text string may be quoted with " or ' or {}. 

this development fixes parsing error for text defined with region description (before '#'), like
`image;text 100 200 "My label"`
this fixing is made on both javascript & java sides. 

test (javascript side): 
start demo/ffapi-footprint-test.html
add  the region description into the region editing area like, 

'image;text 700 700 "My text"' 
 
and click 'Create Footprint Layer'

test (server side):
start a image search, 
upload a region file containing region description like 
`'image;text 200 200 "My text"`

