### PR TITLE
FIREFLY-78: tbl save to workspace should respect file format selection

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
@@ -19,6 +19,8 @@ import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.visualize.VisJsonSerializer;
 import edu.caltech.ipac.firefly.visualize.PlotState;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
+import edu.caltech.ipac.table.TableUtil;
+import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.visualize.plot.ImagePt;
 
 import java.util.ArrayList;
@@ -264,6 +266,24 @@ public class SrvParam {
     public TableServerRequest getTableServerRequest(String key) {
         String reqString = getRequired(key);
         return QueryUtil.convertToServerRequest(reqString);
+    }
+
+    public TableUtil.Format getTableFormat() {
+        final String fileFormat = getOptional("file_format").toLowerCase();
+
+        Map<String, TableUtil.Format> allFormats = TableUtil.getAllFormats();
+
+        String formatInMap;
+        if (StringUtils.isEmpty(fileFormat)) {
+            formatInMap = "ipac";
+        } else {
+            Object[] formats = allFormats.keySet().stream()
+                    .filter((t) -> fileFormat.equals(t))
+                    .toArray();
+            formatInMap = (formats.length != 1) ? "ipac" : (String)formats[0];
+        }
+
+        return allFormats.get(formatInMap);
     }
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HttpServCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HttpServCommands.java
@@ -16,11 +16,6 @@ import edu.caltech.ipac.table.TableUtil;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.json.simple.JSONObject;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Arrays;
 
 public class HttpServCommands {
 
@@ -32,36 +27,13 @@ public class HttpServCommands {
     public static class TableSave extends BaseServletCommand {
         static final Logger.LoggerImpl DL_LOGGER = Logger.getLogger(Logger.DOWNLOAD_LOGGER);
 
-        private static Map<String, TableUtil.Format> allFormats = new HashMap<>();
-        static {
-            allFormats.put("ipac", TableUtil.Format.IPACTABLE);
-            allFormats.put("csv", TableUtil.Format.CSV);
-            allFormats.put("tsv", TableUtil.Format.TSV);
-            allFormats.put("votable-tabledata", TableUtil.Format.VO_TABLE_TABLEDATA);
-            allFormats.put("votable-binary-inline", TableUtil.Format.VO_TABLE_BINARY);
-            allFormats.put("votable-binary2-inline", TableUtil.Format.VO_TABLE_BINARY2);
-            allFormats.put("votable-fits-inline", TableUtil.Format.VO_TABLE_FITS);
-            allFormats.put("fits", TableUtil.Format.FITS);
-        }
-
         public void processRequest(HttpServletRequest req, HttpServletResponse res, SrvParam sp) throws Exception {
             TableServerRequest request = sp.getTableServerRequest();
             if (request == null) throw new IllegalArgumentException("Invalid request");
 
             String fileName = sp.getOptional("file_name");
-            final String fileFormat = sp.getOptional("file_format").toLowerCase();
 
-            String formatInMap;
-            if (StringUtils.isEmpty(fileFormat)) {
-                formatInMap = "ipac";
-            } else {
-                Object[] formats = allFormats.keySet().stream()
-                        .filter((t) -> fileFormat.equals(t))
-                        .toArray();
-                formatInMap = (formats.length != 1) ? "ipac" : (String)formats[0];
-            }
-
-            TableUtil.Format tblFormat = allFormats.get(formatInMap);
+            TableUtil.Format tblFormat = sp.getTableFormat();
             String fileNameExt = tblFormat.getFileNameExt();
 
             if (StringUtils.isEmpty(fileName)) {
@@ -76,10 +48,7 @@ public class HttpServCommands {
 
             FileInfo fi = am.save(res.getOutputStream(), request, tblFormat);
             if (fi != null) {
-                long length = 0;
-                if (fi != null) {
-                    length = fi.getSizeInBytes();
-                }
+                long length = fi.getSizeInBytes(); // if written from the db, the length is 0
                 logStats(length, "fileName", fi.getExternalName());
                 // maintain counters for applicaiton monitoring
                 Counters.getInstance().increment(Counters.Category.Download, "SaveAsIpacTable");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerCommands.java
@@ -4,7 +4,6 @@
 package edu.caltech.ipac.firefly.server.ws;
 
 
-import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.data.WspaceMeta;
 import edu.caltech.ipac.firefly.server.ServCommand;
@@ -12,15 +11,18 @@ import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.SrvParam;
 import edu.caltech.ipac.firefly.server.query.SearchManager;
 import edu.caltech.ipac.firefly.server.servlets.AnyFileDownload;
+import edu.caltech.ipac.table.TableUtil;
+import edu.caltech.ipac.util.FileUtil;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.util.List;
-import java.util.HashMap;
 
 import static edu.caltech.ipac.firefly.server.servlets.AnyFileDownload.FILE_PARAM;
-import static edu.caltech.ipac.firefly.server.servlets.AnyFileDownload.RETURN_PARAM;
 
 /**
  * Handle the commands to manage ws
@@ -174,18 +176,32 @@ public class WsServerCommands {
         /**
          * If table, it will get it and then put it into WS under relative path passed to {@link WsServerParams}
          *
-         * @param sp
-         * @return
+         * @param sp parameters
+         * @return response as JSON string
          * @throws Exception
          */
         public String doCommand(SrvParam sp) throws Exception {
 
             TableServerRequest request = sp.getTableServerRequest();
             if (request == null) throw new IllegalArgumentException("Invalid/Missing table request");
-            FileInfo f = new SearchManager().getFileInfo(request);
+
+            TableUtil.Format tblFormat = sp.getTableFormat();
+            String fileNameExt = tblFormat.getFileNameExt();
+
+            File file = File.createTempFile(request.getRequestId(), fileNameExt, ServerContext.getTempWorkDir());
+
+            SearchManager am = new SearchManager();
+            try (OutputStream out = new BufferedOutputStream(new FileOutputStream(file), (int) (32 * FileUtil.K))) {
+                am.save(out, request, tblFormat);
+            }
 
             WsServerParams wsParams = convertToWsServerParams(sp);
-            WsResponse wsResponse = getWsUtils().putFile(wsParams, f.getFile());
+            String fileName = wsParams.getRelPath();
+            if (!fileName.toLowerCase().endsWith(fileNameExt)) {
+                fileName += fileNameExt;
+                wsParams.set(WsServerParams.WS_SERVER_PARAMS.CURRENTRELPATH, fileName);
+            }
+            WsResponse wsResponse = getWsUtils().putFile(wsParams, file);
 
             return getResponseOnRelpath(wsResponse, wsParams);
             //return wsResponse.doContinue()?RESPONSE.TRUE.name().toLowerCase():RESPONSE.FALSE.name().toLowerCase();

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -228,6 +228,20 @@ public class TableUtil {
         }
     }
 
+    private static Map<String, Format> allFormats = new HashMap<>();
+    static {
+        allFormats.put("ipac", Format.IPACTABLE);
+        allFormats.put("csv", Format.CSV);
+        allFormats.put("tsv", Format.TSV);
+        allFormats.put("votable-tabledata", Format.VO_TABLE_TABLEDATA);
+        allFormats.put("votable-binary-inline", Format.VO_TABLE_BINARY);
+        allFormats.put("votable-binary2-inline", Format.VO_TABLE_BINARY2);
+        allFormats.put("votable-fits-inline", Format.VO_TABLE_FITS);
+        allFormats.put("fits", Format.FITS);
+    }
+
+    public static Map<String, Format> getAllFormats() { return allFormats; }
+
     public static class ColCheckInfo {
         HashMap<String, CheckInfo> colCheckInfos = new HashMap<>();  // keyed by column name
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-78
Added support for file_format to WsServerCommands.WsPutTableFile

Test deployment: https://irsawebdev9.ipac.caltech.edu/ff78_tblSaveToWorkspace/irsaviewer/
- Log into workspace at https://irsadev.ipac.caltech.edu
- Catalog search m31, 100''
- Save table with various file formats
- The file is saved as an IPAC table in all cases.