### PR TITLE
Simplify Firefly dockerfile

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -9,7 +9,7 @@ BuildType = "Final"
 
 config.dir = "/hydra/server/config"
 work.directory = "/hydra/workarea"
-stats.log.dir = '${catalina.base}/logs'
+stats.log.dir = '${catalina.base}/logs/statistics'
 alerts.dir = "/hydra/alerts"
 
 debug.mode = false

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,11 +1,28 @@
-FROM tomcat:9.0-jdk11-openjdk
-
+# Description:
+# A tomcat application server running as UID 91(tomcat) by default.
+# It's designed to support running as a different user via -u or --user param.
+#
 #-----------------------------------------------------------------------------
 # To build: docker build -t ipac/firefly --build-arg IMAGE_NAME=ipac/firefly .
 # For help in running: docker run --rm  ipac/firefly --help
 #-----------------------------------------------------------------------------
+#
+# Below are predefined directories Firefly uses during runtime.
+# Mount these directories to an external volume or to the host filesystem if you would like it
+# to persists beyond the container's lifecycle.
+#
+# Firefly mountPaths:
+# /firefly/config           : used to override application properties
+# /firefly/workarea         : work area for temporary files
+# /firefly/shared-workarea  : work area for files that are shared between multiple instances of the application
+# /firefly/logs             : logs directory
+# /firefly/logs/statistics  : directory for statistics logs
+# /firefly/alerts           : alerts monitor will watch this directory for application alerts
+# /external                 : default external data directory visible to Firefly
 
-# Support single server deployments
+
+FROM tomcat:9.0-jdk11-openjdk
+
 
 # - add packages: vim, wget, etc
 # - add any other standard apt packages here
@@ -15,24 +32,15 @@ RUN apt-get update && apt-get install -y \
         vim procps wget \
         && rm -rf /var/lib/apt/lists/*;
 
-# First set of environment variable
-#        - create catalina_base directory .. so tomcat can run as non-root
-#        - These environment varibles are not really made to be overridden
-#           they can be but are mostly for setup
-#        - work dir and config dir might be overridden if they were used in a mounted volume
-#           in the case make sure the directories exist
-#        - BUILD_TIME_NAME - container has access to the image name, used for help only
-# Second set of environment variable
-# These are the users replaceable ones, basicly runtime arguments
+# These are the users replaceable environment variables, basically runtime arguments
 #          MIN_JVM_SIZE and MAX_JVM_SIZE can be used to set the min and max JVM side
 #          - If MAX_JVM_SIZE is not set, the memory is autosized to the memory available to the container.
 #          - Set the available memory on the command line with --memory="4g"
 #          - You can change MAX_RAM_PERCENT on the command line with -e "MAX_RAM_PERCENT=80"
 #          - also- User name and password to use admin
 #          - FIREFLY_OPTS could be used to pass any properties
-ENV CATALINA_HOME=/usr/local/tomcat \
-    EXTERNAL_MOUNT_POINT=/external \
-    MAX_JVM_SIZE=\
+
+ENV MAX_JVM_SIZE='' \
     MIN_JVM_SIZE=1G \
     INIT_RAM_PERCENT=10\
     MAX_RAM_PERCENT=93\
@@ -55,44 +63,37 @@ ENV CATALINA_HOME=/usr/local/tomcat \
 ARG IMAGE_NAME=''
 
 ENV JPDA_ADDRESS=*:5050 \
-    CATALINA_PID=${CATALINA_HOME}/bin/catalina.pid \
-    SERVER_CONFIG_DIR=${CATALINA_HOME}/firefly-config \
-    FIREFLY_WORK_DIR=${CATALINA_HOME}/firefly-work \
-    FIREFLY_SHARED_WORK_DIR='' \
-    VISUALIZE_FITS_SEARCH_PATH=${EXTERNAL_MOUNT_POINT} \
+    VISUALIZE_FITS_SEARCH_PATH='' \
     BUILD_TIME_NAME=${IMAGE_NAME} \
     START_MODE=run
 
 WORKDIR ${CATALINA_HOME}
 
 # set up directory protections, copy stuff around, add tomcat user and group
-RUN mkdir -p bin conf conf/Catalina/localhost lib logs temp webapps work /local/www && \
-    chmod +rw ${CATALINA_HOME}/conf/* && \
-    chmod 777 /local /local/www conf && \
-    chmod -R +rX ${CATALINA_HOME} &&\
-    groupadd -g 91 tomcat && \
-    useradd -r -u 91 -g tomcat tomcat
+RUN mkdir -p conf/Catalina/localhost /local/www /firefly/config /firefly/workarea /firefly/shared-workarea /firefly/logs/statistics /firefly/alerts &&  \
+    rm -r logs && ln -s /firefly/logs logs &&  \
+    chmod -R 777 /firefly && \
+    chmod 777 webapps temp work /local /local/www conf && \
+    chmod +rw conf/*
 
 # These are the file that are executed at startup: start tomcat, logging, help, etc
 COPY *.sh *.txt ${CATALINA_HOME}/
 
 # Tomcat config files, tomcat-users is for the admin username and password
 # context.xml set delegate to true for we can use the classpath of tomcat
-COPY tomcat-users.xml context.xml  ${CATALINA_HOME}/conf/
-COPY local.xml ${CATALINA_HOME}/conf/Catalina/localhost
+COPY tomcat-users.xml context.xml  conf/
+COPY local.xml conf/Catalina/localhost
 
 # Make directories, make scripts executable, save old tomcat config files, remove unwanted apps
 # increase max header size to avoid failing on large auth token
-RUN chmod +x ${CATALINA_HOME}/*.sh; \
-    mkdir -p ${SERVER_CONFIG_DIR} ${FIREFLY_WORK_DIR} ${EXTERNAL_MOUNT_POINT}; \
-    chmod 777 bin conf lib logs temp webapps work ${CATALINA_HOME} ${SERVER_CONFIG_DIR} ${FIREFLY_WORK_DIR}; \
-    mv ${CATALINA_HOME}/conf/tomcat-users.xml ${CATALINA_HOME}/conf/tomcat-users.xml.in; \
+RUN chmod +x *.sh; \
+    mv conf/tomcat-users.xml conf/tomcat-users.xml.in; \
     sed -i 's/Connector port="8080"/Connector maxHttpHeaderSize="24576" port="8080"/g' ${CATALINA_HOME}/conf/server.xml
 
 # 8080 - http,  5050 - debug
 EXPOSE 8080 5050
 
-USER tomcat:tomcat
+USER 91:91
 
 #copy all wars, typically there should only be one
 COPY *.war ${CATALINA_HOME}/webapps/

--- a/docker/base/customize-firefly.txt
+++ b/docker/base/customize-firefly.txt
@@ -4,10 +4,10 @@ Customize:
    Replacing the launch page - index.html or slate.html with your own with different configurations
       - first extract and prepare you file from the example
            - create a empty directory to map to the container (example - mkdir /myDir)
-           > docker run --rm  -v /myDir:local/www  --name firefly ipac/firefly:latest --help
+           > docker run --rm  -v /myDir:/local/www  --name firefly ipac/firefly:latest --help
            - if the directory was empty, the container will place example html files into it.
            - edit index.html to you liking (example - /myDir/index.html)
-      > docker run -p 80:8080 -v /myDir:local/www -m 4g --rm --name firefly ipac/firefly:latest
-      - firefly maps this directory to "local"
+      > docker run -p 80:8080 -v /myDir:/local/www -m 4g --rm --name firefly ipac/firefly:latest
+      - firefly maps this directory to "/local"
       - start firefly with your alternative launch page- with http://localhost/local/ or http://localhost/local/myFireflyPage.html
 

--- a/docker/base/launchTomcat.sh
+++ b/docker/base/launchTomcat.sh
@@ -20,31 +20,38 @@ echo "!!============================================================"
 echo "!!============================================================"
 echo -e "!!============================================================\n\n"
 
-echo "========== Information:  you can set properties using -e on docker run line =====  "
+echo "========== Information:  you can set environment varible using -e on docker run line =====  "
 echo 
-echo "Properties: "
-echo "        Description                  Property                 Value"
-echo "        -----------                  --------                 -----"
-echo "        Min JVM size (*)             MIN_JVM_SIZE            ${MIN_JVM_SIZE}${MM_NOT_USED}"
-echo "        Max JVM size (*)             MAX_JVM_SIZE            ${MAX_JVM_SIZE}${MM_NOT_USED}"
-echo "        Initial JVM size (**)        INIT_RAM_PERCENT        ${INIT_RAM_PERCENT}${PER_NOT_USED}"
-echo "        Max JVM size (**)            MAX_RAM_PERCENT         ${MAX_RAM_PERCENT}${PER_NOT_USED}"
-echo "        CPU cores (0 means guess)    JVM_CORES               ${JVM_CORES}"
-echo "        Admin username               ADMIN_USER              ${ADMIN_USER}"
-echo "        Admin password               ADMIN_PASSWORD          ${ADMIN_PASSWORD}"
-echo "        Run tomcat with debug        DEBUG                   ${DEBUG}"
-echo "        Extra firefly properties     FIREFLY_OPTS            ${FIREFLY_OPTS}"
-echo "        Shared work Area             FIREFLY_SHARED_WORK_DIR ${FIREFLY_SHARED_WORK_DIR}"
-echo "(*)  If MAX_JVM_SIZE is blank, autosizing properties INIT_RAM_PERCENT and MAX_RAM_PERCENT are used instead"
-echo "(**) Autosizing properties INIT_RAM_PERCENT and MAX_RAM_PERCENT are not used if MAX_JVM_SIZE is set"
+echo "Using Environment Variables: \n"
+echo "        Description                  Name                       Value"
+echo "        -----------                  --------                   -----"
+echo "        Admin username               ADMIN_USER                 ${ADMIN_USER}"
+echo "        Admin password               ADMIN_PASSWORD             ${ADMIN_PASSWORD}"
+echo "        Additional data path         VISUALIZE_FITS_SEARCH_PATH ${VISUALIZE_FITS_SEARCH_PATH}"
+echo
+echo "  Advanced environment variables:"
+echo "        Min JVM size (*)             MIN_JVM_SIZE               ${MIN_JVM_SIZE}${MM_NOT_USED}"
+echo "        Max JVM size (*)             MAX_JVM_SIZE               ${MAX_JVM_SIZE}${MM_NOT_USED}"
+echo "        Initial JVM size (**)        INIT_RAM_PERCENT           ${INIT_RAM_PERCENT}${PER_NOT_USED}"
+echo "        Max JVM size (**)            MAX_RAM_PERCENT            ${MAX_RAM_PERCENT}${PER_NOT_USED}"
+echo "        CPU cores (0 means guess)    JVM_CORES                  ${JVM_CORES}"
+echo "        Run tomcat with debug        DEBUG                      ${DEBUG}"
+echo "        Extra firefly properties     FIREFLY_OPTS               ${FIREFLY_OPTS}"
+echo "  (*)  If MAX_JVM_SIZE is blank, autosizing properties INIT_RAM_PERCENT and MAX_RAM_PERCENT are used instead"
+echo "  (**) Autosizing properties INIT_RAM_PERCENT and MAX_RAM_PERCENT are not used if MAX_JVM_SIZE is set"
 echo
 echo "Ports: "
 echo "        8080 - http"
 echo "        5050 - debug"
 echo
 echo "Volume Mount Points: "
-echo "        Log directory : ${CATALINA_HOME}/logs : Directory for logs files"
-echo "        Local Images  : /local/data : Root directory for images and tables that firefly can read"
+echo "    /firefly/config           : used to override application properties"
+echo "    /firefly/workarea         : work area for temporary files"
+echo "    /firefly/shared-workarea  : work area for files that are shared between multiple instances of the application"
+echo "    /firefly/logs             : logs directory"
+echo "    /firefly/logs/statistics  : directory for statistics logs"
+echo "    /firefly/alerts           : alerts monitor will watch this directory for application alerts"
+echo "    /external                 : default external data directory visible to Firefly"
 echo
 echo "Command line options: "
 echo "        --help  : show help message, examples, stop"
@@ -67,31 +74,35 @@ if [ "$1" = "--help" ] || [ "$1" = "-help" ] || [ "$1" = "-h" ]; then
     exit 0
 fi
 
-if [ "x$FIREFLY_SHARED_WORK_DIR" != "x" ]; then
-      mkdir -p ${FIREFLY_SHARED_WORK_DIR}
-fi
-
-
 if [ -z ${MAX_JVM_SIZE} ]; then
    JVM_SIZING="-XX:InitialRAMPercentage=${INIT_RAM_PERCENT} -XX:MaxRAMPercentage=${MAX_RAM_PERCENT}"
 else
    JVM_SIZING="-Xms${MIN_JVM_SIZE} -Xmx${MAX_JVM_SIZE}"
 fi
 
+if [ -z ${VISUALIZE_FITS_SEARCH_PATH} ]; then
+   VIS_PATH="/external"
+else
+   VIS_PATH="/external:${VISUALIZE_FITS_SEARCH_PATH}"
+fi
+
 #---------   CATALINA_OPTS must be exported for catalina.sh to pick them up
 export CATALINA_OPTS="\
-        ${JVM_SIZING} \
-        -Dserver.cores=${JVM_CORES} \
-        -Djava.net.preferIPv4Stack=true \
-        -Dnet.sf.ehcache.enableShutdownHook=true \
-        -Dserver_config_dir=${SERVER_CONFIG_DIR} \
-        -Dwork.directory=${FIREFLY_WORK_DIR} \
-        -Dshared.work.directory=${FIREFLY_SHARED_WORK_DIR} \
-        -Dvisualize.fits.search.path=${VISUALIZE_FITS_SEARCH_PATH} \
-	   ${FIREFLY_OPTS}"
+  ${JVM_SIZING} \
+  -Dhost.name=${HOSTNAME} \
+  -Dserver.cores=${JVM_CORES} \
+  -Djava.net.preferIPv4Stack=true \
+  -Dwork.directory=/firefly/workarea \
+  -Dshared.work.directory=/firefly/shared-workarea \
+  -Dserver_config_dir=/firefly/config \
+  -Dstats.log.dir=/firefly/logs/statistics \
+  -Dalerts.dir=/firefly/alerts \
+  -Dvisualize.fits.search.path=${VIS_PATH} \
+	${FIREFLY_OPTS}"
+
 
 #------- start background scripts: cleanup and log to console
-${CATALINA_HOME}/cleanup.sh ${FIREFLY_WORK_DIR} ${FIREFLY_SHARED_WORK_DIR} &
+${CATALINA_HOME}/cleanup.sh /firefly/workarea /firefly/shared-workarea &
 ${CATALINA_HOME}/sendLogsToConsole.sh &
 
 echo "launchTomcat.sh: Starting Tomcat"

--- a/docker/base/launchTomcat.sh
+++ b/docker/base/launchTomcat.sh
@@ -20,7 +20,7 @@ echo "!!============================================================"
 echo "!!============================================================"
 echo -e "!!============================================================\n\n"
 
-echo "========== Information:  you can set environment varible using -e on docker run line =====  "
+echo "========== Information:  you can set environment variable using -e on docker run line =====  "
 echo 
 echo "Using Environment Variables: \n"
 echo "        Description                  Name                       Value"
@@ -45,13 +45,15 @@ echo "        8080 - http"
 echo "        5050 - debug"
 echo
 echo "Volume Mount Points: "
-echo "    /firefly/config           : used to override application properties"
+echo "    /firefly/logs             : logs directory"
 echo "    /firefly/workarea         : work area for temporary files"
 echo "    /firefly/shared-workarea  : work area for files that are shared between multiple instances of the application"
-echo "    /firefly/logs             : logs directory"
+echo "    /external                 : default external data directory visible to Firefly"
+echo
+echo "  Less used:"
+echo "    /firefly/config           : used to override application properties"
 echo "    /firefly/logs/statistics  : directory for statistics logs"
 echo "    /firefly/alerts           : alerts monitor will watch this directory for application alerts"
-echo "    /external                 : default external data directory visible to Firefly"
 echo
 echo "Command line options: "
 echo "        --help  : show help message, examples, stop"

--- a/docker/base/setupFireflyExample.sh
+++ b/docker/base/setupFireflyExample.sh
@@ -10,8 +10,8 @@ onlyWar=`echo ${aWarFile} | awk -F/ '{print $NF}'`
 dirEmpty=`find /local/www -maxdepth 0 -empty -exec echo true \;`
 if [ "$onlyWar" = "firefly.war" ] && [ "$dirEmpty" = "true" ]; then
     echo "Alt Entry Point: beginning set up example"
-    mkdir tmp-expand
-    cd tmp-expand
+    mkdir /local/tmp-expand
+    cd /local/tmp-expand
     unzip -d . ${aWarFile} firefly.html slate.html firefly-dev.html
     mv slate.html slate-old.html
     mv firefly-dev.html firefly-dev-old.html
@@ -20,6 +20,6 @@ if [ "$onlyWar" = "firefly.war" ] && [ "$dirEmpty" = "true" ]; then
     cat firefly-dev-old.html | sed -e s,firefly_loader.js,/firefly/firefly_loader.js, > firefly-dev.html
     cp {index,slate,firefly-dev}.html /local/www
     cd ..
-    rm -r tmp-expand
+    rm -r /local/tmp-expand
     echo "Alt Entry Point: setting up example: index.html, slate.html, firefly-dev.html in /www/local"
 fi

--- a/docker/base/start-examples.txt
+++ b/docker/base/start-examples.txt
@@ -30,18 +30,18 @@ Map a directory for direct file reading:
    - start firefly with - http://localhost/firefly/
 
 Write to logging directory outside of docker image:
-   > docker run -p 80:8080 -v /local/myLogDir:/usr/local/tomcat-base/logs --memory=8g --rm ipac/firefly:latest
+   > docker run -p 80:8080 -v /local/myLogDir:/firefly/logs --memory=8g --rm ipac/firefly:latest
    - start firefly with - http://localhost/firefly/
 
 Debugging:
-   > docker run -p 8055:8080 -p 5050:5050 -p 9050:9050 --memory=4g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="TRUE" --rm --name firefly ipac/firefly:latest
+   > docker run -p 8055:8080 -p 5050:5050 --memory=4g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="TRUE" --rm --name firefly ipac/firefly:latest
    - start firefly with - http://localhost:8055/firefly/
 
 Production like:
-   > docker run -p 8055:8080 -p 9050:9050 --memory=30g -e "ADMIN_PASSWORD=myPassword" -e -e DEBUG="FALSE" --name productionServer ipac/firefly:latest
+   > docker run -p 8055:8080 -p --memory=30g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="FALSE" --name productionServer ipac/firefly:latest
    - start firefly with - http://localhost:8055/firefly/
 
 Production like, multiple tomcats, using a shared work directory:
-   > docker run -p 8055:8080 -p 9050:9050 --memory=30g -e "ADMIN_PASSWORD=myPassword" \
-             -e "FIREFLY_SHARED_WORK_DIR=/local/shared/work/area" -v /local/shared/work/area --name productionServer ipac/firefly:latest
+   > docker run -p 8055:8080 -p --memory=30g -e "ADMIN_PASSWORD=myPassword" \
+             -v /local/shared/work/area:/firefly/shared-workarea --name productionServer ipac/firefly:latest
    - start firefly with - http://localhost:8055/firefly/

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -78,6 +78,7 @@ public class ServerContext {
     private static final String WORK_DIR_PROP = "work.directory";
     private static final String SHARED_WORK_DIR_PROP= "shared.work.directory";
     public static final String VIS_SEARCH_PATH= "visualize.fits.search.path";
+    public static final String STATS_LOG_DIR= "stats.log.dir";
 
 
     private static RequestOwnerThreadLocal owner = new RequestOwnerThreadLocal();
@@ -167,7 +168,11 @@ public class ServerContext {
         // initializes log4j
         File cfg = getConfigFile("log4j.properties");
         if (cfg.canRead()) {
-            System.out.println("Initializing Log4J using file:" + cfg.getAbsolutePath());
+            String statsDir = AppProperties.getProperty(STATS_LOG_DIR);
+            if (!StringUtils.isEmpty(statsDir)) {
+                initDir(new File(statsDir));
+            }
+            System.out.println(String.format("Initializing Log4J using file: %s  => %s", cfg.getAbsolutePath(), statsDir));
             PropertyConfigurator.configureAndWatch(cfg.getAbsolutePath());
         }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -11,6 +11,7 @@ import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.firefly.server.visualize.VisContext;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.Assert;
+import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.CacheManager;
 import nom.tam.fits.FitsFactory;
@@ -100,7 +101,7 @@ public class ServerContext {
     private volatile static String CACHE_PATH_STR;
     private volatile static String IRSA_ROOT_PATH_STR;
 
-
+    public static final String ACCESS_TEST_EXT= "access.test";
 
 
     private static final Logger.LoggerImpl log= Logger.getLogger();
@@ -209,6 +210,13 @@ public class ServerContext {
         if (!StringUtils.isEmpty(sharedWorkDirRoot)) {
             sharedWorkingDirFile= initDir(new File(sharedWorkDirRoot));
             setSharedWorkingDir(new File(sharedWorkingDirFile, contextName));
+            try {
+                File f= new File(getSharedWorkingDir(), FileUtil.getHostname()+"."+ACCESS_TEST_EXT);
+                if (f.canWrite()) f.delete();
+                f.createNewFile();
+            } catch (IOException e) {
+                Logger.error("Could not create a test file in "+ getSharedWorkingDir().toString());
+            }
         }
 
 
@@ -334,6 +342,16 @@ public class ServerContext {
         return initDir(workingDir);
     }
 
+
+    /**
+     * Don't use this call, it does not guarantee a safe dir
+     * @return File the original requested SharedWorkingDirRequested, may not be a good directory
+     */
+    public static File getSharedWorkingDirRequested() {
+        return sharedWorkingDir;
+    }
+
+
     public static File getSharedWorkingDir() {
         if (sharedWorkingDir==null) return getWorkingDir();
         initDir(sharedWorkingDir);
@@ -349,6 +367,9 @@ public class ServerContext {
 
     public static void setSharedWorkingDir(File sharedWorkDir) {
         sharedWorkingDir = sharedWorkDir;
+        if (!sharedWorkingDir.canWrite()) {
+            Logger.getLogger().error("Cannot write to Shared Worked Dir: " + sharedWorkDir.toString());
+        }
     }
 
     public static File getHiPSDir() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -4,11 +4,13 @@
 package edu.caltech.ipac.firefly.server.servlets;
 
 import edu.caltech.ipac.firefly.messaging.Messenger;
+import edu.caltech.ipac.firefly.server.Counters;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
 import edu.caltech.ipac.firefly.server.packagedata.PackagingController;
-import edu.caltech.ipac.firefly.server.Counters;
+import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CachePeerProviderFactory;
@@ -21,6 +23,7 @@ import net.sf.ehcache.statistics.StatisticsGateway;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.rmi.RemoteException;
@@ -28,10 +31,14 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static edu.caltech.ipac.firefly.server.ServerContext.ACCESS_TEST_EXT;
+
 
 /**
  * Date: Jun 3, 2009
@@ -50,6 +57,9 @@ public class ServerStatus extends BaseHttpServlet {
         PrintWriter writer = res.getWriter();
         try {
             showCountStatus(writer);
+            skip(writer);
+
+            showWorkAreaStatus(writer);
             skip(writer);
 
             showPackagingStatus(writer);
@@ -167,6 +177,50 @@ public class ServerStatus extends BaseHttpServlet {
 
     private static void showCountStatus(PrintWriter w) {
         w.println(StringUtils.toString(Counters.getInstance().reportStatus(), "\n"));
+    }
+
+
+    private static void showWorkAreaStatus(PrintWriter w) {
+        w.println("Work Areas");
+        w.println("  - Internal: " + ServerContext.getWorkingDir().toString());
+        File sharedDir= ServerContext.getSharedWorkingDir();
+        if (sharedDir.equals(ServerContext.getWorkingDir())) {
+            File sharedDirRequested= ServerContext.getSharedWorkingDirRequested();
+            if (sharedDirRequested!=null && !sharedDirRequested.canWrite()) {
+                w.println("  - Shared working dir does not have write access, using Internal work area");
+                w.println("  - Shared (failed): " + ServerContext.getSharedWorkingDirRequested());
+            }
+            else {
+                w.println("  - No Shared work area defined.");
+            }
+        }
+        else {
+            w.println("  - Shared:   " + sharedDir.toString());
+            File [] matchFiles= FileUtil.listFilesWithExtension(sharedDir, ACCESS_TEST_EXT);
+            if (matchFiles.length==0) return;
+            int maxLen= 5;
+            Arrays.sort(matchFiles, (f1,f2) -> (int)(f2.lastModified()-f1.lastModified()));
+            w.println("              Most recent host using the shared working directory:");
+            int len= Math.min(maxLen,matchFiles.length);
+            for(int i=0; (i<len); i++) {
+                File f= matchFiles[i];
+                String hostname= f.getName().substring(0,f.getName().length()- ACCESS_TEST_EXT.length()-1);
+                String detailStr= hostname.equals(FileUtil.getHostname()) ? "(self) " : "";
+                if (isDocker(hostname)) detailStr+= "(probably Docker)";
+                w.println(String.format( "%19s%-20s  --  %s %s",
+                        "- ", hostname, new Date(f.lastModified()).toString(), detailStr ));
+            }
+            if (matchFiles.length>maxLen) w.println("              and " + (matchFiles.length-maxLen) + " more");
+        }
+    }
+
+    private static boolean isDocker(String hostname) {
+        try {
+            Long.parseLong(hostname, 16);
+            return true;
+        } catch (NumberFormatException ignored) {
+            return false;
+        }
     }
 
     private static void showEventsStatus(PrintWriter w) {

--- a/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
@@ -74,6 +74,8 @@ public class FileUtil
 
     public enum ConvertTo {MEG,GIG,K}
 
+    private static String hostNameReturn= null;
+
   private final static String  ADD_START= "---";
 
     /**
@@ -749,6 +751,7 @@ public class FileUtil
     }
 
     public static String getHostname() {
+        if (hostNameReturn!=null) return hostNameReturn;
         String retHost= "UNKNOWN_HOST";
         try {
             String host= InetAddress.getLocalHost().getHostName();
@@ -774,6 +777,7 @@ public class FileUtil
         } catch (UnknownHostException e) {
             retHost= "UNKNOWN_HOST";
         }
+        hostNameReturn= retHost;
         return retHost;
     }
 


### PR DESCRIPTION
- remove unused variables
- predefine Firefly runtime directories, making it easier for user to mount into
- move statistics directory into logs/statistics
- VISUALIZE_FITS_SEARCH_PATH now defaults to blank.  Setting it will append to the '/external' set by default.