### PR TITLE
Firefly-44: Make data product display work with ObsCore

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
@@ -156,9 +156,9 @@ public class LockingVisNetwork {
             if (_key != null) {
                 String offStr = "";
                 if (ev.getMax() > 0) {
-                    offStr = " of " + FileUtil.getSizeAsString(ev.getMax());
+                    offStr = " of " + FileUtil.getSizeAsString(ev.getMax(),true);
                 }
-                String messStr = "Retrieved " + FileUtil.getSizeAsString(ev.getCurrent()) + offStr;
+                String messStr = "Retrieved " + FileUtil.getSizeAsString(ev.getCurrent(),true) + offStr;
                 PlotServUtils.updatePlotCreateProgress(_key, _plotId, ProgressStat.PType.DOWNLOADING, messStr);
             }
         }

--- a/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
@@ -697,11 +697,10 @@ public class FileUtil
 
 
 
-    public static String getSizeAsString(long size) {
-        return getSizeAsString(size,false);
-    }
+    public static String getSizeAsString(long size) { return getSizeAsString(size,false, false); }
+    public static String getSizeAsString(long size,boolean truncate) { return getSizeAsString(size,truncate, false); }
 
-    public static String getSizeAsString(long size, boolean verbose) {
+    public static String getSizeAsString(long size, boolean truncate, boolean verbose) {
         String retval= "0";
         String kStr= "K";
         String mStr= "M";
@@ -718,8 +717,13 @@ public class FileUtil
         else if (size >= (1*MEG) && size <  (2*GIG) ) {
             long megs = size / MEG;
             long remain= size % MEG;
-            long decimal = remain / MEG_TENTH;
-            retval= megs +"."+ decimal + mStr;
+            if (truncate) {
+                retval= megs+ mStr;
+            }
+            else {
+                long decimal = remain / MEG_TENTH;
+                retval= megs +"."+ decimal + mStr;
+            }
         }
         else if (size >= (2*GIG) ) {
             long gigs = size / GIG;

--- a/src/firefly/java/edu/caltech/ipac/util/download/Downloader.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/Downloader.java
@@ -67,7 +67,7 @@ public class Downloader {
         String outStr;
         Date startDate = null;
         TimeStats timeStats = null;
-        int informInc = (int) (30* FileUtil.MEG) / BUFFER_SIZE;
+        int informInc = (int) (15* FileUtil.MEG) / BUFFER_SIZE;
         long totalRead = 0;
         boolean elapseIncreased = false;
         long lastElapse = 0;

--- a/src/firefly/js/core/MasterSaga.js
+++ b/src/firefly/js/core/MasterSaga.js
@@ -349,14 +349,15 @@ function startTableTypeWatchersForTable(tbl_id, action, getDefList) {
                 stopProp= stopPropagation;
                 excludeList= union(excludeList, excludes);
                 let abort= false;
-                d.watcher(tbl_id, undefined, ()=> (abort=true), {sharedData, options});
+                const initParams= d.watcher(tbl_id, undefined, ()=> (abort=true), {sharedData, options});
                 if (abort) return;
                 dispatchAddActionWatcher({
                     id:`${TTW_PREFIX}${id}-${tbl_id}`,
                     actions,
                     callback: (action,cancelSelf,params) => {
                         return d.watcher(tbl_id, action, cancelSelf, {...params, sharedData, options});
-                    } } );
+                    },
+                    params:initParams});
             }
         });
     });

--- a/src/firefly/js/metaConvert/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/ObsCoreConverter.js
@@ -1,0 +1,133 @@
+import {get} from 'lodash';
+import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
+import {getCellValue, doFetchTable} from '../tables/TableUtil.js';
+import {getObsCoreAccessURL, getObsCoreProdType} from '../util/VOAnalyzer.js';
+import {
+    findTableCenterColumns,
+    getDataLinkAccessUrls,
+    getObsCoreProdTypeCol,
+    isFormatDataLink,
+    isFormatVoTable
+} from '../util/VOAnalyzer';
+import {makeFileRequest} from '../tables/TableRequestUtil';
+import {ZoomType} from '../visualize/ZoomType.js';
+import {makeWorldPt} from '../visualize/Point.js';
+
+const GIG= 1048576 * 1024;
+
+export function makeObsCoreConverter(table, converterTemplate) {
+    const ret= {...converterTemplate};
+    ret.hasRelatedBands= false;
+
+    const propTypeCol= getObsCoreProdTypeCol(table);
+    if (propTypeCol.enumVals) {
+        const pTypes= propTypeCol.enumVals.split(',');
+        if (pTypes.every( (s) => s.toLocaleLowerCase()==='image' || s.toLocaleLowerCase()==='cube')) {
+            ret.canGrid= true;
+            ret.maxPlots= 8;
+            return ret;
+        }
+    }
+    const filters= get(table, 'request.filters');
+    if (filters) {
+        const fList= filters.split(';');
+        const pTFilter= fList.find( (f) => f.includes(propTypeCol.name) && f.includes('IN'));
+        if (pTFilter) {
+            const inList=  pTFilter.substring( pTFilter.indexOf('(')+1, pTFilter.indexOf(')')).split(',');
+            if (inList.every( (s) => s.toLocaleLowerCase()==='\'image\'' || s.toLocaleLowerCase()==='\'cube\'')) {
+                ret.canGrid= true;
+                ret.maxPlots= 8;
+                return ret;
+            }
+        }
+    }
+
+    ret.canGrid= false;
+    ret.maxPlots= 1;
+
+    return ret;
+}
+
+/**
+ *  Support data the we don't know about
+ * @param table
+ * @param row
+ * @param includeSingle
+ * @param includeStandard
+ * @return {{}}
+ */
+export function makeRequestForObsCore(table, row, includeSingle, includeStandard) {
+
+    const dataSource= getObsCoreAccessURL(table,row);
+    const prodType= (getObsCoreProdType(table,row) || '').toLocaleLowerCase();
+    const canHandleProdType= prodType.includes('image') || prodType.includes('cube');
+    const isVoTable= isFormatVoTable(table, row);
+    const isDataLink= isFormatDataLink(table,row);
+
+    if (!dataSource || !canHandleProdType || (isVoTable && !isDataLink)) return Promise.resolve({});
+
+    let obsCollect= getCellValue(table,row,'obs_collection') || '';
+    const iName= getCellValue(table,row,'instrument_name') || '';
+    const obsId= getCellValue(table,row,'obs_id') || '';
+    if (obsCollect===iName) obsCollect= '';
+
+    const titleStr= `${obsCollect?obsCollect+', ':''}${iName?iName+', ':''}${obsId}`;
+
+    const cen= findTableCenterColumns(table);
+    const positionWP= cen && makeWorldPt(getCellValue(table,row,cen.lonCol), getCellValue(table,row,cen.latCol), cen.csys);
+
+    if (isDataLink) {
+        const tableReq= makeFileRequest('no title', dataSource, { startIdx : 0, pageSize : 1000});
+
+        return doFetchTable(tableReq).then(
+            (datalinkTable) => {
+                const listOfUrls= getDataLinkAccessUrls(table, datalinkTable, 'fits', GIG);
+                let idx= listOfUrls.findIndex( (item) => item.semantics.includes('this'));
+                if (idx<0) idx= 0;
+                return (listOfUrls.length) ? makeRequestForObsCoreItem(listOfUrls[idx].url,positionWP,titleStr,includeSingle,includeStandard) : {};
+            }
+        ).catch(
+            (reason) => {
+                console.warn(`Failed to catalog plot data: ${reason}`, reason);
+            }
+        );
+
+    }
+    else {
+        return Promise.resolve(makeRequestForObsCoreItem(dataSource,positionWP,titleStr,includeSingle,includeStandard));
+    }
+}
+
+function makeRequestForObsCoreItem(dataSource, positionWP, titleStr, includeSingle, includeStandard) {
+    const retval= {};
+    if (includeSingle) {
+        retval.single= makeObsCoreRequest(dataSource,positionWP, titleStr);
+    }
+
+    if (includeStandard) {
+        retval.standard= [makeObsCoreRequest(dataSource,positionWP, titleStr)];
+        retval.highlightPlotId= retval.standard[0].getPlotId();
+    }
+    return retval;
+}
+
+
+function makeObsCoreRequest(dataSource, positionWP, titleStr) {
+    if (!dataSource) return null;
+
+    const r = WebPlotRequest.makeURLPlotRequest(dataSource, 'Fits Image');
+    r.setZoomType(ZoomType.FULL_SCREEN);
+    if (titleStr.length>7) {
+        r.setTitleOptions(TitleOptions.NONE);
+        r.setTitle(titleStr);
+    }
+    else {
+        r.setTitleOptions(TitleOptions.FILE_NAME);
+    }
+    r.setPlotId(dataSource);
+    if (positionWP) r.setOverlayPosition(positionWP);
+
+    return r;
+}
+
+

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -86,13 +86,14 @@ export const computePlotId= (plotIdRoot ,plotIdx) => `${plotIdRoot}-row-${plotId
  */
 export function findGridTableRows(table,maxRows, plotIdRoot) {
 
-    const {startIdx, endIdx, highlightedRow}= getTblInfo(table, maxRows);
+    const {startIdx, endIdx, hlRowIdx}= getTblInfo(table, maxRows);
 
     let j= 0;
     const retval= [];
 
     for(let i=startIdx; (i<endIdx );i++) {
-        retval[j++] = {plotId: computePlotId(plotIdRoot, i), row: i, highlight: i === highlightedRow};
+        retval[j] = {plotId: computePlotId(plotIdRoot, i), row: i, highlight: j === hlRowIdx};
+        j++;
     }
     return retval;
 }

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -169,6 +169,7 @@ export const PlotAttribute= {
     MINIMAL_READOUT : 'MINIMAL_READOUT',
 
     TABLE_ROW : 'TABLE_ROW',
+    TABLE_ID : 'TABLE_ID',
 
 
     UNIQUE_KEY : 'UNIQUE_KEY'

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -150,6 +150,7 @@ const C= {
     PLOT_ID : 'plotId',
     OVERLAY_IDS: 'PredefinedOverlayIds',
     RELATED_TABLE_ROW : 'RELATED_TABLE_ROW',
+    RELATED_TABLE_ID : 'RELATED_TABLE_ID',
     HIPS_ROOT_URL: 'hipsRootUrl',
     HIPS_SURVEYS_ID: 'hipsSurveysId',
 
@@ -1293,6 +1294,11 @@ export class WebPlotRequest extends ServerRequest {
     setRelatedTableRow(id) { this.setParam(C.RELATED_TABLE_ROW,id); }
 
     getRelatedTableRow() { return this.getIntParam(C.RELATED_TABLE_ROW,-1); }
+
+    setRelatedTableId(id) { this.setParam(C.RELATED_TABLE_ID,id); }
+
+    getRelatedTableId() { return this.getParam(C.RELATED_TABLE_ID); }
+
 
     setDownloadFileNameRoot(nameRoot) { this.setParam(C.DOWNLOAD_FILENAME_ROOT, nameRoot); }
 

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -102,7 +102,7 @@ export function watchCatalogs(tbl_id, action, cancelSelf, params) {
 
         case ImagePlotCntlr.PLOT_HIPS:
         case ImagePlotCntlr.PLOT_IMAGE:
-            attachToCatalog(tbl_id, payload.pvNewPlotInfoAry);
+            attachToCatalog(tbl_id, payload);
             break;
     }
     return {tableManaged:true};
@@ -224,10 +224,13 @@ function updateDrawingLayer(tbl_id, title, tableData, tableMeta, tableRequest,
     }
 }
 
-function attachToCatalog(tbl_id, pvNewPlotInfoAry=[]) {
+function attachToCatalog(tbl_id, payload) {
+    const {pvNewPlotInfoAry=[], wpRequest, wpRequestAry} = payload;
     const dl= getDrawLayerById(dlRoot(), tbl_id);
     if (!dl) return;
-    pvNewPlotInfoAry.forEach( (info) => {
+    pvNewPlotInfoAry.forEach( (info, idx) => {
+        const r= wpRequest || wpRequestAry[idx];
+        if (!r || r.getRelatedTableId()===tbl_id) return;
         dispatchAttachLayerToPlot(dl.drawLayerId, info.plotId);
         const pv= getPlotViewById(visRoot(), info.plotId);
         const pvSubGroup= get(pv, 'drawingSubGroupId');

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -408,6 +408,7 @@ function makePlot(wpInit,plotId, attributes) {
     plot.title= makePostPlotTitle(plot,r);
     if (r.isMinimalReadout()) plot.attributes[PlotAttribute.MINIMAL_READOUT]= true;
     if (r.getRelatedTableRow()>-1) plot.attributes[PlotAttribute.TABLE_ROW]= r.getRelatedTableRow();
+    if (r.getRelatedTableId()) plot.attributes[PlotAttribute.TABLE_ID]= r.getRelatedTableId();
     Object.assign(plot.attributes,attributes);
     return plot;
 }

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
@@ -64,24 +64,25 @@ export function ImageMetaDataToolbarView({activePlotId, viewerId, viewerPlotIds=
         };
     }
     const showThreeColorButton= converter.threeColor && viewer.layoutDetail!==GRID_FULL && !(viewerPlotIds[0].includes(GRID_FULL.toLowerCase()));
-    const showPager= activeTable && viewer.layoutDetail===GRID_FULL;
+    const showPager= activeTable && converter.canGrid && viewer.layoutDetail===GRID_FULL;
+    const showMultiImageOps= converter.canGrid || converter.hasRelatedBands;
 
 
 
     return (
         <div style={toolsStyle}>
             <div style={{whiteSpace: 'nowrap'}}>
-                <ToolbarButton icon={ONE} tip={'Show single image at full size'}
+                {showMultiImageOps && <ToolbarButton icon={ONE} tip={'Show single image at full size'}
                                imageStyle={{width:24,height:24, flex: '0 0 auto'}}
                                enabled={true} visible={true}
                                horizontal={true}
-                               onClick={() => handleViewerLayout(viewerId,SINGLE)}/>
+                               onClick={() => handleViewerLayout(viewerId,SINGLE)}/>}
 
-                <ToolbarButton icon={FULL_GRID} tip={'Show full grid'}
+                {converter.canGrid && <ToolbarButton icon={FULL_GRID} tip={'Show full grid'}
                                enabled={true} visible={true} horizontal={true}
                                imageStyle={{width:24,height:24, flex: '0 0 auto'}}
                                additionalStyle={{marginLeft: 5}}
-                               onClick={() => handleViewerLayout(viewerId,'grid',GRID_FULL)}/>
+                               onClick={() => handleViewerLayout(viewerId,'grid',GRID_FULL)}/>}
 
                 {converter.hasRelatedBands  &&
                             <ToolbarButton icon={GRID_GROUP} tip={'Show all as tiles'}
@@ -107,7 +108,7 @@ export function ImageMetaDataToolbarView({activePlotId, viewerId, viewerPlotIds=
                                  onClick={() => dispatchChangeActivePlotView(viewerPlotIds[nextIdx])} />
                 }
             </div>
-            <WcsMatchOptions activePlotId={activePlotId} wcsMatchType={wcsMatchType} />
+            {showMultiImageOps && <WcsMatchOptions activePlotId={activePlotId} wcsMatchType={wcsMatchType} />}
             {showPager && <ImagePager pageSize={converter.maxPlots} tbl_id={activeTable.tbl_id} />}
             {handleInlineTools && <InlineRightToolbarWrapper visRoot={vr} pv={pv} dlAry={pvDlAry} />}
         </div>

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -48,7 +48,8 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
     }
     const onTabSelect = (idx, id) => dispatchUpdateLayoutInfo({images:{selectedTab:id}});
     const table= getTblById(metaDataTableId);
-    const metaTitle= get(table,'tableMeta.title')  || 'Image Meta Data';
+    const title= get(table,'title', '');
+    const metaTitle= `Data Product${title?': ' : ''}${title}`;
 
 
     // showCoverage= true; // todo - let the application control is coverage is visible
@@ -86,7 +87,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
 
     }
     else {
-        return <div>todo</div>;
+        return <div/>;
     }
 }
 
@@ -191,14 +192,12 @@ function handleNewTable(layoutInfo, action) {
     const isMeta = isMetaDataTable(tbl_id);
     
     if ((isMeta || isCatalog(tbl_id)) && showTables ) {
-        if (!showFits) {
-            // only show coverage if there are not images or coverage is showing
-            showFits= shouldShowFits();
-            coverageLockedOn= !showFits||coverageLockedOn;
-            selectedTab = 'coverage';
-            showCoverage = coverageLockedOn;
-            showImages = true;
-        }
+        if (!showFits) selectedTab = 'coverage';
+        showFits= showFits || shouldShowFits();
+        // coverageLockedOn= !showFits||coverageLockedOn;
+        coverageLockedOn= true;
+        showCoverage = coverageLockedOn;
+        showImages = true;
     }
     if (isMeta && showTables) {
         showImages = true;
@@ -219,7 +218,7 @@ function onActiveTable (layoutInfo, action) {
 
     if (!tbl_id) {
         images = {showMeta: false, showCoverage: false, showFits, metaDataTableId: null};
-        return smartMerge(layoutInfo, {images, showImages:showFits, coverageLockedOn:false});
+        return smartMerge(layoutInfo, {images, showImages:showFits, coverageLockedOn:true});
     }
 
     const tblGroup= findGroupByTblId(tbl_id);
@@ -232,12 +231,12 @@ function onActiveTable (layoutInfo, action) {
     const anyHasCatalog= hasCatalogTable(tblList);
     const anyHasMeta= hasMetaTable(tblList);
 
-    if (coverageLockedOn) {
-        coverageLockedOn= anyHasCatalog || anyHasMeta;
-    }
+    // if (coverageLockedOn) {
+    //     coverageLockedOn= anyHasCatalog || anyHasMeta;
+    // }
 
     if (anyHasCatalog || anyHasMeta) {
-        showCoverage = coverageLockedOn;
+        showCoverage = true;
         showImages = true;
     } else {
         showCoverage = false;
@@ -258,11 +257,12 @@ function onActiveTable (layoutInfo, action) {
 function onPlotDelete(layoutInfo, action) {
     const {images={}}  = layoutInfo;
     let {showImages} = layoutInfo;
-    let {coverageLockedOn} = images;
+    let {coverageLockedOn, metaDataTableId} = images;
     const showFits = shouldShowFits();
     if (!get(visRoot(), 'plotViewAry.length', 0)) {
-        coverageLockedOn = false;
-        showImages = false;
+        coverageLockedOn = true;
+        showImages= metaDataTableId ? true : false;
+        // showImages = false;
     }
     return smartMerge(layoutInfo, {showImages, images:{coverageLockedOn, showFits}});
 }
@@ -276,10 +276,12 @@ function onNewImage(layoutInfo, action) {
         // select meta tab when new images are added to meta image group.
         selectedTab = 'meta';
         showMeta = true;
+        coverageLockedOn = true;
     } else if (viewerId === DEFAULT_FITS_VIEWER_ID) {
         // select fits tab when new images are added to default group.
         selectedTab = 'fits';
         showFits = true;
+        coverageLockedOn = true;
     } else {
         // why lock coverage here?
         coverageLockedOn = true;


### PR DESCRIPTION
Firefly-44: Make data product display work with ObsCore

  - Recognize ObsCore tables
  - Show products if it is a FITS image and less than 1 GIG
  - Put in simple support for data link: only access_url so far
  - Data link tries show the #this semantics image if available
  - Give option to show grid of images when filtered down to image and/or cube


_To test:_
https://irsawebdev9.ipac.caltech.edu/firefly-44-obs-core-meta/firefly/firefly-dev.html

Load a ObsCore table: 
 - TAP Searches => **Tap Service**: CDAC or MAST => **Schema**: ivoa => **Table**: ivoa.obscore
 - Spacial search around small area e.g. 200 arcsec

What happens:
- When you click on a row with the data produce image or a cube it will attempt to load the image
- For CDAC it will do a Data Link indirection and if possible load the `#this` image.