### PR TITLE
FIREFLY-389: fix single file package download

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/Packager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/Packager.java
@@ -135,23 +135,18 @@ public class Packager {
 
     public void packageAll() {
         BackgroundStatus bgStat = null;
-        if (isOneFile()) {
-            bgStat= packageOneFile(_fgList.get(0).getFileInfo(0));
-        }
-        else {
-            for (int idx = 0; idx < _estimateStat.getPackageCount(); idx++) {
-                if (!backgroundInfoCacher.isCanceled()) {
-                    bgStat = packageElement(idx);
-                    if (bgStat.getState() != BackgroundState.SUCCESS)
-                        break;
-                } else {
-                    bgStat =  _estimateStat.cloneWithState(BackgroundState.CANCELED);
+        for (int idx = 0; idx < _estimateStat.getPackageCount(); idx++) {
+            if (!backgroundInfoCacher.isCanceled()) {
+                bgStat = packageElement(idx);
+                if (bgStat.getState() != BackgroundState.SUCCESS)
                     break;
-                }
+            } else {
+                bgStat =  _estimateStat.cloneWithState(BackgroundState.CANCELED);
+                break;
             }
-            if (bgStat == null) {
-                bgStat =  _estimateStat.cloneWithState(BackgroundState.FAIL);
-            }
+        }
+        if (bgStat == null) {
+            bgStat =  _estimateStat.cloneWithState(BackgroundState.FAIL);
         }
 
         // handle 'save to Workspace' option:  pushes files to workspace

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingController.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingController.java
@@ -317,7 +317,7 @@ public class PackagingController {
         String details = " zTime= " + UTCTimeUtil.getHMSFromMills(procMS) +
                 ", wTime= " + UTCTimeUtil.getHMS(waitSec) +
                 ", size= " + StringUtils.getSizeAsString(zipTotal, true);
-        if (pi.getPackager().isOneFile())  details+=", One file not zipped";
+//        if (pi.getPackager().isOneFile())  details+=", One file not zipped";
 
         _log.info("Package ID: " + id,
                   "Packaging completed: " + details);


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-389
Test: https://irsawebdev9.ipac.caltech.edu/FIREFLY-389_single_file_download/applications/sofia/

Additional changes: https://github.com/IPAC-SW/irsa-ife/pull/91

There are 2 issues:

1.  When download resulted in only 1 file, it does not save the file with the selected 'Save As' value. 
This can be duplicated in ZTF Time Series or SOFIA by selecting only 1 row.

2. When download resulted in only 1 file in which you do not have access or privilege to, it saves the error HTML page as the content of the file without any warnings. 
This can be duplicated using SOFIA -> 'M17', level 2 -> FORCAST -> select 1 row -> Prepare Download

 Also: fixed `undefined` showing up in `Save As` in SOFIA download dialog.

