### PR TITLE
DM-15552: fixed jupyter widgets reloading and not being able to replo…

### DIFF
--- a/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
+++ b/src/firefly/js/templates/fireflyslate/FireflySlateManager.js
@@ -2,8 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {take} from 'redux-saga/effects';
-import {filter, isEmpty, get, isArray, uniq} from 'lodash';
+import {filter, isEmpty, isArray, uniq} from 'lodash';
 
 import {startImageMetadataWatcher} from '../../visualize/saga/ImageMetaDataWatcher.js';
 import {startCoverageWatcher} from '../../visualize/saga/CoverageWatcher.js';
@@ -20,7 +19,6 @@ import {clone} from '../../util/WebUtil.js';
 
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
 import {REPLACE_VIEWER_ITEMS, IMAGE, getViewerItemIds, getMultiViewRoot, getViewer, findViewerWithItemId} from '../../visualize/MultiViewCntlr.js';
-import {getAppOptions} from '../../core/AppDataCntlr.js';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../../core/MasterSaga.js';
 
 

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -389,12 +389,12 @@ export function getAViewFromMultiView(multiViewRoot, containerType, renderTreeId
                                             (get(entry, 'canReceiveNewPlots') === NewPlotMode.create_replace.key)));
     if (viewer.reservedContainer && renderTreeId) {
         const newId= `${viewer.viewerId}_${renderTreeId}`;
-        const modViewer= getViewer(multiViewRoot, newId)
+        const modViewer= getViewer(multiViewRoot, newId);
         if (modViewer) return modViewer;
         dispatchAddViewer(newId, NewPlotMode.create_replace.key,
                       containerType,false,renderTreeId);
 
-        return getViewer(getMultiViewRoot(), newId)
+        return getViewer(getMultiViewRoot(), newId);
     }
     else {
         return viewer;
@@ -555,7 +555,15 @@ function removeViewer(state,action) {
  * @return {MultiViewerRoot}
  */
 function addItems(state,viewerId,itemIdAry, containerType, renderTreeId) {
+
+    if (renderTreeId) {
+        itemIdAry.forEach( (id) => {
+            const v= findViewerWithItemId(state, id, containerType);
+            if (v && v.renderTreeId!==renderTreeId) state= deleteSingleItem(state,id,containerType);
+        });
+    }
     let viewer= state.find( (entry) => entry.viewerId===viewerId);
+
     if (!viewer) {
         state= addViewer(state,{viewerId,containerType, renderTreeId});
         viewer= state.find( (entry) => entry.viewerId===viewerId);
@@ -616,7 +624,6 @@ function removeItems(state,action) {
 
     return state.map( (entry) => entry.viewerId===viewerId ? clone(entry, updateViewer(entry)) : entry);
 }
-
 
 /**
  * Delete an item with only knowing the itemId and containerType but not the viewerId


### PR DESCRIPTION
fixed jupyter widgets reloading and not being able to replot an image

_to test:_

Execute slate-widget-demo.ipynb that is one of the examples for the extension. Run all the cells once; then restart the Python kernel for that notebook; then re-execute. Image should display both times.