### PR TITLE
Adjust error message produced when attempting to load 1D image

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -210,11 +210,11 @@ public class FitsReadUtil {
             int naxis = header.getIntValue("NAXIS", -1);
 
 
-            // check weather image is valid
+            // check whether image is valid
             boolean goodImage = true;
             if (naxis <= 0) goodImage = false;
             else if (naxis == 1) {
-                delayedExceptionMsg = "FITS image contains only one dimension, two are required.";
+                delayedExceptionMsg = "One-dimensional images (NAXIS==1) are not currently supported.";
                 goodImage = false;
             } else {
                 for (int i = 1; i <= naxis; i++) {


### PR DESCRIPTION
The error message for attempts to load 1D images is changed to avoid implying that 1D images are non-conformant; we just don't support them (yet!).