### PR TITLE
Firefly-995: support defining then passing firefly options from server to client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       dockerfile: firefly/docker/Dockerfile
     ports:
       - "8080:8080"
-    environment: # any variable listed in catalina.sh and usually set in tomcat's setenv.sh, could be set here
-      - ADMIN_PASSWORD      # value taken from env
+    env_file:
+      - ./firefly-docker.env
   test:
     image: ipac/firefly:deps
     build:

--- a/docker/README.md
+++ b/docker/README.md
@@ -98,14 +98,14 @@ Firefly has many configurable runtime parameters.  For more information, run
 There are many `docker run` examples on how to use these parameters.  Consider add them into a docker-compose.yml for 
 easy operation.  For information on how to do this, go here: https://docs.docker.com/compose/compose-file/compose-file-v3/
 
-Docker-compose file allows for variables substitute.  You can set the values in the environment, as argument on the command 
-line, or place them in a `.env` file.
+Docker-compose file allows for variables substitute.  You can set the values in the environment, by adding a line
+to `firefly-docker.env` file.
 
-For example, Firefly's docker-compose.yml contains BUILD_TAG and ADMIN_PASSWORD variables.  The values can come from the 
-`.env` file, like this
+For example, Firefly's `docker-compose.yml` can have additional environment variables.  The values can come from the 
+`firefly-docker.env` file, like this
 
-    cat .env
+    cat firefly-docker.env
     ADMIN_PASSWORD=reset-me
-    BUILD_TAG=my-test 
+    CLEANUP_INTERVAL=3h
 
 

--- a/docker/launchTomcat.sh
+++ b/docker/launchTomcat.sh
@@ -16,16 +16,19 @@ echo -e "!!============================================================\n\n"
 echo "========== Information:  you can set environment variable using -e on docker run line =====  "
 echo 
 echo "Environment Variables:"
-echo "        Description                      Name                       Value"
-echo "        -----------                      --------                   -----"
-echo "        Admin username                   ADMIN_USER                 ${ADMIN_USER}"
-echo "        Admin password                   ADMIN_PASSWORD             ${ADMIN_PASSWORD}"
-echo "        Additional data path             VISUALIZE_FITS_SEARCH_PATH ${VISUALIZE_FITS_SEARCH_PATH}"
-echo "        Clean internal(eg- 720m, 5h, 3d) CLEANUP_INTERVAL           ${CLEANUP_INTERVAL}"
+echo "        Description                      Name                          Value"
+echo "        -----------                      --------                      -----"
+echo "        Admin username                   ADMIN_USER                    ${ADMIN_USER}"
+echo "        Admin password                   ADMIN_PASSWORD                ${ADMIN_PASSWORD}"
+echo "        Additional data path             VISUALIZE_FITS_SEARCH_PATH    ${VISUALIZE_FITS_SEARCH_PATH}"
+echo "        Clean internal(eg- 720m, 5h, 3d) CLEANUP_INTERVAL              ${CLEANUP_INTERVAL}"
 echo
 echo "Advanced environment variables:"
-echo "        Run tomcat with debug            DEBUG                      ${DEBUG}"
-echo "        Extra firefly properties(*)      PROPS                      ${PROPS}"
+echo "        Run tomcat with debug            DEBUG                         ${DEBUG}"
+echo "        Extra firefly properties(*)      PROPS                         ${PROPS}"
+echo "        Redis host                       PROPS_redis__host             ${PROPS_redis__host}"
+echo "        SSO host                         PROPS_sso__req__auth__hosts   ${PROPS_sso__req__auth__hosts}"
+echo "        firefly.options (JSON string)    PROPS_FIREFLY_OPTIONS         ${PROPS_FIREFLY_OPTIONS}"
 echo " (*) key=value pairs separated by spaces"
 echo
 echo "Ports: "
@@ -109,7 +112,7 @@ CATALINA_OPTS="$CATALINA_OPTS \
 #------- start background scripts: cleanup
 ${CATALINA_HOME}/cleanup.sh /firefly/workarea /firefly/shared-workarea &
 
-echo "launchTomcat.sh: Starting Tomcat"
+echo -e "\nlaunchTomcat.sh: Starting Tomcat"
 if [ "$DEBUG" = "true" ] ||[ "$DEBUG" = "t" ] ||[ "$DEBUG" = "1" ] ||  \
    [ "$DEBUG" = "TRUE" ] || [ "$DEBUG" = "True" ] || [ "$1" = "--debug" ]; then
     exec ${CATALINA_HOME}/bin/catalina.sh jpda ${START_MODE}

--- a/docker/start-examples.txt
+++ b/docker/start-examples.txt
@@ -22,26 +22,27 @@ To find releases try- https://hub.docker.com/r/ipac/firefly/tags
 -------------------- More advanced:
 
 Background:
-   > docker run -p 80:8080  --memory=8g --rm ipac/firefly:latest >& my.log &
+   > docker run -p 80:8080  -m 8g --rm ipac/firefly:latest >& my.log &
    - start firefly with - http://localhost/firefly/
 
 Map a directory for direct file reading:
-   > docker run -p 80:8080  -v /local/data:/external --memory=8g --rm ipac/firefly:latest
+   > docker run -p 80:8080  -v /local/data:/external -m 8g --rm ipac/firefly:latest
    - start firefly with - http://localhost/firefly/
 
+
 Write to logging directory outside of docker image:
-   > docker run -p 80:8080 -v /local/myLogDir:/firefly/logs --memory=8g --rm ipac/firefly:latest
+   > docker run -p 80:8080 -v /local/myLogDir:/firefly/logs -m 8g --rm ipac/firefly:latest
    - start firefly with - http://localhost/firefly/
 
 Debugging:
-   > docker run -p 8055:8080 -p 5050:5050 --memory=4g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="TRUE" --rm --name firefly ipac/firefly:latest
+   > docker run -p 8055:8080 -p 5050:5050 -m 4g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="TRUE" --rm --name firefly ipac/firefly:latest
    - start firefly with - http://localhost:8055/firefly/
 
 Production like:
-   > docker run -p 8055:8080 -p --memory=30g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="FALSE" --name productionServer ipac/firefly:latest
+   > docker run -p 8055:8080 -p -m 30g -e "ADMIN_PASSWORD=myPassword" -e DEBUG="FALSE" --name productionServer ipac/firefly:latest
    - start firefly with - http://localhost:8055/firefly/
 
 Production like, multiple tomcats, using a shared work directory:
-   > docker run -p 8055:8080 -p --memory=30g -e "ADMIN_PASSWORD=myPassword" \
+   > docker run -p 8055:8080 -p -m 30g -e "ADMIN_PASSWORD=myPassword" \
              -v /local/shared/work/area:/firefly/shared-workarea --name productionServer ipac/firefly:latest
    - start firefly with - http://localhost:8055/firefly/

--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -1,0 +1,7 @@
+#---- Set environment variables for the docker startup
+#---- Examples-
+#PROPS_FIREFLY_OPTIONS=$'{ "coverage":  {"hipsSourceURL" : "ivo://CDS/P/2MASS/color"} }'
+#ADMIN_PASSWORD=reset-me
+#CLEANUP_INTERVAL=3h
+#---- Empty declarations: environment will come from the shell
+ADMIN_PASSWORD

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -171,6 +171,7 @@ public class ServerParams {
     public static final String JSON_SEARCH = "jsonSearch";
 
     public static final String INIT_APP = "CmdInitApp";
+    public static final String SRV_DEFINED_OPTIONS= "CmdSrvDefinedOptions";
     public static final String LOGOUT = "CmdLogout";
     public static final String TILE_SIZE = "tileSize";
     public static final String DATA_COMPRESS = "dataCompress";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -8,7 +8,10 @@ import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
 import edu.caltech.ipac.firefly.server.security.SsoAdapter;
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.util.AppProperties;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 public class AppServerCommands {
     private static final String SPA_NAME = "spaName";
@@ -23,9 +26,28 @@ public class AppServerCommands {
             AlertsMonitor.checkAlerts(true);
             // update login status
             UserInfo userInfo = ServerContext.getRequestOwner().getUserInfo();
-            LOG.briefInfo("Init "+spaName);
+            LOG.info("Init "+spaName);
             LOG.debug("User info for this client: " + userInfo);
             return "true";
+        }
+    }
+
+    public static class SrvDefinedOptions extends ServCommand {
+        static boolean firstTime= true;
+        static String json = AppProperties.getProperty(ServerContext.JSON_OPTIONS,"{}");
+        public String doCommand(SrvParam params) throws Exception {
+
+            if (firstTime) {
+                try {
+                    new JSONParser().parse(json);
+                    LOG.info("Client Options ("+ServerContext.JSON_OPTIONS+"): " +json);
+                } catch (ParseException e){
+                    LOG.error("Could not parse Client Options ("+ServerContext.JSON_OPTIONS+") to JSON: " +json);
+                    json = "{}";
+                }
+                firstTime= false;
+            }
+            return json;
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
@@ -93,6 +93,7 @@ public class ServerCommandAccess {
         _cmdMap.put(ServerParams.VIS_PUSH_ACTION,        new PushCommands.PushAction());
 
         _cmdMap.put(ServerParams.INIT_APP,               new AppServerCommands.InitApp());
+        _cmdMap.put(ServerParams.SRV_DEFINED_OPTIONS,    new AppServerCommands.SrvDefinedOptions());
         _cmdMap.put(ServerParams.LOGOUT,                 new AppServerCommands.Logout());
         _cmdMap.put(ServerParams.GET_USER_INFO,          new AppServerCommands.GetUserInfo());
         _cmdMap.put(ServerParams.GET_ALERTS,             new AppServerCommands.GetAlerts());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -77,6 +77,7 @@ public class ServerContext {
     private static final String SHARED_WORK_DIR_PROP= "shared.work.directory";
     public static final String VIS_SEARCH_PATH= "visualize.fits.search.path";
     public static final String STATS_LOG_DIR= "stats.log.dir";
+    public static final String JSON_OPTIONS= "FIREFLY_OPTIONS";
 
 
     private static RequestOwnerThreadLocal owner = new RequestOwnerThreadLocal();

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -217,7 +217,7 @@ export function getRootUrlPath() {
 }
 
 export function getAppOptions() {
-    return flux.getState()[APP_DATA_PATH].appOptions || window.firefly?.options;
+    return flux.getState()[APP_DATA_PATH].appOptions ?? window.firefly?.options ?? {};
 }
 
 export function getUserInfo() {

--- a/src/firefly/js/core/JsonUtils.js
+++ b/src/firefly/js/core/JsonUtils.js
@@ -68,7 +68,7 @@ export function jsonFetch(url, params, doPost, useBigInt) {
 /**
  * 
  * @param {string} cmd
- * @param paramList
+ * @param [paramList]
  * @param {boolean} doPost
  * @param {boolean} useBigInt  // support BigInt in JSON.  default to false
  * @return {Promise} a promise with the results

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -147,6 +147,7 @@ export const ServerParams = {
         UPLOAD: 'upload',
         LOG_OUT: 'CmdLogout',
         INIT_APP: 'CmdInitApp',
+        SRV_DEFINED_OPTIONS: 'CmdSrvDefinedOptions',
         GET_IMAGE_MASTER_DATA: 'getImageMasterData',
         GET_FLOAT_DATA: 'getFloatData',
         GET_BYTE_DATA: 'getStretchedByteData',

--- a/src/firefly/js/rpc/CoreServices.js
+++ b/src/firefly/js/rpc/CoreServices.js
@@ -31,6 +31,9 @@ export function notifyServerAppInit({spaName}={}) {
     return doJsonRequest(ServerParams.INIT_APP, {spaName});
 }
 
+export function getServerDefinedOptions() {
+    return doJsonRequest(ServerParams.SRV_DEFINED_OPTIONS);
+}
 
 
 

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -5,6 +5,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
+import {getAppOptions} from '../core/AppDataCntlr.js';
 
 import {ValidationField} from '../ui/ValidationField.jsx';
 import {VALUE_CHANGE, dispatchValueChange} from '../fieldGroup/FieldGroupCntlr.js';
@@ -26,7 +27,7 @@ import {FieldGroup} from './FieldGroup.jsx';
 
 import CsysConverter from '../visualize/CsysConverter.js';
 import {primePlot, getActivePlotView, getFoV} from '../visualize/PlotViewUtil.js';
-import { makeImagePt, makeWorldPt, makeScreenPt, makeDevicePt} from '../visualize/Point.js';
+import {makeImagePt, makeWorldPt, makeScreenPt, makeDevicePt, parseWorldPt} from '../visualize/Point.js';
 import {visRoot} from '../visualize/ImagePlotCntlr.js';
 import {getValueInScreenPixel} from '../visualize/draw/ShapeDataObj.js';
 
@@ -331,7 +332,7 @@ function sizeArea(groupKey, searchType, imageCornerCalc) {
             </div>
         );
     } else if (searchType === SpatialMethod.Polygon.value) {
-        return renderPolygonDataArea(imageCornerCalc);
+        return renderPolygonDataArea({imageCornerCalc});
     } else {
         return (
 
@@ -342,7 +343,9 @@ function sizeArea(groupKey, searchType, imageCornerCalc) {
     }
 }
 
-export function renderPolygonDataArea(imageCornerCalc, labelWidth, labelStyle, wrapperStyle) {
+export function renderPolygonDataArea({imageCornerCalc, labelWidth, labelStyle, wrapperStyle,
+                                          hipsUrl= getAppOptions().coverage?.hipsSourceURL  ??  'ivo://CDS/P/2MASS/color',
+                                          centerWP, fovDeg=240 }) {
     wrapperStyle = {padding: 5, display: 'flex', ...wrapperStyle};
 
     let cornerTypeOps=
@@ -367,6 +370,7 @@ export function renderPolygonDataArea(imageCornerCalc, labelWidth, labelStyle, w
             cornerTypeOps.splice(cornerTypeOps.length-1, 0, {label: 'Selection', value: 'area-selection'});
         }
     }
+    const wp= parseWorldPt(centerWP) ?? makeWorldPt(0,0);
     return (
         <div
             style={{padding:5, border:'solid #a3aeb9 1px' }}>
@@ -389,6 +393,10 @@ export function renderPolygonDataArea(imageCornerCalc, labelWidth, labelStyle, w
                 fieldKey:'polygoncoords',
                 style:{overflow:'auto',height:'65px', maxHeight:'200px', width:'220px', maxWidth:'300px'},
                 initialState:{},
+                hipsDisplayKey:fovDeg,
+                hipsUrl,
+                hipsFOVInDeg:fovDeg,
+                centerPt:wp,
                 label:'Coordinates:',
                 labelStyle,
                 labelWidth,

--- a/src/firefly/js/ui/InputAreaFieldView.jsx
+++ b/src/firefly/js/ui/InputAreaFieldView.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {forwardRef, useEffect, useRef, useState} from 'react';
 import PropTypes from 'prop-types';
 import {PointerPopup} from '../ui/PointerPopup.jsx';
 import {InputFieldLabel} from './InputFieldLabel.jsx';
@@ -48,9 +48,9 @@ const ICON_SPACE_STYLE= {
     display:'inline-block'};
 
 
-export function InputAreaFieldView({ visible,label,tooltip,rows,cols,labelWidth,value,style,wrapperStyle,labelStyle,
+export const InputAreaFieldView= forwardRef( ({ visible,label,tooltip,rows,cols,labelWidth,value,style,wrapperStyle,labelStyle,
                                        button,inline, valid,onChange, onBlur, onKeyPress, showWarning,
-                                       message, type, placeholder, additionalClasses, idName } ) {
+                                       message, type, placeholder, additionalClasses, idName },ref ) => {
     const [hasFocus,setHasFocus]= useState(false);
     const [infoPopup,setInfoPopup]= useState(false);
     const {current:warn}= useRef({warnIcon:undefined, hider:undefined});
@@ -78,7 +78,7 @@ export function InputAreaFieldView({ visible,label,tooltip,rows,cols,labelWidth,
                 : (<div style={ICON_SPACE_STYLE}/>) : false;
 
     return (
-        <div style={{whiteSpace:'nowrap', display: inline?'inline-block':'block', ...wrapperStyle}}>
+        <div style={{whiteSpace:'nowrap', display: inline?'inline-block':'block', ...wrapperStyle}} ref={ref}>
             {label && <InputFieldLabel labelStyle={labelStyle} label={label} tooltip={tooltip} labelWidth={labelWidth}/> }
             <textarea style={{display:'inline-block', ...style}}
                       rows={rows}
@@ -107,7 +107,7 @@ export function InputAreaFieldView({ visible,label,tooltip,rows,cols,labelWidth,
             {Boolean(button) && button}
         </div>
     );
-}
+});
 
 InputAreaFieldView.propTypes= {
     valid   : PropTypes.bool,

--- a/src/firefly/js/ui/PopupPanel.jsx
+++ b/src/firefly/js/ui/PopupPanel.jsx
@@ -9,23 +9,24 @@ import {getDefaultPopupPosition, humanStart, humanMove, humanStop} from './Popup
 import './PopupPanel.css';
 import DEL_ICO from 'html/images/blue_delete_10x10.png';
 
-/** @typedef {Object} LayoutType
+/**
+ * @typedef {Object} LayoutType
  * enum can be one of
  * @prop CENTER
  * @prop TOP_EDGE_CENTER
  * @prop TOP_CENTER
  * @prop TOP_LEFT
  * @prop TOP_RIGHT
+ * @prop TOP_RIGHT_OF_BUTTON
  * @prop NONE
  * @prop USER_POSITION
- * @type {Enum}
  */
-export const LayoutType= new Enum(['CENTER', 'TOP_EDGE_CENTER', 'TOP_CENTER', 'TOP_LEFT', 'TOP_RIGHT', 'NONE', 'USER_POSITION']);
+export const LayoutType= new Enum(['CENTER', 'TOP_EDGE_CENTER', 'TOP_CENTER', 'TOP_LEFT', 'TOP_RIGHT', 'NONE', 'USER_POSITION', 'TOP_RIGHT_OF_BUTTON']);
 
 export const PopupPanel= memo((props) => {
     const {title='', visible=true, layoutPosition=LayoutType.TOP_CENTER, closePromise, closeCallback, modal=false,
         requestToClose, mouseInDialog, requestOnTop, dialogId, zIndex=0, children, style,
-        initLeft, initTop, onMove}= props;
+        initLeft, initTop, onMove, element}= props;
     const [{left,top}, setPos]= useState({left:0,top:0});
     const [layout, setLayout]= useState(LayoutType.NONE);
     const {current:ctxRef} = useRef({ mouseCtx: undefined, popupRef : undefined, titleBarRef: undefined});
@@ -35,7 +36,7 @@ export const PopupPanel= memo((props) => {
             setPos({left:initLeft,top:initTop});
         }
         else {
-            setPos(getDefaultPopupPosition(ctxRef.popupRef,layoutPosition));
+            setPos(getDefaultPopupPosition(ctxRef.popupRef,layoutPosition, element));
         }
 
         setLayout(layoutPosition);

--- a/src/firefly/js/ui/PopupPanelHelper.js
+++ b/src/firefly/js/ui/PopupPanelHelper.js
@@ -101,12 +101,14 @@ const endMove= (ctx) => void (ctx && (ctx.moving= false));
 /**
  * @param {element} e
  * @param layoutType
+ * @param {element} positionElement
  * @return {{top: number, left: number}}
  */
-export const getDefaultPopupPosition= function(e, layoutType) {
+export const getDefaultPopupPosition= function(e, layoutType,positionElement) {
 
     let left= 0;
     let top= 0;
+    const posBound= positionElement?.getBoundingClientRect() ?? {};
     switch (layoutType.toString()) {
         case 'CENTER' :
             left= window.innerWidth/2 - e.offsetWidth/2 + window.scrollX;
@@ -127,6 +129,12 @@ export const getDefaultPopupPosition= function(e, layoutType) {
         case 'TOP_EDGE_CENTER' :
             left= window.innerWidth/2 - e.offsetWidth/2 + window.scrollX;
             top= window.scrollY+ 3;
+            break;
+        case 'TOP_RIGHT_OF_BUTTON' :
+            if (!positionElement) return getDefaultPopupPosition(e,'TOP_RIGHT');
+            left= posBound.width + posBound.x + 5  + e.offsetWidth < window.innerWidth ?
+                posBound.width + posBound.x + 5 : window.innerWidth - e.offsetWidth;
+            top= posBound.y > e.offsetHeight ? posBound.y - e.offsetHeight : 5;
             break;
     }
     return {left, top};

--- a/src/firefly/js/ui/tap/TapKnownServices.js
+++ b/src/firefly/js/ui/tap/TapKnownServices.js
@@ -4,7 +4,7 @@
 /* eslint-disable  quotes */
 import {Logger} from 'firefly/util/Logger.js';
 
-const tapEntry= (label,url,examples) => ({ label, value: url, examples});
+const tapEntry= (label,url,examples,hipsUrl, fovDeg,centerWP) => ({ label, value: url, examples, fovDeg, centerWP});
 
 export function getTAPServices(nameList) {
     const services= makeServices();

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -218,13 +218,24 @@ export function getColumnAttribute(columnsModel, colName, attrName) {
 
 const hasElements= (a) => Boolean(isArray(a) && a?.length);
 
+function mergeAdditionalServices(tapServices, additional) {
+    if (!hasElements(additional)) return tapServices;
+
+    const modifiedOriginal= tapServices.map( (t) => {
+        const match= additional.find( (a) => a.label===t.label);
+        return match ? {...t,...match} : t;
+    });
+    const trulyAdditional= additional.filter( (a) => !tapServices.find( (t) => t.label===a.label) );
+
+    return [...trulyAdditional,...modifiedOriginal];
+}
+
 export function getTapServices(webApiUserAddedService) {
-    const tapServices = getAppOptions()?.tap?.services;
-    const additionalServices = getAppOptions()?.tap?.additional?.services;
-    const retVal= hasElements(tapServices) ? [...tapServices] : [...TAP_SERVICES_FALLBACK];
-    hasElements(additionalServices) && retVal.unshift(...additionalServices);
-    webApiUserAddedService && retVal.push(webApiUserAddedService);
-    return retVal;
+    const {tap} = getAppOptions();
+    const startingTapServices= hasElements(tap?.services) ? [...tap.services] : [...TAP_SERVICES_FALLBACK];
+    const mergedServices= mergeAdditionalServices(startingTapServices,tap?.additional?.services);
+    webApiUserAddedService && mergedServices.push(webApiUserAddedService);
+    return mergedServices;
 }
 
 const validTableNameRE= /^[A-Za-z][A-Za-z_0-9]*(\.[A-Za-z][A-Za-z_0-9]*){0,2}$/;

--- a/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
+++ b/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
@@ -121,7 +121,8 @@ function isWpArysEquals(wpAry1, wpAry2) {
 }
 
 
-export const HiPSTargetView = ({style, hipsUrl=DEFAULT_HIPS, hipsFOVInDeg= DEFAULT_FOV, centerPt=makeWorldPt(0,0),
+export const HiPSTargetView = ({style, hipsDisplayKey='none',
+                                   hipsUrl=DEFAULT_HIPS, hipsFOVInDeg= DEFAULT_FOV, centerPt=makeWorldPt(0,0),
                                    targetKey='UserTargetWorldPt', sizeKey='none---Size', polygonKey='non---Polygon',
                                    whichOverlay= CONE_CHOICE_KEY,
                                    coordinateSys, mocList, minSize=1/3600, maxSize=100,
@@ -152,7 +153,7 @@ export const HiPSTargetView = ({style, hipsUrl=DEFAULT_HIPS, hipsFOVInDeg= DEFAU
         return () => {
             if (cleanup) dispatchDeletePlotView({plotId});
         };
-    },[]);
+    },[hipsDisplayKey]);
 
     useEffect(() => { // if plot view changes then update the target or polygon field
         if (whichOverlay!==CONE_CHOICE_KEY && whichOverlay!==POLY_CHOICE_KEY) return;
@@ -305,7 +306,7 @@ function showHiPSPanelPopup({element, plotId= defPopupPlotId, ...restOfProps}) {
     };
 
     const hipsPanel= (
-        <PopupPanel title={'Choose Target'} layoutPosition={LayoutType.TOP_RIGHT}
+        <PopupPanel title={'Choose Target'} layoutPosition={LayoutType.TOP_RIGHT_OF_BUTTON} element={element}
                     closeCallback={() => doClose()} >
             <div style={{
                 padding: 3, display:'flex', flexDirection:'column', width: 500, height:400,
@@ -450,6 +451,7 @@ function getDetailsFromSelection(plot) {
 
 function makeRelativePolygonAry(plot, polygonAry) {
     const cc= CsysConverter.make(plot);
+    if (!cc) return;
     const dAry= polygonAry.map( (pt) => cc.getImageCoords(pt)).filter( (pt) => pt);
     if (dAry.length <3) return;
     const avgX= dAry.reduce( (sum,{x}) => sum+x,0)/dAry.length;


### PR DESCRIPTION
#### [Firefly-995](https://jira.ipac.caltech.edu/browse/FIREFLY-995)

  - The property java `FIREFLY_OPTIONS` can contain a json string equivalent  `firefly.options` on the client. 
  - This json object will be merge with what is running on the client at startup time.
  - Also fixes a bug I introduced in my last PR that breaks the advanced TAP panel. Related to converting `InputAreaFieldView` to a functional component

#### Testing
  - use docker to test
  - define an environment variable from bash
     - `export PROPS_FIREFLY_OPTIONS=$'\'{ "tap" : { "additional":{ "services": [ { "label": "I-internal", "value": "https://irsasearchops.ipac.caltech.edu/TAP" } ] } } }\''`
  - `docker compose up firefly`
  - The tap option should show a new tap service labeled 'I-internal'
  - To override the IRSA server try: 
    - `export PROPS_FIREFLY_OPTIONS=$'\'{ "tap" : { "additional":{ "services": [ { "label": "IRSA", "value": "https://irsasearchops.ipac.caltech.edu/TAP" } ] } } }\''`