### PR TITLE
FIREFLY-599_1002: Multi tickets changes

### DIFF
--- a/config/web.xml
+++ b/config/web.xml
@@ -130,7 +130,7 @@
     <security-constraint>
       <web-resource-collection>
         <web-resource-name> Admin Area </web-resource-name>
-        <url-pattern>/admin/* </url-pattern>
+        <url-pattern>${ADMIN_PROTECTED:-/admin/*} </url-pattern>
       </web-resource-collection>
       <auth-constraint>
         <!-- Roles that have access -->

--- a/docker/launchTomcat.sh
+++ b/docker/launchTomcat.sh
@@ -2,6 +2,7 @@
 
 NAME=${BUILD_TIME_NAME:-"ipac/firefly"}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-`echo $RANDOM | base64 | head -c 8`}
+USE_ADMIN_AUTH=${USE_ADMIN_AUTH:-"true"}
 
 echo -e "\n!!============================================================"
 echo "!!============================================================"
@@ -88,8 +89,8 @@ export CATALINA_OPTS="\
   -Dvisualize.fits.search.path=${VIS_PATH} \
 	"
 
-#----- override ADMIN_PROTECTED path if set
-if [ ! -z ${ADMIN_PROTECTED+x} ]; then export CATALINA_OPTS="${CATALINA_OPTS} -DADMIN_PROTECTED='${ADMIN_PROTECTED}'"; fi
+#----- remove ADMIN_PROTECTED path so it no longer restricted by basic auth
+if [ "${USE_ADMIN_AUTH,,}" = "false" ]; then export CATALINA_OPTS="${CATALINA_OPTS} -DADMIN_PROTECTED="; fi
 
 #----- eval PROPS if exists.  key-value pairs are separated by spaces. therefore, it does not support values with spaces in it.
 if [ ! -z "${PROPS}" ]; then

--- a/docker/launchTomcat.sh
+++ b/docker/launchTomcat.sh
@@ -88,6 +88,9 @@ export CATALINA_OPTS="\
   -Dvisualize.fits.search.path=${VIS_PATH} \
 	"
 
+#----- override ADMIN_PROTECTED path if set
+if [ ! -z ${ADMIN_PROTECTED+x} ]; then export CATALINA_OPTS="${CATALINA_OPTS} -DADMIN_PROTECTED='${ADMIN_PROTECTED}'"; fi
+
 #----- eval PROPS if exists.  key-value pairs are separated by spaces. therefore, it does not support values with spaces in it.
 if [ ! -z "${PROPS}" ]; then
   jvmProps=`sed -r 's/( )+/ -D/g;s/^/-D/' <<< $PROPS`     # add -D to every key=val pair

--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -1,7 +1,11 @@
-#---- Set environment variables for the docker startup
-#---- Examples-
+##---- Set environment variables for the docker startup
+##---- Examples-
 #PROPS_FIREFLY_OPTIONS=$'{ "coverage":  {"hipsSourceURL" : "ivo://CDS/P/2MASS/color"} }'
 #ADMIN_PASSWORD=reset-me
 #CLEANUP_INTERVAL=3h
-#---- Empty declarations: environment will come from the shell
+
+## Override admin protected path.  Empty string("") to disable protection altogether.
+#ADMIN_PROTECTED=""
+
+##---- Empty declarations: environment will come from the shell
 ADMIN_PASSWORD

--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -4,8 +4,8 @@
 #ADMIN_PASSWORD=reset-me
 #CLEANUP_INTERVAL=3h
 
-## Override admin protected path.  Empty string("") to disable protection altogether.
-#ADMIN_PROTECTED=""
+## Use Tomcat Admin basic auth on protected resources.  Defaults to true.
+#USE_ADMIN_AUTH=false
 
 ##---- Empty declarations: environment will come from the shell
 ADMIN_PASSWORD

--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -4,7 +4,8 @@
 #ADMIN_PASSWORD=reset-me
 #CLEANUP_INTERVAL=3h
 
-## Use Tomcat Admin basic auth on protected resources.  Defaults to true.
+## Use Tomcat Admin basic auth on protected resources under .../admin/*. Defaults to true.
+## May be disabled in deployments where authorization is handled externally, e.g., by applying authorization-dependent redirects in a Kubernetes environment.
 #USE_ADMIN_AUTH=false
 
 ##---- Empty declarations: environment will come from the shell

--- a/src/firefly/js/ui/Banner.css
+++ b/src/firefly/js/ui/Banner.css
@@ -21,6 +21,8 @@
 
 .banner__right {
     flex-grow: 0;
+    display: flex;
+    align-items: center;
 }
 
 .banner__middle--title {
@@ -48,17 +50,13 @@
 }
 
 .banner__user-info {
-    display: inline-flex;
-    align-items: center;
-    position: absolute;
-    right: 0;
-    bottom: -20px;
-    height: 20px;
+    display: flex;
+    align-items: flex-end;
+    flex-direction: column;
     color: white;
     padding: 0 10px;
     background: url("~images/ipac_bar.jpg");
     border-bottom-left-radius: 5px;
-    z-index: 1000;
 }
 
 .banner__user-info > *{
@@ -71,4 +69,12 @@
 .banner__user-info--links:hover {
     cursor: pointer;
     color: grey;
+}
+
+.banner__user-info--name {
+    font-style: italic;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 150px;
+    white-space: nowrap;
 }

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -32,9 +32,8 @@ export const Banner = memo( ({menu, readout, appIcon, visPreview, appTitle, addi
                 </div>
             </div>
             <div className='banner__right'>
-                {visPreview}
+                {showUserInfo && <UserInfo/>}
             </div>
-            {showUserInfo && <UserInfo/>}
         </div>
     );
 });
@@ -72,7 +71,7 @@ const UserInfo= memo(() => {
 
     return (
         <div className='banner__user-info'>
-            <span>{displayName}</span>
+            <span className='banner__user-info--name' title={displayName}>{displayName}</span>
             {!isGuest && <div className='banner__user-info--links' onClick={onLogout}>Logout</div>}
             {isGuest && <div className='banner__user-info--links' onClick={onLogin}>Login</div>}
         </div>


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-599
- move user-info to the right of Background Monitor
 
https://jira.ipac.caltech.edu/browse/FIREFLY-1002
- add docker support to change basic auth path, including the ability to disable it

Manually added `USE_ADMIN_AUTH` override after deployed:
```
    kubectl edit deploy firefly-599-1002-userinfo-loc-admin-path-suit
    # add USE_ADMIN_AUTH env var to deployment
      - env:
        - name: USE_ADMIN_AUTH
          value: false
```

Test: https://firefly-599-1002-userinfo-loc-admin-path.irsakudev.ipac.caltech.edu/suit/
- check user-info is on the right of Background Monitor
- user's name is limited to 150px.  mouse-over to see the complete text
- suit/admin/status does not require user-id/password
