### PR TITLE
FIREFLY-185: 3-image composition doesn't work

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -278,9 +278,6 @@ public class VisJsonSerializer {
         BandState bandStateAry[]= s.getBandStateAry();
         if (s.isThreeColor()) {
             JSONArray list = new JSONArray();
-            for(BandState bs : bandStateAry) {
-                list.add((bs==null || (!bs.hasRequest() && bs.getOriginalFitsFileStr()==null)) ? null : serializeBandState(bs));
-            }
             for(int i= 0; (i< bandStateAry.length); i++) {
                 list.add((bandStateAry[i]==null || (!bandStateAry[i].hasRequest() && bandStateAry[i].getOriginalFitsFileStr()==null)) ?
                         null : serializeBandState(bandStateAry[i]));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
@@ -270,16 +270,18 @@ public class WebPlotFactory {
 
 
         List<RelatedData> rdList= pInfo.getRelatedData();
-        int cubePlane= headerAry[NO_BAND.getIdx()].getIntValue("SPOT_PL",-1);
-        if (cubePlane==0) state.setCubePlaneNumber(0,NO_BAND);
-
-        if (!state.isThreeColor() && cubePlane>0) {  // have a cube
-            state.setCubePlaneNumber(cubePlane,NO_BAND);
-            headerAry= null;
-            rdList= null;
-            dataWidth= -1;
-            dataHeight= -1;
-            imageCoordSys= null;
+        if (!state.isThreeColor()) {
+            int cubePlane = headerAry[NO_BAND.getIdx()].getIntValue("SPOT_PL", -1);
+            if (cubePlane>=0) {
+                state.setCubePlaneNumber(cubePlane,NO_BAND);
+                if (cubePlane>0) {  // have a cube
+                    headerAry = null;
+                    rdList = null;
+                    dataWidth = -1;
+                    dataHeight = -1;
+                    imageCoordSys = null;
+                }
+            }
         }
 
         if (clearHeaderData) {

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -405,15 +405,13 @@ export const WebPlot= {
         }
         const zf= plotState.getZoomLevel();
 
+        // because of history we keep directFileAccessData in the plot state, however now we compute it on the client
+        // also- we need to keep a copy in plotState for backward compatability and in the plot to put in back in the plotState
+        // when a new one is generated
         for(let i= 0; (i<3); i++) {
             if (headerAry[i]) plotState.get(i).directFileAccessData= makeDirectFileAccessData(headerAry[i], cubeCtx?cubeCtx.cubePlane:-1);
         }
-
-        //original plot state come with header information for getting flux.
-        // this is only need for one call, so most time we strip it out.
-        // keeping clientFitsHeaderAry allows a way to put back the original
-        //todo: i think is could be cached on the server side so we don't need to be send it back and forth
-        const directFileAccessDataAry= plotState.getBands().map( (b) => plotState.getDirectFileAccessData(b));
+        const directFileAccessDataAry= plotState.bandStateAry.map( (bs) => bs.directFileAccessData);
 
         const imageCoordSys= cubeCtx ? cubeCtx.imageCoordSys : wpInit.imageCoordSys;
         let plot= makePlotTemplate(plotId,'image',asOverlay, CoordinateSys.parse(imageCoordSys));

--- a/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
+++ b/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
@@ -98,6 +98,7 @@ const SGAL = 3;
 
 export function parseSpacialHeaderInfo(header, altWcs='', zeroHeader) {
 
+    if (!header) return {};
 
     let ctype1_trim = '';
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-185
Test deployment: https://irsawebdev9.ipac.caltech.edu/firefly-185-3color/firefly/

Fixed two bugs related to 3-color: 
1) exception described in the ticket (when less than 3 bands are used) 
2) no image (server-side) failure when red band is not used

Two test, create a 3-color image with 1 or 2 bands, with and without red.