### PR TITLE
 Firefly-264,Firefly-58, Firefly-145: fixed bugs

### DIFF
--- a/src/firefly/js/drawingLayers/MarkerTool.js
+++ b/src/firefly/js/drawingLayers/MarkerTool.js
@@ -392,7 +392,7 @@ function getLayerChanges(drawLayer, action) {
             if (plotIdAry) {
                 return updateMarkerText(markerText, markerTextLoc, dd[DataTypes.DATA], plotIdAry);
             }
-            break;
+            return {};
 
         case ImagePlotCntlr.CHANGE_CENTER_OF_PROJECTION:
         case ImagePlotCntlr.ANY_REPLOT:
@@ -412,10 +412,10 @@ function getLayerChanges(drawLayer, action) {
             break;
 
         default:
-            return retV;
+            return {};
 
     }
-    return retV;
+    return {};
 }
 
 const cornerCursor = ['pointer', 'pointer', 'nwse-resize', 'nesw-resize', 'nwse-resize', 'nesw-resize'];

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -1072,6 +1072,26 @@ export function findIntersectionPt(seg1x1, seg1y1, seg1x2, seg1y2, seg2x1, sec2y
     };
 }
 
+export function doSegmentsCross(seg1x1, seg1y1, seg1x2, seg1y2, seg2x1, sec2y2, seg2x2, seg2y2) {
+    const result= findIntersectionPt(seg1x1, seg1y1, seg1x2, seg1y2, seg2x1, sec2y2, seg2x2, seg2y2);
+    if (!result) return false;
+    return result.onSeg1 || result.onSeg2;
+}
+
+export function lineCrossesRect(segX1, segY1, segX2, segY2, x, y, w,h) {
+
+    if (segX1>=x && segY1>=y && segX1<=x+w && segY1<=y+h) return true;
+    if (segX2>=x && segY2>=y && segX2<=x+w && segY2<=y+h) return true;
+
+    return Boolean(
+        doSegmentsCross(segX1, segY1, segX2, segY2, x,y, x+w,y) ||
+        doSegmentsCross(segX1, segY1, segX2, segY2, x+w,y, x+w,y+h) ||
+        doSegmentsCross(segX1, segY1, segX2, segY2, x+w,y+h, x,y+h) ||
+        doSegmentsCross(segX1, segY1, segX2, segY2, x,y+h, x,y)
+    );
+
+}
+
 /**
  * distance between point and line defined by two end points
  * @param pts

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -18,6 +18,7 @@ import {visRoot} from '../ImagePlotCntlr.js';
 import {getPixScaleArcSec, getScreenPixScaleArcSec} from '../WebPlot.js';
 import {toRadians, toDegrees,isPlotNorth} from '../VisUtil.js';
 import {rateOpacity, maximizeOpacity} from '../../util/Color.js';
+import {lineCrossesRect} from '../VisUtil';
 
 const FONT_FALLBACK= ',sans-serif';
 
@@ -596,8 +597,7 @@ function drawLine(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
     const devPt1= plot.getDeviceCoords(pts[1]);
     if (!devPt0 || !devPt1) return;
 
-
-    if (plot.pointOnDisplay(devPt0) || plot.pointOnDisplay(devPt1)) {
+    if (lineCrossesRect(devPt0.x,devPt0.y,devPt1.x,devPt1.y,0,0,plot.viewDim.width,plot.viewDim.height)){
         inView= true;
         if (!onlyAddToPath || style===Style.HANDLED) {
             DrawUtil.beginPath(ctx, color,lineWidth, renderOptions);

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -328,7 +328,7 @@ function changeHiPS(state,action) {
     if (!originalPlot) return state;
 
     let plot= clone(originalPlot);
-
+    const originalImageCoordSys= plot.imageCoordSys;
 
     // single plot stuff
 

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -349,7 +349,7 @@ export function makeChangeHiPSAction(rawAction) {
                 .then( (hipsProperties) => {
                     dispatcher(
                         { type: ImagePlotCntlr.CHANGE_HIPS,
-                            payload: clone(payload, {hipsUrlRoot, hipsProperties})
+                            payload: clone(payload, {hipsUrlRoot, hipsProperties, coordSys:plot.imageCoordSys})
                         });
                     initCorrectCoordinateSys(getPlotViewById(visRoot(),plotId));
                 })

--- a/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
@@ -95,7 +95,7 @@ function makeModel(tbl_id,plotViewAry, expandedIds, oldModel) {
     if (oldModel) {
         const oldSi= SelectInfo.newInstance(oldModel.selectInfo);
         const vr= visRoot();
-        let filterStr= ''
+        let filterStr= '';
         oldModel.tableData.data.forEach( (row, idx) => {
             const plotId= row[PID_IDX];
             if (getPlotViewById(vr,plotId) && oldSi.isSelected(idx)) {


### PR DESCRIPTION
 
  - Firefly-264: FIXED: Marker, once uncheck will not recheck and become visible
  - Firefly-58: FIXED: Draw distance disappears after zoom points too far out
  - Firefly-145: changing hips will not change coordinate system

_To Test:_
   
 https://irsawebdev9.ipac.caltech.edu/firefly-264-marker-58-distance/firefly/

- Firefly-58: load an image, use distance across the middle. Zoom until the endpoints are out of view. The line should still be visible.
-  Firefly-264: load an image, add a marker, bring up layer control.  Hide and then show the marker.  It should work.
- Firefly-145: show a 2mass HiPS, change coordinate sys to Galactic, change to another 2mass HiPS (there are 4 total)