### PR TITLE
DM-14514 provide UI for uploading 'instrument footprints' in region description

### DIFF
--- a/src/firefly/html/demo/ffapi-footprint-test.html
+++ b/src/firefly/html/demo/ffapi-footprint-test.html
@@ -18,36 +18,31 @@
 
 
 <div style="width: 500px; padding: 10px 0 0 10px;">
-    This page demos footprint on image with target at (0;0; J2000)
+    This page demos footprint on image with target at (10.68;41.26)
     <br>
 </div>
 
-<div id ="imageForRegion" style="border: 1px solid blue;width: 600px; height: 600px; margin: 10px;"></div>
+<div id ="imageForFootprint" style="border: 1px solid blue;width: 600px; height: 600px; margin: 10px;"></div>
 
 <div style="width:800px">
 
     <p style="margin-top:3px">Add new footprint overlay on above image:  <p/>
     <ul>
     <li><span style="color: blue">Create Footprint Layer:</span> enter region ID or use the hint, compose footprint description in the editing area, then click to add the new layer</li>
-    <li><span style="color: blue">Select Footprint Layer:</span> select a layer from the list and click to select the layer, the description of the selected footprint is shown in the editing area and the
-                                  first region in the footprint is highlighted</li>
     <li><span style="color: blue">Delete Footprint Layer:</span> select a layer from the list and click to delete the layer </li>
     </ul>
 </div>
 
 <div>
-    <a title="create a new region layer" href='javascript:createRegionLayer()'>Create Footprint Layer</a>
-    <input type='text' placeholder='' list='regionCreated' id='createRegionId' name='createRegionLayer'>
-    <datalist id='regionCreated'>
+    <a title="create a new region layer" href='javascript:createFootprintLayer()'>Create Footprint Layer</a>
+    <input type='text' placeholder='' list='footprintCreated' id='createFootprintId' name='createFootprintLayer'>
+    <datalist id='footprintCreated'>
     </datalist>
     &nbsp;
-    <a title="select a region layer" href='javascript:selectRegion()'>Select Footprint Layer:</a>
-    <select id='regionLayers'><option selected disabled>Region Layers:</option></select>
-    &nbsp;
-    <a title="delete a region layer" href='javascript:deleteRegionLayer()'>Delete Foorprint Layer</a>
-    <select id='regionList_delete'><option selected disabled>Region Layer:</option></select>
+    <a title="delete a region layer" href='javascript:deleteFootprintLayer()'>Delete Foorprint Layer</a>
+    <select id='footprintList_delete'><option selected disabled>Footprint Layer:</option></select>
     <div>
-        <textarea id="regionLayerContent" style="width: 800px; height: 300px; margin: 10px;"> </textarea>
+        <textarea id="footprintLayerContent" style="width: 800px; height: 300px; margin: 10px;"> </textarea>
     </div>
 </div>
 
@@ -72,21 +67,22 @@
             var util= firefly.util;
             var ui= firefly.ui;
 
-            firefly.showImage('imageForRegion', {
+            firefly.showImage('imageForFootprint', {
                 Type      : 'SERVICE',
-                plotId:   'regiontest',
+                plotId:   'footprinttest',
                 plotGroupId : 'myGroup',
                 Service  : 'WISE',
                 Title     : 'WISE W1 (3.4 microns)',
                 SurveyKey  : '3a',
                 SurveyKeyBand  : '1',
-                WorldPt    : '0.0;0.0;EQ_J2000',
-                SizeInDeg  : '1.5',
+                WorldPt    : '10.68;41.26;EQ_J2000',
+                SizeInDeg  : '0.8',
                 AllowImageSelection : true});
 
             window.regionAry = [
+                'global rotate=0',
                 'J2000',
-                'POLYGON -0.2D -0.2D -0.2D 0.2D 0.2D 0.2D 0.2D -0.2D # COLOR=ORANGE',
+                'POLYGON -0.2D -0.2D -0.2D 0.2D 0.2D 0.2D 0.2D -0.2D # COLOR=RED',
                 'POLYGON -0.18D -0.18D -0.18D 0.18D 0.18D 0.18D 0.18D -0.18D # COLOR=RED'
             ];
 
@@ -95,20 +91,21 @@
             window.regionsList = {};
             window.regionId = 0;
 
-            document.getElementById('regionLayerContent').value = window.regionAry.join('\n');
-            document.getElementById('createRegionId').placeholder = "Region_Plot_" + (window.regionId+1);
+            document.getElementById('footprintLayerContent').value = window.regionAry.join('\n');
+            document.getElementById('createFootprintId').placeholder = "Region_Plot_" + (window.regionId+1);
         };
 
-        createRegionLayer = function() {
-            var layerId = document.getElementById('createRegionId').value;
+
+        createFootprintLayer = function() {
+            var layerId = document.getElementById('createFootprintId').value;
 
             if (!layerId) {
                 window.regionId++;
-                layerId = "Region_Plot_" + window.regionId;
-                document.getElementById('createRegionId').value = layerId;
+                layerId = "Footprint_Plot_" + window.regionId;
+                document.getElementById('createFootprintId').value = layerId;
             }
             if (layerId) {
-                var regionAry = document.getElementById('regionLayerContent').value.split('\n').filter(function (r) {
+                var regionAry = document.getElementById('footprintLayerContent').value.split('\n').filter(function (r) {
                     return (r.length !== 0);
                 });
 
@@ -116,14 +113,16 @@
                     window.regions.push(layerId);
                 }
                 window.regionsList[layerId] = regionAry;  // add new or update existing region layer
-                updateRegionLayerList();
+                updateFootprintLayerList();
 
-                firefly.action.dispatchCreateRegionLayer(layerId, layerId, null, regionAry, 'regiontest');
+                firefly.action.dispatchCreateFootprintLayer(layerId, null, {relocateBy: 'origin', fromRegionAry: regionAry},
+                                                            'footprinttest', true);
+
             }
         };
 
         updateDataList = function() {
-            var datalist = document.getElementById('regionCreated');
+            var datalist = document.getElementById('footprintCreated');
             var options = '';
 
             window.regions.forEach( function(r) {
@@ -131,12 +130,12 @@
             });
 
             datalist.innerHTML = options;
-            document.getElementById('createRegionId').value = '';
-            document.getElementById('createRegionId').placeholder = "Region_Plot_" + (window.regionId+1);
+            document.getElementById('createFootprintId').value = '';
+            document.getElementById('createFootprintId').placeholder = "Region_Plot_" + (window.regionId+1);
         };
 
-        updateRegionLayerList = function() {
-            var selectListIds = ['regionLayers', 'regionList_delete'];
+        updateFootprintLayerList = function() {
+            var selectListIds = ['footprintList_delete'];
 
             selectListIds.forEach( function(selectId) {
                 var selectBox = document.getElementById(selectId);
@@ -157,33 +156,17 @@
 
         };
 
-        selectRegion = function() {
-            var selectBox=document.getElementById('regionLayers');
-            var selectedLayerId = selectBox.options[selectBox.selectedIndex].value;
-
-            if (window.regions.indexOf(selectedLayerId) >= 0) {
-                var regionAry = window.regionsList[selectedLayerId];
-                var regionArea = document.getElementById('regionLayerContent');
-
-                regionArea.value = regionAry.join('\n');
-
-                if (selectedLayerId) {
-                    firefly.action.dispatchSelectRegion(selectedLayerId, regionAry);
-                }
-            }
-        };
-
-        deleteRegionLayer = function() {
-            var selectBox = document.getElementById('regionList_delete');
+        deleteFootprintLayer = function() {
+            var selectBox = document.getElementById('footprintList_delete');
 
             if (selectBox.selectedIndex !== 0) {
                 var selectedLayerId = selectBox.options[selectBox.selectedIndex].value;
 
                 window.regions.splice(selectBox.selectedIndex - 1, 1);
                 delete window.regionsList[selectedLayerId];
-                updateRegionLayerList();
+                updateFootprintLayerList();
 
-                firefly.action.dispatchDeleteRegionLayer(selectedLayerId, 'regiontest');
+                firefly.action.dispatchDetachLayerFromPlot(selectedLayerId, 'footprinttest', true, true);
             }
         };
 

--- a/src/firefly/html/demo/ffapi-footprint-test.html
+++ b/src/firefly/html/demo/ffapi-footprint-test.html
@@ -79,13 +79,21 @@
                 SizeInDeg  : '0.8',
                 AllowImageSelection : true});
 
+
             window.regionAry = [
                 'global rotate=0',
                 'J2000',
                 'POLYGON -0.2D -0.2D -0.2D 0.2D 0.2D 0.2D 0.2D -0.2D # COLOR=RED',
                 'POLYGON -0.18D -0.18D -0.18D 0.18D 0.18D 0.18D 0.18D -0.18D # COLOR=RED'
             ];
-
+            /*
+            window.regionAry = [
+                'global rotate=1',
+                'physical;circle(0,0,150) # color=red text={this is a circle}',
+                'ellipse(465, 578, 40, 20, 30) # fixed=1 text={this is an ellipse}',
+                'box(465, 578, 40, 20, 30) # fixed=1 text={this is a box}'
+            ];
+            */
             window.emptyRegion = '';
             window.regions = [];
             window.regionsList = {};

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
@@ -348,6 +348,7 @@ public class VisServerCommands {
 
     public static class DS9Region extends ServCommand {
         private static final String footprintKey = "${footprintDef}";
+        private static final String footprintFileKey="${footprintFile}";
 
         public String doCommand(SrvParam sp) throws IllegalArgumentException, IOException {
             String fileKey = sp.getRequired(ServerParams.FILE_KEY);
@@ -355,6 +356,8 @@ public class VisServerCommands {
 
             if (fileKey.contains(footprintKey)) {
                 result = VisServerOps.getFootprintRegion(fileKey.substring(footprintKey.length()));
+            } else if (fileKey.contains(footprintFileKey)) {
+                result = VisServerOps.getRelocatableRegions(fileKey.substring(footprintFileKey.length()));
             } else {
                 result = VisServerOps.getDS9Region(fileKey);
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -67,14 +67,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.ColorModel;
-import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.RandomAccessFile;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1148,6 +1141,40 @@ public class VisServerOps {
         }
     }
 
+    public static WebPlotResult getRelocatableRegions(String fileKey) {
+        List<String> rAsStrList =  new ArrayList<>();
+        List<String> msgList =  new ArrayList<>();
+        WebPlotResult retval = new WebPlotResult();
+
+        try {
+            Cache sessionCache = UserCache.getInstance();
+            File fpFile = ServerContext.convertToFile(fileKey);
+
+            if (fpFile == null || !fpFile.canRead()) {
+                UploadFileInfo tmp = (UploadFileInfo) (sessionCache.get(new StringKey(fileKey)));
+                fpFile = tmp.getFile();
+            }
+
+
+            InputStream in = new FileInputStream(fpFile);
+            BufferedReader br = new BufferedReader(new InputStreamReader(in));
+            String tmpLine;
+
+            while ((tmpLine = br.readLine()) != null) {
+                tmpLine = tmpLine.trim();
+                if (!tmpLine.startsWith("#")) rAsStrList.add(tmpLine);
+            }
+            if (rAsStrList.size() == 0) {
+                msgList.add("no region is defined in the footprint file");
+            }
+        } catch (Exception e) {
+                retval = createError("on getRelocatableRegion", null, e);
+        }
+
+        retval.putResult(WebPlotResult.REGION_DATA, StringUtils.combineStringList(rAsStrList));
+        retval.putResult(WebPlotResult.REGION_ERRORS, StringUtils.combineStringList(msgList));
+        return retval;
+    }
 
     public static WebPlotResult getFootprintRegion(String fpInfo) {
 

--- a/src/firefly/js/drawingLayers/FootprintToolUI.jsx
+++ b/src/firefly/js/drawingLayers/FootprintToolUI.jsx
@@ -140,11 +140,12 @@ class FootprintToolUI extends PureComponent {
             marginTop: 5
         };
 
-        var textOnLink = get(this.state.fpInfo, 'fromFile') ? `Add ${get(this.state.fpInfo, 'fromFile')}`
-                         :(get(this.state.fpInfo, 'fromRegionAry')
+        var {isValidAngle, angleDeg, fpText, fpTextLoc, fpInfo} = this.state;
+        var textOnLink = get(fpInfo, 'fromFile') ? `Add ${get(fpInfo, 'fromFile')}`
+                         :(get(fpInfo, 'fromRegionAry')
                                         ? `Add ${this.props.drawLayer.title}`
-                                        : `Add ${get(this.state.fpInfo, 'footprint')} ${get(this.state.fpInfo, 'instrument')}`);
-        var {isValidAngle, angleDeg, fpText, fpTextLoc} = this.state;
+                                        : `Add ${get(fpInfo, 'footprint')} ${get(fpInfo, 'instrument')}`);
+
 
         return (
             <div style={{display:'flex', justifyContent:'flex-start', flexDirection: 'column', padding:'5px 0 9px 0'}}>

--- a/src/firefly/js/drawingLayers/FootprintToolUI.jsx
+++ b/src/firefly/js/drawingLayers/FootprintToolUI.jsx
@@ -133,14 +133,17 @@ class FootprintToolUI extends PureComponent {
         const tStyle= {
             display:'flex',
             flexDirection:'column',
-            paddingLeft : 10,
+            paddingLeft : 10
         };
 
         const mStyle = {
             marginTop: 5
         };
 
-        var textOnLink = `Add ${get(this.state.fpInfo, 'footprint')} ${get(this.state.fpInfo, 'instrument')}`;
+        var textOnLink = get(this.state.fpInfo, 'fromFile') ? `Add ${get(this.state.fpInfo, 'fromFile')}`
+                         :(get(this.state.fpInfo, 'fromRegionAry')
+                                        ? `Add ${this.props.drawLayer.title}`
+                                        : `Add ${get(this.state.fpInfo, 'footprint')} ${get(this.state.fpInfo, 'instrument')}`);
         var {isValidAngle, angleDeg, fpText, fpTextLoc} = this.state;
 
         return (

--- a/src/firefly/js/drawingLayers/RegionPlot.js
+++ b/src/firefly/js/drawingLayers/RegionPlot.js
@@ -50,7 +50,6 @@ function* regionsRemoveSaga({id, plotId}, dispatch, getState) {
 }
 
 let idCnt = 0;
-
 export const createNewRegionLayerId = () => {
     const layerList =  getDrawLayersByType(getDlAry(), TYPE_ID);
 
@@ -67,20 +66,23 @@ export const createNewRegionLayerId = () => {
 
 let titleCnt = 1;
 export const getRegionLayerTitle = (layerTitle) => {
-    if (layerTitle) return layerTitle;
-
     const defaultRegionTitle = 'ds9 region overlay';
     const layerList =  getDrawLayersByType(getDlAry(), TYPE_ID);
+    let   cntTitle = 0;
 
     while (true) {
-        const newTitle = `${defaultRegionTitle}-${titleCnt++}`;
+        const newTitle = layerTitle ? (!cntTitle ? layerTitle : `${layerTitle}-${cntTitle}`)
+                                    : `${defaultRegionTitle}-${titleCnt++}`;
         const dl = layerList.find((layer) => {
             return (layer.title && layer.title === newTitle);
         });
-
+        if (layerTitle) {
+            cntTitle++;
+        }
         if (!dl) {
             return newTitle;
         }
+
     }
 };
 
@@ -116,7 +118,7 @@ function creator(initPayload) {
                        DrawLayerCntlr.REGION_SELECT];
 
     const title = get(initPayload, 'title');
-    const id = get(initPayload, 'drawLayerId', createNewRegionLayerId());
+    const id = initPayload.drawLayerId ?  initPayload.drawLayerId : createNewRegionLayerId();
     const dl = DrawLayer.makeDrawLayer( id, TYPE_ID, getRegionLayerTitle(title),
                                           options, drawingDef, actionTypes, pairs );
 

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import CoordinateSys from './CoordSys.js';
-import {isUndefined, get} from 'lodash';
+import {get} from 'lodash';
 import VisUtil from './VisUtil.js';
 import {makeRoughGuesser} from './ImageBoundsData.js';
 import Point, {makeImageWorkSpacePt, makeImagePt,

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -532,12 +532,24 @@ export function dispatchSelectRegion(drawLayerId, selectedRegion, dispatcher = f
 export function dispatchCreateMarkerLayer(markerId, layerTitle, plotId = [], attachPlotGroup=true, dispatcher = flux.process) {
     dispatcher({type: MARKER_CREATE, payload: {plotId, markerId, layerTitle, attachPlotGroup}});
 }
+
+/**
+ * Footprint Info.  The data object containing footprint info.
+ * @typedef {object} footprintInfo
+ * @prop {string} footprint - name of footprint project, such as 'HST', 'WFIRST', etc. or footprint file at the server
+ * @prop {string} instrument - name of instrument for the footprint
+ * @prop {string} relocateBy - name of instrument for the footprint from the server, method of relocation for the uploaded footprint
+ * @prop {string} fromFile - filename, not including the extension, of the uploaded file
+ * @prop {string[]} fromRegionAry - array or string of region description
+ *
+ * @public
+ */
+
 /**
  * @summary create drawing layer with footprint
  * @param {string} footprintId - id of the drawing layer
  * @param {string} layerTitle - title of the drawing layer
- * @param {string} footprint - name of footprint project, such as 'HST', 'WFIRST', etc.
- * @param {string} instrument - name of instrument for the footprint
+ * @param {footprintInfo} footprintData footprint information for footprint layer
  * @param {string[]|string} plotId - array or string of plot id. If plotId is empty, all plots of the active group are applied
  * @param {bool} attachPlotGroup - attach all plots of the same plot group
  * @param dispatcher
@@ -545,9 +557,10 @@ export function dispatchCreateMarkerLayer(markerId, layerTitle, plotId = [], att
  * @function dispatchCreateFootprintLayer
  * @memberof firefly.action
  */
-export function dispatchCreateFootprintLayer(footprintId, layerTitle, footprint, instrument, plotId = [],
-                                                                      attachPlotGroup=true, dispatcher = flux.process) {
-    dispatcher({type: FOOTPRINT_CREATE, payload: {plotId, footprintId, layerTitle, footprint, instrument, attachPlotGroup}});
+export function dispatchCreateFootprintLayer(footprintId, layerTitle,
+                                             {footprint=null, instrument=null, relocateBy='origin',  fromFile=null, fromRegionAry=null},
+                                             plotId = [], attachPlotGroup=true, dispatcher = flux.process) {
+    dispatcher({type: FOOTPRINT_CREATE, payload: {plotId, footprintId, layerTitle, footprint, instrument, relocateBy, attachPlotGroup, fromFile, fromRegionAry}});
 
 }
 

--- a/src/firefly/js/visualize/Point.js
+++ b/src/firefly/js/visualize/Point.js
@@ -120,6 +120,15 @@ export class SimplePt {
         }
     }
     toString() { return this.x+';'+this.y; }
+
+    static make(x, y, type) {
+        const pt = new SimplePt(x, y);
+
+        if (type && Object.keys(Point).includes(type)) {
+            pt.type = type;
+        }
+        return pt;
+    }
 }
 
 

--- a/src/firefly/js/visualize/draw/FootprintFactory.js
+++ b/src/firefly/js/visualize/draw/FootprintFactory.js
@@ -54,7 +54,7 @@ export class FootprintFactory {
     }
 
     static getOriginalRegionsFromStc(defAry, isInstrument, bAllowHeader = false) {
-        var regions = RegionFactory.parseRegionDS9(defAry, bAllowHeader);
+        var regions = RegionFactory.parseRegionDS9(defAry, bAllowHeader, true);
 
         regions.forEach( (oneRegion) => Object.assign(oneRegion, {isInstrument}));
         return regions;

--- a/src/firefly/js/visualize/draw/FootprintFactory.js
+++ b/src/firefly/js/visualize/draw/FootprintFactory.js
@@ -4,14 +4,13 @@
 
 import Enum from 'enum';
 import {has} from 'lodash';
-import {makeWorldPt} from '../Point.js';
+import Point, {makeWorldPt, makeImagePt} from '../Point.js';
 import {RegionFactory} from '../region/RegionFactory.js';
 import {drawRegions} from '../region/RegionDrawer.js';
 import VisUtil from '../VisUtil.js';
 
 const PRELIM = 'prelim.';
 const NoPRELIM = '';
-const FPCMD = 'footprint';
 
 // SPITZER is not included  06/24/2016
 export const FootprintList = ['HST', 'JWST', 'WFIRST', 'SPITZER'];
@@ -54,27 +53,68 @@ export class FootprintFactory {
         return label;
     }
 
-    static getOriginalRegionsFromStc(defAry, isInstrument) {
-        var regions = RegionFactory.parseRegionDS9(defAry, false);
+    static getOriginalRegionsFromStc(defAry, isInstrument, bAllowHeader = false) {
+        var regions = RegionFactory.parseRegionDS9(defAry, bAllowHeader);
 
         regions.forEach( (oneRegion) => Object.assign(oneRegion, {isInstrument}));
         return regions;
     }
 
-    static getDrawObjFromOriginalRegion(regions, refCenter, moveToRelativeCenter) {
-        var getCenter = (wpAry) => VisUtil.computeCentralPointAndRadius(wpAry).centralPoint;
-        var moveRegion = (region, refCenter, moveToRelativeCenter, instCenter) => {
-                    var centerWpt = moveToRelativeCenter&&instCenter? instCenter : makeWorldPt(0, 0);
+    /**
+     * get drawObj from region description, move the center from instrument center or worldPt (0, 0) to reference center
+     * @param regions
+     * @param refCenter
+     * @param moveToRelativeCenter
+     * @param cc
+     * @returns {*}
+     */
+    static getDrawObjFromOriginalRegion(regions, refCenter, moveToRelativeCenter, cc) {
+        const getCenter = (wpAry) => {
+            if (wpAry[0].type === Point.W_PT) {
+                return VisUtil.computeCentralPointAndRadius(wpAry).centralPoint;
+            } else {
+                return getImageCenter(wpAry);
+            }
+        };
 
+        const getImageCenter = (wpAry) => {
+            const total = wpAry.reduce((prev, onePt) => {
+                prev.totalX += onePt.x;
+                prev.totalY += onePt.y;
+                return prev;
+            }, {totalX: 0.0, totalY : 0.0} );
+
+            return makeImagePt(total.totalX/wpAry.length, total.totalY/wpAry.length);
+        };
+
+        var moveRegion = (region, refCenter, moveToRelativeCenter, instCenter) => {
+                if (!region.wpAry || region.wpAry.length <= 0 ) return;
+                if (region.wpAry[0].type === Point.W_PT) {
+                    const centerWpt = moveToRelativeCenter && instCenter ? instCenter : makeWorldPt(0, 0);
                     region.wpAry = region.wpAry.map((wp) => VisUtil.getTranslateAndRotatePosition(centerWpt, refCenter, wp));
+                } else {
+                    // move center of footprint or image pt (0,0) to refCenter
+                    const refCenterImg = cc.getImageCoords(refCenter);
+                    const centerImgPt = moveToRelativeCenter && instCenter ? instCenter : makeImagePt(0, 0);
+                    const deltaX = refCenterImg.x - centerImgPt.x;
+                    const deltaY = refCenterImg.y - centerImgPt.y;
+
+                    region.wpAry = region.wpAry.map((wp) => {
+                        const newPt = Object.assign({}, wp);
+                        newPt.x += deltaX;
+                        newPt.y += deltaY;
+
+                        return newPt;
+                    });
+                }
         };
 
         if (regions) {
-            var newRegions = regions.map( (oneRegion) => Object.assign({}, oneRegion));
-            var instCenter = null;
+            const newRegions = regions.map( (oneRegion) => Object.assign({}, oneRegion));
+            let   instCenter = null;
 
             if (moveToRelativeCenter) {
-                var vertices = regions.reduce((prev, oneRegion) => {
+                const vertices = regions.reduce((prev, oneRegion) => {
                     prev = prev.concat(oneRegion.wpAry);
                     return prev;
                 }, []);

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -286,7 +286,7 @@ const draw=  {
             const x = xSum/xTot;
             const y = ySum/yTot;
 
-            return type === Point.W_PT ? makeWorldPt(x, y) : Object.assign(new SimplePt(x, y), {type});
+            return type === Point.W_PT ? makeWorldPt(x, y) : SimplePt.make(x, y, type);
 
         } else {
             return makeWorldPt(0, 0);

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -8,7 +8,7 @@ import DrawObj from './DrawObj';
 import DrawUtil from './DrawUtil';
 import VisUtil, {convertAngle, computeScreenDistance, convert} from '../VisUtil.js';
 import {TextLocation, Style, DEFAULT_FONT_SIZE} from './DrawingDef.js';
-import Point, {makeScreenPt, makeDevicePt, makeOffsetPt, makeWorldPt, makeImagePt} from '../Point.js';
+import Point, {makeScreenPt, makeDevicePt, makeOffsetPt, makeWorldPt, makeImagePt, SimplePt} from '../Point.js';
 import {toRegion} from './ShapeToRegion.js';
 import {getDrawobjArea,  isScreenPtInRegion, makeHighlightShapeDataObj} from './ShapeHighlight.js';
 import CsysConverter from '../CsysConverter.js';
@@ -268,19 +268,29 @@ const draw=  {
 
     getCenterPt(drawObj) {
         const {pts}= drawObj;
-        let xSum = 0;
-        let ySum = 0;
-        let xTot = 0;
-        let yTot = 0;
 
-        pts.forEach((wp) => {
-           xSum += wp.x;
-           ySum += wp.y;
-           xTot++;
-           yTot++;
-        });
+        if (pts && pts.length > 0) {
+            let xSum = 0;
+            let ySum = 0;
+            let xTot = 0;
+            let yTot = 0;
 
-        return makeWorldPt(xSum / xTot, ySum / yTot);
+            pts.forEach((wp) => {
+                xSum += wp.x;
+                ySum += wp.y;
+                xTot++;
+                yTot++;
+            });
+
+            const type = pts[0].type;
+            const x = xSum/xTot;
+            const y = ySum/yTot;
+
+            return type === Point.W_PT ? makeWorldPt(x, y) : Object.assign(new SimplePt(x, y), {type});
+
+        } else {
+            return makeWorldPt(0, 0);
+        }
     },
 
     getScreenDist(drawObj,plot, pt) {
@@ -1609,6 +1619,11 @@ export function rotateAround(plot, pts, angle, wc) {
         if (!p1) return null;
 
         const pti= plot.getImageCoords(p1);
+
+        if (!pti) {
+            return null;
+        }
+
         const x1 = pti.x - center.x;
         const y1 = pti.y - center.y;
         const sin = Math.sin(-angle);

--- a/src/firefly/js/visualize/region/RegionFactory.js
+++ b/src/firefly/js/visualize/region/RegionFactory.js
@@ -223,8 +223,7 @@ export class RegionFactory {
         var csys = getRegionCoordSys(tmpAry[0]);  // test the split first string
 
         if (csys !== RegionCsys.UNDEFINED) {
-            if (globalOptions) globalOptions.coordSys = tmpAry[0].toLowerCase();
-
+            if (globalOptions) globalOptions.coordSys = csys;
             if (tmpAry.length <= 1) {    // pure coordinate string
                 return null;
             }
@@ -244,7 +243,7 @@ export class RegionFactory {
         } else {                        // description only
             // default coordinate is PHYSICAL in case not specified
             regionCoord = globalOptions && has(globalOptions, regionPropsList.COORD)  ?
-                globalOptions[regionPropsList.COORD] : defaultCoord;
+                globalOptions[regionPropsList.COORD].key : defaultCoord;
         }
 
         // separate the region description and property part
@@ -320,8 +319,15 @@ export class RegionFactory {
             return makeRegionMsg(`[${RegionParseError.InvalidParam}] ${rgMsg}`);
         }
 
+        if (rg.options) {
+           Object.keys(globalOptions).forEach((op) => {
+               if (!has(rg.options, op)) {
+                   set(rg.options, op, globalOptions[op]);
+               }
+           });
+        }
         // check region properties
-        rgProps = rf.parseRegionOptions(regionOptions, opInclude,  (has(rg, 'options') ? rg.options : null), regionCsys);
+        rgProps = rf.parseRegionOptions(regionOptions, opInclude,  (has(rg, 'options') ? rg.options : globalOptions), regionCsys);
 
         if (rgProps.message) {
             return makeRegionMsg(`[${RegionParseError.InvalidProp}] ${rgProps.message} at ${rgMsg}`);

--- a/src/firefly/js/visualize/region/RegionTask.js
+++ b/src/firefly/js/visualize/region/RegionTask.js
@@ -20,7 +20,7 @@ var [RegionIdErr, RegionErr, NoRegionErr, JSONErr] = [
     'no region is specified',
     'get region json error'];
 
-var getPlotId = (plotId) => {
+export const getPlotId = (plotId) => {
     //return (!plotId || (isArray(plotId)&&plotId.length === 0)) ? get(visRoot(), 'activePlotId') : plotId;
     if (!plotId || (isArray(plotId)&&plotId.length === 0)) {
         const pid = get(visRoot(), 'activePlotId');


### PR DESCRIPTION
This development provides, 
- UI to upload 'instrument footprints' file: 
   . 'instrument footprints' file upload is treated like region file upload and the uploaded region file is set to be relocatable,  the origin (at either world coordinate or image coordinate system) of the footprint is initially replaced to the search position of the image. 
   . UI dialog:  using the same dialog for region file upload and a checkbox, 'treat as relocatable' is added to the dialog specifically  for 'instrument footprints' file upload. 
- API for creating 'instrument footprint' layer from a footprint file or an array of region description. 
- Each footprint entity is in default 'rotatable' and can be defined to be non-rotatable in region description. 

test:
for UI, upload the footprint file samples from 'firefly_test_data/region-test-files/footprint_upload'
- start image search or HiPS search
- upload 'instrument footprints' file by using region upload dialog and checking 'treat as relocatable' from the dialog

for API:
start firefly/demo/ffapi-footprint-test.html
clicking 'Create Footprint Layer' (or/and composing region description in the text area)  to add footprint layer. 



