### PR TITLE
FIREFLY-381: Prepare download dialog updates

### DIFF
--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {dispatchJobAdd} from './BackgroundCntlr.js';
 import {getComponentState} from '../../core/ComponentCntlr.js';
-import {SimpleComponent} from '../../ui/SimpleComponent.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 
 
 /**
@@ -15,41 +15,37 @@ import {SimpleComponent} from '../../ui/SimpleComponent.jsx';
  */
 
 
-export class BgMaskPanel extends SimpleComponent {
+export const BgMaskPanel = React.memo(({componentKey, style={}}) => {
 
-    getNextState(np) {
-        return getComponentState(this.props.componentKey);
-    }
+    const [{inProgress, bgStatus}] = useStoreConnector(() => getComponentState(componentKey));
 
-    render() {
-        const {inProgress, bgStatus} = this.state;
-        const sendToBg = () => {
-            const {bgStatus} = this.state;
-            bgStatus && dispatchJobAdd(bgStatus);
-        };
+    const sendToBg = () => {
+        bgStatus && dispatchJobAdd(bgStatus);
+    };
+    const maskStyle = {...defMaskStyle, ...style};
 
-        if (inProgress) {
-            return (
-                <div style={maskStyle}>
-                    <div className='loading-mask'/>
-                    {bgStatus &&
-                    <div style={{display: 'flex', alignItems: 'center'}}>
-                        <button type='button' style={maskButton} className='button std' onClick={sendToBg}>Send to background</button>
-                    </div>
-                    }
+    if (inProgress) {
+        return (
+            <div style={maskStyle}>
+                <div className='loading-mask'/>
+                {bgStatus &&
+                <div style={{display: 'flex', alignItems: 'center'}}>
+                    <button type='button' style={maskButton} className='button std' onClick={sendToBg}>Send to background</button>
                 </div>
-            );
-        } else {
-            return null;
-        }
+                }
+            </div>
+        );
+    } else {
+        return null;
     }
-}
+});
 
 BgMaskPanel.propTypes = {
-    componentKey: PropTypes.string.isRequired, // key used to identify this background job
+    componentKey: PropTypes.string.isRequired,  // key used to identify this background job
+    style: PropTypes.object                     // used for overriding default styling
 };
 
-const maskStyle = {
+const defMaskStyle = {
             position: 'relative',
             width: '100%',
             height: '100%',


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-381

Add progress indicator and option to background prepare download jobs.  This should be implemented such that the behavior is consistent among all applications using Firefly.
See `Intended behavior: ` section of the ticket for more details.

To test, use Time Series:  https://irsawebdev9.ipac.caltech.edu/FIREFLY-381_download_dialog_mask/firefly/ts.html
- Upload a file
- Select all from the `Input Data` result table
- Click `Prepare Download` located top right corner.


PS.  
https://irsawebdev9.ipac.caltech.edu/FIREFLY-381_download_dialog_mask/applications/finderchart/
I built finderchart to see if the above changes would propagate down to finderchart, and it did not.  The reason is because finderchart is using a copy of the above dialog and not using one made through widget composition. (FinderchartDownloadDialog.jsx)  This is an example of the multiple versions issue I mentioned in the meeting.
