### PR TITLE
IRSA-3009: Table sort wrongly interpret proprietary data

### DIFF
--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -145,7 +145,7 @@ BasicTableViewInternal.propTypes = {
     bgColor: PropTypes.string,
     error:  PropTypes.string,
     size: PropTypes.object.isRequired,
-    highlightedRowClsName: PropTypes.func,
+    highlightedRowHandler: PropTypes.func,
     renderers: PropTypes.objectOf(
         PropTypes.shape({
             cellRenderer: PropTypes.func,

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -212,7 +212,7 @@ export class TablePanel extends PureComponent {
                                 callbacks={tableConnector}
                                 { ...{columns, data, hlRowIdx, rowHeight, selectable, showUnits, allowUnits, showTypes, showFilters,
                                     selectInfoCls, filterInfo, sortInfo, textView, showMask, currentPage,
-                                    tableConnector, renderers, tbl_ui_id, highlightedRowHandler} }
+                                    tableConnector, renderers, tbl_ui_id, highlightedRowHandler, startIdx} }
                             />
                             {showOptionButton && !showToolbar &&
                             <img className='TablePanel__options--small'


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-3009

In tables with proprietary data, it failed to interpret row access beyond first page.  This is due to `startIdx` not being passed to the table rendering logic.

To test, follow the instructions from the ticket.
Test build:  https://irsawebdev9.ipac.caltech.edu/IRSA-3009_sort_proprietary_rows/applications/sofia/