### PR TITLE
Firefly-584: set default color table to reverse grayscale and give app option and option to change it

### DIFF
--- a/src/firefly/html/firefly-dev.html
+++ b/src/firefly/html/firefly-dev.html
@@ -46,6 +46,9 @@
                     defHipsSources: {source: 'irsa', label: 'IRSA Featured'},
                     mergedListPriority: 'Irsa'
                 },
+                image : {
+                    defaultColorTable : 5
+                },
                 coverage : { // example of using DSS and wise combination for coverage (not that anyone would want to combination)
                     hipsSourceURL : 'http://alasky.u-strasbg.fr/DSS/DSSColor', // url
                     imageSourceParams: {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -31,6 +31,7 @@ import {dispatchOnAppReady} from './core/AppDataCntlr.js';
 import {getBootstrapRegistry} from './core/BootstrapRegistry.js';
 import {showLostConnection} from './ui/LostConnection.jsx';
 import {recordHistory} from './core/History.js';
+import {setDefaultImageColorTable} from './visualize/WebPlotRequest.js';
 
 
 var initDone = false;
@@ -142,6 +143,9 @@ const defFireflyOptions = {
         defHipsSources: {source: 'irsa', label: 'Featured'},
         mergedListPriority: 'irsa'
     },
+    image : {
+        defaultColorTable: 1,
+    },
     coverage : {
         // TODO: need to define all options with defaults here.  used in FFEntryPoint.js
     },
@@ -185,6 +189,7 @@ function installOptions(options) {
     options.disableDefaultDropDown && dispatchUpdateLayoutInfo({disableDefaultDropDown:true});
     options.readoutDefaultPref && dispatchChangeReadoutPrefs(options.readoutDefaultPref);
     options.wcsMatchType && dispatchWcsMatch({matchType:options.wcsMatchType, lockMatch:true});
+    setDefaultImageColorTable(options.image?.defaultColorTable ?? 1);
 
     if (options.imageScrollsToHighlightedTableRow!==visRoot().autoScrollToHighlightedTableRow) {
         dispatchChangeTableAutoScroll(options.imageScrollsToHighlightedTableRow);

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -4,7 +4,7 @@
 
 import {isEmpty} from 'lodash';
 import {ServerRequest} from '../data/ServerRequest.js';
-import {WebPlotRequest} from '../visualize/WebPlotRequest.js';
+import {getDefaultImageColorTable, WebPlotRequest} from '../visualize/WebPlotRequest.js';
 import {ZoomType} from '../visualize/ZoomType.js';
 import {getCellValue, getTblInfo} from '../tables/TableUtil.js';
 import {makeFileRequest} from '../tables/TableRequestUtil';
@@ -279,7 +279,7 @@ export function createChartSingleRowArrayActivate(source, titleStr, activatePara
  * @return {function} see below, function takes plotId, reqKey,title, rowNum, extranParams and returns a WebPlotRequest
  *
  */
-export function makeServerRequestBuilder(table, colToUse, headerParams, rv=null, colorTableId=0) {
+export function makeServerRequestBuilder(table, colToUse, headerParams, rv=null, colorTableId= getDefaultImageColorTable()) {
     /**
      * @param plotId - the plot id for the request
      * @param reqKey - search processor request key


### PR DESCRIPTION
### Firefly-584: set default color table to reverse grayscale and give app option and option to change it

the app option is `image.defaultColorTable`

_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-584

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-584-reverse/firefly/
- All image should come up in reverse gray scale.