### PR TITLE
FIREFLY-676: Mouse focus blocked on column filter input field

### DIFF
--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -14,11 +14,11 @@
 
 .TablePanel_NoData {
     position: absolute;
-    top: 45px;
+    top: 60px;
     z-index: 1;
     color: gray;
     font-size: large;
-    height: calc(100% - 45px);
+    height: calc(100% - 60px);
     width: 100%;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-676

When 'No Data Found' is displayed in the table, the column filter input fox is partially blocked, making it hard to set focus.

Test: https://loi.irsakudev.ipac.caltech.edu/applications/sofia/

See ticket for details on how to duplicate bug.