### PR TITLE
FIREFLY-533: Change tri-view layout

### DIFF
--- a/src/firefly/js/templates/fireflyviewer/ResultsPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/ResultsPanel.jsx
@@ -106,11 +106,11 @@ function resolveComponents(standard, imagePlot, xyPlot, tables) {
     if(standard.has(LO_VIEW.images)) {
         components.push(imagePlot);
     }
-    if(standard.has(LO_VIEW.tables)) {
-        components.push(tables);
-    }
     if(standard.has(LO_VIEW.xyPlots)) {
         components.push(xyPlot);
+    }
+    if(standard.has(LO_VIEW.tables)) {
+        components.push(tables);
     }
     return filter(components);  // only takes declared items
 }


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-533

Changed Firefly's tri-view layout as described in ticket.
images top-left, chart top-right, table bottom half.

Test with IRSAViewer:  https://irsakudevlb1.ipac.caltech.edu/firefly-533-triview-layout/
Enter `m51` into `Search for Source` (radar) then click `Search`
on first row, click `To IRSAViewer`

Or, go straight to IRSAViewer: https://irsakudevlb1.ipac.caltech.edu/firefly-533-triview-layout/irsaviewer/
Then do a Catalog search