### PR TITLE
Firefly-8: Clean up react lifecycle deprecated methods and context

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -45,7 +45,6 @@ export const Templates = {
     HydraViewer
 };
 
-
 /**
  * @global
  * @public
@@ -320,3 +319,4 @@ function getCookie(name) {
         .split(';')
         .shift();
 }
+

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -26,7 +26,7 @@ class ChartPanelView extends PureComponent {
         this.iAmMounted = true;
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         const {chartId, showChart} = nextProps;
         if (!chartId) { return; }
 

--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -20,6 +20,7 @@ import {BasicOptions} from './options/BasicOptions.jsx';
 import {ScatterOptions} from './options/ScatterOptions.jsx';
 import {HeatmapOptions} from './options/HeatmapOptions.jsx';
 import {FireflyHistogramOptions} from './options/FireflyHistogramOptions.jsx';
+import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
 
 const chartActionPanelKey = 'ChartSelectPanel-actions';
 const chartActionKey = 'chartAction';
@@ -104,7 +105,7 @@ export class ChartSelectPanel extends SimpleComponent {
         this.state = this.getNextState();
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         const {chartId, tbl_id, chartAction} = this.props;
         const oldChartAction = getFieldVal(chartActionPanelKey, chartActionKey);
         let newChartAction = chartAction;
@@ -168,9 +169,7 @@ ChartSelectPanel.defaultProps = {
     showMultiTrace: true,
 
 };
-ChartSelectPanel.contextTypes= {
-    renderTreeId: PropTypes.string
-};
+ChartSelectPanel.contextType= RenderTreeIdCtx;
 
 function ChartAction(props) {
 

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -99,7 +99,7 @@ export class ChartsContainer extends PureComponent {
 
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         const {viewerId=DEFAULT_PLOT2D_VIEWER_ID, tbl_group, addDefaultChart, chartId} = this.props;
         if (tbl_group) {
             if (addDefaultChart) {

--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -185,7 +185,7 @@ export class HistogramOptions extends Component {
 
     }
 
-    componentWillReceiveProps(np) {
+    UNSAFE_componentWillReceiveProps(np) {
         if (this.props.histogramParams !== np.histogramParams) {
             setOptions(np.groupKey, np.histogramParams);
         }

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -53,7 +53,7 @@ export class PlotlyChartArea extends Component {
         return !(propsEqual && stateEqual);
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         const {chartId} = this.props;
         const {data, fireflyData, mounted} = getChartData(chartId);
         if (mounted === 1) {

--- a/src/firefly/js/charts/ui/options/Errors.jsx
+++ b/src/firefly/js/charts/ui/options/Errors.jsx
@@ -43,11 +43,12 @@ export class Errors extends PureComponent {
         };
     }
 
-    componentWillUpdate(nextProps) {
-        const {axis, groupKey, activeTrace} = nextProps;
-        this.setState({
+    static getDerivedStateFromProps(props,state) {
+        const {axis, groupKey, activeTrace} = props;
+        return {
             selectedErrType : getFieldVal(groupKey, errorTypeFieldKey(activeTrace, axis), 'none')
-        });
+        };
+
     }
 
     componentDidMount() {

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -49,7 +49,7 @@ class BasicTableViewInternal extends PureComponent {
         return (hlRowIdx === index) ? 'tablePanel__Row_highlighted' : '';
     }
 
-    componentWillReceiveProps(nProps) {
+    UNSAFE_componentWillReceiveProps(nProps) {
         if (isEmpty(this.state.columnWidths) && !isEmpty(nProps.columns)) {
             this.setState({columnWidths: makeColWidth(nProps.columns, nProps.data)});
         }

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -70,7 +70,7 @@ export class TablePanel extends PureComponent {
         return Object.assign({}, this.props, uiState);
     }
 
-    componentWillReceiveProps(props) {
+    UNSAFE_componentWillReceiveProps(props) {
         if (!shallowequal(this.props, props)) {
             this.setState(this.setupInitState(props));
         }

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -101,25 +101,23 @@ export class FireflySlate extends PureComponent {
             return (<div style={{top: 0}} className='loading-mask'/>);
         } else {
             return (
+                <RenderTreeIdCtx.Provider value={{renderTreeId : this.props.renderTreeId}}>
                     <div id='App' className='rootStyle' style={style}>
                         <header>
                             <BannerSection {...{menu, appTitle, appIcon, altAppIcon}}/>
                             <div id={warningDivId} data-decor='full' className='warning-div center'/>
-                            <RenderTreeIdCtx.Provider value={{renderTreeId : this.props.renderTreeId}}>
-                                <DropDownContainer
-                                    key='dropdown'
-                                    footer={footer}
-                                    visible={!!visible}
-                                    selected={view}
-                                    {...{dropdownPanels} } />
-                            </RenderTreeIdCtx.Provider>
+                            <DropDownContainer
+                                key='dropdown'
+                                footer={footer}
+                                visible={!!visible}
+                                selected={view}
+                                {...{dropdownPanels} } />
                         </header>
                         <main style={{height:'100%'}}>
-                            <RenderTreeIdCtx.Provider value={{renderTreeId : this.props.renderTreeId}}>
-                                {mainView({expanded, gridView, gridColumns})}
-                            </RenderTreeIdCtx.Provider>
+                            {mainView({expanded, gridView, gridColumns})}
                         </main>
                     </div>
+                </RenderTreeIdCtx.Provider>
             );
         }
     }

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -30,6 +30,7 @@ import {getMultiViewRoot, findViewerWithItemId, PLOT2D} from '../../visualize/Mu
 import FFTOOLS_ICO from 'html/images/fftools-logo-offset-small-75x75.png';
 import {warningDivId} from '../../ui/LostConnection';
 import {startTTFeatureWatchers} from '../common/ttFeatureWatchers.js';
+import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
 
 
 
@@ -55,10 +56,6 @@ export class FireflySlate extends PureComponent {
         startTTFeatureWatchers();
         this.stopLayoutManager= startLayoutManager(this.props.renderTreeId, {renderTreeId:this.props.renderTreeId});
 
-    }
-
-    getChildContext() {
-        return {renderTreeId : this.props.renderTreeId};
     }
 
     getNextState() {
@@ -104,29 +101,29 @@ export class FireflySlate extends PureComponent {
             return (<div style={{top: 0}} className='loading-mask'/>);
         } else {
             return (
-                <div id='App' className='rootStyle' style={style}>
-                    <header>
-                        <BannerSection {...{menu, appTitle, appIcon, altAppIcon}}/>
-                        <div id={warningDivId} data-decor='full' className='warning-div center'/>
-                        <DropDownContainer
-                            key='dropdown'
-                            footer={footer}
-                            visible={!!visible}
-                            selected={view}
-                            {...{dropdownPanels} } />
-                    </header>
-                    <main style={{height:'100%'}}>
-                        {mainView({expanded, gridView, gridColumns})}
-                    </main>
-                </div>
+                    <div id='App' className='rootStyle' style={style}>
+                        <header>
+                            <BannerSection {...{menu, appTitle, appIcon, altAppIcon}}/>
+                            <div id={warningDivId} data-decor='full' className='warning-div center'/>
+                            <RenderTreeIdCtx.Provider value={{renderTreeId : this.props.renderTreeId}}>
+                                <DropDownContainer
+                                    key='dropdown'
+                                    footer={footer}
+                                    visible={!!visible}
+                                    selected={view}
+                                    {...{dropdownPanels} } />
+                            </RenderTreeIdCtx.Provider>
+                        </header>
+                        <main style={{height:'100%'}}>
+                            <RenderTreeIdCtx.Provider value={{renderTreeId : this.props.renderTreeId}}>
+                                {mainView({expanded, gridView, gridColumns})}
+                            </RenderTreeIdCtx.Provider>
+                        </main>
+                    </div>
             );
         }
     }
 }
-
-FireflySlate.childContextTypes= {
-    renderTreeId : PropTypes.string
-};
 
 
 const closeExpanded= () => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);
@@ -222,7 +219,8 @@ FireflySlate.propTypes = {
     showViewsSwitch: PropTypes.bool,
     leftButtons: PropTypes.arrayOf( PropTypes.func ),
     centerButtons: PropTypes.arrayOf( PropTypes.func ),
-    rightButtons: PropTypes.arrayOf( PropTypes.func )
+    rightButtons: PropTypes.arrayOf( PropTypes.func ),
+    renderTreeId: PropTypes.string,
 };
 
 FireflySlate.defaultProps = {

--- a/src/firefly/js/templates/fireflyslate/GridLayoutPanel.jsx
+++ b/src/firefly/js/templates/fireflyslate/GridLayoutPanel.jsx
@@ -15,6 +15,7 @@ import {MultiChartViewer} from '../../charts/ui/MultiChartViewer.jsx';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {LO_VIEW, getGridDim, dispatchUpdateGridView} from '../../core/LayoutCntlr.js';
 import {NewPlotMode} from '../../visualize/MultiViewCntlr.js';
+import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
 
 import './react-grid-layout_styles.css';
 import './react-resizable_styles.css';
@@ -139,15 +140,13 @@ class SlateView extends Component {
 }
 
 
+SlateView.contextType= RenderTreeIdCtx;
+
 SlateView.propTypes= {
     gridView : PropTypes.array.isRequired,
     size: PropTypes.object.isRequired,
     gridColumns : PropTypes.number.isRequired
 };
-SlateView.contextTypes= {
-    renderTreeId: PropTypes.string
-};
-
 
 const sizeMeHOC = sizeMe(config);
 

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -60,7 +60,7 @@ export class CatalogSearchMethodType extends PureComponent {
         });
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         // const fields= FieldGroupUtils.getGroupFields(this.nextProps.groupKey);
         const {coneMax, boxMax, groupKey}= nextProps;
         if (coneMax && boxMax && groupKey) {
@@ -420,10 +420,6 @@ CatalogSearchMethodType.propTypes = {
     boxMax: PropTypes.number,
     withPos: PropTypes.bool
 };
-
-/*CatalogSearchMethodType.contextTypes = {
- groupKey: PropTypes.string
- };*/
 
 // Enumerate spatial methods - see SearchMethod values in edu.caltech.ipac.firefly.server.catquery.GatorQuery
 export const SpatialMethod = new Enum({

--- a/src/firefly/js/ui/CloseButton.jsx
+++ b/src/firefly/js/ui/CloseButton.jsx
@@ -40,11 +40,6 @@ export function CloseButton({text='Close', tip='Close',style={}, onClick}) {
     );
 }
 
-
-//CloseButton.contextTypes= {
-//};
-
-
 CloseButton.propTypes= {
     text : PropTypes.string,
     style : PropTypes.object,

--- a/src/firefly/js/ui/CompleteButton.jsx
+++ b/src/firefly/js/ui/CompleteButton.jsx
@@ -2,10 +2,11 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {Component} from 'react';
+import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 import {validateFieldGroup, getFieldGroupResults} from '../fieldGroup/FieldGroupUtils.js';
 import {dispatchHideDialog} from '../core/ComponentCntlr.js';
+import {GroupKeyCtx} from './FieldGroup';
 
 
 
@@ -48,8 +49,9 @@ function onClick(onSuccess,onFail,closeOnValid,groupKey,dialogId,includeUnmounte
 
 export function CompleteButton ({onFail, onSuccess, groupKey=null, text='OK',
                           closeOnValid=true, dialogId,includeUnmounted= false,
-                          style={}, changeMasking}, context) {
-    if (!groupKey && context) groupKey= context.groupKey;
+                          style={}, changeMasking}) {
+    const context= useContext(GroupKeyCtx);
+    if (!groupKey && context) groupKey= context;
     const onComplete = () => onClick(onSuccess,onFail,closeOnValid,groupKey,dialogId,includeUnmounted,changeMasking);
     return (
         <div style={style}>
@@ -70,11 +72,5 @@ CompleteButton.propTypes= {
     includeUnmounted : PropTypes.bool,
     changeMasking: PropTypes.func
 };
-
-CompleteButton.contextTypes= {
-    groupKey: PropTypes.string
-};
-
-CompleteButton.defaultProps= { includeUnmounted : false };
 
 export default CompleteButton;

--- a/src/firefly/js/ui/DialogRootContainer.jsx
+++ b/src/firefly/js/ui/DialogRootContainer.jsx
@@ -49,19 +49,22 @@ export function hideDropDown(id='') {
     if (ddDiv) ReactDOM.unmountComponentAtNode(ddDiv);
 }
 
+
+const getPos = (props) => {
+    const {atElRef:el} = props;
+    if (!get(el, 'isConnected', true)) hideDropDown(props.id);                                                  // referenced element is no longer visible.. hide drop-down.
+    const {x:o_x, y:o_y, width:o_width, height:o_height} = document.documentElement.getBoundingClientRect();    // outer box
+    const {x=0, y=0, width=0, height=0} = el ? el.getBoundingClientRect() : {};                                 // inner box
+    return {x, y, width, height,  o_x, o_y, o_width, o_height};
+};
+
+
 class DropDown extends PureComponent {
 
     constructor(props) {
         super(props);
 
-        this.getPos = (el) => {
-            if (!get(el, 'isConnected', true)) hideDropDown(props.id);                                                  // referenced element is no longer visible.. hide drop-down.
-            const {x:o_x, y:o_y, width:o_width, height:o_height} = document.documentElement.getBoundingClientRect();    // outter box
-            const {x=0, y=0, width=0, height=0} = el ? el.getBoundingClientRect() : {};                                 // inner box
-            return {x, y, width, height,  o_x, o_y, o_width, o_height};
-        };
-
-        this.state = this.getPos(props.atElRef);
+        this.state = getPos(props);
         this.hideDropDown = this.hideDropDown.bind(this);
     }
 
@@ -69,8 +72,8 @@ class DropDown extends PureComponent {
         hideDropDown(this.props.id);
     }
 
-    componentWillReceiveProps(np) {
-        this.setState(this.getPos(np.atElRef));
+    static getDerivedStateFromProps(props) {
+        return getPos(props);
     }
 
     componentDidMount() {

--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -43,12 +43,10 @@ export class DownloadOptionsDialog extends PureComponent {
         this.state = {where, fileName: props.fileName, wsSelect, fileOverwritable, wsList, isUpdating};
     }
 
-    componentWillReceiveProps(nextProps) {
-        const {fileName} = nextProps;
 
-        if (fileName !== this.state.fileName) {
-            this.setState({fileName});
-        }
+    static getDerivedStateFromProps(props,state) {
+        const {fileName} = props;
+        return (fileName !== state.fileName) ? {fileName} : null;
     }
 
     componentWillUnmount() {

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -225,16 +225,14 @@ export function HiPSPopupMsg(msg, title) {
 export class HiPSSurveyListSelection extends PureComponent {
     constructor(props) {
         super(props);
-
-        this.state = {[fKeyHiPSSources]: initHiPSCheckboxStatus()};
-    }
-
-    componentWillMount() {
         const sources = sourcesPerChecked();
-        const {dataType, surveysId, hipsUrl} = this.props;
+        const {dataType, surveysId, hipsUrl} = props;
 
         loadHiPSSurverysWithHighlight({dataTypes: dataType, id: surveysId, sources, ivoOrUrl: hipsUrl, columnName: URL_COL});
-        this.setState({isUpdatingHips: isLoadingHiPSSurverys(makeHiPSSurveysTableName(surveysId, sources))});
+
+        this.state = {[fKeyHiPSSources]: initHiPSCheckboxStatus(),
+                       isUpdatingHips: isLoadingHiPSSurverys(makeHiPSSurveysTableName(surveysId, sources))
+        };
     }
 
     componentWillUnmount() {

--- a/src/firefly/js/ui/IbeSpacialType.jsx
+++ b/src/firefly/js/ui/IbeSpacialType.jsx
@@ -23,6 +23,7 @@ import FieldGroupUtils from '../fieldGroup/FieldGroupUtils.js';
 import {RadioGroupInputField} from './RadioGroupInputField.jsx';
 import {ListBoxInputField} from './ListBoxInputField.jsx';
 import {SizeInputFields} from './SizeInputField.jsx';
+import {GroupKeyCtx} from './FieldGroup';
 
 
 const mcenTip= `Specifies whether to return only the most centered (in pixel space)
@@ -43,7 +44,8 @@ export class IbeSpacialType extends PureComponent {
 
     componentDidMount() {
         this.iAmMounted= true;
-        this.removeListener= FieldGroupUtils.bindToStore(this.context.groupKey, (fields) => {
+        const groupKey= this.context;
+        this.removeListener= FieldGroupUtils.bindToStore(groupKey, (fields) => {
             this.setState({fields});
         });
     }
@@ -82,6 +84,10 @@ export class IbeSpacialType extends PureComponent {
 
 
 }
+
+
+IbeSpacialType.contextType = GroupKeyCtx;
+
 
 function renderSearchRegion(visible) {
     
@@ -132,12 +138,5 @@ function renderMostCenter(visible) {
         />
     );
 }
-
-
-
-
-
-
-IbeSpacialType.contextTypes = { groupKey: PropTypes.string };
 
 

--- a/src/firefly/js/ui/InputAreaField.jsx
+++ b/src/firefly/js/ui/InputAreaField.jsx
@@ -41,8 +41,8 @@ export class InputAreaField extends PureComponent {
         this.setState(nState);
     }
 
-    componentWillReceiveProps(nProps) {
-        this.setState(newState({value: nProps.value}));
+    static getDerivedStateFromProps(props) {
+        return newState({value: props.value});
     }
 
     render() {

--- a/src/firefly/js/ui/InputField.jsx
+++ b/src/firefly/js/ui/InputField.jsx
@@ -48,9 +48,10 @@ export class InputField extends PureComponent {
         this.setState(nState);
     }
 
-    componentWillReceiveProps(nProps) {
-        //this.setState(newState({value: nProps.value}));
-        this.setState({value: nProps.value});
+
+
+    static getDerivedStateFromProps(props) {
+        return {value: props.value};
     }
 
     render() {

--- a/src/firefly/js/ui/LinkButton.jsx
+++ b/src/firefly/js/ui/LinkButton.jsx
@@ -41,11 +41,6 @@ export function LinkButton({text, tip='$text',style={}, onClick}) {
     );
 }
 
-
-//CloseButton.contextTypes= {
-//};
-
-
 LinkButton.propTypes= {
     text : PropTypes.string,
     style : PropTypes.object,

--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -73,14 +73,19 @@ class ShapePickerWrapper extends PureComponent {
     }
 
 
-    componentWillReceiveProps(nextProps) {
-        var {size, symbol} = nextProps.drawingDef;
-        var {width} = DrawUtil.getDrawingSize(size, symbol);
-        var validSize = (width >= MINSIZE) && (width <= MAXSIZE);
+    componentDidUpdate(prevProps) {
+        const {size, symbol} = this.props.drawingDef;
+        const {size:prevSize, symbol:prevSymbol} = prevProps.drawingDef;
+        const {width} = DrawUtil.getDrawingSize(size, symbol);
+        const {width:prevWidth} = DrawUtil.getDrawingSize(prevSize, prevSymbol);
 
-        this.setState({drawingDef: nextProps.drawingDef, size: `${width}`, validSize}); // sizexsize: the overal size shown on UI
-        this.displayGroupId = nextProps.displayGroupId;
-        this.plotId = nextProps.plotId;
+        if (size!==prevSize || symbol!==prevSymbol || width!==prevWidth) {
+            const validSize = (width >= MINSIZE) && (width <= MAXSIZE);
+            this.setState({drawingDef: this.props.drawingDef, size: `${width}`, validSize}); // sizexsize: the overal size shown on UI
+        }
+        this.displayGroupId = this.props.displayGroupId;
+        this.plotId = this.props.plotId;
+
     }
 
     componentDidMount() {

--- a/src/firefly/js/ui/RangeSliderView.jsx
+++ b/src/firefly/js/ui/RangeSliderView.jsx
@@ -17,10 +17,9 @@ export class RangeSliderView extends PureComponent {
         this.decimalDig = (d < 0) ? 0 : (d > 20) ? 20 : d;
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState( {value: parseFloat(nextProps.slideValue)} );
+    static getDerivedStateFromProps(props,state) {
+        return {value: parseFloat(props.slideValue)};
     }
-
 
     onSliderChange(v) {
         const {handleChange, minStop, maxStop} = this.props;

--- a/src/firefly/js/ui/RenderTreeIdCtx.jsx
+++ b/src/firefly/js/ui/RenderTreeIdCtx.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const RenderTreeIdCtx = React.createContext( {
+    renderTreeId: undefined
+});

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -9,7 +9,7 @@ export class SimpleComponent extends PureComponent {
         this.state = this.getNextState(props);
     }
 
-    componentWillReceiveProps(np) {
+    UNSAFE_componentWillReceiveProps(np) {
         if (!this.isUnmounted) {
             if (!shallowequal(this.props, np)) {
                 this.setState(this.getNextState(np));

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -108,10 +108,9 @@ class SizeInputFieldView extends PureComponent {
         this.state = updateSizeInfo(props);
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState( updateSizeInfo(nextProps) );
+    static getDerivedStateFromProps(props) {
+        return updateSizeInfo(props);
     }
-
 
 
     onSizeChange(ev) {

--- a/src/firefly/js/ui/StatedInputfield.jsx
+++ b/src/firefly/js/ui/StatedInputfield.jsx
@@ -29,8 +29,8 @@ export class StateInputField extends PureComponent {
         this.setState(() => ({valid, value}));
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState(() => ({valid:true, value:nextProps.defaultValue}));
+    static getDerivedStateFromProps(props) {
+        return {valid: true, value: props.defaultValue};
     }
 
 

--- a/src/firefly/js/ui/SuggestBoxInputField.jsx
+++ b/src/firefly/js/ui/SuggestBoxInputField.jsx
@@ -124,11 +124,14 @@ class SuggestBoxInputFieldView extends PureComponent {
         this.updateSuggestions = debounce(this.updateSuggestions.bind(this), 200);
     }
 
-    componentWillReceiveProps(nextProps) {
-        const {valid, message, value} = nextProps;
-        if (valid !== this.state.valid || message !== this.state.message || value !== this.state.displayValue) {
-            this.setState({valid, message, displayValue: value});
+
+
+    static getDerivedStateFromProps(props,state) {
+        const {valid, message, value} = props;
+        if (valid !== state.valid || message !== state.message || value !== state.displayValue) {
+            return {valid, message, displayValue: value};
         }
+        return null;
     }
 
     onValueChange(ev) {

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import './ToolbarButton.css';
 import {dispatchHideDialog} from '../core/ComponentCntlr.js';
 import {DROP_DOWN_KEY} from './DropDownToolbarButton.jsx';
-
+import {ToolTipCtx} from '../visualize/ui/VisToolbar.jsx';
 
 
 export function makeBadge(cnt) {
@@ -173,11 +173,7 @@ export class ToolbarButton extends PureComponent {
     }
 }
 
-ToolbarButton.contextTypes= {
-    tipOnCB : PropTypes.func,
-    tipOffCB : PropTypes.func
-};
-
+ToolbarButton.contextType = ToolTipCtx;
 
 ToolbarButton.propTypes= {
     icon : PropTypes.string,

--- a/src/firefly/js/ui/panel/CollapsiblePanel.jsx
+++ b/src/firefly/js/ui/panel/CollapsiblePanel.jsx
@@ -46,8 +46,8 @@ export class CollapsiblePanel extends PureComponent {
         this.getContentHeight = this.getContentHeight.bind(this);
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState( () => collapsibleStateFromProps(nextProps));
+    static getDerivedStateFromProps(props) {
+        return collapsibleStateFromProps(props);
     }
 
     handleClick() {

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -83,10 +83,10 @@ export class Tabs extends PureComponent {
         this.state= tabsStateFromProps(props);
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.setState( () => tabsStateFromProps(nextProps));
+    static getDerivedStateFromProps(props) {
+        return tabsStateFromProps(props);
     }
-    
+
     componentWillUnmount() {
         this.isUnmounted = true;
     }
@@ -168,7 +168,7 @@ export class Tab extends PureComponent {
         super(props);
     }
 
-    componentWillMount() {
+    componentDidMount() {
         const {selected, onSelect, id, name} = this.props;
         if (selected) {
             onSelect(id, name);

--- a/src/firefly/js/util/BrowserUtil.js
+++ b/src/firefly/js/util/BrowserUtil.js
@@ -10,7 +10,7 @@ import {getProp} from './WebUtil.js';
 
 const SCRIPT_NAME = getProp('SCRIPT_NAME');
 
-var getScriptURL = (function() {
+const getScriptURL = (() => {
     
     var scripts = document.getElementsByTagName('script');
     var myScript;
@@ -22,14 +22,14 @@ var getScriptURL = (function() {
             }
         }
     }
-    return function() { return myScript; };
+    return () => myScript;
 })();
 
 
-export var getRootURL = (function() {
-    var rootURL = '//localhost:8080/';
+export const getRootURL = (() => {
+    let rootURL = '//localhost:8080/';
     if (SCRIPT_NAME !== undefined) {
-        var workingURL= getScriptURL() || window.location.href;
+        const workingURL= getScriptURL() || window.location.href;
         rootURL= workingURL.substring(0,workingURL.lastIndexOf('/')) + '/';
     }
     return () => rootURL;
@@ -37,20 +37,20 @@ export var getRootURL = (function() {
 
 
 
-export var getRootPath = (function() {
-    var url= getRootURL();
-    var rootPath= url;
-    if (url.startsWith('http')) {
-        var part1= url.substring(url.indexOf('://')+3);
-        rootPath= part1.substring(part1.indexOf('/'));
-    }
-    return () =>rootPath;
-})();
+// export var getRootPath = (function() {
+//     var url= getRootURL();
+//     var rootPath= url;
+//     if (url.startsWith('http')) {
+//         var part1= url.substring(url.indexOf('://')+3);
+//         rootPath= part1.substring(part1.indexOf('/'));
+//     }
+//     return () =>rootPath;
+// })();
 
 
-export var getHost = (function() {
-    var url= getRootURL();
-    var host= url.substring(url.indexOf('//')+2);
+export var getHost = (() => {
+    const url= getRootURL();
+    let host= url.substring(url.indexOf('//')+2);
     if (host.indexOf('/')>-1){
         host= host.substr(0,host.indexOf('/'));
     }
@@ -60,9 +60,9 @@ export var getHost = (function() {
     return () =>host;
 })();
 
-export var getPort = (function() {
-    var port= -1;
-    var url= getRootURL();
+export const getPort = (function() {
+    let port= -1;
+    const url= getRootURL();
     if (url.startsWith('http')) {
         port= url.startsWith('https') ? 144 : 80;
     }
@@ -78,8 +78,8 @@ export var getPort = (function() {
 
 
 export const getAbsoluteLeft= function(elem) {
-    var left = 0;
-    var curr = elem;
+    let left = 0;
+    let curr = elem;
     // This intentionally excludes body which has a null offsetParent.
     while (curr.offsetParent) {
         left -= curr.scrollLeft;
@@ -93,8 +93,8 @@ export const getAbsoluteLeft= function(elem) {
 };
 
 export const getAbsoluteTop= function(elem) {
-    var top = 0;
-    var curr = elem;
+    let top = 0;
+    let curr = elem;
     // This intentionally excludes body which has a null offsetParent.
     while (curr.offsetParent) {
         top -= curr.scrollTop;
@@ -115,14 +115,14 @@ export const getAbsoluteTop= function(elem) {
  * @return {string}
  */
 export const modifyURLToFull= function(url, rootPath) {
-    var retURL = url;
+    let retURL = url;
     if (url) {
         if (!isFull(url)) {
             if (!rootPath) {
-                var docUrl = document.URL;
-                var lastSlash = docUrl.lastIndexOf('/');
+                const docUrl = document.URL;
+                const lastSlash = docUrl.lastIndexOf('/');
                 if (lastSlash > -1) {
-                    var rootURL = docUrl.substring(0, lastSlash + 1);
+                    const rootURL = docUrl.substring(0, lastSlash + 1);
                     retURL = rootURL + url;
                 } else {
                     retURL = docUrl + '/' + url;

--- a/src/firefly/js/util/StringUtils.js
+++ b/src/firefly/js/util/StringUtils.js
@@ -1,6 +1,3 @@
-import validator from 'validator';
-
-
 /**
  * This File is Deprecated.  It is only used by 3 other modules and that will be cleaned up eventually
  */
@@ -116,8 +113,4 @@ export function convertExtendedAscii(sbOriginal) {
         }
     }
     return sbOriginal;
-}
-
-export function parseInt(s,failValue= 0) {
-    return (validator.isInt(s+'')) ? validator.toInt(s+'') : failValue;
 }

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -603,10 +603,10 @@ export class CysConverter {
     /**
      * @desc Return the sky coordinates given a image x (fsamp) and  y (fline)
      * @param {PointPt} pt  the point to convert
-     * @param  {CoordinateSys} outputCoordSys (optional) The coordinate system to return, default to coordinate system of image
+     * @param  {CoordinateSys} [outputCoordSys] (optional) The coordinate system to return, default to coordinate system of image
      * @returns {WorldPt} the translated coordinates
      */
-    getWorldCoords(pt, outputCoordSys) {
+    getWorldCoords(pt, outputCoordSys= undefined) {
         if (!isValidPoint(pt)) return null;
 
         let retval = null;

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -113,33 +113,28 @@ export class ImageViewerLayout extends PureComponent {
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        const {width,height}= nextProps;
-        const {viewDim}= nextProps.plotView;
-        if (width!==viewDim.width && height!==viewDim.height && width && height) {
-            dispatchUpdateViewSize(nextProps.plotView.plotId,width,height);
-        }
-
-        // case: a new plot force other plot to zoom match
-        if (!primePlot(this.props.plotView) &&  primePlot(nextProps.plotView)) {
-            const paging= isImageViewerSingleLayout(getMultiViewRoot(), visRoot(), nextProps.plotView.plotId);
-            updateZoom(nextProps.plotView.plotId,paging);
-        }
-    }
-
-    componentDidUpdate() {
+    componentDidUpdate(prevProp) {
         const {width,height,externalWidth,externalHeight, plotView:pv}= this.props;
-        const {prevWidth,prevHeight, prevExternalWidth, prevExternalHeight, prevPlotId}= this.previousDim;
-        if (!pv) return;
+        const {prevWidth,prevHeight, prevExternalWidth, prevExternalHeight}= this.previousDim;
+        if (!pv || !width || !height) return;
 
-        if ((prevWidth!==width || prevHeight!==height || prevPlotId!==pv.plotId) && width && height) {
-            dispatchUpdateViewSize(pv.plotId,width,height);
+        const {viewDim}= pv;
+        if (width!==viewDim.width || height!==viewDim.height || prevWidth!==width || prevHeight!==height ) {
+            dispatchUpdateViewSize(pv.plotId,width,height); // case: any resizing
+
             if (primePlot(pv)) {
+                                 // case: resizing, todo: document how this is different than normal resizing
                 if (prevExternalWidth!==externalWidth || prevExternalHeight!==externalHeight) {
                     updateZoom(pv.plotId,false);
                 }
             }
             this.previousDim= makePrevDim(this.props);
+        }
+
+        // case: a new plot force other plot to zoom match
+        if (!primePlot(prevProp.plotView) &&  primePlot(pv)) {
+            const paging= isImageViewerSingleLayout(getMultiViewRoot(), visRoot(), pv.plotId);
+            updateZoom(pv.plotId,paging);
         }
     }
 
@@ -534,9 +529,9 @@ class DrawingLayers extends Component {
         let drawingAry= null;
         const {width,height}= pv.viewDim;
         if (dlIdAry) {
-            drawingAry= dlIdAry.map( (dlId, idx) => <DrawerComponent plot={plot} drawLayerId={dlId}
+            drawingAry= dlIdAry.map( (dlId, idx) => (<DrawerComponent plot={plot} drawLayerId={dlId}
                                                                      width={width} height={height}
-                                                                     idx={idx} key={dlId}/> );
+                                                                     idx={idx} key={dlId}/>) );
         }
         return (
             <div className='drawingArea'

--- a/src/firefly/js/visualize/draw/CanvasWrapper.jsx
+++ b/src/firefly/js/visualize/draw/CanvasWrapper.jsx
@@ -96,7 +96,7 @@ class CanvasWrapper extends Component {
         super(props);
         this.drawer= null;
         this.lastDrawLayer= null;
-        
+        this.drawer= Drawer.makeDrawer();
     }
 
     shouldComponentUpdate(nProps) {
@@ -125,10 +125,6 @@ class CanvasWrapper extends Component {
         window.requestAnimationFrame(() => {
             if (this.drawer) updateDrawer(this.drawer,plot,width,height,dl,force);
         });
-    }
-
-    componentWillMount() {
-        this.drawer= Drawer.makeDrawer();
     }
 
     componentDidMount() {

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -161,7 +161,7 @@ function watchCoverage(tbl_id, action, cancelSelf, params) {
         return;
     }
 
-    if (paused && (action.type===MultiViewCntlr.VIEWER_MOUNTED && action.type===MultiViewCntlr.ADD_VIEWER) )  {
+    if (action.type===MultiViewCntlr.VIEWER_MOUNTED || action.type===MultiViewCntlr.ADD_VIEWER)  {
         updateCoverage(tbl_id, viewerId, decimatedTables, options);
         return {paused:false};
     }

--- a/src/firefly/js/visualize/ui/ApiFullImageDisplay.jsx
+++ b/src/firefly/js/visualize/ui/ApiFullImageDisplay.jsx
@@ -16,6 +16,8 @@ import {readoutRoot} from '../../visualize/MouseReadoutCntlr.js';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
 import {MultiImageViewer} from './MultiImageViewer.jsx';
 import {NewPlotMode} from '../MultiViewCntlr.js';
+import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
+
 // import {ExpandedTools} from '../iv/ExpandedTools.jsx';
 
 
@@ -30,10 +32,6 @@ export class ApiFullImageDisplay extends PureComponent {
     componentWillUnmount() {
         if (this.removeListener) this.removeListener();
         if (this.removeMouseListener) this.removeMouseListener();
-    }
-
-    getChildContext() {
-        return {renderTreeId : this.props.renderTreeId };
     }
 
     componentDidMount() {
@@ -57,32 +55,34 @@ export class ApiFullImageDisplay extends PureComponent {
         const {closeFunc, viewerId}= this.props;
         const {visRoot,currMouseState, readout, showHealpixPixel}= this.state;
         return (
-            <div style={{width:'100%', height:'100%', display:'flex', flexWrap:'nowrap',
-                         alignItems:'stretch', flexDirection:'column'}}>
-                <div style={{position: 'relative', marginBottom:'6px',
-                         display:'flex', flexWrap:'nowrap', flexDirection:'row', justifyContent: 'center'}}
-                     className='banner-background'>
-                    <div style={{display:'flex', flexDirection:'row', alignItems:'flex-end'}}>
-                        <VisHeaderView visRoot={visRoot} currMouseState={currMouseState} readout={readout}
-                                       showHealpixPixel={showHealpixPixel}/>
+            <RenderTreeIdCtx.Provider value={{renderTreeId : this.props.renderTreeId}}>
+                <div style={{width:'100%', height:'100%', display:'flex', flexWrap:'nowrap',
+                    alignItems:'stretch', flexDirection:'column'}}>
+                    <div style={{position: 'relative', marginBottom:'6px',
+                        display:'flex', flexWrap:'nowrap', flexDirection:'row', justifyContent: 'center'}}
+                         className='banner-background'>
+                        <div style={{display:'flex', flexDirection:'row', alignItems:'flex-end'}}>
+                            <VisHeaderView visRoot={visRoot} currMouseState={currMouseState} readout={readout}
+                                           showHealpixPixel={showHealpixPixel}/>
+                        </div>
+                    </div>
+                    <div>
+                        <VisToolbar messageUnder={Boolean(closeFunc)}/>
+                    </div>
+                    <div style={{flex: '1 1 auto', display:'flex'}}>
+                        <MultiImageViewer viewerId= {viewerId}
+                                          insideFlex={true}
+                                          canReceiveNewPlots={NewPlotMode.create_replace.key}
+                                          Toolbar={MultiViewStandardToolbar}/>
+                    </div>
+                    <div style={{display:'flex', flexDirection:'row', alignItems:'flex-end', position: 'absolute',
+                        bottom: 3, right: 4, borderTop: '2px ridge', borderLeft: '2px ridge'
+                    }}
+                    >
+                        <VisPreview {...{showPreview:true, visRoot, currMouseState, readout}}/>
                     </div>
                 </div>
-                <div>
-                    <VisToolbar messageUnder={Boolean(closeFunc)}/>
-                </div>
-                <div style={{flex: '1 1 auto', display:'flex'}}>
-                    <MultiImageViewer viewerId= {viewerId}
-                                      insideFlex={true}
-                                      canReceiveNewPlots={NewPlotMode.create_replace.key}
-                                      Toolbar={MultiViewStandardToolbar}/>
-                </div>
-                <div style={{display:'flex', flexDirection:'row', alignItems:'flex-end', position: 'absolute',
-                             bottom: 3, right: 4, borderTop: '2px ridge', borderLeft: '2px ridge'
-                           }}
-                >
-                    <VisPreview {...{showPreview:true, visRoot, currMouseState, readout}}/>
-                </div>
-            </div>
+            </RenderTreeIdCtx.Provider>
             );
     }
 }
@@ -98,6 +98,3 @@ ApiFullImageDisplay.defaultProps= {
     closeFunc:null
 };
 
-ApiFullImageDisplay.childContextTypes= {
-    renderTreeId : PropTypes.string
-};

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -70,7 +70,7 @@ export class CatalogConstraintsPanel extends PureComponent {
         this.fetchDD(catname, makeFormType(showFormType, dd_short), createDDRequest, true, this.afterFetchDD); //short form as default
     }
 
-    componentWillReceiveProps(np) {
+    UNSAFE_componentWillReceiveProps(np) {
         const ddShort = makeFormType(np.showFormType, np.dd_short);
 
         if (np.processId !== this.props.processId) {

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -297,11 +297,6 @@ class CatalogSelectView extends PureComponent {
             this.state = {master: {catmaster, cols}};
         } else {
             this.state = {master: {}};
-        }
-    }
-
-    componentWillMount() {
-        if (isEmpty(catmaster)) {
             this.loadMasterCatalogTable();
         }
     }

--- a/src/firefly/js/visualize/ui/ColorBandPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorBandPanel.jsx
@@ -63,23 +63,19 @@ export class ColorBandPanel extends PureComponent {
         this.mouseMove= this.mouseMove.bind(this);
         this.mouseLeave= this.mouseLeave.bind(this);
         this.bandReplot= debounce(getReplotFunc(props.groupKey, props.band), 600);
+        const {plot,band}= props;
+        this.initImages(plot,band);
     }
-
-
-    componentWillReceiveProps(nextProps) {
-        const {plot:nPlot}= nextProps;
-        const {plot}= this.props;
+    
+    componentDidUpdate(prevProps) {
+        const {plot:nPlot}= this.props;
+        const {plot}= prevProps;
         if (nPlot.plotId!==plot.plotId || nPlot.plotState!==plot.plotState) {
-            this.initImages(nPlot,nextProps.band);
+            this.initImages(nPlot,this.props.band);
         }
-        if (nextProps.groupKey !== this.props.groupKey) {
+        if (this.props.groupKey !== prevProps.groupKey) {
             this.bandReplot= debounce(getReplotFunc(this.props.groupKey, this.props.band), 600);
         }
-    }
-
-    componentWillMount() {
-        const {plot,band}= this.props;
-        this.initImages(plot,band);
     }
 
     initImages(plot,band) {

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
@@ -35,7 +35,7 @@ export class ImageMetaDataToolbar extends Component {
         if (this.removeListener) this.removeListener();
     }
     
-    componentWillMount() {
+    componentDidMount() {
         this.iAmMounted= true;
         this.removeListener= flux.addListener(() => this.storeUpdate(this.props));
     }

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {PureComponent} from 'react';
+import React, {PureComponent, useContext} from 'react';
 import PropTypes from 'prop-types';
 import {get, includes, isNil} from 'lodash';
 import {FormPanel} from '../../ui/FormPanel.jsx';
@@ -36,6 +36,7 @@ import {HiPSImageSelect, makeHiPSWebPlotRequest} from '../../ui/HiPSImageSelect.
 import {sourcesPerChecked} from '../../ui/HiPSSurveyListDisplay.jsx';
 
 import './ImageSearchPanelV2.css';
+import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
 
 
 const FG_KEYS = {
@@ -127,14 +128,12 @@ function ImageSearchPanel({resizable=true, onSubmit, gridSupport = false, multiS
     );
 }
 
-export function ImageSearchDropDown({gridSupport, resizable=true}, {renderTreeId}) {
+export function ImageSearchDropDown({gridSupport, resizable=true}) {
+    const {renderTreeId} = useContext(RenderTreeIdCtx);
     const {plotId, viewerId, multiSelect} = getContexInfo(renderTreeId);
     const onSubmit = (request) => onSearchSubmit({request, plotId, viewerId, gridSupport, renderTreeId});
     return <ImageSearchPanel {...{resizable, gridSupport, onSubmit, multiSelect, onCancel:dispatchHideDropDown}}/>;
 }
-
-ImageSearchDropDown.contextTypes= {renderTreeId: PropTypes.string};
-
 
 function GridSupport() {
     return (

--- a/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
+++ b/src/firefly/js/visualize/ui/ImageSelectPanel.jsx
@@ -248,7 +248,7 @@ export class ImageSelection extends PureComponent {
          };
      }
 
-    componentWillReceiveProps (nextProps) {
+    UNSAFE_componentWillReceiveProps (nextProps) {
         this.allfields = getAllGroupFields(panelKey,...rgbFieldGroup);
 
         this.setState({
@@ -373,7 +373,7 @@ class ImageSelectionView extends PureComponent {
         this.changeMasking= (doMask) => this.setState(() => ({doMask}));
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
 
         this.setState ({
             crtCatalogId: computeCurrentCatalogId(nextProps.fields,

--- a/src/firefly/js/visualize/ui/VisToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbar.jsx
@@ -25,17 +25,20 @@ const omList= ['plotViewAry'];
 const pvPickList= ['plotViewCtx','primeIdx', 'flipY'];
 const hipsUrl = 'hipsUrlRoot';
 
+
+
+export const ToolTipCtx = React.createContext( {
+    tipOnCB : undefined,
+    tipOffCB : undefined,
+});
+
+
 export class VisToolbar extends PureComponent {
     constructor(props) {
         super(props);
         this.state= {visRoot:visRoot(), dlCount:0, tip:''};
         this.tipOn= (tip) => this.setState({tip});
         this.tipOff= () => this.setState({tip:null});
-    }
-
-
-    getChildContext() {
-        return {tipOnCB: this.tipOn, tipOffCB: this.tipOff};
     }
 
     componentWillUnmount() {
@@ -98,18 +101,16 @@ export class VisToolbar extends PureComponent {
         const {messageUnder, style}= this.props;
         const {visRoot,tip,dlCount}= this.state;
         return (
-            <VisToolbarViewWrapper visRoot={visRoot} toolTip={tip} dlCount={dlCount} 
-                                      messageUnder={messageUnder} style={style}/>
+
+            <ToolTipCtx.Provider value={{tipOnCB: this.tipOn, tipOffCB: this.tipOff}}>
+                <VisToolbarViewWrapper visRoot={visRoot} toolTip={tip} dlCount={dlCount}
+                                       messageUnder={messageUnder} style={style}/>
+            </ToolTipCtx.Provider>
         );
     }
 
 
 }
-
-VisToolbar.childContextTypes= {
-    tipOnCB : PropTypes.func,
-    tipOffCB : PropTypes.func
-};
 
 VisToolbar.propTypes= {
     messageUnder : PropTypes.bool,


### PR DESCRIPTION
Firefly-8: Clean up react lifecycle deprecated methods and context
   - updated all context to use new context api
   - update many lifecycle method to new style
   - deprecated lifecycle methods that I did not update now start with UNSAFE_
   - payed particular attention to field group

_To test:_

Do _some_ (not all) of the following:
 - try any dialog or panel you are familiar with and make sure it works as expected.
 - Make sure images seem to work
 - Make sure all UI elements works
 - Make sure multi chart viewing works

_To Do:_
 - @tgoldina, @loitly You are welcome to add commits to this pull request:
```bash
  cd firefly/src/firefly/js
  find . -name '*.jsx' -exec fgrep -H 'UNSAFE_' {} \;
```
 - Any file you are familiar with could be updated:
          https://reactjs.org/blog/2018/03/29/react-v-16-3.html
- Some of them should be straight forward but I was not quite sure how to verify if it was working correctly.
