### PR TITLE
FIREFLY-112: Client table filter does not fail when strings are used …

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
@@ -50,7 +50,7 @@ public class TableMeta implements Serializable {
 
 
     public static final String RESULTSET_ID = "resultSetID";            // this meta if exists contains the ID of the resultset returned.
-    public static final String RESULTSET_REQ = "resultSetRequest";      // this meta if exists contains the Request used to create this of the resultset.
+    public static final String RESULTSET_REQ = "resultSetRequest";      // this meta if exists contains the Request used to create this resultset.
 
     public static final String IS_FULLY_LOADED = "isFullyLoaded";
 

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -39,7 +39,7 @@ function renderHiPSSurveysTable(hipsId, sources, moreStyle={}) {
     const tableId = makeHiPSSurveysTableName(hipsId, sources);
     const tableModel = getTblById(tableId);
 
-    return (tableModel && !tableModel.error) ? (
+    return tableModel && (
         <div style={surveyTableStyle}>
             <TablePanel
                 key={tableModel.tbl_id}
@@ -51,10 +51,8 @@ function renderHiPSSurveysTable(hipsId, sources, moreStyle={}) {
                 showFilters={true}
                 showOptionButton={true}
             />
-        </div>) :
-        (<div style={{display:'flex', justifyContent: 'center', alignItems: 'center', padding: 10}}>
-               {getHiPSLoadingMessage(tableId)}
-        </div>);
+        </div>
+    );
 }
 
 /**

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -705,6 +705,19 @@ export function convertToIdentityObj(ary) {
 /*---------------------------- update >----------------------------*/
 
 /**
+ * A strict version of parseInt.  Anything that is not an integer will return NaN, i.e '12xx34'
+ * @param value
+ * @returns {number} a number or NaN if it cannot be parse into an interger
+ */
+export function strictParseInt(value) {
+    if (/^[-+]?(\d+|Infinity)$/.test(value)) {
+        return Number(value);
+    } else {
+        return NaN;
+    }
+}
+
+/**
  * return the boolean value of prop for the given object
  * @param object
  * @param prop

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -49,7 +49,7 @@ const textStyle={ paddingTop:5,paddingLeft:3, width:140, color: 'Black', fontWei
 const tableAndTitleInfoStyle = {width: '100%', height: 'calc(100% - 40px)', display: 'flex', resize:'none'};
 
 //define the table style only in the table div
-const tableStyle = {boxSizing: 'border-box', paddingLeft:5,paddingRight:5, width: '100%', height: 'calc(100% - 70px)', overflow: 'hidden', flexGrow: 1, display: 'flex', resize:'none'};
+const tableStyle = {boxSizing: 'border-box', paddingLeft:5,paddingRight:5, width: '100%', height: 'calc(100% - 70px)', overflow: 'hidden', flexGrow: 1, resize:'none'};
 
 const tableOnTabStyle = {boxSizing: 'border-box',paddingLeft:5,paddingRight:5, width: '100%', height: 'calc(100% - 30px)', overflow: 'hidden', flexGrow: 1, display: 'flex', resize:'none'};//
 //define the size of the text on the tableInfo style in the title div


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-112

When filtering numeric columns, client table shows `No data..` when non-numeric values are used in the criteria.  In server-backed tables, an error is displayed instead.  Make the client tables behavior consistent with server-backed tables.

Also, 
- added support for 'and' and 'or' to client table.
This was missing from previous ticket in which `and` and `or` was added to the filtering syntax for server-back tables.

Tests: https://irsawebdev9.ipac.caltech.edu/FIREFLY-112_client_table_filter_noresults/firefly/

Try entering `abc` into a numeric column.  Do this on a client table(View HiPS Images) as well as a server-backed table(catalogs).  The behavior is the same now.  Do the same thing on irsadev to see what it did before.
( although not consistent, I thought it was more user friendly on irsadev )

Client table now support `and` and `or`.  Try:
`> 0 and < 1000`  or `< 0 or in (8,9,10)`

