### PR TITLE
Firefly-1045: Fixed several bugs

### DIFF
--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -8,6 +8,11 @@
 ## May be disabled in deployments where authorization is handled externally, e.g., by applying authorization-dependent redirects in a Kubernetes environment.
 #USE_ADMIN_AUTH=false
 
+# to set up personal access tokens
+#PROPS_sso__framework__name=PAT
+#ROPS_sso__req__auth__hosts=.ncsa.illinois.edu,.lsst.cloud
+#ROPS_sso__access__token=xxx
+
 ##---- Empty declarations: environment will come from the shell
 ADMIN_PASSWORD
 env

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -144,7 +144,7 @@ public class IpacTableFromSource extends IpacTablePartProcessor {
                 } else if (checkForUpdates) {
                     FileUtil.writeStringToFile(nFile, "workaround");
                     nFile.setLastModified(res.lastModified());
-                    URLDownload.Options ops= new URLDownload.Options(false,true);
+                    URLDownload.Options ops= URLDownload.Options.modifiedOp(false);
                     FileInfo finfo = URLDownload.getDataToFile(url, nFile, inputs.getCookies(), inputs.getHeaders(), ops);
                     if (finfo.getResponseCode() != HttpURLConnection.HTTP_NOT_MODIFIED) {
                         checkForFailures(finfo);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HiPSRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HiPSRetrieve.java
@@ -7,7 +7,6 @@ package edu.caltech.ipac.firefly.server.servlets;
 
 
 import edu.caltech.ipac.firefly.data.FileInfo;
-import edu.caltech.ipac.firefly.server.RequestOwner;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.util.download.URLDownload;
@@ -39,9 +38,7 @@ public class HiPSRetrieve {
             if (!dir.exists()) dir.mkdirs();
 
             File targetFile= new File(dir, new File((pathExt == null ? url.getFile() : pathExt)).getName());
-            URLDownload.Options ops= new URLDownload.Options(true,true);
-            RequestOwner ro = ServerContext.getRequestOwner();
-            FileInfo fi= URLDownload.getDataToFile(url,targetFile,ro.getCookieMap(), null, ops);
+            FileInfo fi= URLDownload.getDataToFile(url,targetFile,null, null, URLDownload.Options.modifiedOp(true));
             int rCode= fi.getResponseCode();
             File retFile= fi.getFile();
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
@@ -119,7 +119,7 @@ public class LockingVisNetwork {
 
         try {
             File fileName= (fileInfo==null) ? CacheHelper.makeFile(params.getFileDir(), params.getUniqueString()) : fileInfo.getFile();
-            URLDownload.Options ops= new URLDownload.Options(true,true,params.getMaxSizeToDownload(),true,dl);
+            var ops= URLDownload.Options.listenerOp(params.getMaxSizeToDownload(), dl);
             fileInfo= URLDownload.getDataToFile(params.getURL(), fileName, params.getCookies(), params.getHeaders(), ops);
             if (fileInfo.getResponseCode()==200) CacheHelper.putFileInfo(params,fileInfo);
             return fileInfo;

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -360,8 +360,10 @@ function renderRoot(viewer, props, webApiCommands) {
         return;
     }
 
-    const doAppRender= () => ReactDOM.render(React.createElement(viewer, props), e);
-    isUsingWebApi(webApiCommands) ? handleWebApi(webApiCommands, e, doAppRender) : doAppRender();
+
+    const webApi= isUsingWebApi(webApiCommands);
+    const doAppRender= () => ReactDOM.render(React.createElement(viewer, {...props, normalInit: !webApi }), e);
+    webApi ? handleWebApi(webApiCommands, e, doAppRender) : doAppRender();
 }
 
 
@@ -370,9 +372,14 @@ function handleWebApi(webApiCommands, e, doAppRender) {
         params, badParams, missingParams}= evaluateWebApi(webApiCommands);
     switch (status) {
         case WebApiStat.EXECUTE_API_CMD:
+            let apiCompleted= false;
             window.history.pushState('home', 'Home', new URL(window.location).pathname); // ?? is this necessary?
             doAppRender();
-            dispatchOnAppReady(() =>  execute?.(cmd,params));
+            dispatchOnAppReady(() =>  {
+                if (apiCompleted) return;
+                execute?.(cmd,params);
+                apiCompleted= true;
+            });
             break;
         case WebApiStat.SHOW_HELP:
             ReactDOM.render(

--- a/src/firefly/js/api/webApiCommands/TapCommands.js
+++ b/src/firefly/js/api/webApiCommands/TapCommands.js
@@ -86,9 +86,29 @@ const tapPanelExamples= [
         }
     },
     {
+        desc:'Open tap panel- setup  gia search for data release 2',
+        params:{
+            service: 'https://gea.esac.esa.int/tap-server/tap',
+            schema:'gaiadr2',
+            table:'gaiadr2.gaia_source',
+            WorldPt: '83.63321237;22.01446012;EQ_J2000',
+            sr: '20s',
+        }
+    },
+    {
+        desc:'Execute adql gia search on sources for data release 2',
+        params:{
+            service: 'https://gea.esac.esa.int/tap-server/tap',
+            adql: ` SELECT * 
+FROM gaiadr2.gaia_source 
+WHERE CONTAINS(POINT('ICRS', ra, dec),CIRCLE('ICRS', 83.63321237, 22.01446012, 0.027777777777777776))=1 `,
+            execute: 'true'
+        }
+    },
+    {
         desc:'Show tap tables for CADC',
         params:{
-            service: 'https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/tap',
+            service: 'https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/argus/',
             schema:'tap_schema',
             table:'tap_schema.tables',
             execute: 'true'
@@ -99,7 +119,7 @@ const tapPanelExamples= [
         params:{
             service: 'https://irsa.ipac.caltech.edu/TAP',
             adql:
-`SELECT ra,dec,sigra,sigdec,sigradec,w1mpro,w1sigmpro,w1snr,w1rchi2,w1mpro_allwise,w1sigmpro_allwise,,w4mpro_allwise,w4sigmpro_allwise \
+`SELECT ra,dec,sigra,sigdec,sigradec,w1mpro,w1sigmpro,w1snr,w1rchi2,w1mpro_allwise,w1sigmpro_allwise,w4mpro_allwise,w4sigmpro_allwise \
 FROM neowiser_p1bs_psd WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE(\'ICRS\', 10.68479, 41.26906, 0.013))=1`,
         }
     },

--- a/src/firefly/js/drawingLayers/HiPSMOC.js
+++ b/src/firefly/js/drawingLayers/HiPSMOC.js
@@ -143,7 +143,7 @@ function creator(initPayload) {
     dl.mocTable= undefined;
     dl.rootTitle= dl.title;
 
-        dispatchAddActionWatcher({
+    dispatchAddActionWatcher({
         callback:loadMocFitsWatcher,
         params: {id: dl.drawLayerId, mocFitsInfo},
         actions:[DrawLayerCntlr.CHANGE_VISIBILITY, DrawLayerCntlr.ATTACH_LAYER_TO_PLOT]

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -3,6 +3,7 @@
  */
 
 import {get, isEmpty, isArray} from 'lodash';
+import {RangeValues, SIGMA, STRETCH_LINEAR} from '../visualize/RangeValues.js';
 import {makeWisePlotRequest} from './WiseRequestList.js';
 import {make2MassPlotRequest} from './TwoMassRequestList.js';
 import {makeAtlasPlotRequest} from './AtlasRequestList.js';
@@ -481,6 +482,7 @@ function makeMovingRequest(table, row, dataSource, positionWP, plotId) {
     r.setTitleOptions(TitleOptions.FILE_NAME);
     r.setZoomType(ZoomType.TO_WIDTH_HEIGHT);
     r.setPlotId(plotId);
+    r.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
     r.setOverlayPosition(positionWP);
     return r;
 

--- a/src/firefly/js/metaConvert/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/ObsCoreConverter.js
@@ -1,4 +1,5 @@
 import {get, isEmpty, uniqueId} from 'lodash';
+import {RangeValues, SIGMA, STRETCH_LINEAR} from '../visualize/RangeValues.js';
 import {WebPlotRequest, TitleOptions} from '../visualize/WebPlotRequest.js';
 import {getCellValue, doFetchTable, hasRowAccess} from '../tables/TableUtil.js';
 import {
@@ -198,7 +199,9 @@ export function makeObsCoreRequest(dataSource, positionWP, titleStr) {
         r.setTitleOptions(TitleOptions.FILE_NAME);
     }
     r.setPlotId(uniqueId('obscore-'));
+
     if (positionWP) r.setOverlayPosition(positionWP);
+    r.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
 
     return r;
 }

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -35,7 +35,7 @@ const TT_SAVE = 'Save the content as an IPAC, CSV, or TSV table';
 const TT_TEXT_VIEW = 'Text View';
 const TT_TABLE_VIEW = 'Table View';
 const TT_CLEAR_FILTER = 'Remove all filters';
-const TT_SHOW_FILTER = 'The Filter Panel can be used to remove unwanted data from the search results';
+const TT_SHOW_FILTER = 'Filters can be used to remove unwanted rows from the search results';
 const TT_EXPAND = 'Expand this panel to take up a larger area';
 
 

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -65,7 +65,7 @@ export class FireflyViewer extends PureComponent {
 
     componentDidMount() {
         dispatchOnAppReady((state) => {
-            onReady({state, menu: this.props.menu, views: this.props.views,
+            onReady({state, menu: this.props.menu, views: this.props.views, normalInit:this.props.normalInit??true,
                 options:this.props.options, initLoadingMessage:this.props.initLoadingMessage, initLoadCompleted:this.state.initLoadCompleted});
         });
         this.removeListener = flux.addListener(() => this.storeUpdate());
@@ -133,6 +133,7 @@ FireflyViewer.propTypes = {
     rightButtons: PropTypes.arrayOf( PropTypes.func ),
     options: PropTypes.object,
     initLoadingMessage: PropTypes.string,
+    normalInit: PropTypes.bool
 };
 
 FireflyViewer.defaultProps = {
@@ -140,13 +141,13 @@ FireflyViewer.defaultProps = {
     views: 'images | tables | xyPlots'
 };
 
-function onReady({menu, views, options={}, initLoadingMessage, initLoadCompleted}) {
+function onReady({menu, views, options={}, initLoadingMessage, initLoadCompleted, normalInit}) {
     if (menu) {
         const {backgroundMonitor= true}= options;
         dispatchSetMenu({menuItems: menu, showBgMonitor:backgroundMonitor});
     }
     const {hasImages, hasTables, hasXyPlots} = getLayouInfo();
-    if (!(hasImages || hasTables || hasXyPlots)) {
+    if (normalInit && (!(hasImages || hasTables || hasXyPlots))) {
         let goto = getActionFromUrl();
         if (!goto) goto= (!initLoadingMessage || initLoadCompleted) && {type: SHOW_DROPDOWN};
         if (goto) flux.process(goto);

--- a/src/firefly/js/ui/PopupPanelHelper.js
+++ b/src/firefly/js/ui/PopupPanelHelper.js
@@ -108,18 +108,19 @@ export const getDefaultPopupPosition= function(e, layoutType,positionElement) {
 
     let left= 0;
     let top= 0;
+    const {offsetWidth=0,offsetHeight=0}= e??{};
     const posBound= positionElement?.getBoundingClientRect() ?? {};
     switch (layoutType.toString()) {
         case 'CENTER' :
-            left= window.innerWidth/2 - e.offsetWidth/2 + window.scrollX;
-            top= window.innerHeight/2 - e.offsetHeight/2 + window.scrollY;
+            left= window.innerWidth/2 - offsetWidth/2 + window.scrollX;
+            top= window.innerHeight/2 - offsetHeight/2 + window.scrollY;
             break;
         case 'TOP_CENTER' :
-            left= window.innerWidth/2 - e.offsetWidth/2 + window.scrollX;
+            left= window.innerWidth/2 - offsetWidth/2 + window.scrollX;
             top= window.scrollY+ 100;
             break;
         case 'TOP_RIGHT' :
-            left= window.innerWidth - e.offsetWidth - 30 + window.scrollX;
+            left= window.innerWidth - offsetWidth - 30 + window.scrollX;
             top= window.scrollY+ 3;
             break;
         case 'TOP_LEFT' :
@@ -127,14 +128,14 @@ export const getDefaultPopupPosition= function(e, layoutType,positionElement) {
             top= window.scrollY+ 3;
             break;
         case 'TOP_EDGE_CENTER' :
-            left= window.innerWidth/2 - e.offsetWidth/2 + window.scrollX;
+            left= window.innerWidth/2 - offsetWidth/2 + window.scrollX;
             top= window.scrollY+ 3;
             break;
         case 'TOP_RIGHT_OF_BUTTON' :
             if (!positionElement) return getDefaultPopupPosition(e,'TOP_RIGHT');
-            left= posBound.width + posBound.x + 5  + e.offsetWidth < window.innerWidth ?
-                posBound.width + posBound.x + 5 : window.innerWidth - e.offsetWidth;
-            top= posBound.y > e.offsetHeight ? posBound.y - e.offsetHeight : 5;
+            left= posBound.width + posBound.x + 5  + offsetWidth < window.innerWidth ?
+                posBound.width + posBound.x + 5 : window.innerWidth - offsetWidth;
+            top= posBound.y > offsetHeight ? posBound.y - offsetHeight : 5;
             break;
     }
     return {left, top};

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -177,7 +177,7 @@ export const SizeInputFields = memo( (props) => {
 
     const {viewProps, fireValueChange}=  useFieldGroupConnector(
         {
-            ...props,
+            nullAllowed:props.initialState.nullAllowed??false, ...props,
             initialState:{...props.initialState,
                 validator: (value) => {
                     const v= (value+'').trim();

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -219,9 +219,6 @@ export function BasicUI(props) {
                 setSchemaName(schema);
                 setTableName(table);
             }
-        } else {
-            setSchemaName(undefined);
-            setTableName(undefined);
         }
     }, [serviceUrl, selectBy]);
 

--- a/src/firefly/js/visualize/HiPSMocUtil.js
+++ b/src/firefly/js/visualize/HiPSMocUtil.js
@@ -57,7 +57,12 @@ function doHeadersMatchMOC(sourceHeaderEntries, doTableValidation= true) {
     const k= 0;
     const v= 1;
     const mocKeySet = [{PCOUNT: '0'}, {GCOUNT: '1'}, {TFIELDS: '1'},
-        [{TFORM1: '1J',  NAXIS1: '4'}, {TFORM1: '1K', NAXIS1: '8'}]];
+        [
+            {TFORM1: '1J',  NAXIS1: '4'},
+            {TFORM1: 'J',  NAXIS1: '4'},
+            {TFORM1: '1K', NAXIS1: '8'},
+            {TFORM1: 'K', NAXIS1: '8'}
+        ]];
 
     const mocKeys = flatten(mocKeySet).reduce((prev, oneCond) => {
         Object.keys(oneCond).forEach((aKey) => {

--- a/src/firefly/js/visualize/PlotGroup.js
+++ b/src/firefly/js/visualize/PlotGroup.js
@@ -13,6 +13,7 @@
  * @prop {boolean} allSelected
  * @prop {boolean} rotateNorthLockSticky
  * @prop {boolean} flipYSticky
+ * @prop {RangeValues} defaultRangeValues
  */
 
 /**
@@ -22,7 +23,7 @@
  */
 export const makePlotGroup= (plotGroupId,overlayColorLock) =>
     ({ plotGroupId, overlayColorLock, enableSelecting :false, allSelected :false,
-        rotateNorthLockSticky:false, flipYSticky : false,
+        rotateNorthLockSticky:false, flipYSticky : false, defaultRangeValues: undefined,
     });
 
 /**

--- a/src/firefly/js/visualize/RangeValues.js
+++ b/src/firefly/js/visualize/RangeValues.js
@@ -210,6 +210,10 @@ export class RangeValues {
 
     }
 
+    static make2To10SigmaLinear() {
+        return RangeValues.makeRV({which:SIGMA, lowerValue:-2, upperValue:10, algorithm:STRETCH_LINEAR});
+    }
+
     /**
      *
      * @param boundsType one of 'percent', 'absolute', 'sigma'

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -1003,8 +1003,11 @@ function makeDataOnlyRequestString(r) {
     if (!r) return '';
     r= r.makeCopy();
     r.setRequestKey('');
+    r.setPlotId('');
+    r.setPlotGroupId('');
     r.setInitialRangeValues();
     r.setInitialColorTable(getDefaultImageColorTable());
+    r.setAnnotationOps(AnnotationOps.INLINE);
     return r.toString();
 }
 

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -39,6 +39,7 @@ import {updateTransform, makeTransform} from '../PlotTransformUtils.js';
  * @prop {String} plotId, immutable
  * @prop {String} plotGroupId, immutable
  * @prop {String} drawingSubGroupId, immutable
+ * @prop {WebPlotRequest} request
  * @prop {boolean} visible true when we draw the base image
  * @prop {Array.<WebPlot>} plots all the plots that this plotView can show, usually the image in the fits file
  * @prop {String} plottingStatusMsg, end user description of the what is doing on

--- a/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanel.jsx
@@ -71,7 +71,7 @@ const dialogBuilder= getDialogBuilder();
 
 export function showDrawingLayerPopup(div) {
     dialogBuilder(div);
-    dispatchShowDialog(DRAW_LAYER_POPUP);
+    dispatchShowDialog(DRAW_LAYER_POPUP,div);
 }
 
 export function hideDrawingLayerPopup() { dispatchHideDialog(DRAW_LAYER_POPUP); }

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -18,6 +18,7 @@ import {getSizeAsString} from '../../util/WebUtil.js';
 import {makeFileRequest} from '../../tables/TableRequestUtil.js';
 import {SelectInfo} from '../../tables/SelectInfo.js';
 import {getAViewFromMultiView, getMultiViewRoot, IMAGE} from '../MultiViewCntlr.js';
+import RangeValues from '../RangeValues.js';
 import WebPlotRequest from '../WebPlotRequest.js';
 import ImagePlotCntlr, {dispatchPlotImage, visRoot} from '../ImagePlotCntlr.js';
 import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
@@ -690,6 +691,7 @@ function sendImageRequest(imageIndices, request, fileCacheKey) {
     const {fileName, parts=[]} = currentReport;
 
     const wpRequest = WebPlotRequest.makeFilePlotRequest(fileCacheKey);
+    wpRequest.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
     const {viewerId=''} = getAViewFromMultiView(getMultiViewRoot(), IMAGE) || {};
 
     if (viewerId) {

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -110,6 +110,7 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element, initLeft, initTop, o
         } else {
             const crtPlot = primePlot(visRoot());
             const newTableInfo = createFitsHeaderTable(null, crtPlot);
+            if (!newTableInfo) return {displayedPlotId, displayedHdu};
 
             Object.keys(newTableInfo).reduce((prev, oneBand) => {
                 prev = prev || updateTableSort(newTableInfo[oneBand]);

--- a/src/firefly/js/visualize/ui/StretchDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/StretchDropDownView.jsx
@@ -76,7 +76,8 @@ export function StretchDropDownView({toolbarElement}) {
     const pv = useStoreConnector(() => getActivePlotView(visRoot()));
     const enabled= Boolean(pv);
     const plot= primePlot(pv);
-    const rv= plot.plotState.getRangeValues();
+    if (!plot) return <div/>;
+    const rv= plot?.plotState?.getRangeValues();
 
     const zscaleStretchMatches= (rv, algorithm) => rv.upperWhich===ZSCALE && algorithm===rv.algorithm;
 

--- a/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
+++ b/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
@@ -433,7 +433,7 @@ async function initHiPSPlot({ hipsUrl, plotId, viewerId, centerPt, hipsFOVInDeg,
         .forEach( ({drawLayerId}) => dispatchDestroyDrawLayer(drawLayerId));// clean up any old moc layers
     const wpRequest= WebPlotRequest.makeHiPSRequest(hipsUrl, centerPt, hipsFOVInDeg);
     wpRequest.setPlotGroupId(plotId+'-group');
-    wpRequest.setOverlayIds(['none']);
+    wpRequest.setOverlayIds([HiPSMOC.TYPE_ID]);
     wpRequest.setPlotId(plotId);
     if (coordinateSys) {
         wpRequest.setHipsUseCoordinateSys(coordinateSys);


### PR DESCRIPTION
#### [FIREFLY-1045](https://jira.ipac.caltech.edu/browse/FIREFLY-1045): Fix several bugs

- Fixed: Expanding/restoring an image in MultiProductViewer causes a reload stretch and color are reset
- Fixed: Exceptions happening when FItsHeaderView is up
- Fixed: Exceptions happening with StretchDropDownView
- Fixed: draw layer panel is hidden at times (zIndex was not correct)
- Fixed: on resize or when popping up mouse readout displayed zoomed to fix when it should not have
- Fixed: Moc validation was not accepting a valid FITs TFORM header
- Fixed: Better support for authorization in URLDownload.java
- Fixed: Expose MOC in Target Hips Panel
- Fixed: double load of web api
- Fixed: TAP search api did not init table correctly, also- fixed some bugs in examples
- Stretch should be sticky on MultiProductViewer
- Stretch should be stick for multi HDU images, if the same extension type
- [Firefly-1048](https://jira.ipac.caltech.edu/browse/FIREFLY-1049): Fixed: tooltip


#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1045-bugs/firefly/
 - Some issues are too hard to test
 - Do an obscore search with TAP. (this test same bug found in wise, ztf, sofia)
     - MAST - ivoa - ivoa.obscore - m1  
    - change color on an image and expand then colapse - color should not change
    - change stretch and change image (by click on another row), stretch type should be sticky
 - on the tap panel - bring up visual target chooser - show layer dialog, you should be able to see it.
 - show a HiPS image and zoom in, resize the window and the HiPs will not rezoom, it should just stay the same
 - If you have an multi-hdu image with the same EXTTYPE keyword, upload, then changed the stretch, it will apply to all with that extension type
 - load https://fireflydev.ipac.caltech.edu/firefly-1045-bugs/firefly/?api=hips then click one of the the examples.  There should just be one HiPS loaded (not 2, fixes the double load)