### PR TITLE
Firefly-524: DataProducts viewer update

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -122,6 +122,7 @@ public class FileAnalysis {
                 putPartVal(h, p.getChartTableDefOption().name(),i,"chartTableDefOption");
                 if (p.getFileLocationIndex()>-1) putPartVal(h, p.getFileLocationIndex(),i,"fileLocationIndex");
                 if (p.isDefaultPart()) putPartVal(h,p.isDefaultPart(),i,"defaultPart");
+                if (p.isInterpretedData()) putPartVal(h,p.isInterpretedData(),i,"interpretedData");
                 if (p.getTotalTableRows()>-1) putPartVal(h, p.getTotalTableRows(), i, "totalTableRows");
                 if (!isEmpty(p.getDetails())) {
                     putPartVal(h, JsonTableUtil.toJsonDataGroup(p.getDetails(),true), i, "details");

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
@@ -28,8 +28,8 @@ public class FileAnalysisReport {
 
     public enum Type {Image, Table, Spectrum, HeaderOnly, PDF, TAR, Unknown}
     public enum UIRender {Table, Chart, Image, NotSpecified}
-    public enum UIEntry {UseSpecified, UseGuess, UseBoth}
-    public enum ChartTableDefOption {auto, showChart, showTable};
+    public enum UIEntry {UseSpecified, UseGuess, UseAll}
+    public enum ChartTableDefOption {auto, showChart, showTable, showImage};
 
 
 
@@ -95,18 +95,29 @@ public class FileAnalysisReport {
     public void replaceParts(List<Part> parts) {
         this.parts= new ArrayList<>(parts);
     }
+    public void insertPartAtTop(Part part) { insertPart(0,part); }
+
+    public void insertPart(int pos,Part part) {
+        if (parts == null) parts = new ArrayList<>();
+        parts.add(pos,part);
+    }
+
+    public void insertPartAfter(Part existingPart, Part newPart) {
+        if (parts == null) parts = new ArrayList<>();
+        int idx= parts.indexOf(existingPart);
+        if (idx==-1 || idx+1>=parts.size()) parts.add(newPart);
+        else parts.add(idx+1,newPart);
+
+
+    }
 
     public void addPart(Part part) {
         if (parts == null) parts = new ArrayList<>();
         parts.add(part);
     }
 
-    public void setPart(Part part, int i) {
-        if (i<parts.size()) parts.set(i,part);
-    }
-    public Part getPart(int i) {
-        return parts.get(i);
-    }
+    public void setPart(Part part, int i) { if (i<parts.size()) parts.set(i,part); }
+    public Part getPart(int i) { return parts.get(i); }
 
     public String getDataType() {
         if (dataType == null) {
@@ -157,7 +168,7 @@ public class FileAnalysisReport {
     public static class Part {
         private final Type type;
         private UIRender uiRender=UIRender.NotSpecified;
-        private UIEntry uiEntry= UIEntry.UseBoth;;
+        private UIEntry uiEntry= UIEntry.UseAll;;
         private int index= 0;
         private String desc;
         private int fileLocationIndex = -1;   // todo: populate: fits (hdu idx) or VO (table idx)
@@ -167,6 +178,7 @@ public class FileAnalysisReport {
         private List<String> tableColumnNames= null; //only use for a fits image that is read as a table
         private List<String> tableColumnUnits= null; //only use for a fits image that is read as a table
         private boolean defaultPart= false;
+        private boolean interpretedData= false;
         private DataGroup details;
         private ChartTableDefOption chartTableDefOption= ChartTableDefOption.auto;
         private int totalTableRows=-1;
@@ -224,6 +236,9 @@ public class FileAnalysisReport {
 
         public boolean isDefaultPart() { return defaultPart; }
         public void setDefaultPart(boolean defaultPart) { this.defaultPart = defaultPart; }
+
+        public boolean isInterpretedData() { return interpretedData; }
+        public void setInterpretedData(boolean interpretedData) { this.interpretedData = interpretedData; }
 
         public UIRender getUiRender() { return uiRender; }
         public void setUiRender(UIRender uiRender) { this.uiRender = uiRender; }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/Demo1Analyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/Demo1Analyzer.java
@@ -144,6 +144,7 @@ public class Demo1Analyzer implements DataProductAnalyzer {
             addPart.setUiRender(FileAnalysisReport.UIRender.Image);
             addPart.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
             addPart.setConvertedFileName(ServerContext.replaceWithPrefix(f));
+            addPart.setInterpretedData(true);
             retRep.addPart(addPart);
             return retRep;
         } catch (MalformedURLException|FailedRequestException  e) {
@@ -166,7 +167,7 @@ public class Demo1Analyzer implements DataProductAnalyzer {
             boolean isImage= xtension==null || xtension.equalsIgnoreCase("IMAGE");
             if (naxis2>0 && naxis2<30 && isImage) {
                 part.setUiRender(FileAnalysisReport.UIRender.Chart);
-                part.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
+                part.setUiEntry(FileAnalysisReport.UIEntry.UseAll);
                 List<String> cNames= new ArrayList<>(naxis2+1);
                 List<String> cUnits= new ArrayList<>(naxis2+1);
                 cNames.add("The_Index");
@@ -292,6 +293,7 @@ public class Demo1Analyzer implements DataProductAnalyzer {
             addPart.setUiRender(FileAnalysisReport.UIRender.Chart);
             addPart.setUiEntry(FileAnalysisReport.UIEntry.UseSpecified);
             addPart.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showChart);
+            addPart.setInterpretedData(true);
 
 
             FileAnalysisReport.ChartParams cp= new FileAnalysisReport.ChartParams();

--- a/src/firefly/js/data/FileAnalysis.js
+++ b/src/firefly/js/data/FileAnalysis.js
@@ -20,7 +20,7 @@ export const UIRender = {
 export const UIEntry=  {
     UseSpecified: 'UseSpecified',
     UseGuess: 'UseGuess',
-    UseBoth : 'UseBoth'
+    UseAll : 'UseAll'
 };
 
 
@@ -65,7 +65,7 @@ export const makeFileAnalysisPart= (index,fileLocationIndex=0) => (
     {
         index,
         fileLocationIndex,
-        uiEntry: UIEntry.UseBoth,
+        uiEntry: UIEntry.UseAll,
         uiRender: UIRender.NotSpecified,
         convertedFileName: undefined,
         chartParams: undefined,
@@ -123,7 +123,8 @@ export const makeFileAnalysisPart= (index,fileLocationIndex=0) => (
  *  @prop {Array.<string>} [tableColumnNames] only use for a fits image that is read as a table
  *  @prop {Array.<string>} [tableColumnUnits] only use for a fits image that is read as a table
  *  @prop {boolean} [defaultPart]
- *  @prop {string} chartTableDefOption - only used if there is a chart on of 'auto', 'showChart', 'showTable'
+ *  @prop {boolean} [interpretedData] - should be true if this is data that has been added to the original
+ *  @prop {string} chartTableDefOption - only used if there is a chart on of 'auto', 'showChart', 'showTable', 'showImage'
  *  @prop {TableModel} [details]
  *
  *

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -289,7 +289,7 @@ function activateMenuItem(state,action) {
     }
     dpData.activeMenuKeys= {...activeMenuKeys, [activeMenuLookupKey]:aMenuItem.menuKey};
 
-    const {activate,url, displayType}= aMenuItem;
+    const {activate,imageActivate, url, displayType}= aMenuItem;
 
     const requiresActivate= ACTIVATE_REQUIRED.includes(displayType);
     if (requiresActivate && !activate) {
@@ -303,8 +303,8 @@ function activateMenuItem(state,action) {
             case DPtypes.IMAGE:
             case DPtypes.TABLE:
             case DPtypes.CHART:
-            case DPtypes.CHART_TABLE:
-                dpData.dataProducts= {displayType, menuKey, menu, fileMenu, activeMenuKey:menuKey, activeMenuLookupKey, activate};
+            case DPtypes.CHOICE_CTI:
+                dpData.dataProducts= {displayType, menuKey, menu, fileMenu, activeMenuKey:menuKey, activeMenuLookupKey, activate, imageActivate};
                 break;
             case DPtypes.PNG:
                 dpData.dataProducts= {displayType, url, menuKey, menu, activeMenuKey:menuKey, activeMenuLookupKey};
@@ -321,7 +321,7 @@ function activateMenuItem(state,action) {
 }
 
 
-const FILE_MENU_REQUIRED= [DPtypes.IMAGE,DPtypes.TABLE,DPtypes.CHART_TABLE,DPtypes.CHART,DPtypes.MESSAGE];
+const FILE_MENU_REQUIRED= [DPtypes.IMAGE,DPtypes.TABLE,DPtypes.CHOICE_CTI,DPtypes.CHART,DPtypes.MESSAGE];
 
 export function changeActiveFileMenuItem(state,action) {
 
@@ -343,7 +343,7 @@ export function changeActiveFileMenuItem(state,action) {
     const actIdx= fileMenu.menu.findIndex( (m) => m.menuKey===newActiveFileMenuKey);
     const fileMenuItem= fileMenu.menu[actIdx<0? fileMenu.initialDefaultIndex: actIdx];
 
-    const {activate,displayType,message,chartTableDefOption}= fileMenuItem;
+    const {activate,imageActivate,displayType,message,chartTableDefOption}= fileMenuItem;
 
     dpData.activeFileMenuKeys={...activeFileMenuKeys, [fileMenu.activeItemLookupKey]:fileMenuItem.menuKey};
 
@@ -357,7 +357,8 @@ export function changeActiveFileMenuItem(state,action) {
     }
 
     const newFileMenu= {...fileMenu, activeFileMenuKey:newActiveFileMenuKey};
-    const newDisplayProduct= { ...selectedMenuDataProduct, displayType, chartTableDefOption, activate, message, fileMenu:newFileMenu, activeMenuKey:menuKey};
+    const newDisplayProduct= { ...selectedMenuDataProduct, displayType, chartTableDefOption, activate, imageActivate, message,
+        fileMenu:newFileMenu, activeMenuKey:menuKey};
     const newMenu= menu && menu.map( (menuItem) => (menuItem.menuKey!==menuKey) ? menuItem : newDisplayProduct );
     dpData.dataProducts= {...newDisplayProduct, menu:newMenu};
     return insertOrReplace(state,dpData);

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -35,7 +35,7 @@ export const DPtypes= {
     IMAGE_SNGLE_AXIS: 'image-single-axis',
     TABLE: 'table',
     CHART: 'xyplot',
-    CHART_TABLE: 'chartTable',
+    CHOICE_CTI: 'chartTable',
     DOWNLOAD: 'download',
     PNG: 'png',
     ANALYZE: 'analyze',
@@ -44,6 +44,7 @@ export const DPtypes= {
 
 export const SHOW_CHART='showChart';
 export const SHOW_TABLE='showTable';
+export const SHOW_IMAGE='showImage';
 export const AUTO='auto';
 
 /**
@@ -150,7 +151,7 @@ export function dpdtChart(name, activate, menuKey='chart-0', extra={}) {
  * @return {DataProductsDisplayType}
  */
 export function dpdtChartTable(name, activate, menuKey='chart-table-0', extra={}) {
-    return { displayType:DPtypes.CHART_TABLE, name, activate, menuKey, ...extra};
+    return { displayType:DPtypes.CHOICE_CTI, name, activate, menuKey, ...extra};
 }
 
 /**

--- a/src/firefly/js/visualize/ui/MetaDataMultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MetaDataMultiProductViewer.jsx
@@ -17,6 +17,6 @@ const startWatcher= once((dpId) => startDataProductsWatcher({ dataTypeViewerId:d
  * If you are have more that on MultiProductViewer you should lay the out directly
  */
 export const MetaDataMultiProductViewer= memo(({ dpId='DataProductsType', metaDataTableId, autoStartWatcher=true, }) => {
-    autoStartWatcher && startWatcher(dpId);
+    autoStartWatcher && setTimeout(() => startWatcher(dpId),5);
     return (<MultiProductViewer viewerId={dpId} metaDataTableId={metaDataTableId}/>);
 });


### PR DESCRIPTION
#### Firefly-524: DataProducts viewer update 

  - add a setInterpreted to FileAnalysisPart
   - indent and don't modify title if setInterpreted is true
   - for certain images show image,table, and chart options as one button
   - easier to add parts to FileAnalysis object

_Ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-524

#### Testing:

- _url:_ https://fireflydev.ipac.caltech.edu/firefly-524-dp/firefly/
- _Upload_: http://web.ipac.caltech.edu.s3-us-west-2.amazonaws.com/staff/roby/data-products-test/dp-test.tbl
- computed products will be indented (line 3 of the table)
- now does image,table,chart toggle see line 21, "demo - image as table"


