### PR TITLE
Null Check in VOAnalyzer.applyTokenSub function

### DIFF
--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1153,11 +1153,7 @@ export function applyLinkSub(tableModel, href='', rowIdx, defval='') {
  */
 export function applyTokenSub(tableModel, val='', rowIdx, def) {
 
-    if (!val) {
-        return def;
-    }
-
-    const vars = val.match && val.match(/\${[\w -.]+}/g);
+    const vars = val?.match?.(/${[\w -.]+}/g);
     let rval = val;
     if (vars) {
         vars.forEach((v) => {

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1152,6 +1152,11 @@ export function applyLinkSub(tableModel, href='', rowIdx, defval='') {
  * @returns {string}    the resolved href after subsitution
  */
 export function applyTokenSub(tableModel, val='', rowIdx, def) {
+
+    if (!val) {
+        return def;
+    }
+
     const vars = val.match && val.match(/\${[\w -.]+}/g);
     let rval = val;
     if (vars) {


### PR DESCRIPTION
### Issue Description:

When a user manually enters the URL of a TAP Service, Firefly runs a number of TAP_SCHEMA queries to the TAP service to gather the metadata. If the VOTable results of these queries contain null entries (i.e. Units, UCDs & UTypes) the Firefly UI crashes with the following JS Exception:

```
VOAnalyzer.js:1155 Uncaught TypeError: Cannot read property 'match' of null
    at applyTokenSub (VOAnalyzer.js:1155)
    at TableRenderer.js:675
    at renderWithHooks (react-dom.development.js:16260)
    at updateFunctionComponent (react-dom.development.js:18347)
    at updateSimpleMemoComponent (react-dom.development.js:18285)
    at updateMemoComponent (react-dom.development.js:18188)
    at beginWork$1 (react-dom.development.js:20248)
    at HTMLUnknownElement.callCallback (react-dom.development.js:336)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:385)
    at invokeGuardedCallback (react-dom.development.js:440)
```

For example the following query by the CmdSrv:
`http://TAP_SERVICE/sync?REQUEST=doQuery&LANG=ADQL&QUERY=SELECT+*+FROM+TAP_SCHEMA.columns+WHERE+table_name+like+'TAP_SCHEMA.schemas'" `
may produce a VOTable with the following row:

```
<TR>
    <TD>0</TD>
    <TD>1</TD>
    <TD>0</TD> 
    <TD>1</TD>
    <TD>-1</TD>
    <TD>-1</TD>
    <TD>1</TD>
    <TD>char</TD> 
    <TD/>
    <TD/>
    <TD/>
    <TD>schema name, possibly qualified</TD>
    <TD>schema_name</TD>
    <TD>TAP_SCHEMA.schemas</TD>
</TR>
```
In this case the empty rows correspond to a unit, ucd & utype.
This causes the above exception.

### Version:
The version used for this was:
commit bac5c320ae9cd4372251fb7751169fc559d5c1d9
Date:   Wed Sep 30 15:18:03 2020 -0600
This was tested as part of the Rubin Observatory Science platform, which adds some additional wrappers/modifications to Firefly.

### Fix:
A potential fix contained in this pull request adds a null check in the VOAnalyzer.applyTokenSub function, which seems to fix the problem.

### Note:
This is just a proposed change, which hasn't been thoroughly tested. Please feel free to disregard if you think its an invalid issue, or if it potentially introduces other bugs.