### PR TITLE
FIREFLY-136: Support right justification of numeric columns in Firefly table

### DIFF
--- a/src/firefly/html/test/tests-main.html
+++ b/src/firefly/html/test/tests-main.html
@@ -182,9 +182,9 @@
     <div id="expected" >
         <div>Using META-INFO API to show cell value as links
             <ul class='expected-list'>
-                <li><b>band</b> should be shown as links</li>
-                <li>first one links to irsa</li>
-                <li>second links to ivoa with constant text</li>
+                <li><b>band</b> should be shown as links, right aligned</li>
+                <li><b>in_row_id</b> should contain 2 links</li>
+                <li>one with its value and the second is fixed text 'ivoa'</li>
             </ul>
         </div>
     </div>
@@ -195,7 +195,8 @@
         function onFireflyLoaded(firefly) {
             tblReq1 = firefly.util.table.makeFileRequest(null, 'http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',null,
                 { META_INFO: {
-                    "col.band.Links": [{href: "https://irsa.ipac.caltech.edu/?id="}, {href: "http://ivoa.net/?id=", value: 'ivoa'}]
+                    "col.band.Links": [{href: "https://irsa.ipac.caltech.edu/?id="}],
+                    "col.in_row_id.Links": [{href: "https://irsa.ipac.caltech.edu/?id="}, {href: "http://ivoa.net/?id=", value: 'ivoa'}]
                 }});
             firefly.showTable('tables-1', tblReq1);
         }

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -361,7 +361,7 @@ function makeColumnTag(props, col, idx) {
             key={col.name}
             columnKey={idx}
             header={<HeadRenderer {...{col, showUnits, showTypes, showFilters, filterInfo, sortInfo, onSort, onFilter, tbl_id}} />}
-            cell={<CellRenderer {...{style, data, tbl_id, colIdx:idx}} />}
+            cell={<CellRenderer {...{style, data, tbl_id, col, colIdx:idx}} />}
             fixed={fixed}
             width={columnWidths[idx]}
             isResizable={true}

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -310,6 +310,10 @@
     padding: 3px;
 }
 
+.public_fixedDataTableCell_cellContent.right_align {
+    text-align: right;
+}
+
 .public_fixedDataTableCell_columnResizerKnob {
     background-color: #0284ff
 }

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -837,3 +837,7 @@ export function hashCode(str) {
      * signed int to an unsigned by doing an unsigned bitshift. */
     return hash >>> 0;
 }
+
+export function isNumeric(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-136

Changes:
- right-align columns with numeric types.  This is based on the column's type and not its values.
- for links:
   - when there's only one link, align it based on its link `text`.
   - When there's more than one, left align.

To test:
https://irsawebdev9.ipac.caltech.edu/FIREFLY-136/
Make sure all tables are behaving this way.  For links, look at test #6 of this page.
https://irsawebdev9.ipac.caltech.edu/FIREFLY-136/firefly/test/tests-main.html#test-6
