### PR TITLE
FIREFLY-722: helpid to point to location instead

### DIFF
--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -238,7 +238,7 @@ export const TableSearchMethods = FunctionalTableSearchMethods;
 function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCoreEnabled, useConstraintReducer, useFieldGroupReducer}) {
     const panelTitle = !obsCoreEnabled ? Spatial : 'Location';
     const panelValue = Spatial;
-    const panelPrefix = getPanelPrefix(Spatial);
+    const panelPrefix = getPanelPrefix(panelTitle);
     const {POSITION:worldPt, radiusInArcSec}= initArgs;
     const [spatialMethod, setSpatialMethod] = useState(TapSpatialSearchMethod.Cone.value);
     const [spatialRegionOperation, setSpatialRegionOperation] = useState('contains_shape');
@@ -342,7 +342,7 @@ function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCo
                             {label: 'Observation boundary contains shape', value: 'contains_shape'},
                             {label: 'Observation boundary is contained by shape', value: 'contained_by_shape'},
                             {label: 'Observation boundary intersects shape', value: 'intersects'},
-                            {label: 'central point (s_ra, s_dec) is contained by shape', value: 'center_contained'},
+                            {label: 'Central point (s_ra, s_dec) is contained by shape', value: 'center_contained'},
                         ]}
                     initialState={{
                         value: 'contains_shape'


### PR DESCRIPTION
The change here is to fix how we get the panel prefix id to be used as HelpId when ObsCore is enabled.

It should be picking up the 'location' prefix instead of always 'spatial'.

Please, make sure that the change in 'ObsCore''s case doesn't affect the fieldgroup or other UI bindings and kept the difference between Spatial and Location panel.

This PR include minor label change - FIREFLY-773