### PR TITLE
Firefly-179: Fixed right-east align and align w/rotation issues

### DIFF
--- a/src/firefly/js/data/ServerRequest.js
+++ b/src/firefly/js/data/ServerRequest.js
@@ -6,6 +6,7 @@ import {has} from 'lodash';
 import validator from 'validator';
 import {parseWorldPt} from '../visualize/Point.js';
 import {replaceAll, isDefined} from '../util/WebUtil.js';
+import {toBoolean} from '../util/WebUtil';
 
 
 const REQUEST_CLASS= 'RequestClass';
@@ -222,7 +223,7 @@ export class ServerRequest {
 //  convenience data converting routines
 //====================================================================
     getBooleanParam(key, def=false) {
-        return has(this.params,key) ? Boolean(this.params[key]) : def;
+        return has(this.params,key) ? toBoolean(this.params[key]) : def;
     }
 
     getIntParam(key, def=0) {

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -19,12 +19,13 @@ import {RangeSliderView} from './RangeSliderView';
 import HelpIcon from './HelpIcon.jsx';
 import ROTATE_NORTH_OFF from 'html/images/icons-2014/RotateToNorth.png';
 import ROTATE_NORTH_ON from 'html/images/icons-2014/RotateToNorth-ON.png';
+import {hasWCSProjection} from '../visualize/PlotViewUtil';
 
 const DIALOG_ID= 'fitsRotationDialog';
 
 export function showFitsRotationDialog() {
     const popup = (
-        <PopupPanel title={'Rotate Image In Degrees'}>
+        <PopupPanel title={'Rotate Image'}>
             <FitsRotationImmediatePanel/>
         </PopupPanel>
     );
@@ -33,9 +34,9 @@ export function showFitsRotationDialog() {
 }
 
 function getCurrentRotation(pv) {
-    if (!pv || !pv.rotation || pv.rotation>359) return 0;
+    if (!pv || !pv.rotation || pv.rotation>359 || pv.rotation<.5) return 0;
     const angle=  isEastLeftOfNorth(primePlot(pv)) ? 360-pv.rotation : pv.rotation;
-    return Math.trunc(angle*100)/100;
+    return Math.round(angle);
 }
 
 const marks = { 0: '0', 45:'45', 90:'90', 135: '135', 180:'180', 225: '225', 270:'270', 315:'315', 359:'359' };
@@ -49,8 +50,9 @@ function FitsRotationImmediatePanel() {
 
     const plot= primePlot(pv);
     const currRotation= getCurrentRotation(pv);
+    const hasWcs= hasWCSProjection(pv);
 
-    const validator= (value) => Validate.floatRange(0, 360, 2, 'angle', value, true);
+    const validator= (value) => Validate.intRange(0, 360, 'angle', value, true);
 
     const changeRotation= (rotation) => {
         const angle= Number(rotation);
@@ -75,7 +77,7 @@ function FitsRotationImmediatePanel() {
 
     return (
         <div>
-            <div style={{padding: '25px 20px 40px 20px'}}>
+            <div style={{padding: '25px 20px 10px 20px'}}>
                 <div style={{display:'flex', flexDirection: 'column', alignItems:'center',
                                       justifyContent:'space-between', padding: '0 3px'}}>
                     <div style={{display:'flex', alignItems:'center', justifyContent:'space-between'}}>
@@ -90,6 +92,7 @@ function FitsRotationImmediatePanel() {
                                                 style={{border: '1px solid rgba(0,0,0,.2)'}}
                                                 isIconOn={pv&&plot ? pv.plotViewCtx.rotateNorthLock : false }
                                                 tip='Rotate this image so that North is up'
+                                                enabled={hasWcs}
                                                 visible={true}
                                                 iconOn={ROTATE_NORTH_ON}
                                                 iconOff={ROTATE_NORTH_OFF}
@@ -101,6 +104,9 @@ function FitsRotationImmediatePanel() {
                         min:0,max:359, step:1,vertical:false, marks,
                         defaultValue:currRotation, slideValue:currRotation,
                         handleChange:(v) => changeRotation(v)}} />
+                </div>
+                <div style={{paddingTop:40, textAlign:'center'}}>
+                    {hasWcs?'Angle in degrees East of North' : 'Angle in degrees counter clockwise'}
                 </div>
             </div>
             <div style={{textAlign:'center', display:'flex', justifyContent:'space-between', padding: '0 16px'}}>

--- a/src/firefly/js/ui/StatedInputfield.jsx
+++ b/src/firefly/js/ui/StatedInputfield.jsx
@@ -6,7 +6,7 @@ import {InputFieldView} from './InputFieldView.jsx';
 
 
 export function StateInputField({defaultValue, visible=true, message, label='', tooltip, labelWidth= 100, showWarning,
-                                    style='', wrapperStyle={}, onKeyDown, onKeyUp, validator, valueChange}) {
+                                    style={}, wrapperStyle={}, onKeyDown, onKeyUp, validator, valueChange}) {
 
     const [value, setValue] = useState(defaultValue);
     const [valid, setValid] = useState(true);

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -65,7 +65,8 @@ function handleClick(onClick, dropdownCB ,divElement) {
  * @param tipOnCB
  * @param tipOffCB
  * @param lastTextItem
- * @param additionalStyle
+ * @param additionalStyle - a style to apply (deprecated)
+ * @param style - a style to apply
  * @param todo show a todo message
  * @param ctx
  * @return {object}
@@ -103,7 +104,7 @@ export class ToolbarButton extends PureComponent {
         const {
             icon,text,tip,badgeCount=0,enabled=true,
             horizontal=true, bgDark, visible=true, active,
-            imageStyle, lastTextItem=false, todo, additionalStyle,
+            imageStyle, lastTextItem=false, todo, additionalStyle, style={},
             hasHorizontalLayoutSep, useDropDownIndicator,
             hasCheckBox=false, checkBoxOn=false } = this.props;
 
@@ -130,7 +131,7 @@ export class ToolbarButton extends PureComponent {
             s.fontSize= '10pt';
             s.position= 'relative';
             textCName= 'ff-menuItemHText';
-            const topStyle= Object.assign({}, {display:'inline-block', height:'100%', flex:'0 0 auto' },additionalStyle);
+            const topStyle= Object.assign({}, {display:'inline-block', height:'100%', flex:'0 0 auto' },additionalStyle,style);
             return (
                 <div style={topStyle}>
                     <div style={{ display:'inline-block',
@@ -156,7 +157,7 @@ export class ToolbarButton extends PureComponent {
 
         }
         else {
-            Object.assign(s,additionalStyle);
+            Object.assign(s,additionalStyle,style);
             if (icon&&text) {  // button in vertical style with both icon and text
                 return (
                     <div title={tip} style={{display: 'flex', alignItems: 'center'}} className={cName}
@@ -220,6 +221,7 @@ ToolbarButton.propTypes= {
     lastTextItem : PropTypes.bool,
     useDropDownIndicator: PropTypes.bool,
     additionalStyle : PropTypes.object,
+    style : PropTypes.object,
     hasCheckBox: PropTypes.bool,
     checkBoxOn: PropTypes.bool,
 };

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -490,7 +490,7 @@ export function dispatchRotate({plotId, rotateType, angle=-1,
  */
 export function dispatchFlip({plotId, isY=true, rematchAfterFlip= true,
                                      actionScope=ActionScope.GROUP, dispatcher= flux.process}) {
-    dispatcher({ type: FLIP, payload: { plotId, isY, actionScope}});
+    dispatcher({ type: FLIP, payload: { plotId, isY, rematchAfterFlip, actionScope}});
 }
 
 /**

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -27,7 +27,7 @@ import {colorChangeActionCreator, stretchChangeActionCreator, cropActionCreator}
 import {wcsMatchActionCreator} from './task/WcsMatchTask.js';
 import {autoPlayActionCreator, changePointSelectionActionCreator,
     restoreDefaultsActionCreator, deletePlotViewActionCreator} from './task/PlotAdminTask.js';
-import {processScrollActionCreator, recenterActionCreator} from './task/PlotChangeTask';
+import {flipActionCreator, processScrollActionCreator, recenterActionCreator} from './task/PlotChangeTask';
 
 /** enum can be 'COLLAPSE', 'GRID', 'SINGLE' */
 export const ExpandType= new Enum(['COLLAPSE', 'GRID', 'SINGLE']);
@@ -279,6 +279,7 @@ function actionCreators() {
         [DELETE_PLOT_VIEW]: deletePlotViewActionCreator,
         [RECENTER]: recenterActionCreator,
         [PROCESS_SCROLL]: processScrollActionCreator,
+        [FLIP]: flipActionCreator,
     };
 }
 
@@ -459,7 +460,8 @@ export function dispatchWcsMatch({plotId, matchType, lockMatch= true, dispatcher
  * @param {Object}  p
  * @param {string} p.plotId
  * @param {Enum} p.rotateType enum RotateType
- * @param {number} p.angle
+ * @param {number} p.angle - rotation angle- rotation is always toward the east of north. That is east-left images will
+ * rotate counter-clockwise, while east-right image will rotate clockwise
  * @param {string|ActionScope} p.actionScope enum ActionScope
  * @param {Function} p.dispatcher only for special dispatching uses such as remote
  *
@@ -478,6 +480,7 @@ export function dispatchRotate({plotId, rotateType, angle=-1,
  * @param {Object}  p
  * @param {string} p.plotId
  * @param {boolean} p.isY
+ * @param {boolean} p.rematchAfterFlip
  * @param {string|ActionScope} p.actionScope enum ActionScope
  * @param {Function} [p.dispatcher] only for special dispatching uses such as remote
  *
@@ -485,7 +488,8 @@ export function dispatchRotate({plotId, rotateType, angle=-1,
  * @function dispatchFlip
  * @memberof firefly.action
  */
-export function dispatchFlip({plotId, isY=true, actionScope=ActionScope.GROUP, dispatcher= flux.process}) {
+export function dispatchFlip({plotId, isY=true, rematchAfterFlip= true,
+                                     actionScope=ActionScope.GROUP, dispatcher= flux.process}) {
     dispatcher({ type: FLIP, payload: { plotId, isY, actionScope}});
 }
 

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -447,8 +447,15 @@ export function isPlotNorth(plot) {
     return retval;
 }
 
+/**
+ * Return true if east if left of north.  If east is right of north return false. This works regardless of the rotation
+ * of the image.
+ * @param {WebPlot} plot
+ * @return {boolean} true if is is left of north.
+ */
 export function isEastLeftOfNorth(plot) {
     if (!plot) return true;
+    if (!plot.projection.isSpecified() || !plot.projection.isImplemented()) return true;
 
     const mx = plot.dataWidth/2;
     const my = plot.dataHeight/2;
@@ -458,8 +465,10 @@ export function isEastLeftOfNorth(plot) {
 
     const cc= CysConverter.make(plot);
     const wptC = cc.getWorldCoords(makeImageWorkSpacePt(mx, my));
+    if (!wptC) return true;
     const wptNorth = makeWorldPt(wptC.x, wptC.y+worldOffset);
     const wptE = makeWorldPt(wptC.x+worldOffset, wptC.y);
+    if (!wptE) return true;
 
     const impNorth= cc.getImageCoords(wptNorth);
     const impE= cc.getImageCoords(wptE);
@@ -468,8 +477,7 @@ export function isEastLeftOfNorth(plot) {
     const angleN= getAngleInDeg(mx,my,impNorth.x,impNorth.y);
     const angleE= getAngleInDeg(mx,my,impE.x,impE.y);
     
-    // return Math.abs(angleN-angleE) < 180;
-    return angleE-angleN > 0;
+    return ((angleE-angleN) + 360)%360 < 180;
 }
 
 /**

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -472,6 +472,42 @@ export function isEastLeftOfNorth(plot) {
     return angleE-angleN > 0;
 }
 
+/**
+ * return an angle that will rotate the pv to match the rotation of masterPv
+ * @param masterPv
+ * @param pv
+ * @return {number}
+ */
+export function getMatchingRotationAngle(masterPv, pv) {
+    const plot= primePlot(pv);
+    const masterPlot= primePlot(masterPv);
+    if (!plot || !masterPlot) return 0;
+    const masterRot= masterPv.rotation * (masterPv.flipY ? -1 : 1);
+    const rot=getRotationAngle(plot);
+    let targetRotation;
+    if (isEastLeftOfNorth(masterPlot)) {
+        targetRotation= ((getRotationAngle(masterPlot)+  masterRot)  - rot) * (masterPv.flipY ? 1 : -1);
+    }
+    else {
+        targetRotation= ((getRotationAngle(masterPlot)+  (360-masterRot))  - rot) * (masterPv.flipY ? 1 : -1);
+
+    }
+    if (!isCsysDirMatching(plot,masterPlot)) targetRotation= 360-targetRotation;
+    if (targetRotation<0) targetRotation+= 360;
+    if (targetRotation>359) targetRotation%= 360;
+    return targetRotation;
+}
+
+/**
+ *
+ * @param {plot} p1
+ * @param {plot} p2
+ * @return {boolean}
+ */
+export function isCsysDirMatching(p1,p2) {
+    return isEastLeftOfNorth(p1)===isEastLeftOfNorth(p2);
+}
+
 
 function getAngleInDeg(cx,cy,x,y) {
     const ptX= Math.round(x)-Math.round(cx);

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -402,7 +402,9 @@ function rotatePv(pv, targetAngle, rotateNorthLock) {
 function rotatePvToMatch(pv, masterPv, rotateNorthLock) {
     if (isRotationMatching(pv,masterPv)) return pv;
     const masterPlot= primePlot(masterPv);
-    const csysDirMatching= isCsysDirMatching(primePlot(pv),masterPlot);
+    const plot= primePlot(pv);
+    if (getRotationAngle(masterPlot)!==getRotationAngle(plot)) rotateNorthLock= false;
+    const csysDirMatching= isCsysDirMatching(plot,masterPlot);
     let rotation= getMatchingRotationAngle(masterPv,pv);
     if (isEastLeftOfNorth(masterPlot)) {
         rotation= csysDirMatching ? 360-rotation :360+rotation;
@@ -463,7 +465,7 @@ function updateClientRotation(state,action) {
     }
     else {
         plotViewAry= actionScope===ActionScope.GROUP ?
-            applyToOnePvOrAll(state.positionLock, plotViewAry,plotId,false, (pv) => rotatePv(pv,targetAngle, rotateNorthLock)) :
+            applyToOnePvOrAll(state.positionLock, plotViewAry,plotId,false, (aPv) => rotatePv(aPv,targetAngle, rotateNorthLock&&aPv===pv)) :
             clonePvAryWithPv(plotViewAry, masterPv);
     }
 

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -172,6 +172,7 @@ function addPlot(state,action, setActive, newPlot) {
             activePlotId = pv.plotId;
         }
         pv = replacePlots(pv, plotAry, overlayPlotViews, state.expandedMode, newPlot);
+        pv.request= pv.plots[0].plotState.getWebPlotRequest();
         if (pv.plotViewCtx.rotateNorthLock) {
             pv.rotation= 360 - getRotationAngle(primePlot(pv));
             pv= updateTransform(pv);

--- a/src/firefly/js/visualize/task/PlotAdminTask.js
+++ b/src/firefly/js/visualize/task/PlotAdminTask.js
@@ -4,21 +4,19 @@
 
 import {get} from 'lodash';
 import ImagePlotCntlr, {dispatchChangeActivePlotView, dispatchPlotHiPS,
-    visRoot, IMAGE_PLOT_KEY, dispatchRotate, dispatchFlip, dispatchPlotImage } from '../ImagePlotCntlr.js';
+    visRoot, IMAGE_PLOT_KEY, dispatchRotate, dispatchFlip, dispatchPlotImage,
+    ActionScope, dispatchWcsMatch } from '../ImagePlotCntlr.js';
 import {getExpandedViewerItemIds, findViewerWithItemId,
     getMultiViewRoot, IMAGE} from '../MultiViewCntlr.js';
 import PointSelection from '../../drawingLayers/PointSelection.js';
-import {dispatchAttachLayerToPlot,
-    dispatchCreateDrawLayer,
-    dispatchDetachLayerFromPlot,
-    DRAWING_LAYER_KEY} from '../DrawLayerCntlr.js';
-import { getPlotViewById, applyToOnePvOrAll, findPlotGroup, isDrawLayerAttached,
+import {dispatchAttachLayerToPlot, dispatchCreateDrawLayer,
+    dispatchDetachLayerFromPlot, DRAWING_LAYER_KEY} from '../DrawLayerCntlr.js';
+import { getPlotViewById, applyToOnePvOrAll, isDrawLayerAttached,
     primePlot, getDrawLayerByType } from '../PlotViewUtil.js';
-import {isHiPS, isImage} from '../WebPlot.js';
+import {isImage} from '../WebPlot.js';
 import {RotateType} from '../PlotState.js';
 import {clone} from '../../util/WebUtil.js';
 import {detachSelectAreaRelatedLayers} from '../ui/SelectAreaDropDownView.jsx';
-import {dispatchWcsMatch} from '../ImagePlotCntlr';
 
 export function autoPlayActionCreator(rawAction) {
     return (dispatcher) => {
@@ -104,8 +102,9 @@ export function restoreDefaultsActionCreator(rawAction) {
                     const def= vr.plotRequestDefaults[pv.plotId];
                     const viewerId= findViewerWithItemId(getMultiViewRoot(), pv.plotId, IMAGE);
                     if (isImage(plot)) {
-                        if (pv.rotation) dispatchRotate({plotId: pv.plotId, rotateType: RotateType.UNROTATE});
-                        if (pv.flipY) dispatchFlip({plotId: pv.plotId});
+                        if (pv.rotation) dispatchRotate({plotId: pv.plotId, rotateType: RotateType.UNROTATE,
+                                                                   actionScope:ActionScope.SINGLE});
+                        if (pv.flipY) dispatchFlip({plotId: pv.plotId, actionScope:ActionScope.SINGLE});
                     }
                     switch (def.plotType) {
                         case 'threeColor' :

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -22,9 +22,9 @@ import {matchHiPStoPlotView} from './PlotHipsTask';
 
 export function flipActionCreator(rawAction) {
     return (dispatcher,getState) => {
-        const {plotId}=rawAction.payload;
+        const {plotId, rematchAfterFlip}=rawAction.payload;
         dispatcher(rawAction);
-        if (!rawAction.rematchAfterFlip) return;
+        if (!rematchAfterFlip) return;
         const matchType= getState()[IMAGE_PLOT_KEY].wcsMatchType;
         if (matchType) {
             dispatchWcsMatch({plotId,matchType});

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -4,7 +4,7 @@
 
 import {get} from 'lodash';
 import {logError} from '../../util/WebUtil.js';
-import ImagePlotCntlr, {IMAGE_PLOT_KEY, WcsMatchType} from '../ImagePlotCntlr.js';
+import ImagePlotCntlr, {IMAGE_PLOT_KEY, WcsMatchType, dispatchWcsMatch} from '../ImagePlotCntlr.js';
 import {primePlot, getPlotViewById, operateOnOthersInOverlayColorGroup, getPlotStateAry} from '../PlotViewUtil.js';
 import {callCrop, callChangeColor, callRecomputeStretch} from '../../rpc/PlotServicesJson.js';
 import WebPlotResult from '../WebPlotResult.js';
@@ -18,6 +18,19 @@ import {matchHiPStoPlotView} from './PlotHipsTask';
 //=======================================================================
 //-------------------- Action Creators ----------------------------------
 //=======================================================================
+
+
+export function flipActionCreator(rawAction) {
+    return (dispatcher,getState) => {
+        const {plotId}=rawAction.payload;
+        dispatcher(rawAction);
+        if (!rawAction.rematchAfterFlip) return;
+        const matchType= getState()[IMAGE_PLOT_KEY].wcsMatchType;
+        if (matchType) {
+            dispatchWcsMatch({plotId,matchType});
+        }
+    };
+}
 
 
 export function recenterActionCreator(rawAction) {

--- a/src/firefly/js/visualize/task/WcsMatchTask.js
+++ b/src/firefly/js/visualize/task/WcsMatchTask.js
@@ -28,6 +28,7 @@ import {getCenterOfProjection, hasWCSProjection} from '../PlotViewUtil';
 import {isHiPS, isImage} from '../WebPlot';
 import {matchHiPStoPlotView} from './PlotHipsTask';
 import {dispatchChangeCenterOfProjection, dispatchChangeHiPS} from '../ImagePlotCntlr';
+import {getMatchingRotationAngle} from '../VisUtil';
 
 
 export function* watchForCompletedPlot(options, dispatch, getState) {
@@ -257,30 +258,13 @@ function zoomToLevel(plot, newZoomLevel) {
 function rotateToMatch(pv, masterPv) {
     const plot= primePlot(pv);
     const masterPlot= primePlot(masterPv);
-    if (!plot) return;
-    const masterRot= masterPv.rotation * (masterPv.flipY ? -1 : 1);
-    let targetRotation;
-    const rot=getRotationAngle(plot);
-    if (isEastLeftOfNorth(masterPlot)) {
-        targetRotation= ((getRotationAngle(masterPlot)+  masterRot)  - rot) * (masterPv.flipY ? 1 : -1);
-    }
-    else {
-        targetRotation= ((getRotationAngle(masterPlot)+  (360-masterRot))  - rot) * (masterPv.flipY ? 1 : -1);
-
-    }
-    if (!isCsysDirMatching(plot,masterPlot)) targetRotation= 360-targetRotation;
-    if (targetRotation<0) targetRotation+= 360;
+    if (!plot || !masterPlot) return;
     dispatchRotate({
-        plotId: plot.plotId,
+        plotId: pv.plotId,
         rotateType: RotateType.ANGLE,
-        angle: targetRotation,
+        angle: getMatchingRotationAngle(masterPv,pv),
         actionScope: ActionScope.SINGLE,
     });
-}
-
-
-function isCsysDirMatching(p1,p2) {
-    return isEastLeftOfNorth(p1)===isEastLeftOfNorth(p2);
 }
 
 

--- a/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
+++ b/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
@@ -14,9 +14,9 @@ import {dispatchCreateDrawLayer,
 
 
 export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,visible,
-                                            plotTypeMustMatch= false, style={},
+                                            plotTypeMustMatch= false, style={}, enabled= true,
                                             todo= false, isIconOn, onClick, dropDown, allPlots= true }) {
-    const enabled= Boolean(primePlot(pv));
+    const enableButton= Boolean(primePlot(pv)) && enabled;
     let isOn= isIconOn;
     if (typeId && pv) {
         const distLayer= getDrawLayerByType(getDlAry(),typeId);
@@ -27,7 +27,7 @@ export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,vi
         return (
             <DropDownToolbarButton  icon={iconOff}
                                     tip='Select an area for cropping or statistics'
-                                    enabled={enabled}
+                                    enabled={enableButton}
                                     horizontal={true}
                                     visible={visible}
                                     dropDown={dropDown} />
@@ -37,7 +37,7 @@ export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,vi
         return (
             <ToolbarButton icon={isOn ? iconOn : iconOff}
                            tip={tip}
-                           enabled={enabled}
+                           enabled={enableButton}
                            horizontal={true}
                            visible={visible}
                            todo={todo}
@@ -60,6 +60,7 @@ SimpleLayerOnOffButton.propTypes= {
     allPlots: PropTypes.bool,
     plotTypeMustMatch: PropTypes.bool,
     dropDown: PropTypes.object,
+    enabled: PropTypes.bool,
     style : PropTypes.object,
 };
 

--- a/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
+++ b/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
@@ -14,7 +14,7 @@ import {dispatchCreateDrawLayer,
 
 
 export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,visible,
-                                            plotTypeMustMatch= false,
+                                            plotTypeMustMatch= false, style={},
                                             todo= false, isIconOn, onClick, dropDown, allPlots= true }) {
     const enabled= Boolean(primePlot(pv));
     let isOn= isIconOn;
@@ -41,6 +41,7 @@ export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,vi
                            horizontal={true}
                            visible={visible}
                            todo={todo}
+                           style={style}
                            onClick={() => onClick ? onClick(pv,!isOn) : onOff(pv,typeId,allPlots,plotTypeMustMatch,todo)}/>
         );
     }
@@ -58,7 +59,8 @@ SimpleLayerOnOffButton.propTypes= {
     isIconOn : PropTypes.bool,
     allPlots: PropTypes.bool,
     plotTypeMustMatch: PropTypes.bool,
-    dropDown: PropTypes.object
+    dropDown: PropTypes.object,
+    style : PropTypes.object,
 };
 
 SimpleLayerOnOffButton.defaultProps= {

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -71,6 +71,7 @@ import STRETCH from 'html/images/icons-2014/28x28_Log.png';
 import MARKER from 'html/images/icons-2014/MarkerCirclesIcon_28x28.png';
 import {MatchLockDropDown} from './MatchLockDropDown';
 import {ImageCenterDropDown} from './ImageCenterDropDown';
+import {hasWCSProjection} from '../PlotViewUtil';
 
 export const VIS_TOOLBAR_HEIGHT=34;
 export const VIS_TOOLBAR_V_HEIGHT=48;
@@ -222,6 +223,7 @@ export class VisToolbarView extends PureComponent {
                 <SimpleLayerOnOffButton plotView={pv}
                                         isIconOn={pv&&plot ? pv.plotViewCtx.rotateNorthLock : false }
                                         tip='Rotate this image so that North is up'
+                                        enabled={hasWCSProjection(pv)}
                                         iconOn={ROTATE_NORTH_ON}
                                         iconOff={ROTATE_NORTH_OFF}
                                         visible={mi.rotateNorth && image}


### PR DESCRIPTION
Firefly-179: Fixed right-east align and align w/rotation issues
 
  - right-east image align now work
   - fixed issue with aligning to rotated images
   - fixed align left-east with right-east image
   - clean up of rotation dialog: (fixes some issues in FIREFLY-146)
        - fixed multiple issues with rotation dialog and improved it.
        - now does immediate results
        - operates on active image.
        - has a north up button
        - show active images's rotation
        - Added slider
        - rotation dialog hides when all image removed
 
https://jira.ipac.caltech.edu/browse/FIREFLY-179

_To Test:_

 https://irsawebdev9.ipac.caltech.edu/firefly-179-wcs-match-bug/firefly/

  - load two images at same target (i.e. 2mass, wise), rotate one then match the other to it. Check that they scroll around together
  - load two east-right images (firefly_test_data/east-right-images)
  - you should be able to match them
  - load two east-right images, rotate one, then match
  - load a each right image from `firefly_test_data/east-right-images` then load a wise at 
`3h32m02.85s, -27d26m20.7s`, 792 arcsec.  try matching.
   - bring up the updated rotation dialog and play with it after loading a set of images.

