### PR TITLE
IRSA-3165_SOFIA_proprietary_data_warning_message_is_not_showing_in_th…

### DIFF
--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -111,6 +111,8 @@ const noticeCss = {
     padding: 3,
     borderRadius: 2,
     marginBottom: 10,
+    whiteSpace: 'nowrap',
+    textAlign: 'center'
 };
 
 let dlTitleIdx = 0;

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -223,7 +223,7 @@ export function TitleField({style={}, labelWidth, value, label='Title:', size=30
             forceReinit={true}
             fieldKey='Title'
             tooltip='Enter a description to identify this download.'
-            {...{validator:NotBlank, value, label, labelWidth, size, style}}
+            {...{validator:NotBlank, initialState:{value}, label, labelWidth, size, style}}
         />
     );
 }

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -110,7 +110,7 @@ const noticeCss = {
     border: '1px solid #cacaae',
     padding: 3,
     borderRadius: 2,
-    marginBottom: 3,
+    marginBottom: 10,
 };
 
 let dlTitleIdx = 0;
@@ -160,8 +160,7 @@ export function DownloadOptionPanel (props) {
     const dlTitle = get(dlParams, 'TitlePrefix', 'Download') + '-' + dlTitleIdx;
 
     return (
-        <div style = {Object.assign({margin: '4px', position: 'relative', minWidth:400}, style)}>
-            {showWarnings && <div style={noticeCss}>This table contains proprietary data. Only data to which you have access will be downloaded.</div>}
+        <div style = {Object.assign({margin: '4px', position: 'relative', minWidth:400, height:'auto'}, style)}>
             <FormPanel
                 submitText = 'Prepare Download'
                 groupKey = {groupKey}
@@ -169,6 +168,7 @@ export function DownloadOptionPanel (props) {
                 onCancel = {() => dispatchHideDialog(ttl)}
                 help_id  = {help_id}>
                 <FieldGroup groupKey={groupKey} keepState={true}>
+                    {showWarnings && <div style={noticeCss}>This table contains proprietary data. Only data to which you have access will be downloaded.</div>}
                     <div className='FieldGroup__vertical--more'>
                         {showTitle && <TitleField {...{labelWidth, value:dlTitle }}/>}
 
@@ -302,7 +302,7 @@ export function EmailNotification({style}) {
 
 function hasProprietaryData(tableModel={}) {
 
-    if (getProprietaryInfo().length === 0) return false;
+    if (getProprietaryInfo(tableModel).length === 0) return false;
 
     const {selectInfo} = tableModel;
     const selectInfoCls = SelectInfo.newInstance(selectInfo);


### PR DESCRIPTION
This ticket fixes:
1- display warning message when row(s) with proprietary data is chosen for download.
2- Fixes the CSS for the download dialog box. Initially, the message box is pushing other content out of form's boundary.

Jira: https://jira.ipac.caltech.edu/browse/IRSA-3165
K8s: https://irsawebdev9.ipac.caltech.edu/irsa-3165/applications/sofia/

Test: use m42 as single position search value. Make sure to select level 2 for the processing levels.  
    