### PR TITLE
irsa-3276:FIFI-LS level 3 file contents menu

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaFitsConverterUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/sofia/SofiaFitsConverterUtil.java
@@ -53,7 +53,7 @@ public class SofiaFitsConverterUtil {
         //PS3_0 is the EXTNAME in the BinaryTableHDU
         header.addLine(new HeaderCard( "PS3_0", waveTableName, "WAVE-TAB binary table name (added by Sofia)"));
         //PS3_1 is the column name for the coordinate array
-        header.addLine(new HeaderCard( "PS3_1", "COORDS", "WAVE-TAB Coordinate (added by Sofia)"));
+        header.addLine(new HeaderCard( "PS3_1", "wavelength", "WAVE-TAB Coordinate (added by Sofia)"));
         header.addLine(new HeaderCard( "PS3_3", 1, "axis number for the Coordinate (added by Sofia)"));
         //If the wavelength is depending on the axes, the PC3_j (j=1, 2, 3) have to be defined.  By default, PC3_3 is 1.
         if (!header.containsKey("PC3_1")) {
@@ -89,7 +89,7 @@ public class SofiaFitsConverterUtil {
 
         BinaryTable tbl = BinaryTableHDU.encapsulate(cols);
         Header hdr = BinaryTableHDU.manufactureHeader(tbl);
-        hdr.addValue("TTYPE1", "COORDS", "number of table fields (added by Sofia)");
+        hdr.addValue("TTYPE1", "wavelength", "number of table fields (added by Sofia)");
         hdr.addValue("EXTNAME", header.getStringValue("EXTNAME"), "wavelength table name from the original image header (added by Sofia)");
 
         return new BinaryTableHDU(hdr, tbl);

--- a/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
+++ b/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
@@ -324,7 +324,7 @@ function processAnalysisResult({table, row, request, activateParams, serverCache
     const imageParts= partAnalysis.filter( (pa) => pa.imageResult);
     let makeAllImageOption= !disableAllImageOption;
     if (makeAllImageOption) makeAllImageOption= imageParts.length>1 || (imageParts.length===1 && parts.length===1);
-    if (makeAllImageOption) makeAllImageOption= imageParts.every( (ip) => !ip.imageResult.override);
+    if (makeAllImageOption) makeAllImageOption= !(imageParts.every( (ip) => ip.imageResult.override));
     const duoImageTableParts= partAnalysis.filter( (pa) => pa.imageResult && pa.tableResult);
     if (makeAllImageOption && duoImageTableParts.length===1 && imageParts===1) makeAllImageOption= false;
     const useImagesFromPartAnalysis= parts.length>1 || !makeAllImageOption || duoImageTableParts.length;

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -232,9 +232,9 @@ function analyzeImageResult(part, request, table, row, fileFormat, fileOnServer,
     if (uiEntry===UIEntry.UseSpecified && uiRender!==UIRender.Image) return undefined;
     const newReq= request.makeCopy();
     let override= false;
-    if (fileOnServer) {
+    if (part.convertedFileName) {
         newReq.setRequestType(RequestType.FILE);
-        newReq.setFileName(fileOnServer);
+        newReq.setFileName(part.convertedFileName);
         newReq.setTitle(title);
         newReq.setTitleOptions(TitleOptions.NONE);
         override= true;


### PR DESCRIPTION
  https://jira.ipac.caltech.edu/browse/IRSA-3726

 This ticket is about the consistency of file content menu among instruments.  The FIFI-LS LEVEL4 has "All Image In File" in the file content but FIFI-LS LEVEL_3 does not.  The analysis is logged in the ticket above.  
 
This PR removed the dependency on added analyzer with convertedFileName set.  The WCS TAB's table column name is changed to wavelength instead of coords. 

To test:
 URL: https://lijun-irsa-3276.irsakudev.ipac.caltech.edu/applications/sofia/


