### PR TITLE
Firefly: multiple tickets:  Firefly-678,  Firefly-380,  Firefly-727, Firefly-731

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -172,7 +172,7 @@ const defFireflyOptions = {
             tapEntry('IRSA', 'https://irsa.ipac.caltech.edu/TAP'),
             tapEntry('NED', 'https://ned.ipac.caltech.edu/tap/'),
             tapEntry('NASA Exoplanet Archive', 'https://exoplanetarchive.ipac.caltech.edu/TAP/'),
-            // KOA?
+            tapEntry('KOA', 'https://koa.ipac.caltech.edu/TAP/'),
             tapEntry('HEASARC', 'https://heasarc.gsfc.nasa.gov/xamin/vo/tap'),
             tapEntry('MAST Images', 'https://vao.stsci.edu/CAOMTAP/TapService.aspx'),
             tapEntry('CADC', 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap'),

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -306,7 +306,7 @@ function bootstrap(props, options, webApiCommands) {
         getOrCreateWsConn().then((client) => {
             fireflyInit(props, options, webApiCommands);
 
-            client.addListener(ActionEventHandler)
+            client.addListener(ActionEventHandler);
             window.firefly.wsClient = client;
             notifyServerAppInit({spaName:`${props.appTitle||''}--${props.template?props.template:'api'}`});
             resolve?.();

--- a/src/firefly/js/api/ApiUtilImage.jsx
+++ b/src/firefly/js/api/ApiUtilImage.jsx
@@ -49,7 +49,8 @@ export {startDataProductsWatcher} from '../visualize/saga/DataProductsWatcher.js
 export {getSelectedRegion} from '../drawingLayers/RegionPlot.js';
 
 export {extensionAdd, extensionRemove} from '../core/ExternalAccessUtils.js';
-export {makeWorldPt, makeScreenPt, makeImagePt, parsePt} from '../visualize/Point.js';
+export {makeWorldPt, makeScreenPt, makeImagePt, parsePt, parseAnyPt, parseWorldPt } from '../visualize/Point.js';
+export {CoordinateSys} from '../visualize/CoordSys.js';
 
 export {IMAGE, NewPlotMode} from '../visualize/MultiViewCntlr';
 

--- a/src/firefly/js/core/ExternalAccessCntlr.js
+++ b/src/firefly/js/core/ExternalAccessCntlr.js
@@ -93,16 +93,17 @@ function reducer(state=initState, action={}) {
 }
 
 const addExtension= function(state, action) {
-    var {extension}= action.payload;
+    const {extension}= action.payload;
     const {extensionList}= state;
-    var newAry;
-    if (extensionList.find( (e) => e.id===extension.id)) {
-        newAry= extensionList.map( (e) => e.id===extension.id ? extension : e);
-    }
-    else {
-        newAry= [...state.extensionList, extension];
-    }
-    return Object.assign({}, state, {extensionList:newAry});
+
+    const matchExt= (e) =>
+        (e.id===extension.id ||
+        (e.plotId===extension.plotId && e.extType===extension.extType &&
+            e.title===extension.title && e.shortcutKey===extension.shortcutKey));
+
+    const newAry= extensionList.find(matchExt) ?
+        extensionList.map( (e) => matchExt(e) ? extension : e) : [...state.extensionList, extension];
+    return {...state, extensionList:newAry};
 };
 
 const removeExtension= function(state, action) {

--- a/src/firefly/js/data/form/PositionFieldDef.js
+++ b/src/firefly/js/data/form/PositionFieldDef.js
@@ -1,7 +1,7 @@
 import PositionParser from '../../util/PositionParser.js';
 import CoordinateSys from '../../visualize/CoordSys.js';
 import CoordUtil from '../../visualize/CoordUtil.js';
-import Point, {makeWorldPt} from '../../visualize/Point.js';
+import Point, {makeResolvedWorldPt, makeWorldPt} from '../../visualize/Point.js';
 
 import {sprintf} from '../../externalSource/sprintf';
 import {matchesIgCase} from '../../util/WebUtil.js';
@@ -153,7 +153,7 @@ var makePositionFieldDef= function(properties) {
                 }
             }
             if (retval ===null) {
-                retval = formatTargetForHelp(makeWorldPt(wp.getLon, wp.getLat(), wp.getCoordSys(), name, resolver));
+                retval = formatTargetForHelp(makeResolvedWorldPt(makeWorldPt(wp.getLon, wp.getLat(), wp.getCoordSys()), name, resolver));
             }
         }
         else {

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -1,6 +1,7 @@
 .TablePanel {
     display: flex;
     height: 100%;
+    width: 100%;
     flex-direction: column;
     overflow: hidden;
 }

--- a/src/firefly/js/ui/ToolbarButton.css
+++ b/src/firefly/js/ui/ToolbarButton.css
@@ -59,7 +59,9 @@
 
 .ff-menuItemHText {
     display: inline-block;
-    padding-top: 4px;
+    padding: 6px 2px 6px 2px;
+    border: 1px solid rgba(0,0,0,.2);
+    border-radius: 5px;
 }
 
 .ff-menuItemHText-last {

--- a/src/firefly/js/ui/ZoomOptionsPopup.jsx
+++ b/src/firefly/js/ui/ZoomOptionsPopup.jsx
@@ -1,163 +1,39 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import React, {PureComponent} from 'react';
-import PropTypes from 'prop-types';
-import {flux} from '../core/ReduxFlux.js';
+import React, {useEffect} from 'react';
 import {dispatchShowDialog, dispatchHideDialog} from '../core/ComponentCntlr.js';
 import DialogRootContainer from './DialogRootContainer.jsx';
 import {PopupPanel} from './PopupPanel.jsx';
-import {getActivePlotView, primePlot, getFoV} from '../visualize/PlotViewUtil.js';
+import {getActivePlotView, getFoV, primePlot} from '../visualize/PlotViewUtil.js';
 import {visRoot, dispatchZoom} from '../visualize/ImagePlotCntlr.js';
-import {levels, UserZoomTypes, convertZoomToString, makeFoVString} from '../visualize/ZoomUtil';
+import {imageLevels, UserZoomTypes, makeFoVString} from '../visualize/ZoomUtil';
 import {ToolbarButton} from './ToolbarButton.jsx';
-
-const _levels = levels;
-
-function getDialogBuilder() {
-    var popup = null;
-    return () => {
-        if (!popup) {
-            const popup = (
-                <PopupPanel title={'Choose Field of View'}>
-                    <ZoomOptionsPopup groupKey={'ZOOM_OPTIONS_FORM'}/>
-                </PopupPanel>
-            );
-            DialogRootContainer.defineDialog('zoomOptionsDialog', popup);
-        }
-        return popup;
-    };
-}
-
-const dialogBuilder = getDialogBuilder();
+import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 
 export function showZoomOptionsPopup() {
-    dialogBuilder();
+    const popup = ( <PopupPanel title={'Choose Field of View'}> <ZoomOptionsPopup/> </PopupPanel> );
+    DialogRootContainer.defineDialog('zoomOptionsDialog', popup);
     dispatchShowDialog('zoomOptionsDialog');
 }
 
-
-/**
- * This method is called when the dialog is rendered. Only when an image is loaded, the PlotView is available.
- * Then, the color band, plotState etc can be determined.
- * @returns {{plotState, colors: Array, hasThreeColorBand: boolean}}
- */
-function getInitialPlotState() {
-    var pv= getActivePlotView(visRoot());
-    var plot= primePlot(pv);
-
-    //var plot = primePlot(visRoot());
-
-    var initcurrLevel = plot && plot.zoomFactor;
-
-    return {
-        pv,
-        plot,
-        initcurrLevel,
-        colors: [],
-        hasThreeColorBand: false,
-    };
-
-}
-
-class ZoomOptionsPopup extends PureComponent {
-
-    constructor(props)  {
-        super(props);
-        this.state = {plot:primePlot(visRoot()),
-            initcurrLevel:primePlot(visRoot()).zoomFactor,
-            plotView:getActivePlotView(visRoot())};
-    }
-
-    componentWillUnmount() {
-        if (this.removeListener) this.removeListener();
-
-    }
-
-    componentDidMount() {
-
-        this.removeListener= flux.addListener(() => {
-            const { plot, initcurrLevel} = getInitialPlotState();
-            if (plot===this.state.plot) return;
-            if (plot) {
-                this.setState({plot, initcurrLevel});
-            }
-            else {
-                if (this.removeListener) this.removeListener();
-                dispatchHideDialog('zoomOptionsDialog');
-            }
-        });
-    }
-
-
-    render() {
-        const { plot, initcurrLevel, plotView} = this.state;
-        return <ZoomOptionsPopupForm  plotView={plotView} plot={plot} initcurrLevel={initcurrLevel}/>;
-    }
-
-}
-
-function makeZoomLabel(pv, zfactor) {
-    return makeFoVString(getFoV(pv,zfactor));
-}
-
-function ZoomOptionsPopupForm() {
-
-   const {plot, pv, initcurrLevel} = getInitialPlotState();
-
-    var verticalColumn = {display: 'inline-block', padding: '10px 10px 20px 25px'};
-    var zoom_levels = _levels;
-
-    var initcurrZoomLevelStr = convertZoomToString(initcurrLevel);
-
-
-    var optionArray = [];
-    for (var i = 0; i < zoom_levels.length; i++) {
-        // optionArray[i] = {label: convertZoomToString(zoom_levels[i]), value: zoom_levels[i]};
-        optionArray[i] = {label: makeZoomLabel(pv,zoom_levels[i]), value: zoom_levels[i]};
-    }
-
-    return (
-            <div style={{ minWidth:150, minHeight: 300} }>
-
-                <div style={verticalColumn}>
-                    {makezoomItems(plot, optionArray)}
-                </div>
-
-            </div>
-
-    );
-
-}
-
-
-function makezoomItems(plot,opAry) {
-    return opAry.map( (levelStr,opId) => {
-        if (levelStr.value===plot.zoomFactor) {
-            return(
-                <u key={opId}>{levelStr.label} :  Current </u>
-
-            );
-
-        }
-        else {
-            return (
-                <ToolbarButton text={levelStr.label} tip={levelStr.label}
-                               enabled={true} horizontal={false} key={opId}
-                               onClick={() =>resultsSuccess(plot.plotId,levelStr.value)}
-                />
-            );
-        }
-    });
-}
-
-makezoomItems.propTypes= {
-    plot: PropTypes.object.isRequired,
-    opAry : PropTypes.array.isRequired,
-    currLevel : PropTypes.number.isRequired
+const ZoomOptionsPopup = () => {
+    const [pv]= useStoreConnector( () => getActivePlotView(visRoot()));
+    useEffect(() => void (!primePlot(pv) && dispatchHideDialog('zoomOptionsDialog')), [pv]);
+    return primePlot(pv) ? <ZoomOptionsPopupForm pv={pv}/> : <div/>;
 };
 
-function resultsSuccess(plotId,zoomLevel) {
-    var zoom= Number(zoomLevel);
-    dispatchZoom({plotId, userZoomType:UserZoomTypes.LEVEL, level:zoom});
-}
+const ZoomOptionsPopupForm= ({pv}) => (
+    <div style={{ minWidth:150, minHeight: 300} }>
+        <div style={{display: 'inline-block', padding: '10px 10px 20px 25px'}}> {makeZoomItems(pv)} </div>
+    </div>
+);
+
+const makeZoomItems= (pv) => imageLevels
+    .map((zl) => ({label: makeFoVString(getFoV(pv,zl)), level: zl}))
+    .map( ({label,level},opId) =>
+        (level===primePlot(pv).zoomFactor) ?
+            (<u key={opId}>{`${label} : Current`}</u> ) :
+            (<ToolbarButton text={label} tip={label} horizontal={false} key={opId}
+                            onClick={() => dispatchZoom({plotId:pv.plotId, userZoomType:UserZoomTypes.LEVEL, level})}/>)
+    );

--- a/src/firefly/js/util/fetch.js
+++ b/src/firefly/js/util/fetch.js
@@ -33,7 +33,7 @@ export async function fetchUrl(url, options={}, doValidation = true, enableDefOp
     if (!url) return;
 
     // define defaults request options
-    if (!enableDefOptions) return lowLevelDoFetch(url, options, doValidation, logger);
+    if (!enableDefOptions) return lowLevelDoFetch(url, options, doValidation, logger?.tag('fetchUrl').debug);
     const {connId, channel}= await getOrCreateWsConn();
     const optionsWithDef= {
         method: 'get',

--- a/src/firefly/js/visualize/CoordSys.js
+++ b/src/firefly/js/visualize/CoordSys.js
@@ -18,6 +18,7 @@ export const ECLIPTIC_J   = 13;
  * @description value is one of the following constants; EQ_J2000, EQ_B2000, EQ_B1950, GALACTIC,
  * SUPERGALACTIC, ECL_J2000, ECL_B1950, PIXEL, SCREEN_PIXEL, UNDEFINED,
  *
+ * @prop isEquatorial
  * @global
  * @public
  */

--- a/src/firefly/js/visualize/CoordUtil.js
+++ b/src/firefly/js/visualize/CoordUtil.js
@@ -1,25 +1,24 @@
 /*eslint no-empty:0*/
-
-
+/*eslint quotes:0*/
 import {sprintf} from '../externalSource/sprintf';
 
 /**
  *  This class provides conversion of user's
  *  coordinate string to a double
- *  Translated from Rick Ebert's coord.c
+ *  Translated to javascript from java from Rick Ebert's coord.c
  *
  *  April 10, 2001
  *  Copied from the original Coord.java, modified to provide the convenient
  *  static methods to do validation, formatting, and conversion from decimal
  *  degree to HMS/DMS string and vice versa.  -xiuqin
+ *  March 26, 2021 - Trey
+ *  Cleaned up the code more for JavaScript, cut out about 400 lines, removed dd2sex functionality that we don't use.
+ *  Still more cleanup could be done
  *  @author Booth Hartley, G.Turek, Xiuqin Wu
  */
-const DEFAULT_PRECISION = 8;
 const MAX_PRECISION = 8;
-const FORM_DECIMAL_DEGREE = 0;  // 12.34d
 const FORM_DMS = 1;             // 12d34m23.4s
 const FORM_HMS = 2;             // 12h34m23.4s
-
 const LAT_OUT_RANGE = 'Latitude is out of range [-90.0, +90.0]';
 const LON_TOO_BIG = 'Longitude is too big (>=360.0)';
 const LON_NEGATIVE = 'Longitude can not be negative';
@@ -33,40 +32,22 @@ const INVALID_SEPARATOR = 'Invalid input';
 
 const isDigit = (c) => (!!c.trim() && (c > -1));
 
-
 /**
  * @param coordstr
  * @param islat true if the coordstr is latitude
  * @param isequ true if the coordstr is in equatorial system
  */
-var sex2dd = function (coordstr, islat, isequ) {
+const sex2dd = function (coordstr, islat, isequ) {
+    const sep = [];
+    const part = [];
+    const point = [];
+    let isdec= false;
+    let degrees = -1;
+    let p = coordstr.trim();
 
-    var sign;
-    var p, r;
-    var pointseen, i, done, cntdigits, numseen, parts;
-    var degrees;
-    var sep = [];
-    var part = [];
-    var modangle, angle, base;
-    var point = [];
-    var strpart = [];
-    var isdec;
+    if (!p.length) throw 'length 0';
 
-    //System.out.println("Coord:  now in c_coord");
-    //System.out.println("Coord: coord = " + coordstr);
-    //System.out.println("Coord: islat = " + islat);
-    //System.out.println("Coord: isequ = " + isequ);
-
-    r = null;
-    parts = 0;
-    degrees = -1;
-
-    p = coordstr.trim();
-    if (p.length === 0) {
-        throw 'length 0';
-    }
-
-    sign = 1;  // assume positive
+    let sign = 1;  // assume positive
     if (p.charAt(0) === '-') {
         sign = -1;
         p = p.substring(1);
@@ -76,623 +57,236 @@ var sex2dd = function (coordstr, islat, isequ) {
         p = p.substring(1);
     }
     p = p.trim();  // allow space between sign and nbr
-    if (p.length === 0) {
-        throw INVALID_STRING;
-    }
+    if (!p.length) throw INVALID_STRING;
 
-    for (i = 0; i < 3 && (p.length > 0); i++) {
-        pointseen = 0;
-        done = 0;
-        cntdigits = 0;
-        numseen = 0;
-        r = null;
+    for (let i = 0; i < 3 && (p.length > 0); i++) {
+        let pointseen = 0;
+        let done = false;
+        let numseen = 0;
+        let r = undefined;
 
-        while ((p.length > 0) && done === 0) {
+        while ((p.length > 0) && !done) {
             if (p.charAt(0) === '.') {
-                if (pointseen === 1) {
-                    throw INVALID_STRING;
-                }
-                else {
-                    pointseen = 1;
-                    if (r ===null) {
-                        r = p;
-                    }  //Mark this place - number starts here
-                }
+                if (pointseen === 1) throw INVALID_STRING;
+                pointseen = 1;
+                if (!r) r = p;   //Mark this place - number starts here
             }
             else if (isDigit(p.charAt(0))) {
-                if (pointseen===0) {
-                    cntdigits++;
-                }
-                if (r===null) {
-                    r = p;
-                }  //Mark this place - number starts here
+                if (!r) r = p;  //Mark this place - number starts here
                 numseen++;
             }
             else {
-                done = 1;
+                done= true;
             }
-
-            if (done===0) {
-                p = p.substring(1);
-            }
+            if (!done) p = p.substring(1);
         }  // end of inner-while
 
-        if (numseen===0) {
-            throw INVALID_STRING;
-        }
+        if (numseen===0) throw INVALID_STRING;
 
         //convert it and save it
-        //System.out.println("RBH i = "+i + " numseen = "+numseen);
-        strpart[i] = r.substring(0, numseen + pointseen);
-        //part[i] = (Double.valueOf(strpart[i])).doubleValue();
-        part[i] = parseFloat(strpart[i]);
-        //System.out.println("RBH i = "+i+" strpart[i] = "+strpart[i] + " part[i] = " + part[i] );
+        part[i] = parseFloat(r.substring(0, numseen + pointseen));
 
         r = p;  // now deal with the separator
         p = p.trim();
         sep[i] = cSeparator(p);
-        if (sep[i] === '\0') {
-            // this character is NOT a separator
-            if (r.charAt(0) === ' ') {
-                sep[i] = ' ';
-                p = r;
-            }
-            else {
-                throw INVALID_STRING;
-            }
+        if (sep[i] === '\0') { // this character is NOT a separator
+            if (r.charAt(0) !== ' ') throw INVALID_STRING;
+            sep[i] = ' ';
+            p = r;
         }
-        point[i] = pointseen;
-        parts++;
-        if (p.length > 0) {
-            p = p.substring(1);
-        }
+        point[i] = Boolean(pointseen);
+        if (p.length > 0) p = p.substring(1);
         p = p.trim();
     } // outer-for loop ends here
 
     // when we get here we've cracked as many as 3 parts
     // if there's anything left, the whole string is junk
-    p = p.trim();
-    if (p.length > 0) {
-        throw INVALID_STRING;
-    }
+    if (p.trim().length > 0) throw INVALID_STRING;
 
     // Another way to be junk is to have a decimal point in any but
     // the 'last' part
+    if (point.slice(0,point.length-1).some( (pt) => pt)) throw 'Invalid input';
+    // must has found 1 to 3 parts
+    if (part.length===0 || part.length>3) throw INVALID_STRING;
 
-    if ((parts ===3 && (point[0] ===1 || point[1] ===1 )) || (parts ===2 && point[0] ===1)) {
-        throw 'Invalid input';
-    }
 
     // and another way to be junk is to use inconsistent or out
     // of order separators
-    // Here we also crack whether the input was ""decimal"" or not
+    // Here we also crack whether the input was "decimal" or not
 
-    if (parts=== 3) {
-        isdec = false;
-        if (sep[0] ==='h' && sep[1] ==='m' && sep[2] ==='s') {
-            degrees = 0;
-        }
-        else if (sep[0] ==='h' && sep[1] ==='m' && sep[2] ===' ') {
-            degrees = 0;
-        }
-        else if (sep[0] ==='d' && sep[1] ==='m' && sep[2] ==='s') {
-            degrees = 1;
-        }
-        else if (sep[0] ==='d' && sep[1] ==='m' && sep[2] ===' ') {
-            degrees = 1;
-        }
-        else if (sep[0] ===':' && sep[1] ===':' && sep[2] ===' ') {
-        }
-        else if (sep[0] ===' ' && sep[1] ===' ' && sep[2] ===' ') {
-        }
-        else if (sep[0] ==='d' && sep[1] ==='\'' && sep[2] ==='\"') {
-            degrees = 1;
-        }
-        else if (sep[0] ==='d' && sep[1] ==='\'' && sep[2] ===' ') {
-            degrees = 1;
-        }
-        else {
-            throw INVALID_SEPARATOR;
-        }
+    const sepJoin= sep.join(''); // join all the separators for easier testing
+    if (part.length===3) {
+        if (sepJoin==='hms' || sepJoin==='hm ') degrees = 0;
+        else if (sepJoin==='dms' || sepJoin==='dm ' || sepJoin===`d'"` || sepJoin===`d' `) degrees = 1;
+        else if (sepJoin===':: ' || sepJoin==='   ') degrees = -1;
+        else throw INVALID_SEPARATOR;
     }
-    else if (parts ===2) {
-        isdec = false;
-        if (sep[0] ==='h' && sep[1] ==='m') {
-            degrees = 0;
-        }
-        else if (sep[0] ==='h' && sep[1] ===' ') {
-            degrees = 0;
-        }
-        else if (sep[0] ==='d' && sep[1] ==='m') {
-            degrees = 1;
-        }
-        else if (sep[0] ==='d' && sep[1] ===' ') {
-            degrees = 1;
-        }
-        else if (sep[0] ==='m' && sep[1] ==='s') {
-        }
-        else if (sep[0] ==='m' && sep[1] ===' ') {
-        }
-        else if (sep[0] ===':' && sep[1] ===' ') {
-        }
-        else if (sep[0] ===' ' && sep[1] ===' ') {
-        }
-        else if (sep[0] ==='d' && sep[1] ==='\'') {
-            degrees = 1;
-        }
-        else if (sep[0] ==='\'' && sep[1] ==='\"') {
-            degrees = 1;
-        }
-        else if (sep[0] ==='\'' && sep[1] ===' ') {
-            degrees = 1;
-        }
-        else {
-            throw INVALID_SEPARATOR;
-        }
+    else if (part.length===2) {
+        if (sepJoin==='hm' || sepJoin==='h ') degrees = 0;
+        else if (sepJoin==='dm' || sepJoin==='d ' || sepJoin===`d'` ||  sepJoin===`'"` || sepJoin===`' `) degrees = 1;
+        else if (sepJoin==='ms' || sepJoin==='m ' || sepJoin===': ' || sepJoin==='  ') degrees = -1;
+        else throw INVALID_SEPARATOR;
     }
-    else if (parts ===1) {
+    else if (part.length===1) {
         if (sep[0] ==='h') {
             degrees = 0;
-            isdec = false;
-
         } else if (sep[0] ==='d') {
             degrees = 1;
             isdec = true;
-
         } else if (sep[0] ===' ') {
-
-            isdec= !(isequ && !islat);  // per CoordUtil.java
-
-        } else if (sep[0] ==='m') {
-            isdec = false;
-
-        } else if (sep[0] ==='s') {
-            isdec = false;
-
-        } else if (sep[0] ==='\'') {
+            degrees = -1;
+            isdec= !(isequ && !islat);
+        } else if (sep[0] ==='m' || sep[0] ==='s') {
+            degrees = -1;
+        } else if (sep[0] ===`'` || sep[0] ==='"') {
             degrees = 1;
-            isdec = false;
-
-        } else if (sep[0] ==='\"') {
-            degrees = 1;
-            isdec = false;
-
         } else {
             throw INVALID_SEPARATOR;
         }
-
-    } else {
-        throw INVALID_STRING;
-    }  // parts == 0
-
-    if (degrees=== -1) {
-        if (islat) {
-            degrees = 1;
-        } // input is a latitude
-        else if (isequ) {
-            degrees = 0;
-        }  // input is equatorial longitude (RA)
-        else {
-            degrees = 1;
-        }  // all else is DMS
     }
 
-    // No HMS for latitudes
-    if (degrees=== 0)  // not in degree format
-    {
-        if (islat){
-            throw HMS_FOR_LAT;
-        }
+    if (degrees===-1) {
+        if (islat)  degrees = 1;     // input is a latitude
+        else if (isequ) degrees = 0; // input is equatorial longitude (RA)
+        else degrees = 1;            // all else is DMS
     }
 
-    // No sexigesimal input for non-equatorial systems
-    if (!isequ && !isdec) {
-        throw SEX_FOR_NONE_EQU;
-    }
+    // No HMS for latitudes, not in degree format
+    if (degrees=== 0 && islat) throw HMS_FOR_LAT;
+
+    // No sexagesimal input for non-equatorial systems
+    if (!isequ && !isdec) throw SEX_FOR_NONE_EQU;
+
 
     // now modularize the input and convert to a double
 
-    //System.out.println("part[0] = "+part[0]+"  part[1] = "+part[1]+ " part[2] ="+part[2]);
-    if (parts > 1) {
-        for (i = parts - 1; i >= 1; i--) {
-            if (part[i] >= 60.0) {
-                throw MIN_SEC_TOO_BIG;
-                //part[i-1] += Math.floor(part[i] / 60.0);
-                //part[i] = part[i] % 60.0;
-            }
+    if (part.length > 1) {
+        for (let i = part.length - 1; i >= 1; i--) {
+            if (part[i] >= 60.0) throw MIN_SEC_TOO_BIG;
         }
     }
-    //System.out.println("part[0] = "+part[0]+"  part[1] = "+part[1]+ "  part[2] ="+part[2]);
 
-    if (degrees !==0) {
-        modangle = 360.0;
-    }    // in degree
-    else {
-        modangle = 24.0;
-    }   // Hours RA
+    const modangle = (degrees !==0) ? 360.0 : 24.0;
 
-    for (i = 0, angle = 0.0, base = 1.0; i < parts; i++, base *= 60.0){
-        angle += part[i] / base;
+    let returnAngle= 0;
+    for (let i = 0, base = 1.0; i < part.length; i++, base *= 60.0) {
+        returnAngle += part[i] / base;
     }
-
 
     // the input might be  xxm[xx[.xx]s] or just xx[.xx]s or xx[.xx]m
     // so we apply appropriate weighting - whether it's min arc or time
     // we worry about further on.
 
-    if (sep[0] ==='m' || sep[0] ==='\'') {
-        angle /= 60.0;
-    }
-    else if (sep[0] ==='s' || sep[0] ==='\"') {
-        angle /= 3600.0;
-    }
+    if (sep[0] ==='m' || sep[0] ==='\'') returnAngle /= 60.0;
+    else if (sep[0] ==='s' || sep[0] ==='"') returnAngle /= 3600.0;
 
-    angle *= sign;
+    returnAngle *= sign;
 
     if (islat) {
-        if (angle > 90.0 || angle < -90.0) {
-            throw LAT_OUT_RANGE;
-        }
+        if (returnAngle > 90.0 || returnAngle < -90.0) throw LAT_OUT_RANGE;
     }
-    else // input is longitude
-    {
-        if (angle >= modangle) {
-            if (degrees !==0) {
-                throw LON_TOO_BIG;
-            }
-            else {
-                throw RA_TOO_BIG;
-            }
-            //angle = angle % modangle;
+    else  { // input is longitude
+        if (returnAngle >= modangle) {
+            if (degrees !==0) throw LON_TOO_BIG;
+            else throw RA_TOO_BIG;
         }
-        else if (angle < 0.0) {
+        else if (returnAngle < 0.0) {
             throw LON_NEGATIVE;
-            //angle = (angle % modangle) + modangle;
         }
     }
 
     // make angle degrees if it isn't already and needs to be,
     // from hours to degrees.
     // we've already disallowed 'hours' as a valid form for latitudes
+    if (degrees ===0) returnAngle *= 15.0;
 
-    if (degrees ===0) {
-        angle *= 15.0;
-    }
-
-    // canonical string
-    /*
-     if (isequ)
-     {
-     if (islat) form = 1;
-     else form = 2;
-     }
-     else form = 0;
-
-
-     dangle = angle;
-     dangle_set = true;
-
-     buf = c_ddsex(form);
-
-     */
-    //System.out.println("RBH coordstr [" + coordstr + "]");
-
-    //System.out.println("Coord.java: buf = " + buf);
-    //System.out.println("Coord.java: isdec = " + isdec);
-    //System.out.println("Coord: dangle = " + dangle);
-
-    return angle;
+    return returnAngle;
 };
 
 
 /**
  * Converts decimal angle to string format
- * @param dangle decimal angle
- * @param islat true if the coordstr is latitude
- * @param isequ true if the coordstr is in equatorial system
- * @param precision for DMS, precision = 4+ number of
- *                            decimal digits you want in seconds
- *                       for HMS, precision = 3+ number of
- *                            decimal digits you want in seconds
-
- *  @return String representation of angle
+ * @param {number} dangle decimal angle
+ * @param {boolean} islat true if the coordstr is latitude
+ * @param {boolean} isequ true if the coordstr is in equatorial system
+ * @param {number} precision for DMS
+ * @return String representation of angle
  */
 export const dd2sex = function (dangle, islat, isequ, precision=5) {
-    var cPrecision;
-    var form;
-    var tmp, dfs;
-    var ofs;
-    var hd, m, s;
-    var rhd, rm, rs, rfs;
-    var drfs;
-    var d;
-    var circ;
-    var chd;
-    var cm = 'm';
-    var cs = 's';
-    var isign = 1;
-    var signstr;
-    //NumberFormat df;
-    var fmtstr;
-    var i;
-    var buf;
+    const cPrecision= (precision <= 0) ? 0: (precision >= MAX_PRECISION) ? MAX_PRECISION : precision;
 
-    // if (precision) {
-    //     precision = 5;
-    // }
-    if (precision <= 0) {
-        cPrecision = 0;
-    }
-    else if (precision <= MAX_PRECISION) {
-        cPrecision = precision;
-    }
-    else {
-        cPrecision = DEFAULT_PRECISION;
-    }
-
-    if ((dangle < 0.0) && islat) {
-        isign = -1;
-    }
-    if ((dangle < 0.0) && !islat) {
-        dangle = (dangle % 360.0) + 360.0;
-    }
-    if ((dangle >= 360.0) && !islat) {
-        dangle = dangle % 360.0;
-    }
+    if ((dangle < 0.0) && !islat) dangle = (dangle % 360.0) + 360.0;
+    if ((dangle >= 360.0) && !islat) dangle = dangle % 360.0;
 
     // sign for Latitude/Dec  '+' or '-'
-    if (isign ===1) {
-        signstr=  islat ? '+' : '';
-    }
-    else {
-        signstr = '-';
+    if (!isequ){  // form == form_decimal_degree or otherwise unrecognized
+        return ((islat && dangle >= 0) ? '+' : '') + sprintf(`%.${cPrecision}f`,dangle) +'d';
     }
 
-    if (isequ) {
-        form= islat ? FORM_DMS : FORM_HMS;
+    const form=islat ? FORM_DMS : FORM_HMS;
+
+    if (form===FORM_HMS)  dangle /= 15.0;   // convert degree to hours
+
+    const circ = form===FORM_HMS ? 24 : 360;
+    const secPrecision = form===FORM_HMS ? cPrecision - 3 : cPrecision - 4;
+    const isign =  ((dangle < 0.0) && islat) ? -1 : 1;
+    const signstr= isign ===1 ? islat ? '+' : '' : '-';
+
+    let tmp = Math.abs(dangle);
+    const degOrHours = Math.floor(tmp);
+    tmp -= degOrHours;
+    tmp *= 60.0;
+    const minutes = Math.floor(tmp);
+    tmp -= minutes;
+    tmp *= 60.0;
+    const seconds = Math.floor(tmp);
+    tmp -= seconds;
+    const dfs = tmp;
+
+    let rs = seconds;
+    let rm = minutes;
+    let rhd = degOrHours;
+    const ofs = Math.floor(Math.pow(10, secPrecision));
+    let rfs = Math.round(dfs * ofs);
+    if (rfs >= ofs) {
+        rfs -= ofs;
+        rs++;
     }
-    else {
-        form = FORM_DECIMAL_DEGREE;
+    if (rs >= 60) {
+        rs -= 60;
+        rm++;
     }
-
-    if (form ===FORM_HMS) {
-        dangle /= 15.0;
-    }  // convert degree to hours
-    if ((form ===FORM_DMS) || (form ===FORM_HMS)) {
-        tmp = Math.abs(dangle);
-        hd = Math.floor(tmp);
-        tmp -= hd;
-        tmp *= 60.0;
-        m = Math.floor(tmp);
-        tmp -= m;
-        tmp *= 60.0;
-        s = Math.floor(tmp);
-        tmp -= s;
-        dfs = tmp;
-
-        if (form ===FORM_DMS) {
-            // sexigesimal degrees
-            circ = 360;
-            chd = 'd';
-            switch (cPrecision) {
-                case 0:
-                    d = 1;
-                    break;
-
-                case 1:
-                case 2:
-                    d = 2;
-                    break;
-
-                case 3:
-                case 4:
-                    d = 3;
-                    break;
-
-                default:
-                    d = cPrecision - 1;    // 3 + precision + 4
-                    break;
-            }
-            drfs = cPrecision - 4;
-        }
-        else {
-            // sexigesimal hours min sec
-            circ = 24;
-            chd = 'h';
-            switch (cPrecision) {
-                case 0:
-                case 1:
-                    d = 2;
-                    break;
-
-                case 2:
-                case 3:
-                    d = 3;
-                    break;
-
-                default:
-                    d = cPrecision;
-                    break;    // 3+p-3
-            }
-            drfs = cPrecision - 3;   // the digits after seconds
-        }
-        switch (d) {
-            case 1:   // only degree
-                rhd = hd + ((m >= 30) ? 1 : 0);
-                if (rhd >= circ) {
-                    rhd -= circ;
-                }
-                buf = signstr;
-                //df = NumberFormat.getFormat('00');
-                //buf += df.format(rhd);
-                buf += sprintf('%02d',rhd);
-                buf += 'd';
-                break;
-
-            case 2:   // degree + minutes
-                rm = m + ((s >= 30) ? 1 : 0);
-                rhd = hd;
-                if (rm >= 60) {
-                    rm -= 60;
-                    rhd++;
-                }
-                if (rhd >= circ) {
-                    rhd -= circ;
-                }
-                buf = signstr;
-                buf += rhd;
-                buf += chd;
-                //df = NumberFormat.getFormat('00');
-                //buf += df.format(rm);
-                buf += sprintf('%02d',rm);
-                buf += cm;
-                break;
-
-            case 3:   // degree + minutes + seconds
-                rs = s + ((dfs >= 0.5) ? 1 : 0);
-                rm = m;
-                rhd = hd;
-                if (rs >= 60) {
-                    rs -= 60;
-                    rm++;
-                }
-                if (rm >= 60) {
-                    rm -= 60;
-                    rhd++;
-                }
-                if (rhd >= circ) {
-                    rhd -= circ;
-                }
-                buf = signstr;
-                buf += rhd;
-                buf += chd;
-                //df = NumberFormat.getFormat('00');
-                //buf += df.format(rm);
-                buf += sprintf('%02d',rm);
-                buf += cm;
-                //buf += df.format(rs);
-                buf += sprintf('%02d',rs);
-                buf += cs;
-                break;
-
-            default:
-                rs = s;
-                rm = m;
-                rhd = hd;
-                tmp = Math.pow(10, drfs);
-                ofs = Math.floor(tmp);
-                rfs = Math.round(dfs * ofs);
-                if (rfs >= ofs) {
-                    rfs -= ofs;
-                    rs++;
-                }
-                if (rs >= 60) {
-                    rs -= 60;
-                    rm++;
-                }
-                if (rm >= 60) {
-                    rm -= 60;
-                    rhd++;
-                }
-                if (rhd >= circ) {
-                    rhd -= circ;
-                }
-                buf = signstr;
-                buf += rhd;
-                buf += chd;
-                //df = NumberFormat.getFormat('00');
-                //buf += df.format(rm);
-                buf += sprintf('%02d',rm);
-                buf += cm;
-                //buf += df.format(rs);
-                buf += sprintf('%02d',rs);
-                buf += '.';
-                // for (i = 0, fmtstr = ''; i < drfs; i++) {
-                //     fmtstr += '0';
-                // }
-                //df = NumberFormat.getFormat(fmtstr);
-                //buf += df.format(rfs);
-                // buf += numeral(rfs).format(fmtstr);
-                buf += sprintf(`%0${drfs}d`,rfs);
-                buf += cs;
-                break;
-        }
+    if (rm >= 60) {
+        rm -= 60;
+        rhd++;
     }
-    else // form == FORM_DECIMAL_DEGREE or otherwise unrecognized
-    {
-        buf= (islat && dangle >= 0) ? '+' : '';
-        buf += sprintf(`%.${cPrecision}f`,dangle);
-        buf += 'd';
-    }
+    if (rhd >= circ) rhd -= circ;
 
-    return buf;
+    return signstr + rhd + (form===FORM_HMS ? 'h' : 'd')+
+        sprintf('%02d',rm) + 'm' +
+        sprintf('%02d',rs) + '.' + sprintf(`%0${secPrecision}d`,rfs) + 's';
 };
 
-function cSeparator (str) {
-    if (str.length===0) {
-        return ' ';
-    }
-    switch (str.charAt(0)) {
-        case 'h':
-        case 'H':
-            return 'h';
-        case 'd':
-        case 'D':
-            return 'd';
-        case 'm':
-        case 'M':
-            return 'm';
-        case 's':
-        case 'S':
-            return 's';
-        case ':':
-            return ':';
-        case '\'':
-        case '\"':
-            return str.charAt(0);
-        case ' ':
-        case '\t':
-            return '\0';
-        default:
-            return '\0';
-    }
+function cSeparator(str) {
+    if (!str) return ' ';
+    const char0= str.charAt(0).toLowerCase();
+    return [ 'h', 'd', 'm', 's', ':', '\'', '"'].includes(char0) ? char0 : '\0';
 }
 
-
-var validLon = function (hms, coordSystem) {
-    var returnVal= false;
+const validLon = (hms, coordSystem) => {
     try {
-        returnVal.convertStringToLon(hms, coordSystem);
-        returnVal = true;
+        convertStringToLon(hms, coordSystem);
+        return true;
     } catch (e) {
-        returnVal = false;
+        return false;
     }
-    return returnVal;
 };
 
+const convertLonToString = (lon, coordSystem) => dd2sex(lon, false, coordSystem.isEquatorial());
+const convertLatToString = (lat, coordSystem) => dd2sex(lat, true, coordSystem.isEquatorial());
+const convertStringToLon = (hms, coordSystem) => sex2dd(hms, false, coordSystem.isEquatorial());
+const convertStringToLat = (dms, coordSystem) => sex2dd(dms, true, coordSystem.isEquatorial());
 
-var convertLonToString = function (lon, coordSystem) {
-  return dd2sex(lon, false, coordSystem.isEquatorial(), 5);
-};
-
-
-var convertLatToString = function (lat, coordSystem) {
-  return dd2sex(lat, true, coordSystem.isEquatorial(), 5);
-};
-
-var convertStringToLon = function (hms, coordSystem) {
-  var eq = coordSystem.isEquatorial();
-  return sex2dd(hms, false, eq);
-};
-
-var convertStringToLat = function (dms, coordSystem) {
-  var eq = coordSystem.isEquatorial();
-  return sex2dd(dms, true, eq);
-};
-
-var CoordUtil= {
-  convertLonToString, convertLatToString, convertStringToLon, convertStringToLat, validLon
-};
+const CoordUtil= { convertLonToString, convertLatToString, convertStringToLon, convertStringToLat, validLon };
 
 export default CoordUtil;
-

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -567,14 +567,17 @@ export function dispatchChangeCenterOfProjection({plotId,centerProjPt, dispatche
  * @param {boolean} p.centerOnImage only used if centerPt is not defined.  If true then the centering will be
  *                                  the center of the image.  If false, then the center point will be the
  *                                  FIXED_TARGET attribute, if defined. Otherwise it will be the center of the image.
+ * @param {boolean} [updateFixedTarget] if true and centerPt is a worldPt, it will update the
+ *                                  FIXED_TARGET attribute on the plot
  * @param {Function} [p.dispatcher] only for special dispatching uses such as remote
  *
  * @public
  * @function dispatchRecenter
  * @memberof firefly.action
  */
-export function dispatchRecenter({plotId, centerPt= undefined, centerOnImage=false, dispatcher= flux.process}) {
-    dispatcher({type: RECENTER, payload: {plotId, centerPt, centerOnImage} });
+export function dispatchRecenter({plotId, centerPt= undefined, centerOnImage=false,
+                                     updateFixedTarget= false, dispatcher= flux.process}) {
+    dispatcher({type: RECENTER, payload: {plotId, centerPt, centerOnImage, updateFixedTarget} });
 }
 
 /**
@@ -827,6 +830,7 @@ export function dispatchOverlayPlotChangeAttributes({plotId,imageOverlayId, attr
  * @param {boolean} [p.zoomLockingEnabled]
  * @param {boolean} [p.forceDelay]
  * @param {number} [p.level] the level to zoom to, used only userZoomType 'LEVEL'
+ * @param {number} [p.upDownPercent] value between 0 and 1 - 1 is 100% of the next step up or down
  * @param {string|ActionScope} [p.actionScope] default to group
  * @param {DevicePt} devicePt
  * @param {Function} [p.dispatcher] only for special dispatching uses such as remote
@@ -849,14 +853,14 @@ export function dispatchOverlayPlotChangeAttributes({plotId,imageOverlayId, attr
  * // Example of zoom to level, if you are connected to a widget that is changing  the level fast, zlevel is the varible with the zoom level
  * action.dispatchZoom({plotId:’myplot’, userZoomType:’LEVEL’, level: zlevel, forceDelay: true }};
  */
-export function dispatchZoom({plotId, userZoomType, maxCheck= true,
+export function dispatchZoom({plotId, userZoomType, maxCheck= true, upDownPercent=1,
                              zoomLockingEnabled=false, forceDelay=false, level, devicePt,
                              actionScope=ActionScope.GROUP,
                              dispatcher= flux.process} ) {
     dispatcher({
         type: ZOOM_IMAGE,
         payload :{
-            plotId, userZoomType, actionScope, maxCheck, zoomLockingEnabled, forceDelay, level, devicePt
+            plotId, userZoomType, actionScope, maxCheck, zoomLockingEnabled, forceDelay, level, devicePt, upDownPercent,
         }});
 }
 

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -41,7 +41,7 @@ const {MOVE,DOWN,DRAG,UP, DRAG_COMPONENT, EXIT, ENTER}= MouseState;
 const draggingOrReleasing = (ms) => ms===DRAG || ms===DRAG_COMPONENT || ms===UP || ms===EXIT || ms===ENTER;
 
 
-const dispatchZoomThrottled= throttle((params) => dispatchZoom(params), 60, {leading:true, trailing:true});
+const dispatchZoomThrottled= throttle((params) => dispatchZoom(params), 30, {leading:true, trailing:true});
 
 /**
  * when a resize happens and zoom locking is enable then we need to start a zoom level change
@@ -156,7 +156,7 @@ export class ImageViewerLayout extends PureComponent {
         }
     }
 
-    eventCB(plotId,mouseState,screenPt,screenX,screenY) {
+    eventCB(plotId,mouseState,screenPt,screenX,screenY,nativeEv) {
         const {drawLayersAry,plotView}= this.props;
         const mouseStatePayload= makeMouseStatePayload(plotId,mouseState,screenPt,screenX,screenY);
         const list= drawLayersAry.filter( (dl) => dl.visiblePlotIdAry.includes(plotView.plotId) &&
@@ -167,13 +167,14 @@ export class ImageViewerLayout extends PureComponent {
             fireMouseEvent(dl,mouseState,mouseStatePayload);
         }
         else if (mouseState===MouseState.WHEEL_UP) {
-
             const devicePt= CCUtil.getDeviceCoords(primePlot(plotView),screenPt);
-            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.UP, devicePt });
+            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.DOWN, devicePt,
+                upDownPercent:Math.abs(nativeEv.wheelDeltaY)%120===0?1:.4 });
         }
         else if (mouseState===MouseState.WHEEL_DOWN) {
             const devicePt= CCUtil.getDeviceCoords(primePlot(plotView),screenPt);
-            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.DOWN , devicePt});
+            dispatchZoomThrottled({plotId, userZoomType:UserZoomTypes.UP , devicePt,
+                upDownPercent:Math.abs(nativeEv.wheelDeltaY)%120===0?1:.3 } );
         }
         else {
             const ownerCandidate= findMouseOwner(list,primePlot(plotView),screenPt);         // see if anyone can own that mouse

--- a/src/firefly/js/visualize/ZoomUtil.js
+++ b/src/firefly/js/visualize/ZoomUtil.js
@@ -1,7 +1,6 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-
 import Enum from 'enum';
 import {sprintf} from '../externalSource/sprintf';
 import {logger} from '../util/Logger.js';
@@ -11,25 +10,14 @@ import {getFoV, primePlot} from './PlotViewUtil.js';
 import {convertAngle} from './VisUtil.js';
 
 
-export const levels= [.03125, .0625, .125,.1,.25,.3, .4, .5, .75, .8, .9, 1, 1.25, 1.5,2, 2.5,3, 3.5,
-                         4,5, 6, 7,8, 9, 10, 11, 12, 13, 14, 15, 16, 18,20,22,24,28, 32];
-export const FullType = new Enum(['ONLY_WIDTH', 'WIDTH_HEIGHT', 'ONLY_HEIGHT', 'SMART']);
+export const FullType = new Enum(['ONLY_WIDTH', 'WIDTH_HEIGHT', 'ONLY_HEIGHT']);
 
-// const hiPSLevelsOLD= [0.000000007445312,
-//                    0.00000000930664,
-//                    0.000000011167969,
-//                    0.00000002978125,
-//                    0.0000000595625,
-//                    0.000000119125,
-//                    0.00000357421875, 0.00000023825, 0.0000004765, 0.000000953,0.000001906,
-//                    0.0000038125, 0.000002859375, 0.000007625, 0.00001525, 0.0000305,
-//                    0.0000610, 0.000122070, 0.000244140625, 0.00048828125,
-//                    0.0009765625, .001953125, 0.00390625,  .0078125,
-//                    .015625, .03125, .0625, .125,.25, .5, .75, 1,2, 4, 8, 10,
-//                    14, 16, 32, 64, 128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192,
-//                    10240, 16364, 24556, 32728, 57284, 65456, 122740, 130928 ];
+export const imageLevels= [.03125, .0625, .125,.1,.25,.3, .4, .5, .75, .8, .9, 1, 1.25, 1.5,2, 2.5,3, 3.5,
+    4,5, 6, 7,8, 9, 10, 11, 12, 13, 14, 15, 16, 18,20,22,24,28, 32];
+export const imageLevelsReversed= [...imageLevels].reverse();
 
-const hiPSLevels=  (()=> {
+
+const hipsLevels=  (()=> {
     const upMax= 3;
     const downMax= 62;
     const up= [1];
@@ -40,10 +28,10 @@ const hiPSLevels=  (()=> {
     return [...down, ...up];
 })();
 
-// const hiPSLevels= computeHipsLevels();
+export const hipsLevelsReversed= [...hipsLevels].reverse();
 
-const IMAGE_ZOOM_MAX= levels[levels.length-1];
-const HIPS_ZOOM_MAX= hiPSLevels[hiPSLevels.length-1];
+const IMAGE_ZOOM_MAX= imageLevels[imageLevels.length-1];
+const HIPS_ZOOM_MAX= hipsLevels[hipsLevels.length-1];
 
 /**
  * can be 'UP','DOWN', 'FIT', 'FILL', 'ONE', 'LEVEL', 'WCS_MATCH_PREV'
@@ -52,52 +40,45 @@ const HIPS_ZOOM_MAX= hiPSLevels[hiPSLevels.length-1];
  */
 export const UserZoomTypes= new Enum(['UP','DOWN', 'FIT', 'FILL', 'ONE', 'LEVEL', 'WCS_MATCH_PREV'], { ignoreCase: true });
 
-
-
 /**
  *
  * @param {WebPlot} plot
  * @param {ZoomType} zoomType
+ * @param {number} upDownPercent
  * @return {number}
  */
-export function getNextZoomLevel(plot, zoomType) {
+export function getNextZoomLevel(plot, zoomType, upDownPercent=1) {
+    if (zoomType===UserZoomTypes.ONE) return 1;
     const {zoomFactor}= plot;
-    const availableLevels= isImage(plot) ? levels : hiPSLevels;
     const zoomMax= isImage(plot)  ? IMAGE_ZOOM_MAX : HIPS_ZOOM_MAX;
-    let newLevel= 1;
+    const availableLevels= isImage(plot) ? imageLevels : hipsLevels;
     if (zoomType===UserZoomTypes.UP) {
-        newLevel= zoomFactor>=zoomMax ? zoomMax : availableLevels.find( (l) => l>zoomFactor);
-    }
-    else if (zoomType===UserZoomTypes.ONE) {
-        newLevel= 1;
+        if (zoomFactor>=zoomMax) return zoomMax;
+        const idx= availableLevels.findIndex( (l) => l>zoomFactor);
+        if (upDownPercent===1 || idx===0) return availableLevels[idx];
+        return zoomFactor + (availableLevels[idx]-availableLevels[idx-1])*upDownPercent;
     }
     else if (zoomType===UserZoomTypes.DOWN) {
-        newLevel= availableLevels[0];
-        let found= false;
-        for(let i= availableLevels.length-1; (i>=0); i--) {
-            found= (availableLevels[i]<zoomFactor);
-            if (found) {
-                newLevel= availableLevels[i];
-                break;
-            }
-        }
+        if (zoomFactor<=availableLevels[0]) return availableLevels[0];
+        const revLevels= isImage(plot) ? imageLevelsReversed : hipsLevelsReversed;
+        const idx= revLevels.findIndex((l) => l<zoomFactor );
+        if (upDownPercent===1 || idx===0 || idx===revLevels.length-1) return revLevels[idx];
+        return zoomFactor - (revLevels[idx]-revLevels[idx+1])*upDownPercent;
     }
     else {
         logger.error('unsupported zoomType');
+        return 1;
     }
-    return newLevel;
 }
 
 
 
 /**
- *
  * @param plot
  * @param screenDim
  * @param fullType
- * @param tryMinFactor
  */
-export function getEstimatedFullZoomFactor(plot, screenDim, fullType, tryMinFactor=-1) {
+export function getEstimatedFullZoomFactor(plot, screenDim, fullType) {
     const {width,height} = screenDim;
     let overrideFullType= fullType;
 
@@ -106,46 +87,29 @@ export function getEstimatedFullZoomFactor(plot, screenDim, fullType, tryMinFact
         if (FullType.has(s)) overrideFullType= FullType.get(s);
     }
     return getEstimatedFullZoomFactorDetails(overrideFullType, plot.dataWidth, plot.dataHeight,
-                                              width,height, tryMinFactor);
+                                              width,height);
 }
 
 function getEstimatedFullZoomFactorDetails(fullType, dataWidth, dataHeight,
-                                           screenWidth, screenHeight, tryMinFactor=-1) {
-    let zFact;
+                                           screenWidth, screenHeight) {
+    const zFactW =  screenWidth /  dataWidth;
+    const zFactH =  screenHeight /  dataHeight;
     if (fullType===FullType.ONLY_WIDTH || screenHeight <= 0 || dataHeight <= 0) {
-        zFact =  screenWidth /  dataWidth;
+        return  zFactW;
     } else if (fullType===FullType.ONLY_HEIGHT || screenWidth <= 0 || dataWidth <= 0) {
-        zFact =  screenHeight /  dataHeight;
+        return zFactH;
     } else {
-        const zFactW =  screenWidth /  dataWidth;
-        const zFactH =  screenHeight /  dataHeight;
-        if (fullType===FullType.SMART) {
-            zFact = zFactW;
-            if (zFactW > Math.max(tryMinFactor, 2)) {
-                zFact = Math.min(zFactW, zFactH);
-            }
-        } else {
-            zFact = Math.min(zFactW, zFactH);
-        }
+        return Math.min(zFactW, zFactH);
     }
-    return zFact;
 }
 
 
-export function getZoomMax(plot) { return isImage(plot) ? levels[levels.length-1] : hiPSLevels[hiPSLevels.length-1]; }
-
-
+export const getZoomMax= (plot) => isImage(plot) ? imageLevels[imageLevels.length-1] : hipsLevels[hipsLevels.length-1];
 
 function getOnePlusLevelDesc(level) {
-    let retval;
     const remainder= level % 1;
-    if (remainder < .1 || remainder>.9) {
-        retval= Math.round(level)+'x';
-    }
-    else {
-        retval= sprintf('%.3fx',level);
-    }
-    return retval;
+    if (remainder < .1 || remainder>.9) return Math.round(level)+'x';
+    else return sprintf('%.3fx',level);
 }
 
 /**
@@ -154,31 +118,24 @@ function getOnePlusLevelDesc(level) {
  * @param zoomFact
  * @return {number}
  */
-export function getArcSecPerPix(plot, zoomFact) {
-    return getPixScaleArcSec(plot) / zoomFact;
-}
+export const getArcSecPerPix= (plot, zoomFact) => getPixScaleArcSec(plot) / zoomFact;
 
-export function getZoomLevelForScale(plot, arcsecPerPix) {
-    return getPixScaleArcSec(plot) / arcsecPerPix;
-}
+export const getZoomLevelForScale= (plot, arcsecPerPix) => getPixScaleArcSec(plot) / arcsecPerPix;
 
 export function convertZoomToString(level) {
-    let retval;
     const zfInt= Math.floor(level*10000);
-
-    if (zfInt>=10000)      retval= getOnePlusLevelDesc(level); // if level > then 1.0
-    else if (zfInt===39)   retval= '1/256x';    // 1/256
-    else if (zfInt===78)   retval= '1/128x';    // 1/128
-    else if (zfInt===156)  retval= '1/64x';     // 1/64
-    else if (zfInt===312)  retval= '1/32x';     // 1/32
-    else if (zfInt===625)  retval= '1/16x';     // 1/16
-    else if (zfInt===1250) retval= '1/8x';      // 1/8
-    else if (zfInt===2500) retval= String.fromCharCode(188) +'x'; // 1/4
-    else if (zfInt===7500) retval= String.fromCharCode(190) +'x';   // 3/4
-    else if (zfInt===5000) retval= String.fromCharCode(189) +'x';   // 1/2
-    else if (level<.125)   retval= sprintf('%.3fx',level);
-    else                   retval= sprintf('%.1fx',level);
-    return retval;
+    if (zfInt>=10000)      return getOnePlusLevelDesc(level); // if level > then 1.0
+    else if (zfInt===39)   return '1/256x';    // 1/256
+    else if (zfInt===78)   return '1/128x';    // 1/128
+    else if (zfInt===156)  return '1/64x';     // 1/64
+    else if (zfInt===312)  return '1/32x';     // 1/32
+    else if (zfInt===625)  return '1/16x';     // 1/16
+    else if (zfInt===1250) return '1/8x';      // 1/8
+    else if (zfInt===2500) return String.fromCharCode(188) +'x'; // 1/4
+    else if (zfInt===7500) return String.fromCharCode(190) +'x';   // 3/4
+    else if (zfInt===5000) return String.fromCharCode(189) +'x';   // 1/2
+    else if (level<.125)   return sprintf('%.3fx',level);
+    else                   return sprintf('%.1fx',level);
 }
 
 const formatFOV = (charCode, fNum) => {
@@ -188,17 +145,13 @@ const formatFOV = (charCode, fNum) => {
 };
 
 export function makeFoVString(fov) {
-    let fovFormatted;
     if (isNaN(fov)) return '';
-    if (fov > 1.0) {
-        fovFormatted= formatFOV(String.fromCharCode(176), fov);
+    if (fov > 1) {
+        return formatFOV(String.fromCharCode(176), fov);
     } else {
         const fovMin = convertAngle('deg', 'arcmin', fov);
-
-        fovFormatted= fovMin > 1.0 ? formatFOV("'", fovMin) :
-            formatFOV('"', convertAngle('arcmin', 'arcsec', fovMin));
+        return fovMin > 1 ? formatFOV("'", fovMin) : formatFOV('"', convertAngle('arcmin', 'arcsec', fovMin));
     }
-    return fovFormatted;
 }
 
 /**
@@ -208,11 +161,10 @@ export function makeFoVString(fov) {
  */
 export function getZoomDesc(pv) {
     const plot= primePlot(pv);
-    if (!plot || !plot.viewDim) return {fovFormatted:'',zoomLevelFormatted:''};
-
-    const zoomLevelFormatted= isImage(plot) ? convertZoomToString(plot.zoomFactor) : '';
-    const fovFormatted= makeFoVString(getFoV(pv));
-
-    return {fovFormatted,zoomLevelFormatted};
+    if (!plot?.viewDim) return {fovFormatted:'',zoomLevelFormatted:''};
+    return {
+        zoomLevelFormatted: isImage(plot) ? convertZoomToString(plot.zoomFactor) : '',
+        fovFormatted: makeFoVString(getFoV(pv))
+    };
 
 }

--- a/src/firefly/js/visualize/iv/EventLayer.jsx
+++ b/src/firefly/js/visualize/iv/EventLayer.jsx
@@ -105,9 +105,9 @@ export const EventLayer = memo( ({transform,plotId, eventCallback}) => {
     };
 
     useEffect( () => {
-        eRef.element.addEventListener('wheel', onWheel);
-        return () => eRef.element.removeEventListener('wheel', onWheel);
-    });
+        eRef.element?.addEventListener('wheel', onWheel);
+        return () => eRef.element?.removeEventListener('wheel', onWheel);
+    }, [eRef.element, transform,plotId, eventCallback]);
 
     return (
         <div className='event-layer' style={style}

--- a/src/firefly/js/visualize/iv/EventLayer.jsx
+++ b/src/firefly/js/visualize/iv/EventLayer.jsx
@@ -12,11 +12,12 @@ const style={left:0,top:0,right:0, bottom:0,position:'absolute'};
 function fireEvent(ev,transform, plotId,mouseState, eventCallback, doPreventDefault= true) {
     if (doPreventDefault) ev.preventDefault();
     ev.stopPropagation();
-    const {screenX, screenY, offsetX, offsetY}= ev.nativeEvent;
+    const nativeEvent= ev.nativeEvent ? ev.nativeEvent : ev;
+    const {screenX, screenY, offsetX, offsetY}= nativeEvent;
     const trans= Matrix.from(transform).inverse();
     const tmpScreenPt= trans.applyToPoint(offsetX,offsetY);
     const spt= makeScreenPt(tmpScreenPt.x,tmpScreenPt.y);
-    eventCallback(plotId,mouseState,spt,screenX,screenY);
+    eventCallback(plotId,mouseState,spt,screenX,screenY,nativeEvent);
 }
 
 function fireDocEvent(element, nativeEv,transform, plotId,mouseState, eventCallback) {
@@ -29,7 +30,7 @@ function fireDocEvent(element, nativeEv,transform, plotId,mouseState, eventCallb
     const trans= Matrix.from(transform).inverse();
     const tmpScreenPt= trans.applyToPoint(compOffX, compOffY);
     const spt= makeScreenPt(tmpScreenPt.x,tmpScreenPt.y);
-    eventCallback(plotId,mouseState,spt,screenX,screenY);
+    eventCallback(plotId,mouseState,spt,screenX,screenY,nativeEv);
 }
 
 export const EventLayer = memo( ({transform,plotId, eventCallback}) => {
@@ -100,15 +101,21 @@ export const EventLayer = memo( ({transform,plotId, eventCallback}) => {
 
     const onWheel= (ev) => {
         if (!ev.deltaY) return;
-        fireEvent(ev,transform,plotId,ev.deltaY>0 ? MouseState.WHEEL_UP : MouseState.WHEEL_DOWN, eventCallback, false);
+        fireEvent(ev,transform,plotId,ev.deltaY>0 ? MouseState.WHEEL_UP : MouseState.WHEEL_DOWN, eventCallback, true);
     };
 
+    useEffect( () => {
+        eRef.element.addEventListener('wheel', onWheel);
+        return () => eRef.element.removeEventListener('wheel', onWheel);
+    });
+
     return (
-        <div className='event-layer' style={style} ref={(c) => eRef.element=c}
+        <div className='event-layer' style={style}
+             ref={ (c) => eRef.element=c}
              onClick={onClick} onDoubleClick={onDoubleClick} onMouseDownCapture={onMouseDown}
              onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}
              onMouseMoveCapture={onMouseMove} onTouchCancel={onTouchCancel}
-             onTouchEnd={onTouchEnd} onTouchMove={onTouchMove} onTouchStart={onTouchStart} onWheel={onWheel}
+             onTouchEnd={onTouchEnd} onTouchMove={onTouchMove} onTouchStart={onTouchStart}
         />
     );
 });

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -37,7 +37,7 @@ import {
     isRotationMatching,
     hasWCSProjection, canLoadStretchDataDirect
 } from '../PlotViewUtil.js';
-import {parseAnyPt, makeImagePt, makeWorldPt, makeDevicePt} from '../Point.js';
+import Point, {parseAnyPt, makeImagePt, makeWorldPt, makeDevicePt} from '../Point.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import PlotState, {RotateType} from '../PlotState.js';
 import {updateTransform} from '../PlotTransformUtils.js';
@@ -645,16 +645,17 @@ function updateViewSize(state,action) {
  * @return {VisRoot}
  */
 function recenter(state,action) {
-    const {plotId, centerPt, centerOnImage }= action.payload;
+    const {plotId, centerPt, centerOnImage, updateFixedTarget= false}= action.payload;
     const {wcsMatchType}= state;
     const pv= getPlotViewById(state,plotId);
 
     let plotViewAry;
     if (wcsMatchType) {
-        plotViewAry= recenterUsingWcsMatch(state,pv,centerPt,centerOnImage);
+        plotViewAry= recenterUsingWcsMatch(state,pv,centerPt,centerOnImage, false, updateFixedTarget);
     }
     else {
-        plotViewAry= applyToOnePvOrAll(state.positionLock, state.plotViewAry,plotId,false, recenterPv(centerPt, centerOnImage));
+        plotViewAry= applyToOnePvOrAll(state.positionLock, state.plotViewAry,plotId,false,
+            recenterPv(centerPt, centerOnImage, updateFixedTarget));
     }
 
 
@@ -662,10 +663,10 @@ function recenter(state,action) {
 }
 
 
-function recenterUsingWcsMatch(state, pv, centerPt, centerOnImage=false, onlyImages= false) {
+function recenterUsingWcsMatch(state, pv, centerPt, centerOnImage=false, onlyImages= false, updateFixedTarget= false) {
     const {wcsMatchType}= state;
     let   {plotViewAry}= state;
-    const newPv= recenterPv(centerPt, centerOnImage)(pv);
+    const newPv= recenterPv(centerPt, centerOnImage, updateFixedTarget)(pv);
     plotViewAry= replacePlotView(plotViewAry, newPv);
     plotViewAry= matchPlotViewByPositionGroup(state, newPv, plotViewAry, false, (pv) => {
         if (onlyImages && isHiPS(primePlot(pv))) return pv;
@@ -673,7 +674,7 @@ function recenterUsingWcsMatch(state, pv, centerPt, centerOnImage=false, onlyIma
             return updateScrollToWcsMatch(wcsMatchType, newPv, pv);
         }
         else {
-            return recenterPv(centerPt, centerOnImage)(pv);
+            return recenterPv(centerPt, centerOnImage, updateFixedTarget)(pv);
         }
     } );
     return plotViewAry;
@@ -686,10 +687,11 @@ function recenterUsingWcsMatch(state, pv, centerPt, centerOnImage=false, onlyIma
  * @param {boolean} centerOnImage - only used if centerPt is not defined.  If true then the centering will be
  *                  the center of the image.  If false, then the center point will be the
  *                  FIXED_TARGET attribute, if defined. Otherwise it will be the center of the image.
+ * @param {boolean} updateFixedTarget if true the PlotAttribute.FIXED_TARGET will but updated to this point
  * @return {Function} a new plot view
  */
 
-function recenterPv(centerPt,  centerOnImage) {
+function recenterPv(centerPt,  centerOnImage, updateFixedTarget= false) {
     return (pv) => {
         const plot = primePlot(pv);
         if (!plot) return pv;
@@ -707,14 +709,21 @@ function recenterPv(centerPt,  centerOnImage) {
         }
 
         if (isImage(primePlot(pv))) {
-            return updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv, centerImagePt));
+            const newPv= updatePlotViewScrollXY(pv, findScrollPtToCenterImagePt(pv, centerImagePt));
+            if (!updateFixedTarget || centerPt.type!==Point.W_PT) return newPv;
+            const newPlot= {...primePlot(pv), attributes:{...plot.attributes,[PlotAttribute.FIXED_TARGET]:centerPt}};
+            return replacePrimaryPlot(newPv,newPlot);
         }
         else {
             let cp;
             if (centerPt) cp= CCUtil.getWorldCoords(plot,centerPt);
             if (!cp) cp= plot.attributes[PlotAttribute.FIXED_TARGET];
             if (!cp) cp= makeWorldPt(0,0,plot.imageCoordSys);
-            return replacePrimaryPlot(pv, changeProjectionCenter(plot,cp));
+            const newPlot= changeProjectionCenter(plot,cp);
+            if (updateFixedTarget || centerPt.type===Point.W_PT) {
+                newPlot.attributes= {...newPlot.attributes, [PlotAttribute.FIXED_TARGET]:centerPt};
+            }
+            return replacePrimaryPlot(pv, newPlot);
         }
 
     };

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -275,6 +275,7 @@ function zoomStart(state, action) {
 
 function installTiles(state, action) {
     const {plotViewAry, mpwWcsPrimId, wcsMatchType}= state;
+    const clearLocal= action.type===Cntlr.STRETCH_CHANGE;
     const {plotId, primaryStateJson,primaryTiles,overlayUpdateAry,
         rawData,bias,contrast, useRed, useGreen, useBlue}= action.payload;
     let pv= getPlotViewById(state,plotId);
@@ -333,6 +334,7 @@ function installTiles(state, action) {
     }
 
     plot= primePlot(pv); // get the updated on
+    if (clearLocal) plot.dataRequested= false;
     PlotPref.putCacheColorPref(pv.plotViewCtx.preferenceColorKey, plot.plotState);
     const processedTiles= state.processedTiles.filter( (d) => d.plotId!==plotId); // remove old client tile data
 
@@ -408,7 +410,7 @@ function changeHiPS(state,action) {
     if (!isUndefined(cubeIdx) && plot.cubeDepth>1 && cubeIdx<plot.cubeDepth) {
         plot.cubeIdx= cubeIdx;
     }
-    if (!isUndefined(blankColor)) plot.blankColor= blankColor
+    if (!isUndefined(blankColor)) plot.blankColor= blankColor;
 
     if (hipsProperties || hipsUrlRoot || !isUndefined(cubeIdx)) {
         plot.plotImageId= `${pv.plotId}--${pv.plotViewCtx.plotCounter}`;

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -21,7 +21,6 @@ import {PlotAttribute} from '../PlotAttribute.js';
 import PlotState from '../PlotState.js';
 import {RangeValues} from '../RangeValues.js';
 import {
-    clearLocalStretchData,
     loadStretchData, queueChangeLocalRawDataColor,
     stretchRawData
 } from '../rawData/RawDataOps.js';
@@ -117,7 +116,7 @@ export function colorChangeActionCreator(rawAction) {
         }
 
 
-        const aType= ImagePlotCntlr.STRETCH_CHANGE;
+        const aType= ImagePlotCntlr.COLOR_CHANGE;
         if (rawAction.payload.actionScope===ActionScope.SINGLE){
             const local=hasLocalStretchByteData(plot);
             const taskId= makeTaskId();
@@ -239,7 +238,6 @@ export function stretchChangeActionCreator(rawAction) {
                 processPlotUpdateLocal(dispatcher, plotId, taskId, stretchRawData(stretchPlot,rvAry), ImagePlotCntlr.STRETCH_CHANGE);
             }
             else if (hasLocalStretchByteData(stretchPlot) || hasClearedByteData(stretchPlot)){
-                clearLocalStretchData(stretchPlot);
                 await doStretchServerCall(dispatcher,getState, store,plotId,stretchData);
             }
             else {

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -394,9 +394,9 @@ class ConstraintPanel extends PureComponent {
         const totalCol = columns ? (columns.length-1) : 0;
 
         return (
-            <div style={{display:'inline-block', flex: '1 1 auto', padding: '5px 5px'}}>
-                <div style={{ position: 'relative', width: '100%', height: '100%'}}>
-                    <div className='TablePanel'>
+            <div style={{display:'flex', flex: '1 1 auto', padding: '5px 5px'}}>
+                <div style={{ display:'flex', flex: '1 1 auto', position: 'relative', width: '100%', height: '100%'}}>
+                    <div className='TablePanel' style={{minHeight:180, flex: '1 1 auto'}}>
                         <div className={'TablePanel__wrapper--border'}>
                             <div className='TablePanel__table' style={{top: 0}}>
                                 <BasicTableViewWithConnector

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -74,6 +74,7 @@ export class CatalogSelectViewPanel extends PureComponent {
             <div style={{width:'100%'}}>
                 <FormPanel
                     width='auto' height='auto'
+                    style={{width:'100%', height:'100%'}}
                     groupKey={[irsaCatalogGroupKey, gkeySpacial]}
                     onSuccess={(request) => onSearchSubmit(request)}
                     onError={(request) => onSearchFail(request)}
@@ -550,7 +551,7 @@ class CatalogDDList extends PureComponent {
         const tbl_id = `${catname0}-${shortdd}-dd-table-constraint`;
 
         const {cols} = master;
-        const catPanelStyle = {height: 350};
+        const catPanelStyle = {height: 300};
 
         const polygonDefWhenPlot= get(getAppOptions(), 'catalogSpacialOp')==='polygonWhenPlotExist';
 

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -22,8 +22,10 @@ import {getComponentState} from '../../core/ComponentCntlr.js';
 
 
 const startWatcher= once((viewerId) => {
-    const coverageOps= get(getAppOptions(), 'coverage',{});
-    startCoverageWatcher({...coverageOps, viewerId, ignoreCatalogs:true});
+    setTimeout(() => {
+        const coverageOps= get(getAppOptions(), 'coverage',{});
+        startCoverageWatcher({...coverageOps, viewerId, ignoreCatalogs:true});
+    },1);
 });
 
 const isCoverageFail= (covState,tbl_id) => covState.find( (e) => e.tbl_id===tbl_id)?.status===COVERAGE_FAIL;
@@ -33,9 +35,10 @@ export function CoverageViewer({viewerId='coverageImages',insideFlex=true, noCov
                                 workingMessage='Working...', noCovStyle={}}) {
 
     startWatcher(viewerId);
-    const [pv,tbl_id,covState] = useStoreConnector(
+    const [pv,tbl_id,isFetching,covState] = useStoreConnector(
         () => getActivePlotView(visRoot()),
         () => getActiveTableId(),
+        () => getTblById(getActiveTableId())?.isFetching ?? false,
         () => getComponentState(COVERAGE_WATCH_CID,[]));
 
 
@@ -63,7 +66,7 @@ export function CoverageViewer({viewerId='coverageImages',insideFlex=true, noCov
     }
     else {
         let msg= noCovMessage;
-        if (tblHasCoverage || getTblById(tbl_id)?.isFetching) {
+        if (tblHasCoverage || isFetching) {
             msg= isCoverageFail(covState,tbl_id) ? noCovMessage : workingMessage;
         }
         else if (forceShow) {

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -178,7 +178,7 @@ function layoutHandler(action, cancelSelf) {
 function closeExpanded() {
     dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);
 }
-const hasCatalogTable= (tblList) => tblList.some( (id) => isCatalog(id) );
+const hasCoverageTable= (tblList) => tblList.some( (id) => hasCoverageData(id) );
 const hasOrbitalPathTable= (tblList) => tblList.some( (id) => isOrbitalPathTable(id) );
 const hasMetaTable= (tblList) => tblList.some( (id) => isMetaDataTable(id) );
 const findFirstMetaTable= (tblList) => tblList.find( (id) => isMetaDataTable(id) );
@@ -229,7 +229,7 @@ function onActiveTable (layoutInfo, action) {
     if (isEmpty(tblList)) return smartMerge(layoutInfo, {showImages});
 
     // check for catalog or meta images
-    const anyHasCatalog= hasCatalogTable(tblList);
+    const anyHasCoverage= hasCoverageTable(tblList);
     const hasOrbitalPath=  hasOrbitalPathTable(tblList);
     const anyHasMeta= hasMetaTable(tblList);
 
@@ -238,7 +238,7 @@ function onActiveTable (layoutInfo, action) {
     //     coverageLockedOn= anyHasCatalog || anyHasMeta;
     // }
 
-    if (anyHasCatalog || anyHasMeta || hasOrbitalPath) {
+    if (anyHasCoverage || anyHasMeta || hasOrbitalPath) {
         showCoverage = true;
         showImages = true;
     } else {

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -6,7 +6,7 @@ import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, isString} from 'lodash';
 import {
-    primePlot,getPlotViewById, isMultiHDUFits, getCubePlaneCnt, getHDU,
+    primePlot,getPlotViewById, isMultiHDUFits, getCubePlaneCnt, getHDU, getActivePlotView,
     convertHDUIdxToImageIdx, convertImageIdxToHDU, getFormattedWaveLengthUnits,
     getHDUCount, getHDUIndex, getPtWavelength, hasPlaneOnlyWLInfo, isImageCube } from '../PlotViewUtil.js';
 import {getHeader} from '../FitsHeaderUtil.js';
@@ -59,10 +59,14 @@ function makeExtensionButtons(extensionAry,pv) {
     return extensionAry.map( (ext,idx) => {
             return (
                 <ToolbarButton icon={ext.imageUrl} text={ext.title}
-                               tip={ext.toolTip} key={ext.id}
+                               tip={ext.toolTip} key={ext.id} shortcutKey={ext.shortcutKey}
                                horizontal={true} enabled={true}
                                lastTextItem={idx===(extensionAry.length-1)}
-                               onClick={() => dispatchExtensionActivate(ext,makePlotSelectionExtActivateData(ext,pv))}/>
+                               onClick={() => {
+                                   if (getActivePlotView(visRoot())?.plotId===pv.plotId) {
+                                       dispatchExtensionActivate(ext,makePlotSelectionExtActivateData(ext,pv));
+                                   }
+                               }}/>
                 );
         }
     );
@@ -239,9 +243,6 @@ export const VisCtxToolbarView= memo((props) => {
             <ToolbarButton icon={CROP} tip='Crop the image to the selected area'
                            horizontal={true} onClick={() => crop(pv)}/>}
 
-            {showSelectionTools && image &&
-            <ToolbarButton icon={STATISTICS} tip='Show statistics for the selected area'
-                           horizontal={true} onClick={() => stats(pv)}/>}
 
             {showCatSelect &&
             <ToolbarButton icon={SELECTED} tip='Mark data in area as selected'
@@ -263,10 +264,15 @@ export const VisCtxToolbarView= memo((props) => {
             <ToolbarButton icon={SELECTED_ZOOM} tip='Zoom to fit selected area'
                            horizontal={true}
                            onClick={() => zoomIntoSelection(pv)}/>}
-
+                           
             { showSelectionTools &&
             <ToolbarButton icon={SELECTED_RECENTER} tip='Recenter image to selected area'
                            horizontal={true} onClick={() => recenterToSelection(pv)}/>}
+                           
+            {showSelectionTools && image &&
+            <ToolbarButton icon={STATISTICS} tip='Show statistics for the selected area'
+                           horizontal={true} onClick={() => stats(pv)}/>}
+
 
             {makeExtensionButtons(extensionAry,pv)}
 


### PR DESCRIPTION
### Implements multiple tickets

 - Firefly-678: coverage now supports HMS coordinate strings in the table
 - Firefly-380: coverage now updates when a table is filtered to empty
 - Firefly-727: coverage now updates correctly when a empty table is loaded
 - Firefly-731: keyboard shortcuts now supported when adding extensions from python/remote API
 - Firefly-735: reverse the scroll wheel zoom dir
 - Firefly-720: fixed: document scroll with mouse wheel zoom
 - Firefly-736: only a partial fix to work around safari bugs, we might work on it more later
 - `dispatchRecenter` now supports `updateFixedTarget` parameter
 - Cleaned up CoordUtil.js - removed options we don't and will probably never use
 - Added KOA to TAP list

#### Tickets:
 - https://jira.ipac.caltech.edu/browse/FIREFLY-678
 - https://jira.ipac.caltech.edu/browse/FIREFLY-380
 - https://jira.ipac.caltech.edu/browse/FIREFLY-727
 - https://jira.ipac.caltech.edu/browse/FIREFLY-731
 - https://jira.ipac.caltech.edu/browse/FIREFLY-720
 - https://jira.ipac.caltech.edu/browse/FIREFLY-735
 - https://jira.ipac.caltech.edu/browse/FIREFLY-736


#### To test:

https://fireflydev.ipac.caltech.edu/firefly-multi-ticket/firefly/

  - try searching KOA
  
 For coverage:
   -  do a search with results, the following it up with a search with no results )
      - I did tap `koa` - `koa_hires` - `kepler10` - `100 arcsec`, followed by the coords `1,2`
   - filter a table so it is empty
   - read in a table with hms coordinates (example in Firefly-727)
   
The python extension shortcut is hard to test since we have to release the `firefly_client` that accesses the features
 
the `dispatchRecenter` can be tested by @cwang2016 
```js
firefly.action.dispatchRecenter({
                        plotId:pId,
                        centerPt:pos[nextIdx],
                        updateFixedTarget:true
                    });
```


