### PR TITLE
Firefly 978 big table performance

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -12,7 +12,6 @@ work.directory = ""
 stats.log.dir = '${sys:catalina.base}/logs/statistics'
 alerts.dir = ""
 
-debug.mode = false
 ignore.auth=true
 
 /*  keep vis.shared.mem.size small if pct is used */

--- a/config/common.prop
+++ b/config/common.prop
@@ -14,9 +14,6 @@ DbAdapter.type = hsql
 # default to System.getProperty("java.io.tmpdir") + "/workarea"
 work.directory=@work.directory@
 
-# set this to false to disable debug related code, like logging, etc.
-debug.mode=@debug.mode@
-
 # Allow JMX to monitor ehcache's status.
 # Enabling this feature may incur a small performance hit.
 ehcache.jmx.monitor=true

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -204,7 +204,6 @@ public class ServerContext {
         Logger.info("",
                 "CACHE_PROVIDER : " + EhcacheProvider.class.getName(),
                 "WORK_DIR       : " + getWorkingDir(),
-                "DEBUG_MODE     : " + AppProperties.getBooleanProperty("debug.mode", false),
                 "Available Cores: " + getAvailableCores() );
 
          if (!getWorkingDir().equals(getSharedWorkingDir())) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
@@ -19,7 +19,7 @@ public class HsqlDbAdapter extends BaseDbAdapter{
     private static final String[] DB_FILES = new String[]{".properties",".script",".log",".data",".lck",".backup"};
 
     protected EmbeddedDbInstance createDbInstance(File dbFile) {
-        String dbUrl = String.format("jdbc:hsqldb:file:%s;hsqldb.log_size=1024;sql.syntax_ora=true;sql.ignore_case=true;sql.double_nan=false", dbFile.getPath());
+        String dbUrl = String.format("jdbc:hsqldb:file:%s;hsqldb.log_data=false;sql.syntax_ora=true;sql.ignore_case=true;sql.double_nan=false", dbFile.getPath());
         EmbeddedDbInstance dbInst = new EmbeddedDbInstance(getName(), dbFile, dbUrl, "org.hsqldb.jdbc.JDBCDriver");
         dbInst.consumeProps(String.format("%s=%s", DbInstance.USE_REAL_AS_DOUBLE, true));
         return dbInst;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/Logger.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/Logger.java
@@ -12,6 +12,8 @@ import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.ThrowableUtil;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
@@ -96,9 +98,9 @@ public class Logger {
 
     /**
      * Programmatically send all logs to System.out, but have it turned off.
-     * Anywhere in your code, use setProgLog() to control what get printed to console.
+     * Anywhere in your code, use setLogLevel() to control what get printed to console.
      */
-    public static void initProgLog() {
+    private static void initConsoleLog() {
         try {
             ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
             builder.add(builder.newAppender("console", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT));
@@ -116,7 +118,16 @@ public class Logger {
         }
     }
 
-    public static void setProLog(Level level, String logger) {
+    public static void setLogLevel(Level level) {
+        setLogLevel(level, null);
+    }
+
+    public static void setLogLevel(Level level, String logger) {
+        Appender console = ((LoggerContext) LogManager.getContext(false)).getConfiguration().getAppender("console");
+        if (console == null) {
+            initConsoleLog();
+        }
+
         logger = StringUtils.isEmpty(logger) ? "" : logger;
         if (logger.length() == 0) {
             Configurator.setRootLevel(level);
@@ -127,7 +138,8 @@ public class Logger {
                     level == Level.WARN ? java.util.logging.Level.WARNING :
                     level == Level.INFO ? java.util.logging.Level.INFO :
                     level == Level.DEBUG ? java.util.logging.Level.FINE :
-                    java.util.logging.Level.FINER;
+                    level == Level.TRACE ? java.util.logging.Level.FINER :
+                                java.util.logging.Level.OFF;
         java.util.logging.Logger.getLogger(logger).setLevel(jl);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/StopWatch.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/StopWatch.java
@@ -29,14 +29,13 @@ public class StopWatch {
         }
     };
 
-    private static boolean DEBUG_MODE = AppProperties.getBooleanProperty("debug.mode", false);
     private static ThreadLocal<StopWatch> stopWatch = new ThreadLocal<StopWatch>(){
                         protected StopWatch initialValue() {
                             return new StopWatch();
                         }
                     };
     private Map<String, Tracker> logs = new HashMap<String, Tracker>();
-    private Logger.LoggerImpl logger = Logger.getLogger("StopWatch");
+    private Logger.LoggerImpl logger = Logger.getLogger();
 
     private StopWatch() {
     }
@@ -54,7 +53,6 @@ public class StopWatch {
      * @return
      */
     public StopWatch enable() {
-        DEBUG_MODE = true;
         return this;
     }
 
@@ -64,8 +62,6 @@ public class StopWatch {
     }
 
     public StopWatch start(String desc) {
-        if (!DEBUG_MODE) return this;        // if not running in debug mode, ignore StopWatch logging
-
         Tracker l = getTracker(desc);
         if (l == null) {
             l = new Tracker(desc, logger);
@@ -88,8 +84,6 @@ public class StopWatch {
     }
 
     public StopWatch printLog(String desc, Unit unit) {
-
-        if (!DEBUG_MODE) return this;        // if not running in debug mode, ignore StopWatch logging
 
         if (getTracker(desc) != null) {
             getTracker(desc).printLog(unit);
@@ -152,9 +146,9 @@ public class StopWatch {
         public void printLog(Unit unit) {
             if (isRunning) stops();
             if (numStops == 1) {
-                logger.info(String.format("%s ran with elapsed time of %.4f %s", desc, getElapsedTime(unit),  unit.name()));
+                logger.debug(String.format("%s ran with elapsed time of %.4f %s", desc, getElapsedTime(unit),  unit.name()));
             } else {
-                logger.info(String.format("%s ran %d times.", desc, numStops),
+                logger.debug(String.format("%s ran %d times.", desc, numStops),
                              String.format("Elapsed Time: %.4f %s.", getElapsedTime(unit), unit.name()),
                              String.format("Total time is %.4f %s", getTotalTime(unit), unit.name()),
                              String.format("Avg time is %.4f %s.", getAvgTime(unit), unit.name()));

--- a/src/firefly/java/edu/caltech/ipac/firefly/tools/FitsHeaderTool.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/tools/FitsHeaderTool.java
@@ -20,7 +20,7 @@ import java.net.URL;
  */
 public class FitsHeaderTool {
 
-    private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
+    private static final Logger.LoggerImpl LOGGER = Logger.getLogger("FitsHeaderTool");
     private static File tempFile;
 
     public static void main(String[] args) throws FitsException, IOException {
@@ -28,7 +28,7 @@ public class FitsHeaderTool {
         if (args.length != 1) {
             usage();
         }
-        Logger.setProLog(Level.INFO, null);
+        Logger.setLogLevel(Level.INFO, "FitsHeaderTool");  // show only logs from this class
         //String url ="https://irsa.ipac.caltech.edu/data/SOFIA/FIFI-LS/OC5I/20170726_F422/proc/p4647/data/g11/F0422_FI_IFS_70050813_RED_RP0_100696.fits";
         try {
             URL uri = new URL(args[0]);

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -28,6 +28,7 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
     private List<ResourceInfo> resources = new ArrayList<>();  // for <RESOURCE> in VOTABLE
     private transient DataType[] cachedColumnsAry = null;
     private transient int highlightedRow = -1;
+    private int initCapacity = 1000;
 
     public DataGroup() {}
 
@@ -39,6 +40,8 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
         this.title = title;
         dataDefs.forEach(this::addDataDefinition);
     }
+
+    public void setInitCapacity(int initCap) { this.initCapacity = initCap; }
 
     public String getTitle() {
         return title;
@@ -480,21 +483,21 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
             DataType dt = getDataDefintion(cname);
             if (dt != null) {
                 if (dt.getArraySize() != null) {
-                    dataList =  new PrimitiveList.Objects();
+                    dataList =  new PrimitiveList.Objects(initCapacity);
                 } else {
                     Class clz = dt.getDataType();
                     if (clz == Double.class) {
-                        dataList = new PrimitiveList.Doubles();
+                        dataList = new PrimitiveList.Doubles(initCapacity);
                     } else if (clz == Float.class) {
-                        dataList = new PrimitiveList.Floats();
+                        dataList = new PrimitiveList.Floats(initCapacity);
                     } else if (clz == Long.class) {
-                        dataList = new PrimitiveList.Longs();
+                        dataList = new PrimitiveList.Longs(initCapacity);
                     } else if (clz == Integer.class) {
-                        dataList = new PrimitiveList.Integers();
+                        dataList = new PrimitiveList.Integers(initCapacity);
                     } else if (clz == Boolean.class) {
-                        dataList = new PrimitiveList.Booleans();
+                        dataList = new PrimitiveList.Booleans(initCapacity);
                     } else {
-                        dataList = new PrimitiveList.Objects();
+                        dataList = new PrimitiveList.Objects(initCapacity);
                     }
                 }
                 data.put(cname, dataList);

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -140,6 +140,21 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
     }
 
     /**
+     * Add a full row of data based on the columns index.
+     * @param row   the array of data based on the columns index.
+     */
+    public void add(Object[] row) {
+        if (row != null) {
+            if (data.size() == 0) size = 0;                    // reset size if there's no data
+            DataType[] cols = getDataDefinitions();
+            for (int i = 0; i < cols.length; i++) {
+                addData(cols[i].getKeyName(), row[i]);
+            }
+            size++;
+        }
+    }
+
+    /**
      * @param key   if null, meta will be treated as a comment
      * @param value meta value
      */

--- a/src/firefly/java/edu/caltech/ipac/table/DataObject.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataObject.java
@@ -71,6 +71,21 @@ public class DataObject implements Serializable, Cloneable {
         }
     }
 
+    /**
+     * Set the data for this DataObject(row)
+     * @param data the full row of data in the same order as its columns
+     */
+    public void setData(Object[] data) {
+        DataType[] cols = group.getDataDefinitions();
+        for(int i = 0; i < cols.length; i++) {
+            if (rowData != null) {
+                rowData.put(cols[i].getKeyName(), data[i]);
+            } else {
+                group.setData(cols[i].getKeyName(), rowNum, data[i]);
+            }
+        }
+    }
+
     public String getFixedFormatedData(DataType dt) {
         return dt.formatFixedWidth(getDataElement(dt));      // this is used by ipac table only
     }

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableDef.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableDef.java
@@ -19,14 +19,14 @@ public class IpacTableDef extends TableMeta {
     private int rowCount;
     private int rowStartOffset;
     private transient KeyVal<Integer, String> extras;     // used by IpacTableUtil to store extras data while parsing an ipac table via input stream
-    private transient TableUtil.ColCheckInfo colCheckInfos = new TableUtil.ColCheckInfo();      // used by IpacTableUtil to store check logic on a variety of things.
+    private transient TableUtil.ParsedInfo parsedInfo = new TableUtil.ParsedInfo();      // used by IpacTableUtil to store check logic on a variety of things.
 
     public KeyVal<Integer, String> getExtras() {
         return extras;
     }
 
-    public TableUtil.ColCheckInfo getColCheckInfos() {
-        return colCheckInfos;
+    public TableUtil.ParsedColInfo getParsedInfo(String cname) {
+        return parsedInfo.getInfo(cname);
     }
 
     public int getColOffset(int idx) {

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -6,7 +6,6 @@ package edu.caltech.ipac.table;
 import edu.caltech.ipac.util.CollectionUtil;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
-import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 
 import java.io.BufferedReader;
@@ -267,13 +266,16 @@ public class IpacTableUtil {
         if (line != null && line.startsWith("|")) {
             String[] names = parseHeadings(line.trim());
             int cursor = 1;
-            String cname;
+            String cname; String cval;
             for (int idx = 0; idx < names.length; idx++) {
-                cname = names[idx];
-                DataType dt = new DataType(cname.trim(), null);
+                cval = names[idx];
+                cname = cval.trim();
+                DataType dt = new DataType(cname, null);
                 cols.add(dt);
-                tableDef.setColOffsets(idx, cursor);
-                cursor += cname.length() + 1;
+                TableUtil.ParsedColInfo pci = tableDef.getParsedInfo(cname);
+                pci.startIdx = cursor;
+                pci.endIdx = cursor + cval.length();
+                cursor = pci.endIdx + 1;
             }
         }
         tableDef.setCols(cols);
@@ -322,13 +324,13 @@ public class IpacTableUtil {
         }
     }
 
-    public static void applyGuessLogic(DataType type, String val, TableUtil.CheckInfo chkInfo) {
+    public static void applyGuessLogic(DataType type, String val, TableUtil.ParsedColInfo pci) {
 
-        if (!chkInfo.formatChecked) {
-            chkInfo.formatChecked = guessFormatInfo(type, val);
+        if (!pci.formatChecked) {
+            pci.formatChecked = guessFormatInfo(type, val);
         }
 
-        if (!chkInfo.htmlChecked) {
+        if (!pci.htmlChecked) {
             // disable sorting if value is HTML, or unit is 'html'
             // this block should only be executed once, when formatInfo is not set.
             if (type.getDataType() == String.class ) {
@@ -338,7 +340,7 @@ public class IpacTableUtil {
                     type.setFilterable(false);
                 }
             }
-            chkInfo.htmlChecked = true;
+            pci.htmlChecked = true;
         }
     }
 
@@ -400,7 +402,7 @@ public class IpacTableUtil {
     public static DataObject parseRow(DataGroup source, String line, IpacTableDef tableDef) {
         if (line==null) return null;
         DataType[] headers = source.getDataDefinitions();
-        int offset=0, endOfLine=0, endoffset=0;
+        int endOfLine=0, endoffset=0;
         try {
             if (line.startsWith(" ") && line.trim().length() > 0) {
                 DataObject row = new DataObject(source);
@@ -409,40 +411,28 @@ public class IpacTableUtil {
                 DataType dt;
                 for (int idx = 0; idx < headers.length; idx++) {
                     dt = headers[idx];
-                    offset = tableDef.getColOffset(idx);
-                    if (offset > endOfLine) {
+                    TableUtil.ParsedColInfo pci = tableDef.getParsedInfo(dt.getKeyName());
+                    if (pci.startIdx > endOfLine) {
                         // it's okay.  we'll take what's given and treat the rest as null.
                         break;
                     }
-                    endoffset = idx < headers.length-1 ? tableDef.getColOffset(idx+1) : endOfLine;
-
                     // if ending spaces are missing... just ignore it.
-                    if (endoffset > endOfLine) {
-                        endoffset = endOfLine;
-                    }
+                    endoffset = Math.min(pci.endIdx, endOfLine);
 
-                    String val = line.substring(offset, endoffset).trim();
+                    String val = line.substring(pci.startIdx, endoffset).trim();
                     if (!dt.isKnownType()) {
                         IpacTableUtil.guessDataType(dt, val);
                     }
-
-                    TableUtil.CheckInfo checkInfo = tableDef.getColCheckInfos().getCheckInfo(dt.getKeyName());
-                    if (!String.valueOf(tableDef.getAttribute("fixlen")).trim().equals("T")) {
-                        checkInfo.formatChecked = true;     // if fixlen != T, don't guess format
-                    }
-                    applyGuessLogic(dt, val, checkInfo);
+                    applyGuessLogic(dt, val, pci);
 
                     row.setDataElement(dt, dt.convertStringToData(val));
-
-                    offset = endoffset;
                 }
                 return row;
             } else if (line.trim().length() > 0 && !line.startsWith("\\") && !line.startsWith("|")) {
                 throw new RuntimeException("Data row must start with a space.");
             }
         } catch (StringIndexOutOfBoundsException e) {
-            throw new StringIndexOutOfBoundsException("offset="+offset+",endoffset="+endoffset+
-                    ",line.length()="+line.length()+",line="+line);
+            throw new StringIndexOutOfBoundsException("line.length()="+line.length()+",line="+line);
         }
         return null;
     }
@@ -468,6 +458,13 @@ public class IpacTableUtil {
         } finally {
             FileUtil.silentClose(reader);
         }
+    }
+    public static IpacTableDef getMetaInfo(File inf, Map<String, String> metaInfo) throws IOException {
+        IpacTableDef tableDef = getMetaInfo(inf);
+        if (metaInfo != null) {
+            metaInfo.entrySet().forEach((e -> tableDef.setAttribute(e.getKey(), e.getValue())));
+        }
+        return tableDef;
     }
 
     public static IpacTableDef getMetaInfo(BufferedReader reader) throws IOException {

--- a/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
+++ b/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
@@ -44,7 +44,7 @@ public interface PrimitiveList {
      */
     default int newCapacity(int minCapacity, int oldCapacity) {
         // overflow-conscious code
-        int newCapacity = oldCapacity + (oldCapacity >> 1);
+        int newCapacity = oldCapacity + Math.min(oldCapacity >> 1, 100000);     // setting a newCapacity size limit to ensure HUGE table do not require unnecessary amount of memory to load.
         if (newCapacity - minCapacity < 0)
             newCapacity = minCapacity;
         return newCapacity;
@@ -52,7 +52,13 @@ public interface PrimitiveList {
     }
 
     public static class Objects implements PrimitiveList {
-        private ArrayList<Object> data = new ArrayList<>(100);
+        private ArrayList<Object> data;
+
+        public Objects() { this(1000); }
+
+        public Objects(int initCapacity) {
+            this.data = new ArrayList<>(initCapacity);
+        }
 
         public Class getDataClass() {
             return Object.class;
@@ -83,6 +89,12 @@ public interface PrimitiveList {
         private double[] data;
         private int size;
 
+        public Doubles() { this(1000); }
+
+        public Doubles(int initCapacity) {
+            data  = new double[initCapacity];
+        }
+
         public Class getDataClass() {
             return Double.class;
         }
@@ -112,9 +124,6 @@ public interface PrimitiveList {
          * @param minCapacity
          */
         private void ensureCapacity(int minCapacity) {
-            if (data == null) {
-                data  = new double[100];
-            }
             if (minCapacity >= data.length) {
                 data = Arrays.copyOf(data, newCapacity(minCapacity, data.length));
             }
@@ -130,6 +139,12 @@ public interface PrimitiveList {
     public static class Floats implements PrimitiveList {
         private float[] data;
         private int size;
+
+        public Floats() { this(1000); }
+
+        public Floats(int initCapacity) {
+            data  = new float[initCapacity];
+        }
 
         public Class getDataClass() {
             return Float.class;
@@ -156,9 +171,6 @@ public interface PrimitiveList {
         }
 
         private void ensureCapacity(int minCapacity) {
-            if (data == null) {
-                data = new float[100];
-            }
             if (minCapacity >= data.length) {
                 data = Arrays.copyOf(data, newCapacity(minCapacity, data.length));
             }
@@ -174,6 +186,12 @@ public interface PrimitiveList {
     public static class Longs implements PrimitiveList {
         private long[] data;
         private int size;
+
+        public Longs() { this(1000); }
+
+        public Longs(int initCapacity) {
+            data  = new long[initCapacity];
+        }
 
         public Class getDataClass() {
             return Long.class;
@@ -200,9 +218,6 @@ public interface PrimitiveList {
         }
 
         private void ensureCapacity(int minCapacity) {
-            if (data == null) {
-                data = new long[100];
-            }
             if (minCapacity >= data.length) {
                 data = Arrays.copyOf(data, newCapacity(minCapacity,data.length));
             }
@@ -218,6 +233,12 @@ public interface PrimitiveList {
     public static class Integers implements PrimitiveList {
         private int[] data = null;
         private int size;
+
+        public Integers() { this(1000); }
+
+        public Integers(int initCapacity) {
+            data  = new int[initCapacity];
+        }
 
         public Class getDataClass() {
             return Integer.class;
@@ -244,9 +265,6 @@ public interface PrimitiveList {
         }
 
         private void ensureCapacity(int minCapacity) {
-            if (data == null) {
-                data = new int[100];
-            }
             if (minCapacity >= data.length) {
                 data = Arrays.copyOf(data, newCapacity(minCapacity, data.length));
             }
@@ -262,6 +280,13 @@ public interface PrimitiveList {
     public static class Booleans implements PrimitiveList {
         private boolean[] data = null;
         private int size;
+
+        public Booleans() { this(1000); }
+
+        public Booleans(int initCapacity) {
+            data  = new boolean[initCapacity];
+        }
+
 
         public Class getDataClass() {
             return Boolean.class;
@@ -288,9 +313,6 @@ public interface PrimitiveList {
         }
 
         private void ensureCapacity(int minCapacity) {
-            if (data == null) {
-                data = new boolean[100];
-            }
             if (minCapacity >= data.length) {
                 data = Arrays.copyOf(data, newCapacity(minCapacity, data.length));
             }

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -180,11 +180,14 @@ public class TableUtil {
         RandomAccessFile reader = new RandomAccessFile(inf, "r");
         long skip = ((long)start * (long)tableDef.getLineWidth()) + (long)tableDef.getRowStartOffset();
         int count = 0;
+        TableUtil.ParsedColInfo[] parsedColInfos = Arrays.stream(dg.getDataDefinitions())
+                                                        .map(dt -> tableDef.getParsedInfo(dt.getKeyName()))
+                                                        .toArray(TableUtil.ParsedColInfo[]::new);
         try {
             reader.seek(skip);
             String line = reader.readLine();
             while (line != null && count < rows) {
-                DataObject row = IpacTableUtil.parseRow(dg, line, tableDef);
+                Object[] row = IpacTableUtil.parseRow(line, dg.getDataDefinitions(), parsedColInfos);
                 if (row != null) {
                     dg.add(row);
                     count++;

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -330,22 +330,25 @@ public class TableUtil {
 
     public static Map<String, Format> getAllFormats() { return allFormats; }
 
-    public static class ColCheckInfo {
-        HashMap<String, CheckInfo> colCheckInfos = new HashMap<>();  // keyed by column name
+    public static class ParsedInfo {
+        HashMap<String, ParsedColInfo> parsedInfo = new HashMap<>();  // keyed by column name
 
-        public CheckInfo getCheckInfo(String cname) {
-            CheckInfo checkInfo = colCheckInfos.get(cname);
+        public ParsedColInfo getInfo(String cname) {
+            ParsedColInfo checkInfo = parsedInfo.get(cname);
             if (checkInfo == null) {
-                checkInfo = new CheckInfo();
-                colCheckInfos.put(cname, checkInfo);
+                checkInfo = new ParsedColInfo();
+                parsedInfo.put(cname, checkInfo);
             }
             return checkInfo;
         }
     }
 
-    public static class CheckInfo {
+    public static class ParsedColInfo {
         public boolean formatChecked;              // indicates guess format logic has been performed
         public boolean htmlChecked;                // indicates html content check has been performed
+        public int startIdx;
+        public int endIdx;
+
     }
 }
 

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -58,7 +58,7 @@ public class DsvTableIO {
             CSVRecord cols = records.get(0);
             List<DataType> columns = convertToDataType(cols);
             DataGroup dg = new DataGroup(null, columns);
-            TableUtil.ColCheckInfo colCheckInfo = new TableUtil.ColCheckInfo();
+            TableUtil.ParsedInfo colCheckInfo = new TableUtil.ParsedInfo();
 
             // parse the data
             for (int i = 1; i < records.size(); i++) {
@@ -122,7 +122,7 @@ public class DsvTableIO {
         return columns;
     }
 
-    static DataObject parseRow(DataGroup source, CSVRecord line, TableUtil.ColCheckInfo colCheckInfo) {
+    static DataObject parseRow(DataGroup source, CSVRecord line, TableUtil.ParsedInfo colCheckInfo) {
 
         DataType[] headers = source.getDataDefinitions();
         if (line != null && line.size() > 0) {
@@ -136,7 +136,7 @@ public class DsvTableIO {
                     }
                     row.setDataElement(type, type.convertStringToData(val));
 
-                    TableUtil.CheckInfo checkInfo = colCheckInfo.getCheckInfo(type.getKeyName());
+                    TableUtil.ParsedColInfo checkInfo = colCheckInfo.getInfo(type.getKeyName());
                     IpacTableUtil.applyGuessLogic(type, val, checkInfo);
                 }
             return row;

--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
@@ -457,6 +457,7 @@ public final class FITSTableReader
                 if (colUnits!=null && colUnits.length>1) idxDT.setUnits(colUnits[1]);
                 dataTypes.add(dataDT);
                 DataGroup dataGroup = new DataGroup(desc, dataTypes);
+                dataGroup.setInitCapacity(data.length);
                 for (int i = 0; (i < data.length); i++) {
                     DataObject aRow = new DataObject(dataGroup);
                     aRow.setDataElement(idxDT, i);
@@ -486,6 +487,7 @@ public final class FITSTableReader
                 }
 
                 DataGroup dataGroup = new DataGroup(desc, dataTypes);
+                dataGroup.setInitCapacity(data[0].length);
 
                 DataType[] dd;
                 for (int row = 0; row < data[0].length; row++) {
@@ -580,6 +582,7 @@ public final class FITSTableReader
 
         // creating DataGroup rows.
         DataGroup dataGroup = new DataGroup(table.getName(), dataTypes);
+        dataGroup.setInitCapacity((int)table.getRowCount());
         for (long row = 0; row < table.getRowCount(); row++){
             addRowToDataGroup(table, dataGroup, colIdxMap, row, strategy);
         }

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -240,6 +240,7 @@ public class VoTableReader {
 
         DataGroup dg = getTableHeader(tableEl);
         List<DataType> cols = Arrays.asList(dg.getDataDefinitions());
+        dg.setInitCapacity((int)table.getRowCount());
 
         // post-process to handle custom logic
         DataType raCol = cols.stream().filter(dt -> HMS_UCD_PATTERN.matcher(String.valueOf(dt.getUCD())).matches())

--- a/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
@@ -55,6 +55,7 @@ public class CacheManager {
     }
 
     public static boolean setCacheProvider(String cacheProviderClassName) {
+        if (isDisabled) return true;
         setCacheProvider(newInstanceOf(cacheProviderClassName));
         return cacheProvider != null;
     }

--- a/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
@@ -5,12 +5,14 @@ import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.ws.WsCredentials;
 import edu.caltech.ipac.util.AppProperties;
+import org.apache.logging.log4j.Level;
 import org.junit.BeforeClass;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -37,10 +39,9 @@ public class ConfigTest {
     @BeforeClass
     public static void initializeTest() {
 
-        Logger.initProgLog();
-        // uncomment line below to test
-        //Logger.setProLog(Level.DEBUG, null);
-        Logger.getLogger("test").debug("!!!!!!!!!!TEST log works");
+        Logger.setLogLevel(Level.OFF);
+        // Turn off logging initially.
+        // use Logger.setLogLevel() anywhere else to adjust logging level.
 
         try {
             loadProperties();
@@ -48,7 +49,6 @@ public class ConfigTest {
             System.err.println(TEST_PROP_FILE + " not found");
         }
     }
-
 
     /**
      * Load properties from test config file app-test.config to overwrite the app.config (OPS)
@@ -101,21 +101,22 @@ public class ConfigTest {
         }
     }
 
-    protected static void setupServerContext(RequestAgent requestAgent) {
+    public static void setupServerContext(RequestAgent requestAgent) {
         String contextPath = System.getenv("contextPath");
         String contextName = System.getenv("contextName");
         String webappConfigPath = System.getenv("webappConfigPath");
 
+        AppProperties.setProperty("CacheManager.disabled", "true");
+        AppProperties.setProperty("work.directory", Paths.get("build").toAbsolutePath().toString());
+
         contextPath = contextPath == null ? "/firefly" : contextPath;
         contextName = contextName == null ? "firefly" : contextName;
-        webappConfigPath = webappConfigPath == null ? "build/firefly/war/WEB-INF/config" : webappConfigPath;
+        webappConfigPath = webappConfigPath == null ? Paths.get("config/test/").toAbsolutePath().toString() : webappConfigPath;
 
-        requestAgent = requestAgent == null ? new RequestAgent(null, "HTTP", "/", "localhost:8080/", "unknow", UUID.randomUUID().toString(), contextPath): null;
+        requestAgent = requestAgent == null ? new RequestAgent(null, "localhost", "/test", "localhost:8080/", "127.0. 0.1", UUID.randomUUID().toString(), contextPath): requestAgent;
 
-        System.setProperty("stats.log.dir", System.getProperty("java.io.tmpdir"));
         ServerContext.getRequestOwner().setRequestAgent(requestAgent);
         ServerContext.init(contextPath, contextName, webappConfigPath);
-
     }
 
 }

--- a/src/firefly/test/edu/caltech/ipac/firefly/TestUtil.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/TestUtil.java
@@ -32,6 +32,7 @@ public class TestUtil {
     public static void logMemUsage(Supplier<String> run) {
         ManagementFactory.getMemoryMXBean().gc();
         long before = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        LOG.trace(String.format("Memory before=%6.2fMB", before/1024.0/1024.0));
 
         long start = System.currentTimeMillis();
         String desc = run.get();
@@ -39,8 +40,9 @@ public class TestUtil {
         long peak = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() - before;
 
         ManagementFactory.getMemoryMXBean().gc();
-        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() - before;
-        LOG.info(String.format("%s:  Memory Usage peak=%6.2fMB  final:%6.2fMB  elapsed:%4.2fsecs", desc, peak/1024.0/1024.0, after/1024.0/1024.0, elapsed/1000.0));
+        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+        LOG.trace(String.format("Memory after=%6.2fMB",  after/1024.0/1024.0));
+        LOG.info(String.format("%s:  Memory Usage peak=%6.2fMB  final:%6.2fMB  elapsed:%4.2fsecs", desc, peak/1024.0/1024.0, (after-before)/1024.0/1024.0, elapsed/1000.0));
     }
 
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/TestUtil.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/TestUtil.java
@@ -1,0 +1,86 @@
+package edu.caltech.ipac.firefly;
+
+import edu.caltech.ipac.firefly.server.RequestAgent;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.ws.WsCredentials;
+import edu.caltech.ipac.util.AppProperties;
+import org.junit.BeforeClass;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryUsage;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class TestUtil {
+
+    private static final String TEST_DATA_ROOT = "firefly_test_data/";
+    private static final Logger.LoggerImpl LOG = Logger.getLogger("test");
+
+
+    /**
+     * Log the memory usage of this run.
+     * @param run the function to run
+     */
+    public static void logMemUsage(Supplier<String> run) {
+        ManagementFactory.getMemoryMXBean().gc();
+        long before = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+
+        long start = System.currentTimeMillis();
+        String desc = run.get();
+        long elapsed = System.currentTimeMillis() - start;
+        long peak = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() - before;
+
+        ManagementFactory.getMemoryMXBean().gc();
+        long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() - before;
+        LOG.info(String.format("%s:  Memory Usage peak=%6.2fMB  final:%6.2fMB  elapsed:%4.2fsecs", desc, peak/1024.0/1024.0, after/1024.0/1024.0, elapsed/1000.0));
+    }
+
+
+    /**
+     * @return the root directory of firefly test data
+     */
+    public static File getDataFile() {
+        Path root = Paths.get("").toAbsolutePath().getParent().resolve(TEST_DATA_ROOT);
+        return root.toFile();
+    }
+
+    /**
+     * @param cls the class used to resolve the data directory
+     * @return the test data directory for the given class.  This directory is parallel to the class's package relative to firefly test data
+     * i.e  edu.caltech.ipac.firefly.core.FileAnalysisTest -> edu/caltech/ipac/firefly/core/
+     */
+    public static File getDataFile(Class cls) {
+        File root = getDataFile();
+        if (cls == null) return root;
+        String relPath = cls.getPackageName().replaceAll("\\.", "/");
+
+        return new File(root, relPath);
+    }
+
+    /**
+     * @param cls the class used to resolve the data directory
+     * @param path a relative path or file name
+     * @return the file or directory for the given cls and path
+     */
+    public static File getDataFile(Class cls, String path) {
+        return new File(getDataFile(cls), path);
+    }
+
+    /**
+     * @param path
+     * @return a File represented by the given path relative to firefly test data root
+     */
+    public static File getDataFile(String path) {
+        return new File(getDataFile(), path);
+    }
+
+
+}

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/FileAnalysisTest.java
@@ -9,6 +9,7 @@ import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.firefly.util.FileLoader;
 import edu.caltech.ipac.table.DataGroup;
+import org.apache.logging.log4j.Level;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -244,7 +245,8 @@ public class FileAnalysisTest extends ConfigTest {
     @Test
     public void perfTest() throws Exception {
 
-        StopWatch.getInstance().start("perfTestMidSize").enable().setLogger(Logger.getLogger("console"));
+        Logger.setLogLevel(Level.TRACE, "edu.caltech");     // exclude numerous nom.tam warnings
+        StopWatch.getInstance().start("perfTestMidSize");
         for(int i=0; i < 10; i++) {
             StopWatch.getInstance().start("voTable");
             FileAnalysis.analyze(voTable, FileAnalysisReport.ReportType.Details);

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
@@ -171,52 +171,67 @@ public class DataGroupReadTest {
     public void memTest() {
         Logger.setLogLevel(Level.DEBUG);
         int testSize = 10000000;
+        final Ref<Object> ref = new Ref<>();        // prevent gc from collecting
 
-        List<Object> olist = new ArrayList<>(100);
         logMemUsage(() -> {
+            List<Object> olist = new ArrayList<>();
+            ref.setSource(olist);
             for (int i=0; i< testSize; i++) olist.add(i + Math.random());
             return String.format("List<Object>(%,d)", testSize);
         });
+        ref.setSource(null);        // allow gc to collect
 
-        PrimitiveList.Objects objects = new PrimitiveList.Objects();
         logMemUsage(() -> {
+            PrimitiveList.Objects objects = new PrimitiveList.Objects();
+            ref.setSource(objects);
             for (int i=0; i< testSize; i++) objects.add(i + Math.random());
             return String.format("Object[](%,d)    ", testSize);
         });
+        ref.setSource(null);
 
-        List<Double> dlist = new ArrayList<>(100);
         logMemUsage(() -> {
+            List<Double> dlist = new ArrayList<>();
+            ref.setSource(dlist);
             for (int i=0; i< testSize; i++) dlist.add(i + Math.random());
             return String.format("List<Double>(%,d)", testSize);
         });
+        ref.setSource(null);
 
-        PrimitiveList.Doubles doubleAry = new PrimitiveList.Doubles();
         logMemUsage(() -> {
+            PrimitiveList.Doubles doubleAry = new PrimitiveList.Doubles();
+            ref.setSource(doubleAry);
             for (int i=0; i< testSize; i++) doubleAry.add(i * Math.random());
             return String.format("double[](%,d)    ", testSize);
         });
+        ref.setSource(null);
 
-        PrimitiveList.Integers intAry = new PrimitiveList.Integers();
         logMemUsage(() -> {
+            PrimitiveList.Integers intAry = new PrimitiveList.Integers();
+            ref.setSource(intAry);
             for (int i=0; i< testSize; i++) intAry.add((int) (i * Math.random()));
             return String.format("int[](%,d)       ", testSize);
         });
+        ref.setSource(null);
 
-        String[] strAry = new String[testSize];
         logMemUsage(() -> {
+            String[] strAry = new String[testSize];
+            ref.setSource(strAry);
             for (int i=0; i< testSize; i++) {
                 strAry[i] = String.valueOf(i%10);
             }
             return String.format("strAry[](%,d)    ", testSize);
         });
+        ref.setSource(null);
 
-        List<String> strList = new ArrayList<>();
         logMemUsage(() -> {
+            List<String> strList = new ArrayList<>();
+            ref.setSource(strList);
             for (int i=0; i< testSize; i++) {
                 strList.add(String.valueOf(i%10));
             }
             return String.format("strList[](%,d)   ", testSize);
         });
+        ref.setSource(null);
     }
 
     private static DataGroup readTest(File inFile) throws IOException {

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
@@ -4,14 +4,24 @@
 package edu.caltech.ipac.firefly.server.util.tables;
 
 import edu.caltech.ipac.TestCategory;
-import edu.caltech.ipac.firefly.util.FileLoader;
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.db.DbAdapter;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.query.SearchManager;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.util.Ref;
 import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataGroupPart;
 import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.PrimitiveList;
 import edu.caltech.ipac.table.io.FITSTableReader;
 import edu.caltech.ipac.table.io.IpacTableReader;
 import edu.caltech.ipac.table.io.IpacTableWriter;
 import edu.caltech.ipac.table.io.VoTableReader;
 import nom.tam.fits.FitsException;
+import org.apache.logging.log4j.Level;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -23,6 +33,10 @@ import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static edu.caltech.ipac.firefly.TestUtil.getDataFile;
+import static edu.caltech.ipac.firefly.TestUtil.logMemUsage;
 
 /**
  * @author loi
@@ -30,11 +44,11 @@ import java.util.List;
  */
 public class DataGroupReadTest {
 
-    private static final File largeIpacTable = new File("/hydra/cm/firefly_test_data/large-ipac-tables/wise-950000.tbl");
-    private static final File midIpacTable = FileLoader.resolveFile(DataGroupReadTest.class, "50k.tbl");
-    private static final File ipacTable = FileLoader.resolveFile(DataGroupReadTest.class, "DataGroupTest.tbl");
-    private static final File voTable = FileLoader.resolveFile(DataGroupReadTest.class, "p3am_cdd.xml");
-    private static final File fitsTable = FileLoader.resolveFile(DataGroupReadTest.class, "lsst-table.fits");
+    private static final File largeIpacTable = getDataFile("large-ipac-tables/wise-950000.tbl");
+    private static final File midIpacTable = getDataFile(DataGroupReadTest.class, "50k.tbl");
+    private static final File ipacTable = getDataFile(DataGroupReadTest.class, "DataGroupTest.tbl");
+    private static final File voTable = getDataFile(DataGroupReadTest.class, "p3am_cdd.xml");
+    private static final File fitsTable =getDataFile(DataGroupReadTest.class, "lsst-table.fits");
 
     @Test
     public void ipacTable() throws IOException {
@@ -114,158 +128,122 @@ public class DataGroupReadTest {
 
     @Category({TestCategory.Perf.class})
     @Test
+    public void perfTestEmbeddedDB() throws DataAccessException {
+        /*
+            3/23/2022: git branch: research_big_table_performance
+            Originally:
+                - largeIpacTable is a 360mb file, requiring 550mb of RAM in memory
+                - to ingest to DB, 3 copies is needed: DataGroup, PrepareStatement, DB tables in memory
+                - Minimum memory needed to load this table is 1.7gb (550*3)
+            Changes:
+                - Turn off DB logging, IO time is cut in half.  From 6s to 3s.
+                - Instead of loading the full table in one batch commit, separate the table into multiple smaller batches(set to 10000)
+                  A PrepareStatement of 10000 rows take less memory than having the 3rd copy.
+                - After the changes, it requires 1.4gb to load this table instead of the 1.7gb.
+         */
+        ConfigTest.setupServerContext(null);
+        Logger.setLogLevel(Level.TRACE);
+
+        TableServerRequest tsr = new TableServerRequest("IpacTableFromSource");
+        tsr.setParam(ServerParams.SOURCE, "file://" + largeIpacTable.getPath());
+        tsr.setPageSize(100);
+        DataGroupPart dgp = (DataGroupPart) SearchManager.getProcessor(tsr.getRequestId()).getData(tsr);
+        System.out.println("total rows: " + dgp.getRowCount());
+        DbAdapter.getAdapter().cleanup(true);
+    }
+
+    @Category({TestCategory.Perf.class})
+    @Test
     public void perfTestMidSize() throws IOException {
+        Logger.setLogLevel(Level.DEBUG);
         tableIoTest(midIpacTable);
     }
 
     @Category({TestCategory.Perf.class})
     @Test
     public void perfTestLargeSize() throws IOException {
+        Logger.setLogLevel(Level.DEBUG);
         tableIoTest(largeIpacTable);
     }
 
     @Category({TestCategory.Perf.class})
     @Test
-    public void memTest() throws IOException {
-        Runtime.getRuntime().gc();
-        long beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        long start = System.currentTimeMillis();
-        int testSize = 5000000;
+    public void memTest() {
+        Logger.setLogLevel(Level.DEBUG);
+        int testSize = 10000000;
 
-        List<Object> objects = new ArrayList<>(100);
-        for (int i=0; i< testSize; i++) {
-            objects.add(i + Math.random());
-        }
+        List<Object> olist = new ArrayList<>(100);
+        logMemUsage(() -> {
+            for (int i=0; i< testSize; i++) olist.add(i + Math.random());
+            return String.format("List<Object>(%,d)", testSize);
+        });
 
-        long elapsed = System.currentTimeMillis() - start;
-        long usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        long usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("List<Object>(%,d):  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs %n", testSize, usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0);
+        PrimitiveList.Objects objects = new PrimitiveList.Objects();
+        logMemUsage(() -> {
+            for (int i=0; i< testSize; i++) objects.add(i + Math.random());
+            return String.format("Object[](%,d)    ", testSize);
+        });
 
-        //-------------------
+        List<Double> dlist = new ArrayList<>(100);
+        logMemUsage(() -> {
+            for (int i=0; i< testSize; i++) dlist.add(i + Math.random());
+            return String.format("List<Double>(%,d)", testSize);
+        });
 
-        beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        start = System.currentTimeMillis();
-        Object[] objectAry = new Object[testSize];
-        for (int i=0; i< testSize; i++) {
-            objectAry[i] = i + Math.random();
-        }
+        PrimitiveList.Doubles doubleAry = new PrimitiveList.Doubles();
+        logMemUsage(() -> {
+            for (int i=0; i< testSize; i++) doubleAry.add(i * Math.random());
+            return String.format("double[](%,d)    ", testSize);
+        });
 
-        elapsed = System.currentTimeMillis() - start;
-        usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("Object[](%,d)    :  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs  total:%.2fsecs %n", testSize, usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0, (System.currentTimeMillis()-start)/1000.0);
+        PrimitiveList.Integers intAry = new PrimitiveList.Integers();
+        logMemUsage(() -> {
+            for (int i=0; i< testSize; i++) intAry.add((int) (i * Math.random()));
+            return String.format("int[](%,d)       ", testSize);
+        });
 
-        //-------------------
-
-        beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        start = System.currentTimeMillis();
-        List<Double> doubles = new ArrayList<>(100);
-        for (int i=0; i< testSize; i++) {
-            doubles.add(i + Math.random());
-        }
-
-        elapsed = System.currentTimeMillis() - start;
-        usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("List<Double>(%,d):  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs %n", testSize, usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0);
-
-        //-------------------
-
-        beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        start = System.currentTimeMillis();
-        double[] doubleAry = new double[testSize];
-        for (int i=0; i< testSize; i++) {
-            doubleAry[i] = i + Math.random();
-        }
-
-        elapsed = System.currentTimeMillis() - start;
-        usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("double[](%,d)    :  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs  total:%.2fsecs %n", testSize, usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0, (System.currentTimeMillis()-start)/1000.0);
-
-
-        //-------------------
-
-        beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        start = System.currentTimeMillis();
-        int[] intAry = new int[testSize];
-        for (int i=0; i< testSize; i++) {
-            intAry[i] = (int) (i + Math.random());
-        }
-
-        elapsed = System.currentTimeMillis() - start;
-        usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("int[](%,d)       :  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs  total:%.2fsecs %n", testSize, usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0, (System.currentTimeMillis()-start)/1000.0);
-
-        //-------------------
-
-        beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        start = System.currentTimeMillis();
         String[] strAry = new String[testSize];
-        for (int i=0; i< testSize; i++) {
-            strAry[i] = String.valueOf(i%10);
-        }
+        logMemUsage(() -> {
+            for (int i=0; i< testSize; i++) {
+                strAry[i] = String.valueOf(i%10);
+            }
+            return String.format("strAry[](%,d)    ", testSize);
+        });
 
-        elapsed = System.currentTimeMillis() - start;
-        usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("strAry[](%,d)      :  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs  total:%.2fsecs %n", testSize, usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0, (System.currentTimeMillis()-start)/1000.0);
-
-        //-------------------
-
-        beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        start = System.currentTimeMillis();
         List<String> strList = new ArrayList<>();
-        for (int i=0; i< testSize; i++) {
-            strList.add(String.valueOf(i%10));
-        }
+        logMemUsage(() -> {
+            for (int i=0; i< testSize; i++) {
+                strList.add(String.valueOf(i%10));
+            }
+            return String.format("strList[](%,d)   ", testSize);
+        });
+    }
 
-        elapsed = System.currentTimeMillis() - start;
-        usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("strList[](%,d)       :  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs  total:%.2fsecs %n", testSize, usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0, (System.currentTimeMillis()-start)/1000.0);
+    private static DataGroup readTest(File inFile) throws IOException {
+        Ref<DataGroup> data = new Ref<>();
+        logMemUsage(() -> {
+            try {
+                data.setSource(IpacTableReader.read(inFile));
+                return String.format("READ(%,d)", data.getSource().size());
+            } catch (IOException e) {return "ERROR:" + e.getMessage();}
+        });
+        return data.getSource();
+    }
 
-        //-------------------
-
-        Object v = objects.get(0);
-        v = objectAry[0];
-        v = doubles.get(0);
-        v = doubleAry[0];
-        v = intAry[0];
-        v = strAry[0];
-        v = strList.get(0);
-
+    private static void writeTest(DataGroup data) throws IOException {
+        logMemUsage(() -> {
+            try {
+                File outf = new File("./tmp.tbl");
+                outf.deleteOnExit();
+                IpacTableWriter.save(outf, data);
+                return String.format("WRITE(%,d)", data.size());
+            } catch (IOException e) {return "ERROR:" + e.getMessage();}
+        });
     }
 
     private static void tableIoTest(File inFile) throws IOException {
-        Runtime.getRuntime().gc();
-        long beginMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        long start = System.currentTimeMillis();
-
-        DataGroup data = IpacTableReader.read(inFile);
-        long elapsed = System.currentTimeMillis() - start;
-        long usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        Runtime.getRuntime().gc();
-        long usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - beginMem;
-        System.out.printf("READ(%,d):  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs %n", data.size(), usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0);
-
-        File outf = new File("./tmp.tbl");
-        outf.deleteOnExit();
-        IpacTableWriter.save(outf, data);
-        usedB4Gc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - usedAfGc;
-        Runtime.getRuntime().gc();
-        usedAfGc = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() - usedAfGc;
-        elapsed = System.currentTimeMillis() - start - elapsed;
-        System.out.printf("WRITE(%,d):  Memory temp=%.2fMB  final:%.2fMB  elapsed:%.2fsecs  total:%.2fsecs %n", data.size(), usedB4Gc/1000/1000.0, usedAfGc/1000/1000.0, elapsed/1000.0, (System.currentTimeMillis()-start)/1000.0);
+        DataGroup data = readTest(inFile);
+        writeTest(data);
 
         System.out.println("");
         List<MemoryPoolMXBean> pools = ManagementFactory.getMemoryPoolMXBeans();

--- a/src/firefly/test/edu/caltech/ipac/table/VoTableReaderTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/VoTableReaderTest.java
@@ -10,6 +10,7 @@ import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.firefly.util.FileLoader;
 import edu.caltech.ipac.table.io.VoTableReader;
+import org.apache.logging.log4j.Level;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,7 +42,8 @@ public class VoTableReaderTest extends ConfigTest {
         // before code refactor
         // [main] INFO  console  - getheader ran 10 times., Elapsed Time: 0.3430 SECONDS., Total time is 4.2630 SECONDS, Avg time is 0.4263 SECONDS.
 
-        StopWatch.getInstance().start("perfTestMidSize").enable().setLogger(Logger.getLogger("console"));
+        Logger.setLogLevel(Level.DEBUG, "edu.caltech");     // exclude starlink warning logs
+        StopWatch.getInstance().start("perfTestMidSize");
         for(int i=0; i < 10; i++) {
             StopWatch.getInstance().start("getheader");
             VoTableReader.analyze(midFile, FileAnalysisReport.ReportType.Details);
@@ -56,7 +58,8 @@ public class VoTableReaderTest extends ConfigTest {
         // before code refactor
         // [main] INFO  console  - getheader ran 10 times., Elapsed Time: 0.6150 SECONDS., Total time is 6.6650 SECONDS, Avg time is 0.6665 SECONDS
 
-        StopWatch.getInstance().start("perfTestLargeSize").enable().setLogger(Logger.getLogger("console"));
+        Logger.setLogLevel(Level.DEBUG, "edu.caltech");
+        StopWatch.getInstance().start("perfTestLargeSize");
         for(int i=0; i < 10; i++) {
             StopWatch.getInstance().start("getheader");
             VoTableReader.analyze(largeFile, FileAnalysisReport.ReportType.Details);


### PR DESCRIPTION
ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-978
test: https://fireflydev.ipac.caltech.edu/firefly-978-big-table-performance/firefly/

Improve reading IPAC table
- Replace the use of DataGroup and DataObject with indexed values when reading IPAC table to DataGroup
- Greatly reduces read time for large table. (~30%)
- The sample file used to take over 7s now takes around 4.5s to read.

Improve loading IPAC table info DB
- turn off DB logging.  reduce DB ingestion time from 6s to 3s

Lower memory requirement
A sample 1 million rows WISE catalog is around 360mb file; requiring 550mb of RAM in memory.
To ingest the table into the DB requires 3 copies in memory; DataGroup, PrepareStatement, and the DB tables in memory.
  - Instead of loading the full table in one batch commit, separate the table into multiple smaller batches(set to 10000)
  - A PrepareStatement of 10k rows take less memory than having the 3rd copy
  - This slightly decreases loading performance, but uses less memory.
   
Also:
- expand Test functionalities
  - added util functions
  - enhance logging capability
- remove and clean unused flag ‘debug.mode’
