### PR TITLE
DM-14350: Improve the cube and multi-image FITS display controls

### DIFF
--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -97,6 +97,8 @@ export class InputFieldView extends PureComponent {
         // if form is not given, it will default to __ignore so that it does not interfere with embedded forms.
         form = form || undefined;
 
+        const currValue= (type==='file') ? undefined : value;
+
         return (
             <div style={wrapperStyle}>
                 {label && <InputFieldLabel labelStyle={labelStyle} label={label} tooltip={tooltip} labelWidth={labelWidth}/> }
@@ -108,10 +110,10 @@ export class InputFieldView extends PureComponent {
                                 onBlur && onBlur(ev);
                                 this.setState({hasFocus:false, infoPopup:false});
                             }}
-                       onKeyPress={(ev) => onKeyPress && onKeyPress(ev)}
-                       onKeyDown={(ev) => onKeyDown && onKeyDown(ev)}
+                       onKeyPress={(ev) => onKeyPress && onKeyPress(ev,currValue)}
+                       onKeyDown={(ev) => onKeyDown && onKeyDown(ev,currValue)}
                        onKeyUp={(ev) => onKeyUp && onKeyUp(ev)}
-                       value={type==='file' ? undefined : value}
+                       value={currValue}
                        title={ (!showWarning && !valid) ? message : tooltip}
                        {...pickBy({size, type, disabled, placeholder, form})}
                 />

--- a/src/firefly/js/ui/StatedInputfield.jsx
+++ b/src/firefly/js/ui/StatedInputfield.jsx
@@ -5,6 +5,11 @@ import {has} from 'lodash';
 import {InputFieldView} from './InputFieldView.jsx';
 
 
+
+const ARROW_UP = 38;
+const ARROW_DOWN = 40;
+
+
 export class StateInputField extends PureComponent {
 
     constructor(props) {
@@ -30,7 +35,8 @@ export class StateInputField extends PureComponent {
 
 
     render() {
-        const {visible=true, message, label='', tooltip, labelWidth= 100, showWarning, style='', wrapperStyle=''}= this.props;
+        const {visible=true, message, label='', tooltip, labelWidth= 100, showWarning,
+            style='', wrapperStyle='', onKeyDown, onKeyUp}= this.props;
         const {value, valid}= this.state;
 
         return (
@@ -47,6 +53,8 @@ export class StateInputField extends PureComponent {
             showWarning={showWarning}
             style={style}
             wrapperStyle={wrapperStyle}
+            onKeyDown={onKeyDown}
+            onKeyUp={onKeyUp}
         />
         );
     }
@@ -67,6 +75,8 @@ StateInputField.propTypes= {
     showWarning : PropTypes.bool,
     type: PropTypes.string,
     validator: PropTypes.func,
+    onKeyUp: PropTypes.func,
+    onKeyDown: PropTypes.func,
     valueChange: PropTypes.func.isRequired
 };
 

--- a/src/firefly/js/ui/StatedInputfield.jsx
+++ b/src/firefly/js/ui/StatedInputfield.jsx
@@ -1,0 +1,81 @@
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import {has} from 'lodash';
+
+import {InputFieldView} from './InputFieldView.jsx';
+
+
+export class StateInputField extends PureComponent {
+
+    constructor(props) {
+        super(props);
+        this.state= {
+            value: props.defaultValue
+        };
+        this.onChange= this.onChange.bind(this);
+    }
+
+    onChange(ev) {
+        const {validator, valueChange}= this.props;
+        let value = ev.target.value;
+        const {valid,message, ...others}= validator ? validator(value) : {valid:true, message:''};
+        has(others, 'value') && (value = others.value);    // allow the validator to modify the value.. useful in auto-correct.
+        valueChange && valueChange({ value, message, valid });
+        this.setState(() => ({valid, value}));
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState(() => ({valid:true, value:nextProps.defaultValue}));
+    }
+
+
+    render() {
+        const {visible=true, message, label='', tooltip, labelWidth= 100, showWarning, style='', wrapperStyle=''}= this.props;
+        const {value, valid}= this.state;
+
+        return (
+            <InputFieldView
+            valid={valid}
+            visible={visible}
+            message={message}
+            onChange={this.onChange}
+            label={''}
+            value={value}
+            tooltip={tooltip}
+            labelWidth={labelWidth}
+            inline={true}
+            showWarning={showWarning}
+            style={style}
+            wrapperStyle={wrapperStyle}
+        />
+        );
+    }
+
+}
+
+StateInputField.propTypes= {
+    message : PropTypes.string,
+    tooltip : PropTypes.string,
+    label : PropTypes.string,
+    inline : PropTypes.bool,
+    labelWidth: PropTypes.number,
+    style: PropTypes.object,
+    wrapperStyle: PropTypes.object,
+    labelStyle: PropTypes.object,
+    defaultValue: PropTypes.string.isRequired,
+    size : PropTypes.number,
+    showWarning : PropTypes.bool,
+    type: PropTypes.string,
+    validator: PropTypes.func,
+    valueChange: PropTypes.func.isRequired
+};
+
+StateInputField.defaultProps= {
+    showWarning : true,
+    valid : true,
+    visible : true,
+    message: '',
+    type: 'text',
+    style: {},
+    wrapperStyle: {}
+};

--- a/src/firefly/js/visualize/BandState.js
+++ b/src/firefly/js/visualize/BandState.js
@@ -44,36 +44,6 @@ export class BandState {
     }
 
     /**
-     *
-     * @return {number}
-     */
-    getImageIdx() { return this.imageIdx; }
-
-
-    /**
-     *
-     * @return {boolean}
-     */
-    isMultiImageFile() { return this.multiImageFile; }
-
-    /**
-     *
-     */
-    getCubePlaneNumber() { return this.cubePlaneNumber; }
-
-    /**
-     *
-     * @return {number}
-     */
-    getCubeCnt() { return this.cubeCnt; }
-
-    /**
-     *
-     * @return {number|*}
-     */
-    getOriginalImageIdx() { return this.originalImageIdx; }
-
-    /**
      * get a copy of the WebPlotRequest for this BandState.  Any changes to the object will not be reflected in
      * BandState you must set it back in
      * @return {WebPlotRequest}
@@ -100,7 +70,7 @@ export class BandState {
      *
      * @return {ClientFitsHeader}
      */
-    getHeader() { return this.directFileAccessData; }
+    getDirectFileAccessData() { return this.directFileAccessData; }
 
     /**
      *
@@ -152,7 +122,7 @@ export class BandState {
 
     /**
      * @param {BandState} bs
-     * @param {boolean} includeDirectAccessData include the clientFitsHeader object
+     * @param {boolean} includeDirectAccessData include the directFileAccessData object
      */
     static convertToJSON(bs, includeDirectAccessData= true) {
         if (!bs || !bs.plotRequestSerialize) return null;

--- a/src/firefly/js/visualize/PlotState.js
+++ b/src/firefly/js/visualize/PlotState.js
@@ -136,28 +136,6 @@ export class PlotState {
      */
     getWebPlotRequest(band) { return this.get(band || this.firstBand()).getWebPlotRequest(); }
 
-
-    /**
-     * @summary Check to see it this plot is from a multi image file
-     * @param {Band} [band] the band check for, if not passed the used the primary band
-     * @return {boolean} the WebPlotRequest
-     * @public
-     */
-    isMultiImageFile(band = undefined) { return this.get(band || this.firstBand()).isMultiImageFile(); }
-
-    /**
-     * @summary if a cube, checkout how many images it contains
-     * @param {Band} [band] the band check for, if not passed the used the primary band
-     * @return {number} the WebPlotRequest
-     * @public
-     */
-    getCubeCnt(band) { return this.get(band || this.firstBand()).getCubeCnt(); }
-
-
-    getCubePlaneNumber(band) {
-        return this.get(band || this.firstBand()).getCubePlaneNumber();
-    }
-
     /**
      * Get the range values for the plot.
      * @param {band} [band] the band get range value for, parameter is unnecessary for non-three color plots
@@ -165,13 +143,12 @@ export class PlotState {
      */
     getRangeValues(band) { return this.get(band || this.firstBand()).getRangeValues(); }
 
-
     /**
      *
      * @param band
      * @return {ClientFitsHeader}
      */
-    getHeader(band) { return this.get(band).getHeader(); }
+    getDirectFileAccessData(band) { return this.get(band).getDirectFileAccessData(); }
 
 
     /**
@@ -188,11 +165,6 @@ export class PlotState {
 
 
     getUploadFileName(band) { return band ? this.get(band).getUploadedFileName() : null; }
-
-    getImageIdx(band) { return this.get(band).getImageIdx(); }
-
-
-    getOriginalImageIdx(band) { return this.get(band).getOriginalImageIdx(); }
 
     /**
      *
@@ -272,7 +244,7 @@ export class PlotState {
     /**
      * @summary convert his PlotState to something can be used with JSON.stringify
      * @param {PlotState} s
-     * @param {boolean} includeDirectAccessData include the clientFitsHeader object
+     * @param {boolean} includeDirectAccessData include the includeDirectAccessData object
      */
     static convertToJSON(s, includeDirectAccessData= true) {
         if (!s) return null;

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -770,7 +770,7 @@ export function getNumberOfCubesInPV(pv) {
     if (!pv || !isImage(primePlot(pv)) ) return 0;
     return pv.plots.reduce( (total, p, idx) => {
         if (idx===0) return getImageCubeIdx(p)>=1 ? 1 : 0;
-        return (getHDU(p)!==getHDU(pv.plots[idx-1] && getImageCubeIdx(p)>-1)) ? total+1 : total;
+        return ( getHDU(p)!==getHDU(pv.plots[idx-1]) && getImageCubeIdx(p)>-1) ? total+1 : total;
     }, 0);
 }
 
@@ -797,7 +797,7 @@ export function getPrimaryPlotHdu(pv) {
     if (!pv) return 0;
     const p= primePlot(pv);
     if (!isImage(p)) return 0;
-    return p ? getHDU(plot) : 0;
+    return p ? getHDU(p) : 0;
 }
 
 /**

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -69,8 +69,6 @@ export const ServerCallStatus= new Enum(['success', 'working', 'fail'], { ignore
  * @prop {boolean} zoomLockingEnabled the plot will automaticly adjust the zoom when resized
  * @prop {UserZoomTypes} zoomLockingType the type of zoom lockeing
  * @prop {number} lastCollapsedZoomLevel used for returning from expanded mode, keeps recode of the level before expanded
- * @prop {boolean} containsMultiImageFits is a multi image fits file
- * @prop {boolean} containsMultipleCubes  is a multi cube
  * @prop {HipsImageConversionSettings} hipsImageConversion -  if defined, then plotview can convert between hips and image
  * @prop {number} plotCounter index of how many plots, used for making next ID
  */
@@ -151,8 +149,6 @@ function createPlotViewContextData(req, pvOptions={}) {
         preferenceColorKey: req.getPreferenceColorKey(),
         preferenceZoomKey:  req.getPreferenceZoomKey(), // currently not used
         defThumbnailSize: DEFAULT_THUMBNAIL_SIZE,
-        containsMultiImageFits : false,
-        containsMultipleCubes : false,
         plotCounter:0 // index of how many plots, used for making next ID
     };
 
@@ -256,10 +252,6 @@ export function replacePlots(pv, plotAry, overlayPlotViews, expandedMode, newPlo
     PlotPref.putCacheColorPref(pv.plotViewCtx.preferenceColorKey, pv.plots[pv.primeIdx].plotState);
     PlotPref.putCacheZoomPref(pv.plotViewCtx.preferenceZoomKey, pv.plots[pv.primeIdx].plotState);
 
-    if (pv.plots.length>1) {
-        pv.plotViewCtx.containsMultiImageFits= pv.plots.every( (p) => p.plotState.isMultiImageFile());
-    }
-    pv.plotViewCtx.containsMultipleCubes= pv.plots.every( (p) => p.plotState.getCubeCnt()>1);
     if (expandedMode===ExpandType.COLLAPSE) {
         pv.plotViewCtx.lastCollapsedZoomLevel= pv.plots[pv.primeIdx].zoomFactor;
     }

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -644,15 +644,15 @@ function makeWebPlotRequests(request, imageMasterData, plotId, plotGroupId){
 
     } else if (request.imageSource === 'upload') {
         const fileName = get(request, 'fileUpload');
-        return [addStdParams(WebPlotRequest.makeFilePlotRequest(fileName), plotId, plotGroupId)];
+        return [addStdParams(WebPlotRequest.makeFilePlotRequest(fileName), 'image', plotId, plotGroupId)];
 
     } else if (request.imageSource === ServerParams.IS_WS) {
         const fileName = get(request, 'wsFilepath');
-        return [addStdParams(WebPlotRequest.makeWorkspaceRequest(fileName), plotId, plotGroupId)];
+        return [addStdParams(WebPlotRequest.makeWorkspaceRequest(fileName),'image',  plotId, plotGroupId)];
 
     } else if (request.imageSource === 'url') {
         const url = get(request, 'txURL');
-        return [addStdParams(WebPlotRequest.makeURLPlotRequest(url), plotId, plotGroupId)];
+        return [addStdParams(WebPlotRequest.makeURLPlotRequest(url), 'image', plotId, plotGroupId)];
 
     } else {
         const wp = parseWorldPt(request[ServerParams.USER_TARGET_WORLD_PT]);

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -7,7 +7,8 @@ import numeral from 'numeral';
 import PropTypes from 'prop-types';
 import {isEmpty, get, padEnd} from 'lodash';
 import {primePlot,isMultiImageFitsWithSameArea, getPlotViewById,
-                getDrawLayersByType, isDrawLayerAttached, getAllDrawLayersForPlot } from '../PlotViewUtil.js';
+        getDrawLayersByType, isDrawLayerAttached, getAllDrawLayersForPlot,
+        isMultiHDUFits, getCubePlaneCnt, getHDU } from '../PlotViewUtil.js';
 import {findScrollPtToCenterImagePt} from '../reducer/PlotView.js';
 import {CysConverter} from '../CsysConverter.js';
 import {PlotAttribute,isHiPS, isImage} from '../WebPlot.js';
@@ -42,6 +43,8 @@ import {isOutlineImageForSelectArea, detachSelectArea, SELECT_AREA_TITLE} from '
 import {convertAngle} from '../VisUtil.js';
 import {convertToHiPS, convertToImage, doHiPSImageConversionIfNecessary} from '../task/PlotHipsTask.js';
 import {RequestType} from '../RequestType.js';
+import {StateInputField} from '../../ui/StatedInputfield.jsx';
+import Validate from '../../util/Validate.js';
 import LSSTFootprint, {selectFootprint, unselectFootprint, filterFootprint, clearFilterFootprint} from '../../drawingLayers/ImageLineBasedFootprint';
 
 import CROP from 'html/images/icons-2014/24x24_Crop.png';
@@ -225,7 +228,7 @@ function crop(pv, dlAry) {
     const ip1=  cc.getImageCoords(sel.pt1);
 
 
-    const cropMultiAll= pv.plotViewCtx.containsMultiImageFits && isMultiImageFitsWithSameArea(pv);
+    const cropMultiAll= isMultiImageFitsWithSameArea(pv);
 
     dispatchCrop({plotId:pv.plotId, imagePt1:ip0, imagePt2:ip1, cropMultiAll});
     attachImageOutline(pv, dlAry);
@@ -535,7 +538,7 @@ export class VisCtxToolbarView extends PureComponent {
             <div style={rS}>
                 {showMultiImageController && <MultiImageControllerView plotView={pv} />}
                 {showOptions && <div
-                    style={{padding: '0 0 5px 2px', fontStyle: 'italic'}}>
+                    style={{padding: '0 0 2px 2px', fontStyle: 'italic', fontWeight: 'bold'}}>
                     Options:</div>
                 }
                 {showSelectionTools && isImage(plot) &&
@@ -642,6 +645,7 @@ export function MultiImageControllerView({plotView:pv}) {
     let prevIdx;
     let length;
     let desc;
+    let positionStr= '';
 
     if (image) {
         cIdx= plots.findIndex( (p) => p.plotImageId===plot.plotImageId);
@@ -650,6 +654,10 @@ export function MultiImageControllerView({plotView:pv}) {
         prevIdx= cIdx ? cIdx-1 : plots.length-1;
         length= plots.length;
         desc= plots[cIdx].plotDesc;
+        if (isMultiHDUFits(pv)) {
+            if (plot.cubeIdx>-1) positionStr+= `, Cube: ${plot.cubeIdx}/${getCubePlaneCnt(pv,plot)}`;
+            positionStr+= `, HDU: ${getHDU(plot)}`;
+        }
     }
     else {
         cIdx= plot.cubeIdx;
@@ -660,22 +668,25 @@ export function MultiImageControllerView({plotView:pv}) {
         desc= getHipsCubeDesc(plot);
     }
 
-    if (length<3) leftImageStyle.visibility='hidden';
+    // if (length<3) leftImageStyle.visibility='hidden';
     if (cIdx<0) cIdx= 0;
-
+    const useText= length>8;
 
 
 
     return (
         <div style={mulImStyle}>
-            <div style={{fontStyle: 'italic', padding: '0 0 0 5px'}}>Image:</div>
+            <div style={{fontStyle: 'italic', fontWeight: 'bold', padding: '0 0 0 5px'}}>Image:</div>
             <img style={{...leftImageStyle}} src={PAGE_LEFT}
                  onClick={() => image ? dispatchChangePrimePlot({plotId,primeIdx:prevIdx}) : dispatchChangeHiPS({plotId, cubeIdx:prevIdx})}/>
             <img style={{verticalAlign:'bottom', cursor:'pointer', float: 'right', paddingLeft:3, flex: '0 0 auto'}}
                  src={PAGE_RIGHT}
                  onClick={() => image ? dispatchChangePrimePlot({plotId,primeIdx:nextIdx}): dispatchChangeHiPS({plotId, cubeIdx:nextIdx})} />
             {desc && <div style={{minWidth: '3em', padding:'0 5px 0 5px', fontWeight:'bold'}}>{desc}</div>}
-            <div style={{minWidth: '3em', padding:'0 10px 0 4px'}}>{`${cIdx+1}/${length}`}</div>
+            <div style={{minWidth: '3em', padding:'0 10px 0 4px'}}>
+                {useText ? makeframeInput(plot,cIdx+1,length) : `${cIdx+1}`}
+                {`${useText?' / ' : '/'}${length}${positionStr}`}
+                </div>
         </div>
     );
 }
@@ -749,4 +760,29 @@ function clearFilterDrawingLayer(pv,dlAry) {
             clearFilterFootprint(pv, allLayers);
         }
     }
+}
+
+function makeframeInput(plot, curr, max) {
+
+    const {plotId}= plot;
+
+    const handleFrameChange= (update) => {
+        const {valid,value}= update;
+        const frameNumber= Number(value);
+        if (valid && frameNumber) {
+            isImage(plot) ? dispatchChangePrimePlot({plotId,primeIdx:frameNumber-1}) :
+                            dispatchChangeHiPS({plotId, cubeIdx:frameNumber-1})
+        }
+    };
+
+    const validator= (value) => Validate.intRange(1, max, 'step range', value, false);
+
+    return (
+        <StateInputField defaultValue={curr+''} valueChange={handleFrameChange}
+                         labelWidth={0} label={''} tooltip={'End a frame to jump to'}
+                         showWarning={false} style={{width:`${max<1000?2:4}em`, textAlign:'right'}}
+             validator={validator}
+
+        />
+    );
 }


### PR DESCRIPTION
  Improve the cube and multi-image FITS display controls

  - Added individual cube readout display for cases with multiple cubes
   - Show the HDU number if more than one or not the 0 HDU (simple FITS)
   - Added: for HiPS/FITS cubes and multi image FITS text entry field to jump directly to the plane
   - show show the text entry field if more than 8 planes
   - Created a text entry StatedInputField for text input outside of a field group
   - Fixed bug: a plot id not being created correctly for upload and URL
   - add a set of PlotViewUtil functions to get cube and multi-image FITS info
   - cleaned up of unused BandState and PlotState functions

_To Test:_

  - load any of the multi image fits or cubes in `firefly_test_data/multi-ext-fits`
  - observe the control area of the cube / multi image FITS
  - this will also work with HIPS cube
