### PR TITLE
FIREFLY-756: A string filter bug

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -44,9 +44,10 @@ public class JobManager {
 
     private static final int KEEP_ALIVE_INTERVAL = AppProperties.getIntProperty("job.keepalive.interval", 30);    // default keepalive interval in seconds
     private static final int WAIT_COMPLETE = AppProperties.getIntProperty("job.wait.complete", 1);                // wait for complete after submit in seconds
+    private static final int MAX_PACKAGERS = AppProperties.getIntProperty("job.max.packagers", 10);               // maximum number of simultaneous packaging threads
 
     private static Logger.LoggerImpl LOG = Logger.getLogger();
-    private static ExecutorService packagers = Executors.newFixedThreadPool(10);
+    private static ExecutorService packagers = Executors.newFixedThreadPool(MAX_PACKAGERS);
     private static ExecutorService searches = Executors.newCachedThreadPool();
     private static HashMap<String, JobEntry> runningJobs = new HashMap<>();
     private static HashMap<String, JobInfo> allJobInfos = new HashMap<>();

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -266,6 +266,8 @@ public class VoTableReader {
                         if ((val instanceof Double && Double.isNaN((Double) val)) ||
                                 (val instanceof Float && Float.isNaN((Float) val))    )    {
                             val = null;
+                        } else if(val instanceof String) {
+                            val = ((String) val).trim();
                         }
                         row.setDataElement(dtype, val);
                     }

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -63,7 +63,7 @@ export function useStoreConnector(stateGetter, deps=[]) {
         let cState = val;
         const remover = flux.addListener(() => {
             if (isMounted) {
-                const nState = stateGetter(val);      // if getter returns oldState then no state update
+                const nState = stateGetter(cState);      // if getter returns oldState then no state update
                 if (nState===cState) return;             // comparator might be overridden, use === first for efficiency
                 if ( !comparator(cState, nState) ) {
                     cState = nState;


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-756
Test: https://fireflydev.ipac.caltech.edu/firefly-756-string-filter/firefly/

To test, follow the steps provided in the ticket.  
**Note**:  After the fix, the 'first two' values referred in the ticket are no longer first two.  After trimming, they fall under their natural order.

StarTable return string values without trimming.  Trim before saving.
Also:
- add property for JobManager max packaging queue
- small fix to useStoreConnector
