### PR TITLE
DM-15490 Modify behavior of 2D-histogram (heatmap) fallback

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/TableFunctionProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/TableFunctionProcessor.java
@@ -46,13 +46,9 @@ public abstract class TableFunctionProcessor extends EmbeddedDbProcessor {
 
     @Override
     public File createDbFile(TableServerRequest treq) throws DataAccessException {
-        try {
-            TableServerRequest sreq = getSearchRequest(treq);
-            return getSearchProcessor(sreq).createDbFile(sreq);
-        } catch (DataAccessException e) {
-            // should not happen
-            return super.createDbFile(treq);
-        }
+        // table function processor operates on the original table
+        // we don't want to create a dummy table in db
+        return null;
     }
 
     /**
@@ -63,7 +59,7 @@ public abstract class TableFunctionProcessor extends EmbeddedDbProcessor {
         TableServerRequest sreq = getSearchRequest(treq);
         sreq.setPageSize(1);  // set to small number it's not used.
         new SearchManager().getDataGroup(sreq).getData();
-        return new FileInfo(dbFile);
+        return new FileInfo(getDbFile(treq));
     }
 
     /**

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -114,8 +114,7 @@ const defFireflyOptions = {
 
     charts: {
         defaultDeletable: undefined, // by default if there are more than one chart in container, all charts are deletable
-        maxRowsForScatter: undefined, // maximum table rows for scatter chart support, undefined means unlimited
-        maxRowsForDefaultScatter: 5000, // maximum table rows for which the default chart is scatter, heatmap is created for larger tables
+        maxRowsForScatter: 5000, // maximum table rows for scatter chart support, heatmap is created for larger tables
         minScatterGLRows: 1000, // minimum number of points to use WebGL 'scattergl' instead of SVG 'scatter'
         singleTraceUI: false, // by default we support multi-trace in UI
         upperLimitUI: false, // by default user can not set upper limit column in scatter options

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -13,12 +13,13 @@ import * as TablesCntlr from '../tables/TablesCntlr.js';
 import {logError} from '../util/WebUtil.js';
 import {DEFAULT_PLOT2D_VIEWER_ID, dispatchAddViewerItems, dispatchUpdateCustom, dispatchRemoveViewerItems,
     getMultiViewRoot, getViewer} from '../visualize/MultiViewCntlr.js';
-import {flattenAnnotations, formatColExpr, getPointIdx, getRowIdx, handleTableSourceConnections, clearChartConn, newTraceFrom,
-        applyDefaults, HIGHLIGHTED_PROPS, SELECTED_PROPS, TBL_SRC_PATTERN} from './ChartUtil.js';
+import {applyDefaults, flattenAnnotations, formatColExpr, getPointIdx, getRowIdx, handleTableSourceConnections, clearChartConn, newTraceFrom,
+        setupTableWatcher, HIGHLIGHTED_PROPS, SELECTED_PROPS, TBL_SRC_PATTERN} from './ChartUtil.js';
 import {FilterInfo} from '../tables/FilterInfo.js';
 import {SelectInfo} from '../tables/SelectInfo.js';
 import {REINIT_APP, getAppOptions} from '../core/AppDataCntlr.js';
 import {makeHistogramParams, makeXYPlotParams} from './ChartUtil.js';
+import {adjustColorbars, hasFireflyColorbar} from './dataTypes/FireflyHeatmap.js';
 
 export const CHART_SPACE_PATH = 'charts';
 export const UI_PREFIX = `${CHART_SPACE_PATH}.ui`;
@@ -32,6 +33,7 @@ export const useChartRedraw = toBoolean(sessionStorage.getItem('chartRedraw')); 
 export const CHART_ADD = `${DATA_PREFIX}/chartAdd`;
 export const CHART_UPDATE = `${DATA_PREFIX}/chartUpdate`;
 export const CHART_REMOVE = `${DATA_PREFIX}/chartRemove`;
+export const CHART_TRACE_REMOVE = `${DATA_PREFIX}/chartTraceRemove`;
 export const CHART_HIGHLIGHT = `${DATA_PREFIX}/chartHighlight`;
 export const CHART_SELECT = `${DATA_PREFIX}/chartSelectSelection`;
 export const CHART_FILTER_SELECTION = `${DATA_PREFIX}/chartFilterSelection`;
@@ -42,7 +44,7 @@ export const CHART_MOUNTED = `${UI_PREFIX}/mounted`;
 export const CHART_UNMOUNTED = `${UI_PREFIX}/unmounted`;
 
 
-const FIREFLY_TRACE_TYPES = ['scatter', 'fireflyHistogram', 'fireflyHeatmap'];
+const FIREFLY_TRACE_TYPES = ['scatter', 'scattergl', 'fireflyHistogram', 'fireflyHeatmap'];
 
 const EMPTY_ARRAY = [];
 
@@ -57,6 +59,7 @@ function actionCreators() {
     return {
         [CHART_ADD]:     chartAdd,
         [CHART_REMOVE]:  chartRemove,
+        [CHART_TRACE_REMOVE]:  chartTraceRemove,
         [CHART_UPDATE]:  chartUpdate,
         [CHART_HIGHLIGHT]: chartHighlight,
         [CHART_FILTER_SELECTION]: chartFilterSelection,
@@ -102,6 +105,19 @@ export function dispatchChartAdd({chartId, chartType='plot.ly', groupId='main', 
  */
 export function dispatchChartRemove(chartId, dispatcher= flux.process) {
     dispatcher({type: CHART_REMOVE, payload: {chartId}});
+}
+
+/*
+ * Delete chart trace and the related data
+ *  @param {string} chartId - chart id
+ *  @param {number} traceNum - trace index to remove
+ *  @param {Function} [dispatcher=flux.process] - only for special dispatching uses such as remote
+ *  @public
+ *  @function dispatchChartTraceRemove
+ *  @memberof firefly.action
+ */
+export function dispatchChartTraceRemove(chartId, traceNum, dispatcher= flux.process) {
+    dispatcher({type: CHART_TRACE_REMOVE, payload: {chartId, traceNum}});
 }
 
 /**
@@ -275,6 +291,24 @@ function chartRemove(action) {
             }
         }
         dispatch({type: action.type, payload: Object.assign({},action.payload, {viewerId})});
+    };
+}
+
+function chartTraceRemove(action) {
+    return (dispatch) => {
+        const {chartId, traceNum} = action.payload;
+        const {tablesources=[]} = getChartData(chartId);
+        // cancel and replace table watchers, affected by the trace removal
+        tablesources.forEach((ts,i) => {
+            if (i>=traceNum && ts && ts._cancel) {
+                ts._cancel();
+                if (i !== traceNum) {
+                    const newIdx = i-1;
+                    ts._cancel = setupTableWatcher(chartId, ts, newIdx);
+                }
+            }
+        });
+        dispatch(action);
     };
 }
 
@@ -583,6 +617,21 @@ function reduceData(state={}, action={}) {
 
             return updateSet(state, chartId, chartData);
         }
+        case (CHART_TRACE_REMOVE)  :
+        {
+            const {chartId, traceNum} = action.payload;
+            const {changes, moreChanges} = removeTrace({chartId, traceNum});
+            let chartData = getChartData(chartId);
+            if (!isEmpty(changes)) {
+                // changes to array fields: data, fireflyData, etc
+                chartData = updateObject(chartData, changes);
+                if (!isEmpty(moreChanges)) {
+                    // changes to the specific trace attributes
+                    chartData = updateObject(chartData, moreChanges);
+                }
+            }
+            return updateSet(state, chartId, chartData);
+        }
         case (CHART_REMOVE)  :
         {
             const {chartId} = action.payload;
@@ -691,7 +740,7 @@ function cleanupRelatedChartData(action) {
             if (data.length === 1) {
                 dispatchChartRemove(chartId);
             } else {
-                removeTrace({chartId, traceNum});
+                dispatchChartTraceRemove(chartId, traceNum);
             }
             traceNum = getMatchingTSIdx(chartId);
         }
@@ -722,15 +771,22 @@ export function resetChart(chartId) {
     _original && dispatchChartAdd(_original);
 }
 
-export function removeTrace({chartId, traceNum}) {
-    const {activeTrace, data, fireflyData, tablesources, curveNumberMap} = getChartData(chartId);
+function removeTrace({chartId, traceNum}) {
+    const {activeTrace, data, fireflyData, layout, tablesources, curveNumberMap} = getChartData(chartId);
     const changes = {};
+    const moreChanges = {};
+
 
     [[data, 'data'], [fireflyData, 'fireflyData'], [tablesources, 'tablesources']].forEach(([arr,name]) => {
         if (arr && traceNum < arr.length) {
             changes[name] = arr.filter((e,i) => i !== traceNum);
         }
     });
+    
+    // handle colorbars
+    if (hasFireflyColorbar(chartId, traceNum)) {
+        Object.assign(moreChanges, adjustColorbars({data: changes['data'], fireflyData: changes['fireflyData'], layout}));
+    }
 
     if (curveNumberMap && traceNum < curveNumberMap.length) {
         // new curve map has the same order of traces as the old curve map
@@ -753,9 +809,7 @@ export function removeTrace({chartId, traceNum}) {
         }
     }
 
-    if (!isEmpty(changes)) {
-        dispatchChartUpdate({chartId, changes});
-    }
+    return {changes, moreChanges};
 }
 
 export function getChartData(chartId, defaultChartData={}) {

--- a/src/firefly/js/charts/Colorscale.js
+++ b/src/firefly/js/charts/Colorscale.js
@@ -1,0 +1,120 @@
+//import Color from '../util/Color.js';
+
+// Sequential color scales from colorlover
+// roughly matching the first 8 trace colors:
+// '#1f77b4', '#2ca02c', '#d62728', '#9467bd',
+// '#8c564b', '#e377c2', '#7f7f7f', '#17becf'.
+// They all start from the pale and end with the dark color
+//   and are good to represent density maps.
+export const SevenColorSequential = {
+    'BlueSeq': [
+        [0.0, 'rgb(239,243,255)'],
+        [0.1, 'rgb(198,219,239)'],
+        [0.2, 'rgb(158,202,225)'],
+        [0.4, 'rgb(107,174,214)'],
+        [0.6, 'rgb(66,146,198)'],
+        [0.8, 'rgb(33,113,181)'],
+        [1.0, 'rgb(8,69,148)']
+    ],
+    'GreenSeq': [
+        [0.0, 'rgb(237,248,233)'],
+        [0.1, 'rgb(199,233,192)'],
+        [0.2, 'rgb(161,217,155)'],
+        [0.4, 'rgb(116,196,118)'],
+        [0.6, 'rgb(65,171,93)'],
+        [0.8, 'rgb(35,139,69)'],
+        [1.0, 'rgb(0,90,50)']
+    ],
+    'RedSeq': [
+        [0.0, 'rgb(254,229,217)'],
+        [0.1, 'rgb(252,187,161)'],
+        [0.2, 'rgb(252,146,114)'],
+        [0.4, 'rgb(251,106,74)'],
+        [0.6, 'rgb(239,59,44)'],
+        [0.8, 'rgb(203,24,29)'],
+        [1.0, 'rgb(153,0,13)']
+    ],
+    'PurpleSeq': [
+        [0.0, 'rgb(242,240,247)'],
+        [0.1, 'rgb(218,218,235)'],
+        [0.2, 'rgb(188,189,220)'],
+        [0.4, 'rgb(158,154,200)'],
+        [0.6, 'rgb(128,125,186)'],
+        [0.8, 'rgb(106,81,163)'],
+        [1.0, 'rgb(74,20,134)']
+    ],
+    'BrownSeq': [
+        [0.0, 'rgb(249,237,234)'],
+        [0.1, 'rgb(236,203,193)'],
+        [0.2, 'rgb(220,167,151)'],
+        [0.4, 'rgb(202,131,111)'],
+        [0.6, 'rgb(182,98,75)'],
+        [0.8, 'rgb(161,65,41)'],
+        [1.0, 'rgb(135,20,0)']
+    ],
+    'RdPuSeq': [
+        [0.0, 'rgb(254,235,226)'],
+        [0.1, 'rgb(252,197,192)'],
+        [0.2, 'rgb(250,159,181)'],
+        [0.4, 'rgb(247,104,161)'],
+        [0.6, 'rgb(221,52,151)'],
+        [0.8, 'rgb(174,1,126)'],
+        [1.0, 'rgb(122,1,119)']
+    ],
+    'GreySeq': [
+        [0.0, 'rgb(247,247,247)'],
+        [0.1, 'rgb(217,217,217)'],
+        [0.2, 'rgb(189,189,189)'],
+        [0.4, 'rgb(150,150,150)'],
+        [0.6, 'rgb(115,115,115)'],
+        [0.8, 'rgb(82,82,82)'],
+        [1.0, 'rgb(37,37,37)']
+    ],
+    'GnBuSeq': [
+        [0.0, 'rgb(240,249,232)'],
+        [0.1, 'rgb(204,235,197)'],
+        [0.2, 'rgb(168,221,181)'],
+        [0.4, 'rgb(123,204,196)'],
+        [0.6, 'rgb(78,179,211)'],
+        [0.8, 'rgb(43,140,190)'],
+        [1.0, 'rgb(8,88,158)']
+    ]
+};
+
+// Plotly colorscales are purpose-based
+// for example:
+// Reds - for non-negative numeric values
+// Blues - for non-positive numeric values
+// RdBu or Picnic - diverging scales to show departure from middle values
+export const PlotlyCS = [
+    'Greys','YlGnBu','Greens','YlOrRd','Bluered','RdBu',
+    'Reds','Blues','Picnic','Rainbow','Portland','Jet',
+    'Hot','Blackbody','Earth','Electric','Viridis','Cividis'];
+
+export const OneColorSequentialCS = Object.keys(SevenColorSequential);
+
+export const ALL_COLORSCALE_NAMES = Object.keys(SevenColorSequential).concat(PlotlyCS);
+
+export function colorscaleNameToVal(name) {
+    const colorscale = SevenColorSequential[name];
+    if (colorscale) {
+        return colorscale;
+    } else if (PlotlyCS.includes(name)) {
+        return name;
+    }
+    return undefined;
+
+}
+
+// does not work well
+// function createColorScale(baseColor) {
+//     const numcols = 5;
+//     return [[0.0, 'rgb(237, 237, 237)']].concat(
+//         Color.makeSimpleColorMap(baseColor, numcols, true).map((e,i) => {
+//             const [r, g, b] = Color.toRGB(e);
+//             let p = 1.0;
+//             if (i < (numcols-1)) p = (i+1)*(1/numcols);
+//             return [p, `rgb(${r},${g},${b})`];
+//         })
+//     );
+// }

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -1,16 +1,18 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {get, uniqueId} from 'lodash';
+import {get, isArray} from 'lodash';
 import {getTblById, getColumn, doFetchTable, stripColumnNameQuotes} from '../../tables/TableUtil.js';
 import {makeTableFunctionRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {dispatchChartUpdate, dispatchError, getChartData} from '../ChartsCntlr.js';
-import {singleTraceUI} from '../ChartUtil.js';
+import {isScatter2d, getMaxScatterRows, singleTraceUI} from '../ChartUtil.js';
 import {serializeDecimateInfo, parseDecimateKey} from '../../tables/Decimate.js';
 import BrowserInfo from  '../../util/BrowserInfo.js';
 import {formatColExpr} from '../ChartUtil.js';
+import {colorscaleNameToVal, OneColorSequentialCS, PlotlyCS} from '../Colorscale.js';
 import {cloneRequest} from '../../tables/TableRequestUtil.js';
 import {COL_TYPE, getColumns} from '../../tables/TableUtil.js';
+import {getTraceTSEntries as genericTSGetter} from './FireflyGenericData.js';
 
 /**
  * This function creates table source entries to get firefly scatter and error data from the server
@@ -54,8 +56,21 @@ export function getTraceTSEntries({traceTS, chartId, traceNum}) {
 
 function fetchData(chartId, traceNum, tablesource) {
 
-    const {tbl_id, options, mappings} = tablesource;
+    const {tbl_id, options} = tablesource;
     const tableModel = getTblById(tbl_id);
+
+    // if heatmap is used to represent scatter
+    // and the number of rows falls below a threshhold,
+    // scatter chart should be produced
+    const {fireflyData} = getChartData(chartId);
+    const scatterOrHeatmap = get(fireflyData, [traceNum, 'scatterOrHeatmap']);
+    const totalRows= get(tableModel, 'totalRows');
+    if (scatterOrHeatmap && totalRows <= getMaxScatterRows()) {
+        const {options:scatterOptions, fetchData:scatterFetchData} = genericTSGetter({traceTS:tablesource, chartId, traceNum});
+        const scatterTS = Object.assign({}, tablesource, {options: scatterOptions});
+        return scatterFetchData(chartId, traceNum, scatterTS);
+    }
+
     const numericCols = getColumns(tableModel, COL_TYPE.NUMBER).map((c) => c.name);
     const {request} = tableModel;
 
@@ -85,7 +100,7 @@ function fetchData(chartId, traceNum, tablesource) {
 
         if (tableModel.tableData && tableModel.tableData.data) {
 
-            const changes = getChanges({tableModel, mappings, chartId, traceNum});
+            const changes = getChanges({tableModel, tablesource, chartId, traceNum});
             changes[`fireflyData.${traceNum}.isLoading`] = false;
             dispatchChartUpdate({chartId, changes});
 
@@ -98,8 +113,8 @@ function fetchData(chartId, traceNum, tablesource) {
     );
 }
 
-function getChanges({tableModel, mappings, chartId, traceNum}) {
-
+function getChanges({tableModel, tablesource, chartId, traceNum}) {
+    const {mappings} = tablesource;
     const {tableMeta} = tableModel;
     const decimateKey = tableMeta['decimate_key'];
 
@@ -175,11 +190,29 @@ function getChanges({tableModel, mappings, chartId, traceNum}) {
         [`data.${traceNum}.y`]: y,
         [`data.${traceNum}.z`]: z,
         [`data.${traceNum}.text`]: text,
-        [`data.${traceNum}.hoverinfo`]: 'text',
-        [`fireflyData.${traceNum}.toRowIdx`]: toRowIdx
+        [`data.${traceNum}.hoverinfo`]: 'text'
     };
 
-    const {layout, data} = getChartData(chartId) || {};
+    const chartData = getChartData(chartId);
+    const {layout, data} = chartData;
+
+    // check for scatter represented by heatmap
+    if (isScatter2d(get(data, `${traceNum}.type`, 'scatter'))) {
+        // moving from scatter to heatmap representation
+        changes[`fireflyData.${traceNum}.scatterOrHeatmap`] = true;
+        // clean arrays set in scatter mode
+        changes[`data.${traceNum}.hoverText`] = undefined;
+        // set colorscale if it was not set before
+        const colorscale = get(data, `${traceNum}.colorscale`);
+        if (!colorscale || (!isArray(colorscale) && !PlotlyCS.includes(colorscale))) {
+            const colorscaleName = OneColorSequentialCS[traceNum % OneColorSequentialCS.length];
+            changes[`data.${traceNum}.colorscale`] = colorscaleNameToVal(colorscaleName);
+            changes[`fireflyData.${traceNum}.colorscale`] = colorscaleName;
+        }
+        // tablesource options have changed
+        const {options} = tablesource;
+        changes[`tablesources.${traceNum}.options`] = options;
+    }
 
     if (data && data.length===1) {
         // set default title if it's the first trace
@@ -236,12 +269,43 @@ function getChanges({tableModel, mappings, chartId, traceNum}) {
     return changes;
 }
 
+export function hasFireflyColorbar(chartId, traceNum) {
+    const {fireflyData=[]} = getChartData(chartId);
+    return Boolean(get(fireflyData, `${traceNum}.fireflyColorbar`));
+}
+
+/**
+ * Returns object with changes
+ * @param p
+ * @param p.data
+ * @param p.fireflyData
+ * @param p.layout
+ * @return changes
+ */
+export function adjustColorbars({data, fireflyData, layout}) {
+    if (data) {
+        const changes = {};
+        const nbars = data.filter((d) => get(d, 'colorbar') && get(d, 'showscale', true)).length;
+        const yside = get(layout, 'yaxis.side');
+        const yOpposite = (yside === 'right');
+        let cnt = 1;
+        data.forEach((d, i) => {
+            if (get(fireflyData, `${i}.fireflyColorbar`) && get(d, 'colorbar') && get(d, 'showscale', true)) {
+                addColorbarLengthChanges(changes, yOpposite, nbars, i, cnt);
+                cnt++;
+            }
+        });
+        return changes;
+    }
+}
+
 function addColorbarLengthChanges(changes, yOpposite, nbars, traceNum, cnt) {
     changes[`data.${traceNum}.colorbar.yanchor`] = 'bottom';
     changes[`data.${traceNum}.colorbar.len`] = 1/nbars;
     changes[`data.${traceNum}.colorbar.y`] = 1-cnt/nbars; // first trace on top
     addColorbarChanges(changes, yOpposite, traceNum);
     changes['layout.legend.orientation'] = 'h'; // horizontal legend at the bottom
+    changes[`fireflyData.${traceNum}.fireflyColorbar`] = true;
 }
 
 // colorbar needs to be on the opposite size of the axis

--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -215,7 +215,7 @@ function ChartActionOptions(props) {
     const chartId = chartAction === CHART_ADDNEW ? undefined : chartIdProp;
 
     if (chartAction === CHART_ADDNEW || chartAction === CHART_TRACE_ADDNEW) {
-        return (<NewTracePanel {...{groupKey, tbl_id, chartId, hideDialog, showMultiTrace}}/>);
+        return (<NewTracePanel key={chartAction} {...{groupKey, tbl_id, chartId, hideDialog, showMultiTrace}}/>);
     }
     if (chartAction === CHART_TRACE_MODIFY) {
         return (

--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -10,7 +10,7 @@ import {getFieldVal, getReducerFunc} from '../../fieldGroup/FieldGroupUtils.js';
 
 import {RadioGroupInputField} from './../../ui/RadioGroupInputField.jsx';
 import {SimpleComponent} from './../../ui/SimpleComponent.jsx';
-import {CHART_UPDATE, dataLoadedUpdate, getChartData, removeTrace} from '../ChartsCntlr.js';
+import {CHART_UPDATE, dataLoadedUpdate, getChartData, dispatchChartTraceRemove} from '../ChartsCntlr.js';
 import {NewTracePanel, getNewTraceType, getSubmitChangesFunc, addNewTrace} from './options/NewTracePanel.jsx';
 
 import {showOptionsPopup} from './../../ui/PopupUtil.jsx';
@@ -65,7 +65,9 @@ function onChartAction({chartAction, tbl_id, chartId, hideDialog}) {
              case CHART_TRACE_MODIFY:
                 const {activeTrace, data, fireflyData} = getChartData(chartId);
                 const type = get(data, `${activeTrace}.type`, 'scatter');
-                const ftype = get(fireflyData, `${activeTrace}.dataType`);
+                let ftype = get(fireflyData, `${activeTrace}.dataType`);
+                const scatterOrHeatmap = get(fireflyData, [activeTrace, 'scatterOrHeatmap']);
+                if (scatterOrHeatmap) ftype = 'scatterOrHeatmap';
                 const submitChangesFunc = getSubmitChangesFunc(type, ftype);
                 //hideDialog();
                 submitChangesFunc && submitChangesFunc({chartId, activeTrace, fields, tbl_id});
@@ -73,7 +75,7 @@ function onChartAction({chartAction, tbl_id, chartId, hideDialog}) {
             case CHART_TRACE_REMOVE:
                 hideDialog();
                 const {activeTrace:traceNum} = getChartData(chartId);
-                removeTrace({chartId, traceNum});
+                dispatchChartTraceRemove(chartId, traceNum);
                 break;
             default:
                 console.log(`onChartAction - unsupported action ${chartAction}`);
@@ -309,11 +311,19 @@ export function getOptionsUI(chartId) {
     if (dataType === 'fireflyHistogram') {
         return FireflyHistogramOptions;
     } else if (dataType === 'fireflyHeatmap') {
-        return HeatmapOptions;
+        if (get(fireflyData, [activeTrace, 'scatterOrHeatmap']) && isScatter2d(type)) {
+            return ScatterOptions;
+        } else {
+            return HeatmapOptions;
+        }
     } else if (isScatter2d(type)) {
         return ScatterOptions;
     } else {
-        return BasicOptions;
+        if (get(fireflyData, [activeTrace, 'scatterOrHeatmap']) && type === 'heatmap') {
+            return HeatmapOptions;
+        } else {
+            return BasicOptions;
+        }
     }
 }
 

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -22,6 +22,7 @@ import {getColumnType, getTblById} from '../../../tables/TableUtil.js';
 import {getColValStats} from '../../TableStatsCntlr.js';
 import {getColValidator} from '../ColumnOrExpression.jsx';
 import {uniqueChartId, TRACE_COLORS, toRGBA, colorsOnTypes} from '../../ChartUtil.js';
+import {colorscaleNameToVal} from '../../Colorscale.js';
 
 import MAGNIFYING_GLASS from 'html/images/icons-2014/magnifyingGlass.png';
 import {ToolbarButton} from '../../../ui/ToolbarButton.jsx';
@@ -552,7 +553,13 @@ export function submitChanges({chartId, fields, tbl_id}) {
                     }
                 }
             }
-
+        } else if (k.match(/^fireflyData.+colorscale$/)) {
+            // colorscale name is saved in fireflyData
+            // the corresponding colorscale value must be set in data
+            const colorscale = colorscaleNameToVal(v);
+            if (colorscale) {
+                changes[k.replace(/^fireflyData/, 'data')] = colorscale;
+            }
         }
 
         // move colorbar to the other side of the chart

--- a/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
+++ b/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {get, isUndefined} from 'lodash';
+import {get, isArray, isUndefined} from 'lodash';
 
 import {getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
@@ -13,6 +13,7 @@ import {SimpleComponent} from '../../../ui/SimpleComponent.jsx';
 import {BasicOptionFields, basicFieldReducer, helpStyle, submitChanges} from './BasicOptions.jsx';
 import {getColValStats} from '../../TableStatsCntlr.js';
 import {ColumnOrExpression} from '../ColumnOrExpression.jsx';
+import {ALL_COLORSCALE_NAMES, PlotlyCS} from '../../Colorscale.js';
 
 
 
@@ -51,6 +52,13 @@ export function fieldReducer({chartId, activeTrace}) {
     const getFields = () => {
         const {data, fireflyData, tablesources = {}} = getChartData(chartId);
         const tablesourceMappings = get(tablesources[activeTrace], 'mappings');
+        let colorscaleName = get(fireflyData, `${activeTrace}.colorscale`);
+        if (!colorscaleName) {
+            const colorscale = get(data, `${activeTrace}.colorscale`);
+            if (colorscale && PlotlyCS.includes(colorscale)) {
+                colorscaleName = colorscale;
+            }
+        }
 
         const fields = {
 
@@ -72,9 +80,9 @@ export function fieldReducer({chartId, activeTrace}) {
                 labelWidth: 95,
                 size: 5
             },
-            [`data.${activeTrace}.colorscale`]: {
-                fieldKey: `data.${activeTrace}.colorscale`,
-                value: get(data, `${activeTrace}.colorscale`),
+            [`fireflyData.${activeTrace}.colorscale`]: {
+                fieldKey: `fireflyData.${activeTrace}.colorscale`,
+                value: colorscaleName,
                 tooltip: 'Select colorscale for color map',
                 label: 'Color Scale:',
                 ...fieldProps
@@ -135,11 +143,9 @@ export function TableSourcesOptions({tablesource={}, activeTrace, groupKey}) {
             {colValStats && <ColumnOrExpression {...xProps}/>}
             {colValStats && <ColumnOrExpression {...yProps}/>}
             <div style={{whiteSpace: 'nowrap'}}>
-                <ListBoxInputField fieldKey={`data.${activeTrace}.colorscale`}
+                <ListBoxInputField fieldKey={`fireflyData.${activeTrace}.colorscale`}
                                    inline={true}
-                                   options={[{value:'Greys'}, {value:'Bluered'}, {value:'Blues'}, {value:'Earth'}, {value:'Electric'}, {value:'Greens'},
-                                         {value:'Hot'}, {value:'Jet'}, {value:'Picnic'}, {value:'Portland'}, {value:'Rainbow'},
-                                         {value:'RdBu'}, {value:'Reds'}, {value:'Viridis'}, {value:'YlGnBu'}, {value:'YlOrRd'}]}/>
+                                   options={[{value:'Default'}].concat(ALL_COLORSCALE_NAMES.map((e)=>({value:e})))}/>
                 <CheckboxGroupInputField
                     fieldKey={`data.${activeTrace}.reversescale`}
                     wrapperStyle={{display: 'inline-block'}}
@@ -157,7 +163,7 @@ export function TableSourcesOptions({tablesource={}, activeTrace, groupKey}) {
 export function submitChangesHeatmap({chartId, activeTrace, fields, tbl_id}) {
     const dataType = (!tbl_id) ? 'heatmap' : 'fireflyHeatmap';
     const changes = {
-        [`fireflyData.${activeTrace}.type`] : 'heatmap',
+        [`data.${activeTrace}.type`] : 'heatmap',
         [`fireflyData.${activeTrace}.dataType`] : dataType
     };
 

--- a/src/firefly/js/charts/ui/options/NewTracePanel.jsx
+++ b/src/firefly/js/charts/ui/options/NewTracePanel.jsx
@@ -17,7 +17,14 @@ const fieldProps = {labelWidth: 62, size: 15};
 
 export function getSubmitChangesFunc(traceType, fireflyType) {
     const type = fireflyType || traceType;
+    
     switch(type) {
+        case 'scatterOrHeatmap':
+            if (traceType === 'heatmap') {
+                return submitChangesHeatmap;
+            } else {
+                return submitChangesScatter;
+            }
         case 'scatter':
         case 'scattergl':
             return submitChangesScatter;

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -18,6 +18,7 @@ import {ColumnOrExpression} from '../ColumnOrExpression.jsx';
 import {Errors, errorTypeFieldKey, errorFieldKey, errorMinusFieldKey, getDefaultErrorType} from './Errors.jsx';
 import {getAppOptions} from '../../../core/AppDataCntlr.js';
 import {getTblById} from '../../../tables/TableUtil.js';
+import {PlotlyCS} from '../../Colorscale.js';
 
 
 const fieldProps = {labelWidth: 62, size: 15};
@@ -245,9 +246,7 @@ export function TableSourcesOptions({chartId, tablesource={}, activeTrace, group
                 <ColumnOrExpression {...sizeMapProps}/>
                 <ColumnOrExpression {...colorMapProps}/>
                 <ListBoxInputField fieldKey={`data.${activeTrace}.marker.colorscale`}
-                                   options={[{value: 'Default'}, {value: 'Bluered'}, {value: 'Blues'}, {value: 'Earth'}, {value: 'Electric'}, {value: 'Greens'},
-                                       {value: 'Greys'}, {value: 'Hot'}, {value: 'Jet'}, {value: 'Picnic'}, {value: 'Portland'}, {value: 'Rainbow'},
-                                       {value: 'RdBu'}, {value: 'Reds'}, {value: 'Viridis'}, {value: 'YlGnBu'}, {value: 'YlOrRd'}]}/>
+                                   options={PlotlyCS.map((e)=>({value:e}))}/>
             </div>
             }
         </div>

--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -186,7 +186,7 @@ function resolveObject(posFieldDef, resolver) {
         }
     ).catch((e) => {
         let feedback = `Could not resolve: ${objName}`;
-        if (e.name === 'AbortError') {
+        if (e && e.name === 'AbortError') {
             feedback += '. Unresponsive service.';
         } else {
             feedback += '. Unexpected error.';

--- a/src/firefly/js/util/Color.js
+++ b/src/firefly/js/util/Color.js
@@ -114,7 +114,7 @@ function makeSimpleColorMap(baseColor, mapSize, reverse=false) {
         var rgb= toRGB(baseColor);
         var maxCnt= 0;
         var minCnt= 0;
-        rgb.foreach( (idx) => {
+        rgb.forEach( (idx) => {
             if (idx>250) maxCnt++;
             if (idx<5)   minCnt++;
         });

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -17,7 +17,7 @@ import {MetaConst} from '../../data/MetaConst.js';
 import Catalog from '../../drawingLayers/Catalog.js';
 import {CoordinateSys} from '../CoordSys.js';
 import {logError} from '../../util/WebUtil.js';
-import {getMaxDefaultScatterRows} from '../../charts/ChartUtil.js';
+import {getMaxScatterRows} from '../../charts/ChartUtil.js';
 
 
 /**
@@ -82,7 +82,7 @@ function handleCatalogUpdate(tbl_id) {
 
     
     const {tableMeta,totalRows,tableData, request, highlightedRow,selectInfo, title}= sourceTable;
-    const maxScatterRows = getMaxDefaultScatterRows();
+    const maxScatterRows = getMaxScatterRows();
 
 
 


### PR DESCRIPTION
Ticket: https://jira.lsstcorp.org/browse/DM-15490
Test deployment: https://irsawebdev9.ipac.caltech.edu/dm-15490/firefly/

- Modified Firefly behavior of scatter charts to move between scatter and heatmap representation depending on whether the number of table rows exceeds the threshold stored in charts.maxRowsForScatter application option. 
- Introduced custom (non-plotly) color scales, see Colorscale.js so that the color of the first 8 traces does not change dramatically, when switching between scatter and heatmap. 
- Fixed a  bug, preventing TableFunctionProcessor from refetching the table data after session timeout has passed.
- Fixed bugs related to trace removal.