### PR TITLE
Remove build_client from GWT builds

### DIFF
--- a/buildScript/gwt_webapp.gincl
+++ b/buildScript/gwt_webapp.gincl
@@ -140,7 +140,7 @@ war {
   description= 'Build application. Creates a war file.'
   group = WEBAPP_GROUP
 
-  dependsOn webapp, jar, gwtCompile, buildClient, prepareWebapp
+  dependsOn webapp, jar, gwtCompile, prepareWebapp
   outputs.dir gwt.warDir
   classpath = configurations.webappLib
   from gwt.warDir
@@ -259,7 +259,6 @@ task publishToGithub (dependsOn: loadConfig) {
 // define task order
 //-------------------------
 loadConfig.mustRunAfter gwt
-buildClient.mustRunAfter prepareWebapp
 prepareWebapp.mustRunAfter gwtCompile
 gwtCompile.mustRunAfter jar
 deploy.mustRunAfter war

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,6 @@ FROM openjdk:8-jdk-slim-buster AS deps
 RUN apt-get update && apt-get install -y curl git htmldoc unzip wget bzip2
 
 RUN apt-get update \
-# use node v12.x. may not be available via apt-get
-    && curl -sL https://deb.nodesource.com/setup_12.x | bash -  \
-    && apt-get install -y nodejs \
-    && npm install yarn -g  \
 # gradle version 4.10.  Not available via apt-get
     && cd /usr/local \
     && wget  -q https://services.gradle.org/distributions/gradle-4.10-bin.zip \
@@ -34,7 +30,7 @@ COPY . .
 
 WORKDIR /opt/work/${build_dir}
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false"
-RUN gradle -Penv=${env} -p ../firefly :firefly:jar -x buildClient && gradle -Penv=${env} ${target} -x buildClient
+RUN gradle -Penv=${env} -p ../firefly :firefly:jar && gradle -Penv=${env} ${target}
 
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,14 +22,8 @@ RUN apt-get update \
 
 WORKDIR "/opt/work"
 
-FROM deps AS node_module
 
-WORKDIR "/opt/work/lib"
-COPY firefly/package.json firefly/package-lock.json ./
-RUN npm install --no-package-lock
-
-
-FROM node_module AS builder
+FROM deps AS builder
 
 ARG build_dir
 ARG target
@@ -37,11 +31,10 @@ ARG env
 
 WORKDIR /opt/work
 COPY . .
-COPY --from=node_module /opt/work/lib/node_modules ./firefly/node_modules
 
 WORKDIR /opt/work/${build_dir}
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false"
-RUN gradle -Penv=${env} -b ../firefly/build.gradle :firefly:jar && gradle -Penv=${env} ${target}
+RUN gradle -Penv=${env} -p ../firefly :firefly:jar -x buildClient && gradle -Penv=${env} ${target} -x buildClient
 
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,17 +9,17 @@ Docker and Docker-Compose
 - https://docs.docker.com/get-docker/
 - https://docs.docker.com/compose/install/
 
+**Note:**  Some versions of Docker includes docker compose.  In that case, you can skip docker-compose installation and
+can use `docker compose` instead of `docker-compose`. 
 
-## Quick Start
-
-**Clone source**
+### Clone source
 
 In this example, `cm` is used as a top-level directory for these repositories.  But, it does not need to be named `cm`.
 It can be named anything you want.
 
-    $ mkdir cm && cd cm
-    $ git clone https://github.com/Caltech-IPAC/firefly
-    $ git clone https://github.com/Caltech-IPAC/firefly-help
+    mkdir cm && cd cm
+    git clone https://github.com/Caltech-IPAC/firefly
+    git clone https://github.com/Caltech-IPAC/firefly-help
 
 On macOS, only shared paths are accessible by Docker.  
 You can configure shared paths from `Docker -> Preferences... -> Resources -> File Sharing.`  
@@ -28,21 +28,53 @@ See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
 These paths are needed:  
 `cm`: source files  
 
-**Build and start Firefly**
 
-    $ cd cm/firefly
-    $ docker-compose up
+> :warning: **The steps below does not applies to GWT branches**  
+> In GWT, there is not a Firefly application, only the framework
+
+
+### Build Firefly
+
+    cd cm/firefly
+    docker-compose build firefly
+
+If you've made changes to the source, this will pick up the changes and create a new Docker image with your changes.  
+Because Firefly uses multi-stage builds, Docker is smart enough to reuse unaffected layers to speed up the build process.  
+However, if you want a completely clean build, add `--no-cache` to the above command.  
+For more details on docker-compose usage, go here: https://docs.docker.com/compose/reference/
+
+BUILD_TAG environment variable defaults to 'latest'.  You can tag this build by setting it to something else.
+
+### Run Firefly
+
+    cd cm/firefly
+    docker-compose up firefly
 
 Firefly is now up and running at http://localhost:8080/firefly/
 
 
+### Run Firefly in DevMode
 
-## HOW-TO
+> :info: **If you are using Mac Docker Desktop**:
+> Docker on Mac has had some performance issues since the beginning. These are related to volume performance, 
+> the way volumes are mounted, and the underlying osxfs filesystem.  
+> Release 4.6 fixes this with the introduction of virtiofs.  
+> 
+> To use virtiofs, you must have macOS 12.2 or later and the new Virtualization Framework enabled.
+> Go to Docker Desktop -> Preferences -> Experimental Features 
+> and enable the two features.
 
-**Monitor Firefly logs**
+DevMode is Firefly development mode.  When running, it will detect changes in the source code, and automatically
+deploy it.  Reload the page in your browser to see the changes.  
 
-    $ docker-compose logs -f 
+    cd cm/firefly
+    docker-compose up dev
 
+DevMode only applies to client-side code.  If you made changes to server-side(.java) code, you need to rerun `docker-compose up dev` 
+to have it rebuild and redeploy.
+
+
+### HOW-TO
 
 **Interactive bash shell in the container**
 
@@ -51,39 +83,22 @@ Firefly is now up and running at http://localhost:8080/firefly/
 
 **Cleanly shutdown Firefly**
 
-    $ docker-compose down
+    docker-compose down
 
-**Build Firefly from source**
-
-    $ docker-compose build
-
-If you've made changes to the source, this will pick up the changes and create a new Docker image with your changes.  
-Because Firefly uses multi-stage builds, Docker is smart enough to reuse unaffected layers to speed up the build process.  
-However, if you want a complete clean build, add `--no-cache` to the above command.  
-For more details on docker-compose usage, go here: https://docs.docker.com/compose/reference/ 
-
-BUILD_TAG variable defaults to 'latest'.  You can tag this build by setting it to something else.
-
-
-**Build Firefly from source with arguments**
-
-By default, Firefly builds includes documentation and help pages.  To build only Firefly, 
-
-    $ docker-compose build --build-arg target=war
-
-`target` is the gradle task used when building.  There are others, like `test`.
+This will stop Firefly and removes everything created by `up`.
 
 
 **To publish this build to DockerHub**
 
-    $ docker-compose push
+    docker-compose push firefly
 
 **To run Firefly from DockerHub**
 
 If you want to run a version available from DockerHub.  
 Set BUILD_TAG to the version you want, then 
 
-    $ docker-compose pull && docker-compose up -d
+    export BUILD_TAG=latest
+    docker-compose pull && docker-compose up firefly
 
 
 
@@ -91,19 +106,19 @@ Set BUILD_TAG to the version you want, then
 
 Firefly has many configurable runtime parameters.  For more information, run
 
-    $ docker run --rm ipac/firefly:latest --help
+    docker run --rm ipac/firefly:latest --help
 
 There are many `docker run` examples on how to use these parameters.  Consider add them into a docker-compose.yml for 
 easy operation.  For information on how to do this, go here: https://docs.docker.com/compose/compose-file/compose-file-v3/
 
-Docker-compose file allows for variables substitute.  You can set the values in the environment, as argument on the command 
-line, or place them in a `.env` file.
+Docker-compose file allows for variables substitute.  You can set the values in the environment, by adding a line
+to `firefly-docker.env` file.
 
-For example, Firefly's docker-compose.yml contains BUILD_TAG and ADMIN_PASSWORD variables.  The values can come from the 
-`.env` file, like this
+For example, Firefly's `docker-compose.yml` can have additional environment variables.  The values can come from the 
+`firefly-docker.env` file, like this
 
-    $ cat .env
+    cat firefly-docker.env
     ADMIN_PASSWORD=reset-me
-    BUILD_TAG=my-test 
+    CLEANUP_INTERVAL=3h
 
 

--- a/src/firefly/build.gradle
+++ b/src/firefly/build.gradle
@@ -14,8 +14,6 @@ dependencies {
 
 jar {
 
-  dependsOn buildClient
-
   baseName = 'firefly'
   includes = ['edu/caltech/ipac/**/*']
   from sourceSets.main.allJava


### PR DESCRIPTION
- it's not needed
- it intermittently hangs on npm install, causing a long delay during build