### PR TITLE
FIREFLY-1020-1021-1022: Chart multi-ticket UI changes

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -113,7 +113,7 @@ div.rootStyle img {
     border: 1px solid #acacac;
     border-radius: 2px;
     white-space: nowrap;
-}
+    font-weight: normal;}
 
 .button.text:hover {
     border: 1px solid #878787;
@@ -179,19 +179,17 @@ div.rootStyle img {
 .Pane.vertical .content, .Pane.horizontal  .content{
     overflow: hidden;
     position: absolute;
-    top: 5px;
-    bottom: 5px;
-    left: 5px;
-    right: 5px;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
 }
 
 .Pane.vertical .wrapper, .Pane.horizontal .wrapper{
     flex: auto;
     display: flex;
     overflow: hidden;
-    /*border: 1px solid #a3aeb9;*/
-    border-radius: 5px;
-    margin: 3px;
+    margin: 5px;
     position: relative;
 }
 

--- a/src/firefly/js/charts/ui/ChartPanel.css
+++ b/src/firefly/js/charts/ui/ChartPanel.css
@@ -64,27 +64,32 @@
 
 .ChartPanel__section--title .label {
     border: 1px solid #b3b3b3;
-    height: 16px;
+    height: 17px;
     padding: 3px 15px 0;
     border-top-left-radius: 5px;
     background-color: #c8c8c8;
     z-index: 1;
-    margin-bottom: -1px;
-    border-bottom: none;}
+    border-bottom: none;
+}
 
 .ChartPanel__section--title {
     display: inline-flex;
     justify-content: space-between;
     font-weight: bold;
-    align-items: center;
-    height: 20px;
+    align-items: flex-start;
+    height: 21px;
     margin-left: 5px;
+    margin-bottom: -1px;
+}
+
+.ChartPanel__section--title .button.text {
+    line-height: 15px;
 }
 
 .ChartPanel__section--title.tabs {
     position: absolute;
     right: 1px;
-    top: 4px;
+    top: 2px;
     z-index: 1;
 }
 

--- a/src/firefly/js/charts/ui/ChartPanel.css
+++ b/src/firefly/js/charts/ui/ChartPanel.css
@@ -54,6 +54,41 @@
     right: 0;
 }
 
+.ChartPanel__section {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    border-top-left-radius: 3px;
+    overflow: hidden;
+}
+
+.ChartPanel__section--title .label {
+    border: 1px solid #b3b3b3;
+    height: 16px;
+    padding: 3px 15px 0;
+    border-top-left-radius: 5px;
+    background-color: #c8c8c8;
+    z-index: 1;
+    margin-bottom: -1px;
+    border-bottom: none;}
+
+.ChartPanel__section--title {
+    display: inline-flex;
+    justify-content: space-between;
+    font-weight: bold;
+    align-items: center;
+    height: 20px;
+    margin-left: 5px;
+}
+
+.ChartPanel__section--title.tabs {
+    position: absolute;
+    right: 1px;
+    top: 4px;
+    z-index: 1;
+}
+
+
 .ChartPanel__glass {
     background-color: transparent
 }

--- a/src/firefly/js/charts/ui/ChartWorkArea.jsx
+++ b/src/firefly/js/charts/ui/ChartWorkArea.jsx
@@ -165,7 +165,7 @@ export const ChartWorkArea = (props) => {
         return (
             <div className='ChartPanel__container'>
                 <TabToolbar/>
-                <StatefulTabs componentKey={PINNED_VIEWER_ID} defaultSelected={0} useFlex={true} style={{flex: '1 1 0', marginTop: 5}}>
+                <StatefulTabs componentKey={PINNED_VIEWER_ID} defaultSelected={0} useFlex={true} style={{flex: '1 1 0', marginTop: 1}}>
                     <Tab name={activeLabel}>
                         <DefaultChartsContainer {...props}/>
                     </Tab>
@@ -188,7 +188,7 @@ ChartWorkArea.propTypes = {
     useOnlyChartsInViewer :PropTypes.bool
 };
 
-const Help = () => <HelpIcon helpId={'chartarea.info'} style={{margin: '0 10px'}}/>;
+const Help = () => <HelpIcon helpId={'chartarea.info'} style={{marginLeft:10}}/>;
 
 const PinChart = ({viewerId, tbl_group}) => {
     const {sideBySide=false, selectedIdx} = getComponentState(PINNED_VIEWER_ID);
@@ -201,7 +201,7 @@ const PinChart = ({viewerId, tbl_group}) => {
         }
         pinChart({chartId});
     };
-    return canPin ? <TextButton onClick={doPinChart} title='Pin the active chart' style={{height:15}}>Pin Chart</TextButton> : null;
+    return canPin ? <TextButton onClick={doPinChart} title='Pin the active chart'>Pin Chart</TextButton> : null;
 };
 
 const ShowTable = ({tbl_group}) => {
@@ -217,7 +217,7 @@ const ShowTable = ({tbl_group}) => {
     const {sideBySide=false, selectedIdx} = getComponentState(PINNED_VIEWER_ID);
     const canShowTable = activeChartTblId && (sideBySide || selectedIdx === 1);
 
-    return canShowTable ? <TextButton onClick={showTable} title='Show the table associated with this chart' style={{height:15}}>Show Table</TextButton> : null;
+    return canShowTable ? <TextButton onClick={showTable} title='Show the table associated with this chart'>Show Table</TextButton> : null;
 };
 
 const ToggleMode = () => {
@@ -226,7 +226,7 @@ const ToggleMode = () => {
     const canToggle =  getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID)?.length > 0;
     const [modeLabel, modeTitle] = sideBySide ? ['As Tabs', 'Switch to tabs layout'] : ['Side-By-Side', 'Switch to Side-By-Side layout'];
 
-    return canToggle ? <TextButton onClick={toggleSideBySide} title={modeTitle} style={{height:15}}>{modeLabel}</TextButton> : null;
+    return canToggle ? <TextButton onClick={toggleSideBySide} title={modeTitle}>{modeLabel}</TextButton> : null;
 };
 
 

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -85,7 +85,7 @@ export class MultiChartViewer extends PureComponent {
     }
 
     render() {
-        const {viewerId, expandedMode, closeable, noChartToolbar} = this.props;
+        const {viewerId, expandedMode, closeable, noChartToolbar, label} = this.props;
         const {viewer}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId);
         if (!viewer || isEmpty(viewer.itemIdAry)) {
@@ -139,7 +139,8 @@ export class MultiChartViewer extends PureComponent {
             activeItemId,
             layoutType,
             makeItemViewer,
-            makeItemViewerFull
+            makeItemViewerFull,
+            label
         };
 
         //console.log('Active chart ID: '+activeItemId);

--- a/src/firefly/js/ui/panel/DockLayoutPanel.jsx
+++ b/src/firefly/js/ui/panel/DockLayoutPanel.jsx
@@ -2,6 +2,31 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SplitPane from 'react-split-pane';
 
+import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
+import {useStoreConnector} from '../SimpleComponent.jsx';
+
+
+/**
+ * A wrapper for SplitPane with persistent split position
+ * @param p  component properties
+ * @param p.children  pass through children component
+ * @param p.defaultSize   the default split size
+ * @param p.pKey  an identifier for this panel.  One will be created if not given
+ * @returns {JSX.Element}
+ */
+export const SplitPanel = ({children, defaultSize, pKey, ...rest}) => {
+    pKey = 'SplitPanel-' + pKey;
+    const {pos}  = useStoreConnector(() => getComponentState(pKey));
+    const onChange = (pos) => dispatchComponentStateChange(pKey, {pos});
+    
+    return (
+        <SplitPane split='horizontal' defaultSize={pos ?? defaultSize} onChange={onChange} {...rest}>
+            {children}
+        </SplitPane>
+    );
+};
+
+
 /**
  * decorate the content with DockLayoutPanel's look and feel.
  * @param content
@@ -13,7 +38,9 @@ export function createContentWrapper(content) {
 
 /**
  * decorate the content with DockLayoutPanel's look and feel.
- * @param children  content of this panel
+ * @param p  component props
+ * @param p.style  additional style to container
+ * @param p.children  content of this panel
  */
 export function SplitContent({style, children}) {
     return ( <div className='wrapper'>
@@ -43,28 +70,28 @@ function two(config, items){
         const top = config.north || config.center;
         const bottom = config.south || config.center;
         return (
-            <SplitPane split='horizontal'  {...top}>
+            <SplitPanel {...top} pKey='one'>
                 <SplitContent>
                     {items[top.index]}
                 </SplitContent>
                 <SplitContent>
                     {items[bottom.index]}
                 </SplitContent>
-            </SplitPane>
+            </SplitPanel>
 
         );
     } else if (config.east || config.west) {
         const left = config.east || config.center;
         const right = config.west || config.center;
         return (
-            <SplitPane split='vertical' {...left}>
+            <SplitPanel split='vertical' {...left} pKey='one'>
                 <SplitContent>
                     {items[left.index]}
                 </SplitContent>
                 <SplitContent>
                     {items[right.index]}
                 </SplitContent>
-            </SplitPane>
+            </SplitPanel>
         );
     }
 }
@@ -76,37 +103,37 @@ function three(config, items){
         if (config.south) {
             const two = config.east || config.center || config.west;
             return (
-                <SplitPane split='horizontal' {...config.north}>
+                <SplitPanel  {...config.north} pKey='one'>
                     <SplitContent>
                         {items[config.north.index]}
                     </SplitContent>
-                    <SplitPane split='horizontal' {...two}>
+                    <SplitPanel  {...two} pKey='two'>
                         <SplitContent>
                             {items[two.index]}
                         </SplitContent>
                         <SplitContent>
                             {items[config.south.index]}
                         </SplitContent>
-                    </SplitPane>
-                </SplitPane>
+                    </SplitPanel>
+                </SplitPanel>
             );
         } else {
             const two = config.east || config.center;
             const three = config.west || config.center;
             return (
-                <SplitPane split='horizontal' {...config.north}>
+                <SplitPanel  {...config.north} pKey='one'>
                     <SplitContent>
                         {items[config.north.index]}
                     </SplitContent>
-                    <SplitPane split='vertical' {...two.config}>
+                    <SplitPanel split='vertical' {...two.config} pKey='two'>
                         <SplitContent>
                             {items[two.index]}
                         </SplitContent>
                         <SplitContent>
                             {items[three.index]}
                         </SplitContent>
-                    </SplitPane>
-                </SplitPane>
+                    </SplitPanel>
+                </SplitPanel>
             );
         }
     } else {
@@ -114,35 +141,35 @@ function three(config, items){
             const one = config.east || config.center;
             const two = config.west || config.center;
             return (
-                <SplitPane split='horizontal' {...config.south}>
-                    <SplitPane split='vertical' {...one}>
+                <SplitPanel  {...config.south} pKey='one'>
+                    <SplitPanel split='vertical' {...one} pKey='two'>
                         <SplitContent>
                             {items[one.index]}
                         </SplitContent>
                         <SplitContent>
                             {items[two.index]}
                         </SplitContent>
-                    </SplitPane>
+                    </SplitPanel>
                     <SplitContent>
                         {items[config.south.index]}
                     </SplitContent>
-                </SplitPane>
+                </SplitPanel>
             );
         } else {
             return (
-                <SplitPane split='vertical' {...config.east}>
+                <SplitPanel split='vertical' {...config.east} pKey='one'>
                     <SplitContent>
                         {items[config.east.index]}
                     </SplitContent>
-                    <SplitPane split='vertical' {...config.west}>
+                    <SplitPanel split='vertical' {...config.west} pKey='two'>
                         <SplitContent>
                             {items[config.center.index]}
                         </SplitContent>
                         <SplitContent>
                             {items[config.west.index]}
                         </SplitContent>
-                    </SplitPane>
-                </SplitPane>
+                    </SplitPanel>
+                </SplitPanel>
             );
         }
     }


### PR DESCRIPTION
Test: https://firefly-1020-1021-1022-chart-ui-changes.irsakudev.ipac.caltech.edu/irsaviewer/

https://jira.ipac.caltech.edu/browse/FIREFLY-1020
persistent split pane position  

https://jira.ipac.caltech.edu/browse/FIREFLY-1021
plural/singular pinned chart label

https://jira.ipac.caltech.edu/browse/FIREFLY-1022
location of 'pin chart' button

Beside the requested changes, I've also added these:
- Increase max pinned charts to 12 so you can see how crowded it can get.  If you want me to remove the limit completely, I can do that as well.
- Decreased the gap between split panels.  This is a global change.  All split panels will look like this.
- Change Active and Pinned Charts panel UI.  They look like separate tabs now.

I am open to changes.  Just leave comments below.

