### PR TITLE
IRSA-4562: finderchart API broken

### DIFF
--- a/docker/launchTomcat.sh
+++ b/docker/launchTomcat.sh
@@ -110,6 +110,8 @@ export CATALINA_OPTS="\
 # Firefly apps requires these module to be opened
 CATALINA_OPTS="$CATALINA_OPTS \
     --add-opens java.base/java.util=ALL-UNNAMED \
+    --add-opens java.base/java.text=ALL-UNNAMED \
+    --add-opens java.desktop/java.awt.font=ALL-UNNAMED \
     "
 
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-4562
See Tim's comment.  It's not related to original ticket.

Fixed by adding additional `--add-opens` startup parameters.

test: https://irsa-4562-finderchart-api-broken.irsakudev.ipac.caltech.edu/applications/finderchart/servlet/api?locstr=146.22351+22.88512&subsetsize=1.0&reproject=true