### PR TITLE
FIREFLY-789: fix custom base.help.url override test page

### DIFF
--- a/src/firefly/html/test/tests-main.html
+++ b/src/firefly/html/test/tests-main.html
@@ -148,17 +148,20 @@
 
 <template title="Custom Online-Help URL" class="tpl sm">
     <div id="expected" >
-        Click table's Help(?) icon and it should take you to "https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/"
+        Click table's Help(?) icon and it should take you to "https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/#id=tables"
+        instead of firefly's help.
     </div>
     <div id="actual" class="box x3"/>
     <script>
         function onFireflyLoaded(firefly) {
+            // override 'help.base.url', all help links will go to irsaviewer's help instead of firefly's.
             firefly.action.dispatchAppOptions({"help.base.url": "https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/"});
 
             const columns = [{name: 'Greetings'}];
             const data = [["Hello, World!"]];
             const table = { tableData: { columns, data }, title: "Custom Help"};
-            firefly.showClientTable('actual', table, {help_id: "https://irsa.ipac.caltech.edu/onlinehelp/irsaviewer/"});
+            // for testing, add {help_id: "tables"} to put a help icon into the toolbar linking it to help topic 'tables'
+            firefly.showClientTable('actual', table, {help_id: "tables"});
         }
     </script>
 </template>

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -137,7 +137,7 @@ const defFireflyOptions = {
     wcsMatchType: false,
     imageScrollsToHighlightedTableRow: true,
     imageScrollsToActiveTableOnLoadOrSelect: true,
-    'help.base.url': undefined,
+    'help.base.url': undefined,                     // this overrides property set during build time.
 
     charts: {
         defaultDeletable: undefined, // by default if there are more than one chart in container, all charts are deletable


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-789

From ticket: The test for custom URL to go to a different  online help than the default is not working.

This is a case of user's error due to bad documentation.  I fixed the test page to clarify on its usage.  I also added a description to `help.base.url` appOption.

Test: https://fireflydev.ipac.caltech.edu/firefly-789-custom-help-base-url/firefly/test/tests-main.html?test=Custom+Online-Help+URL
- click on `source: show` to see how it's used
- click on table's help icon to see it go to irsaviewer's help instead of firefly's.
