### PR TITLE
firefly-914: clean up of firefly/js/visualize

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotRequest.java
@@ -63,7 +63,6 @@ public class WebPlotRequest extends ServerRequest {
     public static final String URL = "URL";
     public static final String SIZE_IN_DEG = "SizeInDeg";
     public static final String SURVEY_KEY = "SurveyKey";
-    public static final String SURVEY_KEY_ALT = "SurveyKeyAlt";
     public static final String SURVEY_KEY_BAND = "SurveyKeyBand";
     public static final String FILTER = "filter";
     public static final String TYPE = "Type";
@@ -133,7 +132,7 @@ public class WebPlotRequest extends ServerRequest {
     public static final String WAVE_LENGTH_UM= "WAVE_LENGTH_UM";
 
     private static final String _allKeys[] = {FILE, WORLD_PT, URL, SIZE_IN_DEG, SURVEY_KEY,
-                                              SURVEY_KEY_ALT, SURVEY_KEY_BAND, TYPE, ZOOM_TYPE,
+                                              SURVEY_KEY_BAND, TYPE, ZOOM_TYPE,
                                               SERVICE, USER_DESC, INIT_ZOOM_LEVEL,
                                               TITLE, ROTATE_NORTH, ROTATE_NORTH_TYPE, ROTATE, ROTATION_ANGLE,
                                               HEADER_KEY_FOR_TITLE,
@@ -893,14 +892,6 @@ public class WebPlotRequest extends ServerRequest {
 
     public String getSurveyKey() {
         return getParam(SURVEY_KEY);
-    }
-
-    public void setSurveyKeyAlt(String key) {
-        setParam(SURVEY_KEY_ALT, key);
-    }
-
-    public String getSurveyKeyAlt() {
-        return getParam(SURVEY_KEY_ALT);
     }
 
     public String getSurveyBand() { return getParam(SURVEY_KEY_BAND); }

--- a/src/firefly/js/api/ApiViewer.js
+++ b/src/firefly/js/api/ApiViewer.js
@@ -29,6 +29,13 @@ import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
 
 const logger = Logger('ApiViewer');
 
+/**
+ * @typedef ViewerType
+ * one of
+ * @prop TriView
+ * @prop Grid
+ * @type {Enum}
+ */
 export const ViewerType= new Enum([
     'TriView',  // use what it in the title
     'Grid' // use the plot description key

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -20,7 +20,23 @@ import {getDefaultChartProps} from '../charts/ChartUtil.js';
 export const LAYOUT_PATH = 'layout';
 
 // this enum is flaggable, therefore you can use any combination of the 3, i.e. 'tables | images'.
+/**
+ * @typedef LO_VIEW
+ * @type {Enum}
+ * @prop none
+ * @prop tables
+ * @prop images
+ * @prop xyPlots
+ * @prop tableImageMeta
+ * @prop coverageImage
+ */
 export const LO_VIEW = new Enum(['none', 'tables', 'images', 'xyPlots', 'tableImageMeta', 'coverageImage'], { ignoreCase: true });
+/**
+ * @typedef LO_MODE
+ * @type {Enum}
+ * @prop expanded
+ * @prop standard
+ */
 export const LO_MODE = new Enum(['expanded', 'standard']);
 export const SPECIAL_VIEWER = new Enum(['tableImageMeta', 'coverageImage'], { ignoreCase: true });
 

--- a/src/firefly/js/drawingLayers/SelectedShape.js
+++ b/src/firefly/js/drawingLayers/SelectedShape.js
@@ -2,4 +2,12 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import Enum from 'enum';
+
+/**
+ * @typedef SelectedShape
+ * enum can be one of rect, circle
+ * @prop rect
+ * @prop circle
+ * @type {Enum}
+ */
 export const SelectedShape = new Enum(['rect', 'circle']);

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -1,26 +1,21 @@
 
 import {union, get, isEmpty, difference, isArray} from 'lodash';
 import {
-    dispatchReplaceViewerItems,
-    getViewerItemIds,
-    getMultiViewRoot,
-    isImageViewerSingleLayout,
-    getLayoutType, GRID, DEFAULT_FITS_VIEWER_ID
+    dispatchReplaceViewerItems, getViewerItemIds, getMultiViewRoot,
+    getLayoutType, GRID, DEFAULT_FITS_VIEWER_ID, IMAGE
 } from '../visualize/MultiViewCntlr.js';
 import ImagePlotCntlr, {
     dispatchPlotImage, dispatchDeletePlotView, visRoot, dispatchZoom,
-    dispatchPlotGroup, dispatchChangeActivePlotView, dispatchPlotMaskLazyLoad
-} from '../visualize/ImagePlotCntlr.js';
+    dispatchPlotGroup, dispatchChangeActivePlotView } from '../visualize/ImagePlotCntlr.js';
 import {AnnotationOps, isImageDataRequestedEqual} from '../visualize/WebPlotRequest.js';
-import {getPlotViewAry, getPlotViewById, isPlotIdInPvNewPlotInfoAry, primePlot} from '../visualize/PlotViewUtil.js';
-import {UserZoomTypes} from '../visualize/ZoomUtil.js';
+import {
+    getPlotViewAry, getPlotViewById, isImageExpanded, primePlot } from '../visualize/PlotViewUtil.js';
 import {allBandAry} from '../visualize/Band.js';
 import {getTblById} from '../tables/TableUtil.js';
 import {PlotAttribute} from '../visualize/PlotAttribute.js';
 import {dispatchTableHighlight} from '../tables/TablesCntlr.js';
-import {isImageExpanded} from '../visualize/ImagePlotCntlr';
 import {DPtypes} from 'firefly/metaConvert/DataProductsType.js';
-import {showPinMessage, showTmpModal} from 'firefly/ui/PopupUtil.jsx';
+import {showPinMessage} from 'firefly/ui/PopupUtil.jsx';
 import {dispatchAddActionWatcher} from 'firefly/core/MasterSaga.js';
 import {logger} from 'firefly/util/Logger.js';
 
@@ -84,7 +79,7 @@ let extractedPlotId= 1;
 
 
 function copyRequest(inR) {
-    const r= inR.makeCopy(inR);
+    const r= inR.makeCopy();
     const plotId= `extract-plotId-${extractedPlotId}`;
     r.setPlotId(plotId);
     r.setPlotGroupId('extract-group');
@@ -104,18 +99,7 @@ export function createSingleImageExtraction(request) {
 }
 
 
-
-
-
-export function zoomPlotPerViewSizeOLD(plotId, zoomType) {
-    setTimeout(() => {
-        if (!visRoot().wcsMatchType) {
-            dispatchZoom({plotId, userZoomType: zoomType});
-        }
-    },5);
-}
-///=========================
-
+/** @type actionWatcherCallback */
 function watchForCompletedPlot(action, cancelSelf, params) {
     const {afterComplete, plotId}= params;
     const {payload,type}= action;
@@ -159,7 +143,7 @@ export function zoomPlotPerViewSize(plotId, zoomType) {
 ///=========================
 
 export function resetImageFullGridActivePlot(tbl_id, plotIdAry) {
-    if (!tbl_id || isEmpty(plotIdAry)) return
+    if (!tbl_id || isEmpty(plotIdAry)) return;
 
     const {highlightedRow = 0} = getTblById(tbl_id)||{};
     const vr = visRoot();
@@ -225,7 +209,7 @@ function replotImageDataProducts(activePlotId, imageViewerId, tbl_id, reqAry, th
     const inViewerIds= getViewerItemIds(getMultiViewRoot(), imageViewerId);
     const idUnionLen= union(plottingIds,inViewerIds).length;
     if (idUnionLen!== inViewerIds.length || plottingIds.length<inViewerIds.length) {
-        dispatchReplaceViewerItems(imageViewerId,plottingIds);
+        dispatchReplaceViewerItems(imageViewerId,plottingIds,IMAGE);
     }
 
 

--- a/src/firefly/js/metaConvert/converterUtils.js
+++ b/src/firefly/js/metaConvert/converterUtils.js
@@ -148,7 +148,6 @@ export function createTableExtraction(source,titleInfo,tbl_index,colNames,colUni
  * @param {ChartInfo} chartInfo
  * @param {Number} tbl_index
  * @param {String} dataTypeHint  stuff like 'spectrum', 'image', 'cube', etc
- * @param {boolean} isSpectrumHint true if we think this table might a a spectrum
  * @param {Array.<String>} colNames - an array of column names
  * @param {Array.<String>} colUnits - an array of types names
  * @param {boolean} connectPoints if a default scatter chart then connect the points

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -14,7 +14,6 @@ import {TriViewImageSection} from '../../visualize/ui/TriViewImageSection.jsx';
 import {AppInitLoadingMessage} from '../../ui/AppInitLoadingMessage.jsx';
 import {getExpandedChartProps} from '../../charts/ChartsCntlr.js';
 import {DEFAULT_PLOT2D_VIEWER_ID} from '../../visualize/MultiViewCntlr.js';
-import {VisMiniToolbar} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
 
 export class TriViewPanel extends PureComponent {
 
@@ -44,7 +43,6 @@ export class TriViewPanel extends PureComponent {
         const {title, mode, showTables, showImages, showXyPlots, images={}} = this.state;
         const {expanded, standard, closeable} = mode || {};
         const content = {};
-        var visToolbar;
 
         if (initLoadingMessage && !initLoadCompleted) return (<AppInitLoadingMessage message={initLoadingMessage}/>);
 

--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -24,7 +24,6 @@ import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {warningDivId} from '../../ui/LostConnection';
 import {startTTFeatureWatchers} from '../common/ttFeatureWatchers.js';
 import {dispatchSetLayoutMode, LO_MODE} from '../../core/LayoutCntlr';
-import {} from '../../core/AppDataCntlr';
 import {getExpandedChartProps} from '../../charts/ChartsCntlr.js';
 import {DEFAULT_PLOT2D_VIEWER_ID} from '../../visualize/MultiViewCntlr.js';
 

--- a/src/firefly/js/templates/hydra/SampleHydra.jsx
+++ b/src/firefly/js/templates/hydra/SampleHydra.jsx
@@ -3,7 +3,7 @@
  */
 
 
-import React, {Component, PropTypes} from 'react';
+import React from 'react';
 import {get} from 'lodash';
 import SplitPane from 'react-split-pane';
 

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -142,7 +142,7 @@ function getInitState()  {
     return {
         plot, pv, colors,
         threeC: isThreeColor(plot),
-        hasOperation: plot.plotState.hasOperation(Operation.CROP) && !plot.plotState.hasOperation(Operation.ROTATE),
+        hasOperation: plot.plotState.hasOperation(Operation.CROP)
     };
 }
 

--- a/src/firefly/js/visualize/Band.js
+++ b/src/firefly/js/visualize/Band.js
@@ -4,12 +4,16 @@
 import Enum from 'enum';
 
 /**
- * @typedef Band
+ * @typedef  Band
  * A Band in an image plot
  * must be enum 'RED', 'GREEN', 'BLUE', 'NO_BAND'
+ * @prop RED
+ * @prop GREEN
+ * @prop BLUE
+ * @prop NO_BAND
+ * @type {Enum}
  * @public
  * @global
- * @prop value
  */
 export const Band= new Enum({'RED':0, 'GREEN':1, 'BLUE':2, 'NO_BAND':0}, {ignoreCase:true});
 

--- a/src/firefly/js/visualize/BandState.js
+++ b/src/firefly/js/visualize/BandState.js
@@ -1,9 +1,8 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-
-
-import WebPlotRequest from './WebPlotRequest.js';
+import {isString} from 'lodash';
+import {WebPlotRequest} from './WebPlotRequest.js';
 import {RangeValues} from './RangeValues.js';
 
 /**
@@ -15,151 +14,84 @@ import {RangeValues} from './RangeValues.js';
  * @prop uploadFileNameStr
  * @prop imageIdx
  * @prop originalImageIdx
- * @prop plotRequestSerialize
+ * @prop plotRequest
  * @prop rangeValuesSerialize
+ * @prop rangeValues
  * @prop directFileAccessData
  * @prop multiImageFile
  * @prop tileCompress
  * @prop cubeCnt
  * @prop cubePlaneNumber
  */
-export class BandState {
-    constructor() {
-        this.workingFitsFileStr = null;
-        this.originalFitsFileStr= null;
-        this.uploadFileNameStr= null;
-        this.imageIdx= 0;
-        this.originalImageIdx= 0;
 
-        this.plotRequestSerialize = null; // Serialized WebPlotRequest
-        this.rangeValuesSerialize = null; // Serialized RangeValues
-        this.directFileAccessData= null;
-        this.multiImageFile = false;
-        this.tileCompress = false;
-        this.cubeCnt = 0;
-        this.cubePlaneNumber = 0;
-
-        this.plotRequestTmp= null;
-        this.rangeValues   = null;
-    }
-
-    /**
-     *
-     */
-    getCubePlaneNumber() { return this.cubePlaneNumber; }
-
-    /**
-     *
-     * @return {number}
-     */
-    getCubeCnt() { return this.cubeCnt; }
-
-
-    /**
-     * get a copy of the WebPlotRequest for this BandState.  Any changes to the object will not be reflected in
-     * BandState you must set it back in
-     * @return {WebPlotRequest}
-     */
-    getWebPlotRequest() {
-        if (!this.plotRequestTmp) this.plotRequestTmp= WebPlotRequest.parse(this.plotRequestSerialize);
-        return this.plotRequestTmp;
-    }
-
-    hasRequest() { return this.plotRequestSerialize!==null; }
-
-
-    /**
-     *
-     * @return {RangeValues}
-     */
-    getRangeValues() {
-        if (!this.rangeValues) this.rangeValues= RangeValues.parse(this.rangeValuesSerialize);
-        return this.rangeValues;
-    }
-
-
-   /**
-     *
-     * @return {ClientFitsHeader}
-     */
-    getDirectFileAccessData() { return this.directFileAccessData; }
-
-    /**
-     *
-     * @return {string}
-     */
-    getWorkingFitsFileStr() { return this.workingFitsFileStr; }
-
-
-    /**
-     *
-     * @return {string}
-     */
-    getOriginalFitsFileStr() { return this.originalFitsFileStr; }
-
-
-
-    /**
-     *
-     * @return {string}
-     */
-    getUploadedFileName() { return this.uploadFileNameStr; }
-
-    static makeBandState() { return new BandState(); }
-
-    /**
-     * make a BandState from a pure json representation
-     * @param {object} bsJson parsed json object
-     * @return {BandState}
-     */
-    static makeBandStateWithJson(bsJson) {
-        if (!bsJson) return null;
-        const bState= BandState.makeBandState();
-
-
-
-        bState.workingFitsFileStr= bsJson.workingFitsFileStr;
-        bState.originalFitsFileStr= bsJson.originalFitsFileStr;
-        if (bsJson.uploadFileNameStr) bState.uploadFileNameStr= bsJson.uploadFileNameStr;
-        bState.imageIdx= bsJson.imageIdx || 0;
-        bState.originalImageIdx= bsJson.originalImageIdx || 0;
-        bState.plotRequestSerialize= bsJson.plotRequestSerialize;
-        bState.rangeValuesSerialize= bsJson.rangeValuesSerialize;
-        bState.multiImageFile= Boolean(bsJson.multiImageFile);
-        bState.tileCompress = Boolean(bsJson.tileCompress);
-        bState.cubeCnt= bsJson.cubeCnt || 0;
-        bState.cubePlaneNumber= bsJson.cubePlaneNumber || 0;
-        bState.directFileAccessData= bsJson.directFileAccessData;
-        return bState;
-    }
-
-    /**
-     * @param {BandState} bs
-     * @param {boolean} includeDirectAccessData include the directFileAccessData object
-     */
-    static convertToJSON(bs, includeDirectAccessData= true) {
-        if (!bs || !bs.plotRequestSerialize) return null;
-        const json= {};
-        json.workingFitsFileStr= bs.workingFitsFileStr;
-        if (bs.workingFitsFileStr!==bs.originalFitsFileStr) json.originalFitsFileStr= bs.originalFitsFileStr;
-        if (bs.uploadFileNameStr) json.uploadFileNameStr= bs.uploadFileNameStr;
-        if (bs.imageIdx) json.imageIdx= bs.imageIdx;
-        if (bs.originalImageIdx) json.originalImageIdx= bs.originalImageIdx;
-        json.plotRequestSerialize= bs.getWebPlotRequest().toStringServerSideOnly();
-
-
-        json.rangeValuesSerialize= bs.rangeValuesSerialize;
-        if (includeDirectAccessData) json.directFileAccessData= bs.directFileAccessData;
-        if (bs.multiImageFile) json.multiImageFile= bs.multiImageFile;
-        if (bs.tileCompress) json.tileCompress = bs.tileCompress;
-        if (bs.cubeCnt) json.cubeCnt= bs.cubeCnt;
-        if (bs.cubePlaneNumber) json.cubePlaneNumber= bs.cubePlaneNumber;
-        return json;
-
-    }
+/**
+ * @param {WebPlotRequest|String} plotRequest - the plot request or serialized version
+ * @param {RangeValues|String} rangeValues - the range values or serialized version
+ * @return {BandState}
+ */
+export function makeBandState(plotRequest, rangeValues) {
+    return {
+        workingFitsFileStr: undefined,
+        originalFitsFileStr: undefined,
+        uploadFileNameStr: undefined,
+        imageIdx: 0,
+        originalImageIdx: 0,
+        directFileAccessData: undefined,
+        multiImageFile: false,
+        tileCompress: false,
+        cubeCnt: 0,
+        cubePlaneNumber: 0,
+        plotRequest : isString(plotRequest) ? WebPlotRequest.parse(plotRequest) : plotRequest,
+        rangeValues: isString(rangeValues) ? RangeValues.parse(rangeValues) : rangeValues,
+    };
 }
 
 
+/**
+ * make a BandState from a pure json representation
+ * @param {object} bsJson parsed json object
+ * @param {WebPlotRequest|String} overridePlotRequest -  a request or the serialized string version
+ * @param {RangeValues|String} overrideRV -  a RangeValues or the serialized string version
+ * @return {BandState}
+ */
+export function makeBandStateWithJson(bsJson, overridePlotRequest, overrideRV ) {
+    if (!bsJson) return undefined;
+    const bState= makeBandState(overridePlotRequest ?? bsJson.plotRequestSerialize, overrideRV ?? bsJson.rangeValuesSerialize);
+    bState.workingFitsFileStr= bsJson.workingFitsFileStr;
+    bState.originalFitsFileStr= bsJson.originalFitsFileStr;
+    if (bsJson.uploadFileNameStr) bState.uploadFileNameStr= bsJson.uploadFileNameStr;
+    bState.imageIdx= bsJson.imageIdx || 0;
+    bState.originalImageIdx= bsJson.originalImageIdx || 0;
+    bState.multiImageFile= Boolean(bsJson.multiImageFile);
+    bState.tileCompress = Boolean(bsJson.tileCompress);
+    bState.cubeCnt= bsJson.cubeCnt || 0;
+    bState.cubePlaneNumber= bsJson.cubePlaneNumber || 0;
+    bState.directFileAccessData= bsJson.directFileAccessData;
+    // bState.rangeValues= RangeValues.parse(bState.rangeValuesSerialize);
+    return bState;
+}
+
+/**
+ * @param {BandState|undefined|null} bs
+ * @param {boolean} includeDirectAccessData include the directFileAccessData object
+ */
+export function convertBandStateToJSON(bs, includeDirectAccessData= true) {
+    if (!bs || !bs.plotRequest) return undefined;
+    const json= {};
+    json.workingFitsFileStr= bs.workingFitsFileStr;
+    if (bs.workingFitsFileStr!==bs.originalFitsFileStr) json.originalFitsFileStr= bs.originalFitsFileStr;
+    if (bs.uploadFileNameStr) json.uploadFileNameStr= bs.uploadFileNameStr;
+    if (bs.imageIdx) json.imageIdx= bs.imageIdx;
+    if (bs.originalImageIdx) json.originalImageIdx= bs.originalImageIdx;
+    json.plotRequestSerialize= bs.plotRequest.toStringServerSideOnly();
 
 
-export default BandState;
+    json.rangeValuesSerialize= bs.rangeValues.toJSON();
+    if (includeDirectAccessData) json.directFileAccessData= bs.directFileAccessData;
+    if (bs.multiImageFile) json.multiImageFile= bs.multiImageFile;
+    if (bs.tileCompress) json.tileCompress = bs.tileCompress;
+    if (bs.cubeCnt) json.cubeCnt= bs.cubeCnt;
+    if (bs.cubePlaneNumber) json.cubePlaneNumber= bs.cubePlaneNumber;
+    return json;
+
+}

--- a/src/firefly/js/visualize/ChangePrime.js
+++ b/src/firefly/js/visualize/ChangePrime.js
@@ -60,6 +60,7 @@ export function changePrime(rawAction, dispatcher, getState) {
     checkZoom(plotId,oldP, newP, scrollToImagePt,visRoot);
 }
 
+/** @type actionWatcherCallback */
 function zoomCompleteWatch(action, cancelSelf, {plotId,scrollToImagePt},dispatch,getState) {
     if (action.payload.plotId===plotId) {
         const visRoot= getState()[IMAGE_PLOT_KEY];

--- a/src/firefly/js/visualize/CoordSys.js
+++ b/src/firefly/js/visualize/CoordSys.js
@@ -18,16 +18,16 @@ export const ECLIPTIC_J   = 13;
  * @description value is one of the following constants; EQ_J2000, EQ_B2000, EQ_B1950, GALACTIC,
  * SUPERGALACTIC, ECL_J2000, ECL_B1950, PIXEL, SCREEN_PIXEL, UNDEFINED,
  *
- * @prop isEquatorial
+ * @prop {Function} isEquatorial
+ * @prop {Function} getJsys
+ * @prop {Function} getEquinox
  * @global
  * @public
  */
 
 
 export const CoordinateSys = function () {
-
-
-    var init = function (desc, equatorial, jsys, equinox) {
+    const init = (desc, equatorial, jsys, equinox) => {
         return {
             toString() { return desc; },
             isEquatorial() { return equatorial; },
@@ -36,71 +36,55 @@ export const CoordinateSys = function () {
         };
     };
 
-    var EQ_J2000 = init('EQ_J2000', true, EQUATORIAL_J, 2000 );
-    var EQ_B2000 = init('EQ_B2000', true, EQUATORIAL_B, 2000);
-    var EQ_B1950 = init('EQ_B1950', true, EQUATORIAL_B, 1950);
-    var GALACTIC = init('GALACTIC', false, GALACTIC_JSYS, 2000);
-    var SUPERGALACTIC = init('SUPERGALACTIC', false, SUPERGALACTIC_JSYS, 2000 );
-    var ECL_J2000 = init('EC_J2000', false, ECLIPTIC_J, 2000);
-    var ECL_B1950 = init('EC_B1950', false, ECLIPTIC_B, 1950);
+    const EQ_J2000 = init('EQ_J2000', true, EQUATORIAL_J, 2000 );
+    const EQ_B2000 = init('EQ_B2000', true, EQUATORIAL_B, 2000);
+    const EQ_B1950 = init('EQ_B1950', true, EQUATORIAL_B, 1950);
+    const GALACTIC = init('GALACTIC', false, GALACTIC_JSYS, 2000);
+    const SUPERGALACTIC = init('SUPERGALACTIC', false, SUPERGALACTIC_JSYS, 2000 );
+    const ECL_J2000 = init('EC_J2000', false, ECLIPTIC_J, 2000);
+    const ECL_B1950 = init('EC_B1950', false, ECLIPTIC_B, 1950);
 
-    var PIXEL = init('PIXEL', false,-999, 0);
-    var SCREEN_PIXEL = init('SCREEN_PIXEL', false,-999, 0);
-    var UNDEFINED = init('UNDEFINED', false,-999, 0);
-    var ZEROBASED = init('ZERO-BASED', false, -999, 0);
-    var FITSPIXEL = init('FITSPIXEL', false, -999, 0);
+    const PIXEL = init('PIXEL', false,-999, 0);
+    const SCREEN_PIXEL = init('SCREEN_PIXEL', false,-999, 0);
+    const UNDEFINED = init('UNDEFINED', false,-999, 0);
+    const ZEROBASED = init('ZERO-BASED', false, -999, 0);
+    const FITSPIXEL = init('FITSPIXEL', false, -999, 0);
 
 
-    var parse= function(desc) {
-        var coordSys;
-        if (!desc) return null;
+    const parse= (desc) => {
+        if (!desc) return undefined;
         desc= desc.toUpperCase();
         if        (desc===EQ_J2000.toString() || desc==='EQJ2000' ||desc==='EQJ' || desc==='J2000' || desc==='ICRS') {
-            coordSys = EQ_J2000;
+            return EQ_J2000;
         } else if (desc===EQ_B2000.toString() || desc==='EQB2000' )  {
-            coordSys = EQ_B2000;
+            return EQ_B2000;
         } else if (desc===EQ_B1950.toString() || desc==='EQB1950' || desc==='EQB' || desc==='B1950' ) {
-            coordSys = EQ_B1950;
+            return EQ_B1950;
         } else if (desc===GALACTIC.toString() || desc==='GAL') {
-            coordSys = GALACTIC;
+            return GALACTIC;
         } else if (desc===SUPERGALACTIC.toString()) {
-            coordSys = SUPERGALACTIC;
+            return SUPERGALACTIC;
         } else if (desc===ECL_J2000.toString() || desc==='ECJ2000' | desc==='ECLJ2000' || desc==='ECJ') {
-            coordSys = ECL_J2000;
+            return ECL_J2000;
         } else if (desc===ECL_B1950.toString() || desc==='ECLB1950'|| desc==='ECB') {
-            coordSys = ECL_B1950;
+            return ECL_B1950;
         } else if (desc===SCREEN_PIXEL.toString()) {
-            coordSys = SCREEN_PIXEL;
+            return SCREEN_PIXEL;
         } else if (desc===PIXEL.toString()) {
-            coordSys = PIXEL;
+            return PIXEL;
         } else if (desc===ZEROBASED.toString() || desc==='ZERO_BASED') {
-            coordSys = ZEROBASED;
+            return ZEROBASED;
         } else if (desc===FITSPIXEL.toString()) {
-            coordSys = FITSPIXEL;
+            return FITSPIXEL;
         } else {
-            coordSys = null;
+            return undefined;
         }
-
-        return coordSys;
     };
 
-    var retval = {};
-    retval.parse= parse;
-    retval.EQ_J2000 = EQ_J2000;
-    retval.EQ_B2000 = EQ_B2000;
-    retval.EQ_B1950 = EQ_B1950;
-    retval.GALACTIC = GALACTIC;
-    retval.SUPERGALACTIC = SUPERGALACTIC;
-    retval.ECL_J2000 = ECL_J2000;
-    retval.ECL_B1950 = ECL_B1950;
-    retval.PIXEL = PIXEL;
-    retval.ZEROBASED = ZEROBASED;
-    retval.FITSPIXEL = FITSPIXEL;
-    retval.SCREEN_PIXEL = SCREEN_PIXEL;
-    retval.UNDEFINED = UNDEFINED;
-
-
-    return retval;
+    return {
+        parse, EQ_J2000, EQ_B2000, EQ_B1950, GALACTIC, SUPERGALACTIC, ECL_J2000, ECL_B1950,
+        PIXEL, ZEROBASED, FITSPIXEL, SCREEN_PIXEL, UNDEFINED
+    };
 }();
 
 export function findCoordSys(jsys, equinox) {
@@ -115,4 +99,3 @@ export function findCoordSys(jsys, equinox) {
 }
 
 export default CoordinateSys;
-

--- a/src/firefly/js/visualize/CoordUtil.js
+++ b/src/firefly/js/visualize/CoordUtil.js
@@ -85,7 +85,7 @@ const sex2dd = function (coordstr, islat, isequ) {
         if (numseen===0) throw INVALID_STRING;
 
         //convert it and save it
-        part[i] = parseFloat(r.substring(0, numseen + pointseen));
+        part[i] = parseFloat(r?.substring(0, numseen + pointseen));
 
         r = p;  // now deal with the separator
         p = p.trim();

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -333,7 +333,7 @@ export class CysConverter {
                 retval= CysConverter.makeIPtFromFitsImPt(pt);
                 break;
             case Point.ZERO_BASED_IM_PT:
-                retval= this.makeIPtFromxZeroImPt(pt);
+                retval= this.makeIPtFromZeroImPt(pt);
                 break;
             case Point.W_PT:
                 retval = this.getImageCoordsFromWorldPt(pt);
@@ -356,7 +356,7 @@ export class CysConverter {
         return pt ? makeImagePt(pt.x-.5, pt.y-.5) : null;
     }
 
-    makeIPtFromxZeroImPt(pt) {
+    makeIPtFromZeroImPt(pt) {
         if (!pt) return null;
         const {ltv1,ltv2}= CysConverter.getLtv(this.header);
         return makeImagePt(pt.x+.5+ltv1, pt.y+.5+ltv2);
@@ -429,7 +429,6 @@ export class CysConverter {
             case Point.SPT:
                 retval= this.makeDevicePtFromSp(pt, altTransform);
                 break;
-                break;
         }
         return retval;
     }
@@ -448,7 +447,7 @@ export class CysConverter {
     /**
      *
      * @param {Object} sp ScreenPt
-     * @param {Object} altTransform
+     * @param {Object} [altTransform]
      * @return {DevicePt}
      */
      makeDevicePtFromSp(sp, altTransform) {
@@ -580,7 +579,7 @@ export class CysConverter {
 
     /**
      *
-     * @param {ImageWorkspacePt} iwpt ImageWorkspacePt
+     * @param {ImageWpt} iwpt ImageWorkspacePt
      * @param {number} [altZoomLevel]
      */
     makeSPtFromIWPt(iwpt, altZoomLevel) {
@@ -598,7 +597,7 @@ export class CysConverter {
 
     /**
      * @desc Return the sky coordinates given a image x (fsamp) and  y (fline)
-     * @param {Point} pt  the point to convert
+     * @param {Point|undefined} pt  the point to convert
      * @param  {CoordinateSys} [outputCoordSys] (optional) The coordinate system to return, default to coordinate system of image
      * @returns {WorldPt} the translated coordinates
      */
@@ -721,7 +720,7 @@ export const CCUtil = {
     /**
      *
      * Convert to Image Point
-     * @param {WebPlot} plot - the image
+     * @param {WebPlot|undefined} plot - the image
      * @param {object} pt - the point to convert
      * @return {ImagePt}
      * @function getImageCoords
@@ -747,7 +746,7 @@ export const CCUtil = {
      * Convert to Screen Point
      * */
     /**
-     * @param {WebPlot} plot - the image
+     * @param {WebPlot|undefined} plot - the image
      * @param {object} pt - the point to convert
      * @function  getScreenCoords
      * @memberof  firefly.util.image.CCUtil
@@ -757,7 +756,7 @@ export const CCUtil = {
     /**
      *
      * Convert to World Point
-     * @param {WebPlot} plot - the image
+     * @param {WebPlot|undefined} plot - the image
      * @param  pt - the point to convert
      * @return {WorldPt}
      * @function getWorldCoords
@@ -766,12 +765,6 @@ export const CCUtil = {
      */
     getWorldCoords: (plot,pt) => plot && CysConverter.make(plot).getWorldCoords(pt),
 
-    /**
-     *
-     * @ignore
-     *
-     */
-    getWorldPtRepresentation
 };
 
 

--- a/src/firefly/js/visualize/FitsHeaderUtil.js
+++ b/src/firefly/js/visualize/FitsHeaderUtil.js
@@ -2,8 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get} from 'lodash';
-import {isImage,isPlot} from './WebPlot.js';
+import {isImage} from './WebPlot.js';
 
 
 /**
@@ -15,11 +14,6 @@ import {isImage,isPlot} from './WebPlot.js';
  * @prop {number} height
  *
  */
-
-
-
-
-
 export const HdrConst= {
 
     // Common FITS Headers
@@ -42,6 +36,7 @@ export const HdrConst= {
     NAXIS1   : 'NAXIS1',
     NAXIS2   : 'NAXIS2',
     NAXIS3   : 'NAXIS3',
+    NAXIS4   : 'NAXIS4',
 
     // FITS Headers that are added by firefly
     SPOT_OFF : 'SPOT_OFF', // Extension Offset (added by Firefly)
@@ -57,7 +52,7 @@ export const HdrConst= {
 export function makeHeaderParse(header, altWcs='') {
     return {
         header,
-        getIntValue: (key, def= 0) => parseInt(getNumberHeader(header,key,def)),
+        getIntValue: (key, def= 0) => Math.trunc(getNumberHeader(header,key,def)),
 
         getIntOneOfValue: (keyAry, def=0) => {
             const foundKey= keyAry.find( (k) => !isNaN(getNumberHeader(header,k,NaN)) );
@@ -130,7 +125,7 @@ export function makeDoubleHeaderParse(header,zeroHeader,altWcs) {
         getDoubleAry(keyRoot,altWcs, startIdx,endIdx,def=undefined) {
             if (startIdx>endIdx) return def;
             const retAry= hp.getDoubleAry(keyRoot,altWcs,startIdx,endIdx, def);
-            let validValueArr = retAry.filter( (v)=> v!==def );
+            const validValueArr = retAry.filter( (v)=> v!==def );
             if (validValueArr.length>0) return retAry;
             return zhp ? zhp.getDoubleAry(keyRoot,altWcs, startIdx,endIdx,def) : def;
         },

--- a/src/firefly/js/visualize/HiPSListUtil.js
+++ b/src/firefly/js/visualize/HiPSListUtil.js
@@ -6,7 +6,13 @@ import {getColumnIdx, doFetchTable} from '../tables/TableUtil.js';
 import {ServerParams} from '../data/ServerParams.js';
 import {isBlankHiPSURL} from './WebPlot.js';
 
-export const HiPSId = 'hips';
+/**
+ * @typedef HiPSDataType
+ * @prop image
+ * @prop cube
+ * @prop catalog
+ * @type {Enum}
+ */
 export const HiPSDataType= new Enum([ 'image', 'cube', 'catalog'], { ignoreCase: true });
 export const HiPSData = [HiPSDataType.image, HiPSDataType.cube];
 export const HiPSSources = ServerParams.IRSA + ',' + ServerParams.CDS;
@@ -27,6 +33,12 @@ export function useForImageSearch() {
 }
 
 // convert comma separated string into trimmed-lowercase.
+/**
+ *
+ * @param {String} items
+ * @param {String} sep
+ * @return {Array.<String>}
+ */
 const toCsvLowercase = (items, sep = ',') => {
     return items?.split(sep).map( (s) => s?.trim()?.toLowerCase()).join(sep);
 };
@@ -36,12 +48,8 @@ const toCsvLowercase = (items, sep = ',') => {
  * @returns {string}
  */
 export function getHiPSSources() {
-    let srcs =  get(getAppOptions(), [HIPS_SEARCH, ServerParams.HIPS_SOURCES], ServerParams.ALL);
-
-    if (srcs.toLowerCase() === ServerParams.ALL.toLowerCase()) {
-        srcs = HiPSSources;
-    }
-    return toCsvLowercase(srcs);
+    const srcs = getAppOptions()?.[HIPS_SEARCH]?.[ServerParams.HIPS_SOURCES] ?? ServerParams.ALL;
+    return (srcs.toLowerCase() === ServerParams.ALL.toLowerCase()) ? HiPSSources : toCsvLowercase(srcs);
 }
 
 /**
@@ -61,7 +69,7 @@ export function defHiPSSources() {
 
 /**
  * get HiPS source priority for the merged list
- * @returns {string}
+ * @returns {Array.<string>}
  */
 export function getHiPSMergePriority() {
     const mergeP = get(getAppOptions(), [HIPS_SEARCH, ServerParams.HIPS_MERGE_PRIORITY], '');

--- a/src/firefly/js/visualize/HiPSMocUtil.js
+++ b/src/firefly/js/visualize/HiPSMocUtil.js
@@ -1,15 +1,13 @@
+import {get, set, isEmpty, flatten, isArray} from 'lodash';
 import {getDrawLayersByType} from './PlotViewUtil.js';
 import {getDlAry, dispatchCreateDrawLayer} from './DrawLayerCntlr.js';
 import HiPSMOC from '../drawingLayers/HiPSMOC.js';
 import {getHealpixCornerTool} from './HiPSUtil.js';
-import {get, set, isEmpty, flatten, isArray} from 'lodash';
 import {getAppOptions} from '../core/AppDataCntlr.js';
-import {getBooleanMetaEntry, getMetaEntry, getTblById} from '../tables/TableUtil';
+import {getBooleanMetaEntry, getTblById} from '../tables/TableUtil';
 import {MetaConst} from 'firefly/data/MetaConst.js';
 const HEADER_KEY_COL = 1;
 const HEADER_VAL_COL = 2;
-const HEADER_COMMENT_COL = 3;
-const HEADER_IDX_COL = 0;
 
 const MOC = '_moc';
 let   mocCnt = 0;

--- a/src/firefly/js/visualize/HiPSUtil.js
+++ b/src/firefly/js/visualize/HiPSUtil.js
@@ -143,7 +143,7 @@ const nOrderForPixAsSizeCacheMap= {};
  * Return the best norder for a given screen pixel angular size in arc seconds
  * Results are cached so this function is very efficient.
  * @param {Number} sizeInArcSec - pixel size in arc seconds
- * @return {Number} the best norder for the pixet l
+ * @return {Number} the best norder for the pixel
  */
 function getNOrderForPixArcSecSize(sizeInArcSec) {
     const sizeInArcSecKey= sizeInArcSec.toFixed(7);
@@ -415,7 +415,7 @@ function healpixPixelTo512TileXY(pixel) {
 /**
  *
  * @param norder
- * @param {WorldPt} centerWp - center of visible area, coorindate system of this point should be same as the projection
+ * @param {WorldPt} centerWp - center of visible area, coordinate system of this point should be same as the projection
  * @param {number} fov - Math.max(width, height) of the field of view in degrees (i think)
  * @param {CoordinateSys} dataCoordSys
  * @return {Array.<{ipix:string, wpCorners:Array.<WorldPt>}>} an array of objects the contain the healpix
@@ -477,9 +477,9 @@ export function makeSpatialVector(wp) {
 
 
 /**
- * convert to radius and extend a litte (suggestion from Aladin)
+ * convert to radius and extend a little (suggestion from Aladin)
  * @param {number} fov in degrees
- * @return {number} exetended radius in radians
+ * @return {number} extended radius in radians
  */
 function getSearchRadiusInRadians(fov) {
 

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -49,6 +49,14 @@ export const EXPANDED_MODE_RESERVED= 'EXPANDED_MODE_RESERVED';
 export const GRID_RELATED='gridRelated';
 export const GRID_FULL='gridFull';
 
+/**
+ * @typedef NewPlotMode
+ * enum one of
+ * @prop create_replace
+ * @prop replace_only
+ * @prop none
+ * @type {Enum}
+ */
 export const NewPlotMode = new Enum(['create_replace', 'replace_only', 'none']);
 
 function initState() {

--- a/src/firefly/js/visualize/PlotGroup.js
+++ b/src/firefly/js/visualize/PlotGroup.js
@@ -27,7 +27,7 @@ export const makePlotGroup= (plotGroupId,overlayColorLock) =>
 
 /**
  * get the plot view with the id
- * @param {VisRoot|Array.<PlotGroup>} visRootOrGroupAry- root of the visualization object in storet
+ * @param {VisRoot|Array.<PlotGroup>} visRootOrGroupAry - root of the visualization object in store
  * @param {string} plotGroupId
  * @return {object} the plot group object
  */

--- a/src/firefly/js/visualize/RangeValues.js
+++ b/src/firefly/js/visualize/RangeValues.js
@@ -2,7 +2,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-//LZ 06/11/15 add arcsine and power law gamma parameters
 import {isNumber, isString, isObject} from 'lodash';
 
 
@@ -63,25 +62,25 @@ export class RangeValues {
                  scalingK=1.0,
                  bias= 0.5,
                  contrast= 1.0 ) {
-        this.lowerWhich= parseInt(lowerWhich);
-        this.lowerValue= parseFloat(lowerValue);
-        this.upperWhich= parseInt(upperWhich);
-        this.upperValue= parseFloat(upperValue);
-        this.asinhQValue = parseFloat(asinhQValue);
-        this.gammaValue=parseFloat(gammaValue);
-        this.algorithm=  parseInt(algorithm);
-        this.zscaleContrast= parseInt(zscaleContrast);
-        this.zscaleSamples= parseInt(zscaleSamples); /* desired number of pixels in sample */
-        this.zscaleSamplesPerLine= parseInt(zscaleSamplesPerLine); /* optimal number of pixels per line */
-        this.rgbPreserveHue=  parseInt(rgbPreserveHue); /* if 0, stretch by band, otherwise preserve hue*/
-        this.asinhStretch=parseFloat(asinhStretch);
-        this.scalingK=parseFloat(scalingK);
+        this.lowerWhich= parseInt(lowerWhich+'');
+        this.lowerValue= parseFloat(lowerValue+'');
+        this.upperWhich= parseInt(upperWhich+'');
+        this.upperValue= parseFloat(upperValue+'');
+        this.asinhQValue = parseFloat(asinhQValue+'');
+        this.gammaValue=parseFloat(gammaValue+'');
+        this.algorithm=  parseInt(algorithm+'');
+        this.zscaleContrast= parseInt(zscaleContrast+'');
+        this.zscaleSamples= parseInt(zscaleSamples+''); /* desired number of pixels in sample */
+        this.zscaleSamplesPerLine= parseInt(zscaleSamplesPerLine+''); /* optimal number of pixels per line */
+        this.rgbPreserveHue=  parseInt(rgbPreserveHue+''); /* if 0, stretch by band, otherwise preserve hue*/
+        this.asinhStretch=parseFloat(asinhStretch+'');
+        this.scalingK=parseFloat(scalingK+'');
         if (this.rgbPreserveHue > 0) {
             this.algorithm = STRETCH_ASINH;
             this.upperWhich = ZSCALE;
         }
-        this.bias= parseFloat(bias);
-        this.contrast= parseFloat(contrast);
+        this.bias= parseFloat(bias+'');
+        this.contrast= parseFloat(contrast+'');
     }
 
 
@@ -89,7 +88,7 @@ export class RangeValues {
     /**
      * @return {RangeValues}
      */
-    static clone() {
+    clone() {
         return new RangeValues( this.lowerWhich, this.lowerValue, this.upperWhich,
             this.upperValue, this.asinhQValue,  this.gammaValue, this.algorithm,
             this.zscaleContrast, this.zscaleSamples, this.zscaleSamplesPerLine,

--- a/src/firefly/js/visualize/RelatedDataUtil.js
+++ b/src/firefly/js/visualize/RelatedDataUtil.js
@@ -113,7 +113,7 @@ export function setMaskVisible(opv, visible) {
 /**
  * Do processing to turn this related data into a drawing layer
  * @param {VisRoot}  vr
- * @param {PlotView} pv
+ * @param {PlotView|undefined} pv
  * @param {RelatedData} relatedData
  */
 export function enableRelatedDataLayer(vr, pv, relatedData) {
@@ -213,7 +213,7 @@ function enableRelatedDataLayerTableOverlay(pv, relatedData) {
  * search matchOverlayPlotViews array and find any related data in the passed PlotView. Enable the layers
  * that match.
  * This function has side effect of dispatching actions
- * @param {PlotView} pv the plot view the contains the related data
+ * @param {PlotView|undefined} pv the plot view the contains the related data
  * @param {OverlayPlotView[]} matchOverlayPlotViews array of OverlayPlotView that must be matched
  */
 export function enableMatchingRelatedData(pv, matchOverlayPlotViews) {

--- a/src/firefly/js/visualize/RequestType.js
+++ b/src/firefly/js/visualize/RequestType.js
@@ -5,9 +5,22 @@
 import Enum from 'enum';
 
 /**
+ * @typedef RequestType
  * @summary web plot request type
  * @description can be 'SERVICE', 'FILE', 'URL', 'ALL_SKY', 'HiPS', 'BLANK', 'PROCESSOR', 'RAWDATASET_PROCESSOR',
  * 'TRY_FILE_THEN_URL', 'WORKSPACE'
+ *
+ * @prop SERVICE
+ * @prop FILE
+ * @prop URL
+ * @prop ALL_SKY
+ * @prop HiPS
+ * @prop BLANK
+ * @prop PROCESSOR
+ * @prop RAWDATASET_PROCESSOR
+ * @prop TRY_FILE_THEN_URL
+ * @prop WORKSPACE
+ * @type {Enum}
  * @public
  * @global
  */

--- a/src/firefly/js/visualize/VisMouseSync.js
+++ b/src/firefly/js/visualize/VisMouseSync.js
@@ -13,6 +13,22 @@ import {isHiPS} from './WebPlot.js';
 import {getHealpixPixel} from './HiPSUtil';
 import {STANDARD_READOUT} from './MouseReadoutCntlr';
 
+/**
+ * @typedef MouseState
+ * @prop NONE,
+ * @prop ENTER,
+ * @prop EXIT,
+ * @prop DOWN,
+ * @prop UP,
+ * @prop DRAG_COMPONENT,
+ * @prop DRAG,
+ * @prop MOVE,
+ * @prop CLICK,
+ * @prop WHEEL_UP,
+ * @prop WHEEL_DOWN,
+ * @prop DOUBLE_CLICK,
+ * @type {Enum}
+ */
 export const MouseState= new Enum(['NONE', 'ENTER', 'EXIT', 'DOWN', 'UP',
     'DRAG_COMPONENT', 'DRAG', 'MOVE', 'CLICK', 'WHEEL_UP', 'WHEEL_DOWN',
     'DOUBLE_CLICK']);

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -433,7 +433,7 @@ export function isPlotRotatedNorth(plot, csys= CoordinateSys.EQ_J2000) {
 /**
  * Return true if east if left of north.  If east is right of north return false. This works regardless of the rotation
  * of the image.
- * @param {WebPlot} plot
+ * @param {WebPlot|undefined} plot
  * @return {boolean} true if is is left of north.
  */
 export function isEastLeftOfNorth(plot) {
@@ -465,8 +465,8 @@ export function isEastLeftOfNorth(plot) {
 
 /**
  *
- * @param {WebPlot} p1
- * @param {WebPlot} p2
+ * @param {WebPlot|undefined} p1
+ * @param {WebPlot|undefined} p2
  * @return {boolean}
  */
 export const isCsysDirMatching= (p1,p2) => isEastLeftOfNorth(p1)===isEastLeftOfNorth(p2);
@@ -685,7 +685,7 @@ function getSelectedPtsFromEllipse(selection, plot, objList) {
 }
 
 /**
- * get selected points from rectanglur selected area
+ * get selected points from rectangular selected area
  * @param {object} selection obj with two properties pt0 & pt1
  * @param {WebPlot} plot web plot
  * @param objList array of DrawObj (must be an array and contain a getCenterPt() method)
@@ -966,7 +966,7 @@ export function lineCrossesRect(segX1, segY1, segX2, segY2, x, y, w,h) {
 function direction(a, b, c) {
     const d = (b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y);
 
-    if (d == 0) {
+    if (d===0) {
         return 0;   // a, b, c collinear
     } else {
         return (d < 0) ? 2 : 1;

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -4,7 +4,6 @@ import Enum from 'enum';
 import {ServerRequest} from '../data/ServerRequest.js';
 import {RequestType} from './RequestType.js';
 import {ZoomType} from './ZoomType.js';
-import Point from './Point.js';
 import {parseResolver} from '../astro/net/Resolver.js';
 import {RangeValues} from './RangeValues.js';
 import {PlotAttribute} from './PlotAttribute.js';
@@ -18,16 +17,42 @@ const DEFAULT_HIPS_OVERLAYS= ['ACTIVE_TARGET_TYPE','POINT_SELECTION_TYPE', 'NORT
     'OVERLAY_MARKER_TYPE', 'OVERLAY_FOOTPRINT_TYPE', 'REGION_PLOT_TYPE', 'HIPS_GRID_TYPE', 'MOC_PLOT_TYPE'];
 
 /**
+ * @typedef ServiceType
  * @summary service type
  * @description can be 'IRIS', 'ISSA', 'DSS', 'SDSS', 'TWOMASS', 'MSX', 'WISE', 'ATLAS','ZTF', 'PTF', 'UNKNOWN'
+ *
+ * @prop IRIS
+ * @prop ISSA
+ * @prop DSS
+ * @prop SDSS
+ * @prop TWOMASS
+ * @prop MSX
+ * @prop WISE
+ * @prop ATLAS
+ * @prop ZTF
+ * @prop PTF
+ * @prop UNKNOWN
+ *
+ * @type {Enum}
  * @public
  * @global
  */
 export const ServiceType= new Enum(['IRIS', 'ISSA', 'DSS', 'SDSS', 'TWOMASS', 'MSX', 'WISE', 'ATLAS', 'ZTF', 'PTF', 'UNKNOWN'],
                                               { ignoreCase: true });
 /**
+ * @typedef {Object} TitleOptions
  * @summary title options
  * @description can be 'CLEARED', 'PLOT_DESC', 'FILE_NAME', 'HEADER_KEY', 'PLOT_DESC_PLUS', 'SERVICE_OBS_DATE'
+ *
+ * @prop NONE
+ * @prop CLEARED
+ * @prop PLOT_DESC
+ * @prop FILE_NAME
+ * @prop HEADER_KEY
+ * @prop PLOT_DESC_PLUS
+ * @prop SERVICE_OBS_DATE'
+ *
+ * @type {Enum}
  * @public
  * @global
  */
@@ -40,6 +65,18 @@ export const TitleOptions= new Enum([
     'SERVICE_OBS_DATE'
 ], { ignoreCase: true });
 
+/**
+ * @typedef {Object} AnnotationOps
+ * @prop INLINE
+ * @prop INLINE_BRIEF
+ * @prop INLINE_BRIEF_TOOLS
+ * @prop TITLE_BAR
+ * @prop TITLE_BAR_BRIEF
+ * @prop TITLE_BAR_BRIEF_TOOLS
+ * @prop TITLE_BAR_BRIEF_CHECK_BO
+ *
+ * @type {Enum}
+ */
 export const AnnotationOps= new Enum([  // note - this is not completely implemented - only finder chart using it now
     'INLINE',    //default inline title full title and tools
     'INLINE_BRIEF',  // inline brief title, no tools
@@ -50,6 +87,13 @@ export const AnnotationOps= new Enum([  // note - this is not completely impleme
     'TITLE_BAR_BRIEF_CHECK_BOX' // title bar brief title with a check box (used in planck)
 ], { ignoreCase: true });
 
+/**
+ * @typedef {Object} GridOnStatus
+ * @prop FALSE
+ * @prop TRUE
+ * @prop TRUE_LABELS_FALSE
+ * @type {Enum}
+ */
 export const GridOnStatus= new Enum(['FALSE','TRUE','TRUE_LABELS_FALSE'], { ignoreCase: true });
 
 export const DEFAULT_THUMBNAIL_SIZE= 70;
@@ -61,7 +105,6 @@ export const WPConst= {
     URLKEY : 'URL',
     SIZE_IN_DEG : 'SizeInDeg',
     SURVEY_KEY : 'SurveyKey',
-    SURVEY_KEY_ALT : 'SurveyKeyAlt',
     SURVEY_KEY_BAND : 'SurveyKeyBand',
     TYPE : 'Type',
     ZOOM_TYPE : 'ZoomType',
@@ -80,13 +123,6 @@ export const WPConst= {
     ZOOM_TO_WIDTH : 'ZoomToWidth',
     ZOOM_TO_HEIGHT : 'ZoomToHeight',
     ZOOM_ARCSEC_PER_SCREEN_PIX : 'ZoomArcsecPerScreenPix',
-    POST_CROP : 'PostCrop',
-    POST_CROP_AND_CENTER : 'PostCropAndCenter',
-    POST_CROP_AND_CENTER_TYPE : 'PostCropAndCenterType',
-    CROP_PT1 : 'CropPt1',
-    CROP_PT2 : 'CropPt2',
-    CROP_WORLD_PT1 : 'CropWorldPt1',
-    CROP_WORLD_PT2 : 'CropWorldPt2',
     OBJECT_NAME : 'ObjectName',
     RESOLVER : 'Resolver',
     PROGRESS_KEY : 'ProgressKey',
@@ -128,7 +164,7 @@ const paramKeys= Object.values(WPConst);
 const allKeys= new Enum([...paramKeys, ...plotAttKeys ], { ignoreCase: true });
 
 
-const clientSideKeys = [WPConst.PREFERENCE_COLOR_KEY, WPConst.ALLOW_IMAGE_SELECTION, WPConst.GRID_ON,
+const clientSideKeys = [WPConst.PREFERENCE_COLOR_KEY, WPConst.GRID_ON,
          WPConst.TITLE_OPTIONS, WPConst.POST_TITLE, WPConst.PRE_TITLE, WPConst.OVERLAY_POSITION,
          WPConst.PLOT_GROUP_ID, WPConst.DRAWING_SUB_GROUP_ID,
          WPConst.DOWNLOAD_FILENAME_ROOT, WPConst.PLOT_ID, WPConst.GROUP_LOCKED, WPConst.OVERLAY_IDS
@@ -146,7 +182,7 @@ const defParams= {
 };
 
 /**
- * @summary Web plot request. This object can be created by using the method of making survey request like *makexxxRequest*
+ * @summary Web plot request. This object can be created by using the method of making survey request like *makeXXXRequest*
  * and the method of setting the parameters.
  * @param {RequestType} type request type
  * @param {string} userDesc description
@@ -593,39 +629,6 @@ export class WebPlotRequest extends ServerRequest {
     setFlipY(flipY) { this.setParam(WPConst.FLIP_Y,flipY+''); }
 
 //======================================================================
-//----------------------- Crop Settings --------------------------------
-// this is not really used right now from the client, we might later.
-// the FinderChart api uses post crop
-//======================================================================
-    /**
-     * Crop the image before returning it.  If rotation is set then the crop will happen post rotation.
-     * Note: setCropPt1 & setCropPt2 are required to crop
-     *
-     * @param postCrop boolean, do the post crop
-     */
-    setPostCrop(postCrop) { this.setParam(WPConst.POST_CROP, postCrop + ''); }
-
-    /**
-     * set the post crop
-     * @param postCrop boolean
-     */
-    setPostCropAndCenter(postCrop) { this.setParam(WPConst.POST_CROP_AND_CENTER, postCrop + ''); }
-
-    /**
-     * Set to coordinate system for crop and center, eq j2000 is the default
-     * @param csys CoordinateSys, the CoordinateSys, default CoordinateSys.EQ_J2000
-     */
-    setPostCropAndCenterType(csys) { this.setParam(WPConst.POST_CROP_AND_CENTER_TYPE, csys.toString()); }
-
-    setCropPt1(pt1) {
-        if (pt1) this.setParam((pt1.type===Point.W_PT) ? WPConst.CROP_WORLD_PT1 : WPConst.CROP_PT1, pt1.toString());
-    }
-
-    setCropPt2(pt2) {
-        if (pt2) this.setParam((pt2.type===Point.W_PT) ? WPConst.CROP_WORLD_PT2 : WPConst.CROP_PT2, pt2.toString());
-    }
-
-//======================================================================
 //----------------------- Retrieval Settings --------------------------------
 //======================================================================
 
@@ -700,16 +703,6 @@ export class WebPlotRequest extends ServerRequest {
      * @return {string} key string
      */
     getSurveyKey() { return this.getParam(WPConst.SURVEY_KEY); }
-
-    /**
-     * @param {string} key string
-     */
-    setSurveyKeyAlt(key) { this.setParam(WPConst.SURVEY_KEY_ALT, key); }
-
-    /**
-     * @return {string} key string
-     */
-    getSurveyKeyAlt() { return this.getParam(WPConst.SURVEY_KEY_ALT); }
 
     /**
      * @return {string} key string
@@ -943,7 +936,7 @@ export class WebPlotRequest extends ServerRequest {
      * @param {string} str the serialized WebPlotRequest
      * @return (WebPlotRequest) the deserialized WebPlotRequest
      */
-    static parse(str) { return ServerRequest.parse(str, new WebPlotRequest()); }
+    static parse(str) { return ServerRequest.parseAndAdd(str, new WebPlotRequest()); }
 
     static isWPR(o) {return isObject(o) && o.getRequestClass?.()===WEB_PLOT_REQUEST_CLASS;}
 

--- a/src/firefly/js/visualize/WorkspaceCntlr.js
+++ b/src/firefly/js/visualize/WorkspaceCntlr.js
@@ -24,6 +24,13 @@ export const WORKSPACE_IN_LOADING = `${WORKSPACE_PREFIX}.inLoading`;
 
 export default {actionCreators, reducers };
 export const WS_HOME = 'WS_Home';
+/**
+ * @typedef {Object} WS_SERVER_PARAM
+ * @prop should_overwrite
+ * @prop currentrelpath
+ * @prop newpath
+ * @type {Enum}
+ */
 export const WS_SERVER_PARAM = new Enum(['should_overwrite', 'currentrelpath', 'newpath']);
 
 

--- a/src/firefly/js/visualize/ZoomType.js
+++ b/src/firefly/js/visualize/ZoomType.js
@@ -10,8 +10,17 @@
 import Enum from 'enum';
 
 /**
+ * @typedef ZoomType
  * @summary zoom type
  * @description can be 'STANDARD', 'LEVEL', 'FULL_SCREEN', 'TO_WIDTH_HEIGHT', 'TO_WIDTH', 'TO_HEIGHT', 'ARCSEC_PER_SCREEN_PIX'
+ * @prop STANDARD
+ * @prop LEVEL
+ * @prop FULL_SCREEN
+ * @prop TO_WIDTH_HEIGHT
+ * @prop TO_WIDTH
+ * @prop TO_HEIGHT
+ * @prop ARCSEC_PER_SCREEN_PIX
+ * @type {Enum}
  * @public
  * @global
  */
@@ -24,12 +33,3 @@ export const ZoomType= new Enum([
                       'TO_HEIGHT',         // requires height, not yet implemented
                       'ARCSEC_PER_SCREEN_PIX' // arcsec
                       ]);
-
-const whArray= [ZoomType.TO_WIDTH, ZoomType.TO_HEIGHT, ZoomType.FULL_SCREEN,
-                ZoomType.TO_WIDTH_HEIGHT, ZoomType.ARCSEC_PER_SCREEN_PIX];
-
-/**
- * Return true if zoom type requires width and height
- * @param zoomType
- */
-export const requiresWidthHeight= (zoomType) => whArray.includes( zoomType);

--- a/src/firefly/js/visualize/ZoomUtil.js
+++ b/src/firefly/js/visualize/ZoomUtil.js
@@ -10,6 +10,15 @@ import {getFoV, primePlot} from './PlotViewUtil.js';
 import {convertAngle} from './VisUtil.js';
 
 
+/**
+ * @typedef FullType
+ * enum can be one of
+ * @prop ONLY_WIDTH
+ * @prop WIDTH_HEIGHT
+ * @prop ONLY_HEIGHT
+ * @prop {Function} has
+ * @type {Enum}
+ */
 export const FullType = new Enum(['ONLY_WIDTH', 'WIDTH_HEIGHT', 'ONLY_HEIGHT']);
 
 export const imageLevels= [.0125, .025, .05,.1,.25,.3, .4, .5, .75, .8, .9, 1, 1.25, 1.5,2, 2.5,3, 3.5,
@@ -34,7 +43,16 @@ const IMAGE_ZOOM_MAX= imageLevels[imageLevels.length-1];
 const HIPS_ZOOM_MAX= hipsLevels[hipsLevels.length-1];
 
 /**
+ * @typedef UserZoomTypes
  * can be 'UP','DOWN', 'FIT', 'FILL', 'ONE', 'LEVEL', 'WCS_MATCH_PREV'
+ * @prop UP,
+ * @prop DOWN,
+ * @prop FIT,
+ * @prop FILL,
+ * @prop ONE,
+ * @prop LEVEL,
+ * @prop WCS_MATCH_PREV,
+ * @type {Enum}
  * @public
  * @global
  */

--- a/src/firefly/js/visualize/draw/DrawOp.js
+++ b/src/firefly/js/visualize/draw/DrawOp.js
@@ -36,8 +36,8 @@ class DrawOp {
     }
 
     /**
-     *
      * @param drawObj
+     * @return {Point}
      */
     static getCenterPt(drawObj) {
         return op(drawObj,'getCenterPt')(drawObj);

--- a/src/firefly/js/visualize/iv/ImageExpandedMode.jsx
+++ b/src/firefly/js/visualize/iv/ImageExpandedMode.jsx
@@ -3,11 +3,12 @@
  */
 import React, {memo, useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {visRoot, dispatchChangeExpandedMode, isImageExpanded, ExpandType} from '../ImagePlotCntlr.js';
+import {visRoot, dispatchChangeExpandedMode, ExpandType} from '../ImagePlotCntlr.js';
 import {getMultiViewRoot, getViewer, getExpandedViewerItemIds, EXPANDED_MODE_RESERVED} from '../MultiViewCntlr.js';
 import {ExpandedTools} from './ExpandedTools.jsx';
 import {MultiImageViewerView} from '../ui/MultiImageViewerView.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent';
+import {isImageExpanded} from 'firefly/visualize/PlotViewUtil.js';
 
 export const ImageExpandedMode= memo(({closeFunc,insideFlex=true,viewerId, forceExpandedMode=true}) => {
 

--- a/src/firefly/js/visualize/rawData/RawFloatData.js
+++ b/src/firefly/js/visualize/rawData/RawFloatData.js
@@ -109,7 +109,7 @@ async function changeLocalRawDataStretch(plotImageId, dataWidth, dataHeight, plo
         allBandAry.forEach( (b,idx) => {
             plotState.bandStateAry[b.value].rangeValues = undefined;
             if (plotState.isBandUsed(b)) {
-                plotState.bandStateAry[b.value].rangeValuesSerialize = (rvAry[idx]||fallbackRV).toJSON();
+                plotState.bandStateAry[b.value].rangeValues= (rvAry[idx]||fallbackRV);
             }
         });
 
@@ -123,8 +123,7 @@ async function changeLocalRawDataStretch(plotImageId, dataWidth, dataHeight, plo
 
         const rv = rvAry[bIdx];
         rawTileDataGroup= await stretchStandardAsync(rawTileDataGroup, float1d, processHeader, histogram, rv);
-        plotState.bandStateAry[bIdx].rangeValues = undefined;
-        plotState.bandStateAry[bIdx].rangeValuesSerialize = rv.toJSON();
+        plotState.bandStateAry[bIdx].rangeValues = rv;
     }
     const {retRawTileDataGroup, localRawTileDataGroup}=
         await populateRawImagePixelDataInWorker(rawTileDataGroup, plotState.getColorTableId(), threeColor, false, '', .5, 1, rootUrl);

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -164,11 +164,6 @@ export function reducer(state, action) {
             retState= changeHipsImageConversionSettings(state,action);
             break;
 
-
-        case Cntlr.ADD_PROCESSED_TILES:
-            retState= addProcessedTileData(state,action);
-            break;
-
         case Cntlr.UPDATE_RAW_IMAGE_DATA:
             retState= updateRawImageData(state,action);
             break;

--- a/src/firefly/js/visualize/task/ImageOverlayTask.js
+++ b/src/firefly/js/visualize/task/ImageOverlayTask.js
@@ -212,7 +212,6 @@ function processMaskSuccessResponse(dispatcher, payload, result) {
 
         const plotState= PlotState.makePlotStateWithJson(PlotCreate[0].plotState);
         const imageOverlayId= plotState.getWebPlotRequest().getPlotId();
-        // const imageOverlayId= WebPlotRequest.parse(result.PlotCreateHeader.plotRequestSerialize).getPlotId();
 
         var plot= WebPlot.makeWebPlotData(imageOverlayId, PlotCreate[0], {}, true);
         if (canLoadStretchDataDirect(plot,true)) plot.tileData = undefined;

--- a/src/firefly/js/visualize/task/ZoomTask.js
+++ b/src/firefly/js/visualize/task/ZoomTask.js
@@ -9,12 +9,10 @@ import {logger} from '../../util/Logger.js';
 import {isImage, isHiPS} from '../WebPlot.js';
 import ImagePlotCntlr, {
     ActionScope, IMAGE_PLOT_KEY, WcsMatchType,
-    dispatchUpdateViewSize, dispatchRecenter, dispatchChangeCenterOfProjection
-} from '../ImagePlotCntlr.js';
+    dispatchUpdateViewSize, dispatchRecenter, dispatchChangeCenterOfProjection } from '../ImagePlotCntlr.js';
 import {
     getPlotViewById, primePlot, getPlotStateAry, operateOnOthersInPositionGroup,
-    applyToOnePvOrAll, hasLocalStretchByteData
-} from '../PlotViewUtil.js';
+    applyToOnePvOrAll, hasLocalStretchByteData } from '../PlotViewUtil.js';
 import {callSetZoomLevel} from '../../rpc/PlotServicesJson.js';
 import {isImageViewerSingleLayout, getMultiViewRoot} from '../MultiViewCntlr.js';
 import {WebPlotResult} from '../WebPlotResult.js';
@@ -93,7 +91,7 @@ export function zoomActionCreator(rawAction) {
  * @param {UserZoomTypes} userZoomType
  * @param {boolean} forceDelay
  * @param {number} payloadLevel
- * @param {number} [p.upDownPercent] value between 0 and 1 - 1 is 100% of the next step up or down
+ * @param {number} [upDownPercent] value between 0 and 1 - 1 is 100% of the next step up or down
  * @return {{level: number, isFullScreen: boolean, useDelay: boolean, validParams: boolean}}
  */
 function evaluateZoomType(visRoot, pv, userZoomType, forceDelay, payloadLevel= 1, upDownPercent=1) {
@@ -204,7 +202,7 @@ function makeZoomLevelMatcher(dispatcher, visRoot, sourcePv,level,matchByScale,i
  * @param {number} zoomLevel
  * @param {boolean} isFullScreen
  * @param {boolean} zoomLockingEnabled
- * @param {UserZoomType} userZoomType
+ * @param {UserZoomTypes} userZoomType
  * @param {DevicePt} devicePt
  * @param {boolean} useDelay
  * @param {Function} getState

--- a/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
@@ -323,7 +323,7 @@ function doRotateNorth(pv,rotate) {
         dispatchChangeHiPS( {plotId:pv.plotId,  coordSys: rotate?CoordinateSys.EQ_J2000:CoordinateSys.GALACTIC});
     }
     else {
-        dispatchRotate({plotId:pv.plotId, rotateType:rotate?RotateType.NORTH:RotateType.UNROTATE});
+        dispatchRotate({ploId:pv.plotId, rotateType:rotate?RotateType.NORTH:RotateType.UNROTATE});
     }
 }
 
@@ -479,7 +479,7 @@ function startExtraction(type,setModalEndInfo, modalEndInfo) {
 
 }
 
-const ExtractRow= ({style,image,mi,pv,enabled,setModalEndInfo, modalEndInfo}) => {
+const ExtractRow= ({style,image,pv,enabled,setModalEndInfo, modalEndInfo}) => {
     const standIm= !isThreeColor(pv);
     return (
         <div style={{display:'flex', alignItems:'center', ...style}}>


### PR DESCRIPTION
####  [firefly-914](https://jira.ipac.caltech.edu/browse/FIREFLY-914) : clean up of firefly/js/visualize 

 - Mostly documentation cleanup and a little refactoring
 - Refactor: converted BandState from class to simple object
 - removed unused code from WebPlotRequest
 - removed unused, commented out code, and unused imports in several other files
 - clean up javadocs: spelling, some optional parameters, add javadocs to some enums



_testing:_ https://fireflydev.ipac.caltech.edu/firefly-914/firefly/
