### PR TITLE
FIREFLY-488: enforce new cache policy

### DIFF
--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -119,13 +119,14 @@ task createVersionTag  {
         props.setProperty('BuildMajor', major)
         props.setProperty('BuildMinor', minor)
         props.setProperty('BuildRev', rev)
-        props.setProperty('ClientBuildEnv', project.hasProperty("env") ? project.env : "local")
         props.setProperty('BuildType', type)
         props.setProperty('BuildNumber', buildNum)
         props.setProperty('BuildDate', build_date)
         props.setProperty('BuildTime', build_time)
         props.setProperty('BuildTag', tag)
         props.setProperty('BuildCommit', getCommitHash())
+
+        props.setProperty('ExtendedCache', project.env == "local" ? (project.hasProperty("ExtendedCache") ? project.ExtendedCache : "true") : "false")
 
         if (fireflyPath != rootDir.getPath()) {
             props.setProperty('BuildCommitFirefly', getCommitHash(fireflyPath))
@@ -823,7 +824,7 @@ task buildAndPublish( dependsOn: war ) {
 }
 
 
-task devMode (dependsOn: loadConfig) {
+task devMode (dependsOn: createVersionTag) {
     description= 'JavaScript Dev Mode'
     group = DEV_GROUP
     outputs.upToDateWhen { false }

--- a/buildScript/webpack.config.js
+++ b/buildScript/webpack.config.js
@@ -61,9 +61,8 @@ export default function makeWebpackConfig(config) {
     }
 
     const globals = {
-        'process.env'   : {NODE_ENV : JSON.stringify(config.env)},
-        NODE_ENV        : config.env,
         __PROPS__       : {
+            BUILD_ENV   : JSON.stringify(process.env.BUILD_ENV || 'local'),
             SCRIPT_NAME : JSON.stringify(script_names),
             MODULE_NAME : JSON.stringify(config.name)
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -35,9 +35,10 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
     public static final String FIXED_LENGTH = "fixedLength";
     public static final String META_INFO = "META_INFO";
     public static final String META_OPTIONS = "META_OPTIONS";
-    public static final List<String> SYS_PARAMS = Arrays.asList(REQUEST_CLASS,INCL_COLUMNS,SORT_INFO,FILTERS,SQL_FILTER,PAGE_SIZE,START_IDX,FIXED_LENGTH,META_INFO,TBL_ID);
+    public static final String FF_SESSION_ID = "ffSessionId";
     public static final String TBL_INDEX = "tbl_index";     // the table to show if it's a multi-table file.
     public static final String SELECT_INFO = "selectInfo";  // a property of META_INFO.  deserialize into SelectionInfo.java
+    private static final List<String> SYS_PARAMS = Arrays.asList(REQUEST_CLASS,INCL_COLUMNS,SORT_INFO,FILTERS,SQL_FILTER,PAGE_SIZE,START_IDX,FIXED_LENGTH,META_INFO,TBL_ID, FF_SESSION_ID);
 
     private int pageSize = -1;
     private int startIdx;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
@@ -24,6 +24,8 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.SortedSet;
 
+import static edu.caltech.ipac.firefly.data.TableServerRequest.FF_SESSION_ID;
+
 /**
  * Date: Jun 5, 2009
  *
@@ -58,22 +60,11 @@ public interface SearchProcessor<Type> {
     static String getUniqueIDDef(TableServerRequest request) {
         RequestOwner ro = ServerContext.getRequestOwner();
         SortedSet<Param> params = request.getSearchParams();
-        params.add(new Param("sessID", ro.getRequestAgent().getSessId()));
+        params.add(new Param("sessID", request.getParam(FF_SESSION_ID)));
         if (ro.isAuthUser()) {
             params.add( new Param("userID", ro.getUserInfo().getLoginName()));
         }
         return StringUtils.toString(params, "|");
-    }
-
-    static void prepareTableMetaDef(TableMeta defaults, List<DataType> columns, ServerRequest request) {
-        if (defaults != null && request instanceof TableServerRequest) {
-            TableServerRequest tsreq = (TableServerRequest) request;
-            if (tsreq.getMeta() != null && tsreq.getMeta().size() > 0) {
-                for (String key : tsreq.getMeta().keySet()) {
-                    defaults.setAttribute(key, tsreq.getMeta(key));
-                }
-            }
-        }
     }
 
     static void logStats(String searchType, int rows, long fileSize, boolean fromCached, Object... params) {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -23,7 +23,7 @@ import {reduxFlux} from './core/ReduxFlux.js';
 import {wsConnect} from './core/messaging/WebSocketClient.js';
 import {ActionEventHandler} from './core/messaging/MessageHandlers.js';
 import {init} from './rpc/CoreServices.js';
-import {getPropsWith, mergeObjectOnly, getProp} from './util/WebUtil.js';
+import {getPropsWith, mergeObjectOnly, getProp, toBoolean} from './util/WebUtil.js';
 import {initLostConnectionWarning} from './ui/LostConnection.jsx';
 import {dispatchChangeTableAutoScroll, dispatchWcsMatch, visRoot} from './visualize/ImagePlotCntlr';
 
@@ -32,7 +32,7 @@ export const flux = reduxFlux;
 var initDone = false;
 
 export const getFireflySessionId= once(() =>
-    getProp('version.ClientBuildEnv')==='local' ? 'LOCAL_SESSION' : `FF-Session-${Date.now()}`);
+    toBoolean(getProp('version.ExtendedCache')) ? 'KEEP_SESSION' : `FF-Session-${Date.now()}`);
 
 /**
  * A list of available templates

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -18,6 +18,7 @@ import {getTblById, getResultSetID, getResultSetRequest} from '../tables/TableUt
 import {MAX_ROW, DataTagMeta, getTblId, setResultSetID, setResultSetRequest, setSelectInfo} from '../tables/TableRequestUtil.js';
 import {SelectInfo} from '../tables/SelectInfo.js';
 import {getBackgroundJobs} from '../core/background/BackgroundUtil.js';
+import {getFireflySessionId} from '../Firefly.js';
 
 export const DownloadProgress= new Enum(['STARTING', 'WORKING', 'DONE', 'UNKNOWN', 'FAIL']);
 export const ScriptAttributes= new Enum(['URLsOnly', 'Unzip', 'Ditto', 'Curl', 'Wget', 'RemoveZip']);
@@ -42,7 +43,8 @@ export function fetchTable(tableRequest, hlRowIdx) {
 
     const def = {
         startIdx: 0,
-        pageSize : MAX_ROW
+        pageSize : MAX_ROW,
+        ffSessionId: getFireflySessionId(),
     };
     
     tableRequest = setupNewRequest(tableRequest, def);


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-488

Implement new cache policy for table searches.
Table results are only saved for the duration of the page.  Upon reload, all table searches should refetch data and not use cached version.

Also in this PR, fix Gator master table processor (CatMasterTableQuery) so that it does not do any caching of its own.  It should follow the same caching policy mentioned above.  In doing so, the code is rewritten to parse the IPAC table directly from IO stream avoiding having to write out the IPAC table into `perm-files` first.  This is one step closer to removing `perm_files` directory.  This should also fix the exception encountered when `perm_files` directory is deleted during runtime.

Test:  https://irsawebdev9.ipac.caltech.edu/FIREFLY-488_table_cache_update/firefly/
I test this using catalog search with larger radius.  It's obvious when a new fetch happens versus a cached load.

Also, added the ability to disabled  extended caching feature added for developer in a previous PR.  This allow a developer to experience the behavior of production environment locally.

To do disable extended caching:

`echo 'ExtendedCache = "false"' >> ~/.gradle/build.config `



