### PR TITLE
FIREFLY-43 Recognize the "access_url" column in a table and display it as a link

### DIFF
--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -1,7 +1,9 @@
 import {dispatchAddTableTypeWatcherDef} from '../../core/MasterSaga.js';
 import {catalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
+import {urlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
 
 
-export function startTTFeatureWatchers(startIds=[catalogWatcherDef.id]) {
+export function startTTFeatureWatchers(startIds=[catalogWatcherDef.id, urlLinkWatcherDef.id]) {
     startIds.includes(catalogWatcherDef.id) && dispatchAddTableTypeWatcherDef(catalogWatcherDef);
+    startIds.includes(urlLinkWatcherDef.id) && dispatchAddTableTypeWatcherDef(urlLinkWatcherDef);
 }

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -625,15 +625,26 @@ export function findTableCenterColumns(table) {
 }
 
 
+/**
+ * find ObsCore defined 's_region' column
+ * @param table
+ * @returns {(*|TableRecognizer)|*}
+ */
 export function findTableRegionColumn(table) {
     const tblRecog = get(table, ['tableData', 'columns']) && TableRecognizer.newInstance(table);
     return tblRecog && tblRecog.getRegionColumn();
 }
 
+/**
+ * find the ObsCore defined 'access_url' column
+ * @param table
+ * @returns {Object}
+ */
 export function findTableAccessURLColumn(table) {
     const urlCol = getObsCoreTableColumn(table, 'access_url');
     return isEmpty(urlCol) ? null : urlCol;
 }
+
 /**
  * Given a TableModel or a table id return a table model
  * @param {TableModel|String} tableOrId - a table model or a table id

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -70,7 +70,7 @@ function getObsCoreTableColumn(tableOrId, name) {
         const prefUtype= cols.find( (c) => c.name===name);
         return prefUtype ? prefUtype : cols[0];
     }
-    cols= tblRec.getTblColumnsOnUCD(entry.ucd);
+    cols= tblRec.getTblColumnsOnDefinedUCDValue(entry.ucd);
     if (cols.length) {
         if (cols.length===1) return cols[0];
         const prefUcd= cols.find( (c) => c.name===name);
@@ -224,6 +224,22 @@ class TableRecognizer {
         return this.regionColumnInfo;
     }
 
+    /**
+     * filter the columns per ucd value defined in the UCD value of relevant OBSTAP column
+     * @param ucds ucd value defined in OBSTAP, it may contain more than one ucd values
+     * @returns {*}
+     */
+    getTblColumnsOnDefinedUCDValue(ucds) {
+        const ucdList = ucds.split(';');
+
+        return ucdList.reduce((prev, ucd) => {
+                prev = prev.filter((oneCol) => {
+                    return (has(oneCol, 'UCD') && isUCDWith(oneCol.UCD, ucd, get(ucdSyntaxMap, ucd)));
+                });
+                return prev;
+        }, this.columns);
+
+    }
     /**
      * get columns containing the same ucd value
      * @param ucd
@@ -613,6 +629,11 @@ export function findTableRegionColumn(table) {
     const tblRecog = get(table, ['tableData', 'columns']) && TableRecognizer.newInstance(table);
     return tblRecog && tblRecog.getRegionColumn();
 }
+
+export function findTableAccessURLColumn(table) {
+    const urlCol = getObsCoreTableColumn(table, 'access_url');
+    return isEmpty(urlCol) ? null : urlCol;
+}
 /**
  * Given a TableModel or a table id return a table model
  * @param {TableModel|String} tableOrId - a table model or a table id
@@ -623,6 +644,7 @@ function getTableModel(tableOrId) {
     if (isObject(tableOrId)) return tableOrId;
     return undefined;
 }
+
 
 /**
  * table analyzer based on the table model for columns which contains column_name & ucd columns

--- a/src/firefly/js/visualize/saga/UrlLinkWatcher.js
+++ b/src/firefly/js/visualize/saga/UrlLinkWatcher.js
@@ -1,0 +1,52 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {TABLE_LOADED} from '../../tables/TablesCntlr.js';
+import {findTableAccessURLColumn} from '../../util/VOAnalyzer.js';
+
+
+/** type {TableWatcherDef}
+ *  TODO: for testTable, more logic could be added if the API of setting table meta for any link-like column is supported
+ * */
+export const urlLinkWatcherDef = {
+    id : 'URLLinkWatcher',
+    watcher : watchURLLinkColumns,
+    testTable : (table) => findTableAccessURLColumn(table),
+    actions: [TABLE_LOADED]
+};
+
+
+
+/**
+ * Action watcher callback: watch the tables with access_url column and update table column attributes for
+ * table rendering which displays access_url column as a link.
+ * @param tbl_id
+ * @param action
+ * @param cancelSelf
+ * @param params
+ * @return {*}
+ */
+export function watchURLLinkColumns(tbl_id, action, cancelSelf, params) {
+    if (!action) {
+        return params;
+    }
+    const {payload}= action;
+    if (payload.tbl_id && payload.tbl_id!==tbl_id) return params;
+
+    switch (action.type) {
+        case TABLE_LOADED:
+            handleLinkColumnUpdate(tbl_id);
+            break;
+    }
+    return params;
+}
+
+function handleLinkColumnUpdate(tbl_id) {
+    const linkCol = findTableAccessURLColumn(tbl_id);
+
+    if (linkCol && (!linkCol.type || linkCol.type === 'char')) {
+        linkCol.type = 'location';
+        //linkCol.links = [ { }];
+    }
+}

--- a/src/firefly/js/visualize/saga/UrlLinkWatcher.js
+++ b/src/firefly/js/visualize/saga/UrlLinkWatcher.js
@@ -4,6 +4,9 @@
 
 import {TABLE_LOADED} from '../../tables/TablesCntlr.js';
 import {findTableAccessURLColumn} from '../../util/VOAnalyzer.js';
+import {getTblById} from '../../tables/TableUtil.js';
+import {dispatchTableUpdate} from '../../tables/TablesCntlr.js';
+import {clone} from '../../util/WebUtil.js';
 
 
 /** type {TableWatcherDef}
@@ -43,10 +46,12 @@ export function watchURLLinkColumns(tbl_id, action, cancelSelf, params) {
 }
 
 function handleLinkColumnUpdate(tbl_id) {
+    const tbl = getTblById(tbl_id);
     const linkCol = findTableAccessURLColumn(tbl_id);
 
     if (linkCol && (!linkCol.type || linkCol.type === 'char')) {
         linkCol.type = 'location';
         //linkCol.links = [ { }];
+        dispatchTableUpdate(clone(tbl));
     }
 }


### PR DESCRIPTION
This PR is for https://jira.ipac.caltech.edu/browse/FIREFLY-43, includes development:
- add a watcher to find the qualified table which has 'access_url' column 
- display the column as a link and enable the link to be used for a download of the associated data file.

test
https://irsawebdev9.ipac.caltech.edu/firefly-43/firefly/firefly-dev.html
do TAP search on MAST->ivoa->ivoa.obscore & spatial search 
get a table in which each cell of access_url column is shown as a link