### PR TITLE
DM-14778: fix asinh stretch

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -114,7 +114,6 @@ public class ServerParams {
     public static final String CREATE_PLOT_GROUP = "CmdCreatePlotGroup";
     public static final String ZOOM = "CmdZoom";
     public static final String STRETCH = "CmdStretch";
-    public static final String GET_BETA = "CmdGetBeta";
     public static final String REMOVE_BAND = "CmdRemoveBand";
     public static final String CHANGE_COLOR = "CmdChangeColor";
     public static final String ROTATE_NORTH = "CmdRotateNorth";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
@@ -45,7 +45,6 @@ public class ServerCommandAccess {
         _cmdMap.put(ServerParams.CREATE_PLOT_GROUP,  new VisServerCommands.GetWebPlotGroupCmd());
         _cmdMap.put(ServerParams.ZOOM,         new VisServerCommands.ZoomCmd());
         _cmdMap.put(ServerParams.STRETCH,      new VisServerCommands.StretchCmd());
-        _cmdMap.put(ServerParams.GET_BETA,     new VisServerCommands.GetBetaCmd());
         _cmdMap.put(ServerParams.REMOVE_BAND,  new VisServerCommands.RemoveBandCmd());
         _cmdMap.put(ServerParams.CHANGE_COLOR, new VisServerCommands.ChangeColor());
         _cmdMap.put(ServerParams.DELETE,       new VisServerCommands.DeletePlot());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
@@ -145,30 +145,6 @@ public class VisServerCommands {
     }
 
 
-    public static class GetBetaCmd extends ServCommand {
-
-        public String doCommand(SrvParam sp) throws IllegalArgumentException {
-
-            PlotState state= sp.getState();
-            double resultAry[]= VisServerOps.getBeta(state);
-
-            JSONObject obj= new JSONObject();
-            obj.put("success", true);
-
-            JSONArray data= new JSONArray();
-            for(double r : resultAry) data.add(r);
-
-            JSONArray wrapperAry= new JSONArray();
-            obj.put("data", data);
-            wrapperAry.add(obj);
-
-            return wrapperAry.toJSONString();
-        }
-    }
-
-
-
-
     public static class StretchCmd extends ServCommand {
 
         public String doCommand(SrvParam sp) throws IllegalArgumentException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -315,7 +315,6 @@ public class ImagePlotCreator {
 
 
     /**
-     * 5/13/16 LZ modified to add the beta in the WebFitsData calling parameter
      * @param frGroup group
      * @param band which band
      * @param f file

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -225,21 +225,6 @@ public class VisServerOps {
         return true;
     }
 
-    public static double[] getBeta(PlotState state) {
-        double[] resultsAry= new double[] {Double.NaN,Double.NaN,Double.NaN};
-        try {
-            ActiveCallCtx ctx = CtxControl.prepare(state);
-            FitsRead frAry[]= ctx.getFitsReadGroup().getFitsReadAry();
-            for(int i= 0; (i<frAry.length);i++) {
-                if (frAry[i]!=null) resultsAry[i]= frAry[i].getDefaultBeta();
-            }
-            return resultsAry;
-
-        } catch (Exception e) {
-            return resultsAry;
-        }
-    }
-
     static final boolean USE_DIRECT_FLUX_IF_POSSIBLE = true;
 
     private static boolean isDirectFluxAccessAvailable(PlotState state) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
@@ -43,9 +43,6 @@ public class HistogramOps {
 
     public FitsRead getFitsRead() { return fitsReadAry[band.getIdx()]; }
 
-    //5/13/16 LZ added this method so the beta can be passed to the client side
-    public double getBeta(){ return fitsReadAry[band.getIdx()].getDefaultBeta();}
-
     public Histogram getDataHistogram() {
         return fitsReadAry[band.getIdx()].getHistogram();
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
@@ -24,8 +24,7 @@ public class ImageDataGroup implements Iterable<ImageData> {
     private       ImageData  _imageDataAry[];
     private final int _width;
     private final int _height;
-    private double betaValue= Double.NaN;
-
+    
 
 //======================================================================
 //----------------------- Constructors ---------------------------------
@@ -47,7 +46,6 @@ public class ImageDataGroup implements Iterable<ImageData> {
         _width = fr.getNaxis1();
         _height = fr.getNaxis2();
 
-        rangeValues= ensureBetaValues(rangeValues, fitsReadAry);
 
         int totWidth= _width;
         int totHeight= _height;
@@ -124,24 +122,6 @@ public class ImageDataGroup implements Iterable<ImageData> {
 //----------------------- Public Methods -------------------------------
 //======================================================================
 
-    private RangeValues ensureBetaValues(RangeValues rv, FitsRead fitsReadAry[]) {
-        if (rv.getStretchAlgorithm()==RangeValues.STRETCH_ASINH && Double.isNaN(rv.getBetaValue())) {
-                               //if asinH and the default beta then compute the beta
-            if (Double.isNaN(this.betaValue)) {
-                for(FitsRead testFr : fitsReadAry) {
-                    if (testFr!=null) {
-                        this.betaValue= testFr.getDefaultBeta();
-                        break;
-                    }
-                }
-            }
-            return new RangeValues(rv.getLowerWhich(), rv.getLowerValue(), rv.getUpperWhich(), rv.getUpperValue(),
-                    this.betaValue, rv.getGammaValue(), rv.getStretchAlgorithm(),
-                    rv.getZscaleContrast(), rv.getZscaleSamples(), rv.getZscaleSamplesPerLine());
-        }
-        return rv;
-    }
-
     public Iterator<ImageData> iterator() {
         return Arrays.asList(_imageDataAry).iterator();
     }
@@ -194,7 +174,6 @@ public class ImageDataGroup implements Iterable<ImageData> {
                                  RangeValues rangeValues,
                                  boolean force) {
 
-        rangeValues= ensureBetaValues(rangeValues, fitsReadAry);
         for(ImageData id : _imageDataAry) {
             id.recomputeStretch(fitsReadAry,idx,rangeValues, force);
         }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
@@ -1,8 +1,5 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
- *
- * 05/04/16
- * LZ Remove DP, WP parameters and changed DR to beta instead due to the changes in the asinh algorithm
  */
 package edu.caltech.ipac.visualize.plot;
 
@@ -30,7 +27,7 @@ public class RangeValues implements Cloneable, Serializable {
     public static final int ZSCALE     = 91;
     public static final int SIGMA      = 92;
 
-    public static final double BETA =Double.NaN;
+    public static final double ASINH_Q =10.0;
     public static final double GAMMA=2.0;
 
     public static final String LINEAR_STR= "Linear";
@@ -58,7 +55,7 @@ public class RangeValues implements Cloneable, Serializable {
     private double _lowerValue;
     private int    _upperWhich;
     private double _upperValue;
-    private double _betaValue;
+    private double _asinhQValue;
     private double _gammaValue;
     private int    _algorithm= STRETCH_LINEAR;
     private int    _zscale_contrast;
@@ -68,19 +65,19 @@ public class RangeValues implements Cloneable, Serializable {
     private double _contrast;
 
     public RangeValues() {
-       this( PERCENTAGE, 1.0, PERCENTAGE, 99.0, BETA, GAMMA, STRETCH_LINEAR, 25, 600, 120);
+        this( PERCENTAGE, 1.0, PERCENTAGE, 99.0, ASINH_Q, GAMMA, STRETCH_LINEAR, 25, 600, 120);
     }
 
     public RangeValues(int algorithm ) {
 
-        this( PERCENTAGE, 1.0, PERCENTAGE, 99.0, BETA, GAMMA, algorithm, 25, 600, 120);
+        this( PERCENTAGE, 1.0, PERCENTAGE, 99.0, ASINH_Q, GAMMA, algorithm, 25, 600, 120);
     }
     public RangeValues( int    lowerWhich,
                         double lowerValue,
                         int    upperWhich,
                         double upperValue,
-                     int    algorithm) {
-        this( lowerWhich, lowerValue, upperWhich, upperValue,BETA, GAMMA,algorithm, 25, 600, 120);
+                        int    algorithm) {
+        this( lowerWhich, lowerValue, upperWhich, upperValue, ASINH_Q, GAMMA,algorithm, 25, 600, 120);
     }
 
     //added
@@ -88,13 +85,13 @@ public class RangeValues implements Cloneable, Serializable {
                         double lowerValue,
                         int    upperWhich,
                         double upperValue,
-                        double betaValue,
+                        double asinhQValue,
                         double gammaValue,
                         int    algorithm) {
-        this( lowerWhich, lowerValue, upperWhich, upperValue,betaValue, gammaValue, algorithm, 25, 600, 120);
+        this( lowerWhich, lowerValue, upperWhich, upperValue, asinhQValue, gammaValue, algorithm, 25, 600, 120);
     }
 
-        public RangeValues( int    lowerWhich,
+    public RangeValues( int    lowerWhich,
                         double lowerValue,
                         int    upperWhich,
                         double upperValue,
@@ -103,7 +100,7 @@ public class RangeValues implements Cloneable, Serializable {
                         int    zscale_samples,
                         int    zscale_samples_per_line) {
 
-        this( lowerWhich, lowerValue, upperWhich, upperValue, BETA, GAMMA, algorithm,
+        this( lowerWhich, lowerValue, upperWhich, upperValue, ASINH_Q, GAMMA, algorithm,
                 zscale_contrast, zscale_samples, zscale_samples_per_line,
                 0.5, 1.0);
     }
@@ -112,14 +109,14 @@ public class RangeValues implements Cloneable, Serializable {
                         double lowerValue,
                         int    upperWhich,
                         double upperValue,
-                        double betaValue,
+                        double asinhQValue,
                         double gammaValue,
                         int    algorithm,
                         int    zscale_contrast,
                         int    zscale_samples,
                         int    zscale_samples_per_line) {
 
-        this( lowerWhich, lowerValue, upperWhich, upperValue,betaValue,gammaValue, algorithm,
+        this( lowerWhich, lowerValue, upperWhich, upperValue, asinhQValue, gammaValue, algorithm,
                 zscale_contrast, zscale_samples, zscale_samples_per_line,
                 0.5, 1.0);
     }
@@ -130,7 +127,7 @@ public class RangeValues implements Cloneable, Serializable {
                         double lowerValue,
                         int    upperWhich,
                         double upperValue,
-                        double betaValue,
+                        double asinhQValue,
                         double gammaValue,
                         int    algorithm,
                         int    zscale_contrast,
@@ -144,8 +141,8 @@ public class RangeValues implements Cloneable, Serializable {
         _upperWhich= upperWhich;
         _upperValue= upperValue;
         _algorithm = algorithm;
-         _betaValue = betaValue;
-         _gammaValue=gammaValue;
+        _asinhQValue = asinhQValue;
+        _gammaValue=gammaValue;
         _zscale_contrast = zscale_contrast;
         _zscale_samples = zscale_samples;
         _zscale_samples_per_line = zscale_samples_per_line;
@@ -190,7 +187,7 @@ public class RangeValues implements Cloneable, Serializable {
     //LZ 6/11/15 added this method
     public static RangeValues create(String stretchType,
                                      double lowerValue,
-                                     double upperValue, double betaValue, double gammaValue,
+                                     double upperValue, double asinhQValue, double gammaValue,
                                      String algorithm) {
         int s= PERCENTAGE;
         if (!isEmpty(stretchType)) {
@@ -210,11 +207,11 @@ public class RangeValues implements Cloneable, Serializable {
             else if (algorithm.equalsIgnoreCase(POWERLAW_GAMMA_STR)) a= STRETCH_POWERLAW_GAMMA;
 
         }
-        return new RangeValues(s,lowerValue,s,upperValue,betaValue, gammaValue, a);
+        return new RangeValues(s,lowerValue,s,upperValue,asinhQValue, gammaValue, a);
     }
 
    //LZ 05/21/15 add the following two lines
-    public double getBetaValue() { return _betaValue; }
+    public double getAsinhQValue() { return _asinhQValue; }
     public double getGammaValue() { return _gammaValue; }
 
     public int    getLowerWhich() { return _lowerWhich; }
@@ -243,7 +240,7 @@ public class RangeValues implements Cloneable, Serializable {
 
     public Object clone() {
         return new RangeValues( _lowerWhich, _lowerValue, _upperWhich,
-		_upperValue, _betaValue, _gammaValue, _algorithm,
+		_upperValue, _asinhQValue, _gammaValue, _algorithm,
 		_zscale_contrast, _zscale_samples, _zscale_samples_per_line, _bias, _contrast );
     }
 
@@ -273,7 +270,7 @@ public class RangeValues implements Cloneable, Serializable {
             double lowerValue=              parseDouble(s[i++]);
             int    upperWhich=              Integer.parseInt(s[i++]);
             double upperValue=              parseDouble(s[i++]);
-            double betaValue=               parseDouble(s[i++]);
+            double asinhQValue=             parseDouble(s[i++]);
             double gammaValue=              parseDouble(s[i++]);
             int    algorithm=               Integer.parseInt(s[i++]);
             int    zscale_contrast=         Integer.parseInt(s[i++]);
@@ -284,7 +281,7 @@ public class RangeValues implements Cloneable, Serializable {
                                    lowerValue,
                                    upperWhich,
                                    upperValue,
-                                   betaValue,
+                                   asinhQValue,
                                    gammaValue,
                                    algorithm,
                                    zscale_contrast,
@@ -304,7 +301,7 @@ public class RangeValues implements Cloneable, Serializable {
                getLowerValue()+","+
                getUpperWhich()+","+
                getUpperValue()+","+
-               getBetaValue()+","+
+               getAsinhQValue()+","+
                getGammaValue()+","+
                getStretchAlgorithm()+","+
                getZscaleContrast()+","+

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
@@ -27,7 +27,7 @@ public class RangeValues implements Cloneable, Serializable {
     public static final int ZSCALE     = 91;
     public static final int SIGMA      = 92;
 
-    public static final double ASINH_Q =10.0;
+    public static final double ASINH_Q =  Double.NaN; // if NaN, Q will be estimated based on range;
     public static final double GAMMA=2.0;
 
     public static final String LINEAR_STR= "Linear";
@@ -212,6 +212,7 @@ public class RangeValues implements Cloneable, Serializable {
 
    //LZ 05/21/15 add the following two lines
     public double getAsinhQValue() { return _asinhQValue; }
+    public void setAsinhQValue(double val) { _asinhQValue = val; }
     public double getGammaValue() { return _gammaValue; }
 
     public int    getLowerWhich() { return _lowerWhich; }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/Zscale.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/Zscale.java
@@ -291,7 +291,7 @@ public class Zscale
 	if (npix <= 0)
 	    return new FitLineRetval(1, 0.0F, 0.0F);
 	else if (npix == 1) {
-		    return new FitLineRetval(1, data[1], 0.0F);
+	    return new FitLineRetval(1, data[1], 0.0F);
 	} else
 	    xscale = 2.0 / (npix - 1);
 
@@ -384,14 +384,14 @@ public class Zscale
 		break;
 	}
 
-	/* Transform the line coefficients back to the X range [1:npix]. */
-	float zstart = (float) (z0 - dz);
-	float  zslope = (float) (dz * xscale);
-        if (Math.abs(zslope) < 0.001)
-            zslope = (float) (o_dz * xscale);
+	  /* Transform the line coefficients back to the X range [1:npix]. */
+	  float zstart = (float) (z0 - dz);
+	  float  zslope = (float) (dz * xscale);
+	  if (Math.abs(zslope) < 1e-10)
+		  zslope = (float) (o_dz * xscale);
 
 
-	return new FitLineRetval(ngoodpix, zstart, zslope);
+	  return new FitLineRetval(ngoodpix, zstart, zslope);
 }
 
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -138,16 +138,6 @@ public class FitsRead implements Serializable {
     public BinaryTableHDU getTableHDU() { return tableHDU; } //todo - remove this methdo
 
 
-
-
-    public double getDefaultBeta() {
-        if (Double.isNaN(this.defBetaValue)) {
-            this.defBetaValue= ImageStretch.computeSigma(float1d, imageHeader);
-        }
-        return this.defBetaValue;
-    }
-
-
     public static RangeValues getDefaultFutureStretch() {
         return DEFAULT_RANGE_VALUE;
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
@@ -2,16 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-/*
- * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
- */
-
 package edu.caltech.ipac.visualize.plot.plotdata;
-/**
- * User: roby
- * Date: 7/13/18
- * Time: 11:53 AM
- */
 
 
 import edu.caltech.ipac.util.Assert;
@@ -70,7 +61,7 @@ public class ImageStretch {
          * stretch algorithm
          */
         if (rangeValues.getStretchAlgorithm()==RangeValues.STRETCH_ASINH) {
-            stretchPixelsUsingAsin( startPixel, lastPixel,startLine,lastLine, naxis1, imageHeader,
+            stretchPixelsUsingAsinh( startPixel, lastPixel,startLine,lastLine, naxis1, imageHeader,
                     blank_pixel_value, float1dArray, pixeldata, rangeValues,slow,shigh);
 
 
@@ -185,48 +176,39 @@ public class ImageStretch {
     }
 
     /**
-     * The asinh stretch algorithm is defined in the paper by Robert Lupton et al at "The Astronomical Journal 118: 1406-1410, 1999 Sept"
-     * In the paper:
-     *    magnitude = m_0-2.5log(b) - a* asinh (x/2b)  = mu_0  -a * asinh (x/2b), where mu_0 =m_0 - 2.5 * ln(b), a =2.5ln(e) = 1.08574,
-     *    m_o=2.5log(flux_0), flux_0 is the flux of an object with magnitude 0.0.
-     *    b is an arbitrary "softening" which determines the flux level as which the liner behavior is set in, and x is the flux,
+     * The algorithm accepts positive Q, which should be controlled by a slider.
+     * The mapping from flux to color value is 255 * 0.1 * asinh(Q*(x-xMin)/(xMax-xMin)) / asinh(0.1*Q)
+     * Below xMin, the color will be 0; above xMax, the equation has to be applied and then clipped to 244, (255 is reserved)
      *
+     * The parametrization using Q is explained in the footnote on page 3 of https://arxiv.org/pdf/astro-ph/0312483.pdf
+     * The algorithm is based on asinh stretch algorithm used in
+     *     https://github.com/astropy/astropy/blob/master/astropy/visualization/lupton_rgb.py
      *
-     *   Since  mu_0 and a are constant, we can use just:
-     *     mu =  asinh( flux/(2.0*b)) ) = asin(x/beta); where beta=2*b;
-     * @param beta
+     * Lupton’s formulation assumes that xMax is far below the bright features in the image.
+     * He wants to see the features above xMax.
+     *
+     * If we know the brightest data value and upper and lower range values,
+     * we can get the default Q from the following equation:
+     *    0.1 * asinh(Q*(xDataMax-xMin)/(xMax-xMin)) / asinh(0.1*Q) = 1
+     *
+     * @param flux
+     * @param maxFlux
+     * @param minFlux
+     * @param qvalue
      * @return
      */
-    private static double  getASinhStretchedPixelValue(double flux, double maxFlux, double minFlux, double beta)  {
+    private static double  getASinhStretchedPixelValue(double flux, double maxFlux, double minFlux, double qvalue)  {
+
         if (flux <= minFlux) { return 0d; }
-        if (flux >= maxFlux) { return 254d; }
 
-        /*
-         Since the data range is from minFlux to maxFlux, we can shift the data to  the range [0 - (maxFlux-minFlux)].
-         Thus,
-                   flux_new = flux-minFlux,
-                   minFlux_new = 0
-                   maxFlux_new = maxFlux - minFlux
-         min = asinh( abs(minFlux_new) -square(minFlux_new*minFlux_new+1) ) =0
-         max = (max-min) = asinh( maxFlux_new/beta) = asinh( (maxFlux-minFlux)/beta)
-         diff = max - min = max
-         */
-        double asinhMagnitude =  asinh( (flux-minFlux) / beta); //beta = 2*b
+        double color = 255 * 0.1 * asinh(qvalue*(flux - minFlux) / (maxFlux - minFlux)) / asinh(0.1 * qvalue);
 
-        //normalize to 0 - 255:  (nCorlor-1 )*(x - Min)/(Max - Min), 8 bit nCorlor=256
-        //this formula is referred from IDL function: BYTSCL
-        double diff =   asinh ( (maxFlux-minFlux)/beta );
-        return  255* asinhMagnitude/ diff ;
+        return (color > 254d) ? 254d : color;
 
     }
 
     private static double asinh(double x) {
-
-        double y  = Math.log( Math.abs(x ) + Math.sqrt(x * x + 1));
-        y = x<0? -y:y;
-
-        return y;
-
+        return Math.log(x + Math.sqrt(x * x + 1));
     }
 
     private static int getNoneLinerStretchedPixelValue(double dRunVal, double[] dtbl, int delta) {
@@ -307,58 +289,89 @@ public class ImageStretch {
         return dtbl;
     }
 
-    private static void stretchPixelsUsingAsin(int startPixel,
-                                                 int lastPixel,
-                                                 int startLine,
-                                                 int lastLine,
-                                                 int naxis1,
-                                                 ImageHeader imageHeader,
-                                                 byte blank_pixel_value,
-                                                 float[] float1dArray,
-                                                 byte[] pixeldata,
-                                                 RangeValues rangeValues,
-                                                 double slow,
-                                                 double shigh){
+    private static void stretchPixelsUsingAsinh(int startPixel,
+                                                int lastPixel,
+                                                int startLine,
+                                                int lastLine,
+                                                int naxis1,
+                                                ImageHeader imageHeader,
+                                                byte blank_pixel_value,
+                                                float[] float1dArray,
+                                                byte[] pixeldata,
+                                                RangeValues rangeValues,
+                                                double slow,
+                                                double shigh){
 
 
-          double qvalue = rangeValues.getAsinhQValue();
+        double qvalue = rangeValues.getAsinhQValue();
 
-          if (qvalue < 1e-10) {
-              qvalue = 0.1;
-          } else if (qvalue > 1e10) {
-              qvalue = 1e10;
-          }
+        if (qvalue < 1e-10) {
+            qvalue = 0.1;
+        } else if (qvalue > 1e10) {
+            qvalue = 1e10;
+        }
 
-          double maxFlux = getFlux(shigh, imageHeader);
-          double minFlux = getFlux(slow, imageHeader);
-          if (Double.isNaN(minFlux) || Double.isInfinite((minFlux))){
-              double[] minMax=getMinMaxData(float1dArray);
-              minFlux = getFlux(minMax[0],imageHeader);
-          }
+        double maxFlux = getFlux(shigh, imageHeader);
+        double minFlux = getFlux(slow, imageHeader);
+        if (Double.isNaN(minFlux) || Double.isInfinite((minFlux))){
+            double[] minMax=getMinMaxData(float1dArray);
+            minFlux = getFlux(minMax[0],imageHeader);
+        }
 
-          if ( Double.isNaN(maxFlux) || Double.isInfinite((maxFlux)) ) {
-              double[] minMax=getMinMaxData(float1dArray);
-              minFlux = getFlux(minMax[1], imageHeader);
-          }
-          int pixelCount = 0;
-          double flux;
+        if ( Double.isNaN(maxFlux) || Double.isInfinite((maxFlux)) ) {
+            double[] minMax=getMinMaxData(float1dArray);
+            minFlux = getFlux(minMax[1], imageHeader);
+        }
 
-          for (int line = startLine; line <= lastLine; line++) {
-              int start_index = line * naxis1 + startPixel;
-              int last_index = line * naxis1 + lastPixel;
-              for (int index = start_index; index <= last_index; index++) {
-                  flux = getFlux(float1dArray[index], imageHeader);
-                  if (Double.isNaN(flux)) { // if original pixel value is NaN, assign it to blank
-                      pixeldata[pixelCount] = blank_pixel_value;
-                  } else {
-                      pixeldata[pixelCount] = (byte) getASinhStretchedPixelValue(flux, maxFlux, minFlux, qvalue);
-                  }
-                  pixelCount++;
-              }
-          }
-      }
+        if ( !Double.isFinite(qvalue) ) {
+            double[] minMax=getMinMaxData(float1dArray);
+            double dataMaxFlux = getFlux(minMax[1], imageHeader);
+            qvalue = getDefaultAsinhQ(minFlux, maxFlux, dataMaxFlux);
+            rangeValues.setAsinhQValue(qvalue);
+        }
 
+        int pixelCount = 0;
+        double flux;
 
+        for (int line = startLine; line <= lastLine; line++) {
+            int start_index = line * naxis1 + startPixel;
+            int last_index = line * naxis1 + lastPixel;
+            for (int index = start_index; index <= last_index; index++) {
+                flux = getFlux(float1dArray[index], imageHeader);
+                if (Double.isNaN(flux)) { // if original pixel value is NaN, assign it to blank
+                    pixeldata[pixelCount] = blank_pixel_value;
+                } else {
+                    pixeldata[pixelCount] = (byte) getASinhStretchedPixelValue(flux, maxFlux, minFlux, qvalue);
+                }
+                pixelCount++;
+            }
+        }
+    }
+
+    /**
+     * Find default Q from asinh(Q*(xDataMax-xMin)/(xMax-xMin)) = 10 * asinh(0.1*Q)
+     * @param minFlux
+     * @param maxFlux
+     * @param dataMaxFlux
+     * @return
+     */
+    private static double getDefaultAsinhQ(double minFlux, double maxFlux, double dataMaxFlux) {
+        double bestQ = 0.1;
+        double step = 0.1;
+        double minDiff = Double.MAX_VALUE;
+        double fact = (dataMaxFlux-minFlux)/(maxFlux-minFlux);
+        double diff;
+        // max default Q is 12 - which corresponds to fact=1000
+        // (points 1000 times brighter than maxFlux will saturate)
+        for (double q=0.1; q<=12d; q=q+step) {
+            diff = Math.abs(asinh(fact*q)-10*asinh(0.1*q));
+            if ( diff < minDiff) {
+                minDiff = diff;
+                bestQ = q;
+            }
+        }
+        return Math.round(10*bestQ)/10.0; // round to 1 decimal digit
+    }
 
     /**
      * fill the 256 element table with values for a squared stretch

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -98,7 +98,6 @@ export const ServerParams = {
         CREATE_PLOT_GROUP : 'CmdCreatePlotGroup',
         ZOOM : 'CmdZoom',
         STRETCH : 'CmdStretch',
-        GET_BETA : 'CmdGetBeta',
         REMOVE_BAND : 'CmdRemoveBand',
         CHANGE_COLOR : 'CmdChangeColor',
         ROTATE_NORTH : 'CmdRotateNorth',

--- a/src/firefly/js/rpc/PlotServicesJson.js
+++ b/src/firefly/js/rpc/PlotServicesJson.js
@@ -119,12 +119,6 @@ export function callChangeColor(state, colorTableId) {
     return doJsonRequest(ServerParams.CHANGE_COLOR, params, true);
 }
 
-export function callGetBeta(state) {
-    const params= [
-        {name:ServerParams.STATE, value: state.toJson(false)},
-    ];
-    return doJsonRequest(ServerParams.GET_BETA, params, true);
-}
 
 export function callRecomputeStretch(state, stretchDataAry) {
     var params= {

--- a/src/firefly/js/ui/RangeSlider.jsx
+++ b/src/firefly/js/ui/RangeSlider.jsx
@@ -1,9 +1,7 @@
-import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import { has, isNaN} from 'lodash';
 import {fieldGroupConnector} from './FieldGroupConnector.jsx';
-import {dispatchValueChange} from '../fieldGroup/FieldGroupCntlr.js';
-import {RangeSliderView, adjustMax, checkMarksObject} from './RangeSliderView.jsx'
+import {RangeSliderView, checkMarksObject} from './RangeSliderView.jsx';
 
 function getProps(params, fireValueChange) {
 
@@ -24,9 +22,9 @@ function handleOnChange(value, params, fireValueChange){
          value
      });
 
-    var {min, max} = params;    //displayValue in string, min, max, step: number
-    var {minStop=min, maxStop=max} = params;
-    var val = parseFloat(value);
+    const {min, max} = params;    //displayValue in string, min, max, step: number
+    const {minStop=min, maxStop=max} = params;
+    const val = parseFloat(value);
 
     if (!isNaN(val) && val >= minStop && val <= maxStop) {
         if (has(params, 'onValueChange')) {
@@ -38,8 +36,8 @@ function handleOnChange(value, params, fireValueChange){
 const propTypes={
     associatedKey: PropTypes.string,
     label:       PropTypes.string,             // slider label
-    slideValue:  PropTypes.string.required,    // slider value
-    value:       PropTypes.string,
+    slideValue:  PropTypes.oneOfType([PropTypes.string,PropTypes.number]).required, // slider value
+    value:       PropTypes.oneOfType([PropTypes.string,PropTypes.number]),
     onValueChange: PropTypes.func,                  // callback on slider change
     min:         PropTypes.number,                  // minimum end of slider
     max:         PropTypes.number,                  // maximum end of slider

--- a/src/firefly/js/ui/RangeSliderView.jsx
+++ b/src/firefly/js/ui/RangeSliderView.jsx
@@ -13,7 +13,7 @@ export class RangeSliderView extends PureComponent {
 
         this.state = {value: parseFloat(props.slideValue)};
         this.onSliderChange = this.onSliderChange.bind(this);
-        var d = get(props, 'decimalDig', 3);
+        const d = get(props, 'decimalDig', 3);
         this.decimalDig = (d < 0) ? 0 : (d > 20) ? 20 : d;
     }
 
@@ -23,7 +23,7 @@ export class RangeSliderView extends PureComponent {
 
 
     onSliderChange(v) {
-        var {handleChange, minStop, maxStop} = this.props;
+        const {handleChange, minStop, maxStop} = this.props;
 
         if (minStop && v < minStop ) {
             v = minStop;
@@ -41,10 +41,10 @@ export class RangeSliderView extends PureComponent {
 
 
     render() {
-        var {wrapperStyle={}, sliderStyle={}, className, marks, vertical,
+        const {wrapperStyle={}, sliderStyle={}, className, marks, vertical,
              defaultValue, handle, label, labelWidth, tooltip, minStop, maxStop, min, max, step} = this.props;
-        var {value} = this.state;    //displayValue in string, min, max, step: number
-        var val = parseFloat(value);
+        const {value} = this.state;    //displayValue in string, min, max, step: number
+        let val = parseFloat(value);
 
         if (minStop && val < minStop ) {
             val = minStop;
@@ -55,7 +55,7 @@ export class RangeSliderView extends PureComponent {
 
         return (
             <div style={wrapperStyle}>
-                <div style={sliderStyle} display='flex'>
+                <div style={Object.assign({display: 'flex'}, sliderStyle)}>
                     <div title={tooltip} style={{width: labelWidth, marginBottom: 5}}>{label}</div>
                     <Slider min={min}
                             max={max}
@@ -85,8 +85,8 @@ RangeSliderView.propTypes = {
     step: PropTypes.number,
     vertical: PropTypes.bool,
     defaultValue: PropTypes.number,
-    slideValue: PropTypes.string.isRequired,
-    value: PropTypes.string,
+    slideValue: PropTypes.oneOfType([PropTypes.string,PropTypes.number]).isRequired,
+    value: PropTypes.oneOfType([PropTypes.string,PropTypes.number]),
     handle: PropTypes.element,
     wrapperStyle: PropTypes.object,
     sliderStyle: PropTypes.object,

--- a/src/firefly/js/visualize/RangeValues.js
+++ b/src/firefly/js/visualize/RangeValues.js
@@ -3,8 +3,6 @@
  */
 
 //LZ 06/11/15 add arcsine and power law gamma parameters
-//LZ 06/26/15 add zp and wp parameters
-//LZ 05/03/16 Remove zp, wp parameters and changed dp to beta
 import validator from 'validator';
 
 
@@ -18,18 +16,7 @@ export const ABSOLUTE   = 90;
 export const ZSCALE     = 91;
 export const SIGMA      = 92;
 
-
-export const LINEAR_STR= 'linear';
-export const LOG_STR= 'log';
-export const LOGLOG_STR= 'loglog';
-export const EQUAL_STR= 'equal';
-export const SQUARED_STR= 'squared';
-export const SQRT_STR= 'sqrt';
-
-export const ASINH_STR= 'asinh';
-export const POWERLAW_GAMMA_STR= 'powerlaw_gamma';
-
-
+// the values should match the constants in RangeValues.java
 export const STRETCH_LINEAR= 44;
 export const STRETCH_LOG   = 45;
 export const STRETCH_LOGLOG= 46;
@@ -39,13 +26,7 @@ export const STRETCH_SQRT    = 49;
 export const STRETCH_ASINH   = 50;
 export const STRETCH_POWERLAW_GAMMA   = 51;
 
-const BYTE_MAX_VALUE= 127;
-
-const boundsStrToConst = {
-    percent:  PERCENTAGE,
-    absolute: ABSOLUTE,
-    sigma: SIGMA
-};
+const LINEAR_STR= 'linear';
 
 const alStrToConst = {
     log : STRETCH_LOG,
@@ -57,13 +38,21 @@ const alStrToConst = {
     powerlaw_gamma : STRETCH_POWERLAW_GAMMA,
 };
 
+const BYTE_MAX_VALUE= 127;
+
+const boundsStrToConst = {
+    percent:  PERCENTAGE,
+    absolute: ABSOLUTE,
+    sigma: SIGMA
+};
+
 
 export class RangeValues {
     constructor( lowerWhich= PERCENTAGE,
                  lowerValue= 1.0,
                  upperWhich= PERCENTAGE,
                  upperValue= 99.0,
-                 betaValue=NaN,
+                 asinhQValue=10.0,
                  gammaValue=2.0,
                  algorithm= STRETCH_LINEAR,
                  zscaleContrast= 25,
@@ -75,7 +64,7 @@ export class RangeValues {
         this.lowerValue= parseFloat(lowerValue);
         this.upperWhich= parseInt(upperWhich);
         this.upperValue= parseFloat(upperValue);
-        this.betaValue = parseFloat(betaValue);
+        this.asinhQValue = parseFloat(asinhQValue);
         this.gammaValue=parseFloat(gammaValue);
         this.algorithm=  parseInt(algorithm);
         this.zscaleContrast= parseInt(zscaleContrast);
@@ -103,7 +92,7 @@ export class RangeValues {
      */
     static clone() {
         return new RangeValues( this.lowerWhich, this.lowerValue, this.upperWhich,
-                                this.upperValue, this.betaValue,  this.gammaValue, this.algorithm,
+                                this.upperValue, this.asinhQValue,  this.gammaValue, this.algorithm,
                                 this.zscaleContrast, this.zscaleSamples,
                                 this.zscaleSamplesPerLine,
                                 this.bias, this.contrast );
@@ -142,7 +131,7 @@ export class RangeValues {
      * @param p.lowerValue
      * @param p.upperWhich
      * @param p.upperValue
-     * @param p.betaValue
+     * @param p.asinhQValue
      * @param p.gammaValue
      * @param p.algorithm
      * @param p.zscaleContrast
@@ -157,7 +146,7 @@ export class RangeValues {
                    lowerValue= 1.0,
                    upperWhich,
                    upperValue= 99.0,
-                   betaValue=NaN,
+                   asinhQValue= 10.0,
                    gammaValue=2.0,
                    algorithm= STRETCH_LINEAR,
                    zscaleContrast= 25,
@@ -168,7 +157,7 @@ export class RangeValues {
 
         lowerWhich= lowerWhich || which;
         upperWhich= upperWhich || which;
-        return new RangeValues( lowerWhich, lowerValue, upperWhich, upperValue, betaValue,
+        return new RangeValues( lowerWhich, lowerValue, upperWhich, upperValue, asinhQValue,
             gammaValue, algorithm, zscaleContrast, zscaleSamples,
             zscaleSamplesPerLine, bias, contrast);
     }
@@ -179,7 +168,7 @@ export class RangeValues {
      * @param lowerValue
      * @param upperWhich
      * @param upperValue
-     * @param betaValue
+     * @param asinhQValue
      * @param gammaValue
      * @param algorithm
      * @param zscaleContrast
@@ -193,7 +182,7 @@ export class RangeValues {
                 lowerValue= 1.0,
                 upperWhich= PERCENTAGE,
                 upperValue= 99.0,
-                betaValue=NaN,
+                asinhQValue=10.0,
                 gammaValue=2.0,
                 algorithm= STRETCH_LINEAR,
                 zscaleContrast= 25,
@@ -202,7 +191,7 @@ export class RangeValues {
                 bias= 0.5,
                 contrast= 1.0 ) {
 
-        return new RangeValues( lowerWhich, lowerValue, upperWhich, upperValue, betaValue,
+        return new RangeValues( lowerWhich, lowerValue, upperWhich, upperValue, asinhQValue,
              gammaValue, algorithm, zscaleContrast, zscaleSamples,
             zscaleSamplesPerLine, bias, contrast);
     }
@@ -273,7 +262,7 @@ export class RangeValues {
                rv.lowerValue+','+
                rv.upperWhich+','+
                rv.upperValue+','+
-               rv.betaValue+','+
+               rv.asinhQValue+','+
                rv.gammaValue+','+
                rv.algorithm+','+
                rv.zscaleContrast+','+

--- a/src/firefly/js/visualize/RangeValues.js
+++ b/src/firefly/js/visualize/RangeValues.js
@@ -46,13 +46,12 @@ const boundsStrToConst = {
     sigma: SIGMA
 };
 
-
 export class RangeValues {
     constructor( lowerWhich= PERCENTAGE,
                  lowerValue= 1.0,
                  upperWhich= PERCENTAGE,
                  upperValue= 99.0,
-                 asinhQValue=10.0,
+                 asinhQValue=NaN,
                  gammaValue=2.0,
                  algorithm= STRETCH_LINEAR,
                  zscaleContrast= 25,
@@ -146,7 +145,7 @@ export class RangeValues {
                    lowerValue= 1.0,
                    upperWhich,
                    upperValue= 99.0,
-                   asinhQValue= 10.0,
+                   asinhQValue= NaN,
                    gammaValue=2.0,
                    algorithm= STRETCH_LINEAR,
                    zscaleContrast= 25,
@@ -182,7 +181,7 @@ export class RangeValues {
                 lowerValue= 1.0,
                 upperWhich= PERCENTAGE,
                 upperValue= 99.0,
-                asinhQValue=10.0,
+                asinhQValue=NaN,
                 gammaValue=2.0,
                 algorithm= STRETCH_LINEAR,
                 zscaleContrast= 25,

--- a/src/firefly/js/visualize/ui/ColorBandPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorBandPanel.jsx
@@ -5,12 +5,13 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import numeral from 'numeral';
+import {debounce, get} from 'lodash';
 
 import {ValidationField} from '../../ui/ValidationField.jsx';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {CheckboxGroupInputField} from '../../ui/CheckboxGroupInputField.jsx';
-import {callGetColorHistogram, callGetBeta} from '../../rpc/PlotServicesJson.js';
-import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
+import {RangeSlider} from '../../ui/RangeSlider.jsx';
+import {callGetColorHistogram} from '../../rpc/PlotServicesJson.js';
 import {encodeServerUrl} from '../../util/WebUtil.js';
 import {formatFlux} from '../VisUtil.js';
 import {getRootURL} from '../../util/BrowserUtil.js';
@@ -20,7 +21,11 @@ import {
     STRETCH_LINEAR, STRETCH_LOG, STRETCH_LOGLOG, STRETCH_EQUAL,
     STRETCH_SQUARED, STRETCH_SQRT, STRETCH_ASINH, STRETCH_POWERLAW_GAMMA} from '../RangeValues.js';
 
-
+import {getFieldGroupResults} from '../../fieldGroup/FieldGroupUtils.js';
+import {dispatchStretchChange, visRoot} from '../ImagePlotCntlr.js';
+import {getActivePlotView} from '../PlotViewUtil.js';
+import {makeSerializedRv} from './ColorDialog.jsx';
+import {toBoolean} from '../../util/WebUtil.js';
 
 
 const LABEL_WIDTH= 105;
@@ -54,26 +59,23 @@ export class ColorBandPanel extends PureComponent {
 
     constructor(props) {
         super(props);
-        this.state={exit:true, retrievedBetaValue:NaN};
+        this.state={exit:true};
         this.handleReadout= this.handleReadout.bind(this);
         this.mouseMove= this.mouseMove.bind(this);
         this.mouseLeave= this.mouseLeave.bind(this);
+        this.bandReplot= debounce(getReplotFunc(props.groupKey, props.band), 600);
     }
 
 
     componentWillReceiveProps(nextProps) {
-        const {plot:nPlot, fields:nFields}= nextProps;
-        let {retrievedBetaValue}= this.state;
+        const {plot:nPlot}= nextProps;
         const {plot}= this.props;
         if (nPlot.plotId!==plot.plotId || nPlot.plotState!==plot.plotState) {
             this.initImages(nPlot,nextProps.band);
-            retrievedBetaValue= NaN;
-            this.setState(() => ({retrievedBetaValue}));
         }
-        if (isNaN(retrievedBetaValue) && nFields.algorithm.value===STRETCH_ASINH) {
-            this.retrieveBeta(nPlot,nextProps.band);
+        if (nextProps.groupKey !== this.props.groupKey) {
+            this.bandReplot= debounce(getReplotFunc(this.props.groupKey, this.props.band), 600);
         }
-        
     }
 
     componentWillMount() {
@@ -81,21 +83,8 @@ export class ColorBandPanel extends PureComponent {
         this.initImages(plot,band);
     }
 
-
-    retrieveBeta(plot,band) {
-        if (this.state.doMask) return;
-        this.setState(() => ({doMask:true}));
-        callGetBeta(plot.plotState)
-            .then( (betaAry) => {
-                const beta= !isNaN(betaAry[band.value]) ? betaAry[band.value].toFixed(2) : betaAry[band.value];
-                this.setState(() => ({doMask:false, retrievedBetaValue:beta}));
-                if (isNaN(this.props.fields.beta.value)) {
-                    dispatchValueChange({fieldKey:'beta', groupKey:this.props.groupKey, value:beta,valid:true } );
-                }
-            });
-    }
-
     initImages(plot,band) {
+
         callGetColorHistogram(plot.plotState,band,HIST_WIDTH,HIST_HEIGHT)
             .then(  (result) => {
                 const dataHistUrl= encodeServerUrl(getRootURL() + 'sticky/FireFly_ImageDownload',
@@ -112,7 +101,7 @@ export class ColorBandPanel extends PureComponent {
     mouseMove(ev) {
         const {offsetX:x}= ev;
         const {dataHistogram,dataBinMeanArray}= this.state;
-        var idx= Math.trunc((x *(dataHistogram.length/HIST_WIDTH)));
+        const idx= Math.trunc((x *(dataHistogram.length/HIST_WIDTH)));
         const histValue= dataHistogram[idx];
         const histMean= dataBinMeanArray[idx];
         this.setState({histIdx:idx,histValue,histMean,exit:false});
@@ -129,19 +118,17 @@ export class ColorBandPanel extends PureComponent {
     }
 
     render() {
-        var {fields,plot,band}=this.props;
-        const {dataHistUrl,cbarUrl, histIdx, histValue,histMean,exit, doMask, retrievedBetaValue}=  this.state;
+        const {fields,plot,band}=this.props;
+        const {dataHistUrl,cbarUrl, histIdx, histValue,histMean,exit, doMask}=  this.state;
 
 
 
-        var panel;
-        var showBeta=false;
+        let panel;
         if (fields) {
             const {algorithm, zscale}=fields;
-            var a= Number.parseInt(algorithm.value);
+            const a= Number.parseInt(algorithm.value);
             if (a===STRETCH_ASINH) {
-                panel= renderAsinH(fields);
-                showBeta=true;
+                panel= renderAsinH(fields, this.bandReplot);
             }
             else if (a===STRETCH_POWERLAW_GAMMA) {
                 panel= renderGamma(fields);
@@ -175,10 +162,11 @@ export class ColorBandPanel extends PureComponent {
                     </div>
 
                     {panel}
-                    <div>
-                        {suggestedValuesPanel( plot,band, showBeta && !isNaN(retrievedBetaValue), retrievedBetaValue)}
-                    </div>
+
                     <div style={{position:'absolute', bottom:5, left:5, right:5}}>
+                        <div>
+                            {suggestedValuesPanel( plot,band )}
+                        </div>
                         <div style={{display:'table', margin:'auto auto', paddingBottom:5}}>
                             <CheckboxGroupInputField
                                 options={ [ {label: 'Use ZScale for bounds', value: 'zscale'} ] }
@@ -205,41 +193,27 @@ ColorBandPanel.propTypes= {
 const readTopBaseStyle= { fontSize: '11px', paddingBottom:5, height:16 };
 const dataStyle= { color: 'red' };
 
-function suggestedValuesPanel( plot,band, showBeta, betaValue) {
+function suggestedValuesPanel( plot,band ) {
 
     const precision6Digit = '0.000000';
-   // const precision2Digit = '0.00';
-    const style= { fontSize: '11px', paddingBottom:5, height:16, marginTop:50,  whiteSpace: 'pre'};
+    const style= { fontSize: '11px', paddingBottom:5, height:16, whiteSpace: 'pre'};
 
     const  fitsData= plot.webFitsData[band.value];
     const {dataMin, dataMax} = fitsData;
     const dataMaxStr = `DataMax: ${numeral(dataMax).format(precision6Digit)} `;
     const dataMinStr = `DataMin: ${numeral(dataMin).format(precision6Digit)}`;
-    const betaStr =  `Beta: ${numeral(betaValue).format(precision6Digit)}`;
 
-    if (showBeta) {
-       return (
-
-           <div style={style}>
-                <span style={{float:'left', paddingRight:2, opacity:.5 , marginLeft:30}}>
-                    {dataMinStr}   {dataMaxStr}   {betaStr}
-                </span>
-           </div>
-       );
-    }
-    else {
-      return (
+    return (
         <div style={style}>
                 <span style={{float:'left', paddingRight:2, opacity:.5, marginLeft:40 }}>
                   {dataMinStr}            {dataMaxStr}
                 </span>
         </div>
-       );
-    }
+    );
 }
 
 function ReadoutPanel({exit, plot,band,idx,histValue,histMean,width}) {
-    var topStyle= Object.assign({width},readTopBaseStyle);
+    const topStyle= Object.assign({width},readTopBaseStyle);
     if (exit) {
         return (
             <div style={topStyle}>
@@ -359,8 +333,8 @@ function getStretchTypeField() {
 }
 
 function renderGamma(fields) {
-    var {zscale}= fields;
-    var range= (zscale.value==='zscale') ? renderZscale() : getUpperAndLowerFields();
+    const {zscale}= fields;
+    const range= (zscale.value==='zscale') ? renderZscale() : getUpperAndLowerFields();
     return (
         <div>
             {range}
@@ -370,16 +344,83 @@ function renderGamma(fields) {
     );
 }
 
-function renderAsinH(fields) {
-    var {zscale}= fields;
-    var range= (zscale.value==='zscale') ? renderZscale() : getUpperAndLowerFields();
+const asinhSliderMarks = {
+ 0: '0', 5: '5', 10: '10', 15: '15', 20: '20', 25: 'InF'
+};
+
+
+
+function renderAsinH(fields, bandReplot) {
+    const {zscale}= fields;
+    const range= (zscale.value==='zscale') ? renderZscale() : getUpperAndLowerFields();
+    const qvalue = get(fields, ['asinhQ', 'value'], 10.0);
+    const label = `Q: ${Number.parseFloat(qvalue).toFixed(1)} `;
+
+    const autorange = (zscale.value==='zscale') ? null : <Autorange auto={sessionStorage.getItem('autoAsinh')}/>;
+
     return (
         <div>
             {range}
-            <div style={{paddingTop:10}}/>
-            <ValidationField  wrapperStyle={textPadding} labelWidth={LABEL_WIDTH} fieldKey='beta' />
+            <span style={{float:'right', paddingRight:15, opacity:.4, textAlign: 'center' }}>
+                Q = 0 results in linear; Q = InF in log stretch
+            </span>
+            <div style={{paddingTop:2}}/>
+            <RangeSlider fieldKey='asinhQ'
+                         min={0}
+                         minStop={0.1}
+                         max={25}
+                         maxStop={25}
+                         marks={asinhSliderMarks}
+                         step={0.2}
+                         slideValue={qvalue}
+                         label={label}
+                         labelWidth={60}
+                         wrapperStyle={{marginTop: 15, marginBottom: 20, marginRight: 15}}
+                         decimalDig={1}
+                         onValueChange={bandReplot}
+            />
+            {autorange}
         </div>
     );
 }
 
+class Autorange extends PureComponent {
 
+    constructor(props) {
+        super(props);
+        this.state = {auto: toBoolean(props.auto)};
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.auto != this.props.auto) {
+            this.setState({auto: toBoolean(nextProps.auto)});
+        }
+    }
+
+    render() {
+        const {auto} = this.state;
+        const toggleAuto = () => {
+            const newVal = !auto;
+            sessionStorage.setItem('autoAsinh', newVal);
+            this.setState({auto: newVal});
+        };
+        return (
+            <div style={{marginRight: 20, textAlign: 'center'}}>
+                <input type='checkbox' name='autoAsinh' checked={auto}
+                       onChange={toggleAuto}
+                /> Autofill for full range
+            </div>
+        );
+    }
+}
+
+function getReplotFunc(groupKey, band) {
+
+    return (val) => {
+        const request = getFieldGroupResults(groupKey);
+        const serRv = makeSerializedRv(request);
+        const stretchData = [{band: band.key, rv: serRv, bandVisible: true}];
+        const pv = getActivePlotView(visRoot());
+        if (pv) dispatchStretchChange({plotId: pv.plotId, stretchData});
+    };
+}

--- a/src/firefly/js/visualize/ui/ColorBandPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorBandPanel.jsx
@@ -25,7 +25,6 @@ import {getFieldGroupResults} from '../../fieldGroup/FieldGroupUtils.js';
 import {dispatchStretchChange, visRoot} from '../ImagePlotCntlr.js';
 import {getActivePlotView} from '../PlotViewUtil.js';
 import {makeSerializedRv} from './ColorDialog.jsx';
-import {toBoolean} from '../../util/WebUtil.js';
 
 
 const LABEL_WIDTH= 105;
@@ -200,8 +199,8 @@ function suggestedValuesPanel( plot,band ) {
 
     const  fitsData= plot.webFitsData[band.value];
     const {dataMin, dataMax} = fitsData;
-    const dataMaxStr = `DataMax: ${numeral(dataMax).format(precision6Digit)} `;
-    const dataMinStr = `DataMin: ${numeral(dataMin).format(precision6Digit)}`;
+    const dataMaxStr = `Data Max: ${numeral(dataMax).format(precision6Digit)} `;
+    const dataMinStr = `Data Min: ${numeral(dataMin).format(precision6Digit)}`;
 
     return (
         <div style={style}>
@@ -345,10 +344,10 @@ function renderGamma(fields) {
 }
 
 const asinhSliderMarks = {
- 0: '0', 5: '5', 10: '10', 15: '15', 20: '20', 25: 'InF'
+ 0: '0', 5: '5', 10: '10', 15: '15', 20: '20'
 };
 
-
+const ASINH_Q_MAX_SLIDE_VAL = 20;
 
 function renderAsinH(fields, bandReplot) {
     const {zscale}= fields;
@@ -356,63 +355,30 @@ function renderAsinH(fields, bandReplot) {
     const qvalue = get(fields, ['asinhQ', 'value'], 10.0);
     const label = `Q: ${Number.parseFloat(qvalue).toFixed(1)} `;
 
-    const autorange = (zscale.value==='zscale') ? null : <Autorange auto={sessionStorage.getItem('autoAsinh')}/>;
-
     return (
-        <div>
+        <div style={{paddingBottom: 60}}>
             {range}
-            <span style={{float:'right', paddingRight:15, opacity:.4, textAlign: 'center' }}>
-                Q = 0 results in linear; Q = InF in log stretch
-            </span>
-            <div style={{paddingTop:2}}/>
+            <div style={{paddingTop: 5, paddingRight: 15, opacity: .4, textAlign: 'center'}}>
+                Q=0 for linear stretch;<br/> increase Q to make brighter features visible
+            </div>
             <RangeSlider fieldKey='asinhQ'
                          min={0}
-                         minStop={0.1}
-                         max={25}
-                         maxStop={25}
+                         minStop={0}
+                         max={ASINH_Q_MAX_SLIDE_VAL}
+                         maxStop={ASINH_Q_MAX_SLIDE_VAL}
                          marks={asinhSliderMarks}
-                         step={0.2}
+                         step={0.1}
                          slideValue={qvalue}
                          label={label}
                          labelWidth={60}
-                         wrapperStyle={{marginTop: 15, marginBottom: 20, marginRight: 15}}
+                         wrapperStyle={{marginTop: 10, marginBottom: 20, marginRight: 15}}
                          decimalDig={1}
                          onValueChange={bandReplot}
             />
-            {autorange}
         </div>
     );
 }
 
-class Autorange extends PureComponent {
-
-    constructor(props) {
-        super(props);
-        this.state = {auto: toBoolean(props.auto)};
-    }
-
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.auto != this.props.auto) {
-            this.setState({auto: toBoolean(nextProps.auto)});
-        }
-    }
-
-    render() {
-        const {auto} = this.state;
-        const toggleAuto = () => {
-            const newVal = !auto;
-            sessionStorage.setItem('autoAsinh', newVal);
-            this.setState({auto: newVal});
-        };
-        return (
-            <div style={{marginRight: 20, textAlign: 'center'}}>
-                <input type='checkbox' name='autoAsinh' checked={auto}
-                       onChange={toggleAuto}
-                /> Autofill for full range
-            </div>
-        );
-    }
-}
 
 function getReplotFunc(groupKey, band) {
 

--- a/src/firefly/js/visualize/ui/ColorDialog.jsx
+++ b/src/firefly/js/visualize/ui/ColorDialog.jsx
@@ -265,7 +265,7 @@ function replot3Color(redReq,greenReq,blueReq,activeTab, usedBands) {
 }
 
 
-function makeSerializedRv(request) {
+export function makeSerializedRv(request) {
     const useZ= Boolean(request.zscale);
 
     const rv= RangeValues.makeRV( {
@@ -273,7 +273,7 @@ function makeSerializedRv(request) {
             upperWhich: useZ ? ZSCALE : request.upperWhich,
             lowerValue: request.lowerRange,
             upperValue: request.upperRange,
-            betaValue: request.beta,
+            asinhQValue: request.asinhQ,
             gammaValue: request.gamma,
             algorithm: request.algorithm,
             zscaleContrast: request.zscaleContrast,

--- a/src/firefly/js/visualize/ui/ColorPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ColorPanelReducer.js
@@ -7,7 +7,8 @@ import FieldGroupCntlr, {INIT_FIELD_GROUP} from '../../fieldGroup/FieldGroupCntl
 import ImagePlotCntlr from '../ImagePlotCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {primePlot} from '../PlotViewUtil.js';
-import RangeValues, {STRETCH_LINEAR, PERCENTAGE, ABSOLUTE,SIGMA,ZSCALE, STRETCH_ASINH} from './../RangeValues.js';
+import RangeValues, {STRETCH_LINEAR, STRETCH_ASINH, PERCENTAGE, ABSOLUTE, SIGMA, ZSCALE} from './../RangeValues.js';
+import {toBoolean} from '../../util/WebUtil.js';
 
 
 const clone = (obj,params={}) => Object.assign({},obj,params);
@@ -29,14 +30,14 @@ export const NO_BAND_PANEL= 'nobandPanel';
 export const colorPanelChange= function(band) {
     return (fields,action) => {
         if (!fields || !Object.keys(fields).length) fields= getFieldInit();
-        var plot= primePlot(visRoot());
+        const plot= primePlot(visRoot());
         if (!plot || !plot.plotState.isBandUsed(band)) return fields;
 
         const fitsData= plot.webFitsData[band.value];
         const plottedRV= plot.plotState.getRangeValues(band);
         if (!fitsData || !plottedRV) return fields;
 
-        return computeColorPanelState(fields, plottedRV, fitsData, band, action.type);
+        return computeColorPanelState(fields, plottedRV, fitsData, band, action);
     };
 };
 
@@ -49,17 +50,20 @@ export const colorPanelChange= function(band) {
  * @param plottedRV
  * @param fitsData
  * @param band
- * @param actionType
+ * @param action
  * @return {*}
  */
-const computeColorPanelState= function(fields, plottedRV, fitsData, band, actionType) {
+const computeColorPanelState= function(fields, plottedRV, fitsData, band, action) {
 
-    switch (actionType) {
+    switch (action.type) {
         case FieldGroupCntlr.VALUE_CHANGE:
             var valid= Object.keys(fields).every( (key) => {
                 return !fields[key].mounted ? true :  fields[key].valid;
             } );
             if (!valid) return fields;
+            if (['asinhQ','algorithm', 'zscale'].includes(action.payload.fieldKey)) {
+                fields = syncAsinhFields(fields,fitsData);
+            }
             return syncFields(fields,makeRangeValuesFromFields(fields),fitsData);
             break;
 
@@ -76,6 +80,32 @@ const computeColorPanelState= function(fields, plottedRV, fitsData, band, action
 
 };
 
+/**
+ * For asinh algorithm if set upperRange that would enable to use full color range.
+ * Finds xMax for which 0.1 * asinh(Q*(xDataMax-xDataMin)/(xMax-xDataMin)) / asinh(0.1*Q) = 1
+ * @param fields
+ * @param fitsData
+ */
+function syncAsinhFields(fields,fitsData) {
+    // use double equal to handle string to number comparision
+    if (toBoolean(sessionStorage.getItem('autoAsinh')) && fields.algorithm.value == STRETCH_ASINH && fields.zscale.value !== 'zscale') {
+
+        const qvalue = Number.parseFloat(fields.asinhQ.value);
+
+        const xMax = fitsData.dataMin +
+            (fitsData.dataMax - fitsData.dataMin) * qvalue / Math.sinh(10 * Math.asinh(0.1 * qvalue));
+        if (xMax > fitsData.dataMin && xMax <= fitsData.dataMax) {
+            const newFields = clone(fields);
+
+            newFields.lowerRange= cloneWithValue(fields.lowerRange, 0);
+            newFields.lowerWhich = cloneWithValue(fields.lowerWhich, PERCENTAGE);
+            newFields.upperRange= cloneWithValue(fields.upperRange, xMax);
+            newFields.upperWhich = cloneWithValue(fields.upperWhich, ABSOLUTE);
+            return newFields;
+        }
+    }
+    return fields;
+}
 
 /**
  * Sync the fields so that are consistent with the passed RangeValues object.
@@ -179,7 +209,7 @@ const makeRangeValuesFromFields= function(fields) {
             fields.lowerRange.value,
             upperWhich,
             fields.upperRange.value,
-            fields.beta.value,
+            fields.asinhQ.value,
             fields.gamma.value,
             fields.algorithm.value,
             fields.zscaleContrast.value,
@@ -198,7 +228,7 @@ const updateFieldsFromRangeValues= function(fields,rv) {
     fields.lowerRange= cloneWithValue(fields.lowerRange, rv.lowerValue);
     fields.upperWhich= cloneWithValue(fields.upperWhich, rv.lowerWhich===ZSCALE ? PERCENTAGE : rv.upperWhich);
     fields.upperRange= cloneWithValue(fields.upperRange, rv.upperValue);
-    fields.beta= cloneWithValue(fields.beta, rv.betaValue);
+    fields.asinhQ= cloneWithValue(fields.asinhQ, rv.asinhQValue);
     fields.gamma= cloneWithValue(fields.gamma, rv.gammaValue);
     fields.algorithm= cloneWithValue(fields.algorithm, rv.algorithm);
     fields.zscaleContrast= cloneWithValue(fields.zscaleContrast, rv.zscaleContrast);
@@ -211,7 +241,7 @@ const updateFieldsFromRangeValues= function(fields,rv) {
 
 /**
  * defines fields
- * @return {{lowerRange: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, upperRange: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleContrast: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleSamples: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleSamplesPerLine: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, beta: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, gamma: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, BP: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, WP: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, algorithm: {tooltip: string, label: string, value}, lowerWhich: {tooltip: string, label: string, value}, upperWhich: {tooltip: string, label: string, value}, zscale: {value: string, tooltip: string, label: string}}}
+ * @return {{lowerRange: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, upperRange: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleContrast: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleSamples: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleSamplesPerLine: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, asinhQ: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, gamma: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, BP: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, WP: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, algorithm: {tooltip: string, label: string, value}, lowerWhich: {tooltip: string, label: string, value}, upperWhich: {tooltip: string, label: string, value}, zscale: {value: string, tooltip: string, label: string}}}
  */
 var getFieldInit= function() {
 
@@ -252,18 +282,17 @@ var getFieldInit= function() {
             label: 'Samples per line:'
         },
 
-        beta: {
-            fieldKey: 'beta',
-            value: NaN,
-            validator: Validate.isPositiveFiniteNumber.bind(null, 'Beta'),
-            tooltip: 'an arbitrary "softness"',
-            label: 'Beta:'
+        asinhQ: {
+            fieldKey: 'asinhQ',
+            validator: Validate.floatRange.bind(null, 0, 30, 4, 'Q'),
+            tooltip: 'The asinh softening parameter. Small Q values result in a linear stretch. Large values make a log stretch.',
+            label: 'Q:'
         },
         gamma: {
             fieldKey: 'gamma',
             value: '2.0',
             validator: Validate.floatRange.bind(null, 0, 100, 4, 'Gamma'),
-            tooltip: ' The Gamma value of the Power Law Gamma Stretch',
+            tooltip: 'The Gamma value of the Power Law Gamma Stretch',
             label: 'Gamma:'
         },
 

--- a/src/firefly/js/visualize/ui/StretchDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/StretchDropDownView.jsx
@@ -29,7 +29,7 @@ import {showColorDialog} from './ColorDialog.jsx';
 
 
 function getLabel(rv,baseLabel) {
-    var algor= rv.algorithm;
+    const algor= rv.algorithm;
     switch (algor) {
         case STRETCH_LINEAR : return 'Linear: '+baseLabel;
         case STRETCH_LOG : return 'Log: '+baseLabel;
@@ -61,7 +61,7 @@ function changeStretch(pv,rv) {
  * @param algorithm
  */
 function stretchByZscaleAlgorithm(pv,currRV,algorithm) {
-    var newRv= Object.assign({},currRV);
+    const newRv= Object.assign({},currRV);
     newRv.algorithm= algorithm;
     newRv.upperWhich= ZSCALE;
     newRv.lowerWhich= ZSCALE;
@@ -80,20 +80,24 @@ function stretchByZscaleAlgorithm(pv,currRV,algorithm) {
  * @param sType
  * @param min
  * @param max
+ * @param asinhQ
  */
-function stretchByType(pv,currRV,sType,min,max) {
-    var newRv= Object.assign({},currRV);
+function stretchByType(pv,currRV,sType,min,max,asinhQ) {
+    const newRv= Object.assign({},currRV);
     newRv.upperWhich= sType;
     newRv.lowerWhich= sType;
     newRv.upperValue= max;
     newRv.lowerValue= min;
+    if (asinhQ) {
+        newRv.asinhQValue= asinhQ;
+    }
     changeStretch(pv,newRv);
 }
 
 
 export function StretchDropDownView({plotView:pv, toolbarElement}) {
-    var enabled= pv ? true : false;
-    var rv= primePlot(pv).plotState.getRangeValues();
+    const enabled= pv ? true : false;
+    const rv= primePlot(pv).plotState.getRangeValues();
     return (
         <SingleColumnMenu>
             <ToolbarButton text='Color stretch...'
@@ -114,36 +118,13 @@ export function StretchDropDownView({plotView:pv, toolbarElement}) {
                            tip='Z Scale Log-Log Stretch'
                            enabled={enabled} horizontal={false}
                            onClick={() => stretchByZscaleAlgorithm(pv,rv,STRETCH_LOGLOG)}/>
+            <ToolbarButton text='Z Scale Asinh Stretch'
+                           tip='Z Scale Asinh Stretch'
+                           enabled={enabled} horizontal={false}
+                           onClick={() => stretchByZscaleAlgorithm(pv,rv,STRETCH_ASINH)}/>
             <DropDownVerticalSeparator/>
 
-            <ToolbarButton text={getLabel(rv,'Stretch to 99%')}
-                           tip='Stretch range 1% to 99%'
-                           enabled={enabled} horizontal={false}
-                           onClick={() => stretchByType(pv,rv,PERCENTAGE,1,99)}/>
-            <ToolbarButton text={getLabel(rv,'Stretch to 98%')}
-                           tip='Stretch range 2% to 98%'
-                           enabled={enabled} horizontal={false}
-                           onClick={() => stretchByType(pv,rv,PERCENTAGE,2,98)}/>
-            <ToolbarButton text={getLabel(rv,'Stretch to 97%')}
-                           tip='Stretch range 3% to 97%'
-                           enabled={enabled} horizontal={false}
-                           onClick={() => stretchByType(pv,rv,PERCENTAGE,3,97)}/>
-            <ToolbarButton text={getLabel(rv,'Stretch to 95%')}
-                           tip='Stretch range 5% to 95%'
-                           enabled={enabled} horizontal={false}
-                           onClick={() => stretchByType(pv,rv,PERCENTAGE,5,95)}/>
-            <ToolbarButton text={getLabel(rv,'Stretch to 85%')}
-                           tip='Stretch range 15% to 85%'
-                           enabled={enabled} horizontal={false}
-                           onClick={() => stretchByType(pv,rv,PERCENTAGE,15,85)}/>
-            <ToolbarButton text={getLabel(rv,'Stretch -2 Sigma to 10 Sigma')}
-                           tip='Stretch -2 Sigma to 10 Sigma'
-                           enabled={enabled} horizontal={false}
-                           onClick={() => stretchByType(pv,rv,SIGMA,-2,10)}/>
-            <ToolbarButton text={getLabel(rv,'Stretch -1 Sigma to 30 Sigma')}
-                           tip='Stretch -1 Sigma to 30 Sigma'
-                           enabled={enabled} horizontal={false}
-                           onClick={() => stretchByType(pv,rv,SIGMA,-1,30)}/>
+            {enabled && <AlgorithmDependentItems {...{pv,rv}}/>}
         </SingleColumnMenu>
         );
 
@@ -153,3 +134,66 @@ StretchDropDownView.propTypes= {
     plotView : PropTypes.object,
     toolbarElement : PropTypes.object
 };
+
+function AlgorithmDependentItems({pv,rv}) {
+    const enabled = true;
+    if (rv.algorithm === STRETCH_ASINH) {
+        return (
+            <div>
+                <ToolbarButton text={getLabel(rv, 'Stretch with Q=4')}
+                               tip='Stretch range 1% to 80%, Q=4'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 1, 80, 4)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch with Q=6')}
+                               tip='Stretch range 1% to 80%, Q=6'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 1, 80, 6)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch with Q=8')}
+                               tip='Stretch range 1% to 80%, Q=8'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 1, 80, 8)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch with Q=10')}
+                               tip='Stretch range 1% to 80%, Q=10'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 1, 80, 10)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch with Q=12')}
+                               tip='Stretch range 1% to 80%, Q=12'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 1, 80, 12)}/>
+            </div>
+    );
+    } else {
+        return (
+            <div>
+                <ToolbarButton text={getLabel(rv, 'Stretch to 99%')}
+                               tip='Stretch range 1% to 99%'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 1, 99)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch to 98%')}
+                               tip='Stretch range 2% to 98%'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 2, 98)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch to 97%')}
+                               tip='Stretch range 3% to 97%'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 3, 97)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch to 95%')}
+                               tip='Stretch range 5% to 95%'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 5, 95)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch to 85%')}
+                               tip='Stretch range 15% to 85%'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, PERCENTAGE, 15, 85)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch -2 Sigma to 10 Sigma')}
+                               tip='Stretch -2 Sigma to 10 Sigma'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, SIGMA, -2, 10)}/>
+                <ToolbarButton text={getLabel(rv, 'Stretch -1 Sigma to 30 Sigma')}
+                               tip='Stretch -1 Sigma to 30 Sigma'
+                               enabled={enabled} horizontal={false}
+                               onClick={() => stretchByType(pv, rv, SIGMA, -1, 30)}/>
+            </div>
+        );
+    }
+}


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-14778

- Improved algorithm to calculate asinh stretch using Q parameter
- Added slider for Q parameter (with image refresh on slider change pause)
- Autofill range option (for non z-scale case) for cases when full data range can be used. This option works well for small images, but might not be appropriate for large images. 

Deployment to test: https://irsawebdev9.ipac.caltech.edu/dm-14778/firefly/