### PR TITLE
irsa-3526-sending to finderchart from gator is broken

### DIFF
--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -213,30 +213,6 @@ export function encodeParams(params) {
         .join('&');     // combine the parts, separating them by '&'
 }
 
-/**
- * convert a queryStr into an Object.  This is an inverse of encodeParams.
- * It support Object whose value is another Object.
- * @param queryStr
- * @returns {*}
- */
-export function decodeParams(queryStr) {
-    const toVal = (s) => {
-        let val = s;
-        try {
-            val = JSON.parse(val);
-        } catch(e) {
-            val = isBooleanString(val) ? toBoolean(val) : val;
-        }
-        return val;
-    };
-
-    return  queryStr.replace(/^\?/, '')                     // remove prefex '?' if exists
-                    .split('&')                             // separate into param array
-                    .map((p) => p.split('=', 2))             // split into key/value pairs
-                    .map(([key, val='']) => [key.trim(), val.trim()] )   // trim key and values
-                    .map(([key, val]) => [key, toVal(decodeURIComponent(val))]) // decode and convert val
-                    .reduce((rval, [key, val]) => set(rval, [key], val), {}); // create a simple object of key/value.
-}
 
 
 /**
@@ -467,7 +443,13 @@ export function parseUrl(url) {
 
     // Convert query string to object map with decoded key/value pairs
     const searchObject = {};
-    searchParams.forEach((val, key) => searchObject[key] = val);
+    const parseVal = (val) => {
+        try {
+            val = JSON.parse(val);
+        } catch(e) {}
+         return isBooleanString(val) ? toBoolean(val) : val;
+    };
+    searchParams.forEach((val, key) => searchObject[key] =parseVal(val));
 
     const paths = pathname.replace(/^\//, '').split('/');
     const filename = last(paths).split(';')[0];


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-3526
  
Fixed the bug about parse an object (key, val) issue in WebUtil.js.  

To test:

 Follow the steps in the bug report using https://irsakudevlb1.ipac.caltech.edu/front, and then after "send to finderchart", adding the "irsa-3526-finderchart" to the path before the "application/finderchart"
or
Just run 
servlet/api? https://irsakudevlb1.ipac.caltech.edu/irsa-3526-finderchart/applications/finderchart/servlet/api?mode=getResult&UserTargetWorldPt=148.88821;+69.06529;EQ_J2000&subsize=0.083&grid=true


URL
 https://irsakudevlb1.ipac.caltech.edu/irsa-3526-finderchart/applications/finderchart/

