### PR TITLE
FIREFLY-643: Resizing a column to zero makes it disappear forever

### DIFF
--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -102,7 +102,7 @@ export class TableConnector {
         TblCntlr.dispatchTableUiUpdate(changes);
     }
 
-    onOptionUpdate({pageSize, columns, showUnits, showTypes, showFilters, sortInfo, filterInfo, sqlFilter}) {
+    onOptionUpdate({pageSize, columns, showUnits, showTypes, showFilters, sortInfo, filterInfo, sqlFilter, resetColWidth}) {
         if (pageSize) {
             this.onPageSizeChange(pageSize);
         }
@@ -133,6 +133,8 @@ export class TableConnector {
             }
         }
 
+        if (resetColWidth) changes.columnWidths = undefined;
+
         if (!isEmpty(changes)) {
             changes.tbl_ui_id = this.tbl_ui_id;
             TblCntlr.dispatchTableUiUpdate(changes);
@@ -144,7 +146,7 @@ export class TableConnector {
         var {showUnits, showTypes, showFilters, pageSize} = this.orig || {};
         
         pageSize = get(ctable, 'request.pageSize') !== pageSize ? pageSize : undefined;
-        this.onOptionUpdate({pageSize,
+        this.onOptionUpdate({pageSize, resetColWidth: true,
                         columns: cloneDeep(get(ctable, 'tableData.columns', [])),
                         showUnits, showTypes, showFilters});
 

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -362,6 +362,7 @@ function makeColumnTag(props, col, idx) {
             cell={cell}
             fixed={fixed}
             width={columnWidths[idx]}
+            minWidth={5}
             isResizable={resizable}
             isReorderable={true}
             allowCellsRecycling={true}

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -291,7 +291,7 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange}) {
                     </div>
                     <InputAreaFieldConnected
                         ref={sqlEl}
-                        style={{width: 'calc(100% - 9px)', resize: 'none', ...errStyle}} rows={7}
+                        style={{width: 'calc(100% - 9px)', resize: 'none', backgroundColor: 'white', ...errStyle}} rows={7}
                         validator={FilterInfo.validator.bind(null,columns)}
                         groupKey={groupKey}
                         fieldKey={sqlKey}

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -244,7 +244,7 @@ export const ColumnOptions = React.memo(({tbl_id, tbl_ui_id, ctm_tbl_id, onChang
                 showOptionButton = {false}
                 showFilters={true}
                 selectable = {true}
-                rowHeight = {24}
+                rowHeight = {27}
                 highlightedRowHandler = {()=>undefined}
             />
         </div>

--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -42,7 +42,7 @@ export function ColumnConstraintsPanel({tableModel, style}) {
                                 selectable={true}
                                 showOptionButton={true}
                                 border= {false}
-                                rowHeight={23}
+                                rowHeight={24}
                                 renderers={{
                                     //name: { cellRenderer: createLinkCell({hrefColIdx: totalCol})},
                                     constraints: { cellRenderer: newInputCell}

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -409,6 +409,7 @@ class ConstraintPanel extends PureComponent {
                                     currentPage={1}
                                     key={tableModel.tbl_id}
                                     error={tableModel.error}
+                                    rowHeight={24}
                                     callbacks={{
                                         onRowSelect: updateRowSelected(tableModel.tbl_id, onTableChanged),
                                         onSelectAll: updateRowSelected(tableModel.tbl_id, onTableChanged)


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-643

Set the minimum width of the table's column to 5px.  This prevents it from resizing to zero.
Also,
- Reset button in the Table option panel will also reset all columns back to theirs default width
- Adjust row height for several tables with input fields, i.e.  TAP constraint table, IRSA catalog constraint table, and Table Option panel
- Only show More Actions (...) icon when the column has a default text based renderer

Test URL: https://fireflydev.ipac.caltech.edu/firefly-643-col-resize-min/firefly/