### PR TITLE
Firefly-324: Fixed: when a catalog is reloaded from the background manager its color changes.

### DIFF
--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -48,6 +48,11 @@ export const MetaConst = {
     /** a string or html rgb color that can be set in metadata, use with catalog overlay */
     DEFAULT_COLOR : 'DEFAULT_COLOR',
 
+    /** a string to represent the drawing symbol
+     * @see ../visualize/draw/PointDataObj.js for a list of draw symbols, DrawSymbol
+     */
+    DEFAULT_SYMBOL : 'DEFAULT_SYMBOL',
+
     /** used by time series, defines the mission
      * @see LcManager.js
      * @see getConverterId

--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -9,7 +9,7 @@ import {primePlot,getAllDrawLayersForPlot} from '../visualize/PlotViewUtil.js';
 import {visRoot, dispatchUseTableAutoScroll} from '../visualize/ImagePlotCntlr.js';
 import PointDataObj, {DrawSymbol} from '../visualize/draw/PointDataObj.js';
 import FootprintObj from '../visualize/draw/FootprintObj.js';
-import {makeDrawingDef, getNextColor} from '../visualize/draw/DrawingDef.js';
+import {makeDrawingDef, getNextColor, releaseColor} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {DataTypes,ColorChangeType} from '../visualize/draw/DrawLayer.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
 import DrawLayerCntlr, {SUBGROUP} from '../visualize/DrawLayerCntlr.js';
@@ -41,7 +41,7 @@ const CatalogType = new Enum(['X', 'BOX', 'REGION']);
 
 
 const findColIdx= (columns,colId) => columns.findIndex( (c) => c.name===colId);
-const factoryDef= makeFactoryDef(TYPE_ID,creator,getDrawData,getLayerChanges,null,getUIComponent);
+const factoryDef= makeFactoryDef(TYPE_ID,creator,getDrawData,getLayerChanges,layerRemoved,getUIComponent);
 export default {factoryDef, TYPE_ID}; // every draw layer must default export with factoryDef and TYPE_ID
 
 
@@ -65,7 +65,9 @@ function creator(initPayload, presetDefaults={}) {
 
     const drawingDef= {...makeDrawingDef(),
             size: size || 5,
-            symbol: DrawSymbol.get(symbol) || DrawSymbol.SQUARE,
+            symbol: DrawSymbol.get(symbol) ||
+                DrawSymbol.get(get(tableMeta,MetaConst.DEFAULT_SYMBOL)) ||
+                DrawSymbol.SQUARE,
         ...presetDefaults};
 
     const pairs= { [MouseState.DOWN.key]: highlightChange };
@@ -117,6 +119,10 @@ function creator(initPayload, presetDefaults={}) {
         searchTargetVisible: true,
         searchTargetDrawingDef,
     };
+}
+
+function layerRemoved(drawLayer,action) {
+    releaseColor(drawLayer.drawingDef.color);
 }
 
 

--- a/src/firefly/js/drawingLayers/DistanceTool.js
+++ b/src/firefly/js/drawingLayers/DistanceTool.js
@@ -95,10 +95,15 @@ function creator() {
 
 function onDetach(drawLayer,action) {
     var {plotIdAry}= action.payload;
-    plotIdAry.forEach( (plotId) => dispatchAttributeChange({
-        plotId,overlayColorScope:false,
-        attKey:PlotAttribute.ACTIVE_DISTANCE,attValue:null
-    }));
+    plotIdAry.forEach( (plotId) => {
+        const plot= primePlot(visRoot(),plotId);
+        if (plot && plot.attributes[PlotAttribute.ACTIVE_DISTANCE]) {
+            dispatchAttributeChange({
+                plotId,overlayColorScope:false,
+                attKey:PlotAttribute.ACTIVE_DISTANCE,attValue:null
+            });
+        }
+    });
 }
 
 function getCursor(plotView, screenPt) {

--- a/src/firefly/js/drawingLayers/PointSelection.js
+++ b/src/firefly/js/drawingLayers/PointSelection.js
@@ -43,9 +43,14 @@ function dispatchSelectPoint(mouseStatePayload) {
 
 function onDetach(drawLayer,action) {
     const {plotIdAry}= action.payload;
-    plotIdAry.forEach( (plotId) => dispatchAttributeChange(
-        { plotId ,overlayColorScope:false,attKey:PlotAttribute.ACTIVE_POINT,attValue:null }
-    ));
+    plotIdAry.forEach( (plotId) => {
+        const plot= primePlot(visRoot(),plotId);
+        if (plot && plot.attributes[PlotAttribute.ACTIVE_POINT]) {
+            dispatchAttributeChange(
+                { plotId ,overlayColorScope:false,attKey:PlotAttribute.ACTIVE_POINT,attValue:null }
+            );
+        }
+    });
 }
 
 

--- a/src/firefly/js/drawingLayers/SelectArea.js
+++ b/src/firefly/js/drawingLayers/SelectArea.js
@@ -108,8 +108,13 @@ function creator(initPayload) {
 function onDetach(drawLayer,action) {
     const {plotIdAry}= action.payload;
     plotIdAry.forEach( (plotId) => {
-        dispatchAttributeChange({plotId, overlayColorScope:false, attKey:PlotAttribute.SELECTION, attValue:null});
-        dispatchAttributeChange({plotId,overlayColorScope:false,attKey:PlotAttribute.IMAGE_BOUNDS_SELECTION,attValue:null});
+        const plot= primePlot(visRoot(),plotId);
+        if (plot && plot.attributes[PlotAttribute.SELECTION]) {
+            dispatchAttributeChange({plotId, overlayColorScope:false, attKey:PlotAttribute.SELECTION, attValue:null});
+        }
+        if (plot && plot.attributes[PlotAttribute.IMAGE_BOUNDS_SELECTION]) {
+            dispatchAttributeChange({plotId,overlayColorScope:false,attKey:PlotAttribute.IMAGE_BOUNDS_SELECTION,attValue:null});
+        }
     });
 }
 

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -145,6 +145,7 @@ export function getDrawLayerCntlrDef(drawLayerFactory) {
         actionCreators() {
             return {
                 [DETACH_LAYER_FROM_PLOT] :  makeDetachLayerActionCreator(drawLayerFactory),
+                [DESTROY_DRAWING_LAYER] :  makeDestoyLayerActionCreator(drawLayerFactory),
                 [CHANGE_VISIBILITY] :  makeChangeVisibilityActionCreator(drawLayerFactory),
                 [SELECT_AREA_END] :  selectAreaEndActionCreator,
                 [DT_END] :  distanceToolEndActionCreator,
@@ -603,6 +604,17 @@ function getDrawLayerIdAry(dlRoot,id, matchTitles= false) {
 //=============================================
 //=============================================
 //=============================================
+
+function makeDestoyLayerActionCreator(factory) {
+    return (action) => {
+        return (dispatcher) => {
+            const {drawLayerId}= action.payload;
+            const drawLayer= getDrawLayerById(getDlAry(), drawLayerId);
+            factory.onDetachAction(drawLayer,action);
+            dispatcher(action);
+        };
+    };
+}
 
 function makeDetachLayerActionCreator(factory) {
     return (action) => {

--- a/src/firefly/js/visualize/draw/DrawingDef.js
+++ b/src/firefly/js/visualize/draw/DrawingDef.js
@@ -6,17 +6,21 @@ import {DrawSymbol} from './PointDataObj.js';
 import Enum from 'enum';
 
 
-export const COLOR_SELECTED_PT = '#ffff00';
+export const COLOR_SELECTED_PT = '#ffff00'; // yellow
 export const COLOR_HIGHLIGHTED_PT = '#ff8000'; // orange
-export const COLOR_PT_1 = '#ff0000'; // red
-export const COLOR_PT_2 = '#00ff00'; //green
-export const COLOR_PT_3 = 'pink';  // pink
-export const COLOR_PT_4 = '#00a8ff'; //blue
-export const COLOR_PT_5 =  '#990099'; //purple
-export const COLOR_PT_6 = '#ff8000'; //orange
+const COLOR_PT_1 = '#ff0000'; // red
+const COLOR_PT_2 = '#00ff00'; //green
+const COLOR_PT_3 = 'pink';  // pink
+const COLOR_PT_4 = '#00a8ff'; //blue
+const COLOR_PT_5 =  '#990099'; //purple
+const COLOR_PT_6 = '#ff8000'; //orange
+const COLOR_PT_7 = '#00ffff'; //Aqua
+const COLOR_PT_8 = '#800000'; //Maroon
 
-export const COLOR_DRAW_1 = '#ff0000';
-export const COLOR_DRAW_2 = '#5500ff';
+const USED_COLORS= [COLOR_PT_1, COLOR_PT_2, COLOR_PT_3, COLOR_PT_5, COLOR_PT_6, COLOR_PT_7, COLOR_PT_8];
+
+export const COLOR_DRAW_1 = '#ff0000'; // red
+export const COLOR_DRAW_2 = '#5500ff'; // purple
 
 /** 
  *  enum
@@ -77,7 +81,7 @@ export const DEFAULT_FONT_SIZE = '9pt';
  * Object to hold defaults for drawing a group of objects.
  *
  * @param color
- * @param pointData
+ * @param presetDefaults
  * @return {DrawingDef}
  */
 export function makeDrawingDef(color= 'red', presetDefaults= {}) {
@@ -101,17 +105,21 @@ export function makeDrawingDef(color= 'red', presetDefaults= {}) {
     return Object.assign({}, def, presetDefaults);
 }
 
+const colorList= USED_COLORS.map( (c) => ({count:0, name:c}));
 
-
-export function *colorGenerator() {
-    const defColors= [COLOR_PT_1, COLOR_PT_2, COLOR_PT_3, COLOR_PT_5, COLOR_PT_6];
-    var colorCnt= 0;
-    while (true) {
-        yield defColors[colorCnt% defColors.length];
-        colorCnt++;
-    }
+export function getNextColor() {
+    const nextColor= [...colorList].sort( (cO1, cO2) => cO1.count-cO2.count)[0];
+    nextColor.count++;
+    return nextColor.name;
 }
 
-const nextColor= colorGenerator();
+export function releaseColor(cName) {
+    const colorObj= colorList.find( (cO) => cO.name===cName);
+    if (colorObj && colorObj.count>0) colorObj.count--;
+}
 
-export const getNextColor= () => nextColor.next().value;
+
+
+
+
+

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -106,8 +106,7 @@ export function watchCatalogs(tbl_id, action, cancelSelf, params) {
 
 function handleCatalogUpdate(tbl_id) {
     const sourceTable= getTblById(tbl_id);
-
-
+    if (!sourceTable || sourceTable.isFetching) return;
     const {totalRows, request, highlightedRow,selectInfo, title}= sourceTable;
     const maxScatterRows = getMaxScatterRows();
     const columns= findTableCenterColumns(sourceTable);
@@ -117,7 +116,7 @@ function handleCatalogUpdate(tbl_id) {
     const params= {
         startIdx : 0,
         pageSize : MAX_ROW,
-        inclCols : `"${columns.lonCol}","${columns.latCol}","ROW_IDX"`        // column names should be in quotes
+        inclCols : `"${columns.lonCol}","${columns.latCol}","ROW_IDX"`        // clumn names should be in quotes
     };
 
     let req = cloneRequest(sourceTable.request, params);

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -250,7 +250,7 @@ function updateCoverage(tbl_id, viewerId, preparedTables, options, tblCatIdMap, 
 
     try {
         const table = getTblById(tbl_id);
-        if (!table) return;
+        if (!table || table.isFetching) return;
         if (preparedTables[tbl_id] === 'WORKING') return;
 
 
@@ -645,8 +645,9 @@ function cleanUpOptions(options) {
  */
 function findPreferredHiPS(tbl_id,prevPreferredHipsSourceURL, optionHipsSourceURL, preparedTable) {
 
+    const table = getTblById(tbl_id);
+    if (!table || table.isFetching) return optionHipsSourceURL;
     if (!preparedTable) { // if a new table then the meta takes precedence
-        const table = getTblById(tbl_id);
         if (table && table.tableMeta[MetaConst.COVERAGE_HIPS]) return table.tableMeta[MetaConst.COVERAGE_HIPS];
     }
     const plot= primePlot(visRoot(), PLOT_ID);


### PR DESCRIPTION
Firefly-324: Fixed: when a catalog is reloaded from the background manager its color changes.

 - Other bugs: not checking when tableMode.isFetching, table model was not complete
 - Added a couple of more color so catalogs are less likely to duplicate
 - Firefly-181: now can define DEFAULT_SYMBOL in table meta just like you can DEFAULT_COLOR

see issue described in  https://jira.ipac.caltech.edu/browse/FIREFLY-324 _or_
https://jira.lsstcorp.org/browse/DM-11426

_to test:_

 https://irsawebdev9.ipac.caltech.edu/firefly-324-redraw/firefly/

- do a catalog search long enough to take a few seconds e.g. wise/m31/400 arcsec
- send it to the background as soon as the message appears on the tab.
- load the table from the background monitor
- after everything come up, click on the background monitor again, it will reload the table with the same color for the overlay.

