### PR TITLE
DM-15233 support global statement on coordsys for DS9 region 

### DIFF
--- a/src/firefly/html/demo/ffapi-region-test.html
+++ b/src/firefly/html/demo/ffapi-region-test.html
@@ -112,13 +112,17 @@
             ];
 
             window.basicRegions = [
-                'circle  202.4844693750341 47.23118060364845 13.9268922364868 # color=cyan text={circle 1}',
-                'J2000;box 202.4844693750341 47.23118060364845 0.0069268922364 0.0069268922364  0  # color=red text={box 2}',
+                'global color=yellow',
+                'global coordsys FK5',
+                'circle 202.4244693750341 47.16818060364845 13.9268922364868"  # text={circle 1}',
+                'J2000;box 202.4664693750341 47.20798060364845 0.0069268922364 0.0069268922364  0  # color=red text={box 2}',
                 'image;circle  100.4844693750341 147.23118060364845 10.0239268922364868 # color=#B8E986 text={circle 2}',
                 'image;ellipse 99 88 10 20 -30 # color=orange text={ellipse with good coordinate}',
                 'image:ellipse 80 77 nani nani nan # color=yellow text={ellipse with nan coodinate}',
                 'text 215p 300p # color=magenta text={text test 3 } edit=0 highlite=0  font="BRAGGADOCIO 10 normal italic" textangle=30',
-                'box 215p 300p 80 30 30  # color=blue text={box on # J2000 with size w=80 & h=30} width=2'
+                'global color=blue',
+                'global coordsys FK5',
+                'box 215p 300p 0.050 0.030 30  # text={box on # J2000 with size w=80 & h=30} width=2'
             ];
 
 

--- a/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/util/RegionFactory.java
@@ -138,13 +138,21 @@ public class RegionFactory {
             boolean include= true;
 
 
+
             try
             {
                 if (st.hasMoreToken()) {
                     lineBegin = st.nextToken();
                     if (lineBegin.startsWith("global")) {
-                        globalOps= parseRegionOption(st.getRestOfString(),globalOps,true);
-                        retList.add(new Global(globalOps));
+                        RegOpsParseRet globalSetting = parseRegionGlobal(st.getRestOfString(), globalOps, true);
+                        if (globalSetting.coordsys != null) {
+                            coordSys = getCoordSys(globalSetting.coordsys);
+                            if (allowHeader) {
+                                retList.add(coordSys);
+                            }
+                        } else {
+                            retList.add(new Global(globalSetting.ops));
+                        }
                         continue;
                     }
                     if (isCoordSys(lineBegin)) {
@@ -597,8 +605,13 @@ public class RegionFactory {
         return new RegionValue(pV.getValue(),unit);
     }
 
+    private static RegOpsParseRet parseRegionGlobal(String s, RegionOptions fallback, boolean include) {
+        return parseRegionOptionPlus(s,fallback,include);
+    }
+
     private static RegionOptions parseRegionOption(String s, RegionOptions fallback, boolean include) {
         RegOpsParseRet ret= parseRegionOptionPlus(s,fallback,include);
+
         return ret.ops;
     }
 
@@ -616,6 +629,14 @@ public class RegionFactory {
         while (st.hasMoreToken())
         {
             String token = st.nextToken();
+            if (token.toLowerCase().startsWith("coordsys")) {
+                if (st.hasMoreToken()) {
+                    retval.coordsys = st.nextToken();
+                } else {
+                    retval.coordsys = "";
+                }
+                break;
+            }
             if (token.toLowerCase().startsWith("color=")) {
                 retval.ops.setColor(parseColor(token));
             }
@@ -1105,6 +1126,7 @@ public class RegionFactory {
     private static class RegOpsParseRet {
         RegionPoint.PointType pointType= RegionPoint.PointType.X;
         RegionOptions ops= null;
+        String coordsys = null;
         int ptSize = -1;
     }
 

--- a/src/firefly/js/visualize/draw/ShapeToRegion.js
+++ b/src/firefly/js/visualize/draw/ShapeToRegion.js
@@ -89,7 +89,7 @@ var getFontSize = (fontSize) => {
  */
 function makeTextRegion( inPt, cc, drawObj, drawParams) {
     var {color}= drawParams;
-    var {text}= drawObj;
+    var {text, textAngle=0}= drawObj;
     var des;
     var retList = [];
 
@@ -107,6 +107,10 @@ function makeTextRegion( inPt, cc, drawObj, drawParams) {
 
     if (text) {
         des += addTextRelatedProps(drawObj, drawParams);
+    }
+
+    if (textAngle !== 0) {
+        des += setRegionPropertyDes(regionPropsList.TEXTANGLE, textAngle);
     }
     des = endRegionDes(des);
     retList.push(des);

--- a/src/firefly/js/visualize/region/Region.js
+++ b/src/firefly/js/visualize/region/Region.js
@@ -96,7 +96,7 @@ export const makeRegion = (
  * @param {number} offsetY default: 0
  * @param {string} message default: '', containing parsing (error) message
  * @param {string} tag default: ''
- * @param {string} coordSys default: 'PHYSICAL'
+ * @param {Object} coordSys default: RegionCsys.PHYSICAL
  * @function makeRegionOptions
  */
 
@@ -182,7 +182,7 @@ export const defaultRegionProperty = {
     source: 1,
     offsetX: 0,
     offsetY: 0,
-    coordSys: 'PHYSICAL',
+    coordSys: RegionCsys.PHYSICAL,
     textLoc: 'DEFAULT',
     textAngle: 0,
     message: ''

--- a/src/firefly/js/visualize/region/RegionDescription.js
+++ b/src/firefly/js/visualize/region/RegionDescription.js
@@ -33,7 +33,8 @@ const RegionPropertyName = {
     [regionPropsList.LNWIDTH]: 'width',
     [regionPropsList.OFFX]: 'offsetx',
     [regionPropsList.OFFY]: 'offsety',
-    [regionPropsList.TEXTLOC]:'textloc'
+    [regionPropsList.TEXTLOC]:'textloc',
+    [regionPropsList.TEXTANGLE]: 'textangle'
 };
 
 const DS9RegionName = {
@@ -233,6 +234,7 @@ export function setRegionPropertyDes(prop, value) {
         case regionPropsList.LNWIDTH:
         case regionPropsList.OFFX:
         case regionPropsList.OFFY:
+        case regionPropsList.TEXTANGLE:
             if (value !== v) {
                 des = `${pname}${value}`;
             }


### PR DESCRIPTION
This PR support
- support global statement on coordinate system in  form of 'global coordsys <coordinate_specifier>', where coordinate_specifier could be FK4, B1950, FK5, J2000, ICRS, GALACTIC, or ECLIPTIC.
- multiple global lines (for coordsys and region property) may be used within  a region file. 
   (server side only allows the global lines defined before the region description).  

test,
from the client side:  
start the page on firefly/demo/ffapi-region-test.html
click 'Load sample image' and the 'Create Region Layer' for the regions defined  in the first text area in which multiple global lines for properties and coordsys are included. 

from the server side: 
start firefly, do image search on m51, 
upload region test file at firefly_test_data/region-test-files/test5_global.reg


