### PR TITLE
FIREFLY-165 Update the firefly docker with clean up and auto VM sizing

### DIFF
--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -511,7 +511,7 @@ task dockerImage (dependsOn: loadConfig) {
         docker_tag = project.appConfigProps.docker_tag ?: docker_tag
         docker_registry = project.appConfigProps.docker_registry ?: docker_registry
         docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
-        def docker_build_args = "--build-arg IMAGE_NAME=${docker_registry}${docker_repo} --build-arg APP_NAME=${project['app-name']}"
+        def docker_build_args = "--build-arg IMAGE_NAME=${docker_registry}${docker_repo}"
 
         def res = exec {
             workingDir "${project.buildDir}/docker"

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -511,10 +511,11 @@ task dockerImage (dependsOn: loadConfig) {
         docker_tag = project.appConfigProps.docker_tag ?: docker_tag
         docker_registry = project.appConfigProps.docker_registry ?: docker_registry
         docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
+        def docker_build_args = "--build-arg IMAGE_NAME=${docker_registry}${docker_repo} --build-arg APP_NAME=${project['app-name']}"
 
         def res = exec {
             workingDir "${project.buildDir}/docker"
-            commandLine "docker build --pull -t ${docker_registry}${docker_repo}:${docker_tag} --build-arg IMAGE_NAME=${docker_registry}${docker_repo} .".split(' ')
+            commandLine "docker build --pull -t ${docker_registry}${docker_repo}:${docker_tag} ${docker_build_args} .".split(' ')
         }
         if (res.getExitValue() != 0) {
             throw new GradleException("Fail to create docker image")

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -2,7 +2,7 @@
 FROM tomcat:9.0.11-jre10
 
 #-----------------------------------------------------------------------------
-# To build: docker build -t ipac/firefly --build-arg IMAGE_NAME=ipac/firefly .
+# To build: docker build -t ipac/firefly --build-arg IMAGE_NAME=ipac/firefly --build-arg APP_NAME=firefly .
 # For help in running: docker run --rm  ipac/firefly --help
 #-----------------------------------------------------------------------------
 
@@ -44,10 +44,13 @@ ENV VISUALIZE_FITS_SEARCH_PATH=${EXTERNAL_MOUNT_POINT}
 ARG IMAGE_NAME=''
 ENV BUILD_TIME_NAME=${IMAGE_NAME}
 
-
+# container need access to app name, used for cleanup task
+ARG APP_NAME=''
+ENV FIREFLY_APP_NAME=${APP_NAME}
 
 # These are the file there are executed at startup, they start tomcat
 COPY launchTomcat.sh \
+     cleanup.sh \
      start-examples.txt \
      setupSharedCacheJars.sh ${CATALINA_BASE}/
 
@@ -58,7 +61,7 @@ COPY tomcat-users.xml \
 
 
 # Make directories, make scripts executable, save old tomcat config files, remove unwanted apps
-RUN chmod +x ${CATALINA_BASE}/launchTomcat.sh ${CATALINA_BASE}/setupSharedCacheJars.sh; \
+RUN chmod +x ${CATALINA_BASE}/launchTomcat.sh ${CATALINA_BASE}/cleanup.sh ${CATALINA_BASE}/setupSharedCacheJars.sh; \
     mkdir -p ${SERVER_CONFIG_DIR}; \
     mkdir -p ${FIREFLY_WORK_DIR}; \
     mkdir -p ${EXTERNAL_MOUNT_POINT}; \
@@ -80,16 +83,21 @@ EXPOSE 8080 5050
 # ----------------------------------------------------------
 # ----------------------------------------------------------
 # Overide the following from the command line:
-#          MIN_JVM_SIZE, MAX_JVM_SIZE, ADMIN_USER, ADMIN_PASSWORD,
+#          MIN_JVM_SIZE, MAX_JVM_SIZE,
+#          INIT_RAM_PERCENT, MAX_RAM_PERCENT,
+#          ADMIN_USER, ADMIN_PASSWORD,
 #          DEBUG, jvmRoute, LOG_FILE_TO_CONSOLE, FIREFLY_OPTS,
 # ----------------------------------------------------------
 # ----------------------------------------------------------
 
-# MIN_JVM_SIZE and MAX_JVM_SIZE should be used to set the min and max JVM side
-# at least MAX_JVM_SIZE should almost alway be used on the command line with 
-# parameter such as: -e "MAX_JVM_SIZE=4G"
+# MIN_JVM_SIZE and MAX_JVM_SIZE can be used to set the min and max JVM side
+# If MAX_JVM_SIZE is not set, the memory is autosized to the memory available to the container.
+# Set the available memory on the command line with --memory="4g"
+# You can change MAX_RAM_PERCENT on the command line with -e "MAX_RAM_PERCENT=80"
 ENV MIN_JVM_SIZE=1G
-ENV MAX_JVM_SIZE=8G
+ENV MAX_JVM_SIZE=
+ENV INIT_RAM_PERCENT=10
+ENV MAX_RAM_PERCENT=90
 ENV JVM_CORES=0
 
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -2,7 +2,7 @@
 FROM tomcat:9.0.11-jre10
 
 #-----------------------------------------------------------------------------
-# To build: docker build -t ipac/firefly --build-arg IMAGE_NAME=ipac/firefly --build-arg APP_NAME=firefly .
+# To build: docker build -t ipac/firefly --build-arg IMAGE_NAME=ipac/firefly .
 # For help in running: docker run --rm  ipac/firefly --help
 #-----------------------------------------------------------------------------
 
@@ -43,10 +43,6 @@ ENV VISUALIZE_FITS_SEARCH_PATH=${EXTERNAL_MOUNT_POINT}
 # container has access to the image name, used for help only
 ARG IMAGE_NAME=''
 ENV BUILD_TIME_NAME=${IMAGE_NAME}
-
-# container need access to app name, used for cleanup task
-ARG APP_NAME=''
-ENV FIREFLY_APP_NAME=${APP_NAME}
 
 # These are the file there are executed at startup, they start tomcat
 COPY launchTomcat.sh \

--- a/docker/base/cleanup.sh
+++ b/docker/base/cleanup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Cleanup script for Firefly app
+
+# /usr/bin/find if testing locally
+find_cmd="/bin/find"
+
+function doCleanup() {
+    workarea="${1}"
+
+    # find cleanup logs less than 23 hours old
+    recent_cleanup=`${find_cmd} "${workarea}/cleanup_logs" -type f -mmin -$((60*23))`
+
+    if [[ -z "${recent_cleanup}" ]] ; then
+
+        timestamp=$(date +20%y%m%dT%H%M%S)
+        log_file="${workarea}/cleanup_logs/cleanup.${timestamp}.log"
+
+        echo "Cleaning up old work files in ${workarea}" > "${log_file}" 2>&1
+        ${find_cmd} "${workarea}/stage" -type f -mtime +7 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+        # master catalogs should be cleared more often than other files
+        ${find_cmd} "${workarea}/perm_files" -name 'master*' -mtime +1 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+        ${find_cmd} "${workarea}/perm_files" -type f -mtime +7 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+        ${find_cmd} "${workarea}/temp_files" -type f -mtime +1 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+        ${find_cmd} "${workarea}/visualize" -type f -mtime +2 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+
+        ${find_cmd} "${workarea}/upload" -type f -mtime +7 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+        #${find_cmd} "${workarea}/HiPS" -type f -mtime +90 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+
+        dirs_to_clear=("${workarea}/visualize/users" "${workarea}/temp_files")
+        for d in ${dirs_to_clear[@]}; do
+            if [ -d "${d}" ]; then
+                # remove all empty directories excluding those at the starting level
+                ${find_cmd} "${d}" -mindepth 1 -depth -type d -empty -print -exec /bin/rmdir '{}' \; >> "${log_file}" 2>&1
+            fi
+        done
+
+    fi
+}
+
+sleep 24h
+
+while true; do
+    # Remove temporary products for each Firefly workarea
+    for workarea_dir in "$@"
+    do
+        log_dir="${workarea_dir}/${FIREFLY_APP_NAME}/cleanup_logs"
+        if [ ! -d "${log_dir}" ]; then
+            mkdir -p "${log_dir}"
+        fi
+        # Remove old cleanup log files
+        ${find_cmd} "${log_dir}" -type f -mtime +10 -exec /bin/rm '{}' \+
+
+        if [ -d "${workarea_dir}" ]; then
+            doCleanup "${workarea_dir}/${FIREFLY_APP_NAME}"
+        fi
+    done
+
+    sleep 24h
+done

--- a/docker/base/launchTomcat.sh
+++ b/docker/base/launchTomcat.sh
@@ -32,8 +32,10 @@ echo
 echo "Properties: "
 echo "        Description                  Property                 Value"
 echo "        -----------                  --------                 -----"
-echo "        Min JVM size                 MIN_JVM_SIZE            ${MIN_JVM_SIZE}"
-echo "        Min JVM size                 MAX_JVM_SIZE            ${MAX_JVM_SIZE}"
+echo "        Min JVM size (*)             MIN_JVM_SIZE            ${MIN_JVM_SIZE}"
+echo "        Max JVM size (*)             MAX_JVM_SIZE            ${MAX_JVM_SIZE}"
+echo "        Initial JVM size (**)        INIT_RAM_PERCENT        ${INIT_RAM_PERCENT}"
+echo "        Max JVM size (**)            MAX_RAM_PERCENT         ${MAX_RAM_PERCENT}"
 echo "        CPU cores (0 means guess)    JVM_CORES               ${JVM_CORES}"
 echo "        Multi node sticky routing    jvmRoute                ${JVM_ROUTE}"
 echo "        Admin username               ADMIN_USER              ${ADMIN_USER}"
@@ -44,6 +46,8 @@ echo "        Tomcat Manager available     MANAGER                 ${MANAGER}"
 echo "        Multi web app shared cache   SHARE_CACHE             ${SHARE_CACHE}"
 echo "        Extra firefly properties     FIREFLY_OPTS            ${FIREFLY_OPTS}"
 echo "        Shared work Area             FIREFLY_SHARED_WORK_DIR ${FIREFLY_SHARED_WORK_DIR}"
+echo "(*)  If MAX_JVM_SIZE is blank, autosizing properties INIT_RAM_PERCENT and MAX_RAM_PERCENT are used instead"
+echo "(**) Autosizing properties INIT_RAM_PERCENT and MAX_RAM_PERCENT are not used if MAX_JVM_SIZE is set"
 echo
 echo "Ports: "
 echo "        8080 - http"
@@ -91,6 +95,8 @@ if [ "x$FIREFLY_SHARED_WORK_DIR" != "x" ]; then
       mkdir -p ${FIREFLY_SHARED_WORK_DIR}
 fi
 
+# run cleanup script in the background
+${CATALINA_BASE}/cleanup.sh ${FIREFLY_WORK_DIR} ${FIREFLY_SHARED_WORK_DIR} &
 
 if [ "$DEBUG" = "true" ] ||[ "$DEBUG" = "t" ] ||[ "$DEBUG" = "1" ] ||  \
    [ "$DEBUG" = "TRUE" ] || [ "$DEBUG" = "True" ] || [ "$1" = "--debug" ]; then

--- a/docker/base/setenv.sh
+++ b/docker/base/setenv.sh
@@ -1,7 +1,12 @@
+# if MAX_JVM_SIZE is not specified, use auto-sizing parameters INIT_RAM_PERCENT and MAX_RAM_PERCENT
+if [ -z ${MAX_JVM_SIZE} ]; then
+   JVM_SIZING="-XX:InitialRAMPercentage=${INIT_RAM_PERCENT} -XX:MaxRAMPercentage=${MAX_RAM_PERCENT}"
+else
+   JVM_SIZING="-Xms${MIN_JVM_SIZE} -Xmx${MAX_JVM_SIZE}"
+fi
 
 CATALINA_OPTS="\
-        -Xms${MIN_JVM_SIZE} \
-        -Xmx${MAX_JVM_SIZE} \
+        ${JVM_SIZING} \
         -Dserver.cores=${JVM_CORES} \
         -DjvmRoute=${JVM_ROUTE} \
         -Djava.net.preferIPv4Stack=true"

--- a/docker/base/start-examples.txt
+++ b/docker/base/start-examples.txt
@@ -1,6 +1,7 @@
    _________________________ EXAMPLES ________________________
 
 -e  : Define environment variable in the container
+-m  : (or --memory) The maximum amount of memory the container can use.
 -p  : Map a local port to a the container port (8080 is required)
 -v  : Map a local directory to the container directory
 -rm : Remove the image after the run (recommended)
@@ -8,28 +9,28 @@
 
 -------------------- Very Simple - try this one first:
 
-   docker run -p 8090:8080  -e "MAX_JVM_SIZE=8G" --rm ipac/firefly
+   docker run -p 8090:8080  --memory=8g --rm ipac/firefly
 
 -------------------- More advanced:
 
 Background:
-   docker run -p 8090:8080  -e "MAX_JVM_SIZE=8G" --rm ipac/firefly >& my.log &
+   docker run -p 8090:8080  --memory=8g --rm ipac/firefly >& my.log &
 
 Map a directory for direct file reading:
-   docker run -p 8090:8080  -v /local/data:/external -e "MAX_JVM_SIZE=8G" --rm ipac/firefly
+   docker run -p 8090:8080  -v /local/data:/external --memory=8g --rm ipac/firefly
 
 Write to logging directory outside of docker image:
-   docker run -p 8090:8080 -v /local/myLogDir:/usr/local/tomcat/logs -e "MAX_JVM_SIZE=8G" --rm ipac/firefly
+   docker run -p 8090:8080 -v /local/myLogDir:/usr/local/tomcat/logs --memory=8g --rm ipac/firefly
 
 View log file:
-   docker run -p 8090:8080  -e "MAX_JVM_SIZE=8G" -e "LOG_FILE_TO_CONSOLE=firefly.log" --rm ipac/firefly
+   docker run -p 8090:8080  --memory=8g -e "LOG_FILE_TO_CONSOLE=firefly.log" --rm ipac/firefly
 
 Debugging:
-   docker run -p 8055:8080 -p 5050:5050 -p 9050:9050 -e "MAX_JVM_SIZE=4G" -e "ADMIN_PASSWORD=myPassword" -e DEBUG="TRUE" -e "LOG_FILE_TO_CONSOLE=firefly.log" --rm --name firefly ipac/firefly
+   docker run -p 8055:8080 -p 5050:5050 -p 9050:9050 --memory=4g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="TRUE" -e "LOG_FILE_TO_CONSOLE=firefly.log" --rm --name firefly ipac/firefly
 
 Production like:
-   docker run -p 8055:8080 -p 9050:9050 -e "MAX_JVM_SIZE=30G" -e "ADMIN_PASSWORD=myPassword" -e SHARE_CACHE="TRUE" -e DEBUG="FALSE" -e "jvmRoute=MyHostName" --name productionServer ipac/firefly
+   docker run -p 8055:8080 -p 9050:9050 --memory=30g -e "ADMIN_PASSWORD=myPassword" -e SHARE_CACHE="TRUE" -e DEBUG="FALSE" -e "jvmRoute=MyHostName" --name productionServer ipac/firefly
 
 Production like, multiple tomcats, using a shared work directory:
-   docker run -p 8055:8080 -p 9050:9050 -e "MAX_JVM_SIZE=30G" -e "ADMIN_PASSWORD=myPassword" \
+   docker run -p 8055:8080 -p 9050:9050 --memory=30g -e "ADMIN_PASSWORD=myPassword" \
     -e "FIREFLY_SHARED_WORK_DIR=/local/shared/work/area" -v /local/shared/work/area --name productionServer ipac/firefly

--- a/docker/base/start-examples.txt
+++ b/docker/base/start-examples.txt
@@ -1,7 +1,7 @@
    _________________________ EXAMPLES ________________________
 
 -e  : Define environment variable in the container
--m  : (or --memory) The maximum amount of memory the container can use.
+-m  : (or --memory=) The maximum amount of memory the container can use
 -p  : Map a local port to a the container port (8080 is required)
 -v  : Map a local directory to the container directory
 -rm : Remove the image after the run (recommended)

--- a/docker/k8s/firefly.yaml
+++ b/docker/k8s/firefly.yaml
@@ -34,8 +34,6 @@ spec:
               key: ADMIN_PASSWORD
         - name: FIREFLY_OPTS
           value: "-Dvisualize.fits.search.path=/datasets"
-        - name: MAX_JVM_SIZE
-          value: "15G"
         - name: DEBUG
           value: "FALSE"
       volumes:

--- a/docs/firefly-docker.md
+++ b/docs/firefly-docker.md
@@ -12,7 +12,7 @@ Firefly from docker
 
 To run latest/nightly dev:
 
-`docker run -p 8090:8080  -e "MAX_JVM_SIZE=8G" --rm ipac/firefly:nightly`
+`docker run -p 8090:8080 --memory=8g --rm ipac/firefly:nightly`
 
 See tags here: https://hub.docker.com/r/ipac/firefly/tags
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-165
Test deployment: https://irsawebdev9.ipac.caltech.edu/firefly-165_docker/firefly/

> gradle :firefly:bAAD
> gradle :firefly:dockerImage
> docker run -p 8090:8080  --memory=1g --rm ipac/firefly

(If using mac docker, docker VM is limited by default to 2G, but it can be changed to a higher number using the Whale 🐳 icon in the task bar, then Preferences -> Advanced.)

To see which files were cleaned
> docker stats 
> docker exec -it `containerIdOrName` bash

The cleanup logs are in `/usr/local/tomcat-base/firefly-work/firefly/cleanup_logs`