### PR TITLE
FIREFLY-360: revert changes made previously to onSort behavior

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -471,7 +471,9 @@ function tableSort(action) {
             const [nreq, tableStub, tableModel] = setupTableOps(tbl_id, request);
             if (!tableStub) return;
 
+            // rollback changes to keep current highlighted row.  instead set highlighted to 0.
             // TblUtil.setHlRowByRowIdx(nreq, tableModel);
+            nreq.startIdx = 0;
 
             dispatch({type:TABLE_FETCH, payload: tableStub});
 

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -471,7 +471,7 @@ function tableSort(action) {
             const [nreq, tableStub, tableModel] = setupTableOps(tbl_id, request);
             if (!tableStub) return;
 
-            TblUtil.setHlRowByRowIdx(nreq, tableModel);
+            // TblUtil.setHlRowByRowIdx(nreq, tableModel);
 
             dispatch({type:TABLE_FETCH, payload: tableStub});
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-360
Test: https://irsawebdev9.ipac.caltech.edu/FIREFLY-360_revert_highlight_onsort/firefly/

As described in the ticket, highlighted row should be set to 0 after sorting.  This behavior should be for all tables, including `client` tables.

Some known client tables:
Images -> View HIPS Images -> Select Data Set
Then click the `i` icon on the image toolbar to bring up another client table.
