### PR TITLE
DM-18690: implement maximum record limit in TAP query screens

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -64,6 +64,9 @@ lsst.dax.metaservURL = "/api/meta/v1/db/"
 lsst.dax.imgservURL = "/api/image/v1/"
 lsst.dax.imgserv.repository = "DC_W13_Stripe82"
 
+// maximum number of table rows Firefly can support for TAP queries
+__$tap.maxrec.hardlimit = 10000000
+
 environments {
     local {
         BuildType = "Development"

--- a/config/common.prop
+++ b/config/common.prop
@@ -48,4 +48,6 @@ sso.user.profile.url=@sso.user.profile.url@
 
 help.base.url=@__$help.base.url@
 
+tap.maxrec.maxval=@__$tap.maxrec.hardlimit@
+
 visualize.fits.MaxSizeInBytes= @visualize.fits.MaxSizeInBytes@

--- a/src/firefly/html/demo/ffapi-table-test.html
+++ b/src/firefly/html/demo/ffapi-table-test.html
@@ -194,6 +194,7 @@ There are additional information specific to each input field.  Click the top bu
 * @prop {boolean} [showSave=true]
 * @prop {boolean} [showOptionButton=true]
 * @prop {boolean} [showFilterButton=true]
+* @prop {boolean} [showInfoButton=false]
 * @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.
 * @prop {function[]}  [rightButtons]  an array of functions that returns a button-like component laid out on the right side of this table header.
                 </pre>

--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -36,9 +36,6 @@ var options = {
         mergedListPriority: 'Irsa'
     },
     coverage : { // example of using DSS and wise combination for coverage (not that anyone would want to combination)
-    },
-    tables : {
-        showInfoButton: true // info about table : title, table links, etc.
     }
 };
 

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -140,9 +140,12 @@ const defFireflyOptions = {
                 value: 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap' },
             { label: 'GAIA https://gea.esac.esa.int/tap-server/tap',
                 value: 'https://gea.esac.esa.int/tap-server/tap' },
+            { label: 'GAVO http://dc.g-vo.org/tap',
+                value: 'http://dc.g-vo.org/tap'},
             { label: 'MAST https://vao.stsci.edu/CAOMTAP/TapService.aspx',
                 value: 'https://vao.stsci.edu/CAOMTAP/TapService.aspx' }
-        ]
+        ],
+        defaultMaxrec: 50000
     }
 };
 

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -139,6 +139,7 @@ function buildTablePart(llApi) {
      * @prop {boolean} showSave     defaults to true
      * @prop {boolean} showOptionButton    defaults to true
      * @prop {boolean} showFilterButton    defaults to true
+     * @prop {boolean} showInfoButton     defaults to false
      * @prop {boolean} border       defaults to true
      * @prop {boolean} help_id      link to help if applicable
      * @prop {function[]}  leftButtons   an array of functions that returns a button-like component laid out on the left side of this table header.  Function will be called with table's state.

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -237,7 +237,7 @@ function getChanges({tableModel, tablesource, chartId, traceNum}) {
         // colorbar.title is causing hover text display issues in Firefox
         // see https://github.com/plotly/plotly.js/issues/2003
         if (!BrowserInfo.isFirefox()) {
-            if (singleTraceUI()) {
+            if (singleTraceUI() || (data && data.length===1)) {
                 changes[`data.${traceNum}.colorbar.title`] = 'pts';
             } else {
                 changes[`data.${traceNum}.colorbar.title`] = get(data, `${traceNum}.name`, 'pts');

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -233,6 +233,7 @@
  * @prop {boolean} [showPaging=true]    enable/disable paging feature.  When false, all data will be displayed.
  * @prop {boolean} [showSave=true]
  * @prop {boolean} [showFilterButton=true]
+ * @prop {boolean} [showInfoButton=false] when true, shows additional information about table, if available
  * @prop {boolean} [showOptionButton=true]
  * @prop {boolean} [showUnits=true]
  * @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -123,7 +123,7 @@ export class TablePanel extends PureComponent {
     render() {
         const {tableConnector} = this;
         const { selectable, expandable, expandedMode, border, renderers, title, removable, rowHeight, help_id,
-            showToolbar, showTitle, showInfoButton=get(getAppOptions(), 'tables.showInfoButton'),
+            showToolbar, showTitle, showInfoButton,
             showOptionButton, showPaging, showSave, showFilterButton,
             totalRows, showLoading, columns, showUnits, showTypes, showFilters, textView,
             tbl_id, error, startIdx, hlRowIdx, currentPage, pageSize, selectInfo, showMask,
@@ -271,9 +271,9 @@ TablePanel.propTypes = {
     showTitle: PropTypes.bool,
     showPaging: PropTypes.bool,
     showSave: PropTypes.bool,
-    showInfoButton: PropTypes.bool,
     showOptionButton: PropTypes.bool,
     showFilterButton: PropTypes.bool,
+    showInfoButton: PropTypes.bool,
     leftButtons: PropTypes.arrayOf(PropTypes.func),   // an array of functions that returns a button-like component laid out on the left side of this table header.
     rightButtons: PropTypes.arrayOf(PropTypes.func),  // an array of functions that returns a button-like component laid out on the right side of this table header.
     renderers: PropTypes.objectOf(
@@ -293,6 +293,7 @@ TablePanel.defaultProps = {
     showSave: true,
     showOptionButton: true,
     showFilterButton: true,
+    showInfoButton: false,
     selectable: true,
     expandedMode: false,
     expandable: true,

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -49,7 +49,7 @@ export const FormPanel = function (props) {
     const { children, onSuccess, onSubmit, onCancel=dispatchHideDropDown, onError, groupKey,
         action, params, title,
         submitText='Search',cancelText='Cancel', help_id, changeMasking,
-        includeUnmounted=false, extraButtons=[]} = props;
+        includeUnmounted=false, extraWidgets=[]} = props;
     let { style, inputStyle, submitBarStyle, buttonStyle} = props;
 
     inputStyle = Object.assign({
@@ -82,17 +82,7 @@ export const FormPanel = function (props) {
                         />
                         <button style={{display: 'inline-block'}} type='button' className='button std' onClick={onCancel}>{cancelText}</button>
                     </div>
-
-                    {extraButtons && extraButtons.map((e,i,arr)=>{
-                        const {text, onClick, style={}} = e;
-                        return (
-                            <button style={style}
-                                    type='button' className='button std'
-                                    onClick={onClick} key={'extraBtn'+i}>
-                                {text}
-                            </button>
-                        );
-                    })}
+                    {extraWidgets}
                 </div>
                 {help_id && <HelpIcon helpId={help_id} />}
             </div>
@@ -122,9 +112,22 @@ FormPanel.propTypes = {
     help_id: PropTypes.string,
     changeMasking: PropTypes.func,
     includeUnmounted: PropTypes.bool,
-    extraButtons: PropTypes.arrayOf(
-        PropTypes.shape({
-            text: PropTypes.string,
-            onClick: PropTypes.func
-        }))
+    extraWidgets: PropTypes.arrayOf(PropTypes.element)
+};
+
+export function ExtraButton(props) {
+    const {text, onClick, style={}} = props;
+    return (
+        <button style={style}
+                type='button' className='button std'
+                onClick={onClick}>
+            {text}
+        </button>
+    );
+}
+
+ExtraButton.propTypes = {
+    text: PropTypes.string,
+    onClick: PropTypes.func,
+    style: PropTypes.object
 };

--- a/src/firefly/js/ui/tap/Select.jsx
+++ b/src/firefly/js/ui/tap/Select.jsx
@@ -6,6 +6,23 @@ import LOADING from 'html/images/gxt/loading.gif';
 
 import {fieldGroupConnector} from '../FieldGroupConnector';
 
+export const commonSelectStyles = {
+    option: (styles) => (
+        {...styles,
+            color: 'black', // avoid switching to white for selected item
+            height: '100%'
+        }
+    ),
+    singleValue: () => {
+        return {
+            color: 'black',
+            marginLeft: 2,
+            marginRight: 2,
+            maxWidth: 'calc(100% - 8px)',
+            position: 'absolute'
+        };
+    }
+};
 
 export const selectTheme = (theme) => ({
       ...theme,
@@ -78,26 +95,10 @@ function formatGroupLabel(data) {
 }
 
 export function NameSelect({options, value, onSelect, type, selectProps={}}) {
-    const selectStyles = {
-        option: (styles) => (
-            {...styles,
-                color: 'black', // avoid switching to white for selected item
-                height: '100%'
-            }
-        ),
-        valueContainer: (styles) => (
-            { ...styles, height: 50 }),
-        singleValue: () => {
-            return {
-                color: 'black',
-                marginLeft: 2,
-                marginRight: 2,
-                maxWidth: 'calc(100% - 8px)',
-                position: 'absolute'
-            };
-        }
-
-    };
+    const selectStyles = Object.assign({
+            valueContainer: (styles) => (
+                { ...styles, height: 50 }),
+        }, commonSelectStyles);
 
     const placeholder = value ? `${type} <${value}>. Replace...` : `Select ${type}...`;
 

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -4,7 +4,7 @@ import {makeFileRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {doFetchTable, getColumnIdx, sortTableData} from '../../tables/TableUtil.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
-import {hashCode} from '../../util/WebUtil.js';
+import {getProp, hashCode} from '../../util/WebUtil.js';
 
 const qFragment = '/sync?REQUEST=doQuery&LANG=ADQL&';
 export const HeaderFont={fontSize: 12, fontWeight: 'bold', alignItems: 'center'};
@@ -13,6 +13,15 @@ export const  MJD = 'mjd';
 export const  ISO = 'iso';
 
 const tapBrowserComponentKey = 'TAP_BROWSER';
+
+export function getMaxrecHardLimit() {
+    const defaultValue = Number.parseInt(getProp('tap.maxrec.hardlimit'));
+    if (Number.isNaN(defaultValue)) {
+        return 5000000;
+    } else {
+        return defaultValue;
+    }
+}
 
 export function getTapBrowserState() {
     const tapBrowserState = getComponentState(tapBrowserComponentKey);

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
@@ -44,7 +44,6 @@ public class AsyncTapQueryTest extends ConfigTest {
     /**
      * test results based on the constructed TableServerRequest
      */
-    @Ignore  // unable to parse return doc yet.
     @Test
     public void testError() {
         try {


### PR DESCRIPTION
https://jira.lsstcorp.org/browse/DM-18690
Test build: https://irsawebdev9.ipac.caltech.edu/dm-18690_maxrec/firefly/firefly-dev.html?__action=layout.showDropDown&visible=true&view=TAPSearch

"Row Limit"  field is displayed at the bottom of the TAP Search, along with "Search" and "Cancel" buttons. It is propagated to the server and is translated into MAXREC parameter of the search request. We allow to disable it by clearing.

tap.maxrec.hardlimit property (default 10000000) is a config property. If MAXREC is set, it can not exceed this value.
defaultMaxrec is an application property (default 50000 for Firefly). It is the default value for MAXREC parameter.

Other changes:
- Filters are now shown by default in the TAP result tables
- Removed 'tables.showInfoButton' app property and made it a table option instead.
- Fixed Service URL select box style: the text was truncated a bit on the bottom and selected item was shown in white, which was hard to see on light green.

In a followup ticket, we might want to capture and propagate OVERLOAD indicator. It is passed via "results" resource INFO element, and can be displayed as a part of table info. We are currently not capturing INFO elements outside the Table element, but in most cases there is just one resource element with one table in it. In this case it makes sense for the table to store its parent's INFO.
