### PR TITLE
Firefly-841: UI improvements

### DIFF
--- a/src/firefly/js/drawingLayers/ExtractLineTool.js
+++ b/src/firefly/js/drawingLayers/ExtractLineTool.js
@@ -211,7 +211,7 @@ function start(drawLayer, action) {
     const {imagePt,plotId,shiftDown}= action.payload;
     const plot= primePlot(visRoot(),plotId);
     const mode= getMode(plot);
-    if (!plot) return;
+    if (!plot || shiftDown) return;
     const cc= CsysConverter.make(plot);
     if (!cc.pointInData(imagePt)) return;
     let retObj= {};
@@ -248,10 +248,10 @@ function start(drawLayer, action) {
 
 
 function drag(drawLayer,action) {
-    const {imagePt,plotId}= action.payload;
+    const {imagePt,plotId, shiftDown}= action.payload;
     const plot= primePlot(visRoot(),plotId);
     const cc= CsysConverter.make(plot);
-    if (!cc) return;
+    if (!cc || shiftDown) return;
 
     const newFirst = drawLayer.moveHead ? drawLayer.firstPt : imagePt;
     const newCurrent = drawLayer.moveHead ? imagePt : drawLayer.currentPt;
@@ -262,7 +262,8 @@ function drag(drawLayer,action) {
 }
 
 function end(action) {
-    const {plotId}= action.payload;
+    const {plotId, shiftDown}= action.payload;
+    if (shiftDown) return;
     const mode= getMode(primePlot(visRoot(),plotId));
     const retObj= {};
     if (mode==='select') {

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -227,7 +227,8 @@ export class ImageViewerLayout extends PureComponent {
 
     eventCB(plotId,mouseState,screenPt,screenX,screenY,nativeEv) {
         const {drawLayersAry,plotView}= this.props;
-        const mouseStatePayload= makeMouseStatePayload(plotId,mouseState,screenPt,screenX,screenY, {shiftDown:nativeEv.shiftKey});
+        const shiftDown= nativeEv.shiftKey;
+        const mouseStatePayload= makeMouseStatePayload(plotId,mouseState,screenPt,screenX,screenY, {shiftDown});
         const list= drawLayersAry.filter( (dl) => dl.visiblePlotIdAry.includes(plotView.plotId) &&
                                                 get(dl,['mouseEventMap',mouseState.key],false) );
 
@@ -242,7 +243,7 @@ export class ImageViewerLayout extends PureComponent {
             return;
         }
         else {
-            const ownerCandidate= findMouseOwner(list,primePlot(plotView),screenPt);         // see if anyone can own that mouse
+            const ownerCandidate= !shiftDown && findMouseOwner(list,primePlot(plotView),screenPt);         // see if anyone can own that mouse
             this.mouseOwnerLayerId = DOWN.is(mouseState) && ownerCandidate ? ownerCandidate.drawLayerId : null;   // can only happen on mouseDown
             if (this.mouseOwnerLayerId) {
                 if (DOWN.is(mouseState)) dispatchChangeActivePlotView(plotId);

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -212,10 +212,17 @@ function ZoomPair({pv, show}) {
                 display:'inline-flex',
                 borderRadius:'0 0 5px ',
                 position: 'relative',
+                flexDirection: 'row',
                 alignSelf: 'flex-start',
                 }}>
-            <ZoomButton size={20} plotView={pv} zoomType={ZoomType.UP} horizontal={true}/>
-            <ZoomButton size={20} plotView={pv} zoomType={ZoomType.DOWN} horizontal={true}/>
+            <div style={{display:'flex', alignSelf: 'flex-start'}}>
+                <ZoomButton size={20} plotView={pv} zoomType={ZoomType.UP} horizontal={true}/>
+                <ZoomButton size={20} plotView={pv} zoomType={ZoomType.DOWN} horizontal={true}/>
+            </div>
+            <div style={{display:'flex', alignSelf: 'flex-start'}}>
+                <ZoomButton size={20} plotView={pv} zoomType={ZoomType.FIT} horizontal={true}/>
+                <ZoomButton size={20} plotView={pv} zoomType={ZoomType.FILL} horizontal={true}/>
+            </div>
         </div> : <div/>
     );
     

--- a/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
@@ -23,6 +23,7 @@ import SELECT_CIRCLE_ON from 'html/images/icons-2014/28x28_Circle-ON.png';
 import SELECT_NONE from 'html/images/icons-2014/28x28_Rect_DD.png';
 import {SelectedShape} from '../../drawingLayers/SelectedShape';
 import {visRoot} from '../ImagePlotCntlr.js';
+import {onOff} from 'firefly/visualize/ui/SimpleLayerOnOffButton.jsx';
 
 const NONSELECT = 'nonselect';
 
@@ -62,13 +63,14 @@ export function getSelectedAreaIcon(isSelected = true) {
 }
 
 
-function updateSelect(pv, value, allPlots=true) {
+function updateSelect(pv, value, allPlots=true, modalEndInfo, setModalEndInfo) {
 
     return ()=> {
         if (!pv) return;
 
 
         if (value !== NONSELECT) {
+            modalEndInfo?.f?.();
             detachSelectAreaRelatedLayers( pv, allPlots, selectAreaInfo()[value].typeId);
             detachSelectArea(pv);
             // create a new one
@@ -78,6 +80,10 @@ function updateSelect(pv, value, allPlots=true) {
             if (!isDrawLayerAttached(dl, pv.plotId)) {
                dispatchAttachLayerToPlot(dl.drawLayerId, pv.plotId, allPlots);
             }
+            setModalEndInfo({
+                s:'End Select',
+                f: () => onOff(pv,SelectArea.TYPE_ID,allPlots,false,false,modalEndInfo,setModalEndInfo,'')
+            });
         }
     };
 }
@@ -115,7 +121,7 @@ export function detachSelectAreaRelatedLayers(pv, allPlots = true, selectId = Se
 }
 
 
-export function SelectAreaDropDownView({plotView:pv, allPlots}) {
+export function SelectAreaDropDownView({plotView:pv, allPlots, modalEndInfo, setModalEndInfo}) {
     var enabled = !!pv;
     let sep = 1;
 
@@ -130,7 +136,7 @@ export function SelectAreaDropDownView({plotView:pv, allPlots}) {
                                horizontal={false}
                                icon={selectAreaInfo()[key].iconDropDown }
                                tip={selectAreaInfo()[key].tip}
-                               onClick={updateSelect(pv, key, allPlots)}/>
+                               onClick={updateSelect(pv, key, allPlots, modalEndInfo, setModalEndInfo)}/>
             ));
             prev.push(<DropDownVerticalSeparator key={sep++}/>);
             return prev;

--- a/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
+++ b/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
@@ -14,6 +14,7 @@ import {dispatchCreateDrawLayer,
 
 
 export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,visible,
+                                           modalEndInfo, setModalEndInfo, endText,
                                             plotTypeMustMatch= false, style={}, enabled= true, imageStyle,
                                             todo= false, isIconOn, onClick, dropDown, allPlots= true }) {
     const enableButton= Boolean(primePlot(pv)) && enabled;
@@ -34,7 +35,6 @@ export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,vi
                                     dropDown={dropDown} />
         );
     } else {
-
         return (
             <ToolbarButton icon={isOn ? iconOn : iconOff}
                            tip={tip}
@@ -44,7 +44,8 @@ export function SimpleLayerOnOffButton({plotView:pv,tip,typeId,iconOn,iconOff,vi
                            todo={todo}
                            style={style}
                            imageStyle={imageStyle}
-                           onClick={() => onClick ? onClick(pv,!isOn) : onOff(pv,typeId,allPlots,plotTypeMustMatch,todo)}/>
+                           onClick={() => onClick ? onClick(pv,!isOn) :
+                               onOff(pv,typeId,allPlots,plotTypeMustMatch,todo,modalEndInfo, setModalEndInfo,endText)}/>
         );
     }
 }
@@ -73,7 +74,7 @@ SimpleLayerOnOffButton.defaultProps= {
 
 
 
-function onOff(pv,typeId,allPlots, plotTypeMustMatch, todo) {
+export function onOff(pv,typeId,allPlots, plotTypeMustMatch, todo, modalEndInfo, setModalEndInfo,endText) {
     if (!pv || !typeId) return;
 
     if (todo) {
@@ -86,9 +87,17 @@ function onOff(pv,typeId,allPlots, plotTypeMustMatch, todo) {
 
     if (!isDrawLayerAttached(dl,pv.plotId)) {
         dispatchAttachLayerToPlot(typeId,pv.plotId,allPlots,true, plotTypeMustMatch);
+        modalEndInfo?.f?.();
+        setModalEndInfo?.({
+            f: () => {
+                onOff(pv,typeId,allPlots,plotTypeMustMatch,todo, modalEndInfo, setModalEndInfo,endText);
+            },
+            s: endText
+        });
     }
     else {
         dispatchDetachLayerFromPlot(typeId,pv.plotId,allPlots,dl.destroyWhenAllDetached);
+        setModalEndInfo?.({});
     }
 }
 


### PR DESCRIPTION
 Firefly-841: UI improvements

  - Expose more zoom buttons to the image embedded zoom menu
  - Enabled options to control and turn off the active tool on the image (distance, extract, area select)
  - Shift key will always allow for only scrolling

_ticket:_
https://jira.ipac.caltech.edu/browse/FIREFLY-879

_testing_
 - Firefly: https://fireflydev.ipac.caltech.edu/firefly-879-ui-improve/firefly/
 - ZTF: https://firefly-879-ui-improve.irsakudev.ipac.caltech.edu/applications/ztf/
 - FinderChart:  https://firefly-879-ui-improve.irsakudev.ipac.caltech.edu/applications/finderchart/
