### PR TITLE
DM-30780: Fix ivoa.ObsCore detection

### DIFF
--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -75,6 +75,7 @@ function useStateRef(initialState){
 export function BasicUI(props) {
     const tapFluxState = getTapBrowserState();
     const [error, setError] = useState(undefined);
+    const mountedRef = useRef(false);
     const [serviceUrl, serviceUrlRef, setServiceUrl] = useStateRef(tapFluxState.serviceUrl || props.serviceUrl);
     const [schemaName, schemaRef, setSchemaName] = useStateRef(tapFluxState.schemaName || props.initArgs.schema);
     const [tableName, tableRef, setTableName] = useStateRef(tapFluxState.tableName || props.initArgs.table);
@@ -102,6 +103,9 @@ export function BasicUI(props) {
         // update state for higher level components that might rely on obsCoreTables
 
         loadTapSchemas(requestServiceUrl).then((tableModel) => {
+            if (!mountedRef.current) {
+                return;
+            }
             if (serviceUrlRef.current !== requestServiceUrl) {
                 // stale request which won't reflect UI state if processed
                 return;
@@ -137,6 +141,9 @@ export function BasicUI(props) {
         dispatchValueChange({groupKey: gkey, fieldKey: 'tableName', value: undefined});
 
         loadTapTables(requestServiceUrl, requestSchemaName).then((tableModel) => {
+            if (!mountedRef.current) {
+                return;
+            }
             if (serviceUrlRef.current !== requestServiceUrl || schemaRef.current !== requestSchemaName){
                 // Processing a stale request - skip
                 return;
@@ -165,6 +172,9 @@ export function BasicUI(props) {
         setColumnsModel(undefined);
         //dispatchValueChange({groupKey: gkey, fieldKey: 'columnsModel', value: undefined});
         loadTapColumns(requestServiceUrl, requestSchemaName, requestTableName).then((columnsModel) => {
+            if (!mountedRef.current) {
+                return;
+            }
             if (serviceUrlRef.current !== requestServiceUrl || schemaRef.current !== requestSchemaName || tableRef.current !== requestTableName){
                 // processing a stale request
                 return;
@@ -178,11 +188,16 @@ export function BasicUI(props) {
                 tableName: requestTableName, tableOptions, columnsModel, obsCoreEnabled: matchesObsCore});
         });
     };
+
     useEffect(() => {
+        mountedRef.current = true;
         // properties changes due to changes in TapSearchPanel
         if(props.serviceUrl !== serviceUrl) {
             setServiceUrl(props.serviceUrl);
         }
+        return () => {
+            mountedRef.current = false;
+        };
     });
 
     useEffect(() => {

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -27,7 +27,9 @@ import {
     getTapBrowserState,
     tapHelpId,
     TAP_SERVICES_FALLBACK,
-    getTapServices
+    getTapServices,
+    loadObsCoreSchemaTables,
+    updateTapBrowserState
 } from 'firefly/ui/tap/TapUtil.js';
 import { gkey, SectionTitle, AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
 
@@ -98,11 +100,11 @@ export function TapSearchPanel({initArgs= {}, titleOn=true}) {
     const tapOps= getTapServiceOptions();
     const {current:clickFuncRef} = useRef({clickFunc:undefined});
     const [selectBy, setSelectBy]= useState('basic');
-    const [obsCoreTables, setObsCoreTables] = useState();
+    const [obsCoreTableModel, setObsCoreTableModel] = useState();
     const [serviceUrl, setServiceUrl]= useState(() => getInitServiceUrl(initArgs,tapOps));
     activateInitArgsAdqlOnce(initArgs);
 
-    const obsCoreEnabled = obsCoreTables?.length > 0;
+    const obsCoreEnabled = obsCoreTableModel?.tableData?.data?.length > 0;
 
     const onTapServiceOptionSelect= (selectedOption) => {
         if (!selectedOption) return;
@@ -113,14 +115,13 @@ export function TapSearchPanel({initArgs= {}, titleOn=true}) {
             ]
         );
         setServiceUrl(selectedOption.value);
-        setObsCoreTables(undefined);
+        setObsCoreTableModel(undefined);
     };
 
     useEffect(() => {
         return FieldGroupUtils.bindToStore( gkey, (fields) => {
             setSelectBy(getFieldVal(gkey,'selectBy',selectBy));
-            const obsCoreTables = getTapBrowserState().obsCoreTables;
-            setObsCoreTables(obsCoreTables);
+            setObsCoreTableModel(getTapBrowserState().obsCoreTableModel);
             searchFromAPIOnce( () => validateAutoSearch(fields,initArgs), () => setTimeout(() => clickFuncRef.clickFunc?.(), 5));
         });
     }, []);
@@ -165,10 +166,12 @@ const makePlaceHolderBeforeStyle= (l) =>
 
 
 
-function TapSearchPanelComponents({initArgs, serviceUrl, onTapServiceOptionSelect, tapOps, titleOn=true, selectBy, obsCoreEnabled}) {
+function TapSearchPanelComponents({initArgs, serviceUrl, onTapServiceOptionSelect, tapOps, titleOn=true, selectBy}) {
 
     const label= (serviceUrl && (tapOps.find( (e) => e.value===serviceUrl)?.labelOnly)) || '';
     const placeholder = serviceUrl ? `${serviceUrl} - Replace...` : 'Select TAP...';
+    const [obsCoreTableModel, setObsCoreTableModel] = useState();
+    const hasObsCoreTable = obsCoreTableModel?.tableData?.data?.length > 0;
 
     const tableSelectStyleEnhanced= {
         ...tableSelectStyleEnhancedTemplate,
@@ -180,17 +183,34 @@ function TapSearchPanelComponents({initArgs, serviceUrl, onTapServiceOptionSelec
         {label: 'Edit ADQL (advanced)', value: 'adql', tooltip: 'Enter or edit directly an ADQL query; supports complex queries including JOINs'}
     ];
 
-    if (obsCoreEnabled) {
+    if (hasObsCoreTable) {
         options.push({label: 'Image Search (ObsTAP)', value: 'obscore', tooltip: 'Search the ObsTAP image metadata on this service with a specialized GUI query builder'});
     }
 
     let queryTypeEpilogue = '';
     if (selectBy === 'obscore') {
+        let obsCoreTableName = 'ivoa.ObsCore';
+        if (hasObsCoreTable){
+            obsCoreTableName = obsCoreTableModel?.tableData?.data[0][1];
+        }
         // This component does not know the actual name of the table, but it is guaranteed
         // that name.toLowerCase() === 'ivoa.ObsCore'.toLowerCase()
         queryTypeEpilogue =
-            <div style={{display: 'inline-flex', marginTop: '4px'}}>(Searching the <pre style={{margin: '0px .5em'}}>ivoa.ObsCore</pre> table on this service...)</div>;
+            <div style={{display: 'inline-flex', marginTop: '4px'}}>(Searching the <pre style={{margin: '0px .5em'}}>{obsCoreTableName}</pre> table on this service...)</div>;
     }
+
+    const loadObsCoreTables = (requestServiceUrl) => {
+        loadObsCoreSchemaTables(requestServiceUrl).then((tableModel) => {
+            setObsCoreTableModel(tableModel);
+            // Update state early for ObsCore support
+            // we'll still have to wait for loadTables and loadColumns
+            updateTapBrowserState({obsCoreTableModel: tableModel});
+        });
+    };
+
+    useEffect(() => {
+        loadObsCoreTables(serviceUrl);
+    }, [serviceUrl]);
 
     return (
         <FieldGroup groupKey={gkey} keepState={true} style={{flexGrow: 1, display: 'flex'}}>
@@ -219,7 +239,7 @@ function TapSearchPanelComponents({initArgs, serviceUrl, onTapServiceOptionSelec
                     />
                     {queryTypeEpilogue}
                 </div>
-                {(selectBy === 'basic' || selectBy === 'obscore') && <BasicUI  serviceUrl={serviceUrl} selectBy={selectBy} initArgs={initArgs}/>}
+                {(selectBy === 'basic' || selectBy === 'obscore') && <BasicUI  serviceUrl={serviceUrl} selectBy={selectBy} initArgs={initArgs} obsCoreTableModel={obsCoreTableModel}/>}
                 {selectBy === 'adql' && <AdqlUI serviceUrl={serviceUrl}/>}
             </div>
         </FieldGroup>

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -29,16 +29,16 @@ export const tapHelpId = (id) => `tapSearches.${id}`;
 
 export function getTapBrowserState() {
     const tapBrowserState = getComponentState(tapBrowserComponentKey);
-    const {serviceUrl, schemaOptions, schemaName, tableOptions, tableName, columnsModel, obsCoreEnabled, obsCoreTables} = tapBrowserState || {};
-    return {serviceUrl, schemaOptions, schemaName, tableOptions, tableName, columnsModel, obsCoreEnabled, obsCoreTables};
+    const {serviceUrl, schemaOptions, schemaName, tableOptions, tableName, columnsModel, obsCoreEnabled, obsCoreTableModel} = tapBrowserState || {};
+    return {serviceUrl, schemaOptions, schemaName, tableOptions, tableName, columnsModel, obsCoreEnabled, obsCoreTableModel};
 }
 
 export function setTapBrowserState({serviceUrl, schemaOptions=undefined, schemaName=undefined,
                                        tableOptions=undefined, tableName=undefined, columnsModel=undefined,
-                                       obsCoreEnabled= false, obsCoreTables=undefined}) {
+                                       obsCoreEnabled= false, obsCoreTableModel=undefined}) {
     dispatchComponentStateChange(tapBrowserComponentKey,
         {serviceUrl, schemaOptions, schemaName, tableOptions, tableName, columnsModel,
-            obsCoreEnabled, obsCoreTables});
+            obsCoreEnabled, obsCoreTableModel});
 }
 
 export function updateTapBrowserState(updates) {
@@ -83,7 +83,7 @@ export function loadTapSchemas(serviceUrl) {
 
 export function loadObsCoreSchemaTables(serviceUrl) {
 
-    const url = serviceUrl + qFragment + 'QUERY=SELECT+s.schema_name,+t.table_name+FROM+TAP_SCHEMA.schemas+s+JOIN+TAP_SCHEMA.tables+t+on+(s.schema_name=t.schema_name)+JOIN+TAP_SCHEMA.columns+c+on+(t.table_name=c.table_name+and+c.column_name+in+(\'s_region\',+\'t_min\',+\'t_max\',+\'em_min\',+\'em_max\',+\'calib_level\',+\'dataproduct_type\',+\'obs_collection\'))+GROUP+BY+s.schema_name,+t.table_name+HAVING+count(c.column_name)=8';
+    const url = serviceUrl + qFragment + 'QUERY=SELECT+s.schema_name,+t.table_name+FROM+TAP_SCHEMA.schemas+s+JOIN+TAP_SCHEMA.tables+t+on+(s.schema_name=t.schema_name)+WHERE+s.schema_name=\'ivoa\'+AND+t.table_name+IN+(\'ivoa.obscore\',\'ivoa.ObsCore\')';
     const request = makeFileRequest('schemas', url, null, {pageSize: MAX_ROW});
 
     return doFetchTable(request).then((tableModel) => {


### PR DESCRIPTION
This makes a number of changes to improve ivoa.obscore detection and handling:

1. Rewrite query to go by table name 'ivoa.ObsCore' or 'ivoa.obscore' instead of columns, which also makes it so that the obscore-like tables are no longer considered for the radio button UI ( MAST in particular was not happy with column detection query). It seems like the two hardcoded names are most reliable (rather than relying on a lower casing function in ADQL to be implemented, which isn't guaranteed).
2. This pulls up async detection logic out of BasicUI to the parent component so that the radio button works better when advanced ADQL editor is selected (and also helps with a complicated timing issue). 

