### PR TITLE
Firefly-51: Make FieldGroupConnector use function components with hooks

### DIFF
--- a/src/firefly/js/ui/DateTimePickerField.jsx
+++ b/src/firefly/js/ui/DateTimePickerField.jsx
@@ -1,13 +1,14 @@
-import React, {PureComponent} from 'react';
+import React, {memo, PureComponent} from 'react';
 import {isNaN, get} from 'lodash';
 import PropTypes from 'prop-types';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
 import Moment from 'moment';
 import DateTime from 'react-datetime';
 import Validate from '../util/Validate.js';
 import FieldGroupUtils from '../fieldGroup/FieldGroupUtils';
+import {clone} from '../util/WebUtil.js';
 
 import './tap/react-datetime.css';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 /**
  * try to convert date/time string to Moment, if not, keep the string
  * @param str_or_moment
@@ -179,7 +180,6 @@ DateTimePicker.propTypes= {
     wrapperStyle: PropTypes.object,
     inputStyle: PropTypes.object,
     timeFieldKey: PropTypes.string,
-    groupKey: PropTypes.string
 };
 
 DateTimePicker.defaultValue = {
@@ -190,13 +190,6 @@ DateTimePicker.defaultValue = {
 const propTypes = {
     nullAllowed: PropTypes.bool
 };
-
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params,
-        {
-            onChange: (momentVal) => handleOnChange(momentVal, params, fireValueChange)
-        });
-}
 
 function handleOnChange(momentVal, params, fireValueChange) {
     const {nullAllowed=true} = params;
@@ -212,7 +205,29 @@ function convertMomentToMJD(m) {
     return m.isValid() ? `${(m.valueOf()/msecPerDay + DiffUnixMJD)}`: '';
 }
 
-export const DateTimePickerField = fieldGroupConnector(DateTimePicker, getProps, propTypes);
+export const DateTimePickerField= memo( (props) => {
+    const {viewProps, fireValueChange}= useFieldGroupConnector(props);
+    return (<DateTimePicker {...viewProps}
+                           onChange={(momentVal) => handleOnChange(momentVal,viewProps, fireValueChange)}/>);
+});
+
+
+DateTimePickerField.propTypes= {
+    showInput: PropTypes.bool,
+    openPicker:  PropTypes.bool,
+    onChange: PropTypes.func,
+    onChangeOpenStatus: PropTypes.func,
+    wrapperStyle: PropTypes.object,
+    inputStyle: PropTypes.object,
+    timeFieldKey: PropTypes.string,
+    groupKey: PropTypes.string,
+    initialState: PropTypes.shape({
+        value: PropTypes.string,
+    })
+};
+
+
+
 
 const DiffUnixMJD = 40587.0;
 const DiffUnixJD = 2440587.5;

--- a/src/firefly/js/ui/ExampleDialog.jsx
+++ b/src/firefly/js/ui/ExampleDialog.jsx
@@ -347,7 +347,6 @@ function FieldGroupTestView ({fields}) {
                 <SuggestBoxInputField
                     fieldKey='suggestion1'
                     initialState= {{
-                        fieldKey: 'suggestion1',
                         value: '',
                         validator:  (val) => {
                             let retval = {valid: true, message: ''};
@@ -371,7 +370,6 @@ function FieldGroupTestView ({fields}) {
                 <ValidationField fieldKey='field3'
                                  forceReinit={true}
                                  initialState= {{
-                                     fieldKey: 'field3',
                                      value: '12.12322',
                                      validator: Validate.floatRange.bind(null, 1.23333, 1000, 3,'field 3'),
                                      tooltip: 'more tipping',

--- a/src/firefly/js/ui/FieldGroupConnector.jsx
+++ b/src/firefly/js/ui/FieldGroupConnector.jsx
@@ -2,9 +2,9 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {useContext, useState, useEffect, useRef} from 'react';
+import {useContext, useState, useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
-import {get,omit, isUndefined} from 'lodash';
+import {get,omit} from 'lodash';
 import {dispatchMountComponent,dispatchValueChange} from '../fieldGroup/FieldGroupCntlr.js';
 import FieldGroupUtils, {getFieldGroupState} from '../fieldGroup/FieldGroupUtils.js';
 import {flux} from '../Firefly.js';
@@ -111,7 +111,7 @@ export const fgMinPropTypes= {
 /**
  *
  * Hook to connect a field to the FieldGroup Store. Pass the props object, make sure it includes the required props
- * to connect to the store (fieldKey is the only requirement, see below). The hooks returns qn object with the new
+ * to connect to the store (fieldKey is the only requirement, see below). The hooks returns an object with the new
  * props that you should be able to pass directly to the view.
  *
  * the props object parameter can contain any that should be kept in the store. The parameters below are special.

--- a/src/firefly/js/ui/InputAreaField.jsx
+++ b/src/firefly/js/ui/InputAreaField.jsx
@@ -1,47 +1,45 @@
-import React, {PureComponent} from 'react';
+import React, {forwardRef} from 'react';
+import {omit} from 'lodash';
 import PropTypes from 'prop-types';
 
 import {InputAreaFieldView, propTypes} from './InputAreaFieldView.jsx';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 import {InputFieldActOn} from './InputField';
 
 export const InputAreaField = (props) => <InputFieldActOn View={InputAreaFieldView} {...props}/>;
 
 
-InputAreaField.propTypes = {
-    ...propTypes,
-    fieldKey: PropTypes.string,
-    onChange: PropTypes.func,
-    actOn: PropTypes.arrayOf(PropTypes.oneOf(['blur', 'enter', 'changes'])),
-    validator: PropTypes.func,
-    value: PropTypes.string
-};
+function onChange(ev, validator, fireValueChange) {
+    const {valid,message}= validator(ev.target.value);
+    fireValueChange({ value : ev.target.value, message, valid });
+}
 
-InputAreaField.defaultProps = {
+
+export const InputAreaFieldConnected = forwardRef( (props, ref) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    return (<InputAreaFieldView ref={ref} {...viewProps} onChange={(ev) => onChange(ev,viewProps.validator, fireValueChange)}/>);
+});
+
+
+
+InputAreaFieldConnected.defaultProps = {
     showWarning: true,
     actOn: ['changes'],
     labelWidth: 0,
-    value: '',
     inline: false,
     visible: true,
     rows: 10,
     cols: 50
 };
 
-function onChange(ev, store, fireValueChange) {
+InputAreaFieldConnected.propTypes = {
+    ...omit(propTypes, ['value']),
+    fieldKey: PropTypes.string,
+    onChange: PropTypes.func,
+    actOn: PropTypes.arrayOf(PropTypes.oneOf(['blur', 'enter', 'changes'])),
+    validator: PropTypes.func,
+    initialState: PropTypes.shape({
+        value: PropTypes.string,
+    })
+};
 
-    var {valid,message}= store.validator(ev.target.value);
-
-    fireValueChange({ value : ev.target.value, message, valid });
-}
-
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params,
-        {
-            onChange: (ev) => onChange(ev, params, fireValueChange),
-            value: String(params.value)
-        });
-}
-
-
-export const InputAreaFieldConnected = fieldGroupConnector(InputAreaFieldView, getProps, InputAreaField.propTypes);

--- a/src/firefly/js/ui/InputField.jsx
+++ b/src/firefly/js/ui/InputField.jsx
@@ -31,7 +31,7 @@ export const InputFieldActOn = React.memo(({View, fieldKey, valid=true, value, o
                 const rval = validator(value) || {};
                 valid = rval.valid;
                 message = valid ? '' : (label + rval.message).replace('::', ':');
-                if (rval.value !== NOT_CELL_DATA) {
+                if (rval.value && rval.value !== NOT_CELL_DATA) {
                     value = rval.value;
                 }
             }

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -1,7 +1,6 @@
 import React, {PureComponent} from 'react';
-import PropTypes from 'prop-types';
 import {pickBy} from 'lodash';
-
+import {bool,string,number,object, func, oneOfType} from 'prop-types';
 import {PointerPopup} from '../ui/PointerPopup.jsx';
 import InputFieldLabel from './InputFieldLabel.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
@@ -124,28 +123,28 @@ export class InputFieldView extends PureComponent {
 }
 
 InputFieldView.propTypes= {
-    valid   : PropTypes.bool,
-    visible : PropTypes.bool,
-    disabled : PropTypes.bool,
-    message : PropTypes.string,
-    tooltip : PropTypes.string,
-    label : PropTypes.string,
-    inline : PropTypes.bool,
-    labelWidth: PropTypes.number,
-    style: PropTypes.object,
-    wrapperStyle: PropTypes.object,
-    labelStyle: PropTypes.object,
-    value   : PropTypes.string.isRequired,
-    size : PropTypes.number,
-    onChange : PropTypes.func.isRequired,
-    onBlur : PropTypes.func,
-    onKeyPress : PropTypes.func,
-    onKeyDown: PropTypes.func,
-    onKeyUp: PropTypes.func,
-    showWarning : PropTypes.bool,
-    type: PropTypes.string,
-    placeholder: PropTypes.string,
-    form: PropTypes.string
+    valid   : bool,
+    visible : bool,
+    disabled : bool,
+    message : string,
+    tooltip : string,
+    label : string,
+    inline : bool,
+    labelWidth: number,
+    style: object,
+    wrapperStyle: object,
+    labelStyle: object,
+    value   : oneOfType([string, number]).isRequired,
+    size : number,
+    onChange : func.isRequired,
+    onBlur : func,
+    onKeyPress : func,
+    onKeyDown: func,
+    onKeyUp: func,
+    showWarning : bool,
+    type: string,
+    placeholder: string,
+    form: string
 };
 
 InputFieldView.defaultProps= {

--- a/src/firefly/js/ui/ListBoxInputField.jsx
+++ b/src/firefly/js/ui/ListBoxInputField.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {get, isEmpty}  from 'lodash';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 
 import InputFieldLabel from './InputFieldLabel.jsx';
 
@@ -65,23 +65,6 @@ ListBoxInputFieldView.propTypes= {
     wrapperStyle: PropTypes.object
 };
 
-function getProps(params, fireValueChange) {
-
-    var {value,options}= params;
-    value= convertValue(value,options);
-
-    return Object.assign({}, params,
-        { value,
-          onChange: (ev) => {
-            handleOnChange(ev,params, fireValueChange);
-            if (params.onChange) {
-                params.onChange(ev);
-            }
-          }
-        });
-}
-
-
 function handleOnChange(ev, params, fireValueChange) {
     var options = ev.target.options;
     var val = [];
@@ -99,15 +82,10 @@ function handleOnChange(ev, params, fireValueChange) {
         message,
         valid
     });
+    if (params.onChange) params.onChange(ev);
 }
 
 
-const propTypes= {
-    inline : PropTypes.bool,
-    options : PropTypes.array.isRequired,
-    multiple : PropTypes.bool,
-    labelWidth : PropTypes.number
-};
 
 function checkForUndefined(v,props) {
     var optionContain = (v) => props.options.find ( (op) => op.value === v );
@@ -116,6 +94,31 @@ function checkForUndefined(v,props) {
             (!v ? props.options[0].value : (optionContain(v) ? v : props.options[0].value));
 }
 
-export const ListBoxInputField = fieldGroupConnector(ListBoxInputFieldView,
-                                                     getProps,propTypes,null,checkForUndefined);
+
+export const ListBoxInputField= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmInitialValue:checkForUndefined});
+    const newProps= {
+        ...viewProps,
+        value: convertValue(viewProps.value, viewProps.options),
+        onChange: (ev) => handleOnChange(ev,viewProps, fireValueChange)
+    };
+    return (<ListBoxInputFieldView {...newProps} />);
+});
+
+
+
+ListBoxInputField.propTypes= {
+    fieldKey : PropTypes.string,
+    groupKey : PropTypes.string,
+    forceReinit:  PropTypes.bool,
+    initialState: PropTypes.shape({
+        value: PropTypes.string,
+        tooltip: PropTypes.string,
+        label:  PropTypes.string,
+    }),
+    inline : PropTypes.bool,
+    options : PropTypes.array.isRequired,
+    multiple : PropTypes.bool,
+    labelWidth : PropTypes.number
+};
 

--- a/src/firefly/js/ui/NaifidPanel.jsx
+++ b/src/firefly/js/ui/NaifidPanel.jsx
@@ -14,6 +14,7 @@ import {TargetFeedback} from './TargetFeedback';
 const LABEL_DEFAULT='Moving Target Name:';
 
 const makeValidRet= (valid,message='') => ({valid,message});
+const defValidator= (val) => val ? makeValidRet(false,'Naif name not found') : makeValidRet(true);
 
 class NaifidPanelView extends PureComponent {
 
@@ -21,7 +22,7 @@ class NaifidPanelView extends PureComponent {
         super(props);
         this.state = {suggestions: ''};
         this.getSuggestions = this.getSuggestions.bind(this);
-        this.activeValidator= () => makeValidRet(true);
+        this.activeValidator= defValidator;
     }
 
     componentWillUnmount() {
@@ -34,12 +35,12 @@ class NaifidPanelView extends PureComponent {
     }
 
 
-    getSuggestions(val) {
+    getSuggestions(val= '') {
+            // if (val.length<2) return Promise.resolve([]);
+            this.activeValidator= defValidator;
+            if (val.length<2) return [];
             const rval = resolveNaifidObj(val);
-            if (!rval.p) return undefined;
-            this.activeValidator= (val) => {
-                return val ? makeValidRet(false,'Naif name not found') : makeValidRet(true);
-            };
+            if (!rval.p) return [];
             return rval.p.then((response)=>{
                 //const [result] = response;
                 if(response.valid) {
@@ -52,6 +53,7 @@ class NaifidPanelView extends PureComponent {
                     }
 
                     this.activeValidator= (val= '') => {
+                        if (!val) return makeValidRet(true);
                         if (Object.keys(suggestionsList).find((k) => k.toUpperCase()===val.toUpperCase())) {
                             return makeValidRet(true);
                         }

--- a/src/firefly/js/ui/NaifidPanel.jsx
+++ b/src/firefly/js/ui/NaifidPanel.jsx
@@ -2,30 +2,26 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {PureComponent} from 'react';
+import React, {PureComponent, memo} from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
-import {getFeedback, formatPosForTextField} from './TargetPanelWorker.js';
 import {resolveNaifidObj} from  './NaifidPanelWorker.js';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
-import FieldGroupUtils from '../fieldGroup/FieldGroupUtils.js';
-import {dispatchActiveTarget, getActiveTarget} from '../core/AppDataCntlr.js';
-import {isValidPoint, parseWorldPt} from '../visualize/Point.js';
-import {SuggestBoxInputField} from './SuggestBoxInputField';
-import {flux} from 'firefly/Firefly.js';
+import {SuggestBoxInputFieldView} from './SuggestBoxInputField';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 import {TargetFeedback} from './TargetFeedback';
-import {dispatchValueChange} from '../fieldGroup/FieldGroupCntlr';
 
 
 const LABEL_DEFAULT='Moving Target Name:';
 
+const makeValidRet= (valid,message='') => ({valid,message});
 
 class NaifidPanelView extends PureComponent {
 
     constructor(props) {
         super(props);
-        this.state = {suggestions: '',fld: FieldGroupUtils.getGroupFields(this.props.groupKey)};
+        this.state = {suggestions: ''};
         this.getSuggestions = this.getSuggestions.bind(this);
+        this.activeValidator= () => makeValidRet(true);
     }
 
     componentWillUnmount() {
@@ -35,17 +31,15 @@ class NaifidPanelView extends PureComponent {
 
     componentDidMount() {
         this.iAmMounted = true;
-        this.unbinder = FieldGroupUtils.bindToStore(this.props.groupKey, (fields) => {
-            if (fields !== this.state && this.iAmMounted) {
-                this.setState({fields});
-            }
-        });
     }
 
 
     getSuggestions(val) {
             const rval = resolveNaifidObj(val);
             if (!rval.p) return undefined;
+            this.activeValidator= (val) => {
+                return val ? makeValidRet(false,'Naif name not found') : makeValidRet(true);
+            };
             return rval.p.then((response)=>{
                 //const [result] = response;
                 if(response.valid) {
@@ -57,6 +51,15 @@ class NaifidPanelView extends PureComponent {
                         this.setState({suggestions:''});
                     }
 
+                    this.activeValidator= (val= '') => {
+                        if (Object.keys(suggestionsList).find((k) => k.toUpperCase()===val.toUpperCase())) {
+                            return makeValidRet(true);
+                        }
+                        else {
+                            return makeValidRet(false,'Choose naif name from list');
+                        }
+                    };
+
                     return Object.keys(suggestionsList).map( (k) => `Object Name:${k}, NAIF ID:${suggestionsList[k]}`);
 
                 }else {
@@ -67,23 +70,35 @@ class NaifidPanelView extends PureComponent {
 
 
     render() {
-        const {fieldKey, groupKey, showHelp, valid, message, feedback, value,
-            labelWidth, feedbackStyle, popStyle, label= LABEL_DEFAULT}= this.props;
+        const {showHelp, valid, message, feedback, value,
+            labelWidth, feedbackStyle, popStyle, label= LABEL_DEFAULT, fireValueChange}= this.props;
 
-        let positionField = (<SuggestBoxInputField
-            fieldKey = {fieldKey}
+
+        const validator=  (val) => {
+            return this.activeValidator(val);
+        };
+
+
+        const positionField = (<SuggestBoxInputFieldView
             wrapperStyle={{width:200}}
             label = {label}
             labelWidth={labelWidth}
             style={{width: 50}}
+            valid={valid}
             popStyle={popStyle}
             message={message}
             value={value}
-            valueOnSuggestion={getNaifidValue((selectedSugg) => updateFeedback(selectedSugg, fieldKey, groupKey, valid))}
+            valueOnSuggestion={getNaifidValue((selectedSugg) => {
+                updateFeedback(selectedSugg, true, fireValueChange);
+            })}
             getSuggestions={this.getSuggestions}
             renderSuggestion={renderSuggestion}
+            fireValueChange={(payload) => {
+                fireValueChange({message:payload.message, valid:payload.valid, displayValue:payload.value});
+            }}
+            validator={validator}
         />);
-        let naifidFeedback = (<TargetFeedback {...{feedback}} {...{feedbackStyle}}/>);
+        const naifidFeedback = (<TargetFeedback {...{feedback}} {...{feedbackStyle}}/>);
 
         return (
             <div>
@@ -96,8 +111,6 @@ class NaifidPanelView extends PureComponent {
 }
 
 NaifidPanelView.propTypes = {
-    fieldKey : PropTypes.string,
-    groupKey : PropTypes.string,
     label : PropTypes.string,
     valid   : PropTypes.bool.isRequired,
     showHelp   : PropTypes.bool.isRequired,
@@ -107,98 +120,72 @@ NaifidPanelView.propTypes = {
     labelWidth : PropTypes.number,
     popStyle : PropTypes.object, //style for the suggestion box popup list
     onUnmountCB : PropTypes.func,
-    feedbackStyle: PropTypes.object
+    feedbackStyle: PropTypes.object,
+    fireValueChange: PropTypes.func
 };
 
 
 
-function didUnmount(fieldKey,groupKey, props) {
-    const wp= parseWorldPt(FieldGroupUtils.getFldValue(FieldGroupUtils.getGroupFields(groupKey),fieldKey));
-
-    if (props.nullAllowed && !wp) {
-        dispatchActiveTarget(null);
-    }
-    else if (isValidPoint(wp)) {
-        dispatchActiveTarget(wp);
-    }
-}
-
-
-
-function getProps(params) {
-    let feedback= params.feedback|| '';
-    let value= params.displayValue;
-    let showHelp= get(params,'showHelp', true);
-    const wpStr= params.value;
-    const wp= parseWorldPt(wpStr);
-
-    if (isValidPoint(wp) && !value) {
-        feedback= getFeedback(wp);
-        value= wp.objName || formatPosForTextField(wp);
-        showHelp= false;
-    }
-
-    return Object.assign({}, params,
-        {
-            visible: true,
-            label: params.label || LABEL_DEFAULT,
-            tooltip: 'Enter a target',
-            value,
-            feedback,
-            showHelp,
-            nullAllowed:params.nullAllowed,
-            onUnmountCB: didUnmount
-        });
-}
-
-
-function updateFeedback(value, fieldKey, groupKey, valid){
+function updateFeedback(resolvedStr, valid, fireValueChange){
+   const {objName, naifId}=  parseNaifPair(resolvedStr);
    const payload={
-       fieldKey: fieldKey,
-       groupKey: groupKey,
-       feedback: value,
-       valid: valid
+       feedback: resolvedStr,
+       valid,
+       displayValue: objName,
+       value: naifId,
    };
-   dispatchValueChange(payload);
-}
-
-
-const connectorDefaultProps = {
-    fieldKey : 'UserTargetWorldPt',
-    initialState  : {
-        fieldKey : 'UserTargetWorldPt'
-    }
-};
-
-function replaceValue(v,props) {
-    const t= getActiveTarget();
-    // if (props.nullAllowed && !v) return v;
-    let retVal= v;
-    if (t && t.worldPt) {
-        if (get(t,'worldPt')) retVal= t.worldPt.toString();
-    }
-    return retVal;
+   fireValueChange(payload);
 }
 
 /** Parses the selected option, and returns the value which gets populated in the input field of the suggestion box*/
 function getNaifidValue(onCallBack) {
     return (val, str) => {
         if (! str) return;
-        //const [,naifId] = str.match(/NAIF ID:(.*)/) || [];
-        const [,naifId] = str.match(/Object Name:(.*),/) || [];
+        const result= parseNaifPair(str);
         onCallBack(str);
-        return naifId;
-    }
+        return result.objName;
+    };
+}
+
+function parseNaifPair(str) {
+    const [,objName=''] = str.match(/Object Name:(.*),/) || [];
+    const [,naifId=''] = str.match(/NAIF ID:(.*)/) || [];
+    return {objName,naifId};
 }
 
 
 /** renders suggestion list's popup */
 function renderSuggestion(str){
-    let name = str.split(',')[0].split('Object Name:');
-    let naifid = str.split(',')[1].split('NAIF ID:');
-
-    return  <span>Name:<b>{name}</b>, NAIF ID: <b>{naifid}</b></span>;
+    const {objName, naifId}=  parseNaifPair(str);
+    return  <span>Name:<b>{objName}</b>, NAIF ID: <b>{naifId}</b></span>;
 }
 
-export const NaifidPanel= fieldGroupConnector(NaifidPanelView,getProps,null,connectorDefaultProps, replaceValue);
 
+function handleValueChange(payload, fireValueChange) {
+    const newPayload= {...payload};
+    if (!payload.valid) {
+        newPayload.value= '';
+        newPayload.feedback= '';
+    }
+    fireValueChange(newPayload) ;
+}
+
+export const NaifidPanel= memo( (props) => {
+    const {fieldKey= 'NaifId'}= props;
+    const {viewProps, fireValueChange}=  useFieldGroupConnector({fieldKey, ...props});
+
+
+    const newProps=
+        {
+            ...viewProps,
+            visible: true,
+            label: viewProps.label || LABEL_DEFAULT,
+            tooltip: 'Enter a target',
+            value: viewProps.displayValue,
+            feedback: viewProps.feedback|| '',
+            showHelp: get(viewProps,'showHelp', true),
+            fireValueChange: (payload) => handleValueChange(payload,fireValueChange)
+        };
+
+    return <NaifidPanelView {...newProps} /> ;
+});

--- a/src/firefly/js/ui/RadioGroupInputField.jsx
+++ b/src/firefly/js/ui/RadioGroupInputField.jsx
@@ -1,49 +1,23 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, {memo} from 'react';
+import {bool, array, string, number, object, any, shape} from 'prop-types';
 import {isEmpty, isUndefined, get}  from 'lodash';
 import {RadioGroupInputFieldView} from './RadioGroupInputFieldView.jsx';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 
 
-const convertValue= (value,options,defaultValue) => {
-    if (!value) {
-        return isUndefined(defaultValue) ? options[0].value : defaultValue;
-    } else {
-        return value;
-    }
+const assureValue= (props) => {
+    const {value,options, defaultValue}= props;
+    if (value) return value;
+    return isUndefined(defaultValue) ? options[0].value : defaultValue;
 };
-
-function getProps(params, fireValueChange) {
-
-    var {value,options,defaultValue}= params;
-    value= convertValue(value,options,defaultValue);
-
-    return Object.assign({}, params,
-        {
-            value,
-            onChange: (ev) => handleOnChange(ev,params, fireValueChange)
-        });
-}
 
 function handleOnChange(ev, params, fireValueChange) {
     const val = get(ev, 'target.value', '');
     const checked = get(ev, 'target.checked', false);
-
     if (checked) {
         fireValueChange({ value: val, valid: true});
     }
 }
-
-
-const propTypes= {
-    inline : PropTypes.bool,
-    options: PropTypes.array,
-    defaultValue: PropTypes.string,
-    alignment:  PropTypes.string,
-    labelWidth : PropTypes.number,
-    labelStyle: PropTypes.object,
-    isGrouped: PropTypes.bool
-};
 
 function checkForUndefined(v,props) {
     const {options=[], defaultValue, isGrouped=false} = props;
@@ -55,7 +29,27 @@ function checkForUndefined(v,props) {
     }
 }
 
+export const RadioGroupInputField= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmInitialValue:checkForUndefined});
+    const newProps= {...viewProps,  value: assureValue(viewProps)};
+    return <RadioGroupInputFieldView {...newProps}
+                                     onChange={(ev) => handleOnChange(ev,viewProps, fireValueChange)}/> ;
+});
 
-export const RadioGroupInputField= fieldGroupConnector(RadioGroupInputFieldView,
-    getProps,propTypes,null,checkForUndefined);
 
+RadioGroupInputField.propTypes= {
+    inline : bool,
+    options: array,
+    defaultValue: string,
+    alignment:  string,
+    labelWidth : number,
+    labelStyle: object,
+    isGrouped: bool,
+    forceReinit:  bool,
+    fieldKey:   string,
+    initialState: shape({
+        value: string,
+        tooltip: string,
+        label:  string,
+    }),
+};

--- a/src/firefly/js/ui/RangeSlider.jsx
+++ b/src/firefly/js/ui/RangeSlider.jsx
@@ -1,15 +1,8 @@
+import React, {memo, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import { has, isNaN} from 'lodash';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
 import {RangeSliderView, checkMarksObject} from './RangeSliderView.jsx';
-
-function getProps(params, fireValueChange) {
-
-    return Object.assign({}, params,
-        {
-            handleChange: (v) => handleOnChange(v, params, fireValueChange),
-        });
-}
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 
 /**
  * @summary callback to handle slider value change
@@ -33,7 +26,20 @@ function handleOnChange(value, params, fireValueChange){
     }
 }
 
-const propTypes={
+
+// export const RangeSlider = fieldGroupConnector(RangeSliderView, getProps, propTypes, null);
+
+
+export const RangeSlider= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    return (<RangeSliderView {...viewProps}
+                            handleChange={(value) => handleOnChange(value,viewProps, fireValueChange)}/>);
+});
+
+
+RangeSlider.propTypes={
+    fieldKey: PropTypes.string,
+    groupKey: PropTypes.string,
     associatedKey: PropTypes.string,
     label:       PropTypes.string,             // slider label
     slideValue:  PropTypes.oneOfType([PropTypes.string,PropTypes.number]).isRequired, // slider value
@@ -55,6 +61,4 @@ const propTypes={
     maxStop:  PropTypes.number,                          // maximum value the slider can be changed to
     errMsg: PropTypes.string                            // message for invalid value
 };
-
-export const RangeSlider = fieldGroupConnector(RangeSliderView, getProps, propTypes, null);
 

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -1,13 +1,13 @@
-import React, {PureComponent} from 'react';
+import React, {PureComponent, memo} from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
 import {convertAngle} from '../visualize/VisUtil.js';
 import {InputFieldView} from './InputFieldView.jsx';
 import {ListBoxInputFieldView} from './ListBoxInputField.jsx';
 import Validate from '../util/Validate.js';
 import {toMaxFixed} from '../util/MathUtil.js';
 import validator from 'validator';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 
 const invalidSizeMsg = 'size is not set properly or size is out of range';
 const DECDIGIT = 6;
@@ -46,20 +46,6 @@ function updateSizeInfo(params) {
     return {unit, valid, value, displayValue};
 }
 
-function getProps(params, fireValueChange) {
-
-    var {unit, valid, value, displayValue} = updateSizeInfo(params);
-
-    return Object.assign({}, params,
-        {
-            onChange: (ev, sizeInfo) => handleOnChange(ev, sizeInfo, params, fireValueChange),
-            unit,
-            displayValue,
-            value,
-            valid
-        });
-}
-
 /**
  *
  * @param ev
@@ -82,13 +68,6 @@ function handleOnChange(ev, sizeInfo, params, fireValueChange) {
          valid
      });
 }
-
-const propTypes={
-    label:       PropTypes.string,
-    labelWidth:  PropTypes.number,
-    unit:        PropTypes.string,
-    showFeedback:    PropTypes.bool
-};
 
 /**
  * @param {string} value size value in degree
@@ -226,4 +205,24 @@ SizeInputFieldView.defaultProps = {
     showFeedback: false
 };
 
-export const SizeInputFields = fieldGroupConnector(SizeInputFieldView, getProps, propTypes, null);
+
+export const SizeInputFields = memo( (props) => {
+
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    const {unit, valid, value, displayValue} = updateSizeInfo(viewProps);
+    return (<SizeInputFieldView
+             {...{...viewProps, unit, valid, value, displayValue}}
+             onChange= {(ev, sizeInfo) => handleOnChange(ev, sizeInfo, viewProps, fireValueChange)} />
+             );
+});
+
+
+SizeInputFields.propTypes={
+    fieldKey : PropTypes.string,
+    groupKey : PropTypes.string,
+    initialState:  PropTypes.object,
+    label:       PropTypes.string,
+    labelWidth:  PropTypes.number,
+    unit:        PropTypes.string,
+    showFeedback:    PropTypes.bool
+};

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -220,9 +220,17 @@ export const SizeInputFields = memo( (props) => {
 SizeInputFields.propTypes={
     fieldKey : PropTypes.string,
     groupKey : PropTypes.string,
-    initialState:  PropTypes.object,
+    initialState: PropTypes.shape({
+        value: PropTypes.any,
+        tooltip:  PropTypes.string,
+        unit:  PropTypes.string,
+        min:   PropTypes.number,
+        max:   PropTypes.number,
+        labelWidth:  PropTypes.number,
+        nullAllowed: PropTypes.bool,
+        displayValue: PropTypes.string,
+        label:  PropTypes.string,
+    }),
     label:       PropTypes.string,
-    labelWidth:  PropTypes.number,
-    unit:        PropTypes.string,
     showFeedback:    PropTypes.bool
 };

--- a/src/firefly/js/ui/SuggestBoxInputField.jsx
+++ b/src/firefly/js/ui/SuggestBoxInputField.jsx
@@ -144,7 +144,7 @@ export class SuggestBoxInputFieldView extends PureComponent {
             if (arrayOrPromise === this.suggestionsPromise && isArray(suggestions) && suggestions.length > 0) {
                 this.setState({isOpen: true, suggestions});
             } else {
-                this.setState({isOpen: false, suggestions: []});
+                if (this.state.isOpen) this.setState({isOpen: false, suggestions: []});
             }
         }).catch((err) => logError(err));
     }

--- a/src/firefly/js/ui/SuggestBoxInputField.jsx
+++ b/src/firefly/js/ui/SuggestBoxInputField.jsx
@@ -1,21 +1,14 @@
-import React, {PureComponent} from 'react';
+import React, {memo, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import {get, isArray, isUndefined, debounce} from 'lodash';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 
 import {logError} from '../util/WebUtil.js';
 
 import {InputFieldView} from './InputFieldView.jsx';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
 import './SuggestBoxInputField.css';
 
-
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params,
-        {
-            fireValueChange
-        });
-}
 
 /**
  *  Make sure a component (like highlighted suggestion) is visible
@@ -104,7 +97,7 @@ const SuggestBox = (props) => {
     );
 };
 
-class SuggestBoxInputFieldView extends PureComponent {
+export class SuggestBoxInputFieldView extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {
@@ -179,7 +172,7 @@ class SuggestBoxInputFieldView extends PureComponent {
             const currentSuggestion = suggestions[highlightedIdx];
             const value = valueOnSuggestion ? valueOnSuggestion(displayValue, currentSuggestion) : currentSuggestion;
             if (value !== displayValue) {
-                var {valid,message} = validator? validator(value) : {true : ''};
+                var {valid,message} = validator? validator(value) : {valid: true, message:''};
                 this.setState({
                     isOpen: false,
                     highlightedIdx: undefined,
@@ -233,7 +226,7 @@ class SuggestBoxInputFieldView extends PureComponent {
             <div className={'SuggestBoxInputField'} style={style} onKeyDown={this.handleKeyPress}>
                 <div>
                     <InputFieldView
-                        valid={valid}
+                        valid={Boolean(valid)}
                         onChange={this.onValueChange}
                         onBlur={() => {isOpen && this.changeValue(undefined);}}
                         value={displayValue}
@@ -274,8 +267,37 @@ SuggestBoxInputFieldView.propTypes = {
     valueOnSuggestion : PropTypes.func, //newDisplayValue = valueOnSuggestion(prevValue, suggestion),
     renderSuggestion : PropTypes.func,   // ReactElem = renderSuggestion(suggestion)
     popupIndex: PropTypes.number,
-    inputStyle: PropTypes.object
+    inputStyle: PropTypes.object,
+    valid: PropTypes.bool,
+    message: PropTypes.string,
 };
 
 
-export const SuggestBoxInputField = fieldGroupConnector(SuggestBoxInputFieldView, getProps, SuggestBoxInputFieldView.propTypes, null);
+export const SuggestBoxInputField= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    return <SuggestBoxInputFieldView {...{...viewProps, fireValueChange}} /> ;
+
+});
+
+
+SuggestBoxInputField.propTypes = {
+    fieldKey : PropTypes.string.isRequired,
+    groupKey : PropTypes.string,
+    inline : PropTypes.bool,
+    label:  PropTypes.string,
+    tooltip:  PropTypes.string,
+    labelWidth : PropTypes.number,
+    popStyle : PropTypes.object, //style for the popup list
+    wrapperStyle: PropTypes.object,     //style to merge into the container div
+    getSuggestions : PropTypes.func,   //suggestionsArr = getSuggestions(displayValue)
+    valueOnSuggestion : PropTypes.func, //newDisplayValue = valueOnSuggestion(prevValue, suggestion),
+    renderSuggestion : PropTypes.func,   // ReactElem = renderSuggestion(suggestion)
+    popupIndex: PropTypes.number,
+    initialState: PropTypes.shape({
+        value: PropTypes.string,
+        tooltip: PropTypes.string,
+        label:  PropTypes.string,
+        validator: PropTypes.func
+    }),
+};
+

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -25,8 +25,8 @@ const simbadThenNed= 'simbadthenned';
 class TargetPanelView extends PureComponent {
 
     componentWillUnmount() {
-        const {onUnmountCB, fieldKey, groupKey}= this.props;
-        if (onUnmountCB) onUnmountCB(fieldKey,groupKey, this.props);
+        const {onUnmountCB}= this.props;
+        if (onUnmountCB) onUnmountCB(this.props);
     }
 
     render() {
@@ -69,8 +69,6 @@ class TargetPanelView extends PureComponent {
 
 
 TargetPanelView.propTypes = {
-    fieldKey : PropTypes.string,
-    groupKey : PropTypes.string,
     label : PropTypes.string,
     valid   : PropTypes.bool.isRequired,
     showHelp   : PropTypes.bool.isRequired,
@@ -97,40 +95,6 @@ function didUnmount(fieldKey,groupKey, props) {
         dispatchActiveTarget(wp);
     }
 }
-
-
-
-function getProps(params, fireValueChange) {
-
-    var feedback= params.feedback|| '';
-    var value= params.displayValue;
-    var resolver= params.resolver || nedThenSimbad;
-    var showHelp= get(params,'showHelp', true);
-    const wpStr= params.value;
-    const wp= parseWorldPt(wpStr);
-
-    if (isValidPoint(wp) && !value) {
-        feedback= getFeedback(wp);
-        value= wp.objName || formatPosForTextField(wp);
-        showHelp= false;
-    }
-
-    return Object.assign({}, params,
-        {
-            visible: true,
-            onChange: (value,source) => handleOnChange(value,source,params, fireValueChange),
-            label: params.label || LABEL_DEFAULT,
-            tooltip: 'Enter a target',
-            value,
-            feedback,
-            resolver,
-            showHelp,
-            nullAllowed:params.nullAllowed,
-            onUnmountCB: didUnmount
-        });
-}
-
-
 
 
 function handleOnChange(value, source, params, fireValueChange) {
@@ -212,11 +176,11 @@ function replaceValue(v,props) {
 
 
 
-export const TargetPanel = memo( ({fieldKey= 'UserTargetWorldPt', initialState= { fieldKey : 'UserTargetWorldPt' }, ...restOfProps}) => {
-    const {viewProps, fireValueChange}=  useFieldGroupConnector({fieldKey, initialState, confirmInitialValue:replaceValue});
-    const newProps= computeProps(viewProps, restOfProps);
-    return <TargetPanelView {...newProps}
-                            onChange={(value,source) => handleOnChange(value,source,newProps, fireValueChange)}/> ;
+export const TargetPanel = memo( ({fieldKey= 'UserTargetWorldPt',initialState= {}, ...restOfProps}) => {
+    const {viewProps, fireValueChange, groupKey}=  useFieldGroupConnector({fieldKey, initialState, confirmInitialValue:replaceValue});
+    const newProps= computeProps(viewProps, restOfProps, fieldKey, groupKey);
+    return ( <TargetPanelView {...newProps}
+                              onChange={(value,source) => handleOnChange(value,source,newProps, fireValueChange)}/>);
 });
 
 
@@ -226,11 +190,12 @@ TargetPanel.propTypes = {
     groupKey: PropTypes.string,
     examples: PropTypes.object,
     labelWidth : PropTypes.number,
-    nullAllowed: PropTypes.bool
+    nullAllowed: PropTypes.bool,
+    initialState: PropTypes.object
 };
 
 
-function computeProps(viewProps, componentProps) {
+function computeProps(viewProps, componentProps, fieldKey, groupKey) {
 
     let feedback= viewProps.feedback|| '';
     let value= viewProps.displayValue;
@@ -245,15 +210,15 @@ function computeProps(viewProps, componentProps) {
         showHelp= false;
     }
 
-    return Object.assign({}, viewProps,
-        {
-            visible: true,
-            label: 'Name or Position:',
-            tooltip: 'Enter a target',
-            value,
-            feedback,
-            resolver,
-            showHelp,
-            onUnmountCB: didUnmount
-        }, componentProps);
+    return {
+        ...viewProps,
+        visible: true,
+        label: 'Name or Position:',
+        tooltip: 'Enter a target',
+        value,
+        feedback,
+        resolver,
+        showHelp,
+        onUnmountCB: (props) => didUnmount(fieldKey,groupKey,props),
+        ...componentProps};
 }

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -46,7 +46,7 @@ import {HiPSId, URL_COL} from '../visualize/HiPSListUtil.js';
 import {HiPSPopupMsg, HiPSSurveyListSelection, getTblModelOnPanel,
         getHiPSSourcesChecked, sourcesPerChecked} from './HiPSSurveyListDisplay.jsx';
 import {getCellValue} from '../tables/TableUtil.js';
-import {NaifidPanel} from "./NaifidPanel";
+import {NaifidPanel} from './NaifidPanel';
 
 
 export class TestQueriesPanel extends PureComponent {

--- a/src/firefly/js/ui/TimePanel.jsx
+++ b/src/firefly/js/ui/TimePanel.jsx
@@ -2,12 +2,12 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {PureComponent} from 'react';
+import React, {PureComponent, memo} from 'react';
 import PropTypes from 'prop-types';
 import {has} from 'lodash';
 import {clone} from '../util/WebUtil.js';
 import {InputFieldView} from './InputFieldView.jsx';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 import {convertISOToMJD, convertMJDToISO, validateDateTime, validateMJD, fMoment} from './DateTimePickerField.jsx';
 import {MJD, ISO} from './tap/TapUtil.js';
 
@@ -165,19 +165,6 @@ TimeFeedback.propTypes = {
     timeMode: PropTypes.string
 };
 
-
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params,
-        {
-            onChange: (ev) => handleOnChange(ev, params, fireValueChange),
-            value: params.value || ''
-        });
-}
-
-const propTypes = {
-    timeMode: PropTypes.string
-};
-
 function handleOnChange(ev, params, fireValueChange) {
     const v = ev.target.value;
     const {timeMode = ISO} = params;
@@ -224,6 +211,15 @@ export const isShowHelp = (utc, mjd) => {
     return !utc && !mjd;
 };
 
-export const TimePanel= fieldGroupConnector(TimePanelView, getProps, propTypes);
+export const TimePanel= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    const newProps= {...viewProps, value:viewProps.value || '' };
+    return (<TimePanelView {...newProps} onChange={(ev) => handleOnChange(ev,viewProps, fireValueChange)}/>);
+});
 
+TimePanel.propTypes = {
+    fieldKey : PropTypes.string,
+    groupKey : PropTypes.string,
+    timeMode: PropTypes.string
+};
 

--- a/src/firefly/js/ui/TimePanel.jsx
+++ b/src/firefly/js/ui/TimePanel.jsx
@@ -88,8 +88,6 @@ class TimePanelView extends PureComponent {
 }
 
 TimePanelView.propTypes = {
-    fieldKey : PropTypes.string,
-    groupKey : PropTypes.string,
     showHelp   : PropTypes.bool,
     feedback: PropTypes.string,
     feedbackStyle: PropTypes.object,
@@ -220,6 +218,12 @@ export const TimePanel= memo( (props) => {
 TimePanel.propTypes = {
     fieldKey : PropTypes.string,
     groupKey : PropTypes.string,
-    timeMode: PropTypes.string
+    timeMode: PropTypes.string,
+    icon: PropTypes.string,
+    onClickIcon: PropTypes.func,
+    feedbackStyle: PropTypes.object,
+    labelPosition: PropTypes.oneOf(['top', 'left']),
+    inputStyle: PropTypes.object,
+    inputWidth: PropTypes.number
 };
 

--- a/src/firefly/js/ui/ValidationField.jsx
+++ b/src/firefly/js/ui/ValidationField.jsx
@@ -1,30 +1,24 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, {memo} from 'react';
 import {has} from 'lodash';
-
+import {clone} from '../util/WebUtil.js';
+import {useFieldGroupConnector, fgConnectPropsTypes} from './FieldGroupConnector.jsx';
 import {InputFieldView} from './InputFieldView.jsx';
-import {fieldGroupConnector} from './FieldGroupConnector.jsx';
-import {InputAreaFieldView} from './InputAreaFieldView';
 
 
-function onChange(ev, store, fireValueChange) {
-    var value = ev.target.value;
-    var {valid,message, ...others}= store.validator(value);
+function onChange(ev, validator, fireValueChange) {
+    let value = ev.target.value;
+    const {valid,message, ...others}= validator(value);
     has(others, 'value') && (value = others.value);    // allow the validator to modify the value.. useful in auto-correct.
-
     fireValueChange({ value, message, valid });
 }
 
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params,
-        {
-            onChange: (ev) => onChange(ev,params, fireValueChange),
-            value: String(params.value)
-        });
-}
 
-const propTypes= {
-      inline : PropTypes.bool
+export const ValidationField = memo( (props) => {
+        const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+        return <InputFieldView {...viewProps}
+                               onChange={(ev) => onChange(ev,viewProps.validator, fireValueChange)}/> ;
+});
+
+ValidationField.propType= {
+    ...fgConnectPropsTypes
 };
-
-export const ValidationField= fieldGroupConnector(InputFieldView,getProps,propTypes);

--- a/src/firefly/js/ui/panel/CollapsiblePanel.jsx
+++ b/src/firefly/js/ui/panel/CollapsiblePanel.jsx
@@ -3,11 +3,12 @@
  */
 
 import './CollapsiblePanel.css';
-import React, {PureComponent} from 'react';
+import React, {memo, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {isBoolean, isFunction} from 'lodash';
-import {fieldGroupConnector} from '../FieldGroupConnector.jsx';
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
+import {clone} from '../../util/WebUtil.js';
+import {useFieldGroupConnector} from '../FieldGroupConnector.jsx';
 
 
 export const CollapseBorder = {
@@ -105,6 +106,16 @@ export class CollapsiblePanel extends PureComponent {
     }
 }
 
+
+export const FieldGroupCollapsible= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    const newProps= {...viewProps,
+            isOpen: Boolean(viewProps.value === 'open'),
+            onToggle: (isOpen) => fireValueChange({ value: isOpen ? 'open' : 'closed' })
+        };
+    return ( <CollapsiblePanel {...newProps} /> );
+});
+
 CollapsiblePanel.propTypes = {
     componentKey: PropTypes.string, // if need to preserve state and is not part of the field group
     header: PropTypes.node,
@@ -114,7 +125,10 @@ CollapsiblePanel.propTypes = {
     contentStyle: PropTypes.object,
     wrapperStyle: PropTypes.object,
     borderStyle: PropTypes.number,
-    onToggle: PropTypes.func
+    onToggle: PropTypes.func,
+    initialState: PropTypes.shape({
+        value: PropTypes.string,  // 'open' or 'closed'
+    })
 };
 
 CollapsiblePanel.defaultProps= {
@@ -124,11 +138,3 @@ CollapsiblePanel.defaultProps= {
 };
 
 
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params, {
-        onToggle: (isOpen) => fireValueChange({value: isOpen?'open':'closed'}),
-        isOpen: Boolean(params.value && params.value==='open')
-    });
-}
-
-export const FieldGroupCollapsible= fieldGroupConnector(CollapsiblePanel,getProps);

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -3,11 +3,11 @@
  */
 
 import './TabPanel.css';
-import React, {PureComponent} from 'react';
+import React, {memo, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import sizeMe from 'react-sizeme';
-import {fieldGroupConnector} from '../FieldGroupConnector.jsx';
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
+import {useFieldGroupConnector} from '../FieldGroupConnector.jsx';
 
 
 
@@ -222,23 +222,37 @@ Tab.defaultProps= { selected: false };
 
 
 
-function onChange(idx,id, name, params, fireValueChange) {
+function onChange(idx,id, name, viewProps, fireValueChange) {
     let value= id||name;
     if (!value) value= idx;
 
     fireValueChange({ value});
-    if (params.onTabSelect) {
-        params.onTabSelect(idx, id, name);
+    if (viewProps.onTabSelect) {
+        viewProps.onTabSelect(idx, id, name);
     }
 }
 
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params,
-        {
-            onTabSelect: (idx,id,name) => onChange(idx,id,name,params, fireValueChange),
-            defaultSelected:params.value,
-            useFlex: true
-        });
-}
 
-export const FieldGroupTabs= fieldGroupConnector(Tabs,getProps);
+export const FieldGroupTabs= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    const newProps= {
+        ...viewProps,
+        defaultSelected : viewProps.value,
+        useFlex: true,
+        onTabSelect: (idx,id,name) => onChange(idx,id,name,viewProps, fireValueChange)
+        };
+    return (<Tabs {...newProps} />);
+});
+
+FieldGroupTabs.propTypes= {
+    fieldKey: PropTypes.string,
+    onTabSelect: PropTypes.func,
+    initialState: PropTypes.shape({
+        value: PropTypes.string,
+    }),
+    resizable: PropTypes.bool,
+    headerStyle: PropTypes.object,
+    contentStyle: PropTypes.object,
+    borderless: PropTypes.bool,
+    forceReinit: PropTypes.bool
+};

--- a/src/firefly/js/ui/tap/Select.jsx
+++ b/src/firefly/js/ui/tap/Select.jsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import Select, {components} from 'react-select';
 import {truncate} from 'lodash';
 import LOADING from 'html/images/gxt/loading.gif';
-
-import {fieldGroupConnector} from '../FieldGroupConnector';
+import {useFieldGroupConnector} from '../FieldGroupConnector.jsx';
 
 export const commonSelectStyles = {
     option: (styles) => (
@@ -133,23 +132,26 @@ export function NameSelect({options, value, onSelect, type, selectProps={}}) {
 }
 
 
-export const NameSelectField = fieldGroupConnector(NameSelect, getProps, NameSelect.propTypes, null);
+export const NameSelectField = memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    return ( <NameSelect {...viewProps }
+                         onSelect={(selectedValue) => {
+                             fireValueChange({value: selectedValue});
+                             if (viewProps.onSelect) viewProps.onSelect(selectedValue);
+                         } }/>
+    );
 
-NameSelect.propTypes = {
+});
+
+NameSelectField.propTypes = {
+    fieldKey : PropTypes.string,
+    groupKey : PropTypes.string,
     options: PropTypes.array,
-    value: PropTypes.string,
     onSelect: PropTypes.func,
     type: PropTypes.string,
-    selectProps: PropTypes.object
+    selectProps: PropTypes.object,
+    initialState: PropTypes.shape({
+        value: PropTypes.string,
+    })
 };
 
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params, {
-        onSelect: (selectedValue) => {
-            fireValueChange({value: selectedValue});
-            if (params.onSelect) {
-                params.onSelect(selectedValue);
-            }
-        }
-    });
-}

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -282,7 +282,7 @@ class BasicUI extends PureComponent {
                                 fieldKey='tableName'
                                 type='Table'
                                 options={tableOptions}
-                                value={tableName}
+                                initialState= {{value:tableName}}
                                 onSelect = {(selectedTapTable) => {
                                     this.loadColumns(serviceUrl, schemaName, selectedTapTable);
                                 }}

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {PureComponent} from 'react';
+import React, {PureComponent, memo} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, get, merge, isNil, isArray, cloneDeep, has}from 'lodash';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils.js';
@@ -16,7 +16,7 @@ import {SelectInfo} from '../../tables/SelectInfo.js';
 import {FilterInfo, FILTER_CONDITION_TTIPS} from '../../tables/FilterInfo.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {InputAreaFieldConnected} from '../../ui/InputAreaField.jsx';
-import {fieldGroupConnector} from '../../ui/FieldGroupConnector.jsx';
+import {useFieldGroupConnector} from '../../ui/FieldGroupConnector.jsx';
 const sqlConstraintsCol = {name: 'constraints', idx: 1, type: 'char', width: 10};
 
 import '../../tables/ui/TablePanel.css';
@@ -427,14 +427,17 @@ class ConstraintPanel extends PureComponent {
     }
 }
 
-export const TablePanelConnected = fieldGroupConnector(ConstraintPanel, getProps, null, null);
+export const TablePanelConnected= memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    return (
+        <ConstraintPanel {...viewProps}
+                         onTableChanged= {() => handleOnTableChanged(viewProps, fireValueChange)} />
+    );
+});
 
-function getProps(params, fireValueChange) {
-    return Object.assign({}, params,
-        {
-            onTableChanged: () => handleOnTableChanged(params, fireValueChange)
-        });
-}
+
+
+
 
 /**
  * @summary update row selection (only update selectInfo, not change data in table model)

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -764,14 +764,14 @@ function fieldInit() {
             fieldKey: 'project',
             label: catmaster[0].project,
             value: catmaster[0].project,
-            labelWidth: '100'
+            labelWidth: 100
         },
 
         'catalog': {
             fieldKey: 'catalog',
             label: catmaster[0].subproject[0].value,
             value: catmaster[0].subproject[0].value,
-            labelWidth: '100'
+            labelWidth: 100
         },
         'cattable': {
             fieldKey: 'cattable',

--- a/src/firefly/js/visualize/ui/CatalogTableListField.jsx
+++ b/src/firefly/js/visualize/ui/CatalogTableListField.jsx
@@ -2,10 +2,10 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {PureComponent, Component} from 'react';
+import React, {PureComponent, Component, memo} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, get} from 'lodash';
-import {fieldGroupConnector} from '../../ui/FieldGroupConnector.jsx';
+import {useFieldGroupConnector} from '../../ui/FieldGroupConnector.jsx';
 import './CatalogTableListField.css';
 
 export class CatalogTableView extends Component {
@@ -72,7 +72,20 @@ export class CatalogTableView extends Component {
     }
 }
 
-export const CatalogTableListField = fieldGroupConnector(CatalogTableView, getProps, CatalogTableView.propTypes, null);
+export const CatalogTableListField = memo( (props) => {
+    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    return (
+        <CatalogTableView {...viewProps} onClick= {(ev) => handleOnClick(ev, viewProps, fireValueChange)} />
+    );
+
+});
+
+CatalogTableListField.propTypes= {
+    fieldKey: PropTypes.string,
+    ...CatalogTableView.propTypes,
+};
+
+
 
 CatalogTableView.propTypes = {
     data: PropTypes.array.isRequired,
@@ -86,15 +99,6 @@ CatalogTableView.defaultProps = {
     data: [],
     cols: []
 };
-
-
-function getProps(params, fireValueChange) {
-
-    return Object.assign({}, params,
-        {
-            onClick: (ev) => handleOnClick(ev, params, fireValueChange)
-        });
-}
 
 function handleOnClick(ev, params, fireValueChange) {
     const value = ev.currentTarget.value || ev.currentTarget.attributes['value'].value;

--- a/src/firefly/js/visualize/ui/ColorPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ColorPanelReducer.js
@@ -9,9 +9,9 @@ import ImagePlotCntlr from '../ImagePlotCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {primePlot} from '../PlotViewUtil.js';
 import RangeValues, {STRETCH_LINEAR, STRETCH_ASINH, PERCENTAGE, ABSOLUTE, SIGMA, ZSCALE} from './../RangeValues.js';
+import {clone} from '../../util/WebUtil.js';
 
 
-const clone = (obj,params={}) => Object.assign({},obj,params);
 const cloneWithValue= (field,v) => Object.assign({}, field, {value:v});
 
 


### PR DESCRIPTION
Firefly-51: Make FieldGroupConnector use function components with hooks

  - Created a new field group connector hook
  - converted all `FieldGroup` related components to be functions with hooks
  - updated and cleaned up `NaifidPanel`, it needed a little work
  - updated many propTypes to include shape of initialState
  - removed value from some components props, replaced with initialState:{value}
  - a attempt to better define what should be in initial state
  - hook give a warning is value is passed as prop

_Code to look at_:
 
  - Look at `FieldGroupConnect.jsx`, look at the hook `useFieldGroupConnector`. Don't bother looking at the differences, just look at the new file.
  - All other files are pretty straight forward. You might want to look at a couple of files or focus on the components that you wrote. 
 - Before all code used the HOC `fieldGroupConnector`, now they use the hook `useFieldGroupConnector`. Notice how much easier it is follow how to setup the hook compared to the HOC.
 - @deannaji look at NaifidPanel.jsx.  I had to make some changes, we should discuss it soon.

_to test:_
https://irsawebdev9.ipac.caltech.edu/firefly-51-field-group-with-hooks/firefly/
https://irsawebdev9.ipac.caltech.edu/with-hooks/irsaviewer/

- Check console while testing, look for errors 
- Mostly everything should work as before
 - Critical Stuff:
    - Gator Catalog Search
    - Tap Search
    - Image Search Panel
    - workspace connection
    - naif resolving
