### PR TITLE
Firefly-61: Headers are not passed for every cube plane, show correct cube headers

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotBuilder.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotBuilder.java
@@ -3,8 +3,8 @@
  */
 package edu.caltech.ipac.firefly.server.visualize;
 
-import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.visualize.imageretrieve.FileRetriever;
 import edu.caltech.ipac.firefly.server.visualize.imageretrieve.ImageFileRetrieverFactory;
@@ -13,20 +13,18 @@ import edu.caltech.ipac.firefly.visualize.PlotState;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.visualize.plot.ActiveFitsReadGroup;
-import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
-import edu.caltech.ipac.visualize.plot.plotdata.GeomException;
 import edu.caltech.ipac.visualize.plot.ImagePlot;
 import edu.caltech.ipac.visualize.plot.RangeValues;
+import edu.caltech.ipac.visualize.plot.plotdata.GeomException;
 import nom.tam.fits.FitsException;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Arrays;
 
 import static edu.caltech.ipac.firefly.visualize.Band.*;
 
@@ -126,36 +124,37 @@ public class ImagePlotBuilder {
         return new Results(pInfo,zoomChoice, findElapse,readElapse);
     }
 
-    static Results buildFromFile(WebPlotRequest request,
-                                 FileInfo fileData,
-                                 FitsRead fitsRead,
-                                 int imageIdx,
-                                 PlotState state) throws Exception {
-
-
-        ImagePlotInfo pInfo[];
-        // ------------ read the FITS files
-        long readStart = System.currentTimeMillis();
-        PlotServUtils.updatePlotCreateProgress(request, ProgressStat.PType.CREATING, PlotServUtils.CREATING_MSG);
-        long readElapse = System.currentTimeMillis() - readStart;
-
-
-        Map<Band, FileReadInfo[]> readInfoMap = WebPlotReader.processFitsRead(fileData,request,fitsRead,imageIdx);
-
-        Map<Band,WebPlotRequest> requestMap= new HashMap<>(1);
-        requestMap.put(Band.NO_BAND,request);
-
-        // ------------ make the ImagePlot(s)
-        ZoomChoice zoomChoice = makeZoomChoice(requestMap, readInfoMap);
-        if (state == null) {
-            pInfo = makeNewPlots(readInfoMap, requestMap, zoomChoice, PlotState.MultiImageAction.USE_FIRST, false);
-        } else {
-            pInfo = new ImagePlotInfo[1];
-            pInfo[0] = recreatePlot(state, readInfoMap, zoomChoice);
-        }
-
-        return new Results(pInfo,zoomChoice, 0,readElapse);
-    }
+// Unused code commented out 3/5/2019 - keep around for awhile
+//    static Results buildFromFile(WebPlotRequest request,
+//                                 FileInfo fileData,
+//                                 FitsRead fitsRead,
+//                                 int imageIdx,
+//                                 PlotState state) throws Exception {
+//
+//
+//        ImagePlotInfo pInfo[];
+//        // ------------ read the FITS files
+//        long readStart = System.currentTimeMillis();
+//        PlotServUtils.updatePlotCreateProgress(request, ProgressStat.PType.CREATING, PlotServUtils.CREATING_MSG);
+//        long readElapse = System.currentTimeMillis() - readStart;
+//
+//
+//        Map<Band, FileReadInfo[]> readInfoMap = WebPlotReader.processFitsRead(fileData,request,fitsRead,imageIdx);
+//
+//        Map<Band,WebPlotRequest> requestMap= new HashMap<>(1);
+//        requestMap.put(Band.NO_BAND,request);
+//
+//        // ------------ make the ImagePlot(s)
+//        ZoomChoice zoomChoice = makeZoomChoice(requestMap, readInfoMap);
+//        if (state == null) {
+//            pInfo = makeNewPlots(readInfoMap, requestMap, zoomChoice, PlotState.MultiImageAction.USE_FIRST, false);
+//        } else {
+//            pInfo = new ImagePlotInfo[1];
+//            pInfo[0] = recreatePlot(state, readInfoMap, zoomChoice);
+//        }
+//
+//        return new Results(pInfo,zoomChoice, 0,readElapse);
+//    }
 
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -54,12 +54,15 @@ public class ImagePlotCreator {
          for(int i= 0; (i<readAry.length); i++)  {
              readInfo= readAry[i];
              WebPlotRequest req= stateAry[i].getWebPlotRequest();
-             if (readAry.length>3) {
-                 PlotServUtils.updatePlotCreateProgress(req, ProgressStat.PType.CREATING,
-                                              PlotServUtils.CREATING_MSG+": "+ (i+1)+" of "+readAry.length);
-             }
-             else  {
-                 PlotServUtils.updatePlotCreateProgress(req, ProgressStat.PType.CREATING, PlotServUtils.CREATING_MSG);
+
+             boolean notify= readAry.length<5 || i % ((readAry.length/5)+1)==0;
+             if (notify) {
+                 if (readAry.length > 3) {
+                     PlotServUtils.updatePlotCreateProgress(req, ProgressStat.PType.CREATING,
+                             PlotServUtils.CREATING_MSG + ": " + (i + 1) + " of " + readAry.length);
+                 } else {
+                     PlotServUtils.updatePlotCreateProgress(req, ProgressStat.PType.CREATING, PlotServUtils.CREATING_MSG);
+                 }
              }
              ActiveFitsReadGroup frGroup= new ActiveFitsReadGroup();
              frGroup.setFitsRead(readInfo.getBand(),readInfo.getFitsRead());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -55,7 +55,7 @@ public class ImagePlotCreator {
              readInfo= readAry[i];
              WebPlotRequest req= stateAry[i].getWebPlotRequest();
 
-             boolean notify= readAry.length<5 || i % ((readAry.length/5)+1)==0;
+             boolean notify= readAry.length<5 || i % ((readAry.length/10)+1)==0;
              if (notify) {
                  if (readAry.length > 3) {
                      PlotServUtils.updatePlotCreateProgress(req, ProgressStat.PType.CREATING,

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
@@ -4,9 +4,9 @@
 package edu.caltech.ipac.firefly.server.visualize;
 
 import edu.caltech.ipac.firefly.data.FileInfo;
-import edu.caltech.ipac.firefly.server.visualize.fitseval.FitsDataEval;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.visualize.fitseval.FitsDataEval;
 import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.util.FileUtil;
@@ -17,7 +17,6 @@ import nom.tam.fits.FitsException;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -48,48 +47,49 @@ public class WebPlotReader {
     }
 
 
-    /**
-     * @param fd file data
-     * @param req WebPlotRequest from the search, usually the first
-     * @return the ReadInfo[] object
-     * @throws java.io.IOException        any io problem
-     * @throws nom.tam.fits.FitsException problem reading the fits file
-     * @throws edu.caltech.ipac.util.download.FailedRequestException any other problem
-     * @throws GeomException problem reprojecting
-     */
-    public static Map<Band, FileReadInfo[]> processFitsRead(FileInfo fd, WebPlotRequest req, FitsRead fitsRead, int imageIdx)
-            throws IOException,
-                   FitsException,
-                   FailedRequestException,
-                   GeomException {
-
-        FileReadInfo retval;
-
-        File originalFile = fd.getFile();
-        String uploadedName= null;
-        if (ServerContext.isInUploadDir(originalFile) || originalFile.getName().startsWith("upload_")) {
-            uploadedName= fd.getDesc();
-        }
-
-        ModFileWriter modFileWriter= null;
-        if (req!=null) {
-            WebPlotPipeline.PipelineRet pipeRet= WebPlotPipeline.applyPipeline(req, fitsRead, imageIdx, Band.NO_BAND, originalFile);
-            if (pipeRet.modFileWriter!=null && fitsRead!=pipeRet.fr) {
-                modFileWriter= pipeRet.modFileWriter;
-                FitsCacher.addFitsReadToCache(modFileWriter.getTargetFile(), new FitsRead[]{pipeRet.fr});
-                fitsRead= pipeRet.fr;
-            }
-        }
-        modFileWriter= checkUnzip(imageIdx,Band.NO_BAND,originalFile, modFileWriter);
-
-        retval= new FileReadInfo(originalFile, fitsRead, Band.NO_BAND, imageIdx,
-                                 fd.getDesc(), uploadedName, null, modFileWriter);
-
-        Map<Band, FileReadInfo[]> retMap= new HashMap<>(1);
-        retMap.put(Band.NO_BAND, new FileReadInfo[] {retval});
-
-        return retMap;
-    }
+// Unused code commented out 3/5/2019 - keep around for awhile
+//    /**
+//     * @param fd file data
+//     * @param req WebPlotRequest from the search, usually the first
+//     * @return the ReadInfo[] object
+//     * @throws java.io.IOException        any io problem
+//     * @throws nom.tam.fits.FitsException problem reading the fits file
+//     * @throws edu.caltech.ipac.util.download.FailedRequestException any other problem
+//     * @throws GeomException problem reprojecting
+//     */
+//    public static Map<Band, FileReadInfo[]> processFitsRead(FileInfo fd, WebPlotRequest req, FitsRead fitsRead, int imageIdx)
+//            throws IOException,
+//                   FitsException,
+//                   FailedRequestException,
+//                   GeomException {
+//
+//        FileReadInfo retval;
+//
+//        File originalFile = fd.getFile();
+//        String uploadedName= null;
+//        if (ServerContext.isInUploadDir(originalFile) || originalFile.getName().startsWith("upload_")) {
+//            uploadedName= fd.getDesc();
+//        }
+//
+//        ModFileWriter modFileWriter= null;
+//        if (req!=null) {
+//            WebPlotPipeline.PipelineRet pipeRet= WebPlotPipeline.applyPipeline(req, fitsRead, imageIdx, Band.NO_BAND, originalFile);
+//            if (pipeRet.modFileWriter!=null && fitsRead!=pipeRet.fr) {
+//                modFileWriter= pipeRet.modFileWriter;
+//                FitsCacher.addFitsReadToCache(modFileWriter.getTargetFile(), new FitsRead[]{pipeRet.fr});
+//                fitsRead= pipeRet.fr;
+//            }
+//        }
+//        modFileWriter= checkUnzip(imageIdx,Band.NO_BAND,originalFile, modFileWriter);
+//
+//        retval= new FileReadInfo(originalFile, fitsRead, Band.NO_BAND, imageIdx,
+//                                 fd.getDesc(), uploadedName, null, modFileWriter);
+//
+//        Map<Band, FileReadInfo[]> retMap= new HashMap<>(1);
+//        retMap.put(Band.NO_BAND, new FileReadInfo[] {retval});
+//
+//        return retMap;
+//    }
 
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotResultSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotResultSerializer.java
@@ -79,6 +79,7 @@ public class WebPlotResultSerializer {
                     ary.add(VisJsonSerializer.serializeWebPlotInitializerDeep(wpInit));
                 }
                 map.put(WebPlotResult.PLOT_CREATE, ary);
+                map.put(WebPlotResult.PLOT_CREATE_HEADER, VisJsonSerializer.serializeWebPlotHeaderInitializer(cr.getInitHeader()));
             }
             if (res.containsKey(WebPlotResult.DATA_HIST_IMAGE_URL)) {
                 String s= res.getStringResult(WebPlotResult.DATA_HIST_IMAGE_URL);

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/BandState.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/BandState.java
@@ -149,6 +149,25 @@ public class BandState implements Serializable {
 
     public void setUploadedFileName(String uploadFile) { uploadFileNameStr = uploadFile; }
     public String getUploadedFileName() { return uploadFileNameStr; }
+    
+    public BandState makeCopy() {
+        BandState b= new BandState();
+        b.workingFitsFileStr = this.workingFitsFileStr;
+        b.originalFitsFileStr = this.originalFitsFileStr;
+        b.uploadFileNameStr = this.uploadFileNameStr;
+        b.imageIdx = this.imageIdx;
+        b.originalImageIdx = this.originalImageIdx;
+
+        b.plotRequestSerialize = this.plotRequestSerialize;
+        b.rangeValuesSerialize = this.rangeValuesSerialize;
+        b.directFileAcessData= this.directFileAcessData;
+        b.bandVisible = this.bandVisible;
+        b.multiImageFile = this.multiImageFile;
+        b.tileCompress = this.tileCompress;
+        b.cubeCnt = this.cubeCnt;
+        b.cubePlaneNumber = this.cubePlaneNumber;
+        return b;
+    }
 
 
     public String toString() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/ClientFitsHeader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/ClientFitsHeader.java
@@ -47,10 +47,8 @@ public class ClientFitsHeader implements Serializable, Iterable<String> {
 
     public ClientFitsHeader(int planeNumber,
                             int bitpix,
-                            int naxis,
                             int naxis1,
                             int naxis2,
-                            int naxis3,
                             double cdelt2,
                             double bscale,
                             double bzero,
@@ -58,10 +56,8 @@ public class ClientFitsHeader implements Serializable, Iterable<String> {
                             long dataOffset) {
         _headers.put(PLANE_NUMBER,planeNumber+"");
         _headers.put(BITPIX,      bitpix+"");
-        _headers.put(NAXIS,       naxis+"");
         _headers.put(NAXIS1,      naxis1+"");
         _headers.put(NAXIS2,      naxis2+"");
-        _headers.put(NAXIS3,      naxis3+"");
         _headers.put(CDELT2,      cdelt2+"");
         _headers.put(BSCALE,      bscale+"");
         _headers.put(BZERO,       bzero+"");
@@ -81,10 +77,8 @@ public class ClientFitsHeader implements Serializable, Iterable<String> {
 
     public int getPlaneNumber() { return getIntHeader(PLANE_NUMBER); }
     public int getBixpix() { return getIntHeader(BITPIX); }
-    public int getNaxis() { return getIntHeader(NAXIS); }
     public int getNaxis1() { return getIntHeader(NAXIS1); }
     public int getNaxis2() { return getIntHeader(NAXIS2); }
-    public int getNaxis3() { return getIntHeader(NAXIS3); }
     public double getCDelt2() { return getDoubleHeader(CDELT2); }
     public double getBScale() { return getDoubleHeader(BSCALE); }
     public double getBZero() { return getDoubleHeader(BZERO); }

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/CreatorResults.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/CreatorResults.java
@@ -20,28 +20,32 @@ public class CreatorResults implements Iterable<WebPlotInitializer>, Serializabl
 
     private final static String SPLIT_TOKEN= "--CreatorResults--";
 
-    WebPlotInitializer _wpInit[];
+    private WebPlotHeaderInitializer wpHeader;
+    private WebPlotInitializer[] wpInit;
 
-    public CreatorResults(WebPlotInitializer wpInit[]) {
-        _wpInit= wpInit;
+    public CreatorResults(WebPlotHeaderInitializer wpHeader, WebPlotInitializer[] wpInit) {
+        this.wpInit = wpInit;
+        this.wpHeader= wpHeader;
     }
 
     public Iterator<WebPlotInitializer> iterator() {
-        return Arrays.asList(_wpInit).iterator();
+        return Arrays.asList(wpInit).iterator();
     }
+
+    public WebPlotHeaderInitializer  getInitHeader() { return wpHeader; }
 
     public WebPlotInitializer[] getInitializers() {
-        return _wpInit;
+        return wpInit;
     }
 
-    public int size() { return _wpInit.length; }
+    public int size() { return wpInit.length; }
 
     @Override
     public String toString() {
         StringBuilder sb= new StringBuilder(1000);
-        for(int i= 0; (i<_wpInit.length);i++) {
-            sb.append(_wpInit[i]);
-            if (i<_wpInit.length-1) sb.append(SPLIT_TOKEN);
+        for(int i = 0; (i< wpInit.length); i++) {
+            sb.append(wpInit[i]);
+            if (i< wpInit.length-1) sb.append(SPLIT_TOKEN);
         }
         return sb.toString();
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/PlotState.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/PlotState.java
@@ -318,6 +318,27 @@ public class PlotState {
         return sb.toString();
     }
 
+    public PlotState makeCopy() {
+        PlotState p= new PlotState();
+        p.multiImage= this.multiImage;
+        p.ctxStr= this.ctxStr;
+        p.newPlot= this.newPlot;
+        p.zoomLevel= this.zoomLevel;
+        p.threeColor= this.threeColor;
+        p.colorTableId= this.colorTableId;
+        p.rotationType= this.rotationType;
+        p.rotaNorthType = this.rotaNorthType;
+        p.flippedY = this.flippedY;
+        p.rotationAngle = this.rotationAngle;
+        p.ops = this.ops;
+        for(int i= 0; (i< bandStateAry.length); i++) {
+            if (this.bandStateAry[i]!=null) {
+                p.bandStateAry[i]= this.bandStateAry[i].makeCopy();
+            }
+        }
+        return p;
+    }
+
 
     public boolean equals(Object o) {
         boolean retval= false;

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
@@ -1,0 +1,43 @@
+package edu.caltech.ipac.firefly.visualize;
+/**
+ * User: roby
+ * Date: 2019-04-09
+ * Time: 11:10
+ */
+
+
+/**
+ * @author Trey Roby
+ */
+public class WebPlotHeaderInitializer {
+
+    private String workingFitsFileStr;
+    private String originalFitsFileStr;
+    private String uploadFileNameStr;
+    private String dataDesc;
+    private boolean threeColor;
+    private WebPlotRequest request;
+
+    public WebPlotHeaderInitializer(String originalFitsFileStr, String workingFitsFileStr,
+                                    String uploadFileNameStr, String dataDesc,
+                                    boolean threeColor, WebPlotRequest request) {
+        this.originalFitsFileStr= originalFitsFileStr;
+        this.workingFitsFileStr= workingFitsFileStr;
+        this.uploadFileNameStr = uploadFileNameStr;
+        this.threeColor = threeColor;
+        this.request = request;
+        this.dataDesc= dataDesc;
+    }
+
+    public String getWorkingFitsFileStr() { return workingFitsFileStr; }
+
+    public String getOriginalFitsFileStr() { return originalFitsFileStr; }
+
+    public boolean isThreeColor() { return threeColor; }
+
+    public String getUploadFileNameStr() { return uploadFileNameStr; }
+
+    public String getDataDesc() { return dataDesc; }
+
+    public WebPlotRequest getRequest() { return request; }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
@@ -29,7 +29,7 @@ public class WebPlotInitializer {
     private WebFitsData   _fitsData[];
     private String        _desc;
     private String        _dataDesc;
-    private Header headerAry[];
+    private Header headerAry[]; //passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
     private transient List<RelatedData> relatedData;
 //    private transient Projection _projection;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResult.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResult.java
@@ -20,6 +20,7 @@ public class WebPlotResult implements Iterable<Map.Entry<String,Object>> {
 
 
     public static final String PLOT_CREATE = "PlotCreate";
+    public static final String PLOT_CREATE_HEADER = "PlotCreateHeader";
     public static final String PLOT_STATE = "PlotState";
     public static final String INSERT_BAND_INIT = "InsertBand";
     public static final String STRING= "String";

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
@@ -132,7 +132,7 @@ public class PixelValue {
 	    System.out.println("Fetching value for x = " + x + "  y = " + y);
 	    try
 	    {
-        ClientFitsHeader miniHeader= new ClientFitsHeader(plane_number,bitpix,naxis,naxis1,naxis2,naxis3,
+        ClientFitsHeader miniHeader= new ClientFitsHeader(plane_number,bitpix,naxis1,naxis2,
                                                  cdelt2,bscale,bzero,blank_value,data_offset);
 		pixel_data = PixelValue.pixelVal(fits_file, x, y, miniHeader);
 		fits_file.close();
@@ -168,10 +168,8 @@ public class PixelValue {
 
     int plane_number   = header.getPlaneNumber();
     int bitpix         = header.getBixpix();
-    int naxis          = header.getNaxis();
     int naxis1         = header.getNaxis1();
     int naxis2         = header.getNaxis2();
-    int naxis3         = header.getNaxis3();
     double cdelt2      = header.getCDelt2();
     double bscale      = header.getBScale();
     double bzero       = header.getBZero();

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/output/PlotOutput.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/output/PlotOutput.java
@@ -296,7 +296,8 @@ public class PlotOutput {
         int width= defTileSize;
         int height;
         File file;
-        BufferedImage defImage= createImage(defTileSize,defTileSize, requiresTransparency?Quality.HIGH:Quality.MEDIUM);
+        BufferedImage defImage= null;
+        if (createOnly>0) defImage= createImage(defTileSize,defTileSize, requiresTransparency?Quality.HIGH:Quality.MEDIUM);
 
         ImageDataGroup imageDataGrp= plot.getImageData();
         List<TileFileInfo> retList= new ArrayList<TileFileInfo>(imageDataGrp.size());
@@ -309,12 +310,13 @@ public class PlotOutput {
 
         for(int x= 0; (x<screenWidth);  x+=width) {
             for(int y= 0; (y<screenHeight);  y+=height) {
+                image= null;
                 width= ((x+defTileSize) > screenWidth-defTileSize) ? screenWidth - x : defTileSize;
                 height= ((y+defTileSize) > screenHeight-defTileSize) ? screenHeight - y : defTileSize;
                 if (width==defTileSize && height==defTileSize) {
                     image= defImage;
                 }
-                else {
+                else if (createTile) {
                     image= createImage(width,height, requiresTransparency?Quality.HIGH:Quality.MEDIUM);
                 }
                 file= getTileFile(dir,baseName,x,y,ext);

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -170,20 +170,20 @@ public class FitsReadUtil {
 
         Header newHeader = cloneHeaderFrom(header);
 
-        newHeader.deleteKey("BITPIX");
-        newHeader.setBitpix(-32);
-        newHeader.deleteKey("NAXIS");
-        newHeader.setNaxes(2);
-        newHeader.deleteKey("NAXIS1");
-        newHeader.setNaxis(1, pixels[0].length);
-        newHeader.deleteKey("NAXIS2");
-        newHeader.setNaxis(2, pixels.length);
+//        newHeader.deleteKey("BITPIX");
+//        newHeader.setBitpix(-32);
+//        newHeader.deleteKey("NAXIS");
+//        newHeader.setNaxes(2);
+//        newHeader.deleteKey("NAXIS1");
+//        newHeader.setNaxis(1, pixels[0].length);
+//        newHeader.deleteKey("NAXIS2");
+//        newHeader.setNaxis(2, pixels.length);
 
-        newHeader.deleteKey("DATAMAX");
-        newHeader.deleteKey("DATAMIN");
-        newHeader.deleteKey("NAXIS3");
-        newHeader.deleteKey("NAXIS4");
-        newHeader.deleteKey("BLANK");
+//        newHeader.deleteKey("DATAMAX");
+//        newHeader.deleteKey("DATAMIN");
+//        newHeader.deleteKey("NAXIS3");
+//        newHeader.deleteKey("NAXIS4");
+//        newHeader.deleteKey("BLANK");
 
         ImageData new_image_data = new ImageData(pixels);
         hdu = new ImageHDU(newHeader, new_image_data);
@@ -234,8 +234,9 @@ public class FitsReadUtil {
     private static void insertPositionIntoHeader(Header header, int pos, long hduOffset) throws FitsException {
         if (hduOffset<0) hduOffset= 0;
         if (pos<0) pos= 0;
+        long headerSize= header.getOriginalSize()>0 ? header.getOriginalSize() : header.getSize();
         int bitpix = header.getIntValue("BITPIX", -1);
-        header.addLine(new HeaderCard( "SPOT_HS", header.getOriginalSize(), "Header block size on disk (added by Firefly)"));
+        header.addLine(new HeaderCard( "SPOT_HS", headerSize, "Header block size on disk (added by Firefly)"));
         header.addLine(new HeaderCard( "SPOT_EXT", pos, "Extension Number (added by Firefly)"));
         header.addLine(new HeaderCard( "SPOT_OFF", hduOffset, "Extension Offset (added by Firefly)"));
         header.addLine(new HeaderCard( "SPOT_BP", bitpix, "Original Bitpix value (added by Firefly)"));
@@ -252,7 +253,8 @@ public class FitsReadUtil {
         BasicHDU[] hduList = new BasicHDU[hdu.getHeader().getIntValue("NAXIS3", 0)];
         for (int i = 0; i < hduList.length; i++) {
             hduList[i] = makeHDU(hdu,data32[i] );
-            hduList[i].addValue("SPOT_PL", i, "Plane of FITS cube (added by Firefly)");
+            int bitpix = hduList[i].getHeader().getIntValue("BITPIX", -1);
+            hduList[i].getHeader().addLine(new HeaderCard("SPOT_PL", i, "Plane of FITS cube (added by Firefly)"));
             hduList[i].getHeader().resetOriginalSize();
         }
         return hduList;

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -83,8 +83,8 @@ export class Tabs extends PureComponent {
         this.state= tabsStateFromProps(props);
     }
 
-    static getDerivedStateFromProps(props) {
-        return tabsStateFromProps(props);
+    static getDerivedStateFromProps(props,state) {
+        return props.componentKey ? tabsStateFromProps(props) : state;
     }
 
     componentWillUnmount() {

--- a/src/firefly/js/visualize/BandState.js
+++ b/src/firefly/js/visualize/BandState.js
@@ -44,6 +44,18 @@ export class BandState {
     }
 
     /**
+     *
+     */
+    getCubePlaneNumber() { return this.cubePlaneNumber; }
+
+    /**
+     *
+     * @return {number}
+     */
+    getCubeCnt() { return this.cubeCnt; }
+
+
+    /**
      * get a copy of the WebPlotRequest for this BandState.  Any changes to the object will not be reflected in
      * BandState you must set it back in
      * @return {WebPlotRequest}

--- a/src/firefly/js/visualize/PlotState.js
+++ b/src/firefly/js/visualize/PlotState.js
@@ -3,7 +3,7 @@
  */
 
 
-import {isEmpty} from 'lodash';
+import {isEmpty, isArray} from 'lodash';
 import {Band} from './Band.js';
 import {BandState} from './BandState.js';
 import CoordinateSys from './CoordSys.js';
@@ -135,6 +135,18 @@ export class PlotState {
      * @public
      */
     getWebPlotRequest(band) { return this.get(band || this.firstBand()).getWebPlotRequest(); }
+    /**
+     * @summary if a cube, checkout how many images it contains
+     * @param {Band} [band] the band check for, if not passed the used the primary band
+     * @return {number} the WebPlotRequest
+     * @public
+     */
+    getCubeCnt(band) { return this.get(band || this.firstBand()).getCubeCnt(); }
+
+
+    getCubePlaneNumber(band) {
+        return this.get(band || this.firstBand()).getCubePlaneNumber();
+    }
 
     /**
      * Get the range values for the plot.
@@ -142,6 +154,7 @@ export class PlotState {
      * @return {RangeValues}
      */
     getRangeValues(band) { return this.get(band || this.firstBand()).getRangeValues(); }
+
 
     /**
      *
@@ -223,11 +236,16 @@ export class PlotState {
         if (!psJson) return null;
         const state= PlotState.makePlotState();
 
-        state.bandStateAry= psJson.bandStateAry.map( (bJ) => BandState.makeBandStateWithJson(bJ));
+        if (isArray(psJson.bandStateAry)) {
+            state.bandStateAry= psJson.bandStateAry.map( (bJ) => BandState.makeBandStateWithJson(bJ));
+        }
+        else {
+            state.bandStateAry= [BandState.makeBandStateWithJson(psJson.bandStateAry)];
+        }
 
         state.ctxStr=psJson.ctxStr;
         state.zoomLevel= psJson.zoomLevel;
-        state.colorTableId= psJson.colorTableId;
+        state.colorTableId= psJson.colorTableId || 0;
 
         // if not include used defaulted values
         state.multiImage= psJson.multiImage; // if multiImage is not default we don't care

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -812,7 +812,7 @@ export const getHDU= (plot) => getNumberHeader(plot,FitsHdr.SPOT_EXT,0);
  * @param {WebPlot} plot
  * @return {number} the plane index, -1 if not in a cube
  */
-export const getImageCubeIdx = (plot) => getNumberHeader(plot,FitsHdr.SPOT_PL,-1);
+export const getImageCubeIdx = (plot) => (plot && plot.cubeCtx) ? plot.cubeCtx.cubePlane : -1;
 
 
 /**

--- a/src/firefly/js/visualize/projection/ProjectionInfo.js
+++ b/src/firefly/js/visualize/projection/ProjectionInfo.js
@@ -82,12 +82,9 @@ const startsWithAny= (s,strAry) => Boolean(strAry.find( (sTest) => s.startsWith(
 
 function getBasicHeaderValues(parse) {
 
-    const naxis= parse.getIntValue('NAXIS');
     return {
-        naxis,
         naxis1: parse.getIntValue('NAXIS1'),
         naxis2: parse.getIntValue('NAXIS2'),
-        naxis3: (naxis > 2) ? parse.getIntValue('NAXIS3') : 1,
         cdelt2: parse.getDoubleValue('CDELT2', 0),
         bscale: parse.getDoubleValue('BSCALE', 1.0),
         bzero: parse.getDoubleValue('BZERO', 0.0),
@@ -432,12 +429,11 @@ function getJsys(params) {
 
 
 
-export function makeDirectFileAccessData(header) {
+export function makeDirectFileAccessData(header,cubePlane) {
 
     const parse= makeHeaderParse(header);
     const dataOffset = parse.getIntValue(FitsHdr.SPOT_OFF,0)+ parse.getIntValue(FitsHdr.SPOT_HS,0);
-    const planeNumber= parse.getIntValue(FitsHdr.SPOT_PL,0);
-    const miniHeader= {...getBasicHeaderValues(parse), dataOffset, planeNumber};
+    const miniHeader= {...getBasicHeaderValues(parse), dataOffset, planeNumber:cubePlane>-1?cubePlane:0};
     miniHeader.bitpix= parse.getValue(FitsHdr.SPOT_BP);
 
     if (parse.getValue(ORIGIN,'').startsWith(PALOMAR_ID)) {

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -21,11 +21,12 @@ import numeral from 'numeral';
 import ImagePlotCntlr, {visRoot} from '../ImagePlotCntlr.js';
 import {getTblById} from '../../tables/TableUtil.js';
 import {TABLE_SORT, TABLE_REPLACE, dispatchTableSort} from '../../tables/TablesCntlr.js';
+import {getHDU, isThreeColor} from '../PlotViewUtil';
 
 const popupIdRoot = 'directFileAccessData';
 const popupPanelResizableStyle = {
     width: 450,
-    minWidth: 450,
+    minWidth: 448,
     height: 400,
     minHeight: 300,
     resize: 'both',
@@ -112,7 +113,8 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
 
 
     // update table sort when active image is changed
-    const watchActivePlotChange = (action, cancelSelf) => {
+    const watchActivePlotChange = (action, cancelSelf, params) => {
+        let {displayedPlotId, displayedHdu} = params;
         if (!isDialogVisible(popupId)) {
             cancelSelf();
         } else {
@@ -125,9 +127,14 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
                 return prev;
             }, false);
 
-            updatePopup(crtPlot, newTableInfo)();
+            if (isThreeColor(plot) || displayedPlotId!==crtPlot.plotId || displayedHdu!==getHDU(crtPlot)) {
+                updatePopup(crtPlot, newTableInfo)();
+            }
+            displayedPlotId= crtPlot.plotId;
+            displayedHdu= getHDU(crtPlot);
 
         }
+        return {displayedPlotId, displayedHdu};
     };
 
     const isFitsHeaderTable = (tbl) => {
@@ -139,7 +146,6 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
         if (!isDialogVisible(popupId)) {
             cancelSelf();
         } else {
-            console.log('action.type = '+ action.type);
             let tblModel;
             if (action.type === TABLE_SORT) {
                 const {sortInfo='', tbl_id} = get(action.payload, ['request']) || {};
@@ -204,7 +210,7 @@ function renderColorBandsFitsHeaders(plot, fitsHeaderInfo, popupId) {
     switch (bands.length){
         case 2:
         colorBandTabs = (
-                <Tabs defaultSelected={0} useFlex={true} onTabSelect={onBandSelected(fitsHeaderInfo)}>
+                <Tabs defaultSelected={0} useFlex={true} style={{flexGrow:1}} onTabSelect={onBandSelected(fitsHeaderInfo)}>
                     {renderSingleTab(plot, bands[0],fitsHeaderInfo )}
                     {renderSingleTab(plot, bands[1],fitsHeaderInfo )}
             </Tabs>
@@ -212,7 +218,7 @@ function renderColorBandsFitsHeaders(plot, fitsHeaderInfo, popupId) {
             break;
         case 3:
             colorBandTabs = (
-                <Tabs defaultSelected={0} useFlex={true} onTabSelect={onBandSelected(fitsHeaderInfo)}>
+                <Tabs defaultSelected={0} useFlex={true} style={{flexGrow:1}} onTabSelect={onBandSelected(fitsHeaderInfo)}>
                     {renderSingleTab(plot, bands[0],fitsHeaderInfo )}
                     {renderSingleTab(plot, bands[1],fitsHeaderInfo )}
                     {renderSingleTab(plot, bands[2],fitsHeaderInfo )}


### PR DESCRIPTION
Firefly-61: Headers are not passed for every cube plane, show correct cube headers

  - pass the correct cube headers
  - optimize size of returns
  - fixed crop file mouse readout bug
  - better feedback
  - large cube significantly faster
  - cube result json much smaller
  - standard result json a little smaller

_To Test:_

https://irsawebdev9.ipac.caltech.edu/firefly-61-cube-loading/firefly/

go to `firefly_test_data/multi-ext-fits` and read some file.

 - `sofia-10_ext-10130_images.fits` is the best test case since this file highlighted the bug.
 - read others such as `F0202_FI_IFS_0300595_RED_WXY-10-hdu-69-plane-cube.fits`
 - read other fits files.

Performance should be good.


