### PR TITLE
DM-16034: TabPanel's state may get out-of-sync when tabs are removed

### DIFF
--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -14,17 +14,22 @@ import {dispatchComponentStateChange, getComponentState} from '../../core/Compon
 function tabsStateFromProps(props) {
     const {defaultSelected, componentKey} = props;
     let selectedIdx;
-    // component key should be defined if the state needs to be saved though unmount/mount
-    const savedIdx = componentKey && getComponentState(componentKey).selectedIdx;
-    if (!isNaN(savedIdx)) {
-        selectedIdx = savedIdx;
-    } else if (!isNaN(defaultSelected)) {
-        selectedIdx = defaultSelected;
+    const childrenAry = React.Children.toArray(props.children);         // this returns only valid children excluding undefined and false values.
+
+    if (componentKey) {
+        // component key should be defined if the state needs to be saved though unmount/mount
+        selectedIdx = getComponentState(componentKey).selectedIdx;
+
+        if (selectedIdx >= childrenAry.length) {
+            // selectedIdx is greater than the number of tabs.. update store's state
+            selectedIdx = childrenAry.length-1;
+            dispatchComponentStateChange(componentKey, {selectedIdx});
+        }
+    } else {
+        selectedIdx = childrenAry.findIndex( (c) => c.props.id===defaultSelected );
     }
-    else {
-        const idx= React.Children.toArray(props.children).findIndex( (c) => c.props.id===defaultSelected );
-        selectedIdx= idx>-1 ? idx : 0;
-    }
+
+    selectedIdx = selectedIdx >= 0 ? selectedIdx : defaultSelected;
     return {selectedIdx};
 }
 
@@ -103,12 +108,10 @@ export class Tabs extends PureComponent {
     }
 
     render () {
-        let { selectedIdx}= this.state;
+        const { selectedIdx}= this.state;
         const {children, useFlex, resizable, borderless, headerStyle, contentStyle={}} = this.props;
-        const numTabs = React.Children.count(children);
 
         let  content;
-        selectedIdx = Math.min(selectedIdx, numTabs-1);
         const newChildren = React.Children.toArray(children).filter((el) => !!el).map((child, index) => {
             if (index === selectedIdx) {
                 content = React.Children.only(child.props.children);


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-16034
test deployment: https://irsawebdev9.ipac.caltech.edu/dm-16034/applications/sofia/

`selectedIdx` is a state kept by TabPanel.  It's possible that `selectedIdx` is greater than the number of tabs due to adding and removing tab dynamically.

Currently, this condition is handled in the render function of the component.  This visually appears correct, but the state is out of sync.

This bug is found in the Sofia app.  You can use Sofia to test.

https://irsawebdev9.ipac.caltech.edu/dm-16034/applications/sofia/
- search all-sky 
- select FIFI-LS
- select coverage
- select AOR..
Should see `Details` selected with rendered info.