### PR TITLE
IRSA-2488: Image search is not showing info link icon in single select mode

### DIFF
--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -352,33 +352,44 @@ function DataProduct({groupKey, project, filteredImageData, multiSelect}) {
 function Header({project, hrefInfo='', multiSelect}) {
     const fieldKey= `PROJ_ALL_${project}`;
 
-    const href = hrefInfo;
-    if (!multiSelect) return <div style={{display: 'inline-block'}}>{project}</div>;
-    return (
-        <div className='DataProductList__item--header' >
-            <div onClick={(e) => e.stopPropagation()}>
-            <CheckboxGroupInputField
-                key={fieldKey}
-                fieldKey={fieldKey}
-                initialState={{
-                        value: '',   // workaround for _all_ for now
-                        tooltip: 'Please select some boxes',
-                        label : '' }}
-                options={[{label:project, value:'_all_'}]}
-                alignment='horizontal'
-                labelWidth={35}
-                wrapperStyle={{whiteSpace: 'normal' /*cursor:'pointer'*/}}
-            />
-            </div>
-            <div style={{marginLeft: -5}}>
-                <div>
-                    <a onClick={(e) => e.stopPropagation()} target='_blank' href={href}>
-                        <img style={{width:'14px'}}
-                            src={infoIcon}/></a>
-                </div>
-            </div>
+    const InfoIcon = () => hrefInfo && (
+        <div>
+            <a onClick={(e) => e.stopPropagation()} target='_blank' href={hrefInfo}>
+                <img style={{width:'14px'}} src={infoIcon} alt='info'/></a>
         </div>
     );
+
+    if (multiSelect) {
+        return (
+            <div className='DataProductList__item--header' >
+                <div onClick={(e) => e.stopPropagation()}>
+                    <CheckboxGroupInputField
+                        key={fieldKey}
+                        fieldKey={fieldKey}
+                        initialState={{
+                            value: '',   // workaround for _all_ for now
+                            tooltip: 'Please select some boxes',
+                            label : '' }}
+                        options={[{label:project, value:'_all_'}]}
+                        alignment='horizontal'
+                        labelWidth={35}
+                        wrapperStyle={{whiteSpace: 'normal' /*cursor:'pointer'*/}}
+                    />
+                </div>
+                <div style={{marginLeft: -5}}>
+                    <InfoIcon/>
+                </div>
+            </div>
+        );
+    } else {
+        return (
+            <div style={{display: 'inline-flex', alignItems: 'center'}}>
+                <div style={{marginRight:5}}>{project}</div>
+                <InfoIcon/>
+            </div>
+        );
+    }
+
 }
 
 const hasImageSelection = (groupKey, proj) => {


### PR DESCRIPTION
ticket: https://jira.ipac.caltech.edu/browse/IRSA-2488
k8s:    https://irsawebdev9.ipac.caltech.edu/IRSA-2488_missing_info_link/firefly/

As described in ticket...  test using above k8s url.
> In Gator or in any tri-view catalog search, after a coverage image is displayed, if the user wants to change the image and brign the image search panel, the information icon and links are not shown in this mode (single selection mode)