### PR TITLE
FIREFLY-523: fix fixed column cell transparency issue

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -2,7 +2,7 @@
 // adjustable application runtime properties
 //---------------------------------------------
 BuildMajor = 2020
-BuildMinor = 1
+BuildMinor = -1
 BuildRev = 0
 BuildNumber = 0
 BuildType = "Final"

--- a/docs/new-release-procedure.md
+++ b/docs/new-release-procedure.md
@@ -18,7 +18,7 @@
    
    
 1. **Commit, Tag**
-   - commit you changes
+   - commit you changest
    - tag the `rc-yyyy.m` branch with the release  `release-yyyy.m.r`
    - _example:_ the second release from branch `rc-2020.2` with the git tagged with `release-2020.2.1`
    
@@ -50,10 +50,11 @@
    
 1. **Publish a new release on Github.**
    - The text should use the [release-page-template.md](release-page-template.md)
+   - After using the template, copy the most markdown (for this release only) from the release-notes.md
 
 1. **Merge RR, Reset the Version in config to development, Push dev**
    - merge rc into dev
-   - In the `dev` branch, Edit `firefly/config/app.config` with the correct version.
+   - In the `dev` branch, Edit `firefly/config/app.config` so that you are resetting 
    - Modify:
      - `BuildMajor =` _year_
      - `BuildMinor = -1`

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -343,6 +343,8 @@
     padding: 3px;
     text-overflow: ellipsis;
     overflow: hidden;
+    height: 100%;
+    box-sizing: border-box;
 }
 
 .public_fixedDataTableCell_cellContent.right_align {

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -4,7 +4,7 @@
 
 import React, {Component, PureComponent, useRef, useCallback} from 'react';
 import {Cell} from 'fixed-data-table-2';
-import {set, get, isEqual, pick} from 'lodash';
+import {set, get, isEqual, pick, omit} from 'lodash';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
 import {isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue, getTypeLabel, getColumnIdx, getRowValues, getCellValue} from '../TableUtil.js';
@@ -279,6 +279,8 @@ export const LinkCell = React.memo((props) => {
     const val = getValue(props);
     const className = 'public_fixedDataTableCell_cellContent';
     let textAlign = col.align;
+    const backgroundColor = style.backgroundColor;
+    let mstyle = omit(style, 'backgroundColor');
     if (col.links) {
         const tableModel = getTblById(tbl_id);
         if (col.links.length === 1) {
@@ -288,7 +290,7 @@ export const LinkCell = React.memo((props) => {
             textAlign = textAlign || 'middle';
         }
         return (
-            <div className={className} style={{textAlign}}>
+            <div className={className} style={{textAlign, backgroundColor}}>
                 {
                     col.links.map( (link={}, idx) => {
                         const {href, title, value=val, action} = link;
@@ -296,7 +298,7 @@ export const LinkCell = React.memo((props) => {
                         const rvalue = resolveHRefVal(tableModel, value, absRowIdx);
                         const rhref = resolveHRefVal(tableModel, href, absRowIdx, val);
                         if (!rhref) return '';
-                        const mstyle = idx > 0 ? {marginLeft: 3, ...style} : style;
+                        mstyle = idx > 0 ? {marginLeft: 3, ...mstyle} : mstyle;
                         return (<ATag key={'ATag_' + idx} href={rhref}
                                       {...{value:rvalue, title, target, style:mstyle}}
                                 />);
@@ -307,8 +309,8 @@ export const LinkCell = React.memo((props) => {
     } else {
         textAlign = textAlign || isNumeric(val) ? 'right' : 'left';
         return (
-            <div className={className} style={{textAlign}}>
-                <ATag href={val} value={val} target='_blank' style={style}/>
+            <div className={className} style={{textAlign, backgroundColor}}>
+                <ATag href={val} value={val} target='_blank' style={mstyle}/>
             </div>
         );
     }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-523

When a column is fixed, empty and link cells are either fully or partially transparent, allow hidden contents to appear when scrolled under.

To test, use https://irsawebdev9.ipac.caltech.edu/FIREFLY-523-fixed-column-transparency/firefly/demo/table-api.html 

uncheck `use wise catalog`, paste the url into the `URL` field, then put `{"col.Frequency Targeted.fixed": true}` in the META-INFO input box to set the column to fixed.

Here are links to table with empty cells and table with links:

http://dev1.ned.ipac.caltech.edu/cgi-bin/datasearch?search_type=z_id&zv_breaker=30000.0&of=xml_main&objname=m31&hconst=67.8&omegam=0.308&omegav=0.692&wmap=4&corr_z=1&objid=58141

http://dev1.ned.ipac.caltech.edu/cgi-bin/datasearch?search_type=Diam_id&of=xml_main&objname=m31&hconst=67.8&omegam=0.308&omegav=0.692&wmap=4&corr_z=1&objid=58141

