### PR TITLE
IRSA-2274: export only the original meta

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -58,11 +58,12 @@ abstract public class BaseDbAdapter implements DbAdapter {
             ", links    other" +
             ")";
 
-    private static final String META_INSERT_SQL = "insert into %s_meta values (?,?)";
+    private static final String META_INSERT_SQL = "insert into %s_meta values (?,?,?)";
     private static final String META_CREATE_SQL = "create table %s_meta "+
             "(" +
             "  key      varchar(1024)" +
             ", value    varchar(64000)" +
+            ", isKeyword boolean" +
             ")";
 
     private static final String AUX_DATA_INSERT_SQL = "insert into %s_aux values (?,?,?,?,?)";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
@@ -46,7 +46,6 @@ public class DecimationProcessor extends TableFunctionProcessor {
 
         if (decimateInfo != null) {
             DataGroup retval = QueryUtil.doDecimation(dg, decimateInfo);
-            retval.mergeAttributes(dg.getKeywords());
             return retval;
         } else {
             return dg;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -504,12 +504,11 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
 
     private void setupMeta(DataGroup dg, TableServerRequest req) {
         // merge meta into datagroup from post-processing
-        Map<String, DataGroup.Attribute> cmeta = dg.getAttributes();
         TableMeta meta = new TableMeta();
         prepareTableMeta(meta, Arrays.asList(dg.getDataDefinitions()), req);
-        for (String key : meta.getAttributes().keySet()) {
-            if (!cmeta.containsKey(key)) {
-                dg.addAttribute(key, meta.getAttribute(key));
+        for (DataGroup.Attribute att : meta.getAttributeList()) {
+            if (!dg.getTableMeta().contains(att.getKey())) {
+                dg.getTableMeta().setAttribute(att.getKey(), att.getValue());
             }
         }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
@@ -359,13 +359,12 @@ Thread.sleep(1000);
 
 
     protected DataGroup getOrbitalElements(DataGroup inData) {
-        final String [] names = {"object_name", "element_epoch", "eccentricity", "inclination",
-                "argument_perihelion", "ascending_node", "semimajor_axis", "semimajor_axis", "mean_anomaly",
-                "perihelion_distance", "perihelion_time"};
-        final List<String> namesLst = Arrays.asList(names);
+        final List<String> namesLst = Arrays.asList("object_name", "element_epoch", "eccentricity", "inclination",
+                                                    "argument_perihelion", "ascending_node", "semimajor_axis", "semimajor_axis", "mean_anomaly",
+                                                    "perihelion_distance", "perihelion_time");
         try {
             inData.setTitle("Result Table");
-            Map<String, DataGroup.Attribute> attrMap = inData.getAttributes();
+            Map<String, DataGroup.Attribute> attrMap = inData.getTableMeta().getAttributes();
 
             List<DataType> newDT = new ArrayList<DataType>();
             for (String s : attrMap.keySet()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -301,14 +302,7 @@ public class AnyFileUpload extends BaseHttpServlet {
         tableModel.put("size", size);
 
         JSONObject tableMeta = new JSONObject();
-        Iterator<Entry<String, DataGroup.Attribute>> attributes = dg.getAttributes().entrySet().iterator();
-
-        while( attributes.hasNext() ) {
-            Map.Entry<String, DataGroup.Attribute> entry = attributes.next();
-            DataGroup.Attribute att = entry.getValue();
-
-            tableMeta.put(att.getKey(), att.getValue());
-        }
+        dg.getAttributeList().forEach(att -> tableMeta.put(att.getKey(), att.getValue()));
 
         tableModel.put("tableMeta", tableMeta);
         return tableModel;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -3,7 +3,9 @@
  */
 package edu.caltech.ipac.firefly.server.util;
 
+import com.google.gwt.xml.client.Attr;
 import edu.caltech.ipac.table.IpacTableUtil;
+import edu.caltech.ipac.table.TableMeta;
 import edu.caltech.ipac.table.query.DataGroupQueryStatement;
 import edu.caltech.ipac.astro.net.NedParams;
 import edu.caltech.ipac.astro.net.SimbadParams;
@@ -599,10 +601,10 @@ public class QueryUtil {
 
 
         columns[0] = dg.getDataDefintion(decimateInfo.getxColumnName()).newCopyOf();
-        colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), decimateInfo.getxColumnName()));
+        colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributeList(), decimateInfo.getxColumnName()));
 
         columns[1] = dg.getDataDefintion(decimateInfo.getyColumnName()).newCopyOf();
-        colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributes().values(), decimateInfo.getyColumnName()));
+        colMeta.addAll(IpacTableUtil.getAllColMeta(dg.getAttributeList(), decimateInfo.getyColumnName()));
 
 
         columns[2] = new DataType("rowidx", Integer.class); // need it to tie highlighted and selected to table
@@ -614,7 +616,10 @@ public class QueryUtil {
         Class yColClass = columns[1].getDataType();
 
         DataGroup retval = new DataGroup("decimated results", columns);
-        retval.setKeywords(colMeta);
+        retval.setTableMeta(dg.getTableMeta());
+        for(DataGroup.Attribute att : colMeta) {
+            retval.addAttribute(att.getKey(), att.getValue());
+        }
 
         // determine min/max values of x and y
         boolean checkDeciLimits = false;
@@ -679,9 +684,9 @@ public class QueryUtil {
                 // because the number of rows in the output
                 // is less than decimation limit
 
-                List<DataGroup.Attribute> attributes = retval.getKeywords();
+                TableMeta meta = retval.getTableMeta();
                 retval = new DataGroup("decimated results", new DataType[]{columns[0],columns[1],columns[2]});
-                retval.setKeywords(attributes);
+                retval.setTableMeta(meta);
 
                 for (int rIdx = 0; rIdx < dg.size(); rIdx++) {
                     DataObject row = dg.get(rIdx);

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableDef.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableDef.java
@@ -94,15 +94,6 @@ public class IpacTableDef extends TableMeta {
         setAttribute("source", sourceFile);
     }
 
-    public void getMetaFrom(TableMeta meta) {
-        if (meta == null) return;
-        for (String key : meta.getAttributes().keySet()) {
-            if (!key.equals("source")) {
-                meta.setAttribute(key, meta.getAttribute(key));
-            }
-        }
-    }
-
     public IpacTableDef clone() {
         IpacTableDef copy = (IpacTableDef) super.clone();
         copy.cols = new ArrayList<>(cols);
@@ -111,14 +102,6 @@ public class IpacTableDef extends TableMeta {
         copy.rowCount = rowCount;
         copy.rowStartOffset = rowStartOffset;
         return copy;
-    }
-
-    public static IpacTableDef newInstanceOf(DataGroup dataGroup) {
-        IpacTableDef tableDef = new IpacTableDef();
-        tableDef.setKeywords(dataGroup.getTableMeta().getKeywords());
-        tableDef.ensureStatus();
-        tableDef.setCols(Arrays.asList(dataGroup.getDataDefinitions()));
-        return tableDef;
     }
 }
 /*

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -28,7 +28,7 @@ public class IpacTableUtil {
 
 
     public static List<DataGroup.Attribute> makeAttributes(DataGroup dataGroup) {
-        return makeAttributes(dataGroup.getKeywords(), dataGroup.getDataDefinitions());
+        return makeAttributes(dataGroup.getAttributeList(), dataGroup.getDataDefinitions());
     }
     /**
      * Returns the table's attributes in original sorted order, plus additional
@@ -410,10 +410,6 @@ public class IpacTableUtil {
         return null;
     }
 
-    public static DataGroup.Attribute parseAttribute(String line) {
-        return DataGroup.Attribute.parse(line);
-    }
-
     public static Map<String, String> asMap(DataObject row) {
         HashMap<String, String> retval = new HashMap<String, String>();
         if (row != null) {
@@ -459,7 +455,7 @@ public class IpacTableUtil {
                 dataStartOffset += line.length() + nlchar;
                 line = reader.readLine();
             } else if (line.startsWith("\\")) {
-                DataGroup.Attribute attrib = parseAttribute(line);
+                DataGroup.Attribute attrib = DataGroup.Attribute.parse(line);
                 if (attrib != null) {
                     attribs.add(attrib);
                 }

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -179,7 +179,7 @@ public class TableUtil {
             reader.close();
         }
 
-        dg.setKeywords(tableDef.getKeywords());
+        dg.getTableMeta().setKeywords(tableDef.getKeywords());
 
         long totalRow = tableDef.getLineWidth() == 0 ? 0 :
                         (inf.length()+1 - tableDef.getRowStartOffset())/tableDef.getLineWidth();

--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
@@ -332,7 +332,7 @@ public final class FITSTableReader
         // setting DataGroup meta info
         for(int colIdx = 0; colIdx < dataTypes.size(); colIdx++) {
             DataType dt = dataTypes.get(colIdx);
-            String format = getParam(table, "TDISP" + (colIdx + 1), 20);
+            String format = getParam(table, "TDISP" + (colIdx + 1));
             format = format == null ? null : convertFormat(format);
             if (Double.class.isAssignableFrom(dt.getDataType()) ||
                 Float.class.isAssignableFrom(dt.getDataType())) {
@@ -350,9 +350,9 @@ public final class FITSTableReader
                 if (p instanceof DescribedValue) {
                     DescribedValue dv = (DescribedValue) p;
                     String n = dv.getInfo().getName();
-                    String v = dv.getValueAsString(200);
+                    String v = dv.getValueAsString(Integer.MAX_VALUE);
                     if (hdList == null || hdList.contains(n)) {
-                        dataGroup.addAttribute(n, v);
+                        dataGroup.getTableMeta().addKeyword(n, v);
                     }
                 }
             }
@@ -413,7 +413,7 @@ public final class FITSTableReader
         String unit = colInfo.getUnitString();
         String nullString = null;
         String desc = colInfo.getDescription();
-        desc = desc == null ? getParam(table, "TDOC" + (colIdx+1), 200) : desc; // this is for LSST.. not sure it applies to others.
+        desc = desc == null ? getParam(table, "TDOC" + (colIdx+1)) : desc; // this is for LSST.. not sure it applies to others.
 
         DataType dataType = new DataType(colName, null);
         Class java_class = null;
@@ -454,9 +454,9 @@ public final class FITSTableReader
         return dataType;
     }
 
-    private static String getParam(StarTable table, String key, int maxWidth) {
+    private static String getParam(StarTable table, String key) {
         DescribedValue p = table.getParameterByName(key);
-        return p == null ? null : p.getValueAsString(maxWidth);
+        return p == null ? null : p.getValueAsString(Integer.MAX_VALUE);
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
@@ -95,7 +95,7 @@ public final class IpacTableReader {
             outData = inData;
         }
 
-        outData.setKeywords(attributes);
+        outData.getTableMeta().setKeywords(attributes);
 
         String line = null;
         int lineNum = tableDef.getExtras() == null ? 0 : tableDef.getExtras().getKey();

--- a/src/firefly/java/edu/caltech/ipac/table/io/IpacTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/IpacTableWriter.java
@@ -65,20 +65,20 @@ public class IpacTableWriter {
      *
      * @param stream the output stream to write to
      * @param dataGroup data group
-     * @param ignoreSysMeta ignore meta use by system.
+     * @param forExport only includes original meta and columns that are visible
      * @throws IOException on error
      */
-    public static void save(OutputStream stream, DataGroup dataGroup, boolean ignoreSysMeta)
+    public static void save(OutputStream stream, DataGroup dataGroup, boolean forExport)
             throws IOException {
-        save(new PrintWriter(new BufferedOutputStream(stream, IpacTableUtil.FILE_IO_BUFFER_SIZE)), dataGroup, ignoreSysMeta);
+        save(new PrintWriter(new BufferedOutputStream(stream, IpacTableUtil.FILE_IO_BUFFER_SIZE)), dataGroup, forExport);
     }
 
-    private static void save(PrintWriter out, DataGroup dataGroup, boolean ignoreSysMeta) throws IOException {
+    private static void save(PrintWriter out, DataGroup dataGroup, boolean forExport) throws IOException {
         shrinkToFitData(dataGroup);
         List<DataType> headers = Arrays.asList(dataGroup.getDataDefinitions());
         int totalRow = dataGroup.size();
 
-        if (ignoreSysMeta) {
+        if (forExport) {
             // this should return only visible columns
             headers = headers.stream()
                             .filter(dt -> IpacTableUtil.isVisible(dataGroup, dt)
@@ -87,9 +87,10 @@ public class IpacTableWriter {
                             .collect(Collectors.toList());
         }
 
-        List<DataGroup.Attribute> attributes = IpacTableUtil.makeAttributes(dataGroup);  // add column info as attributes
+        List<DataGroup.Attribute> attributes = forExport ? dataGroup.getTableMeta().getKeywords()
+                                : IpacTableUtil.makeAttributes(dataGroup);  // add column info as attributes
 
-        IpacTableUtil.writeAttributes(out, attributes, ignoreSysMeta);
+        IpacTableUtil.writeAttributes(out, attributes, forExport);
         IpacTableUtil.writeHeader(out, headers);
 
         for (int i = 0; i < totalRow; i++) {

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -686,8 +686,7 @@ public class VoTableReader {
                                                        : getInfosFromTable(tableEl, table);
         for (Object p : dvAry) {
             DescribedValue dv = (DescribedValue)p;
-            //dg.addAttribute(dv.getInfo().getName(), dv.getValueAsString(50).replace("\n", " "));  // take the original string?
-            dg.addAttribute(dv.getInfo().getName(), dv.getValueAsString(Integer.MAX_VALUE).replace("\n", " "));
+            dg.getTableMeta().addKeyword(dv.getInfo().getName(), dv.getValueAsString(Integer.MAX_VALUE).replace("\n", " "));
         }
 
 
@@ -698,10 +697,10 @@ public class VoTableReader {
 
         if (tableEl != null) {
             // attribute ID, ref, ucd, utype from TABLE
-            dg.addAttribute(TableMeta.ID,  getElementAttribute(tableEl, ID));
-            dg.addAttribute(TableMeta.REF, getElementAttribute(tableEl, REF));
-            dg.addAttribute(TableMeta.UCD, getElementAttribute(tableEl, UCD));
-            dg.addAttribute(TableMeta.UTYPE, getElementAttribute(tableEl, UTYPE));
+            dg.getTableMeta().addKeyword(TableMeta.ID,  getElementAttribute(tableEl, ID));
+            dg.getTableMeta().addKeyword(TableMeta.REF, getElementAttribute(tableEl, REF));
+            dg.getTableMeta().addKeyword(TableMeta.UCD, getElementAttribute(tableEl, UCD));
+            dg.getTableMeta().addKeyword(TableMeta.UTYPE, getElementAttribute(tableEl, UTYPE));
 
             // child element PARAM, GROUP, LINK for TABLE
             dg.setParamInfos(makeParamsFromTable(tableEl, table));

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -697,10 +697,10 @@ public class VoTableReader {
 
         if (tableEl != null) {
             // attribute ID, ref, ucd, utype from TABLE
-            dg.getTableMeta().addKeyword(TableMeta.ID,  getElementAttribute(tableEl, ID));
-            dg.getTableMeta().addKeyword(TableMeta.REF, getElementAttribute(tableEl, REF));
-            dg.getTableMeta().addKeyword(TableMeta.UCD, getElementAttribute(tableEl, UCD));
-            dg.getTableMeta().addKeyword(TableMeta.UTYPE, getElementAttribute(tableEl, UTYPE));
+            applyIfNotEmpty(getElementAttribute(tableEl, ID), v -> dg.getTableMeta().addKeyword(TableMeta.ID, v));
+            applyIfNotEmpty(getElementAttribute(tableEl, REF), v -> dg.getTableMeta().addKeyword(TableMeta.REF, v));
+            applyIfNotEmpty(getElementAttribute(tableEl, UCD), v -> dg.getTableMeta().addKeyword(TableMeta.UCD, v));
+            applyIfNotEmpty(getElementAttribute(tableEl, UTYPE), v -> dg.getTableMeta().addKeyword(TableMeta.UTYPE, v));
 
             // child element PARAM, GROUP, LINK for TABLE
             dg.setParamInfos(makeParamsFromTable(tableEl, table));

--- a/src/firefly/java/edu/caltech/ipac/table/query/DataGroupQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/table/query/DataGroupQuery.java
@@ -135,7 +135,7 @@ public class DataGroupQuery {
             boolean needToWriteHeader = true;
             while (line != null) {
                 if (line.startsWith("\\")) {
-                    DataGroup.Attribute attrib = IpacTableUtil.parseAttribute(line);
+                    DataGroup.Attribute attrib = DataGroup.Attribute.parse(line);
                     if (CollectionUtil.matches(lineNum, attrib, getHeaderFilters())) {
                         writer.println(line);
                     }
@@ -219,11 +219,11 @@ public class DataGroupQuery {
 
         // querying for headers
         ArrayList<DataGroup.Attribute> headerResults = new ArrayList<DataGroup.Attribute>();
-        CollectionUtil.filter(src.getAttributes().values(), headerResults, getHeaderFilters());
+        CollectionUtil.filter(src.getAttributeList(), headerResults, getHeaderFilters());
 
         for (Iterator itr = headerResults.iterator(); itr.hasNext(); ) {
             DataGroup.Attribute attrib = (DataGroup.Attribute) itr.next();
-            newDG.addAttribute(attrib.getKey(), attrib.getValue());
+            newDG.getTableMeta().addKeyword(attrib.getKey(), attrib.getValue());
         }
 
         // querying for data
@@ -455,7 +455,7 @@ public class DataGroupQuery {
 
         // merging keywords
         if (includeAttributes) {
-            dgOne.mergeAttributes(dgTwo.getKeywords());
+            dgOne.mergeAttributes(dgTwo.getTableMeta().getKeywords());
         }
 
         // start joining

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -66,6 +66,10 @@ export function fetchTable(tableRequest, hlRowIdx) {
             const selectInfo = SelectInfo.parse(tableModel.selectInfo);
             tableModel.selectInfo = selectInfo.data;
         }
+        if (tableModel.allMeta) {
+            // creates tableMeta from allMeta.
+            tableModel.allMeta.forEach( (m) => m.key && set(tableModel, ['tableMeta', m.key], m.value));
+        }
 
         tableModel.highlightedRow = hlRowIdx || startIdx;
         return tableModel;

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -20,6 +20,7 @@
  * @prop {string}   tbl_id    unique ID of this table.
  * @prop {string}   title     title, used on label.
  * @prop {TableRequest} request  the request used to create this table
+ * @prop {TableKeywords} allMeta  a list of all meta info for this table, including comments and duplicates
  * @prop {TableMeta} tableMeta   table's meta information stored as key/value pair.
  * @prop {TableData} tableData  table's meta information stored as key/value pair.
  * @prop {number}   totalRows   total number of rows.
@@ -117,6 +118,17 @@
  */
 
 /**
+ * The full list of meta info for this table.  It includes the original meta from source, comments, duplicates, and additional meta inserted
+ * @typedef {object} TableKeywords
+ * @prop {string} key  meta key
+ * @prop {string} value meta value
+ * @prop {boolean} isKeyword  true if this entry is from the original source.
+ *
+ * @global
+ * @public
+ */
+
+/**
  * Table meta information.  Below is only a small set of predefined meta used by table.
  * The meta information in this object are used by many components for many reasons.  ie catalog overlay.
  * @typedef {object} TableMeta
@@ -141,7 +153,7 @@
  * @prop {string} inclCols  list of columns to select.  Column names separted by comma(,)
  * @prop {object} META_INFO meta information passed as key/value pair to server then returned as tableMeta.
  * @prop {string} use       one of 'catalog_overlay', 'catalog_primary', 'data_primary'.
- * @prop {string} tbl_id    a unique id of a table. auto-create if not given.
+ * @prop {string} tbl_id    unique id of the table. auto-create if not given.
  *
  * @global
  * @public

--- a/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
+++ b/src/firefly/test/edu/caltech/ipac/astro/IpacTableReaderTest.java
@@ -194,10 +194,10 @@ public class IpacTableReaderTest extends ConfigTest{
         DataGroup dataGroup = IpacTableReader.read(new ByteArrayInputStream(input.getBytes()),onlyColumns);
 
 
-        List<DataGroup.Attribute> comments = dataGroup.getKeywords();
+        List<DataGroup.Attribute> comments = dataGroup.getTableMeta().getKeywords();
         Assert.assertEquals("There should be 0 comments", 0, comments.size());
-        Map<String, DataGroup.Attribute> keywordsMap = dataGroup.getAttributes();
-        Assert.assertEquals("There should be 0 keywords", 0, keywordsMap.size());
+        List<DataGroup.Attribute> keywords = dataGroup.getTableMeta().getKeywords();
+        Assert.assertEquals("There should be 0 keywords", 0, keywords.size());
 
         Assert.assertEquals("ra for row 1", 165.466279, (Double) dataGroup.get(0).getDataElement("ra"), 0.000001);
 
@@ -228,7 +228,7 @@ public class IpacTableReaderTest extends ConfigTest{
 
 
         //Check the Attributes (comments):
-        List<DataGroup.Attribute> attributes = dataGroup.getKeywords();
+        List<DataGroup.Attribute> attributes = dataGroup.getTableMeta().getKeywords();
         Assert.assertTrue(attributes.get(0).isComment());
         Assert.assertEquals("The first attribute has a space so it is parsed as a comment.",
                 attributes.get(0).toString(), "\\ catalog1 = 'A space makes this line as a comment'");
@@ -498,7 +498,7 @@ public class IpacTableReaderTest extends ConfigTest{
         }
 
         //Check the Attributes (comments):
-        List<DataGroup.Attribute> attributes = dataGroup.getKeywords();
+        List<DataGroup.Attribute> attributes = dataGroup.getTableMeta().getKeywords();
         if (attributes.size() == 0){
             //System.out.println("No attributes detected.");
             //Assert.assertTrue("No attributes", noAttributes);
@@ -516,17 +516,12 @@ public class IpacTableReaderTest extends ConfigTest{
         }
 
         //Check the attributes (key, value):
-        Map<String, DataGroup.Attribute> attributeMap = dataGroup.getAttributes();
-        //attributeMap.size();
-        int j = 0;
-        String value;
-        for (Map.Entry entry : attributeMap.entrySet()) {
+        List<DataGroup.Attribute> keywords = dataGroup.getTableMeta().getAttributeList();
+        for (int j = 0; j < keywords.size() -1; j++) {
             //Not check the input file source:
-            if (j < (attributeMap.size() - 1)) {
-                Assert.assertEquals("check the key", entry.getKey(), attributeKeys[j]);
-                value = ((DataGroup.Attribute) entry.getValue()).getValue().toString();
-                //System.out.println(value + " " + attributeValues[j] + " " + j);
-                Assert.assertEquals("check the value", value, attributeValues[j]);
+            if (j < (keywords.size() - 1)) {
+                Assert.assertEquals("check the key", keywords.get(j).getKey(), attributeKeys[j]);
+                Assert.assertEquals("check the value", keywords.get(j).getValue(), attributeValues[j]);
             }
             j++;
         }

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
@@ -8,20 +8,25 @@ import edu.caltech.ipac.firefly.data.SortInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.query.DecimationProcessor;
 import edu.caltech.ipac.table.DataGroupPart;
+import edu.caltech.ipac.table.DataType;
 import edu.caltech.ipac.table.JsonTableUtil;
 import edu.caltech.ipac.table.IpacTableDef;
 import edu.caltech.ipac.firefly.util.FileLoader;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.IpacTableUtil;
 import edu.caltech.ipac.table.io.IpacTableReader;
+import edu.caltech.ipac.table.io.IpacTableWriter;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+
+import static edu.caltech.ipac.table.JsonTableUtil.getMetaFromAllMeta;
 
 /**
  * @author loi
@@ -30,32 +35,43 @@ import java.util.Arrays;
 public class IpacTableTest {
 
     private static final File ipacTable = FileLoader.resolveFile(IpacTableTest.class,  "IpacTableTest.tbl");
-    private static TableServerRequest request;
 
-    @BeforeClass
-    public static void setup() {
-        request = new TableServerRequest("searchProcID");
-        request.setMeta("test-meta", "test-meta-value");
-        DecimationProcessor.setDecimateInfo(request, new DecimateInfo("ra", "dec", 1234, .5f));
-        request.setSortInfo(new SortInfo("ra", "dec"));
-        request.setFilters(Arrays.asList("ra > 0", "dec > 0"));
-
-    }
 
     @Test
     public void testReadIpacTable() throws IOException {
         DataGroup data = IpacTableReader.read(ipacTable);
-        Assert.assertNotNull(data);
+        checkTableData(data);
+    }
+
+    @Test
+    public void testWriteIpacTable() throws IOException {
+        DataGroup data = IpacTableReader.read(ipacTable);
+
+        // instead of comparing the output of write, we'll write it out, read it back in and use the same test to
+        // validate that the round-trip preserves the data.
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        IpacTableWriter.save(output, data, true);
+        data = IpacTableReader.read(new ByteArrayInputStream(output.toByteArray()));
+        checkTableData(data);
     }
 
     @Test
     public void testGetMetaInfo() throws IOException {
         IpacTableDef tableDef = IpacTableUtil.getMetaInfo(ipacTable);
+
         Assert.assertNotNull(tableDef);
+        Assert.assertEquals(21, tableDef.getKeywords().size());    // includes 3 empty comments lines
+        Assert.assertEquals("___ declination (J2000 decimal deg)", tableDef.getKeywords().get(16).getValue());
     }
 
     @Test
     public void testJsonTableUtil() throws IOException {
+        // used to test info from request get into the json tablemodel
+        TableServerRequest request = new TableServerRequest("searchProcID");
+        request.setMeta("test-meta", "test-meta-value");
+        DecimationProcessor.setDecimateInfo(request, new DecimateInfo("ra", "dec", 1234, .5f));
+        request.setSortInfo(new SortInfo("ra", "dec"));
+        request.setFilters(Arrays.asList("ra > 0", "dec > 0"));
         DataGroup data = IpacTableReader.read(ipacTable);
         DataGroupPart page = new DataGroupPart(data, 0, data.size());
 
@@ -72,25 +88,22 @@ public class IpacTableTest {
         Assert.assertEquals("decimate-info", "decimate=ra,dec,1234,0.5,,,,,-1", JsonTableUtil.getPathValue(json, "request", DecimateInfo.DECIMATE_TAG));
 
         // tableMeta
-        Assert.assertEquals("SKYAREA", "'within 500.0 arcsec of  ra=10.68479 dec=+41.26906 Eq J2000 '", JsonTableUtil.getPathValue(json, "tableMeta", "SKYAREA"));
+        Assert.assertEquals("SKYAREA", "'within 500.0 arcsec of  ra=10.68479 dec=+41.26906 Eq J2000 '", getMetaFromAllMeta(json,  "SKYAREA"));
 
         // tableData.columns
-        checkColumn(JsonTableUtil.getPathValue(json, "tableData", "columns", "0"),           // first column
-                                        "ra", "double", "deg", "null", null);
-        checkColumn(JsonTableUtil.getPathValue(json, "tableData", "columns", "17"),           // middle column
-                                        "k_cmsig", "double", "mag", "null", null);
-        checkColumn(JsonTableUtil.getPathValue(json, "tableData", "columns", "43"),           // last column
-                                        "j_k", "double", null, "-", null);
+        checkJsonColumn(json, "tableData.columns.0", "ra", "double", "deg", "null", null);          // first column
+        checkJsonColumn(json, "tableData.columns.3", "clat", "char", null, "null", null);           // middle column
+        checkJsonColumn(json, "tableData.columns.7", "designation", "char", null, "null", null);    // last column
 
         // tableData.data
-        Assert.assertEquals("cell(0,0)", "10.733387", JsonTableUtil.getPathValue(json, "tableData", "data", "0", "0"));     // cell (0,0) first row, first column
-        Assert.assertEquals("cell(8,16)", "14.947", JsonTableUtil.getPathValue(json, "tableData", "data",  "8", "16"));      // cell (8,16) middle row, middle column
-        Assert.assertEquals("cell(15,43)", "1.066", JsonTableUtil.getPathValue(json, "tableData", "data",  "15", "43"));     // cell (15,43) last row, last column
+        Assert.assertEquals("cell(0,0)", "10.733387", JsonTableUtil.getPathValue(json, "tableData", "data", "0", "0"));             // cell (0,0) first row, first column
+        Assert.assertEquals("cell(4,7)", "0.35", JsonTableUtil.getPathValue(json, "tableData", "data",  "7", "4"));                 // cell (4,7) middle row, middle column
+        Assert.assertEquals("cell(7,15)", "00425009+4111543", JsonTableUtil.getPathValue(json, "tableData", "data",  "15", "7"));   // cell (7,15) last row, last column
     }
 
 
-    private void checkColumn(Object col, String name, String type, String units, String nullStr, Integer width) {
-        JSONObject acol = (JSONObject) col;
+    private void checkJsonColumn(JSONObject jsonModel, String path, String name, String type, String units, String nullStr, Integer width) {
+        JSONObject acol = (JSONObject) JsonTableUtil.getPathValue(jsonModel, path.split("\\."));
         Assert.assertEquals("column(" + name + ") name", name, acol.get("name"));
         Assert.assertEquals("column(" + name + ") type", type, acol.get("type"));
         Assert.assertEquals("column(" + name + ") units", units, acol.get("units"));
@@ -98,4 +111,34 @@ public class IpacTableTest {
         Assert.assertEquals("column(" + name + ") width", width, acol.get("width"));
     }
 
+    private void checkColumn(DataType acol, String name, String type, String units, String nullStr, Integer width) {
+        Assert.assertEquals("column(" + name + ") name", name, acol.getKeyName());
+        Assert.assertEquals("column(" + name + ") type", type, acol.getTypeDesc());
+        Assert.assertEquals("column(" + name + ") units", units, acol.getUnits());
+        Assert.assertEquals("column(" + name + ") nullString", nullStr, acol.getNullString());
+        Assert.assertEquals("column(" + name + ") width", (int)width, acol.getWidth());
+    }
+
+
+    private void checkTableData(DataGroup table) {
+        Assert.assertNotNull(table);
+
+        // table meta
+        Assert.assertEquals(21, table.getTableMeta().getKeywords().size());    // includes 3 empty comments lines
+        Assert.assertEquals("___ declination (J2000 decimal deg)", table.getTableMeta().getKeywords().get(16).getValue());
+        Assert.assertEquals("2412", table.getAttribute("RowsRetrieved"));
+
+        // columns
+        checkColumn(table.getDataDefintion("ra"),"ra", "double", "deg", "null", 0);                 // first column
+        checkColumn(table.getDataDefintion("clat"),"clat", "char", "", "null", 0);                // middle column
+        checkColumn(table.getDataDefintion("designation"),"designation", "char", "", "null", 0);  // last column
+
+        // rows
+        Assert.assertEquals(16, table.size());
+
+        // tableData.data
+        Assert.assertEquals("cell(0,0)", 10.733387, table.getData("ra", 0));             // cell (0,0) first row, first column
+        Assert.assertEquals("cell(4,7)", 0.35, table.getData("err_maj", 7));                 // cell (4,7) middle row, middle column
+        Assert.assertEquals("cell(7,15)", "00425009+4111543", table.getData("designation", 15));   // cell (7,15) last row, last column
+    }
 }

--- a/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
@@ -136,6 +136,7 @@ public class EmbeddedDbUtilTest extends ConfigTest {
 		// test meta
 		Assert.assertEquals("'ORIGIN value'", data.getAttribute("ORIGIN"));
 		Assert.assertEquals("'SQL value'", data.getAttribute("SQL"));
+		Assert.assertEquals("'repeated key will get overriden'", data.getTableMeta().getKeywords().get(5).getValue());  // but, it's still in keywords
 
 		// test column meta
 		DataType dt = data.getDataDefintion("dec");

--- a/src/firefly/test/edu/caltech/ipac/table/VotableTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/VotableTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static edu.caltech.ipac.firefly.server.db.DbAdapter.MAIN_DB_TBL;
+import static edu.caltech.ipac.table.JsonTableUtil.getMetaFromAllMeta;
 import static edu.caltech.ipac.table.JsonTableUtil.getPathValue;
 
 public class VotableTest extends ConfigTest {
@@ -148,8 +149,8 @@ public class VotableTest extends ConfigTest {
         Assert.assertEquals("http://ivoa.spectr/server?obsno=${Name}", links.get(0).get("href"));
 
         // test table's meta info
-        Assert.assertEquals("table-info-value", getPathValue(tm, "tableMeta", "table-info"));
-        Assert.assertEquals("table-info-value2", getPathValue(tm, "tableMeta", "table-info2"));
+        Assert.assertEquals("table-info-value", getMetaFromAllMeta(tm, "table-info"));
+        Assert.assertEquals("table-info-value2", getMetaFromAllMeta(tm, "table-info2"));
 
         // table params
         JSONObject param = (JSONObject) getPathValue(tm, "params", "0");


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2274
test deploy: https://irsawebdev9.ipac.caltech.edu/irsa-2274/firefly/
Additional changes in firefly_test_data under the same branch name; updated test file.

This change is to preserve the original meta information from the source for later use.
One usage is when exporting.  It should only export the original meta, not any that were added by Firefly during processing.
In the future, we should have an option where the original meta information is displayed in the UI.
This behavior applies to all table, including FITS, IPAC, and VOTABLE.

Design Notes:
TableMeta now contains 2 types of meta; attributes and keywords.
`keywords` is a list of the original meta info, which may contains comments and duplicate keys.
`attributes` is a map containing all meta info, both from the source and added ones during processing.

As developers, you should continue to use `setAttribute` when you want to add meta info into the table.

To test:
- Load table from different sources; IRSA catalog, uploaded FITS table, uploaded VOTable, etc.
- Apply several operations to the table, like sort, filter, show/hide some columns
- Save the table.

There should be only the original meta info in the downloaded table.
