### PR TITLE
FIREFLY-717_full_url_token URL escape option for <LINK> parameters values for single complete token case

### DIFF
--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1223,8 +1223,9 @@ export const findTargetName = (columns) => columns.find( (c) => DEFAULT_TNAME_OP
  * @returns {string}    the resolved href after subsitution
  */
 export function applyLinkSub(tableModel, href='', rowIdx, fval='') {
-    if (href) fval = encodeURIComponent(fval);                  // if href is given, then we assume fval is a value token and not a full url.
-    const rhref = applyTokenSub(tableModel, href, rowIdx, '', true);
+    const encode = !!href && !href.match(/^\${[\w -.]+}$/g);      // don't encode if href is blank or consists of exact one token.
+    if (encode) fval = encodeURIComponent(fval);                // if encoding is needed, then fval needs to be encoded.
+    const rhref = applyTokenSub(tableModel, href, rowIdx, '', encode);
     if (rhref === href) {
         return fval ? href + fval : '';       // no substitution given, append defval to the url.  set A.1
     }
@@ -1247,7 +1248,6 @@ export function applyTokenSub(tableModel, val='', rowIdx, def, encode=false) {
     const vars = val?.match?.(/\${[\w -.]+}/g);
     let rval = val;
     if (vars) {
-        encode = encode && (vars[0] !== val);
         vars.forEach((v) => {
             const [,cname] = v.match(/\${([\w -.]+)}/) || [];
             const col = getColumnByRef(tableModel, cname);

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1247,6 +1247,7 @@ export function applyTokenSub(tableModel, val='', rowIdx, def, encode=false) {
     const vars = val?.match?.(/\${[\w -.]+}/g);
     let rval = val;
     if (vars) {
+        encode = encode && (vars[0] !== val);
         vars.forEach((v) => {
             const [,cname] = v.match(/\${([\w -.]+)}/) || [];
             const col = getColumnByRef(tableModel, cname);


### PR DESCRIPTION
This PR has the solution regarding  the issue addressed in https://jira.ipac.caltech.edu/browse/FIREFLY-717 
In the case like  `<LINK href=“${columm_name}”>` where the assignment to 'href' is a single independent token, then the value from the relevant column is treated as a full URL, no escape is involved while resolving a tag with 'href' value.

Test: 
https://fireflydev.ipac.caltech.edu/firefly-717-full-url-token/firefly/
Please test two xml samples adapted from NED votables  attached in https://jira.ipac.caltech.edu/browse/FIREFLY-717. 


