### PR TITLE
IRSA-2568: Coverage now does a more rigorous check for validate coverage

### DIFF
--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -512,7 +512,7 @@ function hasCorners(options, table) {
     const cornerColumns= options.getCornersColumns(table);
     if (isEmpty(cornerColumns)) return false;
     const dataCnt= table.tableData.data.reduce( (tot, row) =>
-        cornerColumns.every( (cDef) => row[cDef.lonIdx]!=='' && row[cDef.latIdx]!=='') ? 1 : 0
+        cornerColumns.every( (cDef) => row[cDef.lonIdx]!=='' && row[cDef.latIdx]!=='') ? tot+1 : tot
     ,0);
     return dataCnt/table.tableData.data.length > .1;
 }

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -508,7 +508,14 @@ function getCoverageType(options,table) {
     return options.coverageType;
 }
 
-const hasCorners= (options, table) =>!isEmpty(options.getCornersColumns(table));
+function hasCorners(options, table) {
+    const cornerColumns= options.getCornersColumns(table);
+    if (isEmpty(cornerColumns)) return false;
+    const dataCnt= table.tableData.data.reduce( (tot, row) =>
+        cornerColumns.every( (cDef) => row[cDef.lonIdx]!=='' && row[cDef.latIdx]!=='') ? 1 : 0
+    ,0);
+    return dataCnt/table.tableData.data.length > .1;
+}
 
 function toAngle(d, radianToDegree)  {
     const v= Number(d);
@@ -523,14 +530,19 @@ function getPtAryFromTable(options,table, usesRadians){
     const cDef= options.getCenterColumns(table);
     if (isEmpty(cDef)) return [];
     const {lonIdx,latIdx,csys}= cDef;
-    return table.tableData.data.map( (row) => makePt(row[lonIdx], row[latIdx], csys, usesRadians) );
+    return table.tableData.data
+        .map( (row) =>
+            (row[lonIdx]!=='' && row[latIdx]!=='') ? makePt(row[lonIdx], row[latIdx], csys, usesRadians) : undefined )
+        .filter( (v) => v);
 }
 
 function getBoxAryFromTable(options,table, usesRadians){
     const cDefAry= options.getCornersColumns(table);
     return table.tableData.data
         .map( (row) => cDefAry
-            .map( (cDef) => makeWorldPt(row[cDef.lonIdx], row[cDef.latIdx], cDef.csys)) );
+            .map( (cDef) =>
+                (row[cDef.lonIdx]!=='' && row[cDef.latIdx]!=='') ? makePt(row[cDef.lonIdx], row[cDef.latIdx], cDef.csys, usesRadians) : undefined))
+        .filter( (row) => row.every( (v) => v));
 }
 
 /**


### PR DESCRIPTION
Coverage now does a more rigorous check to validate and show coverage.

  - For box coverage a least 10% of the rows must have non-empty data
  - All empty data rows are thrown out (box or point)
  - Before empty data was creating 0,0 j2000 points.

_To test:_

  - load sofia
  - search m17
  - look at coverage