### PR TITLE
firefly-530:More coordinate hiccups

### DIFF
--- a/src/firefly_data/footprint/Footprint_SOFIA.reg
+++ b/src/firefly_data/footprint/Footprint_SOFIA.reg
@@ -1,41 +1,42 @@
+J2000
 #FORCAST_IMG
-image;box(0, 0, 3.2', 3.4', 0) # color=green tag={FORCAST_IMG}
+box(0, 0, 3.2', 3.4', 0) # color=green tag={FORCAST_IMG}
 #FIFI_LS_BL
-image;box(0, 0, 30", 30", 0)   # color=green tag={FIFI-LS_Blue}
+box(0, 0, 30", 30", 0)   # color=green tag={FIFI-LS_Blue}
 #FIFI_LS_RD
-image;box(0, 0, 60", 60", 0)   # color=green tag={FIFI-LS_Red}
+box(0, 0, 60", 60", 0)   # color=green tag={FIFI-LS_Red}
 #FORCAST_GRISMS_A
-image;box(0, 0, 2.4", 191", 0) # color=green tag={FORCAST_GRISMS_A}
+box(0, 0, 2.4", 191", 0) # color=green tag={FORCAST_GRISMS_A}
 #FORCAST_GRISMS_B
-image;box(0, 0, 4.7", 191", 0) # color=green tag={FORCAST_GRISMS_B}
+box(0, 0, 4.7", 191", 0) # color=green tag={FORCAST_GRISMS_B}
 
 #FLITECAM_GRISMS_ABBA
-image;box(0, 0, 1", 60", 0) # color=green tag={FLITECAM_GRISMS_ABBA}
+box(0, 0, 1", 60", 0) # color=green tag={FLITECAM_GRISMS_ABBA}
 #FLITECAM_GRISMS_AB
-image;box(0, 0, 2", 60", 0) # color=green tag={FLITECAM_GRISMS_AB}
+box(0, 0, 2", 60", 0) # color=green tag={FLITECAM_GRISMS_AB}
 #FLITECAM_IMGE
-image;circle(0, 0, 8') # color=green tag={FLITECAM_IMGE}
+circle(0, 0, 8') # color=green tag={FLITECAM_IMGE}
 
 #HAWC_BAND_A_TOTAL
-image;box(0, 0, 1.7', 2.8', 0)  # color=green tag={HAWC_BAND_A_TOTAL}
+box(0, 0, 1.7', 2.8', 0)  # color=green tag={HAWC_BAND_A_TOTAL}
 #HAWC_BAND_A_POLAR
-image;box(0, 0, 1.7', 1.4', 0)  # color=green tag={HAWC_BAND_A_POLAR}
+box(0, 0, 1.7', 1.4', 0)  # color=green tag={HAWC_BAND_A_POLAR}
 
 #HAWC_BAND_C_TOTAL
-image;box(0, 0, 2.7', 4.2', 0)  # color=green tag={HAWC_BAND_C_TOTAL}
+box(0, 0, 2.7', 4.2', 0)  # color=green tag={HAWC_BAND_C_TOTAL}
 #HAWC_BAND_C_POLAR
-image;box(0, 0, 2.7', 2.1', 0)  # color=green tag={HAWC_BAND_C_POLAR}
+box(0, 0, 2.7', 2.1', 0)  # color=green tag={HAWC_BAND_C_POLAR}
 
 #HAWC_BAND_D_TOTAL
-image;box(0, 0, 4.6', 7.4', 0)  # color=green tag={HAWC_BAND_D_TOTAL}
+box(0, 0, 4.6', 7.4', 0)  # color=green tag={HAWC_BAND_D_TOTAL}
 #HAWC_BAND_D_POLAR
-image;box(0, 0, 4.6', 3.7', 0)  # color=green tag={HAWC_BAND_D_POLAR}
+box(0, 0, 4.6', 3.7', 0)  # color=green tag={HAWC_BAND_D_POLAR}
 
 #HAWC_BAND_E_TOTAL
-image;box(0, 0, 6.3', 10.0', 0)  # color=green tag={HAWC_BAND_E_TOTAL}
+box(0, 0, 6.3', 10.0', 0)  # color=green tag={HAWC_BAND_E_TOTAL}
 #HAWC_BAND_E_POLAR
-image;box(0, 0, 6.3', 5.0', 0)  # color=green tag={HAWC_BAND_E_POLAR}
+box(0, 0, 6.3', 5.0', 0)  # color=green tag={HAWC_BAND_E_POLAR}
 #FPI+
-image;box(0, 0, 8.7', 8.7', 0)  # color=green tag={FPI+}
+box(0, 0, 8.7', 8.7', 0)  # color=green tag={FPI+}
 
 


### PR DESCRIPTION
 https://jira.ipac.caltech.edu/browse/FIREFLY-530

 Fixed the footprints orientation issued reported in FIREFLY-530.

To test:
 URL: https://fireflydev.ipac.caltech.edu/firefly-530-footprint/firefly/
     click the URL above
    search on M16, 500 arcsec, GLIMPSE and WSIE
    when tool loads, pick one of the WISE images as current.
    lock by wcs.
    overlay SOFIA FOV (attached example has FIFI-LS and HAWC+)
    the footprints are aligned 