### PR TITLE
FIREFLY-612:weird lag in chrome/safari layers popup

### DIFF
--- a/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
@@ -55,7 +55,7 @@ export function DrawLayerItemView({maxTitleChars, lastItem, deleteLayer,
                          width:'100%'
                          }} >
                 <div style={{display: 'flex', alignItems: 'center'}}>
-                    <input type='checkbox' style={{visibility: canUserHide?'visible':'hidden'}} checked={visible} onChange={() => changeVisible()} />
+                    <input type='checkbox' style={{visibility: canUserHide?'inherit':'hidden'}} checked={visible} onChange={() => changeVisible()} />
                     {getTitleTag(title,maxTitleChars, autoFormatTitle)}
                 </div>
                 <div style={{padding:'0 4px 0 5px', width: 180, display: 'flex', justifyContent: 'flex-end'}}>
@@ -134,7 +134,7 @@ function makeDelete(canUserDelete,deleteLayer) {
         display:'inline-block',
         whiteSpace: 'nowrap',
         marginLeft: mLeft*2+symbolSize,
-        visibility: canUserDelete ? 'visible' : 'hidden'
+        visibility: canUserDelete ? 'inherit' : 'hidden'
     };
     return (
         <div style={bStyWid}>


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-612

The lag reported is caused by the visibility property in two components.  This only happens when there are more images and layers because restoring them to default takes longer time.  In such situation, when the visibility is true, the component is drawn and displayed before the popup dialog is displayed.  In this PR, the visibility property was changed to default, inherit.  When the parent component is visible, these two components are visible as well.

To test:
URL: https://fireflydev.ipac.caltech.edu/firefly-612-layerpopup/firefly/
1. select at lease four sources to do the image search
2. lock the both overlay and position lock
3. change color 
4. change stretch
5. add many layers as many as 11 layers
6. click restore
7. click the layer button, it may not response immediately because the restoring to default is not finished.  

The bug can be reproduced in the same way using irsadev.ipac.caltech.edu

 