### PR TITLE
IRSA-1571:Finder Chart API: color images for SEIP and Akari are not supported for the moment in API mode. ColorImage Download in Finderchart UI is not working either.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FinderChartRequestUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FinderChartRequestUtil.java
@@ -80,11 +80,11 @@ public class FinderChartRequestUtil {
      * Expected format :  metadata expected to be as "schema.table-band;title"
      */
     private final static String seipCombo[]={
-            "spitzer.seip_science:IRAC1;SEIP IRAC1 (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
-            "spitzer.seip_science:IRAC2;SEIP IRAC2 (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
-            "spitzer.seip_science:IRAC3;SEIP IRAC3 (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
-            "spitzer.seip_science:IRAC4;SEIP IRAC4 (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
-            "spitzer.seip_science:MIPS24;SEIP MIPS (2.4 microns);file_type='science' and fname like '%.mosaic.fits'"
+            "spitzer.seip_science:IRAC1; SEIP  irac1   (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
+            "spitzer.seip_science:IRAC2; SEIP irac2   (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
+            "spitzer.seip_science:IRAC3; SEIP irac3   (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
+            "spitzer.seip_science:IRAC4; SEIP irac4   (2.4 microns);file_type='science' and fname like '%.mosaic.fits'",
+            "spitzer.seip_science:MIPS24;SEIP  mips24 (2.4 microns);file_type='science' and fname like '%.mosaic.fits'"
     };
 
     /**
@@ -92,11 +92,13 @@ public class FinderChartRequestUtil {
      * THis is passed from the client
      * Expected format :  metadata expected to be as "schema.table-band;title"
      */
+
+    //TODO this is the DESC definetion, which is in consistence of the band name specified
     private final static String akariCombo[]={
-            "akari.akari_images:N60;FIS N60 (65 microns)",
-            "akari.akari_images:WideS;FIS WideS (90 microns)",
-            "akari.akari_images:WideL;FIS WideL (140 microns)",
-            "akari.akari_images:N160;FIS N160 (160 microns)"
+            "akari.akari_images:N60  ;FIS n60 (65 microns)",
+            "akari.akari_images:WideS;FIS wideS (90 microns)",
+            "akari.akari_images:WideL;FIS wideL (140 microns)",
+            "akari.akari_images:N160 ;FIS n160 (160 microns)"
     };
 
     private final static String sDssCombo[]={
@@ -161,7 +163,7 @@ public class FinderChartRequestUtil {
                 wpReq= WebPlotRequest.makeSloanDSSRequest(pt, getComboValue(key), radius);
                 break;
             case TWOMASS:
-                wpReq= WebPlotRequest.make2MASSRequest(pt, "asky", getComboValue(key),radius);
+                wpReq= WebPlotRequest.make2MASSRequest(pt, "asky",getComboValue(key),radius);
                 break;
             case AKARI:
             case SEIP:
@@ -189,7 +191,7 @@ public class FinderChartRequestUtil {
      */
     public static String extractSurveyKey(String metadata) {
         String sAry[] = metadata.split(regExAtlasKey);
-        return sAry[0];
+        return sAry[0].trim();
     }
 
     /**
@@ -198,7 +200,7 @@ public class FinderChartRequestUtil {
      */
     public static String extractSurveyKeyBand(String metadata) {
         String sAry[] = metadata.split(regExAtlasKey);
-        return sAry[1];
+        return sAry[1].trim();
     }
 
     /**
@@ -218,7 +220,7 @@ public class FinderChartRequestUtil {
      */
     public static String getComboValue(String combo) {
         String sAry[] = combo.split(regExSplitKey);
-        return sAry.length > 0 ? sAry[0] : combo;
+        return sAry.length > 0 ? sAry[0].trim() : combo;
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/ServiceRetriever.java
@@ -5,6 +5,7 @@ package edu.caltech.ipac.firefly.server.visualize.imageretrieve;
 
 import edu.caltech.ipac.astro.ibe.datasource.AtlasIbeDataSource;
 import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.Param;
 import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.firefly.server.query.ibe.IbeQueryArtifact;
 import edu.caltech.ipac.firefly.server.util.Logger;
@@ -61,9 +62,9 @@ public class ServiceRetriever implements FileRetriever {
             case DSS: return getDssPlot(r);
             case SDSS: return getSloanDSSPlot(r);
             case WISE: return getWisePlot(r);
-            case AKARI:
             case ZTF: return getZtfPlot(r);
             case PTF: return getPtfPlot(r);
+            case AKARI:
             case SEIP:
             case ATLAS: return getAtlasPlot(r);
             case DSS_OR_IRIS: return getDSSorIris(r);
@@ -180,7 +181,7 @@ public class ServiceRetriever implements FileRetriever {
 
     private FileInfo getAtlasPlot(WebPlotRequest r) throws FailedRequestException {
         Circle circle = PlotServUtils.getRequestArea(r);
-        AtlasImageParams params = new AtlasImageParams();
+        AtlasImageParams params = new AtlasImageParams(r.getSurveyKey(), r.getParam("table"));
         params.setWorldPt(circle.getCenter());
         params.setBand(r.getSurveyBand());
         // New image search deals with atlas surveyKey formatted such as 'schema.table'

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AtlasImageParams.java
@@ -18,7 +18,11 @@ public class AtlasImageParams extends IrsaImageParams {
     private String xtraFilter = ""; // i.e fname like '%.mosaic.fits' or file_tye=science
     private String data_type = "image";
 
-    public AtlasImageParams() { super(ImageSourceTypes.ATLAS); }
+    public AtlasImageParams(String service, String table){
+        super(ImageSourceTypes.ATLAS);
+        this.schema = service;
+        this.table = table;
+    }
 
     public void setInstrument(String b) {
         this._instrument = b;


### PR DESCRIPTION
  https://jira.ipac.caltech.edu/browse/IRSA-1571

Fixed the bugs in FinderChartRequestUtil.java, ServiceRetriever.java, and AtlasImageParams.java.
Please see the comments and logs in the ticket IRSA-1571 for details.  The change in Firefly is to make the finderchart API and UI to work properly. 