### PR TITLE
firefly-98: useFieldGroupConnector needs optionally  confirm value for every render

### DIFF
--- a/src/firefly/js/ui/ListBoxInputField.jsx
+++ b/src/firefly/js/ui/ListBoxInputField.jsx
@@ -96,7 +96,7 @@ function checkForUndefined(v,props) {
 
 
 export const ListBoxInputField= memo( (props) => {
-    const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmInitialValue:checkForUndefined});
+    const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmValue:checkForUndefined});
     const newProps= {
         ...viewProps,
         value: convertValue(viewProps.value, viewProps.options),

--- a/src/firefly/js/ui/RadioGroupInputField.jsx
+++ b/src/firefly/js/ui/RadioGroupInputField.jsx
@@ -30,7 +30,7 @@ function checkForUndefined(v,props) {
 }
 
 export const RadioGroupInputField= memo( (props) => {
-    const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmInitialValue:checkForUndefined});
+    const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmValue:checkForUndefined});
     const newProps= {...viewProps,  value: assureValue(viewProps)};
     return <RadioGroupInputFieldView {...newProps}
                                      onChange={(ev) => handleOnChange(ev,viewProps, fireValueChange)}/> ;

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -163,9 +163,8 @@ function makePayloadAndUpdateActive(displayValue, parseResults, resolvePromise, 
 }
 
 
-function replaceValue(v,props) {
+function replaceValue(v) {
     const t= getActiveTarget();
-    // if (props.nullAllowed && !v) return v;
     let retVal= v;
     if (t && t.worldPt) {
        if (get(t,'worldPt')) retVal= t.worldPt.toString();
@@ -177,7 +176,8 @@ function replaceValue(v,props) {
 
 
 export const TargetPanel = memo( ({fieldKey= 'UserTargetWorldPt',initialState= {}, ...restOfProps}) => {
-    const {viewProps, fireValueChange, groupKey}=  useFieldGroupConnector({fieldKey, initialState, confirmInitialValue:replaceValue});
+    const {viewProps, fireValueChange, groupKey}=  useFieldGroupConnector({
+                                fieldKey, initialState, confirmValueOnInit:replaceValue});
     const newProps= computeProps(viewProps, restOfProps, fieldKey, groupKey);
     return ( <TargetPanelView {...newProps}
                               onChange={(value,source) => handleOnChange(value,source,newProps, fireValueChange)}/>);


### PR DESCRIPTION
This radio and List box fields need to be able to confirm that the current value is in the list when the options change.  This is a behavior that is already there but only when it initializes. If will now do it on every render if enabled.

https://irsawebdev9.ipac.caltech.edu/firefly-98-useFieldGroupConnector/firefly/