### PR TITLE
IRSA-4355: Fix Firefly common IBE processing for multi-position search

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/BaseIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/BaseIbeDataSource.java
@@ -4,11 +4,16 @@
 package edu.caltech.ipac.astro.ibe;
 
 import edu.caltech.ipac.util.StringUtils;
+import edu.caltech.ipac.visualize.plot.CoordinateSys;
+import edu.caltech.ipac.visualize.plot.Plot;
+import edu.caltech.ipac.visualize.plot.WorldPt;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
+
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 /**
  * Date: 4/18/14
@@ -46,7 +51,34 @@ public class BaseIbeDataSource implements IbeDataSource {
     }
 
     public IbeQueryParam makeQueryParam(Map<String, String> queryInfo) {
-        return null;
+
+        // handles only the common position search params
+        IbeQueryParam queryParam = new IbeQueryParam();
+
+        String userTargetWorldPt = queryInfo.get("UserTargetWorldPt");
+        String upload = queryInfo.get("filename");
+        if (userTargetWorldPt != null || !isEmpty(upload)) {
+            // search by position
+            if (userTargetWorldPt != null) {
+                WorldPt pt = WorldPt.parse(userTargetWorldPt);
+                if (pt != null) {
+                    pt = Plot.convert(pt, CoordinateSys.EQ_J2000);
+                    queryParam.setPos(pt.getLon() + "," + pt.getLat());
+                }
+            } else {
+                queryParam.setPos(queryInfo.get("filename"));
+            }
+            if (!StringUtils.isEmpty(queryInfo.get("intersect"))) {
+                queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
+            }
+            String mcen = queryInfo.get("mcenter");
+            if (mcen != null && (mcen.equalsIgnoreCase(MCEN) || Boolean.parseBoolean(mcen))) {
+                queryParam.setMcen(true);
+            } else {
+                queryParam.setSize(queryInfo.get("size"));
+            }
+        }
+        return queryParam;
     }
 
     public void setIbeHost(String ibeHost) {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/BaseIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/BaseIbeDataSource.java
@@ -144,7 +144,8 @@ public class BaseIbeDataSource implements IbeDataSource {
 
     @Override
     public String getQueryUrl(IbeQueryParam param) {
-        return getSearchUrl() + "?" + convertToUrl(param);
+        String url = getSearchUrl();
+        return (url.contains("?") ? "&" : "?") + convertToUrl(param);
     }
 
     @Override

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
@@ -341,36 +341,10 @@ public class AtlasIbeDataSource extends BaseIbeDataSource {
     }
 
     @Override
-    public String getQueryUrl(IbeQueryParam param) {
-        return getSearchUrl() + "&" + convertToUrl(param);
-    }
-
-    @Override
     public String getMetaDataUrl() {
         return this.getIbeHost() + "/IBE?table=" +
                 this.getDataset() +
                 "." + this.getTableName() + "&FORMAT=METADATA";
-    }
-
-    private String convertToUrl(IbeQueryParam param) {
-        String s = "";
-        if (param == null) return "";
-
-        if (!StringUtils.isEmpty(param.getRefBy())) {
-            s = addUrlParam(s, REF_BY, param.getRefBy());
-        } else if (!StringUtils.isEmpty(param.getPos())) {
-            s = addUrlParam(s, POS, param.getPos());
-            s = addUrlParam(s, INTERSECT, param.getIntersect());
-            if (param.isMcen()) {
-                s = addUrlParam(s, null, MCEN);
-            } else {
-                s = addUrlParam(s, SIZE, param.getSize());
-            }
-        }
-
-        s = addUrlParam(s, COLUMNS, param.getColumns()); // ATLAS IBE2 doesn't have the columns filter, might want to do TAP data source for that purpose?
-        s = addUrlParam(s, WHERE, param.getWhere(), true);
-        return s;
     }
 
     public String getImageRoot() {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/AtlasIbeDataSource.java
@@ -240,33 +240,9 @@ public class AtlasIbeDataSource extends BaseIbeDataSource {
     @Override
     public IbeQueryParam makeQueryParam(Map<String, String> queryInfo) {
 
-        // source search
-        IbeQueryParam queryParam = new IbeQueryParam();
+        // common position search params
+        IbeQueryParam queryParam = super.makeQueryParam(queryInfo);
 
-        // process POS - target search
-        String userTargetWorldPt = queryInfo.get("UserTargetWorldPt");
-        if (userTargetWorldPt != null) {
-            WorldPt pt = WorldPt.parse(userTargetWorldPt);
-            if (pt != null) {
-                pt = Plot.convert(pt, CoordinateSys.EQ_J2000);
-                queryParam.setPos(pt.getLon() + "," + pt.getLat());
-                if (!StringUtils.isEmpty(queryInfo.get("intersect"))) {
-                    queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
-                }
-                String mcen = queryInfo.get("mcenter");
-                if (mcen != null && (mcen.equalsIgnoreCase(MCEN) || Boolean.parseBoolean(mcen))) {
-                    queryParam.setMcen(true);
-
-                } else {
-                    // workaround:
-                    if (StringUtils.isEmpty(queryInfo.get("radius"))) {
-                        queryParam.setSize(queryInfo.get("size"));
-                    } else {
-                        queryParam.setSize(queryInfo.get("radius"));
-                    }
-                }
-            }
-        }
         // process constraints
         String constraints = processAtlasConstraints(queryInfo);
         if (!StringUtils.isEmpty(constraints)) {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/PtfIbeDataSource.java
@@ -145,28 +145,9 @@ public class PtfIbeDataSource extends BaseIbeDataSource {
     @Override
     public IbeQueryParam makeQueryParam(Map<String, String> queryInfo) {
 
-        // source search
-        IbeQueryParam queryParam = new IbeQueryParam();
+        // common position search params
+        IbeQueryParam queryParam = super.makeQueryParam(queryInfo);
 
-        // process POS - target search
-        String userTargetWorldPt = queryInfo.get("UserTargetWorldPt");
-        if (userTargetWorldPt != null) {
-            WorldPt pt = WorldPt.parse(userTargetWorldPt);
-            if (pt != null) {
-                pt = Plot.convert(pt, CoordinateSys.EQ_J2000);
-                queryParam.setPos(pt.getLon() + "," + pt.getLat());
-                if (!StringUtils.isEmpty(queryInfo.get("intersect"))) {
-                    queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
-                }
-                String mcen = queryInfo.get("mcenter");
-                if (mcen != null && mcen.equalsIgnoreCase(MCEN)) {
-                    queryParam.setMcen(true);
-
-                } else {
-                    queryParam.setSize(queryInfo.get("size"));
-                }
-            }
-        }
         // process constraints
         String constraints = processConstraints(queryInfo);
         if (!StringUtils.isEmpty(constraints)) {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/TwoMassIbeDataSource.java
@@ -165,33 +165,9 @@ public class TwoMassIbeDataSource extends BaseIbeDataSource {
     @Override
     public IbeQueryParam makeQueryParam(Map<String, String> queryInfo) {
 
-        // source search
-        IbeQueryParam queryParam = new IbeQueryParam();
+        // common position search params
+        IbeQueryParam queryParam = super.makeQueryParam(queryInfo);
 
-        // process POS - target search
-        String userTargetWorldPt = queryInfo.get("UserTargetWorldPt");
-        if (userTargetWorldPt != null) {
-            WorldPt pt = WorldPt.parse(userTargetWorldPt);
-            if (pt != null) {
-                pt = Plot.convert(pt, CoordinateSys.EQ_J2000);
-                queryParam.setPos(pt.getLon() + "," + pt.getLat());
-                if (!StringUtils.isEmpty(queryInfo.get("intersect"))) {
-                    queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
-                }
-                String mcen = queryInfo.get("mcenter");
-                if (mcen != null && (mcen.equalsIgnoreCase(MCEN) || Boolean.parseBoolean(mcen))) {
-                    queryParam.setMcen(true);
-
-                } else {
-                    // workaround:
-                    if ( StringUtils.isEmpty(queryInfo.get("radius"))) {
-                        queryParam.setSize(queryInfo.get("size"));
-                    } else {
-                        queryParam.setSize(queryInfo.get("radius"));
-                    }
-                }
-            }
-        }
         // process constraints
         String constraints = processConstraints(queryInfo);
         if (!StringUtils.isEmpty(constraints)) {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/WiseIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/WiseIbeDataSource.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Map;
 
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
+
 /**
  * Date: 4/18/14
  *
@@ -227,36 +229,13 @@ public class WiseIbeDataSource extends BaseIbeDataSource {
     @Override
     public IbeQueryParam makeQueryParam(Map<String, String> queryInfo) {
 
-        // source search
-        IbeQueryParam queryParam = new IbeQueryParam();
+        // common position search params
+        IbeQueryParam queryParam = super.makeQueryParam(queryInfo);
 
-        String userTargetWorldPt = queryInfo.get(USER_TARGET_WORLD_PT);
         String refSourceId = queryInfo.get("refSourceId");
         String sourceId = queryInfo.get("sourceId");
 
-        if (userTargetWorldPt != null) {
-            // search by position
-            WorldPt pt = WorldPt.parse(userTargetWorldPt);
-            if (pt != null) {
-                pt = Plot.convert(pt, CoordinateSys.EQ_J2000);
-                queryParam.setPos(pt.getLon() + "," + pt.getLat());
-                if (!StringUtils.isEmpty(queryInfo.get("intersect"))) {
-                    queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
-                }
-                String mcen = queryInfo.get("mcenter");
-                if (mcen != null && mcen.equalsIgnoreCase(MCEN)) {
-                    queryParam.setMcen(true);
-
-                } else {
-                    // workaround:
-                    if ( StringUtils.isEmpty(queryInfo.get("radius"))) {
-                        queryParam.setSize(queryInfo.get("size"));
-                    } else {
-                        queryParam.setSize(queryInfo.get("radius"));
-                    }
-                }
-            }
-        } else if (refSourceId != null) {
+        if (refSourceId != null) {
             String sourceSpec = WISE + "." + getDataset() + "." + wds.getSourceTable() + "(\"source_id\":\"" + refSourceId + "\")";
             queryParam.setRefBy(sourceSpec);
         } else if (sourceId != null) {

--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/ZtfIbeDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/datasource/ZtfIbeDataSource.java
@@ -18,6 +18,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 
+import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
+
 /**
  * Date: 3/20/2018
  *
@@ -164,28 +167,9 @@ public class ZtfIbeDataSource extends BaseIbeDataSource {
     @Override
     public IbeQueryParam makeQueryParam(Map<String, String> queryInfo) {
 
-        // source search
-        IbeQueryParam queryParam = new IbeQueryParam();
+        // common position search params
+        IbeQueryParam queryParam = super.makeQueryParam(queryInfo);
 
-        // process POS - target search
-        String userTargetWorldPt = queryInfo.get("UserTargetWorldPt");
-        if (userTargetWorldPt != null) {
-            WorldPt pt = WorldPt.parse(userTargetWorldPt);
-            if (pt != null) {
-                pt = Plot.convert(pt, CoordinateSys.EQ_J2000);
-                queryParam.setPos(pt.getLon() + "," + pt.getLat());
-                if (!StringUtils.isEmpty(queryInfo.get("intersect"))) {
-                    queryParam.setIntersect(IbeQueryParam.Intersect.valueOf(queryInfo.get("intersect")));
-                }
-                String mcen = queryInfo.get("mcenter");
-                if (mcen != null && mcen.equalsIgnoreCase(MCEN)) {
-                    queryParam.setMcen(true);
-
-                } else {
-                    queryParam.setSize(queryInfo.get("size"));
-                }
-            }
-        }
         // process constraints
         String constraints = processConstraints(queryInfo);
         if (!StringUtils.isEmpty(constraints)) {


### PR DESCRIPTION
ticket: https://jira.ipac.caltech.edu/browse/IRSA-4355
test: https://irsa-4355-multiposition-ztf.irsakudev.ipac.caltech.edu/applications/ztf/
- changes include fixes to all missions: atlas, ptf, 2mass, wise, ztf

`makeQueryParam` failed to detect Multi-Object Search parameters because `UserTargetWorldPt` parameter is null.  Add logic to include `filename` as well.

After changes, Multi-Object works fine when Search Region is involved.  When `Image contains target` or `Any pixel overlaps search region`  is select, `Science Exposure` timed out.  This is the same behavior found in OPS.  @wmiipac , you should report this to back-end.