### PR TITLE
FIREFLY-443: put back cube images

### DIFF
--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -648,7 +648,7 @@ function doImageSearch({ imageMasterData, request, plotId, plotGroupId, viewerId
     } else {                       // single channel
         const reqAry = makeRequests(get(request, FG_KEYS.single), imageMasterData, plotId, plotGroupId);
         reqAry.forEach( (r) => {
-            if (r.dataType==='image') {
+            if (r.dataType==='image' || r.dataType==='cube') {
                 dispatchPlotImage({wpRequest:r.request, viewerId,renderTreeId,pvOptions});
             }
             else if (r.dataType==='table') {
@@ -694,8 +694,8 @@ function makeRequests(request, imageMasterData, plotId, plotGroupId){
             const list= request[p].split(',');
             list.forEach( (e) => e && imageIdList.push(e));
         });
-        const paramAry= imageMasterData.filter( (d) => imageIdList.includes(d.imageId) && (!d.dataType || d.dataType==='image') );
-        const wpList= paramAry.map( (d) => ({dataType:'image', request:makeWPRequest(wp, radius, d, plotId, plotGroupId)}));
+        const paramAry= imageMasterData.filter( (d) => imageIdList.includes(d.imageId) && (!d.dataType || d.dataType==='image' || d.dataType==='cube') );
+        const wpList= paramAry.map( (d) => ({dataType:'image', request:makeWPRequest(wp, d.dataType === 'cube'?undefined:radius, d, plotId, plotGroupId)}));
         const tParamAry= imageMasterData.filter( (d) => imageIdList.includes(d.imageId) && (d.dataType==='table') );
         const tableList= tParamAry.map( (d) => ({dataType:'table', request:makeTableRequest(wp, radius, d, plotId, plotGroupId)}));
         return [...wpList, ...tableList];


### PR DESCRIPTION
The following PR is about solving the problem explained in ticket [FIREFLY-443](https://jira.ipac.caltech.edu/browse/FIREFLY-443).

It expects to solve a problem found while testing [IRSA-2442](https://jira.ipac.caltech.edu/browse/IRSA-2442) in irsatest and need to be fixed for the upcoming IRSAViewer release in `rc-2019.3` and ultimately merged back to dev.

The image search is not responding, skipping any search where cubes of images are expected from IRSA/IBE searches.
Datasets are defined in a image master data config file and data type column is used to separate images from cubes to be able to avoid using cutout. Somehow this was changed and no longer working in the current `rc-2019.3` and in `dev` branches.
The code involved has changed a lot since this datatype usage was introduced and TLI and other PRs have refactored greatly the image search panel selection code.

Please, confirm that the fix is working and the code still make sense. Thanks.

IRSAViewer build for testing purposes: https://irsawebdev9.ipac.caltech.edu/firefly-443-cube-images/irsaviewer/
<details>
<summary>
Step to reproduce the problem in irsatest
</summary>
Try doing an IRAS/ISSA image search on any target in <a href="https://irsatest.ipac.caltech.edu/irsaviewer/">IRSAViewer</a> on irsatest (also happens in irsadev) - Those images are cubes and cutouts are not possible from IBE. Radius value shouldn't be sent so the IBE logic in the server doesn't do a cutout.
<p>
<details>
Luisa found that 'cube' type of searches doesn't work anymore, example IRAS/ISSA, but any 'cube' types defined in the configuration file edu/caltech/ipac/firefly/resources/irsa-image-master-table.csv, column `dataType`.

Looking at the code {{src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx}} , i can see that `dataType === 'image'` are the only one considered.
</details>