### PR TITLE
FIREFLY-436 place the footprint label when the location corner is changed

### DIFF
--- a/src/firefly/js/drawingLayers/FootprintToolUI.jsx
+++ b/src/firefly/js/drawingLayers/FootprintToolUI.jsx
@@ -160,12 +160,12 @@ class FootprintToolUI extends PureComponent {
                 <div style={{display:'flex', justifyContent:'flex-start'}}>
 
                     <div style={tStyle}>
-                        <div title={'Add a lable to this footprint'}> Label:<input style={{width: 60}}
+                        <div title={'Add a lable to this footprint'}> Label:&nbsp;<input style={{width: 86}}
                                            type='text'
                                            value={fpText}
                                            onChange={this.changeFootprintText}/>
                         </div>
-                        <div style={mStyle} title={'Choose a corner'}> Label Location:
+                        <div style={mStyle} title={'Choose a corner'}> Label Location:&nbsp;
                             <select value={fpTextLoc} onChange={ this.changeFootprintTextLocation }>
                                 <option value={TextLocation.REGION_NE.key}> NE </option>
                                 <option value={TextLocation.REGION_NW.key}> NW </option>

--- a/src/firefly/js/drawingLayers/FootprintToolUI.jsx
+++ b/src/firefly/js/drawingLayers/FootprintToolUI.jsx
@@ -165,7 +165,7 @@ class FootprintToolUI extends PureComponent {
                                            value={fpText}
                                            onChange={this.changeFootprintText}/>
                         </div>
-                        <div style={mStyle} title={'Choose a corner'}> Corners:
+                        <div style={mStyle} title={'Choose a corner'}> Label Location:
                             <select value={fpTextLoc} onChange={ this.changeFootprintTextLocation }>
                                 <option value={TextLocation.REGION_NE.key}> NE </option>
                                 <option value={TextLocation.REGION_NW.key}> NW </option>

--- a/src/firefly/js/visualize/draw/MarkerFootprintObj.js
+++ b/src/firefly/js/visualize/draw/MarkerFootprintObj.js
@@ -1120,7 +1120,7 @@ function drawFootprintText(drawObj, plot, def, ctx) {
     if (isNil(text)) return;
     const outlineObj = (drawObj.drawObjAry.length > drawObj.outlineIndex) ?
                       drawObj.drawObjAry[drawObj.outlineIndex] :
-                      (isHiPS(plot) ? (updateHandle(drawObj, plot, []))[0] : null);
+                      (isHiPS(plot) ? (updateHandle(drawObj, plot, []))[0] : remakeOutlineBox(drawObj, plot, [OutlineType.original]));
 
 
     // if no outline exists, display text as stored location


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-436

Update:
compute the outline box before rendering footprint text when the location corner is changed. 

test:
https://irsawebdev9.ipac.caltech.edu/FIREFLY-436_footprint_label_position/firefly/
do image search
select a footpint 
chage the footprint label corners from the overlay dialog. 
or check the build for Sofia, 
https://irsawebdev9.ipac.caltech.edu/FIREFLY-436_footprint_label_position/applications/sofia/

