### PR TITLE
Firefly 656 bitpix 64 support

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
@@ -243,6 +243,13 @@ public class PixelValue {
 		/*if (Double.isNaN(retval))
 		    throw new PixelValueException("No flux available");*/
 		break;
+		case 64:
+		bytes_per_pixel = 8;
+		file_pointer = data_offset + pixel_offset * bytes_per_pixel;
+		fits_file.seek(file_pointer);
+		file_value = fits_file.readLong();
+		retval = file_value * bscale + bzero;
+		break;
 	    default:
 		retval = Double.NaN;
 		break;

--- a/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
+++ b/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
@@ -150,10 +150,15 @@ export function getFluxInfo(sndReadout){
     const fluxArray= fluxObj.map( ({value,unit,title,precision}) => {
         let fluxValue= value;
         if (!isNaN(value )) {
-            const min = Number('0.'+'0'.repeat(precision-1)+'1');
-            fluxValue = (Math.abs(value) < 1000  &&Math.abs(value)>min ) ?
-                `${myFormat(value, precision)}` :
-                value.toExponential(6).replace('e+', 'E');
+            if (precision) {
+                const min = Number('0.'+'0'.repeat(precision-1)+'1');
+                fluxValue = (Math.abs(value) < 1000  &&Math.abs(value)>min ) ?
+                    `${myFormat(value, precision)}` :
+                    value.toExponential(6).replace('e+', 'E');
+            }
+            else {
+                fluxValue= `${Math.trunc(value)}`;
+            }
             if (unit && !isNaN(value)) fluxValue+= ` ${unit}`;
         }
 


### PR DESCRIPTION
While testing Bolocam: Galactic Plane Survey (GPS) dataset, we found that Firefly was displaying NaN flux value without units in the readout.

One of the discussion was about unit missing but actually what happened here is that the FITS file fetched from the search (Bolocam GPS, band 1.1 mm around 'ic1396' object) has BITPIX = 64 and bunit = Jy/Beam (see also file sample attached in https://jira.ipac.caltech.edu/browse/FIREFLY-651).

I've added the case of BITPIX = 64 in the code where the readout is getting the flux out of the FITS image.

To test, either:
- upload the file sample (in FIREFLY-651) and check that the readout is no longer NaN and missing the unit
https://fireflydev.ipac.caltech.edu/firefly-656-bitpix-64-support/firefly/?__action=layout.showDropDown&view=FileUploadDropDownCmd
or
- do a image search of BOLOCAM GPS 1.1mm around 'ic1396' astronomical object
https://fireflydev.ipac.caltech.edu/firefly-656-bitpix-64-support/firefly/?__action=layout.showDropDown&
or
- use the URL API to display the image ;-)
https://fireflydev.ipac.caltech.edu/firefly-656-bitpix-64-support/firefly/?api=image&url=https://irsa.ipac.caltech.edu:443/data/BOLOCAM_GPS/images/v1/IC1396/v1.0.2_ic1396_13pca_map50.fits