### PR TITLE
[FIREFLY-989] WAVE-TAB: The algorithm is producing incorrect results

### DIFF
--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -7,9 +7,8 @@
  *  3. https://www.aanda.org/articles/aa/full/2002/45/aah3859/aah3859.html,
  *
  */
-import {LinearInterpolator} from '../../util/Interp/LinearInterpolator.js';
 import {isDefined} from '../../util/WebUtil.js';
-export const PLANE  = 'PLANE';
+export const PLANE = 'PLANE';
 export const LINEAR = 'LINEAR';
 export const LOG = 'LOG';
 export const F2W = 'F2W';
@@ -32,8 +31,6 @@ export const VRAD = 'VRAD';
  * @prop {Number} N
  * @prop {Array.<number>} r_j
  * @prop {Array.<number>} pc_3j
- * @prop {Number} s_3
- * @prop {Number} lambda_r
  * @prop {number} restWAV
  * @prop {number} crpix
  * @prop {number} cdelt
@@ -42,48 +39,49 @@ export const VRAD = 'VRAD';
 
 
 
-const wlTypes= {
-    [PLANE] : {
-        getWaveLength : getWaveLengthPlane,
-        implemented : true,
+const wlTypes = {
+    [PLANE]: {
+        getWaveLength: getWaveLengthPlane,
+        implemented: true,
     },
-    [LINEAR] : {
-        getWaveLength : getWaveLengthLinear,
-        implemented : true,
+    [LINEAR]: {
+        getWaveLength: getWaveLengthLinear,
+        implemented: true,
     },
-    [LOG] : {
-        getWaveLength : getWaveLengthLog,
-        implemented : true,
+    [LOG]: {
+        getWaveLength: getWaveLengthLog,
+        implemented: true,
     },
-    [F2W] : {
-        getWaveLength : getWaveLengthNonLinear,
-        implemented : true,
+    [F2W]: {
+        getWaveLength: getWaveLengthNonLinear,
+        implemented: true,
     },
-    [V2W] : {
-        getWaveLength : getWaveLengthNonLinear,
-        implemented : true,
+    [V2W]: {
+        getWaveLength: getWaveLengthNonLinear,
+        implemented: true,
     },
-    [TAB] : {
-        getWaveLength : getWaveLengthTable,
-        implemented : true,
+    [TAB]: {
+        getWaveLength: getWaveLengthTable,
+        implemented: true,
     },
 };
 
 
 export function getWavelength(pt, cubeIdx, wlData) {
-    const {algorithm, wlType}= wlData;
+    const {algorithm, wlType} = wlData;
     if (wlTypes[algorithm] && wlTypes[algorithm].implemented && wlTypes[algorithm].getWaveLength) {
-        const wl=  wlTypes[algorithm].getWaveLength(pt,cubeIdx,wlData);
-        if (wlType===WAVE || wlType===VRAD) return wl;
-        if (wlType===AWAV) return convertAirToVacuum(wl);
+        const wl = wlTypes[algorithm].getWaveLength(pt, cubeIdx, wlData);
+        if (wlType === WAVE || wlType === VRAD) return wl;
+        if (wlType === AWAV) return convertAirToVacuum(wl);
         return wl;
     }
 }
+
 //TODO check here to see the cubeIdx??
 function getWaveLengthPlane(ipt, cubeIdx, wlData) {
     const {crpix, crval, cdelt} = wlData;
-    //pixel count starts from 1 to naxisn
-    const wl = crval + ( cubeIdx + 1  - Math.round(crpix) ) * cdelt;
+    // pixel count starts from 1 to naxisn
+    const wl = crval + (cubeIdx + 1 - Math.round(crpix)) * cdelt;
     return wl;
 }
 
@@ -92,26 +90,21 @@ export function isWLAlgorithmImplemented(wlData) {
 }
 
 /**
- *  calculate the air wavelength and then convert to vacuum wavelength
- *  @param {number} wl
+ *  Function for air to vacuum wavelength conversion (Eq. 66 in paper2.)
+ *  @param {number} wl - air wavelength
  *  @return {number}
  */
-const convertAirToVacuum= (wl) => 1 + 10**-6 * ( 287.6155 + 1.62887/wl**2 + 0.01360/wl**4);
+const convertAirToVacuum = (wl) => 1 + 10 ** -6 * (287.6155 + 1.62887 / wl ** 2 + 0.01360 / wl ** 4);
 
 
 /**
+ * Get linear spectral coordinate value.
  *
- * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
- * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
- * Thus, the k value referenced in the paper is 3 here
+ * Assuming spectral coordinate is the third (ex. CTYPE3 = WAVE)
  *
- *  omega  = x_3 = s_3* Sum [ m3_j * (p_j - r_j) ]
+ * spectral_coord_val = crval_3 + omega
  *
- *  lamda = lambda_r + omega
- *
- *  lambda_r : is the reference value,  given by CRVAL3
- *
- *
+ * where  omega  = x_3 = cdelt_3 * Sum [ m3_j * (p_j - r_j) ]
  *
  * @param {ImagePt} ipt
  * @param {number} cubeIdx
@@ -119,28 +112,24 @@ const convertAirToVacuum= (wl) => 1 + 10**-6 * ( 287.6155 + 1.62887/wl**2 + 0.01
  * @param {Number} wlData.N
  * @param {Array.<number>} wlData.r_j
  * @param {Array.<number>} wlData.pc_3j
- * @param {Number} wlData.s_3
- * @param wlData.lambda_r
+ * @param {Number} wlData.cdelt
+ * @param {Number} wlData.crval
  * @return {number}
  */
 function getWaveLengthLinear(ipt, cubeIdx, wlData) {
-    const {N,  r_j, pc_3j, s_3,  lambda_r}= wlData;
-    return lambda_r + getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
+    const {N, r_j, pc_3j, cdelt, crval} = wlData;
+
+    return crval + getOmega(getPixelCoords(ipt, cubeIdx), N, r_j, pc_3j, cdelt);
 }
 
-// Add other VRAD conversion and algorithem here
-
 /**
+ * Get logarithmic spectral coordinate value.
  *
- * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
- * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
- * Thus, the k value referenced in the paper is 3 here
+ * Assuming spectral coordinate is the third (ex. CTYPE3 = WAVE-LOG)
  *
- *  omega  = x_3 = s_3* Sum [ m3_j * (p_j - r_j) ]
+ * spectral_coord_val = crval_3 * exp (omega/crval_3),  eq. (5)
  *
- *  lamda = lambda_r * exp (omega/s_3)
- *
- *  lambda_r : is the reference value,  given by CRVAL3
+ * where  omega  = x_3 = cdelt_3 * Sum [ m3_j * (p_j - r_j) ]
  *
  * @param {ImagePt} ipt
  * @param {number} cubeIdx
@@ -148,27 +137,30 @@ function getWaveLengthLinear(ipt, cubeIdx, wlData) {
  * @param {Number} wlData.N
  * @param {Array.<number>} wlData.r_j
  * @param {Array.<number>} wlData.pc_3j
- * @param {Number} wlData.s_3
- * @param {Number} wlData.lambda_r
+ * @param {Number} wlData.cdelt
+ * @param {Number} wlData.crval
  * @return {number}
  */
 function getWaveLengthLog(ipt, cubeIdx, wlData) {
-    const {N,  r_j, pc_3j, s_3,  lambda_r}= wlData;
-    const omega= getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
-    return lambda_r* Math.exp(omega/lambda_r);
+    const {N, r_j, pc_3j, cdelt, crval} = wlData;
+    const omega = getOmega(getPixelCoords(ipt, cubeIdx), N, r_j, pc_3j, cdelt);
+    return crval * Math.exp(omega / crval);
 }
 
 /**
+ * Get non-linear spectral coordinate value.
  *
- * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
- * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
- * Thus, the k value referenced in the paper is 3 here
+ * Assuming spectral coordinate is the third,
  *
- *  omega  = x_3 = s_3* Sum [ m3_j * (p_j - r_j) ]
+ * for ex. CTYPE3 = WAVE-F2W:
  *
- *  lamda = lambda_r * exp (omega/s_3)
+ * spectral_coord_val = crval_3 * crval_3 / (crval3 - omega),  eq. (52)
  *
- *  lambda_r : is the reference value,  given by CRVAL3
+ * where   omega = x_3 = cdelt_3 * Sum [ m3_j * (p_j - r_j) ]
+ *
+ * for ex. CTYPE3 = WAVE-V2W: see eq. (57) and (58)
+ *
+ * Other non-linear algorithms may be supported from Table 5 can be added in future.
  *
  * @param {ImagePt} ipt
  * @param {number} cubeIdx
@@ -176,419 +168,330 @@ function getWaveLengthLog(ipt, cubeIdx, wlData) {
  * @param {Number} wlData.N
  * @param {Array.<number>} wlData.r_j
  * @param {Array.<number>} wlData.pc_3j
- * @param {Number} wlData.s_3
- * @param {Number} wlData.lambda_r
+ * @param {Number} wlData.cdelt
+ * @param {Number} wlData.crval
  * @param {string} wlData.algorithm
  * @param {number} wlData.restWAV
  * @return {number}
  */
 function getWaveLengthNonLinear(ipt, cubeIdx, wlData) {
 
-    const {N,  r_j, pc_3j, s_3, lambda_r, algorithm= 'F2W', restWAV=0}= wlData;
-    let lamda= NaN;
-    const omega= getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
+    const {N, r_j, pc_3j, cdelt, crval, algorithm='F2W', restWAV=0} = wlData;
+    let lambda = NaN;
+    const omega = getOmega(getPixelCoords(ipt, cubeIdx), N, r_j, pc_3j, cdelt);
 
-
-    switch (algorithm){
+    switch (algorithm) {
         case 'F2W':
-            lamda =lambda_r *  lambda_r/(lambda_r - omega);
+            lambda = crval * crval / (crval - omega);
             break;
         case 'V2W':
-            const lamda_0 = restWAV;
-            const b_lamda = ( Math.pow(lambda_r, 4) - Math.pow(lamda_0, 4) + 4 *Math.pow(lamda_0, 2)*lambda_r*omega )/
-            Math.pow((Math.pow(lamda_0, 2) + Math.pow(lambda_r, 2) ), 2);
-            lamda = lamda_0 - Math.sqrt( (1 + b_lamda)/(1-b_lamda) );
+            const lambda_0 = restWAV;
+            const b_lambda = (Math.pow(crval, 4) - Math.pow(lambda_0, 4) + 4 * Math.pow(lambda_0, 2) * crval * omega) /
+                Math.pow((Math.pow(lambda_0, 2) + Math.pow(crval, 2)), 2);
+            lambda = lambda_0 - Math.sqrt((1 + b_lambda) / (1 - b_lambda));
             break;
     }
-    return lamda;
+    return lambda;
 }
 
 /**
  * According to the reference papers above, the coordinate has M+1 dimension where the M means the
  *  dependence on the M axis, Coords[M][K1][K2[]...[Km].  In our case, the M=1, the coordinate is the
- *  two dimensional array, and the first dimension is M=1  and the second dimension is K1 which is the sampling
- *  number the data has been sampled. Thus, each image point, it corresponding coordinate is
- *  coords[1][K1].  For example, if the sampling count is K1=100, each cell in the coordinate table, contains 100
- *  data values. The coordinate column can convert to 100 rows of the single value table. 
+ *  two-dimensional array, and the first dimension is M=1 and the second dimension is K1, which is the sampling
+ *  number the data has been sampled. Thus, for each image point, the corresponding index or coordinate array value
+ *  is coords[1][K1].  For example, if the sampling count is K1=100, each cell in the coordinate table, contains 100
+ *  data values. The coordinate column can convert to 100 rows of the single value table.
  *
  *
  * @param table
  * @param columnName
  * @returns {*}
  */
-const getArrayDataFromTable= (table, columnName) => {
-    let tableData = table.tableData;
-    let arrayData = tableData.data;
-    let columns = tableData.columns;
-    for (let i=0; i<columns.length; i++){
-        if (columns[i].name.toUpperCase() === columnName.toUpperCase()){
+const getArrayDataFromTable = (table, columnName) => {
+    const tableData = table.tableData;
+    const arrayData = tableData.data;
+    const columns = tableData.columns;
+    for (let i = 0; i < columns.length; i++) {
+        if (columns[i].name.toUpperCase() === columnName.toUpperCase()) {
             return arrayData[0][i];
-
         }
     }
     return undefined;
 };
 
 /**
+ * Get non-linear spectral coordinate using table lookup, see Section 6 of Paper2.
  *
- * The pre-requirement is that the FITS has three axies, ra (1), dec(2) and wavelength (3).
- * Therefore the keyword for i referenced in the paper is 3
- * ψm = xi + CRVALia: xi = omega, CRVALia = CRIVAL3=lambda_r
+ * The intermediate world coordinate for axis i is calculated as
+ *
+ * psi_m = x_i + CRVALia, eq. (87)
+ *
+ * where   x_i = omega = cdelt_i * Sum [ mi_j * (p_j - r_j) ]
+ *
+ * Using linear interpolation, if necessary, in the indexing vector
+ * for intermediate world coordinate axis i, one determines the
+ * location, Ym, corresponding to psi_m. Then the coordinate value,
+ * Cm, of type specified by the first four characters of CTYPEia,
+ * is that at location (m,Y1,Y2,...Y_M) in the coordinate array,
+ * again using linear interpolation as needed.
+ *
  * @param {ImagePt} ipt
  * @param {number} cubeIdx
  * @param {WaveLengthData} wlData
- * @param {Number} wlData.N
+ * @param {Number} wlData.N number of world coordinate axes
  * @param {Array.<number>} wlData.r_j
  * @param {Array.<number>} wlData.pc_3j
- * @param {Number} wlData.s_3, s_3 is the value of CDELT3
- * @param {Number} wlData.lambda_r
- * @return {number}
+ * @param {Number} wlData.cdelt scaling factor
+ * @param {Number} wlData.crval value at the reference point
+ * @param wlData.wlTable lookup table
+ * @param wlData.ps3_1 column name for the coordinate array
+ * @param wlData.ps3_2 column name for the indexing vector
+ * @return {number} spectral coordinate value
  */
 function getWaveLengthTable(ipt, cubeIdx, wlData) {
 
+    const {N, r_j, cdelt, crval, pc_3j, wlTable, ps3_1, ps3_2} = wlData;
 
-    const {N, r_j, pc_3j, s_3, lambda_r, wlTable, ps3_1, ps3_2}= wlData;
-
-    const omega= getOmega(getPixelCoords(ipt,cubeIdx),  N, r_j, pc_3j, s_3);
-    const psi_m = lambda_r + omega;
+    const omega = getOmega(getPixelCoords(ipt, cubeIdx), N, r_j, pc_3j, cdelt);
+    const psi_m = crval + omega;
     if (!wlTable) return NaN;
-
 
     //read the cell coordinate from the FITS table and save to two one dimensional arrays
     const coordData = getArrayDataFromTable(wlTable, ps3_1 || 'COORDS');
     if (!coordData) return NaN;
 
-    const indexData =  getArrayDataFromTable(wlTable, ps3_2 || 'INDEX');
+    const indexData = getArrayDataFromTable(wlTable, ps3_2 || 'INDEX');
 
     if (!indexData) {
-        //There is no Index table, the C_m is the direct search in the coordinate table
-        //In this case the condition 1<=k <=psi_m<k+1<=kMax does not apply in sofia case
-        return calculateC_m( psi_m,  coordData, coordData.length, false) ;
+        // No indexing vector, psi_m is a direct index into the coordinate array.
+        // psi_m should be an integer between 1 and coordData.length
+        if (Math.round(psi_m) === psi_m && psi_m >= 1 && psi_m <= coordData.length) {
+            return coordData[psi_m - 1];
+        }
+    } else {
+        // Indexing vector is present.
+        const Y_m = calculateY_m(indexData, psi_m);
+
+        if (isDefined(Y_m)) {
+            return calculateC_m(Y_m, coordData, indexData.length);
+        }
     }
-
-
-    const sort = isSorted(indexData); //1:ascending, -1: descending, 0: not sorted
-    if (sort===0){
-        return NaN; //The vector index array has to be either ascending or descending
-    }
-    const gamma_m = calculateGamma_m(indexData, psi_m, sort);
-
-    if (!isDefined(gamma_m)) return NaN;
-
-    return calculateC_m( gamma_m,  coordData, indexData.length) ;
-
+    return NaN;
 }
 
 /**
+ * Get coordinate value, when indexing vector is present.
  * In the case of a single separable coordinate with 1 ≤ k ≤ Υm < k+1 ≤K,
  * the coordinate value is given by
  *     Cm = Ck + (Υm − k) (Ck+1 − Ck)
  * For Υm such that 0.5 ≤ Υm < 1 or K < Υm ≤ K + 0.5 linear
  * extrapolation is permitted, with Cm = C1 when K = 1.
  *
- * @param gamma_m
- * @param coordData
- * @param kMax
- * @param hasIndexTable
+ * @param Y_m index in coordinate data array with range from 0.5 to kMax+0.5
+ * @param coordData coordinate data array
+ * @param kMax index data length (should match coordData.length, at least in 1d case)
  * @returns {*}
  */
-function calculateC_m(gamma_m,  coordData, kMax, hasIndexTable=true){
+export function calculateC_m(Y_m, coordData, kMax) {
+
+    if (kMax !== coordData.length) {
+        // this could happen in 2d case - not yet implemented
+        // the index data length is not matching coordinate data length
+        // the function will produce wrong results,
+        // better not to pretend we know the result
+        return NaN;
+    }
+
+    // The value of Y_m derived from ψm must lie in the range 0.5 ≤ Y_m ≤ K + 0.5;
+    // K > 1: degenerate axes are forbidden
+    if (kMax === 1) {
+        return NaN;
+    }
 
     let C_m = undefined;
 
-    /*The value of gamma_m derived from ψm must lie in the range 0.5 ≤ gamma_m ≤ K + 0.5.
-    However, if the index array is not given, this seems does not apply.  In sofia data, it does not apply.
-    Thus, we can not use kIndex = Math.trunc(gamma_m).
-    * */
+    // linear interpolation: find the value at index i if [v1, v2] have indexes [0, 1]
+    const lerp = (v1, v2, i) => v1 + i * (v2 - v1);
 
-    if (kMax===1) {
-        const k =  Math.trunc(gamma_m);//integer part of the gamma_m
-        if (k===0) return coordData[0];
-    }
+    // function to get C_m; the range of i is from -0.5 to 1.5
+    const findC_m = (i1, i2, i) => lerp(coordData[i1], coordData[i2], i);
 
-    /*In the case of a single separable coordinate with 1 ≤ k ≤ gamma_m < k+1 ≤ kMax, the coordinate value is given by
-     Cm = Ck + (gamma_m − k) (Ck+1 − Ck)
-     Note: we use the index starting from 0, so we have to kIndex>=0.
-    */
-    let kIndex;
-    if (hasIndexTable){
-        /*1 ≤ k ≤ gamma_m < k+1 ≤ Kmax
-        gamma_m = k + (ψm − Ψk(/ (Ψk+1 − Ψk); The value of gamma_m derived from ψm must lie in the
-        range 0.5 ≤Υm ≤ K + 0.5.
-         */
-        kIndex = Math.trunc(gamma_m); //thus gamma_m>kIndex and gamma_m<kIndex+1
-    }
-    else {
-        const sort = isSorted(coordData); //1:ascending, -1: descending, 0: not sorted
-        if (sort === 0) {
-            coordData = coordData.sort((a, b) => { return a - b; }); //sort the data
-        }
-        kIndex = searchIndex(coordData, gamma_m, sort);
-    }
-    if (  (hasIndexTable  && kIndex>=0 && kIndex <= gamma_m && gamma_m < kIndex+1 && kIndex+1 <=kMax-1 ) ||
-          (!hasIndexTable && kIndex >= 0 && coordData[kIndex] <= gamma_m && gamma_m < coordData[kIndex + 1] && kIndex + 1 <= kMax - 1) ) {
-           C_m = coordData[kIndex] + (gamma_m - kIndex - 1) * (coordData[kIndex + 1] - coordData[kIndex]);
-    }
-    else {
-        const inCoords = Array.from(new Array(coordData.length), (x,i) => i);
-        const linearInterpolator = LinearInterpolator(inCoords, coordData, true);
-        if (!hasIndexTable && gamma_m<coordData[0] || hasIndexTable && gamma_m>=0.5 && gamma_m<1) {
-            //linear extrapolation CoorData next to the first coordinate point
-            const coordData_far_left = linearInterpolator(0.5);
-            return coordData_far_left + gamma_m * (coordData[0]-coordData_far_left);
-        }
-        else  if( ( !hasIndexTable && gamma_m>coordData[kMax-1]) || (hasIndexTable && kMax <gamma_m && gamma_m <= kMax+ 0.5) ) {
-            //linear extrapolation CoorData
-            const coordData_far_right = linearInterpolator(kMax + 0.5);
-            return coordData[kMax-1] + (gamma_m-kMax) * (coordData_far_right - coordData[kMax-1]);
-
+    if (Y_m >= 1 && Y_m < kMax) {
+        // In the case of a single separable coordinate with 1 ≤ k ≤ Y_m < k+1 ≤ kMax, the coordinate value is given by
+        // Cm = Ck + (Y_m − k) * (Ck+1 − Ck)  eq. (89) of Paper 2
+        const kIndex = Math.trunc(Y_m);
+        C_m = findC_m(kIndex - 1, kIndex, Y_m - kIndex);
+    } else if (Y_m === kMax) {
+        C_m = coordData[kMax - 1];
+    } else {
+        if (Y_m >= 0.5 && Y_m < 1) {
+            //linear extrapolation coordData next to the first coordinate point
+            C_m = findC_m(0, 1, Y_m - 1);
+        } else if (kMax < Y_m && Y_m <= kMax + 0.5) {
+            //linear extrapolation coordData
+            C_m = findC_m(kMax-2, kMax-1, Y_m - (kMax-1));
         }
     }
-   return C_m;
+    return C_m;
 }
 
-function getGammaByInterpolation(psiIndex, psi_m, indexVec, sort){
-
-    let gamma_m=undefined;
-    /*--------------------------------------------------------------------------------
-        * psiIndex is found, however the following four cases, gamma_m is undefined and so is C_m
-        */
-    //case 1: Ψk+1=Ψk=Ψm, return undefined
-    if (indexVec[psiIndex]===indexVec[psiIndex+1] && indexVec[psiIndex]===psi_m && psiIndex<indexVec.length-1 ||
-      psi_m===indexVec[0] && indexVec[0]===indexVec[1]) {
-        return gamma_m;
-    }
-
-    /* case 2: Ψk < ψm = Ψk+1 for monotonically increasing index values,except when ψm = Ψ1,
-    * If Ψk+2 = Ψk+1 = ψm (or Ψ2 = Ψ1 = ψm), then Υm and Cm are undefined.
-    */
-    if (sort===1 && psiIndex!==0 && indexVec[psiIndex] < psi_m && psi_m===indexVec[psiIndex+1] ||
-
-     /* case 2: Ψk > ψm = Ψk+1 for monotonically decreasing index values,except when ψm = Ψ1
-      * Ψk > ψm = Ψk+1 for monotonically decreasing index values,except when ψm = Ψ1
-      */
-     sort===-1 && psiIndex!==0 && indexVec[psiIndex] >psi_m && psi_m===indexVec[psiIndex+1] ){
-
-        /* Since two consecutive index values may be equal, the index following
-         * the matched index must be examined. If Ψk+2 = Ψk+1 = ψm
-         * (or Ψ2 = Ψ1 = ψm), then Υm and Cm are undefined
-         */
-        if (indexVec[psiIndex+2]===psi_m){
-            return gamma_m;
-        }
-    }
-    //case 4: ψm = Ψ1
-    if (indexVec[0]===psi_m && indexVec[1]===psi_m ){
-        return gamma_m;
-    }
-
-    /*--------------------------------------------------------------------------------
-    * psiIndex is found, the gamma_m can be interpolated
-    */
-    if (indexVec[psiIndex]!==indexVec[psiIndex + 1] ) {
-        // Υm = k + (ψm − Ψk) / (Ψk+1− Ψk) where k = 1,... Kmax,
-        // array index here is from 0, so the k = psiIndex +1.  For example is psiIndex =0, it means k=1, Ψ1=ψm
-        gamma_m =psiIndex+1  + (psi_m - indexVec[psiIndex]) / (indexVec[psiIndex+1] - indexVec[psiIndex]);
-        return gamma_m;
-    }
-}
-function getGammaByExtrarpolation(psi_m, indexVec, sort){
-    let gamma_m=undefined;
-    const kMax = indexVec.length;
-    const inCoords = Array.from(new Array(indexVec.length), (x,i) => i);
-    const linearInterpolator = LinearInterpolator(inCoords, indexVec, true);
-    const left = indexVec[0] - (indexVec[1] - indexVec[0]) / 2;
-    const right = indexVec[kMax - 1] + (indexVec[kMax - 1] - indexVec[kMax - 2]) / 2;
-
-    // When no psi_m is found in the vector psiIndex=-1),  we need to check if the gamma_m can be extrapolated.
-    if (indexVec.length===1){
-        /* When the indexVector's length  = 1 with ψm in the range Ψ1 − 0.5 ≤ ψm ≤ Ψ1 + 0.5 (noting that Ψ1
-        * should be equal to 1 in this case) whence Υm = ψm
-        */
-        if (indexVec[0] - 0.5 <=psi_m && psi_m <=indexVec[0] + 0.5){
-            gamma_m= psi_m;
-        }
-    }
-    else { //do extrapolation
-        switch (sort) {
-            case 1:
-
-                if (left <= psi_m && psi_m < indexVec[0]) {
-                    const psi_left = linearInterpolator( left);
-                    gamma_m = (psi_m - psi_left) /(indexVec[0] -psi_left);
-
-                }
-                else if (indexVec[kMax - 1] < psi_m && psi_m <= right) {
-                    const psi_right =linearInterpolator( right );
-                    gamma_m = indexVec.length + 1 + (psi_m - indexVec[kMax - 1]) /
-                        (psi_right - indexVec[kMax - 1]);
-                }
-
-                break;
-            case -1:
-                if (left >= psi_m && psi_m > indexVec[0]) {
-                    const psi_left = linearInterpolator( left);
-                    gamma_m = (psi_m - psi_left) /
-                        (indexVec[0] - psi_left);
-
-                }
-                else if (indexVec[kMax - 1] > psi_m && psi_m >= right)  {
-                    const psi_right = linearInterpolator( right);
-                    gamma_m = indexVec.length + 1 + (psi_m - indexVec[kMax - 1])/(psi_right - indexVec[kMax - 1]);
-                }
-
-                break;
-        }
-    }
-
-    return gamma_m;
-
-}
 /**
- * The algorithm for computing Υm, and thence Cm,is as follows:
+ * Get Y_m – the index of ψm in the indexing vector.
+ *
+ * The algorithm for computing Υm, and thence Cm, is as follows:
  * Scan the indexing vector, (Ψ1,Ψ2, . . .), sequentially
  * starting from the first element, Ψ1, until a successive
  * pair of index values is found that encompass ψm (i.e. such that
  * Ψk ≤ ψm ≤ Ψk+1 for monotonically increasing index values or
  * Ψk ≥ ψm ≥ Ψk+1 for monotonically decreasing index values
- * for some k). Then, when Ψk  Ψk+1, interpolate linearly on the
- * indices  Υm = k +  (ψm − Ψk)/ (Ψk+1 − Ψk).  The Ym (gamma_m) is the index in
- * the coordinate array.
- *
- * However if Ψk+1 = Ψk, the Υm is undefined.
+ * for some k). Then, when Ψk != Ψk+1, interpolate linearly on the
+ * indices  Υm = k +  (ψm − Ψk)/ (Ψk+1 − Ψk).  The Ym is the index in
+ * the coordinate array. If Ψk+1 == Ψk, the Υm is undefined.
  *
  *  NOTE, the array index starting from 1, not 0 as in javascript
  *
- *  Υm = (k + (psi_m-psi_k)/psi_k+1 - psi_k) )
- *  Υm = k +  ( (ψm − Ψk ) /( Ψk+1 − Ψk) )
- *  How to calculate gamma_m (Υm):
- *  case 1:
- *  where psi is the index vector.  In our case, it is indexVec.
- *  If (psi_k <= psi_m <= psi_k+1) for for monotonically increasing index values
- *  or
- *  If (psi_k >= psi_m >= psi_k+1) for for monotonically decreasing index values
- *  Then the gamma_m = (k + (psi_m-psi_k)/psi_k+1 - psi_k) )
+ *  Υm = k + (psi_m - psi_k) / (psi_k+1 - psi_k)   eq. (88) of Paper2
  *
- *  case 2:
- *    if psi_k = psi_k+1 = psi_m, based on the formula above, the value is undefined. In this case,
- *    we need to find a psi_k such that psi_k < psi_m = psi_k+1 for monotonically increasing index values
- *    or psi_k > psi_m = psi_k+1 for monotonically decreasing index values. Since two consecutive index
- *    values may be equal, the index following the matched index must be examined. If Ψk+2 = Ψk+1 = ψm
- *    (or Ψ2 = Ψ1 = ψm), then Υm and Cm are undefined.
+ *  If Ψk+1 == Ψk, the Υm is undefined.
  *
- * case 3: linear interpolation
- *  If psi_m in the range psi_1 to psi_k inclusive, interpolation is needed.
+ *  Extrapolation can be used
+ *    if psi_m outside range (psi_1, psi_k) and k>1 and
  *
- * case 4:
- *     if Ψk+1 = Ψk, the Υm is undefined.
- *
- * case 5: extrapolation
- *    psi_m outside range psi_1 - psi_k, and k>1,
- *    if (psi_1 - (psi_2-psi_1)/2 ) < = psi_m <psi_1 or
- *    psi_k <psi_m <= (psi_k + (psi_k - psi_k-1) /2)
+ *    (psi_1 - (psi_2-psi_1)/2 ) < = psi_m < psi_1 or
+ *    psi_k < psi_m <= (psi_k + (psi_k - psi_k-1) / 2)
  *    monotonically increasing index values
  *
  *    (psi_1 - (psi_2-psi_1)/2 ) > = psi_m > psi_1 or
- *    psi_k > psi_m >= (psi_k + (psi_k - psi_k-1) /2)
+ *    psi_k > psi_m >= (psi_k + (psi_k - psi_k-1) / 2)
  *    for monotonically decreasing index values
  *
- *
  * @param {Array.<number>} indexVec
- * @param {number} psi_m
- * @param sort
- * @returns {*}
+ * @param {number} psi_m  ψm in eq (87)
+ * @returns {*} the index of psi_m in the indexing vector in range [0.5, indexVec.length]
  */
-function calculateGamma_m(indexVec, psi_m,sort) {
+export function calculateY_m(indexVec, psi_m) {
 
-    const psiIndex = searchIndex(indexVec, psi_m,sort);
+    let Y_m = undefined;
 
+    // inverse linear interpolation: find the index of v if [v1, v2] have indexes [0, 1]
+    const invlerp = (v1, v2, v) => (v - v1) / (v2 - v1);
 
+    // function to get Y: 1-based index in indexVec; Y range is from 0.5 to indexVec.length+0.5
+    const findY = (i1, i2, v) => i2 + invlerp(indexVec[i1], indexVec[i2], v);
 
-    if (isNaN(psiIndex)) {//The index vector is not sorted, return undefined
+    // Indexing vector should be monotonically increasing or decreasing.
+    const sort = isSorted(indexVec); // 1: ascending, -1: descending, 0: not sorted
+    if (sort === 0) {
         return undefined;
     }
 
+    // get zero-based index k of index vector that Ψk ≤ ψm ≤ Ψk+1 or Ψk ≥ ψm ≥ Ψk+1
+    // k is -1 if psi_m is outside the index array
+    const psiIndex = searchIndex(indexVec, psi_m, sort);
 
-    if (psiIndex!==-1){
-        /*
-          Ψk ≤ ψm ≤ Ψk+1 for monotonically increasing index values or
-          Ψk ≥ ψm ≥ Ψk+1 for monotonically decreasing index values for some k (here, we use psiIndex)
-       */
-        return getGammaByInterpolation(psiIndex,psi_m, indexVec, sort);
+    if (psiIndex !== -1) {
+        // calculate Y_m using interpolation
+
+        if (indexVec[psiIndex] !== indexVec[psiIndex + 1]) {
+            // Υm = k + (ψm − Ψk) / (Ψk+1− Ψk) where k = 1,... Kmax,
+            // psiIndex here is from 0, so the k = psiIndex+1.  For example when psiIndex=0, it means k=1, Ψ1=ψm
+            Y_m = findY(psiIndex, psiIndex + 1, psi_m);
+        }
+
+    } else {
+        // calculate Y_m using extrapolation: psi_m is out of the indexVector's range
+
+        if (indexVec.length === 1) {
+            // When the index vector's length  = 1 with ψm in the range Ψ1 − 0.5 ≤ ψm ≤ Ψ1 + 0.5
+            // (noting that Ψ1 should be equal to 1 in this case) hence Υm = ψm
+            if (indexVec[0] - 0.5 <= psi_m && psi_m <= indexVec[0] + 0.5) {
+                Y_m = psi_m;
+            }
+        } else { //do extrapolation
+            const kMax = indexVec.length;
+            const left = indexVec[0] - (indexVec[1] - indexVec[0]) / 2;
+            const right = indexVec[kMax - 1] + (indexVec[kMax - 1] - indexVec[kMax - 2]) / 2;
+
+            switch (sort) {
+                case 1:
+                    if (left <= psi_m && psi_m < indexVec[0]) {
+                        Y_m = findY(0, 1, psi_m);
+                    } else if (indexVec[kMax - 1] < psi_m && psi_m <= right) {
+                        Y_m = findY(kMax - 2, kMax - 1, psi_m);
+                    }
+                    break;
+                case -1:
+                    if (left >= psi_m && psi_m > indexVec[0]) {
+                        Y_m = findY(0, 1, psi_m);
+                    } else if (indexVec[kMax - 1] > psi_m && psi_m >= right) {
+                        Y_m = findY(kMax - 2, kMax - 1, psi_m);
+                    }
+                    break;
+            }
+        }
     }
-    else {
-        // psiIndex=-1: no range found, the psi_m is outside of the indexVector's range
-       return getGammaByExtrarpolation(psi_m, indexVec, sort);
-    }
-
-
+    return Y_m;
 }
 
-
-
+/**
+ * Check if array is monotonically increasing or decreasing.
+ * @param intArray
+ * @returns {number}  1 for increasing, -1 for decreasing, 0 for non-monotonic
+ */
 function isSorted(intArray) {
 
-    const end = intArray.length-1;
+    const end = intArray.length - 1;
     let counterAsc = 0;
     let counterDesc = 0;
 
     for (let i = 0; i < end; i++) {
-        if (intArray[i] < intArray[i+1]) counterAsc++;
-        else if(intArray[i] > intArray[i+1]) counterDesc++;
+        if (intArray[i] < intArray[i + 1]) counterAsc++;
+        else if (intArray[i] > intArray[i + 1]) counterDesc++;
     }
-    if(counterDesc===0) return 1;
-    else if (counterAsc===0) return -1;
+    if (counterDesc === 0) return 1;
+    else if (counterAsc === 0) return -1;
     else return 0;
 }
 
+/**
+ * Get lower array index k for linear interpolation in ****-TAB algorithm. See eq. (88) in Paper2.
+ *
+ * Scan the indexing vector, (Ψ1, Ψ2,...), sequentially starting from the first element, Ψ1,
+ * until a successive pair of index values is found that encompass ψm (i.e. such that Ψk ≤ ψm ≤ Ψk+1
+ * for monotonically increasing index values or Ψk ≥ ψm ≥ Ψk+1 for monotonically decreasing index values
+ * for some k). Return the value of k.
+ *
+ * The data in the indexing vectors must be monotonically increasing or decreasing, although two adjacent
+ * index values in the vector may have the same value.
+ * However, it is not valid for an index value to appear more than twice in an index vector,
+ * nor for an index value to be repeated at the start or at the end of an index vector.
+ *
+ * NOTE: the index in the algorthm is starting with 1, in Javascript, the index is starting from 0.
+ *
+ * @param arrayData
+ * @param psi_m
+ * @param sort 1 if index values are monotonically increasing, -1 o
+ * @returns {number} zero-based k such that Ψk ≤ ψm ≤ Ψk+1 or Ψk ≥ ψm ≥ Ψk+1; -1 if such index does not exist
+ */
+export function searchIndex(arrayData, psi_m, sort) {
 
- /**
- /* Scan the indexing vector, (Ψ1, Ψ2,...), sequentially starting from the ﬁrst element, Ψ1,
-  * until a successive pair of index values is found that encompass ψm (i.e. such that Ψk ≤ ψm ≤ Ψk+1
-  * for monotonically increasing index values or Ψk ≥ ψm ≥ Ψk+1 for monotonically decreasing index values
-  * for some k). Then, when Ψk  Ψk+1, interpolate linearly on the indices
-  *
-  * NOTE: the index in the algorthim is starting with 1, in Javascript, the index is starting from 0.
-  *
-  * @param arrayData
-  * @param psi_m
-  * @param sort
-  * @returns {number}
-  */
- function searchIndex(arrayData, psi_m, sort) {
-
-
-    for (let i=0; i<arrayData.length-1; i++){
-        if (sort===1 && arrayData[i]<=psi_m  && psi_m<=arrayData[i+1]){
+    for (let i = 0; i < arrayData.length - 1; i++) {
+        // monotonically increasing array data
+        if (sort === 1 && arrayData[i] <= psi_m && psi_m <= arrayData[i + 1]) {
             return i;
         }
-        if (sort===-1 && arrayData[i]>=psi_m && psi_m>=arrayData[i+1]){
+        // monotonically decreasing array data
+        if (sort === -1 && arrayData[i] >= psi_m && psi_m >= arrayData[i + 1]) {
             return i;
 
         }
     }
 
-    //no range found, the psi_m is outside of the indexVector's range
+    // no range found, the psi_m is outside the indexVector's range
     return -1;
 }
 
-
-
-
-
 /**
- *
- * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
- * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
- * Thus, the k value referenced in the paper is 3 here
- *
- *                      N
- *  omega  = x_3 = s_3* ∑ [ m3_j * (p_j - r_j) ]
- *                      j=1
- *
- *  lamda = lambda_r + omega
- *
- *  lambda_r : is the reference value,  given by CRVAL3
  *
  * Get pixel at given "ImagePt" coordinates
  *   "ImagePt" coordinates have 0,0 lower left corner of lower left pixel
@@ -603,7 +506,7 @@ function isSorted(intArray) {
  *
  * @param {ImagePt} ipt
  * @param {number} cubeIdx
- * @return {Array.<number>}
+ * @return {Array.<number>}  center of pixel coordinates
  */
 function getPixelCoords(ipt, cubeIdx) {
 
@@ -611,17 +514,17 @@ function getPixelCoords(ipt, cubeIdx) {
     //starts from 0.  Thus, 1 is added here.
     //pixel numbers refer to the center of the pixel, so we subtract 0.5, see notes above
     const p0 = ipt ? Math.round(ipt.x - 0.5) + 1 : 0;
-    const p1 = ipt ? Math.round(ipt.y - 0.5) + 1  : 0;
-    return [p0, p1, cubeIdx+1]; //since cubeIdx starts from 0
+    const p1 = ipt ? Math.round(ipt.y - 0.5) + 1 : 0;
+    return [p0, p1, cubeIdx + 1]; //since cubeIdx starts from 0
 }
 
 /**
- *
+ * Get intermediate world coordinate. (See Fig.1 in WCS Paper 1.)
  * The algorithm is based on the fact that the spectral data is stored in the naxis3.  The naxis1, ctype1:ra
  * naxis2, ctype2: dec, naxis3, ctype3 : wavelength
  * Thus, the k value referenced in the paper is 3 here
- *                      N
- *  omega  = x_3 = s_3* ∑ [ PC3_j * (p_j - r_j) ]
+ *                       N
+ *  omega  = x_3 = s_3 * ∑ [ PC3_j * (p_j - r_j) ]
  *                      j=1
  *
  *  N: is the dimensionality of the WCS representation given by NAXIS or WCSAXES
@@ -630,22 +533,19 @@ function getPixelCoords(ipt, cubeIdx) {
  *  s_3: is a scaling factor given by CDELT3
  *  m3_j: is a linear transformation matrix given either by PC3_j or CD3_j
  *
- *
  * @param pixCoords: pixel coordinates, normally this will be an array [imagePt.x,imagePt.y,plane]
  * @param {number} N
  * @param {Array.<number>} r_j: r j are pixel coordinates of the reference point given by CRPIX j
  * @param {Array.<number>} pc_3j: PC_3j matrix, if length=3 array and first two entries are 0,
  * then probably all pixels on the plane have the same value
- * @param {Number} s_3: CDETl3 value
+ * @param {Number} s_3: CDELT3 value
  * @return number
  */
 
-function getOmega(pixCoords, N,  r_j, pc_3j, s_3){
-    //if (!pc_3j || !r_j ) return s_3*(pixCoords[0]+pixCoords[1]);
-
-    let omega =0.0;
-    for (let i=0; i<N; i++){
-        omega += s_3 * pc_3j[i] * (pixCoords[i]-r_j[i]);
+function getOmega(pixCoords, N, r_j, pc_3j, s_3) {
+    let omega = 0.0;
+    for (let i = 0; i < N; i++) {
+        omega += s_3 * pc_3j[i] * (pixCoords[i] - r_j[i]);
     }
     return omega;
 }

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -24,16 +24,16 @@ import {isDefined} from '../../util/WebUtil.js';
  * @param {Array.<WavelengthTabRelatedData>} wlTableRelatedAry
  * @return {*}
  */
-export function parseWavelengthHeaderInfo(header, altWcs='', zeroHeader, wlTableRelatedAry) {
-    const parse= makeDoubleHeaderParse(header, zeroHeader, altWcs);
-    const which= altWcs?'1':getWCSAXES(parse);
-    const whatType= parse.getValue(`CTYPE${which}${altWcs}`, ' ');
-    const mijMatrixKeyRoot = getPC_ijKey(parse,which);
+export function parseWavelengthHeaderInfo(header, altWcs = '', zeroHeader, wlTableRelatedAry) {
+    const parse = makeDoubleHeaderParse(header, zeroHeader, altWcs);
+    const which = altWcs ? '1' : getWCSAXES(parse);
+    const whatType = parse.getValue(`CTYPE${which}${altWcs}`, ' ');
+    const mijMatrixKeyRoot = getPC_ijKey(parse, which);
     if (!mijMatrixKeyRoot) return; //When both PC i_j and CD i_j are present, we don't show the wavelength
-    const table= findWLTableToMatch(parse,altWcs,which,wlTableRelatedAry);
+    const table = findWLTableToMatch(parse, altWcs, which, wlTableRelatedAry);
     if (whatType.toUpperCase().startsWith('WAVE')) {
         return calculateWavelengthParams(parse, altWcs, which, mijMatrixKeyRoot, table);
-    } else if (whatType.toUpperCase()===VRAD) {
+    } else if (whatType.toUpperCase() === VRAD) {
         return calculateVradParams(parse, altWcs, which, mijMatrixKeyRoot, table);
     }
 }
@@ -41,19 +41,15 @@ export function parseWavelengthHeaderInfo(header, altWcs='', zeroHeader, wlTable
 
 function findWLTableToMatch(parse, altWcs, which, wlTableRelatedAry) {
     if (!wlTableRelatedAry?.length) return;
-    const tName= parse.getValue(`PS${which}_0${altWcs}`);
-    return wlTableRelatedAry.find( (entry) => entry.hduName===tName)?.table;
+    const tName = parse.getValue(`PS${which}_0${altWcs}`);
+    return wlTableRelatedAry.find((entry) => entry.hduName === tName)?.table;
 }
 
-// const isWaveParseDependent = (algorithm) => algorithm===LINEAR || algorithm===LOG  || algorithm===F2W  ||
-//                                             algorithm===V2W  || algorithm===TAB;
-//
-// const isVradParseDependent = (algorithm) => algorithm===LINEAR;
 
-const allGoodValues= (...numbers)  => numbers.every((n) => !isNaN(n));
+const allGoodValues = (...numbers) => numbers.every((n) => !isNaN(n));
 
 
-const L_10= Math.log(10);
+const L_10 = Math.log(10);
 
 /**
  * According to A&A 395, 1061-1075 (2002) DOI: 10.1051/0004-6361:20021326
@@ -71,15 +67,15 @@ const L_10= Math.log(10);
  * @param which
  * @returns {*}
  */
-function getPC_ijKey(parser,which){
+function getPC_ijKey(parser, which) {
 
     const hasPC = parser.hasKeyStartWith(`PC${which}_`);
     const hasCD = parser.hasKeyStartWith(`CD${which}_`);
 
-    if (hasPC && hasCD){
+    if (hasPC && hasCD) {
         return undefined;
     }
-    if (!hasPC && hasCD){
+    if (!hasPC && hasCD) {
         return 'CD';
     }
     return 'PC';
@@ -96,22 +92,20 @@ function getPC_ijKey(parser,which){
  * @param parse
  * @returns {*}
  */
-function getWCSAXES(parse){
-    const  wcsAxis = parse.getValue('WCSAXES');
+function getWCSAXES(parse) {
+    const wcsAxis = parse.getValue('WCSAXES');
 
     if (wcsAxis) return wcsAxis;
 
-    const nAxis= parse.getIntValue('NAXIS');
+    const nAxis = parse.getIntValue('NAXIS');
 
-    const ctype= parse.getValue(`CTYPE${nAxis+1}`, undefined);
+    const ctype = parse.getValue(`CTYPE${nAxis + 1}`, undefined);
 
-    if(ctype){
-        return (nAxis+1).toString();
-    }
-    else{
+    if (ctype) {
+        return (nAxis + 1).toString();
+    } else {
         return nAxis.toString();
     }
-
 }
 
 /**
@@ -129,11 +123,11 @@ function getWCSAXES(parse){
  *   i: the wcsaxes's value, if the wcsaxes = 2, then i=2
  *   j: 0, ...N
  *   If any of the PC_ij is not defined in the header, the following default is assigned:
- *   1.  PC i_j = 	1.0 when i = j
+ *   1.  PC i_j =    1.0 when i = j
  *   2.  PC i_j = 0.0 when i!=j
  *
  *  If instead of using PC, CD is used, the following default is assigned:
- *  CD i_j	0.0  NOTE: CD i_j's default is different from PC i_j
+ *  CD i_j    0.0  NOTE: CD i_j's default is different from PC i_j
  *
  *
  *  r_j: An array of the CRPIX values, the size of the dimension is N.  N is defined by
@@ -149,17 +143,17 @@ function getWCSAXES(parse){
  * @param N
  * @returns {Array}
  */
-function applyDefaultValues(inArr, keyRoot, which, N){
-    const retAry=[];
-    for (let i=0; i<N; i++) {
-        if (inArr && isDefined(inArr[i]) && !isNaN(inArr[i])){
+function applyDefaultValues(inArr, keyRoot, which, N) {
+    const retAry = [];
+    for (let i = 0; i < N; i++) {
+        if (isDefined(inArr?.[i]) && !isNaN(inArr[i])) {
             //if inArr is defined and it has a valid value
-            retAry[i]=inArr[i];
+            retAry[i] = inArr[i];
             continue;
         }
         switch (keyRoot) { //either inArr is undefined, or inArr[i] is undefined
             case 'PC':
-                retAry[i] = (i+1) === parseInt(which)? 1:0;
+                retAry[i] = (i + 1) === parseInt(which) ? 1 : 0;
                 break;
             case 'CRPIX' || 'CD':
                 retAry[i] = 0.0;
@@ -168,11 +162,12 @@ function applyDefaultValues(inArr, keyRoot, which, N){
     }
     return retAry;
 }
-function isWaveLength(ctype, pc_3j){
 
-    if (ctype.trim()==='') return false;
+function isWaveLength(ctype, pc_3j) {
 
-    const sArray= ctype.split('-');
+    if (ctype.trim() === '') return false;
+
+    const sArray = ctype.split('-');
 
     if (sArray[0] !== 'WAVE') return false;
 
@@ -184,14 +179,14 @@ function isWaveLength(ctype, pc_3j){
 }
 
 /**
- * Get the key Spectra headers 
+ * Get the key Spectra headers
  * @param parse
  * @param {string} altWcs one character alternative WCS version, '' for primary
  * @param {number} which index of the world coordinate
  * @param {string} defaultUnits default units
  * @returns {*}
  */
-function getCoreSpectralHeaders(parse, altWcs, which, defaultUnits='') {
+function getCoreSpectralHeaders(parse, altWcs, which, defaultUnits = '') {
     const ctype = parse.getValue(`CTYPE${which}${altWcs}`, ' ');
     const units = parse.getValue(`CUNIT${which}${altWcs}`, defaultUnits);
     const crpix = parse.getDoubleValue(`CRPIX${which}${altWcs}`, 0.0);
@@ -201,6 +196,7 @@ function getCoreSpectralHeaders(parse, altWcs, which, defaultUnits='') {
     const N = parse.getIntOneOfValue(['WCSAXES', 'WCSAXIS', 'NAXIS'], -1);
     return {ctype, units, crpix, crval, cdelt, nAxis, N};
 }
+
 /**
  * NOTE:
  *   pc_3j, means the the wavelength axis is 3.  In fact, the wavelength can be in any axis.
@@ -223,29 +219,29 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key, wlTable) {
     * CUNIT i	' ' (i.e. undefined)
     * NOTE: i is the which variable here.
     */
-    const {ctype, units, crpix, crval, cdelt, nAxis, N}= getCoreSpectralHeaders(parse, altWcs, which);
-    const restWAV= parse.getDoubleValue('RESTWAV'+altWcs, 0);
-    let pc_3j = parse.getDoubleAry(`${pc_3j_key}${which}_`,altWcs,1,N, undefined);
-    let r_j = parse.getDoubleAry('CRPIX',altWcs,1,N, undefined);
+    const {ctype, units, crpix, crval, cdelt, nAxis, N} = getCoreSpectralHeaders(parse, altWcs, which);
+    const restWAV = parse.getDoubleValue('RESTWAV' + altWcs, 0);
+    let pc_3j = parse.getDoubleAry(`${pc_3j_key}${which}_`, altWcs, 1, N, undefined);
+    let r_j = parse.getDoubleAry('CRPIX', altWcs, 1, N, undefined);
 
     //check if any value is not defined, use default
-    pc_3j = applyDefaultValues(pc_3j,pc_3j_key, which, N);
-    r_j   = applyDefaultValues(r_j, 'CRPIX', which, N);
+    pc_3j = applyDefaultValues(pc_3j, pc_3j_key, which, N);
+    r_j = applyDefaultValues(r_j, 'CRPIX', which, N);
 
-    const ps3_0= parse.getValue(`PS${which}_0${altWcs}`, '');
-    const ps3_1= parse.getValue(`PS${which}_1${altWcs}`, '');
-    const ps3_2= parse.getValue(`PS${which}_2${altWcs}`, '');
+    const ps3_0 = parse.getValue(`PS${which}_0${altWcs}`, '');
+    const ps3_1 = parse.getValue(`PS${which}_1${altWcs}`, '');
+    const ps3_2 = parse.getValue(`PS${which}_2${altWcs}`, '');
     //pv3_1: EXTLEVEL, pv3_2: EXTVER, pv3_3: axis number associated with the coordinate array in ps3_1
     //The pv3_i values are not used in our case, since we only handle the FITS with one axis related to TAB wavelength.
     //We processed those values just in case there is need to handle the FITS with more than one TAB axes.
-    const pv3_1= parse.getValue(`PV${which}_1${altWcs}`, '');
-    const pv3_2= parse.getValue(`PV${which}_2${altWcs}`, '');
-    const pv3_3= parse.getValue(`PV${which}_3${altWcs}`, '');
+    const pv3_1 = parse.getValue(`PV${which}_1${altWcs}`, '');
+    const pv3_2 = parse.getValue(`PV${which}_2${altWcs}`, '');
+    const pv3_3 = parse.getValue(`PV${which}_3${altWcs}`, '');
 
     const {algorithm, wlType} = getAlgorithmAndType(ctype, N);
 
 
-    const canDoPlaneCalc= allGoodValues(crpix, crval, cdelt && nAxis===3);
+    const canDoPlaneCalc = allGoodValues(crpix, crval, cdelt && nAxis === 3);
 
     // We only support the standard format in the FITS header. The standard means the CTYPEka='WAVE-ccc" where
     // ccc can be 'F2W', 'V2W', 'LOG', 'TAB' or empty that means linear. If the header does not have this kind
@@ -256,21 +252,21 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key, wlTable) {
     const isWL = isWaveLength(ctype, pc_3j);
 
     //If it is a cube plane FITS, plot and display the wavelength at each plane
-    if (canDoPlaneCalc && nAxis===3  &&  (!isWL || isWL && algorithm==='TAB') ) {
+    if (canDoPlaneCalc && nAxis === 3 && (!isWL || isWL && algorithm === 'TAB')) {
         /* There are two cases for wavelength planes:
         *  1. The FITS has wavelength planes, and each plane has the same wavelength, ie. the third axis
         *     is wavelength.  Then the algorithm is PLANE
         *  2. The FITS has wavelength planes,and the wavelength on each plane is changing with the image point
         *     position.  For example, the algorithm is TAB.
         */
-        const algorithmForPlane = isWL? algorithm: PLANE;
+        const algorithmForPlane = isWL ? algorithm : PLANE;
         //const wlType = whichType;
         //todo - if we are not table then we will table plan
-        if (algorithm!=='TAB' ) {
-            return makeSimplePlaneBased(crpix, crval, cdelt,nAxis, algorithmForPlane, wlType, units,
+        if (algorithm !== 'TAB') {
+            return makeSimplePlaneBased(crpix, crval, cdelt, nAxis, algorithmForPlane, wlType, units,
                 'use PLANE since is cube and parameters missing');
         }
-        return  {
+        return {
             N, algorithm, ctype, restWAV, pc_3j, r_j,
             ps3_0, ps3_1, ps3_2, pv3_1, pv3_2, pv3_3,
             crpix, crval, cdelt, nAxis, wlType, units,
@@ -287,24 +283,23 @@ function calculateWavelengthParams(parse, altWcs, which, pc_3j_key, wlTable) {
      *  3. The FITS file is not wavelength type (may be plane)
      *
      */
-    if (!algorithm || !wlType  || !isWL) return;
+    if (!algorithm || !wlType || !isWL) return;
 
 
-    if (algorithm===LOG){  //the values in CRPIXk and CDi_j (PC_i_j) are log based on 10 rather than natural log, so a factor is needed.
-        r_j && (r_j= r_j.map( (v) => v*L_10));
-        pc_3j && (pc_3j= pc_3j.map( (v) => v*L_10));
+    if (algorithm === LOG) {  //the values in CRPIXk and CDi_j (PC_i_j) are log based on 10 rather than natural log, so a factor is needed.
+        r_j && (r_j = r_j.map((v) => v * L_10));
+        pc_3j && (pc_3j = pc_3j.map((v) => v * L_10));
     }
 
-    let failReason= '';
-    let failWarning= '';
+    let failReason = '';
+    let failWarning = '';
     if (N < 0) {
-        failReason+= 'Dimension value is not available, must be NAXIS or WCSAXES';
-    }
-    else {
+        failReason += 'Dimension value is not available, must be NAXIS or WCSAXES';
+    } else {
         // if (!pc_3j) failReason+= `, PC3_i${altWcs} or CD3_i${altWcs} is not defined`;
         // if (!r_j) failReason+= `, CRPIXi${altWcs} is not defined`;
-        if (!pc_3j) failWarning+= `, PC3_i${altWcs} or CD3_i${altWcs} is not defined`;
-        if (!r_j) failWarning+= `, CRPIXi${altWcs} is not defined`;
+        if (!pc_3j) failWarning += `, PC3_i${altWcs} or CD3_i${altWcs} is not defined`;
+        if (!r_j) failWarning += `, CRPIXi${altWcs} is not defined`;
     }
 
     return {
@@ -332,29 +327,28 @@ function calculateVradParams(parse, altWcs, which, pc_3j_key, vradTable) { // es
     * Only consider VRAD plane case for now
     * the pc_3j_key, vradTalble not used in Plane case
     */
-    const { ctype, units, crpix, crval, cdelt, nAxis} = getCoreSpectralHeaders(parse, altWcs, which, 'm/s');
+    const {ctype, units, crpix, crval, cdelt, nAxis} = getCoreSpectralHeaders(parse, altWcs, which, 'm/s');
     const {algorithm, wlType} = getAlgorithmAndType(ctype);
 
     //If it is a cube plane FITS, plot and display the Vrad at each plane
-    if (allGoodValues(crpix, crval, cdelt) && nAxis===3) {
-        return makeSimplePlaneBased(crpix, crval, cdelt, nAxis, algorithm, wlType, units, 'use PLANE since is cube and parameters missing');
+    if (allGoodValues(crpix, crval, cdelt) && nAxis === 3) {
+        return makeSimplePlaneBased(crpix, crval, cdelt, nAxis, algorithm, wlType, units,
+            'use PLANE since is cube and parameters missing');
     }
-
-    //If it is a cube plane FITS, plot and display the VRAD at each plane
-    //if (!algorithm || !wlType  || !isVR) return;
-
-    //Adding other VRAD algorithm and conversions here
-
 }
 
 function makeSimplePlaneBased(crpix, crval, cdelt, nAxis, algorithm, wlType, units, reason) {
-    if (allGoodValues(crpix, crval, cdelt) && nAxis === 3 ) {
+    if (allGoodValues(crpix, crval, cdelt) && nAxis === 3) {
         //return {algorithm: PLANE, wlType: wlType || WAVE, crpix, crval, cdelt, units, reason};
 
-        return {algorithm, wlType, crpix, crval, cdelt, units, reason, planeOnlyWL:true};
-    }
-    else {
-        return {algorithm: undefined, wlType, failReason: 'CTYPE3, CRVAL3, CDELT3 are required for simple and NAXIS===3', failReason2: reason};
+        return {algorithm, wlType, crpix, crval, cdelt, units, reason, planeOnlyWL: true};
+    } else {
+        return {
+            algorithm: undefined,
+            wlType,
+            failReason: 'CTYPE3, CRVAL3, CDELT3 are required for simple and NAXIS===3',
+            failReason2: reason
+        };
     }
 }
 
@@ -367,30 +361,29 @@ function makeSimplePlaneBased(crpix, crval, cdelt, nAxis, algorithm, wlType, uni
  * @param {String} ctype3
  * @return {{algorithm:string,wlType:string}}
  */
-function getAlgorithmAndType(ctype3){
+function getAlgorithmAndType(ctype3) {
     // let wlType, vradType, algorithm;
     // It is temporary to include Vrad under wlType
     // need to do generic spectral header parser
     let wlType, algorithm;
-    if (!ctype3.trim()) return {algorithm:undefined,wlType:undefined};
-    ctype3= ctype3.toUpperCase();
+    if (!ctype3.trim()) return {algorithm: undefined, wlType: undefined};
+    ctype3 = ctype3.toUpperCase();
     const sArray = ctype3.split('-');
 
     if (ctype3.startsWith(WAVE) || ctype3.startsWith(AWAV)) {
-        if (ctype3.startsWith(WAVE)) wlType= WAVE;
-        else if (ctype3.startsWith(AWAV)) wlType= AWAV;
+        if (ctype3.startsWith(WAVE)) wlType = WAVE;
+        else if (ctype3.startsWith(AWAV)) wlType = AWAV;
 
-        if (sArray.length===1) algorithm= LINEAR;
-        else if (sArray[1].trim()===LOG) algorithm=LOG;
-        else algorithm=sArray[1];
-    }
-    else if (ctype3.startsWith('LAMBDA')) {
-        wlType= WAVE;
-        algorithm= LINEAR;
+        if (sArray.length === 1) algorithm = LINEAR;
+        else if (sArray[1].trim() === LOG) algorithm = LOG;
+        else algorithm = sArray[1];
+    } else if (ctype3.startsWith('LAMBDA')) {
+        wlType = WAVE;
+        algorithm = LINEAR;
     } else if (ctype3.startsWith('VRAD')) {
-        wlType= VRAD;
-        algorithm= PLANE;
+        wlType = VRAD;
+        algorithm = PLANE;
     }
-    return {algorithm,wlType};
+    return {algorithm, wlType};
 }
 

--- a/src/firefly/js/visualize/projection/__tests__/WaveTab-test.js
+++ b/src/firefly/js/visualize/projection/__tests__/WaveTab-test.js
@@ -1,0 +1,53 @@
+import assert from 'assert';
+import {searchIndex, calculateY_m, calculateC_m} from '../Wavelength.js';
+
+const indexVecUp = [50, 100, 100, 200]; // monotonously increasing
+const indexVecDown = [200, 100, 100, 50]; // monotonously decreasing
+
+test('Test searchIndex',   ()=> {
+    const input = [25, 50, 75, 100, 150, 200, 225];
+    const expectedAsc = [-1, 0, 0, 0, 2, 2, -1];
+    const expectedDesc = [-1, 2, 2, 0, 0, 0, -1];
+
+    input.forEach((x, i)  => {
+        const val = searchIndex(indexVecUp, x, 1);
+        assert.equal(val, expectedAsc[i], 'searchIndex asc ' + i);
+    });
+
+    input.forEach((x, i)  => {
+        const val = searchIndex(indexVecDown, x, -1);
+        assert.equal(val, expectedDesc[i], 'searchIndex desc ' + i);
+    });
+});
+
+test('Test calculateY_m',   ()=> {
+    const input = [24, 25, 50, 75, 100, 150, 200, 250, 251];
+    const expectedAsc = [undefined, 0.5, 1, 1.5, 2, 3.5, 4, 4.5, undefined];
+    const expectedDesc = [undefined, 4.5, 4, 3.5, 2, 1.5, 1, 0.5, undefined];
+
+    input.forEach((x, i)  => {
+        const val = calculateY_m(indexVecUp, x);
+        assert.equal(val, expectedAsc[i], 'calculateY_m asc ' + i);
+    });
+
+    input.forEach((x, i)  => {
+        const val = calculateY_m(indexVecDown, x);
+        assert.equal(val, expectedDesc[i], 'calculateY_m desc ' + i);
+    });
+});
+
+test('Test calculateC_m',   ()=> {
+    const input = [0.4, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 4.6];
+    const expectedAsc = [undefined, 25, 50, 75, 100, 100, 100, 150, 200, 250, undefined];
+    const expectedDesc = [undefined, 250, 200, 150, 100, 100, 100, 75, 50, 25, undefined];
+
+    input.forEach((x, i)  => {
+        const val = calculateC_m(x, indexVecUp, 4);
+        assert.equal(val, expectedAsc[i], 'calculateC_m asc '+i);
+    });
+
+    input.forEach((x, i)  => {
+        const val = calculateC_m(x, indexVecDown, 4);
+        assert.equal(val, expectedDesc[i], 'calculateC_m desc '+i);
+    });
+});

--- a/src/firefly/js/visualize/projection/__tests__/Wavelength-test.js
+++ b/src/firefly/js/visualize/projection/__tests__/Wavelength-test.js
@@ -1,19 +1,19 @@
 import assert from 'assert';
 import {parseWavelengthHeaderInfo} from '../WavelengthHeaderParser.js';
-import { getJsonFiles} from './Projection-test.js';
-import {getWavelength, LOG} from '../Wavelength.js';
+import {getJsonFiles} from './Projection-test.js';
+import {getWavelength} from '../Wavelength.js';
 import {makeWorldPt} from '../../Point.js';
 import {getHeader} from '../../FitsHeaderUtil.js';
 import {RDConst} from 'firefly/visualize/WebPlot.js';
 
 const fs = require('fs');
-const precision=10;
+const precision = 10;
 /**
  * This is the unit test suits for Wavelength.  For each algorithm, the expected value is calculated independently based
  * on the algorithm in the reference paper and the known header data values.
  *
  * For Linear, Log, F2W, V2W, the four known points (pointArray) are used.
- * For TAB, the known simulated testing data "wavelengthTable.fits" stored in firefly_test_data under the same path as
+ * For TAB, the known simulated testing data wavelengthTable.fits stored in firefly_test_data under the same path as
  * projection is used.  The coordinates and index arrays are known and so are the psi_m and the pixIndex array.
  * The expected value is calculated according to the algorithm in the reference paper.
  *
@@ -25,225 +25,75 @@ const precision=10;
  * the utility class FitsHeaderToJson.java.
  *
  */
-const pointArray=[
-   {ra: 66.5375697, dec: 66.1379036},
-   {ra:153.0763342, dec:-30.4940466},
-   {ra:233.5892165, dec:-49.1636287},
-   {ra: 63.6285129, dec: -3.5576294}
+const pointArray = [
+    {ra: 66.5375697, dec: 66.1379036},
+    {ra: 153.0763342, dec: -30.4940466},
+    {ra: 233.5892165, dec: -49.1636287},
+    {ra: 63.6285129, dec: -3.5576294}
 ];
-/**
- * This is the two arrays in the wlTable that used for unit testing
- */
-const coords=[
-0.93842,
-0.80334,
-0.48544,
-0.24423,
-0.8719,
-0.33002,
-0.10626,
-0.5729,
-0.2104,
-0.0198,
-300.84592,
-300.63605,
-300.18134,
-300.51,
-300.27945,
-300.03137,
-300.06183,
-300.9286,
-300.3224,
-300.4762,
-300.0438,
-300.43887,
-300.36633,
-300.35422,
-300.5422,
-300.49628,
-300.9784,
-300.25714,
-300.23654,
-300.6987,
-300.54196,
-300.17014,
-300.40082,
-300.76392,
-300.41455,
-300.33228,
-300.58975,
-300.54297,
-300.80682,
-300.59067,
-300.04755,
-300.2681,
-300.82596,
-300.91806,
-300.54764,
-300.3925,
-300.10175,
-300.4943,
-300.89313,
-300.25214,
-300.287,
-300.27628,
-300.13312,
-300.4609,
-300.75735,
-300.50327,
-300.16064,
-300.00058,
-300.59317,
-300.30023,
-300.08948,
-300.549,
-300.00647,
-300.07312,
-300.76205,
-300.74362,
-300.2954,
-300.79175,
-300.20938,
-300.28116,
-300.90735,
-300.9193,
-300.1779,
-300.8492,
-300.97272,
-300.44876,
-300.75287,
-300.89493,
-300.49915,
-300.96185,
-300.1626,
-300.65762,
-300.64664,
-300.99368,
-300.12363,
-300.39447,
-300.1654,
-300.2791,
-300.2836,
-300.33493,
-300.9119,
-300.8512,
-300.10233,
-300.95352,
-300.64737,
-300.83862,
-300.65298,
-300.698,
-300.2936,
-300.11954];
 
-const indexVec=[
-0.0,
-1.0,
-2.0,
-3.0,
-4.0,
-5.0,
-6.0,
-7.0,
-8.0,
-9.0,
- 10.0,
- 11.0,
- 12.0,
- 13.0,
- 14.0,
- 15.0,
- 16.0,
- 17.0,
- 18.0,
- 19.0,
- 20.0,
- 21.0,
- 22.0,
- 23.0,
- 24.0,
- 25.0,
- 26.0,
- 27.0,
- 28.0,
- 29.0,
- 30.0,
- 31.0,
- 32.0,
- 33.0,
- 34.0,
- 35.0,
- 36.0,
- 37.0,
- 38.0,
- 39.0,
- 40.0,
- 41.0,
- 42.0,
- 43.0,
- 44.0,
- 45.0,
- 46.0,
- 47.0,
- 48.0,
- 49.0,
- 50.0,
- 51.0,
- 52.0,
- 53.0,
- 54.0,
- 55.0,
- 56.0,
- 57.0,
- 58.0,
- 59.0,
- 60.0,
- 61.0,
- 62.0,
- 63.0,
- 64.0,
- 65.0,
- 66.0,
- 67.0,
- 68.0,
- 69.0,
- 70.0,
- 71.0,
- 72.0,
- 73.0,
- 74.0,
- 75.0,
- 76.0,
- 77.0,
- 78.0,
- 79.0,
- 80.0,
- 81.0,
- 82.0,
- 83.0,
- 84.0,
- 85.0,
- 86.0,
- 87.0,
- 88.0,
- 89.0];
+// data for TAB algorithm test
+// 5x5 image with wavelength changing in y direction (along NAXIS2)
+const jsonTAB = {
+    'wlTable': {
+        'tableData': {
+            'data': {'0': [[0,2,4], [10,18,20]]},
+            'columns': [
+                {'name':'INDEX','arraySize':'3','type':'float'},
+                {'name':'COORDS','arraySize':'3','type':'float'}
+            ]
+        }},
+    'header':{
+        // only NAXIS mattter in this section
+        'NAXIS':{'comment':'number of array dimensions','value':'2'},
+        'NAXIS1':{'value':5},
+        'NAXIS2':{'value':5},
 
-//This is the points to test WAVE_TAB
-const tabPointArray=[
-    {x: 1744, y: 1069},
-    {x:1371, y:1032},
-    {x:1040, y:1067}
+        'WCSAXESw':{'value':'1'},
+        'WCSNAMEw':{'value':'SPECTRAL'},
+        'CTYPE1w':{'value':'WAVE-TAB'},
+        'CUNIT1w':{'value':'m'},
+        'PS1_0w':{'comment':'table extension name','value':'WCS-table'},
+        'PS1_1w':{'comment':'table version number','value':'COORDS'},
+        'PS1_2w':{'comment':'table level number','value':'INDEX'},
+        'PV1_1w':{'comment':'column for coordinate array','value':'1'},
+        'PV1_2w':{'comment':'column for indexing vector','value':'1'},
+        'PV1_3w':{'comment':'axis number','value':'1'},
+
+        // CRPIXj is 0 by default
+        // we only care about second pixel coordinate
+        'CRPIX2w':{'comment':'Pixel coordinate of reference point','value':'1'},
+        // in our case, CRVAL1w should match the first index in the index array
+        'CRVAL1w':{'comment':'Coordinate value at reference point','value':'0'},
+        'CDELT1w':{'comment':'Coordinate increment at reference point','value':'1'},
+
+        // PCi_j: linear transformation matrix between Pixel Axes j
+        //  and Intermediate-coordinate Axes i
+        //  default values of PCi_j is 1 where i=j and 0 where i!=j
+        'PC1_1w':{'value':'0'},
+        'PC1_2w':{'value':'1'},
+    }
+};
+
+// image points for TAB algorithm test
+// the wavelength is changing in y direction, x does not matter
+const pointArrayTAB=[
+    {x: 0, y: 0},
+    {x: 1, y: 1},
+    {x: 2, y: 2},
+    {x: 3, y: 3},
+    {x: 4, y: 4}
 ];
-//psi_m = lambda_r + cdelt* omega;
-const psi_mAry=[72.500000961253,17.000000851964,69.500000754981 ];
-const pixIdxAry=[73, 18, 70];
+
+// expected wavelength for tab algorithm test
+const expectedWlTAB = [10, 14, 18, 19, 20];
 
 /**
  * This is the testing data location.  The testing data is generated using java FitsHeaderToJson class.
  * The main function in ProjectionTest.java created the json files for Wavelength unit test
  * @type {string}
  */
-const JAVA_TEST_DATA_PATH='firefly_test_data/edu/caltech/ipac/visualize/plot/projection/';
+const JAVA_TEST_DATA_PATH = 'firefly_test_data/edu/caltech/ipac/visualize/plot/projection/';
 
 /**
  * This method gets the testing json file the corresponding algorithm
@@ -251,93 +101,94 @@ const JAVA_TEST_DATA_PATH='firefly_test_data/edu/caltech/ipac/visualize/plot/pro
  * @param fileName
  * @returns {*}
  */
-function getTestJsonFile(allFiles, fileName){
-    for (let i=0; i<allFiles.length; i++){
-        if (allFiles[i].toLowerCase().includes(fileName.toLowerCase())){
+function getTestJsonFile(allFiles, fileName) {
+    for (let i = 0; i < allFiles.length; i++) {
+        if (allFiles[i].toLowerCase().includes(fileName.toLowerCase())) {
             return allFiles[i];
         }
     }
-
 }
 
-function getPixelCoordinates(pt, header){
-    let px = Math.round(pt.x - 0.5) +1 ;//x
-    let py = Math.round(pt.y - 0.5) +1; //y
+function getPixelCoordinates(pt, header) {
+    const px = Math.round(pt.x - 0.5) + 1; //x
+    const py = Math.round(pt.y - 0.5) + 1; //y
 
-    let pz = getHeader(header,'SPOT_PL',0 ) + 1 ;//header.get('SPOT_PL', 0) + 1 ;
+    const pz = getHeader(header, 'SPOT_PL', '0') + 1; //header.get('SPOT_PL', 0) + 1 ;
 
     return [px, py, pz];
 }
-function  getOmega(pixCoords, N, r_j, pc_3j, s_3){
-    let omega=0;
-    for (let i=0; i<N; i++){
-        omega += s_3 * pc_3j[i] * (pixCoords[i]-r_j[i]);
+
+function getOmega(pixCoords, N, r_j, pc_3j, s_3) {
+    let omega = 0;
+    for (let i = 0; i < N; i++) {
+        omega += s_3 * pc_3j[i] * (pixCoords[i] - r_j[i]);
     }
     return omega;
 }
 
-function getParamValues(header,algorithm){
+function getParamValues(header, algorithm) {
 
-    let N = parseInt(getHeader(header, 'WCSAXES', -1));
-    if (N==-1){
-        N=parseInt(getHeader(header, 'NAXIS', -1));
+    let N = parseInt(getHeader(header, 'WCSAXES', '-1'));
+    if (N === -1) {
+        N = parseInt(getHeader(header, 'NAXIS', '-1'));
     }
-    if (N==-1) return undefined;
+    if (N === -1) return undefined;
 
 
-    let r_j = [];
-    let  pc_3j = [];
+    const r_j = [];
+    const pc_3j = [];
     //The pi_j can be either CDi_j or PCi_j, so we have to test both
     for (let i = 0; i < N; i++) {
-        r_j[i] = parseFloat(getHeader(header, 'CRPIX' + (i+1), undefined));
+        r_j[i] = parseFloat(getHeader(header, 'CRPIX' + (i + 1), undefined));
 
         //matrix mij can be either PCij or CDij
-        pc_3j[i]=parseFloat(getHeader(header, 'PC3' +'_'+ (i+1), undefined));
-        if (pc_3j[i]===undefined) {
-            pc_3j[i]=parseFloat(getHeader(header, 'CD3' +'_'+ (i+1), undefined));
+        pc_3j[i] = parseFloat(getHeader(header, 'PC3' + '_' + (i + 1), undefined));
+        if (pc_3j[i] === undefined) {
+            pc_3j[i] = parseFloat(getHeader(header, 'CD3' + '_' + (i + 1), undefined));
         }
 
-        if (r_j[i]===undefined){
+        if (r_j[i] === undefined) {
             throw Error('CRPIXka  is not defined');
         }
-        if ( pc_3j[i]===undefined ){
+        if (pc_3j[i] === undefined) {
             throw Error('Either PC3_i or CD3_i has to be defined');
         }
 
-        if (algorithm==='LOG'){
+        if (algorithm === 'LOG') {
             //the values in CRPIXk and CDi_j (PC_i_j) are log based on 10 rather than natural log, so a factor is needed.
-            r_j[i] *=Math.log(10);
-            pc_3j[i] *=Math.log(10);
+            r_j[i] *= Math.log(10);
+            pc_3j[i] *= Math.log(10);
         }
     }
 
-    let s_3 = parseFloat(getHeader(header, 'CDELT3', 0));
-    let lambda_r =parseFloat(getHeader( header, 'CRVAL3', 0.0));
-    return {N, r_j, pc_3j, s_3,  lambda_r};
+    const cdelt = parseFloat(getHeader(header, 'CDELT3', '0'));
+    const crval = parseFloat(getHeader(header, 'CRVAL3', '0.0'));
+    return {N, r_j, pc_3j, cdelt, crval};
 }
+
 //this is to implement the wavelength independently to verify the wavelength implementation
-function calculatedExpectedValue(pt, algorithm, header){
+function calculatedExpectedValue(pt, algorithm, header) {
 
-     let pixCoords = getPixelCoordinates(pt, header);
-     const {N, r_j, pc_3j, s_3,  lambda_r} = getParamValues(header,algorithm);
+    const pixCoords = getPixelCoordinates(pt, header);
+    const {N, r_j, pc_3j, cdelt, crval} = getParamValues(header, algorithm);
 
-    let omega = getOmega(pixCoords,  N, r_j, pc_3j, s_3);
+    const omega = getOmega(pixCoords, N, r_j, pc_3j, cdelt);
     let wl;
-    switch( algorithm.toUpperCase()){
+    switch (algorithm.toUpperCase()) {
         case 'LINEAR':
-            wl= lambda_r + omega;
+            wl = crval + omega;
             break;
         case 'LOG':
-            wl=lambda_r* Math.exp(omega/lambda_r);
+            wl = crval * Math.exp(omega / crval);
             break;
         case 'F2W':
-            wl=lambda_r *  lambda_r/(lambda_r - omega);
+            wl = crval * crval / (crval - omega);
             break;
         case 'V2W':
-            const lamda_0 = getHeader(header, 'RESTWAV', 0);
-            const b_lamda = ( Math.pow(lambda_r, 4) - Math.pow(lamda_0, 4) + 4 *Math.pow(lamda_0, 2)*lambda_r*omega )/
-            Math.pow((Math.pow(lamda_0, 2) + Math.pow(lambda_r, 2) ), 2);
-            wl = lamda_0 - Math.sqrt( (1 + b_lamda)/(1-b_lamda) );
+            const lambda_0 = parseInt(getHeader(header, 'RESTWAV', '0'));
+            const b_lambda = (Math.pow(crval, 4) - Math.pow(lambda_0, 4) + 4 * Math.pow(lambda_0, 2) * crval * omega) /
+                Math.pow((Math.pow(lambda_0, 2) + Math.pow(crval, 2)), 2);
+            wl = lambda_0 - Math.sqrt((1 + b_lambda) / (1 - b_lambda));
             break;
 
     }
@@ -345,62 +196,16 @@ function calculatedExpectedValue(pt, algorithm, header){
     return wl;
 }
 
-/**
- * The index array is indexAry=[0, 1, 2, 3, ...89]
- *
- * Use a few known values as psi_m to do the test
- * The psi_m array is calculated by hand using the data in the header and stored as a known data
- * pixIdxAry is also a known array because using the psi_m array, the pixIndxAry can be determined using the
- * index array data.
- *
- * @param header
- * @param wlTable
- * @returns {number}
- */
-function calculateExpectedTabWavelength( header, wlTable){
 
-    //lambda_r = crval3=7.5E-07
-    //PC_3_1=2.93E-10
-    //PC3_2 = 1.5
-    //PC3_3=3.5
-    //CDELT3=1.0=S3
-    //let pixCoords = getPixelCoordinates(pt, header);
-    //CRPIX1 = 1024.0, CRPIX2=1024, CRPIX3=0.0
-    // lambda_r = crval3=7.5E-07
-    //psi_m = lambda_r + cdelt* omega = 10.5
-
-
-    let pixCoords, ipt, gamma_m;
-
-    let wl=[];
-    let psiIdx, kIndex;
-    for (let i=0; i<tabPointArray.length; i++){
-        ipt = tabPointArray[i];
-        pixCoords = getPixelCoordinates(ipt, header);
-
-        //const omega= parseFloat(getOmega(pixCoords,  N, r_j, pc_3j, s_3));
-        //console.log('omega='+omega);
-        //psi_m = lambda_r + cdelt* omega;
-        //console.log('psi_m='+psi_m);
-        psiIdx = pixIdxAry[i];
-        gamma_m = psiIdx + 1  + (psi_mAry[i] - indexVec[psiIdx]) / (indexVec[psiIdx+1] - indexVec[psiIdx]);
-        kIndex = Math.floor(gamma_m);
-        wl[i] =coords[kIndex] + (gamma_m - (kIndex+1) )* (coords[kIndex+1]-coords[kIndex]);
-    }
-
-    return wl;
-
-
-}
-function doTest(jsonStr, algorithm){
+function doTest(jsonStr, algorithm) {
     const header = jsonStr.header;
-    const wlData= parseWavelengthHeaderInfo(header, '', undefined, undefined);
+    const wlData = parseWavelengthHeaderInfo(header, '', undefined, undefined);
 
-    for (let i=0; i<pointArray.length; i++){
+    for (let i = 0; i < pointArray.length; i++) {
         const pt = makeWorldPt(pointArray[i].ra, pointArray[i].dec);
         const calculatedWL = getWavelength(pt, 0, wlData);
-        const expectedValue = calculatedExpectedValue(pt, algorithm , header );
-        assert.equal( calculatedWL.toFixed(precision), expectedValue.toFixed(precision), 'The current calculated wavelength value in' +
+        const expectedValue = calculatedExpectedValue(pt, algorithm, header);
+        assert.equal(calculatedWL.toFixed(precision), expectedValue.toFixed(precision), 'The current calculated wavelength value in' +
             '  is not the same as previously stored value');
     }
 }
@@ -412,63 +217,57 @@ describe('A test suite for Wavelength.js', function () {
     //__filename returns absolute path to file where it is placed
     const scriptDirString = path.dirname(fs.realpathSync(__filename));
     const rootPath = scriptDirString.split('firefly')[0];
-    const dataPath =rootPath+JAVA_TEST_DATA_PATH;
+    const dataPath = rootPath + JAVA_TEST_DATA_PATH;
     //read out all test files stored in json format
     const jsonFiles = getJsonFiles(dataPath, true);
 
 
-    test('Test Linear Algorithm',   ()=> {
+    test('Test Linear Algorithm', () => {
         const linearFile = getTestJsonFile(jsonFiles, 'linear');
-        const jsonStr =require(linearFile);
+        const jsonStr = require(linearFile);
         doTest(jsonStr, 'linear');
 
     });
 
-    test('Test Log Algorithm',   ()=> {
+    test('Test Log Algorithm', () => {
         const linearFile = getTestJsonFile(jsonFiles, 'log');
-        const jsonStr =require(linearFile);
+        const jsonStr = require(linearFile);
         doTest(jsonStr, 'log');
 
     });
 
-    test('Test F2W Algorithm',   ()=> {
+    test('Test F2W Algorithm', () => {
         const linearFile = getTestJsonFile(jsonFiles, 'F2W');
-        const jsonStr =require(linearFile);
+        const jsonStr = require(linearFile);
         doTest(jsonStr, 'F2W');
 
     });
 
-    test('Test V2W Algorithm',   ()=> {
+    test('Test V2W Algorithm', () => {
         const linearFile = getTestJsonFile(jsonFiles, 'V2W');
-        const jsonStr =require(linearFile);
+        const jsonStr = require(linearFile);
         doTest(jsonStr, 'V2W');
 
     });
     /**
      * Use the known psi_m and corresponding index to test the calculated value against the expected values.
      */
-    test('Test WAVE-TAB Algorithm',   ()=> {
+    test('Test WAVE-TAB Algorithm', () => {
 
-        const tableFile = getTestJsonFile(jsonFiles, 'Table');
-        const jsonStr =require(tableFile);
-        const header = jsonStr.header;
-        const wlTable = jsonStr.wlTable;
-        const wlData= parseWavelengthHeaderInfo(header, '', undefined,
+        const header = jsonTAB.header;
+        const wlTable = jsonTAB.wlTable;
+        const wlData= parseWavelengthHeaderInfo(header, 'w', undefined,
             [ {dataType:RDConst.WAVELENGTH_TABLE_RESOLVED, table:wlTable, hduName:'WCS-table'} ]);
-        const expectedTabWl = calculateExpectedTabWavelength(header, wlTable);
-        let calculatedTabWl=[];
-        for (let i=0; i<tabPointArray.length; i++){
-            calculatedTabWl[i] = getWavelength(tabPointArray[i], 0, wlData);
+
+        const calculatedWl = [];
+        for (let i = 0; i < pointArrayTAB.length; i++) {
+            calculatedWl[i] = getWavelength(pointArrayTAB[i], 0, wlData);
         }
-        for (let i=0; i<tabPointArray.length; i++){
-            assert.equal( calculatedTabWl[i].toFixed(precision), expectedTabWl[i].toFixed(precision), 'The current calculated wavelength value in' +
-                '  is not the same as previously stored value');
+        for (let i = 0; i < pointArrayTAB.length; i++) {
+            assert.equal(calculatedWl[i].toFixed(precision), expectedWlTAB[i].toFixed(precision),
+                'The current calculated wavelength value ' + i +
+                ' is not the same as previously stored value');
         }
 
     });
-
-
 });
-
-
-


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-989
Test build: https://fireflydev.ipac.caltech.edu/firefly-989-wavetab-1d/firefly/

WAVE-TAB algorithm is described in Section 6 of the second WCS paper: [Representation of spectral coordinates in FITS](https://www.aanda.org/articles/aa/pdf/2006/05/aa3818-05.pdf)

Verified and fixed the WAVE-TAB algorithm for 1d case that was already implemented in Firefly. Tested using the examples in the ticket and Cycle6_GR_OT_06_0112_JJackson_Nessie-A_OI.lmv.fits referenced in "Example MEF, Cube, Spectral Image FITS Files" confluence page. 

- applyDefaultValues in WavelengthHeaderParser.js was wrongly changing all 0 values in PC matrix to the default values.
- TAB algorithm was producing incorrect or misleading results in the cases described in the ticket.
- Added the tests for the key algorithm functions. Fixed and simplified the test data for the original WAVE-TAB test. The indexing vector and coordinate arrays in the test data had different length, which is not allowed and the psi_m values used to calculate the expected result were not consistent with the point coordinates and header values. Overall the test case data were too complex to use for validation.