### PR TITLE
DM-15449 recenter the hips image based on catalog search target

### DIFF
--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -4,14 +4,14 @@
 
 import {take} from 'redux-saga/effects';
 import {isEmpty, isNil, get} from 'lodash';
-import {TABLE_LOADED, TABLE_SELECT,TABLE_HIGHLIGHT,TABLE_REMOVE,TABLE_UPDATE} from '../../tables/TablesCntlr.js';
+import {TABLE_LOADED, TABLE_SELECT,TABLE_HIGHLIGHT,TABLE_REMOVE,TABLE_UPDATE,TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
 import {getDlRoot, SUBGROUP, dispatchAttachLayerToPlot, dispatchChangeVisibility, dispatchCreateDrawLayer,
         dispatchDestroyDrawLayer, dispatchModifyCustomField} from '../DrawLayerCntlr.js';
 import ImagePlotCntlr, {visRoot} from '../ImagePlotCntlr.js';
 import {getTblById, doFetchTable, getTableGroup, isTableUsingRadians} from '../../tables/TableUtil.js';
 import {cloneRequest, makeTableFunctionRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {serializeDecimateInfo} from '../../tables/Decimate.js';
-import {getDrawLayerById, getPlotViewById} from '../PlotViewUtil.js';
+import {getDrawLayerById, getPlotViewById, getActivePlotView, getCenterOfProjection} from '../PlotViewUtil.js';
 import {dlRoot} from '../DrawLayerCntlr.js';
 import {MetaConst} from '../../data/MetaConst.js';
 import Catalog from '../../drawingLayers/Catalog.js';
@@ -19,7 +19,8 @@ import {CoordinateSys} from '../CoordSys.js';
 import {logError} from '../../util/WebUtil.js';
 import {getMaxScatterRows} from '../../charts/ChartUtil.js';
 import {isLsstFootprintTable} from '../task/LSSTFootprintTask.js';
-
+import {dispatchChangeCenterOfProjection} from '../ImagePlotCntlr.js';
+import {parseWorldPt, pointEquals} from '../Point.js';
 
 /**
  * this saga does the following:
@@ -45,7 +46,7 @@ export function* watchCatalogs() {
 
 
     while (true) {
-        const action= yield take([TABLE_LOADED, TABLE_SELECT,TABLE_HIGHLIGHT, TABLE_UPDATE,
+        const action= yield take([TABLE_LOADED, TABLE_SELECT,TABLE_HIGHLIGHT, TABLE_UPDATE,TBL_RESULTS_ACTIVE,
                                   TABLE_REMOVE, ImagePlotCntlr.PLOT_IMAGE, ImagePlotCntlr.PLOT_HIPS]);
         const {tbl_id}= action.payload;
 
@@ -68,6 +69,10 @@ export function* watchCatalogs() {
                 dispatchDestroyDrawLayer(tbl_id);
                 break;
 
+            case TBL_RESULTS_ACTIVE:
+                recenterImage(getTblById(tbl_id));
+                break;
+
             case ImagePlotCntlr.PLOT_HIPS:
             case ImagePlotCntlr.PLOT_IMAGE:
                 attachToAllCatalogs(action.payload.pvNewPlotInfoAry);
@@ -78,6 +83,31 @@ export function* watchCatalogs() {
 
 
 const isCName = (name) => (c) => c.name===name;
+
+/**
+ * update the projection center of hips plor to be aligned with the target of catalog search
+ * @param tbl
+ */
+function recenterImage(tbl) {
+    const pv = getActivePlotView(visRoot());
+    const plot = pv.plots[pv.primeIdx];
+
+    // recenter hips image
+    if (!plot || plot.plotType !== 'hips' || pv.plotGroupId === 'coverageImages') {
+        return;
+    }
+
+    const {UserTargetWorldPt} = tbl.request || {};
+
+    if (UserTargetWorldPt) {
+        const wp = parseWorldPt(UserTargetWorldPt);
+        const centerPt =  getCenterOfProjection(plot);
+
+        if (!pointEquals(wp, centerPt)) {
+            dispatchChangeCenterOfProjection({plotId: plot.plotId, centerProjPt: wp});
+        }
+    }
+}
 
 //todo - this fucntion should start using TableInfoUtil.getCenterColumns
 function handleCatalogUpdate(tbl_id) {
@@ -115,6 +145,9 @@ function handleCatalogUpdate(tbl_id) {
     if (!tableData.columns.find( isCName(columns.lonCol)) && !tableData.columns.find(isCName(columns.latCol))) {
         return;
     }
+
+
+    recenterImage(sourceTable);
 
     const params= {
         startIdx : 0,


### PR DESCRIPTION
This PR recenter the hips image projection center based on the search target when
- doing catalog search 
- changing the active table

test:
- do hips image search with/without entering a target
- do catalogs search on different position or polygon method
the hips image is re-centered as the active table changes