### PR TITLE
IRSA-2825: Console error msg on mouse wheel on any table

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "classnames": "^2.2.5",
     "core-js": "^2.6.4",
     "enum": "^2.5",
-    "fixed-data-table-2": "^0.8.9",
+    "fixed-data-table-2": "^0.8.22",
     "immutability-helper": "^3.0",
     "isomorphic-fetch": "^2.2.1",
     "local-storage": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2779,9 +2779,9 @@ findup-sync@^2.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
-fixed-data-table-2@^0.8.9:
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/fixed-data-table-2/-/fixed-data-table-2-0.8.20.tgz#5fd36235c4cc479ca7dc6dc3927e673f2017a205"
+fixed-data-table-2@^0.8.22:
+  version "0.8.22"
+  resolved "https://registry.yarnpkg.com/fixed-data-table-2/-/fixed-data-table-2-0.8.22.tgz#f30877aa350f751f1a91ba04c7fecff23746d883"
   dependencies:
     create-react-class "^15.5.2"
     prop-types "^15.5.8"


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2825

chrome update causes error messages to appear in console when mouse wheel is used  for scrolling on any table. (https://www.chromestatus.com/features/6662647093133312)
Update `fixed-data-table-2` to latest(v0.8.22) fixes the problem.

Test:  https://irsawebdev9.ipac.caltech.edu/IRSA-2825/applications/sofia/
On any table with data, use mouse wheel to scroll the view.  With this fix, there should not be any error messages in the console.
