### PR TITLE
Firefly-460: Add file analysis & more visualization to data products viewing

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -329,6 +329,19 @@ div.rootStyle img {
     to {transform: rotate(359deg);}
 }
 
+.loading-animation {
+    border-width: 3px;
+    border-style: solid;
+    border-color: transparent rgb(255, 255, 255) rgb(255, 255, 255);
+    border-radius: 50%;
+    top: calc(50% - 12px);
+    left: calc(50% - 12px);
+    animation-name: spin;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+}
+
 .loading-mask::after {
     content: "";
     position: absolute;

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -87,8 +87,9 @@ public class FileAnalysis {
                 helper.setValue(p.index, "parts", i+"", "index");
                 helper.setValue(p.type.name(), "parts", i+"", "type");
                 helper.setValue(p.desc, "parts", i+"", "desc");
+                if (p.totalTableRows>-1) helper.setValue(p.totalTableRows, "parts", i+"", "totalTableRows");
                 if (!isEmpty(p.getDetails())) {
-                    helper.setValue(JsonTableUtil.toJsonDataGroup(p.getDetails()), "parts", i+"", "details");
+                    helper.setValue(JsonTableUtil.toJsonDataGroup(p.getDetails(),true), "parts", i+"", "details");
                 }
             }
         }
@@ -184,6 +185,9 @@ public class FileAnalysis {
         private String desc;
         private DataGroup details;
 
+
+        private int totalTableRows=-1;
+
         public Part(Type type) {
             this.type = type;
         }
@@ -209,6 +213,10 @@ public class FileAnalysis {
         public void setDetails(DataGroup details) {
             this.details = details;
         }
+
+        public int getTotalTableRows() { return totalTableRows; }
+        public void setTotalTableRows(int totalTableRows) { this.totalTableRows = totalTableRows; }
+
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -34,7 +34,7 @@ public class FileAnalysis {
     public enum ReportType {Brief,              // expect to only get a report with one part without details
                             Normal,             // a report with all parts populated, but not details
                             Details}            // a full report with details
-    public enum Type {Image, Table, Spectrum, HeaderOnly, Unknown}
+    public enum Type {Image, Table, Spectrum, HeaderOnly, PDF, TAR, Unknown}
 
 
     public static Report analyze(File infile, ReportType type) throws Exception {
@@ -56,6 +56,12 @@ public class FileAnalysis {
             case CSV:
             case TSV:
                 report =  DsvTableIO.analyze(infile, format.type, mtype);
+                break;
+            case PDF:
+                report =  analyzePDF(infile, mtype);
+                break;
+            case TAR:
+                report =  analyzeTAR(infile, mtype);
                 break;
             default:
                 report = new Report(type, Format.UNKNOWN.name(), infile.length(), infile.getAbsolutePath());
@@ -203,5 +209,20 @@ public class FileAnalysis {
         public void setDetails(DataGroup details) {
             this.details = details;
         }
+    }
+
+
+
+
+    public static FileAnalysis.Report analyzePDF(File infile, FileAnalysis.ReportType type) {
+        FileAnalysis.Report report = new FileAnalysis.Report(type, TableUtil.Format.PDF.name(), infile.length(), infile.getPath());
+        report.addPart(new FileAnalysis.Part(FileAnalysis.Type.PDF, 0, "PDF File"));
+        return report;
+    }
+
+    public static FileAnalysis.Report analyzeTAR(File infile, FileAnalysis.ReportType type) {
+        FileAnalysis.Report report = new FileAnalysis.Report(type, TableUtil.Format.TAR.name(), infile.length(), infile.getPath());
+        report.addPart(new FileAnalysis.Part(FileAnalysis.Type.TAR, 0, "TAR File"));
+        return report;
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
@@ -27,6 +27,11 @@ public class MetaConst {
      */
     public static final String ALL_CORNERS   = "ALL_CORNERS";
 
+    /*
+     * comma separated names of the columns to assign to the table when reading a fits image as a table.
+     */
+    public static final String IMAGE_AS_TABLE_COL_NAMES= "IMAGE_AS_TABLE_COL_NAMES";
+
     /**
      * If defined to any value (but 'false') the the table is a catalog
      * CatalogOverlayType is required to even guess if there is no VO information.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTableFromExternalTask.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTableFromExternalTask.java
@@ -43,7 +43,7 @@ public class IpacTableFromExternalTask extends IpacTablePartProcessor {
             if (!ServerContext.isFileInPath(outFile)) {
                 throw new SecurityException("Access is not permitted.");
             }
-            return TableUtil.readAnyFormat(outFile, tblIdx);
+            return TableUtil.readAnyFormat(outFile, tblIdx, request.getMeta());
         } catch (IOException e) {
             throw new DataAccessException(e.getMessage(), e);
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UserCatalogQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UserCatalogQuery.java
@@ -40,7 +40,7 @@ public class UserCatalogQuery extends IpacTablePartProcessor {
         }
         try {
             int tblIdx = req.getIntParam(TableServerRequest.TBL_INDEX, 0);
-            return TableUtil.readAnyFormat(userCatFile, tblIdx);
+            return TableUtil.readAnyFormat(userCatFile, tblIdx, req.getMeta());
         } catch (IOException e) {
             throw new DataAccessException(e.getMessage(), e);
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -85,7 +85,7 @@ public class IpacTableFromSource extends IpacTablePartProcessor {
 
         try {
             int tblIdx = req.getIntParam(TBL_INDEX, 0);
-            return TableUtil.readAnyFormat(inf, tblIdx);
+            return TableUtil.readAnyFormat(inf, tblIdx, req.getMeta());
         } catch (IOException e) {
             throw new DataAccessException(e.getMessage(), e);
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
@@ -13,11 +13,14 @@ import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.StringKey;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.URLDownload;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 
 /**
  * Date: Feb 11, 2007
@@ -31,6 +34,7 @@ public class AnyFileDownload extends BaseHttpServlet {
     private static final Logger.LoggerImpl _statsLog= Logger.getLogger(Logger.DOWNLOAD_LOGGER);
 
 
+    public static final String EXT_URL  = "externalURL"; // required for downloading something through the firefly server
     public static final String HIPS_PARAM  = "hipsUrl"; // required for HiPS
     public static final String FILE_PARAM  = "file"; // required for other request
     public static final String RETURN_PARAM= "return"; // a name for the file, if empty or USE_SERVER_NAME the use file name on server
@@ -40,12 +44,15 @@ public class AnyFileDownload extends BaseHttpServlet {
 
     public static final String USE_SERVER_NAME = "USE_SERVER_NAME";
     private static final String HIPS_CACHE_CONTROL= "must-revalidate, max-age=1800";
-    private static final String HIPS_SHORT_CACHE_CONTROL= "must-revalidate, max-age=300";
+    private static final String SHORT_CACHE_CONTROL = "must-revalidate, max-age=300";
     private static final String STATIC_CACHE_CONTROL= "max-age=86400";
 
     protected void processRequest(HttpServletRequest req, HttpServletResponse res) throws Exception {
         if (req.getParameterMap().containsKey(HIPS_PARAM)) {
             handleHiPSRequest(req,res,true);
+        }
+        else if (req.getParameterMap().containsKey(EXT_URL)) {
+            handleExternalURLRequest(req,res,true);
         }
         else {
             handleInternalFileRequest(req,res,true);
@@ -57,6 +64,9 @@ public class AnyFileDownload extends BaseHttpServlet {
     protected void doHead(HttpServletRequest req, HttpServletResponse res) throws IOException {
         if (req.getParameterMap().containsKey(HIPS_PARAM)) {
             handleHiPSRequest(req,res,false);
+        }
+        else if (req.getParameterMap().containsKey(EXT_URL)) {
+            handleExternalURLRequest(req,res,false);
         }
         else {
             handleInternalFileRequest(req,res,false);
@@ -80,7 +90,8 @@ public class AnyFileDownload extends BaseHttpServlet {
         else {
             res.addHeader("Cache-Control", STATIC_CACHE_CONTROL);
             if (fullBody) {
-                sendFileToClient(req,res,downloadFile);
+                String local= sp.getOptional(RETURN_PARAM);
+                sendFileToClient(req,res,downloadFile, local);
             }
             else {
                 res.setStatus(200);
@@ -97,7 +108,7 @@ public class AnyFileDownload extends BaseHttpServlet {
 
         if (fi.getFile()==null) {
             if (fi.getResponseCode()==204) {
-                res.addHeader("Cache-Control", HIPS_SHORT_CACHE_CONTROL);
+                res.addHeader("Cache-Control", SHORT_CACHE_CONTROL);
                 res.addDateHeader("Last-Modified", System.currentTimeMillis());
             }
             res.sendError(fi.getResponseCode(), fi.getResponseCodeMsg());
@@ -111,7 +122,50 @@ public class AnyFileDownload extends BaseHttpServlet {
             return;
         }
         if (fullBody) {
-            sendFileToClient(req,res,fi.getFile());
+            sendFileToClient(req,res,fi.getFile(),null);
+        }
+        else {
+            res.setStatus(200);
+        }
+    }
+
+    private void handleExternalURLRequest(HttpServletRequest req, HttpServletResponse res, boolean fullBody)
+            throws IOException {
+        SrvParam sp= new SrvParam(req.getParameterMap());
+        String urlStr= sp.getRequired(EXT_URL);
+        URL url= new URL(urlStr);
+        String fileName= "download.tmp";
+        if (url.getFile().length()>2) {
+            fileName= new File(url.getFile()).getName();
+        }
+        File dFile= File.createTempFile("tmp-","-"+fileName ,ServerContext.getUploadDir());
+        FileInfo fi;
+        try {
+            fi = URLDownload.getDataToFile(url, dFile);
+        } catch (FailedRequestException e) {
+            res.sendError(404, e.toString());
+            return;
+        }
+
+        if (fi.getFile()==null) {
+            if (fi.getResponseCode()==204) {
+                res.addHeader("Cache-Control", SHORT_CACHE_CONTROL);
+                res.addDateHeader("Last-Modified", System.currentTimeMillis());
+            }
+            res.sendError(fi.getResponseCode(), fi.getResponseCodeMsg());
+            return;
+        }
+
+        res.addHeader("Cache-Control", HIPS_CACHE_CONTROL);
+        res.addDateHeader("Last-Modified", System.currentTimeMillis());
+        if (fi.getResponseCode()==304 && req.getDateHeader("If-Modified-Since")> fi.getFile().lastModified()) {
+            res.setStatus(304);
+            return;
+        }
+        if (fullBody) {
+            String local= sp.getOptional(RETURN_PARAM);
+            String retFileStr= (local!=null) ? local : fileName;
+            sendFileToClient(req,res,fi.getFile(),retFileStr);
         }
         else {
             res.setStatus(200);
@@ -119,9 +173,8 @@ public class AnyFileDownload extends BaseHttpServlet {
     }
 
 
-    private void sendFileToClient(HttpServletRequest req, HttpServletResponse res, File f) throws IOException {
+    private void sendFileToClient(HttpServletRequest req, HttpServletResponse res, File f, String local) throws IOException {
         SrvParam sp= new SrvParam(req.getParameterMap());
-        String local= sp.getOptional(RETURN_PARAM);
         boolean log= sp.getOptionalBoolean(LOG_PARAM,false);
         boolean track= sp.getOptionalBoolean(TRACK_PARAM,false);
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
@@ -45,7 +45,7 @@ public class LockingVisNetwork {
     }
 
     public static FileInfo retrieveURL(URL url) throws FailedRequestException {
-        AnyUrlParams p= new AnyUrlParams(url);
+        AnyUrlParams p= new AnyUrlParams(url, url.getFile(),null);
         p.setLocalFileExtensions(Collections.singletonList(FileUtil.FITS));
         return retrieveURL(p);
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
@@ -25,7 +25,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 /**
  * User: roby
  * Date: Feb 26, 2010
@@ -41,6 +44,8 @@ public class URLFileRetriever implements FileRetriever {
 
     public static final long EXPIRE_IN_SEC = 60 * 60 * 4; // 4 hours
     public static final String FITS = "fits";
+    private static List<String> extsList=
+            Arrays.asList(FileUtil.FITS, FileUtil.GZ, "tar", FileUtil.PDF, "votable", "tbl", "csv", "tsv");
 
     public FileInfo getFile(WebPlotRequest request) throws FailedRequestException, GeomException, SecurityException {
         FileInfo fitsFileInfo;
@@ -57,7 +62,8 @@ public class URLFileRetriever implements FileRetriever {
             }
         }
         try {
-            AnyUrlParams params = new AnyUrlParams(new URL(urlStr), request.getProgressKey(),request.getPlotId());
+            String progressKey= !isEmpty(request.getProgressKey()) ? request.getProgressKey() : urlStr;
+            AnyUrlParams params = new AnyUrlParams(new URL(urlStr), progressKey,request.getPlotId());
             RequestOwner ro = ServerContext.getRequestOwner();
             Map<String, String> cookies = ro.getCookieMap();
             if (cookies != null) {
@@ -70,7 +76,7 @@ public class URLFileRetriever implements FileRetriever {
                 params.setSecurityCookie(ro.getRequestAgent().getAuthKey());
             }
             params.setCheckForNewer(request.getUrlCheckForNewer());
-            params.setLocalFileExtensions(Arrays.asList(FileUtil.FITS, FileUtil.GZ)); //assuming WebPlotRequest ONLY expect FITS or GZ file.
+            params.setLocalFileExtensions(extsList);
             params.setMaxSizeToDownload(VisContext.FITS_MAX_SIZE);
             if (request.getUserDesc() != null) params.setDesc(request.getUserDesc()); // set file description
 

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -62,12 +62,19 @@ public class JsonTableUtil {
         return tableModel;
     }
 
+
+
+    public static JSONObject toJsonDataGroup(DataGroup dataGroup) {
+        return toJsonDataGroup(dataGroup,false);
+    }
+
+
     /**
      * Convert the java DataGroup to javascript table model.
      * @param dataGroup
      * @return
      */
-    public static JSONObject toJsonDataGroup(DataGroup dataGroup) {
+    public static JSONObject toJsonDataGroup(DataGroup dataGroup, boolean cleanUpStrings) {
 
         JSONObject tableModel = new JSONObject();
         TableMeta meta = dataGroup.getTableMeta();
@@ -81,7 +88,7 @@ public class JsonTableUtil {
         }
 
         tableModel.put("type", guessType(meta));
-        tableModel.put("tableData", toJsonTableData(dataGroup));
+        tableModel.put("tableData", toJsonTableData(dataGroup,cleanUpStrings));
 
         if (meta.getKeywords().size() > 0) {
             List<JSONObject> keywords = new ArrayList<>();
@@ -148,7 +155,7 @@ public class JsonTableUtil {
      * @param data
      * @return
      */
-    public static JSONObject toJsonTableData(DataGroup data) {
+    public static JSONObject toJsonTableData(DataGroup data, boolean cleanUpStrings) {
 
         JSONObject tdata = new JSONObject();
 
@@ -166,7 +173,7 @@ public class JsonTableUtil {
         if (data.size() > 0) {
             List<List> tableData = new ArrayList<>();
             for (int i = 0; i < data.size(); i++) {
-                Object[] rowData = Arrays.stream(data.get(i).getData()).map(d -> mapToJsonAware(d)).toArray();
+                Object[] rowData = Arrays.stream(data.get(i).getData()).map(d -> mapToJsonAware(d,cleanUpStrings)).toArray();
                 tableData.add(Arrays.asList(rowData));
             }
             tdata.put("data", tableData);
@@ -179,7 +186,7 @@ public class JsonTableUtil {
      * @param obj
      * @return
      */
-    private static Object mapToJsonAware(Object obj) {
+    private static Object mapToJsonAware(Object obj,boolean cleanUpString) {
         if (obj != null) {
             if (obj.getClass().isArray()) {
                 // unbox array into primitive
@@ -212,7 +219,12 @@ public class JsonTableUtil {
             } else {
                 // if it's an object we have a mapper for, return the mapper
                 JSONAware jsonAware = getJsonMapper(obj);
-                if (jsonAware != null) obj = jsonAware;
+                if (jsonAware != null) {
+                    obj = jsonAware;
+                }
+                else if ((obj instanceof String) && cleanUpString) {
+                    obj= ((String)obj).replaceAll("[^\\x01-\\x7F]", " ") ;
+                }
             }
         }
         return obj;

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -4,18 +4,23 @@
 package edu.caltech.ipac.table;
 
 import edu.caltech.ipac.firefly.data.TableServerRequest;
-import edu.caltech.ipac.table.io.DsvTableIO;
 import edu.caltech.ipac.firefly.server.util.JsonToDataGroup;
+import edu.caltech.ipac.table.io.DsvTableIO;
 import edu.caltech.ipac.table.io.FITSTableReader;
 import edu.caltech.ipac.table.io.IpacTableReader;
 import edu.caltech.ipac.table.io.VoTableReader;
-import edu.caltech.ipac.util.*;
 import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.lang.ArrayUtils;
 
-import java.io.*;
-import java.lang.reflect.Array;
 import java.util.*;
+import java.lang.reflect.Array;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
@@ -61,6 +66,11 @@ public class TableUtil {
         int readAhead = 10;
 
         int row = 0;
+
+        if (inf.getName().toLowerCase().endsWith("tar")) {
+            return Format.TAR;
+        }
+
         BufferedReader reader = new BufferedReader(new FileReader(inf), IpacTableUtil.FILE_IO_BUFFER_SIZE);
         try {
             String line = reader.readLine();
@@ -85,6 +95,8 @@ public class TableUtil {
                 } else if (line.startsWith("<VOTABLE") ||
                         (line.contains("<?xml") && line.contains("<VOTABLE "))) {
                     return Format.VO_TABLE;
+                } else if (row==0 && line.toLowerCase().indexOf("pdf")>0) {
+                    return Format.PDF;
                 }
 
                 counts[row][csvIdx] = getColCount(CSVFormat.DEFAULT, line);
@@ -257,7 +269,7 @@ public class TableUtil {
 //====================================================================
 
     public enum Format { TSV(CSVFormat.TDF, ".tsv"), CSV(CSVFormat.DEFAULT, ".csv"), IPACTABLE(".tbl"), UNKNOWN(null),
-                         FIXEDTARGETS(".tbl"), FITS(".fits"), JSON(".json"),
+                         FIXEDTARGETS(".tbl"), FITS(".fits"), JSON(".json"), PDF(".pdf"), TAR(".tar"),
                          VO_TABLE(".xml"), VO_TABLE_TABLEDATA(".vot"), VO_TABLE_BINARY(".vot"), VO_TABLE_BINARY2(".vot"),
                          VO_TABLE_FITS(".vot");
         public CSVFormat type;
@@ -282,6 +294,7 @@ public class TableUtil {
         allFormats.put("votable-binary2-inline", Format.VO_TABLE_BINARY2);
         allFormats.put("votable-fits-inline", Format.VO_TABLE_FITS);
         allFormats.put("fits", Format.FITS);
+        allFormats.put("pdf", Format.PDF);
     }
 
     public static Map<String, Format> getAllFormats() { return allFormats; }

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -33,10 +33,10 @@ import java.util.stream.Collectors;
 public class TableUtil {
 
     public static DataGroup readAnyFormat(File inf) throws IOException {
-        return readAnyFormat(inf, 0);
+        return readAnyFormat(inf, 0, null);
     }
 
-    public static DataGroup readAnyFormat(File inf, int tableIndex) throws IOException {
+    public static DataGroup readAnyFormat(File inf, int tableIndex, Map<String, String> metaInfo) throws IOException {
         Format format = guessFormat(inf);
         if (format == Format.IPACTABLE) {
             return IpacTableReader.read(inf);
@@ -50,7 +50,7 @@ public class TableUtil {
         } else if (format == Format.FITS ) {
             try {
                 // Switch to the new function:
-                return FITSTableReader.convertFitsToDataGroup(inf.getAbsolutePath(), null, null, FITSTableReader.DEFAULT, tableIndex);
+                return FITSTableReader.convertFitsToDataGroup(inf.getAbsolutePath(), metaInfo, FITSTableReader.DEFAULT, tableIndex);
             } catch (Exception e) {
                 throw new IOException("Unable to read FITS file:" + inf, e);
             }

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -165,7 +165,7 @@ public class DsvTableIO {
         DataGroup header = getHeader(infile, csvFormat);
         String format = (csvFormat == CSVFormat.TDF) ? TableUtil.Format.TSV.name() : TableUtil.Format.CSV.name();
         FileAnalysis.Report report = new FileAnalysis.Report(type, format, infile.length(), infile.getPath());
-        FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table, 0, String.format("%s (%d cols x %s rows)", csvFormat.getClass().getSimpleName(), header.getDataDefinitions().length, header.size()));
+        FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.PDF, 0, String.format("%s (%d cols x %s rows)", csvFormat.getClass().getSimpleName(), header.getDataDefinitions().length, header.size()));
         report.addPart(part);
         if (type.equals(FileAnalysis.ReportType.Details)) {
             IpacTableDef meta = new IpacTableDef();

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -166,6 +166,7 @@ public class DsvTableIO {
         String format = (csvFormat == CSVFormat.TDF) ? TableUtil.Format.TSV.name() : TableUtil.Format.CSV.name();
         FileAnalysis.Report report = new FileAnalysis.Report(type, format, infile.length(), infile.getPath());
         FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table, 0, String.format("%s (%d cols x %s rows)", csvFormat.getClass().getSimpleName(), header.getDataDefinitions().length, header.size()));
+        part.setTotalTableRows(header.size());
         report.addPart(part);
         if (type.equals(FileAnalysis.ReportType.Details)) {
             IpacTableDef meta = new IpacTableDef();

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -165,7 +165,7 @@ public class DsvTableIO {
         DataGroup header = getHeader(infile, csvFormat);
         String format = (csvFormat == CSVFormat.TDF) ? TableUtil.Format.TSV.name() : TableUtil.Format.CSV.name();
         FileAnalysis.Report report = new FileAnalysis.Report(type, format, infile.length(), infile.getPath());
-        FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.PDF, 0, String.format("%s (%d cols x %s rows)", csvFormat.getClass().getSimpleName(), header.getDataDefinitions().length, header.size()));
+        FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table, 0, String.format("%s (%d cols x %s rows)", csvFormat.getClass().getSimpleName(), header.getDataDefinitions().length, header.size()));
         report.addPart(part);
         if (type.equals(FileAnalysis.ReportType.Details)) {
             IpacTableDef meta = new IpacTableDef();

--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
@@ -363,7 +363,7 @@ public final class FITSTableReader
                 DataType dt = dataGroup.getDataDefinitions()[dtIdx];
                 ColumnInfo colInfo = colAry[dtIdx];
                 int colIdx = colIdxMap.get(colInfo);
-                Object data = table.getCell(rowIdx, colIdx);
+                Object data =  dt.getDataType()==String.class ? table.getCell(rowIdx, colIdx)+"" :  table.getCell(rowIdx, colIdx);
                 aRow.setDataElement(dt, data);
             }
             dataGroup.add(aRow);
@@ -417,7 +417,7 @@ public final class FITSTableReader
             java_class = Float.class;
         } else if ((classType.contains("double")) || (classType.contains("Double"))) {
             java_class = Double.class;
-        } else if ((classType.contains("char")) || (classType.contains("String"))) {
+        } else if ((classType.contains("char")) || (classType.contains("String") || classType.contains("Character"))) {
             java_class = String.class;
         } else {
             throw new FitsException(

--- a/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
@@ -139,6 +139,7 @@ public final class IpacTableReader {
         IpacTableDef meta = IpacTableUtil.getMetaInfo(infile);
         FileAnalysis.Report report = new FileAnalysis.Report(type, TableUtil.Format.IPACTABLE.name(), infile.length(), infile.getPath());
         FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table, 0, String.format("IPAC Table (%d cols x %s rows)", meta.getCols().size(), meta.getRowCount()));
+        part.setTotalTableRows(meta.getRowCount());
         report.addPart(part);
         if (type.equals(FileAnalysis.ReportType.Details)) {
             part.setDetails(TableUtil.getDetails(0, meta));

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -458,6 +458,7 @@ public class VoTableReader {
             String title = isEmpty(dg.getTitle()) ? "VOTable" : dg.getTitle().trim();
             part.setDetails(dg);
             part.setDesc(String.format("%s (%d cols x %s rows)", title, dg.getDataDefinitions().length, dg.size()));
+            part.setTotalTableRows(dg.size());
             parts.add(part);
         });
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
@@ -9,7 +9,6 @@ import edu.caltech.ipac.util.download.BaseNetParams;
 
 import java.io.File;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,8 +81,14 @@ public class AnyUrlParams extends BaseNetParams {
         }
         //note: "=","," signs causes problem in download servlet.
         retval = retval.replaceAll("[ :\\[\\]\\/\\\\|\\*\\?<>\\=\\,]","\\-");
-        if (_localFileExtensions!=null && !_localFileExtensions.contains(FileUtil.getExtension(retval))) {
-            retval = retval + "." + _localFileExtensions.get(0);
+        if (_localFileExtensions!=null) {
+            String ext= FileUtil.getExtension(fileStr);
+            if (_localFileExtensions.contains(ext)) {
+                retval = retval + "." + ext;
+            }
+            else {
+                retval = retval + "." + _localFileExtensions.get(0);
+            }
         }
         return retval;
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -23,6 +23,8 @@ import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.ImageData;
 import nom.tam.fits.ImageHDU;
+import nom.tam.fits.UndefinedData;
+import nom.tam.fits.UndefinedHDU;
 import nom.tam.image.compression.hdu.CompressedImageHDU;
 import nom.tam.util.ArrayFuncs;
 import nom.tam.util.Cursor;
@@ -514,6 +516,36 @@ public class FitsReadUtil {
 
 
     }
+
+    /**
+     * This returns a 1d array of double.  This is not interchangable with getImageHDUDataInFloatArray. It is used
+     * mostly for tables and if not as efficent.
+     * @param inHDU
+     * @return
+     * @throws FitsException
+     */
+    public static double[] getImageHDUDataInDoubleArray(BasicHDU inHDU) throws FitsException {
+
+
+
+        if (inHDU instanceof UndefinedHDU) {
+            UndefinedData data= (UndefinedData)inHDU.getData();
+            if (data==null) throw new FitsException("No data in HDU");
+            return (double[]) ArrayFuncs.flatten(ArrayFuncs.convertArray(data.getData(), Double.TYPE, true));
+        }
+
+
+        ImageHDU imageHDU;
+        if (inHDU instanceof ImageHDU) imageHDU = (ImageHDU) inHDU;
+        else if (inHDU instanceof CompressedImageHDU) imageHDU = ((CompressedImageHDU) inHDU).asImageHDU();
+        else throw new FitsException("hdu much be a ImageHDU or a CompressedImageHDU or a UndefinedHDU");
+
+        ImageData imageDataObj= imageHDU.getData();
+        if (imageDataObj==null) throw new FitsException("No data in HDU");
+
+        return (double[]) ArrayFuncs.flatten(ArrayFuncs.convertArray(imageDataObj.getData(), Double.TYPE, true));
+    }
+
 
 
 

--- a/src/firefly/js/core/ReduxFlux.js
+++ b/src/firefly/js/core/ReduxFlux.js
@@ -26,6 +26,7 @@ import WorkspaceCntlr from '../visualize/WorkspaceCntlr.js';
 import DrawLayerFactory from '../visualize/draw/DrawLayerFactory.js';
 import DrawLayerCntlr from '../visualize/DrawLayerCntlr.js';
 import MultiViewCntlr from '../visualize/MultiViewCntlr.js';
+import DataProductsCntlr from '../metaConvert/DataProductsCntlr';
 import ComponentCntlr, {DIALOG_OR_COMPONENT_KEY} from '../core/ComponentCntlr.js';
 
 
@@ -137,6 +138,7 @@ registerCntlr(DrawLayerCntlr.getDrawLayerCntlrDef(drawLayerFactory));
 registerCntlr(ChartsCntlrDef);
 registerCntlr(MultiViewCntlr);
 registerCntlr(WorkspaceCntlr);
+registerCntlr(DataProductsCntlr);
 
 
 let redux = null;

--- a/src/firefly/js/data/FileAnalysis.js
+++ b/src/firefly/js/data/FileAnalysis.js
@@ -1,0 +1,11 @@
+
+
+export const FileAnalysisType = {
+    Image: 'Image',
+    Table: 'Table',
+    Spectrum: 'Spectrum',
+    HeaderOnly: 'HeaderOnly',
+    PDF: 'PDF',
+    TAR: 'TAR',
+    Unknown: 'Unknown',
+};

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -74,6 +74,11 @@ export const MetaConst = {
      */
     TS_DATASET : 'TSDatasetId',
 
+    /*
+     * comma separated names of the columns to assign to the table when reading a fits image as a table.
+     */
+    IMAGE_AS_TABLE_COL_NAMES: 'IMAGE_AS_TABLE_COL_NAMES',
+
     /** the column name with the url or filename of the image data */
     DATA_SOURCE : 'DataSource',
 

--- a/src/firefly/js/metaConvert/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/DataLinkProcessor.js
@@ -181,11 +181,11 @@ function makeName(s='', url, auxTot, autCnt, primeCnt=0) {
  * @return {DataProductsDisplayType}
  */
 export function createGuessDataType(name, menuKey, url,ct,makeReq, semantics, activateParams, positionWP, table,row,size) {
-    const {imageViewerId, converterId}= activateParams;
+    const {imageViewerId}= activateParams;
     if (ct.includes('image') || ct.includes('fits') || ct.includes('cube')) {
         const request= makeReq(url,positionWP,name);
         return dpdtImage(name,
-            createSingleImageActivate(request,imageViewerId,converterId,table.tbl_id,row),
+            createSingleImageActivate(request,imageViewerId,table.tbl_id,row),
             menuKey, {request,url, semantics,size});
     }
     else if (ct.includes('table') || ct.includes('spectrum') || semantics.includes('auxiliary')) {

--- a/src/firefly/js/metaConvert/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/DataLinkProcessor.js
@@ -1,0 +1,199 @@
+import {getDataLinkAccessUrls, getObsCoreAccessURL, getObsCoreProdType} from '../util/VOAnalyzer';
+import {
+    dpdtAnalyze,
+    dpdtDownload,
+    dpdtFromMenu,
+    dpdtImage,
+    dpdtMessage,
+    dpdtPNG,
+    dpdtTable,
+    DPtypes
+} from './DataProductsType';
+import {createTableActivate} from './converterUtils';
+import {makeFileAnalysisActivate} from './MultiProductFileAnalyzer';
+import {createSingleImageActivate} from './ImageDataProductsUtil';
+import {dispatchUpdateActiveKey, getActiveMenuKey} from './DataProductsCntlr';
+
+const analysisTypes= ['fits', 'cube', 'table', 'spectrum', 'auxiliary'];
+
+const GIG= 1048576 * 1024;
+
+
+/**
+ *
+ * @param {TableModel} sourceTable
+ * @param {number} row
+ * @param {TableModel} datalinkTable
+ * @param {WorldPt} positionWP
+ * @param {ActivateParams} activateParams
+ * @param {String} titleStr
+ * @param {Function} makeReq
+ * @param {boolean} doFileAnalysis
+ * @return {DataProductsDisplayType}
+ */
+export function processDatalinkTable(sourceTable, row, datalinkTable, positionWP, activateParams, titleStr, makeReq, doFileAnalysis=true) {
+    const dataSource= getObsCoreAccessURL(sourceTable,row);
+    const dataLinkData= getDataLinkAccessUrls(sourceTable, datalinkTable);
+    const prodType= (getObsCoreProdType(sourceTable,row) || '').toLocaleLowerCase();
+    const menu=  dataLinkData.length &&
+         createDataLinkMenuRet(dataSource,dataLinkData,positionWP, sourceTable, row, activateParams,makeReq,prodType,doFileAnalysis);
+
+    const hasData= menu.length>0;
+    const canShow= menu.length>0 && menu.some( (m) => m.displayType!==DPtypes.DOWNLOAD && m.size<GIG);
+    const activeMenuLookupKey= dataSource;
+
+
+    if (canShow) {
+        const {dpId}= activateParams;
+        const activeMenuKey= getActiveMenuKey(dpId, dataSource);
+        let index= menu.findIndex( (m) => m.menuKey===activeMenuKey);
+        if (index<0) index= 0;
+        dispatchUpdateActiveKey({dpId, activeMenuKeyChanges:{[dataSource]:menu[index].menuKey}});
+        return dpdtFromMenu(menu,index,dataSource);
+    }
+
+    if (hasData) {
+        const dMenu= menu.length && convertAllToDownload(menu);
+
+        const msgMenu= [
+            ...dMenu,
+            dpdtTable('Show Datalink VO Table for list of products',
+                createTableActivate(dataSource,'Datalink VO Table', activateParams),
+                'nd0-showtable', {url:dataSource}),
+            dpdtDownload ( 'Download Datalink VO Table for list of products', dataSource, 'nd1-downloadtable' ),
+        ];
+        const msg= dMenu.length?
+            'You may only download data for this row - nothing to display':
+            'No displayable data available for this row';
+        return dpdtMessage( msg, msgMenu, {activeMenuLookupKey,singleDownload:true});
+    }
+    else {
+        return dpdtMessage('No data available for this row',undefined,{activeMenuLookupKey});
+    }
+
+}
+
+
+function addDataLinkEntries(dataSource,activateParams) {
+    return [
+        dpdtTable('Show Datalink VO Table for list of products',
+            createTableActivate(dataSource,'Datalink VO Table', activateParams),
+            'datalink-entry-showtable', {url:dataSource}),
+        dpdtDownload ( 'Download Datalink VO Table for list of products', dataSource, 'datalink-entry-downloadtable' )
+    ];
+
+}
+
+
+
+function convertAllToDownload(menu) {
+    return menu.map( (d) =>  {
+        if (d.displayType===DPtypes.DOWNLOAD) return {...d};
+        if (d.url) return {...d, displayType:DPtypes.DOWNLOAD};
+        if (d.request && d.request.getURL && d.request.getURL()) {
+            return {...d,displayType:DPtypes.DOWNLOAD, url:d.request.getURL()};
+        }
+        else {
+            return {};
+        }
+    }).filter( (d) => d.displayType);
+}
+
+
+
+
+
+
+function createDataLinkMenuRet(dataSource, dataLinkData, positionWP, sourceTable, row, activateParams, makeReq, prodType, doFileAnalysis) {
+    const auxTot= dataLinkData.filter( (e) => e.semantics==='#auxiliary').length;
+    let auxCnt=0;
+    let primeCnt=0;
+    const originalMenu= dataLinkData.reduce( (resultAry,e,idx) => {
+        const ct= e.contentType.toLowerCase();
+        const name= makeName(e.semantics, e.url, auxTot, auxCnt, primeCnt);
+        const {semantics,size,url}= e;
+        const activeMenuLookupKey= dataSource;
+
+        if (ct.includes('tar')|| ct.includes('gz')) {
+            resultAry.push(dpdtDownload('Download file: '+name,url,'dlt-'+idx,{semantics, size, activeMenuLookupKey}));
+        }
+        else if (ct.includes('jpeg') || ct.includes('png') || ct.includes('jpg') || ct.includes('gig')) {
+            resultAry.push(dpdtPNG('Show PNG image: '+name,url,'dlt-'+idx,{semantics, size, activeMenuLookupKey}));
+        }
+        else if (e.size>GIG) {
+            resultAry.push( dpdtDownload('Download FITS: '+name + '(too large to show)',url,'dlt-'+idx,{semantics, size, activeMenuLookupKey}));
+        }
+        else if (ct==='' || analysisTypes.find( (a) => ct.includes(a))) {
+            if (doFileAnalysis) {
+                resultAry.push( dpdtAnalyze('Show: '+name,undefined,url,'dlt-'+idx,{semantics, size, activeMenuLookupKey}));
+            }
+            else {
+                const dpdt= createGuessDataType(name,'guess-'+idx,url,ct,makeReq,semantics, activateParams, positionWP,sourceTable,row,size);
+                dpdt && resultAry.push(dpdt);
+            }
+        }
+        if (e.semantics==='#auxiliary') auxCnt++;
+        if (e.semantics==='#this') primeCnt++;
+        return resultAry;
+    }, []);
+
+    let     newMenu= originalMenu.sort((s1,s2) => s1.semantics==='#this' ? -1 : 0);
+    newMenu= newMenu.sort((s1,s2) => s1.name==='(#this)' ? -1 : 0);
+
+
+    const menuWithDL= [...newMenu, ...addDataLinkEntries(dataSource,activateParams)];
+    newMenu.forEach( (m,idx) => {
+        if (m.displayType===DPtypes.ANALYZE) {
+            const request= makeReq(m.url,positionWP,m.name);
+            m.activate= makeFileAnalysisActivate(sourceTable,row, request,
+                positionWP,activateParams,menuWithDL,m.menuKey, prodType);
+            m.request= request;
+        }
+    });
+    return newMenu;
+}
+
+function makeName(s='', url, auxTot, autCnt, primeCnt=0) {
+    let name= (s==='#this' && primeCnt>0) ? '#this '+primeCnt  : s;
+    name= s.startsWith('#this') ? `Primary product (${name})` : s;
+    name= name[0]==='#' ? name.substring(1) : name;
+    name= (name==='auxiliary' && auxTot>1) ? `${name}: ${autCnt}` : name;
+    return name || url;
+}
+
+
+/**
+ *
+ * @param name
+ * @param menuKey
+ * @param url
+ * @param ct
+ * @param makeReq
+ * @param semantics
+ * @param activateParams
+ * @param positionWP
+ * @param table
+ * @param row
+ * @param size
+ * @return {DataProductsDisplayType}
+ */
+export function createGuessDataType(name, menuKey, url,ct,makeReq, semantics, activateParams, positionWP, table,row,size) {
+    const {imageViewerId, converterId}= activateParams;
+    if (ct.includes('image') || ct.includes('fits') || ct.includes('cube')) {
+        const request= makeReq(url,positionWP,name);
+        return dpdtImage(name,
+            createSingleImageActivate(request,imageViewerId,converterId,table.tbl_id,row),
+            menuKey, {request,url, semantics,size});
+    }
+    else if (ct.includes('table') || ct.includes('spectrum') || semantics.includes('auxiliary')) {
+        return dpdtTable(name,
+            createTableActivate(url, semantics, activateParams),
+            menuKey,{url,semantics,size} );
+    }
+    else if (ct.includes('jpeg') || ct.includes('png') || ct.includes('jpg') || ct.includes('gig')) {
+        return dpdtPNG(name,url,menuKey,{semantics});
+    }
+    else if (ct.includes('tar')|| ct.includes('gz')) {
+        return dpdtDownload(name,url,menuKey,{semantics});
+    }
+}

--- a/src/firefly/js/metaConvert/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/DataLinkProcessor.js
@@ -60,7 +60,7 @@ export function processDatalinkTable(sourceTable, row, datalinkTable, positionWP
             dpdtTable('Show Datalink VO Table for list of products',
                 createTableActivate(dataSource,'Datalink VO Table', activateParams),
                 'nd0-showtable', {url:dataSource}),
-            dpdtDownload ( 'Download Datalink VO Table for list of products', dataSource, 'nd1-downloadtable' ),
+            dpdtDownload ( 'Download Datalink VO Table for list of products', dataSource, 'nd1-downloadtable', 'vo-table' ),
         ];
         const msg= dMenu.length?
             'You may only download data for this row - nothing to display':
@@ -79,7 +79,7 @@ function addDataLinkEntries(dataSource,activateParams) {
         dpdtTable('Show Datalink VO Table for list of products',
             createTableActivate(dataSource,'Datalink VO Table', activateParams),
             'datalink-entry-showtable', {url:dataSource}),
-        dpdtDownload ( 'Download Datalink VO Table for list of products', dataSource, 'datalink-entry-downloadtable' )
+        dpdtDownload ( 'Download Datalink VO Table for list of products', dataSource, 'datalink-entry-downloadtable', 'vo-table' )
     ];
 
 }
@@ -115,13 +115,16 @@ function createDataLinkMenuRet(dataSource, dataLinkData, positionWP, sourceTable
         const activeMenuLookupKey= dataSource;
 
         if (ct.includes('tar')|| ct.includes('gz')) {
-            resultAry.push(dpdtDownload('Download file: '+name,url,'dlt-'+idx,{semantics, size, activeMenuLookupKey}));
+            let fileType;
+            if (ct.includes('tar')) fileType= 'tar';
+            if (ct.includes('gz')) fileType= 'gzip';
+            resultAry.push(dpdtDownload('Download file: '+name,url,'dlt-'+idx,fileType,{semantics, size, activeMenuLookupKey}));
         }
         else if (ct.includes('jpeg') || ct.includes('png') || ct.includes('jpg') || ct.includes('gig')) {
             resultAry.push(dpdtPNG('Show PNG image: '+name,url,'dlt-'+idx,{semantics, size, activeMenuLookupKey}));
         }
         else if (e.size>GIG) {
-            resultAry.push( dpdtDownload('Download FITS: '+name + '(too large to show)',url,'dlt-'+idx,{semantics, size, activeMenuLookupKey}));
+            resultAry.push( dpdtDownload('Download FITS: '+name + '(too large to show)',url,'dlt-'+idx,'fits',{semantics, size, activeMenuLookupKey}));
         }
         else if (ct==='' || analysisTypes.find( (a) => ct.includes(a))) {
             if (doFileAnalysis) {
@@ -194,6 +197,9 @@ export function createGuessDataType(name, menuKey, url,ct,makeReq, semantics, ac
         return dpdtPNG(name,url,menuKey,{semantics});
     }
     else if (ct.includes('tar')|| ct.includes('gz')) {
-        return dpdtDownload(name,url,menuKey,{semantics});
+        let fileType;
+        if (ct.includes('tar')) fileType= 'tar';
+        if (ct.includes('gz')) fileType= 'gzip';
+        return dpdtDownload(name,url,menuKey,fileType,{semantics});
     }
 }

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -1,0 +1,326 @@
+import {flux} from '../Firefly';
+import {REINIT_APP} from '../core/AppDataCntlr';
+import {isArray, isObject,get} from 'lodash';
+import {dpdtMessage, DPtypes} from './DataProductsType';
+import {download, downloadSimple, encodeUrl} from '../util/WebUtil';
+import {getRootURL} from '../util/BrowserUtil';
+
+
+export const DATA_PRODUCTS_KEY= 'dataProducts';
+const PREFIX= 'DataProductCntlr';
+export const UPDATE_DATA_PRODUCTS= `${PREFIX}.UpdateDataProducts`;
+export const UPDATE_ACTIVE_KEY= `${PREFIX}.UpdateActiveKey`;
+export const ACTIVATE_MENU_ITEM= `${PREFIX}.ActivateMenuItem`;
+export const ACTIVATE_FILE_MENU_ITEM= `${PREFIX}.ActivateFileMenuItem`;
+
+export function dataProductRoot() { return flux.getState()[DATA_PRODUCTS_KEY]; }
+
+function reducers() {
+    return {
+        [DATA_PRODUCTS_KEY]: reducer,
+    };
+}
+
+function actionCreators() {
+    return {
+        [ACTIVATE_MENU_ITEM]: activateMenuItemActionCreator,
+        [ACTIVATE_FILE_MENU_ITEM]: activateFileMenuItemActionCreator
+    };
+}
+
+
+const ACTIVATE_REQUIRED= [DPtypes.IMAGE,DPtypes.TABLE,DPtypes.CHART,DPtypes.ANALYZE];
+
+/**
+ * @param {Action} rawAction
+ * @returns {Function}
+ */
+function activateMenuItemActionCreator(rawAction) {
+    return (dispatcher, getState) => {
+        const {dpId,menuKey}= rawAction.payload;
+        const menu= get(getDataProducts(getState()[DATA_PRODUCTS_KEY],dpId),'menu');
+        if (!menu) return;
+        const menuItem= menu.find( (m) => m.menuKey===menuKey);
+        if (!menuItem) return;
+        if (menuItem.displayType===DPtypes.DOWNLOAD) doDownload(menuItem.url);
+        else dispatcher(rawAction);
+    };
+}
+
+function activateFileMenuItemActionCreator(rawAction) {
+    return (dispatcher) => {
+        const {fileMenu, newActiveFileMenuKey}= rawAction.payload;
+        let doDispatch= true;
+        if (fileMenu && fileMenu.menu && newActiveFileMenuKey) {
+            const menuItem= fileMenu.menu.find( (m) => m.menuKey===newActiveFileMenuKey);
+            if (menuItem && menuItem.displayType===DPtypes.DOWNLOAD) {
+                doDownload(menuItem.url);
+                doDispatch= false;
+            }
+        }
+        if (doDispatch) dispatcher(rawAction);
+    };
+}
+
+export function doDownload(url) {
+    const tmpUrl= url.toLowerCase();
+    if (tmpUrl.startsWith('http') || tmpUrl.startsWith('ftp')) {
+        downloadSimple(url);
+    }
+    else if (tmpUrl.startsWith('${')) {
+        const serviceURL = getRootURL() + 'servlet/Download';
+        const params={file: url};
+        download(encodeUrl(serviceURL, params));
+    }
+}
+
+
+
+
+/**
+ *
+ * @typedef {Object} Viewer
+ * @prop {string} dpId
+ * @prop {DataProductsDisplayType} dataProducts
+ * @prop {Object} activeFileMenuKeys - key serialized request, value - activeFileMenuKey, only used with containerType:WRAPPER
+ * @prop {Object} activeMenuKeys - key serialized request, value - activeFileMenuKey, last active menu key, only used with containerType:WRAPPER
+ *
+ * @global
+ * @public
+ */
+
+
+function initState() {
+
+    return [
+        {
+            dpId: 'TEMPLATE',
+            dataProducts: {},
+            activeFileMenuKeys: {},
+            activeMenuKeys: {},
+        }
+    ];
+}
+
+export default {
+    reducers, actionCreators,
+};
+
+
+/**
+ *
+ * @param dpId
+ * @param {Object} dataProducts
+ */
+export function dispatchUpdateDataProducts(dpId, dataProducts) {
+    flux.process({type: UPDATE_DATA_PRODUCTS, payload: {dpId,dataProducts} });
+}
+
+/**
+ * Update the activeMenuKeys and/or the one or more of the activeFileMenuKey's
+ * @param {Object} p
+ * @param {Object} [p.activeMenuKeyChanges] - change the activeMenuItemKey
+ *     this is a map of a cacheKey and the related activeFileMenuKey
+ * @param {Object} [p.activeFileMenuKeyChanges] - changes to the activeFileMenuKey's,
+ *     this is a map of a cacheKey and the related activeFileMenuKey
+ */
+export function dispatchUpdateActiveKey({dpId, activeMenuKeyChanges, activeFileMenuKeyChanges}) {
+    flux.process({type: UPDATE_ACTIVE_KEY, payload: {dpId,activeMenuKeyChanges, activeFileMenuKeyChanges} });
+}
+
+export function dispatchActivateMenuItem(dpId, menuKey) {
+    flux.process({type: ACTIVATE_MENU_ITEM, payload: {dpId,menuKey} });
+}
+
+/**
+ * @param p
+ * @param {String} p.dpId
+ * @param {DataProductsFileMenu} p.fileMenu
+ * @param {String|undefined} [p.newActiveFileMenuKey]
+ * @param {String} [p.currentMenuKey]
+ * @param {Array.<DataProductsDisplayType>|undefined} [p.menu]
+ */
+export function dispatchActivateFileMenuItem({dpId,fileMenu, newActiveFileMenuKey, menu, currentMenuKey}) {
+    flux.process({type: ACTIVATE_FILE_MENU_ITEM, payload: {dpId,fileMenu, newActiveFileMenuKey, currentMenuKey, menu} });
+}
+
+
+
+export function getDataProducts(dpRoot,dpId) {
+    return createOrFind(dpRoot,dpId).dataProducts;
+}
+
+export const getActiveFileMenuKey= (dpId,fileMenu) =>
+    createOrFind(dataProductRoot(),dpId).activeFileMenuKeys[fileMenu.activeItemLookupKey];
+
+
+export const getActiveFileMenuKeyByKey= (dpId,key) =>
+    createOrFind(dataProductRoot(),dpId).activeFileMenuKeys[key];
+
+
+export const getActiveMenuKey= (dpId,activeMenuLookupKey) =>
+    createOrFind(dataProductRoot(),dpId).activeMenuKeys[activeMenuLookupKey];
+
+
+
+function reducer(state=initState(), action={}) {
+
+    if (!action.payload || !action.type) return state;
+    let retState= state;
+
+    switch (action.type) {
+        case UPDATE_DATA_PRODUCTS:
+            retState= updateDataProducts(state,action);
+            break;
+        case UPDATE_ACTIVE_KEY:
+            retState= updateActiveKey(state,action);
+            break;
+        case ACTIVATE_MENU_ITEM:
+            retState= activateMenuItem(state,action);
+            break;
+        case ACTIVATE_FILE_MENU_ITEM:
+            retState= changeActiveFileMenuItem(state,action);
+            break;
+        case REINIT_APP:
+            retState= initState();
+            break;
+        default:
+            break;
+
+    }
+    return retState;
+}
+
+const makeNewDPData= (dpId) =>  ({ dpId, dataProducts: {}, activeFileMenuKeys: {}, activeMenuKeys: {} });
+
+function createOrFindAndCopy(state,dpId) {
+    const dp= state.find( (dpContainer) => dpContainer.dpId===dpId );
+    return dp ? {...dp} : makeNewDPData(dpId);
+}
+
+function createOrFind(state,dpId) {
+    return state.find( (dpContainer) => dpContainer.dpId===dpId ) || makeNewDPData(dpId);
+}
+
+
+function insertOrReplace(state,dpData) {
+    const {dpId}= dpData;
+    const found= Boolean(state.find( (dpContainer) => dpContainer.dpId===dpId ));
+    return found ? state.map( (d) => d.dpId===dpId ? dpData : d) : [...state,dpData];
+}
+
+
+function updateDataProducts(state,action) {
+    const {dpId, dataProducts}= action.payload;
+    const dpData = createOrFindAndCopy(state,dpId);
+    dpData.dataProducts= dataProducts;
+    return insertOrReplace(state,dpData);
+}
+
+function updateActiveKey(state,action) {
+    const {dpId, activeMenuKeyChanges, activeFileMenuKeyChanges}= action.payload;
+    const dpData= createOrFindAndCopy(state,dpId);
+    if (isObject(activeMenuKeyChanges)) dpData.activeMenuKeys= {...dpData.activeMenuKeys,...activeMenuKeyChanges};
+    if (isObject(activeFileMenuKeyChanges)) dpData.activeFileMenuKeys= {...dpData.activeFileMenuKeys,...activeFileMenuKeyChanges};
+    return insertOrReplace(state,dpData);
+}
+
+
+function activateMenuItem(state,action) {
+    const {dpId,menuKey}= action.payload;
+    const dpData= createOrFind(state,dpId);
+    const {dataProducts,activeMenuKeys}= dpData;
+    const {menu, activeMenuKey, activeMenuLookupKey}= dataProducts;
+
+    if (!menu) return state;
+    const menuItem= menu.find( (m) => m.menuKey===menuKey);
+    if (!menuItem) return state;
+
+    const {fileMenu}= menuItem;
+    let aMenuItem;
+
+    if (menuItem.menuKey===activeMenuKey) return state;
+
+    if (fileMenu && isArray(fileMenu.menu)) {
+        const activeFileMenuKey= getActiveFileMenuKey(dpId,fileMenu);
+        aMenuItem= fileMenu.menu.find( (m) => m.menuKey===activeFileMenuKey);
+        if (!aMenuItem) aMenuItem= fileMenu.menu[0];
+    }
+    else {
+        aMenuItem= menuItem;
+    }
+    dpData.activeMenuKeys= {...activeMenuKeys, [activeMenuLookupKey]:aMenuItem.menuKey};
+
+    const {activate,url, displayType}= aMenuItem;
+
+    const requiresActivate= ACTIVATE_REQUIRED.includes(displayType);
+    if (requiresActivate && !activate) {
+        dpData.dataProducts= {
+            displayType: 'message', 'message': `Data Product (${displayType}) not supported (activate required)`,
+            menu, menuKey, fileMenu, activeMenuLookupKey
+        };
+    }
+    else {
+        switch (displayType) {
+            case DPtypes.IMAGE:
+            case DPtypes.TABLE:
+            case DPtypes.CHART:
+            case DPtypes.CHART_TABLE:
+                dpData.dataProducts= {displayType, menuKey, menu, fileMenu, activeMenuKey:menuKey, activeMenuLookupKey, activate};
+                break;
+            case DPtypes.PNG:
+                dpData.dataProducts= {displayType, url, menuKey, menu, activeMenuKey:menuKey, activeMenuLookupKey};
+                break;
+            case DPtypes.DOWNLOAD:
+                dpData.dataProducts= {displayType, url, menuKey, menu, activeMenuKey:menuKey, activeMenuLookupKey};
+                break;
+            case DPtypes.ANALYZE:
+                dpData.dataProducts= {displayType, menuKey, menu, activeMenuKey:menuKey, activate, activeMenuLookupKey};
+        }
+
+    }
+    return insertOrReplace(state,dpData);
+}
+
+
+const FILE_MENU_REQUIRED= [DPtypes.IMAGE,DPtypes.TABLE,DPtypes.CHART_TABLE,DPtypes.CHART,DPtypes.MESSAGE];
+
+export function changeActiveFileMenuItem(state,action) {
+
+    const {dpId,fileMenu, menu:menuParameter, currentMenuKey}= action.payload;
+    let {newActiveFileMenuKey}= action.payload;
+
+    const dpData= createOrFind(state,dpId);
+    const {dataProducts, activeFileMenuKeys}= dpData;
+    const menu= menuParameter || dataProducts.menu || [];
+    const menuKey= currentMenuKey || getActiveMenuKey(dpId, dpData.dataProducts.activeMenuLookupKey);
+
+    const selectedMenuDataProduct= menu.find( (dt) => dt.menuKey===menuKey) || {};
+
+    const currentActiveFileMenuKey= getActiveFileMenuKey(dpId,fileMenu);
+    if (newActiveFileMenuKey===currentActiveFileMenuKey) return state;
+    if (!newActiveFileMenuKey) newActiveFileMenuKey= currentActiveFileMenuKey;
+
+
+    const actIdx= fileMenu.menu.findIndex( (m) => m.menuKey===newActiveFileMenuKey);
+    const fileMenuItem= fileMenu.menu[actIdx<0?0:actIdx];
+
+    const {activate,displayType,message}= fileMenuItem;
+
+    dpData.activeFileMenuKeys={...activeFileMenuKeys, [fileMenu.activeItemLookupKey]:fileMenuItem.menuKey};
+
+    if (!FILE_MENU_REQUIRED.includes(displayType)) {
+        dpData.dataProducts= dpdtMessage(`Data product (${displayType}) not supported`,menu, {fileMenu,menuKey, activeMenuKey:menuKey});
+        return insertOrReplace(state,dpData);
+    }
+    if (!activate && displayType!==DPtypes.MESSAGE) {
+        dpData.dataProducts= dpdtMessage('Data product not supported, no activate available',menu, {fileMenu,menuKey, activeMenuKey:menuKey});
+        return insertOrReplace(state,dpData);
+    }
+
+    const newFileMenu= {...fileMenu, activeFileMenuKey:newActiveFileMenuKey};
+    const newDisplayProduct= { ...selectedMenuDataProduct, displayType, activate, message, fileMenu:newFileMenu, activeMenuKey:menuKey};
+    const newMenu= menu && menu.map( (menuItem) => (menuItem.menuKey!==menuKey) ? menuItem : newDisplayProduct );
+    dpData.dataProducts= {...newDisplayProduct, menu:newMenu};
+    return insertOrReplace(state,dpData);
+}

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -63,9 +63,11 @@ function activateFileMenuItemActionCreator(rawAction) {
 }
 
 export function doDownload(url) {
+    const serviceURL = getRootURL() + 'servlet/Download';
     const tmpUrl= url.toLowerCase();
     if (tmpUrl.startsWith('http') || tmpUrl.startsWith('ftp')) {
-        downloadSimple(url);
+        const params={externalURL: url};
+        download(encodeUrl(serviceURL, params));
     }
     else if (tmpUrl.startsWith('${')) {
         const serviceURL = getRootURL() + 'servlet/Download';

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -54,8 +54,6 @@ const simpleCreate= (table, converterTemplate) => converterTemplate;
  * @prop {string} imageViewerId
  * @prop {string} chartViewerId
  * @prop {string} tableGroupViewerId
- * @prop {string} converterId
- * @prop {string} dataTypeViewerId
  * @prop {string} dpId - data product id
  *
  */
@@ -63,16 +61,16 @@ const simpleCreate= (table, converterTemplate) => converterTemplate;
 
 /**
  * Returns a callback function or a Promise<DataProductsDisplayType>.
- * callback: function(table:TableModel, row:String,activeParams:{imageViewerId:String,chartViewId:String,tableViewId:String,converterId:String})
+ * callback: function(table:TableModel, row:String,activeParams:ActivateParams)
  * @param makeReq
  * @return {function | promise}
  */
 function getSingleDataProductWrapper(makeReq) {
     return (table, row, activateParams) => {
-        const {imageViewerId, converterId}= activateParams;
+        const {imageViewerId}= activateParams;
         const retVal= makeReq(table, row, true);
         const r= get(retVal,'single');
-        const activate= createSingleImageActivate(r,imageViewerId,converterId,table.tbl_id,row);
+        const activate= createSingleImageActivate(r,imageViewerId,table.tbl_id,row);
         return Promise.resolve( dpdtImage('Image', activate));
     };
 }
@@ -81,19 +79,19 @@ function getSingleDataProductWrapper(makeReq) {
 /**
  *
  * Returns a callback function or a Promise<DataProductsDisplayType>.
- * callback: function(table:TableModel, plotRows:Array.<Object>,activeParams:{imageViewerId:String,chartViewId:String,tableViewId:String,converterId:String})
+ * callback: function(table:TableModel, plotRows:Array.<Object>,activeParams:ActivateParams)
  * @param makeReq
  * @return {function | promise}
  */
 function getGridDataProductWrapper(makeReq) {
     return (table, plotRows, activateParams) => {
-        const {imageViewerId, converterId}= activateParams;
+        const {imageViewerId}= activateParams;
 
         const reqAry= plotRows
             .map( (pR) => get(makeReq(table,pR.row,true),'single'))
             .filter( (r) => r);
 
-        const activate= createGridImagesActivate(reqAry,imageViewerId,converterId,table.tbl_id,plotRows);
+        const activate= createGridImagesActivate(reqAry,imageViewerId,table.tbl_id,plotRows);
         return Promise.resolve( dpdtImage('Image Grid', activate));
     };
 }
@@ -106,10 +104,10 @@ function getGridDataProductWrapper(makeReq) {
  */
 function getRelatedDataProductWrapper(makeReq) {
     return (table, row, threeColorOps, highlightPlotId, activateParams) => {
-        const {imageViewerId, converterId}= activateParams;
+        const {imageViewerId}= activateParams;
         const retVal= makeReq(table, row, false,true,threeColorOps);
         if (retVal) {
-            const activate= createRelatedDataGridActivate(retVal,imageViewerId,converterId,table.tbl_id, highlightPlotId);
+            const activate= createRelatedDataGridActivate(retVal,imageViewerId,table.tbl_id, highlightPlotId);
             return Promise.resolve( dpdtImage('Images', activate));
         }
         else {

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -2,7 +2,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-
 import {get, isEmpty, isArray} from 'lodash';
 import {makeWisePlotRequest} from './WiseRequestList.js';
 import {make2MassPlotRequest} from './TwoMassRequestList.js';
@@ -17,19 +16,23 @@ import {makeWorldPt, parseWorldPt} from '../visualize/Point.js';
 import {MetaConst} from '../data/MetaConst.js';
 import {CoordinateSys} from '../visualize/CoordSys.js';
 import {hasObsCoreLikeDataProducts} from '../util/VOAnalyzer.js';
-import {dispatchUpdateCustom} from '../visualize/MultiViewCntlr.js';
 import {makeObsCoreConverter, getObsCoreSingleDataProduct, getObsCoreGridDataProduct} from './ObsCoreConverter.js';
 import {
     createGridImagesActivate,
     createRelatedDataGridActivate,
     createSingleImageActivate
 } from './ImageDataProductsUtil';
+import {makeAnalysisGetGridDataProduct, makeAnalysisGetSingleDataProduct} from './MultiProductFileAnalyzer';
+import {dpdtImage} from './DataProductsType';
+import {dispatchUpdateCustom} from '../visualize/MultiViewCntlr';
+import {getDataSourceColumn} from '../util/VOAnalyzer';
+import {getColumn} from '../tables/TableUtil';
 
 const FILE= 'FILE';
 
 
 function matchById(table,id)  {
-    if (!id) return false;
+    if (!id || !table || table.isFetching) return false;
     const value= findTableMetaEntry(table, [MetaConst.IMAGE_SOURCE_ID, MetaConst.DATASET_CONVERTER]);
     if (!value) return false;
     return value.toUpperCase()===id.toUpperCase();
@@ -43,15 +46,6 @@ function matchById(table,id)  {
 const simpleCreate= (table, converterTemplate) => converterTemplate;
 
 
-/**
- * @global
- * @public
- * @typedef {Object} DataProductsDisplayType
- * @prop {string} displayType
- * @prop {Function} activate
- * @prop {Object} menu
- *
- */
 
 /**
  * @global
@@ -61,6 +55,8 @@ const simpleCreate= (table, converterTemplate) => converterTemplate;
  * @prop {string} chartViewerId
  * @prop {string} tableGroupViewerId
  * @prop {string} converterId
+ * @prop {string} dataTypeViewerId
+ * @prop {string} dpId - data product id
  *
  */
 
@@ -77,7 +73,7 @@ function getSingleDataProductWrapper(makeReq) {
         const retVal= makeReq(table, row, true);
         const r= get(retVal,'single');
         const activate= createSingleImageActivate(r,imageViewerId,converterId,table.tbl_id,row);
-        return Promise.resolve( { displayType:'images', activate, menu:undefined });
+        return Promise.resolve( dpdtImage('Image', activate));
     };
 }
 
@@ -93,12 +89,12 @@ function getGridDataProductWrapper(makeReq) {
     return (table, plotRows, activateParams) => {
         const {imageViewerId, converterId}= activateParams;
 
-        const reqAry= plotRows.map( (pR) => makeReq(table,pR.row,true))
-            .filter( (r) => (r && r.single))
-            .map( (result) => result.single);
+        const reqAry= plotRows
+            .map( (pR) => get(makeReq(table,pR.row,true),'single'))
+            .filter( (r) => r);
 
         const activate= createGridImagesActivate(reqAry,imageViewerId,converterId,table.tbl_id,plotRows);
-        return Promise.resolve( { displayType:'images', activate, menu:undefined });
+        return Promise.resolve( dpdtImage('Image Grid', activate));
     };
 }
 
@@ -114,7 +110,7 @@ function getRelatedDataProductWrapper(makeReq) {
         const retVal= makeReq(table, row, false,true,threeColorOps);
         if (retVal) {
             const activate= createRelatedDataGridActivate(retVal,imageViewerId,converterId,table.tbl_id, highlightPlotId);
-            return Promise.resolve( { displayType:'images', activate, menu:undefined });
+            return Promise.resolve( dpdtImage('Images', activate));
         }
         else {
             return Promise.resolve( {});
@@ -269,18 +265,6 @@ export const converterTemplates = [
         getRelatedDataProduct: () => Promise.reject('related data products not supported')
     },
     {
-        converterId : 'UNKNOWN',
-        tableMatches: (table) => !isEmpty(Object.keys(findADataSourceColumn(table.tableMeta,table.tableData.columns))),
-        create : simpleCreate,
-        threeColor : false,
-        hasRelatedBands : false,
-        canGrid : true,
-        maxPlots : 12,
-        getSingleDataProduct: getSingleDataProductWrapper(makeRequestForUnknown),
-        getGridDataProduct: () => Promise.reject('grid not supported'),
-        getRelatedDataProduct: () => Promise.reject('related data products not supported')
-    },
-    {
         converterId : 'SimpleMoving',
         tableMatches: () => false,
         create : simpleCreate,
@@ -290,6 +274,18 @@ export const converterTemplates = [
         maxPlots : 12,
         getSingleDataProduct: getSingleDataProductWrapper(makeRequestSimpleMoving),
         getGridDataProduct: () => Promise.reject('grid not supported'),
+        getRelatedDataProduct: () => Promise.reject('related data products not supported')
+    },
+    {                            // this one should be last, it is the fallback
+        converterId : 'UNKNOWN',
+        tableMatches: findADataSourceColumn,
+        create : simpleCreate,
+        threeColor : false,
+        hasRelatedBands : false,
+        canGrid : true,
+        maxPlots : 3,
+        getSingleDataProduct: makeAnalysisGetSingleDataProduct(makeRequestForUnknown),
+        getGridDataProduct: makeAnalysisGetGridDataProduct(makeRequestForUnknown),
         getRelatedDataProduct: () => Promise.reject('related data products not supported')
     }
 ];
@@ -351,7 +347,7 @@ function makeRequestForUnknown(table, row, includeSingle, includeStandard) {
 
     const {tableMeta:meta}= table;
 
-    const dataSource= findADataSourceColumn(meta,table.tableData.columns);
+    const dataSource= findADataSourceColumn(table);
     if (!dataSource) return {};
 
 
@@ -385,12 +381,13 @@ function makeRequestForUnknown(table, row, includeSingle, includeStandard) {
 
 }
 
+
 function makeRequestSimpleMoving(table, row, includeSingle, includeStandard) {
 
     const {tableMeta:meta, tableData}= table;
 
 
-    const dataSource= findADataSourceColumn(meta, tableData.columns);
+    const dataSource= findADataSourceColumn(table);
 
     if (!dataSource) return {};
 
@@ -422,13 +419,17 @@ function makeRequestSimpleMoving(table, row, includeSingle, includeStandard) {
 
 
 const defDataSourceGuesses= [ 'FILE', 'FITS', 'DATA', 'SOURCE', 'URL' ];
-const dataSourceUpper= MetaConst.DATA_SOURCE.toUpperCase();
 
-function findADataSourceColumn(meta,columns) {
-    const dsCol= Object.keys(meta).find( (key) => key.toUpperCase()===dataSourceUpper);
-    let guesses= meta[dsCol] ? [meta[dsCol],...defDataSourceGuesses] : defDataSourceGuesses;
-    guesses= guesses.map( (g) => g.toUpperCase());
-    return columns.find( (c) => guesses.includes(c.name.toUpperCase())) || {};
+function findADataSourceColumn(table) {
+    if (!table || table.isFetching) return false;
+    const columns= get(table,'tableData.columns');
+    if (!columns) return false;
+    const dsCol= getDataSourceColumn(table);
+    if (dsCol) return getColumn(table,dsCol);
+    if (dsCol===false) return false;
+    // if dsCol is undefined then start guessing
+    const guesses= defDataSourceGuesses.map( (g) => g.toUpperCase());
+    return columns.find( (c) => guesses.includes(c.name.toUpperCase()));
 }
 
 function findTableMetaEntry(table,ids) {
@@ -476,10 +477,10 @@ function makeRequest(table, dataSource, positionWP, row) {
     let r;
     const source= getCellValue(table, row, dataSource);
     if (dataSource.toLocaleUpperCase() === FILE) {
-        r = WebPlotRequest.makeFilePlotRequest(source, 'Fits Image');
+        r = WebPlotRequest.makeFilePlotRequest(source, 'DataProduct');
     }
     else {
-        r = WebPlotRequest.makeURLPlotRequest(source, 'Fits Image');
+        r = WebPlotRequest.makeURLPlotRequest(source, 'DataProduct');
     }
     r.setZoomType(ZoomType.FULL_SCREEN);
     r.setTitleOptions(TitleOptions.FILE_NAME);
@@ -488,3 +489,4 @@ function makeRequest(table, dataSource, positionWP, row) {
 
     return r;
 }
+

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -32,6 +32,7 @@ export const DPtypes= {
     MESSAGE: 'message',
     PROMISE: 'promise',
     IMAGE: 'image',
+    IMAGE_SNGLE_AXIS: 'image-single-axis',
     TABLE: 'table',
     CHART: 'xyplot',
     CHART_TABLE: 'chartTable',
@@ -93,11 +94,12 @@ export function dpdtWorkingPromise(message,promise,request=undefined, extra={}, 
  * @param {String} message
  * @param {String} titleStr download title str
  * @param {String} url download url
+ * @param {String} [fileType]
  * @return {DataProductsDisplayType}
  */
-export const dpdtMessageWithDownload= (message,titleStr, url) => {
+export const dpdtMessageWithDownload= (message,titleStr, url,fileType=undefined) => {
     const singleDownload= Boolean(titleStr && url);
-    return dpdtMessage(message,singleDownload ?[dpdtDownload(titleStr,url)] : undefined,{singleDownload} );
+    return dpdtMessage(message,singleDownload ?[dpdtDownload(titleStr,url,'download-0',fileType)] : undefined,{singleDownload} );
 };
 
 /**
@@ -166,11 +168,12 @@ export function dpdtAnalyze(name, activate, url, menuKey='analyze-0', extra={}) 
  * @param {string} name
  * @param {string} url
  * @param {number|string} menuKey
+ * @param {string} fileType type of file eg- tar or gz
  * @param {Object} extra - all values in this object are added to the DataProjectType Object
  * @return {DataProductsDisplayType}
  */
-export function dpdtDownload(name, url, menuKey='download-0', extra={}) {
-    return { displayType:DPtypes.DOWNLOAD, name, url, menuKey, ...extra};
+export function dpdtDownload(name, url, menuKey='download-0', fileType, extra={}) {
+    return { displayType:DPtypes.DOWNLOAD, name, url, menuKey, fileType, ...extra};
 }
 
 /**

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -1,0 +1,198 @@
+
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} DataProductsDisplayType
+ * @prop {string} displayType one of 'image', 'message', 'promise', 'table', 'png', 'download, 'xyplot', 'analyze'
+ * @prop {String} menuKey - unique key of this item
+ * @prop {Function} [activate] - function to plot 'image', 'table', 'xyplot', require for those
+ * @prop {String} [url] - required if display type is 'png' or 'download'
+ * @prop {String} [message] - required it type is 'message' or 'promise'
+ * @prop {String} [name]
+ * @prop {boolean} [isWorkingState] - if defined this means we are in a transitive/loading state. expect regular updates
+ * @prop {Promise} [promise] - required it type is 'promise'
+ * @prop {Array.<DataProductsDisplayType>|undefined} menu - if defined, then menu to display
+ *
+ */
+
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} DataProductsFileMenu
+ * @prop {Object} fileAnalysis
+ * @prop {String} activeItemLookUpKey
+ * @prop {Array.<DataProductsDisplayType>|undefined} menu - if defined, then menu to display
+ *
+ */
+
+
+export const DPtypes= {
+    MESSAGE: 'message',
+    PROMISE: 'promise',
+    IMAGE: 'image',
+    TABLE: 'table',
+    CHART: 'xyplot',
+    CHART_TABLE: 'chartTable',
+    DOWNLOAD: 'download',
+    PNG: 'png',
+    ANALYZE: 'analyze',
+};
+
+
+
+/**
+ *
+ * @param {String} message
+ * @param {Array.<DataProductsDisplayType>|undefined} [menu] - if defined, then menu to display
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtMessage(message, menu= undefined, extra={}) {
+    return {displayType:DPtypes.MESSAGE, message, menu, menuKey:'message-0', ...extra};
+}
+
+/**
+ *
+ * @param {String} message
+ * @param {WebPlotRequest} [request]
+ * @param {Object} [extra]
+ * @param {String} [rootMessage] will default to message
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtWorkingMessage(message,request, extra={}, rootMessage=undefined) {
+    return {displayType:DPtypes.MESSAGE, message, rootMessage:rootMessage||message, menuKey:'working-0',
+        isWorkingState:true, menu:undefined, ...extra};
+}
+
+/**
+ *
+ * @param {String} message
+ * @param {Promise} promise
+ * @param {WebPlotRequest} [request]
+ * @param {Object} [extra]
+ * @param {String} [rootMessage] will default to message
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtWorkingPromise(message,promise,request=undefined, extra={}, rootMessage=undefined) {
+    return {
+        displayType:DPtypes.PROMISE,
+        promise,
+        message,
+        request,
+        rootMessage:rootMessage||message, menuKey:'working-promise-0',
+        isWorkingState:true,
+        menu:undefined, ...extra
+    };
+}
+
+
+/**
+ *
+ * @param {String} message
+ * @param {String} titleStr download title str
+ * @param {String} url download url
+ * @return {DataProductsDisplayType}
+ */
+export const dpdtMessageWithDownload= (message,titleStr, url) => {
+    const singleDownload= Boolean(titleStr && url);
+    return dpdtMessage(message,singleDownload ?[dpdtDownload(titleStr,url)] : undefined,{singleDownload} );
+};
+
+/**
+ *
+ * @param {string} name
+ * @param {Function} activate
+ * @param {number|string} menuKey
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtImage(name, activate, menuKey='image-0', extra={}) {
+    return { displayType:DPtypes.IMAGE, name, activate, menuKey, ...extra};
+}
+
+/**
+ *
+ * @param {string} name
+ * @param {Function} activate
+ * @param {number|string} menuKey
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtTable(name, activate, menuKey='table-0', extra={}) {
+    return { displayType:DPtypes.TABLE, name, activate, menuKey, ...extra};
+}
+
+/**
+ *
+ * @param {string} name
+ * @param {Function} activate
+ * @param {number|string} menuKey
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtChart(name, activate, menuKey='chart-0', extra={}) {
+    return { displayType:DPtypes.CHART, name, activate, menuKey, ...extra};
+}
+
+/**
+ *
+ * @param {string} name
+ * @param {Function} activate
+ * @param {number|string} menuKey
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtChartTable(name, activate, menuKey='chart-table-0', extra={}) {
+    return { displayType:DPtypes.CHART_TABLE, name, activate, menuKey, ...extra};
+}
+
+/**
+ *
+ * @param {string} name
+ * @param {Function} activate
+ * @param {String} url
+ * @param {number|string} menuKey
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtAnalyze(name, activate, url, menuKey='analyze-0', extra={}) {
+    return { displayType:DPtypes.ANALYZE, name, url, activate, menuKey, ...extra};
+}
+
+/**
+ *
+ * @param {string} name
+ * @param {string} url
+ * @param {number|string} menuKey
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtDownload(name, url, menuKey='download-0', extra={}) {
+    return { displayType:DPtypes.DOWNLOAD, name, url, menuKey, ...extra};
+}
+
+/**
+ *
+ * @param {string} name
+ * @param {string} url
+ * @param {number|string} menuKey
+ * @param {Object} extra - all values in this object are added to the DataProjectType Object
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtPNG(name, url, menuKey='png-0', extra={}) {
+    return { displayType:DPtypes.PNG, name, url, menuKey, ...extra};
+}
+
+
+/**
+ *
+ * @param {Array.<DataProductsDisplayType>} menu
+ * @param {number} activeIdx
+ * @param {String} activeMenuLookupKey
+ * @return {DataProductsDisplayType}
+ */
+export function dpdtFromMenu(menu,activeIdx,activeMenuLookupKey) {
+    return {...menu[activeIdx], activeMenuLookupKey, menu:menu.length>1?menu:[]};
+}

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -21,6 +21,7 @@ export function createRelatedDataGridActivate(reqRet, imageViewerId, dataId, tbl
 }
 
 
+
 /**
  *
  * @param {Array.<WebPlotRequest>} inReqAry
@@ -28,21 +29,24 @@ export function createRelatedDataGridActivate(reqRet, imageViewerId, dataId, tbl
  * @param {string} dataId
  * @param {string} tbl_id
  * @param {Array.<Object>} plotRows
- * @return {function(): void}
+ * @return {undefined|function(): void}
  */
 export function createGridImagesActivate(inReqAry, imageViewerId, dataId, tbl_id, plotRows) {
-    const reqAry= inReqAry.map( (r,idx) => {
-        if (!r) return;
-        r.setAttributes({[PlotAttribute.DATALINK_TABLE_ROW]: plotRows[idx].row+'',
-                         [PlotAttribute.DATALINK_TABLE_ID]: tbl_id});
-        r.setPlotId(plotRows[idx].plotId);
-        return r;
-    } );
+    const reqAry= inReqAry
+        .map( (r,idx) => {
+            if (!r) return;
+            r.setAttributes({
+                [PlotAttribute.DATALINK_TABLE_ROW]: plotRows[idx].row+'',
+                [PlotAttribute.DATALINK_TABLE_ID]: tbl_id
+            });
+            r.setPlotId(plotRows[idx].plotId);
+            return r;
+        } )
+        .filter( (r) =>r);
     const pR= plotRows.filter( (pR) => pR.highlight).find( (pR) => pR.plotId);
     const highlightPlotId= pR && pR.plotId;
     return () => replotImageDataProducts(highlightPlotId, imageViewerId, dataId, tbl_id, reqAry);
 }
-
 
 /**
  *
@@ -51,11 +55,11 @@ export function createGridImagesActivate(inReqAry, imageViewerId, dataId, tbl_id
  * @param {string} dataId
  * @param {string} tbl_id
  * @param {string} highlightedRow
- * @return {function(): void}
+ * @return {undefined|function(): void}
  */
 export function createSingleImageActivate(request, imageViewerId, dataId, tbl_id, highlightedRow) {
-    if (!request) return;
-    request.setPlotId(`${dataId}-singleview`);
+    if (!request) return undefined;
+    if (!request.getPlotId()) request.setPlotId(`${dataId}-singleview`);
     request.setAttributes({[PlotAttribute.DATALINK_TABLE_ROW]: highlightedRow+'',
                            [PlotAttribute.DATALINK_TABLE_ID]: tbl_id});
     return () => replotImageDataProducts(request.getPlotId(), imageViewerId, dataId, tbl_id, [request]);

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -14,10 +14,10 @@ import {dispatchTableHighlight} from '../tables/TablesCntlr.js';
 
 
 
-export function createRelatedDataGridActivate(reqRet, imageViewerId, dataId, tbl_id, highlightPlotId) {
+export function createRelatedDataGridActivate(reqRet, imageViewerId, tbl_id, highlightPlotId) {
     reqRet.highlightPlotId = highlightPlotId;
     if (isEmpty(reqRet.standard)) return;
-    return () => replotImageDataProducts(highlightPlotId, imageViewerId, dataId, tbl_id, reqRet.standard, reqRet.threeColor);
+    return () => replotImageDataProducts(highlightPlotId, imageViewerId, tbl_id, reqRet.standard, reqRet.threeColor);
 }
 
 
@@ -26,43 +26,45 @@ export function createRelatedDataGridActivate(reqRet, imageViewerId, dataId, tbl
  *
  * @param {Array.<WebPlotRequest>} inReqAry
  * @param {string} imageViewerId
- * @param {string} dataId
  * @param {string} tbl_id
  * @param {Array.<Object>} plotRows
  * @return {undefined|function(): void}
  */
-export function createGridImagesActivate(inReqAry, imageViewerId, dataId, tbl_id, plotRows) {
+export function createGridImagesActivate(inReqAry, imageViewerId, tbl_id, plotRows) {
     const reqAry= inReqAry
         .map( (r,idx) => {
             if (!r) return;
-            r.setAttributes({
-                [PlotAttribute.DATALINK_TABLE_ROW]: plotRows[idx].row+'',
-                [PlotAttribute.DATALINK_TABLE_ID]: tbl_id
-            });
+            if (tbl_id) {
+                r.setAttributes({
+                    [PlotAttribute.DATALINK_TABLE_ROW]: plotRows[idx].row+'',
+                    [PlotAttribute.DATALINK_TABLE_ID]: tbl_id
+                });
+            }
             r.setPlotId(plotRows[idx].plotId);
             return r;
         } )
         .filter( (r) =>r);
     const pR= plotRows.filter( (pR) => pR.highlight).find( (pR) => pR.plotId);
     const highlightPlotId= pR && pR.plotId;
-    return () => replotImageDataProducts(highlightPlotId, imageViewerId, dataId, tbl_id, reqAry);
+    return () => replotImageDataProducts(highlightPlotId, imageViewerId, tbl_id, reqAry);
 }
 
 /**
  *
  * @param {WebPlotRequest} request
  * @param {string} imageViewerId
- * @param {string} dataId
  * @param {string} tbl_id
  * @param {string} highlightedRow
  * @return {undefined|function(): void}
  */
-export function createSingleImageActivate(request, imageViewerId, dataId, tbl_id, highlightedRow) {
+export function createSingleImageActivate(request, imageViewerId, tbl_id, highlightedRow) {
     if (!request) return undefined;
-    if (!request.getPlotId()) request.setPlotId(`${dataId}-singleview`);
-    request.setAttributes({[PlotAttribute.DATALINK_TABLE_ROW]: highlightedRow+'',
-                           [PlotAttribute.DATALINK_TABLE_ID]: tbl_id});
-    return () => replotImageDataProducts(request.getPlotId(), imageViewerId, dataId, tbl_id, [request]);
+    if (!request.getPlotId()) request.setPlotId(`${tbl_id|'no-table'}-singleview`);
+    if (tbl_id) {
+        request.setAttributes({[PlotAttribute.DATALINK_TABLE_ROW]: highlightedRow+'',
+            [PlotAttribute.DATALINK_TABLE_ID]: tbl_id});
+    }
+    return () => replotImageDataProducts(request.getPlotId(), imageViewerId, tbl_id, [request]);
 }
 
 
@@ -107,13 +109,12 @@ export function changeActivePlotView(plotId,tbl_id) {
  *
  * @param {string} activePlotId the new active plot id after the replot
  * @param {string} imageViewerId the id of the viewer
- * @param {string} dataId the id of table table type return by makeDataProductsConverter
  * @param {string} tbl_id table id of the table with the data products
  * @param {Array.<WebPlotRequest>} reqAry an array of request to execute
  * @param {Array.<WebPlotRequest>} [threeReqAry] an array of request for a three color plot, optional, max 3 entries, r,g,b
  */
-function replotImageDataProducts(activePlotId, imageViewerId, dataId, tbl_id, reqAry, threeReqAry)  {
-    const groupId= `${imageViewerId}-${dataId}-standard`;
+function replotImageDataProducts(activePlotId, imageViewerId, tbl_id, reqAry, threeReqAry)  {
+    const groupId= `${imageViewerId}-${tbl_id||'no-table-group'}-standard`;
     reqAry= reqAry.filter( (r) => r);
     let plottingIds= reqAry.map( (r) =>  r && r.getPlotId()).filter( (id) => id);
     let threeCPlotId;

--- a/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
+++ b/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
@@ -1,0 +1,308 @@
+import {doUpload} from '../ui/FileUpload';
+import {FileAnalysisType} from '../data/FileAnalysis';
+import {
+    createGridImagesActivate,
+    createSingleImageActivate
+} from './ImageDataProductsUtil';
+import {PlotAttribute} from '../visualize/PlotAttribute';
+import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../core/MasterSaga';
+import ImagePlotCntlr from '../visualize/ImagePlotCntlr';
+import {
+    dpdtDownload,
+    dpdtImage,
+    dpdtMessage,
+    dpdtMessageWithDownload, dpdtPNG,
+    dpdtWorkingMessage,
+    dpdtWorkingPromise,
+} from './DataProductsType';
+import {hashCode} from '../util/WebUtil';
+import {
+    dataProductRoot, dispatchActivateFileMenuItem, dispatchUpdateActiveKey,
+    dispatchUpdateDataProducts, getActiveFileMenuKeyByKey, getDataProducts
+} from './DataProductsCntlr';
+import {analyzePart, arrangeAnalysisMenu} from './PartAnalyzer';
+import {hasRowAccess} from '../tables/TableUtil';
+
+
+const uploadedCache= {};
+
+const ANALYZING_MSG= 'Loading & Analyzing';
+
+/**
+ * create a function to analyze and show a data product
+ * @param makeReq
+ * @return {function}
+ */
+export function makeAnalysisGetSingleDataProduct(makeReq) {
+    return (table, row, activateParams,dataTypeHint='') => {
+        if (!hasRowAccess(table, row)) return Promise.resolve(dpdtMessage('You do not have access to this data.'));
+        const retVal= makeReq(table, row, true);
+        const r= (retVal && retVal.single) ? retVal.single : retVal;
+        const extDP= fileExtensionSingleProductAnalysis(r,); //todo
+        if (extDP) return Promise.resolve(extDP);
+        const retPromise= doUploadAndAnalysis({table,row,request:r,activateParams,dataTypeHint});
+        return Promise.resolve(dpdtWorkingPromise(ANALYZING_MSG,retPromise,r));
+    };
+}
+
+
+function fileExtensionSingleProductAnalysis(request,name, idx=0) {
+
+    const url= request.getURL();
+    if (!url) return undefined;
+    let ext='';
+    const i = url.lastIndexOf('.');
+    if (i > 0 &&  i < url.length - 1) ext = url.substring(i+1).toLowerCase();
+
+    if (ext.includes('tar')) {
+        return dpdtMessageWithDownload('Cannot not display TAR file, you may only download it', 'Download TAR File', url);
+    }
+    else if (ext.includes('pdf')) {
+        return dpdtMessageWithDownload('Cannot not display PDF file, you may only download it', 'Download PDF File', url);
+    }
+    else if (ext.includes('jpeg') || ext.includes('png') || ext.includes('jpg') || ext.includes('gig')) {
+        return dpdtPNG('Show PNG image',url,'dlt-'+idx);
+    }
+    return undefined;
+}
+
+
+/**
+ * make a activate function for file analysis
+ * @param table
+ * @param row
+ * @param request
+ * @param positionWP
+ * @param activateParams
+ * @param menu
+ * @param menuKey
+ * @param dataTypeHint
+ * @return {function}
+ */
+export function makeFileAnalysisActivate(table, row, request, positionWP, activateParams, menu, menuKey, dataTypeHint) {
+    return () => {
+        doUploadAndAnalysis({
+            table,row,request,activateParams,dataTypeHint,menu,menuKey, activateFirst:true,dispatchWorkingMessage:true });
+    };
+}
+
+/**
+ *
+ * Returns a callback function or a Promise<DataProductsDisplayType>.
+ * callback: function(table:TableModel, plotRows:Array.<Object>,activeParams:{imageViewerId:String,chartViewId:String,tableViewId:String,converterId:String})
+ * @param makeReq
+ * @return {function | promise}
+ */
+export function makeAnalysisGetGridDataProduct(makeReq) {
+    return (table, plotRows, activateParams) => {
+
+        const {imageViewerId, converterId}= activateParams;
+
+        const highlightedPlotRow= plotRows.find( (r) => r.row===table.highlightedRow);
+        const highlightedId= highlightedPlotRow && highlightedPlotRow.plotId;
+
+        const reqAry= plotRows.map( (pR) => {
+                const r = makeReq(table, pR.row, true);
+                if (!r || !r.single) return;
+                r.single.setPlotId(pR.plotId);
+                r.single.setAttributes({
+                    [PlotAttribute.DATALINK_TABLE_ROW]: pR.row + '',
+                    [PlotAttribute.DATALINK_TABLE_ID]: table.tbl_id
+                });
+                return r.single;
+            })
+            .filter( (r) => r);
+
+
+        const promiseAry= reqAry.map( (r) => {
+            return doUploadAndAnalysis({table,request:r,activateParams})
+                .then( (result) => gridEntryHasImages(result.fileMenu.fileAnalysis) && r);
+        });
+
+        const retPromise= Promise.all(promiseAry)
+            .then( (reqAry) => {
+                const newReqAry= reqAry.filter( (r) => r);
+                if (newReqAry.length && newReqAry.find( (r) => r.getPlotId()===highlightedId) ) {
+                    const activate= createGridImagesActivate(newReqAry,imageViewerId,converterId,table.tbl_id,plotRows);
+                    return Promise.resolve( dpdtImage('Image',activate));
+                }
+                else {
+                    return Promise.resolve( dpdtMessage('This product cannot be show in image grid',undefined, {gridNotSupported: true} ));
+                }
+            })
+            .catch( (e) => {
+                return makeErrorResult();
+            });
+
+        return Promise.resolve(dpdtWorkingPromise(ANALYZING_MSG,retPromise));
+    };
+}
+
+
+
+const parseAnalysis= (serverCacheFileKey, analysisResult) =>
+                            serverCacheFileKey && analysisResult && JSON.parse(analysisResult);
+
+
+/**
+ *
+ * @param obj
+ * @param obj.table
+ * @param obj.row
+ * @param obj.request
+ * @param obj.activateParams
+ * @param obj.dataTypeHint
+ * @param obj.menu
+ * @param obj.menuKey
+ * @param obj.activateFirst
+ * @param obj.dispatchWorkingMessage
+ * @return {Promise.<DataProductsDisplayType>}
+ */
+function doUploadAndAnalysis({
+                                 table,
+                                 row,
+                                 request,
+                                 activateParams={},
+                                 dataTypeHint='',
+                                 menu=undefined,
+                                 menuKey= undefined,
+                                 activateFirst=false,
+                                 dispatchWorkingMessage= false
+                             }) {
+
+    const {dpId}= activateParams;
+    const cacheKey= hashCode(request.toString());
+
+
+    const processAndActivate= (serverCacheFileKey, fileFormat, fileAnalysis) => {
+        const {parts,fileName}= fileAnalysis;
+        if (!parts || fileFormat==='UNKNOWN') return makeErrorResult('Could not parse file',fileName,serverCacheFileKey);
+
+        const result= processAnalysisResult({ table, row, request, activateParams, serverCacheFileKey, fileAnalysis, dataTypeHint });
+        activateFirst  && dispatchActivateFileMenuItem({dpId,fileMenu:result.fileMenu,menu,currentMenuKey:menuKey});
+        return result;
+    };
+
+    if (uploadedCache[cacheKey]) {
+        const {serverCacheFileKey, fileFormat, fileAnalysis}= uploadedCache[cacheKey];
+        const result= processAndActivate(serverCacheFileKey, fileFormat, fileAnalysis);
+        return Promise.resolve(result);
+    }
+
+    if (dispatchWorkingMessage) dispatchUpdateDataProducts(dpId, dpdtWorkingMessage(ANALYZING_MSG,request,{menuKey}));
+    const url= request.getURL();
+
+    url && dispatchAddActionWatcher({ id: url, actions:[ImagePlotCntlr.PLOT_PROGRESS_UPDATE],
+        callback:watchForUploadUpdate, params:{url,dpId}});
+
+    return doUpload(undefined, {fileAnalysis:'Details',webPlotRequest:request.toString()})
+        .then(({status, message, cacheKey:serverCacheFileKey, fileFormat, analysisResult}) => {
+            url && dispatchCancelActionWatcher(url);
+            const fileAnalysis= parseAnalysis(serverCacheFileKey, analysisResult);
+            if (fileAnalysis) uploadedCache[cacheKey]= {serverCacheFileKey,fileFormat,fileAnalysis};
+            return processAndActivate(serverCacheFileKey, fileFormat, fileAnalysis);
+        })
+        .catch( (e) => {
+            url && dispatchCancelActionWatcher(url);
+            console.log('Call to Upload failed', e);
+            dispatchUpdateDataProducts(dpId, makeErrorResult(e.message));
+        });
+
+}
+
+function watchForUploadUpdate(action, cancelSelf, {url,dpId}) {
+    const {requestKey,message}= action.payload;
+    const d= getDataProducts(dataProductRoot(),dpId);
+    if (!d || !d.displayType || !d.rootMessage || !d.isWorkingState || url!==requestKey) return;
+    dispatchUpdateDataProducts(dpId,{...d, message: `${d.rootMessage} - ${message}`});
+}
+
+
+const gridEntryHasImages= (fileAnalysis) => fileAnalysis.parts.find( (p) => p.type===FileAnalysisType.Image);
+
+function makeErrorResult(message, fileName,url) {
+    return dpdtMessageWithDownload(`No displayable data available for this row${message?': '+message:''}`, fileName&&'Download: '+fileName, url);
+}
+
+/**
+ *
+ * @param obj
+ * @param obj.table
+ * @param obj.row
+ * @param obj.request
+ * @param obj.activateParams
+ * @param obj.serverCacheFileKey
+ * @param obj.fileAnalysis
+ * @param obj.dataTypeHint
+ * @return {DataProductsDisplayType}
+ */
+function processAnalysisResult({table, row, request, activateParams, serverCacheFileKey, fileAnalysis, dataTypeHint}) {
+
+
+    const {imageViewerId, converterId, dpId}= activateParams;
+    const rStr= request.toString();
+    const activeItemLookupKey= hashCode(rStr);
+
+
+    const {parts,fileName,fileFormat, filePath}= fileAnalysis;
+    if (!parts) return makeErrorResult('',fileName,serverCacheFileKey);
+
+
+    const fileMenu= {fileAnalysis, menu:[],activeItemLookupKey, activeItemLookupKeyOrigin:rStr};
+
+    const url= request.getURL() || serverCacheFileKey;
+    if (fileFormat===FileAnalysisType.PDF) {
+        return dpdtMessageWithDownload('Cannot not display PDF file, you may only download it', 'Download PDF File', url);
+    }
+    if (fileFormat===FileAnalysisType.TAR) {
+        return dpdtMessageWithDownload('Cannot not display Tar file, you may only download it', 'Download Tar File', url);
+    }
+
+
+
+    const partAnalysis= parts.map( (p) => analyzePart(p,fileFormat, serverCacheFileKey,activateParams));
+    const hasImages= Boolean(partAnalysis.find( (pa) => pa.isImage));
+
+
+    const imageEntry= hasImages &&
+        dpdtImage('Image Data', createSingleImageActivate(request,imageViewerId,converterId,table.tbl_id,row),'image-'+0, {request});
+
+
+    if (imageEntry) fileMenu.menu.push(imageEntry);
+    partAnalysis.forEach( (pa) => {
+        pa.tableResult && fileMenu.menu.push(pa.tableResult);
+        pa.chartResult && fileMenu.menu.push(pa.chartResult);
+    });
+
+
+    fileMenu.menu= arrangeAnalysisMenu(fileMenu.menu,parts,fileFormat, dataTypeHint);
+
+
+    fileMenu.menu.forEach( (m,idx) => m.menuKey= 'fm-'+idx);
+
+    let actIdx=0;
+    if (fileMenu.menu.length) {
+        const lastActiveFieldItem= getActiveFileMenuKeyByKey(dpId,activeItemLookupKey);
+        actIdx= fileMenu.menu.findIndex( (m) => m.menuKey===lastActiveFieldItem);
+        if (actIdx<0) actIdx= 0;
+    }
+    else {// error case
+        const dp= dpdtMessage(makeErrorMsg(parts,fileFormat),undefined,{menuKey:'fm-0',name:'failed to load'});
+        fileMenu.menu= [dp,dpdtDownload('Download FITS File',serverCacheFileKey,'fm-1')];
+    }
+    dispatchUpdateActiveKey({dpId, activeFileMenuKeyChanges:{[fileMenu.activeItemLookupKey]:fileMenu.menu[actIdx].menuKey}});
+    return {...fileMenu.menu[actIdx],fileMenu};
+}
+
+
+
+function makeErrorMsg(parts, fileFormat) {
+    if (parts.every( (p) => p.type===FileAnalysisType.HeaderOnly) && fileFormat==='FITS') {
+        return 'You may only download this File - Nothing to display - FITS file has only header HDUs';
+    }
+    else {
+        return 'Cannot analyze file';
+    }
+}
+
+

--- a/src/firefly/js/metaConvert/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/ObsCoreConverter.js
@@ -60,14 +60,14 @@ export function makeObsCoreConverter(table,converterTemplate) {
 export function getObsCoreGridDataProduct(table, plotRows, activateParams) {
     const pAry= plotRows.map( (pR) => getObsCoreSingleDataProduct(table,pR.row,activateParams,false));
     return Promise.all(pAry).then ( (resultAry) => {
-        const {imageViewerId, converterId}= activateParams;
+        const {imageViewerId}= activateParams;
         const requestAry= resultAry
             .filter( (result) => result && result.request && (
                 result.displayType===DPtypes.IMAGE ||
                 result.displayType===DPtypes.PROMISE ||
                 result.displayType===DPtypes.ANALYZE) )
             .map( (result) => result.request);
-        const activate= createGridImagesActivate(requestAry,imageViewerId,converterId, table.tbl_id, plotRows);
+        const activate= createGridImagesActivate(requestAry,imageViewerId, table.tbl_id, plotRows);
         return dpdtImage('image grid', activate,'image-grid-0',{requestAry});
     });
 }

--- a/src/firefly/js/metaConvert/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/ObsCoreConverter.js
@@ -3,20 +3,19 @@ import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
 import {getCellValue, doFetchTable, hasRowAccess} from '../tables/TableUtil.js';
 import {getObsCoreAccessURL, getObsCoreProdType} from '../util/VOAnalyzer.js';
 import {
-    findTableCenterColumns,
-    getDataLinkAccessUrls,
     getObsCoreProdTypeCol,
     isFormatDataLink,
-    isFormatVoTable
+    isFormatVoTable,
+    makeWorldPtUsingCenterColumns
 } from '../util/VOAnalyzer';
 import {makeFileRequest} from '../tables/TableRequestUtil';
 import {ZoomType} from '../visualize/ZoomType.js';
-import {makeWorldPt} from '../visualize/Point.js';
-import {createGridImagesActivate, createSingleImageActivate} from './ImageDataProductsUtil.js';
-import {dispatchTableSearch} from '../tables/TablesCntlr';
+import {createGridImagesActivate} from './ImageDataProductsUtil.js';
+import {makeAnalysisGetSingleDataProduct} from './MultiProductFileAnalyzer';
+import { dpdtImage, dpdtMessage, dpdtMessageWithDownload, DPtypes, } from './DataProductsType';
+import {createGuessDataType, processDatalinkTable} from './DataLinkProcessor';
 
 const GIG= 1048576 * 1024;
-const previewTableId= 'OBCORE-TBL';
 
 /**
  *
@@ -25,234 +24,119 @@ const previewTableId= 'OBCORE-TBL';
  * @return {DataProductsConvertType}
  */
 export function makeObsCoreConverter(table,converterTemplate) {
-    const ret= {...converterTemplate, converterId: `ObsCore-${table.tbl_id}`};
-    ret.hasRelatedBands= false;
+    const baseRetOb= {...converterTemplate,
+        canGrid:false, maxPlots:1, hasRelatedBands:false, converterId: `ObsCore-${table.tbl_id}`};
 
     const propTypeCol= getObsCoreProdTypeCol(table);
     if (propTypeCol.enumVals) {
         const pTypes= propTypeCol.enumVals.split(',');
         if (pTypes.every( (s) => s.toLocaleLowerCase()==='image' || s.toLocaleLowerCase()==='cube')) {
-            ret.canGrid= true;
-            ret.maxPlots= 8;
-            return ret;
+            return {...baseRetOb, canGrid:true,maxPlots:8};
         }
     }
-    const filters= get(table, 'request.filters');
-    if (filters) {
-        const fList= filters.split(';');
+
+    if (get(table, 'request.filters')) {
+        const fList= table.request.filters.split(';');
         const pTFilter= fList.find( (f) => f.includes(propTypeCol.name) && f.includes('IN'));
         if (pTFilter) {
             const inList=  pTFilter.substring( pTFilter.indexOf('(')+1, pTFilter.indexOf(')')).split(',');
             if (inList.every( (s) => s.toLocaleLowerCase()==='\'image\'' || s.toLocaleLowerCase()==='\'cube\'')) {
-                ret.canGrid= true;
-                ret.maxPlots= 8;
-                return ret;
+                return {...baseRetOb, canGrid:true,maxPlots:8};
             }
         }
     }
 
-    ret.canGrid= false;
-    ret.maxPlots= 1;
-
-    return ret;
+    return baseRetOb;
 }
 
 
-
+/**
+ *
+ * @param table
+ * @param plotRows
+ * @param activateParams
+ * @return {Promise.<DataProductsDisplayType>}
+ */
 export function getObsCoreGridDataProduct(table, plotRows, activateParams) {
     const pAry= plotRows.map( (pR) => getObsCoreSingleDataProduct(table,pR.row,activateParams,false));
     return Promise.all(pAry).then ( (resultAry) => {
         const {imageViewerId, converterId}= activateParams;
         const requestAry= resultAry
-            .filter( (result) => result && result.displayType==='images')
+            .filter( (result) => result && result.request && (
+                result.displayType===DPtypes.IMAGE ||
+                result.displayType===DPtypes.PROMISE ||
+                result.displayType===DPtypes.ANALYZE) )
             .map( (result) => result.request);
         const activate= createGridImagesActivate(requestAry,imageViewerId,converterId, table.tbl_id, plotRows);
-        return { displayType:'images', activate, requestAry, menu:undefined};
+        return dpdtImage('image grid', activate,'image-grid-0',{requestAry});
     });
 }
 
 
-
 /**
- *  Support data the we don't know about
+ * Support ObsCore single product
  * @param table
  * @param row
  * @param {ActivateParams} activateParams
- * @param {boolean} includeMenu - if true the build a menu if possible
- * @return {{}}
+ * @param {boolean} doFileAnalysis - if true the build a menu if possible
+ * @return {Promise.<DataProductsDisplayType>}
  */
-export function getObsCoreSingleDataProduct(table, row, activateParams, includeMenu= true) {
+export function getObsCoreSingleDataProduct(table, row, activateParams, doFileAnalysis= true) {
 
+    const {size,titleStr,dataSource,prodType,isVoTable,isDataLink}= getObsCoreRowMetaInfo(table,row);
+
+    if (!dataSource || (isVoTable && !isDataLink)) return Promise.resolve(dpdtMessage(`${prodType} is not supported`));
+    if (!hasRowAccess(table, row)) return Promise.resolve(dpdtMessage('You do not have access to these data.'));
+
+
+    const positionWP= makeWorldPtUsingCenterColumns(table,row);
+
+    if (isDataLink) {
+        return doFetchTable(makeFileRequest('dl table', dataSource))
+            .then( (datalinkTable) =>
+                processDatalinkTable(table,row,datalinkTable,positionWP,activateParams,titleStr, makeObsCoreRequest, doFileAnalysis) )
+            .catch( (reason) =>
+                dpdtMessageWithDownload(`No data to display: Could not retrieve datalink data, ${reason}`, 'Download File: '+titleStr, dataSource)
+        );
+    }
+    else {
+        if (size>GIG) return Promise.resolve(dpdtMessageWithDownload('Data is too large to load', 'Download File: '+titleStr, dataSource));
+        return doFileAnalysis ?
+            makeAnalysisGetSingleDataProduct(() => makeObsCoreRequest(dataSource, positionWP, titleStr))(table,row,activateParams,prodType) :
+            createGuessDataType(titleStr,'guess-0',dataSource,prodType,makeObsCoreRequest,undefined,activateParams, positionWP,table,row,size);
+    }
+}
+
+
+
+function getObsCoreRowMetaInfo(table,row) {
+    if (!table) return {};
     const dataSource= getObsCoreAccessURL(table,row);
     const prodType= (getObsCoreProdType(table,row) || '').toLocaleLowerCase();
-    const imageType= prodType.includes('image') || prodType.includes('cube');
-    const tableType= prodType.includes('spectrum');
-    const canHandleProdType= imageType || tableType;
     const isVoTable= isFormatVoTable(table, row);
     const isDataLink= isFormatDataLink(table,row);
-
-    if (!dataSource || (isVoTable && !isDataLink)) {
-        return Promise.resolve({displayType:'message', message: prodType +' is not yet supported'});
-    }
-
-    if (!hasRowAccess(table, row)) {
-        return Promise.resolve({displayType:'message', message: 'You do not have access to these data.'});
-    }
-
-    let obsCollect= getCellValue(table,row,'obs_collection') || '';
     const iName= getCellValue(table,row,'instrument_name') || '';
     const obsId= getCellValue(table,row,'obs_id') || '';
     const size= Number(getCellValue(table,row,'access_estsize')) || 0;
+    let obsCollect= getCellValue(table,row,'obs_collection') || '';
     if (obsCollect===iName) obsCollect= '';
 
     const titleStr= `${obsCollect?obsCollect+', ':''}${iName?iName+', ':''}${obsId}`;
-
-    const cen= findTableCenterColumns(table);
-    const positionWP= cen && makeWorldPt(getCellValue(table,row,cen.lonCol), getCellValue(table,row,cen.latCol), cen.csys);
-
-    if (isDataLink) {
-        const tableReq= makeFileRequest('no title', dataSource, { startIdx : 0, pageSize : 1000});
-
-        return doFetchTable(tableReq).then(
-            (datalinkTable) => {
-                const dataLinkData= getDataLinkAccessUrls(table, datalinkTable);
-                const menu=  includeMenu && dataLinkData.length>2 ? createMenuRet(dataLinkData,positionWP, table, row, activateParams) : undefined;
-                const filterDLData= dataLinkData
-                    .filter(({contentType,size}) => {
-                        return (contentType.toLowerCase().includes('fits') && (size<=GIG));
-                    });
-
-                if (!filterDLData.length) {
-                    if (dataLinkData.length>0) {
-                        return {
-                            displayType: 'message', message: 'No displayable data available for this row',
-                            menu: [
-                                {
-                                    name: 'Show Datalink VO Table for list of products',
-                                    type: 'table',
-                                    activate: createTableActivate(dataSource,'Datalink VO Table', activateParams),
-                                    url: dataSource
-                                },
-                                {
-                                    name: 'Download Datalink VO Table for list of products',
-                                    type: 'download',
-                                    url: dataSource
-                                },
-                            ]
-                        };
-                    }
-                    else {
-                        return {displayType: 'message', message : 'No data available for this row'};
-                    }
-                }
-                let idx= filterDLData.findIndex( (item) => item.semantics.includes('this'));
-                if (idx<0) idx= 0;
-
-                const canHandle= filterDLData[idx].contentType.toLowerCase().includes('fits');
-                if (!canHandle) {
-                    return {displayType: 'message', message: filterDLData[idx].contentType+' is not yet supported', menu};
-                }
-                const req= makeObsCoreRequest(filterDLData[idx].url,positionWP,titleStr);
-                return makeObsCoreImageDisplayType(req,table,row,menu,activateParams);
-
-            }
-        ).catch(
-            (reason) => {
-                console.warn(`Failed to catalog plot data: ${reason}`, reason);
-            }
-        );
-
-    }
-    else {
-        let retVal;
-        if (imageType) {
-            if (size<GIG) {
-                const req= makeObsCoreRequest(dataSource,positionWP,titleStr);
-                retVal= makeObsCoreImageDisplayType(req,table,row,undefined,activateParams);
-            }
-            else {
-                retVal= {
-                    displayType: 'message',
-                    message : 'Image data is too large to load',
-                    menu : [ { name: 'Download FITS: '+titleStr + ' (too large to show)', type : 'download', url : dataSource} ]
-                };
-            }
-        }
-        else if (tableType) {
-            retVal= {displayType:'table', menu:undefined, activate: createTableActivate(dataSource,titleStr, activateParams)};
-        }
-        else {
-            retVal= {
-                displayType: 'message',
-                message: prodType +' is not yet supported',
-                menu : [ { name: 'Download File: '+titleStr , type : 'download', url : dataSource} ]
-            };
-        }
-        return Promise.resolve(retVal);
-    }
+    return {iName,obsId,size,titleStr,dataSource,prodType,isVoTable,isDataLink};
 }
 
 
-function makeName(s='', url, auxTot, autCnt) {
-    let name= s==='#this' ? 'Primary product (#this)' : s;
-    name= name[0]==='#' ? name.substring(1) : name;
-    name= (name==='auxiliary' && auxTot>1) ? `${name}: ${autCnt}` : name;
-    return name || url;
-}
-
-function createMenuRet(dataLinkData, positionWP, table, row, activateParams) {
-    const {imageViewerId, converterId}= activateParams;
-    const auxTot= dataLinkData.filter( (e) => e.semantics==='#auxiliary').length;
-    let auxCnt=0;
-    const originalMenu= dataLinkData.reduce( (resultAry,e) => {
-        const ct= e.contentType.toLowerCase();
-        const name= makeName(e.semantics, e.url, auxTot, auxCnt);
-        if (ct.includes('fits') || ct.includes('cube')) {
-            if (e.size<GIG) {
-                const request= makeObsCoreRequest(e.url,positionWP,e.semantics);
-                resultAry.push( {
-                    name: 'Show FITS Image: '+name,
-                    type : 'image',
-                    request,
-                    url: e.url,
-                    activate : createSingleImageActivate(request,imageViewerId,converterId,table.tbl_id,row),
-                    semantics: e.semantics
-                });
-            }
-            else {
-                resultAry.push( { name: 'Download FITS: '+name + '(too large to show)', type : 'download', url : e.url , semantics: e.semantics });
-            }
-        }
-        if (ct.includes('table') || ct.includes('spectrum') || e.semantics.includes('auxiliary')) {
-            resultAry.push( { name: 'Show Table: ' + name, type : 'table', url: e.url, semantics: e.semantics,
-                activate: createTableActivate(e.url, e.semantics, activateParams)});
-        }
-        if (ct.includes('jpeg') || ct.includes('png') || ct.includes('jpg') || ct.includes('gig')) {
-            resultAry.push({ name: 'Show PNG image: '+name, type : 'png', url : e.url, semantics: e.semantics  });
-        }
-        if (ct.includes('tar')|| ct.includes('gz')) {
-            resultAry.push({ name: 'Download file: '+name, type : 'download', url : e.url , semantics: e.semantics });
-        }
-        if (e.semantics==='#auxiliary') auxCnt++;
-        return resultAry;
-    }, []);
-
-    return originalMenu.sort((s1,s2) => s1.semantics==='#this' ? -1 : 0);
-
-
-}
-
-function makeObsCoreImageDisplayType(request, table, row, menu, activateParams) {
-    const {imageViewerId, converterId}= activateParams;
-    const activate= createSingleImageActivate(request,imageViewerId,converterId,table.tbl_id,row);
-    return { displayType:'images', activate, request, menu};
-}
-
-
+/**
+ *
+ * @param dataSource
+ * @param positionWP
+ * @param titleStr
+ * @return {undefined|WebPlotRequest}
+ */
 function makeObsCoreRequest(dataSource, positionWP, titleStr) {
-    if (!dataSource) return null;
+    if (!dataSource) return undefined;
 
-    const r = WebPlotRequest.makeURLPlotRequest(dataSource, 'Fits Image');
+    const r = WebPlotRequest.makeURLPlotRequest(dataSource, 'DataProduct');
     r.setZoomType(ZoomType.FULL_SCREEN);
     if (titleStr.length>7) {
         r.setTitleOptions(TitleOptions.NONE);
@@ -265,21 +149,4 @@ function makeObsCoreRequest(dataSource, positionWP, titleStr) {
     if (positionWP) r.setOverlayPosition(positionWP);
 
     return r;
-}
-
-
-function createTableActivate(url, titleStr, activateParams) {
-    return () => {
-        const {tableGroupViewerId}= activateParams;
-        const dataTableReq= makeFileRequest(titleStr, url, undefined, { tbl_id:previewTableId, startIdx : 0, pageSize : 100});
-        dispatchTableSearch(dataTableReq,
-            {
-                noHistory: true,
-                removable:false,
-                tbl_group: tableGroupViewerId,
-                backgroundable: false,
-                showFilters: true,
-                showInfoButton: true
-            });
-    };
 }

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -19,6 +19,7 @@ export function analyzePart(part, fileFormat, serverCacheFileKey, activateParams
 
     return {
         isImage: availableTypes.includes(DPtypes.IMAGE) && type===FileAnalysisType.Image,
+        imageSingleAxis:availableTypes.includes(DPtypes.IMAGE_SNGLE_AXIS),
         tableResult,
         chartResult
     };
@@ -79,7 +80,14 @@ export function arrangeAnalysisMenu(menu,parts,fileFormat, dataTypeHint) {
 function findAvailableTypesForAnalysisPart(part, fileFormat) {
     const {type}= part;
     if (type===FileAnalysisType.HeaderOnly || type===FileAnalysisType.Unknown) return [];
-    if (type===FileAnalysisType.Image) return [DPtypes.IMAGE];
+    if (type===FileAnalysisType.Image) {
+        const naxisRow= part.details.tableData.data.find( (h) => h[1]==='NAXIS');
+        if (naxisRow && naxisRow[2]) {
+            const naxis= Number(naxisRow[2]);
+            return naxis===1 ?[DPtypes.IMAGE_SNGLE_AXIS] :[DPtypes.IMAGE]
+        }
+        return [DPtypes.IMAGE];
+    }
     return [DPtypes.CHART,DPtypes.TABLE];
 }
 

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -1,0 +1,158 @@
+import {dpdtChart, dpdtChartTable, dpdtTable, DPtypes} from './DataProductsType';
+import {FileAnalysisType} from '../data/FileAnalysis';
+import {createChartActivate, createTableActivate} from './converterUtils';
+
+
+
+
+
+export function analyzePart(part, fileFormat, serverCacheFileKey, activateParams) {
+
+    const {type,desc, index}= part;
+    const availableTypes= findAvailableTypesForAnalysisPart(part, fileFormat);
+
+    const chartResult= availableTypes.includes(DPtypes.CHART) && analyzeChartResult(part, fileFormat, serverCacheFileKey,desc,activateParams,index);
+    const tableResult=
+        availableTypes.includes(DPtypes.TABLE) &&
+        (!chartResult || chartResult.displayType!==DPtypes.CHART_TABLE) &&
+        analyzeTableResult(part, fileFormat, serverCacheFileKey,desc,activateParams,index,chartResult);
+
+    return {
+        isImage: availableTypes.includes(DPtypes.IMAGE) && type===FileAnalysisType.Image,
+        tableResult,
+        chartResult
+    };
+}
+
+// todo
+// todo - add intelligence here
+//     - how can this be done on an application specific basis?
+//     - probably needs to be an injection point
+// todo
+/**
+ * Arrange the order of the menu array so that is show the most important stuff on the top
+ * @param menu
+ * @param parts
+ * @param fileFormat
+ * @param dataTypeHint
+ * @return {Array}
+ */
+export function arrangeAnalysisMenu(menu,parts,fileFormat, dataTypeHint) {
+    const imageEntry= menu.find( (m) => m.displayType===DPtypes.IMAGE);
+    if (imageEntry) {
+        menu= menu.filter( (m) => m.displayType!==DPtypes.IMAGE);
+    }
+
+    switch (dataTypeHint) {
+        case 'timeseries':
+            imageEntry && menu.push(imageEntry);
+            break;
+        case 'spectrum':
+            const chartList= menu.filter( (m) => m.displayType===DPtypes.CHART);
+            const noCharts= menu.filter( (m) => m.displayType!==DPtypes.CHART);
+            if (chartList.length) {
+                menu= [...chartList,...noCharts];
+                imageEntry && menu.push(imageEntry);
+            }
+            else {
+                imageEntry && menu.unshift(imageEntry);
+            }
+            break;
+        default:
+            imageEntry && menu.unshift(imageEntry);
+            break;
+    }
+    return menu;
+}
+
+// todo
+// todo - add intelligence here
+//      - how can this be done on an application specific basis?
+//      - probably needs to be an injection point
+// todo
+/**
+ * Determine what type of displays are available for this part
+ * @param part
+ * @param fileFormat
+ * @return {Array.<DPtypes>}
+ */
+function findAvailableTypesForAnalysisPart(part, fileFormat) {
+    const {type}= part;
+    if (type===FileAnalysisType.HeaderOnly || type===FileAnalysisType.Unknown) return [];
+    if (type===FileAnalysisType.Image) return [DPtypes.IMAGE];
+    return [DPtypes.CHART,DPtypes.TABLE];
+}
+
+
+
+
+const C_COL1= ['WAVE'];
+const C_COL2= ['FLUX'];
+
+
+// todo
+// todo - add intelligence here
+//      - how can this be done on an application specific basis?
+//      - probably needs to be an injection point
+// todo
+/**
+ *
+ * @param part
+ * @param fileFormat
+ * @param serverCacheFileKey
+ * @param title
+ * @param activateParams
+ * @param tbl_index
+ * @return {DataProductsDisplayType}
+ */
+function analyzeChartResult(part, fileFormat, serverCacheFileKey, title, activateParams, tbl_index) {
+    if (part.type!==FileAnalysisType.Table) return;
+    if (part.details.totalRows<3) return;
+    const cNames= getColumnNames(part,fileFormat);
+    if (!cNames || cNames.length<2) return;
+    const xCol= cNames.find( (c) => C_COL1.includes(c));
+    const yCol= cNames.find( (c) => C_COL2.includes(c));
+    if (!xCol || !yCol) return;
+
+    //note - based on analysis this could also just call a dpdtChart() function
+
+    return dpdtChartTable('Chart or Table: ' +title,
+        createChartActivate(serverCacheFileKey,title,activateParams,xCol,yCol,tbl_index,false),
+        undefined, {paIdx:tbl_index});
+}
+
+
+/**
+ *
+ * @param part
+ * @param fileFormat
+ * @param serverCacheFileKey
+ * @param title
+ * @param activateParams
+ * @param tbl_index
+ * @return {DataProductsDisplayType}
+ */
+function analyzeTableResult(part, fileFormat, serverCacheFileKey,title, activateParams, tbl_index) {
+    return dpdtTable('Table: ' +title, createTableActivate(serverCacheFileKey,title,activateParams,tbl_index,true),
+        undefined, {paIdx:tbl_index});
+}
+
+
+
+
+
+//todo
+//todo - add intelligence here
+//     - currently only supports fits / needs to support VO
+//     - maybe cvs and tsv?
+//todo
+function getColumnNames(part, fileFormat) {
+    if (fileFormat==='FITS') {
+        return part.details.tableData.data
+            .filter( (row) => row[1].includes('TTYPE'))
+            .map( (row) => row[2]);
+    }
+    else { //todo support more file formats
+        return;
+    }
+}

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -1,11 +1,34 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {get} from 'lodash';
 import {dpdtChart, dpdtChartTable, dpdtTable, DPtypes} from './DataProductsType';
 import {FileAnalysisType} from '../data/FileAnalysis';
-import {createChartActivate, createTableActivate} from './converterUtils';
+import {createChartActivate, createChartSingleRowArrayActivate, createTableActivate} from './converterUtils';
 
 
 
 
+// todo
+// todo - PartAnalyzer will eventually need to have some injected analysis
+//      - We should do this as we better understand the need
+// todo
 
+
+
+
+/**
+ *
+ * @param part
+ * @param fileFormat
+ * @param serverCacheFileKey
+ * @param activateParams
+ * @return {{imageSingleAxis: boolean,
+ *           isImage: boolean,
+ *           tableResult: DataProductsDisplayType|Array.<DataProductsDisplayType>|undefined,
+ *           chartResult: DataProductsDisplayType|Array.<DataProductsDisplayType>|undefined}}
+ */
 export function analyzePart(part, fileFormat, serverCacheFileKey, activateParams) {
 
     const {type,desc, index}= part;
@@ -25,11 +48,7 @@ export function analyzePart(part, fileFormat, serverCacheFileKey, activateParams
     };
 }
 
-// todo
-// todo - add intelligence here
-//     - how can this be done on an application specific basis?
-//     - probably needs to be an injection point
-// todo
+// todo - arrangeAnalysisMenu needs to have injection point for application specific analysis
 /**
  * Arrange the order of the menu array so that is show the most important stuff on the top
  * @param menu
@@ -66,43 +85,52 @@ export function arrangeAnalysisMenu(menu,parts,fileFormat, dataTypeHint) {
     return menu;
 }
 
-// todo
-// todo - add intelligence here
-//      - how can this be done on an application specific basis?
-//      - probably needs to be an injection point
-// todo
+// todo - findAvailableTypesForAnalysisPart needs to have injection point for application specific analysis
 /**
  * Determine what type of displays are available for this part
  * @param part
  * @param fileFormat
- * @return {Array.<DPtypes>}
+ * @return {Array.<String>} return an array of DPTypes string const
  */
 function findAvailableTypesForAnalysisPart(part, fileFormat) {
     const {type}= part;
     if (type===FileAnalysisType.HeaderOnly || type===FileAnalysisType.Unknown) return [];
-    if (type===FileAnalysisType.Image) {
-        const naxisRow= part.details.tableData.data.find( (h) => h[1]==='NAXIS');
-        if (naxisRow && naxisRow[2]) {
-            const naxis= Number(naxisRow[2]);
-            return naxis===1 ?[DPtypes.IMAGE_SNGLE_AXIS] :[DPtypes.IMAGE]
-        }
-        return [DPtypes.IMAGE];
-    }
-    return [DPtypes.CHART,DPtypes.TABLE];
+    if (type!==FileAnalysisType.Image || fileFormat!=='FITS' || is1DImage(part)) return [DPtypes.CHART,DPtypes.TABLE];
+    return (imageCouldBeTable(part)) ? [DPtypes.IMAGE,DPtypes.TABLE,DPtypes.CHART] : [DPtypes.IMAGE];
 }
 
 
+function imageCouldBeTable(part) {
+    const naxis= getIntHeader('NAXIS',part,0);
+    if (naxis<1) return false;
+    const naxisAry= [];
+    for(let i=0; i<naxis;i++) naxisAry[i]= getIntHeader(`NAXIS${i+1}`,part,0);
+    if (naxis===1) return true;
+    else if (naxis===2) return naxisAry[1]<=30;
+    else {
+        let couldBeTable= true;
+        for(let i=2; (i<naxis);i++) if (naxisAry[i]>1) couldBeTable= false;
+        return couldBeTable;
+    }
+}
+
+function is1DImage(part) {
+    const naxis= getIntHeader('NAXIS',part,0);
+    if (naxis<1) return false;
+    const naxisAry= [];
+    for(let i=0; i<naxis;i++) naxisAry[i]= getIntHeader(`NAXIS${i+1}`,part,0);
+    if (naxis===1) return true;
+    let is1DImage= true;
+    for(let i=1; (i<naxis);i++) if (naxisAry[i]>1) is1DImage= false;
+    return is1DImage;
+}
 
 
-const C_COL1= ['WAVE'];
-const C_COL2= ['FLUX'];
+const C_COL1= ['index','wave'];
+const C_COL2= ['flux','data','data1','data2'];
 
 
-// todo
-// todo - add intelligence here
-//      - how can this be done on an application specific basis?
-//      - probably needs to be an injection point
-// todo
+// todo - analyzeChartResult needs to have injection point for application specific analysis
 /**
  *
  * @param part
@@ -114,20 +142,47 @@ const C_COL2= ['FLUX'];
  * @return {DataProductsDisplayType}
  */
 function analyzeChartResult(part, fileFormat, serverCacheFileKey, title, activateParams, tbl_index) {
-    if (part.type!==FileAnalysisType.Table) return;
-    if (part.details.totalRows<3) return;
-    const cNames= getColumnNames(part,fileFormat);
-    if (!cNames || cNames.length<2) return;
-    const xCol= cNames.find( (c) => C_COL1.includes(c));
-    const yCol= cNames.find( (c) => C_COL2.includes(c));
-    if (!xCol || !yCol) return;
+    const hduStr= fileFormat==='FITS' ? ` (HDU# ${part.index})` : '';
+    const imageAsTableColCnt= isImageAsTable(part,fileFormat) ? getImageAsTableColCount(part,fileFormat) : 0;
+    const cNames= imageAsTableColCnt ? [] : getColumnNames(part,fileFormat);
+    const rowsTotal= getRowCnt(part,fileFormat);
+    let xCol;
+    let yCol;
+    if (imageAsTableColCnt) {
+        for(let i=0; i<imageAsTableColCnt; i++) cNames.push(i===0?'naxis1_idx': `naxis1_data_${(i-1)}`);
 
-    //note - based on analysis this could also just call a dpdtChart() function
+        xCol= cNames[0];
+        yCol= cNames[1];
+    }
+    else {
+        if (!cNames || cNames.length<2) return;
+        const xCol= cNames.find( (c) => C_COL1.includes(c.toLowerCase()));
+        const yCol= cNames.find( (c) => C_COL2.includes(c.toLowerCase()));
+        if (rowsTotal<1 || !xCol || !yCol) return;
+    }
 
-    return dpdtChartTable('Chart or Table: ' +title,
-        createChartActivate(serverCacheFileKey,title,activateParams,xCol,yCol,tbl_index,false),
-        undefined, {paIdx:tbl_index});
+
+    if (rowsTotal===1) {
+        return dpdtChartTable(`Chart or Table${hduStr}: ` +title,
+            createChartSingleRowArrayActivate(serverCacheFileKey,'Row 1 Chart',activateParams,xCol,yCol,0,tbl_index),
+            undefined, {paIdx:tbl_index});
+    }
+    else if (imageAsTableColCnt===2) {
+        cNames[1]= 'DataLine';
+        return dpdtChartTable(`Chart or Table${hduStr}: ` +title,
+            createChartActivate(serverCacheFileKey,title,activateParams,cNames[0],cNames[1],tbl_index,cNames),
+            undefined, {paIdx:tbl_index});
+
+    }
+    else {
+        const typeTitle= imageAsTableColCnt ?
+            `View image as Chart or Table${hduStr}: ${title}` :`Chart or Table${hduStr}: ${title}`;
+        return dpdtChartTable(typeTitle,
+                createChartActivate(serverCacheFileKey,title,activateParams,xCol,yCol,tbl_index,cNames),
+                undefined, {paIdx:tbl_index});
+    }
 }
+
 
 
 /**
@@ -141,26 +196,99 @@ function analyzeChartResult(part, fileFormat, serverCacheFileKey, title, activat
  * @return {DataProductsDisplayType}
  */
 function analyzeTableResult(part, fileFormat, serverCacheFileKey,title, activateParams, tbl_index) {
-    return dpdtTable('Table: ' +title, createTableActivate(serverCacheFileKey,title,activateParams,tbl_index,true),
+    const hduStr= fileFormat==='FITS' ? ` (HDU# ${part.index})` : '';
+    return dpdtTable(`Table ${hduStr}: ${title}`, createTableActivate(serverCacheFileKey,title,activateParams,tbl_index,false),
         undefined, {paIdx:tbl_index});
 }
 
 
 
+export const getIntHeader= (header, part, def) => {
+    const resultStr= getHeader(header,part);
+    if (!resultStr) return def;
+    const num= Number(resultStr);
+    return isNaN(num) ? def : num;
+};
+
+function getHeadersThatMatch(header, part) {
+    return part.details.tableData.data
+        .filter( (row) => row[1].includes(header))
+        .map( (row) => row[2]);
+}
+
+function getHeadersThatStartsWith(header, part) {
+    return part.details.tableData.data
+        .filter( (row) => row[1].startsWith(header))
+        .map( (row) => row[2]);
+}
+
+export function getHeader(header, part) {
+    const data= get(part,'details.tableData.data');
+    if (!data) return undefined;
+    const foundRow= part.details.tableData.data.find( (row) => row[1].toLowerCase()===header.toLowerCase());
+    return foundRow && foundRow[2];
+}
 
 
-//todo
-//todo - add intelligence here
-//     - currently only supports fits / needs to support VO
-//     - maybe cvs and tsv?
-//todo
+
 function getColumnNames(part, fileFormat) {
     if (fileFormat==='FITS') {
-        return part.details.tableData.data
-            .filter( (row) => row[1].includes('TTYPE'))
-            .map( (row) => row[2]);
+        const naxis= getIntHeader('NAXIS',part);
+        if (naxis===1) {
+            return ['index', 'data'];
+        }
+        else {
+            const ttNamesAry= getHeadersThatStartsWith('TTYPE',part);
+            if (ttNamesAry.length) return ttNamesAry;
+            const naxis2= getIntHeader('NAXIS2',part,0);
+            if (naxis2<=30) {
+                let dynHeaderNames= ['index'];
+                for(let i=0;i<naxis2;i++) dynHeaderNames.push('data'+i);
+                return dynHeaderNames;
+            }
+        }
     }
-    else { //todo support more file formats
-        return;
+    else {
+        return part.details.tableData.data.map( (row) => row[0]);
     }
 }
+
+function isImageAsTable(part, fileFormat) {
+    if (part.type!==FileAnalysisType.Image) return false;
+    if (fileFormat !== 'FITS') return false;
+    if (is1DImage(part)) return true;
+    const naxis = getIntHeader('NAXIS', part);
+    if (naxis!==2) return false;
+    const naxis2= getIntHeader('NAXIS2',part,0);
+    if (naxis2>30) return false;
+    return true;
+}
+
+function getImageAsTableColCount(part, fileFormat) {
+    if (part.type!==FileAnalysisType.Image) return 0;
+    if (fileFormat !== 'FITS') return 0;
+    if (is1DImage(part)) return 2;
+    const naxis = getIntHeader('NAXIS', part);
+    if (naxis!==2) return 0;
+    const naxis2= getIntHeader('NAXIS2',part,0);
+    if (naxis2>30) return 0;
+    return naxis2+1;
+}
+
+
+
+function getRowCnt(part, fileFormat) {
+    if (part.totalTableRows>0) return part.totalTableRows;
+    if (fileFormat==='FITS') {
+        const naxis2= getIntHeader('NAXIS2',part);
+        const naxis1= getIntHeader('NAXIS1',part);
+        const ttNamesAry= getHeadersThatStartsWith('TTYPE',part);
+        if (ttNamesAry.length) {
+            return isNaN(naxis2) ? -1 : naxis2;
+        }
+        else {
+            return isNaN(naxis1) ? -1 : naxis1;
+        }
+    }
+}
+

--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -31,6 +31,7 @@ import {dispatchSetLayoutMode, LO_MODE} from '../../core/LayoutCntlr';
 
 export const COVERAGE_VIEWER_ID = 'CoverageViewerId';
 export const IMAGE_DATA_VIEWER_ID = META_VIEWER_ID;
+export const CHART_DATA_VIEWER_ID = 'ChartDataProducts';
 const META_DATA_TBL_GROUP_ID= 'TableDataProducts';
 
 
@@ -46,7 +47,8 @@ export class HydraViewer extends PureComponent {
 
         dispatchAddSaga(hydraManager);
         startTTFeatureWatchers();
-        hasDataProduct && startDataProductsWatcher({imageViewerId:IMAGE_DATA_VIEWER_ID, tableGroupViewerId:META_DATA_TBL_GROUP_ID});
+        hasDataProduct && startDataProductsWatcher({imageViewerId:IMAGE_DATA_VIEWER_ID, chartViewerId:CHART_DATA_VIEWER_ID,
+            tableGroupViewerId:META_DATA_TBL_GROUP_ID});
         if (hasCoverage) {
             const coverageOps= get(getAppOptions(), 'coverage',{});
             startCoverageWatcher({...coverageOps, viewerId:COVERAGE_VIEWER_ID, ignoreCatalogs:true});

--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -5,7 +5,7 @@
 
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
-import {pickBy, get} from 'lodash';
+import {pickBy} from 'lodash';
 
 import {flux, firefly} from '../../Firefly.js';
 import {dispatchSetMenu, dispatchOnAppReady, getMenu, isAppReady, getSearchInfo} from '../../core/AppDataCntlr.js';
@@ -23,17 +23,10 @@ import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {warningDivId} from '../../ui/LostConnection';
 import {startTTFeatureWatchers} from '../common/ttFeatureWatchers.js';
-import {getAppOptions} from '../../core/AppDataCntlr';
-import {startDataProductsWatcher} from '../../visualize/saga/DataProductsWatcher';
-import {META_VIEWER_ID} from '../../visualize/MultiViewCntlr';
-import {startCoverageWatcher} from '../../visualize/saga/CoverageWatcher';
 import {dispatchSetLayoutMode, LO_MODE} from '../../core/LayoutCntlr';
 
-export const COVERAGE_VIEWER_ID = 'CoverageViewerId';
-export const IMAGE_DATA_VIEWER_ID = META_VIEWER_ID;
-export const CHART_DATA_VIEWER_ID = 'ChartDataProducts';
-const META_DATA_TBL_GROUP_ID= 'TableDataProducts';
 
+export {META_VIEWER_ID as IMAGE_DATA_VIEWER_ID } from '../../visualize/MultiViewCntlr';
 
 /**
  * This is a viewer.
@@ -43,16 +36,9 @@ export class HydraViewer extends PureComponent {
     constructor(props) {
         super(props);
         this.state = this.getNextState();
-        const {hasCoverage=true, hasDataProduct=true} = props;
 
         dispatchAddSaga(hydraManager);
         startTTFeatureWatchers();
-        hasDataProduct && startDataProductsWatcher({imageViewerId:IMAGE_DATA_VIEWER_ID, chartViewerId:CHART_DATA_VIEWER_ID,
-            tableGroupViewerId:META_DATA_TBL_GROUP_ID});
-        if (hasCoverage) {
-            const coverageOps= get(getAppOptions(), 'coverage',{});
-            startCoverageWatcher({...coverageOps, viewerId:COVERAGE_VIEWER_ID, ignoreCatalogs:true});
-        }
     }
 
     getNextState() {
@@ -201,7 +187,7 @@ function showExpandedView ({expanded}) {
             {view}
         </div>
     );
-};
+}
 
 function closeExpanded() {
     dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);

--- a/src/firefly/js/ui/DropDownMenu.jsx
+++ b/src/firefly/js/ui/DropDownMenu.jsx
@@ -1,6 +1,6 @@
 /*eslint "prefer-template": 0*/
 
-import {isFunction} from 'lodash';
+import {isFunction, isArray} from 'lodash';
 import React, {PureComponent} from 'react';
 import {get} from 'lodash';
 import PropTypes from 'prop-types';
@@ -27,13 +27,19 @@ function placeDropDown(e,x,y, beforeVisible) {
 }
 
 
-export function SingleColumnMenu({children}) {
+export function SingleColumnMenu({children, style={}}) {
+
+    const outStyle= (isArray(children) && children.length> 12) ? {overflow: 'auto', maxHeight:500,...style } : style;
     return (
-        <div className='ff-MenuItem-dropDown disable-select'>
+        <div className='ff-MenuItem-dropDown disable-select allow-scroll' style={outStyle}>
             {children}
         </div>
     );
 }
+
+SingleColumnMenu.propTypes= {
+    style: PropTypes.object
+};
 
 
 

--- a/src/firefly/js/ui/DropDownToolbarButton.jsx
+++ b/src/firefly/js/ui/DropDownToolbarButton.jsx
@@ -121,6 +121,7 @@ export class DropDownToolbarButton extends PureComponent {
                      }
                 }
             }
+            const tgt= ev.target;
             e= ev.target;
             const maxBack= 10;
             let clickOnButton= false;
@@ -130,7 +131,10 @@ export class DropDownToolbarButton extends PureComponent {
                    break;
                 }
             }
-            const onDropDownInput= focusIsDropwdownInput && ev && ev.target.tagName==='INPUT';
+            const onDropDownInput= ev &&
+                (focusIsDropwdownInput && tgt.tagName==='INPUT') ||
+                (tgt.tagName==='DIV' && tgt.className && tgt.className.includes('allow-scroll'));
+
             if (!clickOnButton && !onDropDownInput && dropDownOwnerId===this.ownerId) {
                 dispatchHideDialog(DROP_DOWN_KEY);
             }

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -190,7 +190,7 @@ function makeDoUpload(file, type, isFromURL, fileAnalysis) {
  * @returns {Promise.<{Object}>}  The returned object is : {status:string, message:string, cacheKey:string}
  */
 export function doUpload(file, params={}) {
-    if (!file) return Promise.reject('Required file parameter not given');
+    if (!file && !params.webPlotRequest) return Promise.reject('Required file parameter not given');
 
     if (has(params, 'isFromURL') && params.isFromURL) {
         params = Object.assign(params, {URL: file});
@@ -199,10 +199,9 @@ export function doUpload(file, params={}) {
     }
     const options = {method: 'multipart', params};
 
-    if (params.fileAnalysis && isFunction(params.fileAnalysis)) {
-        params.fileAnalysis();
-        options.params.fileAnalysis = true;
-    }
+    const faFunction= isFunction(params.fileAnalysis) && params.fileAnalysis;
+    faFunction && faFunction(true);
+    if (params.fileAnalysis) options.params.fileAnalysis = true;
 
     return fetchUrl(UL_URL, options).then( (response) => {
         return response.text().then( (text) => {
@@ -212,6 +211,7 @@ export function doUpload(file, params={}) {
                 // there are '::' in the analysisReaults.. put it back
                 analysisResult = analysisResult + '::' + rest.join('::');
             }
+            faFunction && faFunction(false);
             return {status, message, cacheKey, analysisResult};
         });
     });

--- a/src/firefly/js/ui/LinkButton.jsx
+++ b/src/firefly/js/ui/LinkButton.jsx
@@ -34,7 +34,7 @@ export function LinkButton({text, tip='$text',style={}, onClick}) {
         <div style={s} title={tip} onClick={onClick}>
 
             <div style={labelStyle} title={tip}>
-                <href>{text}</href>
+                <a>{text}</a>
             </div>
 
         </div>

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -450,6 +450,21 @@ export function download(url, filename) {
         .catch(({message}) => showInfoPopup(truncate(message, {length: 200}), 'Unexpected error'));
 }
 
+
+export function downloadSimple(url) {
+    let nullFrame = document.getElementById('null_frame');
+    if (!nullFrame) {
+        nullFrame = document.createElement('iframe');
+        nullFrame.id = 'null_frame';
+        nullFrame.style.display = 'none';
+        nullFrame.style.width = '0px';
+        nullFrame.style.height = '0px';
+        document.body.appendChild(nullFrame);
+    }
+    nullFrame.src = url;
+}
+
+
 export function parseUrl(url) {
     const parser = document.createElement('a');
     const pathAry = [];

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -388,8 +388,6 @@ export function findViewerWithItemId(multiViewRoot, itemId, containerType) {
     return v ? v.viewerId : null;
 }
 
-// get an available view from multiple views
-
 /**
  *
  * @param {MultiViewerRoot} multiViewRoot
@@ -676,6 +674,7 @@ function changeMount(state,viewerId,mounted) {
     if (viewer.mounted===mounted) return state;
     return state.map( (entry) => entry.viewerId===viewerId ? clone(entry, {mounted}) : entry);
 }
+
 
 function updateCustomData(state,action) {
     const {viewerId,customData}= action.payload;

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -116,7 +116,7 @@ function initState() {
             viewType:GRID,
             layout: GRID,
             canReceiveNewPlots: NewPlotMode.create_replace.key,
-            reservedContainer:true,
+            reservedContainer:false,
             mounted: false,
             containerType : IMAGE,
             layoutDetail : 'none',
@@ -130,7 +130,7 @@ function initState() {
             viewType:GRID,
             layout: GRID,
             canReceiveNewPlots: NewPlotMode.create_replace.key,
-            reservedContainer:true,
+            reservedContainer:false,
             mounted: false,
             containerType : PLOT2D,
             layoutDetail : 'none',
@@ -169,11 +169,14 @@ function initState() {
  * @param {boolean} mounted
  * @param {string} [renderTreeId] - used only with multiple rendered tree, like slate in jupyter lab
  * @param {string} [layout] - layout type - SINGLE or GRID, defaults to GRID
+ * @param {boolean} reservedContainer
  */
-export function dispatchAddViewer(viewerId, canReceiveNewPlots, containerType, mounted=false, renderTreeId, layout=GRID) {
+export function dispatchAddViewer(viewerId, canReceiveNewPlots, containerType, mounted=false, renderTreeId,
+                                  layout=GRID, reservedContainer=false) {
     flux.process({
         type: ADD_VIEWER,
-        payload: {viewerId, canReceiveNewPlots, containerType, mounted, renderTreeId, lastActiveItemId:'', layout}
+        payload: {viewerId, canReceiveNewPlots, containerType, mounted,
+            renderTreeId, lastActiveItemId:'', layout, reservedContainer}
     });
 }
 
@@ -529,7 +532,7 @@ function imageViewerCanAdd(state, viewerId, plotId) {
 function addViewer(state,payload) {
 
     const {viewerId,containerType, layout=GRID,canReceiveNewPlots=NewPlotMode.replace_only.key,
-             mounted=false, renderTreeId}= payload;
+             mounted=false, renderTreeId, reservedContainer}= payload;
     var   {lastActiveItemId} = payload;
     var entryInState = hasViewerId(state,viewerId);
 
@@ -545,7 +548,7 @@ function addViewer(state,payload) {
         // set default layout for the viewer with viewerId, META_VIEWER_ID, is full-grid type
         const layoutDetail = viewerId === META_VIEWER_ID ? GRID_FULL : undefined;
         const entry = {viewerId, containerType, canReceiveNewPlots, layout, mounted, itemIdAry: [], customData: {},
-                       lastActiveItemId, layoutDetail, renderTreeId};
+                       lastActiveItemId, layoutDetail, renderTreeId, reservedContainer};
         return [...state, entry];
     }
 }

--- a/src/firefly/js/visualize/saga/DataProductsWatcher.js
+++ b/src/firefly/js/visualize/saga/DataProductsWatcher.js
@@ -90,7 +90,7 @@ function watchDataProductsTable(tbl_id, action, cancelSelf, params) {
     if (payload.tbl_id) {
         if (payload.tbl_id!==tbl_id) return params;
         if (action.type===TABLE_REMOVE) {
-            removeAllProducts(activateParams);
+            removeAllProducts(activateParams,tbl_id);
             // todo might need to remove other stuff as well: charts, images, jpeg
             cancelSelf();
             return;
@@ -182,7 +182,7 @@ function updateDataProducts(tbl_id, activateParams, dataTypeViewerId, abortLastP
     const table = getTblById(tbl_id);
     // check to see if tableData is available in this range.
     if (!table || !isTblDataAvail(table.highlightedRow, table.highlightedRow + 1, table)) {
-        removeAllProducts(activateParams);
+        removeAllProducts(activateParams, tbl_id);
         return;
     }
 
@@ -273,12 +273,16 @@ function handleProductResult(p, dpId, isPromiseAborted, imageViewer) {
  *
  * @param {ActivateParams} activateParams
  */
-function removeAllProducts(activateParams) {
-    const {imageViewerId, tableGroupViewerId}= activateParams;
+function removeAllProducts(activateParams, tbl_id) {
+    const {dpId, imageViewerId, tableGroupViewerId}= activateParams;
     if (!imageViewerId) return;
-    const inViewerIds= getViewerItemIds(getMultiViewRoot(), imageViewerId);
-    removeTablesFromGroup(tableGroupViewerId);
-    dispatchReplaceViewerItems(imageViewerId,[],IMAGE);
-    inViewerIds.forEach( (plotId) => dispatchDeletePlotView({plotId}));
+    // removeTablesFromGroup(tableGroupViewerId);
+    // dispatchReplaceViewerItems(imageViewerId,[],IMAGE);
+    const activeTblId= getActiveTableId();
+    if (activeTblId===tbl_id || !isMetaDataTable(activeTblId)) {
+        const inViewerIds= getViewerItemIds(getMultiViewRoot(), imageViewerId);
+        inViewerIds.forEach( (plotId) => dispatchDeletePlotView({plotId}));
+        dispatchUpdateDataProducts(dpId,dpdtMessage('No Data Products'));
+    }
 }
 

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -311,15 +311,17 @@ function continuePlotImageSuccess(dispatcher, payload, successAry, failAry) {
         const resultPayload= Object.assign({},payload, {pvNewPlotInfoAry});
         dispatcher({type: ImagePlotCntlr.PLOT_IMAGE, payload: resultPayload});
         const plotIdAry = pvNewPlotInfoAry.map((info) => info.plotId);
-        dispatcher({type: ImagePlotCntlr.ANY_REPLOT, payload: {plotIdAry}});
+        const filteredPlotIdAry= plotIdAry.filter( (id) => getPlotViewById(visRoot(),id));
+        dispatcher({type: ImagePlotCntlr.ANY_REPLOT, payload: {filteredPotIdAry: filteredPlotIdAry}});
 
-        matchAndActivateOverlayPlotViewsByGroup(plotIdAry);
+        matchAndActivateOverlayPlotViewsByGroup(filteredPlotIdAry);
 
 
         pvNewPlotInfoAry
             .forEach((info) => info.plotAry
                 .forEach( (p)  => {
                     const pv= getPlotViewById(visRoot(),p.plotId);
+                    if (!pv) return;
                     addDrawLayers(p.plotState.getWebPlotRequest(), pv, p);
                     if (p.attributes[PlotAttribute.INIT_CENTER]) dispatchRecenter({plotId:p.plotId});
                 } ));
@@ -327,7 +329,8 @@ function continuePlotImageSuccess(dispatcher, payload, successAry, failAry) {
 
 
         //todo- this this plot is in a group and locked, make a unique list of all the drawing layers in the group and add to new
-        dispatchAddViewerItems(EXPANDED_MODE_RESERVED, plotIdAry, IMAGE);
+
+        dispatchAddViewerItems(EXPANDED_MODE_RESERVED, filteredPlotIdAry, IMAGE);
 
         const vr= visRoot();
         if (vr.wcsMatchType && vr.positionLock) {

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -1,0 +1,73 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+
+
+
+
+
+import React, {useEffect,useContext} from 'react';
+import {once} from 'lodash';
+import PropTypes from 'prop-types';
+import {MultiImageViewer} from './MultiImageViewer';
+import {
+    dispatchAddViewer, dispatchViewerUnmounted, getMultiViewRoot,
+    getViewerItemIds, IMAGE, NewPlotMode, SINGLE, } from '../MultiViewCntlr';
+import {PLOT_ID, startCoverageWatcher} from '../saga/CoverageWatcher';
+import {MultiViewStandardToolbar} from './MultiViewStandardToolbar';
+import {getActivePlotView} from '../PlotViewUtil';
+import {visRoot} from '../ImagePlotCntlr';
+import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx';
+import {useStoreConnector} from '../../ui/SimpleComponent';
+import {getActiveTableId} from '../../tables/TableUtil';
+import {hasCoverageData} from '../../util/VOAnalyzer';
+import {get} from 'lodash';
+import {getAppOptions} from '../../core/AppDataCntlr';
+
+
+
+
+const startWatcher= once((viewerId) => {
+    const coverageOps= get(getAppOptions(), 'coverage',{});
+    startCoverageWatcher({...coverageOps, viewerId, ignoreCatalogs:true});
+});
+
+
+export function CoverageViewer({viewerId='coverageImages',insideFlex=true,
+                                        noCovMessage='No Coverage Available',noCovStyle={}}) {
+
+    startWatcher(viewerId);
+    const [pv,tbl_id] = useStoreConnector(() => getActivePlotView(visRoot(),PLOT_ID), () => getActiveTableId());
+
+
+    useEffect(() => {
+        dispatchAddViewer(viewerId, NewPlotMode.replace_only, IMAGE, true, renderTreeId, SINGLE);
+        return () => dispatchViewerUnmounted(viewerId);
+    }, [viewerId]);
+
+    const hasPlots = (getViewerItemIds(getMultiViewRoot(),viewerId).length===1 && pv);
+    const {renderTreeId} = useContext(RenderTreeIdCtx);
+
+    if (hasPlots && hasCoverageData(tbl_id)) {
+        return (
+            <MultiImageViewer viewerId={viewerId}
+                              insideFlex={insideFlex}
+                              canReceiveNewPlots={NewPlotMode.replace_only.key}
+                              controlViewerMounting={false}
+                              Toolbar={MultiViewStandardToolbar}/>
+        );
+    }
+    else {
+        return (
+            <div style={{...{background: '#c8c8c8', paddingTop:35, width:'100%',textAlign:'center',fontSize:'14pt'},...noCovStyle}}>
+                {noCovMessage}</div>
+        );
+    }
+}
+
+CoverageViewer.propTypes= {
+    viewerId: PropTypes.string,
+    noCovMessage: PropTypes.string,
+    insideFlex: PropTypes.bool,
+};

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -39,6 +39,8 @@ import {PlotAttribute} from '../PlotAttribute.js';
 import {MetaConst} from '../../data/MetaConst.js';
 
 import './FileUploadViewPanel.css';
+import {getIntHeader} from '../../metaConvert/PartAnalyzer';
+import {FileAnalysisType} from '../../data/FileAnalysis';
 
 
 export const panelKey = 'FileUploadAnalysis';
@@ -150,7 +152,8 @@ function getNextState() {
             ];
             const {parts=[]} = currentReport;
             const data = parts.map( (p) => {
-                            return [p.index, p.type, p.desc];
+                            const naxis= getIntHeader('NAXIS',p,0);
+                            return [p.index, (naxis===1 && p.type===FileAnalysisType.Image)?FileAnalysisType.Table :p.type, p.desc];
                         });
 
             currentSummaryModel = {

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -219,7 +219,9 @@ function ImageDisplayOption() {
 
 function UploadOptions({uploadSrc=fileId, isloading, isWsUpdating}) {
 
-    const onLoading = () => dispatchComponentStateChange(panelKey, {isLoading: true});
+    const onLoading = (loading) => {
+        dispatchComponentStateChange(panelKey, {isLoading: loading});
+    };
 
     if (uploadSrc === fileId) {
         return (

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
@@ -10,7 +10,7 @@ import {getPlotViewById, getAllDrawLayersForPlot} from '../PlotViewUtil.js';
 import {dispatchChangeActivePlotView, visRoot} from '../ImagePlotCntlr.js';
 import {VisInlineToolbarView} from './VisInlineToolbarView.jsx';
 import {dispatchChangeViewerLayout, getViewer, getMultiViewRoot,
-        GRID_FULL, GRID_RELATED, SINGLE} from '../MultiViewCntlr.js';
+        GRID_FULL, GRID_RELATED, SINGLE, GRID} from '../MultiViewCntlr.js';
 import {showColorBandChooserPopup} from './ColorBandChooserPopup.jsx';
 import {ImagePager} from './ImagePager.jsx';
 
@@ -64,7 +64,7 @@ export function ImageMetaDataToolbarView({activePlotId, viewerId, viewerPlotIds=
         };
     }
     const showThreeColorButton= converter.threeColor && viewer.layoutDetail!==GRID_FULL && !(viewerPlotIds[0].includes(GRID_FULL.toLowerCase()));
-    const showPager= activeTable && converter.canGrid && viewer.layoutDetail===GRID_FULL;
+    const showPager= activeTable && converter.canGrid && layoutType===GRID && viewer.layoutDetail===GRID_FULL;
     const showMultiImageOps= converter.canGrid || converter.hasRelatedBands;
 
 

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -97,7 +97,7 @@ function getContexInfo(renderTreeId) {
         viewerId= viewer.viewerId;
     }
 
-    if (!viewer || canNotUpdatePlot(viewer)) {
+    if (!viewer || viewer.reservedContainer || canNotUpdatePlot(viewer)) {
         // viewer does not exists or cannot be updated, find another one that can.
         viewer = getAViewFromMultiView(mvroot, IMAGE, renderTreeId);
         viewerId =  viewer && viewer.viewerId;

--- a/src/firefly/js/visualize/ui/MetaDataMultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MetaDataMultiProductViewer.jsx
@@ -1,0 +1,22 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {memo, useContext, useState, useEffect} from 'react';
+import {once} from 'lodash';
+import {startDataProductsWatcher} from '../saga/DataProductsWatcher';
+import {MultiProductViewer} from './MultiProductViewer';
+
+
+const startWatcher= once((dpId) => startDataProductsWatcher({ dataTypeViewerId:dpId, dpId}) );
+
+
+/**
+ * A wrapper for MultiProductViewer for data Products that starts the watcher that updates it.
+ * It should be use in the case where this is the only if it the the only one one the page.
+ * If you are have more that on MultiProductViewer you should lay the out directly
+ */
+export const MetaDataMultiProductViewer= memo(({ dpId='DataProductsType', metaDataTableId, autoStartWatcher=true, }) => {
+    autoStartWatcher && startWatcher(dpId);
+    return (<MultiProductViewer viewerId={dpId} metaDataTableId={metaDataTableId}/>);
+});

--- a/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
+++ b/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
@@ -1,0 +1,51 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {ImageExpandedMode} from '../iv/ImageExpandedMode.jsx';
+import {MultiViewStandardToolbar} from './MultiViewStandardToolbar.jsx';
+import {MultiProductViewer} from './MultiProductViewer';
+import {DEFAULT_FITS_VIEWER_ID, NewPlotMode} from '../MultiViewCntlr.js';
+import {LO_MODE, LO_VIEW, dispatchSetLayoutMode} from '../../core/LayoutCntlr.js';
+import {CHART_DATA_VIEWER_ID, META_DATA_TBL_GROUP_ID} from './TriViewImageSection';
+import {META_VIEWER_ID} from '../MultiViewCntlr';
+
+const closeExpanded= () => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);
+
+/**
+ * A wrapper component for MultiImageViewer where expended mode is supported.
+ */
+export function MultiProductViewerContainer({viewerId= 'DataProductsType',
+                                                metaDataTableId,
+                                                tableGroupViewerId= META_DATA_TBL_GROUP_ID,
+                                                chartMetaViewerId= CHART_DATA_VIEWER_ID,
+                                                imageMetaViewerId= META_VIEWER_ID,
+                                                imageExpandedMode=false, closeable=true, insideFlex=false,
+                                           forceRowSize, Toolbar= MultiViewStandardToolbar}) {
+    
+    if (imageExpandedMode) {
+        return  ( <ImageExpandedMode
+                        key='results-plots-expanded'
+                        insideFlex = {insideFlex}
+                        closeFunc={closeable ? closeExpanded : null}/>
+                );
+    } else {
+        return (
+            <MultiProductViewer viewerId={viewerId}
+                                            metaDataTableId={metaDataTableId}
+                                            tableGroupViewerId={tableGroupViewerId}
+                                            chartMetaViewerId={chartMetaViewerId}
+                                            imageMetaViewerId={imageMetaViewerId}/>
+        );
+    }
+}
+
+
+MultiProductViewerContainer.propTypes = {
+    viewerId: PropTypes.string,
+    imageExpandedMode : PropTypes.bool,
+    closeable: PropTypes.bool,
+    insideFlex: PropTypes.bool,
+};

--- a/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
+++ b/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
@@ -5,8 +5,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {ImageExpandedMode} from '../iv/ImageExpandedMode.jsx';
-import {MultiProductViewer} from './MultiProductViewer';
 import {LO_MODE, LO_VIEW, dispatchSetLayoutMode} from '../../core/LayoutCntlr.js';
+import {MetaDataMultiProductViewer} from './MetaDataMultiProductViewer';
 
 const closeExpanded= () => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);
 
@@ -16,15 +16,11 @@ const closeExpanded= () => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)
 export function MultiProductViewerContainer({ metaDataTableId, imageExpandedMode=false, closeable=true, insideFlex=false}) {
     
     if (imageExpandedMode) {
-        return  ( <ImageExpandedMode
-                        key='results-plots-expanded'
-                        insideFlex = {insideFlex}
+        return  ( <ImageExpandedMode key='results-plots-expanded' insideFlex = {insideFlex}
                         closeFunc={closeable ? closeExpanded : null}/>
                 );
     } else {
-        return (
-            <MultiProductViewer metaDataTableId={metaDataTableId} />
-        );
+        return ( <MetaDataMultiProductViewer metaDataTableId={metaDataTableId} /> );
     }
 }
 

--- a/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
+++ b/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
@@ -5,25 +5,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {ImageExpandedMode} from '../iv/ImageExpandedMode.jsx';
-import {MultiViewStandardToolbar} from './MultiViewStandardToolbar.jsx';
 import {MultiProductViewer} from './MultiProductViewer';
-import {DEFAULT_FITS_VIEWER_ID, NewPlotMode} from '../MultiViewCntlr.js';
 import {LO_MODE, LO_VIEW, dispatchSetLayoutMode} from '../../core/LayoutCntlr.js';
-import {CHART_DATA_VIEWER_ID, META_DATA_TBL_GROUP_ID} from './TriViewImageSection';
-import {META_VIEWER_ID} from '../MultiViewCntlr';
 
 const closeExpanded= () => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);
 
 /**
  * A wrapper component for MultiImageViewer where expended mode is supported.
  */
-export function MultiProductViewerContainer({viewerId= 'DataProductsType',
-                                                metaDataTableId,
-                                                tableGroupViewerId= META_DATA_TBL_GROUP_ID,
-                                                chartMetaViewerId= CHART_DATA_VIEWER_ID,
-                                                imageMetaViewerId= META_VIEWER_ID,
-                                                imageExpandedMode=false, closeable=true, insideFlex=false,
-                                           forceRowSize, Toolbar= MultiViewStandardToolbar}) {
+export function MultiProductViewerContainer({ metaDataTableId, imageExpandedMode=false, closeable=true, insideFlex=false}) {
     
     if (imageExpandedMode) {
         return  ( <ImageExpandedMode
@@ -33,18 +23,13 @@ export function MultiProductViewerContainer({viewerId= 'DataProductsType',
                 );
     } else {
         return (
-            <MultiProductViewer viewerId={viewerId}
-                                            metaDataTableId={metaDataTableId}
-                                            tableGroupViewerId={tableGroupViewerId}
-                                            chartMetaViewerId={chartMetaViewerId}
-                                            imageMetaViewerId={imageMetaViewerId}/>
+            <MultiProductViewer metaDataTableId={metaDataTableId} />
         );
     }
 }
 
 
 MultiProductViewerContainer.propTypes = {
-    viewerId: PropTypes.string,
     imageExpandedMode : PropTypes.bool,
     closeable: PropTypes.bool,
     insideFlex: PropTypes.bool,

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -62,7 +62,7 @@ export class MultiImageViewer extends PureComponent {
         if (!pv || !viewer || !rootWidget || !viewer.lastActiveItemId) return;
         if (viewer.lastActiveItemId!==pv.plotId && rootWidget.offsetWidth && rootWidget.offsetHeight) {
             setTimeout(() => {
-                if (!viewWithIdMounted(pv.plotId)) dispatchChangeActivePlotView(viewer.lastActiveItemId)
+                if (!viewWithIdMounted(pv.plotId)) dispatchChangeActivePlotView(viewer.lastActiveItemId);
             }, 5);
         }
 

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -4,77 +4,64 @@
 
 import React, {memo, useContext, useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {get,isEmpty} from 'lodash';
+import {get,isFunction,isArray} from 'lodash';
 import {flux} from '../../Firefly.js';
 import {NewPlotMode, dispatchAddViewer, dispatchViewerUnmounted, WRAPPER, META_VIEWER_ID, IMAGE,
-        getMultiViewRoot, getViewer, dispatchUpdateCustom} from '../MultiViewCntlr.js';
+        getMultiViewRoot, getViewer, PLOT2D, SINGLE} from '../MultiViewCntlr.js';
 import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
 import {ImageMetaDataToolbar} from './ImageMetaDataToolbar.jsx';
 import {MultiImageViewer} from './MultiImageViewer.jsx';
+import {MultiChartViewer} from '../../charts/ui/MultiChartViewer';
 import {SingleColumnMenu} from '../../ui/DropDownMenu.jsx';
-import { ToolbarButton} from '../../ui/ToolbarButton.jsx';
+import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
+import {CompleteButton} from '../../ui/CompleteButton';
 import {DropDownToolbarButton} from '../../ui/DropDownToolbarButton.jsx';
-import {download} from '../../util/WebUtil.js';
-import {SINGLE} from '../MultiViewCntlr';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
+import {DPtypes} from '../../metaConvert/DataProductsType';
+import {
+    dataProductRoot,
+    dispatchActivateFileMenuItem,
+    dispatchActivateMenuItem,
+    getActiveFileMenuKey,
+    getActiveMenuKey,
+    getDataProducts,
+    doDownload,
+    getActiveFileMenuKeyByKey,
+    dispatchUpdateActiveKey
+} from '../../metaConvert/DataProductsCntlr';
+import {RadioGroupInputFieldView} from '../../ui/RadioGroupInputFieldView';
 
 
-function getDisplayType(viewer) {// todo
-    if (!viewer) return 'unsupported';
-    return get(viewer,'customData.displayType', 'unsupported');
+function FileMenuDropDown({fileMenu, dpId}) {
+    const activeFileMenuKey= getActiveFileMenuKey(dpId,fileMenu);
+    return (
+        <SingleColumnMenu>
+            {fileMenu.menu.map( (fileMenuItem, idx) => {
+                return (
+                    <ToolbarButton text={fileMenuItem.name} tip={fileMenuItem.name}
+                                   enabled={true} horizontal={false} key={'fileMenuOptions-'+idx}
+                                   hasCheckBox={true} checkBoxOn={fileMenuItem.menuKey===activeFileMenuKey}
+                                   onClick={() => dispatchActivateFileMenuItem({dpId,fileMenu,newActiveFileMenuKey:fileMenuItem.menuKey})}/>
+                );
+            })}
+        </SingleColumnMenu>
+    );
 }
+FileMenuDropDown.propTypes= {
+    dpId : PropTypes.string.isRequired,
+    fileMenu : PropTypes.object,
+};
 
-
-function activeMenuItem(menuItem, menu, viewerId) {
-    switch (menuItem.type) {
-
-        case 'image':
-            if (menuItem.activate) {
-                dispatchUpdateCustom(viewerId, {displayType: 'images', menu});
-                menuItem.activate();
-            }
-            else {
-                dispatchUpdateCustom(viewerId, {displayType: 'message', 'message': 'Image not supported',menu});
-            }
-            break;
-        case 'table':
-            if (menuItem.activate) {
-                dispatchUpdateCustom(viewerId, {displayType: 'table', menu});
-                menuItem.activate();
-            }
-            else {
-                dispatchUpdateCustom(viewerId, {displayType: 'message', 'message': 'Table not supported',menu});
-            }
-            break;
-        case 'xyplot':
-            if (menuItem.activate) {
-                dispatchUpdateCustom(viewerId, {displayType: 'xyplot', menu});
-                menuItem.activate();
-            }
-            else {
-                dispatchUpdateCustom(viewerId, {displayType: 'message', 'message': 'chart not supported',menu});
-            }
-            break;
-        case 'png':
-            dispatchUpdateCustom(viewerId, {displayType: 'png', url: menuItem.url, menu});
-            break;
-        case 'download':
-            download(menuItem.url);
-            console.log('MultiProductViewer: download something');
-            break;
-    }
-}
-
-
-
-function OtherOptionsDropDown({menu, viewerId}) {
+function OtherOptionsDropDown({menu, dpId, activeMenuLookupKey}) {
+    const activeMenuKey= getActiveMenuKey(dpId, activeMenuLookupKey);
     return (
         <SingleColumnMenu>
             {menu.map( (menuItem, idx) => {
                 return (
                     <ToolbarButton text={menuItem.name} tip={`${menuItem.semantics} - ${menuItem.url}`}
                                    enabled={true} horizontal={false} key={'otherOptions-'+idx}
-                                   onClick={() => activeMenuItem(menuItem, menu, viewerId)}/>
+                                   hasCheckBox={true} checkBoxOn={menuItem.menuKey===activeMenuKey}
+                                   onClick={() => dispatchActivateMenuItem(dpId,menuItem.menuKey) }/>
                 );
             })}
         </SingleColumnMenu>
@@ -82,101 +69,153 @@ function OtherOptionsDropDown({menu, viewerId}) {
 }
 
 OtherOptionsDropDown.propTypes= {
-    viewerId : PropTypes.string.isRequired,
-    menu : PropTypes.array
+    dpId : PropTypes.string.isRequired,
+    menu : PropTypes.array,
+    activeMenuLookupKey : PropTypes.string,
 };
 
 
-function getMakeDropdown(menu, viewerId) {
+function getMakeDropdown(menu, fileMenu, dpId,activeMenuLookupKey) {
+    const hasFileMenu= get(fileMenu,'menu.length',0)>1;
+    const hasMenu= menu && menu.length>0;
+    if (!hasMenu && !hasFileMenu) return undefined;
     return () => {
         return (
-            <DropDownToolbarButton text={'More'}
-                                   tip='Other data to display'
-                                   enabled={true} horizontal={true}
-                                   visible={true}
-                                   additionalStyle={{paddingRight:20}}
-                                   hasHorizontalLayoutSep={false}
-                                   useDropDownIndicator={true}
-                                   dropDown={<OtherOptionsDropDown menu={menu} viewerId={viewerId}/>} />
+            <div style={{display:'flex', flexDirection:'row'}}>
 
-            );
+                {!hasMenu ?   <div style={{width: 50,height:1 }}/> :
+                <DropDownToolbarButton
+                       text={'More'}
+                       tip='Other data to display'
+                       enabled={true} horizontal={true}
+                       visible={true}
+                       additionalStyle={{paddingRight:20}}
+                       hasHorizontalLayoutSep={false}
+                       useDropDownIndicator={true}
+                       dropDown={<OtherOptionsDropDown {...{menu, dpId, activeMenuLookupKey}} />} /> }
+
+                {hasFileMenu &&
+                <DropDownToolbarButton
+                    text={'In File'}
+                    tip='Other data in file'
+                    enabled={true} horizontal={true}
+                    visible={true}
+                    additionalStyle={{paddingRight:20}}
+                    hasHorizontalLayoutSep={false}
+                    useDropDownIndicator={true}
+                    dropDown={<FileMenuDropDown {...{fileMenu, dpId}} />} />
+                }
+
+            </div>
+        );
 
     };
 }
 
+const SHOW_CHART='showChart';
+const SHOW_TABLE='showTable';
+const makeChartTableLookupKey= (activeItemLookupKey, fileMenuKey) => `${activeItemLookupKey}-charTable-${fileMenuKey}`;
 
-export const MultiProductViewer= memo(({viewerId, imageMetaViewerId=META_VIEWER_ID,metaDataTableId,tableGroupViewerId }) => {
+export const MultiProductViewer= memo(({viewerId, imageMetaViewerId=META_VIEWER_ID,chartMetaViewerId='notsetup-chart', metaDataTableId,tableGroupViewerId }) => {
 
     const {renderTreeId} = useContext(RenderTreeIdCtx);
+    const dpId= viewerId;
     const [viewer, setViewer] = useState(getViewer(getMultiViewRoot(),viewerId));
-    const displayType= getDisplayType(viewer);
-    const activate= get(viewer,'customData.activate');
+    const [dataProductsState, setDataProductsState] = useState(getDataProducts(dataProductRoot(),dpId));
+    const {displayType='unsupported', menu,fileMenu,message,url, isWorkingState, menuKey,
+        activate,activeMenuLookupKey,singleDownload= false}= dataProductsState;
 
 
     useEffect(() => {
         dispatchAddViewer(viewerId, NewPlotMode.none, WRAPPER,true, renderTreeId, SINGLE);
         dispatchAddViewer(imageMetaViewerId, NewPlotMode.none, IMAGE,true, renderTreeId, SINGLE);
+        dispatchAddViewer(chartMetaViewerId, NewPlotMode.none, PLOT2D,true, renderTreeId, SINGLE);
         const removeFluxListener= flux.addListener(()=> {
             const newViewer= getViewer(getMultiViewRoot(),viewerId);
             if (newViewer!==viewer) setViewer(newViewer);
+            const newDataProducts= getDataProducts(dataProductRoot(),dpId);
+            if (newDataProducts && newDataProducts.displayType && newDataProducts.displayType!==DPtypes.DOWNLOAD && newDataProducts!==dataProductsState) {
+                setDataProductsState(newDataProducts);
+            }
         });
         return () => {
             removeFluxListener();
             dispatchViewerUnmounted(viewerId);
             dispatchViewerUnmounted(imageMetaViewerId);
+            dispatchViewerUnmounted(chartMetaViewerId);
         };
     }, [viewerId]);
 
-    useEffect(() => activate && activate(), [activate]);
+    useEffect(() => {
+        const deActivate= activate && activate();
+        return () => {
+            isFunction(deActivate) && deActivate();
+        };
+    }, [activate]);
 
     if (!viewer) return false;
-    const {menu,message,url}= viewer.customData;
-    let result;
+    const makeDropDown= (!singleDownload || menu.length>1) && getMakeDropdown(menu,fileMenu,dpId, activeMenuLookupKey);
 
+    let result;
     switch (displayType) {
-        case 'images' :
+        case DPtypes.IMAGE :
             result= ( <MultiImageViewer viewerId= {imageMetaViewerId} insideFlex={true}
                                         canReceiveNewPlots={NewPlotMode.none.key}
                                         tableId={metaDataTableId} controlViewerMounting={false}
                                         handleInlineToolsWhenSingle={false}
-                                        makeDropDown={menu && getMakeDropdown(menu,viewerId) }
+                                        makeDropDown={makeDropDown}
                                         Toolbar={ImageMetaDataToolbar}/>
             );
             break;
-        case 'message' :
+        case DPtypes.ANALYZE :
+        case DPtypes.MESSAGE :
+        case DPtypes.PROMISE :
             result= (
                 <div style={{display:'flex', flexDirection: 'column', background: '#c8c8c8', width:'100%', height:'100%'}}>
                     <div style={{height:menu?30:0}}>
-                        {menu && getMakeDropdown(menu,viewerId)()}
+                        {makeDropDown && makeDropDown()}
                     </div>
-                    <div style={{alignSelf:'center', fontSize:'14pt', paddingTop:40}}>{message}</div>
+                    <div style={{display:'flex', flexDirection: 'row', alignSelf:'center', paddingTop:40}}>
+                        {isWorkingState ?
+                            <div style={{width:20, height:20, marginRight: 10}} className='loading-animation' /> : ''}
+                        <div style={{alignSelf:'center', fontSize:'14pt'}}>{message}</div>
+                    </div>
+                    {
+                        singleDownload && isArray(menu) && menu.length &&
+                        <CompleteButton style={{alignSelf:'center', paddingTop:25 }} text={menu[0].name}
+                                        onSuccess={() => doDownload(menu[0].url)}/>
+                    }
                 </div>
             );
             break;
-        case 'table' :
-            result= (
-                <div style={{display:'flex', flexDirection: 'column', background: '#c8c8c8', width:'100%', height:'100%'}}>
-                    {!isEmpty(menu) && <div style={{height:30, width:'100%'}}>
-                        {getMakeDropdown(menu,viewerId)()}
-                    </div>}
-                    <TablesContainer tbl_group= {tableGroupViewerId} mode='both' closeable={false} expandedMode={false} />
-                </div>
-            );
+        case DPtypes.TABLE :
+            result= (<MultiProductChartTable {...{dpId,makeDropDown,tableGroupViewerId,SHOW_TABLE}}/>);
             break;
-        case 'png' :
+        case DPtypes.CHART :
+            result= (<MultiProductChartTable {...{dpId,makeDropDown,chartMetaViewerId,SHOW_CHART}}/>);
+            break;
+        case DPtypes.CHART_TABLE :
+            const lookupKey= get(fileMenu,'activeItemLookupKey','');
+            const ctLookupKey= makeChartTableLookupKey(lookupKey,menuKey || getActiveFileMenuKey(dpId,fileMenu));
+            const whatToShow= lookupKey ?
+                getActiveFileMenuKeyByKey(dpId,ctLookupKey) || SHOW_CHART: SHOW_CHART;
+            result= (<MultiProductChartTable {
+                ...{dpId,makeDropDown,chartMetaViewerId,tableGroupViewerId,whatToShow,ctLookupKey,mayToggle:true}}/>);
+            break;
+        case DPtypes.PNG :
             result= (
                 <div style={{display:'flex', flexDirection: 'column', background: '#c8c8c8', width:'100%', height:'100%'}}>
-                    { !isEmpty(menu) &&  <div style={{height:30, width:'100%'}}>
-                        {getMakeDropdown(menu,viewerId)()}
+                    {makeDropDown &&  <div style={{height:30, width:'100%'}}>
+                        {makeDropDown()}
                     </div>}
                     <div style={{overflow:'auto', display:'flex', justifyContent: 'center', alignItem:'center'}}>
                         <img src={url} alt={url} style={{maxWidth:'100%', flexGrow:0, flexShrink:0 }}/>
                     </div>
                 </div>
-        );
+            );
             break;
         default:
-            result= ( <div>{'Unsupported or empty display type. Contact Support. Please check DataProductsFactory'}</div> );
+            result= ( <div/> );
             break;
 
     }
@@ -185,16 +224,65 @@ export const MultiProductViewer= memo(({viewerId, imageMetaViewerId=META_VIEWER_
 });
 
 
-
-
-
 MultiProductViewer.propTypes= {
     viewerId : PropTypes.string.isRequired,
     imageMetaViewerId: PropTypes.string.isRequired,
     tableGroupViewerId: PropTypes.string.isRequired,
-    metaDataTableId : PropTypes.string
+    metaDataTableId : PropTypes.string,
+    chartMetaViewerId: PropTypes.string
 };
+
+const chartTableOptions= [
+    {label: 'Chart', value: SHOW_CHART},
+    {label: 'Table', value: SHOW_TABLE}
+    ];
+
+function MultiProductChartTable({dpId,makeDropDown, chartMetaViewerId,
+                                    tableGroupViewerId,whatToShow,ctLookupKey=undefined, mayToggle=false}) {
+
+    const [ts, setTS] = useState(whatToShow);
+    const [lookupKey, setLookKey] = useState(ctLookupKey);
+    let result;
+
+    useEffect(() => {
+        setTS(whatToShow);
+        setLookKey(ctLookupKey);
+    }, [whatToShow,ctLookupKey]);
+
+
+    const toolbar= (
+        <div style={{display:'flex', flexDirection: 'row', alignItems:'center', height:30}}>
+            {makeDropDown && <div style={{height:30}}> {makeDropDown()} </div>}
+            {mayToggle && <RadioGroupInputFieldView wrapperStyle={{paddingLeft:20}}
+                                      options={chartTableOptions}  value={ts} buttonGroup={true}
+                                      onChange={(ev) => {
+                                          setTS(ev.target.value);
+                                          dispatchUpdateActiveKey({dpId, activeFileMenuKeyChanges:{[ctLookupKey]:ev.target.value}});
+                                      }} />}
+        </div>
+    );
+
+    if (ts===SHOW_CHART) {
+        result= (
+            <div style={{ width:'100%', background: '#c8c8c8'}}>
+                {toolbar}
+                <MultiChartViewer viewerId= {chartMetaViewerId} closeable={false}
+                                  canReceiveNewItems ={NewPlotMode.none.key} />
+            </div>
+        );
+    }
+    else {
+        result= (
+            <div style={{display:'flex', flexDirection: 'column', background: '#c8c8c8', width:'100%', height:'100%'}}>
+                {toolbar}
+                <TablesContainer tbl_group= {tableGroupViewerId} mode='both' closeable={false} expandedMode={false} />
+            </div>
+        );
+    }
+    return result;
+
+}
+
 
 
 MultiProductViewer.contextType= RenderTreeIdCtx;
-

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -24,7 +24,8 @@ import {startDataProductsWatcher} from '../saga/DataProductsWatcher.js';
 import {isCatalog, isMetaDataTable} from '../../util/VOAnalyzer.js';
 import {MultiProductViewer} from  '../ui/MultiProductViewer';
 
-const META_DATA_TBL_GROUP_ID= 'TableDataProducts';
+export const META_DATA_TBL_GROUP_ID= 'TableDataProducts';
+export const CHART_DATA_VIEWER_ID= 'ChartMetaView';
 
 /**
  * This component works with ImageMetaDataWatch sega which should be launch during initialization
@@ -72,6 +73,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
                         <MultiProductViewer viewerId={'DataProductsType'}
                                             metaDataTableId={metaDataTableId}
                                             tableGroupViewerId={META_DATA_TBL_GROUP_ID}
+                                            chartMetaViewerId={CHART_DATA_VIEWER_ID}
                                            imageMetaViewerId={META_VIEWER_ID}/>
                     </Tab>
                 }
@@ -100,13 +102,14 @@ TriViewImageSection.propTypes= {
     imageExpandedMode : PropTypes.bool,
     closeable: PropTypes.bool,
     metaDataTableId: PropTypes.string,
+    chartMetaId: PropTypes.string,
     selectedTab: PropTypes.oneOf(['fits', 'meta', 'coverage']),
     style: PropTypes.object
 };
 
 export function launchTableTypeWatchers() {
     const coverageOps= get(getAppOptions(), 'coverage',{});
-    startDataProductsWatcher({imageViewerId: META_VIEWER_ID,tableGroupViewerId:META_DATA_TBL_GROUP_ID});
+    startDataProductsWatcher({imageViewerId: META_VIEWER_ID, chartViewerId:CHART_DATA_VIEWER_ID, tableGroupViewerId:META_DATA_TBL_GROUP_ID});
     startCoverageWatcher({...coverageOps, viewerId:'coverageImages', ignoreCatalogs:true});
     startLayoutWatcher();
 }

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -19,7 +19,7 @@ import ImagePlotCntlr, {visRoot} from '../../visualize/ImagePlotCntlr.js';
 import {TABLE_LOADED, TBL_RESULTS_ACTIVE, TBL_RESULTS_ADDED} from '../../tables/TablesCntlr.js';
 import {REINIT_APP} from '../../core/AppDataCntlr.js';
 import {isCatalog, isMetaDataTable} from '../../util/VOAnalyzer.js';
-import {MultiProductViewer, META_DATA_TBL_GROUP_ID} from  '../ui/MultiProductViewer';
+import {MetaDataMultiProductViewer} from './MetaDataMultiProductViewer';
 import {CoverageViewer} from './CoveraeViewer';
 
 
@@ -66,7 +66,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
                 }
                 { showMeta &&
                     <Tab name={metaTitle} removable={false} id='meta'>
-                        <MultiProductViewer metaDataTableId={metaDataTableId} />
+                        <MetaDataMultiProductViewer metaDataTableId={metaDataTableId} />
                     </Tab>
                 }
                 { showCoverage &&
@@ -145,17 +145,17 @@ function layoutHandler(action, cancelSelf) {
             newLayoutInfo = onPlotDelete(newLayoutInfo, action);
             break;
         case TABLE_LOADED:
-            if (action.payload.tbl_id!==META_DATA_TBL_GROUP_ID) {
+            if (action.payload.tbl_id) {
                 newLayoutInfo = handleNewTable(newLayoutInfo, action);
             }
             break;
         case TBL_RESULTS_ADDED:
-            if (action.payload.options.tbl_group!==META_DATA_TBL_GROUP_ID) {
+            if (action.payload.options.tbl_group==='main') {
                 newLayoutInfo = handleNewTable(newLayoutInfo, action);
             }
             break;
         case TBL_RESULTS_ACTIVE:
-            if (action.payload.tbl_group!==META_DATA_TBL_GROUP_ID) {
+            if (action.payload.tbl_group==='main') {
                 newLayoutInfo = onActiveTable(newLayoutInfo, action);
             }
             break;

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -9,7 +9,6 @@ import {get, isEmpty} from 'lodash';
 import {ImageExpandedMode} from '../iv/ImageExpandedMode.jsx';
 import {Tab, Tabs} from '../../ui/panel/TabPanel.jsx';
 import {MultiViewStandardToolbar} from './MultiViewStandardToolbar.jsx';
-import {ImageMetaDataToolbar} from './ImageMetaDataToolbar.jsx';
 import {MultiImageViewer} from './MultiImageViewer.jsx';
 import {dispatchAddActionWatcher} from '../../core/MasterSaga.js';
 import {DEFAULT_FITS_VIEWER_ID, REPLACE_VIEWER_ITEMS, NewPlotMode, getViewerItemIds, getMultiViewRoot,
@@ -18,14 +17,11 @@ import {getTblById, findGroupByTblId, getTblIdsByGroup, smartMerge} from '../../
 import {LO_MODE, LO_VIEW, dispatchSetLayoutMode, dispatchUpdateLayoutInfo, getLayouInfo} from '../../core/LayoutCntlr.js';
 import ImagePlotCntlr, {visRoot} from '../../visualize/ImagePlotCntlr.js';
 import {TABLE_LOADED, TBL_RESULTS_ACTIVE, TBL_RESULTS_ADDED} from '../../tables/TablesCntlr.js';
-import {getAppOptions, REINIT_APP} from '../../core/AppDataCntlr.js';
-import {startCoverageWatcher} from '../saga/CoverageWatcher.js';
-import {startDataProductsWatcher} from '../saga/DataProductsWatcher.js';
+import {REINIT_APP} from '../../core/AppDataCntlr.js';
 import {isCatalog, isMetaDataTable} from '../../util/VOAnalyzer.js';
-import {MultiProductViewer} from  '../ui/MultiProductViewer';
+import {MultiProductViewer, META_DATA_TBL_GROUP_ID} from  '../ui/MultiProductViewer';
+import {CoverageViewer} from './CoveraeViewer';
 
-export const META_DATA_TBL_GROUP_ID= 'TableDataProducts';
-export const CHART_DATA_VIEWER_ID= 'ChartMetaView';
 
 /**
  * This component works with ImageMetaDataWatch sega which should be launch during initialization
@@ -70,19 +66,12 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
                 }
                 { showMeta &&
                     <Tab name={metaTitle} removable={false} id='meta'>
-                        <MultiProductViewer viewerId={'DataProductsType'}
-                                            metaDataTableId={metaDataTableId}
-                                            tableGroupViewerId={META_DATA_TBL_GROUP_ID}
-                                            chartMetaViewerId={CHART_DATA_VIEWER_ID}
-                                           imageMetaViewerId={META_VIEWER_ID}/>
+                        <MultiProductViewer metaDataTableId={metaDataTableId} />
                     </Tab>
                 }
                 { showCoverage &&
                     <Tab name='Coverage' removable={false} id='coverage'>
-                        <MultiImageViewer viewerId='coverageImages'
-                                          insideFlex={true}
-                                          canReceiveNewPlots={NewPlotMode.replace_only.key}
-                                          Toolbar={MultiViewStandardToolbar}/>
+                        <CoverageViewer/>
                     </Tab>
                 }
             </Tabs>
@@ -108,9 +97,6 @@ TriViewImageSection.propTypes= {
 };
 
 export function launchTableTypeWatchers() {
-    const coverageOps= get(getAppOptions(), 'coverage',{});
-    startDataProductsWatcher({imageViewerId: META_VIEWER_ID, chartViewerId:CHART_DATA_VIEWER_ID, tableGroupViewerId:META_DATA_TBL_GROUP_ID});
-    startCoverageWatcher({...coverageOps, viewerId:'coverageImages', ignoreCatalogs:true});
     startLayoutWatcher();
 }
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
@@ -113,11 +113,13 @@ public class FileAnalysisTest extends ConfigTest {
         assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
         assertEquals("IPAC Table (25 cols x 49933 rows)", report.getParts().get(0).getDesc());
 
+        System.out.println("file= "+csvTable);
         report= FileAnalysis.analyze(csvTable, reportType);
         assertEquals(FileAnalysis.ReportType.Normal, report.getType());
         assertEquals(csvTable.getPath(), report.getFilePath());
         assertEquals(csvTable.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
+        System.out.println("t= "+report.getParts().get(0).getType());
         assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
         assertEquals("CSVFormat (6 cols x 1000 rows)", report.getParts().get(0).getDesc());
 


### PR DESCRIPTION
Firefly-460: Add file analysis & more visualization to data products viewing

  - Add new controller for the DataProductsType
  - add file FileAnalysis
  - create UI for FileAnalysis results
  - add charts to MultiProduct viewer
  - work on framework for recognizing data
  - refactor and cleanup
  - Improve file upload to include WebPlotRequest
  - Improve file upload to send progress feedback
  - clean up for sofia
  - support tar, pdf on file analysis server side
  - extension improvements with upload
  - catch pdf, tar, png files on the client side if posible without file analysis
  - improve messaging when there in only one download
  - Supported views: table, chart, table/chart flip, image, png, message, download (tar)
  - VOAnalyzer now does all the data product recognition - all case insensitive
  - tested with wise, fixed bugs

https://jira.ipac.caltech.edu/browse/FIREFLY-460

## Test

### All testing

- Data products will show as you click on the related data products table.
- With data link use the `More...` dropdown.
- Any file that has more than one data product will have a `In File...` dropdown

 https://irsawebdev9.ipac.caltech.edu/firefly-460-file-analysis/firefly/
###  Upload Test

1. Go to Upload panel
1. Load: http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/data-products-test/data-product-test-ipac-table.tbl
1. Click on the rows

### Obscore Simple Test
1. Goto the `Tap Searches Menu`
1. Choose MAST
1. Choose ivoa / ivoa.obscore
1. choose m31 / 100 arcsec  (and try other targets)
1. click around you will see some images
1. now filter `obs_collection` on FUSE
1. click around about half way down the page, you will see some charts show up
1. switch between tables and charts using the buttons on toolbar

### Obscore Datalink Test
1. Goto the `Tap Searches Menu`
1. Choose CADC
1. Choose ivoa / ivoa.obscore
1. choose m31 / 100 arcsec  (and try other targets)
1. click around only has stuff that can be downloaded.
1. sort on obs_publisher_did
1. now you click around and will see images
1. try the `More` dropdown



### Sofia Test
ife PR: https://github.com/IPAC-SW/irsa-ife/pull/101
https://irsawebdev9.ipac.caltech.edu/firefly-460-file-analysis/applications/sofia/
1. Do an all sky search
1. Every tab is able to show some sort of data products
1. Not HAWC+: some of the files also have tables (click on the first line after the red). You will see the `In File...` dropdown

### Known bug
Expansion does not work for charts and tables in the DataProductsViewer.  This will be fix in a separate PR or a patch to this one.

## Code Review details

Basic flow:

- Tables are watch by DataProductsWatcher.js
- If the table is a data Products table then the DataProductsFactors determines the correct converter. the only ones that matter of this PR are ObsCore and UNKNOWN
- The converter turns a table row into `DataProductsDisplayType`
- A `DataProductsDisplayType` may have a menu with other  `DataProductsDisplayType`  (data link case)
-  A `DataProductsDisplayType` may have a fileMenu with of  `DataProductsDisplayType`  (result of file analysis)
- The DataProductCntlr maintains the `DataProductsDisplayType` in the store
- `MultiProductViewer` will render when data products
- Rendering requires two two steps:
   - rendering the correct react components
   - calling the activate function passed in the DataProductsDisplayType object.
   - The activate function will call dispatchTableSearch, dispatchPlotImage, etc.


Best files to look at:
- DataProductsCntlr.js
- MultiProductViewer.jsx
- ObsCoreConverter.js
- MultiProductFileAnalyzer.js
- PartAnalyzer.js
- DataLinkProcessor.js
- DataProductsType.js
- AnyFileUpload.java