### PR TITLE
Firefly-484: HiPS/Image WCS match rotate updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are several branches the this repository.  Here are the ones that you shou
  -  [Tomcat 7+] (http://tomcat.apache.org/download-70.cgi)
     Apache Tomcat is an open source software implementation of the Java Servlet and JavaServer Pages technologies.
 
- -  [Node v6.9+] (https://nodejs.org/) >= 12
+ -  [Node v12+] (https://nodejs.org/) 
     Javascript interpreter for command line environment, used for development tools
 
 #### Prepare before the build

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,10 +9,21 @@ See Firefly docker guidelines [here](firefly-docker.md).
 - docker tag: `nightly`
 
 ##### _UI_
+- Tables now handle array type data ([Firefly-150](https://github.com/Caltech-IPAC/firefly/pull/922)
 - Table Options UI Improvements ([Firefly-471](https://github.com/Caltech-IPAC/firefly/pull/928))
   - New `Advanced Filter` tab enabling SQL-like filtering
   - New `Table Meta` tab showing meta information that was once not accessible
   - Added additional column's meta when available
+- WCS match Improvements ([Firefly-484](https://github.com/Caltech-IPAC/firefly/pull/937))
+  - When matching to HiPS, images will rotate, if necessary
+  - When HiPS matched to image - Firefly will change HiPS coordinate system if images has EQJ200 or Galactic rotated north up
+- Better layout of Layer dialog for catalogs overlays ([Firefly-395](https://github.com/Caltech-IPAC/firefly/pull/919))
+- Significant improvements in Data Products Viewing ([Firefly-460](https://github.com/Caltech-IPAC/firefly/pull/924))
+  - Can choose from any HDU in FITS
+  - Table HDUs are show as table and Charts
+  - Firefly now reads 1D FITS images and shows as a chart
+  - Choice of table with VO Tables
+  - PDF and TAR are recognized and downloadable.
 
 
 ### Version 2019.4

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -20,6 +20,7 @@ import HelpIcon from './HelpIcon.jsx';
 import ROTATE_NORTH_OFF from 'html/images/icons-2014/RotateToNorth.png';
 import ROTATE_NORTH_ON from 'html/images/icons-2014/RotateToNorth-ON.png';
 import {hasWCSProjection} from '../visualize/PlotViewUtil';
+import {isImage} from '../visualize/WebPlot';
 
 const DIALOG_ID= 'fitsRotationDialog';
 
@@ -45,7 +46,7 @@ function FitsRotationImmediatePanel() {
     const [pv] = useStoreConnector(() => getActivePlotView(visRoot()));
 
     useEffect(() => {
-        !pv && dispatchHideDialog(DIALOG_ID);
+        (!pv || !isImage(primePlot(pv))) && dispatchHideDialog(DIALOG_ID);
     }, [pv]);
 
     const plot= primePlot(pv);

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -27,7 +27,12 @@ import {colorChangeActionCreator, stretchChangeActionCreator, cropActionCreator}
 import {wcsMatchActionCreator} from './task/WcsMatchTask.js';
 import {autoPlayActionCreator, changePointSelectionActionCreator,
     restoreDefaultsActionCreator, deletePlotViewActionCreator} from './task/PlotAdminTask.js';
-import { flipActionCreator, processScrollActionCreator, recenterActionCreator } from './task/PlotChangeTask';
+import {
+    changeHiPSActionCreator,
+    flipActionCreator,
+    processScrollActionCreator,
+    recenterActionCreator, rotateActionCreator
+} from './task/PlotChangeTask';
 import {makeAbortHiPSAction} from './task/PlotHipsTask';
 
 /** enum can be 'COLLAPSE', 'GRID', 'SINGLE' */
@@ -282,7 +287,9 @@ function actionCreators() {
         [DELETE_PLOT_VIEW]: deletePlotViewActionCreator,
         [RECENTER]: recenterActionCreator,
         [PROCESS_SCROLL]: processScrollActionCreator,
+        [CHANGE_HIPS]: changeHiPSActionCreator,
         [FLIP]: flipActionCreator,
+        [ROTATE]: rotateActionCreator,
     };
 }
 
@@ -647,8 +654,8 @@ export function dispatchPlotGroup({wpRequestAry, viewerId, pvOptions= {},
  * @param {string} p.plotId
  * @param {WebPlotParams|WebPlotRequest} p.wpRequest
  * @param {HipsImageConversionSettings} [p.hipsImageConversion= undefined] if defined, use these parameter to
- * @param {string} p.viewerId
- * @param {PVCreateOptions} p.pvOptions PlotView init Options
+ * @param {string} [p.viewerId]
+ * @param {PVCreateOptions} [p.pvOptions] PlotView init Options
  * @param {Object} [p.attributes] meta data that is added the plot
  * @param {boolean} [p.setNewPlotAsActive] the last completed plot will be active
  * @param {boolean} [p.enableRestore= true] if true the original request is saved for restore

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -95,10 +95,10 @@ export const ServerCallStatus= new Enum(['success', 'working', 'fail'], { ignore
  * @typedef {Object} PVCreateOptions
  * Object used for creating the PlotView
  *
- * @prop {HipsImageConversionSettings} hipsImageConversion If object is defined and populated correctly then
+ * @prop {HipsImageConversionSettings} [hipsImageConversion] If object is defined and populated correctly then
  * the PlotView will convert between HiPS and Image
- * @prop {Object} menuItemKeys - defines which menu items shows on the toolbar
- * @prop {boolean} userCanDeletePlots - default to true, defines if a PlotView can be deleted by the user
+ * @prop {Object} [menuItemKeys] - defines which menu items shows on the toolbar
+ * @prop {boolean} [userCanDeletePlots] - default to true, defines if a PlotView can be deleted by the user
  */
 
 

--- a/src/firefly/js/visualize/saga/ActiveRowCenterWatcher.js
+++ b/src/firefly/js/visualize/saga/ActiveRowCenterWatcher.js
@@ -6,7 +6,7 @@ import {isString, isObject} from 'lodash';
 import {TABLE_LOADED, TABLE_SELECT,TABLE_HIGHLIGHT,TABLE_REMOVE,TABLE_UPDATE,TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
 import {visRoot, dispatchRecenter} from '../ImagePlotCntlr.js';
 import {getTblById, getCellValue} from '../../tables/TableUtil.js';
-import Point, {makeWorldPt, makeAnyPt} from '../Point.js';
+import Point, {makeAnyPt} from '../Point.js';
 import {findTableCenterColumns} from '../../util/VOAnalyzer.js';
 import {
     getActivePlotView,
@@ -14,10 +14,9 @@ import {
     isFullyOnScreen,
     primePlot, willFitOnScreenAtCurrentZoom
 } from '../PlotViewUtil';
-import {toDegrees} from '../VisUtil';
 import {CysConverter} from '../CsysConverter';
 import {dispatchPlotImage, dispatchUseTableAutoScroll} from '../ImagePlotCntlr';
-import {isColRadians, isTableUsingRadians} from '../../tables/TableUtil';
+import {isTableUsingRadians} from '../../tables/TableUtil';
 import {PlotAttribute} from '../PlotAttribute';
 import {isImage} from '../WebPlot';
 import {getAppOptions} from '../../core/AppDataCntlr';
@@ -132,8 +131,9 @@ function recenterImageActiveRow(tbl_id, force=false) {
 
 
 function toAngle(d, radianToDegree)  {
-    const v= Number(d);
-    return (!isNaN(v) && radianToDegree) ? v*180/Math.PI : v;
+    const v= Number(d ?? NaN);
+    if (isNaN(v)) return v;
+    return radianToDegree ? v*180/Math.PI : v;
 }
 
 
@@ -151,10 +151,8 @@ export function getRowCenterWorldPt(tableOrId) {
     const rad= isTableUsingRadians(tbl, [lonCol,latCol]);
     const lon= toAngle(getCellValue(tbl,tbl.highlightedRow, lonCol),rad);
     const lat= toAngle(getCellValue(tbl,tbl.highlightedRow, latCol),rad);
-
-    const tmpPt= makeAnyPt(lon,lat,csys||CoordinateSys.EQ_J2000);
-    if (tmpPt.type!==Point.W_PT) return tmpPt;
-    return makeWorldPt(isColRadians(tbl,lonCol)? toDegrees(lon) : lon, isColRadians(tbl,latCol)? toDegrees(lat): lat, csys);
+    if (isNaN(lon) || isNaN(lat)) return;
+    return makeAnyPt(lon,lat,csys||CoordinateSys.EQ_J2000);
 }
 
 function getTableModel(tableOrId) {

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -11,8 +11,7 @@ import WebPlotResult from '../WebPlotResult.js';
 import {WebPlot} from '../WebPlot.js';
 import {makeCubeCtxAry, populateFromHeader} from './PlotImageTask';
 import {isHiPS, isImage} from '../WebPlot';
-import {matchHiPStoPlotView} from './PlotHipsTask';
-import {matchImageToHips} from './WcsMatchTask';
+import {matchHiPStoPlotView, matchImageToHips} from './WcsMatchTask';
 
 
 
@@ -33,27 +32,25 @@ export function flipActionCreator(rawAction) {
     };
 }
 
-
-export function recenterActionCreator(rawAction) {
-    return (dispatcher,getState) => {
+const dispatchAndMaybeMatch= (rawAction) => (dispatcher,getState) => {
         dispatcher(rawAction);
-        locateHiPSIfMatched(getState()[IMAGE_PLOT_KEY], rawAction.payload.plotId);
+        locateOtherIfMatched(getState()[IMAGE_PLOT_KEY], rawAction.payload.plotId);
     };
-}
 
 
-export function processScrollActionCreator(rawAction) {
-    return (dispatcher,getState) => {
-        dispatcher(rawAction);
-        locateHiPSIfMatched(getState()[IMAGE_PLOT_KEY], rawAction.payload.plotId);
-    };
-}
+export const recenterActionCreator= (rawAction) => dispatchAndMaybeMatch(rawAction);
+export const processScrollActionCreator= (rawAction) => dispatchAndMaybeMatch(rawAction);
+export const changeHiPSActionCreator= (rawAction) => dispatchAndMaybeMatch(rawAction);
+export const rotateActionCreator= (rawAction) => dispatchAndMaybeMatch(rawAction);
+
+
+
 
 /**
  * @param {VisRoot} vr
  * @param {String} plotId
  */
-function locateHiPSIfMatched(vr,plotId) {
+function locateOtherIfMatched(vr,plotId) {
     const pv = getPlotViewById(vr, plotId);
     if (vr.wcsMatchType !== WcsMatchType.Target && vr.wcsMatchType !== WcsMatchType.Standard) return;
     if (isImage(primePlot(pv))) matchHiPStoPlotView(vr, pv);

--- a/src/firefly/js/visualize/task/ZoomTask.js
+++ b/src/firefly/js/visualize/task/ZoomTask.js
@@ -16,8 +16,7 @@ import {isImageViewerSingleLayout, getMultiViewRoot} from '../MultiViewCntlr.js'
 import WebPlotResult from '../WebPlotResult.js';
 import VisUtil from '../VisUtil.js';
 import {doHiPSImageConversionIfNecessary} from './PlotHipsTask.js';
-import {matchHiPStoPlotView} from './PlotHipsTask';
-import {matchImageToHips} from './WcsMatchTask';
+import {matchImageToHips, matchHiPStoPlotView} from './WcsMatchTask';
 
 
 const ZOOM_WAIT_MS= 1500; // 1.5 seconds

--- a/src/firefly/js/visualize/ui/VisToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbar.jsx
@@ -6,7 +6,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {take} from 'redux-saga/effects';
-import {omit,pick, get} from 'lodash';
+import {omit,pick} from 'lodash';
 import shallowequal from 'shallowequal';
 import ImagePlotCntlr, {visRoot} from '../ImagePlotCntlr.js';
 import {getDlAry} from '../DrawLayerCntlr.js';
@@ -21,11 +21,8 @@ import {isHiPS} from '../WebPlot.js';
 import {getPreference} from '../../core/AppDataCntlr';
 import {TARGET_LIST_PREF} from './ImageCenterDropDown';
 
-// import {deepDiff} from '../../util/WebUtil.js';
-
 const omList= ['plotViewAry'];
 const pvPickList= ['plotViewCtx','primeIdx', 'flipY'];
-const hipsUrl = 'hipsUrlRoot';
 
 
 
@@ -88,10 +85,10 @@ export class VisToolbar extends PureComponent {
         if (!needsUpdate) {
             const oldPlot = primePlot(oldPv);
             const newPlot = primePlot(newPv);
-            needsUpdate = get(oldPlot, 'zoomFactor') !== get(newPlot, 'zoomFactor');
+            needsUpdate = oldPlot?.zoomFactor !== newPlot?.zoomFactor;
 
             if (!needsUpdate && isHiPS(oldPlot) && isHiPS(newPlot)) {
-                needsUpdate = get(oldPlot,  hipsUrl) !== get(newPlot, hipsUrl);
+                needsUpdate = (oldPlot.hipsUrl !== newPlot.hipsUrl) || (oldPlot.imageCoordSys !== newPlot.imageCoordSys);
             }
         }
 
@@ -105,7 +102,6 @@ export class VisToolbar extends PureComponent {
         const {messageUnder, style}= this.props;
         const {visRoot,tip,dlCount, recentTargetAry}= this.state;
         return (
-
             <ToolTipCtx.Provider value={{tipOnCB: this.tipOn, tipOffCB: this.tipOff}}>
                 <VisToolbarViewWrapper visRoot={visRoot} toolTip={tip} dlCount={dlCount}
                                        messageUnder={messageUnder} style={style} recentTargetAry={recentTargetAry}/>


### PR DESCRIPTION
Firefly-484: HiPS/Image WCS match rotate updates
  - The actual fix to this bug was to make the image rotate to the FITS orientation
  - Image rotating to the HiPS orientation on WCS match is actually a new feature that was requested in the past

When WCS matching:
   - When FITS rotates the HiPS will change coordsys it if it EQJ2000 north or Galactic north
   - When HiPS changes coordinateSys FITS will rotate to it.
   - FITS will rotate when locking to a HIPS


_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-484

### Testing

https://irsawebdev9.ipac.caltech.edu/firefly-484-hips-rotate/firefly/

1. Attempt repeat the ticket, the problem should be fix.
1. Bring in a FITS and HiPS, wcs match lock
    - switch coordinate system on the HiPS, the fits will rotate
    - rotate the hips as you cross J2000 north or galactic north the HiPS will change coordinate systems.
    - rotate a image north, it the hips is galactic it will change to J2000
