### PR TITLE
DM-18330: Make DropDownContainer support optional layout. 

### DIFF
--- a/src/firefly/js/ui/DropDownContainer.css
+++ b/src/firefly/js/ui/DropDownContainer.css
@@ -12,6 +12,7 @@
 }
 
 .DD-ToolBar__content {
+    display: flex;
     box-shadow:0 0 1px #000000;
     background-color: #E5E5E5;
     margin: 5px 3px;

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -24,7 +24,7 @@ import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 import './DropDownContainer.css';
 
-const flexGrowWithMax = {width: '100%', maxWidth: 1600};
+const flexGrowWithMax = {width: '100%', maxWidth: 900};
 
 export const dropDownMap = {
     Search: {view: <SearchPanel />},

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -5,7 +5,7 @@
 import React, {Component, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
-import {get, pick} from 'lodash';
+import {get, pick, isEmpty} from 'lodash';
 
 import {getDropDownInfo} from '../core/LayoutCntlr.js';
 import {flux, getVersion} from '../Firefly.js';
@@ -24,19 +24,21 @@ import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 import './DropDownContainer.css';
 
+const flexGrowWithMax = {width: '100%', maxWidth: 1600};
+
 export const dropDownMap = {
-    Search: <SearchPanel />,
-    TestSearch: <TestSearchPanel />,
-    TestSearches: <TestQueriesPanel />,
-    TestTAPSearch: <TapSearchPanel />,
-    ImageSearchPanelV2: <ImageSearchDropDown/>,
-    ImageSelectDropDownCmd: <ImageSearchDropDown/>,
-    ImageSelectDropDownSlateCmd: <ImageSearchDropDown gridSupport={true}/>,
-    ChartSelectDropDownCmd: <ChartSelectDropdown />,
-    IrsaCatalogDropDown: <CatalogSelectViewPanel/>,
-    LsstCatalogDropDown: <LSSTCatalogSelectViewPanel/>,
-    FileUploadDropDownCmd: <FileUploadDropdown />,
-    WorkspaceDropDownCmd: <WorkspaceDropdown />
+    Search: {view: <SearchPanel />},
+    TestSearch: {view: <TestSearchPanel />},
+    TestSearches: {view: <TestQueriesPanel />},
+    TestTAPSearch: {view: <TapSearchPanel />, layout: {width: '100%'}},
+    ImageSearchPanelV2: {view: <ImageSearchDropDown />, layout: flexGrowWithMax},
+    ImageSelectDropDownCmd: {view: <ImageSearchDropDown />, layout: flexGrowWithMax},
+    ImageSelectDropDownSlateCmd: {view: <ImageSearchDropDown gridSupport={true} />, layout: flexGrowWithMax},
+    ChartSelectDropDownCmd: {view: <ChartSelectDropdown />},
+    IrsaCatalogDropDown: {view: <CatalogSelectViewPanel />},
+    LsstCatalogDropDown: {view: <LSSTCatalogSelectViewPanel />},
+    FileUploadDropDownCmd: {view: <FileUploadDropdown />},
+    WorkspaceDropDownCmd: {view: <WorkspaceDropdown />},
 };
 
 
@@ -54,14 +56,14 @@ export class DropDownContainer extends Component {
         super(props);
 
         React.Children.forEach(this.props.children, (el) => {
-            const key = get(el, 'props.name');
-            if (key) dropDownMap[key] = el;
+            const {name:key, layout} = get(el, 'props', {});
+            if (key) dropDownMap[key] = {view: el, layout};
         });
 
         if (props.dropdownPanels) {
             props.dropdownPanels.forEach( (el) => {
-                const key = get(el, 'props.name');
-                if (key) dropDownMap[key] = el;
+                const {name:key, layout} = get(el, 'props', {});
+                if (key) dropDownMap[key] = {view: el, layout};
             } );
         }
 
@@ -98,16 +100,19 @@ export class DropDownContainer extends Component {
     render() {
         const {footer, alerts} = this.props;
         const { visible, selected }= this.state;
-        const view = dropDownMap[selected];
-        const {BuildMajor, BuildMinor, BuildRev, Build, BuildType, BuildDate, BuildCommit, BuildCommitFirefly} = getVersion() || {};
+        const {view, layout={}} = dropDownMap[selected] || {};
 
         if (!visible) return <div/>;
+
+        const contentWrapStyle = isEmpty(layout) ? {} : {display: 'flex', width: '100%', justifyContent: 'center'};
+        const contentStyle = {flexGrow: 1, ...layout};
+
         return (
             <div>
                 <div className='DD-ToolBar'>
                     {alerts || <Alerts />}
-                    <div style={{flexGrow: 1}}>
-                        <div className='DD-ToolBar__content'>
+                    <div style={{flexGrow: 1, ...contentWrapStyle}}>
+                        <div style={contentStyle} className='DD-ToolBar__content'>
                             {view}
                         </div>
                     </div>

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -130,10 +130,9 @@ export class Tabs extends PureComponent {
         }
 
         const contentClsName = borderless ? 'TabPanel__Content borderless' : 'TabPanel__Content';
-        const fullHeight = useFlex ? {flexGrow: 1} : {height: '100%'};
 
         return (
-            <div style={{display: 'flex', flexDirection: 'column', overflow: 'hidden', ...fullHeight}}>
+            <div style={{display: 'flex', height: '100%', flexDirection: 'column', flexGrow: 1, overflow: 'hidden'}}>
                 <TabsHeader {...{resizable, headerStyle}}>{newChildren}</TabsHeader>
                 <div ref='contentRef' style={contentStyle} className={contentClsName}>
                     {(content) ? content : ''}

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -130,9 +130,10 @@ export class Tabs extends PureComponent {
         }
 
         const contentClsName = borderless ? 'TabPanel__Content borderless' : 'TabPanel__Content';
+        const fullHeight = useFlex ? {flexGrow: 1} : {height: '100%'};
 
         return (
-            <div style={{display: 'flex', height: '100%', flexDirection: 'column', flexGrow: 1, overflow: 'hidden'}}>
+            <div style={{display: 'flex', flexDirection: 'column', overflow: 'hidden', ...fullHeight}}>
                 <TabsHeader {...{resizable, headerStyle}}>{newChildren}</TabsHeader>
                 <div ref='contentRef' style={contentStyle} className={contentClsName}>
                     {(content) ? content : ''}

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -102,7 +102,7 @@ export class TapSearchPanel extends PureComponent {
 
                         <div className='TapSearch__section'>
                             <div className='TapSearch__section--title'>1. TAP Service <HelpIcon helpId={tapHelpId('tapService')}/> </div>
-                            <div style={{flexGrow: 1, marginRight: 3}}>
+                            <div style={{flexGrow: 1, marginRight: 3, maxWidth: 1000}}>
                                 <CreatableSelect
                                     options={TAP_SERVICE_OPTIONS}
                                     isClearable={true}
@@ -233,7 +233,7 @@ class BasicUI extends PureComponent {
             <Fragment>
                 <div className='TapSearch__section'>
                     <div className='TapSearch__section--title'>3. Select Table <HelpIcon helpId={tapHelpId('selectTable')}/> </div>
-                    <div style={{display: 'inline-flex', width: '100%', marginRight: 3}}>
+                    <div style={{display: 'inline-flex', width: '100%', marginRight: 3, maxWidth: 1000}}>
                         <div style={{flexGrow: 1}}>
                             <NameSelect type='Schema'
                                         options={schemaOptions}

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -81,7 +81,7 @@ export class TapSearchPanel extends PureComponent {
 
         const rightBtns = selectBy === 'basic' ?[{text: 'Populate and edit ADQL', onClick: this.populateAndEditAdql, style: {marginLeft: 50}}] :  [];
 
-        const style = {resize: 'both', overflow: 'hidden', paddingBottom: 5, height: 600, width: 915, minHeight: 600, minWidth: 915};
+        const style = {width: '100%'};
 
         return (
             <div style={style}>

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -109,11 +109,12 @@ function getContexInfo(renderTreeId) {
 
 function ImageSearchPanel({resizable=true, onSubmit, gridSupport = false, multiSelect, submitText, onCancel=dispatchHideDropDown}) {
     const archiveName =  get(getAppOptions(), 'ImageSearch.archiveName');
-    const resize = resizable ? {resize: 'both', overflow: 'hidden', paddingBottom: 5} : {};
+    const resize = {resize: 'both', overflow: 'hidden', paddingBottom: 5};
     const dim = {height: 600, width: 725, minHeight: 600, minWidth: 725};
+    const style = resizable ? {...dim, ...resize} : {width: '100%'};
 
     return (
-        <div style={{...resize, ...dim}}>
+        <div style={style}>
             <FormPanel  inputStyle = {{display: 'flex', flexDirection: 'column', backgroundColor: 'transparent', padding: 'none', border: 'none'}}
                         submitBarStyle = {{flexShrink: 0, padding: '0 4px 3px'}}
                         groupKey = {Object.values(FG_KEYS)} includeUnmounted={true}
@@ -130,7 +131,7 @@ function ImageSearchPanel({resizable=true, onSubmit, gridSupport = false, multiS
     );
 }
 
-export function ImageSearchDropDown({gridSupport, resizable=true}) {
+export function ImageSearchDropDown({gridSupport, resizable=false}) {
     const {renderTreeId} = useContext(RenderTreeIdCtx);
     const {plotId, viewerId, multiSelect} = getContexInfo(renderTreeId);
     const onSubmit = (request) => onSearchSubmit({request, plotId, viewerId, gridSupport, renderTreeId});
@@ -277,7 +278,7 @@ function ThreeColor({imageMasterData, multiSelect, archiveName}) {
         <div className='flex-full' style={{marginTop: 5}}>
             <Tabs componentKey='ImageSearchPanelV2' resizable={false} useFlex={true} borderless={true}
                   contentStyle={{backgroundColor: 'rgb(202, 202, 202)', paddingBottom: 2}}
-                  headerStyle={{display:'inline-flex', justifyContent:'center'}}>
+                  headerStyle={{display:'inline-flex', marginLeft: 185}}>
                 <Tab key='ImageSearchRed' name='red' label={<div style={{width:40, color:'red'}}>Red</div>}>
                     <SingleChannel {...{groupKey: FG_KEYS.red, imageMasterData, multiSelect, archiveName}}/>
                 </Tab>
@@ -365,7 +366,7 @@ function ImageSource({groupKey, imageMasterData, multiSelect, archiveName='Archi
 
 function SelectArchive({groupKey,  imageMasterData, multiSelect}) {
     const title = '4. Select Data Set';
-    const targetStyle = {height: 40};
+    const targetStyle = {height: 40, width: 450};
     const sizeStyle = {margin: '-5px 0 0 36px'};
     const isHips = isHipsImgType();
     const sizeLabel = isHips ? 'Field of view (optional):' : 'Cutout size (leave blank for full size):';


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-18330
test: https://irsawebdev9.ipac.caltech.edu/dm-18330/firefly/firefly-dev.html

Depending on its layout, a dropdown panel may behave differently to window resizing.
In this PR:
- TAP Searches will be fully expanded when window resizes.
- Image Search will be fully expanded up to 1600px.  This is about the width of a `default` retina display.
- Others remain fixed width.
