### PR TITLE
DM-16035 link LSST source and footprint overlay.

### DIFF
--- a/src/firefly/html/demo/ffapi-LSSTfootprint-test.html
+++ b/src/firefly/html/demo/ffapi-LSSTfootprint-test.html
@@ -123,7 +123,7 @@
                 updateLSSTFootprintLayerList();
 
                 firefly.action.dispatchCreateImageLineBasedFootprintLayer(layerId, layerId, JSON.parse(layerJson), 'lsstfootprinttest',
-                                                                                   true, dispatcher = window.ffViewer.dispatch);
+                                                                            null, null, null, true, dispatcher = window.ffViewer.dispatch);
             }
         };
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
@@ -49,6 +49,8 @@ public class SearchServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             TableServerRequest treq = (TableServerRequest) params.getTableServerRequest().cloneRequest();
+            treq.setStartIndex(0);
+            treq.setPageSize(Integer.MAX_VALUE);
             treq.setParam(TableServerRequest.INCL_COLUMNS, params.getOptional(TableServerRequest.INCL_COLUMNS));
             treq.setFilters(StringUtils.asList(params.getOptional(TableServerRequest.FILTERS), ","));
             String sortInfo = params.getOptional(TableServerRequest.SORT_INFO);

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -738,12 +738,25 @@ public class VoTableReader {
         try {
             if (!headerOnly) {
                 RowSequence rs = table.getRowSequence();
+                int len;
+                int find = 0;
+                String findStr;
+
                 while (rs.next()) {
                     DataObject row = new DataObject(dg);
                     for(int i = 0; i < cols.size(); i++) {
                         DataType dtype = cols.get(i);
                         Object val = rs.getCell(i);
                         String sval = table.getColumnInfo(i).formatValue(val, Integer.MAX_VALUE);
+
+                        if (dtype.getKeyName().equals("spans")) {
+                            len = sval.length();
+
+                            if (len > 65536) {
+                                find = 1;
+                                findStr = val.toString();
+                            }
+                        }
                         if (dtype.getDataType().isAssignableFrom(String.class) && !(val instanceof String)) {
                             row.setDataElement(dtype, sval);   // array value
                         } else {

--- a/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
+++ b/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
@@ -1,22 +1,30 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {get, set, has, isEmpty, isString} from 'lodash';
+import {get, set, has, isEmpty, isString,  isUndefined} from 'lodash';
 import {makeDrawingDef, TextLocation, Style} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {DataTypes, ColorChangeType}  from '../visualize/draw/DrawLayer.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
-import {primePlot, getDrawLayerById} from '../visualize/PlotViewUtil.js';
-import DrawLayerCntlr, {dispatchCreateDrawLayer, getDlAry, dlRoot, dispatchAttachLayerToPlot, RegionSelStyle,
-                        RegionSelColor, dispatchSelectRegion} from '../visualize/DrawLayerCntlr.js';
+import {primePlot, getAllDrawLayersForPlot} from '../visualize/PlotViewUtil.js';
+import DrawLayerCntlr, {RegionSelStyle, RegionSelColor, dlRoot, dispatchSelectRegion, dispatchModifyCustomField}
+                                                                     from '../visualize/DrawLayerCntlr.js';
 import {clone} from '../util/WebUtil.js';
 import {MouseState} from '../visualize/VisMouseSync.js';
-import {ImageLineBasedObj, convertConnectedObjsToDrawObjs, getImageCoordsOnFootprint, POLYOBJS, POINTOBJS} from '../visualize/draw/ImageLineBasedObj.js';
+import {convertConnectedObjsToDrawObjs, getImageCoordsOnFootprint, drawHighlightFootprintObj,
+        drawSelectFootprintObj} from '../visualize/draw/ImageLineBasedObj.js';
 import {getUIComponent} from './ImageLineFootPrintUI.jsx';
 import {rateOpacity} from '../util/Color.js';
 import {visRoot} from '../visualize/ImagePlotCntlr.js';
-import DrawOp from '../visualize/draw/DrawOp.js';
 import CsysConverter from '../visualize/CsysConverter.js';
 import {DrawSymbol} from '../visualize/draw/PointDataObj.js';
+import {dispatchTableHighlight,  dispatchTableSelect, dispatchTableFilter} from '../tables/TablesCntlr.js';
+import {findIndex, getTblById, getCellValue} from '../tables/TableUtil.js';
+import {PlotAttribute} from '../visualize/WebPlot.js';
+import {getSelectedShape} from './Catalog.js';
+import {getSelectedPts} from '../visualize/VisUtil.js';
+import {SelectInfo} from '../tables/SelectInfo.js';
+import {detachSelectArea} from '../visualize/ui/SelectAreaDropDownView.jsx';
+import {FilterInfo} from '../tables/FilterInfo.js';
 
 const ID= 'ImageLineBasedFP_PLOT';
 const TYPE_ID= 'ImageLineBasedFP_PLOT_TYPE';
@@ -27,33 +35,7 @@ let idCnt=0;
 const colorList = ['rgba(74, 144, 226, 1.0)', 'blue', 'cyan', 'green', 'magenta', 'orange', 'lime', 'red',  'yellow'];
 const colorN = colorList.length;
 
-function logError(message) {
-    console.log(message);
-}
 
-export function imageLineBasedfootprintActionCreator(action) {
-    return (dispatcher) => {
-        const {footprintData, plotId, drawLayerId, title, style='fill', color, showText} = action.payload;
-
-        if (!drawLayerId) {
-            logError('no lsst drawlayer id specified');
-        } else {
-            const imageLineBasedFP = ImageLineBasedObj(footprintData);
-            if (!isEmpty(imageLineBasedFP)) {
-                const dl = getDrawLayerById(getDlAry(), drawLayerId);
-                if (!dl) {
-                    dispatchCreateDrawLayer(TYPE_ID, {
-                        drawLayerId, title, imageLineBasedFP, color, showText,
-                        style: (style&&(style.toLowerCase() === 'fill')) ? Style.FILL : Style.STANDARD
-                    });
-                }
-                if (plotId) {
-                    dispatchAttachLayerToPlot(drawLayerId, plotId, true);
-                }
-            }
-        }
-    };
-}
 /**
  * create region plot layer
  * @param initPayload moc_nuniq_nums, highlightedCell, selectMode
@@ -61,11 +43,13 @@ export function imageLineBasedfootprintActionCreator(action) {
  */
 function creator(initPayload) {
 
+    const {selectInfo, highlightedRow, tbl_id, tableRequest} = initPayload;
     const drawingDef= makeDrawingDef(get(initPayload, 'color', colorList[idCnt%colorN]),
                                      {style: get(initPayload, 'style', Style.FILL),
                                       showText: get(initPayload, 'showText', false),
                                       canUseOptimization: true,
                                       textLoc: TextLocation.CENTER,
+                                      selectedColor: 'yellow',
                                       size: 3,
                                       symbol: DrawSymbol.X});
 
@@ -79,6 +63,8 @@ function creator(initPayload) {
     const options= {
         canUseMouse:true,
         canHighlight:true,
+        canFilter: true,
+        canSelect: true,
         canUserChangeColor: ColorChangeType.DYNAMIC,
         hasPerPlotData: true,
         destroyWhenAllDetached: true,
@@ -92,6 +78,8 @@ function creator(initPayload) {
                                         options, drawingDef, actionTypes, pairs);
 
     dl.imageLineBasedFP = get(initPayload, 'imageLineBasedFP') || {};
+    Object.assign(dl, {selectInfo, highlightedRow, tbl_id, tableRequest});
+    dl.selectRowIdxs = {};   // map: row_idx / row_num
     return dl;
 }
 
@@ -111,7 +99,7 @@ function highlightChange(mouseStatePayload) {
     const plot = primePlot(visRoot(), plotId);
     const cc = CsysConverter.make(plot);
     const tPt = getImageCoordsOnFootprint(screenPt, cc, pixelSys);
-
+    const {tableRequest} = drawLayer;
 
     function* getDrawObj() {
         let index = 0;
@@ -131,9 +119,21 @@ function highlightChange(mouseStatePayload) {
 
             dlRoot().drawLayerAry.forEach( (dl) => {
                 if (dl.drawLayerId === drawLayer.drawLayerId) {
-                    dispatchSelectRegion(dl.drawLayerId, closestObj);
+                    if (drawLayer.tbl_id) {
+                        if (closestObj) {
+                            findIndex(drawLayer.tbl_id, `ROW_IDX = ${closestObj.tableRowIdx}`).then((highlightedRow) => {
+                                    if (highlightedRow >= 0) {
+                                        dispatchTableHighlight(drawLayer.tbl_id, highlightedRow, tableRequest);
+                                    }
+                                });
+                        }
+                    } else {
+                        dispatchSelectRegion(dl.drawLayerId, closestObj);
+                    }
                 } else if (closestObj) {
-                    dispatchSelectRegion(dl.drawLayerId, null);
+                    if (!drawLayer.tbl_id) {
+                        dispatchSelectRegion(dl.drawLayerId, null);
+                    }
                 }
             });
         }
@@ -193,17 +193,57 @@ function getLayerChanges(drawLayer, action) {
             return {title: tObj};
 
         case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
-            const {fillStyle, targetPlotId} = action.payload.changes;
+            const {changes} = action.payload;
+            const {fillStyle, selectInfo, highlightedRow, selectRowIdxs,
+                   tableRequest, tableData, imageLineBasedFP} = changes;
+            const pId = plotId ? plotId : (plotIdAry ? plotIdAry[0]: null);
 
-            if (fillStyle && targetPlotId) {
+            if (!pId) return null;
+
+            if (fillStyle) {
                 const style = fillStyle.includes('outline') ? Style.STANDARD : Style.FILL;
                 const showText = fillStyle.includes('text');
                 const drawingDef = clone(drawLayer.drawingDef, {style, showText});
 
-                set(dd, [DataTypes.DATA, targetPlotId], null);
+                set(dd, [DataTypes.DATA, pId], null);
                 return Object.assign({}, {drawingDef, drawData: dd});
             }
-            break;
+
+            const changesUpdate = {};
+
+            if (tableData) {    // from watcher on TABLE_LOADED
+                set(dd, [DataTypes.DATA, pId], null);
+            }
+
+            set(dd, [DataTypes.HIGHLIGHT_DATA, pId], null);
+
+            if (imageLineBasedFP) {
+                Object.assign(changesUpdate, {imageLineBasedFP});
+            }
+
+            if (selectInfo && !tableData) {   // from dispatch TableSelect, watcher on TABLE_SELECT or TABLE_LOADED
+                if (tableData) {
+                    Object.assign(changesUpdate, {selectRowIdxs: {}});
+                } else {
+                    const crtRowIdxs = updateSelectRowIdx(drawLayer, selectInfo);
+                    Object.assign(changesUpdate, {selectRowIdxs: crtRowIdxs});
+                }
+                Object.assign(changesUpdate, {selectInfo});
+            }
+
+            if (tableRequest) {  // from watcher TABLE_LOADED
+                Object.assign(changesUpdate, {tableRequest});
+            }
+
+            if (!isUndefined(highlightedRow)) {  // from watcher TABLE_UPDATE, TABLE_HIGHLIGHT, TABLE_LOADED
+                Object.assign(changesUpdate, {highlightedRow});
+            }
+
+            if (!isUndefined(selectRowIdxs)) {   // from selectFootprint
+                Object.assign(changesUpdate, {selectRowIdxs});
+            }
+
+            return Object.assign({}, changesUpdate, {drawData: dd});
 
         case DrawLayerCntlr.REGION_SELECT:
             const {selectedRegion} = action.payload;
@@ -228,22 +268,165 @@ function getLayerChanges(drawLayer, action) {
         default:
             return null;
     }
-    return null;
 }
 
+function updateSelectRowIdx(drawLayer, selectInfo) {
+    const {tbl_id, selectRowIdxs} = drawLayer;
+    const selectInfoCls = SelectInfo.newInstance(selectInfo);
+    const selected = selectInfoCls.getSelected();
+    const tbl = getTblById(tbl_id);
+    const dataRows = get(tbl, ['tableData', 'data', 'length'], 0);
+
+    // remove de-select row
+    const newRowIdxs = Object.keys(selectRowIdxs).reduce((prev, rowIdx) => {
+          const row_num = selectRowIdxs[rowIdx];
+          if (Number(row_num) >= dataRows || Number(row_num) < 0 || selected.has(Number(row_num))) {
+              prev[rowIdx] = row_num;
+          }
+          return prev;
+    }, {});
+
+    // add select row
+    selected.forEach((rownum) => {
+        const row_idx = getCellValue(tbl, rownum, 'ROW_IDX');
+        if (!has(newRowIdxs, row_idx)) {
+            newRowIdxs[row_idx] = `${rownum}`;
+        }
+    });
+
+    return newRowIdxs;
+}
 
 function getDrawData(dataType, plotId, drawLayer, action, lastDataRet) {
-    const {highlightedFootprint, drawingDef} = drawLayer;
+    const {highlightedFootprint, drawingDef, tbl_id} = drawLayer;
 
     switch (dataType) {
         case DataTypes.DATA:    // based on the same drawObjAry to draw the region on each plot
             return isEmpty(lastDataRet) ? plotLayer(drawLayer) : lastDataRet;
         case DataTypes.HIGHLIGHT_DATA:      // create the region drawObj based on the original region for upright case.
-            return isEmpty(lastDataRet) ?
-                plotHighlightRegion(drawLayer, highlightedFootprint, plotId, drawingDef) : lastDataRet;
+            if (!tbl_id) {
+                return isEmpty(lastDataRet) ? plotHighlightRegion(drawLayer, highlightedFootprint, plotId, drawingDef) : lastDataRet;
+            } else {
+                return isEmpty(lastDataRet) ? plotSelectFootprint(drawLayer, plotId, drawingDef) : lastDataRet;
+            }
+            break;
+        /*
+        case DataTypes.SELECTED_IDXS:
+            if (!drawLayer.imageLineBasedFP) return null;
+            if (action.type ===  DrawLayerCntlr.MODIFY_CUSTOM_FIELD && changes && changes.selectInfo) {
+                return isEmpty(lastDataRet) ? computeSelectedIdxAry(drawLayer) : lastDataRet;
+            }
+        */
     }
     return null;
 }
+
+/*
+function computeSelectedIdxAry(dl) {
+    const {selectInfo, selectRowIdxs} = dl;
+    if (!selectInfo) return null;
+
+    const si = SelectInfo.newInstance(selectInfo);
+    if (!si.getSelectedCount()) return null;
+
+    const data = get(dl, ['drawData', 'data']);
+    const pId =  data && Object.keys(data).find((pId) => data[pId]);
+    const footprintObjs = pId ? data[pId] : null;
+
+    const isSelected =  (idx) => {
+        return footprintObjs && selectRowIdxs && selectRowIdxs.includes(footprintObjs[idx].tableRowIdx);
+    };
+    return isSelected;
+}
+*/
+
+
+function getTableData(drawLayer) {
+    const {tbl_id} = drawLayer || {};
+    if (!tbl_id) return null;
+
+    const tbl = getTblById(tbl_id);
+    return tbl.tableData;
+}
+/**
+ * create DrawingObj for highlighted row
+ * @param drawLayer
+ * @param highlightedRow
+ * @param plotId
+ * @param drawingDef
+ */
+function plotHighlightedRow(drawLayer, highlightedRow, plotId, drawingDef) {
+    const tableData = getTableData(drawLayer);
+
+    if (!tableData || !tableData.data || !tableData.columns) return null;
+
+    const {columns} = tableData;
+    const d = tableData.data[highlightedRow];
+    if (!d) return null;
+
+
+    const colIdx = columns.findIndex((c) => {
+        return (c.name === 'id');
+    });
+
+    if (colIdx < 0) return null;
+
+    const id = d[colIdx];
+    const {connectedObjs} = get(drawLayer, 'imageLineBasedFP') || {};
+    if (connectedObjs) {
+        const footprintHighlight = connectedObjs.find((oneFootprintObj) => {
+            return oneFootprintObj.id === id;
+        });
+
+        return plotHighlightRegion(drawLayer, footprintHighlight, plotId, drawingDef);
+    } else {
+        return null;
+    }
+}
+
+/**
+ *
+ * @param drawLayer
+ * @param plotId
+ * @param drawingDef
+ * @returns {*}
+ */
+function plotSelectFootprint(drawLayer, plotId, drawingDef) {
+    //const tableData = getTableData(drawLayer);
+
+    const {highlightedRow, selectRowIdxs} = drawLayer;
+
+    const highlightedObjs = isUndefined(highlightedRow) ? null : plotHighlightedRow(drawLayer, highlightedRow, plotId, drawingDef);
+
+    if (isEmpty(selectRowIdxs)) {
+        return highlightedObjs;
+    }
+    const {connectedObjs=[]} = drawLayer.imageLineBasedFP || {};
+    const selRowIdxs = Object.keys(selectRowIdxs);
+    const selectedCObjs = connectedObjs.filter((cobj) => selRowIdxs.includes(cobj.tableRowIdx));
+
+    if (selectedCObjs.length === 0) {
+        return highlightedObjs;
+    }
+
+    //let polySels, pointSels;
+    const plot = primePlot(visRoot(), plotId);
+    const selDrawDef= Object.assign({}, drawingDef, {selectColor:drawingDef.selectedColor});
+
+    const selDrawObjs = selectedCObjs.reduce((prev, cobj) => {
+        const selObjs = drawSelectFootprintObj(cobj, plot, selDrawDef);
+
+        prev.push(...selObjs);
+        return prev;
+    }, []);
+
+    if (highlightedObjs) {
+        selDrawObjs.push(...highlightedObjs);
+    }
+    return selDrawObjs;
+}
+
+
 
 /**
  * @summary create DrawingObj for highlighted region
@@ -258,37 +441,7 @@ function plotHighlightRegion(drawLayer, highlightedFootprint, plotId, drawingDef
         return [];
     }
 
-    const footprintObj = highlightedFootprint.connectObj;
-    const polyAry = get(footprintObj.basicObjs, POLYOBJS);
-    const pointAry = get(footprintObj.basicObjs, POINTOBJS);
-
-    if (!polyAry) return [];
-    const plot = primePlot(visRoot(), plotId);
-    const {lineWidth = 1} = drawingDef;
-    const lw = lineWidth+1;
-
-    const polyHighlight = polyAry.reduce((prev, onePoly, idx) => {
-                             const newhObj = DrawOp.makeHighlight(onePoly, plot, drawingDef);
-                             newhObj.highlight = 1;
-                             newhObj.text = (idx === 0) ? newhObj.id : '';
-                             newhObj.style = Style.STANDARD;
-                             newhObj.lineWidth = lw;
-
-                             prev.push(newhObj);
-                             return prev;
-                        }, []);
-
-    const pointHighlight = pointAry.reduce((prev, onePoint) => {
-                                    const pointObj = clone(onePoint, {symbol: (drawingDef.symbol || DrawSymbol.X)});
-                                    const newhObj = DrawOp.makeHighlight(pointObj, plot, drawingDef);
-                                    newhObj.highlight = 1;
-                                    newhObj.lineWidth = lw;
-
-                                    prev.push(newhObj);
-                                    return prev;
-                            }, []);
-    return [...polyHighlight,...pointHighlight];
-
+    return drawHighlightFootprintObj(highlightedFootprint, primePlot(visRoot(), plotId), drawingDef);
 }
 
 function plotLayer(dl) {
@@ -298,4 +451,110 @@ function plotLayer(dl) {
     if (!imageLineBasedFP || !imageLineBasedFP.connectedObjs) return null;
     return convertConnectedObjsToDrawObjs(imageLineBasedFP, style,
                                           {fill: rateOpacity(color, 0.5), outline: color, hole: rateOpacity('red', 0.5)}, showText, null, hideFPId);
+}
+
+function getLayers(pv,dlAry) {
+    return getAllDrawLayersForPlot(dlAry, pv.plotId,true)
+        .filter( (dl) => dl.drawLayerTypeId===TYPE_ID);
+}
+
+export function selectFootprint(pv, dlAry) {
+    if (dlAry.length === 0) return;
+
+    const footprintAry = getLayers(pv, dlAry);
+    if (footprintAry.length === 0) return;
+
+    const p= primePlot(pv);
+    const sel= p.attributes[PlotAttribute.SELECTION];
+    if (!sel) return;
+
+    const setSelectInfo = (nums, selectInfoCls) => {
+        nums.forEach((idx) => selectInfoCls.setRowSelect(idx, true));
+    };
+
+    const selectedShape = getSelectedShape(pv, dlAry);
+    footprintAry.forEach( (dl, dlIndex) => {
+        const connectObjs = get(dl.drawData.data, [pv.plotId]);
+
+        const tbl = getTblById(dl.tbl_id);
+        const selectInfoCls = SelectInfo.newInstance(tbl.selectInfo);
+        const allCObjsIdxs = getSelectedPts(sel, p, connectObjs, selectedShape);
+        const row_nums = [];
+        const row_idxs = clone(dl.selectRowIdxs);
+        const dataRows = get(tbl, ['tableData', 'data', 'length'], 0);
+
+        allCObjsIdxs.reduce((ps, cObjIdx, n) => {
+            ps = ps.then(() => {
+                    const rowIdx = connectObjs[cObjIdx].tableRowIdx;
+                    findIndex(dl.tbl_id, `ROW_IDX = ${rowIdx}`).then((row_num) => {
+                        if (row_num >= 0) {
+                            if (row_num < dataRows) {
+                                row_nums.push(row_num);
+                            }
+                        }
+                        row_idxs[rowIdx] = row_num;
+
+                        if (n === allCObjsIdxs.length - 1) {
+                            setSelectInfo(row_nums, selectInfoCls);
+                            dispatchModifyCustomField(dl.tbl_id, {selectRowIdxs: row_idxs}, p.plotId);
+                            dispatchTableSelect(dl.drawLayerId, selectInfoCls.data);
+
+                            if (dlIndex === footprintAry.length - 1) {
+                                detachSelectArea(pv);
+                            }
+                        }
+
+                        return row_num;
+                    });
+            });
+            return ps;
+        }, Promise.resolve());
+    });
+}
+
+
+export function unselectFootprint(pv, dlAry) {
+    const p= primePlot(pv);
+    getLayers(pv,dlAry)
+        .forEach( (dl) => {
+            const connectObjs = get(dl.drawData.data, [pv.plotId]);
+            const selectInfoCls = SelectInfo.newInstance({rowCount: connectObjs ? connectObjs.length : 0});
+            dispatchModifyCustomField(dl.tbl_id, {selectRowIdxs: {}}, p.plotId);
+            dispatchTableSelect(dl.drawLayerId, selectInfoCls.data);
+        });
+}
+
+export function  filterFootprint(pv, dlAry) {
+    const p = primePlot(pv);
+    const sel = p.attributes[PlotAttribute.SELECTION];
+    if (!sel) return;
+
+    const footprintAry = getLayers(pv, dlAry);
+    if (footprintAry.length === 0) return;
+
+    const selectedShape =  getSelectedShape(pv, dlAry);
+    footprintAry.forEach((dl) => {
+        const tbl = getTblById(dl.tbl_id);
+        const filterInfo = get(tbl, 'request.filters');
+        const filterInfoCls = FilterInfo.parse(filterInfo);
+
+        const connectObjs = get(dl.drawData.data, [pv.plotId]);
+        const allCObjsIdx = getSelectedPts(sel, p, connectObjs, selectedShape);
+        const idxs = allCObjsIdx.map((idx) => connectObjs[idx].tableRowIdx);
+
+        const filter= `IN (${idxs.length === 0 ? -1 : idxs.toString()})`;     //  ROW_IDX is always positive.. use -1 to force no row selected
+        filterInfoCls.setFilter('ROW_IDX', filter);
+        const newRequest = {tbl_id: tbl.tbl_id, filters: filterInfoCls.serialize()};
+        dispatchTableFilter(newRequest);
+    });
+    detachSelectArea(pv);
+}
+
+
+export function  clearFilterFootprint(pv, dlAry) {
+    getLayers(pv, dlAry).forEach((dl) => {
+        if (dl.tbl_id) {
+            dispatchTableFilter({tbl_id: dl.tbl_id, filters: ''});
+        }
+    });
 }

--- a/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
+++ b/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
@@ -477,20 +477,19 @@ export function selectFootprint(pv, dlAry) {
         const connectObjs = get(dl.drawData.data, [pv.plotId]);
 
         const tbl = getTblById(dl.tbl_id);
-        const selectInfoCls = SelectInfo.newInstance(tbl.selectInfo);
+        //const selectInfoCls = SelectInfo.newInstance(tbl.selectInfo);
+        const dataRows = get(tbl, ['tableData', 'data', 'length'], 0);
+        const selectInfoCls = SelectInfo.newInstance({rowCount: dataRows});
         const allCObjsIdxs = getSelectedPts(sel, p, connectObjs, selectedShape);
         const row_nums = [];
         const row_idxs = clone(dl.selectRowIdxs);
-        const dataRows = get(tbl, ['tableData', 'data', 'length'], 0);
 
         allCObjsIdxs.reduce((ps, cObjIdx, n) => {
             ps = ps.then(() => {
                     const rowIdx = connectObjs[cObjIdx].tableRowIdx;
                     findIndex(dl.tbl_id, `ROW_IDX = ${rowIdx}`).then((row_num) => {
                         if (row_num >= 0) {
-                            if (row_num < dataRows) {
-                                row_nums.push(row_num);
-                            }
+                            row_nums.push(Number(row_num));
                         }
                         row_idxs[rowIdx] = row_num;
 

--- a/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
+++ b/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
@@ -114,7 +114,7 @@ function highlightChange(mouseStatePayload) {
                 if (dl.drawLayerId === drawLayer.drawLayerId) {
                     if (drawLayer.tbl_id) {
                         if (closestObj) {
-                            const highlightedRow = closestObj.tableRowNum;
+                            const highlightedRow = Number(closestObj.tableRowNum);
 
                             if (!isUndefined(highlightedRow) && highlightedRow >= 0) {
                                 dispatchTableHighlight(drawLayer.tbl_id, highlightedRow, tableRequest);
@@ -140,7 +140,6 @@ function highlightChange(mouseStatePayload) {
                         if (!closestInfo || closestInfo.dist > distInfo.dist) {
                             closestInfo = distInfo;
                             closestObj = dObj;
-                            //console.log('one inside = ' + closestObj.id + ' dist: ' + closestInfo.dist);
                         }
                     }
                 }

--- a/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
+++ b/src/firefly/js/drawingLayers/ImageLineBasedFootprint.js
@@ -66,8 +66,8 @@ function creator(initPayload) {
     const options= {
         canUseMouse:true,
         canHighlight:true,
-        canFilter: true,
-        canSelect: true,
+        canFilter: !!tbl_id,
+        canSelect: !!tbl_id,
         canUserChangeColor: ColorChangeType.DYNAMIC,
         hasPerPlotData: true,
         destroyWhenAllDetached: true,

--- a/src/firefly/js/drawingLayers/ImageLineFootPrintUI.jsx
+++ b/src/firefly/js/drawingLayers/ImageLineFootPrintUI.jsx
@@ -6,7 +6,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {RadioGroupInputFieldView} from '../ui/RadioGroupInputFieldView.jsx';
-import {dispatchModifyCustomField} from '../visualize/DrawLayerCntlr.js';
+import {dispatchChangeDrawingDef} from '../visualize/DrawLayerCntlr.js';
+import {clone} from '../util/WebUtil.js';
+import {Style} from '../visualize/draw/DrawingDef.js';
 
 const options= [ {label: 'outline', value: 'outline'},
                  {label: 'outline/text', value: 'outline_text'},
@@ -33,7 +35,11 @@ function ImageLineFootPrintUI({drawLayer,pv}) {
 
 function changeFootprintPref(drawLayer,pv,value, preValue) {
     if (preValue !== value) {
-        dispatchModifyCustomField(drawLayer.drawLayerId, {fillStyle: value}, pv.plotId);
+        const style = value.includes('outline') ? Style.STANDARD : Style.FILL;
+        const showText = value.includes('text');
+
+        const drawingDef = clone(drawLayer.drawingDef, {style, showText});
+        dispatchChangeDrawingDef(drawLayer.drawLayerId, drawingDef, pv.plotId);
     }
 }
 

--- a/src/firefly/js/drawingLayers/ImageLineFootPrintUI.jsx
+++ b/src/firefly/js/drawingLayers/ImageLineFootPrintUI.jsx
@@ -33,7 +33,7 @@ function ImageLineFootPrintUI({drawLayer,pv}) {
 
 function changeFootprintPref(drawLayer,pv,value, preValue) {
     if (preValue !== value) {
-        dispatchModifyCustomField(drawLayer.drawLayerId, {fillStyle: value, targetPlotId: pv.plotId}, pv.plotId);
+        dispatchModifyCustomField(drawLayer.drawLayerId, {fillStyle: value}, pv.plotId);
     }
 }
 

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -6,8 +6,8 @@
  * Date: 3/5/12
  */
 
-import {get, set, pickBy, cloneDeep} from 'lodash';
 
+import {get, set, pickBy, cloneDeep} from 'lodash';
 import {ServerParams} from '../data/ServerParams.js';
 import {doJsonRequest, DEF_BASE_URL} from '../core/JsonUtils.js';
 import {getBgEmail} from '../core/background/BackgroundUtil.js';

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -257,9 +257,9 @@ export function findIndex(tbl_id, filterInfo) {
     if (idx >= 0) {
         return Promise.resolve(idx);
     } else {
-        const inclCols = 'ROW_NUM';
+        const inclCols = 'ROW_NUM as ORG_ROWNUM';
         return queryTable(tableModel.request, {filters: filterInfo, inclCols}).then( (tableModel) => {
-            return get(getColumnValues(tableModel, inclCols), '0', -1);
+            return get(tableModel, ['tableData','data']) ? get(getColumnValues(tableModel, 'ORG_ROWNUM'), '0', -1) : -1;
         });
     }
 }
@@ -371,7 +371,7 @@ export function getCellValue(tableModel, rowIdx, colName) {
  */
 export function getColumnValues(tableModel, colName) {
     const colIdx = getColumnIdx(tableModel, colName);
-    if (colIdx >= 0 && colIdx < get(tableModel, 'tableData.data.length', 0)) {
+    if (colIdx >= 0 && colIdx < get(tableModel, 'tableData.columns.length', 0)) {
         return get(tableModel, 'tableData.data').map( (r) => r[colIdx]);
     } else {
         return [];

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -28,7 +28,7 @@ import {footprintCreateLayerActionCreator,
         footprintEndActionCreator
 } from '../drawingLayers/FootprintTool.js';
 import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
-import {imageLineBasedfootprintActionCreator} from '../drawingLayers/ImageLineBasedFootprint.js';
+import {imageLineBasedfootprintActionCreator} from './task/LSSTFootprintTask.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
 
 export const DRAWLAYER_PREFIX = 'DrawLayerCntlr';
@@ -565,10 +565,11 @@ export function dispatchCreateFootprintLayer(footprintId, layerTitle,
 }
 
 export function dispatchCreateImageLineBasedFootprintLayer(drawLayerId, title, fpData, plotId = [],
+                                                                     footprintFile, footprintImageFile, tbl_index,
                                                                      attachPlotGroup=true, dispatcher = flux.process) {
     dispatcher({
         type: IMAGELINEBASEDFP_CREATE,
-        payload: {plotId, drawLayerId, title, footprintData: fpData, attachPlotGroup}
+        payload: {plotId, drawLayerId, title, footprintData: fpData, footprintFile, footprintImageFile, tbl_index, attachPlotGroup}
     });
 }
 

--- a/src/firefly/js/visualize/Point.js
+++ b/src/firefly/js/visualize/Point.js
@@ -339,6 +339,28 @@ export const makeOffsetPt= (x,y) => Object.assign(new SimplePt(x,y), {type:OFFSE
 
 
 /**
+ * given an x,y, and a CoordinageSys object or string, make the correct type of point.
+ * @param {number} x
+ * @param {number} y
+ * @param {CoordinateSys|String} coordSys
+ * @return {Point}
+ */
+export function makeAnyPt(x,y,coordSys) {
+    const csys= (coordSys.isEquatorial && coordSys.getJsys && coordSys.getEquinox) ?
+                        coordSys  : CoordinateSys.parse(coordSys);
+
+    switch (csys) {
+        case CoordinateSys.SCREEN_PIXEL:
+        case CoordinateSys.UNDEFINED:    return makeScreenPt(x, y);
+        case CoordinateSys.PIXEL:        return makeImagePt(x, y);
+        case CoordinateSys.ZEROBASED:    return makeZeroBasedImagePt(x, y);
+        case CoordinateSys.FITSPIXEL:    return makeFitsImagePt(x, y);
+        default:                         return makeWorldPt(x,y,coordSys);
+    }
+}
+
+
+/**
  * @summary Test if two points are equals.  They must be the same coordinate system and have the same values to be
  * equal. Two points that are null or undefined are also considered equal.
  * If both points are WorldPt and are equal in values and coordinate system but have a

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -852,8 +852,8 @@ const makePt= function(type,  x, y) {
  * @returns {number}
  */
 export function convertAngle(from, to, angle) {
-    const angleUnit = [['deg', 'degree'], 'arcmin', 'arcsec', 'radian'];
-    const rIdx = angleUnit.indexOf('radian');
+    const angleUnit = [['deg', 'degree'], 'arcmin', 'arcsec', ['radian', 'rad']];
+    const rIdx = angleUnit.length-1;
     let fromIdx, toIdx;
     let numAngle = (typeof angle === 'string') ? parseFloat(angle) : angle;
     const unitIdx = (unit) => angleUnit.findIndex( (au) => (isArray(au) ? au.includes(unit) : au === unit));

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -844,6 +844,10 @@ const makePt= function(type,  x, y) {
     return retval;
 };
 
+export function isAngleUnit(unit) {
+    return ['deg', 'degree', 'arcmin', 'arcsec', 'radian', 'rad'].includes(unit.toLowerCase());
+}
+
 /**
  * convert angle value of one unit to that of another unit
  * @param {string} from 'degree' or 'deg', 'arcmin', 'arcsec', 'radian' case insensitive

--- a/src/firefly/js/visualize/draw/Drawer.js
+++ b/src/firefly/js/visualize/draw/Drawer.js
@@ -288,7 +288,7 @@ export class Drawer {
         else {
             return;
         }
-        const selDrawDef= Object.assign({}, this.drawingDef, {color:this.drawingDef.selectedColor});
+        const selDrawDef= Object.assign({}, this.drawingDef, {color:this.drawingDef.selectedColor, drawMode: 'select'});
         this.doDrawing(makeDrawingParams(selectCanvas, selDrawDef, cc,selectedData));
     }
 

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -20,6 +20,7 @@ import {AREA_SELECT,LINE_SELECT,POINT} from '../../core/ExternalAccessUtils.js';
 import {PlotTitle, TitleType} from './PlotTitle.jsx';
 import './ImageViewerDecorate.css';
 import Catalog from '../../drawingLayers/Catalog.js';
+import LSSTFootprint from '../../drawingLayers/ImageLineBasedFootprint';
 import {DataTypes} from '../draw/DrawLayer.js';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
 
@@ -49,17 +50,20 @@ const toolsAnno= [
  */
 function showSelect(pv,dlAry) {
     return getAllDrawLayersForPlot(dlAry, pv.plotId,true)
-        .some( (dl) => dl.drawLayerTypeId===Catalog.TYPE_ID && dl.canSelect && dl.catalog);
+        .some( (dl) => (dl.drawLayerTypeId === Catalog.TYPE_ID && dl.canSelect && dl.catalog) ||
+                        (dl.drawLayerTypeId === LSSTFootprint.TYPE_ID && dl.canSelect) );
 }
 
 function showFilter(pv,dlAry) {
     return getAllDrawLayersForPlot(dlAry, pv.plotId,true)
-        .some( (dl) => dl.drawLayerTypeId===Catalog.TYPE_ID && dl.canFilter && dl.catalog);
+        .some( (dl) => (dl.drawLayerTypeId===Catalog.TYPE_ID && dl.canFilter && dl.catalog) ||
+                       (dl.drawLayerTypeId === LSSTFootprint.TYPE_ID && dl.canFilter) );
 }
 
 function showClearFilter(pv,dlAry) {
     return getAllDrawLayersForPlot(dlAry, pv.plotId,true)
-        .some( (dl) => dl.drawLayerTypeId===Catalog.TYPE_ID &&  get(dl,'tableRequest.filters') && dl.catalog );
+        .some( (dl) => (dl.drawLayerTypeId===Catalog.TYPE_ID &&  get(dl,'tableRequest.filters') && dl.catalog) ||
+                        (dl.drawLayerTypeId === LSSTFootprint.TYPE_ID && get(dl, 'tableRequest.filters')));
 }
 
 
@@ -72,8 +76,14 @@ function showClearFilter(pv,dlAry) {
  */
 function showUnselect(pv,dlAry) {
     return getAllDrawLayersForPlot(dlAry, pv.plotId,true)
-        .filter( (dl) => dl.drawLayerTypeId===Catalog.TYPE_ID && dl.catalog)
-        .some( (dl) => Boolean(dl.drawData[DataTypes.SELECTED_IDXS] && dl.canSelect));
+        .filter( (dl) => {
+            return (dl.drawLayerTypeId===Catalog.TYPE_ID && dl.catalog) ||
+                   (dl.drawLayerTypeId===LSSTFootprint.TYPE_ID);
+        })
+        .some( (dl) => {
+                  return (Boolean(dl.drawData[DataTypes.SELECTED_IDXS] && dl.canSelect) ||
+                          Boolean(!isEmpty(dl.selectRowIdxs) && dl.canSelect));
+        });
 }
 
 

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -62,7 +62,7 @@ function showFilter(pv,dlAry) {
 
 function showClearFilter(pv,dlAry) {
     return getAllDrawLayersForPlot(dlAry, pv.plotId,true)
-        .some( (dl) => (dl.drawLayerTypeId===Catalog.TYPE_ID &&  get(dl,'tableRequest.filters') && dl.catalog) ||
+        .some( (dl) => (dl.drawLayerTypeId===Catalog.TYPE_ID &&  get(dl,'tableRequest.filters') && dl.catalog ) ||
                         (dl.drawLayerTypeId === LSSTFootprint.TYPE_ID && get(dl, 'tableRequest.filters')));
 }
 
@@ -373,7 +373,7 @@ ImageViewerDecorate.propTypes= {
     handleInlineTools : PropTypes.bool,
     workingIcon: PropTypes.bool,
     inlineTitle: PropTypes.bool,
-    aboveTitle: PropTypes.bool,
+    aboveTitle: PropTypes.bool
 };
 
 

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -49,7 +49,8 @@ export function* watchCatalogs() {
                                   TABLE_REMOVE, ImagePlotCntlr.PLOT_IMAGE, ImagePlotCntlr.PLOT_HIPS]);
         const {tbl_id}= action.payload;
 
-        switch (action.type && (!isLsstFootprintTable(getTblById(tbl_id)))) {
+        if (isLsstFootprintTable(getTblById(tbl_id))) continue;
+        switch (action.type) {
             case TABLE_LOADED:
                 handleCatalogUpdate(tbl_id);
                 break;

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -18,6 +18,7 @@ import Catalog from '../../drawingLayers/Catalog.js';
 import {CoordinateSys} from '../CoordSys.js';
 import {logError} from '../../util/WebUtil.js';
 import {getMaxScatterRows} from '../../charts/ChartUtil.js';
+import {isLsstFootprintTable} from '../task/LSSTFootprintTask.js';
 
 
 /**
@@ -47,7 +48,8 @@ export function* watchCatalogs() {
         const action= yield take([TABLE_LOADED, TABLE_SELECT,TABLE_HIGHLIGHT, TABLE_UPDATE,
                                   TABLE_REMOVE, ImagePlotCntlr.PLOT_IMAGE, ImagePlotCntlr.PLOT_HIPS]);
         const {tbl_id}= action.payload;
-        switch (action.type) {
+
+        switch (action.type && (!isLsstFootprintTable(getTblById(tbl_id)))) {
             case TABLE_LOADED:
                 handleCatalogUpdate(tbl_id);
                 break;
@@ -80,7 +82,7 @@ const isCName = (name) => (c) => c.name===name;
 function handleCatalogUpdate(tbl_id) {
     const sourceTable= getTblById(tbl_id);
 
-    
+
     const {tableMeta,totalRows,tableData, request, highlightedRow,selectInfo, title}= sourceTable;
     const maxScatterRows = getMaxScatterRows();
 

--- a/src/firefly/js/visualize/task/LSSTFootprintTask.js
+++ b/src/firefly/js/visualize/task/LSSTFootprintTask.js
@@ -1,0 +1,355 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {get,  isArray, isUndefined, isEmpty} from 'lodash';
+import {Style} from '../draw/DrawingDef.js';
+import {primePlot, getDrawLayerById} from '../PlotViewUtil.js';
+import {dispatchCreateDrawLayer, getDlAry, dispatchAttachLayerToPlot, dispatchModifyCustomField,
+                        dispatchDestroyDrawLayer} from '../DrawLayerCntlr.js';
+import {logError} from '../../util/WebUtil.js';
+import {ImageLineBasedObj} from '../draw/ImageLineBasedObj.js';
+import ImagePlotCntlr, {visRoot, dispatchPlotImage} from '../ImagePlotCntlr.js';
+import {makeTblRequest, cloneRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
+import {dispatchAddActionWatcher} from '../../core/MasterSaga.js';
+import {getAViewFromMultiView, getMultiViewRoot, IMAGE} from '../MultiViewCntlr.js';
+import WebPlotRequest from '../WebPlotRequest.js';
+import {dispatchTableSearch, TABLE_LOADED, TABLE_SELECT,TABLE_HIGHLIGHT,TABLE_REMOVE,TABLE_UPDATE}
+                from '../../tables/TablesCntlr.js';
+import {getTblById, doFetchTable, getColumnIdx, getColumn} from '../../tables/TableUtil.js';
+import LSSTFootprint from '../../drawingLayers/ImageLineBasedFootprint';
+import {convertAngle} from '../VisUtil.js';
+
+
+export const isLsstFootprintTable = (tableModel, fromAnalysis = false, tbl_idx = 0) => {
+    const HEADER_KEY_COL = 1;
+    const HEADER_VAL_COL = 2;
+    const lsstKeys = ['contains_lsst_footprints', 'contains_lsst_measurements'];
+    const {tableMeta} = tableModel || {};
+
+    if (fromAnalysis && tableMeta) {      // check meta from analysis
+        const metaInfo = JSON.parse(get(tableMeta, [tbl_idx]));
+        const metaAry = metaInfo && get(metaInfo, ['tableData', 'data']);
+
+        if (metaAry && isArray(metaAry)) {
+            const contains = metaAry.reduce((prev, oneMeta) => {
+                if (prev.length === lsstKeys.length) return prev;  // all keys are set
+                if ((oneMeta.length > HEADER_VAL_COL) && lsstKeys.includes(oneMeta[HEADER_KEY_COL]) &&
+                     oneMeta[HEADER_VAL_COL] === 'true' && (!prev.includes(oneMeta[HEADER_KEY_COL]))) {
+                    prev.push(oneMeta[HEADER_VAL_COL]);
+                }
+                return prev;
+            }, []);
+
+            return (contains.length === lsstKeys.length);
+        }
+    } else if (tableMeta) {                                        // not from analysis summary table
+        const filterRes = Object.keys(tableMeta).reduce((prev, oneKey) => {
+            if (prev.length === lsstKeys.length) return prev;
+            if (lsstKeys.includes(oneKey) && tableMeta[oneKey] === 'true' && !prev.includes(oneKey)) {
+                prev.push(oneKey);
+            }
+            return prev;
+        }, []);
+        return (filterRes.length === lsstKeys.length);
+    }
+    return false;
+};
+
+// columns in footprint table
+const spans = 'spans';
+const peaks = 'peaks';
+const corner1_x = 'footprint_corner1_x';
+const corner1_y = 'footprint_corner1_y';
+const corner2_x = 'footprint_corner2_x';
+const corner2_y = 'footprint_corner2_y';
+const footprintid = 'id';
+const table_rowidx = 'ROW_IDX';
+const ra_col = 'coord_ra';
+const dec_col = 'coord_dec';
+
+// column set
+const hiddenColumns =[spans, peaks, corner1_x, corner1_y, corner2_x, corner2_y];
+const tblIdxCols = [footprintid, table_rowidx];
+const posCols = [ra_col, dec_col];
+
+function getFileNameFromPath(filePath) {
+    return filePath.split(/(\\|\/)/g).pop();
+}
+
+/**
+ * create lsst footprint by checking if a footprint source catalog, an lsst image file or footprint data is send
+ * - if an image file is set, load the image and then load the footprint file (table) if there is and get the footprint
+ * data from the loaded file (table)
+ * - if a footprint file is set, load the footpriont file (table) and then get the footprint data from the loaded table
+ * - create the drawlayer per footprint data.
+ * @param action
+ * @returns {Function}
+ */
+export function imageLineBasedfootprintActionCreator(action) {
+    return (dispatcher) => {
+        const {footprintFile, footprintImageFile, footprintData, drawLayerId, tbl_index,
+               title, style='fill', color, showText, plotId} = action.payload;
+        const fpParams = {title, style, color, showText};
+        let   imagePlotId = isArray(plotId) ? plotId[0] : plotId;
+
+        if (!drawLayerId) {
+            logError('no lsst drawlayer id specified');
+            return;
+        }
+
+        if (!imagePlotId) {
+            if (footprintImageFile) {
+                imagePlotId = getFileNameFromPath(footprintImageFile);  // create a new plot
+            } else {
+                const pv = primePlot(visRoot());      // check the active plot
+                imagePlotId = pv ? pv.plotId : null;
+            }
+        }
+
+        if (!imagePlotId) {
+            logError('no lsst image for footprint overlay');
+            return;
+        }
+
+        const getFootprintData = (footprintFile, pId, tbl_index = 0) => {
+            loadFootprintTable(footprintFile, pId, drawLayerId, tbl_index).then((tableModel) => {
+                return getFootprintDataFromTable(tableModel);
+            }).then((fpData) => {
+                initFootprint(fpData, drawLayerId, pId, fpParams);
+            });
+        };
+
+        const footprintImageWatcher = (action, cancelSelf) => {
+            const {plotId} = action.payload;
+
+            if (plotId === imagePlotId) {
+                if (footprintFile) {
+                    getFootprintData(footprintFile, plotId, tbl_index);
+                } else if (footprintData) {
+                    initFootprint(footprintData, drawLayerId, plotId, fpParams);
+                }
+                if (cancelSelf) {
+                    cancelSelf();
+                }
+            }
+        };
+
+
+        if (footprintImageFile) {
+            dispatchAddActionWatcher({actions: [ImagePlotCntlr.PLOT_IMAGE], callback: footprintImageWatcher});
+            loadFootprintImage(footprintImageFile, imagePlotId);
+        } else if (footprintFile) {
+            getFootprintData(footprintFile, imagePlotId, tbl_index);
+        } else if (footprintData) {
+            initFootprint(footprintData, drawLayerId, imagePlotId, fpParams);
+        }
+    };
+}
+
+function loadFootprintImage(imageFileOnServer, plotId) {
+    const wpr = WebPlotRequest.makeFilePlotRequest(imageFileOnServer);
+    const {viewerId=''} = getAViewFromMultiView(getMultiViewRoot(), IMAGE) || {};
+
+    if (viewerId) {
+        wpr.setPlotGroupId(viewerId);
+        dispatchPlotImage({plotId, wpRequest: wpr, viewerId});
+    }
+}
+
+
+function getFootprintDataFromTable(tableModel) {
+    const allColumns = hiddenColumns.concat(posCols).concat(tblIdxCols);
+
+    const inclCols = allColumns.map((col) => (`"${col}"`)).join(',');
+
+    const params = {
+        startIdx: 0,
+        pageSize: MAX_ROW,
+        inclCols
+    };
+
+
+    const req = cloneRequest(tableModel.request, params);
+    req.tbl_id = `data-${tableModel.tbl_id}`;
+
+    return doFetchTable(req).then(
+        (footprintTblModel) => {
+
+            const everyOtherData = (ary, numInGroup, type = 'integer') => {
+                const numIdx = [...Array(numInGroup).keys()];
+                const aryIdx = [...Array(Math.trunc(ary.length/numInGroup)).keys()];
+
+                const newArray = aryIdx.reduce((prev, gIdx) => {
+                    const newGroup = numIdx.reduce((prev, idx) => {
+                        const v = ary[gIdx * numInGroup + idx];
+                        prev.push((type === 'integer' ? parseInt(v) : parseFloat(v)));
+                        return prev;
+                    }, []);
+
+                    prev.push(newGroup);
+                    return prev;
+                }, []);
+
+                return newArray;
+            };
+
+            const {data} = get(footprintTblModel, ['tableData']);
+            const footprintData = {pixelsys: 'zero-based', feet: {}};
+            let   failCol = false;
+            const colsIdxMap = allColumns.reduce((prev, colName) => {
+                prev[colName] = getColumnIdx(footprintTblModel, colName);
+                if (prev[colName] < 0) {
+                    failCol = true;
+                }
+                return prev;
+            }, {});
+
+            const worldUnit = get(getColumn(footprintTblModel, ra_col), 'units', 'deg');
+
+            if (!failCol && data) {
+                data.reduce((prev, oneFootprint) => {
+                    const id = oneFootprint[colsIdxMap[footprintid]];
+                    const c1_x = parseInt(oneFootprint[colsIdxMap[corner1_x]]);
+                    const c1_y = parseInt(oneFootprint[colsIdxMap[corner1_y]]);
+                    const c2_x = parseInt(oneFootprint[colsIdxMap[corner2_x]]);
+                    const c2_y = parseInt(oneFootprint[colsIdxMap[corner2_y]]);
+                    const spansStr = oneFootprint[colsIdxMap[spans]];
+                    const peaksStr = oneFootprint[colsIdxMap[peaks]];
+                    const ra = convertAngle(worldUnit, 'deg', Number(oneFootprint[colsIdxMap[ra_col]]));
+                    const dec = convertAngle(worldUnit, 'deg', Number(oneFootprint[colsIdxMap[dec_col]]));
+
+
+                    // skip no spans case
+                    if (c1_x >= 0 && c1_y >= 0 && c2_x >= 0 && c2_y >= 0 && spansStr && peaksStr && ra && dec) {
+                        const corners = [[c1_x, c1_y], [c2_x, c1_y], [c2_x, c2_y], [c1_x, c2_y]];
+                        const spans = everyOtherData(spansStr.replace(/\(|\)|,/g, '').split(' '), 3);
+                        const peaks = everyOtherData(peaksStr.replace(/\(|\)|,/g, '').split(' '), 2, 'float');
+
+                        prev[id] = {corners, spans, peaks, rowIdx: oneFootprint[colsIdxMap[table_rowidx]],
+                                    ra, dec};
+                    }
+                    return prev;
+                }, footprintData.feet);
+
+                return footprintData;
+            }
+            return null;
+        }
+    ).catch(
+        (reason) => {
+            logError(`Failed to lsst footprint data: ${reason}`, reason);
+        }
+    );
+}
+
+
+function initFootprint(footprintData, drawLayerId, plotId, footprintParams) {
+    const imageLineBasedFP = ImageLineBasedObj(footprintData);
+    const {title, style, color, showText} = footprintParams || {};
+    const sourceTable = getTblById(drawLayerId);
+    const {highlightedRow, selectInfo, request, tbl_id, tableData} = sourceTable || {};
+
+    if (!isEmpty(imageLineBasedFP)) {
+        const dl = getDrawLayerById(getDlAry(), drawLayerId);
+        if (!dl) {
+            dispatchCreateDrawLayer(LSSTFootprint.TYPE_ID, {
+                drawLayerId, title, imageLineBasedFP, color, showText,
+                highlightedRow, selectInfo, tbl_id,
+                tableRequest: request,
+                style: (style&&(style.toLowerCase() === 'fill')) ? Style.FILL : Style.STANDARD
+            });
+            if (plotId) {
+                dispatchAttachLayerToPlot(drawLayerId, plotId, false);    // only one plot is attached
+            }
+        } else {
+            dispatchModifyCustomField(tbl_id,
+                    {tableData, imageLineBasedFP,
+                     highlightedRow, selectInfo, tableRequest: request, tbl_id}, plotId);
+        }
+    }
+}
+
+const footprintTableWatcher = (action, cancelSelf, params) => {
+    const {tbl_id} = action.payload;
+    const {plotId, drawLayerId, footprintTableId} = params || {};
+
+    if (tbl_id !== footprintTableId) return;
+
+
+    switch(action.type) {
+        case TABLE_LOADED:
+            handleFootprintUpdate(tbl_id, drawLayerId, plotId);
+            break;
+
+        case TABLE_SELECT:
+            dispatchModifyCustomField(tbl_id, {selectInfo: action.payload.selectInfo}, plotId);
+            break;
+
+        case TABLE_HIGHLIGHT:
+        case TABLE_UPDATE:
+            dispatchModifyCustomField(tbl_id, {highlightedRow:action.payload.highlightedRow}, plotId);
+            break;
+
+        case TABLE_REMOVE:
+            dispatchDestroyDrawLayer(drawLayerId);
+            break;
+
+    }
+};
+
+function loadFootprintTable(footprintFileOnServer, plotId, drawLayerId, tbl_index) {
+
+    return new Promise((resolve) => {
+        const title = footprintFileOnServer.split(/(\\|\/)/g).pop();
+        const hiddenColumnMeta = hiddenColumns.concat(['flags', 'footprint']).reduce( (prev, oneCol) => {
+            const colKey = `col.${oneCol}.Visibility`;
+
+            prev[colKey] = 'hidden';
+            return prev;
+        }, {});
+        const footprintTableId = drawLayerId;   // table Id is the same as drawLayerId
+        const tblReq = makeTblRequest('userCatalogFromFile', title,
+                                        { filePath: footprintFileOnServer},
+                                        { tbl_id: footprintTableId,
+                                          META_INFO: hiddenColumnMeta,
+                                          removable: true,
+                                          pageSize: 200
+                                        });
+
+        if (!isUndefined(tbl_index)) {
+            tblReq.tbl_index = tbl_index;
+        }
+
+        const loadFootprintTableWatcher = (action, canself) => {
+            const {tbl_id} = action.payload;
+            if (tbl_id !== footprintTableId) return;
+
+            const tableModel = getTblById(tbl_id);
+            dispatchAddActionWatcher({
+                    actions: [TABLE_SELECT, TABLE_HIGHLIGHT, TABLE_UPDATE, TABLE_REMOVE, TABLE_LOADED],
+                    callback: footprintTableWatcher,
+                    params: {plotId, drawLayerId, footprintTableId}
+            });
+            resolve(tableModel);
+            if (canself) {
+                canself();
+            }
+        };
+
+        dispatchAddActionWatcher({actions: [TABLE_LOADED], callback: loadFootprintTableWatcher});
+        dispatchTableSearch(tblReq);
+    });
+}
+
+function handleFootprintUpdate(tbl_id, drawLayerId, plotId) {
+    const sourceTable = getTblById(tbl_id);
+
+    getFootprintDataFromTable(sourceTable).then((fpData) => {
+        initFootprint(fpData, drawLayerId, plotId, null);
+    }).catch (
+        (reason) => {
+            logError(reason);
+        }
+    );
+}
+

--- a/src/firefly/js/visualize/task/LSSTFootprintTask.js
+++ b/src/firefly/js/visualize/task/LSSTFootprintTask.js
@@ -362,19 +362,6 @@ function loadFootprintTable(footprintFileOnServer, plotId, drawLayerId, tbl_inde
         const footprintTableId = getTableId(drawLayerId);   // table Id is uniquely derived from drawLayerId
         const tbl = getTblById(footprintTableId);
 
-        /*
-        const tableRemoveWatcher = (action, canself) => {
-            const {tbl_id} = action.payload;
-            if (tbl_id !== footprintTableId) return;
-
-            loadTable();
-            if (canself) {
-                canself();
-            }
-
-        };
-        */
-
         const loadTable = () => {
             const tblReq = makeTblRequest('userCatalogFromFile', title,
                 {filePath: footprintFileOnServer},
@@ -395,7 +382,7 @@ function loadFootprintTable(footprintFileOnServer, plotId, drawLayerId, tbl_inde
 
                 const tableModel = getTblById(tbl_id);
                 dispatchAddActionWatcher({
-                    actions: [TABLE_SELECT, TABLE_HIGHLIGHT, TABLE_UPDATE, TABLE_REMOVE],
+                    actions: [TABLE_SELECT, TABLE_HIGHLIGHT, TABLE_REMOVE, TABLE_UPDATE],
                     callback: footprintTableWatcher,
                     params: {plotId, drawLayerId, footprintTableId}
                 });
@@ -414,13 +401,6 @@ function loadFootprintTable(footprintFileOnServer, plotId, drawLayerId, tbl_inde
         };
 
         if (tbl) {
-            /*
-            dispatchAddActionWatcher({
-                actions: [TABLE_REMOVE],
-                callback: tableRemoveWatcher,
-                params: {plotId, drawLayerId, footprintTableId}
-            });
-            */
             dispatchTableRemove(footprintTableId);
         }
         loadTable();

--- a/src/firefly/js/visualize/task/LSSTFootprintTask.js
+++ b/src/firefly/js/visualize/task/LSSTFootprintTask.js
@@ -73,7 +73,7 @@ const tblIdxCols = [footprintid, table_rowidx];
 const posCols = [ra_col, dec_col];
 
 function getFileNameFromPath(filePath) {
-    return filePath.split(/(\\|\/)/g).pop();
+    return filePath.split(/(\\|\/)/g).pop().replace('.', '_');
 }
 
 /**
@@ -88,8 +88,8 @@ function getFileNameFromPath(filePath) {
 export function imageLineBasedfootprintActionCreator(action) {
     return (dispatcher) => {
         const {footprintFile, footprintImageFile, footprintData, drawLayerId, tbl_index,
-               title, style='fill', color, showText, plotId} = action.payload;
-        const fpParams = {title, style, color, showText};
+               title, style='fill', color, selectColor, highlightColor, showText, plotId} = action.payload;
+        const fpParams = {title, style, color, selectColor, highlightColor, showText};
         let   imagePlotId = isArray(plotId) ? plotId[0] : plotId;
 
         if (!drawLayerId) {
@@ -112,7 +112,7 @@ export function imageLineBasedfootprintActionCreator(action) {
         }
 
         const getFootprintData = (footprintFile, pId, tbl_index = 0) => {
-            loadFootprintTable(footprintFile, pId, drawLayerId, tbl_index).then((tableModel) => {
+            loadFootprintTable(footprintFile, pId, drawLayerId, tbl_index, title).then((tableModel) => {
                 return getFootprintDataFromTable(tableModel);
             }).then((fpData) => {
                 initFootprint(fpData, drawLayerId, pId, fpParams);
@@ -245,7 +245,7 @@ function getFootprintDataFromTable(tableModel) {
 
 function initFootprint(footprintData, drawLayerId, plotId, footprintParams) {
     const imageLineBasedFP = ImageLineBasedObj(footprintData);
-    const {title, style, color, showText} = footprintParams || {};
+    const {title, style, color, showText, selectColor, highlightColor} = footprintParams || {};
     const sourceTable = getTblById(drawLayerId);
     const {highlightedRow, selectInfo, request, tbl_id, tableData} = sourceTable || {};
 
@@ -253,7 +253,8 @@ function initFootprint(footprintData, drawLayerId, plotId, footprintParams) {
         const dl = getDrawLayerById(getDlAry(), drawLayerId);
         if (!dl) {
             dispatchCreateDrawLayer(LSSTFootprint.TYPE_ID, {
-                drawLayerId, title, imageLineBasedFP, color, showText,
+                drawLayerId, title, imageLineBasedFP,
+                color, showText, selectColor, highlightColor,
                 highlightedRow, selectInfo, tbl_id,
                 tableRequest: request,
                 style: (style&&(style.toLowerCase() === 'fill')) ? Style.FILL : Style.STANDARD
@@ -297,10 +298,10 @@ const footprintTableWatcher = (action, cancelSelf, params) => {
     }
 };
 
-function loadFootprintTable(footprintFileOnServer, plotId, drawLayerId, tbl_index) {
+function loadFootprintTable(footprintFileOnServer, plotId, drawLayerId, tbl_index, tableTitle) {
 
     return new Promise((resolve) => {
-        const title = footprintFileOnServer.split(/(\\|\/)/g).pop();
+        const title = tableTitle || footprintFileOnServer.split(/(\\|\/)/g).pop();
         const hiddenColumnMeta = hiddenColumns.concat(['flags', 'footprint']).reduce( (prev, oneCol) => {
             const colKey = `col.${oneCol}.Visibility`;
 

--- a/src/firefly/js/visualize/task/LSSTFootprintTask.js
+++ b/src/firefly/js/visualize/task/LSSTFootprintTask.js
@@ -265,7 +265,7 @@ function initFootprint(footprintData, drawLayerId, plotId, footprintParams) {
         } else {
             dispatchModifyCustomField(tbl_id,
                     {tableData, imageLineBasedFP,
-                     highlightedRow, selectInfo, tableRequest: request, tbl_id}, plotId);
+                     highlightedRow, selectInfo,  tableRequest: request, tbl_id}, plotId);
         }
     }
 }
@@ -276,10 +276,9 @@ const footprintTableWatcher = (action, cancelSelf, params) => {
 
     if (tbl_id !== footprintTableId) return;
 
-
     switch(action.type) {
-        case TABLE_LOADED:
-            handleFootprintUpdate(tbl_id, drawLayerId, plotId);
+        case TABLE_UPDATE:
+             handleFootprintUpdate(tbl_id, drawLayerId, plotId);
             break;
 
         case TABLE_SELECT:
@@ -287,7 +286,6 @@ const footprintTableWatcher = (action, cancelSelf, params) => {
             break;
 
         case TABLE_HIGHLIGHT:
-        case TABLE_UPDATE:
             dispatchModifyCustomField(tbl_id, {highlightedRow:action.payload.highlightedRow}, plotId);
             break;
 
@@ -327,7 +325,7 @@ function loadFootprintTable(footprintFileOnServer, plotId, drawLayerId, tbl_inde
 
             const tableModel = getTblById(tbl_id);
             dispatchAddActionWatcher({
-                    actions: [TABLE_SELECT, TABLE_HIGHLIGHT, TABLE_UPDATE, TABLE_REMOVE, TABLE_LOADED],
+                    actions: [TABLE_SELECT, TABLE_HIGHLIGHT, TABLE_UPDATE, TABLE_REMOVE],
                     callback: footprintTableWatcher,
                     params: {plotId, drawLayerId, footprintTableId}
             });

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -26,11 +26,12 @@ import {isAccessWorkspace, getWorkspaceConfig} from '../WorkspaceCntlr.js';
 import {getAppHiPSForMoc, addNewMocLayer} from '../HiPSMocUtil.js';
 import {primePlot, getDrawLayerById} from '../PlotViewUtil.js';
 import {genHiPSPlotId} from './ImageSearchPanelV2.jsx';
-import DrawLayerCntlr, {dispatchAttachLayerToPlot, dlRoot} from '../DrawLayerCntlr.js';
+import DrawLayerCntlr, {dispatchAttachLayerToPlot, dlRoot, dispatchCreateImageLineBasedFootprintLayer}
+        from '../DrawLayerCntlr.js';
 import {dispatchAddActionWatcher} from '../../core/MasterSaga.js';
 import HiPSMOC from '../../drawingLayers/HiPSMOC.js';
 import {isMOCFitsFromUploadAnalsysis, MOCInfo, UNIQCOL} from '../HiPSMocUtil.js';
-
+import {isLsstFootprintTable} from '../task/LSSTFootprintTask.js';
 
 import './ImageSelectPanel.css';
 
@@ -706,6 +707,11 @@ function selectRowFromSummaryTable(tblModel) {
     return selectInfoCls.data;
 }
 
+const tableTitle = (displayValue, uploadTabs) => {
+    const n = displayValue.lastIndexOf((uploadTabs === fileId) ? '\\' : '\/');
+    return  displayValue.slice(n+1);   // n = -1 or n >= 0
+};
+
 /**
  * send request to get the data of table unit, for votable and fits, the table index is mapped to be
  * that at the server side
@@ -784,29 +790,30 @@ function sendImageRequest(fileCacheKey, fName, idx, extMap, imageDisplay) {
     }
 }
 
+const getUniqueTblId = (uploadMethod, displayValue) => {
+    let filePath;
+    if (uploadMethod === fileId) {
+        filePath =  displayValue.split(/[\\|\/]/g).pop().replace('.', '_');
+    } else {
+        if (uploadMethod === urlId) {
+            displayValue = displayValue.replace(/^http[s]?:[\\|\/]{2}/i, '');
+        }
+        filePath = displayValue.replace(/[\\|\/|\.]/g, '_');
+    }
+
+    let idCnt = 0;
+    while (true) {
+        const tableId = idCnt === 0 ? filePath : `${filePath}-${idCnt}`;
+        idCnt++;
+
+        if (!getTblById(tableId)) return tableId;
+    }
+};
+
 
 function sendMocRequest(uploadPath, displayValue, uploadMethod, mocFits) {
 
-    const uniqueTblId = () => {
-        let filePath;
-        if (uploadMethod === fileId) {
-            filePath =  displayValue.split(/[\\|\/]/g).pop().replace('.', '_');
-        } else {
-            if (uploadMethod === urlId) {
-                displayValue = displayValue.replace(/^http[s]?:[\\|\/]{2}/i, '');
-            }
-            filePath = displayValue.replace(/[\\|\/|\.]/g, '_');
-        }
-
-        let idCnt = 0;
-        while (true) {
-            const tableId = idCnt === 0 ? filePath : `${filePath}-${idCnt}`;
-            idCnt++;
-
-            if (!getTblById(tableId)) return tableId;
-        }
-    };
-    const tblId = uniqueTblId();
+    const tblId = getUniqueTblId(uploadMethod, displayValue);
     const pv = primePlot(visRoot());
 
     const overlayMocOnPlot = (plotId) => {
@@ -852,6 +859,20 @@ function sendMocRequest(uploadPath, displayValue, uploadMethod, mocFits) {
         overlayMocOnPlot(pv.plotId);
     }
 }
+
+export const isMocTable = (tableModel) => {
+    return  get(tableModel, ['isMocFits', 'valid']);
+};
+
+function sendLSSTFootprintRequest(uploadPath, displayValue, uploadMethod, selectedResults) {
+    const tbl_id = 'lsst_footprint_'+getUniqueTblId(uploadMethod, displayValue);
+    const pv = primePlot(visRoot());
+    const pIds = pv ? [pv.plotId]: [];
+
+    dispatchCreateImageLineBasedFootprintLayer(tbl_id, 'lsst footprint: '+ tableTitle(displayValue, uploadMethod), null, pIds,
+                                              uploadPath, null, selectedResults ? selectedResults.table[0]: null);
+
+}
 /*
     the map which maps summary table row index to table index and image extension number at the server
  */
@@ -879,10 +900,6 @@ function getExtensionMap(model) {
  * @returns {Function}
  */
 export function resultSuccess() {
-    const tableTitle = (displayValue, uploadTabs) => {
-        const n = displayValue.lastIndexOf((uploadTabs === fileId) ? '\\' : '\/');
-        return  displayValue.slice(n+1);   // n = -1 or n >= 0
-    };
 
     return (request) => {
         const {uploadTabs, imageDisplay} = request;
@@ -901,8 +918,10 @@ export function resultSuccess() {
                 sendImageRequest(uploadPath, displayValue, selectResults.image, extensionMap.imageMap, imageDisplay);
             }
             if (selectResults.table.length !== 0) {
-                if (get(analysisModel, ['isMocFits', 'valid'])) {
+                if (isMocTable(analysisModel)) {
                     sendMocRequest(uploadPath, displayValue, uploadTabs, analysisModel.isMocFits);
+                } else if (isLsstFootprintTable(analysisModel, true, (selectResults.table)[0])) {
+                    sendLSSTFootprintRequest(uploadPath, displayValue, uploadTabs,  selectResults);
                 } else {
                     selectResults.table.forEach((idx) => {
                         sendTableRequest(uploadPath, tableTitle(displayValue, uploadTabs), idx, extensionMap.tableMap,

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -771,7 +771,7 @@ function sendImageRequest(fileCacheKey, fName, idx, extMap, imageDisplay) {
                 wpr.setPostTitle(`- ext. ${extList}`);
             }
 
-            plotId = `${fName}-${idx.join('_')}`;
+            plotId = `${fName.replace('.', '_')}-${idx.join('_')}`;
             dispatchPlotImage({plotId, wpRequest: wpr, viewerId});
         } else {
 
@@ -869,7 +869,8 @@ function sendLSSTFootprintRequest(uploadPath, displayValue, uploadMethod, select
     const pv = primePlot(visRoot());
     const pIds = pv ? [pv.plotId]: [];
 
-    dispatchCreateImageLineBasedFootprintLayer(tbl_id, 'lsst footprint: '+ tableTitle(displayValue, uploadMethod), null, pIds,
+    dispatchCreateImageLineBasedFootprintLayer(tbl_id, tableTitle(displayValue, uploadMethod),
+                                              null, pIds,
                                               uploadPath, null, selectedResults ? selectedResults.table[0]: null);
 
 }

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -7,7 +7,7 @@ import numeral from 'numeral';
 import PropTypes from 'prop-types';
 import {isEmpty, get, padEnd} from 'lodash';
 import {primePlot,isMultiImageFitsWithSameArea, getPlotViewById,
-                getDrawLayersByType, isDrawLayerAttached } from '../PlotViewUtil.js';
+                getDrawLayersByType, isDrawLayerAttached, getAllDrawLayersForPlot } from '../PlotViewUtil.js';
 import {findScrollPtToCenterImagePt} from '../reducer/PlotView.js';
 import {CysConverter} from '../CsysConverter.js';
 import {PlotAttribute,isHiPS, isImage} from '../WebPlot.js';
@@ -24,7 +24,7 @@ import {dispatchCrop, dispatchChangeCenterOfProjection, dispatchChangePrimePlot,
         dispatchChangeHiPS, dispatchChangeHipsImageConversion, visRoot} from '../ImagePlotCntlr.js';
 import {makePlotSelectionExtActivateData} from '../../core/ExternalAccessUtils.js';
 import {dispatchExtensionActivate} from '../../core/ExternalAccessCntlr.js';
-import {selectCatalog,unselectCatalog,filterCatalog,clearFilterCatalog} from '../../drawingLayers/Catalog.js';
+import Catalog, {selectCatalog,unselectCatalog,filterCatalog,clearFilterCatalog} from '../../drawingLayers/Catalog.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import {SelectedShape} from '../../drawingLayers/SelectArea.js';
 import {isImageOverlayLayersActive} from '../RelatedDataUtil.js';
@@ -42,6 +42,7 @@ import {isOutlineImageForSelectArea, detachSelectArea, SELECT_AREA_TITLE} from '
 import {convertAngle} from '../VisUtil.js';
 import {convertToHiPS, convertToImage, doHiPSImageConversionIfNecessary} from '../task/PlotHipsTask.js';
 import {RequestType} from '../RequestType.js';
+import LSSTFootprint, {selectFootprint, unselectFootprint, filterFootprint, clearFilterFootprint} from '../../drawingLayers/ImageLineBasedFootprint';
 
 import CROP from 'html/images/icons-2014/24x24_Crop.png';
 import STATISTICS from 'html/images/icons-2014/24x24_Statistics.png';
@@ -547,19 +548,19 @@ export class VisCtxToolbarView extends PureComponent {
 
                 {showCatSelect &&
                 <ToolbarButton icon={SELECTED} tip='Mark data in area as selected'
-                               horizontal={true} onClick={() => selectCatalog(pv,dlAry)}/>}
+                               horizontal={true} onClick={() => selectDrawingLayer(pv,dlAry)}/>}
 
                 {showCatUnSelect &&
                 <ToolbarButton icon={UNSELECTED} tip='Mark all data unselected'
-                               horizontal={true} onClick={() => unselectCatalog(pv,dlAry)}/>}
+                               horizontal={true} onClick={() => unselectDrawingLayer(pv,dlAry)}/>}
 
                 {showFilter &&
                 <ToolbarButton icon={FILTER} tip='Filter in the selected area'
-                               horizontal={true} onClick={() => filterCatalog(pv,dlAry)}/>}
+                               horizontal={true} onClick={() => filterDrawingLayer(pv,dlAry)}/>}
 
                 {showClearFilter &&
                 <ToolbarButton icon={CLEAR_FILTER} tip='Clear all the Filters'
-                               horizontal={true} onClick={() => clearFilterCatalog(pv,dlAry)}/>}
+                               horizontal={true} onClick={() => clearFilterDrawingLayer(pv,dlAry)}/>}
 
                 {showSelectionTools &&
                 <ToolbarButton icon={SELECTED_ZOOM} tip='Zoom to fit selected area'
@@ -700,4 +701,52 @@ function getHipsCubeDesc(plot) {
     const bunit3= (data_cube_bunit3!=='null' && data_cube_bunit3!=='nil' && data_cube_bunit3!=='undefined') ?
                                data_cube_bunit3 : '';
     return `${doFormat(value,dp)} ${bunit3}`;
+}
+
+function selectDrawingLayer(pv,dlAry) {
+    const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
+    if (allLayers.length > 0) {
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+            selectCatalog(pv, allLayers);
+        }
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+            selectFootprint(pv, allLayers);
+        }
+    }
+}
+
+function unselectDrawingLayer(pv,dlAry) {
+    const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
+    if (allLayers.length > 0) {
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+            unselectCatalog(pv, allLayers);
+        }
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+            unselectFootprint(pv, allLayers);
+        }
+    }
+}
+
+function filterDrawingLayer(pv,dlAry) {
+    const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
+    if (allLayers.length > 0) {
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+            filterCatalog(pv, allLayers);
+        }
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+            filterFootprint(pv, allLayers);
+        }
+    }
+}
+
+function clearFilterDrawingLayer(pv,dlAry) {
+    const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
+    if (allLayers.length > 0) {
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+            clearFilterCatalog(pv, allLayers);
+        }
+        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+            clearFilterFootprint(pv, allLayers);
+        }
+    }
 }

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -730,10 +730,10 @@ function unselectDrawingLayer(pv,dlAry) {
 function filterDrawingLayer(pv,dlAry) {
     const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
     if (allLayers.length > 0) {
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === Catalog.TYPE_ID)) {
             filterCatalog(pv, allLayers);
         }
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID)) {
             filterFootprint(pv, allLayers);
         }
     }
@@ -742,10 +742,10 @@ function filterDrawingLayer(pv,dlAry) {
 function clearFilterDrawingLayer(pv,dlAry) {
     const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
     if (allLayers.length > 0) {
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === Catalog.TYPE_ID)) {
             clearFilterCatalog(pv, allLayers);
         }
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID)) {
             clearFilterFootprint(pv, allLayers);
         }
     }

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -706,10 +706,10 @@ function getHipsCubeDesc(plot) {
 function selectDrawingLayer(pv,dlAry) {
     const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
     if (allLayers.length > 0) {
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === Catalog.TYPE_ID)) {
             selectCatalog(pv, allLayers);
         }
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID)) {
             selectFootprint(pv, allLayers);
         }
     }
@@ -718,10 +718,10 @@ function selectDrawingLayer(pv,dlAry) {
 function unselectDrawingLayer(pv,dlAry) {
     const allLayers = getAllDrawLayersForPlot(dlAry, pv.plotId, true);
     if (allLayers.length > 0) {
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === Catalog.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === Catalog.TYPE_ID)) {
             unselectCatalog(pv, allLayers);
         }
-        if (allLayers.findIndex((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID) >= 0) {
+        if (allLayers.some((l) => l.drawLayerTypeId === LSSTFootprint.TYPE_ID)) {
             unselectFootprint(pv, allLayers);
         }
     }


### PR DESCRIPTION
the PR links LSST source and footprint overlay including the following functions, 
- source table and footprint overlay can be highlighted, selected, and filtered in sync.
- the API can take either footprint source and data file  or footprint data in json format.
 
test:
test samples,
-download image file from https://caltech.app.box.com/s/91itmkiz0s68b14qy3nnj7sriqh80mxg
-download votable, combined_sources_and_footprints.xml, containing more than 34K footprints, from https://caltech.app.box.com/s/kob0ri00fai75eruyspfbobs3lxx9gzs 
- get votable files with 500, 2000, 5000 footprint data extracted from above votable sample from firefly_test_data.

test steps:
start firefly, 
upload the image file and search the first image 
upload one of the footprint votable file (try the one with smaller set of footprint first), search the table

footprint source table and overlay are shown, try highlight, selection, and filtering between the overlay and the table. 


