### PR TITLE
Default Spatial Target with proper Errors validation

### DIFF
--- a/src/firefly/js/ui/tap/ObsCore.jsx
+++ b/src/firefly/js/ui/tap/ObsCore.jsx
@@ -185,19 +185,21 @@ export function ObsCoreSearch({cols, groupKey, fields, useConstraintReducer}) {
         const constraintsResult = makeConstraints(fields, fieldsValidity, panelActive);
         updatePanelFields(constraintsResult.fieldsValidity, constraintsResult.valid, fields, newFields, panelValue, panelPrefix);
         if (isPanelChecked(panelValue, panelPrefix, newFields)) {
-            if (constraintsResult.valid){
-                if (constraintsResult.adqlConstraint?.length > 0){
+            if (constraintsResult.valid) {
+                if (constraintsResult.adqlConstraint?.length > 0) {
                     adqlConstraint = constraintsResult.adqlConstraint;
                 } else {
                     adqlConstraintErrors.push(`Unknown error processing ${panelValue} constraints`);
                 }
-                if  (constraintsResult.siaConstraints?.length > 0){
+                if (constraintsResult.siaConstraints?.length > 0) {
                     siaConstraints.push(...constraintsResult.siaConstraints);
                 }
-                if  (constraintsResult.siaConstraintErrors?.length > 0){
+                if (constraintsResult.siaConstraintErrors?.length > 0) {
                     siaConstraintErrors.push(...constraintsResult.siaConstraintErrors);
                 }
-            } else if (!constraintsResult.adqlConstraint) {
+            } else {
+                const firstMessage = Array.from(constraintsResult.fieldsValidity.values()).find((v) => !v.valid)?.message;
+                adqlConstraintErrors.push(`Error processing ${panelValue} constraints: ${firstMessage}`);
                 logger.warn(`invalid ${panelValue} adql constraints`);
             }
         }
@@ -214,7 +216,7 @@ export function ObsCoreSearch({cols, groupKey, fields, useConstraintReducer}) {
     return (
         <FieldGroupCollapsible header={<Header title={panelTitle} helpID={tapHelpId(panelPrefix)}
                                                checkID={`${panelPrefix}Check`} panelValue={panelValue} message={message}/>}
-                               initialState={{value: 'closed'}}
+                               initialState={{value: 'open'}}
                                fieldKey={`${panelPrefix}SearchPanel`}
                                wrapperStyle={{marginBottom: 15}}
                                headerStyle={HeaderFont}
@@ -457,7 +459,9 @@ export function ExposureDurationSearch({cols, groupKey, fields, useConstraintRed
                 if (constraintsResult.siaConstraints?.length > 0) {
                     siaConstraints.push(...constraintsResult.siaConstraints);
                 }
-            } else if (!constraintsResult.adqlConstraint) {
+            } else {
+                const firstMessage = Array.from(fieldsValidity.values()).find((v) => !v.valid)?.message;
+                adqlConstraintErrors.push(`Error processing ${panelValue} constraints: ${firstMessage}`);
                 logger.warn(`invalid ${panelValue} adql constraints`);
             }
         }
@@ -845,7 +849,9 @@ export function ObsCoreWavelengthSearch({cols, groupKey, fields, useConstraintRe
                 if (constraintsResult.siaConstraints?.length > 0) {
                     siaConstraints.push(...constraintsResult.siaConstraints);
                 }
-            } else if (!constraintsResult.adqlConstraint) {
+            } else {
+                const firstMessage = Array.from(fieldsValidity.values()).find((v) => !v.valid)?.message;
+                adqlConstraintErrors.push(`Error processing ${panelValue} constraints: ${firstMessage}`);
                 logger.warn(`invalid ${panelValue} adql constraints`);
             }
         }

--- a/src/firefly/js/ui/tap/TableSearchHelpers.jsx
+++ b/src/firefly/js/ui/tap/TableSearchHelpers.jsx
@@ -202,6 +202,7 @@ export const updatePanelFields = (fieldsValidity, valid, fields, newFields, pane
         const panelValid = get(fields, [panelFieldKey, 'panelValid'], false);
         for (const [key, validity] of fieldsValidity.entries()) {
             newFields[key].validity = validity;
+            newFields[key].message = validity.message;
             if (has(newFields[key], 'nullAllowed')) {
                 newFields[key].nullAllowed = !panelActive;
                 newFields[key].valid = panelActive ? validity.valid : true;

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -260,7 +260,7 @@ function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCo
     useEffect(() => {
         const centerColObj = formCenterColumns(columnsModel);
         // we have ra+dec columns and it's not obsCore
-        if (centerColObj.lon.length && centerColObj.lat.length && !obsCoreEnabled){
+        if (centerColObj.lon.length && centerColObj.lat.length || obsCoreEnabled){
             dispatchValueChange({...{value: panelValue}, fieldKey: `${panelPrefix}Check`, groupKey});
         } else {  // no ra+dec columns
             dispatchValueChange({...{value: ''}, fieldKey: `${panelPrefix}Check`, groupKey});

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -257,6 +257,19 @@ function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCo
         });
     }, []);
 
+    useEffect(() => {
+        const centerColObj = formCenterColumns(columnsModel);
+        // we have ra+dec columns and it's not obsCore
+        if (centerColObj.lon.length && centerColObj.lat.length && !obsCoreEnabled){
+            dispatchValueChange({...{value: panelValue}, fieldKey: `${panelPrefix}Check`, groupKey});
+        } else {  // no ra+dec columns
+            dispatchValueChange({...{value: ''}, fieldKey: `${panelPrefix}Check`, groupKey});
+        }
+        dispatchValueChange({...{validator: getColValidator(cols, false, false), value: centerColObj.lon, valid: true}, fieldKey: CenterLonColumns, groupKey});
+        dispatchValueChange({...{validator: getColValidator(cols, false, false), value: centerColObj.lat, valid: true}, fieldKey: CenterLatColumns, groupKey});
+        dispatchValueChange({...{value: columnsModel.tbl_id}, fieldKey: CrtColumnsModel, groupKey});
+    }, [columnsModel, obsCoreEnabled]);
+
     const onChange = (inFields, action, rFields) => {
         const {fieldKey, value} = action.payload;
 
@@ -383,7 +396,7 @@ function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCo
                                cols={cols}
                                name={getLabel(CenterLatColumns).toLowerCase()} // label that appears in column chooser
                                inputStyle={{overflow:'auto', height:12, width: Width_Column}}
-                               initValue={centerColObj.lat}
+
                                tooltip={'Center latitude column for spatial search'}
                                label={getLabel(CenterLatColumns, ':')}
                                labelWidth={SpatialLableSaptail}
@@ -990,16 +1003,8 @@ function buildTapSearchMethodReducer(columnsModel) {
             const onResetColumnsTable = () => {
                 const cols = getAvailableColumns(columnsModel);
                 set(rFields, [CrtColumnsModel, 'value'], columnsModel.tbl_id );
-                const centerColObj = formCenterColumns(columnsModel);
-                Object.assign(rFields[CenterLonColumns],
-                                       {validator: getColValidator(cols, false, false), value: centerColObj.lon, valid: true});
-                Object.assign(rFields[CenterLatColumns],
-                                       {validator: getColValidator(cols, false, false), value: centerColObj.lat, valid: true});
-
                 Object.assign(rFields[TemporalColumns],
                                         {validator: getColValidator(cols, false, false), value: '', valid: true});
-
-                // validateTemporalConstraints(inFields, rFields);
             };
 
 

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -238,11 +238,10 @@ export const TableSearchMethods = FunctionalTableSearchMethods;
 function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCoreEnabled, useConstraintReducer, useFieldGroupReducer}) {
     const panelTitle = !obsCoreEnabled ? Spatial : 'Location';
     const panelValue = Spatial;
-    const panelPrefix = getPanelPrefix(panelTitle);
+    const panelPrefix = getPanelPrefix(panelValue);
     const {POSITION:worldPt, radiusInArcSec}= initArgs;
     const [spatialMethod, setSpatialMethod] = useState(TapSpatialSearchMethod.Cone.value);
     const [spatialRegionOperation, setSpatialRegionOperation] = useState('contains_shape');
-    const centerColObj = formCenterColumns(columnsModel);
     const [message, setMessage] = useState();
 
     // useEffect(() => {
@@ -308,13 +307,14 @@ function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCo
                 if (constraintsResult.adqlConstraint?.length > 0){
                     adqlConstraint = constraintsResult.adqlConstraint;
                 } else {
-                    adqlConstraintErrors.push(`Unknown error processing ${panelValue} constraints`);
+                    adqlConstraintErrors.push(`Unknown error processing ${panelTitle} constraints`);
                 }
                 if  (constraintsResult.siaConstraints?.length > 0){
                     siaConstraints.push(...constraintsResult.siaConstraints);
                 }
-            } else if (!constraintsResult.adqlConstraint) {
-                logger.warn(`invalid ${panelValue} adql constraints`);
+            } else {
+                const firstMessage = Array.from(constraintsResult.fieldsValidity.values()).find((v) => !v.valid)?.message;
+                adqlConstraintErrors.push(`Error processing ${panelTitle} constraints: ${firstMessage}`);
             }
         }
         return {
@@ -371,7 +371,7 @@ function SpatialSearch({cols, columnsModel, groupKey, fields, initArgs={}, obsCo
                            cols={cols}
                            name={getLabel(CenterLonColumns).toLowerCase()} // label that appears in column chooser
                            inputStyle={{overflow:'auto', height:12, width: Width_Column}}
-                           initValue={centerColObj.lon}
+
                            tooltip={'Center longitude column for spatial search'}
                            label={getLabel(CenterLonColumns, ':')}
                            labelWidth={SpatialLableSaptail}
@@ -439,6 +439,7 @@ SpatialSearch.propTypes = {
  */
 function TemporalSearch({cols, columnsModel, groupKey, fields, useConstraintReducer, useFieldGroupReducer}) {
     const panelTitle = Temporal;
+    const panelValue = panelTitle;
     const panelPrefix = getPanelPrefix(panelTitle);
     const [message, setMesage] = useState();
 
@@ -551,17 +552,19 @@ function TemporalSearch({cols, columnsModel, groupKey, fields, useConstraintRedu
         const constraintsResult = makeTemporalConstraints(fields, columnsModel, newFields);
         updatePanelFields(constraintsResult.fieldsValidity, constraintsResult.valid, fields, newFields, panelTitle, panelPrefix);
         if (isPanelChecked(panelTitle, panelPrefix, newFields)) {
-            if (constraintsResult.valid){
-                if (constraintsResult.adqlConstraint?.length > 0){
+            if (constraintsResult.valid) {
+                if (constraintsResult.adqlConstraint?.length > 0) {
                     adqlConstraint = constraintsResult.adqlConstraint;
                 } else {
                     adqlConstraintErrors.push(`Unknown error processing ${panelTitle} constraints`);
                 }
-                if  (constraintsResult.siaConstraints?.length > 0){
+                if (constraintsResult.siaConstraints?.length > 0) {
                     siaConstraints.push(...constraintsResult.siaConstraints);
                 }
-            } else if (!constraintsResult.adqlConstraint) {
-                logger.warn(`invalid ${panelTitle} adql constraints`);
+            } else {
+                const firstMessage = Array.from(constraintsResult.fieldsValidity.values()).find((v) => !v.valid)?.message;
+                adqlConstraintErrors.push(`Error processing ${panelTitle} constraints: ${firstMessage}`);
+                logger.warn(`invalid ${panelValue} adql constraints`);
             }
         }
         return {
@@ -746,12 +749,14 @@ function makeSpatialConstraints(fields, columnsModel, newFields) {
         const fieldValidity = fieldsValidity.get(ServerParams.USER_TARGET_WORLD_PT);
         const worldPt = parseWorldPt(get(fields, [ServerParams.USER_TARGET_WORLD_PT, 'value']));
         let newWpt = {};
-        if (worldPt){
-            newWpt = convert(worldPt, worldSys);
-        } else {
-            // Point wasn't actually valid
-            fieldValidity.valid = false;
-            fieldValidity.message = 'no target found';
+        if (fieldValidity.valid){
+            if (worldPt){
+                newWpt = convert(worldPt, worldSys);
+            } else {
+                // Point wasn't actually valid
+                fieldValidity.valid = false;
+                fieldValidity.message = 'no target found';
+            }
         }
         return {...newWpt, ...fieldValidity};
     };
@@ -965,7 +970,11 @@ export function tableSearchMethodsConstraints(columnsModel) {
     const fields = FieldGroupUtils.getGroupFields(skey);
     const {constraintResults} = fields;
     if (constraintResults){
-        return {valid: true, where: constraintResults.adqlConstraints.join(' AND ')};
+        return {
+            valid: constraintResults.adqlConstraintErrors?.length === 0,
+            messages: constraintResults.adqlConstraintErrors,
+            where: constraintResults.adqlConstraints.join(' AND ')
+        };
     }
     return {valid: true};
 }

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -320,6 +320,8 @@ function getAdqlQuery(showErrors= true) {
     // spatial and temporal constraints
     const whereFragment = tableSearchMethodsConstraints(columnsModel);
     if (!whereFragment.valid) {
+        const firstMessage = whereFragment.messages[0];
+        showInfoPopup(firstMessage, 'Error');
         return null;
     }
     let constraints = whereFragment.where || '';


### PR DESCRIPTION
Fixes validation issues in TAP panel, both the error messages themselves and the bubbling up of those errors.

This adds the following logic to the UI when switching between tables:

• If ra/dec columns are identified in a table, ~and the table is NOT an ObsCore table~ or the table is an ObsCore table, then preselect the Spatial dropdown requiring a target in the TAP panel
• If you switch to a table without ra/dec, deselect Spatial dropdown when switching tables.
~• If you switch to ObsCore table (which does have an ra/dec), deselect "Spatial" Dropdown (same widget but it has a different title)~

The last case exists because we don't necessarily expect ra/dec to be the primary way to search an ObsCore table.