### PR TITLE
IRSA-2590-SOFIA FIFI-LS: missing information when displaying Level 3 from spectral images

### DIFF
--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -225,8 +225,8 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
             const part1 = {
                 N, algorithm, ctype, restWAV, pc_3j, r_j,
                 ps3_0, ps3_1, ps3_2, pv3_1, pv3_2,pv3_3,
-                s_3: isNaN(cdelt) ? 0 : cdelt,
-                lambda_r: isNaN(crval) ? 0 : crval,
+                s_3:  cdelt,
+                lambda_r:  crval,
                 wlTable
             };
 
@@ -271,10 +271,10 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
 
 
     return {
-        N, algorithm, ctype, restWAV, wlType, crpix, crval, cdelt, failReason, failWarning, units, pc_3j, r_j,
+        N, algorithm, ctype, restWAV, wlType, crpix, crval, failReason, failWarning, units, pc_3j, r_j,
         ps3_0, ps3_1, ps3_2, pv3_1, pv3_2, pv3_3,
-        s_3: isNaN(cdelt) ? 0 : cdelt,
-        lambda_r: isNaN(crval) ? 0 : crval,
+        s_3: cdelt,
+        lambda_r:  crval,
         wlTable
     };
 }

--- a/src/firefly/js/visualize/projection/__tests__/Wavelength-test.js
+++ b/src/firefly/js/visualize/projection/__tests__/Wavelength-test.js
@@ -372,6 +372,7 @@ function calculateExpectedTabWavelength( header, wlTable){
     let pixCoords, ipt, gamma_m;
 
     let wl=[];
+    let psiIdx, kIndex;
     for (let i=0; i<tabPointArray.length; i++){
         ipt = tabPointArray[i];
         pixCoords = getPixelCoordinates(ipt, header);
@@ -380,10 +381,10 @@ function calculateExpectedTabWavelength( header, wlTable){
         //console.log('omega='+omega);
         //psi_m = lambda_r + cdelt* omega;
         //console.log('psi_m='+psi_m);
-        gamma_m =pixIdxAry[i] + 1  + (psi_mAry[i] - indexVec[pixIdxAry[i]]) / (indexVec[pixIdxAry[i]+1] - indexVec[pixIdxAry[i]]);
-        const kIndex = Math.floor(gamma_m);
+        psiIdx = pixIdxAry[i];
+        gamma_m = psiIdx + 1  + (psi_mAry[i] - indexVec[psiIdx]) / (indexVec[psiIdx+1] - indexVec[psiIdx]);
+        kIndex = Math.floor(gamma_m);
         wl[i] =coords[kIndex] + (gamma_m - (kIndex+1) )* (coords[kIndex+1]-coords[kIndex]);
-
     }
 
     return wl;


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-517
https://jira.ipac.caltech.edu/browse/IRSA-2590

Two tickets above were implemented in this PR. 
  
- Fixed  bugs in Wavelength calculation formula
- Changed the calculation for the case that has no index table and the coordinate table does not follow the standard
- Update the unit tests based on the new changes
The UI can be tested by combining with https://github.com/IPAC-SW/irsa-ife/pull/105. 
To test unit test, 
  gradle :fi:jTest
  
URL: https://irsawebdev9.ipac.caltech.edu/IRSA-2590-sofia-FIFI-LS/irsaviewer/