### PR TITLE
Firefly-935: Add quotes to table or columns where needed

### DIFF
--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -12,7 +12,7 @@ import {cloneDeep, defer, isArray, isObject} from 'lodash';
 
 import {InputAreaFieldConnected} from '../InputAreaField.jsx';
 import {SplitContent} from '../panel/DockLayoutPanel';
-import {loadTapSchemas, loadTapTables, loadTapColumns, getTapServices} from './TapUtil';
+import {loadTapSchemas, loadTapTables, loadTapColumns, getTapServices, maybeQuote} from './TapUtil';
 import {getColumnIdx} from '../../tables/TableUtil.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
@@ -115,11 +115,11 @@ export function AdvancedADQL({adqlKey, defAdqlKey, groupKey, serviceUrl, style={
             if (taVal) {
                 insertAtCursor(textArea, tname, adqlKey, groupKey, prismLiveRef.current);
             } else {
-                dispatchValueChange({fieldKey: adqlKey, groupKey, value: `SELECT TOP 1000 * FROM ${tname}`, valid: true});
+                dispatchValueChange({fieldKey: adqlKey, groupKey, value: `SELECT TOP 1000 * FROM ${maybeQuote(tname,true)}`, valid: true});
                 window.setTimeout( () => prismLiveRef.current.syncStyles?.(), 10);
             }
         } else if (type === 'column') {
-            const val = ffcn.current.checked ? `${tname}.${cname}` : cname;
+            const val = ffcn.current.checked ? `${maybeQuote(tname,true)}.${maybeQuote(cname)}` : maybeQuote(cname);
             insertAtCursor(textArea, val, adqlKey, groupKey, prismLiveRef.current);
         }
     };

--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -5,6 +5,7 @@ import {FILTER_CONDITION_TTIPS, FilterInfo} from '../../tables/FilterInfo.js';
 
 import {getColumnIdx, getTblById} from '../../tables/TableUtil.js';
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
+import {maybeQuote} from 'firefly/ui/tap/TapUtil.js';
 
 /**
  * @summary component to display column constraints and selections using a table
@@ -84,7 +85,7 @@ export function getTableConstraints(tbl_id) {
                 if (!valid) {
                     errors += (errors.length > 0 ? `, "${value}"` : `Invalid constraints: "${value}"`);
                 } else if (v) {
-                    const oneConstraint = `${colName} ${v}`;
+                    const oneConstraint = `${maybeQuote(colName)} ${v}`;
                     whereFragment += (whereFragment.length > 0 ? ` AND ${oneConstraint}` : oneConstraint);
                 }
             });
@@ -97,7 +98,7 @@ export function getTableConstraints(tbl_id) {
     let selcolsFragment = tbl_data.reduce((prev, d, idx) => {
             if ((sel_info.selectAll && (!sel_info.exceptions.has(idx))) ||
                 (!sel_info.selectAll && (sel_info.exceptions.has(idx)))) {
-                prev += d[0] + ',';
+                prev += maybeQuote(d[0]) + ',';
                 selcolsArray.push(d[0]);
             } else {
                 allSelected = false;

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -22,7 +22,7 @@ import {FieldGroupCollapsible} from '../panel/CollapsiblePanel.jsx';
 import {RadioGroupInputField} from '../RadioGroupInputField.jsx';
 import {convertMJDToISO, validateDateTime, validateMJD} from '../DateTimePickerField.jsx';
 import {TimePanel} from '../TimePanel.jsx';
-import {getColumnAttribute, HeaderFont, ISO, MJD, tapHelpId} from './TapUtil.js';
+import {maybeQuote, getColumnAttribute, HeaderFont, ISO, MJD, tapHelpId} from './TapUtil.js';
 import {ColsShape, ColumnFld, getColValidator} from '../../charts/ui/ColumnOrExpression';
 import {
     changeDatePickerOpenStatus,
@@ -846,7 +846,7 @@ function makeSpatialConstraints(fields, columnsModel, newFields) {
         const ucdCoord = getUCDCoord(centerLonColumns.value);
         const worldSys = posCol[ucdCoord.key].coord;
         const adqlCoordSys = posCol[ucdCoord.key].adqlCoord;
-        const point = `POINT('${adqlCoordSys}', ${centerLonColumns.value}, ${centerLatColumns.value})`;
+        const point = `POINT('${adqlCoordSys}', ${maybeQuote(centerLonColumns.value)}, ${maybeQuote(centerLatColumns.value)})`;
         const userAreaResult = checkUserArea(spatialMethod, fields, worldSys, adqlCoordSys);
         userAreaResult.fieldsValidity.forEach((value, key) => fieldsValidity.set(key, value));
         if (userAreaResult.valid) {
@@ -953,7 +953,7 @@ function makeTemporalConstraints(fields, columnsModel, newFields) {
                     return '';
                 } else {
                     const limit  = useISO ? `'${oneRange}'` : oneRange;
-                    return idx === FROM ? `${timeColumn} >= ${limit}` : `${timeColumn} <= ${limit}`;
+                    return idx === FROM ? `${maybeQuote(timeColumn)} >= ${limit}` : `${maybeQuote(timeColumn)} <= ${limit}`;
                 }
             });
 

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -281,7 +281,7 @@ export function BasicUI(props) {
                 <div className='expandable'>
                     <SplitPane split='vertical' maxSize={splitMax} mixSize={20} defaultSize={splitDef}>
                         <SplitContent>
-                            {columnsModel ?  <TableSearchMethods initArgs={props.initArgs} columnsModel={columnsModel} obsCoreEnabled={obsCoreEnabled}/>
+                            {columnsModel ?  <TableSearchMethods initArgs={props.initArgs} serviceUrl={serviceUrl} columnsModel={columnsModel} obsCoreEnabled={obsCoreEnabled}/>
                                 : <div className='loading-mask'/>
                             }
                         </SplitContent>

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -22,14 +22,8 @@ import {dispatchHideDropDown} from 'firefly/core/LayoutCntlr.js';
 import {tableColumnsConstraints} from 'firefly/ui/tap/TableColumnsConstraints.jsx';
 import {skey, tableSearchMethodsConstraints} from 'firefly/ui/tap/TableSearchMethods.jsx';
 import {commonSelectStyles, selectTheme} from 'firefly/ui/tap/Select.jsx';
-import {
-    getMaxrecHardLimit,
-    getTapBrowserState,
-    tapHelpId,
-    getTapServices,
-    loadObsCoreSchemaTables,
-    updateTapBrowserState
-} from 'firefly/ui/tap/TapUtil.js';
+import { getMaxrecHardLimit, getTapBrowserState, tapHelpId, getTapServices,
+    loadObsCoreSchemaTables, updateTapBrowserState, maybeQuote } from 'firefly/ui/tap/TapUtil.js';
 import { gkey, SectionTitle, AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
 
 
@@ -343,7 +337,7 @@ function onTapSearchSubmit(request,serviceUrl) {
 
 
 function getAdqlQuery(showErrors= true) {
-    const tableName = FieldGroupUtils.getGroupFields(gkey)?.tableName?.value;
+    const tableName = maybeQuote(FieldGroupUtils.getGroupFields(gkey)?.tableName?.value, true);
     if (!tableName) return;
 
     const {columnsModel} = getTapBrowserState();

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -227,6 +227,25 @@ export function getTapServices(webApiUserAddedService) {
     return retVal;
 }
 
+const validTableNameRE= /^[A-Za-z][A-Za-z_0-9]*(\.[A-Za-z][A-Za-z_0-9]*){0,2}$/;
+const validColumnNameRE=/^[A-Za-z][A-Za-z_0-9]*(\.[A-Za-z][A-Za-z_0-9]*){0,3}$/;
+
+/**
+ * Add quotes around a table or column name if it is not already quoted and if non-standard names.
+ * @param {string} name a table or column name
+ * @param {boolean} [isTable] - if the the name is a table name otherwise it is a colunm name
+ * @return {string}
+ */
+export function maybeQuote(name, isTable=false) {
+    if (!name || (name.startsWith('"') && name.endsWith('"'))) return name;
+    const re= isTable ? validTableNameRE : validColumnNameRE;
+    return  (name.match(re)) ? name : `"${name}"`;
+}
+
+// --- keep for reference //todo delete after 2022.2 release
+// export const maybeQuoteByService= (serviceURL, item, isTable) =>
+//           (serviceURL && serviceURL.includes('VizieR')) ? maybeQuote(item,isTable) : item;
+
 export const TAP_SERVICES_FALLBACK = [
     {
         label: 'https://irsa.ipac.caltech.edu/TAP',

--- a/src/firefly/js/util/ObsCoreSRegionParser.js
+++ b/src/firefly/js/util/ObsCoreSRegionParser.js
@@ -217,7 +217,7 @@ export function parseObsCoreRegion(sRegionVal, unit='deg', isCorners=false) {
 
         default:
             valid = false;
-            message = errorMessage[ErrorRegion.ErrorRegion.errorShape.key];
+            message = errorMessage[ErrorRegion.errorShape.key];
             break;
     }
 


### PR DESCRIPTION
#### Firefly-935: Add quotes to table or columns where needed 
  - check table and columns using regular expressions
  - also fixed small bug in ObsCoreSRegionParser

_ticket:_ [FIREFLY-935](https://jira.ipac.caltech.edu/browse/FIREFLY-935)

#### Testing the TAP Panel
  - Version: 2022.1-DEV:firefly-935-quotes_0d46
  - URL: https://fireflydev.ipac.caltech.edu/firefly-935-quotes/firefly/
  - Do a VizieR Search
    - @lrebull Search: VizieR, collections: J_ApJ, table: 752/127  (no other constraints)
  - try various searches with the advance panel

