### PR TITLE
DM-15248 add 'textangle' to text region per DS9 documentation.

### DIFF
--- a/src/firefly/html/demo/ffapi-region-test.html
+++ b/src/firefly/html/demo/ffapi-region-test.html
@@ -113,10 +113,12 @@
 
             window.basicRegions = [
                 'circle  202.4844693750341 47.23118060364845 13.9268922364868 # color=cyan text={circle 1}',
-                'J2000;box 202.4844693750341 47.23118060364845 0.0069268922364 0.0069268922364  0 # color=red text={box 2}',
+                'J2000;box 202.4844693750341 47.23118060364845 0.0069268922364 0.0069268922364  0  # color=red text={box 2}',
                 'image;circle  100.4844693750341 147.23118060364845 10.0239268922364868 # color=#B8E986 text={circle 2}',
-                'image;ellipse 99 88 10 20 -5 # color=orange text={ellipse with good coordinate}',
-                'image:ellipse 80 77 nani nani nan # color=yellow text={ellipse with nan coodinate}'
+                'image;ellipse 99 88 10 20 -30 # color=orange text={ellipse with good coordinate}',
+                'image:ellipse 80 77 nani nani nan # color=yellow text={ellipse with nan coodinate}',
+                'text 215p 300p # color=magenta text={text test 3 } edit=0 highlite=0  font="BRAGGADOCIO 10 normal italic" textangle=30',
+                'box 215p 300p 80 30 30  # color=blue text={box on # J2000 with size w=80 & h=30} width=2'
             ];
 
 

--- a/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
@@ -687,6 +687,9 @@ public class RegionFactory {
                 retval.pointType= parsePointType(token);
                 lookForPointSize= true;
             }
+            else if (token.toLowerCase().startsWith("textangle=")) {
+                retval.ops.setTextAngle(parseFloat(token, 0));
+            }
             else if (lookForPointSize) {
                 try {
                     retval.ptSize= Integer.parseInt(token);
@@ -761,6 +764,22 @@ public class RegionFactory {
             }
         }
         return width ;
+    }
+
+    private static float parseFloat(String token, float defVal)
+    {
+        float val = defVal;
+        StringTokenizer st1 = new StringTokenizer(token, "=");
+        if (st1.hasMoreToken()) st1.nextToken();
+        if (st1.hasMoreToken())
+        {
+            try {
+                val= Float.parseFloat(st1.nextToken().trim());
+            } catch (NumberFormatException e) {
+                val= defVal;
+            }
+        }
+        return val;
     }
 
     private static boolean isCoordSys(String s) {
@@ -916,6 +935,8 @@ public class RegionFactory {
 
     private static String makeValue(String k, String v) { return k+"="+v+" "; }
 
+    private static String makeValue(String k, float v) { return makeValue(k, v+""); }
+
     private static String makeValue(String k, boolean v) {
         String vStr= v ? "1" : "0";
         return k+"="+vStr+" ";
@@ -988,6 +1009,11 @@ public class RegionFactory {
             if (!op.getFont().equals(globalOps.getFont())) {
                 sb.append(makeValue("font","\""+op.getFont()+"\""));
             }
+            if (op.getTextAngle() != globalOps.getTextAngle()) {
+                sb.append(makeValue("textangle", op.getTextAngle()));
+
+            }
+
             if (optionElement instanceof RegionPoint) {
                 RegionPoint rp= (RegionPoint)optionElement;
                 sb.append(makeValue("point", rp.getPointType().toString().toLowerCase()));

--- a/src/firefly/java/edu/caltech/ipac/util/dd/RegionOptions.java
+++ b/src/firefly/java/edu/caltech/ipac/util/dd/RegionOptions.java
@@ -27,6 +27,7 @@ public class RegionOptions implements Serializable {
     private int     offsetX= 0;
     private int     offsetY= 0;
     private String  text= "";
+    private float textAngle=0;
     private RegionFont font= new RegionFont("helvetica", 10, "normal", "roman");
 
     public RegionOptions() {}
@@ -135,6 +136,12 @@ public class RegionOptions implements Serializable {
     public void setInclude(boolean include) {
         this.include = include;
     }
+
+    public void setTextAngle(float textAngle) {
+        this.textAngle = textAngle;
+    }
+
+    public float getTextAngle() { return textAngle; }
 
     public RegionOptions copy() {
         RegionOptions op= new RegionOptions();

--- a/src/firefly/js/util/Color.js
+++ b/src/firefly/js/util/Color.js
@@ -191,6 +191,9 @@ export function getRGBA(color) {
 
 export function rateOpacity(color, ratio) {
     const rgba = getRGBA(color);
+    if (!rgba) {
+        return 'rgba(255, 255, 255,' + (1.0*ratio) + ')';
+    }
     const newAlpha = Math.max(Math.min(rgba[3] * ratio, 1.0), 0.0);
     const newColor = rgba.slice(R, A);
     newColor.push(newAlpha);
@@ -200,6 +203,11 @@ export function rateOpacity(color, ratio) {
 
 export function maximizeOpacity(color) {
     const rgba = getRGBA(color);
+
+    if (!rgba) {
+        return 'rgba(255, 255, 255, 1.0)';
+    }
+
     rgba[A] = 1.0;
     return toRGBAString(rgba);
 }

--- a/src/firefly/js/visualize/draw/DrawUtil.js
+++ b/src/firefly/js/visualize/draw/DrawUtil.js
@@ -179,9 +179,9 @@ function drawTextCanvas(ctx, text, x,y,color= 'red', renderOptions= {}, location
 
 
     const {textBaseline= 'top', textAlign= 'start', rotationAngle=0} = locationOptions;
-    const {fontFamily='helvetica', fontSize='9px', fontWeight='normal', fontStyle='normal'} = fontOptions;
+    const {fontName='helvetica', fontSize='9px', fontWeight='normal', fontStyle='normal'} = fontOptions;
 
-    ctx.font= `${fontStyle} ${fontSize} ${fontFamily}`;
+    ctx.font= `${fontStyle} ${fontWeight} ${fontSize} ${fontName}`;
     // offscreenCtx.fillStyle= 'rgba(0,0,0,.4)';
     // offscreenCtx.strokeStyle='rgba(0,0,0,.2)';
     // ctx.textAlign= 'center';

--- a/src/firefly/js/visualize/draw/MocObj.js
+++ b/src/firefly/js/visualize/draw/MocObj.js
@@ -15,6 +15,7 @@ import {rateOpacity} from '../../util/Color.js';
 const MOC_OBJ= 'MOCObj';
 const DEFAULT_STYLE= Style.STANDARD;
 const DEF_WIDTH = 1;
+const MAX_MAPORDER = 25;
 
 /**
  * Draw one or more polygons defined in Multi-Order Coverage Map, MOC.
@@ -247,7 +248,7 @@ export class MocGroup {
         this.visibleMap = {};
         this.highestOrderInMap = 0;
 
-        new Array(this.displayOrder).fill(0).map((i, idx) => idx + 1)
+        new Array(Math.min(this.displayOrder, MAX_MAPORDER)).fill(0).map((i, idx) => idx + 1)
             .find((d) => {
                 if ((d > 1) && Object.keys(this.visibleMap[d - 1]).length > 5000) {
                     return true;
@@ -402,7 +403,7 @@ export class MocGroup {
             return true;
         }
 
-        if (toOrder >this.displayOrder) return false;
+        if (toOrder > Math.min(this.displayOrder, MAX_MAPORDER)) return false;
 
         const lastOrder = this.getHighestOrderFromMap(toOrder);
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -222,7 +222,7 @@ function makePolygon(ptAry, drawObjAry=null) {
  * @desc make a text
  *  @param   pt
  *  @param  text
- *  @param  rotationAngle - the rotation angle + deg
+ *  @param  rotationAngle - the rotation angle + 'deg'
  * @return {*}
  */
 function makeText(pt, text, rotationAngle=undefined) {
@@ -668,7 +668,7 @@ function drawCircle(drawObj, ctx,  plot, drawParams) {
 export function drawText(drawObj, ctx, plot, inPt, drawParams) {
     if (!inPt) return false;
     
-    const {text, textOffset, renderOptions, rotationAngle, textBaseline= 'top', textAlign='start'}= drawObj;
+    const {text, textOffset, renderOptions, rotationAngle, textBaseline= 'top', textAlign='start', textAngle=0}= drawObj;
     //the angle of the grid line
     var angle=undefined;
     var pvAngle=undefined;
@@ -683,16 +683,24 @@ export function drawText(drawObj, ctx, plot, inPt, drawParams) {
             angle = pvAngle + lineAngle;
         }
         if (angle){
-            angle = angle>360? (angle-360)+'deg' : angle+'deg';
+            //angle = angle>360? (angle-360)+'deg' : angle+'deg';
+            while (angle > 360 || angle < -360) {
+                angle = angle > 360 ? (angle-360) : (angle+360);
+            }
         }
+    }
 
+    if (textAngle) {
+        angle = angle ? angle - textAngle : -textAngle;
     }
 
     const {fontName, fontSize, fontWeight, fontStyle}= drawParams;
     const color = drawParams.color || drawObj.color || 'black';
 
     const devicePt= plot.getDeviceCoords(inPt);
-    if (!plot.pointOnDisplay(devicePt)) {
+
+    //if (!plot.pointOnDisplay(devicePt)) {
+    if (!devicePt) {
         return false;
     }
 

--- a/src/firefly/js/visualize/region/Region.js
+++ b/src/firefly/js/visualize/region/Region.js
@@ -122,10 +122,11 @@ export const makeRegionOptions = (
                 offsetY,
                 message,
                 tag,
-                coordSys} )  => (
+                coordSys,
+                textAngle} )  => (
                 cloneArg({color, text, font, pointType, pointSize,
                           editable, movable, rotatable, highlightable, deletable, fixedSize, include,
-                          lineWidth, dashable, dashlist, source, offsetX, offsetY, message, tag, coordSys})
+                          lineWidth, dashable, dashlist, source, offsetX, offsetY, message, tag, coordSys, textAngle})
                 );
 
 
@@ -154,7 +155,8 @@ export const regionPropsList = {
         OFFY:    'offsetY',
         TEXTLOC: 'textloc',
         COORD:   'coordSys',
-        MSG:     'message'
+        MSG:     'message',
+        TEXTANGLE: 'textAngle'
 };
 
 export const defaultRegionProperty = {
@@ -182,7 +184,7 @@ export const defaultRegionProperty = {
     offsetY: 0,
     coordSys: 'PHYSICAL',
     textLoc: 'DEFAULT',
-
+    textAngle: 0,
     message: ''
 };
 

--- a/src/firefly/js/visualize/region/RegionDrawer.js
+++ b/src/firefly/js/visualize/region/RegionDrawer.js
@@ -221,6 +221,13 @@ function updateDrawobjProp(rgPropAry, rgOptions, dObj) {
                 dObj.size = get(rgOptions, regionProp, getRegionDefault(regionProp));
                 break;
 
+            case regionPropsList.TEXTANGLE:
+                const a = get(rgOptions, regionProp, getRegionDefault(regionProp));
+                if (a) {
+                    dObj.textAngle = a;
+                }
+                break;
+
             default:
                 break;
         }
@@ -615,8 +622,10 @@ function drawRegionText(regionObj) {
     }
 
     var tObj = ShapeDataObj.makeText(regionObj.wpAry[0], text);
-    updateDrawobjProp([regionPropsList.COLOR, regionPropsList.FONT, regionPropsList.OFFX],
+    updateDrawobjProp([regionPropsList.COLOR, regionPropsList.FONT, regionPropsList.OFFX, regionPropsList.TEXTANGLE],
                        regionObj.options, tObj);
+    tObj.textAlign = 'center';        // the text is aligned to the center for ds9 text region
+    tObj.textBaseline = 'middle';
 
     return [tObj];
 }

--- a/src/firefly/js/visualize/region/RegionFactory.js
+++ b/src/firefly/js/visualize/region/RegionFactory.js
@@ -952,7 +952,7 @@ export class RegionFactory {
         const [ERR, CONT, STOP] = [0, 1, 2];
         const optionsName = [ 'color', 'dashlist','text', 'width','font','select', 'highlite',
                               'dash', 'fixed',  'edit', 'move', 'delete', 'include', 'rotate',
-                               'source', 'background', 'line', 'ruler', 'point'];
+                              'source', 'background', 'line', 'ruler', 'point', 'textangle'];
 
         if (rgCsys) {
             set(rgOptions, regionPropsList.COORD, rgCsys);
@@ -1178,6 +1178,13 @@ export class RegionFactory {
                     opValRes = getOptionValue(ops, getValueBeforeChar, ' ');
                     if (opValRes.valueStr) {
                         set(rgOptions, regionPropsList.SOURCE, isTrue(opValRes.valueStr));
+                    }
+                    break;
+
+                case 'textangle':
+                    opValRes = getOptionValue(ops, getValueBeforeChar, ' ');
+                    if (opValRes.valueStr) {
+                        set(rgOptions, regionPropsList.TEXTANGLE, parseFloat(opValRes.valueStr));
                     }
                     break;
 

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -225,6 +225,7 @@ function renderTable(band, fitsHeaderInfo, isPlacedOnTab) {
 /**
  * This function will return the popup component.  As React conversion, the CamelCase is used.
  * @param plotView
+ * @param element
  */
 export function fitsHeaderView(plotView,element) {
 


### PR DESCRIPTION
The development includes
- allow 'textangle' to be provided in the property of region description, like
  `text 1074 110 "Text" # color=yellow textangle=45.0`
   text of  region 'text' is shown to be rotated if the region description is with 'textangle'. 
- the development is made at both javascript and server sides.
- a test sample in Python for region text with 'textangle' is added into firefly_client. 
   https://github.com/Caltech-IPAC/firefly_client/pull/29

also includes some extra fixing for MOC display - set a upper limit on the order for  generating visible tiles per display field of view to filter out invisible tiles defined in MOC file.

To test: 
- for the sever side, get region 'text' from uploaded region file,
   start firefly, upload region file from firefly_test_data/region-test-files/regionText.reg
- for the client side, 
   start firefly/demo/ffapi-region-test.html, click 'load sample image', click 'create region layer', a region 'text' with 'textangle' is shown. 



  

