### PR TITLE
FIREFLY-717: Auto escape values when used as part of a URL in a <LINK> tag

### DIFF
--- a/src/firefly/js/util/__tests__/VOAnalyzer-test.js
+++ b/src/firefly/js/util/__tests__/VOAnalyzer-test.js
@@ -547,7 +547,7 @@ describe('VOAnalyzer:', () => {
                     data: [
                         ['a-1', 'b-1', 'b-1'],
                         ['a-2', 'b-2', 'c-2'],
-                        ['a-3', 'b-3', 'c-3'],
+                        ['a-3', '', '1984A&AS...56..381B'],
                     ],
                 }
             };
@@ -559,6 +559,19 @@ describe('VOAnalyzer:', () => {
         // substituting values from column a and c into the href
         result = applyLinkSub(tableModel, 'https://acme.org/abc?x=${a}&y=${c}', 1, 'b-2');
         expect(result).toBe('https://acme.org/abc?x=a-2&y=c-2');
+
+        // don't encode cell data when href is not given
+        result = applyLinkSub(tableModel, '', 2, 'http://acme.org/?id=1984A%26AS...56..381B');
+        expect(result).toBe('http://acme.org/?id=1984A%26AS...56..381B');
+
+        // auto-encode cell data when used as tokens and not a full url
+        result = applyLinkSub(tableModel, 'http://acme.org/?id=${c}', 2, 'failed');
+        expect(result).toBe('http://acme.org/?id=1984A%26AS...56..381B');
+
+        // null condition
+        result = applyLinkSub(tableModel, '${b}', 2, '');
+        expect(result).toBe('');
+
 
     });
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-717

Instead of adding an option or an attribute to a votable LINK tag which will violate its xml schema, it's best to change the way these values are interpreted.

So, instead of taking the value as is, we will determine whether or not encoding is needed based on how it's used.
If it's used as tokens to construct a URL, then we will encode it.  If the value is intended to be a complete URL, then it's taken as is without any encoding

Test case added with two examples: src/firefly/js/util/tests/VOAnalyzer-test.js

Test deployment is here: https://fireflydev.ipac.caltech.edu/firefly-717-escape-link-url/firefly/