### PR TITLE
FIREFLY-114: improved message for an API user on non-existent column

### DIFF
--- a/src/firefly/html/test/tests-chart.html
+++ b/src/firefly/html/test/tests-chart.html
@@ -209,6 +209,47 @@
     </script>
 </template>
 
+<template title="Chart errors: non-existing column" class="tpl xxl" >
+    <div id="expected">
+        <ul class='expected-list'>
+            <li>Single trace chart error: trace should not be mentioned</li>
+            <li>Multi-trace chart error: error should mention the trace name or number</li>
+            <li>If multiple columns do not exist, only the first one is mentioned</li>
+            <li>Non-existing column name is shown in lower case</li>
+        </ul>
+    </div>
+    <div id="actual" class="flow-h" style="width: 800px">
+        <div id="xyplotHere" class="box"></div>
+    </div>
+    <script>
+        onFireflyLoaded= function(firefly) {
+            firefly.debug = true;
+            const searchRequest = firefly.util.table.makeFileRequest(
+                'WiseDemoTable', // title
+                'http://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',  // source
+                null,  // alt_source
+                {pageSize: 1} // options
+            );
+            const tblIdDemo = searchRequest.tbl_id;
+            firefly.action.dispatchTableFetch(searchRequest);
+
+            const traces = [];
+            // typo in column name: "decl" should be "dec"
+            for (let i = 1; i <= 4; i++) {
+                traces.push({
+                    name: 'corner ' + i,
+                    tbl_id: tblIdDemo,
+                    x: 'tables::ra' + i,  // references to table columns ra1,ra2,ra3,ra4
+                    y: 'tables::decL' + i, // references to table columns dec1,dec2,dec3,dec4
+                    mode: 'markers'
+                });
+            }
+            firefly.showChart('xyplotHere', {data: [traces[0]]}); // single trace chart
+            firefly.showChart('xyplotHere', {data: traces}); // multi-trace chart
+        }
+    </script>
+</template>
+
 <template title="Multitrace Histogram" class="tpl xxl" >
     <div id="expected">
         <img width="100%" src="images/chart_hist.png">

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -836,14 +836,20 @@ export function getErrors(chartId) {
 export function dispatchError(chartId, traceNum, reason) {
 
     const {data=[]} = getChartData(chartId);
-    const name = get(data, `${traceNum}.name`, `trace ${traceNum}`);
-    let message = `Failed to plot ${name} data`;
+    let forTrace = '';
+    if (data.length > 1) {
+        // only mention trace, when there are multiple traces
+        const name = get(data, `${traceNum}.name`, `trace ${traceNum}`);
+        forTrace = ` for ${name}`;
+    }
+    let message = `Cannot display requested data${forTrace}`;
     logError(`${message}: ${reason}`);
 
     let reasonStr = `${reason}`.toLowerCase();
     if (reasonStr.match(/not supported/)) {
         reasonStr = 'Unsupported feature requested. Please choose valid options.';
-    } else if (reasonStr.match(/data exception/)) {
+    } else if (reasonStr.match(/data exception/) || reasonStr.match(/column not found/)) {
+        // error from db
         reasonStr = reasonStr.replace('error: ', '');
     } else if (reasonStr.match(/invalid column/)) {
         reasonStr = 'Non-existent column or invalid expression. Please choose valid X and Y.';


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-114
To test, check case 4 (Chart errors: non-existing column):
https://irsawebdev9.ipac.caltech.edu/firefly-114_apiErr/firefly/test/tests-chart.html

These are minimum changes to help API user to find a problem, when an error happens because of a non-existent column. Basically, in "column not found" case, an error from db is passed to the user. 

The limitations of this implementation are the following:
- If multiple columns are misspelled, only the first one is mentioned
- Non-existing column name is shown in lower case