### PR TITLE
Firefly-497: Updates for Data Products Viewer

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -26,6 +26,7 @@ import {init} from './rpc/CoreServices.js';
 import {getPropsWith, mergeObjectOnly, getProp, toBoolean} from './util/WebUtil.js';
 import {initLostConnectionWarning} from './ui/LostConnection.jsx';
 import {dispatchChangeTableAutoScroll, dispatchWcsMatch, visRoot} from './visualize/ImagePlotCntlr';
+import {makeAnalysisGetGridDataProduct, makeAnalysisGetSingleDataProduct} from './metaConvert/MultiProductFileAnalyzer';
 
 export const flux = reduxFlux;
 
@@ -139,6 +140,10 @@ const defFireflyOptions = {
     },
     coverage : {
         // TODO: need to define all options with defaults here.  used in FFEntryPoint.js
+    },
+    multiProducesViewer : {
+        factoryOverride: [
+        ]
     },
     tap : {
         services: [

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -341,7 +341,7 @@ export function changeActiveFileMenuItem(state,action) {
 
 
     const actIdx= fileMenu.menu.findIndex( (m) => m.menuKey===newActiveFileMenuKey);
-    const fileMenuItem= fileMenu.menu[actIdx<0?0:actIdx];
+    const fileMenuItem= fileMenu.menu[actIdx<0? fileMenu.initialDefaultIndex: actIdx];
 
     const {activate,displayType,message,chartTableDefOption}= fileMenuItem;
 

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -343,7 +343,7 @@ export function changeActiveFileMenuItem(state,action) {
     const actIdx= fileMenu.menu.findIndex( (m) => m.menuKey===newActiveFileMenuKey);
     const fileMenuItem= fileMenu.menu[actIdx<0?0:actIdx];
 
-    const {activate,displayType,message}= fileMenuItem;
+    const {activate,displayType,message,chartTableDefOption}= fileMenuItem;
 
     dpData.activeFileMenuKeys={...activeFileMenuKeys, [fileMenu.activeItemLookupKey]:fileMenuItem.menuKey};
 
@@ -357,7 +357,7 @@ export function changeActiveFileMenuItem(state,action) {
     }
 
     const newFileMenu= {...fileMenu, activeFileMenuKey:newActiveFileMenuKey};
-    const newDisplayProduct= { ...selectedMenuDataProduct, displayType, activate, message, fileMenu:newFileMenu, activeMenuKey:menuKey};
+    const newDisplayProduct= { ...selectedMenuDataProduct, displayType, chartTableDefOption, activate, message, fileMenu:newFileMenu, activeMenuKey:menuKey};
     const newMenu= menu && menu.map( (menuItem) => (menuItem.menuKey!==menuKey) ? menuItem : newDisplayProduct );
     dpData.dataProducts= {...newDisplayProduct, menu:newMenu};
     return insertOrReplace(state,dpData);

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -27,6 +27,7 @@ import {dpdtImage} from './DataProductsType';
 import {dispatchUpdateCustom} from '../visualize/MultiViewCntlr';
 import {getDataSourceColumn} from '../util/VOAnalyzer';
 import {getColumn, getMetaEntry} from '../tables/TableUtil';
+import {getAppOptions} from '../core/AppDataCntlr';
 
 const FILE= 'FILE';
 
@@ -152,145 +153,184 @@ function getRelatedDataProductWrapper(makeReq) {
  */
 
 
-/**
- * @type {Array.<DataProductsConvertType>}
- */
-export const converterTemplates = [
-    {
-        converterId : 'wise',
-        tableMatches: (table) => matchById(table,'wise'),
-        create : simpleCreate,
-        threeColor : true,
-        hasRelatedBands : true,
-        canGrid : true,
-        maxPlots : 12,
-        getSingleDataProduct: getSingleDataProductWrapper(makeWisePlotRequest),
-        getGridDataProduct: getGridDataProductWrapper(makeWisePlotRequest),
-        getRelatedDataProduct: getRelatedDataProductWrapper(makeWisePlotRequest),
-        threeColorBands : {
-            b1 : {color : Band.RED, title: 'Band 1'},
-            b2 : {color : Band.GREEN, title: 'Band 2'},
-            b3 : {color : null, title: 'Band 3'},
-            b4 : {color : Band.BLUE, title: 'Band 4'}
+
+
+function initConverterTemplates() {
+    /**
+     * @type {Array.<DataProductsConvertType>}
+     */
+    const originalConverterTemplates = [
+        {
+            converterId: 'wise',
+            tableMatches: (table) => matchById(table, 'wise'),
+            create: simpleCreate,
+            threeColor: true,
+            hasRelatedBands: true,
+            canGrid: true,
+            maxPlots: 12,
+            getSingleDataProduct: getSingleDataProductWrapper(makeWisePlotRequest),
+            getGridDataProduct: getGridDataProductWrapper(makeWisePlotRequest),
+            getRelatedDataProduct: getRelatedDataProductWrapper(makeWisePlotRequest),
+            threeColorBands: {
+                b1: {color: Band.RED, title: 'Band 1'},
+                b2: {color: Band.GREEN, title: 'Band 2'},
+                b3: {color: null, title: 'Band 3'},
+                b4: {color: Band.BLUE, title: 'Band 4'}
+            },
         },
-    },
-    {
-        converterId : 'atlas',
-        tableMatches: (table) => matchById(table,'atlas'),
-        create : simpleCreate,
-        hasRelatedBands : true,
-        canGrid : true,
-        maxPlots : 5,
-        getSingleDataProduct: getSingleDataProductWrapper(makeAtlasPlotRequest),
-        getGridDataProduct: getGridDataProductWrapper(makeAtlasPlotRequest),
-        getRelatedDataProduct: getRelatedDataProductWrapper(makeAtlasPlotRequest),
-    },
-    {
-        converterId : 'twomass',
-        tableMatches: (table) => matchById(table,'twomass'),
-        create : simpleCreate,
-        threeColor : true,
-        hasRelatedBands : true,
-        canGrid : true,
-        maxPlots : 12,
-        getSingleDataProduct: getSingleDataProductWrapper(make2MassPlotRequest),
-        getGridDataProduct: getGridDataProductWrapper(make2MassPlotRequest),
-        getRelatedDataProduct: getRelatedDataProductWrapper(make2MassPlotRequest),
-        threeColorBands : {
-            J : {color : Band.RED, title: 'J'},
-            H : {color : Band.GREEN, title: 'H'},
-            K : {color : Band.BLUE, title: 'K'}
+        {
+            converterId: 'atlas',
+            tableMatches: (table) => matchById(table, 'atlas'),
+            create: simpleCreate,
+            hasRelatedBands: true,
+            canGrid: true,
+            maxPlots: 5,
+            getSingleDataProduct: getSingleDataProductWrapper(makeAtlasPlotRequest),
+            getGridDataProduct: getGridDataProductWrapper(makeAtlasPlotRequest),
+            getRelatedDataProduct: getRelatedDataProductWrapper(makeAtlasPlotRequest),
+        },
+        {
+            converterId: 'twomass',
+            tableMatches: (table) => matchById(table, 'twomass'),
+            create: simpleCreate,
+            threeColor: true,
+            hasRelatedBands: true,
+            canGrid: true,
+            maxPlots: 12,
+            getSingleDataProduct: getSingleDataProductWrapper(make2MassPlotRequest),
+            getGridDataProduct: getGridDataProductWrapper(make2MassPlotRequest),
+            getRelatedDataProduct: getRelatedDataProductWrapper(make2MassPlotRequest),
+            threeColorBands: {
+                J: {color: Band.RED, title: 'J'},
+                H: {color: Band.GREEN, title: 'H'},
+                K: {color: Band.BLUE, title: 'K'}
+            }
+        },
+        {
+            converterId: 'ztf',
+            tableMatches: (table) => matchById(table, 'ztf'),
+            create: simpleCreate,
+            hasRelatedBands: false,
+            canGrid: true,
+            maxPlots: 12,
+            getSingleDataProduct: getSingleDataProductWrapper(makeZtfPlotRequest),
+            getGridDataProduct: getGridDataProductWrapper(makeZtfPlotRequest),
+            getRelatedDataProduct: getRelatedDataProductWrapper(makeZtfPlotRequest),
+        },
+        {
+            converterId: 'lsst_sdss',
+            tableMatches: (table) => matchById(table, 'lsst_sdss'),
+            create: simpleCreate,
+            threeColor: true,
+            hasRelatedBands: true,
+            canGrid: true,
+            maxPlots: 12,
+            getSingleDataProduct: getSingleDataProductWrapper(makeLsstSdssPlotRequest),
+            getGridDataProduct: getGridDataProductWrapper(makeLsstSdssPlotRequest),
+            getRelatedDataProduct: getRelatedDataProductWrapper(makeLsstSdssPlotRequest),
+            threeColorBands: {
+                u: {color: null, title: 'u'},
+                g: {color: Band.RED, title: 'g'},
+                r: {color: Band.GREEN, title: 'r'},
+                i: {color: null, title: 'i'},
+                z: {color: Band.BLUE, title: 'z'}
+            }
+        },
+        {
+            converterId: 'lsst_wise',
+            tableMatches: (table) => matchById(table, 'lsst_wise'),
+            create: simpleCreate,
+            threeColor: true,
+            hasRelatedBands: true,
+            canGrid: true,
+            maxPlots: 12,
+            getSingleDataProduct: getSingleDataProductWrapper(makeLsstWisePlotRequest),
+            getGridDataProduct: getGridDataProductWrapper(makeLsstWisePlotRequest),
+            getRelatedDataProduct: getRelatedDataProductWrapper(makeLsstWisePlotRequest),
+            threeColorBands: {
+                b1: {color: Band.RED, title: 'Band 1'},
+                b2: {color: Band.GREEN, title: 'Band 2'},
+                b3: {color: null, title: 'Band 3'},
+                b4: {color: Band.BLUE, title: 'Band 4'}
+            }
+        },
+        {
+            converterId: 'ObsCore',
+            tableMatches: hasObsCoreLikeDataProducts,
+            create: makeObsCoreConverter,
+            threeColor: false,
+            hasRelatedBands: false,
+            canGrid: true,
+            maxPlots: 8,
+            getSingleDataProduct: getObsCoreSingleDataProduct,
+            getGridDataProduct: getObsCoreGridDataProduct,
+            getRelatedDataProduct: () => Promise.reject('related data products not supported')
+        },
+        {
+            converterId: 'SimpleMoving',
+            tableMatches: () => false,
+            create: simpleCreate,
+            threeColor: false,
+            hasRelatedBands: false,
+            canGrid: false,
+            maxPlots: 12,
+            getSingleDataProduct: getSingleDataProductWrapper(makeRequestSimpleMoving),
+            getGridDataProduct: () => Promise.reject('grid not supported'),
+            getRelatedDataProduct: () => Promise.reject('related data products not supported')
+        },
+        {                            // this one should be last, it is the fallback
+            converterId: 'UNKNOWN',
+            tableMatches: findADataSourceColumn,
+            create: simpleCreate,
+            threeColor: false,
+            hasRelatedBands: false,
+            canGrid: true,
+            maxPlots: 3,
+            getSingleDataProduct: makeAnalysisGetSingleDataProduct(makeRequestForUnknown),
+            getGridDataProduct: makeAnalysisGetGridDataProduct(makeRequestForUnknown),
+            getRelatedDataProduct: () => Promise.reject('related data products not supported')
         }
-    },
-    {
-        converterId : 'ztf',
-        tableMatches: (table) => matchById(table,'ztf'),
-        create : simpleCreate,
-        hasRelatedBands : false,
-        canGrid : true,
-        maxPlots : 12,
-        getSingleDataProduct: getSingleDataProductWrapper(makeZtfPlotRequest),
-        getGridDataProduct: getGridDataProductWrapper(makeZtfPlotRequest),
-        getRelatedDataProduct: getRelatedDataProductWrapper(makeZtfPlotRequest),
-    },
-    {
-        converterId : 'lsst_sdss',
-        tableMatches: (table) => matchById(table,'lsst_sdss'),
-        create : simpleCreate,
-        threeColor : true,
-        hasRelatedBands : true,
-        canGrid : true,
-        maxPlots : 12,
-        getSingleDataProduct: getSingleDataProductWrapper(makeLsstSdssPlotRequest),
-        getGridDataProduct: getGridDataProductWrapper(makeLsstSdssPlotRequest),
-        getRelatedDataProduct: getRelatedDataProductWrapper(makeLsstSdssPlotRequest),
-        threeColorBands : {
-            u : {color : null, title: 'u'},
-            g : {color : Band.RED, title: 'g'},
-            r : {color : Band.GREEN, title: 'r'},
-            i : {color : null,  title: 'i'},
-            z : {color : Band.BLUE, title: 'z'}
-        }
-    },
-    {
-        converterId : 'lsst_wise',
-        tableMatches: (table) => matchById(table,'lsst_wise'),
-        create : simpleCreate,
-        threeColor : true,
-        hasRelatedBands : true,
-        canGrid : true,
-        maxPlots : 12,
-        getSingleDataProduct: getSingleDataProductWrapper(makeLsstWisePlotRequest),
-        getGridDataProduct: getGridDataProductWrapper(makeLsstWisePlotRequest),
-        getRelatedDataProduct: getRelatedDataProductWrapper(makeLsstWisePlotRequest),
-        threeColorBands : {
-            b1 : {color : Band.RED, title: 'Band 1'},
-            b2 : {color : Band.GREEN, title: 'Band 2'},
-            b3 : {color : null, title: 'Band 3'},
-            b4 : {color : Band.BLUE, title: 'Band 4'}
-        }
-    },
-    {
-        converterId : 'ObsCore',
-        tableMatches: hasObsCoreLikeDataProducts,
-        create : makeObsCoreConverter,
-        threeColor : false,
-        hasRelatedBands : false,
-        canGrid : true,
-        maxPlots : 8,
-        getSingleDataProduct: getObsCoreSingleDataProduct,
-        getGridDataProduct: getObsCoreGridDataProduct,
-        getRelatedDataProduct: () => Promise.reject('related data products not supported')
-    },
-    {
-        converterId : 'SimpleMoving',
-        tableMatches: () => false,
-        create : simpleCreate,
-        threeColor : false,
-        hasRelatedBands : false,
-        canGrid : false,
-        maxPlots : 12,
-        getSingleDataProduct: getSingleDataProductWrapper(makeRequestSimpleMoving),
-        getGridDataProduct: () => Promise.reject('grid not supported'),
-        getRelatedDataProduct: () => Promise.reject('related data products not supported')
-    },
-    {                            // this one should be last, it is the fallback
-        converterId : 'UNKNOWN',
-        tableMatches: findADataSourceColumn,
-        create : simpleCreate,
-        threeColor : false,
-        hasRelatedBands : false,
-        canGrid : true,
-        maxPlots : 3,
-        getSingleDataProduct: makeAnalysisGetSingleDataProduct(makeRequestForUnknown),
-        getGridDataProduct: makeAnalysisGetGridDataProduct(makeRequestForUnknown),
-        getRelatedDataProduct: () => Promise.reject('related data products not supported')
+    ];
+
+
+    const {factoryOverride} = getAppOptions()?.multiProducesViewer ?? {};
+    let converterTemplates = originalConverterTemplates;
+    if (isArray(factoryOverride)) {
+        converterTemplates = originalConverterTemplates.map((t) => {
+            const overTemp = factoryOverride.find((tTmp) => tTmp.converterId === t.converterId);
+            return overTemp ? {...t, ...overTemp} : t;
+        });
     }
-];
+    return converterTemplates;
+}
+
+
+
+
+
+export const {getConverterTemplates, addTemplate, addTemplateToEnd}= (() => {
+    let converterTemplates;
+
+        const getConverterTemplates= () => {
+            if (!converterTemplates) converterTemplates= initConverterTemplates();
+            return converterTemplates;
+        };
+        const addTemplate= (template) => {
+            getConverterTemplates();
+            converterTemplates.unshift(template);
+        };
+        const addTemplateToEnd= (template) => {
+            getConverterTemplates();
+            converterTemplates.push(template);
+        };
+
+        return {getConverterTemplates,addTemplate,addTemplateToEnd};
+})();
+
 
 
 export function initImage3ColorDisplayManagement(viewerId) {
-     const customEntry= converterTemplates.reduce( (newObj, template) => {
+     const customEntry= getConverterTemplates().reduce( (newObj, template) => {
         if (!template.threeColor) return newObj;
         newObj[template.converterId]= {...template.threeColorBands, threeColorVisible:false};
         return newObj;
@@ -306,7 +346,7 @@ export function initImage3ColorDisplayManagement(viewerId) {
  * @return {DataProductsConvertType}
  */
 export function defaultMakeDataProductsConverter(table) {
-    const t= converterTemplates.find( (template) => template.tableMatches(table) );
+    const t= getConverterTemplates().find( (template) => template.tableMatches(table) );
     return t && t.create(table,t);
 }
 /**
@@ -326,12 +366,6 @@ export const makeDataProductsConverter= (table) =>
     (overrideMakeDataProductsConverter && overrideMakeDataProductsConverter(table)) || defaultMakeDataProductsConverter(table);
 
 export const setOverrideDataProductsConverterFactory = (f) => overrideMakeDataProductsConverter= f;
-
-
-export function addTemplate(template) { converterTemplates.unshift(template); }
-
-export function addTemplateToEnd(template) { converterTemplates.push(template); }
-
 
 /**
  *  Support data the we don't know about

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -42,6 +42,8 @@ export const DPtypes= {
 };
 
 
+export const SHOW_CHART='showChart';
+export const SHOW_TABLE='showTable';
 
 /**
  *

--- a/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
+++ b/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
@@ -22,7 +22,7 @@ import {
     dataProductRoot, dispatchActivateFileMenuItem, dispatchUpdateActiveKey,
     dispatchUpdateDataProducts, getActiveFileMenuKeyByKey, getDataProducts
 } from './DataProductsCntlr';
-import {analyzePart, arrangeAnalysisMenu} from './PartAnalyzer';
+import {analyzePart, chooseDefaultEntry} from './PartAnalyzer';
 import {hasRowAccess} from '../tables/TableUtil';
 
 
@@ -274,12 +274,6 @@ function processAnalysisResult({table, row, request, activateParams, serverCache
     const useImagesFromPartAnalysis= parts.length>1;
 
 
-    // const hasOnlySingleAxisImages= Boolean(partAnalysis.every( (pa) => pa.imageSingleAxis));
-    // if (hasOnlySingleAxisImages) {
-    //     return dpdtMessageWithDownload('Cannot not display One-dimensional images (NAXIS==1)', 'download fits file', url);
-    // }
-    //
-
 
     const imageEntry= makeImages &&
         dpdtImage(`Image Data ${imageParts.length>1? ': All Images in File' :''}`,
@@ -296,22 +290,15 @@ function processAnalysisResult({table, row, request, activateParams, serverCache
         pAry.forEach( (r) => fileMenu.menu.push(r));
     });
 
-    // const oneDErr= partAnalysis.reduce( (str,pa,idx) => {
-    //     if (pa.imageSingleAxis) str+= `${str?', ':''}${idx}`;
-    //     return str;
-    // },'');
-    // if (oneDErr) fileMenu.menu.push(dpdtDownload(`Download Only, Ext ${oneDErr}: Cannot display One-dimensional images (NAXIS==1)`, url));
-
-    // fileMenu.menu= arrangeAnalysisMenu(fileMenu.menu,parts,fileFormat, dataTypeHint);
-
-
     fileMenu.menu.forEach( (m,idx) => m.menuKey= 'fm-'+idx);
+
+    fileMenu.initialDefaultIndex= chooseDefaultEntry(fileMenu.menu,parts,fileFormat, dataTypeHint);
 
     let actIdx=0;
     if (fileMenu.menu.length) {
         const lastActiveFieldItem= getActiveFileMenuKeyByKey(dpId,activeItemLookupKey);
         actIdx= fileMenu.menu.findIndex( (m) => m.menuKey===lastActiveFieldItem);
-        if (actIdx<0) actIdx= 0;
+        if (actIdx<0) actIdx= fileMenu.initialDefaultIndex;
     }
     else {// error case
         const msg= makeErrorMsg(parts,fileFormat);

--- a/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
+++ b/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
@@ -268,19 +268,20 @@ function processAnalysisResult({table, row, request, activateParams, serverCache
 
 
 
-    const partAnalysis= parts.map( (p) => analyzePart(p,fileFormat, serverCacheFileKey,activateParams));
-    const imageParts= partAnalysis.filter( (pa) => pa.isImage);
-    const hasImages= imageParts.length>0;
+    const partAnalysis= parts.map( (p) => analyzePart(p,request, table, row, fileFormat, serverCacheFileKey,activateParams));
+    const imageParts= partAnalysis.filter( (pa) => pa.imageResult);
+    const makeImages= imageParts.length>1 || (imageParts.length===1 && parts.length===1);
+    const useImagesFromPartAnalysis= parts.length>1;
 
 
-    const hasOnlySingleAxisImages= Boolean(partAnalysis.every( (pa) => pa.imageSingleAxis));
-    if (hasOnlySingleAxisImages) {
-        return dpdtMessageWithDownload('Cannot not display One-dimensional images (NAXIS==1)', 'download fits file', url);
-    }
+    // const hasOnlySingleAxisImages= Boolean(partAnalysis.every( (pa) => pa.imageSingleAxis));
+    // if (hasOnlySingleAxisImages) {
+    //     return dpdtMessageWithDownload('Cannot not display One-dimensional images (NAXIS==1)', 'download fits file', url);
+    // }
+    //
 
 
-
-    const imageEntry= hasImages &&
+    const imageEntry= makeImages &&
         dpdtImage(`Image Data ${imageParts.length>1? ': All Images in File' :''}`,
             createSingleImageActivate(request,imageViewerId,table.tbl_id,row),'image-'+0, {request});
 
@@ -288,19 +289,20 @@ function processAnalysisResult({table, row, request, activateParams, serverCache
     if (imageEntry) fileMenu.menu.push(imageEntry);
     partAnalysis.forEach( (pa) => {
         let pAry= [];
+        if (useImagesFromPartAnalysis && pa.imageResult) pAry= isArray(pa.imageResult) ? pa.imageResult : [pa.imageResult];
         if (pa.tableResult) pAry= isArray(pa.tableResult) ? pa.tableResult : [pa.tableResult];
         if (pa.chartResult) pAry= isArray(pa.chartResult) ? [...pAry,...pa.chartResult] : [...pAry,pa.chartResult];
 
         pAry.forEach( (r) => fileMenu.menu.push(r));
     });
 
-    const oneDErr= partAnalysis.reduce( (str,pa,idx) => {
-        if (pa.imageSingleAxis) str+= `${str?', ':''}${idx}`;
-        return str;
-    },'');
-    if (oneDErr) fileMenu.menu.push(dpdtDownload(`Download Only, Ext ${oneDErr}: Cannot display One-dimensional images (NAXIS==1)`, url));
+    // const oneDErr= partAnalysis.reduce( (str,pa,idx) => {
+    //     if (pa.imageSingleAxis) str+= `${str?', ':''}${idx}`;
+    //     return str;
+    // },'');
+    // if (oneDErr) fileMenu.menu.push(dpdtDownload(`Download Only, Ext ${oneDErr}: Cannot display One-dimensional images (NAXIS==1)`, url));
 
-    fileMenu.menu= arrangeAnalysisMenu(fileMenu.menu,parts,fileFormat, dataTypeHint);
+    // fileMenu.menu= arrangeAnalysisMenu(fileMenu.menu,parts,fileFormat, dataTypeHint);
 
 
     fileMenu.menu.forEach( (m,idx) => m.menuKey= 'fm-'+idx);
@@ -316,7 +318,7 @@ function processAnalysisResult({table, row, request, activateParams, serverCache
         return dpdtMessageWithDownload(msg, 'Download File', url, fileFormat==='FITS'&&'FITS');
     }
     dispatchUpdateActiveKey({dpId, activeFileMenuKeyChanges:{[fileMenu.activeItemLookupKey]:fileMenu.menu[actIdx].menuKey}});
-    return {...fileMenu.menu[actIdx],fileMenu};
+    return {...fileMenu.menu[actIdx],fileMenu}; //todo add which one to activate, right now it will activate the first
 }
 
 

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -53,42 +53,31 @@ export function analyzePart(part, request, table, row, fileFormat, serverCacheFi
     };
 }
 
-// todo - arrangeAnalysisMenu needs to have injection point for application specific analysis
 /**
- * Arrange the order of the menu array so that is show the most important stuff on the top
+ * Determine which entry should be the default
  * @param menu
  * @param parts
  * @param fileFormat
  * @param dataTypeHint
  * @return {Array}
  */
-export function arrangeAnalysisMenu(menu,parts,fileFormat, dataTypeHint) {
-    const imageEntry= menu.find( (m) => m.displayType===DPtypes.IMAGE);
-    if (imageEntry) {
-        menu= menu.filter( (m) => m.displayType!==DPtypes.IMAGE);
-    }
+export function chooseDefaultEntry(menu,parts,fileFormat, dataTypeHint) {
+    if (!menu || !menu.length) return undefined;
+    let defIndex= menu.findIndex( (m) => m.requestDefault);
+    if (defIndex > -1) return defIndex;
 
     switch (dataTypeHint) {
         case 'timeseries':
-            imageEntry && menu.push(imageEntry);
+            defIndex= menu.find( (m) => m.displayType===DPtypes.CHART);
             break;
         case 'spectrum':
-            const chartList= menu.filter( (m) => m.displayType===DPtypes.CHART);
-            const noCharts= menu.filter( (m) => m.displayType!==DPtypes.CHART);
-            if (chartList.length) {
-                menu= [...chartList,...noCharts];
-                imageEntry && menu.push(imageEntry);
-            }
-            else {
-                imageEntry && menu.unshift(imageEntry);
-            }
-            break;
-        default:
-            imageEntry && menu.unshift(imageEntry);
-            break;
+            defIndex= menu.find( (m) => m.displayType===DPtypes.CHART);
     }
-    return menu;
+    return defIndex > -1 ? defIndex : 0;
 }
+
+
+
 
 // todo - findAvailableTypesForAnalysisPart needs to have injection point for application specific analysis
 /**

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -110,30 +110,30 @@ export function createChartActivate(source, titleStr, activateParams, xAxis, yAx
             }
         };
 
-        const histogramParams= {
-            viewerId: chartViewerId,
-            groupId: chartViewerId,
-            chartId: chartId+'-hist',
-            data: [{
-                type: 'fireflyHistogram',
-                firefly: {
-                    tbl_id,
-                    options: {
-                        algorithm: 'fixedSizeBins',
-                        fixedBinSizeSelection: 'numBins',
-                        numBins: 30,
-                        columnOrExpr: yAxis,
-                    }
-                },
-
-            }],
-            layout: {
-                title: {text: titleStr},
-            }
-        };
+        // const histogramParams= {
+        //     viewerId: chartViewerId,
+        //     groupId: chartViewerId,
+        //     chartId: chartId+'-hist',
+        //     data: [{
+        //         type: 'fireflyHistogram',
+        //         firefly: {
+        //             tbl_id,
+        //             options: {
+        //                 algorithm: 'fixedSizeBins',
+        //                 fixedBinSizeSelection: 'numBins',
+        //                 numBins: 30,
+        //                 columnOrExpr: yAxis,
+        //             }
+        //         },
+        //
+        //     }],
+        //     layout: {
+        //         title: {text: titleStr},
+        //     }
+        // };
         onTableLoaded(tbl_id).then( () => {
             dispatchChartAdd(dispatchParams);
-            dispatchChartAdd(histogramParams);
+            // dispatchChartAdd(histogramParams);
         });
         return () => {
             dispatchTableRemove(tbl_id,false);

--- a/src/firefly/js/visualize/saga/DataProductsWatcher.js
+++ b/src/firefly/js/visualize/saga/DataProductsWatcher.js
@@ -76,7 +76,7 @@ function watchDataProductsTable(tbl_id, action, cancelSelf, params) {
         if (paused) {
             paused= !Boolean(imView || dpView);
         }
-        if (!paused) updateDataProducts(tbl_id, activateParams);
+        if (!paused && getActiveTableId()===tbl_id) updateDataProducts(tbl_id, activateParams);
         initImage3ColorDisplayManagement(imageViewerId); //todo: 3 color not working
         return {paused};
     }

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -20,7 +20,7 @@ import {getActivePlotView} from '../PlotViewUtil';
 import {visRoot} from '../ImagePlotCntlr';
 import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx';
 import {useStoreConnector} from '../../ui/SimpleComponent';
-import {getActiveTableId, getBooleanMetaEntry, getTblById} from '../../tables/TableUtil';
+import {getActiveTableId, getBooleanMetaEntry, getTblById, getTblIdsByGroup} from '../../tables/TableUtil';
 import {hasCoverageData} from '../../util/VOAnalyzer';
 import {get} from 'lodash';
 import {getAppOptions} from '../../core/AppDataCntlr';
@@ -51,9 +51,10 @@ export function CoverageViewer({viewerId='coverageImages',insideFlex=true,
     const hasPlots = (getViewerItemIds(getMultiViewRoot(),viewerId).length===1 && pv);
     const {renderTreeId} = useContext(RenderTreeIdCtx);
     const forceShow= getBooleanMetaEntry(tbl_id,MetaConst.COVERAGE_SHOWING,false);
+    const tblHasCoverage= hasCoverageData(tbl_id);
 
 
-    if (hasPlots && (hasCoverageData(tbl_id) || forceShow)) {
+    if (hasPlots && (tblHasCoverage || forceShow)) {
         return (
             <MultiImageViewer viewerId={viewerId}
                               insideFlex={insideFlex}
@@ -63,7 +64,13 @@ export function CoverageViewer({viewerId='coverageImages',insideFlex=true,
         );
     }
     else {
-        const msg= (getTblById(tbl_id)?.isFetching) ? workingMessage : noCovMessage;
+        let msg= noCovMessage;
+        if (tblHasCoverage || getTblById(tbl_id)?.isFetching) {
+            msg= workingMessage;
+        }
+        else if (forceShow) {
+            msg= getTblIdsByGroup().some( (tbl_id) => hasCoverageData(tbl_id)) ? workingMessage : noCovMessage;
+        }
         return (
             <div style={{...{background: '#c8c8c8', paddingTop:35, width:'100%',textAlign:'center',fontSize:'14pt'},...noCovStyle}}>
                 {msg}</div>

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -17,7 +17,7 @@ import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
 import {CompleteButton} from '../../ui/CompleteButton';
 import {DropDownToolbarButton} from '../../ui/DropDownToolbarButton.jsx';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
-import {DPtypes} from '../../metaConvert/DataProductsType';
+import {DPtypes, SHOW_CHART, SHOW_TABLE} from '../../metaConvert/DataProductsType';
 import {
     dataProductRoot,
     dispatchActivateFileMenuItem,
@@ -97,7 +97,7 @@ function getMakeDropdown(menu, fileMenu, dpId,activeMenuLookupKey) {
 
                 {hasFileMenu &&
                 <DropDownToolbarButton
-                    text={'In File'}
+                    text={'File Contents'}
                     tip='Other data in file'
                     enabled={true} horizontal={true}
                     visible={true}
@@ -113,9 +113,9 @@ function getMakeDropdown(menu, fileMenu, dpId,activeMenuLookupKey) {
     };
 }
 
-const SHOW_CHART='showChart';
-const SHOW_TABLE='showTable';
 const makeChartTableLookupKey= (activeItemLookupKey, fileMenuKey) => `${activeItemLookupKey}-charTable-${fileMenuKey}`;
+
+// const getActiveFileMenuDP= (fileMenu) => fileMenu?.menu.find( (m) => m.menuKey===fileMenu.activeFileMenuKey);
 
 export const MultiProductViewer= memo(({ viewerId='DataProductsType', metaDataTableId}) => {
 
@@ -126,7 +126,7 @@ export const MultiProductViewer= memo(({ viewerId='DataProductsType', metaDataTa
     const [dataProductsState, setDataProductsState] = useState(getDataProducts(dataProductRoot(),dpId));
     const {imageViewerId,chartViewerId,tableGroupViewerId}=  getActivateParams(dataProductRoot(),dpId);
     const {displayType='unsupported', menu,fileMenu,message,url, isWorkingState, menuKey,
-        activate,activeMenuLookupKey,singleDownload= false}= dataProductsState;
+        activate,activeMenuLookupKey,singleDownload= false, chartTableDefOption=SHOW_CHART}= dataProductsState;
 
 
     useEffect(() => {
@@ -209,10 +209,10 @@ export const MultiProductViewer= memo(({ viewerId='DataProductsType', metaDataTa
             result= (<MultiProductChartTable {...{dpId,makeDropDown,chartViewerId,whatToShow:SHOW_CHART}}/>);
             break;
         case DPtypes.CHART_TABLE :
-            const lookupKey= get(fileMenu,'activeItemLookupKey','');
+            const lookupKey= fileMenu?.activeItemLookupKey ?? '';
             const ctLookupKey= makeChartTableLookupKey(lookupKey,menuKey || getActiveFileMenuKey(dpId,fileMenu));
             const whatToShow= lookupKey ?
-                getActiveFileMenuKeyByKey(dpId,ctLookupKey) || SHOW_CHART: SHOW_CHART;
+                (getActiveFileMenuKeyByKey(dpId,ctLookupKey) || chartTableDefOption): chartTableDefOption;
             result= (<MultiProductChartTable {
                 ...{dpId,makeDropDown,chartViewerId,tableGroupViewerId,whatToShow,ctLookupKey,mayToggle:true}}/>);
             break;
@@ -244,12 +244,13 @@ MultiProductViewer.propTypes= {
 };
 
 const chartTableOptions= [
-    {label: 'Chart', value: SHOW_CHART},
-    {label: 'Table', value: SHOW_TABLE}
+    {label: 'Table', value: SHOW_TABLE},
+    {label: 'Chart', value: SHOW_CHART}
     ];
 
 function MultiProductChartTable({dpId,makeDropDown, chartViewerId,
-                                    tableGroupViewerId,whatToShow,ctLookupKey=undefined, mayToggle=false}) {
+                                    tableGroupViewerId,whatToShow,
+                                    ctLookupKey=undefined, mayToggle=false}) {
 
     const [ts, setTS] = useState(whatToShow);
     const [lookupKey, setLookKey] = useState(ctLookupKey);

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -675,12 +675,16 @@ export function MultiImageControllerView({plotView:pv}) {
         if (cIdx<0) cIdx= 0;
         length= plots.length;
         if (multiHdu) {
+            const hduNum= getHDU(plot);
             startStr= 'Image: ';
             if (plot.plotDesc) {
-                startStr= 'HDU: ';
+                startStr= `HDU (#${hduNum}): `;
                 hduDesc= `${plot.plotDesc || getHeader(plot,HdrConst.EXTNAME,'')}`;
+                tooltip+= `HDU: ${hduNum}, ${hduDesc}`;
             }
-            tooltip+= `HDU: ${getHDU(plot)}`;
+            else {
+                tooltip+= `HDU: ${hduNum}`;
+            }
         }
         if (plot.cubeIdx>-1) {
             tooltip+= `${multiHdu ? ', ':''} Cube: ${plot.cubeIdx+1}/${getCubePlaneCnt(pv,plot)}`;


### PR DESCRIPTION
## Firefly-497: Updates for Data Products Viewer

This PR includes the following changes to the Data Products Viewer
- Pull down entry: HDU #index (Type) Description/Extname
   - Also show a show all images option
- Data that can be both images or table, has two entries
- When a user select the item in the list, by default the viewer should show a table first  not a chart.
    - For 1-d image show chart first (seems to make more sense, because a image is made to be visualized)
- Switch buttons 'chart'/'table' _to_  'table'/'chart' 
- When chart is selected, the viewer would show X-Y plot only, no histogram
- In SOFIA, we don't need the grid multi-viewer around the file data product viewer, that can be disabled in the SOFIA context.

https://jira.ipac.caltech.edu/browse/FIREFLY-497

### To Test

_sofia:_ 
- https://irsawebdev9.ipac.caltech.edu/firefly-497-dpv-updates/applications/sofia/
- Do an allsky serach and look at the data products

_firefly viewer:_ 
- https://irsawebdev9.ipac.caltech.edu/firefly-497-dpv-updates/firefly/
- do a tap search (e.g.- mast, obscore, m31, 100 arcsec)

