### PR TITLE
FIREFLY-732_custom_JSON_parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fixed-data-table-2": "~1.2",
     "prismjs": "~1.22",
     "blissfuljs": "~1.0",
-    "json-bigint-patch": "^0.0.4"
+    "json-bigint": "git://github.com/Caltech-IPAC/json-bigint.git"
   },
   "devDependencies": {
     "@babel/core": "~7.8",

--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -631,12 +631,6 @@ public class JsonTableUtil {
 
         if (obj instanceof Date) {
             return () -> "\"" + JSON_DATE.format(obj) + "\"";
-        } else if (obj instanceof Double) {
-            double d = (Double) obj;
-            long l = (long)d;
-            if (d == l) {
-                return () -> String.format("%d", l);      //  when BigInt(> 9.0e+15) is written in scientific notation, parsing will fail.  Use decimal format instead.
-            }
         }
         return null;
     }

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -4,7 +4,6 @@
  */
 
 import 'isomorphic-fetch';
-import 'json-bigint-patch';         // patch JSON parse/stringify to recognize bigint
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {set, defer, once} from 'lodash';

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -33,6 +33,11 @@ const SELECTION_INFO = 'selectionInfo';
 //TODO: convert FileStatus
 
 
+const doBigIntRequest = (cmd, params) => {
+    return doJsonRequest(ServerParams.TABLE_SEARCH, params, true, true);
+};
+
+
 /**
  * tableRequest will be sent to the server as a json string.
  * @param {TableRequest} tableRequest is a table request params object
@@ -56,7 +61,7 @@ export function fetchTable(tableRequest, hlRowIdx) {
         [ServerParams.REQUEST]: JSON.stringify(tableRequest),
     };
 
-    return doJsonRequest(ServerParams.TABLE_SEARCH, params)
+    return doBigIntRequest(ServerParams.TABLE_SEARCH, params)
     .then( (tableModel) => {
         const startIdx = get(tableModel, 'request.startIdx', 0);
         if (startIdx > 0) {
@@ -95,7 +100,7 @@ export function fetchTable(tableRequest, hlRowIdx) {
 export function queryTable(tableRequest, {filters, sortInfo, inclCols}) {
 
     const params = Object.assign(pickBy({filters, sortInfo, inclCols}), {[ServerParams.REQUEST]: JSON.stringify(tableRequest)});
-    return doJsonRequest(ServerParams.QUERY_TABLE, params)
+    return doBigIntRequest(ServerParams.QUERY_TABLE, params)
         .then( (index) => {
             return index;
         });
@@ -112,7 +117,7 @@ export function queryTable(tableRequest, {filters, sortInfo, inclCols}) {
 export function selectedValues({columnNames, request, selectedRows}) {
     columnNames = Array.isArray(columnNames) ? columnNames.join() : String(columnNames);
     selectedRows = Array.isArray(selectedRows) ? selectedRows.join() : String(selectedRows);
-    return doJsonRequest(ServerParams.SELECTED_VALUES, {columnNames, request: JSON.stringify(request), selectedRows})
+    return doBigIntRequest(ServerParams.SELECTED_VALUES, {columnNames, request: JSON.stringify(request), selectedRows})
             .then((tableModel) => {
                 return tableModel;
             });
@@ -146,7 +151,7 @@ export function packageRequest(dlRequest, searchRequest, selectionInfo) {
         [SELECTION_INFO]: selectionInfo
     };
 
-    return doJsonRequest(ServerParams.PACKAGE_REQUEST, params);
+    return doBigIntRequest(ServerParams.PACKAGE_REQUEST, params);
 }
 
 
@@ -159,7 +164,7 @@ export function getJsonData(request) {
     const paramList = [];
     paramList.push({name:ServerParams.REQUEST, value: request.toString()});
 
-    return doJsonRequest(ServerParams.JSON_DATA, paramList
+    return doBigIntRequest(ServerParams.JSON_DATA, paramList
     ).then((data) => {return data; });
 }
 
@@ -186,7 +191,7 @@ export function submitBackgroundSearch(request, clientRequest, waitMillis) {
     };
     clientRequest && (params[ServerParams.CLIENT_REQUEST] = JSON.stringify(clientRequest));
 
-    return doJsonRequest(ServerParams.SUB_BACKGROUND_SEARCH, params);
+    return doBigIntRequest(ServerParams.SUB_BACKGROUND_SEARCH, params);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,6 +1521,10 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
 
+bignumber.js@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -4135,9 +4139,11 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-bigint-patch@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/json-bigint-patch/-/json-bigint-patch-0.0.4.tgz#9c1cb80ec364fa685061e1afb7abcc9a7fb6f6f0"
+"json-bigint@git://github.com/Caltech-IPAC/json-bigint.git":
+  version "1.0.0"
+  resolved "git://github.com/Caltech-IPAC/json-bigint.git#ea685899db7444edda1af4836b73e45ec45cc1ac"
+  dependencies:
+    bignumber.js "^9.0.0"
 
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
ticket: 
- https://jira.ipac.caltech.edu/browse/FIREFLY-732

test: 
- https://fireflydev.ipac.caltech.edu/firefly-732-custom-json-parser/firefly/
- https://firefly-732-custom-json-parser.irsakudev.ipac.caltech.edu/applications/sofia/


- fork json-bigint to fix its inability to handle scientific notation and long decimal.
- add flag to allow JSON with bigint support only if requested.
- rollback chart's support for bigint as it's not applicable

JSON parsing with BigInt support is limited to only a few Table's calls where it expects original table data with BigInt.
Although, JSON.stringify with BigInt support is available, it need to explicitly request it.

Fork of json-bigint is here: https://github.com/Caltech-IPAC/json-bigint
