### PR TITLE
firefly-73: Added improved cube, wavelength and spectral info support

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
@@ -17,6 +17,7 @@ public class RelatedData implements Serializable {
     public static final String IMAGE_OVERLAY= "IMAGE_OVERLAY";
     public static final String IMAGE_MASK= "IMAGE_MASK";
     public static final String TABLE= "TABLE";
+    public static final String WAVELENGTH_TABLE= "WAVELENGTH_TABLE";
 
     private String dataType= ""; // image or table
     private String desc;
@@ -109,6 +110,16 @@ public class RelatedData implements Serializable {
     public static RelatedData makeTabularRelatedData(Map<String,String> searchParams, String dataKey, String desc) {
         RelatedData d= new RelatedData(true);
         d.dataType= TABLE;
+        d.searchParams= searchParams;
+        d.dataKey = dataKey;
+        d.desc= desc;
+        return d;
+    }
+
+    public static RelatedData makeWavelengthTabularRelatedData(Map<String,String> searchParams,
+                                                               String dataKey, String desc) {
+        RelatedData d= new RelatedData(true);
+        d.dataType= WAVELENGTH_TABLE;
         d.searchParams= searchParams;
         d.dataKey = dataKey;
         d.desc= desc;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -54,6 +54,7 @@ public class VisJsonSerializer {
             if (wpHeader.isThreeColor()) map.put("threeColor", wpHeader.isThreeColor());
             map.put("plotRequestSerialize", wpHeader.getRequest().toString());
             map.put("dataDesc", wpHeader.getDataDesc());
+            map.put("zeroHeaderAry", serializeHeaderAry(wpHeader.getZeroHeaderAry()));
         }
         return map;
     }
@@ -62,12 +63,12 @@ public class VisJsonSerializer {
     public static JSONObject serializeWebPlotInitializerDeep(WebPlotInitializer wpInit) {
         JSONObject map = new JSONObject();
 
-        map.put("imageCoordSys", wpInit.getCoordinatesOfPlot().toString());
+        if (wpInit.getCoordinatesOfPlot()!=null) map.put("imageCoordSys", wpInit.getCoordinatesOfPlot().toString());
         if (wpInit.getHeaderAry()!=null) map.put("headerAry", serializeHeaderAry(wpInit.getHeaderAry()));
+        if (wpInit.getZeroHeaderAry()!=null) map.put("zeroHeaderAry", serializeHeaderAry(wpInit.getZeroHeaderAry()));
         if (wpInit.getRelatedData()!=null) map.put("relatedData", serializeRelatedDataArray(wpInit.getRelatedData()));
-        map.put("dataWidth", wpInit.getDataWidth());
-        map.put("dataHeight", wpInit.getDataHeight());
-        map.put("imageScaleFactor", wpInit.getImageScaleFactor());
+        if (wpInit.getDataWidth()>=0) map.put("dataWidth", wpInit.getDataWidth());
+        if (wpInit.getDataWidth()>=0) map.put("dataHeight", wpInit.getDataHeight());
         map.put("initImages", serializePlotImages(wpInit.getInitImages()));
         map.put("plotState", serializePlotState(wpInit.getPlotState()));
         map.put("desc", wpInit.getPlotDesc());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsEvaluation.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsEvaluation.java
@@ -53,7 +53,7 @@ public class FitsEvaluation {
             if (HDUs == null || HDUs.length==0) throw new FitsException("Bad format in FITS file");
             FitsRead frAry[] = FitsReadFactory.createFitsReadArray(HDUs, clearHdu);
             FitsDataEval fitsDataEval= new FitsDataEval(frAry);
-            if (frAry.length >1) { // Do evaluation
+            if (HDUs.length >1) { // Do evaluation
                 for(int i= 0; i<frAry.length; i++) {
                     if (frAry[i].getPlaneNumber()==0) {
                         for (Eval e : evalList) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/MaskEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/MaskEval.java
@@ -39,6 +39,7 @@ class MaskEval implements FitsEvaluation.Eval {
      * @return the data relations
      */
     public List<RelatedData> evaluate(File f, FitsRead[] frAry, BasicHDU[] HDUs, int fitsReadIndex, int hduIndex, WebPlotRequest req) {
+        if (HDUs.length<2) return null;
         String extType = frAry[fitsReadIndex].getExtType();
         if (extType.equalsIgnoreCase("IMAGE")) {
             List<RelatedData> relatedList = new ArrayList<>();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
@@ -11,12 +11,17 @@ package edu.caltech.ipac.firefly.server.visualize.fitseval;
 
 
 import edu.caltech.ipac.firefly.data.RelatedData;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import nom.tam.fits.BasicHDU;
+import nom.tam.fits.Header;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Trey Roby
@@ -24,9 +29,51 @@ import java.util.List;
 class SpectralCubeEval implements FitsEvaluation.Eval {
     @Override
     public List<RelatedData> evaluate(File f, FitsRead[] frAry, BasicHDU[] HDUs, int fitsReadIndex, int hduIndex, WebPlotRequest req) {
-        if (req!=null && !req.getBooleanParam("SpectralCube")) return null;
-        // do spectral cube processing here
-        // todo Convert FitsCube to work in this environment
-        return null;
+        int idx= findWaveTabHDU(HDUs);
+        if (idx==-1)  return null;
+        Map<String,String> params= new HashMap<>(10);
+        params.put("id", "IpacTableFromSource");
+        params.put("startIdx", "0");
+        params.put("pageSize", "30000");
+        params.put("tbl_index", idx+"");
+        params.put("source", ServerContext.replaceWithPrefix(f));
+        return Collections.singletonList(
+                RelatedData.makeWavelengthTabularRelatedData(params, "WAVE-TAB", "Table Wavelength information"));
+    }
+
+
+    public static int findWaveTabHDU(BasicHDU[] HDUs) {
+        int tabHduIdx= -1;
+        for(int i=0; (i<HDUs.length); i++) {
+            tabHduIdx= findWaveTabHDU(HDUs,i);
+            if (tabHduIdx>-1) break;
+        }
+        return tabHduIdx;
+    }
+
+    public static int findWaveTabHDU(BasicHDU[] HDUs, int hduIdx) {
+        if (HDUs.length<2) return -1;
+        int tableIdx=0;
+        BasicHDU hdu= HDUs[hduIdx];
+        Header header= hdu.getHeader();
+        String xtensionPrim= header.getStringValue("XTENSION");
+//        if (!"IMAGE".equals(xtensionPrim)) return -1;
+        if (xtensionPrim!=null && xtensionPrim.equals("BINTABLE")) return -1;
+        String ctype= header.getStringValue("CTYPE3");
+        if (!"WAVE-TAB".equals(ctype)) return -1;
+        String waveHDUName= header.getStringValue("PS3_0");
+        if  (waveHDUName==null) return -1;
+        for(int i=0; (i<HDUs.length); i++) {
+            if (i!=hduIdx) {
+                Header hIHeader= HDUs[i].getHeader();
+                String xtension= hIHeader.getStringValue("XTENSION");
+                String extName= hIHeader.getStringValue("EXTNAME");
+                if ("BINTABLE".equals(xtension) && waveHDUName.equals(extName)) {
+                    return tableIdx;
+                }
+                if ("BINTABLE".equals(xtension)) tableIdx++;
+            }
+        }
+        return -1;
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
@@ -6,6 +6,8 @@ package edu.caltech.ipac.firefly.visualize;
  */
 
 
+import nom.tam.fits.Header;
+
 /**
  * @author Trey Roby
  */
@@ -17,16 +19,18 @@ public class WebPlotHeaderInitializer {
     private String dataDesc;
     private boolean threeColor;
     private WebPlotRequest request;
+    private Header[] zeroHeaderAry;
 
     public WebPlotHeaderInitializer(String originalFitsFileStr, String workingFitsFileStr,
                                     String uploadFileNameStr, String dataDesc,
-                                    boolean threeColor, WebPlotRequest request) {
+                                    boolean threeColor, WebPlotRequest request, Header[] zeroHeaderAry) {
         this.originalFitsFileStr= originalFitsFileStr;
         this.workingFitsFileStr= workingFitsFileStr;
         this.uploadFileNameStr = uploadFileNameStr;
         this.threeColor = threeColor;
         this.request = request;
         this.dataDesc= dataDesc;
+        this.zeroHeaderAry= zeroHeaderAry;
     }
 
     public String getWorkingFitsFileStr() { return workingFitsFileStr; }
@@ -40,4 +44,6 @@ public class WebPlotHeaderInitializer {
     public String getDataDesc() { return dataDesc; }
 
     public WebPlotRequest getRequest() { return request; }
+
+    public Header[] getZeroHeaderAry() { return zeroHeaderAry; }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
@@ -23,13 +23,13 @@ public class WebPlotInitializer {
     private CoordinateSys _imageCoordSys;
     private int           _dataWidth;
     private int           _dataHeight;
-    private int           _imageScaleFactor;
     private PlotImages    _initImages;
     private PlotState     _plotState;
     private WebFitsData   _fitsData[];
     private String        _desc;
     private String        _dataDesc;
     private Header headerAry[]; //passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
+    private Header zeroHeaderAry[]; //passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
     private transient List<RelatedData> relatedData;
 //    private transient Projection _projection;
 
@@ -37,10 +37,10 @@ public class WebPlotInitializer {
     public WebPlotInitializer(PlotState plotState,
                              PlotImages images,
                              CoordinateSys imageCoordSys,
-                             Header headerAry[] ,
+                             Header[] headerAry,
+                             Header[] zeroHeaderAry,
                              int dataWidth,
                              int dataHeight,
-                             int imageScaleFactor,
                              WebFitsData  fitsData[],
                              String desc,
                              String dataDesc,
@@ -52,11 +52,11 @@ public class WebPlotInitializer {
 //        _projection= projection;
         _dataWidth= dataWidth;
         _dataHeight= dataHeight;
-        _imageScaleFactor= imageScaleFactor;
         _fitsData= fitsData;
         _desc= desc;
         _dataDesc= dataDesc;
         this.headerAry = headerAry;
+        this.zeroHeaderAry = zeroHeaderAry;
         this.relatedData= relatedData;
     }
 
@@ -75,13 +75,13 @@ public class WebPlotInitializer {
 
     public int getDataWidth() { return _dataWidth; }
     public int getDataHeight() { return _dataHeight; }
-    public int getImageScaleFactor() { return _imageScaleFactor; }
     public WebFitsData[] getFitsData()  { return _fitsData; }
 
     public String getPlotDesc() { return _desc; }
     public void setPlotDesc(String d) { _desc= d; }
     public String getDataDesc() { return _dataDesc; }
     public Header[] getHeaderAry() { return this.headerAry; }
+    public Header[] getZeroHeaderAry() { return this.zeroHeaderAry; }
 
 
     private static String getString(String s) { return s.equals("null") ? null : s; }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -56,6 +56,7 @@ public class FitsRead implements Serializable {
     private float[] float1d;
     private ImageHeader imageHeader;
     private Header header;
+    private Header zeroHeader;
     private Histogram hist;
 
     private final boolean tileCompress;
@@ -70,7 +71,7 @@ public class FitsRead implements Serializable {
      * @param imageHdu
      * @throws FitsException
      */
-    FitsRead( BasicHDU imageHdu, boolean clearHdu) throws FitsException {
+    FitsRead( BasicHDU imageHdu, Header zeroHeader, boolean clearHdu) throws FitsException {
 
         tileCompress= (imageHdu instanceof CompressedImageHDU);
 
@@ -86,6 +87,7 @@ public class FitsRead implements Serializable {
 
 
         header = hdu.getHeader();
+        this.zeroHeader= zeroHeader;
         planeNumber = header.getIntValue("SPOT_PL", 0);
         hduNumber = header.getIntValue("SPOT_EXT", 0);
         long HDUOffset= header.getIntValue("SPOT_OFF", 0);
@@ -113,9 +115,9 @@ public class FitsRead implements Serializable {
      * @param clearHdu
      * @throws FitsException
      */
-    FitsRead( BasicHDU imageHdu, BinaryTableHDU tableHDU, boolean clearHdu) throws FitsException {
+    FitsRead( BasicHDU imageHdu, BinaryTableHDU tableHDU, Header zeroHeader, boolean clearHdu) throws FitsException {
 
-        this(imageHdu, clearHdu);
+        this(imageHdu, zeroHeader, clearHdu);
         this.tableHDU = tableHDU;
     }
 
@@ -253,6 +255,7 @@ public class FitsRead implements Serializable {
     }
 
     public Header getHeader() { return header; }
+    public Header getZeroHeader() { return zeroHeader; }
 
 
 

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -202,7 +202,7 @@ ToolbarButton.propTypes= {
     tipOffCB : PropTypes.func,
     dropDownCB : PropTypes.func,
     imageStyle : PropTypes.object,
-    lastTextItem : PropTypes.boolean,
+    lastTextItem : PropTypes.bool,
     useDropDownIndicator: PropTypes.bool,
     additionalStyle : PropTypes.object
 };
@@ -222,13 +222,18 @@ ToolbarButton.DefaultProps= {
 };
 
 
-export function ToolbarHorizontalSeparator({top=0}) {
-    return <div style={{top}} className='ff-horizontal-separator'/>;
+export function ToolbarHorizontalSeparator({top=0, style={}}) {
+    const s= {top, ...style}
+    return <div style={s} className='ff-horizontal-separator'/>;
 }
 
-ToolbarButton.propTypes= {
+ToolbarHorizontalSeparator.propTypes= {
+    style:PropTypes.object,
     top : PropTypes.number
+
 };
+
+
 
 export function DropDownVerticalSeparator() {
     return <div className='ff-vertical-separator'/>;

--- a/src/firefly/js/visualize/FitsHeaderUtil.js
+++ b/src/firefly/js/visualize/FitsHeaderUtil.js
@@ -1,0 +1,201 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {get} from 'lodash';
+import {isImage,isPlot} from './WebPlot.js';
+
+
+/**
+ * @global
+ * @public
+ * @typedef {Array.<{}>} FitsHeader
+ *
+ * @prop <Array
+ * @prop {number} height
+ *
+ */
+
+
+
+
+
+export const HdrConst= {
+
+    // Common FITS Headers
+    CTYPE1   : 'CTYPE1',
+    CTYPE2   : 'CTYPE2',
+    CTYPE3   : 'CTYPE3',
+    BITPIX   : 'BITPIX',
+    CRPIX1   : 'CRPIX1',
+    CRPIX2   : 'CRPIX2',
+    CRVAL1   : 'CRVAL1',
+    CRVAL2   : 'CRVAL2',
+    CDELT1   : 'CDELT1',
+    CDELT2   : 'CDELT2',
+    CROTA1   : 'CROTA1',
+    CROTA2   : 'CROTA2',
+    DATAMAX  : 'DATAMAX',
+    DATAMIN  : 'DATAMIN',
+    EXTNAME  : 'EXTNAME',
+    NAXIS1   : 'NAXIS1',
+    NAXIS2   : 'NAXIS2',
+    NAXIS3   : 'NAXIS3',
+
+    // FITS Headers that are added by firefly
+    SPOT_OFF : 'SPOT_OFF', // Extension Offset (added by Firefly)
+    SPOT_EXT : 'SPOT_EXT', // Extension Number (added by Firefly)
+    SPOT_HS  : 'SPOT_HS',  // Header block size on disk (added by Firefly)
+    SPOT_BP  : 'SPOT_BP',  // Original Bitpix value (added by Firefly)
+    SPOT_PL  : 'SPOT_PL',  // Plane of FITS cube (added by Firefly)
+};
+
+
+const alphabetAry= 'ABCDEFGHIJKLMNOPQRSTUVWZYZ'.split('');
+
+/**
+ * return an array of all the alt projections in this file.
+ * @param header
+ * @return {string[]}
+ */
+export const geAtlProjectionIDs= (header) => alphabetAry.filter( (c) => header[HdrConst.CTYPE1+c]);
+
+
+export function makeHeaderParse(header, altWcs='') {
+    return {
+        header,
+        getIntValue: (key, def= 0) => parseInt(getNumberHeader(header,key,def)),
+
+        getIntOneOfValue: (keyAry, def=0) => {
+            const foundKey= keyAry.find( (k) => !isNaN(getNumberHeader(header,k,NaN)) );
+            return foundKey ? getNumberHeader(header, foundKey,def) : def;
+        },
+        getValue: (key, def= '') => getHeader(header, key, def),
+        getDoubleValue: (key, def) => getNumberHeader(header,key,def),
+        getDoubleOneOfValue: (keyAry, def=0) => {
+            const foundKey= keyAry.find( (k) => !isNaN(getNumberHeader(header,k,NaN)) );
+            return foundKey ? getNumberHeader(header, foundKey,def) : def;
+        },
+        isDefinedHeaderList(list) {
+            const key= list.find( (i) =>  header[i+altWcs]);
+            return Boolean(key);
+        },
+
+        getDoubleAry(keyRoot,altWcs, startIdx,endIdx,def=undefined) {
+            if (startIdx>endIdx) return def;
+            const retAry= [];
+            let i= 0;
+            for (let headerIdx = startIdx; headerIdx <= endIdx; headerIdx++) {
+                retAry[i]= getNumberHeader(header, `${keyRoot}${headerIdx}${altWcs}`,NaN);
+                if (isNaN(retAry[i])) return def;
+                i++;
+            }
+            return retAry;
+        }
+    };
+}
+
+export function makeDoubleHeaderParse(header,zeroHeader,altWcs) {
+    const hp= makeHeaderParse(header, altWcs);
+    const zhp= zeroHeader && makeHeaderParse(zeroHeader, altWcs);
+    return {
+        header,
+        zeroHeader,
+        getIntValue(key, def = 0) {
+            const v1 = hp.getIntValue(key, NaN);
+            if (!isNaN(v1)) return v1;
+            return zhp ? zhp.getIntValue(key, def) : def;
+        },
+        getIntOneOfValue: (keyAry, def=0) => {
+            const v1= hp.getIntOneOfValue(keyAry,NaN);
+            if (!isNaN(v1)) return v1;
+            return zhp ? zhp.getIntOneOfValue(keyAry, def) : def;
+        },
+        getValue: (key, def = '') => {
+            const v1 = hp.getValue(key, 'TEST--EMPTY');
+            if (v1!=='TEST--EMPTY') return v1;
+            return zhp ? zhp.getValue(key, def) : def;
+        },
+        getDoubleValue(key, def) {
+            const v1 = hp.getDoubleValue(key, NaN);
+            if (!isNaN(v1)) return v1;
+            return zhp ? zhp.getDoubleValue(key, def) : def;
+        },
+        getDoubleOneOfValue(keyAry, def) {
+            const v1= hp.getDoubleOneOfValue(keyAry,NaN);
+            if (!isNaN(v1)) return v1;
+            return zhp ? zhp.getDoubleOneOfValue(keyAry, def) : def;
+        },
+        getDoubleAry(keyRoot,altWcs, startIdx,endIdx,def=undefined) {
+            if (startIdx>endIdx) return def;
+            const retAry= hp.getDoubleAry(keyRoot,altWcs,startIdx,endIdx);
+            if (retAry) return retAry;
+            return zhp ? zhp.getDoubleAry(keyRoot,altWcs, startIdx,endIdx,def) : def;
+        },
+        isDefinedHeaderList: (list) => hp.isDefinedHeaderList(list) || (zhp && zhp.isDefinedHeaderList(list))
+    };
+}
+
+
+//=============================================================
+//=============================================================
+//---------- Header functions
+//=============================================================
+//=============================================================
+
+
+
+
+/**
+ *
+ * @param {WebPlot|Object} plotOrHeader image WebPlot or Header obj
+ * @param headerKey
+ * @return {{value:string,comment:string,idx:number}}
+ */
+function getHeaderObj(plotOrHeader,headerKey) {
+    if (!plotOrHeader) return {};
+    if (isPlot(plotOrHeader)) {
+        const plot= plotOrHeader;
+        if (!isImage(plot) ) return {};
+        return get(plot,['header',headerKey],{});
+    }
+    else {
+        return plotOrHeader[headerKey] || {};
+    }
+}
+
+/**
+ * return a header description given a header key
+ * @param {WebPlot|Object} plotOrHeader image WebPlot or Header obj
+ * @param {string} headerKey key
+ * @return {string} the description of the header if it exist otherwise an empty string
+ */
+export function getHeaderDesc(plotOrHeader,headerKey) {
+    return getHeaderObj(plotOrHeader, headerKey)['comment'] || '';
+}
+
+/**
+ * return a header value given a header key
+ * @param {WebPlot|Object} plotOrHeader image WebPlot or Header obj
+ * @param {string} headerKey key
+ * @param {string} [defVal] the default value
+ * @return {string} the value of the header if it exist, otherwise the default value
+ */
+export function getHeader(plotOrHeader,headerKey, defVal= undefined) {
+    return getHeaderObj(plotOrHeader, headerKey)['value'] || defVal;
+}
+
+/**
+ * return a header number value given a header key
+ * @param {WebPlot|Object} plotOrHeader image WebPlot or Header obj
+ * @param {string} headerKey key
+ * @param {number} [defVal] the default value
+ * @return {number} the number value of the header if it exist and can be converted to a number, otherwise the default value
+ */
+export function getNumberHeader(plotOrHeader, headerKey, defVal= NaN) {
+    const v= getHeader(plotOrHeader,headerKey,'');
+    if (v==='') return defVal;
+    const n= Number(v);
+    return isNaN(n) ? defVal : n;
+}
+

--- a/src/firefly/js/visualize/MouseReadoutCntlr.js
+++ b/src/firefly/js/visualize/MouseReadoutCntlr.js
@@ -134,6 +134,8 @@ const initState= function() {
             hipsMouseReadout2:'galactic',
             healpixPixel:'healpixPixel',
             healpixNorder:'healpixNorder',
+            wl:'wl',
+            
         }
     };
 

--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -1,0 +1,373 @@
+
+
+
+
+
+export const PLANE  = 'PLANE';
+export const LINEAR = 'LINEAR';
+export const LOG = 'LOG';
+export const F2W = 'F2W';
+export const V2W = 'V2W';
+export const TAB = 'TAB';
+
+
+export const WAVE= 'WAVE';
+export const AWAV= 'AWAV';
+
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} WaveLengthData
+ *
+ * @prop {string} algorithm
+ * @prop {string} wlType
+ * @prop {Number} N
+ * @prop {Array.<number>} r_j
+ * @prop {Array.<number>} pc_3j
+ * @prop {Number} s_3
+ * @prop {Number} lambda_r
+ * @prop {number} restWAV
+ * @prop {number} crpix
+ * @prop {number} cdelt
+ * @prop {number} crval
+ */
+
+
+
+const wlTypes= {
+    [PLANE] : {
+        getWaveLength : getWaveLengthPlane,
+        implemented : true,
+    },
+    [LINEAR] : {
+        getWaveLength : getWaveLengthLinear,
+        implemented : true,
+    },
+    [LOG] : {
+        getWaveLength : getWaveLengthLog,
+        implemented : true,
+    },
+    [F2W] : {
+        getWaveLength : getWaveLengthNonLinear,
+        implemented : true,
+    },
+    [V2W] : {
+        getWaveLength : getWaveLengthNonLinear,
+        implemented : true,
+    },
+    [TAB] : {
+        getWaveLength : getWaveLengthTable,
+        implemented : true,
+    }
+};
+
+
+export function getWavelength(pt, cubeIdx, wlData) {
+    const {algorithm, wlType}= wlData;
+    if (wlTypes[algorithm] && wlTypes[algorithm].implemented && wlTypes[algorithm].getWaveLength) {
+        const wl=  wlTypes[algorithm].getWaveLength(pt,cubeIdx,wlData);
+        if (wlType===WAVE) return wl;
+        if (wlType===AWAV) return convertAirToVacuum(wl);
+        return wl;
+    }
+}
+
+function getWaveLengthPlane(ipt, cubeIdx, wlData) {
+    const {crpix, crval, cdelt} = wlData;
+    const wl = crval + ( cubeIdx - crpix ) * cdelt;
+    return wl;
+}
+
+export function isWLAlgorithmImplemented(wlData) {
+    const {algorithm}= wlData;
+    return wlTypes[algorithm].implemented;
+}
+
+/**
+ *  calculate the air wavelength and then convert to vacuum wavelength
+ *  @param {number} wl
+ *  @return {number}
+ */
+const convertAirToVacuum= (wl) => 1 + 10**-6 * ( 287.6155 + 1.62887/wl**2 + 0.01360/wl**4);
+
+
+/**
+ *
+ * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
+ * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
+ * Thus, the k value referenced in the paper is 3 here
+ *
+ *  omega  = x_3 = s_3* Sum [ m3_j * (p_j - r_j) ]
+ *
+ *  lamda = lambda_r + omega
+ *
+ *  lambda_r : is the reference value,  given by CRVAL3
+ *
+ *
+ *
+ * @param {ImagePt} ipt
+ * @param {number} cubeIdx
+ * @param {Object} wlData
+ * @param {Number} wlData.N
+ * @param {Array.<number>} wlData.r_j
+ * @param {Array.<number>} wlData.pc_3j
+ * @param {Number} wlData.s_3
+ * @param wlData.lambda_r
+ * @return {number}
+ */
+function getWaveLengthLinear(ipt, cubeIdx, wlData) {
+    const {N,  r_j, pc_3j, s_3,  lambda_r}= wlData;
+    return lambda_r + getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
+}
+
+/**
+ *
+ * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
+ * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
+ * Thus, the k value referenced in the paper is 3 here
+ *
+ *  omega  = x_3 = s_3* Sum [ m3_j * (p_j - r_j) ]
+ *
+ *  lamda = lambda_r * exp (omega/s_3)
+ *
+ *  lambda_r : is the reference value,  given by CRVAL3
+ *
+ * @param {ImagePt} ipt
+ * @param {number} cubeIdx
+ * @param {WaveLengthData} wlData
+ * @param {Number} wlData.N
+ * @param {Array.<number>} wlData.r_j
+ * @param {Array.<number>} wlData.pc_3j
+ * @param {Number} wlData.s_3
+ * @param {Number} wlData.lambda_r
+ * @return {number}
+ */
+function getWaveLengthLog(ipt, cubeIdx, wlData) {
+    const {N,  r_j, pc_3j, s_3,  lambda_r}= wlData;
+    const omega= getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
+    return lambda_r* Math.exp(omega/lambda_r);
+}
+
+/**
+ *
+ * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
+ * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
+ * Thus, the k value referenced in the paper is 3 here
+ *
+ *  omega  = x_3 = s_3* Sum [ m3_j * (p_j - r_j) ]
+ *
+ *  lamda = lambda_r * exp (omega/s_3)
+ *
+ *  lambda_r : is the reference value,  given by CRVAL3
+ *
+ * @param {ImagePt} ipt
+ * @param {number} cubeIdx
+ * @param {WaveLengthData} wlData
+ * @param {Number} wlData.N
+ * @param {Array.<number>} wlData.r_j
+ * @param {Array.<number>} wlData.pc_3j
+ * @param {Number} wlData.s_3
+ * @param {Number} wlData.lambda_r
+ * @param {string} wlData.algorithm
+ * @param {number} wlData.restWAV
+ * @return {number}
+ */
+function getWaveLengthNonLinear(ipt, cubeIdx, wlData) {
+
+    const {N,  r_j, pc_3j, s_3,  lambda_r, algorithm= 'F2W', restWAV=0}= wlData;
+    let lamda= NaN;
+    const omega= getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
+
+
+    switch (algorithm){
+        case 'F2W':
+            lamda =lambda_r *  lambda_r/(lambda_r - omega);
+            break;
+        case 'V2W':
+            const lamda_0 = restWAV;
+            const b_lamda = ( Math.pow(lambda_r, 4) - Math.pow(lamda_0, 4) + 4 *Math.pow(lamda_0, 2)*lambda_r*omega )/
+            Math.pow((Math.pow(lamda_0, 2) + Math.pow(lambda_r, 2) ), 2);
+            lamda = lamda_0 - Math.sqrt( (1 + b_lamda)/(1-b_lamda) );
+            break;
+    }
+    return lamda;
+}
+
+const getArrayDataFromTable= (table, rowIdx, columnName) => undefined;  // todo implement
+
+
+/**
+ *
+ * The pre-requirement is that the FITS has three axies, ra (1), dec(2) and wavelength (3).
+ * Therefore the keyword for i referenced in the paper is 3
+ * @param {ImagePt} ipt
+ * @param {number} cubeIdx
+ * @param {WaveLengthData} wlData
+ * @param {Number} wlData.N
+ * @param {Array.<number>} wlData.r_j
+ * @param {Array.<number>} wlData.pc_3j
+ * @param {Number} wlData.s_3
+ * @param {Number} wlData.lambda_r
+ * @return {number}
+ */
+function getWaveLengthTable(ipt, cubeIdx, wlData) {
+
+
+    const {N, r_j, pc_3j, s_3, cdelt, lambda_r, wlTable, ps3_1, ps3_2}= wlData;
+
+    const omega= getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
+    const psi_m = !isNaN(cdelt)? lambda_r + cdelt* omega : lambda_r + omega;
+    if (!wlTable) return NaN;
+
+
+    //read the cell coordinate from the FITS table and save to two one dimensional arrays
+    const coordData = getArrayDataFromTable(wlTable,0, ps3_1 || 'COORDS');
+    if (!coordData) return NaN;
+
+    const indexData =  getArrayDataFromTable(wlTable,0, ps3_2 || 'INDEX');
+    if (!indexData) return coordData[psi_m];
+
+    const psiIndex = searchIndex(indexData, psi_m);
+    if (isNaN(psiIndex) || psiIndex===-1) return NaN; // No index found in the index array, gamma is undefined, so is coordinate
+
+    const gamma_m = calculateGamma_m(indexData, psi_m, psiIndex);
+    if (isNaN(gamma_m)) return NaN;
+
+    return  coordData[psiIndex] + (gamma_m - psiIndex) * (coordData[psiIndex+1] - coordData[psiIndex]);
+}
+
+
+/**
+ *
+ * @param {Array.<number>} indexVec
+ * @param {number} psi
+ * @param {number} idx
+ * @return {*}
+ */
+function calculateGamma_m(indexVec, psi, idx) {
+    /* Scan the indexing vector, (Ψ1, Ψ2,...), sequen-tially starting from the ﬁrst element, Ψ1,
+     * until a successive pair of index values is found that encompass ψm (i.e. such that Ψk ≤ ψm ≤ Ψk+1
+     * for monotonically increasing index values or Ψk ≥ ψm ≥ Ψk+1 for monotonically decreasing index values
+     * for some k). Then, when Ψk  Ψk+1, interpolate linearly on the indices
+     */
+
+
+    if (idx!==-1 && indexVec[idx-1]!==indexVec[idx]){
+        // Υm = k + (ψm − Ψk) / (Ψk+1− Ψk)
+        return  idx + (psi-indexVec[idx-1])/(indexVec[idx]-indexVec[idx-1]);
+    }
+    else {
+        return NaN; // No index found in the index array, gamma is undefined, so is coordinate
+    }
+
+}
+
+
+
+
+
+function isSorted(intArray) {
+
+    const end = intArray.length-1;
+    let counterAsc = 0;
+    let counterDesc = 0;
+
+    for (let i = 0; i < end; i++) {
+        if (intArray[i] < intArray[i+1]) counterAsc++;
+        else if(intArray[i] > intArray[i+1]) counterDesc++;
+    }
+    if(counterDesc===0) return 1;
+    else if (counterAsc===0) return -1;
+    else return 0;
+}
+
+
+
+
+function searchIndex(indexVec, psi) {
+    /*Scan the indexing vector, (Ψ1, Ψ2,...), sequen-tially starting from the ﬁrst element, Ψ1,
+      until a successive pair of index values is found that encompass ψm (i.e. such that Ψk ≤ ψm ≤ Ψk+1
+      for monotonically increasing index values or Ψk ≥ ψm ≥ Ψk+1 for monotonically decreasing index values
+      for some k). Then, when Ψk  Ψk+1, interpolate linearly on the indices
+     */
+
+    const sort = isSorted(indexVec); //1:ascending, -1: descending, 0: not sorted
+    if (sort===0){
+        return NaN; //The vector index array has to be either ascending or descending
+    }
+
+
+    for (let i=1; i<indexVec.length; i++){
+        if (sort===1 && indexVec[i-1]<=psi  && psi<=indexVec[i]){
+            return i;
+        }
+        if (sort===-1 && indexVec[i-1]>=psi && psi>=indexVec[i]){
+            return i;
+
+        }
+    }
+    return -1;
+}
+
+
+
+
+
+/**
+ *
+ * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
+ * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
+ * Thus, the k value referenced in the paper is 3 here
+ *
+ *                      N
+ *  omega  = x_3 = s_3* ∑ [ m3_j * (p_j - r_j) ]
+ *                      j=1
+ *
+ *  lamda = lambda_r + omega
+ *
+ *  lambda_r : is the reference value,  given by CRVAL3
+ *
+ * @param {ImagePt} ipt
+ * @param {number} cubeIdx
+ * @return {Array.<number>}
+ */
+function getPixelCoords(ipt, cubeIdx) {
+    const p0 = Math.round(ipt.x - 0.5); //x
+    const p1 = Math.round(ipt.y - 0.5); //y
+    return [p0, p1, cubeIdx];
+}
+
+/**
+ *
+ * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
+ * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
+ * Thus, the k value referenced in the paper is 3 here
+ *                      N
+ *  omega  = x_3 = s_3* ∑ [ m3_j * (p_j - r_j) ]
+ *                      j=1
+ *
+ *  N: is the dimensionality of the WCS representation given by NAXIS or WCSAXES
+ *  p_j: is the pixel coordinates
+ *  r_j: is the pixel coordinate of the reference point given by CRPIXJ where j=1... N, where N=3 in our case
+ *  s_3: is a scaling factor given by CDELT3
+ *  m3_j: is a linear transformation matrix given either by PC3_j or CD3_j
+ *
+ *
+ * @param pixCoords
+ * @param {number} N
+ * @param {Array.<number>} r_j
+ * @param {Array.<number>} pc_3j
+ * @param {Number} s_3
+ * @return number
+ */
+function getOmega(pixCoords, N,  r_j, pc_3j, s_3){
+    if (!pc_3j || !r_j ) return s_3*(pixCoords[0]+pixCoords[1]);
+
+    let omega =0.0;
+    for (let i=0; i<N; i++){
+        omega += s_3 * pc_3j[i] * (pixCoords[i]-r_j[i]);
+    }
+    return omega;
+}
+

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -1,0 +1,123 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {makeDoubleHeaderParse} from '../FitsHeaderUtil.js';
+import {AWAV, F2W, LINEAR, LOG, PLANE, TAB, V2W, WAVE} from './Wavelength.js';
+
+export function parseWavelengthHeaderInfo(header, altWcs='', zeroHeader, wlTable) {
+    const parse= makeDoubleHeaderParse(header, zeroHeader, altWcs);
+    return calculateWavelengthParams(parse,altWcs, wlTable);
+}
+
+
+const isWaveParseDependent = (algorithm) => algorithm===LINEAR || algorithm===LOG  || algorithm===F2W  ||
+                                            algorithm===V2W  || algorithm===TAB;
+
+const allGoodValues= (...numbers)  => numbers.every((n) => !isNaN(n));
+
+
+const L_10= Math.log(10);
+
+function calculateWavelengthParams(parse, altWcs, wlTable) {
+
+    const which= altWcs?'1':'3';
+
+    const ctype= parse.getValue(`CTYPE${which}${altWcs}`);
+    const crpix= parse.getDoubleValue(`CRPIX${which}${altWcs}`, NaN);
+    const crval= parse.getDoubleValue(`CRVAL${which}${altWcs}`, NaN);
+    const cdelt= parse.getDoubleValue(`CDELT${which}${altWcs}`, NaN);
+    const units= parse.getValue(`CUNIT${which}${altWcs}`, '');
+    const restWAV= parse.getDoubleValue('RESTWAV'+altWcs, 0);
+    const nAxis= parse.getIntValue('NAXIS'+altWcs);
+    // const N= parse.getIntOneOfValue(['WCSAXES'+altWcs, 'WCSAXIS'+altWcs, 'NAXIS'+altWcs], -1);
+    const N= parse.getIntOneOfValue(['WCSAXES', 'WCSAXIS', 'NAXIS'], -1);
+    let pc_3j = parse.getDoubleAry('PC3_',altWcs,1,N) || parse.getDoubleAry('CD3_',altWcs,1,N);
+    let r_j = parse.getDoubleAry('CRPIX',altWcs,1,N);
+    const ps3_0= parse.getValue(`PS${which}_0${altWcs}`, '');
+    const ps3_1= parse.getValue(`PS${which}_1${altWcs}`, '');
+    const ps3_2= parse.getValue(`PS${which}_2${altWcs}`, '');
+    const pv3_0= parse.getValue(`PV${which}_0${altWcs}`, '');
+    const pv3_1= parse.getValue(`PV${which}_1${altWcs}`, '');
+    const pv3_2= parse.getValue(`PV${which}_2${altWcs}`, '');
+
+    const {algorithm, wlType} = getAlgorithmAndType(ctype,N);
+
+    const canDoPlaneCalc= allGoodValues(crpix,crval,cdelt) && nAxis===3;
+    if (canDoPlaneCalc && (!algorithm || !pc_3j || !r_j)) {
+        return makeSimplePlaneBased(crpix, crval, cdelt, nAxis, wlType, units, 'use PLANE since is cube and parameters missing');
+    }
+
+    if (!algorithm || !wlType) return;
+
+
+    if (algorithm===LOG){  //the values in CRPIXk and CDi_j (PC_i_j) are log based on 10 rather than natural log, so a factor is needed.
+        r_j && (r_j= r_j.map( (v) => v*L_10));
+        pc_3j && (pc_3j= pc_3j.map( (v) => v*L_10));
+    }
+
+    let failReason= '';
+    let failWarning= '';
+    if (N<0) {
+        failReason+= 'Dimension value is not available, must be NAXIS or WCSAXES';
+    }
+    else {
+        // if (!pc_3j) failReason+= `, PC3_i${altWcs} or CD3_i${altWcs} is not defined`;
+        // if (!r_j) failReason+= `, CRPIXi${altWcs} is not defined`;
+        if (!pc_3j) failWarning+= `, PC3_i${altWcs} or CD3_i${altWcs} is not defined`;
+        if (!r_j) failWarning+= `, CRPIXi${altWcs} is not defined`;
+    }
+
+    if (algorithm===TAB) failWarning+= ', Table array types not implemented';
+
+
+
+    return {
+        N, algorithm, ctype, restWAV, wlType, crpix, crval, cdelt, failReason, failWarning, units, pc_3j, r_j,
+        ps3_0, ps3_1, ps3_2, pv3_0, pv3_1, pv3_2,
+        s_3: isNaN(cdelt) ? 0 : cdelt,
+        lambda_r: isNaN(crval) ? 0 : crval,
+        wlTable
+    };
+}
+
+function makeSimplePlaneBased(crpix,crval, cdelt, nAxis, wlType, units, reason) {
+    if (allGoodValues(crpix,crval,cdelt) && nAxis===3 ) {
+        return {algorithm: PLANE, wlType: wlType || WAVE, crpix, crval, cdelt, units, reason};
+    }
+    else {
+        return {algorithm: undefined, wlType, failReason: 'CTYPE3, CRVAL3, CDELT3 are required for simple and NAXIS===3', failReason2: reason};
+    }
+}
+
+
+/**
+ * This method will return the algorithm specified in the FITS header.
+ * If the algorithm is TAB, the header has to contain the keyword "EXTNAME".
+ * The fitsType = header.getStringValue("CTYPE3"), will tell what algorithm it is.
+ * The value of "CTYPE3" is WAVE-AAA, the AAA means algorithm.  If the fitsType only has
+ * "WAVE', it is linear.
+ * @param {String} ctype3
+ * @return {{algorithm:string,wlType:string}}
+ */
+function getAlgorithmAndType(ctype3){
+    let wlType, algorithm;
+    if (!ctype3) return {algorithm:undefined,wlType:undefined};
+    ctype3= ctype3.toUpperCase();
+    const sArray = ctype3.split('-');
+
+    if (ctype3.startsWith(WAVE) || ctype3.startsWith(AWAV)) {
+        if (ctype3.startsWith(WAVE)) wlType= WAVE;
+        else if (ctype3.startsWith(AWAV)) wlType= AWAV;
+
+        if (sArray.length===1) algorithm= LINEAR;
+        else if (sArray[1].trim()===LOG) algorithm=LOG;
+        else algorithm=sArray[1];
+    }
+    else if (ctype3.startsWith('LAMBDA')) {
+        wlType= WAVE;
+        algorithm=LINEAR;
+    }
+    return {algorithm,wlType};
+}
+

--- a/src/firefly/js/visualize/ui/MouseReadout.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadout.jsx
@@ -3,7 +3,7 @@
  */
 
 import React, {Fragment,memo} from 'react';
-import PropTypes from 'prop-types';
+import {number,string,oneOfType,object,func,bool} from 'prop-types';
 import {get} from 'lodash';
 import {getNonFluxDisplayElements, getFluxInfo} from './MouseReadoutUIUtil.js';
 import {dispatchChangePointSelection} from '../ImagePlotCntlr.js';
@@ -15,11 +15,13 @@ import './MouseReadout.css';
 export function MouseReadout({readout, readoutData}){
 
     if (!readoutData.readoutItems) return (<div className='mouseReadoutDisplaySpace'/>);
+    const {threeColor}= readoutData;
 
     const title= get(readoutData, 'readoutItems.title.value','');
 
     const displayEle= getNonFluxDisplayElements(readoutData.readoutItems,  readout.readoutPref, false);
-    const {readout1, readout2, pixelSize, showReadout1PrefChange, showReadout2PrefChange, showPixelPrefChange}= displayEle;
+    const {readout1, readout2, pixelSize, showReadout1PrefChange, showWavelengthFailed,
+        showReadout2PrefChange, showPixelPrefChange, waveLength}= displayEle;
 
     const fluxArray = getFluxInfo(readoutData);
 
@@ -35,7 +37,9 @@ export function MouseReadout({readout, readoutData}){
                              value={pixelSize.value} prefChangeFunc={showPixelPrefChange}/>
                              
             <DataReadoutItem lArea='redLabel' vArea='redValue' label={fluxArray[0].label} value={fluxArray[0].value}/>
-            <DataReadoutItem lArea='greenLabel' vArea='greenValue' label={fluxArray[1].label} value={fluxArray[1].value}/>
+            {threeColor && <DataReadoutItem lArea='greenLabel' vArea='greenValue' label={fluxArray[1].label} value={fluxArray[1].value}/>}
+            {waveLength && <DataReadoutItem lArea='greenLabel' vArea='greenValue' label={waveLength.label} value={waveLength.value}
+                prefChangeFunc={showWavelengthFailed} /> }
             <DataReadoutItem lArea='blueLabel' vArea='blueValue' label={fluxArray[2].label} value={fluxArray[2].value}/>
 
             <MouseReadoutLock gArea='lock' lockByClick={readout.lockByClick} />
@@ -44,8 +48,8 @@ export function MouseReadout({readout, readoutData}){
 }
 
 MouseReadout.propTypes = {
-    readout: PropTypes.object,
-    readoutData: PropTypes.object
+    readout: object,
+    readoutData: object
 };
 
 
@@ -66,9 +70,9 @@ export const MouseReadoutLock= memo(({gArea, style={}, lockByClick}) => {
 });
 
 MouseReadoutLock.propTypes = {
-    style:       PropTypes.object,
-    gArea:       PropTypes.string, // grid Area used with css grid-template-areas
-    lockByClick: PropTypes.bool.isRequired
+    style:       object,
+    gArea:       string, // grid Area used with css grid-template-areas
+    lockByClick: bool.isRequired
 };
 
 
@@ -87,11 +91,11 @@ export const DataReadoutItem= memo(({lArea, vArea, labelStyle={}, valueStyle={},
 });
 
 DataReadoutItem.propTypes = {
-    lArea:          PropTypes.string,   //  label grid Area used with css grid-template-areas
-    vArea:          PropTypes.string,   //  value grid Area used with css grid-template-areas
-    labelStyle:     PropTypes.object,
-    valueStyle:     PropTypes.object,
-    label:          PropTypes.string,
-    value:          PropTypes.string,
-    prefChangeFunc: PropTypes.func,
+    lArea:          string,   //  label grid Area used with css grid-template-areas
+    vArea:          string,   //  value grid Area used with css grid-template-areas
+    labelStyle:     object,
+    valueStyle:     object,
+    label:          string,
+    value:          oneOfType([number,string]),
+    prefChangeFunc: func,
 };

--- a/src/firefly/js/visualize/ui/VisHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/VisHeaderView.jsx
@@ -55,7 +55,7 @@ export function VisHeaderView({readout, readoutData, showHealpixPixel=false}) {
 
 VisHeaderView.propTypes= {
     readout:  PropTypes.object.isRequired,
-    readoutData:  PropTypes.object.isRequired,
+    readoutData:  PropTypes.object,
     showHealpixPixel : PropTypes.bool
 };
 


### PR DESCRIPTION
Firefly-73: Added improved cube, wavelength and spectral info support
   - Added zero header passed and managed by client
   - converted wavelength projection type parsing to client
   - client now maintains both projections and wavelength data
   - Updated readout to show Wavelength info
   - Improved cube paging controls to page though HDU's and cubes
   - Show wave length in cube paging controls

_To test:_

https://irsawebdev9.ipac.caltech.edu/firefly-73-cube-updates/firefly/

Read in cube:

- Notice cube controls.
- Read in multi-HDU cubes, notice  cube controls
- read in cube with wavelength information should show in mouse readout and navigation controls

@lznakano  - can you pay attentions to:
 - `Wavelength.js` - This file contains the algorithms
 - `WavelengthInfo.js` - This file analyzes the headers and prepares the parameters. 