### PR TITLE
FIREFLY-25_firefly_footprint_menu_should_be_able_to_dropdown_wherever…

### DIFF
--- a/src/firefly/js/ui/DropDownDirContext.js
+++ b/src/firefly/js/ui/DropDownDirContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const DropDownDirCTX = React.createContext({
+    dropdownDirection : ''
+});

--- a/src/firefly/js/ui/DropDownMenu.css
+++ b/src/firefly/js/ui/DropDownMenu.css
@@ -4,8 +4,9 @@
     border-radius: 0 0 5px 5px;
     background-color: rgba(245,245,245,.97);
     box-shadow: 0 5px 10px rgba(0,0,0,0.3);
-    min-width: 100px;
+    min-width: 180px;
 }
+
 
 .ff-MenuItem-dropDown .menuItemText {
     font-size: 10pt;
@@ -14,4 +15,30 @@
 
 .ff-MenuItem-dropDown .menuItemText:HOVER {
     background-color: rgba(255,255,255,.97);
+}
+
+
+.dropdown-menu__left {
+    position: absolute;
+    top: -10px;
+    left: auto;
+    right: 175px;
+}
+
+
+.dropdown-menu__right {
+    position: absolute;
+    top: -10px;
+    left: 8px;
+}
+
+
+.menu-text-style__left{
+    width: 99%;
+    text-align:left;
+}
+
+.menu-text-style__right{
+    width: 99%;
+    text-align:left;
 }

--- a/src/firefly/js/ui/DropDownMenu.jsx
+++ b/src/firefly/js/ui/DropDownMenu.jsx
@@ -1,6 +1,7 @@
 /*eslint "prefer-template": 0*/
 
 import React, {PureComponent} from 'react';
+import {get} from 'lodash';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import {DropDownDirCTX} from './DropDownDirContext.js';
@@ -83,7 +84,6 @@ export class DropDownSubMenu extends PureComponent {
         this.state= {showSubMenu: false};
         this.show = this.show.bind(this);
         this.hide = this.hide.bind(this);
-        this.dropdownDirection = context.dropdownDirection || DEFAULT_DROPDOWN_DIR;
     }
 
     show() {
@@ -96,6 +96,7 @@ export class DropDownSubMenu extends PureComponent {
     }
 
     render() {
+        const dropdownDirection = get(this.context, 'dropdownDirection', DEFAULT_DROPDOWN_DIR);
         const {text, tip, visible=true, children} = this.props;
         const {showSubMenu} = this.state;
         if (!visible) return null;
@@ -103,11 +104,11 @@ export class DropDownSubMenu extends PureComponent {
             <div className='ff-MenuItem ff-MenuItem-light' title={tip}>
                 <div className='menuItemText subMenu' onMouseEnter={this.show} onMouseLeave={this.hide}>
 
-                    <div className={'menu-text-style__' + this.dropdownDirection}>{text}</div>
+                    <div className={'menu-text-style__' + dropdownDirection}>{text}</div>
 
                     <div style={{position: 'relative', marginRight: 0}}>
                         {showSubMenu &&
-                        <div className={'dropdown-menu__' + this.dropdownDirection} onMouseEnter={this.show}>
+                        <div className={'dropdown-menu__' + dropdownDirection} onMouseEnter={this.show}>
                             <SingleColumnMenu>
                                 {children}
                             </SingleColumnMenu>

--- a/src/firefly/js/ui/DropDownMenu.jsx
+++ b/src/firefly/js/ui/DropDownMenu.jsx
@@ -3,12 +3,10 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-
-import {dispatchShowDialog, dispatchHideDialog, isDialogVisible, getDialogOwner} from '../core/ComponentCntlr.js';
-
+import {DropDownDirCTX} from './DropDownDirContext.js';
 import './DropDownMenu.css';
 
-
+const DEFAULT_DROPDOWN_DIR = 'right';
 
 const computePosition= (tgtX,tgtY)  => ({x:tgtX,y:tgtY+18});
 
@@ -26,13 +24,11 @@ function placeDropDown(e,x,y) {
 
 
 export function SingleColumnMenu({children}) {
-
     return (
-        <div className='ff-MenuItem-dropDown' >
+        <div className='ff-MenuItem-dropDown'>
             {children}
         </div>
     );
-
 }
 
 
@@ -40,7 +36,7 @@ export function SingleColumnMenu({children}) {
 export class DropDownMenuWrapper extends PureComponent {
     constructor(props) {
         super(props);
-    }
+}
 
     componentDidMount() {
         var {x,y}= this.props;
@@ -56,7 +52,7 @@ export class DropDownMenuWrapper extends PureComponent {
         if (!visible) return false;
         if (!x && !y && !content) return false;
         return (
-            <div style={{position:'absolute',left:0,top:0, visibility:'hidden',zIndex }}
+            <div style={{position:'absolute', left:0, top:0, visibility:'hidden', zIndex}}
                  onClick={futureCallback} >
                     <div style={{padding : 5}} className='ff-dropdown-menu'>
                         {content}
@@ -82,12 +78,12 @@ DropDownMenuWrapper.propTypes= {
 
 export class DropDownSubMenu extends PureComponent {
 
-    constructor(props) {
+    constructor(props, context) {
         super(props);
         this.state= {showSubMenu: false};
         this.show = this.show.bind(this);
         this.hide = this.hide.bind(this);
-
+        this.dropdownDirection = context.dropdownDirection || DEFAULT_DROPDOWN_DIR;
     }
 
     show() {
@@ -106,25 +102,34 @@ export class DropDownSubMenu extends PureComponent {
         return (
             <div className='ff-MenuItem ff-MenuItem-light' title={tip}>
                 <div className='menuItemText subMenu' onMouseEnter={this.show} onMouseLeave={this.hide}>
-                    <div>{text}</div>
-                    <div style={{position: 'relative', marginLeft: 10}}>
-                        <div className='arrow-right'/>
+
+                    <div className={'menu-text-style__' + this.dropdownDirection}>{text}</div>
+
+                    <div style={{position: 'relative', marginRight: 0}}>
                         {showSubMenu &&
-                        <div style={{position: 'absolute', top:-10, left:8}} onMouseEnter={this.show}>
+                        <div className={'dropdown-menu__' + this.dropdownDirection} onMouseEnter={this.show}>
                             <SingleColumnMenu>
                                 {children}
                             </SingleColumnMenu>
                         </div>
                         }
                     </div>
+
+                    {<div className={'arrow-right'}/>}
+
                 </div>
             </div>
         );
     }
 }
 
+DropDownSubMenu.contextType = DropDownDirCTX;
+
+
 DropDownSubMenu.propTypes= {
     text: PropTypes.string.isRequired,
     visible: PropTypes.bool,
     tip: PropTypes.string,
+    direction: PropTypes.string
 };
+

--- a/src/firefly/js/ui/DropDownToolbarButton.jsx
+++ b/src/firefly/js/ui/DropDownToolbarButton.jsx
@@ -139,7 +139,12 @@ DropDownToolbarButton.propTypes= {
 
 
 function calcDropDownDir(element, menuWidth){
+    if (!element || !menuWidth) return DEFAULT_DROPDOWN_DIR;
     const bodyRect = document.body.getBoundingClientRect();
+    const elemRect = element.getBoundingClientRect();
+    const space = bodyRect.width - elemRect.x;
+    return space < menuWidth ? 'left' : 'right';
+    /*const bodyRect = document.body.getBoundingClientRect();
     const elemRect = element.getBoundingClientRect();
     const space = bodyRect.width - elemRect.x;
 
@@ -147,5 +152,5 @@ function calcDropDownDir(element, menuWidth){
 
     space < menuWidth ? dropdownDir ='left' : dropdownDir = 'right';
 
-    return dropdownDir;
+    return dropdownDir;*/
 }

--- a/src/firefly/js/ui/DropDownToolbarButton.jsx
+++ b/src/firefly/js/ui/DropDownToolbarButton.jsx
@@ -144,13 +144,4 @@ function calcDropDownDir(element, menuWidth){
     const elemRect = element.getBoundingClientRect();
     const space = bodyRect.width - elemRect.x;
     return space < menuWidth ? 'left' : 'right';
-    /*const bodyRect = document.body.getBoundingClientRect();
-    const elemRect = element.getBoundingClientRect();
-    const space = bodyRect.width - elemRect.x;
-
-    let dropdownDir = DEFAULT_DROPDOWN_DIR;
-
-    space < menuWidth ? dropdownDir ='left' : dropdownDir = 'right';
-
-    return dropdownDir;*/
 }

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -266,6 +266,7 @@ export class VisToolbarView extends PureComponent {
                                        tip='Overlay Markers and Instrument Footprints'
                                        enabled={enabled} horizontal={true}
                                        visible={mi.markerToolDD}
+                                       menuMaxWidth={580}
                                        dropDown={<MarkerDropDownView plotView={pv}/>} />
 
                 <SimpleLayerOnOffButton plotView={pv}


### PR DESCRIPTION
This PR is to add the ability for the drop-down menu button to calculate the space available on the right first, if not then the drop-down sub-menus will pop to the left.

Jira: https://jira.ipac.caltech.edu/browse/FIREFLY-25
K8s: https://irsawebdev9.ipac.caltech.edu/firefly-25/firefly/

To test:
1- Click on the K8s link above
2- Search for an image (ex: M17)
3- Click on the overlay button in the top menu and look for the submenu direction
4- Resize the browser window to make the right space less than the left, the menu direction should change.
   