### PR TITLE
IRSA-2420: Make HiPS table "Properties" column show links

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterList.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterList.java
@@ -15,15 +15,13 @@ import edu.caltech.ipac.firefly.server.query.ParamDoc;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.EmbeddedDbProcessor;
-import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
-import edu.caltech.ipac.firefly.data.FileInfo;
-import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.visualize.hips.HiPSMasterListEntry.PARAMS;
-import nom.tam.fits.Data;
+import edu.caltech.ipac.table.LinkInfo;
 
-import java.io.File;
 import java.util.*;
 import java.io.IOException;
+
+import static edu.caltech.ipac.visualize.VisConstants.INFO_ICON_STUB;
 
 /**
  * @author Cindy Wang
@@ -181,6 +179,13 @@ public class HiPSMasterList extends EmbeddedDbProcessor {
                 colDT.setVisibility(DataType.Visibility.hidden);
             }
         }
+
+        // turn Properties column into a link.
+        DataType col = dg.getDataDefintion("Properties");
+        col.setWidth(4);
+        col.setFilterable(false);
+        col.setSortable(false);
+        col.setLinkInfos(Collections.singletonList(new LinkInfo(null, INFO_ICON_STUB, null, "link to HiPS properties", null, null, null)));
     }
 
     private static DataGroup createTableDataFromListEntry(List<HiPSMasterListEntry> hipsMaps) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterListEntry.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterListEntry.java
@@ -71,9 +71,9 @@ public class HiPSMasterListEntry {
     private static List<DataType> cols = new ArrayList<>();
 
     // columns included in the HiPS list table, some column may be hidden, URL, SOURCE
-    private static PARAMS[] orderCols = new PARAMS[]{PARAMS.TYPE, PARAMS.TITLE, PARAMS.WAVELENGTH,
+    private static PARAMS[] orderCols = new PARAMS[]{PARAMS.TYPE,  PARAMS.PROPERTIES, PARAMS.TITLE, PARAMS.WAVELENGTH,
                                             PARAMS.RELEASEDATE, PARAMS.FRAME, PARAMS.ORDER, PARAMS.PIXELSCALE,
-                                            PARAMS.FRACTION,  PARAMS.PROPERTIES, PARAMS.URL,
+                                            PARAMS.FRACTION, PARAMS.URL,
                                             PARAMS.SOURCE, PARAMS.IVOID};
     static {
         for (PARAMS param : orderCols) {

--- a/src/firefly/java/edu/caltech/ipac/table/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataType.java
@@ -24,6 +24,7 @@ public class DataType implements Serializable, Cloneable {
 
     private static final String DOUBLE = "double";
     private static final String REAL = "real";
+    public static final String LOCATION = "location";
 
     private static final String FLOAT = "float";
     private static final String INTEGER = "int";
@@ -39,6 +40,7 @@ public class DataType implements Serializable, Cloneable {
     private static final String S_CHAR = "c";
     private static final String S_BOOL = "b";
     public static final String LONG_STRING = "long_string";
+
     private static final List<String> FLOATING_TYPES = Arrays.asList(DOUBLE, REAL, FLOAT, S_DOUBLE, S_REAL, S_FLOAT);
     private static final List<String> INT_TYPES = Arrays.asList(INTEGER, LONG, S_INTEGER, S_LONG);
     public static final List<String> NUMERIC_TYPES = Stream.concat(FLOATING_TYPES.stream(), INT_TYPES.stream()).collect(Collectors.toList());
@@ -492,6 +494,8 @@ public class DataType implements Serializable, Cloneable {
             case BOOL:
             case S_BOOL:
                 return Boolean.class;
+            case LOCATION:
+                return String.class;
             default:
                 return String.class;
         }

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -377,8 +377,10 @@ public class JsonTableUtil {
             applyIfNotEmpty(link.getID(),       v -> json.put("ID", v));
             applyIfNotEmpty(link.getHref(),     v -> json.put("href", v));
             applyIfNotEmpty(link.getTitle(),    v -> json.put("title", v));
+            applyIfNotEmpty(link.getValue(),    v -> json.put("value", v));
             applyIfNotEmpty(link.getRole(),     v -> json.put("role", v));
             applyIfNotEmpty(link.getType(),     v -> json.put("type", v));
+            applyIfNotEmpty(link.getAction(),   v -> json.put("action", v));
             return json;
         }).collect(Collectors.toList());
     }

--- a/src/firefly/java/edu/caltech/ipac/table/LinkInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/table/LinkInfo.java
@@ -8,13 +8,25 @@ import edu.caltech.ipac.util.StringUtils;
  * Created by cwang on 9/28/18.
  */
 public class LinkInfo  implements Serializable, Cloneable {
+    private String ID;            // LINK ID
+    private String value;
     private String href;     // LINK href
     private String title;    // LINK title
     private String contentRole;   // LINK content-role
     private String contentType;   // LINK content-type
-    private String ID;            // LINK ID
+    private String action;
 
     public LinkInfo() {}
+
+    public LinkInfo(String ID, String value, String href, String title, String contentRole, String contentType, String action) {
+        this.ID = ID;
+        this.value = value;
+        this.href = href;
+        this.title = title;
+        this.contentRole = contentRole;
+        this.contentType = contentType;
+        this.action = action;
+    }
 
     public void setHref(String href) { this.href = href; }
     public String getHref() {
@@ -38,14 +50,18 @@ public class LinkInfo  implements Serializable, Cloneable {
         return contentType;
     }
 
-
-
     public void setID(String id) {
         this.ID = id;
     }
     public String getID() {
         return ID;
     }
+
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+
+    public String getAction() { return action; }
+    public void setAction(String action) { this.action = action;}
 
     public Object clone() throws CloneNotSupportedException {
         return super.clone();

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -203,6 +203,8 @@ public class VoTableReader {
         applyIfNotEmpty(el.getAttribute("content-type"), li::setType);
         applyIfNotEmpty(el.getAttribute("title"), li::setTitle);
         applyIfNotEmpty(el.getAttribute("href"), li::setHref);
+        applyIfNotEmpty(el.getAttribute("value"), li::setValue);
+        applyIfNotEmpty(el.getAttribute("action"), li::setAction);
         return li;
     }
 
@@ -701,6 +703,18 @@ public class VoTableReader {
             String desc = cinfo.getDescription();
             if (desc != null) {
                 dt.setDesc(desc.replace("\n", " "));
+            }
+
+            // attribute type  .. this is not yet standard, mentioned in appendix
+            // used for generating links and link substitutions
+            DescribedValue type = cinfo.getAuxDatumByName("Type");
+            if (type != null) {
+                String val = String.valueOf(type.getValue());
+                if (val.equals(DataType.LOCATION)) {
+                    dt.setTypeDesc(val);
+                } else if (val.equals("hidden")) {
+                    dt.setVisibility(DataType.Visibility.hidden);
+                }
             }
 
             // child elements <LINK> and <VALUES>

--- a/src/firefly/java/edu/caltech/ipac/visualize/VisConstants.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/VisConstants.java
@@ -19,6 +19,9 @@ public class VisConstants {
     public final static double    ARCSEC_TO_DEG = .00027777778;
     public final static double    DEG_TO_ARCMIN = 60.0;
     public final static double    DEG_TO_ARCSEC = 3600.0;
+
+    // a template to be converted into an <img> tag with src keyed by 'info'
+    public final static String INFO_ICON_STUB = "<img data-src='info'/>";
 }
 
 

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -322,6 +322,23 @@ export function getColumn(tableModel, colName) {
     }
 }
 
+/**
+ * returns column information for the given ID.
+ * @param {TableModel} tableModel
+ * @param {string} ID
+ * @returns {TableColumn}
+ * @public
+ * @func getColumn
+ * @memberof firefly.util.table
+ */
+export function getColumnByID(tableModel, ID) {
+    const colIdx = getColumns(tableModel).findIndex((col) => col.ID === ID);
+    if (colIdx >= 0) {
+        return get(tableModel, `tableData.columns.${colIdx}`);
+    }
+}
+
+
 export function getFilterCount(tableModel) {
     const filterInfo = get(tableModel, 'request.filters');
     const filterCount = filterInfo ? filterInfo.split(';').length : 0;

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -105,9 +105,11 @@
  * @typedef {object} LINK
  * @prop {string} ID     ID used to reference this LINK.
  * @prop {string} href   href of this LINK.
+ * @prop {string} value  text of this LINK.
  * @prop {string} title  title/label of this LINK.
  * @prop {string} role   role,  see VOTable content-role
  * @prop {string} type   type, see VOTable content-type
+ * @prop {string} action see VOTable LINK action
  *
  * @global
  * @public

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -15,6 +15,7 @@ import {SortInfo} from '../SortInfo.js';
 import {TextCell, HeaderCell, SelectableHeader, SelectableCell} from './TableRenderer.js';
 
 import './TablePanel.css';
+import {LinkCell} from './TableRenderer';
 
 const {Table, Column} = FixedDataTable;
 const noDataMsg = 'No Data Found';
@@ -251,7 +252,7 @@ function makeColumns ({columns, columnWidths, data, selectable, showUnits, showT
     var colsEl = columns.map((col, idx) => {
         if (col.visibility && col.visibility !== 'show') return false;
         const HeadRenderer = get(renderers, [col.name, 'headRenderer'], HeaderCell);
-        const CellRenderer = get(renderers, [col.name, 'cellRenderer'], TextCell);
+        const CellRenderer = get(renderers, [col.name, 'cellRenderer'], getDefaultRenderer(col, tbl_id));
         const fixed = col.fixed || false;
         const style = col.fixed && {backgroundColor: bgColor};
 
@@ -260,7 +261,7 @@ function makeColumns ({columns, columnWidths, data, selectable, showUnits, showT
                 key={col.name}
                 columnKey={idx}
                 header={<HeadRenderer {...{col, showUnits, showTypes, showFilters, filterInfo, sortInfo, onSort, onFilter, tbl_id}} />}
-                cell={<CellRenderer style={style} data={data} colIdx={idx} />}
+                cell={<CellRenderer {...{style, data, tbl_id, colIdx:idx}} />}
                 fixed={fixed}
                 width={columnWidths[idx]}
                 isResizable={true}
@@ -284,4 +285,10 @@ function makeColumns ({columns, columnWidths, data, selectable, showUnits, showT
     return colsEl.filter((c) => c);
 }
 
+function getDefaultRenderer(col={}, tbl_id) {
+    if (col.type === 'location' || !isEmpty(col.links)) {
+        return ((props) => <LinkCell {...props} {...{tbl_id, col}}/>);
+    }
 
+    return TextCell;
+}

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -50,11 +50,11 @@ export class TablesContainer extends PureComponent {
     }
 
     render() {
-        const {closeable, tbl_group, expandedMode, tables, tableOptions, layout, active} = this.state;
+        const {closeable, tbl_group, expandedMode, tables, tableOptions, layout, active, style} = this.state;
         if (expandedMode) {
             return <ExpandedView {...{active, tables, tableOptions, layout, expandedMode, closeable, tbl_group}} />;
         } else {
-            return isEmpty(tables) ? <div></div> : <StandardView {...{active, tables, tableOptions, expandedMode, tbl_group}} />;
+            return isEmpty(tables) ? <div></div> : <StandardView {...{active, tables, tableOptions, expandedMode, tbl_group, style}} />;
         }
     }
 }
@@ -63,6 +63,7 @@ TablesContainer.propTypes = {
     expandedMode: PropTypes.bool,
     closeable: PropTypes.bool,
     tbl_group: PropTypes.string,
+    style: PropTypes.object,
     mode: PropTypes.oneOf(['expanded', 'standard', 'both'])
 };
 TablesContainer.defaultProps = {
@@ -94,7 +95,7 @@ function ExpandedView(props) {
 
 
 function StandardView(props) {
-    const {tables, tableOptions, expandedMode, active, tbl_group} = props;
+    const {tables, tableOptions, expandedMode, active, tbl_group, style={}} = props;
 
     var activeIdx = Object.keys(tables).findIndex( (tbl_ui_id) => get(tables,[tbl_ui_id,'tbl_id']) === active);
     activeIdx = activeIdx === -1 ? 0 : activeIdx;
@@ -107,7 +108,7 @@ function StandardView(props) {
         return <SingleTable table={get(tables, [keys[0]])} expandedMode={expandedMode} tableOptions={tableOptions}/>;
     } else {
         return (
-            <Tabs defaultSelected={activeIdx} onTabSelect={onTabSelect} resizable={true}>
+            <Tabs style={{height: '100%', ...style}} defaultSelected={activeIdx} onTabSelect={onTabSelect} resizable={true}>
                 {tablesAsTab(tables, tableOptions, expandedMode)}
             </Tabs>
         );

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -24,7 +24,7 @@ import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 import './DropDownContainer.css';
 
-const flexGrowWithMax = {width: '100%', maxWidth: 900};
+const flexGrowWithMax = {width: '100%', maxWidth: 1200};
 
 export const dropDownMap = {
     Search: {view: <SearchPanel />},

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -27,7 +27,7 @@ export class SearchPanel extends SimpleComponent {
             return (
                 <div>
                     {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
-                    <SearchForm searchItem={searchItem} />
+                    <SearchForm style={{height: 'auto'}} searchItem={searchItem} />
                 </div>
             );
         }
@@ -82,11 +82,11 @@ function searchesAsTabs(allSearchItems) {
 
 
 
-function SearchForm({searchItem}) {
-    const {name, form, } = searchItem;
+function SearchForm({searchItem, style}) {
+    const {name, form} = searchItem;
     const {render:Render, ...rest} = form;
     return (
-        <FormPanel groupKey={name} {...rest}>
+        <FormPanel groupKey={name} style={style} {...rest}>
             <Render {...{searchItem}} />
         </FormPanel>
     );

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -109,7 +109,7 @@ export class Tabs extends PureComponent {
 
     render () {
         const { selectedIdx}= this.state;
-        const {children, useFlex, resizable, borderless, headerStyle, contentStyle={}} = this.props;
+        const {children, useFlex, resizable, borderless, style={}, headerStyle, contentStyle={}} = this.props;
 
         let  content;
         const newChildren = React.Children.toArray(children).filter((el) => !!el).map((child, index) => {
@@ -132,7 +132,7 @@ export class Tabs extends PureComponent {
         const contentClsName = borderless ? 'TabPanel__Content borderless' : 'TabPanel__Content';
 
         return (
-            <div style={{display: 'flex', height: '100%', flexDirection: 'column', flexGrow: 1, overflow: 'hidden'}}>
+            <div style={{display: 'flex', flexDirection: 'column', overflow: 'hidden', ...style}}>
                 <TabsHeader {...{resizable, headerStyle}}>{newChildren}</TabsHeader>
                 <div ref='contentRef' style={contentStyle} className={contentClsName}>
                     {(content) ? content : ''}
@@ -150,6 +150,7 @@ Tabs.propTypes= {
     onTabSelect: PropTypes.func,
     useFlex: PropTypes.bool,
     resizable: PropTypes.bool,
+    style: PropTypes.object,
     headerStyle: PropTypes.object,
     contentStyle: PropTypes.object,
     borderless: PropTypes.bool

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -4,7 +4,7 @@
 
 import {get, has, isArray, isEmpty, isObject, isString} from 'lodash';
 import Enum from 'enum';
-import {getColumn, getColumnIdx, getColumnValues, getColumns, getTblById} from '../tables/TableUtil.js';
+import {getColumn, getColumnIdx, getColumnValues, getColumns, getTblById, getCellValue, getColumnByID} from '../tables/TableUtil.js';
 import {getCornersColumns} from '../tables/TableInfoUtil.js';
 import {MetaConst} from '../data/MetaConst.js';
 import {CoordinateSys} from '../visualize/CoordSys.js';
@@ -750,4 +750,30 @@ export const findTargetName = (columns) => columns.find( (c) => DEFAULT_TNAME_OP
  * @prop {CoordinateSys} csys - the coordinate system to use
  */
 
+
+/**
+ * @see {@link http://www.ivoa.net/documents/VOTable/20130920/REC-VOTable-1.3-20130920.html#ToC54}
+ * A.1 link substitution
+ * @param tableModel    table model with data and columns info
+ * @param href          the href value of the LINK
+ * @param rowIdx        row index to be resolved
+ * @param defval        the field's value, or cell data.  Append field's value to href, if no substitution is needed.
+ * @returns {string}    the resolved href after subsitution
+ */
+export function resolveHRefVal(tableModel, href='', rowIdx, defval='') {
+    const vars = href.match(/\${[\w -.]+}/g);
+    if (vars) {
+        let rhref = href;
+        vars.forEach((v) => {
+            const [,cname] = v.match(/\${([\w -.]+)}/) || [];
+            const col = getColumnByID(tableModel, cname) || getColumn(tableModel, cname);
+            const rval = getCellValue(tableModel, rowIdx, col.name);
+            rhref = rhref.replace(v, rval);
+        });
+        return rhref;
+    } else {
+        return href + defval;
+    }
+
+}
 

--- a/src/firefly/js/util/__tests__/VOAnalyzer-test.js
+++ b/src/firefly/js/util/__tests__/VOAnalyzer-test.js
@@ -1,10 +1,11 @@
 // import initTest from '../InitTest.js';
 
 import {reject} from 'lodash';
-import {findTableCenterColumns, isCatalog, hasCoverageData, isMetaDataTable} from '../VOAnalyzer';
+import {findTableCenterColumns, isCatalog, hasCoverageData, isMetaDataTable, resolveHRefVal} from '../VOAnalyzer';
+import {SelectInfo} from '../../tables/SelectInfo';
 
 
-describe('Center columns tests, isCatalog test', () => {
+describe('VOAnalyzer:', () => {
 
     /**
      * guessing column name; ra/dec or lon/lat
@@ -279,7 +280,7 @@ describe('Center columns tests, isCatalog test', () => {
     /**
      * check the isCatalog works as expected
      */
-    test('test isCatalog', () => {
+    test('isCatalog', () => {
         const table = {
             tableData: {
                 columns: [
@@ -388,7 +389,7 @@ describe('Center columns tests, isCatalog test', () => {
     /**
      * check the hasCoverageData works as expected
      */
-    test('test hasCoverageData', () => {
+    test('hasCoverageData', () => {
         const table = {
             totalRows: 2,
             tableData: {
@@ -501,7 +502,7 @@ describe('Center columns tests, isCatalog test', () => {
     /**
      * check the isMetaDataTable works as expected
      */
-    test('test isMetaDataTable', () => {
+    test('isMetaDataTable', () => {
         const table = {
             totalRows: 2,
             tableData: {
@@ -532,6 +533,32 @@ describe('Center columns tests, isCatalog test', () => {
         table.tableMeta= {ImageSourceId:'wise'};
         result= isMetaDataTable(table);
         expect(result).toBeTruthy();
+
+    });
+
+    /**
+     * guessing column name; ra/dec or lon/lat
+     */
+    test('resolveHRefVal', () => {
+
+        const tableModel = {
+                tableData: {
+                    columns: [ {name: 'a'}, {name: 'b'}, {name: 'c'}],
+                    data: [
+                        ['a-1', 'b-1', 'b-1'],
+                        ['a-2', 'b-2', 'c-2'],
+                        ['a-3', 'b-3', 'c-3'],
+                    ],
+                }
+            };
+
+        // no substitution, simply append value to end of href
+        let result = resolveHRefVal(tableModel, 'https://acme.org/abc?p=', 1, 'b-2');
+        expect(result).toBe('https://acme.org/abc?p=b-2');
+
+        // substituting values from column a and c into the href
+        result = resolveHRefVal(tableModel, 'https://acme.org/abc?x=${a}&y=${c}', 1, 'b-2');
+        expect(result).toBe('https://acme.org/abc?x=a-2&y=c-2');
 
     });
 

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -277,6 +277,7 @@ function ThreeColor({imageMasterData, multiSelect, archiveName}) {
     return (
         <div className='flex-full' style={{marginTop: 5}}>
             <Tabs componentKey='ImageSearchPanelV2' resizable={false} useFlex={true} borderless={true}
+                  style={{flexGrow: 1}}
                   contentStyle={{backgroundColor: 'rgb(202, 202, 202)', paddingBottom: 2}}
                   headerStyle={{display:'inline-flex', marginLeft: 185}}>
                 <Tab key='ImageSearchRed' name='red' label={<div style={{width:40, color:'red'}}>Red</div>}>

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -38,7 +38,7 @@ import {isCatalog, isMetaDataTable} from '../../util/VOAnalyzer.js';
  */
 export function TriViewImageSection({showCoverage=false, showFits=false, selectedTab='fits',
                                      showMeta=false, imageExpandedMode=false, closeable=true,
-                                     metaDataTableId}) {
+                                     metaDataTableId, style={}}) {
 
     if (imageExpandedMode) {
         return  ( <ImageExpandedMode
@@ -55,7 +55,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
 
     if (showCoverage || showFits || showMeta) {
         return (
-            <Tabs onTabSelect={onTabSelect} defaultSelected={selectedTab} useFlex={true} resizable={true}>
+            <Tabs style={{height: '100%', ...style}} onTabSelect={onTabSelect} defaultSelected={selectedTab} useFlex={true} resizable={true}>
                 { showFits &&
                     <Tab name='Images' removable={false} id='fits'>
                         <MultiImageViewer viewerId= {DEFAULT_FITS_VIEWER_ID}
@@ -98,7 +98,8 @@ TriViewImageSection.propTypes= {
     imageExpandedMode : PropTypes.bool,
     closeable: PropTypes.bool,
     metaDataTableId: PropTypes.string,
-    selectedTab: PropTypes.oneOf(['fits', 'meta', 'coverage'])
+    selectedTab: PropTypes.oneOf(['fits', 'meta', 'coverage']),
+    style: PropTypes.object
 };
 
 export function launchTableTypeWatchers() {


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2420

http://www.ivoa.net/documents/VOTable/20130920/REC-VOTable-1.3-20130920.html#ToC54
- implements VOTable LINK substitution A.1
- implements VOTable FIELDs as Data Pointers A.4
- increase ImageSearch panel's max-width to 1200 from 900
- move `Properties` column between `Type` and `Title`
- added test for link substitution function

To test:
- https://irsawebdev9.ipac.caltech.edu/irsa-2420/firefly/
- from Image Search, select `View HiPS Images`
- the 2nd column `Pr...` is the new Properties column, with an `info` icon instead of long url string
- position of the column is moved to between `Type` and `Title` as requested in ticket.

There's also a test file attached to the ticket to demonstrate other usage of LINKs.
As usual, ran `gradle :firefly:jsTest` to test the new test added

Added a commit to fix layout issues raised due to changes to TabPanel.
Linked with https://github.com/IPAC-SW/irsa-ife/pull/57