### PR TITLE
FIREFLY-158_uplaod_panel_buttons_are_too_down_in_ts

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -268,7 +268,7 @@ export class UploadPanel extends SimpleComponent {
         };
 
         return (
-            <div style={{padding: 10}}>
+            <div style={{padding: 10, marginBottom:15}}>
                 <div style={{margin: '0px 5px 5px'}}>{instruction}</div>
                 <FormPanel
                     groupKey={vFileKey}


### PR DESCRIPTION
The buttons in the upload panel were down to the bottom in Time Series application.

Jira: https://jira.ipac.caltech.edu/browse/FIREFLY-158
K8s: https://irsawebdev9.ipac.caltech.edu/firefly-158/irsaviewer/timeseries