### PR TITLE
IRSA-3272: Header popup panel was not updating as the FITS image changed

### DIFF
--- a/src/firefly/html/firefly-dev.html
+++ b/src/firefly/html/firefly-dev.html
@@ -57,6 +57,13 @@
         };
 
         function getMoreImagePanelDataTest() {
+            // available URL mappings-
+            //        ra, dec - for position J2000
+            //        galLon, galLat - for position Galactic
+            //        size, sizeDeg, sizeArcMin, sizeArcSec   - if user leaves cutout size blank then blank will be substituted
+            //        sizeOrMax, sizeDegOrMax, sizeArcMinOrMax, sizeArcSecOrMax, - if user leaves cutout size blank then maxRangeDeg will be used to determine max
+            //        sizeOrZero, sizeDegOrZero, sizeArcMinOrZero, sizeArcSecOrZero - if user leaves cutout size blank then 0 will be substituted
+
             return [
                 {
                     acronym: "test Dss search using URLS",
@@ -67,8 +74,8 @@
                     minRangeDeg: "0.016",
                     missionId: "test-extension",
                     plotRequestParams: {
-                        // available mappings- ra,dec,size, sizeDeg, sizeArcMin, sizeArcSec
-                        URL: 'http://archive.stsci.edu:80/cgi-bin/dss_search?r=${ra}&d=${dec}e=J2000&h=${sizeArcMin}&w=${sizeArcMin}&f=FITS&v=poss2ukstu_red&s=ON&c=gz',
+                        // available mappings- ra,dec,galLon, galLat, size, sizeDeg, sizeArcMin, sizeArcSec
+                        URL: 'http://archive.stsci.edu:80/cgi-bin/dss_search?r=${ra}&d=${dec}&e=J2000&h=${sizeArcMinOrZero}&w=${sizeArcMinOrZero}&f=FITS&v=poss2ukstu_red&s=ON&c=gz',
                         title: "Test DSS red",
                         type: "URL",
                     },
@@ -92,8 +99,8 @@
                     minRangeDeg: "0.016",
                     missionId: "test-extension",
                     plotRequestParams: {
-                        // available mappings- ra,dec,size, sizeDeg, sizeArcMin, sizeArcSec
-                        URL: 'http://archive.stsci.edu:80/cgi-bin/dss_search?r=${ra}&d=${dec}e=J2000&h=${sizeArcMin}&w=${sizeArcMin}&f=FITS&v=poss2ukstu_ir&s=ON&c=gz',
+                        // available mappings- set description above
+                        URL: 'http://archive.stsci.edu:80/cgi-bin/dss_search?r=${ra}&d=${dec}&e=J2000&h=${sizeArcMin}&w=${sizeArcMin}&f=FITS&v=poss2ukstu_ir&s=ON&c=gz',
                         title: "Test DSS IR",
                         type: "URL",
                     },
@@ -116,7 +123,7 @@
                     minRangeDeg: "0.016",
                     missionId: "test-extension",
                     tableRequestParams: {
-                        // available mappings- ra,dec,size, sizeDeg, sizeArcMin, sizeArcSec
+                        // available mappings- set description above
                         URL: 'https://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-query?outfmt=1&catalog=allwise_p3as_psd&objstr=${ra}d+${dec}d+eq+j2000&spatial=Cone&radius=${sizeArcSec}&onlist=1'
                     },
                     project: "test extension tables",
@@ -138,7 +145,7 @@
                     minRangeDeg: "0.016",
                     missionId: "test-extension",
                     tableRequestParams: {
-                        // available mappings- ra,dec,size, sizeDeg, sizeArcMin, sizeArcSec
+                        // available mappings- set description above
                         URL: 'http://web.ipac.caltech.edu/staff/roby/demo/test-table4.tbl',
                         datasource: 'FITS'
                     },
@@ -161,7 +168,7 @@
                     minRangeDeg: "0.016",
                     missionId: "test-extension",
                     tableRequestParams: {
-                        // available mappings- ra,dec,size, sizeDeg, sizeArcMin, sizeArcSec
+                        // available mappings- set description above
                         URL:'https://vao.stsci.edu/CAOMTAP/TapService.aspx/sync?request=doQuery&QUERY=SELECT%20*%20FROM%20ivoa.obscore%20WHERE%20CONTAINS(POINT(\'ICRS\',%20s_ra,s_dec),CIRCLE(\'ICRS\',%20${ra},${dec},${sizeDeg}))=1&LANG=ADQL&MAXREC=50000',
                     },
                     project: "test extension tables",

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -128,7 +128,7 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element) {
                 return prev;
             }, false);
 
-            if (isThreeColor(plot) || displayedPlotId!==crtPlot.plotId || displayedHdu!==getHDU(crtPlot)) {
+            if (action.type===ImagePlotCntlr.PLOT_IMAGE || isThreeColor(plot) || displayedPlotId!==crtPlot.plotId || displayedHdu!==getHDU(crtPlot) ) {
                 updatePopup(crtPlot, newTableInfo)();
             }
             displayedPlotId= crtPlot.plotId;
@@ -356,6 +356,8 @@ export function fitsHeaderView(plotView,element) {
 
 }
 
+var tblCnt= 0;
+
 /**
  * produce table Id based on band info
  * @param plot
@@ -384,7 +386,9 @@ function createTableIdForFitsHeader(plot) {
     }
 
     const str = plot.plotImageId.replace(/\s/g, '');                   //remove the white places
-    return  str.replace(/[^a-zA-Z0-9]/g, '_')  + colors; //replace the no numeric/alphabet character by _
+    const tbl_id= str.replace(/[^a-zA-Z0-9]/g, '_')  + colors+ '--' + tblCnt; //replace the no numeric/alphabet character by _
+    tblCnt++;
+    return  tbl_id;
 }
 
 
@@ -407,6 +411,7 @@ function createRowData(header,hduStr) {
  * @returns {*}
  */
 function createFitsHeaderTable(tableId, plot) {
+    if (!plot) return null;
     const {headerAry,zeroHeader} = plot;
     if (!headerAry) return null;
 


### PR DESCRIPTION
IRSA-3272: Header popup panel was not updating as the FITS image changed

   - Bug fix in `FitsHeaderView.jsx`
   - Also fix a small URL substitution bug, (`firefly-dev.html`,`ImageSearchPanelV2.jsx`)

https://jira.ipac.caltech.edu/browse/IRSA-3272

_to test:_

 https://irsawebdev9.ipac.caltech.edu/IRSA-3272-header-popup-bug/applications/sofia/


- Do an all sky sofia search
- switch to data tab
- bring up some images by switching tabs and clicking on rows
- bring up header view
- continue to switch images, the header panel should update.


