### PR TITLE
IRSA-2015 Add ZTF filtercode to the image display title.

### DIFF
--- a/src/firefly/js/templates/lightcurve/ztf/ZTFPlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/ztf/ZTFPlotRequests.js
@@ -46,7 +46,7 @@ export function getWebPlotRequestViaZTFIbe(tableModel, hlrow, cutoutSize, params
         // flux/value column control this | unless UI has radio button band enabled, put bandName back here to match band
         //const band = `${params.filtercode}`;
 
-        let title = 'ZTF-' + filefracday;
+        let title = 'ZTF-' + filefracday + '-' + filtercode;
 
         const sr = new ServerRequest('ibe_file_retrieve');
         sr.setParam('mission', 'ztf');


### PR DESCRIPTION
Add ZTF filtercode to the image display title.
To test, upload the attached ztf lightcurve table in jira IRSA-2015 (login on irsadev first for ZTF image retrieve):
https://irsawebdev9.ipac.caltech.edu/irsa-2015/irsaviewer/ts.html




