### PR TITLE
Firefly-573: fix two bugs

### DIFF
--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -153,7 +153,11 @@ export function showTableDownloadDialog({tbl_id, tbl_ui_id}) {
 
 function TableDLReducer(tbl_id) {
     return (inFields, action) => {
-        const {request} = getTblById(tbl_id) || {};
+        const {request,tableMeta} = getTblById(tbl_id) || {};
+        const chooseFileNameSource= () => {
+            const fname= request?.META_INFO?.title ?? '';
+            return fname==='${filename}' ? tableMeta?.title : fname;
+        };
         const fixFileName = (fName) => {
 
             const tableFormat = inFields ? get(inFields, [fKeyDef.fileFormat.fKey, 'value'], 'ipac') : 'ipac';
@@ -181,12 +185,12 @@ function TableDLReducer(tbl_id) {
             set(defV, [fKeyDef.wsSelect.fKey, 'value'], '');
             set(defV, [fKeyDef.wsSelect.fKey, 'validator'], isWsFolder());
             set(defV, [fKeyDef.fileName.fKey, 'validator'], fileNameValidator(tblDownloadGroupKey));
-            set(defV, [fKeyDef.fileName.fKey, 'value'], fixFileName(get(request, 'META_INFO.title'), ''));
+            set(defV, [fKeyDef.fileName.fKey, 'value'], fixFileName(chooseFileNameSource()));
             return defV;
         } else {
             switch (action.type) {
                 case FieldGroupCntlr.MOUNT_FIELD_GROUP:
-                    const fName = fixFileName(get(request, 'META_INFO.title', ''));
+                    const fName = fixFileName(chooseFileNameSource());
 
                     inFields = updateSet(inFields, [fKeyDef.fileName.fKey, 'value'], fName);
                     break;
@@ -201,7 +205,7 @@ function TableDLReducer(tbl_id) {
                             inFields = updateSet(inFields, [fKeyDef.fileName.fKey, 'value'], fName);
                         }
                     } else if (action.payload.fieldKey === fKeyDef.fileFormat.fKey) {
-                        const fName = fixFileName(get(request, 'META_INFO.title', ''));
+                        const fName = fixFileName(chooseFileNameSource());
 
                         inFields = updateSet(inFields, [fKeyDef.fileName.fKey, 'value'], fName);
                     }

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -113,7 +113,7 @@ export class DropDownContainer extends Component {
                     {alerts || <Alerts />}
                     <div style={{flexGrow: 1, ...contentWrapStyle}}>
                         <div style={contentStyle} className='DD-ToolBar__content'>
-                            {React.cloneElement(view, { initArgs } ) }
+                            {view && React.cloneElement(view, { initArgs } ) }
                         </div>
                     </div>
                     <div id='footer' className='DD-ToolBar__footer'>


### PR DESCRIPTION
#### Firefly-573: fix two bugs 

1.  found be ned: it not buttons (commands) are set in the menu firefly crashes
2.  found in another PR. when table is saving an uploaded file, it show the name of ${filename}

_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-573

#### Testing
_url:_  https://fireflydev.ipac.caltech.edu/firefly-573-2-bugs/firefly/

testing bug 1 - @cwang2016 has a test for it.
testing bug 2 - upload a file from catalog panel and then save it.  It should have a file name that is not ${filename}