### PR TITLE
IRSA-1991-ZTF:ZTF time series: North up not applied

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
 import java.util.Map;
 
 import static edu.caltech.ipac.astro.ibe.BaseIbeDataSource.addUrlParam;
@@ -147,7 +148,8 @@ public class IBE {
             qstr = addUrlParam(qstr, "gzip", param.isDoZip());
         }
 
-        url += (qstr.length() > 0 ? "?" + qstr : "");
+        //url += (qstr.length() > 0 ? "?" + qstr : "");
+        url += (qstr.length() > 0 ? "?" + URLEncoder.encode(qstr, "UTF-8") : "");
 
         return new URL(url);
     }

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -738,6 +738,7 @@ export function setupImages(layoutInfo, invokedBy=TABLE_FETCH){
             const rowNum = Number(plotId.substring(plotIdRoot.length));
             const webPlotReq = converterData.webplotRequestCreator(tableModel, rowNum, cutoutSize,
                 getImagePlotParams(layoutInfo));
+            webPlotReq.setRotateNorth(true);
 
             if (webPlotReq && (!pv || get(pv, ['request', 'params', 'Title']) !== webPlotReq.getTitle() ||
                 get(pv, ['request', 'params', 'UserDesc']) !== webPlotReq.getUserDesc())) {


### PR DESCRIPTION
   Fixed the ztf image direction issue
   Fixed the ra/dec format issue in IBE.java

   Test URL:  https://irsawebdev9.ipac.caltech.edu/irsa-1991/irsaviewer/ts.html
   Please use the ztf_tbl attached in the ticket IRSA-1991.  This is the most recently table saved from IBE gator searching result.
