### PR TITLE
FIREFLY-31: make any popup panel text selectable and copyable

### DIFF
--- a/src/firefly/js/ui/PopupPanel.jsx
+++ b/src/firefly/js/ui/PopupPanel.jsx
@@ -131,7 +131,7 @@ export class PopupPanel extends PureComponent {
         return (
             <div style={{zIndex: this.props.zIndex, position:'relative'}}>
                 {this.props.modal && <div className='popup-panel-glass'/>}
-                <div ref={(c) => this.popupRef=c} style={rootStyle} className={'popup-panel-shadow disable-select'}
+                <div ref={(c) => this.popupRef=c} style={rootStyle} className={'popup-panel-shadow enable-select'}
                      onTouchStart={this.dialogMoveStart}
                      onTouchMove={this.dialogMove}
                      onTouchEnd={this.dialogMoveEnd}


### PR DESCRIPTION
This small change is to allow user to select and copy text from a popup panel and dialog which was requested in those other tickets:
IRSA-1613 (marker coordinates not copyable) and FIREFLY-65 (hips properties info dialog).

Please test that any dialog or popup text can be selected and copied and confirm.