### PR TITLE
IRSA-2013 ZTF time series: overlay sra,sdec coordinates instead of ra…

### DIFF
--- a/src/firefly/js/templates/lightcurve/ztf/ZTFPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/ztf/ZTFPlotRequests.js
@@ -24,8 +24,10 @@ export function getWebPlotRequestViaZTFIbe(tableModel, hlrow, cutoutSize, params
     fluxCol: 'mag',
     dataSource: 'field'
 }) {
-    const ra = getCellValue(tableModel, hlrow, 'ra');
-    const dec = getCellValue(tableModel, hlrow, 'dec');
+    const ra = getCellValue(tableModel, hlrow, 'sra');
+    const dec = getCellValue(tableModel, hlrow, 'sdec');
+    const cra = getCellValue(tableModel, hlrow, 'ra');
+    const cdec = getCellValue(tableModel, hlrow, 'dec');
     const field = getCellValue(tableModel, hlrow, 'field');
     const ccdid = getCellValue(tableModel, hlrow, 'ccdid');
     const qid = getCellValue(tableModel, hlrow, 'qid');
@@ -62,7 +64,7 @@ export function getWebPlotRequestViaZTFIbe(tableModel, hlrow, cutoutSize, params
         let wp = null;
         sr.setParam('doCutout', 'false');
         if (!isNil(ra) && !isNil(dec)) {
-            sr.setParam('center', `${ra},${dec}`);
+            sr.setParam('center', `${cra},${cdec}`);
             sr.setParam('in_ra', `${ra}`);
             sr.setParam('in_dec', `${dec}`);
             wp = makeWorldPt(ra, dec, CoordinateSys.EQ_J2000);

--- a/src/firefly/js/templates/lightcurve/ztf/ZTFPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/ztf/ZTFPlotRequests.js
@@ -64,7 +64,7 @@ export function getWebPlotRequestViaZTFIbe(tableModel, hlrow, cutoutSize, params
         let wp = null;
         sr.setParam('doCutout', 'false');
         if (!isNil(ra) && !isNil(dec)) {
-            sr.setParam('center', `${cra},${cdec}`);
+            sr.setParam('center', `${ra},${dec}`);
             sr.setParam('in_ra', `${ra}`);
             sr.setParam('in_dec', `${dec}`);
             wp = makeWorldPt(ra, dec, CoordinateSys.EQ_J2000);


### PR DESCRIPTION
This PR is to change the overlay position to sra,sdec for ZTF time series, these positions reflect the measurement epochs. 
To test, upload the attached ztf_lc table in https://jira.ipac.caltech.edu/browse/IRSA-2013
https://irsawebdev9.ipac.caltech.edu/irsa-2013/irsaviewer/ts.html
select mission ZTF. You will need to zoom in on the image to see the sra, sdec position changes.


