### PR TITLE
Firefly-915: redo the versioning

### DIFF
--- a/buildScript/global.gincl
+++ b/buildScript/global.gincl
@@ -156,6 +156,34 @@ ext.getCommitTag = { workDir="." ->
     }
 }
 
+ext.getDevCycleTag = { workDir=".", fallback="" ->
+    try {
+        def hashOut = new ByteArrayOutputStream()
+        exec {
+            commandLine "git", "describe", "--tags", "--match", "cycle-*", "--abbrev=0"
+            workingDir = workDir
+            standardOutput = hashOut
+        }
+        return hashOut.toString().trim();
+    } catch (Exception e) {
+        return fallback
+    }
+}
+
+ext.getBranch = { workDir=".", fallback="" ->
+    try {
+        def hashOut = new ByteArrayOutputStream()
+        exec {
+            commandLine "git", "rev-parse", "--abbrev-ref", "HEAD"
+            workingDir = workDir
+            standardOutput = hashOut
+        }
+        return hashOut.toString().trim();
+    } catch (Exception e) {
+        return fallback
+    }
+}
+
 ext.getVersionInfo = { key ->
     if (!project.hasProperty("tag_file")) {
         project.ext.tag_file = "${project.buildDir}/version.tag"

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -131,7 +131,9 @@ task createVersionTag  {
         props.setProperty('BuildTime', build_time)
         props.setProperty('BuildTag', tag)
         props.setProperty('BuildCommit', getCommitHash())
-        props.setProperty('BuildGitTagFirefly', getCommitTag(fireflyPath))
+        props.setProperty('BuildFireflyTag', getCommitTag(fireflyPath))
+        props.setProperty('BuildFireflyBranch', getBranch(fireflyPath))
+        props.setProperty('DevCycleTag', getDevCycleTag(fireflyPath, "unknown"))
 
         props.setProperty('ExtendedCache', project.env == "local" ? (project.hasProperty("ExtendedCache") ? project.ExtendedCache : "true") : "false")
 

--- a/config/app.config
+++ b/config/app.config
@@ -1,8 +1,10 @@
 //---------------------------------------------
 // adjustable application runtime properties
 //---------------------------------------------
-BuildMajor = 2021
-BuildMinor = 4
+
+/* BuildMajor,  BuildMinor,  BuildRev, BuildNumber are not used for the Firefly library and should be 0 */
+BuildMajor = 0
+BuildMinor = 0
 BuildRev = 0
 BuildNumber = 0
 BuildType = "Final"

--- a/config/common.prop
+++ b/config/common.prop
@@ -9,7 +9,9 @@ BuildTime=@build_time@
 BuildTag=@BuildTag@
 BuildCommit=@BuildCommit@
 BuildCommitFirefly=@BuildCommitFirefly@
-BuildGitTagFirefly=@BuildGitTagFirefly@
+BuildFireflyTag=@BuildFireflyTag@
+BuildFireflyBranch=@BuildFireflyBranch@
+DevCycleTag=@DevCycleTag@
 
 
 #==========================================================

--- a/docs/new-release-procedure.md
+++ b/docs/new-release-procedure.md
@@ -27,20 +27,20 @@
 
 5. **Build docker images and deploy it to IRSA Kubernetes**
    - Best to use Jenkins: https://irsawebdev5.ipac.caltech.edu:8443/view/IRSA%20k8s/job/ikc_firefly/build
-   - Build the docker with the following docker tags: `rc-yyyy.m`, `release-yyyy.m`,`release-yyyy.m.r`, `latest` 
-   - _example:_ from the example above the release would be built with: `rc-2021.2`, `release-2021.2`,`release-2021.2.1`, `latest`
+   - Build the docker with the following docker tags: `rc-yyyy.m`, `yyyy.m`,`yyyy.m.r`, `latest` 
+   - _example:_ from the example above the release would be built with: `rc-2021.2`, `2021.2`,`2021.2.1`, `latest`
    - `BUILD_ENV`: Select 'ops'
    - `ACTION`: Select 'both'  
    - `DEPLOY_ENV`: Select 'ops' to have this release deploy to fireflyops.ipac.caltech.edu
    - _notes:_ 
        - the `rc-yyyy.m` docker tag does not represent the release, it is just the most recent build of the branch
-       - the `release-yyyy.m` docker tag always represents the latest release of the version
+       - the `yyyy.m` docker tag always represents the latest release of the version
        - the `latest` tag is always the latest formal release. (note- development release use `nightly`)
        
 6. **Test the release.**
    - start docker on your laptop
-   - `docker pull ipac/firefly:release-yyyy.m.r`
-   - `docker run --rm  -p 8090:8080 -m 4G --name firefly ipac/firefly:release-yyyy.m.r`
+   - `docker pull ipac/firefly:yyyy.m.r`
+   - `docker run --rm  -p 8090:8080 -m 4G --name firefly ipac/firefly:yyyy.m.r`
    - Look at the main page: 
      - http://localhost:8090/firefly/
      - bring up version information, confirm build date and version

--- a/docs/new-release-procedure.md
+++ b/docs/new-release-procedure.md
@@ -1,12 +1,6 @@
 
 # New release procedure
 
-1. **Set the Version in config**
-   - In the `rc-yyyy.x` branch, Edit `firefly/config/app.config` with the correct version.
-   - Modify:
-     - `BuildMajor =` _year_
-     - `BuildMinor =` _release of the year_
-     - `BuildRev =` _patch #_
 
 1. **Update Release Notes.**
    In the `rc-yyyy.x` branch, edit the release notes and do the following (firefly/docs/release-notes.md):
@@ -17,21 +11,21 @@
    - Make sure you edit the docker tags section of this release
    - Update the "Pull Request for this release section", change the text and the URLs for all PR and bug fixes 
    
-1. **Ensure release passes Test**
+2. **Ensure release passes Test**
    - `gradle :firefly:test`
    
-1. **Commit, Tag**
+3. **Commit, Tag**
    - commit your changes - _example message:_ "Release 2021.1.0: document updates"
    - tag the `rc-yyyy.m` branch with the release  `release-yyyy.m.r`
    - _example:_ 
       - the second release from branch `rc-2021.2` with the git tagged with `release-2021.2.1`
       - `git tag release-2021.2.1`
    
-1. **Push to GitHub**: 
+4. **Push to GitHub**: 
    - push the rc: _example:_ `git push origin rc-2021.1`
    - push the tags: `git push origin --tags`   
 
-1. **Build docker images and deploy it to IRSA Kubernetes**
+5. **Build docker images and deploy it to IRSA Kubernetes**
    - Best to use Jenkins: https://irsawebdev5.ipac.caltech.edu:8443/view/IRSA%20k8s/job/ikc_firefly/build
    - Build the docker with the following docker tags: `rc-yyyy.m`, `release-yyyy.m`,`release-yyyy.m.r`, `latest` 
    - _example:_ from the example above the release would be built with: `rc-2021.2`, `release-2021.2`,`release-2021.2.1`, `latest`
@@ -43,7 +37,7 @@
        - the `release-yyyy.m` docker tag always represents the latest release of the version
        - the `latest` tag is always the latest formal release. (note- development release use `nightly`)
        
-1. **Test the release.**
+6. **Test the release.**
    - start docker on your laptop
    - `docker pull ipac/firefly:release-yyyy.m.r`
    - `docker run --rm  -p 8090:8080 -m 4G --name firefly ipac/firefly:release-yyyy.m.r`
@@ -54,22 +48,29 @@
    - Look at test pages
      - http://localhost:8090/firefly/test
    
-1. **Merge RC, Reset the Version in config to development, Push dev**
-   - merge rc into dev
-   - In the `dev` branch, Edit `firefly/config/app.config` so that you are resetting 
-   - Modify:
-     - `BuildMajor =` _year_
-     - `BuildMinor = -1`
-     - `BuildRev = 0`
+7. **Merge RC, Start a new development cycle**
+   - merge rc into dev, use `--no-ff` to create a new commit
+     - `git checkout dev`
+     - `git merge --no-ff <rc-branch>` 
+   - Add the new dev cycle tag, but only if you just did the `.0` release
+      - _Important:_ Only do this step if this on `.0` releases.
+         - For example- if you just did the `2021.2.0` do this step. If you just did the `2021.2.1` skip this step.
+     - Tag the dev branch with the new cycle with the form - `cycle-yyyy.x`
+     - For example- If you just did the 2022.1.0 release, and we are beginning work on the 2022.2 cycle: 
+       - on the dev branch
+       - `git tag cycle-2022.2`
+8. Update Docs and push
    - add any improvements to this file
    - commit and push dev, _example message_ - "Post 2021.1 release: dev clean up"
+   - `git push origin dev`
+   - push the tags: `git push origin --tags`
    
-1. **Edit docker hub instructions**
+9. **Edit docker hub instructions**
    - Go the the Firefly page on docker hub. https://cloud.docker.com/u/ipac/repository/docker/ipac/firefly
    - Edit the markdown to include the recent tags
    
-1. **Publish a new release on Github.**
-   - The text should use the [release-page-template.md](release-page-template.md)
-   - After using the template, copy the markdown (for this release only) from the release-notes.md
-   - paste markdown at the end of the template
+10. **Publish a new release on Github.**
+    - The text should use the [release-page-template.md](release-page-template.md)
+    - After using the template, copy the markdown (for this release only) from the release-notes.md
+    - paste markdown at the end of the template
 

--- a/docs/pre-release-procedure.md
+++ b/docs/pre-release-procedure.md
@@ -1,0 +1,17 @@
+# Pre-release procedure
+
+1. Change to dev branch and pull all new changes
+2. Ensure release passes Test
+    - `gradle :firefly:test`
+3. Tag
+   - Use the pre-release tag style of pre-#-yyyy.mm
+   - _Example:_ 
+        - for the forth pre-release of the 2023.2 cycle: `pre-4-2023.2`
+        - `git tag pre-4-2023.2`
+4. Push the tag: `git push origin --tags`
+5. **Build docker images and deploy it to IRSA Kubernetes**
+    - Best to use Jenkins: https://irsawebdev5.ipac.caltech.edu:8443/view/IRSA%20k8s/job/ikc_firefly/build
+    - Build the docker with the following docker based of the git tag: example - `2023.2-pre-4`
+    - `BUILD_ENV`: Select 'ops'
+    - `ACTION`: Select 'both'
+    - `DEPLOY_ENV`: Select 'dev' to have this release deploy to fireflydev.ipac.caltech.edu

--- a/docs/tags-and-branches.md
+++ b/docs/tags-and-branches.md
@@ -1,23 +1,60 @@
-## Release/RC branches and tags
+## Branch and Tag Naming
+
+
+## Release Overview
 
 When we do a release, we will create a release candidate branch and tag the commit for each version of the release in that branch.
-
 When a rc branches and tags are named by the current year and the release number of that year.  Release tags include the revision of the release.
 
 
-### Branch naming
+## Branch naming
+
+### Development
+
+Development happens on the `dev` branch
+
+### Ticket branches
+
+Tickets are implemented in branches and then merge in after an approved pull request
+
+ - Branch Scheme: `Ticket Name` - `word or two description`
+ - Such As: Ticket fix as a table feature might be: `Firefly-123-table-sort`
+ - Such As: Ticket fix an image bug: `Firefly-456-image-zoom`
+
+### Release Candidates
 
  - Branch Scheme: `rc` - _year_ *.*  _release # of that year_    
  - Such as: `rc-2019.2`
 
 _Example:_ The first release of 2019 branch name will the `rc-2019.1`, the next one will be `rc-2019.2`
 
-### Tag naming
+## Tag naming
 
-All the versions of that release will be tagged using the same similar scheme but adding a revision number at the end.
+Firefly will use tags to label a release, a prerelease and a development cycles.
+
+### Release
 
  - Tag Scheme: `release` - _year_ *.*  _release # of that year_ *.* _revision of release_
  - Such as: `release-2019.2.3`
 
 
-_Example:_ the release versions for the second 2019 release branch will be tagged. `release-2019.2.0`, `release-2019.2.1`, `release-2019.2.2`, etc. These tags will all be in the `rc-2019.2` branch.
+   _Example:_ The release versions for the second 2022 release branch will be tagged. `release-2022.2.0`, `release-2022.2.1`, `release-2022.2.2`, etc. These tags will all be in the `rc-2022.2` branch.
+
+### Prerelease
+
+- Tag Scheme: `pre` *-* _prerelease number_ *-* _year_ *.*  _release # of that year_ 
+- Such as: `pre-2-2019.2`
+
+
+_Example:_ The prerelease versions third 2023 dev cycle will be tagged. `pre-1-2023.3`, `pre-2-2023.3`, `pre-3-2023.3`, etc. These tags will all be in the `dev` branch.
+
+
+### Development Cycle tags
+
+At the beginning of a development cycle in the `dev` branch, the first commit will be tagged with the cycle number.
+
+- Tag Scheme: `cycle` - _year_ *.*  _release # of that year_
+- Such as: `cycle-2022.4`
+
+
+_Example:_ After the`2022.2.0` release. The first commit in the `dev` branch will label the next cycle. It will be tagged `cycle-2022.3` 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
@@ -30,7 +30,8 @@ public class Version implements Serializable {
     private String      _buildTag= "";
     private String      _buildCommit= "";
     private String      _buildCommitFirefly= "";
-    private String      _buildGitTagFirefly= "";
+    private String      _buildFireflyTag = "";
+    private String      _devCycleTag = "";
     private long        _configLastModTime = 0;
 
 //======================================================================
@@ -73,9 +74,8 @@ public class Version implements Serializable {
         this._buildCommitFirefly = _buildCommitFirefly;
     }
 
-    public void setBuildGitTagFirefly(String buildGitTagFirefly) {
-        this._buildGitTagFirefly= buildGitTagFirefly;
-    }
+    public void setBuildFireflyTag(String buildFireflyTag) { this._buildFireflyTag = buildFireflyTag; }
+    public void setDevCycleTag(String devCycleTag) { this._devCycleTag = devCycleTag; }
 
     public String getBuildTime() {
         return _buildTime;
@@ -100,7 +100,8 @@ public class Version implements Serializable {
     public String getBuildDate() { return _buildDate; }
     public int getBuildNumber() { return _build;  }
     public String getAppName() { return _appName; }
-    public String getBuildGitTagFirefly() { return _buildGitTagFirefly; }
+    public String getBuildFireflyTag() { return _buildFireflyTag; }
+    public String getDevCycleTag() { return _devCycleTag; }
 
     @Override
     public String toString() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
@@ -36,7 +36,8 @@ public class VersionUtil {
     private static final String BUILD_TAG  ="BuildTag";
     private static final String BUILD_COMMIT  ="BuildCommit";
     private static final String BUILD_COMMIT_FIREFLY  ="BuildCommitFirefly";
-    private static final String BUILD_GIT_TAG_FIREFLY ="BuildGitTagFirefly";
+    private static final String BUILD_FIREFLY_TAG ="BuildFireflyTag";
+    private static final String DEV_CYCLE_TAG ="DevCycleTag";
 
     private static final String VERSION_FILE = "version.tag";
     private static final String unknownVersionUA= "Firefly/development";
@@ -75,7 +76,8 @@ public class VersionUtil {
             _version.setBuildTag(props.getProperty(BUILD_TAG));
             _version.setBuildCommit(props.getProperty(BUILD_COMMIT));
             _version.setBuildCommitFirefly(props.getProperty(BUILD_COMMIT_FIREFLY));
-            _version.setBuildGitTagFirefly(props.getProperty(BUILD_GIT_TAG_FIREFLY));
+            _version.setBuildFireflyTag(props.getProperty(BUILD_FIREFLY_TAG));
+            _version.setDevCycleTag(props.getProperty(DEV_CYCLE_TAG));
         } catch (IOException e) {
             // just ignore
         }
@@ -102,11 +104,18 @@ public class VersionUtil {
     }
 
     private static String getFireflyUA() {
-        String tag = getAppVersion().getBuildGitTagFirefly();
-        if (StringUtils.isEmpty(tag)) return unknownVersionUA;
+        String releaseTag = getAppVersion().getBuildFireflyTag();
+        String devCycle = getAppVersion().getDevCycleTag();
+        if (StringUtils.isEmpty(releaseTag) && StringUtils.isEmpty(devCycle)) return unknownVersionUA;
+        Matcher m;
         try {
-            Matcher m= Pattern.compile("\\d+(\\.\\d+)+").matcher(tag);
-            return m.find() ? "Firefly/" +m.group(0) : unknownVersionUA;
+            if (!StringUtils.isEmpty(releaseTag)) {
+                m= Pattern.compile("\\d+(\\.\\d+)+").matcher(releaseTag);
+                if (m.find()) return "Firefly/" +m.group(0) + (releaseTag.startsWith("pre") ? "-prerelease" : "");
+            }
+            m= Pattern.compile("\\d+(\\.\\d+)+").matcher(devCycle);
+            if (m.find()) return "Firefly/" +m.group(0)+"-development";
+            return unknownVersionUA;
         } catch (Exception e) {
             return unknownVersionUA;
         }

--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -16,6 +16,9 @@
  * @prop {string} BuildTag      vcs tag string if it were tagged
  * @prop {string} BuildCommit   vcs commit used to build this app
  * @prop {string} BuildCommitFirefly    Firefly's vcs commit used to build this app.
+ * @prop {string} BuildFireflyTag firefly tag used for this build
+ * @prop {string} BuildFireflyBranch firefly branch used for this build
+ * @prop {string} DevCycle the tag that marks this development cycle
  */
 
 /**

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -8,10 +8,10 @@ import PropTypes from 'prop-types';
 import {useStoreConnector} from './SimpleComponent.jsx';
 import {getUserInfo} from '../core/AppDataCntlr.js';
 import {logout} from '../rpc/CoreServices.js';
-import {getVersionInfoStr, showFullVersionInfoDialog} from '../ui/DropDownContainer.jsx';
+import {getVersionInfoStr, showFullVersionInfoDialog} from 'firefly/ui/VersionInfo.jsx';
 import './Banner.css';
 
-const getVersionTipStr= (appTitle) => `${appTitle?appTitle+' ':''}Version:\n${getVersionInfoStr(true)}`;
+const getVersionTipStr= (appTitle) => `${appTitle?appTitle+' ':''}Version:\n${getVersionInfoStr(true,true)}`;
 
 export const Banner = memo( ({menu, readout, appIcon, visPreview, appTitle, additionalTitleStyle = {},
                                  showUserInfo=false, enableVersionDialog= false, showTitleOnBanner=false,

--- a/src/firefly/js/ui/DropDownContainer.css
+++ b/src/firefly/js/ui/DropDownContainer.css
@@ -79,24 +79,3 @@
     src: local('Varela'), url(//themes.googleusercontent.com/static/fonts/varela/v4/maB5vWJo0EAVzvHPjBkLM-vvDin1pK8aKteLpeZ5c0A.woff) format('woff');
 }
 
-.DD-Version {
-    user-select: text;
-}
-
-.DD-Version__item {
-    display: inline-flex;
-    padding: 2px 0;
-}
-
-.DD-Version__key {
-    font-weight: bold;
-    width: 125px;
-    text-align: right;
-    margin-right: 5px;
-    white-space: nowrap;
-}
-
-.DD-Version__value {
-    white-space: nowrap;
-    margin-right: 25px;
-}

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -5,11 +5,10 @@
 import React, {Component, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
-import {get, pick, isEmpty} from 'lodash';
+import {get, isEmpty, pick} from 'lodash';
 
 import {getDropDownInfo} from '../core/LayoutCntlr.js';
 import {flux} from '../core/ReduxFlux.js';
-import {getVersion} from '../Firefly.js';
 import {SearchPanel} from '../ui/SearchPanel.jsx';
 import {ImageSearchDropDown} from '../visualize/ui/ImageSearchPanelV2.jsx';
 import {TestSearchPanel} from '../ui/TestSearchPanel.jsx';
@@ -19,11 +18,11 @@ import {LSSTCatalogSelectViewPanel} from '../visualize/ui/LSSTCatalogSelectViewP
 import {FileUploadDropdown} from '../ui/FileUploadDropdown.jsx';
 import {WorkspaceDropdown} from '../ui/WorkspaceDropdown.jsx';
 import {getAlerts} from '../core/AppDataCntlr.js';
-import {showInfoPopup} from '../ui/PopupUtil.jsx';
 
 import './DropDownContainer.css';
 import {MultiSearchPanel} from 'firefly/ui/MultiSearchPanel.jsx';
 import {TapSearchPanel} from 'firefly/ui/tap/TapSearchRootPanel.jsx';
+import {VersionInfo} from 'firefly/ui/VersionInfo.jsx';
 
 const flexGrowWithMax = {width: '100%', maxWidth: 1400};
 
@@ -148,62 +147,6 @@ DropDownContainer.propTypes = {
 DropDownContainer.defaultProps = {
     visible: false
 };
-
-
-export const showFullVersionInfoDialog = (title='') => showInfoPopup(versionInfoFull(getVersion()), `${title} Version Information`);
-
-
-export function getVersionInfoStr(includeBuiltOnDate) {
-    const {BuildMajor, BuildMinor, BuildRev, BuildType, BuildDate} = getVersion();
-    let version = `v${BuildMajor}.${Number(BuildMinor)===-1?'Next':BuildMinor}`;
-    version += BuildRev !== '0' ? `.${BuildRev}` : '';
-    version += BuildType === 'Final' ? '' : `_${BuildType}`;
-    return includeBuiltOnDate ? version + ` Built On: ${BuildDate}`: version;
-}
-
-const VersionInfo= ()  => <div onClick={() => showFullVersionInfoDialog()}>{getVersionInfoStr(true)}</div>;
-
-function versionInfoFull({BuildMajor, BuildMinor, BuildRev, BuildNumber, BuildType, BuildTime, BuildTag, BuildCommit, BuildGitTagFirefly, BuildCommitFirefly}) {
-    let version = `v${BuildMajor}.${Number(BuildMinor)===-1?'Next':BuildMinor}`;
-    version += BuildRev !== '0' ? `.${BuildRev}` : '';
-    return (
-        <div className='DD-Version'>
-            <div className='DD-Version__item'>
-                <div className='DD-Version__key'>Version</div>
-                <div className='DD-Version__value'>{version}</div>
-            </div>
-            <div className='DD-Version__item'>
-                <div className='DD-Version__key'>Type</div>
-                <div className='DD-Version__value'>{BuildType}</div>
-            </div>
-            <div className='DD-Version__item'>
-                <div className='DD-Version__key'>Build Number</div>
-                <div className='DD-Version__value'>{BuildNumber}</div>
-            </div>
-            <div className='DD-Version__item'>
-                <div className='DD-Version__key'>Built On</div>
-                <div className='DD-Version__value'>{BuildTime}</div>
-            </div>
-            <div className='DD-Version__item'>
-                <div className='DD-Version__key'>Git commit</div>
-                <div className='DD-Version__value'>{BuildCommit}</div>
-            </div>
-            { BuildCommitFirefly &&
-                <div className='DD-Version__item'>
-                    <div className='DD-Version__key'>Git commit(Firefly)</div>
-                    <div className='DD-Version__value'>{BuildCommitFirefly}</div>
-                </div>
-            }
-            { BuildGitTagFirefly &&
-            <div className='DD-Version__item'>
-                <div className='DD-Version__key'>Firefly Git Tag</div>
-                <div className='DD-Version__value'>{BuildGitTagFirefly}</div>
-            </div>
-            }
-        </div>
-    );
-
-}
 
 export class Alerts extends PureComponent {
 

--- a/src/firefly/js/ui/VersionInfo.css
+++ b/src/firefly/js/ui/VersionInfo.css
@@ -1,0 +1,30 @@
+.Version-grid {
+    user-select: text;
+    display: grid;
+    grid-template-columns: auto auto;
+    grid-column-gap: 5px;
+    grid-row-gap: 5px;
+}
+
+.Version-grid-desc {
+    font-weight: bold;
+    grid-column-start: 1;
+    justify-self: end;
+    white-space: nowrap;
+    height: 14px;
+}
+
+.Version-grid-value {
+    grid-column-start: 2;
+    justify-self: start;
+    white-space: nowrap;
+    height: 14px;
+}
+
+.Version-grid-warning {
+    grid-column-start: 1;
+    grid-column-end: span 2;
+    text-align: center;
+    color: red;
+    padding-top:10px
+}

--- a/src/firefly/js/ui/VersionInfo.jsx
+++ b/src/firefly/js/ui/VersionInfo.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+    getDevCycle, getFireflyLibraryVersionStr, getVersion, isVersionFormalRelease, isVersionPreRelease
+} from 'firefly/Firefly.js';
+
+import {CopyToClipboard} from '../visualize/ui/MouseReadout.jsx';
+import {showInfoPopup} from './PopupUtil.jsx';
+import './VersionInfo.css';
+
+const VER = 'Version';
+const BUILT_ON = 'Built On';
+const COMMIT = 'Git Commit';
+const FF_LIB = 'Firefly Library Version';
+const FF_COM = 'Firefly Git Commit';
+const FF_TAG = 'Firefly Git Tag';
+
+
+export function getVersionInfoStr(includeBuiltOnDate, includeBuildType) {
+    const {BuildMajor = 0, BuildMinor, BuildRev, BuildType, BuildDate} = getVersion();
+    const major = Number(BuildMajor);
+    let version;
+    if (major) {
+        version = `v${BuildMajor}.${BuildMinor}`;
+        version += BuildRev !== '0' ? `.${BuildRev}` : '';
+    } else {
+        version = getFireflyLibraryVersionStr();
+    }
+    if (includeBuildType) version += BuildType === 'Final' ? '' : `, ${BuildType}`;
+    return includeBuiltOnDate ? version + `, Built On: ${BuildDate}` : version;
+}
+
+export const VersionInfo = () => <div onClick={() => showFullVersionInfoDialog()}>{getVersionInfoStr(true, true)}</div>;
+
+const Entry = ({desc, value}) =>
+    (<React.Fragment>
+        <div className='Version-grid-desc'>{desc}</div>
+        <div className='Version-grid-value'>{value}</div>
+    </React.Fragment>);
+
+function VersionInfoFull() {
+    const {BuildTime, BuildMajor, BuildCommit, BuildFireflyTag:ffTag, BuildCommitFirefly:ffCommit} = getVersion();
+    const major = Number(BuildMajor);
+    const version = getVersionInfoStr(false, false);
+
+    const versionAsText =
+        `${VER}:    ${version}\n${BUILT_ON}:   ${BuildTime}\n${COMMIT}: ${BuildCommit}`
+        + (major ? `\n${FF_LIB}: ${getFireflyLibraryVersionStr()}` : '')
+        + (ffCommit ? `\n${FF_COM}:      ${ffCommit}` : '')
+        + (ffTag ? `\n${FF_TAG}:         ${ffTag}` : '');
+
+    return (
+        <div style={{display: 'flex', justifyContent: 'space-evenly'}}>
+            <div className='Version-grid'>
+                <Entry desc={VER} value={version}/>
+                <Entry desc={BUILT_ON} value={BuildTime}/>
+                <Entry desc={COMMIT} value={BuildCommit}/>
+                {major ? <Entry desc={FF_LIB} value={getFireflyLibraryVersionStr()}/> : ''}
+                {ffCommit && <Entry desc={FF_COM} value={ffCommit}/>}
+                {ffTag && <Entry desc={FF_TAG} value={ffTag}/>}
+                {
+                    !isVersionFormalRelease() &&
+                    <div className='Version-grid-warning'>
+                        {isVersionPreRelease() ?
+                            'Warning: Untested, early preview version of firefly on dev cycle ' + getDevCycle() :
+                            'Warning: Untested, development build of firefly on dev cycle ' + getDevCycle()}
+                    </div>
+                }
+            </div>
+            <CopyToClipboard style={{justifySelf: 'end', marginLeft: 10}}
+                             value={versionAsText} size={16} buttonStyle={{backgroundColor: 'unset'}}/>
+        </div>
+    );
+}
+
+export const showFullVersionInfoDialog = (title = '') => showInfoPopup( <VersionInfoFull/>, `${title} Version Information`);

--- a/src/firefly/js/ui/VersionInfo.jsx
+++ b/src/firefly/js/ui/VersionInfo.jsx
@@ -61,8 +61,9 @@ function VersionInfoFull() {
                     !isVersionFormalRelease() &&
                     <div className='Version-grid-warning'>
                         {isVersionPreRelease() ?
-                            'Warning: Untested, early preview version of firefly on dev cycle ' + getDevCycle() :
-                            'Warning: Untested, development build of firefly on dev cycle ' + getDevCycle()}
+                            `Warning: Early preview of Firefly ${getDevCycle()}` :
+                            `Warning: Development build of Firefly on dev cycle ${getDevCycle()}`
+                        }
                     </div>
                 }
             </div>


### PR DESCRIPTION
### Firefly-915: redo the versioning

- Two new concepts
   - pre-release tagging
   - dev cycle tagging, including branch
- We now support 3 types of tags
   - `release-<version>` - just as before, marks a formal release - ie `release-2022.1.0`
   -  `pre-#-<version>` - a prerelease - version is in the form of development cycle - number, ie `pre-5-2022.1`
   - `cycle-<version>` - a development cycle, tag is added to the next commit after a release, ie. `cycle-2022.1`
- Updated Gradle build to support finding the current tag, current branch, and last tag to fit a description
- Docs updated
- Firefly library not longer uses the following properties: BuildMajor, BuildMinor,BuildRev, BuildNumber 
    - Only applications built against Firefly uses the properties. 
- Version dialog updated substantially  
   - Version React code broken out to its own file (`VersionInfo.jsx`)
   - Uses Grid
   - Stronger tracking of the Firefly library version
   - Now every Firefly branch will have a unique version id
   - Warnings shown when the version is not a `release-<version>`, ie warnings if the version is a `pre-#-<version>` or there is no tag
   - Tracking of the development cycle based on the `cycle-<version>` tag
   - Add copy-to-clipboard for version information

_Ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-915

### Testing
I did not build a test because see how it works it requires creating and deleting different types of tags.
#### To Test:
-  Test 1:
   - build the branch 
   - view the version dialog
-  Test 2:
    - tag the branch with something like `pre-4-2022.2`
    - build the branch 
    - view the version dialog
    - delete the tag
- Test 3:
    - tag the branch with something like `release-2022.2.0`
    - build the branch 
    - view the version dialog
    - delete the tag

Repeat the test by doing the exact same tagging in firefly but building IrsaViewer instead. This will demonstrate how The applications that use the `BuildMajor`, `BuildMinor`,`BuildRev` properties for versioning work with the Firefly library versioning



