### PR TITLE
FIREFLY-115:Spitzer footprint option 'All' doesn't appear to work

### DIFF
--- a/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/MarkerDropDownView.jsx
@@ -96,7 +96,7 @@ export function MarkerDropDownView({plotView:pv}) {
                     const items = instruments.map((inst) => footprintCmdJSX(inst, fp, inst));
 
                     //SPITZER doesn't have any full footprint to overlay, skip
-                    if (fpDesc && fp !== ('SPITZER' &&  'SOFIA') ){
+                    if (fpDesc && fp !== 'SPITZER'  &&  fp!== 'SOFIA'){
                         items.splice(0, 0, footprintCmdJSX('All', fp));  // add to the beginning of the array.
                     }
 


### PR DESCRIPTION
  Remove the "all" entry in the SPITZER footprint menu.
 URL: https://irsawebdev9.ipac.caltech.edu/FIREFLY-115/irsaviewer/