### PR TITLE
IRSA-1093: vertical line appears due to an external outer <center> tag.

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -29,9 +29,10 @@
     font-family: tahoma,arial,helvetica,sans-serif;
     font-size: 11px;
     line-height: 1;
+    text-align: initial;
 }
 
-.rootStyle, div.rootStyle>img, div.rootStyle > html {
+div.rootStyle>img, div.rootStyle > html {
     border:0 none;
 }
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-1093

Problem:  
See the attached image in the ticket.

Solution:
Add style to rootStyle to remove `center` tag affect.

Test:  https://irsadev.ipac.caltech.edu:9201/

Note: There's a side effect to this solution.  Although, this remove the unwanted vertical line, it also remove the `center` affect as well.  
In general, we do not want external style to affect our firefly component.  This is the reason why rootStyle were introduced.  
But, since IRTF is already in production.  I just wanted to point out the visual differences after this PR.

There's a ticket created already to provide more styling to a table.
