### PR TITLE
Firefly-544: Fixed: now we can add a table to a report

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -116,6 +116,7 @@ public class FileAnalysis {
                 putPartVal(h, p.getUiRender().name(), i, "uiRender");
                 putPartVal(h, p.getDesc(), i, "desc");
                 putPartVal(h, p.getConvertedFileName(),i,"convertedFileName");
+                putPartVal(h, p.getConvertedFileFormat(),i,"convertedFileFormat");
                 putPartVal(h, p.getTableColumnNames(),i,"tableColumnNames");
                 putPartVal(h, p.getTableColumnUnits(),i,"tableColumnUnits");
                 putPartVal(h, p.getChartTableDefOption().name(),i,"chartTableDefOption");

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
@@ -162,6 +162,7 @@ public class FileAnalysisReport {
         private String desc;
         private int fileLocationIndex = -1;   // todo: populate: fits (hdu idx) or VO (table idx)
         private String convertedFileName= null; // only set if this entry is has a alternate file than the one analyzed
+        private String convertedFileFormat = null;
         private List<ChartParams> chartParams= null;
         private List<String> tableColumnNames= null; //only use for a fits image that is read as a table
         private List<String> tableColumnUnits= null; //only use for a fits image that is read as a table
@@ -203,6 +204,9 @@ public class FileAnalysisReport {
 
         public String getConvertedFileName() { return convertedFileName; }
         public void setConvertedFileName(String convertedFileName) { this.convertedFileName = convertedFileName; }
+
+        public String getConvertedFileFormat() { return convertedFileFormat; }
+        public void setConvertedFileFormat(String convertedFileFormat) { this.convertedFileFormat = convertedFileFormat; }
 
         public List<ChartParams> getChartParams() { return chartParams; }
         public void setChartParams(ChartParams chartParams) {

--- a/src/firefly/js/data/FileAnalysis.js
+++ b/src/firefly/js/data/FileAnalysis.js
@@ -118,6 +118,7 @@ export const makeFileAnalysisPart= (index,fileLocationIndex=0) => (
  *  @prop {string} desc
  *  @prop {number} fileLocationIndex - either the FITS HDU number or some other location scheme
  *  @prop {string} [convertedFileName] - only set if this entry is has a alternate file than the one analyzed
+ *  @prop {string} [convertedFileFormat] - format string
  *  @prop {FileAnalysisChartParams} [chartParams]
  *  @prop {Array.<string>} [tableColumnNames] only use for a fits image that is read as a table
  *  @prop {Array.<string>} [tableColumnUnits] only use for a fits image that is read as a table

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -177,14 +177,15 @@ function getTableDropTitleStr(title,part,fileFormat,tableOnly) {
  */
 function analyzeChartTableResult(tableOnly, part, fileFormat, fileOnServer, title, activateParams, tbl_index=0) {
     const {uiEntry,uiRender,chartParamsAry, defaultPart:requestDefault= false}= part;
+    const partFormat= part.convertedFileFormat||fileFormat;
     if (uiEntry===UIEntry.UseSpecified) {
         if (tableOnly && uiRender!==UIRender.Table) return undefined;
         else if (uiRender!==UIRender.Chart) return undefined;
     }
 
 
-    const ddTitleStr= getTableDropTitleStr(title,part,fileFormat,tableOnly);
-    const {xCol,yCol,cNames,cUnits}= getTableChartColInfo(part,fileFormat);
+    const ddTitleStr= getTableDropTitleStr(title,part,partFormat,tableOnly);
+    const {xCol,yCol,cNames,cUnits}= getTableChartColInfo(part,partFormat);
 
 
     if (tableOnly) {
@@ -196,14 +197,14 @@ function analyzeChartTableResult(tableOnly, part, fileFormat, fileOnServer, titl
     else {
         if ( (!xCol || !yCol) && !chartParamsAry) return;
         let {chartTableDefOption}= part;
-        if (getRowCnt(part,fileFormat)===1) {
+        if (getRowCnt(part,partFormat)===1) {
             if (chartTableDefOption===AUTO) chartTableDefOption= SHOW_TABLE;
             return dpdtChartTable(ddTitleStr,
                 createChartSingleRowArrayActivate(fileOnServer,'Row 1 Chart',activateParams,xCol,yCol,0,tbl_index),
                 undefined, {paIdx:tbl_index, chartTableDefOption, requestDefault});
         }
         else {
-            const imageAsTableColCnt= isImageAsTable(part,fileFormat) ? getImageAsTableColCount(part,fileFormat) : 0;
+            const imageAsTableColCnt= isImageAsTable(part,partFormat) ? getImageAsTableColCount(part,partFormat) : 0;
             const chartInfo= {xAxis:xCol, yAxis:yCol, chartParamsAry};
             if (chartTableDefOption===AUTO) chartTableDefOption= imageAsTableColCnt===2 ? SHOW_CHART : SHOW_TABLE;
             return dpdtChartTable(ddTitleStr,


### PR DESCRIPTION
Firefly-544: Fixed: now we can add a table to a report

  - fixed the bug
  - created an example

_to test_

https://fireflydev.ipac.caltech.edu/firefly-544-fa-add-table/firefly/

- upload: http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/data-products-test/dp-test.tbl
- click on the 3rd row, one with code EM
- Example for how to add a table: https://github.com/Caltech-IPAC/firefly/blob/368aa15799f5e77016adbdb15d292026b432543e/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/Demo1Analyzer.java#L275