### PR TITLE
Firefly-886: add user agent based on tag to firefly network calls

### DIFF
--- a/buildScript/global.gincl
+++ b/buildScript/global.gincl
@@ -142,6 +142,19 @@ ext.getCommitHash = { workDir="." ->
     }
 }
 
+ext.getCommitTag = { workDir="." ->
+    try {
+        def hashOut = new ByteArrayOutputStream()
+        exec {
+            commandLine "git", "tag", "--points-at", "HEAD"
+            workingDir = workDir
+            standardOutput = hashOut
+        }
+        return hashOut.toString().trim();
+    } catch (Exception e) {
+        return 'n/a'
+    }
+}
 
 ext.getVersionInfo = { key ->
     if (!project.hasProperty("tag_file")) {

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -131,11 +131,13 @@ task createVersionTag  {
         props.setProperty('BuildTime', build_time)
         props.setProperty('BuildTag', tag)
         props.setProperty('BuildCommit', getCommitHash())
+        props.setProperty('BuildGitTagFirefly', getCommitTag())
 
         props.setProperty('ExtendedCache', project.env == "local" ? (project.hasProperty("ExtendedCache") ? project.ExtendedCache : "true") : "false")
 
         if (fireflyPath != rootDir.getPath()) {
             props.setProperty('BuildCommitFirefly', getCommitHash(fireflyPath))
+            props.setProperty('BuildGitTagFirefly', getCommitTag(fireflyPath))
         }
 
         props.store(file("${project.buildDir}/version.tag").newWriter(), "Version Info")

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -131,13 +131,12 @@ task createVersionTag  {
         props.setProperty('BuildTime', build_time)
         props.setProperty('BuildTag', tag)
         props.setProperty('BuildCommit', getCommitHash())
-        props.setProperty('BuildGitTagFirefly', getCommitTag())
+        props.setProperty('BuildGitTagFirefly', getCommitTag(fireflyPath))
 
         props.setProperty('ExtendedCache', project.env == "local" ? (project.hasProperty("ExtendedCache") ? project.ExtendedCache : "true") : "false")
 
         if (fireflyPath != rootDir.getPath()) {
             props.setProperty('BuildCommitFirefly', getCommitHash(fireflyPath))
-            props.setProperty('BuildGitTagFirefly', getCommitTag(fireflyPath))
         }
 
         props.store(file("${project.buildDir}/version.tag").newWriter(), "Version Info")

--- a/config/common.prop
+++ b/config/common.prop
@@ -9,6 +9,7 @@ BuildTime=@build_time@
 BuildTag=@BuildTag@
 BuildCommit=@BuildCommit@
 BuildCommitFirefly=@BuildCommitFirefly@
+BuildGitTagFirefly=@BuildGitTagFirefly@
 
 
 #==========================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
@@ -3,8 +3,6 @@
  */
 package edu.caltech.ipac.firefly.data;
 
-import edu.caltech.ipac.util.StringUtils;
-
 import java.io.Serializable;
 
 /**
@@ -32,6 +30,7 @@ public class Version implements Serializable {
     private String      _buildTag= "";
     private String      _buildCommit= "";
     private String      _buildCommitFirefly= "";
+    private String      _buildGitTagFirefly= "";
     private long        _configLastModTime = 0;
 
 //======================================================================
@@ -74,6 +73,10 @@ public class Version implements Serializable {
         this._buildCommitFirefly = _buildCommitFirefly;
     }
 
+    public void setBuildGitTagFirefly(String buildGitTagFirefly) {
+        this._buildGitTagFirefly= buildGitTagFirefly;
+    }
+
     public String getBuildTime() {
         return _buildTime;
     }
@@ -97,6 +100,7 @@ public class Version implements Serializable {
     public String getBuildDate() { return _buildDate; }
     public int getBuildNumber() { return _build;  }
     public String getAppName() { return _appName; }
+    public String getBuildGitTagFirefly() { return _buildGitTagFirefly; }
 
     @Override
     public String toString() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.network;
 
+import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.download.URLDownload;
 import edu.caltech.ipac.firefly.server.util.Logger;
@@ -34,14 +35,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
-import static org.apache.commons.httpclient.params.HttpMethodParams.USER_AGENT;
 
 
 /**
@@ -188,7 +187,7 @@ public class HttpServices {
             LOG.info("HttpServices URL:" + method.getURI().toString());
 
             method.setRequestHeader("Connection", "close");            // request server to NOT keep-alive.. we don't plan to reuse this connection.
-            method.setRequestHeader("User-Agent", URLDownload.getUserAgentString());
+            method.setRequestHeader("User-Agent", VersionUtil.getUserAgentString());
             method.setRequestHeader(HttpHeaders.ACCEPT_ENCODING, "gzip");
             if (method instanceof GetMethod) {
                 method.setFollowRedirects(input.isFollowRedirect());    // post are not allowed to follow redirect

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
@@ -188,7 +188,7 @@ public class HttpServices {
             LOG.info("HttpServices URL:" + method.getURI().toString());
 
             method.setRequestHeader("Connection", "close");            // request server to NOT keep-alive.. we don't plan to reuse this connection.
-            method.setRequestHeader("User-Agent", USER_AGENT);
+            method.setRequestHeader("User-Agent", URLDownload.getUserAgentString());
             method.setRequestHeader(HttpHeaders.ACCEPT_ENCODING, "gzip");
             if (method instanceof GetMethod) {
                 method.setFollowRedirects(input.isFollowRedirect());    // post are not allowed to follow redirect

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
@@ -4,7 +4,6 @@
 package edu.caltech.ipac.firefly.server.servlets;
 
 import edu.caltech.ipac.firefly.server.util.StopWatch;
-import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.firefly.ui.creator.CommonParams;
 import edu.caltech.ipac.util.ComparisonUtil;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
@@ -5,7 +5,6 @@ package edu.caltech.ipac.firefly.server.util;
 
 import edu.caltech.ipac.firefly.data.Version;
 import edu.caltech.ipac.firefly.server.ServerContext;
-import edu.caltech.ipac.util.AppProperties;
 
 import javax.servlet.ServletContext;
 import java.io.File;
@@ -34,6 +33,7 @@ public class VersionUtil {
     private static final String BUILD_TAG  ="BuildTag";
     private static final String BUILD_COMMIT  ="BuildCommit";
     private static final String BUILD_COMMIT_FIREFLY  ="BuildCommitFirefly";
+    private static final String BUILD_GIT_TAG_FIREFLY ="BuildGitTagFirefly";
 
     private static final String VERSION_FILE = "version.tag";
 
@@ -70,7 +70,9 @@ public class VersionUtil {
             _version.setBuildTime(props.getProperty(BUILD_TIME));
             _version.setBuildTag(props.getProperty(BUILD_TAG));
             _version.setBuildCommit(props.getProperty(BUILD_COMMIT));
+            _version.setBuildCommit(props.getProperty(BUILD_COMMIT));
             _version.setBuildCommitFirefly(props.getProperty(BUILD_COMMIT_FIREFLY));
+            _version.setBuildGitTagFirefly(props.getProperty(BUILD_GIT_TAG_FIREFLY));
         } catch (IOException e) {
             // just ignore
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
@@ -5,12 +5,15 @@ package edu.caltech.ipac.firefly.server.util;
 
 import edu.caltech.ipac.firefly.data.Version;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.util.StringUtils;
 
 import javax.servlet.ServletContext;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 /**
  * User: roby
  * Date: May 15, 2009
@@ -36,6 +39,7 @@ public class VersionUtil {
     private static final String BUILD_GIT_TAG_FIREFLY ="BuildGitTagFirefly";
 
     private static final String VERSION_FILE = "version.tag";
+    private static final String unknownVersionUA= "Firefly/development";
 
     private static final Version _version= new Version();
     private static boolean init= false;
@@ -70,7 +74,6 @@ public class VersionUtil {
             _version.setBuildTime(props.getProperty(BUILD_TIME));
             _version.setBuildTag(props.getProperty(BUILD_TAG));
             _version.setBuildCommit(props.getProperty(BUILD_COMMIT));
-            _version.setBuildCommit(props.getProperty(BUILD_COMMIT));
             _version.setBuildCommitFirefly(props.getProperty(BUILD_COMMIT_FIREFLY));
             _version.setBuildGitTagFirefly(props.getProperty(BUILD_GIT_TAG_FIREFLY));
         } catch (IOException e) {
@@ -89,6 +92,41 @@ public class VersionUtil {
         }
         return retval;
     }
+
+    public static String getUserAgentString() {
+        String fUA= getFireflyUA();
+        Version v= getAppVersion();
+        if (v.getAppName().equalsIgnoreCase("firefly")) return fUA;
+        if (v.getMajor()==0) return fUA;
+        return fUA + " ("+v.getAppName() + "/" + v.getMajor()+"."+v.getMinor()+"."+v.getRev() + ")";
+    }
+
+    private static String getFireflyUA() {
+        String tag = getAppVersion().getBuildGitTagFirefly();
+        if (StringUtils.isEmpty(tag)) return unknownVersionUA;
+        try {
+            Matcher m= Pattern.compile("\\d+(\\.\\d+)+").matcher(tag);
+            return "Firefly/" + m.results().findFirst().get().group();
+        } catch (Exception e) {
+            return unknownVersionUA;
+        }
+    }
+
+//    private static String getFireflyUA() {
+//        String unknown= "Firefly/development";
+//        String tag = getAppVersion().getBuildGitTagFirefly();
+//        if (StringUtils.isEmpty(tag)) return unknown;
+//        Matcher m = Pattern.compile("[1-9]").matcher(tag);
+//        if (!m.find()) return unknown;
+//        int firstIdx= m.start();
+//        int lastIdx= m.start();
+//        while (m.find()) lastIdx= m.start();
+//        try {
+//            return "Firefly/" + tag.substring(firstIdx,lastIdx+1);
+//        } catch (Exception e) {
+//            return unknown;
+//        }
+//    }
 
 }
 

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -5,7 +5,6 @@ package edu.caltech.ipac.util.download;
 
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.HttpResultInfo;
-import edu.caltech.ipac.firefly.data.Version;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.util.Base64;
@@ -32,8 +31,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -48,30 +45,6 @@ public class URLDownload {
 
     public static String getUserFromUrl(String url) { return getUserInfoPart(url,0); }
     public static String getPasswordFromUrl(String url) { return getUserInfoPart(url,1); }
-
-    public static String getUserAgentString() {
-        Version v= VersionUtil.getAppVersion();
-        String fUA= getFireflyUA(v);
-        if (v.getAppName().equalsIgnoreCase("firefly")) return fUA;
-        if (v.getMajor()==0) return fUA;
-        return fUA + " ("+v.getAppName() + "/" + v.getMajor()+"."+v.getMinor()+"."+v.getRev() + ")";
-    }
-
-    private static String getFireflyUA(Version v) {
-        String unknown= "Firefly/development";
-        String tag = v.getBuildGitTagFirefly();
-        if (StringUtils.isEmpty(tag)) return unknown;
-        Matcher m = Pattern.compile("[1-9]").matcher(tag);
-        if (!m.find()) return unknown;
-        int firstIdx= m.start();
-        int lastIdx= m.start();
-        while (m.find()) lastIdx= m.start();
-        try {
-            return "Firefly/" + tag.substring(firstIdx,lastIdx+1);
-        } catch (Exception e) {
-            return unknown;
-        }
-    }
 
     private static String getUserInfoPart(String url,int idx) {
         try {
@@ -130,7 +103,7 @@ public class URLDownload {
         try {
             URLConnection conn = url.openConnection();
             if (conn instanceof HttpURLConnection) {
-                conn.setRequestProperty("User-Agent", getUserAgentString());
+                conn.setRequestProperty("User-Agent", VersionUtil.getUserAgentString());
                 conn.setRequestProperty("Accept-Encoding", "gzip, deflate");
                 addCookiesToConnection(conn, cookies);
                 String[] userInfo = getUserInfo(url);

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -163,7 +163,7 @@ export function getVersionInfoStr(includeBuiltOnDate) {
 
 const VersionInfo= ()  => <div onClick={() => showFullVersionInfoDialog()}>{getVersionInfoStr(true)}</div>;
 
-function versionInfoFull({BuildMajor, BuildMinor, BuildRev, BuildNumber, BuildType, BuildTime, BuildTag, BuildCommit, BuildCommitFirefly}) {
+function versionInfoFull({BuildMajor, BuildMinor, BuildRev, BuildNumber, BuildType, BuildTime, BuildTag, BuildCommit, BuildGitTagFirefly, BuildCommitFirefly}) {
     let version = `v${BuildMajor}.${Number(BuildMinor)===-1?'Next':BuildMinor}`;
     version += BuildRev !== '0' ? `.${BuildRev}` : '';
     return (
@@ -193,6 +193,12 @@ function versionInfoFull({BuildMajor, BuildMinor, BuildRev, BuildNumber, BuildTy
                     <div className='DD-Version__key'>Git commit(Firefly)</div>
                     <div className='DD-Version__value'>{BuildCommitFirefly}</div>
                 </div>
+            }
+            { BuildGitTagFirefly &&
+            <div className='DD-Version__item'>
+                <div className='DD-Version__key'>Firefly Git Tag</div>
+                <div className='DD-Version__value'>{BuildGitTagFirefly}</div>
+            </div>
             }
         </div>
     );


### PR DESCRIPTION
### Firefly-886: add user agent based on tag to firefly network calls
 
 - gets the firefly tag 
 - show it in the version dialog
 - use the tag to make a user agent for net work calls

_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-886

#### Testing

- add a tag to the branch such as `release-2033.44.33` (that you will delete later)
- build the branch
- You should be the tag in the about dialog and any network call will log the user agent as `firefly/2033.44.33`
