### PR TITLE
DM-14799 hue-preserving 3 color stretch (lupton_rgb)

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -218,7 +218,7 @@ public class ImagePlotCreator {
             rv= FitsRead.getDefaultFutureStretch();
             state.setRangeValues(rv, band);
         }
-        histOps.recomputeStretch(rv, true);
+        histOps.recomputeStretch(rv);
 
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -44,7 +44,6 @@ import edu.caltech.ipac.visualize.draw.Metric;
 import edu.caltech.ipac.visualize.draw.Metrics;
 import edu.caltech.ipac.visualize.plot.ActiveFitsReadGroup;
 import edu.caltech.ipac.visualize.plot.CropFile;
-import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import edu.caltech.ipac.visualize.plot.Histogram;
 import edu.caltech.ipac.visualize.plot.HistogramOps;
 import edu.caltech.ipac.visualize.plot.ImagePlot;
@@ -55,6 +54,7 @@ import edu.caltech.ipac.visualize.plot.PixelValueException;
 import edu.caltech.ipac.visualize.plot.PlotGroup;
 import edu.caltech.ipac.visualize.plot.ProjectionException;
 import edu.caltech.ipac.visualize.plot.Pt;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
@@ -66,7 +66,7 @@ import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.Rectangle2D;
-import java.awt.image.IndexColorModel;
+import java.awt.image.ColorModel;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -914,7 +914,7 @@ public class VisServerOps {
 
 
             boolean three = plot.isThreeColor();
-            IndexColorModel newColorModel = plot.getImageData().getColorModel();
+            ColorModel newColorModel = plot.getImageData().getColorModel();
 
 
             HistogramDisplay dataHD = new HistogramDisplay();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsDataEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsDataEval.java
@@ -7,7 +7,7 @@
  */
 
 package edu.caltech.ipac.firefly.server.visualize.fitseval;
-/**
+/*
  * User: roby
  * Date: 7/5/18
  * Time: 9:20 AM
@@ -16,7 +16,6 @@ package edu.caltech.ipac.firefly.server.visualize.fitseval;
 
 import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
-import nom.tam.fits.Header;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -29,7 +28,6 @@ public class FitsDataEval implements Serializable {
 
     private final FitsRead frAry[];
     private final List<RelatedData> relatedDataAry[];
-    private final List<Header> headerList= new ArrayList<>();
 
 
     FitsDataEval(FitsRead frAry[]) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/draw/AreaStatisticsUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/draw/AreaStatisticsUtil.java
@@ -10,7 +10,6 @@ import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.util.SUTDebug;
 import edu.caltech.ipac.visualize.plot.ActiveFitsReadGroup;
 import edu.caltech.ipac.visualize.plot.CoordinateSys;
-import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import edu.caltech.ipac.visualize.plot.ImageHeader;
 import edu.caltech.ipac.visualize.plot.ImagePlot;
 import edu.caltech.ipac.visualize.plot.ImagePt;
@@ -20,12 +19,12 @@ import edu.caltech.ipac.visualize.plot.Plot;
 import edu.caltech.ipac.visualize.plot.ProjectionException;
 import edu.caltech.ipac.visualize.plot.Pt;
 import edu.caltech.ipac.visualize.plot.WorldPt;
-import nom.tam.fits.FitsException;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 
-import java.awt.Shape;
+import java.awt.*;
+import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-import java.awt.geom.Ellipse2D;
 import java.text.NumberFormat;
 import java.util.HashMap;
 
@@ -426,12 +425,7 @@ public class AreaStatisticsUtil {
 	// calculate integrated flux
 //	ImageHeader imageHdr = fitsRead.getImageHeader();
 
-        ImageHeader imageHdr = null;
-        try {
-            imageHdr = new ImageHeader(fitsRead.getHeader());
-        } catch (FitsException e) {
-            e.printStackTrace();
-        }
+        ImageHeader imageHdr = new ImageHeader(fitsRead.getHeader());
 
         // pixel area in steradian
 	double pixelArea =  Math.abs(imageHdr.cdelt1*DtoR*imageHdr.cdelt2*DtoR);

--- a/src/firefly/java/edu/caltech/ipac/visualize/draw/ColorDisplay.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/draw/ColorDisplay.java
@@ -6,25 +6,19 @@ package edu.caltech.ipac.visualize.draw;
 
 import edu.caltech.ipac.util.Assert;
 
-import javax.swing.Icon;
-import javax.swing.JComponent;
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Insets;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
 
 public class ColorDisplay extends JComponent implements Icon {
 
-    private IndexColorModel _model       = null;
+    private ColorModel _model       = null;
     private Color           _colorBand   = null;
 
     public ColorDisplay() { };
 
-    public void setColor(IndexColorModel model) {
+    public void setColor(ColorModel model) {
        _model= model;
        _colorBand= null;
        repaint();
@@ -71,8 +65,8 @@ public class ColorDisplay extends JComponent implements Icon {
           int        idx;
           Graphics2D g2     = (Graphics2D)g;
           Insets     insets = getInsets();
-           int        clength= _colorBand==null ?  _model.getMapSize() - 1 :
-                                                   255;
+           int        clength= _colorBand==null  && (_model instanceof IndexColorModel)?
+                                  ((IndexColorModel)_model).getMapSize() - 1 : 255;
           Dimension  dim    = getSize();
           int        width  = getIconWidth()  - (insets.left + insets.right);
           int        height = getIconHeight() - (insets.top + insets.bottom);

--- a/src/firefly/java/edu/caltech/ipac/visualize/draw/HistogramDisplay.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/draw/HistogramDisplay.java
@@ -8,16 +8,9 @@ import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.visualize.plot.ColorTable;
 
-import javax.swing.Icon;
-import javax.swing.JComponent;
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Insets;
-import java.awt.image.IndexColorModel;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.ColorModel;
 
 public class HistogramDisplay extends JComponent implements Icon {
 
@@ -26,7 +19,7 @@ public class HistogramDisplay extends JComponent implements Icon {
     private static final int LOWER = 46;
 
     private int             _histogram[] = null;
-    private IndexColorModel _model       = null;
+    private ColorModel _model       = null;
     private boolean         _do2nd= false;
     private boolean         _boundsEnabled= true;
     private byte            _histColorIdx[];
@@ -43,7 +36,7 @@ public class HistogramDisplay extends JComponent implements Icon {
         }
     }
 
-    public void setHistogramArray(int histogram[], byte histColorIdx[], IndexColorModel model) {
+    public void setHistogramArray(int histogram[], byte histColorIdx[], ColorModel model) {
         _histogram= histogram;
         _histColorIdx= histColorIdx;
         _model= model;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/Histogram.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/Histogram.java
@@ -99,9 +99,9 @@ public class Histogram {
             datamax = histDatamax;
 
 	        /* redo if more than 1% of pixels fell off histogram */
-            if (underflowCount > float1dArray.length / .01)
+            if (underflowCount > float1dArray.length * .01)
                 redo_flag = true;
-            if (overflowCount > float1dArray.length / .01)
+            if (overflowCount > float1dArray.length * .01)
                 redo_flag = true;
 
             /* check if we got a good spread */

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
@@ -34,7 +34,7 @@ public class HistogramOps {
 
 
     public void recomputeStretch(RangeValues rangeValues) {
-        _imageData.recomputeStretch(band.getIdx(), rangeValues);
+        _imageData.recomputeStretch(fitsReadAry, band.getIdx(), rangeValues);
     }
 
     public FitsRead getFitsRead() { return fitsReadAry[band.getIdx()]; }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/HistogramOps.java
@@ -34,11 +34,7 @@ public class HistogramOps {
 
 
     public void recomputeStretch(RangeValues rangeValues) {
-        recomputeStretch(rangeValues,false);
-    }
-
-    public void recomputeStretch(RangeValues rangeValues, boolean force) {
-        _imageData.recomputeStretch(fitsReadAry, band.getIdx(), rangeValues,force);
+        _imageData.recomputeStretch(band.getIdx(), rangeValues);
     }
 
     public FitsRead getFitsRead() { return fitsReadAry[band.getIdx()]; }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
@@ -3,8 +3,10 @@
  */
 package edu.caltech.ipac.visualize.plot;
 
+import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
+import edu.caltech.ipac.visualize.plot.plotdata.ImageStretch;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
@@ -14,7 +16,6 @@ import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 9/11/15
@@ -26,26 +27,35 @@ public class ImageData implements Serializable {
 
 
     public enum ImageType {TYPE_8_BIT, TYPE_24_BIT}
-    private       ImageType       _imageType;
-    private RangeValues rangeValues;
-    private IndexColorModel _cm;
-    private int             _colorTableID= 0;   // this is not as flexible as color model and will be set to -1 when color model is set
-    private BufferedImage   _bufferedImage;
-    private boolean         _imageOutOfDate= true;
+    private IndexColorModel cm;
+    private int colorTableID = 0;   // this is not as flexible as color model and will be set to -1 when color model is set
+    private BufferedImage bufferedImage;
+    private boolean imageOutOfDate = true;
     private ImageMask[] imageMasks=null;
-    private final int       _x;
-    private final int       _y;
-    private final int       _width;
-    private final int       _height;
-    private final int       _lastPixel;
-    private final int       _lastLine;
-    private int _idx; //IRSA-572, save the band index so only this band is going to be stretched
 
-    private AtomicInteger inUseCnt= new AtomicInteger(0);
+    private final ImageType imageType;
+    private final RangeValues rangeValuesAry[];
+    private final int x;
+    private final int y;
+    private final int width;
+    private final int height;
+    private final int lastPixel;
+    private final int lastLine;
 
-    private WritableRaster  _raster; // currently only used with 24 bit images
+    private WritableRaster raster;
 
-   
+
+    private ImageData( ImageType imageType, int x, int y, int width, int height, RangeValues rangeValues) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+        this.lastPixel = this.x + this.width -1;
+        this.lastLine = this.y + this.height -1;
+        this.rangeValuesAry= new RangeValues[] {rangeValues, rangeValues, rangeValues};
+        this.imageType = imageType;
+    }
+
 
     public ImageData(ImageType imageType,
                      int colorTableID,
@@ -54,22 +64,12 @@ public class ImageData implements Serializable {
                      int y,
                      int width,
                      int height) {
-
-        _x= x;
-        _y= y;
-        _width= width;
-        _height= height;
-        _lastPixel= _x+_width-1;
-        _lastLine= _y+_height-1;
-
-        _imageType= imageType;
-        _colorTableID= colorTableID;
-        this.rangeValues= rangeValues;
-
-        _cm = ColorTable.getColorModel(colorTableID);
-        if (imageType==ImageType.TYPE_24_BIT) {
-            _raster= Raster.createBandedRaster( DataBuffer.TYPE_BYTE, _width,_height,3, null);
-        }
+        this(imageType,x,y,width,height,rangeValues);
+        this.colorTableID = colorTableID;
+        cm = ColorTable.getColorModel(colorTableID);
+        raster = imageType==ImageType.TYPE_24_BIT ?
+                Raster.createBandedRaster( DataBuffer.TYPE_BYTE, this.width, this.height,3, null) :
+                Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, this.width, this.height, 1, null);
     }
 
     //LZ 7/20/15 add this to make an ImageData with given IndexColorModel
@@ -81,117 +81,58 @@ public class ImageData implements Serializable {
                      int width,
                      int height) {
 
-        _x= x;
-        _y= y;
-        _width= width;
-        _height= height;
-        _lastPixel= _x+_width-1;
-        _lastLine= _y+_height-1;
-
-        _imageType= imageType;
-
-        this.rangeValues= rangeValues;
-
+        this(imageType,x,y,width,height,rangeValues);
         imageMasks=iMasks;
-       _cm=  getIndexColorModel(iMasks);// getIndexColorModelWithAlpha(iMasks); // getIndexColorModel(iMasks); //getIndexColorModel(iMasks); //getColorModelTest(iMasks);//
-
-
-        if (imageType==ImageType.TYPE_24_BIT) {
-            _raster= Raster.createBandedRaster( DataBuffer.TYPE_BYTE, _width,_height,3, null);
-        }
-
+        cm =  getIndexColorModelForMask(iMasks);
+        raster = imageType==ImageType.TYPE_24_BIT ?
+                Raster.createBandedRaster( DataBuffer.TYPE_BYTE, width,height,3, null) :
+                Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, width, height, 1, null);
     }
 
     public BufferedImage getImage(FitsRead fitsReadAry[])       {
-        if (_imageOutOfDate) constructImage(fitsReadAry);
-        return _bufferedImage;
+        if (imageOutOfDate) constructImage(fitsReadAry);
+        return bufferedImage;
     }
 
 
     public void freeResources() {
-        _imageType= null;
-        _cm= null;
-        _bufferedImage= null;
-        _raster= null;
-        _imageOutOfDate= true;
+        cm = null;
+        bufferedImage = null;
+        raster = null;
+        imageOutOfDate = true;
     }
 
-    public int getX() { return _x;}
-    public int getY() { return _y;}
+    public int getX() { return x;}
+    public int getY() { return y;}
 
-    public int getWidth() { return _width;}
-    public int getHeight() { return _height;}
+    public int getWidth() { return width;}
+    public int getHeight() { return height;}
 
-    private byte[] getDataArray(int idx) {
-        DataBufferByte db;
-        if (_raster==null) { // means an 8 bit image
-            db= (DataBufferByte) _bufferedImage.getRaster().getDataBuffer();
-        }
-        else { // 24 bit image
-            db= (DataBufferByte) _raster.getDataBuffer();
-        }
-        return db.getData(idx);
+    void setColorModel(IndexColorModel color_model) {
+        colorTableID = -1;
+        cm =color_model;
+        imageOutOfDate =true;
     }
 
-
-    public void setColorModel(IndexColorModel color_model) {
-        _colorTableID= -1;
-        _cm=color_model;
-        _imageOutOfDate=true;
-    }
-
-    public int getColorTableId() { return _colorTableID; }
+    public int getColorTableId() { return colorTableID; }
 
 
     /**
      * don't compute the color model.  Should only be call from ImageDataGroup
      * @param colorTableID the id
      */
-    void setColorTableIdOnly(int colorTableID) {
-        _colorTableID= colorTableID;
-    }
+    void setColorTableIdOnly(int colorTableID) { this.colorTableID = colorTableID; }
 
 
-    public IndexColorModel getColorModel() { return _cm; }
+    IndexColorModel getColorModel() { return cm; }
 
-    public void markImageOutOfDate() {
-        _imageOutOfDate= true;
-    }
+    void markImageOutOfDate() { imageOutOfDate = true; }
 
-    public boolean isImageOutOfDate() { return _imageOutOfDate; }
+    boolean isImageOutOfDate() { return imageOutOfDate; }
 
-    public void recomputeStretch(FitsRead fitsReadAry[], int idx, RangeValues updatedRangeValues, boolean force) {
-
-
-        inUseCnt.incrementAndGet();
-        boolean mapBlankPixelToZero= (_imageType == ImageType.TYPE_24_BIT);
-
-        //IRSA-219, IRSA-571
-        // update the range values when the new rangeValues is passed. For 8 bit image, the stretch is done without
-        //recreating the image, for 24 bit images, it needs the new rangeValues to computer the stretch and then to
-        //build the image.
-
-        // if this is an 8 bit image I can recompute the stretch without rebuilding the image
-        // if it is 24 bit, I will have to restretch and rebuild so don't both restretching now,
-        // just mark the image as out of date
-
-
-        if (_raster!=null || _imageOutOfDate) {  // raster!=null means a 24 bit image (3 color)
-            _imageOutOfDate= true;
-            //these two parameters are for color stretch
-            rangeValues = updatedRangeValues;
-            _idx = idx;
-
-            if (force) {
-                fitsReadAry[idx].doStretch(rangeValues, getDataArray(idx),
-                             mapBlankPixelToZero, _x, _lastPixel, _y, _lastLine);
-            }
-        }
-        else {
-            fitsReadAry[idx].doStretch(updatedRangeValues, getDataArray(idx),
-                                       mapBlankPixelToZero, _x, _lastPixel, _y, _lastLine);
-        }
-        inUseCnt.decrementAndGet();
+    void recomputeStretch(int idx, RangeValues updatedRangeValues) {
+        imageOutOfDate = true;
+        rangeValuesAry[idx] = updatedRangeValues;
     }
 
 
@@ -208,12 +149,11 @@ public class ImageData implements Serializable {
      *       3             white color
      *
      *
-     * @param lsstMasks
-     * @return
+     * @param lsstMasks the mask settings
+     * @return the new color model
      */
 
-    private static IndexColorModel getIndexColorModel(ImageMask[] lsstMasks){
-
+    private static IndexColorModel getIndexColorModelForMask(ImageMask[] lsstMasks){
 
         byte[] cmap=new byte[4*(lsstMasks.length+1) ];
 
@@ -231,57 +171,48 @@ public class ImageData implements Serializable {
         cmap[4*lsstMasks.length+2]= (byte) 255;
         cmap[4*lsstMasks.length+3]= (byte) 0; //alpha=0, transparent
 
-        return  new IndexColorModel(8, lsstMasks.length+1, cmap, 0, true);
+        return new IndexColorModel(8, lsstMasks.length+1, cmap, 0, true);
     }
 
-
-
-
-
     private void constructImage(FitsRead fitsReadAry[])  {
-
-
-        if (_imageType==ImageType.TYPE_8_BIT) {
-            _raster = null;
+        DataBufferByte db= (DataBufferByte) raster.getDataBuffer();
+        if (imageType ==ImageType.TYPE_8_BIT) {
             if (imageMasks!=null && imageMasks.length!=0){
-
-               _bufferedImage = new BufferedImage(_width, _height, BufferedImage.TYPE_BYTE_INDEXED, _cm);
-               fitsReadAry[0].doStretchMask( getDataArray(0),  _x, _lastPixel, _y, _lastLine, imageMasks);
+               bufferedImage = new BufferedImage(cm, raster, false, null);
+               fitsReadAry[0].doStretchMask( db.getData(0), x, lastPixel, y, lastLine, imageMasks);
 
             }
             else {
-
-
-                _bufferedImage = new BufferedImage(_width, _height,
-                BufferedImage.TYPE_BYTE_INDEXED, _cm);
-                fitsReadAry[0].doStretch(rangeValues, getDataArray(0), false, _x, _lastPixel, _y, _lastLine);
-
+                bufferedImage = new BufferedImage(cm, raster, false, null);
+                ImageHeader imHead= new ImageHeader(fitsReadAry[0].getHeader());
+                ImageStretch.stretchPixels8Bit(rangeValuesAry[Band.NO_BAND.getIdx()],
+                                               fitsReadAry[0].getRawFloatAry(), db.getData(0),
+                                               imHead,  fitsReadAry[0].getHistogram(),
+                                               x, lastPixel, y, lastLine );
 
             }
         }
+        else if (imageType ==ImageType.TYPE_24_BIT) {
+            bufferedImage = new BufferedImage(width, height,BufferedImage.TYPE_INT_RGB);
 
-        else if (_imageType==ImageType.TYPE_24_BIT) {
-            _bufferedImage= new BufferedImage(_width,_height,BufferedImage.TYPE_INT_RGB);
 
-            for(int i=0; (i<fitsReadAry.length); i++) {
-                if (i!=_idx) continue;
-                byte array[]= getDataArray(i);
-                if(fitsReadAry[i]!=null) {
-                    fitsReadAry[i].doStretch(rangeValues, array,true, _x,_lastPixel, _y, _lastLine);
-                }
-                else {
-                    for(int j=0; j<array.length; j++) array[j]= 0;
-                }
+            float[][] float1dAry= new float[3][];
+            byte[][] pixelDataAry= new byte[3][];
+            ImageHeader imHeadAry[]= new ImageHeader[3];
+            Histogram[] histAry= new Histogram[3];
+            for(int i=0;i<3; i++) {
+                float1dAry[i]= fitsReadAry[i].getRawFloatAry();
+                pixelDataAry[i]= db.getData(i);
+                imHeadAry[i]= new ImageHeader(fitsReadAry[i].getHeader());
+                histAry[i]= fitsReadAry[i].getHistogram();
             }
-            _bufferedImage.setData(_raster);
-
-
+            ImageStretch.stretchPixels3Color(rangeValuesAry, float1dAry, pixelDataAry, imHeadAry, histAry,
+                                             x, lastPixel, y, lastLine );
+            bufferedImage.setData(raster);
         }
         else {
             Assert.tst(false, "image type must be TYPE_8_BIT or TYPE_24_BIT");
         }
-        _imageOutOfDate=false;
-        inUseCnt.decrementAndGet();
-
+        imageOutOfDate =false;
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
@@ -164,18 +164,10 @@ public class ImageDataGroup implements Iterable<ImageData> {
         }
     }
 
-
-//    public void recomputeStretch(FitsRead fitsReadAry[], int idx, RangeValues rangeValues) {
-//        recomputeStretch(fitsReadAry,idx,rangeValues,false);
-//    }
-
-    public void recomputeStretch(FitsRead fitsReadAry[],
-                                 int idx,
-                                 RangeValues rangeValues,
-                                 boolean force) {
+    public void recomputeStretch(int idx, RangeValues rangeValues) {
 
         for(ImageData id : _imageDataAry) {
-            id.recomputeStretch(fitsReadAry,idx,rangeValues, force);
+            id.recomputeStretch(idx,rangeValues);
         }
     }
 
@@ -188,16 +180,5 @@ public class ImageDataGroup implements Iterable<ImageData> {
         }
     }
 
-//=======================================================================
-//-------------- Method from LabelSource Interface ----------------------
-//=======================================================================
-
-//======================================================================
-//------------------ Private / Protected Methods -----------------------
-//======================================================================
-
-// =====================================================================
-// -------------------- Factory Methods --------------------------------
-// =====================================================================
 
 }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.visualize.plot;
 import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 
+import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -76,11 +77,7 @@ public class ImageDataGroup implements Iterable<ImageData> {
      * LZ 07/20/15
      * @return
      */
-    public ImageDataGroup(FitsRead fitsReadAry[],
-                          ImageData.ImageType imageType,
-                          ImageMask[] iMasks,
-                          RangeValues rangeValues,
-                          int tileSize) {
+    public ImageDataGroup(FitsRead fitsReadAry[], ImageMask[] iMasks, RangeValues rangeValues, int tileSize) {
         FitsRead fr= null;
         for(FitsRead testFr : fitsReadAry) {
             if (testFr!=null) {
@@ -110,7 +107,7 @@ public class ImageDataGroup implements Iterable<ImageData> {
             for(int j= 0; j<yPanels; j++) {
                 int width= (i<xPanels-1) ? tileSize : ((totWidth-1) % tileSize + 1);
                 int height= (j<yPanels-1) ? tileSize : ((totHeight-1) % tileSize + 1);
-                _imageDataAry[(i*yPanels) +j]= new ImageData(imageType,
+                _imageDataAry[(i*yPanels) +j]= new ImageData(
                         iMasks,rangeValues,
                         tileSize*i,tileSize*j,
                         width, height);
@@ -148,7 +145,7 @@ public class ImageDataGroup implements Iterable<ImageData> {
         }
     }
 
-    public IndexColorModel getColorModel() {
+    public ColorModel getColorModel() {
         return _imageDataAry[0].getColorModel();
     }
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
@@ -5,12 +5,13 @@ package edu.caltech.ipac.visualize.plot;
 
 import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
+import edu.caltech.ipac.visualize.plot.plotdata.RGBIntensity;
 
 import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
 import java.util.Arrays;
 import java.util.Iterator;
-/**
+/*
  * User: roby
  * Date: Aug 21, 2008
  * Time: 1:22:48 PM
@@ -25,7 +26,10 @@ public class ImageDataGroup implements Iterable<ImageData> {
     private       ImageData  _imageDataAry[];
     private final int _width;
     private final int _height;
-    
+
+    RGBIntensity _rgbIntensity; // for 3-color hew-preserving images only
+
+
 
 //======================================================================
 //----------------------- Constructors ---------------------------------
@@ -55,7 +59,8 @@ public class ImageDataGroup implements Iterable<ImageData> {
         int yPanels= totHeight / tileSize;
         if (totWidth % tileSize > 0) xPanels++;
         if (totHeight % tileSize > 0) yPanels++;
-
+        
+        _rgbIntensity = null;
 
         _imageDataAry= new ImageData[xPanels * yPanels];
 
@@ -70,8 +75,6 @@ public class ImageDataGroup implements Iterable<ImageData> {
             }
         }
     }
-
-
 
     /**
      * LZ 07/20/15
@@ -161,9 +164,20 @@ public class ImageDataGroup implements Iterable<ImageData> {
         }
     }
 
-    public void recomputeStretch(int idx, RangeValues rangeValues) {
+    public void recomputeStretch(FitsRead[] fitsReadAry, int idx, RangeValues rangeValues) {
+        boolean setRGBIntensity = false;
+        if (rangeValues.rgbPreserveHue()) {
+            if (_rgbIntensity == null) {
+                _rgbIntensity = new RGBIntensity();
+            }
+            _rgbIntensity.addRangeValues(fitsReadAry, idx, rangeValues);
+            setRGBIntensity = !Arrays.asList(fitsReadAry).contains(null);
+        }
 
         for(ImageData id : _imageDataAry) {
+            if (setRGBIntensity) {
+                id.setRGBIntensity(_rgbIntensity);
+            }
             id.recomputeStretch(idx,rangeValues);
         }
     }
@@ -175,7 +189,13 @@ public class ImageDataGroup implements Iterable<ImageData> {
             }
             _imageDataAry= null;
         }
+        if (_rgbIntensity !=null) {
+            _rgbIntensity = null;
+        }
     }
+
+
+
 
 
 }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
@@ -8,7 +8,6 @@ import edu.caltech.ipac.firefly.visualize.VisUtil;
 import edu.caltech.ipac.util.SUTDebug;
 import edu.caltech.ipac.visualize.plot.projection.Projection;
 import edu.caltech.ipac.visualize.plot.projection.ProjectionParams;
-import nom.tam.fits.FitsException;
 import nom.tam.fits.Header;
 
 import java.io.Serializable;
@@ -81,13 +80,12 @@ public class ImageHeader implements Serializable
     {
     }
 
-    public ImageHeader(Header header) throws FitsException
+    public ImageHeader(Header header)
     {
 	this(header, 0L, 0);
     }
 
     public ImageHeader(Header header, long HDU_offset, int _plane_number)
-	throws FitsException
     {
 	int i, j;
 	boolean got_cd1_1, got_cd1_2, got_cd2_1, got_cd2_2;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImagePlot.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImagePlot.java
@@ -83,10 +83,7 @@ public class ImagePlot extends Plot implements Serializable {
         imageScaleFactor= frGroup.getFitsRead(Band.NO_BAND).getImageScaleFactor();
         _threeColor= false;
         useForMask = true;
-
-       _imageData = new ImageDataGroup(frGroup.getFitsReadAry(),  ImageData.ImageType.TYPE_8_BIT,
-                                       iMasks,stretch,SQUARE);
-
+       _imageData = new ImageDataGroup(frGroup.getFitsReadAry(), iMasks,stretch,SQUARE);
         configureImage(frGroup);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/RangeValues.java
@@ -17,28 +17,28 @@ import java.io.Serializable;
 public class RangeValues implements Cloneable, Serializable {
 
 
-    public static final String PERCENTAGE_STR = "Percent";
-    public static final String ABSOLUTE_STR   = "Absolute";
-    public static final String SIGMA_STR      = "Sigma";
+//    public static final String PERCENTAGE_STR = "Percent";
+//    public static final String ABSOLUTE_STR   = "Absolute";
+//    public static final String SIGMA_STR      = "Sigma";
 
     public static final int PERCENTAGE = 88;
-    public static final int MAXMIN     = 89;
+//    public static final int MAXMIN     = 89;  // obsolete
     public static final int ABSOLUTE   = 90;
     public static final int ZSCALE     = 91;
     public static final int SIGMA      = 92;
 
-    public static final double ASINH_Q =  Double.NaN; // if NaN, Q will be estimated based on range;
-    public static final double GAMMA=2.0;
+    private static final double ASINH_Q =  Double.NaN; // if NaN, Q will be estimated based on range;
+    private static final double GAMMA=2.0;
 
-    public static final String LINEAR_STR= "Linear";
-    public static final String LOG_STR= "Log";
-    public static final String LOGLOG_STR= "LogLog";
-    public static final String EQUAL_STR= "Equal";
-    public static final String SQUARED_STR= "Squared";
-    public static final String SQRT_STR= "Sqrt";
-
-    public static final String ASINH_STR= "Asinh";
-    public static final String POWERLAW_GAMMA_STR= "powerlaw_gamma";
+//    public static final String LINEAR_STR= "Linear";
+//    public static final String LOG_STR= "Log";
+//    public static final String LOGLOG_STR= "LogLog";
+//    public static final String EQUAL_STR= "Equal";
+//    public static final String SQUARED_STR= "Squared";
+//    public static final String SQRT_STR= "Sqrt";
+//
+//    public static final String ASINH_STR= "Asinh";
+//    public static final String POWERLAW_GAMMA_STR= "powerlaw_gamma";
 
 
     public static final int STRETCH_LINEAR= 44;
@@ -50,14 +50,17 @@ public class RangeValues implements Cloneable, Serializable {
     public static final int STRETCH_ASINH   = 50;
     public static final int STRETCH_POWERLAW_GAMMA   = 51;
 
+    private static final short RGB_PRESERVE_HUE_DEFAULT = 0; // use 0 for false, 1 for true
+
 
     private int    _lowerWhich;
     private double _lowerValue;
     private int    _upperWhich;
     private double _upperValue;
     private double _asinhQValue;
-    private double _gammaValue;
+    private double _gammaOrStretch; // gamma for Power Law Gamma stretch or stretch value for hue preserving RGB
     private int    _algorithm= STRETCH_LINEAR;
+    private short  _rgbPreserveHue;
     private int    _zscale_contrast;
     private int    _zscale_samples; /* desired number of pixels in sample */
     private int    _zscale_samples_per_line; /* optimal number of pixels per line */
@@ -65,74 +68,37 @@ public class RangeValues implements Cloneable, Serializable {
     private double _contrast;
 
     public RangeValues() {
-        this( PERCENTAGE, 1.0, PERCENTAGE, 99.0, ASINH_Q, GAMMA, STRETCH_LINEAR, 25, 600, 120);
+        this( PERCENTAGE, 1.0, PERCENTAGE, 99.0, ASINH_Q, GAMMA, STRETCH_LINEAR, 25, 600, 120, RGB_PRESERVE_HUE_DEFAULT);
     }
 
-    public RangeValues(int algorithm ) {
-
-        this( PERCENTAGE, 1.0, PERCENTAGE, 99.0, ASINH_Q, GAMMA, algorithm, 25, 600, 120);
-    }
-    public RangeValues( int    lowerWhich,
-                        double lowerValue,
-                        int    upperWhich,
-                        double upperValue,
-                        int    algorithm) {
-        this( lowerWhich, lowerValue, upperWhich, upperValue, ASINH_Q, GAMMA,algorithm, 25, 600, 120);
-    }
-
-    //added
     public RangeValues( int    lowerWhich,
                         double lowerValue,
                         int    upperWhich,
                         double upperValue,
                         double asinhQValue,
-                        double gammaValue,
-                        int    algorithm) {
-        this( lowerWhich, lowerValue, upperWhich, upperValue, asinhQValue, gammaValue, algorithm, 25, 600, 120);
-    }
-
-    public RangeValues( int    lowerWhich,
-                        double lowerValue,
-                        int    upperWhich,
-                        double upperValue,
-                        int    algorithm,
-                        int    zscale_contrast,
-                        int    zscale_samples,
-                        int    zscale_samples_per_line) {
-
-        this( lowerWhich, lowerValue, upperWhich, upperValue, ASINH_Q, GAMMA, algorithm,
-                zscale_contrast, zscale_samples, zscale_samples_per_line,
-                0.5, 1.0);
-    }
-   //LZ added
-    public RangeValues( int    lowerWhich,
-                        double lowerValue,
-                        int    upperWhich,
-                        double upperValue,
-                        double asinhQValue,
-                        double gammaValue,
-                        int    algorithm,
-                        int    zscale_contrast,
-                        int    zscale_samples,
-                        int    zscale_samples_per_line) {
-
-        this( lowerWhich, lowerValue, upperWhich, upperValue, asinhQValue, gammaValue, algorithm,
-                zscale_contrast, zscale_samples, zscale_samples_per_line,
-                0.5, 1.0);
-    }
-
-
-    //LZ  added
-    public RangeValues( int    lowerWhich,
-                        double lowerValue,
-                        int    upperWhich,
-                        double upperValue,
-                        double asinhQValue,
-                        double gammaValue,
+                        double gammaOrStretch,
                         int    algorithm,
                         int    zscale_contrast,
                         int    zscale_samples,
                         int    zscale_samples_per_line,
+                        short  rgbPreserveHue) {
+        this( lowerWhich, lowerValue, upperWhich, upperValue, asinhQValue, gammaOrStretch, algorithm,
+                zscale_contrast, zscale_samples, zscale_samples_per_line, rgbPreserveHue,
+                0.5, 1.0);
+    }
+
+
+    public RangeValues( int    lowerWhich,
+                        double lowerValue,
+                        int    upperWhich,
+                        double upperValue,
+                        double asinhQValue,
+                        double gammaOrStretch,
+                        int    algorithm,
+                        int    zscale_contrast,
+                        int    zscale_samples,
+                        int    zscale_samples_per_line,
+                        short  rgbPreserveHue,
                         double bias,
                         double contrast) {
 
@@ -140,80 +106,21 @@ public class RangeValues implements Cloneable, Serializable {
         _lowerValue= lowerValue;
         _upperWhich= upperWhich;
         _upperValue= upperValue;
-        _algorithm = algorithm;
+        _algorithm = (rgbPreserveHue > 0) ? STRETCH_ASINH : algorithm;
         _asinhQValue = asinhQValue;
-        _gammaValue=gammaValue;
+        _gammaOrStretch=gammaOrStretch;
         _zscale_contrast = zscale_contrast;
         _zscale_samples = zscale_samples;
         _zscale_samples_per_line = zscale_samples_per_line;
+        _rgbPreserveHue = rgbPreserveHue;
         _bias = bias;
         _contrast = contrast;
     }
-   
-    /**
-     *
-     * @param stretchType the stretch type, possible values:  "Percent", "Absolute", "Sigma"
-     * @param lowerValue the lower value based on the stretch type
-     * @param upperValue the upper value based on the stretch type
-     * @param algorithm The Stretch algorithm, possible values "Linear", "Log", "LogLog", "Equal", "Squared", "Sqrt"
-     *
-     * @return
-     */
-    public static RangeValues create(String stretchType,
-                                     double lowerValue,
-                                     double upperValue,
-                                     String algorithm) {
-        int s= PERCENTAGE;
-        if (!isEmpty(stretchType)) {
-            if (stretchType.equalsIgnoreCase(PERCENTAGE_STR)) s=PERCENTAGE;
-            else if (stretchType.equalsIgnoreCase(ABSOLUTE_STR)) s=ABSOLUTE;
-            else if (stretchType.equalsIgnoreCase(SIGMA_STR)) s=SIGMA;
-        }
-        int a= STRETCH_LINEAR;
-        if (!isEmpty(algorithm)) {
-            if (algorithm.equalsIgnoreCase(LINEAR_STR)) a= STRETCH_LINEAR;
-            else if (algorithm.equalsIgnoreCase(LOG_STR)) a=STRETCH_LOG;
-            else if (algorithm.equalsIgnoreCase(LOGLOG_STR)) a= STRETCH_LOGLOG;
-            else if (algorithm.equalsIgnoreCase(EQUAL_STR)) a= STRETCH_EQUAL;
-            else if (algorithm.equalsIgnoreCase(SQUARED_STR)) a= STRETCH_SQUARED;
-            else if (algorithm.equalsIgnoreCase(SQRT_STR)) a= STRETCH_SQRT;
-            else if (algorithm.equalsIgnoreCase(ASINH_STR)) a= STRETCH_ASINH;
-            else if (algorithm.equalsIgnoreCase(POWERLAW_GAMMA_STR)) a= STRETCH_POWERLAW_GAMMA;
 
-        }
-        return new RangeValues(s,lowerValue,s,upperValue,a);
-    }
-
-    //LZ 6/11/15 added this method
-    public static RangeValues create(String stretchType,
-                                     double lowerValue,
-                                     double upperValue, double asinhQValue, double gammaValue,
-                                     String algorithm) {
-        int s= PERCENTAGE;
-        if (!isEmpty(stretchType)) {
-            if (stretchType.equalsIgnoreCase(PERCENTAGE_STR)) s=PERCENTAGE;
-            else if (stretchType.equalsIgnoreCase(ABSOLUTE_STR)) s=ABSOLUTE;
-            else if (stretchType.equalsIgnoreCase(SIGMA_STR)) s=SIGMA;
-        }
-        int a= STRETCH_LINEAR;
-        if (!isEmpty(algorithm)) {
-            if (algorithm.equalsIgnoreCase(LINEAR_STR)) a= STRETCH_LINEAR;
-            else if (algorithm.equalsIgnoreCase(LOG_STR)) a=STRETCH_LOG;
-            else if (algorithm.equalsIgnoreCase(LOGLOG_STR)) a= STRETCH_LOGLOG;
-            else if (algorithm.equalsIgnoreCase(EQUAL_STR)) a= STRETCH_EQUAL;
-            else if (algorithm.equalsIgnoreCase(SQUARED_STR)) a= STRETCH_SQUARED;
-            else if (algorithm.equalsIgnoreCase(SQRT_STR)) a= STRETCH_SQRT;
-            else if (algorithm.equalsIgnoreCase(ASINH_STR)) a= STRETCH_ASINH;
-            else if (algorithm.equalsIgnoreCase(POWERLAW_GAMMA_STR)) a= STRETCH_POWERLAW_GAMMA;
-
-        }
-        return new RangeValues(s,lowerValue,s,upperValue,asinhQValue, gammaValue, a);
-    }
-
-   //LZ 05/21/15 add the following two lines
     public double getAsinhQValue() { return _asinhQValue; }
     public void setAsinhQValue(double val) { _asinhQValue = val; }
-    public double getGammaValue() { return _gammaValue; }
+    public double getGammaOrStretch() { return _gammaOrStretch; }
+    public void setGammaOrStretch(double val) { _gammaOrStretch = val; }
 
     public int    getLowerWhich() { return _lowerWhich; }
     public double getLowerValue() { return _lowerValue; }
@@ -226,6 +133,8 @@ public class RangeValues implements Cloneable, Serializable {
     public int getZscaleSamplesPerLine() { return _zscale_samples_per_line; }
 
     public int getStretchAlgorithm() { return _algorithm; }
+
+    public boolean rgbPreserveHue() { return _rgbPreserveHue != 0; }
 
     public byte computeBiasAndContrast(byte data) {
         short value = data>=0?data:(short)(2*(Byte.MAX_VALUE+1)+data);
@@ -241,25 +150,11 @@ public class RangeValues implements Cloneable, Serializable {
 
     public Object clone() {
         return new RangeValues( _lowerWhich, _lowerValue, _upperWhich,
-		_upperValue, _asinhQValue, _gammaValue, _algorithm,
-		_zscale_contrast, _zscale_samples, _zscale_samples_per_line, _bias, _contrast );
+		_upperValue, _asinhQValue, _gammaOrStretch, _algorithm,
+		_zscale_contrast, _zscale_samples, _zscale_samples_per_line, _rgbPreserveHue, _bias, _contrast );
     }
 
     public String toString() { return serialize(); }
-
-
-    public static RangeValues makeDefaultSigma() {
-        return new RangeValues(SIGMA,-2F,SIGMA,10F,STRETCH_LINEAR);
-    }
-    public static RangeValues makeDefaultPercent() {
-        return new RangeValues(PERCENTAGE,-2F,PERCENTAGE,10F,STRETCH_LINEAR);
-    }
-
-
-    public static RangeValues makeDefaultZScale() {
-        return new RangeValues(ZSCALE,1F,ZSCALE,1F,STRETCH_LINEAR,25, 600, 120);
-    }
-
 
     public static RangeValues parse(String sIn) {
         if (isEmpty(sIn)) return null;
@@ -272,22 +167,25 @@ public class RangeValues implements Cloneable, Serializable {
             int    upperWhich=              Integer.parseInt(s[i++]);
             double upperValue=              parseDouble(s[i++]);
             double asinhQValue=             parseDouble(s[i++]);
-            double gammaValue=              parseDouble(s[i++]);
+            double gammaOrStretch=              parseDouble(s[i++]);
             int    algorithm=               Integer.parseInt(s[i++]);
             int    zscale_contrast=         Integer.parseInt(s[i++]);
             int    zscale_samples=          Integer.parseInt(s[i++]);
-            int    zscale_samples_per_line= Integer.parseInt(s[i]);
+            int    zscale_samples_per_line= Integer.parseInt(s[i++]);
+            short  rgbPreserveHue=          s.length > 10 ? Short.parseShort(s[i]) : RGB_PRESERVE_HUE_DEFAULT;
+
 
             return new RangeValues(lowerWhich,
-                                   lowerValue,
-                                   upperWhich,
-                                   upperValue,
-                                   asinhQValue,
-                                   gammaValue,
-                                   algorithm,
-                                   zscale_contrast,
-                                   zscale_samples,
-                                   zscale_samples_per_line);
+                    lowerValue,
+                    upperWhich,
+                    upperValue,
+                    asinhQValue,
+                    gammaOrStretch,
+                    algorithm,
+                    zscale_contrast,
+                    zscale_samples,
+                    zscale_samples_per_line,
+                    rgbPreserveHue);
 
         } catch (Exception e) {
             return null;
@@ -299,15 +197,16 @@ public class RangeValues implements Cloneable, Serializable {
     public String serialize() {
 
         return getLowerWhich()+","+
-               getLowerValue()+","+
-               getUpperWhich()+","+
-               getUpperValue()+","+
-               getAsinhQValue()+","+
-               getGammaValue()+","+
-               getStretchAlgorithm()+","+
-               getZscaleContrast()+","+
-               getZscaleSamples()+","+
-               getZscaleSamplesPerLine();
+                getLowerValue()+","+
+                getUpperWhich()+","+
+                getUpperValue()+","+
+                getAsinhQValue()+","+
+                getGammaOrStretch()+","+
+                getStretchAlgorithm()+","+
+                getZscaleContrast()+","+
+                getZscaleSamples()+","+
+                getZscaleSamplesPerLine()+","+
+                _rgbPreserveHue;
     }
 
     private static boolean isEmpty(String s) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/output/PlotOutput.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/output/PlotOutput.java
@@ -23,7 +23,6 @@ import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageOutputStream;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.awt.image.IndexColorModel;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -39,7 +38,7 @@ public class PlotOutput {
     public static final int PNG=  84;
     public static final int BMP=  82;
 
-    public enum Quality {HIGH, MEDIUM, LOW}
+    public enum Quality {HIGH, MEDIUM}
     private static final int _trySizes[]= {512,640,500,630,748,760,494,600,700,420,800,825,650};
     public static final int CREATE_ALL= -1;
     private final ImagePlot _plot;
@@ -381,10 +380,6 @@ public class PlotOutput {
         switch (quality) {
             case HIGH:
                 retval=  new BufferedImage(width,height, BufferedImage.TYPE_INT_ARGB);
-                break;
-            case LOW:
-                IndexColorModel cm= _plot.getImageData().getColorModel();
-                retval= new BufferedImage(width,height, BufferedImage.TYPE_BYTE_INDEXED, cm);
                 break;
             case MEDIUM:
                 retval= new BufferedImage(width,height, BufferedImage.TYPE_USHORT_565_RGB);

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/output/PlotOutput.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/output/PlotOutput.java
@@ -385,7 +385,7 @@ public class PlotOutput {
                 retval= new BufferedImage(width,height, BufferedImage.TYPE_USHORT_565_RGB);
                 break;
             default :
-                Assert.argTst(false, "quality must be HIGH, MEDIUM, or LOW");
+                Assert.argTst(false, "quality must be HIGH or MEDIUM");
                 retval= null;
                 break;
         }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -137,6 +137,7 @@ public class FitsRead implements Serializable {
 
     public BinaryTableHDU getTableHDU() { return tableHDU; } //todo - remove this methdo
 
+    public float[] getRawFloatAry() { return float1d; }
 
     public static RangeValues getDefaultFutureStretch() {
         return DEFAULT_RANGE_VALUE;
@@ -148,29 +149,21 @@ public class FitsRead implements Serializable {
 
 
 
-    public synchronized void doStretch(RangeValues rangeValues,
-                                       byte[] pixelData,
-                                       boolean mapBlankToZero,
-                                       int startPixel,
-                                       int lastPixel,
-                                       int startLine,
-                                       int lastLine){
 
-
-
-
-
-        double slow = ImageStretch.getSlow(rangeValues, float1d, imageHeader, hist);
-        double shigh = ImageStretch.getShigh(rangeValues, float1d, imageHeader, hist);
-
-        byte blank_pixel_value = mapBlankToZero ? 0 : (byte) 255;
-
-
-        ImageStretch.stretchPixels(startPixel, lastPixel, startLine, lastLine,imageHeader.naxis1, imageHeader, hist,
-                blank_pixel_value, float1d, pixelData, rangeValues, slow, shigh);
-
-
-    }
+//    public void doStretch(RangeValues rangeValues,
+//                          byte[] pixelData,
+//                          boolean mapBlankToZero,
+//                          int startPixel,
+//                          int lastPixel,
+//                          int startLine,
+//                          int lastLine){
+//
+//        byte blank_pixel_value = mapBlankToZero ? 0 : (byte) 255;
+//        ImageStretch.stretchPixels(startPixel, lastPixel, startLine, lastLine,imageHeader.naxis1, imageHeader, hist,
+//                blank_pixel_value, float1d, pixelData, rangeValues);
+//
+//
+//    }
 
 
     public short[] getDataAsMask() {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -13,29 +13,11 @@ import edu.caltech.ipac.table.DataObject;
 import edu.caltech.ipac.table.DataType;
 import edu.caltech.ipac.table.IpacTableToFITS;
 import edu.caltech.ipac.table.io.FITSTableReader;
-import edu.caltech.ipac.visualize.plot.CoordinateSys;
-import edu.caltech.ipac.visualize.plot.Histogram;
-import edu.caltech.ipac.visualize.plot.ImageHeader;
-import edu.caltech.ipac.visualize.plot.ImageMask;
-import edu.caltech.ipac.visualize.plot.ImagePt;
-import edu.caltech.ipac.visualize.plot.PixelValueException;
-import edu.caltech.ipac.visualize.plot.RangeValues;
-import nom.tam.fits.BasicHDU;
-import nom.tam.fits.BinaryTableHDU;
-import nom.tam.fits.Fits;
-import nom.tam.fits.FitsException;
-import nom.tam.fits.Header;
-import nom.tam.fits.HeaderCard;
-import nom.tam.fits.HeaderCardException;
-import nom.tam.fits.ImageHDU;
+import edu.caltech.ipac.visualize.plot.*;
+import nom.tam.fits.*;
 import nom.tam.image.compression.hdu.CompressedImageHDU;
-import nom.tam.util.ArrayFuncs;
 
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Serializable;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.zip.DataFormatException;
@@ -58,7 +40,7 @@ public class FitsRead implements Serializable {
     private ImageHeader imageHeader;
     private Header header;
     private Histogram hist;
-    private  double defBetaValue= Double.NaN;
+
     private final boolean tileCompress;
 
 
@@ -166,13 +148,13 @@ public class FitsRead implements Serializable {
 //    }
 
 
-    public short[] getDataAsMask() {
-        float[] fMasks = getDataFloat();
-        //convert to its original type
-        short[] maskData= (short[]) ArrayFuncs.convertArray(fMasks, Short.TYPE, true);
-        return maskData;
-
-    }
+//    public short[] getDataAsMask() {
+//        float[] fMasks = getDataFloat();
+//        //convert to its original type
+//        short[] maskData= (short[]) ArrayFuncs.convertArray(fMasks, Short.TYPE, true);
+//        return maskData;
+//
+//    }
 
 
     /**
@@ -196,10 +178,10 @@ public class FitsRead implements Serializable {
 
         int[] pixelhist = new int[256];
 
-        //covert the raw mask data to real mask : rawMask * imageHeader.bscale + imageHeader.bzero;
-        float[] fMasks = getDataFloat();
-
-        //convert to its original type
+//        //covert the raw mask data to real mask : rawMask * imageHeader.bscale + imageHeader.bzero;
+//        float[] fMasks = getDataFloat();
+//
+//        //convert to its original type
 //        int[] masks= (int[]) ArrayFuncs.convertArray(fMasks, Integer.TYPE, true);
 
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/Geom.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/Geom.java
@@ -238,18 +238,10 @@ public class Geom {
 
 
    /* set mapping from input */
-        try {
     /* should really clone in_header, but this may suffice */
-            temp_hdr = new ImageHeader(in_fits_header);
-            temp_hdr.cdelt2 = in_header.cdelt2;
-            temp_hdr.crpix2 = in_header.crpix2;
-        } catch (FitsException e) {
-            if (SUTDebug.isDebug()) {
-                System.out.println("got FitsException: " + e.getMessage());
-                e.printStackTrace();
-            }
-            throw e;
-        }
+        temp_hdr = new ImageHeader(in_fits_header);
+        temp_hdr.cdelt2 = in_header.cdelt2;
+        temp_hdr.crpix2 = in_header.crpix2;
 
         temp_hdr.crpix1 = 0;
         temp_hdr.crpix2 = 0;
@@ -1498,17 +1490,9 @@ printf("sum = %g   weight = %f   out_data[n1] = %g\n",
             }
             throw new FitsException("got HeaderCardException: " + hce.getMessage());
         }
-        try {
-            out_header = new ImageHeader(in_fits_header);
+        out_header = new ImageHeader(in_fits_header);
             //System.out.println("RAA out_header.crpix1 = " + out_header.crpix1);
             //System.out.println("RAA out_header.toString()= " + out_header.toString());
-        } catch (FitsException e) {
-            if (SUTDebug.isDebug()) {
-                System.out.println("got FitsException: " + e.getMessage());
-                e.printStackTrace();
-            }
-            throw e;
-        }
 
         out_coordinate_sys = CoordinateSys.makeCoordinateSys(
                 out_header.getJsys(), out_header.file_equinox);
@@ -1538,15 +1522,7 @@ printf("sum = %g   weight = %f   out_data[n1] = %g\n",
 
         in_fits_header.resetOriginalSize();  // RBH added 3-25-2010
 
-        try {
-            out_header = new ImageHeader(in_fits_header);
-        } catch (FitsException e) {
-            if (SUTDebug.isDebug()) {
-                System.out.println("got FitsException: " + e.getMessage());
-                e.printStackTrace();
-            }
-            throw e;
-        }
+        out_header = new ImageHeader(in_fits_header);
         out_coordinate_sys = CoordinateSys.makeCoordinateSys(
                 out_header.getJsys(), out_header.file_equinox);
         if (SUTDebug.isDebug()) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
@@ -32,8 +32,10 @@ public class ImageStretch {
                                          int lastPixel,
                                          int startLine,
                                          int lastLine ) {
+        double slow = ImageStretch.getSlow(rangeValues, float1d, imageHeader, hist);
+        double shigh = ImageStretch.getShigh(rangeValues, float1d, imageHeader, hist);
         stretchPixelsByBand(startPixel, lastPixel, startLine, lastLine,imageHeader.naxis1, imageHeader, hist,
-                (byte)255, float1d, pixelData, rangeValues);
+                (byte)255, float1d, pixelData, rangeValues,slow,shigh);
     }
 
     public static void stretchPixels3Color(RangeValues rangeValuesAry[],
@@ -56,8 +58,10 @@ public class ImageStretch {
         else {
             for(int i=0; (i<float1dAry.length); i++) {
                 if (float1dAry[i]!=null) {
+                    double slow = ImageStretch.getSlow(rangeValuesAry[i], float1dAry[i], imageHeaderAry[i], histAry[i]);
+                    double shigh = ImageStretch.getShigh(rangeValuesAry[i], float1dAry[i], imageHeaderAry[i], histAry[i]);
                     stretchPixelsByBand(startPixel, lastPixel, startLine, lastLine,imageHeaderAry[i].naxis1, imageHeaderAry[i], histAry[i],
-                            (byte)0, float1dAry[i], pixelDataAry[i], rangeValuesAry[i]);
+                            (byte)0, float1dAry[i], pixelDataAry[i], rangeValuesAry[i],slow,shigh);
                 }
                 else {
                     Arrays.fill(pixelDataAry[i], (byte)0);
@@ -96,13 +100,11 @@ public class ImageStretch {
                                            byte blank_pixel_value,
                                            float[] float1dArray,
                                            byte[] pixeldata,
-                                           RangeValues rangeValues) {
+                                           RangeValues rangeValues,
+                                           double slow,
+                                           double shigh) {
 
 
-
-
-        double slow = ImageStretch.getSlow(rangeValues, float1dArray, imageHeader, hist);
-        double shigh = ImageStretch.getShigh(rangeValues, float1dArray, imageHeader, hist);
 
         /*
          * This loop will go through all the pixels and assign them new values based on the
@@ -471,6 +473,9 @@ public class ImageStretch {
             hist_bin_values[i] = (float) hist.getDNfromBin(i);
         }
 
+        double slow = getSlow(rangeValues, float1d, imageHeader,hist);
+        double shigh = getShigh(rangeValues, float1d, imageHeader, hist);
+
         int start_pixel = 0;
         int last_pixel = 4095;
         int start_line = 0;
@@ -481,7 +486,7 @@ public class ImageStretch {
         stretchPixelsByBand(start_pixel, last_pixel,
                 start_line, last_line, naxis1,imageHeader, hist,
                 blank_pixel_value, hist_bin_values,
-                pixeldata,  rangeValues);
+                pixeldata,  rangeValues, slow, shigh);
 
         return pixeldata;
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
@@ -6,13 +6,8 @@ package edu.caltech.ipac.visualize.plot.plotdata;
 
 
 import edu.caltech.ipac.util.Assert;
-import edu.caltech.ipac.visualize.plot.Histogram;
-import edu.caltech.ipac.visualize.plot.ImageHeader;
-import edu.caltech.ipac.visualize.plot.ImageMask;
-import edu.caltech.ipac.visualize.plot.RangeValues;
-import edu.caltech.ipac.visualize.plot.Zscale;
+import edu.caltech.ipac.visualize.plot.*;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 
 /**
@@ -20,7 +15,9 @@ import java.util.Arrays;
  */
 public class ImageStretch {
 
-    private static boolean isHuePreserving(RangeValues rv) { return false;}
+    private static boolean isHuePreserving(RangeValues rv) {
+        return rv.rgbPreserveHue();
+    }
 
 
     public static void stretchPixels8Bit(RangeValues rangeValues,
@@ -34,7 +31,7 @@ public class ImageStretch {
                                          int lastLine ) {
         double slow = ImageStretch.getSlow(rangeValues, float1d, imageHeader, hist);
         double shigh = ImageStretch.getShigh(rangeValues, float1d, imageHeader, hist);
-        stretchPixelsByBand(startPixel, lastPixel, startLine, lastLine,imageHeader.naxis1, imageHeader, hist,
+        stretchPixelsByBand(startPixel, lastPixel, startLine, lastLine, imageHeader.naxis1, hist,
                 (byte)255, float1d, pixelData, rangeValues,slow,shigh);
     }
 
@@ -43,6 +40,7 @@ public class ImageStretch {
                                            byte[][] pixelDataAry,
                                            ImageHeader[] imageHeaderAry,
                                            Histogram[] histAry,
+                                           RGBIntensity rgbIntensity,
                                            int startPixel,
                                            int lastPixel,
                                            int startLine,
@@ -53,14 +51,15 @@ public class ImageStretch {
         }
 
         if (isHuePreserving(rangeValuesAry[0])) {
-            //todo - lupton stretch
+            stretchPixelsHuePreserving(startPixel, lastPixel, startLine, lastLine, imageHeaderAry, histAry,
+                    rgbIntensity, (byte)0, float1dAry, pixelDataAry, rangeValuesAry);
         }
         else {
             for(int i=0; (i<float1dAry.length); i++) {
                 if (float1dAry[i]!=null) {
                     double slow = ImageStretch.getSlow(rangeValuesAry[i], float1dAry[i], imageHeaderAry[i], histAry[i]);
                     double shigh = ImageStretch.getShigh(rangeValuesAry[i], float1dAry[i], imageHeaderAry[i], histAry[i]);
-                    stretchPixelsByBand(startPixel, lastPixel, startLine, lastLine,imageHeaderAry[i].naxis1, imageHeaderAry[i], histAry[i],
+                    stretchPixelsByBand(startPixel, lastPixel, startLine, lastLine,imageHeaderAry[i].naxis1, histAry[i],
                             (byte)0, float1dAry[i], pixelDataAry[i], rangeValuesAry[i],slow,shigh);
                 }
                 else {
@@ -71,7 +70,108 @@ public class ImageStretch {
 
     }
 
+    private static void stretchPixelsHuePreserving(int startPixel,
+                                                  int lastPixel,
+                                                  int startLine,
+                                                  int lastLine,
+                                                  ImageHeader[] imageHeaderAry,
+                                                  Histogram[] histAry,
+                                                  RGBIntensity rgbIntensity,
+                                                  byte blank_pixel_value,
+                                                  float[][]float1dAry, byte[][] pixelDataAry, RangeValues[] rangeValuesAry) {
 
+        for (int i = 0; (i < float1dAry.length); i++) {
+            if (float1dAry[i] == null || imageHeaderAry[i] == null || histAry[i] == null) {
+                throw new IllegalArgumentException("3 bands are required for hue preserving stretch.");
+            }
+        }
+        if (imageHeaderAry[0].naxis1 != imageHeaderAry[1].naxis1 || imageHeaderAry[1].naxis1 != imageHeaderAry[2].naxis1 ||
+                imageHeaderAry[0].naxis2 != imageHeaderAry[1].naxis2 || imageHeaderAry[1].naxis2 != imageHeaderAry[2].naxis2) {
+            throw new IllegalArgumentException("naxis1 and naxis2 must match. " +
+                    "r: (" + imageHeaderAry[0].naxis1 + "," + imageHeaderAry[0].naxis2 + ") " +
+                    "g: (" + imageHeaderAry[1].naxis1 + "," + imageHeaderAry[1].naxis2 + ") " +
+                    "b: (" + imageHeaderAry[2].naxis1 + "," + imageHeaderAry[2].naxis2 + ")");
+        }
+        // use zscale to compute lower value for each band and upper value for intensity
+        RangeValues rv = rangeValuesAry[0];
+
+        double blankPxValAry[] = new double[3];
+        double [] slowAry = new double[3];
+        for(int i=0; i<3; i++) {
+            blankPxValAry[i]= imageHeaderAry[i].blank_value;
+            slowAry[i] = getSlow(rv, float1dAry[i], imageHeaderAry[i], histAry[i]);
+            slowAry[i] = getFlux(slowAry[i], imageHeaderAry[i]);
+        }
+
+        // recreate an array of intensities (the part that will be used)
+        int naxis1 = imageHeaderAry[0].naxis1;
+        float [] intensity = new float[float1dAry[0].length];
+        Arrays.fill(intensity, Float.NaN);
+        int pixelCount = 0;
+        for (int line = startLine; line <= lastLine; line++) {
+            int start_index = line * naxis1 + startPixel;
+            int last_index = line * naxis1 + lastPixel;
+
+            for (int index = start_index; index <= last_index; index++) {
+                
+                if (float1dAry[0][index] != blankPxValAry[0] && float1dAry[1][index] != blankPxValAry[1] && float1dAry[2][index] != blankPxValAry[1]) {
+                    intensity[index] = RGBIntensity.computeIntensity(index, float1dAry, imageHeaderAry, slowAry);
+                }
+                pixelCount++;
+            }
+        }
+
+        // stretch an array of intensities
+        byte[] pixelData = new byte[pixelCount];
+
+        boolean useZ = rangeValuesAry[0].getLowerWhich()==RangeValues.ZSCALE;
+        double slow = useZ ? rgbIntensity.getIntensityLow() : rgbIntensity.getIntensityDataLow(); // lower range for intensity
+        double stretch = useZ ? rgbIntensity.getIntensityHigh()-rgbIntensity.getIntensityLow() : rv.getGammaOrStretch();
+        double shigh = slow + stretch; // upper range for intensity
+
+        stretchPixelsUsingAsinh( startPixel, lastPixel,startLine,lastLine, naxis1,
+                rgbIntensity.getIntensityDataLow(), rgbIntensity.getIntensityDataHigh(),
+                blank_pixel_value, intensity, pixelData, rangeValuesAry[0], slow, shigh);
+        for (RangeValues anRV : rangeValuesAry) {
+            anRV.setAsinhQValue(rv.getAsinhQValue());
+            if (useZ) anRV.setGammaOrStretch(stretch);
+        }
+
+        // fill pixel data for each band
+        pixelCount = 0;
+        float [] rgb = new float[3];
+        short pixmax = 255;
+        float maxv; // max value
+        double flux;
+        for (int line = startLine; line <= lastLine; line++) {
+            int start_index = line * naxis1 + startPixel;
+            int last_index = line * naxis1 + lastPixel;
+
+            for (int index = start_index; index <= last_index; index++) {
+                maxv = 0;
+                for (int c=0; c<3; c++) {
+                    flux = getFlux(float1dAry[c][index], imageHeaderAry[c])-slowAry[c];
+                    if (flux < 0) {
+                        rgb[c] = 0;
+                    } else {
+                        rgb[c] = (0xFF&pixelData[pixelCount])*((float)flux)/intensity[index];
+                        if (rgb[c]>maxv) {
+                            maxv = rgb[c];
+                        }
+                    }
+                }
+                if (maxv > pixmax) {
+                    rgb[0] = pixmax * rgb[0] / maxv;
+                    rgb[1] = pixmax * rgb[1] / maxv;
+                    rgb[2] = pixmax * rgb[2] / maxv;
+                }
+                pixelDataAry[0][pixelCount] = (byte)rgb[0];
+                pixelDataAry[1][pixelCount] = (byte)rgb[1];
+                pixelDataAry[2][pixelCount] = (byte)rgb[2];
+                pixelCount++;
+            }
+        }
+    }
 
     /**
      * A pixel is a cell or small rectangle which stores the information the computer can handle. A discrete pixels make the map.
@@ -84,18 +184,17 @@ public class ImageStretch {
      * other values in between change accordingly (using the same formula). As 0 is by default displayed in black, and 255 in white, the
      * contrast will be better when the image is displayed.
      *
-     * @param startPixel
-     * @param lastPixel
-     * @param startLine
-     * @param lastLine
-     * @param blank_pixel_value
+     * @param startPixel (tile info) start pixel in each line
+     * @param lastPixel (tile info) end pixel in each line
+     * @param startLine (tile info) start line
+     * @param lastLine (tile info) end line
+     * @param blank_pixel_value blank pixel value
      */
     public static void stretchPixelsByBand(int startPixel,
                                            int lastPixel,
                                            int startLine,
                                            int lastLine,
                                            int naxis1,
-                                           ImageHeader imageHeader,
                                            Histogram hist,
                                            byte blank_pixel_value,
                                            float[] float1dArray,
@@ -111,7 +210,7 @@ public class ImageStretch {
          * stretch algorithm
          */
         if (rangeValues.getStretchAlgorithm()==RangeValues.STRETCH_ASINH) {
-            stretchPixelsUsingAsinh( startPixel, lastPixel,startLine,lastLine, naxis1, imageHeader,
+            stretchPixelsUsingAsinh( startPixel, lastPixel,startLine,lastLine, naxis1, hist.getDNMin(), hist.getDNMax(),
                     blank_pixel_value, float1dArray, pixeldata, rangeValues,slow,shigh);
 
 
@@ -147,7 +246,7 @@ public class ImageStretch {
 
     }
 
-    public static void stretchPixelsUsingOtherAlgorithms(int startPixel,
+    private static void stretchPixelsUsingOtherAlgorithms(int startPixel,
                                                          int lastPixel,
                                                          int startLine,
                                                          int lastLine,
@@ -178,7 +277,7 @@ public class ImageStretch {
         }
         int deltasav = sdiff > 0 ? 64 : -64;
 
-        double gamma=rangeValues.getGammaValue();
+        double gamma=rangeValues.getGammaOrStretch();
         int pixelCount = 0;
         for (int line = startLine; line <= lastLine; line++) {
             int start_index = line * naxis1 + startPixel;
@@ -192,7 +291,7 @@ public class ImageStretch {
                     if (rangeValues.getStretchAlgorithm() == RangeValues.STRETCH_LINEAR) {
 
                         double dRunval = ((float1dArray[index] - slow) * 254 / sdiff);
-                        pixeldata[pixelCount] = getLinearStrectchedPixelValue(dRunval);
+                        pixeldata[pixelCount] = getLinearStretchedPixelValue(dRunval);
 
                     } else if (rangeValues.getStretchAlgorithm() == RangeValues.STRETCH_POWERLAW_GAMMA) {
 
@@ -208,21 +307,6 @@ public class ImageStretch {
             }
         }
 
-    }
-
-    private static double[] getMinMaxData(float[] float1d){
-        double min=Double.MAX_VALUE;
-        double max = Double.MIN_VALUE;
-        for (int i=0; i<float1d.length; i++){
-            if (float1d[i]<min){
-                min=float1d[i];
-            }
-            if (float1d[i]>max){
-                max = float1d[i];
-            }
-        }
-        double[] ret = {min, max};
-        return ret;
     }
 
     /**
@@ -311,7 +395,7 @@ public class ImageStretch {
         return pixval;
     }
 
-    private static byte getLinearStrectchedPixelValue(double dRenVal) {
+    private static byte getLinearStretchedPixelValue(double dRenVal) {
 
         if (dRenVal < 0)
             return 0;
@@ -344,7 +428,8 @@ public class ImageStretch {
                                                 int startLine,
                                                 int lastLine,
                                                 int naxis1,
-                                                ImageHeader imageHeader,
+                                                double dnmin,
+                                                double dnmax,
                                                 byte blank_pixel_value,
                                                 float[] float1dArray,
                                                 byte[] pixeldata,
@@ -361,22 +446,19 @@ public class ImageStretch {
             qvalue = 1e10;
         }
 
-        double maxFlux = getFlux(shigh, imageHeader);
-        double minFlux = getFlux(slow, imageHeader);
+        // using raw_dn for flux
+        double maxFlux = shigh;
+        double minFlux = slow;
         if (Double.isNaN(minFlux) || Double.isInfinite((minFlux))){
-            double[] minMax=getMinMaxData(float1dArray);
-            minFlux = getFlux(minMax[0],imageHeader);
+            minFlux = dnmin;
         }
 
         if ( Double.isNaN(maxFlux) || Double.isInfinite((maxFlux)) ) {
-            double[] minMax=getMinMaxData(float1dArray);
-            minFlux = getFlux(minMax[1], imageHeader);
+            maxFlux = dnmax;
         }
 
         if ( !Double.isFinite(qvalue) ) {
-            double[] minMax=getMinMaxData(float1dArray);
-            double dataMaxFlux = getFlux(minMax[1], imageHeader);
-            qvalue = getDefaultAsinhQ(minFlux, maxFlux, dataMaxFlux);
+            qvalue = getDefaultAsinhQ(minFlux, maxFlux, dnmax);
             rangeValues.setAsinhQValue(qvalue);
         }
 
@@ -387,7 +469,7 @@ public class ImageStretch {
             int start_index = line * naxis1 + startPixel;
             int last_index = line * naxis1 + lastPixel;
             for (int index = start_index; index <= last_index; index++) {
-                flux = getFlux(float1dArray[index], imageHeader);
+                flux = float1dArray[index];
                 if (Double.isNaN(flux)) { // if original pixel value is NaN, assign it to blank
                     pixeldata[pixelCount] = blank_pixel_value;
                 } else {
@@ -484,7 +566,7 @@ public class ImageStretch {
         byte blank_pixel_value = 0;
 
         stretchPixelsByBand(start_pixel, last_pixel,
-                start_line, last_line, naxis1,imageHeader, hist,
+                start_line, last_line, naxis1, hist,
                 blank_pixel_value, hist_bin_values,
                 pixeldata,  rangeValues, slow, shigh);
 
@@ -513,7 +595,7 @@ public class ImageStretch {
         return shigh;
     }
 
-    private static Zscale.ZscaleRetval getZscaleValue(float[] float1d, ImageHeader imageHeader, RangeValues rangeValues) {
+    public static Zscale.ZscaleRetval getZscaleValue(float[] float1d, ImageHeader imageHeader, RangeValues rangeValues) {
 
         double contrast = rangeValues.getZscaleContrast();
         int optSize = rangeValues.getZscaleSamples();
@@ -550,79 +632,79 @@ public class ImageStretch {
         }
         return slow;
     }
-
-    /**
-     * This sigma value is calculated using the whole image data.
-     * sigma = SQRT [  ( sum (xi-x_average)^2 )/n
-     *   where x_average is the mean value of the x array
-     *   n is the total number of the element of x array
-     * @return
-     */
-    public static double computeSigma(float[] float1d, ImageHeader imageHeader) {
-
-        //get none zero and finite flux values
-        double [] validData = getNoneZeroValidReadoutArray(float1d, imageHeader);
-        /*
-         When the index.length>25, the IDL atv uses sky to computer sigma. However the sky.pro uses many other
-         numerical receipt methods such as value_local, fitting etc. Here we uses stddev instead.
-       */
-        if (validData.length>5 ){
-            return getStdDev( validData);
-        }
-        else {
-            return  1.0;
-
-        }
-    }
-
-    /**
-     * Process the image fluxes to exclude the 0.0 and NaN and infinity values
-     * @return
-     */
-    private static double[] getNoneZeroValidReadoutArray(float[] float1d, ImageHeader imageHeader){
-        ArrayList<Double> list= new ArrayList<>();
-
-        for (int i=0; i<float1d.length; i++){
-            if (!Double.isNaN(float1d[i]) && !Double.isInfinite(float1d[i]) && float1d[1]!=0.0){
-                list.add( getFlux(float1d[i], imageHeader ) );
-            }
-        }
-        double[] arr = new double[list.size()];
-        for(int i = 0; i < list.size(); i++) {
-            arr[i] = list.get(i);
-        }
-        return arr;
-    }
-
-    /**
-     * Calculate variance and then standard deviation
-     * @param data
-     * @return
-     */
-    private static double getStdDev(double[] data) {
-
-        int size = data.length;
-        double mean = getMean(data);
-        double temp = 0.0f;
-        for(double a :data)
-            temp += (mean - a) * (mean - a);
-
-        return Math.sqrt(temp/size);
-    }
-
-    /**
-     * Calculate the mean flux value
-     * @param data
-     * @return
-     */
-    private static double getMean(double [] data ) {
-
-        int size = data.length;
-        float sum = 0.0f;
-        for(double a : data)
-            sum += a;
-        return sum/size;
-    }
+    
+//    /**
+//     * This sigma value is calculated using the whole image data.
+//     * sigma = SQRT [  ( sum (xi-x_average)^2 )/n
+//     *   where x_average is the mean value of the x array
+//     *   n is the total number of the element of x array
+//     * @return
+//     */
+//    public static double computeSigma(float[] float1d, ImageHeader imageHeader) {
+//
+//        //get none zero and finite flux values
+//        double [] validData = getNoneZeroValidReadoutArray(float1d, imageHeader);
+//        /*
+//         When the index.length>25, the IDL atv uses sky to computer sigma. However the sky.pro uses many other
+//         numerical receipt methods such as value_local, fitting etc. Here we uses stddev instead.
+//       */
+//        if (validData.length>5 ){
+//            return getStdDev( validData);
+//        }
+//        else {
+//            return  1.0;
+//
+//        }
+//    }
+//
+//    /**
+//     * Process the image fluxes to exclude the 0.0 and NaN and infinity values
+//     * @return
+//     */
+//    private static double[] getNoneZeroValidReadoutArray(float[] float1d, ImageHeader imageHeader){
+//        ArrayList<Double> list= new ArrayList<>();
+//
+//        for (int i=0; i<float1d.length; i++){
+//            if (!Double.isNaN(float1d[i]) && !Double.isInfinite(float1d[i]) && float1d[1]!=0.0){
+//                list.add( getFlux(float1d[i], imageHeader ) );
+//            }
+//        }
+//        double[] arr = new double[list.size()];
+//        for(int i = 0; i < list.size(); i++) {
+//            arr[i] = list.get(i);
+//        }
+//        return arr;
+//    }
+//
+//    /**
+//     * Calculate variance and then standard deviation
+//     * @param data
+//     * @return
+//     */
+//    private static double getStdDev(double[] data) {
+//
+//        int size = data.length;
+//        double mean = getMean(data);
+//        double temp = 0.0f;
+//        for(double a :data)
+//            temp += (mean - a) * (mean - a);
+//
+//        return Math.sqrt(temp/size);
+//    }
+//
+//    /**
+//     * Calculate the mean flux value
+//     * @param data
+//     * @return
+//     */
+//    private static double getMean(double [] data ) {
+//
+//        int size = data.length;
+//        float sum = 0.0f;
+//        for(double a : data)
+//            sum += a;
+//        return sum/size;
+//    }
 
     /**
      * add a new stretch method to do the mask plot

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/RGBIntensity.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/RGBIntensity.java
@@ -1,0 +1,160 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.visualize.plot.plotdata;
+
+import edu.caltech.ipac.visualize.plot.Histogram;
+import edu.caltech.ipac.visualize.plot.ImageHeader;
+import edu.caltech.ipac.visualize.plot.RangeValues;
+import edu.caltech.ipac.visualize.plot.Zscale;
+
+import java.util.Arrays;
+
+import static edu.caltech.ipac.visualize.plot.plotdata.ImageStretch.getFlux;
+
+/**
+ * This class is used to store intensity-related info for RGB hue preserving algorithm.
+ * It accumulates range values and calculates the statistics for the intensity, when the range value info
+ * for all three bands is available.
+ * Intensity and the related values are recalculated only when the black points (as reflected by range values) are changing.
+ * @author tatianag
+ */
+public class RGBIntensity {
+
+    private RangeValues[] _rangeValuesAry;
+
+    private String _intensityCacheKey; // derived from range values: when black points change, intensity needs to be recalculated
+
+    // the values below are good for the intensity produced with the intensityCacheKey
+    private float _intensityDataLow; // minimum data value for intensity
+    private float _intensityDataHigh; // maximum data value for intensity
+    private double _intensityLow; // lower range for intensity
+    private double _intensityHigh; // upper range for intensity
+
+    public RGBIntensity() {
+        _rangeValuesAry = null;
+        _intensityCacheKey = "";
+        _intensityDataLow = Float.NaN;
+        _intensityDataHigh = Float.NaN;
+        _intensityLow = Double.NaN;
+        _intensityHigh = Double.NaN;
+    }
+
+    public void addRangeValues(FitsRead[] fitsReadAry, int idx, RangeValues rv) {
+        if (_rangeValuesAry == null) {
+            _rangeValuesAry = new RangeValues[3];
+        }
+        _rangeValuesAry[idx] = rv;
+        if (idx == 2 && !_intensityCacheKey.equals(getCacheKey(_rangeValuesAry))) {
+            computeRGBIntensityStats(fitsReadAry, _rangeValuesAry);
+            _rangeValuesAry = null;
+        }
+    }
+
+    /**
+     * Intensity and the limits needs to be recalculated when the black points of the bands change.
+     * If the key is the same, no need to recalculate.
+     * @param rangeValuesAry and array of red, green, and blue range values
+     * @return a string describing black points, derived from range values
+     */
+    private static String getCacheKey(RangeValues[] rangeValuesAry) {
+        StringBuilder key = new StringBuilder("");
+        if (rangeValuesAry==null) { return key.toString(); }
+        for (RangeValues rv : rangeValuesAry)  {
+            key.append(rv.getLowerWhich()).append(",").append(rv.getLowerValue()).append(";");
+        }
+        return key.toString();
+    }
+
+    private void computeRGBIntensityStats(FitsRead[] fitsReadAry, RangeValues[] rangeValuesAry) {
+
+        if (Arrays.asList(fitsReadAry).contains(null)) {
+            throw new IllegalArgumentException("fitsReadAry should contain 3 non-null values for hue-preserving RGB.");
+        }
+
+        float[][] float1dAry= new float[3][];
+        ImageHeader imageHeaderAry[]= new ImageHeader[3];
+        double blankPxValAry[] = new double[3];
+        Histogram[] histAry= new Histogram[3];
+        for(int i=0; i<3; i++) {
+            float1dAry[i]= fitsReadAry[i].getRawFloatAry();
+            imageHeaderAry[i]= new ImageHeader(fitsReadAry[i].getHeader());
+            blankPxValAry[i]= imageHeaderAry[i].blank_value;
+            histAry[i]= fitsReadAry[i].getHistogram();
+        }
+        for(int i=0; (i<float1dAry.length); i++) {
+            if (float1dAry[i]==null || imageHeaderAry[i]==null || histAry[i]==null) {
+                throw new IllegalArgumentException("3 bands are required for hue preserving stretch.");
+            }
+        }
+        if (imageHeaderAry[0].naxis1!=imageHeaderAry[1].naxis1 || imageHeaderAry[1].naxis1!=imageHeaderAry[2].naxis1 ||
+                imageHeaderAry[0].naxis2!=imageHeaderAry[1].naxis2 || imageHeaderAry[1].naxis2!=imageHeaderAry[2].naxis2) {
+            throw new IllegalArgumentException("Hue-preserving stretch: naxis1 and naxis2 must match. "+
+                    "r: ("+imageHeaderAry[0].naxis1+","+imageHeaderAry[0].naxis2+") "+
+                    "g: ("+imageHeaderAry[1].naxis1+","+imageHeaderAry[1].naxis2+") "+
+                    "b: ("+imageHeaderAry[2].naxis1+","+imageHeaderAry[2].naxis2+")");
+        }
+//        if (imageHeaderAry[0].bzero!=imageHeaderAry[1].bzero || imageHeaderAry[1].bzero!=imageHeaderAry[2].bzero ||
+//                imageHeaderAry[0].bscale!=imageHeaderAry[1].bscale || imageHeaderAry[1].bscale!=imageHeaderAry[2].bscale) {
+//            throw new IllegalArgumentException("Hue-preserving stretch: bzero and bscale must match. "+
+//                    "r: ("+imageHeaderAry[0].bzero+","+imageHeaderAry[0].bscale+") "+
+//                    "g: ("+imageHeaderAry[1].bzero+","+imageHeaderAry[1].bscale+") "+
+//                    "b: ("+imageHeaderAry[2].bzero+","+imageHeaderAry[2].bscale+")");
+//        }
+
+
+        double [] slowAry = new double[3];
+        for(int i=0; i<3; i++) {
+            blankPxValAry[i]= imageHeaderAry[i].blank_value;
+            slowAry[i] = ImageStretch.getSlow(rangeValuesAry[i], float1dAry[i], imageHeaderAry[i], histAry[i]);
+            slowAry[i] = getFlux(slowAry[i], imageHeaderAry[i]);
+        }
+        float [] intensity = new float[float1dAry[0].length];
+        Arrays.fill(intensity, Float.NaN);
+        float val, minVal = Float.MAX_VALUE, maxVal=Float.MIN_VALUE;
+        for (int i=0; i<float1dAry[0].length; i++) {
+            // check for blank pixel values
+            if (float1dAry[0][i] == blankPxValAry[0] || float1dAry[1][i] == blankPxValAry[1] || float1dAry[2][i] == blankPxValAry[1]) {
+                continue;
+            }
+
+            val = computeIntensity(i, float1dAry, imageHeaderAry, slowAry);
+            if (val < 0) { val = 0; }
+
+            // save min and max
+            if (val < minVal) { minVal = val; }
+            if (val > maxVal) { maxVal = val; }
+
+            intensity[i] = val;
+        }
+        _intensityDataLow = (minVal != Float.MAX_VALUE) ? minVal : Float.NaN;
+        _intensityDataHigh = (maxVal != Float.MAX_VALUE) ? maxVal : Float.NaN;
+
+        // zscale settings are shared between bands
+        boolean useZ = rangeValuesAry[0].getLowerWhich()==RangeValues.ZSCALE;
+        if (useZ) {
+            // for zscale only: calculate z1 and z2 for intensity
+            // use the last image header, because after reprojection, bzero and bscale are removed in green and blue
+            // zscale parameters are shared between range values, no matter range values which to use
+            Zscale.ZscaleRetval zscale_retval = ImageStretch.getZscaleValue(intensity, imageHeaderAry[2], rangeValuesAry[0]);
+            _intensityLow = zscale_retval.getZ1();
+            _intensityHigh = zscale_retval.getZ2();
+        } else {
+            _intensityLow = Double.NaN;
+            _intensityHigh = Double.NaN;
+        }
+        _intensityCacheKey = getCacheKey(rangeValuesAry);
+    }
+
+    float getIntensityDataLow() { return _intensityDataLow; }
+    float getIntensityDataHigh() { return _intensityDataHigh; }
+    float getIntensityLow() { return (float)_intensityLow; }
+    float getIntensityHigh() { return (float)_intensityHigh; }
+
+    static float computeIntensity(int i, float[][] float1dAry, ImageHeader[] imageHeaderAry, double[] slowAry) {
+        return (float)(getFlux(float1dAry[0][i], imageHeaderAry[0])-slowAry[0]+
+                            getFlux(float1dAry[1][i], imageHeaderAry[1])-slowAry[1]+
+                            getFlux(float1dAry[2][i], imageHeaderAry[2])-slowAry[2])/3f;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/ProjectionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/ProjectionUtil.java
@@ -10,9 +10,8 @@ package edu.caltech.ipac.visualize.plot.projection;
  */
 
 
-import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import edu.caltech.ipac.visualize.plot.ImageHeader;
-import nom.tam.fits.FitsException;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 
 /**
  * @author Trey Roby
@@ -23,16 +22,12 @@ public class ProjectionUtil {
         boolean result = false;
 
         if (firstFitsRead.getProjectionType()== secondFitsread.getProjectionType()) {
-            try {
-                ImageHeader H1 = new ImageHeader(firstFitsRead.getHeader());
-                ImageHeader H2 = new ImageHeader(secondFitsread.getHeader());
-                if (H1.maptype == Projection.PLATE) {
-                    result = checkPlate(H1, H2);
-                } else {
-                    result = checkOther(H1, H2);
-                }
-            } catch (FitsException e) {
-                result= false;
+            ImageHeader H1 = new ImageHeader(firstFitsRead.getHeader());
+            ImageHeader H2 = new ImageHeader(secondFitsread.getHeader());
+            if (H1.maptype == Projection.PLATE) {
+                result = checkPlate(H1, H2);
+            } else {
+                result = checkOther(H1, H2);
             }
         }
         return result;

--- a/src/firefly/js/ui/RangeSlider.jsx
+++ b/src/firefly/js/ui/RangeSlider.jsx
@@ -36,7 +36,7 @@ function handleOnChange(value, params, fireValueChange){
 const propTypes={
     associatedKey: PropTypes.string,
     label:       PropTypes.string,             // slider label
-    slideValue:  PropTypes.oneOfType([PropTypes.string,PropTypes.number]).required, // slider value
+    slideValue:  PropTypes.oneOfType([PropTypes.string,PropTypes.number]).isRequired, // slider value
     value:       PropTypes.oneOfType([PropTypes.string,PropTypes.number]),
     onValueChange: PropTypes.func,                  // callback on slider change
     min:         PropTypes.number,                  // minimum end of slider

--- a/src/firefly/js/visualize/ui/ColorDialog.jsx
+++ b/src/firefly/js/visualize/ui/ColorDialog.jsx
@@ -3,30 +3,36 @@
  */
 
 import React, {PureComponent} from 'react';
+import {get} from 'lodash';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import {CompleteButton} from '../../ui/CompleteButton.jsx';
 import {Band} from '../Band.js';
 import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
+import {RadioGroupInputFieldView} from '../../ui/RadioGroupInputFieldView.jsx';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils.js';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {dispatchInitFieldGroup} from '../../fieldGroup/FieldGroupCntlr.js';
 import {ColorBandPanel} from './ColorBandPanel.jsx';
+import {ColorRGBHuePreservingPanel} from './ColorRGBHuePreservingPanel.jsx';
 import ImagePlotCntlr, {dispatchStretchChange, visRoot} from '../ImagePlotCntlr.js';
 import {primePlot, getActivePlotView} from '../PlotViewUtil.js';
+import { RangeValues, ZSCALE, STRETCH_ASINH}from '../RangeValues.js';
 import {flux} from '../../Firefly.js';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 import {isHiPS, isImage} from '../WebPlot';
 import {FieldGroupTabs, Tab} from '../../ui/panel/TabPanel.jsx';
 
 import {RED_PANEL,
-        GREEN_PANEL,
-        BLUE_PANEL,
-        NO_BAND_PANEL,
-        colorPanelChange} from './ColorPanelReducer.js';
+    GREEN_PANEL,
+    BLUE_PANEL,
+    NO_BAND_PANEL,
+    RGB_HUEPRESERVE_PANEL,
+    colorPanelChange, rgbHuePreserveChange} from './ColorPanelReducer.js';
 
 
-import { RangeValues, ZSCALE}from '../RangeValues.js';
+
+
 
 
 export function showColorDialog(element) {
@@ -41,6 +47,7 @@ export function showColorDialog(element) {
     dispatchInitFieldGroup( RED_PANEL, true, null, colorPanelChange(Band.RED), watchActions);
     dispatchInitFieldGroup( GREEN_PANEL, true, null, colorPanelChange(Band.GREEN), watchActions);
     dispatchInitFieldGroup( BLUE_PANEL, true, null, colorPanelChange(Band.BLUE), watchActions);
+    dispatchInitFieldGroup( RGB_HUEPRESERVE_PANEL, true, null, rgbHuePreserveChange([Band.RED, Band.GREEN, Band.BLUE]), watchActions);
     dispatchShowDialog('ColorStretchDialog');
 }
 
@@ -53,7 +60,10 @@ class ColorDialog extends PureComponent {
         const rFields= FieldGroupUtils.getGroupFields(RED_PANEL);
         const gFields= FieldGroupUtils.getGroupFields(GREEN_PANEL);
         const bFields= FieldGroupUtils.getGroupFields(BLUE_PANEL);
-        this.state= {plot, fields, rFields, gFields, bFields};
+        const rgbFields= FieldGroupUtils.getGroupFields(RGB_HUEPRESERVE_PANEL);
+        const isHuePreserving= Boolean(get(plot, 'plotState.bandStateAry.0.rangeValues.rgbPreserveHue'));
+        this.setHuePreserving = this.setHuePreserving.bind(this);
+        this.state= {plot, fields, rFields, gFields, bFields, rgbFields, isHuePreserving};
     }
     
     componentWillUnmount() {
@@ -68,30 +78,56 @@ class ColorDialog extends PureComponent {
     }
 
     storeUpdate() {
-        var {state}= this;
+        const {state}= this;
         const plot= primePlot(visRoot());
 
         const fields= FieldGroupUtils.getGroupFields(NO_BAND_PANEL);
         const rFields= FieldGroupUtils.getGroupFields(RED_PANEL);
         const gFields= FieldGroupUtils.getGroupFields(GREEN_PANEL);
         const bFields= FieldGroupUtils.getGroupFields(BLUE_PANEL);
+        const rgbFields= FieldGroupUtils.getGroupFields(RGB_HUEPRESERVE_PANEL);
 
-
-        if (plot!=state.plot || fields!=state.fields ||
-            rFields!=state.rFields || gFields!=state.gFields || bFields!=state.bFields) {
-            this.setState({plot, fields, rFields, gFields, bFields});
+        if (get(plot,'plotState')!==get(state.plot,'plotState') || fields!==state.fields ||
+            rFields!==state.rFields || gFields!==state.gFields || bFields!==state.bFields ||
+            rgbFields!==state.rgbFields) {
+            this.setState({plot, fields, rFields, gFields, bFields, rgbFields});
         }
     }
 
+    setHuePreserving(val) {
+        this.setState({isHuePreserving: val==='huePreserving'});
+
+    }
 
     render() {
-        const {plot,fields, rFields,gFields,bFields}= this.state;
+        const {plot,fields,rFields,gFields,bFields,rgbFields}= this.state;
         if (!plot) return false;
 
 
         if (isImage(plot)) {
-            if (plot.plotState.isThreeColor()) {
-                return renderThreeColorView(plot,rFields,gFields,bFields);
+            const {plotState} = plot;
+            if (plotState.isThreeColor()) {
+                const canBeHuePreserving = plotState.isBandUsed(Band.RED) && plotState.isBandUsed(Band.GREEN) && plotState.isBandUsed(Band.BLUE);
+                const isHuePreservingSelected = this.state.isHuePreserving;
+                const threeColorStretchMode = canBeHuePreserving &&
+                    <RadioGroupInputFieldView
+                        options={[
+                            {label: 'Per-band stretch', value: 'perBand'},
+                            {label: 'Hue preserving stretch', value: 'huePreserving'}
+
+                        ]}
+                        wrapperStyle={{padding: 5}}
+                        value={isHuePreservingSelected ? 'huePreserving' : 'perBand'}
+                        onChange={(ev) => this.setHuePreserving(ev.target.value)}
+                    />;
+
+                return (
+                    <div>
+                        {threeColorStretchMode}
+                        {isHuePreservingSelected && renderHuePreservingThreeColorView(plot, rgbFields)}
+                        {!isHuePreservingSelected && renderThreeColorView(plot, rFields, gFields, bFields)}
+                    </div>
+                );
             }
             else {
                 return renderStandardView(plot,fields);
@@ -114,6 +150,27 @@ class ColorDialog extends PureComponent {
     }
 }
 
+function renderHuePreservingThreeColorView(plot,rgbFields) {
+    const groupKey = RGB_HUEPRESERVE_PANEL;
+    return (
+        <div style={{paddingTop:4}}>
+            <FieldGroup groupKey={groupKey} keepState={false}>
+                <ColorRGBHuePreservingPanel {...{plot, rgbFields, groupKey}}/>
+                <CompleteButton
+                    closeOnValid={false}
+                    style={{padding: '2px 0 7px 10px'}}
+                    onSuccess={(request)=>replot3ColorHuePreserving(request)}
+                    onFail={invalidMessage}
+                    text='Refresh'
+                    dialogId='ColorStretchDialog'
+                />
+            </FieldGroup>
+        </div>
+
+    );
+}
+
+
 function renderThreeColorView(plot,rFields,gFields,bFields) {
     const {plotState}= plot;
     const usedBands = plotState? plotState.usedBands:null;
@@ -134,7 +191,7 @@ function renderThreeColorView(plot,rFields,gFields,bFields) {
                     <Tab name='Green' id='green'>
                         <FieldGroup groupKey={GREEN_PANEL} keepState={true} >
                             <ColorBandPanel groupKey={GREEN_PANEL} band={Band.GREEN} fields={gFields}
-                                            plot={plot}key={Band.GREEN.key}/>
+                                            plot={plot} key={Band.GREEN.key}/>
                         </FieldGroup>
                     </Tab>
                     }
@@ -177,7 +234,6 @@ function renderStandardView(plot,fields) {
                     closeOnValid={false}
                     style={{padding: '2px 0 7px 10px'}}
                     onSuccess={replot()}
-
                     onFail={invalidMessage}
                     text='Refresh'
                     dialogId='ColorStretchDialog'
@@ -188,23 +244,20 @@ function renderStandardView(plot,fields) {
        );
 }
 
-//TODO check request here to see it it has tab information
-//the request does not pass it here correctly
 function replot(usedBands=null) {
 
     return (request)=> {
 
         if (request.colorDialogTabs) {
 
-         replot3Color(
-            request.redPanel, request.greenPanel,
-            request.bluePanel,
-            request.colorDialogTabs.colorTabs, usedBands);
-       }
-    else {
-        replotStandard(request);
-      }
-   };
+            replot3Color(
+                request.redPanel, request.greenPanel,
+                request.bluePanel,
+                request.colorDialogTabs.colorTabs, usedBands);
+        } else {
+            replotStandard(request);
+        }
+    };
 }
 
 
@@ -215,12 +268,32 @@ function invalidMessage() {
 
 function replotStandard(request) {
     // console.log(request);
-
-    var serRv=  makeSerializedRv(request);
-    const stretchData= [{ band : Band.NO_BAND.key, rv :  serRv, bandVisible: true }];
+    const serRv=  makeSerializedRv(request);
+    const stretchData= [{ band: Band.NO_BAND.key, rv:  serRv, bandVisible: true }];
     const pv= getActivePlotView(visRoot());
     if (pv) dispatchStretchChange({plotId:pv.plotId,stretchData});
 }
+
+export function replot3ColorHuePreserving(request) {
+    console.log(request);
+    const useZ= Boolean(request.zscale);
+    const stretchData = [[Band.RED.key, 'lowerWhichRed','lowerRangeRed'],
+        [Band.GREEN.key, 'lowerWhichGreen','lowerRangeGreen'],
+        [Band.BLUE.key, 'lowerWhichBlue', 'lowerRangeBlue']].map(([band, lowerWhich, lowerRange]) => {
+        const rv= RangeValues.makeRV( {
+            lowerWhich: useZ ? ZSCALE : request[lowerWhich],
+            lowerValue: request[lowerRange],
+            asinhQValue: request.asinhQ,
+            gammaOrStretch: request.stretch,
+            algorithm: STRETCH_ASINH,
+            rgbPreserveHue: 1
+        });
+        return {band, rv, bandVisible: true};
+    });
+    const pv= getActivePlotView(visRoot());
+    if (pv) dispatchStretchChange({plotId:pv.plotId,stretchData});
+}
+
 
 /**
  *
@@ -231,32 +304,24 @@ function replotStandard(request) {
  *  @param usedBands
  */
 function replot3Color(redReq,greenReq,blueReq,activeTab, usedBands) {
-    // console.log('activeTab',activeTab);
-    // console.log('red',redReq);
-    // console.log('green',greenReq);
-    // console.log('blue',blueReq);
+
     const stretchData= [];
 
-   //IRSA-572: Since only one band type is selected for stretch, only one stretchData is needed.
-   //Only when the band equals to the active band, its data is stored to the stretchData and send to the server.
     for (let i=0; i<usedBands.length; i++){
-        if( activeTab===usedBands[i].key.toLowerCase() ) {
-            switch (usedBands[i].key.toLowerCase()) {
-                case 'red':
+        switch (usedBands[i].key.toLowerCase()) {
+            case 'red':
 
-                    stretchData.push({band: Band.RED.key, rv: makeSerializedRv(redReq), bandVisible: true});
+                stretchData.push({band: Band.RED.key, rv: makeSerializedRv(redReq), bandVisible: true});
 
-                    break;
-                case 'green':
-                     stretchData.push({band: Band.GREEN.key, rv: makeSerializedRv(greenReq), bandVisible: true});
+                break;
+            case 'green':
+                stretchData.push({band: Band.GREEN.key, rv: makeSerializedRv(greenReq), bandVisible: true});
 
-                    break;
-                case 'blue':
-                     stretchData.push({band: Band.BLUE.key, rv: makeSerializedRv(blueReq), bandVisible: true});
+                break;
+            case 'blue':
+                stretchData.push({band: Band.BLUE.key, rv: makeSerializedRv(blueReq), bandVisible: true});
 
-                    break;
-            }
-            break;
+                break;
         }
     }
 
@@ -274,7 +339,7 @@ export function makeSerializedRv(request) {
             lowerValue: request.lowerRange,
             upperValue: request.upperRange,
             asinhQValue: request.asinhQ,
-            gammaValue: request.gamma,
+            gammaOrStretch: request.gamma,
             algorithm: request.algorithm,
             zscaleContrast: request.zscaleContrast,
             zscaleSamples: request.zscaleSamples,

--- a/src/firefly/js/visualize/ui/ColorPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ColorPanelReducer.js
@@ -2,12 +2,13 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
+import {get} from 'lodash';
 import Validate from '../../util/Validate.js';
 import FieldGroupCntlr, {INIT_FIELD_GROUP} from '../../fieldGroup/FieldGroupCntlr.js';
 import ImagePlotCntlr from '../ImagePlotCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {primePlot} from '../PlotViewUtil.js';
-import RangeValues, {STRETCH_LINEAR, PERCENTAGE, ABSOLUTE, SIGMA, ZSCALE} from './../RangeValues.js';
+import RangeValues, {STRETCH_LINEAR, STRETCH_ASINH, PERCENTAGE, ABSOLUTE, SIGMA, ZSCALE} from './../RangeValues.js';
 
 
 const clone = (obj,params={}) => Object.assign({},obj,params);
@@ -17,6 +18,7 @@ const cloneWithValue= (field,v) => Object.assign({}, field, {value:v});
 export const RED_PANEL= 'redPanel';
 export const GREEN_PANEL= 'greenPanel';
 export const BLUE_PANEL= 'bluePanel';
+export const RGB_HUEPRESERVE_PANEL= 'rgbHuePreservePanel';
 export const NO_BAND_PANEL= 'nobandPanel';
 
 
@@ -26,7 +28,7 @@ export const NO_BAND_PANEL= 'nobandPanel';
  * @param {Band} band
  * @return a reducer function. a standard type reducer function.
  */
-export const colorPanelChange= function(band) {
+export function colorPanelChange(band) {
     return (fields,action) => {
         if (!fields || !Object.keys(fields).length) fields= getFieldInit();
         const plot= primePlot(visRoot());
@@ -38,7 +40,7 @@ export const colorPanelChange= function(band) {
 
         return computeColorPanelState(fields, plottedRV, fitsData, band, action);
     };
-};
+}
 
 
 /**
@@ -52,29 +54,29 @@ export const colorPanelChange= function(band) {
  * @param action
  * @return {*}
  */
-const computeColorPanelState= function(fields, plottedRV, fitsData, band, action) {
+function computeColorPanelState(fields, plottedRV, fitsData, band, action) {
 
     switch (action.type) {
         case FieldGroupCntlr.VALUE_CHANGE:
-            var valid= Object.keys(fields).every( (key) => {
+            const valid= Object.keys(fields).every( (key) => {
                 return !fields[key].mounted ? true :  fields[key].valid;
             } );
             if (!valid) return fields;
             return syncFields(fields,makeRangeValuesFromFields(fields),fitsData);
-            break;
 
         case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
         case INIT_FIELD_GROUP:
         case ImagePlotCntlr.ANY_REPLOT:
             if (!plottedRV && !fitsData) return fields;
-            var newFields = updateFieldsFromRangeValues(fields,plottedRV);
+            // no update if hue-preserving: gammaOrStretch is a reused field
+            if (get(plottedRV, 'rgbPreserveHue', 0) > 0) return fields;
+            const newFields = updateFieldsFromRangeValues(fields,plottedRV);
             return syncFields(newFields,plottedRV,fitsData);
-            break;
 
     }
     return fields;
 
-};
+}
 
 
 /**
@@ -93,12 +95,12 @@ function syncFields(fields,rv,fitsData) {
     newFields.algorithm= clone(fields.algorithm, {value: rv.algorithm});
     newFields.lowerWhich=   clone(fields.lowerWhich, {value: rv.lowerWhich});
     newFields.upperWhich=   clone(fields.upperWhich, {value: rv.upperWhich});
+
     if (newFields.lowerWhich.value===ZSCALE) newFields.lowerWhich.value= PERCENTAGE;
     if (newFields.upperWhich.value===ZSCALE) newFields.upperWhich.value= PERCENTAGE;
 
     return  newFields;
 }
-
 
 /**
  * This function creates new 'lowerRange' field based on the 'lowerWhich' value. The min and max will be different
@@ -106,30 +108,32 @@ function syncFields(fields,rv,fitsData) {
  * @param {object} fields - map of fields
  * @param {RangeValues} rv
  * @param {WebFitsData} fitsData
+ * @param {String} lowerWhich - field key for the type of lower range
+ * @param {String} lowerRange - field key for lower range field
 */
-const computeLowerRangeField= function (fields,rv,fitsData) {
-    var resetDefault= (fields.lowerWhich.value!==rv.lowerWhich);
-    var retval;
+function computeLowerRangeField(fields,rv,fitsData,lowerWhich='lowerWhich', lowerRange='lowerRange') {
+    const resetDefault= (fields[lowerWhich].value!==rv.lowerWhich);
+    let retval;
     switch (rv.lowerWhich) {
         case PERCENTAGE:
         default :
             retval= {validator: Validate.floatRange.bind(null, 0, 100, 1, 'Lower range'),
-                value : resetDefault ? 1 : fields.lowerRange.value
+                value : resetDefault ? 1 : fields[lowerRange].value
             };
             break;
         case ABSOLUTE:
             retval= {validator: Validate.floatRange.bind(null,fitsData.dataMin, fitsData.dataMax, 3, 'Lower range'),
-                value : resetDefault ? fitsData.dataMin : fields.lowerRange.value
+                value : resetDefault ? fitsData.dataMin : fields[lowerRange].value
             };
             break;
         case SIGMA:
             retval= {validator: Validate.isFloat.bind(null,'Lower range'),
-                value : resetDefault ? -2 : fields.lowerRange.value
+                value : resetDefault ? -2 : fields[lowerRange].value
             };
             break;
     }
     return retval;
-};
+}
 
 /**
  * This function creates new 'upperRange' field based on the 'upperWhich' value. The min and max will be different
@@ -139,9 +143,9 @@ const computeLowerRangeField= function (fields,rv,fitsData) {
  * @param fitsData
  * @return {*}
  */
-const computeUpperRangeField= function(fields,rv,fitsData) {
-    var retval;
-    var resetDefault= (fields.upperWhich.value!==rv.upperWhich);
+function computeUpperRangeField(fields,rv,fitsData) {
+    let retval;
+    const resetDefault= (fields.upperWhich.value!==rv.upperWhich);
     switch (rv.upperWhich) {
         case PERCENTAGE:
         default :
@@ -162,17 +166,17 @@ const computeUpperRangeField= function(fields,rv,fitsData) {
             break;
     }
     return retval;
-};
+}
 
 /**
  * Make a new RangeValue object from the field settings.
  * @param fields
  * @return {RangeValues}
  */
-const makeRangeValuesFromFields= function(fields) {
+function makeRangeValuesFromFields(fields) {
 
-    var lowerWhich= (fields.zscale.value==='zscale') ? ZSCALE : fields.lowerWhich.value;
-    var upperWhich= (fields.zscale.value==='zscale') ? ZSCALE : fields.upperWhich.value;
+    const lowerWhich= (fields.zscale.value==='zscale') ? ZSCALE : fields.lowerWhich.value;
+    const upperWhich= (fields.zscale.value==='zscale') ? ZSCALE : fields.upperWhich.value;
 
     return new RangeValues(
             lowerWhich,
@@ -185,35 +189,35 @@ const makeRangeValuesFromFields= function(fields) {
             fields.zscaleContrast.value,
             fields.zscaleSamples.value,
             fields.zscaleSamplesPerLine.value);
-};
+}
 
 /**
  * Update all the fields from a RangeValues object.
  * @param fields
  * @param {RangeValues} rv
  */
-const updateFieldsFromRangeValues= function(fields,rv) {
+function updateFieldsFromRangeValues(fields,rv) {
     fields= clone(fields);
     fields.lowerWhich= cloneWithValue(fields.lowerWhich, rv.lowerWhich===ZSCALE ? PERCENTAGE : rv.lowerWhich);
     fields.lowerRange= cloneWithValue(fields.lowerRange, rv.lowerValue);
     fields.upperWhich= cloneWithValue(fields.upperWhich, rv.lowerWhich===ZSCALE ? PERCENTAGE : rv.upperWhich);
     fields.upperRange= cloneWithValue(fields.upperRange, rv.upperValue);
     fields.asinhQ= cloneWithValue(fields.asinhQ, rv.asinhQValue);
-    fields.gamma= cloneWithValue(fields.gamma, rv.gammaValue);
+    fields.gamma= cloneWithValue(fields.gamma, rv.gammaOrStretch);
     fields.algorithm= cloneWithValue(fields.algorithm, rv.algorithm);
     fields.zscaleContrast= cloneWithValue(fields.zscaleContrast, rv.zscaleContrast);
     fields.zscaleSamples= cloneWithValue(fields.zscaleSamples, rv.zscaleSamples);
     fields.zscaleSamplesPerLine= cloneWithValue(fields.zscaleSamplesPerLine, rv.zscaleSamplesPerLine);
     fields.zscale= cloneWithValue(fields.zscale,  rv.lowerWhich===ZSCALE ? 'zscale' : '');
     return fields;
-};
+}
 
 
 /**
  * defines fields
  * @return {{lowerRange: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, upperRange: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleContrast: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleSamples: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, zscaleSamplesPerLine: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, asinhQ: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, gamma: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, BP: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, WP: {fieldKey: string, value: string, validator: (function(this:null)), tooltip: string, label: string}, algorithm: {tooltip: string, label: string, value}, lowerWhich: {tooltip: string, label: string, value}, upperWhich: {tooltip: string, label: string, value}, zscale: {value: string, tooltip: string, label: string}}}
  */
-var getFieldInit= function() {
+function getFieldInit() {
 
     return {
         lowerRange: {
@@ -287,5 +291,179 @@ var getFieldInit= function() {
             label: ''
         }
     };
-};
+}
+
+
+function getHuePreserveFieldInit() {
+
+    return {
+        lowerRangeRed: {
+            value: '0',
+            validator: Validate.floatRange.bind(null, 0, 100, 1, 'Red pedestal'),
+            tooltip: 'Pedestal (black point value) for the red',
+            label: 'Red pedestal:'
+        },
+        lowerRangeGreen: {
+            value: '0',
+            validator: Validate.floatRange.bind(null, 0, 100, 1, 'Green pedestal'),
+            tooltip: 'Pedestal (black point value) for the green',
+            label: 'Green pedestal:'
+        },
+        lowerRangeBlue: {
+            value: '0',
+            validator: Validate.floatRange.bind(null, 0, 100, 1, 'Blue pedestal'),
+            tooltip: 'Pedestal (black point value) for the blue',
+            label: 'Blue pedestal:'
+        },
+        lowerWhichRed: {
+            tooltip: 'Type of pedestal value for the red',
+            label: '',
+            value: PERCENTAGE
+        },
+        lowerWhichGreen: {
+            tooltip: 'Type of pedestal value for the green',
+            label: '',
+            value: PERCENTAGE
+        },
+        lowerWhichBlue: {
+            tooltip: 'Type of pedestal value for the blue',
+            label: '',
+            value: PERCENTAGE
+        },
+        asinhQ: {
+            validator: Validate.floatRange.bind(null, 0, Number.MAX_VALUE, 4, 'Q'),
+            tooltip: 'The asinh softening parameter. Small Q values result in a linear stretch. Large values make a log stretch.',
+            label: 'Q:'
+        },
+        stretch: {
+            validator: Validate.floatRange.bind(null, 0.001, Number.MAX_VALUE, 4, 'Stretch'),
+            tooltip: 'The asinh stretch parameter. (The difference between min and max intensity.)',
+            label: 'Stretch:'
+        },
+        zscale: {
+            value: '',
+            tooltip: 'Use ZScale for bounds instead of entering them manually ',
+            label: ''
+        }
+    };
+}
+
+
+/**
+ * Reducer entry point. This function returns a reducer initialized to work with the passed band.
+ * @param {Array.<Band>} bands
+ * @return a reducer function. a standard type reducer function.
+ */
+export function rgbHuePreserveChange(bands) {
+
+    return (fields,action) => {
+        if (!fields || !Object.keys(fields).length) fields= getHuePreserveFieldInit();
+        const plot= primePlot(visRoot());
+        if (!plot || bands.some((b) => !plot.plotState.isBandUsed(b))) return fields;
+
+        const fitsDataAry= bands.map((b)=>plot.webFitsData[b.value]);
+        const plottedRVAry= bands.map((b)=>plot.plotState.getRangeValues(b));
+        if (fitsDataAry.some((fd)=>!fd) || plottedRVAry.some((rv)=>(!rv))) return fields;
+
+        return computeHuePreservePanelState(fields, plottedRVAry, fitsDataAry, bands, action);
+    };
+}
+
+/**
+ * Recompute the state. If there is a field value change then update the fields based on that.
+ * If there is a replot or a init the update all the fields based on the current plot
+ * @param fields
+ * @param plottedRVAry
+ * @param fitsDataAry
+ * @param bands
+ * @param action
+ * @returns {*}
+ */
+export function computeHuePreservePanelState(fields, plottedRVAry, fitsDataAry, bands, action) {
+
+    switch (action.type) {
+        case FieldGroupCntlr.VALUE_CHANGE:
+            const valid= Object.keys(fields).every( (key) => {
+                return !fields[key].mounted ? true :  fields[key].valid;
+            } );
+            if (!valid) return fields;
+            return syncFieldsHuePreserve(fields,makeHuePreserveRangeValuesFromFields(fields),fitsDataAry);
+
+        case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
+        case INIT_FIELD_GROUP:
+        case ImagePlotCntlr.ANY_REPLOT:
+            if (plottedRVAry.some((rv)=>!rv) && fitsDataAry.some((fd)=>!fd)) return fields;
+            const newFields = updateHuePreserveFieldsFromRangeValues(fields,plottedRVAry);
+            return syncFieldsHuePreserve(newFields,plottedRVAry,fitsDataAry);
+    }
+    return fields;
+}
+
+/**
+ * Sync the fields so that are consistent with the passed RangeValues.
+ * @param fields
+ * @param {Array} rvAry
+ * @param {Array} fitsDataAry
+ */
+function syncFieldsHuePreserve(fields,rvAry,fitsDataAry) {
+    const newFields= clone(fields);
+    [['lowerWhichRed','lowerRangeRed'],
+        ['lowerWhichGreen','lowerRangeGreen'],
+        ['lowerWhichBlue', 'lowerRangeBlue']].forEach(
+            ([lowerWhich,lowerRange],i) => {
+        if (Number.parseInt(rvAry[i].lowerRange)!==ZSCALE) {
+            newFields[lowerRange]= clone(fields[lowerRange], computeLowerRangeField(fields,rvAry[i],fitsDataAry[i],lowerWhich,lowerRange));
+        }
+        newFields[lowerWhich]=   clone(fields[lowerWhich], {value: rvAry[i].lowerWhich});
+        if (newFields[lowerWhich].value===ZSCALE) newFields[lowerWhich].value= PERCENTAGE;
+    });
+    newFields.algorithm= clone(fields.algorithm, {value: rvAry[0].algorithm});
+    return  newFields;
+}
+
+/**
+ * Make a new RangeValue object from the field settings.
+ * @param fields
+ * @return {Array.<RangeValues>}
+ */
+function makeHuePreserveRangeValuesFromFields(fields) {
+    const useZ = Boolean(fields.zscale.value);
+
+    const rvAry = [['lowerWhichRed','lowerRangeRed'],
+        ['lowerWhichGreen','lowerRangeGreen'],
+        ['lowerWhichBlue', 'lowerRangeBlue']].map(
+        ([lowerWhich,lowerRange]) => {
+            // using lower range values to calculate black points for each band
+            const lowerWhichVal= useZ ? ZSCALE : fields[lowerWhich].value;
+            return new RangeValues(
+                lowerWhichVal,
+                fields[lowerRange].value,
+                ZSCALE,
+                99,
+                fields.asinhQ.value,
+                fields.stretch.value,
+                STRETCH_ASINH);
+        });
+    return rvAry;
+}
+
+/**
+ * Update all the fields from a RangeValues object.
+ * @param fields
+ * @param {Array.<RangeValues>} rvAry
+ */
+function updateHuePreserveFieldsFromRangeValues(fields,rvAry) {
+    fields= clone(fields);
+    [['lowerWhichRed','lowerRangeRed'],
+        ['lowerWhichGreen','lowerRangeGreen'],
+        ['lowerWhichBlue', 'lowerRangeBlue']].forEach(([lowerWhich, lowerRange], i) => {
+        fields[lowerWhich]= cloneWithValue(fields[lowerWhich], rvAry[i].lowerWhich===ZSCALE ? PERCENTAGE : rvAry[i].lowerWhich);
+        fields[lowerRange]= cloneWithValue(fields[lowerRange], rvAry[i].lowerValue);
+    });
+    fields.asinhQ= cloneWithValue(fields.asinhQ, rvAry[0].asinhQValue);
+    fields.stretch= cloneWithValue(fields.stretch, Number(rvAry[0].gammaOrStretch).toFixed(1));
+    fields.zscale= cloneWithValue(fields.zscale,  rvAry[0].lowerWhich===ZSCALE ? 'zscale' : '');
+    return fields;
+}
+
 

--- a/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
@@ -1,0 +1,75 @@
+import React, {PureComponent} from 'react';
+import {debounce} from 'lodash';
+import {replot3ColorHuePreserving} from './ColorDialog.jsx';
+import {getTypeMinField, getZscaleCheckbox, renderAsinH} from './ColorBandPanel.jsx';
+import {getFieldGroupResults} from '../../fieldGroup/FieldGroupUtils';
+import {ValidationField} from '../../ui/ValidationField.jsx';
+
+
+export class ColorRGBHuePreservingPanel extends PureComponent {
+
+    constructor(props) {
+        super(props);
+        this.doReplot= debounce(getReplotFunc(props.groupKey), 600);
+    }
+
+    render() {
+        const {rgbFields} = this.props;
+        const textPadding = {paddingBottom:3};
+        const LABEL_WIDTH= 105;
+        const renderRange = (isZscale) => {
+            if (isZscale) {
+                return null;
+            } else {
+                return (
+                    <div>
+                        <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='lowerRangeRed'
+                            />
+                            {getTypeMinField('lowerWhichRed')}
+                        </div>
+                        <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='lowerRangeGreen'
+                            />
+                            {getTypeMinField('lowerWhichGreen')}
+                        </div>
+                        <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='lowerRangeBlue'
+                            />
+                            {getTypeMinField('lowerWhichBlue')}
+                        </div>
+                        <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='stretch'/>
+                        </div>
+                    </div>
+                );
+            }
+        };
+
+        const asinH = renderAsinH(rgbFields, renderRange, this.doReplot);
+        return (
+            <div style={{minWidth:360, padding:5, position: 'relative'}}>
+                {asinH}
+                <div style={{position:'absolute', bottom:5, left:5, right:5}}>
+                    {getZscaleCheckbox()}
+                </div>
+            </div>
+        );
+    }
+}
+
+function getReplotFunc(groupKey) {
+
+    return () => {
+        const request = getFieldGroupResults(groupKey);
+        replot3ColorHuePreserving(request);
+    };
+}

--- a/src/firefly/js/visualize/ui/StretchDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/StretchDropDownView.jsx
@@ -124,7 +124,7 @@ export function StretchDropDownView({plotView:pv, toolbarElement}) {
                            onClick={() => stretchByZscaleAlgorithm(pv,rv,STRETCH_ASINH)}/>
             <DropDownVerticalSeparator/>
 
-            {enabled && <AlgorithmDependentItems {...{pv,rv}}/>}
+            {enabled && renderAlgorithmDependentItems({pv,rv})}
         </SingleColumnMenu>
         );
 
@@ -135,7 +135,7 @@ StretchDropDownView.propTypes= {
     toolbarElement : PropTypes.object
 };
 
-function AlgorithmDependentItems({pv,rv}) {
+function renderAlgorithmDependentItems({pv,rv}) {
     const enabled = true;
     if (rv.algorithm === STRETCH_ASINH) {
         return (

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/ImageDataTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/ImageDataTest.java
@@ -4,7 +4,8 @@ package edu.caltech.ipac.visualize.plot;
 import edu.caltech.ipac.firefly.util.FileLoader;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsReadFactory;
-import nom.tam.fits.*;
+import nom.tam.fits.Fits;
+import nom.tam.fits.FitsException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -13,6 +14,7 @@ import org.junit.Test;
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.IndexColorModel;
 import java.io.File;
@@ -139,7 +141,7 @@ public class ImageDataTest {
      */
     @Test
     public void testGetColorModel(){
-        IndexColorModel indexColorModel = imageData.getColorModel();
+        ColorModel indexColorModel = imageData.getColorModel();
         Assert.assertNotNull(indexColorModel );
         Assert.assertEquals(ColorTable.getColorModel(0), indexColorModel);
     }
@@ -151,7 +153,7 @@ public class ImageDataTest {
     public void testRecomputeStretch(){
         //Recalculate stretch
         imageData.getImage(frArray);
-        imageData.recomputeStretch(frArray, 0, rangeValues, true);
+        imageData.recomputeStretch(0, rangeValues);
         BufferedImage  stretchImage  =imageData.getImage(frArray);
         Assert.assertNotEquals(expectedImage, stretchImage);
     }
@@ -175,7 +177,7 @@ public class ImageDataTest {
 
 
         //Test the ImageData withmask
-        ImageData  imageDataWithMask = new ImageData(IMAGE_TYPE,imageMasks, rangeValues, 0,0, 100, 100);
+        ImageData  imageDataWithMask = new ImageData(imageMasks, rangeValues, 0,0, 100, 100);
         BufferedImage calculatedImageWithMask  = imageDataWithMask.getImage(frArray);
         compareImage(expectedImageWithMask,calculatedImageWithMask);
 
@@ -237,7 +239,7 @@ public class ImageDataTest {
 
 
         //test ImageData with mask
-        imageData = new ImageData(IMAGE_TYPE,imageMasks,rangeValues, 0,0, 100, 100);
+        imageData = new ImageData(imageMasks,rangeValues, 0,0, 100, 100);
         bufferedImage = imageData.getImage(frArray);
         outputfile = new File(FileLoader.getDataPath(ImageDataTest.class)+"imageDataWithMaskTest.png");
         ImageIO.write(bufferedImage, "png", outputfile);


### PR DESCRIPTION
Test deployment: https://irsawebdev9.ipac.caltech.edu/dm-14799/firefly/
Ticket: https://jira.lsstcorp.org/browse/DM-14799

This PR is an implementation of Lupton 2004 RGB stretch, using astropy lupton_rgb.py as a reference.
Hue-preserving option is added to 3-color stretch dialog, when red, blue, and green bands are used.
For best results, the images need to be on the same scale, with background subtracted.

The easiest way to use this stretch is with zscale option enabled. In this case zscale is used to obtain black points (pedestal values or minimums) for each band. After intensity is calculated, zscale is used to obtain stretch value for asinh algorithm. (You can see the stretch used, if you turn off zscale option.)

With zscale option is unchecked, pedestal values for each band and stretch (intensity range for asinh algorithm) can be entered directly.

Paper:
https://arxiv.org/pdf/astro-ph/0312483.pdf

Implementation in  astropy:
https://github.com/astropy/astropy/blob/master/astropy/visualization/lupton_rgb.py