### PR TITLE
Fix reducermap registration/deregistration

### DIFF
--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -148,16 +148,15 @@ function useConstraintReducer(component, constraintReducer, watchFields) {
             return constraintResult;
         }
         constraintReducers.adqlReducerMap.set(component, reduceQuery);
-        return () => {
-            constraintReducers.adqlReducerMap.delete(component);
-        };
-    });
 
-    useEffect(() => {
-        return FieldGroupUtils.bindToStore(skey, (fields) => {
+        const storeListener = FieldGroupUtils.bindToStore(skey, (fields) => {
             const constraintResults = get(fields, [fieldName]);
             setConstraintResult(constraintResults);
         });
+        return () => {
+            storeListener();
+            constraintReducers.adqlReducerMap.delete(component);
+        };
     }, []);
 
     const deps = watchFields || [];


### PR DESCRIPTION
This fixes some useEffect hooks to do things on component mount/unmount, instead of every time.