### PR TITLE
Firefly-416: useFieldGroupConnector was not unmounting fields properly

### DIFF
--- a/src/firefly/html/test/template.html
+++ b/src/firefly/html/test/template.html
@@ -61,7 +61,8 @@
                     },
                     tables : {
                         showInfoButton: false // info about table : title, table links, etc.
-                    }
+                    },
+                    MenuItemKeys: {matchLockDropDown:false}
                 }
             }
         }

--- a/src/firefly/js/ui/FieldGroupConnector.jsx
+++ b/src/firefly/js/ui/FieldGroupConnector.jsx
@@ -191,7 +191,11 @@ export const useFieldGroupConnector= (props) => {
             if (fieldState !== gState.fields[fieldKey]) setFieldState(gState.fields[fieldKey]);
         });
     }, effectChangeAry);
-    
+
+    useEffect(() => {  // only run on dismount
+        return () => dispatchMountComponent( groupKey, fieldKey, false);
+    }, []);
+
     return {
         fireValueChange, viewProps: buildViewProps(fieldState,props,fieldKey,groupKey, value), fieldKey, groupKey
     };

--- a/src/firefly/js/visualize/MenuItemKeys.js
+++ b/src/firefly/js/visualize/MenuItemKeys.js
@@ -32,7 +32,8 @@ export const MenuItemKeys= {
     restore : 'restore',
     overlayColorLock: 'overlayColorLock',
     fitsHeader: 'fitsHeader',
-    panByTableRow: 'panByTableRow'
+    panByTableRow: 'panByTableRow',
+    matchLockDropDown: 'matchLockDropDown'
 };
 
 const defaultOff = [MenuItemKeys.lockImage, MenuItemKeys.irsaCatalog, MenuItemKeys.maskOverlay];

--- a/src/firefly/js/visualize/ui/MatchLockDropDown.jsx
+++ b/src/firefly/js/visualize/ui/MatchLockDropDown.jsx
@@ -34,7 +34,7 @@ const getCountWithTarget= (vr) =>
 
 
 
-export function MatchLockDropDown({visRoot:vr, enabled}) {
+export function MatchLockDropDown({visRoot:vr, enabled, visible}) {
     const {wcsMatchType}= vr;
     const wcsCnt= getCountWithWCS(vr);
     const tCnt= getCountWithTarget(vr);
@@ -124,7 +124,7 @@ export function MatchLockDropDown({visRoot:vr, enabled}) {
         <DropDownToolbarButton icon={wcsMatchType?MATCH_LOCKED:MATCH_UNLOCKED }
                                tip='Determine how to align images'
                                enabled={enabled} horizontal={true}
-                               visible={true}
+                               visible={visible}
                                hasHorizontalLayoutSep={false}
                                useDropDownIndicator={true}
                                dropDown={dropDown}/>

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -325,7 +325,7 @@ export class VisToolbarView extends PureComponent {
                                 onClick={() => toggleOverlayColorLock(pv,plotGroupAry)}
                                  />
 
-                <MatchLockDropDown visRoot={visRoot} enabled={enabled} />
+                <MatchLockDropDown visRoot={visRoot} enabled={enabled} visible={mi.matchLockDropDown} />
 
 
                 <ToolbarButton icon={FITS_HEADER}


### PR DESCRIPTION
Firefly-416: useFieldGroupConnector was not unmounting fields properly

  - also enable wcs button to be turned off
  - added line to demonstrate removing wcs lock in gator
       - IRSA-3070 should use this example

https://jira.ipac.caltech.edu/browse/FIREFLY-416

_to test:_
https://irsawebdev9.ipac.caltech.edu/firefly-416-bad-validation/firefly/

- The problem described in the ticket is fixed.

