### PR TITLE
IRSA-3179: implement proprietary data access for SOFIA

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/JdbcFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/JdbcFactory.java
@@ -121,7 +121,7 @@ public class JdbcFactory {
     }
 
     private static DataSource getDirectDataSource(DbInstance dbInstance) {
-        logger.briefDebug("Getting a new database connection for " + dbInstance.dbUrl + " using DriverManager");
+        logger.trace("Getting a new database connection for " + dbInstance.dbUrl + " using DriverManager");
         DriverManagerDataSource driver = new DriverManagerDataSource(
                     dbInstance.dbUrl,
                     dbInstance.userId,

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
@@ -29,12 +29,19 @@ public class HttpServiceInput implements Cloneable{
     private String userId;
     private String passwd;
 
+    public HttpServiceInput() {}
+
+    public HttpServiceInput(String requestUrl) {
+        this.requestUrl = requestUrl;
+    }
+
     public String getRequestUrl() {
         return requestUrl;
     }
 
-    public void setRequestUrl(String requestUrl) {
+    public HttpServiceInput setRequestUrl(String requestUrl) {
         this.requestUrl = requestUrl;
+        return this;
     }
 
     public String getUserId() {
@@ -104,21 +111,21 @@ public class HttpServiceInput implements Cloneable{
         StringBuilder sb = new StringBuilder();
 
         if (userId != null) {
-            sb.append("userId: ").append(userId)
-                .append("  passwd:").append(passwd).append("\n");
+            sb.append("\n\tuserId: ").append(userId)
+                .append("  passwd:").append(passwd);
         }
 
         if (params != null) {
-            sb.append("params: ").append(params.toString()).append("\n");
+            sb.append("\n\tparams: ").append(params.toString());
         }
         if (headers != null) {
-            sb.append("headers: ").append(headers.toString()).append("\n");
+            sb.append("\n\theaders: ").append(headers.toString());
         }
         if (cookies != null) {
-            sb.append("cookies: ").append(cookies.toString()).append("\n");
+            sb.append("\n\tcookies: ").append(cookies.toString());
         }
         if (files != null) {
-            sb.append("files: ").append(files.toString()).append("\n");
+            sb.append("\n\tfiles: ").append(files.toString());
         }
         return sb.toString();
     }
@@ -149,13 +156,23 @@ public class HttpServiceInput implements Cloneable{
 //  convenience functions
 //====================================================================
 
+    /**
+     * returns an HttpServiceInput that contains the required credential to access backend services.
+     * This credential information is based on the implementer of SsoAdapter.
+     * @return
+     */
     public static HttpServiceInput createWithCredential() {
         return createWithCredential(null);
     }
 
+    /**
+     * return an HttpServiceInput with the requestUrl that may contains credential needed to access backend services.
+     * The given requestUrl is used to determine whether or not to include the credential in the call.
+     * @param requestUrl
+     * @return
+     */
     public static HttpServiceInput createWithCredential(String requestUrl) {
-        HttpServiceInput input = new HttpServiceInput();
-        input.setRequestUrl(requestUrl);
+        HttpServiceInput input = new HttpServiceInput(requestUrl);
         SsoAdapter ssoAdapter = ServerContext.getRequestOwner().getSsoAdapter();
         if (ssoAdapter != null) {
             ssoAdapter.setAuthCredential(input);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -110,14 +110,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
      */
     public File getDbFile(TableServerRequest treq) {
         String fname = String.format("%s_%s.%s", treq.getRequestId(), DigestUtils.md5Hex(getUniqueID(treq)), DbAdapter.getAdapter(treq).getName());
-        return new File(getTempDir(), fname);
-    }
-
-    protected File getTempDir() {
-        String sessId = ServerContext.getRequestOwner().getRequestAgent().getSessId();
-        File tempDir = new File(ServerContext.getTempWorkDir(), sessId.substring(0, 3));
-        if (!tempDir.exists()) tempDir.mkdirs();
-        return tempDir;
+        return new File(QueryUtil.getTempDir(), fname);
     }
 
     /**
@@ -304,7 +297,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     }
 
     protected File createTempFile(TableServerRequest request, String fileExt) throws IOException {
-        return File.createTempFile(request.getRequestId(), fileExt, getTempDir());
+        return File.createTempFile(request.getRequestId(), fileExt, QueryUtil.getTempDir());
     }
 
     public boolean doCache() {return false;}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IbeTemplateProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IbeTemplateProcessor.java
@@ -30,7 +30,7 @@ public class IbeTemplateProcessor extends SharedDbProcessor {
         try {
             String url = treq.getParam("url");
             ByteArrayOutputStream results = new ByteArrayOutputStream();
-            HttpServices.getData(url, results, HttpServiceInput.createWithCredential(url));
+            HttpServices.getData(HttpServiceInput.createWithCredential(url), results);
             return IpacTableReader.read(new StringInputStream(results.toString()));
         } catch (IOException e) {
             throw new DataAccessException(e.getMessage(), e);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.Param;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.RequestOwner;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.TableMeta;
 import edu.caltech.ipac.table.TableUtil;
@@ -55,8 +56,12 @@ public interface SearchProcessor<Type> {
      * @return
      */
     static String getUniqueIDDef(TableServerRequest request) {
+        RequestOwner ro = ServerContext.getRequestOwner();
         SortedSet<Param> params = request.getSearchParams();
-        params.add(new Param("sessID", ServerContext.getRequestOwner().getRequestAgent().getSessId()));
+        params.add(new Param("sessID", ro.getRequestAgent().getSessId()));
+        if (ro.isAuthUser()) {
+            params.add( new Param("userID", ro.getUserInfo().getLoginName()));
+        }
         return StringUtils.toString(params, "|");
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
@@ -11,6 +11,7 @@ import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbInstance;
 import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.db.spring.JdbcFactory;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.table.DataGroupPart;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.util.StringUtils;
@@ -36,7 +37,7 @@ public abstract class SharedDbProcessor extends EmbeddedDbProcessor {
     public File getDbFile(TableServerRequest treq) {
         DbAdapter dbAdapter = DbAdapter.getAdapter(treq);
         String fname = String.format("%s_%s.%s", treq.getRequestId(), ServerContext.getRequestOwner().getRequestAgent().getSessId(), dbAdapter.getName());
-        return new File(getTempDir(), fname);
+        return new File(QueryUtil.getTempDir(), fname);
     }
 
     public FileInfo ingestDataIntoDb(TableServerRequest treq, File dbFile) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
@@ -54,10 +54,6 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
 
     public abstract URL getURL(ServerRequest sr) throws MalformedURLException;
 
-    public static FileInfo retrieveViaURL(URL url, File dir) throws IOException, DataAccessException {
-        return retrieveViaURL(url, dir, null, null, null, null);
-    }
-
     public static FileInfo retrieveViaURL(URL url,
                                           File dir,
                                           String progressKey,

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/IrsaLightCurveHandler.java
@@ -165,9 +165,9 @@ public class IrsaLightCurveHandler implements LightCurveHandler {
         saveInputToTable(request);
 
         //do a HTTP post
-        HttpServiceInput httpInputs = getHttpInput(request);
+        HttpServiceInput httpInputs = getHttpInput(request).setRequestUrl(rootApiUrl);
         BufferedOutputStream writer = new BufferedOutputStream(new FileOutputStream(apiResultTempFile), 10240);
-        HttpServices.postData(rootApiUrl, writer, httpInputs);
+        HttpServices.postData(httpInputs, writer);
         writer.close();
 
         return apiResultTempFile;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMetaSearch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lsst/LSSTMetaSearch.java
@@ -62,11 +62,11 @@ public class LSSTMetaSearch  extends IpacTablePartProcessor{
 
         File file = createFile(request, ".json");
 
-        HttpServiceInput inputs = HttpServiceInput.createWithCredential(LSSTQuery.getMetaservURL());
+        HttpServiceInput inputs = HttpServiceInput.createWithCredential(url);
         inputs.setHeader("Accept", "application/json");
 
         long cTime = System.currentTimeMillis();
-        HttpServices.Status status = HttpServices.getData(url, file, inputs);
+        HttpServices.Status status = HttpServices.getData(inputs, file);
         _log.briefDebug("Metadata call took " + (System.currentTimeMillis() - cTime) + "ms");
 
         if (status.isError()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/OidcAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/OidcAdapter.java
@@ -162,7 +162,7 @@ public class OidcAdapter implements SsoAdapter {
 
     private Token getToken(String url, HttpServiceInput input) {
         ByteArrayOutputStream results = new ByteArrayOutputStream();
-        if (HttpServices.postData(url, results, input).isError()) return null;
+        if (HttpServices.postData(input.setRequestUrl(url), results).isError()) return null;
 
         Token token = null;
         try {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
@@ -86,6 +86,8 @@ public interface SsoAdapter {
 //====================================================================
 
     static boolean requireAuthCredential(String reqUrl, String... reqAuthHosts) {
+        if (reqUrl == null) return true;
+
         if (!isEmpty(reqUrl)) {
             try {
                 String reqHost = new URL(ServerContext.resolveUrl(reqUrl)).getHost().toLowerCase();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/Logger.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/Logger.java
@@ -207,6 +207,8 @@ public class Logger {
             this.name = name;
         }
 
+        public void trace(String... msgs) { log(Type.NORMAL, Level.TRACE, msgs); }
+
         public void briefDebug(String msgs) {
             log(Type.BRIEF, Level.DEBUG, msgs);
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -3,7 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.util;
 
-import com.google.gwt.xml.client.Attr;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.table.IpacTableUtil;
 import edu.caltech.ipac.table.TableMeta;
 import edu.caltech.ipac.table.query.DataGroupQueryStatement;
@@ -68,6 +68,19 @@ public class QueryUtil {
             return "http://" + url.trim();
         }
     }
+
+    /**
+     * returns a hierarchical temporary directory.
+     * @return
+     */
+    public static File getTempDir() {
+        String sessId = ServerContext.getRequestOwner().getRequestAgent().getSessId();
+        File tempDir = new File(ServerContext.getTempWorkDir(), sessId.substring(0, 3));
+        if (!tempDir.exists()) tempDir.mkdirs();
+        return tempDir;
+    }
+
+
 
     public static DownloadRequest convertToDownloadRequest(String dlReqStr, String searchReqStr, String selInfoStr) {
         DownloadRequest retval = new DownloadRequest(convertToServerRequest(searchReqStr), null, null);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
@@ -126,8 +126,7 @@ public class LockingVisNetwork {
 
         try {
             File fileName= (fileInfo==null) ? CacheHelper.makeFile(params.getFileDir(), params.getUniqueString()) : fileInfo.getFile();
-            Map<String, String> headers = params.getAddtlInfo() == null ? null : params.getAddtlInfo().getHeaders();
-            fileInfo= URLDownload.getDataToFile(params.getURL(), fileName, params.getCookies(), headers,
+            fileInfo= URLDownload.getDataToFile(params.getURL(), fileName, params.getCookies(), params.getHeaders(),
                                                 dl, false,true, params.getMaxSizeToDownload());
             if (fileInfo.getResponseCode()==200) CacheHelper.putFile(params,fileInfo);
             return fileInfo;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ws/WsServerUtils.java
@@ -225,7 +225,7 @@ public class WsServerUtils {
         String fileName =  (idx >= 0) ? relPath.substring(idx + 1) : relPath;
         File f = getTempUploadFile(fileName);
 
-        HttpServices.getData(url, f, input);
+        HttpServices.getData(input, f);
 
         return ServerContext.replaceWithPrefix(f);
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
@@ -109,8 +109,9 @@ public class AnyUrlParams extends BaseNetParams {
         cookies.put(key,value);
     }
 
-    public String getCookie(String key) {
-        return cookies!=null ? cookies.get(key) : null;
+
+    public Map<String, String> getHeaders() {
+        return addtlInfo == null ? null : addtlInfo.getHeaders();
     }
 
     public Map<String,String> getCookies() {

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
@@ -54,7 +54,7 @@ public class HttpServicesTest {
 	public void testGetData(){
 
 		ByteArrayOutputStream results = new ByteArrayOutputStream();
-		HttpServices.Status status = HttpServices.getData(GET_URL, results, input);
+		HttpServices.Status status = HttpServices.getData(input.setRequestUrl(GET_URL), results);
 		validateResults(status, results);
 	}
 
@@ -62,7 +62,7 @@ public class HttpServicesTest {
 	public void testPostData(){
 
 		ByteArrayOutputStream results = new ByteArrayOutputStream();
-		HttpServices.Status status = HttpServices.postData(POST_URL, results, input);
+		HttpServices.Status status = HttpServices.postData(input.setRequestUrl(POST_URL), results);
 		validateResults(status, results);
 	}
 
@@ -76,7 +76,7 @@ public class HttpServicesTest {
 		input.setFile("samplePng", samplePng);
 
 		ByteArrayOutputStream results = new ByteArrayOutputStream();
-		HttpServices.Status status = HttpServices.postData(POST_URL, results, input);
+		HttpServices.Status status = HttpServices.postData(input.setRequestUrl(POST_URL), results);
 
 		validateResults(status, results);
 
@@ -103,7 +103,7 @@ public class HttpServicesTest {
 	public void testGzipData(){
 
 		ByteArrayOutputStream results = new ByteArrayOutputStream();
-		HttpServices.Status status = HttpServices.getData(GZIP_URL, results, input);
+		HttpServices.Status status = HttpServices.getData(input.setRequestUrl(GZIP_URL), results);
 
 		assertFalse("Has error", status.isError());
 
@@ -114,7 +114,7 @@ public class HttpServicesTest {
 	public void testRedirectData(){
 		input.setParam("url", GET_URL);  // redirect back to get
 		ByteArrayOutputStream results = new ByteArrayOutputStream();
-		HttpServices.Status status = HttpServices.getData(REDIRECT_URL, results, input);
+		HttpServices.Status status = HttpServices.getData(input.setRequestUrl(REDIRECT_URL), results);
 
 		assertFalse("Has error", status.isError());
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-3179
Test: https://irsawebdev9.ipac.caltech.edu/IRSA-3179_sofia_proprietary_not_working/applications/sofia/

Additional changes:  https://github.com/IPAC-SW/irsa-ife/pull/93


SOFIA: proprietary queries/downloads not working.

When accessing proprietary data aware services, user's credential has to be explicitly requested when the connection is created.  This has not been done to any of IRSA's React based applications.  This PR added a few things to enable this feature and also ensure that SOFIA's server-side code implements it.

Also, refactor HttpServices to simplify its API.

To test:
Query SOFIA proprietary data.  (I use `m17` with Level 2,3,4)
This should return some FORECAST with pink(no access) rows.

Sign in as someone with access to SOFIA data.
Repeat the same query.
