### PR TITLE
IRSA-2067: FileInfoProcessor need to take into consideration login status when caching

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/BaseFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/BaseFileInfoProcessor.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.firefly.core.SearchDescResolver;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.table.TableMeta;
 import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.DataType;
 import edu.caltech.ipac.util.StringUtils;
@@ -66,7 +67,8 @@ public abstract class BaseFileInfoProcessor implements SearchProcessor<FileInfo>
     }
 
     public String getUniqueID(ServerRequest request) {
-        return request.getRequestId() + "-" + StringUtils.toString(request.getParams());
+        String id = ServerContext.getRequestOwner().isAuthUser() ? ServerContext.getRequestOwner().getUserInfo().getLoginName() : "";
+        return request.getRequestId() + "-" + id + "-" + StringUtils.toString(request.getParams());
     }
 
     public FileInfo writeData(OutputStream out, ServerRequest request) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/FileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/FileGroupsProcessor.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.firefly.core.SearchDescResolver;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.table.TableMeta;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.util.Logger;
@@ -92,7 +93,8 @@ abstract public class FileGroupsProcessor implements SearchProcessor<List<FileGr
     }
 
     public String getUniqueID(ServerRequest request) {
-        return request.getRequestId() + "-" + StringUtils.toString(request.getParams());
+        String id = ServerContext.getRequestOwner().isAuthUser() ? ServerContext.getRequestOwner().getUserInfo().getLoginName() : "";
+        return request.getRequestId() + "-" + id + "-" + StringUtils.toString(request.getParams());
     }
 
     public FileInfo writeData(OutputStream out, ServerRequest request) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
@@ -78,6 +78,9 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
                     params.addCookie(key, identityCookies.get(key));
                 }
             }
+            if (ServerContext.getRequestOwner().isAuthUser()) {
+                params.setLoginName(ServerContext.getRequestOwner().getUserInfo().getLoginName());
+            }
             retval= LockingVisNetwork.retrieveURL(params);
             if (retval.getResponseCode()>=500) {
                 File f= new File(retval.getInternalFilename());

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
@@ -47,8 +47,10 @@ public class AnyUrlParams extends BaseNetParams {
             securCookie= "-"+ cookies.get(_securityCookie);
         }
 
-        String baseKey= loginName+ securCookie +"-"+ fileStr;
-        int originalHashCode = (_url.getHost()+ baseKey).hashCode();
+        // since this string is limited to MAX_LENGTH, having loginName in the baseKey is not ideal
+        // loginName can be long.  it'll be used in hashcode calculation instead.
+        String baseKey = securCookie +"-"+ fileStr;
+        int originalHashCode = (_url.getHost() + loginName + baseKey).hashCode();
         baseKey= baseKey.replaceAll("[ :\\[\\]\\/\\\\|\\*\\?\\+<>]", "");
 
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2067

To test, using irsadev Gator, download a light curve table.
-> login as someone with ztf access -> click example link -> To Time Series Tool -> Download Light Curve Table

Goto https://irsawebdev9.ipac.caltech.edu/irsa-2067/irsaviewer/timeseries
You should be logged in as the same user.
-> upload previously downloaded file -> select ztf -> upload 
-> navigate through table rows to load protected images -> logout
-> as guest user -> upload same file -> select ztf -> upload 
the images are no longer loading because they are protected and cannot be view by user without privileges

Doing the same test in IRSA ops will reveal the security breach.

@robyww, when you have time next week, it would be nice if you can take a look at the changes to ensure that it does not impact anything else.

Also, you may want to take a look at the current implementation of edu.caltech.ipac.visualize.net.AnyUrlParams#getUniqueString
It's used as a cache key as well as filename.  When favoring for a shorter filename, it deceases the uniqueness of the cache key.