### PR TITLE
FIREFLY-631: fixing spectra and other instrument data product viewer related issues

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/Sofia1DSpectraExtractor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/Sofia1DSpectraExtractor.java
@@ -107,10 +107,13 @@ public class Sofia1DSpectraExtractor extends DataExtractUtil {
         DataType[] dd;
 
         double[][] fdata = (double[][]) ArrayFuncs.convertArray(p.getKernel(), Double.TYPE, true);
+        if(fdata.length < 2) throw new FitsException("Data has less than 2 columns, this is not chartable as 1D spectra. data length is " + fdata.length);
         for (int row = 0; row < fdata[0].length; row++) {
             DataObject aRow = new DataObject(dataGroup);
             dd = dt.toArray(new DataType[dt.size()]);
             for (int dtIdx = 0; dtIdx < fdata.length; dtIdx++) {
+                //if the data has changed without notice, at least we pick up the old model unless there is less data than the model itself but at least 2 column should be present
+                if(dtIdx == dd.length) break;
                 aRow.setDataElement(dd[dtIdx], fdata[dtIdx][row]);
             }
             dataGroup.add(aRow);

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaFitsConverterUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaFitsConverterUtil.java
@@ -213,7 +213,7 @@ public class SofiaFitsConverterUtil {
     public static  Fits convertToWaveTabFits(Fits inFits) throws FitsException, IOException {
         BasicHDU[] HDUs = inFits.read();
         if (!isWaveTabFits(HDUs)) {
-            throw new IllegalArgumentException("This is not a WAVE-TAB FITs");
+            throw new IllegalArgumentException("This is not a WAVE-TAB FITS, skipping analysis");
         }
         Fits outFits = new Fits();
         BinaryTableHDU bhdu;

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaSpectraModel.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaSpectraModel.java
@@ -93,7 +93,7 @@ public class SofiaSpectraModel implements VOSpectraModel {
                     put("SW", "SW");
                     put("LW", "LW");
                 }},
-                defaultSofiaSpectraCols
+                new VOSpectraModel.SPECTRA_FIELDS[]{SPECTRA_FIELDS.WAVELENGTH, SPECTRA_FIELDS.FLUX, SPECTRA_FIELDS.ERROR_FLUX, VOSpectraModel.SPECTRA_FIELDS.ATMOS_TRANSMISSION, SPECTRA_FIELDS.INST_RESP_CURVE}
         ),
         FIFILS("FIFI-LS"),
         HAWC("HAWC_PLUS"),

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
@@ -70,7 +70,7 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
 
         if(isSpectra) return addingSpectraExtractedTableAPart(inputReport, inst);
 
-        if (inst.equals("FIFI-LS")) {
+        if (inst.equals("FIFI-LS") && level.equals("LEVEL_3") && code.equals("wavelength_resampled")) {
             try {
                 return convertFIFIImage(inFile.getAbsolutePath());
             }
@@ -78,7 +78,7 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
                 e.printStackTrace();
             }
         }
-        if ( inst.equals("GREAT")){
+        if ( inst.equals("GREAT") && level.equals("LEVEL_4")){
             try {
                 return convertToFrequencyParts(inputReport, inFile.getAbsolutePath());
             } catch (FitsException e) {
@@ -90,9 +90,7 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
             }
         }
 
-
-        FileAnalysisReport retRep = inputReport.copy();
-        return retRep;
+        return inputReport;
     }
 
     /**
@@ -149,6 +147,7 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
         int partIndex=0;
         for (int i=0; i<hdus.length; i++){
             String fileName = fitsFileNameRoot+i;
+            parts[i].setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showImage);
             partIndex++;
             FileAnalysisReport.Part chartPart = makeChartPart(hdus[i], fileName,i, partIndex);
             if (chartPart!=null) {
@@ -227,6 +226,10 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
             SofiaSpectraModel.SpectraInstrument instrument = SofiaSpectraModel.SpectraInstrument.getInstrument(inst);
             File spectra = extractSpectraTable(inputReport.getFilePath(), instrument);
             FileAnalysisReport retRep = inputReport.copy();
+            List<FileAnalysisReport.Part> partList = retRep.getParts();
+            for (FileAnalysisReport.Part p:partList) {
+                p.setChartTableDefOption(FileAnalysisReport.ChartTableDefOption.showImage);
+            }
             DataGroup dg = retRep.getPart(0).getDetails();
             String spectraName = "Extracted Data ";
             for (int i = 0; i <dg.size();i++) {


### PR DESCRIPTION
This is a PR that should fix most of the problem seen lately and related to 1d spectra and SOFIA analyzer. In particular:

+ GREAT L1 1D image default shown as chart
+ GREAT L4 checked
+ FIFI-LS types other than L3 wavelength_resampled to be shown as table (binary table types)
+ FORCAST spectra 1D test/check that table extracted and VO model is aligned with data
+ FILTECAM L2 spec spectra 1D test/check that table extracted and VO model is aligned with data
+ EXES L3 'mrgordspec' spectra 1D test/check that table extracted and VO model is aligned with data

See ticket for more details [here FIREFLY-631](https://jira.ipac.caltech.edu/browse/FIREFLY-631).

Please test the different cases here and confirm:
https://firefly-631.irsakudev.ipac.caltech.edu/applications/sofia/
Thanks!