### PR TITLE
FIREFLY-976: TablePanel failed to pickup new changes when tbl_ui_id changes

### DIFF
--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -162,7 +162,7 @@ ChartSelectPanel.contextType= RenderTreeIdCtx;
 
 function ChartAction({chartId, chartActions, chartAction, chartActionChanged}) {
 
-    const [activeTrace=0] = useStoreConnector(() => getChartData(chartId)?.activeTrace);
+    const activeTrace = useStoreConnector(() => getChartData(chartId)?.activeTrace ?? 0);
     const {ChooseTrace} = basicOptions({chartId, activeTrace});
 
     const options = [];
@@ -251,7 +251,7 @@ function SyncedOptionsUI (props) {
     // based on chartData, determine what options to display
 
     const {chartId, groupKey} = props;
-    const [{useSpectrum, dataType, type, activeTrace}] = useStoreConnector.bind({comparator: shallowequal})(() =>  {
+    const {useSpectrum, dataType, type, activeTrace} = useStoreConnector(() =>  {
         const {data, fireflyData, activeTrace=0} = getChartData(chartId);
         const dataType = fireflyData?.[activeTrace]?.dataType;
         const fval = getFieldVal(groupKey, `fireflyData.${activeTrace}.useSpectrum`);
@@ -259,6 +259,7 @@ function SyncedOptionsUI (props) {
         const type = get(data, [activeTrace, 'type'], 'scatter');
         return {useSpectrum, dataType, type, activeTrace};
     });
+
     const {fireflyData} = getChartData(chartId);
 
     useEffect( ()=> {

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -73,9 +73,7 @@ function findViewerId(viewerId= DEFAULT_PLOT2D_VIEWER_ID, renderTreeId= undefine
 
 export function BasicOptions({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, groupKey}) {
     
-    const [activeTrace] = useStoreConnector(() => {
-        return pActiveTrace ?? getChartData(chartId)?.activeTrace ?? 0;
-    });
+    const activeTrace = useStoreConnector(() =>  pActiveTrace ?? getChartData(chartId)?.activeTrace ?? 0);
     useEffect(() => {
        return () => hideColSelectPopup();
     }, []);
@@ -236,7 +234,7 @@ export function PlotBoundaries({activeTrace:pActiveTrace, tbl_id, chartId, group
 
 function XyRatio({groupKey, Xyratio, Stretch, xNoLog}) {
 
-    const [showStretch] = useStoreConnector(() => {
+    const showStretch = useStoreConnector(() => {
         const {value, valid} = getField(groupKey, xyratioFldName) || {};
         return !!value && valid;
     });

--- a/src/firefly/js/charts/ui/options/Errors.jsx
+++ b/src/firefly/js/charts/ui/options/Errors.jsx
@@ -132,7 +132,7 @@ export function Error_X({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, grou
     errorMinus = errorMinus || get(mappings, [activeTrace, 'error_x.arrayminus'], '');
     const colValStats = getColValStats(tbl_id);
 
-    const [type] = useStoreConnector(() => getFieldVal(groupKey, fldName, defType));
+    const type = useStoreConnector(() => getFieldVal(groupKey, fldName, defType));
 
     return <Error {...{axis: 'x', groupKey, colValStats, activeTrace, type, error, errorMinus, labelWidth, readonly}}/>;
 }
@@ -146,7 +146,7 @@ export function Error_Y({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, grou
     errorMinus = errorMinus || get(mappings, ['error_y.arrayminus'], '');
     const colValStats = getColValStats(tbl_id);
 
-    const [type] = useStoreConnector(() => getFieldVal(groupKey, fldName, defType));
+    const type = useStoreConnector(() => getFieldVal(groupKey, fldName, defType));
 
     return <Error {...{axis: 'y', groupKey, colValStats, activeTrace, type, error, errorMinus, labelWidth, readonly}}/>;
 }

--- a/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/FireflyHistogramOptions.jsx
@@ -12,9 +12,7 @@ import {FieldGroupCollapsible} from '../../../ui/panel/CollapsiblePanel.jsx';
 
 export function FireflyHistogramOptions({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, groupKey}) {
 
-    const [activeTrace] = useStoreConnector(() => {
-        return pActiveTrace ?? getChartData(chartId)?.activeTrace;
-    });
+    const activeTrace = useStoreConnector(() => pActiveTrace ?? getChartData(chartId)?.activeTrace);
 
     groupKey = groupKey || `${chartId}-ffhist-${activeTrace}`;
     const {tbl_id, noColor, multiTrace} = getChartProps(chartId, ptbl_id, activeTrace);

--- a/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
+++ b/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
@@ -23,9 +23,8 @@ const fieldProps = {labelWidth: 62, size: 15};
 
 export function HeatmapOptions({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, groupKey}) {
 
-    const [activeTrace] = useStoreConnector(() => {
-        return  pActiveTrace ?? getChartData(chartId)?.activeTrace;
-    });
+    const activeTrace = useStoreConnector(() => pActiveTrace ?? getChartData(chartId)?.activeTrace);
+
     groupKey = groupKey || `${chartId}-heatmap-${activeTrace}`;
     const {tablesource, tbl_id, multiTrace} = getChartProps(chartId, ptbl_id, activeTrace);
     const {Name} = basicOptions({activeTrace, tbl_id, chartId, groupKey, fieldProps:{labelWidth: 60}});

--- a/src/firefly/js/charts/ui/options/PlotlyHistogramOptions.jsx
+++ b/src/firefly/js/charts/ui/options/PlotlyHistogramOptions.jsx
@@ -21,9 +21,7 @@ const fieldProps = {labelWidth: 62, size: 15};
  */
 export function HistogramOptions({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, groupKey}) {
 
-    const [activeTrace] = useStoreConnector(() => {
-        return pActiveTrace ?? getChartData(chartId)?.activeTrace;
-    });
+    const activeTrace = useStoreConnector(() => pActiveTrace ?? getChartData(chartId)?.activeTrace);
 
     groupKey = groupKey || `${chartId}-ffhist-${activeTrace}`;
     const {tbl_id, multiTrace, noColor} = getChartProps(chartId, ptbl_id, activeTrace);

--- a/src/firefly/js/charts/ui/options/ScatterOptions.jsx
+++ b/src/firefly/js/charts/ui/options/ScatterOptions.jsx
@@ -48,7 +48,7 @@ export function yLimitUI() {
  */
 export function ScatterOptions({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, groupKey}) {
 
-    const [activeTrace] = useStoreConnector(() => pActiveTrace ?? getChartData(chartId)?.activeTrace);
+    const activeTrace = useStoreConnector(() => pActiveTrace ?? getChartData(chartId)?.activeTrace);
     useEffect(() => {
         return () => hideColSelectPopup();
     }, []);

--- a/src/firefly/js/charts/ui/options/SpectrumOptions.jsx
+++ b/src/firefly/js/charts/ui/options/SpectrumOptions.jsx
@@ -20,7 +20,7 @@ import {getSpectrumProps} from '../../dataTypes/FireflySpectrum.js';
 
 export function SpectrumOptions ({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, groupKey}) {
 
-    const [activeTrace=0] = useStoreConnector(() => pActiveTrace ?? getChartData(chartId)?.activeTrace);
+    const activeTrace = useStoreConnector(() => pActiveTrace ?? getChartData(chartId)?.activeTrace ?? 0);
 
     groupKey = groupKey || `${chartId}-ffsed-${activeTrace}`;
 

--- a/src/firefly/js/core/background/BackgroundMonitor.jsx
+++ b/src/firefly/js/core/background/BackgroundMonitor.jsx
@@ -47,7 +47,7 @@ export function showBackgroundMonitor(show=true) {
 
  function BackgroundMonitor() {
 
-    const [{jobs={}, email, enableEmail, help_id}] = useStoreConnector(() => getBackgroundInfo());
+    const {jobs={}, email, enableEmail, help_id} = useStoreConnector(() => getBackgroundInfo());
 
     const items = Object.values(jobs)
                     .filter((job) => job?.monitored)
@@ -212,7 +212,7 @@ function JobProgress({jobInfo}) {
 
 
 function PackageItem({SINGLE, jobId, index}) {
-    const [jobInfo] = useStoreConnector(() => getJobInfo(jobId));
+    const jobInfo = useStoreConnector(() => getJobInfo(jobId));
 
     const {parameters, downloadState} = jobInfo;
     const dlreq = JSON.parse(parameters?.downloadRequest);

--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -24,7 +24,7 @@ const logger = Logger('BgMaskPanel');
 
 export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, style={}}) => {
 
-    const [{inProgress, jobInfo}] = useStoreConnector((oldState={}) => {
+    const {inProgress, jobInfo} = useStoreConnector((oldState={}) => {
         const {inProgress:oProg, jobInfo:oInfo} = oldState;
         const {inProgress=false, jobId} = getComponentState(componentKey);
         const jobInfo = getJobInfo(jobId);

--- a/src/firefly/js/core/background/BgMonitorButton.jsx
+++ b/src/firefly/js/core/background/BgMonitorButton.jsx
@@ -14,7 +14,7 @@ const showBgMonAction = { type:'COMMAND',
 
 export function BgMonitorButton () {
 
-    const [{jobs={}}] = useStoreConnector(() => getBackgroundInfo());
+    const {jobs={}} = useStoreConnector(() => getBackgroundInfo());
 
     const monitoredJobs = Object.values(jobs).filter( (info) => info?.monitored );
     const working = monitoredJobs.some( (info) => isActive(info) );

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -29,7 +29,7 @@ export function showJobInfo(jobId) {
 
 
 export function JobInfo({jobId, style}) {
-    const [{phase, startTime, endTime, dataOrigin, results, error, summary}] = useStoreConnector(() => getJobInfo(jobId) || {});
+    const {phase, startTime, endTime, dataOrigin, results, error, summary} = useStoreConnector(() => getJobInfo(jobId) || {});
     return (
         <div className='JobInfo__main' style={style}>
             <div className='JobInfo__items'>

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -226,7 +226,7 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange}) {
 
 
     const sqlEl = useRef(null);                                                // using a useRef hook
-    const [uiState] = useStoreConnector(() => getTableUiById(tbl_ui_id));
+    const uiState = useStoreConnector(() => getTableUiById(tbl_ui_id));
 
     useEffect(() => {
         const {op='AND', sql=''} = getSqlFilter(tbl_id);

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -6,7 +6,7 @@ import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, truncate, get, set} from 'lodash';
 
-import {useStoreState} from '../../ui/SimpleComponent.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {dispatchTableRemove, dispatchTblExpanded, dispatchTableFetch, dispatchTableAddLocal, dispatchTableUiUpdate} from '../TablesCntlr.js';
 import {uniqueTblUiId, uniqueTblId, getTableUiById, getTableUiByTblId, makeBgKey, getResultSetRequest} from '../TableUtil.js';
 import {TablePanelOptions} from './TablePanelOptions.jsx';
@@ -44,7 +44,7 @@ export function TablePanel(props) {
     tbl_id = tbl_id || tableModel?.tbl_id || uniqueTblId();
     tbl_ui_id = tbl_ui_id || uniqueTblUiId();
 
-    const uiState = useStoreState(() => getTableUiById(tbl_ui_id) || {}, [tbl_ui_id]);
+    const uiState = useStoreConnector(() => getTableUiById(tbl_ui_id) || {columns:[]}, [tbl_ui_id]);
 
     useEffect( () => {
         if (!getTableUiByTblId(tbl_id)) {

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -6,7 +6,7 @@ import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, truncate, get, set} from 'lodash';
 
-import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {useStoreState} from '../../ui/SimpleComponent.jsx';
 import {dispatchTableRemove, dispatchTblExpanded, dispatchTableFetch, dispatchTableAddLocal, dispatchTableUiUpdate} from '../TablesCntlr.js';
 import {uniqueTblUiId, uniqueTblId, getTableUiById, getTableUiByTblId, makeBgKey, getResultSetRequest} from '../TableUtil.js';
 import {TablePanelOptions} from './TablePanelOptions.jsx';
@@ -44,7 +44,7 @@ export function TablePanel(props) {
     tbl_id = tbl_id || tableModel?.tbl_id || uniqueTblId();
     tbl_ui_id = tbl_ui_id || uniqueTblUiId();
 
-    const [uiState] = useStoreConnector(() => getTableUiById(tbl_ui_id) || {columns: []});
+    const uiState = useStoreState(() => getTableUiById(tbl_ui_id) || {}, [tbl_ui_id]);
 
     useEffect( () => {
         if (!getTableUiByTblId(tbl_id)) {
@@ -56,7 +56,6 @@ export function TablePanel(props) {
             dispatchTableAddLocal(tableModel, undefined, false);
         }
     }, [tbl_id, tbl_ui_id, tableModel]);
-
 
     const {selectable, expandable, expandedMode, border, renderers, title, removable, rowHeight, help_id,
         showToolbar, showTitle, showInfoButton, showMetaInfo, showOptions,

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -25,7 +25,7 @@ import {HelpIcon} from '../../ui/HelpIcon.jsx';
 
 export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOptionReset}) => {
 
-    const [uiState] = useStoreConnector(() => getTableUiById(tbl_ui_id));
+    const uiState = useStoreConnector(() => getTableUiById(tbl_ui_id));
     const ctm_tbl_id = `${tbl_ui_id}-columnOptions`;
     const showAdvFilter = !isClientTable(tbl_id);
 
@@ -99,7 +99,7 @@ TablePanelOptions.propTypes = {
 
 function OptionsFilterStats({tbl_id}) {
 
-    const [filterCnt] = useStoreConnector(() => getFilterCount(getTblById(tbl_id)));
+    const filterCnt = useStoreConnector(() => getFilterCount(getTblById(tbl_id)));
     const filterStr = filterCnt === 0 ? '' : filterCnt === 1 ? '1 filter' : `${filterCnt} filters`;
     const clearFilters = () => dispatchTableFilter({tbl_id, filters: ''});;
 

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -81,13 +81,13 @@ const blurEnter = ['blur','enter'];
 
 function Filter({cname, onFilter, filterInfo, tbl_id}) {
 
-    const colGetter= () => getColumn(getTblById((tbl_id)), cname);
+    const colGetter= () => getColumn(getTblById((tbl_id)), cname) ?? {};
 
     const inputRef = useRef(null);
     const enumArrowEl = useRef(null);
-    const [col={}] = useStoreConnector(colGetter);
+    const col = useStoreConnector(colGetter);
 
-    const [focusCol] = useStoreConnector(() => getTableUiByTblId(tbl_id)?.focusCol);
+    const focusCol = useStoreConnector(() => getTableUiByTblId(tbl_id)?.focusCol);
     useEffect(() => {
         const onFocus = () => {
             const {tbl_ui_id} = getTableUiByTblId(tbl_id);

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -26,11 +26,9 @@ export function TablesContainer(props) {
     const {mode, closeable, tableOptions, style, expandedMode:xMode} = props;
     let {tbl_group} = props;
 
-    const [tables, active, expandedMode] = useStoreConnector(
-        () => TblUtil.getTableGroup(tbl_group)?.tables,
-        () => TblUtil.getTableGroup(tbl_group)?.active,
-        () => xMode || getExpandedMode() === LO_VIEW.tables
-    );
+    const tables = useStoreConnector(() => TblUtil.getTableGroup(tbl_group)?.tables);
+    const active = useStoreConnector(() => TblUtil.getTableGroup(tbl_group)?.active);
+    const expandedMode = useStoreConnector(() => xMode || getExpandedMode() === LO_VIEW.tables);
 
     useEffect(() => {
         if (expandedMode && mode !== 'standard') {

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -63,7 +63,7 @@ function getNextState(prevS, renderTreeId) {
  */
 export const FireflySlate= memo(( {initLoadingMessage, appTitle= 'Firefly', appIcon=FFTOOLS_ICO, altAppIcon,
                                       footer, style, renderTreeId, menu:menuItems, showBgMonitor=false}) => {
-    const [state]= useStoreConnector( (prevState) => getNextState(prevState,renderTreeId));
+    const state= useStoreConnector( (prevState) => getNextState(prevState,renderTreeId));
     const {isReady, mode={}, gridView= [], gridColumns=1, menu={}, dropDown={}, layoutInfo, initLoadCompleted, dropdownPanels} = state;
     const {expanded} = mode;
     const {visible, view, initArgs} = dropDown;

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -56,10 +56,9 @@ export const LcViewer = memo((props) => {
         dispatchOnAppReady((state) => onReady({state, menu:props.menu}));
     }, []);
 
-    const [storeState]= useStoreConnector((oldState={}) => {
+    const storeState= useStoreConnector(() => {
         const fileLocation = getFieldVal(vFileKey, 'uploadContainer', 'isLocal');
-        const newState= {fileLocation, menu:getMenu(), isReady:isAppReady(), ...getLayouInfo()};
-        return shallowequal(oldState,newState) ? oldState : newState;
+        return {fileLocation, menu:getMenu(), isReady:isAppReady(), ...getLayouInfo()};
     });
 
     const {isReady, menu={}, appTitle, altAppIcon, dropDown,
@@ -180,7 +179,7 @@ function getUploadPanelState(oldState) {
 
 
 export const UploadPanel = ({initArgs}) =>{
-    const [{missionOptions,fileLocation}]= useStoreConnector(getUploadPanelState );
+    const {missionOptions,fileLocation} = useStoreConnector(getUploadPanelState );
 
     useEffect( () => {
         executeOnce( () => validateAutoSearch(initArgs), () => callAutoSearch(initArgs));

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -3,7 +3,6 @@
  */
 
 import React, {memo} from 'react';
-import shallowequal from 'shallowequal';
 import PropTypes from 'prop-types';
 import {useStoreConnector} from './SimpleComponent.jsx';
 import {getUserInfo} from '../core/AppDataCntlr.js';
@@ -56,12 +55,7 @@ Banner.propTypes= {
 
 
 const UserInfo= memo(() => {
-    const [userInfo={}]= useStoreConnector(
-        (prev) => {
-            const userInfo= getUserInfo();
-            if (!prev) return userInfo;
-            return shallowequal(prev,userInfo) ? prev : userInfo;
-        });
+    const userInfo = useStoreConnector(() => getUserInfo() ?? {});
 
     const {loginName='Guest', firstName='', lastName='', login_url, logout_url} = userInfo;
     const isGuest = loginName === 'Guest';

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -80,7 +80,8 @@ export function DownloadButton(props) {
     const tblIdGetter = () => props.tbl_id || getActiveTableId(tbl_grp);
     const selectInfoGetter = () => get(getTblById(tblIdGetter()), 'selectInfo');
 
-    const [tbl_id, selectInfo] = useStoreConnector(tblIdGetter, selectInfoGetter);
+    const tbl_id = useStoreConnector(tblIdGetter);
+    const selectInfo = useStoreConnector(selectInfoGetter);
     const selectInfoCls = SelectInfo.newInstance(selectInfo);
 
     const onClick = useCallback(() => {
@@ -319,7 +320,7 @@ export function DownloadCutout({style={}, fieldKey='dlCutouts', labelWidth}) {
     );
 }
 export function EmailNotification({style, groupKey}) {
-    const [enableEmail] = useStoreConnector(() => getFieldVal(groupKey, emailNotif));
+    const enableEmail = useStoreConnector(() => getFieldVal(groupKey, emailNotif));
 
     return (
         <div style={style}>

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -46,7 +46,7 @@ function getCurrentRotation(pv) {
 const marks = { 0: '0', 45:'45', 90:'90', 135: '135', 180:'180', 225: '225', 270:'270', 315:'315', 359:'359' };
 
 function FitsRotationImmediatePanel() {
-    const [pv] = useStoreConnector(() => getActivePlotView(visRoot()));
+    const pv = useStoreConnector(() => getActivePlotView(visRoot()));
 
     useEffect(() => {
         (!pv || !isImage(primePlot(pv))) && dispatchHideDialog(DIALOG_ID);

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -41,7 +41,7 @@ let activeHipsTblId;
 let activeGroupKey;
 
 export const HiPSImageSelect= ({style={}, groupKey}) => {
-    const [imageSource] = useStoreConnector(() => getFieldVal(groupKey,'imageSource'));
+    const imageSource = useStoreConnector(() => getFieldVal(groupKey,'imageSource'));
     activeGroupKey = groupKey;
 
     if (imageSource === 'url') {
@@ -194,7 +194,7 @@ export function makeHiPSWebPlotRequest(request, plotId, groupId= DEFAULT_FITS_VI
 
 function HiPSSurveyTable({groupKey, moc=false}) {
 
-    let [sources] = useStoreConnector(() => getFieldVal(groupKey, moc ? useSourceMOC : useSourceHiPS));
+    let sources = useStoreConnector(() => getFieldVal(groupKey, moc ? useSourceMOC : useSourceHiPS));
     sources = sources ||  getHiPSSources();
     activeHipsTblId = 'HiPS_tbl_id-' + (moc ? '--moc--' : '--hips--') + sources.replaceAll(',', '-');
 

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -16,7 +16,6 @@ import {dispatchMultiValueChange} from '../fieldGroup/FieldGroupCntlr.js';
 import {dispatchComponentStateChange} from '../core/ComponentCntlr.js';
 import {updateSet} from '../util/WebUtil.js';
 import {useStoreConnector} from './SimpleComponent';
-import shallowequal from 'shallowequal';
 
 import './ImageSelect.css';
 import infoIcon from 'html/images/info-icon.png';
@@ -58,7 +57,7 @@ export function ImageSelect({style, imageMasterData, groupKey, multiSelect=true,
         ['missionId', 'project', 'subProject'].forEach((k) => d[k] = d[k] || '');
     });
 
-    const [filteredImageData] = useStoreConnector.bind({comparator: shallowequal})(() => getFilteredImageData(imageMasterData, groupKey));
+    const filteredImageData = useStoreConnector(() => getFilteredImageData(imageMasterData, groupKey));
     const [, setLastMod] = useState(new Date().getTime());
     const pStyle = scrollDivId ? {flexGrow: 1, display: 'flex'} : {flexGrow: 1, display: 'flex', height: 1};
 
@@ -186,7 +185,8 @@ function ToolBar({className, filteredImageData, groupKey, onChange}) {
             .map((o) => o.label).join() )                 // takes the label of the selected field
         .join();
 
-    const [allFilter, allSelect] = useStoreConnector(calcFilter,calcSelect);
+    const allFilter = useStoreConnector(calcFilter);
+    const allSelect = useStoreConnector(calcSelect);
 
     return (
         <div className={className}>

--- a/src/firefly/js/ui/PagingBar.jsx
+++ b/src/firefly/js/ui/PagingBar.jsx
@@ -36,7 +36,7 @@ export function PagingBar(props) {
                 <div onClick={() => callbacks.onGotoPage(currentPage - 1)} className='PagingBar__button previous' title='Previous Page'/>
                 <div style={{display: 'inline-flex', alignItems: 'center'}}>
                     <InputField
-                        style={{textAlign: 'right', width: `${nchar}ch`}}
+                        style={{textAlign: 'right', width: `${nchar+1}ch`}}
                         validator = {intValidator(1, totalPages, 'Page Number')}
                         tooltip = 'Jump to this page'
                         value = {currentPage+''}

--- a/src/firefly/js/ui/WorkspaceSelectPane.jsx
+++ b/src/firefly/js/ui/WorkspaceSelectPane.jsx
@@ -42,8 +42,9 @@ export function WsSaveOptions (props) {
     saveAsProps = {label:'Save as:', labelWidth, wrapperStyle:{margin: '3px 0'}, size:30, ...saveAsProps};
     fileLocProps = {label:'File Location:', labelWidth, ...fileLocProps};
 
-    const [loc, wsSelect] = useStoreConnector(  () => getFieldVal(groupKey, 'fileLocation'),
-                                                () => getFieldVal(groupKey, 'wsSelect'));
+    const loc      = useStoreConnector(() => getFieldVal(groupKey, 'fileLocation'));
+    const wsSelect = useStoreConnector(() => getFieldVal(groupKey, 'wsSelect'));
+
     useEffect(() => {
         dispatchWorkspaceUpdate();
     }, [loc]);
@@ -80,7 +81,8 @@ WsSaveOptions.propTypes = {
 
 function ShowWorkspace({wsSelect}) {
 
-    const [wsList, isUpdating] = useStoreConnector(getWorkspaceList, isAccessWorkspace);
+    const wsList     = useStoreConnector(getWorkspaceList);
+    const isUpdating = useStoreConnector(isAccessWorkspace);
 
     const content = isUpdating ? <div className='loading-mask' style={{margin:-3}}/>
                     : isEmpty(wsList) ? <div style={{color:'maroon', fontStyle:'italic', padding:10}}> {'Workspace access error: ' + getWorkspaceErrorMsg()} </div>

--- a/src/firefly/js/ui/ZoomOptionsPopup.jsx
+++ b/src/firefly/js/ui/ZoomOptionsPopup.jsx
@@ -18,7 +18,7 @@ export function showZoomOptionsPopup() {
 }
 
 const ZoomOptionsPopup = () => {
-    const [pv]= useStoreConnector( () => getActivePlotView(visRoot()));
+    const pv= useStoreConnector( () => getActivePlotView(visRoot()));
     useEffect(() => void (!primePlot(pv) && dispatchHideDialog('zoomOptionsDialog')), [pv]);
     return primePlot(pv) ? <ZoomOptionsPopupForm pv={pv}/> : <div/>;
 };

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -240,9 +240,7 @@ Tabs.defaultProps = TabsView.defaultProps;
 export const StatefulTabs = React.memo( (props) => {
     const {children=[], defaultSelected=0, onTabSelect, componentKey} = props;
 
-    let [selectedIdx = defaultSelected] = useStoreConnector( () => {
-        return getComponentState(componentKey)?.selectedIdx;
-    });
+    let selectedIdx = useStoreConnector( () => getComponentState(componentKey)?.selectedIdx ?? defaultSelected);
 
     const onSelect = useCallback( (index,id,name) => {
         dispatchComponentStateChange(componentKey, {selectedIdx: index});

--- a/src/firefly/js/visualize/draw/DrawerComponent.jsx
+++ b/src/firefly/js/visualize/draw/DrawerComponent.jsx
@@ -22,7 +22,7 @@ export const DrawerComponent= memo( (props) => {
 
     const {plot, width, height, idx, drawLayerId, setSimpleUpdateNotify, getDrawLayer }=  props;
     const [drawLayerManual, setDrawLayerManual]= useState(() => undefined);
-    const [drawLayerFromStore]= useStoreConnector((prev)  => findDrawLayerInStore(prev,drawLayerId));
+    const drawLayerFromStore = useStoreConnector((prev)  => findDrawLayerInStore(prev,drawLayerId));
 
     useEffect(() => {
             if (!setSimpleUpdateNotify) return;

--- a/src/firefly/js/visualize/iv/ImageExpandedMode.jsx
+++ b/src/firefly/js/visualize/iv/ImageExpandedMode.jsx
@@ -12,7 +12,8 @@ import {isImageExpanded} from 'firefly/visualize/PlotViewUtil.js';
 
 export const ImageExpandedMode= memo(({closeFunc,insideFlex=true,viewerId, forceExpandedMode=true}) => {
 
-    const [vr,multiViewRoot]= useStoreConnector(visRoot, getMultiViewRoot);
+    const vr            = useStoreConnector(visRoot);
+    const multiViewRoot = useStoreConnector(getMultiViewRoot);
     useEffect(() => {
         forceExpandedMode && !isImageExpanded(vr.expandedMode) && dispatchChangeExpandedMode(true);
         return () => forceExpandedMode && dispatchChangeExpandedMode(ExpandType.COLLAPSE);

--- a/src/firefly/js/visualize/iv/ImageViewer.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewer.jsx
@@ -64,7 +64,7 @@ const TEN_SECONDS= 10000;
 export const ImageViewer= memo( ({showWhenExpanded=false, plotId, inlineTitle, aboveTitle}) => {
 
     const [mousePlotId, setMousePlotId] = useState(lastMouseCtx().plotId);
-    const [{plotView,vr,drawLayersAry,taskCount}] = useStoreConnector( (oldState) => getStoreState(plotId,oldState) );
+    const {plotView,vr,drawLayersAry,taskCount} = useStoreConnector( (oldState) => getStoreState(plotId,oldState) );
     const {current:timeoutRef} = useRef({timeId:undefined});
 
     useEffect(() => {

--- a/src/firefly/js/visualize/ui/ColorDialog.jsx
+++ b/src/firefly/js/visualize/ui/ColorDialog.jsx
@@ -62,7 +62,7 @@ function getStoreUpdate(oldS) {
 }
 
 export const ColorDialog= memo(() => {
-    const [{plot,fields,rFields,gFields,bFields,rgbFields}]= useStoreConnector(getStoreUpdate);
+    const {plot,fields,rFields,gFields,bFields,rgbFields} = useStoreConnector(getStoreUpdate);
     const [huePreserving, setHuePreserving]= useState(plot?.plotState.getRangeValues().rgbPreserveHue);
     if (!plot) return false;
 

--- a/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
@@ -141,10 +141,10 @@ function getContrast(plot) {
 }
 
 const AdvancedColorPanel= ({allowPopout}) => {
-    const [plot]= useStoreConnector( () => {
+    const plot = useStoreConnector( () => {
         return primePlot(visRoot());
     });
-    const [allLoaded] = useStoreConnector(() => isAllStretchDataLoaded(visRoot()));
+    const allLoaded = useStoreConnector(() => isAllStretchDataLoaded(visRoot()));
     const [bias,setBias]= useState( () => getBias(plot));
     const [contrast,setContrast]= useState( () => getContrast(plot));
     const [colorTableId,setColorTableId]= useState( () => Number(plot?.plotState.getColorTableId()));
@@ -335,7 +335,7 @@ export function showColorDialog() {
 
 
 function PopoutColorPanel() {
-    const [pv]= useStoreConnector( () => getActivePlotView(visRoot()));
+    const pv = useStoreConnector( () => getActivePlotView(visRoot()));
     if (!primePlot(pv)) return <div/>;
     return <AdvancedColorPanel allowPopout={false}/>;
 }

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -37,12 +37,10 @@ export function CoverageViewer({viewerId='coverageImages',insideFlex=true, noCov
                                 workingMessage='Working...', noCovStyle={}}) {
 
     startWatcher(viewerId);
-    const [pv,tbl_id,isFetching,covState] = useStoreConnector(
-        () => getActivePlotView(visRoot()),
-        () => getActiveOrFirstTblId(),
-        () => getTblById(getActiveOrFirstTblId())?.isFetching ?? false,
-        () => getComponentState(COVERAGE_WATCH_CID,[]));
-
+    const pv        = useStoreConnector(() => getActivePlotView(visRoot()));
+    const tbl_id    = useStoreConnector(() => getActiveOrFirstTblId());
+    const isFetching= useStoreConnector(() => getTblById(getActiveOrFirstTblId())?.isFetching ?? false);
+    const covState  = useStoreConnector(() => getComponentState(COVERAGE_WATCH_CID,[]));
 
     useEffect(() => {
         dispatchAddViewer(viewerId, NewPlotMode.replace_only, IMAGE, true, renderTreeId, SINGLE);

--- a/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
@@ -63,7 +63,7 @@ function DrawLayerPanel() {
 
 const defaultTitle = 'Layers- ';
 export function DrawLayerPanelTitle({}) {
-    const [plotTitle] = useStoreConnector(() => primePlot(visRoot())?.title );
+    const plotTitle = useStoreConnector(() => primePlot(visRoot())?.title );
     return (plotTitle ? `${defaultTitle}${plotTitle}` : defaultTitle);
 }
 

--- a/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
@@ -195,7 +195,8 @@ function ImageViewOptionsPanel() {
     const tbl_ui_id = TABLE_ID + '-ui';
 
 
-    const [plotViewAry, expandedIds] = useStoreConnector(getPvAry, getExpandedIds);
+    const plotViewAry = useStoreConnector(getPvAry);
+    const expandedIds = useStoreConnector(getExpandedIds);
     const [model, setModel] = useState(undefined);
 
 

--- a/src/firefly/js/visualize/ui/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/ExtractionDialog.jsx
@@ -111,7 +111,7 @@ export function endExtraction() {
 }
 
 function ExtractDialog({extractionType,wasCanceled}) {
-    const [{pv, pvCnt}] = useStoreConnector( getStoreState);
+    const {pv, pvCnt} = useStoreConnector( getStoreState);
     const {canCreateExtractionTable}= getAppOptions().image;
     const {Panel}= exTypeCntl[extractionType];
 

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -83,13 +83,10 @@ let keyCnt=0;
 
 export function FileUploadViewPanel({setSubmitText}) {
 
-    const [{isLoading,statusKey}, isWsUpdating, uploadSrc, {message, analysisResult, report, summaryModel, detailsModel}] =
-        useStoreConnector.bind({comparator: shallowequal}) (
-            () => getComponentState(panelKey, {isLoading:false,statusKey:''}),
-            () => isAccessWorkspace(),
-            () => getFieldVal(panelKey, uploadOptions),
-            (oldState) => getNextState(oldState)
-        );
+    const {isLoading,statusKey} = (() => getComponentState(panelKey, {isLoading:false,statusKey:''}));
+    const isWsUpdating          = (() => isAccessWorkspace());
+    const uploadSrc             = (() => getFieldVal(panelKey, uploadOptions));
+    const {message, analysisResult, report, summaryModel, detailsModel} = ((oldState) => getNextState(oldState));
 
     const [loadingMsg,setLoadingMsg]= useState(() => '');
     const [uploadKey,setUploadKey]= useState(() => FILE_UPLOAD_KEY+keyCnt);
@@ -422,7 +419,7 @@ function getFileCacheKey() {
 
 function TableDisplayOption({isMoc}) {
 
-    const [selectedTables] = useStoreConnector(() => getFileFormat() ? getSelectedRows('Table') : [] );
+    const selectedTables = useStoreConnector(() => getFileFormat() ? getSelectedRows('Table') : [] );
     if ( selectedTables.length < 1) return null;
 
     if (isMoc) {
@@ -456,7 +453,7 @@ function TableDisplayOption({isMoc}) {
 
 function ImageDisplayOption() {
 
-    const [selectedImages] = useStoreConnector(() => getSelectedRows('Image'));
+    const selectedImages = useStoreConnector(() => getSelectedRows('Image'));
     if ( selectedImages.length < 2) return null;
 
     const imgOptions = [{value: 'oneWindow', label: 'All images in one window'},

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -121,7 +121,7 @@ function ImageSearchPanel({resizable=true, onSubmit, gridSupport = false, multiS
     const dim = {height: 600, width: 725, minHeight: 600, minWidth: 725};
     const style = resizable ? {...dim, ...resize} : {width: '100%'};
 
-    const [imageType]= useStoreConnector(() => getFieldVal(FG_KEYS.main, FD_KEYS.type));
+    const imageType = useStoreConnector(() => getFieldVal(FG_KEYS.main, FD_KEYS.type));
 
     return (
         <div style={style}>
@@ -219,7 +219,7 @@ function ImageSearchPanelV2 ({archiveName='Search', title='Image Search', multiS
             });
     }, []);
 
-    const [imageType]= useStoreConnector(() => getFieldVal(FG_KEYS.main, FD_KEYS.type));
+    const imageType = useStoreConnector(() => getFieldVal(FG_KEYS.main, FD_KEYS.type));
     const {isThreeColorImgType, isHipsImgType, isSingleChannelImgType} = isImageType(imageType);
 
     multiSelect = !isThreeColorImgType && multiSelect;
@@ -327,11 +327,11 @@ function ImageType({}) {
 
 function ImageSource({groupKey, imageMasterData, multiSelect, archiveName='Archive', noScroll}) {
 
-    const [imageType]= useStoreConnector(() => getFieldVal(FG_KEYS.main, FD_KEYS.type));
+    const imageType = useStoreConnector(() => getFieldVal(FG_KEYS.main, FD_KEYS.type));
     const {isThreeColorImgType, isHipsImgType} = isImageType(imageType);
 
     const defaultValue = isThreeColorImgType ? 'none' : 'archive';
-    const [imageSource] = useStoreConnector(() => getFieldVal(groupKey, FD_KEYS.source, defaultValue));
+    const imageSource  = useStoreConnector(() => getFieldVal(groupKey, FD_KEYS.source, defaultValue));
 
 
     const options = [   {label: archiveName, value: 'archive'},

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -61,14 +61,11 @@ const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId, 
     const {renderTreeId} = useContext(RenderTreeIdCtx);
     const [currentCTIChoice, setCurrentCTIChoice] = useState(undefined);
     const [lookupKey, setLookKey] = useState(undefined);
-    const [dataProductsState, serviceParamsAry]= useStoreConnector(
-        (old) => {
+    const dataProductsState = useStoreConnector((old) => {
             const newDp= getDataProducts(dataProductRoot(),dpId)||{};
             return (!old || (newDp!==old && newDp.displayType && newDp.displayType!==DPtypes.DOWNLOAD)) ? newDp : old;
-        },
-        () => getServiceParamsAry(dataProductRoot(),dpId)
-    );
-
+        });
+    const serviceParamsAry = useStoreConnector(() => getServiceParamsAry(dataProductRoot(),dpId));
 
     const {imageViewerId,chartViewerId,tableGroupViewerId}=  getActivateParams(dataProductRoot(),dpId);
 

--- a/src/firefly/js/visualize/ui/PngViewer.jsx
+++ b/src/firefly/js/visualize/ui/PngViewer.jsx
@@ -3,10 +3,9 @@ import {useStoreConnector} from '../../ui/SimpleComponent';
 import {getActiveTableId, getCellValue, getMetaEntry, getTblById} from '../../tables/TableUtil';
 
 export const PngViewer = memo(()=> {
-    const [tbl_id, highlightedRow] = useStoreConnector(
-        () => getActiveTableId(),
-        () => getTblById(getActiveTableId()) ?. highlightedRow ?? -1
-    );
+    const tbl_id         = useStoreConnector(() => getActiveTableId());
+    const highlightedRow = useStoreConnector(() => getTblById(getActiveTableId())?.highlightedRow ?? -1);
+
     const tableModel = getTblById(tbl_id);
     const [badUrl, setBadUrl] = useState(undefined);
 

--- a/src/firefly/js/visualize/ui/StretchDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/StretchDropDownView.jsx
@@ -112,7 +112,7 @@ const contrastMarks = { 0: '0', 5:'.5', 10:'1', 15:'1.5',  20:'2' };
 
 
 export function StretchDropDownView({toolbarElement}) {
-    const [pv] = useStoreConnector(() => getActivePlotView(visRoot()));
+    const pv = useStoreConnector(() => getActivePlotView(visRoot()));
     const enabled= pv ? true : false;
     const plot= primePlot(pv);
     const rv= plot.plotState.getRangeValues();

--- a/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
@@ -123,7 +123,7 @@ function getStoreState(oldState) {
 }
 
 export const VisMiniToolbar = memo( ({style, manageExpand=true, expandGrid=false}) => {
-    const [{visRoot,dlCount, recentTargetAry, modalEndInfo}] = useStoreConnector(getStoreState);
+    const {visRoot,dlCount, recentTargetAry, modalEndInfo} = useStoreConnector(getStoreState);
     const setModalEndInfo= (info) => dispatchComponentStateChange('ModalEndInfo',  {...emptyModalEndInfo, ...info});
 
     return (


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-976
more changes here: https://github.com/IPAC-SW/irsa-ife/pull/208

After TablePanel was converted to a functional component([FIREFLY-930](https://jira.ipac.caltech.edu/browse/FIREFLY-930)), it failed to pickup new changes when tbl_ui_id changes.  This was reported by Mike Lund.

@robyww , there a few shortcomings in the popular `useStoreConnector` function I would like to change.
1. The interface allow for multiple state getters but is rarely used.  This introduces unnecessary complexity in the code.
2. It uses `Object.is` by default when comparing `old state` vs `new state`.  But, in most cases, we want `shallowequal`.
3. No way to update the getter function once its dependencies changes.

The new `useStoreState` is what I would like to replace it with.  But, I don't want to introduce a new function.  I would like to update the old function and fix any necessary code that uses it.  There will be many of changes(file touched), and regression testing is needed.  How do you think?  

Test: https://fireflydev.ipac.caltech.edu/firefly-976-tablepanel-rerender/firefly/