### PR TITLE
FIREFLY-30: Add support for proprietary data display in table

### DIFF
--- a/__jest__/InitTest.js
+++ b/__jest__/InitTest.js
@@ -83,7 +83,7 @@ jest.mock('firefly/visualize/WorkspaceCntlr.js', () => {
 
 jest.mock('firefly/tables/TablesCntlr.js', () => {
     return {
-        TABLE_UPDATE:'',TABLE_REPLACE:'',TABLE_SPACE_PATH: '',
+        TABLE_UPDATE:'',TABLE_REPLACE:'',TABLE_SPACE_PATH: '', TABLE_LOADED: 'table.loaded',
         dispatchTableFilter: () => '',
         dispatchTableSelect: () => '',
     };

--- a/src/firefly/html/demo/ffapi-table-test.html
+++ b/src/firefly/html/demo/ffapi-table-test.html
@@ -206,21 +206,24 @@ There are additional information specific to each input field.  Click the top bu
 Anything set in META_INFO will go into the resulting table as tableMeta.
 
 Column property can be set via META_INFO as well.  However, there's a discrepancy between the JS and Java constants.
-This will be resolved in the near future.
+This will be resolved in the near future.  These exposed properties should mirrored java code: edu.caltech.ipac.table.IpacTableUtil.consumeColumnInfo
 Use format:  col.[col-name].[col-prop]
 
 [col-prop] : java -> javascript
-Label               * @prop {string} label     display name of the column
-Unit                * @prop {string} units     data units
+Label               * @prop {string} label      display name of the column
+Visibility          * @prop {string} visibility show, hide, or hidden.  hidden columns are not viewable by users.
+Width               * @prop {number} width      max width needed to display data.
+PrefWidth           * @prop {number} prefWidth  preferred width, regardless of the data.
+Desc                * @prop {string} desc       description of the column
+ShortDescription    * @prop {string} desc       description of the column        // @deprecated, for backward compatibility only
 NullStr             * @prop {string} nullString string used to represent null value
-Desc                * @prop {string} desc      description of the column
-Width               * @prop {number} width     max width needed to display data.
-PrefWidth           * @prop {number} prefWidth     preferred width, regardless of the data.
-Sortable            * @prop {boolean} sortable     true if undefined
-Filterable          * @prop {boolean} filterable   true if undefined
-Visibility          * @prop {string} visibility    show, hide, or hidden.  hidden columns are not viewable by users.
+Unit                * @prop {string} units      data units
+Format              * @prop {string} format     a java format to be applied to the value.  This can applies to any data type.
+FmtDisp             * @prop {string} fmtDisp    alias to Format.                // @deprecated, for backward compatibility only
+Sortable            * @prop {boolean} sortable  true if undefined
+Filterable          * @prop {boolean} filterable true if undefined
+SortByCols          * @prop {string} sortByCols column to be sorted by.  values are separted by comma(',')
 EnumVals            * @prop {string} enumVals   contains only values in this list.  values are seprated by comma(',')
-Format              * @prop {string} format   a java format to be applied to the value.  This can applies to any data type.
 Precision           * @prop {string} precision applies only to floating point numbers.
                                                A string Tn where T is either F, E, or G
                                                If T is not present, it defaults to F.
@@ -229,9 +232,10 @@ Precision           * @prop {string} precision applies only to floating point nu
 UCD                 * @prop {string} UCD       UCD of this column.
 UType               * @prop {string} utype     UType of this column.
 Ref                 * @prop {string} ref       refer to this column for declarations.
-Value               * @prop {string} value     static value of this column for all of the rows in this table
-MaxValue            * @prop {string} maxValue  maximum value.
 MinValue            * @prop {string} minValue  minimum value.
+MaxValue            * @prop {string} maxValue  maximum value.
+Links               * @prop {string} links     array of LINK if any
+Value               * @prop {string} value     static value of this column for all of the rows in this table
 
                 </pre>
             </div>

--- a/src/firefly/html/test/styles.css
+++ b/src/firefly/html/test/styles.css
@@ -80,16 +80,16 @@ ul.expected-list li{
     padding: 3px;
     margin: 5px 10px;
     flex-direction: column;
+    min-height: 800px;
 }
 .tst-iframe-container {
     overflow: hidden;
+    margin: 5px 0;
 }
 
 .tst-iframe-container iframe {
     border: 0;
     width: 100%;
-    resize : both;
-    display: flex;
     background-color: rgba(0,0,0, .04);
     margin-bottom: 5px;
 }
@@ -98,6 +98,12 @@ ul.expected-list li{
     height: 100%;
     display: flex;
     flex-direction: column;
+}
+
+#expected {
+    width: 400px;
+    white-space: normal;
+    padding-top: 2px;
 }
 
 .tpl-test-container {
@@ -137,3 +143,15 @@ ul.expected-list li{
     min-width: 0;
 }
 
+.tst-iframe-container.popout {
+    position: absolute;
+    border: 1px solid #b3b3b3;
+    height: calc(100% - 50px);
+    width: calc(100% - 50px);
+    background: #cccccc;
+    box-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}
+
+#tpl-popout {
+    margin-left: 20px;
+}

--- a/src/firefly/html/test/styles.css
+++ b/src/firefly/html/test/styles.css
@@ -144,12 +144,14 @@ ul.expected-list li{
 }
 
 .tst-iframe-container.popout {
-    position: absolute;
-    border: 1px solid #b3b3b3;
-    height: calc(100% - 50px);
-    width: calc(100% - 50px);
+    position: fixed;
+    border: 2px solid #b3b3b3;
+    height: calc(100% - 50px) !important;
+    width: calc(100% - 50px) !important;
     background: #cccccc;
-    box-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+    box-shadow: 5px 5px 10px 0 rgba(0,0,0,0.3);
+    margin: 0 -10px;
+    border-radius: 3px;
 }
 
 #tpl-popout {

--- a/src/firefly/html/test/template.html
+++ b/src/firefly/html/test/template.html
@@ -65,15 +65,36 @@
             }
         }
 
+        function closePopout() {
+            window.template.iframeContainer.classList.remove('popout');
+            const handle = document.getElementById('tpl-popout');
+            handle.onclick = popout;
+            handle.textContent = "expand"
+            const container = document.getElementById('tpl-container');
+            container.classList.remove('fullHeight');
+        }
+
+        function popout() {
+            window.template.iframeContainer.classList.add('popout');
+            const handle = document.getElementById('tpl-popout');
+            handle.onclick = closePopout;
+            handle.textContent = "close"
+            const container = document.getElementById('tpl-container');
+            container.classList.add('fullHeight');
+        }
+
     </script>
 
 </head>
 
-<body style='height: 100%;'>
+<body style='height: 100%;margin: 0;'>
 
 
 <template id="test_template">
-    <div id="tpl-title"></div>
+    <div style="display: inline-flex">
+        <div id="tpl-title"></div>
+        <a id="tpl-popout" onclick="popout()" href="javascript:void(0)">expand</a>
+    </div>
     <div class="tpl-test-container">
         <div  class="tpl-item-box">
             <div class="tpl-label">expected:</div>

--- a/src/firefly/html/test/template.html
+++ b/src/firefly/html/test/template.html
@@ -67,6 +67,7 @@
 
         function closePopout() {
             window.template.iframeContainer.classList.remove('popout');
+            window.frameElement.style.position = 'initial';
             const handle = document.getElementById('tpl-popout');
             handle.onclick = popout;
             handle.textContent = "expand"
@@ -76,6 +77,7 @@
 
         function popout() {
             window.template.iframeContainer.classList.add('popout');
+            window.frameElement.style.position = 'absolute';
             const handle = document.getElementById('tpl-popout');
             handle.onclick = closePopout;
             handle.textContent = "close"

--- a/src/firefly/html/test/template_loader.js
+++ b/src/firefly/html/test/template_loader.js
@@ -10,22 +10,24 @@
             const scpt = c.querySelector('script');
             const title = cnt++ + ' - ' + test.title;
 
-            renderTest(expected, actual, scpt, title, test.className);
+            renderTest(expected, actual, scpt, title, test);
         });
     };
 
-    function renderTest(expected, actual, script, title, className) {
+    function renderTest(expected, actual, script, title, testTmpl) {
         const iframe = document.createElement('iframe');
+        iframe.id = 'iframe';
         iframe.src = './template.html';
-        iframe.style.minHeight= '200px';
-        const idiv = document.createElement('div');
-        idiv.className = 'tst-iframe-container';
-        idiv.appendChild(iframe);
-        document.getElementById('tst-container').appendChild(idiv);
+        iframe.style.height= '100%';
+        const iframeContainer = document.createElement('div');
+        iframeContainer.className = 'tst-iframe-container ' + testTmpl.className;
+        iframeContainer.style.cssText = testTmpl.style.cssText;
+        iframeContainer.appendChild(iframe);
+        document.getElementById('tst-container').appendChild(iframeContainer);
 
-        iframe.contentWindow.template = {expected, actual, script, title, className};
+        iframe.contentWindow.template = {expected, actual, script, title, className: testTmpl.className, iframeContainer};
         iframe.contentWindow.resizeIframeToHeight= function (size) {
-            iframe.style.minHeight= size;
+            iframe.parentElement.style.minHeight= size;
         };
     }
 

--- a/src/firefly/html/test/tests-main.html
+++ b/src/firefly/html/test/tests-main.html
@@ -18,7 +18,7 @@
 <!-- define all of your tests below -->
 
 <template title="IRSA Gator Table" class="tpl" >
-    <div id="expected" class="flow-h">
+    <div id="expected" class="flow-h" style="width: 450px">
         <div class="source-code indent-3">
             - widgets loaded
             - toolbars match
@@ -31,7 +31,6 @@
         <div id="gatorXy" class="box"></div>
     </div>
     <script>
-        resizeIframeToHeight('300px');
         irsaviewer_init();
 
         onFireflyLoaded = function (firefly) {
@@ -73,7 +72,7 @@
 </template>
 
 
-<template title="NED catalog VOTable" class="tpl sm">
+<template title="NED catalog VOTable" class="tpl">
     <div id="expected">
         <img src="./images/ned-table.jpg">
         <div class="source-code indent-3">
@@ -83,7 +82,6 @@
     </div>
     <div id="actual" class="box x3"></div>
     <script>
-        resizeIframeToHeight('240px');
         onFireflyLoaded = function (firefly) {
             tblReq = firefly.util.table.makeTblRequest('NedSearch', 'm8 (NED SCS 10)',
                 { use: "catalog_overlay",
@@ -124,8 +122,8 @@
     </script>
 </template>
 
-<template title="Failed API Image Load" class="tpl sm">
-    <div id="expected" style="width: 400px; white-space: normal; padding-top: 2px">
+<template title="Failed API Image Load" class="tpl" style="height: 260px">
+    <div id="expected" >
         <div>Image load fails. The following should happen:
             <ul class='expected-list'>
                 <li>No Image</li>
@@ -137,7 +135,6 @@
     </div>
     <div id="actual" class="box x3"></div>
     <script>
-        resizeIframeToHeight('260px');
         function onFireflyLoaded(firefly) {
             const req= {
                 plotGroupId : 'myGroup',
@@ -151,8 +148,8 @@
     </script>
 </template>
 
-<template title="Two table coverage" class="tpl sm">
-    <div id="expected" style="width: 400px; white-space: normal; padding-top: 2px">
+<template title="Two table coverage" class="tpl" style="height: 260px">
+    <div id="expected" >
         <div>Both tables cover similar area, HiPS coverage
             <ul class='expected-list'>
                 <li>one from url, one from service</li>
@@ -166,7 +163,6 @@
         <div id='coverageHere' class="box"></div>
     </div>
     <script>
-        resizeIframeToHeight('260px');
         function onFireflyLoaded(firefly) {
             firefly.showCoverage('coverageHere', {gridOn:true});
             tblReq1 = firefly.util.table.makeIrsaCatalogRequest('allwise_p3as_psd', 'WISE', 'allwise_p3as_psd',
@@ -180,6 +176,53 @@
                 });
             firefly.showTable('tables-1', tblReq1);
             firefly.showTable('tables-1', tblReq3);
+        }
+    </script>
+</template>
+
+<template title="Column links via API" class="tpl sm">
+    <div id="expected" >
+        <div>Using META-INFO API to show cell value as links
+            <ul class='expected-list'>
+                <li><b>band</b> should be shown as links</li>
+                <li>first one links to irsa</li>
+                <li>second links to ivoa with constant text</li>
+            </ul>
+        </div>
+    </div>
+    <div id="actual" class="flow-h" style="width: 600px">
+        <div id='tables-1' class="box"></div>
+    </div>
+    <script>
+        function onFireflyLoaded(firefly) {
+            tblReq1 = firefly.util.table.makeFileRequest(null, 'http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',null,
+                { META_INFO: {
+                    "col.band.Links": [{href: "https://irsa.ipac.caltech.edu/?id="}, {href: "http://ivoa.net/?id=", value: 'ivoa'}]
+                }});
+            firefly.showTable('tables-1', tblReq1);
+        }
+    </script>
+</template>
+
+
+<template title="Test Proprietary Data Display" class="tpl sm">
+    <div id="expected" >
+        <div>Set <b>band</b> as a data_rights columns. Values that will resolve to true are: 'public', 'secure', '1', 'true', 't'
+            <ul class='expected-list'>
+                <li>all rows where band != 1 will show up as no-access(pink)</li>
+            </ul>
+        </div>
+    </div>
+    <div id="actual" class="flow-h" style="width: 600px">
+        <div id='tables-1' class="box"></div>
+    </div>
+    <script>
+        function onFireflyLoaded(firefly) {
+            tblReq1 = firefly.util.table.makeFileRequest(null, 'http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',null,
+                { META_INFO: {
+                        DATARIGHTS_COL: "band"
+                    }});
+            firefly.showTable('tables-1', tblReq1);
         }
     </script>
 </template>

--- a/src/firefly/html/test/tests-viewer.html
+++ b/src/firefly/html/test/tests-viewer.html
@@ -18,7 +18,7 @@
 <!-- define all of your tests below -->
 
 <template title="Slate Test" class="tpl sm">
-    <div id="expected" style="width: 400px; white-space: normal; padding-top: 2px">
+    <div id="expected" >
         <div>Click on each link in order
             <ul class='expected-list'>
                 <li>new tab should start</li>
@@ -303,7 +303,7 @@
 
 
 <template title="Send to HiPS Viewer Test" class="tpl sm">
-    <div id="expected" style="width: 400px; white-space: normal; padding-top: 2px">
+    <div id="expected" >
         <div>Click on load six link...
             <ul class='expected-list'>
                 <li>start a new viewer window</li>

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -7,7 +7,9 @@ import edu.caltech.ipac.firefly.data.Param;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.util.StringUtils;
 import netscape.javascript.JSObject;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,6 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 /**
  * @author loi
@@ -370,7 +373,7 @@ public class JsonTableUtil {
      * @param linkInfos
      * @return
      */
-    private static List<JSONObject> toJsonLinkInfos(List<LinkInfo> linkInfos) {
+    public static List<JSONObject> toJsonLinkInfos(List<LinkInfo> linkInfos) {
 
         return linkInfos.stream().map(link -> {
             JSONObject json = new JSONObject();
@@ -383,6 +386,34 @@ public class JsonTableUtil {
             applyIfNotEmpty(link.getAction(),   v -> json.put("action", v));
             return json;
         }).collect(Collectors.toList());
+    }
+
+    /**
+     * The invert of #toJsonLinkInfos().  This convert the JSON linkInfos string into
+     * a List of LinkInfo.
+     * @param jsonLinkInfos     the string to parse into LinkInfo
+     * @return  a List of LinkInfo
+     */
+    public static List<LinkInfo> toLinkInfos(String jsonLinkInfos) {
+
+        List<LinkInfo> rval = new ArrayList<>();
+        if (!isEmpty(jsonLinkInfos)) {
+            JSONArray links = (JSONArray) JSONValue.parse(jsonLinkInfos);
+            for (int i = 0; i < links.size(); i++) {
+                JSONObject li = (JSONObject) links.get(i);
+                LinkInfo linkInfo = new LinkInfo();
+                applyIfNotEmpty(li.get("ID"),    v -> linkInfo.setID(v.toString()));
+                applyIfNotEmpty(li.get("href"),  v -> linkInfo.setHref(v.toString()));
+                applyIfNotEmpty(li.get("title"), v -> linkInfo.setTitle(v.toString()));
+                applyIfNotEmpty(li.get("value"), v -> linkInfo.setValue(v.toString()));
+                applyIfNotEmpty(li.get("role"),  v -> linkInfo.setRole(v.toString()));
+                applyIfNotEmpty(li.get("type"),  v -> linkInfo.setType(v.toString()));
+                applyIfNotEmpty(li.get("action"), v -> linkInfo.setAction(v.toString()));
+                rval.add(linkInfo);
+            }
+            return rval;
+        }
+        return null;
     }
 
     private static JSONObject toJsonMetaEntry(String key, String value, boolean isKeyword) {

--- a/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
@@ -45,6 +45,7 @@ public class TableMeta implements Serializable {
     public static final String MIN_VALUE_TAG = "col.@.MinValue";
     public static final String MAX_VALUE_TAG = "col.@.MaxValue";
     public static final String VALUE_TAG = "col.@.Value";
+    public static final String LINKS_TAG = "col.@.Links";
 
 
     public static final String RESULTSET_ID = "resultSetID";            // this meta if exists contains the ID of the resultset returned.

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -57,6 +57,11 @@ export const MetaConst = {
     /** the column name with the url or filename of the image data */
     DATA_SOURCE : 'DataSource',
 
+    /** the column name with access rights info;  true if (public, 1, or true), otherwise false  */
+    DATARIGHTS_COL : 'DATARIGHTS_COL',
+
+    /** the column name with public release date info;  null is considered not public */
+    RELEASE_DATE_COL : 'RELEASE_DATE_COL',
 
     /** @deprecated use CENTER_COLUMN */
     CATALOG_COORD_COLS : 'CatalogCoordColumns',

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -61,10 +61,10 @@ const simpleCreate= (table, converterTemplate) => converterTemplate;
 
 
 /**
- *
+ * Returns a callback function or a Promise<DataProductsDisplayType>.
+ * callback: function(table:TableModel, row:String,activeParams:{imageViewerId:String,chartViewId:String,tableViewId:String,converterId:String})
  * @param makeReq
- * @return {function(table:TableModel, row:String,activeParams:{imageViewerId:String,chartViewId:String,tableViewId:String,converterId:String})
- *                                : Promise<DataProductsDisplayType>}
+ * @return {function | promise}
  */
 function getSingleDataProductWrapper(makeReq) {
     return (table, row, activateParams) => {
@@ -79,9 +79,10 @@ function getSingleDataProductWrapper(makeReq) {
 
 /**
  *
+ * Returns a callback function or a Promise<DataProductsDisplayType>.
+ * callback: function(table:TableModel, plotRows:Array.<Object>,activeParams:{imageViewerId:String,chartViewId:String,tableViewId:String,converterId:String})
  * @param makeReq
- * @return {function(table:TableModel, plotRows:Array.<Object>,activeParams:{imageViewerId:String,chartViewId:String,tableViewId:String,converterId:String})
- *                                : Promise<DataProductsDisplayType>}
+ * @return {function | promise}
  */
 function getGridDataProductWrapper(makeReq) {
     return (table, plotRows, activateParams) => {

--- a/src/firefly/js/metaConvert/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/ObsCoreConverter.js
@@ -1,6 +1,6 @@
 import {get} from 'lodash';
 import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
-import {getCellValue, doFetchTable} from '../tables/TableUtil.js';
+import {getCellValue, doFetchTable, getProprietaryInfo} from '../tables/TableUtil.js';
 import {getObsCoreAccessURL, getObsCoreProdType} from '../util/VOAnalyzer.js';
 import {
     findTableCenterColumns,
@@ -14,6 +14,7 @@ import {ZoomType} from '../visualize/ZoomType.js';
 import {makeWorldPt} from '../visualize/Point.js';
 import {createGridImagesActivate, createSingleImageActivate} from './ImageDataProductsUtil.js';
 import {dispatchTableSearch} from '../tables/TablesCntlr';
+import {hasRowAccess} from '../tables/TableUtil';
 
 const GIG= 1048576 * 1024;
 const previewTableId= 'OBCORE-TBL';
@@ -93,6 +94,10 @@ export function getObsCoreSingleDataProduct(table, row, activateParams, includeM
 
     if (!dataSource || (isVoTable && !isDataLink)) {
         return Promise.resolve({displayType:'message', message: prodType +' is not yet supported'});
+    }
+
+    if (getProprietaryInfo(table).length > 0 && !hasRowAccess(table, table.highlightedRow)) {
+        return Promise.resolve({displayType:'message', message: 'You do not have access to these data.'});
     }
 
     let obsCollect= getCellValue(table,row,'obs_collection') || '';

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -17,6 +17,7 @@ import {selectedValues} from '../rpc/SearchServicesJson.js';
 import {trackBackgroundJob, isSuccess, isDone, getErrMsg} from '../core/background/BackgroundUtil.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
 import {dispatchComponentStateChange} from '../core/ComponentCntlr.js';
+import {dispatchJobAdd} from '../core/background/BackgroundCntlr.js';
 
 
 export const TABLE_SPACE_PATH = 'table_space';

--- a/src/firefly/js/tables/reducer/TableDataReducer.js
+++ b/src/firefly/js/tables/reducer/TableDataReducer.js
@@ -74,7 +74,7 @@ function handleTableUpdates(root, action) {
     return root;
 }
 
-/* Additional logic to applies to the table before it's place into the store */
+/* Applies ObsCore's related logic to the table before it's placed into the store */
 function handleObsCoreTable(root, action) {
 
     const {tbl_id} = action.payload || {};

--- a/src/firefly/js/tables/reducer/TableDataReducer.js
+++ b/src/firefly/js/tables/reducer/TableDataReducer.js
@@ -7,72 +7,130 @@ import {updateSet} from '../../util/WebUtil.js';
 import * as TblUtil from '../TableUtil.js';
 import * as Cntlr from '../TablesCntlr.js';
 import {SelectInfo} from '../SelectInfo.js';
-
+import {getColByUCD, getColByUtype, getTblById, getColumn} from '../TableUtil.js';
+import {isObsCoreLike} from '../../util/VOAnalyzer.js';
+import {MetaConst} from '../../data/MetaConst.js';
 
 
 /*---------------------------- REDUCERS -----------------------------*/
 export function dataReducer(state={data:{}}, action={}) {
-    var root = state.data;
+    let root = state.data;
+
+    if (!action || !action.payload) return root;
+
+    root = handleTableUpdates(root, action);
+    root = handleObsCoreTable(root, action);
+
+    return root;
+}
+
+/*-------------------------------------------------------------------------*/
+
+function handleTableUpdates(root, action) {
+
+    const {tbl_id, selectInfo} = action.payload;
+
     switch (action.type) {
-        case (Cntlr.TABLE_SELECT)  :
+        case (Cntlr.TABLE_SELECT) :
         {
-            const {tbl_id, selectInfo} = action.payload;
             if (selectInfo) {
                 const nroot = clientTableSelectionSync(root, tbl_id, selectInfo); // no change for non-client tables
                 return updateSet(nroot, [tbl_id, 'selectInfo'], selectInfo);
-            } else return root;
+            }
+            break;
         }
-        case (Cntlr.TABLE_LOADED)  :
+        case (Cntlr.TABLE_LOADED) :
         {
-            const {tbl_id} = action.payload;
             const statusPath = [tbl_id, 'tableMeta', 'Loading-Status'];
             if (get(root, statusPath, 'COMPLETED') !== 'COMPLETED') {
                 return updateSet(root, statusPath, 'COMPLETED');
-            } else return root;
+            }
+            break;
         }
-        case (Cntlr.TABLE_HIGHLIGHT)  :
-        case (Cntlr.TABLE_UPDATE)  :
+        case (Cntlr.TABLE_HIGHLIGHT)    :
+        case (Cntlr.TABLE_UPDATE)       :
         {
-            var {tbl_id} = action.payload;
             const updates = {[tbl_id] : {isFetching:false, ...action.payload}};
             return TblUtil.smartMerge(root, updates);
         }
         case (Cntlr.TABLE_FETCH)      :
         {
-            const {tbl_id} = action.payload || {};
-            const nTable = Object.assign({isFetching:true, selectInfo: SelectInfo.newInstance({rowCount:0}).data}, action.payload);
+            const nTable = Object.assign({ isFetching: true, selectInfo: SelectInfo.newInstance({rowCount: 0}).data }, action.payload);
             const origTableModel = get(root, [tbl_id, 'origTableModel']);
             if (origTableModel) { nTable.origTableModel = origTableModel; }
             return updateSet(root, [tbl_id], nTable);
         }
         case (Cntlr.TABLE_REPLACE)  :
         {
-            const {tbl_id} = action.payload || {};
             const rowCount = action.payload.totalRows || get(action, 'payload.tableData.data.length', 0);
-            const nTable = Object.assign({isFetching:false, selectInfo: SelectInfo.newInstance({rowCount}).data}, action.payload);
+            const nTable = Object.assign({ isFetching: false, selectInfo: SelectInfo.newInstance({rowCount}).data }, action.payload);
             return updateSet(root, [tbl_id], nTable);
         }
         case (Cntlr.TABLE_REMOVE)  :
         {
-            const {tbl_id} = action.payload;
             return omit(root, [tbl_id]);
         }
-        default:
-            return root;
     }
+    return root;
 }
 
-function clientTableSelectionSync(state, tbl_id, selectInfo) {
-    const origTableModel = get(state, [tbl_id, 'origTableModel']);
+/* Additional logic to applies to the table before it's place into the store */
+function handleObsCoreTable(root, action) {
+
+    const {tbl_id} = action.payload || {};
+
+    if (action.type === Cntlr.TABLE_LOADED) {
+        // obscore related
+        root = checkReleaseDate(root, tbl_id);
+        root = checkDataRights(root, tbl_id);
+    }
+    return root;
+}
+
+function checkReleaseDate (root, tbl_id) {
+
+    if (!tbl_id) return root;
+    const tableModel = getTblById(tbl_id);
+
+    if (!getColumn(tableModel, MetaConst.RELEASE_DATE_COL)) {
+        const col = getColByUtype(tableModel, 'obscore:Curation.releaseDate')[0] ||
+                    getColByUCD(tableModel, 'time.release')[0] ||
+                    ( isObsCoreLike(tableModel) && getColumn(tableModel, 'obs_release_date'));
+
+        return col ? updateSet(root, [tbl_id, 'tableMeta', MetaConst.RELEASE_DATE_COL], col.name) : root;
+    }
+    return root;
+};
+
+function checkDataRights (root, tbl_id) {
+
+    // values may be one of Public/Secure/Proprietary.  Secure is authenticated, public access is allowed.
+
+    if (!tbl_id) return root;
+    const tableModel = getTblById(tbl_id);
+
+    if (!getColumn(tableModel, MetaConst.DATARIGHTS_COL)) {
+        const col = getColByUtype(tableModel, 'obscore:Curation.rights')[0] ||
+                    // getColByUCD(tableModel, 'meta.code')[0] ||                           // This UCD is not exclusive to data_rights.  We should not use it.
+                    ( isObsCoreLike(tableModel) && getColumn(tableModel, 'data_rights'));
+
+        return col ? updateSet(root, [tbl_id, 'tableMeta', MetaConst.DATARIGHTS_COL], col.name) : root;
+    }
+    return root;
+};
+
+
+function clientTableSelectionSync(root, tbl_id, selectInfo) {
+    const origTableModel = get(root, [tbl_id, 'origTableModel']);
     const origTblData = get(origTableModel, 'tableData.data');
     if (!origTableModel || !origTblData) {
-        return state;
+        return root;
     }
     // if ORIG_IDX column is present in the table, its row indexes differ from the original table
-    const tableModel = get(state, [tbl_id]);
+    const tableModel = get(root, [tbl_id]);
     const idxCol = TblUtil.getColumnIdx(tableModel, 'ORIG_IDX');
     if (idxCol < 0) {
-        return updateSet(state, [tbl_id, 'origTableModel', 'selectInfo'], selectInfo);
+        return updateSet(root, [tbl_id, 'origTableModel', 'selectInfo'], selectInfo);
     }
     const data = get(tableModel, 'tableData.data');
     const selectInfoCls = SelectInfo.newInstance(selectInfo);
@@ -82,5 +140,5 @@ function clientTableSelectionSync(state, tbl_id, selectInfo) {
         const origIdx = parseInt(row[idxCol]);
         origSelectInfoCls.setRowSelect(origIdx, selectInfoCls.isSelected(i));
     });
-    return updateSet(state, [tbl_id, 'origTableModel', 'selectInfo'], origSelectInfoCls.data);
+    return updateSet(root, [tbl_id, 'origTableModel', 'selectInfo'], origSelectInfoCls.data);
 }

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -229,6 +229,14 @@
     background-color: rgba(255,255,255,.8);
 }
 
+.TablePanel__no-access {
+    background-color: #ffe8e8;
+}
+
+.TablePanel__no-access--highlighted {
+    background-color: #ffc1c1;
+}
+
 /** below are taken from FixedDataTable with some modifications */
 
 /**

--- a/src/firefly/js/ui/WorkspaceViewer.jsx
+++ b/src/firefly/js/ui/WorkspaceViewer.jsx
@@ -164,7 +164,10 @@ export const WorkspacePickerPopup = memo( ({fieldKey='WorkspacePickerPopup', onC
 });
 
 
-WorkspacePickerPopup.propTypes = defaultWorkspaceFieldPropTypes;
+WorkspacePickerPopup.propTypes = {
+    defaultWorkspaceFieldPropTypes,
+    ...{fieldKey: PropTypes.string}
+};
 
 
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-30

Adds ability to handle table with proprietary data.
- introduced DATARIGHTS_COL and RELEASE_DATE_COL column metas.
  - When one of these columns exists, table contains proprietary data.
  - has access is when DATARIGHTS_COL resolved to `true` or RELEASE_DATE_COL is less than today's date
- renders table row with pink when user does not have access
- added warning to DownloadDialog when a table with proprietary data is selected for download
- added additional JS unit tests to` TableUtil-Test.js`
- added Firefly API test: #7-Test Proprietary Data Display

Also:
Added Links to META-INFO API
 - You can inject `links` into a column via API's META-INFO.
 - added Firefly API test: 6 - Column links via API
 - you can also use ./firefly/demo/ffapi-table-test.html to test this.

Added `expand/close` feature to Firefly API test.
- converted a couple of table's components into functional components.

firefly test: https://irsawebdev9.ipac.caltech.edu/FIREFLY-30/firefly/
firefly API test: https://irsawebdev9.ipac.caltech.edu/FIREFLY-30/firefly/test/

