### PR TITLE
IRSA-1316: adjust footer so that it does not shrink

### DIFF
--- a/src/firefly/js/ui/DropDownContainer.css
+++ b/src/firefly/js/ui/DropDownContainer.css
@@ -28,6 +28,7 @@
     min-height: 25px;
     width: 100%;
     position: relative;
+    flex-shrink: 0;
 }
 
 .DD-ToolBar__version {


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-1316
k8s: https://irsawebdev9.ipac.caltech.edu/irsa-1316/irsaviewer/

Additional changes here:  https://github.com/IPAC-SW/irsa-ife/pull/40

Catalog search panel is pushing into the footer, causes footer to rendered badly as well as links not working correctly.

The test deploy is for irsaviewer, but this will fix finderchart, sofia, and firefly as well.