### PR TITLE
FIREFLY-414: Fail to retrieve results from LSST async TAP queries

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
@@ -28,6 +28,7 @@ public class HttpServiceInput implements Cloneable{
     private Map<String, File> files;
     private String userId;
     private String passwd;
+    private boolean followRedirect = true;
 
     public HttpServiceInput() {}
 
@@ -38,7 +39,6 @@ public class HttpServiceInput implements Cloneable{
     public String getRequestUrl() {
         return requestUrl;
     }
-
     public HttpServiceInput setRequestUrl(String requestUrl) {
         this.requestUrl = requestUrl;
         return this;
@@ -47,38 +47,22 @@ public class HttpServiceInput implements Cloneable{
     public String getUserId() {
         return userId;
     }
-
-    public String getPasswd() {
-        return passwd;
-    }
-
-    public Map<String, String> getParams() {
-        return params;
-    }
-
-    public Map<String, String> getHeaders() {
-        return headers;
-    }
-
-    public Map<String, String> getCookies() {
-        return cookies;
-    }
-
-    public Map<String, File> getFiles() {
-        return files;
-    }
-
-
     public HttpServiceInput setUserId(String userId) {
         this.userId = userId;
         return this;
     }
 
+    public String getPasswd() {
+        return passwd;
+    }
     public HttpServiceInput setPasswd(String passwd) {
         this.passwd = passwd;
         return this;
     }
 
+    public Map<String, String> getParams() {
+        return params;
+    }
     public HttpServiceInput setParam(String key, String value) {
         if (StringUtils.isEmpty(key)) return this;
         if (params == null) params = new HashMap<>();
@@ -86,6 +70,9 @@ public class HttpServiceInput implements Cloneable{
         return this;
     }
 
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
     public HttpServiceInput setHeader(String key, String value) {
         if (StringUtils.isEmpty(key)) return this;
         if (headers == null) headers = new HashMap<>();
@@ -93,6 +80,9 @@ public class HttpServiceInput implements Cloneable{
         return this;
     }
 
+    public Map<String, String> getCookies() {
+        return cookies;
+    }
     public HttpServiceInput setCookie(String key, String value) {
         if (StringUtils.isEmpty(key)) return this;
         if (cookies == null) cookies = new HashMap<>();
@@ -100,10 +90,19 @@ public class HttpServiceInput implements Cloneable{
         return this;
     }
 
+    public Map<String, File> getFiles() {
+        return files;
+    }
     public HttpServiceInput setFile(String key, File value) {
         if (StringUtils.isEmpty(key)) return this;
         if (files == null) files = new HashMap<>();
         files.put(key, value);
+        return this;
+    }
+
+    public boolean isFollowRedirect() { return followRedirect; }
+    public HttpServiceInput setFollowRedirect(boolean followRedirect) {
+        this.followRedirect = followRedirect;
         return this;
     }
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
@@ -18,9 +18,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 
 import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class HttpServicesTest {
 
@@ -120,6 +118,23 @@ public class HttpServicesTest {
 
 		assertEquals("url should be redirected to /get now", GET_URL, getProp(results.toString(), "url"));
 	}
+
+	@Test
+	public void testFollowRedirect(){
+		HttpServiceInput nInput = input.setRequestUrl(REDIRECT_URL)
+										.setParam("url", "http://www.acme.org")
+										.setParam("status_code", "301");
+
+		HttpServices.getData(nInput, (method -> {
+			assertFalse(HttpServices.isRedirected(method));
+		}));
+
+		HttpServices.getData(nInput.setFollowRedirect(false), (method -> {
+			assertTrue(HttpServices.isRedirected(method));
+			assertEquals("redirect to www.acme.org", method.getResponseHeader("location").getValue(), "http://www.acme.org");
+		}));
+	}
+
 
 //====================================================================
 //  private


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-414

- add followRedirect to HttpServices
- manually handle redirection from aync TAP queries

Test: https://lsst-lsp-int.ncsa.illinois.edu/portal/app/

Problem:
LSST TAP results endpoint redirect to AWS.  HttpClient from Apache includes the headers when follow redirect.  This causes the request to fail at AWS due to credential header being sent.

Solution:
Manually handle redirection.  Include credential info only when redirected back to ncsa.

