### PR TITLE
IRSA-4111: Finderchart access from NED stopped working

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
@@ -149,29 +149,11 @@ public class RequestAgent {
             this.response = response;
 
             // getting the base url including the application path is a bit tricky when behind reverse proxy(ies)
-            URL referer = null;
-
-            try {
-                String url = getHeader("Referer", getHeader("Origin"));
-                referer = new URL(url);
-            } catch (MalformedURLException e) {}
-
-            String proto = referer != null ? referer.getProtocol() : getHeader("X-Forwarded-Proto", request.getScheme());
-            String host  = referer != null ? referer.getHost()     : getHeader("X-Forwarded-Server", getHeader("X-Forwarded-Host", request.getServerName()));
-            String port  = referer != null && referer.getPort() > 0 ? referer.getPort()+""  : getHeader("X-Forwarded-Port", String.valueOf(request.getServerPort()));
+            String proto = getHeader("X-Forwarded-Proto", request.getScheme());
+            String host  = getHeader("X-Forwarded-Server", getHeader("X-Forwarded-Host", request.getServerName()));
+            String port  = getHeader("X-Forwarded-Port", String.valueOf(request.getServerPort()));
             port = port.matches("443|80") ? "" : ":" + port;
-
-            String contextPath = getHeader("X-Forwarded-Path");
-            if (contextPath == null && referer != null) {
-                contextPath = referer.getPath();
-                int idx = contextPath.lastIndexOf("/");
-                if (idx > 0) {
-                    contextPath = contextPath.substring(0, idx);
-                }
-            }
-            if (StringUtils.isEmpty(contextPath)) {
-                contextPath = request.getContextPath();
-            }
+            String contextPath = getHeader("X-Forwarded-Path", request.getContextPath());
 
             String hostUrl = String.format("%s://%s%s", proto, host, port);
             String baseUrl = hostUrl + contextPath;


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-4111
https://jira.ipac.caltech.edu/browse/IRSA-4113
These 2 tickets are duplicates.
- remove the use of `referer` header because it leads to false info in API case

Test: https://irsa-4111-fc-api-bad-redirect.irsakudev.ipac.caltech.edu/

Taken from IRSA-4113:
> if i go to Radar and search (example around 'arp220') and then if i click on ‘FinderChart’ logo at the bottom in the banner to send it to FinderChart , it displays an empty webapge ‘forbidden’.

@cwang2016 I am not sure you want to test this.  It may requires a lot of setup on your ends.