### PR TITLE
FIREFLY-172: put back read from URL in VoTableReader

### DIFF
--- a/config/logging.properties
+++ b/config/logging.properties
@@ -12,3 +12,5 @@ java.util.logging.FileHandler.append=true
 #java.util.logging.FileHandler.count=3
 java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
 
+# lower starlink logging level to avoid the enormous amount of repetitive warning messages
+uk.ac.starlink.votable.level=SEVERE

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
@@ -42,7 +42,7 @@ public abstract class QueryVOTABLE extends IpacTablePartProcessor {
     public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
         try {
             File votable = getSearchResult(getQueryString(req), getFilePrefix(req));
-            DataGroup[] groups = VoTableReader.voToDataGroups(votable.getAbsolutePath(), false);
+            DataGroup[] groups = VoTableReader.voToDataGroups(votable.getAbsolutePath());
             DataGroup dg;
             int tblIdx = req.getIntParam(TBL_INDEX, 0);
             if (groups.length <= tblIdx ) {

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -61,15 +61,9 @@ public class VoTableReader {
      * @return an array of DataGroup object
      */
     public static DataGroup[] voToDataGroups(String location, boolean headerOnly) throws IOException, DataAccessException {
-        //VOTableBuilder votBuilder = new VOTableBuilder();
         List<DataGroup> groups = new ArrayList<>();
 
         try {
-            //DataSource datsrc = DataSource.makeDataSource(voTableFile);
-            //StoragePolicy policy = StoragePolicy.getDefaultPolicy();
-            //TableSequence tseq = votBuilder.makeStarTables( datsrc, policy );
-            //StarTableFactory stFactory = new StarTableFactory();
-            //TableSequence tseq = stFactory.makeStarTables(location, null);
 
             List<TableElement> tableAry = getTableElementsFromFile( location, null);
             for ( TableElement tableEl : tableAry ) {
@@ -109,21 +103,17 @@ public class VoTableReader {
     }
 
     // root VOElement for a votable file
-    private static VOElement makeVOElement(File infile, StoragePolicy policy) throws DataAccessException {
+    private static VOElement getVOElementFromVOTable(String location, StoragePolicy policy) throws DataAccessException {
         try {
             policy = policy == null ? PREFER_MEMORY : policy;
             VOElementFactory voFactory =  new VOElementFactory();
             voFactory.setStoragePolicy(policy);
-            return voFactory.makeVOElement(infile);
+            return voFactory.makeVOElement(location);
         }  catch (SAXException |IOException e) {
             e.printStackTrace();
-            throw new DataAccessException("unable to parse "+ infile.getPath() + "\n" +
+            throw new DataAccessException("unable to parse "+ location + "\n" +
                     e.getMessage(), e);
         }
-    }
-
-    private static VOElement getVOElementFromVOTable(String location, StoragePolicy policy) throws DataAccessException {
-        return makeVOElement(new File(location), policy);
     }
 
     // get all <RESOURCE> under VOTable root or <RESOURCE>
@@ -325,11 +315,6 @@ public class VoTableReader {
                 LinkInfo linkObj = linkElementToLinkInfo(link);
 
                 if (linkObj != null) {
-                    List<LinkInfo> dtLinkInfos = dt.getLinkInfos();
-
-                    if (dtLinkInfos != null) {
-                        dtLinkInfos.add(linkObj);
-                    }
                     linkObjs.add(linkObj);
                 }
             }
@@ -578,7 +563,7 @@ public class VoTableReader {
 
             // child elements <LINK> and <VALUES>
             if (tableEl != null) {
-                makeLinkInfosFromField(tableEl, dt);
+                dt.setLinkInfos(makeLinkInfosFromField(tableEl, dt));
                 getValuesFromField(tableEl, dt);
             }
 
@@ -767,7 +752,7 @@ public class VoTableReader {
     public static FileAnalysis.Report analyze(File infile, FileAnalysis.ReportType type) throws Exception {
 
         FileAnalysis.Report report = new FileAnalysis.Report(type, TableUtil.Format.VO_TABLE.name(), infile.length(), infile.getPath());
-        VOElement root = makeVOElement(infile, null);
+        VOElement root = getVOElementFromVOTable(infile.getAbsolutePath(), null);
         List<FileAnalysis.Part> parts = describeDocument(root);
         parts.forEach(report::addPart);
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-172
Test:  https://irsawebdev9.ipac.caltech.edu/FIREFLY-172_sofia_table_stopped_working/applications/sofia/

Additional changes here: https://github.com/IPAC-SW/irsa-ife/pull/78


- put back the ability to read VOTable from URL.
- revert changes to SofiaQuery made as a workaround to previous changes

Also
- set higher logging level for starlink to avoid repetitive warning messages


