### PR TITLE
IRSA-2211: Make popup image list resizable

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -467,5 +467,5 @@
 .flex-full {
     display: flex;
     flex-direction: column;
-    flex-grow: 1
+    flex-grow: 1;
 }

--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -463,3 +463,9 @@
     border-bottom: 5px solid transparent;
     border-right: 5px solid black;
 }
+
+.flex-full {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1
+}

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -51,7 +51,7 @@ export class ImageSelect extends PureComponent {
         return (
             <div style={style} className='ImageSelect'>
                 <ToolBar className='ImageSelect__toolbar' {...{filteredImageData, groupKey, onChange: () => this.setState({lastMod:new Date().getTime()})}}/>
-                <div style={{flexGrow: 1, display: 'flex', minHeight: 1}}>
+                <div style={{flexGrow: 1, display: 'flex', height: 1}}>
                     <div className='ImageSelect__panels' style={{marginRight: 3, flexGrow: 0}}>
                         <FilterPanel {...{imageMasterData, groupKey}}/>
                     </div>

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -54,7 +54,7 @@ class TabsHeaderInternal extends PureComponent {
                 return React.cloneElement(child, {maxTitleWidth});
             });
         }
-        const style = Object.assign({flexGrow: 0, height: 20}, headerStyle);
+        const style = Object.assign({flexShrink: 0, height: 20}, headerStyle);
         return (
             <div style={style}>
                 {(widthPx||!resizable) ? <ul className='TabPanel__Tabs'>

--- a/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
@@ -30,6 +30,7 @@ export function showExpandedOptionsPopup(plotViewAry) {
 
 
 function ExpandedOptionsPanel ({plotViewAry}) {
+    const groupKey = 'WHICH_PLOTS';
     var loadedPv= plotViewAry.filter( (pv) => primePlot(pv)?true:false );
     var options= loadedPv.map( (pv) => ({label: primePlot(pv).title, value:pv.plotId}));
     const expandedIds= getExpandedViewerItemIds(getMultiViewRoot());
@@ -39,25 +40,27 @@ function ExpandedOptionsPanel ({plotViewAry}) {
     },'');
 
     return (
-        <FieldGroup groupKey={'WHICH_PLOTS'} keepState={false}>
-            <div style={{padding:'10px 10px 5px 15px'}}>
-                <CheckboxGroupInputField
-                    alignment={'vertical'}
-                    initialState= {{
-                        value: enabledStr,
-                        tooltip: 'Select which plot to display',
-                        label : ''
-                    }}
-                    options={options}
-                    fieldKey='optionCheckBox'
-                />
-            </div>
+        <div style={{resize: 'both', overflow: 'hidden', display: 'flex', flexDirection: 'column', width: 300, height: 300, minWidth: 250, minHeight: 200}}>
+            <FieldGroup groupKey={groupKey} keepState={false} style={{flexGrow:1, overflow: 'auto'}}>
+                <div style={{padding:'10px 10px 5px 15px'}}>
+                    <CheckboxGroupInputField
+                        alignment={'vertical'}
+                        initialState= {{
+                            value: enabledStr,
+                            tooltip: 'Select which plot to display',
+                            label : ''
+                        }}
+                        options={options}
+                        fieldKey='optionCheckBox'
+                    />
+                </div>
+            </FieldGroup>
             <CompleteButton
-                style={{padding : '12px 0 5px 5px'}}
+                groupKey={groupKey}
+                style={{padding : 5, borderTop: '1px solid rgb(163, 174, 185)', boxShadow: '0 -2px 10px 0 #ffffff'}}
                 onSuccess={updateView}
                 dialogId='ExpandedOptionsPopup' />
-
-        </FieldGroup>
+        </div>
     );
 }
 

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.css
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.css
@@ -24,6 +24,7 @@
     display: inline-flex;
     align-items: baseline;
     box-sizing: border-box;
+    flex-shrink: 0;
 }
 
 .ImageSearch__section--title {

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -102,7 +102,7 @@ function getContexInfo() {
 function ImageSearchPanel({resizable=true, onSubmit, gridSupport = false, multiSelect, submitText, onCancel}) {
     const archiveName =  get(getAppOptions(), 'ImageSearch.archiveName');
     const resize = resizable ? {resize: 'both', overflow: 'hidden', paddingBottom: 5} : {};
-    const dim = {height: 600, width: 725, minHeight: 500, minWidth: 600};
+    const dim = {height: 600, width: 725, minHeight: 600, minWidth: 725};
 
     return (
         <div style={{...resize, ...dim}}>


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2211
Test deploy: https://irsawebdev9.ipac.caltech.edu/irsa-2211/firefly/

To test:
- Image Search with multiple images returned
- From toobar, select "Choose which plot to show" icon.. 3rd one in the 3 icon set.
This dialog should be resizable now.

Also, Image Search drop-down and pop-up is also resizable.
To test:
- select Image Search from menu
The panel is resizable by dragging the bottom-right corner

To test popup:
- firefly/demo/ffapi-coverage-test.html
- mouse-over image -> select toolbar
- select New Image from toolbar, 2nd icon from left.


