### PR TITLE
DM-17740: improve caching and reading of HiPS images

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
@@ -100,7 +100,9 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
     public void putAttribute(String key, String value) { attributes.put(key,value); }
     public String getAttribute(String key) {return attributes.get(key); }
 
-    public File getFile() {  return new File(attributes.get(INTERNAL_NAME)); }
+    public File getFile() {
+        return attributes.containsKey(INTERNAL_NAME) ? new File(attributes.get(INTERNAL_NAME)) : null;
+    }
     public String getDesc() { return attributes.get(DESC); }
     public boolean isBlank() { return StringUtils.getBoolean(attributes.get(BLANK), false); }
     public int getResponseCode() { return StringUtils.getInt(attributes.get(RESPONSE_CODE), 200); }
@@ -134,7 +136,9 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
 
     public String getExternalName() { return getAttribute(EXTERNAL_NAME); }
 
-    public void setInternalName(String filename) { putAttribute(INTERNAL_NAME,filename); }
+    public void setInternalName(String filename) {
+        if (filename!=null) putAttribute(INTERNAL_NAME,filename);
+    }
     public void setExternalName(String filename) { putAttribute(EXTERNAL_NAME,filename); }
 
     public long getSizeInBytes() { return StringUtils.getInt(getAttribute(SIZE_IN_BYTES),0); }

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.data;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.CacheKey;
+import edu.caltech.ipac.util.download.ResponseMessage;
 
 import java.io.File;
 import java.io.Serializable;
@@ -61,6 +62,11 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
 
     public FileInfo(File file, String externalName, int responseCode, String responseCodeMsg) {
         this(file, externalName, externalName, responseCode, responseCodeMsg);
+    }
+
+
+    public FileInfo(File file, int responseCode) {
+        this(file, file!=null?file.getName():"", responseCode, ResponseMessage.getHttpResponseMessage(responseCode));
     }
 
     private FileInfo(File file, String externalName, String desc, int responseCode, String responseCodeMsg) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
@@ -40,6 +40,7 @@ public class AnyFileDownload extends BaseHttpServlet {
 
     public static final String USE_SERVER_NAME = "USE_SERVER_NAME";
     private static final String HIPS_CACHE_CONTROL= "must-revalidate, max-age=1800";
+    private static final String HIPS_SHORT_CACHE_CONTROL= "must-revalidate, max-age=300";
     private static final String STATIC_CACHE_CONTROL= "max-age=86400";
 
     protected void processRequest(HttpServletRequest req, HttpServletResponse res) throws Exception {
@@ -95,6 +96,10 @@ public class AnyFileDownload extends BaseHttpServlet {
         FileInfo fi= HiPSRetrieve.retrieveHiPSData(hips, null);
 
         if (fi.getFile()==null) {
+            if (fi.getResponseCode()==204) {
+                res.addHeader("Cache-Control", HIPS_SHORT_CACHE_CONTROL);
+                res.addDateHeader("Last-Modified", System.currentTimeMillis());
+            }
             res.sendError(fi.getResponseCode(), fi.getResponseCodeMsg());
             return;
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.servlets;
 
+import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.SrvParam;
 import edu.caltech.ipac.firefly.server.cache.UserCache;
@@ -12,13 +13,11 @@ import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.StringKey;
-import edu.caltech.ipac.util.download.URLDownload;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 
 /**
  * Date: Feb 11, 2007
@@ -32,30 +31,42 @@ public class AnyFileDownload extends BaseHttpServlet {
     private static final Logger.LoggerImpl _statsLog= Logger.getLogger(Logger.DOWNLOAD_LOGGER);
 
 
-    public static final String HIPS_PARAM  = "hipsUrl";
-    public static final String FILE_PARAM  = "file";
-    public static final String RETURN_PARAM= "return";
-    public static final String LOG_PARAM   = "log";
-    public static final String TRACK_PARAM = "track";
-    public static final String USE_SERVER_NAME = "USE_SERVER_NAME";
+    public static final String HIPS_PARAM  = "hipsUrl"; // required for HiPS
+    public static final String FILE_PARAM  = "file"; // required for other request
+    public static final String RETURN_PARAM= "return"; // a name for the file, if empty or USE_SERVER_NAME the use file name on server
+    public static final String LOG_PARAM   = "log"; // if true, log status
+    public static final String TRACK_PARAM = "track"; // if true, send progress to cleint
 
+
+    public static final String USE_SERVER_NAME = "USE_SERVER_NAME";
+    private static final String HIPS_CACHE_CONTROL= "must-revalidate, max-age=1800";
+    private static final String STATIC_CACHE_CONTROL= "max-age=86400";
 
     protected void processRequest(HttpServletRequest req, HttpServletResponse res) throws Exception {
-        SrvParam sp= new SrvParam(req.getParameterMap());
-        String hips= sp.getOptional(HIPS_PARAM);
-        String fname= hips==null ? sp.getRequired(FILE_PARAM): null;
-        String local= sp.getOptional(RETURN_PARAM);
-        boolean log= sp.getOptionalBoolean(LOG_PARAM,false);
-        boolean track= sp.getOptionalBoolean(TRACK_PARAM,false);
-        File downloadFile;
-
-        if (hips!=null) {
-            downloadFile= retrieveHiPSData(hips, null);
+        if (req.getParameterMap().containsKey(HIPS_PARAM)) {
+            handleHiPSRequest(req,res,true);
         }
         else {
-            downloadFile= ServerContext.convertToFile(fname);
+            handleInternalFileRequest(req,res,true);
         }
 
+    }
+
+    @Override
+    protected void doHead(HttpServletRequest req, HttpServletResponse res) throws IOException {
+        if (req.getParameterMap().containsKey(HIPS_PARAM)) {
+            handleHiPSRequest(req,res,false);
+        }
+        else {
+            handleInternalFileRequest(req,res,false);
+        }
+    }
+
+    private void handleInternalFileRequest(HttpServletRequest req, HttpServletResponse res, boolean fullBody)
+            throws IOException {
+        SrvParam sp= new SrvParam(req.getParameterMap());
+        String fname= sp.getRequired(FILE_PARAM);
+        File downloadFile= ServerContext.convertToFile(fname);
         if (downloadFile==null) {
             res.sendError(HttpServletResponse.SC_NOT_FOUND,"Could not convert input to a file" );
             _log.warn("Cannot convert file: "+ fname + " to valid path, returning 404");
@@ -63,39 +74,81 @@ public class AnyFileDownload extends BaseHttpServlet {
         else if (!downloadFile.canRead()) {
             res.sendError(HttpServletResponse.SC_NOT_FOUND,"File was not found" );
             _log.warn("Cannot read file: "+ downloadFile.getPath(),
-                      "fname: "+fname, " returning 404");
+                    "fname: "+fname, " returning 404");
         }
         else {
-            res.addHeader("Cache-Control", "max-age=86400");
-            String retFile= (local!=null) ? local : downloadFile.getName();
-            if (retFile.equals(USE_SERVER_NAME)) retFile= downloadFile.getName();
-            insertResponseHeaders(res, downloadFile,retFile);
-            if (track) trackProgress(req, BackgroundEnv.DownloadProgress.WORKING);
-            try {
-                FileUtil.writeFileToStream(downloadFile, res.getOutputStream());
-                if (track) trackProgress(req, BackgroundEnv.DownloadProgress.DONE);
-                if (log) logActivity(downloadFile);
-            } catch (IOException e) {
-                if (track) trackProgress(req, BackgroundEnv.DownloadProgress.FAIL);
-                throw e;
+            res.addHeader("Cache-Control", STATIC_CACHE_CONTROL);
+            if (fullBody) {
+                sendFileToClient(req,res,downloadFile);
             }
+            else {
+                res.setStatus(200);
+            }
+        }
+
+    }
+
+    private void handleHiPSRequest(HttpServletRequest req, HttpServletResponse res, boolean fullBody)
+            throws IOException {
+        SrvParam sp= new SrvParam(req.getParameterMap());
+        String hips= sp.getRequired(HIPS_PARAM);
+        FileInfo fi= HiPSRetrieve.retrieveHiPSData(hips, null);
+
+        if (fi.getFile()==null) {
+            res.sendError(fi.getResponseCode(), fi.getResponseCodeMsg());
+            return;
+        }
+
+        res.addHeader("Cache-Control", HIPS_CACHE_CONTROL);
+        res.addDateHeader("Last-Modified", System.currentTimeMillis());
+        if (fi.getResponseCode()==304 && req.getDateHeader("If-Modified-Since")> fi.getFile().lastModified()) {
+            res.setStatus(304);
+            return;
+        }
+        if (fullBody) {
+            sendFileToClient(req,res,fi.getFile());
+        }
+        else {
+            res.setStatus(200);
         }
     }
 
 
-    public void insertResponseHeaders(HttpServletResponse res, File f, String retFileStr) {
+    private void sendFileToClient(HttpServletRequest req, HttpServletResponse res, File f) throws IOException {
+        SrvParam sp= new SrvParam(req.getParameterMap());
+        String local= sp.getOptional(RETURN_PARAM);
+        boolean log= sp.getOptionalBoolean(LOG_PARAM,false);
+        boolean track= sp.getOptionalBoolean(TRACK_PARAM,false);
 
         String mType= getServletContext().getMimeType(f.getName());
         if (mType!=null) res.setContentType(mType);
 
-        long fileLength= f.length();
-        if(fileLength <= Integer.MAX_VALUE) res.setContentLength((int)fileLength);
-        else                                res.addHeader("Content-Length", fileLength+"");
+        res.addHeader("Content-Length", f.length()+"");
 
+        String retFileStr= (local!=null) ? local : f.getName();
+        if (retFileStr.equals(USE_SERVER_NAME)) retFileStr= f.getName();
         if (!StringUtils.isEmpty(retFileStr)) {
             res.addHeader("Content-Disposition", "attachment; filename="+retFileStr);
         }
+
+
+
+        if (track) trackProgress(req, BackgroundEnv.DownloadProgress.WORKING);
+        try {
+            FileUtil.writeFileToStream(f, res.getOutputStream());
+            if (track) trackProgress(req, BackgroundEnv.DownloadProgress.DONE);
+            if (log) logActivity(f);
+        } catch (IOException e) {
+            if (track) trackProgress(req, BackgroundEnv.DownloadProgress.FAIL);
+            throw e;
+        }
+
     }
+
+
+
+
+
 
     private static void logActivity(File f) {
         String logStr= "File download -- File: " + f.getPath()+
@@ -113,15 +166,4 @@ public class AnyFileDownload extends BaseHttpServlet {
 
     public static Cache getCache() { return UserCache.getInstance(); }
 
-    public static File retrieveHiPSData(String urlStr, String pathExt) throws Exception {
-        URL url= new URL(urlStr);
-
-        String fPath = pathExt == null ? url.getPath() : (url.getPath() + "/" + pathExt);
-        File dir= new File(ServerContext.getHiPSDir(),new File(url.getHost() + fPath).getParent());
-        if (!dir.exists()) dir.mkdirs();
-
-        File targetFile= new File(dir, new File((pathExt == null ? url.getFile() : pathExt)).getName());
-        URLDownload.getDataToFile(url,targetFile);
-        return targetFile;
-    }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HiPSRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HiPSRetrieve.java
@@ -51,24 +51,28 @@ public class HiPSRetrieve {
                     return fi;
                 default:
                     if (retFile!=null)  retFile.delete();
-                    return new FileInfo(null, rCode);
+                    if (rCode==404 && imageRequest(retFile)) return new FileInfo(null, 204);
+                    else return new FileInfo(null, rCode);
             }
         } catch (MalformedURLException | FailedRequestException e) {
             return new FileInfo(null, null, 404, e.toString());
         }
     }
 
-    private static boolean isValid(File f) {
+    private static boolean imageRequest(File f) {
         String fLowStr= f.getAbsolutePath().toLowerCase();
+        return fLowStr.endsWith("jpg") || fLowStr.endsWith("jpeg") || fLowStr.endsWith("png");
+    }
+
+    private static boolean isValid(File f) {
         try {
+            String fLowStr= f.getAbsolutePath().toLowerCase();
             if (fLowStr.equals("properties") || fLowStr.equals("list")) {
                 Properties p = new Properties();
                 p.load(new FileReader(f));
                 if (p.size()<2) return false;
             }
-            else if (f.getAbsolutePath().toLowerCase().endsWith("jpg") ||
-                    f.getAbsolutePath().toLowerCase().endsWith("jpeg") ||
-                    f.getAbsolutePath().toLowerCase().endsWith("png")) {
+            else if (imageRequest(f)) {
                 BufferedImage i = ImageIO.read(f);
                 if (i==null) return false;
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HiPSRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HiPSRetrieve.java
@@ -1,0 +1,84 @@
+package edu.caltech.ipac.firefly.server.servlets;
+/**
+ * User: roby
+ * Date: 2019-02-12
+ * Time: 11:50
+ */
+
+
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.URLDownload;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+
+/**
+ * @author Trey Roby
+ */
+public class HiPSRetrieve {
+
+    public static FileInfo retrieveHiPSData(String urlStr, String pathExt) {
+        try {
+            URL url= new URL(urlStr);
+
+            String fPath = pathExt == null ? url.getPath() : (url.getPath() + "/" + pathExt);
+            File dir= new File(ServerContext.getHiPSDir(),new File(url.getHost() + fPath).getParent());
+            if (!dir.exists()) dir.mkdirs();
+
+            File targetFile= new File(dir, new File((pathExt == null ? url.getFile() : pathExt)).getName());
+            FileInfo fi= URLDownload.getDataToFile(url,targetFile);
+            int rCode= fi.getResponseCode();
+            File retFile= fi.getFile();
+
+            switch (rCode) {
+                case 200:
+                    if (isValid(retFile)) {
+                        return fi;
+                    }
+                    else {
+                        retFile.delete();
+                        return new FileInfo(null, rCode);
+                    }
+                case 304:
+                    return fi;
+                default:
+                    if (retFile!=null)  retFile.delete();
+                    return new FileInfo(null, rCode);
+            }
+        } catch (MalformedURLException | FailedRequestException e) {
+            return new FileInfo(null, null, 404, e.toString());
+        }
+    }
+
+    private static boolean isValid(File f) {
+        String fLowStr= f.getAbsolutePath().toLowerCase();
+        try {
+            if (fLowStr.equals("properties") || fLowStr.equals("list")) {
+                Properties p = new Properties();
+                p.load(new FileReader(f));
+                if (p.size()<2) return false;
+            }
+            else if (f.getAbsolutePath().toLowerCase().endsWith("jpg") ||
+                    f.getAbsolutePath().toLowerCase().endsWith("jpeg") ||
+                    f.getAbsolutePath().toLowerCase().endsWith("png")) {
+                BufferedImage i = ImageIO.read(f);
+                if (i==null) return false;
+            }
+
+        } catch (IOException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/IrsaHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/IrsaHiPSListSource.java
@@ -1,30 +1,30 @@
 package edu.caltech.ipac.firefly.server.visualize.hips;
 
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.server.servlets.HiPSRetrieve;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.visualize.hips.HiPSMasterListEntry.PARAMS;
-import edu.caltech.ipac.firefly.data.ServerParams;
-import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.table.DataGroup;
-import edu.caltech.ipac.table.io.DsvTableIO;
-import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.table.DataObject;
 import edu.caltech.ipac.table.DataType;
-import edu.caltech.ipac.firefly.server.servlets.AnyFileDownload;
+import edu.caltech.ipac.table.io.DsvTableIO;
+import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.download.FailedRequestException;
 import org.apache.commons.csv.CSVFormat;
 
-import java.util.List;
-import java.util.Map;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.File;
-import java.io.BufferedReader;
-import java.io.StringReader;
-import java.lang.StringBuilder;
-import java.io.FileReader;
 
 
 /**
@@ -85,7 +85,9 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
 
             long cTime = System.currentTimeMillis();
 
-            File listFile = AnyFileDownload.retrieveHiPSData(url, childExt);
+            FileInfo listFileInfo = HiPSRetrieve.retrieveHiPSData(url, childExt);
+            File listFile= listFileInfo.getFile();
+            if (listFile==null) throw new IOException("Could not retrieve file: "+ listFileInfo.getResponseCode());
 
             _log.briefDebug("get " + source + " HiPS took " + (System.currentTimeMillis() - cTime) + "ms");
 
@@ -195,7 +197,10 @@ public class IrsaHiPSListSource implements HiPSMasterListSourceType {
         if (propUrl == null || listEntry == null) return;
 
         try {
-            File propFile = AnyFileDownload.retrieveHiPSData(propUrl, null);
+            FileInfo propFileInfo = HiPSRetrieve.retrieveHiPSData(propUrl, null);
+            File propFile= propFileInfo.getFile();
+            if (propFile==null) throw new IOException("Could not retrieve file: "+ propFileInfo.getResponseCode());
+
             BufferedReader br = new BufferedReader(new FileReader(propFile));
             String strLine;
             StringBuilder sb = new StringBuilder();

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -193,6 +193,7 @@ export function startAsAppFromApi(divId, props={}, options={}, ) {
     props= {...props, ...{div:divId}};
     const {template} = props;
     const viewer = get(Templates, template);
+    options = mergeObjectOnly(defFireflyOptions, options);
     dispatchAppOptions(options);
     if (props.disableDefaultDropDown) {
         dispatchUpdateLayoutInfo({disableDefaultDropDown:true});

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -254,9 +254,11 @@ export class FitsDownloadDialogForm extends PureComponent {
 
                 const baseName = this.getDefaultFileName(hasOperation, Band.NO_BAND);
 
-                fileNames[Band.NO_BAND.key] = baseName;
-                fileNames['png'] = baseName.replace('.fits', '.png');
-                fileNames['reg'] = baseName.replace('.fits', '.reg');
+                const cleanName= baseName.replace(/[()&^@,;.]/g, '_');
+
+                fileNames[Band.NO_BAND.key] = cleanName.replace('_fits', '.fits');
+                fileNames['png'] = cleanName.replace('_fits', '.png');
+                fileNames['reg'] = cleanName.replace('_fits', '.reg');
             }
             return fileNames;
         };

--- a/src/firefly/js/visualize/iv/ImageRender.jsx
+++ b/src/firefly/js/visualize/iv/ImageRender.jsx
@@ -50,15 +50,6 @@ export class ImageRender extends Component {
         };
     }
 
-    componentWillUpdate(np,ns) {
-        this.tileDrawer= null;
-        this.drawInit= (canvas) => {
-            const {plot, opacity,plotView, tileAttributes, shouldProcess=false, processor}= np;
-            this.tileDrawer= initTileDrawer(canvas, plot);
-            this.tileDrawer(plot, opacity,plotView, {tileAttributes, shouldProcess, processor} );
-        };
-    }
-
     shouldComponentUpdate(np,ns) {
         const {props}= this;
         const {plotView:pv}= props;

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -166,6 +166,8 @@ function watchCoverage(tbl_id, action, cancelSelf, params) {
         return {paused:false};
     }
 
+    if (paused) return {paused};
+
     switch (action.type) {
 
         case TABLE_LOADED:


### PR DESCRIPTION
Improve caching and reading of HiPS images 

_Ticket issues:_
 - HiPS retrieve now check status and only serves good files
  - HiPS retrieve validates image and hips property files
  - HiPS retrieve change of caching parameters, also now supports 304, If-Modified-Since
  - refactor of AnyFileDownload.java

bulk of ticket work in `AnyFileDownload.java` and `HiPSRetrieve.java`

_Other issues found and fixed:_
  - fixed regression issue if CoverageWatcher (`CoverageWatcher.js`)
  - fixed sometimes bad file naming with download region files (`FitsDownloadDialog.jsx`)
  - fixed HiPS option not showing in jupyter slate. (`Firefly.js`)
  - fixed a regression scrolling issue (`ImageRender.jsx`)