### PR TITLE
IRSA-4233: Add shared.work.directory concept to GWT codebase

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/FitsUpload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/FitsUpload.java
@@ -37,7 +37,7 @@ public class FitsUpload extends BaseHttpServlet {
 
     protected void processRequest(HttpServletRequest req, HttpServletResponse res) throws Exception {
 
-        File dir= ServerContext.getVisUploadDir();
+        File dir= ServerContext.getUploadDir();
         File uploadedFile= getUniqueName(dir);
 
         String overrideKey= req.getParameter("cacheKey");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/FitsCacher.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/FitsCacher.java
@@ -78,7 +78,7 @@ public class FitsCacher {
                         } catch (FitsException e) {
                             File dir= fitsFile.getParentFile();
                             if ( dir.equals(ServerContext.getVisCacheDir()) ||      // if in cache or upload dir, rename the file
-                                    dir.equals(ServerContext.getVisUploadDir()) ) {
+                                    dir.equals(ServerContext.getUploadDir()) ) {
                                 String newF= fitsFile.getAbsolutePath()+"--bad-file";
                                 fitsFile.renameTo(new File(newF));
                                 FitsException newE= new FitsException("bad fits file renamed to: "+newF);


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-4233

When the concept of `shared.work.directory` was introduced in 2018, it was not implemented in GWT.  As a result, GWT based applications are writing all of the 'shared' work files into its local filesystem and are not accessible by other instances of the same app.

Also:
- init stats.log.dir on start up as needed

@robyww  This is more like a FYI.  I don't expect you test it.
