### PR TITLE
Firefly 342 improve jenkins to manage multiple tags

### DIFF
--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -589,7 +589,7 @@ task dockerDelete (dependsOn: loadConfig){
     group = DOCKER_GROUP
 
     ext.docker_repo = "ipac/firefly"
-    ext.docker_registry = ''
+    ext.docker_registry = "https://cloud.docker.com/v2/repositories" //Docker registry defaults to Docker Hub. In case this needs to change, then either change this value here, or using 'project.appConfigProps'
 
     doLast {
         try {
@@ -610,7 +610,7 @@ task dockerDelete (dependsOn: loadConfig){
         docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
 
         //DELETE Restful call:
-        def str = "https://cloud.docker.com/v2/repositories/${docker_repo}/tags/${docker_tag}/"
+        def str = "${docker_registry}${docker_repo}/tags/${docker_tag}/"
         def encoding = "${docker_user}:${docker_passwd}".bytes.encodeBase64().toString()
 
         def conn = new URL(str).openConnection();

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -584,7 +584,8 @@ task dockerPublish (dependsOn: dockerImage) {
 
 
 task dockerDelete (dependsOn: loadConfig){
-    description = 'Delete a docker image from docker hub.'
+    description = ''' Delete a docker image from docker hub.
+                      Example:  gradle -Pdocker_tag=<tag name> :firefly:dockerDelete '''
     group = DOCKER_GROUP
 
     ext.docker_repo = "ipac/firefly"
@@ -620,7 +621,7 @@ task dockerDelete (dependsOn: loadConfig){
         conn.connect()
 
         if(conn.getResponseCode() >= 400) {
-            throw new GradleException("Fail to delete docker image")
+            throw new GradleException("Fail to delete docker image, using URL: ${str}")
         }
 
     }

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -582,6 +582,51 @@ task dockerPublish (dependsOn: dockerImage) {
 }
 
 
+
+task dockerDelete (dependsOn: loadConfig){
+    description = 'Delete a docker image from docker hub.'
+    group = DOCKER_GROUP
+
+    ext.docker_repo = "ipac/firefly"
+    ext.docker_registry = ''
+
+    doLast {
+        try {
+            "docker --version".execute()
+        } catch (Exception e) {
+            println ">> docker is not installed.  This task required docker"
+            throw new GradleException("docker is not installed.  This task required docker", e)
+        }
+
+        if (project.appConfigProps.docker_user != '') {
+            def proc = "docker login --username ${project.appConfigProps.docker_user} --password ${project.appConfigProps.docker_passwd}".execute()
+            proc.waitForOrKill(10000)
+            println ">> docker login as ${project.appConfigProps.docker_user} with exit status ${proc.exitValue()}"
+        }
+
+        docker_repo = project.appConfigProps.docker_repo ?: docker_repo
+        docker_registry = project.appConfigProps.docker_registry ?: docker_registry
+        docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
+
+        //DELETE Restful call:
+        def str = "https://cloud.docker.com/v2/repositories/${docker_repo}/tags/${docker_tag}/"
+        def encoding = "${docker_user}:${docker_passwd}".bytes.encodeBase64().toString()
+
+        def conn = new URL(str).openConnection();
+        conn.setRequestMethod("DELETE")
+        conn.setDoOutput(true)
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+        conn.setRequestProperty("Authorization", "Basic " + encoding)
+        conn.connect()
+
+        if(conn.getResponseCode() >= 400) {
+            throw new GradleException("Fail to delete docker image")
+        }
+
+    }
+}
+
+
 task onlinehelp (dependsOn: [loadConfig]) {
     description = 'Bundled onlinehelp with the webapp'
     group = SUB_GROUP

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -508,7 +508,6 @@ task dockerImage (dependsOn: loadConfig) {
         }
 
         docker_repo = project.appConfigProps.docker_repo ?: docker_repo
-        docker_tag = project.appConfigProps.docker_tag ?: docker_tag
         docker_registry = project.appConfigProps.docker_registry ?: docker_registry
         docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
         def docker_build_args = "--build-arg IMAGE_NAME=${docker_registry}${docker_repo}"
@@ -545,6 +544,7 @@ task dockerPublish (dependsOn: dockerImage) {
             throw new GradleException("docker is not installed.  This task required docker", e)
         }
 
+
         if (project.appConfigProps.docker_user != '') {
             def proc = "docker login --username ${project.appConfigProps.docker_user} --password ${project.appConfigProps.docker_passwd}".execute()
             proc.waitForOrKill(10000)
@@ -556,14 +556,28 @@ task dockerPublish (dependsOn: dockerImage) {
         def docker_registry = project.appConfigProps.docker_registry ?: dockerImage.docker_registry
         docker_registry = docker_registry == '' || docker_registry.endsWith('/') ? docker_registry : docker_registry + '/'
 
-        def res = exec {
-            workingDir "${project.buildDir}/docker"
-            commandLine "docker push ${docker_registry}${docker_repo}:${docker_tag}".split(' ')
+
+        def docker_tags = docker_tag.split(',')
+        def res = ''
+
+        for (tag in docker_tags){
+            exec {
+              workingDir "${project.buildDir}/docker"
+              commandLine "docker tag ${docker_repo}:${dockerImage.docker_tag} ${docker_repo}:${tag}".split(' ')
+            }
+
+            res = exec {
+                  workingDir "${project.buildDir}/docker"
+                  commandLine "docker push ${docker_repo}:${tag}".split(' ')
+                }
+            if (res.getExitValue() != 0) {
+                throw new GradleException("Fail to push docker image")
+            }
         }
-        if (res.getExitValue() != 0) {
-            throw new GradleException("Fail to push docker image")
-        }
+
         return res;
+
+
     }
 }
 


### PR DESCRIPTION
This ticket does:
1- Modifying gradle "dockerPublish" task to take multiple tags for a K8s build.
2- Adding new "dockerDelete" task to gradle tasks. This task deletes docker image form docker hub.

To test:
1- Use Jenkins's [snadbox](http://irsawebdev5:8100/job/sandbox/) job to build K8s build, and specify multiple tags for that build: 
2- Use Jenkins's [sandbox2](http://irsawebdev5:8100/job/sandbox2/) job to delete the K8s build. It should delete the image tag from docker hub too.

irsa-ife-env PR: https://github.com/IPAC-SW/irsa-ife-env/pull/4 