### PR TITLE
IRSA-2637: URL value encoded and passed to api

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
@@ -21,13 +21,11 @@ import edu.caltech.ipac.table.io.VoTableReader;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.util.download.URLDownload;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
 
 import static edu.caltech.ipac.firefly.server.query.lc.PeriodogramAPIRequest.LC_FILE;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
@@ -216,9 +214,11 @@ public class IrsaLightCurveHandler implements LightCurveHandler {
         URL url = null;
         try {
             url = new URL(source);
-            inf = "input=" + url.toString();
+            inf = "input=" + URLEncoder.encode(url.toString(),"UTF-8");
         } catch (MalformedURLException e) {
             inf = ServerContext.convertToFile(source).getAbsolutePath();
+        } catch (UnsupportedEncodingException e) {
+            LOG.error("Unsupported encoding error URL:"+url.toString());
         }
         return inf;
     }


### PR DESCRIPTION
This PR is about fixing the problem of the peridogram tool (period finder) in TimeSeries when sending the table from Gator. 
Gator send the table (light-curve) with a URL source input file that contains '&' and other characters and get passed to the tool and period finder use it without encoding before calling the API and fails.

To test, you will need to use this branch with Gator in irsadev - go to WISE multiepoch photometry catalog and do a search, then click on 'Time Series tool' button in the result page and then click on 'period finder' on the time series tool and calculate the peirodogram with default value.

Another way is to replace the test 'LightCurveProcessorTest' with a sample URL (from Gator search test) which contains '&' and overwrite 'edu.caltech.ipac.firefly.server.query.LightCurveProcessorTest.PeriodogramAPIRequestTest#getLcSource'.