### PR TITLE
DM-16661: Firefly tableviewer column does not apply column formatting on user filter attempt	

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -5,9 +5,9 @@ package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.server.RequestOwner;
-import edu.caltech.ipac.table.IpacTableUtil;
 import edu.caltech.ipac.firefly.server.events.FluxAction;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
+import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.table.io.IpacTableException;
 import edu.caltech.ipac.table.io.IpacTableWriter;
 import edu.caltech.ipac.firefly.data.FileInfo;
@@ -94,32 +94,6 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     abstract public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException;
 
     /**
-     * Fetches the data for the given search request, then save it into a database
-     * The database should contains at least 3 named tables: DATA, DD, and META
-     * DATA table contains the data
-     * DD table contains definition of the columns, including name, label, format, etc
-     * META table contains meta information taken from the table.
-     *
-     * @param req  search request
-     * @throws DataAccessException
-     */
-    public FileInfo ingestDataIntoDb(TableServerRequest req, File dbFile) throws DataAccessException {
-
-        DbAdapter dbAdapter = DbAdapter.getAdapter(req);
-
-        StopWatch.getInstance().start("fetchDataGroup: " + req.getRequestId());
-        DataGroup dg = fetchDataGroup(req);
-        StopWatch.getInstance().stop("fetchDataGroup: " + req.getRequestId()).printLog("fetchDataGroup: " + req.getRequestId());
-
-        setupMeta(dg, req);
-
-        StopWatch.getInstance().start("ingestDataIntoDb: " + req.getRequestId());
-        FileInfo finfo = EmbeddedDbUtil.ingestDataGroup(dbFile, dg, dbAdapter, "data");
-        StopWatch.getInstance().stop("ingestDataIntoDb: " + req.getRequestId()).printLog("ingestDataIntoDb: " + req.getRequestId());
-        return finfo;
-    }
-
-    /**
      * returns the database file for the given request.
      * This implementation returns a file based on sessionId + search parameters
      * @param treq
@@ -179,7 +153,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             File dbFile = getDbFile(treq);
             if (!dbFile.exists()) {
                 StopWatch.getInstance().start("createDbFile: " + treq.getRequestId());
-                dbFile = populateDataTable(treq);
+                dbFile = createDbFromRequest(treq);
                 dbFileCreated = true;
                 StopWatch.getInstance().stop("createDbFile: " + treq.getRequestId()).printLog("createDbFile: " + treq.getRequestId());
             }
@@ -198,12 +172,8 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             }
             StopWatch.getInstance().stop("getDataset: " + request.getRequestId()).printLog("getDataset: " + request.getRequestId());
 
-            // put all of the meta-info from the request into tablemeta
-            if (treq.getMeta() != null) {
-                for (String key : treq.getMeta().keySet()) {
-                    results.getData().getTableMeta().setAttribute(key, treq.getMeta(key));
-                }
-            }
+            // ensure all meta are collected and set accordingly
+            TableUtil.consumeColumnMeta(results.getData(), treq);
 
             if (dbFileCreated) {
                 if (doLogging()) {
@@ -224,7 +194,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         }
     }
 
-    private File populateDataTable(TableServerRequest treq) throws DataAccessException {
+    private File createDbFromRequest(TableServerRequest treq) throws DataAccessException {
         DbAdapter dbAdapter = DbAdapter.getAdapter(treq);
         File dbFile = createDbFile(treq);
         try {
@@ -240,6 +210,33 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         }
         EmbeddedDbUtil.setDbMetaInfo(treq, dbAdapter, dbFile);
         return dbFile;
+    }
+
+    /**
+     * Fetches the data for the given search request, then save it into a database
+     * The database should contains at least 3 named tables: DATA, DD, and META
+     * DATA table contains the data
+     * DD table contains definition of the columns, including name, label, format, etc
+     * META table contains meta information taken from the table.
+     *
+     * @param req  search request
+     * @throws DataAccessException
+     */
+    protected FileInfo ingestDataIntoDb(TableServerRequest req, File dbFile) throws DataAccessException {
+
+        DbAdapter dbAdapter = DbAdapter.getAdapter(req);
+
+        StopWatch.getInstance().start("fetchDataGroup: " + req.getRequestId());
+        DataGroup dg = fetchDataGroup(req);
+        StopWatch.getInstance().stop("fetchDataGroup: " + req.getRequestId()).printLog("fetchDataGroup: " + req.getRequestId());
+
+        prepareTableMeta(dg.getTableMeta(), Arrays.asList(dg.getDataDefinitions()), req);
+        TableUtil.consumeColumnMeta(dg, null);      // META-INFO in the request should only be pass-along and not persist.
+
+        StopWatch.getInstance().start("ingestDataIntoDb: " + req.getRequestId());
+        FileInfo finfo = EmbeddedDbUtil.ingestDataGroup(dbFile, dg, dbAdapter, "data");
+        StopWatch.getInstance().stop("ingestDataIntoDb: " + req.getRequestId()).printLog("ingestDataIntoDb: " + req.getRequestId());
+        return finfo;
     }
 
     public File getDataFile(TableServerRequest request) throws IpacTableException, IOException, DataAccessException {
@@ -276,7 +273,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     }
 
     public void prepareTableMeta(TableMeta defaults, List<DataType> columns, ServerRequest request) {
-        SearchProcessor.prepareTableMetaDef(defaults, columns, request);
+        // This is part of the older api.  In the new API, you should update these info directly in fetchDataGroup().
     }
 
     public QueryDescResolver getDescResolver() {
@@ -499,21 +496,6 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         }
 
         return e.getMessage();
-    }
-
-    private void setupMeta(DataGroup dg, TableServerRequest req) {
-        // merge meta into datagroup from post-processing
-        Map<String, DataGroup.Attribute> cmeta = dg.getAttributes();
-        TableMeta meta = new TableMeta();
-        prepareTableMeta(meta, Arrays.asList(dg.getDataDefinitions()), req);
-        for (String key : meta.getAttributes().keySet()) {
-            if (!cmeta.containsKey(key)) {
-                dg.addAttribute(key, meta.getAttribute(key));
-            }
-        }
-
-        IpacTableUtil.consumeColumnInfo(dg);
-
     }
 
     private static void enumeratedValuesCheckBG(File dbFile, DataGroupPart results, TableServerRequest treq) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -438,9 +438,7 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
         return resultsFile;
     }
 
-    public void prepareTableMeta(TableMeta defaults, List<DataType> columns, ServerRequest request) {
-        SearchProcessor.prepareTableMetaDef(defaults, columns, request);
-    }
+    public void prepareTableMeta(TableMeta defaults, List<DataType> columns, ServerRequest request) {}
 
     public void prepareAttributes(int rows, BufferedWriter writer, ServerRequest sr) throws IOException {
     }

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.table;
 
+import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.table.io.DsvTableIO;
 import edu.caltech.ipac.firefly.server.util.JsonToDataGroup;
 import edu.caltech.ipac.table.io.FITSTableReader;
@@ -191,11 +192,27 @@ public class TableUtil {
         return new DataGroupPart(tableDef, dg, start, (int) totalRow);
     }
 
+    /**
+     * takes all of the TableMeta that is column's related and use it to set column's properties.
+     * remove the TableMeta that was used.
+     * @param dg
+     * @param treq  if not null, merge META-INFO from this request into TableMeta before consuming
+     */
+    public static void consumeColumnMeta(DataGroup dg, TableServerRequest treq) {
+        if (treq != null && treq.getMeta() != null) {
+            treq.getMeta().forEach((k,v) -> {
+                dg.getTableMeta().setAttribute(k, v);
+            });
+        }
+        IpacTableUtil.consumeColumnInfo(dg);
+    }
+
+
 //====================================================================
 //
 //====================================================================
 
-    public static enum Format { TSV(CSVFormat.TDF), CSV(CSVFormat.DEFAULT), IPACTABLE(), UNKNOWN(), FIXEDTARGETS(), FITS(), JSON(), VO_TABLE();
+    public enum Format { TSV(CSVFormat.TDF), CSV(CSVFormat.DEFAULT), IPACTABLE(), UNKNOWN(), FIXEDTARGETS(), FITS(), JSON(), VO_TABLE();
         CSVFormat type;
         Format() {}
         Format(CSVFormat type) {this.type = type;}

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -1,11 +1,11 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, isEqual, unset} from 'lodash';
+import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, isEqual, unset, merge} from 'lodash';
 
 import {flux} from '../Firefly.js';
 import * as TblUtil from './TableUtil.js';
-import {MAX_ROW} from './TableRequestUtil.js'
+import {MAX_ROW} from './TableRequestUtil.js';
 import {submitBackgroundSearch} from '../rpc/SearchServicesJson.js';
 import shallowequal from 'shallowequal';
 import {dataReducer} from './reducer/TableDataReducer.js';
@@ -477,7 +477,7 @@ function setupTableOps(tbl_id, nrequest) {
 
     const {request, tableMeta, selectInfo} = tableModel;
     const tableData = pick(tableModel.tableData, 'columns');
-    const nreq = Object.assign({}, request, nrequest);
+    const nreq = merge({}, request, nrequest);
     return {tbl_id, request:nreq, tableMeta, selectInfo, tableData};
 }
 


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-16661
k8s: https://irsawebdev9.ipac.caltech.edu/dm-16661/firefly/

According to the ticket, column's properties when sent via META-INFO is lost when filter is applied.
You can test this on our nightly build: http://irsawebdev5:8100/view/k8s/job/k8s_firefly/demo/ffapi-table-test.html.
- clear META-INFO
- click show table
- enter `{"col.ra.FmtDisp": "%.2f"}` into META-INFO
- click show table again
- should see `ra` is formatted with only 2 decimal places
- open column filter bar
- enter `> 0` into a numeric column, i.e `sigdec`
- `ra` is back to its original precision.

Doing the same on this PR's k8s build should yield the expected results.