### PR TITLE
FIREFLY-994: Create chart view that support multiple charts from different tables

### DIFF
--- a/docker/java.security.override
+++ b/docker/java.security.override
@@ -1,0 +1,33 @@
+#
+# Algorithm restrictions for Secure Socket Layer/Transport Layer Security
+# (SSL/TLS/DTLS) processing
+#
+# In some environments, certain algorithms or key lengths may be undesirable
+# when using SSL/TLS/DTLS.  This section describes the mechanism for disabling
+# algorithms during SSL/TLS/DTLS security parameters negotiation, including
+# protocol version negotiation, cipher suites selection, peer authentication
+# and key exchange mechanisms.
+#
+# Disabled algorithms will not be negotiated for SSL/TLS connections, even
+# if they are enabled explicitly in an application.
+#
+# For PKI-based peer authentication and key exchange mechanisms, this list
+# of disabled algorithms will also be checked during certification path
+# building and validation, including algorithms used in certificates, as
+# well as revocation information such as CRLs and signed OCSP Responses.
+# This is in addition to the jdk.certpath.disabledAlgorithms property above.
+#
+# See the specification of "jdk.certpath.disabledAlgorithms" for the
+# syntax of the disabled algorithm string.
+#
+# Note: The algorithm restrictions do not apply to trust anchors or
+# self-signed certificates.
+#
+# Note: This property is currently used by the JDK Reference implementation.
+# It is not guaranteed to be examined and used by other implementations.
+#
+# Example:
+#   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, DH keySize < 1024, \
+    EC keySize < 224, 3DES_EDE_CBC, anon, NULL
+# NOTE: above setting is taken from openJDK v11.0.2 because later versions disabled TLSv1.1 which is needed by mail0.ipac.caltech.edu

--- a/docker/launchTomcat.sh
+++ b/docker/launchTomcat.sh
@@ -85,6 +85,7 @@ export CATALINA_OPTS="\
   -Dserver_config_dir=/firefly/config \
   -Dstats.log.dir=/firefly/logs/statistics \
   -Dalerts.dir=/firefly/alerts \
+  -Djava.security.properties=/usr/local/tomcat/conf/java.security.override \
   -Dvisualize.fits.search.path=${VIS_PATH} \
 	"
 

--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -107,6 +107,19 @@ div.rootStyle img {
     cursor: pointer;
 }
 
+.button.text {
+    line-height: 1.5;
+    padding: 0 5px;
+    border: 1px solid #acacac;
+    border-radius: 2px;
+    white-space: nowrap;
+}
+
+.button.text:hover {
+    border: 1px solid #878787;
+    background-color: #c4c4c4;
+}
+
 .button.large {
     white-space: nowrap;
     border: 2px solid white;

--- a/src/firefly/html/firefly.html
+++ b/src/firefly/html/firefly.html
@@ -19,6 +19,9 @@
                 hips: {
                     readoutShowsPixel: true
                 },
+                charts: {
+                    useChartWorkArea: true
+                },
                 coverage: { // example of using DSS and wise combination for coverage (not that anyone would want to combination)
                     hipsSourceURL: 'http://alasky.u-strasbg.fr/DSS/DSSColor', // url
                     imageSourceParams: {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -139,12 +139,13 @@ const defFireflyOptions = {
     'help.base.url': undefined,                     // this overrides property set during build time.
 
     charts: {
-        defaultDeletable: undefined, // by default if there are more than one chart in container, all charts are deletable
-        maxRowsForScatter: 5000, // maximum table rows for scatter chart support, heatmap is created for larger tables
-        minScatterGLRows: 1000, // minimum number of points to use WebGL 'scattergl' instead of SVG 'scatter'
-        singleTraceUI: false, // by default we support multi-trace in UI
-        upperLimitUI: false, // by default user can not set upper limit column in scatter options
-        ui: {HistogramOptions: {fixedAlgorithm: undefined}} // by default we allow both "uniform binning" and "bayesian blocks"
+        defaultDeletable: undefined,    // by default if there are more than one chart in container, all charts are deletable
+        maxRowsForScatter: 5000,        // maximum table rows for scatter chart support, heatmap is created for larger tables
+        minScatterGLRows: 1000,         // minimum number of points to use WebGL 'scattergl' instead of SVG 'scatter'
+        singleTraceUI: false,           // by default we support multi-trace in UI
+        upperLimitUI: false,            // by default user can not set upper limit column in scatter options
+        useChartWorkArea: false,        // true to use Chart container with 'pin' feature
+        ui: {HistogramOptions: {fixedAlgorithm: undefined}}     // by default we allow both "uniform binning" and "bayesian blocks"
     },
     hips : {
         useForImageSearch: true,

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -513,7 +513,7 @@ export function handleTableSourceConnections({chartId, data, fireflyData}) {
         }
 
         // make sure table watcher is set for all non-empty table sources
-        if (!isEmpty(traceTS) && !traceTS._cancel) {
+        if (!isEmpty(traceTS)) {
             //creates a new one.. and save the cancel handle
             if (doUpdate) {
                 // fetch data syncs highlighted and selected with the table
@@ -527,7 +527,7 @@ export function handleTableSourceConnections({chartId, data, fireflyData}) {
                     updateSelected(chartId, selectInfo);
                 }
             }
-            traceTS._cancel = setupTableWatcher(chartId, traceTS, idx);
+            if (!traceTS._cancel) traceTS._cancel = setupTableWatcher(chartId, traceTS, idx);
         }
         tablesources[idx] = traceTS;
     });

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -85,6 +85,14 @@ export function getMinScatterGLRows() {
 }
 
 /**
+ * @returns {boolean} return true if ChartWorkArea is used.
+ */
+export function useChartWorkArea() {
+    return getAppOptions()?.charts?.useChartWorkArea ?? false;
+}
+
+
+/**
  * @summary Get unique chart id
  * @param {string} [prefix] - prefix
  * @returns {string} unique chart id
@@ -556,16 +564,17 @@ function tablesourcesEqual(newTS, oldTS) {
 
 function updateChartData(chartId, traceNum, tablesource, action={}) {
 
+    const chartData = getChartData(chartId);
+
+    // make sure the chart is not yet removed
+    if (isEmpty(chartData) || !chartData?.mounted) { return; }
+
     // Only Scatter Plot does update on a table sort event.
     if (action.type === TABLE_LOADED && action.payload.invokedBy === TABLE_SORT) {
-        const {data} = getChartData(chartId);
-        const traceType = get(data, [traceNum, 'type'], 'scatter');
+        const traceType = get(chartData, ['data', traceNum, 'type'], 'scatter');
         if (!traceType.includes('scatter')) return;
     }
 
-
-    // make sure the chart is not yet removed
-    if (isEmpty(getChartData(chartId))) { return; }
     const {tbl_id, resultSetID, mappings} = tablesource;
     if (action.type === TABLE_HIGHLIGHT) {
         // ignore if traceNum is not active

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -681,11 +681,9 @@ function reduceData(state={}, action={}) {
         case (CHART_MOUNTED) :
         {
             const {chartId} = action.payload;
-            // if (has(state, chartId)) {
-                const n = get(state, [chartId,'mounted'], 0);
-                state = updateSet(state, [chartId,'mounted'], Number(n) + 1);
-                logger.info(`CHART_MOUNTED ${chartId} #mounted ${state[chartId].mounted}`);
-            // }
+            const n = get(state, [chartId,'mounted'], 0);
+            state = updateSet(state, [chartId,'mounted'], Number(n) + 1);
+            logger.info(`CHART_MOUNTED ${chartId} #mounted ${state[chartId].mounted}`);
 
             return state;
         }

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -292,7 +292,7 @@ function chartRemove(action) {
         const viewerId = get(getChartData(chartId), 'viewerId');
         if (viewerId) {
             dispatchRemoveViewerItems(viewerId, [chartId]);
-            if (getViewer(getMultiViewRoot(), viewerId).customData.activeItemId === chartId) {
+            if (getViewer(getMultiViewRoot(), viewerId)?.customData?.activeItemId === chartId) {
                 dispatchUpdateCustom(viewerId, {activeItemId: undefined});
             }
         }
@@ -681,11 +681,11 @@ function reduceData(state={}, action={}) {
         case (CHART_MOUNTED) :
         {
             const {chartId} = action.payload;
-            if (has(state, chartId)) {
+            // if (has(state, chartId)) {
                 const n = get(state, [chartId,'mounted'], 0);
                 state = updateSet(state, [chartId,'mounted'], Number(n) + 1);
                 logger.info(`CHART_MOUNTED ${chartId} #mounted ${state[chartId].mounted}`);
-            }
+            // }
 
             return state;
         }
@@ -920,6 +920,17 @@ export function getExpandedChartProps() {
     return {chartId, expandedViewerId};
 }
 
+
+export function getChartIdsForTable(tbl_id) {
+    const chartIds = [];
+    const state = get(flux.getState(), [CHART_SPACE_PATH, 'data']);
+    Object.keys(state).forEach((cid) => {
+        if (state[cid].tbl_id === tbl_id) {
+            chartIds.push(cid);
+        }
+    });
+    return chartIds;
+}
 
 export function getChartIdsInGroup(groupId) {
     const chartIds = [];

--- a/src/firefly/js/charts/ui/ChartPanel.css
+++ b/src/firefly/js/charts/ui/ChartPanel.css
@@ -12,6 +12,11 @@
     border: 2px solid orange;
 }
 
+.ChartPanel--default {
+    border: 3px solid #8cb3da;
+    border-radius: 2px;
+}
+
 .ChartPanel__container {
     display: flex;
     flex: auto;
@@ -21,6 +26,8 @@
 }
 
 .ChartPanel__wrapper {
+    display: flex;
+    flex-direction: column;
     position: relative;
     background-color: #c8c8c8;
     flex-grow: 1;
@@ -44,15 +51,7 @@
     top: 0;
     bottom: 0;
     left: 0;
-    right: 0
-}
-
-.ChartPanel__chartarea--withToolbar {
-    position: absolute;
-    top: 29px;
-    bottom: 0;
-    left: 1px;
-    right: 0
+    right: 0;
 }
 
 .ChartPanel__glass {
@@ -86,11 +85,8 @@
 
 .ChartToolbar {
     display: inline-flex;
-    flex-direction: row;
-    width: 100%;
     height: 30px;
     align-items: center;
-    justify-content: flex-end;
 }
 
 .ChartToolbar__buttons {
@@ -179,6 +175,12 @@
 .ChartToolbar__clear-selected {
     background-image: url("~images/icons-2014/24x24_CheckmarkOff_Circle.png");
 }
+
+.ChartToolbar__pin {
+    background-image: url("~images/icons-2014/24x24_Save.png");
+}
+
+
 /* hide the popup doubleclick tooltips since we turned it off */
 div.plotly-notifier {
     visibility: hidden;

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -1,97 +1,42 @@
 import './ChartPanel.css';
-import React, {PureComponent} from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
-import {flux} from '../../core/ReduxFlux.js';
 import {get, isEmpty, isUndefined} from 'lodash';
-import {singleTraceUI} from '../ChartUtil.js';
 import {PlotlyChartArea} from './PlotlyChartArea.jsx';
 import {PlotlyToolbar} from './PlotlyToolbar.jsx';
 import {dispatchChartMounted, dispatchChartRemove, dispatchChartUnmounted, getChartData, getErrors} from '../ChartsCntlr.js';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 
 import DELETE from 'html/images/blue_delete_10x10.png';
 
-class ChartPanelView extends PureComponent {
 
-    constructor(props) {
-        super(props);
-    }
+function ChartPanelView(props) {
 
+    const {chartId, chartData, expandable, expandedMode, Toolbar, showToolbar} = props;
 
-    componentDidMount() {
-        const {chartId, showChart} = this.props;
-        if (showChart) {
-            dispatchChartMounted(chartId);
-        }
-    }
-
-    componentWillUnmount() {
-        const {chartId, showChart} = this.props;
-        if (showChart) {
+    useEffect(() => {
+        dispatchChartMounted(chartId);
+        return () => {
             dispatchChartUnmounted(chartId);
-        }
+        };
+    }, [chartId]);
+
+    if (isEmpty(chartData?.chartType) || isUndefined(Toolbar)) {
+        return <div/>;
     }
 
-    render() {
-        const {chartId, chartData, deletable:deletableProp, expandable, expandedMode, Toolbar, showToolbar, showChart, glass} = this.props;
-        const deletable = isUndefined(get(chartData, 'deletable')) ? deletableProp : get(chartData, 'deletable');
-
-        if (isEmpty(chartData) || isUndefined(Toolbar)) {
-            return (
-                <div/>
-            );
-        }
-
-        // var {widthPx, heightPx} = this.state;
-        const errors  = getErrors(chartId);
-
-        if (showChart) {
-            // chart with toolbar
-            if (showToolbar) {
-                return (
-                    <div className='ChartPanel__container'>
-                        <div className='ChartPanel__wrapper'>
-                            <Toolbar {...{chartId, expandable, expandedMode}}/>
-                            <div className='ChartPanel__chartarea--withToolbar'>
-                                <ResizableChartArea
-                                    {...Object.assign({}, this.props, {errors})} />
-                                {glass && <div className='ChartPanel__chartarea--withToolbar ChartPanel__glass'/>}
-                                { deletable &&
-                                <img style={{display: 'inline-block', position: 'absolute', top: 29, right: 0, alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}
-                                     title='Delete this chart'
-                                     src={DELETE}
-                                     onClick={(ev) => {dispatchChartRemove(chartId); stopPropagation(ev);}}
-                                />}
-                            </div>
-                        </div>
-                    </div>
-                );
-            } else {
-                // chart only
-                return (
-                    <div className='ChartPanel__container'>
-                        <div className='ChartPanel__chartarea'>
-                            <ResizableChartArea
-                                {...Object.assign({}, this.props, {errors})} />
-                            {glass && <div className='ChartPanel__chartarea ChartPanel__glass'/>}
-                            {deletable &&
-                            <img style={{display: 'inline-block', position: 'absolute', top: 0, right: 0, alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}
-                                 title='Delete this chart'
-                                 src={DELETE}
-                                 onClick={(ev) => {dispatchChartRemove(chartId); stopPropagation(ev);}}
-                            />}
-                        </div>
-                    </div>
-                );
-            }
-        } else {
-            // toolbar only
-            return (
-                <div className='ChartPanel__chartarea'>
-                    <Toolbar {...{chartId, expandable, expandedMode}}/>
-                </div>
-            );
-        }
+    if (showToolbar) {
+        // chart with toolbar
+        return (
+            <div className='ChartPanel__container'>
+                <ChartToolbar {...{chartId, expandable, expandedMode, Toolbar}}/>
+                <ChartArea glass={true} {...props}/>
+            </div>
+        );
+    } else {
+        // chart only
+        return <ChartArea glass={false} {...props}/>;
     }
 }
 
@@ -115,28 +60,48 @@ ChartPanelView.defaultProps = {
     Toolbar: PlotlyToolbar
 };
 
+const ResizableChartAreaInternal = React.memo((props) => {
+    const {errors, Chart, size}= props;
+    const {width:widthPx, height:heightPx}= size;
+    const knownSize = widthPx && heightPx;
+    return (
+        <div id='chart-resizer' className='ChartPanel__chartresizer'>
+            {knownSize ?
+                errors.length > 0 || isUndefined(Chart) ?
+                    <ErrorPanel errors={errors}/> :
+                    <Chart {...Object.assign({}, props, {widthPx, heightPx})}/> :
+                <div/>}
+        </div>
+    );
+});
 
-class ResizableChartAreaInternal extends PureComponent {
-    render() {
-        const {errors, Chart}= this.props;
-        const {width:widthPx, height:heightPx}= this.props.size;
-        const knownSize = widthPx && heightPx;
-        return (
-            <div id='chart-resizer' className='ChartPanel__chartresizer'>
-                {knownSize ?
-                    errors.length > 0 || isUndefined(Chart) ?
-                        <ErrorPanel errors={errors}/> :
-                        <Chart {...Object.assign({}, this.props, {widthPx, heightPx})}/> :
-                    <div/>}
-            </div>
-        );
+export const ChartToolbar = (props={}) => {
+    const {Toolbar=PlotlyToolbar, chartId, expandable, expandedMode} = props;
+    return <Toolbar {...{chartId, expandable, expandedMode}}/>;
+};
 
-    }
-}
+const ChartArea = (props) => {
+    const {chartId, chartData, deletable:deletableProp, glass} = props;
+    const deletable = isUndefined(get(chartData, 'deletable')) ? deletableProp : get(chartData, 'deletable');
+    const errors  = getErrors(chartId);
+    return (
+        <div className='ChartPanel__chartarea'>
+            <ResizableChartArea
+                {...Object.assign({}, props, {errors})} />
+            {glass && <div className='ChartPanel__chartarea ChartPanel__glass'/>}
+            {deletable &&
+            <img style={{display: 'inline-block', position: 'absolute', top: 0, right: 0, alignSelf: 'baseline', padding: 2, cursor: 'pointer'}}
+                 title='Delete this chart'
+                 src={DELETE}
+                 onClick={(ev) => {dispatchChartRemove(chartId); ev.stopPropagation();}}
+            />}
+        </div>
+    );
+};
+
 
 const ResizableChartArea= wrapResizer(ResizableChartAreaInternal);
 
-const stopPropagation= (ev) => ev.stopPropagation();
 
 function ErrorPanel({errors}) {
     return (
@@ -162,52 +127,12 @@ ErrorPanel.propTypes = {
         }))
 };
 
-export class ChartPanel extends PureComponent {
-
-    constructor(props) {
-        super(props);
-        this.state = this.getNextState();
-        this.test = props;
-    }
-
-    componentDidMount() {
-        this.removeListener = flux.addListener(() => this.storeUpdate());
-        this.iAmMounted = true;
-    }
-
-    componentWillUnmount() {
-        this.iAmMounted=false;
-        this.removeListener && this.removeListener();
-    }
-
-    getNextState() {
-        const {chartId} = this.props;
-        const chartData =  getChartData(chartId);
-        if (!isEmpty(chartData)) {
-
-            return {
-                chartData
-            };
-        } else {
-            return {};
-        }
-    }
-
-    storeUpdate() {
-        if (this.iAmMounted) {
-
-            if (getChartData(this.props.chartId) !== this.state.chartData) {
-                this.setState(this.getNextState());
-            }
-        }
-    }
-
-    render() {
-        return (
-            <ChartPanelView key={this.props.chartId} {...this.props} {...this.state}/>
-        );
-    }
-}
+export const ChartPanel = ({chartId, ...props}) => {
+    const chartData = useStoreConnector(() => getChartData(chartId));
+    return (
+        <ChartPanelView key={chartId} {...{chartId, chartData}} {...props}/>
+    );
+};
 
 ChartPanel.propTypes = {
     chartId: PropTypes.string.isRequired,

--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -123,7 +123,7 @@ export class ChartSelectPanel extends SimpleComponent {
     }
 
     render() {
-        const {tbl_id, chartId, inputStyle={}, hideDialog} = this.props;
+        const {tbl_id, chartId, inputStyle={}, hideDialog, style={}} = this.props;
         const {renderTreeId}= this.context;
 
         const chartActions = getChartActions({chartId, tbl_id});
@@ -133,7 +133,7 @@ export class ChartSelectPanel extends SimpleComponent {
         const chartActionChanged = (chartAction) => { this.setState({chartAction}); };
 
         return (
-            <div style={{padding: 10}}>
+            <div style={{padding: 10, ...style}}>
                 <FormPanel
                     groupKey={groupKey}
                     submitText={chartAction===CHART_TRACE_MODIFY ? 'Apply' : 'OK'}
@@ -142,6 +142,7 @@ export class ChartSelectPanel extends SimpleComponent {
                     onError={() => {}}
                     onCancel={hideDialog}
                     inputStyle = {inputStyle}
+                    style={{padding:5}}
                     changeMasking={this.changeMasking}>
                     <ChartAction {...{chartId, chartActions, chartAction, chartActionChanged}}/>
                     <ChartActionOptions {...{chartAction, tbl_id, chartId, groupKey, hideDialog}}/>
@@ -191,7 +192,7 @@ function ChartAction({chartId, chartActions, chartAction, chartActionChanged}) {
         };
 
         return (
-            <div style={{marginTop:-10}}>
+            <div>
                 <RadioGroupInputFieldView
                     options={options}
                     alignment={'horizontal'}
@@ -312,6 +313,7 @@ export function showChartsDialog(chartId) {
                 tbl_id,
                 chartId,
                 chartAction: CHART_TRACE_MODIFY,
+                style: {marginTop: -10},
                 inputStyle: {backgroundColor:'none', padding: 3, border: 'none', borderBottom: 'solid 1px #a5a5a'},
                 hideDialog: ()=>dispatchHideDialog(popupId)}}/>
         </PopupPanel>

--- a/src/firefly/js/charts/ui/ChartWorkArea.jsx
+++ b/src/firefly/js/charts/ui/ChartWorkArea.jsx
@@ -32,6 +32,7 @@ import {HelpIcon} from '../../ui/HelpIcon';
 import {getComponentState, dispatchComponentStateChange} from '../../core/ComponentCntlr';
 import {SplitContent} from '../../ui/panel/DockLayoutPanel';
 import {hideInfoPopup, showInfoPopup, showYesNoPopup, showPinMessage} from '../../ui/PopupUtil.jsx';
+import {TextButton} from '../../ui/TextButton.jsx';
 
 const logger = Logger('ChartWorkArea');
 const PINNED_CHART_PREFIX = 'pinned-';
@@ -196,7 +197,7 @@ const Toolbar = ({viewerId, tbl_group, style={}}) => {
 
     return (
         <div style={{display: 'inline-flex', justifyContent: 'flex-end', backgroundColor: 'inherit', marginBottom: 3, ...style}}>
-            {canPin && <div onClick={doPinChart} title='Pin the active chart' className='button text' style={{marginRight:20}}>Pin Chart</div>}
+            {canPin && <TextButton onClick={doPinChart} title='Pin the active chart' style={{marginRight:20}}>Pin Chart</TextButton>}
             {canShowTable && <div onClick={showTable} title='Show the table associated with this chart' className='button text'>Show Table</div>}
             {canToggle && <div onClick={toggleSideBySide} title={modeTitle} className='button text'>{modeLabel}</div>}
             <HelpIcon helpId={'chartarea.info'} style={{margin: '0 10px'}}/>

--- a/src/firefly/js/charts/ui/ChartWorkArea.jsx
+++ b/src/firefly/js/charts/ui/ChartWorkArea.jsx
@@ -1,0 +1,339 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import './ChartPanel.css';
+
+import React, {useContext, useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {isEmpty, isEqual, isUndefined, omit, cloneDeep, set} from 'lodash';
+import SplitPane from 'react-split-pane';
+
+import {CloseButton} from '../../ui/CloseButton.jsx';
+import {ChartPanel} from './ChartPanel.jsx';
+import {MultiItemViewerView} from '../../visualize/ui/MultiItemViewerView.jsx';
+import {
+    dispatchAddViewer, dispatchViewerUnmounted, dispatchUpdateCustom,
+    getMultiViewRoot, getViewer, getLayoutType, PLOT2D, getViewerItemIds, dispatchRemoveViewerItems, dispatchAddViewerItems, NewPlotMode
+} from '../../visualize/MultiViewCntlr.js';
+import {getExpandedChartProps, getChartData, CHART_ADD, CHART_REMOVE, getChartIdsInGroup, dispatchChartAdd, dispatchChartRemove} from '../ChartsCntlr.js';
+import {LO_VIEW, LO_MODE, dispatchSetLayoutMode} from '../../core/LayoutCntlr.js';
+import {MultiChartToolbarStandard, MultiChartToolbarExpanded} from './MultiChartToolbar.jsx';
+import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent';
+import {Logger} from '../../util/Logger.js';
+import {findGroupByTblId, getActiveTableId, getTblById, monitorChanges} from '../../tables/TableUtil';
+import {TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_REMOVE, dispatchActiveTableChanged} from '../../tables/TablesCntlr';
+import {uniqueChartId} from '../../charts/ChartUtil';
+import {getActiveViewerItemId} from '../../charts/ui/MultiChartViewer';
+import {DefaultChartsContainer} from '../../charts/ui/ChartsContainer';
+import {StatefulTabs, switchTab, Tab} from '../../ui/panel/TabPanel';
+import {HelpIcon} from '../../ui/HelpIcon';
+import {getComponentState, dispatchComponentStateChange} from '../../core/ComponentCntlr';
+import {SplitContent} from '../../ui/panel/DockLayoutPanel';
+import {hideInfoPopup, showInfoPopup, showYesNoPopup, showPinMessage} from '../../ui/PopupUtil.jsx';
+
+const logger = Logger('ChartWorkArea');
+const PINNED_CHART_PREFIX = 'pinned-';
+
+const PINNED_VIEWER_ID = 'PINNED_CHARTS_VIEWER';
+const PINNED_GROUP = PINNED_VIEWER_ID;                 // use same id for now.
+const PINNED_MAX = 6;
+
+
+
+export function pinChart({chartId, autoLayout=true}) {
+    const chartData = cloneDeep(omit(getChartData(chartId), ['_original', 'mounted']));
+    chartData?.tablesources?.forEach((ts) => Reflect.deleteProperty(ts, '_cancel'));
+
+    const pinnedCnt = getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID)?.length ?? 0;
+    if (pinnedCnt >= PINNED_MAX) {
+        showInfoPopup('You have reached the maximum number of allowable pinned charts');
+        return;
+    }
+
+    const addChart = () => {
+        dispatchChartAdd({
+            ...chartData,
+            chartId: uniqueChartId(PINNED_CHART_PREFIX),
+            groupId: PINNED_GROUP,
+            viewerId: PINNED_VIEWER_ID,
+            deletable: true,
+            mounted: true
+        });
+        if (autoLayout && pinnedCnt === 0) {
+            // if auto-layout, show side-by-side on first pinned chart
+            showSideBySide();
+        }
+        const {sideBySide} = getComponentState(PINNED_VIEWER_ID);
+        if (!sideBySide) showPinMessage('Pinning chart');
+    };
+
+    if (!chartData?.layout?.title?.text) {
+        // if chart has no title, ask to use table's title
+        const tbl_id = chartData?.data?.[0]?.tbl_id || chartData?.fireflyData?.[0].tbl_id;
+        let title = getTblById(tbl_id)?.title || '';
+        showYesNoPopup(
+            (
+                <div style={{display: 'inline-flex', whiteSpace: 'nowrap', alignItems: 'center'}}>
+                    <div style={{marginRight: 3}}>Chart Title:</div>
+                    <input defaultValue={title} onClick={(e)=>e?.target.select()} onChange={(e) => title=e?.target?.value}/>
+                </div>
+            ),
+            (p,ans) => {
+                if (ans) set(chartData, 'layout.title', title);
+                addChart();
+                hideInfoPopup();
+            },
+            'Add a title?'
+        );
+    } else {
+        addChart();
+    }
+}
+
+export const toggleSideBySide = () => {
+    const {sideBySide=false} = getComponentState(PINNED_VIEWER_ID);
+    dispatchComponentStateChange(PINNED_VIEWER_ID, {sideBySide: !sideBySide});
+};
+
+export const showSideBySide = () => {
+    dispatchComponentStateChange(PINNED_VIEWER_ID, {sideBySide: true});
+};
+
+export const showAsTabs = (showPinnedCharts=false) => {
+    if (showPinnedCharts) {
+        switchTab(PINNED_VIEWER_ID, 1);     // tab index 1 is pinned charts
+    }
+    dispatchComponentStateChange(PINNED_VIEWER_ID, {sideBySide: false});
+};
+
+
+let splitLoc = 400;
+export const ChartWorkArea = (props) => {
+    const {viewerId, tbl_group} = props;
+
+    const chartIds = useStoreConnector(() =>  getChartIdsInGroup(PINNED_GROUP));
+    const tabs = useStoreConnector(() =>  getComponentState(PINNED_VIEWER_ID));
+    const activeLabel = useStoreConnector(() => getViewerItemIds(getMultiViewRoot(), viewerId)?.length > 1 ? 'Active Charts' : 'Active Chart');
+
+    if (!chartIds?.length)  {           // use the default container if there's no pinned charts
+        return (
+            <div className='TabPanel__main boxed' style={{height: '100%'}}>
+                <Toolbar {...{viewerId, tbl_group}}/>
+                <DefaultChartsContainer {...props}/>
+            </div>
+        );
+    }
+
+    if (tabs?.sideBySide) {
+        const label = {fontWeight: 'bold', height: 15, marginLeft: 3};
+        return (
+            <div className='TabPanel__main boxed' style={{height: '100%'}}>
+                <Toolbar {...{viewerId, tbl_group, style:{position: 'absolute', right:0, zIndex: 1}}}/>
+                <div style={{flexGrow: 1, position: 'relative'}}>
+                    <SplitPane split='vertical' defaultSize={splitLoc} onChange={(size) => splitLoc = size} style={{display: 'inline-flex'}}>
+                        <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
+                            <div style={label}>{activeLabel}</div>
+                            <DefaultChartsContainer {...props}/>
+                        </SplitContent>
+                        <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
+                            <div style={label}>Pinned Charts</div>
+                            <PinnedCharts {...props}/>
+                        </SplitContent>
+                    </SplitPane>
+                </div>
+            </div>
+        );
+    } else {
+        return (
+            <div className='TabPanel__main boxed' style={{height: '100%'}}>
+                <Toolbar {...{viewerId, tbl_group, style:{position: 'absolute', right:0, zIndex: 1}}}/>
+                <StatefulTabs componentKey={PINNED_VIEWER_ID} defaultSelected={0} useFlex={true} style={{flex: '1 1 0', marginTop: 5}}>
+                    <Tab name={activeLabel}>
+                        <DefaultChartsContainer {...props}/>
+                    </Tab>
+                    <Tab name='Pinned Charts'>
+                        <PinnedCharts {...props}/>
+                    </Tab>
+                </StatefulTabs>
+            </div>
+        );
+    }
+};
+ChartWorkArea.propTypes = {
+    expandedMode: PropTypes.bool,
+    closeable: PropTypes.bool,
+    chartId: PropTypes.string,
+    viewerId : PropTypes.string,
+    tbl_group : PropTypes.string,
+    addDefaultChart : PropTypes.bool,
+    noChartToolbar : PropTypes.bool,
+    useOnlyChartsInViewer :PropTypes.bool
+};
+
+const Toolbar = ({viewerId, tbl_group, style={}}) => {
+    const doPinChart = () => {
+        let chartId = getActiveViewerItemId(viewerId);      // viewerId is Active Charts viewer
+        if (!chartId) {
+            const tblId = getActiveTableId(tbl_group);
+            chartId = getChartIdsInGroup(tblId)?.[0] ?? getChartIdsInGroup('default')?.[0];
+        }
+        pinChart({chartId});
+    };
+    const activeChartTblId = useStoreConnector(() => {
+        const chartId = getActiveViewerItemId(PINNED_VIEWER_ID);
+        return getChartData(chartId)?.data?.[0]?.tbl_id;
+    });
+
+    const showTable = () => dispatchActiveTableChanged(activeChartTblId, tbl_group);
+
+    const {sideBySide=false, selectedIdx} = getComponentState(PINNED_VIEWER_ID);
+    const canPin = sideBySide || selectedIdx !== 1;
+    const canShowTable = activeChartTblId && (sideBySide || selectedIdx === 1);
+    const canToggle =  getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID)?.length > 0;
+    const [modeLabel, modeTitle] = sideBySide ? ['As Tabs', 'Switch to tabs layout'] : ['Side-By-Side', 'Switch to Side-By-Side layout'];
+
+    return (
+        <div style={{display: 'inline-flex', justifyContent: 'end', backgroundColor: 'inherit', marginBottom: 3, ...style}}>
+            {canPin && <div onClick={doPinChart} title='Pin the active chart' className='button text' style={{marginRight:20}}>Pin Chart</div>}
+            {canShowTable && <div onClick={showTable} title='Show the table associated with this chart' className='button text'>Show Table</div>}
+            {canToggle && <div onClick={toggleSideBySide} title={modeTitle} className='button text'>{modeLabel}</div>}
+            <HelpIcon helpId={'chartarea.info'} style={{margin: '0 10px'}}/>
+        </div>
+    );
+};
+
+export const PinnedCharts = (props) => {
+
+    const {tbl_group='main', expandedMode} = props;
+    const canReceiveNewItems=NewPlotMode.create_replace.key, closeable=false, noChartToolbar=false;
+    const viewerId = 'PINNED_CHARTS_VIEWER';
+
+    const {renderTreeId} = useContext(RenderTreeIdCtx);
+
+    // ensure viewer is initialized
+    useEffect(() => {
+        dispatchAddViewer(viewerId, canReceiveNewItems, PLOT2D,true, renderTreeId);
+        if (expandedMode) {
+            const {chartId} = getExpandedChartProps();
+            dispatchUpdateCustom(viewerId, {activeItemId: chartId});
+        }
+        return () => dispatchViewerUnmounted(viewerId);
+
+    }, [viewerId, expandedMode, renderTreeId]);
+
+    useEffect(() => {
+        // make sure the viewer is updated with related charts on start
+        // important when we use external viewer
+        doUpdateViewer(viewerId, tbl_group);
+
+        const accept = (a) => {
+            const {tbl_id, chartId} = a.payload;
+            return chartId || tbl_group === findGroupByTblId(tbl_id);
+        };
+        return monitorChanges([CHART_ADD, CHART_REMOVE, TBL_RESULTS_ACTIVE, TABLE_REMOVE, TABLE_LOADED], accept, (a)=> doUpdateViewer(viewerId, tbl_group, a), `wtg-${viewerId}-${tbl_group}`);
+
+    }, [tbl_group, viewerId]);
+
+    const viewer = useStoreConnector(() => getViewer(getMultiViewRoot(),viewerId));
+
+    if (!viewer || isEmpty(viewer.itemIdAry)) {
+        return expandedMode && closeable ? <BlankClosePanel/> : null;
+    }
+
+    let activeItemId = getActiveViewerItemId(viewerId);
+    if (isUndefined(activeItemId) || !getChartData(activeItemId)?.chartType) {
+        activeItemId = viewer.itemIdAry[0];
+    }
+
+    const deletable = viewer.itemIdAry.length > 1;                  // if there are more than 1 chart in the viewer, they should be deletable by default
+    const layoutType= getLayoutType(getMultiViewRoot(), viewerId);
+
+    const onChartSelect = (ev,chartId) => {
+        if (chartId !== activeItemId) {
+            dispatchUpdateCustom(viewerId, {activeItemId: chartId});
+        }
+        stopPropagation(ev);
+    };
+
+    const makeItemViewer = (chartId) => (
+        <div className={chartId === activeItemId ? 'ChartPanel ChartPanel--active' : 'ChartPanel'}
+             onClick={(ev)=>onChartSelect(ev,chartId)}
+             onTouchStart={stopPropagation}
+             onMouseDown={stopPropagation}>
+            <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
+        </div>
+    );
+
+    const makeItemViewerFull = (chartId) => (
+        <div onClick={stopPropagation}
+             onTouchStart={stopPropagation}
+             onMouseDown={stopPropagation}>
+            <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
+        </div>
+    );
+
+    const viewerItemIds = viewer.itemIdAry;
+    const ToolBar = expandedMode ? MultiChartToolbarExpanded : MultiChartToolbarStandard;
+
+    logger.log('Active chart ID: ' + activeItemId);
+
+    return (
+        <div className='ChartPanel__container'>
+            <div className='ChartPanel__wrapper'>
+                <ToolBar chartId={activeItemId} expandable={!expandedMode} {...{expandedMode, closeable, viewerId, layoutType, activeItemId}}/>
+                <MultiItemViewerView {...props} {...{layoutType, makeItemViewer, makeItemViewerFull, viewerItemIds}}/>
+            </div>
+        </div>
+    );
+};
+
+PinnedCharts.propTypes= {
+    tbl_group: PropTypes.string,
+    expandedMode: PropTypes.bool,
+};
+
+
+
+function stopPropagation(ev) {
+    ev.stopPropagation();
+}
+
+function BlankClosePanel() {
+    return (
+        <div className='ChartPanel__container'>
+            <div style={{position: 'relative', flexGrow: 1}}>
+                <CloseButton style={{paddingLeft: 10, position: 'absolute', top: 0, left: 0}} onClick={() => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)}/>
+            </div>
+        </div>
+    );
+}
+
+function doUpdateViewer(viewerId, tbl_group, action) {
+    if (action?.type === TABLE_REMOVE) {
+        const {tbl_id} = action.payload;
+        getChartIdsInGroup(PINNED_GROUP)
+            .filter((id) => getChartData(id)?.tbl_id === tbl_id)
+            .forEach((id) => dispatchChartRemove(id));
+    }
+
+    const currentIds = getViewerItemIds(getMultiViewRoot(), PINNED_GROUP);
+    const chartIds = getChartIdsInGroup(PINNED_GROUP);
+
+    if (!isEqual(chartIds, currentIds)) {
+        dispatchRemoveViewerItems(PINNED_GROUP, currentIds);
+        dispatchAddViewerItems(PINNED_GROUP, chartIds, PLOT2D);
+    }
+}
+
+// const ToolBar = (props) => {
+//     const {expandedMode, closeable, viewerId, layoutType, activeItemId, chartId, expandable} = props;
+//     const MultiChartTB = expandedMode ? MultiChartToolbarExpanded : MultiChartToolbarStandard;
+//     return (
+//         <div>
+//             <MultiChartTB {...{closeable, viewerId, layoutType, activeItemId}}/>
+//             <ToolbarUI {...{chartId, expandable, expandedMode}}/>
+//         </div>
+//     );
+// };

--- a/src/firefly/js/charts/ui/ChartWorkArea.jsx
+++ b/src/firefly/js/charts/ui/ChartWorkArea.jsx
@@ -207,7 +207,7 @@ const Toolbar = ({viewerId, tbl_group, style={}}) => {
 export const PinnedCharts = (props) => {
 
     const {tbl_group='main', expandedMode} = props;
-    const canReceiveNewItems=NewPlotMode.create_replace.key, closeable=false, noChartToolbar=false;
+    const canReceiveNewItems=NewPlotMode.create_replace.key, closeable=false;
     const viewerId = 'PINNED_CHARTS_VIEWER';
 
     const {renderTreeId} = useContext(RenderTreeIdCtx);
@@ -311,11 +311,21 @@ function BlankClosePanel() {
 }
 
 function doUpdateViewer(viewerId, tbl_group, action) {
-    if (action?.type === TABLE_REMOVE) {
-        const {tbl_id} = action.payload;
-        getChartIdsInGroup(PINNED_GROUP)
-            .filter((id) => getChartData(id)?.tbl_id === tbl_id)
-            .forEach((id) => dispatchChartRemove(id));
+    switch (action?.type) {
+        case TABLE_REMOVE: {
+            const {tbl_id} = action.payload;
+            getChartIdsInGroup(PINNED_GROUP)
+                .filter((id) => getChartData(id)?.tbl_id === tbl_id)
+                .forEach((id) => dispatchChartRemove(id));
+            break;
+        }
+        case CHART_REMOVE: {
+            const pinnedCnt = getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID)?.length ?? 0;
+            if (pinnedCnt <= 0) {
+                switchTab(PINNED_VIEWER_ID, 0);  // set selected tab back to 0
+            }
+            break;
+        }
     }
 
     const currentIds = getViewerItemIds(getMultiViewRoot(), PINNED_GROUP);
@@ -326,14 +336,3 @@ function doUpdateViewer(viewerId, tbl_group, action) {
         dispatchAddViewerItems(PINNED_GROUP, chartIds, PLOT2D);
     }
 }
-
-// const ToolBar = (props) => {
-//     const {expandedMode, closeable, viewerId, layoutType, activeItemId, chartId, expandable} = props;
-//     const MultiChartTB = expandedMode ? MultiChartToolbarExpanded : MultiChartToolbarStandard;
-//     return (
-//         <div>
-//             <MultiChartTB {...{closeable, viewerId, layoutType, activeItemId}}/>
-//             <ToolbarUI {...{chartId, expandable, expandedMode}}/>
-//         </div>
-//     );
-// };

--- a/src/firefly/js/charts/ui/ChartWorkArea.jsx
+++ b/src/firefly/js/charts/ui/ChartWorkArea.jsx
@@ -195,7 +195,7 @@ const Toolbar = ({viewerId, tbl_group, style={}}) => {
     const [modeLabel, modeTitle] = sideBySide ? ['As Tabs', 'Switch to tabs layout'] : ['Side-By-Side', 'Switch to Side-By-Side layout'];
 
     return (
-        <div style={{display: 'inline-flex', justifyContent: 'end', backgroundColor: 'inherit', marginBottom: 3, ...style}}>
+        <div style={{display: 'inline-flex', justifyContent: 'flex-end', backgroundColor: 'inherit', marginBottom: 3, ...style}}>
             {canPin && <div onClick={doPinChart} title='Pin the active chart' className='button text' style={{marginRight:20}}>Pin Chart</div>}
             {canShowTable && <div onClick={showTable} title='Show the table associated with this chart' className='button text'>Show Table</div>}
             {canToggle && <div onClick={toggleSideBySide} title={modeTitle} className='button text'>{modeLabel}</div>}

--- a/src/firefly/js/charts/ui/MultiChartToolbar.jsx
+++ b/src/firefly/js/charts/ui/MultiChartToolbar.jsx
@@ -16,24 +16,77 @@ import PAGE_RIGHT from 'html/images/icons-2014/20x20_PageRight.png';
 import PAGE_LEFT from 'html/images/icons-2014/20x20_PageLeft.png';
 
 import {PagingControl} from '../../visualize/iv/ExpandedTools.jsx';
+import {ChartToolbar} from './ChartPanel';
+import {CloseButton} from '../../ui/CloseButton';
+import {dispatchSetLayoutMode, LO_MODE, LO_VIEW} from '../../core/LayoutCntlr';
 
 
-const toolsStyle= {
-    position:'absolute',
-    top: 'calc(0% + 1px)',
-    left: 'calc(50% - 50px)',
-    zIndex:1,
-    display:'flex',
-    flexDirection:'row',
-    flexWrap:'nowrap',
-    // alignItems: 'center',
-    height: 25,
-    justifyContent: 'space-between'
-};
-
-export function MultiChartToolbarStandard({viewerId,
+export function MultiChartToolbarStandard({viewerId, chartId, expandable, expandedMode,
     layoutType=getLayoutType(getMultiViewRoot(), viewerId),
     activeItemId=getViewer(getMultiViewRoot(), viewerId).customData.activeItemId}) {
+
+    return (
+        <div style={tbstyle}>
+            <MultiChartStd {...{viewerId, layoutType, activeItemId}}/>
+            <ChartToolbar {...{chartId, expandable, expandedMode}}/>
+        </div>
+    );
+}
+
+MultiChartToolbarStandard.propTypes= {
+    viewerId : PropTypes.string.isRequired,
+    layoutType : PropTypes.string,
+    activeItemId : PropTypes.string,
+    chartId: PropTypes.string.isRequired,
+    expandable: PropTypes.bool,
+    expandedMode: PropTypes.bool
+};
+
+
+const tbstyle= {
+    display: 'inline-flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+    marginBottom: 2
+};
+
+
+const viewerTitleStyle= {
+    display: 'inline-block',
+    paddingLeft: 5,
+    paddingRight: 10,
+    lineHeight: '2em',
+    fontSize: '10pt',
+    fontWeight: 'bold',
+    alignSelf : 'center'
+};
+
+export function MultiChartToolbarExpanded({viewerId, chartId, expandable, expandedMode, closeable,
+    layoutType=getLayoutType(getMultiViewRoot(), viewerId),
+    activeItemId=getViewer(getMultiViewRoot(), viewerId)?.customData?.activeItemId}) {
+
+    return (
+        <div style={tbstyle}>
+            {closeable && <CloseButton onClick={() => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)}/>}
+            <MultiChartExt {...{viewerId, layoutType, activeItemId}}/>
+            <ChartToolbar {...{chartId, expandable, expandedMode}}/>
+        </div>
+    );
+
+}
+
+MultiChartToolbarExpanded.propTypes= {
+    viewerId : PropTypes.string.isRequired,
+    layoutType : PropTypes.string,
+    activeItemId : PropTypes.string,
+    chartId: PropTypes.string.isRequired,
+    expandable: PropTypes.bool,
+    expandedMode: PropTypes.bool,
+    closeable: PropTypes.bool
+};
+
+const MultiChartStd = ({viewerId, layoutType, activeItemId}) => {
 
     const viewerItemIds = getViewerItemIds(getMultiViewRoot(), viewerId);
     var cIdx= viewerItemIds.findIndex( (itemId) => itemId===activeItemId);
@@ -54,119 +107,73 @@ export function MultiChartToolbarStandard({viewerId,
     const nextIdx= cIdx===viewerItemIds.length-1 ? 0 : cIdx+1;
     const prevIdx= cIdx ? cIdx-1 : viewerItemIds.length-1;
 
-
     return (
-        <div style={toolsStyle}>
-            <div style={{display:'flex', flexDirection:'row', flexWrap:'nowrap'}}>
-                <ToolbarButton icon={ONE} tip={'Show single chart'}
-                               imageStyle={{width:24,height:24, flex: '0 0 auto'}}
-                               enabled={true} visible={true}
-                               horizontal={true}
-                               onClick={() => dispatchChangeViewerLayout(viewerId,'single')}/>
-                <ToolbarButton icon={GRID} tip={'Show all charts as tiles'}
-                               enabled={true} visible={true} horizontal={true}
-                               imageStyle={{width:24,height:24,  paddingLeft:5, flex: '0 0 auto'}}
-                               onClick={() => dispatchChangeViewerLayout(viewerId,'grid')}/>
-                {layoutType==='single' && viewerItemIds.length>2 &&
-                <img style={leftImageStyle} src={PAGE_LEFT}
-                     onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[prevIdx]})} />
-                }
-                {layoutType==='single' && viewerItemIds.length>1 &&
-                <img style={{verticalAlign:'bottom', cursor:'pointer', float: 'right', paddingLeft:5, flex: '0 0 auto'}}
-                     src={PAGE_RIGHT}
-                     onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[nextIdx]})} />
-                }
-            </div>
+        <div style={{display:'inline-flex', alignItems: 'center'}}>
+            <ToolbarButton icon={ONE} tip={'Show single chart'}
+                           imageStyle={{width:24,height:24, flex: '0 0 auto'}}
+                           enabled={true} visible={true}
+                           horizontal={true}
+                           onClick={() => dispatchChangeViewerLayout(viewerId,'single')}/>
+            <ToolbarButton icon={GRID} tip={'Show all charts as tiles'}
+                           enabled={true} visible={true} horizontal={true}
+                           imageStyle={{width:24,height:24,  paddingLeft:5, flex: '0 0 auto'}}
+                           onClick={() => dispatchChangeViewerLayout(viewerId,'grid')}/>
+            {layoutType==='single' && viewerItemIds.length>2 &&
+            <img style={leftImageStyle} src={PAGE_LEFT}
+                 onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[prevIdx]})} />
+            }
+            {layoutType==='single' && viewerItemIds.length>1 &&
+            <img style={{verticalAlign:'bottom', cursor:'pointer', float: 'right', paddingLeft:5, flex: '0 0 auto'}}
+                 src={PAGE_RIGHT}
+                 onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[nextIdx]})} />
+            }
         </div>
     );
-}
-
-MultiChartToolbarStandard.propTypes= {
-    viewerId : PropTypes.string.isRequired,
-    layoutType : PropTypes.string,
-    activeItemId : PropTypes.string
 };
 
 
-const toolsStyleExpanded= {
-    position:'absolute',
-    top: 0,
-    left: 'calc(0% + 200px)',
-    right:'calc(0% + 300px)',
-    zIndex:1,
-    display:'flex',
-    flexDirection:'row',
-    flexWrap:'nowrap',
-    // alignItems: 'center',
-    height: 28,
-    justifyContent: 'space-between'
-};
-
-
-const viewerTitleStyle= {
-    display: 'inline-block',
-    paddingLeft: 5,
-    paddingRight: 10,
-    lineHeight: '2em',
-    fontSize: '10pt',
-    fontWeight: 'bold',
-    alignSelf : 'center'
-};
-
-export function MultiChartToolbarExpanded({viewerId,
-    layoutType=getLayoutType(getMultiViewRoot(), viewerId),
-    activeItemId=getViewer(getMultiViewRoot(), viewerId).customData.activeItemId}) {
-
+const MultiChartExt = ({viewerId, layoutType, activeItemId}) => {
     const viewerItemIds = getViewerItemIds(getMultiViewRoot(), viewerId);
 
-    if (viewerItemIds.length===1) {
-        return (
-            <div style={toolsStyleExpanded}/>);
+    if (viewerItemIds.length < 2) {
+        return null;
     }
 
-    var viewerTitle = (
+    const viewerTitle = (
         <div style={viewerTitleStyle}>
             {layoutType==='single' ? getChartTitle(activeItemId, viewerItemIds) : 'Tiled View'}
-        </div>);
+        </div>
+    );
 
     return (
-        <div style={toolsStyleExpanded}>
-            <div style={{width:'100%', display: 'flex', justifyContent:'space-between'}} className='disable-select'>
-                <div style={{alignSelf:'flex-start', whiteSpace:'nowrap'}}>
-                    {viewerTitle}
+        <div style={{display: 'inline-flex', flexGrow: 1, justifyContent: 'space-evenly'}} className='disable-select'>
+            <div style={{alignSelf:'flex-start', whiteSpace:'nowrap'}}>
+                {viewerTitle}
+            </div>
+            <div style={{alignSelf:'flex-end', whiteSpace:'nowrap', height: 24, paddingBottom:3}}>
+                <div style={{display: 'inline-block', verticalAlign:'top'}}>
+                    <ToolbarButton icon={ONE} tip={'Show single chart'}
+                                   imageStyle={{width:24,height:24, flex: '0 0 auto'}}
+                                   enabled={true} visible={true}
+                                   horizontal={true}
+                                   onClick={() => dispatchChangeViewerLayout(viewerId,'single')}/>
+                    <ToolbarButton icon={GRID} tip={'Show all charts as tiles'}
+                                   enabled={true} visible={true} horizontal={true}
+                                   imageStyle={{width:24,height:24,  paddingLeft:5, flex: '0 0 auto'}}
+                                   onClick={() => dispatchChangeViewerLayout(viewerId,'grid')}/>
                 </div>
-                <div style={{alignSelf:'flex-end', whiteSpace:'nowrap', height: 24, paddingBottom:3}}>
-                    <div style={{display: 'inline-block', verticalAlign:'top'}}>
-                        <ToolbarButton icon={ONE} tip={'Show single chart'}
-                                       imageStyle={{width:24,height:24, flex: '0 0 auto'}}
-                                       enabled={true} visible={true}
-                                       horizontal={true}
-                                       onClick={() => dispatchChangeViewerLayout(viewerId,'single')}/>
-                        <ToolbarButton icon={GRID} tip={'Show all charts as tiles'}
-                                       enabled={true} visible={true} horizontal={true}
-                                       imageStyle={{width:24,height:24,  paddingLeft:5, flex: '0 0 auto'}}
-                                       onClick={() => dispatchChangeViewerLayout(viewerId,'grid')}/>
-                    </div>
-                    <div style={{display: 'inline-block', verticalAlign:'middle'}}>
-                        <PagingControl
-                            viewerItemIds={viewerItemIds}
-                            activeItemId={activeItemId}
-                            isPagingMode={layoutType==='single'}
-                            getItemTitle={(itemId) => getChartTitle(itemId, viewerItemIds)}
-                            onActiveItemChange={(itemId) => dispatchUpdateCustom(viewerId, {activeItemId: itemId})}
-                        />
-                    </div>
+                <div style={{display: 'inline-block', verticalAlign:'middle'}}>
+                    <PagingControl
+                        viewerItemIds={viewerItemIds}
+                        activeItemId={activeItemId}
+                        isPagingMode={layoutType==='single'}
+                        getItemTitle={(itemId) => getChartTitle(itemId, viewerItemIds)}
+                        onActiveItemChange={(itemId) => dispatchUpdateCustom(viewerId, {activeItemId: itemId})}
+                    />
                 </div>
             </div>
         </div>
     );
-
-}
-
-MultiChartToolbarExpanded.propTypes= {
-    viewerId : PropTypes.string.isRequired,
-    layoutType : PropTypes.string,
-    activeItemId : PropTypes.string
 };
 
 const getChartTitle = (chartId, viewerItemIds) => {

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -21,7 +21,7 @@ import {MultiChartToolbarStandard, MultiChartToolbarExpanded} from './MultiChart
 import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
 
 export function getActiveViewerItemId(viewerId) {
-    return getViewer(getMultiViewRoot(), viewerId).customData.activeItemId;
+    return getViewer(getMultiViewRoot(), viewerId)?.customData?.activeItemId;
 }
 
 
@@ -122,7 +122,7 @@ export class MultiChartViewer extends PureComponent {
                  onClick={(ev)=>onChartSelect(ev,chartId)}
                  onTouchStart={stopPropagation}
                  onMouseDown={stopPropagation}>
-                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable} glass={glass}/>
+                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
             </div>
         );
 
@@ -130,7 +130,7 @@ export class MultiChartViewer extends PureComponent {
             <div onClick={stopPropagation}
                  onTouchStart={stopPropagation}
                  onMouseDown={stopPropagation}>
-                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable} glass={glass}/>
+                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
             </div>
         );
 
@@ -144,30 +144,13 @@ export class MultiChartViewer extends PureComponent {
 
         //console.log('Active chart ID: '+activeItemId);
 
-        const showChartToolbar = !Boolean(noChartToolbar);
-        const hasToolbar = showChartToolbar || (viewer.itemIdAry.length > 1);
-        const chartAreaClass = `ChartPanel__chartarea${hasToolbar?'--withToolbar':''}`;
-        
+        const ToolBar = expandedMode ? MultiChartToolbarExpanded : MultiChartToolbarStandard;
+
         return (
-        <div className='ChartPanel__container'>
-            <div className='ChartPanel__wrapper'>
-                {expandedMode ? <MultiChartToolbarExpanded {...{closeable, viewerId, layoutType, activeItemId}}/> : <MultiChartToolbarStandard {...{viewerId, layoutType, activeItemId}}/>}
-                {showChartToolbar &&
-                <ChartPanel key={'toolbar-'+activeItemId}
-                            expandedMode={expandedMode}
-                            expandable={!expandedMode}
-                            showChart={false}
-                            chartId={activeItemId}
-                            deletable={deletable}/>
-                }
-
-                <div className={chartAreaClass}>
-                    <MultiItemViewerView {...this.props} {...newProps}/>
-                </div>
-                {expandedMode && closeable && <CloseButton style={{paddingLeft: 10, position: 'absolute', top: 0, left: 0}} onClick={() => dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none)}/>}
+            <div style={{position: 'relative', width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>
+                <ToolBar chartId={activeItemId} expandable={!expandedMode} {...{expandedMode, closeable, viewerId, layoutType, activeItemId}}/>
+                <MultiItemViewerView {...this.props} {...newProps}/>
             </div>
-        </div>
-
         );
     }
 }

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -147,7 +147,7 @@ export class MultiChartViewer extends PureComponent {
         const ToolBar = expandedMode ? MultiChartToolbarExpanded : MultiChartToolbarStandard;
 
         return (
-            <div style={{position: 'relative', width: '100%', height: '100%', display: 'flex', flexDirection: 'column'}}>
+            <div className='ChartPanel__wrapper' style={{width: '100%', height: '100%', boxSizing: 'border-box'}}>
                 <ToolBar chartId={activeItemId} expandable={!expandedMode} {...{expandedMode, closeable, viewerId, layoutType, activeItemId}}/>
                 <MultiItemViewerView {...this.props} {...newProps}/>
             </div>

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -213,8 +213,7 @@ function onClick(chartId) {
 
         const traceNum = curveNumber >= curveNumberMap.length ? curveNumber : curveNumberMap[curveNumber];
         if (traceNum !== activeTrace && traceNum < curveNumberMap.length) {
-            activeTrace = traceNum;
-            dispatchSetActiveTrace({chartId, activeTrace});
+            dispatchSetActiveTrace({chartId, activeTrace: traceNum});
         }
 
         // traceNum is related to any of trace data or SELECTED trace or HIGHLIGHTED trace

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -20,14 +20,7 @@ import {findViewerWithItemId, getMultiViewRoot, PLOT2D} from '../../visualize/Mu
 export function PlotlyToolbar({chartId, expandable, expandedMode}) {
     const {activeTrace} = getChartData(chartId);
     const ToolbarUI = getToolbarUI(chartId, activeTrace);
-    return (
-        <div className={`PanelToolbar ChartPanel__toolbar ${expandedMode?'ChartPanel__toolbar--offsetLeft':''}`}>
-            <div className='PanelToolbar__group'/>
-            <div className='PanelToolbar__group'>
-                <ToolbarUI {...{chartId, expandable}}/>
-                </div>
-        </div>
-    );
+    return <ToolbarUI {...{chartId, expandable}}/>;
 }
 
 PlotlyToolbar.propTypes = {

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -23,7 +23,7 @@ export function TableInfo(props) {
    const jobId = getJobIdFromTblId(tbl_id);
 
     return (
-        <div style={{padding: 10, padding: '10px 5px 5px', height: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column'}}>
+        <div style={{padding: '10px 5px 5px', height: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column'}}>
             <StatefulTabs componentKey='TablePanelOptions' defaultSelected={0} borderless={true} useFlex={true} style={{flex: '1 1 0'}}>
                 {jobId &&
                 <Tab name='Job Info'>

--- a/src/firefly/js/ui/TextButton.jsx
+++ b/src/firefly/js/ui/TextButton.jsx
@@ -6,40 +6,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const labelStyle= {
-    display: 'inline-block',
-    fontSize: '10pt',
-    fontStyle: 'italic',
-    color: 'blue',
-    verticalAlign:'baseline'
+export const TextButton = ({text, style, children, ...rest}) => {
+    const val = text || children || '';
+    return (
+        <div className='button text' style={style} {...{...rest}}>{val}</div>
+    );
 };
 
-/**
- *
- * @param text
- * @param tip
- * @param onClick
- * @param style
- * @return react object
- */
-export function TextButton({text, tip='$text',style={}, onClick}) {
-    var s= Object.assign({cursor:'pointer', verticalAlign:'bottom'},style);
-    return (
-        <div style={s} title={tip} onClick={onClick}>
-            <div style={labelStyle} title={tip}>
-                <u>{text}</u>
-            </div>
-
-        </div>
-    );
-}
-
-
 TextButton.propTypes= {
-    text : PropTypes.string,
-    style : PropTypes.object,
-    tip : PropTypes.string,
-    onClick : PropTypes.func
+    text: PropTypes.string,
+    style: PropTypes.object
 };
 
 

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -266,6 +266,11 @@ StatefulTabs.propTypes = {
 StatefulTabs.defaultProps = TabsView.defaultProps;
 
 
+export function switchTab(componentKey, selectedIdx) {
+    dispatchComponentStateChange(componentKey, {selectedIdx});
+}
+
+
 /*----------------------------------------------------------------------------------------------*/
 
 function onChange(idx,id, name, viewProps, fireValueChange) {

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -360,7 +360,7 @@ function getMakeDropdown(dpId, dataProductState, showMenu, showRedoSearchButton,
     const hasMenu= showMenu && menu && menu.length>0;
     if (!hasMenu && !hasFileMenu && !showRedoSearchButton && !extraction) return undefined;
     return () => (
-            <div style={{display:'flex', flexDirection:'row'}}>
+            <div style={{display:'inline-flex', alignItems: 'center', height: 30}}>
                 {!hasMenu ? <div style={{width: 50,height:1 }}/> :
                     <DropDownToolbarButton
                         text={'More'}
@@ -382,7 +382,7 @@ function getMakeDropdown(dpId, dataProductState, showMenu, showRedoSearchButton,
                     dropDown={<FileMenuDropDown {...{fileMenu, dpId}} />} />
                 }
                 { extraction &&
-                <div className='button text' style={{lineHeight: '18px'}} title={extractionText || 'Pin'} onClick={() => extraction()}>{extractionText || 'Pin'}</div> }
+                <div className='button text' style={{lineHeight: '18px', height: 18}} title={extractionText || 'Pin'} onClick={() => extraction()}>{extractionText || 'Pin'}</div> }
                 {showRedoSearchButton && analysisActivateFunc &&
                     <ToolbarButton
                         text='Redo Search' tip={'Redo Search'} horizontal={true}

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -13,6 +13,7 @@ import {MultiImageViewer} from './MultiImageViewer.jsx';
 import {MultiChartViewer} from '../../charts/ui/MultiChartViewer';
 import {SingleColumnMenu} from '../../ui/DropDownMenu.jsx';
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
+import {TextButton} from '../../ui/TextButton.jsx';
 import {CompleteButton} from '../../ui/CompleteButton';
 import {DropDownToolbarButton} from '../../ui/DropDownToolbarButton.jsx';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
@@ -382,7 +383,7 @@ function getMakeDropdown(dpId, dataProductState, showMenu, showRedoSearchButton,
                     dropDown={<FileMenuDropDown {...{fileMenu, dpId}} />} />
                 }
                 { extraction &&
-                <div className='button text' style={{lineHeight: '18px', height: 18}} title={extractionText || 'Pin'} onClick={() => extraction()}>{extractionText || 'Pin'}</div> }
+                <TextButton style={{lineHeight: '18px', height: 18}} title={extractionText || 'Pin'} onClick={() => extraction()}>{extractionText || 'Pin'}</TextButton> }
                 {showRedoSearchButton && analysisActivateFunc &&
                     <ToolbarButton
                         text='Redo Search' tip={'Redo Search'} horizontal={true}

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -382,7 +382,7 @@ function getMakeDropdown(dpId, dataProductState, showMenu, showRedoSearchButton,
                     dropDown={<FileMenuDropDown {...{fileMenu, dpId}} />} />
                 }
                 { extraction &&
-                <ToolbarButton text={extractionText || 'Pin'} tip={extractionText || 'Pin'} horizontal={true} onClick={() => extraction()} /> }
+                <div className='button text' style={{lineHeight: '18px'}} title={extractionText || 'Pin'} onClick={() => extraction()}>{extractionText || 'Pin'}</div> }
                 {showRedoSearchButton && analysisActivateFunc &&
                     <ToolbarButton
                         text='Redo Search' tip={'Redo Search'} horizontal={true}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-994
Test: https://fireflydev.ipac.caltech.edu/firefly-994-multi-table-chart-view/firefly/

Basic description of the added features, copied from ticket.
When useChartWorkArea is enabled,
- Chart Viewer may contains Active Charts and Pinned Charts
  - Displayed as tabs or side-by-side
  - Top toolbar added with help anchor
- Pin Chart button is available with Active Chart is visible
- When pinning chart
  - Ask for title if one does not exist
  - Default to table's title if exists otherwise blank
  - Not allowed after max number of pinned charts is reached (set at 6)
  - On first pin, switch to side-by-side view so the user can visually see a new chart is added to Pinned Charts tab
- When a table is deleted or removed, remove all pinned charts associated with the table.
- Show Table button: set table of the highlighted chart to active tab


Additional changes made to PR not mentioned in ticket:
- convert ChartPanel to functional component
- fix: fail to send email from docker container due to unsupported protocol
- fix: chart toolbar composition and layout