### PR TITLE
DM-13630: Fixed bug: flip fail when there is a fail image plot in the group

### DIFF
--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -462,6 +462,7 @@ function flipPv(pv, isY) {
     if (isY) pv.flipY= !pv.flipY;
     else     pv.flipX= !pv.flipX;
     const cc= CysConverter.make(primePlot(pv));
+    if (!cc) return pv;
     const {width,height}= pv.viewDim;
     const centerOfDev= makeDevicePt(width/2,height/2);
     const ipt= cc.getImageCoords(centerOfDev);


### PR DESCRIPTION
Fixed bug: flip fail when there is a fail image plot in the group

_to test:_

https://irsawebdev9.ipac.caltech.edu/dm-13630-dist-tool/firefly/

Make image plots with m34 on SEIP. Four images should come up and one should fail- then do a flip. It if works and there are not errors in the console the bug is fixed.