### PR TITLE
FIREFLY-1040: Allow Firefly to startup with a predefined access token

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*;
 
 ENV CATALINA_HOME=/opt/tomcat \
-    USE_ADMIN_AUTH="false"
+    USE_ADMIN_AUTH=false \
+    DEBUG=true
 
 ENV work_dir=firefly
 ENV project=firefly

--- a/docker/launchTomcat.sh
+++ b/docker/launchTomcat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-JPDA_ADDRESS=${JPDA_ADDRESS:-*:5050}
+export JPDA_ADDRESS="*:5050"
 VISUALIZE_FITS_SEARCH_PATH=${VISUALIZE_FITS_SEARCH_PATH:-''}
 START_MODE=${START_MODE:-run}
 NAME=${BUILD_TIME_NAME:-"ipac/firefly"}
@@ -126,8 +126,7 @@ CATALINA_OPTS="$CATALINA_OPTS \
 ${CATALINA_HOME}/cleanup.sh /firefly/workarea /firefly/shared-workarea &
 
 echo -e "\nlaunchTomcat.sh: Starting Tomcat"
-if [ "$DEBUG" = "true" ] ||[ "$DEBUG" = "t" ] ||[ "$DEBUG" = "1" ] ||  \
-   [ "$DEBUG" = "TRUE" ] || [ "$DEBUG" = "True" ] || [ "$1" = "--debug" ]; then
+if [ "${DEBUG,,}" = "true" ] || [ "$1" = "--debug" ]; then
     exec ${CATALINA_HOME}/bin/catalina.sh jpda ${START_MODE}
 else
     exec ${CATALINA_HOME}/bin/catalina.sh ${START_MODE}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/PersonalAccessToken.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/PersonalAccessToken.java
@@ -1,0 +1,52 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.firefly.server.security;
+
+import edu.caltech.ipac.firefly.data.userdata.UserInfo;
+import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
+import edu.caltech.ipac.util.AppProperties;
+
+import java.util.Arrays;
+
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
+
+/**
+ * Date: 8/1/22
+ *
+ * @author loi
+ * @version : $
+ */
+public class PersonalAccessToken implements SsoAdapter {
+
+    private static final String ACCESS_TOKEN  = AppProperties.getProperty("sso.access.token");
+    private static final String AUTH_HOSTS    = AppProperties.getProperty(REQ_AUTH_HOSTS, "");
+    private static final String[] reqAuthHosts;
+    private static Token authToken;
+    private static UserInfo userInfo;
+
+    static {
+        reqAuthHosts = Arrays.stream(AUTH_HOSTS.split(","))
+                            .map(String::trim)
+                            .toArray(String[]::new);
+        if (!isEmpty(ACCESS_TOKEN)) {
+            authToken = new Token(ACCESS_TOKEN);
+            userInfo = new UserInfo();
+            userInfo.setLoginName(ACCESS_TOKEN.substring(0, Math.min(6, ACCESS_TOKEN.length())));
+        }
+    }
+
+    public Token getAuthToken() { return authToken; }
+
+    public UserInfo getUserInfo() { return userInfo; }
+
+    public void setAuthCredential(HttpServiceInput inputs) {
+        Token token = getAuthToken();
+        if (token != null && token.getId() != null) {
+            if (SsoAdapter.requireAuthCredential(inputs.getRequestUrl(), reqAuthHosts)) {
+                inputs.setHeader("Authorization", "Bearer " + token.getId());
+            }
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/SsoAdapter.java
@@ -26,10 +26,17 @@ public interface SsoAdapter {
     String SSO_FRAMEWORK_NAME = "sso.framework.name";
     String SSO_FRAMEWORK_ADAPTER = "sso.framework.adapter";
 
+    // common properties keys used by SsoAdapter implementers
+    String LOGIN_URL         = "sso.login.url";
+    String LOGOUT_URL        = "sso.logout.url";
+    String REQ_AUTH_HOSTS    = "sso.req.auth.hosts";
+
+
     enum SsoFramework {
         josso(JOSSOAdapter.class),
         oidc(OidcAdapter.class),
-        mod_auth_openidc(AuthOpenidcMod.class);
+        mod_auth_openidc(AuthOpenidcMod.class),
+        PAT(PersonalAccessToken.class);
 
         Class clz;
         SsoFramework(Class clz) { this.clz= clz;}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1040
- Implements a PersonalAccessToken `SsoAdapter`
- Define property used by PersonalAccessToken to set token at startup

To test:

#### Create a token if you don't have one  

	https://jira.lsstcorp.org/browse/DM-35788

#### Get PR changes

	git fetch &&  git checkout FIREFLY-1040_personal_access_token

#### Define token on startup
Add these properties into `./firefly-docker.env`

	## Properties needed for PersonalAccessToken SsoAdapter
	PROPS_sso__framework__name=PAT
	PROPS_sso__req__auth__hosts=.ncsa.illinois.edu,.lsst.cloud
	PROPS_sso__access__token=[secret-token]

#### Start Firefly

	docker compose up firefly --build

#### Test
Goto http://localhost:8080/firefly/?__action=layout.showDropDown&view=MultiTableSearchCmd
Enter 'https://data.lsst.cloud/api/tap' into `Select TAP Service` field then [Return]
You should see Schema and Tables loaded.


