### PR TITLE
Irsa 3871 display plane with value and unit in the cube

### DIFF
--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -905,16 +905,18 @@ export const wavelengthInfoParsedSuccessfully= (plot) => hasWLInfo(plot) && !Boo
 export const getWavelengthParseFailReason= (plot) => hasWLInfo(plot) && plot.wlData.failReason;
 
 /**
- * also check if vrad data is available, when CTYPE# = 'VRAS-xxx', hasVRADInfo is true.
+ * also check if vrad data is available, when CTYPE# = 'VRAD-xxx', hasVRADInfo is true.
  * @param {WebPlot} plot
  * @returns {boolean}
  */
+/*
 export const hasVRADInfo= (plot) =>
            Boolean(plot && plot.wlData && isDefined(plot.vradData.vradType) && isVRADAlgorithmImplemented(plot.vradData) );
 
 export const vradInfoParsedSuccessfully= (plot) => hasVRADInfo(plot) && !Boolean(plot.vradData.failReason);
 
 export const getVradParseFailReason= (plot) => hasVRADInfo(plot) && plot.vradData.failReason;
+*/
 
 /**
  * check to see if wavelength data is available as the plain level (not pixel level) only
@@ -925,7 +927,7 @@ export const hasPlaneOnlyWLInfo= (plot) => hasWLInfo(plot) && plot.wlData.algori
 
 export const hasPixelLevelWLInfo= (plot) => hasWLInfo(plot) && plot.wlData.algorithm!==PLANE;
 
-export const hasPlaneOnlyVRADInfo= (plot) => hasVRADInfo(plot) && plot.vradData.algorithm===PLANE;
+//export const hasPlaneOnlyVRADInfo= (plot) => hasVRADInfo(plot) && plot.vradData.algorithm===PLANE;
 
 /**
  * Return the units string
@@ -977,8 +979,8 @@ export const getPtWavelength= (plot, pt, cubeIdx) =>
  * @param {number} cubeIdx
  * @return {number}
  */
-export const getPtVrad= (plot, pt, cubeIdx) =>
-          hasVRADInfo(plot) && getVrad(CCUtil.getImageCoords(plot,pt),cubeIdx,plot.vradData);
+//export const getPtVrad= (plot, pt, cubeIdx) =>
+//          hasVRADInfo(plot) && getVrad(CCUtil.getImageCoords(plot,pt),cubeIdx,plot.vradData);
 
 //=============================================================
 //=============================================================

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -892,7 +892,7 @@ export function convertImageIdxToHDU(pv, imageIdx) {
 /**
  * check to see if wavelength/radio velocity/frequency data is available
  * Only CTYPEka = 'WAVE-ccc', exists, the hasWLInfo is true.
- * also check if vrad data is available, when CTYPE# = 'VRAS-xxx', hasVRADInfo is true.
+ * also check if vrad data is available, when CTYPE# = 'VRAD-xxx', hasVRADInfo is true.
  * If the wlType or vradType is not defined, it is a pure cube data
  * @param {WebPlot} plot
  * @return {boolean}
@@ -905,20 +905,6 @@ export const wavelengthInfoParsedSuccessfully= (plot) => hasWLInfo(plot) && !Boo
 export const getWavelengthParseFailReason= (plot) => hasWLInfo(plot) && plot.wlData.failReason;
 
 /**
- * also check if vrad data is available, when CTYPE# = 'VRAD-xxx', hasVRADInfo is true.
- * @param {WebPlot} plot
- * @returns {boolean}
- */
-/*
-export const hasVRADInfo= (plot) =>
-           Boolean(plot && plot.wlData && isDefined(plot.vradData.vradType) && isVRADAlgorithmImplemented(plot.vradData) );
-
-export const vradInfoParsedSuccessfully= (plot) => hasVRADInfo(plot) && !Boolean(plot.vradData.failReason);
-
-export const getVradParseFailReason= (plot) => hasVRADInfo(plot) && plot.vradData.failReason;
-*/
-
-/**
  * check to see if wavelength data is available as the plain level (not pixel level) only
  * @param {WebPlot} plot
  * @return {boolean}
@@ -926,8 +912,6 @@ export const getVradParseFailReason= (plot) => hasVRADInfo(plot) && plot.vradDat
 export const hasPlaneOnlyWLInfo= (plot) => hasWLInfo(plot) && plot.wlData.algorithm===PLANE;
 
 export const hasPixelLevelWLInfo= (plot) => hasWLInfo(plot) && plot.wlData.algorithm!==PLANE;
-
-//export const hasPlaneOnlyVRADInfo= (plot) => hasVRADInfo(plot) && plot.vradData.algorithm===PLANE;
 
 /**
  * Return the units string
@@ -969,15 +953,6 @@ export function getFormattedWaveLengthUnits(plotOrStr, anyPartOfStr=false) {
 export const getPtWavelength= (plot, pt, cubeIdx) =>
           hasWLInfo(plot) && getWavelength(CCUtil.getImageCoords(plot,pt),cubeIdx,plot.wlData);
 
-/**
- *
- * @param {WebPlot} plot
- * @param {Point} pt
- * @param {number} cubeIdx
- * @return {number}
- */
-//export const getPtVrad= (plot, pt, cubeIdx) =>
-//          hasVRADInfo(plot) && getVrad(CCUtil.getImageCoords(plot,pt),cubeIdx,plot.vradData);
 
 //=============================================================
 //=============================================================

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -936,9 +936,6 @@ export const hasPixelLevelWLInfo= (plot) => hasWLInfo(plot) && plot.wlData.algor
  */
 export function getWaveLengthUnits(plot) {
     if (!plot || !hasWLInfo(plot)) return '';
-    /*if (plot.header.CTYPE3==='VRAD') {
-        return plot.wlData.units= 'km/s';
-    }*/
     return plot.wlData?.units ?? '';
 }
 

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -12,6 +12,7 @@ import {CysConverter} from './CsysConverter.js';
 import {makeImagePt} from './Point';
 import {makeDirectFileAccessData, parseSpacialHeaderInfo} from './projection/ProjectionHeaderParser.js';
 import {parseWavelengthHeaderInfo} from './projection/WavelengthHeaderParser.js';
+//import {parseAllSpectralHeaderInfo} from './projection/SpectraHeaderParser';
 import {TAB} from './projection/Wavelength';
 import {memorizeLastCall} from '../util/WebUtil';
 import {makePlotStateShimForHiPS} from './PlotState';
@@ -79,6 +80,8 @@ export const getHiPsTitleFromProperties= (hipsProperties) => hipsProperties.obs_
  * @prop {Dimension} screenSize - width/height in screen pixels
  * @prop {Projection} projection - projection routines for this projections
  * @prop {Object} wlData - data object to wave length conversions, if defined then this conversion is available
+ * @prop {Object} vradData - data object to vrad conversions, if defined then this conversion is available
+ * @prop {Object} spectralData - data object to spectral wcs conversions, if defined then this conversion is available
  * @prop {Object} affTrans - the affine transform
  * @prop {Array.<RawData>} rawData
  * @prop {{width:number, height:number}} viewDim  size of viewable area  (div size: offsetWidth & offsetHeight)
@@ -284,6 +287,17 @@ function processAllWavelengthAltWcs(header,wlTable) {
         return obj;
     }, {});
 }
+
+/*function processAllSpectralAltWcs(header,spectralTable) {
+    const availableAry= getAtlProjectionIDs(header);
+    if (isEmpty(availableAry)) return {};
+
+    return availableAry.reduce( (obj, altChar) => {
+        const spectralData= parseAllSpeHeaderInfo(header, altChar, undefined, spectralTable);
+        if (spectralData) obj[altChar]= spectralData;
+        return obj;
+    }, {});
+}*/
 
 
 /**

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -12,7 +12,6 @@ import {CysConverter} from './CsysConverter.js';
 import {makeImagePt} from './Point';
 import {makeDirectFileAccessData, parseSpacialHeaderInfo} from './projection/ProjectionHeaderParser.js';
 import {parseWavelengthHeaderInfo} from './projection/WavelengthHeaderParser.js';
-//import {parseAllSpectralHeaderInfo} from './projection/SpectraHeaderParser';
 import {TAB} from './projection/Wavelength';
 import {memorizeLastCall} from '../util/WebUtil';
 import {makePlotStateShimForHiPS} from './PlotState';
@@ -287,17 +286,6 @@ function processAllWavelengthAltWcs(header,wlTable) {
         return obj;
     }, {});
 }
-
-/*function processAllSpectralAltWcs(header,spectralTable) {
-    const availableAry= getAtlProjectionIDs(header);
-    if (isEmpty(availableAry)) return {};
-
-    return availableAry.reduce( (obj, altChar) => {
-        const spectralData= parseAllSpeHeaderInfo(header, altChar, undefined, spectralTable);
-        if (spectralData) obj[altChar]= spectralData;
-        return obj;
-    }, {});
-}*/
 
 
 /**

--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -17,8 +17,9 @@ export const V2W = 'V2W';
 export const TAB = 'TAB';
 
 
-export const WAVE= 'WAVE';
-export const AWAV= 'AWAV';
+export const WAVE = 'WAVE';
+export const AWAV = 'AWAV';
+export const VRAD = 'VRAD';
 
 
 /**
@@ -65,16 +66,25 @@ const wlTypes= {
     [TAB] : {
         getWaveLength : getWaveLengthTable,
         implemented : true,
-    }
+    },
 };
+
+/*const vradTypes= {
+    [PLANE] : {
+        getVrad : getVradPlane,
+        implemented : true,
+    },
+};*/
 
 
 export function getWavelength(pt, cubeIdx, wlData) {
     const {algorithm, wlType}= wlData;
     if (wlTypes[algorithm] && wlTypes[algorithm].implemented && wlTypes[algorithm].getWaveLength) {
         const wl=  wlTypes[algorithm].getWaveLength(pt,cubeIdx,wlData);
-        if (wlType===WAVE) return wl;
+        //const vrad= wlTypes[algorithm].getVrad(pt,cubeIdx,wlData);
+        if (wlType===WAVE || wlType===VRAD) return wl;
         if (wlType===AWAV) return convertAirToVacuum(wl);
+        //if (wlType===VRAD) return getWavelengthPlane(wl);
         return wl;
     }
 }
@@ -82,7 +92,7 @@ export function getWavelength(pt, cubeIdx, wlData) {
 function getWaveLengthPlane(ipt, cubeIdx, wlData) {
     const {crpix, crval, cdelt} = wlData;
     //pixel count starts from 1 to naxisn
-    const wl = crval + ( cubeIdx + 1  - crpix ) * cdelt;
+    const wl = crval + ( cubeIdx + 1  - Math.round(crpix) ) * cdelt;
     return wl;
 }
 
@@ -90,6 +100,28 @@ export function isWLAlgorithmImplemented(wlData) {
     const {algorithm}= wlData;
     return wlTypes[algorithm].implemented;
 }
+
+
+/*export function getVrad(ipt, cubeIdx, wl) {
+    const {algorithm, wlType}= vradData;
+    if (wlTypes[algorithm] && wlTypes[algorithm].implemented && wlTypes[algorithm].getVrad) {
+        const vrad=  wlTypes[algorithm].getVrad(ipt,cubeIdx,vradData);
+        if (wlType===VRAD) return vrad;
+        return vrad;
+    }
+}*/
+
+/*function getVradPlane(ipt, cubeIdx, vradData) {
+    const {crpix, crval, cdelt} = vradData;
+    //pixel count starts from 1 to naxisn
+    const vrad = crval + ( cubeIdx + 1  - Math.round(crpix) ) * cdelt;
+    return vrad;
+}
+
+export function isVRADAlgorithmImplemented(vradData) {
+    const {algorithm}= vradData;
+    return vradTypes[algorithm].implemented;
+}*/
 
 /**
  *  calculate the air wavelength and then convert to vacuum wavelength
@@ -127,6 +159,19 @@ function getWaveLengthLinear(ipt, cubeIdx, wlData) {
     const {N,  r_j, pc_3j, s_3,  lambda_r}= wlData;
     return lambda_r + getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
 }
+
+/**
+ * Note that CTYPE3R= 'VRAD' indicates that the conversion between frequency and radio velocity is linear.
+ * @param ipt
+ * @param cubeIdx
+ * @param vradData
+ */
+/*function getVradLinear(ipt, cubeIdx, vradData) {
+    const {crpix, crval, cdelt} = vradData;
+    //pixel count starts from 1 to naxisn
+    const vrad = crval + ( cubeIdx + 1  - crpix ) * cdelt;
+    return vrad;
+}*/
 
 /**
  *

--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -69,22 +69,13 @@ const wlTypes= {
     },
 };
 
-/*const vradTypes= {
-    [PLANE] : {
-        getVrad : getVradPlane,
-        implemented : true,
-    },
-};*/
-
 
 export function getWavelength(pt, cubeIdx, wlData) {
     const {algorithm, wlType}= wlData;
     if (wlTypes[algorithm] && wlTypes[algorithm].implemented && wlTypes[algorithm].getWaveLength) {
         const wl=  wlTypes[algorithm].getWaveLength(pt,cubeIdx,wlData);
-        //const vrad= wlTypes[algorithm].getVrad(pt,cubeIdx,wlData);
         if (wlType===WAVE || wlType===VRAD) return wl;
         if (wlType===AWAV) return convertAirToVacuum(wl);
-        //if (wlType===VRAD) return getWavelengthPlane(wl);
         return wl;
     }
 }
@@ -100,28 +91,6 @@ export function isWLAlgorithmImplemented(wlData) {
     const {algorithm}= wlData;
     return wlTypes[algorithm].implemented;
 }
-
-
-/*export function getVrad(ipt, cubeIdx, wl) {
-    const {algorithm, wlType}= vradData;
-    if (wlTypes[algorithm] && wlTypes[algorithm].implemented && wlTypes[algorithm].getVrad) {
-        const vrad=  wlTypes[algorithm].getVrad(ipt,cubeIdx,vradData);
-        if (wlType===VRAD) return vrad;
-        return vrad;
-    }
-}*/
-
-/*function getVradPlane(ipt, cubeIdx, vradData) {
-    const {crpix, crval, cdelt} = vradData;
-    //pixel count starts from 1 to naxisn
-    const vrad = crval + ( cubeIdx + 1  - Math.round(crpix) ) * cdelt;
-    return vrad;
-}
-
-export function isVRADAlgorithmImplemented(vradData) {
-    const {algorithm}= vradData;
-    return vradTypes[algorithm].implemented;
-}*/
 
 /**
  *  calculate the air wavelength and then convert to vacuum wavelength

--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -160,18 +160,7 @@ function getWaveLengthLinear(ipt, cubeIdx, wlData) {
     return lambda_r + getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
 }
 
-/**
- * Note that CTYPE3R= 'VRAD' indicates that the conversion between frequency and radio velocity is linear.
- * @param ipt
- * @param cubeIdx
- * @param vradData
- */
-/*function getVradLinear(ipt, cubeIdx, vradData) {
-    const {crpix, crval, cdelt} = vradData;
-    //pixel count starts from 1 to naxisn
-    const vrad = crval + ( cubeIdx + 1  - crpix ) * cdelt;
-    return vrad;
-}*/
+// Add other VRAD conversion and algorithem here
 
 /**
  *

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -320,25 +320,20 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
 
 /**
  * NOTE:
- *   pc_3j, means the the wavelength axis is 3.  In fact, the wavelength can be in any axis.
- *   Which means which axis has the wavelength
+ *   pc_3j, means the the wavelength axis is 3.
+ *
  * @param parse
  * @param altWcs
  * @param which
  * @param pc_3j_key
- * @param wlTable
+ * @param vradTable
  * @returns {*}
  */
-function calculateVradParams(parse, altWcs, which, pc_3j_key,wlTable) {
+function calculateVradParams(parse, altWcs, which, pc_3j_key,vradTable) {
 
     /*
-    * Base on the reference: A&A 395, 1061-1075 (2002) DOI: 10.1051/0004-6361:20021326
-    * Representations of world coordinates in FITS E. W. Greisen.  The default values
-    * defined below:
-    * CDELT i	1.0
-    * CTYPE i	' ' (i.e. a linear undefined axis)
-    * CUNIT i	' ' (i.e. undefined)
-    * NOTE: i is the which variable here.
+    * Only consider VRAD plane case for now
+    * the pc_3j_key, vradTalble not used in Plane case
     */
     const ctype= parse.getValue(`CTYPE${which}${altWcs}`, ' ');
     const crpix= parse.getDoubleValue(`CRPIX${which}${altWcs}`, 0.0);
@@ -377,17 +372,6 @@ function calculateVradParams(parse, altWcs, which, pc_3j_key,wlTable) {
     }
 
     //If it is a cube plane FITS, plot and display the VRAD at each plane
-    /*if (canDoPlaneCalc && nAxis===3  &&  isVR) {
-        /!* There are two cases for wavelength planes:
-        *  The FITs has vrad planes, and the algorithm is LINEAR
-        *
-        *!/
-        const algorithmForLinear = isVR? algorithm: PLANE;
-        //const vradType = whichType;
-        const units = 'km/s';
-        const ret = makeSimplePlaneBased(crpix, crval, cdelt,nAxis, algorithmForLinear, vradType, units, 'use PLANE since is cube and parameters missing');
-            return ret;
-    }*/
 
 
     //Plot and display the wavelength as one of the mouse readout only if the FITs header
@@ -403,7 +387,8 @@ function calculateVradParams(parse, altWcs, which, pc_3j_key,wlTable) {
 
     /*Adding other VRAD algorithm and conversions here
     *
-    * */
+    *
+    */
 }
 
 function makeSimplePlaneBased(crpix,crval, cdelt, nAxis,algorithm, wlType, units, reason) {
@@ -445,10 +430,10 @@ function getAlgorithmAndType(ctype3){
     }
     else if (ctype3.startsWith('LAMBDA')) {
         wlType= WAVE;
-        algorithm=LINEAR;
+        algorithm= LINEAR;
     } else if (ctype3.startsWith('VRAD')) {
-        wlType = VRAD;
-        algorithm=PLANE;
+        wlType= VRAD;
+        algorithm= PLANE;
     }
     return {algorithm,wlType};
 }

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -446,6 +446,9 @@ function getAlgorithmAndType(ctype3){
     else if (ctype3.startsWith('LAMBDA')) {
         wlType= WAVE;
         algorithm=LINEAR;
+    } else if (ctype3.startsWith('VRAD')) {
+        wlType = VRAD;
+        algorithm=PLANE;
     }
     return {algorithm,wlType};
 }

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -164,15 +164,6 @@ function isVrad(ctype){
     if (!ctype.trim()) return false;
 
     const sArray= ctype.split('-');
-
-    //The header has the axis dependency information, ie. pc_31 (naxis1) or pc_32 (naxis2) are defined.
-    //If no such information, and it is not a "TAB", thus there is no dependency.  The wavelength will not
-    // be displayed in the mouse readout.
-
-    /*if ( (sArray[0]==='VRAD' )){
-            return true;
-        }
-        return false;*/
     return (sArray[0]==='VRAD');
 }
 

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -3,19 +3,27 @@
  */
 
 import {makeDoubleHeaderParse} from '../FitsHeaderUtil.js';
-import {AWAV, F2W, LINEAR, LOG, PLANE, TAB, V2W, WAVE} from './Wavelength.js';
+import {AWAV, F2W, LINEAR, LOG, PLANE, TAB, V2W, WAVE,VRAD} from './Wavelength.js';
 
 export function parseWavelengthHeaderInfo(header, altWcs='', zeroHeader, wlTable) {
     const parse= makeDoubleHeaderParse(header, zeroHeader, altWcs);
     const which= altWcs?'1':getWCSAXES(parse);
+    const whatType= parse.getValue(`CTYPE${which}${altWcs}`, ' ');
     const mijMatrixKeyRoot = getPC_ijKey(parse,which);
     if (!mijMatrixKeyRoot) return; //When both PC i_j and CD i_j are present, we don't show the wavelength
-    return calculateWavelengthParams(parse,altWcs,which,mijMatrixKeyRoot, wlTable);
+    if (whatType===WAVE) {
+        return calculateWavelengthParams(parse, altWcs, which, mijMatrixKeyRoot, wlTable);
+    } else if (whatType===VRAD) {
+        return calculateVradParams(parse, altWcs, which, mijMatrixKeyRoot, wlTable);
+    }
+    //return calculateWavelengthParams(parse,altWcs,which,mijMatrixKeyRoot,wlTable);
 }
 
 
 const isWaveParseDependent = (algorithm) => algorithm===LINEAR || algorithm===LOG  || algorithm===F2W  ||
                                             algorithm===V2W  || algorithm===TAB;
+
+const isVradParseDependent = (algorithm) => algorithm===LINEAR;
 
 const allGoodValues= (...numbers)  => numbers.every((n) => !isNaN(n));
 
@@ -151,6 +159,22 @@ function isWaveLength(ctype, pc_3j){
     return false;
 
 }
+
+function isVrad(ctype){
+    if (ctype.trim()==='') return false;
+
+    const sArray= ctype.split('-');
+
+    //The header has the axis dependency information, ie. pc_31 (naxis1) or pc_32 (naxis2) are defined.
+    //If no such information, and it is not a "TAB", thus there is no dependency.  The wavelength will not
+    // be displayed in the mouse readout.
+
+    if ( (sArray[0]==='VRAD' )){
+        return true;
+    }
+    return false;
+}
+
 /**
  * NOTE:
  *   pc_3j, means the the wavelength axis is 3.  In fact, the wavelength can be in any axis.
@@ -220,6 +244,7 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
         *     position.  For example, the algorithm is TAB.
         */
         const algorithmForPlane = isWL? algorithm: PLANE;
+        //const wlType = whichType;
         const ret = makeSimplePlaneBased(crpix, crval, cdelt,nAxis, algorithmForPlane, wlType, units, 'use PLANE since is cube and parameters missing');
         if (algorithm==='TAB') {
             const part1 = {
@@ -237,6 +262,20 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
         }
 
     }
+
+    //If it is a cube plane FITS, plot and display the VRAD at each plane
+    /*if (canDoPlaneCalc && nAxis===3  &&  isVR) {
+        /!* There are two cases for wavelength planes:
+        *  The FITs has vrad planes, and the algorithm is LINEAR
+        *
+        *!/
+        const algorithmForLinear = isVR? algorithm: PLANE;
+        //const vradType = whichType;
+        const units = 'km/s';
+        const ret = makeSimplePlaneBased(crpix, crval, cdelt,nAxis, algorithmForLinear, vradType, units, 'use PLANE since is cube and parameters missing');
+            return ret;
+    }*/
+
 
     //Plot and display the wavelength as one of the mouse readout only if the FITs header
     //contains the required parameters and the wavelength is depending on the image axes.
@@ -279,6 +318,94 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key,wlTable) {
     };
 }
 
+/**
+ * NOTE:
+ *   pc_3j, means the the wavelength axis is 3.  In fact, the wavelength can be in any axis.
+ *   Which means which axis has the wavelength
+ * @param parse
+ * @param altWcs
+ * @param which
+ * @param pc_3j_key
+ * @param wlTable
+ * @returns {*}
+ */
+function calculateVradParams(parse, altWcs, which, pc_3j_key,wlTable) {
+
+    /*
+    * Base on the reference: A&A 395, 1061-1075 (2002) DOI: 10.1051/0004-6361:20021326
+    * Representations of world coordinates in FITS E. W. Greisen.  The default values
+    * defined below:
+    * CDELT i	1.0
+    * CTYPE i	' ' (i.e. a linear undefined axis)
+    * CUNIT i	' ' (i.e. undefined)
+    * NOTE: i is the which variable here.
+    */
+    const ctype= parse.getValue(`CTYPE${which}${altWcs}`, ' ');
+    const crpix= parse.getDoubleValue(`CRPIX${which}${altWcs}`, 0.0);
+    const crval= parse.getDoubleValue(`CRVAL${which}${altWcs}`, 0.0);
+    const cdelt= parse.getDoubleValue(`CDELT${which}${altWcs}`, 1.0);
+    const units= parse.getValue(`CUNIT${which}${altWcs}`, 'm/s');
+    const nAxis= parse.getIntValue('NAXIS'+altWcs);
+    const N= parse.getIntOneOfValue(['WCSAXES', 'WCSAXIS', 'NAXIS'], -1);
+
+    const {algorithm, wlType} = getAlgorithmAndType(ctype,N);
+
+
+    const canDoPlaneCalc= allGoodValues(crpix,crval,cdelt && nAxis===3 ) ;
+
+    //We only support the standard format in the FITs header.  The standard means the CTYPEka='WAVE-ccc" where
+    //ccc can be 'F2W', 'V2W', 'LOG', 'TAB' or empty that means linear. If the header does not have this kind
+    // CTYPEka defined, we check if it is a spectra cube.  If it is a spectra cube,and it is independent of the
+    // images we display the wavelength at each plane.  If it is a spectra cube and it is wavelength is depending on
+    // the image coordinates, we display the wavelength at the mouse readout at each plane.
+    // This is to check if the ctype is WAVE and the wavelength depends on the two-dimension image coordinates.
+
+    const isVR = isVrad(ctype);
+
+    //If it is a cube plane FITS, plot and display the Vrad at each plane
+    if (canDoPlaneCalc && nAxis===3) {
+        /* There are two cases for wavelength planes:
+        *  1. The FITs has wavelength planes, and each plane has the same wavelength, ie. the third axis
+        *     is wavelength.  Then the algorithm is PLANE
+        *  2. The FITs has wavelength planes,and the wavelength on each plane is changing with the image point
+        *     position.  For example, the algorithm is TAB.
+        */
+        const algorithmForPlane = isVrad? algorithm: PLANE;
+        const ret = makeSimplePlaneBased(crpix, crval, cdelt,nAxis, algorithmForPlane, wlType, units, 'use PLANE since is cube and parameters missing');
+
+        return ret;
+    }
+
+    //If it is a cube plane FITS, plot and display the VRAD at each plane
+    /*if (canDoPlaneCalc && nAxis===3  &&  isVR) {
+        /!* There are two cases for wavelength planes:
+        *  The FITs has vrad planes, and the algorithm is LINEAR
+        *
+        *!/
+        const algorithmForLinear = isVR? algorithm: PLANE;
+        //const vradType = whichType;
+        const units = 'km/s';
+        const ret = makeSimplePlaneBased(crpix, crval, cdelt,nAxis, algorithmForLinear, vradType, units, 'use PLANE since is cube and parameters missing');
+            return ret;
+    }*/
+
+
+    //Plot and display the wavelength as one of the mouse readout only if the FITs header
+    //contains the required parameters and the wavelength is depending on the image axes.
+    /* We don't show the wavelength in the mouse readout in following three situations:
+     *  1. Algorithm is not defined
+     *  2. wlType is not defined or the type is not supported
+     *  3. The FITs file is not wavelength type (may be plane)
+     *
+     */
+    if (!algorithm || !wlType  || !isVR) return;
+
+
+    /*Adding other VRAD algorithm and conversions here
+    *
+    * */
+}
+
 function makeSimplePlaneBased(crpix,crval, cdelt, nAxis,algorithm, wlType, units, reason) {
     if (allGoodValues(crpix,crval,cdelt) && nAxis===3 ) {
         //return {algorithm: PLANE, wlType: wlType || WAVE, crpix, crval, cdelt, units, reason};
@@ -300,6 +427,9 @@ function makeSimplePlaneBased(crpix,crval, cdelt, nAxis,algorithm, wlType, units
  * @return {{algorithm:string,wlType:string}}
  */
 function getAlgorithmAndType(ctype3){
+    //let wlType, vradType, algorithm;
+    // It is temporary to include Vrad under wlType
+    // need to do generic spectral header parser
     let wlType, algorithm;
     if (!ctype3.trim()) return {algorithm:undefined,wlType:undefined};
     ctype3= ctype3.toUpperCase();

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -8,7 +8,8 @@ import {isEmpty, isString} from 'lodash';
 import {
     primePlot,getPlotViewById, isMultiHDUFits, getCubePlaneCnt, getHDU, getActivePlotView,
     convertHDUIdxToImageIdx, convertImageIdxToHDU, getFormattedWaveLengthUnits,
-    getHDUCount, getHDUIndex, getPtWavelength, hasPlaneOnlyWLInfo, isImageCube } from '../PlotViewUtil.js';
+    getHDUCount, getHDUIndex, getPtWavelength, hasPlaneOnlyWLInfo, hasPlaneOnlyVRADInfo, isImageCube, getPtVrad
+} from '../PlotViewUtil.js';
 import {getHeader} from '../FitsHeaderUtil.js';
 import {isHiPS, isImage} from '../WebPlot.js';
 import {HdrConst} from '../FitsHeaderUtil.js';
@@ -264,11 +265,11 @@ export const VisCtxToolbarView= memo((props) => {
             <ToolbarButton icon={SELECTED_ZOOM} tip='Zoom to fit selected area'
                            horizontal={true}
                            onClick={() => zoomIntoSelection(pv)}/>}
-                           
+
             { showSelectionTools &&
             <ToolbarButton icon={SELECTED_RECENTER} tip='Recenter image to selected area'
                            horizontal={true} onClick={() => recenterToSelection(pv)}/>}
-                           
+
             {showSelectionTools && image &&
             <ToolbarButton icon={STATISTICS} tip='Show statistics for the selected area'
                            horizontal={true} onClick={() => stats(pv)}/>}
@@ -332,6 +333,7 @@ export function MultiImageControllerView({plotView:pv}) {
     let cIdx;
     let length;
     let wlStr= '';
+    let vradStr= '';
     let startStr;
     const  cube= isImageCube(plot) || !image;
     const multiHdu= isMultiHDUFits(pv);

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -50,7 +50,6 @@ import SELECTED_ZOOM from 'html/images/icons-2014/ZoomFitToSelectedSpace.png';
 import SELECTED_RECENTER from 'html/images/icons-2014/RecenterImage-selection.png';
 import {pvEqualExScroll} from '../PlotViewUtil';
 import shallowequal from 'shallowequal';
-//import {getVrad} from 'firefly/visualize/projection/Wavelength';
 
 
 
@@ -334,7 +333,7 @@ export function MultiImageControllerView({plotView:pv}) {
     let cIdx;
     let length;
     let wlStr= '';
-    let vradStr= '';
+    //let vradStr= '';
     let startStr;
     const  cube= isImageCube(plot) || !image;
     const multiHdu= isMultiHDUFits(pv);
@@ -361,11 +360,7 @@ export function MultiImageControllerView({plotView:pv}) {
                 const wl= doFormat(getPtWavelength(plot,null, plot.cubeIdx),4);
                 const unitStr= getFormattedWaveLengthUnits(plot);
                 wlStr= `${wl} ${unitStr}`;
-            } /*else if (hasPlaneOnlyVRADInfo(plot)) {
-                const vrad =doFormat(getPtVrad(plot, null, plot.cubeIdx), 2);
-                const unitStr= 'km/s';
-                vradStr=`${vrad} ${unitStr}`;
-            }*/
+            }
         }
         tooltip+= `, Image Count: ${cIdx+1} / ${length}`;
     }

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -50,6 +50,7 @@ import SELECTED_ZOOM from 'html/images/icons-2014/ZoomFitToSelectedSpace.png';
 import SELECTED_RECENTER from 'html/images/icons-2014/RecenterImage-selection.png';
 import {pvEqualExScroll} from '../PlotViewUtil';
 import shallowequal from 'shallowequal';
+//import {getVrad} from 'firefly/visualize/projection/Wavelength';
 
 
 
@@ -360,7 +361,11 @@ export function MultiImageControllerView({plotView:pv}) {
                 const wl= doFormat(getPtWavelength(plot,null, plot.cubeIdx),4);
                 const unitStr= getFormattedWaveLengthUnits(plot);
                 wlStr= `${wl} ${unitStr}`;
-            }
+            } /*else if (hasPlaneOnlyVRADInfo(plot)) {
+                const vrad =doFormat(getPtVrad(plot, null, plot.cubeIdx), 2);
+                const unitStr= 'km/s';
+                vradStr=`${vrad} ${unitStr}`;
+            }*/
         }
         tooltip+= `, Image Count: ${cIdx+1} / ${length}`;
     }


### PR DESCRIPTION
As requested in [IRSA-3871](https://jira.ipac.caltech.edu/browse/IRSA-3871), this PR will only trying to add a case to display the VRAD value and units (m/s is the default) for each plane in the FITs cube. The handling of the generic spectral coordinates translation will be added later. 
To test, use k8s URL: https://fireflydev.ipac.caltech.edu/irsa-3871/firefly/ 

click  "Select Image Souces" -> "Use my image" and upload the test file [IRSA-3871](https://jira.ipac.caltech.edu/browse/IRSA-3871). Also test the wavelength case using [FIFI-LS level 4 data](https://irsa.ipac.caltech.edu/data/SOFIA/FIFI-LS/L4/p3991/data/g12/F0314_FI_IFS_04004934_RED_WXY_100872-100887.fits) 
