### PR TITLE
FIREFLY-891-895: ZTF tab and table bugs

### DIFF
--- a/src/firefly/js/ui/panel/TabPanel.css
+++ b/src/firefly/js/ui/panel/TabPanel.css
@@ -23,10 +23,11 @@
 }
 
 .TabPanel__Tabs {
-  list-style: none;
-  padding:0;
-  margin:0;
+    list-style: none;
+    padding:0;
+    margin:0;
     display: inline-flex;
+    overflow: hidden;
 }
 
 

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -37,7 +37,7 @@ const TabsHeaderInternal = React.memo((props) => {
     let sizedChildren = children;
     if (widthPx && resizable) {
         // 2*5px - border, for each tab: 2x1px - border, 2x6px - padding, 6px - left margin
-        const availableWidth = widthPx - 5 - 20 * numTabs;
+        const availableWidth = widthPx - 25 - 20 * numTabs;
         maxTitleWidth = Math.min(200, Math.trunc(availableWidth / numTabs));
         if (maxTitleWidth < 0) { maxTitleWidth = 1; }
         sizedChildren = childrenAry.map((child) => {


### PR DESCRIPTION
More changes in irsa-ife:  https://github.com/IPAC-SW/irsa-ife/pull/186

https://jira.ipac.caltech.edu/browse/FIREFLY-891
- Table's text-view off alignment

https://jira.ipac.caltech.edu/browse/FIREFLY-895
- ztf: location of x's to close tabs are now too close to the edge of the tab
- `Open Tabs` search button(down-arrow)  is hidden/cut off when there are many tabs

Test: https://firefly-891-895-tab-text-issues.irsakudev.ipac.caltech.edu/applications/ztf/
