### PR TITLE
firefly-487-Add validation to WAVE-TAB WCS implementation

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
@@ -18,10 +18,8 @@ import nom.tam.fits.BasicHDU;
 import nom.tam.fits.Header;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Trey Roby
@@ -51,9 +49,57 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
         return tabHduIdx;
     }
 
+
+    /**
+     * If a FITS file contains multiple XTENSION HDUs (headerdata
+     * units) with the specified EXTNAME, EXTLEVEL, and
+     * EXTVER, then the result of the WCS table lookup is undefined.
+     * If the specified FITS BINTABLE contains no column, or multiple
+     * columns, with the specified TTYPEn, then the result of the
+     * WCS table lookup is undefined. The specified FITS BINTABLE
+     * must contain only one row.
+     * No units conversions are to
+     * @return
+     */
+    private static boolean isValidWCSForTab(BasicHDU[] HDUs){
+
+        List<String> extNames = new ArrayList<String>();
+        List<Integer> extLevels= new ArrayList<Integer>();
+        List<Integer> extVers  = new ArrayList<Integer>();
+
+
+        for (int i=0; i<HDUs.length; i++){
+            Header header= HDUs[i].getHeader();
+            String xtension= header.getStringValue("XTENSION");
+            if ("BINTABLE".equals(xtension)) {
+                extNames.add(header.getStringValue("EXTNAME"));
+                extLevels.add( header.getIntValue("EXTLEVEL"));
+                extVers.add( header.getIntValue("EXTVER"));
+
+            }
+        }
+
+
+        for (int i=0; i<extNames.size(); i++){
+            for (int j=i+1; j<extNames.size();j++){
+                if (extNames.get(i) == extNames.get(j) &&
+                   extLevels.get(i) == extLevels.get(j) &&
+                   extVers.get(i)   == extVers.get(j) ){
+                    return false;
+                }
+            }
+        }
+
+
+        return true;
+    }
     /**
      * NOTE:  HDUs here is the array of all HDUs in the FITs file.
-     * For each image HDU, look for its coressonding BinaryTableHDU.  This only applies for WAVE-TAB case
+     *        For each image HDU, look for its corresponding BinaryTableHDU.  This only applies for WAVE-TAB case.
+     *        The -TAB implementation is more complicated than most other WCS conventions because the coordinate system
+     *        is not completely defined by keywords in a single FITS header.
+     *        The necessary WCS parameters that are in general distributed over two FITS HDUs and in the body
+     *        of the WCS extension table.
      * @param HDUs
      * @param hduIdx
      * @return
@@ -61,14 +107,36 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
     public static int findWaveTabHDU(BasicHDU[] HDUs, int hduIdx) {
 
         if (HDUs.length<2) return -1;
+
+
         BasicHDU hdu= HDUs[hduIdx];
         Header header= hdu.getHeader();
         String xtensionPrim= header.getStringValue("XTENSION");
-        if (xtensionPrim!=null && xtensionPrim.equals("BINTABLE")) return -1;
+        if (xtensionPrim!=null && "BINTABLE".equals(xtensionPrim) ) return -1;
         String ctype= header.getStringValue("CTYPE3");
         if (!"WAVE-TAB".equals(ctype)) return -1;
+
+        //If it is WAVE-TAB, validate it first
+        if (!isValidWCSForTab(HDUs)) return -1;
         String waveHDUName= header.getStringValue("PS3_0");
-        if  (waveHDUName==null) return -1;
+        int waveExtVer= header.containsKey("PV3_1") ? header.getIntValue("PV3_1"): 1;
+        int waveExtLevel=header.containsKey("PV3_2") ? header.getIntValue("PV3_2"):1;
+
+        ////When PS3_0 is undefined, use the binary table whose name starts with "WCS-".
+        if (waveHDUName==null){
+            for(int i=0; i<HDUs.length; i++) {
+                if (i!=hduIdx) {
+                    Header hIHeader= HDUs[i].getHeader();
+                    String xtension= hIHeader.getStringValue("XTENSION");
+                    String extName= hIHeader.getStringValue("EXTNAME");
+                    if ("BINTABLE".equals(xtension) && extName.startsWith("WCS-")) {
+                        return i;
+                    }
+                }
+            }
+
+        }
+
         //The hdu= HDUs[hduIdx] is the an image HDU, it has a corresponding BinaryTableHDU
         //that contains the WAVE-TAB information. The loop below, is to find the index number of the BinaryTableHDU.
         for(int i=0; i<HDUs.length; i++) {
@@ -76,12 +144,17 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
                 Header hIHeader= HDUs[i].getHeader();
                 String xtension= hIHeader.getStringValue("XTENSION");
                 String extName= hIHeader.getStringValue("EXTNAME");
-                if ("BINTABLE".equals(xtension) && waveHDUName.equals(extName)) {
+                int extVer = hIHeader.containsKey("EXTVER")?hIHeader.getIntValue("EXTVER"):1;
+                int extLevel = hIHeader.containsKey("EXTLEVEL")?hIHeader.getIntValue("EXTLEVEL"):1;
+                if ("BINTABLE".equals(xtension) && waveHDUName.equals(extName) &&
+                    extVer == waveExtVer && extLevel == waveExtLevel) {
                     return i;
                 }
 
             }
         }
+
+
         return -1;
     }
 }

--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -227,7 +227,6 @@ const getArrayDataFromTable= (table, columnName) => {
     return undefined;
 };
 
-
 /**
  *
  * The pre-requirement is that the FITS has three axies, ra (1), dec(2) and wavelength (3).

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -191,9 +191,12 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
     const ps3_0= parse.getValue(`PS${which}_0${altWcs}`, '');
     const ps3_1= parse.getValue(`PS${which}_1${altWcs}`, '');
     const ps3_2= parse.getValue(`PS${which}_2${altWcs}`, '');
-    const pv3_0= parse.getValue(`PV${which}_0${altWcs}`, '');
+    //pv3_1: EXTLEVEL, pv3_2: EXTVER, pv3_3: axis number associated with the coordinate array in ps3_1
+    //The pv3_i values are not used in our case, since we only handle the FITS with one axis related to TAB wavelength.
+    //We processed those values just in case there is need to handle the FITS with more than one TAB axes.
     const pv3_1= parse.getValue(`PV${which}_1${altWcs}`, '');
     const pv3_2= parse.getValue(`PV${which}_2${altWcs}`, '');
+    const pv3_3= parse.getValue(`PV${which}_3${altWcs}`, '');
 
     const {algorithm, wlType} = getAlgorithmAndType(ctype,N);
 
@@ -221,7 +224,7 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
         if (algorithm==='TAB') {
             const part1 = {
                 N, algorithm, ctype, restWAV, pc_3j, r_j,
-                ps3_0, ps3_1, ps3_2, pv3_0, pv3_1, pv3_2,
+                ps3_0, ps3_1, ps3_2, pv3_1, pv3_2,pv3_3,
                 s_3: isNaN(cdelt) ? 0 : cdelt,
                 lambda_r: isNaN(crval) ? 0 : crval,
                 wlTable
@@ -269,7 +272,7 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
 
     return {
         N, algorithm, ctype, restWAV, wlType, crpix, crval, cdelt, failReason, failWarning, units, pc_3j, r_j,
-        ps3_0, ps3_1, ps3_2, pv3_0, pv3_1, pv3_2,
+        ps3_0, ps3_1, ps3_2, pv3_1, pv3_2, pv3_3,
         s_3: isNaN(cdelt) ? 0 : cdelt,
         lambda_r: isNaN(crval) ? 0 : crval,
         wlTable


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-487 

When the WAVE-TAB was implemented,  the validation process was ignore.  When the FITs has multiple HDUs, it can have more binary tables.  Thus, the validation is necessary to guarantee that the right table is used.  This pull request is to add WAVE-TAB WCS validation according to the paper " Representations of spectral coordinates in FITS by E. W. Greisen et al."   All changes are in sever side.  
What it does it to check all the binary tables and find the right one whose extver number, extlevel number and extname are the same as thePV3_i  (i=1, 2) and PS3_i  respectively.  Also the extname in the binary table should start with "WCS-". 

To test it, please use previously known working FITs files (in the ticket). 
URL: https://irsawebdev9.ipac.caltech.edu/firefly-487-waveTab-validation/firefly/