### PR TITLE
FIREFLY-707: coordinate transformation defined by PCi_j is not applied

### DIFF
--- a/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
+++ b/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
@@ -245,10 +245,12 @@ export function parseSpacialHeaderInfo(header, altWcs='', zeroHeader) {
 	    if ( (p.cdelt1) && (p.cdelt2) ) p.cd1_1 = undefined;
 	}
 
-	if (!isNaN(p.crval2) && !isNaN(p.crval1) && !isNaN(p.crpix1) && !isNaN(p.crpix2) && (p.maptype !== UNRECOGNIZED) &&
-		( parse.isDefinedHeaderList(CD1_1_HEADERS) || parse.isDefinedHeaderList(CD1_2_HEADERS) ||
-          parse.isDefinedHeaderList(CD2_1_HEADERS) || parse.isDefinedHeaderList(CD2_2_HEADERS) ) ) {
-	    if (p.axes_reversed) {
+    if (!isNaN(p.crval2) && !isNaN(p.crval1) && !isNaN(p.crpix1) && !isNaN(p.crpix2) && (p.maptype !== UNRECOGNIZED) &&
+        ( parse.isDefinedHeaderList(CD1_1_HEADERS) || parse.isDefinedHeaderList(CD1_2_HEADERS) ||
+            parse.isDefinedHeaderList(CD2_1_HEADERS) || parse.isDefinedHeaderList(CD2_2_HEADERS) ||
+            isDefined(p.pc1_1) || isDefined(p.pc1_2) || isDefined(p.pc2_1) || isDefined(p.pc2_2)
+        ) ) {
+        if (p.axes_reversed) {
             let temp = p.crval1;
             p.crval1 = p.crval2;
             p.crval2 = temp;


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-707

Fixed a bug in the the display of images with WCS defined by PCi_j.  Rotation defined by PCi_j had no effect. (PCi_j is a linear transformation matrix without scale. When CDELT values are equal, the PCi_j matrix is a pure rotation. It is a FITS standard alternative to CROTA2 or CDi_j.)

Test at https://fireflydev.ipac.caltech.edu/firefly-707/firefly/
1. Load image from URL http://spherexdev1:8080/simulated/simulator_delivery1/outputs/SPHEREx_simulation_1_field_2_array_2.fits
2. Use E,N button and notice that the image orientation it is now matching DS9 screenshot. 
3. The catalog of the sources from the third extension now overlays exactly with the image. 