### PR TITLE
IRSA-3498: update help anchors

### DIFF
--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -137,7 +137,7 @@ export function showTableDownloadDialog({tbl_id, tbl_ui_id}) {
                                 </div>
                             </div>
                             <div style={{ textAlign:'right', marginRight: 10}}>
-                                <HelpIcon helpId={'tablesCST.header'}/>
+                                <HelpIcon helpId={'tables.save'}/>
                             </div>
                         </div>
                     </div>

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -182,7 +182,7 @@ const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
                                     onFail={resultsFail} />
                     <CompleteButton text='Cancel' groupKey='' onSuccess={() => closePopup(popupId)} />
                 </div>
-                <HelpIcon helpId={'visualization.imageoptions'}/>
+                <HelpIcon helpId={'visualization.saveimage'}/>
             </div>
         </FieldGroup>
     );

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -116,7 +116,7 @@ function FitsRotationImmediatePanel() {
             <div style={{textAlign:'center', display:'flex', justifyContent:'space-between', padding: '0 16px'}}>
                 <CompleteButton text='Close' dialogId={DIALOG_ID} />
                 <div style={{ textAlign:'center', marginBottom: 20}}>
-                    <HelpIcon helpId={'visualization.imageoptions'} />
+                    <HelpIcon helpId={'visualization.rotate'} />
                 </div>
             </div>
         </div>

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -137,7 +137,7 @@ export function showHiPSSurverysPopup(hipsUrl,  pv, surveysId = HiPSId, dataType
                             </div>
                         </div>
                         <div style={{ textAlign:'right', marginRight: 10}}>
-                            <HelpIcon helpId={'visualization.hipsViewer'}/>
+                            <HelpIcon helpId={'visualization.changehips'}/>
                         </div>
                     </div>
                 </div>

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -80,7 +80,7 @@ export class CatalogSelectViewPanel extends PureComponent {
                     onError={(request) => onSearchFail(request)}
                     params={{hideOnInvalid: false}}
                     buttonStyle={{justifyContent: 'left'}} submitBarStyle={{padding: '2px 3px 3px'}}
-                    help_id={'basics.catalogs'}
+                    help_id={'catalogs'}
                     onCancel={hideSearchPanel}>
                     <CatalogSelectView fields={fields}/>
                 </FormPanel>

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -80,7 +80,7 @@ export class CatalogSelectViewPanel extends PureComponent {
                     onError={(request) => onSearchFail(request)}
                     params={{hideOnInvalid: false}}
                     buttonStyle={{justifyContent: 'left'}} submitBarStyle={{padding: '2px 3px 3px'}}
-                    help_id={'catalogs'}
+                    help_id={'catalogs.irsacatalogs'}
                     onCancel={hideSearchPanel}>
                     <CatalogSelectView fields={fields}/>
                 </FormPanel>

--- a/src/firefly/js/visualize/ui/ExtraIpacSearches.jsx
+++ b/src/firefly/js/visualize/ui/ExtraIpacSearches.jsx
@@ -53,13 +53,13 @@ export const ClassicCatalogUploadPanel= () => (
 );
 
 export const ClassicVOCatalogPanel= () => (
-    <FormTemplate groupKey='VO_CLASSIC' onSuccess={(request) => doVoSearch(request)} help_id='catalogs.vo' >
+    <FormTemplate groupKey='VO_CLASSIC' onSuccess={(request) => doVoSearch(request)} help_id='catalogs.voscs' >
         <VoSearchPanel fieldKey='vopanel'/>
     </FormTemplate>
 );
 
 export const ClassicNedSearchPanel= () => (
-    <FormTemplate groupKey='NED_CLASSIC' onSuccess={(request) => doVoSearch(request,'NED')} help_id= 'catalogs.ned'>
+    <FormTemplate groupKey='NED_CLASSIC' onSuccess={(request) => doVoSearch(request,'NED')} help_id= 'catalogs.nedcatalogs'>
         <NedSearchPanel/>
     </FormTemplate>
 );

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -267,7 +267,7 @@ function renderCloseAndHelpButtons(popupId){
             />
         </div>
         <div style={helpIdStyle}>
-            <HelpIcon helpId={'visualization.fitsViewer'}/>
+            <HelpIcon helpId={'visualization.tables'}/>
         </div>
     </div>
 );

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -267,7 +267,7 @@ function renderCloseAndHelpButtons(popupId){
             />
         </div>
         <div style={helpIdStyle}>
-            <HelpIcon helpId={'visualization.tables'}/>
+            <HelpIcon helpId={'tables'}/>
         </div>
     </div>
 );

--- a/src/firefly/js/visualize/ui/HiPSPropertyView.jsx
+++ b/src/firefly/js/visualize/ui/HiPSPropertyView.jsx
@@ -106,7 +106,7 @@ function renderCloseAndHelpButtons(popupId){
             />
         </div>
         <div style={helpIdStyle}>
-            <HelpIcon helpId={'visualization.hipsViewer'}/>
+            <HelpIcon helpId={'visualization.tables'}/>
         </div>
     </div>
 );

--- a/src/firefly/js/visualize/ui/HiPSPropertyView.jsx
+++ b/src/firefly/js/visualize/ui/HiPSPropertyView.jsx
@@ -106,7 +106,7 @@ function renderCloseAndHelpButtons(popupId){
             />
         </div>
         <div style={helpIdStyle}>
-            <HelpIcon helpId={'visualization.tables'}/>
+            <HelpIcon helpId={'tables'}/>
         </div>
     </div>
 );

--- a/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
@@ -23,7 +23,7 @@ import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
 
 
 const popupId = 'ImageAreaStatsPopup';
-const helpId = 'visualization.fitsViewer';
+const helpId = 'visualization.selectregion';
 const typeId = StatsPoint.TYPE_ID;
 const noBand = 'NO_BAND';
 

--- a/src/firefly/js/visualize/ui/VisToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisToolbarView.jsx
@@ -338,7 +338,7 @@ export const VisToolbarView = memo( ({visRoot,dlCount}) => {
 
             <div style={{display:'inline-block', height:'100%', flex:'0 0 auto', marginLeft:'10px'}}>
                 <HelpIcon
-                    helpId={'visualization.imageoptions'}/>
+                    helpId={'visualization.toolbar'}/>
             </div>
 
         </div>


### PR DESCRIPTION
I've tried to update the help anchors id where it says 'edit' in the ticket [IRSA-3498](https://jira.ipac.caltech.edu/browse/IRSA-3498).
The build of Firefly and IRSAViewer are here for testing:

https://irsa-3498-update-helpid.irsakudev.ipac.caltech.edu/irsaviewer/

https://fireflydev.ipac.caltech.edu/irsa-3498-update-helpid/firefly/

I think that some helpId will point to IRSAViewer content but not in Firefly. Example: '#visualization.selectregion'.

Please check, and let me know. Thanks.

Upload helpid is different in IRSAViewer . this needs an IFE change, see here:https://github.com/IPAC-SW/irsa-ife/pull/158