### PR TITLE
IRSA-2556:SOFIA: image title label is wrong

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -521,7 +521,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                                                                         owner.getEventChannel(), owner.getUserKey());
         SHORT_TASK_EXEC.submit(() -> {
             enumeratedValuesCheck(dbFile, results, treq);
-            DataGroup updates = new DataGroup("updates", results.getData().getDataDefinitions());
+            DataGroup updates = new DataGroup(null, results.getData().getDataDefinitions());
             updates.getTableMeta().setTblId(results.getData().getTableMeta().getTblId());
 
             FluxAction action = new FluxAction(FluxAction.TBL_UPDATE, JsonTableUtil.toJsonDataGroup(updates));


### PR DESCRIPTION
Fixed the wrong title in larger table (row count >5000).

When a searched table has more than 5000 rows, the function changed the title by hard coded "updates".  
To produce it: 
1.  clean your browser cache, in your workarea remove sofia folder
2. run https://irsadev.ipac.caltech.edu/applications/sofia/
3. do an allsky search, then select "FIFI-LS", and see the image in Data tab, the image label is "updates FOV: angle". 

Clean cache and workarea, and then run the URL for this pull request, the image label is "FIFI-LS FOV:angle".  

The issue only happens for table's row count> 5000 and the first time the table is load. 
