### PR TITLE
Firefly-94 Workspace with WebDAV servers not supporting depth 'Infinity'

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/WspaceMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/WspaceMeta.java
@@ -40,12 +40,12 @@ public class WspaceMeta implements Serializable {
     }
 
     public enum Includes {
-        NONE(false, 0), NONE_PROPS(true, 0), CHILDREN(false, 1), CHILDREN_PROPS(true, 1), ALL(false), ALL_PROPS(true);
+        NONE(false, 0), NONE_PROPS(true, 0), CHILDREN(false, 1), CHILDREN_PROPS(true, 1), ALL(false), ALL_PROPS(true, 1);
         public boolean inclProps = false;
         public int depth = 0;
 
         Includes(boolean b) {
-            this(b, Integer.MAX_VALUE);
+            this(b, 1);
         }
 
         Includes(boolean b, int d) {
@@ -142,6 +142,7 @@ public class WspaceMeta implements Serializable {
         s.append(wsHome).append(relPath).append("\n");
         s.append("creationDate:").append(creationDate).append("\n");
         s.append("lastModified:").append(lastModified).append("\n");
+        s.append("isFile:").append(isFile).append("\n");
         s.append("contentType:").append(contentType).append("\n");
         s.append("size:").append(size).append("\n");
         s.append("url:").append(url).append("\n");

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/WspaceMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/WspaceMeta.java
@@ -17,6 +17,7 @@ import java.util.Map;
  */
 public class WspaceMeta implements Serializable {
 
+
     public static final String SEARCH_DIR = "searches";
     public static final String STAGING_DIR = "staging";
     public static final String CATALOGS = "catalogs";
@@ -40,12 +41,12 @@ public class WspaceMeta implements Serializable {
     }
 
     public enum Includes {
-        NONE(false, 0), NONE_PROPS(true, 0), CHILDREN(false, 1), CHILDREN_PROPS(true, 1), ALL(false), ALL_PROPS(true, 1);
-        public boolean inclProps = false;
-        public int depth = 0;
+        NONE(false, 0), NONE_PROPS(true, 0), CHILDREN(false, 1), CHILDREN_PROPS(true, 1), ALL(false), ALL_PROPS(true);
+        public boolean inclProps = false; // include properties
+        public int depth = 0; // desired depth, can be 0, 1, or Integer.MAX_VALUE for infinity (which might not be supported by WS server)
 
         Includes(boolean b) {
-            this(b, 1);
+            this(b, Integer.MAX_VALUE);
         }
 
         Includes(boolean b, int d) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
@@ -24,7 +24,8 @@ import java.util.function.Consumer;
  */
 public class LocalFSWorkspace implements WorkspaceManager {
     //TODO We might need to change those properties if we need to deal with 2 or more workspaces at the same time
-    String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
+    private String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
+
 
 
     private final WsCredentials wscred;
@@ -42,7 +43,7 @@ public class LocalFSWorkspace implements WorkspaceManager {
         wscred = cred;
     }
 
-    public static final String WS_ROOT_DIR = ".";
+    private static final String WS_ROOT_DIR = ".";
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
 
@@ -143,10 +144,10 @@ public class LocalFSWorkspace implements WorkspaceManager {
         return WsUtil.error(500);
     }
 
-    @Override
-    public File createWsLocalFile(String wspaceSaveDirectory, String filePrefix, String fileExt) {
-        return null;
-    }
+//    @Override
+//    public File createWsLocalFile(String wspaceSaveDirectory, String filePrefix, String fileExt) {
+//        return null;
+//    }
 
     @Override
     public WsResponse delete(String uri) throws WsException {
@@ -179,10 +180,10 @@ public class LocalFSWorkspace implements WorkspaceManager {
         return false;
     }
 
-    @Override
-    public WspaceMeta newLocalWsMeta(File file, String propName, String value) {
-        throw new IllegalArgumentException("not implemented");
-    }
+//    @Override
+//    public WspaceMeta newLocalWsMeta(File file, String propName, String value) {
+//        throw new IllegalArgumentException("not implemented");
+//    }
 
     @Override
     public WsCredentials getCredentials() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/LocalFSWorkspace.java
@@ -64,7 +64,7 @@ public class LocalFSWorkspace implements WorkspaceManager {
         if (propFound.equals(PROPS.ROOT_URL)) {
             propVal = WS_HOST_URL;
         } else if (propFound.equals(PROPS.ROOT_DIR)) {
-            propVal = WS_ROOT_DIR;
+            propVal = getWsHome();
         } else if (propFound.equals(PROPS.AUTH)) {
             propVal = "NONE";
         } else if (propFound.equals(PROPS.PROTOCOL)) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
@@ -56,8 +56,8 @@ public class WebDAVWorkspaceManager extends WebDAVWorkspaceManagerBase {
         }
         if (propFound.equals(PROPS.ROOT_URL)) {
             propVal = WS_HOST_URL;
-//        } else if (propFound.equals(PROPS.ROOT_DIR)) {
-//            propVal = WS_ROOT_DIR;
+        } else if (propFound.equals(PROPS.ROOT_DIR)) {
+            propVal = getWsHome();
         } else if (propFound.equals(PROPS.AUTH)) {
             propVal = this.partition.name();
         } else if (propFound.equals(PROPS.PROTOCOL)) {
@@ -221,7 +221,11 @@ public class WebDAVWorkspaceManager extends WebDAVWorkspaceManagerBase {
         man.setMeta(meta);
         man.setMeta(ufilePath, "added_by", man.userHome);
 
-        WspaceMeta meta2 = man.getMeta("/", WspaceMeta.Includes.ALL_PROPS);
-        System.out.println(meta2.getNodesAsString());
+        try {
+            WspaceMeta meta2 = man.getMeta("/", WspaceMeta.Includes.ALL_PROPS);
+            System.out.println(meta2.getNodesAsString());
+        } catch (Exception e) {
+            e.printStackTrace(System.err);
+        }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManager.java
@@ -8,33 +8,14 @@ import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.network.HttpServices;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.ws.WsCredentials;
-import edu.caltech.ipac.firefly.server.ws.WsException;
 import edu.caltech.ipac.firefly.server.ws.WsResponse;
-import edu.caltech.ipac.firefly.server.ws.WsUtil;
-import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
-import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
-import org.apache.commons.httpclient.methods.RequestEntity;
-import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.apache.commons.io.FileUtils;
-import org.apache.jackrabbit.webdav.DavConstants;
-import org.apache.jackrabbit.webdav.DavMethods;
-import org.apache.jackrabbit.webdav.MultiStatus;
-import org.apache.jackrabbit.webdav.MultiStatusResponse;
-import org.apache.jackrabbit.webdav.client.methods.*;
-import org.apache.jackrabbit.webdav.property.*;
-import org.apache.jackrabbit.webdav.xml.Namespace;
+import org.apache.jackrabbit.webdav.client.methods.DavMethod;
+import org.apache.jackrabbit.webdav.client.methods.MkColMethod;
+
 
 import java.io.*;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
  * WebDAV implementation for IRSA
@@ -44,21 +25,24 @@ import java.util.function.Consumer;
  * @author loi
  * @version $Id: $
  */
-public class WebDAVWorkspaceManager implements WorkspaceManager {
+public class WebDAVWorkspaceManager extends WebDAVWorkspaceManagerBase {
 
     /**
      * TODO is this used currently or should/will it be used in the future?
      */
-    private static final Namespace IRSA_NS = Namespace.getNamespace("irsa", "https://irsa.ipac.caltech.edu/namespace/");
+    private static final String IRSA_NS_PREFIX = "irsa";
+    private static final String IRSA_NS_URI = "https://irsa.ipac.caltech.edu/namespace/";
+    //private static final Namespace IRSA_NS = Namespace.getNamespace("irsa", "https://irsa.ipac.caltech.edu/namespace/");
     //TODO We might need to change those properties if we need to deal with 2 or more workspaces at the same time
-    private static String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
-    private static String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
+    // //WS_ROOT_DIR is used only for testing and is confusing things, getWsHome() should be used instead
+    //private static String WS_ROOT_DIR = AppProperties.getProperty("workspace.root.dir", "/work");
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     private WsCredentials creds;
 
     @Override
     public String getProp(PROPS prop) {
+        // TODO: this method is used only in test - do we need it?
         PROPS propFound = null;
         for (PROPS p : PROPS.values()) {
             if (p.name().equalsIgnoreCase(prop.name())) {
@@ -67,10 +51,13 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
             }
         }
         String propVal = prop + " doesn't exist";
+        if (propFound == null) {
+            return propVal;
+        }
         if (propFound.equals(PROPS.ROOT_URL)) {
             propVal = WS_HOST_URL;
-        } else if (propFound.equals(PROPS.ROOT_DIR)) {
-            propVal = WS_ROOT_DIR;
+//        } else if (propFound.equals(PROPS.ROOT_DIR)) {
+//            propVal = WS_ROOT_DIR;
         } else if (propFound.equals(PROPS.AUTH)) {
             propVal = this.partition.name();
         } else if (propFound.equals(PROPS.PROTOCOL)) {
@@ -90,7 +77,6 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
 
     private Partition partition;
     private String userHome;
-    private Map<String, String> cookies;
 
     /**
      * Used by {@link edu.caltech.ipac.firefly.server.ws.WebDAVWorkspaceHandler#withCredentials(WsCredentials)}}
@@ -114,582 +100,69 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
     }
 
     public WebDAVWorkspaceManager(Partition partition, WsCredentials cred, boolean initialize) {
-        this(partition, cred.getWsId(), cred.getCookies(), initialize);
+        this(partition, cred.getWsId(), initialize);
         this.creds = cred;
     }
 
-    public WebDAVWorkspaceManager(Partition partition, String wsId, Map<String, String> cookies, boolean initialize) {
+    public WebDAVWorkspaceManager(Partition partition, String wsId, boolean initialize) {
 
-        cookies = HttpServiceInput.createWithCredential(WS_HOST_URL).getCookies();          // should look at this again.
+        Map<String, String> cookies = HttpServiceInput.createWithCredential(WS_HOST_URL).getCookies();          // should look at this again.
 
         this.creds = new WsCredentials(wsId, cookies);
         this.partition = partition;
         this.userHome = WspaceMeta.ensureWsHomePath(wsId);
-        this.cookies = cookies;
         if (initialize) {
             davMakeDir("");
         }
     }
 
-    /**
-     * returns the local filesystem path of the given relpath.
-     *
-     * @param relPath relative to the user's workspace and must starts with '/'
-     * @return
-     */
-    public String getLocalFsPath(String relPath) {
-        return WS_ROOT_DIR + getAbsPath(relPath);
-    }
 
-    /**
-     * returns the webdav's absolute path.  for IRSA, it's /partition/user_ws/relpath.
-     *
-     * @param relPath relative to the user's workspace and must starts with '/'
-     * @return
-     */
-    public String getAbsPath(String relPath) {
-        String s = WspaceMeta.ensureRelPath(relPath);
-        return getWsHome() + s;
-    }
-
-    /**
-     * returns the relative path given the file.  for IRSA, it's /partition/user_ws/relpath.
-     *
-     * @param file relative to the user's workspace and must starts with '/'
-     * @return
-     */
-    public String getRelPath(File file) {
-        String s = file.getAbsolutePath().replaceFirst(WS_ROOT_DIR, "");
-        s = s.replaceFirst(getWsHome(), "");
-        return s;
-    }
-
-    /**
-     * return the url of this resource.
-     *
-     * @param relPath
-     * @return
-     */
-    public String getResourceUrl(String relPath) {
-        String valid = null;
-        try {
-            valid = WsUtil.encode(relPath);
-        } catch (URISyntaxException e) {
-            LOG.error(e, "Continue with relative path as it is: "+relPath);
-            e.printStackTrace();
-        }
-        return WS_HOST_URL + getAbsPath(valid);
-    }
-
-    public String getWsHome() {
-        return "/" + partition + userHome;
-    }
-
-    public File createWsLocalFile(String parent, String fname, String fext) {
-        davMakeDir(parent);
-        return new File(new File(getLocalFsPath(parent)), fname + "-" + System.currentTimeMillis() % 1000000 + fext);
-    }
-
-
+    //====================================================================
+//  overrides and abstract methods implementations
 //====================================================================
-//  WEBDAV functions
-//====================================================================
-
-    /**
-     * create a directory given by the relPath parameter.
-     *
-     * @param relPath relative to the user's workspace
-     * @return the absolute path to the directory on the filesystem.
-     */
-    public File davMakeDir(String relPath) {
-        try {
-            String[] parts = relPath.split("/");
-            String cdir = "/";
-            for (String s : parts) {
-                cdir += StringUtils.isEmpty(s) ? "" : s + "/";
-                WspaceMeta m = getMeta(cdir, WspaceMeta.Includes.NONE);
-                if (m == null) {
-                    DavMethod mkcol = new MkColMethod(getResourceUrl(cdir));
-                    if (!executeMethod(mkcol)) {
-                        // handle error
-                        LOG.error("Unable to create directory:" + relPath + " -- " + mkcol.getStatusText());
-                        return null;
-                    }
-                }
-            }
-            return new File(getLocalFsPath(relPath));
-        } catch (Exception e) {
-            LOG.error(e, "Error while makeCollection:" + relPath);
-        }
-        return null;
-    }
-
-    boolean exists(String relRemoteUri) {
-        return getMeta(relRemoteUri, WspaceMeta.Includes.NONE) != null;
-    }
-
-
-
-    /**
-     *
-     * @param upload
-     * @param relPath   expecting uri folder with file name attached optionally a/b
-     * @param overwrite when true, put will overwrite existing file with the same name
-     * @param contentType
-     * @return
-     */
-    public WsResponse davPut(File upload, String relPath, boolean overwrite, String contentType) {
-        try {
-
-            int idx = relPath.lastIndexOf('/');
-            String newFileName = relPath.substring(idx + 1);
-
-            relPath = relPath.substring(0, idx+1);
-            String parentPath = WsUtil.ensureUriFolderPath(relPath);
-            //if (!exists(parentPath)) {
-            WsResponse response = createParent(parentPath);
-
-            String newPath;
-            String newUrl;
-            if (newFileName.length() == 0) {
-                newPath = parentPath + upload.getName();
-                newUrl =  getResourceUrl(parentPath) + WsUtil.encode(upload.getName());
-            } else {
-                newPath = parentPath + newFileName;
-                newUrl =  getResourceUrl(parentPath) + WsUtil.encode(newFileName);
-            }
-            //}
-            // If parent and file name exists already, stop
-            if (!response.doContinue()) {
-                return WsUtil.error(Integer.parseInt(response.getStatusCode()), response.getStatusText(), parentPath);
-            }
-
-
-            if (exists(newPath) && (!overwrite)) {
-                //if (exists(relPath)) {
-                return WsUtil.error(304, newUrl);// not modified, already exists
-            }
-
-            PutMethod put = new PutMethod(newUrl);
-
-            // TODO Content Type doesn't seems to be passed on
-            RequestEntity requestEntity = new InputStreamRequestEntity(new BufferedInputStream(
-                    new FileInputStream(upload), HttpServices.BUFFER_SIZE), upload.length(), contentType);
-            put.setRequestEntity(requestEntity);
-            /** is to allow a client that is sending a request message with a request body
-             *  to determine if the origin server is willing to accept the request
-             * (based on the request headers) before the client sends the request body.
-             * this require server supporting HTTP/1.1 protocol.
-             */
-            put.getParams().setBooleanParameter(
-                    HttpMethodParams.USE_EXPECT_CONTINUE, true);
-
-            if (!executeMethod(put)) {
-                // handle error
-                LOG.error("Unable to upload file:" + relPath + " -- " + put.getStatusText());
-                return WsUtil.error(put.getStatusCode(), put.getStatusText());
-            }
-
-            return WsUtil.success(put.getStatusCode(), put.getStatusText(), newUrl);
-        } catch (Exception e) {
-            LOG.error(e, "Error while uploading file:" + upload.getPath());
-        }
-        return WsUtil.error(500);
-    }
-
-    public WsResponse davGet(File outfile, String fromPath) throws IOException {
-        String url = getResourceUrl(fromPath);
-        WebDAVGetMethod get = new WebDAVGetMethod(url);
-        InputStream in = null;
-        try {
-            if (!executeMethod(get, false)) {
-                // handle error
-                LOG.error("Unable to download file:" + fromPath + " , url " +url+" -- "+ get.getStatusText());
-                return WsUtil.error(get.getStatusCode(), get.getStatusText());
-            }
-            if (get.getResponseContentLength() > 0) {
-                in = get.getResponseBodyAsStream();
-                FileUtils.copyInputStreamToFile(in, outfile);
-            }
-        } catch (Exception e) {
-            LOG.error(e, "Error while downloading remote file:" + url);
-        } finally {
-            get.releaseConnection();
-        }
-        return WsUtil.success(200, "File downloaded " + outfile.getAbsolutePath(), "");
-    }
-
-//====================================================================
-//  for firefly use
-//====================================================================
-
-    private HttpServiceInput convertToHttpInput(WsCredentials creds) {
-        HttpServiceInput input = new HttpServiceInput().setUserId(creds.getWsId()).setPasswd(creds.getPassword());
-        if (creds.getCookies() != null) {
-            creds.getCookies().forEach((k, v) -> input.setCookie(k, v));
-        }
-        return input;
-    }
-
     @Override
     public WsCredentials getCredentials() {
         return this.creds;
     }
 
     @Override
-    public PROTOCOL getProtocol() {
-        return PROTOCOL.WEBDAV;
+    public String getWsHome() {
+        return "/" + partition + userHome;
     }
 
     @Override
-    public WsResponse getList(String parentUri, int depth) throws WsException {
-
-        WspaceMeta.Includes prop = WspaceMeta.Includes.CHILDREN_PROPS;
-
-        if (depth < 0) {
-            prop = WspaceMeta.Includes.ALL_PROPS;
-        } else if (depth == 0) {
-            prop = WspaceMeta.Includes.NONE_PROPS;
-        }
-
-        WsResponse resp = new WsResponse("200", "List", "");
-
-        WspaceMeta meta = getMeta(parentUri, prop);
-        if (meta == null) {
-            WsResponse response = getResponse(parentUri);
-            return response;
-        }
-        List<WspaceMeta> childNodes = new ArrayList<>();
-        childNodes.add(meta);
-
-        //If no child, set the (self) meta in response:
-        resp.setWspaceMeta(childNodes);
-
-        if (meta.getChildNodes() != null) {
-            // Childs replaced here:
-            childNodes = meta.getChildNodes();
-            resp.setWspaceMeta(childNodes);
-            String respString = "";
-            Iterator<WspaceMeta> it = childNodes.iterator();
-            int child = 0;
-            while (it.hasNext()) {
-                WspaceMeta next = it.next();
-                respString += next.getRelPath() + ", ";
-                child++;
-
-            }
-            resp.setResponse(respString);
-        }
-
-        return resp;
-    }
-
-    @Override
-    public WsResponse getFile(String fileUri, File outputFile) throws WsException {
-        try {
-            return davGet(outputFile, fileUri);
-        } catch (IOException e) {
-            throw new WsException("Fail to get the file " + fileUri);
-        }
-    }
-
-    @Override
-    public WsResponse getFile(String fileUri, Consumer consumer) throws WsException {
-        throw new IllegalArgumentException("not implemented");
-    }
-
-
-    @Override
-    public WsResponse putFile(String relPath, boolean overwrite, File item, String contentType) throws WsException {
-        String ct = contentType;
-        if (contentType == null) {
-            //ct = ContentType.DEFAULT_BINARY.getMimeType();
-            //ct="image/fits";
-        }
-
-        return davPut(item, relPath, overwrite, ct);
-    }
-
-    @Override
-    public WsResponse delete(String uri) throws WsException {
-        if (WspaceMeta.ensureWsHomePath(uri).equals("")) {
-            return WsUtil.error(304, "Attempt to delete home, skipping...");
-        }
-        String url = getResourceUrl(uri);
-        WebDAVDeleteMethod rm = new WebDAVDeleteMethod(url);
-        try {
-            if (!executeMethod(rm, true)) {
-                // handle error
-                LOG.error("Unable to delete file uri:" + uri + " -- " + rm.getStatusText());
-                return WsUtil.error(rm);
-            }
-        } catch (Exception e) {
-            LOG.error(e, "Error while deleting remote file:" + url);
-        }
-        return WsUtil.success(200, "Deleted " + uri, uri);
-    }
-
-    @Override
-    public WsResponse createParent(String newRelPath) throws WsException {
-        String[] parts = newRelPath.split("/");
-        String cdir = "/";
-        for (String s : parts) {
-            cdir += StringUtils.isEmpty(s) ? "" : s + "/";
-            WspaceMeta m = getMeta(cdir, WspaceMeta.Includes.NONE);
-            if (m == null) {
-                try {
-                    URI uri = new URI(getResourceUrl(cdir));
-
-                    DavMethod mkcol = new MkColMethod(uri.toURL().toString());
-                    if (!executeMethod(mkcol)) {
-                        // handle error
-                        LOG.error("Unable to create directory:" + newRelPath + " -- " + mkcol.getStatusText());
-                        return WsUtil.error(mkcol, "Resource already exist");
-                    }
-                } catch (URISyntaxException e) {
-                    return WsUtil.error(e);
-                } catch (MalformedURLException e) {
-                    return WsUtil.error(e);
-                }
-            }
-        }
-        return WsUtil.success(200, "Created", getResourceUrl(newRelPath));
-    }
-
-    public WsResponse moveFile(String originalFileRelPath, String newPath, boolean overwrite) throws WsException {
-        WspaceMeta meta = new WspaceMeta(newPath);
-        String parent = meta.getParentPath();
-
-        //WARNING: WEBDAv forces me to create new parent first! UGLY!
-        createParent(parent);
-
-        String newUrl = getResourceUrl(newPath);
-
-        // This doesn't create parent , you must create the parent folder in order to move it
-        MoveMethod move = new MoveMethod(getResourceUrl(originalFileRelPath), newUrl, overwrite);
-        if (!executeMethod(move)) {
-            // handle error
-            LOG.error("Unable to move:" + originalFileRelPath + " based on url -- " +newUrl+" -- "+ move.getStatusText());
-            return WsUtil.error(move.getStatusCode(), move.getStatusLine().getReasonPhrase());
-        }
-        return WsUtil.success(move.getStatusCode(), move.getStatusText(), newUrl);
-    }
-
-    @Override
-    public WsResponse renameFile(String originalFileRelPath, String newfileName, boolean overwrite) throws WsException {
-        WspaceMeta meta = new WspaceMeta(originalFileRelPath);
-        String parent = meta.getParentPath();
-
-        String newUrl = null;
-        try {
-            newUrl = getResourceUrl(parent) + WsUtil.encode(newfileName);
-        } catch (URISyntaxException e) {
-            LOG.error("Unable to convert to URI:" + newfileName);
-        }
-
-        MoveMethod move = new MoveMethod(getResourceUrl(originalFileRelPath), newUrl, overwrite);
-        if (!executeMethod(move)) {
-            // handle error
-            LOG.error("Unable to move:" + originalFileRelPath + " based on url -- " +newUrl+" -- "+ move.getStatusText());
-            return WsUtil.error(move.getStatusCode(), move.getStatusLine().getReasonPhrase());
-        }
-        return WsUtil.success(move.getStatusCode(), move.getStatusText(), newUrl);
-    }
-
-    public WspaceMeta getMeta(String relPath) {
-        return getMeta(relPath, WspaceMeta.Includes.ALL);
-    }
-
-    public WspaceMeta getMeta(String relPath, WspaceMeta.Includes includes) {
-
-        // this can be optimized by retrieving only the props we care for.
-        DavMethod pFind = null;
-        try {
-            if (includes.inclProps) {
-                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_ALL_PROP, includes.depth);
-            } else {
-                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_BY_PROPERTY, includes.depth);
-            }
-
-            if (!executeMethod(pFind, false)) {
-                // handle error
-                if (pFind.getStatusCode() != 404) {
-                    LOG.error("Unable to find property:" + relPath + " -- " + pFind.getStatusText());
-                }
-                return null;
-            }
-
-            MultiStatus multiStatus = pFind.getResponseBodyAsMultiStatus();
-            MultiStatusResponse[] resps = multiStatus.getResponses();
-            if (resps == null || resps.length == 0) {
-                return null;
-            }
-            WspaceMeta root = new WspaceMeta(getWsHome(), relPath);
-
-            for (MultiStatusResponse res : resps) {
-                if (res.getHref().equals(WsUtil.encode(root.getAbsPath()))) {
-                    convertToWspaceMeta(root, res);
-                } else {
-                    addToRoot(root, res);
-                }
-            }
-            return root;
-        } catch (Exception e) {
-            LOG.error(e, "Error while getting meta for:" + relPath);
-        } finally {
-            if (pFind != null) {
-                pFind.releaseConnection();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * convenience method to create meta for a local file in the workspace
-     *
-     * @param file
-     * @param propName
-     * @param value
-     * @return
-     */
-    public WspaceMeta newLocalWsMeta(File file, String propName, String value) {
-        WspaceMeta meta = new WspaceMeta(getWsHome(), getRelPath(file));
-        meta.setProperty(propName, value);
-        return meta;
-    }
-
-    /**
-     * convenience method to set one property on a resource.
-     * if the property value is null, that property will be removed.
-     * otherwise, the property will be either added or updated.
-     *
-     * @param relPath
-     * @param propName
-     * @param value
-     * @return
-     */
-    public boolean setMeta(String relPath, String propName, String value) {
-        WspaceMeta meta = new WspaceMeta(null, relPath);
-        meta.setProperty(propName, value);
-        return setMeta(meta);
-    }
-
-    /**
-     * set meta information on this dav's resource.
-     * if the property value is null, that property will be removed.
-     * otherwise, the property will be either added or updated.
-     *
-     * @param metas
-     * @return
-     */
-    public boolean setMeta(WspaceMeta... metas) {
-        if (metas == null) return false;
-        for (WspaceMeta meta : metas) {
-
-            Map<String, String> props = meta.getProperties();
-            if (props != null && props.size() > 0) {
-                DavPropertySet newProps = new DavPropertySet();
-                DavPropertyNameSet removeProps = new DavPropertyNameSet();
-
-                for (String key : props.keySet()) {
-                    String v = props.get(key);
-                    if (v == null) {
-                        removeProps.add(DavPropertyName.create(key, IRSA_NS));
-                    } else {
-                        DavProperty p = new DefaultDavProperty(key, props.get(key), IRSA_NS);
-                        newProps.add(p);
-                    }
-                }
-                try {
-                    PropPatchMethod proPatch = new PropPatchMethod(getResourceUrl(meta.getRelPath()), newProps, removeProps);
-                    if (!executeMethod(proPatch)) {
-                        // handle error
-                        LOG.error("Unable to update property:" + newProps.toString() + " -- " + proPatch.getStatusText());
-                        return false;
-                    }
-                    return true;
-                } catch (IOException e) {
-                    LOG.error(e, "Error while setting property: " + meta);
-                    e.printStackTrace();
-                }
-
-            }
-
-        }
-        return false;
-    }
-
-//====================================================================
-//
-//====================================================================
-
-    private WspaceMeta convertToWspaceMeta(WspaceMeta meta, MultiStatusResponse res) throws UnsupportedEncodingException {
-        if (meta == null) {
-            meta = new WspaceMeta(getWsHome(), URLDecoder.decode(res.getHref().replaceFirst(getWsHome(), ""),"UTF-8"));
-        }
-        if (res.getHref() != null) {
-            meta.setUrl(WS_HOST_URL + res.getHref());
-        }
-        DavPropertySet props = res.getProperties(200);
-        if (props != null) {
-            for (DavProperty p : props) {
-                String name = (p == null || p.getName() == null) ? null : p.getName().getName();
-                if (name != null) {
-                    String v = String.valueOf(p.getValue());
-                    if (name.equals(DavConstants.PROPERTY_GETLASTMODIFIED)) {
-                        meta.setLastModified(v);
-                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTLENGTH)) {
-                        long size = Long.parseLong(v);
-                        meta.setSize(size);
-                        meta.setIsFile(true); // WEBDAV/IRSA only set cvontent length for files. (?)TODO: is it WEBDav general behaviour?
-                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTTYPE)) {
-                        meta.setContentType(v);
-                    } else if (p.getName().getNamespace().equals(IRSA_NS)) {
-                        meta.setProperty(name, String.valueOf(p.getValue()));
-                    } else if (name.equals(DavConstants.PROPERTY_CREATIONDATE)) {
-                        meta.setCreationDate(v);
-                    }
-                }
-            }
-        }
-        return meta;
-    }
-
-    private void addToRoot(WspaceMeta root, MultiStatusResponse res) throws UnsupportedEncodingException {
-        WspaceMeta meta = convertToWspaceMeta(null, res);
-        WspaceMeta p = root.find(meta.getParentPath());
-        if (p != null) {
-            p.addChild(meta);
+    protected HttpServices.Status doExecuteMethod(DavMethod method) throws IOException {
+        if (partition.equals(Partition.PUBSPACE)) {
+            return HttpServices.executeMethod(method);
         } else {
-            root.addChild(meta);
-        }
-    }
-
-    private boolean executeMethod(DavMethod method) {
-        return executeMethod(method, true);
-    }
-
-    private boolean executeMethod(DavMethod method, boolean releaseConnection) {
-        try {
-            HttpServices.Status status = partition.equals(Partition.PUBSPACE) ? HttpServices.executeMethod(method) :
-                    HttpServices.executeMethod(method, convertToHttpInput(getCredentials()));
-            return !status.isError();
-        } catch (IOException e) {
-            return false;
-        } finally {
-            if (releaseConnection && method != null) {
-                method.releaseConnection();
+            HttpServiceInput input = new HttpServiceInput().setUserId(creds.getWsId()).setPasswd(creds.getPassword());
+            if (creds.getCookies() != null) {
+                creds.getCookies().forEach(input::setCookie);
             }
+            return HttpServices.executeMethod(method, input);
         }
-
-
     }
+
+    @Override
+    protected String getNamespacePrefix() {
+        return IRSA_NS_PREFIX;
+    }
+
+    @Override
+    protected String getNamespaceUri() {
+        return IRSA_NS_URI;
+    }
+
+
+//====================================================================
+//  testing
+//====================================================================
 
     public static void main(String[] args) {
-        WebDAVWorkspaceManager man = null;
-//        man = (WebDAVWorkspaceManager) ServerContext.getRequestOwner().getWsManager();
 
-        man = new WebDAVWorkspaceManager("ejoliet-tmp2");
+//        WebDAVWorkspaceManager man = (WebDAVWorkspaceManager) ServerContext.getRequestOwner().getWsManager();
+
+        WebDAVWorkspaceManager man = new WebDAVWorkspaceManager("ejoliet-tmp2");
 
         simpleTest(man);
 
@@ -701,10 +174,36 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
 //        simpleTest(man);
     }
 
+    /**
+     * //TODO: can I use super.createParent instead of this one: they seem to be virtually identical
+     * create a directory given by the relPath parameter.
+     *
+     * @param relPath relative to the user's workspace
+     */
+    private void davMakeDir(String relPath) {
+        try {
+            String[] parts = relPath.split("/");
+            String cdir = "/";
+            for (String s : parts) {
+                cdir += StringUtils.isEmpty(s) ? "" : s + "/";
+                WspaceMeta m = getMeta(cdir, WspaceMeta.Includes.NONE);
+                if (m == null) {
+                    DavMethod mkcol = new MkColMethod(getResourceUrl(cdir));
+                    if (!executeMethod(mkcol)) {
+                        // handle error
+                        LOG.error("Unable to create directory:" + relPath + " -- " + mkcol.getStatusText());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error(e, "Error while makeCollection:" + relPath);
+        }
+    }
+
     private static void simpleTest(WebDAVWorkspaceManager man) {
         String relPath = "124/";
-        File f = man.davMakeDir(relPath);
-        System.out.println("new directory: " + String.valueOf(f));
+        man.davMakeDir(relPath);
+        System.out.println("new directory: " + String.valueOf(relPath));
 
         WspaceMeta m = new WspaceMeta(null, relPath);
         m.setProperty("test1", "an awesome idea");
@@ -724,57 +223,5 @@ public class WebDAVWorkspaceManager implements WorkspaceManager {
 
         WspaceMeta meta2 = man.getMeta("/", WspaceMeta.Includes.ALL_PROPS);
         System.out.println(meta2.getNodesAsString());
-    }
-
-    public WsResponse getResponse(String relPath){
-        DavMethod pFind = null;
-        try {
-            pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_BY_PROPERTY, WspaceMeta.Includes.ALL_PROPS.depth);
-
-
-            if (!executeMethod(pFind, false)) {
-                // handle error
-                if (pFind.succeeded()){// != 404) {
-                    LOG.error("Unable to get property:" + relPath + " -- " + pFind.getStatusText());
-                }
-                return WsUtil.error(pFind.getStatusCode(), pFind.getStatusText());
-            }
-            return WsUtil.success(pFind.getStatusCode(), pFind.getStatusText(), pFind.getPath());
-        } catch (Exception e) {
-            LOG.error(e, "Error while getting meta for:" + relPath);
-        } finally {
-            if (pFind != null) {
-                pFind.releaseConnection();
-            }
-        }
-        return new WsResponse();
-    }
-
-    class WebDAVGetMethod extends DavMethodBase {
-        public WebDAVGetMethod(String uri) {
-            super(uri);
-        }
-
-        public String getName() {
-            return DavMethods.METHOD_GET;
-        }
-
-        public boolean isSuccess(int statusCode) {
-            return statusCode == 200;
-        }
-    }
-
-    class WebDAVDeleteMethod extends DavMethodBase {
-        public WebDAVDeleteMethod(String uri) {
-            super(uri);
-        }
-
-        public String getName() {
-            return DavMethods.METHOD_DELETE;
-        }
-
-        public boolean isSuccess(int statusCode) {
-            return statusCode == 200;
-        }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManagerBase.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WebDAVWorkspaceManagerBase.java
@@ -1,0 +1,590 @@
+package edu.caltech.ipac.firefly.server;
+
+import edu.caltech.ipac.firefly.data.WspaceMeta;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
+import edu.caltech.ipac.firefly.server.network.HttpServices;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
+import edu.caltech.ipac.firefly.server.ws.WsException;
+import edu.caltech.ipac.firefly.server.ws.WsResponse;
+import edu.caltech.ipac.firefly.server.ws.WsUtil;
+import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.StringUtils;
+import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
+import org.apache.commons.httpclient.methods.RequestEntity;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.apache.commons.io.FileUtils;
+import org.apache.jackrabbit.webdav.DavConstants;
+import org.apache.jackrabbit.webdav.DavMethods;
+import org.apache.jackrabbit.webdav.MultiStatus;
+import org.apache.jackrabbit.webdav.MultiStatusResponse;
+import org.apache.jackrabbit.webdav.client.methods.*;
+import org.apache.jackrabbit.webdav.property.*;
+import org.apache.jackrabbit.webdav.xml.Namespace;
+
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+public abstract class WebDAVWorkspaceManagerBase implements WorkspaceManager {
+
+    protected static String WS_HOST_URL = AppProperties.getProperty("workspace.host.url", "https://irsa.ipac.caltech.edu");
+
+    private static final Logger.LoggerImpl LOG = Logger.getLogger();
+
+    @Override
+    public String getProp(PROPS prop) {
+        // TODO: this method is used only in test - do we need it?
+        throw new IllegalArgumentException("not implemented");
+    }
+
+
+    /**
+     * returns the webdav's absolute path.  for IRSA, it's /partition/user_ws/relpath.
+     *
+     * @param relPath relative to the user's workspace and must starts with '/'
+     * @return absolute path to a resource
+     */
+    private String getAbsPath(String relPath) {
+        String s = WspaceMeta.ensureRelPath(relPath);
+        return getWsHome() + s;
+    }
+
+    /**
+     * return the url of this resource.
+     *
+     * @param relPath relative path to a resource
+     * @return url to a resource
+     */
+    String getResourceUrl(String relPath) {
+        String valid = null;
+        try {
+            valid = WsUtil.encode(relPath);
+        } catch (URISyntaxException e) {
+            LOG.error(e, "Continue with relative path as it is: "+relPath);
+            e.printStackTrace();
+        }
+        return WS_HOST_URL + getAbsPath(valid);
+    }
+
+    private Namespace getNamespace() {
+        return Namespace.getNamespace(getNamespacePrefix(), getNamespaceUri());
+    }
+
+//====================================================================
+//  absract methods
+//====================================================================
+
+    public abstract WsCredentials getCredentials();
+
+    public abstract String getWsHome();
+
+    protected abstract String getNamespacePrefix();
+
+    protected abstract String getNamespaceUri();
+
+
+//====================================================================
+//  WEBDAV functions
+//====================================================================
+
+
+
+    boolean exists(String relRemoteUri) {
+        return getMeta(relRemoteUri, WspaceMeta.Includes.NONE) != null;
+    }
+
+
+
+    /**
+     *
+     * @param upload  upload file
+     * @param relPath   expecting uri folder with file name attached optionally a/b
+     * @param overwrite when true, put will overwrite existing file with the same name
+     * @param contentType content type
+     * @return WsResponse object
+     */
+    public WsResponse davPut(File upload, String relPath, boolean overwrite, String contentType) {
+        try {
+
+            int idx = relPath.lastIndexOf('/');
+            String newFileName = relPath.substring(idx + 1);
+
+            relPath = relPath.substring(0, idx+1);
+            String parentPath = WsUtil.ensureUriFolderPath(relPath);
+            //if (!exists(parentPath)) {
+            WsResponse response = createParent(parentPath);
+
+            String newPath;
+            String newUrl;
+            if (newFileName.length() == 0) {
+                newPath = parentPath + upload.getName();
+                newUrl =  getResourceUrl(parentPath) + WsUtil.encode(upload.getName());
+            } else {
+                newPath = parentPath + newFileName;
+                newUrl =  getResourceUrl(parentPath) + WsUtil.encode(newFileName);
+            }
+            //}
+            // If parent and file name exists already, stop
+            if (!response.doContinue()) {
+                return WsUtil.error(Integer.parseInt(response.getStatusCode()), response.getStatusText(), parentPath);
+            }
+
+
+            if (exists(newPath) && (!overwrite)) {
+                //if (exists(relPath)) {
+                return WsUtil.error(304, newUrl);// not modified, already exists
+            }
+
+            PutMethod put = new PutMethod(newUrl);
+
+            // TODO Content Type doesn't seems to be passed on
+            RequestEntity requestEntity = new InputStreamRequestEntity(new BufferedInputStream(
+                    new FileInputStream(upload), HttpServices.BUFFER_SIZE), upload.length(), contentType);
+            put.setRequestEntity(requestEntity);
+            /* is to allow a client that is sending a request message with a request body
+             *  to determine if the origin server is willing to accept the request
+             * (based on the request headers) before the client sends the request body.
+             * this require server supporting HTTP/1.1 protocol.
+             */
+            put.getParams().setBooleanParameter(
+                    HttpMethodParams.USE_EXPECT_CONTINUE, true);
+
+            if (!executeMethod(put)) {
+                // handle error
+                LOG.error("Unable to upload file:" + relPath + " -- " + put.getStatusText());
+                return WsUtil.error(put.getStatusCode(), put.getStatusText());
+            }
+
+            return WsUtil.success(put.getStatusCode(), put.getStatusText(), newUrl);
+        } catch (Exception e) {
+            LOG.error(e, "Error while uploading file:" + upload.getPath());
+        }
+        return WsUtil.error(500);
+    }
+
+    private WsResponse davGet(File outfile, String fromPath) {
+        String url = getResourceUrl(fromPath);
+        WebDAVGetMethod get = new WebDAVGetMethod(url);
+        InputStream in;
+        try {
+            if (!executeMethod(get, false)) {
+                // handle error
+                LOG.error("Unable to download file:" + fromPath + " , url " +url+" -- "+ get.getStatusText());
+                return WsUtil.error(get.getStatusCode(), get.getStatusText());
+            }
+            if (get.getResponseContentLength() > 0) {
+                in = get.getResponseBodyAsStream();
+                FileUtils.copyInputStreamToFile(in, outfile);
+            }
+        } catch (Exception e) {
+            LOG.error(e, "Error while downloading remote file:" + url);
+            return WsUtil.error(e);
+        } finally {
+            get.releaseConnection();
+        }
+        return WsUtil.success(200, "File downloaded " + outfile.getAbsolutePath(), "");
+    }
+
+//====================================================================
+//  for firefly use
+//====================================================================
+
+
+    @Override
+    public PROTOCOL getProtocol() {
+        return PROTOCOL.WEBDAV;
+    }
+
+    @Override
+    public WsResponse getList(String parentUri, int depth) {
+
+        WspaceMeta.Includes prop = WspaceMeta.Includes.CHILDREN_PROPS;
+
+        if (depth < 0) {
+            prop = WspaceMeta.Includes.ALL_PROPS;
+        } else if (depth == 0) {
+            prop = WspaceMeta.Includes.NONE_PROPS;
+        }
+
+        WsResponse resp = new WsResponse("200", "List", "");
+
+        WspaceMeta meta = getMeta(parentUri, prop);
+        if (meta == null) {
+            return getResponse(parentUri);
+        }
+        List<WspaceMeta> childNodes = new ArrayList<>();
+        childNodes.add(meta);
+
+        //If no child, set the (self) meta in response:
+        resp.setWspaceMeta(childNodes);
+
+        if (meta.getChildNodes() != null) {
+            // Childs replaced here:
+            childNodes = meta.getChildNodes();
+            resp.setWspaceMeta(childNodes);
+            String respString = "";
+            Iterator<WspaceMeta> it = childNodes.iterator();
+            int child = 0;
+            while (it.hasNext()) {
+                WspaceMeta next = it.next();
+                respString += next.getRelPath() + ", ";
+                child++;
+            }
+            resp.setResponse(respString);
+        }
+
+        return resp;
+    }
+
+    @Override
+    public WsResponse getFile(String fileUri, File outputFile) {
+        return davGet(outputFile, fileUri);
+    }
+
+    @Override
+    public WsResponse getFile(String fileUri, Consumer consumer) {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+
+    @Override
+    public WsResponse putFile(String relPath, boolean overwrite, File item, String contentType) throws WsException {
+        String ct = contentType;
+        if (contentType == null) {
+            //ct = ContentType.DEFAULT_BINARY.getMimeType();
+            //ct="image/fits";
+        }
+
+        return davPut(item, relPath, overwrite, ct);
+    }
+
+    @Override
+    public WsResponse delete(String uri) {
+        if (WspaceMeta.ensureWsHomePath(uri).equals("")) {
+            return WsUtil.error(304, "Attempt to delete home, skipping...");
+        }
+        String url = getResourceUrl(uri);
+        WebDAVDeleteMethod rm = new WebDAVDeleteMethod(url);
+        try {
+            if (!executeMethod(rm, true)) {
+                // handle error
+                LOG.error("Unable to delete file uri:" + uri + " -- " + rm.getStatusText());
+                return WsUtil.error(rm);
+            }
+        } catch (Exception e) {
+            LOG.error(e, "Error while deleting remote file:" + url);
+        }
+        return WsUtil.success(200, "Deleted " + uri, uri);
+    }
+
+    @Override
+    public WsResponse createParent(String newRelPath) {
+        String[] parts = newRelPath.split("/");
+        String cdir = "/";
+        for (String s : parts) {
+            cdir += StringUtils.isEmpty(s) ? "" : s + "/";
+            WspaceMeta m = getMeta(cdir, WspaceMeta.Includes.NONE);
+            if (m == null) {
+                try {
+                    URI uri = new URI(getResourceUrl(cdir));
+
+                    DavMethod mkcol = new MkColMethod(uri.toURL().toString());
+                    if (!executeMethod(mkcol)) {
+                        // handle error
+                        LOG.error("Unable to create directory:" + newRelPath + " -- " + mkcol.getStatusText());
+                        return WsUtil.error(mkcol, "Resource already exist");
+                    }
+                } catch (URISyntaxException|MalformedURLException e) {
+                    return WsUtil.error(e);
+                }
+            }
+        }
+        return WsUtil.success(200, "Created", getResourceUrl(newRelPath));
+    }
+
+    public WsResponse moveFile(String originalFileRelPath, String newPath, boolean overwrite) {
+        WspaceMeta meta = new WspaceMeta(newPath);
+        String parent = meta.getParentPath();
+
+        //WARNING: WEBDAv forces me to create new parent first! UGLY!
+        createParent(parent);
+
+        String newUrl = getResourceUrl(newPath);
+
+        // This doesn't create parent , you must create the parent folder in order to move it
+        MoveMethod move = new MoveMethod(getResourceUrl(originalFileRelPath), newUrl, overwrite);
+        if (!executeMethod(move)) {
+            // handle error
+            LOG.error("Unable to move:" + originalFileRelPath + " based on url -- " +newUrl+" -- "+ move.getStatusText());
+            return WsUtil.error(move.getStatusCode(), move.getStatusLine().getReasonPhrase());
+        }
+        return WsUtil.success(move.getStatusCode(), move.getStatusText(), newUrl);
+    }
+
+    @Override
+    public WsResponse renameFile(String originalFileRelPath, String newfileName, boolean overwrite) {
+        WspaceMeta meta = new WspaceMeta(originalFileRelPath);
+        String parent = meta.getParentPath();
+
+        String newUrl;
+        try {
+            newUrl = getResourceUrl(parent) + WsUtil.encode(newfileName);
+        } catch (URISyntaxException e) {
+            LOG.error("Unable to convert to URI:" + newfileName);
+            return WsUtil.error(e);
+        }
+
+        MoveMethod move = new MoveMethod(getResourceUrl(originalFileRelPath), newUrl, overwrite);
+        if (!executeMethod(move)) {
+            // handle error
+            LOG.error("Unable to move:" + originalFileRelPath + " based on url -- " +newUrl+" -- "+ move.getStatusText());
+            return WsUtil.error(move.getStatusCode(), move.getStatusLine().getReasonPhrase());
+        }
+        return WsUtil.success(move.getStatusCode(), move.getStatusText(), newUrl);
+    }
+
+    public WspaceMeta getMeta(String relPath) {
+        return getMeta(relPath, WspaceMeta.Includes.ALL);
+    }
+
+    public WspaceMeta getMeta(String relPath, WspaceMeta.Includes includes) {
+
+        // this can be optimized by retrieving only the props we care for.
+        DavMethod pFind = null;
+        try {
+            if (includes.inclProps) {
+                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_ALL_PROP, includes.depth);
+            } else {
+                pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_BY_PROPERTY, includes.depth);
+            }
+
+            if (!executeMethod(pFind, false)) {
+                // handle error
+                if (pFind.getStatusCode() != 404) {
+                    LOG.error("Unable to find property:" + relPath + " -- " + pFind.getStatusText());
+                }
+                return null;
+            }
+
+            MultiStatus multiStatus = pFind.getResponseBodyAsMultiStatus();
+            MultiStatusResponse[] resps = multiStatus.getResponses();
+            if (resps == null || resps.length == 0) {
+                return null;
+            }
+            WspaceMeta root = new WspaceMeta(getWsHome(), relPath);
+
+            for (MultiStatusResponse res : resps) {
+                if (res.getHref().equals(WsUtil.encode(root.getAbsPath()))) {
+                    convertToWspaceMeta(root, res);
+                } else {
+                    addToRoot(root, res);
+                }
+            }
+            return root;
+        } catch (Exception e) {
+            LOG.error(e, "Error while getting meta for:" + relPath);
+        } finally {
+            if (pFind != null) {
+                pFind.releaseConnection();
+            }
+        }
+        return null;
+    }
+
+
+    /**
+     * convenience method to set one property on a resource.
+     * if the property value is null, that property will be removed.
+     * otherwise, the property will be either added or updated.
+     *
+     * @param relPath relative path
+     * @param propName property name
+     * @param value property value
+     * @return true on success, false on error
+     */
+    public boolean setMeta(String relPath, String propName, String value) {
+        WspaceMeta meta = new WspaceMeta(null, relPath);
+        meta.setProperty(propName, value);
+        return setMeta(meta);
+    }
+
+    /**
+     * set meta information on this dav's resource.
+     * if the property value is null, that property will be removed.
+     * otherwise, the property will be either added or updated.
+     *
+     * @param metas meta information
+     * @return false on error, true otherwise
+     */
+    public boolean setMeta(WspaceMeta... metas) {
+        if (metas == null) return false;
+        Namespace namespace = getNamespace();
+        for (WspaceMeta meta : metas) {
+
+            Map<String, String> props = meta.getProperties();
+            if (props != null && props.size() > 0) {
+                DavPropertySet newProps = new DavPropertySet();
+                DavPropertyNameSet removeProps = new DavPropertyNameSet();
+
+                for (String key : props.keySet()) {
+                    String v = props.get(key);
+                    if (v == null) {
+                        removeProps.add(DavPropertyName.create(key, namespace));
+                    } else {
+                        DavProperty p = new DefaultDavProperty(key, props.get(key), namespace);
+                        newProps.add(p);
+                    }
+                }
+                try {
+                    PropPatchMethod proPatch = new PropPatchMethod(getResourceUrl(meta.getRelPath()), newProps, removeProps);
+                    if (!executeMethod(proPatch)) {
+                        // handle error
+                        LOG.error("Unable to update property:" + newProps.toString() + " -- " + proPatch.getStatusText());
+                        return false;
+                    }
+                    return true;
+                } catch (IOException e) {
+                    LOG.error(e, "Error while setting property: " + meta);
+                    e.printStackTrace();
+                }
+
+            }
+
+        }
+        return false;
+    }
+
+//====================================================================
+//
+//====================================================================
+
+    private WspaceMeta convertToWspaceMeta(WspaceMeta meta, MultiStatusResponse res) throws UnsupportedEncodingException {
+        if (meta == null) {
+            meta = new WspaceMeta(getWsHome(), URLDecoder.decode(res.getHref().replaceFirst(getWsHome(), ""),"UTF-8"));
+        }
+        if (res.getHref() != null) {
+            meta.setUrl(WS_HOST_URL + res.getHref());
+        }
+        DavPropertySet props = res.getProperties(200);
+        if (props != null) {
+            Namespace namespace = getNamespace();
+            for (DavProperty p : props) {
+                String name = (p == null || p.getName() == null) ? null : p.getName().getName();
+                if (name != null) {
+                    String v = String.valueOf(p.getValue());
+                    if (name.equals(DavConstants.PROPERTY_GETLASTMODIFIED)) {
+                        meta.setLastModified(v);
+                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTLENGTH)) {
+                        long size = Long.parseLong(v);
+                        meta.setSize(size);
+                        //meta.setIsFile(true); // WEBDAV/IRSA only set content length for files. // not WEBDav standard behaviour
+                    } else if (name.equals(DavConstants.PROPERTY_GETCONTENTTYPE)) {
+                        meta.setContentType(v);
+                    } else if (p.getName().getNamespace().equals(namespace)) {
+                        meta.setProperty(name, String.valueOf(p.getValue()));
+                    } else if (name.equals(DavConstants.PROPERTY_CREATIONDATE)) {
+                        meta.setCreationDate(v);
+                    } else if (name.equals(DavConstants.PROPERTY_RESOURCETYPE)){
+                        meta.setIsFile(v == null || !v.toLowerCase().contains("collection"));
+                    }
+                }
+            }
+        }
+        return meta;
+    }
+
+    private void addToRoot(WspaceMeta root, MultiStatusResponse res) throws UnsupportedEncodingException {
+        WspaceMeta meta = convertToWspaceMeta(null, res);
+        WspaceMeta p = root.find(meta.getParentPath());
+        if (p != null) {
+            p.addChild(meta);
+        } else {
+            root.addChild(meta);
+        }
+    }
+    boolean executeMethod(DavMethod method) {
+        return executeMethod(method, true);
+    }
+
+    private boolean executeMethod(DavMethod method, boolean releaseConnection) {
+        try {
+            HttpServices.Status status = doExecuteMethod(method);
+            return !status.isError();
+        } catch (IOException e) {
+            return false;
+        } finally {
+            if (releaseConnection && method != null) {
+                method.releaseConnection();
+            }
+        }
+    }
+
+    protected HttpServices.Status doExecuteMethod(DavMethod method) throws IOException {
+        HttpServiceInput input = HttpServiceInput.createWithCredential(WS_HOST_URL);
+        return HttpServices.executeMethod(method, input);
+    }
+
+
+    private WsResponse getResponse(String relPath){
+        DavMethod pFind = null;
+        try {
+            pFind = new PropFindMethod(getResourceUrl(relPath), DavConstants.PROPFIND_BY_PROPERTY, WspaceMeta.Includes.ALL_PROPS.depth);
+
+
+            if (!executeMethod(pFind, false)) {
+                // handle error
+                if (pFind.succeeded()){// != 404) {
+                    LOG.error("Unable to get property:" + relPath + " -- " + pFind.getStatusText());
+                }
+                return WsUtil.error(pFind.getStatusCode(), pFind.getStatusText());
+            }
+            return WsUtil.success(pFind.getStatusCode(), pFind.getStatusText(), pFind.getPath());
+        } catch (Exception e) {
+            LOG.error(e, "Error while getting meta for:" + relPath);
+        } finally {
+            if (pFind != null) {
+                pFind.releaseConnection();
+            }
+        }
+        return new WsResponse();
+    }
+
+    class WebDAVGetMethod extends DavMethodBase {
+        WebDAVGetMethod(String uri) {
+            super(uri);
+        }
+
+        public String getName() {
+            return DavMethods.METHOD_GET;
+        }
+
+        public boolean isSuccess(int statusCode) {
+            return statusCode == 200;
+        }
+    }
+
+    class WebDAVDeleteMethod extends DavMethodBase {
+        WebDAVDeleteMethod(String uri) {
+            super(uri);
+        }
+
+        public String getName() {
+            return DavMethods.METHOD_DELETE;
+        }
+
+        public boolean isSuccess(int statusCode) {
+            return statusCode == 200;
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/WorkspaceManager.java
@@ -15,42 +15,42 @@ import java.io.File;
  */
 public interface WorkspaceManager extends Workspaces {
 
-    String SEARCH_DIR = WspaceMeta.SEARCH_DIR;
+    //String SEARCH_DIR = WspaceMeta.SEARCH_DIR;
 
     WsCredentials getCredentials();
 
     String getWsHome();
 
-    public enum PROTOCOL {LOCAL, WEBDAV, VOSPACE}
+    enum PROTOCOL {LOCAL, WEBDAV, VOSPACE}
 
     enum PROPS {PROTOCOL, AUTH, ROOT_URL, ROOT_DIR}
 
-    public PROTOCOL getProtocol();
+    PROTOCOL getProtocol();
 
-    public String getProp(PROPS ps);
+    String getProp(PROPS ps);
 
-    /**
-     * TODO kept this because somehow we used it elsewhere
-     * TODO but i think we should be using http and not local access
-     * Create file in ws relative path
-     *
-     * @param wspaceRelDir
-     * @param filePrefix
-     * @param fileExt
-     * @return File created
-     * @deprecated should be using {@link Workspaces#putFile(String, File, String)}
-     */
-    @Deprecated
-    File createWsLocalFile(String wspaceRelDir, String filePrefix, String fileExt);
+//    /**
+//     * TODO kept this because somehow we used it elsewhere
+//     * TODO but i think we should be using http and not local access
+//     * Create file in ws relative path
+//     *
+//     * @param wspaceRelDir
+//     * @param filePrefix
+//     * @param fileExt
+//     * @return File created
+//     * @deprecated should be using {@link Workspaces#putFile(String, boolean, File, String)}
+//     */
+//    @Deprecated
+//    File createWsLocalFile(String wspaceRelDir, String filePrefix, String fileExt);
 
-    /**
-     * build ws meta from local file in ws fs
-     *
-     * @param file     file located in ws fs
-     * @param propName
-     * @param value
-     * @return WspaceMeta
-     * ¬
-     */
-    WspaceMeta newLocalWsMeta(File file, String propName, String value);
+//    /**
+//     * build ws meta from local file in ws fs
+//     *
+//     * @param file     file located in ws fs
+//     * @param propName
+//     * @param value
+//     * @return WspaceMeta
+//     * ¬
+//     */
+//    WspaceMeta newLocalWsMeta(File file, String propName, String value);
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/UserServicesImpl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/UserServicesImpl.java
@@ -17,6 +17,7 @@ import edu.caltech.ipac.firefly.server.persistence.HistoryAndTagsDao;
 import edu.caltech.ipac.firefly.server.persistence.PreferencesDao;
 import edu.caltech.ipac.firefly.server.servlets.AnyFileDownload;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
+import edu.caltech.ipac.firefly.server.ws.WsException;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.cache.Cache;
@@ -294,7 +295,7 @@ public class UserServicesImpl {
         return new ArrayList<Alert>(alerts.values());
     }
 
-    public WspaceMeta getMeta(String relPath, WspaceMeta.Includes includes) {
+    public WspaceMeta getMeta(String relPath, WspaceMeta.Includes includes) throws WsException {
         return ServerContext.getRequestOwner().getWsManager().getMeta(relPath, includes);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/JOSSOAdapter.java
@@ -277,7 +277,7 @@ public class JOSSOAdapter implements SsoAdapter {
             Cookie c = new Cookie(AUTH_KEY, "");
             c.setMaxAge(0);
             c.setValue(TO_BE_DELETE);
-            c.setDomain(".ipac.caltech.edu");
+            c.setDomain("ipac.caltech.edu");
             c.setPath("/");
             ServerContext.getRequestOwner().getRequestAgent().sendCookie(c);
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WebDAVWorkspaceHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WebDAVWorkspaceHandler.java
@@ -30,7 +30,6 @@ public class WebDAVWorkspaceHandler implements WorkspaceHandler {
     public WorkspaceManager withCredentials(WsCredentials cred) {
 
         synchronized (cred) {
-            String id = cred.getWsId();
             String protocol = AppProperties.getProperty("workspace.protocol", "webdav");
             String managerClass = AppProperties.getProperty("workspace.protocol."+protocol.toLowerCase(), "edu.caltech.ipac.firefly.server.WebDAVWorkspaceManager");
 
@@ -44,15 +43,7 @@ public class WebDAVWorkspaceHandler implements WorkspaceHandler {
                 Constructor<?> ctor = clazz.getConstructor(WsCredentials.class);
                 ws = (WorkspaceManager) ctor.newInstance(new Object[]{cred});
                 wsPool.put(cred.getWsId(), ws);
-            } catch (InstantiationException e) {
-                e.printStackTrace();
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            } catch (ClassNotFoundException e) {
-                e.printStackTrace();
-            } catch (NoSuchMethodException e) {
-                e.printStackTrace();
-            } catch (InvocationTargetException e) {
+            } catch (InstantiationException|IllegalAccessException|ClassNotFoundException|NoSuchMethodException|InvocationTargetException e) {
                 e.printStackTrace();
             }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/Workspaces.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/Workspaces.java
@@ -96,7 +96,7 @@ public interface Workspaces {
     WsResponse moveFile(String originalFileRelPath, String newfilepath, boolean shouldOverwrite) throws WsException;
 
 
-    WspaceMeta getMeta(String uri, WspaceMeta.Includes includes);
+    WspaceMeta getMeta(String uri, WspaceMeta.Includes includes) throws WsException;
 
     boolean setMeta(WspaceMeta... metas);
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsException.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsException.java
@@ -6,7 +6,8 @@ import java.io.IOException;
  * Created by ejoliet on 6/19/17.
  */
 public class WsException extends IOException {
-    public WsException(String s) {
-        super(s);
+    public WsException(String message) {
+        super(message);
     }
+    public WsException(String message, Throwable cause) {super(message, cause);}
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerCommands.java
@@ -41,7 +41,8 @@ public class WsServerCommands {
         FILE_CREATED_DATE("createdDate"),
         FILE_SIZE_BYTES("sizeBytes"),
         FILE_PROPS_MAP("extraProperties"),
-        FILE_CONTENT_TYPE("contentType");
+        FILE_CONTENT_TYPE("contentType"),
+        FILE_IS_FOLDER("isFolder");
 
         private final String key;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerUtils.java
@@ -112,8 +112,9 @@ public class WsServerUtils {
      * @param wsParams see {@link edu.caltech.ipac.firefly.server.ws.WsServerParams}
      * @param level    see {@link WspaceMeta.Includes}
      * @return list of metadata
+     * @throws WsException on error
      */
-    public List<WspaceMeta> getMeta(WsServerParams wsParams, WspaceMeta.Includes level) {
+    public List<WspaceMeta> getMeta(WsServerParams wsParams, WspaceMeta.Includes level) throws IOException {
         WorkspaceManager wsm = getWsManager(wsParams);
 
         WspaceMeta meta = wsm.getMeta(wsParams.getRelPath(), level);
@@ -126,7 +127,7 @@ public class WsServerUtils {
      * @param wsParams parameters
      * @return see {@link WspaceMeta}
      */
-    public WspaceMeta getMeta(WsServerParams wsParams) {
+    public WspaceMeta getMeta(WsServerParams wsParams) throws IOException {
         WorkspaceManager wsm = getWsManager(wsParams);
 
         WspaceMeta meta = wsm.getMeta(wsParams.getRelPath(), WspaceMeta.Includes.ALL);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerUtils.java
@@ -8,18 +8,14 @@ import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.download.FailedRequestException;
-import edu.caltech.ipac.util.download.URLDownload;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.network.HttpServices;
-import edu.caltech.ipac.firefly.server.util.multipart.UploadFileInfo;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -34,9 +30,9 @@ public class WsServerUtils {
 
     /**
      *
-     * @param filePath
-     * @return
-     * @throws DataAccessException
+     * @param filePath file path
+     * @return object, representing a file from workspace
+     * @throws DataAccessException on I/O or other failure
      */
     public static File getFileFromWorkspace(String filePath) throws DataAccessException {
         WsServerParams wsParams = new WsServerParams();
@@ -57,7 +53,7 @@ public class WsServerUtils {
      * @param wsParams see {@link edu.caltech.ipac.firefly.server.ws.WsServerParams}
      * @param depth    if -1, give all the folders/files below the parent, 0 return the parent, 1 return children only (one level)
      * @return response
-     * @throws IOException
+     * @throws IOException on I/O error
      */
     public WsResponse getList(WsServerParams wsParams, int depth) throws IOException {
         WorkspaceManager wsm = getWsManager(wsParams);
@@ -67,11 +63,11 @@ public class WsServerUtils {
     }
 
     /**
-     * Put file into the workspace {@link WorkspaceManager#putFile(String, File, String)}
+     * Put file into the workspace {@link WorkspaceManager#putFile(String, boolean, File, String)}
      *
      * @param wsParams see {@link edu.caltech.ipac.firefly.server.ws.WsServerParams}
      * @return response
-     * @throws IOException
+     * @throws IOException on I/O error
      */
     public WsResponse putFile(WsServerParams wsParams, File item) throws IOException {
         WorkspaceManager wsm = getWsManager(wsParams);
@@ -86,7 +82,7 @@ public class WsServerUtils {
      *
      * @param wsParams see {@link edu.caltech.ipac.firefly.server.ws.WsServerParams}
      * @return response
-     * @throws IOException
+     * @throws IOException on I/O error
      */
     public WsResponse deleteFile(WsServerParams wsParams) throws IOException {
         WorkspaceManager wsm = getWsManager(wsParams);
@@ -100,7 +96,7 @@ public class WsServerUtils {
      *
      * @param wsParams see {@link edu.caltech.ipac.firefly.server.ws.WsServerParams}
      * @return response
-     * @throws WsException
+     * @throws WsException on error
      */
     public WsResponse move(WsServerParams wsParams) throws IOException {
         WorkspaceManager wsm = getWsManager(wsParams);
@@ -116,9 +112,8 @@ public class WsServerUtils {
      * @param wsParams see {@link edu.caltech.ipac.firefly.server.ws.WsServerParams}
      * @param level    see {@link WspaceMeta.Includes}
      * @return list of metadata
-     * @throws IOException
      */
-    public List<WspaceMeta> getMeta(WsServerParams wsParams, WspaceMeta.Includes level) throws IOException {
+    public List<WspaceMeta> getMeta(WsServerParams wsParams, WspaceMeta.Includes level) {
         WorkspaceManager wsm = getWsManager(wsParams);
 
         WspaceMeta meta = wsm.getMeta(wsParams.getRelPath(), level);
@@ -128,11 +123,10 @@ public class WsServerUtils {
 
     /**
      * Get ALL metadata from a node
-     * @param wsParams
+     * @param wsParams parameters
      * @return see {@link WspaceMeta}
-     * @throws IOException
      */
-    public WspaceMeta getMeta(WsServerParams wsParams) throws IOException {
+    public WspaceMeta getMeta(WsServerParams wsParams) {
         WorkspaceManager wsm = getWsManager(wsParams);
 
         WspaceMeta meta = wsm.getMeta(wsParams.getRelPath(), WspaceMeta.Includes.ALL);
@@ -144,7 +138,7 @@ public class WsServerUtils {
      * Create parent
      * @param wsParams should contain the new path to create
      * @return response
-     * @throws WsException
+     * @throws WsException on error
      */
     public WsResponse createParent(WsServerParams wsParams) throws WsException {
         WorkspaceManager wsm = getWsManager(wsParams);
@@ -194,8 +188,7 @@ public class WsServerUtils {
     }
 
     private static WsJson serializeWsMeta(WspaceMeta next) {
-        WsJson map = new WsJson(next);
-        return map;
+        return new WsJson(next);
     }
 
     private WorkspaceManager getWsManager(WsServerParams wsParams) {
@@ -207,16 +200,16 @@ public class WsServerUtils {
     }
 
     /**
-     * @param wsParams
+     * @param wsParams parameters
      * @return path string
-     * @throws IOException
+     * @throws IOException on I/O error
      * @throws FailedRequestException
      */
     public String upload(WsServerParams wsParams) throws IOException, FailedRequestException {
 
         String url = getMeta(wsParams).getUrl();
         Map<String, String> cookies = getCredentials().getCookies();
-        HttpServiceInput input = new HttpServiceInput();
+        HttpServiceInput input = HttpServiceInput.createWithCredential(url);
 
         input.setUserId("x");
         input.setPasswd("x");
@@ -226,20 +219,14 @@ public class WsServerUtils {
             }
         }
 
-//      URLConnection conn = URLDownload.makeConnection(new URL(meta.getUrl()), getCredentials().getCookies());
-//      conn.setRequestProperty("Accept", "*/*");
-
         String relPath = wsParams.getRelPath();
         int idx = wsParams.getRelPath().lastIndexOf('/');
-        String fileName =  (idx >= 0) ? relPath.substring(idx + 1) : new String(relPath);
+        String fileName =  (idx >= 0) ? relPath.substring(idx + 1) : relPath;
         File f = getTempUploadFile(fileName);
 
         HttpServices.getData(url, f, input);
 
-        //URLDownload.getDataToFile(conn, f);
-
-        String rPathInfo = ServerContext.replaceWithPrefix(f);
-        return rPathInfo;
+        return ServerContext.replaceWithPrefix(f);
     }
 
     public File getTempUploadFile(String fileName) throws IOException {
@@ -259,6 +246,7 @@ public class WsServerUtils {
             JSONArray arr = new JSONArray();
             JSONObject map = new JSONObject();
             map.put(FILE_PATH.getKey(), meta.getRelPath());
+            map.put(FILE_IS_FOLDER.getKey(), !meta.isFile());
             map.put(FILE_SIZE_BYTES.getKey(), meta.getSize());
             map.put(FILE_MOD_DATE.getKey(), meta.getLastModified());
             map.put(FILE_CREATED_DATE.getKey(), meta.getCreationDate());

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -19,9 +19,8 @@ import {RadioGroupInputField} from './RadioGroupInputField.jsx';
 import {ListBoxInputField} from './ListBoxInputField.jsx';
 import {SizeInputFields} from './SizeInputField.jsx';
 import {InputAreaFieldConnected} from './InputAreaField.jsx';
-import {FileUpload} from '../ui/FileUpload.jsx';
 import {UploadOptionsDialog} from './UploadOptionsDialog.jsx';
-import {getWorkspaceConfig,initWorkspace} from '../visualize/WorkspaceCntlr.js';
+import {getWorkspaceConfig} from '../visualize/WorkspaceCntlr.js';
 import {FieldGroup} from './FieldGroup.jsx';
 
 import CsysConverter from '../visualize/CsysConverter.js';

--- a/src/firefly/js/ui/WorkspaceViewer.jsx
+++ b/src/firefly/js/ui/WorkspaceViewer.jsx
@@ -1,6 +1,5 @@
-import React, {PureComponent, memo} from 'react';
+import React, {memo} from 'react';
 import PropTypes from 'prop-types';
-import {flux} from '../Firefly.js';
 import {get} from 'lodash';
 import {isFunction, isNil, isEmpty} from 'lodash';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
@@ -32,58 +31,43 @@ const workspaceUploadDef = { file: {fkey: 'uploadfile', label: 'Workspace Upload
 const workspacePopupId = 'workspacePopupId';
 
 import LOADING from 'html/images/gxt/loading.gif';
+import ComponentCntlr from '../core/ComponentCntlr.js';
 
 /*-----------------------------------------------------------------------------------------*/
 /* core component as FilePicker wrapper
 /*-----------------------------------------------------------------------------------------*/
-export class WorkspaceView extends PureComponent {
-    constructor(props) {
-        super(props);
-        this.state = {files: this.props.files, currentSelection: ''};
+
+export const WorkspaceView = memo( (props) => {
+
+    const {canCreateFolder, canCreateFiles, canRenameFolder, canRenameFile,
+        canDeleteFolder, canDeleteFile, onClickItem, files, wrapperStyle={width: '100%', height: '100%'},
+        keepSelect, folderLevel=1, selectedItem} = props;
+    const eventHandlers = {
+        onCreateFolder: canCreateFolder ? onCreateFolder : undefined,
+        onCreateFiles: canCreateFiles ? onCreateFiles : undefined,
+        onRenameFolder: canRenameFolder ? onRenameFolder : undefined,
+        onRenameFile: canRenameFile ? onRenameFile : undefined,
+        onDeleteFolder: canDeleteFolder ? onDeleteFolder : undefined,
+        onDeleteFile: canDeleteFile ? onDeleteFile : undefined,
+        onClickItem};
+
+    let openFolders = getFolderUnderLevel(folderLevel);
+    // keep selected folder open initially
+    // it requires the ancestor folders to be open too
+    const selectedFile = files.find((oneFile) => oneFile.key === selectedItem);
+    if (selectedFile && selectedFile.isFolder && selectedFile.childrenRetrieved) {
+        openFolders = {};
+        const parts = selectedItem.split('/').filter((e)=>e);
+        parts.map((e,i,a)=>a.slice(0,i+1)
+            .join('/'))
+            .forEach((e) => {openFolders[e+'/'] = true;});
     }
-
-    componentWillUnmount() {
-        if (this.removeListener) this.removeListener();
-        this.iAmMounted = false;
-    }
-
-    componentDidMount() {
-        this.iAmMounted = true;
-        this.removeListener = flux.addListener(() => this.storeUpdate());
-    }
-
-    storeUpdate() {
-        if (this.iAmMounted) {
-            const workspaceList = getWorkspaceList();
-            if (this.state.files !== workspaceList) {
-                this.setState({files: workspaceList});
-            }
-        }
-    }
-
-
-    render () {
-        const {canCreateFolder, canCreateFiles, canRenameFolder, canRenameFile,
-               canDeleteFolder, canDeleteFile, onClickItem, files, wrapperStyle={width: '100%', height: '100%'},
-               keepSelect, folderLevel=1} = this.props;
-        const {selectedItem} = this.props;
-        const eventHandlers = {
-                onCreateFolder: canCreateFolder ? onCreateFolder : undefined,
-                onCreateFiles: canCreateFiles ? onCreateFiles : undefined,
-                onRenameFolder: canRenameFolder ? onRenameFolder : undefined,
-                onRenameFile: canRenameFile ? onRenameFile : undefined,
-                onDeleteFolder: canDeleteFolder ? onDeleteFolder : undefined,
-                onDeleteFile: canDeleteFile ? onDeleteFile : undefined,
-                onClickItem};
-
-        const openFolders = getFolderUnderLevel(folderLevel);
-        return (
-            <div style={wrapperStyle}>
-                {FilePicker({files, selectedItem, keepSelect, openFolders, ...eventHandlers})}
-            </div>
-        );
-    }
-}
+    return (
+        <div style={wrapperStyle}>
+            {FilePicker({files, selectedItem: selectedFile?selectedItem:WS_HOME+'/', keepSelect, openFolders, ...eventHandlers})}
+        </div>
+    );
+});
 
 WorkspaceView.defaultProps = {
     canCreateFolder: false,
@@ -120,8 +104,17 @@ WorkspaceView.propTypes = {
 export const WorkspaceViewField = memo( (props) => {
     const {viewProps, fireValueChange} = useFieldGroupConnector(props);
 
+    const onClickItem = (key) => {
+        fireValueChange({value: key});
+        const files = get(props, 'files', []);
+        const file = files.find((oneFile) => oneFile.key === key);
+        if (file && file.isFolder && !file.childrenRetrieved) {
+            dispatchWorkspaceUpdate({relPath: file.relPath});
+        }
+    };
+
     return (<WorkspaceView {...{...viewProps, selectedItem: viewProps.value}}
-                           onClickItem={(key) => fireValueChange({value: key})}/>); // get key from FilePicker
+                           onClickItem={onClickItem}/>); // get key from FilePicker
 });
 
 
@@ -182,15 +175,24 @@ WorkspacePickerPopup.propTypes = {
  */
 export function showWorkspaceDialog({onComplete, value, fieldKey}) {
     dispatchAddActionWatcher({
-        actions:[WORKSPACE_LIST_UPDATE],
+        id: 'workspaceRead',
+        actions:[WORKSPACE_LIST_UPDATE, ComponentCntlr.HIDE_DIALOG],
         callback: (a , cancelSelf) => {
-            cancelSelf();
-
-            const newList = getWorkspaceList() || [];
-            if (isEmpty(newList)) {
-                workspacePopupMsg('Workspace access error: ' + getWorkspaceErrorMsg() , 'Workspace access');
-            } else {
-                showWorkspaceAsPopup({onComplete, value, fieldKey});
+            switch (a.type) {
+                case ComponentCntlr.HIDE_DIALOG:
+                    const dialogId = get(a.payload, 'dialogId');
+                    if (dialogId === workspacePopupId) {
+                        cancelSelf();
+                    }
+                    break;
+                case WORKSPACE_LIST_UPDATE:
+                    const newList = getWorkspaceList() || [];
+                    if (isEmpty(newList)) {
+                        workspacePopupMsg('Workspace access error: ' + getWorkspaceErrorMsg(), 'Workspace access');
+                    } else {
+                        showWorkspaceAsPopup({onComplete, value, fieldKey});
+                    }
+                    break;
             }
         }
     });

--- a/src/firefly/js/visualize/WorkspaceCntlr.js
+++ b/src/firefly/js/visualize/WorkspaceCntlr.js
@@ -487,11 +487,12 @@ const convertFileToKey = (wsFile) => {
  */
 function convertFilesToList(wFiles) {
     const list = flattenDeep(wFiles).reduce((prev, oneFile) => {
-        const {relPath, modifiedDate:modified, sizeBytes:size, url} = oneFile;
+        const {relPath, modifiedDate:modified, sizeBytes, url, isFolder:isFolderVal} = oneFile;
 
         if (relPath && !relPath.includes('/.')) {
             const key = convertFileToKey(relPath);
-            const isFolder = key.lastIndexOf('/') === (key.length - 1);
+            const isFolder = isFolderVal || (key.lastIndexOf('/') === (key.length - 1));
+            const size = isFolder ? 0 : sizeBytes;
 
             //const key = relPath;
             prev.push({key, modified, size, url, relPath, isFolder});

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPropTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPropTest.java
@@ -38,13 +38,9 @@ public class WsPropTest extends ConfigTest {
             WorkspaceManager m = ws.withCredentials(getWsCredentials());
             Assert.assertTrue(m.getProp(prop).equals(urlHost));
             Assert.assertTrue(m.getProp(WorkspaceManager.PROPS.PROTOCOL).equalsIgnoreCase(prot));
-
-
         } catch (Exception e) {
             e.printStackTrace();
         }
-
-
     }
     @Test
     public void testPoolWsManager() {

--- a/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPutGetTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ws/WsPutGetTest.java
@@ -108,7 +108,7 @@ public class WsPutGetTest extends ConfigTest {
 
     }
 
-    private void printPath(WspaceMeta parent, boolean avoidFolders) {
+    private void printPath(WspaceMeta parent, boolean avoidFolders) throws WsException {
 
         if(avoidFolders && parent.getContentType()==null || (parent.getContentType()!=null && !parent.getContentType().contains("directory"))){
             LOG.info("File: "+parent.getUrl());


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-94
https://jira.lsstcorp.org/browse/DM-13112 (firefly part)

Test builds:
IrsaViewer with the unchanged behavior:
https://irsawebdev9.ipac.caltech.edu/firefly-94_ws_irsa/irsaviewer/ 

IrsaViewer as it would be if WebDAV server did not support depth-'infinity'
https://irsawebdev9.ipac.caltech.edu/firefly-94_ws_noInfinity/irsaviewer/

The behavior is controlled by application property workspace.propfind.infinity (server and client, must be '__$workspace.propfind.infinity' in config). If this property is not specified, we assume that WebDAV server supports depth='infinity'. In this case the whole file tree is retrieved at once and passed to the client.

If workspace.propfind.infinity=false, only one level of workspace file tree is retrieved at a time. The tree is updated as user clicks on folders.

To test:
- Log in. Use 'Load Catalog' from workspace to browse workspace files. 
- Check that tables and images can be saved into workspace and read from workspace.
- Create subfolders with "Add subfolder" when saving. (You need to use 'Enter' for new path to be added to the workspace.) 
