### PR TITLE
DM-16273: fix search processors from saving as ipac table first

### DIFF
--- a/config/test/app-test.prop
+++ b/config/test/app-test.prop
@@ -1,6 +1,10 @@
 # properties are loaded via AppProperties and classes use AppProperties.getProperty()
 # add here the test value you want to overwrite from app.config file (OPS)
 
+catalina.base=./build/
+stats.log.dir=./build/
+
+
 # Property used in Light-curve API periodogram - use a result sample as basis to extract periodogram/peaks
 #irsa.gator.service.periodogram.url=http://web.ipac.caltech.edu/staff/ejoliet/demo/irsa-lc-sample-result-test.xml
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
 import static edu.caltech.ipac.table.TableMeta.DESC_TAG;
 import static edu.caltech.ipac.table.TableMeta.makeAttribKey;
 
@@ -44,11 +45,12 @@ public abstract class QueryVOTABLE extends IpacTablePartProcessor {
             File votable = getSearchResult(getQueryString(req), getFilePrefix(req));
             DataGroup[] groups = VoTableReader.voToDataGroups(votable.getAbsolutePath(), false);
             DataGroup dg;
-            if (groups.length < 1) {
+            int tblIdx = req.getIntParam(TBL_INDEX);
+            if (groups.length <= tblIdx ) {
                 dg = new DataGroup("empty",new DataType[]{new DataType("empty", String.class)});
                 //throw new EndUserException("cone search query failed", "no results");
             } else {
-                dg = groups[0];
+                dg = groups[tblIdx];
             }
             String raColAttr = dg.getAttribute("POS_EQ_RA_MAIN");
             String decColAttr = dg.getAttribute("POS_EQ_DEC_MAIN");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
@@ -45,7 +45,7 @@ public abstract class QueryVOTABLE extends IpacTablePartProcessor {
             File votable = getSearchResult(getQueryString(req), getFilePrefix(req));
             DataGroup[] groups = VoTableReader.voToDataGroups(votable.getAbsolutePath(), false);
             DataGroup dg;
-            int tblIdx = req.getIntParam(TBL_INDEX);
+            int tblIdx = req.getIntParam(TBL_INDEX, 0);
             if (groups.length <= tblIdx ) {
                 dg = new DataGroup("empty",new DataType[]{new DataType("empty", String.class)});
                 //throw new EndUserException("cone search query failed", "no results");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -218,6 +218,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                 }
             }
 
+            results.getData().getTableMeta().setAttribute(DataGroupPart.LOADING_STATUS, DataGroupPart.State.COMPLETED.name());
             return results;
         } finally {
             activeRequests.remove(unigueReqID);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTableFromExternalTask.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTableFromExternalTask.java
@@ -3,16 +3,20 @@ package edu.caltech.ipac.firefly.server.query;
 import edu.caltech.ipac.firefly.data.Param;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.TableMeta;
 import edu.caltech.ipac.firefly.server.ExternalTaskHandler;
 import edu.caltech.ipac.firefly.server.ExternalTaskHandlerImpl;
 import edu.caltech.ipac.firefly.server.ExternalTaskLauncher;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.TableUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
+import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
 
 /**
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
@@ -21,23 +25,30 @@ import java.util.List;
  */
 @SearchProcessorImpl(id = "TableFromExternalTask")
 public class IpacTableFromExternalTask extends IpacTablePartProcessor {
-    protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
 
-        String launcher = request.getParam(ExternalTaskHandler.LAUNCHER);
-        ExternalTaskLauncher taskLauncher = new ExternalTaskLauncher(launcher);
+    public DataGroup fetchDataGroup(TableServerRequest request) throws DataAccessException {
+        try {
+            String launcher = request.getParam(ExternalTaskHandler.LAUNCHER);
+            ExternalTaskLauncher taskLauncher = new ExternalTaskLauncher(launcher);
+            int tblIdx = request.getIntParam(TBL_INDEX, 0);
 
+            ExternalTaskHandlerImpl handler = new ExternalTaskHandlerImpl(request.getParam(ExternalTaskHandler.TASK), request.getParam(ExternalTaskHandler.TASK_PARAMS));
+            taskLauncher.setHandler(handler);
 
-        ExternalTaskHandlerImpl handler = new ExternalTaskHandlerImpl(request.getParam(ExternalTaskHandler.TASK), request.getParam(ExternalTaskHandler.TASK_PARAMS));
-        taskLauncher.setHandler(handler);
+            taskLauncher.execute();
+            File outFile = handler.getOutfile();
 
-        taskLauncher.execute();
-        File outFile = handler.getOutfile();
-
-        if (!ServerContext.isFileInPath(outFile)) {
-            throw new SecurityException("Access is not permitted.");
+            if (!ServerContext.isFileInPath(outFile)) {
+                throw new SecurityException("Access is not permitted.");
+            }
+            return TableUtil.readAnyFormat(outFile, tblIdx);
+        } catch (IOException e) {
+            throw new DataAccessException(e.getMessage(), e);
         }
+    }
 
-        return convertToIpacTable(outFile, request);
+    protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
+        return loadDataFileImpl(request);
     }
 
     @Override

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -75,41 +75,6 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
         return eio;
     }
 
-    /**
-     * Convert the given file to ipac table format if needed.
-     * if conversion is needed, the converted file must be written into the workarea.
-     * @param tblFile
-     * @param request
-     * @return
-     * @throws IOException
-     * @throws DataAccessException
-     */
-    public static File convertToIpacTable(File tblFile, TableServerRequest request) throws IOException, DataAccessException {
-
-        TableUtil.Format format = TableUtil.guessFormat(tblFile);
-        int tblIdx = request.getIntParam(TableServerRequest.TBL_INDEX, 0);
-        boolean isFixedLength = request.getBooleanParam(TableServerRequest.FIXED_LENGTH, true);
-        if (format == TableUtil.Format.IPACTABLE && isFixedLength) {
-            IpacTableDef tableDef = IpacTableUtil.getMetaInfo(tblFile);
-            String fixlen = tableDef.getAttribute("fixlen");
-            if (fixlen != null && fixlen.equalsIgnoreCase("T") &&
-                !tableDef.getCols().stream().anyMatch(c -> !c.isKnownType()) ) {
-                // table is in fixed length ipac format.. and pass validation
-                return tblFile;
-            }
-        }
-        // conversion is need;
-        if ( format != TableUtil.Format.UNKNOWN) {
-            // read in any format.. then write it back out as ipac table
-            DataGroup dg = TableUtil.readAnyFormat(tblFile, tblIdx);
-            File convertedFile = File.createTempFile(request.getRequestId(), ".tbl", ServerContext.getTempWorkDir());
-            IpacTableWriter.save(convertedFile, dg);
-            return convertedFile;
-        } else {
-            throw new DataAccessException("Source file has an unknown format:" + ServerContext.replaceWithPrefix(tblFile));
-        }
-    }
-
     public boolean isSecurityAware() {
         return false;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
@@ -76,7 +76,6 @@ public class SearchManager {
         dgp = (DataGroupPart) processor.getData(request);
 
         TableMeta meta = dgp.getData().getTableMeta();
-        meta.setAttribute(IS_FULLY_LOADED, "true");
         processor.prepareTableMeta(meta,
                 Arrays.asList(dgp.getData().getDataDefinitions()),
                 request);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UserCatalogQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UserCatalogQuery.java
@@ -67,28 +67,7 @@ public class UserCatalogQuery extends IpacTablePartProcessor {
     }
 
     protected File loadDataFile(TableServerRequest req) throws IOException, DataAccessException {
-
-        String filePath = req.getParam("filePath");
-        if (!StringUtils.isEmpty(filePath)) {
-            if (ServerParams.IS_WS.equals(req.getParam(ServerParams.SOURCE_FROM))) {
-                WsServerParams wsParams = new WsServerParams();
-                wsParams.set(WsServerParams.WS_SERVER_PARAMS.CURRENTRELPATH, filePath);
-                WsServerUtils wsUtil= new WsServerUtils();
-                try {
-                    String s=  wsUtil.upload(wsParams);
-                    return ServerContext.convertToFile(s);      // this logic is wrong if file is not IPAC format.
-                } catch (IOException|FailedRequestException e) {
-                    throw new DataAccessException("Could now retrieve file from workspace",e);
-                }
-
-            }
-            else {
-                File f = ServerContext.convertToFile(filePath);
-                return convertToIpacTable(f, req);
-            }
-        } else {
-            throw new DataAccessException("filePath parameter is not found");
-        }
+        return loadDataFileImpl(req);
     }
 
     @Override

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -431,9 +431,10 @@ export function getSelectedData(tbl_id, columnNames=[]) {
  * @memberof ffirefly.util.table
  * @func isTableLoaded
  */
-export function isTableLoaded(tableModel) {
-    const status = tableModel && !tableModel.isFetching && get(tableModel, 'tableMeta.Loading-Status', 'COMPLETED');
-    return status === 'COMPLETED';
+export function isTableLoaded(tableModel={}) {
+    const {isFetching} = tableModel;
+    const status = get(tableModel, 'tableMeta.Loading-Status');
+    return !isFetching && status === 'COMPLETED';
 }
 
 /**

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -14,11 +14,9 @@ import {resultsReducer} from './reducer/TableResultsReducer.js';
 import {updateMerge, logError} from '../util/WebUtil.js';
 import {FilterInfo} from './FilterInfo.js';
 import {selectedValues} from '../rpc/SearchServicesJson.js';
-import {BG_STATUS, BG_JOB_ADD, dispatchJobAdd} from '../core/background/BackgroundCntlr.js';
 import {trackBackgroundJob, isSuccess, isDone, getErrMsg} from '../core/background/BackgroundUtil.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
 import {dispatchComponentStateChange} from '../core/ComponentCntlr.js';
-import {getTblById, isTableLoaded} from './TableUtil';
 
 
 export const TABLE_SPACE_PATH = 'table_space';

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -5,7 +5,7 @@ import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, isEqual, unse
 
 import {flux} from '../Firefly.js';
 import * as TblUtil from './TableUtil.js';
-import {MAX_ROW} from './TableRequestUtil.js'
+import {MAX_ROW} from './TableRequestUtil.js';
 import {submitBackgroundSearch} from '../rpc/SearchServicesJson.js';
 import shallowequal from 'shallowequal';
 import {dataReducer} from './reducer/TableDataReducer.js';
@@ -18,6 +18,7 @@ import {BG_STATUS, BG_JOB_ADD, dispatchJobAdd} from '../core/background/Backgrou
 import {trackBackgroundJob, isSuccess, isDone, getErrMsg} from '../core/background/BackgroundUtil.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
 import {dispatchComponentStateChange} from '../core/ComponentCntlr.js';
+import {getTblById, isTableLoaded} from './TableUtil';
 
 
 export const TABLE_SPACE_PATH = 'table_space';
@@ -248,7 +249,7 @@ export function dispatchTableSelect(tbl_id, selectInfo) {
 /**
  * remove the table's data given its id.
  * @param tbl_id  unique table identifier.
- * @param {boolean} fireActiveTableChanged=true  true to fire TBL_RESULTS_ACTIVE when applicable.
+ * @param {boolean} [fireActiveTableChanged=true]  true to fire TBL_RESULTS_ACTIVE when applicable.
  */
 export function dispatchTableRemove(tbl_id, fireActiveTableChanged=true) {
     flux.process( {type: TABLE_REMOVE, payload: {tbl_id, fireActiveTableChanged}});

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -122,7 +122,6 @@
  * @typedef {object} TableMeta
  * @prop {string} Loading-Status COMPLETED or INPROGRESS
  * @prop {string} resultSetID ID for this table.  If sorted or filtered, a new one will be generated.
- * @prop {string} isFullyLoaded 'true' when table is completely loaded on the server-side.
  * @prop {string} source    path of the original table source before any operations were performed. ie sort, filter, etc.  this may not be fully supported.
  * @prop {string} relatedCols  highlight related rows based on this column's value.
  *

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -121,7 +121,7 @@ function addPhaseToTable(tbl, timeName, tzero, period) {
     var tPF = {tableData: cloneDeep(tbl.tableData),
                tableMeta: cloneDeep(tbl.tableMeta),
                tbl_id, title};
-    tPF.tableMeta = omit(tPF.tableMeta, ['source', 'resultSetID', 'sortInfo', 'isFullyLoaded']);
+    tPF.tableMeta = omit(tPF.tableMeta, ['source', 'resultSetID', 'sortInfo']);
 
     var phaseC = {desc: 'number of period elapsed since starting time.',
                   name: LC.PHASE_CNAME, type: 'double', width: 6 };

--- a/src/firefly/test/edu/caltech/ipac/table/IpacTableFromSourceTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/IpacTableFromSourceTest.java
@@ -1,0 +1,117 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.table;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.query.tables.IpacTableFromSource;
+import edu.caltech.ipac.firefly.util.FileLoader;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
+import static edu.caltech.ipac.table.JsonTableUtil.getPathValue;
+
+public class IpacTableFromSourceTest extends ConfigTest {
+
+    @BeforeClass
+    public static void setUp() {
+        // needed by test testGetSelectedData because it's dealing with code running in a server's context, ie  SearchProcessor, RequestOwner, etc.
+        setupServerContext(null);
+    }
+
+    @Test
+    public void fromFileSystem() {
+        try {
+            File testFile = FileLoader.resolveFile(VotableTest.class, "/sample_multi_votable.xml");
+
+            TableServerRequest req = new TableServerRequest(IpacTableFromSource.PROC_ID);
+            req.setParam(ServerParams.SOURCE, testFile.getAbsolutePath());
+            req.setParam(TBL_INDEX, "0");
+
+            DataGroup results = new IpacTableFromSource().fetchDataGroup(req);
+            verifyTableData(results, null);
+
+
+            // now load the 2nd table.  columns and table IDs are appended with "-1", but the data are the same
+            // using same validation test.. but for 2nd table
+            req.setParam(TBL_INDEX, "1");
+            results = new IpacTableFromSource().fetchDataGroup(req);
+            verifyTableData(results, "-1");
+        } catch (Exception e) {
+            Assert.fail("IpacTableFromSourceTest.fromFileSystem failed with exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void fromUrl() {
+        try {
+            TableServerRequest req = new TableServerRequest(IpacTableFromSource.PROC_ID);
+            req.setParam(ServerParams.SOURCE, "http://web.ipac.caltech.edu/staff/loi/demo/sample_multi_votable.xml");
+
+            DataGroup results = new IpacTableFromSource().fetchDataGroup(req);
+            verifyTableData(results, null);
+
+            // now load the 2nd table.  columns and table IDs are appended with "-1", but the data are the same
+            // using same validation test.. but for 2nd table
+            req.setParam(TBL_INDEX, "1");
+            results = new IpacTableFromSource().fetchDataGroup(req);
+            verifyTableData(results, "-1");
+        } catch (Exception e) {
+            Assert.fail("IpacTableFromSourceTest.fromUrl failed with exception: " + e.getMessage());
+        }
+    }
+
+    private void verifyTableData(DataGroup data, String suffix) {
+        suffix = suffix == null ? "" : suffix;
+        // test table row and column count
+        Assert.assertEquals("Number of rows:", 3, data.size());
+        Assert.assertEquals("Number of columns:", 6, data.getDataDefinitions().length);
+
+        // test table's data
+        Assert.assertEquals(10.68, data.get(0).getFloat("RA" + suffix, Float.MIN_VALUE), 0.00001);
+        Assert.assertEquals("N 6744", data.get(1).getDataElement("Name" + suffix));
+        Assert.assertEquals(0.7, data.get(2).getFloat("R" + suffix, Float.MIN_VALUE), 0.00001);
+
+        // test table's meta info
+        Assert.assertNull(data.getAttribute("resource-info"));			// we ignore info outside of the table
+        Assert.assertNull(data.getAttribute("resource-info2"));		// we ignore info outside of the table
+        Assert.assertEquals("table-info-value", data.getAttribute("table-info"));
+        Assert.assertEquals("table-info-value2", data.getAttribute("table-info2"));
+
+        // test column info
+        DataType col6 = data.getDataDefintion("R" + suffix);
+        Assert.assertEquals("col6" + suffix, col6.getID());
+        Assert.assertEquals(Float.class, col6.getDataType());
+        Assert.assertEquals("Mpc", col6.getUnits());
+        Assert.assertEquals("pos.distance;pos.heliocentric", col6.getUCD());
+        Assert.assertEquals("F1", col6.getPrecision());
+        Assert.assertEquals(4, col6.getWidth());
+        List<LinkInfo> links = col6.getLinkInfos();
+        Assert.assertEquals(1, links.size());
+        Assert.assertEquals("query", links.get(0).getRole());
+        Assert.assertEquals("http://ivoa.spectr/server?obsno=${Name}", links.get(0).getHref());
+
+        // test table's aux data info
+        List<GroupInfo> groups = data.getGroupInfos();
+        Assert.assertEquals(groups.size(), 1);
+        Assert.assertEquals("J2000" + suffix, groups.get(0).getID());
+        Assert.assertEquals(2, groups.get(0).getColumnRefs().size());
+        Assert.assertEquals("col1" + suffix, groups.get(0).getColumnRefs().get(0).getRef());
+        Assert.assertEquals("col2" + suffix, groups.get(0).getColumnRefs().get(1).getRef());
+
+        Assert.assertEquals(1, groups.get(0).getParamInfos().size());
+        Assert.assertEquals("cooframe", groups.get(0).getParamInfos().get(0).getKeyName());
+        Assert.assertEquals("pos.frame", groups.get(0).getParamInfos().get(0).getUCD());
+        Assert.assertEquals("UTC-ICRS-TOPO", groups.get(0).getParamInfos().get(0).getValue());
+        Assert.assertEquals("char", groups.get(0).getParamInfos().get(0).getTypeDesc());
+        Assert.assertEquals("stc:AstroCoords.coord_system_id", groups.get(0).getParamInfos().get(0).getUType());
+    }
+}


### PR DESCRIPTION
This PR was closed but a bug was found and needed to be re-opened.

After conversion, a couple of the SearchProcessors no longer take `table index` into consideration when loading table.  This was spotted by @tgoldina .

Also in this PR, I've fixed a condition in which Table wrongly marked as completed even though `data` hasn't returned.  This was spotted by @cwang2016 

Also added a unit-test to test IpacTableFromSource.
`gradle :fi:test -x jsTest --tests *IpacTableFromSourceTest`

Will you two help review the code to see if it addresses the problem you raised?
Thank you.
