### PR TITLE
firefly-159-The issues in "prepare download" that are seen in Time Series, Sofia etc.

### DIFF
--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -434,7 +434,8 @@ function resolveFileName(resp) {
 export function download(url, filename) {
     const {protocol, host, path, hash, searchObject={}} = parseUrl(url);
     const cmd = searchObject[ServerParams.COMMAND];
-    url = `${protocol}//${host}${path}?${ServerParams.COMMAND}=${cmd}` + (hash ? '#' + hash : '');      // add cmd into the url as a workaround for server-side code not supporting it
+    url = cmd? `${protocol}//${host}${path}?${ServerParams.COMMAND}=${cmd}` + (hash ? '#' + hash : ''):      // add cmd into the url as a workaround for server-side code not supporting it
+        url;
 
     const params = Object.fromEntries(
                         Object.entries(searchObject)


### PR DESCRIPTION
  Firefly Ticket :  https://jira.ipac.caltech.edu/browse/FIREFLY-159
  
 There are five issues reported originally, please see the ticket above.  Two of the three issues (fileName and backgroundable) are fixed in Loi's two pull requests. The open dialog issue is 
 an intended behavior in the updated DownloadDialog.  

 In this pull request, two remaining issues, the non-stop spiny mask and check mark are fixed.
 The fix is very trivial.   Please check the fix to see if it was fixed properly.  The test URL is

  https://irsawebdev9.ipac.caltech.edu/firefly-159-Lijun/irsaviewer/ts.html

  Thanks!