### PR TITLE
IRSA-3121-showing the option to Send to background in TimeSeries

### DIFF
--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -173,10 +173,12 @@ function bgPackage(action) {
         SearchServices.packageRequest(dlRequest, searchRequest, selectionInfo)
             .then((bgStatus) => {
                 if (bgStatus) {
+                    const fileName = dlRequest.fileName|| dlRequest.Title.split(':')[0];
+                    bgStatus.fileName = fileName;
                     bgStatus = bgStatusTransform(bgStatus);
                     const url = get(bgStatus, ['ITEMS', 0, 'url']);
                     if (url && isSuccess(get(bgStatus, 'STATE'))) {
-                        download(url);
+                        download(url, bgStatus.fileName);
                     } else {
                         dispatchJobAdd(bgStatus);
                     }

--- a/src/firefly/js/core/background/BackgroundMonitor.jsx
+++ b/src/firefly/js/core/background/BackgroundMonitor.jsx
@@ -184,7 +184,7 @@ function PackageStatus(bgStatus) {
     );
 }
 
-function SinglePackage({ID, Title, STATE, ITEMS=[]}) {
+function SinglePackage({ID, Title, fileName, STATE, ITEMS=[]}) {
     var progress;
     if (BG_STATE.WAITING.is(STATE)) {
         progress = <div className='BGMon__header--waiting'>Computing number of packages... <img style={{marginLeft: 3}} src={LOADING}/></div>;
@@ -194,17 +194,17 @@ function SinglePackage({ID, Title, STATE, ITEMS=[]}) {
         progress = <div>User aborted this request</div>;
     } else {
         const params = ITEMS[0] || {};
-        progress = <PackageItem SINGLE={true} STATE={STATE} ID={ID} {...params} />;
+        progress = <PackageItem SINGLE={true} STATE={STATE} ID={ID} Title={Title} fileName={fileName} {...params} />;
     }
     return (
         <PackageHeader {...{ID, Title, progress, STATE}} />
     );
 }
 
-function MultiPackage({ID, Title, STATE, ITEMS}) {
+function MultiPackage({ID, Title, fileName, STATE, ITEMS}) {
     var progress = BG_STATE.CANCELED.is(STATE) && <div>User aborted this request</div>;
     const packages = ITEMS.map( (pi, INDEX) => {
-                return <PackageItem key={'multi-' + INDEX} STATE={STATE} ID={ID} {...ITEMS[INDEX]} />;
+                return <PackageItem key={'multi-' + INDEX} STATE={STATE} fileName={fileName} ID={ID} {...ITEMS[INDEX]} />;
             });
 
     return (
@@ -244,11 +244,12 @@ function PackageHeader({ID, Title, progress, STATE}) {
 }
 
 function PackageItem(progress) {
-    const {SINGLE, ID, INDEX, STATE, finalCompressedBytes, processedBytes, totalBytes, processedFiles, totalFiles, url, downloaded} = progress;
+    const {SINGLE, ID, fileName, INDEX, STATE, finalCompressedBytes, processedBytes, totalBytes, processedFiles, totalFiles, url, downloaded} = progress;
     const doDownload = () => {
         var bgStatus = set({ID}, ['ITEMS', INDEX, 'downloaded'], DownloadProgress.WORKING);
         dispatchBgStatus(bgStatus);
-        downloadWithProgress(url)
+        downloadWithProgress(url,fileName)
+
             .then( () => {
                 bgStatus = set({ID}, ['ITEMS', INDEX, 'downloaded'], DownloadProgress.DONE);
                 dispatchBgStatus(bgStatus);

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -152,10 +152,14 @@ export const BG_STATE  = new Enum([
 ]);
 
 
-export function bgDownload({dlRequest, searchRequest, selectInfo}, {key, onComplete, sentToBg}) {
+export function bgDownload({dlRequest, searchRequest, selectInfo}, {key, onComplete, sentToBg, isWs=false}) {
     dispatchComponentStateChange(key, {inProgress:true, bgStatus:undefined});
     packageRequest(dlRequest, searchRequest, SelectInfo.newInstance(selectInfo).toString())
         .then((bgStatus) => {
+            //add fileLocation and fileName information to the bgStatus
+            bgStatus.isWs=isWs;
+            const fileName = dlRequest.fileName|| dlRequest.Title.split(':')[0];
+            bgStatus.fileName = fileName;
             if (bgStatus) {
                 dispatchComponentStateChange(key, {bgStatus});
                 bgStatus = bgStatusTransform(bgStatus);

--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -28,13 +28,18 @@ export class BgMaskPanel extends SimpleComponent {
             bgStatus && dispatchJobAdd(bgStatus);
         };
 
+        const button = bgStatus && bgStatus.isWs?
+            <button type='button' style={maskButton} className='button std'> Saving to workspace, please wait...</button>:
+            <button type='button' style={maskButton} className='button std' onClick={sendToBg}>Please click to send to background</button>;
+
+
         if (inProgress) {
             return (
                 <div style={maskStyle}>
                     <div className='loading-mask'/>
                     {bgStatus &&
                     <div style={{display: 'flex', alignItems: 'center'}}>
-                        <button type='button' style={maskButton} className='button std' onClick={sendToBg}>Send to background</button>
+                      {button}
                     </div>
                     }
                 </div>

--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -13,13 +13,13 @@ import {basicURLPlotRequest} from './basic/BasicPlotRequests';
 import {LsstSdssSettingBox, lsstSdssOnNewRawTable, lsstSdssOnFieldUpdate, lsstSdssRawTableRequest} from './lsst_sdss/LsstSdssMissionOptions.js';
 import {DefaultSettingBox, defaultOnNewRawTable, defaultOnFieldUpdate, defaultRawTableRequest} from './generic/DefaultMissionOptions.js';
 import {BasicSettingBox, basicOnNewRawTable, basicOnFieldUpdate, basicRawTableRequest, imagesShouldBeDisplayed} from './basic/BasicMissionOptions.js';
-import {WiseSettingBox, wiseOnNewRawTable, wiseOnFieldUpdate, wiseRawTableRequest, wiseYColMappings, isValidWiseTable} from './wise/WiseMissionOptions.js';
-import {PTFSettingBox, ptfOnNewRawTable, ptfOnFieldUpdate, ptfRawTableRequest, isValidPTFTable, ptfDownloaderOptPanel} from './ptf/PTFMissionOptions.js';
-import {ZTFSettingBox, ztfOnNewRawTable, ztfOnFieldUpdate, ztfRawTableRequest, isValidZTFTable, ztfDownloaderOptPanel} from './ztf/ZTFMissionOptions.js';
+import {WiseSettingBox, wiseYColMappings, isValidWiseTable} from './wise/WiseMissionOptions.js';
+import {PTFSettingBox, isValidPTFTable} from './ptf/PTFMissionOptions.js';
+import {ZTFSettingBox, isValidZTFTable} from './ztf/ZTFMissionOptions.js';
 import {getWebPlotRequestViaZTFIbe} from './ztf/ZTFPlotRequests.js';
-
+import {onNewRawTable, onFieldUpdate , makeRawTableRequest} from './LcUtil';
 import {LC} from './LcManager.js';
-import {getColumnIdx, getTblInfoById} from '../../tables/TableUtil';
+import { getTblInfoById} from '../../tables/TableUtil';
 
 export const DL_DATA_TAG = 'timeseries-package';
 export const UNKNOWN_MISSION = 'generic';
@@ -90,9 +90,9 @@ const converters = {
         getYColMappings: wiseYColMappings,
         missionName: 'WISE/NEOWISE',
         MissionOptions: WiseSettingBox,
-        onNewRawTable: wiseOnNewRawTable,
-        onFieldUpdate: wiseOnFieldUpdate,
-        rawTableRequest: wiseRawTableRequest,
+        onNewRawTable: onNewRawTable,
+        onFieldUpdate: onFieldUpdate,
+        rawTableRequest: makeRawTableRequest,
         /*timeNames: ['mjd'],*/
         /*yNames: ['w1mpro_ep', 'w2mpro_ep', 'w3mpro_ep', 'w4mpro_ep'],*/
         yErrNames: '',
@@ -130,15 +130,14 @@ const converters = {
         defaultYErrCname: '',
         missionName: 'PTF',
         MissionOptions: PTFSettingBox,
-        onNewRawTable: ptfOnNewRawTable,
-        onFieldUpdate: ptfOnFieldUpdate,
-        rawTableRequest: ptfRawTableRequest,
+        onNewRawTable: onNewRawTable,
+        onFieldUpdate: onFieldUpdate,
+        rawTableRequest: makeRawTableRequest,
         yErrNames: '',
         dataSource: 'pid',
         webplotRequestCreator: getWebPlotRequestViaPTFIbe,
         shouldImagesBeDisplayed: () => {return true;},
         isTableUploadValid:isValidPTFTable,
-        downloadOptions: ptfDownloaderOptPanel,
         yNamesChangeImage: [],
         showPlotTitle:getPlotTitle
     },
@@ -150,15 +149,14 @@ const converters = {
         defaultYErrCname: '',
         missionName: 'ZTF',
         MissionOptions: ZTFSettingBox,
-        onNewRawTable: ztfOnNewRawTable,
-        onFieldUpdate: ztfOnFieldUpdate,
-        rawTableRequest: ztfRawTableRequest,
+        onNewRawTable: onNewRawTable,
+        onFieldUpdate: onFieldUpdate,
+        rawTableRequest: makeRawTableRequest,
         yErrNames: '',
         dataSource: 'field',
         webplotRequestCreator: getWebPlotRequestViaZTFIbe,
         shouldImagesBeDisplayed: () => {return true;},
         isTableUploadValid:isValidZTFTable,
-        downloadOptions: ztfDownloaderOptPanel,
         yNamesChangeImage: [],
         showPlotTitle:getPlotTitle
     },

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -39,8 +39,9 @@ import {convertAngle} from '../../visualize/VisUtil.js';
 
 const resultItems = ['title', 'mode', 'showTables', 'showImages', 'showXyPlots', 'searchDesc', 'images',
     LC.MISSION_DATA, LC.GENERAL_DATA, 'periodState'];
+import {BgMaskPanel} from '../../core/background/BgMaskPanel.jsx';
 
-
+export const LcXYPlotCompKey='XYPLOTAREA';
 export class LcResult extends PureComponent {
 
     constructor(props) {
@@ -138,22 +139,19 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
     const cutoutSizeInDeg = (convertAngle('arcmin','deg', cutoutSize)).toString();
     const currentTime =  (new Date()).toLocaleString('en-US', { hour12: false });
     const style = {width: 223};
-    const defaultOptPanel = (m, c) => {
+    const dlParams = getParamters(mission, LcXYPlotCompKey );
+    const downloaderOptPanel = (m, c) => {
         return (
             <DownloadButton>
                 <DownloadOptionPanel
                     groupKey = {mission}
                     dataTag = {DL_DATA_TAG}
                     cutoutSize={c}
+                    backgroundable = {true}
                     title={'Image Download Options'}
                     style = {{width: 400}}
-                    dlParams={{
-                        MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
-                        FilePrefix: `${m}_Files`,
-                        BaseFileName: `${m}_Files`,
-                        DataSource: `${m} images`,
-                        FileGroupProcessor: 'LightCurveFileGroupsProcessor'
-                    }}>
+                    dlParams={dlParams}
+                    >
                     <ValidationField
                         style={style}
                         initialState={{
@@ -167,7 +165,6 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
         );
     };
 
-    const downloaderOptPanel = convertData.downloadOptions || defaultOptPanel;
 
     let tsView = (err) => {
 
@@ -183,7 +180,10 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
                                 </div>
                             </div>
                         </SplitContent>
-                        <SplitContent>{xyPlot}</SplitContent>
+                        <SplitContent>
+                            <BgMaskPanel componentKey={LcXYPlotCompKey}/>
+                            {xyPlot}
+                        </SplitContent>
                     </SplitPane>
                     <SplitContent>{imagePlot}</SplitContent>
                 </SplitPane>
@@ -199,7 +199,10 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
                             </div>
                         </div>
                     </SplitContent>
-                    <SplitContent>{xyPlot}</SplitContent>
+                    <SplitContent>
+                        <BgMaskPanel componentKey={LcXYPlotCompKey}/>
+                        {xyPlot}
+                     </SplitContent>
                 </SplitPane>
             );
         }
@@ -375,3 +378,47 @@ function updateFullRawTable(callback) {
        }
     }
 }
+
+
+function getParamters(mission, bgMaskPanelKey){
+    switch (mission.toLowerCase()){
+        case 'ptf':
+            return {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ptf image is ~33mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'PtfLcDownload',
+                ProductLevel:'l1',
+                schema:'images',
+                table:'level1',
+                key: `${bgMaskPanelKey}`
+            };
+            break;
+        case 'ztf' :
+            return  {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ztf image is ~37mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'ZtfLcDownload',
+                ProductLevel:'sci',
+                schema:'products',
+                table:'sci',
+                key: `${bgMaskPanelKey}`
+            };
+            break;
+        default:
+            return  {
+                MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
+                FilePrefix: `${mission}_Files`,
+                BaseFileName: `${mission}_Files`,
+                DataSource: `${mission} images`,
+                FileGroupProcessor: 'LightCurveFileGroupsProcessor',
+                key: `${bgMaskPanelKey}`
+            };
+    };
+
+
+}
+

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -1,15 +1,10 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get,  set, isNil} from 'lodash';
-import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
-import {getCellValue, getTblById, getColumnIdx, smartMerge, getColumns, COL_TYPE} from '../../../tables/TableUtil.js';
-import {makeFileRequest} from '../../../tables/TableRequestUtil.js';
-import {sortInfoString} from '../../../tables/SortInfo.js';
-import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
+import {getCellValue, getTblById} from '../../../tables/TableUtil.js';
+import {getInitialDefaultValues,renderMissionView,validate,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
-import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
-import {ValidationField} from '../../../ui/ValidationField.jsx';
-import {DL_DATA_TAG} from '../LcConverterFactory.js';
+
 
 
 const labelWidth = 80;
@@ -87,106 +82,4 @@ export function isValidPTFTable() {
                         Please select the "Other" upload option for tables that do not meet these requirements.`;
         return {errorMsg, isValid:false};
    }
-}
-
-/**
- * Pregex pattern for ptf, at least to find obsmjd and mag_autocorr if present
- * @type {string[]}
- */
-const xyColPattern = ['obsmjd', 'mag_autocorr'];
-
-export function ptfOnNewRawTable(rawTable, missionEntries, generalEntries, converterData, layoutInfo) {
-
-    // Update default values AND sortInfo and
-    const metaInfo = rawTable && rawTable.tableMeta;
-
-    const numericalCols = getColumns(rawTable, COL_TYPE.NUMBER).map((c) => c.name);
-    const defaultDataSource = (getColumnIdx(rawTable, converterData.dataSource) > 0) ? converterData.dataSource : numericalCols[3];
-
-    const {defaultCTimeName,defaultYColName } = getTimeAndYColInfo(numericalCols, xyColPattern, rawTable,converterData );
-
-    const defaultValues = {
-        [LC.META_TIME_CNAME]: get(metaInfo, LC.META_TIME_CNAME, defaultCTimeName),
-        [LC.META_FLUX_CNAME]: get(metaInfo, LC.META_FLUX_CNAME, defaultYColName),
-        [LC.META_TIME_NAMES]: get(metaInfo, LC.META_TIME_NAMES, numericalCols),
-        [LC.META_FLUX_NAMES]: get(metaInfo, LC.META_FLUX_NAMES, numericalCols),
-        [LC.META_URL_CNAME]: get(metaInfo, LC.META_URL_CNAME, defaultDataSource),
-        [LC.META_FLUX_BAND]: get(metaInfo, LC.META_FLUX_BAND, 'g')
-
-    };
-
-    missionEntries = Object.assign({}, missionEntries, defaultValues);
-    const newLayoutInfo = smartMerge(layoutInfo, {missionEntries, generalEntries});
-
-    return {newLayoutInfo, shouldContinue: false};
-}
-
-//TODO if ptfRawTableRequest and ptfOnFieldUpdate are nothing different from the ones in ptfMssionOption, these two can be replaced.
-export function ptfRawTableRequest(converter, source, uploadFileName='') {
-    const timeCName = converter.defaultTimeCName;
-    const mission = converter.converterId;
-    const options = {
-        tbl_id: LC.RAW_TABLE,
-        sortInfo: sortInfoString(timeCName), // if present, it will skip LcManager.js#ensureValidRawTable
-        META_INFO: {[LC.META_MISSION]: mission, timeCName},
-        pageSize: LC.TABLE_PAGESIZE,
-        uploadFileName
-
-    };
-    return makeFileRequest('Input Data', source, null, options);
-
-}
-
-
-export function ptfOnFieldUpdate(fieldKey, value) {
-    // images are controlled by radio button -> filter g, R.
-    if (fieldKey === LC.META_TIME_CNAME) {
-        return fileUpdateOnTimeColumn(fieldKey, value);
-    } else if ([LC.META_FLUX_CNAME, LC.META_ERR_CNAME,  LC.META_FLUX_BAND].includes(fieldKey)) {
-        return {[fieldKey]: value};
-    }
-
-
-}
-
-/**
- *  This is specialized for PTF download.
- *  Gets the download option panel for PTF with specific file processor id 'PtfDownload'
- * @param mission
- * @param cutoutSizeInDeg
- * @returns {XML}
- */
-export function ptfDownloaderOptPanel (mission, cutoutSizeInDeg) {
-    const currentTime = (new Date()).toLocaleString('en-US', { hour12: false });
-
-    const style = {width: 167};
-    return (
-        <DownloadButton>
-            <DownloadOptionPanel
-                groupKey = {mission}
-                dataTag = {DL_DATA_TAG}
-                cutoutSize={cutoutSizeInDeg}
-                title={'Image Download Options'}
-                dlParams={{
-                    MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ptf image is ~33mb
-                    FilePrefix: `${mission}_Files`,
-                    BaseFileName: `${mission}_Files`,
-                    DataSource: `${mission} images`,
-                    FileGroupProcessor: 'PtfLcDownload',
-                    ProductLevel:'l1',
-                    schema:'images',
-                    table:'level1'
-                }}>
-                <ValidationField
-                    style={style}
-                    initialState={{
-                        value: `${mission}_Files: ${currentTime}`,
-                        label: 'PTF:'
-                    }}
-
-                    fieldKey='Title'
-                    labelWidth={110}/>
-            </DownloadOptionPanel>
-        </DownloadButton>
-    );
 }

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -13,6 +13,9 @@ import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 import update from 'immutability-helper';
 import {ServerParams} from '../data/ServerParams';
+import {validateFileName} from '../ui/DownloadOptionsDialog';
+import {getWorkspacePath, WS_SERVER_PARAM} from '../visualize/WorkspaceCntlr';
+import {doDownloadWorkspace} from '../ui/WorkspaceViewer';
 
 
 const MEG          = 1048576;
@@ -376,11 +379,13 @@ export function copyToClipboard(str) {
 }
 
 /**
- * @param {string} url  the url to download.  It should be based on AnyFileDownload
- * @param {number} [numTries=1000]  number of time to check for progress until giving up
- * @returns {Promise}  resolve is called on DONE and reject when FAIL.
+ *
+ * @param url
+ * @param fileName
+ * @param numTries
+ * @returns {Promise<any>}
  */
-export function downloadWithProgress(url, numTries=1000) {
+export function downloadWithProgress(url, fileName, numTries=1000) {
     return new Promise(function(resolve, reject) {
         const {search} = parseUrl(url);
         let cnt = 0;
@@ -405,7 +410,7 @@ export function downloadWithProgress(url, numTries=1000) {
             }, interval);
         };
         doIt();
-        download(url);
+        download(url, fileName);
     });
 }
 
@@ -434,7 +439,8 @@ function resolveFileName(resp) {
 export function download(url, filename) {
     const {protocol, host, path, hash, searchObject={}} = parseUrl(url);
     const cmd = searchObject[ServerParams.COMMAND];
-    url = `${protocol}//${host}${path}?${ServerParams.COMMAND}=${cmd}` + (hash ? '#' + hash : '');      // add cmd into the url as a workaround for server-side code not supporting it
+    url = cmd? `${protocol}//${host}${path}?${ServerParams.COMMAND}=${cmd}` + (hash ? '#' + hash : ''):      // add cmd into the url as a workaround for server-side code not supporting it
+        url;
 
     const params = Object.fromEntries(
                         Object.entries(searchObject)
@@ -849,3 +855,31 @@ export function hashCode(str) {
 export function isNumeric(n) {
     return !isNaN(parseFloat(n)) && isFinite(n);
 }
+
+
+export function doDownload (bgStatus, isWorkSpace, wsSelect, fileName) {
+    const url1 = get(bgStatus, ['ITEMS', 0, 'url']);
+    const urlInfo =parseUrl(url1);
+    const searchObj = urlInfo.searchObject;
+    const file = searchObj.file;
+    const url = isWorkSpace ? `${getRootURL()}sticky/CmdSrv`
+        : url1;
+
+    if (isWorkSpace) {
+        if (!validateFileName(wsSelect, fileName)) return false;
+    }
+
+    if (isWorkSpace) {
+        const zipFileName = fileName + '.zip';
+        const params = {[WS_SERVER_PARAM.currentrelpath.key]:getWorkspacePath(wsSelect, zipFileName),
+            [WS_SERVER_PARAM.newpath.key]: zipFileName,
+            file,
+            [ServerParams.COMMAND]: ServerParams.WS_PUT_IMAGE_FILE,
+            [WS_SERVER_PARAM.should_overwrite.key]: true};
+
+        url && doDownloadWorkspace(url, {params});
+        //showInfoPopup('File:' + fileName + '.zip is saved to workspace!', 'Workspace Info');
+    } else {
+        url && download(url, fileName);
+    }
+};


### PR DESCRIPTION
  1. Remove the redundancy of the  download panel (ZtfDownloadOptionPanel, PtfDownloadOptionPanel), and all download among missions share the same download panel
  2. Modify the downloaderOptPanel in LcResult,  to make it backgorundable and share with all missions
  3. Add BgMaskPanel in LcResult

@ejoliet 
When I worked on Firefly-159 and IRSA-3113, I found that the multi-downloand panel is very problem pron.  I fixed the bug in DefaultPanel, I found only WISE worked right and ZTF, PTF all did not work.  After I looked into these two, I found there is no need to maintain three similar download panels.   If you compare the ptf/ztf panel with the default panel, you find the only difference is the mission parameters.  Thus, I removed ZTF/PTF download panel and modified the default download panel to share among the missions.  When I fix bug, I only need to fix it in one download panel. 

This pull request is depending on Firefly-159.  FYI

Test URL is
 https://irsawebdev9.ipac.caltech.edu/irsa-3121-Lijun/irsaviewer/ts.html


