### PR TITLE
firefly-45,firefly-543,Firefly-633: Multiple tickets

### DIFF
--- a/src/firefly/html/test/test-image.html
+++ b/src/firefly/html/test/test-image.html
@@ -77,8 +77,41 @@
         onFireflyLoaded = function (firefly) {
 
             const req= {
-                url: 'https://irsa.ipac.caltech.edu/cgi-bin/Subimage/nph-subimage?origfile=/irsadata/AKARI//images/N60/l000.85_b+65.00_ecl_6deg_N60_sigma.fits&ra=317.778840&dec=56.472080&xsize=2.000000',
+                url: 'https://web.ipac.caltech.edu/staff/roby/many-images/mips_IER_7735552_ier600_A24_P24_10s.cal.fits',
                 Title: 'Image Title Here'
+            };
+
+            firefly.showImage( 'show-image',req);
+        }
+    </script>
+</template>
+
+<template title="Show Image with no toolbar" class="tpl" >
+    <div id="expected" style="position: relative" >
+        <div class="source-code indent-3" style="position: absolute; bottom: 0; left: 0">
+            show image with no toolbar.
+            <code>
+                window.firefly= {
+                       options: {
+                            MenuItemKeys: {
+                                showImageToolbar:false
+                            }
+                        }
+                    };
+            </code>
+        </div>
+    </div>
+    <div id="actual" class="flow-h">
+        <div id="show-image" class="box"></div>
+    </div>
+    <script>
+
+        window.firefly= {options: {MenuItemKeys: {showImageToolbar:false}}};
+        onFireflyLoaded = function (firefly) {
+
+            const req= {
+                url: 'http://web.ipac.caltech.edu/staff/roby/demo/moving/49277b135-w1-int-1b.fits',
+                Title: 'Image With not Toolbar'
             };
 
             firefly.showImage( 'show-image',req);

--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -40,6 +40,16 @@ import {SelectedShape} from './SelectedShape';
 
 
 const TYPE_ID= 'CATALOG_TYPE';
+/**
+ * @typedef {Object} CatalogType
+ * enum can be one of
+ * @prop POINT
+ * @prop BOX
+ * @prop REGION
+ * @prop ORBITAL_PATH
+ * @prop POINT_IMAGE_PT
+ * @type {Enum}
+ */
 export const CatalogType = new Enum(['POINT', 'BOX', 'REGION', 'ORBITAL_PATH', 'POINT_IMAGE_PT']);
 
 

--- a/src/firefly/js/visualize/MenuItemKeys.js
+++ b/src/firefly/js/visualize/MenuItemKeys.js
@@ -37,6 +37,7 @@ export function getDefMenuItemKeys() {
         extractLine: true,
         extractPoint: true,
         extract: true,
+        showImageToolbar: true,
     };
     return {...MenuItemKeys, ...getAppOptions()?.MenuItemKeys};
 }

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -182,29 +182,31 @@ export function computeCentralPointAndRadius(inPoints) {
     return {centralPoint, maxRadius};
 }
 
+
 /**
  * call computeCentralPointAndRadius in 2 ways first with a flatten version of the 2d array
  * then again with group of points.  This allows us not to overweight a larger group when computing the center.
  *
  * @param {Array.<Array.<WorldPt>>} inPoints2dAry  a 2d array of world points. Each array represents a group of points
+ * @param {number} minSizeDeg
  * @return {{centralPoint:WorldPt, maxRadius:number, avgOfCenters:WorldPt}}
  */
-export function computeCentralPtRadiusAverage(inPoints2dAry) {
+export function computeCentralPtRadiusAverage(inPoints2dAry,minSizeDeg=.11) {
 
     const testAry= flattenDeep(inPoints2dAry);
 
-    if (isEmpty(testAry)) return {centralPoint:undefined, maxRadius: 0, avgOfCenters:undefined};
-    if (isOnePoint(testAry)) return {centralPoint:testAry[0], maxRadius: .05, avgOfCenters:testAry[0]};
+    if (isEmpty(testAry)) return {centralPoint:undefined, fovSize: 0, avgOfCenters:undefined};
+    if (isOnePoint(testAry)) return {centralPoint:testAry[0], fovSize: minSizeDeg, avgOfCenters:testAry[0]};
 
     const {centralPoint, maxRadius}= computeCentralPointAndRadius(testAry);
-    if (inPoints2dAry.length===1) return {centralPoint, maxRadius, avgOfCenters:centralPoint};
+    if (inPoints2dAry.length===1) return {centralPoint, fovSize:Math.max(maxRadius,minSizeDeg), avgOfCenters:centralPoint};
 
     const centers= inPoints2dAry
         .map( (ptAry) => isOnePoint(ptAry) ? ptAry[0] : computeCentralPointAndRadius(ptAry).centralPoint)
         .filter((pt) => pt); // filter out undefined centers
 
     const {centralPoint:avgOfCenters}= computeCentralPointAndRadius(centers);
-    return {centralPoint, maxRadius, avgOfCenters};
+    return {centralPoint, fovSize: Math.max(maxRadius,minSizeDeg), avgOfCenters};
 }
 
 function isOnePoint(wpList) {

--- a/src/firefly/js/visualize/draw/DrawSymbol.js
+++ b/src/firefly/js/visualize/draw/DrawSymbol.js
@@ -1,8 +1,20 @@
 import Enum from 'enum';
 
 /**
- *  enum
- *  one of 'X','SQUARE','CROSS','DIAMOND','DOT','CIRCLE', 'SQUARE_X', 'EMP_CROSS','EMP_SQUARE_X', 'BOXCIRCLE', 'ARROW'
+ * @typedef {Object} DrawSymbol
+ * enum can be one of
+ * @prop X
+ * @prop SQUARE
+ * @prop CROSS
+ * @prop DIAMOND
+ * @prop DOT
+ * @prop CIRCLE
+ * @prop SQUARE_X
+ * @prop EMP_CROSS
+ * @prop EMP_SQUARE_X
+ * @prop BOXCIRCLE
+ * @prop ARROW
+ * @type {Enum}
  */
 export const DrawSymbol = new Enum([
     'X','SQUARE','CROSS','DIAMOND','DOT','CIRCLE', 'SQUARE_X', 'EMP_CROSS','EMP_SQUARE_X',

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -3,7 +3,7 @@
  */
 
 
-import React, {memo, useEffect, useRef, useState} from 'react';
+import React, {memo, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
 import {isEmpty,omit,isFunction} from 'lodash';
@@ -24,7 +24,12 @@ import {DataTypes} from '../draw/DrawLayer.js';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
 import {getNumFilters} from '../../tables/FilterInfo';
 import {ZoomButton, ZoomType} from 'firefly/visualize/ui/ZoomButton.jsx';
+import {ToolbarButton} from 'firefly/ui/ToolbarButton.jsx';
+import {expand} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
+import {getDefMenuItemKeys} from 'firefly/visualize/MenuItemKeys.js';
+
 import './ImageViewerDecorate.css';
+import OUTLINE_EXPAND from 'images/icons-2014/24x24_ExpandArrowsWhiteOutline.png';
 
 const EMPTY_ARRAY=[];
 
@@ -201,7 +206,11 @@ function arePropsEquals(props, np) {
 } //todo: look at closely for optimization
 
 
-function ZoomPair({pv, show}) {
+function ZoomGroup({visRoot, pv, show}) {
+
+    const {showImageToolbar}= pv?.menuItemKeys ?? getDefMenuItemKeys();
+    const manageExpand= !showImageToolbar && visRoot.expandedMode===ExpandType.COLLAPSE;
+
     return (
         primePlot(pv) ? <div
             style={{
@@ -215,6 +224,11 @@ function ZoomPair({pv, show}) {
                 flexDirection: 'row',
                 alignSelf: 'flex-start',
                 }}>
+
+            {manageExpand && <ToolbarButton icon={OUTLINE_EXPAND}
+                                            tip='Expand this panel to take up a larger area'
+                                            horizontal={true} onClick={() =>expand(pv?.plotId, false)}/>}
+            
             <div style={{display:'flex', alignSelf: 'flex-start'}}>
                 <ZoomButton size={20} plotView={pv} zoomType={ZoomType.UP} horizontal={true}/>
                 <ZoomButton size={20} plotView={pv} zoomType={ZoomType.DOWN} horizontal={true}/>
@@ -296,7 +310,7 @@ const ImageViewerDecorate= memo((props) => {
                     {(plot && inlineTitle) ?
                         <PlotTitle brief={brief} titleType={TitleType.INLINE} plotView={pv}
                                    working={workingIcon} /> : undefined}
-                    <ZoomPair pv={pv} show={showZoom} />
+                    <ZoomGroup visRoot={visRoot} pv={pv} show={showZoom} />
                 </div>
                 <VisInlineToolbarView pv={pv} showDelete={showDelete} show={showDel}/>
             </div>

--- a/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
+++ b/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
@@ -13,6 +13,8 @@ import GRID from 'html/images/icons-2014/Images-Tiled.png';
 import PAGE_RIGHT from 'html/images/icons-2014/20x20_PageRight.png';
 import PAGE_LEFT from 'html/images/icons-2014/20x20_PageLeft.png';
 import {VisMiniToolbar} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
+import {getDefMenuItemKeys} from 'firefly/visualize/MenuItemKeys.js';
+import {getActivePlotView, getPlotViewById} from 'firefly/visualize/PlotViewUtil.js';
 
 
 
@@ -55,6 +57,8 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds,
 
 
     const style= {...toolsStyle, ...toolbarStyle};
+    const {showImageToolbar}= getActivePlotView(visRoot)?.menuItemKeys ?? getDefMenuItemKeys();
+    if (!showImageToolbar) return <div/>;
 
     return (
         <div style={style}>

--- a/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
@@ -311,7 +311,7 @@ function toggleOverlayColorLock(pv,plotGroupAry){
     dispatchOverlayColorLocking(pv.plotId,!hasOverlayColorLock(pv,plotGroup));
 }
 
-function expand(plotId, grid) {
+export function expand(plotId, grid) {
     dispatchChangeActivePlotView(plotId);
     dispatchSetLayoutMode( LO_MODE.expanded, LO_VIEW.images );
     grid ? dispatchChangeExpandedMode(ExpandType.GRID) : dispatchChangeExpandedMode(true);

--- a/src/firefly/js/visualize/ui/ZoomButton.jsx
+++ b/src/firefly/js/visualize/ui/ZoomButton.jsx
@@ -6,8 +6,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
 import {dispatchZoom} from '../ImagePlotCntlr.js';
-import {getZoomMax, getNextZoomLevel, UserZoomTypes} from '../ZoomUtil.js';
-import {primePlot} from '../PlotViewUtil.js';
+import {getZoomMax, getNextZoomLevel, UserZoomTypes, getZoomDesc} from '../ZoomUtil.js';
+import {getFoV, primePlot} from '../PlotViewUtil.js';
 import {showZoomOptionsPopup} from '../../ui/ZoomOptionsPopup.jsx';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 import {isImage} from '../WebPlot.js';
@@ -44,11 +44,12 @@ function getZoomer() {
         if (zType===ZoomType.UP) {
             if (isZoomMax(pv)) {
                 let msg;
+                const zlRet= getZoomDesc(pv);
                 if (isImage(plot)) {
-                    msg= 'You may not zoom beyond ' + getZoomMax(plot) + 'x';
+                    msg= `Maximum Zoom: You reached you maximum zoom: FOV: ${zlRet.fovFormatted}`;
                 }
                 else {
-                    msg= `You may not zoom beyond HiPS Norder level ${MAX_SUPPORTED_HIPS_LEVEL}`;
+                    msg= `You may not zoom beyond HiPS Norder level ${MAX_SUPPORTED_HIPS_LEVEL}, FOV: ${zlRet.fovFormatted}`;
                 }
 
                 const renderContent= <div style={{padding: '5px 0 5px 0',whiteSpace: 'nowrap'}}> {msg} </div> ;


### PR DESCRIPTION
#### Multiple Tickets

 - [Firefly-45](https://jira.ipac.caltech.edu/browse/FIREFLY-45): api option to hide image toolbar
 - [Firefly-543](https://jira.ipac.caltech.edu/browse/FIREFLY-543): better computation of  minimum size for coverage
 - [Firefly-633](https://jira.ipac.caltech.edu/browse/FIREFLY-633): Improve terminology for zoom max

Testing:
- Version: 2022.1-DEV:firefly-45_543_633_e575
- URL: https://fireflydev.ipac.caltech.edu/firefly-45-543-633/firefly/
- [Firefly-543](https://jira.ipac.caltech.edu/browse/FIREFLY-543)
   - do any search and then sort down to 1 object
   - now sort down to 3 to 5 objects that are fairly close together
   - The image size should be the same.
 - [Firefly-633](https://jira.ipac.caltech.edu/browse/FIREFLY-633)
   - zoom all the way to make the image as big as possible. 
   - Clicking the zoom plus one more time will show a maximum zoom message that does not include the level.
   - If this message is not quite right then maybe someone (@lrebull?) could give me better working. 
-  [Firefly-45](https://jira.ipac.caltech.edu/browse/FIREFLY-45)
   - URL: https://fireflydev.ipac.caltech.edu/firefly-45-543-633/firefly/test/test-image.html?test=Show+Image+with+no+toolbar
   - The image will not show the toolbar
   - Expanding it will have a toolbar