### PR TITLE
irsa-3638:The analyzer for "GREAT" instrument image does not have the image tab

### DIFF
--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -8,7 +8,7 @@ import {RequestType} from '../visualize/RequestType.js';
 import {TitleOptions} from '../visualize/WebPlotRequest';
 import {createChartTableActivate, createChartSingleRowArrayActivate} from './converterUtils';
 import {createSingleImageActivate} from './ImageDataProductsUtil';
-
+import {isEmpty} from 'lodash';
 /**
  *
  * @param part
@@ -24,6 +24,8 @@ export function analyzePart(part, request, table, row, fileFormat, serverCacheFi
 
     const {type,desc, fileLocationIndex}= part;
     const availableTypes= findAvailableTypesForAnalysisPart(part, fileFormat);
+    if (isEmpty(availableTypes)) return {imageResult:false, tableResult:false};
+
     const fileOnServer= (part.convertedFileName) ? part.convertedFileName : serverCacheFileKey;
 
     const imageResult= availableTypes.includes(DPtypes.IMAGE) && type===FileAnalysisType.Image &&
@@ -71,7 +73,7 @@ export function chooseDefaultEntry(menu,parts,fileFormat, dataTypeHint) {
 function findAvailableTypesForAnalysisPart(part, fileFormat) {
     const {type}= part;
     if (type===FileAnalysisType.HeaderOnly || type===FileAnalysisType.Unknown) return [];
-    if (type!==FileAnalysisType.Image || fileFormat!=='FITS' || is1DImage(part)) return [DPtypes.CHART,DPtypes.TABLE];
+    if (type!==FileAnalysisType.Image &&  fileFormat!=='FITS' &&  is1DImage(part) || type===FileAnalysisType.Table) return [DPtypes.CHART,DPtypes.TABLE];
     return (imageCouldBeTable(part)) ? [DPtypes.IMAGE,DPtypes.TABLE,DPtypes.CHART] : [DPtypes.IMAGE];
 }
 


### PR DESCRIPTION
 https://jira.ipac.caltech.edu/browse/IRSA-3638

This issue affected all instruments except FIFI-LS because FIFI-LS does not have one-dimension table.  The bug is a small logic issue in the PartAnalyzer.  Please see the attached images in the ticket https://jira.ipac.caltech.edu/browse/IRSA-3638. All the images were screenshots from running the nightly build. 

The issue first was notified in the GREAT instrument which I was adding an analyzer to.   I commented in the ticket that all the instruments have the same issue.  But I did not change the ticket title.

Please test it
URL: https://irsa-3638-analyzer.irsakudev.ipac.caltech.edu/applications/sofia/

If you prefer, you can run the nightly build to compare, thus, you can see the difference between this two build.  The image tag is shown in my PR among all instruments if the data has the analyzer.  The image tab was not shown in the nightly build. 



