### PR TITLE
IRSA-2441_irsaviewer_fits_header_table_popup_should'nt_have_units

### DIFF
--- a/src/firefly/html/demo/ffapi-table-test.html
+++ b/src/firefly/html/demo/ffapi-table-test.html
@@ -187,6 +187,7 @@ There are additional information specific to each input field.  Click the top bu
 * @prop {boolean} [removable=true]  true if this table can be removed from view.
 * @prop {boolean} [border=true]
 * @prop {boolean} [showUnits=true]
+* @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.
 * @prop {boolean} [showFilters=false]
 * @prop {boolean} [showToolbar=true]
 * @prop {boolean} [showTitle=true]

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -236,6 +236,7 @@
  * @prop {boolean} [showInfoButton=false] when true, shows additional information about table, if available
  * @prop {boolean} [showOptionButton=true]
  * @prop {boolean} [showUnits=true]
+ * @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.
  * @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.
  * @prop {function[]}  [rightButtons]  an array of functions that returns a button-like component laid out on the right side of this table header.
  */

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -31,7 +31,8 @@ export class FilterEditor extends PureComponent {
 
         if (isEmpty(columns)) return false;
 
-        const {cols, data, selectInfoCls} = prepareOptionData(columns, sortInfo, filterInfo, selectable);
+        const {allowUnits} = getTableUiById(tbl_ui_id);
+        const {cols, data, selectInfoCls} = prepareOptionData(columns, sortInfo, filterInfo, selectable, allowUnits);
         const callbacks = makeCallbacks(onChange, columns, data, filterInfo);
         const renderers = makeRenderers(callbacks.onFilter, tbl_id);
         
@@ -79,12 +80,12 @@ FilterEditor.defaultProps = {
     selectable: true
 };
 
-function prepareOptionData(columns, sortInfo, filterInfo, selectable) {
+function prepareOptionData(columns, sortInfo, filterInfo, selectable, allowUnits) {
 
     var cols = [
         {name: 'Column', fixed: true},
         {name: 'Filter'},
-        {name: 'Units'},
+        allowUnits ? {name: 'Units'} : {name: 'Units', visibility:'hidden'},
         {name: '', visibility: 'hidden'},
         {name: 'Selected', visibility: 'hidden'}
     ];

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -125,7 +125,7 @@ export class TablePanel extends PureComponent {
         const { selectable, expandable, expandedMode, border, renderers, title, removable, rowHeight, help_id,
             showToolbar, showTitle, showInfoButton,
             showOptionButton, showPaging, showSave, showFilterButton,
-            totalRows, showLoading, columns, showUnits, showTypes, showFilters, textView,
+            totalRows, showLoading, columns, showUnits, allowUnits, showTypes, showFilters, textView,
             tbl_id, error, startIdx, hlRowIdx, currentPage, pageSize, selectInfo, showMask,
             filterInfo, filterCount, sortInfo, data, backgroundable} = this.state;
         var {leftButtons, rightButtons} =  this.state;
@@ -203,7 +203,7 @@ export class TablePanel extends PureComponent {
                         >
                             <BasicTableView
                                 callbacks={tableConnector}
-                                { ...{columns, data, hlRowIdx, rowHeight, selectable, showUnits, showTypes, showFilters,
+                                { ...{columns, data, hlRowIdx, rowHeight, selectable, showUnits, allowUnits, showTypes, showFilters,
                                     selectInfoCls, filterInfo, sortInfo, textView, showMask, currentPage,
                                     tableConnector, renderers, tbl_ui_id} }
                             />
@@ -265,6 +265,7 @@ TablePanel.propTypes = {
     removable: PropTypes.bool,
     border: PropTypes.bool,
     showUnits: PropTypes.bool,
+    allowUnits: PropTypes.bool,
     showTypes: PropTypes.bool,
     showFilters: PropTypes.bool,
     showToolbar: PropTypes.bool,
@@ -286,6 +287,7 @@ TablePanel.propTypes = {
 
 TablePanel.defaultProps = {
     showUnits: false,
+    allowUnits: true,
     showFilters: false,
     showToolbar: true,
     showTitle: true,

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -10,6 +10,7 @@ import {FilterEditor} from './FilterEditor.jsx';
 import {InputField} from '../../ui/InputField.jsx';
 import {intValidator} from '../../util/Validate.js';
 import * as TblUtil from '../TableUtil.js';
+import {getTableUiById} from "../TableUtil";
 
 
 const labelStyle = {display: 'inline-block', whiteSpace: 'nowrap', width: 50};
@@ -25,7 +26,7 @@ export class TablePanelOptions extends SimpleComponent  {
 
     render() {
         const {onChange, onOptionReset, tbl_ui_id} = this.props;
-        const {columns, pageSize, showUnits=false, showTypes=false, showFilters=false, showPaging=true, optSortInfo, filterInfo} = this.state;
+        const {columns, pageSize, showUnits=true, allowUnits=true,showTypes=false, showFilters=false, showPaging=true, optSortInfo, filterInfo} = this.state;
 
         if (isEmpty(columns)) return false;
 
@@ -36,10 +37,12 @@ export class TablePanelOptions extends SimpleComponent  {
                 <div style={{display: 'inline-flex', justifyContent: 'space-between'}}>
                     <div style={{display: 'inline-block', whiteSpace: 'nowrap'}}>
                         <div style={{...labelStyle, width: 35}}>Show:</div>
-                        <div style={labelStyle}><input type='checkbox'
+                        {allowUnits &&
+                               <div style={labelStyle}><input type='checkbox'
                                                        onChange={(e) => onPropChanged(e.target.checked, 'showUnits')}
                                                        checked={showUnits}/>Units
-                        </div>
+                               </div>
+                        }
                         <div style={{...labelStyle, width: 80}}><input type='checkbox'
                                                                        onChange={(e) => onPropChanged(e.target.checked, 'showTypes')}
                                                                        checked={showTypes}/>Data Types

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -327,6 +327,7 @@ function renderTable(band, fitsHeaderInfo, isPlacedOnTab) {
                showToolbar={false}
                selectable={false}
                showOptionButton={true}
+               allowUnits={false}
            />
 
         </div>


### PR DESCRIPTION
This ticket is about removing "Units" from FITS header table options.
Jira: https://jira.ipac.caltech.edu/browse/IRSA-2441 

To test:
1- Goto: https://irsawebdev9.ipac.caltech.edu/irsa-2441/irsaviewer/
2- Select an image ex:(object: m17, mission: akari)
3- Click on "Show Fits Header" from the top menu (located all the way to the right).
4- Click on "Edit Table Options" (on the top right).
5- There should be no more "Units" column, or checkbox.
