### PR TITLE
DM-15219: chart bug fixes, found in NED 

### DIFF
--- a/src/firefly/html/demo/ffapi-sed.html
+++ b/src/firefly/html/demo/ffapi-sed.html
@@ -50,10 +50,7 @@
                 null,  // alt_source
                 {filters: '"NED Units" like \'Jy\''} // options
             );
-
-            // while waiting for NED to provide us a numeric column for upper limit and uncertainty
-            // using the db expression to generate upper limit column:
-            tblReq.inclCols = '"No.","Frequency","NED Photometry Measurement","NED Uncertainty",CASEWHEN(IFNULL("NED Photometry Measurement", 0) > 0, NULL, 10) as "NED Limit"'
+            //tblReq.inclCols = '"No.","Frequency","Flux Density","Upper limit of Flux Density","Lower limit of uncertainty","Upper limit of uncertainty"'
 
             var wrapperReq = firefly.util.table.makeTblRequest('IpacTableFromSource', 'SED: ARP-220',
                 {searchRequest: tblReq}, {pageSize: 50});
@@ -66,15 +63,19 @@
                     name: 'sed',
                     tbl_id: tblId,
                     //text: 'tables::"No."', // does not display - probably not needed, if chart and table are connected
-                    x: 'tables::log(Frequency)',
+                    x: 'tables::log("Frequency")',
                     // error_x: {
                     //     // assuming error is a fifth of the Frequency
-                    //     array_minus: 'tables::log("Frequency")-log("Frequency"-"Frequency"/5)', // error bar (minus)
+                    //     arrayminus: 'tables::log("Frequency")-log("Frequency"-"Frequency"/5)', // error bar (minus)
                     //     array: 'tables::log("Frequency"+"Frequency"/5)-log("Frequency")', // error bar (plus)
                     // },
-                    y: 'tables::log("NED Photometry Measurement")',
+                    y: 'tables::log("Flux Density")',
+                    error_y: {
+                         arrayminus: 'tables::log("Flux Density")-log("Flux Density"-"Lower limit of uncertainty")', // error bar (minus)
+                         array: 'tables::log("Flux Density"+"Upper limit of uncertainty")-log("Flux Density")', // error bar (plus)
+                    },
                     firefly: {
-                        yMax: 'tables::log("NED Limit")'
+                        yMax: 'tables::log("Upper limit of Flux Density")'
                     },
                     mode: 'markers'
                 }],

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -15,7 +15,7 @@ import {
 import shallowequal from 'shallowequal';
 
 import {getAppOptions} from '../core/AppDataCntlr.js';
-import {getTblById, isFullyLoaded, watchTableChanges} from '../tables/TableUtil.js';
+import {getTblById, isFullyLoaded, stripColumnNameQuotes, watchTableChanges} from '../tables/TableUtil.js';
 import {TABLE_HIGHLIGHT, TABLE_LOADED, TABLE_SELECT} from '../tables/TablesCntlr.js';
 import {dispatchLoadTblStats} from './TableStatsCntlr.js';
 import {dispatchChartUpdate, dispatchChartHighlighted, dispatchChartSelect, getChartData} from './ChartsCntlr.js';
@@ -703,10 +703,6 @@ export function formatColExpr({colOrExpr, quoted, colNames}) {
     return colOrExpr;
 }
 
-export function replaceQuotesIfSurrounding(s) {
-    const newS = s.replace(/^"(.+)"$/, '$1');
-    return newS.includes('"') ? s : newS;
-}
 
 // plotly default color (items 0-7) + color-blind friendly colors
 export const TRACE_COLORS = [  '#1f77b4', '#2ca02c', '#d62728', '#9467bd',

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -2,10 +2,10 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {get, uniqueId} from 'lodash';
-import {getTblById, getColumn, doFetchTable} from '../../tables/TableUtil.js';
+import {getTblById, getColumn, doFetchTable, stripColumnNameQuotes} from '../../tables/TableUtil.js';
 import {makeTableFunctionRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {dispatchChartUpdate, dispatchError, getChartData} from '../ChartsCntlr.js';
-import {singleTraceUI, replaceQuotesIfSurrounding} from '../ChartUtil.js';
+import {singleTraceUI} from '../ChartUtil.js';
 import {serializeDecimateInfo, parseDecimateKey} from '../../tables/Decimate.js';
 import BrowserInfo from  '../../util/BrowserInfo.js';
 import {formatColExpr} from '../ChartUtil.js';
@@ -110,8 +110,8 @@ function getChanges({tableModel, mappings, chartId, traceNum}) {
     }
 
     // default axes labels for the first trace (remove surrounding quotes, if any)
-    const xLabel = replaceQuotesIfSurrounding(get(mappings, 'x'));
-    const yLabel = replaceQuotesIfSurrounding(get(mappings, 'y'));
+    const xLabel = stripColumnNameQuotes(get(mappings, 'x'));
+    const yLabel = stripColumnNameQuotes(get(mappings, 'y'));
     const xTipLabel = xLabel.length > 20 ? xLabel.substring(0,18)+'...' : xLabel;
     const yTipLabel = yLabel.length > 20 ? yLabel.substring(0,18)+'...' : yLabel;
 

--- a/src/firefly/js/charts/dataTypes/FireflyHistogram.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHistogram.js
@@ -3,10 +3,10 @@
  */
 import {get, identity, isArray, isUndefined, uniqueId} from 'lodash';
 import {logError} from '../../util/WebUtil.js';
-import {COL_TYPE, getColumn, getColumns, getTblById, doFetchTable} from '../../tables/TableUtil.js';
+import {COL_TYPE, getColumn, getColumns, getTblById, doFetchTable, stripColumnNameQuotes} from '../../tables/TableUtil.js';
 import {cloneRequest, makeTableFunctionRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {dispatchChartUpdate, dispatchError, getChartData} from '../ChartsCntlr.js';
-import {formatColExpr, replaceQuotesIfSurrounding} from '../ChartUtil.js';
+import {formatColExpr} from '../ChartUtil.js';
 
 
 import {toMaxFixed, getDecimalPlaces} from '../../util/MathUtil.js';
@@ -123,7 +123,7 @@ function fetchData(chartId, traceNum, tablesource) {
                     const xColumn = getColumn(getTblById(tbl_id), xLabel);
                     const xUnit = get(xColumn, 'units', '');
                     //remove surrounding quotes, if any
-                    if (xLabel.startsWith('"')) { xLabel = replaceQuotesIfSurrounding(xLabel); }
+                    if (xLabel.startsWith('"')) { xLabel = stripColumnNameQuotes(xLabel); }
                     changes['layout.xaxis.title'] = xLabel + (xUnit ? ` (${xUnit})` : '');
                 }
                 const yAxisLabel = get(layout, 'yaxis.title');

--- a/src/firefly/js/charts/ui/options/Errors.jsx
+++ b/src/firefly/js/charts/ui/options/Errors.jsx
@@ -15,9 +15,23 @@ export const ERR_TYPE_OPTIONS = [
 
 ];
 
-export function errorTypeFieldKey(activeTrace, axis) { return `data.${activeTrace}.fireflyData.error_${axis}.errorsType`; }
+export function errorTypeFieldKey(activeTrace, axis) { return `fireflyData.${activeTrace}.error_${axis}.errorsType`; }
 export function errorFieldKey(activeTrace, axis) { return `_tables.data.${activeTrace}.error_${axis}.array`; }
 export function errorMinusFieldKey(activeTrace, axis) { return `_tables.data.${activeTrace}.error_${axis}.arrayminus`; }
+
+export function getDefaultErrorType(chartData, activeTrace, axis) {
+    const errorMinus = get(chartData, errorMinusFieldKey(activeTrace, axis).replace(/^_tables./, ''));
+    if (errorMinus) {
+        return 'asym';
+    } else {
+        const error = get(chartData, errorFieldKey(activeTrace, axis).replace(/^_tables./, ''));
+        if (error) {
+            return 'sym';
+        } else {
+            return 'none';
+        }
+    }
+}
 
 export class Errors extends PureComponent {
 

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -15,7 +15,7 @@ import {updateSet} from '../../../util/WebUtil.js';
 import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
 import {getColValStats} from '../../TableStatsCntlr.js';
 import {ColumnOrExpression} from '../ColumnOrExpression.jsx';
-import {Errors, errorTypeFieldKey, errorFieldKey, errorMinusFieldKey} from './Errors.jsx';
+import {Errors, errorTypeFieldKey, errorFieldKey, errorMinusFieldKey, getDefaultErrorType} from './Errors.jsx';
 import {getAppOptions} from '../../../core/AppDataCntlr.js';
 import {getTblById} from '../../../tables/TableUtil.js';
 
@@ -78,7 +78,8 @@ export function fieldReducer({chartId, activeTrace}) {
     const basicReducer = basicFieldReducer({chartId, activeTrace});
 
     const getFields = () => {
-        const {data, fireflyData, tablesources={}} = getChartData(chartId);
+        const chartData = getChartData(chartId);
+        const {data, fireflyData, tablesources={}} = chartData;
         const tablesourceMappings = get(tablesources[activeTrace], 'mappings');
 
         // when a symbol is substituted with an array,
@@ -109,11 +110,11 @@ export function fieldReducer({chartId, activeTrace}) {
             },
             [errorTypeFieldKey(activeTrace, 'x')]: {
                 fieldKey: errorTypeFieldKey(activeTrace, 'x'),
-                value: get(data, errorTypeFieldKey(activeTrace, 'x').replace(/^data./, ''), 'none')
+                value: get(chartData, errorTypeFieldKey(activeTrace, 'x'), getDefaultErrorType(chartData, activeTrace, 'x'))
             },
             [errorTypeFieldKey(activeTrace, 'y')]: {
                 fieldKey: errorTypeFieldKey(activeTrace, 'y'),
-                value: get(data, errorTypeFieldKey(activeTrace, 'y').replace(/^data./, ''), 'none')
+                value: get(chartData, errorTypeFieldKey(activeTrace, 'y'), getDefaultErrorType(chartData, activeTrace, 'y'))
             },
             ...basicReducer(null)
         };

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {getColumnIdx, getColumn, isNumericType, getTblById} from './TableUtil.js';
+import {getColumnIdx, getColumn, isNumericType, getTblById, stripColumnNameQuotes} from './TableUtil.js';
 import {Expression} from '../util/expr/Expression.js';
 import {isUndefined, get, isArray, isEmpty} from 'lodash';
 import {showInfoPopup} from '../ui/PopupUtil.jsx';
@@ -33,7 +33,7 @@ function parseInput(input, options={}) {
     cname = op ? cname.trim() : '';
     if (!isEmpty(rest)) val += rest.join(); // value contains operators.  just put it back.
     if (removeQuotes) {
-        cname = cname.replace(/"([A-Za-z\d_]+)"/g, '$1');
+        cname = stripColumnNameQuotes(cname);
     }
     return [cname, op, val];
 }
@@ -63,7 +63,7 @@ export class FilterInfo {
      * @returns {FilterInfo}
      */
     static parse(filterString) {
-        var filterInfo = new FilterInfo();
+        const filterInfo = new FilterInfo();
         filterString && filterString.split(';').forEach( (v) => {
                 const [cname, op, val] = parseInput(v, {removeQuotes: true});
                 if (cname && op) {
@@ -137,7 +137,6 @@ export class FilterInfo {
         const rval = [true, ''];
         const allowCols = columns.concat({name:'ROW_IDX'});
         if (filterInfo && filterInfo.trim().length > 0) {
-            filterInfo = filterInfo.replace(/"(.+?)"/g, '$1'); // remove quotes
             return filterInfo.split(';').reduce( ([isValid, msg], v) => {
                 const [cname] = parseInput(v);
                 if (!cname) {
@@ -457,3 +456,4 @@ function autoCorrectCondition(v, isNumeric=false) {
     }
     return `${op} ${val}`;
 }
+

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -911,7 +911,18 @@ export function makeBgKey(tbl_id) {
     return `tables:${tbl_id}`;
 }
 
+/**
+ * If input is '"x"', outputs 'x', but if input is '"x"+"y"' or 'log("x")' output is the same as input
+ * @param s
+ * @returns {*}
+ */
+export function stripColumnNameQuotes(s) {
+    const newS = s.replace(/^"(.+)"$/, '$1');
+    return newS.includes('"') ? s : newS;
+}
+
 /*-------------------------------------private------------------------------------------------*/
+
 /**
  * Action watcher callback for table update, which is invoked when
  * the table given by tbl_id is fully loaded.

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -151,7 +151,7 @@ function makeCallbacks(onChange, columns, data, orgFilterInfo='') {
 
     const onFilter = (fieldVal) => {
         if (fieldVal.valid) {
-            const filterInfo = collectFilterInfo(data);
+            const filterInfo = collectFilterInfo(data, orgFilterInfo);
             if (filterInfo !== orgFilterInfo) {
                 onChange && onChange({filterInfo});
             }
@@ -161,11 +161,12 @@ function makeCallbacks(onChange, columns, data, orgFilterInfo='') {
     return {onSelectAll, onRowSelect, onSort, onFilter, onAllFilter};
 }
 
-function collectFilterInfo(data) {
-    const filterCls = FilterInfo.parse('');
-    data.filter( (row) => row[1]).forEach( (row) => {
+function collectFilterInfo(data, orgFilterInfo) {
+    const filterCls = FilterInfo.parse(orgFilterInfo);
+    // filter the cells with a value or previous value
+    data.filter( (row) => row[1]||filterCls.getFilter(row[0])).forEach( (row) => {
         if (row[1] !== NOT_CELL_DATA) {
-            filterCls.addFilter(row[0], row[1]);
+            filterCls.setFilter(row[0], row[1]);
         }
     });
     return filterCls.serialize();

--- a/src/firefly/js/util/expr/Expr.js
+++ b/src/firefly/js/util/expr/Expr.js
@@ -43,6 +43,8 @@
 // NVL2 - If <value expr 1> is not null, returns <value expr 2>, otherwise returns <value expr 3>. (HyperSQL)
 /** Ternary operator: if null         */  export const NVL2  = 200;
 
+export const ANY_FUNC = 500;
+
 /**
  * Make a literal expression.
  * @param {number} v the constant value of the expression
@@ -105,6 +107,19 @@ export function makeApp3(rator, rand0, rand1, rand2) {
             ? new LiteralExpr(app.value())
             : app;
 }
+/**
+ * Make an expression that applies a n-ary operator to n operands.
+ * @param {number} rator - a code for a binary operator
+ * @param {Array.<Expr>} randAry - operands
+ * @return an expression meaning rator(...randAry)
+ */
+export function makeAppN(rator, randAry) {
+    const app = new NaryExpr(rator, randAry);
+    return randAry.every((e) => e instanceof LiteralExpr)
+            ? new LiteralExpr(app.value())
+            : app;
+}
+
 /**
  * Make a conditional expression.
  * @param test (Expr) `if' part
@@ -213,6 +228,19 @@ class TernaryExpr {
         switch (this.rator) {
             case NVL2: Number.isFinite(arg0) ? arg1 : arg2;
             default: throw 'BUG: bad rator: '+this.rator;
+        }
+    }
+}
+
+class NaryExpr {
+
+    constructor(rator, randAry) {
+        this.rator = rator;
+        //this.randAry = randAry;
+    }
+    value() {
+        switch (this.rator) {
+            default: throw 'Unsupported function: '+this.rator;
         }
     }
 }

--- a/src/firefly/js/util/expr/Expression.js
+++ b/src/firefly/js/util/expr/Expression.js
@@ -21,6 +21,10 @@ export class Expression {
         if (isArray(allowedVariables)) {
             allowedVariables.forEach((v)=>{
                 parser.allow(makeVariable(v));
+                // also allow quoted variables
+                if (!v.startsWith('\"')) {
+                    parser.allow(makeVariable(`"${v}"`));
+                }
             });
         }
         try {

--- a/src/firefly/js/util/expr/Parser.js
+++ b/src/firefly/js/util/expr/Parser.js
@@ -55,6 +55,10 @@ const rators3 = [
     Expr.NVL2
 ];
 
+const procsN = [
+    'decimate_key'
+];
+
 /**
  Parses strings representing mathematical formulas with variables.
  The following operators, in descending order of precedence, are
@@ -193,7 +197,7 @@ const rators3 = [
         let expr = this.parseFactor();
         loop1:
         for (;;) {
-            var l, r, rator;
+            let l, r, rator;
 
             // The operator precedence table.
             // l = left precedence, r = right precedence, rator = operator.
@@ -240,7 +244,7 @@ const rators3 = [
 
 
     parseFactor() {
-        var i;
+        let i;
         switch (this.token.ttype) {
             case Token.TT_NUMBER: {
                 const lit = Expr.makeLiteral(this.token.nval);
@@ -287,6 +291,18 @@ const rators3 = [
                         const rand3 = this.parseExpr(0);
                         this.expect(')');
                         return Expr.makeApp3(rators3[i], rand1, rand2, rand3);
+                    }
+                }
+                for (i = 0; i < procsN.length; ++i) {
+                    if (procsN[i]===this.token.sval) {
+                        this.nextToken();
+                        this.expect('(');
+                        const rand1 = this.parseExpr(0);
+                        const randAry = [rand1];
+                        while (this.expectOneOf([',', ')']) !== ')') {
+                            randAry.push(this.parseExpr(0));
+                        }
+                        return Expr.makeAppN(Expr.ANY_FUNC, randAry);
                     }
                 }
                 if (this.token.sval === 'if') {
@@ -338,6 +354,18 @@ const rators3 = [
                 SyntaxException.EXPECTED, '' + ttype);
         }
         this.nextToken();
+    }
+
+    expectOneOf(ttypeAry) {
+        if (ttypeAry.includes(this.token.ttype)) {
+            const ttypeMatched = this.token.ttype;
+            this.nextToken();
+            return ttypeMatched;
+        } else {
+            const aryAsStr = '"' + ttypeAry.join('" or "') + '"';
+            throw this.error(aryAsStr + ' expected',
+                SyntaxException.EXPECTED, aryAsStr);
+        }
     }
 
 }

--- a/src/firefly/js/util/expr/SyntaxException.js
+++ b/src/firefly/js/util/expr/SyntaxException.js
@@ -28,6 +28,9 @@ export const UNKNOWN_VARIABLE = 4;
 
 
 function quotify(s) {
+    if (Array.isArray(s)) {
+        return '"' + s.join('","') + '"';
+    }
     return `"${s}"`;
 }
 
@@ -44,7 +47,7 @@ function theToken(scanner) {
 function isLegalToken(scanner) {
     const t = scanner.getCurrentToken();
     return t.ttype !== Token.TT_EOF
-            && t.ttype != Token.TT_ERROR;
+            && t.ttype !== Token.TT_ERROR;
 }
 
 function explainWhere(scanner) {


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-15219
https://jira.lsstcorp.org/browse/DM-14886
Test deployment: https://irsawebdev9.ipac.caltech.edu/dm-15219/firefly/

This PR addresses multiple chart and filter related bugs, found in NED:
- Fixed filter bug, described in DM-15148: error when chart is filtered after another table filter is applied (for example on Units)
- Quoted columns should be considered valid in chart options 
- Error type in chart options should match the data
- When error is empty, no error bar should not be displayed (0 length bar was displayed before) 
- FilterEditor should allow filters update without clearing expression-based filters.
- Allow filter update by changing free-form filter in FilterEditor

To test, use http://localhost:8080/firefly/demo/ffapi-sed.html
- apply filters from table and then chart and vice versa
- verify that chart options show Asym errors for the first chart, and Sym errors for the second
- change the chart via options (apply grid, for example) - there should be no validation errors in the pre-populated fields, like "Frequency".
- check that points without uncertainty appear as dots
- try modifying or removing filters in FilterEditor