### PR TITLE
DM-16021: work to make the api work in a Jupyter slate  environment

### DIFF
--- a/src/firefly/html/slate.html
+++ b/src/firefly/html/slate.html
@@ -17,7 +17,9 @@
                     {label:'Images', action:'ImageSelectDropDownSlateCmd'},
                     {label:'Catalogs', action:'IrsaCatalogDropDown'},
                     {label:'Charts', action:'ChartSelectDropDownCmd'},
+                    {label:'Upload', action: 'FileUploadDropDownCmd'},
                 ],
+                showBgMonitor: false
             },
             options : {
                 MenuItemKeys: {maskOverlay:true},

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -31,8 +31,12 @@ export function buildHighLevelApi(llApi) {
     return Object.assign({}, deprecated, current);
 }
 
+const STANDARD= 'standard';
+const ENCAPUSULATE= 'encapusulate';
+
 
 var globalImageViewDefParams= {};
+var globalPrefs= {imageDisplayType:STANDARD};
 
 /**
  * Build the deprecated API
@@ -46,6 +50,7 @@ function build(llApi) {
     const imagePart= buildImagePart(llApi);
     const chartPart= buildChartPart(llApi);
     const tablePart= buildTablePart(llApi);
+
     return Object.assign({}, commonPart, imagePart,chartPart,tablePart);
 }
 
@@ -222,7 +227,9 @@ function buildCommon(llApi) {
      */
     const setRootPath= (rootUrlPath) => llApi.action.dispatchRootUrlPath(rootUrlPath);
 
-    return {setRootPath};
+    const setGlobalPref= (pref)=> Object.assign(globalPrefs, pref);
+
+    return {setRootPath,setGlobalPref};
 }
 
 function buildImagePart(llApi) {
@@ -296,6 +303,8 @@ function buildImagePart(llApi) {
      * @param {WebPlotParams|WebPlotRequest} request a request object with the plotting parameters
      * @param {HipsImageConversionSettings} [hipsImageConversion= undefined] if defined, use these parameter to
      *                                                convert between image and HiPS
+     * @param {boolean} userCanDelete User can delete the image
+     *
      * @memberof firefly
      * @public
      * @example firefly.showImage('myPlot',
@@ -312,8 +321,8 @@ function buildImagePart(llApi) {
      *
      *
      */
-    const showImage= (targetDiv, request, hipsImageConversion)  =>
-                   showImageInMultiViewer(llApi, targetDiv, request, false, hipsImageConversion);
+    const showImage= (targetDiv, request, hipsImageConversion, userCanDelete)  =>
+                   showImageInMultiViewer(llApi, targetDiv, request, false, hipsImageConversion, userCanDelete);
 
     /**
      * @summary A convenience plotting function to plot a file on the server or a url.  If first looks for the file then
@@ -361,6 +370,7 @@ function buildImagePart(llApi) {
      * @param {WebPlotParams|WebPlotRequest} request a request object with Type=='HiPS' used to display a HiPS
      * @param {HipsImageConversionSettings} [hipsImageConversion=undefined] if defined, use these parameter to
      *                                                convert between image and HiPS
+     * @param {boolean} userCanDelete User can delete the image
      * @memberof firefly
      * @public
      * @example firefly.showHiPS('hipsDIV1',
@@ -384,8 +394,8 @@ function buildImagePart(llApi) {
      *
      */
 
-    const showHiPS= (targetDiv, request, hipsImageConversion)  =>
-                        showImageInMultiViewer(llApi, targetDiv, request, true, hipsImageConversion);
+    const showHiPS= (targetDiv, request, hipsImageConversion, userCanDelete)  =>
+                        showImageInMultiViewer(llApi, targetDiv, request, true, hipsImageConversion, userCanDelete);
 
 
     /**
@@ -538,38 +548,94 @@ function showImageOrHiPSInMultiViewer(llApi, targetDiv, hipsRequest, imageReques
 }
 
 
+var firstShowImage= false;
+var imageRenderType;
 
-function showImageInMultiViewer(llApi, targetDiv, request, isHiPS, hipsImageConversion) {
-    const {dispatchPlotImage, dispatchPlotHiPS, dispatchAddViewer}= llApi.action;
+
+function showImageInMultiViewer(llApi, targetDiv, request, isHiPS, hipsImageConversion, userCanDelete=true) {
+    const {dispatchPlotImage, dispatchPlotHiPS, dispatchAddViewer, dispatchUpdateCustom}= llApi.action;
     const {IMAGE, NewPlotMode}= llApi.util.image;
     const {renderDOM}= llApi.util;
-    const {MultiImageViewer, MultiViewStandardToolbar}= llApi.ui;
-
-    highlevelImageInit(llApi);
-
+    const {MultiImageViewer, ApiFullImageDisplay, MultiViewStandardToolbar}= llApi.ui;
     request = validatePlotRequest(llApi, targetDiv, request);
-
     const plotId= getPlotIdFromRequest(request);
+    const viewerId= targetDiv;
+
+
+    if (!firstShowImage) {
+        firstShowImage= true;
+        imageRenderType= globalPrefs.imageDisplayType;
+        if (imageRenderType===STANDARD) highlevelImageInit(llApi);
+    }
+
+
     dispatchAddViewer(targetDiv, NewPlotMode.create_replace.key, IMAGE);
+    dispatchUpdateCustom(viewerId, {independentLayout: true});
 
 
-   if (isHiPS) {
+    if (isHiPS) {
         request.Type= 'HiPS';
         if (hipsImageConversion && !hipsImageConversion.hipsRequestRoot) {
             hipsImageConversion.hipsRequestRoot= request;
         }
-        dispatchPlotHiPS({plotId, wpRequest:request, viewerId:targetDiv, hipsImageConversion});
+        dispatchPlotHiPS({plotId, wpRequest:request, viewerId,
+            hipsImageConversion, pvOptions: { userCanDeletePlots: userCanDelete}
+        });
     }
     else {
         if (hipsImageConversion && !hipsImageConversion.imageRequestRoot) {
             hipsImageConversion.imageRequestRoot= request;
         }
-        dispatchPlotImage({plotId, wpRequest:request, viewerId:targetDiv, hipsImageConversion});
+        dispatchPlotImage({plotId, wpRequest:request, viewerId,
+            hipsImageConversion, pvOptions: { userCanDeletePlots: userCanDelete}
+        });
     }
 
-    renderDOM(targetDiv, MultiImageViewer,
-        {viewerId:targetDiv, canReceiveNewPlots:NewPlotMode.create_replace.key, Toolbar:MultiViewStandardToolbar });
+    if (imageRenderType===STANDARD) {
+        renderDOM(targetDiv, MultiImageViewer,
+            {viewerId,  canReceiveNewPlots:NewPlotMode.create_replace.key, Toolbar:MultiViewStandardToolbar });
+    }
+    else {
+        renderDOM(targetDiv, ApiFullImageDisplay,
+            {viewerId, renderTreeId:viewerId, canReceiveNewPlots:NewPlotMode.create_replace.key, Toolbar:MultiViewStandardToolbar });
+    }
+
 }
+
+
+// function showImageInMultiViewer(llApi, targetDiv, request, isHiPS, hipsImageConversion) {
+//     const {dispatchPlotImage, dispatchPlotHiPS, dispatchAddViewer}= llApi.action;
+//     const {IMAGE, NewPlotMode}= llApi.util.image;
+//     const {renderDOM}= llApi.util;
+//     const {MultiImageViewer, MultiViewStandardToolbar}= llApi.ui;
+//
+//     highlevelImageInit(llApi);
+//
+//     request = validatePlotRequest(llApi, targetDiv, request);
+//
+//     const plotId= getPlotIdFromRequest(request);
+//     dispatchAddViewer(targetDiv, NewPlotMode.create_replace.key, IMAGE);
+//
+//
+//     if (isHiPS) {
+//         request.Type= 'HiPS';
+//         if (hipsImageConversion && !hipsImageConversion.hipsRequestRoot) {
+//             hipsImageConversion.hipsRequestRoot= request;
+//         }
+//         dispatchPlotHiPS({plotId, wpRequest:request, viewerId:targetDiv, hipsImageConversion});
+//     }
+//     else {
+//         if (hipsImageConversion && !hipsImageConversion.imageRequestRoot) {
+//             hipsImageConversion.imageRequestRoot= request;
+//         }
+//         dispatchPlotImage({plotId, wpRequest:request, viewerId:targetDiv, hipsImageConversion});
+//     }
+//
+//     renderDOM(targetDiv, MultiImageViewer,
+//         {viewerId:targetDiv, canReceiveNewPlots:NewPlotMode.create_replace.key, Toolbar:MultiViewStandardToolbar });
+// }
+
+
 
 
 function initCoverage(llApi, targetDiv,options= {}) {
@@ -592,7 +658,7 @@ function initCoverage(llApi, targetDiv,options= {}) {
 var imageInit= false;
 function highlevelImageInit(llApi) {
     if (!imageInit) {
-        llApi.util.image.dispatchApiToolsView(true);
+        llApi.action.dispatchApiToolsView(true);
         llApi.util.image.initAutoReadout();
         imageInit= true;
     }

--- a/src/firefly/js/api/ApiUtil.js
+++ b/src/firefly/js/api/ApiUtil.js
@@ -26,7 +26,7 @@ export {ServerParams} from  '../data/ServerParams.js';
 
 export {getWsConnId, getWsChannel} from '../core/AppDataCntlr.js';
 
-export {getVersion} from '../Firefly.js';
+export {startAsAppFromApi, getVersion} from '../Firefly.js';
 
 /**
  * show a debug message if debugging is enabled
@@ -63,6 +63,10 @@ export function renderDOM(div, Component, props) {
     );
 
     ReactDOM.render(renderStuff,divElement);
+}
+
+export function unrender(Component) {
+    ReactDOM.unmountComponentAtNode(Component)
 }
 
 

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -39,7 +39,7 @@ const API_READOUT= 'apiReadout';
 export {RangeValues} from '../visualize/RangeValues.js';
 export {WPConst, WebPlotRequest, findInvalidWPRKeys, confirmPlotRequest} from '../visualize/WebPlotRequest.js';
 export {RequestType} from '../visualize/RequestType';
-export {ExpandType, dispatchApiToolsView} from '../visualize/ImagePlotCntlr.js';
+export {ExpandType, visRoot} from '../visualize/ImagePlotCntlr.js';
 
 export {CysConverter} from '../visualize/CsysConverter.js';
 export {CCUtil} from '../visualize/CsysConverter.js';

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -220,7 +220,7 @@ export function dispatchChartUnmounted(chartId, dispatcher= flux.process) {
 
 function chartAdd(action) {
     return (dispatch) => {
-        const {chartId, chartType, deletable} = action.payload;
+        const {chartId, chartType, deletable, renderTreeId} = action.payload;
         clearChartConn({chartId});
 
         if (chartType === 'plot.ly') {
@@ -235,7 +235,7 @@ function chartAdd(action) {
             const {viewerId, data, fireflyData} = actionToDispatch.payload;
             if (viewerId) {
                 // viewer will be added if it does not exist already
-                dispatchAddViewerItems(viewerId, [chartId], 'plot2d');
+                dispatchAddViewerItems(viewerId, [chartId], 'plot2d', renderTreeId);
             }
 
             // lazy table connection

--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -53,11 +53,11 @@ function getChartActions({chartId, tbl_id}) {
 }
 
 
-function onChartAction({chartAction, tbl_id, chartId, hideDialog}) {
+function onChartAction({chartAction, tbl_id, chartId, hideDialog, renderTreeId}) {
     return (fields) => {
         switch (chartAction) {
             case CHART_ADDNEW:
-                addNewTrace({fields, tbl_id, hideDialog}); // no chart id
+                addNewTrace({fields, tbl_id, hideDialog, renderTreeId}); // no chart id
                 break;
             case CHART_TRACE_ADDNEW:
                 addNewTrace({fields, tbl_id, chartId, hideDialog});
@@ -130,6 +130,7 @@ export class ChartSelectPanel extends SimpleComponent {
     render() {
 
         const {tbl_id, chartId, inputStyle={}, hideDialog, showMultiTrace} = this.props;
+        const {renderTreeId}= this.context;
 
         const chartActions = getChartActions({chartId, tbl_id});
         const {chartAction} = this.state;
@@ -141,7 +142,7 @@ export class ChartSelectPanel extends SimpleComponent {
                 <FormPanel
                     groupKey={groupKey}
                     submitText={chartAction===CHART_TRACE_MODIFY ? 'Apply' : 'OK'}
-                    onSuccess={onChartAction({chartAction, tbl_id, chartId, hideDialog})}
+                    onSuccess={onChartAction({chartAction, tbl_id, chartId, hideDialog, renderTreeId})}
                     cancelText='Close'
                     onError={() => {}}
                     onCancel={hideDialog}
@@ -166,6 +167,9 @@ ChartSelectPanel.propTypes = {
 ChartSelectPanel.defaultProps = {
     showMultiTrace: true,
 
+};
+ChartSelectPanel.contextTypes= {
+    renderTreeId: PropTypes.string
 };
 
 function ChartAction(props) {

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -32,7 +32,8 @@ export class MultiChartViewer extends PureComponent {
 
     componentWillReceiveProps(nextProps) {
         if (this.props.viewerId!==nextProps.viewerId) {
-            dispatchAddViewer(nextProps.viewerId,nextProps.canReceiveNewItems,PLOT2D,true);
+            const {renderTreeId}= this.context;
+            dispatchAddViewer(nextProps.viewerId,nextProps.canReceiveNewItems,PLOT2D,true,renderTreeId);
             dispatchViewerUnmounted(this.props.viewerId);
         } else if (nextProps.expandedMode && this.props.expandedMode!==nextProps.expandedMode) {
             const {chartId} = getExpandedChartProps();
@@ -49,8 +50,9 @@ export class MultiChartViewer extends PureComponent {
     }
 
     componentWillMount() {
-        var {viewerId, canReceiveNewItems, expandedMode}= this.props;
-        dispatchAddViewer(viewerId,canReceiveNewItems,PLOT2D,true);
+        const {viewerId, canReceiveNewItems, expandedMode}= this.props;
+        const {renderTreeId}= this.context;
+        dispatchAddViewer(viewerId,canReceiveNewItems,PLOT2D,true, renderTreeId);
         if (expandedMode) {
             const {chartId} = getExpandedChartProps();
             dispatchUpdateCustom(viewerId, {activeItemId: chartId});
@@ -150,6 +152,9 @@ export class MultiChartViewer extends PureComponent {
 
 const stopPropagation= (ev) => ev.stopPropagation();
 
+MultiChartViewer.contextTypes= {
+    renderTreeId: PropTypes.string
+};
 
 MultiChartViewer.propTypes= {
     viewerId : PropTypes.string,

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -23,6 +23,7 @@ import {getColValStats} from '../../TableStatsCntlr.js';
 import {getColValidator} from '../ColumnOrExpression.jsx';
 import {uniqueChartId, TRACE_COLORS, toRGBA, colorsOnTypes} from '../../ChartUtil.js';
 import {colorscaleNameToVal} from '../../Colorscale.js';
+import {DEFAULT_PLOT2D_VIEWER_ID} from '../../../visualize/MultiViewCntlr.js';
 
 import MAGNIFYING_GLASS from 'html/images/icons-2014/magnifyingGlass.png';
 import {ToolbarButton} from '../../../ui/ToolbarButton.jsx';
@@ -85,6 +86,10 @@ function hasNoXY(type, tablesource) {
     return (!get(tablesource, ['mappings', 'x']) || !get(tablesource, ['mappings', 'y']));
 }
 
+function findViewerId(viewerId= DEFAULT_PLOT2D_VIEWER_ID, renderTreeId= undefined) {
+    if (viewerId===DEFAULT_PLOT2D_VIEWER_ID && renderTreeId) return `${viewerId}_${renderTreeId}`;
+    return viewerId;
+}
 
 function isNonNumColumn(tbl_id, colExp) {
     const numTypes = ['double', 'd', 'long', 'l', 'int', 'i', 'float', 'f'];
@@ -470,8 +475,9 @@ BasicOptionFields.propTypes = {
  * @param {string} p.chartId
  * @param {object} p.fields
  * @param {string} p.tbl_id
+ * @param {string} p.renderTreeId
  */
-export function submitChanges({chartId, fields, tbl_id}) {
+export function submitChanges({chartId, fields, tbl_id, renderTreeId}) {
     if (!fields) return;                // fields failed validations..  quick/dirty.. may need to separate the logic later.
     if (!chartId) chartId = uniqueChartId();
     const {layout={}, data=[], fireflyData, activeTrace:traceNum=0} = getChartData(chartId, {});
@@ -583,7 +589,9 @@ export function submitChanges({chartId, fields, tbl_id}) {
         // create chart data from changes and add chart
         const newChartData = {chartId, groupId: tbl_id};
         Object.entries(changes).forEach(([k,v]) => set(newChartData, k, v));
-        dispatchChartAdd({chartId, chartType: 'plot.ly', groupId: tbl_id, ...newChartData});
+        dispatchChartAdd({chartId, chartType: 'plot.ly', groupId: tbl_id, renderTreeId,
+            viewerId: findViewerId(DEFAULT_PLOT2D_VIEWER_ID,renderTreeId),
+            ...newChartData});
     } else {
         // update chart from options scenario
         dispatchChartUpdate({chartId, changes});

--- a/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
@@ -37,9 +37,9 @@ export class FireflyHistogramOptions extends SimpleComponent {
     }
 }
 
-export function submitChangesFFHistogram({chartId, activeTrace, fields, tbl_id}) {
+export function submitChangesFFHistogram({chartId, activeTrace, fields, tbl_id, renderTreeId}) {
     const changes = histogramOptionsToChanges(activeTrace, fields, tbl_id);
-    submitChanges({chartId, fields: changes, tbl_id});
+    submitChanges({chartId, fields: changes, tbl_id, renderTreeId});
 }
 
 function histogramOptionsToChanges(activeTrace, fields, tbl_id) {

--- a/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
+++ b/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
@@ -160,7 +160,7 @@ export function TableSourcesOptions({tablesource={}, activeTrace, groupKey}) {
     );
 }
 
-export function submitChangesHeatmap({chartId, activeTrace, fields, tbl_id}) {
+export function submitChangesHeatmap({chartId, activeTrace, fields, tbl_id, renderTreeId}) {
     const dataType = (!tbl_id) ? 'heatmap' : 'fireflyHeatmap';
     const changes = {
         [`data.${activeTrace}.type`] : 'heatmap',
@@ -172,6 +172,6 @@ export function submitChangesHeatmap({chartId, activeTrace, fields, tbl_id}) {
     // reversescale is boolean
     changes[`data.${activeTrace}.reversescale`] = toBoolean(get(fields, `data.${activeTrace}.reversescale`));
 
-    submitChanges({chartId, fields: changes, tbl_id});
+    submitChanges({chartId, fields: changes, tbl_id, renderTreeId});
 }
 

--- a/src/firefly/js/charts/ui/options/NewTracePanel.jsx
+++ b/src/firefly/js/charts/ui/options/NewTracePanel.jsx
@@ -62,7 +62,7 @@ export function getNewTraceType() {
     return getFieldVal('new-trace', 'type') || 'scatter';
 }
 
-export function addNewTrace({chartId, tbl_id, fields, hideDialog}) {
+export function addNewTrace({chartId, tbl_id, fields, hideDialog, renderTreeId}) {
     const type = getNewTraceType();
     const submitChangesFunc =  getSubmitChangesFunc(type);
     const data = get(getChartData(chartId), 'data', []);
@@ -78,7 +78,7 @@ export function addNewTrace({chartId, tbl_id, fields, hideDialog}) {
     // need to hide before the changes are submitted to avoid React Internal error:
     //    too much recursion (mounting/unmouting fields)
     hideDialog();
-    submitChangesFunc({chartId, activeTrace, fields, tbl_id});
+    submitChangesFunc({chartId, activeTrace, fields, tbl_id, renderTreeId});
 }
 
 export class NewTracePanel extends SimpleComponent {

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -261,7 +261,7 @@ TableSourcesOptions.propTypes = {
     showMultiTrace: PropTypes.bool
 };
 
-export function submitChangesScatter({chartId, activeTrace, fields, tbl_id}) {
+export function submitChangesScatter({chartId, activeTrace, fields, tbl_id, renderTreeId}) {
 
     // trace type can switch between scatter and scattergl depending on the number of points
     const changes = {[`data.${activeTrace}.type`] : getTraceType(chartId, tbl_id, activeTrace)};
@@ -280,7 +280,7 @@ export function submitChangesScatter({chartId, activeTrace, fields, tbl_id}) {
     }
 
     Object.assign(changes, fields);
-    submitChanges({chartId, fields: changes, tbl_id});
+    submitChanges({chartId, fields: changes, tbl_id, renderTreeId});
 }
 
 /**

--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -74,13 +74,21 @@
  * @prop {boolean}  showTables  show tables panel
  * @prop {boolean}  showXyPlots show charts panel
  * @prop {boolean}  showImages  show images panel
+ * @prop {Object.<string, GridViewData>} gridViewsData used only with the grid view, undefined for other views
+ */
+
+
+/**
+ *
+ * @typedef {Object} GridViewData
  * @prop {Array.<GridViewEntry>} gridView used only with the grid view, undefined for other views
+ * @prop {number} gridColumns number of columns in this grid View
  */
 
 
 /**
  * Entry for grid layout. These entries are stored in an array by LayoutCntlr
- * @typedef GridViewEntry
+ * @typedef {Object} GridViewEntry
  * @prop {LO_VIEW} type
  * @prop {string} cellId
  * @prop {number} row

--- a/src/firefly/js/core/messaging/WebSocketClient.js
+++ b/src/firefly/js/core/messaging/WebSocketClient.js
@@ -46,10 +46,13 @@ export function wsConnect(callback, baseUrl=getRootURL()) {
     baseUrl = baseUrl.replace('https:', 'wss:').replace('http:', 'ws:');
 
     const urlInfo = parseUrl(document.location);
-    var wsch = get(urlInfo,['searchObject', WSCH]);
-    wsch = wsch ? `?${CH_ID}=${wsch}` : '';
+    let wsch = get(urlInfo,['searchObject', WSCH], ''); // get channel from url
 
-    const wsUrl = `${baseUrl}/sticky/firefly/events${wsch}`;
+    if (!wsch && get(window,'firefly.wsch')) { // if not defined, try window.firefly
+        wsch= window.firefly.wsch;
+    }
+    const wschParam = wsch ? `?${CH_ID}=${wsch}` : '';
+    const wsUrl = `${baseUrl}/sticky/firefly/events${wschParam}`;
     console.log('Connecting to ' + wsUrl);
     makeConnection(wsUrl);
     pinger = makePinger(callback, wsUrl);

--- a/src/firefly/js/data/ServerRequest.js
+++ b/src/firefly/js/data/ServerRequest.js
@@ -5,7 +5,7 @@
 import {has} from 'lodash';
 import validator from 'validator';
 import {parseWorldPt} from '../visualize/Point.js';
-import {replaceAll} from '../util/WebUtil.js';
+import {replaceAll, isDefined} from '../util/WebUtil.js';
 
 
 const REQUEST_CLASS= 'RequestClass';
@@ -184,7 +184,7 @@ export class ServerRequest {
     toString() {
         var idStr= (ID_KEY+KW_VAL_SEP+this.params[ID_KEY]);
         var retStr= Object.keys(this.params).sort().reduce((str,key) => {
-            if (key!==ID_KEY) str+= PARAM_SEP+key+KW_VAL_SEP+this.params[key];
+            if (key!==ID_KEY && isDefined(this.params[key])) str+= PARAM_SEP+key+KW_VAL_SEP+this.params[key];
             return str;
         },idStr);
         return retStr;

--- a/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
+++ b/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
@@ -9,95 +9,88 @@ import {startImageMetadataWatcher} from '../../visualize/saga/ImageMetaDataWatch
 import {startCoverageWatcher} from '../../visualize/saga/CoverageWatcher.js';
 
 import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, ENABLE_SPECIAL_VIEWER, SPECIAL_VIEWER,
-          getLayouInfo, dispatchUpdateLayoutInfo, dispatchAddCell, dispatchRemoveCell, getNextCell} from '../../core/LayoutCntlr.js';
+          getLayouInfo, dispatchUpdateLayoutInfo,
+          dispatchAddCell, dispatchRemoveCell, getNextCell, getGridView} from '../../core/LayoutCntlr.js';
 import {findGroupByTblId, getTblIdsByGroup, getTblById} from '../../tables/TableUtil.js';
 import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE, TABLE_SORT} from '../../tables/TablesCntlr.js';
 import {dispatchLoadTblStats} from '../../charts/TableStatsCntlr';
 
 import {CHART_ADD, CHART_REMOVE} from '../../charts/ChartsCntlr.js';
+import {clone} from '../../util/WebUtil.js';
 
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
-import {REPLACE_VIEWER_ITEMS, IMAGE, getViewerItemIds, getMultiViewRoot, findViewerWithItemId} from '../../visualize/MultiViewCntlr.js';
+import {REPLACE_VIEWER_ITEMS, IMAGE, getViewerItemIds, getMultiViewRoot, getViewer, findViewerWithItemId} from '../../visualize/MultiViewCntlr.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
+import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../../core/MasterSaga.js';
+
+
+export function startLayoutManager(id, params) {
+
+    const actions = [
+        ImagePlotCntlr.PLOT_IMAGE_START, ImagePlotCntlr.PLOT_IMAGE,
+        ImagePlotCntlr.DELETE_PLOT_VIEW, REPLACE_VIEWER_ITEMS,
+        TABLE_REMOVE, TABLE_LOADED, TBL_RESULTS_ADDED, TBL_RESULTS_ACTIVE,
+        CHART_ADD, CHART_REMOVE,
+        SHOW_DROPDOWN, SET_LAYOUT_MODE, ENABLE_SPECIAL_VIEWER
+    ];
+    dispatchAddActionWatcher({id, actions, callback: layoutManager, params});
+    const stopLayoutManger= () => dispatchCancelActionWatcher(id);
+    return stopLayoutManger;
+}
+
+
+
 
 /**
  * this manager manages what main components get display on the screen.
  * These main components are image plots, charts, tables, dropdown panel, etc.
  * This manager implements the default firefly viewer's requirements.
  * Because it may differs between applications, it is okay to have a custom layout manager if needed.
- * @param {object} p
- * @param {string} [p.title] title to display
- * @param {string} [p.views] defaults to tri-view if not given.
+ * @param {Action} action
+ * @param {Function} cancelSelf
+ * @param {Object} params
  */
-export function* layoutManager({title}) {
+function layoutManager(action, cancelSelf, params) {
 
-    let alreadyStartSagas= [];
+    let {alreadyStartSagas= [], renderTreeId}= params;
 
-    while (true) {
-        const action = yield take([
-            ImagePlotCntlr.PLOT_IMAGE_START, ImagePlotCntlr.PLOT_IMAGE,
-            ImagePlotCntlr.DELETE_PLOT_VIEW, REPLACE_VIEWER_ITEMS,
-            TABLE_REMOVE, TABLE_LOADED, TBL_RESULTS_ADDED, TBL_RESULTS_ACTIVE,
-            CHART_ADD, CHART_REMOVE,
-            SHOW_DROPDOWN, SET_LAYOUT_MODE, ENABLE_SPECIAL_VIEWER
-        ]);
+    const layoutInfo = getLayouInfo();
+    let newLayoutInfo = layoutInfo;
 
-        /**
-         * This is the current state of the layout store.  Action handlers should return newLayoutInfo if state changes
-         * If state has changed, it will be dispatched into the flux.
-         * @type {LayoutInfo}
-         * @prop {boolean}  layoutInfo.showTables  show tables panel
-         * @prop {boolean}  layoutInfo.showXyPlots show charts panel
-         * @prop {boolean}  layoutInfo.showImages  show images panel
-         * @prop {string}   layoutInfo.searchDesc  optional string describing search criteria used to generate this result.
-         * @prop {boolean}  layoutInfo.autoExpand  this is true when manager think it should be expanded, ie. single view
-         * @prop {Object}   layoutInfo.images      images specific states
-         * @prop {string}   layoutInfo.images.metaTableId  tbl_id of the image meta table
-         * @prop {string}   layoutInfo.images.selectedTab  selected tab of the images tabpanel
-         * @prop {string}   layoutInfo.images.showCoverage  show images coverage tab
-         * @prop {string}   layoutInfo.images.showFits  show images fits data tab
-         * @prop {string}   layoutInfo.images.showMeta  show images image metea tab
-         * @prop {string}   layoutInfo.images.coverageLockedOn
-         */
-        var layoutInfo = getLayouInfo();
-        var newLayoutInfo = layoutInfo;
+    switch (action.type) {
+        case ImagePlotCntlr.PLOT_IMAGE_START:
+        case ImagePlotCntlr.PLOT_IMAGE :
+        case REPLACE_VIEWER_ITEMS:
 
-        switch (action.type) {
-            case ImagePlotCntlr.PLOT_IMAGE_START:
-            case ImagePlotCntlr.PLOT_IMAGE :
-            case REPLACE_VIEWER_ITEMS:
-
-                newLayoutInfo = handleNewImage(newLayoutInfo, action);
-                break;
-            case ImagePlotCntlr.DELETE_PLOT_VIEW:
-                newLayoutInfo = handlePlotDelete(newLayoutInfo, action);
-                break;
-            case TBL_RESULTS_ADDED:
-                newLayoutInfo = handleNewTable(newLayoutInfo, action);
-                break;
-            case TABLE_LOADED:
-                newLayoutInfo = handleTableLoaded(newLayoutInfo, action);
-                break;
-            case TABLE_REMOVE:
-                newLayoutInfo = handleTableDelete(newLayoutInfo, action);
-                break;
-            case CHART_ADD:
-                newLayoutInfo = handleNewChart(newLayoutInfo, action);
-                break;
-            case CHART_REMOVE:
-                newLayoutInfo = handleChartDelete(newLayoutInfo, action);
-                break;
-            case ENABLE_SPECIAL_VIEWER:
-                const startCellId= startSpecialViewerSaga(action, alreadyStartSagas);
-                if (startCellId) alreadyStartSagas= [...alreadyStartSagas,startCellId];
-                break;
-        }
-
-
-        if (newLayoutInfo !== layoutInfo) {
-            dispatchUpdateLayoutInfo(newLayoutInfo);
-        }
+            newLayoutInfo = handleNewImage(newLayoutInfo, action, renderTreeId);
+            break;
+        case ImagePlotCntlr.DELETE_PLOT_VIEW:
+            newLayoutInfo = handlePlotDelete(newLayoutInfo, action, renderTreeId);
+            break;
+        case TBL_RESULTS_ADDED:
+            newLayoutInfo = handleNewTable(newLayoutInfo, action, renderTreeId);
+            break;
+        case TABLE_LOADED:
+            newLayoutInfo = handleTableLoaded(newLayoutInfo, action, renderTreeId);
+            break;
+        case TABLE_REMOVE:
+            newLayoutInfo = handleTableDelete(newLayoutInfo, action, renderTreeId);
+            break;
+        case CHART_ADD:
+            newLayoutInfo = handleNewChart(newLayoutInfo, action, renderTreeId);
+            break;
+        case CHART_REMOVE:
+            newLayoutInfo = handleChartDelete(newLayoutInfo, action, renderTreeId);
+            break;
+        case ENABLE_SPECIAL_VIEWER:
+            const startCellId= startSpecialViewerSaga(action, alreadyStartSagas, renderTreeId);
+            if (startCellId) alreadyStartSagas= [...alreadyStartSagas,startCellId];
+            break;
     }
+    if (newLayoutInfo !== layoutInfo) {
+        dispatchUpdateLayoutInfo(newLayoutInfo);
+    }
+    return clone(params, {alreadyStartSagas});
 }
 
 
@@ -120,21 +113,21 @@ function startSpecialViewerSaga(action, alreadyStarted) {
     return cellId;
 }
 
-function handleNewTable(layoutInfo, action) {
+function handleNewTable(layoutInfo, action, renderTreeId) {
     const {tbl_id} = action.payload;
-    const {gridView=[]}= layoutInfo;
+    const gridView= getGridView(layoutInfo, renderTreeId);
     const tbl_group= findGroupByTblId(tbl_id);
     if (tbl_group) {
         const item= gridView.find( (g) => g.cellId===tbl_group);
         if (!item) {
             const cell= getNextCell(gridView,2,1);
-            dispatchAddCell({row:cell.row,col:cell.col,width:2,height:1,cellId:tbl_group,type:LO_VIEW.tables});
+            dispatchAddCell({row:cell.row,col:cell.col,width:2,height:1,cellId:tbl_group,type:LO_VIEW.tables, renderTreeId});
         }
     }
     return layoutInfo;
 }
 
-function handleTableLoaded(layoutInfo, action) {
+function handleTableLoaded(layoutInfo, action, renderTreeId) {
     const {tbl_id, invokedBy} = action.payload;
     const table= getTblById(tbl_id);
     if (table && invokedBy !== TABLE_SORT &&  !table.origTableModel) {
@@ -142,34 +135,34 @@ function handleTableLoaded(layoutInfo, action) {
     }
 }
 
-function handleTableDelete(layoutInfo, action) {
+function handleTableDelete(layoutInfo, action, renderTreeId) {
     const {tbl_group}= action.payload;
     const tblIdAry= getTblIdsByGroup(tbl_group);
     if (tbl_group && isEmpty(tblIdAry)) {
-        dispatchRemoveCell({cellId:tbl_group});
+        dispatchRemoveCell({cellId:tbl_group, renderTreeId});
     }
 }
 
-function handlePlotDelete(layoutInfo, action) {
+function handlePlotDelete(layoutInfo, action, renderTreeId) {
     const {viewerId}= action.payload;
     const itemAry= getViewerItemIds(getMultiViewRoot(), viewerId);
     if (isEmpty(itemAry)) {
-        dispatchRemoveCell({cellId:viewerId});
+        dispatchRemoveCell({cellId:viewerId, renderTreeId});
     }
 }
 
-function handleChartDelete(layoutInfo, action) {
+function handleChartDelete(layoutInfo, action, renderTreeId) {
     const {viewerId}= action.payload;
     const itemAry= getViewerItemIds(getMultiViewRoot(), viewerId);
     if (isEmpty(itemAry)) {
-        dispatchRemoveCell({cellId:viewerId});
+        dispatchRemoveCell({cellId:viewerId, renderTreeId});
     }
 }
 
 
-function handleNewImage(layoutInfo, action) {
+function handleNewImage(layoutInfo, action, renderTreeId) {
     const {payload}= action;
-    const {gridView=[]}= layoutInfo;
+    const gridView= getGridView(layoutInfo, renderTreeId);
     const mvRoot= getMultiViewRoot();
     let wpRequestAry;
     if (payload.wpRequestAry) { // multi image case
@@ -189,28 +182,51 @@ function handleNewImage(layoutInfo, action) {
     const plotIdAry= uniq(wpRequestAry.map( (r) => r.getPlotId() ));
 
     plotIdAry.forEach( (plotId) => {
-        const viewer= findViewerWithItemId(mvRoot, plotId, IMAGE);
-        if (viewer) {
-             const item= gridView.find( (g) => g.cellId===viewer);
-             if (!item) {
-                 const cell= getNextCell(gridView,2,2);
-                 dispatchAddCell({row:cell.row,col:cell.col,width:2,height:2,cellId:viewer,type:LO_VIEW.images});
-             }
+        const viewerId= findViewerWithItemId(mvRoot, plotId, IMAGE);
+        const viewer= viewerId && getViewer(mvRoot, viewerId);
+        console.log(`handleNewImage: ${renderTreeId}: v: ${viewer && viewer.renderTreeId}, p: ${payload.renderTreeId}`)
+        if (!viewer) return;
+        if (isUnmatchingLayout(renderTreeId,viewer, payload)) return layoutInfo;
+        if (viewer.customData.independentLayout) return;
+        
+        const item= gridView.find( (g) => g.cellId===viewer.viewerId);
+        if (!item) {
+            const cell= getNextCell(gridView,2,2);
+            dispatchAddCell({row:cell.row,col:cell.col,width:2,height:2,cellId:viewer.viewerId,type:LO_VIEW.images, renderTreeId});
         }
     });
 
     return layoutInfo;
 }
 
-function handleNewChart(layoutInfo, action) {
 
-    const {viewerId}= action.payload;
-    const {gridView=[]}= layoutInfo;
+function isUnmatchingLayout(renderTreeId, viewer, payload) {
+    if (!renderTreeId) return false;
+
+    if ((viewer.renderTreeId && renderTreeId!==viewer.renderTreeId) ||
+        (payload.renderTreeId && renderTreeId!==payload.renderTreeId))  {
+        return true;
+    }
+    return false;
+}
+
+
+
+
+function handleNewChart(layoutInfo, action, renderTreeId) {
+
+    const {payload}= action;
+    const {viewerId}= payload;
+    const gridView= getGridView(layoutInfo, renderTreeId);
 
     const item= gridView.find( (g) => g.cellId===viewerId);
+    if (renderTreeId && payload.renderTreeId && renderTreeId!==payload.renderTreeId) {
+        return layoutInfo;
+    }
+    
     if (!item) {
         const cell= getNextCell(gridView,3,1);
-        dispatchAddCell({row:cell.row,col:cell.col,width:1,height:1,cellId:viewerId,type:LO_VIEW.xyPlots});
+        dispatchAddCell({row:cell.row,col:cell.col,width:1,height:1,cellId:viewerId,type:LO_VIEW.xyPlots, renderTreeId});
     }
 
     return layoutInfo;

--- a/src/firefly/js/templates/fireflyslate/GridLayoutPanel.jsx
+++ b/src/firefly/js/templates/fireflyslate/GridLayoutPanel.jsx
@@ -13,7 +13,7 @@ import {MultiImageViewer} from '../../visualize/ui/MultiImageViewer.jsx';
 import {MultiViewStandardToolbar} from '../../visualize/ui/MultiViewStandardToolbar.jsx';
 import {MultiChartViewer} from '../../charts/ui/MultiChartViewer.jsx';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
-import {LO_VIEW, getGridDim, dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
+import {LO_VIEW, getGridDim, dispatchUpdateGridView} from '../../core/LayoutCntlr.js';
 import {NewPlotMode} from '../../visualize/MultiViewCntlr.js';
 
 import './react-grid-layout_styles.css';
@@ -81,6 +81,7 @@ class SlateView extends Component {
     renderedLayoutUpdated(layout) {
 
         const {gridView}= this.props;
+        const {renderTreeId}= this.context;
 
         const nextGridView= gridView.map( (entry) => {
             const l= layout.find( (le) => le.i===entry.cellId);
@@ -89,7 +90,7 @@ class SlateView extends Component {
 
         //-------
         // todo dispatch the new view
-        dispatchUpdateLayoutInfo({gridView:nextGridView});
+        dispatchUpdateGridView(nextGridView, renderTreeId);
     }
 
     dragStart() {
@@ -100,6 +101,8 @@ class SlateView extends Component {
         const {gridView,size:{width,height}, gridColumns}= this.props;
         this.renderedGridView= gridView;
 
+
+        console.log(`grid view: ${gridView.length},  ${width}x${height}`);
 
         if (isEmpty(gridView) || width<10 || height<10) return <div  style={{flex: '1 1 auto', overflow: 'auto'}}/>;
 
@@ -143,6 +146,10 @@ SlateView.propTypes= {
     size: PropTypes.object.isRequired,
     gridColumns : PropTypes.number.isRequired
 };
+SlateView.contextTypes= {
+    renderTreeId: PropTypes.string
+};
+
 
 const sizeMeHOC = sizeMe(config);
 
@@ -150,8 +157,10 @@ export const GridLayoutPanel= sizeMeHOC(SlateView);
 
 GridLayoutPanel.propTypes= {
     gridView : PropTypes.array.isRequired,
-    gridColumns : PropTypes.number.isRequired
+    gridColumns : PropTypes.number.isRequired,
 };
+
+
 
 
 

--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -5,9 +5,9 @@
 //-----------------
 import PositionParser from '../util/PositionParser';
 import PositionFieldDef from '../data/form/PositionFieldDef';
-import {getRootPath} from '../util/BrowserUtil.js';
 import {fetchUrl} from '../util/WebUtil.js';
 import {parseWorldPt} from '../visualize/Point';
+import {getRootURL} from '../util/BrowserUtil';
 
 
 export {formatPosForTextField} from '../data/form/PositionFieldDef.js';
@@ -55,7 +55,7 @@ function makeResolverPromise(objName, resolver) {
 
 function makeSearchPromise(objName, resolver= 'nedthensimbad') {
     let rejectFunc= null;
-    const url= `${getRootPath()}sticky/CmdSrv?objName=${objName}&resolver=${resolver}&cmd=CmdResolveName`;
+    const url= `${getRootURL()}sticky/CmdSrv?objName=${objName}&resolver=${resolver}&cmd=CmdResolveName`;
     const searchPromise= new Promise(
         function(resolve, reject) {
             let fetchOptions = {};

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -39,6 +39,10 @@ export function getProp(key, def) {
     return get(GLOBAL_PROPS, [key], def);
 }
 
+
+
+export const isDefined= (x) => x!==undefined;
+
 /**
  * returns an object of key:value where keyPrefix is removed from the keys.  i.e
  * <code>

--- a/src/firefly/js/visualize/BandState.js
+++ b/src/firefly/js/visualize/BandState.js
@@ -162,7 +162,9 @@ export class BandState {
         if (bs.uploadFileNameStr) json.uploadFileNameStr= bs.uploadFileNameStr;
         if (bs.imageIdx) json.imageIdx= bs.imageIdx;
         if (bs.originalImageIdx) json.originalImageIdx= bs.originalImageIdx;
-        json.plotRequestSerialize= bs.plotRequestSerialize;
+        json.plotRequestSerialize= bs.getWebPlotRequest().toStringServerSideOnly();
+
+
         json.rangeValuesSerialize= bs.rangeValuesSerialize;
         if (includeDirectAccessData) json.directFileAccessData= bs.directFileAccessData;
         if (bs.multiImageFile) json.multiImageFile= bs.multiImageFile;

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -1445,6 +1445,12 @@ export class WebPlotRequest extends ServerRequest {
 
     getPlotDescAppend() { return this.getParam(C.PLOT_DESC_APPEND); }
 
+    toStringServerSideOnly() {
+        const retReq= this.makeCopy();
+        clientSideKeys.forEach( (k) => retReq.params[k]= undefined);
+        return retReq.toString();
+    }
+
     /**
      * @return boolean
      */

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -199,9 +199,9 @@ function makeInlineRightToolbar(visRoot,pv,dlAry,mousePlotId, handleInlineTools,
             return false;
         }
     }
-    const lVis= BrowserInfo.isTouchInput() || (visRoot.apiToolsView && mousePlotId===pv.plotId);
+    const lVis= BrowserInfo.isTouchInput() || (visRoot.useFloatToolbar && mousePlotId===pv.plotId);
     const exVis= BrowserInfo.isTouchInput() || mousePlotId===pv.plotId;
-    const tb= !isExpanded && visRoot.apiToolsView;
+    const tb= !isExpanded && visRoot.useFloatToolbar;
     const style= (lVis || tb) && handleInlineTools ? bgFFGray : bgSlightGray;
     return (
         <div style={style} className='iv-decorate-inline-toolbar-container'>

--- a/src/firefly/js/visualize/reducer/HandlePlotAdmin.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotAdmin.js
@@ -12,7 +12,7 @@ export function reducer(state, action) {
 
     switch (action.type) {
         case Cntlr.API_TOOLS_VIEW  :
-            return clone(state,{apiToolsView:action.payload.apiToolsView});
+            return clone(state,{apiToolsView:action.payload.apiToolsView, useFloatToolbar: action.payload.useFloatToolbar});
 
         case Cntlr.CHANGE_ACTIVE_PLOT_VIEW:
             return changeActivePlotView(state,action);

--- a/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
+++ b/src/firefly/js/visualize/saga/ImageMetaDataWatcher.js
@@ -84,7 +84,7 @@ function watchImageMetadata(action, cancelSelf, params) {
 
         case MultiViewCntlr.CHANGE_VIEWER_LAYOUT:
         case MultiViewCntlr.UPDATE_VIEWER_CUSTOM_DATA:
-            if (!paused) updateImagePlots(tbl_id, viewerId);
+            if (!paused) updateImagePlots(tbl_id, viewerId, true);
             break;
 
 
@@ -106,7 +106,7 @@ function watchImageMetadata(action, cancelSelf, params) {
             break;
 
         case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
-            if (!paused) changeActivePlotView(action.payload.plotId,tbl_id);
+            if (!paused) changeActivePlotView(action.payload.plotId,tbl_id, true);
             break;
 
         case ImagePlotCntlr.ANY_REPLOT:
@@ -131,12 +131,14 @@ const getKey= (threeOp, band) => Object.keys(threeOp).find( (k) => threeOp[k].co
  * 
  * @param tbl_id
  * @param viewerId
+ * @param layoutChange
  * @return {Array}
  */
-function updateImagePlots(tbl_id, viewerId) {
+function updateImagePlots(tbl_id, viewerId, layoutChange= false) {
 
     var viewer = getViewer(getMultiViewRoot(), viewerId);
 
+    if (!viewer) return;
 
     const table = getTblById(tbl_id);
     // check to see if tableData is available in this range.
@@ -176,7 +178,7 @@ function updateImagePlots(tbl_id, viewerId) {
 
     // keep the plotId array for 'single' layout
 
-    if (viewer.layout===SINGLE && !isEmpty(viewer.itemIdAry)) {
+    if (layoutChange && viewer.layout===SINGLE && !isEmpty(viewer.itemIdAry)) {
         if (viewer.itemIdAry[0].includes(GRID_FULL.toLowerCase())) {   // from full grid images
             const activePid = visRoot().activePlotId;
 
@@ -348,6 +350,7 @@ function resetFullGridActivePlot(tbl_id, plotIdAry) {
 
     plotIdAry.find((pId) => {
         const plot = primePlot(vr, pId);
+        if (!plot) return false;
 
         if (get(plot.attributes, PlotAttribute.TABLE_ROW, -1) !== highlightedRow) return false;
 

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -190,10 +190,10 @@ export function makePlotHiPSAction(rawAction) {
     return (dispatcher) => {
 
         const {payload}= rawAction;
-        const {plotId, attributes, pvOptions}= payload;
+        const {plotId, attributes, pvOptions, renderTreeId}= payload;
         const wpRequest= ensureWPR(payload.wpRequest);
 
-        const newPayload= clone(payload, {wpRequest, plotType:'hips', wpRequestAry:[wpRequest]});
+        const newPayload= clone(payload, {wpRequest, plotType:'hips', wpRequestAry:[wpRequest], renderTreeId});
         newPayload.viewerId= determineViewerId(payload.viewerId, plotId);
         const hipsImageConversion= getHipsImageConversion(payload.hipsImageConversion);
         if (hipsImageConversion) newPayload.pvOptions= clone(pvOptions, {hipsImageConversion});
@@ -347,7 +347,7 @@ export function makeImageOrHiPSAction(rawAction) {
         if (!validateHipsAndImage(imageRequest, hipsRequest, payload.fovDegFallOver)) return;
 
 
-        const {plotId, fovDegFallOver, fovMaxFitsSize, autoConvertOnZoom,
+        const {plotId, fovDegFallOver, fovMaxFitsSize, autoConvertOnZoom, renderTreeId,
                 pvOptions, attributes, plotAllSkyFirst=false}= payload;
         const viewerId= determineViewerId(payload.viewerId, plotId);
         const size= getSizeInDeg(imageRequest, hipsRequest);
@@ -372,10 +372,10 @@ export function makeImageOrHiPSAction(rawAction) {
         wpRequest.setPlotGroupId(groupId);
 
         if (useImage) {
-            dispatchPlotImage({plotId, wpRequest, viewerId, hipsImageConversion, pvOptions, attributes});
+            dispatchPlotImage({plotId, wpRequest, viewerId, hipsImageConversion, pvOptions, attributes, renderTreeId});
         }
         else {
-            dispatchPlotHiPS({plotId, wpRequest, viewerId, hipsImageConversion, pvOptions, attributes});
+            dispatchPlotHiPS({plotId, wpRequest, viewerId, hipsImageConversion, pvOptions, attributes, renderTreeId});
         }
     };
 }

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -66,7 +66,8 @@ const getFirstReq= (wpRAry) => isArray(wpRAry) ? wpRAry.find( (r) => Boolean(r))
 function makeSinglePlotPayload(vr, rawPayload, requestKey) {
 
    const {threeColor, attributes, setNewPlotAsActive= true,
-         holdWcsMatch= false, useContextModifications= true, enableRestore= true}= rawPayload;
+         holdWcsMatch= false, useContextModifications= true, enableRestore= true,
+         renderTreeId}= rawPayload;
    let {plotId, wpRequest, pvOptions= {}}= rawPayload;
 
     wpRequest= ensureWPR(wpRequest);
@@ -99,7 +100,7 @@ function makeSinglePlotPayload(vr, rawPayload, requestKey) {
                      viewerId: determineViewerId(rawPayload.viewerId, plotId),
                      hipsImageConversion,
                      requestKey, attributes, pvOptions, enableRestore,
-                     useContextModifications, threeColor, setNewPlotAsActive};
+                     useContextModifications, threeColor, setNewPlotAsActive, renderTreeId};
 
     const existingPv= getPlotViewById(vr,plotId);
     if (existingPv) {
@@ -143,7 +144,8 @@ export function makePlotImageAction(rawAction) {
         else {
             const {viewerId=DEFAULT_FITS_VIEWER_ID, attributes,
                    setNewPlotAsActive= true, pvOptions= {},
-                   useContextModifications= true, enableRestore= true}= rawAction.payload;
+                   useContextModifications= true, enableRestore= true,
+                   renderTreeId}= rawAction.payload;
             payload= {
                 wpRequestAry:ensureWPR(wpRequestAry),
                 viewerId,
@@ -154,7 +156,8 @@ export function makePlotImageAction(rawAction) {
                 useContextModifications,
                 enableRestore,
                 groupLocked:true,
-                requestKey
+                requestKey,
+                renderTreeId
             };
 
             payload.wpRequestAry= payload.wpRequestAry.map( (req) =>

--- a/src/firefly/js/visualize/task/ZoomTask.js
+++ b/src/firefly/js/visualize/task/ZoomTask.js
@@ -40,7 +40,8 @@ export function zoomActionCreator(rawAction) {
         actionScope= ActionScope.get(actionScope);
         let visRoot= getState()[IMAGE_PLOT_KEY];
         const pv= getPlotViewById(visRoot,plotId);
-        if (!pv) return;
+        const plot= primePlot(pv);
+        if (!plot) return;
 
 
         const {level, isFullScreen, useDelay, validParams}=
@@ -54,7 +55,6 @@ export function zoomActionCreator(rawAction) {
 
 
 
-        const plot= primePlot(pv);
         let zoomActive= true;
         if (isImage(plot) && Math.floor(plot.zoomFactor*1000)===Math.floor(level*1000)) { //zoom level the same - just return
             if (isFitFill(userZoomType)) dispatchRecenter({plotId, centerOnImage:true});

--- a/src/firefly/js/visualize/ui/ApiFullImageDisplay.jsx
+++ b/src/firefly/js/visualize/ui/ApiFullImageDisplay.jsx
@@ -32,6 +32,9 @@ export class ApiFullImageDisplay extends PureComponent {
         if (this.removeMouseListener) this.removeMouseListener();
     }
 
+    getChildContext() {
+        return {renderTreeId : this.props.renderTreeId };
+    }
 
     componentDidMount() {
         this.removeListener= flux.addListener(() => this.storeUpdate());
@@ -87,9 +90,14 @@ export class ApiFullImageDisplay extends PureComponent {
 ApiFullImageDisplay.propTypes= {
     forceExpandedMode : PropTypes.bool,
     closeFunc: PropTypes.func,
-    viewerId: PropTypes.string
+    viewerId: PropTypes.string,
+    renderTreeId : PropTypes.string
 };
 
 ApiFullImageDisplay.defaultProps= {
     closeFunc:null
+};
+
+ApiFullImageDisplay.childContextTypes= {
+    renderTreeId : PropTypes.string
 };

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -22,7 +22,8 @@ export class MultiImageViewer extends PureComponent {
 
     componentWillReceiveProps(nextProps) {
         if (this.props.viewerId!==nextProps.viewerId) {
-            dispatchAddViewer(nextProps.viewerId, nextProps.canReceiveNewPlots, IMAGE,true);
+            const {renderTreeId}= this.context;
+            dispatchAddViewer(nextProps.viewerId, nextProps.canReceiveNewPlots, IMAGE,true, renderTreeId);
             dispatchViewerUnmounted(this.props.viewerId);
 
             var viewer = getViewer(getMultiViewRoot(), nextProps.viewerId);
@@ -43,7 +44,8 @@ export class MultiImageViewer extends PureComponent {
         this.iAmMounted= true;
         this.removeListener= flux.addListener(() => this.storeUpdate(this.props));
         var {viewerId, canReceiveNewPlots}= this.props;
-        dispatchAddViewer(viewerId,canReceiveNewPlots,IMAGE, true);
+        const {renderTreeId}= this.context;
+        dispatchAddViewer(viewerId,canReceiveNewPlots,IMAGE, true, renderTreeId);
     }
 
     storeUpdate(props) {
@@ -101,6 +103,10 @@ MultiImageViewer.propTypes= {
 
 // if gridDefFunc is defined it overrides the forceRowSize and forceColSize parameters.
 // forceRowSize is defined if overrides forceColSize parameter.
+
+MultiImageViewer.contextTypes= {
+    renderTreeId: PropTypes.string
+};
 
 
 MultiImageViewer.defaultProps= {


### PR DESCRIPTION
     - web socket channel now works
     - api will will with single slate and multiple other divs
     - working on multi slates views (not done)
     - Firefly.js now has a exported function `startAsAppFromApi`
     - `startAsAppFromApi` exported to `firefly.util` in the API
     - SlateLayoutManger attempts on only manage containers in it div tree (not done)
     - lodash has not `isDefined` function, added one in WebUtil
     -