### PR TITLE
FIREFLY-717: Auto escape URL in href of <LINK> tag

### DIFF
--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1223,12 +1223,18 @@ export const findTargetName = (columns) => columns.find( (c) => DEFAULT_TNAME_OP
  * @returns {string}    the resolved href after subsitution
  */
 export function applyLinkSub(tableModel, href='', rowIdx, defval='') {
-    const rhref = applyTokenSub(tableModel, href, rowIdx, defval);
+    let rhref = applyTokenSub(tableModel, href, rowIdx, defval);
     if (rhref === defval) {
-        return '';      // no href
+        rhref = '';      // no href
     } else if (rhref === href) {
-        return href + defval;       // no substitution given, append defval to the url.  set A.1
+        rhref = href + defval;       // no substitution given, append defval to the url.  set A.1
     }
+    // encode the href if needed
+    const base = 'https://fake.me';        // base is only used when url is relative, otherwise it will get a parse error.
+    const {href:chref} = new URL(rhref, base);        // chref contains href that's encoded, but fully qualified
+    rhref = rhref.toLowerCase().match(/^http(s)?:\/\//) ? chref :
+            rhref.startsWith('/') ? chref.replace(base, '') :       // remove base if it were used.
+            chref.replace(base, '').substring(1);
     return rhref;
 }
 

--- a/src/firefly/js/util/__tests__/VOAnalyzer-test.js
+++ b/src/firefly/js/util/__tests__/VOAnalyzer-test.js
@@ -547,7 +547,7 @@ describe('VOAnalyzer:', () => {
                     data: [
                         ['a-1', 'b-1', 'b-1'],
                         ['a-2', 'b-2', 'c-2'],
-                        ['a-3', 'b-3', 'c-3'],
+                        ['a-3', '/api/getImg?p=360\'180"&radius=3"&desc=my fav', 'https://acme.org/abc?x=360\'180"'],
                     ],
                 }
             };
@@ -560,6 +560,13 @@ describe('VOAnalyzer:', () => {
         result = applyLinkSub(tableModel, 'https://acme.org/abc?x=${a}&y=${c}', 1, 'b-2');
         expect(result).toBe('https://acme.org/abc?x=a-2&y=c-2');
 
+        // auto-encode href with absolute url
+        result = applyLinkSub(tableModel, '${c}', 2, 'failed');
+        expect(result).toBe('https://acme.org/abc?x=360%27180%22');
+
+        // auto-encode href with relative url
+        result = applyLinkSub(tableModel, '${b}', 2, 'failed');
+        expect(result).toBe('/api/getImg?p=360%27180%22&radius=3%22&desc=my%20fav');
     });
 
 });


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-717

Automatically escape/encode URL in `href` of a votable LINK when rendering it as a link in a Firefly table.
Test case added with two examples: src/firefly/js/util/__tests__/VOAnalyzer-test.js
If NED can provide an example, I would gladly add that to our test cases.

Test deployment is here: https://fireflydev.ipac.caltech.edu/firefly-717-escape-link-url/firefly/