### PR TITLE
FIREFLY-166: fixed condition when Link Substitution fails, table fail to load.

### DIFF
--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1075,7 +1075,7 @@ export function resolveHRefVal(tableModel, href='', rowIdx, defval='') {
         vars.forEach((v) => {
             const [,cname] = v.match(/\${([\w -.]+)}/) || [];
             const col = getColumnByID(tableModel, cname) || getColumn(tableModel, cname);
-            const rval = getCellValue(tableModel, rowIdx, col.name);
+            const rval = col ? getCellValue(tableModel, rowIdx, col.name) : v;  // if the variable cannot be resolved, show it as is.
             rhref = rhref.replace(v, rval);
         });
         return rhref;


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-166

When VOTable Link contains bad column reference, table should not fail to load.
This fix applies to both `href` and `value` substitution.  When the substitution fail to resolve, it will use what is given.

To test:
https://irsawebdev9.ipac.caltech.edu/FIREFLY-166_link_substitution_error_handling/firefly/

- upload the attached file in the ticket.  In the 4th column, the 5th links should say 
`info-${non-existing-column}-NGC6543`, because `non-existing-column` is not a valid column in this table.

