### PR TITLE
IRSA-1973:TimeSeries tool: Add workspace option to download dialog for packaging images

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -138,7 +138,7 @@ const converters = {
         webplotRequestCreator: getWebPlotRequestViaPTFIbe,
         shouldImagesBeDisplayed: () => {return true;},
         isTableUploadValid:isValidPTFTable,
-        downloadOptions: ptfDownloaderOptPanel,
+        //downloadOptions: ptfDownloaderOptPanel,
         yNamesChangeImage: [],
         showPlotTitle:getPlotTitle
     },
@@ -158,7 +158,7 @@ const converters = {
         webplotRequestCreator: getWebPlotRequestViaZTFIbe,
         shouldImagesBeDisplayed: () => {return true;},
         isTableUploadValid:isValidZTFTable,
-        downloadOptions: ztfDownloaderOptPanel,
+        //downloadOptions: ztfDownloaderOptPanel,
         yNamesChangeImage: [],
         showPlotTitle:getPlotTitle
     },

--- a/src/firefly/js/templates/lightcurve/LcDownloadPanel.jsx
+++ b/src/firefly/js/templates/lightcurve/LcDownloadPanel.jsx
@@ -1,0 +1,162 @@
+
+import React, {PureComponent} from 'react';
+import {set,  cloneDeep} from 'lodash';
+
+import {LC, } from './LcManager.js';
+
+import { DownloadButton} from '../../ui/DownloadDialog.jsx';
+import {DL_DATA_TAG} from './LcConverterFactory.js';
+import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
+import { getTypeData,WORKSPACE,validateFileName} from '../../ui/DownloadOptionsDialog.jsx';
+import {getTblInfoById} from '../../tables/TableUtil.js';
+import {DataTagMeta} from '../../tables/TableRequestUtil.js';
+import {makeTblRequest} from '../../tables/TableRequestUtil.js';
+import {dispatchPackage} from '../../core/background/BackgroundCntlr.js';
+import { IRSADownloadOptionPanel} from '../../ui/IRSADownloadOptionalPanel.jsx';
+import {SelectInfo} from '../../tables/SelectInfo.js';
+import {WS_SERVER_PARAM,getWorkspacePath} from  '../../visualize/WorkspaceCntlr.js';
+import {ServerParams} from '../../data/ServerParams.js';
+
+const currentTime =  (new Date()).toLocaleString('en-US', { hour12: false });
+
+export const LcDownloadPanel = (mission, cutoutSize) => {
+    const fKeyDef = {
+        fileName: {fKey: 'fileName', label: mission+':'},
+        location: {fKey: 'fileLocation', label: 'File Location:'},
+        wsSelect: {fKey: 'wsSelect', label: ''},
+        overWritable: {fKey: 'fileOverwritable', label: 'File overwritable: '}
+    };
+
+    const labelWidth = 110;
+    const defValues = {
+        [fKeyDef.fileName.fKey]: Object.assign(getTypeData(fKeyDef.fileName.fKey, `${mission}_Files: ${currentTime}`,
+            'Please enter a filename, a default name will be used if it is blank', fKeyDef.fileName.label, labelWidth), {validator: null}),
+        [fKeyDef.location.fKey]: Object.assign(getTypeData(fKeyDef.location.fKey, 'isLocal',
+            'select the location where the file is downloaded to', fKeyDef.location.label, labelWidth), {validator: null}),
+        [fKeyDef.wsSelect.fKey]: Object.assign(getTypeData(fKeyDef.wsSelect.fKey, '',
+            'workspace file system', fKeyDef.wsSelect.label, labelWidth), {validator: null}),
+        [fKeyDef.overWritable.fKey]: Object.assign(getTypeData(fKeyDef.overWritable.fKey, '0',
+            'File is overwritable', fKeyDef.overWritable.label, labelWidth), {validator: null})
+    };
+
+    const rParams = {fKeyDef, defValues};
+    const dlParams = getParamters(mission);
+
+    const onSearchSubmit = (options) => {
+        var {request, selectInfo} = getTblInfoById(LC.RAW_TABLE);
+        const {fileLocation, wsSelect, fileName} = options || {};
+        const isWorkspace = () => (fileLocation && fileLocation === WORKSPACE);
+        const {FileGroupProcessor} = dlParams;
+        /*If the default file name is used, the default file name is mission, some mission such as WISE/NEWWISE,
+          there is '/' in the name, it needs to be removed
+         */
+        const fName = fileName?fileName.replace('/', '_').split(':')[0]:'';
+        const dreq = makeTblRequest(FileGroupProcessor, fName, Object.assign(dlParams, {cutoutSize}, options));
+        dreq.Title = fName;
+        request = set(cloneDeep(request), DataTagMeta, DL_DATA_TAG);
+        if (isWorkspace()){
+            const fName = isWorkspace()?fileName.replace('/', '_').split(':')[0]:fileName;
+            const zipFileName = fName.replace('/', '_').split(':')[0] + '.zip';
+            if (!validateFileName(wsSelect, zipFileName) ) return false;
+            const params = {
+                wsCmd: ServerParams.WS_PUT_IMAGE_FILE,
+                [WS_SERVER_PARAM.currentrelpath.key]:getWorkspacePath(wsSelect, zipFileName),
+                [WS_SERVER_PARAM.newpath.key]: zipFileName,
+                [ServerParams.COMMAND]: ServerParams.WS_PUT_IMAGE_FILE,
+                [WS_SERVER_PARAM.should_overwrite.key]: true};
+            dispatchPackage(dreq, request, SelectInfo.newInstance(selectInfo).toString(), true, params);
+        }
+        else{
+            dispatchPackage(dreq, request, SelectInfo.newInstance(selectInfo).toString());
+        }
+
+    };
+
+
+    const children = (<div>
+            {cutoutSize &&
+            <ListBoxInputField
+                wrapperStyle={{marginTop: 5}}
+                fieldKey ='dlCutouts'
+                initialState = {{
+                    tooltip: 'Download Cutouts Option',
+                    label : 'Download:'
+                }}
+                options = {[
+                    {label: 'Specified Cutouts', value: 'cut'},
+                    {label: 'Original Images', value: 'orig'}
+                ]}
+                labelWidth = {110}
+            />
+            }
+            <ListBoxInputField
+                wrapperStyle={{marginTop: 5}}
+                fieldKey ='zipType'
+                initialState = {{
+                    tooltip: 'Zip File Structure',
+                    label : 'Zip File Structure:'
+                }}
+                options = {[
+                    {label: 'Structured (with folders)', value: 'folder'},
+                    {label: 'Flattened (no folders)', value: 'flat'}
+                ]}
+                labelWidth = {labelWidth}
+            />
+
+        </div>
+    );
+
+
+    return (
+
+        <DownloadButton>
+            <IRSADownloadOptionPanel
+                groupKey = {mission}
+                children = {children}
+                submitRequest = {(options)=>onSearchSubmit(options)}
+                title = {mission + ' Image Download Options'}
+                rParams={rParams}
+            />
+        </DownloadButton>
+
+    );
+
+};
+
+function getParamters(mission){
+    switch (mission.toLowerCase()){
+        case 'ptf':
+           return {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ptf image is ~33mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'PtfLcDownload',
+                ProductLevel:'l1',
+                schema:'images',
+                table:'level1'
+            };
+            break;
+        case 'ztf' :
+            return  {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ztf image is ~37mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'ZtfLcDownload',
+                ProductLevel:'sci',
+                schema:'products',
+                table:'sci'};
+            break;
+        default:
+            return  {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'LightCurveFileGroupsProcessor'
+            };
+    };
+
+
+}

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -1,15 +1,12 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get,  set, isNil} from 'lodash';
-import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
 import {getCellValue, getTblById, getColumnIdx, smartMerge, getColumns, COL_TYPE} from '../../../tables/TableUtil.js';
 import {makeFileRequest} from '../../../tables/TableRequestUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
-import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
-import {ValidationField} from '../../../ui/ValidationField.jsx';
-import {DL_DATA_TAG} from '../LcConverterFactory.js';
+
 
 
 const labelWidth = 80;
@@ -156,6 +153,7 @@ export function ptfOnFieldUpdate(fieldKey, value) {
  * @param cutoutSizeInDeg
  * @returns {XML}
  */
+/*
 export function ptfDownloaderOptPanel (mission, cutoutSizeInDeg) {
     const currentTime = (new Date()).toLocaleString('en-US', { hour12: false });
 
@@ -189,4 +187,4 @@ export function ptfDownloaderOptPanel (mission, cutoutSizeInDeg) {
             </DownloadOptionPanel>
         </DownloadButton>
     );
-}
+}*/

--- a/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
@@ -1,15 +1,12 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get,  set, isNil} from 'lodash';
-import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
 import {getCellValue, getTblById, getColumnIdx, smartMerge, getColumns, COL_TYPE} from '../../../tables/TableUtil.js';
 import {makeFileRequest} from '../../../tables/TableRequestUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
-import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
-import {ValidationField} from '../../../ui/ValidationField.jsx';
-import {DL_DATA_TAG} from '../LcConverterFactory.js';
+
 
 
 const labelWidth = 80;
@@ -155,6 +152,7 @@ export function ztfOnFieldUpdate(fieldKey, value) {
  * @param cutoutSizeInDeg
  * @returns {XML}
  */
+/*
 export function ztfDownloaderOptPanel (mission, cutoutSizeInDeg) {
     const currentTime = (new Date()).toLocaleString('en-US', { hour12: false });
 
@@ -188,4 +186,4 @@ export function ztfDownloaderOptPanel (mission, cutoutSizeInDeg) {
             </DownloadOptionPanel>
         </DownloadButton>
     );
-}
+}*/

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -92,7 +92,7 @@ export class DownloadButton extends PureComponent {
     onClick() {
         const {tbl_id, selectInfo={}} = this.state;
         const selectInfoCls = SelectInfo.newInstance(selectInfo);
-        if (selectInfoCls.getSelectedCount()) {
+        if (selectInfoCls.getSelectedCount() || !this.props.requiredColsCount) {
             var panel = this.props.children ? React.Children.only(this.props.children) : <DownloadOptionPanel/>;
             panel = React.cloneElement(panel, {tbl_id});
             showDownloadDialog(panel);
@@ -105,12 +105,13 @@ export class DownloadButton extends PureComponent {
         const {selectInfo={}} = this.state;
         const selectInfoCls = SelectInfo.newInstance(selectInfo);
         const style = selectInfoCls.getSelectedCount() ? 'button std attn' : 'button std hl';
+        const buttonText = this.props.text||'Prepare Download';
         return (
             <button style={{display: 'inline-block'}}
                     type = 'button'
                     className = {style}
                     onClick = {this.onClick}
-            >Prepare Download</button>
+            >{buttonText}</button>
         );
     }
 }
@@ -119,8 +120,13 @@ export class DownloadButton extends PureComponent {
 DownloadButton.propTypes = {
     tbl_id      : PropTypes.string,
     tbl_grp     : PropTypes.string,
+    text        : PropTypes.string,
+    requiredColsCount: PropTypes.bool
 };
 
+DownloadButton.defaultProps = {
+    requiredColsCount: true
+};
 
 export class DownloadOptionPanel extends SimpleComponent {
 
@@ -252,7 +258,7 @@ DownloadOptionPanel.defaultProps= {
  * @param {Component}  panel  the panel to show in the popup.
  * @param {boolean} [show=true] show or hide this dialog
  */
-function showDownloadDialog(panel, show=true) {
+export function showDownloadDialog(panel, show=true) {
     const ttl = panel.props.title || DOWNLOAD_DIALOG_ID;
     if (show) {
         const content= (

--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -159,20 +159,21 @@ export class DownloadOptionsDialog extends PureComponent {
 
         return (
             <div style={{height: '100%', width: '100%'}}>
-                <div>
-                    {children}
-                </div>
                 <ValidationField
                     wrapperStyle={{marginTop: 10}}
                     size={40}
                     fieldKey={'fileName'}
                 />
-
+                <div>
+                    {children}
+                </div>
+                
                 {this.workspace && showLocation()}
 
                 <div  style={{width: dialogWidth, height: dialogHeight}}>
                     {where === WORKSPACE && showWorkspace()}
                 </div>
+
             </div>
         );
     }

--- a/src/firefly/js/ui/IRSADownloadOptionalPanel.jsx
+++ b/src/firefly/js/ui/IRSADownloadOptionalPanel.jsx
@@ -1,0 +1,185 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+import {DownloadOptionsDialog, fileNameValidator, WORKSPACE, LOCALFILE} from './DownloadOptionsDialog.jsx';
+
+import {getWorkspaceConfig,isWsFolder, isValidWSFolder,
+   dispatchWorkspaceUpdate} from  '../visualize/WorkspaceCntlr.js';
+import {workspacePopupMsg} from './WorkspaceViewer.jsx';
+import {FieldGroup} from './FieldGroup.jsx';
+import {get,set} from 'lodash';
+import {updateSet} from '../util/WebUtil.js';
+import {SimpleComponent} from './SimpleComponent.jsx';
+import FieldGroupUtils,{getFieldVal,getGroupFields} from '../fieldGroup/FieldGroupUtils.js';
+import {getBgEmailInfo} from '../core/background/BackgroundUtil.js';
+import {dispatchBgSetEmailInfo} from '../core/background/BackgroundCntlr.js';
+import Validate from '../util/Validate.js';
+import {dispatchHideDialog} from '../core/ComponentCntlr.js';
+import {showDownloadDialog} from './DownloadDialog';
+import {InputField} from './InputField.jsx';
+import FieldGroupCntlr from '../fieldGroup/FieldGroupCntlr.js';
+
+
+import {FormPanel} from './FormPanel.jsx';
+
+const DOWNLOAD_DIALOG_ID = 'Download Panel';
+
+export class IRSADownloadOptionPanel extends SimpleComponent {
+
+  getNextState() {
+    const fields=FieldGroupUtils.getGroupFields(this.props.groupKey);
+    const {email, enableEmail} = getBgEmailInfo();
+    const currentFileLocation = getFieldVal(fields, 'fileLocation', LOCALFILE);
+    return {fields, mask:false, email, enableEmail,currentFileLocation};
+  }
+
+  componentDidUpdate(oldState) {
+    if (oldState.currentFileLocation!==WORKSPACE && this.state.currentFileLocation=== WORKSPACE) {
+      dispatchWorkspaceUpdate();
+    }
+  }
+  onEmailChanged(v) {
+    if (get(v, 'valid')) {
+      const {email} = this.state;
+      if (email !== v.value) dispatchBgSetEmailInfo({email: v.value});
+    }
+  }
+
+  render() {
+
+
+
+     const { groupKey, children, rParams, submitRequest, title,  help_id, style}= this.props;
+     const { mask, email, enableEmail} = this.state;
+      const ttl = title || DOWNLOAD_DIALOG_ID;
+      const toggleEnableEmail = (e) => {
+          const enableEmail = e.target.checked;
+          const email = enableEmail ? email : '';
+          dispatchBgSetEmailInfo({email, enableEmail});
+      };
+      const isWs = getWorkspaceConfig();
+      const onSubmit = (options) => {
+
+          submitRequest(options);
+          showDownloadDialog(this, false);
+      };
+
+    return (
+        <div style = {Object.assign({margin: '4px', position: 'relative', minWidth: 350}, style)}>
+            {mask && <div style={{width: '100%', height: '100%'}} className='loading-mask'/>}
+        <FormPanel
+            submitText = 'Prepare Download'
+            groupKey = {groupKey}
+            onSubmit = {onSubmit}
+            onCancel = {() => dispatchHideDialog(ttl)}
+            onError = { resultsFail()}
+            help_id  = {help_id}
+         >
+
+          <FieldGroup groupKey={groupKey} keepState={true}
+                      reducerFunc= { DLReducer(rParams, groupKey)} >
+
+
+
+            <DownloadOptionsDialog fromGroupKey={groupKey}
+                                   workspace={isWs}
+                                   dialogWidth={'100%'}
+                                   dialogHeight={'calc(100% - 200pt)'}
+                                   children={children}
+            />
+              <div style={{width: 250, marginTop: 10}}>
+                  <input type='checkbox' checked={enableEmail} onChange={toggleEnableEmail}/>Also send me email with URLs to download
+              </div>
+              {showEmail(enableEmail, email,this.onEmailChanged.bind(this))}
+          </FieldGroup>
+        </FormPanel>
+        </div>
+    );
+  }
+}
+
+
+IRSADownloadOptionPanel.propTypes = {
+        groupKey:   PropTypes.string,
+        onSubmit:  PropTypes.func,
+        tbl_id:     PropTypes.string,
+        cutoutSize: PropTypes.string,
+        help_id:    PropTypes.string,
+        title:      PropTypes.string
+};
+
+IRSADownloadOptionPanel.defaultProps= {
+    groupKey: 'IRSADownloadOptionPanel'
+};
+
+const showEmail = (enabled, email, onChange)=>{
+    if(enabled) {
+        return (
+            <InputField
+                validator={Validate.validateEmail.bind(null, 'an email field')}
+                tooltip='Enter an email to be notified when a process completes.'
+                label='Email:'
+                labelStyle={{display: 'inline-block', marginLeft: 18, width: 32, fontWeight: 'bold'}}
+                value={email}
+                placeholder='Enter an email to get notification'
+                style={{width: 170}}
+                onChange={onChange}
+                actOn={['blur','enter']}
+            />
+        );
+    }
+    else{
+        return (<div></div>);
+    }
+
+};
+
+function resultsFail() {
+    return (request) => {
+        const {wsSelect, fileLocation} = request;
+
+        if (fileLocation === WORKSPACE) {
+            if (!wsSelect) {
+                workspacePopupMsg('please select a workspace folder', 'Save to workspace');
+            } else {
+                const isAFolder = isValidWSFolder(wsSelect);
+                if (!isAFolder.valid) {
+                    workspacePopupMsg(isAFolder.message, 'Save to workspace');
+                }
+            }
+        }
+    };
+}
+
+
+function DLReducer(rParams, groupKey) {
+    const {fKeyDef, defValues} = rParams;
+    return (inFields, action) => {
+
+        if (!inFields) {
+            const defV = Object.assign({}, defValues);
+            set(defV, [fKeyDef.wsSelect.fKey, 'value'], '');
+            set(defV, [fKeyDef.wsSelect.fKey, 'validator'], isWsFolder());
+            set(defV, [fKeyDef.fileName.fKey, 'validator'], fileNameValidator(groupKey));
+            return defV;
+        } else {
+            if (action.type===FieldGroupCntlr.VALUE_CHANGE) {
+
+                if (action.payload.fieldKey === fKeyDef.wsSelect.fKey) {
+                    // change the filename if a file is selected from the file picker
+                    const val = action.payload.value;
+
+                    if (val && isValidWSFolder(val, false).valid) {
+                        const fName = val.substring(val.lastIndexOf('/') + 1);
+
+                        inFields = updateSet(inFields, [fKeyDef.fileName.fKey, 'value'], fName);
+                    }
+                }
+
+            }
+            return Object.assign({}, inFields);
+        }
+    };
+}
+


### PR DESCRIPTION
  1. Refactor workspace downloaded related codes
  2. Changed the DownloadButton's property in DowloadDialog
  3. Added a new class IRSADownloadOptionPanel which is used by Finderchart and Time Series
  4. Added LcDownloadPanel which will be used by ptf, ztf, wise and all other missions.
  5. Removed the defaultPanel, ZTFDownloadPanel, PTFDownloadPanel
  7. Add min/max in SizeInputFields since they are required fields

I introduced two new classes, one I named IRSADownloadOptionPanel which is used by Finderchart and Time Series.  In order to make the workspace download work, I also modified BackgroundCntlr.js. @loitly Please check what I did is appropriate.   

To test Time Series:
https://irsawebdev9.ipac.caltech.edu/irsa-1973/irsaviewer/

To test Finderchart
URL: https://irsawebdev9.ipac.caltech.edu/irsa-1973/applications/finderchart/