### PR TITLE
FIREFLY-53: Saving a table with large number of columns results in HTTP 400 (Bad Request)

### DIFF
--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -17,7 +17,7 @@ import {get, set, isEmpty} from 'lodash';
 import {dispatchShowDialog, dispatchHideDialog, isDialogVisible} from '../core/ComponentCntlr.js';
 import {Operation} from '../visualize/PlotState.js';
 import {getRootURL} from '../util/BrowserUtil.js';
-import {download, downloadViaAnchor, encodeUrl, updateSet} from '../util/WebUtil.js';
+import {download, downloadBlob, encodeUrl, updateSet} from '../util/WebUtil.js';
 import {RadioGroupInputField} from './RadioGroupInputField.jsx';
 import CompleteButton from './CompleteButton.jsx';
 import {FieldGroup} from './FieldGroup.jsx';
@@ -779,9 +779,7 @@ function makePngLocal(plotId, filename= 'a.png') {
 
     if (canvas) {
         canvas.toBlob( (blob) => {
-            const url= URL.createObjectURL(blob);
-            downloadViaAnchor(url, filename);
-            URL.revokeObjectURL(url);
+            downloadBlob(blob, filename);
         }, 'image/png');
     }
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-53

As described in the ticket, when the URL length exceed its limit, table save will get a `Bad Request` error.  In this PR, the logic is to switch to a HTTP `post` method to avoid the limit constraint.  I've also refactored Image's PNG save to make use of common code.
Please include that in your testing as well.

Test: https://irsawebdev9.ipac.caltech.edu/FIREFLY-53_bad_request/firefly/

Things affected:  tables and images save/download.

