### PR TITLE
firefly-590:IRSA Viewer: return to defaults doesn't change color table back

### DIFF
--- a/src/firefly/js/visualize/task/PlotAdminTask.js
+++ b/src/firefly/js/visualize/task/PlotAdminTask.js
@@ -19,7 +19,10 @@ import {clone} from '../../util/WebUtil.js';
 import {detachSelectAreaRelatedLayers} from '../ui/SelectAreaDropDownView.jsx';
 import {getAppOptions} from '../../core/AppDataCntlr';
 import {WcsMatchType} from '../ImagePlotCntlr';
+import {hasOverlayColorLock, findPlotGroup } from '../PlotViewUtil';
 import {onPlotComplete} from '../PlotCompleteMonitor';
+
+
 
 export function autoPlayActionCreator(rawAction) {
     return (dispatcher) => {
@@ -92,14 +95,16 @@ export function changePointSelectionActionCreator(rawAction) {
  */
 export function restoreDefaultsActionCreator(rawAction) {
     return (dispatcher, getState) => {
-        const vr= getState()[IMAGE_PLOT_KEY];
-        const {plotId}= rawAction.payload;
-        const {plotViewAry, positionLock}= vr;
-        const pv= getPlotViewById(vr,plotId);
+        const vr = getState()[IMAGE_PLOT_KEY];
+        const {plotId} = rawAction.payload;
+        const {plotViewAry, positionLock} = vr;
+        const pv = getPlotViewById(vr, plotId);
+        const plotGroup= findPlotGroup(pv.plotGroupId,vr.plotGroupAry);
+        const toAll =  hasOverlayColorLock(pv, plotGroup) | positionLock;
 
         detachSelectAreaRelatedLayers(pv, true);
         const {wcsMatchType:matchType, defNorthUpLock}= getAppOptions();
-        applyToOnePvOrAll(positionLock, plotViewAry, plotId, false,
+        applyToOnePvOrAll(toAll, plotViewAry, plotId, false,
             (pv)=> {
                 if (vr.plotRequestDefaults[pv.plotId]) {
                     const plot= primePlot(pv);

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -3,7 +3,7 @@
  */
 
 import {logError} from '../../util/WebUtil.js';
-import ImagePlotCntlr, {IMAGE_PLOT_KEY, dispatchWcsMatch} from '../ImagePlotCntlr.js';
+import ImagePlotCntlr, {IMAGE_PLOT_KEY, dispatchWcsMatch, ActionScope} from '../ImagePlotCntlr.js';
 import {primePlot, getPlotViewById, operateOnOthersInOverlayColorGroup, getPlotStateAry} from '../PlotViewUtil.js';
 import {callCrop, callChangeColor, callRecomputeStretch} from '../../rpc/PlotServicesJson.js';
 import {WebPlotResult} from '../WebPlotResult.js';
@@ -57,16 +57,26 @@ export function colorChangeActionCreator(rawAction) {
         const pv= getPlotViewById(store,plotId);
         if (!pv) return;
 
-
-        if (!primePlot(pv).plotState.isThreeColor()) {
-            doColorChange(dispatcher,getState, store,plotId,cbarId);
-        }
-        operateOnOthersInOverlayColorGroup(store,pv, (pv) => {
-            const p= primePlot(pv);
-            if (p && !p.plotState.isThreeColor()) { // only do others that are not three color
-                doColorChange(dispatcher,getState, store,pv.plotId,cbarId);
+        if (rawAction.payload.actionScope===ActionScope.SINGLE){
+            if (!primePlot(pv).plotState.isThreeColor()) {
+                doColorChange(dispatcher,getState, store,plotId,cbarId);
             }
-        });
+        }
+        else {
+            //active plot
+            if (!primePlot(pv).plotState.isThreeColor()) {
+                doColorChange(dispatcher,getState, store,plotId,cbarId);
+            }
+            //all other plots
+            operateOnOthersInOverlayColorGroup(store,pv, (pv) => {
+                const p= primePlot(pv);
+                if (p && !p.plotState.isThreeColor()) { // only do others that are not three color
+                    doColorChange(dispatcher,getState, store,pv.plotId,cbarId);
+                }
+            });
+
+        }
+
 
     };
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-590  
Fixed restore to default about the color issue.  
I did not change the behavior of the second button.  I don't know what is the expected behavior in the case below:
   1.  color overlay lock is in lock position
   2. change all plots to a different color (all image changed at the same time)
   3.  unlock the color overlay lock, and lock the second lock (image alignment)
   4. click "restore default",  all the image changed to the default color and the image
  
  One issue I noticed, "restore to default" also changed to "North up".  Is this the requested behavior? 


Test URL:
 https://firefly-590-colorissue.irsakudev.ipac.caltech.edu/irsaviewer/