### PR TITLE
Firefly-823: Implement the file saving standard

### DIFF
--- a/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
+++ b/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
@@ -1,0 +1,79 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React from 'react';
+import {getWorkspaceConfig} from 'firefly/visualize/WorkspaceCntlr.js';
+import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
+import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
+import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr.js';
+import {isString} from 'lodash';
+import CompleteButton from 'firefly/ui/CompleteButton.jsx';
+import HelpIcon from 'firefly/ui/HelpIcon.jsx';
+import {FieldGroup} from 'firefly/ui/FieldGroup.jsx';
+import {ValidationField} from 'firefly/ui/ValidationField.jsx';
+import {downloadBlob, makeDefaultDownloadFileName} from 'firefly/util/fetch.js';
+
+
+const DIALOG_ID= 'plotDownloadDialog';
+
+export function showPlotLySaveDialog(Plotly, chartDiv, chartId) {
+    // if (fileLocation === WORKSPACE) dispatchWorkspaceUpdate(); //todo keep if we add workspace support, it probably goes somewhere else
+
+    const isWs = getWorkspaceConfig(); //todo - keep if we add workspace support
+    const  popup = (
+        <PopupPanel title={'Save Chart'}>
+                <PlotLySavePanel {...{Plotly, chartDiv, chartId, isWs, filename:getDefaultFilename(chartDiv,chartId)}}/>
+        </PopupPanel>
+    );
+    DialogRootContainer.defineDialog(DIALOG_ID, popup);
+    dispatchShowDialog(DIALOG_ID);
+}
+
+function generateTitleFromAxis(layout) {
+    const xaxis= layout.xaxis?.title?.text;
+    const yaxis= layout.yaxis?.title?.text;
+    return (isString(xaxis) || isString(yaxis)) ? `${isString(xaxis)?xaxis:''} ${isString(yaxis)?yaxis:''}` : undefined;
+}
+
+function getDefaultFilename(chartDiv)  {
+    const {layout}= chartDiv;
+    const title=  isString(layout.title) ? layout.title : layout.title?.text;
+    const axisTitle= generateTitleFromAxis(layout);
+    return makeDefaultDownloadFileName('chart',title??axisTitle,'png');
+}
+
+
+async function saveFile(request, Plotly, chartDiv) {
+    const filename= request.filename.toLowerCase().endsWith('.png') ? request.filename : request.filename+'.png';
+    const dataurl= await Plotly.toImage(chartDiv, {format: 'png'});
+    const blob = await (await window.fetch(dataurl)).blob();
+    downloadBlob(blob,filename);
+}
+
+
+const PlotLySavePanel= function( {isWs,Plotly, chartDiv, chartId, filename}) {
+    return (
+        <FieldGroup groupKey={'PlotLySaveField'} style={{display:'flex', flexDirection:'column'}}>
+            <div style={ {padding: 10}}>
+                <ValidationField
+                    wrapperStyle={{marginTop: 10}} size={50} fieldKey={'filename'}
+                    initialState= {{
+                        value: filename,
+                        tooltip: 'Enter filename of chart png',
+                        label: 'Chart Filename:',
+                        labelWidth: 80
+                    }} />
+            </div>
+            <div style={{textAlign:'center', display:'flex', justifyContent:'space-between', padding: '15px 15px 7px 8px'}}>
+                <div style={{display:'flex', justifyContent:'space-between'}}>
+                    <CompleteButton text='Save' dialogId={DIALOG_ID}
+                                    onSuccess={(request) => saveFile(request,Plotly, chartDiv, chartId)} />
+                    <CompleteButton text='Cancel' groupKey='' style={{paddingLeft:10}}
+                                    onSuccess={() => dispatchHideDialog(DIALOG_ID)} />
+                </div>
+                <HelpIcon helpId='charts.save' style={{display:'flex', alignItems:'center'}}/>
+            </div>
+        </FieldGroup>
+    );
+}

--- a/src/firefly/js/drawingLayers/ComputeWebGridData.js
+++ b/src/firefly/js/drawingLayers/ComputeWebGridData.js
@@ -103,7 +103,7 @@ export function makeGridDrawData (plot,  cc, useLabels, numOfGridLines=11){
     const centerWpt = convert(centerWp,csys);
 
 
-    if (width > 0 && height >0) {
+    if (centerWpt && width > 0 && height >0) {
         const bounds = new Rectangle(0, 0, width, height);
 
         const {xLines, yLines, labels} = plot.plotType==='hips'?computeHipGridLines(cc, csys,screenWidth, numOfGridLines, labelFormat,plot,fov, centerWpt)

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -673,6 +673,20 @@ export function toBoolean(val, def=undefined, trueList=['true']) {
  */
 export const replaceAll= (str, find, replace) => str.replace(new RegExp(find, 'g'), replace);
 
+
+/**
+ * replace or add and extension to a filename
+ * @param {string} filename
+ * @param {string} ext
+ * @return {string} the new filename
+ */
+export function replaceExt(filename='unknown-file',ext) {
+    if (filename.endsWith('.'+ext)) return filename;
+    const idx= filename.lastIndexOf('.');
+    return (idx>-1) ? filename.substring(0,idx)+'.'+ext : filename+'.'+ext;
+}
+
+
 /**
  * return true if val is 'true' or 'false' case-insensitive
  * @param val the string value to check.

--- a/src/firefly/js/util/fetch.js
+++ b/src/firefly/js/util/fetch.js
@@ -2,6 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {isPlainObject, truncate} from 'lodash';
+import slug from 'slug';
 import {getOrCreateWsConn} from '../core/messaging/WebSocketClient.js';
 import {ServerParams} from '../data/ServerParams.js';
 import {showInfoPopup} from '../ui/PopupUtil.jsx';
@@ -124,4 +125,26 @@ export async function download(url, filename) {
     } catch ({message}) {
         showInfoPopup(truncate(message, {length: 200}), 'Unexpected error');
     }
+}
+
+
+/**
+ * create the default download filename
+ * @param {String} root - should be one of 'image', 'HiPS', 'table', 'chart'  (we can add to this list as appropriate)
+ * @param {String} [title] - the title associated with the visualizer, if falsy then the name is build without a title
+ * @param {String} [ext] - the extensionn (without the dot). i.e. 'fits', 'png', 'cvs', etc
+ * @return {string}
+ */
+export function makeDefaultDownloadFileName(root= 'unknown', title='', ext= 'png') {
+    const MAX_SAVE_FILE_LENGTH= 50;
+    const DOT_SUB= 'DOTDOTDOTDOTDOT';
+    const US_SUB= 'UNDERSCOREUNDERSCOREUNDERSCORE';
+    const dotExt= '.'  + ext;
+    const base= title ? `${root}_${title}` : root;
+    let filename=  (base.length<=MAX_SAVE_FILE_LENGTH) ? base : base.substring(0,MAX_SAVE_FILE_LENGTH);
+    filename= filename.toLowerCase().endsWith(dotExt) ? filename.substring(0,filename.length-dotExt.length) : filename;
+    const tmpF= filename.replaceAll('.',DOT_SUB).replaceAll('_',US_SUB);
+    const slugTmpF= slug(tmpF, {lower:false});
+    filename= slugTmpF.replaceAll(DOT_SUB, '.').replaceAll(US_SUB,'_');
+    return filename+dotExt;
 }

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -112,6 +112,7 @@ export function getLatDist(lat1,lat2) {
  * @return {WorldPt} the world point in the new coordinate system
  */
 export function convert(wpt, to= CoordinateSys.EQ_J2000) {
+    if (wpt) return;
     const from = wpt.getCoordSys();
     if (!to || from===to) return wpt;
 

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -238,7 +238,7 @@ async function makeHiPSPlot(rawAction, dispatcher) {
         const resolvedHipsRootUrl= await resolveHiPSIvoURL(wpRequest.getHipsRootUrl());
         if (currentPlots[plotId]!==requestKey) {
             // hipsFail('hips plot expired or aborted');
-            console.log('hips plot expired or aborted');
+            // console.log('hips plot expired or aborted');
             return;
         }
         dispatcher( { type: ImagePlotCntlr.PLOT_IMAGE_START,payload:newPayload} );
@@ -262,7 +262,7 @@ async function makeHiPSPlot(rawAction, dispatcher) {
         }
         if (currentPlots[plotId]!==requestKey) {
             // hipsFail('hips plot expired or aborted');
-            console.log('hips plot expired or aborted');
+            // console.log('hips plot expired or aborted');
             return;
         }
         plot= await addAllSky(plot);


### PR DESCRIPTION
### Firefly-823: Implement the file saving standard 

 - standard is referenced in the ticket
 - created a utility function for the standard: makeDefaultDownloadFileName in fetch.js

_Test build_: https://fireflydev.ipac.caltech.edu/firefly-823-save-files/firefly/
_Ticket_: https://jira.ipac.caltech.edu/browse/FIREFLY-823

#### Testing
_It is very important to look at the ticket first to understand what was implemented_

Save the following types of files:

Charts
- save a file from chart using the default
- save a file from chart using another name
- add a title and save a chart

Tables
- save a file from table using the defaults
- change the type and save
- edit the name then change the type and save

Images
- save a image or region or png using the default
- change the default then change the type and save
- save a three color
- save a three color but change the band first
- save a three color but change the name then change the band
- save a three color png.