### PR TITLE
FIREFLY-80: switch to Java 11 openJDK and Java 1.8 openJDK

### DIFF
--- a/buildScript/depends.gincl
+++ b/buildScript/depends.gincl
@@ -24,6 +24,7 @@ ext {
                  ':jaxrpc',
                  ':saaj',
                  ':activation',
+                 ':jta',
                  ':mail']
 
   j2ee_lib = [j2ee_rt_lib,


### PR DESCRIPTION
see https://github.com/IPAC-SW/irsa-ife-env/pull/2