### PR TITLE
FIREFLY-465: adding sofia analyzer and include spectra 1d extraction from FITS image data

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/DataExtractUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/DataExtractUtil.java
@@ -1,0 +1,47 @@
+package edu.caltech.ipac.firefly.data.sofia;
+
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.ServerCommandAccess;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.SrvParam;
+import edu.caltech.ipac.firefly.server.cache.UserCache;
+import edu.caltech.ipac.firefly.server.query.EmbeddedDbProcessor;
+import edu.caltech.ipac.firefly.server.util.multipart.UploadFileInfo;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.util.cache.Cache;
+import edu.caltech.ipac.util.cache.StringKey;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+
+/**
+ * Should implement child that returns datagroups,
+ * source file from request or overwritten in child or unit/integration tests
+ * Could be called as link service or return a datalink table
+ */
+public abstract class DataExtractUtil {
+
+
+    /**
+     * @param f File to extract data from
+     * @return File the data extracted/transformed
+     * @throws Exception
+     */
+    public abstract DataGroup extract(File inf) throws Exception;
+
+    /**
+     * @param req
+     * @return
+     */
+    public File getSourceFile(ServerRequest req) {
+        String fileKey = req.getParam("file");
+        Cache sessionCache = UserCache.getInstance();
+        File sourceFile = ServerContext.convertToFile(fileKey);
+        if (sourceFile == null || !sourceFile.canRead()) {
+            UploadFileInfo tmp = (UploadFileInfo) (sessionCache.get(new StringKey(fileKey)));
+            sourceFile = tmp.getFile();
+        }
+        return sourceFile;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/Sofia1DSpectraExtractor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/Sofia1DSpectraExtractor.java
@@ -1,0 +1,237 @@
+package edu.caltech.ipac.firefly.data.sofia;
+
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataObject;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.io.VoTableWriter;
+import edu.caltech.ipac.util.FitsHDUUtil;
+import edu.caltech.ipac.util.download.URLDownload;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsReadFactory;
+import nom.tam.fits.BasicHDU;
+import nom.tam.fits.Fits;
+import nom.tam.fits.FitsException;
+import nom.tam.fits.Header;
+import nom.tam.util.ArrayFuncs;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.ArrayList;
+
+import static edu.caltech.ipac.table.TableUtil.Format.VO_TABLE_TABLEDATA;
+
+/**
+ * Util class to extract 1d spectra from SOFIA FITS file -
+ * particular SOFIA instruments and data product levels encoded spectra in an image,
+ * each row of the image represents a data vector flux, wavelength, etc.
+ * Intruments ("processing, product type")
+ * FORCAST (L2 rspscpec, mrgspec, combspec),
+ * EXES (L3 mrgordspec, combspec, spec),
+ * FLITECAM (L3 combspec, calspec)
+ *
+ * See processing:
+ * https://irsa.ipac.caltech.edu/TAP/sync?QUERY=SELECT+distinct+o.instrument_name,jsonb_extract_path_text(p.provenance_keywords,%27PROCSTAT%27,%270%27)+as+processing+FROM+sofia.observation+o,sofia.plane+p+where+o.obsid=p.obsid&format=IPAC_TABLE
+ * See product type:
+ * https://irsa.ipac.caltech.edu/TAP/sync?QUERY=SELECT+distinct+o.instrument_name,jsonb_extract_path_text(p.provenance_keywords,%27PRODTYPE%27,%270%27)+as+product_type+FROM+sofia.observation+o,sofia.plane+p+where+o.obsid=p.obsid&format=IPAC_TABLE
+ */
+public class Sofia1DSpectraExtractor extends DataExtractUtil {
+
+    private static final Logger.LoggerImpl _log = Logger.getLogger();
+    private final SofiaSpectraModel model;
+    private final SofiaSpectraModel.SpectraInstrument instrument;
+//    public static DataGroup extract1DSpectra(File sourceFile, VOSpectraModel model) throws FitsException, IOException {
+////        List<DataType> meta = model.getMeta();//FIELDs
+//        String[] meta = null;
+//        return FITSTableReader.convertFitsToDataGroup(sourceFile.getAbsolutePath(),new String[]{"Flux", "Wavelength"}, meta, FITSTableReader.DEFAULT,0);
+//    }
+
+    public Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument inst){
+        this.model = new SofiaSpectraModel(inst);
+        this.instrument = inst;
+    }
+    /**
+     * Extract table flux,wavelength and other dataset into class Spectra1D
+     * #   Confirm that the data HDU shape is as expected.  This kind of file has four stripes of data:
+     * #     0: wavenumber
+     * #     1: flux per wavenumber bin
+     * #     2: flux error
+     * #     3: reference spectrum
+     * 4...
+     * most likely file is a cache of the reference/source data (FITS)
+     */
+    private DataGroup extract1DSpectra(File file) throws FitsException {
+        Fits fit = new Fits(file);
+        FitsRead[] fitsReadArray = FitsReadFactory.createFitsReadArray(fit);
+        int hdu = fitsReadArray.length;
+        if (hdu > 1)
+            throw new FitsException("Can't extract SOFIA spectra: number of HDU is " + hdu);
+        BasicHDU p = fitsReadArray[0].getHDU();
+
+        int axis[] = new int[]{0, 0};
+        String xunit = null, yunit = null;
+        Header hdr = p.getHeader();
+
+        String xu = hdr.getStringValue("XUNITS");
+        String yu = hdr.getStringValue("YUNITS");
+
+        xunit = xu != null ? xu : "";
+        yunit = yu != null ? yu : "";
+
+        // Populate units, ucds, utype?
+        model.setUnits(VOSpectraModel.SPECTRA_FIELDS.FLUX, yu);
+        model.setUnits(VOSpectraModel.SPECTRA_FIELDS.WAVELENGTH, xu);
+        model.setUnits(VOSpectraModel.SPECTRA_FIELDS.ERROR_FLUX, yu);
+        if(model.getMeta().get(VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION.getKey())!=null) {
+            model.setUnits(VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION, "");//TODO where is the unit, no idea.Ask scientist/PI
+        }
+        if(model.getMeta().get(VOSpectraModel.SPECTRA_FIELDS.INST_RESP_CURVE.getKey())!=null) {
+            model.setUnits(VOSpectraModel.SPECTRA_FIELDS.INST_RESP_CURVE, "Me/s/Jy");//TODO where is the unit, no idea.Ask scientist/PI
+        }
+        axis[0] = hdr.getIntValue("NAXIS1");
+        axis[1] = hdr.getIntValue("NAXIS2");
+
+        //From the defined model above, iterate and populate a Datagroup witht the datatype derived from the model
+        ArrayList<DataType> dt = new ArrayList<DataType>(model.getMeta().values());
+        DataGroup dataGroup = new DataGroup(hdr.getStringValue("FILENAME"), dt);
+        DataType[] dd;
+
+        double[][] fdata = (double[][]) ArrayFuncs.convertArray(p.getKernel(), Double.TYPE, true);
+        for (int row = 0; row < fdata[0].length; row++) {
+            DataObject aRow = new DataObject(dataGroup);
+            dd = dt.toArray(new DataType[dt.size()]);
+            for (int dtIdx = 0; dtIdx < fdata.length; dtIdx++) {
+                aRow.setDataElement(dd[dtIdx], fdata[dtIdx][row]);
+            }
+            dataGroup.add(aRow);
+        }
+
+        dataGroup.trimToSize();
+        return dataGroup;
+
+        //return new SofiaSpectra(new SofiaSpectra.Axis(fdata[0], xunit), new SofiaSpectra.Axis(fdata[1], yunit));
+    }
+
+    public boolean isSpectra(String key, String value) {
+        return key.equals("NAXIS") && Integer.parseInt(value) == 2;
+    }
+
+    static boolean is64bits(Header hdr, String value) {
+        int val = hdr.getIntValue(value);
+        if (val == -64) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public static FileInfo exportDg(DataGroup dg, File file) throws IOException {
+
+        OutputStream out = new FileOutputStream(file, false);
+        dataGroup2VOTable(dg, out);
+        return new FileInfo(file);
+    }
+    public static void dataGroup2VOTable(DataGroup dg, OutputStream out) throws IOException {
+        VoTableWriter.save(out, dg, VO_TABLE_TABLEDATA);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String url = "https://irsa.ipac.caltech.edu/data/SOFIA/FORCAST/OC4G/20160713_F320/proc/p3374/data/g2/F0320_FO_GRI_9000493_FORG227_MRG_0454.fits"; //mrgspec forcast
+                //"https://irsa.ipac.caltech.edu/data/SOFIA/EXES/OC3A/20150305_F198/proc/p956/data/g13/F0198_EX_SPE_0200793_EXEELONEXEECHL_MRD_5131-5134.fits";
+        //"https://irsa.ipac.caltech.edu/data/SOFIA/FLITECAM/OC2A/20140225_F148/proc/p322/data/02_0066_Rivkin_Level3/Pallas_FLT_C2_LM_apcombined.fits";
+        //"https://irsa.ipac.caltech.edu/data/SOFIA/FORCAST/OC4G/20160718_F323/proc/p3342/data/g1/F0323_FO_GRI_9000492_FORG227_CMB_0312-0326.fits\n";
+        //https://irsa.ipac.caltech.edu/data/SOFIA/FORCAST/OC5K/20170926_F433/proc/p4792/data/g2/F0433_FO_GRI_9000644_FORG063_RSP_0105.fits";
+
+        Sofia1DSpectraExtractor ss = new Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument.FORCAST);
+
+        File tempFile = File.createTempFile("Sofia1DSpectraExtractor-", ".fits");
+        FileInfo file = URLDownload.getDataToFile(new URL(url), tempFile);
+        tempFile.deleteOnExit();
+        FitsHDUUtil.FitsAnalysisReport retRep = FitsHDUUtil.analyze(tempFile, FileAnalysisReport.ReportType.Details);
+        DataGroup dg = retRep.getReport().getPart(0).getDetails();
+        String spectraName = "Extracted Spectra";
+        for (int i = 0; i <dg.size();i++) {
+            String key = (String) dg.getData("key", i);
+            if(key.equals("FILENAME")){
+                String tmpName = (String) dg.getData("value", i);
+                spectraName = tmpName.substring(0,tmpName.lastIndexOf("."));
+                break;
+            }
+        }
+//        FileAnalysis.Report analyze = FitsHDUUtil.analyze(file.getFile(), FileAnalysis.ReportType.Details);
+//        BasicHDU[] parts = new Fits(file.getFile()).read();
+
+        DataGroup headerDg = FitsHDUUtil.fitsHeaderToDataGroup(tempFile.getAbsolutePath());
+
+//        SofiaSpectra s = extract1DSpectra(file.getFile());
+        DataGroup dataObjects = ss.extract(file.getFile());
+
+//        Iterator<DataObject> iterator = dataObjects.iterator();
+//        while(iterator.hasNext()){
+//            DataObject next = iterator.next();
+//            Object[] data = next.getData();
+//            for (int i = 0; i < data.length ; i++) {
+//                System.out.println(data[i].toString());
+//            }
+//        }
+        File tempSpectraFile = File.createTempFile("Sofia1DSpectraExtractor-", ".xml");
+        VoTableWriter.save(tempSpectraFile, dataObjects, VO_TABLE_TABLEDATA);
+        System.out.println("Wrote VOTable xml here:" + tempSpectraFile.getAbsolutePath());
+
+
+//        int axis[] = new int[]{0, 0};
+//        String xunit, yunit;
+//        double[] flux, wave;
+//        for (BasicHDU p : parts) {
+//            System.out.println(p.getHeader());
+//            xunit = p.getHeader().getStringValue("XUNIT");
+//            axis[0] = p.getHeader().getIntValue("NAXIS1");
+//            axis[1] = p.getHeader().getIntValue("NAXIS2");
+//            xunit = p.getHeader().getStringValue("XUNIT");
+//            yunit = p.getHeader().getStringValue("YUNIT");
+//            double[][] fdata = (double[][]) p.getKernel();
+//            flux = fdata[0];
+//            wave = fdata[1];
+//            s = SofiaSpectra.makeSpectra(fdata, new String[]{xunit, yunit});
+//        }
+
+
+//        BasicHDU[] parts = new Fits(file.getFile()).read();
+//
+//        FitsHDUUtil.fitsHeaderToDataGroup(file.getFile());
+
+    }
+
+    @Override
+    public DataGroup extract(File inf) throws Exception {
+        return extract1DSpectra(inf);
+    }
+}
+
+/*
+ * THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE CALIFORNIA
+ * INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S. GOVERNMENT CONTRACT WITH
+ * THE NATIONAL AERONAUTICS AND SPACE ADMINISTRATION (NASA). THE SOFTWARE
+ * IS TECHNOLOGY AND SOFTWARE PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS
+ * AND IS PROVIDED AS-IS TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND,
+ * INCLUDING ANY WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR
+ * A PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC 2312-2313)
+ * OR FOR ANY PURPOSE WHATSOEVER, FOR THE SOFTWARE AND RELATED MATERIALS,
+ * HOWEVER USED.
+ *
+ * IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA BE LIABLE
+ * FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT LIMITED TO, INCIDENTAL
+ * OR CONSEQUENTIAL DAMAGES OF ANY KIND, INCLUDING ECONOMIC DAMAGE OR INJURY TO
+ * PROPERTY AND LOST PROFITS, REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE
+ * ADVISED, HAVE REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
+ *
+ * RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF THE SOFTWARE
+ * AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY CALTECH AND NASA FOR
+ * ALL THIRD-PARTY CLAIMS RESULTING FROM THE ACTIONS OF RECIPIENT IN THE USE
+ * OF THE SOFTWARE.
+ */

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/Sofia1DSpectraExtractor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/Sofia1DSpectraExtractor.java
@@ -85,7 +85,12 @@ public class Sofia1DSpectraExtractor extends DataExtractUtil {
 
         // Populate units, ucds, utype?
         model.setUnits(VOSpectraModel.SPECTRA_FIELDS.FLUX, yu);
-        model.setUnits(VOSpectraModel.SPECTRA_FIELDS.WAVELENGTH, xu);
+        if(model.getMeta().get(VOSpectraModel.SPECTRA_FIELDS.WAVENUMBER.getKey())!=null) {
+            model.setUnits(VOSpectraModel.SPECTRA_FIELDS.WAVENUMBER, xu);//TODO where is the unit, no idea.Ask scientist/PI
+        }
+        if(model.getMeta().get(VOSpectraModel.SPECTRA_FIELDS.WAVELENGTH.getKey())!=null) {
+            model.setUnits(VOSpectraModel.SPECTRA_FIELDS.WAVELENGTH, xu);
+        }
         model.setUnits(VOSpectraModel.SPECTRA_FIELDS.ERROR_FLUX, yu);
         if(model.getMeta().get(VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION.getKey())!=null) {
             model.setUnits(VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION, "");//TODO where is the unit, no idea.Ask scientist/PI

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaSpectraModel.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaSpectraModel.java
@@ -1,0 +1,165 @@
+package edu.caltech.ipac.firefly.data.sofia;
+
+import edu.caltech.ipac.table.DataType;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Define SOFIA spectra model in terms of VO fields
+ * Default fields for this model are Flux and Wavelength
+ */
+public class SofiaSpectraModel implements VOSpectraModel {
+
+    public static final SPECTRA_FIELDS[] defaultSofiaSpectraCols =
+            new VOSpectraModel.SPECTRA_FIELDS[]{SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX, SPECTRA_FIELDS.ERROR_FLUX, VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION, SPECTRA_FIELDS.INST_RESP_CURVE}; // make an enum SPECTRA_COLS("Flux",unit,ucd,type)..?;
+
+    private final Map<String, DataType> voCols;
+    private SPECTRA_FIELDS[] spectraCols;
+
+    public SofiaSpectraModel() {
+        this(defaultSofiaSpectraCols);
+    }
+
+    /**
+     * Define spectra model with specific columns
+     * Constructor with particular data type fields
+     *
+     * @param fields
+     */
+    public SofiaSpectraModel(VOSpectraModel.SPECTRA_FIELDS[] fields) {
+        spectraCols = fields;
+
+        voCols = new LinkedHashMap<>(); //Keep order of the column default set above, important to extract the data rom images row as SOFIA model defined.
+        for (SPECTRA_FIELDS param : spectraCols) {
+            DataType dt = new DataType(param.getKey(), param.getTitle(), param.getMetaClass());
+            dt.setDesc(param.getDescription());
+            dt.setUnits(param.getUnits());
+            dt.setUCD(param.getUcd());
+            dt.setUType(param.getUtype());
+//            dt.setWidth();
+//            dt.setPrecision();
+            voCols.put(param.getKey(), dt);
+        }
+    }
+    /**
+     * Define spectra model from instrument enum
+     * Constructor with particular data type fields
+     *
+     * @param inst {@link SpectraInstrument}
+     */
+    public SofiaSpectraModel(SpectraInstrument inst) {
+        this(inst.getSpectraCols());
+    }
+
+    @Override
+    public Map<String, DataType> getMeta() {
+        return voCols;
+    }
+
+    @Override
+    public void setUnits(SPECTRA_FIELDS field, String units) {
+        voCols.get(field.getKey()).setUnits(units);
+    }
+
+    @Override
+    public void setUcd(SPECTRA_FIELDS field, String ucd) {
+        voCols.get(field.getKey()).setUCD(ucd);
+    }
+    /*
+    VOTable Example from NED:
+    <VOTABLE version="v1.0">
+    <RESOURCE utype="sed:SED">
+        <TABLE name="./DATA/NGC_3034:S:HI:r1980_votable.xml" utype="sed:Segment">
+        <GROUP utype="sed:Segment.SpectralCoord">
+            <FIELDref ref="Frequency"/>
+        </GROUP>
+        <GROUP utype="sed:Segment.Flux">
+            <FIELDref ref="Flux"/>
+        </GROUP>
+        <FIELD ID="Frequency" unit="Hz" datatype="double" name="Frequency" utype="sed:Segment.Points.SpectralCoord.Value"/>
+        <FIELD ID="Flux" unit="W/m^2/Hz" datatype="double" name="Flux" utype="sed:Segment.Points.Flux.Value"/>
+     */
+
+    public enum INSTRUMENTS {
+        GREAT("GREAT"),
+        FORCAST("FORCAST",
+                new HashMap<String, String>() {{
+                    put("IMAGING", "IMAGING");
+                }},
+                new HashMap<String, String>() {{
+                    put("SW", "SW");
+                    put("LW", "LW");
+                }},
+                defaultSofiaSpectraCols
+        ),
+        FIFILS("FIFI-LS"),
+        HAWC("HAWC_PLUS"),
+        EXES("EXES",null, null,new VOSpectraModel.SPECTRA_FIELDS[]{SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX, SPECTRA_FIELDS.ERROR_FLUX, VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION}),
+        FLITECAM("FLITECAM",null,null,new VOSpectraModel.SPECTRA_FIELDS[]{SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX, SPECTRA_FIELDS.ERROR_FLUX}),
+        FPI("FPI_PLUS");
+
+        private final SPECTRA_FIELDS[] spectraFields;
+        private String name;
+        private Map<String, String> config;
+        private Map<String, String> camera;
+
+        INSTRUMENTS(String name) {
+            this(name, null, null,null);
+        }
+
+        INSTRUMENTS(String name, Map<String, String> config) {
+            this(name, config, null,null);
+        }
+
+        INSTRUMENTS(String name, Map<String, String> config, Map<String, String> camera, VOSpectraModel.SPECTRA_FIELDS[] cols) {
+            this.name = name;
+            this.config = config;
+            this.camera = camera;
+            this.spectraFields = cols;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public Map<String, String> getConfig() {
+            return this.config;
+        }
+
+        public Map<String, String> getCamera() {
+            return this.camera;
+        }
+
+        public SPECTRA_FIELDS[] getSpectraFields() {
+            return spectraFields;
+        }
+    }
+
+    /*
+       SOFIA product where spectra 1d (flux vs wavelength tipially is coded in an image with at least 2 rows, first wavlenegtth and 2 flux.
+        */
+    public enum SpectraInstrument {
+
+        FORCAST(SofiaSpectraModel.INSTRUMENTS.FORCAST, SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX),
+        EXES(SofiaSpectraModel.INSTRUMENTS.EXES, SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX),
+        FLITECAM(SofiaSpectraModel.INSTRUMENTS.FLITECAM, SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX);
+
+
+        //GREAT, FIFILS... more complicated.
+
+        private final SPECTRA_FIELDS idxXaxis, idxYaxis;
+        private final SofiaSpectraModel.INSTRUMENTS instrument;
+
+        SpectraInstrument(SofiaSpectraModel.INSTRUMENTS inst, SPECTRA_FIELDS x, SPECTRA_FIELDS y) {
+            this.idxXaxis = x;
+            this.idxYaxis = y;
+            this.instrument = inst;
+        }
+
+        public SPECTRA_FIELDS[] getSpectraCols() {
+            return this.instrument.getSpectraFields();
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaSpectraModel.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaSpectraModel.java
@@ -96,7 +96,7 @@ public class SofiaSpectraModel implements VOSpectraModel {
         ),
         FIFILS("FIFI-LS"),
         HAWC("HAWC_PLUS"),
-        EXES("EXES",null, null,new VOSpectraModel.SPECTRA_FIELDS[]{SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX, SPECTRA_FIELDS.ERROR_FLUX, VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION}),
+        EXES("EXES",null, null,new VOSpectraModel.SPECTRA_FIELDS[]{SPECTRA_FIELDS.WAVENUMBER, SPECTRA_FIELDS.FLUX, SPECTRA_FIELDS.ERROR_FLUX, VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION}),
         FLITECAM("FLITECAM",null,null,new VOSpectraModel.SPECTRA_FIELDS[]{SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX, SPECTRA_FIELDS.ERROR_FLUX}),
         FPI("FPI_PLUS");
 
@@ -143,7 +143,7 @@ public class SofiaSpectraModel implements VOSpectraModel {
     public enum SpectraInstrument {
 
         FORCAST(SofiaSpectraModel.INSTRUMENTS.FORCAST, SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX),
-        EXES(SofiaSpectraModel.INSTRUMENTS.EXES, SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX),
+        EXES(SofiaSpectraModel.INSTRUMENTS.EXES, SPECTRA_FIELDS.WAVENUMBER, SPECTRA_FIELDS.FLUX),
         FLITECAM(SofiaSpectraModel.INSTRUMENTS.FLITECAM, SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX);
 
 
@@ -158,8 +158,20 @@ public class SofiaSpectraModel implements VOSpectraModel {
             this.instrument = inst;
         }
 
+        public static SpectraInstrument getInstrument(String inst) {
+            return valueOf(inst.toUpperCase());
+        }
+
         public SPECTRA_FIELDS[] getSpectraCols() {
             return this.instrument.getSpectraFields();
+        }
+
+        public SPECTRA_FIELDS getXaxis() {
+            return idxXaxis;
+        }
+
+        public SPECTRA_FIELDS getYaxis() {
+            return idxYaxis;
         }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/VOSpectraModel.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/VOSpectraModel.java
@@ -1,0 +1,114 @@
+package edu.caltech.ipac.firefly.data.sofia;
+
+import edu.caltech.ipac.table.DataType;
+
+import java.util.Map;
+
+/**
+ * A way to define spectral model to map data into VO model vocabularies
+ * http://cdsweb.u-strasbg.fr/UCD/ucd1p-words.txt
+ * from http://www.ivoa.net/documents/UCD1+/20180527/index.html
+ * tree in browser http://cdsweb.u-strasbg.fr/UCD/tree/js/
+ *
+ * IVOA docs: http://www.ivoa.net/documents/index.html
+ */
+public interface VOSpectraModel {
+
+
+    // TODO
+    //  ADD HEADER to PARAMS ??
+    /*
+    <GROUP ID="FITS-Headers" name="FITS-Headers" ucd="meta.fits">?
+    or
+    <TABLE name="sofia-spectra">
+        <PARAM datatype="float" name="WAVELENGTH" unit=".." value="">
+        <DESCRIPTION>The spectral range</DESCRIPTION>
+            <VALUES>
+                <min>
+                <max>
+            </values>
+        </PARAM>
+        <PARAM datatype="float" name="ANY FROM HEADER CARD KEY!" unit=".." value="CARD_HEADER.value()">
+     */
+    //TODO add to this enum to cover more spectra content attributes
+    public enum SPECTRA_FIELDS {
+        //Y AXIS
+        FLUX("flux", "Flux", Double.class,"phot.flux.density;em.MIR"), // unit should be replace by extractor
+        //X AXIS
+        WAVELENGTH("wavelength", "Wavelength", Double.class,"em.wavenumber;em.MIR"),
+//        FREQUENCY("wavelength", "Wavelength", Double.class),
+        //ERRORs
+        ERROR_FLUX("error", "Error", Double.class,"stat.error;phot.flux.density;em.MIR"),
+        ATMOS_TRANSMISSION("transmission", "Transmission", Double.class,"phys.transmission;em.MIR"),
+        INST_RESP_CURVE("response", "Response", Double.class,"instr.det;em.MIR") ;
+        // ORDERS...
+        String key;
+        String label;
+        Class metaClass;
+        String description, units, utype, ucd; // ref?, ID? group (see vizier tables)
+
+        SPECTRA_FIELDS(String key, String label, Class c) {
+            this(key, label, c, null, null, null, null);
+        }
+        SPECTRA_FIELDS(String key, String label, Class c, String ucd) {
+            this(key, label, c, null, null, ucd, null);
+        }
+        SPECTRA_FIELDS(String key, String label, Class c, String des, String units, String ucd, String utype) {
+            this.key = key;
+            this.label = label;
+            this.metaClass = c;
+            this.description = des;
+            this.units = units;
+            this.ucd = ucd;
+            this.utype = utype;
+
+        }
+
+       public String getKey() {
+            return this.key;
+        }
+
+        String getTitle() {
+            return this.label;
+        }
+
+        Class getMetaClass() {
+            return this.metaClass;
+        }
+
+        String getDescription() {
+            return this.description;
+        }
+
+        String getUnits() {
+            return this.units;
+        }
+
+        String getUtype() {
+            return this.utype;
+        }
+
+        String getUcd() {
+            return this.ucd;
+        }
+    }
+
+    Map<String, DataType> getMeta(); //VOTAble <FIELD>
+
+    /**
+     * Sets units
+     *
+     * @param field
+     * @param units
+     */
+    void setUnits(SPECTRA_FIELDS field, String units);
+
+    /**
+     * Sets the ucd
+     *
+     * @param field
+     * @param ucd
+     */
+    void setUcd(SPECTRA_FIELDS field, String ucd);
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/VOSpectraModel.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/VOSpectraModel.java
@@ -35,7 +35,8 @@ public interface VOSpectraModel {
         //Y AXIS
         FLUX("flux", "Flux", Double.class,"phot.flux.density;em.MIR"), // unit should be replace by extractor
         //X AXIS
-        WAVELENGTH("wavelength", "Wavelength", Double.class,"em.wavenumber;em.MIR"),
+        WAVELENGTH("wavelength", "Wavelength", Double.class,"em.wl;em.MIR"),
+        WAVENUMBER("wavenumber", "Wavenumber", Double.class,"em.wavenumber;em.MIR"),
 //        FREQUENCY("wavelength", "Wavelength", Double.class),
         //ERRORs
         ERROR_FLUX("error", "Error", Double.class,"stat.error;phot.flux.density;em.MIR"),

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
@@ -3,7 +3,6 @@ package edu.caltech.ipac.firefly.server.dpanalyze;
 import edu.caltech.ipac.firefly.core.FileAnalysisReport;
 import edu.caltech.ipac.firefly.data.sofia.Sofia1DSpectraExtractor;
 import edu.caltech.ipac.firefly.data.sofia.SofiaSpectraModel;
-import edu.caltech.ipac.firefly.data.sofia.VOSpectraModel;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.io.VoTableReader;
@@ -15,7 +14,7 @@ import nom.tam.fits.Header;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.Map;
 
 import static edu.caltech.ipac.table.TableUtil.Format.VO_TABLE_TABLEDATA;
 
@@ -24,12 +23,6 @@ import static edu.caltech.ipac.table.TableUtil.Format.VO_TABLE_TABLEDATA;
  */
 @DataProductAnalyzerImpl(id = "analyze-sofia")
 public class SofiaAnalyzer implements DataProductAnalyzer {
-
-
-    @Override
-    public FileAnalysisReport analyze(FileAnalysisReport inputReport, File inFile, String analyzerId, Map<String, String> params) {
-        return inputReport;
-    }
 
     @Override
     public FileAnalysisReport analyzeFits(FileAnalysisReport inputReport,
@@ -40,43 +33,33 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
 
 
         String code = params.getOrDefault("product_type", "");
-        String level = params.getOrDefault("processing_level", "");
-        String inst = params.getOrDefault("instrument", "");
+        String level = params.getOrDefault("processing_level", "").toUpperCase();
+        String inst = params.getOrDefault("instrument", "").toUpperCase();
         //
-        // - how to replace the analysis file with another file
+        // Add spectra extracted data from image
         //
-        Sofia1DSpectraExtractor model;
-        if (inst.equalsIgnoreCase("FORCAST")) {
-            model = new Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument.FORCAST);
-            if (level.equalsIgnoreCase("LEVEL_2") && (code.equals("rspspec") || code.equals("mrgspec"))) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
-                return addingSpectraExtractedTableAPart(inputReport, model);
-            } else if (level.equalsIgnoreCase("LEVEL_3") && code.equals("combspec")) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
-                return addingSpectraExtractedTableAPart(inputReport, model);
+        boolean isSpectra = false;
+        if (inst.equals("FORCAST")) {
+            if (level.equals("LEVEL_2") && (code.equals("rspspec") || code.equals("mrgspec"))) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+                isSpectra = true;
+            } else if (level.equals("LEVEL_3") && (code.equals("combspec") || code.equals("calspec"))) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+                isSpectra = true;
             }
-        } else if (inst.equalsIgnoreCase("EXES") && level.equalsIgnoreCase("LEVEL_3")) {
-            model = new Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument.EXES);
+        } else if (inst.equals("EXES") && level.equals("LEVEL_3")) {
             if (code.equals("mrgordspec") || code.equals("combspec") || code.equals("spec")) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
-                return addingSpectraExtractedTableAPart(inputReport, model);
+                isSpectra = true;
             }
-        } else if (inst.equalsIgnoreCase("FLITECAM") && level.equalsIgnoreCase("LEVEL_3")) {
-            model = new Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument.FLITECAM);
-            if (code.equals("calspec") || code.equals("combspec")) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
-                return addingSpectraExtractedTableAPart(inputReport, model);
+        } else if (inst.equals("FLITECAM")) {
+            if (level.equals("LEVEL_3") && (code.equals("calspec") || code.equals("combspec"))) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+                isSpectra = true;
+            } else if(level.equals("LEVEL_2") && (code.equals("spec") || code.equals("rspspec"))){
+                isSpectra = true;
             }
         }
 
-        FileAnalysisReport retRep = inputReport.copy();
+        if(isSpectra) return addingSpectraExtractedTableAPart(inputReport, inst);
 
-//        //
-//        // - how to make a part the default
-//        //
-//        try {
-//            int codeNum = Integer.parseInt(code);
-//            if (codeNum > -1 && codeNum < inputReport.getParts().size()) {
-//                retRep.getPart(codeNum).setDefaultPart(true);
-//            }
-//        } catch (NumberFormatException ignored) {
-//        }
+        FileAnalysisReport retRep = inputReport.copy();
         return retRep;
     }
 
@@ -105,10 +88,10 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
         }
     }
 
-    private FileAnalysisReport addingSpectraExtractedTableAPart(FileAnalysisReport inputReport, Sofia1DSpectraExtractor model) {
+    private FileAnalysisReport addingSpectraExtractedTableAPart(FileAnalysisReport inputReport, String inst) {
         try {
-
-            File spectra = extractSpectraTable(inputReport.getFilePath(), model);
+            SofiaSpectraModel.SpectraInstrument instrument = SofiaSpectraModel.SpectraInstrument.getInstrument(inst);
+            File spectra = extractSpectraTable(inputReport.getFilePath(), instrument);
             FileAnalysisReport retRep = inputReport.copy();
             DataGroup dg = retRep.getPart(0).getDetails();
             String spectraName = "Extracted Data ";
@@ -133,15 +116,13 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
             addPart.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
             addPart.setDefaultPart(true);
 
-
-
             //TODO add error bars?
             FileAnalysisReport.ChartParams cp = new FileAnalysisReport.ChartParams();
-            String xCol = VOSpectraModel.SPECTRA_FIELDS.WAVELENGTH.getKey();
-            String yCol = VOSpectraModel.SPECTRA_FIELDS.FLUX.getKey();
+            String xCol = instrument.getXaxis().getKey();
+            String yCol = instrument.getYaxis().getKey();
             cp.setxAxisColName(xCol);
             cp.setyAxisColName(yCol);
-            cp.setMode("markers");
+            cp.setMode("lines+markers");
             addPart.setChartParams(cp);
             retRep.addPart(addPart);
 
@@ -152,134 +133,11 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
         }
     }
 
-    private File extractSpectraTable(String fitsPath, Sofia1DSpectraExtractor model) throws Exception {
-//        String example = "http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/ejoliet/demo/cds-votable-sample.xml";
-//        File f = new File(ServerContext.getTempWorkDir(), "x.xml");
-//        URL url = new URL(example);
-//        URLDownload.getDataToFile(url, f);
-//         return f;
+    private File extractSpectraTable(String fitsPath, SofiaSpectraModel.SpectraInstrument instrument) throws Exception {
+        Sofia1DSpectraExtractor model = new Sofia1DSpectraExtractor(instrument);
         DataGroup dataObjects = model.extract(new File(fitsPath));
         File tempSpectraFile = File.createTempFile("sofia1d-spectra-", ".xml", ServerContext.getTempWorkDir());
         VoTableWriter.save(tempSpectraFile, dataObjects, VO_TABLE_TABLEDATA);
         return tempSpectraFile;
-    }
-
-    /**
-     *Add column names and units to a fits image rendered as table
-     */
-    private FileAnalysisReport demoAddColumnNamesAndUnits(FileAnalysisReport inputReport, Header[] headerAry) {
-        FileAnalysisReport retRep = inputReport.copy();
-        List<FileAnalysisReport.Part> parts = retRep.getParts();
-        for (FileAnalysisReport.Part part : parts) {
-            Header h = headerAry[part.getIndex()];
-            int naxis2 = h.getIntValue("NAXIS2", 0);
-            String xtension = h.getStringValue("XTENSION");
-            boolean isImage = xtension == null || xtension.equalsIgnoreCase("IMAGE");
-            if (naxis2 > 0 && naxis2 < 30 && isImage) {
-                part.setUiRender(FileAnalysisReport.UIRender.Chart);
-                part.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
-                List<String> cNames = new ArrayList<>(naxis2 + 1);
-                List<String> cUnits = new ArrayList<>(naxis2 + 1);
-                cNames.add("The_Index");
-                cUnits.add("count");
-                for (int i = 1; i < naxis2 + 1; i++) cNames.add("Col-" + i);
-                for (int i = 1; i < naxis2 + 1; i++) cUnits.add("Unit-" + i);
-                part.setTableColumnNames(cNames);
-                part.setTableColumnUnits(cUnits);
-            }
-        }
-        return retRep;
-    }
-
-    /*
-     * - Add column names and units to a fits image rendered as table
-     * - Create a customized chart
-     * - make chart the default
-     * - also demonstrates chaining - the image rendered as a table is set up by demoAddColumnNamesAndUnits
-     */
-    private FileAnalysisReport demoCreate3Charts(FileAnalysisReport inputReport, Header[] headerAry) {
-        FileAnalysisReport retRep = demoAddColumnNamesAndUnits(inputReport, headerAry);
-        List<FileAnalysisReport.Part> parts = retRep.getParts();
-        for (FileAnalysisReport.Part part : parts) {
-            Header h = headerAry[part.getIndex()];
-            int naxis2 = h.getIntValue("NAXIS2", 0);
-            String xtension = h.getStringValue("XTENSION");
-            boolean isImage = xtension == null || xtension.equalsIgnoreCase("IMAGE");
-            if (naxis2 > 0 && naxis2 < 30 && isImage) {
-                List<FileAnalysisReport.ChartParams> cpList = new ArrayList<>();
-
-                FileAnalysisReport.ChartParams cp = new FileAnalysisReport.ChartParams();
-                cp.setxAxisColName("Col-7");
-                cp.setyAxisColName("Col-8");
-                cp.setMode("markers");
-                cp.addLayout(Collections.singletonMap("title", "My Customized Scatter Chart"));
-                cpList.add(cp);
-
-
-                cp = new FileAnalysisReport.ChartParams();
-                cp.setNumBins(40);
-                cp.setyAxisColName("Col-1");
-                cp.setSimpleChartType(FileAnalysisReport.ChartParams.ChartType.Histogram);
-                cp.addLayout(Collections.singletonMap("title", "My Customized Histogram"));
-                cpList.add(cp);
-
-
-                cp = new FileAnalysisReport.ChartParams();
-                cp.setxAxisColName("The_Index");
-                cp.setyAxisColName("Col-1");
-                cp.setMode("lines+markers");
-                cp.setSimpleChartType(FileAnalysisReport.ChartParams.ChartType.XYChart);
-                cp.addLayout(Collections.singletonMap("title", "My Customized XY Chart"));
-                cpList.add(cp);
-
-                part.setChartParams(cpList);
-                part.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
-            }
-        }
-        return retRep;
-    }
-
-    /*
-     * - make a chart with two traces
-     * - also demonstrates chaining - the image rendered as a table is set up by demoAddColumnNamesAndUnits
-     */
-    private FileAnalysisReport demoCreate2Traces(FileAnalysisReport inputReport, Header[] headerAry) {
-        FileAnalysisReport retRep = demoAddColumnNamesAndUnits(inputReport, headerAry);
-        List<FileAnalysisReport.Part> parts = retRep.getParts();
-        for (FileAnalysisReport.Part part : parts) {
-            Header h = headerAry[part.getIndex()];
-            int naxis2 = h.getIntValue("NAXIS2", 0);
-            String xtension = h.getStringValue("XTENSION");
-            boolean isImage = xtension == null || xtension.equalsIgnoreCase("IMAGE");
-            if (naxis2 > 0 && naxis2 < 30 && isImage) {
-                FileAnalysisReport.ChartParams cp = new FileAnalysisReport.ChartParams();
-                List<Map<String, Object>> traces = new ArrayList<>();
-
-                // setup trace 1
-                Map<String, Object> trace = new HashMap<>();
-                trace.put("x", "tables::The_Index");
-                trace.put("y", "tables::Col-1");
-                trace.put("name", "col1 vs index");
-                trace.put("mode", "lines+markers");
-                traces.add(trace);
-
-                // setup trace 2
-                trace = new HashMap<>();
-                trace.put("x", "tables::The_Index");
-                trace.put("y", "tables::Col-10");
-                trace.put("name", "col10 vs index");
-                trace.put("mode", "lines+markers");
-                traces.add(trace);
-
-
-                cp.addLayout(Collections.singletonMap("title", "Chart With 2 Traces"));
-                cp.addLayout(Collections.singletonMap("xaxis", Collections.singletonMap("title", "the index")));
-                cp.addLayout(Collections.singletonMap("yaxis", Collections.singletonMap("title", "value")));
-                cp.setTraces(traces);
-                part.setChartParams(Collections.singletonList(cp));
-                part.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
-            }
-        }
-        return retRep;
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
@@ -1,0 +1,285 @@
+package edu.caltech.ipac.firefly.server.dpanalyze;
+
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
+import edu.caltech.ipac.firefly.data.sofia.Sofia1DSpectraExtractor;
+import edu.caltech.ipac.firefly.data.sofia.SofiaSpectraModel;
+import edu.caltech.ipac.firefly.data.sofia.VOSpectraModel;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.io.VoTableReader;
+import edu.caltech.ipac.table.io.VoTableWriter;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.URLDownload;
+import nom.tam.fits.Header;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+
+import static edu.caltech.ipac.table.TableUtil.Format.VO_TABLE_TABLEDATA;
+
+/*
+ Analyzer for SOFIA extracted Spectra from FITS 'image'
+ */
+@DataProductAnalyzerImpl(id = "analyze-sofia")
+public class SofiaAnalyzer implements DataProductAnalyzer {
+
+
+    @Override
+    public FileAnalysisReport analyze(FileAnalysisReport inputReport, File inFile, String analyzerId, Map<String, String> params) {
+        return inputReport;
+    }
+
+    @Override
+    public FileAnalysisReport analyzeFits(FileAnalysisReport inputReport,
+                                          File inFile,
+                                          String analyzerId,
+                                          Map<String, String> params,
+                                          Header[] headerAry) {
+
+
+        String code = params.getOrDefault("product_type", "");
+        String level = params.getOrDefault("processing_level", "");
+        String inst = params.getOrDefault("instrument", "");
+        //
+        // - how to replace the analysis file with another file
+        //
+        Sofia1DSpectraExtractor model;
+        if (inst.equalsIgnoreCase("FORCAST")) {
+            model = new Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument.FORCAST);
+            if (level.equalsIgnoreCase("LEVEL_2") && (code.equals("rspspec") || code.equals("mrgspec"))) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+                return addingSpectraExtractedTableAPart(inputReport, model);
+            } else if (level.equalsIgnoreCase("LEVEL_3") && code.equals("combspec")) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+                return addingSpectraExtractedTableAPart(inputReport, model);
+            }
+        } else if (inst.equalsIgnoreCase("EXES") && level.equalsIgnoreCase("LEVEL_3")) {
+            model = new Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument.EXES);
+            if (code.equals("mrgordspec") || code.equals("combspec") || code.equals("spec")) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+                return addingSpectraExtractedTableAPart(inputReport, model);
+            }
+        } else if (inst.equalsIgnoreCase("FLITECAM") && level.equalsIgnoreCase("LEVEL_3")) {
+            model = new Sofia1DSpectraExtractor(SofiaSpectraModel.SpectraInstrument.FLITECAM);
+            if (code.equals("calspec") || code.equals("combspec")) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+                return addingSpectraExtractedTableAPart(inputReport, model);
+            }
+        }
+
+        FileAnalysisReport retRep = inputReport.copy();
+
+//        //
+//        // - how to make a part the default
+//        //
+//        try {
+//            int codeNum = Integer.parseInt(code);
+//            if (codeNum > -1 && codeNum < inputReport.getParts().size()) {
+//                retRep.getPart(codeNum).setDefaultPart(true);
+//            }
+//        } catch (NumberFormatException ignored) {
+//        }
+        return retRep;
+    }
+
+
+    /**
+     * how to replace the analysis file with another file
+     */
+    private FileAnalysisReport demoReplacingData(FileAnalysisReport inputReport) {
+        try {
+            File f = new File(ServerContext.getUploadDir(), "x.fits");
+            URL url = new URL("http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/demo/wise-00.fits");
+            URLDownload.getDataToFile(url, f);
+            FileAnalysisReport retRep = inputReport.copy(false);
+            FileAnalysisReport.Part replacePart =
+                    new FileAnalysisReport.Part(FileAnalysisReport.Type.Image, "A image to replace");
+            replacePart.setFileLocationIndex(0);
+            replacePart.setDefaultPart(true);
+            replacePart.setUiRender(FileAnalysisReport.UIRender.Image);
+            replacePart.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
+            replacePart.setConvertedFileName(ServerContext.replaceWithPrefix(f));
+            retRep.addPart(replacePart);
+            return retRep;
+        } catch (MalformedURLException | FailedRequestException e) {
+            e.printStackTrace();
+            return inputReport;
+        }
+    }
+
+    private FileAnalysisReport addingSpectraExtractedTableAPart(FileAnalysisReport inputReport, Sofia1DSpectraExtractor model) {
+        try {
+
+            File spectra = extractSpectraTable(inputReport.getFilePath(), model);
+            FileAnalysisReport retRep = inputReport.copy();
+            DataGroup dg = retRep.getPart(0).getDetails();
+            String spectraName = "Extracted Data ";
+            for (int i = 0; i <dg.size();i++) {
+                String key = (String) dg.getData("key", i);
+                if(key.equals("FILENAME")){
+                    String tmpName = (String) dg.getData("value", i);
+                    spectraName += tmpName.substring(0,tmpName.lastIndexOf("."));
+                    break;
+                }
+            }
+            FileAnalysisReport tempRep = VoTableReader.analyze(spectra, FileAnalysisReport.ReportType.Details);
+            FileAnalysisReport.Part tempPart = tempRep.getPart(0);
+            FileAnalysisReport.Part addPart = tempPart.copy();
+            addPart.setDesc(spectraName.trim());
+            addPart.setFileLocationIndex(0);
+            addPart.setConvertedFileName(ServerContext.replaceWithPrefix(spectra));
+            addPart.setConvertedFileFormat(tempRep.getFormat());
+            addPart.setIndex(1);
+            addPart.setUiRender(FileAnalysisReport.UIRender.Chart);
+            addPart.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
+            addPart.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
+            addPart.setDefaultPart(true);
+
+
+
+            //TODO add error bars?
+            FileAnalysisReport.ChartParams cp = new FileAnalysisReport.ChartParams();
+            String xCol = VOSpectraModel.SPECTRA_FIELDS.WAVELENGTH.getKey();
+            String yCol = VOSpectraModel.SPECTRA_FIELDS.FLUX.getKey();
+            cp.setxAxisColName(xCol);
+            cp.setyAxisColName(yCol);
+            cp.setMode("markers");
+            addPart.setChartParams(cp);
+            retRep.addPart(addPart);
+
+            return retRep;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return inputReport;
+        }
+    }
+
+    private File extractSpectraTable(String fitsPath, Sofia1DSpectraExtractor model) throws Exception {
+//        String example = "http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/ejoliet/demo/cds-votable-sample.xml";
+//        File f = new File(ServerContext.getTempWorkDir(), "x.xml");
+//        URL url = new URL(example);
+//        URLDownload.getDataToFile(url, f);
+//         return f;
+        DataGroup dataObjects = model.extract(new File(fitsPath));
+        File tempSpectraFile = File.createTempFile("sofia1d-spectra-", ".xml", ServerContext.getTempWorkDir());
+        VoTableWriter.save(tempSpectraFile, dataObjects, VO_TABLE_TABLEDATA);
+        return tempSpectraFile;
+    }
+
+    /**
+     *Add column names and units to a fits image rendered as table
+     */
+    private FileAnalysisReport demoAddColumnNamesAndUnits(FileAnalysisReport inputReport, Header[] headerAry) {
+        FileAnalysisReport retRep = inputReport.copy();
+        List<FileAnalysisReport.Part> parts = retRep.getParts();
+        for (FileAnalysisReport.Part part : parts) {
+            Header h = headerAry[part.getIndex()];
+            int naxis2 = h.getIntValue("NAXIS2", 0);
+            String xtension = h.getStringValue("XTENSION");
+            boolean isImage = xtension == null || xtension.equalsIgnoreCase("IMAGE");
+            if (naxis2 > 0 && naxis2 < 30 && isImage) {
+                part.setUiRender(FileAnalysisReport.UIRender.Chart);
+                part.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
+                List<String> cNames = new ArrayList<>(naxis2 + 1);
+                List<String> cUnits = new ArrayList<>(naxis2 + 1);
+                cNames.add("The_Index");
+                cUnits.add("count");
+                for (int i = 1; i < naxis2 + 1; i++) cNames.add("Col-" + i);
+                for (int i = 1; i < naxis2 + 1; i++) cUnits.add("Unit-" + i);
+                part.setTableColumnNames(cNames);
+                part.setTableColumnUnits(cUnits);
+            }
+        }
+        return retRep;
+    }
+
+    /*
+     * - Add column names and units to a fits image rendered as table
+     * - Create a customized chart
+     * - make chart the default
+     * - also demonstrates chaining - the image rendered as a table is set up by demoAddColumnNamesAndUnits
+     */
+    private FileAnalysisReport demoCreate3Charts(FileAnalysisReport inputReport, Header[] headerAry) {
+        FileAnalysisReport retRep = demoAddColumnNamesAndUnits(inputReport, headerAry);
+        List<FileAnalysisReport.Part> parts = retRep.getParts();
+        for (FileAnalysisReport.Part part : parts) {
+            Header h = headerAry[part.getIndex()];
+            int naxis2 = h.getIntValue("NAXIS2", 0);
+            String xtension = h.getStringValue("XTENSION");
+            boolean isImage = xtension == null || xtension.equalsIgnoreCase("IMAGE");
+            if (naxis2 > 0 && naxis2 < 30 && isImage) {
+                List<FileAnalysisReport.ChartParams> cpList = new ArrayList<>();
+
+                FileAnalysisReport.ChartParams cp = new FileAnalysisReport.ChartParams();
+                cp.setxAxisColName("Col-7");
+                cp.setyAxisColName("Col-8");
+                cp.setMode("markers");
+                cp.addLayout(Collections.singletonMap("title", "My Customized Scatter Chart"));
+                cpList.add(cp);
+
+
+                cp = new FileAnalysisReport.ChartParams();
+                cp.setNumBins(40);
+                cp.setyAxisColName("Col-1");
+                cp.setSimpleChartType(FileAnalysisReport.ChartParams.ChartType.Histogram);
+                cp.addLayout(Collections.singletonMap("title", "My Customized Histogram"));
+                cpList.add(cp);
+
+
+                cp = new FileAnalysisReport.ChartParams();
+                cp.setxAxisColName("The_Index");
+                cp.setyAxisColName("Col-1");
+                cp.setMode("lines+markers");
+                cp.setSimpleChartType(FileAnalysisReport.ChartParams.ChartType.XYChart);
+                cp.addLayout(Collections.singletonMap("title", "My Customized XY Chart"));
+                cpList.add(cp);
+
+                part.setChartParams(cpList);
+                part.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
+            }
+        }
+        return retRep;
+    }
+
+    /*
+     * - make a chart with two traces
+     * - also demonstrates chaining - the image rendered as a table is set up by demoAddColumnNamesAndUnits
+     */
+    private FileAnalysisReport demoCreate2Traces(FileAnalysisReport inputReport, Header[] headerAry) {
+        FileAnalysisReport retRep = demoAddColumnNamesAndUnits(inputReport, headerAry);
+        List<FileAnalysisReport.Part> parts = retRep.getParts();
+        for (FileAnalysisReport.Part part : parts) {
+            Header h = headerAry[part.getIndex()];
+            int naxis2 = h.getIntValue("NAXIS2", 0);
+            String xtension = h.getStringValue("XTENSION");
+            boolean isImage = xtension == null || xtension.equalsIgnoreCase("IMAGE");
+            if (naxis2 > 0 && naxis2 < 30 && isImage) {
+                FileAnalysisReport.ChartParams cp = new FileAnalysisReport.ChartParams();
+                List<Map<String, Object>> traces = new ArrayList<>();
+
+                // setup trace 1
+                Map<String, Object> trace = new HashMap<>();
+                trace.put("x", "tables::The_Index");
+                trace.put("y", "tables::Col-1");
+                trace.put("name", "col1 vs index");
+                trace.put("mode", "lines+markers");
+                traces.add(trace);
+
+                // setup trace 2
+                trace = new HashMap<>();
+                trace.put("x", "tables::The_Index");
+                trace.put("y", "tables::Col-10");
+                trace.put("name", "col10 vs index");
+                trace.put("mode", "lines+markers");
+                traces.add(trace);
+
+
+                cp.addLayout(Collections.singletonMap("title", "Chart With 2 Traces"));
+                cp.addLayout(Collections.singletonMap("xaxis", Collections.singletonMap("title", "the index")));
+                cp.addLayout(Collections.singletonMap("yaxis", Collections.singletonMap("title", "value")));
+                cp.setTraces(traces);
+                part.setChartParams(Collections.singletonList(cp));
+                part.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
+            }
+        }
+        return retRep;
+    }
+}

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -225,7 +225,7 @@ function analyzeImageResult(part, request, table, row, fileFormat, fileOnServer,
         newReq.setTitleOptions(TitleOptions.NONE);
         override= true;
     }
-    hduIdx ?? newReq.setMultiImageExts(hduIdx+'');
+    hduIdx && newReq.setMultiImageExts(hduIdx+'');
     const {imageViewerId}= activateParams;
 
     const ddTitleStr= (part.uiEntry===UIEntry.UseSpecified || fileOnServer) ?


### PR DESCRIPTION
The purpose of this PR is to add an DP analyzer that will be used for SOFIA data product purposes. See ticket here: [FIREFLY-465](https://jira.ipac.caltech.edu/browse/FIREFLY-465)
This PR has a counterpart PR for SOFIA in IFE [here](https://github.com/IPAC-SW/irsa-ife/pull/115).

The analyzer will trigger and add an extracted spectra to the report returned using a custom FITS HUD image extractor (also included) and a spectra model defined for SOFIA using VO UCDs and units as standard as possible.
Extracted and added spectra will depend on a couple of columns: instrument, product type and level.

The interesting code to look for and complete or update is here:
- The analyzer: `edu.caltech.ipac.firefly.server.dpanalyze.SofiaAnalyzer`
- The extractor: `edu.caltech.ipac.firefly.data.sofia.Sofia1DSpectraExtractor`
- The meta info added to the client dispatch in IFE to make use of the Firefly analyzer can be found here: `src/irsa/js/sofia/Sofia.jsx`

The analyzer will extract the data and add it to the report as a VOTable following a drafted spectral model. (See `edu.caltech.ipac.firefly.data.sofia.VOSpectraModel`)
The analyzer should be completed with other analysis, replacement or extraction as we go.

Caveats: 

1. The combinations to identify 1D spectra included in the FITS images are still in progress ([see confluence page](https://confluence.ipac.caltech.edu/pages/viewpage.action?spaceKey=IRSA&title=SOFIA+-+Plotting+flux+versus+wavelength
 )). 
2. Spectral model used is also in progress, ucds, units, etc. That will need more expertise/review.
3. What is absolutely left out the PR is how to deal with multiple plane (case of NAXIS3 or 'cube') , visualizing multiple spectra.

A way to test the 1D spectra is to 
- go to Firefly build here:
https://fireflydev.ipac.caltech.edu/firefly-465-sofia-analyzer/firefly/
- upload the table [here](http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/ejoliet/sofia/FORCAST-with-meta-analyzer.tbl), 
- select the second row
- noticed that the 'File Contents' now has 3rd part which correspond to the extracted data from the primary HDU and the chart represent flux and wavelength.
 
Another way to test is to 
- go to the SOFIA app build here:
https://irsakudevlb1.ipac.caltech.edu/firefly-465/applications/sofia/
- do a search around moving object 'Pallas' with level 2,3,4 checked and look for FORCAST, EXES or FLITECAM instruments on different product type and level. Using FORCAST table as an example, filter the table by product type column with `IN ('combspec','mrgspec','rspspec')`, first row highlighted should show a chart wavelength vs flux.
The menu 'File Contents' on those data product and other combination of instrument, product types and levels should show an additional part which represent the spectra extracted

For example, FLITECAM LEVEL 3 and product type 'IN ('calspec')'... etc.

If you got to this point and not satisfied with the testing, look at the if-then-else statement in the code `edu.caltech.ipac.firefly.server.dpanalyze.SofiaAnalyzer#analyzeFits` or see confluence page [here](https://confluence.ipac.caltech.edu/pages/viewpage.action?spaceKey=IRSA&title=SOFIA+-+Plotting+flux+versus+wavelength
 ).