### PR TITLE
DM-15826 Improvements on reading VOTable in Firefly 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
@@ -99,7 +99,7 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
                 DataGroup errorTbl = results[0];
                 return errorTbl.getAttribute("QUERY STATUS");
             } catch (IOException e) {
-                e.printStackTrace();
+                logger.error(e);
             }
             return "";
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
@@ -14,6 +14,7 @@ import edu.caltech.ipac.util.StringUtils;
 import org.apache.commons.httpclient.Header;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 @SearchProcessorImpl(id = AsyncTapQuery.ID, params = {
         @ParamDoc(name = "serviceUrl", desc = "base TAP url endpoint excluding '/async'"),
@@ -93,9 +94,14 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
         }
 
         public String getErrorMsg() {
-            DataGroup[] results = VoTableReader.voToDataGroups(baseJobUrl + "/error");
-            DataGroup errorTbl = results[0];
-            return errorTbl.getAttribute("QUERY STATUS");
+            try {
+                DataGroup[] results = VoTableReader.voToDataGroups(baseJobUrl + "/error");
+                DataGroup errorTbl = results[0];
+                return errorTbl.getAttribute("QUERY STATUS");
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return "";
         }
 
         public long getTimeout() {

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -22,6 +22,14 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
     private TableMeta meta = new TableMeta();
     private String title;
     private int size;
+    private String ID;
+    private String ref;
+    private String ucd;
+    private String utype;
+    private String desc;
+    private List<GroupInfo> groups = new ArrayList<>();   // for <GROUP> under <TABLE> of VOTable
+    private List<LinkInfo> links = new ArrayList<>();     // for <LINK> under <TABLE> of VOTable
+    private List<DataType> staticColumns = new ArrayList<>();  // for <PARAM> under <TABLE> of VOTABLE
     private transient DataType[] cachedColumnsAry = null;
 
     public DataGroup(String title, DataType[] dataDefs) {
@@ -309,6 +317,149 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
                 }
             }
         }
+    }
+
+    //============================================
+    // description of table
+    //============================================
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public void setDesc(String desc) {
+        this.desc = desc;
+    }
+
+    //=============================================
+    // ID for table, ex: ID attribute in votable
+    //=============================================
+    public void setID(String id) {
+        this.ID = id;
+    }
+
+    public String getID() {
+        return this.ID;
+    }
+
+    //==================================================
+    // ref for table, ex: ref attribute in votable
+    //==================================================
+    public void setRef(String value) {
+        this.ref = value;
+    }
+
+    public String getRef() {
+        return this.ref;
+    }
+
+
+    //============================================================
+    // ucd, utype for table, ex: ucd, utype attribute in votable
+    //===========================================================
+    public void setUCD(String ucd) {
+        this.ucd = ucd;
+    }
+
+    public String getUCD() {
+        return this.ucd;
+    }
+
+    public void setUType(String utype) {
+        this.utype = utype;
+    }
+
+    public String getUType() {
+        return this.utype;
+    }
+
+    //==========================================================
+    // group of columns for table, ex: GROUP element in votable
+    //==========================================================
+    public void addGroup(GroupInfo gObj) {
+        groups.add(gObj);
+    }
+
+    public void removeGroup(int i) {
+        if (i >= 0 && i < groups.size()) {
+            groups.remove(i);
+        }
+    }
+
+    public void removeGroup(GroupInfo gObj) {
+        groups.remove(gObj);
+    }
+
+    public GroupInfo getGroup(int i) {
+        if (i >= 0 && i < groups.size()) {
+            return groups.get(i);
+        } else {
+            return null;
+        }
+    }
+
+    public List<GroupInfo> getGroups() {
+        return groups;
+    }
+
+    //==============================================
+    // links for table, ex: LINK element in votable
+    //==============================================
+    public void addLink(LinkInfo linkObj) {
+        links.add(linkObj);
+    }
+
+    public void removeLink(int i) {
+        if (i >= 0 && i < links.size()) {
+            links.remove(i);
+        }
+    }
+
+    public void removeLink(LinkInfo linkObj) {
+        links.remove(linkObj);
+    }
+
+    public LinkInfo getLink(int i) {
+        if (i >= 0 && i < links.size()) {
+            return links.get(i);
+        } else {
+            return null;
+        }
+    }
+
+    public List<LinkInfo> getLinks() {
+        return links;
+    }
+
+    //===============================
+    // columns with static value
+    // ex: PARAM element for votable
+    //================================
+
+    public void addParam(DataType dt) {
+        staticColumns.add(dt);
+    }
+
+    public void removeParam(int i) {
+        if (i >= 0 && i < staticColumns.size()) {
+            staticColumns.remove(i);
+        }
+    }
+
+    public void removeParam(DataType dt) {
+        staticColumns.remove(dt);
+    }
+
+    public DataType getParam(int i) {
+        if (i >= 0 && i < staticColumns.size()) {
+            return staticColumns.get(i);
+        } else {
+            return null;
+        }
+    }
+
+    public List<DataType> getParams() {
+        return staticColumns;
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -22,11 +22,6 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
     private TableMeta meta = new TableMeta();
     private String title;
     private int size;
-    private String ID;
-    private String ref;
-    private String ucd;
-    private String utype;
-    private String desc;
     private List<GroupInfo> groups = new ArrayList<>();   // for <GROUP> under <TABLE> of VOTable
     private List<LinkInfo> links = new ArrayList<>();     // for <LINK> under <TABLE> of VOTable
     private List<DataType> staticColumns = new ArrayList<>();  // for <PARAM> under <TABLE> of VOTABLE
@@ -319,145 +314,26 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
         }
     }
 
-    //============================================
-    // description of table
-    //============================================
-
-    public String getDesc() {
-        return desc;
-    }
-
-    public void setDesc(String desc) {
-        this.desc = desc;
-    }
-
-    //=============================================
-    // ID for table, ex: ID attribute in votable
-    //=============================================
-    public void setID(String id) {
-        this.ID = id;
-    }
-
-    public String getID() {
-        return this.ID;
-    }
-
-    //==================================================
-    // ref for table, ex: ref attribute in votable
-    //==================================================
-    public void setRef(String value) {
-        this.ref = value;
-    }
-
-    public String getRef() {
-        return this.ref;
-    }
-
-
-    //============================================================
-    // ucd, utype for table, ex: ucd, utype attribute in votable
-    //===========================================================
-    public void setUCD(String ucd) {
-        this.ucd = ucd;
-    }
-
-    public String getUCD() {
-        return this.ucd;
-    }
-
-    public void setUType(String utype) {
-        this.utype = utype;
-    }
-
-    public String getUType() {
-        return this.utype;
-    }
-
-    //==========================================================
-    // group of columns for table, ex: GROUP element in votable
-    //==========================================================
-    public void addGroup(GroupInfo gObj) {
-        groups.add(gObj);
-    }
-
-    public void removeGroup(int i) {
-        if (i >= 0 && i < groups.size()) {
-            groups.remove(i);
-        }
-    }
-
-    public void removeGroup(GroupInfo gObj) {
-        groups.remove(gObj);
-    }
-
-    public GroupInfo getGroup(int i) {
-        if (i >= 0 && i < groups.size()) {
-            return groups.get(i);
-        } else {
-            return null;
-        }
-    }
-
-    public List<GroupInfo> getGroups() {
+    /**
+     * get GroupInfo list
+     * @return list of GroupInfo object
+     */
+    public List<GroupInfo> getGroupInfos() {
         return groups;
     }
 
-    //==============================================
-    // links for table, ex: LINK element in votable
-    //==============================================
-    public void addLink(LinkInfo linkObj) {
-        links.add(linkObj);
-    }
-
-    public void removeLink(int i) {
-        if (i >= 0 && i < links.size()) {
-            links.remove(i);
-        }
-    }
-
-    public void removeLink(LinkInfo linkObj) {
-        links.remove(linkObj);
-    }
-
-    public LinkInfo getLink(int i) {
-        if (i >= 0 && i < links.size()) {
-            return links.get(i);
-        } else {
-            return null;
-        }
-    }
-
-    public List<LinkInfo> getLinks() {
+    /**
+     * get LinkInfo list
+     * @return a list of LinkInfo
+     */
+    public List<LinkInfo> getLinkInfos() {
         return links;
     }
 
-    //===============================
-    // columns with static value
-    // ex: PARAM element for votable
-    //================================
-
-    public void addParam(DataType dt) {
-        staticColumns.add(dt);
-    }
-
-    public void removeParam(int i) {
-        if (i >= 0 && i < staticColumns.size()) {
-            staticColumns.remove(i);
-        }
-    }
-
-    public void removeParam(DataType dt) {
-        staticColumns.remove(dt);
-    }
-
-    public DataType getParam(int i) {
-        if (i >= 0 && i < staticColumns.size()) {
-            return staticColumns.get(i);
-        } else {
-            return null;
-        }
-    }
-
+    /**
+     * get a list static column (like PARAM in votable)
+     * @return a list of static columns in form of DataType objects
+     */
     public List<DataType> getParams() {
         return staticColumns;
     }

--- a/src/firefly/java/edu/caltech/ipac/table/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataType.java
@@ -10,6 +10,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.ArrayList;
 
 public class DataType implements Serializable, Cloneable {
 
@@ -51,6 +52,16 @@ public class DataType implements Serializable, Cloneable {
     private       String format;           // format string used for formating
     private       String fmtDisp;          // format string for diplay ... this is deprecated
     private       String sortByCols;       // comma-separated of column names
+    private       String ID;
+    private       String precision;
+    private       String ucd;
+    private       String utype;
+    private       String ref = "";
+    private       List<LinkInfo> links = new ArrayList<>();
+    private       String maxValue = "";
+    private       String minValue = "";
+    private       String[] options = null;
+    private       String staticValue;
 
 //    private transient PrimitiveList data;       // column-based data
     private transient int maxDataWidth = 0;     // this is the max width of the data...from reading the file.  only used by shrinkToFit
@@ -204,6 +215,89 @@ public class DataType implements Serializable, Cloneable {
     public int getMaxDataWidth() { return maxDataWidth; }
 
     public void setMaxDataWidth(int maxDataWidth) { this.maxDataWidth = maxDataWidth; }
+
+    public void setID (String id) {
+        this.ID = id;
+    }
+
+    public String getID () {
+        return ID;
+    }
+
+    // for numeric data type,
+    // precision string format: wwEn or wwFn,
+    //                          ww: number of character,
+    //                          En: n means number of significant figures
+    //                          Fn: n means the significant figures after decimal point
+    public void setPrecision(String prec) {
+        this.precision = prec;
+    }
+
+    public String getPrecision() {
+        return precision;
+    }
+
+    public void setUCD(String ucd) {
+        this.ucd = ucd;
+    }
+
+    public String getUCD() {
+        return ucd;
+    }
+
+    public void setUType(String utype) {
+        this.utype = utype;
+    }
+
+    public String getUType() {
+        return utype;
+    }
+
+    public void setMaxValue(String max) {
+        this.maxValue = max;
+    }
+
+    public String getMaxValue() {
+        return maxValue;
+    }
+
+    public void setMinValue(String min) {
+        this.minValue = min;
+    }
+
+    public String getMinValue() {
+        return minValue;
+    }
+
+    public void setValue(String value) {
+        this.staticValue = value;
+    }
+
+    public String getValue() {
+        return staticValue;
+    }
+
+    // options of the data
+    public void setOptions(String[] srcStr) {
+        if (srcStr == null || srcStr.length == 0) {
+            options = null;
+        } else {
+            options = new String[srcStr.length];
+            Arrays.copyOf(srcStr, srcStr.length);
+        }
+    }
+
+    public String[] getOptions() {
+        return options;
+    }
+
+    public void setRef(String value) {
+        this.ref = value;
+    }
+
+    public String getRef() {
+        return ref;
+    }
 
     /**
      * returns the formatted header of this column padded to max width
@@ -394,4 +488,35 @@ public class DataType implements Serializable, Cloneable {
             return null; // should not happen;
         }
     }
+
+
+    //===================================================================
+    // links for Column, ex: LINK element(s) under FIELD element in votable
+    //===================================================================
+    public void addLink(LinkInfo linkObj) {
+        this.links.add(linkObj);
+    }
+
+    public void removeLink(int i) {
+        if (i >= 0 && i < links.size()) {
+            links.remove(i);
+        }
+    }
+
+    public void removeLink(LinkInfo linkObj) {
+        links.remove(linkObj);
+    }
+
+    public LinkInfo getLink(int i) {
+        if (i >= 0 && i < links.size()) {
+            return links.get(i);
+        } else {
+            return null;
+        }
+    }
+
+    public List<LinkInfo> getLinks() {
+        return links;
+    }
+
 }

--- a/src/firefly/java/edu/caltech/ipac/table/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataType.java
@@ -224,11 +224,12 @@ public class DataType implements Serializable, Cloneable {
         return ID;
     }
 
-    // for numeric data type,
-    // precision string format: wwEn or wwFn,
-    //                          ww: number of character,
-    //                          En: n means number of significant figures
-    //                          Fn: n means the significant figures after decimal point
+    /**
+     * set precision for numeric data, En or Fn
+     *          En: n means number of significant figures
+     *          Fn: n means the significant figures after decimal point
+     * @param prec
+     */
     public void setPrecision(String prec) {
         this.precision = prec;
     }
@@ -490,32 +491,11 @@ public class DataType implements Serializable, Cloneable {
     }
 
 
-    //===================================================================
-    // links for Column, ex: LINK element(s) under FIELD element in votable
-    //===================================================================
-    public void addLink(LinkInfo linkObj) {
-        this.links.add(linkObj);
-    }
-
-    public void removeLink(int i) {
-        if (i >= 0 && i < links.size()) {
-            links.remove(i);
-        }
-    }
-
-    public void removeLink(LinkInfo linkObj) {
-        links.remove(linkObj);
-    }
-
-    public LinkInfo getLink(int i) {
-        if (i >= 0 && i < links.size()) {
-            return links.get(i);
-        } else {
-            return null;
-        }
-    }
-
-    public List<LinkInfo> getLinks() {
+    /**
+     * get LinkInfo list
+     * @return a list of LinkInfo
+     */
+    public List<LinkInfo> getLinkInfos() {
         return links;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/table/GroupInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/table/GroupInfo.java
@@ -2,6 +2,7 @@ package edu.caltech.ipac.table;
 
 import java.io.Serializable;
 import java.util.*;
+import edu.caltech.ipac.util.StringUtils;
 
 /**
  * Object representing the info. for group of columns, like GROUP element under the TABLE element in VOTable
@@ -12,7 +13,6 @@ public class GroupInfo implements Serializable, Cloneable{
     private String desc;      // group description
     private String ID;        // group ID
     private List<FieldRef> fieldRefs = new ArrayList<>();      // referenced columns in form of FieldRef objects
-    private List<DataType> dataTypeAry = new ArrayList<>();    // referenced columns in form of DataType objects
 
     public GroupInfo(String name, String desc) {
         this.name = name;
@@ -39,18 +39,15 @@ public class GroupInfo implements Serializable, Cloneable{
         return ID;
     }
 
-    public void addFieldRef(String ref, String ucd, String utype) {
-        FieldRef fRef = new FieldRef(ref, ucd, utype);
-        addFieldRef(fRef);
-    }
-
-    public void addFieldRef(FieldRef ref) {
-        fieldRefs.add(ref);
+    public List<FieldRef> getFieldRefs() {
+        return fieldRefs;
     }
 
     // convert FieldRef into DataType
     public List<DataType> getReferencedColumns(List<DataType> columns) {
-        if (dataTypeAry.size() == 0 && fieldRefs.size() > 0) {
+        List<DataType> dataTypeAry = new ArrayList<>();
+
+        if (fieldRefs.size() > 0) {
             for (FieldRef fRef : fieldRefs) {
                 String refName = fRef.getRef();
                 for (DataType col : columns) {
@@ -65,56 +62,32 @@ public class GroupInfo implements Serializable, Cloneable{
     }
 
     public Object clone() throws CloneNotSupportedException {
-        GroupInfo gobj = (GroupInfo) super.clone();
+        GroupInfo gobj = new GroupInfo(name, desc);
+        List<FieldRef>  newRefs = gobj.getFieldRefs();
+
         for (FieldRef ref : fieldRefs) {
-            gobj.addFieldRef((FieldRef)ref.clone());
+           newRefs.add((FieldRef)ref.clone());
         }
         return gobj;
     }
 
-    private String outString(boolean isJson) {
-        String q = isJson ? "\"" : "";
-        StringBuffer sb = new StringBuffer("{");
-
-        int idx = 0;
-
-        idx = LinkInfo.outKeyValue(idx, q, "ID", getID(), sb );
-        idx = LinkInfo.outKeyValue(idx, q, "name", getName(), sb );
-        idx = LinkInfo.outKeyValue(idx, q, "description", desc, sb);
-
-        if (idx > 0) {
-            sb.append(", ");
-        }
-        sb.append(q).append("refs").append(q).append(":[");
-
-        idx = 0;
-
-        for (FieldRef ref : fieldRefs) {
-            if (idx++ != 0) {
-                sb.append(", ");
-            }
-            if (isJson) {
-                sb.append(ref.toJsonString());
-            } else {
-                sb.append(ref.toString());
-            }
-        }
-        sb.append("]}");
-
-        return sb.toString();
-    }
-
-    public String toJsonString() {
-        return outString(true);
-    }
 
     public String toString() {
-        return outString(false);
+        StringBuilder sb =  new StringBuilder(StringUtils.isEmpty(name) ? "[" : name+", [");
+
+        for (int i = 0; i < fieldRefs.size(); i++) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            sb.append("\"").append(fieldRefs.get(i).getRef()).append("\"");
+        }
+
+        sb.append("]");
+        return sb.toString();
+
     }
 
-
-
-    public static class FieldRef implements Serializable, Cloneable {
+    public static class FieldRef implements Cloneable {
         private String ref;
         private String ucd;
         private String utype;
@@ -139,28 +112,6 @@ public class GroupInfo implements Serializable, Cloneable{
 
         public Object clone() throws CloneNotSupportedException {
             return super.clone();
-        }
-
-
-        private String outString(boolean isJson) {
-            String q = isJson ? "\"" : "";
-            StringBuffer sb = new StringBuffer("{");
-
-            sb.append(q).append("ref").append(q).append(":\"").append(getRef()).append("\"");
-
-            LinkInfo.outKeyValue(1, q, "ucd", getUcd(), sb);
-            LinkInfo.outKeyValue(1, q, "utype", getUtype(), sb);
-
-            sb.append("}");
-            return sb.toString();
-        }
-
-        public String toJsonString() {
-            return outString(true);
-        }
-
-        public String toString() {
-            return outString(false);
         }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/table/GroupInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/table/GroupInfo.java
@@ -1,0 +1,166 @@
+package edu.caltech.ipac.table;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * Object representing the info. for group of columns, like GROUP element under the TABLE element in VOTable
+ * Created by cwang on 9/28/18.
+ */
+public class GroupInfo implements Serializable, Cloneable{
+    private String name;      // group name
+    private String desc;      // group description
+    private String ID;        // group ID
+    private List<FieldRef> fieldRefs = new ArrayList<>();      // referenced columns in form of FieldRef objects
+    private List<DataType> dataTypeAry = new ArrayList<>();    // referenced columns in form of DataType objects
+
+    public GroupInfo(String name, String desc) {
+        this.name = name;
+        this.desc = desc;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setDescription(String desc) {
+        this.desc = desc;
+    }
+
+    public String getDescription() {
+        return desc;
+    }
+
+    public void setID(String id) {
+        this.ID = id;
+    }
+
+    public String getID() {
+        return ID;
+    }
+
+    public void addFieldRef(String ref, String ucd, String utype) {
+        FieldRef fRef = new FieldRef(ref, ucd, utype);
+        addFieldRef(fRef);
+    }
+
+    public void addFieldRef(FieldRef ref) {
+        fieldRefs.add(ref);
+    }
+
+    // convert FieldRef into DataType
+    public List<DataType> getReferencedColumns(List<DataType> columns) {
+        if (dataTypeAry.size() == 0 && fieldRefs.size() > 0) {
+            for (FieldRef fRef : fieldRefs) {
+                String refName = fRef.getRef();
+                for (DataType col : columns) {
+                    String id = col.getID();
+                    if (id != null && id.equals(refName)) {
+                        dataTypeAry.add(col);
+                    }
+                }
+            }
+        }
+        return dataTypeAry;
+    }
+
+    public Object clone() throws CloneNotSupportedException {
+        GroupInfo gobj = (GroupInfo) super.clone();
+        for (FieldRef ref : fieldRefs) {
+            gobj.addFieldRef((FieldRef)ref.clone());
+        }
+        return gobj;
+    }
+
+    private String outString(boolean isJson) {
+        String q = isJson ? "\"" : "";
+        StringBuffer sb = new StringBuffer("{");
+
+        int idx = 0;
+
+        idx = LinkInfo.outKeyValue(idx, q, "ID", getID(), sb );
+        idx = LinkInfo.outKeyValue(idx, q, "name", getName(), sb );
+        idx = LinkInfo.outKeyValue(idx, q, "description", desc, sb);
+
+        if (idx > 0) {
+            sb.append(", ");
+        }
+        sb.append(q).append("refs").append(q).append(":[");
+
+        idx = 0;
+
+        for (FieldRef ref : fieldRefs) {
+            if (idx++ != 0) {
+                sb.append(", ");
+            }
+            if (isJson) {
+                sb.append(ref.toJsonString());
+            } else {
+                sb.append(ref.toString());
+            }
+        }
+        sb.append("]}");
+
+        return sb.toString();
+    }
+
+    public String toJsonString() {
+        return outString(true);
+    }
+
+    public String toString() {
+        return outString(false);
+    }
+
+
+
+    public static class FieldRef implements Serializable, Cloneable {
+        private String ref;
+        private String ucd;
+        private String utype;
+
+        public FieldRef(String ref, String ucd, String utype) {
+            this.ref = ref;
+            this.ucd = ucd;
+            this.utype = utype;
+        }
+
+        public String getRef() {
+            return ref;
+        }
+
+        public String getUcd() {
+            return ucd;
+        }
+
+        public String getUtype() {
+            return utype;
+        }
+
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+
+
+        private String outString(boolean isJson) {
+            String q = isJson ? "\"" : "";
+            StringBuffer sb = new StringBuffer("{");
+
+            sb.append(q).append("ref").append(q).append(":\"").append(getRef()).append("\"");
+
+            LinkInfo.outKeyValue(1, q, "ucd", getUcd(), sb);
+            LinkInfo.outKeyValue(1, q, "utype", getUtype(), sb);
+
+            sb.append("}");
+            return sb.toString();
+        }
+
+        public String toJsonString() {
+            return outString(true);
+        }
+
+        public String toString() {
+            return outString(false);
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -305,6 +305,63 @@ public class JsonTableUtil {
 
     //============================= //============================= //============================= //============================= //============================= //=============================
 
+    /**
+     * list of Json Object for list of GroupInfo under table model
+     * @param groupInfos
+     * @return
+     */
+    public List<JSONObject> toJsonTableGroupInfos(List<GroupInfo> groupInfos) {
+        List<JSONObject> groupsJson = new ArrayList<>();
+
+        for (GroupInfo gInfo : groupInfos) {
+            JSONObject groupJson = new JSONObject();
+            List<JSONObject> fRefJsons = new ArrayList<>();
+
+            groupJson.put("name", gInfo.getName());
+            groupJson.put("desc", gInfo.getDescription());
+            groupJson.put("ID", gInfo.getID());
+
+            for (GroupInfo.FieldRef ref : gInfo.getFieldRefs()) {
+                JSONObject fRefJson = new JSONObject();
+
+                fRefJson.put("ref", ref.getRef());
+                fRefJson.put("ucd", ref.getUcd());
+                fRefJson.put("utype", ref.getUtype());
+
+                fRefJsons.add(fRefJson);
+            }
+
+            groupJson.put("refts", fRefJsons);
+            groupsJson.add(groupJson);
+        }
+
+        return groupsJson;
+    }
+
+    /**
+     * list of json object for a list of LinkInfo under table model
+     * @param linkInfos
+     * @return
+     */
+    public List<JSONObject> toJsonTableLinkInfos(List<LinkInfo> linkInfos) {
+        List<JSONObject> linksJson = new ArrayList<>();
+
+        for (LinkInfo linkInfo : linkInfos) {
+            JSONObject linkJson = new JSONObject();
+
+            linkJson.put("title", linkInfo.getTitle());
+            linkJson.put("ID", linkInfo.getID());
+            linkJson.put("href", linkInfo.getHref());
+            linkJson.put("content-role", linkInfo.getRole());
+            linkJson.put("content-type", linkInfo.getType());
+
+            linksJson.add(linkJson);
+
+        }
+
+        return linksJson;
+    }
+
 
 }
 

--- a/src/firefly/java/edu/caltech/ipac/table/LinkInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/table/LinkInfo.java
@@ -56,40 +56,8 @@ public class LinkInfo  implements Serializable, Cloneable {
         return super.clone();
     }
 
-    // for output optional key/value
-    public static int outKeyValue(int idx, String quote, String key, String value, StringBuffer sb) {
-        if (!StringUtils.isEmpty(value)) {
-            if (idx++ > 0) {
-                sb.append(", ");
-            }
-            sb.append(quote).append(key).append(quote).append(":\"").append(value).append("\"");
-        }
-        return idx;
-    }
-
-    private String outString(boolean isJson) {
-        String q = isJson ? "\"" : "";
-        StringBuffer sb = new StringBuffer("{");
-
-        int idx = 0;
-        idx = outKeyValue(idx, q, "ID", getID(), sb);
-        idx = outKeyValue(idx, q, "href", getHref(), sb);
-        idx = outKeyValue(idx, q, "title", getTitle(), sb);
-        idx = outKeyValue(idx, q, "contnet-role", getRole(), sb);
-        outKeyValue(idx, q, "content-type", getType(), sb);
-
-        sb.append("}");
-
-        return sb.toString();
-    }
-
-    public String toJsonString() {
-        return outString(true);
-    }
-
     public String toString() {
-        return outString(false);
-
+        return StringUtils.isEmpty(this.contentType) ? this.href : (this.contentType+", "+this.href);
     }
 
 }

--- a/src/firefly/java/edu/caltech/ipac/table/LinkInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/table/LinkInfo.java
@@ -1,0 +1,95 @@
+package edu.caltech.ipac.table;
+
+import java.io.Serializable;
+import edu.caltech.ipac.util.StringUtils;
+
+/**
+ * Object representing the link info., like LINK element under the TABLE element or FIELD element in VOTable
+ * Created by cwang on 9/28/18.
+ */
+public class LinkInfo  implements Serializable, Cloneable {
+    private String href;     // LINK href
+    private String title;    // LINK title
+    private String contentRole;   // LINK content-role
+    private String contentType;   // LINK content-type
+    private String ID;            // LINK ID
+
+    public LinkInfo(String href, String title) {
+        this.href = href;
+        this.title = title;
+    }
+
+    public void setRole(String role) {
+        this.contentRole = role;
+    }
+
+    public String getRole() {
+        return contentRole;
+    }
+
+    public void setType(String type) {
+        this.contentType = type;
+    }
+
+    public String getType() {
+        return contentType;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public String getTitle() {
+        return title;
+
+    }
+
+    public void setID(String id) {
+        this.ID = id;
+    }
+
+    public String getID() {
+        return ID;
+    }
+
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+
+    // for output optional key/value
+    public static int outKeyValue(int idx, String quote, String key, String value, StringBuffer sb) {
+        if (!StringUtils.isEmpty(value)) {
+            if (idx++ > 0) {
+                sb.append(", ");
+            }
+            sb.append(quote).append(key).append(quote).append(":\"").append(value).append("\"");
+        }
+        return idx;
+    }
+
+    private String outString(boolean isJson) {
+        String q = isJson ? "\"" : "";
+        StringBuffer sb = new StringBuffer("{");
+
+        int idx = 0;
+        idx = outKeyValue(idx, q, "ID", getID(), sb);
+        idx = outKeyValue(idx, q, "href", getHref(), sb);
+        idx = outKeyValue(idx, q, "title", getTitle(), sb);
+        idx = outKeyValue(idx, q, "contnet-role", getRole(), sb);
+        outKeyValue(idx, q, "content-type", getType(), sb);
+
+        sb.append("}");
+
+        return sb.toString();
+    }
+
+    public String toJsonString() {
+        return outString(true);
+    }
+
+    public String toString() {
+        return outString(false);
+
+    }
+
+}

--- a/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
@@ -46,6 +46,11 @@ public class TableMeta implements Serializable {
 
     public static final String IS_FULLY_LOADED = "isFullyLoaded";     // do not format data
 
+    public static final String ID = "ID";
+    public static final String REF = "ref";
+    public static final String UCD = "ucd";
+    public static final String UTYPE = "utype";
+    public static final String DESC = "desc";
     /*
       attributes is a key/value map of table meta information.
       keywords is a list of all table meta information including comments and duplicate attribute entries.

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -9,6 +9,7 @@ import edu.caltech.ipac.table.DataType;
 import edu.caltech.ipac.table.IpacTableUtil;
 import edu.caltech.ipac.table.GroupInfo;
 import edu.caltech.ipac.table.LinkInfo;
+import edu.caltech.ipac.table.TableMeta;
 import edu.caltech.ipac.util.FitsHDUUtil;
 import uk.ac.starlink.table.*;
 import uk.ac.starlink.votable.VOStarTable;
@@ -697,10 +698,10 @@ public class VoTableReader {
 
         if (tableEl != null) {
             // attribute ID, ref, ucd, utype from TABLE
-            dg.addAttribute(ID,  getElementAttribute(tableEl, ID));
-            dg.addAttribute(REF, getElementAttribute(tableEl, REF));
-            dg.addAttribute(UCD, getElementAttribute(tableEl, UCD));
-            dg.addAttribute(UTYPE, getElementAttribute(tableEl, UTYPE));
+            dg.addAttribute(TableMeta.ID,  getElementAttribute(tableEl, ID));
+            dg.addAttribute(TableMeta.REF, getElementAttribute(tableEl, REF));
+            dg.addAttribute(TableMeta.UCD, getElementAttribute(tableEl, UCD));
+            dg.addAttribute(TableMeta.UTYPE, getElementAttribute(tableEl, UTYPE));
 
             // child element PARAM, GROUP, LINK for TABLE
             makeParamsFromTable(tableEl, table, dg);
@@ -710,7 +711,7 @@ public class VoTableReader {
             // child element DESCRIPTION
             String tDesc = tableEl.getDescription();
             if (tDesc != null) {
-                dg.addAttribute(DESC, tDesc.replace("\n", " "));
+                dg.addAttribute(TableMeta.DESC, tDesc.replace("\n", " "));
             }
         }
 

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -7,11 +7,17 @@ import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataObject;
 import edu.caltech.ipac.table.DataType;
 import edu.caltech.ipac.table.IpacTableUtil;
-import edu.caltech.ipac.table.io.IpacTableWriter;
+import edu.caltech.ipac.table.GroupInfo;
+import edu.caltech.ipac.table.LinkInfo;
 import edu.caltech.ipac.util.FitsHDUUtil;
 import uk.ac.starlink.table.*;
 import uk.ac.starlink.votable.VOStarTable;
-import uk.ac.starlink.votable.VOTableBuilder;
+import uk.ac.starlink.votable.VOElement;
+import uk.ac.starlink.votable.VOElementFactory;
+import uk.ac.starlink.votable.TableElement;
+import uk.ac.starlink.votable.LinkElement;
+import uk.ac.starlink.votable.FieldElement;
+import uk.ac.starlink.votable.ValuesElement;
 import org.json.simple.JSONObject;
 
 import java.io.File;
@@ -20,6 +26,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.Arrays;
+import org.xml.sax.SAXException;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 /**
  * Date: Dec 5, 2011
@@ -39,37 +48,321 @@ public class VoTableReader {
     /**
      * returns an array of DataGroup from a vo table.
      * @param location  location of the vo table data source using automatic format detection.  Can be file or url.
-     * @return
+     * @return an array of DataGroup objects
      */
     public static DataGroup[] voToDataGroups(String location) {
         return voToDataGroups(location,false);
     }
 
     /**
-     * returns an array of DataGroup from a vo table.
-     * @param location  location of the vo table data source using automatic format detection.  Can be file or url.
+     * returns an array of DataGroup from a votable file.
+     * @param location  location of the votable data source using automatic format detection.  Can be file or url.
      * @param headerOnly  if true, returns only the headers, not the data.
-     * @return
+     * @return an array of DataGroup object
      */
     public static DataGroup[] voToDataGroups(String location, boolean headerOnly) {
-        VOTableBuilder votBuilder = new VOTableBuilder();
-        List<DataGroup> groups = new ArrayList<DataGroup>();
+        //VOTableBuilder votBuilder = new VOTableBuilder();
+        List<DataGroup> groups = new ArrayList<>();
+
         try {
             //DataSource datsrc = DataSource.makeDataSource(voTableFile);
             //StoragePolicy policy = StoragePolicy.getDefaultPolicy();
             //TableSequence tseq = votBuilder.makeStarTables( datsrc, policy );
-            StarTableFactory stFactory = new StarTableFactory();
-            TableSequence tseq = stFactory.makeStarTables(location, null);
+            //StarTableFactory stFactory = new StarTableFactory();
+            //TableSequence tseq = stFactory.makeStarTables(location, null);
 
-            for ( StarTable table; ( table = tseq.nextTable() ) != null; ) {
-                DataGroup dg = convertToDataGroup(table, headerOnly);
-                groups.add( dg );
+            List<TableElement> tableAry = getTableElementsFromFile( location, null);
+            for ( TableElement tableEl : tableAry ) {
+                DataGroup dg = convertToDataGroup(tableEl, new VOStarTable(tableEl), headerOnly);
+                groups.add(dg);
             }
         } catch (IOException e) {
             e.printStackTrace();
         }
 
         return groups.toArray(new DataGroup[groups.size()]);
+    }
+
+    private static String UCD = "ucd";
+    private static String REF = "ref";
+    private static String UTYPE = "utype";
+    private static String ID = "ID";
+
+    private static String getElementAttribute(VOElement element, String attName) {
+        return element.hasAttribute(attName) ? element.getAttribute(attName) : null;
+    }
+
+
+    // root VOElement for a votable file
+    private static VOElement getVOElementFromVOTable(String location, StoragePolicy policy) {
+        try {
+            VOElementFactory voFactory =  new VOElementFactory();
+            if (policy != null) {
+                voFactory.setStoragePolicy(policy);
+            }
+           return voFactory.makeVOElement(location);
+        }  catch (SAXException|IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    // get all <RESOURCE> under VOTable root or <RESOURCE>
+    private static VOElement[] getResourceChildren(VOElement parent) {
+        return parent.getChildrenByName( "RESOURCE" );
+    }
+
+    // get all <TABLE> children under <RESOURCE>
+    private static VOElement[] getTableChildren(VOElement parent) {
+        return parent.getChildrenByName( "TABLE" );
+    }
+
+    // get all <GROUP> under <TABLE>
+    private static VOElement[] getGroupsFromTable(TableElement tableEl) {
+        return tableEl.getChildrenByName("GROUP");
+    }
+
+    // get all <LINK> under <TABLE>
+    private static LinkElement[] getLinksFromTable(TableElement tableEl) {
+        return tableEl.getLinks();
+    }
+
+    // get all <PARAM> under <TABLE>
+    private  static VOElement[] getParamsFromTable(TableElement tableEl) {
+        return tableEl.getChildrenByName("PARAM");
+    }
+
+    // get all <INFO> under <TABLE>
+    private static VOElement[] getInfosFromTable(TableElement tableEl) {
+        return tableEl.getChildrenByName("INFO");
+
+    }
+
+    // get all <FIELD> under <TABLE>
+    private static FieldElement[] getFieldsFromTable(TableElement tableEl) {
+        return tableEl.getFields();
+    }
+
+    // get all <LINK> from <FIELD>
+    private static VOElement[] getLinksFromField(FieldElement fieldEl) {
+        // VOElement -> LinkElement
+        VOElement[] voLinkAry = fieldEl.getChildrenByName("LINK");
+        VOElement[] links = new LinkElement[voLinkAry.length];
+        System.arraycopy(voLinkAry, 0, links, 0, voLinkAry.length);
+
+        return links;
+    }
+
+    // convert <GROUP>s under <TABLE> to a list of GroupInfo and add it to the associatede table (a DataGroup object)
+    private static List<GroupInfo> makeGroupInfosFromTable(TableElement tableEl, DataGroup dg) {
+        VOElement[] groupAry = getGroupsFromTable(tableEl);
+        List<GroupInfo> groupObjAry = new ArrayList<>();
+
+        for (VOElement group : groupAry) {
+            String name = group.getName();
+            String desc = group.getDescription();
+            VOElement[] fieldRef = group.getChildrenByName("FIELDref");
+
+            GroupInfo gObj = new GroupInfo(name, desc);
+            gObj.setID(getElementAttribute(group, ID));
+
+            for (VOElement fRef : fieldRef) {
+                String refStr = getElementAttribute(fRef, REF);
+                String ucdStr = getElementAttribute(fRef, UCD);
+                String utypeStr = getElementAttribute(fRef, UTYPE);
+                gObj.addFieldRef(refStr, ucdStr, utypeStr);
+            }
+
+
+            if (dg != null) {
+                dg.addGroup(gObj);
+            }
+            groupObjAry.add(gObj);
+
+        }
+        return groupObjAry;
+    }
+
+    // convert LinkElement to LinkInfo
+    private static LinkInfo linkElementToLinkInfo(VOElement voEl) {
+        LinkElement lnkEl = (LinkElement) voEl;
+        String ContentRole = "content-role";
+        String ContentType = "content-type";
+
+        try {
+            String title = lnkEl.getHandle();
+            URL href = lnkEl.getHref();
+            String linkRef = (href != null) ? href.toString() : null;
+            LinkInfo linkObj = new LinkInfo(linkRef, title);
+
+            linkObj.setRole(getElementAttribute(voEl, ContentRole));
+            linkObj.setType(getElementAttribute(voEl, ContentType));
+            linkObj.setID(getElementAttribute(voEl, ID));
+            return linkObj;
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+    }
+
+    // convert <LINK>s under <TABLE> to a list of LinkInfo and add it to the associated table (a DataGroup object)
+    private static List<LinkInfo> makeLinkInfosFromTable(TableElement tableEl, DataGroup dg) {
+        VOElement[] linkAry = getLinksFromTable(tableEl);
+        List<LinkInfo> linkObjAry = new ArrayList<>();
+
+        for (VOElement link : linkAry) {
+            LinkInfo linkObj = linkElementToLinkInfo(link);
+
+            if (linkObj != null) {
+                if (dg != null) {
+                    dg.addLink(linkObj);
+                }
+                linkObjAry.add(linkObj);
+            }
+        }
+
+        return linkObjAry;
+    }
+
+
+    // precision: "2" => width+"F2", "F2"=> width+"F2", "E3" => width+"E3"
+    private static String makePrecisionStr(String precisionStr, String width) {
+        return (precisionStr.matches("^[1-9][0-9]*$")) ? (width+"F"+precisionStr) : (width+precisionStr);
+    }
+
+    // convert <PARAM>s under <TABLE> to a list of <DataType> and add it to the associated table (a DataGroup object)
+    private static List<DataType> makeParamsFromTable(TableElement tableEl, StarTable table, DataGroup dg) {
+        VOElement[] paramsEl = getParamsFromTable(tableEl);
+        List<DataType> allParams = new ArrayList<>();
+
+        for (VOElement param : paramsEl) {
+            String name = getElementAttribute(param, "name");
+            DescribedValue dv = table.getParameterByName(name);
+            if (dv == null) continue;
+
+            ValueInfo vInfo = dv.getInfo();
+            Class clz = vInfo.isArray() ? String.class : vInfo.getContentClass();
+
+            // create Datatype
+            DataType dt = new DataType(name, clz, null, vInfo.getUnitString(), null, null);
+
+            // set precision
+            String precisionStr = getElementAttribute(param, "precision");
+            String widthStr = getElementAttribute(param, "width");
+
+            if (precisionStr != null) {
+                if (widthStr == null) widthStr = "";
+                precisionStr = makePrecisionStr(precisionStr, widthStr);
+            } else {
+                precisionStr = "";
+            }
+            dt.setPrecision(precisionStr);
+
+            // set ucd, utype and value to DataType
+            dt.setUCD(getElementAttribute(param, "ucd"));
+            dt.setUType(getElementAttribute(param, "utype"));
+            dt.setID(getElementAttribute(param, "ID"));
+            dt.setValue(getElementAttribute(param, "value"));
+            allParams.add(dt);
+
+            if (dg != null) {
+                dg.addParam(dt);
+            }
+        }
+        return allParams;
+    }
+
+    // get <INFO>s under <TABLE> as a list of DescribeValue
+    private static List<DescribedValue> getInfosFromTable(TableElement tableEl, StarTable table) {
+
+        VOElement[] infoEl = getInfosFromTable(tableEl);
+        List<DescribedValue> infosAry = new ArrayList<>();
+
+        for (VOElement param : infoEl) {
+            String name = getElementAttribute(param, "name");
+            if (name != null) {
+                infosAry.add(table.getParameterByName(name));
+            }
+        }
+        return infosAry;
+    }
+
+    // get the FieldElement from a TableElement per field name
+    private static FieldElement getFieldElementByName(TableElement tableEl, String name) {
+        FieldElement[] fields = getFieldsFromTable(tableEl);
+
+        for (FieldElement f : fields) {
+            if (f.getName().equals(name)) {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    // convert <LINK>s under <FIELD> to a list of LinkInfo and add it to the associated column (a DataType Object)
+    private static List<LinkInfo> makeLinkInfosFromField(TableElement tableEl, DataType dt) {
+        List<LinkInfo> linkObjs = new ArrayList<>();
+        FieldElement fieldEle = getFieldElementByName(tableEl, dt.getKeyName());
+
+        VOElement[] links = (fieldEle != null) ? getLinksFromField(fieldEle) : null;
+        if (links != null) {
+            for (VOElement link : links) {
+                LinkInfo linkObj = linkElementToLinkInfo(link);
+
+                if (linkObj != null) {
+                    dt.addLink(linkObj);
+                    linkObjs.add(linkObj);
+                }
+            }
+        }
+        return linkObjs;
+    }
+
+    // add info of <VALUES> under a <FIELD> to the associated column (a DataType object)
+    // the added info includes: minimum/maximum values, options, or null string
+    private static void getValuesFromField(TableElement tableEl, DataType dt) {
+        FieldElement fieldEle = getFieldElementByName(tableEl, dt.getKeyName());
+
+        ValuesElement values = fieldEle.getActualValues();
+
+        if (values != null) {
+            dt.setNullString(values.getNull());
+            dt.setMaxValue(values.getMaximum());
+            dt.setMinValue(values.getMinimum());
+            dt.setOptions(values.getOptions());
+        }
+    }
+
+    // recursively collect all table element
+    private static void getTableElements(VOElement root, List<TableElement>tblAry) {
+        VOElement[] resources = getResourceChildren(root);
+
+        for (VOElement resource : resources) {
+            VOElement[] tables = getTableChildren(resource);
+
+            for (VOElement tbl : tables) {
+                TableElement tableEl = (TableElement) tbl;
+                tblAry.add(tableEl);
+            }
+
+            VOElement[] subResources = getResourceChildren(resource);
+            for (VOElement res : subResources) {
+                getTableElements(res, tblAry);
+            }
+        }
+    }
+
+    // get all <TABLE> from one votable file
+    private static List<TableElement> getTableElementsFromFile(String location, StoragePolicy policy) {
+        VOElement top = getVOElementFromVOTable(location, policy);
+        List<TableElement> tableAry = new ArrayList<>();
+
+        if (top != null) {
+            getTableElements(top, tableAry);
+        }
+
+        return tableAry;
     }
 
     private enum MetaInfo {
@@ -110,8 +403,21 @@ public class VoTableReader {
         }
     }
 
+    /**
+     *
+     * Compose a summary table containing analysis result of the VOTable file
+     * the summary table includes:
+     *  columns: defined in FitsHDUUtil.java
+     *  rows:    contain info for each TABLE in the votable file.
+     *  metadata: contain the header info for each TABLE in the votable file, the header info includes key/value from
+     *            name attribute of the TABLE element and children elements DESCRIPTION, INFO, PARAM, LINK and GROUP
+     *            of the TABLE element
+     *
+     * @param voTableFile path of votable file
+     * @return summary table of votable file
+     */
     public static DataGroup voHeaderToDataGroup(String voTableFile) {
-        List<DataType> cols = new ArrayList<DataType>();
+        List<DataType> cols = new ArrayList<>();
 
         for ( MetaInfo meta : MetaInfo.values()) {    // index, name, row, column
             DataType dt = new DataType(meta.getKey(), meta.getTitle(), meta.getMetaClass());
@@ -122,44 +428,101 @@ public class VoTableReader {
         String invalidMsg = "invalid votable file";
 
         try {
+            /*
             StarTableFactory stFactory = new StarTableFactory();
             TableSequence tseq = stFactory.makeStarTables(voTableFile, null);
+            */
 
+            // parse the votable file using Starlink VOTable aware DOM parser
+            // by setting StoragePolicy.DISCARD as the storage policy (throw away the rows), note: # of rows is lost
+            //List<TableElement> tableAry = getTableElementsFromFile( voTableFile, StoragePolicy.DISCARD);
+
+            List<TableElement> tableAry = getTableElementsFromFile( voTableFile, null);
             int index = 0;
             List<JSONObject> headerColumns = FitsHDUUtil.createHeaderTableColumns(true);
 
-            for ( StarTable table; ( table = tseq.nextTable() ) != null; ) {
+            for (TableElement tableEl : tableAry) {
+                StarTable table = new VOStarTable(tableEl);
                 String title = table.getName();
-                Long rowNo = new Long(table.getRowCount());
-                Integer columnNo = new Integer(table.getColumnCount());
-
+                Long rowNo = table.getRowCount();
+                Integer columnNo = table.getColumnCount();
                 String tableName = String.format("%d cols x %d rows", columnNo, rowNo) ;
-                List<List<String>> headerRows = new ArrayList<>();
 
-                List<DescribedValue> tblParams = table.getParameters();
+                List<List<String>> headerRows = new ArrayList<>();
+                //List<DescribedValue> tblParams = table.getParameters();
                 int rowIdx = 0;
 
-                List<String> rowStats = new ArrayList<>();
+                List<String> rowStats = new ArrayList<>();     // first key/value/comment for header
                 rowStats.add(Integer.toString(rowIdx++));
                 rowStats.add("Name");
                 rowStats.add(title);
                 rowStats.add("Table name");
                 headerRows.add(rowStats);
 
-                for (DescribedValue dv : tblParams) {
+                String desc = tableEl.getDescription();
+
+                // DESCRIPTION element under TABLE if there is
+                if (desc != null) {
+                    rowStats = new ArrayList<>();     // first key/value/comment for header
+                    rowStats.add(Integer.toString(rowIdx++));
+                    rowStats.add("Description");
+                    rowStats.add(desc);
+                    rowStats.add("Table description");
+                    headerRows.add(rowStats);
+                }
+
+                // add INFO name/value/comment to the header
+                List<DescribedValue> tblInfos = getInfosFromTable(tableEl, table);
+                for (DescribedValue dv : tblInfos) {
                     ValueInfo vInfo = dv.getInfo();
 
                     rowStats = new ArrayList<>();
                     rowStats.add(Integer.toString(rowIdx++));
                     rowStats.add(vInfo.getName());
-                    rowStats.add(dv.getValueAsString(200));
+                    rowStats.add(dv.getValueAsString(Integer.MAX_VALUE));
 
-                    String desc = vInfo.getDescription();
+                    desc = vInfo.getDescription();
                     if (desc == null) {
                         desc = "";
                     }
                     rowStats.add(desc);
 
+                    headerRows.add(rowStats);
+                }
+
+                // add PARAM name/value/comment to the header
+                List<DataType> tblParams = makeParamsFromTable(tableEl, table, null);
+                for (DataType param : tblParams) {
+                    rowStats = new ArrayList<>();
+
+                    rowStats.add(Integer.toString(rowIdx++));
+                    rowStats.add(param.getKeyName());
+                    rowStats.add(param.getValue());
+                    rowStats.add("PARAM in TABLE");
+                    headerRows.add(rowStats);
+                }
+
+                // add LINK link/href/comment to the header
+                List<LinkInfo> links = makeLinkInfosFromTable(tableEl, null);
+                for (LinkInfo link : links) {
+                    rowStats = new ArrayList<>();
+
+                    rowStats.add(Integer.toString(rowIdx++));
+                    rowStats.add(link.getTitle());
+                    rowStats.add(link.toString());
+                    rowStats.add("LINK in TABLE");
+                    headerRows.add(rowStats);
+                }
+
+                // get Group Group/refs/comment to the header
+                List<GroupInfo> groups = makeGroupInfosFromTable(tableEl, null);
+                for (GroupInfo group : groups) {
+                    rowStats = new ArrayList<>();
+
+                    rowStats.add(Integer.toString(rowIdx++));
+                    rowStats.add("GROUP");
+                    rowStats.add(group.toString());
+                    rowStats.add("GROUP in TABLE");
                     headerRows.add(rowStats);
                 }
 
@@ -179,13 +542,9 @@ public class VoTableReader {
             if (index == 0) {
                 throw new IOException(invalidMsg);
             } else {
-                //File ff = new File(voTableFile);
-
-                //String title = "A VOTable file with " + index + (index > 1 ? " tables" : " table");
-
-                String title = String.format("VOTable" +
+                String title = "VOTable" +
                         "-- The following left table shows the file summary and the right table shows the information of " +
-                        "the table which is highlighted in the file summary.");
+                        "the table which is highlighted in the file summary.";
                 dg.setTitle(title);
             }
         } catch (IOException e) {
@@ -197,26 +556,66 @@ public class VoTableReader {
     }
 
 
-    private static DataGroup convertToDataGroup(StarTable table, boolean headerOnly) {
+    /**
+     * convert votable content into DataGroup mainly by collecting TABLE elements and TABLE included metadata and data
+     * For TABLE, collect attributes including ID, name, ucd, utype, ref, (as ID, title, ucd, utype, ref in DataGroup),
+     *            and child elements including DESCRIPTION, FIELD, GROUP, LINK, (as desc, columns, groups, links in DataGroup),
+     *                                         PARAM (as staticColumns in DataGroup and staticValue in DataType),
+     *                                         INFO (as meta in DataGroup)
+     *            and table data in DATA element if not headerOnly (data in DataGroup)
+     * For FIELD, collect attributes including ID, name, datatype, unit, precision, width, ref, ucd, utype
+     *                                         (as ID, keyName, type, units, precision, ref, ucd, utype in DataType)
+     *            and child elements including DESCRIPTION, LINK and VALUES
+     *                                         (as desc, links, minValue, maxValue, options, nullstring in DataType)
+     *
+     * @param tableEl    TableElement object
+     * @param table      StarTable object
+     * @param headerOnly get column and metadata only (no table data)
+     * @return a DataGroup object representing a TABLE in votable file
+     */
+    private static DataGroup convertToDataGroup(TableElement tableEl, StarTable table,  boolean headerOnly) {
         String title = table.getName();
-        List<DataType> cols = new ArrayList<DataType>();
+        List<DataType> cols = new ArrayList<>();
         String raCol=null, decCol=null;
         int precision = 8;
+        String precisionStr = "";
+
+        // collect FIELD from TABLE
+        // collect attributes of <FIELD> including name, datatype, unit, precision, width, ref, ID, ucd, utype
+        // collect children elements including <DESCRIPTION>, <LINK>, <VALUES>
         for (int i = 0; i < table.getColumnCount(); i++) {
             ColumnInfo cinfo = table.getColumnInfo(i);
+
+            // attribute datatype, if the column is with data in array style, set the datatype to be "string" type
+            Class clz = cinfo.isArray() ? String.class : cinfo.getContentClass();
+
+            // attribute name & unit
+            DataType dt = new DataType(cinfo.getName(), clz, null, cinfo.getUnitString(), null, null);
+
+            // attribute precision & width
             if(cinfo.getAuxDatum(VOStarTable.PRECISION_INFO)!=null){
                 try{
-                    precision = Integer.parseInt(cinfo.getAuxDatum(VOStarTable.PRECISION_INFO).toString());
+                    DescribedValue pDV  = cinfo.getAuxDatum(VOStarTable.PRECISION_INFO);
+
+                    if (pDV != null) {
+                        precisionStr = pDV.toString();
+                        precision = Integer.parseInt(precisionStr);
+
+                        DescribedValue wDV = cinfo.getAuxDatum(VOStarTable.WIDTH_INFO);
+                        precisionStr = makePrecisionStr(precisionStr, (wDV != null) ? wDV.toString() : "");
+                    }
                 }catch (NumberFormatException e){
                     // problem with VOTable vinfo precision: should be numeric - keep default min precision
                 }
             }
-            Class clz = cinfo.isArray() ? String.class : cinfo.getContentClass();
-            DataType dt = new DataType(cinfo.getName(), clz, null, cinfo.getUnitString(), null, null);
-            String desc = cinfo.getDescription();
-            if (desc != null) {
-                dt.setDesc(desc.replace("\n", " "));
+            dt.setPrecision(precisionStr);
+
+            // attribute ref
+            if (cinfo.getAuxDatum(VOStarTable.REF_INFO) != null) {
+                dt.setRef(cinfo.getAuxDatum(VOStarTable.REF_INFO).toString());
             }
+
+            // attribute ucd
             String ucd = cinfo.getUCD();
             if ( ucd != null) { // should we save all UCDs?
                 if (HMS_UCD_PATTERN.matcher( ucd ).matches()) {
@@ -225,20 +624,72 @@ public class VoTableReader {
                 if (DMS_UCD_PATTERN.matcher( ucd ).matches()) {
                     decCol = cinfo.getName();
                 }
+                dt.setUCD(ucd);
             }
+
+            // attribute utype
+            if (cinfo.getAuxDatum(VOStarTable.UTYPE_INFO) != null) {
+                dt.setRef(cinfo.getAuxDatum(VOStarTable.UTYPE_INFO).toString());
+            }
+
+            // attribute ID
+            if (cinfo.getAuxDatum(VOStarTable.ID_INFO) != null) {
+                dt.setID(cinfo.getAuxDatum(VOStarTable.ID_INFO).toString());
+            }
+
+            // child element DESCRIPTION
+            String desc = cinfo.getDescription();
+            if (desc != null) {
+                dt.setDesc(desc.replace("\n", " "));
+            }
+
+            // child elements <LINK> and <VALUES>
+            if (tableEl != null) {
+                makeLinkInfosFromField(tableEl, dt);
+                getValuesFromField(tableEl, dt);
+            }
+
             cols.add(dt);
         }
+
+        // attribute name from TABLE
         DataGroup dg = new DataGroup(title, cols);
 
-        for (Object p : table.getParameters()) {
+        // metadata for TABLE
+        List<DescribedValue> dvAry = (tableEl == null) ? table.getParameters()
+                                                       : getInfosFromTable(tableEl, table);
+        for (Object p : dvAry) {
             DescribedValue dv = (DescribedValue)p;
-            dg.addAttribute(dv.getInfo().getName(), dv.getValueAsString(50).replace("\n", " "));
+            //dg.addAttribute(dv.getInfo().getName(), dv.getValueAsString(50).replace("\n", " "));  // take the original string?
+            dg.addAttribute(dv.getInfo().getName(), dv.getValueAsString(Integer.MAX_VALUE).replace("\n", " "));
         }
+
+
         if (raCol != null && decCol != null) {
             dg.addAttribute("POS_EQ_RA_MAIN", raCol);
             dg.addAttribute("POS_EQ_DEC_MAIN", decCol);
         }
 
+        if (tableEl != null) {
+            // attribute ID, ref, ucd, utype from TABLE
+            dg.setID((tableEl != null) ? getElementAttribute(tableEl, ID) : null);
+            dg.setRef((tableEl != null) ? getElementAttribute(tableEl, REF) : null);
+            dg.setUCD((tableEl != null) ? getElementAttribute(tableEl, UCD) : null);
+            dg.setUType((tableEl != null) ? getElementAttribute(tableEl, UTYPE) : null);
+
+            // child element PARAM, GROUP, LINK for TABLE
+            makeParamsFromTable(tableEl, table, dg);
+            makeGroupInfosFromTable(tableEl, dg);
+            makeLinkInfosFromTable(tableEl, dg);
+
+            // child element DESCRIPTION
+            String tDesc = tableEl.getDescription();
+            if (tDesc != null) {
+                dg.setDesc(tDesc.replace("\n", " "));
+            }
+        }
+
+        // table data
         try {
             if (!headerOnly) {
                 RowSequence rs = table.getRowSequence();
@@ -247,7 +698,7 @@ public class VoTableReader {
                     for(int i = 0; i < cols.size(); i++) {
                         DataType dtype = cols.get(i);
                         Object val = rs.getCell(i);
-                        String sval = table.getColumnInfo(i).formatValue(val, 1000);
+                        String sval = table.getColumnInfo(i).formatValue(val, Integer.MAX_VALUE);
                         if (dtype.getDataType().isAssignableFrom(String.class) && !(val instanceof String)) {
                             row.setDataElement(dtype, sval);   // array value
                         } else {


### PR DESCRIPTION
This PR includes Improvement on reading VOTable by processing more elements and the attributes from TABLE and FIELD elements  in votable file, 

- Using Starlink votable-aware DOM parser to traverse the xml elements in the votable file and collect more details from TABLE element including info. from TABLE's attributes (ID, name, ucd, utype, ref) and from TABLE's children elements (DESCRIPTION, LINK, GROUP, PARAM, INFO, LINK, FIELD). 
- collect more details from FIELD element including info. from FIELD's attributes such as  ID, name, datatype, unit, precision, width, ref, ucd, utype  and from FIELD's children elements including DESCRIPTION, LINK, and VALUES. 
- The JAVA class implementation regarding the table (DataGroup) and table column (DatType)  are updated accordingly. 

Test:
Run firefly and upload votable example (ex. firefly_test_data/FileUpload-samples/VOTable/tabledata/multiTables_Ned_test.xml)  from upload dialog.

Result of  example '/multiTables_Ned_test.xml': 
- 826 tables are shown in the summary table
- Highlight the first table with index 0, then table name from attribute ‘name’,  table description from child element DESCRIPTION, and table info from child element INFO, PARAM, LINK, GROUP  of that TABLE are shown at the right side of the summary table. 




