### PR TITLE
FIREFLY-67: Fixes TabPanel

### DIFF
--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -9,7 +9,7 @@ import {isEmpty, get} from 'lodash';
 import {flux} from '../../Firefly.js';
 import * as TblUtil from '../TableUtil.js';
 import {TablePanel} from './TablePanel.jsx';
-import {Tabs, Tab} from '../../ui/panel/TabPanel.jsx';
+import {StatelessTabs, Tab} from '../../ui/panel/TabPanel.jsx';
 import {dispatchTableRemove, dispatchActiveTableChanged} from '../TablesCntlr.js';
 
 
@@ -108,9 +108,9 @@ function StandardView(props) {
         return <SingleTable table={get(tables, [keys[0]])} expandedMode={expandedMode} tableOptions={tableOptions}/>;
     } else {
         return (
-            <Tabs style={{height: '100%', ...style}} defaultSelected={activeIdx} onTabSelect={onTabSelect} resizable={true}>
+            <StatelessTabs style={{height: '100%', ...style}} defaultSelected={activeIdx} onTabSelect={onTabSelect} resizable={true}>
                 {tablesAsTab(tables, tableOptions, expandedMode)}
-            </Tabs>
+            </StatelessTabs>
         );
     }
 }

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -9,8 +9,9 @@ import {isEmpty, get} from 'lodash';
 import {flux} from '../../Firefly.js';
 import * as TblUtil from '../TableUtil.js';
 import {TablePanel} from './TablePanel.jsx';
-import {StatelessTabs, Tab} from '../../ui/panel/TabPanel.jsx';
+import {TabsView, Tab} from '../../ui/panel/TabPanel.jsx';
 import {dispatchTableRemove, dispatchActiveTableChanged} from '../TablesCntlr.js';
+import {hashCode} from '../../util/WebUtil.js';
 
 
 import {LO_VIEW, LO_MODE, dispatchSetLayoutMode, getExpandedMode} from '../../core/LayoutCntlr.js';
@@ -107,10 +108,11 @@ function StandardView(props) {
     if (keys.length === 1) {
         return <SingleTable table={get(tables, [keys[0]])} expandedMode={expandedMode} tableOptions={tableOptions}/>;
     } else {
+        const uid = hashCode(keys.join());
         return (
-            <StatelessTabs style={{height: '100%', ...style}} defaultSelected={activeIdx} onTabSelect={onTabSelect} resizable={true}>
+            <TabsView key={hashCode(keys.join())} style={{height: '100%', ...style}} defaultSelected={activeIdx} onTabSelect={onTabSelect} resizable={true}>
                 {tablesAsTab(tables, tableOptions, expandedMode)}
-            </StatelessTabs>
+            </TabsView>
         );
     }
 }

--- a/src/firefly/js/ui/ExampleDialog.jsx
+++ b/src/firefly/js/ui/ExampleDialog.jsx
@@ -24,9 +24,9 @@ import FieldGroupUtils, {revalidateFields} from '../fieldGroup/FieldGroupUtils';
 import {updateSet} from '../util/WebUtil.js';
 
 import {CollapsiblePanel} from './panel/CollapsiblePanel.jsx';
-import {Tabs, Tab,FieldGroupTabs} from './panel/TabPanel.jsx';
+import {StatefulTabs, Tab,FieldGroupTabs} from './panel/TabPanel.jsx';
 import {dispatchShowDialog} from '../core/ComponentCntlr.js';
-import {NaifidPanel} from "./NaifidPanel";
+import {NaifidPanel} from './NaifidPanel.jsx';
 
 
 
@@ -203,7 +203,6 @@ function FieldGroupWithMasterDependent() {
 
 
 /// test
-
 export class AllTest extends PureComponent {
 
 
@@ -215,7 +214,7 @@ export class AllTest extends PureComponent {
         return (
             <div style={{padding:'5px', minWidth: 480}}>
                 <div>
-                    <Tabs componentKey='exampleOuterTabs' defaultSelected={0} useFlex={true}>
+                    <StatefulTabs componentKey='exampleOuterTabs' defaultSelected={0} useFlex={true}>
                         <Tab name='First'>
                             <FieldGroupTest />
                         </Tab>
@@ -231,7 +230,7 @@ export class AllTest extends PureComponent {
                                 <FieldGroupWithMasterDependent />
                             </div>
                         </Tab>
-                    </Tabs>
+                    </StatefulTabs>
                 </div>
 
             </div>

--- a/src/firefly/js/ui/ListBoxInputField.jsx
+++ b/src/firefly/js/ui/ListBoxInputField.jsx
@@ -117,7 +117,7 @@ ListBoxInputField.propTypes= {
         label:  PropTypes.string,
     }),
     inline : PropTypes.bool,
-    options : PropTypes.array.isRequired,
+    options : PropTypes.array,
     multiple : PropTypes.bool,
     labelWidth : PropTypes.number
 };

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -9,7 +9,7 @@ import {dispatchUpdateAppData} from '../core/AppDataCntlr.js';
 import {getSearchInfo} from '../core/AppDataCntlr.js';
 import {FormPanel} from './FormPanel.jsx';
 import {SimpleComponent} from './SimpleComponent.jsx';
-import {Tabs, Tab} from './panel/TabPanel.jsx';
+import {StatefulTabs, Tab} from './panel/TabPanel.jsx';
 
 export class SearchPanel extends SimpleComponent {
 
@@ -52,9 +52,9 @@ export class SearchPanel extends SimpleComponent {
             return (
                 <div>
                     {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
-                    <Tabs componentKey={`SearchPanel_${title}`} onTabSelect={onTabSelect} resizable={true} useFlex={true} borderless={true} contentStyle={{backgroundColor: 'transparent'}}>
+                    <StatefulTabs componentKey={`SearchPanel_${title}`} onTabSelect={onTabSelect} resizable={true} useFlex={true} borderless={true} contentStyle={{backgroundColor: 'transparent'}}>
                         {searchesAsTabs(allSearchItems)}
-                    </Tabs>
+                    </StatefulTabs>
                 </div>
             );
         }

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -60,7 +60,7 @@ export function useStoreConnector(...stateGetters) {
                     setter(getter());
                 });
         });
-    }), [];     // only run once
+    }, []);     // only run once
 
     return rval;
 }

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -54,14 +54,11 @@ export function useStoreConnector(...stateGetters) {
         return [getter, setter];
     });
 
-    const isMounted = true;
     useEffect(() => {
         return flux.addListener(() => {
-            if (isMounted) {
                 setters.forEach(([getter, setter]) => {
                     setter(getter());
                 });
-            }
         });
     }), [];     // only run once
 

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react';
+import React, {PureComponent, useEffect, useState} from 'react';
 import shallowequal from 'shallowequal';
 
 import {flux} from '../Firefly.js';
@@ -33,4 +33,37 @@ export class SimpleComponent extends PureComponent {
             this.setState(this.getNextState(this.props));
         }
     }
+}
+
+
+
+/**
+ * A replacement for SimpleComponent.
+ * This function make use of useState and useEffect to
+ * trigger a re-render of functional components when the value in the store changes.
+ *
+ * @param stateGetters  one or more functions returning a state
+ * @returns {Object[]}  an array of state's value in the order of the given stateGetters
+ */
+export function useStoreConnector(...stateGetters) {
+
+    const rval = [];
+    const setters = stateGetters.map((getter) => {
+        const [val, setter] = useState(getter());
+        rval.push(val);
+        return [getter, setter];
+    });
+
+    const isMounted = true;
+    useEffect(() => {
+        return flux.addListener(() => {
+            if (isMounted) {
+                setters.forEach(([getter, setter]) => {
+                    setter(getter());
+                });
+            }
+        });
+    }), [];     // only run once
+
+    return rval;
 }

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -167,6 +167,7 @@ TabsView.defaultProps= {
 };
 
 
+/*----------------------------------------------------------------------------------------------*/
 /**
  * TabPanel with internal state
  * State will be lost after unload.

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -15,7 +15,7 @@ import './TabPanel.css';
 
 
 /**
- * There are 4 implementations of TabPanel:  Tabs, StatelessTabs, StatefulTabs, and FieldGroupTabs
+ * There are 4 implementations of TabPanel:  Tabs, TabsView, StatefulTabs, and FieldGroupTabs
  * See each component description below for more details.
  */
 
@@ -109,7 +109,7 @@ Tab.defaultProps= { selected: false };
  * A strictly presentational(dumb) component.  No state is used.
  * The selected Tab is determine by defaultSelected which can be an index or the 'id' of its Tabs.
  */
-export const StatelessTabs = React.memo((props) => {
+export const TabsView = React.memo((props) => {
 
     const {children, onTabSelect, defaultSelected, useFlex, resizable, borderless, style={}, headerStyle, contentStyle={}} = props;
 
@@ -148,7 +148,7 @@ export const StatelessTabs = React.memo((props) => {
 });
 
 
-StatelessTabs.propTypes = {
+TabsView.propTypes = {
     defaultSelected:  PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     onTabSelect: PropTypes.func,
     useFlex: PropTypes.bool,
@@ -159,7 +159,7 @@ StatelessTabs.propTypes = {
     borderless: PropTypes.bool
 };
 
-StatelessTabs.defaultProps= {
+TabsView.defaultProps= {
     defaultSelected: 0,
     useFlex: false,
     resizable: false,
@@ -183,11 +183,11 @@ export const Tabs = React.memo( (props) => {
         }
     });
 
-    return (<StatelessTabs {...props} defaultSelected={selectedIdx} onTabSelect={onSelect} />);
+    return (<TabsView {...props} defaultSelected={selectedIdx} onTabSelect={onSelect} />);
 });
 
-Tabs.propTypes = StatelessTabs.propTypes;
-Tabs.defaultProps = StatelessTabs.defaultProps;
+Tabs.propTypes = TabsView.propTypes;
+Tabs.defaultProps = TabsView.defaultProps;
 
 
 /*----------------------------------------------------------------------------------------------*/
@@ -198,7 +198,7 @@ Tabs.defaultProps = StatelessTabs.defaultProps;
 export const StatefulTabs = React.memo( (props) => {
     const {children=[], defaultSelected=0, onTabSelect, componentKey} = props;
 
-    const [selectedIdx = defaultSelected] = useStoreConnector( () => {
+    let [selectedIdx = defaultSelected] = useStoreConnector( () => {
         return get(getComponentState(componentKey), 'selectedIdx');
     });
 
@@ -215,15 +215,15 @@ export const StatefulTabs = React.memo( (props) => {
         }
     });
 
-    return (<StatelessTabs {...props} onTabSelect={onSelect} defaultSelected={selectedIdx} />);
+    return (<TabsView {...props} onTabSelect={onSelect} defaultSelected={selectedIdx} />);
 
 });
 
 StatefulTabs.propTypes = {
     componentKey: PropTypes.string,
-    ...StatelessTabs.propTypes
+    ...TabsView.propTypes
 };
-StatefulTabs.defaultProps = StatelessTabs.defaultProps;
+StatefulTabs.defaultProps = TabsView.defaultProps;
 
 
 /*----------------------------------------------------------------------------------------------*/

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -2,68 +2,48 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import './TabPanel.css';
-import React, {memo, PureComponent} from 'react';
+import React, {memo, useEffect, useState, useCallback} from 'react';
 import PropTypes from 'prop-types';
 import sizeMe from 'react-sizeme';
+import {get, omit} from 'lodash';
+
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
 import {useFieldGroupConnector} from '../FieldGroupConnector.jsx';
+import {useStoreConnector} from '../SimpleComponent.jsx';
+
+import './TabPanel.css';
 
 
+/**
+ * There are 4 implementations of TabPanel:  Tabs, StatelessTabs, StatefulTabs, and FieldGroupTabs
+ * See each component description below for more details.
+ */
 
-function tabsStateFromProps(props) {
-    const {defaultSelected, componentKey} = props;
-    let selectedIdx;
-    const childrenAry = React.Children.toArray(props.children);         // this returns only valid children excluding undefined and false values.
+const TabsHeaderInternal = React.memo((props) => {
+    const {children, resizable, headerStyle={}, size} = props;
 
-    if (componentKey) {
-        // component key should be defined if the state needs to be saved though unmount/mount
-        selectedIdx = getComponentState(componentKey).selectedIdx;
-
-        if (selectedIdx >= childrenAry.length) {
-            // selectedIdx is greater than the number of tabs.. update store's state
-            selectedIdx = childrenAry.length-1;
-            dispatchComponentStateChange(componentKey, {selectedIdx});
-        }
-    } else {
-        selectedIdx = childrenAry.findIndex( (c) => c.props.id===defaultSelected );
+    const {width:widthPx} = size;
+    const numTabs = children.length;
+    let maxTitleWidth = undefined;
+    let sizedChildren = children;
+    if (widthPx && resizable) {
+        // 2*5px - border, for each tab: 2x1px - border, 2x6px - padding, 6px - left margin
+        const availableWidth = widthPx - 5 - 20 * numTabs;
+        maxTitleWidth = Math.min(200, Math.trunc(availableWidth / numTabs));
+        if (maxTitleWidth < 0) { maxTitleWidth = 1; }
+        sizedChildren = React.Children.toArray(children).map((child) => {
+            return React.cloneElement(child, {maxTitleWidth});
+        });
     }
-
-    selectedIdx = selectedIdx >= 0 ? selectedIdx : defaultSelected;
-    return {selectedIdx};
-}
-
-
-class TabsHeaderInternal extends PureComponent {
-    constructor(props) {
-        super(props);
-    }
-
-    render() {
-        const {width:widthPx} = this.props.size;
-        const {children, resizable, headerStyle={}} = this.props;
-        const numTabs = children.length;
-        let maxTitleWidth = undefined;
-        let sizedChildren = children;
-        if (widthPx && resizable) {
-            // 2*5px - border, for each tab: 2x1px - border, 2x6px - padding, 6px - left margin
-            const availableWidth = widthPx - 5 - 20 * numTabs;
-            maxTitleWidth = Math.min(200, Math.trunc(availableWidth / numTabs));
-            if (maxTitleWidth < 0) { maxTitleWidth = 1; }
-            sizedChildren = React.Children.toArray(children).map((child) => {
-                return React.cloneElement(child, {maxTitleWidth});
-            });
-        }
-        const style = Object.assign({flexShrink: 0, height: 20}, headerStyle);
-        return (
-            <div style={style}>
-                {(widthPx||!resizable) ? <ul className='TabPanel__Tabs'>
-                    {sizedChildren}
-                </ul> : <div/>}
-            </div>
-        );
-    }
-}
+    const style = Object.assign({flexShrink: 0, height: 20}, headerStyle);
+    return (
+        <div style={style}>
+            {(widthPx||!resizable) ? <ul className='TabPanel__Tabs'>
+                {sizedChildren}
+            </ul> : <div/>}
+        </div>
+    );
+});
 
 TabsHeaderInternal.propTypes= {
     resizable: PropTypes.bool,
@@ -72,144 +52,47 @@ TabsHeaderInternal.propTypes= {
 };
 
 
+/**
+ * Wrapper supporting resize
+ */
 const TabsHeader= sizeMe({refreshRate: 16})(TabsHeaderInternal);
 
 
-export class Tabs extends PureComponent {
+/*----------------------------- exported components ----------------------------------*/
 
+export const Tab = React.memo( (props) => {
+    const {name, label, selected, onSelect, removable, onTabRemove, id, maxTitleWidth} = props;
 
-    constructor(props) {
-        super(props);
-        this.state= tabsStateFromProps(props);
+    let tabClassName = 'TabPanel__Tab' ;
+    if (selected) {
+        tabClassName += ' TabPanel__Tab--selected';
     }
+    const tabTitle = label || name;
+    // removable width: 14px
+    const textStyle = maxTitleWidth ? {float: 'left', width: maxTitleWidth-(removable?14:0)} : {};
 
-    static getDerivedStateFromProps(props,state) {
-        return props.componentKey ? tabsStateFromProps(props) : state;
-    }
-
-    componentWillUnmount() {
-        this.isUnmounted = true;
-    }
-
-
-    onSelect(index,id,name) {
-        const {onTabSelect, componentKey} = this.props;
-        if (this.state.selectedIdx !== index && !this.isUnmounted) {
-            if (componentKey) {
-                dispatchComponentStateChange(componentKey, {selectedIdx: index});
-            }
-            this.setState({
-                selectedIdx: index
-            });
-        }
-        if (onTabSelect) {
-            onTabSelect(index,id,name);
-        }
-    }
-
-    render () {
-        const { selectedIdx}= this.state;
-        const {children, useFlex, resizable, borderless, style={}, headerStyle, contentStyle={}} = this.props;
-
-        let  content;
-        const newChildren = React.Children.toArray(children).filter((el) => !!el).map((child, index) => {
-            if (index === selectedIdx) {
-                content = React.Children.only(child.props.children);
-            }
-
-            return React.cloneElement(child, {
-                selected: (index === selectedIdx),
-                onSelect: this.onSelect.bind(this, index),
-                key: 'tab-' + (index)
-            });
-        });
-
-        if (content) {
-            content = useFlex ? content : <div style={{display: 'block', position: 'absolute', top:0, bottom:0, left:0, right:0}}>{content}</div>;
-            content = borderless ? content : <div className='TabPanel__Content--inside'>{content}</div>;
-        }
-
-        const contentClsName = borderless ? 'TabPanel__Content borderless' : 'TabPanel__Content';
-
-        return (
-            <div style={{display: 'flex', flexDirection: 'column', overflow: 'hidden', ...style}}>
-                <TabsHeader {...{resizable, headerStyle}}>{newChildren}</TabsHeader>
-                <div ref='contentRef' style={contentStyle} className={contentClsName}>
-                    {(content) ? content : ''}
+    return (
+        <li className={tabClassName} onClick={() => !selected && onSelect(id,name)}>
+            <div style={{height: '100%'}}>
+                <div style={{...textStyle, height: '100%'}} className='text-ellipsis' title={name}>
+                    {tabTitle}
                 </div>
+                {removable &&
+                <div style={{right: -4, top: -2}} className='btn-close'
+                     title='Remove Tab'
+                     onClick={(e) => {
+                         onTabRemove && onTabRemove(name);
+                         e.stopPropagation && e.stopPropagation();
+                     }}/>
+                }
             </div>
-
-        );
-    }
-}
-
-
-Tabs.propTypes= {
-    componentKey: PropTypes.string, // if need to preserve state and is not part of the field group
-    defaultSelected:  PropTypes.any,
-    onTabSelect: PropTypes.func,
-    useFlex: PropTypes.bool,
-    resizable: PropTypes.bool,
-    style: PropTypes.object,
-    headerStyle: PropTypes.object,
-    contentStyle: PropTypes.object,
-    borderless: PropTypes.bool
-};
-
-Tabs.defaultProps= {
-    defaultSelected: 0,
-    useFlex: false,
-    resizable: false,
-    borderless: false
-};
-
-
-export class Tab extends PureComponent {
-    constructor(props) {
-        super(props);
-    }
-
-    componentDidMount() {
-        const {selected, onSelect, id, name} = this.props;
-        if (selected) {
-            onSelect(id, name);
-        }
-    }
-
-    render () {
-        const {name, label, selected, onSelect, removable, onTabRemove, id, maxTitleWidth} = this.props;
-
-        let tabClassName = 'TabPanel__Tab' ;
-        if (selected) {
-            tabClassName += ' TabPanel__Tab--selected';
-        }
-        const tabTitle = label || name;
-        // removable width: 14px
-        const textStyle = maxTitleWidth ? {float: 'left', width: maxTitleWidth-(removable?14:0)} : {};
-
-        return (
-            <li className={tabClassName} onClick={() => onSelect(id,name)}>
-                <div style={{height: '100%'}}>
-                    <div style={{...textStyle, height: '100%'}} className='text-ellipsis' title={name}>
-                         {tabTitle}
-                    </div>
-                    {removable &&
-                            <div style={{right: -4, top: -2}} className='btn-close'
-                                 title='Remove Tab'
-                                 onClick={(e) => {
-                                 onTabRemove && onTabRemove(name);
-                                 e.stopPropagation && e.stopPropagation();
-                            }}/>
-                    }
-                </div>
-            </li>);
-    }
-}
+        </li>);
+});
 
 
 Tab.propTypes= {
     name: PropTypes.string.isRequired, //public
-    label: PropTypes.node,      // used for tab label.  if not given, name will be used as text.      
+    label: PropTypes.node,      // used for tab label.  if not given, name will be used as text.
     id: PropTypes.string,
     selected:  PropTypes.bool.isRequired, // private - true is the tab is currently selected
     onSelect: PropTypes.func, // private - called whenever the tab is clicked
@@ -221,6 +104,129 @@ Tab.propTypes= {
 Tab.defaultProps= { selected: false };
 
 
+/*----------------------------------------------------------------------------------------------*/
+/**
+ * A strictly presentational(dumb) component.  No state is used.
+ * The selected Tab is determine by defaultSelected which can be an index or the 'id' of its Tabs.
+ */
+export const StatelessTabs = React.memo((props) => {
+
+    const {children, onTabSelect, defaultSelected, useFlex, resizable, borderless, style={}, headerStyle, contentStyle={}} = props;
+
+    const onSelect = useCallback( (index,id,name) => {
+        onTabSelect && onTabSelect(index,id,name);
+    }, []);
+
+    const childrenAry = React.Children.toArray(children);         // this returns only valid children excluding undefined and false values.
+    const selectedIdx = Number.isInteger(defaultSelected) ? defaultSelected : childrenAry.findIndex((c) => get(c, 'props.id') === defaultSelected);    // convert defaultSelected to idx if it's an ID
+
+    const headers = childrenAry.map((child, index) => {
+        return React.cloneElement(child, {
+            selected: (index === selectedIdx),
+            onSelect: onSelect.bind(this, index),
+            key: 'tab-' + (index)
+        });
+    });
+
+    let  content = childrenAry.filter( (c, idx) => idx === selectedIdx).map((c) => React.Children.only(c.props.children));
+    if (content) {
+        content = useFlex ? content : <div style={{display: 'block', position: 'absolute', top:0, bottom:0, left:0, right:0}}>{content}</div>;
+        content = borderless ? content : <div className='TabPanel__Content--inside'>{content}</div>;
+    }
+
+    const contentClsName = borderless ? 'TabPanel__Content borderless' : 'TabPanel__Content';
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column', overflow: 'hidden', ...style}}>
+            <TabsHeader {...{resizable, headerStyle}}>{headers}</TabsHeader>
+            <div style={contentStyle} className={contentClsName}>
+                {(content) ? content : ''}
+            </div>
+        </div>
+
+    );
+});
+
+
+StatelessTabs.propTypes = {
+    defaultSelected:  PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    onTabSelect: PropTypes.func,
+    useFlex: PropTypes.bool,
+    resizable: PropTypes.bool,
+    style: PropTypes.object,
+    headerStyle: PropTypes.object,
+    contentStyle: PropTypes.object,
+    borderless: PropTypes.bool
+};
+
+StatelessTabs.defaultProps= {
+    defaultSelected: 0,
+    useFlex: false,
+    resizable: false,
+    borderless: false
+};
+
+
+/**
+ * TabPanel with internal state
+ * State will be lost after unload.
+ */
+export const Tabs = React.memo( (props) => {
+    const {defaultSelected=0, onTabSelect} = props;
+
+    const [selectedIdx, setSelectedIdx] = useState(defaultSelected);
+
+    const onSelect = useCallback( (index,id,name) => {
+        if (index !== selectedIdx) {
+            setSelectedIdx(index);
+            onTabSelect && onTabSelect(index,id,name);
+        }
+    });
+
+    return (<StatelessTabs {...props} defaultSelected={selectedIdx} onTabSelect={onSelect} />);
+});
+
+Tabs.propTypes = StatelessTabs.propTypes;
+Tabs.defaultProps = StatelessTabs.defaultProps;
+
+
+/*----------------------------------------------------------------------------------------------*/
+/**
+ * TabPanel with ComponentCntlr supported state
+ * Selected state is stored as <componentKey>.selectedIdx
+ */
+export const StatefulTabs = React.memo( (props) => {
+    const {children=[], defaultSelected=0, onTabSelect, componentKey} = props;
+
+    const [selectedIdx = defaultSelected] = useStoreConnector( () => {
+        return get(getComponentState(componentKey), 'selectedIdx');
+    });
+
+    const onSelect = useCallback( (index,id,name) => {
+        dispatchComponentStateChange(componentKey, {selectedIdx: index});
+        onTabSelect && onTabSelect(index,id,name);
+    }, []);
+
+    useEffect( ()=> {
+        if (selectedIdx >= children.length) {
+            // selectedIdx is greater than the number of tabs.. update store's state
+            selectedIdx = children.length-1;
+            dispatchComponentStateChange(componentKey, {selectedIdx});
+        }
+    });
+
+    return (<StatelessTabs {...props} onTabSelect={onSelect} defaultSelected={selectedIdx} />);
+
+});
+
+StatefulTabs.propTypes = {
+    componentKey: PropTypes.string,
+    ...StatelessTabs.propTypes
+};
+StatefulTabs.defaultProps = StatelessTabs.defaultProps;
+
+
+/*----------------------------------------------------------------------------------------------*/
 
 function onChange(idx,id, name, viewProps, fireValueChange) {
     let value= id||name;
@@ -232,8 +238,11 @@ function onChange(idx,id, name, viewProps, fireValueChange) {
     }
 }
 
-
-export const FieldGroupTabs= memo( (props) => {
+/**
+ * TabPanel with FieldGroup supported state
+ * The selected index is saved as the value of the field named by fieldKey
+ */
+export const FieldGroupTabs = memo( (props) => {
     const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
     const newProps= {
         ...viewProps,
@@ -244,15 +253,12 @@ export const FieldGroupTabs= memo( (props) => {
     return (<Tabs {...newProps} />);
 });
 
-FieldGroupTabs.propTypes= {
+FieldGroupTabs.propTypes = {
     fieldKey: PropTypes.string,
-    onTabSelect: PropTypes.func,
+    forceReinit: PropTypes.bool,
     initialState: PropTypes.shape({
         value: PropTypes.string,
     }),
-    resizable: PropTypes.bool,
-    headerStyle: PropTypes.object,
-    contentStyle: PropTypes.object,
-    borderless: PropTypes.bool,
-    forceReinit: PropTypes.bool
+    ...omit(Tabs.propTypes, 'defaultSelected')     //  defaultSelected is not used.. use value for defaultSelected.
 };
+FieldGroupTabs.defaultProps = omit(Tabs.defaultProps, 'defaultSelected');

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -11,7 +11,7 @@ import {SizeInputFields} from '../../ui/SizeInputField.jsx';
 import {TargetPanel} from '../../ui/TargetPanel.jsx';
 import {ServerParams} from '../../data/ServerParams.js';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
-import {Tabs, Tab} from '../../ui/panel/TabPanel.jsx';
+import {StatefulTabs, Tab} from '../../ui/panel/TabPanel.jsx';
 import {dispatchHideDropDown} from '../../core/LayoutCntlr.js';
 import {FileUpload} from '../../ui/FileUpload.jsx';
 import {ValidationField} from '../../ui/ValidationField.jsx';
@@ -276,7 +276,7 @@ function ThreeColor({imageMasterData, multiSelect, archiveName}) {
 
     return (
         <div className='flex-full' style={{marginTop: 5}}>
-            <Tabs componentKey='ImageSearchPanelV2' resizable={false} useFlex={true} borderless={true}
+            <StatefulTabs componentKey='ImageSearchPanelV2' resizable={false} useFlex={true} borderless={true}
                   style={{flexGrow: 1}}
                   contentStyle={{backgroundColor: 'rgb(202, 202, 202)', paddingBottom: 2}}
                   headerStyle={{display:'inline-flex', marginLeft: 185}}>
@@ -289,7 +289,7 @@ function ThreeColor({imageMasterData, multiSelect, archiveName}) {
                 <Tab key='ImageSearchBlue' name='blue' label={<div style={{width:40, color:'blue'}}>Blue</div>}>
                     <SingleChannel {...{groupKey: FG_KEYS.blue, imageMasterData, multiSelect, archiveName}}/>
                 </Tab>
-            </Tabs>
+            </StatefulTabs>
         </div>
     );
 }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-67

Tests:  
https://irsawebdev9.ipac.caltech.edu/FIREFLY-67/firefly/
https://irsawebdev9.ipac.caltech.edu/FIREFLY-67/applications/sofia/

Additional changes:  https://github.com/IPAC-SW/irsa-ife/pull/63

TabPanel was not working in some cases.  It was also very complex in the way it handles its multiple use cases.
Changes:
- Refactor TabPanel
  - separate the different tab types using composition.
  -  convert to functional components with hooks
- Fixes Example Js Dialog 'third' tab prop validation error.
- Create replacement for SimplePanel using hooks.

Also:
I think `useFieldGroupConnector` relies on the view not getting unmounted.  When I use StatelessTabs for its view, onChange was not called.  Not a big deal, switching to Tabs(internal state) works fine.