### PR TITLE
FIREFLY-29: inadequate interpretation of the target field value

### DIFF
--- a/src/firefly/js/ui/TargetPanelWorker.js
+++ b/src/firefly/js/ui/TargetPanelWorker.js
@@ -169,7 +169,7 @@ function resolveObject(posFieldDef, resolver) {
                 else {
                     return {
                         showHelp: false,
-                        feedback: `Could not resolve: ${objName}`,
+                        feedback: `Could not resolve: ${decodeURIComponent(objName)}`,
                         valid: false,
                         wpt: null
                     };
@@ -178,7 +178,7 @@ function resolveObject(posFieldDef, resolver) {
             else {
                 return {
                     showHelp: false,
-                    feedback: `Could not resolve: ${objName}`,
+                    feedback: `Could not resolve: ${decodeURIComponent(objName)}`,
                     valid: false,
                     wpt: null
                 };
@@ -187,7 +187,7 @@ function resolveObject(posFieldDef, resolver) {
     ).catch((e) => {
         // e is undefined when a newer request came in, and promise is rejected
         if (e) {
-            let feedback = `Could not resolve: ${objName}`;
+            let feedback = `Could not resolve: ${decodeURIComponent(objName)}`;
             if (e.name === 'AbortError') {
                 feedback += '. Unresponsive service.';
             } else {

--- a/src/firefly/js/util/PositionParser.js
+++ b/src/firefly/js/util/PositionParser.js
@@ -54,11 +54,21 @@ var makePositionParser = function(helper) {
                     isValid = true;
                 }
             } else {
-                var map= getPositionMap(s);
+                const map= getPositionMap(s);
                 _coordSys= getCoordSysFromString(map[COORDINATE_SYS]);
                 _ra = map[RA];
                 _dec = map[DEC];
-                isValid = retPP.getCoordSys() !==CoordinateSys.UNDEFINED && !isNaN(retPP.getRa()) && !isNaN(retPP.getDec());
+                const validRa = !isNaN(retPP.getRa());
+                const validDec = !isNaN(retPP.getDec());
+                // determineType uses the first string to decide if the input is a position or object name.
+                // "12 mus" (a valid object name in NED) would be classified as a position.
+                if (!validDec) {
+                    _inputType = PositionParsedInput.Name;
+                    _objName= s;
+                    isValid = true;
+                } else {
+                    isValid = retPP.getCoordSys() !== CoordinateSys.UNDEFINED && validRa && validDec;
+                }
             }
         }
 

--- a/src/firefly/js/util/StringUtils.js
+++ b/src/firefly/js/util/StringUtils.js
@@ -57,7 +57,7 @@ export function convertExtendedAscii(sbOriginal) {
         return null;
     }
 
-    const retval= sbOriginal;
+    let retval= sbOriginal;
     let origCharAsInt;
     for (let isb = 0; isb < retval.length; isb++) {
 
@@ -66,15 +66,15 @@ export function convertExtendedAscii(sbOriginal) {
             switch (origCharAsInt) {
                 case 223:
                 case 224:
-                    retval[isb]= '"';
+                    retval = replaceAt(retval, isb, '"');
                     break;
                 case 150:
                 case 151:
-                    retval[isb]= '-';
+                    retval = replaceAt(retval, isb, '-');
                     break;
                 default:
                     if (origCharAsInt>127) {
-                        retval[isb]= '?';
+                        retval = replaceAt(retval, isb, '?');
                     }
                     break;
             }
@@ -86,31 +86,35 @@ export function convertExtendedAscii(sbOriginal) {
                 case '\u201A': // lower quotation mark
                 case '\u2039': // Single Left-Pointing Quotation Mark
                 case '\u203A': // Single right-Pointing Quotation Mark
-                    retval[isb]= '\'';
+                    retval = replaceAt(retval, isb, '\'');
                     break;
 
                 case '\u201C': // left double quote
                 case '\u201D': // right double quote
                 case '\u201E': // double low quotation mark
-                    retval[isb]= '"';
+                    retval = replaceAt(retval, isb, '"');
                     break;
 
                 case '\u02DC':
-                    retval[isb]= '~';
+                    retval = replaceAt(retval, isb, '~');
                     break;  // Small Tilde
 
                 case '\u2013': // En Dash
                 case '\u2014': // EM Dash
-                    retval[isb]= '-';
+                    retval = replaceAt(retval, isb, '-');
                     break;
 
                 default:
                     if (origCharAsInt>127) {
-                        retval[isb]= '?';
+                        retval = replaceAt(retval, isb, '?');
                     }
                     break;
             }
         }
     }
-    return sbOriginal;
+    return retval;
+}
+
+function replaceAt(str, index, replacement) {
+    return str.substr(0, index) + replacement+ str.substr(index + replacement.length);
 }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-29
Test build: https://irsawebdev9.ipac.caltech.edu/firefly-29_tgtresolver/firefly/?__action=layout.showDropDown&visible=true&view=IrsaCatalogDropDown

- Objects with the names starting with a number are now resolved
- Names with long-dash are now resolved (they were previously causing "TypeError: Cannot assign to read only property ..." and "Invariant Violation" warnings in React.
- Show unencoded name for failed name resolutions. (They were previously shown encoded.)

Previously failing, now resolving target names:
61 Ursae Majoris
41 Ara
12 Ophiuchi
39 Leonis
SCR J0630–7643

Known issues:
- The greek symbols are not converted into English equivalent.
- Degree symbol is not stripped.

These are the names resolved by http://cds.u-strasbg.fr/cgi-bin/Sesame, but not by Firefly:
Sk -68°137
ξ UMa
β CVn
χ¹ Ori
δ Eri
κ¹ Cet
ζ Puppis

(from https://en.wikipedia.org/wiki/Lists_of_stars)

Firefly replaces unrecognized non-ascii characters with '?', hence giving user a hint how to change the name so that it gets recognized.
 