### PR TITLE
FIREFLY-674: Add custom Online-Help feature to API

### DIFF
--- a/src/firefly/html/test/template_loader.js
+++ b/src/firefly/html/test/template_loader.js
@@ -13,6 +13,13 @@
                     const scpt = c.querySelector('script');
                     renderTest(cnt++, expected, actual, scpt, test, Boolean(exclusiveTest.length));
                 });
+
+        const testId = window.location.hash.substring(1);
+        if (testId) {
+            setTimeout(function() {
+                window.scrollTo(0,document.getElementById(testId).offsetTop);
+            }, 2000);
+        }
     };
 
 

--- a/src/firefly/html/test/tests-main.html
+++ b/src/firefly/html/test/tests-main.html
@@ -146,6 +146,23 @@
     </script>
 </template>
 
+<template title="Custom Online-Help URL" class="tpl sm">
+    <div id="expected" >
+        Click table's Help(?) icon and it should take you to "https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/"
+    </div>
+    <div id="actual" class="box x3"/>
+    <script>
+        function onFireflyLoaded(firefly) {
+            firefly.action.dispatchAppOptions({"help.base.url": "https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/"});
+
+            const columns = [{name: 'Greetings'}];
+            const data = [["Hello, World!"]];
+            const table = { tableData: { columns, data }, title: "Custom Help"};
+            firefly.showClientTable('actual', table, {help_id: "https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/"});
+        }
+    </script>
+</template>
+
 <template title="Two table coverage" class="tpl" >
     <div id="expected" >
         <div>Both tables cover similar area, HiPS coverage

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -129,6 +129,7 @@ const defFireflyOptions = {
     wcsMatchType: false,
     imageScrollsToHighlightedTableRow: true,
     imageScrollsToActiveTableOnLoadOrSelect: true,
+    'help.base.url': undefined,
 
     charts: {
         defaultDeletable: undefined, // by default if there are more than one chart in container, all charts are deletable

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -288,7 +288,7 @@ function grabWindowFocus() {
 function onlineHelpLoad( action )
 {
     return () => {
-        var url = getProp('help.base.url', '');
+        var url = getAppOptions()?.['help.base.url'] || getProp('help.base.url', '');
         var windowName = 'onlineHelp';
         var moduleName = getProp('help.subpath', getModuleName());
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-674

Allow API user to set custom location of Online-Help.  To test, goto `Test` URL below and scroll down to test #5.
Click on the Help icon(?) at upper right side of the table.  Click on `source: show` to see how it's done.


Test: https://fireflydev.ipac.caltech.edu/firefly-674-help-base-url-api/firefly/test/tests-main.html#test-5