### PR TITLE
DM-15498 MOC display hangs when HiPS image is zoomed in on fov around 1 degree or less

### DIFF
--- a/src/firefly/js/drawingLayers/HiPSMOC.js
+++ b/src/firefly/js/drawingLayers/HiPSMOC.js
@@ -312,7 +312,7 @@ function updateMocData(dl, plotId) {
              updateStatus.totalTiles = get(updateStatus.newMocObj, ['allCells'], []).length;
          }
      } else {
-         if (updateStatus.processedTiles.length < updateStatus.totalTiles) {   // form drawObj
+         if (updateStatus.processedTiles.length < updateStatus.totalTiles || (updateStatus.totalTiles === 0)) {   // form drawObj
              const startIdx = updateStatus.processedTiles.length;
              const endIdx = updateStatus.processedTiles.length + updateStatus.maxChunk - 1;
              const moreObjs = createDrawObjsInMoc(updateStatus.newMocObj, plot,

--- a/src/firefly/js/visualize/HiPSMocUtil.js
+++ b/src/firefly/js/visualize/HiPSMocUtil.js
@@ -17,8 +17,8 @@ export function ivoStr(ivoid) {
     return ivoid ? ivoid.trim().replace('ivo://', '').replace(/\//g,'_') : 'moc_table_' + (++mocCnt);
 }
 
-export const NSIDE2 = new Array(30).fill(0).map((v, i) => 2**i);
-export const NSIDE4 = new Array(20).fill(0).map((v, i) => 4**i);
+export const NSIDE2 = new Array(64).fill(0).map((v, i) => 2**i);
+export const NSIDE4 = new Array(32).fill(0).map((v, i) => 4**i);
 
 export function getMocNuniq(order, npix) {
     return NSIDE4[order+1] + npix;

--- a/src/firefly/js/visualize/draw/MocObj.js
+++ b/src/firefly/js/visualize/draw/MocObj.js
@@ -5,7 +5,7 @@ import {makeRegionPolygon} from '../region/Region.js';
 import {drawRegions} from '../region/RegionDrawer.js';
 import {distanceToPolygon} from './ShapeDataObj.js';
 import {getMocOrderIndex, getMocSidePointsNuniq, getCornerForPix, getMocNuniq,
-        isTileVisibleByPosition, initSidePoints, NSIDE4} from '../HiPSMocUtil.js';
+        isTileVisibleByPosition, initSidePoints, NSIDE4, NSIDE2} from '../HiPSMocUtil.js';
 import {getHealpixCornerTool,  getAllVisibleHiPSCells, getPointMaxSide, getHiPSNorderlevel} from '../HiPSUtil.js';
 import DrawOp from './DrawOp.js';
 import CsysConverter from '../CsysConverter.js';
@@ -270,10 +270,10 @@ export class MocGroup {
     }
 
     filterTilesOnOrder(tiles, fromOrder, pOrder, vSet) {
-        const fNum = (fromOrder - pOrder) * 2;
+        const fNum = (fromOrder - pOrder);
 
         return tiles.filter((oneTile) => {
-            const ipix = oneTile.npix >> fNum;
+            const ipix = lowerNpix(oneTile.npix, fNum);
             if (has(vSet, [ipix])) {
                 return oneTile;
             } else {
@@ -371,12 +371,12 @@ export class MocGroup {
 
         const includedNpixs = get(this.incNpixs, [toOrder], []);
         const notIncludedNpixs = get(this.notIncNpixs, [toOrder], []);
-        const pNum = (fromOrder - toOrder) << 1;    // divide by 4 ** (from-to)
+        const pNum = (fromOrder - toOrder);   // divide by 4 ** (from-to)
 
 
         tiles.find((oneTile) => {
             const {npix} = oneTile;
-            const nextNpix = npix >> pNum;           // npix of parent tile at 'toOrder'
+            const nextNpix = lowerNpix(npix, pNum);           // npix of parent tile at 'toOrder'
 
             if (includedNpixs.includes(nextNpix) || notIncludedNpixs.includes(nextNpix)) {    // already tested
                 return false;
@@ -632,3 +632,6 @@ const outputTime = (msg, t0) => {
     console.log(msg + ' took ' + (t1-t0) + ' msec');
 };
 
+const lowerNpix = (npix, level) => {
+    return Math.trunc(npix/NSIDE4[level]);
+};


### PR DESCRIPTION
This development fixes the MOC display bug by using 'division' instead of 'right shift' to calculate 'npix' of lower tile where the higher order tile is nested in. This change is due to the fact that Javascript bitwise operation treats the operands as a sequence of 32 bits, the result will become inaccurate if doing bit shift on 'npix' of some higher order tile. 

test:
searching HiPS 'HST/NICMOS - all bands' by un-checking 'IRSA Featured' and selecting the only HiPS image with order 16. 
check up 'MOC' layer
zoom in the image 
the MOC of all levels (up to order 16) will be shown as image is zoomed in from large fov to small fov. 
 