### PR TITLE
FIREFLY-969-970-961: Multiple tickets PR

### DIFF
--- a/docs/firefly-api-overview.md
+++ b/docs/firefly-api-overview.md
@@ -500,7 +500,7 @@ options -  table options, object with the following properties:
 | ---------- | ---- | ----------- |
 | tbl_group | string | the group this table belongs to, defaults to 'main' |
 | removable  | boolean | true if this table can be removed from view, defaults to true |
-| showUnits  | boolean | defaults to false |
+| showUnits  | boolean | defaults to true if table contains unit info |
 | showFilters | boolean | defaults to false |
 | selectable | boolean | defaults to true |
 | expandable | boolean | defaults to true |

--- a/src/firefly/html/demo/table-api.html
+++ b/src/firefly/html/demo/table-api.html
@@ -207,7 +207,7 @@ There are additional information specific to each input field.  Click the top bu
 @prop {boolean} [expandable=true]
 @prop {boolean} [removable=true]  true if this table can be removed from view.
 @prop {boolean} [border=true]
-@prop {boolean} [showUnits=true]
+@prop {boolean} [showUnits]
 @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.
 @prop {boolean} [showFilters=false]
 @prop {boolean} [showToolbar=true]

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -95,7 +95,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     private static final Map<String, ReentrantLock> activeRequests = new HashMap<>();
     private static final ReentrantLock lockChecker = new ReentrantLock();
     private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
-    private static final int MAX_COL_ENUM_COUNT = AppProperties.getIntProperty("max.col.enum.count", 15);
+    private static final int MAX_COL_ENUM_COUNT = AppProperties.getIntProperty("max.col.enum.count", 32);
     private Job job;
 
     public void setJob(Job job) {

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -145,7 +145,7 @@ function buildTablePart(llApi) {
      * @prop {number}  pageSize     the starting page size.  Will use the request's pageSize if not given.
      * @prop {boolean} removable    true if this table can be removed from view.  Defaults to true.
      * @prop {boolean} backgroundable    true if this search can be sent to background.  Defaults to false.
-     * @prop {boolean} showUnits    defaults to false
+     * @prop {boolean} showUnits    defaults to true if table contains unit info
      * @prop {boolean} showTypes    defaults to false
      * @prop {boolean} showFilters  defaults to false
      * @prop {boolean} selectable   defaults to true

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -273,7 +273,7 @@
  * @prop {boolean} [showFilterButton=true]
  * @prop {boolean} [showInfoButton=false] when true, shows additional information about table, if available
  * @prop {boolean} [showOptionButton=true]
- * @prop {boolean} [showUnits=true]
+ * @prop {boolean} [showUnits]
  * @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.
  * @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.
  * @prop {function[]}  [rightButtons]  an array of functions that returns a button-like component laid out on the right side of this table header.

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -4,23 +4,15 @@
 
 import React, {useCallback, useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {Table,Column} from 'fixed-data-table-2';
+import {Column, Table} from 'fixed-data-table-2';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
-import {get, isEmpty} from 'lodash';
+import {get, isEmpty, isUndefined} from 'lodash';
 
-import {tableTextView, getTableUiById, getProprietaryInfo, getTblById, hasRowAccess, calcColumnWidths, uniqueTblUiId, hasNoData} from '../TableUtil.js';
+import {calcColumnWidths, getProprietaryInfo, getTableUiById, getTblById, hasNoData, hasRowAccess, tableTextView, uniqueTblUiId} from '../TableUtil.js';
 import {SelectInfo} from '../SelectInfo.js';
 import {FilterInfo} from '../FilterInfo.js';
 import {SortInfo} from '../SortInfo.js';
-import {
-    TextCell,
-    HeaderCell,
-    SelectableHeader,
-    SelectableCell,
-    LinkCell,
-    makeDefaultRenderer,
-    CellWrapper
-} from './TableRenderer.js';
+import {CellWrapper, HeaderCell, makeDefaultRenderer, SelectableCell, SelectableHeader} from './TableRenderer.js';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {dispatchTableUiUpdate, TBL_UI_UPDATE} from '../TablesCntlr.js';
 import {Logger} from '../../util/Logger.js';
@@ -37,12 +29,21 @@ const BY_SCROLL = 'byScroll';
 const BasicTableViewInternal = React.memo((props) => {
 
     const {width, height} = props.size;
-    const {columns, data, hlRowIdx, showUnits, showTypes, showFilters, filterInfo, renderers,
+    const {columns, data, hlRowIdx, showTypes, showFilters, filterInfo, renderers,
             bgColor, selectable, selectInfoCls, sortInfo, callbacks, textView, rowHeight,
             error, tbl_ui_id=uniqueTblUiId(), currentPage, startIdx=0, highlightedRowHandler, cellRenderers} = props;
 
     const uiStates = getTableUiById(tbl_ui_id) || {};
     const {tbl_id, columnWidths, scrollLeft=0, scrollTop=0, triggeredBy} = uiStates;
+    let showUnits = uiStates.showUnits ?? props.showUnits;
+
+
+    useEffect( () => {
+        if (isUndefined(showUnits) && !isEmpty(columns)) {
+            showUnits = !!columns.find?.((col) => col?.units);
+            dispatchTableUiUpdate({tbl_ui_id, showUnits});
+        }
+    }, [showUnits, columns]);
 
     const onScrollEnd    = useCallback( doScrollEnd.bind({tbl_ui_id}), [tbl_ui_id]);
     const onColumnResize = useCallback( doColumnResize.bind({columnWidths, tbl_ui_id}), [columnWidths]);
@@ -170,7 +171,6 @@ BasicTableViewInternal.propTypes = {
 
 BasicTableViewInternal.defaultProps = {
     selectable: false,
-    showUnits: false,
     showTypes: false,
     showFilters: false,
     showMask: false,

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -251,7 +251,6 @@ TablePanel.propTypes = {
 
 TablePanel.defaultProps = {
     showMetaInfo: false,
-    showUnits: false,
     allowUnits: true,
     showFilters: false,
     showToolbar: true,

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -112,7 +112,7 @@ function OptionsFilterStats({tbl_id}) {
 }
 
 function Options({uiState, tbl_id, tbl_ui_id, ctm_tbl_id, onOptionReset, onChange}) {
-    const {pageSize, showPaging=true, showUnits=false, allowUnits=true,showTypes=true, showFilters=false} = uiState || {};
+    const {pageSize, showPaging=true, showUnits, allowUnits=true,showTypes=true, showFilters=false} = uiState || {};
 
     const onPageSize = (pageSize) => {
         if (pageSize.valid) {

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -54,7 +54,7 @@ export const HiPSImageSelect= ({style={}, groupKey}) => {
     } else {
         return (
             <div className='ImageSearch__section hips-table' style={style}>
-                <div className='ImageSearch__section--title' style={{display: 'inline-flex',width: '100%'}}>
+                <div className='ImageSearch__section--title' style={{display: 'inline-flex', width: '100%', boxSizing: 'border-box'}}>
                     <div style={{width: 175}}>4. Select Data Set</div>
                     <SourceSelect/>
                 </div>


### PR DESCRIPTION
Changes to irsa-ife as well.   https://github.com/IPAC-SW/irsa-ife/pull/204

FIREFLY-969: Set maximum number of values supported in auto-detected category-column filtering to 32
- fixed as requested

FIREFLY-961: ZTF: details tab changes if you click on the gears
- fixed as requested

FIREFLY-970: Display units if table contains units information by default
- ticket updated based on conversation with @ejoliet and @robyww
- please read ticket to determine the impact of this change

Tests: 
https://firefly-969-961-ztf-details.irsakudev.ipac.caltech.edu/applications/ztf/
https://firefly-969-961-ztf-details.irsakudev.ipac.caltech.edu/irsaviewer/
https://firefly-969-961-ztf-details.irsakudev.ipac.caltech.edu/applications/finderchart/
