### PR TITLE
FIREFLY-829: Input fields inside a table is not being re-rendered correctly

### DIFF
--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -340,7 +340,10 @@ export const CellWrapper =  React.memo( (props) => {
 }, skipCellRender);
 
 function skipCellRender(prev={}, next={}) {
-    return prev.width === next.width &&
+    const {width, colIdx, rowIndex} = prev;
+    const {width:nwidth, colIdx:ncolIdx, rowIndex:nrowIndex} = next;
+
+    return width === nwidth && colIdx === ncolIdx && rowIndex === nrowIndex &&
         getCellInfo(prev)?.text === getCellInfo(next)?.text;
 }
 

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -461,6 +461,7 @@ export const createInputCell = (tooltips, size = 10, validator, onChange, style)
             return (
                 <div style={{padding: '0 2px 0 2px', marginTop:'-2px'}}>
                     <InputField
+                        key={rowIndex + '-' +colIdx}
                         validator={(v) => validator(v, data, rowIndex, colIdx)}
                         tooltip={tooltips}
                         size={size}
@@ -497,6 +498,7 @@ export const inputColumnRenderer = ({tbl_id, cname, tooltips, style={}, isReadOn
             return (
                 <div style={{...style}}>
                     <InputField
+                        key={rowIndex + '-' +colIdx}
                         validator={ validator && ((v) => validator(v, data, rowIndex, colIdx))}
                         tooltip={tooltips}
                         style={{width: '100%', boxSizing: 'border-box', ...style}}

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -79,24 +79,21 @@ export function showHiPSSurverysPopup(pv=visRoot()) {
             dispatchHideDialog(dialogId);
         }
     };
-
     const popup = (
         <PopupPanel title={'Change HiPS Image'} modal={true}>
-            <div className='ImageSearch__HipsPopup'>
-                <FormPanel  submitBarStyle = {{flexShrink: 0, padding: '0 19px 3px 6px'}}
-                            groupKey = {groupKey}
-                            submitText={'Search'}
-                            onSubmit = {onSubmit}
-                            onCancel = {() => dispatchHideDialog(dialogId)}
-                            help_id = 'visualization.changehips'>
-                    <FieldGroup className='flex-full' style={{height: '100%'}} groupKey={groupKey} keepState={true}>
+            <FormPanel  submitBarStyle = {{flexShrink: 0, padding: '0 6px 3px 6px'}}
+                        groupKey = {groupKey}
+                        submitText={'Search'}
+                        onSubmit = {onSubmit}
+                        onCancel = {() => dispatchHideDialog(dialogId)}
+                        help_id = 'visualization.changehips'>
+                <FieldGroup groupKey={groupKey} keepState={true}>
+                    <div className='ImageSearch__HipsPopup'>
                         <SourceSelect/>
-                        <div style={{flexGrow: 1}}>
-                            <HiPSSurveyTable groupKey={groupKey}/>
-                        </div>
-                    </FieldGroup>
-                </FormPanel>
-            </div>
+                        <HiPSSurveyTable groupKey={groupKey}/>
+                    </div>
+                </FieldGroup>
+            </FormPanel>
         </PopupPanel>
     );
 
@@ -173,8 +170,12 @@ function HiPSSurveyTable({groupKey}) {
     }, [sources]);
 
     return (
-        <TablePanel key={activeHipsTblId} tbl_id={activeHipsTblId} tbl_ui_id={activeHipsTblId+'-ui'}
-                    {...{showToolbar: false, selectable:false, showFilters:true, showOptionButton: true}}/>
+        <div style={{flexGrow: 1, width: '100%', position: 'relative'}}>
+            <div style={{position: 'absolute', top:0, bottom:0, left:0, right:0}}>
+                <TablePanel key={activeHipsTblId} tbl_id={activeHipsTblId} tbl_ui_id={activeHipsTblId+'-ui'}
+                        {...{showToolbar: false, selectable:false, showFilters:true, showOptionButton: true}}/>
+            </div>
+        </div>
     );
 
 

--- a/src/firefly/js/ui/ImageSelect.css
+++ b/src/firefly/js/ui/ImageSelect.css
@@ -35,7 +35,7 @@
     flex-grow: 0;
     background-color: #f5f5f5;
     height: 36px;
-    min-height: 15px;
+    min-height: 36px;
     padding: 3px 6px;
     display: flex;
     flex-direction: column;

--- a/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
+++ b/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
@@ -159,11 +159,8 @@ function reorganizeTableModel(tableModel, columnNames, reset) {
         }, []));
     });
 
-    // set column widths
-    const widths = calcColumnWidths(columns, data);
-    columns.forEach((col, idx) => {
-        col.prefWidth = Math.min(widths[idx]+2, 55);
-    });
+    // width is often the declared max char in database; remove it, TablePanel will auto-size it
+    columns.forEach((col) => Reflect.deleteProperty(col, 'width'));
 
     // add constraints column
     const constraintsColIdx = 1;

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.css
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.css
@@ -60,4 +60,6 @@
     min-width: 400px;
     min-height: 350px;
     resize: both;
+    display: flex;
+    flex-direction: column;
 }

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -273,8 +273,8 @@ function ThreeColor({imageMasterData, multiSelect, archiveName, noScroll}) {
     return (
         <div className='flex-full' style={{marginTop: 5}}>
             <StatefulTabs componentKey='ImageSearchPanelV2' resizable={false} useFlex={true} borderless={true}
-                  style={{flexGrow: 1}}
-                  contentStyle={{backgroundColor: 'rgb(202, 202, 202)', paddingBottom: 2}}
+                  style={{flexGrow: 1, overflow: 'unset'}}
+                  contentStyle={{backgroundColor: 'rgb(202, 202, 202)', paddingBottom: 2, overflow: 'unset'}}
                   headerStyle={{display:'inline-flex', marginLeft: 185}}>
                 <Tab key='ImageSearchRed' name='red' label={<div style={{width:40, color:'red'}}>Red</div>}>
                     <SingleChannel {...{key: FG_KEYS.red, groupKey: FG_KEYS.red, imageMasterData, multiSelect, archiveName, noScroll}}/>
@@ -403,7 +403,7 @@ function SelectArchive({groupKey,  imageMasterData, multiSelect, isHipsImgType, 
             </div>
             {isHips ?
                 <HiPSImageSelect groupKey={groupKey} /> :
-                <div className='ImageSearch__section' style={{ display: 'flex', flexDirection: 'column', padding: 'unset', flexShrink: 1, flexGrow: 1}}>
+                <div className='ImageSearch__section' style={{ display: 'flex', flexDirection: 'column', padding: 'unset', flexGrow: 1}}>
                     <div className='ImageSearch__section--title'>4. Select Data Set</div>
                     <ImageSelect style={{flexGrow: 1, width: '100%'}} key={`ImageSelect_${groupKey}`} {...{groupKey, title, addChangeListener, imageMasterData, multiSelect, scrollDivId: !noScroll && scrollDivId}} />
                 </div>


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-829
- Input fields inside a table fail to re-render due to bad comparator
- fix Image Search not rendering correctly in Safari
- fix HiPS table not rendering correctly when pop-up in Safari
- fix Image Search 3-color not rendering correctly in Safari

Also:
- auto-size TAP column constraints

Test:
https://fireflydev.ipac.caltech.edu/firefly-829-client-table-bug/firefly/

Make sure to test all 4 bug fixes in all browsers.
Also, I changed the TAP `Column Selection` table to auto-size the column's width.  In my opinion, it looks a lot better.  But, if CCB does not like it, it's easy to undo.
