### PR TITLE
Firefly-1030: improve visual target selection, (Also Firefly-1025)

### DIFF
--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -88,7 +88,7 @@ export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, style={}})
                 <div style={{display: 'flex', alignItems: 'center'}}>
                     <div className='BgMaskPanel__content'>
                         <div style={{display: 'inline-flex', alignItems: 'center', justifyContent: 'center'}}>
-                            <di style={{marginRight: 5, fontSize: 18}}> {jobInfo.phase} </di>
+                            <div style={{marginRight: 5, fontSize: 18}}> {jobInfo.phase} </div>
                             <img className='JobInfo__items--link' onClick={showInfo} src={INFO} style={{height: 20}}/>
                         </div>
                         <div className='BgMaskPanel__msg'>{msg}</div>

--- a/src/firefly/js/metaConvert/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/ServDescConverter.js
@@ -76,13 +76,13 @@ export function createServDescMenuRet(descriptors, positionWP, sourceTable, row,
     return descriptors
         .filter( (sDesc) => !isDataLinkServiceDesc(sDesc))
         .map( (sDesc,idx) => {
-            const {title,accessURL,standardID,urlParams, ID}= sDesc;
+            const {title,accessURL,standardID,serDefParams, ID}= sDesc;
             const menuKey= 'serdesc-dlt-'+idx;
-            const allowsInput= urlParams.some( (p) => p.allowsInput);
+            const allowsInput= serDefParams.some( (p) => p.allowsInput);
             const request= makeReq(accessURL,positionWP,title);
             const name= 'Show: '+title;
-            const activate= makeFileAnalysisActivate(sourceTable,row, request, positionWP,activateParams,menuKey, undefined, urlParams, name);
-            return dpdtAnalyze(name,activate,accessURL,urlParams,menuKey,{activeMenuLookupKey,request, allowsInput, standardID, ID});
+            const activate= makeFileAnalysisActivate(sourceTable,row, request, positionWP,activateParams,menuKey, undefined, serDefParams, name);
+            return dpdtAnalyze(name,activate,accessURL,serDefParams,menuKey,{activeMenuLookupKey,request, allowsInput, standardID, ID});
         });
 }
 

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -370,7 +370,7 @@ export function renderPolygonDataArea({imageCornerCalc, labelWidth, labelStyle, 
             cornerTypeOps.splice(cornerTypeOps.length-1, 0, {label: 'Selection', value: 'area-selection'});
         }
     }
-    const wp= parseWorldPt(centerWP) ?? makeWorldPt(0,0);
+    const wp= parseWorldPt(centerWP);
     return (
         <div
             style={{padding:5, border:'solid #a3aeb9 1px' }}>

--- a/src/firefly/js/ui/ConnectionCtx.js
+++ b/src/firefly/js/ui/ConnectionCtx.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export const ConnectionCtx = React.createContext( {
+    controlConnected: false,
+    setControlConnected: () => undefined
+});

--- a/src/firefly/js/ui/FieldGroup.jsx
+++ b/src/firefly/js/ui/FieldGroup.jsx
@@ -8,7 +8,7 @@ import {getFieldGroupState, isFieldGroupMounted} from '../fieldGroup/FieldGroupU
 
 export const GroupKeyCtx = React.createContext({});
 export const FieldGroup = memo( ({keepMounted, reducerFunc=undefined, groupKey, keepState=false, children, style, className}) => {
-        const [fields, setFields]= useState(() => getFieldGroupState(groupKey))
+        const [fields, setFields]= useState(() => getFieldGroupState(groupKey));
         const {groupKey:wrapperGroupKey}= useContext(GroupKeyCtx);
         useLayoutEffect(() => {
             dispatchMountFieldGroup(groupKey, true, keepState, reducerFunc, wrapperGroupKey);

--- a/src/firefly/js/ui/InputFieldView.css
+++ b/src/firefly/js/ui/InputFieldView.css
@@ -6,16 +6,30 @@
 
 
 .ff-inputfield-view-valid {
-    border : 1px solid #b5b8c8;              /* NOT part of color palette */
+    border : 1px solid #b5b8c8;
     background: url('~images/text-bg.gif') repeat-x;
     width: auto;
     height: auto;
     padding : 2px;
 }
 
+.ff-inputfield-view-valid-no-bg {
+    border : 1px solid #b5b8c8;
+    width: auto;
+    height: auto;
+    padding : 2px;
+}
+
 .ff-inputfield-view-focus {
-    border : 1px solid #7eadd9;             /* NOT part of color palette */
+    border : 1px solid #7eadd9;
     background: url('~images/text-bg.gif') repeat-x;
+    width: auto;
+    height: auto;
+    padding : 2px;
+}
+
+.ff-inputfield-view-focus-no-bg {
+    border : 1px solid #7eadd9;
     width: auto;
     height: auto;
     padding : 2px;
@@ -23,7 +37,7 @@
 
 
 .ff-inputfield-view-error {
-    border : 1px solid red;                 /* NOT part of color palette */
+    border : 1px solid red;
     width: auto;
     height: auto;
     background: #FFEEEE url('~images/invalid_line.gif') left bottom repeat-x;

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -10,12 +10,17 @@ import EXCLAMATION from 'html/images/exclamation16x16.gif';
 
 
 
-function computeStyle(valid,hasFocus,readonly) {
+function computeStyle(valid,hasFocus,readonly,connectedMarker) {
     if (!valid) {
         return 'ff-inputfield-view-error';
-    } else if(readonly) {
+    }
+    else if(readonly) {
         return 'ff-inputfield-view-readonly';
-    } else {
+    }
+    else if (connectedMarker) {
+        return (hasFocus ? 'ff-inputfield-view-focus-no-bg' : 'ff-inputfield-view-valid-no-bg');
+    }
+    else {
         return hasFocus ? 'ff-inputfield-view-focus' : 'ff-inputfield-view-valid';
     }
 }
@@ -58,10 +63,10 @@ export class InputFieldView extends PureComponent {
     }
 
     componentDidUpdate() {
-        var {infoPopup}= this.state;
+        const {infoPopup}= this.state;
         if (infoPopup && this.warnIcon) {
-            var {warningOffsetX, warningOffsetY}= computeWarningXY(this.warnIcon);
-            var {message}= this.props;
+            const {warningOffsetX, warningOffsetY}= computeWarningXY(this.warnIcon);
+            const {message}= this.props;
             if (this.hider) this.hider();
             this.hider = DialogRootContainer.showTmpPopup(makeInfoPopup(message, warningOffsetX, warningOffsetY));
         }
@@ -87,11 +92,13 @@ export class InputFieldView extends PureComponent {
     }
 
     render() {
-        var {hasFocus}= this.state;
-        var {visible,disabled, label,tooltip,labelWidth,value,style,wrapperStyle,labelStyle, inputRef, autoFocus,
-             valid,size,onChange, onBlur, onKeyPress, onKeyDown, onKeyUp, showWarning, message, type, placeholder, form='__ignore', readonly}= this.props;
+        const {hasFocus}= this.state;
+        const {visible,disabled, label,tooltip,labelWidth,value,style,wrapperStyle,labelStyle, inputRef, autoFocus,
+             valid,size,onChange, onBlur, onKeyPress, onKeyDown, onKeyUp, showWarning, connectedMarker=false,
+            message, type, placeholder, readonly}= this.props;
         if (!visible) return null;
-        wrapperStyle = Object.assign({whiteSpace:'nowrap', display: this.props.inline?'inline-block':'block'}, wrapperStyle);
+        const useWrapperStyle = {whiteSpace:'nowrap', display: this.props.inline?'inline-block':'block', ...wrapperStyle};
+        let {form='__ignore'}= this.props;
         // form to relate this input field to.
         // assign form to null or empty-string to use it within a form tag (similar to input tag without form attribute).
         // if form is not given, it will default to __ignore so that it does not interfere with embedded forms.
@@ -99,11 +106,14 @@ export class InputFieldView extends PureComponent {
 
         const currValue= (type==='file') ? undefined : value;
 
+        const inputStyle= {display:'inline-block'};
+        if (connectedMarker) inputStyle.backgroundColor= 'yellow';
+
         return (
-            <div style={wrapperStyle}>
+            <div style={useWrapperStyle}>
                 {label && <InputFieldLabel labelStyle={labelStyle} label={label} tooltip={tooltip} labelWidth={labelWidth}/> }
-                <input style={Object.assign({display:'inline-block'}, style)}
-                       className={computeStyle(valid,hasFocus, readonly)}
+                <input style={{...inputStyle, ...style}}
+                       className={computeStyle(valid,hasFocus, readonly,connectedMarker)}
                        onChange={(ev) => onChange ? onChange(ev) : null}
                        onFocus={ () => !hasFocus ? this.setState({hasFocus:true, infoPopup:false}) : ''}
                        onBlur={ (ev) => {
@@ -148,6 +158,7 @@ InputFieldView.propTypes= {
     type: string,
     placeholder: string,
     form: string,
+    connectedMarker: bool,
     readonly: bool
 };
 

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -1,6 +1,7 @@
-import React, {useEffect, memo, useState} from 'react';
-import PropTypes from 'prop-types';
+import React, {useEffect, memo, useState, useContext} from 'react';
+import PropTypes, {bool} from 'prop-types';
 import {convertAngle} from '../visualize/VisUtil.js';
+import {ConnectionCtx} from './ConnectionCtx.js';
 import {InputFieldView} from './InputFieldView.jsx';
 import {ListBoxInputFieldView} from './ListBoxInputField.jsx';
 import Validate from '../util/Validate.js';
@@ -79,6 +80,7 @@ function getFeedback(unit, min, max, showFeedback) {
 
 const SizeInputFieldView= (props) => {
     const {nullAllowed, min, max, style= {}, wrapperStyle={} /*wrapperStyle is deprecated*/,
+        connectedMarker= false,
         feedbackStyle={}, labelWidth, label, labelStyle, showFeedback, onChange} = props;
     const [{value, valid, displayValue, unit},setState]= useState(() => updateSizeInfo(props));
     const {feedback, errmsg}= getFeedback(unit,min,max,showFeedback);
@@ -86,6 +88,7 @@ const SizeInputFieldView= (props) => {
     useEffect(() => {
         setState(updateSizeInfo(props));
     }, [ nullAllowed,  min, max,props.value, props.displayValue, props.unit]);
+    const connectContext= useContext(ConnectionCtx);
 
     const onSizeChange= (ev) => {
         const newDisplayValue = ev?.target?.value;
@@ -126,8 +129,9 @@ const SizeInputFieldView= (props) => {
             <div style={{display: 'flex', alignItems: 'center', justifyContent: 'flex-start'}} >
                 <InputFieldView
                     valid={valid}
-                    onChange={onSizeChange} onBlur={onSizeChange} onKeyPress={onSizeChange}
+                    onChange={onSizeChange} onBlur={onSizeChange}
                     value={displayValue} message={errmsg} label={label} labelWidth={labelWidth} labelStyle={labelStyle}
+                    connectedMarker={connectedMarker||connectContext.controlConnected}
                     tooltip={'enter size within the valid range'} />
                 <ListBoxInputFieldView
                     onChange={onUnitChange}
@@ -136,7 +140,7 @@ const SizeInputFieldView= (props) => {
                         {label: 'degrees', value: 'deg'},
                         {label: 'arcminutes', value: 'arcmin'},
                         {label: 'arcseconds', value: 'arcsec'}
-                        ]} />
+                    ]} />
             </div>
             <div style={{marginLeft: labelWidth+5, marginTop:5,  ...feedbackStyle}}> {feedback} </div>
         </div>
@@ -157,6 +161,7 @@ SizeInputFieldView.propTypes = {
     showFeedback: PropTypes.bool,
     wrapperStyle: PropTypes.object, // deprecated
     style: PropTypes.object,  // replaces wrapper style
+    connectedMarker: bool,
     feedbackStyle: PropTypes.object
 };
 
@@ -196,6 +201,7 @@ export const SizeInputFields = memo( (props) => {
 SizeInputFields.propTypes={
     fieldKey : PropTypes.string,
     groupKey : PropTypes.string,
+    connectedMarker: bool,
     initialState: PropTypes.shape({
         value: PropTypes.any,
         tooltip:  PropTypes.string,

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -2,9 +2,9 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {memo, useEffect} from 'react';
-import PropTypes from 'prop-types';
-import {get} from 'lodash';
+import React, {memo, useContext, useEffect} from 'react';
+import PropTypes, {bool} from 'prop-types';
+import {ConnectionCtx} from './ConnectionCtx.js';
 import {parseTarget} from './TargetPanelWorker.js';
 import {formatPosForTextField, formatTargetForHelp} from './PositionFieldDef.js';
 import {TargetFeedback} from './TargetFeedback.jsx';
@@ -27,15 +27,18 @@ const TargetPanelView = (props) =>{
     const {showHelp, feedback, valid, message, onChange, value, style={}, button,
         labelWidth, children, resolver, feedbackStyle, showResolveSourceOp= true, showExample= true,
         targetPanelExampleRow1, targetPanelExampleRow2,
+        connectedMarker=false,
         examples, label= LABEL_DEFAULT, onUnmountCB, wpt}= props;
 
     useEffect(() => () => onUnmountCB(props),[]);
+    const connectContext= useContext(ConnectionCtx);
 
     const positionField = (
         <InputFieldView valid={valid} visible= {true} message={message}
-            onChange={(ev) => onChange(ev.target.value, TARGET)}
-            label={label} value={value} tooltip='Enter a target'
-            labelWidth={labelWidth} labelStyle={{paddingRight:'45px'}}
+                        onChange={(ev) => onChange(ev.target.value, TARGET)}
+                        label={label} value={value} tooltip='Enter a target'
+                        connectedMarker={connectedMarker||connectContext.controlConnected}
+                        labelWidth={labelWidth} labelStyle={{paddingRight:'45px'}}
         />);
     const positionInput = children ? (<div style={{display: 'flex'}}>{positionField} {children}</div>) : positionField;
 
@@ -82,6 +85,7 @@ TargetPanelView.propTypes = {
     showResolveSourceOp: PropTypes.bool,
     targetPanelExampleRow1: PropTypes.arrayOf(PropTypes.string),
     targetPanelExampleRow2: PropTypes.arrayOf(PropTypes.string),
+    connectedMarker: bool,
     showExample: PropTypes.bool
 };
 
@@ -167,12 +171,7 @@ function makePayloadAndUpdateActive(displayValue, parseResults, resolvePromise, 
 function replaceValue(v,defaultToActiveTarget, computedState) {
     if (!defaultToActiveTarget) return v;
     if ((computedState.displayValue || computedState.message) && !computedState.valid) return '';
-    const t= getActiveTarget();
-    let retVal= v;
-    if (t && t.worldPt) {
-       if (get(t,'worldPt')) retVal= t.worldPt.toString();
-    }
-    return retVal;
+    return getActiveTarget()?.worldPt?.toString() ?? v;
 }
 
 
@@ -203,6 +202,7 @@ TargetPanel.propTypes = {
     targetPanelExampleRow1: PropTypes.arrayOf(PropTypes.string),
     targetPanelExampleRow2: PropTypes.arrayOf(PropTypes.string),
     showExample: PropTypes.bool,
+    connectedMarker: bool,
     defaultToActiveTarget: PropTypes.bool,
 };
 

--- a/src/firefly/js/ui/dynamic/DynComponents.jsx
+++ b/src/firefly/js/ui/dynamic/DynComponents.jsx
@@ -178,7 +178,7 @@ function PositionAndPolyFieldEmbed({fieldDefAry}) {
     const [getConeAreaOp] = useFieldGroupValue(CONE_AREA_KEY);
 
     const {
-        hipsUrl, centerPt, hipsFOVInDeg = 240, coordinateSys: csysStr = 'EQ_J2000', mocList,
+        hipsUrl, centerPt, hipsFOVInDeg = 240, coordinateSys: csysStr = 'EQ_J2000', mocList, sRegion,
         targetPanelExampleRow1, targetPanelExampleRow2} = targetDetails ?? polyType?.targetDetails ?? {};
     const coordinateSys = CoordinateSys.parse(csysStr) ?? CoordinateSys.EQ_J2000;
 
@@ -194,7 +194,7 @@ function PositionAndPolyFieldEmbed({fieldDefAry}) {
         <div key='targetGroup'
              style={{display: 'flex', flexDirection: 'column', alignItems: 'center', alignSelf: 'stretch'}}>
             <HiPSTargetView {...{
-                hipsUrl, centerPt, hipsFOVInDeg, mocList, coordinateSys,
+                hipsUrl, centerPt, hipsFOVInDeg, mocList, coordinateSys, sRegion,
                 minSize: minValue, maxSize: maxValue, whichOverlay: getConeAreaOp(),
                 targetKey, sizeKey, polygonKey, style: {height: 400, alignSelf: 'stretch'}
             }}/>
@@ -317,7 +317,7 @@ function CircleField({ fieldKey, desc, tooltip = '', initValue, minValue, maxVal
 
 function PolygonField({ fieldKey, desc = 'Coordinates', initValue = '', style={},
                           labelWidth = DEF_LABEL_WIDTH, tooltip = 'Enter polygon coordinates search',
-                          targetDetails: {targetPanelExampleRow1 = DEF_AREA_EXAMPLE}, ...restOfProps }) {
+                          targetDetails: {targetPanelExampleRow1 = DEF_AREA_EXAMPLE, sRegion}, ...restOfProps }) {
 
     const help = [
         'Each vertex is defined by a J2000 RA and Dec position pair',
@@ -336,6 +336,7 @@ function PolygonField({ fieldKey, desc = 'Coordinates', initValue = '', style={}
                 labelStyle: {},
                 labelWidth,
                 tooltip,
+                sRegion,
                 ...restOfProps
             }}
             />

--- a/src/firefly/js/ui/dynamic/DynamicDef.js
+++ b/src/firefly/js/ui/dynamic/DynamicDef.js
@@ -134,24 +134,46 @@ export const makeUnknownDef = ({key, desc, tooltip, units, initValue, nullAllowe
 export const makeAreaDef = ({key, minValue, maxValue, desc, tooltip, initValue, nullAllowed}) =>
     ({type: AREA, key, desc, tooltip, initValue, minValue, maxValue, nullAllowed});
 
-export function makeCircleDef({
-                                  key, targetKey, sizeKey, minValue, maxValue, desc, tooltip, initValue, nullAllowed,
-                                  centerPt, hipsFOVInDeg, coordinateSys,
+/**
+ *
+ * @param {Object} obj
+ * @param {String} obj.key
+ * @param {String} obj.targetKey
+ * @param {String} [obj.sizeKey]
+ * @param obj.minValue
+ * @param obj.maxValue
+ * @param {String} obj.desc
+ * @param {String} obj.tooltip
+ * @param obj.initValue
+ * @param obj.nullAllowed
+ * @param obj.centerPt
+ * @param obj.hipsFOVInDeg
+ * @param obj.coordinateSys
+ * @param {String} [obj.sRegion]  an obsCore s_region type string
+ * @param obj.hipsUrl
+ * @param obj.mocList
+ * @param {String} [obj.targetPanelExampleRow1]
+ * @param {String} [obj.targetPanelExampleRow2]
+ * @returns {FieldDef}
+ */
+export function makeCircleDef({ key, targetKey, sizeKey, minValue, maxValue, desc, tooltip, initValue, nullAllowed,
+                                  centerPt, hipsFOVInDeg, coordinateSys, sRegion,
                                   hipsUrl, mocList, targetPanelExampleRow1, targetPanelExampleRow2
                               }) {
     return ({
         type: CIRCLE, key, desc, tooltip, initValue, minValue, maxValue, nullAllowed,
         targetDetails: {
             hipsUrl, centerPt, hipsFOVInDeg, coordinateSys, mocList,
-            targetKey, sizeKey,
+            targetKey, sizeKey, sRegion,
             targetPanelExampleRow1, targetPanelExampleRow2
         }
     });
 }
 
-export const makePolygonDef = ({key, desc, tooltip, initValue, targetPanelExampleRow1, nullAllowed, popupHiPS=true}) =>
+export const makePolygonDef = ({key, desc, tooltip, initValue, targetPanelExampleRow1, sRegion,
+                                   nullAllowed, popupHiPS=true}) =>
     ({type: POLYGON, key, desc, tooltip, initValue, nullAllowed,
-        targetDetails: {targetPanelExampleRow1,popupHiPS,polygonKey:key}
+        targetDetails: {targetPanelExampleRow1,popupHiPS,polygonKey:key, sRegion}
     });
 
 /**
@@ -190,6 +212,7 @@ export const makePolygonDef = ({key, desc, tooltip, initValue, targetPanelExampl
  * @prop {String} targetKey
  * @prop {String} sizeKey
  * @prop {String} polygonKey
+ * @prop {String} obj.sRegion  an obsCore s_region type string
  * @prop {Array.<String>} targetPanelExampleRow1 eg- [`'62, -37'`, `'60.4 -35.1'`, `'4h11m59s -32d51m59s equ j2000'`, `'239.2 -47.6 gal'`],
  * @prop {Array.<String>} targetPanelExampleRow2  eg= [`'NGC 1532' (NB: DC2 is a simulated sky, so names are not useful)`],
  */

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1076,7 +1076,7 @@ export function hasObsCoreLikeDataProducts(tableOrId) {
  * @prop {string} value
  * @prop {boolean} allowsInput - use may change the parameter
  * @prop {boolean} inputRequired - user must enter something
- * @prop {Array.<ServiceDescriptorInputParam>} urlParams
+ * @prop {Array.<ServiceDescriptorInputParam>} serDefParams
  */
 
 /**
@@ -1112,7 +1112,7 @@ export function getServiceDescriptors(tableOrId) {
             title: desc ?? 'Service Descriptor '+idx,
             accessURL: params.find( ({name}) => name==='accessURL')?.value,
             standardID: params.find( ({name}) => name==='standardID')?.value,
-            urlParams: groups
+            serDefParams: groups
                 .find( (g) => g.name==='inputParams')
                 ?.params.map( (p) => {
                     const optionalParam= !p.ref && !p.value && !p.options;
@@ -1136,6 +1136,25 @@ export function getServiceDescriptors(tableOrId) {
  * @return {string}
  */
 export const getObsCoreAccessFormat= (tableOrId, rowIdx) => getObsCoreCellValue(tableOrId,rowIdx, 'access_format');
+
+
+/**
+ * return s_region cell data
+ * @param {TableModel|String} tableOrId - a table model or a table id
+ * @param rowIdx
+ * @return {string}
+ */
+export const getObsCoreSRegion= (tableOrId, rowIdx) => getObsCoreCellValue(tableOrId,rowIdx, 's_region');
+
+/**
+ * return obs_title cell data
+ * @param {TableModel|String} tableOrId - a table model or a table id
+ * @param rowIdx
+ * @return {string}
+ */
+export const getObsTitle= (tableOrId, rowIdx) => getObsCoreCellValue(tableOrId,rowIdx, 'obs_title');
+
+
 /**
  * return access_url cell data
  * @param {TableModel|String} tableOrId - a table model or a table id

--- a/src/firefly/js/visualize/iv/HiPSTileDrawer.js
+++ b/src/firefly/js/visualize/iv/HiPSTileDrawer.js
@@ -266,7 +266,7 @@ function makeOffScreenCanvas(plotView, plot, overlayTransparent) {
 
     const aitoff= isHiPSAitoff(plot);
     let altDevRadius= plotView.viewDim.width/2 + plotView.scrollX - 4;
-    if (aitoff) altDevRadius*= 2.85;
+    if (aitoff) altDevRadius*= 2.92;
     if (aitoff && fov>=360) {
         clipForFullScreen(ctx, width,height, centerDevPt, altDevRadius, true);
     }

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -3,6 +3,7 @@
  */
 
 import {isEmpty, isString} from 'lodash';
+import CoordSys, {CoordinateSys} from '../CoordSys.js';
 import ImagePlotCntlr, {
     dispatchChangeCenterOfProjection,
     dispatchPlotHiPS,
@@ -16,6 +17,7 @@ import ImagePlotCntlr, {
     WcsMatchType,
     makeUniqueRequestKey
 } from '../ImagePlotCntlr.js';
+import {makeWorldPt} from '../Point.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import {WebPlot, isHiPS, isImage, isBlankHiPSURL} from '../WebPlot.js';
 import {PlotAttribute} from '../PlotAttribute.js';
@@ -422,7 +424,11 @@ export function makeImageOrHiPSAction(rawAction) {
         const useImage= !plotAllSkyFirst && imageRequest.getWorldPt() && (size !== 0) && (size < fovDegFallOver);
 
         const wpRequest= useImage ? imageRequest.makeCopy() : hipsRequest.makeCopy();
-        if (hipsAitoff) wpRequest.setHipsUseAitoffProjection(true);
+        if (hipsAitoff) {
+            wpRequest.setHipsUseAitoffProjection(true);
+            wpRequest.setWorldPt(makeWorldPt(0,0,CoordinateSys.GALACTIC));
+            wpRequest.setHipsUseCoordinateSys(CoordinateSys.GALACTIC);
+        }
 
         const hipsImageConversion= {hipsRequestRoot:hipsRequest, imageRequestRoot:imageRequest, fovMaxFitsSize,
                                     autoConvertOnZoom, fovDegFallOver, plotAllSkyFirst};

--- a/src/firefly/js/visualize/ui/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiProductViewer.jsx
@@ -36,7 +36,7 @@ import {
 } from '../../metaConvert/DataProductsCntlr';
 import {RadioGroupInputFieldView} from '../../ui/RadioGroupInputFieldView';
 import {dispatchChangeActivePlotView} from '../ImagePlotCntlr';
-import {ActivateMenu} from './ActivateMenu.jsx';
+import {ServiceDescriptorPanel} from './ServiceDescriptorPanel.jsx';
 import {getServiceParamsAry} from '../../metaConvert/DataProductsCntlr.js';
 
 
@@ -137,13 +137,14 @@ const MultiProductViewerImpl= memo(({ dpId='DataProductsType', metaDataTableId, 
             return makeMultiImageViewer(imageViewerId,metaDataTableId,makeDropDown,ImageMetaDataToolbar);
         case DPtypes.ANALYZE :
             if (allowsInput && !searchParams) {
-                return (<ActivateMenu
+                return (<ServiceDescriptorPanel
                     {...{
                         serDefParams,
                         serviceDefRef:dataProductsState.serviceDefRef,
                         setSearchParams: (params) => dispatchSetSearchParams({dpId,activeMenuLookupKey,menuKey,params}),
                         title:dataProductsState.name,
                         makeDropDown,
+                        sRegion: dataProductsState.sRegion,
                         }} />);
             }
             else {

--- a/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
@@ -82,7 +82,8 @@ function updateSelect(pv, value, allPlots=true, modalEndInfo, setModalEndInfo) {
             }
             setModalEndInfo({
                 s:'End Select',
-                f: () => onOff(pv,SelectArea.TYPE_ID,allPlots,false,false,modalEndInfo,setModalEndInfo,'')
+                f: () => onOff(pv,SelectArea.TYPE_ID,allPlots,false,false,modalEndInfo,setModalEndInfo,''),
+                offOnNewPlot: true,
             });
         }
     };

--- a/src/firefly/js/visualize/ui/ServiceDescriptorPanel.jsx
+++ b/src/firefly/js/visualize/ui/ServiceDescriptorPanel.jsx
@@ -19,13 +19,14 @@ const GROUP_KEY= 'ActivateMenu';
 const titleStyle= {width: '100%', textAlign:'center', padding:'10px 0 5px 0', fontSize:'larger', fontWeight:'bold'};
 
 
-export const ActivateMenu= memo(({ serviceDefRef='none', serDefParams, setSearchParams, title, makeDropDown}) => {
+export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDefParams, setSearchParams,
+                                               title, makeDropDown, sRegion}) => {
 
 
     const loadParams= (request) => {
         setSearchParams(request);
     };
-    const fieldDefAry= makeFieldDefs(serDefParams);
+    const fieldDefAry= makeFieldDefs(serDefParams, sRegion);
     return (
         <div key={serviceDefRef}>
             {makeDropDown?.()}
@@ -44,7 +45,7 @@ export const ActivateMenu= memo(({ serviceDefRef='none', serDefParams, setSearch
     );
 });
 
-ActivateMenu.propTypes= {
+ServiceDescriptorPanel.propTypes= {
     serDefParams: arrayOf(object),
     title: string,
     serviceDefRef: string,
@@ -90,7 +91,7 @@ const isNumberField= ({type,minValue,maxValue,value}) =>
 
 
 
-function makeFieldDefs(serDefParams) {
+function makeFieldDefs(serDefParams, sRegion) {
     return serDefParams
         .filter( (sdP) => !sdP.ref )
         .map( (sdP) => {
@@ -107,11 +108,13 @@ function makeFieldDefs(serDefParams) {
                         targetKey:'circleTarget', sizeKey:'circleSize',
                         initValue:radius,
                         centerPt, minValue, maxValue,
-                        hipsFOVInDeg:radius*2+radius*.2 });
+                        hipsFOVInDeg:radius*2+radius*.2,
+                        sRegion
+                    });
                 }
                 if (isPolygonField(sdP)) {
                     const {value}= getPolygonInfo(sdP);
-                    return makePolygonDef({key:name, desc:name, tooltip, units, initValue:value});
+                    return makePolygonDef({key:name, desc:name, tooltip, units, initValue:value, sRegion});
                 }
                 else if (isNumberField(sdP)) {
                         const minNum= Number(sdP.minValue);

--- a/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
+++ b/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
@@ -92,7 +92,8 @@ export function onOff(pv,typeId,allPlots, plotTypeMustMatch, todo, modalEndInfo,
             f: () => {
                 onOff(pv,typeId,allPlots,plotTypeMustMatch,todo, modalEndInfo, setModalEndInfo,endText);
             },
-            s: endText
+            s: endText,
+            offOnNewPlot: true
         });
     }
     else {

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -6,6 +6,7 @@ import React, {memo,Fragment} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, isString} from 'lodash';
 import shallowequal from 'shallowequal';
+import {flux} from '../../core/ReduxFlux.js';
 import {sprintf} from '../../externalSource/sprintf';
 import {
     primePlot,getPlotViewById, isMultiHDUFits, getCubePlaneCnt, getHDU, getActivePlotView,
@@ -13,13 +14,14 @@ import {
     getHDUCount, getHDUIndex, getPtWavelength, hasPlaneOnlyWLInfo, isImageCube,
 } from '../PlotViewUtil.js';
 import {getExtName, getExtType} from '../FitsHeaderUtil.js';
+import {makeWorldPt} from '../Point.js';
 import {isHiPS, isHiPSAitoff, isImage} from '../WebPlot.js';
 import {ToolbarButton, ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
 import {RadioGroupInputFieldView} from '../../ui/RadioGroupInputFieldView.jsx';
 import {dispatchExtensionActivate} from '../../core/ExternalAccessCntlr.js';
 import {
     dispatchChangePrimePlot, dispatchChangeHiPS,
-    dispatchChangeHipsImageConversion, visRoot, dispatchChangeCenterOfProjection
+    dispatchChangeHipsImageConversion, visRoot, dispatchChangeCenterOfProjection, WcsMatchType, dispatchRecenter
 } from '../ImagePlotCntlr.js';
 import {makePlotSelectionExtActivateData} from '../../core/ExternalAccessUtils.js';
 import {ListBoxInputFieldView} from '../../ui/ListBoxInputField';
@@ -311,6 +313,15 @@ export const VisCtxToolbarView= memo((props) => {
             {hips && !canConvertHF && <HipsProjConvertButton pv={pv}/>}
             {hips && <HiPSCoordSelect plotId={plot?.plotId} imageCoordSys={plot?.imageCoordSys}/>}
             {hips && makeHiPSImageTable(pv)}
+            {isHiPSAitoff(plot) &&
+                <ToolbarButton text='Center Galactic' tip='Align Aitoff HiPS to Galactic 0,0'
+                               horizontal={true}
+                               onClick={() => dispatchChangeHiPS({
+                                   plotId:plot.plotId,
+                                   coordSys:CoordinateSys.GALACTIC,
+                                   centerProjPt:makeWorldPt(0, 0, CoordinateSys.GALACTIC) })
+                               } />
+            }
         </Fragment>
     );
 

--- a/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
@@ -174,6 +174,10 @@ const VisMiniToolbarView= memo( ({visRoot,dlCount,availableWidth, manageExpand, 
             if (!rect) return;
             setColorDrops(Boolean(window.innerHeight-rect.bottom>560));
         }
+        return () => {
+            const modalEndInfo= getComponentState('ModalEndInfo', emptyModalEndInfo);
+            if (modalEndInfo.offOnNewPlot) closeToolbarModalLayers();
+        };
     }, []);
 
     const pv= getActivePlotView(visRoot);
@@ -451,7 +455,8 @@ function startExtraction(element,type,setModalEndInfo, modalEndInfo) {
             ended= true;
             endExtraction();
             setModalEndInfo({});
-        }
+        },
+        offOnNewPlot: false
     });
 
 }


### PR DESCRIPTION
#### [Firefly-1030](https://jira.ipac.caltech.edu/browse/FIREFLY-1030): improve visual target selection
 - Visual target selection
   - make fields yellow that are being editied
   - set FOV smarter
   - add help text at top of visual selection, and help icon
   - show s_region

 - Other stuff:
   - revamp aitoff coverage so if AITOFF if always comes up at 0,0 gal
   - add a 0,0, galactic button if showing aitoff
   - if coverage start with aitoff have option of different image
   - fixed: distance tool turn off button sometime shows when it should not
   - fixed: remove distributed data” from tool tip
   - image will show EXTNAME or EXTTYPE
- Also Fixes: [Firefly-1025](https://jira.ipac.caltech.edu/browse/FIREFLY-1025): improve visual target selection

#### Testing

  - https://fireflydev.ipac.caltech.edu/firefly-1030-map-selection/firefly/
  - TAP:
     - Goto tap dialog and select an area
     - do a search with CADC, ivoa/ivoa.obscore - target m1, 
         - with first line of result select, choose cutout under the `more` dropdown
         - click on the pointer, you should see the s_region overdraw 
  - Coverage:
     - load a search with all sky
     - the coverage will come up with always centered on 0,0 GAL with a galactic projection
     - If the first result is all sky the default hips will be a DIRBE
     - any time hips is switch to Aitoff a button will appear to center on Galactic 0,0 with a galactic projection