### PR TITLE
DM-15378 Scale the size and synchronize the movement of footprint/marker on both HiPS and fits display

### DIFF
--- a/src/firefly/js/drawingLayers/DistanceTool.js
+++ b/src/firefly/js/drawingLayers/DistanceTool.js
@@ -321,7 +321,7 @@ function makeSelectObj(firstPt,currentPt, posAngle,cc) {
     var anyPt1;
     var anyPt2;
     var dist;
-    var world= cc.projection.isSpecified();
+    var world= cc.projection.isSpecified() && cc.projection.isImplemented();
 
     if (world) {
         anyPt1 = cc.getWorldCoords(ptAry[0]);

--- a/src/firefly/js/drawingLayers/MarkerToolUI.jsx
+++ b/src/firefly/js/drawingLayers/MarkerToolUI.jsx
@@ -20,7 +20,7 @@ class MarkerToolUI extends PureComponent {
         super(props);
 
         var markerObj = get(this.props.drawLayer, ['drawData', 'data', this.props.pv.plotId], {});
-        var {text = '', textLoc = defaultMarkerTextLoc} = markerObj;
+        var {text = '', textLoc = defaultMarkerTextLoc} = markerObj||{};
         var markerType = get(this.props.drawLayer, ['markerType'], 'marker');
 
         this.state = {markerText: text,  markerTextLoc: textLoc.key, markerType};

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -198,6 +198,13 @@ export class CysConverter {
 
     };
 
+    /* check it the point is viewable by checking if the point is within range of viewDim for
+        hips image or if the point is within plot range for fits image
+     */
+    isPointViewable(pt) {
+        return isHiPS(this) ? this.pointInView(pt) : this.pointOnDisplay(pt);
+    };
+
 //========================================================================================
 //----------------------------- End pointIn Methods  -------------------------------------
 //========================================================================================

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -549,7 +549,9 @@ export function dispatchCreateMarkerLayer(markerId, layerTitle, plotId = [], att
  * @summary create drawing layer with footprint
  * @param {string} footprintId - id of the drawing layer
  * @param {string} layerTitle - title of the drawing layer
- * @param {footprintInfo} footprintData footprint information for footprint layer
+ * @param {footprintInfo} footprintData footprint information for footprint layer,
+ *                        relocateBy: 'origin' means relocating footprint origin to the target location
+ *                                    'center' means relocating footprint center to the target location
  * @param {string[]|string} plotId - array or string of plot id. If plotId is empty, all plots of the active group are applied
  * @param {bool} attachPlotGroup - attach all plots of the same plot group
  * @param dispatcher

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -4,7 +4,7 @@
 
 import React, {Component, PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {xor,isNil, isEmpty,get, isString, isFunction, throttle} from 'lodash';
+import {xor,isNil, isEmpty,get, isString, isFunction, throttle, isNumber, isArray} from 'lodash';
 import {flux} from '../Firefly.js';
 import {ImageRender} from './iv/ImageRender.jsx';
 import {EventLayer} from './iv/EventLayer.jsx';
@@ -453,6 +453,19 @@ function findMouseOwner(dlList, plot, screenPt) {
 
                       // Step 3
     const cc= CysConverter.make(plot);
+
+    const getDist = (vertexDef) => {
+        const {pointDist} = vertexDef || {};
+
+        return isNumber(pointDist) ?  pointDist : get(pointDist, [cc.plotId], 0.0);
+    };
+
+    const getPoints = (vertexDef) => {
+        const {points} = vertexDef || {};
+
+        return isArray(points) ? points : get(points, [cc.plotId], []);
+    };
+
     const vertexDL= exList
         .filter((dl) => {
             const exType= get(dl,'exclusiveDef.type','');
@@ -461,12 +474,14 @@ function findMouseOwner(dlList, plot, screenPt) {
         })
         .find( (dl)  => {
             const {vertexDef}= dl;
-            const dist= vertexDef.pointDist || 5;
+            const pDist = getDist(vertexDef);
+
+            const dist= pDist || 5;
             const x= screenPt.x- dist;
             const y= screenPt.y- dist;
             const w= dist*2;
             const h= dist*2;
-            return vertexDef.points.find( (pt) => {
+            return getPoints(vertexDef).find( (pt) => {
                 const spt= cc.getScreenCoords(pt);
                 return spt && contains(x,y,w,h,spt.x,spt.y);
             } );

--- a/src/firefly/js/visualize/draw/DrawLayer.js
+++ b/src/firefly/js/visualize/draw/DrawLayer.js
@@ -232,7 +232,10 @@ function makeDrawLayer(drawLayerId,
 
         // if defined then Object with:
                   // points: array of points, // if not define or empty the down is exclusive anywhere
-                  // pointDist: 10, // how close to the points in the array to match
+                                              // it could be an object with plotId(key)/points(value) representing array of points for the plot with plotId
+                  // pointDist: 10, // how close to the points in the array to match, measured in screen pixel coordinate
+                                    // it could be an object with plotId(key)/pointDist(value) representing pointDist for the plot with plotId
+
         vertexDef: null, 
         
 


### PR DESCRIPTION
This development mainly fixes the issues when footprint/marker layer is attached to both HiPS and FITS images: 
- the point distance (how close to the center of the footprint or marker) on screen
pixel coordinate is adjusted per plot  (HiPS plot or FITS plot) that the footprint/marker layer attached to. 
- Scale the size of the marker according to the primary image while a new plot is created. 
   Every new marker is added with fixed screen pixel size no matter if the primary image is HIPS or FITS and the plot created later should have the marker scaled in world coordinate by looking at that in the primary image. 
- fix bugs to show the fake outline box when the outline box surrounding the footprint/marker is out of view. (this may happen when you move the marker/footprint on HiPS image and that causes the appearance of marker/footprint out of FITS image's coverage).  

Here is brief definition of two types of fake outline box as proposed in https://jira.lsstcorp.org/browse/DM-6516,
1. 'center outline box' for  the case that the center of the footprint/marker but no sides of the original outline box are within the plot area
2. 'plotcenter outline box' for the case that both the center of footprint/marker and sides of original  outline box are not within the plot area.
Both fake outline boxes are shown with resize and rotate handles for operating the marker/footprint.
'plotcenter outline box' is shown in solid line, and 'center outline box' is shown in dotted line. 
- Synchronize the movement, rotation and resizing among all types of images. 

test:
case 1: 
start a FITS image on a target, 
start a HiPS image search on the same target
case 2: 
start 2 FITS image search on the same target
case 3:
start 2 HiPS image search on the same target

for each case, 
- pick one image as the primary image, 
- add a new marker or footprint
- operate the marker or footprint (move, resize, rotate) on the primary image. 
- switch to another image as the primary image, operate the marker or footprint

to check:
- when you operate the footprint/marker on HiPS image, if the other image is FITS image, try to resize the marker or move the marker/footprint to be out of the coverage of the FITS image and see the change of outline box on FITS image. 
- when you switch around two images, make sure the footprint/marker on the primary image can be selected and moved smoothly. 

