### PR TITLE
DM-15399 Fix the MOC display in Galatic coordinate system

### DIFF
--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -407,12 +407,11 @@ export function getAllVisibleHiPSCells (norder, centerWp, fov, dataCoordSys) {
 
         return cells.filter( (cell) =>{
             const {wpCorners}= cell;
-            const visibleCorner = wpCorners.find((oneCorner) => computeDistance(centerWp, oneCorner) < 90);
+            const visibleCorner = wpCorners.find((oneCorner) => computeDistance(dataCenterWp, oneCorner) < 90);
 
             return visibleCorner;
 
         });
-        return filterAllSky(dataCenterWp, healpixCache.getFullCellList(norder,dataCoordSys));
     } else { // get only the healpix number for the fov and create the cell list
         const nside = 2**norder;
         const pixList = getHealpixIndex(nside).queryDisc(makeSpatialVector(dataCenterWp), getSearchRadiusInRadians(fov), true, true);


### PR DESCRIPTION
this development fixed the MOC display bugs in Galactic coordinate system by converting the world point with the same coordinate system as that of the project center while finding some pixel alongside the great circle passing the given projection center and a world point. 

test: 
do hips image search and get moc display in galactic coordinate system. 