### PR TITLE
FIREFLY-526 update the fill color for round-up tiles when the color changes

### DIFF
--- a/src/firefly/js/drawingLayers/HiPSMOC.js
+++ b/src/firefly/js/drawingLayers/HiPSMOC.js
@@ -24,6 +24,7 @@ import {cloneRequest} from '../tables/TableRequestUtil';
 import {dispatchAddActionWatcher} from '../core/MasterSaga';
 import {MetaConst} from '../data/MetaConst';
 import {getNextColor} from '../visualize/draw/DrawingDef';
+import {rateOpacity} from '../util/Color.js';
 
 const ID= 'MOC_PLOT';
 const TYPE_ID= 'MOC_PLOT_TYPE';
@@ -267,6 +268,16 @@ function getLayerChanges(drawLayer, action) {
                 }
             }
             break;
+
+        case DrawLayerCntlr.CHANGE_DRAWING_DEF:   // from color change
+            const {color} = action.payload.drawingDef || {};
+            const newMocObj = createMocObj(drawLayer);
+
+            if (newMocObj && newMocObj.color != color) {
+                newMocObj.color = color;
+                return {mocObj: newMocObj};
+            }
+            break;
         default:
             return null;
     }
@@ -290,6 +301,21 @@ function changeMocDrawingStyle(dl, style, plotId) {
     const dObjs = get(dl.drawData, [DataTypes.DATA, plotId], []);
 
     return dObjs.map((oneObj) => Object.assign({}, oneObj, {style}));
+}
+
+function changeMocDrawingColor(dl, pId) {
+
+    const color = dl?.mocObj?.color ?? dl.drawingDef.color;
+    const fillColor = rateOpacity(color, MocObj.PTILE_OPACITY_RATIO);
+
+    const dObjs = get(dl.drawData, [DataTypes.DATA, pId],[]);
+    return dObjs.map((oneObj) => {
+        if (oneObj.fillColor && oneObj.fillColor != fillColor) {
+            return Object.assign({}, oneObj, {fillColor});
+        } else {
+            return oneObj;
+        }
+    });
 }
 
 function removeTask(plotId, taskId) {
@@ -407,7 +433,7 @@ function abortUpdate(dl, updateStatusAry, pId, updateMethod = LayerUpdateMethod.
  */
 function asyncComputeDrawData(drawLayer, action) {
     const forAction = [ImagePlotCntlr.CHANGE_CENTER_OF_PROJECTION, ImagePlotCntlr.ANY_REPLOT,
-                       DrawLayerCntlr.MODIFY_CUSTOM_FIELD];
+                       DrawLayerCntlr.MODIFY_CUSTOM_FIELD, DrawLayerCntlr.CHANGE_DRAWING_DEF];
     if (!forAction.includes(action.type) || !drawLayer.mocObj) return;
 
     const {mocStyle={}} = drawLayer;
@@ -419,6 +445,17 @@ function asyncComputeDrawData(drawLayer, action) {
                                 mocStyle?.[targetPlotId] ?? drawLayer.drawingDef?.style ?? Style.STANDARD,
                                     targetPlotId),
             drawLayer, targetPlotId);
+    } else if (action.type === DrawLayerCntlr.CHANGE_DRAWING_DEF) {
+        const {plotIdAry} = drawLayer;
+        const dd = Object.assign({}, drawLayer.drawData);
+
+        plotIdAry.forEach((pId) => {
+            const newObjs = changeMocDrawingColor(drawLayer, pId);
+            set(dd[DataTypes.DATA], [pId], newObjs);
+        });
+
+        const newDrawLayer = clone(drawLayer, {drawData: dd});
+        dispatchUpdateDrawLayer(newDrawLayer);
     } else {
         const {plotId, plotIdAry} = action.payload;
         const {visiblePlotIdAry, updateStatusAry} = drawLayer;

--- a/src/firefly/js/visualize/draw/MocObj.js
+++ b/src/firefly/js/visualize/draw/MocObj.js
@@ -16,6 +16,7 @@ const MOC_OBJ= 'MOCObj';
 const DEFAULT_STYLE= Style.STANDARD;
 const DEF_WIDTH = 1;
 const MAX_MAPORDER = 25;
+const PTILE_OPACITY_RATIO = 0.5;
 
 /**
  * Draw one or more polygons defined in Multi-Order Coverage Map, MOC.
@@ -29,7 +30,7 @@ const MAX_MAPORDER = 25;
  * @return {object}
  */
 function make(cellNums, drawingDef) {
-    if (!cellNums && !cellNums.length) return null;
+    if (!cellNums || !cellNums.length) return null;
 
     const {style=DEFAULT_STYLE, color} = drawingDef || {};
     const obj = DrawObj.makeDrawObj();
@@ -117,7 +118,7 @@ const draw=  {
 	}
 };
 
-export default {make,draw, MOC_OBJ};
+export default {make,draw, MOC_OBJ, PTILE_OPACITY_RATIO};
 
 ////////////////////////////////////////////////
 ////////////////////////////////////////////////
@@ -586,7 +587,7 @@ export function createDrawObjsInMoc(mocObj, plot, startIdx, endIdx, storedSidePo
             //  drawObj.text = ''+ nuniq;
             drawObj.style = style;
             if (isParentTile) {       // this fill color is specifically for the round-up tile
-                drawObj.fillColor = rateOpacity(color, 0.5);
+                drawObj.fillColor = rateOpacity(color, PTILE_OPACITY_RATIO);
             }
             prev.push(drawObj);
         }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-526

The development  fixes the color of the round-up tiles when the color is changed from the color editor. 

test:
 https://irsawebdev9.ipac.caltech.edu/FIREFLY-526_MOC_color/firefly/

- do HiPS image, ex. GALEX GR6 AIS (until March 2014)- Color composition
- zoom the image to fit entirely within the frame
- open the overlay dialog, turn on "MOC - CDS_P_GALEXGR6_AIS_color" layer
- check 'fill' to show MOC in 'fill' style, you will see majority tiles with higher opacity and the round-up tiles with lower opacity (half of high opacity) 
- open the color panel to select a different color and check if the color of all tiles including round-up tiles changes accordingly. 