### PR TITLE
FIREFLY-69,70: handling edge case FITS from SOFIA pipelines

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/PlotGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/PlotGroup.java
@@ -131,6 +131,8 @@ public class PlotGroup implements Iterable<Plot> {
    public void setZoomTo(float level) {
        _screenWidth  = (int)((Math.abs(_minX) + Math.abs(_maxX))  * level);
        _screenHeight = (int)((Math.abs(_minY) + Math.abs(_maxY))  * level);
+       if (_screenWidth == 0 && _minX != _maxX) {  _screenWidth = 1; }
+       if (_screenHeight == 0 && _minY != _maxY) {  _screenHeight = 1; }
        _maxYscale = (int)(Math.abs(_maxY) * level);
        _minXscale = (int)(Math.abs(_minX) * level);
        double scaleX =  1.0 * level;

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -15,7 +15,7 @@ import {
 import shallowequal from 'shallowequal';
 
 import {getAppOptions} from '../core/AppDataCntlr.js';
-import {getTblById, isFullyLoaded, watchTableChanges} from '../tables/TableUtil.js';
+import {getTblById, isFullyLoaded, isNumericType, watchTableChanges} from '../tables/TableUtil.js';
 import {TABLE_HIGHLIGHT, TABLE_LOADED, TABLE_SELECT} from '../tables/TablesCntlr.js';
 import {dispatchLoadTblStats} from './TableStatsCntlr.js';
 import {dispatchChartUpdate, dispatchChartHighlighted, dispatchChartSelect, getChartData} from './ChartsCntlr.js';
@@ -103,7 +103,7 @@ export function getNumericCols(cols) {
     const ncols = [];
     const excludeNames = ['ROW_IDX', 'ROW_NUM'];
     cols.forEach((c) => {
-        if (c.type.match(/^[dfil]/) !== null) {      // int, float, double, long .. or their short form.
+        if (isNumericType(c)) {
             if (!excludeNames.includes(c.name)) { ncols.push(c); }
         }
     });


### PR DESCRIPTION
Tickets:
https://jira.ipac.caltech.edu/browse/FIREFLY-69
https://jira.ipac.caltech.edu/browse/FIREFLY-70

Test deployment: https://irsawebdev9.ipac.caltech.edu/ff69_70-edge_case_fits/firefly/

- Fixed the bug preventing the display of very thin or very long FITS images.
- Improved error message when only one dimension is available in a FITS file.
- Fixed default chart bug: when picking numeric columns for plotting, 'long_string' was taken for a numeric column and plotting failed.

Used FITS images, referenced in the ticket to test. (Please, not that 2017-05-12_HA_F394_001_CAL_unk_HAWE_HWPE_RAW.fits is 324MB and takes long time to upload.) Here is the result:

![Screen Shot 2019-05-24 at 8 55 57 AM](https://user-images.githubusercontent.com/11876160/58341455-15f6ac80-7e03-11e9-90ba-5fb96fd82204.png)
