### PR TITLE
Firefly 259 filter bug

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -373,7 +373,8 @@ export function getDataChangesForMappings({tableModel, mappings, traceNum}) {
     if (tableModel) {
         const cols = tableModel.tableData.columns.map((c) => c.name);
         const transposed = tableModel.tableData.columns.map(() => []);
-        tableModel.tableData.data.forEach((r) => {
+        const data = get(tableModel, 'tableData.data', []);
+        data.forEach((r) => {
             r.map((e, idx) => transposed[idx].push(e));
         });
         // tableModel columns are named as the paths to the trace arrays

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -859,8 +859,8 @@ export function dispatchError(chartId, traceNum, reason) {
     // } else if (reasonStr.match(/same column/)) {
     //     message = 'The columns requested are identical or one of them is not numerical.';
     //     reasonStr = reason;
-    } else if (reasonStr.match(/null/)){
-        message = `No data available: ${name} data`;
+    } else if (reasonStr.match(/no data/) || reasonStr.match(/null/)){
+        message = `No data available${forTrace}`;
         reasonStr = '';
     } else {
         reasonStr = '';

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -93,6 +93,8 @@ function fetchData(chartId, traceNum, tablesource) {
                 dispatchChartUpdate({chartId, changes});
                 updateHighlighted(chartId, traceNum, highlightedRow);
                 updateSelected(chartId, selectInfo);
+            } else {
+                dispatchError(chartId, traceNum, 'No data');
             }
         }
     ).catch(

--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -106,6 +106,8 @@ function fetchData(chartId, traceNum, tablesource) {
             dispatchChartUpdate({chartId, changes});
 
             // TODO: what should happen on table highlight or cell click?
+        } else {
+            dispatchError(chartId, traceNum, 'No data');
         }
     }).catch(
         (reason) => {

--- a/src/firefly/js/charts/dataTypes/FireflyHistogram.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHistogram.js
@@ -83,6 +83,9 @@ function fetchData(chartId, traceNum, tablesource) {
             if (tableModel.error) {
                 dispatchError(chartId, traceNum, tableModel.error);
                 return;
+            } else if (!get(tableModel, 'tableData.data')) {
+                dispatchError(chartId, traceNum, 'No data');
+                return;
             }
 
             let histogramData = [];

--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -540,6 +540,7 @@ function doFilter(dl,p,sel, selectedShape) {
 
     const tbl= getTblById(dl.tblId);
     if (!tbl) return;
+    const tableDataLength = dl.tableData.data.length;
     const filterInfo = get(tbl, 'request.filters');
     const filterInfoCls = FilterInfo.parse(filterInfo);
     let filter;
@@ -548,19 +549,23 @@ function doFilter(dl,p,sel, selectedShape) {
     const decimateIdx= findColIdx(dl.tableData.columns,'decimate_key');
     if (decimateIdx>1 && dl.tableMeta['decimate_key']) {
         const idxs= getSelectedPts(sel, p, dl.drawData.data, selectedShape)
+            .filter((idx) => idx < tableDataLength)
             .map( (idx) => `'${dl.tableData.data[idx][decimateIdx]}'`);
         filter= `IN (${idxs.toString()})`;
         filterInfoCls.addFilter(dl.tableMeta['decimate_key'], filter);
         newRequest = {tbl_id: tbl.tbl_id, filters: filterInfoCls.serialize()};
         dispatchTableFilter(newRequest);
-        console.log(newRequest);
-        console.log(idxs);
+        //console.log(newRequest);
+        //console.log(idxs);
     }
     else {
         const rowidIdx= findColIdx(dl.tableData.columns,'ROW_IDX');
-        let idxs= getSelectedPts(sel, p, dl.drawData.data, selectedShape);
-        idxs = rowidIdx < 0 ? idxs : idxs.map( (idx) => get(dl,`tableData.data[${idx}][${rowidIdx}]`) );
-        filter= `IN (${idxs.length === 0 ? -1 : idxs.toString()})`;     //  ROW_IDX is always positive.. use -1 to force no row selected 
+        let idxs= getSelectedPts(sel, p, dl.drawData.data, selectedShape)
+            .filter((idx) => idx < tableDataLength);
+        if (rowidIdx >= 0) {
+            idxs = idxs.map( (idx) => get(dl,`tableData.data[${idx}][${rowidIdx}]`) );
+        }
+        filter= `IN (${idxs.length === 0 ? -1 : idxs.toString()})`;     //  ROW_IDX is always positive.. use -1 to force no row selected
         filterInfoCls.setFilter('ROW_IDX', filter);
         newRequest = {tbl_id: tbl.tbl_id, filters: filterInfoCls.serialize()};
         dispatchTableFilter(newRequest);


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-259
Test build: https://irsawebdev9.ipac.caltech.edu/firefly-259_filterBug/firefly/

- Fixed a bug which was indirectly introduced by firefly-88: a list of drawing drawing objects for a catalog overlay now can have extra objects (like search center), which do not correspond to catalog table rows. These objects should be excluded when filter by ROW_IDX is constructed. 
To test, select on image a subset of points that includes search center and use filter button.

- Also fixed non-returning spinning wheel in charts when there are no data. To test, select an empty area on image and filter or filter from the table with such constraints that no data are left. An error message "No data available" should show up for the related charts. 

