### PR TITLE
FIREFLY-59: Filtering fail when value contains semicolon

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -42,6 +42,8 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
     private Map<String, String> metaInfo;
     private transient Map<String, String> metaOptions;               // options to apply for this request.  it will not persist nor returned to the client
 
+    private static String FILTER_SEP = "_AND_";         // need to match what's defined in FilterInfo.js
+
     public TableServerRequest() {
     }
 
@@ -251,12 +253,12 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
 
     public static List<String> parseFilters(String s) {
         if (StringUtils.isEmpty(s)) return null;
-        String[] filters = s.split(";");
+        String[] filters = s.split(FILTER_SEP);
         return Arrays.asList(filters);
     }
 
     public static String toFilterStr(List<String> l) {
-        return StringUtils.toString(l,";");
+        return StringUtils.toString(l,FILTER_SEP);
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -20,6 +20,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
 
     public static final String TBL_FILE_PATH = "tblFilePath";       // this meta if exists contains source of the data
     public static final String TBL_FILE_TYPE = "tblFileType";       // this meta if exists contains storage type, ipac, h2, sqlite, etc
+    public static final String FILTER_SEP = "_AND_";         // need to match what's defined in FilterInfo.js
 
     public static final String TBL_ID = "tbl_id";
     public static final String TITLE = "title";
@@ -42,7 +43,6 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
     private Map<String, String> metaInfo;
     private transient Map<String, String> metaOptions;               // options to apply for this request.  it will not persist nor returned to the client
 
-    private static String FILTER_SEP = "_AND_";         // need to match what's defined in FilterInfo.js
 
     public TableServerRequest() {
     }

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static edu.caltech.ipac.firefly.data.TableServerRequest.FILTER_SEP;
 import static edu.caltech.ipac.table.JsonTableUtil.getMetaFromAllMeta;
 
 /**
@@ -84,7 +85,7 @@ public class IpacTableTest {
         // the request
         Assert.assertEquals("meta-info", "test-meta-value", JsonTableUtil.getPathValue(json, "request", TableServerRequest.META_INFO, "test-meta"));
         Assert.assertEquals("sort-info", "ASC,ra,dec", JsonTableUtil.getPathValue(json, "request", TableServerRequest.SORT_INFO));
-        Assert.assertEquals("filter-into", "ra > 0;dec > 0", JsonTableUtil.getPathValue(json, "request", TableServerRequest.FILTERS));
+        Assert.assertEquals("filter-into", "ra > 0" + FILTER_SEP + "dec > 0", JsonTableUtil.getPathValue(json, "request", TableServerRequest.FILTERS));
         Assert.assertEquals("decimate-info", "decimate=ra,dec,1234,0.5,,,,,-1", JsonTableUtil.getPathValue(json, "request", DecimateInfo.DECIMATE_TAG));
 
         // tableMeta


### PR DESCRIPTION
ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-59
test:    https://irsawebdev9.ipac.caltech.edu/FIREFLY-59/firefly/firefly-dev.html

As reported, filtering fail when the value contains semicolon.  Because we were using semicolon to separate conditions, this messes up the underlying query statement.

Instead of just fixing the problem, I went ahead and allow the conditions delimiter to be either `AND` or `OR`.  Although this added a useful requested feature, it also may require updates to our online help.  Please coordinate with the appropriate people after merging.

Sample conditions:
`> 0 and < 50 or is NULL`
`< 0 or > 100`
`in ('m31', 'm41') or is NULL`

