### PR TITLE
Firefly-552: Fixed: Jupyter lab start is broken.

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -230,7 +230,15 @@ export function startAsAppFromApi(divId, props={template: 'FireflySlate'}) {
         !viewer && logger.error(`required: props.template, must be one of ${Object.keys(Templates).join()}`);
         return;
     }
+
+    props.disableDefaultDropDown && dispatchUpdateLayoutInfo({disableDefaultDropDown:true});
+    props.readoutDefaultPref && dispatchChangeReadoutPrefs(props.readoutDefaultPref);
+    props.wcsMatchType && dispatchWcsMatch({matchType:props.wcsMatchType, lockMatch:true});
+
+
+
     props = {...mergeObjectOnly({...defAppProps}, props), div:divId};
+    
     const controlObj= {
         unrender: () => ReactDOM.unmountComponentAtNode(document.getElementById(divId)),
         render: () => renderRoot(viewer, props)

--- a/src/firefly/js/api/ApiUtil.js
+++ b/src/firefly/js/api/ApiUtil.js
@@ -8,6 +8,7 @@ import ReactDOM from 'react-dom';
 import {isArray, isElement, isString} from 'lodash';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../core/MasterSaga.js';
 import {Logger} from '../util/Logger.js';
+import {uniqueID} from '../util/WebUtil';
 
 const logger = Logger('Firefly');
 // NOTE 

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -55,7 +55,8 @@ export class FireflySlate extends PureComponent {
         super(props);
         this.state = this.getNextState();
         startTTFeatureWatchers();
-        this.stopLayoutManager= startLayoutManager(this.props.renderTreeId, {renderTreeId:this.props.renderTreeId});
+        this.stopLayoutManager= startLayoutManager(this.props.renderTreeId,
+            {renderTreeId:this.props.renderTreeId, groupIgnoreFilter:'DPC'});
 
     }
 

--- a/src/firefly/js/templates/fireflyslate/GridLayoutPanel.jsx
+++ b/src/firefly/js/templates/fireflyslate/GridLayoutPanel.jsx
@@ -187,9 +187,7 @@ function makeComponent(g) {
             return (
                 <div key={g.cellId} style={{flex: 'auto', display: 'flex'}} >
 
-                    <MultiProductViewer key={g.cellId}  viewerId={'DataProductsType'}
-                                        metaDataTableId={getActiveTableId()}
-                                        imageMetaViewerId={g.cellId}/>
+                    <MultiProductViewer key={g.cellId}  viewerId={g.cellId} metaDataTableId={getActiveTableId()} />
                 </div>
             );
             break;

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -86,6 +86,7 @@ function initState() {
      * @prop {string} containerType - one of 'image', 'plot2d', 'wrapper'
      * @prop {boolean} mounted - if the react component using the store is mounted
      * @prop {Object|String} layoutDetail - may be any object, string, etc- Hint for the UI, can be any string but with 2 reserved  GRID_RELATED, GRID_FULL
+     * @prop {boolean} internallyManaged - this viewer is managed by other viewers
      * @prop {object} customData: {}
      *
      * @global
@@ -169,14 +170,15 @@ function initState() {
  * @param {boolean} mounted
  * @param {string} [renderTreeId] - used only with multiple rendered tree, like slate in jupyter lab
  * @param {string} [layout] - layout type - SINGLE or GRID, defaults to GRID
- * @param {boolean} reservedContainer
+ * @param {boolean} [reservedContainer]
+ * @param {boolean} [internallyManaged]
  */
 export function dispatchAddViewer(viewerId, canReceiveNewPlots, containerType, mounted=false, renderTreeId,
-                                  layout=GRID, reservedContainer=false) {
+                                  layout=GRID, reservedContainer=false, internallyManaged=false) {
     flux.process({
         type: ADD_VIEWER,
         payload: {viewerId, canReceiveNewPlots, containerType, mounted,
-            renderTreeId, lastActiveItemId:'', layout, reservedContainer}
+            renderTreeId, lastActiveItemId:'', layout, reservedContainer, internallyManaged}
     });
 }
 
@@ -532,7 +534,7 @@ function imageViewerCanAdd(state, viewerId, plotId) {
 function addViewer(state,payload) {
 
     const {viewerId,containerType, layout=GRID,canReceiveNewPlots=NewPlotMode.replace_only.key,
-             mounted=false, renderTreeId, reservedContainer}= payload;
+             mounted=false, renderTreeId, reservedContainer, internallyManaged}= payload;
     var   {lastActiveItemId} = payload;
     var entryInState = hasViewerId(state,viewerId);
 
@@ -548,7 +550,7 @@ function addViewer(state,payload) {
         // set default layout for the viewer with viewerId, META_VIEWER_ID, is full-grid type
         const layoutDetail = viewerId === META_VIEWER_ID ? GRID_FULL : undefined;
         const entry = {viewerId, containerType, canReceiveNewPlots, layout, mounted, itemIdAry: [], customData: {},
-                       lastActiveItemId, layoutDetail, renderTreeId, reservedContainer};
+                       lastActiveItemId, layoutDetail, renderTreeId, reservedContainer, internallyManaged};
         return [...state, entry];
     }
 }

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -131,8 +131,8 @@ export const MultiProductViewer= memo(({ viewerId='DataProductsType', metaDataTa
 
     useEffect(() => {
         dispatchAddViewer(viewerId, NewPlotMode.none, WRAPPER,true, renderTreeId, SINGLE);
-        dispatchAddViewer(imageViewerId, NewPlotMode.none, IMAGE,true, renderTreeId, SINGLE, true);
-        dispatchAddViewer(chartViewerId, NewPlotMode.none, PLOT2D,true, renderTreeId, GRID);
+        dispatchAddViewer(imageViewerId, NewPlotMode.none, IMAGE,true, renderTreeId, SINGLE, true,true);
+        dispatchAddViewer(chartViewerId, NewPlotMode.none, PLOT2D,true, renderTreeId, GRID, false, true);
         const removeFluxListener= flux.addListener(()=> {
             const newViewer= getViewer(getMultiViewRoot(),viewerId);
             if (newViewer!==viewer) setViewer(newViewer);


### PR DESCRIPTION
Firefly-552: Fixed: Jupyter lab start is broken.
 
- fixed: Lab cannot start firefly using `startAsAppFromApi`
- fixed: data products cell hangs in slate

https://jira.ipac.caltech.edu/browse/FIREFLY-552

_to test:_ bring up lab and start firefly using `FireflyClient.make_lab_client()`

https://fireflydev.ipac.caltech.edu/firefly-552-jl-open/firefly/


to set the firefly URL in `~/.jupyter/jupyter_notebook_config.json`
add entry:
```json
  "Firefly": {
      "url":  "https://fireflydev.ipac.caltech.edu/firefly-552-jl-open/firefly/"
  }
```
