### PR TITLE
firelfy-347:tickbox on top of catalog search column

### DIFF
--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -514,9 +514,9 @@ function handleOnTableChanged(params, fireValueChange) {
 
     if (isEmpty(selCols)) {
         errors = 'Invalid selection: no column is selected';
-    } else if (allSelected) {
+    } /*else if (allSelected) {
         selCols = '';
-    }
+    }*/
 
 
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-347

This PR fixed the none responsive tickbox on top of catalog search column.  It is in Firefly, so I did not make an ife branch.  I did test it by switching long/short and individual selection, all seem working fine. I did not clean it up since my fix may not be the the best way.  

Here is the test URL:
 https://fireflydev.ipac.caltech.edu/firelfy-347/firefly/