### PR TITLE
FIREFLY-64: Enable default history handling.

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -25,6 +25,7 @@ export const TABLE_RESULTS_PATH = 'table_space.results.tables';
 export const DATA_PREFIX = 'table';
 export const RESULTS_PREFIX = 'tableResults';
 export const UI_PREFIX = 'tableUi';
+export const LOG_HISTORY = 'logHistory';
 
 /*---------------------------- ACTIONS -----------------------------*/
 /**


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-64

Additional changes here: https://github.com/IPAC-SW/irsa-ife/pull/99

Issue: Browser back button doesn't behaves as user expect.

This ticket was raised while testing SOFIA.  In SOFIA, a single search triggers multiple Firefly table's searches.  Firefly record history based on an action at a time.  This causes the problem reported in the ticket.
In this PR, I've created a new SOFIA_SEARCH action creator to capture the multiple searches logic.  This action creator is then `registered` to Firefly to make Firefly aware of the new action.

This should fix the `Back` button issue as well as the copy/paste of the URL.

Test: https://irsawebdev9.ipac.caltech.edu/FIREFLY-64_back_button/applications/sofia/

