### PR TITLE
Multiple tickets PR(FIREFLY-960, FIREFLY-962, FIREFLY-963)

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -2,23 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {
-    get,
-    set,
-    has,
-    isEmpty,
-    isUndefined,
-    uniqueId,
-    cloneDeep,
-    omitBy,
-    isNil,
-    isPlainObject,
-    isArray,
-    padEnd,
-    chunk,
-    isString,
-    isObject
-} from 'lodash';
+import {chunk, cloneDeep, get, has, isArray, isEmpty, isNil, isObject, isPlainObject, isString, isUndefined, omitBy, padEnd, set, uniqueId} from 'lodash';
 import Enum from 'enum';
 
 import {getWsConnId} from '../core/AppDataCntlr.js';
@@ -257,7 +241,7 @@ export function getTableUiById(tbl_ui_id) {
  */
 export function getTableUiByTblId(tbl_id) {
     const uiRoot = get(flux.getState(), [TblCntlr.TABLE_SPACE_PATH, 'ui'], {});
-    return Object.keys(uiRoot).find( (ui_id) => get(uiRoot, [ui_id, 'tbl_id']) === tbl_id);
+    return Object.values(uiRoot).find( (tblUiState) => tblUiState?.tbl_id === tbl_id);
 }
 
 /**

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -70,7 +70,7 @@ export function TablePanel(props) {
 
     const toggleFilter = () => connector.onOptionUpdate({showFilters: !showFilters});
     const toggleTextView = () => connector.onToggleTextView(!textView);
-    const clearFilter = () => connector({filters: '', sqlFilter: ''});
+    const clearFilter = () => connector.applyFilterChanges({filterInfo: '', sqlFilter: ''});
     const toggleOptions = () => connector.onToggleOptions(!showOptions);
     const onOptionUpdate = (value) => connector.onOptionUpdate(value);
     const onOptionReset = () => connector.onOptionReset(props);
@@ -98,7 +98,7 @@ export function TablePanel(props) {
     const showInfoDialog = () => showTableInfoDialog(tbl_id);
 
     const tstate = getTableState(uiState);
-    logger.debug(`render.. state:[${tstate}] -- ${tbl_id}`);
+    logger.debug(`render.. state:[${tstate}] -- ${tbl_id}  ${tbl_ui_id}`);
 
     if (['ERROR','LOADING'].includes(tstate))  return <NotReady {...{showTitle, tbl_id, title, removable, backgroundable, error}}/>;
 

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -88,7 +88,7 @@ export class InputFieldView extends PureComponent {
 
     render() {
         var {hasFocus}= this.state;
-        var {visible,disabled, label,tooltip,labelWidth,value,style,wrapperStyle,labelStyle,
+        var {visible,disabled, label,tooltip,labelWidth,value,style,wrapperStyle,labelStyle, inputRef, autoFocus,
              valid,size,onChange, onBlur, onKeyPress, onKeyDown, onKeyUp, showWarning, message, type, placeholder, form='__ignore', readonly}= this.props;
         if (!visible) return null;
         wrapperStyle = Object.assign({whiteSpace:'nowrap', display: this.props.inline?'inline-block':'block'}, wrapperStyle);
@@ -116,7 +116,8 @@ export class InputFieldView extends PureComponent {
                        value={currValue}
                        disabled={readonly}
                        title={ (!showWarning && !valid) ? message : tooltip}
-                       {...pickBy({size, type, disabled, placeholder, form})}
+                       ref={inputRef}
+                       {...pickBy({size, type, disabled, placeholder, form, autoFocus})}
                 />
                 {showWarning && this.makeWarningArea(!valid)}
             </div>


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-960
FIREFLY-960: cancel filters from table doesn't work
- fixed.  regression bug.

https://jira.ipac.caltech.edu/browse/FIREFLY-962
FIREFLY-962: can't turn on filters in catalogs if they're loaded from the background
- fixed.  regression bug.

https://jira.ipac.caltech.edu/browse/FIREFLY-963
FIREFLY-963: strange behavior of tab keys to navigate among filters
- I noticed this behavior in OPS as well.  The table re-render after applying the filter then focus is lost.  I thought it was expected
- But, I went ahead and add the code needed to keep focus after re-rendering.
- Also, I don't understand the "lock by click" test case.  Please test to see if my fix also fixes that.

Test: https://fireflydev.ipac.caltech.edu/firefly-960-962-963-table-filters/firefly/