### PR TITLE
FIREFLY-384: update to download dialog

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -107,6 +107,17 @@ div.rootStyle img {
     cursor: pointer;
 }
 
+.button.large {
+    white-space: nowrap;
+    border: 2px solid white;
+    border-radius: 7px;
+    color: white;
+    font-weight: bold;
+    font-size: larger;
+    padding: 6px;
+    background-color: gray
+}
+
 .clickable:hover {
     cursor: pointer;
 }

--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -420,6 +420,10 @@ div.rootStyle img {
     margin-bottom: 3px;
 }
 
+.FieldGroup__vertical--more > * {
+    margin-bottom: 5px;
+}
+
 /*------------------- styled-select >---------------------*/
 .styled-select select {
     background: transparent;

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/BackgroundStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/BackgroundStatus.java
@@ -44,6 +44,7 @@ public class BackgroundStatus implements Serializable {
     public static final String FILE_PATH = "FILE_PATH";
     public static final String TOTAL_BYTES = "TOTAL_BYTES";
     public static final String DATA_TAG = "DataTag";
+    public static final String WS_DEST_PATH = "WS_DEST_PATH";
 
     // most likely not used anymore  <---
     public static final String PUSH_DATA_BASE = "PUSH_DATA_#";

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/DownloadRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/DownloadRequest.java
@@ -19,6 +19,8 @@ public class DownloadRequest extends ServerRequest implements Serializable {
     public static final String EMAIL = "Email";
     public static final String MAX_BUNDLE_SIZE = "MaxBundleSize";
     public static final String DATA_SOURCE = "DataSource";
+    public static final String FILE_LOC = "fileLocation";
+    public static final String WS_DEST_PATH = "wsSelect";
 
 
     private TableServerRequest searchRequest;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/BackgroundInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/BackgroundInfo.java
@@ -26,6 +26,7 @@ class BackgroundInfo implements Serializable {
     private String baseFileName;
     private String title;
     private String dataTag;
+    private String workspaceDestPath;           // if this is not null, push the packaged files to workspace
     private ServerEvent.EventTarget eventTarget;
 //======================================================================
 //----------------------- Constructors ---------------------------------
@@ -36,6 +37,7 @@ class BackgroundInfo implements Serializable {
                           String baseFileName,
                           String title,
                           String dataTag,
+                          String workspaceDestPath,
                           ServerEvent.EventTarget eventTarget,
                           boolean canceled) {
         this.bgStat= bgStat;
@@ -45,6 +47,8 @@ class BackgroundInfo implements Serializable {
         this.dataTag = dataTag;
         this.eventTarget= eventTarget;
         this.title = title;
+        this.workspaceDestPath = workspaceDestPath;
+
     }
 
 //======================================================================
@@ -80,6 +84,10 @@ class BackgroundInfo implements Serializable {
 
     public String getTitle() { return title; }
 
+    public String getWorkspaceDestPath() {
+        return workspaceDestPath;
+    }
+
     public void setTitle(String title) {
         this.title = title;
         bgStat.setParam(BackgroundStatus.TITLE, title);
@@ -87,10 +95,6 @@ class BackgroundInfo implements Serializable {
 
     public String getDataTag() {
         return dataTag;
-    }
-
-    public void setDataTag(String dataTag) {
-        this.dataTag = dataTag;
     }
 
     public ServerEvent.EventTarget getEventTarget() { return eventTarget; }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/BackgroundInfoCacher.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/BackgroundInfoCacher.java
@@ -44,9 +44,9 @@ public class BackgroundInfoCacher {
      * @param baseFileName base name
      * @param title title
      */
-    public BackgroundInfoCacher(String key, String email, String baseFileName, String title, String dataTag, ServerEvent.EventTarget target) {
+    public BackgroundInfoCacher(String key, String email, String baseFileName, String title, String dataTag, String wsDestPath, ServerEvent.EventTarget target) {
         this(key);
-        updateInfo(new BackgroundInfo(null, email, baseFileName, title, dataTag, target, false));
+        updateInfo(new BackgroundInfo(null, email, baseFileName, title, dataTag, wsDestPath, target, false));
     }
 
     public static void fireBackgroundJobAdd(BackgroundStatus bgStat) {
@@ -176,6 +176,7 @@ public class BackgroundInfoCacher {
             bgStatus.setParam(ServerParams.TITLE, info.getTitle());
             bgStatus.setParam(ServerParams.EMAIL, info.getEmailAddress());
             bgStatus.setParam(BackgroundStatus.DATA_TAG, info.getDataTag());
+            bgStatus.setParam(BackgroundStatus.WS_DEST_PATH, info.getWorkspaceDestPath());
         }
     }
 
@@ -194,6 +195,7 @@ public class BackgroundInfoCacher {
                                         info.getBaseFileName(),
                                         info.getTitle(),
                                         info.getDataTag(),
+                                        info.getWorkspaceDestPath(),
                                         info.getEventTarget(),
                                         info.isCanceled());
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackageMaster.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackageMaster.java
@@ -14,6 +14,7 @@ import edu.caltech.ipac.firefly.server.query.SearchProcessor;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.FileUtil;
+import edu.caltech.ipac.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -164,9 +165,14 @@ public class PackageMaster  {
 
         PackagingWorker worker= new PackagingWorker(processor,req);
         String dataTag = req.getSearchRequest() != null ? req.getSearchRequest().getMeta(BackgroundStatus.DATA_TAG) : null;
+
+        String fileLoc = req.getParam(DownloadRequest.FILE_LOC);
+        String wsDestPath = StringUtils.isEmpty(fileLoc) ? null : req.getParam(DownloadRequest.WS_DEST_PATH);
+
         BackgroundEnv.BackgroundProcessor backProcess=
                 new BackgroundEnv.BackgroundProcessor( worker,  req.getBaseFileName(),
                                                        req.getTitle(), dataTag,
+                                                       wsDestPath,
                                                        req.getEmail(),
                                                        req.getDataSource(),
                                                        ServerContext.getRequestOwner());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/BackgroundEnv.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/BackgroundEnv.java
@@ -475,6 +475,7 @@ public class BackgroundEnv {
         private final String _baseFileName;
         private final String _title;
         private final String _dataTag;
+        private final String _wsDestPath;
         private final String _email;
         private final String _dataSource;
         private final RequestOwner _requestOwner;
@@ -485,26 +486,18 @@ public class BackgroundEnv {
                                    String baseFileName,
                                    String title,
                                    String dataTag,
+                                   String wsDestPath,
                                    String email,
                                    String dataSource,
                                    RequestOwner requestOwner) {
-            this(worker,baseFileName,title,dataTag,email,dataSource,requestOwner,null,null);
-        }
-
-        public BackgroundProcessor(Worker worker,
-                                   String title,
-                                   String dataTag,
-                                   String dataSource,
-                                   RequestOwner requestOwner,
-                                   String bid,
-                                   ServerEvent.EventTarget target) {
-            this(worker,null,title,dataTag,null,dataSource,requestOwner,bid,target);
+            this(worker,baseFileName,title,dataTag,wsDestPath,email,dataSource,requestOwner,null,null);
         }
 
         public BackgroundProcessor(Worker worker,
                                    String baseFileName,
                                    String title,
                                    String dataTag,
+                                   String wsDestPath,
                                    String email,
                                    String dataSource,
                                    RequestOwner requestOwner,
@@ -515,10 +508,11 @@ public class BackgroundEnv {
             _baseFileName= baseFileName;
             _title= title;
             _dataTag = dataTag;
+            _wsDestPath = wsDestPath;
             _email= email;
             _dataSource= dataSource;
             _requestOwner= requestOwner;
-            piCacher= new BackgroundInfoCacher(_bid, _email, _baseFileName, _title, _dataTag, evTarget); // force a cache entry here
+            piCacher= new BackgroundInfoCacher(_bid, _email, _baseFileName, _title, _dataTag, _wsDestPath, evTarget); // force a cache entry here
         }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
@@ -158,6 +158,7 @@ public class SearchManager {
         BackgroundEnv.BackgroundProcessor processor=
                               new BackgroundEnv.BackgroundProcessor(worker,  null,
                                                                     title, request.getMeta(BackgroundStatus.DATA_TAG),
+                                                                    null,                                   // used for workspace's put.. n/a here.
                                                                     email, request.getRequestId(),
                                                                     ServerContext.getRequestOwner() );
         return BackgroundEnv.backgroundProcess(waitMillis, processor, BackgroundStatus.BgType.SEARCH);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerParams.java
@@ -55,8 +55,9 @@ public class WsServerParams {
         return b != null ? Boolean.parseBoolean(b.toLowerCase().trim()) : false;
     }
 
-    public void set(WS_SERVER_PARAMS p, String val) {
+    public WsServerParams set(WS_SERVER_PARAMS p, String val) {
         map.put(p.getKey(), val);
+        return this;
     }
 
 }

--- a/src/firefly/js/core/background/BackgroundMonitor.css
+++ b/src/firefly/js/core/background/BackgroundMonitor.css
@@ -123,3 +123,8 @@
 .BGMon__packageItem--url:hover {
     cursor: pointer;
 }
+
+.BGMon__packageItem--info {
+    color: dimgray;
+    margin: auto 4px;
+}

--- a/src/firefly/js/core/background/BackgroundStatus.js
+++ b/src/firefly/js/core/background/BackgroundStatus.js
@@ -41,6 +41,7 @@ export const Keys= {
     FILE_PATH: 'FILE_PATH',
     TOTAL_BYTES: 'TOTAL_BYTES',
     DATA_TAG: 'DataTag',             // a tag describing the content of the returned data.  ie. 'catalog', 'imagemeta'
+    WS_DEST_PATH: 'WS_DEST_PATH',
     PUSH_DATA_BASE: 'PUSH_DATA_#',
     PUSH_TYPE_BASE: 'PUSH_TYPE_#',
     PUSH_CNT:       'PUSH_CNT',

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -187,6 +187,7 @@ function bgTracker(action, cancelSelf, params={}) {
     const bgStatus = bgStatusTransform(action.payload || {});
     const {STATE, ID} = bgStatus;
     if (ID === bgID) {
+        dispatchComponentStateChange(key, {bgStatus});
         switch (action.type) {
             case BG_STATUS:
                 if (isDone(STATE)) {

--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {get} from 'lodash';
 
 import {dispatchJobAdd} from './BackgroundCntlr.js';
 import {getComponentState} from '../../core/ComponentCntlr.js';
@@ -23,15 +24,20 @@ export const BgMaskPanel = React.memo(({componentKey, style={}}) => {
         bgStatus && dispatchJobAdd(bgStatus);
     };
     const maskStyle = {...defMaskStyle, ...style};
+    const parts = get(bgStatus, 'ITEMS.length', 0);
+    const msg = 'Working...' + (parts > 1 ? ` part #${parts}` : '');
 
     if (inProgress) {
         return (
             <div style={maskStyle}>
                 <div className='loading-mask'/>
-                {bgStatus &&
-                <div style={{display: 'flex', alignItems: 'center'}}>
-                    <button type='button' style={maskButton} className='button std' onClick={sendToBg}>Send to background</button>
-                </div>
+                { bgStatus &&
+                    <div style={{display: 'flex', alignItems: 'center'}}>
+                        <div style={maskButton} >
+                            <div style={{textAlign: 'center', margin: 5, fontSize: 'larger', fontStyle: 'italic'}}>{msg}</div>
+                            <div className='button large' onClick={sendToBg}>Send to background</div>
+                        </div>
+                    </div>
                 }
             </div>
         );
@@ -56,10 +62,8 @@ const defMaskStyle = {
         };
 
 const maskButton =  {
-            zIndex: 1,
-            marginTop: '80px',
-            border: '1px solid rgb(125,125,125)',
-            boxSizing: 'content-box',
-            backgroundColor: 'rgb(220,220,220)',
-            borderRadius: 4
-        };
+    marginTop: '95px',
+    position: 'relative',
+    color: 'white'
+
+};

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -14,8 +14,8 @@ import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {CompleteButton} from '../../ui/CompleteButton.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
-import {doDownloadWorkspace, workspacePopupMsg} from '../../ui/WorkspaceViewer.jsx';
-import {DownloadOptionsDialog, fileNameValidator, getTypeData, validateFileName,
+import {doDownloadWorkspace, workspacePopupMsg, validateFileName} from '../../ui/WorkspaceViewer.jsx';
+import {DownloadOptionsDialog, fileNameValidator, getTypeData,
         WORKSPACE, LOCALFILE} from '../../ui/DownloadOptionsDialog.jsx';
 import {WS_SERVER_PARAM, isWsFolder, isValidWSFolder,
         getWorkspacePath, dispatchWorkspaceUpdate} from  '../../visualize/WorkspaceCntlr.js';

--- a/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
+++ b/src/firefly/js/templates/lightcurve/LcImageToolbarView.jsx
@@ -40,13 +40,6 @@ const closeButtonStyle= {
     padding: '1px 12px 0 1px'
 };
 
-var options= [];
-
-for(var i= 1; (i<=LC.MAX_IMAGE_CNT); i+=2) {
-    options.push({label: String(i), value: String(i)});
-}
-
-
 export function LcImageToolbarView({activePlotId, viewerId, viewerPlotIds, layoutType, dlAry, tableId, closeFunc=null}) {
     const converter = getConverterData();
     if (!converter) { return null; }
@@ -94,6 +87,11 @@ export function LcImageToolbarView({activePlotId, viewerId, viewerPlotIds, layou
         return `Sorted by column: ${sInfo.sortColumns.join(',')} `+
                ` ${orderInfo[sInfo.direction]}`;
     };
+
+    const options= [];
+    for(var i= 1; (i<=LC.MAX_IMAGE_CNT); i+=2) {
+        options.push({label: String(i), value: String(i)});
+    }
 
     return (
         <div>

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -1,15 +1,12 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get,  set, isNil} from 'lodash';
-import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
 import {getCellValue, getTblById, getColumnIdx, smartMerge, getColumns, COL_TYPE} from '../../../tables/TableUtil.js';
 import {makeFileRequest} from '../../../tables/TableRequestUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
-import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
-import {ValidationField} from '../../../ui/ValidationField.jsx';
-import {DL_DATA_TAG} from '../LcConverterFactory.js';
+import {defaultDownloadPanel} from '../LcResult.jsx';
 
 
 const labelWidth = 80;
@@ -157,36 +154,12 @@ export function ptfOnFieldUpdate(fieldKey, value) {
  * @returns {XML}
  */
 export function ptfDownloaderOptPanel (mission, cutoutSizeInDeg) {
-    const currentTime = (new Date()).toLocaleString('en-US', { hour12: false });
-
-    const style = {width: 167};
-    return (
-        <DownloadButton>
-            <DownloadOptionPanel
-                groupKey = {mission}
-                dataTag = {DL_DATA_TAG}
-                cutoutSize={cutoutSizeInDeg}
-                title={'Image Download Options'}
-                dlParams={{
-                    MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ptf image is ~33mb
-                    FilePrefix: `${mission}_Files`,
-                    BaseFileName: `${mission}_Files`,
-                    DataSource: `${mission} images`,
+    return defaultDownloadPanel(mission, cutoutSizeInDeg,
+    {
                     FileGroupProcessor: 'PtfLcDownload',
                     ProductLevel:'l1',
                     schema:'images',
                     table:'level1'
-                }}>
-                <ValidationField
-                    style={style}
-                    initialState={{
-                        value: `${mission}_Files: ${currentTime}`,
-                        label: 'PTF:'
-                    }}
-
-                    fieldKey='Title'
-                    labelWidth={110}/>
-            </DownloadOptionPanel>
-        </DownloadButton>
-    );
+                }
+        );
 }

--- a/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
@@ -1,15 +1,12 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get,  set, isNil} from 'lodash';
-import {RadioGroupInputField} from '../../../ui/RadioGroupInputField.jsx';
 import {getCellValue, getTblById, getColumnIdx, smartMerge, getColumns, COL_TYPE} from '../../../tables/TableUtil.js';
 import {makeFileRequest} from '../../../tables/TableRequestUtil.js';
 import {sortInfoString} from '../../../tables/SortInfo.js';
 import {getInitialDefaultValues,renderMissionView,validate,getTimeAndYColInfo,fileUpdateOnTimeColumn,setValueAndValidator} from '../LcUtil.jsx';
 import {LC} from '../LcManager.js';
-import {DownloadOptionPanel, DownloadButton} from '../../../ui/DownloadDialog.jsx';
-import {ValidationField} from '../../../ui/ValidationField.jsx';
-import {DL_DATA_TAG} from '../LcConverterFactory.js';
+import {defaultDownloadPanel} from '../LcResult.jsx';
 
 
 const labelWidth = 80;
@@ -156,36 +153,13 @@ export function ztfOnFieldUpdate(fieldKey, value) {
  * @returns {XML}
  */
 export function ztfDownloaderOptPanel (mission, cutoutSizeInDeg) {
-    const currentTime = (new Date()).toLocaleString('en-US', { hour12: false });
 
-    const style = {width: 167};
-    return (
-        <DownloadButton>
-            <DownloadOptionPanel
-                groupKey = {mission}
-                dataTag = {DL_DATA_TAG}
-                cutoutSize={cutoutSizeInDeg}
-                title={'Image Download Option'}
-                dlParams={{
-                    MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each ztf image is ~37mb
-                    FilePrefix: `${mission}_Files`,
-                    BaseFileName: `${mission}_Files`,
-                    DataSource: `${mission} images`,
-                    FileGroupProcessor: 'ZtfLcDownload',
-                    ProductLevel:'sci',
-                    schema:'products',
-                    table:'sci'
-                }}>
-                <ValidationField
-                    style={style}
-                    initialState={{
-                        value: `${mission}_Files: ${currentTime}`,
-                        label: 'ZTF:'
-                    }}
-
-                    fieldKey='Title'
-                    labelWidth={110}/>
-            </DownloadOptionPanel>
-        </DownloadButton>
+    return defaultDownloadPanel(mission, cutoutSizeInDeg,
+        {
+            FileGroupProcessor: 'ZtfLcDownload',
+            ProductLevel:'sci',
+            schema:'products',
+            table:'sci'
+        }
     );
 }

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -27,6 +27,7 @@ import {DataTagMeta} from '../tables/TableRequestUtil.js';
 import {useStoreConnector} from './SimpleComponent.jsx';
 import {BgMaskPanel} from '../core/background/BgMaskPanel.jsx';
 import {WsSaveOptions} from './WorkspaceSelectPane.jsx';
+import {NotBlank} from '../util/Validate.js';
 
 const DOWNLOAD_DIALOG_ID = 'Download Options';
 /**
@@ -118,13 +119,6 @@ export function DownloadOptionPanel (props) {
     const {groupKey, cutoutSize, help_id, children, style, title, tbl_id, dlParams, dataTag} = props;
     const { showZipStructure=true, showEmailNotify=true, showFileLocation=true, showTitle=true } = props;
 
-    const [{email, enableEmail}] = useStoreConnector(getBgEmailInfo);
-    const onEmailChanged = useCallback((v) => {
-        if (get(v, 'valid')) {
-            if (email !== v.value) dispatchBgSetEmailInfo({email: v.value});
-        }
-    }, [email]);
-
     const labelWidth = 110;
     const ttl = title || DOWNLOAD_DIALOG_ID;
     const bgKey = 'DownloadOptionPanel-' + tbl_id;
@@ -139,14 +133,7 @@ export function DownloadOptionPanel (props) {
         dlTitleIdx++;
     }, tbl_id);
 
-    const toggleEnableEmail = (e) => {
-        const enableEmail = e.target.checked;
-        const email = enableEmail ? email : '';
-        dispatchBgSetEmailInfo({email, enableEmail});
-    };
-
     const showWarnings = hasProprietaryData(getTblById(tbl_id));
-    const useWs = getWorkspaceConfig() && showFileLocation;
 
     const maskStyle = {
         position: 'absolute',
@@ -186,8 +173,8 @@ export function DownloadOptionPanel (props) {
 
                         {cutoutSize         && <DownloadCutout {...{labelWidth}} />}
                         {showZipStructure   && <ZipStructure {...{labelWidth}} />}
-                        {useWs              && <WsSaveOptions {...{groupKey, labelWidth, saveAsProps}}/>}
-                        {showEmailNotify    && <EmailNotification {...{email, onEmailChanged, enableEmail, toggleEnableEmail}}/>}
+                        {showFileLocation   && <WsSaveOptions {...{groupKey, labelWidth, saveAsProps}}/>}
+                        {showEmailNotify    && <EmailNotification/>}
                     </div>
                 </FieldGroup>
             </FormPanel>
@@ -227,11 +214,13 @@ DownloadOptionPanel.defaultProps= {
 
 
 export function TitleField({style={}, labelWidth, value, label='Title:', size=30}) {
+
     return (
         <ValidationField
+            forceReinit={true}
             fieldKey='Title'
             tooltip='Enter a description to identify this download.'
-            {...{value, label, labelWidth, size, style}}
+            {...{validator:NotBlank, value, label, labelWidth, size, style}}
         />
     );
 }
@@ -272,7 +261,21 @@ export function DownloadCutout({style={}, fieldKey='dlCutouts', labelWidth}) {
         />
     );
 }
-export function EmailNotification({style, email, onEmailChanged, enableEmail, toggleEnableEmail}) {
+export function EmailNotification({style}) {
+
+    const [{email, enableEmail}] = useStoreConnector(getBgEmailInfo);
+
+    const toggleEnableEmail = (e) => {
+        const enableEmail = e.target.checked;
+        const email = enableEmail ? email : '';
+        dispatchBgSetEmailInfo({email, enableEmail});
+    };
+
+    const onEmailChanged = useCallback((v) => {
+        if (get(v, 'valid')) {
+            if (email !== v.value) dispatchBgSetEmailInfo({email: v.value});
+        }
+    }, [email]);
 
     return (
         <div style={style}>

--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -205,18 +205,3 @@ export function fileNameValidator() {
     };
 }
 
-export function validateFileName(wsSelect, fileName) {
-    if (isNil(wsSelect)) {
-        return false;
-    }
-    const fullPath = getWorkspacePath(wsSelect, fileName);
-
-    if (isExistWorspaceFile(fullPath)) {
-        workspacePopupMsg(`the file, ${fullPath}, already exists in workspace, please change the file name.`,
-                          'Save to workspace');
-        return false;
-    } else {
-        return true;
-    }
-
-}

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -33,10 +33,10 @@ import {isImage} from '../visualize/WebPlot.js';
 import {makeRegionsFromPlot} from '../visualize/region/RegionDescription.js';
 import {saveDS9RegionFile} from '../rpc/PlotServicesJson.js';
 import FieldGroupCntlr from '../fieldGroup/FieldGroupCntlr.js';
-import {DownloadOptionsDialog, fileNameValidator, getTypeData, validateFileName,
+import {DownloadOptionsDialog, fileNameValidator, getTypeData,
         WORKSPACE, LOCALFILE} from './DownloadOptionsDialog.jsx';
 import {isValidWSFolder, WS_SERVER_PARAM, getWorkspacePath, isWsFolder, dispatchWorkspaceUpdate} from '../visualize/WorkspaceCntlr.js';
-import {doDownloadWorkspace, workspacePopupMsg} from './WorkspaceViewer.jsx';
+import {doDownloadWorkspace, workspacePopupMsg, validateFileName} from './WorkspaceViewer.jsx';
 import {ServerParams} from '../data/ServerParams.js';
 import {INFO_POPUP, showInfoPopup} from './PopupUtil.jsx';
 import {getWorkspaceConfig} from '../visualize/WorkspaceCntlr.js';

--- a/src/firefly/js/ui/PopupUtil.jsx
+++ b/src/firefly/js/ui/PopupUtil.jsx
@@ -88,6 +88,13 @@ export function showInfoPopup(content, title='Information', isCopyable) {
     dispatchShowDialog(INFO_POPUP);
 }
 
+/**
+ * Hide the info popup
+ */
+export function hideInfoPopup() {
+    dispatchHideDialog(INFO_POPUP);
+}
+
 function makeContent(content, isCopyable) {
     return (
         <div style={{padding:5}}>

--- a/src/firefly/js/ui/WorkspaceSelectPane.jsx
+++ b/src/firefly/js/ui/WorkspaceSelectPane.jsx
@@ -14,6 +14,7 @@ import {getWorkspaceList, isAccessWorkspace} from '../visualize/WorkspaceCntlr.j
 import {WorkspaceSave} from './WorkspaceViewer.jsx';
 import {useStoreConnector} from './SimpleComponent.jsx';
 import {dispatchWorkspaceUpdate, getWorkspaceErrorMsg} from '../visualize/WorkspaceCntlr.js';
+import {getWorkspaceConfig} from '../visualize/WorkspaceCntlr';
 
 export const LOCALFILE = 'isLocal';
 export const WORKSPACE = 'isWs';
@@ -25,9 +26,9 @@ export const WORKSPACE = 'isWs';
  */
 
 
-
 /*
  * A selection pane used for saving a file either to local disk or workspace.
+ * If workspace is not used, that option is not shown and only Save As is displayed.
  * There are 3 values that may come out of this selection pane.
  * 1. where it should be saved(isLocal or isWs).  default keyed as 'fileLocation'
  * 2. what is should be save as.  default keyed as 'fileName'
@@ -42,23 +43,25 @@ export function WsSaveOptions (props) {
 
     const [loc, wsSelect] = useStoreConnector(  () => getFieldVal(groupKey, fileLocProps.fieldKey),
                                                 () => getFieldVal(groupKey, wsSelectKey));
-
     useEffect(() => {
         dispatchWorkspaceUpdate();
     }, [loc]);
 
+    const useWs = getWorkspaceConfig();
 
     return (
         <div style={style}>
             <ValidationField {...saveAsProps}/>
-            <RadioGroupInputField
-                {...fileLocProps}
-                options={[
-                    {label: 'Local File', value: LOCALFILE},
-                    {label: 'Workspace', value: WORKSPACE }
-                ]}
-            />
-            {loc === WORKSPACE && <ShowWorkspace {...{wsSelect, wsSelectKey}}/>}
+            { useWs &&
+                <RadioGroupInputField
+                    {...fileLocProps}
+                    options={[
+                        {label: 'Local File', value: LOCALFILE},
+                        {label: 'Workspace', value: WORKSPACE }
+                    ]}
+                />
+            }
+            { useWs && (loc === WORKSPACE) && <ShowWorkspace {...{wsSelect, wsSelectKey}}/> }
         </div>
     );
 
@@ -72,7 +75,6 @@ WsSaveOptions.propTypes = {
     saveAsProps:    PropTypes.object,       // properties to send into the Save As input box..  see render function for defaults
     wsSelectKey:    PropTypes.string
 };
-
 
 
 function ShowWorkspace({wsSelect, wsSelectKey}) {
@@ -89,40 +91,3 @@ function ShowWorkspace({wsSelect, wsSelectKey}) {
         </div>
     );
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/firefly/js/ui/WorkspaceSelectPane.jsx
+++ b/src/firefly/js/ui/WorkspaceSelectPane.jsx
@@ -1,0 +1,128 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+
+import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {isEmpty} from 'lodash';
+
+import {ValidationField} from './ValidationField.jsx';
+import {RadioGroupInputField} from './RadioGroupInputField.jsx';
+import {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
+import {getWorkspaceList, isAccessWorkspace} from '../visualize/WorkspaceCntlr.js';
+import {WorkspaceSave} from './WorkspaceViewer.jsx';
+import {useStoreConnector} from './SimpleComponent.jsx';
+import {dispatchWorkspaceUpdate, getWorkspaceErrorMsg} from '../visualize/WorkspaceCntlr.js';
+
+export const LOCALFILE = 'isLocal';
+export const WORKSPACE = 'isWs';
+
+
+/**
+ * This intend of this module is to group commonly used components related to workspace.
+ * The components should be written so that composition is possible.
+ */
+
+
+
+/*
+ * A selection pane used for saving a file either to local disk or workspace.
+ * There are 3 values that may come out of this selection pane.
+ * 1. where it should be saved(isLocal or isWs).  default keyed as 'fileLocation'
+ * 2. what is should be save as.  default keyed as 'fileName'
+ * 3. if workspace, path to the folder to save it to.  default keyed as 'wsSelect'
+ */
+export function WsSaveOptions (props) {
+    const {groupKey, style, wsSelectKey='wsSelect', labelWidth} = props;
+    let {fileLocProps={}, saveAsProps={}} = props;
+
+    saveAsProps = {fieldKey:'fileName', label:'Save as:', labelWidth, wrapperStyle:{margin: '3px 0'}, size:30, ...saveAsProps};
+    fileLocProps = {fieldKey:'fileLocation', label:'File Location:', labelWidth, ...fileLocProps};
+
+    const [loc, wsSelect] = useStoreConnector(  () => getFieldVal(groupKey, fileLocProps.fieldKey),
+                                                () => getFieldVal(groupKey, wsSelectKey));
+
+    useEffect(() => {
+        dispatchWorkspaceUpdate();
+    }, [loc]);
+
+
+    return (
+        <div style={style}>
+            <ValidationField {...saveAsProps}/>
+            <RadioGroupInputField
+                {...fileLocProps}
+                options={[
+                    {label: 'Local File', value: LOCALFILE},
+                    {label: 'Workspace', value: WORKSPACE }
+                ]}
+            />
+            {loc === WORKSPACE && <ShowWorkspace {...{wsSelect, wsSelectKey}}/>}
+        </div>
+    );
+
+}
+
+WsSaveOptions.propTypes = {
+    groupKey:       PropTypes.string.isRequired,
+    style:          PropTypes.string,
+    labelWidth:     PropTypes.number,
+    fileLocProps:   PropTypes.object,       // properties to send into the File Location radio button..  see render function for defaults
+    saveAsProps:    PropTypes.object,       // properties to send into the Save As input box..  see render function for defaults
+    wsSelectKey:    PropTypes.string
+};
+
+
+
+function ShowWorkspace({wsSelect, wsSelectKey}) {
+
+    const [wsList, isUpdating] = useStoreConnector(getWorkspaceList, isAccessWorkspace);
+
+    const content = isUpdating ? <div className='loading-mask'/>
+                    : isEmpty(wsList) ? <div style={{color:'maroon', fontStyle:'italic', padding:10}}> {'Workspace access error: ' + getWorkspaceErrorMsg()} </div>
+                    : <WorkspaceSave fieldKey={wsSelectKey} files={wsList} value={wsSelect} />;
+
+    return (
+        <div style={{ border:'1px solid #eaeaea', padding:3, position:'relative', minHeight:60, minWidth:550}}>
+            {content}
+        </div>
+    );
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/firefly/js/ui/WorkspaceViewer.jsx
+++ b/src/firefly/js/ui/WorkspaceViewer.jsx
@@ -33,6 +33,7 @@ const workspacePopupId = 'workspacePopupId';
 
 import LOADING from 'html/images/gxt/loading.gif';
 import ComponentCntlr from '../core/ComponentCntlr.js';
+import {isExistWorspaceFile} from '../visualize/WorkspaceCntlr';
 
 /*-----------------------------------------------------------------------------------------*/
 /* core component as FilePicker wrapper
@@ -395,6 +396,23 @@ export function doDownloadWorkspace(url, options) {
             }
         });
     }).catch(({message}) => showInfoPopup(truncate(message, {length: 200}), 'Unexpected error'));
+}
+
+
+export function validateFileName(wsSelect, fileName) {
+    if (isNil(wsSelect)) {
+        return false;
+    }
+    const fullPath = getWorkspacePath(wsSelect, fileName);
+
+    if (isExistWorspaceFile(fullPath)) {
+        workspacePopupMsg(`the file, ${fullPath}, already exists in workspace, please change the file name.`,
+            'Save to workspace');
+        return false;
+    } else {
+        return true;
+    }
+
 }
 
 export function workspacePopupMsg(msg, title) {

--- a/src/firefly/js/util/Validate.js
+++ b/src/firefly/js/util/Validate.js
@@ -76,6 +76,15 @@ var validateRange = function(min,max,precision,description,dType, valStr, nullAl
     return retval;
 };
 
+export function NotBlank(val='') {
+    const retval = {valid: true,message: ''};
+    if (!val.trim()) {
+        retval.valid = false;
+        retval.message = 'Value must not be blank';
+    }
+    return retval;
+};
+
 export const validateEmail = function(description,valStr) {
     var retval = {
         valid: true,


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-384

additional changes here: https://github.com/IPAC-SW/irsa-ife/pull/90

- create new workspace selection panel as an example of how to write composable widgets
- add Title to dialog
- add SaveAs plus workspace support
- add show* props to allow for more flexibility when laying out fields.
- refactor LightCurve download dialogs.

To test:
https://irsawebdev9.ipac.caltech.edu/FIREFLY-384_update_download_dialog/irsaviewer/timeseries
https://irsawebdev9.ipac.caltech.edu/FIREFLY-384_update_download_dialog/applications/sofia/

PS:  Workspace selection UI and related selection data is added to the dialog and also to the download request.  But, the logic to `save to workspace` is not yet implemented.
If you wish for me to add that logic to the PR as well, let me know.