### PR TITLE
FIREFLY-340: Filter Editor can not be invoked from a chart

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -20,7 +20,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
 
     public static final String TBL_FILE_PATH = "tblFilePath";       // this meta if exists contains source of the data
     public static final String TBL_FILE_TYPE = "tblFileType";       // this meta if exists contains storage type, ipac, h2, sqlite, etc
-    public static final String FILTER_SEP = "_AND_";         // need to match what's defined in FilterInfo.js
+    public static final String FILTER_SEP = " _AND_ ";         // need to match what's defined in FilterInfo.js
 
     public static final String TBL_ID = "tbl_id";
     public static final String TITLE = "title";

--- a/src/firefly/js/charts/ui/FilterEditorWrapper.jsx
+++ b/src/firefly/js/charts/ui/FilterEditorWrapper.jsx
@@ -2,56 +2,46 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {Component} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {get, isUndefined} from 'lodash';
 
 import {FilterEditor} from '../../tables/ui/FilterEditor.jsx';
-import * as TblUtil from '../../tables/TableUtil.js';
-import * as TablesCntlr from '../../tables/TablesCntlr.js';
+import {dispatchTableFilter} from '../../tables/TablesCntlr.js';
+import {getTblById} from '../../tables/TableUtil.js';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 
-export class FilterEditorWrapper extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            sortInfo: ''
-        };
-    }
+export const FilterEditorWrapper = React.memo(({tbl_id}) => {
+    const [sortInfo, setSortInfo] = useState('');
+    useStoreConnector(() => get(getTblById(tbl_id), 'request.filters'));
+    const tableModel = getTblById(tbl_id);
+    return (
+         <div className='TablePanelOptionsWrapper'>
+             <div className='TablePanelOptions'>
+                 <FilterEditor
+                     tbl_id={tbl_id}
+                     columns={get(tableModel, 'tableData.columns', [])}
+                     selectable={false}
+                     filterInfo={get(tableModel, 'request.filters')}
+                     sortInfo={sortInfo}
+                     onChange={(obj) => {
+                         const fi = obj.filterInfo;
+                         const {request} = getTblById(tbl_id);
+                         if (!isUndefined(fi) && (fi !== get(request, 'filters'))) {
+                             const newRequest = Object.assign({}, request, {filters: obj.filterInfo});
+                             dispatchTableFilter(newRequest);
+                         } else if (!isUndefined(obj.sortInfo)) {
+                             setSortInfo(obj.sortInfo);
+                         }
+                     } }/>
+             </div>
+         </div>
+     );
+});
 
-    shouldComponentUpdate(np, ns) {
-        const tblId = get(np.tableModel, 'tbl_id');
-        return ns.sortInfo !== this.state.sortInfo || tblId !== get(this.props.tableModel, 'tbl_id') ||
-            (TblUtil.isFullyLoaded(tblId) && np.tableModel !== this.props.tableModel); // to avoid flickering when changing the filter
-    }
-
-    render() {
-        const {tableModel} = this.props;
-        const {sortInfo} = this.state;
-        return (
-            <div className='TablePanelOptionsWrapper'>
-                <div className='TablePanelOptions'>
-                    <FilterEditor
-                        columns={get(tableModel, 'tableData.columns', [])}
-                        selectable={false}
-                        filterInfo={get(tableModel, 'request.filters')}
-                        sortInfo={sortInfo}
-                        onChange={(obj) => {
-                            if (!isUndefined(obj.filterInfo)) {
-                                const newRequest = Object.assign({}, tableModel.request, {filters: obj.filterInfo});
-                                TablesCntlr.dispatchTableFilter(newRequest);
-                            } else if (!isUndefined(obj.sortInfo)) {
-                                this.setState({sortInfo: obj.sortInfo});
-                            }
-                        } }/>
-                </div>
-            </div>
-        );
-    }
-}
 
 FilterEditorWrapper.propTypes = {
-    toggleFilters : PropTypes.func,
-    tableModel : PropTypes.object
+    tbl_id : PropTypes.string
 };
 
 

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -412,9 +412,8 @@ function ClearFilter({style={}, tbl_id}) {
 function showFilterDialog(chartId) {
     const {data, fireflyData, activeTrace} = getChartData(chartId);
     const tbl_id = get(data, `${activeTrace}.tbl_id`) || get(fireflyData, `${activeTrace}.tbl_id`);
-    const tableModel = getTblById(tbl_id);
     const content= (
-        <FilterEditorWrapper tableModel={tableModel}/>
+        <FilterEditorWrapper tbl_id={tbl_id}/>
     );
 
     showOptionsPopup({content, title: 'Filters', modal: true, show: true});

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -26,11 +26,13 @@ export const FILTER_TTIPS =
 * when IN is used, enclose the values in parentheses
 * you may combine conditions with either 'and' or 'or'
 * grouping by parentheses is not supported at the moment
-* '${FILTER_SEP}' serves as groups separator at the moment 
 Examples:  
-  "ra" > 5 and "color" != 'blue' or "band" IN (1,2,3)
-  "ra" < 5 or "ra" > 6 _AND_ "dec" < -1 or "dec" > 1
+  "ra" > 5 and "color" != 'blue' or "band" IN (1,2,3) 
 `;
+
+// ('${FILTER_SEP}' serves as groups separator for now when grouping is necessary)
+// "ra" < 5 or "ra" > 6 _AND_ "dec" < -1 or "dec" > 1
+
 
 export const NULL_TOKEN = '%NULL';          // need to match DbAdapter.NULL_TOKEN
 

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -9,6 +9,9 @@ import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 const operators = /(!=|>=|<=|<|>|=| like | in | is not | is )/i;
 
+// filter group separator
+const FILTER_SEP = ' _AND_ ';        // internal use need to match what's defined in TableServerRequest.FILTER_SEP
+
 export const FILTER_CONDITION_TTIPS =
 `Valid values are one of (=, >, <, !=, >=, <=, LIKE, IS, IS NOT) followed by a value separated by a space.
 Or 'IN', followed by a list of values separated by commas.
@@ -22,14 +25,30 @@ export const FILTER_TTIPS =
 * string value must be enclosed in single quotes
 * when IN is used, enclose the values in parentheses
 * you may combine conditions with either 'and' or 'or'
-* grouping by parentheses is not supported at the moment 
-Examples:  "ra" > 12345 and "color" != 'blue' or "band" IN (1,2,3)
+* grouping by parentheses is not supported at the moment
+* '${FILTER_SEP}' serves as groups separator at the moment 
+Examples:  
+  "ra" > 5 and "color" != 'blue' or "band" IN (1,2,3)
+  "ra" < 5 or "ra" > 6 _AND_ "dec" < -1 or "dec" > 1
 `;
 
 export const NULL_TOKEN = '%NULL';          // need to match DbAdapter.NULL_TOKEN
 
+// condition separator
 const COND_SEP = new RegExp('( and | or )', 'i');
-const FILTER_SEP = '_AND_';                 // internal use need to match what's defined in TableServerRequest.FILTER_SEP
+
+/**
+ * returns the number of individual filters
+ * @param filterInfoStr
+ * @returns {number}
+ */
+export function getNumFilters(filterInfoStr) {
+    if (filterInfoStr) {
+        return Math.round((filterInfoStr.split(new RegExp(`( and | or |${FILTER_SEP})`, 'i')).length+1)/2);
+    } else {
+        return 0;
+    }
+}
 
 
 /**
@@ -93,7 +112,7 @@ export class FilterInfo {
     }
 
     /**
-     * given a list of filters separated by semicolon,
+     * given a list of filters separated by condition separator,
      * transform them into valid filters if they are not already so.
      * @param filterInfo
      * @param columns
@@ -101,20 +120,22 @@ export class FilterInfo {
      */
     static autoCorrectFilter(filterInfo, columns) {
         if (filterInfo) {
-            const parts = filterInfo.split(COND_SEP);
-            for (let i = 0; i < parts.length; i += 2) {
-                const [cname, op, val] = parseInput(parts[i]);
-                if (cname) {
-                    let isNumeric = false;
-                    if (columns) {
-                        const col = columns.find((c) => c.name === cname);
-                        // assume all expressions are numeric
-                        isNumeric = !col || isNumericType(col);
+            filterInfo.split(FILTER_SEP).map( (filter) => {
+                const parts = filter.split(COND_SEP);
+                for (let i = 0; i < parts.length; i += 2) {
+                    const [cname, op, val] = parseInput(parts[i]);
+                    if (cname) {
+                        let isNumeric = false;
+                        if (columns) {
+                            const col = columns.find((c) => c.name === cname);
+                            // assume all expressions are numeric
+                            isNumeric = !col || isNumericType(col);
+                        }
+                        parts[i] = `${cname} ${autoCorrectCondition(op + ' ' + val, isNumeric)}`;
                     }
-                    parts[i] = `${cname} ${autoCorrectCondition(op + ' ' + val, isNumeric)}`;
                 }
-            }
-            return parts.join('');
+                return parts.join('');
+            }).join(FILTER_SEP);
         } else {
             return filterInfo;
         }
@@ -169,22 +190,23 @@ export class FilterInfo {
         const allowCols = columns.concat({name:'ROW_IDX'});
         if (filterInfo) {
             let msg = '';
-            const parts = filterInfo.split(COND_SEP);
-            for (let i = 0; i < parts.length; i += 2) {
-                const [cname] = parseInput(parts[i]);
-                if (!cname) {
-                    msg += `\n"${parts[i]}" is not a valid filter.`;
-                } else if (!allowCols.some( (c) => c.name === cname)) {
-                    const expr = new Expression(cname, allowCols.map((s)=>s.name));
-                    if (!expr.isValid()) {
-                        msg += `\n"${parts[i]}" unrecognized column or expression.\n`;
+            filterInfo.split(FILTER_SEP).forEach( (filter) => {
+                const parts = filter.split(COND_SEP);
+                for (let i = 0; i < parts.length; i += 2) {
+                    const [cname] = parseInput(parts[i]);
+                    if (!cname) {
+                        msg += `\n"${parts[i]}" is not a valid filter.`;
+                    } else if (!allowCols.some((c) => c.name === cname)) {
+                        const expr = new Expression(cname, allowCols.map((s) => s.name));
+                        if (!expr.isValid()) {
+                            msg += `\n"${parts[i]}" unrecognized column or expression.\n`;
+                        }
                     }
+                    if (msg) return [false, msg];
                 }
-                if (msg) return [false, msg];
-            }
-        } else {
-            return [true, ''];
+            });
         }
+        return [true, ''];
     }
 
     /**

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -8,7 +8,7 @@ import Enum from 'enum';
 import {makeFileRequest, MAX_ROW} from './TableRequestUtil.js';
 import * as TblCntlr from './TablesCntlr.js';
 import {SortInfo, SORT_ASC, UNSORTED} from './SortInfo.js';
-import {FilterInfo} from './FilterInfo.js';
+import {FilterInfo, getNumFilters} from './FilterInfo.js';
 import {SelectInfo} from './SelectInfo.js';
 import {flux} from '../Firefly.js';
 import {encodeServerUrl, uniqueID} from '../util/WebUtil.js';
@@ -341,7 +341,7 @@ export function getColumnByID(tableModel, ID) {
 
 export function getFilterCount(tableModel) {
     const filterInfo = get(tableModel, 'request.filters');
-    const filterCount = filterInfo ? filterInfo.split(';').length : 0;
+    const filterCount = getNumFilters(filterInfo);
     return filterCount;
 }
 

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -7,6 +7,7 @@ import {has, get, isEmpty, cloneDeep, findKey, omit} from 'lodash';
 import {updateSet, updateMerge} from '../../util/WebUtil.js';
 import * as Cntlr from '../TablesCntlr.js';
 import {getTblInfo, isTableLoaded, smartMerge, getAllColumns} from '../TableUtil.js';
+import {getNumFilters} from '../FilterInfo.js';
 
 
 /*---------------------------- REDUCERS -----------------------------*/
@@ -82,7 +83,7 @@ function uiStateReducer(ui, tableModel) {
     // if (!get(tableModel, 'tableData')) return ui;
     const {startIdx, endIdx, tbl_id, ...others} = getTblInfo(tableModel);
     const filterInfo = get(tableModel, 'request.filters');
-    const filterCount = filterInfo ? filterInfo.split(';').length : 0;
+    const filterCount = getNumFilters(filterInfo);
     const sortInfo = get(tableModel, 'request.sortInfo');
     const showLoading = !isTableLoaded(tableModel);
     const showMask = tableModel && tableModel.isFetching;

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -31,7 +31,7 @@ export class FilterEditor extends PureComponent {
 
         if (isEmpty(columns)) return false;
 
-        const {allowUnits} = getTableUiById(tbl_ui_id);
+        const {allowUnits} = getTableUiById(tbl_ui_id)||{};
         const {cols, data, selectInfoCls} = prepareOptionData(columns, sortInfo, filterInfo, selectable, allowUnits);
         const callbacks = makeCallbacks(onChange, columns, data, filterInfo);
         const renderers = makeRenderers(callbacks.onFilter, tbl_id);


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-340
Test deployment: https://irsawebdev9.ipac.caltech.edu/firefly-340_chartFilterEditor/firefly/

Filter Editor can be now invoked from the chart, the behavior is similar to the its behavior when it's invoked from a table. 

Bug fixes 
- Users should be able to update or remove expression filters set from the chart or ROW_IDX filters set from the image using Filter Editor's "Filters" box, which shows all filters.
- The number of filters on the badge on table toolbar should reflect the number of individual filters.