### PR TITLE
Firefly-463: Add infrastructure to further process file FileAnalysis results

### DIFF
--- a/src/firefly/html/test/tests-viewer.html
+++ b/src/firefly/html/test/tests-viewer.html
@@ -303,7 +303,7 @@
 </template>
 
 
-<template title="Remote API: Tri-view: Send to HiPS Viewer Test" class="tpl sm">
+<template title="Remote API: Tri-view: Send to HiPS Viewer Test" class="tpl sm exclusive">
     <div id="expected" >
         <div>Click on load six link...
             <ul class='expected-list'>

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
@@ -1,0 +1,325 @@
+package edu.caltech.ipac.firefly.core;
+/**
+ * User: roby
+ * Date: 3/25/20
+ * Time: 11:00 AM
+ */
+
+
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author Trey Roby
+ */
+public class FileAnalysisReport {
+
+    public enum ReportType {Brief,              // expect to only get a report with one part without details
+        Normal,             // a report with all parts populated, but not details
+        Details}            // a full report with details
+
+    public enum Type {Image, Table, Spectrum, HeaderOnly, PDF, TAR, Unknown}
+    public enum UIRender {Table, Chart, Image, NotSpecified}
+    public enum UIEntry {UseSpecified, UseGuess, UseBoth}
+    public enum ChartTableDefOption {auto, showChart, showTable};
+
+
+
+    private ReportType type;
+    private long fileSize;
+    private String filePath;
+    private String fileName;
+    private String fileFormat;
+    private List<Part> parts;
+    private String dataType;
+    private boolean disableAllImagesOption = false;
+    private String dataProductsAnalyzerId;
+    private boolean analyzerFound= false;
+
+    public FileAnalysisReport(ReportType type, String fileFormat, long fileSize, String filePath) {
+        this.type = type;
+        this.fileFormat = fileFormat;
+        this.fileSize = fileSize;
+        this.filePath = filePath;
+    }
+
+    public ReportType getType() {
+        return type;
+    }
+
+    public String getFormat() {
+        return fileFormat;
+    }
+
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public List<Part> getParts() {
+        return parts;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+
+    public String getDataProductsAnalyzerId() { return dataProductsAnalyzerId; }
+    public void setDataProductsAnalyzerId(String dataProductsAnalyzerId) {
+        this.dataProductsAnalyzerId = dataProductsAnalyzerId;
+    }
+
+    public boolean isAnalyzerFound() { return analyzerFound; }
+    public void setAnalyzerFound(boolean analyzerFound) { this.analyzerFound = analyzerFound; }
+
+    public boolean isDisableAllImagesOption() { return disableAllImagesOption; }
+
+    public void setDisableAllImagesOption(boolean d) { this.disableAllImagesOption = d; }
+
+    public void replaceParts(List<Part> parts) {
+        this.parts= new ArrayList<>(parts);
+    }
+
+    public void addPart(Part part) {
+        if (parts == null) parts = new ArrayList<>();
+        parts.add(part);
+    }
+
+    public void setPart(Part part, int i) {
+        if (i<parts.size()) parts.set(i,part);
+    }
+    public Part getPart(int i) {
+        return parts.get(i);
+    }
+
+    public String getDataType() {
+        if (dataType == null) {
+            if (parts != null) {
+                if (parts.size() == 1) {
+                    dataType = parts.get(0).type.name();
+                } else {
+                    List<String> types = parts.stream().map(part -> part.type.name()).distinct().collect(Collectors.toList());
+                    dataType = StringUtils.toString(types);
+                }
+            } else {
+                dataType = "";
+            }
+        }
+        return dataType;
+    }
+
+
+    public FileAnalysisReport copy() { return copy(true); }
+
+    public FileAnalysisReport copy(boolean includeParts) {
+        FileAnalysisReport r= new FileAnalysisReport(type,fileFormat,fileSize,filePath);
+        r.fileName= this.fileName;
+        if (includeParts) r.parts= parts.stream().map(Part::copy).collect(Collectors.toList());
+        r.dataType= this.dataType;
+        return r;
+    }
+
+    /**
+     * convert this report into a Brief version.
+     */
+    void makeBrief() {
+        if (type == ReportType.Brief) return;       // nothing to do
+        getDataType();  // init dataType
+        if (parts != null) {
+            // keep only the first part with data.
+            Part first = parts.stream()
+                    .filter(p -> !Arrays.asList(Type.HeaderOnly, Type.Unknown).contains(p.getType()))
+                    .findFirst()
+                    .orElse(null);
+            if (first != null) {
+                parts = Collections.singletonList(first);
+            }
+        }
+    }
+
+
+    public static class Part {
+        private final Type type;
+        private UIRender uiRender=UIRender.NotSpecified;
+        private UIEntry uiEntry= UIEntry.UseBoth;;
+        private int index= 0;
+        private String desc;
+        private int fileLocationIndex = -1;   // todo: populate: fits (hdu idx) or VO (table idx)
+        private String convertedFileName= null; // only set if this entry is has a alternate file than the one analyzed
+        private List<ChartParams> chartParams= null;
+        private List<String> tableColumnNames= null; //only use for a fits image that is read as a table
+        private List<String> tableColumnUnits= null; //only use for a fits image that is read as a table
+        private boolean defaultPart= false;
+        private DataGroup details;
+        private ChartTableDefOption chartTableDefOption= ChartTableDefOption.auto;
+        private int totalTableRows=-1;
+
+        public Part(Type type) {
+            this(type,null);
+        }
+
+        public Part(Type type, String desc) {
+            this.type = type;
+            this.desc = desc;
+        }
+
+        public Type getType() { return type; }
+
+        public int getIndex() { return index; }
+        public void setIndex(int index) { this.index = index; }
+
+        public String getDesc() { return desc;}
+        public void setDesc(String desc) { this.desc = desc; }
+
+        public DataGroup getDetails() {
+            return details;
+        }
+        public void setDetails(DataGroup details) {
+            this.details = details;
+        }
+
+        public int getTotalTableRows() { return totalTableRows; }
+        public void setTotalTableRows(int totalTableRows) { this.totalTableRows = totalTableRows; }
+
+
+        public int getFileLocationIndex() { return fileLocationIndex; }
+        public void setFileLocationIndex(int fileLocationIndex) { this.fileLocationIndex = fileLocationIndex; }
+
+        public String getConvertedFileName() { return convertedFileName; }
+        public void setConvertedFileName(String convertedFileName) { this.convertedFileName = convertedFileName; }
+
+        public List<ChartParams> getChartParams() { return chartParams; }
+        public void setChartParams(ChartParams chartParams) {
+            this.chartParams = Collections.singletonList(chartParams);
+        }
+        public void setChartParams(List<ChartParams> chartParams) {
+            this.chartParams = chartParams;
+        }
+
+        public List<String> getTableColumnNames() { return tableColumnNames; }
+        public void setTableColumnNames(List<String> tableColumnNames) { this.tableColumnNames = tableColumnNames; }
+
+        public List<String> getTableColumnUnits() { return tableColumnUnits; }
+        public void setTableColumnUnits(List<String> tableColumnUnits) { this.tableColumnUnits = tableColumnUnits; }
+
+        public boolean isDefaultPart() { return defaultPart; }
+        public void setDefaultPart(boolean defaultPart) { this.defaultPart = defaultPart; }
+
+        public UIRender getUiRender() { return uiRender; }
+        public void setUiRender(UIRender uiRender) { this.uiRender = uiRender; }
+
+        public UIEntry getUiEntry() { return uiEntry; }
+        public void setUiEntry(UIEntry uiEntry) { this.uiEntry = uiEntry; }
+
+        public ChartTableDefOption getChartTableDefOption() { return chartTableDefOption; }
+        public void setChartTableDefOption(ChartTableDefOption chartTableDefOption) {
+            this.chartTableDefOption = chartTableDefOption;
+        }
+
+        public Part copy() {
+            Part p= new Part(type, desc);
+            p.details= details;
+            p.uiRender= uiRender;
+            p.uiEntry= uiEntry;
+            p.index= index;
+            p.fileLocationIndex = fileLocationIndex;
+            p.convertedFileName= convertedFileName;
+            if (chartParams!=null) {
+                p.chartParams = chartParams.stream().map(ChartParams::copy).distinct().collect(Collectors.toList());
+            }
+            p.tableColumnNames= tableColumnNames!=null ? new ArrayList<>(tableColumnNames) : null;
+            p.tableColumnUnits= tableColumnUnits!=null ? new ArrayList<>(tableColumnUnits) : null;
+            p.defaultPart= defaultPart;
+            return p;
+        }
+    }
+
+    public static class ChartParams {
+
+        public enum ChartType {XYChart, Histogram };
+
+        private boolean layoutAdds= false;
+        private boolean simpleData= true;
+        private ChartType simpleChartType= ChartType.XYChart;
+        private Map<String,Object> layout= null;
+        private String xAxisColName = null;
+        private String yAxisColName= null;
+        private String mode= null;
+        private int numBins= 0;
+        private List<Map<String,Object>> traces= null;
+
+        public String getxAxisColName() { return xAxisColName; }
+        public void setxAxisColName(String xAxisColName) { this.xAxisColName = xAxisColName; }
+        public String getyAxisColName() { return yAxisColName; }
+        public void setyAxisColName(String yAxisColName) { this.yAxisColName = yAxisColName; }
+        public String getMode() { return mode; }
+        public void setMode(String mode) { this.mode = mode; }
+
+        public int getNumBins() { return numBins; }
+
+        public void setNumBins(int numBins) { this.numBins = numBins; }
+
+        public ChartType getSimpleChartType() { return simpleChartType; }
+        public void setSimpleChartType(ChartType simpleChartType) { this.simpleChartType = simpleChartType; }
+
+        public void setLayout(Map<String,Object> layout) {
+            layoutAdds= false;
+            this.layout= layout;
+        }
+
+        public void addLayout(Map<String,Object> layoutEntries) {
+            layoutAdds= true;
+            if (layout==null) layout= new HashMap<>();
+            layout.putAll(layoutEntries);
+        }
+
+        public Map<String, Object> getLayout() {
+            return layout;
+        }
+
+        public List<Map<String, Object>> getTraces() {
+            return traces;
+        }
+
+        public void setTraces(List<Map<String,Object>> traces) {
+            simpleData= false;
+            this.traces= traces;
+        }
+
+        public boolean isLayoutAdds() { return layoutAdds; }
+        public boolean isSimpleData() { return simpleData; }
+
+        public ChartParams copy() {
+            ChartParams c= new ChartParams();
+            c.layoutAdds= layoutAdds;
+            c.simpleData= simpleData;
+            c.simpleChartType= simpleChartType;
+            c.layout= layout!=null ? new HashMap<>(layout) : null;
+            c.xAxisColName = xAxisColName;
+            c.yAxisColName= yAxisColName;
+            c.mode= mode;
+            c.numBins= numBins;
+            if (traces!=null) {
+                c.traces = traces.stream().map(HashMap::new).distinct().collect(Collectors.toList());
+            }
+            return c;
+        }
+
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
@@ -32,6 +32,11 @@ public class MetaConst {
      */
     public static final String IMAGE_AS_TABLE_COL_NAMES= "IMAGE_AS_TABLE_COL_NAMES";
 
+    /*
+     * comma separated names of the units to assign to the table when reading a fits image as a table.
+     */
+    public static final String IMAGE_AS_TABLE_UNITS= "IMAGE_AS_TABLE_UNITS";
+
     /**
      * If defined to any value (but 'false') the the table is a catalog
      * CatalogOverlayType is required to even guess if there is no VO information.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
@@ -44,6 +44,27 @@ public class SrvParam {
         return paramMap;
     }
 
+    /**
+     * Return any parameters that are not in ignore list. If the parameter has more then one entry, only return the first
+     * @param ignoreList an array list of parameters to ignore
+     * @return a map of the parameters that we not ignored
+     */
+    public Map<String, String> getParamMapUsingExcludeList(List<String> ignoreList) {
+        Map<String,String> retMap= new HashMap<>();
+        for(Map.Entry<String,String[]> entry : this.paramMap.entrySet()) {
+            if (!ignoreList.contains(entry.getKey())) {
+                retMap.put(entry.getKey(),entry.getValue()[0]);
+            }
+        }
+//        retMap= this.paramMap.entrySet().stream().filter( entry -> !ignoreList.contains(entry.getKey()))
+//                .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue());
+        return retMap;
+    }
+//    public Map<String, String> getParamMapUsingExcludeList(List<String> ignoreList) {
+//        return this.paramMap.entrySet().stream().filter( entry -> !ignoreList.contains(entry.getKey()))
+//                .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue());
+//    }
+
     public static SrvParam makeSrvParamSimpleMap(Map<String, String> map) {
         Map<String, String[]> targetMap= new HashMap<>();
         for( Map.Entry<String,String> entry : map.entrySet()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/DataProductAnalyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/DataProductAnalyzer.java
@@ -1,0 +1,25 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.dpanalyze;
+
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
+import nom.tam.fits.Header;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * @author Trey Roby
+ */
+public interface DataProductAnalyzer {
+    default FileAnalysisReport analyze(FileAnalysisReport inputReport,
+                                       File inFile,
+                                       String analyzerId,
+                                       Map<String,String> params) { return inputReport;}
+    default FileAnalysisReport analyzeFits(FileAnalysisReport inputReport,
+                                           File inFile,
+                                           String analyzerId,
+                                           Map<String,String> params,
+                                           Header headerAry[]) {return inputReport;}
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/DataProductAnalyzerFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/DataProductAnalyzerFactory.java
@@ -1,0 +1,57 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.dpanalyze;
+
+import org.reflections.Reflections;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Trey Roby
+ */
+public final class DataProductAnalyzerFactory {
+
+    private volatile static DataProductAnalyzerFactory instance;
+    private final Map<String, DataProductAnalyzer> analyzerMap= new ConcurrentHashMap<>();
+    private final DataProductAnalyzer identityAnalyzer= new IdentityAnalyzer();
+
+    private DataProductAnalyzerFactory() {
+        Reflections reflections = new Reflections("edu.caltech.ipac");
+        Set<Class<?>> annotated = reflections.getTypesAnnotatedWith(DataProductAnalyzerImpl.class);
+
+        for (Class<?> fileRetrieve: annotated) {
+            DataProductAnalyzerImpl rAnna = fileRetrieve.getAnnotation(DataProductAnalyzerImpl.class);
+            String requestId = rAnna.id();
+            try {
+                analyzerMap.put(requestId, (DataProductAnalyzer) fileRetrieve.newInstance());
+            } catch (IllegalAccessException | InstantiationException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static DataProductAnalyzerFactory getInstance() {
+        if (instance!=null) return instance;
+        synchronized (DataProductAnalyzerFactory.class) {
+            if (instance==null) instance= new DataProductAnalyzerFactory();
+        }
+        return instance;
+    }
+
+
+    public static DataProductAnalyzer getAnalyzer(String id) {
+        return hasAnalyzer(id) ? getInstance().analyzerMap.get(id) : getInstance().identityAnalyzer;
+    }
+
+    public static boolean hasAnalyzer(String id) {
+        if (id==null) return false;
+        return getInstance().analyzerMap.containsKey(id);
+    }
+
+    public static void addAnalyzer(String key, DataProductAnalyzer fa) { getInstance().analyzerMap.put(key, fa); }
+
+    private static class IdentityAnalyzer implements DataProductAnalyzer {};
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/DataProductAnalyzerImpl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/DataProductAnalyzerImpl.java
@@ -1,0 +1,18 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.dpanalyze;
+
+import edu.caltech.ipac.firefly.server.query.ParamDoc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DataProductAnalyzerImpl {
+    String id();
+    ParamDoc[] params() default {};
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/Demo1Analyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/Demo1Analyzer.java
@@ -1,0 +1,270 @@
+package edu.caltech.ipac.firefly.server.dpanalyze;
+/**
+ * User: roby
+ * Date: 3/27/20
+ * Time: 9:25 AM
+ */
+
+
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.URLDownload;
+import nom.tam.fits.Header;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Trey Roby
+ */
+@DataProductAnalyzerImpl(id ="analyze-demo1")
+public class Demo1Analyzer implements DataProductAnalyzer {
+
+
+    @Override
+    public FileAnalysisReport analyze(FileAnalysisReport inputReport, File inFile, String analyzerId, Map<String, String> params) {
+        return inputReport;
+    }
+
+    @Override
+    public FileAnalysisReport analyzeFits(FileAnalysisReport inputReport,
+                                          File inFile,
+                                          String analyzerId,
+                                          Map<String, String> params,
+                                          Header[] headerAry) {
+
+
+
+        String code= params.getOrDefault("Code", "");
+        //
+        // - how to replace the analysis file with another file
+        //
+        if (code.equals("REP") && params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+            return demoReplacingData(inputReport);
+        }
+
+        //
+        // - how to add another file to return with analysis file
+        //
+        if (code.equals("ADD") && params.containsKey("addAPart") && Boolean.parseBoolean(params.get("addAPart"))) {
+            return demoAddingAPart(inputReport);
+        }
+
+        //
+        // - Add column names and units to a fits image rendered as table
+        //
+        FileAnalysisReport retRep= inputReport.copy();
+        if (code.equals("TAB")) {
+            retRep= demoAddColumnNamesAndUnits(inputReport,headerAry);
+        }
+        //
+        // - Add column names and units to a fits image rendered as table
+        // - Create a customized chart
+        // - make chart the defult
+        //
+        else if (code.equals("TABCH")) {
+            retRep= demoCreate3Charts(inputReport,headerAry);
+        }
+
+        //
+        // - make a chart with two traces
+        //
+        else if (code.equals("TAB2CH")) {
+            retRep= demoCreate2Traces(inputReport,headerAry);
+        }
+
+
+        //
+        // - how to make a part the default
+        //
+        try {
+            int codeNum= Integer.parseInt(code);
+            if (codeNum>-1 && codeNum<inputReport.getParts().size()) {
+                retRep.getPart(codeNum).setDefaultPart(true);
+            }
+        } catch (NumberFormatException ignored) { }
+
+        //
+        // - how to disable the "All Image in file option
+        //
+        if (code.equals("NOALL") && params.containsKey("noimages") && Boolean.parseBoolean(params.get("noimages"))) {
+            retRep.setDisableAllImagesOption(true);
+        }
+
+
+        return retRep;
+    }
+
+
+
+    /**
+     * how to replace the analysis file with another file
+     */
+    private FileAnalysisReport demoReplacingData(FileAnalysisReport inputReport) {
+        try {
+            File f= new File(ServerContext.getUploadDir(),"x.fits");
+            URL url = new URL("http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits");
+            URLDownload.getDataToFile(url, f);
+            FileAnalysisReport retRep= inputReport.copy(false);
+            FileAnalysisReport.Part replacePart=
+                    new FileAnalysisReport.Part( FileAnalysisReport.Type.Image, "A image to replace");
+            replacePart.setFileLocationIndex(0);
+            replacePart.setDefaultPart(true);
+            replacePart.setUiRender(FileAnalysisReport.UIRender.Image);
+            replacePart.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
+            replacePart.setConvertedFileName(ServerContext.replaceWithPrefix(f));
+            retRep.addPart(replacePart);
+            return retRep;
+        } catch (MalformedURLException|FailedRequestException  e) {
+            e.printStackTrace();
+            return inputReport;
+        }
+    }
+
+    private FileAnalysisReport demoAddingAPart(FileAnalysisReport inputReport) {
+        try {
+            File f= new File(ServerContext.getUploadDir(),"x.fits");
+            URL url = new URL("http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits");
+            URLDownload.getDataToFile(url, f);
+            FileAnalysisReport retRep= inputReport.copy();
+            FileAnalysisReport.Part addPart=
+                    new FileAnalysisReport.Part( FileAnalysisReport.Type.Image, "An additional image ");
+            addPart.setFileLocationIndex(0);
+            addPart.setUiRender(FileAnalysisReport.UIRender.Image);
+            addPart.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
+            addPart.setConvertedFileName(ServerContext.replaceWithPrefix(f));
+            retRep.addPart(addPart);
+            return retRep;
+        } catch (MalformedURLException|FailedRequestException  e) {
+            e.printStackTrace();
+            return inputReport;
+        }
+
+    }
+
+    /**
+     *Add column names and units to a fits image rendered as table
+     */
+    private FileAnalysisReport demoAddColumnNamesAndUnits(FileAnalysisReport inputReport, Header[] headerAry) {
+        FileAnalysisReport retRep= inputReport.copy();
+        List<FileAnalysisReport.Part> parts= retRep.getParts();
+        for(FileAnalysisReport.Part part : parts) {
+            Header h= headerAry[part.getIndex()];
+            int naxis2= h.getIntValue("NAXIS2",0);
+            String xtension= h.getStringValue("XTENSION");
+            boolean isImage= xtension==null || xtension.equalsIgnoreCase("IMAGE");
+            if (naxis2>0 && naxis2<30 && isImage) {
+                part.setUiRender(FileAnalysisReport.UIRender.Chart);
+                part.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
+                List<String> cNames= new ArrayList<>(naxis2+1);
+                List<String> cUnits= new ArrayList<>(naxis2+1);
+                cNames.add("The_Index");
+                cUnits.add("count");
+                for(int i=1; i<naxis2+1;i++) cNames.add("Col-"+i);
+                for(int i=1; i<naxis2+1;i++) cUnits.add("Unit-"+i);
+                part.setTableColumnNames(cNames);
+                part.setTableColumnUnits(cUnits);
+            }
+        }
+        return retRep;
+    }
+
+    /*
+     * - Add column names and units to a fits image rendered as table
+     * - Create a customized chart
+     * - make chart the default
+     * - also demonstrates chaining - the image rendered as a table is set up by demoAddColumnNamesAndUnits
+     */
+    private FileAnalysisReport demoCreate3Charts(FileAnalysisReport inputReport, Header[] headerAry) {
+        FileAnalysisReport retRep= demoAddColumnNamesAndUnits(inputReport,headerAry);
+        List<FileAnalysisReport.Part> parts= retRep.getParts();
+        for(FileAnalysisReport.Part part : parts) {
+            Header h= headerAry[part.getIndex()];
+            int naxis2= h.getIntValue("NAXIS2",0);
+            String xtension= h.getStringValue("XTENSION");
+            boolean isImage= xtension==null || xtension.equalsIgnoreCase("IMAGE");
+            if (naxis2>0 && naxis2<30 && isImage) {
+                List<FileAnalysisReport.ChartParams> cpList= new ArrayList<>();
+
+                FileAnalysisReport.ChartParams cp= new FileAnalysisReport.ChartParams();
+                cp.setxAxisColName("Col-7");
+                cp.setyAxisColName("Col-8");
+                cp.setMode("markers");
+                cp.addLayout(Collections.singletonMap("title", "My Customized Scatter Chart"));
+                cpList.add(cp);
+
+
+                cp= new FileAnalysisReport.ChartParams();
+                cp.setNumBins(40);
+                cp.setyAxisColName("Col-1");
+                cp.setSimpleChartType(FileAnalysisReport.ChartParams.ChartType.Histogram);
+                cp.addLayout(Collections.singletonMap("title", "My Customized Histogram"));
+                cpList.add(cp);
+
+
+                cp= new FileAnalysisReport.ChartParams();
+                cp.setxAxisColName("The_Index");
+                cp.setyAxisColName("Col-1");
+                cp.setMode("lines+markers");
+                cp.setSimpleChartType(FileAnalysisReport.ChartParams.ChartType.XYChart);
+                cp.addLayout(Collections.singletonMap("title", "My Customized XY Chart"));
+                cpList.add(cp);
+
+                part.setChartParams(cpList);
+                part.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
+            }
+        }
+        return retRep;
+    }
+
+    /*
+     * - make a chart with two traces
+     * - also demonstrates chaining - the image rendered as a table is set up by demoAddColumnNamesAndUnits
+     */
+    private FileAnalysisReport demoCreate2Traces(FileAnalysisReport inputReport, Header[] headerAry) {
+        FileAnalysisReport retRep= demoAddColumnNamesAndUnits(inputReport,headerAry);
+        List<FileAnalysisReport.Part> parts= retRep.getParts();
+        for(FileAnalysisReport.Part part : parts) {
+            Header h= headerAry[part.getIndex()];
+            int naxis2= h.getIntValue("NAXIS2",0);
+            String xtension= h.getStringValue("XTENSION");
+            boolean isImage= xtension==null || xtension.equalsIgnoreCase("IMAGE");
+            if (naxis2>0 && naxis2<30 && isImage) {
+                FileAnalysisReport.ChartParams cp= new FileAnalysisReport.ChartParams();
+                List<Map<String,Object>> traces= new ArrayList<>();
+
+                // setup trace 1
+                Map<String,Object> trace= new HashMap<>();
+                trace.put("x", "tables::The_Index");
+                trace.put("y", "tables::Col-1");
+                trace.put("name", "col1 vs index");
+                trace.put("mode", "lines+markers");
+                traces.add(trace);
+
+                // setup trace 2
+                trace= new HashMap<>();
+                trace.put("x", "tables::The_Index");
+                trace.put("y", "tables::Col-10");
+                trace.put("name", "col10 vs index");
+                trace.put("mode", "lines+markers");
+                traces.add(trace);
+
+
+                cp.addLayout(Collections.singletonMap("title", "Chart With 2 Traces"));
+                cp.addLayout(Collections.singletonMap("xaxis", Collections.singletonMap("title", "the index")));
+                cp.addLayout(Collections.singletonMap("yaxis", Collections.singletonMap("title", "value")));
+                cp.setTraces(traces);
+                part.setChartParams(Collections.singletonList(cp));
+                part.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
+            }
+        }
+        return retRep;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
@@ -98,7 +98,7 @@ public class ServerEventManager {
     }
 
     public static void addEventQueue(ServerEventQueue queue) {
-        Logger.briefInfo("create new Queue for: "+ queue.getQueueID() );
+        Logger.briefInfo("Channel: create new Queue for: "+ queue.getQueueID() );
         evQueueList.add(queue);
         repQueueList.setQueueListForNode(evQueueList);
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
@@ -7,6 +7,7 @@ package edu.caltech.ipac.firefly.server.rpc;
 import edu.caltech.ipac.astro.net.HorizonsEphPairs;
 import edu.caltech.ipac.astro.net.Resolver;
 import edu.caltech.ipac.firefly.core.FileAnalysis;
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.server.ServCommand;
 import edu.caltech.ipac.firefly.server.SrvParam;
@@ -16,8 +17,11 @@ import edu.caltech.ipac.visualize.plot.ResolvedWorldPt;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import static edu.caltech.ipac.firefly.server.servlets.AnyFileUpload.ANALYZER_ID;
 
 /**
  * @author Trey Roby
@@ -103,8 +107,12 @@ public class ResolveServerCommands {
             try {
                 infile = sp.getRequired("filePath");
                 String rtype = sp.getOptional("reportType");
-                FileAnalysis.ReportType reportType = StringUtils.isEmpty(rtype) ? FileAnalysis.ReportType.Brief : FileAnalysis.ReportType.valueOf(rtype);   // defaults to Brief
-                FileAnalysis.Report report = FileAnalysis.analyze(new File(infile), reportType);
+                FileAnalysisReport.ReportType reportType = StringUtils.isEmpty(rtype) ? FileAnalysisReport.ReportType.Brief : FileAnalysisReport.ReportType.valueOf(rtype);   // defaults to Brief
+
+                FileAnalysisReport report = FileAnalysis.analyze(
+                        new File(infile), reportType,
+                        sp.getOptional(ANALYZER_ID),
+                        sp.getParamMapUsingExcludeList(Arrays.asList("filePath","reportType")));
                 return FileAnalysis.toJsonString(report);
             }catch (Exception e){
                 throw new Exception("Fail to analyze file: "+ infile);

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -3,7 +3,7 @@
  */
 package edu.caltech.ipac.table.io;
 
-import edu.caltech.ipac.firefly.core.FileAnalysis;
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
 import edu.caltech.ipac.table.IpacTableDef;
 import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.table.DataGroup;
@@ -161,14 +161,14 @@ public class DsvTableIO {
         }
     }
 
-    public static FileAnalysis.Report analyze(File infile, CSVFormat csvFormat, FileAnalysis.ReportType type) throws IOException {
+    public static FileAnalysisReport analyze(File infile, CSVFormat csvFormat, FileAnalysisReport.ReportType type) throws IOException {
         DataGroup header = getHeader(infile, csvFormat);
         String format = (csvFormat == CSVFormat.TDF) ? TableUtil.Format.TSV.name() : TableUtil.Format.CSV.name();
-        FileAnalysis.Report report = new FileAnalysis.Report(type, format, infile.length(), infile.getPath());
-        FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table, 0, String.format("%s (%d cols x %s rows)", csvFormat.getClass().getSimpleName(), header.getDataDefinitions().length, header.size()));
+        FileAnalysisReport report = new FileAnalysisReport(type, format, infile.length(), infile.getPath());
+        FileAnalysisReport.Part part = new FileAnalysisReport.Part(FileAnalysisReport.Type.Table, String.format("%s (%d cols x %s rows)", csvFormat.getClass().getSimpleName(), header.getDataDefinitions().length, header.size()));
         part.setTotalTableRows(header.size());
         report.addPart(part);
-        if (type.equals(FileAnalysis.ReportType.Details)) {
+        if (type.equals(FileAnalysisReport.ReportType.Details)) {
             IpacTableDef meta = new IpacTableDef();
             meta.setCols(Arrays.asList(header.getDataDefinitions()));
             part.setDetails(TableUtil.getDetails(0, meta));

--- a/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/IpacTableReader.java
@@ -3,7 +3,7 @@
  */
 package edu.caltech.ipac.table.io;
 
-import edu.caltech.ipac.firefly.core.FileAnalysis;
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataObject;
@@ -135,13 +135,13 @@ public final class IpacTableReader {
         return outData;
     }
 
-    public static FileAnalysis.Report analyze(File infile, FileAnalysis.ReportType type) throws IOException {
+    public static FileAnalysisReport analyze(File infile, FileAnalysisReport.ReportType type) throws IOException {
         IpacTableDef meta = IpacTableUtil.getMetaInfo(infile);
-        FileAnalysis.Report report = new FileAnalysis.Report(type, TableUtil.Format.IPACTABLE.name(), infile.length(), infile.getPath());
-        FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table, 0, String.format("IPAC Table (%d cols x %s rows)", meta.getCols().size(), meta.getRowCount()));
+        FileAnalysisReport report = new FileAnalysisReport(type, TableUtil.Format.IPACTABLE.name(), infile.length(), infile.getPath());
+        FileAnalysisReport.Part part = new FileAnalysisReport.Part(FileAnalysisReport.Type.Table, String.format("IPAC Table (%d cols x %s rows)", meta.getCols().size(), meta.getRowCount()));
         part.setTotalTableRows(meta.getRowCount());
         report.addPart(part);
-        if (type.equals(FileAnalysis.ReportType.Details)) {
+        if (type.equals(FileAnalysisReport.ReportType.Details)) {
             part.setDetails(TableUtil.getDetails(0, meta));
         }
         return report;

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -3,7 +3,7 @@
  */
 package edu.caltech.ipac.table.io;
 
-import edu.caltech.ipac.firefly.core.FileAnalysis;
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.network.HttpServices;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
@@ -470,14 +470,14 @@ public class VoTableReader {
 //  file analysis support
 //====================================================================
 
-    public static FileAnalysis.Report analyze(File infile, FileAnalysis.ReportType type) throws Exception {
+    public static FileAnalysisReport analyze(File infile, FileAnalysisReport.ReportType type) throws Exception {
 
-        FileAnalysis.Report report = new FileAnalysis.Report(type, TableUtil.Format.VO_TABLE.name(), infile.length(), infile.getPath());
-        List<FileAnalysis.Part> parts = tablesToParts(infile);
+        FileAnalysisReport report = new FileAnalysisReport(type, TableUtil.Format.VO_TABLE.name(), infile.length(), infile.getPath());
+        List<FileAnalysisReport.Part> parts = tablesToParts(infile);
         parts.forEach(report::addPart);
 
         for(int i = 0; i < parts.size(); i++) {
-            if (type == FileAnalysis.ReportType.Details) {
+            if (type == FileAnalysisReport.ReportType.Details) {
                 // convert DataGroup headers into Report's details
                 DataGroup p = parts.get(i).getDetails();
                 IpacTableDef meta = new IpacTableDef();
@@ -500,16 +500,17 @@ public class VoTableReader {
      * @param infile  input file to analyze
      * @return each Table as a part with details containing DataGroup without data
      */
-    private static List<FileAnalysis.Part> tablesToParts(File infile) throws Exception {
+    private static List<FileAnalysisReport.Part> tablesToParts(File infile) throws Exception {
 
         VOElement docRoot = getVoTableRoot(infile.getAbsolutePath(), null);
         List<TableElement> tables = getAllTableElements(docRoot);
         List<ResourceInfo> resources = getAllResources(docRoot);
 
-        List<FileAnalysis.Part> parts = new ArrayList<>();
+        List<FileAnalysisReport.Part> parts = new ArrayList<>();
         tables.forEach(table -> {
-            FileAnalysis.Part part = new FileAnalysis.Part(FileAnalysis.Type.Table);
+            FileAnalysisReport.Part part = new FileAnalysisReport.Part(FileAnalysisReport.Type.Table);
             part.setIndex(parts.size());
+            part.setFileLocationIndex(parts.size());
             DataGroup dg = getTableHeader(table);
             if (resources != null) dg.setResourceInfos(resources);
             String title = isEmpty(dg.getTitle()) ? "VOTable" : dg.getTitle().trim();

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -139,9 +139,13 @@ const defFireflyOptions = {
     coverage : {
         // TODO: need to define all options with defaults here.  used in FFEntryPoint.js
     },
-    multiProducesViewer : {
+    dataProducts : {
         factoryOverride: [
-        ]
+        ],
+        clientAnalysis: {
+            // xxxx : abcDataProductsAnalyzer
+
+        },
     },
     tap : {
         services: [

--- a/src/firefly/js/data/FileAnalysis.js
+++ b/src/firefly/js/data/FileAnalysis.js
@@ -9,3 +9,137 @@ export const FileAnalysisType = {
     TAR: 'TAR',
     Unknown: 'Unknown',
 };
+
+export const UIRender = {
+    Table: 'Table',
+    Chart: 'Chart',
+    Image: 'Image',
+    NotSpecified: 'NotSpecified'
+};
+
+export const UIEntry=  {
+    UseSpecified: 'UseSpecified',
+    UseGuess: 'UseGuess',
+    UseBoth : 'UseBoth'
+};
+
+
+export const Format= {
+    TSV: 'TSV',
+    CSV: 'CSV',
+    IPACTABLE: 'IPACTABLE',
+    UNKNOWN: 'UNKNOWN',
+    FIXEDTARGETS: 'FIXEDTARGETS',
+    FITS: 'FITS',
+    JSON: 'JSON',
+    PDF: 'PDF',
+    TAR: 'TAR',
+    VO_TABLE: 'VO_TABLE',
+    VO_TABLE_TABLEDATA: 'VO_TABLE_TABLEDATA',
+    VO_TABLE_BINARY: 'VO_TABLE_BINARY',
+    VO_TABLE_BINARY2: 'VO_TABLE_BINARY2',
+    VO_TABLE_FITS: 'VO_TABLE_FITS'
+};
+
+export const ChartType = {
+    XYChart : 'XYChart',
+    Histogram : 'Histogram',
+};
+
+
+export const makeFileAnalysisReport= (type) => (
+    {
+        type,
+        filePath: undefined,
+        fileName: undefined,
+        fileSize: undefined,
+        fileFormat: undefined,
+        dataType: undefined,
+        parts: [
+            makeFileAnalysisPart(0),
+        ]
+    });
+
+
+export const makeFileAnalysisPart= (index,fileLocationIndex=0) => (
+    {
+        index,
+        fileLocationIndex,
+        uiEntry: UIEntry.UseBoth,
+        uiRender: UIRender.NotSpecified,
+        convertedFileName: undefined,
+        chartParams: undefined,
+        tableColumnNames: undefined,
+        tableColumnUnits: undefined,
+        defaultPart: false,
+    } );
+
+
+
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} ChartInfo
+ *
+ * @prop {string} xAxis
+ * @prop {string} yAxis
+ * @prop {Array.<FileAnalysisChartParams>} chartParamsAry
+ *
+ */
+
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} FileAnalysisReport
+ *
+ * @prop {string} type
+ * @prop {number} fileSize - size in bytes of the file
+ * @prop {string} filePath
+ * @prop {string} fileFormat - format of the file
+ * @prop {Array.<FileAnalysisPart>} parts
+ * @prop {string} dataType
+ * @prop {boolean} [disableAllImagesOption] - if true the the UI should not show an "All Images" options
+ * @prop {string} [dataProductsAnalyzerId] - the id of the data products analyzer
+ * @prop {boolean} analyzerFound - an data products analyzer was found and further processed this report
+ *
+ */
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} FileAnalysisPart
+ *
+ *  @prop {string} type - see FileAnalysisType
+ *  @prop {string} uiRender - see UIRender object
+ *  @prop {string} uiEntry - see UIEntry object
+ *  @prop {number} index - index of the part (may be different from fileLocationIndex)
+ *  @prop {string} desc
+ *  @prop {number} fileLocationIndex - either the FITS HDU number or some other location scheme
+ *  @prop {string} [convertedFileName] - only set if this entry is has a alternate file than the one analyzed
+ *  @prop {FileAnalysisChartParams} [chartParams]
+ *  @prop {Array.<string>} [tableColumnNames] only use for a fits image that is read as a table
+ *  @prop {Array.<string>} [tableColumnUnits] only use for a fits image that is read as a table
+ *  @prop {boolean} [defaultPart]
+ *  @prop {string} chartTableDefOption - only used if there is a chart on of 'auto', 'showChart', 'showTable'
+ *  @prop {TableModel} [details]
+ *
+ *
+ */
+
+/**
+ * @global
+ * @public
+ * @typedef {Object} FileAnalysisChartParams
+ *
+ * @prop {boolean} layoutAdds
+ * @prop {boolean} simpleData
+ * @prop {string} [simpleChartType] - see ChartType
+ * @prop {Array.<string>} [layout] - a layout to be add or to replace the default
+ * @prop {string} [xAxisColName]
+ * @prop {string} [yAxisColName]
+ * @prop {string} [mode]
+ * @prop {Array.<Object>} [traces] - if defined it replaces the default
+ *
+ */

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -88,6 +88,11 @@ export const MetaConst = {
      */
     IMAGE_AS_TABLE_COL_NAMES: 'IMAGE_AS_TABLE_COL_NAMES',
 
+    /*
+     * comma separated names of the units to assign to the table when reading a fits image as a table.
+     */
+    IMAGE_AS_TABLE_UNITS: 'IMAGE_AS_TABLE_UNITS',
+
     /** the column name with the url or filename of the image data */
     DATA_SOURCE : 'DataSource',
 
@@ -116,6 +121,30 @@ export const MetaConst = {
     HIGHLIGHTED_ROW             : 'highlightedRow',                 // row to highlight on data fetch
     HIGHLIGHTED_ROW_BY_ROWIDX   : 'highlightedRowByRowIdx',         // row to highlight on data fetch based on original row index
 
+
+    /**
+     * The id of the file analyzer to call
+     * example - analyzerId: Sofia
+     */
+    ANALYZER_ID : 'AnalyzerId',
+
+    /**
+     * a list of columns, separated by commas, whose values will be send as parameter to the related DataProductAnalyzer
+     * The key will the the columns names, the values will the taken from the active row. Therefore the values
+     * will change as different rows are selected.
+     * example - analyzerColumns: Processing Level,Product Type,Bandpass
+     *
+     */
+    ANALYZER_COLUMNS : 'AnalyzerColumns',
+
+    /**
+     * a list of parameters, separated by commas, that will be send to the data product analyzer. The key/value pairs will be the same
+     * regardless of which row is selected.
+     * example - analyzerIdParams: instrument=FLITECAM,A=123
+     */
+    ANALYZER_PARAMS : 'AnalyzerParams',
+
+
     /** @deprecated use CENTER_COLUMN */
     CATALOG_COORD_COLS : 'CatalogCoordColumns',
 
@@ -124,5 +153,6 @@ export const MetaConst = {
 
     /** @deprecated replaced by IMAGE_SOURCE_ID */
     DATASET_CONVERTER : 'datasetInfoConverterId'
+
 
 };

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -293,7 +293,7 @@ function initConverterTemplates() {
     ];
 
 
-    const {factoryOverride} = getAppOptions()?.multiProducesViewer ?? {};
+    const {factoryOverride} = getAppOptions()?.dataProducts ?? {};
     let converterTemplates = originalConverterTemplates;
     if (isArray(factoryOverride)) {
         converterTemplates = originalConverterTemplates.map((t) => {

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -44,6 +44,7 @@ export const DPtypes= {
 
 export const SHOW_CHART='showChart';
 export const SHOW_TABLE='showTable';
+export const AUTO='auto';
 
 /**
  *

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -33,10 +33,10 @@ import {encodeServerUrl, uniqueID} from '../util/WebUtil.js';
 import {fetchTable, queryTable, selectedValues} from '../rpc/SearchServicesJson.js';
 import {DEF_BASE_URL} from '../core/JsonUtils.js';
 import {ServerParams} from '../data/ServerParams.js';
-import {doUpload} from '../ui/FileUpload.jsx';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../core/MasterSaga.js';
 import {MetaConst} from '../data/MetaConst';
 import {toBoolean} from '../util/WebUtil';
+import {upload} from '../rpc/CoreServices.js';
 import {dd2sex} from '../visualize/CoordUtil.js';
 
 
@@ -907,7 +907,7 @@ export function getAsyncTableSourceUrl(tbl_ui_id, params) {
     const ipacTable = tableToIpac(getTblById(tbl_id));
     const blob = new Blob([ipacTable]);
     //const file = new File([new Blob([ipacTable])], filename);
-    return doUpload(blob).then( ({status, cacheKey}) => {
+    return upload(blob).then( ({status, cacheKey}) => {
         const request = makeFileRequest('save as text', cacheKey, null, {pageSize: MAX_ROW});
         return makeTableSourceUrl(columns, request, params);
     });

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -3,7 +3,6 @@
  */
 
 import {get, set, slice, isArray, isString, cloneDeep, pick, omit} from 'lodash';
-import {doUpload} from '../../ui/FileUpload.jsx';
 import {dispatchChartAdd} from '../../charts/ChartsCntlr.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
@@ -12,6 +11,7 @@ import {makeFileRequest} from '../../tables/TableRequestUtil.js';
 import {LC, getFullRawTable, getConverterId} from './LcManager.js';
 import {getLayouInfo} from '../../core/LayoutCntlr.js';
 import {getConverter, getYColMappings} from './LcConverterFactory.js';
+import {upload} from '../../rpc/CoreServices.js';
 
 
 const DEC_PHASE = 3;       // decimal digit
@@ -27,7 +27,7 @@ export function uploadPhaseTable(tbl, flux) {
     const blob = new Blob([ipacTable]);
     //const file = new File([new Blob([ipacTable])], `${tbl_id}.tbl`);
 
-    doUpload(blob).then(({status, cacheKey}) => {
+    upload(blob).then(({status, cacheKey}) => {
         const tReq = makeFileRequest(title, cacheKey, null,
                                      {tbl_id,
                                       sortInfo:sortInfoString(LC.PHASE_CNAME),

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -42,7 +42,7 @@ import {INFO_POPUP, showInfoPopup} from './PopupUtil.jsx';
 import {getWorkspaceConfig} from '../visualize/WorkspaceCntlr.js';
 
 import HelpIcon from './HelpIcon.jsx';
-import {fetchUrl} from '../util/WebUtil';
+import {upload} from '../rpc/CoreServices.js';
 
 const STRING_SPLIT_TOKEN= '--STR--';
 const dialogWidth = 500;
@@ -766,14 +766,6 @@ function getHyphenatedName(str){
     return fName;
 }
 
-const UL_URL = `${getRootURL()}sticky/CmdSrv?${ServerParams.COMMAND}=${ServerParams.UPLOAD}`;
-
-function doUpload(file, params={}) {
-    params = Object.assign(params, {file});   // file should be the last param due to AnyFileUpload limitation
-    const options = {method: 'multipart', params};
-    return fetchUrl(UL_URL, options);
-}
-
 function makePngLocal(plotId, filename= 'a.png') {
     const canvas= makeImageCanvas(plotId);
 
@@ -800,7 +792,7 @@ function makePngWorkspace(plotId, path, filename= 'a.png') {
                 [WS_SERVER_PARAM.should_overwrite.key]: true
             };
 
-            return doUpload(blob, params).then( ({status, cacheKey}) => {
+            return upload(blob, false, params).then( ({status, cacheKey}) => {
             });
         }, 'image/png');
     }

--- a/src/firefly/js/ui/WorkspaceViewer.jsx
+++ b/src/firefly/js/ui/WorkspaceViewer.jsx
@@ -34,6 +34,7 @@ const workspacePopupId = 'workspacePopupId';
 import LOADING from 'html/images/gxt/loading.gif';
 import ComponentCntlr from '../core/ComponentCntlr.js';
 import {isExistWorspaceFile} from '../visualize/WorkspaceCntlr';
+import {parseUploadResults} from '../rpc/CoreServices.js';
 
 /*-----------------------------------------------------------------------------------------*/
 /* core component as FilePicker wrapper
@@ -368,15 +369,7 @@ function doUploadWorkspace(file, params={}) {
     }
 
     return fetchUrl(UL_URL, options).then( (response) => {
-        return response.text().then((text) => {
-            // text is in format ${status}::${message}::${message}::${cacheKey}::${analysisResult}
-            let [status, message, cacheKey, analysisResult, ...rest] = text.split('::');
-            if (rest.length > 0) {
-                // there are '::' in the analysisReaults.. put it back
-                analysisResult = analysisResult + '::' + rest.join('::');
-            }
-            return {status, message, cacheKey, analysisResult};
-        });
+        return response.text().then((text) => parseUploadResults(text) );
     });
 }
 

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -3,8 +3,8 @@
  */
 
 import shallowequal from 'shallowequal';
-import {get, set, has, omit, isObject, union, isFunction, isEqual,  isNil, memoize,
-        last, isPlainObject, forEach, fromPairs, mergeWith, isArray, truncate, find} from 'lodash';
+import {get, set, has, omit, isObject, union, isFunction, isEqual,  isNil,
+        last, isPlainObject, forEach, fromPairs, mergeWith, isArray, truncate} from 'lodash';
 
 import {getRootURL} from './BrowserUtil.js';
 import {getDownloadProgress, DownloadProgress} from '../rpc/SearchServicesJson.js';
@@ -309,7 +309,7 @@ function doFetchUrl(url, options, doValidation) {
                     params.forEach( ({name, value}) => {
                         data.append(name, value);
                     });
-                    options.body = data;
+                    options.boy = data;
                 }
                 Reflect.deleteProperty(options, 'params');
             }

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -1,5 +1,5 @@
 /* eslint prefer-template:0 */
-import {get, isString, isPlainObject, isArray, join, omit, pick} from 'lodash';
+import {get, isString, isPlainObject, isArray, join, omit, pick, isObject} from 'lodash';
 import Enum from 'enum';
 import {ServerRequest} from '../data/ServerRequest.js';
 import {RequestType} from './RequestType.js';
@@ -53,7 +53,7 @@ export const AnnotationOps= new Enum([  // note - this is not completely impleme
 export const GridOnStatus= new Enum(['FALSE','TRUE','TRUE_LABELS_FALSE'], { ignoreCase: true });
 
 export const DEFAULT_THUMBNAIL_SIZE= 70;
-const WEB_PLOT_REQUEST_CLASS= 'WebPlotRequest';
+export const WEB_PLOT_REQUEST_CLASS= 'WebPlotRequest';
 
 export const WPConst= {
     FILE : 'File',
@@ -944,6 +944,8 @@ export class WebPlotRequest extends ServerRequest {
      * @return (WebPlotRequest) the deserialized WebPlotRequest
      */
     static parse(str) { return ServerRequest.parse(str, new WebPlotRequest()); }
+
+    static isWPR(o) {return isObject(o) && o.getRequestClass?.()===WEB_PLOT_REQUEST_CLASS;}
 
     /**
      * @return {WebPlotRequest}

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -57,10 +57,10 @@ import HiPSGrid from '../../drawingLayers/HiPSGrid.js';
 import {resolveHiPSIvoURL} from '../HiPSListUtil.js';
 import {addNewMocLayer, isMOCFitsFromUploadAnalsysis, makeMocTableId, MOCInfo, UNIQCOL} from '../HiPSMocUtil.js';
 import HiPSMOC from '../../drawingLayers/HiPSMOC.js';
-import {doUpload} from '../../ui/FileUpload.jsx';
 import {getRowCenterWorldPt} from '../saga/ActiveRowCenterWatcher';
 import {getActiveTableId} from '../../tables/TableUtil';
 import {locateOtherIfMatched, matchHiPStoPlotView} from './WcsMatchTask';
+import {upload} from '../../rpc/CoreServices.js';
 
 const PROXY= true;
 
@@ -295,7 +295,7 @@ async function createHiPSMocLayer(ivoid, hipsUrl, plot, mocFile = 'Moc.fits') {
     }
 
     try {
-        const {status, cacheKey, analysisResult}=  await doUpload(mocUrl, {isFromURL: true, fileAnalysis: ()=>{}});
+        const {status, cacheKey, analysisResult}=  await upload(mocUrl, 'details');
         if (status === '200') {
             const report = JSON.parse(analysisResult) || {};
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
@@ -44,81 +44,81 @@ public class FileAnalysisTest extends ConfigTest {
 
         // brief reports only the bare minimum..  path, size, type and descriptions
         // The following tests is to ensure that all analyzers(fits, votable, ipactable, and csv/tsv) capture this information correctly
-        FileAnalysis.ReportType reportType = FileAnalysis.ReportType.Brief;
+        FileAnalysisReport.ReportType reportType = FileAnalysisReport.ReportType.Brief;
 
-        FileAnalysis.Report report= FileAnalysis.analyze(voTable, reportType);
-        assertEquals(FileAnalysis.ReportType.Brief, report.getType());
+        FileAnalysisReport report= FileAnalysis.analyze(voTable, reportType);
+        assertEquals(FileAnalysisReport.ReportType.Brief, report.getType());
         assertEquals(voTable.getPath(), report.getFilePath());
         assertEquals(voTable.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("VOTable (271 cols x 5000 rows)", report.getParts().get(0).getDesc());
 
         report= FileAnalysis.analyze(ipacTable, reportType);
-        assertEquals(FileAnalysis.ReportType.Brief, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Brief, report.getType());
         assertEquals(ipacTable.getPath(), report.getFilePath());
         assertEquals(ipacTable.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("IPAC Table (25 cols x 49933 rows)", report.getParts().get(0).getDesc());
 
         report= FileAnalysis.analyze(fitsTables, reportType);
-        assertEquals(FileAnalysis.ReportType.Brief, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Brief, report.getType());
         assertEquals(fitsTables.getPath(), report.getFilePath());
         assertEquals(fitsTables.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.HeaderOnly, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.HeaderOnly, report.getParts().get(0).getType());
         assertEquals("Primary", report.getParts().get(0).getDesc());
 
         report= FileAnalysis.analyze(multiImage, reportType);
-        assertEquals(FileAnalysis.ReportType.Brief, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Brief, report.getType());
         assertEquals(multiImage.getPath(), report.getFilePath());
         assertEquals(multiImage.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.HeaderOnly, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.HeaderOnly, report.getParts().get(0).getType());
         assertEquals("Primary", report.getParts().get(0).getDesc());
 
         report= FileAnalysis.analyze(csvTable, reportType);
-        assertEquals(FileAnalysis.ReportType.Brief, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Brief, report.getType());
         assertEquals(csvTable.getPath(), report.getFilePath());
         assertEquals(csvTable.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("CSVFormat (6 cols x 1000 rows)", report.getParts().get(0).getDesc());
     }
 
     @Test
     public void testNormal() throws Exception {
         // normal reports on individual parts but without details
-        FileAnalysis.ReportType reportType = FileAnalysis.ReportType.Normal;
+        FileAnalysisReport.ReportType reportType = FileAnalysisReport.ReportType.Normal;
 
-        FileAnalysis.Report report= FileAnalysis.analyze(voTable, reportType);
-        assertEquals(FileAnalysis.ReportType.Normal, report.getType());
+        FileAnalysisReport report= FileAnalysis.analyze(voTable, reportType);
+        assertEquals(FileAnalysisReport.ReportType.Normal, report.getType());
         assertEquals(voTable.getPath(), report.getFilePath());
         assertEquals(voTable.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("VOTable (271 cols x 5000 rows)", report.getParts().get(0).getDesc());
 
         File wNrows = FileLoader.resolveFile("/votable-samples/stilbinary.xml");                 // VOTable with nrows
         report= FileAnalysis.analyze(wNrows, reportType);
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("Main Information Table for NED objects within 1.000 arcmin of object MESSIER 031 (17 cols x 165 rows)", report.getParts().get(0).getDesc());        // first table
 
         report= FileAnalysis.analyze(ipacTable, reportType);
-        assertEquals(FileAnalysis.ReportType.Normal, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Normal, report.getType());
         assertEquals(ipacTable.getPath(), report.getFilePath());
         assertEquals(ipacTable.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("IPAC Table (25 cols x 49933 rows)", report.getParts().get(0).getDesc());
 
         report= FileAnalysis.analyze(csvTable, reportType);
-        assertEquals(FileAnalysis.ReportType.Normal, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Normal, report.getType());
         assertEquals(csvTable.getPath(), report.getFilePath());
         assertEquals(csvTable.length(), report.getFileSize());
         assertEquals(1, report.getParts().size());
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("CSVFormat (6 cols x 1000 rows)", report.getParts().get(0).getDesc());
 
         // files with multiple parts
@@ -126,37 +126,37 @@ public class FileAnalysisTest extends ConfigTest {
         File multiVoTable = FileLoader.resolveFile("FileUpload-samples/VOTable/tabledata/multiTables_Ned.xml");    // VOTable with multiple parts
         report= FileAnalysis.analyze(multiVoTable, reportType);
         assertEquals(826, report.getParts().size());
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(0).getType());
         assertEquals("Main Information Table for NED objects within 1.000 arcmin of object MESSIER 031 (17 cols x 165 rows)", report.getParts().get(0).getDesc());       // first table
         assertEquals("Table of all names in NED for MESSIER 031 (2 cols x 49 rows)", report.getParts().get(1).getDesc());                                                // second table
         assertEquals("Table of External Links for the  SSTSL2 J004244.22+411708.6 (3 cols x 12 rows)", report.getParts().get(825).getDesc());                            // last table
 
         // mixed images and table in a fits file
         report= FileAnalysis.analyze(fitsTables, reportType);
-        assertEquals(FileAnalysis.ReportType.Normal, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Normal, report.getType());
         assertEquals(fitsTables.getPath(), report.getFilePath());
         assertEquals(fitsTables.length(), report.getFileSize());
         assertEquals(11, report.getParts().size());
-        assertEquals(FileAnalysis.Type.HeaderOnly, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.HeaderOnly, report.getParts().get(0).getType());
         assertEquals("Primary", report.getParts().get(0).getDesc());
         assertEquals("NoName", report.getParts().get(1).getDesc());
 
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(4).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(4).getType());
         assertEquals("NoName (7 cols x 12 rows)", report.getParts().get(4).getDesc());
 
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(8).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(8).getType());
         assertEquals("NoName (3 cols x 4 rows)", report.getParts().get(8).getDesc());
 
-        assertEquals(FileAnalysis.Type.Table, report.getParts().get(10).getType());
+        assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(10).getType());
         assertEquals("NoName (4 cols x 1 rows)", report.getParts().get(10).getDesc());
 
         // multiple images in a fits file
         report= FileAnalysis.analyze(multiImage, reportType);
-        assertEquals(FileAnalysis.ReportType.Normal, report.getType());
+        assertEquals(FileAnalysisReport.ReportType.Normal, report.getType());
         assertEquals(multiImage.getPath(), report.getFilePath());
         assertEquals(multiImage.length(), report.getFileSize());
         assertEquals(62, report.getParts().size());
-        assertEquals(FileAnalysis.Type.HeaderOnly, report.getParts().get(0).getType());
+        assertEquals(FileAnalysisReport.Type.HeaderOnly, report.getParts().get(0).getType());
         assertEquals("Primary", report.getParts().get(0).getDesc());
         assertEquals("NoName", report.getParts().get(1).getDesc());
         assertEquals("NoName", report.getParts().get(61).getDesc());
@@ -165,10 +165,10 @@ public class FileAnalysisTest extends ConfigTest {
     @Test
     public void testDetails() throws Exception {
         // details report on all of the above plus additional information like fits/image/table headers plus columns, links, and groups information if it's a table.
-        FileAnalysis.ReportType reportType = FileAnalysis.ReportType.Details;
+        FileAnalysisReport.ReportType reportType = FileAnalysisReport.ReportType.Details;
 
         // a VO table with one table... has headers
-        FileAnalysis.Report report= FileAnalysis.analyze(voTable, reportType);
+        FileAnalysisReport report= FileAnalysis.analyze(voTable, reportType);
         DataGroup details = report.getParts().get(0).getDetails();
         // test headers
         assertEquals("true", details.getAttribute("contains_lsst_footprints"));
@@ -245,23 +245,23 @@ public class FileAnalysisTest extends ConfigTest {
         StopWatch.getInstance().start("perfTestMidSize").enable().setLogger(Logger.getLogger("console"));
         for(int i=0; i < 10; i++) {
             StopWatch.getInstance().start("voTable");
-            FileAnalysis.analyze(voTable, FileAnalysis.ReportType.Details);
+            FileAnalysis.analyze(voTable, FileAnalysisReport.ReportType.Details);
             StopWatch.getInstance().stop("voTable");
 
             StopWatch.getInstance().start("ipacTable");
-            FileAnalysis.analyze(ipacTable, FileAnalysis.ReportType.Details);
+            FileAnalysis.analyze(ipacTable, FileAnalysisReport.ReportType.Details);
             StopWatch.getInstance().stop("ipacTable");
 
             StopWatch.getInstance().start("fitsTables");
-            FileAnalysis.analyze(fitsTables, FileAnalysis.ReportType.Details);
+            FileAnalysis.analyze(fitsTables, FileAnalysisReport.ReportType.Details);
             StopWatch.getInstance().stop("fitsTables");
 
             StopWatch.getInstance().start("multiImage");
-            FileAnalysis.analyze(multiImage, FileAnalysis.ReportType.Details);
+            FileAnalysis.analyze(multiImage, FileAnalysisReport.ReportType.Details);
             StopWatch.getInstance().stop("multiImage");
 
             StopWatch.getInstance().start("csvTable");
-            FileAnalysis.analyze(csvTable, FileAnalysis.ReportType.Details);
+            FileAnalysis.analyze(csvTable, FileAnalysisReport.ReportType.Details);
             StopWatch.getInstance().stop("csvTable");
         }
 

--- a/src/firefly/test/edu/caltech/ipac/table/VoTableReaderTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/VoTableReaderTest.java
@@ -5,7 +5,7 @@ package edu.caltech.ipac.table;
 
 import edu.caltech.ipac.TestCategory;
 import edu.caltech.ipac.firefly.ConfigTest;
-import edu.caltech.ipac.firefly.core.FileAnalysis;
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.firefly.util.FileLoader;
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * @author loi
@@ -45,7 +44,7 @@ public class VoTableReaderTest extends ConfigTest {
         StopWatch.getInstance().start("perfTestMidSize").enable().setLogger(Logger.getLogger("console"));
         for(int i=0; i < 10; i++) {
             StopWatch.getInstance().start("getheader");
-            VoTableReader.analyze(midFile, FileAnalysis.ReportType.Details);
+            VoTableReader.analyze(midFile, FileAnalysisReport.ReportType.Details);
             StopWatch.getInstance().stop("getheader");
         }
         StopWatch.getInstance().printLog("getheader", StopWatch.Unit.SECONDS);
@@ -60,7 +59,7 @@ public class VoTableReaderTest extends ConfigTest {
         StopWatch.getInstance().start("perfTestLargeSize").enable().setLogger(Logger.getLogger("console"));
         for(int i=0; i < 10; i++) {
             StopWatch.getInstance().start("getheader");
-            VoTableReader.analyze(largeFile, FileAnalysis.ReportType.Details);
+            VoTableReader.analyze(largeFile, FileAnalysisReport.ReportType.Details);
             StopWatch.getInstance().stop("getheader");
         }
         StopWatch.getInstance().printLog("getheader", StopWatch.Unit.SECONDS);


### PR DESCRIPTION
### Firefly-463: Add infrastructure to further process file FileAnalysis results

 - FileAnalysisReport can now be replaced or updated by a DataProductAnalyzer
 - Table meta allows us to specify what parameters are passed to the DataProductAnalyzer
 - On server side created DataProductAnalyzer interface and framework to call
 - On client side create a from work to call as well
 - Added support on client side to charting parameters
 - More fine turn control over what is displayed
 - Added a way to add or replace Parts in the data analysis

_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-463

### To Test

_Test URL:_  https://irsawebdev9.ipac.caltech.edu/firefly-463-fa-upgrade/firefly/

- There is an example implementation of a DataProductAnalyzer, ` Demo1Analyzer`
- Use the upload panel to load the following: 
  - http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/data-products-test/dp-test.tbl
- The table has various results, rows with a 1 in the DP changed column has DataProduct results that have been modified by `Demo1Analyzer.java`
- the meta data controls if a `DataProductAnalyzer` is called
