### PR TITLE
FIREFLY-22 Fix the reader for FITS table or VOTable with fields of 'byte' or 'short' type

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
+++ b/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.table;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Date: 6/15/18
@@ -20,16 +21,34 @@ public interface PrimitiveList {
     int size();
     void clear();
     void trimToSize();
+    List<Class> numberTypeList = Arrays.asList(new Class[] {Byte.class, Short.class, Integer.class});
 
     default void add(Object val) {
         set(size(), val);
     }
 
     default void checkType(Object val) {
-        if (val != null && !val.getClass().isAssignableFrom(getDataClass())) {
+        int vIdx = val == null ? -1 : numberTypeList.indexOf(val.getClass());
+        int dIdx = numberTypeList.indexOf(getDataClass());
+
+        // number type value or non number type value
+        if ((vIdx >= 0 && dIdx >= 0 && vIdx > dIdx) ||
+            (vIdx < 0 && val != null && !val.getClass().isAssignableFrom(getDataClass()))) {
             throw new RuntimeException(String.format("Type mismatch(%s): expecting %s but found %s", val, getDataClass(), val.getClass()));
         }
     }
+
+    default int getIntValue(Object val) {
+        int toIdx = numberTypeList.indexOf(Integer.class);
+        int fromIdx = numberTypeList.indexOf(val.getClass());
+
+        if (toIdx == fromIdx) {
+            return ((Integer) val).intValue();
+        } else {
+            return (toIdx == 0) ? ((Byte) val).intValue() : ((Short) val).intValue();
+        }
+    }
+
 
     /**
      * returns a new capacity base on the given parameters
@@ -222,7 +241,7 @@ public interface PrimitiveList {
         public void set(int idx, Object val) {
             checkType(val);
             ensureCapacity(idx);
-            data[idx] = val == null ? Integer.MIN_VALUE : (int) val;
+            data[idx] = val == null ? Integer.MIN_VALUE : getIntValue(val);
             if (idx >= size()) size = idx+1;
         }
 

--- a/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
+++ b/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
@@ -6,7 +6,6 @@ package edu.caltech.ipac.table;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 /**
  * Date: 6/15/18
@@ -21,32 +20,22 @@ public interface PrimitiveList {
     int size();
     void clear();
     void trimToSize();
-    List<Class> numberTypeList = Arrays.asList(new Class[] {Byte.class, Short.class, Integer.class});
 
     default void add(Object val) {
         set(size(), val);
     }
 
     default void checkType(Object val) {
-        int vIdx = val == null ? -1 : numberTypeList.indexOf(val.getClass());
-        int dIdx = numberTypeList.indexOf(getDataClass());
-
-        // number type value or non number type value
-        if ((vIdx >= 0 && dIdx >= 0 && vIdx > dIdx) ||
-            (vIdx < 0 && val != null && !val.getClass().isAssignableFrom(getDataClass()))) {
+        if (val != null && !val.getClass().isAssignableFrom(getDataClass())) {
             throw new RuntimeException(String.format("Type mismatch(%s): expecting %s but found %s", val, getDataClass(), val.getClass()));
         }
     }
 
     default int getIntValue(Object val) {
-        int toIdx = numberTypeList.indexOf(Integer.class);
-        int fromIdx = numberTypeList.indexOf(val.getClass());
-
-        if (toIdx == fromIdx) {
-            return ((Integer) val).intValue();
-        } else {
-            return (toIdx == 0) ? ((Byte) val).intValue() : ((Short) val).intValue();
-        }
+        if (val instanceof Integer) return (int)val;
+        else if (val instanceof Byte) return (int)(Byte)val;
+        else if (val instanceof Short) return (int)(Short)val;
+        throw new RuntimeException(String.format("%s is with type %s, can not be assigned to Integer", val, getDataClass()));
     }
 
 
@@ -239,9 +228,9 @@ public interface PrimitiveList {
         }
 
         public void set(int idx, Object val) {
-            checkType(val);
+            int ival = val == null ? Integer.MIN_VALUE : getIntValue(val);
             ensureCapacity(idx);
-            data[idx] = val == null ? Integer.MIN_VALUE : getIntValue(val);
+            data[idx] = ival;
             if (idx >= size()) size = idx+1;
         }
 

--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
@@ -398,7 +398,7 @@ public final class FITSTableReader
      * @throws FitsException
      */
     public static DataType convertToDataType(StarTable table, int colIdx, String strategy)
-            throws FitsException{
+        throws FitsException{
 
         ColumnInfo colInfo = table.getColumnInfo(colIdx);
         String colName = colInfo.getName();

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -474,9 +474,7 @@ export class FileUploadViewPanel extends PureComponent {
                         fieldKey={fileId}
                         fileAnalysis={this.onLoading}
                         innerStyle={{width: 80}}
-                        initialState={{tooltip: 'Select a file with FITS, VOTABLE, CSV, TSV, or IPAC format',
-                                           label: ''
-                                           }}/>
+                    />
 
                 );
             } else if (uploadSrc === urlId) {
@@ -487,9 +485,7 @@ export class FileUploadViewPanel extends PureComponent {
                         fileAnalysis={this.onLoading}
                         isFromURL={true}
                         innerStyle={{width: '70%'}}
-                        initialState={{tooltip: 'Select a URL with file in FITS, VOTABLE, CSV, TSV, or IPAC format',
-                                           label: 'Enter URL of a file:'
-                                         }}/>
+                    />
                 );
             } else if (uploadSrc === wsId) {
                 return (
@@ -499,9 +495,7 @@ export class FileUploadViewPanel extends PureComponent {
                         fieldKey={wsId}
                         isLoading={isUploading || isWsUpdating}
                         fileAnalysis={this.onLoading}
-                        initialState={{tooltip: 'Select a file in FITS, VOTABLE, CSV, TSV, or IPAC format from workspace',
-                                       label: ''
-                                       }}/>
+                    />
 
                 );
             }
@@ -1030,11 +1024,19 @@ function fieldInit() {
             },
             [fileId]: {
                 fieldKey: fileId,
-                value: ''
+                value: '',
+                tooltip: 'Select a file with FITS, VOTABLE, CSV, TSV, or IPAC format'
             },
             [urlId]: {
                 fieldKey: urlId,
-                value: ''
+                value: '',
+                label: 'Enter URL of a file:',
+                tooltip: 'Select a URL with file in FITS, VOTABLE, CSV, TSV, or IPAC format'
+            },
+            [wsId]: {
+                fieldKey: wsId,
+                value: '',
+                tooltip: 'Select a file in FITS, VOTABLE, CSV, TSV, or IPAC format from workspace'
             }
         }
     );


### PR DESCRIPTION
This PR contains developments for  https://jira.ipac.caltech.edu/browse/FIREFLY-22 
- fix fits table reader and votable reader to handle the fields of type 'byte' or 'short' 
- fix the missing label on upload panel when URL is selected.

test 
start Firefly
upload the FITS sample from URL
http://web.ipac.caltech.edu/staff/ejoliet/gaia/query-sels/result.fits

k8s: https://irsawebdev9.ipac.caltech.edu/firefly-22/firefly/