### PR TITLE
Improve nested error handling in retrieval of TAP error documents

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -41,6 +41,9 @@
   - Fixed: mouse wheel / trackpad scrolling performance issue ([Firefly-793](https://github.com/Caltech-IPAC/firefly/pull/1098))
   - Fixed: Handle redirects when retrieving TAP errors ([DM-30073](https://github.com/Caltech-IPAC/firefly/pull/1092))
   - Fixed: problem is misusing the referer header
+- 2021.2.X
+  - Fixed: initialization of userInfo object
+  - Fixed: further refinement to error handling when retrieving TAP error documents
 
 
 ##### _Pull Request in this release_


### PR DESCRIPTION
Ensure that errors in both the initial retrieval and in the retrieval of a
redirected error document are handled correctly.  Previous version was
incorrectly still reporting an error after a successful redirect.