### PR TITLE
DM-13099 set binning value of any axis on decimated plot 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -787,6 +787,8 @@ public class QueryUtil {
                 retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".Y-UNIT", String.valueOf(yUnit));
                 retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".WEIGHT-MIN", String.valueOf(minWeight));
                 retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".WEIGHT-MAX", String.valueOf(maxWeight));
+                retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".XBINS", String.valueOf(nXs));
+                retval.addAttribute(DecimateInfo.DECIMATE_TAG + ".YBINS", String.valueOf(nYs));
 
                 java.util.Date endTime = new java.util.Date();
                 Logger.briefInfo(decimateInfoStr + " - took "+(endTime.getTime()-startTime.getTime())+"ms");

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -15,6 +15,7 @@ import {COL_TYPE, getColumns} from '../../tables/TableUtil.js';
 import {getTraceTSEntries as genericTSGetter} from './FireflyGenericData.js';
 import {DECIMATE_TAG} from '../../tables/Decimate.js';
 
+const DEFBINS = 100;
 /**
  * This function creates table source entries to get firefly scatter and error data from the server
  * (The search processor knows how to handle expressions and eliminates null x or y)
@@ -33,12 +34,11 @@ export function getTraceTSEntries({traceTS, chartId, traceNum}) {
     // server call parameters
     const xbins = get(fireflyData, `${traceNum}.nbins.x`);
     const ybins = get(fireflyData, `${traceNum}.nbins.y`);
-    let maxbins = 10000;
-    let xyratio = get(fireflyLayout, 'xyratio', 1.0);
-    if (xbins && ybins) {
-        maxbins = xbins * ybins;
-        xyratio = xbins/ybins;
-    }
+    const xNum = xbins ? Number(xbins) : DEFBINS;
+    const yNum = ybins ? Number(ybins) : DEFBINS;
+
+    const maxbins = xNum * yNum;
+    const xyratio = xNum/yNum;
 
     //should we take into account zoom?
     const xmin = get(fireflyLayout, 'xaxis.min');

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -13,6 +13,7 @@ import {colorscaleNameToVal, OneColorSequentialCS, PlotlyCS} from '../Colorscale
 import {cloneRequest} from '../../tables/TableRequestUtil.js';
 import {COL_TYPE, getColumns} from '../../tables/TableUtil.js';
 import {getTraceTSEntries as genericTSGetter} from './FireflyGenericData.js';
+import {DECIMATE_TAG} from '../../tables/Decimate.js';
 
 /**
  * This function creates table source entries to get firefly scatter and error data from the server
@@ -26,7 +27,7 @@ import {getTraceTSEntries as genericTSGetter} from './FireflyGenericData.js';
 export function getTraceTSEntries({traceTS, chartId, traceNum}) {
     const {mappings} = traceTS;
 
-    if (!mappings) return {}; 
+    if (!mappings) return {};
 
     const {fireflyData, fireflyLayout} = getChartData(chartId) || {};
     // server call parameters
@@ -194,7 +195,7 @@ function getChanges({tableModel, tablesource, chartId, traceNum}) {
     };
 
     const chartData = getChartData(chartId);
-    const {layout, data} = chartData;
+    const {layout, data, fireflyData} = chartData;
 
     // check for scatter represented by heatmap
     if (isScatter2d(get(data, `${traceNum}.type`, 'scatter'))) {
@@ -265,6 +266,20 @@ function getChanges({tableModel, tablesource, chartId, traceNum}) {
             addColorbarLengthChanges(changes, yOpposite, nbars, traceNum, cnt);
         }
     }
+
+    // update xbins or ybins in fireflyData
+    ['x', 'y'].forEach((axis) => {
+        const metaKey = `${DECIMATE_TAG}.${axis.toUpperCase()}BINS`;
+
+        if (tableMeta[metaKey]) {
+            const binPath = `${traceNum}.nbins.${axis}`;
+
+            if (get(fireflyData, binPath) !== tableMeta[metaKey]) {
+                changes[`fireflyData.${binPath}`] = tableMeta[metaKey];
+            }
+        }
+    });
+
 
     return changes;
 }

--- a/src/firefly/js/tables/Decimate.js
+++ b/src/firefly/js/tables/Decimate.js
@@ -8,7 +8,7 @@
  * Decimation allows to reduce the number of the points to be plotted.
  */
 
-const DECIMATE_TAG='decimate';
+export const DECIMATE_TAG='decimate';
 
 
 /*


### PR DESCRIPTION
This development includes, 
- fixing the bug regarding changing binning value on the plot parameter dialog of Heatmap chart
- the numbers (including the defaults for the plot in the beginning)  for x-bins & y-bins fields are  shown in plot parameters setting dialog. 

test:
start catalog search on cone search with large radius and that will result in a table more than 5000 rows. (default setting in Firefly.js), ex: m31 & radius=1600"
open up charts options and tools dialog,  change  the number of xbins or ybins or both and apply the change. 
