### PR TITLE
IRSA-3851: ${filename} appears in table title

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UserCatalogQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UserCatalogQuery.java
@@ -59,13 +59,7 @@ public class UserCatalogQuery extends IpacTablePartProcessor {
         if (filePath!=null) {
             UploadFileInfo uFi=(UploadFileInfo)UserCache.getInstance().get(new StringKey(filePath));
             if (uFi!=null) {
-                String currentTitle= ((TableServerRequest) request).getMeta().get("title");
-                if (StringUtils.isEmpty(currentTitle)) {
-                    meta.setAttribute("title", uFi.getFileName());
-                }
-                else {
-                    meta.setAttribute("title", currentTitle.replace("${filename}",uFi.getFileName()));
-                }
+                meta.setAttribute("title", uFi.getFileName());
             }
         }
         meta.setAttribute(MetaConst.CATALOG_OVERLAY_TYPE, "TRUE");

--- a/src/firefly/js/tables/TableRequestUtil.js
+++ b/src/firefly/js/tables/TableRequestUtil.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, set, unset, cloneDeep, omit, omitBy, isNil} from 'lodash';
+import {get, set, unset, cloneDeep, omit, omitBy, isNil, pickBy} from 'lodash';
 
 import {uniqueTblId} from './TableUtil.js';
 import {Keys} from '../core/background/BackgroundStatus.js';
@@ -28,9 +28,9 @@ export const DataTagMeta = ['META_INFO', Keys.DATA_TAG]; // a tag describing the
  */
 export function makeTblRequest(id, title, params={}, options={}) {
     var req = {startIdx: 0, pageSize: 100};
-    title = title || id;
+    title = title ?? id;
     const tbl_id = options.tbl_id || uniqueTblId();
-    var META_INFO = Object.assign(options.META_INFO || {}, {title, tbl_id});
+    var META_INFO = pickBy(Object.assign(options.META_INFO || {}, {title, tbl_id}));
     options = omit(options, 'tbl_id');
     return omitBy(Object.assign(req, options, params, {META_INFO, tbl_id, id}), isNil);
 }
@@ -50,10 +50,10 @@ export function makeTblRequest(id, title, params={}, options={}) {
 export function makeFileRequest(title, source, alt_source, options={}) {
     const id = 'IpacTableFromSource';
     var req = {startIdx: 0, pageSize: 100};
-    title = title || source;
+    title = title ?? source;
     const tbl_id = options.tbl_id || uniqueTblId();
     options = omit(options, 'tbl_id');
-    var META_INFO = Object.assign(options.META_INFO || {}, {title, tbl_id});
+    var META_INFO = pickBy(Object.assign(options.META_INFO || {}, {title, tbl_id}));
     return omitBy(Object.assign(req, options, {source, alt_source, META_INFO, tbl_id, id}), isNil);
 }
 
@@ -123,12 +123,12 @@ export function makeIrsaWorkspaceRequest(source, title, options={}) {
  */
 export function makeIrsaCatalogRequest(title, project, catalog, params={}, options={}) {
     var req = {startIdx: 0, pageSize: 100};
-    title = title || catalog;
+    title = title ?? catalog;
     const tbl_id = options.tbl_id || uniqueTblId();
     const id = 'GatorQuery';
     const UserTargetWorldPt = params.UserTargetWorldPt || params.position;  // may need to convert to worldpt.
     const catalogProject = project;
-    var META_INFO = Object.assign(options.META_INFO || {}, {title, tbl_id});
+    var META_INFO = pickBy(Object.assign(options.META_INFO || {}, {title, tbl_id}));
 
     options = omit(options, 'tbl_id');
     params = omit(params, 'position');
@@ -150,13 +150,13 @@ export function makeIrsaCatalogRequest(title, project, catalog, params={}, optio
 export function makeLsstCatalogRequest(title, project, catalog, params={}, options={}) {
     const req = {startIdx: 0, pageSize: 100};
 
-    title = title || catalog;
+    title = title ?? catalog;
     const tbl_id = options.tbl_id || uniqueTblId();
     const id = get(params, 'SearchMethod')==='Table'?'LSSTMultiObjectSearch':'LSSTCatalogSearch';
     const UserTargetWorldPt = params.UserTargetWorldPt || params.position;  // may need to convert to worldpt.
     const table_name = catalog;
     const meta_table = catalog;
-    const META_INFO = Object.assign(options.META_INFO || {}, {title, tbl_id});
+    const META_INFO = pickBy(Object.assign(options.META_INFO || {}, {title, tbl_id}));
 
 
     options = omit(options, 'tbl_id');

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -843,7 +843,7 @@ export function getTblInfoById(tbl_id, aPageSize) {
 export function getTblInfo(tableModel, aPageSize) {
     if (!tableModel) return {};
     var {tbl_id, request, highlightedRow=0, totalRows=0, tableMeta={}, selectInfo, error} = tableModel;
-    const title = tableMeta.title || get(request, 'META_INFO.title');
+    const title = tableMeta.title || request?.META_INFO?.title;
     const pageSize = aPageSize || get(request, 'pageSize', MAX_ROW);  // there should be a pageSize.. default to 1 in case of error.  pageSize cannot be 0 because it'll overflow.
     if (highlightedRow < 0 ) {
         highlightedRow = 0;

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -390,7 +390,6 @@ function tblResultsAdded(action) {
         if (!action.err) {
             var {tbl_id, title, options={}, tbl_ui_id} = action.payload;
 
-            title = title || tbl_id;
             options = Object.assign({tbl_group: 'main', removable: true, setAsActive:true}, options);
             const pageSize = get(options, 'pageSize');
             if ( pageSize && !Number.isInteger(pageSize)) {

--- a/src/firefly/js/tables/reducer/TableResultsReducer.js
+++ b/src/firefly/js/tables/reducer/TableResultsReducer.js
@@ -34,7 +34,10 @@ export function resultsReducer(state={results:{}}, action={}) {
         case Cntlr.TABLE_REMOVE    :
         case Cntlr.TBL_RESULTS_REMOVE    :
             return removeTable(root, action);
-        
+
+        case Cntlr.TABLE_UPDATE   :
+            return updateTableInfo(root, action);
+
         default:
             return root;
     }
@@ -51,4 +54,16 @@ function removeTable(root, action) {
     return root;
 }
 
+function updateTableInfo(root, action) {
+
+    const {tbl_id, title, tableMeta, request} = action.payload;
+    const mtitle = title ?? tableMeta?.title ?? request?.META_INFO?.title;
+    Object.keys(root).forEach( (tbl_group) => {
+        if (has(root, [tbl_group, 'tables', tbl_id])) {
+            root = updateSet(root, [tbl_group, 'tables', tbl_id, 'title'], mtitle);
+        }
+    });
+
+    return root;
+}
 /*---------------------------- DISPATCHERS -----------------------------*/

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -157,7 +157,7 @@ function TableDLReducer(tbl_id) {
         const {request,tableMeta} = getTblById(tbl_id) || {};
         const chooseFileNameSource= () => {
             const fname= request?.META_INFO?.title ?? '';
-            return fname==='${filename}' ? tableMeta?.title : fname;
+            return tableMeta?.title || fname;
         };
         const fixFileName = (fName) => {
 

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -82,7 +82,7 @@ export class CatalogSelectViewPanel extends PureComponent {
                 <FormPanel
                     width='auto' height='auto'
                     groupKey={[gkey, gkeySpacial]}
-                    onSubmit={(request) => onSearchSubmit(request)}
+                    onSuccess={(request) => onSearchSubmit(request)}
                     onError={(request) => onSearchFail(request)}
                     params={{hideOnInvalid: false}}
                     onCancel={hideSearchPanel}>
@@ -294,7 +294,7 @@ function doVoSearch(request, providerName = '') {
 
 function doLoadTable(request) {
     const fileLocation = get(request, 'fileLocation', LOCALFILE);
-    var tReq = makeTblRequest('userCatalogFromFile', '${filename}', {
+    var tReq = makeTblRequest('userCatalogFromFile', '', {
         filePath: ( fileLocation === LOCALFILE) ? request.fileUpload : request.workspaceUpload,
         sourceFrom: fileLocation
     });

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
@@ -17,6 +17,7 @@ import org.junit.experimental.categories.Category;
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author loi
@@ -138,17 +139,17 @@ public class FileAnalysisTest extends ConfigTest {
         assertEquals(fitsTables.length(), report.getFileSize());
         assertEquals(11, report.getParts().size());
         assertEquals(FileAnalysisReport.Type.HeaderOnly, report.getParts().get(0).getType());
-        assertEquals("Primary", report.getParts().get(0).getDesc());
-        assertEquals("NoName", report.getParts().get(1).getDesc());
+        assertNull(report.getParts().get(0).getDesc());
+        assertNull(report.getParts().get(1).getDesc());
 
         assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(4).getType());
-        assertEquals("NoName (7 cols x 12 rows)", report.getParts().get(4).getDesc());
+        assertEquals(" 7 cols x 12 rows ", report.getParts().get(4).getDesc());
 
         assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(8).getType());
-        assertEquals("NoName (3 cols x 4 rows)", report.getParts().get(8).getDesc());
+        assertEquals(" 3 cols x 4 rows ", report.getParts().get(8).getDesc());
 
         assertEquals(FileAnalysisReport.Type.Table, report.getParts().get(10).getType());
-        assertEquals("NoName (4 cols x 1 rows)", report.getParts().get(10).getDesc());
+        assertEquals(" 4 cols x 1 rows ", report.getParts().get(10).getDesc());
 
         // multiple images in a fits file
         report= FileAnalysis.analyze(multiImage, reportType);
@@ -157,9 +158,9 @@ public class FileAnalysisTest extends ConfigTest {
         assertEquals(multiImage.length(), report.getFileSize());
         assertEquals(62, report.getParts().size());
         assertEquals(FileAnalysisReport.Type.HeaderOnly, report.getParts().get(0).getType());
-        assertEquals("Primary", report.getParts().get(0).getDesc());
-        assertEquals("NoName", report.getParts().get(1).getDesc());
-        assertEquals("NoName", report.getParts().get(61).getDesc());
+        assertNull(report.getParts().get(0).getDesc());
+        assertNull(report.getParts().get(1).getDesc());
+        assertNull(report.getParts().get(61).getDesc());
     }
 
     @Test


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-3851
https://jira.ipac.caltech.edu/browse/IRSA-3563

Also:
- remove multiple TableSearch called
- remove the use of ${filename} token
- fix failed test cause by https://jira.ipac.caltech.edu/browse/IRSA-3721

3851 test: https://irsa-3851-filename-as-title.irsakudev.ipac.caltech.edu/irsaviewer/
Upload multiple files using Catalog upload dialog.

3563 test: https://irsa-3851-filename-as-title.irsakudev.ipac.caltech.edu/applications/finderchart/
batch search, then overlay with same uploaded file.  open layer dialog to see overlay name.