### PR TITLE
Firefly 785 fieldgroup

### DIFF
--- a/src/firefly/js/charts/ui/HistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/HistogramOptions.jsx
@@ -299,7 +299,7 @@ export class HistogramOptions extends Component {
         // to avoid width change due to scroll bar appearing when full height suggest box is rendered
         return (
             <div>
-                <FieldGroup groupKey={groupKey} validatorFunc={null} keepState={false}
+                <FieldGroup groupKey={groupKey} keepState={false}
                             reducerFunc={columnNameReducer(colValStats,basicFieldsReducer)}>
 
                     <ColumnOrExpression {...xProps}/>

--- a/src/firefly/js/core/BootstrapRegistry.js
+++ b/src/firefly/js/core/BootstrapRegistry.js
@@ -16,7 +16,7 @@ import ComponentCntlr, {DIALOG_OR_COMPONENT_KEY} from './ComponentCntlr.js';
 import AppDataCntlr from './AppDataCntlr.js';
 import BackgroundCntlr from './background/BackgroundCntlr.js';
 import ImagePlotCntlr from '../visualize/ImagePlotCntlr.js';
-import FieldGroupCntlr, {addFieldGroupRelatedWatcher, MOUNT_COMPONENT} from '../fieldGroup/FieldGroupCntlr.js';
+import FieldGroupCntlr, {MOUNT_COMPONENT} from '../fieldGroup/FieldGroupCntlr.js';
 import MouseReadoutCntlr from '../visualize/MouseReadoutCntlr.js';
 import TablesCntlr from '../tables/TablesCntlr.js';
 import DrawLayerCntlr from '../visualize/DrawLayerCntlr.js';
@@ -125,7 +125,6 @@ export const getBootstrapRegistry= once(() => {
         sagaMiddleware.run(masterSaga);
         dispatchAddSaga( imagePlotter);
         dispatchAddSaga( watchReadout);
-        addFieldGroupRelatedWatcher();
         addExtensionWatcher();
     };
 

--- a/src/firefly/js/fieldGroup/FieldGroupUtils.js
+++ b/src/firefly/js/fieldGroup/FieldGroupUtils.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get,isFunction,hasIn,isBoolean} from 'lodash';
+import {get,isFunction,hasIn,isBoolean, isEmpty} from 'lodash';
 import {flux} from '../core/ReduxFlux.js';
 import {clone} from '../util/WebUtil.js';
 import {smartMerge} from '../tables/TableUtil.js';
@@ -130,35 +130,25 @@ export function getFieldGroupResults(groupKey,includeUnmounted=false) {
  * @param {string} groupKey
  * @return {object}
  */
-export function getFieldGroupState(groupKey) {
-    const fieldGroupMap= flux.getState()[FIELD_GROUP_KEY];
-    return fieldGroupMap[groupKey] ? fieldGroupMap[groupKey] : null;
-}
+export const getFieldGroupState= (groupKey) => flux.getState()[FIELD_GROUP_KEY]?.[groupKey];
+
+export const isFieldGroupMounted = (groupKey) => getFieldGroupState(groupKey)?.isMounted
 
 export function getFieldVal(groupKey, fldName, defval=undefined) {
     return get(getGroupFields(groupKey), [fldName, 'value'], defval);
 }
 
-export function getField(groupKey, fldName) {
-    return get(getGroupFields(groupKey), fldName);
-}
+export const getField= (groupKey, fldName) => getGroupFields(groupKey)?.[fldName];
 
-export function getReducerFunc(groupKey) {
-    const groupState= getFieldGroupState(groupKey);
-    return get(groupState, 'reducerFunc');
-}
-
+export const getReducerFunc= (groupKey) => getFieldGroupState(groupKey)?.reducerFunc;
 /**
  * Get the group fields for a key
- *
  * @param {string} groupKey
  * @return {object}
  */
 export const getGroupFields= (groupKey) => getFieldGroupState(groupKey)?.fields ?? {};
 
-export function getFldValue(fields, fldName, defval=undefined) {
-    return (fields? get(fields, [fldName, 'value'], defval) : defval);
-}
+export const getFldValue= (fields, fldName, defval=undefined) => fields?.[fldName]?.value ?? defval;
 
 /**
  *
@@ -168,10 +158,11 @@ export function getFldValue(fields, fldName, defval=undefined) {
  * @return {function} a function that will unbind the store, should be called on componentWillUnmount
  */
 function bindToStore(groupKey, stateUpdaterFunc) {
-    const storeListenerRemove= flux.addListener( () => {
+    return flux.addListener( () => {
+        const fields= getGroupFields(groupKey);
+        if (isEmpty(fields)) return;
         stateUpdaterFunc(getGroupFields(groupKey));
-    });
-    return storeListenerRemove;
+    } );
 }
 
 

--- a/src/firefly/js/templates/hydra/SampleHydra.jsx
+++ b/src/firefly/js/templates/hydra/SampleHydra.jsx
@@ -97,7 +97,7 @@ const sampleSearches = [group1, group2];
 function WiseForm ({searchItem}) {
     const groupKey = searchItem.name;
     return (
-        <FieldGroup key={groupKey} groupKey={groupKey} validatorFunc={null} keepState={true}>
+        <FieldGroup key={groupKey} groupKey={groupKey} keepState={true}>
             <h3 style={{textAlign:'center'}}> {searchItem.desc} </h3>
 
             <div style={{padding:'5px 0 5px 0'}}>

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -460,8 +460,7 @@ function clearResults(layoutInfo) {
     clearLcImages();
 
     if (has(layoutInfo, [LC.MISSION_DATA])) {
-        dispatchMountFieldGroup(getViewerGroupKey(get(layoutInfo, LC.MISSION_DATA)), false, false,
-            null, null, [], undefined, true);
+        dispatchMountFieldGroup(getViewerGroupKey(get(layoutInfo, LC.MISSION_DATA)), false, false);
     }
     return smartMerge(layoutInfo, {
         showImages: false,

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -235,7 +235,7 @@ export const UploadPanel = ({initArgs}) =>{
             <FormPanel
                 groupKey={vFileKey} onSubmit={(request) => onSearchSubmit(request)} onCancel={dispatchHideDropDown}
                 submitText={'Upload'} help_id={'loadingTSV'}>
-                <FieldGroup groupKey={vFileKey} validatorFunc={null} keepState={true}>
+                <FieldGroup groupKey={vFileKey} keepState={true}>
                     <div style={{padding:5 }}>
                         <div style={{padding:5 }}>
                             {showUploadLocation()}

--- a/src/firefly/js/ui/ExampleDialog.jsx
+++ b/src/firefly/js/ui/ExampleDialog.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {TargetPanel} from './TargetPanel.jsx';
 import {InputGroup} from './InputGroup.jsx';
-import Validate from '../util/Validate.js';
+import Validate, {intValidator} from '../util/Validate.js';
 import {ValidationField} from './ValidationField.jsx';
 import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
 import {RadioGroupInputField} from './RadioGroupInputField.jsx';
@@ -26,6 +26,7 @@ import {StatefulTabs, Tab,FieldGroupTabs} from './panel/TabPanel.jsx';
 import {dispatchShowDialog} from '../core/ComponentCntlr.js';
 import {NaifidPanel} from './NaifidPanel.jsx';
 import {useBindFieldGroupToStore} from 'firefly/ui/SimpleComponent.jsx';
+import {getGroupFields} from 'firefly/fieldGroup/FieldGroupUtils.js';
 
 
 
@@ -76,13 +77,6 @@ const defValues= {
         tooltip: 'Please enter an email',
         label: 'Email:'
     },
-    low: {
-        fieldKey: 'low',
-        value: '1',
-        validator: Validate.intRange.bind(null, 1, 100, 'low field'),
-        tooltip: 'this is a tip for low field',
-        label: 'Low Field:'
-    },
     high: {
         fieldKey: 'high',
         value: '3',
@@ -116,7 +110,7 @@ function exDialogReducer(inFields, action) {
         return defValues;
     }
     else {
-        let {low,high}= inFields;
+        let {low={valid:false},high}= inFields;
         // inFields= revalidateFields(inFields);
         if (!low.valid || !high.valid) {
             return inFields;
@@ -286,6 +280,10 @@ const defaultExamples = <div style={{display : 'inline-block'}}>
     {makeSpan(5)}  '20h27m36.3467s +40d01m21.649s Equ B1950'
 </div>;
 
+let lowDefValue=2;
+let lowKey= 'abc';
+
+
 function FieldGroupTestView ({fields={}}) {
 
     var hide = false;
@@ -295,6 +293,13 @@ function FieldGroupTestView ({fields={}}) {
     }
     var field1 = makeField1(hide);
 
+    const lowField= getGroupFields('DEMO_FORM')?.low;
+    const highField= getGroupFields('DEMO_FORM')?.high;
+    if (Number(highField?.value)===100) {
+        lowDefValue=50;
+        lowKey='newLowKey';
+    }
+    console.log(lowField);
 
     const tabX3CheckBoxOps= [
         {label: 'Carrots', value: 'C'},
@@ -311,11 +316,12 @@ function FieldGroupTestView ({fields={}}) {
 
 
 
+
     const validSuggestions = [];
     for (var i=1; i<100; i++) { validSuggestions.push(...[`w${i}mpro`, `w${i}mprosig`, `w${i}snr`]); }
 
     return (
-        <FieldGroup style= {{padding:5}} groupKey={'DEMO_FORM'} initValues={{extraData:'asdf',field1:'4'}}
+        <FieldGroup style= {{padding:5}} groupKey={'DEMO_FORM'}
                     reducerFunc={exDialogReducer} keepState={true}>
             <InputGroup labelWidth={110}>
                 <TargetPanel examples={defaultExamples} />
@@ -353,7 +359,16 @@ function FieldGroupTestView ({fields={}}) {
                                      labelWidth : 100
                                  }} />
                 <ValidationField fieldKey='field4'/>
-                <ValidationField fieldKey='low'/>
+                <ValidationField fieldKey='low'
+                                 key={lowKey}
+                                 initialState= {{
+                                     value: lowDefValue,
+                                     validator: intValidator(1, 100, 'low field')
+                                 }}
+                                 tooltip='this is a tip for low field'
+                                 label= 'Low Field:'
+
+                />
                 <ValidationField fieldKey='high'/>
                 
                 <br/>

--- a/src/firefly/js/ui/FieldGroup.jsx
+++ b/src/firefly/js/ui/FieldGroup.jsx
@@ -1,125 +1,49 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-
-
-
-import React, {Component} from 'react';
+import React, {Component, memo, useContext, useEffect, useLayoutEffect, useState} from 'react';
 import PropTypes from 'prop-types';
-import shallowequal from 'shallowequal';
-import {dispatchMountFieldGroup, MOUNT_FIELD_GROUP} from '../fieldGroup/FieldGroupCntlr.js';
-import {getFieldGroupState} from '../fieldGroup/FieldGroupUtils.js';
-import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
-import {Logger} from '../util/Logger.js';
-
-const logger = Logger('FieldGroup');
-
-/**
- * Watch for an unmount for a field group this is marked as mounted. Then we immediately do a mount.
- * @param action
- * @param cancelSelf
- * @param params
- */
-function remountWatcher(action, cancelSelf, params) {
-    const {payload}= action;
-    if (action.type===MOUNT_FIELD_GROUP && !payload.mounted && payload.groupKey===params.props.groupKey) {
-        doMountDispatch(params.props, params.wrapperGroupKey);
-        cancelSelf();
-    }
-}
-
-
-function doMountDispatch(props,wrapperGroupKey) {
-    const {groupKey, reducerFunc, keepState, initValues, actionTypes}= props;
-    dispatchMountFieldGroup(groupKey, true, keepState, initValues, reducerFunc, actionTypes, wrapperGroupKey);
-}
-
-function doMounting(props, wrapperGroupKey) {
-    const groupState= getFieldGroupState(props.groupKey);
-    if (groupState && groupState.mounted) {
-        // as of react 16 mount happens before unmount:
-        // if a mounted group is unmounted, I will delay the remount until the componentWillUnmount is called
-        dispatchAddActionWatcher({
-            actions:[MOUNT_FIELD_GROUP], callback:remountWatcher, params:{props, wrapperGroupKey}}
-        );
-    }
-    else {
-        doMountDispatch(props, wrapperGroupKey);
-    }
-
-}
-
+import {dispatchMountFieldGroup} from '../fieldGroup/FieldGroupCntlr.js';
+import {getFieldGroupState, isFieldGroupMounted} from '../fieldGroup/FieldGroupUtils.js';
 
 export const GroupKeyCtx = React.createContext({});
+export const FieldGroup = memo( ({keepMounted, reducerFunc=undefined, groupKey, keepState=false, children, style, className}) => {
+        const [fields, setFields]= useState(() => getFieldGroupState(groupKey))
+        const {groupKey:wrapperGroupKey}= useContext(GroupKeyCtx);
+        useLayoutEffect(() => {
+            dispatchMountFieldGroup(groupKey, true, keepState, reducerFunc, wrapperGroupKey);
+            return () => {
+                if (!keepMounted) dispatchMountFieldGroup(groupKey, false);
+            };
+        }, [groupKey, wrapperGroupKey, reducerFunc?.ver]);
 
-export class FieldGroup extends Component {
+        useEffect(() => {
+            if (isFieldGroupMounted(groupKey)) {
+                dispatchMountFieldGroup(groupKey, true, keepState, reducerFunc, wrapperGroupKey);
+            }
+        },[keepState, keepMounted, reducerFunc]);
 
-    constructor(props, context) {
-        super(props);
-        const wrapperGroupKey= context;
-        doMounting(props,wrapperGroupKey);
-        this.firstMount= true;
-    }
-
-    shouldComponentUpdate(nextProps,nextState, nextContext) {// using this function to do a remount side effect
-        if (shallowequal(this.props, nextProps)) return false;
-        const wrapperGroupKey= nextContext;
-        const {groupKey, reducerFunc, keepState, actionTypes}= nextProps;
-        // added check for 'reducerFunc.ver' to re-register if needed.  Should revisit this for a better solution
-        if (this.props.groupKey!==groupKey || this.props?.reducerFunc?.ver !== reducerFunc?.ver) {// support change the groupKey property on the form without unmounting
-            dispatchMountFieldGroup(groupKey, false);
-            dispatchMountFieldGroup(groupKey, true, keepState, null, reducerFunc, actionTypes, wrapperGroupKey);
-            if (this.props.reducerFunc !== reducerFunc) logger.log('!!reducerFunc changed: ' + groupKey);
-        }
-        return true;
-    }
-
-    componentDidMount() {
-        if (this.firstMount) {
-            this.firstMount= false;
-        }
-        else {
-            const wrapperGroupKey= this.context;
-            doMounting(this.props,wrapperGroupKey);
-        }
-    }
-
-    componentWillUnmount() {
-        if (!this.props.keepMounted) {
-            dispatchMountFieldGroup(this.props.groupKey, false);
-        }
-    }
-
-    render() {
-        const {style, className, groupKey} = this.props;
+        useEffect(() => {
+            if (reducerFunc) setFields(getFieldGroupState(groupKey));
+        },[]);
+        
         return (
             <GroupKeyCtx.Provider value={{groupKey}}>
                 <div className={className} style={style} groupkey={groupKey}>
-                    {this.props.children}
+                    {children}
                 </div>
             </GroupKeyCtx.Provider>
         );
-    }
-}
+    });
 
-FieldGroup.contextType = GroupKeyCtx;
 
 FieldGroup.propTypes= {
     groupKey : PropTypes.string.isRequired,
     reducerFunc: PropTypes.func,
-    actionTypes: PropTypes.arrayOf(PropTypes.string),
     keepState : PropTypes.bool,
-    initValues : PropTypes.object,
     style : PropTypes.object,
     keepMounted: PropTypes.bool,
     className: PropTypes.string
 };
 
-
-FieldGroup.defaultProps=  {
-    reducerFunc: null,
-    validatorFunc: null,
-    keepState : false,
-    keepMounted : false
-};
-
+FieldGroup.contextType = GroupKeyCtx;

--- a/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
+++ b/src/firefly/js/ui/HiPSSurveyListDisplay.jsx
@@ -282,7 +282,7 @@ export class HiPSSurveyListSelection extends PureComponent {
 
         return (
             <div style={wrapperStyle}>
-                <FieldGroup groupKey={gKeyHiPSPanel} validatorFunc={null} keepState={true}
+                <FieldGroup groupKey={gKeyHiPSPanel} keepState={true}
                             reducerFunc={fieldReducer(hipsSources)}
                             style={{height: '100%', width: '100%'}}>
                    <div style={{height: 20, width: '100%'}}>

--- a/src/firefly/js/ui/RadioGroupInputField.jsx
+++ b/src/firefly/js/ui/RadioGroupInputField.jsx
@@ -8,7 +8,7 @@ import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 const assureValue= (props) => {
     const {value,options, defaultValue}= props;
     if (value) return value;
-    return isUndefined(defaultValue) ? options[0].value : defaultValue;
+    return isUndefined(defaultValue) ? options?.[0].value : defaultValue;
 };
 
 function handleOnChange(ev, params, fireValueChange) {
@@ -21,7 +21,7 @@ function handleOnChange(ev, params, fireValueChange) {
 
 function checkForUndefined(v,props) {
     const {options=[], defaultValue, isGrouped=false} = props;
-    const optionContain = (v) => v && options.find((op) => op.value === v);
+    const optionContain = (v) => Boolean(v && options.find((op) => op.value === v));
     if (isEmpty(options) || optionContain(v) || isGrouped) {
         return v;
     } else {
@@ -31,7 +31,9 @@ function checkForUndefined(v,props) {
 
 export const RadioGroupInputField= memo( (props) => {
     const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmValue:checkForUndefined});
-    const newProps= {...viewProps,  value: assureValue(viewProps)};
+    const value= assureValue(viewProps);
+    if (isUndefined(value)) return <div/>;
+    const newProps= {...viewProps,  value};
     return <RadioGroupInputFieldView {...newProps}
                                      onChange={(ev) => handleOnChange(ev,viewProps, fireValueChange)}/> ;
 });

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -69,7 +69,7 @@ export class TestQueriesPanel extends PureComponent {
                     groupKey='TEST_CAT_PANEL'
                     onSubmit={(request) => onSearchSubmit(request)}
                     onCancel={hideSearchPanel}>
-                    <FieldGroup groupKey='TEST_CAT_PANEL' validatorFunc={null} keepState={true}>
+                    <FieldGroup groupKey='TEST_CAT_PANEL' keepState={true}>
                         <div style={{padding:'5px 0 5px 0'}}>
                             <TargetPanel/>
                         </div>

--- a/src/firefly/js/ui/TestSearchPanel.jsx
+++ b/src/firefly/js/ui/TestSearchPanel.jsx
@@ -29,7 +29,7 @@ export const TestSearchPanel = (props) => {
                 <p>
                     <input type='button' name='dowload' value='Download Sample File' onClick={doFileDownload} />
                 </p>
-                <FieldGroup groupKey='TBL_BY_URL_PANEL' validatorFunc={null} keepState={true}>
+                <FieldGroup groupKey='TBL_BY_URL_PANEL' keepState={true}>
                     <ValidationField style={{width:500}}
                                      fieldKey='srcTable'
                                      initialState= {{

--- a/src/firefly/js/visualize/ui/ActivateMenu.jsx
+++ b/src/firefly/js/visualize/ui/ActivateMenu.jsx
@@ -26,7 +26,7 @@ export const ActivateMenu= memo(({ serDefParams, setSearchParams, title, makeDro
             {makeDropDown?.()}
             <div style={{padding: '5px 5px 5px 5px'}}>
                 <div style= {titleStyle}> {title} </div>
-                <FieldGroup groupKey={GROUP_KEY} validatorFunc={null} keepState={false}>
+                <FieldGroup groupKey={GROUP_KEY} keepState={false}>
                     {makeActivateInput(serDefParams)}
                 </FieldGroup>
                 <CompleteButton style={{padding: '20px 0 0 0'}} onSuccess={loadParams} text={'Submit'} groupKey={GROUP_KEY} />

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -33,7 +33,6 @@ import './CatalogSelectViewPanel.css';
  */
 export const irsaCatalogGroupKey = 'CATALOG_PANEL';
 export const gkeySpacial = 'CATALOG_PANEL_spacial';
-export const initRadiusArcSec = (10 / 3600) + '';
 
 const RADIUS_COL = '7';
 const COLDEF1 = 9;
@@ -201,7 +200,7 @@ function doCatalog(request) {
     }
 
     const {txtareasql} = FieldGroupUtils.getGroupFields(irsaCatalogGroupKey);
-    const sqlTxt = txtareasql.value.trim();
+    const sqlTxt = txtareasql.value?.trim() ?? '';
     if (sqlTxt.length > 0) {
         tReq.constraints += (addAnd ? ' AND ' : '') + validateSql(sqlTxt);
     }
@@ -439,16 +438,16 @@ function userChangeDispatch() {
                 //
                 // }
 
-                const radius = parseFloat(catTable[currentIdx].cat[RADIUS_COL]);
+                // const radius = parseFloat(catTable[currentIdx].cat[RADIUS_COL]);
                 const coldef = catTable[currentIdx].cat[COLDEF1] === 'null' ? catTable[currentIdx].cat[COLDEF2] : catTable[currentIdx].cat[COLDEF1];
                 inFields = updateMerge(inFields, 'cattable', {
                     indexClicked: currentIdx,
                     value: catTable[currentIdx].value,
                     coldef
                 });
-                inFields = updateMerge(inFields, 'conesize', {
-                    max: sizeFactor * radius / 3600
-                });
+                // inFields = updateMerge(inFields, 'conesize', {
+                //     max: sizeFactor * radius / 3600
+                // });
 
                 const catname = get(inFields, 'cattable.value', '');
                 const formsel = get(inFields, 'ddform.value', 'true');
@@ -657,28 +656,10 @@ function fieldInit() {
             coldef: catmaster[0].catalogs[0].option[0].cat[COLDEF1],
             indexClicked: 0
         },
-        'conesize': {
-            fieldKey: 'conesize',
-            value: initRadiusArcSec,
-            unit: 'arcsec',
-            min: 1 / 3600,
-            max: parseInt(catmaster[0].catalogs[0].option[0].cat[RADIUS_COL]) / 3600
-        },
-        'nedconesize': {
-            fieldKey: 'nedconesize',
-            value: initRadiusArcSec,
-            unit: 'arcsec',
-            min: 1 / 3600,
-            max: 5
-        },
         'tableconstraints': {
             fieldKey: 'tableconstraints',
             value: {constraints: '', selcols: '', errorConstraints: ''},
             tbl_id: ''
-        },
-        'txtareasql': {
-            fieldKey: 'txtareasql',
-            value: ''
         },
         'ddform': {
             fieldKey: 'ddform',

--- a/src/firefly/js/visualize/ui/ColorBandPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorBandPanel.jsx
@@ -16,7 +16,7 @@ import {
     PERCENTAGE,  ABSOLUTE,SIGMA, STRETCH_LINEAR, STRETCH_LOG, STRETCH_LOGLOG, STRETCH_EQUAL,
     STRETCH_SQUARED, STRETCH_SQRT, STRETCH_ASINH, STRETCH_POWERLAW_GAMMA} from '../RangeValues.js';
 import {getFieldGroupResults, validateFieldGroup} from '../../fieldGroup/FieldGroupUtils.js';
-import {dispatchStretchChange, visRoot} from '../ImagePlotCntlr.js';
+import ImagePlotCntlr, {dispatchStretchChange, visRoot} from '../ImagePlotCntlr.js';
 import {getActivePlotView, isThreeColor} from '../PlotViewUtil.js';
 import {makeSerializedRv} from './ColorDialog.jsx';
 import {getFluxUnits} from '../WebPlot';
@@ -26,6 +26,8 @@ import {
     makeColorHistImage,
     makeColorTableImage
 } from 'firefly/visualize/rawData/rawAlgorithm/ColorTable.js';
+import {useWatcher} from 'firefly/ui/SimpleComponent.jsx';
+import {dispatchForceFieldGroupReducer} from 'firefly/fieldGroup/FieldGroupCntlr.js';
 
 
 const LABEL_WIDTH= 105;
@@ -52,6 +54,16 @@ export const ColorBandPanel= memo(({fields,plot,band, groupKey}) => {
     const {plotId, plotState}= plot ?? {};
     const doMask= false;
     const {current:lastProps} = useRef({ rvStr:'',plotId:'',groupKey:'',band:'' });
+
+    useEffect(() => {
+        dispatchForceFieldGroupReducer(groupKey);
+    },[]);
+
+    useWatcher([ImagePlotCntlr.ANY_REPLOT, ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW],
+        (action) => {
+            dispatchForceFieldGroupReducer(groupKey, action);
+        }
+     );
 
     useEffect(() => {
         let mounted= true;
@@ -122,7 +134,7 @@ ColorBandPanel.propTypes= {
     groupKey : PropTypes.string.isRequired,
     band : PropTypes.object.isRequired,
     plot : PropTypes.object.isRequired,
-    fields : PropTypes.object.isRequired
+    fields : PropTypes.object
 };
 
 function ColorInput({fields,bandReplot}) {

--- a/src/firefly/js/visualize/ui/ColorPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ColorPanelReducer.js
@@ -4,7 +4,7 @@
 
 import {get} from 'lodash';
 import Validate from '../../util/Validate.js';
-import FieldGroupCntlr, {INIT_FIELD_GROUP} from '../../fieldGroup/FieldGroupCntlr.js';
+import FieldGroupCntlr, {FORCE_FIELD_GROUP_REDUCER, INIT_FIELD_GROUP} from '../../fieldGroup/FieldGroupCntlr.js';
 import ImagePlotCntlr from '../ImagePlotCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {primePlot} from '../PlotViewUtil.js';
@@ -66,6 +66,7 @@ function computeColorPanelState(fields, plottedRV, fitsData, band, action) {
 
         case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
         case INIT_FIELD_GROUP:
+        case FORCE_FIELD_GROUP_REDUCER:
         case ImagePlotCntlr.ANY_REPLOT:
             if (!plottedRV && !fitsData) return fields;
             // no update if hue-preserving
@@ -409,6 +410,7 @@ export function computeHuePreservePanelState(fields, plottedRVAry, fitsDataAry, 
             if (!valid) return fields;
             return syncFieldsHuePreserve(fields,makeHuePreserveRangeValuesFromFields(fields),fitsDataAry);
 
+        case FORCE_FIELD_GROUP_REDUCER:
         case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
         case INIT_FIELD_GROUP:
         case ImagePlotCntlr.ANY_REPLOT:

--- a/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
@@ -1,90 +1,97 @@
-import React, {PureComponent} from 'react';
-import {debounce, get} from 'lodash';
+import React, {useEffect} from 'react';
+import {debounce} from 'lodash';
 import {replot3ColorHuePreserving} from './ColorDialog.jsx';
 import {getTypeMinField, getZscaleCheckbox, renderAsinH} from './ColorBandPanel.jsx';
 import {getFieldGroupResults, validateFieldGroup} from '../../fieldGroup/FieldGroupUtils';
 import {ValidationField} from '../../ui/ValidationField.jsx';
 import {RangeSlider} from '../../ui/RangeSlider.jsx';
 import {FieldGroupCollapsible} from '../../ui/panel/CollapsiblePanel.jsx';
+import {useWatcher} from 'firefly/ui/SimpleComponent.jsx';
+import ImagePlotCntlr from 'firefly/visualize/ImagePlotCntlr.js';
+import {dispatchForceFieldGroupReducer} from 'firefly/fieldGroup/FieldGroupCntlr.js';
 
-const isDebug = () => get(window, 'firefly.debugStretch', false);
+const isDebug = () => window.firefly?.debugStretch ?? false;
 
-export class ColorRGBHuePreservingPanel extends PureComponent {
+export const ColorRGBHuePreservingPanel= ({rgbFields,groupKey}) => {
 
-    constructor(props) {
-        super(props);
-        this.doReplot= debounce(getReplotFunc(props.groupKey), 600);
-    }
+    const doReplot= debounce(getReplotFunc(groupKey), 600);
 
-    render() {
-        const {rgbFields} = this.props;
-        const {zscale} = rgbFields;
-        const zscaleValue = get(zscale, 'value');
-        const textPadding = {paddingBottom:3};
-        const LABEL_WIDTH= 90;
-        const renderRange = (isZscale) => {
-            if (isZscale) {
-                return null;
-            } else {
-                return (
-                    <div>
-                        <FieldGroupCollapsible  header='Pedestals (black point values)'
-                                                initialState= {{ value:'closed' }}
-                                                fieldKey='rangeParameters'>
-                            <div style={{whiteSpace: 'no-wrap'}}>
-                                <ValidationField wrapperStyle={textPadding} inline={true}
-                                                 labelWidth={LABEL_WIDTH}
-                                                 fieldKey='lowerRangeRed'
-                                />
-                                {getTypeMinField('lowerWhichRed')}
-                            </div>
-                            <div style={{whiteSpace: 'no-wrap'}}>
-                                <ValidationField wrapperStyle={textPadding} inline={true}
-                                                 labelWidth={LABEL_WIDTH}
-                                                 fieldKey='lowerRangeGreen'
-                                />
-                                {getTypeMinField('lowerWhichGreen')}
-                            </div>
-                            <div style={{whiteSpace: 'no-wrap'}}>
-                                <ValidationField wrapperStyle={textPadding} inline={true}
-                                                 labelWidth={LABEL_WIDTH}
-                                                 fieldKey='lowerRangeBlue'
-                                />
-                                {getTypeMinField('lowerWhichBlue')}
-                            </div>
-                            {!zscaleValue && <div style={{paddingTop: 5}}>{getZscaleCheckbox()}</div>}
-                            {isDebug() && <div style={{whiteSpace: 'no-wrap'}}>
-                                <ValidationField wrapperStyle={textPadding} inline={true}
-                                                 labelWidth={LABEL_WIDTH}
-                                                 fieldKey='stretch'/>
-                            </div>}
-                        </FieldGroupCollapsible>
-                    </div>
-                );
-            }
-        };
+    useEffect(() => {
+        dispatchForceFieldGroupReducer(groupKey);
+    },[]);
 
-        const wrapperStyle = zscaleValue ? {paddingBottom: 40} : {paddingBottom: 10};
-        const asinH = renderAsinH(rgbFields, renderRange, this.doReplot, wrapperStyle, true);
-        const scale = renderScalingCoefficients(rgbFields, this.doReplot);
-        return (
-            <div style={{minWidth: 360, padding: 5, position: 'relative'}}>
-                <div style={{paddingBottom: 8, opacity: .7, textAlign: 'center'}}>
-                    Brightness-independent color-preserving asinh stretch;<br/>
-                    images must be free of background artifacts
+    useWatcher([ImagePlotCntlr.ANY_REPLOT, ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW],
+        (action) => {
+            dispatchForceFieldGroupReducer(groupKey, action);
+        }
+    );
+    if (!rgbFields) return <div/>;
+    const {zscale} = rgbFields;
+    const zscaleValue = zscale?.value;
+    const textPadding = {paddingBottom:3};
+    const LABEL_WIDTH= 90;
+    const renderRange = (isZscale) => {
+        if (isZscale) {
+            return null;
+        } else {
+            return (
+                <div>
+                    <FieldGroupCollapsible  header='Pedestals (black point values)'
+                                            initialState= {{ value:'closed' }}
+                                            fieldKey='rangeParameters'>
+                        <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='lowerRangeRed'
+                            />
+                            {getTypeMinField('lowerWhichRed')}
+                        </div>
+                        <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='lowerRangeGreen'
+                            />
+                            {getTypeMinField('lowerWhichGreen')}
+                        </div>
+                        <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='lowerRangeBlue'
+                            />
+                            {getTypeMinField('lowerWhichBlue')}
+                        </div>
+                        {!zscaleValue && <div style={{paddingTop: 5}}>{getZscaleCheckbox()}</div>}
+                        {isDebug() && <div style={{whiteSpace: 'no-wrap'}}>
+                            <ValidationField wrapperStyle={textPadding} inline={true}
+                                             labelWidth={LABEL_WIDTH}
+                                             fieldKey='stretch'/>
+                        </div>}
+                    </FieldGroupCollapsible>
                 </div>
-                {scale}
-                {asinH}
-                {zscaleValue && <div style={{position:'absolute', bottom:5, left:5, right:5}}>
-                    {getZscaleCheckbox()}
-                </div>}
+            );
+        }
+    };
+
+    const wrapperStyle = zscaleValue ? {paddingBottom: 40} : {paddingBottom: 10};
+    const asinH = renderAsinH(rgbFields, renderRange, doReplot, wrapperStyle, true);
+    const scale = renderScalingCoefficients(rgbFields, doReplot);
+    return (
+        <div style={{minWidth: 360, padding: 5, position: 'relative'}}>
+            <div style={{paddingBottom: 8, opacity: .7, textAlign: 'center'}}>
+                Brightness-independent color-preserving asinh stretch;<br/>
+                images must be free of background artifacts
             </div>
-        );
-    }
-}
+            {scale}
+            {asinH}
+            {zscaleValue && <div style={{position:'absolute', bottom:5, left:5, right:5}}>
+                {getZscaleCheckbox()}
+            </div>}
+        </div>
+    );
+};
 
 const scaleMarks = {
- '-1': '.1', '-0.699': '.2', '-0.301': '.5', '0': '1', '0.301': '2', '0.699': '5', '1': '10'
+    '-1': '.1', '-0.699': '.2', '-0.301': '.5', '0': '1', '0.301': '2', '0.699': '5', '1': '10'
 };
 
 function renderScalingCoefficients(fields, replot) {
@@ -96,7 +103,7 @@ function renderScalingCoefficients(fields, replot) {
                                     fieldKey='bandScaling'>
                 {['Red', 'Green', 'Blue'].map((c) => {
                     const fieldKey = `k${c}`;
-                    const value = get(fields, [fieldKey, 'value'], 1);
+                    const value = fields?.[fieldKey].value ?? 1;
                     const displayVal = Math.pow(10, value).toFixed(2);
                     const label = `${c}: ${displayVal}`;
 

--- a/src/firefly/js/visualize/ui/ImageCenterDropDown.jsx
+++ b/src/firefly/js/visualize/ui/ImageCenterDropDown.jsx
@@ -125,7 +125,7 @@ export function ImageCenterDropDown({visRoot:vr, visible, mi}) {
 
             <DropDownVerticalSeparator useLine={true}/>
             <FieldGroup style={{display:'flex', fontSize:'10pt', padding:'5px 0 0 0'}}
-                        groupKey='TARGET_DROPDOWN' validatorFunc={null} keepState={false}>
+                        groupKey='TARGET_DROPDOWN' keepState={false}>
                 <TargetPanel groupKey={'target-move-group'} labelWidth={80}
                              label={'Center On:'} defaultToActiveTarget={false}
                              showResolveSourceOp={false} showExample={false}/>

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -334,7 +334,7 @@ function ImageType({}) {
         <FieldGroup className='ImageSearch__section' groupKey={FG_KEYS.main} keepState={true}>
             <div className='ImageSearch__section--title'>1. Choose Image Type</div>
             <RadioGroupInputField
-                initialState= {{ defaultValue: 'singleChannel',
+                initialState= {{ value: 'singleChannel',
                              tooltip: 'Please select the image type'}}
                 options={ options }
                 fieldKey={ FD_KEYS.type }


### PR DESCRIPTION
Do the following with FieldGroup:

 

Change Field group to a function component
play with the FieldGroupConnector Effect for the component still works like before.
remove all sorts of functionality that was put into FieldGroup but not used or barely used.
related actions - Monitoring actions with a saga or watch
simplify `keepState` remove initValues functionality (never used)
Removed a lot of `validatorFunc`  properties from field group, I am not sure how this every got in there.


https://fireflydev.ipac.caltech.edu/firefly/