### PR TITLE
Firefly-742: fixes issue calling NED with a '+'

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/net/NedNameResolver.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/net/NedNameResolver.java
@@ -12,6 +12,7 @@ import edu.caltech.ipac.visualize.plot.ResolvedWorldPt;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -22,11 +23,12 @@ public class NedNameResolver {
     private static final String SERVER = AppProperties.getProperty("ned.host", "https://ned.ipac.caltech.edu");
     private static final String NED_URL_STR= SERVER + "/srs/ObjectLookup";
     private static final String POST_TEMPLATE = "{\"name\":{\"v\":\"%s\"}}";
+    private static final Map<String,String> header = Collections.singletonMap("Content-Type", "application/json");
 
     public static ResolveResult resolveName(String objName) throws FailedRequestException {
         try {
-            Map<String,String> postData= CollectionUtil.stringMap("json",String.format(POST_TEMPLATE, objName));
-            String jsonStr= URLDownload.getDataFromURL(new URL(NED_URL_STR),postData , null, null).getResultAsString();
+            Map<String,String> postData= CollectionUtil.stringMap("",String.format(POST_TEMPLATE, objName));
+            String jsonStr= URLDownload.getDataFromURL(new URL(NED_URL_STR),postData , null,header).getResultAsString();
             JsonHelper helper= JsonHelper.parse(jsonStr);
             long resultCode= helper.getValue(0L, "ResultCode");
             if (resultCode != 2 && resultCode != 3) throw makeEx(objName, "resultCode="+resultCode,null);

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -316,6 +316,9 @@ public class URLDownload {
 
     private static String postDataToString(Map<String,String> postData) {
         StringBuilder sBuff= new StringBuilder();
+        if (postData.size()==1 && postData.get("")!=null) {
+            return postData.get("");
+        }
         for(Map.Entry<String,String> entry : postData.entrySet()) {
             if (sBuff.length()>0) sBuff.append("&");
             sBuff.append(entry.getKey()).append("=").append(entry.getValue());
@@ -327,7 +330,9 @@ public class URLDownload {
         if (!(conn instanceof HttpURLConnection) || postData==null) return;
         String postStr= postDataToString(postData);
         ((HttpURLConnection)conn).setRequestMethod("POST");
-        conn.setRequestProperty( "Content-Type", "application/x-www-form-urlencoded" );
+        if (conn.getRequestProperty("Content-Type")==null) {
+            conn.setRequestProperty( "Content-Type", "application/x-www-form-urlencoded" );
+        }
         conn.setRequestProperty( "Content-Length", String.valueOf(postStr.length()));
         conn.setDoOutput(true);
         OutputStream os = conn.getOutputStream();


### PR DESCRIPTION
Fixes issue with calling NED passing `Content-Type: application/json`

testing:
https://fireflydev.ipac.caltech.edu/firefly-742-ned-call/firefly/

Use target panel and try : `SSTSL2 J140258.51+542318.3`
