### PR TITLE
IRSA-2624:FIFI-LS Level 3 "wavelength_resampled" cube fails to be cropped (reported by SMO)

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -23,6 +23,7 @@ import edu.caltech.ipac.firefly.visualize.WebPlotInitializer;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.firefly.visualize.WebPlotResult;
 import edu.caltech.ipac.firefly.visualize.ZoomType;
+import edu.caltech.ipac.firefly.visualize.BandState;
 import edu.caltech.ipac.firefly.visualize.draw.StaticDrawInfo;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataObject;
@@ -450,6 +451,7 @@ public class VisServerOps {
         try {
 
             Band bands[] = state.getBands();
+            BandState[] bandStateAry = state.getBandStateAry();
             WebPlotRequest cropRequest[] = new WebPlotRequest[bands.length];
 
             for (int i = 0; (i < bands.length); i++) {
@@ -462,6 +464,8 @@ public class VisServerOps {
                         ServerContext.getVisSessionDir());
 
                 Fits cropFits;
+
+
                 boolean saveCropFits = true;
                 if (state.isMultiImageFile(bands[i])) {
                     if (cropMultiAll) {
@@ -478,9 +482,20 @@ public class VisServerOps {
                                 (int) c2.getX(), (int) c2.getY());
                     }
                 } else {
+
                     Fits fits = new Fits(PlotStateUtil.getWorkingFitsFile(state, bands[i]));
-                    cropFits = CropFile.do_crop(fits, (int) c1.getX(), (int) c1.getY(),
-                            (int) c2.getX(), (int) c2.getY());
+
+                    String multiImageExtValue = bandStateAry[i].getWebPlotRequest().getMultiImageExts();
+                    int multiImageExt = multiImageExtValue!=null?Integer.parseInt(multiImageExtValue):0;
+
+                    if ( multiImageExt>0){
+                        cropFits = CropFile.do_crop(fits, multiImageExt, (int) c1.getX(), (int) c1.getY(),
+                                (int) c2.getX(), (int) c2.getY());
+                    }
+                    else {
+                        cropFits = CropFile.do_crop(fits, (int) c1.getX(), (int) c1.getY(),
+                                (int) c2.getX(), (int) c2.getY());
+                    }
                 }
 
                 FitsRead fr[] = FitsCacher.loadFits(cropFits, cropFile).getFitReadAry();

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/CropFile.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/CropFile.java
@@ -260,9 +260,9 @@ public class CropFile {
         newHeader.addValue("NAXIS2", newNaxis2, null);
 
         float crpix1 = old_header.getFloatValue("CRPIX1", Float.NaN);
-        newHeader.addValue("CRPIX1", (crpix1 - minX), null);
+        if (!Float.isNaN(crpix1))newHeader.addValue("CRPIX1", (crpix1 - minX), null);
         float crpix2 = old_header.getFloatValue("CRPIX2", Float.NaN);
-        newHeader.addValue("CRPIX2", (crpix2 - minY), null);
+        if (!Float.isNaN(crpix2))newHeader.addValue("CRPIX2", (crpix2 - minY), null);
 
         if (newHeader.containsKey("PLTRAH")) {
 	        /* it's a PLATE projection  */

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -270,21 +270,27 @@ const draw=  {
 
     getCenterPt(drawObj) {
         const {pts}= drawObj;
+        const validPts = pts.filter( (pt) => pt!==null);
 
-        if (pts && pts.length > 0) {
+        if (validPts && validPts.length > 0) {
             let xSum = 0;
             let ySum = 0;
             let xTot = 0;
             let yTot = 0;
 
-            pts.forEach((wp) => {
-                xSum += wp.x;
-                ySum += wp.y;
-                xTot++;
-                yTot++;
+            validPts.forEach((wp) => {
+                if (wp!==null) {
+                    xSum += wp.x;
+                    ySum += wp.y;
+                    xTot++;
+                    yTot++;
+                }
+
             });
 
-            const type = pts[0].type;
+
+            const type = validPts[0].type;
+
             const x = xSum/xTot;
             const y = ySum/yTot;
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-2624  
https://jira.ipac.caltech.edu/browse/FIREFLY-628

   In this PR, several bugs in two tickets were detected and fixed.   
   Please note:  This fix is only for FIFI-LS data.  Each instrument in sofia, the FITs are different.  There could be issues in other instruments.  

Test URL: https://irsa-2624-sofia-chop.irsakudev.ipac.caltech.edu/applications/sofia/
To test:
 Search:
   CasA
   Select "FIFI-LS"  in instrument constrains