### PR TITLE
DM-15215: support an initial scroll position for the images

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
@@ -100,6 +100,7 @@ public class WebPlotRequest extends ServerRequest {
     public static final String THUMBNAIL_SIZE = "thumbnailSize";
     public static final String PIPELINE_ORDER = "pipelineOrder"; // todo: convert, doc, add to allKeys
     public static final String URL_CHECK_FOR_NEWER = "urlCheckForNewer"; // todo: convert, doc, add to allKeys
+    public static final String INITIAL_CENTER_POSITION= "InitialCenterPosition";
 
     public static final String MASK_BITS= "MaskBits";
     public static final String PLOT_AS_MASK= "PlotAsMask";
@@ -155,7 +156,8 @@ public class WebPlotRequest extends ServerRequest {
                                               GRID_ON, TITLE_OPTIONS, EXPANDED_TITLE_OPTIONS,
                                               POST_TITLE, PRE_TITLE, OVERLAY_POSITION,
                                               TITLE_FILENAME_MODE_PFX, MINIMAL_READOUT, DRAWING_SUB_GROUP_ID, GRID_ID,
-                                              DOWNLOAD_FILENAME_ROOT, PLOT_ID, ROTATE_FROM_NORTH
+                                              DOWNLOAD_FILENAME_ROOT, PLOT_ID, ROTATE_FROM_NORTH,
+                                              INITIAL_CENTER_POSITION
 
     };
 
@@ -169,7 +171,8 @@ public class WebPlotRequest extends ServerRequest {
                                                      POST_TITLE, PRE_TITLE, OVERLAY_POSITION,
                                                      TITLE_FILENAME_MODE_PFX, MINIMAL_READOUT,
                                                      DRAWING_SUB_GROUP_ID, GRID_ID,
-                                                     DOWNLOAD_FILENAME_ROOT, PLOT_ID
+                                                     DOWNLOAD_FILENAME_ROOT, PLOT_ID, INITIAL_CENTER_POSITION
+
     };
 
 

--- a/src/firefly/js/visualize/CoordSys.js
+++ b/src/firefly/js/visualize/CoordSys.js
@@ -66,6 +66,10 @@ export const CoordinateSys = function () {
             coordSys = ECL_J2000;
         } else if (desc===ECL_B1950.toString() || desc==='ECB') {
             coordSys = ECL_B1950;
+        } else if (desc===SCREEN_PIXEL.toString()) {
+            coordSys = SCREEN_PIXEL;
+        } else if (desc===PIXEL.toString()) {
+            coordSys = PIXEL;
         } else {
             coordSys = null;
         }

--- a/src/firefly/js/visualize/Point.js
+++ b/src/firefly/js/visualize/Point.js
@@ -200,34 +200,26 @@ export class WorldPt {
 }
 
 
+/**
+ *
+ * @param {Array.<String>} wpParts
+ * @return {*}
+ */
 function stringAryToWorldPt(wpParts) {
-    let retval= null;
-    let parsedLon;
-    let parseLat;
-    let parsedCoordSys;
-    if (wpParts.length===3) {
-        parsedLon= Number(wpParts[0]);
-        parseLat= Number(wpParts[1]);
-        parsedCoordSys= CoordinateSys.parse(wpParts[2]);
-        if (!isNaN(parsedLon) && !isNaN(parseLat) && parsedCoordSys!==null) {
-            retval= makeWorldPt(parsedLon,parseLat,parsedCoordSys);
-        }
-    }
-    else if (wpParts.length===2) {
-        parsedLon= Number(wpParts[0]);
-        parseLat= Number(wpParts[1]);
-        if (!isNaN(parsedLon) && !isNaN(parseLat)) {
-            retval= makeWorldPt(parsedLon,parseLat);
-        }
-    }
-    else if (wpParts.length===5 || wpParts.length===4) {
-        parsedLon= Number(wpParts[0]);
-        parseLat= Number(wpParts[1]);
-        parsedCoordSys= CoordinateSys.parse(wpParts[2]);
-        const resolver= wpParts.length===5 ? parseResolver(wpParts[4]) : Resolver.UNKNOWN;
-        return makeWorldPt(parsedLon,parseLat,parsedCoordSys, wpParts[3],resolver);
-    }
-    return retval;
+    const len= wpParts.length;
+    const x= Number(wpParts[0]);
+    const y= Number(wpParts[1]);
+    if  (isNaN(x) || isNaN(y)) return null;
+
+    const csys= CoordinateSys.parse(wpParts[2]);
+
+    if (csys===CoordinateSys.PIXEL)        return makeImagePt(x, y); // image point
+    if (csys===CoordinateSys.SCREEN_PIXEL) return makeScreenPt(x, y); // screen point
+
+    if (len===2 || len===3) return makeWorldPt(x,y,csys);
+
+    const resolver= wpParts[4] ? parseResolver(wpParts[4]) : Resolver.UNKNOWN;
+    return makeWorldPt(x,y,csys, wpParts[3], resolver);
 }
 
 /**

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -57,6 +57,11 @@ export const PlotAttribute= {
     FIXED_TARGET: 'FIXED_TARGET',
 
     /**
+     *
+     */
+    INIT_CENTER: 'INIT_CENTER',
+
+    /**
      * This will probably be a double with the requested size of the plot
      */
     REQUESTED_SIZE: 'REQUESTED_SIZE',

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -140,6 +140,7 @@ const C= {
     HAS_NEW_PLOT_CONTAINER : 'HasNewPlotContainer',
     GRID_ON : 'GridOn',
     OVERLAY_POSITION : 'OverlayPosition',
+    INITIAL_CENTER_POSITION : 'InitialCenterPosition',
     MINIMAL_READOUT: 'MinimalReadout',
     PLOT_GROUP_ID: 'plotGroupId',
     GROUP_LOCKED: 'GroupLocked',
@@ -187,7 +188,7 @@ const clientSideKeys =
          C.MINIMAL_READOUT,
          C.PLOT_GROUP_ID, C.DRAWING_SUB_GROUP_ID,  C.RELATED_TABLE_ROW,
          C.DOWNLOAD_FILENAME_ROOT, C.PLOT_ID, C.GROUP_LOCKED,
-         C.OVERLAY_IDS
+         C.OVERLAY_IDS, C.INITIAL_CENTER_POSITION
         ];
 
 const ignoreForEquals = [C.PROGRESS_KEY, C.ZOOM_TO_WIDTH, C.ZOOM_TO_HEIGHT,
@@ -611,6 +612,20 @@ export class WebPlotRequest extends ServerRequest {
      * @return {WorldPt}
      */
     getOverlayPosition() { return this.getWorldPtParam(C.OVERLAY_POSITION); }
+
+    /**
+     * @param {WorldPt|String} worldPt - the point object of the position to scroll image to when loaded
+     */
+    setInitialCenterPosition(worldPt) {
+        this.setParam(C.INITIAL_CENTER_POSITION, worldPt ? worldPt.toString() : false);
+    }
+
+    /**
+     *
+     * @return {WorldPt}
+     */
+    getInitialCenterPosition() { return this.getWorldPtParam(C.INITIAL_CENTER_POSITION); }
+
 
 //======================================================================
 //----------------------- Color Settings ------------------------------

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -580,7 +580,7 @@ function recenterPv(centerPt,  centerOnImage) {
                 centerImagePt = makeWorldPt(centerPt.x, centerPt.y);
             }
         } else {
-            const wp = plot.attributes[PlotAttribute.FIXED_TARGET];
+            const wp = plot.attributes[PlotAttribute.INIT_CENTER] || plot.attributes[PlotAttribute.FIXED_TARGET] ;
             if (wp && !centerOnImage) {
                 centerImagePt = CCUtil.getImageCoords(plot, wp);
             }

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -458,6 +458,13 @@ function getNewAttributes(plot) {
             if (circle) attributes[PlotAttribute.REQUESTED_SIZE]= circle.radius;  // says radius but really size
         }
     }
+
+    if (req.containsParam(WPConst.INITIAL_CENTER_POSITION)) {
+        attributes[PlotAttribute.INIT_CENTER]= req.getInitialCenterPosition();
+    }
+
+
+
     if (req.getUniqueKey())     attributes[PlotAttribute.UNIQUE_KEY]= req.getUniqueKey();
     if (req.isMinimalReadout()) attributes[PlotAttribute.MINIMAL_READOUT]=true;
 

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -26,6 +26,7 @@ import {modifyRequestForWcsMatch} from './WcsMatchTask.js';
 import WebGrid from '../../drawingLayers/WebGrid.js';
 import HiPSGrid from '../../drawingLayers/HiPSGrid.js';
 import {getDlAry} from '../DrawLayerCntlr.js';
+import {dispatchRecenter} from '../ImagePlotCntlr';
 
 //======================================== Exported Functions =============================
 //======================================== Exported Functions =============================
@@ -291,7 +292,10 @@ export function processPlotImageSuccessResponse(dispatcher, payload, result) {
 
         pvNewPlotInfoAry
             .forEach((info) => info.plotAry
-                .forEach( (p)  => addDrawLayers(p.plotState.getWebPlotRequest(), p) ));
+                .forEach( (p)  => {
+                    addDrawLayers(p.plotState.getWebPlotRequest(), p);
+                    if (p.attributes[PlotAttribute.INIT_CENTER]) dispatchRecenter({plotId:p.plotId});
+                } ));
 
 
 


### PR DESCRIPTION
Loan an image with an initial position

_to test:_

This must be tested from python using the slate.html entry point.  I loaded the `firefly_client/demo/basic-demo` jupyter notebook.

I modified the two cells the first to start slate.html


`fc = FireflyClient('http://127.0.0.1:8080/firefly', html_file='slate.html')`

then later when I loaded an image.

`status = fc.show_fits(file_on_server=imval, plot_id="wise-cutout", title='WISE Cuteout', InitialCenterPosition='5;5;PIXEL', InitZoomLevel='5', ZoomType='STANDARD')`

The `InitialCenterPosition` should be in the middle of the screen.