### PR TITLE
FIREFLY-502: table filter text comparison is no longer case insensitive

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -206,7 +206,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
 
         Class type = dataType.getDataType();
         if (type == null || String.class.isAssignableFrom(type)) {
-            return "longvarchar";                           // to ensure it can accommodate any length
+            return "varchar(4000000)";                           // to ensure it can accommodate any length
         } else if (Byte.class.isAssignableFrom(type)) {
             return "tinyint";
         } else if (Short.class.isAssignableFrom(type)) {


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-502

Text comparison is suppose to be case insensitive.  This applies to `like` as well as other comparison operators, i.e. `=`, `>`, `!=`
This was broken.  It is now fixed.

To test: https://fireflydev.ipac.caltech.edu/firefly-502-table-filter-like/firefly/
Bring up a table with `char` data.  Try catalog search or table upload.
Test text filtering on a `char` column.