### PR TITLE
IRSA-2578: make target examples a prop

### DIFF
--- a/src/firefly/js/ui/ExampleDialog.jsx
+++ b/src/firefly/js/ui/ExampleDialog.jsx
@@ -312,7 +312,18 @@ class FieldGroupTest extends PureComponent {
 
 // initValues={{extraData:'asdf'}}
 
+const makeSpan= (w) => <span style={{paddingLeft: `${w}px`}}/>;
 
+/*
+    If you want to see the examples back to default, just replace this with ={}
+ */
+const defaultExamples = <div style={{display : 'inline-block'}}>
+    {makeSpan(5)} 'M17' {makeSpan(15)} 'NGC6946' {makeSpan(15)}  '141.607 -47.347 gal'
+    <br />
+    {makeSpan(15)} '46.53 -0.251 gal' {makeSpan(5)}'12h34m27.0504s +2d11m17.304s Equ J2000'
+    <br />
+    {makeSpan(5)}  '20h27m36.3467s +40d01m21.649s Equ B1950'
+</div>;
 
 function FieldGroupTestView ({fields}) {
 
@@ -330,7 +341,7 @@ function FieldGroupTestView ({fields}) {
         <FieldGroup style= {{padding:5}} groupKey={'DEMO_FORM'} initValues={{extraData:'asdf',field1:'4'}}
                     reducerFunc={exDialogReducer} keepState={true}>
             <InputGroup labelWidth={110}>
-                <TargetPanel/>
+                <TargetPanel examples={defaultExamples} />
                 <SuggestBoxInputField
                     fieldKey='suggestion1'
                     initialState= {{

--- a/src/firefly/js/ui/TargetFeedback.jsx
+++ b/src/firefly/js/ui/TargetFeedback.jsx
@@ -15,24 +15,26 @@ const titleStyle= {
     display : 'inline-block',
     verticalAlign: 'top'
 };
+const makeSpan= (w) => <span style={{paddingLeft: `${w}px`}}/>;
+const defaultExamples = <div style={exDivStyle}>
+    {makeSpan(5)} 'm81' {makeSpan(15)} 'ngc 18' {makeSpan(15)}  '12.34 34.89'  {makeSpan(15)} '46.53 -0.251 gal'
+    <br />
+    {makeSpan(5)}'19h17m32s 11d58m02s equ j2000' {makeSpan(5)}  '12.3 8.5 b1950'
+</div>;
 
-
-export function TargetFeedback ({showHelp, feedback, style={}}) {
+export function TargetFeedback ({showHelp, feedback, style={}, examples={}}) {
     let retval;
+    examples =  Object.assign({},defaultExamples, examples);
     style = Object.assign({}, topDivStyle, style);
     if (showHelp) {
-        const makeSpan= (w) => <span style={{paddingLeft: `${w}px`}}/>;
+
         retval= (
             <div  style={style}>
                 <div >
                     <div style={titleStyle}>
                         <i>Examples: </i>
                     </div>
-                    <div style={exDivStyle}>
-                        {makeSpan(5)} 'm81' {makeSpan(15)} 'ngc 13' {makeSpan(15)}  '12.34 34.89'  {makeSpan(15)} '46.53 -0.251 gal'
-                        <br />
-                        {makeSpan(5)}'19h17m32s 11d58m02s equ j2000' {makeSpan(5)}  '12.3 8.5 b1950'
-                    </div>
+                    {examples}
                 </div>
             </div>
         );

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -31,7 +31,7 @@ class TargetPanelView extends PureComponent {
 
     render() {
         const {showHelp, feedback, valid, message, onChange, value,
-            labelWidth, children, resolver, feedbackStyle, label= LABEL_DEFAULT}= this.props;
+            labelWidth, children, resolver, feedbackStyle, examples, label= LABEL_DEFAULT}= this.props;
         let positionField = (<InputFieldView
                                 valid={valid}
                                 visible= {true}
@@ -61,7 +61,7 @@ class TargetPanelView extends PureComponent {
                         wrapperStyle={{}}
                     />
                 </div>
-                <TargetFeedback {...{showHelp, feedback, style:feedbackStyle}}/>
+                <TargetFeedback {...{showHelp, feedback, style:feedbackStyle, examples}}/>
             </div>
         );
     }
@@ -75,6 +75,7 @@ TargetPanelView.propTypes = {
     valid   : PropTypes.bool.isRequired,
     showHelp   : PropTypes.bool.isRequired,
     feedback: PropTypes.string.isRequired,
+    examples: PropTypes.object,
     resolver: PropTypes.string.isRequired,
     message: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
This pr consist of making the examples custom to a particular target panel by making them a prop of the target panel view.

An example has been used in ExampleDialog.js. 
Go to localhost:8080/firefly/firefly-dev.html and open Example dialog popup. See the examples are different and are taken from SOFIA request.

This PR has been triggered and is associated with SOFIA request change in irsatest and can be seen by building SOFIA in IFE repos with same branch name.