### PR TITLE
firefly-847: fixed: TAP Panel Bug in "populate" ADQL from the SingleTable input panel

### DIFF
--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -70,7 +70,7 @@ export function getNumFilters(request) {
  * @prop {boolean} options.removeQuotes  remove double-quotes from column name if present
  * @returns {string[]}
  */
-function parseInput(input, options={}) {
+export function parseInput(input, options={}) {
     const {removeQuotes=false} = options;
     let [cname='', op='', val='', ...rest] = (' '+input).split(operators);
     op = op.trim();
@@ -158,7 +158,6 @@ export class FilterInfo {
             const parts = conditions.split(COND_SEP);
             for (let i = 0; i < parts.length; i += 2) {
                 const [cname, op, val] = parseInput(parts[i]);
-                if (isNaN(Number(val))) return false;
                 if (cname || !op || !val) return false;
             }
         }

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -158,6 +158,7 @@ export class FilterInfo {
             const parts = conditions.split(COND_SEP);
             for (let i = 0; i < parts.length; i += 2) {
                 const [cname, op, val] = parseInput(parts[i]);
+                if (isNaN(Number(val))) return false;
                 if (cname || !op || !val) return false;
             }
         }

--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -85,7 +85,13 @@ export function getTableConstraints(tbl_id) {
                 if (!valid) {
                     errors += (errors.length > 0 ? `, "${value}"` : `Invalid constraints: "${value}"`);
                 } else if (v) {
-                    const oneConstraint = `${maybeQuote(colName)} ${v}`;
+                    const condAry = v.split(/( and | or )/i).map( (s) => s.trim().toUpperCase());
+                    const qCol= maybeQuote(colName);
+                    const constraint= '(' + condAry.reduce((full,part) => {
+                            if (!full) return `${qCol} ${part}`;
+                            return (part==='AND' || part==='OR') ? `${full} ${part}` : `${full} ${qCol} ${part}`;
+                        },'') + ')';
+                    const oneConstraint= condAry>1 ? `(${constraint})` : constraint;
                     whereFragment += (whereFragment.length > 0 ? ` AND ${oneConstraint}` : oneConstraint);
                 }
             });

--- a/src/firefly/js/visualize/iv/ExpandedTools.jsx
+++ b/src/firefly/js/visualize/iv/ExpandedTools.jsx
@@ -105,7 +105,7 @@ export function ExpandedTools({visRoot,closeFunc}) {
     };
 
     return (
-            <div style={{display: 'flex', alignItems:'center', marginTop:-4,
+            <div style={{display: 'flex', alignItems:'center', marginTop:-3,
                 borderBottom: '1px solid rgba(0,0,0,.2)' }}>
                 {closeFunc && <CloseButton style={closeButtonStyle} onClick={closeFunc}/>}
                 {!single &&


### PR DESCRIPTION
#### firefly-847: fixed: TAP Panel Bug in "populate" ADQL from the SingleTable input panel

  - fixed bug
  - added support for "OR"
  - column constrains and now be entered >1 AND <4
  - fixed a 1 pixel layout error with "close button"

_ticket:_ https://jira.ipac.caltech.edu/browse/FIREFLY-847

#### Testing
- Version: 2022.1-DEV:firefly-847-col-parse-err_958e
- URL: https://fireflydev.ipac.caltech.edu/firefly-847-col-parse-err/firefly/
- On the tap panel 
    - `IRSA` / `wise_allwise` / `allwise_p3as_psd` / target - `m1` / `400 arcsec`
    - on the column constrains  column `nb`: `=1 or =3`, column `w1mpro`: `>10 and < 16`
    - click `Populate and edit ADQL` is should look right
    - do a search
    - try other combinations and look at them in the ADQL panel


