### PR TITLE
Firefly-489: caching of HiPS properties and tiles should only last until a reload happens

### DIFF
--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -119,6 +119,7 @@ task createVersionTag  {
         props.setProperty('BuildMajor', major)
         props.setProperty('BuildMinor', minor)
         props.setProperty('BuildRev', rev)
+        props.setProperty('ClientBuildEnv', project.hasProperty("env") ? project.env : "local")
         props.setProperty('BuildType', type)
         props.setProperty('BuildNumber', buildNum)
         props.setProperty('BuildDate', build_date)

--- a/docker/base/cleanup.sh
+++ b/docker/base/cleanup.sh
@@ -28,7 +28,7 @@ function doCleanup() {
         fi
 
         ${find_cmd} "${workarea}/upload" -type f -mtime +7 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
-        #${find_cmd} "${workarea}/HiPS" -type f -mtime +90 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
+        ${find_cmd} "${workarea}/HiPS" -type f -mtime +90 -exec /bin/rm '{}' \+ -print >> "${log_file}" 2>&1
 
         dirs_to_clear=("${workarea}/visualize/users" "${workarea}/temp_files")
         for d in ${dirs_to_clear[@]}; do

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -6,7 +6,7 @@
 import 'isomorphic-fetch';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {set, get, defer} from 'lodash';
+import {set, get, defer, once} from 'lodash';
 import 'styles/global.css';
 
 import {APP_LOAD, dispatchAppOptions, dispatchUpdateAppData} from './core/AppDataCntlr.js';
@@ -23,13 +23,16 @@ import {reduxFlux} from './core/ReduxFlux.js';
 import {wsConnect} from './core/messaging/WebSocketClient.js';
 import {ActionEventHandler} from './core/messaging/MessageHandlers.js';
 import {init} from './rpc/CoreServices.js';
-import {getPropsWith, mergeObjectOnly} from './util/WebUtil.js';
+import {getPropsWith, mergeObjectOnly, getProp} from './util/WebUtil.js';
 import {initLostConnectionWarning} from './ui/LostConnection.jsx';
 import {dispatchChangeTableAutoScroll, dispatchWcsMatch, visRoot} from './visualize/ImagePlotCntlr';
 
 export const flux = reduxFlux;
 
 var initDone = false;
+
+export const getFireflySessionId= once(() =>
+    getProp('version.ClientBuildEnv')==='local' ? 'LOCAL_SESSION' : `FF-Session-${Date.now()}`);
 
 /**
  * A list of available templates

--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -22,6 +22,7 @@ import {replaceHeader, getScreenPixScaleArcSec} from './WebPlot.js';
 import {primePlot} from './PlotViewUtil.js';
 import CoordinateSys from './CoordSys';
 import {getRootURL} from '../util/BrowserUtil.js';
+import {getFireflySessionId} from '../Firefly';
 
 
 export const MAX_SUPPORTED_HIPS_LEVEL= ORDER_MAX-1;
@@ -191,6 +192,7 @@ export function makeHiPSAllSkyUrlFromPlot(plot) {
 export function makeHipsUrl(url, proxy) {
     if (proxy) {
         const params= {
+            downloadSessionId: getFireflySessionId(),
             hipsUrl : url
         };
         return encodeServerUrl(getRootURL() + 'servlet/Download', params);


### PR DESCRIPTION
### Firefly-489: caching of HiPS properties and tiles should only last until a reload happens

   - After a reload all HiPS tile and property caching should be cleared
   - new function Firefly.js: getFireflySessionId()
   - Firefly-490: allow reload caching to happen in local mode
   - Firefly-361: docker clean will cleanup hips cache over 90 days


### Testing
https://irsawebdev9.ipac.caltech.edu/firefly-489-hips-cache/firefly/

You will need to bring up developer tools and watch the network tab. Watch for the message `(disk cache)` or `(memory cache)` when fits tiles are loading.

_First try_
1. Chose a target and HiPS selection, you will use this same one again and again.
1. make sure developer tools, network tab is up
1. load the HiPS and zoom down to around 5 degree FOV, and scroll around that area
1. you will see a lot of activity on the network tab, watch the size
1. as you scroll around you will see more `(disk cache)` or `(memory cache)` under size

_Second try_
1. delete that HiPS (don't reload) and do the same thing again, zoom down to around 5 degrees
1. this time you will see and lot more `(disk cache)` or `(memory cache)` under size

_Now Reload, Third try_
1. load the same HiPS and same target and zoom down to around 5 degress.
1. This time you should not see many `(disk cache)` or `(memory cache)`



