### PR TITLE
Fix ADQL query generation

### DIFF
--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -93,10 +93,12 @@ export function getTableConstraints(tbl_id) {
 
     // collect the names of all selected columns
     let allSelected = true;
+    let selcolsArray = [];
     let selcolsFragment = tbl_data.reduce((prev, d, idx) => {
             if ((sel_info.selectAll && (!sel_info.exceptions.has(idx))) ||
                 (!sel_info.selectAll && (sel_info.exceptions.has(idx)))) {
                 prev += d[0] + ',';
+                selcolsArray.push(d[0]);
             } else {
                 allSelected = false;
             }
@@ -107,7 +109,7 @@ export function getTableConstraints(tbl_id) {
         selcolsFragment = '';
     }
 
-    return {whereFragment, selcolsFragment, errors, filters};
+    return {whereFragment, selcolsFragment, errors, filters, selcolsArray};
 }
 
 /**

--- a/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
+++ b/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
@@ -215,5 +215,5 @@ export function tableColumnsConstraints(columnsModel) {
     const colsToSelect = selcolsFragment.lastIndexOf(',') > 0 ?
         selcolsFragment.substring(0, selcolsFragment.lastIndexOf(',')) : selcolsFragment;
 
-    return {valid: true, where: whereFragment, selcols: (colsToSelect.length > 0) ? colsToSelect : ''};
+    return {valid: true, where: whereFragment, selcols: (colsToSelect.length > 0) ? colsToSelect : '', selcolsArray: tableconstraints.selcolsArray};
 }

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -266,6 +266,7 @@ export function BasicUI(props) {
                             value={tableName}
                             onSelect={(selectedTapTable) => {
                                 setTableName(selectedTapTable);
+                                dispatchValueChange({groupKey: gkey, fieldKey: 'tableName', value: selectedTapTable});
                             }}
                         />
                     </div>


### PR DESCRIPTION
Table name changes were being properly dispatched, so building queries was being done on stale table names. This fixes that.

This also adds some newline breaking to generated ADQL text when the list of column names is very long, while also breaking on FROM and WHERE keywords.

_To test:_ https://fireflydev.ipac.caltech.edu/brian-fix-table/firefly/