### PR TITLE
DM-18409: Loading mask z-index is breaking natural stacking order of the components

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -281,7 +281,6 @@
     position: absolute;
     width: 100%;
     height: 100%;
-    z-index: 1;
 }
 
 .loading-mask::before {


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-18409
test: https://irsawebdev9.ipac.caltech.edu/dm-18409/firefly/

As reported in ticket, `mask` css style uses z-index and therefore interfere with the natural stacking order of the other components.
In this PR, z-index is removed.  Please verify everything is working as before.

