### PR TITLE
FIREFLY-274: fix the disappearing of DS9 region

### DIFF
--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -968,10 +968,10 @@ function isTwoSegmentsIntersect(line1Pt1, line1Pt2, line2Pt1, line2Pt2) {
 
     if (dir1 !== dir2 && dir3 !== dir4) return true;
 
-    if (dir1 == 0 && onSameSegment(line1Pt1, line1Pt2, line2Pt1)) return true;
-    if (dir2 == 0 && onSameSegment(line1Pt1, line1Pt2, line2Pt2)) return true;
-    if (dir3 == 0 && onSameSegment(line2Pt1, line2Pt2, line1Pt1)) return true;
-    if (dir4 == 0 && onSameSegment(line2Pt1, line2Pt2, line1Pt2)) return true;
+    if (dir1 === 0 && onSameSegment(line1Pt1, line1Pt2, line2Pt1)) return true;
+    if (dir2 === 0 && onSameSegment(line1Pt1, line1Pt2, line2Pt2)) return true;
+    if (dir3 === 0 && onSameSegment(line2Pt1, line2Pt2, line1Pt1)) return true;
+    if (dir4 === 0 && onSameSegment(line2Pt1, line2Pt2, line1Pt2)) return true;
 
     return false;
 }
@@ -1102,7 +1102,6 @@ export default {
     computeScreenDistance, computeDistance, computeSimpleDistance,convert,
     computeCentralPointAndRadius, getPositionAngle, getRotationAngle,getTranslateAndRotatePosition,
     intersects, contains, containsRec,containsCircle, getArrowCoords, calculatePosition,
-    convertAngle, distToLine, distanceToPolygon, distanceToCircle, computeSimpleSlopeAngle,
-    segmentIntersectRect
+    convertAngle, distToLine, distanceToPolygon, distanceToCircle, computeSimpleSlopeAngle
 };
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -628,9 +628,8 @@ function boxIntersectRect(pts, plot, w, h, isCenter, sRect, renderOptions) {
     }
 
     const x1 = 0;
-    const x2 = plot.viewDim.width;
     const y1 = 0;
-    const y2 = plot.viewDim.height;
+    const {width: x2, height: y2} = plot.viewDim;
     const view_two_corners = [makeDevicePt(x1, y1), makeDevicePt(x2, y2)];
 
 
@@ -652,8 +651,7 @@ function circleIntersectRect(centerPt, circleRadius, plot, renderOptions) {
     const center_dev = plot.getDeviceCoords(centerPt);
     const rect_x1 = 0;
     const rect_y1 = 0;
-    const rect_x2 = plot.viewDim.width;
-    const rect_y2 = plot.viewDim.height;
+    const {width: rect_x2, height: rect_y2} = plot.viewDim;
     const {translation} = renderOptions || {};
     const center_x_dev = center_dev.x + (translation ? translation.x : 0);
     const center_y_dev = center_dev.y + (translation ? translation.y : 0);
@@ -674,7 +672,7 @@ function circleIntersectRect(centerPt, circleRadius, plot, renderOptions) {
         for (let y of [rect_y1, rect_y2]) {
             const loc = diff_dist_to_center(x, y);
 
-            if (loc === 0.0) {   // circle outline interset the corner
+            if (loc === 0.0) {   // circle outline intersect the corner
                 return true;
             }
 
@@ -810,7 +808,7 @@ function drawCircle(drawObj, ctx,  plot, drawParams) {
             case UnitType.ARCSEC: screenRadius= getValueInScreenPixel(plot,radius);
                 break;
         }
-        cenDevPt= plot.getDeviceCoords(pts[0]);
+        cenDevPt= plot ? plot.getDeviceCoords(pts[0]) : pts[0];
 
 
         if (!cenDevPt) {
@@ -818,15 +816,15 @@ function drawCircle(drawObj, ctx,  plot, drawParams) {
         }
 
         // check if center is within display area or circle intersect the display area
-        if (plot.pointOnDisplay(cenDevPt) ||
+        if (!plot || plot.pointOnDisplay(cenDevPt) ||
             circleIntersectRect(pts[0], screenRadius, plot, renderOptions)) {
             inView = true;
             DrawUtil.drawCircle(ctx,cenDevPt.x, cenDevPt.y,color, screenRadius, lineWidth, renderOptions,false);
         }
     }
     else {
-        const pt0= plot.getDeviceCoords(pts[0]);
-        const pt1= plot.getDeviceCoords(pts[1]);
+        const pt0= plot ? plot.getDeviceCoords(pts[0]) : pts[0];
+        const pt1= plot ? plot.getDeviceCoords(pts[1]) : pts[1];
         if (!pt0 || !pt1) return;
 
         cenDevPt = makeDevicePt((pt0.x+pt1.x)/2, (pt0.y+pt1.y)/2);
@@ -834,7 +832,7 @@ function drawCircle(drawObj, ctx,  plot, drawParams) {
         const yDist= Math.abs(pt0.y-pt1.y)/2;
         screenRadius= Math.min(xDist,yDist);
 
-        if (plot.pointOnDisplay(pt0) || plot.pointOnDisplay(pt1) || plot.pointOnDisplay(cenDevPt) ||
+        if (!plot || plot.pointOnDisplay(pt0) || plot.pointOnDisplay(pt1) || plot.pointOnDisplay(cenDevPt) ||
             circleIntersectRect(cenDevPt, screenRadius, plot, renderOptions)) {
             inView = true;
             DrawUtil.drawCircle(ctx,cenDevPt.x,cenDevPt.y,color, screenRadius, lineWidth, renderOptions,false );


### PR DESCRIPTION
The development mainly fixes the disappearing of the circle, box, and ellipse regions. 
https://jira.ipac.caltech.edu/browse/FIREFLY-274
The development adds one more level testing to determine if rendering the following region shapes, 
- circle: 
      before fixing, no circle is rendered in case the circle center is out of display area. 
      after fixing, if the circle center is out of the display area, further checking if there is an intersection between the border of the circle and the display area. 
- box/ellipse: 
       before fixing: no box or ellipse is rendered in case none of the corners of the box (or box enclosing the ellipse)  is inside the display area.
      after fixing, if none of the box corners is inside the display area, further checking if there is an intersection between the borders of the box and the display area. 

test: https://fireflydev.ipac.caltech.edu/firefly-274-zoom-region/firefly/
1. test on region file, 
- do an image search, M8, 1.0 deg, Spitzer, SEIP, IRAC1.
- upload region file, locations_2.reg as posted in [FIREFLY-274](https://jira.ipac.caltech.edu/browse/FIREFLY-274). This sample is derived from 'locations.reg' posted in FIREFLY-274 by adding some box regions inside (per ellipse regions in locations.reg) or across the image area.
(locates_2.reg is also added into GitHub at firefly_test_data/region-test-files). 
- zoom in the image and check if the region across the border of the display area stays when the region still has some portion within the display area while zooming the image. 

2. test on  SOFIA footprint,  (regarding [FIREFLY-438](https://jira.ipac.caltech.edu/browse/FIREFLY-438) mentioned in the comment of FIREFLY-274)
- do an image search on 81.4500042,-5.5416578, 60 arcsec, 2MASS, all-sky, K_s, 
- load footprint from SOPHIA->FLITECAM->FLITECAM->Grism ABBA
- zoom in the image and rotate the footprint to make sure that the footprint stays while zooming the image. 



