### PR TITLE
IRSA-2562: modify filter tooltips to reflect current support format.

### DIFF
--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -15,8 +15,13 @@ Or 'IN', followed by a list of values separated by commas.
 Examples:  > 12345; != 3000; IN a,b,c,d`;
 
 export const FILTER_TTIPS =
-`Filters are "column_name operator condition" separated by commas.
-${FILTER_CONDITION_TTIPS}`;
+`Conditional statements in the form of "column_name" operator value separated by semicolon.
+* operator is one of =, >, <, !=, >=, <=, LIKE, IN, IS, IS NOT
+* column_name must be enclosed in double quotes
+* string value must be enclosed in single quotes
+* when IN is used, enclose the values in parentheses
+Examples:  "ra" > 12345; "color" != 'blue'; "band" IN (1,2,3)
+`;
 
 /**
  * return [column_name, operator, value] triplet.

--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {get, isEmpty} from 'lodash';
 import {createInputCell} from '../../tables/ui/TableRenderer.js';
-import {FILTER_TTIPS, FilterInfo} from '../../tables/FilterInfo.js';
+import {FILTER_CONDITION_TTIPS, FilterInfo} from '../../tables/FilterInfo.js';
 
 import {getColumnIdx, getTblById, watchTableChanges} from '../../tables/TableUtil.js';
 import {fieldGroupConnector} from '../FieldGroupConnector.jsx';
@@ -28,7 +28,7 @@ export function ColConstraintsPanel({tableModel, onTableChanged, style}) {
     }, [tableModel]);
 
 
-    const newInputCell = createInputCell(FILTER_TTIPS,
+    const newInputCell = createInputCell(FILTER_CONDITION_TTIPS,
                 15,
                 FilterInfo.conditionValidatorNoAutoCorrect,
                 onTableChanged, {width: '100%', boxSizing: 'border-box'});

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -13,7 +13,7 @@ import {BasicTableView} from '../../tables/ui/BasicTableView.jsx';
 import {createLinkCell, createInputCell} from '../../tables/ui/TableRenderer.js';
 import * as TblCntlr from '../../tables/TablesCntlr.js';
 import {SelectInfo} from '../../tables/SelectInfo.js';
-import {FilterInfo, FILTER_TTIPS} from '../../tables/FilterInfo.js';
+import {FilterInfo, FILTER_CONDITION_TTIPS} from '../../tables/FilterInfo.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {InputAreaFieldConnected} from '../../ui/InputAreaField.jsx';
 import {fieldGroupConnector} from '../../ui/FieldGroupConnector.jsx';
@@ -366,7 +366,7 @@ class ConstraintPanel extends PureComponent {
     constructor(props) {
         super(props);
 
-        this.newInputCell = createInputCell(FILTER_TTIPS,
+        this.newInputCell = createInputCell(FILTER_CONDITION_TTIPS,
             15,
             FilterInfo.conditionValidatorNoAutoCorrect,
             this.props.onTableChanged, {width: '100%', boxSizing: 'border-box'});


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2562

The tooltip for the free-form `Filters:` input is wrong.  Without clear instruction in the ticket, I changed it to what I think is correct.  Feel free to request changes.

To test:   https://irsawebdev9.ipac.caltech.edu/IRSA-2562_filters_tooltips/irsaviewer/
- Any search that produce a table, i.e. Catalog search.
- Click on options (gears icon)
- mouse over `Filters:` input to see tooltips.