### PR TITLE
FIREFLY-855: Improve the firefly tab bar to handle large number of tabs

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -291,6 +291,22 @@ div.rootStyle img {
     font-weight: bold;
 }
 
+.round-btn {
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    padding: 1px;
+    justify-content: center;
+}
+
+.round-btn:hover {
+    background-color: rgba(0,0,0, .15);
+    border-radius: 50%;
+    cursor: pointer;
+    border: 1px solid rgba(0,0,0, 0.15);
+}
+
 
 .keyword-label  {
     font-weight: bold;

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -436,7 +436,7 @@ function autoCorrectCondition(v, col) {
     // empty string or string with no value
     if (!op && !val) return v.trim();
 
-    op = op ? op.toLowerCase() : (useQuote ? 'like' : '=');      // no operator is treated as 'like'
+    op = op ? op.toLowerCase() : (!col?.type || useQuote ? 'like' : '=');      // use 'like' when column type is string-like or not defined
 
     switch (op) {
         case 'like':

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -25,10 +25,10 @@ export class TableConnector {
         const {tbl_ui_id, tbl_id, tableModel} = this;
         if (!getTableUiByTblId(tbl_id)) {
             TblCntlr.dispatchTableUiUpdate({tbl_ui_id, tbl_id, ...this.options});
-            if (tableModel && !tableModel.origTableModel) {
-                set(tableModel, 'request.tbl_id', tbl_id);
-                TblCntlr.dispatchTableAddLocal(tableModel, undefined, false);
-            }
+        }
+        if (tableModel && !tableModel.origTableModel) {
+            set(tableModel, 'request.tbl_id', tbl_id);
+            TblCntlr.dispatchTableAddLocal(tableModel, undefined, false);
         }
     }
 

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -242,6 +242,7 @@ export const ColumnOptions = React.memo(({tbl_id, tbl_ui_id, ctm_tbl_id, onChang
                 renderers = {renderers}
                 showToolbar = {false}
                 showOptionButton = {false}
+                showTypes={false}
                 showFilters={true}
                 selectable = {true}
                 rowHeight = {27}

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -72,7 +72,7 @@ export class TablesContainer extends PureComponent {
         if (expandedMode) {
             return <ExpandedView {...{active, tables, tableOptions, layout, expandedMode, closeable, tbl_group}} />;
         } else {
-            return isEmpty(tables) ? <div></div> : <StandardView {...{active, tables, tableOptions, expandedMode, tbl_group, style}} />;
+            return isEmpty(tables) ? <div/> : <StandardView {...{active, tables, tableOptions, expandedMode, tbl_group, style}} />;
         }
     }
 }
@@ -127,7 +127,8 @@ function StandardView(props) {
     } else {
         const uid = hashCode(keys.join());
         return (
-            <TabsView key={uid} style={{height: '100%', width: '100%', ...style}} defaultSelected={activeIdx} onTabSelect={onTabSelect} resizable={true}>
+            <TabsView key={uid} style={{height: '100%', width: '100%', ...style}} defaultSelected={activeIdx}
+                      onTabSelect={onTabSelect} resizable={true} showOpenTabs={true} tabId={'TableContainers-' + (tbl_group||'main')}>
                 {tablesAsTab(tables, tableOptions, expandedMode)}
             </TabsView>
         );

--- a/src/firefly/js/ui/DialogRootContainer.jsx
+++ b/src/firefly/js/ui/DialogRootContainer.jsx
@@ -46,6 +46,10 @@ export function showDropDown({id='',content, style={}, atElRef, locDir, wrapperS
     return ddDiv;
 }
 
+export function isDropDownShowing(id) {
+    return document.getElementById(getddDiv(id));
+}
+
 export function hideDropDown(id='') {
     const ddDiv = document.getElementById(getddDiv(id));
     if (ddDiv) {

--- a/src/firefly/js/ui/panel/TabPanel.css
+++ b/src/firefly/js/ui/panel/TabPanel.css
@@ -1,7 +1,33 @@
+.TabPanel__main {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    flex-shrink: 0;
+    height: 20px;
+    position: relative;
+    box-sizing: border-box;
+}
+.TabPanel__main.boxed {
+    background-color: #d7d6d6;
+    padding-top: 4px;
+    border: 1px solid #cdcdcd;
+    border-bottom: none;
+    border-top-right-radius: 2px;
+    border-top-left-radius: 2px;
+}
+
+.TabPanel__Header {
+    display: inline-flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+}
+
 .TabPanel__Tabs {
   list-style: none;
   padding:0;
   margin:0;
+    display: inline-flex;
 }
 
 

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -16,6 +16,7 @@ import {getCellValue, getTblById, watchTableChanges} from '../../tables/TableUti
 import {TABLE_FILTER, TABLE_HIGHLIGHT, TABLE_SORT} from '../../tables/TablesCntlr.js';
 
 import './TabPanel.css';
+import {dispatchChartUpdate} from '../../charts/ChartsCntlr.js';
 
 
 export function uniqueTabId() {
@@ -48,7 +49,11 @@ const TabsHeaderInternal = React.memo((props) => {
 
     const arrowEl = useRef(null);
     const showTabs = (ev) => handleOpenTabs({ev, doOpen: !isDropDownShowing(tabId), tabId, onSelect, arrowEl, childrenAry});
-    if (isDropDownShowing(tabId)) handleOpenTabs({doOpen: false});
+
+    const titles = getTabTitles(childrenAry).join();
+    useEffect( ()=> {
+        if (isDropDownShowing(tabId)) handleOpenTabs({tabId, doOpen: false});
+    }, [tabId, titles]);
 
     return (
         <div style={style}>
@@ -305,13 +310,10 @@ function handleOpenTabs({ev, doOpen, tabId, onSelect, childrenAry, arrowEl}) {
     ev?.stopPropagation?.();
     if (doOpen) {
         // create table model for the drop down
-        const columns = [{name: 'OPEN TABS', width: 50, type: 'char'}];
+        const columns = [{name: 'OPEN TABS', width: 50}];
         const highlightedRow = childrenAry.findIndex((child) => child?.props?.selected);
         const tbl_id = tabId;
-        const data = childrenAry.map((child, idx) => {
-            const p = child?.props;
-            return [isString(p.label) ? p.label : p.name || `[blank]-${idx}`];
-        });
+        const data = getTabTitles(childrenAry);
         const tableModel = {tbl_id, tableData: {columns, data}, highlightedRow, totalRows: data.length};
         // monitor for changes
         watchTableChanges(tabId, [TABLE_HIGHLIGHT, TABLE_SORT, TABLE_FILTER], () => {
@@ -333,3 +335,11 @@ function handleOpenTabs({ev, doOpen, tabId, onSelect, childrenAry, arrowEl}) {
         hideDropDown(tabId);
     }
 };
+
+function getTabTitles(childrenAry) {
+    return childrenAry.map((child, idx) => {
+        const p = child?.props;
+        return [isString(p.label) ? p.label : p.name || `[blank]-${idx}`];
+    });
+
+}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-855
Test: https://fireflydev.ipac.caltech.edu/firefly-855-improved-tabpanel/firefly/

- Add 'Search open tabs' button  option to TabPanel.jsx

This is modeled after the Chrome browser 'Search Tabs' feature.  When this option is enabled, a `down-arrow` will appears on the right side of the tab panel.  The drop down panel consist of only a single column containing the Tab's title.  
From this dropdown, you can: 
- select the active tab
- sort and filter

`Allow the user to edit the name of a tab` is not implemented, yet.  It requires the tab panel to maintain states, which was not in the original design.  May need to refactor/rewrite `TabPanel.jsx` to accommodate more advance features in the future.

Things to consider:
- This feature is only enabled for the multi-tables displayed as tabs.
- It appears even if there's only one tab.  Do we need to set a min-count before this appears?

