### PR TITLE
FIREFLY-629:FIFI-LS: Image button shouldn't be present in HDU table type

### DIFF
--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -73,8 +73,14 @@ export function chooseDefaultEntry(menu,parts,fileFormat, dataTypeHint) {
  */
 function findAvailableTypesForAnalysisPart(part, fileFormat) {
     const {type}= part;
+    const naxis= getIntHeader('NAXIS',part,0);
     if (type===FileAnalysisType.HeaderOnly || type===FileAnalysisType.Unknown) return [];
-    if (type!==FileAnalysisType.Image &&  fileFormat!=='FITS' &&  is1DImage(part) || type===FileAnalysisType.Table) return [DPtypes.CHART,DPtypes.TABLE];
+    if (type!==FileAnalysisType.Image &&  fileFormat!=='FITS' &&  is1DImage(part) || type===FileAnalysisType.Table ) return [DPtypes.CHART,DPtypes.TABLE];
+    if (type===FileAnalysisType.Image && naxis===1) {
+        part.chartTableDefOption=SHOW_CHART;
+        return [DPtypes.CHART,DPtypes.TABLE];
+    }
+
     return (imageCouldBeTable(part)) ? [DPtypes.IMAGE,DPtypes.TABLE,DPtypes.CHART] : [DPtypes.IMAGE];
 }
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-629  

 This PR fixed issue that the image tab is present for 1D Image.

To test:
URL: https://lijun.irsakudev.ipac.caltech.edu/applications/sofia/

Target: CasA
Instrument: FIFI-LS

