### PR TITLE
DM-15225: docker container should not run as root by default

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -17,6 +17,16 @@ RUN apt-get update && apt-get install -y \
         && rm -rf var/lib/apt/lists//*
 
 
+# create catalina_base directory .. so tomcat can run as non-root
+ENV CATALINA_HOME=/usr/local/tomcat
+ENV CATALINA_BASE=/usr/local/tomcat-base
+WORKDIR ${CATALINA_BASE}
+RUN chmod g-s ${CATALINA_BASE} && \
+    mkdir bin conf lib logs temp webapps work && \
+    cp ${CATALINA_HOME}/conf/* ${CATALINA_BASE}/conf/ && \
+    chmod +rw ${CATALINA_BASE}/conf/*
+
+
 # These environment varibles are not really made to be overridden
 # they can be but are mostly for setup
 ENV JPDA_ADDRESS=5050
@@ -24,8 +34,8 @@ ENV CATALINA_PID=${CATALINA_BASE}/bin/catalina.pid
 
 # work dir and config dir might be overridden if they were used in a mounted volume
 # in the case make sure the directories exist
-ENV SERVER_CONFIG_DIR=/usr/local/tomcat/firefly-config
-ENV FIREFLY_WORK_DIR=/usr/local/tomcat/firefly-work
+ENV SERVER_CONFIG_DIR=${CATALINA_BASE}/firefly-config
+ENV FIREFLY_WORK_DIR=${CATALINA_BASE}/firefly-work
 ENV EXTERNAL_MOUNT_POINT=/external
 ENV VISUALIZE_FITS_SEARCH_PATH=${EXTERNAL_MOUNT_POINT}
 
@@ -33,31 +43,30 @@ ENV VISUALIZE_FITS_SEARCH_PATH=${EXTERNAL_MOUNT_POINT}
 ARG IMAGE_NAME=''
 ENV BUILD_TIME_NAME=${IMAGE_NAME}
 
+
+
 # These are the file there are executed at startup, they start tomcat
 COPY launchTomcat.sh \
      start-examples.txt \
-     setupSharedCacheJars.sh /usr/local/tomcat/
-
-# Make directories, make scripts executable, save old tomcat config files, remove unwanted apps
-RUN chmod +x /usr/local/tomcat/launchTomcat.sh /usr/local/tomcat/setupSharedCacheJars.sh; \
-    mv /usr/local/tomcat/conf/context.xml /usr/local/tomcat/conf/context.xml.bak; \
-    mv /usr/local/tomcat/conf/tomcat-users.xml /usr/local/tomcat/conf/tomcat-users.xml.bak; \
-    rm -rf /usr/local/tomcat/webapps/examples \
-           /usr/local/tomcat/webapps/docs \
-           /usr/local/tomcat/webapps/host-manager \
-           /usr/local/tomcat/webapps/ROOT; \
-    mkdir -p ${SERVER_CONFIG_DIR}; \
-    mkdir -p ${FIREFLY_WORK_DIR}; \
-    mkdir -p ${EXTERNAL_MOUNT_POINT}
-
+     setupSharedCacheJars.sh ${CATALINA_BASE}/
 
 # Tomcat config files, tomcat-users is for the admin username and password
 # context.xml set delegate to true for we can use the classpath of tomcat
 COPY tomcat-users.xml \
-     context.xml  /usr/local/tomcat/conf/
+     context.xml  ${CATALINA_BASE}/conf/
+
+
+# Make directories, make scripts executable, save old tomcat config files, remove unwanted apps
+RUN chmod +x ${CATALINA_BASE}/launchTomcat.sh ${CATALINA_BASE}/setupSharedCacheJars.sh; \
+    mkdir -p ${SERVER_CONFIG_DIR}; \
+    mkdir -p ${FIREFLY_WORK_DIR}; \
+    mkdir -p ${EXTERNAL_MOUNT_POINT}; \
+    chmod 777 bin conf lib logs temp webapps work ${SERVER_CONFIG_DIR} ${FIREFLY_WORK_DIR}; \
+    mv ${CATALINA_BASE}/conf/tomcat-users.xml ${CATALINA_BASE}/conf/tomcat-users.xml.in
+
 
 # setenv.sh is used to defined CATALINA_OPTS and JAVA_OPTS
-COPY setenv.sh /usr/local/tomcat/bin/
+COPY setenv.sh ${CATALINA_BASE}/bin/
 
 # 8080 - http
 # 5050 - debug
@@ -100,9 +109,13 @@ ENV FIREFLY_OPTS=''
 ENV SHARE_CACHE=FALSE
 
 
-
 #copy all wars, typically there should only be one
-COPY *.war /usr/local/tomcat/webapps/
+COPY *.war ${CATALINA_BASE}/webapps/
+
+RUN groupadd -g 91 tomcat && \
+    useradd -r -u 91 -g tomcat tomcat
+
+USER tomcat:tomcat
 
 #CMD ["bin/catalina.sh","jpda", "run"]
 #CMD ["/bin/bash", "./launchTomcat.sh"]

--- a/docker/base/launchTomcat.sh
+++ b/docker/base/launchTomcat.sh
@@ -49,7 +49,7 @@ echo "        8080 - http"
 echo "        5050 - debug"
 echo
 echo "Volume Mount Points: "
-echo "        Log directory : /usr/local/tomcat/logs : Directory for logs files"
+echo "        Log directory : ${CATALINA_BASE}/logs : Directory for logs files"
 echo "        Local Images  : /local/data : Root directory for images and tables that firefly can read"
 echo
 echo "Command line options: "
@@ -57,12 +57,10 @@ echo "        --help  : show help message, examples, stop"
 echo "        --debug : start in debug mode"
 
 
-userFile=/usr/local/tomcat/conf/tomcat-users.xml
-sed "s/USER/${ADMIN_USER}/" ${userFile} | sed "s/PASSWORD/${ADMIN_PASSWORD}/" > u.tmp
-mv u.tmp ${userFile}
+sed "s/USER/${ADMIN_USER}/" ${CATALINA_BASE}/conf/tomcat-users.xml.in | sed "s/PASSWORD/${ADMIN_PASSWORD}/" > ${CATALINA_BASE}/conf/tomcat-users.xml
 
 if [ "x$LOG_FILE_TO_CONSOLE" != "x" ]; then
-     logFile=/usr/local/tomcat/logs/${LOG_FILE_TO_CONSOLE}
+     logFile=${CATALINA_BASE}/logs/${LOG_FILE_TO_CONSOLE}
      touch $logFile
      tail -f $logFile &
 fi
@@ -80,16 +78,16 @@ if [ "$SHARE_CACHE" = "true" ] ||[ "$SHARE_CACHE" = "t" ] ||[ "$SHARE_CACHE" = "
    ./setupSharedCacheJars.sh
 fi
 
-if [ "$MANAGER" != "true" ] && [ "$MANAGER" != "t" ] && [ "$MANAGER" != "1" ] &&  \
-   [ "$MANAGER" != "TRUE" ] && [ "$MANAGER" != "True" ] ; then
-   rm -r /usr/local/tomcat/webapps/manager
+if [ "$MANAGER" = "true" ] || [ "$MANAGER" = "t" ] || [ "$MANAGER" = "1" ] ||  \
+   [ "$MANAGER" = "TRUE" ] || [ "$MANAGER" = "True" ] ; then
+   cp -r ${CATALINA_HOME}/webapps/manager ${CATALINA_BASE}/webapps/
 fi
 
 
 
 if [ "$DEBUG" = "true" ] ||[ "$DEBUG" = "t" ] ||[ "$DEBUG" = "1" ] ||  \
    [ "$DEBUG" = "TRUE" ] || [ "$DEBUG" = "True" ] || [ "$1" = "--debug" ]; then
-     exec /usr/local/tomcat/bin/catalina.sh jpda run
+     exec ${CATALINA_HOME}/bin/catalina.sh jpda run
 else
-     exec /usr/local/tomcat/bin/catalina.sh run
+     exec ${CATALINA_HOME}/bin/catalina.sh run
 fi

--- a/docker/base/setupSharedCacheJars.sh
+++ b/docker/base/setupSharedCacheJars.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-tcDir=/usr/local/tomcat
+tmpDir=${CATALINA_BASE}/temp
 webLib=WEB-INF/lib
-mkdir ${tcDir}/tmpUnzip
-cd ${tcDir}/tmpUnzip
+mkdir ${tmpDir}/tmpUnzip
+cd ${tmpDir}/tmpUnzip
 
-aWarFile=`ls ${tcDir}/webapps/*.war | head -1 | awk '{print $1}'`
+aWarFile=`ls ${CATALINA_BASE}/webapps/*.war | head -1 | awk '{print $1}'`
 echo "aWarFile=${aWarFile}"
 if [ -f ${aWarFile} ]; then
       unzip -n -j ${aWarFile}  ${webLib}/ehcache-2.7.4.jar \
                                ${webLib}/ehcache-web-2.0.4.jar \
                                ${webLib}/slf4j-api-1.6.6.jar
-      mv ehcache-2.7.4.jar ehcache-web-2.0.4.jar slf4j-api-1.6.6.jar ${tcDir}/lib
+      mv ehcache-2.7.4.jar ehcache-web-2.0.4.jar slf4j-api-1.6.6.jar ${CATALINA_BASE}/lib
       echo "successfully extracted ehcache-2.7.4.jar ehcache-web-2.0.4.jar slf4j-api-1.6.6.jar from ${aWarFile}"
-      echo "moved jars to ${tcDir}/lib"
+      echo "moved jars to ${CATALINA_BASE}/lib"
 else
       echo "Could not find a war file to extract cache jars"
 fi
-cd ${tcDir}
-rmdir ${tcDir}/tmpUnzip
+cd ${CATALINA_BASE}
+rmdir ${tmpDir}/tmpUnzip
 
 
 


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-15225

- Update dockerfile to run as tomcat(91:91) by default.
- Using CATALINA_BASE inside the container to separate files owned by tomcat vs root.
- Use docker run parameter `--user=[user:group | uid:gid] ` to override default tomcat user.

This image is current deployed on irsawebdev5: http://irsawebdev5.ipac.caltech.edu:8888/firefly/
The way verify this is to ssh in to irsawebdev5;
`ps -ef | grep docker ` to see that the tomcat process is now owed by a uid other then root.

You may also want to modify stop/start scripts under /home/irsadmin directory to test the `--user` parameter or anything else.

