### PR TITLE
FIREFLY-357: after filtering decimated plot table crashes

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -418,7 +418,8 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                 highlightedRow =  JdbcFactory.getSimpleTemplate(dbAdapter.getDbInstance(dbFile))
                         .queryForInt(String.format("select row_num from %s where ROW_IDX = %d", resultSetID, hlRowByRowIdx));
             } catch (Exception e) {
-                // row does not exists in new resultset.. ignore the error.
+                // row does not exists in new resultset.. reset highlightedRow.
+                highlightedRow = 0;
             }
         }
         if (highlightedRow >= 0) {

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -838,16 +838,15 @@ export function dispatchError(chartId, traceNum, reason) {
     const {data=[]} = getChartData(chartId);
     let forTrace = '';
     if (data.length == 1) {
-        // this apply to Radar SED plot
         const name = get(data, `${traceNum}.name`);
-        forTrace = ` ${name}`;
+        // if a trace is user named, mention the name
+        forTrace = name && !name.toLowerCase().startsWith('trace') ? ` for ${name}` : '';
     } else if (data.length > 1) {
-        // only mention trace, when there are multiple traces
+        // mention trace name when there are multiple traces
         const name = get(data, `${traceNum}.name`, `trace ${traceNum}`);
         forTrace = ` for ${name}`;
     }
     let message = `Cannot display requested data${forTrace}`;
-    logError(`${message}: ${reason}`);
 
     let reasonStr = `${reason}`.toLowerCase();
     if (reasonStr.match(/not supported/)) {
@@ -864,9 +863,10 @@ export function dispatchError(chartId, traceNum, reason) {
     //     message = 'The columns requested are identical or one of them is not numerical.';
     //     reasonStr = reason;
     } else if (reasonStr.match(/failed to retrieve/) || reasonStr.match(/no data/) || reasonStr.match(/null/)){
-        message = `No data available:${forTrace} data`;
+        message = `No data available${forTrace}`;
         reasonStr = '';
     } else {
+        logError(`${message}: ${reason}`);
         reasonStr = '';
     }
     const changes = {};

--- a/src/firefly/js/charts/dataTypes/FireflyHistogram.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHistogram.js
@@ -89,7 +89,8 @@ function fetchData(chartId, traceNum, tablesource) {
             }
 
             let histogramData = [];
-            if (tableModel.tableData && tableModel.tableData.data) {
+            const tblData = get(tableModel, 'tableData.data');
+            if (tblData) {
                 // if logarithmic values were requested, convert the returned exponents back
                 var toNumber = get(options, 'x', '').includes('log') ?
                     (val, i)=> {
@@ -97,7 +98,7 @@ function fetchData(chartId, traceNum, tablesource) {
                         return (i === 0) ? Number(val) : Math.pow(10, Number(val));
                     } : (val)=>Number(val);
                 var nrow, lastIdx;
-                histogramData = tableModel.tableData.data.reduce((data, arow, i) => {
+                histogramData = tblData.reduce((data, arow, i) => {
                     nrow = arow.map(toNumber);
                     lastIdx = data.length - 1;
                     if (i > 0 && data[lastIdx][1] === nrow[1]) {

--- a/src/firefly/js/drawingLayers/Artifact.js
+++ b/src/firefly/js/drawingLayers/Artifact.js
@@ -182,15 +182,15 @@ function toAngle(d, radianToDegree)  {
 function createDrawData(drawLayer, tableModel) {
     if (!tableModel) return;
 
-    const {tableData}= tableModel;
-    if (!tableData.data.length) return;
+    const tblData = get(tableModel, 'tableData.data', []);
+    if (!tblData.length) return;
 
     const columns= findTableCenterColumns(tableModel);
     if (isEmpty(columns) || columns.lonIdx<0 || columns.latIdx<0) return null;
 
     const {angleInRadian:rad}= drawLayer;
 
-    const data= tableData.data.map( (d) => {
+    const data= tblData.map( (d) => {
         const wp= makeWorldPt( toAngle(d[columns.lonIdx],rad), toAngle(d[columns.latIdx],rad), columns.csys);
         return PointDataObj.make(wp);
     });

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -55,11 +55,14 @@ export function fetchTable(tableRequest, hlRowIdx) {
     .then( (tableModel) => {
         const startIdx = get(tableModel, 'request.startIdx', 0);
         if (startIdx > 0) {
-            // shift data arrays indices to match partial fetch
-            tableModel.tableData.data = tableModel.tableData.data.reduce( (nAry, v, idx) => {
-                nAry[idx+startIdx] = v;
-                return nAry;
-            }, []);
+            const tblData = get(tableModel, 'tableData.data');
+            if (tblData) {
+                // shift data arrays indices to match partial fetch
+                tableModel.tableData.data = tblData.reduce((nAry, v, idx) => {
+                    nAry[idx + startIdx] = v;
+                    return nAry;
+                }, []);
+            }
         }
         if (tableModel.selectInfo) {
             // convert selectInfo to JS object

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -993,7 +993,7 @@ export function getDataLinkAccessUrls(originTableOrId, dataLinkTable, filterStr=
     const originTable= getTableModel(originTableOrId);
     const data= get(dataLinkTable, 'tableData.data', []);
     if (!data.length) return [];
-    const urlOptions= dataLinkTable.tableData.data.map( (row,idx) => {
+    const urlOptions= get(dataLinkTable, 'tableData.data', []).map( (row,idx) => {
         const url= getCellValue(dataLinkTable,idx,'access_url' );
         const contentType= getCellValue(dataLinkTable,idx,'content_type' );
         const size= Number(getCellValue(dataLinkTable,idx,'content_length' ));

--- a/src/firefly/js/visualize/HiPSListUtil.js
+++ b/src/firefly/js/visualize/HiPSListUtil.js
@@ -206,7 +206,7 @@ export function resolveHiPSIvoURL(ivoOrUrl) {
             if (ivoIdx<0 || urlIdx<1) return undefined;
             const lowerIvo= ivoOrUrl.toLowerCase();
             // now match the table
-            const foundRow= tableModel.tableData.data.find( (row) =>
+            const foundRow= get(tableModel,'tableData.data', []).find( (row) =>
                                 row[ivoIdx] && row[ivoIdx].toLowerCase().includes(lowerIvo) );
             const replaceUrl= foundRow && foundRow[urlIdx];
             return replaceUrl || ivoOrUrl;

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -197,8 +197,9 @@ export function computeCentralPtRadiusAverage(inPoints2dAry) {
     const {centralPoint, maxRadius}= computeCentralPointAndRadius(testAry);
     if (inPoints2dAry.length===1) return {centralPoint, maxRadius, avgOfCenters:centralPoint};
 
-    const centers= inPoints2dAry.map( (ptAry) =>
-              isOnePoint(ptAry) ? ptAry[0] : computeCentralPointAndRadius(ptAry).centralPoint);
+    const centers= inPoints2dAry
+        .map( (ptAry) => isOnePoint(ptAry) ? ptAry[0] : computeCentralPointAndRadius(ptAry).centralPoint)
+        .filter((pt) => pt); // filter out undefined centers
 
     const {centralPoint:avgOfCenters}= computeCentralPointAndRadius(centers);
     return {centralPoint, maxRadius, avgOfCenters};

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -132,7 +132,7 @@ function handleCatalogUpdate(tbl_id) {
 
     doFetchTable(req).then(
         (tableModel) => {
-            if (tableModel.tableData && tableModel.tableData.data) {
+            if (tableModel.tableData) {
                 updateDrawingLayer(tbl_id, tableModel,
                     request, highlightedRow, selectInfo, columns, dataTooBigForSelection);
             }

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -220,7 +220,7 @@ function updateColumnWidth(anyTableModel, colName, colWidth) {
 
         if (idx >= 0) {
             if (colWidth < 0) {
-                colWidth = anyTableModel.tableData.data.reduce((prev, d) => {
+                colWidth = get(anyTableModel, 'tableData.data', []).reduce((prev, d) => {
                     if (d[idx].length > prev)  {
                         prev = d[idx].length;
                     }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-357
Test build: https://irsawebdev9.ipac.caltech.edu/firefly-357_filterbugs/firefly/

- Fixed a bug in EmbeddedDbProcessor:handleHighlightedRowRequest - when highlighted row is not in [filtered] table, it should be reset. (This was causing empty table when filtering from a chart when on last pages and with highlighted row not in filtered table.
- Since tableData.data can be undefined when no data available, we should handle this situation. When data are used as an array, use empty array.
- When filtering from image and no points are in the selection, "IN ( )" was causing database errors. Using ROW_IDX<0 instead.
- Catalog overlay should not show, when the connected table is empty after filtering.
- IRSA-3117 merge partially reverted  previous behavior that trace name should be mentioned only when there are multiple traces. The trace name should be mentioned when it's user assigned, but should not be mentioned, when it's Firefly assigned (ex. "trace 1")

Known bugs:
Coverage overlay stays unchanged when the connected table is filtered to empty. 
CoverageWatcher behavior needs to be revisited in a separate ticket.
