### PR TITLE
IRSA-2271: Add support for array types to DataGroup

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -33,7 +33,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
     private static Logger.LoggerImpl LOGGER = Logger.getLogger();
     private static EmbeddedDbStats dbStats = new EmbeddedDbStats();
 
-    private static final String DD_INSERT_SQL = "insert into %s_dd values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+    private static final String DD_INSERT_SQL = "insert into %s_dd values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
     private static final String DD_CREATE_SQL = "create table %s_dd "+
             "(" +
             "  cname    varchar(64000)" +
@@ -58,6 +58,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
             ", minValue varchar(64000)" +
             ", links    other" +
             ", dataOptions varchar(64000)" +
+            ", arraySize varchar(64000)" +
             ")";
 
     private static final String META_INSERT_SQL = "insert into %s_meta values (?,?,?)";
@@ -97,7 +98,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
         tblName = StringUtils.isEmpty(tblName) ? MAIN_DB_TBL : tblName;
         List<String> coldefs = new ArrayList<>();
         for(DataType dt : dtTypes) {
-            coldefs.add( String.format("\"%s\" %s", dt.getKeyName(), getDataType(dt)));       // add quotes to avoid reserved words clashes
+            coldefs.add( String.format("\"%s\" %s", dt.getKeyName(), toDbDataType(dt)));       // add quotes to avoid reserved words clashes
         }
 
         return String.format("create table %s (%s)", tblName, StringUtils.toString(coldefs, ","));
@@ -187,7 +188,9 @@ abstract public class BaseDbAdapter implements DbAdapter {
         return false;
     }
 
-    public String getDataType(DataType dataType) {
+    public String toDbDataType(DataType dataType) {
+        if (dataType.getArraySize() != null) return "other";
+
         Class type = dataType.getDataType();
         if (String.class.isAssignableFrom(type)) {
             return dataType.getTypeDesc().equals(DataType.LONG_STRING) ? "longvarchar" : "varchar(64000)";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
@@ -71,7 +71,7 @@ public interface DbAdapter {
      * @param type
      * @return this database's datatype representation of the given java class.
      */
-    String getDataType(DataType type);
+    String toDbDataType(DataType type);
 
     /**
      * @return true if transaction should be used during batch import of the table data.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -416,6 +416,7 @@ public class EmbeddedDbUtil {
                             dt.getMinValue(),
                             dt.getLinkInfos(),
                             dt.getDataOptions(),
+                            dt.getArraySize()
                     }
             );
         }
@@ -455,6 +456,7 @@ public class EmbeddedDbUtil {
                 applyIfNotEmpty(rs.getString("minValue"), dtype::setMinValue);
                 applyIfNotEmpty(rs.getObject("links"), v -> dtype.setLinkInfos((List<LinkInfo>) v));
                 applyIfNotEmpty(rs.getString("dataOptions"), dtype::setDataOptions);
+                applyIfNotEmpty(rs.getString("arraySize"), dtype::setArraySize);
 
             } while (rs.next());
         } catch (SQLException e) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
@@ -80,7 +80,8 @@ public class AnyFileUpload extends BaseHttpServlet {
             // from a URL.. get it
             int idx = fromUrl.lastIndexOf('/');
             String fname = (idx >= 0) ? fromUrl.substring(idx + 1) : fromUrl;
-            File tmpFile = File.createTempFile("upload_", fname, ServerContext.getUploadDir());
+            fname = fname.contains("?") ? fname.substring(0, fname.indexOf("?")) : fname;       // don't save queryString as file name.  this will confuse reader expecting a url, like VoTableReader
+            File tmpFile = File.createTempFile("upload_", "-" + fname, ServerContext.getUploadDir());
             FileInfo status = URLDownload.getDataToFile(new URL(fromUrl), tmpFile);
             if (status != null && !(status.getResponseCodeMsg().equals("OK"))) {
                 throw new Exception("invalid upload from URL: " + status.getResponseCodeMsg());

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -472,19 +472,23 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
         if (dataList == null) {
             DataType dt = getDataDefintion(cname);
             if (dt != null) {
-                Class clz = dt.getDataType();
-                if (clz == Double.class) {
-                    dataList = new PrimitiveList.Doubles();
-                } else if (clz == Float.class) {
-                    dataList = new PrimitiveList.Floats();
-                } else if (clz == Long.class) {
-                    dataList = new PrimitiveList.Longs();
-                } else if (clz == Integer.class) {
-                    dataList = new PrimitiveList.Integers();
-                } else if (clz == Boolean.class) {
-                    dataList = new PrimitiveList.Booleans();
+                if (dt.getArraySize() != null) {
+                    dataList =  new PrimitiveList.Objects();
                 } else {
-                    dataList = new PrimitiveList.Objects();
+                    Class clz = dt.getDataType();
+                    if (clz == Double.class) {
+                        dataList = new PrimitiveList.Doubles();
+                    } else if (clz == Float.class) {
+                        dataList = new PrimitiveList.Floats();
+                    } else if (clz == Long.class) {
+                        dataList = new PrimitiveList.Longs();
+                    } else if (clz == Integer.class) {
+                        dataList = new PrimitiveList.Integers();
+                    } else if (clz == Boolean.class) {
+                        dataList = new PrimitiveList.Booleans();
+                    } else {
+                        dataList = new PrimitiveList.Objects();
+                    }
                 }
                 data.put(cname, dataList);
             }

--- a/src/firefly/java/edu/caltech/ipac/table/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataType.java
@@ -73,6 +73,16 @@ public class DataType implements Serializable, Cloneable {
     private       String minValue = "";
     private       String dataOptions;
 
+    /**
+     * follows section 2.2. of the "VOTable Format Definition" convention where arraySize can be
+     *      '*': variable length
+     *      'n': where n is an integer corresponding to the fixed length of the array
+     *      'n*': array with length of 0 to n
+     *      'nxnxn*' : multidimensional array where the last dimension may be variable, ie. 64x64x5
+     *  the data will be stored as a single array.  The information in arraySize can be used to "fold/unfold" the value.
+     */
+    private       String   arraySize;
+
     private transient Boolean isFloatingPoint;      // cached to improve formatting performance.
     private transient Boolean isWholeNumber;        // cached to improve formatting performance.
 
@@ -288,6 +298,11 @@ public class DataType implements Serializable, Cloneable {
     public String getDataOptions() { return dataOptions; }
 
     public void setDataOptions(String options) {this.dataOptions = options;}
+
+    public String getArraySize() { return arraySize; }
+
+    public void setArraySize(String arraySize) { this.arraySize = arraySize; }
+
     /**
      * Firefly has 3 metas that affect the formatting of the column's data.  They are
      * listed below in order of highest to lowest precedence.
@@ -306,6 +321,10 @@ public class DataType implements Serializable, Cloneable {
      */
     public String format(Object value, boolean replaceCtrl) {
         if (value == null) return getNullString();
+
+        if (getArraySize() != null) {
+            return String.format("%s [%s]", getTypeDesc(), getArraySize());
+        }
 
         // do escaping if requested
         if (replaceCtrl && type == String.class) {

--- a/src/firefly/java/edu/caltech/ipac/table/ParamInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/table/ParamInfo.java
@@ -9,8 +9,8 @@ public class ParamInfo extends DataType implements Serializable, Cloneable {
 
     private String value;
 
-    public ParamInfo(String name, Class clz) {
-        this(name, clz, null);
+    public ParamInfo() {
+        this(null, null, null);
     }
 
     public ParamInfo(String keyName, Class type, String value) {

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -33,9 +33,9 @@ public class TableUtil {
         if (format == Format.IPACTABLE) {
             return IpacTableReader.read(inf);
         } else if (format == Format.VO_TABLE) {
-            DataGroup[] tables = VoTableReader.voToDataGroups(inf.getAbsolutePath());
-            if (tables.length > tableIndex) {
-                return tables[tableIndex];
+            DataGroup[] tables = VoTableReader.voToDataGroups(inf.getAbsolutePath(), tableIndex);
+            if (tables.length > 0) {
+                return tables[0];
             } else return null;
         } else if (format == Format.CSV || format == Format.TSV) {
             return DsvTableIO.parse(inf, format.type);

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -72,7 +72,7 @@ public class VoTableReader {
             List<Integer> indicesList = indices == null ? null : CollectionUtil.asList(indices);
             List<TableElement> tableAry = getAllTableElements( location, null);
             for (int i = 0; i < tableAry.size(); i++) {
-                if (indices == null || indicesList.contains(i)) {
+                if (indices == null || indices.length == 0 || indicesList.contains(i)) {
                     TableElement tableEl = tableAry.get(i);
                     DataGroup dg = convertToDataGroup(tableEl, new VOStarTable(tableEl), headerOnly);
                     groups.add(dg);

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -5,14 +5,12 @@ package edu.caltech.ipac.table.io;
 
 import edu.caltech.ipac.firefly.core.FileAnalysis;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.table.*;
-import edu.caltech.ipac.util.FitsHDUUtil;
-import edu.caltech.ipac.util.StringUtils;
-import org.json.simple.JSONObject;
+import edu.caltech.ipac.util.CollectionUtil;
 import org.xml.sax.SAXException;
 import uk.ac.starlink.table.*;
 import uk.ac.starlink.votable.*;
-import uk.ac.starlink.util.DOMUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +18,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
@@ -34,6 +33,13 @@ import static uk.ac.starlink.table.StoragePolicy.PREFER_MEMORY;
  */
 public class VoTableReader {
 
+    private static final String ID = "ID";
+    private static final String REF = "ref";
+    private static final String UCD = "ucd";
+    private static final String UTYPE = "utype";
+    private static final String NAME = "name";
+
+
     private static final Pattern HMS_UCD_PATTERN =
             Pattern.compile( "POS_EQ_RA.*|pos\\.eq\\.ra.*",
                     Pattern.CASE_INSENSITIVE );
@@ -41,37 +47,39 @@ public class VoTableReader {
             Pattern.compile( "POS_EQ_DEC.*|pos\\.eq\\.dec.*",
                     Pattern.CASE_INSENSITIVE );
 
+    private static Logger.LoggerImpl LOG = Logger.getLogger();
+
     /**
      * returns an array of DataGroup from a vo table.
      * @param location  location of the vo table data source using automatic format detection.  Can be file or url.
      * @return an array of DataGroup objects
      */
-    public static DataGroup[] voToDataGroups(String location) throws IOException {
-        try {
-            return voToDataGroups(location, false);
-        } catch (DataAccessException e) {
-            throw new IOException(e.getMessage());
-        }
+    public static DataGroup[] voToDataGroups(String location, int ...indices) throws IOException {
+        return voToDataGroups(location, false, indices);
     }
 
     /**
      * returns an array of DataGroup from a votable file.
      * @param location  location of the votable data source using automatic format detection.  Can be file or url.
      * @param headerOnly  if true, returns only the headers, not the data.
+     * @param indices   only return table from this list of indices
      * @return an array of DataGroup object
      */
-    public static DataGroup[] voToDataGroups(String location, boolean headerOnly) throws IOException, DataAccessException {
+    public static DataGroup[] voToDataGroups(String location, boolean headerOnly, int ...indices) throws IOException {
         List<DataGroup> groups = new ArrayList<>();
 
         try {
-
-            List<TableElement> tableAry = getTableElementsFromFile( location, null);
-            for ( TableElement tableEl : tableAry ) {
-                DataGroup dg = convertToDataGroup(tableEl, new VOStarTable(tableEl), headerOnly);
-                groups.add(dg);
+            List<Integer> indicesList = indices == null ? null : CollectionUtil.asList(indices);
+            List<TableElement> tableAry = getAllTableElements( location, null);
+            for (int i = 0; i < tableAry.size(); i++) {
+                if (indices == null || indicesList.contains(i)) {
+                    TableElement tableEl = tableAry.get(i);
+                    DataGroup dg = convertToDataGroup(tableEl, new VOStarTable(tableEl), headerOnly);
+                    groups.add(dg);
+                }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e);
             throw new IOException(e.getMessage());
         }
 
@@ -85,315 +93,21 @@ public class VoTableReader {
             VOElement top = voFactory.makeVOElement(inputStream, null);
             return getQueryStatusError(top);
         }  catch (SAXException |IOException e) {
-            e.printStackTrace();
+            LOG.error(e);
             throw new DataAccessException("unable to parse " + location + "\n"+
                     e.getMessage(), e);
         }
     }
 
-    public static final String ID = "ID";
-    public static final String REF = "ref";
-    public static final String UCD = "ucd";
-    public static final String UTYPE = "utype";
-    public static final String DESC = "desc";
-    public static final String NAME = "name";
 
-    private static String getElementAttribute(VOElement element, String attName) {
-        return element.hasAttribute(attName) ? element.getAttribute(attName) : null;
-    }
-
-    // root VOElement for a votable file
-    private static VOElement getVOElementFromVOTable(String location, StoragePolicy policy) throws DataAccessException {
-        try {
-            policy = policy == null ? PREFER_MEMORY : policy;
-            VOElementFactory voFactory =  new VOElementFactory();
-            voFactory.setStoragePolicy(policy);
-            return voFactory.makeVOElement(location);
-        }  catch (SAXException |IOException e) {
-            e.printStackTrace();
-            throw new DataAccessException("unable to parse "+ location + "\n" +
-                    e.getMessage(), e);
-        }
-    }
-
-    // get all <RESOURCE> under VOTable root or <RESOURCE>
-    private static VOElement[] getResourceChildren(VOElement parent) {
-        return parent.getChildrenByName( "RESOURCE" );
-    }
-
-    // get all <TABLE> children under <RESOURCE>
-    private static VOElement[] getTableChildren(VOElement parent) {
-        return parent.getChildrenByName( "TABLE" );
-    }
-
-    // get all <GROUP> under <TABLE>
-    private static VOElement[] getGroupsFromTable(TableElement tableEl) {
-        return tableEl.getChildrenByName("GROUP");
-    }
-
-    // get all <LINK> under <TABLE>
-    private static LinkElement[] getLinksFromTable(TableElement tableEl) {
-        return tableEl.getLinks();
-    }
-
-    // get all <PARAM> under <TABLE>
-    private  static VOElement[] getParamsFromTable(TableElement tableEl) {
-        return tableEl.getChildrenByName("PARAM");
-    }
-
-    // get all <INFO> under <TABLE>
-    private static VOElement[] getInfoElementsFromTable(TableElement tableEl) {
-        return tableEl.getChildrenByName("INFO");
-
-    }
-
-    // get all <FIELD> under <TABLE>
-    private static FieldElement[] getFieldsFromTable(TableElement tableEl) {
-        return tableEl.getFields();
-    }
-
-    // get all <LINK> from <FIELD>
-    private static VOElement[] getLinksFromField(FieldElement fieldEl) {
-        // VOElement -> LinkElement
-        VOElement[] voLinkAry = fieldEl.getChildrenByName("LINK");
-        VOElement[] links = new LinkElement[voLinkAry.length];
-        System.arraycopy(voLinkAry, 0, links, 0, voLinkAry.length);
-
-        return links;
-    }
-
-    // convert <GROUP>s under <TABLE> to a list of GroupInfo and add it to the associatede table (a DataGroup object)
-    private static List<GroupInfo> makeGroupInfosFromTable(TableElement tableEl) {
-        VOElement[] groupAry = getGroupsFromTable(tableEl);
-        List<GroupInfo> groupObjAry = new ArrayList<>();
-
-        for (VOElement group : groupAry) {
-            String name = group.getName();
-            String desc = group.getDescription();
-
-            GroupInfo gObj = new GroupInfo(name, desc);
-            gObj.setID(getElementAttribute(group, ID));
-
-            // add FIELDref
-            Arrays.stream(group.getChildrenByName("FIELDref"))
-                    .forEach(pEl -> gObj.getColumnRefs().add(refInfoFromEl(pEl)));
-
-            // add PARAMrefs
-            Arrays.stream(group.getChildrenByName("PARAMref"))
-                    .forEach(pEl -> gObj.getParamRefs().add(refInfoFromEl(pEl)));
-
-            // add PARAMs
-            Arrays.stream(group.getChildrenByName("PARAM"))
-                .forEach(pEl -> gObj.getParamInfos().add(paramInfoFromEl(pEl)));
-
-            groupObjAry.add(gObj);
-        }
-        return groupObjAry;
-    }
-
-    // convert LinkElement to LinkInfo
-    private static LinkInfo linkElementToLinkInfo(VOElement el) {
-        if (el == null) return null;
-        LinkInfo li = new LinkInfo();
-        applyIfNotEmpty(el.getAttribute(ID), li::setID);
-        applyIfNotEmpty(el.getAttribute("content-role"), li::setRole);
-        applyIfNotEmpty(el.getAttribute("content-type"), li::setType);
-        applyIfNotEmpty(el.getAttribute("title"), li::setTitle);
-        applyIfNotEmpty(el.getAttribute("href"), li::setHref);
-        applyIfNotEmpty(el.getAttribute("value"), li::setValue);
-        applyIfNotEmpty(el.getAttribute("action"), li::setAction);
-        return li;
-    }
-
-    // convert <LINK>s under <TABLE> to a list of LinkInfo and add it to the associated table (a DataGroup object)
-    private static List<LinkInfo> makeLinkInfosFromTable(TableElement tableEl) {
-        VOElement[] linkAry = getLinksFromTable(tableEl);
-        List<LinkInfo> linkObjAry = new ArrayList<>();
-
-        for (VOElement link : linkAry) {
-            LinkInfo linkObj = linkElementToLinkInfo(link);
-
-            if (linkObj != null) {
-                linkObjAry.add(linkObj);
-            }
-        }
-
-        return linkObjAry;
-    }
-
-
-    // precision: "2" => "F2", "F2"=> "F2", "E3" => "E3"
-    private static String makePrecisionStr(String precisionStr) {
-        return (precisionStr.matches("^[1-9][0-9]*$")) ? ("F"+precisionStr) : precisionStr;
-    }
-
-    // convert <PARAM>s under <TABLE> to a list of <DataType> and add it to the associated table (a DataGroup object)
-    private static List<ParamInfo> makeParamsFromTable(TableElement tableEl, StarTable table) {
-
-        VOElement[] paramsEl = getParamsFromTable(tableEl);
-        List<ParamInfo> allParams = new ArrayList<>();
-
-        for (VOElement param : paramsEl) {
-            String name = getElementAttribute(param, "name");
-            DescribedValue dv = table.getParameterByName(name);
-            if (dv == null) continue;
-
-            ValueInfo vInfo = dv.getInfo();
-            Class clz = vInfo.isArray() ? String.class : vInfo.getContentClass();
-
-            // create Datatype
-            ParamInfo params = new ParamInfo(name, clz);
-            params.setUnits(vInfo.getUnitString());
-
-            if (vInfo.isArray()) params.setTypeDesc(DataType.LONG_STRING);
-
-            // set precision
-            String precisionStr = getElementAttribute(param, "precision");
-            String widthStr = getElementAttribute(param, "width");
-
-            if (precisionStr != null) {
-                precisionStr = makePrecisionStr(precisionStr);
-                params.setPrecision(precisionStr);
-            }
-
-            // set width
-            if (widthStr != null) {
-                params.setWidth(Integer.parseInt(widthStr));
-            }
-
-            // set ucd, utype and value to DataType
-            params.setUCD(getElementAttribute(param, "ucd"));
-            params.setUType(getElementAttribute(param, "utype"));
-            params.setID(getElementAttribute(param, "ID"));
-            params.setValue(getElementAttribute(param, "value"));
-            VOElement desElement = param.getChildByName("DESCRIPTION");
-            if (desElement != null) {
-                params.setDesc(DOMUtils.getTextContent(desElement));
-            }
-
-            allParams.add(params);
-        }
-        return allParams;
-    }
-
-    // get <INFO>s under <TABLE> as a list of DescribeValue
-    private static List<DescribedValue> getInfosFromTable(TableElement tableEl) {
-
-        VOElement[] infoEl = getInfoElementsFromTable(tableEl);
-        List<DescribedValue> infosAry = new ArrayList<>();
-
-        for (VOElement param : infoEl) {
-            String name = getElementAttribute(param, "name");
-            String val = getElementAttribute(param, "value");
-            if (name != null && val != null) {
-                infosAry.add(new DescribedValue(new DefaultValueInfo(name), val));
-            }
-        }
-        return infosAry;
-    }
-
-    // get the FieldElement from a TableElement per field name
-    private static FieldElement getFieldElementByName(TableElement tableEl, String name) {
-        FieldElement[] fields = getFieldsFromTable(tableEl);
-
-        for (FieldElement f : fields) {
-            if ((f.getName() != null) && (f.getName().equals(name))) {
-                return f;
-            }
-        }
-        return null;
-    }
-
-    // convert <LINK>s under <FIELD> to a list of LinkInfo and add it to the associated column (a DataType Object)
-    private static List<LinkInfo> makeLinkInfosFromField(TableElement tableEl, DataType dt) {
-        List<LinkInfo> linkObjs = new ArrayList<>();
-        FieldElement fieldEle = getFieldElementByName(tableEl, dt.getKeyName());
-
-        VOElement[] links = (fieldEle != null) ? getLinksFromField(fieldEle) : null;
-        if (links != null) {
-            for (VOElement link : links) {
-                LinkInfo linkObj = linkElementToLinkInfo(link);
-
-                if (linkObj != null) {
-                    linkObjs.add(linkObj);
-                }
-            }
-        }
-        return linkObjs;
-    }
-
-    private static String optionsToStr(String[] options) {
-        if (options != null) {
-            for (int i = 0; i < options.length; i++) {
-                options[i] = options[i].trim();
-            }
-        }
-        return StringUtils.toString(options, ",");
-    }
-
-    // add info of <VALUES> under a <FIELD> to the associated column (a DataType object)
-    // the added info includes: minimum/maximum values, options, or null string
-    private static void getValuesFromField(TableElement tableEl, DataType dt) {
-        FieldElement fieldEle = getFieldElementByName(tableEl, dt.getKeyName());
-        if (fieldEle == null) return;
-
-        ValuesElement values = fieldEle.getActualValues();
-
-        if (values != null) {
-            dt.setNullString(values.getNull());
-            dt.setMaxValue(values.getMaximum());
-            dt.setMinValue(values.getMinimum());
-
-            String[] options = values.getOptions();
-            if (options != null) {
-                dt.setDataOptions(optionsToStr(options));
-            }
-        }
-    }
-
-    // recursively collect all table element
-    private static void getTableElements(VOElement root, List<TableElement>tblAry) {
-        VOElement[] resources = getResourceChildren(root);
-
-        for (VOElement resource : resources) {
-            VOElement[] tables = getTableChildren(resource);
-
-            for (VOElement tbl : tables) {
-                TableElement tableEl = (TableElement) tbl;
-                tblAry.add(tableEl);
-            }
-
-            VOElement[] subResources = getResourceChildren(resource);
-            for (VOElement res : subResources) {
-                getTableElements(res, tblAry);
-            }
-        }
-    }
-
-    // get all <TABLE> from one votable file
-    private static List<TableElement> getTableElementsFromFile(String location, StoragePolicy policy) throws DataAccessException {
-        VOElement top = getVOElementFromVOTable(location, policy);
-
-        List<TableElement> tableAry = new ArrayList<>();
-
-        if (top != null) {
-            getTableElements(top, tableAry);
-
-            if (tableAry.size() == 0) {
-                String error = getQueryStatusError(top);
-                if (error != null) {
-                    throw new DataAccessException(error);
-                }
-            }
-        }
-
-        return tableAry;
-    }
+//====================================================================
+//
+//====================================================================
 
     private static String getQueryStatusError(VOElement top) {
         String error = null;
         // check for errors: section 4.4 of http://www.ivoa.net/documents/DALI/20170517/REC-DALI-1.1.html
-        VOElement[] resources = getResourceChildren(top);
+        VOElement[] resources = top.getChildrenByName( "RESOURCE" );
         for (VOElement r : resources) {
             if ("results".equals(r.getAttribute("type"))) {
                 VOElement[] infos = r.getChildrenByName("INFO");
@@ -418,44 +132,38 @@ public class VoTableReader {
         return error;
     }
 
-    private enum MetaInfo {
-        INDEX("Index", "Index", Integer.class, "table index"),
-        TABLE("Table", "Table", String.class, "table name"),
-        TYPE("Type", "Type", String.class, "table type");
+    // get all <TABLE> from one votable file
+    private static List<TableElement> getAllTableElements(String location, StoragePolicy policy) throws IOException {
 
-        String keyName;
-        String title;
-        Class  metaClass;
-        String description;
-
-        MetaInfo(String key, String title, Class c, String des) {
-            this.keyName = key;
-            this.title = title;
-            this.metaClass = c;
-            this.description = des;
+        VOElement root;
+        try {
+            policy = policy == null ? PREFER_MEMORY : policy;
+            VOElementFactory voFactory =  new VOElementFactory();
+            voFactory.setStoragePolicy(policy);
+            root = voFactory.makeVOElement(location);
+        }  catch (SAXException | IOException e) {
+            throw new IOException("unable to parse "+ location + "\n" +
+                    e.getMessage(), e);
         }
 
-        List<Object> getInfo() {
-            return Arrays.asList(keyName, title, metaClass, description);
+        List<TableElement> tableAry = new ArrayList<>();
+        if (root != null) {
+            Arrays.stream(root.getChildrenByName("RESOURCE"))
+                    .forEach( res -> {
+                        Arrays.stream(res.getChildrenByName("TABLE"))
+                                .forEach(table -> tableAry.add((TableElement) table));
+                    });
+
+            if (tableAry.size() == 0) {
+                String error = getQueryStatusError(root);
+                if (error != null) {
+                    throw new IOException(error);
+                }
+            }
         }
 
-        String getKey() {
-            return keyName;
-        }
-
-        String getTitle() {
-            return title;
-        }
-
-        Class getMetaClass() {
-            return metaClass;
-        }
-
-        String getDescription() {
-            return description;
-        }
+        return tableAry;
     }
-
 
     /**
      * convert votable content into DataGroup mainly by collecting TABLE elements and TABLE included metadata and data
@@ -475,171 +183,39 @@ public class VoTableReader {
      * @return a DataGroup object representing a TABLE in votable file
      */
     private static DataGroup convertToDataGroup(TableElement tableEl, StarTable table,  boolean headerOnly) {
-        String title = table.getName();
-        List<DataType> cols = new ArrayList<>();
-        String raCol=null, decCol=null;
         int precision = 8;
-        String precisionStr = "";
 
-        VOElement[] fields = tableEl.getChildrenByName("FIELD");
+        DataGroup dg = getTableHeader(tableEl);
+        List<DataType> cols = Arrays.asList(dg.getDataDefinitions());
 
-
-        // collect FIELD from TABLE
-        // collect attributes of <FIELD> including name, datatype, unit, precision, width, ref, ID, ucd, utype
-        // collect children elements including <DESCRIPTION>, <LINK>, <VALUES>
-        for (int i = 0; i < table.getColumnCount(); i++) {
-            ColumnInfo cinfo = table.getColumnInfo(i);
-
-            DataType dt = convertToDataType(cinfo);
-
-            // quick and dirty way to fix column name when it's not provided
-            dt.setKeyName(getCName(fields[i], i));
-
-            // attribute precision
-            if(cinfo.getAuxDatum(VOStarTable.PRECISION_INFO)!=null){
-                try{
-                    DescribedValue pDV  = cinfo.getAuxDatum(VOStarTable.PRECISION_INFO);
-
-                    if (pDV != null) {
-                        precisionStr = pDV.getValue().toString();
-                        precisionStr = makePrecisionStr(precisionStr);
-                        dt.setPrecision(precisionStr);
-                    }
-                } catch (NumberFormatException e){
-                    // problem with VOTable vinfo precision: should be numeric - keep default min precision
-                }
-            }
-
-            // attribute width
-            if (cinfo.getAuxDatum(VOStarTable.WIDTH_INFO) != null) {
-                dt.setWidth(Integer.parseInt(cinfo.getAuxDatum(VOStarTable.WIDTH_INFO).getValue().toString()));
-            }
-
-            // attribute ref
-            if (cinfo.getAuxDatum(VOStarTable.REF_INFO) != null) {
-                dt.setRef(cinfo.getAuxDatum(VOStarTable.REF_INFO).getValue().toString());
-            }
-
-            // attribute ucd
-            String ucd = cinfo.getUCD();
-            if ( ucd != null) { // should we save all UCDs?
-                if (HMS_UCD_PATTERN.matcher( ucd ).matches()) {
-                    raCol = cinfo.getName();
-                }
-                if (DMS_UCD_PATTERN.matcher( ucd ).matches()) {
-                    decCol = cinfo.getName();
-                }
-                dt.setUCD(ucd);
-            }
-
-            // attribute utype
-            String utype = cinfo.getUtype();
-            if (utype != null) {
-                dt.setUType(utype);
-            }
-
-            // attribute ID
-            if (cinfo.getAuxDatum(VOStarTable.ID_INFO) != null) {
-                dt.setID(cinfo.getAuxDatum(VOStarTable.ID_INFO).getValue().toString());
-            }
-
-            // child element DESCRIPTION
-            String desc = cinfo.getDescription();
-            if (desc != null) {
-                dt.setDesc(desc.replace("\n", " "));
-            }
-
-            // attribute type  .. this is not yet standard, mentioned in appendix
-            // used for generating links and link substitutions
-            DescribedValue type = cinfo.getAuxDatumByName("Type");
-            if (type != null) {
-                String val = String.valueOf(type.getValue());
-                if (val.equals(DataType.LOCATION)) {
-                    dt.setTypeDesc(val);
-                } else if (val.equals("hidden")) {
-                    dt.setVisibility(DataType.Visibility.hidden);
-                }
-            }
-
-            // child elements <LINK> and <VALUES>
-            if (tableEl != null) {
-                dt.setLinkInfos(makeLinkInfosFromField(tableEl, dt));
-                getValuesFromField(tableEl, dt);
-            }
-
-            cols.add(dt);
-        }
-
-        // attribute name from TABLE
-        DataGroup dg = new DataGroup(title, cols);
-
-        // metadata for TABLE
-        List<DescribedValue> dvAry = (tableEl == null) ? new ArrayList<>()
-                                                       : getInfosFromTable(tableEl);
-        for (Object p : dvAry) {
-            DescribedValue dv = (DescribedValue)p;
-            dg.getTableMeta().addKeyword(dv.getInfo().getName(), dv.getValueAsString(Integer.MAX_VALUE).replace("\n", " "));
-        }
-
-
+        // post-process to handle custom logic
+        DataType raCol = cols.stream().filter(dt -> HMS_UCD_PATTERN.matcher(String.valueOf(dt.getUCD())).matches())
+                .findFirst().orElse(null);
+        DataType decCol = cols.stream().filter(dt -> DMS_UCD_PATTERN.matcher(String.valueOf(dt.getUCD())).matches())
+                .findFirst().orElse(null);
         if (raCol != null && decCol != null) {
-            dg.addAttribute("POS_EQ_RA_MAIN", raCol);
-            dg.addAttribute("POS_EQ_DEC_MAIN", decCol);
-        }
-
-        if (tableEl != null) {
-            // attribute ID, ref, ucd, utype from TABLE
-            applyIfNotEmpty(getElementAttribute(tableEl, ID), v -> dg.getTableMeta().addKeyword(TableMeta.ID, v));
-            applyIfNotEmpty(getElementAttribute(tableEl, REF), v -> dg.getTableMeta().addKeyword(TableMeta.REF, v));
-            applyIfNotEmpty(getElementAttribute(tableEl, UCD), v -> dg.getTableMeta().addKeyword(TableMeta.UCD, v));
-            applyIfNotEmpty(getElementAttribute(tableEl, UTYPE), v -> dg.getTableMeta().addKeyword(TableMeta.UTYPE, v));
-            applyIfNotEmpty(getElementAttribute(tableEl, NAME), v -> dg.getTableMeta().addKeyword(TableMeta.NAME, v));
-
-            // child element PARAM, GROUP, LINK for TABLE
-            dg.setParamInfos(makeParamsFromTable(tableEl, table));
-            dg.setGroupInfos(makeGroupInfosFromTable(tableEl));
-            dg.setLinkInfos(makeLinkInfosFromTable(tableEl));
-
-            // child element DESCRIPTION
-            String tDesc = tableEl.getDescription();
-            if (tDesc != null) {
-                dg.getTableMeta().addKeyword(TableMeta.DESC, tDesc.replace("\n", " "));
-            }
+            dg.addAttribute("POS_EQ_RA_MAIN", raCol.getKeyName());
+            dg.addAttribute("POS_EQ_DEC_MAIN", decCol.getKeyName());
         }
 
         // table data
         try {
             if (!headerOnly) {
                 RowSequence rs = table.getRowSequence();
-                int len;
-                int find = 0;
-                String findStr;
 
                 while (rs.next()) {
                     DataObject row = new DataObject(dg);
                     for(int i = 0; i < cols.size(); i++) {
                         DataType dtype = cols.get(i);
                         Object val = rs.getCell(i);
-                        String sval = table.getColumnInfo(i).formatValue(val, Integer.MAX_VALUE);
 
-                        if (dtype.getKeyName().equals("spans")) {
-                            len = sval.length();
-
-                            if (len > 65536) {
-                                find = 1;
-                                findStr = val.toString();
-                            }
-                        }
-                        if (dtype.getDataType().isAssignableFrom(String.class) && !(val instanceof String)) {
-                            row.setDataElement(dtype, sval);   // array value
-                        } else {
-                            if ((val instanceof Double && Double.isNaN((Double) val)) ||
+                        if ((val instanceof Double && Double.isNaN((Double) val)) ||
                                 (val instanceof Float && Float.isNaN((Float) val))    )    {
-                                val = null;
-                            }
-                            row.setDataElement(dtype, val);
+                            val = null;
                         }
+                        row.setDataElement(dtype, val);
                         if (dtype.getPrecision() == null) {
+                            String sval = table.getColumnInfo(i).formatValue(val, Integer.MAX_VALUE);
                             IpacTableUtil.guessFormatInfo(dtype, sval, precision);// precision min 8 can come from VOTable attribute 'precision' later on.
                         }
                     }
@@ -647,79 +223,157 @@ public class VoTableReader {
                 }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e);
         }
         dg.trimToSize();
         return dg;
     }
 
-    public static DataType convertToDataType(ColumnInfo cinfo) {
-        // attribute datatype, if the column is with data in array style, set the datatype to be "string" type
-        Class clz = cinfo.isArray() ? String.class : cinfo.getContentClass();
-        String nullString = null;
+    private static DataGroup getTableHeader(TableElement table) {
 
-        String classType = DefaultValueInfo.formatClass(clz);
-        Class java_class;
-
-        if ((classType.contains("boolean")) || (classType.contains("Boolean"))) {
-            java_class = Boolean.class;
-        } else if ((classType.contains("byte")) || (classType.contains("Byte"))) {
-            java_class = Integer.class;
-        } else if ((classType.contains("short")) || (classType.contains("Short"))) {
-            java_class = Integer.class;
-        } else if ((classType.contains("int")) || (classType.contains("Integer"))) {
-            java_class = Integer.class;
-        } else if ((classType.contains("long")) || (classType.contains("Long"))) {
-            java_class = Long.class;
-        } else if ((classType.contains("float")) || (classType.contains("Float"))) {
-            java_class = Float.class;
-        } else if ((classType.contains("double")) || (classType.contains("Double"))) {
-            java_class = Double.class;
-        } else {        // char, string or else
-            java_class = String.class;
+        // FIELD info  => columns
+        VOElement[] fields = table.getChildrenByName("FIELD");
+        List<DataType> cols = new ArrayList<>(fields.length);
+        for (int i=0; i < fields.length; i++) {
+            DataType dt = fieldElToDataType(null, fields[i], i, cols);
+            cols.add(dt);
         }
+        String name = table.getAttribute(NAME);
+        DataGroup dg = new DataGroup(name, cols);
 
-        // attribute name & unit
-        DataType dt = new DataType(cinfo.getName(), java_class, null, cinfo.getUnitString(), nullString, null);
-        if (cinfo.isArray()) dt.setTypeDesc(DataType.LONG_STRING);
+        // attribute ID, ref, ucd, utype from TABLE
+        applyIfNotEmpty(name, v -> dg.getTableMeta().addKeyword(TableMeta.NAME, v));
+        applyIfNotEmpty(table.getAttribute(ID), v -> dg.getTableMeta().addKeyword(TableMeta.ID, v));
+        applyIfNotEmpty(table.getAttribute(REF), v -> dg.getTableMeta().addKeyword(TableMeta.REF, v));
+        applyIfNotEmpty(table.getAttribute(UCD), v -> dg.getTableMeta().addKeyword(TableMeta.UCD, v));
+        applyIfNotEmpty(table.getAttribute(UTYPE), v -> dg.getTableMeta().addKeyword(TableMeta.UTYPE, v));
+        applyIfNotEmpty(table.getDescription(), v -> dg.getTableMeta().addKeyword(TableMeta.DESC, v.replace("\n", " ")));
 
-        return dt;
+        // PARAMs info
+        Arrays.stream(table.getChildrenByName("PARAM"))
+                .forEach(el -> dg.getParamInfos().add(paramElToParamInfo(el)));
+
+        // GROUP info
+        Arrays.stream(table.getChildrenByName("GROUP"))
+                .forEach(el -> dg.getGroupInfos().add(groupElToGroupInfo(el)));
+
+        // LINK info  => table level
+        Arrays.stream(table.getChildrenByName("LINK"))
+                .forEach(el -> dg.getLinkInfos().add(linkElToLinkInfo(el)));
+
+        // INFO     => only takes name/value pairs for now
+        Arrays.stream(table.getChildrenByName("INFO"))
+                .forEach(el -> {
+                    dg.getTableMeta().setAttribute(el.getName(), el.getAttribute("value"));
+                });
+        if (table.hasAttribute("nrows")) {
+            dg.setSize((int) table.getNrows());
+        } else {
+            // if no nrows attribute, pull in the data and count the rows.
+            try {
+                dg.setSize((int)  new VOStarTable(table).getRowCount());
+            } catch (IOException e) { }     // just ignore it.
+        }
+        return dg;
     }
 
-//====================================================================
-//  DOM based setters
-//====================================================================
 
-    private static ParamInfo paramInfoFromEl(VOElement el) {
-        ParamInfo dt = new ParamInfo(null, null);
-        populateDataType(dt, el);
-        applyIfNotEmpty(el.getAttribute("value"), dt::setValue);
-        return dt;
+    // precision: "2" => "F2", "F2"=> "F2", "E3" => "E3"
+    private static String makePrecisionStr(String precisionStr) {
+        return (precisionStr.matches("^[1-9][0-9]*$")) ? ("F"+precisionStr) : precisionStr;
     }
 
     /**
      * returns the column name for the given field.
      * Although name is a required attribute for FIELD, some VOTable may not provide it.
-     * In this case, use ID or name is COLUMN_[IDX] where IDX is the index of the fields.
+     * When name is not given, use ID if exists. Otherwise, use COLUMN_${IDX} where IDX is the index of the fields.
+     *
+     * In VOTable section 3.2, name does not need to be unique, although it is recommended that name of a FIELD be unique for a TABLE.
+     * In Firefly, DataType.name has to be unique.  Therefore, if name is not unique, we will append _${IDX} to it.
      * @param el
      * @param colIdx
      * @return
      */
-    private static String getCName(VOElement el, int colIdx) {
+    private static String getCName(VOElement el, int colIdx, List<DataType> cols) {
         if (el == null) return null;
         String name = el.getAttribute("name");
         if (isEmpty(name)) name = el.getAttribute("ID");
         if (isEmpty(name)) name = "COLUMN_" + colIdx;
-        else name = name.replace("\"","");
+
+        name = name.replace("\"","");
+
+        if (cols != null) {
+            String finalName = name;
+            if (CollectionUtil.findFirst(cols, dt -> Objects.equals(dt.getKeyName(), finalName)) != null) {
+                // name is not unique
+                name = name + "_" + colIdx;
+            }
+        }
         return name;
     }
 
+//====================================================================
+//  private conversion functions
+//====================================================================
+
+    private static GroupInfo groupElToGroupInfo(VOElement group) {
+
+        String name = group.getName();
+        String desc = group.getDescription();
+
+        GroupInfo gObj = new GroupInfo(name, desc);
+        applyIfNotEmpty(group.getAttribute(ID), gObj::setID);
+
+        // add FIELDref
+        Arrays.stream(group.getChildrenByName("FIELDref"))
+                .forEach(pEl -> gObj.getColumnRefs().add(refElToRefInfo(pEl)));
+
+        // add PARAMrefs
+        Arrays.stream(group.getChildrenByName("PARAMref"))
+                .forEach(pEl -> gObj.getParamRefs().add(refElToRefInfo(pEl)));
+
+        // add PARAMs
+        Arrays.stream(group.getChildrenByName("PARAM"))
+            .forEach(pEl -> gObj.getParamInfos().add(paramElToParamInfo(pEl)));
+
+        return gObj;
+    }
+
+    // convert LinkElement to LinkInfo
+    private static LinkInfo linkElToLinkInfo(VOElement el) {
+        if (el == null) return null;
+        LinkInfo li = new LinkInfo();
+        applyIfNotEmpty(el.getAttribute(ID), li::setID);
+        applyIfNotEmpty(el.getAttribute("content-role"), li::setRole);
+        applyIfNotEmpty(el.getAttribute("content-type"), li::setType);
+        applyIfNotEmpty(el.getAttribute("title"), li::setTitle);
+        applyIfNotEmpty(el.getAttribute("href"), li::setHref);
+        applyIfNotEmpty(el.getAttribute("value"), li::setValue);
+        applyIfNotEmpty(el.getAttribute("action"), li::setAction);
+        return li;
+    }
+
+    private static ParamInfo paramElToParamInfo(VOElement el) {
+        ParamInfo dt = (ParamInfo) fieldElToDataType(new ParamInfo(), el,0, null);
+        applyIfNotEmpty(el.getAttribute("value"), dt::setValue);
+        return dt;
+    }
+
+    private static GroupInfo.RefInfo refElToRefInfo(VOElement el) {
+        String refStr = el.getAttribute(REF);
+        String ucdStr = el.getAttribute(UCD);
+        String utypeStr = el.getAttribute(UTYPE);
+        return new GroupInfo.RefInfo(refStr, ucdStr, utypeStr);
+    }
 
     /**  used by both ParamInfo and DataType  */
-    private static void populateDataType(DataType dt, VOElement el) {
+    private static DataType fieldElToDataType(DataType col, VOElement el, int idx, List<DataType> cols) {
+
+        DataType dt = col == null ? new DataType(null, null) : col;
+        String name = getCName(el, idx, cols);
+        dt.setKeyName(name);
 
         applyIfNotEmpty(el.getAttribute(ID), dt::setID);
-        applyIfNotEmpty(el.getAttribute("name"), dt::setKeyName);
         applyIfNotEmpty(el.getAttribute("unit"), dt::setUnits);
         applyIfNotEmpty(el.getAttribute("precision"), v -> dt.setPrecision(makePrecisionStr(v)));
         applyIfNotEmpty(el.getAttribute("width"), v -> dt.setWidth(Integer.parseInt(v)));
@@ -727,33 +381,39 @@ public class VoTableReader {
         applyIfNotEmpty(el.getAttribute("ucd"), dt::setUCD);
         applyIfNotEmpty(el.getAttribute("utype"), dt::setUType);
         applyIfNotEmpty(el.getDescription(), dt::setDesc);
-//        callIfNotEmpty(el.getAttribute("arraysize"), dt::setArraySize);
         applyIfNotEmpty(el.getAttribute("datatype"), v -> {
-            dt.setDataType(DataType.descToType(v));
             dt.setTypeDesc(v);
+            dt.setDataType(DataType.descToType(v));
         });
+        applyIfNotEmpty(el.getAttribute("type"), v -> {
+            if (v.equals("hidden")) {       // mentioned in appendix A.1(LINK substitutions)
+                dt.setVisibility(DataType.Visibility.hidden);
+            }
+        });
+
+        if (dt.getDataType() != String.class) {
+            // we will ignore multi-dimensional char arrays for now
+            applyIfNotEmpty(el.getAttribute("arraysize"), dt::setArraySize);
+        }
 
         // add all links
         Arrays.stream(el.getChildrenByName("LINK"))
-                .forEach(lel -> dt.getLinkInfos().add(linkElementToLinkInfo(lel)));
+                .forEach(lel -> dt.getLinkInfos().add(linkElToLinkInfo(lel)));
+        return dt;
     }
 
-    private static GroupInfo.RefInfo refInfoFromEl(VOElement el) {
-        String refStr = el.getAttribute(REF);
-        String ucdStr = el.getAttribute(UCD);
-        String utypeStr = el.getAttribute(UTYPE);
-        return new GroupInfo.RefInfo(refStr, ucdStr, utypeStr);
-    }
+
+
 
 //====================================================================
-//
+//  file analysis support
 //====================================================================
 
     public static FileAnalysis.Report analyze(File infile, FileAnalysis.ReportType type) throws Exception {
 
         FileAnalysis.Report report = new FileAnalysis.Report(type, TableUtil.Format.VO_TABLE.name(), infile.length(), infile.getPath());
-        VOElement root = getVOElementFromVOTable(infile.getAbsolutePath(), null);
-        List<FileAnalysis.Part> parts = describeDocument(root);
+        List<TableElement> tables = getAllTableElements(infile.getAbsolutePath(), null);
+        List<FileAnalysis.Part> parts = tablesToParts(tables);
         parts.forEach(report::addPart);
 
         for(int i = 0; i < parts.size(); i++) {
@@ -776,70 +436,23 @@ public class VoTableReader {
     }
 
     /**
-     * @param root  the root element of the VOTable
+     * @param tables  a list of table element
      * @return each Table as a part with details containing DataGroup without data
      */
-    private static List<FileAnalysis.Part> describeDocument(VOElement root) {
+    private static List<FileAnalysis.Part> tablesToParts(List<TableElement> tables) {
         List<FileAnalysis.Part> parts = new ArrayList<>();
-        Arrays.stream(root.getChildrenByName("RESOURCE"))
-                .forEach( res -> {
-                    Arrays.stream(res.getChildrenByName("TABLE"))
-                            .forEach(table -> {
-                                FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table);
-                                part.setIndex(parts.size());
-                                DataGroup dg = getTableHeader((TableElement)table);
-                                String title = isEmpty(dg.getTitle()) ? "VOTable" : dg.getTitle().trim();
-                                part.setDetails(dg);
-                                part.setDesc(String.format("%s (%d cols x %s rows)", title, dg.getDataDefinitions().length, dg.size()));
-                                parts.add(part);
-                            });
-                });
-
+        tables.forEach(table -> {
+            FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table);
+            part.setIndex(parts.size());
+            DataGroup dg = getTableHeader((TableElement)table);
+            String title = isEmpty(dg.getTitle()) ? "VOTable" : dg.getTitle().trim();
+            part.setDetails(dg);
+            part.setDesc(String.format("%s (%d cols x %s rows)", title, dg.getDataDefinitions().length, dg.size()));
+            parts.add(part);
+        });
 
         return parts;
     }
 
-    private static DataGroup getTableHeader(TableElement table) {
-        String title = table.getAttribute("name");
-        // FIELD info  => columns
-        VOElement[] fields = table.getChildrenByName("FIELD");
-        List<DataType> cols = new ArrayList<>(fields.length);
-        for (int i=0; i < fields.length; i++) {
-                    DataType dt = new DataType(getCName(fields[i], i), null);
-                    populateDataType(dt, fields[i]);
-                    cols.add(dt);
-            }
-        DataGroup dg = new DataGroup(title, cols);
-
-        // PARAMs info
-        Arrays.stream(table.getChildrenByName("PARAM"))
-                .forEach(el -> dg.getParamInfos().add(paramInfoFromEl(el)));
-        // GROUP info
-        dg.setGroupInfos(makeGroupInfosFromTable(table));
-
-        // LINK info  => table level
-        Arrays.stream(table.getChildrenByName("LINK"))
-                .forEach(el -> dg.getLinkInfos().add(linkElementToLinkInfo(el)));
-
-        // INFO     => only takes name/value pairs for now
-        Arrays.stream(table.getChildrenByName("INFO"))
-                .forEach(el -> {
-                    dg.getTableMeta().setAttribute(el.getName(), el.getAttribute("value"));
-                });
-        if (table.hasAttribute("nrows")) {
-            dg.setSize((int) table.getNrows());
-        } else {
-            // if no nrows attribute, pull in the data and count the rows.
-            try {
-                dg.setSize((int)  new VOStarTable(table).getRowCount());
-            } catch (IOException e) { }     // just ignore it.
-        }
-        return dg;
-    }
-
-
-
-
-
-
 }
+

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
@@ -303,7 +303,8 @@ public class VoTableWriter {
                                      (!isEmpty(prec) && prec.startsWith("G")) ? prec.substring(1) : prec) +
                           elementAtt("unit", dt.getUnits()) +
                           elementAtt(TableMeta.UTYPE, dt.getUType()) +
-                          elementAtt(TableMeta.REF, dt.getRef());
+                          elementAtt(TableMeta.UTYPE, dt.getUType()) +
+                          elementAtt("arraySize", dt.getArraySize());
 
 
             return atts;

--- a/src/firefly/java/edu/caltech/ipac/util/CollectionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/CollectionUtil.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Utility class dealing with Collection.
@@ -270,10 +271,10 @@ public class CollectionUtil {
         return newMap;
     }
 
-    public static <T> T findFirst(List<T> list, Filter<T> matcher) {
+    public static <T> T findFirst(List<T> list, Predicate<T> matcher) {
         if (!isEmpty(list)) {
             for(T item : list) {
-                if (matcher.accept(item)) {
+                if (matcher.test(item)) {
                     return item;
                 }
             }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2271
test: 
https://irsawebdev9.ipac.caltech.edu/IRSA-2271_table_array_type/firefly/
https://irsawebdev9.ipac.caltech.edu/IRSA-2271_table_array_type/applications/sofia/

Sample file with array types:
${firefly_test_data}/FileUpload-samples/fits/imagetable/calexp-005882-i1-0406.fits

- adds support for array types
  - use VOTable arraysize format
  - display array values as `datatype [arraysize]`
- refactor VoTableReader and add support for reading specific table indices.