### PR TITLE
FIREFLY-56 Change ruler tool behavior for image with or without WCS and HiPS

### DIFF
--- a/src/firefly/js/drawingLayers/DistanceTool.js
+++ b/src/firefly/js/drawingLayers/DistanceTool.js
@@ -3,7 +3,7 @@
  */
 
 import numeral from 'numeral';
-import {isBoolean, isEmpty, get} from 'lodash';
+import {isBoolean, isEmpty, get, isUndefined} from 'lodash';
 import DrawLayerCntlr, {DRAWING_LAYER_KEY} from '../visualize/DrawLayerCntlr.js';
 import {getPreference} from '../core/AppDataCntlr.js';
 import {visRoot,dispatchAttributeChange} from '../visualize/ImagePlotCntlr.js';
@@ -12,7 +12,7 @@ import DrawLayer, {ColorChangeType}  from '../visualize/draw/DrawLayer.js';
 import {MouseState} from '../visualize/VisMouseSync.js';
 import {PlotAttribute} from '../visualize/PlotAttribute.js';
 import CsysConverter from '../visualize/CsysConverter.js';
-import { makeOffsetPt, makeWorldPt, makeImagePt} from '../visualize/Point.js';
+import { makeOffsetPt, makeWorldPt, makeScreenPt} from '../visualize/Point.js';
 import BrowserInfo from '../util/BrowserInfo.js';
 import VisUtil from '../visualize/VisUtil.js';
 import ShapeDataObj from '../visualize/draw/ShapeDataObj.js';
@@ -20,6 +20,7 @@ import {primePlot, getDrawLayerById} from '../visualize/PlotViewUtil.js';
 import {getUIComponent} from './DistanceToolUI.jsx';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
 import {hasWCSProjection} from '../visualize/PlotViewUtil';
+import {isHiPS} from '../visualize/WebPlot.js';
 
 
 const EDIT_DISTANCE= BrowserInfo.isTouchInput() ? 18 : 10;
@@ -28,11 +29,16 @@ const EDIT_DISTANCE= BrowserInfo.isTouchInput() ? 18 : 10;
 const ID= 'DISTANCE_TOOL';
 const TYPE_ID= 'DISTANCE_TOOL_TYPE';
 
+export const UNIT_PIXEL_ONLY = 0;
+export const UNIT_NO_PIXEL = 1;
+export const UNIT_ALL = 2;
 
 export const DIST_READOUT = 'DistanceReadout';
 export const ARC_MIN = 'arcmin';
 export const ARC_SEC = 'arcsec';
 export const DEG = 'deg';
+export const PIXEL = 'pixel';
+
 const HTML_DEG= String.fromCharCode(176);
 
 
@@ -124,13 +130,10 @@ function getLayerChanges(drawLayer, action) {
     switch (action.type) {
         case DrawLayerCntlr.DT_START:
             return start(action);
-            break;
         case DrawLayerCntlr.DT_MOVE:
             return drag(drawLayer,action);
-            break;
         case DrawLayerCntlr.DT_END:
             return end(action);
-            break;
         case DrawLayerCntlr.ATTACH_LAYER_TO_PLOT:
             if (isEmpty(get(drawLayer, ['drawData', 'data']))) {
                 return attach();
@@ -138,10 +141,8 @@ function getLayerChanges(drawLayer, action) {
             break;
         case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
             return dealWithMods(drawLayer,action);
-            break;
         case DrawLayerCntlr.FORCE_DRAW_LAYER_UPDATE:
             return dealWithUnits(drawLayer,action);
-            break;
 
     }
     return null;
@@ -167,37 +168,62 @@ function makeBaseReturnObj(plot,firstPt,currPt,drawAry )  {
 
 }
 
+
 function dealWithUnits(drawLayer,action) {
     var {plotIdAry}= action.payload;
     const plot= primePlot(visRoot(),plotIdAry[0]);
     var cc= CsysConverter.make(plot);
     if (!cc) return null;
-    var drawAry= makeSelectObj(drawLayer.firstPt, drawLayer.currentPt, drawLayer.posAngle,cc);
+    var drawAry= makeSelectObj(drawLayer.firstPt, drawLayer.currentPt, drawLayer.offsetCal,cc);
 
     return makeBaseReturnObj(plot,drawLayer.firstPt, drawLayer.currentPt,drawAry);
 }
 
-
-
 function dealWithMods(drawLayer,action) {
     var {changes,plotIdAry}= action.payload;
-    if (isBoolean(changes.posAngle)) {
+    if (isBoolean(changes.offsetCal)) {
         const plot= primePlot(visRoot(),plotIdAry[0]);
         var cc= CsysConverter.make(plot);
         if (!cc) return null;
-        var drawAry= makeSelectObj(drawLayer.firstPt, drawLayer.currentPt, changes.posAngle,cc);
-        return Object.assign({posAngle:changes.posAngle},
+        var drawAry= makeSelectObj(drawLayer.firstPt, drawLayer.currentPt, changes.offsetCal, cc);
+        return Object.assign({offsetCal:changes.offsetCal},
                               makeBaseReturnObj(plot,drawLayer.firstPt, drawLayer.currentPt,drawAry));
     }
     return null;
 }
 
 
+export function getUnitStyle(cc, world) {
+    if (isUndefined(world)) {
+        world = hasWCSProjection(cc);
+    }
+
+    if (!world) {
+        return UNIT_PIXEL_ONLY;
+    }
+    const plot= primePlot(visRoot(),cc.plotId);
+    const aHiPS = isHiPS(plot);
+    if (aHiPS) {
+        return UNIT_NO_PIXEL;
+    }
+    return UNIT_ALL;
+}
+
+export function getUnitPreference(unitStyle) {
+    if (unitStyle === UNIT_PIXEL_ONLY) {
+        return PIXEL;
+    }
+    const uFromPref = getPreference(DIST_READOUT);
+    return (unitStyle === UNIT_NO_PIXEL && uFromPref === PIXEL) ? DEG : uFromPref || DEG;
+}
+
+
+
 function attach() {
     return {
         helpLine: selHelpText,
         drawData:{data:null},
-        posAngle: false,
+        offsetCal: false,
         firstPt: null,
         currentPt: null,
         vertexDef: {points:null, pointDist:EDIT_DISTANCE},
@@ -252,7 +278,7 @@ function drag(drawLayer,action) {
     const plot= primePlot(visRoot(),plotId);
     var cc= CsysConverter.make(plot);
     if (!cc) return;
-    var drawAry= makeSelectObj(drawLayer.firstPt, imagePt, drawLayer.posAngle,cc); //todo switch back
+    var drawAry= makeSelectObj(drawLayer.firstPt, imagePt, drawLayer.offsetCal, cc); //todo switch back
     return Object.assign({currentPt:imagePt}, makeBaseReturnObj(plot,drawLayer.firstPt, imagePt,drawAry));
 }
 
@@ -265,7 +291,6 @@ function end(action) {
     }
     return retObj;
 }
-
 
 
 function setupSelect(imagePt) {
@@ -293,12 +318,11 @@ const screenDistance= (pt1,pt2) => VisUtil.computeScreenDistance(pt1.x,pt1.y,pt2
 /**
  *
  * @param dist
- * @param isWorld
  * @param pref
  * @return {*}
  */
-function getDistText(dist, isWorld, pref) {
-    if (isWorld)  {
+function getDistText(dist, pref) {
+    if (pref !== PIXEL)  {     // world & pref is undefined or  world & pref is not PIXEL
         if(pref===ARC_MIN){
             return ` ${numeral(dist*60.0).format('0.000')}'`;
         }
@@ -307,106 +331,214 @@ function getDistText(dist, isWorld, pref) {
         } else {
             return ` ${numeral(dist).format('0.000')}${HTML_DEG}`;
         }
-    }
-    else {
+    } else {                                        // not world or world & pref is PIXEL
         return ` ${Math.floor(dist)} Pixels`;
+    }
+}
+
+function getPosAngleText(pt0, pt1, isWorld, cc, pref) {
+    if (!isWorld) return '';
+
+    const PAPrefix = 'PA = ';
+    const w0 = cc.getWorldCoords(pt0);
+    const w1 = cc.getWorldCoords(pt1);
+    let   posAngle = VisUtil.getPositionAngle(w0.x, w0.y, w1.x, w1.y);
+
+    while (true) {
+        if (posAngle > 180.0) {
+            posAngle -= 360.0;
+        } else if (posAngle <= -180.0) {
+            posAngle += 360.0;
+        } else {
+            break;
+        }
+    }
+
+    if(pref===ARC_MIN){
+        return ` ${PAPrefix}${numeral(posAngle*60.0).format('0.000')}'`;
+    } else if(pref===ARC_SEC){
+        return ` ${PAPrefix}${numeral(posAngle*3600).format('0.000')}"`;
+    } else {
+        return ` ${PAPrefix}${numeral(posAngle).format('0.000')}${HTML_DEG}`;
     }
 }
 
 
 /**
- *
+ * check if the point is below the line by placing x & y with p.x & p.y in
+ * ax+by+c formed by two ends of the line and check the value after that
+ * @param line_pt1
+ * @param line_pt2   point of greater  y
+ * @param pt
+ * @param cc
+ * @returns {boolean}
+ */
+function isPointBelowLine(line_pt1, line_pt2, pt, cc) {
+    const pt1 = cc.getScreenCoords(line_pt1);
+    const pt2 = cc.getScreenCoords(line_pt2);
+    const p = cc.getScreenCoords(pt);
+    const diff = (p.x - pt2.x)*(pt2.y - pt1.y)-(pt2.x - pt1.x)*(p.y - pt2.y);
+
+    return ((pt2.x <= pt1.x) && (diff >= 0)) || ((pt2.x > pt1.x) && (diff < 0)) ;
+}
+/**
  * @param {object} firstPt
  * @param {object} currentPt
- * @param {boolean} posAngle
+ * @param {boolean} offsetCal
  * @param {CysConverter} cc
  * @return {Array}
  */
-function makeSelectObj(firstPt,currentPt, posAngle,cc) {
-    var pref= getPreference(DIST_READOUT);
-    var retval;
-    var ptAry= [firstPt,currentPt];
+function makeSelectObj(firstPt,currentPt, offsetCal, cc) {
+    const world = hasWCSProjection(cc);
+    const unitStyle = getUnitStyle(cc, world);
+    const pref = getUnitPreference(unitStyle);
 
-    var anyPt1;
-    var anyPt2;
-    var dist;
-    const world= hasWCSProjection(cc);
+    const ptAry= [firstPt,currentPt];
+    let retval;
+    let anyPt1;
+    let anyPt2;
+    let dist;
+    const LWIDTH = 3;
 
-    if (world) {
+    if (pref === PIXEL) {
+        anyPt1 = cc.getScreenCoords(ptAry[0]);
+        anyPt2 = cc.getScreenCoords(ptAry[1]);
+        if (!anyPt1 || !anyPt2) return null;
+        dist = screenDistance(anyPt1,anyPt2);
+    } else {
         anyPt1 = cc.getWorldCoords(ptAry[0]);
         anyPt2 = cc.getWorldCoords(ptAry[1]);
         if (!anyPt1 || !anyPt2) return null;
         dist= VisUtil.computeDistance(anyPt1,anyPt2);
     }
-    else {
-        anyPt1 = ptAry[0];
-        anyPt2 = ptAry[1];
-        if (!anyPt1 || !anyPt2) return null;
-        dist= screenDistance(anyPt1,anyPt2);
-    }
 
+    const d1 = cc.getScreenCoords(anyPt1);
+    const d2 = cc.getScreenCoords(anyPt2);
+    const d_midx = (d1.x+d2.x)/2;
+    const d_midy = (d1.y+d2.y)/2;
 
-    var obj= ShapeDataObj.makeLine(anyPt1,anyPt2);
-    obj.style= Style.HANDLED;
-    obj.text= getDistText(dist,world,pref);
-    obj.textLoc=TextLocation.LINE_MID_POINT;
-    obj.textOffset= makeOffsetPt(-15, 0);
+    const obj= ShapeDataObj.makeLine(anyPt1,anyPt2, true);   // make line with arrow at the second end
+    const distText = getDistText(dist, pref);
+    const posAText = getPosAngleText(firstPt, currentPt, world, cc, DEG);
+    obj.text = ((posAText) ? (posAText + '\n') : '') + distText;
+    obj.style= Style.STARTHANDLED;
+    obj.lineWidth = LWIDTH;
+    obj.fontSize = '16px';
+    obj.fontWeight = 'bold';
+    obj.textLoc=TextLocation.LINE_TOP_STACK;
+    obj.texttBaseLine = 'middle';
 
-    if (posAngle) {
-        var eastPt;
-        var westPt;
+    if (offsetCal) {
+        let highPt;
+        let lowPt;
 
-        if (anyPt1.x>anyPt2.x) {
-            eastPt= anyPt1;
-            westPt= anyPt2;
+        if (d1.y <= d2.y) {
+            highPt = anyPt1;
+            lowPt = anyPt2;
+        } else {
+            highPt = anyPt2;
+            lowPt = anyPt1;
         }
-        else {
-            eastPt= anyPt2;
-            westPt= anyPt1;
-        }
 
-        var adjDist;
-        var opDist;
-        var lonDelta1;
-        var lonDelta2;
-        var latDelta1;
-        var latDelta2;
-        if (world) {
-            lonDelta1= makeWorldPt(eastPt.x, eastPt.y);
-            lonDelta2= makeWorldPt(westPt.x, eastPt.y);
-            adjDist= VisUtil.computeDistance(lonDelta1,lonDelta2);
+        let adjDist;
+        let opDist;
+        let lonDelta1;
+        let lonDelta2;
+        let latDelta1;
+        let latDelta2;
+        const plot= primePlot(visRoot(),cc.plotId);
+        const aHiPS = isHiPS(plot);
+        let  corner_pt;
 
-            latDelta1= makeWorldPt(westPt.x, eastPt.y);
-            latDelta2= makeWorldPt(westPt.x, westPt.y);
-            opDist= VisUtil.computeDistance(latDelta1,latDelta2);
-        }
-        else {
-            lonDelta1= makeImagePt(eastPt.x, eastPt.y);
-            lonDelta2= makeImagePt(westPt.x, eastPt.y);
+        if (pref !== PIXEL) {
+            corner_pt = makeWorldPt(highPt.x, lowPt.y);
+
+            if (isPointBelowLine(highPt, lowPt, corner_pt, cc)) {
+                lonDelta1 = makeWorldPt(lowPt.x, lowPt.y);
+                lonDelta2 = corner_pt;
+                adjDist = VisUtil.computeDistance(lonDelta1, lonDelta2);
+
+                latDelta1 = corner_pt;
+                latDelta2 = makeWorldPt(highPt.x, highPt.y);
+                opDist = VisUtil.computeDistance(latDelta1, latDelta2);
+            } else {
+                corner_pt = makeWorldPt(lowPt.x, highPt.y);
+                lonDelta1 = makeWorldPt(highPt.x, highPt.y);
+                lonDelta2 = corner_pt;
+                adjDist = VisUtil.computeDistance(lonDelta1, lonDelta2);
+
+                latDelta1 = corner_pt;
+                latDelta2 = makeWorldPt(lowPt.x, lowPt.y);
+                opDist = VisUtil.computeDistance(latDelta1, latDelta2);
+            }
+        } else {
+            lonDelta1= makeScreenPt(highPt.x, lowPt.y);
+            lonDelta2= makeScreenPt(lowPt.x, lowPt.y);
             adjDist= screenDistance(lonDelta1,lonDelta2);
 
-            latDelta1= makeImagePt(westPt.x, eastPt.y);
-            latDelta2= makeImagePt(westPt.x, westPt.y);
+            latDelta1= makeScreenPt(highPt.x, lowPt.y);
+            latDelta2= makeScreenPt(highPt.x, highPt.y);
             opDist= screenDistance(latDelta1,latDelta2);
         }
 
-        var adj= ShapeDataObj.makeLine(lonDelta1,lonDelta2);
-        var op= ShapeDataObj.makeLine(latDelta1, latDelta2);
-        var lonDelta1TextPt= lonDelta1;
+        const adj = ShapeDataObj.makeLine(lonDelta1,lonDelta2);
+        const op = ShapeDataObj.makeLine(latDelta1, latDelta2);
 
+        adj.lineWidth = LWIDTH;
+        op.lineWidth = LWIDTH;
+
+        const lineD = (d2.y - d1.y)*(d2.x - d1.x);
+
+        let end1 = cc.getScreenCoords(adj.pts[0]);
+        let end2 = cc.getScreenCoords(adj.pts[1]);
+        const seg1 = 10.0;
+        const seg2 = 16.0;
+
+        console.log('seg1: '+seg1+ ' seg2: '+seg2);
+        const ad_midy = (end1.y+end2.y)/2;
         adj.textLoc=TextLocation.LINE_MID_POINT;
-        adj.text= getDistText(adjDist,world,pref);
+        adj.textAlign = 'center';
+        adj.textBaseLine = 'middle';
+        adj.text = aHiPS || lineD !== 0 ? getDistText(adjDist,pref) : '';
+        adj.textOffset = ad_midy >= d_midy ? makeOffsetPt(0, seg1) : makeOffsetPt(-seg2, -seg2);
+        adj.style = Style.HANDLED;
+        adj.fontSize = '16px';
+        adj.fontWeight = 'bold';
+        adj.offsetOnScreen = true;
+
+        // for HiPS image, adj may not be perfectly horizontal
+        if (end1.y === end2.y) {
+            adj.textAngle = 0.0;
+        } else {
+            adj.textAngle = -Math.atan((end2.y - end1.y) / (end2.x -end1.x)) * 180.0 / Math.PI;
+        }
+
+        end1 = cc.getScreenCoords(op.pts[0]);
+        end2 = cc.getScreenCoords(op.pts[1]);
+        const op_midx = (end1.x + end2.x)/2;
         op.textLoc=TextLocation.LINE_MID_POINT;
-        op.text= getDistText(opDist,world,pref);
-        op.textOffset= makeOffsetPt(0,15);
+        op.text= lineD !== 0 || aHiPS ? getDistText(opDist,pref) : '';
+        op.textAlign = op_midx < d_midx ? 'end' : 'start';
+        op.textOffset = op_midx < d_midx ? makeOffsetPt(-seg1, 0) : makeOffsetPt(seg1, 0);
+        op.textBaseLine = 'middle';
+        op.style = Style.HANDLED;
+        op.fontSize = '16px';
+        op.fontWeight = 'bold';
+        op.offsetOnScreen = true;
 
-        var sinX= opDist/dist;
-        var angle= VisUtil.toDegrees(Math.asin(sinX));
+        // for HiPS image, op may not be perfectly vertical
+        if (end1.x === end2.x) {
+            op.textAngle = 0.0;
+        } else {
+            const a =  Math.atan((end2.y- end1.y)/(end2.x - end1.x));
 
-        var aStr=  `${numeral(angle).format('0.000')}${HTML_DEG}`;
-        var angleShape= ShapeDataObj.makeTextWithOffset(makeOffsetPt(8,-8), lonDelta1TextPt, aStr);
-
-        retval= [obj,adj,op,angleShape];
+            if (a > 0) {
+                op.textAngle = -(a - Math.PI/2) * 180.0/Math.PI;
+            } else {
+                op.textAngle = -(a + Math.PI/2) * 180.0/Math.PI;
+            }
+        }
+        retval= [obj,adj,op];
     }
     else {
         retval= [obj];

--- a/src/firefly/js/drawingLayers/DistanceTool.js
+++ b/src/firefly/js/drawingLayers/DistanceTool.js
@@ -21,6 +21,8 @@ import {getUIComponent} from './DistanceToolUI.jsx';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
 import {hasWCSProjection} from '../visualize/PlotViewUtil';
 import {isHiPS} from '../visualize/WebPlot.js';
+import {DrawingType} from '../visualize/draw/DrawObj';
+import {makeImagePt} from '../visualize/Point';
 
 
 const EDIT_DISTANCE= BrowserInfo.isTouchInput() ? 18 : 10;
@@ -401,8 +403,8 @@ function makeSelectObj(firstPt,currentPt, offsetCal, cc) {
     const LWIDTH = 3;
 
     if (pref === PIXEL) {
-        anyPt1 = cc.getScreenCoords(ptAry[0]);
-        anyPt2 = cc.getScreenCoords(ptAry[1]);
+        anyPt1 = cc.getImageCoords(ptAry[0]);
+        anyPt2 = cc.getImageCoords(ptAry[1]);
         if (!anyPt1 || !anyPt2) return null;
         dist = screenDistance(anyPt1,anyPt2);
     } else {
@@ -427,6 +429,7 @@ function makeSelectObj(firstPt,currentPt, offsetCal, cc) {
     obj.fontWeight = 'bold';
     obj.textLoc=TextLocation.LINE_TOP_STACK;
     obj.texttBaseLine = 'middle';
+    obj.supportedDrawingTypes=  (pref===PIXEL) ? DrawingType.ImageCoordsOnly : DrawingType.WcsCoordsOnly;
 
     if (offsetCal) {
         let highPt;
@@ -472,12 +475,12 @@ function makeSelectObj(firstPt,currentPt, offsetCal, cc) {
                 opDist = VisUtil.computeDistance(latDelta1, latDelta2);
             }
         } else {
-            lonDelta1= makeScreenPt(highPt.x, lowPt.y);
-            lonDelta2= makeScreenPt(lowPt.x, lowPt.y);
+            lonDelta1= makeImagePt(highPt.x, lowPt.y);
+            lonDelta2= makeImagePt(lowPt.x, lowPt.y);
             adjDist= screenDistance(lonDelta1,lonDelta2);
 
-            latDelta1= makeScreenPt(highPt.x, lowPt.y);
-            latDelta2= makeScreenPt(highPt.x, highPt.y);
+            latDelta1= makeImagePt(highPt.x, lowPt.y);
+            latDelta2= makeImagePt(highPt.x, highPt.y);
             opDist= screenDistance(latDelta1,latDelta2);
         }
 
@@ -505,6 +508,8 @@ function makeSelectObj(firstPt,currentPt, offsetCal, cc) {
         adj.fontSize = '16px';
         adj.fontWeight = 'bold';
         adj.offsetOnScreen = true;
+        adj.supportedDrawingTypes=  (pref===PIXEL) ? DrawingType.ImageCoordsOnly : DrawingType.WcsCoordsOnly;
+
 
         // for HiPS image, adj may not be perfectly horizontal
         if (end1.y === end2.y) {
@@ -525,6 +530,7 @@ function makeSelectObj(firstPt,currentPt, offsetCal, cc) {
         op.fontSize = '16px';
         op.fontWeight = 'bold';
         op.offsetOnScreen = true;
+        op.supportedDrawingTypes=  (pref===PIXEL) ? DrawingType.ImageCoordsOnly : DrawingType.WcsCoordsOnly;
 
         // for HiPS image, op may not be perfectly vertical
         if (end1.x === end2.x) {

--- a/src/firefly/js/drawingLayers/DistanceToolUI.jsx
+++ b/src/firefly/js/drawingLayers/DistanceToolUI.jsx
@@ -13,6 +13,10 @@ import CsysConverter from '../visualize/CsysConverter';
 
 
 export const getUIComponent = (drawLayer,pv) => <DistanceToolUI drawLayer={drawLayer} pv={pv}/>;
+const worldUnit = [ {label: 'degrees', value: 'deg'},
+    {label: 'arcminutes', value: 'arcmin'},
+    {label: 'arcseconds', value: 'arcsec'}];
+const pixelUnit = [{label: 'pixels', value: 'pixel'}];
 
 function DistanceToolUI({drawLayer,pv}) {
 
@@ -26,12 +30,7 @@ function DistanceToolUI({drawLayer,pv}) {
     const plot = pv.plots[pv.primeIdx];
     const cc = CsysConverter.make(plot);
     const isWorld = hasWCSProjection(cc);
-    const worldUnit = [ {label: 'degrees', value: 'deg'},
-                        {label: 'arcminutes', value: 'arcmin'},
-                        {label: 'arcseconds', value: 'arcsec'}];
-    const pixelUnit = [{label: 'pixels', value: 'pixel'}];
     const unitStyle = getUnitStyle(cc, isWorld);
-
     const pref = getUnitPreference(unitStyle);
     const options = (unitStyle === UNIT_ALL) ? worldUnit.concat(pixelUnit)
                                              : ((unitStyle === UNIT_NO_PIXEL)? worldUnit : pixelUnit);

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -18,7 +18,6 @@ import {primePlot} from './PlotViewUtil.js';
 import {doConv} from '../astro/conv/CoordConv.js';
 import Point, {makeImageWorkSpacePt, makeImagePt, makeScreenPt,
                makeWorldPt, makeDevicePt, isValidPoint, pointEquals} from './Point.js';
-import {Matrix} from 'transformation-matrix-js';
 import {getPixScaleDeg, getFluxUnits} from './WebPlot.js';
 import {SelectedShape} from '../drawingLayers/SelectArea.js';
 
@@ -75,7 +74,6 @@ export function computeDistance(p1, p2) {
 }
 
 /**
- *
  * @param p1 {Pt}
  * @param p2 {Pt}
  * @return {number}
@@ -84,6 +82,14 @@ const computeSimpleDistance= function(p1, p2) {
     const dx = p1.x - p2.x;
     const dy = p1.y - p2.y;
     return Math.sqrt(dx * dx + dy * dy);
+};
+
+
+const computeSimpleSlopeAngle = function (fromPt, toPt) {
+    const dx = toPt.x - fromPt.x;
+    const dy = toPt.y - fromPt.y;
+
+    return Math.atan2(dy, dx);
 };
 
 /**
@@ -1204,7 +1210,7 @@ export default {
     intersects, contains, containsRec,containsCircle,
     getArrowCoords, calculatePosition, getCorners,
     makePt, getWorldPtRepresentation, getCenterPtOfPlot, toDegrees, convertAngle,
-    distToLine, distanceToPolygon, distanceToCircle
+    distToLine, distanceToPolygon, distanceToCircle, computeSimpleSlopeAngle
 };
 
 

--- a/src/firefly/js/visualize/draw/DrawObj.js
+++ b/src/firefly/js/visualize/draw/DrawObj.js
@@ -2,17 +2,42 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
+import Enum from 'enum';
+
 export default {makeDrawObj};
 
+/**
+ * @summary the type of data this draw object can draw on
+ * @description can be 'WcsCoordsOnly', 'ImageCoordsOnly', 'All'
+ * @public
+ * @global
+ */
+export const DrawingType= new Enum(['WcsCoordsOnly', 'ImageCoordsOnly', 'All']);
+
+
+/**
+ * @typedef {Object} DrawObj
+ *
+ * @prop {Object} supportedDrawingTypes
+ * @prop {Object} renderOptions
+ * @prop {String} type
+ */
+
+
+/**
+ *
+ * @return {DrawObj}
+ */
 function makeDrawObj() {
 
-    var obj= {
+    const obj= {
         // color:
         // selected:
         // highlighted
         // representCnt
         // lineWidth : 1;
 
+        supportedDrawingTypes: DrawingType.All,
         renderOptions : {}, // can contain keys: shadow,translation,rotAngle
                             // shadow  - a shadow object, use makeShadow()
                             // translation - a ScreenPt use Point.makeScreenPt

--- a/src/firefly/js/visualize/draw/DrawUtil.js
+++ b/src/firefly/js/visualize/draw/DrawUtil.js
@@ -763,6 +763,13 @@ function clearCanvas(canvas) {
 }
 
 
+/**
+ * add a solid arrow to the second end of the line
+ * @param ctx
+ * @param fromPt in device coordinate
+ * @param toPt   in device coordinate
+ * @param color
+ */
 function drawArrowOnLine(ctx, fromPt, toPt, color) {
     const ahead = 16;
     const aAngle = Math.PI/6;

--- a/src/firefly/js/visualize/draw/DrawUtil.js
+++ b/src/firefly/js/visualize/draw/DrawUtil.js
@@ -1,7 +1,8 @@
 
 import numeral from 'numeral';
+
 import {isNil, set} from 'lodash';
-import {makeScreenPt} from '../Point.js';
+import {makeScreenPt,  makeDevicePt} from '../Point.js';
 import {DrawSymbol} from './DrawSymbol.js';
 import {toRadians} from '../VisUtil.js';
 
@@ -13,7 +14,9 @@ export default {getColor, beginPath, stroke, strokeRec, drawLine, drawText, draw
                 drawX, drawSquareX, drawSquare, drawEmpSquareX, drawCross, drawSymbol, drawPointMarker,
                 drawEmpCross, drawDiamond, drawDot, drawCircle, drawEllipse, drawBoxcircle,
                 drawArrow, drawRotate, clear,clearCanvas, fillRec, getDrawingSize, polygonPath,
-                getSymbolSize, getSymbolSizeBasedOn, beginFillPath, endFillPath, fillPath};
+                getSymbolSize, getSymbolSizeBasedOn, beginFillPath, endFillPath, fillPath,
+                drawArrowOnLine
+                };
 
 function drawHandledLine(ctx, color, sx, sy, ex, ey, onlyAddToPath= false) {
     let slope= NaN;
@@ -757,4 +760,22 @@ function clear(ctx,width,height) {
 function clearCanvas(canvas) {
     if (!canvas) return;
     clear(canvas.getContext('2d'),canvas.width,canvas.height);
+}
+
+
+function drawArrowOnLine(ctx, fromPt, toPt, color) {
+    const ahead = 16;
+    const aAngle = Math.PI/6;
+    const dx = toPt.x - fromPt.x;
+    const dy = toPt.y - fromPt.y;
+    const d = Math.sqrt(dx*dx+dy*dy);
+    const aD = d < ahead ? d : ahead;
+    const angle = Math.atan2(dy, dx);
+    const pts = [];
+
+    pts.push(toPt);
+    pts.push(makeDevicePt(toPt.x - aD * Math.cos(angle - aAngle), toPt.y - aD * Math.sin(angle - aAngle)));
+    pts.push(makeDevicePt(toPt.x - aD * Math.cos(angle + aAngle), toPt.y - aD * Math.sin(angle + aAngle)));
+
+    fillPath(ctx, color, pts, true);
 }

--- a/src/firefly/js/visualize/draw/Drawer.js
+++ b/src/firefly/js/visualize/draw/Drawer.js
@@ -11,7 +11,11 @@ import DrawUtil from './DrawUtil.js';
 import Color from '../../util/Color.js';
 import CsysConverter, {CCUtil} from '../CsysConverter.js';
 import {POINT_DATA_OBJ} from './PointDataObj.js';
+import {DrawingType} from './DrawObj.js';
 import DrawOp from './DrawOp.js';
+import {isHiPS, isImage} from '../WebPlot';
+import {hasWCSProjection} from '../PlotViewUtil';
+
 
 const ENABLE_COLORMAP= false;
 let drawerCnt=0;
@@ -568,11 +572,19 @@ function drawObj(ctx, def, csysConv, obj, vpPtM, onlyAddToPath) {
  * it is draw on a WebPlot, and if it is in the drawing area.
  * Otherwise it will always return true
  * @param {CysConverter} csysConv the WebPlot to draw on
- * @param obj the DrawingObj to check
+ * @param {DrawObj} obj the DrawingObj to check
  * @return {boolean} true is it should be drawn
  */
 function shouldDrawObj(csysConv, obj) {
     if (!obj) return false;
+    if (obj.supportedDrawingTypes === DrawingType.WcsCoordsOnly) {
+        if (!csysConv) return false;
+        else if (isImage(csysConv) && !hasWCSProjection(csysConv)) return false;
+    }
+    else if (obj.supportedDrawingTypes===DrawingType.ImageCoordsOnly && isHiPS(csysConv)) {
+        return false;
+    }
+
     if (csysConv && obj.pt && obj.type===POINT_DATA_OBJ) {
         return csysConv.pointOnDisplay(obj.pt);
     }

--- a/src/firefly/js/visualize/draw/DrawingDef.js
+++ b/src/firefly/js/visualize/draw/DrawingDef.js
@@ -32,6 +32,7 @@ export const TextLocation = new Enum([ 'DEFAULT',
     'LINE_MID_POINT',
     'LINE_MID_POINT_OR_BOTTOM',
     'LINE_MID_POINT_OR_TOP',
+    'LINE_TOP_STACK',
     'CIRCLE_NE',
     'CIRCLE_NW',
     'CIRCLE_SE',
@@ -50,7 +51,7 @@ export const TextLocation = new Enum([ 'DEFAULT',
     'REGION_SW',
     'CENTER']); // use MID_X, MID_X_LONG, MID_Y, MID_Y_LONG for vertical or horizontal lines
 
-export const Style= new Enum(['STANDARD','HANDLED', 'LIGHT', 'FILL']);
+export const Style= new Enum(['STANDARD','HANDLED', 'STARTHANDLED', 'ENDHANDLED', 'LIGHT', 'FILL']);
 
 export const DEFAULT_FONT_SIZE = '9pt';
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -6,17 +6,17 @@ import Enum from 'enum';
 import validator from 'validator';
 import DrawObj from './DrawObj';
 import DrawUtil from './DrawUtil';
-import VisUtil, {convertAngle, computeScreenDistance, convert} from '../VisUtil.js';
+import VisUtil, {convertAngle, convert} from '../VisUtil.js';
 import {TextLocation, Style, DEFAULT_FONT_SIZE} from './DrawingDef.js';
 import Point, {makeScreenPt, makeDevicePt, makeOffsetPt, makeWorldPt, makeImagePt, SimplePt} from '../Point.js';
 import {toRegion} from './ShapeToRegion.js';
-import {getDrawobjArea,  isScreenPtInRegion, makeHighlightShapeDataObj, DELTA} from './ShapeHighlight.js';
+import {getDrawobjArea,  isScreenPtInRegion, makeHighlightShapeDataObj} from './ShapeHighlight.js';
 import CsysConverter from '../CsysConverter.js';
 import {has, isNil, get, set, isEmpty} from 'lodash';
-import {getPlotViewById, getCenterOfProjection, primePlot} from '../PlotViewUtil.js';
+import {getPlotViewById, getCenterOfProjection} from '../PlotViewUtil.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {getPixScaleArcSec, getScreenPixScaleArcSec} from '../WebPlot.js';
-import {toRadians, toDegrees,isPlotNorth} from '../VisUtil.js';
+import {toRadians, toDegrees} from '../VisUtil.js';
 import {rateOpacity, maximizeOpacity} from '../../util/Color.js';
 import {lineCrossesRect} from '../VisUtil';
 
@@ -109,8 +109,8 @@ function make(sType) {
     return obj;
 }
 
-function makeLine(pt1, pt2) {
-    return Object.assign(make(ShapeType.Line), {pts:[pt1, pt2]});
+function makeLine(pt1, pt2, bArrow=false) {
+    return Object.assign(make(ShapeType.Line), {pts:[pt1, pt2], withArrow: bArrow});
 }
 
 function makeCircle(pt1, pt2) {
@@ -589,7 +589,7 @@ export function drawShape(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
  * @param onlyAddToPath
  */
 function drawLine(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
-    const {pts, text, renderOptions}= drawObj;
+    const {pts, text, renderOptions, withArrow}= drawObj;
     const {style, color, lineWidth, textLoc, fontSize}= drawParams;
 
     let inView= false;
@@ -605,16 +605,40 @@ function drawLine(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
         ctx.moveTo(devPt0.x, devPt0.y);
         ctx.lineTo(devPt1.x, devPt1.y);
         if (!onlyAddToPath || style===Style.HANDLED) DrawUtil.stroke(ctx);
+        if (withArrow) {
+            DrawUtil.drawArrowOnLine(ctx, devPt0, devPt1, color);
+        }
     }
 
     if (!isNil(text) && inView) {
-        const textLocPt= makeTextLocationLine(plot, textLoc, fontSize,pts[0], pts[1]);
-        drawText(drawObj,  ctx, plot, plot.getDeviceCoords(textLocPt), drawParams);
+        if (textLoc === TextLocation.LINE_TOP_STACK) {
+            const textLines = text.split('\n');
+            textLines.forEach((oneText, idx) => {
+                const tLocPt = makeTextLocationLine(plot, textLoc, fontSize, pts[0], pts[1], idx+1, drawObj);
+                drawObj.text = oneText;
+                drawText(drawObj,  ctx, plot, plot.getDeviceCoords(tLocPt), drawParams);
+            });
+            drawObj.text = text;
+        } else {
+            const textLocPt = makeTextLocationLine(plot, textLoc, fontSize, pts[0], pts[1]);
+            drawText(drawObj, ctx, plot, plot.getDeviceCoords(textLocPt), drawParams);
+        }
     }
 
-    if (style===Style.HANDLED && inView) {
-        DrawUtil.fillRec(ctx, color,devPt0.x-2, devPt0.y-2, 5,5, renderOptions);
-        DrawUtil.fillRec(ctx, color,devPt1.x-2, devPt1.y-2, 5,5, renderOptions);
+    if ([Style.HANDLED, Style.STARTHANDLED, Style.ENDHANDLED].includes(style) && inView) {
+        const rAngle = VisUtil.computeSimpleSlopeAngle(devPt0, devPt1);
+        const rOptions = {};
+
+        rOptions.rotAngle = rAngle;
+
+        if (style !== Style.ENDHANDLED) {
+            rOptions.translation = {x: devPt0.x, y: devPt0.y};
+            DrawUtil.fillRec(ctx, color, -3, -3, 7, 7, rOptions);
+        }
+        if (style !== Style.STARTHANDLED) {
+            rOptions.translation = {x: devPt1.x, y: devPt1.y};
+            DrawUtil.fillRec(ctx, color, -3, -3, 7, 7, rOptions);
+        }
     }
 }
 
@@ -682,7 +706,8 @@ function drawCircle(drawObj, ctx,  plot, drawParams) {
 export function drawText(drawObj, ctx, plot, inPt, drawParams) {
     if (!inPt) return false;
     
-    const {text, textOffset, renderOptions, rotationAngle, isLonLine, textBaseline= 'top', textAlign='start', textAngle=0}= drawObj;
+    const {text, textOffset, renderOptions, rotationAngle, isLonLine, textBaseline= 'top',
+           textAlign='start', textAngle=0, offsetOnScreen=false}= drawObj;
     //the angle of the grid line
     let angle=0;
     let pvAngle=undefined;
@@ -694,7 +719,7 @@ export function drawText(drawObj, ctx, plot, inPt, drawParams) {
         if (pvAngle>0) {
             if (isLonLine  && pvAngle<=210 ){
                 //flip the label text
-                    pvAngle +=180;
+                pvAngle +=180;
 
             }
 
@@ -706,39 +731,46 @@ export function drawText(drawObj, ctx, plot, inPt, drawParams) {
         }
 
         angle = pvAngle + lineAngle;
+    } else {
+        const pv = getPlotViewById(visRoot(), plot.plotId);
+        angle = pv.flipY? 180 - pv.rotation:pv.rotation;
+    }
 
+    let devicePt= plot.getDeviceCoords(inPt);
+    if (!devicePt) {
+        return false;
+    }
 
+    let x, y;
+    if (offsetOnScreen) {
+        const scrPt = plot.getScreenCoords(inPt);
+        x = textOffset ? scrPt.x + textOffset.x : scrPt.x;
+        y = textOffset ? scrPt.y + textOffset.y : scrPt.y;
+
+        devicePt = plot.getDeviceCoords(makeScreenPt(x, y));
+        if (!devicePt) {
+            return false;
+        }
+        x = devicePt.x;
+        y = devicePt.y;
+    } else  {
+        x = textOffset ? devicePt.x + textOffset.x : devicePt.x;
+        y = textOffset ? devicePt.y + textOffset.y : devicePt.y;
     }
 
     if (textAngle) {
         angle = angle ? angle - textAngle : -textAngle;
     }
 
-
     const {fontName, fontSize, fontWeight, fontStyle}= drawParams;
     const color = drawParams.color || drawObj.color || 'black';
-
-    const devicePt= plot.getDeviceCoords(inPt);
-
-    //if (!plot.pointOnDisplay(devicePt)) {
-    if (!devicePt) {
-        return false;
-    }
-
-    let {x,y}= devicePt;
 
     let textHeight= 12;
     if (validator.isFloat(fontSize.substring(0, fontSize.length - 2))) {
         textHeight = parseFloat(fontSize.substring(0, fontSize.length - 2)) * 14 / 10;
     }
 
-
     const textWidth = textHeight*text.length*8/20;
-    if (textOffset) {
-        x+=textOffset.x;
-        y+=textOffset.y;
-    }
-
 
     if (x<2) {
         if (x<=-textWidth) return false; // don't draw
@@ -1364,22 +1396,25 @@ function makeTextLocationCircle(plot, textLoc, fontSize, centerPt, screenRadius)
  * @param fontSize
  * @param inPt0
  * @param inPt1
+ * @param tIndex text line number for multipe text lines on LINE_TOP_STACK location style
+ * @param drawObj line obj
  * @return {ScreenPt}
  */
-function makeTextLocationLine(plot, textLoc, fontSize, inPt0, inPt1) {
+function makeTextLocationLine(plot, textLoc, fontSize, inPt0, inPt1, tIndex, drawObj) {
     if (!inPt0 || !inPt1) return null;
     let pt0= plot.getScreenCoords(inPt0);
     let pt1= plot.getScreenCoords(inPt1);
 
     if (!pt0 || !pt1) return null;
     const height= fontHeight(fontSize);
+    let x, y;
 
-    // pt1 is supposed to be lower on screen
-    if (pt0.y > pt1.y) {
+    // pt1 is supposed to be lower on screen, not for TextLocation.LINE_TOP_STACK
+    if ((pt0.y > pt1.y) && (textLoc !== TextLocation.LINE_TOP_STACK)) {
         [pt1, pt0] = [pt0, pt1];
+        x = pt1.x+5;
+        y = pt1.y+5;
     }
-    let x = pt1.x+5;
-    let y = pt1.y+5;
 
     if (textLoc===TextLocation.LINE_MID_POINT || textLoc===TextLocation.LINE_MID_POINT_OR_BOTTOM ||
             textLoc===TextLocation.LINE_MID_POINT_OR_TOP) {
@@ -1405,6 +1440,30 @@ function makeTextLocationLine(plot, textLoc, fontSize, inPt0, inPt1) {
         case TextLocation.LINE_MID_POINT_OR_TOP:
             x= (pt1.x+pt0.x)/2;
             y= (pt1.y+pt0.y)/2;
+            break;
+        case TextLocation.LINE_TOP_STACK:    // stack multiple text lines at top side of the line
+                                             // calculate rotation angle on screen coordinate domain
+            const slope = VisUtil.computeSimpleSlopeAngle(pt0, pt1);
+            const ratio = [1/5, 4/5];
+            let   offset = height * (tIndex + 0.5);
+
+            if (slope >= -Math.PI/2 && slope < Math.PI/2) { // quadrant 1 & 4
+                x = pt1.x * ratio[0] + pt0.x * ratio[1];    // closer to p0
+                y = pt1.y * ratio[0] + pt0.y * ratio[1];
+                if (drawObj) {
+                    drawObj.textAngle = -slope*180.0/Math.PI;
+                }
+             } else {                                      // quadrant 2 & 3
+                x = pt0.x * ratio[0] + pt1.x * ratio[1];   // closer to p1
+                y = pt0.y * ratio[0] + pt1.y * ratio[1];
+                offset *= -1;
+                if (drawObj) {
+                    drawObj.textAngle = (Math.PI - slope)*180.0/Math.PI;
+                }
+            }
+            x = x + offset * Math.sin(slope);
+            y = y - Math.abs(offset * Math.cos(slope));
+
             break;
         default:
             break;

--- a/src/firefly/js/visualize/iv/HiPSSingleTileRender.js
+++ b/src/firefly/js/visualize/iv/HiPSSingleTileRender.js
@@ -1,3 +1,5 @@
+import {get} from 'lodash';
+
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
@@ -17,18 +19,51 @@
 export function drawOneHiPSTile(ctx, img, cornersAry, tileSize, offsetPt, applyCorrection, norder) {
 
     const delta = norder<=3 ? 0.2 : 0;
+    const triangles= get(window,'firefly.hipsTriangles',2);
+    
 
-    const triangle1= [{x:tileSize-delta, y:tileSize-delta}, {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}];
-    const triangle2= [ {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}, {x:delta, y:delta} ];
+    if (triangles===2) {
+        const triangle1= [{x:tileSize-delta, y:tileSize-delta}, {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}];
+        const triangle2= [ {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}, {x:delta, y:delta} ];
 
-    drawTexturedTriangle(ctx, img,
-        cornersAry[0], cornersAry[1], cornersAry[3],
-        triangle1[0], triangle1[1], triangle1[2],
-        offsetPt, applyCorrection);
-    drawTexturedTriangle(ctx, img,
-        cornersAry[1], cornersAry[3], cornersAry[2],
-        triangle2[0], triangle2[1], triangle2[2],
-        offsetPt, applyCorrection);
+        drawTexturedTriangle(ctx, img,
+            cornersAry[0], cornersAry[1], cornersAry[3],
+            triangle1[0], triangle1[1], triangle1[2],
+            offsetPt, applyCorrection);
+        drawTexturedTriangle(ctx, img,
+            cornersAry[1], cornersAry[3], cornersAry[2],
+            triangle2[0], triangle2[1], triangle2[2],
+            offsetPt, applyCorrection);
+    }
+    else if (triangles===4) {
+        const mp=tileSize/2;
+        const cMx= cornersAry.reduce( (total,pt) => total+pt.x, 0)/cornersAry.length;
+        const cMy= cornersAry.reduce( (total,pt) => total+pt.y, 0)/cornersAry.length;
+        const cPt= {x:cMx,y:cMy};
+
+        const triangle1= [{x:tileSize-delta, y:tileSize-delta}, {x:mp-delta, y:mp-delta}, {x:tileSize-delta, y:delta}];
+        const triangle2= [{x:tileSize-delta, y:delta}, {x:mp-delta, y:mp-delta}, {x:delta, y:delta}];
+        const triangle3= [{x:delta, y:tileSize-delta}, {x:mp-delta, y:mp-delta}, {x:delta, y:delta}];
+        const triangle4= [{x:tileSize-delta, y:tileSize-delta}, {x:mp-delta, y:mp-delta}, {x:delta, y:tileSize-delta}];
+
+        drawTexturedTriangle(ctx, img,
+            cornersAry[0], cPt, cornersAry[1],
+            triangle1[0], triangle1[1], triangle1[2],
+            offsetPt, applyCorrection);
+        drawTexturedTriangle(ctx, img,
+            cornersAry[1], cPt, cornersAry[2],
+            triangle2[0], triangle2[1], triangle2[2],
+            offsetPt, applyCorrection);
+        drawTexturedTriangle(ctx, img,
+            cornersAry[3], cPt, cornersAry[2],
+            triangle3[0], triangle3[1], triangle3[2],
+            offsetPt, applyCorrection);
+        drawTexturedTriangle(ctx, img,
+            cornersAry[0], cPt, cornersAry[3],
+            triangle4[0], triangle4[1], triangle4[2],
+            offsetPt, applyCorrection);
+
+    }
 }
 
 


### PR DESCRIPTION
The developement fixes the ruler tool behavior based on the following JIRA tickets, 
https://jira.ipac.caltech.edu/browse/FIREFLY-56
https://jira.ipac.caltech.edu/browse/FIREFLY-1

Here is the  summry of the fixing, 
- increase the line thickness and font size and style of the ruler tool
- display PA along angular distance without requiring the user to click in the layer dialog
   --  PA angle and angular disatance are displayed in parallell, above and along the anglular distance vector 
   -- PA angle is measured East from North, in unit 'degree'
- Add an arrow head at the end of angllar distance vector 
- Unit update including that on layer dialog, 
   -- add unit 'pixel' to image with WCS case 
   -- image without WCS has only unit 'pixel' option
   -- HiPS has no 'pixel' unit
-  lines and the relevant text from offset calculation
   -- add handles (squares) at both ends of the lines. 
   -- text is rotated per the direction of each line

test: 
https://irsawebdev9.ipac.caltech.edu/FIREFLY-56_RulerToolChange/firefly/
- start image search on regular image, image without WCS, or HiPS
   (samples for image without WCS are located at firefly_test_data/no-projection-images)
- turn on the distance tool icon and locate the the tool on the image. 
- start the layer dialog, click 'offset calculation' and select the unit to check the display of the tool. 
- for non HiPS case, rotate the image and view the distance tool is rotated accordingly. 