### PR TITLE
Firefly 693 ts phase precision too low

### DIFF
--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -42,8 +42,7 @@ export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOpt
                         position: 'absolute',
                         right: 2,
                         borderLeft: '10px solid transparent',
-                        borderTop: '10px solid rgb(71, 138, 163)',
-                        position: 'absolute'
+                        borderTop: '10px solid rgb(71, 138, 163)'
                     }}/>
             </div>
         );

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -61,8 +61,8 @@ const fKeyDef = {
 };
 
 const STEP = 1;            // step for slider
-const DEC_PHASE = 3;       // decimal digit
-const PERIOD_MIN = 0;      // set the period min value at 0, validation for period is larger than 0
+const DEC_PHASE = 5;       // decimal digit
+const PERIOD_MIN = 0.0;      // set the period min value at 0, validation for period is larger than 0
 
 // defValues used to keep the initial values for parameters in phase finding field group
 // time: time column

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -14,7 +14,7 @@ import {getConverter, getYColMappings} from './LcConverterFactory.js';
 import {upload} from '../../rpc/CoreServices.js';
 
 
-const DEC_PHASE = 3;       // decimal digit
+const DEC_PHASE = 5;       // decimal digit
 
 /**
  * @summary upload phase table with the column arranged as needed
@@ -122,7 +122,7 @@ function addPhaseToTable(tbl, timeName, tzero, period) {
 
     var tPF = {tableData: cloneDeep(tbl.tableData),
                tableMeta: cloneDeep(tbl.tableMeta),
-               tbl_id, title};
+               tbl_id, title, META_INFO:{'col.phase.precision': 'F5'}};
     tPF.tableMeta = omit(tPF.tableMeta, ['source', 'resultSetID', 'sortInfo']);
 
     var phaseC = {desc: 'number of period elapsed since starting time.',

--- a/src/firefly/js/templates/lightcurve/LcPhaseTable.js
+++ b/src/firefly/js/templates/lightcurve/LcPhaseTable.js
@@ -29,7 +29,7 @@ export function uploadPhaseTable(tbl, flux) {
 
     upload(blob).then(({status, cacheKey}) => {
         const tReq = makeFileRequest(title, cacheKey, null,
-                                     {tbl_id,
+                                     {tbl_id,  META_INFO:{'col.phase.precision': 'F5'},
                                       sortInfo:sortInfoString(LC.PHASE_CNAME),
                                       pageSize: LC.TABLE_PAGESIZE
                                      });


### PR DESCRIPTION
Fix the phase fold table column "phase" precision.  
To test on k8 dev build:
https://fireflydev.ipac.caltech.edu/wmi-firefly-693/firefly/ts.html
 upload the attached ts table in [Jira ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-693), follow the phase fold steps.