### PR TITLE
Firefly-810: Fixed mask not loading correctly when zooming

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,8 +5,10 @@
 - To Access current (unstable) development - (Version _next_, unreleased) use docker tag: `nightly`
 
 ## Version 2021.2
+- 2021.2.4 (July 2021)
+  - docker tag: `latest`, `release-2021.2`, `release-2021.2.4`
 - 2021.2.3 (June 2021)
-  - docker tag: `latest`, `release-2021.2`, `release-2021.2.3`
+  - docker tag: `release-2021.2.3`
 - 2021.2.2 (June 2021)
   - docker tag: `release-2021.2.2`
 - 2021.2.1 (May 2021)
@@ -48,6 +50,11 @@
   - Fixed: further refinement to error handling when retrieving TAP error documents
   - Fixed: Simbad name resolution issue ([Firefly-797](https://github.com/Caltech-IPAC/firefly/pull/1103))
   - Fixed: Mouse zoom not working correctly ([Firefly-803](https://github.com/Caltech-IPAC/firefly/pull/1103))
+- 2021.2.4
+  - Fixed: Image mask not zooming correctly ([Firefly-810](https://github.com/Caltech-IPAC/firefly/pull/1106))
+  - Fixed: HiPS select table _i_ link not working ([Firefly-819](https://github.com/Caltech-IPAC/firefly/pull/1106))
+  - Fixed: bias slider not working in 3 color mode ([PR](https://github.com/Caltech-IPAC/firefly/pull/1106))
+  - Fixed: boolean table filters not working ([Firefly-805](https://github.com/Caltech-IPAC/firefly/pull/1104))
 
 
 ##### _Pull Request in this release_
@@ -58,7 +65,7 @@
 
 ## Version 2021.1
 - 2021.1.0  (February 2021)
-  - docker tag: `latest`, `release-2021.1`, `release-2021.1.0`
+  - docker tag: `release-2021.1`, `release-2021.1.0`
   - original release
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -169,6 +169,8 @@ public class ServerParams {
     public static final String LOGOUT = "CmdLogout";
     public static final String TILE_SIZE = "tileSize";
     public static final String BACK_TO_URL= "backToUrl";
+    public static final String MASK_DATA= "maskData";
+    public static final String MASK_BITS= "maskBits";
 
     //Workspaces
     public static final String WS_LIST = "wsList"; // Gets the list of content/files

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
@@ -187,8 +187,10 @@ public class VisServerCommands {
         public void processRequest(HttpServletRequest req, HttpServletResponse res, SrvParam sp) throws Exception {
 
             PlotState state= sp.getState();
+            boolean mask= sp.getOptionalBoolean(ServerParams.MASK_DATA,false);
+            int maskBits= sp.getOptionalInt(ServerParams.MASK_BITS,0);
             int tileSize = sp.getRequiredInt(ServerParams.TILE_SIZE);
-            byte [] byte1D= VisServerOps.getByteStretchArray(state,tileSize);
+            byte [] byte1D= VisServerOps.getByteStretchArray(state,tileSize,mask,maskBits);
             res.setContentType("application/octet-stream");
 
             ByteBuffer byteBuf = ByteBuffer.wrap(byte1D);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -406,12 +406,12 @@ public class VisServerOps {
 
 
 
-    public static byte[] getByteStretchArray(PlotState state, int tileSize) {
+    public static byte[] getByteStretchArray(PlotState state, int tileSize, boolean mask, long maskBits) {
         try {
             long start = System.currentTimeMillis();
             ActiveCallCtx ctx = CtxControl.prepare(state);
             ActiveFitsReadGroup frGroup= ctx.getFitsReadGroup();
-            byte [] byte1d= DirectStretchUtils.getStretchData(state,frGroup,tileSize);
+            byte [] byte1d= DirectStretchUtils.getStretchData(state,frGroup,tileSize,mask, maskBits);
             long elapse = System.currentTimeMillis() - start;
             PlotServUtils.statsLog("byteAry",
                     "total-MB", (float)byte1d.length / StringUtils.MEG,

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterList.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/HiPSMasterList.java
@@ -195,7 +195,7 @@ public class HiPSMasterList extends EmbeddedDbProcessor {
         col.setWidth(4);
         col.setFilterable(false);
         col.setSortable(false);
-        col.setLinkInfos(Collections.singletonList(new LinkInfo(null, INFO_ICON_STUB, null, "link to HiPS properties", null, null, null)));
+        col.setLinkInfos(Collections.singletonList(new LinkInfo(null, INFO_ICON_STUB, "${Properties}", "link to HiPS properties", null, null, null)));
     }
 
     private static DataGroup createTableDataFromListEntry(List<HiPSMasterListEntry> hipsMaps) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
@@ -266,8 +266,22 @@ public class ImageData implements Serializable {
         return byteAry;
     }
 
+    public byte[] stretchMask(final float [] float1d, final int naxis1) {
+        byte [] byteAry= new byte[this.width * this.height];
+        byte blank_pixel_value = (byte) 255;
+        int[] pixelhist = new int[256];
+
+        ImageStretch.stretchPixelsForMask(x, lastPixel, y, lastLine, naxis1,
+                blank_pixel_value, float1d, byteAry, pixelhist, imageMasks);
+        return byteAry;
+    }
+
     public void stretch8bitAndSave(final float [] float1d, final Header header, final Histogram histogram) {
         this.saveStandardStretch = stretch8bit(float1d,header,histogram);
+    }
+
+    public void stretchMaskAndSave(final float [] float1d, final int naxis1) {
+        this.saveStandardStretch = stretchMask(float1d,naxis1);
     }
 
     public byte[] getSavedStandardStretch() { return this.saveStandardStretch; }

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -65,6 +65,8 @@ export const ServerParams = {
         SCROLL_Y: 'scrollY',
         ZOOM_FACTOR: 'zoomFactor',
         RANGE_VALUES: 'rangeValues',
+        MASK_DATA: 'maskData',
+        MASK_BITS: 'maskBits',
 
         EXT_TYPE: 'extType',
         IMAGE: 'image',

--- a/src/firefly/js/util/Color.js
+++ b/src/firefly/js/util/Color.js
@@ -45,7 +45,7 @@ function toRGBA(/* String */ color, /* Number */ alpha=1) {
     }
 }
 
-function toRGB(/* String */ color) {
+export function toRGB(/* String */ color) {
     if (color.startsWith('rgb')) {
         const intColor= toRGBA(color);
         intColor.length=3;

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -69,7 +69,7 @@ export const isOffscreenCanvas= (b) => getGlobalObj().OffscreenCanvas && (b inst
 
 export function createCanvas(width,height) {
     const global= getGlobalObj();
-    const c = global.document ? global.document.createElement('canvas') : new OffscreenCanvas(w,h);
+    const c = global.document ? global.document.createElement('canvas') : new OffscreenCanvas(width,height);
     c.width = width;
     c.height = height;
     return c;

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -939,8 +939,8 @@ export function dispatchUseTableAutoScroll(useAutoScroll) {
     flux.process({ type: USE_TABLE_AUTO_SCROLL, payload: {useAutoScroll} });
 }
 
-export function dispatchRequestLocalData({plotId, plotImageId, dataRequested=true}) {
-    flux.process({ type: REQUEST_LOCAL_DATA, payload: {plotId,plotImageId, dataRequested} });
+export function dispatchRequestLocalData({plotId, plotImageId, imageOverlayId, dataRequested=true}) {
+    flux.process({ type: REQUEST_LOCAL_DATA, payload: {plotId,plotImageId, dataRequested, imageOverlayId} });
 }
 
 /**

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -112,13 +112,29 @@ const rootStyle= {
     overflow:'hidden'
 };
 
-function getDataIfNecessary(pv) {
+function getPlotImageToRequest(pv) {
     const plot= primePlot(pv);
-    if (!plot || plot.dataRequested) return;
+    if (!plot) return undefined;
     const {viewDim:{width,height}}= pv;
-    if (!width || !height) return;
-    const {plotImageId,plotId}= plot;
-    dispatchRequestLocalData({plotId,plotImageId});
+    if (!width || !height) return undefined;
+    if (plot.dataRequested && !pv.overlayPlotViews?.length) return undefined;
+    if (!plot.dataRequested) return {plotImageId:plot.plotImageId};
+    if (pv.overlayPlotViews?.length) {
+        const overPv= pv.overlayPlotViews.find( (oPv) => oPv?.plot?.dataRequested===false);
+        if (!overPv) return undefined;
+        return {plotImageId:overPv.plot.plotImageId, imageOverlayId:overPv.imageOverlayId};
+    }
+    return undefined;
+
+}
+
+function getDataIfNecessary(pv) {
+    const result= getPlotImageToRequest(pv);
+    if (!result) return;
+    const plot= primePlot(pv);
+    if (!plot) return;
+    const {plotId}= plot;
+    dispatchRequestLocalData({plotId,plotImageId:result.plotImageId, imageOverlayId:result.imageOverlayId});
 }
 
 export class ImageViewerLayout extends PureComponent {

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -13,7 +13,7 @@ import {getWavelength, isWLAlgorithmImplemented, PLANE} from './projection/Wavel
 import {getNumberHeader, HdrConst} from './FitsHeaderUtil.js';
 import {computeDistance, getRotationAngle, isCsysDirMatching, isEastLeftOfNorth, isPlotNorth} from './VisUtil';
 import {removeRawData} from './rawData/RawDataCache.js';
-import {MAX_DIRECT_IMAGE_SIZE, MAX_RAW_IMAGE_SIZE} from './rawData/RawDataCommon.js';
+import {MAX_DIRECT_IMAGE_SIZE, MAX_DIRECT_MASK_IMAGE_SIZE, MAX_RAW_IMAGE_SIZE} from './rawData/RawDataCommon.js';
 import {hasClearedDataInStore, hasLocalRawDataInStore, hasLocalStretchByteDataInStore} from './rawData/RawDataOps.js';
 
 
@@ -227,7 +227,10 @@ export const getOverlayByPvAndId = (ref,plotId,imageOverlayId) =>
 
 
 
-export const removeRawDataByPlotView= (pv) => pv?.plots.forEach( (p) => removeRawData(p.plotImageId));
+export function removeRawDataByPlotView(pv) {
+    pv?.plots.forEach( (p) => removeRawData(p.plotImageId));
+    pv?.overlayPlotViews?.forEach( (oPv) => oPv?.plot?.plotImageId && removeRawData(oPv.plot.plotImageId) );
+}
 
 /**
  * construct an array of drawing layer from the store
@@ -1099,10 +1102,12 @@ export function canLoadStretchData(plot) {
     return (plot.dataWidth*plot.dataHeight) < MAX_RAW_IMAGE_SIZE;
 }
 
-export function canLoadStretchDataDirect(plot) {
+export function canLoadStretchDataDirect(plot, mask=false) {
     if (!plot || !isImage(plot)) return false;
     const size= (plot.dataWidth*plot.dataHeight);
-    return size<Math.min(MAX_RAW_IMAGE_SIZE,MAX_DIRECT_IMAGE_SIZE);
+    return mask ?
+        size<Math.min(MAX_RAW_IMAGE_SIZE,MAX_DIRECT_MASK_IMAGE_SIZE)  :
+        size<Math.min(MAX_RAW_IMAGE_SIZE,MAX_DIRECT_IMAGE_SIZE);
 }
 
 export function isAllStretchDataLoadable(vr) {

--- a/src/firefly/js/visualize/RelatedDataUtil.js
+++ b/src/firefly/js/visualize/RelatedDataUtil.js
@@ -171,7 +171,7 @@ function addMaskLayer(pv, maskNumber, hdu, fileKey, relatedData) {
     const title= makeMaskTitle(maskNumber, relatedData.availableMask);
 
     dispatchPlotMask({plotId:pv.plotId,
-        imageOverlayId:`${maskIdRoot}_#${maskNumber}_${maskCnt}`,
+        imageOverlayId:`${pv.plotId}-${maskIdRoot}_#${maskNumber}_${maskCnt}`,
         fileKey, maskNumber, maskValue:Math.pow(2,Number(maskNumber)),
         uiCanAugmentTitle:false, imageNumber:hdu, title,
         relatedDataId, lazyLoad:true});

--- a/src/firefly/js/visualize/rawData/RawDataCommon.js
+++ b/src/firefly/js/visualize/rawData/RawDataCommon.js
@@ -16,19 +16,20 @@ const abortControllers= new Map(); // map of imagePlotId and AbortController
 export const TILE_SIZE = 3000;
 export const MAX_RAW_IMAGE_SIZE = 400*MEG; // 400 megs
 export const MAX_DIRECT_IMAGE_SIZE= 250*K;
+export const MAX_DIRECT_MASK_IMAGE_SIZE= 200*MEG;
 const USE_GPU = true;
 
-async function populateRawTileDataArray(rawTileDataAry, colorModel, isThreeColor, bias, contrast, bandUse, rootUrl) {
+async function populateRawTileDataArray(rawTileDataAry, colorModel, isThreeColor, mask, maskColor, bias, contrast, bandUse, rootUrl) {
     const GPU = USE_GPU ? await getGpuJs(rootUrl) : undefined;
     const createTransitionalTile = USE_GPU ? getGPUOps(GPU).createTransitionalTileWithGPU : createTransitionalTileWithCPU;
-    const presult = rawTileDataAry.map((id) => createTransitionalTile(id, colorModel, isThreeColor, bias, contrast, bandUse));
+    const presult = rawTileDataAry.map((id) => createTransitionalTile(id, colorModel, isThreeColor, mask, maskColor, bias, contrast, bandUse));
     return await Promise.all(presult);
 }
 
-export async function populateRawImagePixelDataInWorker(rawTileDataGroup, colorTableId, isThreeColor, bias, contrast, bandUse, rootUrl) {
-    if (isGPUAvailableInWorker()) {
+export async function populateRawImagePixelDataInWorker(rawTileDataGroup, colorTableId, isThreeColor, mask, maskColor, bias, contrast, bandUse, rootUrl) {
+    if (isGPUAvailableInWorker() && !mask) {
         const colorModel = getColorModel(colorTableId);
-        const rawTileDataAry = await populateRawTileDataArray(rawTileDataGroup.rawTileDataAry, colorModel, isThreeColor, bias, contrast, bandUse, rootUrl);
+        const rawTileDataAry = await populateRawTileDataArray(rawTileDataGroup.rawTileDataAry, colorModel, isThreeColor,  mask, maskColor, bias, contrast, bandUse, rootUrl);
 
 
         const localRawTileDataGroup = {...rawTileDataGroup, rawTileDataAry, colorTableId};

--- a/src/firefly/js/visualize/rawData/RawDataThreadActionCreators.js
+++ b/src/firefly/js/visualize/rawData/RawDataThreadActionCreators.js
@@ -99,9 +99,12 @@ export function makeLoadAction(plot, band, workerKey) {
  * @param {WebPlot} plot
  * @param plotState
  * @param {String} workerKey
+ * @param {boolean} mask
+ * @param {number} maskBits
+ * @param {string} maskColor
  * @return {WorkerAction}
  */
-export function makeRetrieveStretchByteDataAction(plot, plotState, workerKey) {
+export function makeRetrieveStretchByteDataAction(plot, plotState, mask, maskBits, maskColor, workerKey) {
     const {plotImageId} = plot;
     const b = plot.plotState.firstBand();
     const {processHeader} = plot.rawData.bandData[b.value];
@@ -113,6 +116,9 @@ export function makeRetrieveStretchByteDataAction(plot, plotState, workerKey) {
         workerKey,
         payload: {
             plotImageId,
+            mask,
+            maskBits,
+            maskColor,
             dataWidth: plot.dataWidth,
             dataHeight: plot.dataHeight,
             plotStateSerialized: plotState.toJson(false),

--- a/src/firefly/js/visualize/rawData/RawFloatData.js
+++ b/src/firefly/js/visualize/rawData/RawFloatData.js
@@ -127,7 +127,7 @@ async function changeLocalRawDataStretch(plotImageId, dataWidth, dataHeight, plo
         plotState.bandStateAry[bIdx].rangeValuesSerialize = rv.toJSON();
     }
     const {retRawTileDataGroup, localRawTileDataGroup}=
-        await populateRawImagePixelDataInWorker(rawTileDataGroup, plotState.getColorTableId(), threeColor, .5, 1, rootUrl);
+        await populateRawImagePixelDataInWorker(rawTileDataGroup, plotState.getColorTableId(), threeColor, false, '', .5, 1, rootUrl);
     entry.rawTileDataGroup= localRawTileDataGroup;
 
 

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -110,7 +110,6 @@ export function reducer(state, action) {
             retState= zoomImage(state,action);
             break;
         case Cntlr.COLOR_CHANGE  :
-        case Cntlr.ZOOM_IMAGE  :
         case Cntlr.STRETCH_CHANGE  :
             retState= installTiles(state,action);
             break;
@@ -870,20 +869,49 @@ function addProcessedTileData(state,action) {
 }
 
 function updateRawImageData(state, action) {
-    const {plotId, plotImageId, rawData}= action.payload;
+    const {plotId, plotImageId, imageOverlayId, rawData}= action.payload;
     const pv= getPlotViewById(state,plotId);
     if (!pv) return state;
-    const plots= pv.plots.map( (p) => p.plotImageId===plotImageId ? {...p,rawData}: p);
-    const plotViewAry= replacePlotView(state.plotViewAry,{...pv,plots});
+    let updatedPv;
+
+    if (imageOverlayId) {
+        const overlayPlotViews= pv.overlayPlotViews?.map( (oPv) => {
+            if (oPv?.plot?.plotImageId!==plotImageId) return oPv;
+            oPv.plot= {...oPv.plot,rawData};
+            return oPv;
+        });
+        updatedPv= {...pv, overlayPlotViews};
+    }
+    else {
+        const plots= pv.plots.map( (p) => p.plotImageId===plotImageId ? {...p,rawData}: p);
+        updatedPv= {...pv,plots};
+    }
+
+    const plotViewAry= replacePlotView(state.plotViewAry,updatedPv);
     return {...state, plotViewAry};
 }
 
 function requestLocalData(state, action) {
-    const {plotImageId, plotId, dataRequested=true}= action.payload;
+    const {plotImageId, plotId, dataRequested=true, imageOverlayId}= action.payload;
     const pv= getPlotViewById(state,plotId);
     if (!pv) return state;
-    const plots= pv.plots.map( (p) => p.plotImageId===plotImageId ? {...p,dataRequested}: p);
-    const plotViewAry= replacePlotView(state.plotViewAry,{...pv,plots});
+    let updatedPv;
+    if (imageOverlayId) {
+        const overlayPlotViews= pv.overlayPlotViews.map( (oPv) => {
+            if (oPv?.plot?.plotImageId!==plotImageId) return oPv;
+            oPv.plot= {...oPv.plot,dataRequested};
+            return oPv;
+        });
+        updatedPv= {...pv, overlayPlotViews};
+    }
+    else {
+        const plots= pv.plots.map( (p) => p.plotImageId===plotImageId ? {...p,dataRequested}: p);
+        updatedPv= {...pv,plots};
+    }
+
+
+
+    const plotViewAry= replacePlotView(state.plotViewAry,updatedPv);
     return {...state, plotViewAry};
 }
 

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -10,7 +10,13 @@ import {
     getPlotViewById,
     operateOnOthersInOverlayColorGroup,
     getPlotStateAry,
-    isThreeColor, findPlot, canLoadStretchData, hasClearedByteData, hasLocalStretchByteData, hasLocalRawData
+    isThreeColor,
+    findPlot,
+    canLoadStretchData,
+    hasClearedByteData,
+    hasLocalStretchByteData,
+    hasLocalRawData,
+    getOverlayById
 } from '../PlotViewUtil.js';
 import {callCrop, callChangeColor, callRecomputeStretch} from '../../rpc/PlotServicesJson.js';
 import {WebPlotResult} from '../WebPlotResult.js';
@@ -34,9 +40,9 @@ import {Band} from '../Band.js';
 
 export function requestLocalDataActionCreator(rawAction) {
     return (dispatcher,getState) => {
-        const {plotId, plotImageId, dataRequested}=rawAction.payload;
+        const {plotId, plotImageId, dataRequested= true, imageOverlayId}=rawAction.payload;
         const pv= getPlotViewById(visRoot(),plotId);
-        const plot= findPlot(pv,plotImageId);
+        const plot= imageOverlayId ? getOverlayById(pv,imageOverlayId)?.plot : findPlot(pv,plotImageId);
         if (!canLoadStretchData(plot)) return;
         if (dataRequested===false) {
             dispatcher(rawAction);
@@ -45,8 +51,7 @@ export function requestLocalDataActionCreator(rawAction) {
         if (plot.dataRequested) return;
         dispatcher(rawAction);
         // loadRawData(plot,dispatcher);
-        // loadRawData(plot,dispatcher);
-        loadStretchData(plot,dispatcher);
+        loadStretchData(pv, plot,dispatcher);
     };
 }
 

--- a/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
@@ -158,7 +158,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
     const [useBlue,setUseBlue]= useState( () => plot?.rawData.useBlue);
     const threeColor= isThreeColor(plot);
 
-    const biasInt= isArray(bias) ? bias.map( (b) => Math.trunc(b*100))  : Math.trunc(bias*40);
+    const biasInt= isArray(bias) ? bias.map( (b) => Math.trunc(b*40))  : Math.trunc(bias*40);
     const contrastInt= isArray(contrast) ? contrast.map( (c) => Math.trunc(c*10)) : Math.trunc(contrast*10);
     const image= isImage(plot);
     const plotId= plot?.plotId;

--- a/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
@@ -257,7 +257,7 @@ function modifyMaskColor(opv) {
                     attributes:{colorAttributes,opacity:a}});
             });
 
-        });
+        }, '', '', .58);
 }
 
 function modifyShape(dl, plotId) {


### PR DESCRIPTION
### Firefly-810: Fixed mask not loading correctly when zooming

 - Change mask to use local data
 - Mask should be faster with smaller memory load, mask data compress to bits
 - Added transparency to the color palette of the color change dialog
 - Fixed: Firefly-819 (simple one line fix)
 - Fixed: Bias sliders not working in 3-color mode

#### Testing URL
https://fireflydev.ipac.caltech.edu/firefly-810-mask/firefly/

#### Testing Steps
1. Load a fits file with mask
2. Enable the mask and zoom up and down

#### Ticket(s)
https://jira.ipac.caltech.edu/browse/FIREFLY-810
https://jira.ipac.caltech.edu/browse/FIREFLY-819

