### PR TITLE
Dm 14501 add lsst auth adapter

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.astro.ibe;
 
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.table.io.IpacTableException;
 import edu.caltech.ipac.table.io.IpacTableReader;
 import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
@@ -162,9 +163,10 @@ public class IBE {
                 progressKey = sourceParams.get("ProgressKey");
                 plotId = sourceParams.get("plotId");
             }
-            Map<String, String> identityCookies = ServerContext.getRequestOwner().getIdentityCookies();
 
-            return URLFileInfoProcessor.retrieveViaURL(url, dir, progressKey, plotId, null, identityCookies);
+            HttpServiceInput addtlInfo = HttpServiceInput.createWithCredential();
+
+            return URLFileInfoProcessor.retrieveViaURL(url, dir, progressKey, plotId, null, addtlInfo);
         } catch (DataAccessException e) {
             throw new IOException(e.getMessage(), e);
         }

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
@@ -164,7 +164,7 @@ public class IBE {
                 plotId = sourceParams.get("plotId");
             }
 
-            HttpServiceInput addtlInfo = HttpServiceInput.createWithCredential();
+            HttpServiceInput addtlInfo = HttpServiceInput.createWithCredential(url.toString());
 
             return URLFileInfoProcessor.retrieveViaURL(url, dir, progressKey, plotId, null, addtlInfo);
         } catch (DataAccessException e) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.data;
 
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.CacheKey;
 
@@ -26,9 +27,9 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
     public static final String HAS_ACCESS="hasAccess";
 
     private final Map<String,String> attributes= new HashMap<>(9);
-    private Map<String, String> cookies= null;
     private transient FileNameResolver resolver= null;
     private List<RelatedData> relatedData= null;
+    private HttpServiceInput requestInfo= null;
 
 
 //======================================================================
@@ -115,12 +116,12 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
 
     public List<RelatedData> getRelatedData() { return relatedData; }
 
-    public Map<String, String> getCookies() {
-        return cookies;
+    public HttpServiceInput getRequestInfo() {
+        return requestInfo;
     }
 
-    public void setCookies(Map<String, String> cookies) {
-        this.cookies = cookies;
+    public void setRequestInfo(HttpServiceInput requestInfo) {
+        this.requestInfo = requestInfo;
     }
 
     public String getInternalFilename() { return getAttribute(INTERNAL_NAME); }
@@ -175,8 +176,8 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
     public FileInfo copy() {
         FileInfo fi= new FileInfo();
         fi.attributes.putAll(this.attributes);
-        if (cookies!=null) {
-            fi.cookies= new HashMap<>(cookies);
+        if (requestInfo!=null) {
+            fi.requestInfo= requestInfo.copy();
         }
         if (resolver!=null) fi.resolver= resolver;
         if (relatedData!=null) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -34,9 +34,9 @@ public class AppServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             // should handle logout request.
-            String authToken = SsoAdapter.getAdapter().getAuthTokenId();
-            if (authToken != null) {
-                SsoAdapter.getAdapter().logout(authToken);
+            SsoAdapter ssoAdapter = ServerContext.getRequestOwner().getSsoAdapter();
+            if (ssoAdapter != null) {
+                ssoAdapter.logout();
             }
             // update login status
             UserInfo userInfo = ServerContext.getRequestOwner().getUserInfo();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -90,7 +90,7 @@ public class RequestOwner implements Cloneable {
             if (userInfo.isGuestUser()) {
                 wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(getUserKey()));
             } else {
-                wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(userInfo.getLoginName(), HttpServiceInput.createWithCredential().getCookies()));
+                wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(userInfo.getLoginName()));
             }
         }
         return wsManager;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -250,6 +250,7 @@ public class RequestOwner implements Cloneable {
         action.setValue(userInfo.getInstitute(), "institute");
         if (getSsoAdapter() != null) {
             action.setValue(getSsoAdapter().getLoginUrl(""), "login_url");
+            action.setValue(getSsoAdapter().getLogoutUrl(""), "logout_url");
         }
         ServerEventManager.fireAction(action);
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -7,12 +7,12 @@ import edu.caltech.ipac.firefly.data.userdata.UserInfo;
 import edu.caltech.ipac.firefly.server.cache.UserCache;
 import edu.caltech.ipac.firefly.server.events.FluxAction;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.security.SsoAdapter;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.ws.WorkspaceFactory;
 import edu.caltech.ipac.firefly.server.ws.WsCredentials;
 import edu.caltech.ipac.util.AppProperties;
-import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.cache.StringKey;
@@ -40,7 +40,6 @@ public class RequestOwner implements Cloneable {
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     public static String USER_KEY = "usrkey";
     public static final String SET_USERINFO_ACTION = "app_data.setUserInfo";
-//    private static final String[] ID_COOKIE_NAMES = new String[]{WebAuthModule.AUTH_KEY, "ISIS"};
     private static boolean ignoreAuth = AppProperties.getBooleanProperty("ignore.auth", false);
     private RequestAgent requestAgent;
     private Date startTime;
@@ -54,6 +53,7 @@ public class RequestOwner implements Cloneable {
 
     //------------------------------------------------------------------------------------
     private transient UserInfo userInfo;
+    private transient SsoAdapter ssoAdapter;
 
 
     public RequestOwner(String userKey, Date startTime) {
@@ -63,6 +63,13 @@ public class RequestOwner implements Cloneable {
 
     public RequestAgent getRequestAgent() {
         return requestAgent;
+    }
+
+    public SsoAdapter getSsoAdapter() {
+        if (ssoAdapter == null) {
+            ssoAdapter = SsoAdapter.getAdapter();
+        }
+        return ssoAdapter;
     }
 
     public void setRequestAgent(RequestAgent requestAgent) {
@@ -83,7 +90,7 @@ public class RequestOwner implements Cloneable {
             if (userInfo.isGuestUser()) {
                 wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(getUserKey()));
             } else {
-                wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(userInfo.getLoginName(), getIdentityCookies()));
+                wsManager = WorkspaceFactory.getWorkspaceHandler().withCredentials(new WsCredentials(userInfo.getLoginName(), HttpServiceInput.createWithCredential().getCookies()));
             }
         }
         return wsManager;
@@ -142,21 +149,16 @@ public class RequestOwner implements Cloneable {
         requestAgent.sendRedirect(url);
     }
 
-    public Map<String, String> getIdentityCookies() {
-        return SsoAdapter.getAdapter().getIdentities();
-    }
-
     public boolean isAuthUser() {
-        return !StringUtils.isEmpty(SsoAdapter.getAdapter().getAuthTokenId());
+        return getSsoAdapter() != null && getSsoAdapter().getAuthToken() != null;
     }
 
     public UserInfo getUserInfo() {
         if (userInfo == null) {
             if (isAuthUser() && !ignoreAuth) {
-                SsoAdapter sso = SsoAdapter.getAdapter();
-                userInfo = sso.getUserInfo();
+                userInfo = ssoAdapter.getUserInfo();
                 if (userInfo == null) {
-                    sso.clearAuthInfo();
+                    ssoAdapter.clearAuthInfo();
                 }
             }
 
@@ -246,7 +248,9 @@ public class RequestOwner implements Cloneable {
         action.setValue(userInfo.getFirstName(), "firstName");
         action.setValue(userInfo.getLastName(), "lastName");
         action.setValue(userInfo.getInstitute(), "institute");
-        action.setValue(SsoAdapter.getAdapter().makeAuthCheckUrl(""), "login_url");
+        if (getSsoAdapter() != null) {
+            action.setValue(getSsoAdapter().getLoginUrl(""), "login_url");
+        }
         ServerEventManager.fireAction(action);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
@@ -51,8 +51,8 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
      */
     private static final Namespace IRSA_NS = Namespace.getNamespace("irsa", "https://irsa.ipac.caltech.edu/namespace/");
     //TODO We might need to change those properties if we need to deal with 2 or more workspaces at the same time
-    private String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
-    private String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
+    private static String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
+    private static String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     private WsCredentials creds;
@@ -97,7 +97,7 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
      * @param cred {@link WsCredentials}
      */
     public WebDAVWorkspaceManager(WsCredentials cred) {
-        this(((cred.getPassword()!=null) || (cred.getCookies() != null))?Partition.SSOSPACE:Partition.PUBSPACE, cred, true);
+        this(ServerContext.getRequestOwner().isAuthUser() ? Partition.SSOSPACE : Partition.PUBSPACE, cred, true);
     }
 
     public WebDAVWorkspaceManager(String pubspaceId) {
@@ -119,6 +119,9 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
     }
 
     public WebDAVWorkspaceManager(Partition partition, String wsId, Map<String, String> cookies, boolean initialize) {
+
+        cookies = HttpServiceInput.createWithCredential(WS_HOST_URL).getCookies();          // should look at this again.
+
         this.creds = new WsCredentials(wsId, cookies);
         this.partition = partition;
         this.userHome = WspaceMeta.ensureWsHomePath(wsId);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
@@ -21,12 +21,21 @@ import java.util.stream.Collectors;
  * @version $Id: $
  */
 public class HttpServiceInput implements Cloneable{
+    private String requestUrl;
     private Map<String, String> params;
     private Map<String, String> headers;
     private Map<String, String> cookies;
     private Map<String, File> files;
     private String userId;
     private String passwd;
+
+    public String getRequestUrl() {
+        return requestUrl;
+    }
+
+    public void setRequestUrl(String requestUrl) {
+        this.requestUrl = requestUrl;
+    }
 
     public String getUserId() {
         return userId;
@@ -141,7 +150,12 @@ public class HttpServiceInput implements Cloneable{
 //====================================================================
 
     public static HttpServiceInput createWithCredential() {
+        return createWithCredential(null);
+    }
+
+    public static HttpServiceInput createWithCredential(String requestUrl) {
         HttpServiceInput input = new HttpServiceInput();
+        input.setRequestUrl(requestUrl);
         SsoAdapter ssoAdapter = ServerContext.getRequestOwner().getSsoAdapter();
         if (ssoAdapter != null) {
             ssoAdapter.setAuthCredential(input);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static org.apache.commons.httpclient.params.HttpMethodParams.USER_AGENT;
 
 
@@ -99,6 +100,7 @@ public class HttpServices {
      */
     public static Status getData(String url, HttpServiceInput input, Handler handler) {
         try {
+            url = isEmpty(url) && input != null ? input.getRequestUrl() : url;
             HttpMethod method = executeMethod(new GetMethod(url), input, handler);
             return Status.getStatus(method);
         } catch (IOException e) {
@@ -124,6 +126,7 @@ public class HttpServices {
 
     public static Status postData(String url, HttpServiceInput input, Handler handler) {
         try {
+            url = isEmpty(url) && input != null ? input.getRequestUrl() : url;
             HttpMethod method = executeMethod(new PostMethod(url), input, handler);
             return Status.getStatus(method);
         } catch (IOException e) {
@@ -272,7 +275,7 @@ public class HttpServices {
 //====================================================================
 
     private static void handleAuth(HttpClient client, HttpMethod method, String userId, String password) {
-        if (!StringUtils.isEmpty(userId)) {
+        if (!isEmpty(userId)) {
             UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(userId, password);
             client.getState().setCredentials(AuthScope.ANY, credentials);
         } else {
@@ -326,7 +329,7 @@ public class HttpServices {
                 }
             }
         } else {
-            if (StringUtils.isEmpty(method.getQueryString())) {
+            if (isEmpty(method.getQueryString())) {
                 if (params != null && params.size() > 0) {
                     List<NameValuePair> args = new ArrayList<>();
                     params.entrySet().stream()

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/Packager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/Packager.java
@@ -26,6 +26,7 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * User: roby
@@ -167,7 +168,9 @@ public class Packager {
             File targetFile; // target file should be created after the external name is set
             //------------
             if (filename.contains("://")) {
-                URLConnection uc = URLDownload.makeConnection(new URL(filename), fileInfo.getCookies());
+                Map<String, String> cookies = fileInfo.getRequestInfo() != null ? fileInfo.getRequestInfo().getCookies() : null;
+                Map<String, String> headers = fileInfo.getRequestInfo() != null ? fileInfo.getRequestInfo().getHeaders() : null;
+                URLConnection uc = URLDownload.makeConnection(new URL(filename), cookies, headers, false);
                 uc.setRequestProperty("Accept", "text/plain");
                 if (fileInfo.hasFileNameResolver()) {
                     String suggestedFilename = URLDownload.getSugestedFileName(uc);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/ZipHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/ZipHandler.java
@@ -25,6 +25,7 @@ import java.net.URLConnection;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -116,7 +117,9 @@ public class ZipHandler {
         if (filename.contains("://")) {
             try {
                 URL url = new URL(filename);
-                URLConnection uc = URLDownload.makeConnection(url, fi.getCookies());
+                Map<String, String> cookies = fi.getRequestInfo() != null ? fi.getRequestInfo().getCookies() : null;
+                Map<String, String> headers = fi.getRequestInfo() != null ? fi.getRequestInfo().getHeaders() : null;
+                URLConnection uc = URLDownload.makeConnection(url, cookies, headers, false);
                 uc.setRequestProperty("Accept", "text/plain");
 
                 if (fi.hasFileNameResolver()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IbeFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IbeFileRetrieve.java
@@ -15,6 +15,7 @@ import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.query.BaseFileInfoProcessor;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.ParamDoc;
@@ -51,8 +52,8 @@ public class IbeFileRetrieve extends BaseFileInfoProcessor {
             if (ofile == null ||  ofile.getSizeInBytes() == 0) {
                 return null;
             } else {
-                Map<String, String> cookies = ServerContext.getRequestOwner().getIdentityCookies();
-                ofile.setCookies(cookies);
+                HttpServiceInput requestInfo = HttpServiceInput.createWithCredential();
+                ofile.setRequestInfo(requestInfo);
                 ofile.addRelatedDataList( findRelatedDataList(request));
                 return ofile;
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IbeFileRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/IbeFileRetrieve.java
@@ -52,8 +52,6 @@ public class IbeFileRetrieve extends BaseFileInfoProcessor {
             if (ofile == null ||  ofile.getSizeInBytes() == 0) {
                 return null;
             } else {
-                HttpServiceInput requestInfo = HttpServiceInput.createWithCredential();
-                ofile.setRequestInfo(requestInfo);
                 ofile.addRelatedDataList( findRelatedDataList(request));
                 return ofile;
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -291,7 +291,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     }
 
     protected File createTempFile(TableServerRequest request, String fileExt) throws IOException {
-        return File.createTempFile(request.getRequestId(), fileExt, ServerContext.getTempWorkDir());
+        return File.createTempFile(request.getRequestId(), fileExt, getTempDir());
     }
 
     public boolean doCache() {return false;}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IbeTemplateProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IbeTemplateProcessor.java
@@ -30,7 +30,7 @@ public class IbeTemplateProcessor extends SharedDbProcessor {
         try {
             String url = treq.getParam("url");
             ByteArrayOutputStream results = new ByteArrayOutputStream();
-            HttpServices.getData(url, results, HttpServiceInput.createWithCredential());
+            HttpServices.getData(url, results, HttpServiceInput.createWithCredential(url));
             return IpacTableReader.read(new StringInputStream(results.toString()));
         } catch (IOException e) {
             throw new DataAccessException(e.getMessage(), e);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -4,6 +4,7 @@
 package edu.caltech.ipac.firefly.server.query;
 
 
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.table.IpacTableUtil;
 import edu.caltech.ipac.table.io.IpacTableReader;
 import edu.caltech.ipac.table.query.DataGroupQueryStatement;
@@ -82,8 +83,8 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
     public void downloadFile(URL url, File outFile) throws IOException, EndUserException {
         URLConnection conn = null;
         try {
-            Map<String, String> cookies = isSecurityAware() ? ServerContext.getRequestOwner().getIdentityCookies() : null;
-            conn = URLDownload.makeConnection(url, cookies);
+            HttpServiceInput inputs = HttpServiceInput.createWithCredential();
+            conn = URLDownload.makeConnection(url, inputs.getCookies(), inputs.getHeaders(), false);
             conn.setRequestProperty("Accept", "*/*");
             URLDownload.getDataToFile(conn, outFile);
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -83,7 +83,7 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
     public void downloadFile(URL url, File outFile) throws IOException, EndUserException {
         URLConnection conn = null;
         try {
-            HttpServiceInput inputs = HttpServiceInput.createWithCredential();
+            HttpServiceInput inputs = HttpServiceInput.createWithCredential(url.toString());
             conn = URLDownload.makeConnection(url, inputs.getCookies(), inputs.getHeaders(), false);
             conn.setRequestProperty("Accept", "*/*");
             URLDownload.getDataToFile(conn, outFile);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
@@ -38,7 +38,7 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
         HttpServiceInput addtlInfo = null;
 
         if (identityAware()) {
-            addtlInfo = HttpServiceInput.createWithCredential();
+            addtlInfo = HttpServiceInput.createWithCredential(url.toString());
         }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.server.query;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.visualize.LockingVisNetwork;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.util.FileUtil;
@@ -34,14 +35,14 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
         URL url= getURL(sr);
         String progressKey= sr.getParam(WebPlotRequest.PROGRESS_KEY);
         String plotId= sr.getParam(WebPlotRequest.PLOT_ID);
-        Map<String, String> identityCookies= null;
+        HttpServiceInput addtlInfo = null;
 
         if (identityAware()) {
-            identityCookies = ServerContext.getRequestOwner().getIdentityCookies();
+            addtlInfo = HttpServiceInput.createWithCredential();
         }
 
 
-        return retrieveViaURL(url,null,progressKey,plotId,getFileExtension(),identityCookies );
+        return retrieveViaURL(url,null,progressKey,plotId,getFileExtension(),addtlInfo );
 
     }
 
@@ -62,7 +63,7 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
                                           String progressKey,
                                           String plotId,
                                           String fileExtension,
-                                          Map<String, String> identityCookies)
+                                          HttpServiceInput addtlInfo)
                                                  throws IOException, DataAccessException {
         FileInfo retval= null;
         try {
@@ -73,10 +74,9 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
             if (!StringUtils.isEmpty(fileExtension)) {
                 params.setLocalFileExtensions(Arrays.asList(fileExtension));
             }
-            if (identityCookies != null && identityCookies.size() > 0) {
-                for (String key : identityCookies.keySet()) {
-                    params.addCookie(key, identityCookies.get(key));
-                }
+
+            if (addtlInfo != null) {
+                params.setAddtlInfo(addtlInfo);
             }
             if (ServerContext.getRequestOwner().isAuthUser()) {
                 params.setLoginName(ServerContext.getRequestOwner().getUserInfo().getLoginName());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.query.lc;
 
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.table.io.IpacTableException;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.FileInfo;
@@ -74,7 +75,6 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
         double sizeD = StringUtils.isEmpty(subSize) ? 0 : Double.parseDouble(subSize);
         String sizeAsecStr = String.valueOf((int) (sizeD * 3600));
 
-        Map<String, String> cookies = ServerContext.getRequestOwner().getIdentityCookies();
         for (int rowIdx : selectedRows) {
             FileInfo fi = null;
             String pidstr = dgData.get(rowIdx, "pid").toString();
@@ -136,7 +136,8 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
                 fi = new FileInfo(url, extName, 0);
             }
             if (fi != null) {
-                fi.setCookies(cookies);
+                HttpServiceInput requestInfo = HttpServiceInput.createWithCredential();
+                fi.setRequestInfo(requestInfo);
                 fiArr.add(fi);
                 fgSize += fi.getSizeInBytes();
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -131,13 +131,13 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
 //                }
 
                 fi = new FileInfo(url, extName, 0);
+                fi.setRequestInfo(HttpServiceInput.createWithCredential(url));
             } else {
                 String url = baseUrl + fileName;
                 fi = new FileInfo(url, extName, 0);
+                fi.setRequestInfo(HttpServiceInput.createWithCredential(url));
             }
             if (fi != null) {
-                HttpServiceInput requestInfo = HttpServiceInput.createWithCredential();
-                fi.setRequestInfo(requestInfo);
                 fiArr.add(fi);
                 fgSize += fi.getSizeInBytes();
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/ZtfLCFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/ZtfLCFileGroupsProcessor.java
@@ -128,13 +128,13 @@ public class ZtfLCFileGroupsProcessor extends FileGroupsProcessor {
                 logger.briefInfo("cutout url: " + url);
                 // strip out filename when using file resolver
                 fi = new FileInfo(url, extName, 0);
+                fi.setRequestInfo(HttpServiceInput.createWithCredential(url));
             } else {
                 String url = baseUrl + fName;
                 fi = new FileInfo(url, extName,0);
+                fi.setRequestInfo(HttpServiceInput.createWithCredential(url));
             }
             if (fi != null) {
-                HttpServiceInput requestInfo = HttpServiceInput.createWithCredential();
-                fi.setRequestInfo(requestInfo);
                 fiArr.add(fi);
                 fgSize += fi.getSizeInBytes();
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/ZtfLCFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/ZtfLCFileGroupsProcessor.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.query.lc;
 
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.table.io.IpacTableException;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.FileInfo;
@@ -78,8 +79,6 @@ public class ZtfLCFileGroupsProcessor extends FileGroupsProcessor {
         String baseUrl = getBaseURL(request);
 
 
-        Map<String, String> cookies = ServerContext.getRequestOwner().getIdentityCookies();
-
         for (int rowIdx : selectedRows) {
             String filefracday = String.valueOf(dgData.get(rowIdx, "filefracday"));
             String field = String.valueOf(dgData.get(rowIdx, "field"));
@@ -134,7 +133,8 @@ public class ZtfLCFileGroupsProcessor extends FileGroupsProcessor {
                 fi = new FileInfo(url, extName,0);
             }
             if (fi != null) {
-                fi.setCookies(cookies);
+                HttpServiceInput requestInfo = HttpServiceInput.createWithCredential();
+                fi.setRequestInfo(requestInfo);
                 fiArr.add(fi);
                 fgSize += fi.getSizeInBytes();
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCatalogSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTCatalogSearch.java
@@ -294,18 +294,6 @@ public class LSSTCatalogSearch extends LSSTQuery {
     }
 
     @Override
-    protected String getFilePrefix(TableServerRequest request) {
-        String catTable = request.getParam(CatalogRequest.CATALOG);
-        if (catTable == null) {
-            return request.getRequestId();
-        } else {
-            return catTable+"-dd-";
-        }
-
-    }
-
-
-    @Override
     public void prepareTableMeta(TableMeta meta, List<DataType> columns, ServerRequest request) {
 
         super.prepareTableMeta(meta, columns, request);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
@@ -7,8 +7,9 @@ import edu.caltech.ipac.firefly.data.CatalogRequest;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
-import edu.caltech.ipac.firefly.server.query.IpacTablePartProcessor;
+import edu.caltech.ipac.firefly.server.query.EmbeddedDbProcessor;
 import edu.caltech.ipac.firefly.server.query.SearchManager;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.table.DataGroup;
@@ -29,13 +30,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Base class for LSSTCatalogSearch and LSSTLightCurveQuery
  */
-public abstract class LSSTQuery extends IpacTablePartProcessor {
+public abstract class LSSTQuery extends EmbeddedDbProcessor {
     private static final Logger.LoggerImpl _log = Logger.getLogger();
 
     // LSST DAX services are listed in https://confluence.lsstcorp.org/display/DM/DAX+service+URLs
@@ -87,29 +86,17 @@ public abstract class LSSTQuery extends IpacTablePartProcessor {
         }
     }
 
-    protected File loadDataFile(TableServerRequest request) throws IOException, DataAccessException {
-        return loadDataFileImpl(request);
-    }
-
     DataGroup  getDataFromURL(TableServerRequest request) throws Exception {
 
         String sql = "QUERY=" + URLEncoder.encode(buildSqlQueryString(request),"UTF-8");
         _log.briefDebug("Executing SQL query: " + sql);
-        File file = createFile(request, ".json");
-        Map<String, String> requestHeader=new HashMap<>();
-        requestHeader.put("Accept", "application/json");
+        File file = createTempFile(request, ".json");
 
-        // temporary changes for now until it's more clear what to do.
-        Map<String, String> idHeaders = ServerContext.getRequestOwner().getIdentityCookies();
-        if (idHeaders != null && idHeaders.size() > 0) {
-            idHeaders.forEach((key, value) -> {
-                requestHeader.put(key, value);
-                _log.debug("Is logged in with: " + key + ": " + value.substring(0, 20) + "...");
-            });
-        }
+        HttpServiceInput inputs = HttpServiceInput.createWithCredential();
+        inputs.setHeader("Accept", "application/json");
 
         long cTime = System.currentTimeMillis();
-        FileInfo fileData = URLDownload.getDataToFileUsingPost(new URL(getDbservURL()),  sql,null,  requestHeader, file, null, timeout);
+        FileInfo fileData = URLDownload.getDataToFileUsingPost(new URL(getDbservURL()),  sql, inputs.getCookies(), inputs.getHeaders(), file, null, timeout);
         _log.briefDebug("SQL query took " + (System.currentTimeMillis() - cTime) + "ms");
 
         if (fileData.getResponseCode() >= 400) {
@@ -260,8 +247,8 @@ public abstract class LSSTQuery extends IpacTablePartProcessor {
                 jsonMetaInfo = (JSONObject) new JSONParser().parse(lsstMetaStr);
             } catch (Exception e) {
                 jsonMetaInfo = new JSONObject();
-                LOGGER.error("Failed retrieving info from " + resource);
-                LOGGER.error(e);
+                _log.error("Failed retrieving info from " + resource);
+                _log.error(e);
             }
         }
         return jsonMetaInfo;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTQuery.java
@@ -92,7 +92,7 @@ public abstract class LSSTQuery extends EmbeddedDbProcessor {
         _log.briefDebug("Executing SQL query: " + sql);
         File file = createTempFile(request, ".json");
 
-        HttpServiceInput inputs = HttpServiceInput.createWithCredential();
+        HttpServiceInput inputs = HttpServiceInput.createWithCredential(getDbservURL());
         inputs.setHeader("Accept", "application/json");
 
         long cTime = System.currentTimeMillis();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
@@ -62,7 +62,8 @@ public class PtfIbeResolver {
     public String[] getValuesFromColumn(long pid[], String colName) throws IOException {
         File tempFile = getTempFile();
         try {
-            URLConnection aconn = URLDownload.makeConnection(createURL(pid), getAddtlInputs().getCookies(), getAddtlInputs().getHeaders(), false);
+            URL url = createURL(pid);
+            URLConnection aconn = URLDownload.makeConnection(url, getAddtlInputs(url.toString()).getCookies(), getAddtlInputs(url.toString()).getHeaders(), false);
             aconn.setRequestProperty("Accept", "*/*");
             URLDownload.getDataToFile(aconn, tempFile);
         } catch (Exception e) {
@@ -109,8 +110,8 @@ public class PtfIbeResolver {
         return f;
     }
 
-    private HttpServiceInput getAddtlInputs() {
+    private HttpServiceInput getAddtlInputs(String url) {
         if(isTestMode) return new HttpServiceInput();//or overwrite in test unit
-        return HttpServiceInput.createWithCredential();
+        return HttpServiceInput.createWithCredential(url);
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ptf/PtfIbeResolver.java
@@ -4,6 +4,7 @@
 package edu.caltech.ipac.firefly.server.query.ptf;
 
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.table.io.IpacTableReader;
@@ -61,7 +62,7 @@ public class PtfIbeResolver {
     public String[] getValuesFromColumn(long pid[], String colName) throws IOException {
         File tempFile = getTempFile();
         try {
-            URLConnection aconn = URLDownload.makeConnection(createURL(pid), getCookies());
+            URLConnection aconn = URLDownload.makeConnection(createURL(pid), getAddtlInputs().getCookies(), getAddtlInputs().getHeaders(), false);
             aconn.setRequestProperty("Accept", "*/*");
             URLDownload.getDataToFile(aconn, tempFile);
         } catch (Exception e) {
@@ -108,8 +109,8 @@ public class PtfIbeResolver {
         return f;
     }
 
-    public Map<String,String> getCookies() {
-        if(isTestMode) return null;//or overwrite in test unit
-        return ServerContext.getRequestOwner().getIdentityCookies();
+    private HttpServiceInput getAddtlInputs() {
+        if(isTestMode) return new HttpServiceInput();//or overwrite in test unit
+        return HttpServiceInput.createWithCredential();
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
@@ -9,18 +9,16 @@ import edu.caltech.ipac.firefly.server.RequestAgent;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import edu.caltech.ipac.util.StringUtils;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
-import java.util.HashMap;
-import java.util.Map;
 
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 /**
  * This class support authentication in which mod_auth_openidc is used
  * at the proxy level.
+ *
+ * DISCLAIMER: This class is currently unused and untested.
  *
  * @author loi
  * @version $Id: JOSSOAdapter.java,v 1.14 2012/10/10 21:54:45 loi Exp $

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
@@ -88,7 +88,9 @@ public class AuthOpenidcMod implements SsoAdapter {
     public void setAuthCredential(HttpServiceInput inputs) {
         Token token = getAuthToken();
         if (token != null && token.getId() != null) {
-            inputs.setHeader("Authorization", "Bearer " + token.getId());
+            if (SsoAdapter.requireAuthCredential(inputs.getRequestUrl(), null)) {
+                inputs.setHeader("Authorization", "Bearer " + token.getId());
+            }
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
@@ -241,10 +241,12 @@ public class JOSSOAdapter implements SsoAdapter {
     public void setAuthCredential(HttpServiceInput inputs) {
         RequestAgent http = ServerContext.getRequestOwner().getRequestAgent();
         if(http!=null){
-            for (String name : ID_COOKIE_NAMES) {
-                String value = http.getCookieVal(name);
-                if (!isEmpty(value)) {
-                    inputs.setCookie(name, value);
+            if (SsoAdapter.requireAuthCredential(inputs.getRequestUrl(), "ipac.caltech.edu")) {
+                for (String name : ID_COOKIE_NAMES) {
+                    String value = http.getCookieVal(name);
+                    if (!isEmpty(value)) {
+                        inputs.setCookie(name, value);
+                    }
                 }
             }
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
@@ -8,10 +8,12 @@ import edu.caltech.ipac.firefly.data.userdata.RoleList;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
 import edu.caltech.ipac.firefly.server.RequestAgent;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.Base64;
 import edu.caltech.ipac.util.StringUtils;
+import org.apache.http.HttpResponse;
 import org.josso.gateway.ws._1_2.protocol.AssertIdentityWithSimpleAuthenticationRequestType;
 import org.josso.gateway.ws._1_2.protocol.AssertIdentityWithSimpleAuthenticationResponseType;
 import org.josso.gateway.ws._1_2.protocol.AssertionNotValidErrorType;
@@ -46,6 +48,8 @@ import java.rmi.RemoteException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
+
 /**
  * Date: Mar 30, 2010
  *
@@ -72,7 +76,7 @@ public class JOSSOAdapter implements SsoAdapter {
      * @param token
      * @return
      */
-    public long checkSession(String token) {
+    private long checkSession(String token) {
 
         try {
             SSOSessionManager man = getIdSessLoc().getSSOSessionManagerSoap();
@@ -94,7 +98,7 @@ public class JOSSOAdapter implements SsoAdapter {
      * @param token
      * @return
      */
-    public RoleList getRoles(String token) {
+    private RoleList getRoles(String token) {
 
         RoleList roles = new RoleList();
         try {
@@ -154,7 +158,12 @@ public class JOSSOAdapter implements SsoAdapter {
         return old;
     }
 
-    public Token resolveAuthToken(String assertionKey) {
+    public Token resolveAuthToken(HttpServletRequest req) {
+        return resolveAuthToken(req.getParameter(JOSSO_ASSERT_ID));
+    }
+
+    private Token resolveAuthToken(String assertionKey) {
+
         if (assertionKey == null) return null;
         
         try {
@@ -172,9 +181,13 @@ public class JOSSOAdapter implements SsoAdapter {
         return null;
     }
 
-    public boolean logout(String token) {
+    public boolean logout() {
+        return logout(getAuthTokenId());
+    }
+
+    private boolean logout(String token) {
         try {
-            if (!StringUtils.isEmpty(token)) {
+            if (!isEmpty(token)) {
                 SSOIdentityProvider idProv = getIdProvLoc().getSSOIdentityProviderSoap();
                 idProv.globalSignoff(new GlobalSignoffRequestType(REQUESTER, token));
                 return true;
@@ -193,7 +206,7 @@ public class JOSSOAdapter implements SsoAdapter {
         return user;
     }
 
-    public String createSession(String name, String passwd) {
+    private String createSession(String name, String passwd) {
         try {
             SSOIdentityProvider idProv = getIdProvLoc().getSSOIdentityProviderSoap();
             AssertIdentityWithSimpleAuthenticationResponseType rval = idProv.assertIdentityWithSimpleAuthentication(
@@ -207,13 +220,9 @@ public class JOSSOAdapter implements SsoAdapter {
         return null;
     }
 
-    public String getAssertKey() {
-        return JOSSO_ASSERT_ID;
-    }
-
     public String getRequestedUrl(HttpServletRequest req) {
         String backTo = req.getParameter(JossoUtil.VERIFIER_BACK_TO);
-        if (StringUtils.isEmpty(backTo)) {
+        if (isEmpty(backTo)) {
             String path = req.getRequestURL().toString();
             backTo = path.substring(0, path.indexOf(req.getContextPath()));
             String qstr = req.getQueryString() == null ? "" : "?" + req.getQueryString();
@@ -225,37 +234,39 @@ public class JOSSOAdapter implements SsoAdapter {
         return backTo;
     }
 
-    public String makeAuthCheckUrl(String backTo) {
+    public String getLoginUrl(String backTo) {
         return JossoUtil.makeAuthCheckUrl(backTo);
     }
 
-    public Map<String, String> getIdentities() {
-        HashMap<String, String> idCookies = new HashMap<String, String>();
+    public void setAuthCredential(HttpServiceInput inputs) {
         RequestAgent http = ServerContext.getRequestOwner().getRequestAgent();
         if(http!=null){
             for (String name : ID_COOKIE_NAMES) {
                 String value = http.getCookieVal(name);
-                if (!StringUtils.isEmpty(value)) {
-                    idCookies.put(name, value);
+                if (!isEmpty(value)) {
+                    inputs.setCookie(name, value);
                 }
             }
         }
-        return idCookies.size() == 0 ? null : idCookies;
     }
 
     public UserInfo getUserInfo() {
         String authToken = getAuthTokenId();
-        return StringUtils.isEmpty(authToken) ? null : getUserInfo(authToken);
+        return isEmpty(authToken) ? null : getUserInfo(authToken);
     }
 
     public Token getAuthToken() {
         Cookie authCookie = ServerContext.getRequestOwner().getRequestAgent().getCookie(AUTH_KEY);
-        Token token = new Token(getAuthTokenId());
-        token.setExpiresOn(System.currentTimeMillis() + authCookie.getMaxAge() * 1000);
-        return token;
+        if (!isEmpty(authCookie)) {
+            Token token = new Token(getAuthTokenId());
+            token.setExpiresOn(System.currentTimeMillis() + authCookie.getMaxAge() * 1000);
+            return token;
+        } else {
+            return null;
+        }
     }
 
-    public String getAuthTokenId() {
+    private String getAuthTokenId() {
         return ServerContext.getRequestOwner().getRequestAgent().getCookieVal(AUTH_KEY);
     }
 
@@ -276,12 +287,15 @@ public class JOSSOAdapter implements SsoAdapter {
 //====================================================================
 
     private void updateAuthInfo(Token authToken) {
-        String authTokenId = authToken == null ? null : authToken.getId();
-        Cookie c = new Cookie(AUTH_KEY, authTokenId);
-        c.setMaxAge(authToken == null ? 0 : 60 * 60 * 24 * 14);
-        c.setValue(authTokenId);
-        c.setPath("/");
-        ServerContext.getRequestOwner().getRequestAgent().sendCookie(c);
+        RequestAgent agent = ServerContext.getRequestOwner().getRequestAgent();
+        if (agent != null) {
+            String authTokenId = authToken == null ? null : authToken.getId();
+            Cookie c = new Cookie(AUTH_KEY, authTokenId);
+            c.setMaxAge(authToken == null ? 0 : 60 * 60 * 24 * 14);
+            c.setValue(authTokenId);
+            c.setPath("/");
+            agent.sendCookie(c);
+        }
     }
 
     private static SSOIdentityManagerWSLocator getIdManLoc() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
@@ -69,6 +69,7 @@ public interface SsoAdapter {
 
     default String getLoginUrl(String backTo) {return null;}
 
+    default String getLogoutUrl(String backTo) {return null;}
     /**
      * set the require info to identify the current logged in user
      * when making an http request to external services.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
@@ -2,6 +2,7 @@ package edu.caltech.ipac.firefly.server.security;
 
 import edu.caltech.ipac.firefly.data.userdata.RoleList;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
@@ -11,7 +12,10 @@ import org.apache.http.HttpResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.Serializable;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
@@ -81,6 +85,26 @@ public interface SsoAdapter {
 // convenience factory methods
 //====================================================================
 
+    static boolean requireAuthCredential(String reqUrl, String... reqAuthHosts) {
+        if (!isEmpty(reqUrl)) {
+            try {
+                String reqHost = new URL(ServerContext.resolveUrl(reqUrl)).getHost().toLowerCase();
+                String host = ServerContext.getRequestOwner().getHostUrl();
+                if (reqHost.equals(host.toLowerCase())) {
+                    return true;
+                } else if(reqAuthHosts != null) {
+                    for (String domain : reqAuthHosts) {
+                        if (domain != null && reqHost.endsWith(domain.trim().toLowerCase())) {
+                            return true;
+                        }
+                    }
+                }
+            } catch (MalformedURLException e) {
+                // ignore..
+            }
+        }
+        return false;
+    }
 
     static SsoAdapter getAdapter() {
         String byClz = AppProperties.getProperty(SSO_FRAMEWORK_ADAPTER, "");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
@@ -2,13 +2,19 @@ package edu.caltech.ipac.firefly.server.security;
 
 import edu.caltech.ipac.firefly.data.userdata.RoleList;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
+import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
+import org.apache.http.HttpResponse;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 /**
  * Date: 5/16/17
@@ -20,63 +26,55 @@ public interface SsoAdapter {
 
     String SSO_FRAMEWORK_NAME = "sso.framework.name";
     String SSO_FRAMEWORK_ADAPTER = "sso.framework.adapter";
-    String JOSSO = "josso";
-    String OPENID_CONNECT = "oidc";
-    String MOD_AUTH_OPENIDC = "mod_auth_openidc";
+
+    enum SsoFramework {
+        josso(JOSSOAdapter.class),
+        oidc(OidcAdapter.class),
+        mod_auth_openidc(AuthOpenidcMod.class);
+
+        Class clz;
+        SsoFramework(Class clz) { this.clz= clz;}
+        SsoAdapter newAdapter() {
+            try {
+                return (SsoAdapter)clz.newInstance();
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
 
     /**
-     * returns the number of seconds before this session expires.  0 if session is not valid, or it's already expires.
-     * Defaults to expired.
-     * @param token
-     * @return
+     * If your framework uses flow that redirect a user to an identity provider to authenticate,
+     * this method will be used to accept the callback and create an auth token from the response.
      */
-    default long checkSession(String token) { return 0; }
-
-    /**
-     * return all of the roles for a user authenticated with this token.
-     * @param token
-     * @return
-     */
-    RoleList getRoles(String token);
-
-    /**
-     * This is SAML based.. should eventually remove from interface
-     * @param assertionKey
-     */
-    default Token resolveAuthToken(String assertionKey) {return null;}
+    default Token resolveAuthToken(HttpServletRequest req) {return null;}
 
     /**
      * Using the old token, return a refreshed token
      * @param old the old token
      */
-    default Token refreshAuthToken(Token old) {return null;};
+    default Token refreshAuthToken(Token old) {return null;}
 
-    boolean logout(String token);
+    default boolean logout() {return false; }
 
-    /* this may not be needed .. consider removing */
-    default UserInfo login(String name, String passwd) {return null;};
-
-    /* this may not be needed .. consider removing */
-    default String createSession(String name, String passwd) {return null;};
-
-    /**
-     * This is SAML based.. should eventually remove from interface
-     */
-    default String getAssertKey() {return null;};
+    default UserInfo login(String name, String passwd) {return null;}
 
     Token getAuthToken();
 
-    String getAuthTokenId();
-
     UserInfo getUserInfo();
 
-    void clearAuthInfo();
+    default void clearAuthInfo() {};
 
-    Map<String, String> getIdentities();
+    default String getRequestedUrl(HttpServletRequest req) {return null;}
 
-    String getRequestedUrl(HttpServletRequest req);
+    default String getLoginUrl(String backTo) {return null;}
 
-    String makeAuthCheckUrl(String backTo);
+    /**
+     * set the require info to identify the current logged in user
+     * when making an http request to external services.
+     * @param inputs
+     */
+    default void setAuthCredential(HttpServiceInput inputs) {};
 
 //====================================================================
 // convenience factory methods
@@ -84,42 +82,34 @@ public interface SsoAdapter {
 
 
     static SsoAdapter getAdapter() {
-        String ssoFrameworkAdapter = AppProperties.getProperty(SSO_FRAMEWORK_ADAPTER, "");
-        if (!StringUtils.isEmpty(ssoFrameworkAdapter)) {
-            return AdapterGetter.getAdapter(ssoFrameworkAdapter);
-        } else {
-            String ssoFrameworkName = AppProperties.getProperty(SSO_FRAMEWORK_NAME, "");
-            switch (ssoFrameworkName) {
-                case JOSSO:
-                    return new JOSSOAdapter();
-                case OPENID_CONNECT:
-                    return new OidcAdapter();
-                case MOD_AUTH_OPENIDC:
-                    return new AuthOpenidcMod();
-                default:
-                    return new JOSSOAdapter();
+        String byClz = AppProperties.getProperty(SSO_FRAMEWORK_ADAPTER, "");
+        String byName = AppProperties.getProperty(SSO_FRAMEWORK_NAME, "");
+        try {
+            if (!isEmpty(byClz)) {
+                return AdapterClassResovler.getAdapter(byClz);
+            } else if (!isEmpty(byName)) {
+                return SsoFramework.valueOf(byName).newAdapter();
             }
+        } catch (Exception e) {
+            Logger.getLogger().error(e, String.format("Cannot resolve adapter for: byClz: %s  byName: %s", byClz, byName));
         }
+        return null;
     }
 
-    class AdapterGetter {
+    class AdapterClassResovler {
         private static Map<String, Class> LOADED_ADAPTERS;      // to avoid repeatedly loading the same class
 
-        static SsoAdapter getAdapter(String className) {
-            try {
-                System.out.println("SSO_FRAMEWORK_ADAPTER = " + className);
-                if (LOADED_ADAPTERS == null) {
-                    LOADED_ADAPTERS = new HashMap<>();
-                }
-                Class aClass = LOADED_ADAPTERS.get(className);
-                if (aClass == null) {
-                    aClass = SsoAdapter.class.getClassLoader().loadClass(className);
-                    LOADED_ADAPTERS.put(className, aClass);
-                }
-                return (SsoAdapter) aClass.newInstance();
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-                return new JOSSOAdapter();
+        static SsoAdapter getAdapter(String className) throws Exception {
+            if (LOADED_ADAPTERS == null) {
+                LOADED_ADAPTERS = new HashMap<>();
             }
+            Class aClass = LOADED_ADAPTERS.get(className);
+            if (aClass == null) {
+                Logger.getLogger().debug("Loading new SSO_FRAMEWORK_ADAPTER = " + className);
+                aClass = SsoAdapter.class.getClassLoader().loadClass(className);
+                LOADED_ADAPTERS.put(className, aClass);
+            }
+            return (SsoAdapter) aClass.newInstance();
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
@@ -126,7 +126,8 @@ public class LockingVisNetwork {
 
         try {
             File fileName= (fileInfo==null) ? CacheHelper.makeFile(params.getFileDir(), params.getUniqueString()) : fileInfo.getFile();
-            fileInfo= URLDownload.getDataToFile(params.getURL(), fileName, params.getCookies(), null,
+            Map<String, String> headers = params.getAddtlInfo() == null ? null : params.getAddtlInfo().getHeaders();
+            fileInfo= URLDownload.getDataToFile(params.getURL(), fileName, params.getCookies(), headers,
                                                 dl, false,true, params.getMaxSizeToDownload());
             if (fileInfo.getResponseCode()==200) CacheHelper.putFile(params,fileInfo);
             return fileInfo;

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.visualize.net;
 
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.download.BaseNetParams;
 
@@ -24,6 +25,7 @@ public class AnyUrlParams extends BaseNetParams {
     private String _desc = null;
     private File _dir = null; // if null, the use the default dir
     private static long _maxSizeToDownload= 0L;
+    private HttpServiceInput addtlInfo;
 
 
     public AnyUrlParams(URL url) { this(url,null,null); }
@@ -35,6 +37,14 @@ public class AnyUrlParams extends BaseNetParams {
 
     public URL getURL() { return _url; }
 
+    public HttpServiceInput getAddtlInfo() {
+        return addtlInfo;
+    }
+
+    public void setAddtlInfo(HttpServiceInput addtlInfo) {
+        this.addtlInfo = addtlInfo;
+    }
+
     public String getUniqueString() {
         String fileStr= _url.getFile();
         fileStr= fileStr.replace('&','-');
@@ -43,6 +53,7 @@ public class AnyUrlParams extends BaseNetParams {
         if (_loginName!=null)  {
             loginName= "-"+ _loginName;
         }
+
         if (_securityCookie!=null && cookies!=null && cookies.containsKey(_securityCookie))  {
             securCookie= "-"+ cookies.get(_securityCookie);
         }
@@ -50,7 +61,8 @@ public class AnyUrlParams extends BaseNetParams {
         // since this string is limited to MAX_LENGTH, having loginName in the baseKey is not ideal
         // loginName can be long.  it'll be used in hashcode calculation instead.
         String baseKey = securCookie +"-"+ fileStr;
-        int originalHashCode = (_url.getHost() + loginName + baseKey).hashCode();
+        String addtlKeys = addtlInfo == null ? "" : addtlInfo.getDesc();
+        int originalHashCode = (_url.getHost() + loginName + baseKey + addtlKeys).hashCode();
         baseKey= baseKey.replaceAll("[ :\\[\\]\\/\\\\|\\*\\?\\+<>]", "");
 
 
@@ -102,12 +114,12 @@ public class AnyUrlParams extends BaseNetParams {
     }
 
     public Map<String,String> getCookies() {
-        Map<String,String> retval;
-        if (cookies==null) {
-            retval= Collections.emptyMap();
+        Map<String,String> retval = new HashMap<>();
+        if (cookies != null ) {
+            retval.putAll(cookies);
         }
-        else {
-            retval= cookies;
+        if (addtlInfo != null && addtlInfo.getCookies() != null) {
+            retval.putAll(addtlInfo.getCookies());
         }
         return retval;
     }

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -7,8 +7,6 @@ import PropTypes from 'prop-types';
 import {SimpleComponent} from './SimpleComponent.jsx';
 import {getUserInfo} from '../core/AppDataCntlr.js';
 import {logout} from '../rpc/CoreServices.js';
-import {getRootURL} from '../util/BrowserUtil.js';
-import {getProp} from '../util/WebUtil.js';
 import './Banner.css';
 
 
@@ -63,22 +61,21 @@ export class UserInfo extends SimpleComponent {
     }
 
     render() {
-        const logoutUri = getProp('sso_redirect_uri', '');
-
-        const {loginName='Guest', firstName, lastName, login_url} = this.state || {};
+        const {loginName='Guest', firstName, lastName, login_url, logout_url} = this.state || {};
         const isGuest = loginName === 'Guest';
         const onLogin = () => login_url && (window.location = login_url);
         const onLogout = () => {
-            if (logoutUri) {
-                window.location = `${getRootURL()}${logoutUri}?logout=${getRootURL()}`;
-            } else {
-                logout();
+            if (logout_url) {
+                window.location = logout_url;
             }
+            logout();
         };
+
+        const displayName = firstName || lastName ? `${firstName} ${lastName}` : loginName;
 
         return (
             <div className='banner__user-info'>
-                <span>{loginName}</span>
+                <span>{displayName}</span>
                 {!isGuest && <div className='banner__user-info--links' onClick={onLogout}>Logout</div>}
                 {isGuest && <div className='banner__user-info--links' onClick={onLogin}>Login</div>}
             </div>

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -273,20 +273,6 @@ export function fetchUrl(url, options, doValidation= true, enableDefOptions= tru
 
     if (!url) return;
 
-
-    // ?info=json&access_token_refresh_interval=<seconds>
-    const ssoRedirect = getProp('sso_redirect_uri');
-    if (ssoRedirect) {
-        const refreshUrl =  `${getRootURL()}${ssoRedirect}?info=json&access_token_refresh_interval=0`;
-        fetch(refreshUrl).then( (resp) =>  {
-            resp.text().then( (text) => {
-                //console.log( text );
-            });
-        });
-    }
-
-
-
     // define defaults request options
     options = options || {};
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/PtfIbeTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/PtfIbeTest.java
@@ -38,11 +38,6 @@ public class PtfIbeTest extends ConfigTest {
             protected File getTempFile() throws IOException {
                 return f;
             }
-
-            @Override
-            public Map<String, String> getCookies() {
-                return null;
-            }
         };
         String[] fs = res.getValuesFromColumn(pids, "pfilename");
 


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-14501

Add authentication hook for LSST portal to CILogon.

Additional changes in these repositories: 
https://github.com/lsst/suit/pull/10
https://github.com/IPAC-SW/irsa-ife/pull/44

- Cleanup SsoAdapter interface
- Allow custom adapter by class name
- Improve mechanism for handling requests to external services on behalf of the user.
- Converted LSSTQuery to be subclass of DbProcessor

Test:  https://lsst-lsp-int.ncsa.illinois.edu/portal/suit/

Known Bug:  Cannot log in when using NCSA as an identify provider.
You must use your external linked ID, like github or google.

If you go here:
https://identity.lsst.org/manage
... You can login with your NCSA credentials.
You should see, if you linked a provider to your (e.g. Caltech, Google) with your account, an email address for the linked provider in the "External Identities" Section
Only the external identities are working right now, for some reason


To test access to LSST's services using provided tokens:
- External Images -> URL (image source) -> https://lsst-lsp-int.ncsa.illinois.edu/workspace/datasets/decam/2013-05-12/r/decam0205704.fits.fz

This is a very big file.  Use something smaller if you know how to navigate LSST's dataset tree.
I encountered `URL too long` issue when trying to use a smaller image:  https://lsst-lsp-int.ncsa.illinois.edu/workspace/datasets/sdss/preprocessed/dr7/sdss_stripe82_01/calexps/sci-results/1894/4/u/calexp/calexp-001894-u4-0011.fits

Both URLs were given by Brian.

