### PR TITLE
DM-16522: fixed bug in eval of plate projection parameters

### DIFF
--- a/src/firefly/js/visualize/projection/ProjectionInfo.js
+++ b/src/firefly/js/visualize/projection/ProjectionInfo.js
@@ -324,6 +324,7 @@ export function parseSpacialHeaderInfo(header, altWcs='') {
 	/* now do Digital Sky Survey plate solution coefficients */
     if  (header['PLTRAH'+altWcs]) {
         p.maptype = PLATE;
+        p.imageCoordSys= findCoordSys( getJsys(p), p.file_equinox);
         p.rah = parse.getDoubleValue('PLTRAH'+altWcs,0);
         p.ram = parse.getDoubleValue('PLTRAM'+altWcs,0);
         p.ras = parse.getDoubleValue('PLTRAS'+altWcs,0);

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -226,6 +226,7 @@ function makeDrawing(pv,width,height) {
 
     const sptC = cc.getScreenCoords(wptC);
     const sptN = cc.getScreenCoords(wpt2);
+    if (!sptC || !sptN) return null;
     const [x, y] = [(sptN.y - sptC.y) + sptC.x, (-sptN.x + sptC.x)+sptC.y];
     const wptE2 = cc.getWorldCoords(makeScreenPt(x, y));
 


### PR DESCRIPTION
fixed 2 issues:
 
  - ThumbnailViewer does a undefined check it should have been doing, this protects the `render()`
  - A plate projection sets up the coordinate system correctly

_To test:_

  Load the fits file attached to the ticket. It should load OK and have a working readout.

https://jira.lsstcorp.org/browse/DM-16522