### PR TITLE
Firefly-779: improve data product view with ZTF

### DIFF
--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -389,7 +389,8 @@ export function changeActiveFileMenuItem(state,action) {
     const actIdx= fileMenu.menu.findIndex( (m) => m.menuKey===newActiveFileMenuKey);
     const fileMenuItem= fileMenu.menu[actIdx<0? fileMenu.initialDefaultIndex: actIdx];
 
-    const {activate,imageActivate,displayType,serDefParams, message,chartTableDefOption, analysisActivateFunc, originalTitle}= fileMenuItem;
+    const {activate,imageActivate,displayType,serDefParams, message,chartTableDefOption,
+        analysisActivateFunc, originalTitle, noProductsAvailable}= fileMenuItem;
 
     dpData.activeFileMenuKeys={...activeFileMenuKeys, [fileMenu.activeItemLookupKey]:fileMenuItem.menuKey};
 
@@ -404,7 +405,7 @@ export function changeActiveFileMenuItem(state,action) {
 
     const newFileMenu= {...fileMenu, activeFileMenuKey:newActiveFileMenuKey};
     const newDisplayProduct= { ...selectedMenuDataProduct, displayType, chartTableDefOption, activate, imageActivate, message,
-        fileMenu:newFileMenu, activeMenuKey:menuKey, serDefParams, analysisActivateFunc, originalTitle};
+        fileMenu:newFileMenu, activeMenuKey:menuKey, serDefParams, analysisActivateFunc, originalTitle, noProductsAvailable};
     const newMenu= menu && menu.map( (menuItem) => (menuItem.menuKey!==menuKey) ? menuItem : newDisplayProduct );
     dpData.dataProducts= {...newDisplayProduct, menu:newMenu};
     return insertOrReplace(state,dpData);

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -492,7 +492,9 @@ function findADataSourceColumn(table) {
 
 function findTableMetaEntry(table,ids) {
     const testIdAry= isArray(ids) ? ids : [ids];
-    return testIdAry.find( (key) => getMetaEntry(table,key));
+    const id= testIdAry.find( (key) => getMetaEntry(table,key));
+    if (!id) return;
+    return getMetaEntry(table,id);
 }
 
 

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -1,16 +1,23 @@
 
 import {union,get,isEmpty,difference} from 'lodash';
-import {dispatchReplaceViewerItems, getViewerItemIds, getMultiViewRoot, isImageViewerSingleLayout} from '../visualize/MultiViewCntlr.js';
+import {
+    dispatchReplaceViewerItems,
+    getViewerItemIds,
+    getMultiViewRoot,
+    isImageViewerSingleLayout,
+    getLayoutType, GRID
+} from '../visualize/MultiViewCntlr.js';
 import {dispatchPlotImage, dispatchDeletePlotView, visRoot, dispatchZoom,
     dispatchPlotGroup, dispatchChangeActivePlotView} from '../visualize/ImagePlotCntlr.js';
 import {isImageDataRequestedEqual} from '../visualize/WebPlotRequest.js';
-import {getPlotViewById, primePlot} from '../visualize/PlotViewUtil.js';
+import {getPlotViewAry, getPlotViewById, primePlot} from '../visualize/PlotViewUtil.js';
 import {UserZoomTypes} from '../visualize/ZoomUtil.js';
 import {allBandAry} from '../visualize/Band.js';
 import {getTblById} from '../tables/TableUtil.js';
 import {PlotAttribute} from '../visualize/PlotAttribute.js';
 import {dispatchTableHighlight} from '../tables/TablesCntlr.js';
 import {isImageExpanded} from '../visualize/ImagePlotCntlr';
+import {DPtypes} from 'firefly/metaConvert/DataProductsType.js';
 
 
 
@@ -172,10 +179,18 @@ function replotImageDataProducts(activePlotId, imageViewerId, tbl_id, reqAry, th
                 });
         }
     }
+    // const layoutType= getLayoutType(getMultiViewRoot(),imageViewerId);
 
-    return () => { // return the cleanup function
+    return ({nextDisplayType, nextMetaDataTableId}) => { // return the cleanup function
         if (isImageExpanded(visRoot().expandedMode)) return;
-        !isEmpty(wpRequestAry) && wpRequestAry.forEach( (wpR) => dispatchDeletePlotView({plotId:wpR.getPlotId()}) );
+        const layoutType= getLayoutType(getMultiViewRoot(),imageViewerId);
+        if (nextDisplayType===DPtypes.IMAGE && layoutType===GRID && tbl_id===nextMetaDataTableId) {
+            return;
+        }
+        // !isEmpty(wpRequestAry) && wpRequestAry.forEach( (wpR) => dispatchDeletePlotView({plotId:wpR.getPlotId()}) );
+        getPlotViewAry(visRoot())
+            .filter( (pv) => pv.plotGroupId===groupId)
+            .forEach( (pv) => dispatchDeletePlotView({plotId:pv.plotId}) );
         plottingThree && dispatchDeletePlotView({plotId:threeCPlotId});
     };
 }

--- a/src/firefly/js/metaConvert/ZtfRequestList.js
+++ b/src/firefly/js/metaConvert/ZtfRequestList.js
@@ -1,87 +1,32 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-
-
-import {get} from 'lodash';
-import {makeServerRequestBuilder} from './converterUtils.js';
 import {RangeValues,STRETCH_LINEAR,SIGMA} from '../visualize/RangeValues.js';
 import {getCellValue} from '../tables/TableUtil.js';
-import {parseWorldPt} from '../visualize/Point.js';
-import {convertAngle} from '../visualize/VisUtil.js';
+import {makeWebPlotRequestViaZtfIbe} from 'firefly/templates/lightcurve/ztf/IbeZTFPlotRequests.js';
 
-const colToUse= ['field', 'ccdid', 'qid', 'filtercode', 'filefracday', 'expid', 'in_ra', 'in_dec'];
 const rangeValues= RangeValues.makeRV({which:SIGMA, lowerValue:-2, upperValue:10, algorithm:STRETCH_LINEAR});
 
-/**
- * make a list of plot request for ztf. This function works with ConverterFactory.
- * @param table
- * @param row
- * @param includeSingle
- * @param includeStandard
- * @return {{}}
- */
-export function makeZtfPlotRequest(table, row, includeSingle, includeStandard) {
 
-    const overlap= get(table, 'request.intersect', '').toUpperCase()==='OVERLAPS';
-    var headerParams= overlap ? ['mission', 'ProductLevel'] :
-                                ['mission', 'ProductLevel', 'subsize'];
-
-    const svcBuilder= makeServerRequestBuilder(table,colToUse,headerParams,rangeValues,1);
-    const builder = (plotId, reqKey, title, rowNum, extraParams) => {
-        const req= svcBuilder(plotId, reqKey, title, rowNum, extraParams);
-        req.setPreferenceColorKey('ztf-color-pref');
-        const subsize = get(table, 'request.subsize');
-        if (subsize && subsize>0) {
-            const {UserTargetWorldPt, sizeUnit} = get(table, 'request', {});
-            if (UserTargetWorldPt && sizeUnit) {
-                const wp = parseWorldPt(UserTargetWorldPt);
-                // cutout is requested when in_ra, in_dec, and subsize are set (see WiseIbeDataSource)
-                req.setParam('center', `${wp.getLon()},${wp.getLat()}`); // degrees assumed if no unit
-                req.setParam('in_ra', `${wp.getLon()}`);
-                req.setParam('in_dec', `${wp.getLat()}`);
-                const newSize = convertAngle(sizeUnit, 'deg', subsize);
-                req.setParam('subsize', `${newSize}`);
-            }
-        }
-        /*
-        if (table.request.table_name.includes('3band')||table.request.table_name.includes('2band')) {
-            const tblBand = table.request.table_name.includes('3band') ? 3 : 2;
-
-            // add note to replace the query returned fail reason 'No Found'
-            if (Number(extraParams.band) > tblBand) {
-                req.setParam('userFailReason', {'not found': 'No image for band ' + extraParams.band});
-            }
-        }
-        */
-        return req;
-    };
-
-    const field= getCellValue(table,row,'field');
-    const ccdid= getCellValue(table,row,'ccdid');
-    const qid= getCellValue(table,row,'qid');
-    const filtercode = getCellValue(table,row,'filtercode');
-    const filefracday = getCellValue(table, row, 'filefracday');
-    const expid = getCellValue(table, row, 'expid');
-    const subsize = get(table, ['request', 'subsize']);
-    const in_ra = getCellValue(table,row, 'in_ra');
-    const in_dec = getCellValue(table,row, 'in_dec');
-
-    const retval= {};
-
-    if (includeSingle) {
-        retval.single= builder(`ztf-${filefracday}`,'ibe_file_retrieve', `${filefracday} ${filtercode}`, row, {band:`${filtercode}`, field, ccdid, qid, in_ra, in_dec});
-    }
-
-    if (includeStandard) {
-
-        retval.standard= [
-            builder('ztf','ibe_file_retrieve', `${filtercode}`, row, {band:`${filtercode}`, field, ccdid, qid, in_ra, in_dec}),
-        ];
-        retval.highlightPlotId= 0;
-    }
-    
-    return retval;
+function makeZtfRequest(plotId, table, row, size, subsize) {
+    const req= makeWebPlotRequestViaZtfIbe(table,row, size, subsize);
+    req.setPlotId(plotId);
+    req.setInitialRangeValues(rangeValues);
+    return req;
 }
 
 
+export function makeZtfPlotRequest(table, row, includeSingle, includeStandard) {
+    const pid = getCellValue(table, row, 'pid');
+    const nid = getCellValue(table, row, 'nid');
+    const expid = getCellValue(table, row, 'expid');
+    const plotId= `ztf-${pid}-${nid}-${expid}`;
+
+    const retval= {};
+    if (includeSingle) retval.single= makeZtfRequest(plotId, table,row, table.request.size, table.request.subsize);
+    if (includeStandard) {
+        retval.standard= [ makeZtfRequest(`group-1-${plotId}`,table,row, table.request.size, table.request.subsize) ];
+        retval.highlightPlotId= 0;
+    }
+    return retval;
+}

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -179,7 +179,7 @@ export const getActivePlotView= (visRoot) => visRoot?.plotViewAry.find( (pv) => 
 export function isThreeColor(plotOrPv) {
     if (!plotOrPv) return false;
     const plot= isPlotView(plotOrPv) ? primePlot(plotOrPv) : plotOrPv;
-    return Boolean(plot?.plotState.isThreeColor())
+    return Boolean(plot?.plotState.isThreeColor());
 }
 
 /**

--- a/src/firefly/js/visualize/saga/DataProductsWatcher.js
+++ b/src/firefly/js/visualize/saga/DataProductsWatcher.js
@@ -279,7 +279,7 @@ function removeAllProducts(activateParams, tbl_id) {
     if (activeTblId===tbl_id || !isMetaDataTable(activeTblId)) {
         const inViewerIds= getViewerItemIds(getMultiViewRoot(), imageViewerId);
         inViewerIds.forEach( (plotId) => dispatchDeletePlotView({plotId}));
-        dispatchUpdateDataProducts(dpId,dpdtMessage('No Data Products'));
+        dispatchUpdateDataProducts(dpId,dpdtMessage('No Data Products', undefined, {noProductsAvailable:true}));
     }
 }
 

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -30,6 +30,8 @@ const startWatcher= once((viewerId) => {
 
 const isCoverageFail= (covState,tbl_id) => covState.find( (e) => e.tbl_id===tbl_id)?.status===COVERAGE_FAIL;
 
+const getActiveOrFirstTblId= () => getActiveTableId() || getTblIdsByGroup()[0];
+
 
 export function CoverageViewer({viewerId='coverageImages',insideFlex=true, noCovMessage='No Coverage Available',
                                 workingMessage='Working...', noCovStyle={}}) {
@@ -37,8 +39,8 @@ export function CoverageViewer({viewerId='coverageImages',insideFlex=true, noCov
     startWatcher(viewerId);
     const [pv,tbl_id,isFetching,covState] = useStoreConnector(
         () => getActivePlotView(visRoot()),
-        () => getActiveTableId(),
-        () => getTblById(getActiveTableId())?.isFetching ?? false,
+        () => getActiveOrFirstTblId(),
+        () => getTblById(getActiveOrFirstTblId())?.isFetching ?? false,
         () => getComponentState(COVERAGE_WATCH_CID,[]));
 
 

--- a/src/firefly/js/visualize/ui/MetaDataMultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MetaDataMultiProductViewer.jsx
@@ -16,7 +16,7 @@ const startWatcher= once((dpId) => startDataProductsWatcher({ dataTypeViewerId:d
  * It should be use in the case where this is the only if it the the only one one the page.
  * If you are have more that on MultiProductViewer you should lay the out directly
  */
-export const MetaDataMultiProductViewer= memo(({ dpId='DataProductsType', metaDataTableId, autoStartWatcher=true, }) => {
+export const MetaDataMultiProductViewer= memo(({ dpId='DataProductsType', metaDataTableId, autoStartWatcher=true, noProductMessage}) => {
     autoStartWatcher && setTimeout(() => startWatcher(dpId),5);
-    return (<MultiProductViewer viewerId={dpId} metaDataTableId={metaDataTableId}/>);
+    return (<MultiProductViewer viewerId={dpId} metaDataTableId={metaDataTableId} noProductMessage={noProductMessage}/>);
 });

--- a/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
+++ b/src/firefly/js/visualize/ui/MultProductViewerContainer.jsx
@@ -13,14 +13,16 @@ const closeExpanded= () => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)
 /**
  * A wrapper component for MultiImageViewer where expended mode is supported.
  */
-export function MultiProductViewerContainer({ metaDataTableId, imageExpandedMode=false, closeable=true, insideFlex=false}) {
-    
+export function MultiProductViewerContainer({ metaDataTableId, imageExpandedMode=false,
+                                              closeable=true, insideFlex=false,
+                                              noProductMessage= 'No Data Products Available'}) {
+
     if (imageExpandedMode) {
         return  ( <ImageExpandedMode key='results-plots-expanded' insideFlex = {insideFlex}
                         closeFunc={closeable ? closeExpanded : null}/>
                 );
     } else {
-        return ( <MetaDataMultiProductViewer metaDataTableId={metaDataTableId} /> );
+        return ( <MetaDataMultiProductViewer metaDataTableId={metaDataTableId} noProductMessage={noProductMessage}/> );
     }
 }
 

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -55,7 +55,7 @@ MultiProductViewer.propTypes= {
 };
 
 
-const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId}) => {
+const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId, noProductMessage}) => {
     const {renderTreeId} = useContext(RenderTreeIdCtx);
     const [currentCTIChoice, setCurrentCTIChoice] = useState(undefined);
     const [lookupKey, setLookKey] = useState(undefined);
@@ -75,7 +75,7 @@ const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId})
         message,url, isWorkingState, menuKey,
         activeMenuLookupKey,singleDownload= false,
         chartTableDefOption=SHOW_CHART, imageActivate,
-        allowsInput=false, serDefParams= undefined}= dataProductsState;
+        allowsInput=false, serDefParams= undefined, noProductsAvailable=false}= dataProductsState;
 
     const searchParams= getSearchParams(serviceParamsAry,activeMenuLookupKey,menuKey);
 
@@ -111,7 +111,11 @@ const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId})
     useEffect(() => {
         if (allowsInput && !searchParams) return;
         const deActivate= activate?.(menu,searchParams);
-        return () => isFunction(deActivate) && deActivate();
+        return () => isFunction(deActivate) &&
+            deActivate( {
+                nextDisplayType:displayType,
+                nextMetaDataTableId:metaDataTableId
+            });
     }, [activate,searchParams,allowsInput]);
 
 
@@ -147,15 +151,15 @@ const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId})
             }
         case DPtypes.MESSAGE :
         case DPtypes.PROMISE :
-            if (dataProductsState.complexMessage) { //todo
-                                                  // make this work
+            if (dataProductsState.complexMessage) {
                 return (<ComplexMessage {...{menu, makeDropDown, message,
                     detailMsgAry:dataProductsState.detailMsgAry, badUrl:dataProductsState.badUrl,
                     resetMenuKey:dataProductsState.resetMenuKey, dpId, activeMenuLookupKey, doResetButton }} />);
 
             }
             else {
-                return (<ProductMessage {...{menu, singleDownload, makeDropDown, isWorkingState, message}} />);
+                const useMessage= noProductsAvailable && noProductMessage ? noProductMessage : message;
+                return (<ProductMessage {...{menu, singleDownload, makeDropDown, isWorkingState, message:useMessage}} />);
             }
         case DPtypes.DOWNLOAD_MENU_ITEM :
             return (<ProductMessage {...{menu, singleDownload, makeDropDown, isWorkingState:false, message}} />);
@@ -176,7 +180,13 @@ const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId})
         case DPtypes.PNG :
             return (<ProductPNG {...{makeDropDown, url}}/>);
     }
-    return (<div/>);
+
+    if (noProductMessage) {
+        return (<ProductMessage {...{menu, singleDownload, makeDropDown, isWorkingState, message:noProductMessage}} />);
+    }
+    else {
+        return (<div/>);
+    }
 });
 
 
@@ -320,7 +330,7 @@ const OtherOptionsDropDown= ({menu, dpId, activeMenuLookupKey, resetAllSearchPar
                                } }/> )
             )}
         </SingleColumnMenu> );
-}
+};
 
 OtherOptionsDropDown.propTypes= { dpId : string, menu : array, activeMenuLookupKey : string, };
 


### PR DESCRIPTION
Firefly-779: improve data product view with ZTF

- Update the ztf WebPlotRequest creation to work with ZTF
- Make a way to set an "no products" message from a property
- Fix bug finder the dataProductsId
- Make coverage viewer to the right thing when there are tables not an active one

