### PR TITLE
FIREFLY-96 fix the misplaced file information on DS9 region file upload dialog

### DIFF
--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -145,12 +145,13 @@ class RegionUpload extends PureComponent {
             <div style={{padding: 10, width: 380}}>
                 <FieldGroup groupKey={rgUploadGroupKey}>
                     <FileUpload
-                        wrapperStyle={{margin: '5px 0'}}
+                        wrapperStyle={{margin: '5px 0', width: 180}}
+                        innerStyle={{width: 80}}
                         fieldKey={rgUploadFieldKey}
                         initialState={{
                             tooltip: 'Select a region file to upload',
                             label: 'Upload File:'}}
-                        fileNameStyle={{marginLeft: -150, width: '15em', height: 16, fontSize: 12, verticalAlign: 'middle'}}
+                        fileNameStyle={{marginLeft: 0, width: 200, height: 16, fontSize: 12, verticalAlign: 'middle'}}
                     />
                     <CheckboxGroupInputField
                         fieldKey={relocatableKey}

--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -142,7 +142,7 @@ class RegionUpload extends PureComponent {
         const relocateOptions = [{label: 'treat as relocatable', value: relocatable.origin.key}];
 
         return (
-            <div style={{padding: 10}}>
+            <div style={{padding: 10, width: 380}}>
                 <FieldGroup groupKey={rgUploadGroupKey}>
                     <FileUpload
                         wrapperStyle={{margin: '5px 0'}}
@@ -150,6 +150,7 @@ class RegionUpload extends PureComponent {
                         initialState={{
                             tooltip: 'Select a region file to upload',
                             label: 'Upload File:'}}
+                        fileNameStyle={{marginLeft: -150, width: '15em', height: 16, fontSize: 12, verticalAlign: 'middle'}}
                     />
                     <CheckboxGroupInputField
                         fieldKey={relocatableKey}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-96
- fix the styling of file information on 'Load DS9 Region File' dialog, including the position of the file name display and  the characters of the file name  is displayed with no cut-off

test:
 https://irsawebdev9.ipac.caltech.edu/firefly-96/firefly/
do image search
click button 'Load a DS9 region file' to bring up 'Load DS9 Region File' dialog
'No file chosen' before file upalod or a file name after file upload should be located by the right side  'Choose File' button. 
