### PR TITLE
IRSA-3044: fixed image bugs found in SOFIA

### DIFF
--- a/config/ehcache.xml
+++ b/config/ehcache.xml
@@ -479,7 +479,7 @@
      The data store in this cache is large.  it will NOT be replicated.
     -->
     <cache name="VISUALIZE"
-           maxElementsInMemory="30000"
+           maxElementsInMemory="150000"
            eternal="false"
            timeToIdleSeconds="7200"
            memoryStoreEvictionPolicy="LRU"

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/resources/ehcache.xml
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/resources/ehcache.xml
@@ -467,7 +467,7 @@
      The data store in this cache is large.  it will NOT be replicated.
     -->
     <cache name="VISUALIZE"
-           maxElementsInMemory="30000"
+           maxElementsInMemory="150000"
            eternal="false"
            timeToIdleSeconds="7200"
            memoryStoreEvictionPolicy="LRU"

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -76,7 +76,7 @@ function FitsRotationImmediatePanel() {
     if (!pv) return (<div style={{whiteSpace:'nowrap', padding:'10px 35px'}}>No Image Loaded</div>);
 
     return (
-        <div>
+        <div className={'disable-select'}>
             <div style={{padding: '25px 20px 10px 20px'}}>
                 <div style={{display:'flex', flexDirection: 'column', alignItems:'center',
                                       justifyContent:'space-between', padding: '0 3px'}}>

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -63,6 +63,12 @@ export const PlotAttribute= {
     FIXED_TARGET: 'FIXED_TARGET',
 
     /**
+     * a WorldPt
+     * if defined overrides FIXED_TARGET.
+     */
+    CENTER_ON_FIXED_TARGET: 'CENTER_ON_FIXED_TARGET',
+
+    /**
      *
      */
     INIT_CENTER: 'INIT_CENTER',
@@ -415,6 +421,8 @@ export const WebPlot= {
 
         const imageCoordSys= cubeCtx ? cubeCtx.imageCoordSys : wpInit.imageCoordSys;
         let plot= makePlotTemplate(plotId,'image',asOverlay, CoordinateSys.parse(imageCoordSys));
+        const dataWidth= cubeCtx ? cubeCtx.dataWidth : wpInit.dataWidth;
+        const dataHeight= cubeCtx ? cubeCtx.dataHeight : wpInit.dataHeight;
 
         const imagePlot= {
             tileData    : wpInit.initImages,
@@ -429,14 +437,14 @@ export const WebPlot= {
             wlData,
             allWCSMap,
             allWlMap,
-            dataWidth       : cubeCtx ? cubeCtx.dataWidth : wpInit.dataWidth,
-            dataHeight      : cubeCtx ? cubeCtx.dataHeight : wpInit.dataHeight,
+            dataWidth,
+            dataHeight,
             title : '',
             plotDesc        : wpInit.desc,
             dataDesc        : wpInit.dataDesc,
             webFitsData     : isArray(wpInit.fitsData) ? wpInit.fitsData : [wpInit.fitsData],
             //=== Mutable =====================
-            screenSize: {width:wpInit.dataWidth*zf, height:wpInit.dataHeight*zf},
+            screenSize: {width:dataWidth*zf, height:dataHeight*zf},
             zoomFactor: zf,
             attributes,
             directFileAccessDataAry

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -355,7 +355,11 @@ function continuePlotImageSuccess(dispatcher, payload, successAry, failAry) {
             detailFailReason: data.detailFailReason,
             plotId: data.plotId,
         };
-        dispatcher( { type: ImagePlotCntlr.PLOT_IMAGE_FAIL, payload:failPayload} );
+        const pv= getPlotViewById(visRoot(),data.plotId);
+        if (pv && pv.request && pv.request.getRequestKey()===data.requestKey) {
+            dispatcher( { type: ImagePlotCntlr.PLOT_IMAGE_FAIL, payload:failPayload} );
+        }
+
     });
 }
 

--- a/src/firefly/js/visualize/ui/WorldPtFormat.jsx
+++ b/src/firefly/js/visualize/ui/WorldPtFormat.jsx
@@ -51,6 +51,21 @@ export function formatWorldPtToString(wp,addNewLIne=false) {
     }
 }
 
+export function formatWorldPtToStringSimple(wp) {
+    if (!isValidPoint(wp)) return '';
+    if (wp.objName) return wp.objName;
+    if (wp.type!==Point.W_PT) return `${wp.x}, ${wp.y}`;
+    const lonStr = numeral(wp.getLon()).format('#.0[00000]');
+    const latStr = numeral(wp.getLat()).format('#.0[00000]');
+    const hmsRa = CoordUtil.convertLonToString(wp.getLon(), wp.getCoordSys());
+    const hmsDec = CoordUtil.convertLatToString(wp.getLat(), wp.getCoordSys());
+    const csys = coordToString(wp.getCoordSys());
+
+    const coordStr= `${lonStr}, ${latStr}  or   ${hmsRa}, ${hmsDec} ${csys}`;
+    return coordStr;
+
+}
+
 export function formatLonLatToString(wp) {
     if (!isValidPoint(wp)) return '';
     if (wp.type!==Point.W_PT) return `${wp.x}, ${wp.y}`;


### PR DESCRIPTION
IRSA-3044: fixed image bugs found in SOFIA

  - Will now load 60,000 images from cube
  - Fixed: fail of big image after a good load showing the fail message
  - Fixed: later cube screen size not getting initialized in certain cases
  - Changed ImageCenterDropDown "center on target" with coverage (Firefly-180)
    - If all the catalogs have the same target I will enable it
          (sofia case or case where you search m31 with multiple catalogs).
          If the catalogs don’t have the same target
          I will disable it and the use will use the layer control

https://jira.ipac.caltech.edu/browse/IRSA-3044

_to test:_

 https://irsawebdev9.ipac.caltech.edu/irsa-3044-various-sofia-issues/firefly/
 https://irsawebdev9.ipac.caltech.edu/irsa-3044-various-sofia-issues/applications/sofia/