### PR TITLE
Firefly-874: only read cube planes as user request them.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/CtxControl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/CtxControl.java
@@ -164,7 +164,7 @@ public class CtxControl {
         ctx.setPlotState(state);
         ctx.setPlot(plot);
         putPlotCtx(ctx);
-        PlotServUtils.createThumbnail(plot, frGroup, images, true, state.getThumbnailSize());
+        if (images!=null) PlotServUtils.createThumbnail(plot, frGroup, images, true, state.getThumbnailSize());
         state.setNewPlot(false);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -331,9 +331,13 @@ public class ImagePlotCreator {
         long fileLength= (f!=null && f.canRead()) ? f.length() : 0;
         FitsRead fr=  frGroup.getFitsReadAry()[band.getIdx()];
         if (fr==null) return null;
-        Histogram hist= fr.getHistogram();
-        double dataMin= hist.getDNMin() * fr.getBscale() + fr.getBzero();
-        double dataMmax= hist.getDNMax() * fr.getBscale() + fr.getBzero();
+        double dataMin= Double.NaN;
+        double dataMmax= Double.NaN;
+        if (!fr.isDeferredRead()) {
+            Histogram hist= fr.getHistogram();
+            dataMin= hist.getDNMin() * fr.getBscale() + fr.getBzero();
+            dataMmax= hist.getDNMax() * fr.getBscale() + fr.getBzero();
+        }
         return new WebFitsData( dataMin, dataMmax, fileLength, fr.getFluxUnits());
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/PlotClientCtx.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/PlotClientCtx.java
@@ -68,6 +68,7 @@ public class PlotClientCtx implements Serializable {
 
     public PlotImages getImages() { return _images.get(); }
     public void setImages(PlotImages images) {
+        if (images==null) return;
         _images.getAndSet(images);
         updateAccessTime();
         _allImagesList.add(images);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -52,10 +52,14 @@ public class VisJsonSerializer {
             map.put("originalFitsFileStr", wpHeader.getOriginalFitsFileStr());
             if (wpHeader.getUploadFileNameStr()!=null) map.put("uploadFileNameStr", wpHeader.getUploadFileNameStr());
             if (wpHeader.isThreeColor()) map.put("threeColor", wpHeader.isThreeColor());
+            if (wpHeader.getRangeValuesSerialized()!=null) map.put("rangeValuesSerialize", wpHeader.getRangeValuesSerialized());
             map.put("plotRequestSerialize", wpHeader.getRequest().toString());
             map.put("dataDesc", wpHeader.getDataDesc());
             map.put("zeroHeaderAry", serializeHeaderAry(wpHeader.getZeroHeaderAry()));
+            if (wpHeader.isMultiImageFile()) map.put("multiImageFile", wpHeader.isMultiImageFile());
+            map.put("multiImage", wpHeader.getMultiImage().name());
             if (wpHeader.getAttributes()!=null) map.put("attributes", new JSONObject(wpHeader.getAttributes()));
+            map.put("colorTableId", wpHeader.getColorTableId());
         }
         return map;
     }
@@ -259,7 +263,7 @@ public class VisJsonSerializer {
 
 
         // don't pass if defaulted
-        if (s.getMultiImageAction()!=PlotState.MultiImageAction.GUESS) map.put("multiImage", s.getMultiImageAction().toString());
+        if (s.getMultiImageAction()!=null && s.getMultiImageAction()!=PlotState.MultiImageAction.GUESS) map.put("multiImage", s.getMultiImageAction().toString());
         if (!Double.isNaN(s.getRotationAngle())) map.put("rotationAngle", s.getRotationAngle());
         if (s.getRotateType()!=PlotState.RotateType.UNROTATE) map.put("rotationType", s.getRotateType().toString());
         if (s.getRotateNorthType()!=CoordinateSys.EQ_J2000) map.put("rotaNorthType", s.getRotateNorthType().toString());
@@ -394,7 +398,7 @@ public class VisJsonSerializer {
         if (b.isTileCompress()) map.put("tileCompress", b.isTileCompress());
         if (b.getCubeCnt()>0) map.put("cubeCnt", b.getCubeCnt());
         if (b.getCubePlaneNumber()>0) map.put("cubePlaneNumber", b.getCubePlaneNumber());
-        map.put("rangeValuesSerialize", b.getRangeValuesSerialized());
+        if (b.getRangeValuesSerialized()!=null) map.put("rangeValuesSerialize", b.getRangeValuesSerialized());
         return map;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotReader.java
@@ -47,52 +47,6 @@ public class WebPlotReader {
     }
 
 
-// Unused code commented out 3/5/2019 - keep around for awhile
-//    /**
-//     * @param fd file data
-//     * @param req WebPlotRequest from the search, usually the first
-//     * @return the ReadInfo[] object
-//     * @throws java.io.IOException        any io problem
-//     * @throws nom.tam.fits.FitsException problem reading the fits file
-//     * @throws edu.caltech.ipac.util.download.FailedRequestException any other problem
-//     * @throws GeomException problem reprojecting
-//     */
-//    public static Map<Band, FileReadInfo[]> processFitsRead(FileInfo fd, WebPlotRequest req, FitsRead fitsRead, int imageIdx)
-//            throws IOException,
-//                   FitsException,
-//                   FailedRequestException,
-//                   GeomException {
-//
-//        FileReadInfo retval;
-//
-//        File originalFile = fd.getFile();
-//        String uploadedName= null;
-//        if (ServerContext.isInUploadDir(originalFile) || originalFile.getName().startsWith("upload_")) {
-//            uploadedName= fd.getDesc();
-//        }
-//
-//        ModFileWriter modFileWriter= null;
-//        if (req!=null) {
-//            WebPlotPipeline.PipelineRet pipeRet= WebPlotPipeline.applyPipeline(req, fitsRead, imageIdx, Band.NO_BAND, originalFile);
-//            if (pipeRet.modFileWriter!=null && fitsRead!=pipeRet.fr) {
-//                modFileWriter= pipeRet.modFileWriter;
-//                FitsCacher.addFitsReadToCache(modFileWriter.getTargetFile(), new FitsRead[]{pipeRet.fr});
-//                fitsRead= pipeRet.fr;
-//            }
-//        }
-//        modFileWriter= checkUnzip(imageIdx,Band.NO_BAND,originalFile, modFileWriter);
-//
-//        retval= new FileReadInfo(originalFile, fitsRead, Band.NO_BAND, imageIdx,
-//                                 fd.getDesc(), uploadedName, null, modFileWriter);
-//
-//        Map<Band, FileReadInfo[]> retMap= new HashMap<>(1);
-//        retMap.put(Band.NO_BAND, new FileReadInfo[] {retval});
-//
-//        return retMap;
-//    }
-
-
-
 
     /**
      * @param fd file data

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsEvaluation.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsEvaluation.java
@@ -46,7 +46,7 @@ public class FitsEvaluation {
             File fitsFile= uFitsInfo!=null ? uFitsInfo.getFile() : f;
             BasicHDU<?>[]  workingHDUS= uFitsInfo!=null ? uFitsInfo.getHDUs() : HDUs;
             if (workingHDUS.length==0) throw new FitsException("Bad format in FITS file, no HDUs found");
-            FitsRead[] frAry = FitsReadFactory.createFitsReadArray(workingHDUS, clearHdu);
+            FitsRead[] frAry = FitsReadFactory.createFitsReadArray(workingHDUS, f, clearHdu);
             FitsDataEval fitsDataEval= new FitsDataEval(frAry,fitsFile);
             if (workingHDUS.length >1) { // Do evaluation
                 for(int i= 0; i<frAry.length; i++) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/PlotState.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/PlotState.java
@@ -88,18 +88,20 @@ public class PlotState {
         return (bandAry!=null && bandAry.length>0) ? getBands()[0] : null;
     }
 
+    Band[] NO_BAND_ARY= new Band[] {Band.NO_BAND};
+
     public Band[] getBands() {
         if (usedBands ==null || usedBands.length==0) {
-            List<Band> bands= new ArrayList<Band>(3);
             if (threeColor) {
+                List<Band> bands= new ArrayList<Band>(3);
                 if (get(Band.RED).hasRequest())   bands.add(Band.RED);
                 if (get(Band.GREEN).hasRequest()) bands.add(Band.GREEN);
                 if (get(Band.BLUE).hasRequest())  bands.add(Band.BLUE);
+                usedBands = bands.toArray(new Band[bands.size()]);
             }
             else {
-                bands.add(Band.NO_BAND);
+                usedBands= NO_BAND_ARY;
             }
-            usedBands = bands.toArray(new Band[bands.size()]);
         }
         return usedBands;
     }
@@ -366,16 +368,16 @@ public class PlotState {
         }
     }
 
-// =====================================================================
-// -------------------- private Methods --------------------------------
-// =====================================================================
 
-    private BandState get(Band band) {
+    public BandState get(Band band) {
         int idx= band.getIdx();
         if (bandStateAry[idx]==null) bandStateAry[idx]= new BandState();
         return bandStateAry[idx];
     }
 
+// =====================================================================
+// -------------------- private Methods --------------------------------
+// =====================================================================
 
     private void initColorStretch(WebPlotRequest request, Band band) {
         if (request!=null) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.visualize;
  */
 
 
+import edu.caltech.ipac.visualize.plot.RangeValues;
 import nom.tam.fits.Header;
 
 import java.util.Map;
@@ -15,17 +16,23 @@ import java.util.Map;
  */
 public class WebPlotHeaderInitializer {
 
-    private String workingFitsFileStr;
-    private String originalFitsFileStr;
-    private String uploadFileNameStr;
-    private String dataDesc;
-    private boolean threeColor;
-    private WebPlotRequest request;
-    private Header[] zeroHeaderAry;
-    private Map<String,String> attributes;
+    private final String workingFitsFileStr;
+    private final String originalFitsFileStr;
+    private final String uploadFileNameStr;
+    private final String dataDesc;
+    private final String rangeValuesSerialized;
+    private final boolean threeColor;
+    private final WebPlotRequest request;
+    private final Header[] zeroHeaderAry;
+    private final Map<String,String> attributes;
+    private final boolean multiImageFile;
+    private final PlotState.MultiImageAction multiImage;
+    private final int colorTableId;
 
     public WebPlotHeaderInitializer(String originalFitsFileStr, String workingFitsFileStr,
-                                    String uploadFileNameStr, String dataDesc,
+                                    String uploadFileNameStr, RangeValues rv,
+                                    String dataDesc, int colorTableId, boolean multiImageFile,
+                                    PlotState.MultiImageAction multiImage,
                                     boolean threeColor, WebPlotRequest request, Header[] zeroHeaderAry,
                                     Map<String,String> attributes) {
         this.originalFitsFileStr= originalFitsFileStr;
@@ -34,8 +41,12 @@ public class WebPlotHeaderInitializer {
         this.threeColor = threeColor;
         this.request = request;
         this.dataDesc= dataDesc;
+        this.rangeValuesSerialized= rv.serialize();
         this.zeroHeaderAry= zeroHeaderAry;
         this.attributes= attributes;
+        this.multiImage= multiImage;
+        this.multiImageFile= multiImageFile;
+        this.colorTableId= colorTableId;
     }
 
     public String getWorkingFitsFileStr() { return workingFitsFileStr; }
@@ -46,6 +57,8 @@ public class WebPlotHeaderInitializer {
 
     public String getUploadFileNameStr() { return uploadFileNameStr; }
 
+    public String getRangeValuesSerialized() { return rangeValuesSerialized; }
+
     public String getDataDesc() { return dataDesc; }
 
     public WebPlotRequest getRequest() { return request; }
@@ -53,5 +66,11 @@ public class WebPlotHeaderInitializer {
     public Header[] getZeroHeaderAry() { return zeroHeaderAry; }
 
     public Map<String,String> getAttributes() { return attributes;}
+
+    public boolean isMultiImageFile() { return multiImageFile; }
+
+    public PlotState.MultiImageAction getMultiImage() { return multiImage; }
+
+    public int getColorTableId() { return colorTableId; }
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotInitializer.java
@@ -20,18 +20,17 @@ import java.util.List;
  */
 public class WebPlotInitializer {
 
-    private CoordinateSys _imageCoordSys;
-    private int           _dataWidth;
-    private int           _dataHeight;
-    private PlotImages    _initImages;
-    private PlotState     _plotState;
-    private WebFitsData   _fitsData[];
-    private String        _desc;
-    private String        _dataDesc;
-    private Header headerAry[]; //passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
-    private Header zeroHeaderAry[]; //passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
-    private transient List<RelatedData> relatedData;
-//    private transient Projection _projection;
+    private final CoordinateSys _imageCoordSys;
+    private final int           _dataWidth;
+    private final int           _dataHeight;
+    private final PlotImages    _initImages;
+    private final PlotState     _plotState;
+    private final WebFitsData[] _fitsData;
+    private final String        _desc;
+    private final String        _dataDesc;
+    private final Header[] headerAry; //passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
+    private final Header[] zeroHeaderAry; //passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
+    private final transient List<RelatedData> relatedData;
 
 
     public WebPlotInitializer(PlotState plotState,
@@ -41,7 +40,7 @@ public class WebPlotInitializer {
                              Header[] zeroHeaderAry,
                              int dataWidth,
                              int dataHeight,
-                             WebFitsData  fitsData[],
+                             WebFitsData[] fitsData,
                              String desc,
                              String dataDesc,
                              List<RelatedData> relatedData ) {
@@ -68,9 +67,6 @@ public class WebPlotInitializer {
     public CoordinateSys getCoordinatesOfPlot() { return _imageCoordSys; }
     public PlotImages getInitImages() { return _initImages; }
 
-//    public Projection getProjection() {
-//        return _projection;
-//    }
     public List<RelatedData> getRelatedData() { return  relatedData; }
 
     public int getDataWidth() { return _dataWidth; }
@@ -78,7 +74,6 @@ public class WebPlotInitializer {
     public WebFitsData[] getFitsData()  { return _fitsData; }
 
     public String getPlotDesc() { return _desc; }
-    public void setPlotDesc(String d) { _desc= d; }
     public String getDataDesc() { return _dataDesc; }
     public Header[] getHeaderAry() { return this.headerAry; }
     public Header[] getZeroHeaderAry() { return this.zeroHeaderAry; }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageDataGroup.java
@@ -3,11 +3,9 @@
  */
 package edu.caltech.ipac.visualize.plot;
 
-import edu.caltech.ipac.util.Assert;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import edu.caltech.ipac.visualize.plot.plotdata.RGBIntensity;
 
-import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -26,6 +24,11 @@ public class ImageDataGroup implements Iterable<ImageData> {
     private       ImageData  _imageDataAry[];
     private final int _width;
     private final int _height;
+    private final int tileSize;
+    private final ImageData.ImageType imageType;
+    private int colorTableID;
+    private final RangeValues initRangeValues;
+    private final ImageMask[] iMasks;
 
     private RGBIntensity _rgbIntensity; // for 3-color hew-preserving images only
 
@@ -35,62 +38,37 @@ public class ImageDataGroup implements Iterable<ImageData> {
 //----------------------- Constructors ---------------------------------
 //======================================================================
 
-    public ImageDataGroup(FitsRead fitsReadAry[],
+    public ImageDataGroup(int dataWidth, int dataHeight,
                           ImageData.ImageType imageType,
                           int colorTableID,
                           RangeValues rangeValues,
                           int tileSize) {
-        FitsRead fr= null;
-        for(FitsRead testFr : fitsReadAry) {
-            if (testFr!=null) {
-                fr= testFr;
-                break;
-            }
-        }
-        Assert.argTst(fr, "fitsReadAry must have one non-null element.");
-        _width = fr.getNaxis1();
-        _height = fr.getNaxis2();
-
-
-        int totWidth= _width;
-        int totHeight= _height;
-
-        int xPanels= totWidth / tileSize;
-        int yPanels= totHeight / tileSize;
-        if (totWidth % tileSize > 0) xPanels++;
-        if (totHeight % tileSize > 0) yPanels++;
-        
+        _width = dataWidth;
+        _height = dataHeight;
+        this.tileSize= tileSize;
+        this.colorTableID= colorTableID;
+        this.initRangeValues= rangeValues;
+        this.imageType= imageType;
+        this.iMasks= null;
         _rgbIntensity = null;
-
-        _imageDataAry= new ImageData[xPanels * yPanels];
-
-        for(int i= 0; i<xPanels; i++) {
-            for(int j= 0; j<yPanels; j++) {
-                int width= (i<xPanels-1) ? tileSize : ((totWidth-1) % tileSize + 1);
-                int height= (j<yPanels-1) ? tileSize : ((totHeight-1) % tileSize + 1);
-                _imageDataAry[(i*yPanels) +j]= new ImageData(imageType,
-                                                  colorTableID,rangeValues,
-                                                  tileSize*i,tileSize*j,
-                                                  width, height);
-            }
-        }
     }
 
     /**
      * LZ 07/20/15
      * @return
      */
-    public ImageDataGroup(FitsRead fitsReadAry[], ImageMask[] iMasks, RangeValues rangeValues, int tileSize) {
-        FitsRead fr= null;
-        for(FitsRead testFr : fitsReadAry) {
-            if (testFr!=null) {
-                fr= testFr;
-                break;
-            }
-        }
-        Assert.argTst(fr, "fitsReadAry must have one non-null element.");
-        _width = fr.getNaxis1();
-        _height = fr.getNaxis2();
+    public ImageDataGroup(int dataWidth, int dataHeight, ImageMask[] iMasks, RangeValues rangeValues, int tileSize) {
+        _width = dataWidth;
+        _height = dataHeight;
+        this.tileSize= tileSize;
+        this.iMasks = iMasks;
+        this.colorTableID= -1;
+        this.initRangeValues= rangeValues;
+        this.imageType= ImageData.ImageType.TYPE_8_BIT;
+    }
+
+    public ImageData[] getImageDataAry() {
+        if (_imageDataAry!=null) return _imageDataAry;
 
         int totWidth= _width;
         int totHeight= _height;
@@ -101,21 +79,18 @@ public class ImageDataGroup implements Iterable<ImageData> {
         if (totHeight % tileSize > 0) yPanels++;
 
 
-
         _imageDataAry= new ImageData[xPanels * yPanels];
-
-
-
         for(int i= 0; i<xPanels; i++) {
             for(int j= 0; j<yPanels; j++) {
                 int width= (i<xPanels-1) ? tileSize : ((totWidth-1) % tileSize + 1);
                 int height= (j<yPanels-1) ? tileSize : ((totHeight-1) % tileSize + 1);
-                _imageDataAry[(i*yPanels) +j]= new ImageData(
-                        iMasks,rangeValues,
-                        tileSize*i,tileSize*j,
-                        width, height);
+                _imageDataAry[(i*yPanels) +j]= (iMasks==null) ?
+                        new ImageData(imageType, colorTableID,initRangeValues, tileSize*i,tileSize*j, width, height) :
+                        new ImageData( iMasks,initRangeValues, tileSize*i,tileSize*j, width, height);
             }
         }
+        return _imageDataAry;
+
     }
 
 //======================================================================
@@ -123,43 +98,43 @@ public class ImageDataGroup implements Iterable<ImageData> {
 //======================================================================
 
     public Iterator<ImageData> iterator() {
-        return Arrays.asList(_imageDataAry).iterator();
+        return Arrays.asList(getImageDataAry()).iterator();
     }
 
-    public int size() { return _imageDataAry.length; }
-
-    public int getImageWidth() { return _width; }
-    public int getImageHeight() { return _height; }
+    public int size() { return getImageDataAry().length; }
 
     public boolean isUpToDate() {
-        for(ImageData id : _imageDataAry) {
+        if (_imageDataAry==null) return true;
+        for(ImageData id : getImageDataAry()) {
             if (id.isImageOutOfDate()) return false;
         }
         return true;
     }
 
-    public int getColorTableId() { return _imageDataAry[0].getColorTableId(); }
+    public int getColorTableId() { return colorTableID; }
 
     public void setColorTableId(int colorTableID) {
+        this.colorTableID= colorTableID;
         IndexColorModel cm= ColorTable.getColorModel(colorTableID);
-        for(ImageData id : _imageDataAry) {
+        for(ImageData id : getImageDataAry()) {
             id.setColorModel(cm);
             id.setColorTableIdOnly(colorTableID);
         }
     }
 
-    public ColorModel getColorModel() {
-        return _imageDataAry[0].getColorModel();
-    }
-
-    public void setColorModel(IndexColorModel cm) {
-        for(ImageData id : _imageDataAry) {
-            id.setColorModel(cm);
-        }
-    }
+//    public ColorModel getColorModel() {
+//        return _imageDataAry[0].getColorModel();
+//    }
+//
+//    public void setColorModel(IndexColorModel cm) {
+//        for(ImageData id : _imageDataAry) {
+//            id.setColorModel(cm);
+//        }
+//    }
 
     public void markImageOutOfDate() {
-        for(ImageData id : _imageDataAry) {
+        if (_imageDataAry==null) return;
+        for(ImageData id : getImageDataAry()) {
             id.markImageOutOfDate();
         }
     }
@@ -178,7 +153,7 @@ public class ImageDataGroup implements Iterable<ImageData> {
             setRGBIntensity = !Arrays.asList(fitsReadAry).contains(null);
         }
 
-        for(ImageData id : _imageDataAry) {
+        for(ImageData id : getImageDataAry()) {
             if (setRGBIntensity) {
                 id.setRGBIntensity(_rgbIntensity);
             }
@@ -187,13 +162,10 @@ public class ImageDataGroup implements Iterable<ImageData> {
     }
 
     public void freeResources() {
-        if (_imageDataAry!=null) {
-            for(ImageData d : _imageDataAry) {
-                d.freeResources();
-            }
-            _imageDataAry= null;
-        }
         _rgbIntensity = null;
+        if (_imageDataAry==null) return;
+        for(ImageData d : _imageDataAry) d.freeResources();
+        _imageDataAry= null;
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/Wavelength.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/Wavelength.java
@@ -35,11 +35,13 @@ public class Wavelength {
 
     private final Header header;
     private final BinaryTableHDU tableHDU;
+    private final int planeIdx;
     
 
-    public Wavelength(Header header, BinaryTableHDU tableHDU) {
+    public Wavelength(Header header, BinaryTableHDU tableHDU, int planeIdx) {
         this.header= header;
         this.tableHDU= tableHDU;
+        this.planeIdx= planeIdx;
     }
 
     /**
@@ -62,7 +64,7 @@ public class Wavelength {
     public double getWaveLength(ImagePt ipt) throws PixelValueException, FitsException, IOException, DataFormatException {
 
 
-        double[] pixelCoords= Wavelength.getPixelCoords(ipt, header);
+        double[] pixelCoords= Wavelength.getPixelCoords(ipt, header, planeIdx);
 
         int N = header.getIntValue("WCSAXES", -1);
         if (N==-1) {
@@ -522,12 +524,12 @@ public class Wavelength {
      * @return
      * @throws PixelValueException
      */
-    public static double[] getPixelCoords(ImagePt ipt, Header header) throws PixelValueException {
+    public static double[] getPixelCoords(ImagePt ipt, Header header, int planeIdx) throws PixelValueException {
 
         int p0 = (int) Math.round(ipt.getX() - 0.5); //x
         int p1 = (int) Math.round(ipt.getY() - 0.5); //y
 
-        int p2 = header.getIntValue("SPOT_PL", 0)-1; //z  default is 0  // todo: I think subtracting 1 is wrong, this should be looked at
+        int p2 = planeIdx-1; //z  default is 0  // todo: I think subtracting 1 is wrong, this should be looked at
         if (p2<0) p2= 0;
         int naxis1 = header.getIntValue("NAXIS1");
         int naxis2 = header.getIntValue("NAXIS2");
@@ -541,14 +543,14 @@ public class Wavelength {
     }
     //NOTE: This is the version used in javascript.  Based on the paper, the coordinate is starting from 1, not zero.
     //Since the unit test is based on the one above, I kept both to let unit test pass because this class is no longer used.
-    public static double[] getPixelCoordsCorrect(ImagePt ipt, Header header) throws PixelValueException {
+    public static double[] getPixelCoordsCorrect(ImagePt ipt, Header header, int planeIdx) throws PixelValueException {
 
         //pixel numbers refer to the center of the pixel, so we subtract 0.5, see notes above
         //As noted above, the pixel is counting from 1 to naxis j where (j=1, 2,... naxis).  Since the p = Math.round(ipt.x - 0.5)
         //starts from 0.  Thus, 1 is added here.
         int p0 = (int) Math.round(ipt.getX() - 0.5) +1 ; //x
         int p1 = (int) Math.round(ipt.getY() - 0.5) +1; //y
-        int p2 = header.getIntValue("SPOT_PL", 1) + 1;  //since SPOT_PL starts from 0
+        int p2 = planeIdx + 1;  //since planeIdx starts from 0
 
        // if (p2<0) p2= 0;
         int naxis1 = header.getIntValue("NAXIS1");

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -1,5 +1,5 @@
 
-import {union,get,isEmpty,difference} from 'lodash';
+import {union, get, isEmpty, difference, isArray} from 'lodash';
 import {
     dispatchReplaceViewerItems,
     getViewerItemIds,
@@ -77,15 +77,22 @@ export function createSingleImageActivate(request, imageViewerId, tbl_id, highli
 
 let extractedPlotId= 1;
 
+
+function copyRequest(inR) {
+    const r= inR.makeCopy(inR);
+    const plotId= `extract-plotId-${extractedPlotId}`;
+    r.setPlotId(plotId);
+    r.setPlotGroupId('extract-group');
+    extractedPlotId++;
+}
+
 export function createSingleImageExtraction(request) {
     if (!request) return undefined;
-    const wpRequest= request.makeCopy();
-    const plotId= `extract-plotId-${extractedPlotId}`;
-    wpRequest.setPlotId(plotId);
-    wpRequest.setPlotGroupId('extract-group');
-    extractedPlotId++;
+    const wpRequest= isArray(request) ? request.map( (r) => copyRequest(r)) : copyRequest(request)
     return () => {
-        dispatchPlotImage({plotId, viewerId:DEFAULT_FITS_VIEWER_ID, wpRequest});
+        dispatchPlotImage({
+            plotId:isArray(wpRequest)?wpRequest.getPlotId():undefined,
+            viewerId:DEFAULT_FITS_VIEWER_ID, wpRequest});
     };
 }
 

--- a/src/firefly/js/util/Validate.js
+++ b/src/firefly/js/util/Validate.js
@@ -5,8 +5,8 @@ import validator from 'validator';
 import {isNil} from 'lodash';
 
 const isInRange= function(val,min,max) {
-    const retval= !(min !== undefined && min!==null && val<min);
-    return retval && !(max !== undefined && max!==null && val>max);
+    const retval= !(min !== undefined && !isNaN(min) && min!==null && val<min);
+    return retval && !(max !== undefined && !isNaN(min) && max!==null && val>max);
 };
 
 const typeInject= {

--- a/src/firefly/js/visualize/BandState.js
+++ b/src/firefly/js/visualize/BandState.js
@@ -129,6 +129,7 @@ export class BandState {
         bState.tileCompress = Boolean(bsJson.tileCompress);
         bState.cubeCnt= bsJson.cubeCnt || 0;
         bState.cubePlaneNumber= bsJson.cubePlaneNumber || 0;
+        bState.directFileAccessData= bsJson.directFileAccessData;
         return bState;
     }
 

--- a/src/firefly/js/visualize/FitsHeaderUtil.js
+++ b/src/firefly/js/visualize/FitsHeaderUtil.js
@@ -164,10 +164,9 @@ export function makeDoubleHeaderParse(header,zeroHeader,altWcs) {
  */
 function getHeaderObj(plotOrHeader,headerKey) {
     if (!plotOrHeader) return {};
-    if (isPlot(plotOrHeader)) {
-        const plot= plotOrHeader;
-        if (!isImage(plot) ) return {};
-        return get(plot,['header',headerKey],{});
+    if (plotOrHeader.plotImageId) {
+        if (!isImage(plotOrHeader) ) return {};
+        return plotOrHeader.header?.[headerKey] ?? {};
     }
     else {
         return plotOrHeader[headerKey] || {};

--- a/src/firefly/js/visualize/PlotState.js
+++ b/src/firefly/js/visualize/PlotState.js
@@ -120,11 +120,10 @@ export class PlotState {
     isThreeColor() { return this.threeColor; }
 
 
-    /**
-     *
-     * @return {number}
-     */
+    /** @return {number} */
     getZoomLevel() {return this.zoomLevel; }
+
+    setZoomLevel(zl) { this.zoomLevel= zl;}
 
     /**
      *

--- a/src/firefly/js/visualize/rawData/ManageRawDataThread.js
+++ b/src/firefly/js/visualize/rawData/ManageRawDataThread.js
@@ -203,7 +203,7 @@ async function changeLocalRawDataColor(plotImageId, colorTableId, threeColor, bi
         await populateRawImagePixelDataInWorker(entry.rawTileDataGroup, colorTableId, threeColor, false, '',
             bias, contrast, bandUse, rootUrl);
     entry.rawTileDataGroup= localRawTileDataGroup;
-    return {rawTileDataGroup:retRawTileDataGroup, plotStateSerialized: newPlotState.toJson(false)};
+    return {rawTileDataGroup:retRawTileDataGroup, plotStateSerialized: newPlotState.toJson(true)};
 }
 
 

--- a/src/firefly/js/visualize/rawData/RawDataOps.js
+++ b/src/firefly/js/visualize/rawData/RawDataOps.js
@@ -233,7 +233,7 @@ export async function changeLocalRawDataColor(plot, colorTableId, bias, contrast
     else {
         const newPlotState = plot.plotState.copy();
         newPlotState.colorTableId = colorTableId;
-        plotStateSerialized= newPlotState.toJson(false);
+        plotStateSerialized= newPlotState.toJson(true);
         rawTileDataGroup= entry.rawTileDataGroup;
     }
     entry.rawTileDataGroup = await populateTilesAsync(rawTileDataGroup, colorTableId, undefined, undefined, bias,contrast, bandUse);

--- a/src/firefly/js/visualize/rawData/RawDataThreadActionCreators.js
+++ b/src/firefly/js/visualize/rawData/RawDataThreadActionCreators.js
@@ -24,7 +24,7 @@ export function makeColorAction(plot, colorTableId, bias, contrast, bandUse, wor
             bias,
             contrast,
             ...bandUse,
-            plotStateSerialized: plotState.toJson(false),
+            plotStateSerialized: plotState.toJson(true),
             threeColor: isThreeColor(plot),
             rootUrl: getRootURL()
         }
@@ -46,7 +46,7 @@ export function makeFluxDirectAction(plot, ipt, band, workerKey) {
         payload: {
             plotImageId: plot.plotImageId,
             iptSerialized: ipt.toString(),
-            plotStateSerialized: plot.plotState.toJson(false),
+            plotStateSerialized: plot.plotState.toJson(true),
             band,
         }};
 }
@@ -83,7 +83,7 @@ export function makeLoadAction(plot, band, workerKey) {
         workerKey,
         payload: {
             plotImageId,
-            plotStateSerialized: plotState.toJson(false),
+            plotStateSerialized: plotState.toJson(true),
             band,
             bias,
             contrast,
@@ -162,7 +162,7 @@ export function makeStretchAction(plot, band, workerKey, rvAry) {
         workerKey,
         payload: {
             plotImageId,
-            plotStateSerialized: plotState.toJson(false),
+            plotStateSerialized: plotState.toJson(true),
             dataWidth,
             dataHeight,
             datamin,

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -10,7 +10,9 @@ import {WPConst} from '../WebPlotRequest';
 import {makeScreenPt, makeDevicePt, makeImagePt, makeWorldPt} from '../Point';
 import {getActiveTarget} from '../../core/AppDataCntlr.js';
 import { getCenterPtOfPlot, getLatDist, getLonDist } from '../VisUtil.js';
-import {getPlotViewById, matchPlotViewByPositionGroup, primePlot, findCurrentCenterPoint} from '../PlotViewUtil.js';
+import {
+    getPlotViewById, matchPlotViewByPositionGroup, primePlot, findCurrentCenterPoint, getHduPlotStartIndexes
+} from '../PlotViewUtil.js';
 import {changeProjectionCenter} from '../HiPSUtil.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import {ZoomType} from '../ZoomType.js';
@@ -68,6 +70,9 @@ export const ServerCallStatus= new Enum(['success', 'working', 'fail'], { ignore
  * @prop {number} lastCollapsedZoomLevel used for returning from expanded mode, keeps recode of the level before expanded
  * @prop {HipsImageConversionSettings} hipsImageConversion -  if defined, then plotview can convert between hips and image
  * @prop {number} plotCounter index of how many plots, used for making next ID
+ * @prop {boolean} multiHdu true if there is more than one HDUs
+ * @prop {number} cubeCnt - total number of cube in PlotView
+ * @prop {Array.<number>} hduPlotStartIndexes: start indexes of each hdu
  */
 
 /**
@@ -148,7 +153,10 @@ function createPlotViewContextData(req, pvOptions={}) {
         lastCollapsedZoomLevel: 0,
         preferenceColorKey: attributes[PlotAttribute.PREFERENCE_COLOR_KEY],
         defThumbnailSize: DEFAULT_THUMBNAIL_SIZE,
-        plotCounter:0 // index of how many plots, used for making next ID
+        plotCounter:0, // index of how many plots, used for making next ID
+        multiHdu:false, // this is updated when plots are added
+        cubeCnt: 0,     // this is updated when plots are added
+        hduPlotStartIndexes: [0], // this is updated when plots are added
     };
 
     const {hipsImageConversion:hi}= pvOptions;

--- a/src/firefly/js/visualize/task/ZoomTask.js
+++ b/src/firefly/js/visualize/task/ZoomTask.js
@@ -146,7 +146,7 @@ function evaluateZoomType(visRoot, pv, userZoomType, forceDelay, payloadLevel= 1
 
     }
 
-    if (hasLocalStretchByteData(plot)) useDelay= false;
+    if (hasLocalStretchByteData(plot) || !plot.tileData) useDelay= false;
 
     return {level, isFullScreen, useDelay, validParams};
 }
@@ -211,7 +211,7 @@ function makeZoomLevelMatcher(dispatcher, visRoot, sourcePv,level,matchByScale,i
  */
 function doZoom(dispatcher,plot,zoomLevel,isFullScreen, zoomLockingEnabled, userZoomType,devicePt,useDelay,getState) {
 
-    const localRawData=  hasLocalStretchByteData(plot);
+    const localRawData=  hasLocalStretchByteData(plot) || !plot.tileData;
     const oldZoomLevel= plot.zoomFactor;
     const hips= isHiPS(plot);
 
@@ -366,12 +366,21 @@ function processLocalZoom(dispatcher, plot, zoomLevel, isFullScreen, userZoomTyp
 
     const {plotId}= plot;
     const rawData= changeLocalRawDataZoom(plot,zoomLevel,isFullScreen);
+    let primaryStateJson;
+    if (rawData) {
+        primaryStateJson= PlotState.convertToJSON(rawData.plotState,true);
+    }
+    else {
+        const ps= plot.plotState.copy();
+        ps.setZoomLevel(zoomLevel);
+        primaryStateJson= PlotState.convertToJSON(ps,true);
+    }
     dispatcher( {
         type: ImagePlotCntlr.ZOOM_IMAGE,
         payload: {
             zoomLevel, zoomLockingEnabled,userZoomType, devicePt, localRawData:true,
             plotId,
-            primaryStateJson : PlotState.convertToJSON(rawData.plotState,true),
+            primaryStateJson,
             rawData,
             overlayRawDataAry: undefined //todo need to compute this
         }});

--- a/src/firefly/js/visualize/ui/ColorPanelReducer.js
+++ b/src/firefly/js/visualize/ui/ColorPanelReducer.js
@@ -123,7 +123,9 @@ function computeLowerRangeField(fields,rv,fitsData,lowerWhich='lowerWhich', lowe
             };
             break;
         case ABSOLUTE:
-            retval= {validator: Validate.floatRange.bind(null,fitsData.dataMin, fitsData.dataMax, 3, 'Lower range'),
+            retval= {
+                validator:  fitsData.dataMin && fitsData.dataMax ?
+                    Validate.floatRange.bind(null,fitsData.dataMin, fitsData.dataMax, 3, 'Lower range') : undefined,
                 value : resetDefault ? fitsData.dataMin : fields[lowerRange].value
             };
             break;
@@ -156,7 +158,9 @@ function computeUpperRangeField(fields,rv,fitsData) {
             break;
 
         case ABSOLUTE:
-            retval= {validator: Validate.floatRange.bind(null,fitsData.dataMin, fitsData.dataMax, 3, 'Upper range'),
+            retval= {
+                validator: fitsData.dataMin && fitsData.dataMax ?
+                    Validate.floatRange.bind(null,fitsData.dataMin, fitsData.dataMax, 3, 'Upper range') : undefined,
                 value : resetDefault ? fitsData.dataMax : fields.upperRange.value
             };
             break;

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
-import {primePlot, getPlotViewById} from '../PlotViewUtil.js';
+import {primePlot, getPlotViewById, isImageCube, getCubePlaneCnt} from '../PlotViewUtil.js';
 import {Tabs, Tab} from '../../ui/panel/TabPanel.jsx';
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 import {dispatchShowDialog, dispatchHideDialog, isDialogVisible} from '../../core/ComponentCntlr.js';
@@ -43,7 +43,8 @@ const labelColumn1 = { paddingTop:5, width:80, textAlign: 'right', color: 'Black
 //define the second label column in the textStyle div
 const labelColumn2 = { paddingTop:5, width:70, textAlign: 'right',display: 'inline-block', color: 'Black', fontWeight: 'bold'};
 //define the text data style
-const textStyle={ paddingTop:5,paddingLeft:3, width:140, color: 'Black', fontWeight: 'normal', display: 'inline-block'};
+const textStyle={ paddingTop:5,paddingLeft:3, width:60, color: 'Black', fontWeight: 'normal', display: 'inline-block'};
+const textLongStyle={ paddingTop:5,paddingLeft:3, width:110, color: 'Black', fontWeight: 'normal', display: 'inline-block'};
 
 //define the display style for the file size and pixel information and the table in the same div
 const tableAndTitleInfoStyle = {width: '100%', height: 'calc(100% - 40px)', display: 'flex', resize:'none'};
@@ -284,6 +285,8 @@ function renderFileSizeAndPixelSize(plot, band, fitsHeaderInfo, isOnTab) {
     const titleStyleNoTab = {width: '100%', height: 30,display: 'inline-block', background:bgColor};
     const titleStyleOnTab = {width: '100%', height: 30,display: 'inline-block'};
     var titleStyle = isOnTab? titleStyleOnTab:titleStyleNoTab;
+    let dimStr= `${plot.dataWidth} x ${plot.dataHeight}`;
+    if (isImageCube(plot)) dimStr+= ` x ${getCubePlaneCnt(plot)}`;
 
    return (
         <div style={titleStyle}>
@@ -291,6 +294,8 @@ function renderFileSizeAndPixelSize(plot, band, fitsHeaderInfo, isOnTab) {
             < div style= {textStyle} >{pixelSize}</div>
             <div style={ labelColumn2}> File Size:</div>
             <div style= {textStyle} >{fileSizeStr}</div>
+            <div style={ labelColumn2}> Dimensions:</div>
+            <div style= {textLongStyle} >{dimStr}</div>
         </div>
     );
 }

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -381,7 +381,7 @@ export function MultiImageControllerView({plotView:pv}) {
             tooltip+= `HDU: ${hduNum} ${hduDesc?', '+hduDesc:''}`;
         }
         if (plot.cubeIdx>-1) {
-            tooltip+= `${multiHdu ? ', ':''} Cube: ${plot.cubeIdx+1}/${getCubePlaneCnt(pv,plot)}`;
+            tooltip+= `${multiHdu ? ', ':''} Cube: ${plot.cubeIdx+1}/${getCubePlaneCnt(plot)}`;
 
             if (hasPlaneOnlyWLInfo(plot)) {
                 const wl= doFormat(getPtWavelength(plot,null, plot.cubeIdx),4);

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/ImageHeaderTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/ImageHeaderTest.java
@@ -125,7 +125,7 @@ public class ImageHeaderTest  extends ConfigTest {
         FitsRead fitsRead0 = FitsReadFactory.createFitsReadArray(inFits)[0];
         Header header = fitsRead0.getHeader();
         ImageHDU imageHdu = (ImageHDU) fitsRead0.getHDU();
-        int planeNumber = header.getIntValue("SPOT_PL", 0);
+        int planeNumber = fitsRead0.getPlaneNumber();
         int  extension_number = header.getIntValue("SPOT_EXT", -1);
         long HDUOffset = extension_number == -1? imageHdu.getFileOffset():header.getIntValue("SPOT_OFF", 0);
 
@@ -404,7 +404,7 @@ public class ImageHeaderTest  extends ConfigTest {
 
         ImageHDU imageHdu = (ImageHDU) fitsRead0.getHDU();
         Header headerSpot =fitsRead0.getHeader();
-        int planeNumber = headerSpot.getIntValue("SPOT_PL", 0);
+        int planeNumber = fitsRead0.getPlaneNumber();
         int  extension_number = headerSpot.getIntValue("SPOT_EXT", -1);
         long HDUOffset = extension_number == -1? imageHdu.getFileOffset():headerSpot.getIntValue("SPOT_OFF", 0);
         ImageHeader imageHeaderWithSpot = new ImageHeader(headerSpot, HDUOffset, planeNumber);

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/plotdata/GeomTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/plotdata/GeomTest.java
@@ -43,7 +43,7 @@ public class GeomTest extends FitsValidation {
         //get the expected ImageHeader from calling it directly
         ImageHDU imageHdu = (ImageHDU) inFits.getHDU(0);
         Header header =imageHdu.getHeader();
-        int planeNumber = header.getIntValue("SPOT_PL", 0);
+        int planeNumber = header.getIntValue("SPOT_PL", 0); // keep for now, but SPOT_PL is no longer guaranteed
         int extension_number = header.getIntValue("SPOT_EXT", -1);
         long HDU_offset;
         if (extension_number == -1) {


### PR DESCRIPTION
#### Firefly-874: only read cube planes as user request them. 
  - lazy read the cube planes as the user visualizes them
  - added optimizations in transferring and caching data
  - server foot print substantially smaller with large cubes
  - fixed: after changing color the flux readout begin to fail

_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-874

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-874-lazy-cube/firefly/
 - read in a FITS file with any cube. It should work as before, performance will be a little better with large cubes