### PR TITLE
FIREFLY-162: fixed download feature not working in firefox and safari

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -286,7 +286,6 @@ div.rootStyle>img, div.rootStyle > html {
 .keyword-value  {
     color: maroon;
     margin-right: 10px;
-    text-overflow: ellipsis;
 }
 
 

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -41,8 +41,9 @@
 }
 
 .TablePanel__meta {
-    flex-grow: 0;
     display: flex;
+    flex-direction: column;
+    flex-grow: 0;
     border: 1px solid #c8c8c8;
     background-color: #e6e6e6;
     margin-bottom: 2px;

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -316,7 +316,6 @@ TablePanel.defaultProps = {
 function MetaInfo({tbl_id}) {
     const contentStyle={display: 'flex', flexDirection: 'column', maxHeight: 200, overflow: 'auto', paddingBottom: 1};
     const wrapperStyle={width: '100%'};
-    const kwValStyle = {maxWidth: 0, whiteSpace: 'nowrap'};
 
     const {keywords, links, params} = TblUtil.getTblById(tbl_id);
 
@@ -332,7 +331,7 @@ function MetaInfo({tbl_id}) {
                     .map(({value, key}, idx) => {                              // map it into html elements
                         return (
                             <div key={'keywords-' + idx} style={{display: 'inline-flex'}}>
-                                <div className='keyword-label'>{key}=</div><div style={kwValStyle} className='keyword-value'>{value}</div>
+                                <Keyword style={{maxWidth: 0}} label={key} value={value}/>
                             </div>
                         );
                     })
@@ -346,7 +345,7 @@ function MetaInfo({tbl_id}) {
                     .map(({name, value, type='N/A'}, idx) => {
                     return (
                         <div key={'keywords-' + idx} style={{display: 'inline-flex'}}>
-                            <div className='keyword-label'>{name}({type})=</div><div style={kwValStyle} className='keyword-value'>{value}</div>
+                            <Keyword label={`${name}(${type})`} value={value}/>
                         </div>
                     );
                 })
@@ -356,12 +355,13 @@ function MetaInfo({tbl_id}) {
             { !isEmpty(links) &&
             <CollapsiblePanel componentKey={tbl_id + '-links'} header='Links' {...{contentStyle, wrapperStyle}}>
                 {links.map((l, idx) => {
+                    const dispVal = l.value || l.href;
                     return (
-                        <div key={'keywords-' + idx}>
-                            <div className='keyword-label'>ID</div><div style={kwValStyle} className='keyword-value'>{l.ID || 'N/A'}</div>
-                            <div className='keyword-label'>role</div><div style={kwValStyle} className='keyword-value'>{l.role || 'N/A'}</div>
-                            <div className='keyword-label'>type</div><div style={kwValStyle} className='keyword-value'>{l.type || 'N/A'}</div>
-                            <a href={l.href} value={l.value || l.href} title={l.title}/>
+                        <div key={'keywords-' + idx} style={{display: 'inline-flex'}}>
+                            { l.ID && <Keyword label='ID' value={l.ID}/> }
+                            { l.role && <Keyword label='role' value={l.role}/> }
+                            { l.type && <Keyword label='type' value={l.type}/> }
+                            <a style={{whiteSpace: 'nowrap', maxWidth: 300}} href={l.href} title={l.title || dispVal}>{dispVal}</a>
                         </div>
                     );
                 })
@@ -369,6 +369,15 @@ function MetaInfo({tbl_id}) {
             </CollapsiblePanel>
             }
         </div>
+    );
+}
+
+function Keyword({style={}, label, value}) {
+    return (
+        <React.Fragment>
+            <div className='keyword-label'>{label}</div>
+            <div style={{whiteSpace: 'nowrap', ...style}} className='keyword-value'>{value}</div>
+        </React.Fragment>
     );
 }
 

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -419,10 +419,13 @@ export function downloadBlob(blob, filename) {
     if (blob) {
         window.URL = window.URL || window.webkitURL;
         const a = document.createElement('a');
+        a.style.display = 'none';
         a.href = window.URL.createObjectURL(blob);
         a.download = filename;
+        document.body.appendChild(a);
         a.click();
         window.URL.revokeObjectURL(a.href);
+        document.body.removeChild(a);
     }
 }
 

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.css
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.css
@@ -1,7 +1,7 @@
 
 .FileUpload {
     width: 1000px;
-    height: 350px;
+    height: 450px;
     padding: 0 10px;
     display: flex;
     flex-direction: column;}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-162
Test link: https://irsawebdev9.ipac.caltech.edu/FIREFLY-162_save_firefox_safari/firefly/

As reported in ticket, downloading is no longer working in Firefox and Safari.
This is due to a recent chance in the code where the `<A>` tag was not added to the HTML document before triggering a click event.  Not testing it in Firefox and Safari was an oversight.
You should definitely test the fix in all browsers.  :)

- also, minor tweaked to File Upload layout

