### PR TITLE
FIREFLY-888_CORS: Allow CORS access to Content-Disposition response header

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
@@ -110,6 +110,7 @@ public abstract class BaseHttpServlet extends HttpServlet {
             resp.setHeader("Access-Control-Allow-Credentials", "true");
             resp.setHeader("Access-Control-Allow-Origin", req.getHeader("Origin"));
             resp.setHeader("Access-Control-Allow-Headers", req.getHeader("Access-Control-Request-Headers"));
+            resp.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
             resp.setHeader("Access-Control-Max-Age", "86400");      // cache for 1 day
         }
     }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-888

To duplicate:
Change this line: src/firefly/html/test/template.html:148
to, then rebuild firefly:
`    <script src="https://fireflydev.ipac.caltech.edu/firefly/firefly_loader.js"></script>`

then, goto http://localhost:8080/firefly/test/tests-table.html
- click 'Save' table on any table on that page.
You should noticed the saved file is 'undefined.txt'

Now, change that line: src/firefly/html/test/template.html:148
to, then rebuild firefly:
`    <script src="https://fireflydev.ipac.caltech.edu/firefly-888-cors-exposed-headers/firefly/firefly_loader.js"></script>`

then, goto http://localhost:8080/firefly/test/tests-table.html
- click 'Save' table, again.

You should see that the bug is fixed.

