### PR TITLE
Firefly-706: TAP Panel UI cleanup

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -270,6 +270,7 @@ public class URLDownload {
         try {
             FileInfo outFileData;
             Map<String,List<String>> sendHeaders= null;
+            long start = System.currentTimeMillis();
             try {
                 if (timeoutInSec>0) {
                     conn.setConnectTimeout(timeoutInSec * 1000);//Sets a specified timeout value, in milliseconds
@@ -295,7 +296,6 @@ public class URLDownload {
             //------
             logHeader(postData, conn, sendHeaders);
             validFileSize(conn, maxFileSize);
-            long start = System.currentTimeMillis();
             netCopy(makeAnyInStream(conn,uncompress), makeOutStream(outfile), conn, maxFileSize, dl);
             long elapse = System.currentTimeMillis() - start;
             int responseCode= getResponseCode(conn);

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -115,7 +115,7 @@ const defAppProps = {
     ],
 };
 
-const tapEntry= (label,url) => ({ label: `${url}`, value: url, labelOnly:label});
+const tapEntry= (label,url) => ({ label, value: url});
 
 /** @type {FireflyOptions} */
 const defFireflyOptions = {
@@ -179,7 +179,7 @@ const defFireflyOptions = {
             // CDS???
             tapEntry('VisieR (CDS)', 'http://tapvizier.u-strasbg.fr/TAPVizieR/tap/'),
             tapEntry('Simbad (CDS)', 'https://simbad.u-strasbg.fr/simbad/sim-tap'),
-            // ESA
+            // more ESA??
             tapEntry('Gaia', 'https://gea.esac.esa.int/tap-server/tap'),
             tapEntry('GAVO', 'http://dc.g-vo.org/tap'),
             tapEntry('HSA',  'https://archives.esac.esa.int/hsa/whsa-tap-server/tap'),

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -450,7 +450,7 @@ export const createInputCell = (tooltips, size = 10, validator, onChange, style)
             return null;
         } else {
             return (
-                <div style={{padding: 2}}>
+                <div style={{padding: '0 2px 0 2px', marginTop:'-2px'}}>
                     <InputField
                         validator={(v) => validator(v, data, rowIndex, colIdx)}
                         tooltip={tooltips}

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -29,10 +29,11 @@ const flexGrowWithMax = {width: '100%', maxWidth: 1400};
 
 export const irsaStandMultiOptions= [
     {id: 'irsacat', title:'IRSA'},
+    {id: 'nedcat'},
     {id: 'upload'},
-    {id: 'vocat'},
     {id: 'tap', title:'TAP Searches'},
-    {id: 'nedcat'}];
+    {id: 'vocat'},
+];
 
 export const dropDownMap = {
     Search: {view: <SearchPanel />},

--- a/src/firefly/js/ui/InputAreaFieldView.jsx
+++ b/src/firefly/js/ui/InputAreaFieldView.jsx
@@ -97,6 +97,7 @@ export class InputAreaFieldView extends PureComponent {
                 <textarea style={Object.assign({display:'inline-block'}, style)}
                           rows={rows}
                           cols={cols}
+                          spellCheck={false}
                           className={computeStyle(valid,hasFocus,additionalClasses)}
                           id={idName}
                        onChange={(ev) => onChange ? onChange(ev) : null}

--- a/src/firefly/js/ui/RadioGroupInputFieldView.jsx
+++ b/src/firefly/js/ui/RadioGroupInputFieldView.jsx
@@ -8,7 +8,7 @@ function makeRadioGroup(options,alignment ,value,onChange,tooltip, labelStyle) {
 
     return options.map((option) => (
         <span key={option.value}>
-            <div style={{display:'inline-block'}} title={option.tooltip || tooltip}>
+            <div style={{display:'inline-flex', flexDirection:'row', alignItems:'center'}} title={option.tooltip || tooltip}>
                 <input type='radio'
                        title={tooltip}
                        value={option.value}

--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -17,16 +17,16 @@ import {getColumnIdx} from '../../tables/TableUtil.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
 
-import Prism from "prismjs";
+import Prism from 'prismjs';
 // bliss is needed for prism-live
-import "blissfuljs";
+import 'blissfuljs';
 import '../../externalSource/prismLive/prism-sql.js';
 import '../../externalSource/prismLive/prism-live.js';
 
 import '../../externalSource/prismLive/prism.css';
 import '../../externalSource/prismLive/prism-live.css';
 
-const code = {className: "language-sql"};
+const code = {className: 'language-sql'};
 var cFetchKey = Date.now();
 
 export function AdvancedADQL({adqlKey, defAdqlKey, groupKey, serviceUrl, style={}}) {
@@ -61,7 +61,7 @@ export function AdvancedADQL({adqlKey, defAdqlKey, groupKey, serviceUrl, style={
     }, []);
 
     const onSelect = (p) => {
-        const textArea = document.getElementById("adqlEditor");
+        const textArea = document.getElementById('adqlEditor');
 
         const [key=''] = p;
         const [type, , tname, cname] = key.split('--');
@@ -112,7 +112,8 @@ export function AdvancedADQL({adqlKey, defAdqlKey, groupKey, serviceUrl, style={
     return (
             <SplitPane split='vertical' defaultSize={200} style={{position: 'relative', ...style}}>
                 <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
-                    <b>Schema -> Table -> Column</b>
+                    <div style={{fontWeight: 'bold', paddingBottom:5, textAlign:'center'}}>Schema Browser</div>
+                    <div style={{textAlign:'center', paddingBottom:2, }}>Schema -> Table -> Column</div>
                     <div  style={{overflow: 'auto', flexGrow: 1}}>
                         <Tree defaultExpandAll showLine selectedKeys={[]} loadData={onLoadData} onSelect={onSelect}>
                             {treeNodes}

--- a/src/firefly/js/ui/tap/Select.jsx
+++ b/src/firefly/js/ui/tap/Select.jsx
@@ -12,15 +12,8 @@ export const commonSelectStyles = {
             height: '100%'
         }
     ),
-    singleValue: () => {
-        return {
-            color: 'black',
-            marginLeft: 2,
-            marginRight: 2,
-            maxWidth: 'calc(100% - 8px)',
-            position: 'absolute'
-        };
-    }
+    singleValue: () =>
+        ( { color: 'black', marginLeft: 2, marginRight: 2, maxWidth: 'calc(100% - 8px)', position: 'absolute' })
 };
 
 export const selectTheme = (theme) => ({
@@ -34,44 +27,39 @@ export const selectTheme = (theme) => ({
       }});
 
 // LoadingIndicator component
-const LoadingIndicator = () => {
-  return (
-      <img style={{width: 20, height: 20, padding: 5}} src={LOADING}/>
-  );
-};
+const LoadingIndicator = () => ( <img style={{width: 20, height: 20, padding: 5}} src={LOADING}/> );
+const addTarget= (s) => (s.indexOf('<a ')<0) ? s : s.replace('<a ', `<a target='tapOpen' `);
+const cleanUp= (s) => addTarget(truncate(s, {length: 140}));
 
 // Option component
-const SelectOption = ({chidren,...props}) => {
-        const {data} = props;
-        const html = `<b>${data.value}</b><br/>${data.label}`;
-        const v = {__html: html};
-        return (
-            <components.Option {...props}>
-                <div dangerouslySetInnerHTML={v}/>
-            </components.Option>
-        );
+const SelectOption = (props) => {
+    const {data} = props;
+    return (
+        <components.Option {...props}>
+            <div>
+                <b>{data.value}</b>
+                <div dangerouslySetInnerHTML={{__html: `${cleanUp(data.label)}`}}/>
+            </div>
+        </components.Option>
+    );
 };
 
-function getSelectSingleValueComponent(type) {
-    return ({children, ...props}) => {
+const getSelectSingleValueComponent= (type,internalHeight) =>
+    (props) => {
         const {data, options} = props;
-        if (options && options.length > 0) {
-            const html = `<b style="font-size: 9pt">${type}: ${data.value}</b><br/>${truncate(data.label, {length: 140})}`;
-            const v = {__html: html};
-            // use whiteSpace attribute to wrap the text and collapse the whitespace
-            // without it the text does not wrap
-            return (
-                <components.SingleValue {...props}>
-                    <div style={{whiteSpace: 'normal'}}
-                         dangerouslySetInnerHTML={v}
-                    />
-                </components.SingleValue>
-            );
-        } else {
-            return null;
-        }
+        if (!options?.length) return null;
+        return (
+            <components.SingleValue {...props}>
+                <div style={{whiteSpace: 'normal', height: internalHeight}} >
+                    <div style={{paddingBottom: 5}}>
+                        <span style={{paddingRight: 5}}>{type}: </span>
+                        <b style={{fontSize: '9pt'}}> {data.value} </b>
+                    </div>
+                    <div dangerouslySetInnerHTML={{__html: `${cleanUp(data.label)}`}}/>
+                </div>
+            </components.SingleValue>
+        );
     };
-}
 
 const groupStyles = {
     display: 'flex',
@@ -92,18 +80,18 @@ function formatGroupLabel(data) {
     );
 }
 
-export function NameSelect({options, value, onSelect, type, selectProps={}}) {
-    const selectStyles = Object.assign({
-            valueContainer: (styles) => (
-                { ...styles, height: 50 }),
-        }, commonSelectStyles);
+export function NameSelect({options, value, onSelect, typeDesc, typeDescPlural, selectProps={}, internalHeight='45px'}) {
+    const selectStyles = {
+        valueContainer: (styles) => ( { ...styles, height: 55 }),
+        ...commonSelectStyles
+    };
 
-    const placeholder = value ? `${type} <${value}>. Replace...` : `Select ${type}...`;
+    const placeholder = value ? `${typeDesc} <${value}>. Replace...` : `Select ${typeDesc}...`;
 
     let groupedOptions = [];
     if (options && options.length > 0) {
         const nOpts = options.length;
-        const groupLabel = `${type}${(nOpts>1?'s':'')}`;
+        const groupLabel = `${nOpts>1?typeDescPlural:typeDesc}`;
         groupedOptions = [{
             label: groupLabel,
             options
@@ -111,8 +99,8 @@ export function NameSelect({options, value, onSelect, type, selectProps={}}) {
     }
 
     return (
-        <Select key={`select${type}`}
-                components={{ LoadingIndicator, Option: SelectOption, SingleValue: getSelectSingleValueComponent(type) }}
+        <Select key={`select${typeDesc}`}
+                components={{ LoadingIndicator, Option: SelectOption, SingleValue: getSelectSingleValueComponent(typeDesc,internalHeight) }}
                 isLoading={!options}
                 formatGroupLabel={formatGroupLabel}
                 options={groupedOptions}
@@ -147,10 +135,11 @@ NameSelectField.propTypes = {
     groupKey : PropTypes.string,
     options: PropTypes.array,
     onSelect: PropTypes.func,
-    type: PropTypes.string,
+    typeDesc: PropTypes.string,
+    typeDescPlural: PropTypes.string,
     selectProps: PropTypes.object,
+    internalHeight: PropTypes.string,
     initialState: PropTypes.shape({
         value: PropTypes.string,
     })
 };
-

--- a/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
+++ b/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
@@ -34,7 +34,8 @@ export function TableColumnsConstraintsToolbar({columnsModel}) {
 
     const {error} = tableModel || {};
 
-    if (isEmpty(tableModel)) {
+    const totalColumns= tableModel?.tableData?.data?.length ?? 0;
+    if (isEmpty(tableModel) || !totalColumns) {
         return <div/>;
     }
 
@@ -50,6 +51,7 @@ export function TableColumnsConstraintsToolbar({columnsModel}) {
         );
     };
 
+
     return (
         <div style={{display:'inline-flex', padding:'0 0 2px', height: 20, alignSelf: 'center'}}>
             {!error && filterCount > 0 &&
@@ -58,9 +60,10 @@ export function TableColumnsConstraintsToolbar({columnsModel}) {
                     onClick={() => dispatchTableFilter({tbl_id: tableModel.tbl_id, filters: ''})}>
                 Remove <span style={{color: 'blue'}}>{filterCount} filter{filterCount>1?'s':''}</span>
             </button>}
+            <span style={{alignSelf: 'center', padding: '0 5px 0 5px'}}>Column Constraints / Output Column Selection - </span>
             {selectedCount > 0 &&
             <span style={{color: 'blue', alignSelf: 'center', padding: '0 5px 0 5px'}} title='Number of columns to be selected'>
-                {selectedCount} columns
+                {selectedCount} of {totalColumns} columns selected
             </span>}
             {!error && resetButton()}
         </div>

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -68,7 +68,7 @@ const PanelMessage = 'panelMessage';
 const LeftInSearch = 8;
 const LabelWidth = 106;
 const LableSaptail = 100;
-const SpatialWidth = 400;
+const SpatialWidth = 440;
 
 const fieldsMap = {[Spatial]: {
                         [SpatialPanel]: {label: Spatial},
@@ -1236,7 +1236,7 @@ function fieldInit(columnsTable) {
             [CenterLonColumns]: {
                 fieldKey: CenterLonColumns,
                 value: centerColObj.lon,
-                tooltip: 'Center longitude column for spatial search',
+                tooltip: 'Table column that specifies longitude position',
                 label: getLabel(CenterLonColumns, ':'),
                 labelWidth: LabelWidth,
                 validator: getColValidator(cols, false, false)
@@ -1244,7 +1244,7 @@ function fieldInit(columnsTable) {
             [CenterLatColumns]: {
                 fieldKey: CenterLatColumns,
                 value: centerColObj.lat,
-                tooltip: 'Center latitude column for spatial search',
+                tooltip: 'Table column that specifies latitude position',
                 label: getLabel(CenterLatColumns, ':'),
                 labelWidth: LabelWidth,
                 validator: getColValidator(cols, false, false)

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.css
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.css
@@ -28,7 +28,7 @@
     transition: box-shadow .3s ease-in-out;
     background-color: white;
     border-radius: 2px;
-    padding: 6px 2px 4px 2px;
+    padding: 6px 2px 6px 2px;
     margin: 2px 4px;
     outline: none;
     width: calc(100% - 8px);
@@ -51,8 +51,9 @@
     color: #005da4;
     font-size: larger;
     font-weight: bold;
-    padding: 5px;
+    padding-left: 5px;
     width: 175px;
+    height: 100%;
     white-space: nowrap;
     flex-shrink: 0;
 }

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -32,6 +32,9 @@ import './TableSelectViewPanel.css';
 
 export const gkey = 'TAP_SEARCH_PANEL';
 
+export const SectionTitle= ({title,helpId}) => (
+    <div className='TapSearch__section--title'>{title}<HelpIcon helpId={tapHelpId(helpId)}/></div>);
+
 export function AdqlUI({serviceUrl}) {
 
     return (
@@ -78,11 +81,11 @@ export function BasicUI(props) {
     const splitMax = SpattialPanelWidth+80;
 
     const loadSchemas = (requestServiceUrl, requestSchemaName=undefined, requestTableName=undefined) => {
-        setError(undefined)
-        setSchemaOptions(undefined)
-        setTableName(undefined)
-        setTableOptions(undefined)
-        setColumnsModel(undefined)
+        setError(undefined);
+        setSchemaOptions(undefined);
+        setTableName(undefined);
+        setTableOptions(undefined);
+        setColumnsModel(undefined);
         dispatchValueChange({groupKey: gkey, fieldKey: 'tableName', value: undefined});
 
         loadTapSchemas(requestServiceUrl).then((tableModel) => {
@@ -91,7 +94,7 @@ export function BasicUI(props) {
                 return;
             }
             if (tableModel.error) {
-                setError(tableModel.error)
+                setError(tableModel.error);
             } else  {
                 const schemas = getColumnValues(tableModel, 'schema_name');
                 if(!(schemas.length > 0)){
@@ -102,24 +105,24 @@ export function BasicUI(props) {
                     requestSchemaName = schemas[0];
                 }
                 if (requestTableName) {
-                    setTableName(requestTableName)
+                    setTableName(requestTableName);
                 }
                 const schemaDescriptions = getColumnValues(tableModel, 'description');
                 const schemaOptions = schemas.map((e, i) => {
                     const label = schemaDescriptions[i] ? schemaDescriptions[i] : `[${e}]`;
                     return {label, value: e};
                 });
-                setSchemaName(requestSchemaName)
-                setSchemaOptions(schemaOptions)
+                setSchemaName(requestSchemaName);
+                setSchemaOptions(schemaOptions);
             }
         });
-    }
+    };
 
     const loadTables = (requestServiceUrl, requestSchemaName, requestTableName) => {
         // even if we have the new values - clear the current state
-        setTableName(undefined)
-        setTableOptions(undefined)
-        setColumnsModel(undefined)
+        setTableName(undefined);
+        setTableOptions(undefined);
+        setColumnsModel(undefined);
         dispatchValueChange({groupKey: gkey, fieldKey: 'tableName', value: undefined});
 
         loadTapTables(requestServiceUrl, requestSchemaName).then((tableModel) => {
@@ -140,31 +143,31 @@ export function BasicUI(props) {
                     const label = tableDescriptions[i] ? tableDescriptions[i] : `[${e}]`;
                     return {label, value: e};
                 });
-                setTableName(requestTableName)
-                setTableOptions(tableOptions)
+                setTableName(requestTableName);
+                setTableOptions(tableOptions);
                 dispatchValueChange({groupKey: gkey, fieldKey: 'tableName', value: requestTableName});
             }
         });
-    }
+    };
 
     const loadColumns = (requestServiceUrl, requestSchemaName, requestTableName) => {
         if(columnsModel){
-            setColumnsModel(undefined)
+            setColumnsModel(undefined);
         }
         loadTapColumns(requestServiceUrl, requestSchemaName, requestTableName).then((columnsModel) => {
             if (serviceUrlRef.current !== requestServiceUrl || schemaRef.current !== requestSchemaName || tableRef.current !== requestTableName){
                 // processing a stale request
                 return;
             }
-            setColumnsModel(columnsModel)
-            setTapBrowserState({serviceUrl: requestServiceUrl, schemaName: requestSchemaName, schemaOptions: schemaOptions,
-                tableName: requestTableName, tableOptions: tableOptions, columnsModel: columnsModel});
+            setColumnsModel(columnsModel);
+            setTapBrowserState({serviceUrl: requestServiceUrl, schemaName: requestSchemaName, schemaOptions,
+                tableName: requestTableName, tableOptions, columnsModel});
         });
-    }
+    };
     useEffect(() => {
         // properties changes due to changes in TapSearchPanel
         if(props.serviceUrl !== serviceUrl) {
-            setServiceUrl(props.serviceUrl)
+            setServiceUrl(props.serviceUrl);
         }
     });
 
@@ -194,14 +197,16 @@ export function BasicUI(props) {
     return (
         <Fragment>
             <div className='TapSearch__section'>
-                <div className='TapSearch__section--title'>3. Select Table <HelpIcon helpId={tapHelpId('selectTable')}/> </div>
+                <SectionTitle title='3. Select Table' helpId='selectTable'/>
                 <div style={{display: 'inline-flex', width: '100%', marginRight: 3, maxWidth: 1000}}>
                     <div style={{flexGrow: 1}}>
-                        <NameSelect type='Schema'
+                        <NameSelect typeDesc='Table Collection (Schema)'
+                                    typeDescPlural='Table Collections (Schemas)'
                                     options={schemaOptions}
                                     value={schemaName}
+                                    internalHeight={'45px'}
                                     onSelect = {(selectedTapSchema) => {
-                                        setSchemaName(selectedTapSchema)
+                                        setSchemaName(selectedTapSchema);
                                     }}
                         />
                     </div>
@@ -209,7 +214,8 @@ export function BasicUI(props) {
                     <div style={{flexGrow: 1}}>
                         <NameSelectField
                             fieldKey='tableName'
-                            type='Table'
+                            typeDesc='Table'
+                            typeDescPlural='Tables'
                             options={tableOptions}
                             initialState= {{value:tableName}}
                             onSelect = {(selectedTapTable) => {
@@ -222,7 +228,7 @@ export function BasicUI(props) {
 
             <div className='TapSearch__section' style={{flexDirection: 'column', flexGrow: 1}}>
                 <div style={{ display: 'inline-flex', width: 'calc(100% - 3px)', justifyContent: 'space-between'}}>
-                    <div className='TapSearch__section--title'>4. Select Constraints <HelpIcon helpId={tapHelpId('constraints')}/> </div>
+                    <div className='TapSearch__section--title'>4. Enter Constraints <HelpIcon helpId={tapHelpId('constraints')}/> </div>
                     <TableColumnsConstraintsToolbar key={tableName}
                                                     tableName={tableName}
                                                     columnsModel={columnsModel}
@@ -251,7 +257,7 @@ export function BasicUI(props) {
             </div>
 
         </Fragment>
-    )
+    );
 }
 
 

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -11,7 +11,6 @@ import {ExtraButton, FormPanel} from 'firefly/ui/FormPanel.jsx';
 import {ValidationField} from 'firefly/ui/ValidationField.jsx';
 import {intValidator} from 'firefly/util/Validate.js';
 import {FieldGroup} from 'firefly/ui/FieldGroup.jsx';
-import {HelpIcon} from 'firefly/ui/HelpIcon.jsx';
 import CreatableSelect from 'react-select/creatable/dist/react-select.esm.js';
 import {RadioGroupInputField} from 'firefly/ui/RadioGroupInputField.jsx';
 import {makeTblRequest, setNoCache} from 'firefly/tables/TableRequestUtil.js';
@@ -24,7 +23,7 @@ import {tableColumnsConstraints} from 'firefly/ui/tap/TableColumnsConstraints.js
 import {skey, tableSearchMethodsConstraints, validateConstraints} from 'firefly/ui/tap/TableSearchMethods.jsx';
 import {commonSelectStyles, selectTheme} from 'firefly/ui/tap/Select.jsx';
 import {getMaxrecHardLimit, getTapBrowserState, tapHelpId, TAP_SERVICES_FALLBACK} from 'firefly/ui/tap/TapUtil.js';
-import { gkey, AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
+import { gkey, SectionTitle, AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
 
 
 
@@ -150,8 +149,6 @@ const tableSelectStyleEnhancedTemplate= {
 const makePlaceHolderBeforeStyle= (l) =>
     ({ ...extStyles, content: `"Using ${l}"`, height: 10, width: `${(l.length+7)*.6}em`});
 
-const SectionTitle= ({title,helpId}) => (
-    <div className='TapSearch__section--title'>{title}<HelpIcon helpId={tapHelpId(helpId)}/></div>);
 
 
 function TapSearchPanelComponents({initArgs, serviceUrl, onTapServiceOptionSelect, tapOps, titleOn=true, selectBy}) {
@@ -169,7 +166,7 @@ function TapSearchPanelComponents({initArgs, serviceUrl, onTapServiceOptionSelec
             <div className='TapSearch'>
                 {titleOn && <div className='TapSearch__title'>TAP Searches</div>}
                 <div className='TapSearch__section'>
-                    <SectionTitle title='1. TAP Service ' helpId='tapService'/>
+                    <SectionTitle title='1. Select TAP Service ' helpId='tapService'/>
                     <div style={{flexGrow: 1, marginRight: 3, maxWidth: 1000,  zIndex: 9999}}>
                         <CreatableSelect
                             options={tapOps} isClearable={true} onChange={onTapServiceOptionSelect}
@@ -183,10 +180,12 @@ function TapSearchPanelComponents({initArgs, serviceUrl, onTapServiceOptionSelec
                         fieldKey = 'selectBy'
                         initialState = {{
                             defaultValue: 'basic',
-                            options: [{label: 'Single Table', value: 'basic'}, {label: 'ADQL', value: 'adql'}],
+                            options: [
+                                {label: 'Single Table (UI assisted) ', value: 'basic'},
+                                {label: 'Edit ADQL (advanced)', value: 'adql'}
+                            ],
                             tooltip: 'Please select an interface type to use'
                         }}
-                        wrapperStyle={{alignSelf: 'center'}}
                     />
                 </div>
                 {selectBy === 'basic' && <BasicUI  serviceUrl={serviceUrl} initArgs={initArgs}/>}
@@ -227,7 +226,7 @@ function populateAndEditAdql(inAdql) {
 }
 
 const hasElements= (a) => Boolean(isArray(a) && a?.length);
-const getTapServiceOptions= () => getTapServices().map(({label,value,labelOnly})=>({label, value, labelOnly}));
+const getTapServiceOptions= () => getTapServices().map(({label,value})=>({label:value, value, labelOnly:label}));
 
 function getTapServices() {
     const tapServices = getAppOptions()?.tap?.services;


### PR DESCRIPTION
#### Firefly-706: TAP Panel UI cleanup

- _Clean up_:  In "ADQL" mode, there are instructions that say "Schema Browser Usage". However, there's nothing labeled "Schema Browser".
- _Change_: For the column constraints, it's not at all clear what the checkboxes do.  "Column Constraints & Output Selection" maybe.
- _Change_: `1. TAP Service` --> `1. Select TAP Service`
- _Fixed_: FIREFLY-699 specifies a different order than I see at https://firefly-689-combine.irsakudev.ipac.caltech.edu/irsaviewer/
- _Fixed_: "Spatial Constraints", the "Try NED then SIMBAD" button is cut off.
- _Change_: `Single Table` _vs_ `ADQL` --> `Single Table (UI assisted)` _vs_ `Edit ADQL (advanced)`
- _Change_: Single Table" workflow, `Schema` --> `Table Collection (Schema)`
- _Clean up_: 3. Select Table section
- _Change_: `4. Select Constraints` --> `4. Enter Constraints`
- _Fixed_: data entry in constrains table is shifted down
- _Clean up_: checkbox box options aligns better
- _Change_: `xx columns selected` to `xx of yy columns selected`
- _Clean up_: the select dropdowns in section 3

_ticket_: https://jira.ipac.caltech.edu/browse/FIREFLY-706


#### Testing

- Before testing please look at the [ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-706) or (more simply) above to see what we implemented.
- _IrsaViewer_: https://firefly-706-tap-cleanup.irsakudev.ipac.caltech.edu/irsaviewer/
- _Firefly_: https://fireflydev.ipac.caltech.edu/firefly-706-tap-cleanup/firefly/
- Go to TAP panel and observed the changes


