### PR TITLE
FIREFLY-939: Table search sometime do not return results

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -687,6 +687,8 @@ function asyncFetch(request, hlRowIdx, dispatch, tbl_id) {
             if (inProgress) {
                 // not done; track progress
                 trackBackgroundJob({jobId, key: bgKey, onComplete, sentToBg});
+            } else {
+                onComplete(jobInfo);
             }
         }).catch( (error) => {
             dispatchComponentStateChange(bgKey, {inProgress:false});


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-939

```
In certain cases for small searches the table search results are not showing up, 
it just is a blank area instead with not message and no results.
```
This explains it.  This PR fixed the case when an async job returns immediately with `COMPLETED` status, table failed to retrieve the data.

Test: https://fireflydev.ipac.caltech.edu/firefly-939-blank-table/firefly/