### PR TITLE
FIREFLY-723: adding a pre message above Title for SOFIA/Spitzer need

### DIFF
--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -121,6 +121,12 @@ const noticeCss = {
     textAlign: 'center'
 };
 
+const preTitleCss = {
+    padding: 3,
+    marginBottom: 10,
+    whiteSpace: 'wrap',
+};
+
 let dlTitleIdx = 0;
 const newBgKey = () => 'DownloadOptionPanel-' + Date.now();
 
@@ -185,7 +191,10 @@ export function DownloadOptionPanel (props) {
     };
 
     const dlTitle = get(dlParams, 'TitlePrefix', 'Download') + '-' + dlTitleIdx;
-
+    // IRSA-3944: SOFIA required a message to guide the user before downloading AOR such as:
+    // 'All levels associated with this AOR will be downloaded. To download individual data products, go to the relevant instrument tab.'
+    // PreTitleMessage can be added to the dlParams from the parent and passed here (FIREFLY-723)
+    const preTitleMessage = get(dlParams, 'PreTitleMessage', '')
     return (
         <div style = {Object.assign({margin: '4px', position: 'relative', minWidth:400, height:'auto'}, style)}>
             <FormPanel
@@ -197,6 +206,7 @@ export function DownloadOptionPanel (props) {
                 help_id  = {help_id}>
                 <FieldGroup groupKey={groupKey} keepState={true}>
                     {showWarnings && <div style={noticeCss}>This table contains proprietary data. Only data to which you have access will be downloaded.</div>}
+                    {preTitleMessage && <div style={preTitleCss}>{preTitleMessage}</div>}
                     <div className='FieldGroup__vertical--more'>
                         {showTitle && <TitleField {...{labelWidth, value:dlTitle }}/>}
 

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -52,6 +52,7 @@ const DOWNLOAD_DIALOG_ID = 'Download Options';
  *                     FilePrefix: 'WISE_Files',
  *                     BaseFileName: 'WISE_Files',
  *                     DataSource: 'WISE images',
+ *                     PreTitleMessage:'Message to appear above Title field'
  *                     FileGroupProcessor: 'LightCurveFileGroupsProcessor'
  *                 }}>
  *             <ValidationField
@@ -64,6 +65,9 @@ const DOWNLOAD_DIALOG_ID = 'Download Options';
  *         </DownloadOptionPanel>
  *     </DownloadButton>
  * </code>
+ * IRSA-3944: SOFIA required a message to guide the user before downloading AOR such as:
+ * 'All levels associated with this AOR will be downloaded.'
+ * PreTitleMessage can be added to the dlParams from the parent and passed here (FIREFLY-723)
  * @param props
  * @returns {*}
  */
@@ -191,10 +195,7 @@ export function DownloadOptionPanel (props) {
     };
 
     const dlTitle = get(dlParams, 'TitlePrefix', 'Download') + '-' + dlTitleIdx;
-    // IRSA-3944: SOFIA required a message to guide the user before downloading AOR such as:
-    // 'All levels associated with this AOR will be downloaded. To download individual data products, go to the relevant instrument tab.'
-    // PreTitleMessage can be added to the dlParams from the parent and passed here (FIREFLY-723)
-    const preTitleMessage = get(dlParams, 'PreTitleMessage', '')
+    const preTitleMessage = dlParams?.PreTitleMessage ?? '';
     return (
         <div style = {Object.assign({margin: '4px', position: 'relative', minWidth:400, height:'auto'}, style)}>
             <FormPanel


### PR DESCRIPTION
This PR is a change to add a message above the Title of the download dialog.

This is needed for SOFIA/Spitzer who wants to add some warning depending of the table/file to be downloaded to give the user more info about what they are downloading (IRSA-3944).

No build for testing here, see an example to test in IRSA-3944 PR: https://github.com/IPAC-SW/irsa-ife/pull/154