### PR TITLE
FIREFLY-150: Handle data array type

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -189,7 +189,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
     }
 
     public String toDbDataType(DataType dataType) {
-        if (!StringUtils.isEmpty(dataType.getArraySize())) return "other";
+        if (dataType.isArrayType()) return "other";
 
         Class type = dataType.getDataType();
         if (String.class.isAssignableFrom(type)) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -58,7 +58,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
             ", minValue varchar(64000)" +
             ", links    other" +
             ", dataOptions varchar(64000)" +
-            ", arraySize varchar(64000)" +
+            ", arraySize varchar(255)" +
             ")";
 
     private static final String META_INSERT_SQL = "insert into %s_meta values (?,?,?)";
@@ -189,11 +189,11 @@ abstract public class BaseDbAdapter implements DbAdapter {
     }
 
     public String toDbDataType(DataType dataType) {
-        if (dataType.getArraySize() != null) return "other";
+        if (!StringUtils.isEmpty(dataType.getArraySize())) return "other";
 
         Class type = dataType.getDataType();
         if (String.class.isAssignableFrom(type)) {
-            return dataType.getTypeDesc().equals(DataType.LONG_STRING) ? "longvarchar" : "varchar(64000)";
+            return "longvarchar";                           // to ensure it can accommodate any length
         } else if (Byte.class.isAssignableFrom(type)) {
             return "tinyint";
         } else if (Short.class.isAssignableFrom(type)) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/mapper/IpacTableExtractor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/spring/mapper/IpacTableExtractor.java
@@ -185,7 +185,7 @@ public class IpacTableExtractor {
             DataType dt = headers.get(i);
             try {
                 Object obj = rs.getObject(dt.getKeyName());
-                writer.print(" " + dt.format(obj, true));
+                writer.print(" " + dt.format(obj, true, false));
             } catch (SQLException e) {
                 LOG.warn(e, "SQLException at col:" + headers.get(i).getKeyName());
                 writer.print(" " + dt.format("#ERROR#"));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -272,7 +272,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                     VoTableWriter.save(out, page.getData(), format);
                     break;
                 default:
-                    IpacTableWriter.save(out, page.getData(), true);
+                    IpacTableWriter.save(out, page.getData());
             }
                        // this is not accurate information if used to determine exactly what was written to output stream.
             // dbFile is the database file which contains the whole search results.  What get written to the output

--- a/src/firefly/java/edu/caltech/ipac/table/DataObject.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataObject.java
@@ -72,7 +72,7 @@ public class DataObject implements Serializable, Cloneable {
     }
 
     public String getFixedFormatedData(DataType dt) {
-        return dt.formatFixedWidth(getDataElement(dt));
+        return dt.formatFixedWidth(getDataElement(dt));      // this is used by ipac table only
     }
 
     /**
@@ -81,7 +81,7 @@ public class DataObject implements Serializable, Cloneable {
      */
     public String[] getFormattedData(boolean replaceCtrl) {
         return Arrays.stream(group.getDataDefinitions())
-                .map(dt -> dt.format(getDataElement(dt), replaceCtrl))
+                .map(dt -> dt.format(getDataElement(dt), replaceCtrl, true))
                 .toArray(String[]::new);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/table/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataType.java
@@ -440,6 +440,20 @@ public class DataType implements Serializable, Cloneable {
                 .toArray();
     }
 
+    public boolean isArrayType() {
+        int[] shape = getShape();
+        if (getDataType() == String.class) {
+            return shape.length -1 > 0;
+        } else {
+            return shape.length > 0;
+        }
+    }
+
+    public String getTypeLabel() {
+        return getTypeDesc() + (isArrayType() ? "[" + getArraySize() + "]" : "");
+    }
+
+
     /**
      * returns a string the size of the given width.  If the value is longer then the given width,
      * it will be truncated.  Values will be left-padded if numeric and right-padded otherwise.
@@ -480,7 +494,7 @@ public class DataType implements Serializable, Cloneable {
      * @return an object
      */
     public Object convertStringToData(String s) {
-        if (s == null || getNullString().equals(s)) return null;
+        if (s == null || s.length() == 0 || getNullString().equals(s)) return null;
 
         Object retval = s;
         if (StringUtils.isEmpty(getArraySize())) {
@@ -539,7 +553,9 @@ public class DataType implements Serializable, Cloneable {
 
     private Object strToObject(String s) {
         try {
-            if (type ==Boolean.class) {
+            if (type == String.class) {
+                return s;
+            } else if (type ==Boolean.class) {
                 return Boolean.valueOf(s);
             }
             else if (type ==Double.class) {
@@ -564,7 +580,7 @@ public class DataType implements Serializable, Cloneable {
                 return HREF.parseHREF(s);
             }
         } catch (IllegalArgumentException iae) {} // ok to ignore
-        return s;
+        return null;
     }
 
     private String resolveTypeDesc() {

--- a/src/firefly/java/edu/caltech/ipac/table/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataType.java
@@ -5,6 +5,7 @@ package edu.caltech.ipac.table;
 
 import edu.caltech.ipac.util.HREF;
 import edu.caltech.ipac.util.StringUtils;
+import org.json.simple.JSONArray;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -15,9 +16,29 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static edu.caltech.ipac.table.TableUtil.foldAry;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
+import static edu.caltech.ipac.util.StringUtils.split;
+import static org.apache.commons.lang.StringUtils.stripEnd;
 
-
+/**
+ * TODO: need to fix DataType so that it supports these types mapping.
+ * VOTable	        FITS    IPACTable   Firefly     Bytes   Meaning
+ * --------	        ----	---------   -------     -----   -------
+ * boolean	        L	    [char]      boolean     1       Logical
+ * bit	            X	    [int]       [byte]      *       Bit
+ * unsignedByte     B	    [int]       [byte]      1       Byte (0 to 255)
+ * short	        I	    [int]       short       2       Short Integer
+ * int	            J	    int         int         4       Integer
+ * long	            K	    long        long        8       Long integer
+ * char	            A	    char        char        1       ASCII Character
+ * unicodeChar	    [B]     [int]       [int]       2       Unicode Character
+ * float	        E	    float       float       4       Floating point
+ * double	        D	    double      double      8       Double
+ * floatComplex	    C	    [char]      [char]      8       Float Complex (ordered pair of float [real, imag])
+ * doubleComplex    M	    [char]      [char]      16      Double Complex (ordered pair of double [real, imag])
+ * char             [A]     date        date        8       Date
+ */
 public class DataType implements Serializable, Cloneable {
 
     public enum Visibility {show, hide, hidden};
@@ -29,7 +50,8 @@ public class DataType implements Serializable, Cloneable {
     private static final String FLOAT = "float";
     private static final String INTEGER = "int";
     private static final String LONG = "long";
-    private static final String CHAR = "char";
+    public static final String CHAR = "char";
+    private static final String BOOLEAN = "boolean";
     private static final String BOOL = "bool";
     private static final String S_DOUBLE = "d";
     private static final String S_REAL = "r";
@@ -316,14 +338,30 @@ public class DataType implements Serializable, Cloneable {
      *                When T is G, n is the number of significant digits
      *
      * @param value         the value to be formatted
-     * @param replaceCtrl     replace control characters in strings with a replacement character
+     * @param replaceCtrl   replace control characters in strings with a replacement character
+     * @param aryAsJson     true to format array as JSON string.  Otherwise, it will be formatted as space separated.
      * @return
      */
-    public String format(Object value, boolean replaceCtrl) {
+    public String format(Object value, boolean replaceCtrl, boolean aryAsJson) {
         if (value == null) return getNullString();
 
-        if (getArraySize() != null) {
-            return String.format("%s [%s]", getTypeDesc(), getArraySize());
+        if (value.getClass().isArray()) {
+            if (aryAsJson) {
+                JSONArray ary = new JSONArray();
+                ary.addAll(foldAry(this, value));
+                value = ary.toJSONString();
+            } else {
+                if (value instanceof String[]) {
+                    // because starlink auto right-trim char arrays, we need to right pad them
+                    int[] shape = getShape();
+                    if (shape.length > 0) {
+                        value = Arrays.stream((String[])value).map( s -> StringUtils.pad(shape[0], s)).toArray();
+                    }
+                    value = StringUtils.toString(TableUtil.aryToList(value), "");
+                } else {
+                    value = StringUtils.toString(TableUtil.aryToList(value), " ");
+                }
+            }
         }
 
         // do escaping if requested
@@ -361,11 +399,11 @@ public class DataType implements Serializable, Cloneable {
      * @return
      */
     public String format(Object value) {
-        return format(value, false);
+        return format(value, false, true);
     }
 
     public String formatFixedWidth(Object value) {
-        return fitValueInto(format(value, true), getWidth(), isNumeric());
+        return fitValueInto(format(value, true, false), getWidth(), isNumeric());
     }
 
     /**
@@ -393,6 +431,13 @@ public class DataType implements Serializable, Cloneable {
             isWholeNumber = INT_TYPES.contains(typeDesc);
         }
         return isWholeNumber;
+    }
+
+    public int[] getShape() {
+        if (StringUtils.isEmpty(getArraySize())) return new int[0];
+        return Arrays.stream(getArraySize().split("x"))
+                .mapToInt(d -> StringUtils.getInt(d, -1))
+                .toArray();
     }
 
     /**
@@ -437,39 +482,89 @@ public class DataType implements Serializable, Cloneable {
     public Object convertStringToData(String s) {
         if (s == null || getNullString().equals(s)) return null;
 
-        Object retval= s;
-        try {
-             if (type ==Boolean.class) {
-                 retval= Boolean.valueOf(s);
-             }
-             else if (type ==String.class) {
-                 retval= s;
-             }
-             else if (type ==Double.class) {
-                 retval= new Double(s);
-             }
-             else if (type ==Float.class) {
-                 retval= new Float(s);
-             }
-             else if (type ==Integer.class) {
-                 retval= new Integer(s);
-             }
-             else if (type ==Short.class) {
-                 retval = new Short(s);
-             }
-             else if (type ==Long.class) {
-                 retval = new Long(s);
-             }
-             else if (type ==Byte.class) {
-                 retval = new Byte(s);
-             }
-             else if (type ==HREF.class) {
-                 retval = HREF.parseHREF(s);
-             }
-        } catch (IllegalArgumentException iae) {
-            retval = null;
+        Object retval = s;
+        if (StringUtils.isEmpty(getArraySize())) {
+            retval = strToObject(s);
+        } else if (type == String.class) {
+            // char array.. fold first dimension into a string
+            int[] shape = getShape();
+            if (shape.length > 1 && shape[0] > 0) {
+                return split(s, shape[0]).stream().map( v -> stripEnd(v, " ")).toArray(String[]::new);
+            } else {
+                return s;
+            }
+        } else {
+            return strToPrimitiveAry(s.split(" "));
         }
+
         return retval;
+    }
+
+    private Object strToPrimitiveAry(String[] strAry) {
+
+        try {
+            if (type == Boolean.class) {
+                boolean[] ary = new boolean[strAry.length];
+                for (int i=0; i<strAry.length; i++) ary[i] = Boolean.parseBoolean(strAry[i]);
+                return ary;
+            } else if (type == Double.class) {
+                double[] ary = new double[strAry.length];
+                for (int i=0; i<strAry.length; i++) ary[i] = Double.parseDouble(strAry[i]);
+                return ary;
+            } else if (type == Float.class) {
+                float[] ary = new float[strAry.length];
+                for (int i=0; i<strAry.length; i++) ary[i] = Float.parseFloat(strAry[i]);
+                return ary;
+            } else if (type == Integer.class) {
+                int[] ary = new int[strAry.length];
+                for (int i=0; i<strAry.length; i++) ary[i] = Integer.parseInt(strAry[i]);
+                return ary;
+            } else if (type == Short.class) {
+                short[] ary = new short[strAry.length];
+                for (int i=0; i<strAry.length; i++) ary[i] = Short.parseShort(strAry[i]);
+                return ary;
+            } else if (type == Long.class) {
+                long[] ary = new long[strAry.length];
+                for (int i=0; i<strAry.length; i++) ary[i] = Long.parseLong(strAry[i]);
+                return ary;
+            } else if (type == Byte.class) {
+                byte[] ary = new byte[strAry.length];
+                for (int i=0; i<strAry.length; i++) ary[i] = Byte.parseByte(strAry[i]);
+                return ary;
+            }
+        } catch (Exception e) {}  // ignore
+        return strAry;
+    }
+
+
+    private Object strToObject(String s) {
+        try {
+            if (type ==Boolean.class) {
+                return Boolean.valueOf(s);
+            }
+            else if (type ==Double.class) {
+                return new Double(s);
+            }
+            else if (type ==Float.class) {
+                return new Float(s);
+            }
+            else if (type ==Integer.class) {
+                return new Integer(s);
+            }
+            else if (type ==Short.class) {
+                return new Short(s);
+            }
+            else if (type ==Long.class) {
+                return new Long(s);
+            }
+            else if (type ==Byte.class) {
+                return new Byte(s);
+            }
+            else if (type ==HREF.class) {
+                return HREF.parseHREF(s);
+            }
+        } catch (IllegalArgumentException iae) {} // ok to ignore
+        return s;
     }
 
     private String resolveTypeDesc() {
@@ -488,7 +583,7 @@ public class DataType implements Serializable, Cloneable {
         else if (type.equals(Long.class))
             typeDesc = useShortType ? S_LONG : LONG;
         else if (type.equals(Boolean.class))
-            typeDesc = useShortType ? S_BOOL : BOOL;
+            typeDesc = useShortType ? S_BOOL : BOOLEAN;
 
         return typeDesc;
     }
@@ -510,6 +605,7 @@ public class DataType implements Serializable, Cloneable {
             case S_INTEGER:
                 return Integer.class;
             case BOOL:
+            case BOOLEAN:
             case S_BOOL:
                 return Boolean.class;
             case LOCATION:

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -78,6 +78,7 @@ public class IpacTableUtil {
             ensureKey(attribs, col.getKeyName(), col.getRef(), REF_TAG);
             ensureKey(attribs, col.getKeyName(), col.getMinValue(), MIN_VALUE_TAG);
             ensureKey(attribs, col.getKeyName(), col.getMaxValue(), MAX_VALUE_TAG);
+            ensureKey(attribs, col.getKeyName(), col.getArraySize(), ARY_SIZE_TAG);
             if (col instanceof ParamInfo) {
                 ensureKey(attribs, col.getKeyName(), ((ParamInfo)col).getValue(), VALUE_TAG);
             }
@@ -109,7 +110,10 @@ public class IpacTableUtil {
 
     public static void consumeColumnInfo(DataType[] cols, TableMeta meta) {
         for (DataType dt : cols) {
-            consumeMeta(TYPE_TAG, meta, dt, (v, c) -> c.setTypeDesc(v));
+            consumeMeta(TYPE_TAG, meta, dt, (v, c) -> {
+                c.setDataType(DataType.descToType(v));
+                c.setTypeDesc(v);
+            });
             consumeMeta(LABEL_TAG, meta, dt, (v, c) -> c.setLabel(v));
             consumeMeta(VISI_TAG, meta, dt, (v, c) -> c.setVisibility(DataType.Visibility.valueOf(v)));
             consumeMeta(WIDTH_TAG, meta, dt, (v, c) -> c.setWidth(StringUtils.getInt(v, 0)));
@@ -130,6 +134,7 @@ public class IpacTableUtil {
             consumeMeta(REF_TAG, meta, dt, (v, c) -> c.setRef(v));
             consumeMeta(MIN_VALUE_TAG, meta, dt, (v, c) -> c.setMinValue(v));
             consumeMeta(MAX_VALUE_TAG, meta, dt, (v, c) -> c.setMaxValue(v));
+            consumeMeta(ARY_SIZE_TAG, meta, dt, (v, c) -> c.setArraySize(v));
 
             consumeMeta(LINKS_TAG, meta, dt, (json, c) -> applyIfNotEmpty(toLinkInfos(json), infos -> c.setLinkInfos(infos)));
 

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -289,9 +289,9 @@ public class JsonTableUtil {
                 c.put("visibility", dt.getVisibility().name());
             if (dt.getPrefWidth() > 0)
                 c.put("prefWidth", dt.getPrefWidth());
-            if (!dt.isSortable())
+            if (!dt.isSortable() || dt.isArrayType())       // disable sorting for data array type
                 c.put("sortable", false);
-            if (!dt.isFilterable())
+            if (!dt.isFilterable() || dt.isArrayType())     // disable filtering for data array type
                 c.put("filterable", false);
 
             applyIfNotEmpty(dt.getSortByCols(), v -> c.put("sortByCols", v));

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -6,7 +6,6 @@ package edu.caltech.ipac.table;
 import edu.caltech.ipac.firefly.data.Param;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.util.StringUtils;
-import org.apache.commons.lang.ArrayUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -163,41 +162,12 @@ public class JsonTableUtil {
         if (data.size() > 0) {
             List<List> tableData = new ArrayList<>();
             for (int i = 0; i < data.size(); i++) {
-                Object[] rowData = Arrays.stream(data.get(i).getData()).map(d -> unboxedPrimitive(d)).toArray();
+                Object[] rowData = Arrays.stream(data.get(i).getData()).map(d -> TableUtil.boxPrimitive(d)).toArray();
                 tableData.add(Arrays.asList(rowData));
             }
             tdata.put("data", tableData);
         }
         return tdata;
-    }
-
-    /**
-     * if obj is an array of primitive, return a list of its equivalent Objects
-     * @param obj
-     * @return
-     */
-    private static Object unboxedPrimitive(Object obj) {
-        if (obj != null && obj.getClass().isArray()) {
-            switch (obj.getClass().getComponentType().getName()) {
-                case "boolean":
-                    obj = Arrays.asList(ArrayUtils.toObject((boolean[]) obj)); break;
-                case "byte":
-                    obj = Arrays.asList(ArrayUtils.toObject((byte[]) obj)); break;
-                case "char":
-                    obj = Arrays.asList(ArrayUtils.toObject((char[]) obj)); break;
-                case "short":
-                    obj = Arrays.asList(ArrayUtils.toObject((short[]) obj)); break;
-                case "int":
-                    obj = Arrays.asList(ArrayUtils.toObject((int[]) obj)); break;
-                case "long":
-                    obj = Arrays.asList(ArrayUtils.toObject((long[]) obj)); break;
-                case "float":
-                    obj = Arrays.asList(ArrayUtils.toObject((float[]) obj)); break;
-                case "double":
-                    obj = Arrays.asList(ArrayUtils.toObject((double[]) obj)); break;
-            }
-        }
-        return obj;
     }
 
     /**
@@ -313,6 +283,7 @@ public class JsonTableUtil {
             applyIfNotEmpty(dt.getNullString(), v -> c.put("nullString", v));
             applyIfNotEmpty(dt.getDesc(), v -> c.put("desc", v));
             applyIfNotEmpty(dt.getLabel(), v -> c.put("label", v));
+            applyIfNotEmpty(dt.getArraySize(), v -> c.put("arraySize", v));
 
             if (dt.getVisibility() != DataType.Visibility.show)
                 c.put("visibility", dt.getVisibility().name());

--- a/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
@@ -47,6 +47,7 @@ public class TableMeta implements Serializable {
     public static final String MAX_VALUE_TAG = "col.@.maxValue";
     public static final String VALUE_TAG = "col.@.value";
     public static final String LINKS_TAG = "col.@.links";
+    public static final String ARY_SIZE_TAG = "col.@.arraySize";
 
 
     public static final String RESULTSET_ID = "resultSetID";            // this meta if exists contains the ID of the resultset returned.
@@ -67,6 +68,11 @@ public class TableMeta implements Serializable {
     public static String makeAttribKey(String tag, String colName) {
         return tag.replaceFirst("@", colName);
     }
+
+    public static DataGroup.Attribute makeAttribute(String tag, String colName, String val) {
+        return new DataGroup.Attribute(makeAttribKey(tag, colName), val);
+    }
+
 
     public String getTblId() {
         return getAttribute(TableServerRequest.TBL_ID);

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -203,7 +203,7 @@ public class TableUtil {
         for (DataType col : meta.getCols() ) {
             DataObject row = new DataObject(dg);
             row.setDataElement(cols[0], col.getKeyName());
-            row.setDataElement(cols[1], col.getTypeDesc());
+            row.setDataElement(cols[1], col.getTypeLabel());
             row.setDataElement(cols[2], col.getUnits());
             row.setDataElement(cols[3], col.getDesc());
             dg.add(row);

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -180,7 +180,6 @@ public class DsvTableIO {
         try {
             File inf = new File(args[0]);
             DataGroup dg = parse(inf, CSVFormat.DEFAULT);
-            IpacTableWriter.save(System.out, dg);
             write(new File(inf.getAbsolutePath() + ".csv"), dg);
             write(new File(inf.getAbsolutePath() + ".tsv"), dg, CSVFormat.TDF);
         } catch (Exception e) {

--- a/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
@@ -98,6 +98,7 @@ public final class IpacTableReader {
         }
 
         outData.getTableMeta().setKeywords(attributes);
+        IpacTableUtil.consumeColumnInfo(outData);   // move column attributes into columns
 
         String line = null;
         int lineNum = tableDef.getExtras() == null ? 0 : tableDef.getExtras().getKey();
@@ -130,7 +131,6 @@ public final class IpacTableReader {
         } finally {
             bufferedReader.close();
         }
-        IpacTableUtil.consumeColumnInfo(outData);   // move column attributes into columns
         outData.trimToSize();
         return outData;
     }

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -277,7 +277,7 @@ public class VoTableReader {
         // INFO     => only takes name/value pairs for now
         Arrays.stream(table.getChildrenByName("INFO"))
                 .forEach(el -> {
-                    dg.getTableMeta().setAttribute(el.getName(), el.getAttribute("value"));
+                    dg.getTableMeta().addKeyword(el.getName(), el.getAttribute("value"));
                 });
         if (table.hasAttribute("nrows")) {
             dg.setSize((int) table.getNrows());
@@ -404,10 +404,7 @@ public class VoTableReader {
             }
         });
 
-        if (dt.getDataType() != String.class) {
-            // we will ignore multi-dimensional char arrays for now
-            applyIfNotEmpty(el.getAttribute("arraysize"), dt::setArraySize);
-        }
+        applyIfNotEmpty(el.getAttribute("arraysize"), dt::setArraySize);
 
         // add all links
         Arrays.stream(el.getChildrenByName("LINK"))

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
@@ -170,7 +170,6 @@ public class VoTableWriter {
                           elementAtt("unit", dt.getUnits()) +
                           elementAtt(TableMeta.UTYPE, dt.getUType()) +
                           getArraySize(dt);
-                          getArraySize(dt);
 
 
             return atts;

--- a/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
@@ -17,6 +17,9 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 
 /**
  * Date: Nov 2, 2007
@@ -507,6 +510,14 @@ public class StringUtils {
         }
         return rvals.toArray(new String[rvals.size()]);
     }
+
+    public static List<String> split(String source, int chunkSize) {
+        final int numberOfChunks = (source.length() + chunkSize - 1) / chunkSize;
+        return IntStream.range(0, numberOfChunks)
+                .mapToObj(index -> source.substring(index * chunkSize, Math.min((index + 1) * chunkSize, source.length())))
+                .collect(Collectors.toList());
+    }
+
 
     /**
      * this implementation is much faster than GWt's String.trim() once

--- a/src/firefly/java/edu/caltech/ipac/visualize/draw/FixedObjectGroupUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/draw/FixedObjectGroupUtils.java
@@ -533,7 +533,6 @@ public class FixedObjectGroupUtils {
             }
 
             DataGroup.convertHREFTypes(dataGroup);
-            IpacTableWriter.save(System.out, dataGroup);
             System.exit(0);
 
         } catch (Exception e) {

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -495,9 +495,15 @@ export function formatValue(col, val) {
     return String(val);
 }
 
-export function getTypeDesc(col={}) {
-    const {type, arraySize} = col;
-    return (type || '') + (arraySize ? `[${arraySize}]` : '');
+export function getTypeLabel(col={}) {
+    const {type, arraySize=''} = col;
+    if (!type) return '';
+    const aryDim = arraySize.split('x').filter( (s) => s).length;
+    if (type === 'char' && aryDim === 1) {
+        return type;
+    } else {
+        return type + (aryDim > 0 ? `[${arraySize}]` : '');
+    }
 }
 
 /**
@@ -898,7 +904,7 @@ export function tableToIpac(tableModel) {
 
     const head = [
                     columns.map((c, idx) => padEnd(c.name, colWidths[idx])),
-                    columns.map((c, idx) => padEnd(getTypeDesc(c), colWidths[idx])),
+                    columns.map((c, idx) => padEnd(getTypeLabel(c), colWidths[idx])),
                     columns.find((c) => c.units) && columns.map((c, idx) => padEnd(c.units, colWidths[idx])),
                     columns.find((c) => c.nullString) && columns.map((c, idx) => padEnd(c.nullString, colWidths[idx]))
                 ]
@@ -920,7 +926,7 @@ export function tableTextView(columns, dataAry, tableMeta) {
 
     const colSep = '+' + cols.map(([, idx]) => '-'.repeat(colWidths[idx])).join('+') + '+';
     const names  = '|' + cols.map(([c, idx]) => padEnd(c.label || c.name, colWidths[idx])).join('|') + '|';
-    const types  = '|' + cols.map(([c, idx]) => padEnd(getTypeDesc(c), colWidths[idx])).join('|') + '|';
+    const types  = '|' + cols.map(([c, idx]) => padEnd(getTypeLabel(c), colWidths[idx])).join('|') + '|';
 
     const head = [colSep, names, types, colSep].join('\n');
 
@@ -962,7 +968,7 @@ export function tableDetailsView(tbl_id, highlightedRow, details_tbl_id) {
     const data = dataCols.map((c) => {
         const name  = c.label || c.name;
         const value = getCellValue(tableModel, highlightedRow, c.name) || '';
-        const type  = getTypeDesc(c);
+        const type  = getTypeLabel(c);
         const units = c.units || '';
         const desc  = c.desc || '';
 
@@ -1005,7 +1011,7 @@ export function calcColumnWidths(columns, dataAry, {maxAryWidth=Number.MAX_SAFE_
             return width;
         }
         const cname = cv.label || cv.name;
-        width = Math.max(cname.length, get(cv, 'units.length', 0),  getTypeDesc(cv).length);
+        width = Math.max(cname.length, get(cv, 'units.length', 0),  getTypeLabel(cv).length);
         dataAry.forEach((row) => {
             const v = formatValue(columns[idx], row[idx]);
             width = Math.max(width, v.length);

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, set, has, isEmpty, isUndefined, uniqueId, cloneDeep, omitBy, isNil, isPlainObject, isArray, padEnd} from 'lodash';
+import {get, set, has, isEmpty, isUndefined, uniqueId, cloneDeep, omitBy, isNil, isPlainObject, isArray, padEnd, chunk, isString} from 'lodash';
 import Enum from 'enum';
 
 import {sprintf} from '../externalSource/sprintf.js';
@@ -460,8 +460,20 @@ export function formatValue(col, val) {
     const {fmtDisp, format, precision, nullString} = col || {};
 
     if (isNil(val)) return (nullString || '');
+
     if (Array.isArray(val)) {
-        return (col.type || 'array') + `[${val.length}]`;
+        const aryDim = (col.arraySize || '').split('x');
+
+        if (col.type === 'char' && aryDim.length > 0) {
+           aryDim.shift();    // remove first dimension because char array is presented as string
+        }
+
+        if (aryDim.length > 1) {
+            for(let i = 0; i < aryDim.length-1; i++) {
+                val = chunk(val, aryDim[i]);
+            }
+        }
+        return isString(val) ? val : JSON.stringify(val);
     }
 
     if (fmtDisp) {
@@ -483,6 +495,10 @@ export function formatValue(col, val) {
     return String(val);
 }
 
+export function getTypeDesc(col={}) {
+    const {type, arraySize} = col;
+    return (type || '') + (arraySize ? `[${arraySize}]` : '');
+}
 
 /**
  * returns an array of all the values for a columns
@@ -882,7 +898,7 @@ export function tableToIpac(tableModel) {
 
     const head = [
                     columns.map((c, idx) => padEnd(c.name, colWidths[idx])),
-                    columns.map((c, idx) => padEnd(c.type, colWidths[idx])),
+                    columns.map((c, idx) => padEnd(getTypeDesc(c), colWidths[idx])),
                     columns.find((c) => c.units) && columns.map((c, idx) => padEnd(c.units, colWidths[idx])),
                     columns.find((c) => c.nullString) && columns.map((c, idx) => padEnd(c.nullString, colWidths[idx]))
                 ]
@@ -895,27 +911,27 @@ export function tableToIpac(tableModel) {
     return [meta, '\\', head, dataStr].join('\n');
 }
 
-export function tableTextView(columns, dataAry, showUnits=false, tableMeta) {
+export function tableTextView(columns, dataAry, tableMeta) {
 
     const colWidths = calcColumnWidths(columns, dataAry);
     const meta = tableMeta && Object.entries(tableMeta).map(([k,v]) => `\\${k} = ${v}`).join('\n');
-    const head = [
-                    columns.map((c, idx) => get(c,'visibility', 'show') === 'show' && padEnd(c.label || c.name, colWidths[idx])),
-                    columns.map((c, idx) => get(c,'visibility', 'show') === 'show' && padEnd(c.type, colWidths[idx])),
-                    showUnits && columns.map((c, idx) => get(c,'visibility', 'show') === 'show' && padEnd(c.units, colWidths[idx]))
-                ]
-                .filter( (ary) => ary)
-                .map( (ary) => '|' + ary.filter( (v) => v ).join('|') + '|')
-                .join('\n');
 
-    const dataStr = dataAry.map((row) => ' ' +
-                                    row.map((c, idx) => get(columns, `${idx}.visibility`, 'show') === 'show' && padEnd(formatValue(columns[idx],c), colWidths[idx]))
-                                       .filter((v) => v)
-                                       .join(' ')
-                                    + ' ')
-                           .join('\n');
+    const cols = columns.map((c, idx) => get(c,'visibility', 'show') === 'show' ? [c, idx] : null).filter((c) => c);  // only visible columns: [col, colIdx]
 
-    return [meta, head, dataStr].join('\n');
+    const colSep = '+' + cols.map(([, idx]) => '-'.repeat(colWidths[idx])).join('+') + '+';
+    const names  = '|' + cols.map(([c, idx]) => padEnd(c.label || c.name, colWidths[idx])).join('|') + '|';
+    const types  = '|' + cols.map(([c, idx]) => padEnd(getTypeDesc(c), colWidths[idx])).join('|') + '|';
+
+    const head = [colSep, names, types, colSep].join('\n');
+
+    const dataStr = dataAry.map((row) =>
+                ' ' +
+                    cols.map(([c, idx]) =>
+                            padEnd(formatValue(c, row[idx]), colWidths[idx])
+                            .replace(/[^\x1F-\x7F]/g, '\xBF')).join(' ') +              // replace non-printable chars with (191 in LATIN-1) inverted '?'.  same logic as DataType.format()
+                ' ').join('\n');
+
+    return [meta, head, dataStr].filter((c) => c).join('\n');
 }
 
 /**
@@ -946,7 +962,7 @@ export function tableDetailsView(tbl_id, highlightedRow, details_tbl_id) {
     const data = dataCols.map((c) => {
         const name  = c.label || c.name;
         const value = getCellValue(tableModel, highlightedRow, c.name) || '';
-        const type  = c.type || '';
+        const type  = getTypeDesc(c);
         const units = c.units || '';
         const desc  = c.desc || '';
 
@@ -976,11 +992,12 @@ export function tableDetailsView(tbl_id, highlightedRow, details_tbl_id) {
  * the header and the data in a table given columns and dataAry.
  * @param {TableColumn[]} columns  array of column object
  * @param {TableData} dataAry  array of array.
+ * @param {int} maxAryWidth  maximum size of column with array values
  * @returns {number[]} an array of widths corresponding to the given columns array.
  * @memberof firefly.util.table
  * @func calcColumnWidths
  */
-export function calcColumnWidths(columns, dataAry) {
+export function calcColumnWidths(columns, dataAry, {maxAryWidth=Number.MAX_SAFE_INTEGER, maxColWidth=Number.MAX_SAFE_INTEGER}={}) {
     return columns.map( (cv, idx) => {
 
         let width = cv.prefWidth || cv.width;
@@ -988,11 +1005,16 @@ export function calcColumnWidths(columns, dataAry) {
             return width;
         }
         const cname = cv.label || cv.name;
-        width = Math.max(cname.length, get(cv, 'units.length', 0),  get(cv, 'type.length', 0));
+        width = Math.max(cname.length, get(cv, 'units.length', 0),  getTypeDesc(cv).length);
         dataAry.forEach((row) => {
             const v = formatValue(columns[idx], row[idx]);
             width = Math.max(width, v.length);
         });
+
+        if (cv.arraySize) {
+            width = Math.min(width, maxAryWidth);
+        }
+        width = Math.min(width, maxColWidth);
         return width;
     });
 }

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -49,6 +49,7 @@
  * @prop {string} name      name of the column
  * @prop {string} label     display name of the column
  * @prop {string} type      data type.  i.e.  'char', 'str', 'double', 'long', 'int', 'float'
+ * @prop {string} arraySize if column is an array, this describe the dimension of the array as defined here:  http://www.ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html#ToC12
  * @prop {string} units     data units
  * @prop {string} nullString string used to represent null value
  * @prop {string} desc      description of the column

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -256,7 +256,7 @@ function doRowSelect(checked, rowIndex) {
 
 
 const TextView = ({columns, data, showUnits, width, height}) => {
-    const text = tableTextView(columns, data, showUnits);
+    const text = tableTextView(columns, data);
     return (
         <div style={{height, width,overflow: 'hidden'}}>
             <div style={{height: '100%',overflow: 'auto'}}>
@@ -295,7 +295,7 @@ function correctScrollLeftIfNeeded(totalColWidths, scrollLeft, width, triggeredB
 }
 
 function columnWidthsInPixel(columns, data) {
-    return calcColumnWidths(columns, data)
+    return calcColumnWidths(columns, data, {maxColWidth: 100, maxAryWidth: 30})      // set max width for array columns
             .map( (w) =>  (w + 2) * 7);
 }
 

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -317,6 +317,8 @@
     font-size: 11px;
     white-space: nowrap;
     padding: 3px;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .public_fixedDataTableCell_cellContent.right_align {

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -307,6 +307,7 @@ TablePanel.defaultProps = {
     showOptionButton: true,
     showFilterButton: true,
     showInfoButton: false,
+    showTypes: true,
     selectable: true,
     expandedMode: false,
     expandable: true,

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -7,7 +7,7 @@ import FixedDataTable from 'fixed-data-table-2';
 import {set, get, isEqual, pick} from 'lodash';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
-import {isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue} from '../TableUtil.js';
+import {isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue, getTypeDesc} from '../TableUtil.js';
 import {SortInfo} from '../SortInfo.js';
 import {InputField} from '../../ui/InputField.jsx';
 import {SORT_ASC, UNSORTED} from '../SortInfo';
@@ -56,7 +56,7 @@ export class HeaderCell extends PureComponent {
         const cdesc = desc || label || name;
         const sortDir = SortInfo.parse(sortInfo).getDirection(name);
         const sortCol = sortByCols || name;
-        const typeVal = col.type || '';
+        const typeVal = getTypeDesc(col);
         const unitsVal = col.units ? `(${col.units})`: '';
         
         const onClick = toBoolean(sortable, true) ?(() => onSort(sortCol)) : undefined;

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -7,7 +7,7 @@ import FixedDataTable from 'fixed-data-table-2';
 import {set, get, isEqual, pick} from 'lodash';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
-import {isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue, getTypeDesc} from '../TableUtil.js';
+import {isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue, getTypeLabel} from '../TableUtil.js';
 import {SortInfo} from '../SortInfo.js';
 import {InputField} from '../../ui/InputField.jsx';
 import {SORT_ASC, UNSORTED} from '../SortInfo';
@@ -23,6 +23,7 @@ import {getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {useStoreConnector} from './../../ui/SimpleComponent.jsx';
 import {resolveHRefVal} from '../../util/VOAnalyzer.js';
+import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 
 const {Cell} = FixedDataTable;
 const html_regex = /<.+>/;
@@ -56,13 +57,14 @@ export class HeaderCell extends PureComponent {
         const cdesc = desc || label || name;
         const sortDir = SortInfo.parse(sortInfo).getDirection(name);
         const sortCol = sortByCols || name;
-        const typeVal = getTypeDesc(col);
+        const typeVal = getTypeLabel(col);
         const unitsVal = col.units ? `(${col.units})`: '';
+        const className = toBoolean(sortable, true) ? 'clickable' : undefined;
         
-        const onClick = toBoolean(sortable, true) ?(() => onSort(sortCol)) : undefined;
+        const onClick = toBoolean(sortable, true) ? () => onSort(sortCol) : () => showInfoPopup('This column is not sortable');
         return (
             <div style={style} title={cdesc} className='TablePanel__header'>
-                <div style={{height: '100%', width: '100%'}} className='clickable' onClick={onClick}>
+                <div style={{height: '100%', width: '100%'}} className={className} onClick={onClick}>
                     <div style={{display: 'inline-flex', width: '100%', justifyContent: 'center'}}>
                         <div style={{textOverflow: 'ellipsis', overflow: 'hidden'}}>
                             {label || name}

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -274,13 +274,13 @@ function AnalysisTable({summaryModel, detailsModel}) {
 
     const tblOptions = {showToolbar:false, border:false, showOptionButton: false, showFilters: true};
     const details = ! detailsModel ? <div className='FileUpload__noDetails'>Details not available</div>
-                    : <TablePanel title='File Details' tableModel={detailsModel} tbl_ui_id={detailsUiId} {...tblOptions} showMetaInfo={true} selectable={false}/>;
+                    : <TablePanel showTypes={false}  title='File Details' tableModel={detailsModel} tbl_ui_id={detailsUiId} {...tblOptions} showMetaInfo={true} selectable={false}/>;
 
     // Details table need to render first to create a stub to collect data when Summary table is loaded.
     return (
         <div className='FileUpload__summary'>
             <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={350}>
-                <TablePanel title='File Summary' tableModel={summaryModel} tbl_ui_id={summaryUiId} {...tblOptions} />
+                <TablePanel showTypes={false} title='File Summary' tableModel={summaryModel} tbl_ui_id={summaryUiId} {...tblOptions} />
                 {details}
             </SplitPane>
         </div>

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -330,6 +330,7 @@ function renderTable(band, fitsHeaderInfo, isPlacedOnTab) {
                showOptionButton={true}
                allowUnits={false}
                showFilters={true}
+               showTypes={false}
            />
 
         </div>

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
@@ -51,7 +51,7 @@ public class IpacTableTest {
         // instead of comparing the output of write, we'll write it out, read it back in and use the same test to
         // validate that the round-trip preserves the data.
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        IpacTableWriter.save(output, data, true);
+        IpacTableWriter.save(output, data);
         data = IpacTableReader.read(new ByteArrayInputStream(output.toByteArray()));
         checkTableData(data);
     }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-150

General changes:
- `data type` is shown by default.  (most tables)
- `Text View` UI is updated to look more like an SQL client and not IPAC table.
- Data overflow in table cell will be appended with `...`(more indicator).
- By default, column width is set to the data’s length or 100 whichever is less.
- significant update to VoTableWriter - @cwang2016 please review and test to make sure it support all previous use-cases.

Data array:
- Display
    - Full value of the array is displayed in the table cell as JSON string
    - Column width is default to the length of the value or 30 whichever is less.
    - Overflow values are hidden and replaced with `...`
    - In `Text View`, the same JSON string value is shown in full 

- Save
    - VOTable: data array is saved as defined by their supported format: TABLEDATA, BINARY2, FITS
    - IPAC Table:  (array type is not supported)
        - Add data array support to Firefly
        - Data is saved like VOTable's TABLEDATA with additional meta in the header to describe type and shape of the array.
        - This feature is only available in Firefly.  Otherwise, it’ll be recognize as ’char’ or string.
    - for CSV and TSV: (data array is not supported)
        - It will be saved as JSON string and read back as a string

Testing:  https://irsawebdev9.ipac.caltech.edu/FIREFLY-150_table_array_data/firefly/
- Upload the file `tbl.fits` attached to the ticket.
- The first column(`flags`) of the first table has a type of `boolean[57]`.
You should see a partial JSON string representing an array of 57 booleans.  Resize the column to see more/less of the data.
- Switch to `Text View` to see the new UI.  The boolean array is shown in full.
- Click save -> select IPAC Table -> a.tbl
- Open the saved file (`a.tbl`).  It should look exactly like the one you see in `tbl.fits`
- Now, do the same for the other VOTable formats.  They should work the same way.
- Now, if you save it as CSV or TSV, it'll be saved as a string and read back also as string

Multi-dimensional array:
- Save first table in `tbl.fits` as `VOTable - TABLEDATA` (`a.vot`)
- Edit `a.vot` and change `arraysize="*"` to `arraysize="3x*"`
- Load this file.  You should see the array is nicely folded into 3-boolean parts
- You can do the same with IPAC Table
- You can try 3 or 4 dimensions.
- You can also test other types, like `char`
   - try changing `flgs` into a multi-dimensional char array.  i.e. `arraysize="2x2x*"` and type `datatype="char"`
   - you should see an array of 2-char pairs.
   - StarLink right-trim the strings.  I think that makes sense.
- Now, see if you can move from one format to another, i.e open VOTable and save as IPAC

@gpdf if you have time, please take a look.