### PR TITLE
IRSA-2651:overlays keep reappearing

### DIFF
--- a/src/firefly/js/drawingLayers/HiPSMOC.js
+++ b/src/firefly/js/drawingLayers/HiPSMOC.js
@@ -5,7 +5,7 @@ import Enum from 'enum';
 import {makeDrawingDef, TextLocation, Style} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {DataTypes, ColorChangeType}  from '../visualize/draw/DrawLayer.js';
 import {makeFactoryDef} from '../visualize/draw/DrawLayerFactory.js';
-import {primePlot, getDrawLayerById, getPlotViewIdList} from '../visualize/PlotViewUtil.js';
+import {primePlot, getDrawLayerById, getPlotViewIdListInOverlayGroup} from '../visualize/PlotViewUtil.js';
 import {visRoot} from '../visualize/ImagePlotCntlr.js';
 import DrawLayerCntlr, {DRAWING_LAYER_KEY, dispatchUpdateDrawLayer} from '../visualize/DrawLayerCntlr.js';
 import {get, set, isEmpty, cloneDeep, isString} from 'lodash';
@@ -465,7 +465,7 @@ function asyncComputeDrawData(drawLayer, action) {
             pIdAry = plotIdAry;
         } else if (action.type === ImagePlotCntlr.CHANGE_CENTER_OF_PROJECTION ) {
             if (plotId) {
-                pIdAry = getPlotViewIdList(visRoot(), plotId);
+                pIdAry = getPlotViewIdListInOverlayGroup(visRoot(), plotId);
             }
         } else if (plotId) {
             pIdAry = [plotId];

--- a/src/firefly/js/visualize/DrawLayerCntlr.js
+++ b/src/firefly/js/visualize/DrawLayerCntlr.js
@@ -4,7 +4,7 @@
 
 import {flux} from '../Firefly.js';
 import Enum from 'enum';
-import {getPlotViewIdList, getPlotViewById, getDrawLayerById,
+import {getPlotViewIdListInOverlayGroup, getPlotViewById, getDrawLayerById,
           getConnectedPlotsIds, getAllPlotViewIdByOverlayLock} from './PlotViewUtil.js';
 import ImagePlotCntlr, {visRoot}  from './ImagePlotCntlr.js';
 import DrawLayerReducer from './reducer/DrawLayerReducer.js';
@@ -232,7 +232,7 @@ export function dispatchCreateDrawLayer(drawLayerTypeId, params={}) {
  *  @function dispatchChangeVisibility
  */
 export function dispatchChangeVisibility({id,visible, plotId, useGroup= true, subGroupId, matchTitle= false}) {
-    let plotIdAry= useGroup ? getPlotViewIdList(visRoot(), plotId) : [plotId];
+    let plotIdAry= useGroup ? getPlotViewIdListInOverlayGroup(visRoot(), plotId) : [plotId];
     if (subGroupId) {
         const vr= visRoot();
         plotIdAry= plotIdAry.filter( (plotId) => {
@@ -260,7 +260,7 @@ export function dispatchChangeVisibility({id,visible, plotId, useGroup= true, su
  *  @function dispatchChangeDrawingDef
  */
 export function dispatchChangeDrawingDef(id,drawingDef, plotId, matchTitle= false) {
-    const plotIdAry= getPlotViewIdList(visRoot(), plotId);
+    const plotIdAry= getPlotViewIdListInOverlayGroup(visRoot(), plotId);
 
     getDrawLayerIdAry(dlRoot(),id, matchTitle)
         .forEach( (drawLayerId) => {
@@ -280,7 +280,7 @@ export function dispatchChangeDrawingDef(id,drawingDef, plotId, matchTitle= fals
  */
 export function dispatchModifyCustomField(id,changes, plotId) {
 
-    const plotIdAry= getPlotViewIdList(visRoot(), plotId);
+    const plotIdAry= getPlotViewIdListInOverlayGroup(visRoot(), plotId);
 
     getDrawLayerIdAry(dlRoot(),id)
         .forEach( (drawLayerId) => {
@@ -306,7 +306,7 @@ export function dispatchUpdateDrawLayer(drawLayer) {
  */
 export function dispatchForceDrawLayerUpdate(id,plotId) {
 
-    const plotIdAry= getPlotViewIdList(visRoot(), plotId);
+    const plotIdAry= getPlotViewIdListInOverlayGroup(visRoot(), plotId);
 
     getDrawLayerIdAry(dlRoot(),id)
         .forEach( (drawLayerId) => {

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -136,41 +136,31 @@ export function hasWCSProjection(ref) {
  * Return an array of plotId's that are in the plot group associated with the the pvOrId parameter.
  * @param {VisRoot} visRoot - root of the visualization object in store
  * @param pvOrId this parameter will take the plotId string or a plotView object
- * @param onlyIfPositionLocked
- * @param hasPlots
  * @returns {Array.<String>}
  */
-export function getPlotViewIdList(visRoot, pvOrId, onlyIfPositionLocked=true, hasPlots=false) {
+export function getPlotViewIdListByPositionLock(visRoot, pvOrId) {
     if (!pvOrId) return [];
-    const pv= (typeof pvOrId ==='string') ? getPlotViewById(visRoot,pvOrId) : pvOrId;
-    const locked= visRoot.positionLock;
-    if (!locked && onlyIfPositionLocked) return [pv.plotId];
-    const idList=  visRoot.plotViewAry.map( (pv) => pv.plotId);
-    if (!hasPlots) return idList;
-
-    return idList.filter( (id) => get(getPlotViewById(visRoot,id),'plots.length') );
+    const pv= isString(pvOrId) ? getPlotViewById(visRoot,pvOrId) : pvOrId;
+    if (!visRoot.positionLock) return [pv.plotId];
+    return visRoot.plotViewAry
+        .map( (pv) => pv.plotId)
+        .filter( (id) => get(getPlotViewById(visRoot,id),'plots.length') );
 }
-
 /**
  * Return an array of plotId's that are in the plot group associated with the the pvOrId parameter.
  * @param {VisRoot} visRoot - root of the visualization object in store
- * @param pvOrId this parameter will take the plotId string or a plotView object
- * @param onlyIfGroupLocked
- * @param hasPlots
+ * @param pvOrId this parameter will take the plotId string or a plotView objectgs
  * @returns {Array.<String>}
  */
-export function getPlotViewIdListInOverlayGroup(visRoot,pvOrId,onlyIfGroupLocked=true, hasPlots=false) {
+export function getPlotViewIdListInOverlayGroup(visRoot,pvOrId) {
     if (!pvOrId) return [];
     const pv= (typeof pvOrId ==='string') ? getPlotViewById(visRoot,pvOrId) : pvOrId;
     const gid= pv.plotGroupId;
     const group= getPlotGroupById(visRoot,gid);
-    const locked= hasOverlayColorLock(pv,group);
-    if (!locked && onlyIfGroupLocked) return [pv.plotId];
-    const idList=  visRoot.plotViewAry.filter( (pv) => pv.plotGroupId===gid).map( (pv) => pv.plotId);
-    if (!hasPlots) return idList;
-
-    return idList.filter( (id) => get(getPlotViewById(visRoot,id),'plots.length') );
+    if (!hasOverlayColorLock(pv,group) ) return [pv.plotId];
+    return  visRoot.plotViewAry.filter( (pv) => pv.plotGroupId===gid).map( (pv) => pv.plotId);
 }
+
 
 /**
  * return an array of plotIds that are all under visRoot and based on the overlay/color lock of the group associated
@@ -192,10 +182,11 @@ export function getAllPlotViewIdByOverlayLock(visRoot, pvOrId, hasPlots=false, p
         return [majorPv.plotId];
     } else {
         return visRoot.plotViewAry.filter((pv) => !hasPlots || get(pv, 'plots.length'))
-                                  .filter((pv) => !plotTypeMustMatch || isImage(primePlot(pv))===isImage(primePlot(majorPv)))
-                                  .map((pv) => pv.plotId);
+            .filter((pv) => !plotTypeMustMatch || isImage(primePlot(pv))===isImage(primePlot(majorPv)))
+            .map((pv) => pv.plotId);
     }
 }
+
 
 /**
  * Is this plotview the active one

--- a/src/firefly/js/visualize/RelatedDataUtil.js
+++ b/src/firefly/js/visualize/RelatedDataUtil.js
@@ -3,7 +3,7 @@
  */
 
 import {isEmpty, difference,get, flatten, values, uniq} from 'lodash';
-import {primePlot, getPlotViewIdList, getPlotViewById, operateOnOthersInOverlayColorGroup} from './PlotViewUtil.js';
+import {primePlot, getPlotViewIdListInOverlayGroup, getPlotViewById, operateOnOthersInOverlayColorGroup} from './PlotViewUtil.js';
 import {WPConst} from './WebPlotRequest.js';
 import {RDConst} from './WebPlot.js';
 import {visRoot, dispatchPlotMask, dispatchOverlayPlotChangeAttributes, dispatchPlotMaskLazyLoad} from './ImagePlotCntlr.js';
@@ -87,7 +87,7 @@ function unactivatedDataTypeMatches(r,idx, pv) {
  * @param {Function} func  an OverlayPlotView is passed as parameter
  */
 export function operateOnOverlayPlotViewsThatMatch(vr, opv, func) {
-    const opvList= flatten(getPlotViewIdList(vr, opv.plotId)
+    const opvList= flatten(getPlotViewIdListInOverlayGroup(vr, opv.plotId)
         .map( (id) => getPlotViewById(vr,id).overlayPlotViews))
         .filter( (aOpv) => get(aOpv,'title')===opv.title);
 

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -7,7 +7,7 @@ import Cntlr, {WcsMatchType} from '../ImagePlotCntlr.js';
 import {replacePlots, makePlotView, updatePlotViewScrollXY,
         findScrollPtToCenterImagePt, updateScrollToWcsMatch} from './PlotView.js';
 import {makeOverlayPlotView, replaceOverlayPlots} from './OverlayPlotView.js';
-import {primePlot, getPlotViewById, clonePvAry, getOverlayById, getPlotViewIdList} from '../PlotViewUtil.js';
+import {primePlot, getPlotViewById, clonePvAry, getOverlayById,getPlotViewIdListByPositionLock} from '../PlotViewUtil.js';
 import PlotGroup from '../PlotGroup.js';
 import {PlotAttribute} from '../PlotAttribute.js';
 import {CCUtil} from '../CsysConverter.js';
@@ -205,7 +205,7 @@ function updateForWcsMatching(visRoot, pv, mpwWcsPrimId) {
         pv= updateScrollToWcsMatch(visRoot.wcsMatchType, masterPv, pv);
     }
     else if (wcsMatchType===WcsMatchType.Target) {
-        if (getPlotViewIdList(visRoot,pv.plotId,true,true).length<2) {
+        if (getPlotViewIdListByPositionLock(visRoot,pv.plotId) ) {
             const ft=  plot.attributes[PlotAttribute.FIXED_TARGET];
             if (ft) {
                 const centerImagePt = CCUtil.getImageCoords(plot, ft);

--- a/src/firefly/js/visualize/region/RegionTask.js
+++ b/src/firefly/js/visualize/region/RegionTask.js
@@ -6,7 +6,7 @@ import {getDS9Region} from '../../rpc/PlotServicesJson.js';
 import {getDlAry} from '../DrawLayerCntlr.js';
 import DrawLayerCntrl, {dispatchCreateDrawLayer, dispatchDetachLayerFromPlot,
         dispatchAttachLayerToPlot} from '../DrawLayerCntlr.js';
-import {getDrawLayerById, getPlotViewIdList} from '../PlotViewUtil.js';
+import {getDrawLayerById, getPlotViewIdListInOverlayGroup} from '../PlotViewUtil.js';
 import RegionPlot, {createNewRegionLayerId, getRegionLayerTitle} from '../../drawingLayers/RegionPlot.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {logError} from '../../util/WebUtil.js';
@@ -24,8 +24,7 @@ export const getPlotId = (plotId) => {
     //return (!plotId || (isArray(plotId)&&plotId.length === 0)) ? get(visRoot(), 'activePlotId') : plotId;
     if (!plotId || (isArray(plotId)&&plotId.length === 0)) {
         const pid = get(visRoot(), 'activePlotId');
-
-        return getPlotViewIdList(visRoot(), pid, false);
+        return getPlotViewIdListInOverlayGroup(visRoot(), pid);
     } else {
         return plotId;
     }

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -17,7 +17,7 @@ import {PlotPref} from '../PlotPref.js';
 import {clone} from '../../util/WebUtil.js';
 import {makePostPlotTitle} from '../reducer/PlotTitle.js';
 import {dispatchAddViewerItems, getMultiViewRoot, findViewerWithItemId, EXPANDED_MODE_RESERVED, IMAGE, DEFAULT_FITS_VIEWER_ID} from '../MultiViewCntlr.js';
-import {getPlotViewById, getDrawLayerByType, getDrawLayersByType, getDrawLayerById, getPlotViewIdList} from '../PlotViewUtil.js';
+import {getPlotViewById, getDrawLayerByType, getDrawLayersByType, getDrawLayerById, getPlotViewIdListInOverlayGroup} from '../PlotViewUtil.js';
 import {enableMatchingRelatedData, enableRelatedDataLayer} from '../RelatedDataUtil.js';
 import {modifyRequestForWcsMatch} from './WcsMatchTask.js';
 import WebGrid from '../../drawingLayers/WebGrid.js';
@@ -598,7 +598,7 @@ function matchAndActivateOverlayPlotViewsByGroup(plotIdAry) {
         .map( (plotId) => getPlotViewById(visRoot(), plotId))
         .filter( (pv) => pv)
         .forEach( (pv) => {
-            const opvMatchArray= uniqBy(flatten(getPlotViewIdList(vr, pv.plotId)
+            const opvMatchArray= uniqBy(flatten(getPlotViewIdListInOverlayGroup(vr, pv.plotId)
                                                        .filter( (id) => id!== pv.plotId)
                                                        .map( (id) => getPlotViewById(vr,id))
                                                        .map( (gpv) => gpv.overlayPlotViews)),

--- a/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
@@ -10,7 +10,7 @@ import {
     } from '../../ui/ToolbarButton.jsx';
 import {SingleColumnMenu} from '../../ui/DropDownMenu.jsx';
 import {dispatchColorChange} from '../ImagePlotCntlr.js';
-import {primePlot, getPlotViewIdList, isThreeColor} from '../PlotViewUtil.js';
+import {primePlot, getPlotViewIdListInOverlayGroup, isThreeColor} from '../PlotViewUtil.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 
@@ -151,7 +151,7 @@ const isAllThreeColor= (vr,plotIdAry) => plotIdAry.every( (id) => isThreeColor(p
 
 function handleColorChange(pv,cbarId) {
     var vr= visRoot();
-    var plotIdAry= getPlotViewIdList(vr,pv);
+    var plotIdAry= getPlotViewIdListInOverlayGroup(vr,pv);
 
     if (isAllThreeColor(vr,plotIdAry)) {
         showInfoPopup('This is a three color plot, you can not change the color.', 'Color change not allowed');

--- a/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
@@ -92,11 +92,17 @@ function makePermInfo(pv,layers) {
 }
 
 function showAllLayers(layers, pv, visible) {
+
     pv.overlayPlotViews.forEach( (opv) => {
         setMaskVisibleInGroup(opv,visible);
     });
 
-    return layers.forEach( (dl) => {
+
+    let overlayLayers = layers.filter( (l)=>
+       l.drawLayerTypeId!==ImageRoot.TYPE_ID
+    );
+
+    return overlayLayers.forEach( (dl) => {
         changeVisible(dl, visible,pv.plotId );
     });
 }
@@ -305,6 +311,7 @@ function changeVisible(dl, visible, plotId) {
         }
 
     }
+
 }
 
 


### PR DESCRIPTION
The brief description about the issues the PR is dealing with:
In the irsaviewer toolbar, there are a few tool buttons whose actions are adding the overlays to the images.  There is a "Color and Overlay" lock button.  When this button is locked, all such overlay tools can add the layers to all the images.  In the layer dialog, when unselected or "Hide All"  such layers, the layers are reappearing unless the "Align and Lock" button is locked.  The other issue is that when the "Hide All" is clicked in the layer dialog, the selected image was hidden as well.   

This PR fixed two issues that affect all the overlay buttons such as Direction, Selection, Marker, Region and North-up as well as the layer Dialog. 

Please test it by comparing with how the irsaviewer in irsadev works.  So you can see the difference.  

To test:
1. Use the example Luisa provided in the ticket 
2. Lock the first lock button 
3. Add any overlays
4. Open layer dialog, and deselect the overlays, you will see the overlays among all images are gone if the first button is locked. 
5. In the layer dialog, select "Hide All" and "Show All", they also responds to the first lock button. The selected image is no longer hidden when the "Hide All" is pressed.  

Please refer the ticket https://jira.ipac.caltech.edu/browse/IRSA-2651  for details. 
   
 URL: https://irsakudevlb1.ipac.caltech.edu/irsa-2651-overlays/irsaviewer/
URL: https://irsakudevlb1.ipac.caltech.edu/irsa-2651-overlays/applications/finderchart/
