### PR TITLE
IRSA-2421: retain table states between updates including mount/unmount

### DIFF
--- a/src/firefly/html/demo/ffapi-table-test.html
+++ b/src/firefly/html/demo/ffapi-table-test.html
@@ -244,12 +244,12 @@ Value               * @prop {string} value     static value of this column for a
             <div id="META_OPTIONS"  class="tabItem">
                 <h3>META_OPTIONS</h3>
                 <pre>
-META_OPTIONS is internally used to pass options to the server.  The information in this map is intended for single and applies only
-to this request.  Unlike META_INFO, it will not be set back into the returned table.
+META_OPTIONS is internally used to pass options to the server.  The information in this map is intended for single use and applies only
+to this request.  Unlike META_INFO, it will not be sent back to the client.
 
 The available options are defined in MetaConst.js and MetaConst.java:
-highlightedRow          {number}         // the current highlightedRow.
-highlightedRowByRowIdx  {number}         // the highlightedRow's ROW_ID value.  This is the row index of the original table.
+highlightedRow          {number}         // set the highlightedRow to the given value.
+highlightedRowByRowIdx  {number}         // set the highlightedRow to the row with original row index of the given value.
 
                 </pre>
             </div>

--- a/src/firefly/html/demo/ffapi-table-test.html
+++ b/src/firefly/html/demo/ffapi-table-test.html
@@ -160,6 +160,7 @@
             <button class="tabButton" onclick="showTab('ParamInfo')">ParamInfo</button>
             <button class="tabButton" onclick="showTab('META_INFO')">META_INFO</button>
             <button class="tabButton" onclick="showTab('TblOptions')">TblOptions</button>
+            <button class="tabButton" onclick="showTab('META_OPTIONS')">META_OPTIONS</button>
         </div>
         <div class="tabContent">
 
@@ -239,6 +240,20 @@ Value               * @prop {string} value     static value of this column for a
 
                 </pre>
             </div>
+
+            <div id="META_OPTIONS"  class="tabItem">
+                <h3>META_OPTIONS</h3>
+                <pre>
+META_OPTIONS is internally used to pass options to the server.  The information in this map is intended for single and applies only
+to this request.  Unlike META_INFO, it will not be set back into the returned table.
+
+The available options are defined in MetaConst.js and MetaConst.java:
+highlightedRow          {number}         // the current highlightedRow.
+highlightedRowByRowIdx  {number}         // the highlightedRow's ROW_ID value.  This is the row index of the original table.
+
+                </pre>
+            </div>
+
 
             <div id="ParamInfo"  class="tabItem">
                 <h3>ParamInfo</h3>

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -223,7 +223,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
      * by '='.  If the keyword contains a '/' char, then the left side is
      * the keyword, and the right side is its description.
      * @return the serialize version of the class
-     * @deprecated
+     * @deprecated  use JSON format instead.  @see edu.caltech.ipac.table.JsonTableUtil#toJsonTableRequest
      */
     public String toString() {
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -30,6 +30,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
     public static final String INCL_COLUMNS = "inclCols";
     public static final String FIXED_LENGTH = "fixedLength";
     public static final String META_INFO = "META_INFO";
+    public static final String META_OPTIONS = "META_OPTIONS";
     public static final List<String> SYS_PARAMS = Arrays.asList(REQUEST_CLASS,INCL_COLUMNS,SORT_INFO,FILTERS,PAGE_SIZE,START_IDX,FIXED_LENGTH,META_INFO,TBL_ID);
     public static final String TBL_INDEX = "tbl_index";     // the table to show if it's a multi-table file.
     public static final String SELECT_INFO = "selectInfo";  // a property of META_INFO.  deserialize into SelectionInfo.java
@@ -39,6 +40,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
     private ArrayList<String> filters;
     private SelectionInfo selectInfo;
     private Map<String, String> metaInfo;
+    private transient Map<String, String> metaOptions;               // options to apply for this request.  it will not persist nor returned to the client
 
     public TableServerRequest() {
     }
@@ -57,9 +59,6 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
     }
 
     public String getMeta(String key) {
-        if (metaInfo == null) {
-
-        }
         return metaInfo == null ? null : metaInfo.get(key);
     }
 
@@ -68,6 +67,17 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
             metaInfo = new HashMap<>();
         }
         metaInfo.put(meta, value);
+    }
+
+    public String getOption(String key) {
+        return metaOptions == null ? null : metaOptions.get(key);
+    }
+
+    public void setOption(String key, String value) {
+        if (metaOptions == null) {
+            metaOptions = new HashMap<>();
+        }
+        metaOptions.put(key, value);
     }
 
     public void setTblId(String id) {
@@ -185,21 +195,12 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
         super.copyFrom(req);
         if (req instanceof TableServerRequest) {
             TableServerRequest treq = (TableServerRequest) req;
-            pageSize = treq.pageSize;
-            startIdx = treq.startIdx;
-            if (treq.filters == null) {
-                filters = null;
-            } else {
-                filters = new ArrayList<>(treq.filters.size());
-                filters.addAll(treq.filters);
-            }
-            if (treq.metaInfo == null) {
-                metaInfo = null;
-            } else {
-                metaInfo = new HashMap<>(treq.metaInfo.size());
-                metaInfo.putAll(treq.metaInfo);
-            }
-            selectInfo = treq.selectInfo;
+            pageSize    = treq.pageSize;
+            startIdx    = treq.startIdx;
+            filters     = treq.filters == null ? null : new ArrayList<>(treq.filters);
+            metaInfo    = treq.metaInfo == null ? null : new HashMap<>(treq.metaInfo);
+            metaOptions = treq.metaOptions == null ? null : new HashMap<>(treq.metaOptions);
+            selectInfo  = treq.selectInfo;
         }
     }
 
@@ -222,6 +223,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
      * by '='.  If the keyword contains a '/' char, then the left side is
      * the keyword, and the right side is its description.
      * @return the serialize version of the class
+     * @deprecated
      */
     public String toString() {
 
@@ -300,6 +302,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
             tsr.startIdx = startIdx;
             tsr.filters = filters == null ? null : new ArrayList<>(filters);
             tsr.metaInfo = metaInfo == null ? null : new HashMap<>(metaInfo);
+            tsr.metaOptions = metaOptions == null ? null : new HashMap<>(metaOptions);
             tsr.selectInfo = selectInfo == null ? null : (SelectionInfo) selectInfo.clone();
         } catch (CloneNotSupportedException e) {
             // ignore.. should not happen

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
@@ -47,6 +47,8 @@ public class MetaConst {
     /** the column name with public release date info;  null is considered not public */
     public static final String  RELEASE_DATE_COL = "RELEASE_DATE_COL";
 
-
+    // meta options
+    public static final String HIGHLIGHTED_ROW = "highlightedRow";
+    public static final String HIGHLIGHTED_ROW_BY_ROWIDX = "highlightedRowByRowIdx";
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -27,7 +27,6 @@ import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.table.DataGroupPart;
 import edu.caltech.ipac.table.JsonTableUtil;
-import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.CollectionUtil;
 import edu.caltech.ipac.table.DataGroup;
@@ -52,6 +51,8 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import static edu.caltech.ipac.firefly.data.table.MetaConst.HIGHLIGHTED_ROW;
+import static edu.caltech.ipac.firefly.data.table.MetaConst.HIGHLIGHTED_ROW_BY_ROWIDX;
 import static edu.caltech.ipac.firefly.server.ServerContext.SHORT_TASK_EXEC;
 import static edu.caltech.ipac.firefly.server.db.DbAdapter.MAIN_DB_TBL;
 import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.execRequestQuery;
@@ -381,7 +382,14 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             nreq.setInclColumns(cols.toArray(new String[0]));
         }
 
+        // handle highlightedRow request if present
+        // meta can be HIGHLIGHTED_ROW or HIGHLIGHTED_ROW_BY_ROWIDX
+        // if this row exists in the new table, fetch the page where this row is at, and set highlightedRow to it.
+        // Otherwise, return as requested.
+        int highlightedRow = handleHighlighedRowRequest(treq, nreq, dbFile, resultSetID);
+
         DataGroupPart page = execRequestQuery(nreq, dbFile, resultSetID);
+        page.getData().setHighlightedRow(highlightedRow);
 
         // handle selectInfo
         // selectInfo is sent to the server as Request.META_INFO.selectInfo
@@ -394,6 +402,29 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         treq.setMeta(TableMeta.RESULTSET_ID, resultSetID);
 
         return page;
+    }
+
+    // use HIGHLIGHTED_ROW_BY_ROWIDX if exists then check HIGHLIGHTED_ROW
+    private int handleHighlighedRowRequest(TableServerRequest treq, TableServerRequest nreq, File dbFile, String resultSetID) {
+        int highlightedRow = StringUtils.getInt(treq.getOption(HIGHLIGHTED_ROW), -1);
+        int hlRowByRowIdx = StringUtils.getInt(treq.getOption(HIGHLIGHTED_ROW_BY_ROWIDX), -1);
+        if (hlRowByRowIdx >= 0) {
+            DbAdapter dbAdapter = DbAdapter.getAdapter(nreq);
+            try {
+                highlightedRow =  JdbcFactory.getSimpleTemplate(dbAdapter.getDbInstance(dbFile))
+                        .queryForInt(String.format("select row_num from %s where ROW_IDX = %d", resultSetID, hlRowByRowIdx));
+            } catch (Exception e) {
+                // row does not exists in new resultset.. ignore the error.
+            }
+        }
+        if (highlightedRow >= 0) {
+            // based on highlightedRow, update startIdx
+            int currentPage = (int) (Math.floor(highlightedRow / nreq.getPageSize()) + 1);
+            int startIdx = (currentPage-1) * nreq.getPageSize();
+            nreq.setStartIndex(startIdx);
+            treq.setStartIndex(startIdx);
+        }
+        return highlightedRow;
     }
 
     private String makeResultSetReqStr(TableServerRequest treq) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -103,14 +103,19 @@ public class QueryUtil {
                     String skey = String.valueOf(key);
                     if (skey.equals(TableServerRequest.META_INFO)) {
                         Map meta = (Map) val;
-                        for (Object mk : meta.keySet()) {
-                            String mkey = String.valueOf(mk);
+                        meta.forEach((k,v) -> {
+                            String mkey = String.valueOf(k);
                             if (mkey.equals(TableServerRequest.SELECT_INFO)) {
-                                retval.setSelectInfo(SelectionInfo.parse(String.valueOf(meta.get(mkey))));
+                                retval.setSelectInfo(SelectionInfo.parse(String.valueOf(v)));
                             } else {
-                                retval.setMeta(mkey, String.valueOf(meta.get(mk)));
+                                retval.setMeta(mkey, String.valueOf(v));
                             }
-                        }
+                        });
+                    } else if (skey.equals(TableServerRequest.META_OPTIONS)) {
+                        Map options = (Map) val;
+                        options.forEach((k,v) -> {
+                            retval.setOption(String.valueOf(k), String.valueOf(v));
+                        });
                     } else {
                         retval.setTrueParam(skey, String.valueOf(val));
                     }

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -26,6 +26,7 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
     private List<LinkInfo> links = new ArrayList<>();     // for <LINK> under <TABLE> of VOTable
     private List<ParamInfo> params = new ArrayList<>();  // for <PARAM> under <TABLE> of VOTABLE
     private transient DataType[] cachedColumnsAry = null;
+    private transient int highlightedRow = -1;
 
     public DataGroup() {}
 
@@ -200,6 +201,15 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
 
     public int size() {
         return size;
+    }
+
+
+    public int getHighlightedRow() {
+        return highlightedRow;
+    }
+
+    public void setHighlightedRow(int highlightedRow) {
+        this.highlightedRow = highlightedRow;
     }
 
 //======================================================================

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -6,7 +6,6 @@ package edu.caltech.ipac.table;
 import edu.caltech.ipac.firefly.data.Param;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.util.StringUtils;
-import netscape.javascript.JSObject;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -50,6 +49,11 @@ public class JsonTableUtil {
         if (!StringUtils.isEmpty(page.getErrorMsg())) {
             tableModel.put("error", page.getErrorMsg());
         }
+
+        if (page.getData().getHighlightedRow() >= 0) {
+            tableModel.put("highlightedRow", page.getData().getHighlightedRow());
+        }
+
         return tableModel;
     }
 

--- a/src/firefly/js/charts/ui/FilterEditorWrapper.jsx
+++ b/src/firefly/js/charts/ui/FilterEditorWrapper.jsx
@@ -38,7 +38,7 @@ export class FilterEditorWrapper extends Component {
                         onChange={(obj) => {
                             if (!isUndefined(obj.filterInfo)) {
                                 const newRequest = Object.assign({}, tableModel.request, {filters: obj.filterInfo});
-                                TablesCntlr.dispatchTableFilter(newRequest, 0);
+                                TablesCntlr.dispatchTableFilter(newRequest);
                             } else if (!isUndefined(obj.sortInfo)) {
                                 this.setState({sortInfo: obj.sortInfo});
                             }

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -63,6 +63,9 @@ export const MetaConst = {
     /** the column name with public release date info;  null is considered not public */
     RELEASE_DATE_COL : 'RELEASE_DATE_COL',
 
+    HIGHLIGHTED_ROW             : 'highlightedRow',                 // row to highlight on data fetch
+    HIGHLIGHTED_ROW_BY_ROWIDX   : 'highlightedRowByRowIdx',         // row to highlight on data fetch based on original row index
+
     /** @deprecated use CENTER_COLUMN */
     CATALOG_COORD_COLS : 'CatalogCoordColumns',
 

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -7,7 +7,7 @@
  */
 
 
-import {get, set, pickBy, cloneDeep} from 'lodash';
+import {get, set, pickBy, cloneDeep, has} from 'lodash';
 import {ServerParams} from '../data/ServerParams.js';
 import {doJsonRequest, DEF_BASE_URL} from '../core/JsonUtils.js';
 import {getBgEmail} from '../core/background/BackgroundUtil.js';
@@ -71,7 +71,9 @@ export function fetchTable(tableRequest, hlRowIdx) {
             tableModel.allMeta.forEach( (m) => m.key && set(tableModel, ['tableMeta', m.key], m.value));
         }
 
-        tableModel.highlightedRow = hlRowIdx || startIdx;
+        if (!has(tableModel, 'highlightedRow')) {
+            tableModel.highlightedRow = hlRowIdx || startIdx;
+        }
         return tableModel;
     });
 }

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -7,7 +7,7 @@
  */
 
 
-import {get, set, pickBy, cloneDeep, has} from 'lodash';
+import {get, set, pickBy, cloneDeep, has, isUndefined} from 'lodash';
 import {ServerParams} from '../data/ServerParams.js';
 import {doJsonRequest, DEF_BASE_URL} from '../core/JsonUtils.js';
 import {getBgEmail} from '../core/background/BackgroundUtil.js';
@@ -71,8 +71,10 @@ export function fetchTable(tableRequest, hlRowIdx) {
             tableModel.allMeta.forEach( (m) => m.key && set(tableModel, ['tableMeta', m.key], m.value));
         }
 
-        if (!has(tableModel, 'highlightedRow')) {
-            tableModel.highlightedRow = hlRowIdx || startIdx;
+        if (!isUndefined(hlRowIdx)) {
+            tableModel.highlightedRow = hlRowIdx;
+        } else if (!has(tableModel, 'highlightedRow')) {
+            tableModel.highlightedRow = startIdx;
         }
         return tableModel;
     });

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -4,9 +4,8 @@
 
 import {isEmpty, omitBy, isUndefined, cloneDeep, get, set, range} from 'lodash';
 import * as TblCntlr from './TablesCntlr.js';
-import {getTableUiByTblId, getTblById, getTblInfoById, getCellValue} from './TableUtil.js';
+import {getTableUiByTblId, getTblById, getTblInfoById} from './TableUtil.js';
 import {SelectInfo} from './SelectInfo.js';
-import {MetaConst} from '../data/MetaConst.js';
 import {getTableUiById} from './TableUtil';
 
 export class TableConnector {
@@ -34,19 +33,11 @@ export class TableConnector {
     }
 
     onSort(sortInfoString) {
-        const {tableModel, request, highlightedRow} = getTblInfoById(this.tbl_id);
-        const nreq = cloneDeep(request);
-        nreq.sortInfo = sortInfoString;
-        setHlRowByRowIdx(nreq, tableModel, highlightedRow);
-        TblCntlr.dispatchTableSort(nreq);
+        TblCntlr.dispatchTableSort({tbl_id: this.tbl_id, sortInfo: sortInfoString});
     }
 
     onFilter(filterIntoString) {
-        const {tableModel, request, highlightedRow} = getTblInfoById(this.tbl_id);
-        const nreq = cloneDeep(request);
-        nreq.filters = filterIntoString;
-        setHlRowByRowIdx(nreq, tableModel, highlightedRow);
-        TblCntlr.dispatchTableFilter(nreq);
+        TblCntlr.dispatchTableFilter({tbl_id: this.tbl_id, filters: filterIntoString});
     }
 
     /**
@@ -55,10 +46,8 @@ export class TableConnector {
      */
     onFilterSelected(selected) {
         if (isEmpty(selected)) return;
-        const {tableModel, request, highlightedRow} = getTblInfoById(this.tbl_id);
-        const nreq = cloneDeep(request);
-        setHlRowByRowIdx(nreq, tableModel, highlightedRow);
-        TblCntlr.dispatchTableFilterSelrow(nreq, selected);
+        const {request} = getTblInfoById(this.tbl_id);
+        TblCntlr.dispatchTableFilterSelrow(request, selected);
     }
 
     onPageSizeChange(nPageSize) {
@@ -163,11 +152,3 @@ export class TableConnector {
         return new TableConnector(tbl_id, tbl_ui_id, tableModel, options);
     }
 }
-
-function setHlRowByRowIdx(nreq, tableModel, highlightedRow) {
-    const hlRowIdx = getCellValue(tableModel, highlightedRow, 'ROW_IDX');
-    if (hlRowIdx) {
-        set(nreq, ['META_OPTIONS', MetaConst.HIGHLIGHTED_ROW_BY_ROWIDX], hlRowIdx);
-    }
-}
-

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -2,10 +2,12 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {isEmpty, omitBy, isUndefined, cloneDeep, get, set} from 'lodash';
+import {isEmpty, omitBy, isUndefined, cloneDeep, get, set, range} from 'lodash';
 import * as TblCntlr from './TablesCntlr.js';
-import * as TblUtil from './TableUtil.js';
+import {getTableUiByTblId, getTblById, getTblInfoById, getCellValue} from './TableUtil.js';
 import {SelectInfo} from './SelectInfo.js';
+import {MetaConst} from '../data/MetaConst.js';
+import {getTableUiById} from './TableUtil';
 
 export class TableConnector {
     
@@ -22,25 +24,29 @@ export class TableConnector {
 
     onMount() {
         const {tbl_ui_id, tbl_id, tableModel} = this;
-        if (!TblUtil.getTableUiByTblId(tbl_id)) {
+        if (!getTableUiByTblId(tbl_id)) {
             TblCntlr.dispatchTableUiUpdate({tbl_ui_id, tbl_id, ...this.options});
             if (tableModel && !tableModel.origTableModel) {
                 set(tableModel, 'request.tbl_id', tbl_id);
-                const workingTableModel = cloneDeep(tableModel);
-                workingTableModel.origTableModel = tableModel;
-                TblCntlr.dispatchTableAddLocal(workingTableModel, undefined, false);
+                TblCntlr.dispatchTableAddLocal(tableModel, undefined, false);
             }
         }
     }
 
     onSort(sortInfoString) {
-        var {request} = TblUtil.getTblInfoById(this.tbl_id);
-        request = Object.assign({}, request, {sortInfo: sortInfoString});
-        TblCntlr.dispatchTableSort(request);
+        const {tableModel, request, highlightedRow} = getTblInfoById(this.tbl_id);
+        const nreq = cloneDeep(request);
+        nreq.sortInfo = sortInfoString;
+        setHlRowByRowIdx(nreq, tableModel, highlightedRow);
+        TblCntlr.dispatchTableSort(nreq);
     }
 
     onFilter(filterIntoString) {
-        TblCntlr.dispatchTableFilter({tbl_id: this.tbl_id, filters: filterIntoString});
+        const {tableModel, request, highlightedRow} = getTblInfoById(this.tbl_id);
+        const nreq = cloneDeep(request);
+        nreq.filters = filterIntoString;
+        setHlRowByRowIdx(nreq, tableModel, highlightedRow);
+        TblCntlr.dispatchTableFilter(nreq);
     }
 
     /**
@@ -49,13 +55,15 @@ export class TableConnector {
      */
     onFilterSelected(selected) {
         if (isEmpty(selected)) return;
-        const {request} = TblUtil.getTblInfoById(this.tbl_id);
-        TblCntlr.dispatchTableFilterSelrow(request, selected);
+        const {tableModel, request, highlightedRow} = getTblInfoById(this.tbl_id);
+        const nreq = cloneDeep(request);
+        setHlRowByRowIdx(nreq, tableModel, highlightedRow);
+        TblCntlr.dispatchTableFilterSelrow(nreq, selected);
     }
 
     onPageSizeChange(nPageSize) {
         nPageSize = Number.parseInt(nPageSize);
-        const {pageSize, highlightedRow} = TblUtil.getTblInfoById(this.tbl_id);
+        const {pageSize, highlightedRow} = getTblInfoById(this.tbl_id);
         if (Number.isInteger(nPageSize) && nPageSize !== pageSize) {
             const request = {pageSize: nPageSize};
             TblCntlr.dispatchTableHighlight(this.tbl_id, highlightedRow, request);
@@ -63,16 +71,16 @@ export class TableConnector {
     }
 
     onGotoPage(number = '1') {
-        const {currentPage, totalPages, pageSize} = TblUtil.getTblInfoById(this.tbl_id);
+        const {currentPage, totalPages, request, pageSize} = getTblInfoById(this.tbl_id);
         number = Number.parseInt(number);
         if (Number.isInteger(number) && number !== currentPage && number > 0 && number <= totalPages) {
-            const highlightedRow = (number - 1) * pageSize;
-            TblCntlr.dispatchTableHighlight(this.tbl_id, highlightedRow);
+            const startIdx = (number - 1) * pageSize;
+            TblCntlr.dispatchTableFetch({...request, ...{startIdx}});
         }
     }
 
     onRowHighlight(rowIdx) {
-        const {hlRowIdx, startIdx} = TblUtil.getTblInfoById(this.tbl_id);
+        const {hlRowIdx, startIdx} = getTblInfoById(this.tbl_id);
         if (rowIdx !== hlRowIdx) {
             const highlightedRow = startIdx + rowIdx;
             TblCntlr.dispatchTableHighlight(this.tbl_id, highlightedRow);
@@ -80,7 +88,7 @@ export class TableConnector {
     }
 
     onSelectAll(checked) {
-        const {startIdx, tableModel} = TblUtil.getTblInfoById(this.tbl_id);
+        const {startIdx, tableModel} = getTblInfoById(this.tbl_id);
         const selectInfo = tableModel.selectInfo ? cloneDeep(tableModel.selectInfo) : {};
         const selectInfoCls = SelectInfo.newInstance(selectInfo, startIdx);
         selectInfoCls.setSelectAll(checked);
@@ -88,7 +96,7 @@ export class TableConnector {
     }
 
     onRowSelect(checked, rowIndex) {
-        const {tableModel, startIdx} = TblUtil.getTblInfoById(this.tbl_id);
+        const {tableModel, startIdx} = getTblInfoById(this.tbl_id);
         const selectInfo = tableModel.selectInfo ? cloneDeep(tableModel.selectInfo) : {};
         const selectInfoCls = SelectInfo.newInstance(selectInfo, startIdx);
         selectInfoCls.setRowSelect(rowIndex, checked);
@@ -112,7 +120,27 @@ export class TableConnector {
         if (!isUndefined(filterInfo)) {
             this.onFilter(filterInfo);
         }
+
         const changes = omitBy({columns, showUnits, showTypes, showFilters, optSortInfo:sortInfo}, isUndefined);
+
+        if (columns) {
+            const {columns:prevColumns, columnWidths, scrollLeft} = getTableUiById(this.tbl_ui_id);
+            const updColIdx = columns.findIndex((c, idx) => c.visibility !== prevColumns[idx].visibility);
+            if (updColIdx >= 0) {
+                const updColPos = range(0, updColIdx).reduce((pv, idx) => {
+                    const delta =  get(columns, [idx, 'visibility'], 'show') === 'show' ?  columnWidths[idx] : 0;
+                    return pv + delta;
+                }, 0);
+                if (updColPos < scrollLeft) {
+                    if (get(columns, [updColIdx, 'visibility'], 'show') === 'show') {
+                        changes.scrollLeft = scrollLeft + columnWidths[updColIdx];
+                    } else {
+                        changes.scrollLeft = scrollLeft - columnWidths[updColIdx];
+                    }
+                }
+            }
+        }
+
         if (!isEmpty(changes)) {
             changes.tbl_ui_id = this.tbl_ui_id;
             TblCntlr.dispatchTableUiUpdate(changes);
@@ -120,7 +148,7 @@ export class TableConnector {
     }
 
     onOptionReset() {
-        const ctable = TblUtil.getTblById(this.tbl_id);
+        const ctable = getTblById(this.tbl_id);
         var filterInfo = get(ctable, 'request.filters', '').trim();
         filterInfo = filterInfo !== '' ? '' : undefined;
         var {showUnits, showTypes, showFilters, pageSize} = this.orig || {};
@@ -133,6 +161,13 @@ export class TableConnector {
 
     static newInstance(tbl_id, tbl_ui_id, tableModel, options) {
         return new TableConnector(tbl_id, tbl_ui_id, tableModel, options);
+    }
+}
+
+function setHlRowByRowIdx(nreq, tableModel, highlightedRow) {
+    const hlRowIdx = getCellValue(tableModel, highlightedRow, 'ROW_IDX');
+    if (hlRowIdx) {
+        set(nreq, ['META_OPTIONS', MetaConst.HIGHLIGHTED_ROW_BY_ROWIDX], hlRowIdx);
     }
 }
 

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -50,7 +50,7 @@ export function doFetchTable(tableRequest, hlRowIdx) {
     const {tbl_id} = tableRequest;
     const tableModel = getTblById(tbl_id) || {};
     if (tableModel.origTableModel) {
-        return Promise.resolve(processRequest(tableModel.origTableModel, tableRequest, hlRowIdx));
+        return Promise.resolve(processRequest(tableModel, tableRequest, hlRowIdx));
     } else {
         return fetchTable(tableRequest, hlRowIdx);
     }
@@ -564,23 +564,38 @@ export function filterTable(table, filterInfoStr) {
     return table.tableData;
 }
 
-export function processRequest(origTableModel, tableRequest, hlRowIdx) {
-    const {filters, sortInfo, inclCols, startIdx, pageSize} = tableRequest;
 
-    var nTable = cloneDeep(origTableModel);
-    nTable.origTableModel = origTableModel;
+export function cloneClientTable (tableModel) {
+    const nTable = cloneDeep(tableModel);
+    nTable.origTableModel = tableModel;
+
+    nTable.isFetching = false;
+    set(nTable, 'tableMeta.Loading-Status', 'COMPLETED');
+
+    const {data, columns} = nTable.tableData;
+    // add ROW_IDX to working table for tracking original row index
+    columns.push({name: 'ROW_IDX', type: 'int', visibility: 'hidden'});
+    data.forEach((r, idx) => r.push(String(idx)));
+    return nTable;
+}
+
+export function processRequest(tableModel, tableRequest, hlRowIdx) {
+    const {filters, sortInfo, inclCols} = tableRequest;
+    const {origTableModel} = tableModel;
+    let {startIdx, pageSize} = tableRequest;
+
+    const nTable = cloneClientTable(origTableModel);
+    let {data, columns} = nTable.tableData;
+
     nTable.request = tableRequest;
-    var {data, columns} = nTable.tableData;
-
-    if (filters || sortInfo) {      // need to track original rowId.
-        columns.push({name: 'ORIG_IDX', type: 'int', visibility: 'hidden'});
-        data.forEach((r, idx) => r.push(String(idx)));
-    }
+    pageSize = pageSize || data.length || MAX_ROW;
 
     if (filters) {
         filterTable(nTable, filters);
     }
+
     data = nTable.tableData.data;
+
     if (sortInfo) {
         data = sortTableData(data, columns, sortInfo);
     }
@@ -590,13 +605,30 @@ export function processRequest(origTableModel, tableRequest, hlRowIdx) {
         const inclIdices = columns.map( (c) => origTableModel.tableData.indexOf(c));
         data = data.map( (r) =>  r.filters( (c, idx) => inclIdices.includes(idx)));
     }
-    data = data.slice(startIdx, startIdx + (pageSize ? pageSize : data.length));
-    nTable.highlightedRow = hlRowIdx || startIdx;
+
+    const prevHlRowIdx = get(tableRequest, ['META_OPTIONS', MetaConst.HIGHLIGHTED_ROW_BY_ROWIDX], 0);
+    if (hlRowIdx) {
+        const currentPage = Math.floor(hlRowIdx / pageSize) + 1;
+        startIdx = (currentPage-1) * pageSize;
+        nTable.highlightedRow = hlRowIdx;
+    } else if (prevHlRowIdx) {
+        // preserve previous highlightedRow if possible.
+        let relRowIdx = data.findIndex( (r, rIdx) => getCellValue(nTable, rIdx, 'ROW_IDX') === prevHlRowIdx );
+        relRowIdx = relRowIdx < 0 ? 0 : relRowIdx;
+        const currentPage = Math.floor(relRowIdx / pageSize) + 1;
+        startIdx = (currentPage-1) * pageSize;
+        nTable.highlightedRow = relRowIdx;
+    } else {
+        nTable.highlightedRow = startIdx;
+    }
+
+    data = data.slice(startIdx, startIdx + pageSize);
+
     nTable.tableData.data = data;
     nTable.tableData.columns = columns;
 
     // set selections from the original table
-    const idxCol = getColumnIdx(nTable, 'ORIG_IDX');
+    const idxCol = getColumnIdx(nTable, 'ROW_IDX');
     if (idxCol >= 0) {
         const nTableSelectInfoCls = SelectInfo.newInstance({rowCount: data.length});
         const origSelectInfoCls = SelectInfo.newInstance(get(origTableModel, 'selectInfo'));

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -349,7 +349,7 @@ export function getFilterCount(tableModel) {
 export function clearFilters(tableModel) {
     const {request, tbl_id} = tableModel || {};
     if (request && request.filters) {
-        TblCntlr.dispatchTableFilter({tbl_id, filters: ''}, 0);
+        TblCntlr.dispatchTableFilter({tbl_id, filters: ''});
     }
 }
 

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -1,7 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, isEqual, unset, merge} from 'lodash';
+import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, isEqual, unset, merge, omit} from 'lodash';
 
 import {flux} from '../Firefly.js';
 import * as TblUtil from './TableUtil.js';
@@ -466,7 +466,7 @@ function tableSort(action) {
             const {request, hlRowIdx} = action.payload;
             TblUtil.fixRequest(request);
             const {tbl_id} = request;
-            const tableStub = setupTableOps(tbl_id, request);
+            const [nreq, tableStub] = setupTableOps(tbl_id, request);
             if (!tableStub) return;
 
             dispatch({type:TABLE_FETCH, payload: tableStub});
@@ -476,11 +476,13 @@ function tableSort(action) {
                 dispatch(action);
             });
 
-            doTableFetch({tbl_id, request: tableStub.request, hlRowIdx, dispatch});
+            doTableFetch({tbl_id, request: nreq, hlRowIdx, dispatch});
         }
     };
 }
 
+// return the full request after merging with the original and a table sub in
+// an array.  [fullRequest, tableStub]
 function setupTableOps(tbl_id, nrequest) {
     const tableModel = TblUtil.getTblById(tbl_id);
     if (!tableModel) return;
@@ -493,7 +495,7 @@ function setupTableOps(tbl_id, nrequest) {
     // which would cause smartMerge bugs, if we preserve columns.
     const tableData = origTableModel? {} : pick(tableModel.tableData, 'columns');
     const nreq = merge({}, request, nrequest);
-    return {tbl_id, request:nreq, tableMeta, selectInfo, tableData};
+    return [nreq, {tbl_id, tableMeta, selectInfo, tableData}];
 }
 
 
@@ -503,7 +505,7 @@ function tableFilter(action) {
             var {request, hlRowIdx} = action.payload;
             TblUtil.fixRequest(request);
             const {tbl_id} = request;
-            const tableStub = setupTableOps(tbl_id, request);
+            const [nreq, tableStub] = setupTableOps(tbl_id, request);
             if (!tableStub) return;
 
             dispatch({type:TABLE_FETCH, payload: tableStub});
@@ -513,7 +515,7 @@ function tableFilter(action) {
                 dispatch(action);
             });
 
-            doTableFetch({tbl_id, request: tableStub.request, hlRowIdx,  dispatch});
+            doTableFetch({tbl_id, request: nreq, hlRowIdx,  dispatch});
         }
     };
 }

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -526,7 +526,7 @@ function tableFilter(action) {
 }
 
 function doTableFetch({request, hlRowIdx, dispatch, tbl_id}) {
-    request.startIdx = 0;
+    request.startIdx = request.startIdx || 0;
     const backgroundable = get(request, 'META_INFO.backgroundable', false);
     if (backgroundable) {
         asyncFetch(request, hlRowIdx, dispatch, tbl_id);

--- a/src/firefly/js/tables/reducer/TableDataReducer.js
+++ b/src/firefly/js/tables/reducer/TableDataReducer.js
@@ -126,7 +126,7 @@ function clientTableSelectionSync(root, tbl_id, selectInfo) {
     if (!origTableModel || !origTblData) {
         return root;
     }
-    // if ORIG_IDX column is present in the table, its row indexes differ from the original table
+    // if ROW_IDX column is present in the table, its row indexes differ from the original table
     const tableModel = get(root, [tbl_id]);
     const idxCol = TblUtil.getColumnIdx(tableModel, 'ORIG_IDX');
     if (idxCol < 0) {

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -31,7 +31,7 @@ function handleTableUpdates(root, action, state) {
 
         case (Cntlr.TBL_RESULTS_ADDED) :
             const options = onUiUpdate(get(action, 'payload.options', {}));
-            return updateSet(root, [tbl_ui_id], {tbl_ui_id, tbl_id, triggeredBy: action.type, ...options});
+            return updateSet(root, [tbl_ui_id], {tbl_ui_id, tbl_id, triggeredBy: 'byTable', ...options});
 
         case (Cntlr.TABLE_FETCH)      :
         case (Cntlr.TABLE_FILTER)      :
@@ -42,7 +42,7 @@ function handleTableUpdates(root, action, state) {
         case (Cntlr.TABLE_LOADED) :
         case (Cntlr.TABLE_HIGHLIGHT)  :
             // state is in-progress(fresh) data.. use it to reduce ui state.
-            return uiStateReducer(root, get(state, ['data', tbl_id]), action);
+            return uiStateReducer(root, get(state, ['data', tbl_id]));
         default:
             return root;
     }
@@ -78,7 +78,7 @@ function removeTable(root, action) {
     return root;
 }
 
-function uiStateReducer(ui, tableModel, action) {
+function uiStateReducer(ui, tableModel) {
     // if (!get(tableModel, 'tableData')) return ui;
     const {startIdx, endIdx, tbl_id, ...others} = getTblInfo(tableModel);
     const filterInfo = get(tableModel, 'request.filters');
@@ -90,7 +90,7 @@ function uiStateReducer(ui, tableModel, action) {
     var data = has(tableModel, 'tableData.data') ? tableModel.tableData.data.slice(startIdx, endIdx) : [];
     var tableRowCount = data.length;
 
-    var uiData = {tbl_id, startIdx, endIdx, tableRowCount, sortInfo, filterInfo, filterCount, data, showLoading, showMask, triggeredBy: action.type, ...others};
+    var uiData = {tbl_id, startIdx, endIdx, tableRowCount, sortInfo, filterInfo, filterCount, data, showLoading, showMask, triggeredBy: 'byTable', ...others};
 
     Object.keys(ui).filter( (ui_id) => {
         return get(ui, [ui_id, 'tbl_id']) === tbl_id;

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -31,7 +31,7 @@ function handleTableUpdates(root, action, state) {
 
         case (Cntlr.TBL_RESULTS_ADDED) :
             const options = onUiUpdate(get(action, 'payload.options', {}));
-            return updateSet(root, [tbl_ui_id], {tbl_ui_id, tbl_id, ...options});
+            return updateSet(root, [tbl_ui_id], {tbl_ui_id, tbl_id, triggeredBy: action.type, ...options});
 
         case (Cntlr.TABLE_FETCH)      :
         case (Cntlr.TABLE_FILTER)      :
@@ -42,7 +42,7 @@ function handleTableUpdates(root, action, state) {
         case (Cntlr.TABLE_LOADED) :
         case (Cntlr.TABLE_HIGHLIGHT)  :
             // state is in-progress(fresh) data.. use it to reduce ui state.
-            return uiStateReducer(root, get(state, ['data', tbl_id]));
+            return uiStateReducer(root, get(state, ['data', tbl_id]), action);
         default:
             return root;
     }
@@ -54,7 +54,7 @@ function handleUiUpdates(root, action, state) {
     switch (action.type) {
         case (Cntlr.TBL_UI_UPDATE)    :
             const changes = onUiUpdate(action.payload);
-            return updateMerge(root, [tbl_ui_id], changes);
+            return updateMerge(root, [tbl_ui_id], {triggeredBy: action.type, ...changes});
 
         case (Cntlr.TBL_UI_EXPANDED) :
             const tbl_group = findKey(get(state, 'results'), (o) =>  has(o, ['tables', tbl_id]));
@@ -78,7 +78,7 @@ function removeTable(root, action) {
     return root;
 }
 
-function uiStateReducer(ui, tableModel) {
+function uiStateReducer(ui, tableModel, action) {
     // if (!get(tableModel, 'tableData')) return ui;
     const {startIdx, endIdx, tbl_id, ...others} = getTblInfo(tableModel);
     const filterInfo = get(tableModel, 'request.filters');
@@ -90,7 +90,7 @@ function uiStateReducer(ui, tableModel) {
     var data = has(tableModel, 'tableData.data') ? tableModel.tableData.data.slice(startIdx, endIdx) : [];
     var tableRowCount = data.length;
 
-    var uiData = {tbl_id, startIdx, endIdx, tableRowCount, sortInfo, filterInfo, filterCount, data, showLoading, showMask, ...others};
+    var uiData = {tbl_id, startIdx, endIdx, tableRowCount, sortInfo, filterInfo, filterCount, data, showLoading, showMask, triggeredBy: action.type, ...others};
 
     Object.keys(ui).filter( (ui_id) => {
         return get(ui, [ui_id, 'tbl_id']) === tbl_id;

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -258,6 +258,7 @@ function correctScrollLeftIfNeeded(scrollLeft, columns, columnWidths, width) {
             scrollLeft = undefined;
         }
     }
+    return scrollLeft;
 }
 
 function calcMaxWidth(idx, col, data) {

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -56,9 +56,8 @@ const BasicTableViewInternal = React.memo((props) => {
         onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected, tbl_id};
 
     const headerHeight = 22 + (showUnits && 8) + (showTypes && 8) + (showFilters && 22);
-    const scrollToRow = hlRowIdx > 3 ? hlRowIdx + 2 : hlRowIdx;
-
-    let {scrollLeft} = uiStates;
+    let {scrollLeft=0, scrollTop=0} = uiStates;
+    scrollTop = correctScrollTopIfNeeded(scrollTop, height, rowHeight, hlRowIdx);
     scrollLeft = correctScrollLeftIfNeeded(scrollLeft, columns, columnWidths, width);
 
     const content = () => {
@@ -77,8 +76,8 @@ const BasicTableViewInternal = React.memo((props) => {
                         onColumnResizeEndCallback={onColumnResize}
                         onRowClick={(e, index) => callbacks.onRowHighlight && callbacks.onRowHighlight(index)}
                         rowClassNameGetter={rowClassNameGetter(tbl_id, hlRowIdx, startIdx)}
-                        scrollToRow={scrollToRow}
                         onScrollEnd={onScrollEnd}
+                        scrollTop = {scrollTop}
                         scrollLeft={scrollLeft}
                         width={width}
                         height={height}>
@@ -161,11 +160,11 @@ export const BasicTableView = wrapResizer(BasicTableViewInternal);
 
 /*---------------------------------------------------------------------------*/
 
-function doScrollEnd(scrollLeft) {
+function doScrollEnd(scrollLeft, scrollTop) {
     const {tbl_ui_id} = this;
-    const {scrollLeft:cScrollLeft} =  getTableUiById(tbl_ui_id);
-    if (cScrollLeft !== scrollLeft) {
-        dispatchTableUiUpdate({ tbl_ui_id, scrollLeft});
+    const {scrollLeft:cScrollLeft, scrollTop:cScrollTop} =  getTableUiById(tbl_ui_id);
+    if (cScrollLeft !== scrollLeft || cScrollTop !== scrollTop) {
+        dispatchTableUiUpdate({ tbl_ui_id, scrollLeft, scrollTop});
     }
 }
 
@@ -243,6 +242,14 @@ const TextView = ({columns, data, showUnits, width, height}) => {
         </div>
     );
 };
+
+function correctScrollTopIfNeeded(scrollTop, height, rowHeight, hlRowIdx) {
+    const rowHpos = hlRowIdx * rowHeight;
+    if (rowHpos < scrollTop || rowHpos > scrollTop + height) {
+        return rowHpos - 30;
+    }
+    return scrollTop;
+}
 
 function correctScrollLeftIfNeeded(scrollLeft, columns, columnWidths, width) {
     if (scrollLeft < 0) {

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -43,7 +43,7 @@ export class FilterEditor extends PureComponent {
                             columns={cols}
                             rowHeight={24}
                             selectable={selectable}
-                            {...{data, selectInfoCls, sortInfo, callbacks, renderers, tbl_ui_id}}
+                            {...{data, selectInfoCls, sortInfo, callbacks, renderers, tbl_ui_id: `${tbl_ui_id}_FilterEditor`}}
                         />
                     </div>
                 </div>

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -6,7 +6,7 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, cloneDeep, get} from 'lodash';
 
-import {BasicTableView} from './BasicTableView.jsx';
+import {BasicTableViewWithConnector} from './BasicTableView.jsx';
 import {SelectInfo} from '../SelectInfo.js';
 import {createInputCell} from './TableRenderer.js';
 import {FILTER_CONDITION_TTIPS, FILTER_TTIPS, FilterInfo} from '../FilterInfo.js';
@@ -39,7 +39,7 @@ export class FilterEditor extends PureComponent {
             <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
                 <div style={{flexGrow: 1, position: 'relative'}}>
                     <div style={{position: 'absolute', top:0, bottom:5, left:0, right:0, backgroundColor: 'white'}}>
-                        <BasicTableView
+                        <BasicTableViewWithConnector
                             columns={cols}
                             rowHeight={24}
                             selectable={selectable}
@@ -83,7 +83,7 @@ function prepareOptionData(columns, sortInfo, filterInfo, selectable) {
 
     var cols = [
         {name: 'Column', fixed: true},
-        {name: 'Filter'},
+        {name: 'Filter', fixed: true},
         {name: 'Units'},
         {name: '', visibility: 'hidden'},
         {name: 'Selected', visibility: 'hidden'}
@@ -173,7 +173,7 @@ function collectFilterInfo(data, orgFilterInfo) {
 }
 
 function makeRenderers(onFilter, tbl_id) {
-    const style = {width: '100%', boxSizing: 'border-box'};
+    const style = {width: '100%', backgroundColor: 'white', boxSizing: 'border-box'};
     const validator = (cond, data, rowIndex) => {
         const cname = get(data, [rowIndex, 0]);
         return FilterInfo.conditionValidator(cond, tbl_id, cname);

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -152,7 +152,7 @@ function EnumSelect({col, tbl_id, filterInfo, filterInfoCls, onFilter}) {
                 <div className='ff-href' style={{marginLeft: 3, fontSize: 13}} onClick={onApply}>filter</div>
                 <div className='btn-close' onClick={hideEnumSelect} style={{margin: -2, fontSize: 12}}/>
             </div>
-            <CheckboxGroupInputField {...{fieldKey, alignment: 'vertical', initialState:{options,value}}}/>
+            <CheckboxGroupInputField {...{fieldKey, alignment: 'vertical', options, initialState:{value}}}/>
         </FieldGroup>
     );
 }

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, useEffect, useState} from 'react';
+import {PureComponent, useEffect, useState} from 'react';
 import shallowequal from 'shallowequal';
 
 import {flux} from '../Firefly.js';
@@ -42,22 +42,30 @@ export class SimpleComponent extends PureComponent {
  * This function make use of useState and useEffect to
  * trigger a re-render of functional components when the value in the store changes.
  *
+ * By default, this will call Object.is() to ensure the state has changed before
+ * calling setState.  To override this behavior, use useStoreConnector.bind({comparator: your_compare_function}).
+ *
  * @param stateGetters  one or more functions returning a state
  * @returns {Object[]}  an array of state's value in the order of the given stateGetters
  */
 export function useStoreConnector(...stateGetters) {
+    const {comparator=Object.is} = this || {};
 
     const rval = [];
     const setters = stateGetters.map((getter) => {
         const [val, setter] = useState(getter());
         rval.push(val);
-        return [getter, setter];
+        return [getter, setter, val];
     });
 
     useEffect(() => {
         return flux.addListener(() => {
-                setters.forEach(([getter, setter]) => {
-                    setter(getter());
+                setters.forEach(([getter, setter, oldState], idx) => {
+                    const newState = getter();
+                    setters[idx][2] = newState;
+                    if (!comparator(oldState, newState)) {
+                        setter(newState);
+                    }
                 });
         });
     }, []);     // only run once

--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -121,8 +121,8 @@ function mergeConstraintsIntoOrig(tbl) {
     if (!origTableModel || !tblData) {
         return;
     }
-    // if ORIG_IDX column is present in the table, its row indexes differ from the original table
-    const idxCol = getColumnIdx(tbl, 'ORIG_IDX');
+    // if ROW_IDX column is present in the table, its row indexes differ from the original table
+    const idxCol = getColumnIdx(tbl, 'ROW_IDX');
     const origTblData = get(origTableModel, 'tableData.data');
     tblData.forEach((row, i) => {
         const origIdx = idxCol < 0 ? i : parseInt(row[idxCol]);

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -9,7 +9,7 @@ import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {fetchTable} from '../../rpc/SearchServicesJson.js';
 import {getColumnIdx, getTblById, createErrorTbl} from '../../tables/TableUtil.js';
-import {BasicTableView} from '../../tables/ui/BasicTableView.jsx';
+import {BasicTableViewWithConnector} from '../../tables/ui/BasicTableView.jsx';
 import {createLinkCell, createInputCell} from '../../tables/ui/TableRenderer.js';
 import * as TblCntlr from '../../tables/TablesCntlr.js';
 import {SelectInfo} from '../../tables/SelectInfo.js';
@@ -399,7 +399,7 @@ class ConstraintPanel extends PureComponent {
                     <div className='TablePanel'>
                         <div className={'TablePanel__wrapper--border'}>
                             <div className='TablePanel__table' style={{top: 0}}>
-                                <BasicTableView
+                                <BasicTableViewWithConnector
                                     tbl_ui_id={tbl_ui_id}
                                     columns={columns}
                                     data={data}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2421
Test: https://irsawebdev9.ipac.caltech.edu/IRSA-2421/firefly/

copied from ticket:

> This applies both to client-side and server-backed tables
> In Firefly tables, sorting, filtering, or removing a column resets all of the following:
> horizontal scroll
> vertical scroll
> column widths
> None of these extra things should happen.
> 

Also:
- Convert BasicTableView into a React function component with hooks.
  - Remove the use of `UNSAFE_componentWillReceiveProps`

Things to test for:
Make sure table works as before beside scroll position and column widths.
Scroll position and column widths should remain the same between table updates.  This includes sort, filter, show/hide columns, mount, and unmount.
