### PR TITLE
IRSA-2152: Firelfy table filter fails when underscore '_' is in filter

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -111,6 +111,10 @@ abstract public class BaseDbAdapter implements DbAdapter {
         if (treq.getFilters() != null && treq.getFilters().size() > 0) {
             where = "";
             for (String cond :treq.getFilters()) {
+                if (cond.matches("(?i).* LIKE .*(\\\\_|\\\\%|\\\\\\\\).*")) {       // search for LIKE w/  \_, \%, or \\ in the condition.
+                    // for LIKE, to search for '%', '\' or '_' itself, an escape character must also be specified using the ESCAPE clause
+                    cond += " ESCAPE '\\'";
+                }
                 if (where.length() > 0) {
                     where += " and ";
                 }


### PR DESCRIPTION
ticket: https://jira.ipac.caltech.edu/browse/IRSA-2152
test deployment: https://irsawebdev9.ipac.caltech.edu/irsa-2152/applications/sofia/

Ticket provide steps to reproduce bug.  Please use that to confirm that bug is fixed.