### PR TITLE
DM-17499 Support error docs in plain text

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -198,6 +198,8 @@ abstract public class BaseDbAdapter implements DbAdapter {
             return "boolean";
         } else if (Date.class.isAssignableFrom(type)) {
             return "date";
+        } else if (Character.class.isAssignableFrom(type)) {
+            return "char";
         } else {
             return "varchar(64000)";
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
@@ -13,13 +13,12 @@ import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.LinkInfo;
 import edu.caltech.ipac.table.io.VoTableReader;
 import edu.caltech.ipac.util.StringUtils;
-import edu.caltech.ipac.util.download.URLDownload;
 import org.apache.commons.httpclient.Header;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.net.URL;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 @SearchProcessorImpl(id = AsyncTapQuery.ID, params = {
         @ParamDoc(name = "serviceUrl", desc = "base TAP url endpoint excluding '/async'"),
@@ -34,7 +33,7 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
         String lang = request.getParam("LANG");
         String queryStr = createQueryString(request);
 
-        HttpServiceInput inputs = new HttpServiceInput();
+        HttpServiceInput inputs = HttpServiceInput.createWithCredential();
         if (!StringUtils.isEmpty(queryStr)) inputs.setParam("QUERY", queryStr);
         if (StringUtils.isEmpty(lang)) { lang = "ADQL"; }
         inputs.setParam("LANG", lang); // in tap 1.0, lang param is required
@@ -54,7 +53,8 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
 
         AsyncTapJob asyncTap = new AsyncTapJob(location.getSource());
         if (asyncTap.getPhase() == AsyncJob.Phase.PENDING) {
-            HttpServices.postData(asyncTap.baseJobUrl + "/phase", new HttpServiceInput().setParam("PHASE", "RUN"), null);
+            HttpServices.postData(asyncTap.baseJobUrl + "/phase",
+                    HttpServiceInput.createWithCredential().setParam("PHASE", "RUN"), null);
         }
         return asyncTap;
     }
@@ -62,10 +62,10 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
 
     /**
      * override this function to convert a request into an ADQL QUERY string
-     * @param request
+     * @param request server request
      * @return an ADQL QUERY string
      */
-    protected String createQueryString(ServerRequest request) {
+    private String createQueryString(ServerRequest request) {
         return request.getParam("QUERY");
     }
 
@@ -74,16 +74,16 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
         private Logger.LoggerImpl logger = Logger.getLogger();
         private String baseJobUrl;
 
-        public AsyncTapJob(String baseJobUrl) {
+        AsyncTapJob(String baseJobUrl) {
             this.baseJobUrl = baseJobUrl;
         }
 
         public DataGroup getDataGroup() throws DataAccessException {
             try {
                 //download file first: failing to parse gaia results with topcat SAX parser from url
-                String filename = baseJobUrl.replace("(http:|https:)", "").replace("/", "");
+                String filename = getFilename(baseJobUrl);
                 File outFile = File.createTempFile(filename, ".vot", ServerContext.getTempWorkDir());
-                URLDownload.getDataToFile(new URL(baseJobUrl + "/results/result"), outFile);
+                HttpServices.getData(baseJobUrl + "/results/result", outFile, HttpServiceInput.createWithCredential());
                 DataGroup[] results = VoTableReader.voToDataGroups(outFile.getAbsolutePath());
                 if (results.length > 0) {
                     DataGroup dg = results[0];
@@ -96,7 +96,7 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
                 }  else {
                     return null;
                 }
-                return results.length > 0 ? results[0] : null;
+                return results[0];
             } catch (Exception e) {
                 throw new DataAccessException("Failure when retrieving results from "+baseJobUrl+"/results/result\n"+
                         e.getMessage());
@@ -105,13 +105,13 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
 
         public boolean cancel() {
             return ! HttpServices.postData(baseJobUrl + "/phase", new ByteArrayOutputStream(),
-                                            new HttpServiceInput().setParam("PHASE", Phase.ABORTED.name()))
+                    HttpServiceInput.createWithCredential().setParam("PHASE", Phase.ABORTED.name()))
                                 .isError();
         }
 
         public Phase getPhase() throws DataAccessException {
             ByteArrayOutputStream phase = new ByteArrayOutputStream();
-            HttpServices.Status status = HttpServices.getData(baseJobUrl + "/phase", phase, null);
+            HttpServices.Status status = HttpServices.getData(baseJobUrl + "/phase", phase, HttpServiceInput.createWithCredential());
             if (status.isError()) {
                 throw new DataAccessException("Error getting phase from "+baseJobUrl+" "+status.getErrMsg());
             }
@@ -124,31 +124,64 @@ public class AsyncTapQuery extends AsyncSearchProcessor {
         }
 
         public String getErrorMsg()  {
-            try {
-                DataGroup[] results = VoTableReader.voToDataGroups(baseJobUrl + "/error", false);
-                DataGroup errorTbl = results[0];
-                return errorTbl.getAttribute("QUERY_STATUS");
-            } catch (IOException e) {
-                logger.error(e);
-            } catch (DataAccessException e) {
-                return e.getMessage();
+            String errorUrl = baseJobUrl + "/error";
+
+            Ref<String> err = new Ref<>();
+            HttpServices.Status status = HttpServices.getData(errorUrl, HttpServiceInput.createWithCredential(),
+                    (method -> {
+                        boolean decompress = false, isText = false;
+                        Header encoding = method.getResponseHeader("Content-Encoding");
+                        if (encoding != null && encoding.getValue().contains("gzip")) {
+                            decompress = true;
+                        }
+                        Header contentType = method.getResponseHeader("Content-Type");
+                        if (contentType != null && contentType.getValue().startsWith("text/plain")) {
+                            isText = true;
+                        }
+                        try {
+                            InputStream is = method.getResponseBodyAsStream();
+                            if (decompress) { is = new GZIPInputStream(is); }
+                            if (isText) {
+                                // error is text doc
+                                BufferedReader br = new BufferedReader(new InputStreamReader(is));
+                                err.setSource(br.lines().collect(Collectors.joining(System.lineSeparator())));
+                            } else {
+                                // error is VOTable doc
+                                String voError = VoTableReader.getError(is, errorUrl);
+                                if (voError == null) {
+                                    voError = "Non-compliant error doc " + errorUrl;
+                                }
+                                err.setSource(voError);
+                            }
+                        } catch (DataAccessException e) {
+                            err.setSource(e.getMessage());
+                        } catch (Exception e) {
+                            err.setSource("Unable to get error from " + errorUrl);
+                        }
+                    }));
+            if (status.isError()) {
+                return "Unable to get error from "+baseJobUrl+" "+status.getErrMsg();
             }
-            return "";
+            return err.getSource();
         }
 
         public long getTimeout() {
             ByteArrayOutputStream duration = new ByteArrayOutputStream();
-            HttpServices.postData(baseJobUrl + "/executionduration", duration, null);
+            HttpServices.postData(baseJobUrl + "/executionduration", duration, HttpServiceInput.createWithCredential());
             return Long.valueOf(duration.toString());
         }
 
         public void setTimeout(long duration) {
             HttpServices.postData(baseJobUrl + "/executionduration", new ByteArrayOutputStream(),
-                    new HttpServiceInput().setParam("EXECUTIONDURATION", String.valueOf(duration)));
+                    HttpServiceInput.createWithCredential().setParam("EXECUTIONDURATION", String.valueOf(duration)));
         }
 
         protected String getBaseJobUrl() {
             return baseJobUrl;
+        }
+
+        private String getFilename(String urlStr) {
+            return urlStr.replace("(http:|https:)", "").replace("/", "");
         }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/AuthOpenidcMod.java
@@ -86,7 +86,7 @@ public class AuthOpenidcMod implements SsoAdapter {
     public void setAuthCredential(HttpServiceInput inputs) {
         Token token = getAuthToken();
         if (token != null && token.getId() != null) {
-            if (SsoAdapter.requireAuthCredential(inputs.getRequestUrl(), null)) {
+            if (SsoAdapter.requireAuthCredential(inputs.getRequestUrl())) {
                 inputs.setHeader("Authorization", "Bearer " + token.getId());
             }
         }

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -415,14 +415,14 @@ const TAP_SERVICES = [
         query: 'SELECT * FROM fp_psc WHERE CONTAINS(POINT(\'ICRS\',ra,dec),CIRCLE(\'ICRS\',210.80225,54.34894,1.0))=1'
     },
     {
-        label: 'LSST PDAC https://lsst-lspdev.ncsa.illinois.edu/tap',
-        value: 'https://lsst-lspdev.ncsa.illinois.edu/tap',
-        query: 'SELECT TOP 5000 * FROM gaiadr2.gaia_source'
-    },
-    {
         label: 'GAIA http://gea.esac.esa.int/tap-server/tap',
         value: 'http://gea.esac.esa.int/tap-server/tap',
         query: 'SELECT TOP 5000 * FROM gaiadr2.gaia_source'
+    },
+    {
+        label: 'MAST http://vao.stsci.edu/CAOMTAP/TapService.aspx',
+        value: 'http://vao.stsci.edu/CAOMTAP/TapService.aspx',
+        query: 'SELECT * FROM ivoa.obscore WHERE CONTAINS(POINT(\'ICRS\',s_ra,s_dec),CIRCLE(\'ICRS\',32.69,-51.01,1.0))=1'
     },
     {
         label: 'CASDA http://atoavo.atnf.csiro.au/tap',
@@ -430,9 +430,18 @@ const TAP_SERVICES = [
         query: 'SELECT * FROM ivoa.obscore WHERE CONTAINS(POINT(\'ICRS\',s_ra,s_dec),CIRCLE(\'ICRS\',32.69,-51.01,1.0))=1'
     },
     {
-        label: 'MAST http://vao.stsci.edu/CAOMTAP/TapService.aspx',
-        value: 'http://vao.stsci.edu/CAOMTAP/TapService.aspx',
-        query: 'SELECT * FROM ivoa.obscore WHERE CONTAINS(POINT(\'ICRS\',s_ra,s_dec),CIRCLE(\'ICRS\',32.69,-51.01,1.0))=1'
+        label: 'LSST lsp-stable https://lsst-lsp-stable.ncsa.illinois.edu/api/tap',
+        value: 'https://lsst-lsp-stable.ncsa.illinois.edu/api/tap',
+        query: 'SELECT * FROM wise_00.allwise_p3as_psd '+
+            'WHERE CONTAINS(POINT(\'ICRS\', ra, decl),'+
+            'POLYGON(\'ICRS\', 9.4999, -1.18268, 9.4361, -1.18269, 9.4361, -1.11891, 9.4999, -1.1189))=1'
+    },
+    {
+        label: 'LSST lsp-int https://lsst-lsp-int.ncsa.illinois.edu/api/tap',
+        value: 'https://lsst-lsp-int.ncsa.illinois.edu/api/tap',
+        query: 'SELECT * FROM wise_00.allwise_p3as_psd '+
+            'WHERE CONTAINS(POINT(\'ICRS\', ra, decl),'+
+            'POLYGON(\'ICRS\', 9.4999, -1.18268, 9.4361, -1.18269, 9.4361, -1.11891, 9.4999, -1.1189))=1'
     },
     {
         label: 'LSST TEST http://tap.lsst.rocks/tap',


### PR DESCRIPTION
Ticket: https://jira.lsstcorp.org/browse/DM-17499

Needs to be built locally for test, because only LSST is producing plain text error docs, and LSST services require VPN.

"AsyncTapQuery" search processor now handles both formats of errors: VOTable and plain text.

Bugs fixed:
- LSST result queries (when using URLDownload with GET method) were not following redirects
- Single char datatype in VOTable was not converted to the right hsqldb type, which was causing table load failure: "Invalid Statement". 

To test:
1. Build locally, use NCSA VPN to run:
http://localhost:8080/firefly/firefly-dev.html?__action=layout.showDropDown&visible=true&view=TestTAPSearch
2. Use ADQL tab to modify ADQL query to make it invalid. Search.
3. Switch between services (sample query should change). Try both valid and invalid queries.