### PR TITLE
FIREFLY-166: fix votable link using relative index instead of absolute

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -13,9 +13,8 @@ FROM tomcat:9.0.11-jre10
 # add packages: vim, etc
 # add any other standard apt packages here
 RUN apt-get update && apt-get install -y \
-        vim procps wget emacs24-nox \
-        && rm -rf var/lib/apt/lists//*
-
+        vim procps wget emacs-nox \
+        && rm -rf /var/lib/apt/lists/*
 
 # create catalina_base directory .. so tomcat can run as non-root
 ENV CATALINA_HOME=/usr/local/tomcat

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -73,7 +73,7 @@ const BasicTableViewInternal = React.memo((props) => {
 
     const makeColumnsProps = {columns, data, selectable, selectInfoCls, renderers, bgColor,
         columnWidths, filterInfo, sortInfo, showUnits, showTypes, showFilters,
-        onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected, tbl_id};
+        onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected, startIdx, tbl_id};
 
     const content = () => {
         if (error) {
@@ -322,11 +322,11 @@ function makeColumns (props) {
 
 
 function makeColumnTag(props, col, idx) {
-    const {data, columnWidths, showUnits, showTypes, showFilters, filterInfo, sortInfo, onSort, onFilter, tbl_id, renderers, bgColor='white'} = props;
+    const {data, columnWidths, showUnits, showTypes, showFilters, filterInfo, sortInfo, onSort, onFilter, tbl_id, renderers, bgColor='white', startIdx} = props;
 
     if (col.visibility && col.visibility !== 'show') return false;
     const HeadRenderer = get(renderers, [col.name, 'headRenderer'], HeaderCell);
-    const CellRenderer = get(renderers, [col.name, 'cellRenderer'], getDefaultRenderer(col, tbl_id));
+    const CellRenderer = get(renderers, [col.name, 'cellRenderer'], getDefaultRenderer(col, tbl_id, startIdx));
     const fixed = col.fixed || false;
     const style = col.fixed && {backgroundColor: bgColor};
 
@@ -362,9 +362,9 @@ function makeSelColTag({selectable, onSelectAll, showUnits, showTypes, showFilte
     );
 }
 
-function getDefaultRenderer(col={}, tbl_id) {
+function getDefaultRenderer(col={}, tbl_id, startIdx) {
     if (col.type === 'location' || !isEmpty(col.links)) {
-        return ((props) => <LinkCell {...props} {...{tbl_id, col}}/>);
+        return ((props) => <LinkCell {...props} {...{tbl_id, col, startIdx}}/>);
     }
 
     return TextCell;

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -204,7 +204,7 @@ export class TablePanel extends PureComponent {
                                 callbacks={tableConnector}
                                 { ...{columns, data, hlRowIdx, rowHeight, selectable, showUnits, allowUnits, showTypes, showFilters,
                                     selectInfoCls, filterInfo, sortInfo, textView, showMask, currentPage,
-                                    tableConnector, renderers, tbl_ui_id} }
+                                    tableConnector, renderers, tbl_ui_id, startIdx} }
                             />
                             {showOptionButton && !showToolbar &&
                             <img className='TablePanel__options--small'

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -268,14 +268,15 @@ export class TextCell extends Component {
  * LinkCell is implementing A.4 using link substitution based on A.1
  */
 export const LinkCell = React.memo((props) => {
-    const {tbl_id, col={}, rowIndex, style={}} = props;
+    const {tbl_id, col={}, rowIndex, style={}, startIdx} = props;
+    const absRowIdx = rowIndex + startIdx;              // rowIndex is the index of the current page.  Add startIdx to get the absolute index of the row in the full table.
     const val = getValue(props) || '';
     let mStyle = style;
     let className = 'public_fixedDataTableCell_cellContent';
     if (col.links) {
         const tableModel = getTblById(tbl_id);
         if (col.links.length === 1) {
-            const rval = resolveHRefVal(tableModel, get(col, 'links.0.value', val), rowIndex);
+            const rval = resolveHRefVal(tableModel, get(col, 'links.0.value', val), absRowIdx);
             className += isNumeric(rval) ? ' right_align' : '';
         }
         return (
@@ -284,8 +285,8 @@ export const LinkCell = React.memo((props) => {
                     col.links.map( (link={}, idx) => {
                         const {href, title, value=val, action} = link;
                         const target = action || '_blank';
-                        const rvalue = resolveHRefVal(tableModel, value, rowIndex);
-                        const rhref = resolveHRefVal(tableModel, href, rowIndex, val);
+                        const rvalue = resolveHRefVal(tableModel, value, absRowIdx);
+                        const rhref = resolveHRefVal(tableModel, href, absRowIdx, val);
                         if (idx > 0) mStyle = {marginLeft: 3, ...mStyle};
                         return (<ATag key={'ATag_' + idx} href={rhref}
                                       {...{value:rvalue, title, target, style:mStyle}}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-364

As described in the ticket, link substitution uses relative index instead of an absolute one.  The returned value is wrong because it's taken from the first page.  

To test, simply compare this PR build to the one from nightly.  Use `file upload` with sample test file: `firefly_test_data/FileUpload-samples/VOTable/tabledata/multiTables_Ned.xml`
The first column(`Object Name`) has a reference to itself.  You will see in the nightly build that the referenced's value is no longer correct after the first page.  This is fixed in this PR build.

nightly:  https://irsawebdev9.ipac.caltech.edu/nightly/firefly/
PR test: https://irsawebdev9.ipac.caltech.edu/FIREFLY-364_votable_link_substitution/firefly/