### PR TITLE
IRSA-2367-Issue Priority 2. SOFIA crop fails on a cube

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
@@ -24,7 +24,7 @@ import java.util.List;
 class SpectralCubeEval implements FitsEvaluation.Eval {
     @Override
     public List<RelatedData> evaluate(File f, FitsRead[] frAry, BasicHDU[] HDUs, int fitsReadIndex, int hduIndex, WebPlotRequest req) {
-        if (!req.getBooleanParam("SpectralCube")) return null;
+        if (req!=null && !req.getBooleanParam("SpectralCube")) return null;
         // do spectral cube processing here
         // todo Convert FitsCube to work in this environment
         return null;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/CropFile.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/CropFile.java
@@ -140,8 +140,8 @@ public class CropFile {
                 ImageHDU h = (ImageHDU) hdu;
                 Header old_header = h.getHeader();
                 int naxis = old_header.getIntValue("NAXIS");
-                if (naxis == 0) {
-            /* it's a null image - probably the primary image */
+                if (naxis < 2 ){ //Image has to have naxis=2 or 3
+              /* it's a null image - probably the primary image */
                     new_hdu = hdu;
                 } else {
                     Fits temp_fits = common_crop(h, old_header,


### PR DESCRIPTION
Fixed the  bug for cropping the multi-extension 2-d images
Fixed the bug for the cropping cubes image data

Two issues noticed:
1. For sofia cube, the cropped images are not inside the cropped frame
2. In Firefly, when I  do a search in one mission, a group images are displayed. By default, all images are locked as a group.  The selection tool applies on all images, but crop tool only applies to the selected image. Is this a designed behavior?  

Test URL:
URL: https://irsawebdev9.ipac.caltech.edu/irsa-2367/applications/sofia/
