### PR TITLE
Firefly-827: add example for TargetPanel and Tap Panel to appOptions

### DIFF
--- a/src/firefly/html/firefly-dev.html
+++ b/src/firefly/html/firefly-dev.html
@@ -32,6 +32,8 @@
                     {id: 'vocat'},
                     {id: 'nedcat'}
                 ],
+                targetPanelExampleRow1: [`'m82'`, `'ngc 12'`, `'12.22 34.222`, `'46.222-0.222 gal'`],
+                targetPanelExampleRow2: [`'19h22m22s 11d22m22s equ j2000'`],
                 MenuItemKeys: {maskOverlay:true},
                 catalogSpacialOp: 'polygonWhenPlotExist',
                 workspace : {showOptions: true},

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -115,7 +115,7 @@ const defAppProps = {
     ],
 };
 
-const tapEntry= (label,url) => ({ label, value: url});
+const tapEntry= (label,url,examples) => ({ label, value: url, examples});
 
 /** @type {FireflyOptions} */
 const defFireflyOptions = {
@@ -168,22 +168,7 @@ const defFireflyOptions = {
         },
     },
     tap : {
-        services: [
-            tapEntry('IRSA', 'https://irsa.ipac.caltech.edu/TAP'),
-            tapEntry('NED', 'https://ned.ipac.caltech.edu/tap/'),
-            tapEntry('NASA Exoplanet Archive', 'https://exoplanetarchive.ipac.caltech.edu/TAP/'),
-            tapEntry('KOA', 'https://koa.ipac.caltech.edu/TAP/'),
-            tapEntry('HEASARC', 'https://heasarc.gsfc.nasa.gov/xamin/vo/tap'),
-            tapEntry('MAST Images', 'https://vao.stsci.edu/CAOMTAP/TapService.aspx'),
-            tapEntry('CADC', 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap'),
-            // CDS???
-            tapEntry('VizieR (CDS)', 'http://tapvizier.u-strasbg.fr/TAPVizieR/tap/'),
-            tapEntry('Simbad (CDS)', 'https://simbad.u-strasbg.fr/simbad/sim-tap'),
-            // more ESA??
-            tapEntry('Gaia', 'https://gea.esac.esa.int/tap-server/tap'),
-            tapEntry('GAVO', 'http://dc.g-vo.org/tap'),
-            tapEntry('HSA',  'https://archives.esac.esa.int/hsa/whsa-tap-server/tap'),
-        ],
+        services: getTAPServices(),
         defaultMaxrec: 50000
     }
 };
@@ -280,6 +265,58 @@ export const firefly = {
     bootstrap
 };
 
+/* eslint-disable  quotes */
+function getTAPServices() {
+    return [
+        tapEntry('IRSA', 'https://irsa.ipac.caltech.edu/TAP',
+            [
+                {
+                    description: 'From the IRSA TAP service, a 1 degree cone search of the 2MASS point source catalog around M101 would be:',
+                    statement: `SELECT * FROM fp_psc WHERE CONTAINS(POINT('J2000', ra, dec), CIRCLE('J2000', 210.80225, 54.34894, 1.0)) = 1;`
+                },
+                {
+                    description: 'From the IRSA TAP service, a .25 degree cone search of the 2MASS point source catalog around M31 would be:',
+                    statement: `SELECT * FROM fp_psc WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE('ICRS', 10.684, 41.269, .25))=1`
+                },
+                {
+                    description: 'From the IRSA TAP service, a triangle search of the AllWISE point source catalog around M101 would be:',
+                    statement: `SELECT designation, ra, dec, w2mpro FROM allwise_p3as_psd WHERE CONTAINS (POINT('J2000' , ra , dec) , 
+                                                                    POLYGON('J2000' , 209.80225 , 54.34894 , 209.80225 , 55.34894 , 210.80225 , 54.34894))=1`,
+                }
+            ]
+        ),
+        tapEntry('NED', 'https://ned.ipac.caltech.edu/tap/'),
+        tapEntry('NASA Exoplanet Archive', 'https://exoplanetarchive.ipac.caltech.edu/TAP/'),
+        tapEntry('KOA', 'https://koa.ipac.caltech.edu/TAP/'),
+        tapEntry('HEASARC', 'https://heasarc.gsfc.nasa.gov/xamin/vo/tap'),
+        tapEntry('MAST Images', 'https://vao.stsci.edu/CAOMTAP/TapService.aspx'),
+        tapEntry('CADC', 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap'),
+        // CDS???
+        tapEntry('VizieR (CDS)', 'http://tapvizier.u-strasbg.fr/TAPVizieR/tap/'),
+        tapEntry('Simbad (CDS)', 'https://simbad.u-strasbg.fr/simbad/sim-tap'),
+        // more ESA??
+        tapEntry('Gaia', 'https://gea.esac.esa.int/tap-server/tap',
+                [
+                    {
+                        description: 'From the Gaia TAP service, a .25 degree cone search Gaia data release 3 point source catalog around M31 would be:',
+                        statement: `SELECT * FROM gaiaedr3.gaia_source WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE('ICRS', 10.684, 41.269, .25))=1`
+                    },
+                    {
+                        description: 'From the Gaia TAP service, a 1 degree by 1 degree box of the Gaia data release 3 point source catalog around M101 would be:',
+                        statement: `SELECT * FROM gaiaedr3.gaia_source WHERE CONTAINS(POINT('ICRS', ra, dec), BOX('ICRS', 210.80225, 54.34894, 1.0, 1.0))=1`
+                    },
+                    {
+                        description: 'From the Gaia TAP service, a triangle search of of the Gaia data release 3 point source catalog around M101 would be:',
+                        statement: `SELECT source_id, designation, ra, dec, phot_g_mean_mag FROM gaiaedr3.gaia_source WHERE CONTAINS (POINT('ICRS' , ra , dec) , 
+                                                                            POLYGON('ICRS' , 209.80225 , 54.34894 , 209.80225 , 55.34894 , 210.80225 , 54.34894))=1`,
+                    }
+                ]
+        ),
+        tapEntry('GAVO', 'http://dc.g-vo.org/tap'),
+        tapEntry('HSA',  'https://archives.esac.esa.int/hsa/whsa-tap-server/tap'),
+    ];
+
+}
 
 
 /**

--- a/src/firefly/js/ui/TargetFeedback.jsx
+++ b/src/firefly/js/ui/TargetFeedback.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
 
 const topDivStyle= {
     paddingTop: 5,
@@ -7,30 +8,35 @@ const topDivStyle= {
     textAlign : 'center'
 };
 
-const titleStyle= {
-    display : 'inline-block',
-    verticalAlign: 'top'
+const defExampleEntries= {
+    /* eslint-disable-next-line quotes */
+    row1: [`'m81'`, `'ngc 18'`, `'12.34 34.89'`, `'46.53 -0.251 gal'`],
+    /* eslint-disable-next-line quotes */
+    row2: [ `'19h17m32s 11d58m02s equ j2000'`,`'12.3 8.5 b1950'`,`'J140258.51+542318.3'`]
+    };
+
+const defaultExamples= () => {
+    const row1Op= getAppOptions()?.targetPanelExampleRow1 ?? defExampleEntries.row1;
+    const row2Op= getAppOptions()?.targetPanelExampleRow2 ?? defExampleEntries.row2;
+    return (
+        <div style={{ display : 'inline-block', lineHeight : '1.2em'}}>
+            {row1Op?.map( (s,idx) => <span key={s} style={{paddingLeft: (idx===0) ? 5 : 15}}>{s}</span> )}
+            <br/>
+            {row2Op?.map( (s,idx) => <span key={s} style={{paddingLeft: (idx===0) ? 5 : 15}}>{s}</span> )}
+        </div>
+        );
 };
 
-const makeSpan= (w) => <span style={{paddingLeft: w}}/>;
-
-const defaultExamples = (
-    <div style={{ display : 'inline-block', lineHeight : '1.2em'}}>
-        {makeSpan(5)} 'm81' {makeSpan(15)} 'ngc 18' {makeSpan(15)}  '12.34 34.89'  {makeSpan(15)} '46.53 -0.251 gal'
-        <br/>
-        {makeSpan(5)}'19h17m32s 11d58m02s equ j2000' {makeSpan(5)}  '12.3 8.5 b1950' {makeSpan(5)} 'J140258.51+542318.3'
-    </div>);
-
-export function TargetFeedback ({showHelp, feedback, style={}, examples={}}) {
+export function TargetFeedback ({showHelp, feedback, style={}, examples}) {
     const topStyle= {...topDivStyle, ...style};
-    if (!showHelp) return <div style={topStyle}> <span dangerouslySetInnerHTML={{ __html : feedback }}/> </div>
+    if (!showHelp) return (<div style={topStyle}> <span dangerouslySetInnerHTML={{ __html : feedback }}/> </div>);
     return (
         <div style={topStyle}>
             <div>
-                <div style={titleStyle}>
+                <div style={{display : 'inline-block', verticalAlign: 'top'}}>
                     <i>Examples: </i>
                 </div>
-                {{...defaultExamples, ...examples}}
+                {examples ?? defaultExamples()}
             </div>
         </div>
     );

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -22,7 +22,13 @@ import {dispatchHideDropDown} from 'firefly/core/LayoutCntlr.js';
 import {tableColumnsConstraints} from 'firefly/ui/tap/TableColumnsConstraints.jsx';
 import {skey, tableSearchMethodsConstraints} from 'firefly/ui/tap/TableSearchMethods.jsx';
 import {commonSelectStyles, selectTheme} from 'firefly/ui/tap/Select.jsx';
-import {getMaxrecHardLimit, getTapBrowserState, tapHelpId, TAP_SERVICES_FALLBACK} from 'firefly/ui/tap/TapUtil.js';
+import {
+    getMaxrecHardLimit,
+    getTapBrowserState,
+    tapHelpId,
+    TAP_SERVICES_FALLBACK,
+    getTapServices
+} from 'firefly/ui/tap/TapUtil.js';
 import { gkey, SectionTitle, AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
 
 
@@ -250,18 +256,7 @@ function populateAndEditAdql(inAdql) {
     );
 }
 
-const hasElements= (a) => Boolean(isArray(a) && a?.length);
-const getTapServiceOptions= () => getTapServices().map(({label,value})=>({label:value, value, labelOnly:label}));
-
-function getTapServices() {
-    const tapServices = getAppOptions()?.tap?.services;
-    const additionalServices = getAppOptions()?.tap?.additional?.services;
-    const retVal= hasElements(tapServices) ? [...tapServices] : [...TAP_SERVICES_FALLBACK];
-    hasElements(additionalServices) && retVal.unshift(...additionalServices);
-    webApiUserAddedService && retVal.push(webApiUserAddedService);
-    return retVal;
-}
-
+const getTapServiceOptions= () => getTapServices(webApiUserAddedService).map(({label,value})=>({label:value, value, labelOnly:label}));
 
 function onTapSearchSubmit(request,serviceUrl) {
     const isADQL = (request.selectBy === 'adql');


### PR DESCRIPTION
### Firefly-827: add example for TargetPanel and Tap Panel to appOptions

  - target panel is now settable by two appOptions targetPanelExampleRow1, targetPanelExampleRow2, you can see this in `firefly-dev.html`
  - TAP panel examples are now settable by service, You can see this in `Firefly.js`

_test build:_ https://fireflydev.ipac.caltech.edu/firefly-827-examples/firefly/
_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-827

#### Testing

1. TAP panel adql - there are specific examples when the service is IRSA or Gaia otherwise it is the default example.
2. https://fireflydev.ipac.caltech.edu/firefly-827-examples/firefly/firefly-dev.html - notice that the target panel examples are different. 
