### PR TITLE
Firefly-435: fixed a LSST footprint bug that was introduced by table changes churn

### DIFF
--- a/src/firefly/js/visualize/task/LSSTFootprintTask.js
+++ b/src/firefly/js/visualize/task/LSSTFootprintTask.js
@@ -282,8 +282,8 @@ function getFootprintDataFromTable(tableModel) {
                     // skip no spans case
                     if (c1_x >= 0 && c1_y >= 0 && c2_x >= 0 && c2_y >= 0 && spansStr && peaksStr) {
                         const corners = [[c1_x, c1_y], [c2_x, c1_y], [c2_x, c2_y], [c1_x, c2_y]];
-                        const spanSet = everyOtherData(spansStr.replace(/\(|\)|,/g, '').split(' '), 3);
-                        const peakSet = everyOtherData(peaksStr.replace(/\(|\)|,/g, '').split(' '), 2, 'float');
+                        const spanSet = everyOtherData(spansStr, 3);
+                        const peakSet = everyOtherData(peaksStr, 2, 'float');
 
                         prev[id] = {corners, spans: spanSet, peaks: peakSet, rowIdx: oneFootprint[colsIdxMap[table_rowidx]],
                                     rowNum: oneFootprint[colsIdxMap[table_rownum]],


### PR DESCRIPTION
Firefly-435: fixed a LSST footprint bug that was introduced by table changes churn

https://jira.ipac.caltech.edu/browse/FIREFLY-435

_to test:_
https://irsawebdev9.ipac.caltech.edu/firefly-435-footprint-bug/firefly/
- Load an image and the related footprint.  It should overlay correctly as it did before.
