### PR TITLE
FIREFLY-971: showFilters defaults to true for all tables except client tables

### DIFF
--- a/docs/firefly-api-overview.md
+++ b/docs/firefly-api-overview.md
@@ -501,7 +501,7 @@ options -  table options, object with the following properties:
 | tbl_group | string | the group this table belongs to, defaults to 'main' |
 | removable  | boolean | true if this table can be removed from view, defaults to true |
 | showUnits  | boolean | defaults to true if table contains unit info |
-| showFilters | boolean | defaults to false |
+| showFilters | boolean | defaults to true for all tables except client tables |
 | selectable | boolean | defaults to true |
 | expandable | boolean | defaults to true |
 | showToolbar | boolean | defaults to true |

--- a/src/firefly/html/demo/table-api.html
+++ b/src/firefly/html/demo/table-api.html
@@ -209,7 +209,7 @@ There are additional information specific to each input field.  Click the top bu
 @prop {boolean} [border=true]
 @prop {boolean} [showUnits]
 @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.
-@prop {boolean} [showFilters=false]
+@prop {boolean} [showFilters]     defaults to true for all tables except client tables
 @prop {boolean} [showToolbar=true]
 @prop {boolean} [showTitle=true]
 @prop {boolean} [showToggleTextView=true]

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -147,7 +147,7 @@ function buildTablePart(llApi) {
      * @prop {boolean} backgroundable    true if this search can be sent to background.  Defaults to false.
      * @prop {boolean} showUnits    defaults to true if table contains unit info
      * @prop {boolean} showTypes    defaults to false
-     * @prop {boolean} showFilters  defaults to false
+     * @prop {boolean} showFilters  defaults to true for all tables except client tables
      * @prop {boolean} selectable   defaults to true
      * @prop {boolean} expandable   defaults to true
      * @prop {boolean} showToolbar  defaults to true

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -265,7 +265,7 @@
  * @prop {boolean} [removable=true]  true if this table can be removed from view.
  * @prop {boolean} [border=true]
  * @prop {boolean} [showToolbar=true]   when false, showFilters, showTitle, showPaging, showSave, and showFilterButton will be false as well.
- * @prop {boolean} [showFilters=false]
+ * @prop {boolean} [showFilters]        defaults to true for all tables except client tables
  * @prop {boolean} [showTitle=true]
  * @prop {boolean} [showToggleTextView=true]
  * @prop {boolean} [showPaging=true]    enable/disable paging feature.  When false, all data will be displayed.

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -251,7 +251,6 @@ TablePanel.propTypes = {
 TablePanel.defaultProps = {
     showMetaInfo: false,
     allowUnits: true,
-    showFilters: false,
     showToolbar: true,
     showTitle: true,
     showPaging: true,

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -112,7 +112,7 @@ function OptionsFilterStats({tbl_id}) {
 }
 
 function Options({uiState, tbl_id, tbl_ui_id, ctm_tbl_id, onOptionReset, onChange}) {
-    const {pageSize, showPaging=true, showUnits, allowUnits=true,showTypes=true, showFilters=false} = uiState || {};
+    const {pageSize, showPaging=true, showUnits, allowUnits=true,showTypes=true, showFilters} = uiState || {};
 
     const onPageSize = (pageSize) => {
         if (pageSize.valid) {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-971

Turn on the showFilters by default for all tables except for client table.  Ticket updated to reflect this change.

Test: 
https://fireflydev.ipac.caltech.edu/firefly-971-catalog-filter-on/firefly/
