### PR TITLE
FIREFLY-982: Add the capability to a create persistent resource from a table request

### DIFF
--- a/src/firefly/html/test/tests-table.html
+++ b/src/firefly/html/test/tests-table.html
@@ -355,39 +355,34 @@ added in this test.  Open console, then
     <script>
         function onFireflyLoaded(firefly) {
 
-            const {makeFileRequest, makeResourceRequest} = firefly.util.table;
+            const {makeFileRequest, makeResourceRequest, createResource, deleteResource} = firefly.util.table;
 
-            // define 3 resources
-            const gReq = makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl');
-            const global = {request: gReq};     // default to global
+            // simplest use case.  create a public resource then query it.
+            const simplest = {request: makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl')};
+            // createResource(simplest);        // this is optional because a default global scope resource will be created if one does not exists.
+            const simplestTbl = makeResourceRequest(simplest, 'Simplest');
+            firefly.showTable('actual', simplestTbl);
 
-            const uReq = makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl', null, {dummy:'user'});    // insert dummy param to make the request different from global
-            const user = {request: uReq, scope: 'user'};
-
-            const pReq = makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl', null, {dummy:'protected'});
-            const secured = {request: pReq, scope: 'protected', secret: 'mysecret'};
-
-            // create the resources
-            // makeResourceRequest({resource: global, action: 'create'});   // by default, a Resource is created with 'global' scope if one does not exists.  This line is not needed, but is nice for clarity.
-            makeResourceRequest({resource: user, action: 'create'});
-            makeResourceRequest({resource: secured, action: 'create'});
-
-
-
-            const globalTbl =   makeResourceRequest({resource: global, title: 'Global Resource'});
-            const userTbl =     makeResourceRequest({resource: user, title: 'User Resource'});
-            const protectedTbl = makeResourceRequest({resource: secured, title: 'Protected Resource'});
-            const noAccess =    makeResourceRequest({resource: {...secured, secret:''}, title: 'No Access'});        // this should fail.  access protected resource without secret token
-
-            firefly.showTable('actual', globalTbl);
+            // create a 'user' resource
+            const user = {scope: 'user', request: makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/fp_2mass.fp_psc29179.tbl')};
+            createResource(user);
+            const userTbl = makeResourceRequest(user, 'User Resource');
             firefly.showTable('actual', userTbl);
-            firefly.showTable('actual', protectedTbl);
-            firefly.showTable('actual', noAccess);
+
+            // create a 'protected' resource with secret token
+            const secured = {scope: 'protected', secret: 'mysecret', request: makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/wise-orbit-allsky.tbl')};
+            createResource(secured);
+            const securedTbl = makeResourceRequest(secured, 'Protected Resource');
+            firefly.showTable('actual', securedTbl);
+
+            // Accessing 'protected' resource without secret token
+            const accessDeniedTbl = makeResourceRequest({...secured, secret: 'wrong secret'}, 'Access Denied');
+            firefly.showTable('actual', accessDeniedTbl);
 
             firefly.deleteResourceTests = function () {
-                makeResourceRequest({resource: global, action: 'delete'});
-                makeResourceRequest({resource: user, action: 'delete'});
-                makeResourceRequest({resource: secured, action: 'delete'});
+                deleteResource(global);
+                deleteResource(user);
+                deleteResource(secured);
             }
         }
     </script>

--- a/src/firefly/html/test/tests-table.html
+++ b/src/firefly/html/test/tests-table.html
@@ -331,6 +331,67 @@
     </script>
 </template>
 
+<template title="Table as a Resource" class="tpl">
+    <div id="expected">
+        <div style="margin: 10px">
+<pre>
+A resource can be created with different scope:
+  global:   anyone can access it
+  user:     user who create it can access
+  protected: anyone with secret token can access
+
+Once this test is loaded, 'User Resource'
+will fail to load in incognito mode
+because it's consider a different user.
+
+For this test, deleteResourceTests function is
+added to firefly.  Run it to remove the resources
+added in this test.  Open console, then
+    firefly.deleteResourceTests()
+</pre>
+        </div>
+    </div>
+    <div id="actual"  class="box x3"/>
+    <script>
+        function onFireflyLoaded(firefly) {
+
+            const {makeFileRequest, makeResourceRequest} = firefly.util.table;
+
+            // define 3 resources
+            const gReq = makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl');
+            const global = {request: gReq};     // default to global
+
+            const uReq = makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl', null, {dummy:'user'});    // insert dummy param to make the request different from global
+            const user = {request: uReq, scope: 'user'};
+
+            const pReq = makeFileRequest(null, 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl', null, {dummy:'protected'});
+            const secured = {request: pReq, scope: 'protected', secret: 'mysecret'};
+
+            // create the resources
+            // makeResourceRequest({resource: global, action: 'create'});   // by default, a Resource is created with 'global' scope if one does not exists.  This line is not needed, but is nice for clarity.
+            makeResourceRequest({resource: user, action: 'create'});
+            makeResourceRequest({resource: secured, action: 'create'});
+
+
+
+            const globalTbl =   makeResourceRequest({resource: global, title: 'Global Resource'});
+            const userTbl =     makeResourceRequest({resource: user, title: 'User Resource'});
+            const protectedTbl = makeResourceRequest({resource: secured, title: 'Protected Resource'});
+            const noAccess =    makeResourceRequest({resource: {...secured, secret:''}, title: 'No Access'});        // this should fail.  access protected resource without secret token
+
+            firefly.showTable('actual', globalTbl);
+            firefly.showTable('actual', userTbl);
+            firefly.showTable('actual', protectedTbl);
+            firefly.showTable('actual', noAccess);
+
+            firefly.deleteResourceTests = function () {
+                makeResourceRequest({resource: global, action: 'delete'});
+                makeResourceRequest({resource: user, action: 'delete'});
+                makeResourceRequest({resource: secured, action: 'delete'});
+            }
+        }
+    </script>
+</template>
 
 
 <!-- this is where test cases will be attached-->

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerRequest.java
@@ -96,6 +96,11 @@ public class ServerRequest implements Serializable, Cloneable {
         return p == null ? null : p.getValue();
     }
 
+    public String getParam(String param, String def) {
+        String val = getParam(param);
+        return val == null ? def : val;
+    }
+
     public List<Param> getParams() {
         return new ArrayList<Param>(params.values());
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -96,6 +96,14 @@ public class RequestOwner implements Cloneable {
         return wsManager;
     }
 
+    /**
+     * Normally, this is not used, unless for testing or similar cases where you need to change the default behavior.
+     * @param userKey a user key string
+     */
+    public void setUserKey(String userKey) {
+        this.userKey = userKey;
+    }
+
     public String getUserKey() {
         if (userKey == null) {
             userKey = requestAgent == null ? null : requestAgent.getCookieVal(USER_KEY);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -305,6 +305,10 @@ abstract public class BaseDbAdapter implements DbAdapter {
     }
 
     public void cleanup(boolean force) {
+        cleanup(force, false);
+    }
+
+    public void cleanup(boolean force, boolean deleteFile) {
 
         try {
             long MAX_MEMORY_ROWS = DbAdapter.maxMemRows();
@@ -314,7 +318,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
                     .filter((db) -> db.hasExpired() || force).collect(Collectors.toList());
             if (toBeRemove.size() > 0) {
                 LOGGER.info(String.format("There are currently %d databases open.  Of which, %d will be closed.", dbInstances.size(), toBeRemove.size()));
-                toBeRemove.forEach((db) -> close(db.getDbFile(), false));
+                toBeRemove.forEach((db) -> close(db.getDbFile(), deleteFile));
             }
             // remove search results based on LRU when count is greater than the high-water mark
             long totalRows = dbInstances.values().stream().mapToInt((db) -> db.getRowCount()).sum();
@@ -325,7 +329,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
                 for(EmbeddedDbInstance db : active) {
                     cRows += db.getRowCount();
                     if (cRows > highWaterMark) {
-                        close(db.getDbFile(), false);
+                        close(db.getDbFile(), deleteFile);
                     }
                 }
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -53,6 +53,7 @@ public class EmbeddedDbUtil {
      */
     public static void createDbFile(File dbFile, DbAdapter dbAdapter) throws IOException {
         dbAdapter.close(dbFile, true);              // in case database exists in memory, close it and remove all files related to it.
+        if (!dbFile.getParentFile().exists()) dbFile.getParentFile().mkdirs();
         dbFile.createNewFile();                     // creates the file
         createCustomFunctions(dbFile, dbAdapter);   // add custom functions
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
@@ -1,0 +1,176 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.Param;
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.DbAdapter;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataGroupPart;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.util.StringUtils;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Properties;
+import java.util.SortedSet;
+
+import static edu.caltech.ipac.firefly.server.query.ResourceProcessor.PROC_ID;
+import static edu.caltech.ipac.util.FileUtil.writeStringToFile;
+
+
+/**
+ * Resources are persistent data taken from a unique Table Request.  Uniqueness is based on getUniqueID.
+ * Once a resource is created, it will remain unchanged until deleted.
+ * firefly.util.table.makeResourceRequest is created to help work with resources.
+ * See "Table as a Resource" in tests-table.html for sample usage.
+ *
+ * Resource comes with basic security features.  This info is saved as a .acl file next to the database files.
+ * scope: This controls the visibility of a resource.  It can be 'global', 'user', or 'protected'.
+ *      global is public.  Anyone can access it.  If this resource is created with a secret, then that secret is needed to delete it.
+ *      user is visible to only the user who created it.  User is based on a 'usrkey' cookie set on the browser.
+ *      protected resource is one created with a secret token.  It can only be accessed using the same secret token.
+ *
+ * Any resource created without scope is considered global.
+ */
+@SearchProcessorImpl(id = PROC_ID, params =
+        {   @ParamDoc(name = "action",          desc = "required.  one of 'create', 'query', 'delete'"),
+            @ParamDoc(name = "searchRequest",   desc = "required.  the table request to create this resource from"),
+            @ParamDoc(name = "scope",           desc = "visibility of this resource.  one of 'global', 'user', 'protected'.  defaults to 'global'"),
+            @ParamDoc(name = "secret",          desc = "secret token used to access 'protected' resources"),
+        })
+public class ResourceProcessor extends EmbeddedDbProcessor {
+    public static final String PROC_ID = "ResourceProcessor";
+
+    private static final String ACTION = "action";
+    private static final String SCOPE = "scope";
+    private static final String SECRET = "secret";
+
+    private static final String CREATE = "create";
+    private static final String QUERY = "query";
+    private static final String DELETE = "delete";
+
+    private static final String GLOBAL = "global";
+    private static final String USER = "user";
+    private static final String PROTECTED = "protected";
+
+
+    /**
+     * One database per resource with basic access information.
+     * Access info is saved in a file with a .acl extension.
+     */
+    public File getDbFile(TableServerRequest treq) {
+        DbAdapter dbAdapter = DbAdapter.getAdapter(treq);
+        String resourceID = getResourceID(treq);
+        String fname = String.format("resources/%s.%s", resourceID, dbAdapter.getName());
+        return new File(ServerContext.getHiPSDir(), fname);
+    }
+
+    /**
+     * return a string
+     * @param request
+     * @return
+     */
+    public String getUniqueID(ServerRequest request) {
+        try {
+            TableServerRequest sreq = QueryUtil.getSearchRequest((TableServerRequest) request);
+            SortedSet<Param> params = sreq.getSearchParams();
+            return StringUtils.toString(params, "|");
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    protected FileInfo ingestDataIntoDb(TableServerRequest req, File dbFile) throws DataAccessException {
+        writeStringToFile(getAclFile(dbFile), String.format("scope=%s\nsecret=%s\nuser=%s\n",
+                req.getParam(SCOPE, GLOBAL),
+                req.getParam(SECRET, ""),
+                ServerContext.getRequestOwner().getUserKey()));
+
+        return super.ingestDataIntoDb(req, dbFile);
+    }
+
+    public DataGroup fetchDataGroup(TableServerRequest treq) throws DataAccessException {
+        try {
+            TableServerRequest sreq = QueryUtil.getSearchRequest(treq);
+            SearchProcessor processor = SearchManager.getProcessor(sreq.getRequestId());
+            if (processor != null && processor instanceof CanFetchDataGroup) {
+                return ((CanFetchDataGroup)processor).fetchDataGroup(sreq);
+            } else throw new IllegalArgumentException("SearchProcessor not found for the given request: " + getUniqueID(treq));
+        } catch (Exception e) {
+            throw new DataAccessException(e.getMessage(), e);
+        }
+    }
+
+    protected DataGroupPart getResultSet(TableServerRequest treq, File dbFile) throws DataAccessException {
+        if (!hasAccess(treq, dbFile)) throw new DataAccessException("Access denied");
+        String action = treq.getParam(ACTION, QUERY);
+        if (action.equals(DELETE)) {
+            DbAdapter.getAdapter(treq).close(dbFile, true);
+            getAclFile(dbFile).delete();
+            return new DataGroupPart(new DataGroup("empty set", new DataType[]{new DataType("dummy", String.class)}), 0, 0);
+        }
+
+        if (action.equals(CREATE)) treq.setPageSize(0);            // when creating... just load database.  don't return any data.
+        return super.getResultSet(treq, dbFile);
+    }
+
+    public boolean doLogging() {
+        return false;
+    }
+
+//====================================================================
+//
+//====================================================================
+
+    private File getAclFile (File dbFile) {
+        String acl = dbFile.getAbsolutePath().replaceFirst("\\.\\S+$", ".acl");
+        return new File(acl);
+    }
+
+    private boolean hasAccess(TableServerRequest treq, File dbFile) {
+        File aclFile = getAclFile(dbFile);
+        if (aclFile.exists()) {
+            Properties acl = new Properties();
+            try {
+                BufferedInputStream bif = new BufferedInputStream(new FileInputStream(aclFile));
+                acl.load(bif);
+            } catch (Exception e) {}    // ignore.  assume empty file
+            String scope = acl.getProperty(SCOPE,GLOBAL);
+            String secret = acl.getProperty(SECRET, "");
+            String user = acl.getProperty(USER, "");
+            String action = treq.getParam(ACTION, QUERY);
+            if (action.equals(DELETE) && !StringUtils.isEmpty(secret)) {
+                return treq.getParam(SECRET, "").equals(secret);      // to delete a resource with password, you need a password regardless of scope
+            } else {
+                switch (scope) {
+                    case GLOBAL:
+                        return true;
+                    case USER:
+                        return user.equals(ServerContext.getRequestOwner().getUserKey());
+                    case PROTECTED:
+                        return secret.equals(treq.getParam(SECRET, ""));
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * A 32 characters string used as an ID for this resource backed by the given Table Request.
+     * This ID is created from a md5 hex of the parameters in the table request.
+     * @param treq
+     * @return
+     */
+    private String getResourceID(TableServerRequest treq) {
+        return DigestUtils.md5Hex(getUniqueID(treq));
+    }
+}
+

--- a/src/firefly/js/api/ApiUtilTable.jsx
+++ b/src/firefly/js/api/ApiUtilTable.jsx
@@ -9,4 +9,5 @@ export {getTblInfo, getActiveTableId, getTblById, getTableUiByTblId, getTblInfoB
         getColumnIdx, getColumn, getColumns, getCellValue, 
         getColumnValues, getRowValues, getSelectedData} from '../tables/TableUtil.js';
 
-export {makeTblRequest, makeFileRequest, makeIrsaWorkspaceRequest, makeIrsaCatalogRequest, cloneRequest, makeTableFunctionRequest, makeResourceRequest} from '../tables/TableRequestUtil.js';
+export {makeTblRequest, makeFileRequest, makeIrsaWorkspaceRequest, makeIrsaCatalogRequest, cloneRequest,
+        makeTableFunctionRequest, deleteResource, createResource, makeResourceRequest} from '../tables/TableRequestUtil.js';

--- a/src/firefly/js/api/ApiUtilTable.jsx
+++ b/src/firefly/js/api/ApiUtilTable.jsx
@@ -9,4 +9,4 @@ export {getTblInfo, getActiveTableId, getTblById, getTableUiByTblId, getTblInfoB
         getColumnIdx, getColumn, getColumns, getCellValue, 
         getColumnValues, getRowValues, getSelectedData} from '../tables/TableUtil.js';
 
-export {makeTblRequest, makeFileRequest, makeIrsaWorkspaceRequest, makeIrsaCatalogRequest, cloneRequest, makeTableFunctionRequest} from '../tables/TableRequestUtil.js';
+export {makeTblRequest, makeFileRequest, makeIrsaWorkspaceRequest, makeIrsaCatalogRequest, cloneRequest, makeTableFunctionRequest, makeResourceRequest} from '../tables/TableRequestUtil.js';

--- a/src/firefly/js/tables/TableRequestUtil.js
+++ b/src/firefly/js/tables/TableRequestUtil.js
@@ -176,30 +176,59 @@ const voProviders = {'NED':'NedSearch'};
  */
 
 /**
- * Creates a table request object for the given resource
- * @param {object} p                function parameters
- * @param {ResourceInfo} p.resource resource information
- * @param {string} [p.title]        title to display with this table.
- * @param {TableRequest} [p.options] table request options.  see TableRequest for details.
- * @param {string} p.action  one of 'query', 'create', 'delete'.  defautls to 'query'.
- *                         when action is 'create' or 'delete', it will submit the request.
- *                         no further action is needed.
- * @returns {TableRequest}
+ * Create the given Resource
+ * @param {ResourceInfo} resource   resource information
+ * @public
+ * @func  createResource
+ * @memberof firefly.util.table
+ */
+export function createResource(resource) {
+    handleResourceRequest({resource, action: 'create'});
+}
+
+/**
+ * Delete the given Resource
+ * @param {ResourceInfo} resource   resource information
+ * @public
+ * @func  deleteResource
+ * @memberof firefly.util.table
+ */
+export function deleteResource(resource) {
+    handleResourceRequest({resource, action: 'delete'});
+}
+
+/**
+ * @param {ResourceInfo} resource   resource information
+ * @param {string} [title]          title to display with this table.
+ * @param {TableRequest} [options]  table request options.  see TableRequest for details.
+ * @returns {TableRequest} the request to query data from the given resource
  * @public
  * @func  makeResourceRequest
  * @memberof firefly.util.table
  */
-export function makeResourceRequest({resource={}, title, options={}, action='query'}) {
+export function makeResourceRequest(resource={}, title, options={}) {
+    return handleResourceRequest({resource, title, options, action: 'query'});
+}
 
+/**
+ * private function to handle Resource related actions
+ * @param {object} p                function parameters
+ * @param {ResourceInfo} p.resource resource information
+ * @param {string} [p.title]        title to display with this table.
+ * @param {TableRequest} [p.options] table request options.  see TableRequest for details.
+ * @param {string} p.action one of 'query', 'create', 'delete'.  defautls to 'query'.
+ *                          when action is 'create' or 'delete', it will submit the request.
+ *                          no further action is needed.
+ */
+function handleResourceRequest({resource={}, title, options={}, action='query'}) {
     const {request, scope, secret} = resource;
     const searchRequest = JSON.stringify(request);
 
     if (action === 'query') {
-        return  makeTblRequest('ResourceProcessor', title, {searchRequest, action, scope, secret}, options);
+        return makeTblRequest('ResourceProcessor', title, {searchRequest, action, scope, secret}, options);
     } else {
         const req = makeTblRequest('ResourceProcessor', null, {searchRequest, action, scope, secret});
         return fetchTable(req)   // initiate and load the resource
-            .then(() => req)
             .catch((err) => logger.error(`Failed to ${action} Resource from request: ${err}`, `request=${request}`));
     }
 }

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/ResourceProcessorTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/ResourceProcessorTest.java
@@ -1,0 +1,148 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.BaseDbAdapter;
+import edu.caltech.ipac.firefly.server.db.DbAdapter;
+import edu.caltech.ipac.firefly.server.query.tables.IpacTableFromSource;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.table.DataGroupPart;
+import edu.caltech.ipac.table.JsonTableUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static edu.caltech.ipac.firefly.data.ServerParams.SOURCE;
+import static edu.caltech.ipac.firefly.server.query.ResourceProcessor.*;
+
+public class ResourceProcessorTest extends ConfigTest {
+
+	@Before
+	public void setUp() {
+		setupServerContext(null);
+	}
+
+	@After
+	public void tearDown() {
+		((BaseDbAdapter)DbAdapter.getAdapter()).cleanup(true, true);
+	}
+
+	@Test
+	public void testGlobalScope() {
+		try {
+			TableServerRequest tblReq = new TableServerRequest(IpacTableFromSource.PROC_ID);
+			tblReq.setParam(SOURCE, "https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl");
+
+			TableServerRequest req = new TableServerRequest(ResourceProcessor.PROC_ID);
+			req.setParam(QueryUtil.SEARCH_REQUEST, JsonTableUtil.toJsonTableRequest(tblReq).toJSONString());
+			req.setParam(SCOPE, GLOBAL);
+			req.setParam(ACTION, CREATE);
+
+			DataGroupPart results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("DB loaded", 80, results.getRowCount());
+			Assert.assertEquals("Only 1 row returned", 1, results.getData().size());
+
+			req.setParam(ACTION, QUERY);
+			req.setPageSize(25);
+			results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("returns 25 rows", 25, results.getData().size());
+
+			req.setParam(ACTION, DELETE);
+			results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("delete DB", 0, results.getData().size());
+
+		} catch (Exception e) {
+			Assert.fail("testGlobalScope failed with exception: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testUserScope() {
+		try {
+			TableServerRequest tblReq = new TableServerRequest(IpacTableFromSource.PROC_ID);
+			tblReq.setParam(SOURCE, "https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl");
+
+			TableServerRequest req = new TableServerRequest(ResourceProcessor.PROC_ID);
+			req.setParam(QueryUtil.SEARCH_REQUEST, JsonTableUtil.toJsonTableRequest(tblReq).toJSONString());
+			req.setParam(SCOPE, USER);
+			req.setParam(ACTION, CREATE);
+
+			DataGroupPart results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("DB loaded", 80, results.getRowCount());
+
+			ServerContext.getRequestOwner().setUserKey("someone without access");
+			req.setParam(ACTION, QUERY);
+			results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("Access denied", "Access denied", results.getErrorMsg());
+			Assert.assertEquals("No Data Returned", 0, results.getRowCount());
+		} catch (Exception e) {
+			Assert.fail("testGlobalScope failed with exception: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testProtectedScope() {
+		try {
+			TableServerRequest tblReq = new TableServerRequest(IpacTableFromSource.PROC_ID);
+			tblReq.setParam(SOURCE, "https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl");
+
+			TableServerRequest req = new TableServerRequest(ResourceProcessor.PROC_ID);
+			req.setParam(QueryUtil.SEARCH_REQUEST, JsonTableUtil.toJsonTableRequest(tblReq).toJSONString());
+			req.setParam(SCOPE, PROTECTED);
+			req.setParam(SECRET, "top secret");
+			req.setParam(ACTION, CREATE);
+
+			DataGroupPart results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("DB loaded", 80, results.getRowCount());
+
+			req.setParam(ACTION, QUERY);
+			req.setPageSize(25);
+			results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("access with password", 25, results.getData().size());
+
+
+			req.setParam(SECRET, "bad secret");
+			results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("Access denied", "Access denied", results.getErrorMsg());
+			Assert.assertEquals("No Data Returned", 0, results.getRowCount());
+		} catch (Exception e) {
+			Assert.fail("testGlobalScope failed with exception: " + e.getMessage());
+		}
+	}
+
+	@Test
+	public void testRemoveResource() {
+		try {
+			TableServerRequest tblReq = new TableServerRequest(IpacTableFromSource.PROC_ID);
+			tblReq.setParam(SOURCE, "https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl");
+
+			TableServerRequest req = new TableServerRequest(ResourceProcessor.PROC_ID);
+			req.setParam(QueryUtil.SEARCH_REQUEST, JsonTableUtil.toJsonTableRequest(tblReq).toJSONString());
+			req.setParam(SCOPE, GLOBAL);
+			req.setParam(SECRET, "top secret");
+			req.setParam(ACTION, CREATE);
+
+			DataGroupPart results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("DB loaded", 80, results.getRowCount());
+
+			req.setParam(ACTION, DELETE);
+			req.setParam(SECRET, "");		// try deleting without secret
+			results = new SearchManager().getDataGroup(req);
+			Assert.assertEquals("Access denied", "Access denied", results.getErrorMsg());
+
+			req.setParam(ACTION, DELETE);
+			req.setParam(SECRET, "top secret");		// try again with the correct secret
+			results = new SearchManager().getDataGroup(req);
+			Assert.assertNull(null, results.getErrorMsg());
+
+		} catch (Exception e) {
+			Assert.fail("testGlobalScope failed with exception: " + e.getMessage());
+		}
+	}
+
+}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-982

This is taken from ticket under implementation notes.
```
Resources are persistent data taken from a unique Table Request. Uniqueness is based on getUniqueID.
Once a resource is created, it will remain unchanged until deleted.
firefly.util.table.makeResourceRequest is created to help work with resources.
See "Table as a Resource" in tests-table.html for sample usage.

Resource comes with basic security features. This info is saved as a .acl file next to the database files.

scope: This control the visibility of a resource. It can be 'global', 'user', or 'protected'.
    global is public. Anyone can access it. If this resource is created with a secret, then that secret is needed to delete it.
    user is visible to only the user who created it. User is based on a 'usrkey' cookie set on the browser.
    protected resource is one created with a secret token. It can only be accessed using the same secret token.
Any resource created without scope is considered global.
```

See test for an example of how it's used:
https://fireflydev.ipac.caltech.edu/firefly-982-table-as-resource/firefly/test/tests-table.html?test=Table+as+a+Resource
