### PR TITLE
FIREFLY-1049: Table: Filter by selected row returned more than it should

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -563,8 +563,8 @@ public class EmbeddedDbUtil {
                     for (int cidx = 0; cidx < cols.length; cidx++)  {
                         ps.setObject(cidx+1, data.getData(cols[cidx].getKeyName(), ridx));
                     }
-                    ps.setObject(cols.length+1, i);         // add ROW_IDX
-                    ps.setObject(cols.length+2, i);         // add ROW_NUM
+                    ps.setObject(cols.length+1, ridx);         // add ROW_IDX
+                    ps.setObject(cols.length+2, ridx);         // add ROW_NUM
                 }
                 public int getBatchSize() {
                     return batchSize;


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1049

Taken from ticket:
This is a regression bug created by [FIREFLY-978](https://jira.ipac.caltech.edu/browse/FIREFLY-978).  In an attempt to save memory, table ingest is separated into batches of 10,000 rows.  However, it failed to increment `ROW_IDX` between batches causing `ROW_IDX` to repeat on large table that requires multiple batches.

Test:  https://fireflydev.ipac.caltech.edu/firefly-1049-filter-by-selected-row/firefly/
- Load a large table (more than 10k rows)
  - Select 1 row, then filter by selected row
  - Verify that there's only 1 row left
  - Clear filter
- bring up Table Options -> Advanced Filter
  - enter `ROW_IDX = 0 or (ROW_IDX > 9998 and ROW_IDX < 10002)` into constraints field, then apply
  - There should be 4 rows remaining (0, 9999, 10000, and 10001)
  - This verify that row_idx starts from 0 without any gaps in between batches