### PR TITLE
Dm 12636 Modify FITS header display to use local headers 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -135,10 +135,12 @@ public class VisJsonSerializer {
         if (header==null) return null;
         JSONObject map = new JSONObject();
         Cursor<String, HeaderCard> i= header.iterator();
-        for(HeaderCard card= i.next(); i.hasNext();  card= i.next()) {
+        int pos = 0;
+        for(HeaderCard card= i.next(); i.hasNext();  card= i.next(), pos++) {
             JSONObject mapValue = new JSONObject();
             mapValue.put("value", card.getValue());
             mapValue.put("comment", card.getComment());
+            mapValue.put("idx", pos);
             map.put(card.getKey(), mapValue);
         }
         return map;

--- a/src/firefly/js/rpc/PlotServicesJson.js
+++ b/src/firefly/js/rpc/PlotServicesJson.js
@@ -142,6 +142,7 @@ export function callCrop(stateAry, corner1ImagePt, corner2ImagePt, cropMultiAll)
     
 }
 //LZ 3/22/16 DM-4494
+/*
 export  function  callGetFitsHeaderInfo(plotState, tableId) {
 
     var params ={ [ServerParams.STATE]: plotState.toJson(false),
@@ -151,6 +152,7 @@ export  function  callGetFitsHeaderInfo(plotState, tableId) {
     var result = doJsonRequest(ServerParams.FITS_HEADER, params, true);
     return result;//doJsonRequest(ServerParams.FITS_HEADER, params);
 }
+*/
 
 
 export function callGetFileFlux(stateAry, pt) {

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -477,7 +477,7 @@ export function getSizeAsString(size) {
 
     let retval;
     if (size > 0 && size < (MEG)) {
-        retval= ((size / K) + 1) + kStr;
+        retval= ((size / K)) + kStr;
     }
     else if (size >= (MEG) && size <  (2*GIG) ) {
         const megs = Math.round(size / MEG);

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -399,7 +399,7 @@ export const WebPlot= {
             screenSize: {width:wpInit.dataWidth*zf, height:wpInit.dataHeight*zf},
             zoomFactor: zf,
             attributes,
-            clientFitsHeaderAry,
+            clientFitsHeaderAry
             //=== End Mutable =====================
         };
         plot= clone(plot, imagePlot);

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -104,7 +104,8 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
 
 
     if (!isDialogVisible(popupId)) {
-        dispatchAddActionWatcher({actions: [ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW], callback:  watchActivePlotChange});
+        dispatchAddActionWatcher({actions: [ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW, ImagePlotCntlr.CHANGE_PRIME_PLOT],
+                                  callback:  watchActivePlotChange});
         DialogRootContainer.defineDialog(popupId, getPopup(plot, fitsHeaderInfo), element);
         dispatchShowDialog(popupId, plot.plotId);
     }
@@ -301,7 +302,7 @@ function createTableIdForFitsHeader(plot) {
 
     }
 
-    const str = plot.title.replace(/\s/g, '');                   //remove the white places
+    const str = plot.plotImageId.replace(/\s/g, '');                   //remove the white places
     return  str.replace(/[^a-zA-Z0-9]/g, '_')  + colors; //replace the no numeric/alphabet character by _
 }
 

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
-import {primePlot} from '../PlotViewUtil.js';
+import {primePlot, getPlotViewById} from '../PlotViewUtil.js';
 import {Tabs, Tab} from '../../ui/panel/TabPanel.jsx';
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 import {dispatchShowDialog, dispatchHideDialog, isDialogVisible} from '../../core/ComponentCntlr.js';
@@ -74,12 +74,19 @@ function popupForm(plot, fitsHeaderInfo, popupId) {
 const FITSHEADER_DIALOGID = popupIdRoot+'_fitsHeader';
 
 function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
-
-    //var popupId = popupIdRoot + '_' + tableId;
-
     const popupId = FITSHEADER_DIALOGID;
     const getTitle =  (p) => {
-         return 'FITS Header : ' + p.title;
+         const EXT = ': - ext.';
+         const idx = p.title ? p.title.indexOf(EXT) : -1;
+         let   title;
+
+         if (idx < 0) {
+             title = p.title;
+         } else {
+             const pv = getPlotViewById(visRoot(), p.plotId);
+             title = p.title.slice(0, idx) + ' - ' + (pv.primeIdx+1);
+         }
+         return 'FITS Header : ' + title;
     };
 
     const getPopup = (aPlot, fitsHeaderTbl) => {
@@ -98,7 +105,7 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
             const newTableModel = createFitsHeaderTable(null, crtPlot);
 
             DialogRootContainer.defineDialog(popupId, getPopup(crtPlot, newTableModel), element);
-            dispatchShowDialog(popupId, plot.plotId);
+            dispatchShowDialog(popupId, crtPlot.plotId);
         }
     };
 

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -19,6 +19,8 @@ import {get} from 'lodash';
 import {dispatchAddActionWatcher} from '../../core/MasterSaga.js';
 import numeral from 'numeral';
 import ImagePlotCntlr, {visRoot} from '../ImagePlotCntlr.js';
+import {getTblById} from '../../tables/TableUtil.js';
+import {TABLE_SORT, TABLE_REPLACE, dispatchTableSort} from '../../tables/TablesCntlr.js';
 
 const popupIdRoot = 'directFileAccessData';
 const popupPanelResizableStyle = {
@@ -59,6 +61,9 @@ export const helpIdStyle = {'textAlign': 'center', display: 'inline-block', heig
 //3-color styles
 const tabStyle =  {width: '100%',height:'100%', display: 'inline-block', background:bgColor};
 
+const FITSHEADERCONTENT = 'fitsHeader';
+let currentSortInfo = '';
+
 
 function popupForm(plot, fitsHeaderInfo, popupId) {
 
@@ -98,27 +103,85 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
         );
     };
 
+    const updatePopup = (p, tableInfo) => {
+        return () => {
+            DialogRootContainer.defineDialog(popupId, getPopup(p, tableInfo), element);
+            dispatchShowDialog(popupId, p.plotId);
+        };
+    };
+
+
+    // update table sort when active image is changed
     const watchActivePlotChange = (action, cancelSelf) => {
         if (!isDialogVisible(popupId)) {
             cancelSelf();
         } else {
-            const {plotId} = action.payload;
-            const crtPlot = primePlot(visRoot(), plotId);
-            const newTableModel = createFitsHeaderTable(null, crtPlot);
+            const crtPlot = primePlot(visRoot());
+            const newTableInfo = createFitsHeaderTable(null, crtPlot);
 
-            DialogRootContainer.defineDialog(popupId, getPopup(crtPlot, newTableModel), element);
-            dispatchShowDialog(popupId, crtPlot.plotId);
+            Object.keys(newTableInfo).reduce((prev, oneBand) => {
+                prev = prev | updateTableSort(newTableInfo[oneBand]);
+
+                return prev;
+            }, false);
+
+            updatePopup(crtPlot, newTableInfo)();
+
+        }
+    };
+
+    const isFitsHeaderTable = (tbl) => {
+        return tbl&&(get(tbl, ['tableMeta', 'content'], '') === FITSHEADERCONTENT);
+    };
+
+    // update table sort info when there 'sort' happens, update table sort on new table
+    const watchActiveTableChange = (action, cancelSelf) => {
+        if (!isDialogVisible(popupId)) {
+            cancelSelf();
+        } else {
+            console.log('action.type = '+ action.type);
+            let tblModel;
+            if (action.type === TABLE_SORT) {
+                const {sortInfo='', tbl_id} = get(action.payload, ['request']) || {};
+                tblModel = getTblById(tbl_id);
+
+                if (isFitsHeaderTable(tblModel)) {
+                    currentSortInfo = sortInfo;          // when sort happens
+                }
+            } else if (action.type === TABLE_REPLACE) {  // do sorting on newly added table
+                tblModel = action.payload;
+
+                if (isFitsHeaderTable(tblModel)) {
+                    updateTableSort(tblModel);
+                }
+              }
         }
     };
 
 
     if (!isDialogVisible(popupId)) {
-        dispatchAddActionWatcher({actions: [ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW, ImagePlotCntlr.CHANGE_PRIME_PLOT],
+        dispatchAddActionWatcher({actions: [ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW,
+                                            ImagePlotCntlr.CHANGE_PRIME_PLOT,
+                                            ImagePlotCntlr.PLOT_IMAGE,
+                                            ImagePlotCntlr.DELETE_PLOT_VIEW],
                                   callback:  watchActivePlotChange});
-        DialogRootContainer.defineDialog(popupId, getPopup(plot, fitsHeaderInfo), element);
-        dispatchShowDialog(popupId, plot.plotId);
+        dispatchAddActionWatcher({actions: [TABLE_SORT, TABLE_REPLACE],
+                                  callback:  watchActiveTableChange});
+
+        updatePopup(plot, fitsHeaderInfo)();
     }
 }
+
+// update table sort when table tab is changed
+const onBandSelected = (fitsHeaderInfo) => {
+    return (index, id, name) => {
+        const tableModel = fitsHeaderInfo[name];
+
+        if (tableModel) {   // already in store, then sort it if needed
+            updateTableSort(tableModel);
+        }
+    };
+};
 
 function renderSingleBandFitsHeader(plot, fitsHeaderInfo, popupId){
     const band = plot.plotState.getBands()[0];
@@ -141,7 +204,7 @@ function renderColorBandsFitsHeaders(plot, fitsHeaderInfo, popupId) {
     switch (bands.length){
         case 2:
         colorBandTabs = (
-                <Tabs defaultSelected={0} useFlex={true}>
+                <Tabs defaultSelected={0} useFlex={true} onTabSelect={onBandSelected(fitsHeaderInfo)}>
                     {renderSingleTab(plot, bands[0],fitsHeaderInfo )}
                     {renderSingleTab(plot, bands[1],fitsHeaderInfo )}
             </Tabs>
@@ -149,7 +212,7 @@ function renderColorBandsFitsHeaders(plot, fitsHeaderInfo, popupId) {
             break;
         case 3:
             colorBandTabs = (
-                <Tabs defaultSelected={0} useFlex={true}>
+                <Tabs defaultSelected={0} useFlex={true} onTabSelect={onBandSelected(fitsHeaderInfo)}>
                     {renderSingleTab(plot, bands[0],fitsHeaderInfo )}
                     {renderSingleTab(plot, bands[1],fitsHeaderInfo )}
                     {renderSingleTab(plot, bands[2],fitsHeaderInfo )}
@@ -354,11 +417,19 @@ function createFitsHeaderTable(tableId, plot) {
 
     return bands.reduce((prev, oneBand) => {
             const tbl_id = oneBand === Band.NO_BAND ? tableId: `${tableId}-${oneBand.key}`;
-            const data = getHeaderData(get(headerAry, [oneBand]));
+            const tbl = getTblById(tbl_id);
+            if (!tbl) {
+                const data = getHeaderData(get(headerAry, [oneBand]));
 
-            prev[oneBand.key] = {tbl_id, tableData: {columns, data},
-                                 totalRows: data.length, highlightedRow: 0,
-                                 tableMeta: {fileSize: get(plot, ['webFitsData', oneBand, 'getFitsFileSize'])}};
+                prev[oneBand.key] = {
+                    tbl_id, tableData: {columns, data},
+                    totalRows: data.length, highlightedRow: 0,
+                    tableMeta: {fileSize: get(plot, ['webFitsData', oneBand, 'getFitsFileSize']),
+                                content: FITSHEADERCONTENT}
+                };
+            } else {
+                prev[oneBand.key] = tbl;
+            }
         return prev;
     }, {});
 }
@@ -373,3 +444,21 @@ function sortHeaderKey(header) {
         return header[a].idx - header[b].idx;
     };
 }
+
+// resort table based on current sort info.
+const updateTableSort = (tbl) => {
+    if (!getTblById(tbl.tbl_id)) {
+        return false;        // check if table is in store yet.
+    }
+    const sortInfo_add = get(tbl, ['request', 'sortInfo'], '');
+
+    if (sortInfo_add !== currentSortInfo) {
+        const {request={}} = tbl;
+        const req = Object.assign({}, request, {sortInfo: currentSortInfo});
+
+        dispatchTableSort(req, tbl.highlightedRow);
+        return true;
+    } else {
+        return false;
+    }
+};

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -75,16 +75,18 @@ const FITSHEADER_DIALOGID = popupIdRoot+'_fitsHeader';
 
 function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
     const popupId = FITSHEADER_DIALOGID;
+
     const getTitle =  (p) => {
-         const EXT = ': - ext.';
-         const idx = p.title ? p.title.indexOf(EXT) : -1;
+         const pv = getPlotViewById(visRoot(), p.plotId);
          let   title;
 
-         if (idx < 0) {
+         if (pv.plots.length === 1) {
              title = p.title;
          } else {
-             const pv = getPlotViewById(visRoot(), p.plotId);
-             title = p.title.slice(0, idx) + ' - ' + (pv.primeIdx+1);
+             const EXT = ': - ext.';
+             const idx = p.title ? p.title.indexOf(EXT) : -1;
+
+             title = (idx >= 0 ?  p.title.slice(0, idx) : p.title) + ' - ' + (pv.primeIdx+1);
          }
          return 'FITS Header : ' + title;
     };


### PR DESCRIPTION
The development includes, 
- modify FITS header display to use local headers instead of calling the server
- the content of FITS header dialog is updated as the user clicks on the image displayed or goes through the extensions. 

test: 
start Firefly
- get multiple images, open FITS header dialog, change the active image and check the content change of FITS header dialog. 
- upload a FITS image with multiple extensions, get FITS header dialog, change the extensions and check the content change of FITS header dialog. 

 