### PR TITLE
DM-14673 Label for marker disappears when it is moved to the edge and footprint translation is out of shape on HiPS

### DIFF
--- a/src/firefly/js/drawingLayers/FootprintTool.js
+++ b/src/firefly/js/drawingLayers/FootprintTool.js
@@ -462,16 +462,18 @@ function createFootprintObjs(action, dl, plotId, wpt, prevRet) {
      var footprintObj;
 
      if (footprintStatus === FootprintStatus.attached ||
-         footprintStatus === FootprintStatus.attached_relocate) {  // position is relocated after the layer is attached
+         footprintStatus === FootprintStatus.attached_relocate) {
          footprintObj = makeFootprint(regions, wpt, isHandle, cc, text, textLoc);
+
+         // position is relocated after the layer is attached by the click
          if (footprintStatus === FootprintStatus.attached_relocate) {
              footprintObj = translateForRelocate(footprintObj,  move, cc);
+             wpt = get(footprintObj, ['pts', '0']);
          }
 
      } else if (crtFpObj) {
          if ((footprintStatus === FootprintStatus.rotate || footprintStatus === FootprintStatus.relocate) && !isEmpty(move)) {
              var {apt} = move;    // move to relocate or rotate
-
 
              if (apt) {      // translate
                  footprintObj = updateFootprintTranslate(crtFpObj, cc, apt);
@@ -559,7 +561,7 @@ function resetRotateSide(footprintObj) {
 }
 
 /**
- * add the footprint drawing objects into the new plot reated after the drawing layer is created
+ * add the footprint drawing objects into the new plot after the drawing layer is created
  * @param drawLayer
  * @param newPlotId new plot
  * @returns {*}
@@ -584,7 +586,7 @@ function attachToNewPlot(drawLayer, newPlotId) {
 
     if (!isEmpty(translation)) {
         footprintObj = updateFootprintTranslate(footprintObj, cc, translation);
-        footprintObj= updateFootprintOutline(footprintObj, cc);
+        //footprintObj= updateFootprintOutline(footprintObj, cc);
         resetRotateSide(footprintObj);
         wpt = get(footprintObj, ['pts', '0']);
     }

--- a/src/firefly/js/drawingLayers/MarkerTool.js
+++ b/src/firefly/js/drawingLayers/MarkerTool.js
@@ -15,7 +15,7 @@ import {getWorldOrImage, makeMarker, findClosestIndex,  updateFootprintTranslate
         updateFootprintDrawobjText, updateFootprintOutline,  lengthSizeUnit,
         MARKER_DISTANCE, OutlineType, MarkerType, ROTATE_BOX} from '../visualize/draw/MarkerFootprintObj.js';
 import {getMarkerToolUIComponent} from './MarkerToolUI.jsx';
-import {getDrawobjArea, isPointInView} from '../visualize/draw/ShapeHighlight.js';
+import {getDrawobjArea} from '../visualize/draw/ShapeHighlight.js';
 import ShapeDataObj, {lengthToScreenPixel, lengthToArcsec} from '../visualize/draw/ShapeDataObj.js';
 import {makeDevicePt, makeImagePt} from '../visualize/Point.js';
 import {clone} from '../util/WebUtil.js';
@@ -46,7 +46,7 @@ export var initMarkerPos = (plot, cc) => {
 
     if (!cc) cc = CsysConverter.make(plot);
 
-    if (!pos || !isPointInView(getWorldOrImage(pos, cc), cc)) {
+    if (!pos || !cc.pointInView(getWorldOrImage(pos, cc))) {
         pos = makeDevicePt(cc.viewDim.width / 2, cc.viewDim.height / 2);
     }
     return getWorldOrImage(pos, cc);
@@ -130,7 +130,7 @@ export function markerToolStartActionCreator(rawAction) {
             refPt = imagePt;                   // refPt is used as the reference point for next relocation
         }
 
-        if (nextStatus && isPointInView(refPt, cc)) {
+        if (nextStatus && cc.pointInView(refPt)) {
             showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_START, plotId, nextStatus, markerInterval,
                                drawLayerId, {isOutline: true, isResize:true}, wpt, evenSize(currentSize), refPt, move);
         }
@@ -181,7 +181,7 @@ export function markerToolMoveActionCreator(rawAction) {
         cancelTimeoutProcess(timeoutProcess);
 
         if (markerStatus === MarkerStatus.resize)  {               // mmarker stay at current point, and change size
-            if (!isPointInView(getWorldOrImage(imagePt, cc), cc)) return;               // resize stops
+            if (!cc.pointInView(getWorldOrImage(imagePt, cc))) return;               // resize stops
 
             var imgUnit = ShapeDataObj.UnitType.IMAGE_PIXEL;
 
@@ -202,7 +202,7 @@ export function markerToolMoveActionCreator(rawAction) {
                 dy = imagePt.y - prePt.y;
                 wpt = getWorldOrImage(makeImagePt(imageCenter.x + dx, imageCenter.y + dy), cc);
 
-                if (!isPointInView(wpt, cc)) {  // HiPS plot, wpt is out of range, no move
+                if (!cc.pointInView(wpt)) {  // HiPS plot, wpt is out of range, no move
                     //if (isHiPS(cc)) rotateHiPSImage(cc, imageCenter, null, dx, dy);
                     dx = 0;
                     dy = 0;
@@ -221,7 +221,7 @@ export function markerToolMoveActionCreator(rawAction) {
         }
 
         // resize (newDize) or relocate (wpt),  status remains the same
-        if (!isEmpty(move) && isPointInView(refPt, cc)) {
+        if (!isEmpty(move) && cc.pointInView(refPt)) {
             showMarkersByTimer(dispatcher, DrawLayerCntlr.MARKER_MOVE, plotId,
                 markerStatus, 0, drawLayerId, isHandle, wpt, newSize, refPt, move);
         }

--- a/src/firefly/js/drawingLayers/MarkerTool.js
+++ b/src/firefly/js/drawingLayers/MarkerTool.js
@@ -518,11 +518,13 @@ function createMarkerObjs(action, dl, plotId, wpt, size, prevRet) {
     var markObj;
 
     if (markerStatus === MarkerStatus.attached ||
-        markerStatus === MarkerStatus.attached_relocate) {  // position is reloacated after the layer is attached
-
+        markerStatus === MarkerStatus.attached_relocate) {
         markObj = makeMarker(wpt, markerW, markerH, isHandle, cc, text, textLoc, unitT);
+
+        // position is relocated after the layer is attached by the click
         if (markerStatus === MarkerStatus.attached_relocate) {
             markObj = translateForRelocate(markObj,  move, cc);
+            wpt = get(markObj, ['pts', '0']);
         }
     } else if (crtMarkerObj) {
         if ((markerStatus === MarkerStatus.resize || markerStatus === MarkerStatus.relocate) && !isEmpty(move)) {
@@ -674,7 +676,7 @@ function attachToNewPlot(drawLayer, newPlotId) {
 
     if (!isEmpty(translation)) {
         markerObj = updateFootprintTranslate(markerObj, cc, translation);
-        markerObj = updateFootprintOutline(markerObj, cc);
+        //markerObj = updateFootprintOutline(markerObj, cc);
         wpt = get(markerObj, ['pts', '0']);
     }
 

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -8,7 +8,7 @@ import {makeRoughGuesser} from './ImageBoundsData.js';
 import Point, {makeImageWorkSpacePt, makeImagePt,
                makeScreenPt, makeWorldPt, makeDevicePt, isValidPoint} from './Point.js';
 import {Matrix} from 'transformation-matrix-js';
-import {getPixScaleDeg} from './WebPlot.js';
+import {getPixScaleDeg, isHiPS} from './WebPlot.js';
 import {makeFitsImagePt, makeZeroBasedImagePt} from './Point';
 
 
@@ -178,6 +178,23 @@ export class CysConverter {
         return retval;
     }
 
+    /* check if the point within display range for either regular image or hips */
+    pointInView(pt) {
+        if (!pt) return false;
+        if (isHiPS(this)) {
+            const inViewDim = (pt) => {
+                const devPt = this.getDeviceCoords(pt);
+
+                return (devPt) && (devPt.x >= 0 && devPt.x < this.viewDim.width) &&
+                    (devPt.y >= 0 && devPt.y < this.viewDim.height);
+            };
+
+            return inViewDim(pt);
+        } else {
+            return this.pointInData(pt);
+        }
+
+    };
 
 //========================================================================================
 //----------------------------- End pointIn Methods  -------------------------------------

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -719,6 +719,8 @@ export function drawText(drawObj, ctx, plot, inPt, drawParams) {
         );
 
         drawObj.textWorldLoc = plot.getImageCoords(makeDevicePt(x, y));
+    } else {
+        drawObj.pointNotInDisplay = true;  // note on failure
     }
 }
 
@@ -1221,7 +1223,7 @@ export function makeTextLocationComposite(cc, textLoc, fontSize, width, height, 
     const h = height/2 + lineWidth + 2;   // leave space for highlight box
     const scrCenterPt = cc.getScreenCoords(centerPt);
 
-    if (!scrCenterPt || width < 1 || height < 1) return null;
+    if (!scrCenterPt || width <= 0 || height <= 0) return null;
 
     let opt;
     const offy = fontHeight(fontSize);

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -646,9 +646,10 @@ function drawCircle(drawObj, ctx,  plot, drawParams) {
  * @param plot
  * @param inPt
  * @param drawParams
+ * @return {boolean} text is drawn or not
  */
 export function drawText(drawObj, ctx, plot, inPt, drawParams) {
-    if (!inPt) return;
+    if (!inPt) return false;
     
     const {text, textOffset, renderOptions, rotationAngle, textBaseline= 'top', textAlign='start'}= drawObj;
     //the angle of the grid line
@@ -674,54 +675,54 @@ export function drawText(drawObj, ctx, plot, inPt, drawParams) {
     const color = drawParams.color || drawObj.color || 'black';
 
     const devicePt= plot.getDeviceCoords(inPt);
-    if (plot.pointOnDisplay(devicePt)) {
-
-        let {x,y}= devicePt;
-
-        let textHeight= 12;
-        if (validator.isFloat(fontSize.substring(0, fontSize.length - 2))) {
-            textHeight = parseFloat(fontSize.substring(0, fontSize.length - 2)) * 14 / 10;
-        }
-
-
-        const textWidth = textHeight*text.length*8/20;
-        if (textOffset) {
-            x+=textOffset.x;
-            y+=textOffset.y;
-        }
-
-
-        if (x<2) {
-            if (x<=-textWidth) return; // don't draw
-            x = 2;
-        }
-        if (y<2) {
-            if (y<=-textHeight) return; // don't draw
-            y = 2;
-        }
-
-        const dim= plot.viewDim;
-        const south = dim.height - textHeight - 2;
-        const east = dim.width - textWidth - 2;
-
-        if (x > east) {
-            if (x>dim.width) return; // don't draw
-            x = east;
-        }
-        if (y > south) {
-            if (y>dim.height) return; // don't draw
-            y = south;
-        }
-
-        DrawUtil.drawTextCanvas(ctx, text, x, y, color, renderOptions,
-            {rotationAngle:angle, textBaseline, textAlign},
-            {fontName:fontName+FONT_FALLBACK, fontSize, fontWeight, fontStyle}
-        );
-
-        drawObj.textWorldLoc = plot.getImageCoords(makeDevicePt(x, y));
-    } else {
-        drawObj.pointNotInDisplay = true;  // note on failure
+    if (!plot.pointOnDisplay(devicePt)) {
+        return false;
     }
+
+    let {x,y}= devicePt;
+
+    let textHeight= 12;
+    if (validator.isFloat(fontSize.substring(0, fontSize.length - 2))) {
+        textHeight = parseFloat(fontSize.substring(0, fontSize.length - 2)) * 14 / 10;
+    }
+
+
+    const textWidth = textHeight*text.length*8/20;
+    if (textOffset) {
+        x+=textOffset.x;
+        y+=textOffset.y;
+    }
+
+
+    if (x<2) {
+        if (x<=-textWidth) return false; // don't draw
+        x = 2;
+    }
+    if (y<2) {
+        if (y<=-textHeight) return false; // don't draw
+        y = 2;
+    }
+
+    const dim= plot.viewDim;
+    const south = dim.height - textHeight - 2;
+    const east = dim.width - textWidth - 2;
+
+    if (x > east) {
+        if (x>dim.width) return false; // don't draw
+        x = east;
+    }
+    if (y > south) {
+        if (y>dim.height) return false; // don't draw
+        y = south;
+    }
+
+    DrawUtil.drawTextCanvas(ctx, text, x, y, color, renderOptions,
+        {rotationAngle:angle, textBaseline, textAlign},
+        {fontName:fontName+FONT_FALLBACK, fontSize, fontWeight, fontStyle}
+    );
+
+    drawObj.textWorldLoc = plot.getImageCoords(makeDevicePt(x, y));
+    return true;
 }
 
 /**

--- a/src/firefly/js/visualize/draw/ShapeHighlight.js
+++ b/src/firefly/js/visualize/draw/ShapeHighlight.js
@@ -14,6 +14,7 @@ import {isHiPS} from '../WebPlot.js';
 const doAry = 'drawObjAry';
 export const defaultDashline = [8, 5, 2, 5];
 
+/*
 export const isPointInView = (pt, cc) => {
     if (!pt) return false;
     if (isHiPS(cc)) {
@@ -28,9 +29,8 @@ export const isPointInView = (pt, cc) => {
     } else {
         return cc.pointInData(pt);
     }
-
 };
-
+*/
 // in image coordinate or screen coordinate
 var areaObj = (min_x, max_x, min_y, max_y, unit = ShapeDataObj.UnitType.IMAGE_PIXEL) => {
     var c_x = (min_x + max_x) / 2;
@@ -111,7 +111,7 @@ export function isDrawobjAreaInView(cc, drawObj = null, coverArea = null, def={}
         const y = center.y + c[1] * height / 2;
         const cornerP = Object.assign(new SimplePt(x, y), {type: center.type});
 
-        return !isPointInView(cornerP, cc);
+        return !cc.pointInView(cornerP);
     });
 
     return !cornerNotInView;


### PR DESCRIPTION
This development fixes the following issues, 
- when the marker/footprint is moved towards the edge of the display area, the label for the marker/footprint disappears.
   fixing: showing the label when the marker/footprint is moved out of plot area and showing the label in alternate corner location in case the label is being moved out of plot area. 
- when the marker/footprint is relocated farther from the center or the target of the HiPS, the footprint  is shown out of shape as the image is zoomed. 
  fixing: instead of translating each region component on image domain as regular image, each component is re-rendered in world coordinate after relocating the footprint center first per original region description. 

test:
start image search 
add a marker or footprint overlay
move the marker/footprint to anywhere close to the plot border and view the text display

start HiPS search (no FOV entered)
add a footprint overlay
click (relocate) at a point close to the curved border of the HiPS
zoom the image to see more detail of the footprint by zooming and rotating the HIPS 

