### PR TITLE
FIREFLY-883: "Data Type" column in Radar results no longer have filter choices

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -619,13 +619,14 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                         results.getData().getDataDefintion(cname).setEnumVals(enumVals);
                         // update dd table
                         JdbcFactory.getSimpleTemplate(dbAdapter.getDbInstance(dbFile))
-                                .update(String.format("UPDATE data_dd SET enumVals = '%s' WHERE cname = '%s'", enumVals, cname));
+                                .update("UPDATE data_dd SET enumVals = ? WHERE cname = ?", enumVals, cname);
                     }
                 }
             });
             StopWatch.getInstance().stop("enumeratedValuesCheck: " + treq.getRequestId()).printLog("enumeratedValuesCheck: " + treq.getRequestId());
         } catch (Exception ex) {
-            // do nothing.. ignore any errors.
+            LOGGER.error(ex);
+            // do nothing.. ok to ignore errors.
         }
     }
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-883

The `Data Type` column in Radar table results no longer have an enumerated filter choices to pick from.

Test: https://firefly-883-choiced-column-fix.irsakudev.ipac.caltech.edu/frontpage/
Do any Radar search -> turn on filter to see the drop-down option under `Data Type` column.