### PR TITLE
irsa-2424: Link in tables are not saved correctly in ipactable

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -395,7 +395,7 @@ public class IpacTableUtil {
                         }
                     }
 
-                    row.setDataElement(dt, dt.convertStringToData(val, true));
+                    row.setDataElement(dt, dt.convertStringToData(val));
 
                     offset = endoffset;
                 }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2424

The bug was caused by java escaping, which included quote character
Updated behavior: when saving ipac table, replace control characters only with a replacement character (currently inverted question mark)

To test: 
1. NED target search, save as IPAC table, check Details field url. Quotes should be unchanged.
2. To test the replacement of control chars, search for `gaia` tables in `public` schema at 
http://localhost:8080/firefly/demo/ffapi-tap-test.html, save tables (second table) as IPAC table. Description field has control characters. 