### PR TITLE
IRSA-3841: chart plots failing when filters are cancelled

### DIFF
--- a/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
+++ b/src/firefly/js/charts/dataTypes/FireflyHeatmap.js
@@ -68,7 +68,7 @@ function fetchData(chartId, traceNum, tablesource) {
     const totalRows= get(tableModel, 'totalRows');
     if (scatterOrHeatmap && totalRows <= getMaxScatterRows()) {
         const {options:scatterOptions, fetchData:scatterFetchData} = genericTSGetter({traceTS:tablesource, chartId, traceNum});
-        const scatterTS = Object.assign({}, tablesource, {options: scatterOptions});
+        const scatterTS = Object.assign({}, tablesource, {options: {...options, ...scatterOptions}});       // need to save heatmap options in case it's switched back
         return scatterFetchData(chartId, traceNum, scatterTS);
     }
 

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -280,9 +280,10 @@ export function dispatchTblResultsAdded(tbl_id, title, options, tbl_ui_id) {
 /**
  * Remove table UI from the results area.
  * @param {string} tbl_id     table id
+ * @param {boolean} [fireActiveTableChanged=true]  true to fire TBL_RESULTS_ACTIVE when applicable.
  */
-export function dispatchTblResultsRemove(tbl_id) {
-    flux.process( {type: TBL_RESULTS_REMOVE, payload: {tbl_id}});
+export function dispatchTblResultsRemove(tbl_id, fireActiveTableChanged=true) {
+    flux.process( {type: TBL_RESULTS_REMOVE, payload: {tbl_id, fireActiveTableChanged}});
 }
 
 /**


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-3841

---
**UPDATED:**
fixed https://jira.ipac.caltech.edu/browse/IRSA-4133
- previous plot vanishes after a long search is sent to background 
---

Heatmap: failed when an expression filter is applied in expanded mode, then close(collapse) and clear filter.

Test: https://irsa-3841-heatmap-fail-clear-filter.irsakudev.ipac.caltech.edu/irsaviewer/
Follow instructions in ticket to reproduce. Or,
- Images -> m31 -> cutout = 2500" -> WISE -> WISE ALLWISE Atlas - Search
- Catalogs -> Search Method = Polygon -> Search
- expand chart -> setttings (gears icon)
- x: w1mpro-w4mpro -> y: w1mpro -> Apply
- select a small area on the chart, then click filter(funnel icon)
- collapse the chart(close icon)
- clear filters (crossed-out funnel icon)

Also:
- I noticed and Luisa had reported that longer tabular searches sometimes remained in the working state (loading...) forever.  This may be due to the short idle timeout parameters set in kubernetes.  It defaults to 1 minutes.  I increased it to 10 minutes.  Let me know if this helps.
