### PR TITLE
FIREFLY-661: replace DataLine generic column name with title HDU

### DIFF
--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -125,7 +125,7 @@ const C_COL2= ['flux','data','data1','data2'];
  * @param fileFormat
  * @return {{xCol:string,yCol:string,cNames:Array.<String>,cUnits:Array.<String>}|{}}
  */
-function getTableChartColInfo(part, fileFormat) {
+function getTableChartColInfo(title, part, fileFormat) {
     if (isImageAsTable(part,fileFormat)) {
         let cNames= [];
         const {tableColumnNames:overrideColNames, tableColumnUnits=[]}= part;
@@ -135,7 +135,7 @@ function getTableChartColInfo(part, fileFormat) {
         }
         else {
             for(let i=0; i<colCnt; i++) cNames.push(i===0?'naxis1_idx': `naxis1_data_${(i-1)}`);
-            if (colCnt===2) cNames[1]= 'DataLine';
+            if (colCnt===2) cNames[1]= title;
         }
         const cUnits= cNames.length===tableColumnUnits.length ? tableColumnUnits : undefined;
         return {xCol:cNames[0],yCol:cNames[1],cNames,cUnits};
@@ -199,7 +199,7 @@ function analyzeChartTableResult(tableOnly, part, fileFormat, fileOnServer, titl
     }
 
     const ddTitleStr= getTableDropTitleStr(title,part,partFormat,tableOnly);
-    const {xCol,yCol,cNames,cUnits}= getTableChartColInfo(part,partFormat);
+    const {xCol,yCol,cNames,cUnits}= getTableChartColInfo(title, part, partFormat);
 
     if (tableOnly) {
         return dpdtTable(ddTitleStr,


### PR DESCRIPTION
[FIREFLY-661](https://jira.ipac.caltech.edu/browse/FIREFLY-661) request is about changing the column name 'DataLine' for 1D image to be matching the title of the HDU or plot title.

Confirm that for GREAT L1, FIFI-Ls L3 and L4 specific product type (details in ticket) you see no more the 'DataLine' column name and the chart axis is also the same as the HDU title.
Test version available here:
https://firefly-661-dataline.irsakudev.ipac.caltech.edu/applications/sofia/
**Note**: I'm not sure what would happened if 1D image doesn't have HDU title.
