### PR TITLE
FIREFLY-33: no chart toolbar option in API

### DIFF
--- a/src/firefly/html/demo/ffapi-highlevel-charttest.html
+++ b/src/firefly/html/demo/ffapi-highlevel-charttest.html
@@ -25,16 +25,24 @@
 
 <div id="table-lg" style="width: 800px; height: 550px; border: solid 1px;"></div>
 <br/><br/>
-<div id="heatmapHere" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<div id="heatmapHere" style="display: inline-block; width: 800px; height: 550px; border: solid 1px;"></div>
+&nbsp;
+<div id="heatmapHereNT" style="display:inline-block; width: 800px; height: 550px;"></div>
 <br/><br/>
-<div id="histogramHere" style="width: 800px; height: 550px; border: solid 1px"></div>
+<div id="histogramHere" style="display: inline-block; width: 800px; height: 550px; border: solid 1px"></div>
+&nbsp;
+<div id="histogramHereNT" style="display: inline-block; width: 800px; height: 550px;"></div>
 <br/><br/>
-<div id="xyplotHere" style="width: 800px; height: 550px; border: solid 1px;"></div>
+<div id="xyplotHere" style="display: inline-block; width: 800px; height: 550px; border: solid 1px;"></div>
+&nbsp;
+<div id="xyplotHereNT" style="display: inline-block; width: 800px; height: 550px;"></div>
 <br/><br/>
-<div id="plotlyDiv" style="resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px; border: solid 1px gray;"></div>
+<div id="plotlyDiv" style="display: inline-block; resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px; border: solid 1px gray;"></div>
+&nbsp;
+<div id="plotlyDivNT" style="display: inline-block; resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px;"></div>
 <br/><br/>
 <h3>Default chart for 'allwise' table group below</h3>
-<div id="defaultChart" style="resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px; border: solid 1px gray;"></div>
+<div id="defaultChartNT" style="display: inline-block; resize: both; overflow: auto; padding: 5px; width: 800px; height: 550px;"></div>
 <br/><br/>
 <div id="table-1" style="width: 800px; height: 550px; border: solid 1px;"></div>
 <br/><br/>
@@ -82,6 +90,7 @@
             ];
 
             firefly.showChart('histogramHere', {data: dataH});
+            firefly.showChart('histogramHereNT', {data: dataH, noChartToolbar: true});
 
 
             // show scatter chart, which has no table on display
@@ -107,6 +116,7 @@
                 });
             }
             firefly.showChart('xyplotHere', {data: traces});
+            firefly.showChart('xyplotHereNT', {data: traces, noChartToolbar: true});
 
 
             var trace1 = {
@@ -125,6 +135,7 @@
 
             var data = [trace1, trace2];
             firefly.showChart('plotlyDiv', {data: data});
+            firefly.showChart('plotlyDivNT', {data: data, noChartToolbar: true});
 
 
             var tblReq =  firefly.util.table.makeIrsaCatalogRequest('allwise-500', 'WISE', 'allwise_p3as_psd',
@@ -148,7 +159,9 @@
             firefly.showTable('table-1', tblReq, {tbl_group: 'allwise'});
             firefly.showTable('table-1', tblReqSm, {tbl_group: 'allwise'});
 
-            firefly.showChart('defaultChart', {tbl_group: 'allwise'});
+            //can not display both at the same time 
+            //firefly.showChart('defaultChart', {tbl_group: 'allwise'});
+            firefly.showChart('defaultChartNT', {tbl_group: 'allwise',  noChartToolbar: true});
 
             // using column expressions
             var tblReqXpr =  Object.assign({}, tblReq, {inclCols: '"ra" + "dec" as "radec", "ra", "dec", ln("dec") as "LnOfDec", power("ra", 2) as "ra_sq"'});
@@ -165,6 +178,7 @@
             };
 
             firefly.showChart('plotlyDiv', {data: [trace1]});
+            firefly.showChart('plotlyDivNT', {data: [trace1], noChartToolbar: true});
 
 
             var tblReqLg =  firefly.util.table.makeIrsaCatalogRequest('allwise_p3as_psd', 'WISE', 'allwise_p3as_psd',
@@ -204,6 +218,7 @@
             ];
 
             firefly.showChart('heatmapHere', {data: dataHM});
+            firefly.showChart('heatmapHereNT', {data: dataHM, noChartToolbar: true});
 
             // a static Plotly chart (no connection to a table)
             const props = {

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -177,7 +177,10 @@ function buildChartPart(llApi) {
     /**
      * @summary The general function to plot a Plotly chart.
      * @param {string|HTMLDivElement} targetDiv - div to put the chart in.
-     * @param {{data: array.object, layout: object}} parameters - plotly parameters (possibly with firefly extensions)
+     * @param {object} parameters
+     * @param {array.object} parameters.data - plotly data array (possibly with firefly extensions)
+     * @param {object} parameters.layout - plotly layout object (possibly with firefly extensions)
+     * @param {boolean} parameters.noChartToolbar - set true for non-interactive chart with no toolbar
      * @memberof firefly
      * @public
      */
@@ -711,7 +714,8 @@ function doShowChart(llApi, targetDiv, params={}) {
             tbl_group,
             addDefaultChart: Boolean(tbl_group),
             closeable: false,
-            expandedMode: false
+            expandedMode: false,
+            noChartToolbar: params.noChartToolbar
         }
     );
 }

--- a/src/firefly/js/charts/ui/ChartPanel.css
+++ b/src/firefly/js/charts/ui/ChartPanel.css
@@ -55,6 +55,10 @@
     right: 0
 }
 
+.ChartPanel__glass {
+    background-color: transparent
+}
+
 .ChartPanel__chartresizer {
     flex-grow: 1;
     position: relative;

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -23,21 +23,9 @@ class ChartPanelView extends PureComponent {
         if (showChart) {
             dispatchChartMounted(chartId);
         }
-        this.iAmMounted = true;
-    }
-
-    UNSAFE_componentWillReceiveProps(nextProps) {
-        const {chartId, showChart} = nextProps;
-        if (!chartId) { return; }
-
-        if (chartId !== this.props.chartId) {
-            if (this.props.showChart) { dispatchChartUnmounted(this.props.chartId); }
-            if (showChart) { dispatchChartMounted(chartId); }
-        }
     }
 
     componentWillUnmount() {
-        this.iAmMounted = false;
         const {chartId, showChart} = this.props;
         if (showChart) {
             dispatchChartUnmounted(chartId);
@@ -45,7 +33,7 @@ class ChartPanelView extends PureComponent {
     }
 
     render() {
-        const {chartId, chartData, deletable:deletableProp, expandable, expandedMode, Toolbar, showToolbar, showChart} = this.props;
+        const {chartId, chartData, deletable:deletableProp, expandable, expandedMode, Toolbar, showToolbar, showChart, glass} = this.props;
         const deletable = isUndefined(get(chartData, 'deletable')) ? deletableProp : get(chartData, 'deletable');
         const showMultiTrace = !singleTraceUI();
 
@@ -68,6 +56,7 @@ class ChartPanelView extends PureComponent {
                             <div className='ChartPanel__chartarea--withToolbar'>
                                 <ResizableChartArea
                                     {...Object.assign({}, this.props, {errors})} />
+                                {glass && <div className='ChartPanel__chartarea--withToolbar ChartPanel__glass'/>}
                                 { deletable &&
                                 <img style={{display: 'inline-block', position: 'absolute', top: 29, right: 0, alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}
                                      title='Delete this chart'
@@ -85,6 +74,7 @@ class ChartPanelView extends PureComponent {
                         <div className='ChartPanel__chartarea'>
                             <ResizableChartArea
                                 {...Object.assign({}, this.props, {errors})} />
+                            {glass && <div className='ChartPanel__chartarea ChartPanel__glass'/>}
                             {deletable &&
                             <img style={{display: 'inline-block', position: 'absolute', top: 0, right: 0, alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}
                                  title='Delete this chart'
@@ -114,6 +104,7 @@ ChartPanelView.propTypes = {
     expandedMode: PropTypes.bool,
     showToolbar: PropTypes.bool,
     showChart: PropTypes.bool,
+    glass: PropTypes.bool, // for non-interactive chart area (when toolbar is missing)
     Chart: PropTypes.func,
     Toolbar: PropTypes.func
 };
@@ -214,7 +205,7 @@ export class ChartPanel extends PureComponent {
 
     render() {
         return (
-            <ChartPanelView {...this.props} {...this.state}/>
+            <ChartPanelView key={this.props.chartId} {...this.props} {...this.state}/>
         );
     }
 }

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -99,7 +99,7 @@ export class ChartsContainer extends PureComponent {
 
     }
 
-    UNSAFE_componentWillMount() {
+    componentDidMount() {
         const {viewerId=DEFAULT_PLOT2D_VIEWER_ID, tbl_group, addDefaultChart, chartId} = this.props;
         if (tbl_group) {
             if (addDefaultChart) {
@@ -112,10 +112,6 @@ export class ChartsContainer extends PureComponent {
             // important when we use external viewer
             doUpdateViewer(viewerId, tbl_group, chartId);
         }
-    }
-
-    componentDidMount() {
-        const {viewerId=DEFAULT_PLOT2D_VIEWER_ID, tbl_group, addDefaultChart} = this.props;
 
         const monitor = watchTblGroup(viewerId, tbl_group, addDefaultChart);
         this.removeMonitor = monitor();
@@ -127,16 +123,37 @@ export class ChartsContainer extends PureComponent {
     }
 
     render() {
-        const {chartId, expandedMode, closeable, viewerId=DEFAULT_PLOT2D_VIEWER_ID} = this.props;
-
+        const {chartId, expandedMode, closeable, viewerId=DEFAULT_PLOT2D_VIEWER_ID, noChartToolbar} = this.props;
 
         if (chartId) {
-            return expandedMode ?
-                <ExpandedView key='chart-expanded' closeable={closeable} chartId={chartId}/> :
-                <ChartPanel key={chartId} expandable={true} chartId={chartId}/>;
+            if (expandedMode) {
+                return (
+                    <ExpandedView {...{
+                        key: 'chart-expanded',
+                        closeable,
+                        chartId,
+                        noChartToolbar
+                    }}/>
+                );
+            } else {
+                return (
+                    <ChartPanel {...{
+                        key: chartId,
+                        expandable: true,
+                        chartId,
+                        showToolbar: !Boolean(noChartToolbar),
+                        glass: Boolean(noChartToolbar)
+                    }}/>
+                );
+            }
         } else {
             return (
-                <MultiChartViewer {...{closeable, viewerId : viewerId, expandedMode}}/>
+                <MultiChartViewer {...{
+                    closeable,
+                    viewerId,
+                    expandedMode,
+                    noChartToolbar}}
+                />
             );
         }
     }
@@ -148,21 +165,33 @@ ChartsContainer.propTypes = {
     chartId: PropTypes.string,
     viewerId : PropTypes.string,
     tbl_group : PropTypes.string,
-    addDefaultChart : PropTypes.bool
+    addDefaultChart : PropTypes.bool,
+    noChartToolbar : PropTypes.bool
 };
 
 function ExpandedView(props) {
-    const {closeable, chartId} = props;
-
+    const {closeable, chartId, noChartToolbar} = props;
     return (
-        <div style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0}}>
-            <ChartPanel key={'expanded-'+chartId} expandedMode={true} expandable={false} chartId={chartId}/>
-            {closeable && <CloseButton style={{position: 'absolute', top: 0, left: 0, paddingLeft: 10}} onClick={() => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)}/>}
+        <div  style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0}}>
+            <ChartPanel {...{
+                key: 'expanded-'+chartId,
+                expandedMode: true,
+                expandable: false,
+                chartId,
+                showToolbar: !Boolean(noChartToolbar),
+                glass: Boolean(noChartToolbar)
+            }}/>
+            {closeable &&
+            <CloseButton
+                style={{position: 'absolute', top: 0, left: 0, paddingLeft: 10}}
+                onClick={() => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)}/>
+            }
         </div>
     );
 }
 
 ExpandedView.propTypes = {
     closeable: PropTypes.bool,
-    chartId: PropTypes.string
+    chartId: PropTypes.string,
+    noChartToolbar : PropTypes.bool
 };

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -85,7 +85,7 @@ export class MultiChartViewer extends PureComponent {
     }
 
     render() {
-        const {viewerId, expandedMode, closeable} = this.props;
+        const {viewerId, expandedMode, closeable, noChartToolbar} = this.props;
         const {viewer}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId);
         if (!viewer || isEmpty(viewer.itemIdAry)) {
@@ -115,13 +115,14 @@ export class MultiChartViewer extends PureComponent {
             stopPropagation(ev);
         };
 
+        const glass = Boolean(noChartToolbar);
 
         const makeItemViewer = (chartId) => (
             <div className={chartId === activeItemId ? 'ChartPanel ChartPanel--active' : 'ChartPanel'}
                  onClick={(ev)=>onChartSelect(ev,chartId)}
                  onTouchStart={stopPropagation}
                  onMouseDown={stopPropagation}>
-                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
+                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable} glass={glass}/>
             </div>
         );
 
@@ -129,7 +130,7 @@ export class MultiChartViewer extends PureComponent {
             <div onClick={stopPropagation}
                  onTouchStart={stopPropagation}
                  onMouseDown={stopPropagation}>
-                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
+                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable} glass={glass}/>
             </div>
         );
 
@@ -142,13 +143,25 @@ export class MultiChartViewer extends PureComponent {
         };
 
         //console.log('Active chart ID: '+activeItemId);
+
+        const showChartToolbar = !Boolean(noChartToolbar);
+        const hasToolbar = showChartToolbar || (viewer.itemIdAry.length > 1);
+        const chartAreaClass = `ChartPanel__chartarea${hasToolbar?'--withToolbar':''}`;
+        
         return (
         <div className='ChartPanel__container'>
             <div className='ChartPanel__wrapper'>
                 {expandedMode ? <MultiChartToolbarExpanded {...{closeable, viewerId, layoutType, activeItemId}}/> : <MultiChartToolbarStandard {...{viewerId, layoutType, activeItemId}}/>}
-                <ChartPanel key={'toolbar-'+activeItemId} expandedMode={expandedMode} expandable={!expandedMode}  showChart={false} chartId={activeItemId} deletable={deletable}/>
+                {showChartToolbar &&
+                <ChartPanel key={'toolbar-'+activeItemId}
+                            expandedMode={expandedMode}
+                            expandable={!expandedMode}
+                            showChart={false}
+                            chartId={activeItemId}
+                            deletable={deletable}/>
+                }
 
-                <div className='ChartPanel__chartarea--withToolbar'>
+                <div className={chartAreaClass}>
                     <MultiItemViewerView {...this.props} {...newProps}/>
                 </div>
                 {expandedMode && closeable && <CloseButton style={{paddingLeft: 10, position: 'absolute', top: 0, left: 0}} onClick={() => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)}/>}
@@ -172,6 +185,7 @@ MultiChartViewer.propTypes= {
     gridDefFunc : PropTypes.func,
     insideFlex : PropTypes.bool,
     closeable : PropTypes.bool,
-    expandedMode: PropTypes.bool
+    expandedMode: PropTypes.bool,
+    noChartToolbar: PropTypes.bool
 
 };

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -42,7 +42,14 @@ export class PlotlyChartArea extends Component {
 
     constructor(props) {
         super(props);
-        this.state = {};
+
+        const {chartId} = this.props;
+        const {data, fireflyData, mounted} = getChartData(chartId);
+        if (mounted === 1) {
+            handleTableSourceConnections({chartId, data, fireflyData});
+        }
+        this.state = this.getNextState();
+        
         this.afterRedraw = this.afterRedraw.bind(this);
     }
 
@@ -51,15 +58,6 @@ export class PlotlyChartArea extends Component {
         const propsEqual = widthPx === this.props.widthPx && heightPx === this.props.heightPx && chartId === this.props.chartId;
         const stateEqual = shallowequal(ns, this.state);
         return !(propsEqual && stateEqual);
-    }
-
-    UNSAFE_componentWillMount() {
-        const {chartId} = this.props;
-        const {data, fireflyData, mounted} = getChartData(chartId);
-        if (mounted === 1) {
-            handleTableSourceConnections({chartId, data, fireflyData});
-        }
-        this.setState(this.getNextState());
     }
 
     componentDidMount() {

--- a/src/firefly/js/ui/CloseButton.jsx
+++ b/src/firefly/js/ui/CloseButton.jsx
@@ -3,7 +3,7 @@
  */
 
 
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import './ToolbarButton.css';
 
@@ -22,15 +22,15 @@ const middleStyle= {
 };
 
 /**
- *
- * @param text
- * @param tip
- * @param onClick
- * @param style
+ * @param p
+ * @param p.text
+ * @param p.tip
+ * @param p.style
+ * @param p.onClick
  * @return react object
  */
-export function CloseButton({text='Close', tip='Close',style={}, onClick}) {
-    var s= Object.assign({cursor:'pointer', verticalAlign:'baseline', whiteSpace:'nowrap'},style);
+export function CloseButton({text='Close', tip='Close', style={}, onClick}) {
+    const s= Object.assign({cursor:'pointer', verticalAlign:'baseline', whiteSpace:'nowrap'},style);
     return (
         <div style={s} title={tip} onClick={onClick}>
             <img style={{verticalAlign:'bottom'}} src={BUTTON_START} />
@@ -42,8 +42,8 @@ export function CloseButton({text='Close', tip='Close',style={}, onClick}) {
 
 CloseButton.propTypes= {
     text : PropTypes.string,
-    style : PropTypes.object,
     tip : PropTypes.string,
+    style : PropTypes.object,
     onClick : PropTypes.func
 };
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-33
Test: https://irsawebdev9.ipac.caltech.edu/firefly-33_notoolbar_chart/firefly/demo/ffapi-highlevel-charttest.html

- Added noChartToolbar to showChart parameters. When set to true, the chart toolbar will not be displayed and the chart area will be "under the glass", not reacting to any DOM events. If connected to a table, it will update when the table updates.
- Refactored some of the chart code to remove UNSAFE__* methods. 