### PR TITLE
IRSA-2894: ZTF images flipped east-west in time series tool

### DIFF
--- a/src/firefly/js/drawingLayers/NorthUpCompass.js
+++ b/src/firefly/js/drawingLayers/NorthUpCompass.js
@@ -164,7 +164,14 @@ function makeCompass(plotId, action){
     var zf= cc.zoomFactor || 1;
     var wpt2= makeWorldPt(wpStart.getLon(), wpStart.getLat() + (Math.abs(cdelt1)/zf)*(px), CoordinateSys.EQ_J2000);
     var spt2= cc.getScreenCoords(wpt2);
-    var sptE2 = getEastFromNorthOnScreen(cc, sptStart, spt2, Math.PI/2);
+    var wpt3= makeWorldPt(wpStart.getLon() + (Math.abs(cdelt1)/(Math.cos(wpStart.getLat()*Math.PI/180.)*zf))*(px),
+                           wpStart.getLat(), CoordinateSys.EQ_J2000);
+    var spt3= cc.getScreenCoords(wpt3);
+    // don't use spt3 because of funny effects near the celestial poles
+    // the sign of the cross product of compass vectors tells us if the image is mirror-reversed from the sky
+    var cross_product= (spt3.x - sptStart.x)*(spt2.y - sptStart.y) -
+                       (spt3.y - sptStart.y)*(spt2.x - sptStart.x);
+    var sptE2= getEastFromNorthOnScreen(cc, sptStart, spt2, Math.sign(cross_product));
 
     if (sptStart===null || spt2===null || sptE2===null) {
         return null;
@@ -176,12 +183,12 @@ function makeCompass(plotId, action){
     return [dataE, dataN];
 }
 
-function getEastFromNorthOnScreen(cc, origin, nVec) {
+function getEastFromNorthOnScreen(cc, origin, nVec, sign) {
     var originSpt = cc.getScreenCoords(origin);
     var vec1Spt = cc.getScreenCoords(nVec);
 
-    var x2 = (vec1Spt.y - originSpt.y) + originSpt.x;
-    var y2 = -(vec1Spt.x - originSpt.x) + originSpt.y;
+    var x2 = sign*(vec1Spt.y - originSpt.y) + originSpt.x;
+    var y2 = -sign*(vec1Spt.x - originSpt.x) + originSpt.y;
 
     return makeScreenPt(x2, y2);
 }

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -223,11 +223,21 @@ function makeDrawing(pv,width,height) {
     //const wptE2= makeWorldPt(wptC.getLon()+(Math.abs(cdelt1)/thumbZoomFact)*(arrowLength/2), wptC.getLat());
     const wptE1= wptC;
     const wpt1= wptC;
+    const wpt3= makeWorldPt(wptC.getLon() +
+                            (Math.abs(cdelt1)/(Math.cos(wptC.getLat()*Math.PI/180.)/thumbZoomFact)*(arrowLength/1.6)),
+                            wptC.getLat());
+
 
     const sptC = cc.getScreenCoords(wptC);
     const sptN = cc.getScreenCoords(wpt2);
     if (!sptC || !sptN) return null;
-    const [x, y] = [(sptN.y - sptC.y) + sptC.x, (-sptN.x + sptC.x)+sptC.y];
+    const spt3= cc.getScreenCoords(wpt3);
+    // don't use spt3 because of funny effects near the celestial poles
+    // the sign of the cross product of compass vectors tells us if the image is mirror-reversed from the sky
+    const cross_product= (spt3.x - sptC.x)*(sptN.y - sptC.y) -
+                       (spt3.y - sptC.y)*(sptN.x - sptC.x);
+    const [x, y] = [Math.sign(cross_product)*(sptN.y - sptC.y) + sptC.x,
+                    Math.sign(cross_product)*(-sptN.x + sptC.x)+sptC.y];
     const wptE2 = cc.getWorldCoords(makeScreenPt(x, y));
 
     const spt1= cc.getDeviceCoords(wpt1, thumbZoomFact, thumbnailTrans);


### PR DESCRIPTION
ZTF images are mirror-reversed with respect to the sky, with North down and East to the left. Account for this case by computing the cross product of local North and East vectors, and taking the sign to know when to flip the compass.

Link to ticket in JIRA: https://jira.ipac.caltech.edu/browse/IRSA-2894