### PR TITLE
DM-16012: table load failures

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/mapper/IpacTableExtractor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/mapper/IpacTableExtractor.java
@@ -185,10 +185,7 @@ public class IpacTableExtractor {
             DataType dt = headers.get(i);
             try {
                 Object obj = rs.getObject(dt.getKeyName());
-                if (obj instanceof String && ((String)obj).indexOf("\r")>=0) {
-                    obj = ((String)obj).replaceAll("\r", "");
-                }
-                writer.print(" " + dt.formatData(obj));
+                writer.print(" " + dt.formatData(obj, true));
             } catch (SQLException e) {
                 LOG.warn(e, "SQLException at col:" + headers.get(i).getKeyName());
                 writer.print(" " + dt.formatData("#ERROR#"));

--- a/src/firefly/java/edu/caltech/ipac/table/DataObject.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataObject.java
@@ -97,7 +97,7 @@ public class DataObject implements Serializable, Cloneable {
     }
 
     public String getFormatedData(DataType dt) {
-        return dt.formatData(getDataElement(dt));
+        return dt.formatData(getDataElement(dt), true);
     }
 
     public Object getDataElement(DataType fdt) {

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -235,7 +235,7 @@ public class IpacTableUtil {
             String v = row.getFixedFormatedData(dt);
             // when writing out the IPAC table.. if ROWID is given, and data is not found. use the getRowId() value instead.
             if (v == null && dt.getKeyName().equals(DataGroup.ROW_IDX)) {
-                v = dt.formatData(row.getRowNum());
+                v = dt.formatData(row.getRowNum(), true);
             }
             writer.print(" " + v);
         }
@@ -388,7 +388,7 @@ public class IpacTableUtil {
                         }
                     }
 
-                    row.setDataElement(dt, dt.convertStringToData(val));
+                    row.setDataElement(dt, dt.convertStringToData(val, true));
 
                     offset = endoffset;
                 }

--- a/src/firefly/java/edu/caltech/ipac/table/io/IpacTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/IpacTableWriter.java
@@ -5,23 +5,9 @@ package edu.caltech.ipac.table.io;
 
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
-import edu.caltech.ipac.table.DataGroup;
-import edu.caltech.ipac.table.DataGroupPart;
-import edu.caltech.ipac.table.DataObject;
-import edu.caltech.ipac.table.DataType;
-import edu.caltech.ipac.table.IpacTableUtil;
-import edu.caltech.ipac.table.TableMeta;
-import nom.tam.fits.Data;
+import edu.caltech.ipac.table.*;
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.io.RandomAccessFile;
+import java.io.*;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -121,7 +107,7 @@ public class IpacTableWriter {
             int maxWidth = Arrays.stream(headers).mapToInt(s -> s == null ? 0 : s.length()).max().getAsInt();
             for (int i=0; i<dataGroup.size(); i++) {
                 Object val = dataGroup.getData(dt.getKeyName(), i);
-                int dWidth = val == null ? 0 : dt.formatData(val).length();
+                int dWidth = val == null ? 0 : dt.formatData(val, true).length();
                 if (dWidth > maxWidth) maxWidth = dWidth;
             }
             dt.setMaxDataWidth(maxWidth);


### PR DESCRIPTION
Fixed failing table loads when a table contains quoted column name or a control characters in a cell.

https://jira.lsstcorp.org/browse/DM-16012 Firefly fails to load a table with '\n' and '\r' characters in a cell
https://jira.lsstcorp.org/browse/DM-15982 Firefly fails to load a table with a quoted column

Test deploy: https://irsawebdev9.ipac.caltech.edu/dm-16012/firefly

The solution was to remove quotes from column names and to escape/unescape control characters when writing and reading IPAC table to/from file. 

HSQLDB does not accept quotes in table column names. Even though DataGroup can handle quoted columns, we are removing quotes from column name in  DataType constructor rather than during DataGroup ingest into db, because it could result in inconsistent column names before and after ingest, which is undesirable.


The loading can be verified with a simple tap browser:
https://irsawebdev9.ipac.caltech.edu/dm-16012/firefly/demo/ffapi-tap-test.html
(Compare with nightly dev build)

It was previously failing on http://gea.esac.esa.int/tap-server/tap and http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap 