### PR TITLE
Firefly-908: Allow extraction to stay on when new images are added

### DIFF
--- a/src/firefly/js/drawingLayers/ExtractPointsTool.js
+++ b/src/firefly/js/drawingLayers/ExtractPointsTool.js
@@ -50,7 +50,7 @@ function dispatchSelectPoint(mouseStatePayload) {
 
 function onDetach(drawLayer,action) {
     const {plotIdAry}= action.payload;
-    plotIdAry.forEach( (plotId) => {
+    plotIdAry?.forEach( (plotId) => {
         if (primePlot(visRoot(),plotId)?.attributes[PlotAttribute.PT_ARY]) {
             dispatchAttributeChange(
                 { plotId, overlayColorScope:false,
@@ -99,10 +99,34 @@ function getLayerChanges(drawLayer, action) {
             return {drawingDef: clone(drawLayer.drawingDef,action.payload.drawingDef)};
         case DrawLayerCntlr.MODIFY_CUSTOM_FIELD:
             return dealWithMods(drawLayer,action);
-
+        case DrawLayerCntlr.ATTACH_LAYER_TO_PLOT:
+            return attach(drawLayer);
+        case DrawLayerCntlr.FORCE_DRAW_LAYER_UPDATE:
+            return saveLastData(action.payload.plotIdAry[0]);
     }
 }
 
+
+function attach(drawLayer) {
+
+    const plotId= drawLayer.plotIdAry[0];
+    const data= drawLayer.lastData;
+    if (!plotId || !data) return;
+    setTimeout( () => {
+        drawLayer.plotIdAry.forEach( (pId) => {
+            const p= primePlot(visRoot(),pId);
+            if (p && !p.attributes[PlotAttribute.PT_ARY]) {
+                dispatchAttributeChange({plotId:pId, changes:{[PlotAttribute.PT_ARY]:data}, toAllPlotsInPlotView:false});
+                dispatchForceDrawLayerUpdate(drawLayer.drawLayerId, pId);
+            }
+        });
+    }, 3);
+}
+
+function saveLastData(plotId) {
+    const plot= primePlot(visRoot(),plotId);
+    return {lastData:plot?.attributes[PlotAttribute.PT_ARY]};
+}
 
 function dealWithMods(drawLayer,action) {
     const {changes,plotIdAry}= action.payload;
@@ -129,8 +153,8 @@ function makeSelectedPt(screenPt,plotId) {
 }
 
 
-function drawPoints(drawLayer, action, active, pId) {
-    const {plotId, plotIdAry}= action.payload;
+function drawPoints(drawLayer, action, active, plotId) {
+    const {plotIdAry}= action.payload;
 
     const isEmptyData = () => {
         const data = drawLayer?.drawData?.data;
@@ -139,7 +163,7 @@ function drawPoints(drawLayer, action, active, pId) {
     };
     // attach drawing layer to the plot which is created after the drawing layer
     if ( action.type === DrawLayerCntlr.ATTACH_LAYER_TO_PLOT &&
-        !isEmptyData() && plotIdAry && plotIdAry.includes(pId))  {
+        !isEmptyData() && plotIdAry && plotIdAry.includes(plotId))  {
         if (drawLayer.plotIdAry) {
             let dAry;
 
@@ -153,7 +177,9 @@ function drawPoints(drawLayer, action, active, pId) {
     }
 
 
-    const ptAry= primePlot(visRoot(),plotId).attributes[PlotAttribute.PT_ARY] ?? [];
+    const plot= primePlot(visRoot(),plotId||plotIdAry?.[0]);
+    if (!plot) return [];
+    const ptAry= plot.attributes[PlotAttribute.PT_ARY] ?? [];
 
     const drawAry= ptAry.map( (pt) => PointDataObj.make(pt));
 

--- a/src/firefly/js/drawingLayers/PointSelection.js
+++ b/src/firefly/js/drawingLayers/PointSelection.js
@@ -32,6 +32,7 @@ var idCnt=0;
 
 function dispatchSelectPoint(mouseStatePayload) {
     const {plotId,screenPt,drawLayer}= mouseStatePayload;
+    if (mouseStatePayload.shiftDown) return;
     if (drawLayer.drawData.data) {
         flux.process({type:DrawLayerCntlr.SELECT_POINT, payload:mouseStatePayload} );
         dispatchAttributeChange(


### PR DESCRIPTION
### Firefly-908: Allow extraction to stay on when new images are added

_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-908

### Testing
- **Firefly Library Version:** 2022.1-DEV:firefly-908-extract_6a82
- **Firefly**
  - https://fireflydev.ipac.caltech.edu/firefly-908-extract/firefly/
  - Load a couple of images, do extract line or point,  go back to the image dialog load some more
  - Load a image, do extract line or point, delete it, go back to the image dialog load more images
- **ZTF** 
  - https://firefly-908-extract.irsakudev.ipac.caltech.edu/applications/ztf/
  - do search, show the images, turn on line or point extraction, change images back click on the table