### PR TITLE
DM-14779: make last Git commit ID available in Firefly build

### DIFF
--- a/buildScript/depends.gincl
+++ b/buildScript/depends.gincl
@@ -312,7 +312,6 @@ task dockerPublish (dependsOn: dockerImage) {
  */
 ext.NODE = { ...cmd ->
   def wpBuildDir = "${buildDir}/war"
-  def tag = "v" + getVersionTag() + ' Built On:' + build_time;
 
   try {
     def process = "yarn version".execute()
@@ -329,10 +328,12 @@ ext.NODE = { ...cmd ->
     }
   }
 
+  def versionInfo = new Properties()
+  file("${project.buildDir}/version.tag").withInputStream { versionInfo.load(it) }
+
   // any environment starting with '__$' will be defined as global.
   // this is a way send config info to JS code.
   def res = exec {
-    environment '__$version_tag': tag
     environment 'WP_BUILD_DIR': wpBuildDir
     environment 'NODE_ENV': (project.env == 'local' ? 'development' : 'production')
     environment 'BUILD_ENV': project.env
@@ -343,7 +344,11 @@ ext.NODE = { ...cmd ->
         println ">>   " + key + " = " + project.appConfigProps[key]
       }
     }
-
+    // load version info as JS global
+    for (String key : versionInfo.keySet()) {
+      environment ('__$version.'+key, versionInfo[key])
+      println ">>   " + '__$version.'+key + " = " + versionInfo[key]
+    }
   }
   return res;
 }

--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -121,6 +121,9 @@ task prepareWebapp (type:Copy, dependsOn: [gwt, loadConfig, createVersionTag]) {
   // should rerun this everytime.  properties could be modified from external files.
   outputs.upToDateWhen { false }
 
+  from("${buildDir}/version.tag") {
+    into 'WEB-INF/config'
+  }
   from("$rootDir/config/") {
     include '*.prop', '*.xml', 'ignore_sizeof.txt', '*.properties'
     into 'WEB-INF/config'
@@ -292,13 +295,13 @@ task buildAndPublish( dependsOn: war ) {
 }
 
 
-def getVersionLabel() {
+def getReleaseTitle() {
   def major = appConfigProps.get('BuildMajor')
   def minor = appConfigProps.get('BuildMinor')
   def rev = appConfigProps.get('BuildRev')
   def type = appConfigProps.get('BuildType')
 
-  def prefix = project.hasProperty("tag_prefix") ? "${tag_prefix} " : ""
+  def prefix = project.hasProperty("rel_prefix") ? "${rel_prefix} " : ""
   def label = prefix + "v${major}.${minor}.${rev} ${type}"
   return label;
 }
@@ -310,8 +313,8 @@ task publishToGithub (dependsOn: loadConfig) {
   outputs.upToDateWhen { false }
 
   doLast {
-    def tag_label = project.ext.createTagLabel();
-    def rel_title = getVersionLabel();
+    def tag = project.ext.getVersionInfo('BuildTag');
+    def rel_title = getReleaseTitle();
 
     try {
       def process = "node -v".execute()
@@ -328,7 +331,7 @@ task publishToGithub (dependsOn: loadConfig) {
                     |  "assets": ["%s", "%s"]
                     |}
                     """.stripMargin(),
-                    tag_label,
+                    tag,
                     project.property("github.auth.token"),
                     rel_title,
                     "${buildDir}/exec/${webapp.baseWarName}-exec.war", "${buildDir}/exec/${webapp.baseWarName}.war")

--- a/buildScript/init.gincl
+++ b/buildScript/init.gincl
@@ -56,23 +56,45 @@ task createVersionTag  {
 
   doLast {
     // generate version tag
-    def tag = getVersionTag()
-    def props = new Properties();
+    def major = appConfigProps.get('BuildMajor')
+    def minor = appConfigProps.get('BuildMinor')
+    def rev = appConfigProps.get('BuildRev')
+    def type = appConfigProps.get('BuildType')
+    def buildNum = appConfigProps.get('BuildNumber')
+    def tag = "${project.ext['app-name']}_$major.$minor.${rev}_${type}-$buildNum"
+
+    def props = new Properties()
     file(project.buildDir).mkdirs()
-    props.setProperty('tag', tag)
+    props.setProperty('BuildMajor', major)
+    props.setProperty('BuildMinor', minor)
+    props.setProperty('BuildRev', rev)
+    props.setProperty('BuildType', type)
+    props.setProperty('BuildNumber', buildNum)
+    props.setProperty('BuildDate', build_date)
+    props.setProperty('BuildTime', build_time)
+    props.setProperty('BuildTag', tag)
+    props.setProperty('BuildCommit', getCommitHash())
+
+    if (fireflyPath != rootDir.getPath()) {
+      props.setProperty('BuildCommitFirefly', getCommitHash(fireflyPath))
+    }
+
     props.store(file("${project.buildDir}/version.tag").newWriter(), "Version Info")
   }
 }
 
-ext.getVersionTag = { ->
-  // generate version tag
-  def major = appConfigProps.get('BuildMajor')
-  def minor = appConfigProps.get('BuildMinor')
-  def rev = appConfigProps.get('BuildRev')
-  def type = appConfigProps.get('BuildType')
-  def buildNum = appConfigProps.get('BuildNumber')
-
-  return "$major.$minor.${rev}_${type}-$buildNum"
+ext.getCommitHash = { workDir="." ->
+  try {
+    def hashOut = new ByteArrayOutputStream()
+    exec {
+      commandLine "git", "rev-parse", "--short", "HEAD"
+      workingDir = workDir
+      standardOutput = hashOut
+    }
+    return hashOut.toString().trim();
+  } catch (Exception e) {
+    return 'n/a'
+  }
 }
 
 task createTag(dependsOn: loadConfig) {
@@ -80,14 +102,14 @@ task createTag(dependsOn: loadConfig) {
   group = MISC_GROUP
 
   doLast {
-    def tag_label = project.ext.createTagLabel();
-    println "tag: $tag_label"
+    def tag = project.ext.getVersionInfo('BuildTag');
+    println "tag: $tag"
 
     exec {
       executable 'git'
       args 'tag'
       args '-a'
-      args tag_label
+      args tag
       args '-m'
       if (project.hasProperty("tag_message")) {
         args tag_message
@@ -104,7 +126,7 @@ task createTag(dependsOn: loadConfig) {
       } else {
         args 'origin'
       }
-      args tag_label
+      args tag
     }
   }
 }
@@ -162,20 +184,14 @@ class ConfigRepo {
 
 }
 
-ext.createTagLabel = {  ->
-  if (!project.hasProperty("tag_name")) {
-    if (!project.hasProperty("tag_file")) {
-      project.ext.tag_file = "${project.buildDir}/version.tag"
-    }
-    Properties props = new Properties()
-    props.load(new File(tag_file).newDataInputStream())
-    project.ext.tag_name = props.getProperty('tag')
+ext.getVersionInfo = { key ->
+  if (!project.hasProperty("tag_file")) {
+    project.ext.tag_file = "${project.buildDir}/version.tag"
   }
-
-  def prefix = project.hasProperty("tag_prefix") ? "${tag_prefix}_" : ""
-  def suffix = project.hasProperty("tag_suffix") ? "_${tag_suffix}" : ""
-  def tag_label = prefix + tag_name + suffix
-  return tag_label;
+  Properties props = new Properties()
+  props.load(new File(tag_file).newDataInputStream())
+  def val = props.getProperty(key)
+  return val;
 }
 
 ext.mergeDevIntoMaster = {  ->

--- a/config/common.prop
+++ b/config/common.prop
@@ -4,7 +4,11 @@ BuildMinor=@BuildMinor@
 BuildRev=@BuildRev@
 BuildType=@BuildType@
 BuildNumber=@BuildNumber@
-BuildDate=@build_time@
+BuildDate=@build_Date@
+BuildTime=@build_time@
+BuildTag=@BuildTag@
+BuildCommit=@BuildCommit@
+BuildCommitFirefly=@BuildCommitFirefly@
 
 
 #==========================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
@@ -18,8 +18,6 @@ import java.io.Serializable;
  * @author Trey Roby
  */
 public class Version implements Serializable {
-    private final static String SPLIT_TOKEN= "--Version--";
-
     public enum VersionType {Final, Development,
                              Alpha, Beta, RC, Unknown}
 
@@ -30,6 +28,10 @@ public class Version implements Serializable {
     private VersionType _vType= VersionType.Unknown;
     private int         _build = 0;
     private String      _buildDate= "Don't Know";
+    private String      _buildTime= "Don't Know";
+    private String      _buildTag= "";
+    private String      _buildCommit= "";
+    private String      _buildCommitFirefly= "";
     private long        _configLastModTime = 0;
 
 //======================================================================
@@ -37,7 +39,6 @@ public class Version implements Serializable {
 //======================================================================
 
     public Version() {  }
-
 
 //======================================================================
 //----------------------- Public Methods -------------------------------
@@ -51,14 +52,43 @@ public class Version implements Serializable {
     public void setVersionType(VersionType vt) { _vType= vt; }
     public void setBuildDate(String date) { _buildDate= date;}
     public void setRev(int rev) { _rev = rev;  }
-
     /**
      * The build number is only use if type is not final.  Finals should not have a build number
      * @param build build number, not used with final
      */
     public void setBuild(int build) { _build = build; }
 
+    public void setBuildTime(String _buildTime) {
+        this._buildTime = _buildTime;
+    }
 
+    public void setBuildTag(String _buildTag) {
+        this._buildTag = _buildTag;
+    }
+
+    public void setBuildCommit(String _buildCommit) {
+        this._buildCommit = _buildCommit;
+    }
+
+    public void setBuildCommitFirefly(String _buildCommitFirefly) {
+        this._buildCommitFirefly = _buildCommitFirefly;
+    }
+
+    public String getBuildTime() {
+        return _buildTime;
+    }
+
+    public String getBuildTag() {
+        return _buildTag;
+    }
+
+    public String getBuildCommit() {
+        return _buildCommit;
+    }
+
+    public String getBuildCommitFirefly() {
+        return _buildCommitFirefly;
+    }
 
     public int getMajor() { return _major;}
     public int getMinor() { return _minor;}
@@ -138,18 +168,6 @@ public class Version implements Serializable {
             retval= "Unknown";
         }
         return retval;
-    }
-
-    public String serialize() {
-        return StringUtils.combine(SPLIT_TOKEN,
-                                   _appName,
-                                   _major+"",
-                                   _minor+"",
-                                   _rev+"",
-                                   _vType.toString(),
-                                   _build+"",
-                                   _buildDate,
-                                   _configLastModTime+"");
     }
 
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorFactory;
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.firefly.server.visualize.VisContext;
 import edu.caltech.ipac.util.*;
 import edu.caltech.ipac.util.cache.CacheManager;
@@ -793,6 +794,7 @@ public class ServerContext {
             System.out.println("contextInitialized...");
             ServletContext cntx = servletContextEvent.getServletContext();
             ServerContext.init(cntx.getContextPath(), cntx.getServletContextName(), cntx.getRealPath(WEBAPP_CONFIG_LOC));
+            VersionUtil.initVersion(cntx);  // can be called multiple times, only inits on the first call
             Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> DbAdapter.getAdapter().cleanup(false),
                         DbAdapter.CLEANUP_INTVL, DbAdapter.CLEANUP_INTVL, TimeUnit.MILLISECONDS);
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
@@ -31,7 +31,6 @@ public abstract class BaseHttpServlet extends HttpServlet {
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
-        VersionUtil.initVersion(config.getServletContext());  // can be called multiple times, only inits on the first call
         String allowFromValue = config.getInitParameter("AllowFrom");
         if (allowFromValue!=null) {
             allowAccess = false;        // if allowFromValue is given.. access is given based on it.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
@@ -8,6 +8,10 @@ import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.util.AppProperties;
 
 import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
 /**
  * User: roby
  * Date: May 15, 2009
@@ -20,17 +24,21 @@ import javax.servlet.ServletContext;
  */
 public class VersionUtil {
 
-    public static final String MAJOR = "BuildMajor";
-    public static final String MINOR = "BuildMinor";
-    public static final String REV = "BuildRev";
-    public static final String TYPE = "BuildType";
-    public static final String BUILD_NUMBER = "BuildNumber";
-    public static final String BUILD_DATE  ="BuildDate";
-    public static final String APP_NAME  ="AppName";
+    private static final String MAJOR = "BuildMajor";
+    private static final String MINOR = "BuildMinor";
+    private static final String REV = "BuildRev";
+    private static final String TYPE = "BuildType";
+    private static final String BUILD_NUMBER = "BuildNumber";
+    private static final String BUILD_DATE  ="BuildDate";
+    private static final String BUILD_TIME  ="BuildTime";
+    private static final String BUILD_TAG  ="BuildTag";
+    private static final String BUILD_COMMIT  ="BuildCommit";
+    private static final String BUILD_COMMIT_FIREFLY  ="BuildCommitFirefly";
+
+    private static final String VERSION_FILE = "version.tag";
 
     private static final Version _version= new Version();
-
-    public static boolean init= false;
+    private static boolean init= false;
 
     /**
      * Can be called multiple times but will only init the version on the first call.  All other
@@ -46,22 +54,26 @@ public class VersionUtil {
 
     public static void ingestVersion(ServletContext context) {
 
-        String appName= context.getInitParameter(APP_NAME);
-        String major = AppProperties.getProperty(MAJOR);
-        String minor = AppProperties.getProperty(MINOR);
-        String rev = AppProperties.getProperty(REV);
-        String type = AppProperties.getProperty(TYPE);
-        String buildNum = AppProperties.getProperty(BUILD_NUMBER);
-        String buildDate= AppProperties.getProperty(BUILD_DATE);
-
-        _version.setAppName(appName);
-        _version.setMajor(getNum(major));
-        _version.setMinor(getNum(minor));
-        _version.setRev(getNum(rev));
-        _version.setVersionType(Version.convertVersionType(type));
-        _version.setBuild(getNum(buildNum));
-        _version.setBuildDate(buildDate);
+        _version.setAppName(context.getServletContextName());
         _version.setConfigLastModTime(ServerContext.getConfigLastModTime());
+
+        File confDir = ServerContext.getWebappConfigDir();
+        Properties props = new Properties();
+        try {
+            props.load(new FileInputStream(new File(confDir, VERSION_FILE)));
+            _version.setMajor(getNum(props.getProperty(MAJOR)));
+            _version.setMinor(getNum(props.getProperty(MINOR)));
+            _version.setRev(getNum(props.getProperty(REV)));
+            _version.setVersionType(Version.convertVersionType(props.getProperty(TYPE)));
+            _version.setBuild(getNum(props.getProperty(BUILD_NUMBER)));
+            _version.setBuildDate(props.getProperty(BUILD_DATE));
+            _version.setBuildTime(props.getProperty(BUILD_TIME));
+            _version.setBuildTag(props.getProperty(BUILD_TAG));
+            _version.setBuildCommit(props.getProperty(BUILD_COMMIT));
+            _version.setBuildCommitFirefly(props.getProperty(BUILD_COMMIT_FIREFLY));
+        } catch (IOException e) {
+            // just ignore
+        }
     }
 
     public static Version getAppVersion() { return _version;  }

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -23,7 +23,7 @@ import {reduxFlux} from './core/ReduxFlux.js';
 import {wsConnect} from './core/messaging/WebSocketClient.js';
 import {ActionEventHandler} from './core/messaging/MessageHandlers.js';
 import {init} from './rpc/CoreServices.js';
-import {getProp, mergeObjectOnly} from './util/WebUtil.js';
+import {getPropsWith, mergeObjectOnly} from './util/WebUtil.js';
 import {initLostConnectionWarning} from './ui/LostConnection.jsx';
 
 export const flux = reduxFlux;
@@ -166,8 +166,12 @@ function fireflyInit(props, options={}) {
     }
 }
 
+/**
+ * returns version information in a key/value object.
+ * @returns {VersionInfo}
+ */
 export function getVersion() {
-  return getProp('version_tag', 'unknown');
+  return getPropsWith('version.');
 }
 
 

--- a/src/firefly/js/api/ApiUtil.js
+++ b/src/firefly/js/api/ApiUtil.js
@@ -25,6 +25,8 @@ export {getBoolean, toBoolean, isDebug} from '../util/WebUtil.js';
 
 export {getWsConnId, getWsChannel} from '../core/AppDataCntlr.js';
 
+export {getVersion} from '../Firefly.js';
+
 /**
  * show a debug message if debugging is enabled
  * @param {String|Error} msg any number of messages

--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -4,6 +4,21 @@
 
 
 /**
+ * Version information
+ * @typedef {Object} VersionInfo
+ * @prop {string} BuildMajor    major version number
+ * @prop {string} BuildMinor    minor version number
+ * @prop {string} BuildRev      revision version number
+ * @prop {string} BuildType     one of Final, Development, Alpha, Beta, or RC
+ * @prop {string} BuildNumber   build version number
+ * @prop {string} BuildDate     built date
+ * @prop {string} BuildTime     built date including time
+ * @prop {string} BuildTag      vcs tag string if it were tagged
+ * @prop {string} BuildCommit   vcs commit used to build this app
+ * @prop {string} BuildCommitFirefly    Firefly's vcs commit used to build this app.
+ */
+
+/**
  * Information related to searches
  * @typedef {Object} SearchInfo
  * @prop {string} [title]    main title if any.  It will appears on top.

--- a/src/firefly/js/ui/DropDownContainer.css
+++ b/src/firefly/js/ui/DropDownContainer.css
@@ -78,8 +78,6 @@
 }
 
 .DD-Version {
-    background-color: beige;
-    padding: 5px;
     user-select: text;
 }
 

--- a/src/firefly/js/ui/DropDownContainer.css
+++ b/src/firefly/js/ui/DropDownContainer.css
@@ -77,4 +77,25 @@
     src: local('Varela'), url(//themes.googleusercontent.com/static/fonts/varela/v4/maB5vWJo0EAVzvHPjBkLM-vvDin1pK8aKteLpeZ5c0A.woff) format('woff');
 }
 
+.DD-Version {
+    background-color: beige;
+    padding: 5px;
+    user-select: text;
+}
 
+.DD-Version__item {
+    display: inline-flex;
+    padding: 2px 0;
+}
+
+.DD-Version__key {
+    font-weight: bold;
+    width: 125px;
+    text-align: right;
+    margin-right: 5px;
+}
+
+.DD-Version__value {
+    white-space: nowrap;
+    margin-right: 25px;
+}

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -19,7 +19,7 @@ import {LSSTCatalogSelectViewPanel} from '../visualize/ui/LSSTCatalogSelectViewP
 import {FileUploadDropdown} from '../ui/FileUploadDropdown.jsx';
 import {WorkspaceDropdown} from '../ui/WorkspaceDropdown.jsx';
 import {getAlerts} from '../core/AppDataCntlr.js';
-import {showOptionsPopup} from '../ui/PopupUtil.jsx';
+import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 import './DropDownContainer.css';
 
@@ -134,9 +134,7 @@ DropDownContainer.defaultProps = {
 
 function VersionInfo({versionInfo={}}) {
     const {BuildMajor, BuildMinor, BuildRev, BuildType, BuildDate} = versionInfo;
-    const showFullInfo = () => {
-            showOptionsPopup({content: versionInfoFull(versionInfo), title: 'Version Information', modal: true, show: true});
-        };
+    const showFullInfo = () => showInfoPopup(versionInfoFull(versionInfo), 'Version Information');
 
     let version = `v${BuildMajor}.${BuildMinor}.${BuildRev}`;
     version += BuildType === 'Final' ? '' : `_${BuildType}`;
@@ -167,16 +165,12 @@ function versionInfoFull({BuildMajor, BuildMinor, BuildRev, BuildNumber, BuildTy
                 <div className='DD-Version__value'>{BuildTime}</div>
             </div>
             <div className='DD-Version__item'>
-                <div className='DD-Version__key'>VCS Tag</div>
-                <div className='DD-Version__value'>{BuildTag}</div>
-            </div>
-            <div className='DD-Version__item'>
-                <div className='DD-Version__key'>VCS commit</div>
+                <div className='DD-Version__key'>Git commit</div>
                 <div className='DD-Version__value'>{BuildCommit}</div>
             </div>
             { BuildCommitFirefly &&
                 <div className='DD-Version__item'>
-                    <div className='DD-Version__key'>VCS Firefly commit</div>
+                    <div className='DD-Version__key'>Git commit - Firefly</div>
                     <div className='DD-Version__value'>{BuildCommitFirefly}</div>
                 </div>
             }

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -19,6 +19,7 @@ import {LSSTCatalogSelectViewPanel} from '../visualize/ui/LSSTCatalogSelectViewP
 import {FileUploadDropdown} from '../ui/FileUploadDropdown.jsx';
 import {WorkspaceDropdown} from '../ui/WorkspaceDropdown.jsx';
 import {getAlerts} from '../core/AppDataCntlr.js';
+import {showOptionsPopup} from '../ui/PopupUtil.jsx';
 
 import './DropDownContainer.css';
 
@@ -96,6 +97,7 @@ export class DropDownContainer extends Component {
         const {footer, alerts} = this.props;
         const { visible, selected }= this.state;
         const view = dropDownMap[selected];
+        const {BuildMajor, BuildMinor, BuildRev, Build, BuildType, BuildDate, BuildCommit, BuildCommitFirefly} = getVersion() || {};
 
         if (!visible) return <div/>;
         return (
@@ -110,7 +112,7 @@ export class DropDownContainer extends Component {
                     <div id='footer' className='DD-ToolBar__footer'>
                         {footer}
                         <div className='DD-ToolBar__version'>
-                            {getVersion()}
+                            <VersionInfo versionInfo={getVersion()}/>
                         </div>
                     </div>
                 </div>
@@ -129,6 +131,59 @@ DropDownContainer.propTypes = {
 DropDownContainer.defaultProps = {
     visible: false
 };
+
+function VersionInfo({versionInfo={}}) {
+    const {BuildMajor, BuildMinor, BuildRev, BuildType, BuildDate} = versionInfo;
+    const showFullInfo = () => {
+            showOptionsPopup({content: versionInfoFull(versionInfo), title: 'Version Information', modal: true, show: true});
+        };
+
+    let version = `v${BuildMajor}.${BuildMinor}.${BuildRev}`;
+    version += BuildType === 'Final' ? '' : `_${BuildType}`;
+    const builtOn = ` Built On: ${BuildDate}`;
+    return (
+        <div onClick={showFullInfo}>{version + builtOn}</div>
+    );
+
+}
+
+function versionInfoFull({BuildMajor, BuildMinor, BuildRev, BuildNumber, BuildType, BuildTime, BuildTag, BuildCommit, BuildCommitFirefly}) {
+    return (
+        <div className='DD-Version'>
+            <div className='DD-Version__item'>
+                <div className='DD-Version__key'>Version</div>
+                <div className='DD-Version__value'>{`${BuildMajor}.${BuildMinor}.${BuildRev}`}</div>
+            </div>
+            <div className='DD-Version__item'>
+                <div className='DD-Version__key'>Type</div>
+                <div className='DD-Version__value'>{BuildType}</div>
+            </div>
+            <div className='DD-Version__item'>
+                <div className='DD-Version__key'>Build Number</div>
+                <div className='DD-Version__value'>{BuildNumber}</div>
+            </div>
+            <div className='DD-Version__item'>
+                <div className='DD-Version__key'>Built On</div>
+                <div className='DD-Version__value'>{BuildTime}</div>
+            </div>
+            <div className='DD-Version__item'>
+                <div className='DD-Version__key'>VCS Tag</div>
+                <div className='DD-Version__value'>{BuildTag}</div>
+            </div>
+            <div className='DD-Version__item'>
+                <div className='DD-Version__key'>VCS commit</div>
+                <div className='DD-Version__value'>{BuildCommit}</div>
+            </div>
+            { BuildCommitFirefly &&
+                <div className='DD-Version__item'>
+                    <div className='DD-Version__key'>VCS Firefly commit</div>
+                    <div className='DD-Version__value'>{BuildCommitFirefly}</div>
+                </div>
+            }
+        </div>
+    );
+
+}
 
 export class Alerts extends PureComponent {
 

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -39,6 +39,31 @@ export function getProp(key, def) {
     return get(GLOBAL_PROPS, [key], def);
 }
 
+/**
+ * returns an object of key:value where keyPrefix is removed from the keys.  i.e
+ * <code>
+ *      {
+ *          version_a: a_val,
+ *          version_b: b_val
+ *      }
+ *      getPropsWith('version_')  => {a: a_val, b: b_val}
+ * </code>
+ * @param keyPrefix
+ * @returns {*}
+ */
+export function getPropsWith(keyPrefix) {
+    /*global __PROPS__*/        // this is defined at build-time.
+    GLOBAL_PROPS = GLOBAL_PROPS || __PROPS__;
+    if (!GLOBAL_PROPS) return {};
+    return Object.entries(GLOBAL_PROPS)
+        .filter(([k,]) => k.startsWith(keyPrefix))
+        .reduce((rval, [k,v]) => {
+            const prop = k.substring(keyPrefix.length);
+            rval[prop] = v;
+            return rval;
+        }, {});
+}
+
 export function getModuleName() {
     return getProp('MODULE_NAME');
 }


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-14779
https://irsawebdev9.ipac.caltech.edu/dm-14779/firefly/

Add git commit info into Firefly build.

Show a detail view of the version info when the shorten version is clicked.
- click on the version info on the lower-right corner to see the details

Exposes the same information via the JS API as well as from Java server-side environment.
- In JS, open a demo page, open console.  In console, enter `> window.firefly.util.getVersion()`

Jsdoc added:
```
/**
 * Version information
 * @typedef {Object} VersionInfo
 * @prop {string} BuildMajor    major version number
 * @prop {string} BuildMinor    minor version number
 * @prop {string} BuildRev      revision version number
 * @prop {string} BuildType     one of Final, Development, Alpha, Beta, or RC
 * @prop {string} BuildNumber   build version number
 * @prop {string} BuildDate     built date
 * @prop {string} BuildTime     built date including time
 * @prop {string} BuildTag      vcs tag string if it were tagged
 * @prop {string} BuildCommit   vcs commit used to build this app
 * @prop {string} BuildCommitFirefly    Firefly's vcs commit used to build this app.
 */

```