### PR TITLE
Firefly-50: update immutability-helper and replace react-addon-update

### DIFF
--- a/buildScript/webpack.config.js
+++ b/buildScript/webpack.config.js
@@ -183,6 +183,11 @@ export default function makeWebpackConfig(config) {
         );
     }
 
+    if (!ENV_DEV_MODE) { // Adding this so we see it in the log file of our builds
+        console.log('Building client with Global Props:');
+        console.log(globals.__PROPS__);
+    }
+
     const webpack_config = {
         name    : config.name,
         // mode    : 'none',

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "core-js": "^2.6.4",
     "enum": "^2.5",
     "fixed-data-table-2": "^0.8.9",
-    "immutability-helper": "^2.6",
+    "immutability-helper": "^3.0",
     "isomorphic-fetch": "^2.2.1",
     "local-storage": "^1.4.2",
     "lodash": "^4.17",

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -10,13 +10,7 @@ import {getRootURL} from './BrowserUtil.js';
 import {getWsConnId, getWsChannel} from '../core/AppDataCntlr.js';
 import {getDownloadProgress, DownloadProgress} from '../rpc/SearchServicesJson.js';
 
-// todo: we want to replace react-addons-update with immutability-helper. However there is some behavior difference with error
-// todo: handling, I observed it when updateMerge is called from ChartsCntrl.js,reduceData,case CHART_DATA_FETCH, line 415
-// todo: In this case can an exception is thrown. to reproduce: just do catalog search
-// todo: import update from 'immutability-helper';
-import update from 'react-addons-update';
-
-
+import update from 'immutability-helper';
 
 
 const MEG          = 1048576;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,11 +3219,11 @@ ignore@^3.3.3:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
-immutability-helper@^2.6:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.9.1.tgz#71c423ba387e67b6c6ceba0650572f2a2a6727df"
+immutability-helper@^3.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-3.0.0.tgz#a74e989c60e2ddab85a6abeed8078981b2d13271"
   dependencies:
-    invariant "^2.2.0"
+    invariant "^2.2.4"
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -3326,7 +3326,7 @@ interpret@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
 
-invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.1.0, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:


### PR DESCRIPTION
Replace the deprecated library react-addons-update with immutability-helper, also upgrade immutability-helper to the most recent version (3.0).

Note- We have been using immutability-helper for 2 years but did not replace it in WebUtil.js because it had a bug in certain use cases. This bug appears to have been fixed a while back so I think it is safe to replace. This will fix the bug we were seeing with Atmos when they added Prototype.js.

https://irsawebdev9.ipac.caltech.edu/firefly-50-immutability-helper/firefly/