### PR TITLE
DM-13491 handle name resolution failures

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/net/NedNameResolver.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/net/NedNameResolver.java
@@ -19,6 +19,7 @@ import org.apache.xmlbeans.XmlOptions;
 import org.usVo.xml.voTable.VOTABLEDocument;
 
 import java.net.URL;
+import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.HashMap;
 
@@ -28,62 +29,67 @@ import java.util.HashMap;
  */
 public class NedNameResolver {
 
-   private static final String CGI_CMD="/cgi-bin/nph-objsearch?extend=no&out_csys=Equatorial&out_equinox=J2000.0&obj_sort=RA+or+Longitude&of=xml_main&zv_breaker=30000.0&list_limit=1&img_stamp=NO&objname=";
+    private static final String CGI_CMD="/cgi-bin/nph-objsearch?extend=no&out_csys=Equatorial&out_equinox=J2000.0&obj_sort=RA+or+Longitude&of=xml_main&zv_breaker=30000.0&list_limit=1&img_stamp=NO&objname=";
 
 
-   public static PositionJ2000 getPositionVOTable(String objname) throws FailedRequestException {
-      PositionJ2000 pos = null;
-      Logger.info("Requesting name resolution for \"" + objname + "\"...");
+    public static PositionJ2000 getPositionVOTable(String objname) throws FailedRequestException {
+        PositionJ2000 pos = null;
+        Logger.info("Requesting name resolution for \"" + objname + "\"...");
 
-      HostPort hp = NetworkManager.getInstance().getServer(
-            NetworkManager.NED_SERVER);
+        HostPort hp = NetworkManager.getInstance().getServer(
+                NetworkManager.NED_SERVER);
 
-       try {
+        try {
 
 
-           String urlStr = "https://" + hp.getHost() + ":" + hp.getPort() + CGI_CMD + URLEncoder.encode(objname, "UTF-8");
-           System.out.printf("url: %s%n", urlStr);
+            String urlStr = "https://" + hp.getHost() + ":" + hp.getPort() + CGI_CMD + URLEncoder.encode(objname, "UTF-8");
+            System.out.printf("url: %s%n", urlStr);
 
-           URL url = new URL(urlStr);
+            URL url = new URL(urlStr);
+            URLConnection conn = URLDownload.makeConnection(url);
+            // set connect and read timeout in milliseconds
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(10000);
+            
+            String data = URLDownload.getStringFromOpenURL(conn, null);
+            // System.out.println(data);
 
-           String data = URLDownload.getStringFromURL(url, null);
-           // System.out.println(data);
+            XmlOptions xmlOptions = new XmlOptions();
+            HashMap<String, String> substituteNamespaceList =
+                    new HashMap<String, String>();
+            substituteNamespaceList.put("", "http://us-vo.org/xml/VOTable.xsd");
+            xmlOptions.setLoadSubstituteNamespaces(substituteNamespaceList);
+            xmlOptions.setSavePrettyPrint();
+            xmlOptions.setSavePrettyPrintIndent(4);
 
-           XmlOptions xmlOptions = new XmlOptions();
-           HashMap<String, String> substituteNamespaceList =
-                   new HashMap<String, String>();
-           substituteNamespaceList.put("", "http://us-vo.org/xml/VOTable.xsd");
-           xmlOptions.setLoadSubstituteNamespaces(substituteNamespaceList);
-           xmlOptions.setSavePrettyPrint();
-           xmlOptions.setSavePrettyPrintIndent(4);
-
-           //VOTABLEDocument voTableDoc = parseVoTable(data, xmlOptions);
-           VOTABLEDocument voTableDoc = VOTABLEDocument.Factory.parse(
-                   data,xmlOptions);
+            //VOTABLEDocument voTableDoc = parseVoTable(data, xmlOptions);
+            VOTABLEDocument voTableDoc = VOTABLEDocument.Factory.parse(
+                    data,xmlOptions);
 //        PrintWriter outF= new PrintWriter(new File("vo.dat"));
 //        outF.println(voTableDoc.toString());
 
-           //System.out.println(voTableDoc.toString());
+            //System.out.println(voTableDoc.toString());
 
-           //nedResult = NedVOTableParser.makeNedResult(voTableDoc);
+            //nedResult = NedVOTableParser.makeNedResult(voTableDoc);
 
-           FixedObjectGroup fixGroup = FixedObjectGroupUtils.makeFixedObjectGroup(voTableDoc);
-           if (fixGroup.size() >0) {
-               FixedObject fixedObj = fixGroup.get(0);
-               WorldPt wpt = Plot.convert(fixedObj.getPosition(), CoordinateSys.EQ_J2000);
-               pos = new PositionJ2000(wpt.getLon(), wpt.getLat());
-           }
-           else
+            FixedObjectGroup fixGroup = FixedObjectGroupUtils.makeFixedObjectGroup(voTableDoc);
+            if (fixGroup.size() >0) {
+                FixedObject fixedObj = fixGroup.get(0);
+                WorldPt wpt = Plot.convert(fixedObj.getPosition(), CoordinateSys.EQ_J2000);
+                pos = new PositionJ2000(wpt.getLon(), wpt.getLat());
+            }
+            else
                 throw new FailedRequestException("NED did not find the object: " +objname,
-                   "NED could not resolve the input object name: " +objname);
+                        "NED could not resolve the input object name: " +objname);
+
+        } catch (java.net.SocketTimeoutException ste) {
+            throw new FailedRequestException("NED name resolver: connection timed out.");
+        } catch (Exception e) {
+            throw new FailedRequestException("NED did not find the object: " +objname,
+                    "NED could not resolve the input object name: " +objname, e);
+        }
 
 
-       } catch (Exception e) {
-           throw new FailedRequestException("NED did not find the object: " +objname,
-                   "NED could not resolve the input object name: " +objname, e);
-       }
-
-
-      return pos;
-   }
+        return pos;
+    }
 }

--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -58,15 +58,20 @@ function makeSearchPromise(objName, resolver= 'nedthensimbad') {
     const url= `${getRootPath()}sticky/CmdSrv?objName=${objName}&resolver=${resolver}&cmd=CmdResolveName`;
     const searchPromise= new Promise(
         function(resolve, reject) {
-            // fetch will be aborted after timeout
-            const fetchTimeoutMs = 7000;
-            const controller = new AbortController();
-            const signal = controller.signal;
-            setTimeout(() => {
-                controller.abort();
-            }, fetchTimeoutMs);
+            let fetchOptions = {};
+            // AbortController might not be available in older browsers
+            if (typeof AbortController !== 'undefined') {
+                // fetch will be aborted after timeout
+                const fetchTimeoutMs = 7000;
+                const controller = new AbortController();
+                const signal = controller.signal;
+                setTimeout(() => {
+                    controller.abort();
+                }, fetchTimeoutMs);
+                fetchOptions = {signal};
+            }
 
-            fetchUrl(url, {signal}).then( (response) => {
+            fetchUrl(url, fetchOptions).then( (response) => {
                     response.json().then((value) => {
                         resolve(value);
                     });

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -339,7 +339,11 @@ export function fetchUrl(url, options, doValidation= true, enableDefOptions= tru
                 return new Error(`${url} failed with status: ${response}.statusText`);
             }
         }).catch( (error) => {
-            throw new Error(`Request failed: ${url}`, error);
+            if (error.name === 'AbortError') {
+                throw error; // fetch aborted
+            } else {
+                throw new Error(`Request failed: ${url}`, error);
+            }
         });
 }
 


### PR DESCRIPTION
Ticket: https://jira.lsstcorp.org/browse/DM-13491

When name is being resolved and Search button is clicked, the search is not started until all fields are validated. Validation can not be completed until target resolution promise is resolved. If the service is unresponsive, name resolution might not return for a long time.

Enforce timeouts on name resolution calls both on client and server side.
If name resolution times out or fails for another reason, the target field should be shown as invalid, and the search should not continue.