### PR TITLE
FIREFLY-862: add unit to the hover text when the unit is converted for the chart

### DIFF
--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -162,11 +162,9 @@ export function addScatterChanges({changes, chartId, traceNum, tablesource, tabl
     const {mappings} = tablesource;
     const {layout, data, fireflyData} = getChartData(chartId) || {};
     const xColumn = getColumn(tableModel, stripColumnNameQuotes(get(mappings, 'x')));
-    const xUnit = get(xColumn, 'units', '') ||
-                  get(fireflyData, `${traceNum}.xUnit`, '');
+    const xUnit = xColumn?.units || fireflyData?.[traceNum]?.xUnit || '';
     const yColumn = getColumn(tableModel, stripColumnNameQuotes(get(mappings, 'y')));
-    const yUnit = get(yColumn, 'units', '') ||
-                  get(fireflyData, `${traceNum}.yUnit`, '');
+    const yUnit = yColumn?.units || fireflyData?.[traceNum]?.yUnit || '';
 
     // default axes labels for the first trace (remove surrounding quotes, if any)
     const xLabel = stripColumnNameQuotes(get(mappings, 'x'));


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-862

test: 
https://fireflydev.ipac.caltech.edu/firefly-862-unit-suffix-spectrum-chart/firefly/
please upload the votable sample attached to above ticket, 
and check if the tooltip shows the number with unit suffix when the wavelength unit is changed from the 'chart options and tools' panel. 
