### PR TITLE
DM-18122 update Spatial/temporal search panels

### DIFF
--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -127,7 +127,8 @@ ColumnOrExpression.propTypes = {
     nullAllowed: PropTypes.bool
 };
 
-export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidth, tooltip='Table column', name, nullAllowed, canBeExpression=false}) {
+export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidth, tooltip='Table column',
+                           name, nullAllowed, canBeExpression=false, inputStyle}) {
     const value = initValue || getFieldVal(groupKey, fieldKey);
     const colValidator = getColValidator(cols, !nullAllowed, canBeExpression);
     const {valid=true, message=''} = value ? colValidator(value) : {};
@@ -158,6 +159,7 @@ export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidt
                 fieldKey={fieldKey}
                 groupKey={groupKey}
                 {...labelProps}
+                inputStyle={inputStyle}
             />
             <div style={{display: 'inline-block', cursor:'pointer', paddingLeft: 2, verticalAlign: 'top'}}
                  title={`Select ${name} column`}
@@ -178,6 +180,7 @@ ColumnFld.propTypes = {
     name: PropTypes.string.isRequired,
     tooltip: PropTypes.string,
     nullAllowed: PropTypes.bool,
-    canBeExpression: PropTypes.bool
+    canBeExpression: PropTypes.bool,
+    inputStyle: PropTypes.object
 };
 

--- a/src/firefly/js/ui/DateTimePickerField.jsx
+++ b/src/firefly/js/ui/DateTimePickerField.jsx
@@ -37,7 +37,10 @@ export function tryConvertToMoment(str_or_moment, force = false) {
  * @returns {*}
  */
 function aMoment(str, utc=true) {
-    return utc ? Moment.utc(str) : Moment(str);  // utc or local
+    const m = Moment.utc(str);
+    if (!m.isValid()) return m;
+
+    return utc ? Moment(m.format()) : Moment(m.format());  // utc or local
 }
 
 /**

--- a/src/firefly/js/ui/SuggestBoxInputField.jsx
+++ b/src/firefly/js/ui/SuggestBoxInputField.jsx
@@ -222,7 +222,7 @@ class SuggestBoxInputFieldView extends PureComponent {
     render() {
 
         const {displayValue, valid, message, highlightedIdx, isOpen, inputWidth, suggestions, mouseTrigger } = this.state;
-        var {label, labelWidth, tooltip, inline, renderSuggestion, wrapperStyle, popStyle, popupIndex} = this.props;
+        var {label, labelWidth, tooltip, inline, renderSuggestion, wrapperStyle, popStyle, popupIndex, inputStyle} = this.props;
 
         const leftOffset = (labelWidth?labelWidth:0)+4;
         const minWidth = (inputWidth?inputWidth-4:50);
@@ -241,6 +241,7 @@ class SuggestBoxInputFieldView extends PureComponent {
                         label={label}
                         labelWidth={labelWidth}
                         tooltip={tooltip}
+                        style={inputStyle}
                     />
                 </div>
 
@@ -272,7 +273,8 @@ SuggestBoxInputFieldView.propTypes = {
     getSuggestions : PropTypes.func,   //suggestionsArr = getSuggestions(displayValue)
     valueOnSuggestion : PropTypes.func, //newDisplayValue = valueOnSuggestion(prevValue, suggestion),
     renderSuggestion : PropTypes.func,   // ReactElem = renderSuggestion(suggestion)
-    popupIndex: PropTypes.number
+    popupIndex: PropTypes.number,
+    inputStyle: PropTypes.object
 };
 
 

--- a/src/firefly/js/ui/TimePanel.jsx
+++ b/src/firefly/js/ui/TimePanel.jsx
@@ -15,7 +15,7 @@ import {MJD, ISO} from './tap/TapUtil.js';
 import CALENDAR from 'html/images/datetime_picker_16x16.png';
 const invalidDate = 'invalid date/time';
 
-const iconMap = {'calendar': {icon: CALENDAR, title: 'show the calendar for selection'}};
+const iconMap = {'calendar': {icon: CALENDAR, title: 'Show the calendar for selecting date/time'}};
 
 
 
@@ -48,8 +48,8 @@ class TimePanelView extends PureComponent {
              </div>) : null;
 
         const spaceForImage = 16+ImagePadding*2;
-        const newInputStyle = Object.assign({paddingRight: iconField ? spaceForImage : 1}, inputStyle,
-                                            {width: iconField ? inputWidth - spaceForImage : inputWidth-1});
+        const newInputStyle = Object.assign({paddingRight: iconField ? spaceForImage : 2}, inputStyle,
+                                            {width: iconField ? inputWidth - spaceForImage+2 : inputWidth});
         const placeHolder = timeMode === ISO ? 'YYYY-MM-DD HH:mm:ss' : 'float number .... ';
         const newWrapperStyle = clone(wrapperStyle, (iconField ? {width: '%100'} : {}));
         const inputFields = {
@@ -82,7 +82,6 @@ class TimePanelView extends PureComponent {
 TimePanelView.propTypes = {
     fieldKey : PropTypes.string,
     groupKey : PropTypes.string,
-    label : PropTypes.string,
     showHelp   : PropTypes.bool,
     feedback: PropTypes.string,
     feedbackStyle: PropTypes.object,

--- a/src/firefly/js/ui/TimePanel.jsx
+++ b/src/firefly/js/ui/TimePanel.jsx
@@ -26,9 +26,9 @@ class TimePanelView extends PureComponent {
 
 
     render() {
-        const {showHelp, feedback, feedbackStyle, examples,
+        const {showHelp, feedback, feedbackStyle, examples, label, labelStyle, labelPosition,
             valid, message, onChange, value, icon, onClickIcon, tooltip = 'select time',
-            labelWidth, inputStyle, wrapperStyle, inputWidth, timeMode=ISO}= this.props;
+            inputStyle, wrapperStyle, inputWidth, timeMode=ISO}= this.props;
         const ImagePadding = 3;
 
         const iconStyle = {
@@ -54,7 +54,7 @@ class TimePanelView extends PureComponent {
         const newWrapperStyle = clone(wrapperStyle, (iconField ? {width: '%100'} : {}));
         const inputFields = {
             valid, visible: true, message, onChange,
-            value, tooltip, wrapperStyle: newWrapperStyle, style: newInputStyle, labelWidth,
+            value, tooltip, wrapperStyle: newWrapperStyle, style: newInputStyle,
             placeHolder
         };
 
@@ -68,15 +68,23 @@ class TimePanelView extends PureComponent {
                                     : (timeField);
 
         const newFeedbackStyle = clone(feedbackStyle, {width: inputWidth});
-        return (
+        const lStyle = clone(labelStyle, {whiteSpace:'nowrap'});
+        const labelDiv = (<div style={lStyle}>{label}</div>);
+        const timeDiv = (
             <div>
                 {timePart}
                 <TimeFeedback {...{showHelp, feedback, feedbackStyle: newFeedbackStyle, examples, timeMode}}/>
             </div>
         );
+        const flexDirection = (labelPosition && labelPosition === 'top') ? 'column' : 'row';
+
+        return (
+            <div style={{display: 'flex', flexDirection}}>
+                {labelDiv}
+                {timeDiv}
+            </div>
+        );
     }
-
-
 }
 
 TimePanelView.propTypes = {
@@ -90,14 +98,15 @@ TimePanelView.propTypes = {
     onChange: PropTypes.func,
     valid   : PropTypes.bool.isRequired,
     value : PropTypes.string.isRequired,
-    labelWidth : PropTypes.number,
+    labelStyle : PropTypes.object,
+    label: PropTypes.string,
     tooltip: PropTypes.string,
     inputStyle: PropTypes.object,
     wrapperStyle: PropTypes.object,
     timeMode: PropTypes.string,
     icon: PropTypes.string,
     onClickIcon: PropTypes.func,
-    labelPosition: PropTypes.string,
+    labelPosition: PropTypes.oneOf(['top', 'left']),
     inputWidth: PropTypes.number
 };
 

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -83,7 +83,7 @@ export class TapSearchPanel extends PureComponent {
 
         const rightBtns = selectBy === 'basic' ?[{text: 'Populate and edit ADQL', onClick: this.populateAndEditAdql, style: {marginLeft: 50}}] :  [];
 
-        const style = {resize: 'both', overflow: 'hidden', paddingBottom: 5, height: 600, width: 915, minHeight: 600, minWidth: MINWIDTH};
+        const style = {resize: 'both', overflow: 'hidden', paddingBottom: 5, height: 600, width: 915, minHeight: 650, minWidth: MINWIDTH};
 
         return (
             <div style={style}>
@@ -227,7 +227,7 @@ class BasicUI extends PureComponent {
 
         const tapSearchMinWidth = MINWIDTH - 20;  // less than the size of min-width of TAP Search panel
         const splitDef = Math.min(SpattialPanelWidth+80, tapSearchMinWidth);
-        const splitMax =   Math.min(SpattialPanelWidth+150, tapSearchMinWidth);
+        const splitMax = Math.min(SpattialPanelWidth+80, tapSearchMinWidth);
 
         if (error) {
             return (<div>{error}</div>);

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -13,7 +13,7 @@ import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {makeTblRequest, setNoCache} from '../../tables/TableRequestUtil.js';
 import {getColumnValues} from '../../tables/TableUtil.js';
 
-import {TableSearchMethods, tableSearchMethodsConstraints} from './TableSearchMethods.jsx';
+import {TableSearchMethods, tableSearchMethodsConstraints, SpattialPanelWidth} from './TableSearchMethods.jsx';
 import {AdvancedADQL} from './AdvancedADQL.jsx';
 import {loadTapColumns, loadTapTables, loadTapSchemas, getTapBrowserState, setTapBrowserState} from './TapUtil.js';
 import {NameSelect, NameSelectField, selectTheme} from './Select.jsx';
@@ -27,6 +27,8 @@ import {RadioGroupInputField} from '../RadioGroupInputField';
 import './TableSelectViewPanel.css';
 import {HelpIcon} from '../HelpIcon';
 import {showInfoPopup} from '../PopupUtil.jsx';
+
+const MINWIDTH = 915;
 
 /**
  * group key for fieldgroup comp
@@ -81,7 +83,7 @@ export class TapSearchPanel extends PureComponent {
 
         const rightBtns = selectBy === 'basic' ?[{text: 'Populate and edit ADQL', onClick: this.populateAndEditAdql, style: {marginLeft: 50}}] :  [];
 
-        const style = {resize: 'both', overflow: 'hidden', paddingBottom: 5, height: 600, width: 915, minHeight: 600, minWidth: 915};
+        const style = {resize: 'both', overflow: 'hidden', paddingBottom: 5, height: 600, width: 915, minHeight: 600, minWidth: MINWIDTH};
 
         return (
             <div style={style}>
@@ -160,7 +162,7 @@ export class TapSearchPanel extends PureComponent {
                 [
                     {fieldKey: 'defAdqlKey', value: adql},
                     {fieldKey: 'adqlQuery', value: adql},
-                    {fieldKey: 'selectBy', value: 'adql'},
+                    {fieldKey: 'selectBy', value: 'adql'}
                 ]
             );
         }
@@ -223,6 +225,10 @@ class BasicUI extends PureComponent {
         const {serviceUrl} = this.props;
         const {error, schemaOptions, tableOptions, schemaName, tableName, columnsModel}= this.state;
 
+        const tapSearchMinWidth = MINWIDTH - 20;  // less than the size of min-width of TAP Search panel
+        const splitDef = Math.min(SpattialPanelWidth+80, tapSearchMinWidth);
+        const splitMax =   Math.min(SpattialPanelWidth+150, tapSearchMinWidth);
+
         if (error) {
             return (<div>{error}</div>);
         }
@@ -267,7 +273,7 @@ class BasicUI extends PureComponent {
                         />
                     </div>
                     <div className='expandable'>
-                        <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={540}>
+                        <SplitPane split='vertical' maxSize={splitMax} mixSize={20} defaultSize={splitDef}>
                             <SplitContent>
                                 {columnsModel ?  <TableSearchMethods columnsModel={columnsModel}/>
                                     : <div className='loading-mask'/>


### PR DESCRIPTION
This PR includes development for https://jira.lsstcorp.org/browse/DM-18122 
- add checkbox to the disclosure bar on the spatial/temporal search panels
- fix the size of the search panel while moving the resizer in the 'Select Constraints' area. 
- remove all-sky from spatial search method 
- validate the field entries depending on the entered value and the checkbox status of the search panel (empty value is allowed in case the search panel is not checked)
 - add feedback regarding field validation on the disclosure bar when the search panel is checked.
- merge the change regarding column fields in spatial/temporal search panel from dev. 

test: 
start  https://irsawebdev9.ipac.caltech.edu/dm-18122/firefly/firefly-dev.html
for styling,
    - check the size and layout of each panel in 4.Select Constraints area. Check how the size of each panel changes by sliding the resizer and resizing the entire TAP search panel 

for spatial search or temporal search, 
      -  enable spatial search or temporal search by checking the checkbox in the search panel
      - invalid red mark is seen by the field  which has invalid value or empty value (only when the search panel is checked for the search). 
     - an error message pop-up is shown in case there is some invalid entry in the enabled search 
panel while 'search' or 'populate and edit ADQL' is clicked. 
     - test example for spatial search,
         TAP service: IRSA, schema: wise_allwise, table: allwise_p3as_psd
         check Spatial search panel (and uncheck temporal search panel)
         target-> m31 , radius -> 200, and search or populate ADQL again
    - test case for temporal search,
        TAP service: CADC, schema: caom, table: caom2.plane
        check Temporal search panel (and uncheck spatial search panel)
        Temporal column: 'time_bounds_lower'
        time mode MJD mode
        enter '47600' and '47690' for 'from' and 'to' time. 
       
