### PR TITLE
Dm 14512 Use the file name of uploaded ds9 region file as the label in the layer dialog

### DIFF
--- a/src/firefly/html/demo/ffapi-region-test.html
+++ b/src/firefly/html/demo/ffapi-region-test.html
@@ -184,8 +184,8 @@
             var selectMode = {selectStyle: st, selectColor: sc, lineWidth: lw};
 
             window.allRegions[layerId] = regionAry;
-            //firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, 'regiontest', selectMode);
-            firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, null, selectMode, dispatcher = window.ffViewer.dispatch);
+            //firefly.action.dispatchCreateRegionLayer(layerId, null, null, regionAry, 'regiontest', selectMode);
+            firefly.action.dispatchCreateRegionLayer(layerId, null, null, regionAry, null, selectMode, dispatcher = window.ffViewer.dispatch);
         };
 
         updateDataList = function() {

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -154,7 +154,7 @@ function makeDoUpload(file, type, isFromURL, fileAnalysis) {
                 }
             }
 
-            return {isLoading: false, valid, message, value: cacheKey, analysisResult, filename: get(file, 'name')};
+            return {isLoading: false, valid, message, value: cacheKey, analysisResult};
         }).catch((err) => {
             return {isLoading: false, valid: false,
                     message: (isFromURL ? `Unable to upload file from ${file}` : `Unable to upload file: ${get(file, 'name')}`)};

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -47,12 +47,11 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                 </div>
             );
         } else {
-            let fPos = {marginLeft: -150, width: '12em', overflow:'hidden',
-                        textOverflow: 'ellipsis', whiteSpace: 'nowrap'};
+            let fPos = {marginLeft: -150, width: '12em'};
 
             if (!isNil(fileNameStyle)) fPos = Object.assign(fPos, fileNameStyle);
             return (
-                fileName && <div style={{display:'inline-block', ...fPos}} title={fileName}>{fileName}</div>
+                fileName && <div style={{...fPos}} className='text-ellipsis' title={fileName}>{fileName}</div>
             );
         }
     };

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -29,7 +29,7 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                 type={isFromURL ? 'text' : 'file'}
                 label={label}
                 value={value}
-                tooltip={value}
+                tooltip={isFromURL ? 'enter a URL to upload from' : 'click to choose a file'}
                 labelWidth={labelW}
                 inline={true}
                 style={style}
@@ -47,11 +47,12 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                 </div>
             );
         } else {
-            let fPos = {marginLeft: -150};
+            let fPos = {marginLeft: -150, width: '12em', overflow:'hidden',
+                        textOverflow: 'ellipsis', whiteSpace: 'nowrap'};
 
             if (!isNil(fileNameStyle)) fPos = Object.assign(fPos, fileNameStyle);
             return (
-                fileName && <div style={{display:'inline-block', ...fPos}}>{fileName}</div>
+                fileName && <div style={{display:'inline-block', ...fPos}} title={fileName}>{fileName}</div>
             );
         }
     };
@@ -153,7 +154,7 @@ function makeDoUpload(file, type, isFromURL, fileAnalysis) {
                 }
             }
 
-            return {isLoading: false, valid, message, value: cacheKey, analysisResult};
+            return {isLoading: false, valid, message, value: cacheKey, analysisResult, filename: get(file, 'name')};
         }).catch((err) => {
             return {isLoading: false, valid: false,
                     message: (isFromURL ? `Unable to upload file from ${file}` : `Unable to upload file: ${get(file, 'name')}`)};

--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -56,7 +56,8 @@ function uploadAndProcessRegion(request, rgComp, drawLayerId) {
                 if (isEmpty(drawLayerId)) {
                     drawLayerId = createNewRegionLayerId();
                 }
-                const fileName = file ? get(FieldGroupUtils.getGroupFields(rgUploadGroupKey), [rgUploadFieldKey, 'filename']) : '';
+                const dispVal = file ? get(FieldGroupUtils.getGroupFields(rgUploadGroupKey), [rgUploadFieldKey, 'displayValue']) : '';
+                const fileName = dispVal ? dispVal.split(/(\\|\/)/g).pop() : '';
 
                 let title = !fileName ? '' : (fileName.includes('.') ? fileName.slice(0, fileName.lastIndexOf('.')) : fileName);
                 title = getRegionLayerTitle(title);

--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -14,13 +14,13 @@ import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {FileUpload} from '../../ui/FileUpload.jsx';
 import CompleteButton from '../../ui/CompleteButton.jsx';
 import {dispatchHideDialog} from '../../core/ComponentCntlr.js';
-import RegionPlot from '../../drawingLayers/RegionPlot.js';
+import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
+import {createNewRegionLayerId, getRegionLayerTitle} from '../../drawingLayers/RegionPlot.js';
 import {get, isEmpty} from 'lodash';
 
 const popupId = 'RegionFilePopup';
 const rgUploadGroupKey = 'RegionUploadGroup';
 const rgUploadFieldKey = 'regionFileUpload';
-const regionDrawLayerId = RegionPlot.TYPE_ID;
 
 export function showRegionFileUploadPanel(divElement, popTitle='Load DS9 Region File') {
     var popup = (<PopupPanel title={popTitle}>
@@ -31,15 +31,7 @@ export function showRegionFileUploadPanel(divElement, popTitle='Load DS9 Region 
     dispatchShowDialog(popupId);
 }
 
-function* createDrawLayerId() {
-    var idCnt = 0;
 
-    while (true) {
-        yield `${regionDrawLayerId}-${idCnt++}`;
-    }
-}
-
-var drawLayerIdGen = createDrawLayerId();
 
 /**
  * get region json from server, convert json into Region objects and make RegionPlot DrawLayer
@@ -50,9 +42,11 @@ var drawLayerIdGen = createDrawLayerId();
 function uploadAndProcessRegion(request, rgComp, drawLayerId) {
     const [FieldKeyErr] = ['no region file uploaded yet'];
 
-    var regionFile = get(request, rgUploadFieldKey);
-    var setStatus = (file, regionAry, message)  => {
-            var s = {upload: (!!file || !!regionAry),  message};
+     const regionFile = get(request, rgUploadFieldKey);
+
+     const setStatus = (file, regionAry, message)  => {
+            const s = {upload: (!!file || !!regionAry),  message};
+
 
             if (rgComp) {
                 rgComp.setState(s);
@@ -60,9 +54,14 @@ function uploadAndProcessRegion(request, rgComp, drawLayerId) {
 
             if (file || regionAry) {
                 if (isEmpty(drawLayerId)) {
-                    drawLayerId = drawLayerIdGen.next().value;
+                    drawLayerId = createNewRegionLayerId();
                 }
-                dispatchCreateRegionLayer(drawLayerId, drawLayerId, file, regionAry);
+                const fileName = file ? get(FieldGroupUtils.getGroupFields(rgUploadGroupKey), [rgUploadFieldKey, 'filename']) : '';
+
+                let title = !fileName ? '' : (fileName.includes('.') ? fileName.slice(0, fileName.lastIndexOf('.')) : fileName);
+                title = getRegionLayerTitle(title);
+
+                dispatchCreateRegionLayer(drawLayerId, title, file, regionAry);
                 dispatchHideDialog(popupId);
             }
     };
@@ -120,7 +119,7 @@ class RegionUpload extends PureComponent {
     }
 
     onUpload(request) {
-        uploadAndProcessRegion(request, this, drawLayerIdGen.next().value);
+        uploadAndProcessRegion(request, this, createNewRegionLayerId());  // get a new layer
     }
 
     render() {

--- a/src/firefly/js/visualize/region/RegionTask.js
+++ b/src/firefly/js/visualize/region/RegionTask.js
@@ -2,21 +2,18 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {RegionFactory} from './RegionFactory.js';
 import {getDS9Region} from '../../rpc/PlotServicesJson.js';
-import {getDlAry, defaultRegionSelectColor, getRegionSelectStyle} from '../DrawLayerCntlr.js';
+import {getDlAry} from '../DrawLayerCntlr.js';
 import DrawLayerCntrl, {dispatchCreateDrawLayer, dispatchDetachLayerFromPlot,
         dispatchAttachLayerToPlot} from '../DrawLayerCntlr.js';
 import {getDrawLayerById, getPlotViewIdListInGroup} from '../PlotViewUtil.js';
-import RegionPlot from '../../drawingLayers/RegionPlot.js';
-import {getPlotViewAry} from '../PlotViewUtil.js';
+import RegionPlot, {createNewRegionLayerId, getRegionLayerTitle} from '../../drawingLayers/RegionPlot.js';
 import {visRoot} from '../ImagePlotCntlr.js';
-import {logError} from '../../util/WebUtil.js'
+import {logError} from '../../util/WebUtil.js';
 import {has, isArray, isEmpty, get, isNil} from 'lodash';
 
 const regionDrawLayerId = RegionPlot.TYPE_ID;
 
-var cnt = 0;
 var [RegionIdErr, RegionErr, NoRegionErr, JSONErr] = [
     'region id is not specified',
     'invalid description in region file',
@@ -26,7 +23,7 @@ var [RegionIdErr, RegionErr, NoRegionErr, JSONErr] = [
 var getPlotId = (plotId) => {
     //return (!plotId || (isArray(plotId)&&plotId.length === 0)) ? get(visRoot(), 'activePlotId') : plotId;
     if (!plotId || (isArray(plotId)&&plotId.length === 0)) {
-        var pid = get(visRoot(), 'activePlotId');
+        const pid = get(visRoot(), 'activePlotId');
 
         return getPlotViewIdListInGroup(visRoot(), pid, false);
     } else {
@@ -35,13 +32,10 @@ var getPlotId = (plotId) => {
 };
 
 
-var layerId = (drawLayerId, title) => {
-    return isNil(drawLayerId) ? title.slice() : drawLayerId;
+const layerId = (drawLayerId) => {
+    return isNil(drawLayerId) ? createNewRegionLayerId() : drawLayerId;
 };
 
-var getLayerTitle = (layerTitle, titleRef) => {
-    return layerTitle ? layerTitle : (titleRef ? titleRef : `Region Plot - ${cnt++}`);
-};
 
 /**
  * action creator of REGION_CREATE_LAYER, create drawing layer based on region file or array of region description
@@ -50,27 +44,25 @@ var getLayerTitle = (layerTitle, titleRef) => {
  */
 export function regionCreateLayerActionCreator(rawAction) {
     return (dispatcher) => {
-        var {drawLayerId, fileOnServer, layerTitle, regionAry, plotId,
-            selectMode} = rawAction.payload;
-        var title;
+        const {drawLayerId, fileOnServer, layerTitle, regionAry, plotId,
+               selectMode} = rawAction.payload;
 
         if (!drawLayerId) {
-            reportError(RegionIdErr)
+            reportError(RegionIdErr);
         } else if (fileOnServer) {   // region file is given, get region description array
             getDS9Region(fileOnServer).then((result) => {
                 if (has(result, 'RegionData')) {
-                    title = getLayerTitle(layerTitle, (result.Title || drawLayerId));
-                    createRegionLayer(result.RegionData, title, drawLayerId, plotId,
-                                      selectMode, 'json');
+                    createRegionLayer(result.RegionData,  getRegionLayerTitle(layerTitle||result.title),
+                                      drawLayerId, plotId,  selectMode, 'json');
                 } else {
                     reportError(RegionErr);
                 }
             }, () => { reportError(JSONErr); } );
         } else if (!isEmpty(regionAry)) {
-            title = getLayerTitle(layerTitle, drawLayerId);
-            createRegionLayer(regionAry, title, drawLayerId, plotId, selectMode);
+            createRegionLayer(regionAry, getRegionLayerTitle(layerTitle),
+                              drawLayerId, plotId, selectMode);
         } else {
-            reportError(NoRegionErr)
+            reportError(NoRegionErr);
         }
     };
 }
@@ -96,10 +88,10 @@ function createRegionLayer(regionAry, title, drawLayerId, plotId,
         regionAry = [regionAry];
     }
 
-    var pId = getPlotId(plotId);
+    const pId = getPlotId(plotId);
 
-    drawLayerId = layerId(drawLayerId, title);
-    var dl = getDrawLayerById(getDlAry(), drawLayerId);
+    drawLayerId = layerId(drawLayerId);
+    const dl = getDrawLayerById(getDlAry(), drawLayerId);
 
     if (!dl) {
         dispatchCreateDrawLayer(regionDrawLayerId, {title, drawLayerId,
@@ -120,10 +112,10 @@ function createRegionLayer(regionAry, title, drawLayerId, plotId,
  */
 export function regionDeleteLayerActionCreator(rawAction) {
     return (dispatcher) => {
-        var {plotId, drawLayerId} = rawAction.payload;
+        const {plotId, drawLayerId} = rawAction.payload;
 
-        var pId = getPlotId(plotId);
-        var dl = getDrawLayerById(getDlAry(), drawLayerId);
+        const pId = getPlotId(plotId);
+        const dl = getDrawLayerById(getDlAry(), drawLayerId);
 
         if (dl && drawLayerId && pId) {
             dispatchDetachLayerFromPlot(drawLayerId, pId, true, dl.destroyWhenAllDetached);
@@ -140,23 +132,23 @@ export function regionDeleteLayerActionCreator(rawAction) {
  */
 export function regionUpdateEntryActionCreator(rawAction) {
     return (dispatcher) => {
-        var {drawLayerId, regionChanges, layerTitle, plotId,
-             selectMode} = rawAction.payload || {};
+        const {drawLayerId, regionChanges, layerTitle, plotId,
+              selectMode} = rawAction.payload || {};
 
         if (isEmpty(regionChanges)) {
             return;
         }
 
-        var changes = isArray(regionChanges) ? regionChanges : [regionChanges];
-        var dl = drawLayerId ? getDrawLayerById(getDlAry(), drawLayerId) : null;
+        const changes = isArray(regionChanges) ? regionChanges : [regionChanges];
+        const dl = drawLayerId ? getDrawLayerById(getDlAry(), drawLayerId) : null;
 
         // if drawlayer doesn't exist, create a new one
         if (!dl && rawAction.type === DrawLayerCntrl.REGION_ADD_ENTRY) {
-            var title = getLayerTitle(layerTitle, drawLayerId);
+            const title = getRegionLayerTitle(layerTitle);
 
             createRegionLayer(changes, title, drawLayerId, plotId, selectMode);
         } else {
-            var payload = Object.assign(rawAction.payload, {regionChanges: changes});
+            const payload = Object.assign(rawAction.payload, {regionChanges: changes});
 
             if (drawLayerId) {
                 dispatcher(Object.assign(rawAction, {payload})); // add and remove entries

--- a/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
@@ -93,17 +93,13 @@ function getTitleTag(title, maxTitleChars) {
     const maxW = maxTitleChars*.7 > 10 ? Math.min(maxTitleChars*.7, 30) : 10;
 
     const tStyle= {
-        display:'inline-block',
-        whiteSpace: 'nowrap',
         minWidth: minW + 'em',
         maxWidth: maxW + 'em',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
         lineHeight: '1.1em'
     };
 
     return (
-        <div style={tStyle} title={title}>{title}</div>
+        <div style={tStyle} className='text-ellipsis' title={title}>{title}</div>
         );
 }
 

--- a/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
@@ -51,7 +51,7 @@ function DrawLayerItemView({maxTitleChars, lastItem, deleteLayer,
                          alignItems: 'center',
                          width:'100%'
                          }} >
-                <div>
+                <div style={{display: 'flex', alignItems: 'center'}}>
                     <input type='checkbox' checked={visible} onChange={() => changeVisible()} />
                     {getTitleTag(title,maxTitleChars)}
                 </div>
@@ -89,15 +89,21 @@ DrawLayerItemView.propTypes= {
 
 
 function getTitleTag(title, maxTitleChars) {
+    const minW = maxTitleChars*.3 < 30 ? Math.max(maxTitleChars*.3, 10) : 30;
+    const maxW = maxTitleChars*.7 > 10 ? Math.min(maxTitleChars*.7, 30) : 10;
+
     const tStyle= {
         display:'inline-block',
         whiteSpace: 'nowrap',
-        minWidth: (maxTitleChars*.7)+'em'
-        // paddingLeft : 5
+        minWidth: minW + 'em',
+        maxWidth: maxW + 'em',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        lineHeight: '1.1em'
     };
 
     return (
-        <div style={tStyle}>{title}</div>
+        <div style={tStyle} title={title}>{title}</div>
         );
 }
 


### PR DESCRIPTION
This development includes, 
- use the file name of the uploaded ds9 region file as the label in the layer dialog if file is the source of the regions. 
- if the file name is lengthy, the file name is shown in shorter style shorten with '...' at the end. The full file name is shown as tooltip when the mouse is over it. 
- the API has a parameter field for the caller to provide the title (label) to create a new region layer. 
- if no title is provided by the caller, a string like 'ds9 region overlay-{N}', N=1, 2, ... is created as the title in default. 
- File upload panel is also updated to show the long file name of the uploaded file in shorter style as that shown in the layer dialog. 

test:
- start firefly test page, demo/ffapi-region-test.html
- click 'Load sample image' to get Firefly image viewer
- make a couple of clicks on  'Create Region Layer' to get  multiple region layers. Open up the layer dialog and check the title for each created region layer. 
- from Firefly UI, upload a region file with very long file name, ex. 
   firefly_test_data/region-test-files/test_region_file_with_very_long_filename_same_region_content_as_test5_region.reg 
(pull this file from firefly_test_data)
   check the filename shown on the file upload panel and the layer dialog. 
