### PR TITLE
Firefly-677: service descriptors support

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -4,6 +4,7 @@
 
 package edu.caltech.ipac.firefly.core;
 
+import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.messaging.JsonHelper;
 import edu.caltech.ipac.firefly.server.dpanalyze.DataProductAnalyzer;
 import edu.caltech.ipac.firefly.server.dpanalyze.DataProductAnalyzerFactory;
@@ -36,20 +37,18 @@ import static edu.caltech.ipac.util.StringUtils.isEmpty;
 public class FileAnalysis {
 
     public static FileAnalysisReport analyze(File infile, FileAnalysisReport.ReportType type) throws Exception {
-        return analyze(infile,type,null,Collections.emptyMap());
-    }
-    public static FileAnalysisReport analyze(File infile, FileAnalysisReport.ReportType type, String analyzerId, Map<String,String> params) throws Exception {
-       return analyze(infile,type,analyzerId,params,200,null);
+        return analyze(new FileInfo(infile),type,null,Collections.emptyMap());
     }
 
-    public static FileAnalysisReport analyze(File infile,
+    public static FileAnalysisReport analyze(FileInfo fileInfo,
                                              FileAnalysisReport.ReportType type,
                                              String analyzerId,
-                                             Map<String,String> params,
-                                             int responseCode,
-                                             String contentType ) throws Exception {
+                                             Map<String,String> params) throws Exception {
 
         FileAnalysisReport.ReportType mtype = type == FileAnalysisReport.ReportType.Brief ? FileAnalysisReport.ReportType.Normal : type;
+        File infile= fileInfo.getFile();
+        int responseCode= fileInfo.getResponseCode();
+        String contentType= fileInfo.getContentType();
 
         Format format = TableUtil.guessFormat(infile);
         FileAnalysisReport report= null;

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -13,11 +13,14 @@ import edu.caltech.ipac.table.TableUtil.Format;
 import edu.caltech.ipac.table.io.DsvTableIO;
 import edu.caltech.ipac.table.io.IpacTableReader;
 import edu.caltech.ipac.table.io.VoTableReader;
+import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.FitsHDUUtil;
+import nom.tam.fits.FitsException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -35,8 +38,16 @@ public class FileAnalysis {
     public static FileAnalysisReport analyze(File infile, FileAnalysisReport.ReportType type) throws Exception {
         return analyze(infile,type,null,Collections.emptyMap());
     }
-
     public static FileAnalysisReport analyze(File infile, FileAnalysisReport.ReportType type, String analyzerId, Map<String,String> params) throws Exception {
+       return analyze(infile,type,analyzerId,params,200,null);
+    }
+
+    public static FileAnalysisReport analyze(File infile,
+                                             FileAnalysisReport.ReportType type,
+                                             String analyzerId,
+                                             Map<String,String> params,
+                                             int responseCode,
+                                             String contentType ) throws Exception {
 
         FileAnalysisReport.ReportType mtype = type == FileAnalysisReport.ReportType.Brief ? FileAnalysisReport.ReportType.Normal : type;
 
@@ -44,13 +55,24 @@ public class FileAnalysis {
         FileAnalysisReport report= null;
         DataProductAnalyzer dpA= DataProductAnalyzerFactory.getAnalyzer(analyzerId);
         FileAnalysisReport productReport= null;
+        if (responseCode>=400) {
+            return analyzeError(infile, responseCode, contentType);
+        }
+        if (contentType!=null && contentType.toLowerCase().equals("text/html")) {
+            return analyzeLoadInBrowser(infile, contentType);
+        }
         switch (format) {
             case VO_TABLE:
                 report = VoTableReader.analyze(infile, mtype);
                 break;
             case FITS:
-                FitsHDUUtil.FitsAnalysisReport rep = FitsHDUUtil.analyze(infile, mtype);
-                productReport= dpA.analyzeFits(rep.getReport(),infile,analyzerId,params,rep.getHeaderAry());
+                try {
+                    FitsHDUUtil.FitsAnalysisReport rep = FitsHDUUtil.analyze(infile, mtype);
+                    productReport= dpA.analyzeFits(rep.getReport(),infile,analyzerId,params,rep.getHeaderAry());
+                }
+                catch (FitsException e) {
+                    return analyzeFITSError(infile, e.getMessage());
+                }
                 break;
             case IPACTABLE:
                 report = IpacTableReader.analyze(infile, mtype);
@@ -173,5 +195,53 @@ public class FileAnalysis {
         FileAnalysisReport report = new FileAnalysisReport(type, TableUtil.Format.TAR.name(), infile.length(), infile.getPath());
         report.addPart(new FileAnalysisReport.Part(FileAnalysisReport.Type.TAR, "TAR File"));
         return report;
+    }
+
+    private static FileAnalysisReport analyzeError(File infile, int responseCode, String contentType) {
+        FileAnalysisReport report = new FileAnalysisReport(
+                FileAnalysisReport.ReportType.Details, Format.UNKNOWN.name(),
+                infile.length(), infile.getPath());
+        FileAnalysisReport.Part part= new FileAnalysisReport.Part(FileAnalysisReport.Type.ErrorResponse, "Error");
+        part.setDesc("Error in File Retrieve: " + responseCode);
+        if (infile.length()<500 && contentType!=null && contentType.toLowerCase().contains("text/plain")) {
+            try {
+                String content = FileUtil.readFile(infile);
+                part.setDesc( content + "\nResponse Code: " + responseCode);
+            } catch (IOException e) { }
+        }
+        report.addPart(part);
+        return report;
+    }
+
+    private static FileAnalysisReport analyzeFITSError(File infile, String msg) {
+        FileAnalysisReport report = new FileAnalysisReport(
+                FileAnalysisReport.ReportType.Details, Format.UNKNOWN.name(),
+                infile.length(), infile.getPath());
+        FileAnalysisReport.Part part= new FileAnalysisReport.Part(FileAnalysisReport.Type.ErrorResponse, "Error");
+        part.setDesc("Error in FITS Reading: " + msg);
+        report.addPart(part);
+        return report;
+    }
+
+    private static FileAnalysisReport analyzeLoadInBrowser(File infile, String contentType) {
+        FileAnalysisReport report = new FileAnalysisReport( FileAnalysisReport.ReportType.Details, Format.HTML.name(),
+                infile.length(), infile.getPath());
+        FileAnalysisReport.Part part= new FileAnalysisReport.Part(FileAnalysisReport.Type.LoadInBrowser, "Load in browser");
+        part.setDesc("Send to browser");
+        report.addPart(part);
+        return report;
+
+
+    }
+
+    public static FileAnalysisReport makeReportFromException(Exception e) {
+        FileAnalysisReport report = new FileAnalysisReport( FileAnalysisReport.ReportType.Details,
+                Format.UNKNOWN.name(), 0, "");
+        FileAnalysisReport.Part part= new FileAnalysisReport.Part(FileAnalysisReport.Type.ErrorResponse, "Error");
+        part.setDesc("Error in File Retrieve: " + e.getMessage());
+        report.addPart(part);
+        return report;
+
+
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
@@ -26,7 +26,7 @@ public class FileAnalysisReport {
         Normal,             // a report with all parts populated, but not details
         Details}            // a full report with details
 
-    public enum Type {Image, Table, Spectrum, HeaderOnly, PDF, TAR, Unknown}
+    public enum Type {Image, Table, Spectrum, HeaderOnly, PDF, TAR, ErrorResponse, LoadInBrowser, Unknown}
     public enum UIRender {Table, Chart, Image, NotSpecified}
     public enum UIEntry {UseSpecified, UseGuess, UseAll}
     public enum ChartTableDefOption {auto, showChart, showTable, showImage};

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
@@ -22,6 +22,7 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
     public static final String RESPONSE_CODE = "responseCode";
     public static final String RESPONSE_CODE_MSG = "responseCodeMsg";
     public static final String FILE_DOWNLOADED= "fileDownloaded";
+    public static final String CONTENT_TYPE= "contentType";
     public static final String SIZE_IN_BYTES= "sizeInBytes";
     public static final String DESC="desc";
     public static final String BLANK="blank";
@@ -56,12 +57,17 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
         this.resolver = resolver;
     }
 
-    public FileInfo(File file, String desc) { this(file, null, desc, 200, "OK"); }
+    public FileInfo(File file, String desc) { this(file, null, desc, 200, "OK", null); }
 
     public FileInfo(File file) { this(file, file.getName(), 200, "OK"); }
 
+
+    public FileInfo(File file, String externalName, int responseCode, String responseCodeMsg, String contentType) {
+        this(file, externalName, externalName, responseCode, responseCodeMsg, contentType);
+    }
+
     public FileInfo(File file, String externalName, int responseCode, String responseCodeMsg) {
-        this(file, externalName, externalName, responseCode, responseCodeMsg);
+        this(file, externalName, externalName, responseCode, responseCodeMsg, null);
     }
 
 
@@ -69,11 +75,12 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
         this(file, file!=null?file.getName():"", responseCode, ResponseMessage.getHttpResponseMessage(responseCode));
     }
 
-    private FileInfo(File file, String externalName, String desc, int responseCode, String responseCodeMsg) {
+    private FileInfo(File file, String externalName, String desc, int responseCode, String responseCodeMsg, String contentType) {
         setInternalName( file != null ? file.getAbsolutePath() : null);
         putAttribute(RESPONSE_CODE, responseCode + "");
         putAttribute(RESPONSE_CODE_MSG, responseCodeMsg!=null ? responseCodeMsg : "");
         setSizeInBytes(file != null ? file.length()  : -1 );
+        if (contentType!=null) putAttribute(CONTENT_TYPE, contentType);
 
         if (externalName != null) {
             setExternalName(externalName);
@@ -138,6 +145,8 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
     public String getInternalFilename() { return getAttribute(INTERNAL_NAME); }
 
     public String getExternalName() { return getAttribute(EXTERNAL_NAME); }
+
+    public String getContentType() { return getAttribute(CONTENT_TYPE); }
 
     public void setInternalName(String filename) {
         if (filename!=null) putAttribute(INTERNAL_NAME,filename);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -214,6 +214,7 @@ public class ServerContext {
                 File f= new File(getSharedWorkingDir(), FileUtil.getHostname()+"."+ACCESS_TEST_EXT);
                 if (f.canWrite()) f.delete();
                 f.createNewFile();
+                f.deleteOnExit();
             } catch (IOException e) {
                 Logger.error("Could not create a test file in "+ getSharedWorkingDir().toString());
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
@@ -8,6 +8,7 @@ import edu.caltech.ipac.astro.net.HorizonsEphPairs;
 import edu.caltech.ipac.astro.net.Resolver;
 import edu.caltech.ipac.firefly.core.FileAnalysis;
 import edu.caltech.ipac.firefly.core.FileAnalysisReport;
+import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.server.ServCommand;
 import edu.caltech.ipac.firefly.server.SrvParam;
@@ -16,6 +17,7 @@ import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.visualize.plot.ResolvedWorldPt;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -110,7 +112,7 @@ public class ResolveServerCommands {
                 FileAnalysisReport.ReportType reportType = StringUtils.isEmpty(rtype) ? FileAnalysisReport.ReportType.Brief : FileAnalysisReport.ReportType.valueOf(rtype);   // defaults to Brief
 
                 FileAnalysisReport report = FileAnalysis.analyze(
-                        new File(infile), reportType,
+                        new FileInfo(new File(infile)), reportType,
                         sp.getOptional(ANALYZER_ID),
                         sp.getParamMapUsingExcludeList(Arrays.asList("filePath","reportType")));
                 return FileAnalysis.toJsonString(report);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
@@ -162,6 +162,17 @@ public class AnyFileDownload extends BaseHttpServlet {
             res.setStatus(304);
             return;
         }
+
+        if (fi.getExternalName()!=null && fi.getExternalName().length()>2) {
+            String ext = FileUtil.getExtension(fileName);
+            if (ext.length() > 4 || ext.length() < 3 || fileName.indexOf('&') > -1 || fileName.indexOf('=') > -1) {
+                String ftest = fi.getExternalName();
+                if (ftest.startsWith("\"")) ftest = ftest.substring(1);
+                if (ftest.endsWith("\"")) ftest = ftest.substring(0, ftest.length() - 1);
+                fileName = ftest;
+            }
+        }
+
         if (fullBody) {
             String local= sp.getOptional(RETURN_PARAM);
             String retFileStr= (local!=null) ? local : fileName;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/FileRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/FileRetriever.java
@@ -13,4 +13,8 @@ import edu.caltech.ipac.visualize.plot.plotdata.GeomException;
  */
 public interface FileRetriever {
     FileInfo getFile(WebPlotRequest request) throws FailedRequestException, GeomException, SecurityException;
+    default FileInfo getFile(WebPlotRequest request, boolean handleAllErrors)
+            throws FailedRequestException, GeomException, SecurityException {
+        return getFile(request);
+    }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
@@ -48,6 +48,10 @@ public class URLFileRetriever implements FileRetriever {
             Arrays.asList(FileUtil.FITS, FileUtil.GZ, "tar", FileUtil.PDF, "votable", "tbl", "csv", "tsv");
 
     public FileInfo getFile(WebPlotRequest request) throws FailedRequestException, GeomException, SecurityException {
+       return getFile(request,true);
+    }
+
+    public FileInfo getFile(WebPlotRequest request, boolean handleAllErrors) throws FailedRequestException, GeomException, SecurityException {
         FileInfo fitsFileInfo;
         String urlStr = request.getURL();
         if (urlStr.toLowerCase().startsWith("file:///")) {
@@ -85,7 +89,7 @@ public class URLFileRetriever implements FileRetriever {
             fitsFileInfo = LockingVisNetwork.retrieveURL(params);
 
             int responseCode= fitsFileInfo.getResponseCode();
-            if (responseCode>=400) {
+            if (responseCode>=400 && handleAllErrors) {
                 throw new FailedRequestException(fitsFileInfo.getResponseCodeMsg());
             }
 

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -273,7 +273,7 @@ public class TableUtil {
 //====================================================================
 
     public enum Format { TSV(CSVFormat.TDF, ".tsv"), CSV(CSVFormat.DEFAULT, ".csv"), IPACTABLE(".tbl"), UNKNOWN(null),
-                         FIXEDTARGETS(".tbl"), FITS(".fits"), JSON(".json"), PDF(".pdf"), TAR(".tar"),
+                         FIXEDTARGETS(".tbl"), FITS(".fits"), JSON(".json"), PDF(".pdf"), TAR(".tar"), HTML(".html"),
                          VO_TABLE(".xml"), VO_TABLE_TABLEDATA(".vot"), VO_TABLE_BINARY(".vot"), VO_TABLE_BINARY2(".vot"),
                          VO_TABLE_FITS(".vot");
         public CSVFormat type;

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -386,7 +386,7 @@ public class URLDownload {
             netCopy(in, out, conn, maxFileSize, dl);
 
             long elapse = System.currentTimeMillis() - start;
-            outFileData = new FileInfo(f, suggested, responseCode, ResponseMessage.getHttpResponseMessage(responseCode));
+            outFileData = new FileInfo(f, suggested, responseCode, ResponseMessage.getHttpResponseMessage(responseCode), contentType );
             logDownload(outFileData, conn.getURL().toString(), elapse );
 
             if (responseCode>=300 && responseCode<400) {

--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -7,6 +7,7 @@ import {get} from 'lodash';
 import {firefly} from './Firefly.js';
 import {mergeObjectOnly} from './util/WebUtil.js';
 import {getFireflyViewerWebApiCommands} from './api/webApiCommands/ViewerWebApiCommands';
+import {getLcCommands} from './api/webApiCommands/LcWebApiCommands.js';
 
 
 /**
@@ -47,7 +48,7 @@ const {template}= props;
 let apiCommands;
 
 if (template==='FireflyViewer' || template==='FireflySlate') apiCommands= getFireflyViewerWebApiCommands();
-else if (template==='LightCurveViewer') apiCommands= getFireflyViewerWebApiCommands(['table']); // todo add commands for time series viewer
+else if (template==='LightCurveViewer') apiCommands= getLcCommands();
 
 firefly.bootstrap(props, options, apiCommands);
 

--- a/src/firefly/js/api/webApiCommands/LcWebApiCommands.js
+++ b/src/firefly/js/api/webApiCommands/LcWebApiCommands.js
@@ -1,0 +1,54 @@
+import {isEmpty} from 'lodash';
+import {makeExamples} from '../WebApi.js';
+import {dispatchShowDropDown} from '../../core/LayoutCntlr.js';
+
+
+const lcPanelOverview= {
+    overview: [
+        'Load a time series'
+    ],
+    parameters: {
+        url: {desc:'tap service url', isRequired:true},
+        dataset : {desc:'a dataset, must be - neowise, ptf, ztf, lsst_sdss, or generic', isRequired:true},
+        execute: 'true or false - if true execute the tap search'
+    },
+};
+
+const lcPanelExamples= [
+    {
+        desc:'load a time series',
+        params:{
+            url: 'https://irsa.ipac.caltech.edu/cgi-bin/ZTF/nph_light_curves?collection=ztf_dr3&bad_catflags_mask=0&id=695211400134650',
+            dataset: 'ztf',
+            execute: 'true'
+        }
+    },
+];
+
+
+function validateLC(params) {
+    return {valid:true};
+}
+
+function showLcPanel(cmd,params) {
+    const {url, dataset, execute=true, ...rest}= params;
+
+    const newUrl= new URL(url);
+    if (!isEmpty(rest)) {
+        Object.entries(rest).forEach( ([k,v]) => newUrl.searchParams.append(k,v));
+    }
+    dispatchShowDropDown({view:'LCUpload', initArgs:{dataset,execute, url: newUrl.toString()}});
+}
+
+export function getLcCommands() {
+    return [
+        {
+            cmd : 'lc',
+            validate : validateLC,
+            execute:  showLcPanel,
+            allowAdditionalParameters: true,
+            ...lcPanelOverview,
+            examples: makeExamples('lc', lcPanelExamples),
+        },
+    ];
+}

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -348,9 +348,9 @@ function addScatterChanges({changes, chartId, traceNum, tablesource, tableModel}
             const cval = isArray(colors) ? `<br> ${cTipLabel} = ${parseFloat(colors[idx])} ` : '';
             let   ul = '';
             if (annotations[idx]) {
-                if (!isNil(changes[`fireflyData.${traceNum}.yMax`][idx])) {
+                if (!isNil(changes[`fireflyData.${traceNum}.yMax`]?.[idx])) {
                     ul = '<br> Upper Limit ';
-                } else if (!isNil(changes[`fireflyData.${traceNum}.yMin`][idx])) {
+                } else if (!isNil(changes[`fireflyData.${traceNum}.yMin`]?.[idx])) {
                     ul = '<br> Lower Limit ';
                 }
             }

--- a/src/firefly/js/data/FileAnalysis.js
+++ b/src/firefly/js/data/FileAnalysis.js
@@ -7,7 +7,10 @@ export const FileAnalysisType = {
     HeaderOnly: 'HeaderOnly',
     PDF: 'PDF',
     TAR: 'TAR',
-    Unknown: 'Unknown',
+    ErrorResponse: 'ErrorResponse',
+    LoadInBrowser: 'LoadInBrowser',
+    Unknown: 'UNKNOWN',
+    HTML: 'HTML',
 };
 
 export const UIRender = {

--- a/src/firefly/js/metaConvert/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/DataLinkProcessor.js
@@ -14,6 +14,7 @@ import {makeFileAnalysisActivate} from './MultiProductFileAnalyzer';
 import {createSingleImageActivate} from './ImageDataProductsUtil';
 import {dispatchUpdateActiveKey, getActiveMenuKey} from './DataProductsCntlr';
 import {GIG} from '../util/WebUtil.js';
+import {dpdtDownloadMenuItem, dpdtMessageWithDownload} from './DataProductsType.js';
 
 
 
@@ -101,6 +102,8 @@ function convertAllToDownload(menu) {
     }).filter( (d) => d.displayType);
 }
 
+const isThisSem= (semantics) => semantics==='#this';
+const isAuxSem= (semantics) => semantics==='#auxiliary';
 
 /**
  *
@@ -150,7 +153,9 @@ function createDataLinkMenuRet(dataSource, dataLinkData, positionWP, sourceTable
                 let fileType;
                 if (contentType.includes('tar')) fileType= 'tar';
                 if (contentType.includes('gz')) fileType= 'gzip';
-                menuEntry= dpdtDownload('Download file: '+name,url,menuKey,fileType,{semantics, size, activeMenuLookupKey});
+                menuEntry= isThisSem(semantics) ?
+                    dpdtDownloadMenuItem('Download file: '+name,url,menuKey,fileType,{semantics, size, activeMenuLookupKey}) :
+                    dpdtDownload('Download file: '+name,url,menuKey,fileType,{semantics, size, activeMenuLookupKey});
             }
             else if (isImageType(contentType)) {
                 menuEntry= dpdtPNG('Show PNG image: '+name,url,menuKey,{semantics, size, activeMenuLookupKey});
@@ -170,8 +175,8 @@ function createDataLinkMenuRet(dataSource, dataLinkData, positionWP, sourceTable
             }
         }
         menuEntry && menu.push(menuEntry);
-        if (e.semantics==='#auxiliary') auxCnt++;
-        if (e.semantics==='#this') primeCnt++;
+        if (isAuxSem(e.semantics)) auxCnt++;
+        if (isThisSem(e.semantics)) primeCnt++;
     });
     if (additionalServiceDescMenuList) {
         menu.push(...additionalServiceDescMenuList);
@@ -180,8 +185,8 @@ function createDataLinkMenuRet(dataSource, dataLinkData, positionWP, sourceTable
     menu.push(...addDataLinkEntries(dataSource,activateParams));
     return menu
         .sort(({semantics:sem1,name:n1},{semantics:sem2,name:n2}) => {
-            if (sem1==='#this') {
-                if (sem2==='#this') {
+            if (isThisSem(sem1)) {
+                if (isThisSem(sem2)) {
                     if (n1?.includes('(#this)')) return -1;
                     else if (n2?.includes('(#this)')) return 1;
                     else if (n1<n2) return -1;

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -354,6 +354,9 @@ function activateMenuItem(state,action) {
             case DPtypes.DOWNLOAD:
                 dpData.dataProducts= {displayType, name, url, menuKey, menu, activeMenuKey:menuKey, activeMenuLookupKey};
                 break;
+            case DPtypes.DOWNLOAD_MENU_ITEM:
+                dpData.dataProducts= {displayType, name, url, menuKey, menu, activeMenuKey:menuKey, singleDownload: true, activeMenuLookupKey};
+                break;
             case DPtypes.ANALYZE:
                 dpData.dataProducts= {displayType, name, menuKey, menu, activeMenuKey:menuKey, activate,
                                       allowsInput, serDefParams, activeMenuLookupKey, originalTitle};

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -15,8 +15,12 @@ import {getCellValue} from '../tables/TableUtil.js';
 import {makeWorldPt, parseWorldPt} from '../visualize/Point.js';
 import {MetaConst} from '../data/MetaConst.js';
 import {CoordinateSys} from '../visualize/CoordSys.js';
-import {hasObsCoreLikeDataProducts} from '../util/VOAnalyzer.js';
-import {makeObsCoreConverter, getObsCoreSingleDataProduct, getObsCoreGridDataProduct} from './ObsCoreConverter.js';
+import {hasObsCoreLikeDataProducts, hasServiceDescriptors} from '../util/VOAnalyzer.js';
+import {
+    makeObsCoreConverter,
+    getObsCoreGridDataProduct,
+    getObsCoreDataProduct
+} from './ObsCoreConverter.js';
 import {
     createGridImagesActivate,
     createRelatedDataGridActivate,
@@ -28,6 +32,7 @@ import {dispatchUpdateCustom} from '../visualize/MultiViewCntlr';
 import {getDataSourceColumn} from '../util/VOAnalyzer';
 import {getColumn, getMetaEntry} from '../tables/TableUtil';
 import {getAppOptions} from '../core/AppDataCntlr';
+import {getServiceDescSingleDataProduct} from './ServDescConverter.js';
 
 const FILE= 'FILE';
 
@@ -262,8 +267,20 @@ function initConverterTemplates() {
             hasRelatedBands: false,
             canGrid: true,
             maxPlots: 8,
-            getSingleDataProduct: getObsCoreSingleDataProduct,
+            getSingleDataProduct: getObsCoreDataProduct,
             getGridDataProduct: getObsCoreGridDataProduct,
+            getRelatedDataProduct: () => Promise.reject('related data products not supported')
+        },
+        {
+            converterId: 'ServiceDescriptors',
+            tableMatches: hasServiceDescriptors,
+            create: simpleCreate,
+            threeColor: false,
+            hasRelatedBands: false,
+            canGrid: false,
+            maxPlots: 1,
+            getSingleDataProduct: getServiceDescSingleDataProduct,
+            getGridDataProduct: null,
             getRelatedDataProduct: () => Promise.reject('related data products not supported')
         },
         {
@@ -311,20 +328,20 @@ function initConverterTemplates() {
 export const {getConverterTemplates, addTemplate, addTemplateToEnd}= (() => {
     let converterTemplates;
 
-        const getConverterTemplates= () => {
-            if (!converterTemplates) converterTemplates= initConverterTemplates();
-            return converterTemplates;
-        };
-        const addTemplate= (template) => {
-            getConverterTemplates();
-            converterTemplates.unshift(template);
-        };
-        const addTemplateToEnd= (template) => {
-            getConverterTemplates();
-            converterTemplates.push(template);
-        };
+    const getConverterTemplates= () => {
+        if (!converterTemplates) converterTemplates= initConverterTemplates();
+        return converterTemplates;
+    };
+    const addTemplate= (template) => {
+        getConverterTemplates();
+        converterTemplates.unshift(template);
+    };
+    const addTemplateToEnd= (template) => {
+        getConverterTemplates();
+        converterTemplates.push(template);
+    };
 
-        return {getConverterTemplates,addTemplate,addTemplateToEnd};
+    return {getConverterTemplates,addTemplate,addTemplateToEnd};
 })();
 
 

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -39,6 +39,7 @@ export const DPtypes= {
     CHART: 'xyplot',
     CHOICE_CTI: 'chartTable',
     DOWNLOAD: 'download',
+    DOWNLOAD_MENU_ITEM: 'download-menu-item',
     PNG: 'png',
     ANALYZE: 'analyze',
 };
@@ -104,11 +105,12 @@ export const dpdtSendToBrowser= (url, extra={}) => {
  * @param {String} titleStr download title str
  * @param {String} url download url
  * @param {String} [fileType]
+ * @param {Object} [extra] - all values in this object are added to the DataProjectType Object
  * @return {DataProductsDisplayType}
  */
-export const dpdtMessageWithDownload= (message,titleStr, url,fileType=undefined) => {
+export const dpdtMessageWithDownload= (message,titleStr, url,fileType=undefined, extra={}) => {
     const singleDownload= Boolean(titleStr && url);
-    return dpdtMessage(message,singleDownload ?[dpdtDownload(titleStr,url,'download-0',fileType)] : undefined,{singleDownload} );
+    return dpdtMessage(message,singleDownload ?[dpdtDownload(titleStr,url,'download-0',fileType)] : undefined,{singleDownload,...extra} );
 };
 
 export const dpdtMessageWithError= (message,detailMsgAry) => {
@@ -189,6 +191,12 @@ export function dpdtAnalyze(name, activate, url, serDefParams, menuKey='analyze-
 export function dpdtDownload(name, url, menuKey='download-0', fileType, extra={}) {
     return { displayType:DPtypes.DOWNLOAD, name, url, menuKey, fileType, ...extra};
 }
+
+export function dpdtDownloadMenuItem(name, url, menuKey='download-0', fileType, extra={}) {
+    return { displayType:DPtypes.DOWNLOAD_MENU_ITEM, name, url, menuKey, singleDownload: true, fileType, ...extra};
+}
+
+
 
 /**
  *

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -10,6 +10,7 @@
  * @prop {String} [url] - required if display type is 'png' or 'download'
  * @prop {String} [message] - required it type is 'message' or 'promise'
  * @prop {String} [name]
+ * @prop {WebPlotRequest} [request]
  * @prop {boolean} [isWorkingState] - if defined this means we are in a transitive/loading state. expect regular updates
  * @prop {Promise} [promise] - required it type is 'promise'
  * @prop {Array.<DataProductsDisplayType>|undefined} menu - if defined, then menu to display
@@ -30,6 +31,7 @@
 
 export const DPtypes= {
     MESSAGE: 'message',
+    SEND_TO_BROWSER: 'send-to-browser',
     PROMISE: 'promise',
     IMAGE: 'image',
     IMAGE_SNGLE_AXIS: 'image-single-axis',
@@ -92,6 +94,9 @@ export function dpdtWorkingPromise(message,promise,request=undefined, extra={}, 
     };
 }
 
+export const dpdtSendToBrowser= (url, extra={}) => {
+    return {displayType:DPtypes.SEND_TO_BROWSER, url, ...extra};
+}
 
 /**
  *
@@ -104,6 +109,10 @@ export function dpdtWorkingPromise(message,promise,request=undefined, extra={}, 
 export const dpdtMessageWithDownload= (message,titleStr, url,fileType=undefined) => {
     const singleDownload= Boolean(titleStr && url);
     return dpdtMessage(message,singleDownload ?[dpdtDownload(titleStr,url,'download-0',fileType)] : undefined,{singleDownload} );
+};
+
+export const dpdtMessageWithError= (message,detailMsgAry) => {
+    return dpdtMessage(message,undefined,{complexMessage:true, detailMsgAry} );
 };
 
 /**
@@ -159,12 +168,13 @@ export function dpdtChartTable(name, activate, menuKey='chart-table-0', extra={}
  * @param {string} name
  * @param {Function} activate
  * @param {String} url
+ * @param {Object} serDefParams
  * @param {number|string} menuKey
  * @param {Object} extra - all values in this object are added to the DataProjectType Object
  * @return {DataProductsDisplayType}
  */
-export function dpdtAnalyze(name, activate, url, menuKey='analyze-0', extra={}) {
-    return { displayType:DPtypes.ANALYZE, name, url, activate, menuKey, ...extra};
+export function dpdtAnalyze(name, activate, url, serDefParams, menuKey='analyze-0', extra={}) {
+    return { displayType:DPtypes.ANALYZE, name, url, activate, serDefParams, menuKey, ...extra};
 }
 
 /**
@@ -198,8 +208,9 @@ export function dpdtPNG(name, url, menuKey='png-0', extra={}) {
  * @param {Array.<DataProductsDisplayType>} menu
  * @param {number} activeIdx
  * @param {String} activeMenuLookupKey
+ * @param {boolean} keepSingleMenu
  * @return {DataProductsDisplayType}
  */
-export function dpdtFromMenu(menu,activeIdx,activeMenuLookupKey) {
-    return {...menu[activeIdx], activeMenuLookupKey, menu:menu.length>1?menu:[]};
+export function dpdtFromMenu(menu,activeIdx,activeMenuLookupKey, keepSingleMenu=false) {
+    return {...menu[activeIdx], activeMenuLookupKey, menu: (menu.length>1||keepSingleMenu)?menu:[]};
 }

--- a/src/firefly/js/metaConvert/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/ObsCoreConverter.js
@@ -1,7 +1,12 @@
-import {get} from 'lodash';
+import {get, isEmpty} from 'lodash';
 import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
 import {getCellValue, doFetchTable, hasRowAccess} from '../tables/TableUtil.js';
-import {getObsCoreAccessURL, getObsCoreProdType} from '../util/VOAnalyzer.js';
+import {
+    getObsCoreAccessURL,
+    getObsCoreProdType,
+    getServiceDescriptors,
+    isDataLinkServiceDesc
+} from '../util/VOAnalyzer.js';
 import {
     getObsCoreProdTypeCol,
     isFormatDataLink,
@@ -12,8 +17,10 @@ import {makeFileRequest} from '../tables/TableRequestUtil';
 import {ZoomType} from '../visualize/ZoomType.js';
 import {createGridImagesActivate} from './ImageDataProductsUtil.js';
 import {makeAnalysisGetSingleDataProduct} from './MultiProductFileAnalyzer';
-import { dpdtImage, dpdtMessage, dpdtMessageWithDownload, DPtypes, } from './DataProductsType';
+import {dpdtFromMenu, dpdtImage, dpdtMessage, dpdtMessageWithDownload, DPtypes,} from './DataProductsType';
 import {createGuessDataType, processDatalinkTable} from './DataLinkProcessor';
+import {createServDescMenuRet} from './ServDescConverter.js';
+import {dispatchUpdateActiveKey} from './DataProductsCntlr.js';
 
 const GIG= 1048576 * 1024;
 
@@ -58,7 +65,7 @@ export function makeObsCoreConverter(table,converterTemplate) {
  * @return {Promise.<DataProductsDisplayType>}
  */
 export function getObsCoreGridDataProduct(table, plotRows, activateParams) {
-    const pAry= plotRows.map( (pR) => getObsCoreSingleDataProduct(table,pR.row,activateParams,false));
+    const pAry= plotRows.map( (pR) => getObsCoreSingleDataProduct(table,pR.row,activateParams,undefined,false));
     return Promise.all(pAry).then ( (resultAry) => {
         const {imageViewerId}= activateParams;
         const requestAry= resultAry
@@ -73,38 +80,77 @@ export function getObsCoreGridDataProduct(table, plotRows, activateParams) {
 }
 
 
+
+export function getObsCoreDataProduct(table, row, activateParams, doFileAnalysis= true) {
+    let descriptors= getServiceDescriptors(table);
+    descriptors= descriptors && descriptors.filter( (dDesc) => !isDataLinkServiceDesc(dDesc));
+
+    if (isEmpty(descriptors)) {
+        return getObsCoreSingleDataProduct(table, row, activateParams, undefined, doFileAnalysis);
+    }
+
+    const positionWP= makeWorldPtUsingCenterColumns(table,row);
+    const activeMenuLookupKey= `${descriptors[0].accessURL}--${table.tbl_id}--${row}`;
+    let serDescMenu= createServDescMenuRet(descriptors,positionWP,table,row,activateParams,makeObsCoreRequest,activeMenuLookupKey);
+
+    serDescMenu= serDescMenu.map( (m) =>
+        ({...m,
+            semantics: m.semantics ?? '#additional-service-descriptor',
+            size: m.size ?? 0,
+        }));
+
+    return getObsCoreSingleDataProduct(table, row, activateParams, serDescMenu, doFileAnalysis);
+}
+
+
+
 /**
  * Support ObsCore single product
  * @param table
  * @param row
  * @param {ActivateParams} activateParams
+ * @param {Array.<DataProductsDisplayType>} serviceDescMenuList
  * @param {boolean} doFileAnalysis - if true the build a menu if possible
  * @return {Promise.<DataProductsDisplayType>}
  */
-export function getObsCoreSingleDataProduct(table, row, activateParams, doFileAnalysis= true) {
+export async function getObsCoreSingleDataProduct(table, row, activateParams, serviceDescMenuList, doFileAnalysis= true) {
 
     const {size,titleStr,dataSource,prodType,isVoTable,isDataLink}= getObsCoreRowMetaInfo(table,row);
 
-    if (!dataSource || (isVoTable && !isDataLink)) return Promise.resolve(dpdtMessage(`${prodType} is not supported`));
-    if (!hasRowAccess(table, row)) return Promise.resolve(dpdtMessage('You do not have access to these data.'));
-
-
+    if (!dataSource || (isVoTable && !isDataLink)) return dpdtMessage(`${prodType} is not supported`);
+    if (!hasRowAccess(table, row)) return dpdtMessage('You do not have access to these data.');
     const positionWP= makeWorldPtUsingCenterColumns(table,row);
 
     if (isDataLink) {
-        return doFetchTable(makeFileRequest('dl table', dataSource))
-            .then( (datalinkTable) =>
-                processDatalinkTable(table,row,datalinkTable,positionWP,activateParams,titleStr, makeObsCoreRequest, doFileAnalysis) )
-            .catch( (reason) =>
-                dpdtMessageWithDownload(`No data to display: Could not retrieve datalink data, ${reason}`, 'Download File: '+titleStr, dataSource)
-        );
+        try {
+            const datalinkTable= await doFetchTable(makeFileRequest('dl table', dataSource));
+            return processDatalinkTable(table,row,datalinkTable,positionWP,activateParams, makeObsCoreRequest, serviceDescMenuList, doFileAnalysis);
+        } catch (reason) {
+                                  //todo - what about if when the data link fetch fails but there is a serviceDescMenuList - what to do? does it matter?
+            dpdtMessageWithDownload(`No data to display: Could not retrieve datalink data, ${reason}`, 'Download File: '+titleStr, dataSource);
+        }
     }
     else {
-        if (size>GIG) return Promise.resolve(dpdtMessageWithDownload('Data is too large to load', 'Download File: '+titleStr, dataSource));
-        return doFileAnalysis ?
-            makeAnalysisGetSingleDataProduct(() => makeObsCoreRequest(dataSource, positionWP, titleStr))(table,row,activateParams,prodType) :
-            createGuessDataType(titleStr,'guess-0',dataSource,prodType,makeObsCoreRequest,undefined,activateParams, positionWP,table,row,size);
+        if (size>GIG) return dpdtMessageWithDownload('Data is too large to load', 'Download File: '+titleStr, dataSource);
+        if (doFileAnalysis) {
+            const analyzerFunc= makeAnalysisGetSingleDataProduct(() => makeObsCoreRequest(dataSource, positionWP, titleStr));
+            const result= await analyzerFunc(table,row,activateParams,prodType);
+            return singleResultWithServiceDesc(activateParams.dpId, result, size, serviceDescMenuList);
+        }
+        else {
+            const result= createGuessDataType(titleStr,'guess-0',dataSource,prodType,makeObsCoreRequest,undefined,activateParams, positionWP,table,row,size);
+            return singleResultWithServiceDesc(activateParams.dpId, result,size, serviceDescMenuList);
+        }
     }
+}
+
+function singleResultWithServiceDesc(dpId, primResult, size, serviceDescMenuList) {
+    if (!serviceDescMenuList) return primResult;
+    const activeMenuLookupKey= serviceDescMenuList[0].activeMenuLookupKey;
+    primResult= { ...primResult, semantics: primResult.semantics ?? '#this', size, activeMenuLookupKey};
+    const menu= [primResult, ...serviceDescMenuList];
+    dispatchUpdateActiveKey({dpId, activeMenuKeyChanges:{[activeMenuLookupKey]:menu[0].menuKey}});
+    return dpdtFromMenu(menu,0,activeMenuLookupKey,true);
 }
 
 
@@ -133,7 +179,7 @@ function getObsCoreRowMetaInfo(table,row) {
  * @param titleStr
  * @return {undefined|WebPlotRequest}
  */
-function makeObsCoreRequest(dataSource, positionWP, titleStr) {
+export function makeObsCoreRequest(dataSource, positionWP, titleStr) {
     if (!dataSource) return undefined;
 
     const r = WebPlotRequest.makeURLPlotRequest(dataSource, 'DataProduct');

--- a/src/firefly/js/metaConvert/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/ServDescConverter.js
@@ -1,0 +1,90 @@
+import {isEmpty} from 'lodash';
+import {dpdtAnalyze, dpdtFromMenu, dpdtMessage} from './DataProductsType.js';
+import {doFetchTable, getCellValue, hasRowAccess} from '../tables/TableUtil.js';
+import {getServiceDescriptors, isDataLinkServiceDesc, makeWorldPtUsingCenterColumns } from '../util/VOAnalyzer.js';
+import {makeFileAnalysisActivate} from './MultiProductFileAnalyzer.js';
+import {makeObsCoreRequest} from './ObsCoreConverter.js';
+import {getActiveMenuKey} from './DataProductsCntlr.js';
+import {makeFileRequest} from '../tables/TableRequestUtil.js';
+import {processDatalinkTable} from './DataLinkProcessor.js';
+
+
+/**
+ * Support Service descriptor single product
+ * @param table
+ * @param row
+ * @param {ActivateParams} activateParams
+ * @return {Promise.<DataProductsDisplayType>}
+ */
+export async function getServiceDescSingleDataProduct(table, row, activateParams) {
+
+    const descriptors= getServiceDescriptors(table);
+    if (!descriptors) return dpdtMessage('Could not find any service descriptors');
+    if (!hasRowAccess(table, row)) return dpdtMessage('You do not have access to these data.');
+
+    const positionWP= makeWorldPtUsingCenterColumns(table,row);
+
+
+    const activeMenuLookupKey= `${descriptors[0].accessURL}--${table.tbl_id}--${row}`;
+    const menu= createServDescMenuRet(descriptors,positionWP,table,row,activateParams,makeObsCoreRequest,activeMenuLookupKey);
+    const activeMenuKey= getActiveMenuKey(activateParams.dpId, activeMenuLookupKey);
+    let index= menu.findIndex( (m) => m.menuKey===activeMenuKey);
+    if (index<0) index= 0;
+
+    const dlUrl= makeDlUrl(findDataLinkServeDescs(descriptors)[0],table, row);
+    if (dlUrl) {
+        try {
+            const datalinkTable= await doFetchTable(makeFileRequest('dl table', dlUrl));
+            const positionWP= makeWorldPtUsingCenterColumns(table,row);
+            return processDatalinkTable(table,row,datalinkTable,positionWP,activateParams,
+                makeObsCoreRequest, !isEmpty(menu)?menu:undefined);
+        }
+        catch (reason) {
+            return isEmpty(menu) ?
+                dpdtMessage('Data link look up failed: ' + dlUrl) :
+                dpdtFromMenu(menu,index,activeMenuLookupKey,true);
+        }
+    }
+    else {
+        return dpdtFromMenu(menu,index,activeMenuLookupKey,true);
+    }
+}
+
+
+function makeDlUrl(dlServDesc, table, row) {
+    if (!dlServDesc) return undefined;
+    const {urlParams, accessUrl}= dlServDesc;
+    const sendParams={};
+    urlParams.filter( ({ref}) => ref).forEach( (p) => sendParams[p.name]= getCellValue(table, row, p.colName));
+    const newUrl= new URL(accessUrl);
+    Object.entries(sendParams).forEach( ([k,v]) => newUrl.searchParams.append(k,v));
+    return newUrl.toString();
+}
+
+/**
+ *
+ * @param {Array.<ServiceDescriptorDef>} descriptors
+ * @param {WorldPt|undefined} positionWP
+ * @param {TableModel} sourceTable
+ * @param {number} row
+ * @param {ActivateParams} activateParams
+ * @param {Function} makeReq
+ * @param {String} activeMenuLookupKey
+ * @return {Array.<DataProductsDisplayType>}
+ */
+export function createServDescMenuRet(descriptors, positionWP, sourceTable, row, activateParams, makeReq, activeMenuLookupKey) {
+    return descriptors
+        .filter( (sDesc) => !isDataLinkServiceDesc(sDesc))
+        .map( (sDesc,idx) => {
+            const {title,accessURL,standardID,urlParams, ID}= sDesc;
+            const menuKey= 'serdesc-dlt-'+idx;
+            const allowsInput= urlParams.some( (p) => p.allowsInput);
+            const request= makeReq(accessURL,positionWP,title);
+            const name= 'Show: '+title;
+            const activate= makeFileAnalysisActivate(sourceTable,row, request, positionWP,activateParams,menuKey, undefined, urlParams, name);
+            return dpdtAnalyze(name,activate,accessURL,urlParams,menuKey,{activeMenuLookupKey,request, allowsInput, standardID, ID});
+        });
+}
+
+const findDataLinkServeDescs= (descriptors) => descriptors?.filter( (sDesc) => isDataLinkServiceDesc(sDesc));
+

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -108,15 +108,16 @@ function loadTableAndCharts(dataTableReq, tbl_id, tableGroupViewerId, dispatchCh
  * @param {Number} tbl_index
  * @param {Array.<String>} colNames - an array of column names
  * @param {Array.<String>} colUnits - an array of types names
+ * @param {boolean} connectPoints if a default scatter chart then connect the points
  * @param {String} chartId
  * @param {String} tbl_id
  * @return {function} the activate function
  */
 export function createChartTableActivate(chartAndTable,source, titleInfo, activateParams, chartInfo={}, tbl_index=0,
-                                         colNames= undefined, colUnits= undefined,
+                                         colNames= undefined, colUnits= undefined, connectPoints=true,
                                          chartId='part-result-chart', tbl_id= 'part-result-tbl') {
     return () => {
-        const dispatchCharts=  chartAndTable && makeChartObj(chartInfo, activateParams,titleInfo,chartId,tbl_id);
+        const dispatchCharts=  chartAndTable && makeChartObj(chartInfo, activateParams,titleInfo,connectPoints,chartId,tbl_id);
         const dataTableReq= makeTableRequest(source,titleInfo,tbl_id,tbl_index,colNames,colUnits);
         const savedRequest= loadedTablesIds.has(tbl_id) && JSON.stringify(loadedTablesIds.get(tbl_id)?.request);
 
@@ -214,7 +215,7 @@ function makeChartFromParams(tbl_id, chartParams, computeXAxis, computeYAxis,tit
 
 
 
-function makeChartObj(chartInfo,  activateParams, titleInfo, chartId, tbl_id ) {
+function makeChartObj(chartInfo,  activateParams, titleInfo, connectPoints, chartId, tbl_id ) {
 
     const {chartViewerId:viewerId}= activateParams;
     const {chartParamsAry}= chartInfo;
@@ -239,7 +240,7 @@ function makeChartObj(chartInfo,  activateParams, titleInfo, chartId, tbl_id ) {
                     tbl_id,
                     x: `tables::${xAxis}`,
                     y: `tables::${yAxis}`,
-                    mode: 'lines+markers'
+                    mode: connectPoints ? 'lines+markers' : 'markers',
                 }],
             layout: {
                 title: {text: chartTitle},

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -371,6 +371,13 @@ export function getColumn(tableModel, colName) {
     }
 }
 
+
+export function columnIDToName(tableModel, ID) {
+    if (!tableModel || !ID) return undefined;
+    return getAllColumns(tableModel)?.find((col) => col.ID === ID)?.name;
+}
+
+
 /**
  * returns column information for the given ID.
  * @param {TableModel} tableModel

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -19,6 +19,7 @@
  * @typedef {object} TableModel
  * @prop {string}   tbl_id    unique ID of this table.
  * @prop {string}   title     title, used on label.
+ * @prop {Object} resources votable resources
  * @prop {TableRequest} request  the request used to create this table
  * @prop {TableKeywords} keywords  a list of all meta from the original source, including comments and duplicates
  * @prop {TableMeta} tableMeta     additional meta added and keywords as key/value pair.  comments and duplicates are no longer here.

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -68,7 +68,8 @@ export const isImageBitmap= (b) => getGlobalObj().ImageBitmap && (b instanceof g
 export const isOffscreenCanvas= (b) => getGlobalObj().OffscreenCanvas && (b instanceof getGlobalObj().OffscreenCanvas);
 
 export function createCanvas(width,height) {
-    const c = document.createElement('canvas');
+    const global= getGlobalObj();
+    const c = global.document ? global.document.createElement('canvas') : new OffscreenCanvas(w,h);
     c.width = width;
     c.height = height;
     return c;

--- a/src/firefly/js/util/fetch.js
+++ b/src/firefly/js/util/fetch.js
@@ -94,11 +94,17 @@ export function downloadBlob(blob, filename) {
     document.body.removeChild(a);
 }
 
+/**
+ * return the filename from the Content-Disposition header or undefined
+ * @param resp - fetch response
+ * @return {string|undefined}
+ */
 function resolveFileName(resp) {
     if (resp && resp.headers) {
         const cd = resp.headers.get('Content-Disposition') || '';
         const parts = cd.match(/.*filename=(.*)/);
-        if (parts && parts.length > 1) return parts[1];
+        const possibleName= (parts && parts.length > 1) ? parts[1] : undefined;
+        return possibleName?.indexOf('?')>4 ? possibleName.split('?')[0] : possibleName;
     }
 }
 

--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -453,7 +453,7 @@ function getSearchRadiusInRadians(fov) {
 function filterAllSky(centerWp, cells) {
     return cells.filter( (cell) =>{
         const {wpCorners}= cell;
-        return (computeDistance(centerWp, wpCorners[0]) <90);
+        return (computeDistance(centerWp, wpCorners[0]) <100 || computeDistance(centerWp, wpCorners[2]) <100);
     });
 }
 

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -827,6 +827,7 @@ export function dispatchOverlayPlotChangeAttributes({plotId,imageOverlayId, attr
  * @param {boolean} [p.forceDelay]
  * @param {number} [p.level] the level to zoom to, used only userZoomType 'LEVEL'
  * @param {string|ActionScope} [p.actionScope] default to group
+ * @param {DevicePt} devicePt
  * @param {Function} [p.dispatcher] only for special dispatching uses such as remote
  *
  * @public
@@ -848,13 +849,13 @@ export function dispatchOverlayPlotChangeAttributes({plotId,imageOverlayId, attr
  * action.dispatchZoom({plotId:’myplot’, userZoomType:’LEVEL’, level: zlevel, forceDelay: true }};
  */
 export function dispatchZoom({plotId, userZoomType, maxCheck= true,
-                             zoomLockingEnabled=false, forceDelay=false, level,
+                             zoomLockingEnabled=false, forceDelay=false, level, devicePt,
                              actionScope=ActionScope.GROUP,
                              dispatcher= flux.process} ) {
     dispatcher({
         type: ZOOM_IMAGE,
         payload :{
-            plotId, userZoomType, actionScope, maxCheck, zoomLockingEnabled, forceDelay, level
+            plotId, userZoomType, actionScope, maxCheck, zoomLockingEnabled, forceDelay, level, devicePt
         }});
 }
 

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -11,7 +11,7 @@ import {EventLayer} from './iv/EventLayer.jsx';
 import {ImageViewerStatus} from './iv/ImageViewerStatus.jsx';
 import {makeScreenPt, makeDevicePt} from './Point.js';
 import {DrawerComponent}  from './draw/DrawerComponent.jsx';
-import {CysConverter}  from './CsysConverter.js';
+import {CCUtil, CysConverter} from './CsysConverter.js';
 import {UserZoomTypes}  from './ZoomUtil.js';
 import {primePlot, getPlotViewById, hasLocalStretchByteData} from './PlotViewUtil.js';
 import {isImageViewerSingleLayout, getMultiViewRoot} from './MultiViewCntlr.js';
@@ -167,10 +167,13 @@ export class ImageViewerLayout extends PureComponent {
             fireMouseEvent(dl,mouseState,mouseStatePayload);
         }
         else if (mouseState===MouseState.WHEEL_UP) {
-            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.UP });
+
+            const devicePt= CCUtil.getDeviceCoords(primePlot(plotView),screenPt);
+            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.UP, devicePt });
         }
         else if (mouseState===MouseState.WHEEL_DOWN) {
-            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.DOWN });
+            const devicePt= CCUtil.getDeviceCoords(primePlot(plotView),screenPt);
+            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.DOWN , devicePt});
         }
         else {
             const ownerCandidate= findMouseOwner(list,primePlot(plotView),screenPt);         // see if anyone can own that mouse

--- a/src/firefly/js/visualize/PlotState.js
+++ b/src/firefly/js/visualize/PlotState.js
@@ -307,6 +307,7 @@ export function makePlotStateShimForHiPS(wpRequest) {
     const bandState= BandState.makeBandState();
     bandState.plotRequestTmp= wpRequest;
     plotState.bandStateAry= [bandState,null,null];
+    plotState.colorTableId=-1;
     return plotState;
 }
 

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -420,6 +420,10 @@ export const WebPlot= {
             //=== Mutable =====================
             screenSize: {width:HIPS_DATA_WIDTH*zoomFactor, height:HIPS_DATA_HEIGHT*zoomFactor},
             cubeIdx: Number(hipsProperties?.hips_cube_firstframe) || 0,
+            rawData: {
+                useRed: true, useGreen: true, useBlue:true,
+                bandData:[{bias:.5,contrast:1},undefined,undefined]
+            },
             zoomFactor,
             attributes,
             //=== End Mutable =====================

--- a/src/firefly/js/visualize/iv/HiPSRenderer.js
+++ b/src/firefly/js/visualize/iv/HiPSRenderer.js
@@ -88,7 +88,7 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
 
             const tileSize= tile.tileSize || imageData.image.width;
             drawOneHiPSTile(offscreenCtx, imageData.image, tile.devPtCorners,
-                tileSize, {x:tile.dx,y:tile.dy}, true, tile.nside);
+                tileSize, {x:tile.dx,y:tile.dy}, tile.nside);
 
 
             if (doRenderNow()) renderToScreen();
@@ -97,7 +97,7 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
         }).catch(() => {
             renderedCnt++;
             if (abortRender) return;
-            drawOneHiPSTile(offscreenCtx, emptyTileCanvas, tile.devPtCorners, 512, {x:tile.dx,y:tile.dy}, true, tile.nside);
+            drawOneHiPSTile(offscreenCtx, emptyTileCanvas, tile.devPtCorners, 512, {x:tile.dx,y:tile.dy}, tile.nside);
             addFailedImage(src);
             if (doRenderNow()) {
                 removeTask();
@@ -118,7 +118,7 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
         if (image) {
             const tileSize= tile.tileSize || image.width;
             drawOneHiPSTile(offscreenCtx, image, tile.devPtCorners,
-                tileSize, {x:tile.dx,y:tile.dy}, true, tile.nside);
+                tileSize, {x:tile.dx,y:tile.dy}, tile.nside);
         }
         renderedCnt++;
         if (renderedCnt === totalCnt) {

--- a/src/firefly/js/visualize/iv/HiPSRenderer.js
+++ b/src/firefly/js/visualize/iv/HiPSRenderer.js
@@ -2,14 +2,24 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {isNil, get} from 'lodash';
+import {isNil} from 'lodash';
 import {retrieveAndProcessImage} from './ImageProcessor.js';
 import {drawOneHiPSTile} from './HiPSSingleTileRender.js';
-import {findTileCachedImage, addTileCachedImage, addFailedImage, isInFailTileCached} from './HiPSTileCache.js';
+import {
+    findTileCachedImage,
+    addTileCachedImage,
+    addFailedImage,
+    isInFailTileCached,
+} from './HiPSTileCache.js';
 import {dispatchAddTaskCount, dispatchRemoveTaskCount, makeTaskId, getTaskCount} from '../../core/AppDataCntlr.js';
 import {createImageUrl, createEmptyTile} from './TileDrawHelper.jsx';
 
 const emptyTileCanvas= createEmptyTile(512,512);
+
+const colorId = (plot) => {
+    const id= Number(plot.plotState.getColorTableId());
+    return isNaN(id) ? -1 : id;
+};
 
 /**
  * The object that can render a HiPS to the screen.
@@ -19,9 +29,10 @@ const emptyTileCanvas= createEmptyTile(512,512);
  * @param isBaseImage
  * @param tileProcessInfo
  * @param screenRenderEnabled
+ * @param hipsColorOps
  * @return {{drawTile(*=, *=): undefined, drawTileImmediate(*=, *, *=): void, abort(): void}}
  */
-export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tileProcessInfo, screenRenderEnabled) {
+export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tileProcessInfo, screenRenderEnabled, hipsColorOps) {
 
     let renderedCnt=0;
     let abortRender= false;
@@ -42,14 +53,26 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
      * draw a single tile async (retrieve image and draw tile)
      * @param src
      * @param {HiPSDeviceTileData} tile
+     * @param colorTableId
+     * @param bias
+     * @param contrast
      */
-    const drawTileAsync= (src, tile) => {
+    const drawTileAsync= (src, tile, colorTableId,bias,contrast) => {
         if (abortRender) return;
         let inCache;
         let tileData;
         let emptyTile;
 
-        const cachedTile= findTileCachedImage(src);
+        let cachedTile= findTileCachedImage(src,colorTableId,bias,contrast);
+        if (colorTableId!==-1 && !cachedTile) {
+            cachedTile= findTileCachedImage(src);
+            if (cachedTile) {
+                const coloredImage= hipsColorOps.changeHiPSColor(cachedTile.image,colorTableId,bias,contrast);
+                addTileCachedImage(src, coloredImage,colorTableId,bias,contrast);
+                cachedTile= findTileCachedImage(src,colorTableId,bias,contrast);
+            }
+        }
+
         if (!firstRenderTime) firstRenderTime= Date.now();
         if (cachedTile) {
             tileData=  cachedTile.image;
@@ -83,12 +106,23 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
         p.then((imageData) => {
             renderedCnt++;
 
-            if (!inCache && !emptyTile) addTileCachedImage(src, imageData);
+            let image;
+            if (!inCache && !emptyTile) {
+                image= imageData.image;
+                addTileCachedImage(src, image);
+                if (colorTableId!==-1) {
+                    image= hipsColorOps.changeHiPSColor(image,colorTableId,bias,contrast);
+                    addTileCachedImage(src, image,colorTableId,bias,contrast);
+                }
+
+            }
+            else {
+                image= imageData instanceof HTMLCanvasElement ? imageData : imageData.image;
+            }
             if (abortRender) return;
 
-            const tileSize= tile.tileSize || imageData.image.width;
-            drawOneHiPSTile(offscreenCtx, imageData.image, tile.devPtCorners,
-                tileSize, {x:tile.dx,y:tile.dy}, tile.nside);
+            const tileSize= tile.tileSize || image.width;
+            drawOneHiPSTile(offscreenCtx, image, tile.devPtCorners, tileSize, {x:tile.dx,y:tile.dy}, tile.nside);
 
 
             if (doRenderNow()) renderToScreen();
@@ -113,8 +147,8 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
      * @param {HiPSDeviceTileData} tile
      * @param allskyImage
      */
-    const drawTileImmediate= (src, tile, allskyImage) => {
-        const image= allskyImage || get(findTileCachedImage(src),'image.image');
+    const drawTileImmediate= (src, tile, allskyImage, colorTableId, bias, contrast) => {
+        const image= allskyImage || findTileCachedImage(src, colorTableId, bias, contrast)?.image;
         if (image) {
             const tileSize= tile.tileSize || image.width;
             drawOneHiPSTile(offscreenCtx, image, tile.devPtCorners,
@@ -180,7 +214,9 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
             setTimeout( () => {
                 if (!abortRender && !renderComplete) dispatchAddTaskCount(plot.plotId,plotTaskId, true);
             }, 500);
-            tilesToLoad.forEach( (tile) => drawTileAsync(createImageUrl(plot,tile), tile) );
+            const {bias,contrast}= plot.rawData.bandData[0];
+            const colorTableId= colorId(plot);
+            tilesToLoad.forEach( (tile) => drawTileAsync(createImageUrl(plot,tile), tile, colorTableId,bias,contrast) );
         },
 
         /**
@@ -191,8 +227,10 @@ export function makeHipsRenderer(screenRenderParams, totalCnt, isBaseImage, tile
          */
         drawAllTilesImmediate(tilesToLoad, plot) {
             if (abortRender) return;
+            const {bias,contrast}= plot.rawData.bandData[0];
+            const colorTableId= colorId(plot);
             for(let i=0; i<tilesToLoad.length; i++) { // do a classic for loop to increase the fps by 3 or 4
-                drawTileImmediate(createImageUrl(plot, tilesToLoad[i]), tilesToLoad[i]);
+                drawTileImmediate(createImageUrl(plot, tilesToLoad[i]), tilesToLoad[i], undefined, colorTableId, bias, contrast);
             }
         },
 

--- a/src/firefly/js/visualize/iv/HiPSSingleTileRender.js
+++ b/src/firefly/js/visualize/iv/HiPSSingleTileRender.js
@@ -16,15 +16,18 @@ import {Matrix} from '../../externalSource/transformation-matrix-js/matrix';
  */
 export function drawOneHiPSTile(ctx, img, cornersAry, tileSize, offset, norder) {
 
-    const delta = norder<=3 ? 0.2 : 0;
-    const triangles= window.firefly?.hipsTriangles ?? 4;
+    // const delta = norder<=3 ? 0.2 : 0;
+    const delta = 0;
+    // const triangles= window.firefly?.hipsTriangles ?? 4;
+    const triangles= tileSize < 80 ? 2 : 4;
+    const correction= tileSize < 80 ? .05 : tileSize < 150 ? .03 : .01;
 
     if (triangles===2) {
         const triangle1= [{x:tileSize-delta, y:tileSize-delta}, {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}];
         const triangle2= [ {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}, {x:delta, y:delta} ];
 
-        drawTexturedTriangle(ctx, img, offset, ...triangle1, cornersAry[0], cornersAry[1], cornersAry[3]);
-        drawTexturedTriangle(ctx, img,offset, ...triangle2, cornersAry[1], cornersAry[3], cornersAry[2]);
+        drawTexturedTriangle(ctx, img, offset, ...triangle1, cornersAry[0], cornersAry[1], cornersAry[3], correction);
+        drawTexturedTriangle(ctx, img,offset, ...triangle2, cornersAry[1], cornersAry[3], cornersAry[2], correction);
     }
     else if (triangles===4) {
         const mp=tileSize/2;
@@ -37,16 +40,14 @@ export function drawOneHiPSTile(ctx, img, cornersAry, tileSize, offset, norder) 
         const triangle3= [{x:delta, y:tileSize-delta}, {x:mp-delta, y:mp-delta}, {x:delta, y:delta}];
         const triangle4= [{x:tileSize-delta, y:tileSize-delta}, {x:mp-delta, y:mp-delta}, {x:delta, y:tileSize-delta}];
 
-        drawTexturedTriangle(ctx, img, offset, ...triangle1, cornersAry[0], cPt, cornersAry[1]);
-        drawTexturedTriangle(ctx, img, offset, ...triangle2, cornersAry[1], cPt, cornersAry[2]);
-        drawTexturedTriangle(ctx, img, offset, ...triangle3, cornersAry[3], cPt, cornersAry[2]);
-        drawTexturedTriangle(ctx, img, offset, ...triangle4, cornersAry[0], cPt, cornersAry[3]);
+        drawTexturedTriangle(ctx, img, offset, ...triangle1, cornersAry[0], cPt, cornersAry[1], correction);
+        drawTexturedTriangle(ctx, img, offset, ...triangle2, cornersAry[1], cPt, cornersAry[2], correction);
+        drawTexturedTriangle(ctx, img, offset, ...triangle3, cornersAry[3], cPt, cornersAry[2], correction);
+        drawTexturedTriangle(ctx, img, offset, ...triangle4, cornersAry[0], cPt, cornersAry[3], correction);
     }
 }
 
-const scaleCoeff = 0.02;
-const correction = 0.01;
-const applyC= (v,c) => ((1+correction) * v - c * correction);
+const scaleCoeff = 0.01;
 
 /**
  * Reproject and draw the part of the image defined by triangle source point 0,1,2 to triangle pt 0,1,2 of the destination image
@@ -67,14 +68,15 @@ const applyC= (v,c) => ((1+correction) * v - c * correction);
  * @param {Point} pt0 - destination point 0
  * @param {Point} pt1 - destination point 1
  * @param {Point} pt2 - destination point 2
- * @param {boolean} applyCorrection
+ * @param {number} correction
  */
 function drawTexturedTriangle(ctx, img, offset,
-                              s0, s1, s2, {x:x0, y:y0}, {x:x1, y:y1}, {x:x2, y:y2}, applyCorrection= true) {
+                              s0, s1, s2, {x:x0, y:y0}, {x:x1, y:y1}, {x:x2, y:y2}, correction= .01) {
     const xc = (x0 + x1 + x2) / 3;
     const yc = (y0 + y1 + y2) / 3;
 
-    const tgtAry= applyCorrection ?
+    const applyC= (v,c) => ((1+correction) * v - c * correction);
+    const tgtAry= correction ?
         [ applyC(x0,xc), applyC(y0,yc), applyC(x1,xc), applyC(y1,yc), applyC(x2,xc), applyC(y2,yc)] :
         [x0,y0,x1,y1,x2,y2];
 

--- a/src/firefly/js/visualize/iv/HiPSSingleTileRender.js
+++ b/src/firefly/js/visualize/iv/HiPSSingleTileRender.js
@@ -1,39 +1,30 @@
-import {get} from 'lodash';
-
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
+import {Matrix} from '../../externalSource/transformation-matrix-js/matrix';
+
 /**
- *
  * Draw one HiPS tile by breaking it into 2 triangle and draw each. This function follows the aladin's example
  *
  * @param ctx - canvas context
  * @param img - the image tile
- * @param {Array.<DevicePt>} cornersAry
- * @param tileSize - width/height of image tile
- * @param offsetPt
- * @param applyCorrection
- * @param norder
+ * @param {Array.<DevicePt>} cornersAry - array of points of the 4 corners to copy the image to on the destination canvas
+ * @param {Number} tileSize - width/height of image tile
+ * @param {DevicePt} offset - an offset point
+ * @param {Number} norder
  */
-export function drawOneHiPSTile(ctx, img, cornersAry, tileSize, offsetPt, applyCorrection, norder) {
+export function drawOneHiPSTile(ctx, img, cornersAry, tileSize, offset, norder) {
 
     const delta = norder<=3 ? 0.2 : 0;
-    const triangles= get(window,'firefly.hipsTriangles',2);
-    
+    const triangles= window.firefly?.hipsTriangles ?? 4;
 
     if (triangles===2) {
         const triangle1= [{x:tileSize-delta, y:tileSize-delta}, {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}];
         const triangle2= [ {x:tileSize-delta, y:delta}, {x:delta, y:tileSize-delta}, {x:delta, y:delta} ];
 
-        drawTexturedTriangle(ctx, img,
-            cornersAry[0], cornersAry[1], cornersAry[3],
-            triangle1[0], triangle1[1], triangle1[2],
-            offsetPt, applyCorrection);
-        drawTexturedTriangle(ctx, img,
-            cornersAry[1], cornersAry[3], cornersAry[2],
-            triangle2[0], triangle2[1], triangle2[2],
-            offsetPt, applyCorrection);
+        drawTexturedTriangle(ctx, img, offset, ...triangle1, cornersAry[0], cornersAry[1], cornersAry[3]);
+        drawTexturedTriangle(ctx, img,offset, ...triangle2, cornersAry[1], cornersAry[3], cornersAry[2]);
     }
     else if (triangles===4) {
         const mp=tileSize/2;
@@ -46,104 +37,59 @@ export function drawOneHiPSTile(ctx, img, cornersAry, tileSize, offsetPt, applyC
         const triangle3= [{x:delta, y:tileSize-delta}, {x:mp-delta, y:mp-delta}, {x:delta, y:delta}];
         const triangle4= [{x:tileSize-delta, y:tileSize-delta}, {x:mp-delta, y:mp-delta}, {x:delta, y:tileSize-delta}];
 
-        drawTexturedTriangle(ctx, img,
-            cornersAry[0], cPt, cornersAry[1],
-            triangle1[0], triangle1[1], triangle1[2],
-            offsetPt, applyCorrection);
-        drawTexturedTriangle(ctx, img,
-            cornersAry[1], cPt, cornersAry[2],
-            triangle2[0], triangle2[1], triangle2[2],
-            offsetPt, applyCorrection);
-        drawTexturedTriangle(ctx, img,
-            cornersAry[3], cPt, cornersAry[2],
-            triangle3[0], triangle3[1], triangle3[2],
-            offsetPt, applyCorrection);
-        drawTexturedTriangle(ctx, img,
-            cornersAry[0], cPt, cornersAry[3],
-            triangle4[0], triangle4[1], triangle4[2],
-            offsetPt, applyCorrection);
-
+        drawTexturedTriangle(ctx, img, offset, ...triangle1, cornersAry[0], cPt, cornersAry[1]);
+        drawTexturedTriangle(ctx, img, offset, ...triangle2, cornersAry[1], cPt, cornersAry[2]);
+        drawTexturedTriangle(ctx, img, offset, ...triangle3, cornersAry[3], cPt, cornersAry[2]);
+        drawTexturedTriangle(ctx, img, offset, ...triangle4, cornersAry[0], cPt, cornersAry[3]);
     }
 }
 
+const scaleCoeff = 0.02;
+const correction = 0.01;
+const applyC= (v,c) => ((1+correction) * v - c * correction);
 
 /**
- * reproject and draw the part of the image defined by triangle source point 0,1,2 to triangle pt 0,1,2 of the destination image
+ * Reproject and draw the part of the image defined by triangle source point 0,1,2 to triangle pt 0,1,2 of the destination image
  *
- * this code from Aladin which took it from demo code http://www.dhteumeuleu.com/lab/image3D.html
+ * This started with code from Aladin which took it from demo code http://www.dhteumeuleu.com/lab/image3D.html
  * it takes a triangle from a source image and maps to a triangle in the target image
+ * I have modified it to use transformation-matrix-js since the triangle transform is well understood.
+ * transformation-matrix-js is used to compute the affine transform, triangle conversion affine transform
  *
  * This is effectively 3d triangle drawing without using web GL.
  *
- * I don't really understand the affine transform math. it is a far more advanced combination
- * of rotation, translation and scaling than normally done.
- *
- * @param ctx
- * @param img
- * @param pt0
- * @param pt1
- * @param pt2
- * @param srcP0
- * @param srcP1
- * @param srcP2
- * @param {Point} offsetPt
- * @param applyCorrection
+ * @param ctx - canvas context
+ * @param img - source image
+ * @param {Point} offset an offset point, an offset into existing image of the source pt
+ * @param {Point} s0 - source point 0
+ * @param {Point} s1 - source point 1
+ * @param {Point} s2 - source point 2
+ * @param {Point} pt0 - destination point 0
+ * @param {Point} pt1 - destination point 1
+ * @param {Point} pt2 - destination point 2
+ * @param {boolean} applyCorrection
  */
-function drawTexturedTriangle(ctx, img, pt0, pt1, pt2, srcP0, srcP1, srcP2,
-                              offsetPt, applyCorrection= false) {
-
-    let {x:x0, y:y0}= pt0;
-    let {x:x1, y:y1}= pt1;
-    let {x:x2, y:y2}= pt2;
-    let {x:srcX0, y:srcY0}= srcP0;
-    let {x:srcX1, y:srcY1}= srcP1;
-    let {x:srcX2, y:srcY2}= srcP2;
-
-
-    const {x:offX, y:offY}= offsetPt;
-    srcX0 += offX;
-    srcX1 += offX;
-    srcX2 += offX;
-    srcY0 += offY;
-    srcY1 += offY;
-    srcY2 += offY;
-
+function drawTexturedTriangle(ctx, img, offset,
+                              s0, s1, s2, {x:x0, y:y0}, {x:x1, y:y1}, {x:x2, y:y2}, applyCorrection= true) {
     const xc = (x0 + x1 + x2) / 3;
     const yc = (y0 + y1 + y2) / 3;
+
+    const tgtAry= applyCorrection ?
+        [ applyC(x0,xc), applyC(y0,yc), applyC(x1,xc), applyC(y1,yc), applyC(x2,xc), applyC(y2,yc)] :
+        [x0,y0,x1,y1,x2,y2];
+
+    const srcPtAry= [s0.x+offset.x, s0.y+offset.y, s1.x+offset.x, s1.y+offset.y, s2.x+offset.x, s2.y+offset.y];
+
+    // ---- set up clip region to prevent anti-aliasing, scale triangle by (1 + scaleCoeff)
     ctx.save();
-
-
-    let coeff = 0.02;
-
-    // ---- scale triangle by (1 + coeff) to remove anti-aliasing and draw ----
     ctx.beginPath();
-    ctx.moveTo(((1+coeff) * x0 - xc * coeff), ((1+coeff) * y0 - yc * coeff));
-    ctx.lineTo(((1+coeff) * x1 - xc * coeff), ((1+coeff) * y1 - yc * coeff));
-    ctx.lineTo(((1+coeff) * x2 - xc * coeff), ((1+coeff) * y2 - yc * coeff));
+    ctx.moveTo(((1+scaleCoeff) * x0 - xc * scaleCoeff), ((1+scaleCoeff) * y0 - yc * scaleCoeff));
+    ctx.lineTo(((1+scaleCoeff) * x1 - xc * scaleCoeff), ((1+scaleCoeff) * y1 - yc * scaleCoeff));
+    ctx.lineTo(((1+scaleCoeff) * x2 - xc * scaleCoeff), ((1+scaleCoeff) * y2 - yc * scaleCoeff));
     ctx.closePath();
     ctx.clip();
-
-    // this is needed to prevent to see some lines between triangles
-    if (applyCorrection) {
-        coeff = 0.01;
-        x0 = ((1+coeff) * x0 - xc * coeff);
-        y0 = ((1+coeff) * y0 - yc * coeff);
-        x1 = ((1+coeff) * x1 - xc * coeff);
-        y1 = ((1+coeff) * y1 - yc * coeff);
-        x2 = ((1+coeff) * x2 - xc * coeff);
-        y2 = ((1+coeff) * y2 - yc * coeff);
-    }
-
-    // ---- transform texture ----
-    const d_inv = 1/ (srcX0 * (srcY2 - srcY1) - srcX1 * srcY2 + srcX2 * srcY1 + (srcX1 - srcX2) * srcY0);
-    ctx.transform(
-        -(srcY0 * (x2 - x1) -  srcY1 * x2  + srcY2 *  x1 + (srcY1 - srcY2) * x0) * d_inv, // m11
-        (srcY1 *  y2 + srcY0  * (y1 - y2) - srcY2 *  y1 + (srcY2 - srcY1) * y0) * d_inv, // m12
-        (srcX0 * (x2 - x1) -  srcX1 * x2  + srcX2 *  x1 + (srcX1 - srcX2) * x0) * d_inv, // m21
-        -(srcX1 *  y2 + srcX0  * (y1 - y2) - srcX2 *  y1 + (srcX2 - srcX1) * y0) * d_inv, // m22
-        (srcX0 * (srcY2 * x1  -  srcY1 * x2) + srcY0 * (srcX1 *  x2 - srcX2  * x1) + (srcX2 * srcY1 - srcX1 * srcY2) * x0) * d_inv, // imageOffsetX
-        (srcX0 * (srcY2 * y1  -  srcY1 * y2) + srcY0 * (srcX1 *  y2 - srcX2  * y1) + (srcX2 * srcY1 - srcX1 * srcY2) * y0) * d_inv  // imageOffsetY
-    );
+    // --- setup triangle transform and draw
+    ctx.setTransform(Matrix.fromTriangles(srcPtAry, tgtAry));
     ctx.drawImage(img, 0, 0);
     ctx.restore();
 }

--- a/src/firefly/js/visualize/iv/HiPSTileCache.js
+++ b/src/firefly/js/visualize/iv/HiPSTileCache.js
@@ -2,11 +2,11 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {initOffScreenCanvas} from './TileDrawHelper.jsx';
+import {createCanvas} from '../../util/WebUtil.js';
 
 
-const MAX_TILE_IMAGES= 150;
-const MAX_ALLSKY_IMAGES= 20;
-const MAX_FAIL_TILE_IMAGES= 400;
+const MAX_TILE_IMAGES= 400;
+const MAX_ALLSKY_IMAGES= 80;
 
 let cachedImages= new Map();
 let failedCachedImages= new Map();
@@ -23,35 +23,49 @@ let cachedAllSkyImages= new Map();
  */
 
 
+
+const makeKey= (url,colorTableId=-1,bias=.5,contrast=1) =>
+    `${url}-${colorTableId}-${Math.trunc(bias*100)}-${Math.trunc(contrast*100)}`;
+
 /**
  *
  * @param url
+ * @param colorTableId
+ * @param bias
+ * @param contrast
  * @return {HiPSAllSkyCacheInfo}
  */
-export function findAllSkyCachedImage(url) {
-    const result=  cachedAllSkyImages.get(url);
+export function findAllSkyCachedImage(url,colorTableId,bias,contrast) {
+    const result=  cachedAllSkyImages.get(makeKey(url,colorTableId,bias,contrast));
     if (result) result.time= Date.now();
     return result;
 }
 
-export function addAllSkyCachedImage(url, image) {
+export function addAllSkyCachedImage(url, image, colorTableId,bias,contrast) {
     const order2AllSky= makeOrder2AllSkyImages(image);
-    cachedAllSkyImages.set(url, {url, order3:image, order2Array: order2AllSky, colorTable: 'todo', time: Date.now()});
+    cachedAllSkyImages.set(makeKey(url,colorTableId,bias,contrast),
+        {url, colorTableId,bias,contrast, order3:image, order2Array: order2AllSky, colorTable: 'todo', time: Date.now()});
     if (cachedAllSkyImages.size>MAX_ALLSKY_IMAGES+(MAX_ALLSKY_IMAGES*.1)) {
         cachedAllSkyImages= cleanupCache(cachedAllSkyImages,MAX_ALLSKY_IMAGES);
     }
 }
 
 
-export function findTileCachedImage(url) {
-    const result=  cachedImages.get(url);
+export function findTileCachedImage(url, colorTableId,bias,contrast) {
+    const result= cachedImages.get(makeKey(url,colorTableId,bias,contrast));
     if (result) result.time= Date.now();
     return result;
 }
 
 
-export function addTileCachedImage(url, image, emptyTile= false) {
-    cachedImages.set(url, {url, image, emptyTile, colorTable: 'todo', time: Date.now()});
+export function addTileCachedImage(url, image, colorTableId,bias,contrast) {
+    let cacheImage= image;
+    if (image instanceof HTMLImageElement) {
+        cacheImage= createCanvas(image.width,image.height);
+        cacheImage.getContext('2d').drawImage(image,0,0);
+    }
+    cachedImages.set( makeKey(url,colorTableId,bias,contrast),
+        {url, image:cacheImage, colorTableId,bias,contrast, emptyTile:false, colorTable: 'todo', time: Date.now()});
     if (cachedImages.size>MAX_TILE_IMAGES+(MAX_TILE_IMAGES*.25)) {
         cachedImages= cleanupCache(cachedImages, MAX_TILE_IMAGES);
     }
@@ -59,23 +73,33 @@ export function addTileCachedImage(url, image, emptyTile= false) {
 
 export function addFailedImage(url) {
     const result=  cachedImages.get(url);
-    if (!result) failedCachedImages.set(url, Date.now());
+    if (!result) failedCachedImages.set(makeKey(url), Date.now());
 }
 
 export function isInFailTileCached(url) {
-    const time=  failedCachedImages.get(url);
+    const time=  failedCachedImages.get(makeKey(url));
     if (!time) return false;
     const found= Date.now()-time < (1000 * 10); // search less than 10 seconds old
     if (!found) failedCachedImages.delete(url);
     return found;
 }
 
+export function removeNonNativeCachedTiles() {
+    cachedImages= removeNonNativeTilesForCache(cachedImages);
+    cachedAllSkyImages= removeNonNativeTilesForCache(cachedAllSkyImages);
+}
 
 
 function cleanupCache(cacheMap, maxEntries) {
     const entries= Array.from(cacheMap.entries()).sort( (e1, e2) => e2[1].time-e1[1].time);
     if (entries.length>maxEntries) entries.length= maxEntries;
     return new Map(entries);
+}
+
+function removeNonNativeTilesForCache(cacheMap) {
+    const entries= Array.from(cacheMap.entries());
+    const newEntries= entries.filter( ([k,v]) => v.colorTableId===-1);
+    return new Map(newEntries);
 }
 
 
@@ -100,5 +124,4 @@ function makeOrder2AllSkyImages(order3Image) {
         allsky2Array[i]= canvas;
     }
     return allsky2Array;
-
 }

--- a/src/firefly/js/visualize/iv/HipsColor.js
+++ b/src/firefly/js/visualize/iv/HipsColor.js
@@ -1,0 +1,150 @@
+import {createCanvas} from '../../util/WebUtil.js';
+import {getColorModel} from '../rawData/rawAlgorithm/ColorTable.js';
+import {once} from 'lodash';
+import {removeNonNativeCachedTiles} from './HiPSTileCache.js';
+
+
+
+export const getHipsColorOps= once((GPU) => {
+
+    const gpu = new GPU({mode: 'gpu'});
+
+    const findPixelIdx= function(pixel, contrast, offsetShift) {
+        if (pixel===255) pixel= 254;
+        let pixelIdx= pixel*3;
+        if (offsetShift!==0) {
+            const newPixel = Math.floor( offsetShift+(pixel*contrast));
+            pixelIdx= (newPixel > 254) ? 762 : (newPixel<0) ? 0 : newPixel*3;
+        }
+        return pixelIdx;
+    };
+
+
+    // const hipsAnyTileSAVE= function(colorModel, data, contrast, offsetShift) {
+    //     const i= ((this.constants.height-this.thread.y-1) * this.constants.width) + this.thread.x;
+    //     const dI=i*4;
+    //     let pixel= Math.trunc((data[dI]+data[dI+1]+data[dI+2])/3);
+    //     if (pixel===255) pixel= 254;
+    //     let pixelIdx= pixel*3;
+    //     if (offsetShift!==0) {
+    //         const newPixel = Math.floor( offsetShift+(pixel*contrast));
+    //         pixelIdx= (newPixel > 254) ? 762 : (newPixel<0) ? 0 : newPixel*3;
+    //     }
+    //     this.color( colorModel[pixelIdx], colorModel[pixelIdx+1], colorModel[pixelIdx+2],1);
+    // };
+
+    const hipsAnyTile= Function('colorModel', 'data','contrast', 'offsetShift', `
+                 const i= ((this.constants.height-this.thread.y-1) * this.constants.width) + this.thread.x;
+                 const dI=i*4;
+                 let pixel= Math.trunc((data[dI]+data[dI+1]+data[dI+2])/3);
+                 if (pixel===255) pixel= 254;
+                 let pixelIdx= pixel*3;
+                 if (offsetShift!==0) {
+                     const newPixel = Math.floor( offsetShift+(pixel*contrast));
+                     pixelIdx= (newPixel > 254) ? 762 : (newPixel<0) ? 0 : newPixel*3;
+                 }
+                 this.color( colorModel[pixelIdx], colorModel[pixelIdx+1], colorModel[pixelIdx+2],1);`);
+
+
+    let hips512TileGPU;
+    let hips862by928AllSkyGPU;
+
+    function createKernals() {
+        hips512TileGPU= gpu.createKernel(hipsAnyTile,
+            {
+                graphical:true,
+                // dynamicArguments:true,
+                tactic: 'speed',
+                constants: {width:512,height:512},
+                output:[512,512],
+            });
+
+        // hips1728by1856AllSkyGPU= gpu.createKernel(hipsAnyTile,
+        //     {
+        //         graphical:true,
+        //         dynamicArguments:true,
+        //         tactic: 'speed',
+        //         constants: {width:1728,height:1856},
+        //         output:[1728,1856],
+        //     });
+
+        hips862by928AllSkyGPU= gpu.createKernel(hipsAnyTile,
+            {
+                graphical:true,
+                // dynamicArguments:true,
+                tactic: 'speed',
+                constants: {width:864,height:928},
+                output:[864,928],
+            });
+    }
+
+    createKernals();
+    const gpuCanvas = hips512TileGPU.canvas;
+    gpuCanvas.addEventListener('webglcontextlost', (ev) => {
+        ev.preventDefault();
+        createKernals();
+        removeNonNativeCachedTiles();
+        console.log('reset gpu context');
+    }, false);
+
+
+    const changeHiPSColor= (image, ct, bias=.5, contrast=1) => {
+        const width= image.width;
+        const height= image.height;
+        const c= createCanvas(width,height);
+        const outCtx= c.getContext('2d');
+        let inCtx;
+        if (image instanceof HTMLCanvasElement) {
+            inCtx= image.getContext('2d');
+        }
+        else {
+            outCtx.drawImage(image,0,0);
+            inCtx= outCtx;
+        }
+
+        const getInData= (x,y,w,h) => inCtx.getImageData(x,y,w,h).data;
+
+        const cm= getColorModel(ct);
+        const offset = (127*(bias-0.5)*-4);
+        const shift = (127*(1-contrast));
+        const offsetShift= offset+shift;
+
+        if (width===512 && height===512) {
+            hips512TileGPU( cm, getInData(0,0,width,height), contrast, offset+shift);
+            const gpuCanvas= hips512TileGPU.canvas;
+            outCtx.drawImage(hips512TileGPU.canvas,0,gpuCanvas.height-512,width,height,0,0,width,height);
+        }
+        else if (width===1728 && height===1856) {
+            const updateAllSky= (gx,gy) => {
+                const w2=864;
+                const h2=928;
+                hips862by928AllSkyGPU(cm, getInData(w2*gx,h2*gy,w2,h2), contrast, offset+shift);
+                outCtx.drawImage(hips862by928AllSkyGPU.canvas,
+                    0,hips862by928AllSkyGPU.canvas.height-h2,w2,h2,
+                    w2*gx,h2*gy,w2,h2);
+            };
+
+            for(let i=0; (i<2); i++) {
+                for(let j=0; (j<2); j++) {
+                    updateAllSky(i, j);
+                }
+            }
+        }
+        else { // non-GPU approach
+            let pixel, pixelIdx;
+            const imData= inCtx.getImageData(0,0,width,height);
+            const data= imData.data;
+            const len= imData.data.length;
+            for(let i= 0, j=0; i<len; i+=4, j++) {
+                pixel= Math.trunc((data[i]+data[i+1]+data[i+2])/3);
+                pixelIdx= findPixelIdx(pixel,contrast,offsetShift);
+                data[i] = cm[pixelIdx] * 255;
+                data[i+1] = cm[pixelIdx + 1] * 255;
+                data[i+2] = cm[pixelIdx + 2] * 255;
+            }
+            outCtx.putImageData(imData,0,0);
+        }
+        return c;
+    };
+    return {changeHiPSColor};
+});

--- a/src/firefly/js/visualize/iv/ImageProcessor.js
+++ b/src/firefly/js/visualize/iv/ImageProcessor.js
@@ -33,6 +33,9 @@ export function retrieveAndProcessImage(imageData, nextTileAttributes, shouldPro
     if (!imageData) {
         return Promise.resolve(imageData);
     }
+    else if (imageData instanceof HTMLCanvasElement) {
+        return {promise:Promise.resolve(imageData)};
+    }
     else if (isString(imageData)) {
         let {promise, cancelImageLoad}= loadCancelableImage(imageData);
 

--- a/src/firefly/js/visualize/iv/ImageRender.jsx
+++ b/src/firefly/js/visualize/iv/ImageRender.jsx
@@ -10,6 +10,8 @@ import {createHiPSDrawer} from './HiPSTileDrawer.js';
 import {isImage} from '../WebPlot.js';
 import {CANVAS_IMAGE_ID_START} from '../PlotViewUtil.js';
 import {primePlot} from '../PlotViewUtil';
+import {getGpuJs, getGpuJsImmediate} from '../rawData/GpuJsConfig.js';
+import {getRootURL} from '../../util/WebUtil.js';
 
 const BG_IMAGE= 'image-working-background-24x24.png';
 const BACKGROUND_STYLE = `url(+ ${BG_IMAGE} ) top left repeat`;
@@ -30,9 +32,14 @@ const containerStyle={position:'absolute',
  * @param {WebPlot} plot
  * @return {*}
  */
-export function initTileDrawer(targetCanvas, plot) {
+function initTileDrawer(targetCanvas, plot) {
     if (!targetCanvas) return () => undefined;
-    return isImage(plot) ? initImageDrawer(targetCanvas) : createHiPSDrawer(targetCanvas);
+    if (isImage(plot)) {
+        return initImageDrawer(targetCanvas);
+    }
+    else {
+        return createHiPSDrawer(targetCanvas, getGpuJsImmediate());
+    }
 }
 
 

--- a/src/firefly/js/visualize/rawData/GpuJsConfig.js
+++ b/src/firefly/js/visualize/rawData/GpuJsConfig.js
@@ -7,6 +7,8 @@ import {loadScript, getRootURL, getGlobalObj} from '../../util/WebUtil.js';
 const GPU_JS_SCRIPT= 'gpu-browser.min-2.10.0.js';
 const LOAD_ERR_MSG= 'Load Failed: could not load gpu.js';
 
+let foundGPU;
+
 function initGpuJsRetriever(loadNow) {
     let gpuJsLoadBegin= false;
     let waitingResolvers= [];
@@ -25,6 +27,7 @@ function initGpuJsRetriever(loadNow) {
             loadScript(script).then( () => {
                 loadedGpuJs= getGlobalObj().GPU;
                 if (loadedGpuJs) {
+                    foundGPU= loadedGpuJs;
                     waitingResolvers.forEach((r) => r(loadedGpuJs));
                 } else {
                     console.log(`GPU object is not available after ${script} is loaded`);
@@ -56,3 +59,6 @@ function initGpuJsRetriever(loadNow) {
  * function to return a promise to gpu.js
  */
 export const getGpuJs= initGpuJsRetriever(false);
+
+
+export const getGpuJsImmediate = () => foundGPU;

--- a/src/firefly/js/visualize/rawData/RawDataOps.js
+++ b/src/firefly/js/visualize/rawData/RawDataOps.js
@@ -1,7 +1,7 @@
 import {isArray, isArrayBuffer, uniqueId} from 'lodash';
 import {allBandAry, Band} from '../Band.js';
 import {contains, intersects} from '../VisUtil.js';
-import {getPlotViewById, isThreeColor, primePlot} from '../PlotViewUtil.js';
+import {findPlot, getPlotViewById, isThreeColor, primePlot} from '../PlotViewUtil.js';
 import {createCanvas, isGPUAvailableInWorker, isImageBitmap} from '../../util/WebUtil.js';
 import ImagePlotCntlr, {dispatchRequestLocalData, visRoot} from '../ImagePlotCntlr.js';
 import {PlotState} from '../PlotState.js';
@@ -367,7 +367,8 @@ async function loadStandardStretchData( plot, checkForPlotUpdate, workerKey) {
         let latestPlot;
         let continueLoading;
         if (checkForPlotUpdate) {
-            latestPlot = primePlot(visRoot(), plotId);
+            const latestPlotView= getPlotViewById(visRoot(),plot.plotId);
+            latestPlot= findPlot(latestPlotView,plot.plotImageId);
             if (!latestPlot) return;
             const {plotState} = latestPlot;
             continueLoading = plotState.getBands().every((b) => plotState.getRangeValues(b)?.toJSON() === plot.plotState.getRangeValues(b)?.toJSON());
@@ -449,6 +450,8 @@ async function load3ColorRawData( plot, workerKey) {
     if (!latestPlot) return;
     const stretchResult= await postToWorker(makeStretchAction(latestPlot, Band.NO_BAND,workerKey));
     latestPlot= primePlot(visRoot(),plot.plotId);
+    const latestPlotView= getPlotViewById(visRoot(),plot.plotId);
+    latestPlot= findPlot(latestPlotView,plot.plotImageId);
     if (!latestPlot) return;
     return completeLoad(latestPlot,stretchResult);
 }

--- a/src/firefly/js/visualize/rawData/RawImageTilesGPU.js
+++ b/src/firefly/js/visualize/rawData/RawImageTilesGPU.js
@@ -14,82 +14,61 @@ export const getGPUOps= once((GPU) => {
                 let pixelIdx= pixel*3;
                 if (offsetShift!==0) {
                     const newPixel = Math.floor( offsetShift+(pixel*contrast));
-                    if (newPixel>254) pixelIdx= 762;
-                    else if (newPixel<0) pixelIdx= 0;
-                    else pixelIdx= newPixel*3;
+                    pixelIdx= (newPixel > 254) ? 762 : (newPixel<0) ? 0 : newPixel*3;
                 }
-                this.color( colorModel[pixelIdx]/255, colorModel[pixelIdx+1]/255, colorModel[pixelIdx+2]/255);
+                this.color( colorModel[pixelIdx], colorModel[pixelIdx+1], colorModel[pixelIdx+2]);
             }
             else {
                 this.color( 0,0,0);
-            }`);
+            }`
+    );
 
 
-    // function(pixelAry, colorModel,height, contrast, offsetShift) {
+    // const standardFunc= function(pixelAry, colorModel,height, contrast, offsetShift) {
     //         const pixel= pixelAry[height-this.thread.y][this.thread.x];
     //         if (pixel!==255) {
     //             let pixelIdx= pixel*3;
     //             if (offsetShift!==0) {
     //                 const newPixel = Math.floor( offsetShift+(pixel*contrast));
-    //                 if (newPixel>254) pixelIdx= 762;
-    //                 else if (newPixel<0) pixelIdx= 0;
-    //                 else pixelIdx= newPixel*3;
+    //                 pixelIdx= (newPixel > 254) ? 762 : (newPixel<0) ? 0 : newPixel*3;
     //             }
-    //             this.color( colorModel[pixelIdx]/255, colorModel[pixelIdx+1]/255, colorModel[pixelIdx+2]/255);
+    //             this.color( colorModel[pixelIdx], colorModel[pixelIdx+1], colorModel[pixelIdx+2]);
     //         }
     //         else {
     //             this.color( 0,0,0);
     //         }
-    //
+
     const standRawDataTileGPU = gpu.createKernel(standardFunc,{graphical:true, dynamicOutput:true, dynamicArguments:true, tactic: 'speed'});
     
 
-    // const standRawDataTileGPU = gpu.createKernel(function(pixelAry, colorModel,height, contrast, offsetShift) {
-    //     const pixel= pixelAry[height-this.thread.y][this.thread.x];
-    //     if (pixel!==255) {
-    //         let pixelIdx= pixel*3;
-    //         if (offsetShift!==0) {
-    //             const newPixel = Math.floor( offsetShift+(pixel*contrast));
-    //             if (newPixel>254) pixelIdx= 762;
-    //             else if (newPixel<0) pixelIdx= 0;
-    //             else pixelIdx= newPixel*3;
-    //             // pixelIdx= (newPixel > 254) ? 762 : (newPixel<0) ? 0 : newPixel*3;
-    //         }
-    //         this.color( colorModel[pixelIdx]/255, colorModel[pixelIdx+1]/255, colorModel[pixelIdx+2]/255);
-    //     }
-    //     else {
-    //         this.color( 0,0,0);
-    //     }
-    // },{graphical:true, dynamicOutput:true, dynamicArguments:true, tactic: 'speed'});
-
-
     const threeCFunc= Function(
-        'redAry', 'greenAry', 'blueAry', 'useR', 'useG', 'useB', 'contrast', 'offsetShift', 'width','height',
-    `const idx= (height - this.thread.y) * width + this.thread.x;
-    let r= useR ? redAry[idx] : 0;
-    let g= useG ? greenAry[idx] : 0;
-    let b= useB ? blueAry[idx] : 0;
-    if (offsetShift!==0) {
-        if (r!==0) {
-            r= Math.floor( offsetShift+(r*contrast));
-            r= (r > 254) ? 254 : (r<0) ? 0 : r;
-        }
-        if (g!==0) {
-            g= Math.floor( offsetShift+(g*contrast));
-            g= (g > 254) ? 254 : (g<0) ? 0 : g;
-        }
-        if (b!==0) {
-            b= Math.floor( offsetShift+(b*contrast));
-            b= (b > 254) ? 254 : (b<0) ? 0 : b;
-        }
-    }
-    this.color( r/255, g/255, b/255, 1);` );
+        'redAry', 'greenAry', 'blueAry', 'useR', 'useG', 'useB', 'contrast', 'offsetShift', 'width','height', `
+            const idx= (height - this.thread.y) * width + this.thread.x;
+            let r= useR ? redAry[idx] : 0;
+            let g= useG ? greenAry[idx] : 0;
+            let b= useB ? blueAry[idx] : 0;
+            if (offsetShift!==0) {
+                if (r!==0) {
+                    r= Math.floor( offsetShift+(r*contrast));
+                    r= (r > 254) ? 254 : (r<0) ? 0 : r;
+                }
+                if (g!==0) {
+                    g= Math.floor( offsetShift+(g*contrast));
+                    g= (g > 254) ? 254 : (g<0) ? 0 : g;
+                }
+                if (b!==0) {
+                    b= Math.floor( offsetShift+(b*contrast));
+                    b= (b > 254) ? 254 : (b<0) ? 0 : b;
+                }
+            }
+            this.color( r/255, g/255, b/255, 1);`
+    );
 
 
     const threeCRawDataTileGPU = gpu.createKernel(threeCFunc,{graphical:true, dynamicOutput:true, dynamicArguments:true, tactic: 'speed'});
 
 
-    // const threeCRawDataTileGPU = gpu.createKernel(function(redAry, greenAry, blueAry, useR, useG, useB, contrast, offsetShift, width,height) {
+    // const threeCFunc = function(redAry, greenAry, blueAry, useR, useG, useB, contrast, offsetShift, width,height) {
     //     const idx= (height - this.thread.y) * width + this.thread.x;
     //     let r= useR ? redAry[idx] : 0;
     //     let g= useG ? greenAry[idx] : 0;
@@ -109,7 +88,9 @@ export const getGPUOps= once((GPU) => {
     //         }
     //     }
     //     this.color( r/255, g/255, b/255, 1);
-    // },{graphical:true, dynamicOutput:true, dynamicArguments:true, tactic: 'speed'});
+    // };
+
+
     async function createTransitionalTileWithGPU(inData, colorModel, isThreeColor, bias=.5, contrast=1, bandUse) {
         const canvas= createTileWithGPU(inData,colorModel,isThreeColor, bias,contrast, bandUse);
 
@@ -198,5 +179,3 @@ export const getGPUOps= once((GPU) => {
 
     return {createTransitionalTileWithGPU, createTileWithGPU};
 });
-
-

--- a/src/firefly/js/visualize/rawData/rawAlgorithm/ColorTable.js
+++ b/src/firefly/js/visualize/rawData/rawAlgorithm/ColorTable.js
@@ -742,74 +742,69 @@ export function getCurrentColorModel() {
 	return defaultColorModel;
 }
 
-export const getColorModelNEW= memorizeLastCall((colorTableId) => {
-	let old_dn, old_red, old_green, old_blue;
-	let offset;
-	let k;
 
-	//palette: 3 bytes per color * 256 colors = 768 bytes in length
-	// const paletteData = new Uint8Array(768);
-	const paletteData = Array(256)
-	const id= String(colorTableId);
-	const ct= getColorTableMap()[id];
-
-	if (id==='file') console.log('file color tables not yet supported');
-
-	if (!ct) {
-		console.log('ColorTable ERROR: no color table with the ID = ' + id);
-		return [];
-	}
-
-	k = 0;
-	let dn      = ct[k];
-	let red     = ct[k+1];
-	let green   = ct[k+2];
-	let blue    = ct[k+3];
-	k+=4;
-
-	while(true) {
-		old_dn = dn;
-		old_red = red;
-		old_green = green;
-		old_blue = blue;
-
-		if (k>=ct.length) break;
-		dn      = ct[k];
-		red     = ct[k+1];
-		green   = ct[k+2];
-		blue    = ct[k+3];
-		k+=4;
-
-		const inc= (dn > old_dn) ? 1 : -1;
-
-		for(let kk = old_dn; kk !== dn; kk += inc) {
-			if(kk>=0 && kk<=255) {
-				offset =  (kk-old_dn) / (dn-old_dn);
-				paletteData[kk]=Uint8ClampedArray.of(
-					(old_red   + Math.trunc(offset*(red   - old_red  ))),
-					(old_green + Math.trunc(offset*(green - old_green))),
-					(old_blue  + Math.trunc(offset*(blue  - old_blue ))),
-				);
-			}
-		}
-	}
-
-	if(old_dn>=0 && old_dn<=255)
-	{
-		// paletteData[3*old_dn] =  old_red;
-		// paletteData[3*old_dn+1] =  old_green;
-		// paletteData[3*old_dn+2] =  old_blue;
-		paletteData[old_dn]= Uint8ClampedArray.of(old_red,old_green,old_blue);
-	}
-	/* DEBUG set top color = red */
-	// paletteData[3*255] = 255;
-	// paletteData[3*255 + 1] = 0;
-	// paletteData[3*255 + 2] = 0;
-	paletteData[255]= Uint8ClampedArray.of(255,0,0);
-	/* END DEBUG */
-	return paletteData;
-});
-
+// export const getColorModel= memorizeLastCall((colorTableId) => {
+// 	let old_dn, old_red, old_green, old_blue;
+// 	let offset;
+// 	let k;
+//
+// 	//palette: 3 bytes per color * 256 colors = 768 bytes in length
+// 	const paletteData = new Uint8Array(768);
+// 	const id= String(colorTableId);
+// 	const ct= getColorTableMap()[id];
+//
+// 	if (id==='file') console.log('file color tables not yet supported');
+//
+// 	if (!ct) {
+// 		console.log('ColorTable ERROR: no color table with the ID = ' + id);
+// 		return [];
+// 	}
+//
+// 	k = 0;
+// 	let dn      = ct[k];
+// 	let red     = ct[k+1];
+// 	let green   = ct[k+2];
+// 	let blue    = ct[k+3];
+// 	k+=4;
+//
+// 	while(true) {
+// 		old_dn = dn;
+// 		old_red = red;
+// 		old_green = green;
+// 		old_blue = blue;
+//
+// 		if (k>=ct.length) break;
+// 		dn      = ct[k];
+// 		red     = ct[k+1];
+// 		green   = ct[k+2];
+// 		blue    = ct[k+3];
+// 		k+=4;
+//
+// 		const inc= (dn > old_dn) ? 1 : -1;
+//
+// 		for(let kk = old_dn; kk !== dn; kk += inc) {
+// 			if(kk>=0 && kk<=255) {
+// 				offset =  (kk-old_dn) / (dn-old_dn);
+// 				paletteData[3*kk] = (old_red   + Math.trunc(offset*(red   - old_red  )));
+// 				paletteData[3*kk+1] = (old_green + Math.trunc(offset*(green - old_green)));
+// 				paletteData[3*kk+2] = (old_blue  + Math.trunc(offset*(blue  - old_blue )));
+// 			}
+// 		}
+// 	}
+//
+// 	if(old_dn>=0 && old_dn<=255)
+// 	{
+// 		paletteData[3*old_dn] =  old_red;
+// 		paletteData[3*old_dn+1] =  old_green;
+// 		paletteData[3*old_dn+2] =  old_blue;
+// 	}
+// 	/* DEBUG set top color = red */
+// 	paletteData[3*255] = 255;
+// 	paletteData[3*255 + 1] = 0;
+// 	paletteData[3*255 + 2] = 0;
+// 	/* END DEBUG */
+// 	return paletteData;
+// });
 
 export const getColorModel= memorizeLastCall((colorTableId) => {
 	let old_dn, old_red, old_green, old_blue;
@@ -817,7 +812,7 @@ export const getColorModel= memorizeLastCall((colorTableId) => {
 	let k;
 
 	//palette: 3 bytes per color * 256 colors = 768 bytes in length
-	const paletteData = new Uint8Array(768);
+	const paletteData = new Float32Array(768);
 	const id= String(colorTableId);
 	const ct= getColorTableMap()[id];
 
@@ -853,21 +848,21 @@ export const getColorModel= memorizeLastCall((colorTableId) => {
 		for(let kk = old_dn; kk !== dn; kk += inc) {
 			if(kk>=0 && kk<=255) {
 				offset =  (kk-old_dn) / (dn-old_dn);
-				paletteData[3*kk] = (old_red   + Math.trunc(offset*(red   - old_red  )));
-				paletteData[3*kk+1] = (old_green + Math.trunc(offset*(green - old_green)));
-				paletteData[3*kk+2] = (old_blue  + Math.trunc(offset*(blue  - old_blue )));
+				paletteData[3*kk] = (old_red   + Math.trunc(offset*(red   - old_red  )))/255;
+				paletteData[3*kk+1] = (old_green + Math.trunc(offset*(green - old_green)))/255;
+				paletteData[3*kk+2] = (old_blue  + Math.trunc(offset*(blue  - old_blue )))/255;
 			}
 		}
 	}
 
 	if(old_dn>=0 && old_dn<=255)
 	{
-		paletteData[3*old_dn] =  old_red;
-		paletteData[3*old_dn+1] =  old_green;
-		paletteData[3*old_dn+2] =  old_blue;
+		paletteData[3*old_dn] =  old_red/255;
+		paletteData[3*old_dn+1] =  old_green/255;
+		paletteData[3*old_dn+2] =  old_blue/255;
 	}
 	/* DEBUG set top color = red */
-	paletteData[3*255] = 255;
+	paletteData[3*255] = 255/255;
 	paletteData[3*255 + 1] = 0;
 	paletteData[3*255 + 2] = 0;
 	/* END DEBUG */

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -224,7 +224,7 @@ function changeLocking(state,action) {
 
 function zoomStart(state, action) {
     const {wcsMatchType, plotViewAry, expandedMode, mpwWcsPrimId}= state;
-    const {plotId, zoomLevel, userZoomType, zoomLockingEnabled}= action.payload;
+    const {plotId, zoomLevel, userZoomType, zoomLockingEnabled, devicePt}= action.payload;
     const pvIdx=getPlotViewIdxById(state,plotId);
     const plot= pvIdx>-1 ? primePlot(plotViewAry[pvIdx]) : null;
     if (!plot) return state;
@@ -238,8 +238,8 @@ function zoomStart(state, action) {
 
     // update zoom factor and scroll position
     const centerImagePt= isFitFill(userZoomType) ?
-                          makeImagePt(plot.dataWidth/2, plot.dataHeight/2) :
-                          findCurrentCenterPoint(pv);
+                          makeImagePt(plot.dataWidth/2, plot.dataHeight/2) : findCurrentCenterPoint(pv);
+    const mouseOverImagePt= devicePt && CCUtil.getImageCoords(plot,devicePt);
 
     pv= replacePrimaryPlot(pv,clonePlotWithZoom(plot,zoomLevel));
 
@@ -249,7 +249,15 @@ function zoomStart(state, action) {
         pv= updateScrollToWcsMatch(state.wcsMatchType, masterPv, pv);
     }
     else {
-        pv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt));
+        if (isImage(plot)) {
+            pv= updatePlotViewScrollXY(pv,
+                devicePt ? findScrollPtToPlaceOnDevPt(pv, mouseOverImagePt,devicePt) :
+                findScrollPtToCenterImagePt(pv,centerImagePt));
+
+        }
+        else {
+            pv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv,centerImagePt));
+        }
     }
 
 

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -527,3 +527,14 @@ export function findScrollPtToPlaceOnDevPt(pv, ipt, targetDevPtPos) {
 
     return makeScreenPt(pv.flipY ? -x : x,pv.flipX ? -y : y);
 }
+
+
+export function findHipsCenProjToPlaceWptOnDevPt(pv, wpt, targetDevPtPos) {
+    const plot= primePlot(pv);
+    const cc= CysConverter.make(plot);
+    const {viewDim:{width,height}}= plot;
+    const offX= targetDevPtPos.x-width/2;
+    const offY= targetDevPtPos.y-height/2;
+    const tarAsDevPt= cc.getDeviceCoords(wpt);
+    return cc.getWorldCoords(makeDevicePt(tarAsDevPt.x-offX, tarAsDevPt.y-offY));
+}

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -19,7 +19,7 @@ import ImagePlotCntlr, {
 import {UserZoomTypes} from '../ZoomUtil.js';
 import {WebPlot, isHiPS, isImage} from '../WebPlot.js';
 import {PlotAttribute} from '../PlotAttribute.js';
-import {loadImage} from '../../util/WebUtil.js';
+import {getRootURL, loadImage} from '../../util/WebUtil.js';
 import {
     findCurrentCenterPoint,
     getCenterOfProjection,
@@ -62,6 +62,7 @@ import {getActiveTableId} from '../../tables/TableUtil';
 import {locateOtherIfMatched, matchHiPStoPlotView} from './WcsMatchTask';
 import {upload} from '../../rpc/CoreServices.js';
 import {fetchUrl} from '../../util/fetch';
+import {getGpuJs} from '../rawData/GpuJsConfig.js';
 
 const PROXY= true;
 
@@ -265,6 +266,7 @@ async function makeHiPSPlot(rawAction, dispatcher) {
             return;
         }
         plot= await addAllSky(plot);
+        const GPU= await getGpuJs(getRootURL());
         createHiPSGridLayer();
         dispatchAddActionWatcher({
             actions:[ImagePlotCntlr.PLOT_HIPS, ImagePlotCntlr.UPDATE_VIEW_SIZE],

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -8,7 +8,6 @@ import ImagePlotCntlr, {
     visRoot,
     makeUniqueRequestKey,
     IMAGE_PLOT_KEY,
-    dispatchRequestLocalData
 } from '../ImagePlotCntlr.js';
 import {dlRoot, dispatchCreateDrawLayer, dispatchAttachLayerToPlot} from '../DrawLayerCntlr.js';
 import {dispatchActiveTarget, getActiveTarget} from '../../core/AppDataCntlr.js';

--- a/src/firefly/js/visualize/task/WcsMatchTask.js
+++ b/src/firefly/js/visualize/task/WcsMatchTask.js
@@ -197,6 +197,7 @@ export const {matchImageToHips, matchHiPStoPlotView}= (() => {
 
     return {
         matchImageToHips: (hipsPv, imagePv) => {
+            if (isHiPS(primePlot(imagePv))) return;
             if (lock) return;
             lock= true;
             imageToHips(hipsPv,imagePv);

--- a/src/firefly/js/visualize/task/ZoomTask.js
+++ b/src/firefly/js/visualize/task/ZoomTask.js
@@ -75,8 +75,9 @@ export function zoomActionCreator(rawAction) {
         if (actionScope===ActionScope.GROUP) {
             const {wcsMatchType}= visRoot;
             const matchByScale= (wcsMatchType!==WcsMatchType.Pixel && wcsMatchType!==WcsMatchType.PixelCenter);
+            const devPt= isHiPS(plot) ? undefined : devicePt;
             const matchFunc= makeZoomLevelMatcher(dispatcher, visRoot,pv,level,matchByScale, isFullScreen,
-                                                   zoomLockingEnabled,userZoomType,devicePt, useDelay, getState);
+                                                   zoomLockingEnabled,userZoomType,devPt, useDelay, getState);
             operateOnOthersInPositionGroup(getState()[IMAGE_PLOT_KEY],pv, matchFunc);
         }
         alignWCS(getState,pv);

--- a/src/firefly/js/visualize/ui/ActivateMenu.jsx
+++ b/src/firefly/js/visualize/ui/ActivateMenu.jsx
@@ -12,6 +12,7 @@ import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
 
 const GROUP_KEY= 'ActivateMenu';
 
+const titleStyle= {width: '100%', textAlign:'center', padding:'10px 0 5px 0', fontSize:'larger', fontWeight:'bold'};
 
 export const ActivateMenu= memo(({ serDefParams, setSearchParams, title, makeDropDown}) => {
 
@@ -24,10 +25,11 @@ export const ActivateMenu= memo(({ serDefParams, setSearchParams, title, makeDro
         <div>
             {makeDropDown?.()}
             <div style={{padding: '5px 5px 5px 5px'}}>
+                <div style= {titleStyle}> {title} </div>
                 <FieldGroup groupKey={GROUP_KEY} validatorFunc={null} keepState={false}>
                     {makeActivateInput(serDefParams)}
                 </FieldGroup>
-                <CompleteButton style={{padding: '10px 0 0 0'}} onSuccess={loadParams} text={'Load - '+title} groupKey={GROUP_KEY} />
+                <CompleteButton style={{padding: '20px 0 0 0'}} onSuccess={loadParams} text={'Submit'} groupKey={GROUP_KEY} />
             </div>
         </div>
     );
@@ -55,15 +57,17 @@ function makeActivateInput(serDefParams) {
             if (options) {
                 const fieldOps = options.split(',').map( (op) => ({label:op,value:op}));
                 return (
-                    <RadioGroupInputField
-                        key={name}
-                        initialState= {{
-                            value: fieldOps[0],
-                            tooltip,
-                            label: {name}
-                        }}
-                        options={fieldOps} alignment='vertical' fieldKey={name} groupKey={GROUP_KEY}/>
-                    );
+                    <div key={name} style={{paddingTop:16}}>
+                        <RadioGroupInputField
+                            key={name}
+                            initialState= {{
+                                value: fieldOps[0].value,
+                                tooltip,
+                                label: name
+                            }}
+                            options={fieldOps} alignment='vertical' fieldKey={name} groupKey={GROUP_KEY}/>
+                    </div>
+                );
             }
             else {
                 return (

--- a/src/firefly/js/visualize/ui/ActivateMenu.jsx
+++ b/src/firefly/js/visualize/ui/ActivateMenu.jsx
@@ -1,0 +1,95 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {memo} from 'react';
+import PropTypes, {string,func, object, arrayOf} from 'prop-types';
+import {FieldGroup} from '../../ui/FieldGroup.jsx';
+import {CompleteButton} from '../../ui/CompleteButton.jsx';
+import {ValidationField} from '../../ui/ValidationField.jsx';
+import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
+
+
+const GROUP_KEY= 'ActivateMenu';
+
+
+export const ActivateMenu= memo(({ serDefParams, setSearchParams, title, makeDropDown}) => {
+
+
+    const loadParams= (request) => {
+        setSearchParams(request);
+    };
+
+    return (
+        <div>
+            {makeDropDown?.()}
+            <div style={{padding: '5px 5px 5px 5px'}}>
+                <FieldGroup groupKey={GROUP_KEY} validatorFunc={null} keepState={false}>
+                    {makeActivateInput(serDefParams)}
+                </FieldGroup>
+                <CompleteButton style={{padding: '10px 0 0 0'}} onSuccess={loadParams} text={'Load - '+title} groupKey={GROUP_KEY} />
+            </div>
+        </div>
+    );
+});
+
+ActivateMenu.propTypes= {
+    serDefParams: arrayOf(object),
+    title: string,
+    setSearchParams: func,
+    makeDropDown: func
+};
+
+
+/**
+ * @param {ServiceDescriptorInputParam} serviceDefParams
+ * @return {*}
+ */
+
+function makeActivateInput(serDefParams) {
+    return serDefParams
+        .filter( (sdP) => !sdP.ref )
+        .map( (sdP) => {
+            const {optionalParam,minValue, maxValue,value, name,options,desc:tooltip} = sdP;
+
+            if (options) {
+                const fieldOps = options.split(',').map( (op) => ({label:op,value:op}));
+                return (
+                    <RadioGroupInputField
+                        key={name}
+                        initialState= {{
+                            value: fieldOps[0],
+                            tooltip,
+                            label: {name}
+                        }}
+                        options={fieldOps} alignment='vertical' fieldKey={name} groupKey={GROUP_KEY}/>
+                    );
+            }
+            else {
+                return (
+                    <div key={name} style={{paddingTop:8}}>
+                        <ValidationField
+                            style={{width: 300}}
+                            labelStyle={{textAlign:'right'}}
+                            initialState= {{
+                                value: value || '',
+                                tooltip,
+                                validator: (s) => {
+                                    return s||optionalParam ? { valid : true, message : '' } :
+                                        { valid : false, message : 'Value is Required' };
+                                }
+                            }}
+                            fieldKey={name}
+                            groupKey={GROUP_KEY}
+                            labelWidth={100}
+                            label={`${name}${optionalParam?(' (optional)'):''}: `}
+                        />
+                        {minValue && <div style={{paddingTop:5, textAlign:'center'}}>{`Min Value: ${minValue}`}</div>}
+                        {maxValue && <div style={{paddingTop:5, textAlign:'center'}}>{`Max Value: ${maxValue}`}</div>}
+                    </div>
+                );
+            }
+    });
+
+}
+

--- a/src/firefly/js/visualize/ui/MagnifiedView.jsx
+++ b/src/firefly/js/visualize/ui/MagnifiedView.jsx
@@ -139,7 +139,10 @@ function showMagUsingLocal(x,y,pv, plot,size,sizeOffX,sizeOffY) {
     // const dataUrl=  magCanvas.toDataURL();
 
     const drawOnCanvas= (targetCanvas) => {
-        targetCanvas && targetCanvas.getContext('2d').drawImage(magCanvas,0,0);
+        if (!targetCanvas) return;
+        const ctx= targetCanvas.getContext('2d');
+        ctx.clearRect(0, 0, targetCanvas.width, targetCanvas.height);
+        targetCanvas.getContext('2d').drawImage(magCanvas,0,0);
     };
 
     // const s= { position : 'absolute', left : 0, top : 0};

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -34,10 +34,10 @@ export const ThumbnailView = memo(({plotView:pv}) => {
     }, [dataRef.current.drawData]);
 
     const plot= primePlot(pv);
-    if (!plot?.tileData || isHiPS(plot)) return <div style={s}/>;
+    if ( (!plot?.tileData && !hasLocalStretchByteData(plot)) || isHiPS(plot)) return <div style={s}/>;
 
     s.border= '1px solid rgb(187, 187, 187)';
-    const {width,height}= plot.tileData.thumbnailImage;
+    const {width=70,height=70}= plot.tileData?.thumbnailImage ?? {};
     dataRef.current.drawData= makeDrawing(pv,width,height);
 
     const affTrans= makeTransform(0,0,0,0,pv.rotation, pv.flipX, pv.flipY,
@@ -113,7 +113,7 @@ function scrollPlot(pt,pv,width,height) {
 
 function makeImageTag(pv, onImageLoad) {
     const plot= primePlot(pv);
-    const {url,width,height}= plot.tileData.thumbnailImage;
+    const {url, width=70,height=70}= plot.tileData?.thumbnailImage ?? {};
     const s= { position : 'absolute', left : 0, top : 0, width, height };
     const transFormCss= makeThumbnailTransformCSS(pv.rotation,pv.flipX, pv.flipY);
     

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -198,7 +198,7 @@ export const VisToolbarView = memo( ({visRoot,dlCount}) => {
             <DropDownToolbarButton icon={COLOR}
                                    tip='Change the color table'
                                    enabled={enabled} horizontal={true}
-                                   visible={image}
+                                   visible={true}
                                    dropDown={<ColorTableDropDownView plotView={pv}/>} />
 
             <DropDownToolbarButton icon={STRETCH}


### PR DESCRIPTION
### Firefly-677: service descriptors support

  - Better error handling
  - input area for service descriptors that take input
  - Obs core with service descriptors supported
  - Service descriptors in table results supported
  - Non-datalink Obs core that only have one product will be combine with all defined service descriptors
  - handle datalink service descriptors
  - Bug fix: fix some bugs with the new local byte data
  - Feature: Mouse wheel zoom, will now hold the pixel
  - add support for sending timeseries to the timeseries viewer
  - clean up of LcViewer.jsx, convert to functional components


_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-677

### Testing

https://fireflydev.ipac.caltech.edu/firefly-677-servdesc/firefly/?__action=layout.showDropDown&

Using the Tap panel:
- search:  irsa, ztf, ztf_objects_dr3
   - This data set contains one service descriptors
- search: CADC, ivoa, obscore
   - most data products contain some service descriptors (under the `more...` dropdown)
   - most times these down work,  I think it is  a CADC issue, but it is difficult to prove
- upload the file, attached to the ticket:  `ztf-search-result-enhanced-for-ticket.xml`
   - this file has two service descriptors, so you will see the `more...` dropdown
   - try the second one: `show ztf lightcurve in firefly`






