### PR TITLE
firefly-84-TimeSeries tool: Add workspace option to download dialog for packaging images

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
@@ -165,7 +165,18 @@ public class AnyFileDownload extends BaseHttpServlet {
     }
 
     private static void trackProgress(HttpServletRequest req, BackgroundEnv.DownloadProgress progress) {
-        StringKey statusKey= new StringKey(req.getQueryString());
+        String queryString =req.getQueryString();
+
+        if (queryString==null){
+            try {
+                throw new Exception("Status can not be tracked because the queryString is empty");
+            } catch (Exception e) {
+                Logger.error("HttpServletRequest has a null query string, the status can not be tracked");
+
+
+            }
+        }
+        StringKey statusKey= new StringKey(queryString);
         getCache().put(statusKey, progress);
     }
 

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -176,7 +176,7 @@ function bgPackage(action) {
                     bgStatus = bgStatusTransform(bgStatus);
                     const url = get(bgStatus, ['ITEMS', 0, 'url']);
                     if (url && isSuccess(get(bgStatus, 'STATE'))) {
-                        download(url);
+                        download(url, bgStatus.fileName);
                     } else {
                         dispatchJobAdd(bgStatus);
                     }

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -152,10 +152,15 @@ export const BG_STATE  = new Enum([
 ]);
 
 
-export function bgDownload({dlRequest, searchRequest, selectInfo}, {key, onComplete, sentToBg}) {
+export function bgDownload({dlRequest, searchRequest, selectInfo}, {key, onComplete, sentToBg, isWs=false}) {
     dispatchComponentStateChange(key, {inProgress:true, bgStatus:undefined});
     packageRequest(dlRequest, searchRequest, SelectInfo.newInstance(selectInfo).toString())
         .then((bgStatus) => {
+            //add fileLocation and fileName information to the bgStatus
+            bgStatus.isWs=isWs;
+            const fileName = dlRequest.fileName|| dlRequest.Title.split(':');
+            bgStatus.fileName = fileName;
+            bgStatus.wsSelect=dlRequest.wsSelect;
             if (bgStatus) {
                 dispatchComponentStateChange(key, {bgStatus});
                 bgStatus = bgStatusTransform(bgStatus);

--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -28,13 +28,15 @@ export class BgMaskPanel extends SimpleComponent {
             bgStatus && dispatchJobAdd(bgStatus);
         };
 
+
         if (inProgress) {
             return (
                 <div style={maskStyle}>
                     <div className='loading-mask'/>
                     {bgStatus &&
                     <div style={{display: 'flex', alignItems: 'center'}}>
-                        <button type='button' style={maskButton} className='button std' onClick={sendToBg}>Send to background</button>
+                      <button type='button' style={maskButton} className='button std' onClick={sendToBg}>Please click to send to background</button>;
+
                     </div>
                     }
                 </div>

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -13,13 +13,13 @@ import {basicURLPlotRequest} from './basic/BasicPlotRequests';
 import {LsstSdssSettingBox, lsstSdssOnNewRawTable, lsstSdssOnFieldUpdate, lsstSdssRawTableRequest} from './lsst_sdss/LsstSdssMissionOptions.js';
 import {DefaultSettingBox, defaultOnNewRawTable, defaultOnFieldUpdate, defaultRawTableRequest} from './generic/DefaultMissionOptions.js';
 import {BasicSettingBox, basicOnNewRawTable, basicOnFieldUpdate, basicRawTableRequest, imagesShouldBeDisplayed} from './basic/BasicMissionOptions.js';
-import {WiseSettingBox, wiseOnNewRawTable, wiseOnFieldUpdate, wiseRawTableRequest, wiseYColMappings, isValidWiseTable} from './wise/WiseMissionOptions.js';
-import {PTFSettingBox, ptfOnNewRawTable, ptfOnFieldUpdate, ptfRawTableRequest, isValidPTFTable, ptfDownloaderOptPanel} from './ptf/PTFMissionOptions.js';
-import {ZTFSettingBox, ztfOnNewRawTable, ztfOnFieldUpdate, ztfRawTableRequest, isValidZTFTable, ztfDownloaderOptPanel} from './ztf/ZTFMissionOptions.js';
+import {WiseSettingBox, wiseYColMappings, isValidWiseTable} from './wise/WiseMissionOptions.js';
+import {PTFSettingBox, isValidPTFTable} from './ptf/PTFMissionOptions.js';
+import {ZTFSettingBox, isValidZTFTable} from './ztf/ZTFMissionOptions.js';
 import {getWebPlotRequestViaZTFIbe} from './ztf/ZTFPlotRequests.js';
-
+import {onNewRawTable, onFieldUpdate , makeRawTableRequest} from './LcUtil';
 import {LC} from './LcManager.js';
-import {getColumnIdx, getTblInfoById} from '../../tables/TableUtil';
+import { getTblInfoById} from '../../tables/TableUtil';
 
 export const DL_DATA_TAG = 'timeseries-package';
 export const UNKNOWN_MISSION = 'generic';
@@ -90,9 +90,9 @@ const converters = {
         getYColMappings: wiseYColMappings,
         missionName: 'WISE/NEOWISE',
         MissionOptions: WiseSettingBox,
-        onNewRawTable: wiseOnNewRawTable,
-        onFieldUpdate: wiseOnFieldUpdate,
-        rawTableRequest: wiseRawTableRequest,
+        onNewRawTable: onNewRawTable,
+        onFieldUpdate: onFieldUpdate,
+        rawTableRequest: makeRawTableRequest,
         /*timeNames: ['mjd'],*/
         /*yNames: ['w1mpro_ep', 'w2mpro_ep', 'w3mpro_ep', 'w4mpro_ep'],*/
         yErrNames: '',
@@ -130,15 +130,14 @@ const converters = {
         defaultYErrCname: '',
         missionName: 'PTF',
         MissionOptions: PTFSettingBox,
-        onNewRawTable: ptfOnNewRawTable,
-        onFieldUpdate: ptfOnFieldUpdate,
-        rawTableRequest: ptfRawTableRequest,
+        onNewRawTable: onNewRawTable,
+        onFieldUpdate: onFieldUpdate,
+        rawTableRequest: makeRawTableRequest,
         yErrNames: '',
         dataSource: 'pid',
         webplotRequestCreator: getWebPlotRequestViaPTFIbe,
         shouldImagesBeDisplayed: () => {return true;},
         isTableUploadValid:isValidPTFTable,
-        downloadOptions: ptfDownloaderOptPanel,
         yNamesChangeImage: [],
         showPlotTitle:getPlotTitle
     },
@@ -150,15 +149,14 @@ const converters = {
         defaultYErrCname: '',
         missionName: 'ZTF',
         MissionOptions: ZTFSettingBox,
-        onNewRawTable: ztfOnNewRawTable,
-        onFieldUpdate: ztfOnFieldUpdate,
-        rawTableRequest: ztfRawTableRequest,
+        onNewRawTable: onNewRawTable,
+        onFieldUpdate: onFieldUpdate,
+        rawTableRequest: makeRawTableRequest,
         yErrNames: '',
         dataSource: 'field',
         webplotRequestCreator: getWebPlotRequestViaZTFIbe,
         shouldImagesBeDisplayed: () => {return true;},
         isTableUploadValid:isValidZTFTable,
-        downloadOptions: ztfDownloaderOptPanel,
         yNamesChangeImage: [],
         showPlotTitle:getPlotTitle
     },

--- a/src/firefly/js/templates/lightcurve/LcDownloadPanel.jsx
+++ b/src/firefly/js/templates/lightcurve/LcDownloadPanel.jsx
@@ -1,0 +1,300 @@
+
+import React, {useCallback} from 'react';
+import PropTypes from 'prop-types';
+import {set, cloneDeep, get} from 'lodash';
+import {LC } from './LcManager.js';
+import { DownloadButton} from '../../ui/DownloadDialog.jsx';
+import {DL_DATA_TAG} from './LcConverterFactory.js';
+import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
+import { getTypeData,WORKSPACE,DownloadOptionsDialog,fileNameValidator} from '../../ui/DownloadOptionsDialog.jsx';
+import {getTblInfoById} from '../../tables/TableUtil.js';
+import {DataTagMeta, makeTblRequest} from '../../tables/TableRequestUtil.js';
+import {dispatchBgSetEmailInfo} from '../../core/background/BackgroundCntlr.js';
+import {getWorkspaceConfig,isWsFolder, isValidWSFolder} from  '../../visualize/WorkspaceCntlr.js';
+import {workspacePopupMsg} from '../../ui/WorkspaceViewer.jsx';
+import {FieldGroup} from '../../ui/FieldGroup.jsx';
+import {updateSet,doDownload} from '../../util/WebUtil.js';
+import {getBgEmailInfo,bgDownload} from '../../core/background/BackgroundUtil.js';
+import Validate from '../../util/Validate.js';
+import {dispatchHideDialog} from '../../core/ComponentCntlr.js';
+import {InputField} from '../../ui/InputField.jsx';
+import FieldGroupCntlr from '../../fieldGroup/FieldGroupCntlr.js';
+import {FormPanel} from '../../ui/FormPanel.jsx';
+import {ValidationField} from '../../ui/ValidationField.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {showDownloadDialog} from '../../ui/DownloadDialog.jsx';
+import {getGroupFields} from '../../fieldGroup/FieldGroupUtils.js';
+import {LcXYPlotCompKey} from './LcResult';
+
+
+const currentTime =  (new Date()).toLocaleString('en-US', { hour12: false });
+const DOWNLOAD_DIALOG_ID = 'Image Download Options';
+
+
+export function LcDownloadOptionPanel (props) {
+        const {mask,  mission, help_id, style, cutoutSize, title} = props;//this.props; //
+        const [{email, enableEmail}] = useStoreConnector(getBgEmailInfo);
+        const onEmailChanged = useCallback((v) => {
+            if (get(v, 'valid')) {
+                if (email !== v.value) dispatchBgSetEmailInfo({email: v.value});
+            }
+        }, [email]);
+        const ttl = title || DOWNLOAD_DIALOG_ID;
+        const gKey = mission || DOWNLOAD_DIALOG_ID;
+
+        const dlParams = getParamters(mission);
+        const toggleEnableEmail = (e) => {
+            const enableEmail = e.target.checked;
+            const email = enableEmail ? email : '';
+            dispatchBgSetEmailInfo({email, enableEmail});
+        };
+        const isWs = getWorkspaceConfig();
+        const labelWidth = 110;
+        const fKeyDef = {
+
+            fileName: {fKey: 'fileName', label: 'Save As:'},
+            location: {fKey: 'fileLocation', label: 'File Location:'},
+            wsSelect: {fKey: 'wsSelect', label: ''},
+            overWritable: {fKey: 'fileOverwritable', label: 'File overwritable: '}
+
+        };
+        const defValues = {
+            [fKeyDef.fileName.fKey]: Object.assign(getTypeData(fKeyDef.fileName.fKey, `${mission.replace('/', '_')}_Files`,
+                'Please enter a filename, a default name will be used if it is blank', fKeyDef.fileName.label, labelWidth), {validator: null}),
+            [fKeyDef.location.fKey]: Object.assign(getTypeData(fKeyDef.location.fKey, 'isLocal',
+                'select the location where the file is downloaded to', fKeyDef.location.label, labelWidth), {validator: null}),
+            [fKeyDef.wsSelect.fKey]: Object.assign(getTypeData(fKeyDef.wsSelect.fKey, '',
+                'workspace file system', fKeyDef.wsSelect.label, labelWidth), {validator: null}),
+            [fKeyDef.overWritable.fKey]: Object.assign(getTypeData(fKeyDef.overWritable.fKey, '0',
+                'File is overwritable', fKeyDef.overWritable.label, labelWidth), {validator: null})
+        };
+
+        const rParams = {fKeyDef, defValues};
+
+        const onSubmit = useCallback((options) => {
+            let {request, selectInfo} = getTblInfoById(LC.RAW_TABLE);
+            const {fileLocation, wsSelect, fileName} = options || {};
+
+            const isWorkspace = (fileLocation && fileLocation === WORKSPACE) ? true : false;
+            const {FileGroupProcessor} = dlParams;
+            const Title = dlParams.Title || options.Title;
+            const dreq = makeTblRequest(FileGroupProcessor, Title, Object.assign(dlParams, {cutoutSize}, options, {Email:email}, {wsSelect:wsSelect}));
+
+            request = set(cloneDeep(request), DataTagMeta, DL_DATA_TAG);
+
+
+            const onComplete = (bgStatus) => {
+                doDownload(bgStatus, isWorkspace, wsSelect, fileName);
+            };
+
+            bgDownload({dlRequest: dreq, searchRequest: request, selectInfo}, {key: LcXYPlotCompKey, onComplete, isWs:isWorkspace});
+            showDownloadDialog(this,ttl, false);
+        });
+
+        return (
+            <div style={Object.assign({margin: '4px', position: 'relative'}, style)}>
+                {mask && <div style={{width: '100%', height: '100%'}} className='loading-mask'/>}
+                <DownloadButton
+                    defaultPanel={this}>
+
+                    <FormPanel
+                        submitText='Save'
+                        groupKey={gKey}
+                        onSubmit={onSubmit}
+                        onCancel={() => dispatchHideDialog(ttl)}
+                        onError={resultsFail()}
+                        help_id={help_id}
+                        title={ttl}
+                      >
+
+                        <FieldGroup groupKey={gKey} keepState={true}
+                                    reducerFunc={DLReducer(rParams, mission)}>
+                            <DownloadOptionsDialog fromGroupKey={gKey}
+                                                   workspace={isWs}
+                                                   dialogWidth={'100%'}
+                                                   dialogHeight={'calc(100% - 200pt)'}
+                                                   children={children(cutoutSize, labelWidth, mission)}
+
+                            />
+                            <div style={{width: 250, marginTop: 10}}>
+                                <input type='checkbox' checked={enableEmail} onChange={toggleEnableEmail}/>Also send me
+                                email with URLs to download
+                            </div>
+                            {showEmail(enableEmail, email,onEmailChanged)}
+                        </FieldGroup>
+                    </FormPanel>
+
+                </DownloadButton>
+            </div>
+        );
+
+    }
+//}
+
+LcDownloadOptionPanel.propTypes = {
+    cutoutSize: PropTypes.string,
+    help_id:    PropTypes.string,
+    title:      PropTypes.string,
+    mask:       PropTypes.bool,
+    style:      PropTypes.object
+
+};
+
+
+
+const children = (cutoutSize, labelWidth, mission) => {
+    return  (<div>
+            <ValidationField
+                style={{width: 223}}
+                initialState={{
+                    value: `${mission}_Files: ${currentTime}`,
+                    label: `${mission}:`
+                }}
+                fieldKey='Title'
+                labelWidth={labelWidth}
+            />
+            {cutoutSize &&
+            <ListBoxInputField
+                wrapperStyle={{marginTop: 5}}
+                fieldKey ='dlCutouts'
+                initialState = {{
+                    tooltip: 'Download Cutouts Option',
+                    label : 'Download:'
+                }}
+                options = {[
+                    {label: 'Specified Cutouts', value: 'cut'},
+                    {label: 'Original Images', value: 'orig'}
+                ]}
+                labelWidth = {labelWidth}
+            />
+            }
+            <ListBoxInputField
+                wrapperStyle={{marginTop: 5}}
+                fieldKey ='zipType'
+                initialState = {{
+                    tooltip: 'Zip File Structure',
+                    label : 'Zip File Structure:'
+                }}
+                options = {[
+                    {label: 'Structured (with folders)', value: 'folder'},
+                    {label: 'Flattened (no folders)', value: 'flat'}
+                ]}
+                cutoutSize = {cutoutSize}
+                labelWidth = {labelWidth}
+            />
+
+        </div>
+    );
+};
+
+
+function getParamters(mission){
+    switch (mission.toLowerCase()){
+        case 'ptf':
+            return {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ptf image is ~33mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'PtfLcDownload',
+                ProductLevel:'l1',
+                schema:'images',
+                table:'level1'
+            };
+            break;
+        case 'ztf' :
+            return  {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ztf image is ~37mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'ZtfLcDownload',
+                ProductLevel:'sci',
+                schema:'products',
+                table:'sci'};
+            break;
+        default:
+            return  {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'LightCurveFileGroupsProcessor'
+            };
+    };
+
+
+}
+
+const showEmail = (enabled, email, onChange)=>{
+    if(enabled) {
+        return (
+            <InputField
+                validator={Validate.validateEmail.bind(null, 'an email field')}
+                tooltip='Enter an email to be notified when a process completes.'
+                label='Email:'
+                labelStyle={{display: 'inline-block', marginLeft: 18, width: 32, fontWeight: 'bold'}}
+                value={email}
+                placeholder='Enter an email to get notification'
+                style={{width: 170}}
+                onChange={onChange}
+                actOn={['blur','enter']}
+            />
+        );
+    }
+    else{
+        return (<div></div>);
+    }
+
+};
+
+function resultsFail() {
+    return (request) => {
+        const {wsSelect, fileLocation} = request;
+
+        if (fileLocation === WORKSPACE) {
+            if (!wsSelect) {
+                workspacePopupMsg('please select a workspace folder', 'Save to workspace');
+            } else {
+                const isAFolder = isValidWSFolder(wsSelect);
+                if (!isAFolder.valid) {
+                    workspacePopupMsg(isAFolder.message, 'Save to workspace');
+                }
+            }
+        }
+    };
+}
+
+
+function DLReducer(rParams, groupKey) {
+    const {fKeyDef, defValues} = rParams;
+    return (inFields, action) => {
+
+        if (!inFields) {
+            const defV = Object.assign({}, defValues);
+            set(defV, [fKeyDef.wsSelect.fKey, 'value'], '');
+            set(defV, [fKeyDef.wsSelect.fKey, 'validator'], isWsFolder());
+            set(defV, [fKeyDef.fileName.fKey, 'validator'], fileNameValidator(groupKey));
+            return defV;
+        } else {
+           if (action.type===FieldGroupCntlr.VALUE_CHANGE) {
+
+               if (action.payload.fieldKey === fKeyDef.wsSelect.fKey) {
+                   // change the filename if a file is selected from the file picker
+                   const val = action.payload.value;
+
+                   if (val && isValidWSFolder(val, false).valid) {
+                       const fName = val.substring(val.lastIndexOf('/') + 1);
+
+                       inFields = updateSet(inFields, [fKeyDef.fileName.fKey, 'value'], fName);
+                   }
+               }
+
+           }
+           return Object.assign({}, inFields);
+
+        }
+
+    };
+}
+

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -1,15 +1,10 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get,  set, isNil} from 'lodash';
-import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
-import {getCellValue, getTblById, getColumnIdx, smartMerge, getColumns, COL_TYPE} from '../../../tables/TableUtil.js';
-import {makeFileRequest} from '../../../tables/TableRequestUtil.js';
-import {sortInfoString} from '../../../tables/SortInfo.js';
-import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
+import {getCellValue, getTblById} from '../../../tables/TableUtil.js';
+import {getInitialDefaultValues,renderMissionView,validate,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
-import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
-import {ValidationField} from '../../../ui/ValidationField.jsx';
-import {DL_DATA_TAG} from '../LcConverterFactory.js';
+
 
 
 const labelWidth = 80;
@@ -87,106 +82,4 @@ export function isValidPTFTable() {
                         Please select the "Other" upload option for tables that do not meet these requirements.`;
         return {errorMsg, isValid:false};
    }
-}
-
-/**
- * Pregex pattern for ptf, at least to find obsmjd and mag_autocorr if present
- * @type {string[]}
- */
-const xyColPattern = ['obsmjd', 'mag_autocorr'];
-
-export function ptfOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo) {
-
-    // Update default values AND sortInfo and
-    const metaInfo = rawTable && rawTable.tableMeta;
-
-    const numericalCols = getColumns(rawTable, COL_TYPE.NUMBER).map((c) => c.name);
-    const defaultDataSource = (getColumnIdx(rawTable, converterData.dataSource) > 0) ? converterData.dataSource : numericalCols[3];
-
-    const {defaultCTimeName,defaultYColName } = getTimeAndYColInfo(numericalCols, xyColPattern, rawTable,converterData );
-
-    const defaultValues = {
-        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, defaultCTimeName),
-        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, defaultYColName),
-        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES, numericalCols),
-        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES, numericalCols),
-        [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, defaultDataSource),
-        [LC.META_FLUX_BAND]: get(metaInfo, LC.META_FLUX_BAND, 'g')
-
-    };
-
-    missionEntries = Object.assign({}, missionEntries, defaultValues);
-    const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries});
-
-    return {newLayoutInfo, shouldContinue: false};
-}
-
-//TODO if ptfRawTableRequest and ptfOnFieldUpdate are nothing different from the ones in ptfMssionOption, these two can be replaced.
-export function ptfRawTableRequest(converter, source, uploadFileName='') {
-    const timeCName = converter.defaultTimeCName;
-    const mission = converter.converterId;
-    const options = {
-        tbl_id: LC.RAW_TABLE,
-        sortInfo: sortInfoString(timeCName), // if present, it will skip LcManager.js#ensureValidRawTable
-        META_INFO: {[LC.META_MISSION]: mission, timeCName},
-        pageSize: LC.TABLE_PAGESIZE,
-        uploadFileName
-
-    };
-    return makeFileRequest('Input Data', source, null, options);
-
-}
-
-
-export function ptfOnFieldUpdate(fieldKey, value) {
-    // images are controlled by radio button -> filter g, R.
-    if (fieldKey === LC.META_TIME_CNAME) {
-        return fileUpdateOnTimeColumn(fieldKey, value);
-    } else if ([LC.META_FLUX_CNAME, LC.META_ERR_CNAME,  LC.META_FLUX_BAND].includes(fieldKey)) {
-        return {[fieldKey]: value};
-    }
-
-
-}
-
-/**
- *  This is specialized for PTF download.
- *  Gets the download option panel for PTF with specific file processor id 'PtfDownload'
- * @param mission
- * @param cutoutSizeInDeg
- * @returns {XML}
- */
-export function ptfDownloaderOptPanel (mission, cutoutSizeInDeg) {
-    const currentTime = (new Date()).toLocaleString('en-US', { hour12: false });
-
-    const style = {width: 167};
-    return (
-        <DownloadButton>
-            <DownloadOptionPanel
-                groupKey = {mission}
-                dataTag = {DL_DATA_TAG}
-                cutoutSize={cutoutSizeInDeg}
-                title={'Image Download Options'}
-                dlParams={{
-                    MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ptf image is ~33mb
-                    FilePrefix: `${mission}_Files`,
-                    BaseFileName: `${mission}_Files`,
-                    DataSource: `${mission} images`,
-                    FileGroupProcessor: 'PtfLcDownload',
-                    ProductLevel:'l1',
-                    schema:'images',
-                    table:'level1'
-                }}>
-                <ValidationField
-                    style={style}
-                    initialState={{
-                        value: `${mission}_Files: ${currentTime}`,
-                        label: 'PTF:'
-                    }}
-
-                    fieldKey='Title'
-                    labelWidth={110}/>
-            </DownloadOptionPanel>
-        </DownloadButton>
-    );
 }

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -2,10 +2,8 @@ import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get,  set, isNil} from 'lodash';
 import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
-import {getCellValue, getTblById, getColumnIdx, smartMerge, getColumns, COL_TYPE} from '../../../tables/TableUtil.js';
-import {makeFileRequest} from '../../../tables/TableRequestUtil.js';
-import {sortInfoString} from '../../../tables/SortInfo.js';
-import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
+import {getCellValue, getTblById, getColumnIdx} from '../../../tables/TableUtil.js';
+import {getInitialDefaultValues,renderMissionView,validate,setValueAndValidator} from '../LcUtil.jsx';
 
 import {LC} from '../LcManager.js';
 
@@ -105,62 +103,6 @@ export function isValidWiseTable(){
         const errorMsg=`The uploaded table is not valid. The WISE  option requires frame_id, or source_id, or both scan_id and frame_num.
                 Please select the "Other" upload option for tables that do not meet these requirements.`;
         return {errorMsg, isValid:false};
-    }
-}
-
-
-/**
- * Pregex pattern for wise, at least to find mjd and w1mpro if present
- * @type {string[]}
- */
-const xyColPattern = ['\\w*jd\\w*', 'w[1-4]mpro\\w*'];
-
-export function wiseOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo) {
-
-    // Update default values AND sortInfo and
-    const metaInfo = rawTable && rawTable.tableMeta;
-    const numericalCols = getColumns(rawTable, COL_TYPE.NUMBER).map((c) => c.name);
-    let defaultDataSource = (getColumnIdx(rawTable, converterData.dataSource) > 0) ? converterData.dataSource : numericalCols[3];
-
-    const {defaultCTimeName,defaultYColName } = getTimeAndYColInfo(numericalCols, xyColPattern, rawTable,converterData );
-    const defaultValues = {
-        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, defaultCTimeName),
-        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, defaultYColName),
-        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES, numericalCols),
-        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES, numericalCols),
-        [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, defaultDataSource),
-        [LC.META_FLUX_BAND]: get(metaInfo, LC.META_FLUX_BAND, 'w1')
-
-    };
-
-    missionEntries = Object.assign({}, missionEntries, defaultValues);
-    const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries});
-
-    return {newLayoutInfo, shouldContinue: false};
-}
-
-export function wiseRawTableRequest(converter, source, uploadFileName='') {
-    const timeCName = converter.defaultTimeCName;
-    const mission = converter.converterId;
-    const options = {
-        tbl_id: LC.RAW_TABLE,
-        sortInfo: sortInfoString(timeCName), // if present, it will skip LcManager.js#ensureValidRawTable
-        META_INFO: {[LC.META_MISSION]: mission, timeCName},
-        pageSize: LC.TABLE_PAGESIZE,
-        uploadFileName
-
-    };
-
-    return makeFileRequest('Input Data', source, null, options);
-
-}
-
-export function wiseOnFieldUpdate(fieldKey, value) {
-    // images are controlled by radio button -> band w1,w2,w3,w4.
-    if (fieldKey === LC.META_TIME_CNAME) {
-        return fileUpdateOnTimeColumn(fieldKey, value);
-    } else if ([LC.META_FLUX_CNAME, LC.META_ERR_CNAME, LC.META_URL_CNAME, LC.META_FLUX_BAND].includes(fieldKey)) {
-        return {[fieldKey]: value};
     }
 }
 

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -76,7 +76,8 @@ export function DownloadButton(props) {
         if (selectInfoCls.getSelectedCount()) {
             var panel = props.children ? React.Children.only(props.children) : <DownloadOptionPanel/>;
             panel = React.cloneElement(panel, {tbl_id});
-            showDownloadDialog(panel);
+            const ttl = panel.props.title || DOWNLOAD_DIALOG_ID;
+            showDownloadDialog(panel, ttl, true);
         } else {
             showInfoPopup('You have not chosen any data to download', 'No Data Selected');
         }
@@ -128,7 +129,7 @@ export function DownloadOptionPanel (props) {
         const dreq = makeTblRequest(FileGroupProcessor, Title, Object.assign(dlParams, {cutoutSize}, options));
         request = set(cloneDeep(request), DataTagMeta, dataTag);
         dispatchPackage(dreq, request, SelectInfo.newInstance(selectInfo).toString());
-        showDownloadDialog(this, false);
+        showDownloadDialog(this,ttl, false);
     }, tbl_id);
 
     const toggleEnableEmail = (e) => {
@@ -244,24 +245,24 @@ function hasProprietaryData(tableModel={}) {
     return false;
 }
 
-
 /**
- * creates and show the DownloadDialog.
- * @param {Component}  panel  the panel to show in the popup.
- * @param {boolean} [show=true] show or hide this dialog
+ *
+ * @param panel
+ * @param title
+ * @param show
  */
-function showDownloadDialog(panel, show=true) {
-    const ttl = panel.props.title || DOWNLOAD_DIALOG_ID;
+export function showDownloadDialog(panel, title, show=true) {
+
     if (show) {
         const content= (
-            <PopupPanel title={ttl} >
+            <PopupPanel title={title} >
                 {panel}
             </PopupPanel>
         );
-        DialogRootContainer.defineDialog(ttl, content);
-        dispatchShowDialog(ttl);
+        DialogRootContainer.defineDialog(title, content);
+        dispatchShowDialog(title);
     } else {
-        dispatchHideDialog(ttl);
+        dispatchHideDialog(title);
     }
 }
 

--- a/src/firefly/js/ui/WorkspaceViewer.jsx
+++ b/src/firefly/js/ui/WorkspaceViewer.jsx
@@ -388,7 +388,12 @@ export function doDownloadWorkspace(url, options) {
     fetchUrl(url, {method: 'post', ...options}).then( (response) => {
         response.json().then( (value) => {
             if (value.ok === 'true') {
+
+                workspacePopupMsg( 'Saving to workspace...', 'Workspace Info');
                 dispatchWorkspaceCreatePath({files: value.result});
+
+                workspacePopupMsg( 'Data is saved to workspace successfully', 'Workspace Info');
+
             } else {
                 workspacePopupMsg('Save error - '+ value.status,
                                  'Save to workspace');


### PR DESCRIPTION
See ticket here: https://jira.ipac.caltech.edu/browse/FIREFLY-159
and here: https://jira.ipac.caltech.edu/browse/FIREFLY-84

 1. Add LcDownloadPanel.jsx
 2. Instead of having three DownloadPanels, only one LcDownloadPanel is use for all missions.
 3. Instead of duplicating onNewRawTable, rawTableRequest and onFieldUpdate for each mission, these three functions are put in LcUntils.js.

I tried to use existing DownloadDialog but I have to make quite some modifications.  Instead, I added a 
LcDownloadPanel.  I modified the BackgroundCntrl to save the files in the workspace.  Please let me know if there is any better approach.

URL: https://irsawebdev9.ipac.caltech.edu/firefly-Lijun-firefly-84-firefly-159/irsaviewer/ts.html