### PR TITLE
Dm 16656 lc periodogram peak error

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PhaseFoldedCurveProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PhaseFoldedCurveProcessor.java
@@ -19,6 +19,8 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
+
 /**
  * Created by zhang on 10/14/15.
  * This class calculates the statistics of a IpacTable Data.
@@ -77,6 +79,13 @@ public class PhaseFoldedCurveProcessor extends IpacTablePartProcessor {
     }
 
     private File getSourceFile(String source, TableServerRequest request) {
+
+        // handle case when LC_FILE is a JSON TableRequest
+        File srcFile = irsaLcHandler.getSourceFileFromJsonReqest(request);
+        if (srcFile != null) {
+            return  srcFile;
+        }
+
         File inf = null;
         try {
             URL url = makeUrl(source);

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -12,7 +12,7 @@ import {getTypeData} from './LcUtil.jsx';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
 import FieldGroupCntlr, {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import Validate from '../../util/Validate.js';
-import {getTblById} from '../../tables/TableUtil.js';
+import {getTblById, getResultSetRequest} from '../../tables/TableUtil.js';
 import {makeTblRequest} from '../../tables/TableRequestUtil.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {dispatchTableSearch, dispatchActiveTableChanged} from '../../tables/TablesCntlr.js';
@@ -505,7 +505,11 @@ function periodogramSuccess(popupId, hideDropDown = false) {
     return (request) => {
         const tbl = getTblById(LC.RAW_TABLE);
         const layoutInfo = getLayouInfo();
-        const srcFile = get(tbl, 'request.source');
+        let srcFile = get(tbl, 'request.source');
+        srcFile = srcFile || get(tbl, 'request.alt_source');
+        if (!srcFile) {
+            srcFile = getResultSetRequest(LC.RAW_TABLE);
+        }
 
         const pMin = get(request, [pKeyDef.min.fkey]);
         const pMax = get(request, [pKeyDef.max.fkey]);

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -505,7 +505,7 @@ function periodogramSuccess(popupId, hideDropDown = false) {
     return (request) => {
         const tbl = getTblById(LC.RAW_TABLE);
         const layoutInfo = getLayouInfo();
-        const srcFile = get(tbl, ['tableMeta', 'source']);
+        const srcFile = get(tbl, 'request.source');
 
         const pMin = get(request, [pKeyDef.min.fkey]);
         const pMax = get(request, [pKeyDef.max.fkey]);


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-16656
k8s: https://irsawebdev9.ipac.caltech.edu/dm-16656/irsaviewer/

Light Curve viewer was dependence on 'original_table ' meta that is no longer supported. 
This PR replace that logic with something that is supported.

