### PR TITLE
Firefly 1046: Add additional tests to StringUtilsTest.java and TableUtil-test.js

### DIFF
--- a/src/firefly/js/tables/__tests__/TableUtil-test.js
+++ b/src/firefly/js/tables/__tests__/TableUtil-test.js
@@ -146,18 +146,19 @@ describe('TableUtil: ', () => {
         res = formatValue({format: 'cost $%.2f'}, 123.3432);
         expect(res).toEqual('cost $123.34');
 
-        // @Kartikeya Puri, please add tests for precision column meta here...
+        // @Kartikeya Puri, adding tests for precision column meta here...
         // for precision, column must be numeric.. i.e.  {type: 'float', precision: 'E3'}
         // see TableUtil.js->formatValue function descriptions from details
 
         //there is a check in CoordUtil.js's dd2sex method for longitude degree out of range (< 0 or > 360)
         //but currently there's no such check for latitude out of the [-90,90] range
+        //in firefly, we allow DMS/Latitude to be entered in degrees outside of the [-90,90] range?
 
-        //for DMS, islat = true therefore latitude
+        //for DMS, islat = true therefore latitude (dec)
         res = formatValue({type: 'float', precision: 'DMS5'}, "+30.263");
         expect(res).toEqual('+30d15m46.8s');
 
-        //for HMS, islat = false therefore longitutde
+        //for HMS, islat = false therefore longitutde (ra)
         res = formatValue({type: 'float', precision: 'HMS5'}, "+30.263");
         expect(res).toEqual('2h01m03.12s');
 
@@ -167,25 +168,33 @@ describe('TableUtil: ', () => {
         res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude
         expect(res).toEqual('21h37m40.80s');
 
-        //testing below - feel free to change values as needed
-        //this is converted to 40 (400 - 360) -- but shouldn't be allowed to enter > 90 degrees for latitude, correct?
-        //even on firefly if I enter "40 400" (40 for longitude, 400 for dms, 400 is converted to 40)
+        //400, with DMS is converted to 40 (400 - 360) in dd2sex (CoordUtil.js)
+        res = formatValue({type: 'float', precision: 'DMS5'}, "400"); //latitude
+        expect(res).toEqual('+40d00m00.0s');
+
         res = formatValue({type: 'float', precision: 'DMS5'}, "11.973"); //latitude
-        console.log(res);
         expect(res).toEqual('+11d58m22.8s');
 
         res = formatValue({type: 'float', precision: 'HMS'}, "11.973"); //longitude
-        console.log(res);
         expect(res).toEqual('0h47m53.52s');
 
-        res = formatValue({type: 'float', precision: 'E3'}, 453.450664);
+        res = formatValue({type: 'float', precision: 'E3'}, 453.450664); //3 significant digits after decimal
         expect(res).toEqual('4.535E+2');
 
-        res = formatValue({type: 'float', precision: 'G3'}, 43.450664);
+        res = formatValue({type: 'float', precision: 'G3'}, 43.450664); //3 significant digits
         expect(res).toEqual('43.5');
 
-        res = formatValue({type: 'float', precision: 'F2'}, 1.9999);
-        expect(res).toEqual('2.00'); //for 1.9999 this is an edge case, formatValue will return 2.00
+        res = formatValue({type: 'float', precision: 'F2'}, 1.999); //2 significant digits after decimal
+        //edge case for num.9999, will always be rounded to the next whole number
+        //if we try to format down decimal places
+        expect(res).toEqual('2.00');
+
+        res = formatValue({type: 'float', precision: 'F4'}, 1.999); //2 significant digits after decimal
+        //this should return 1.9990
+        expect(res).toEqual('1.9990');
+
+        res = formatValue({type: 'float', precision: 'F3'}, 45.19256); //1 significant digit after decimal
+        expect(res).toEqual('45.193'); //for 1.9999 this is an edge case, formatValue will return 2.00
 
     });
 

--- a/src/firefly/js/tables/__tests__/TableUtil-test.js
+++ b/src/firefly/js/tables/__tests__/TableUtil-test.js
@@ -167,6 +167,17 @@ describe('TableUtil: ', () => {
         res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude
         expect(res).toEqual('21h37m40.80s');
 
+        //testing below - feel free to change values as needed
+        //this is converted to 40 (400 - 360) -- but shouldn't be allowed to enter > 90 degrees for latitude, correct?
+        //even on firefly if I enter "40 400" (40 for longitude, 400 for dms, 400 is converted to 40)
+        res = formatValue({type: 'float', precision: 'DMS5'}, "400"); //latitude
+        console.log(res);
+        expect(res).toEqual('+40d00m00.0s');
+
+        res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude
+        console.log(res);
+        expect(res).toEqual('21h37m40.80s');
+
         res = formatValue({type: 'float', precision: 'E3'}, 453.450664);
         expect(res).toEqual('4.535E+2');
 

--- a/src/firefly/js/tables/__tests__/TableUtil-test.js
+++ b/src/firefly/js/tables/__tests__/TableUtil-test.js
@@ -150,6 +150,31 @@ describe('TableUtil: ', () => {
         // for precision, column must be numeric.. i.e.  {type: 'float', precision: 'E3'}
         // see TableUtil.js->formatValue function descriptions from details
 
+        //there is a check in CoordUtil.js's dd2sex method for longitude degree out of range (< 0 or > 360)
+        //but currently there's no such check for latitude out of the [-90,90] range
+
+        //for DMS, islat = true therefore latitude
+        res = formatValue({type: 'float', precision: 'DMS5'}, "+30.263");
+        expect(res).toEqual('+30d15m46.8s');
+
+        //for HMS, islat = false therefore longitutde
+        res = formatValue({type: 'float', precision: 'HMS5'}, "+30.263");
+        expect(res).toEqual('2h01m03.12s');
+
+        res = formatValue({type: 'float', precision: 'DMS5'}, "-15.530694"); //latitude
+        expect(res).toEqual('-15d31m50.5s');
+
+        res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude
+        expect(res).toEqual('21h37m40.80s');
+
+        res = formatValue({type: 'float', precision: 'E3'}, 453.450664);
+        expect(res).toEqual('4.535E+2');
+
+        res = formatValue({type: 'float', precision: 'G3'}, 43.450664);
+        expect(res).toEqual('43.5');
+
+        res = formatValue({type: 'float', precision: 'F2'}, 1.9999);
+        expect(res).toEqual('2.00'); //for 1.9999 this is an edge case, formatValue will return 2.00
 
     });
 

--- a/src/firefly/js/tables/__tests__/TableUtil-test.js
+++ b/src/firefly/js/tables/__tests__/TableUtil-test.js
@@ -150,10 +150,6 @@ describe('TableUtil: ', () => {
         // for precision, column must be numeric.. i.e.  {type: 'float', precision: 'E3'}
         // see TableUtil.js->formatValue function descriptions from details
 
-        //there is a check in CoordUtil.js's dd2sex method for longitude degree out of range (< 0 or > 360)
-        //but currently there's no such check for latitude out of the [-90,90] range
-        //in firefly, we allow DMS/Latitude to be entered in degrees outside of the [-90,90] range?
-
         //for DMS, islat = true therefore latitude (dec)
         res = formatValue({type: 'float', precision: 'DMS5'}, "+30.263");
         expect(res).toEqual('+30d15m46.8s');
@@ -162,20 +158,20 @@ describe('TableUtil: ', () => {
         res = formatValue({type: 'float', precision: 'HMS5'}, "+30.263");
         expect(res).toEqual('2h01m03.12s');
 
-        res = formatValue({type: 'float', precision: 'DMS5'}, "-15.530694"); //latitude
+        res = formatValue({type: 'float', precision: 'DMS5'}, "-15.530694"); //latitude/dec
         expect(res).toEqual('-15d31m50.5s');
 
-        res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude
+        res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude/ra
         expect(res).toEqual('21h37m40.80s');
 
         //400, with DMS is converted to 40 (400 - 360) in dd2sex (CoordUtil.js)
-        res = formatValue({type: 'float', precision: 'DMS5'}, "400"); //latitude
+        res = formatValue({type: 'float', precision: 'DMS5'}, "400"); //latitude/dec
         expect(res).toEqual('+40d00m00.0s');
 
-        res = formatValue({type: 'float', precision: 'DMS5'}, "11.973"); //latitude
+        res = formatValue({type: 'float', precision: 'DMS5'}, "11.973"); //latitude/dec
         expect(res).toEqual('+11d58m22.8s');
 
-        res = formatValue({type: 'float', precision: 'HMS'}, "11.973"); //longitude
+        res = formatValue({type: 'float', precision: 'HMS'}, "11.973"); //longitude/ra
         expect(res).toEqual('0h47m53.52s');
 
         res = formatValue({type: 'float', precision: 'E3'}, 453.450664); //3 significant digits after decimal
@@ -185,16 +181,14 @@ describe('TableUtil: ', () => {
         expect(res).toEqual('43.5');
 
         res = formatValue({type: 'float', precision: 'F2'}, 1.999); //2 significant digits after decimal
-        //edge case for num.9999, will always be rounded to the next whole number
-        //if we try to format down decimal places
-        expect(res).toEqual('2.00');
+        expect(res).toEqual('2.00'); //edge case
 
-        res = formatValue({type: 'float', precision: 'F4'}, 1.999); //2 significant digits after decimal
+        res = formatValue({type: 'float', precision: 'F4'}, 1.999); //4 significant digits after decimal
         //this should return 1.9990
         expect(res).toEqual('1.9990');
 
-        res = formatValue({type: 'float', precision: 'F3'}, 45.19256); //1 significant digit after decimal
-        expect(res).toEqual('45.193'); //for 1.9999 this is an edge case, formatValue will return 2.00
+        res = formatValue({type: 'float', precision: 'F3'}, 45.19256); //3 significant digits after decimal
+        expect(res).toEqual('45.193');
 
     });
 

--- a/src/firefly/js/tables/__tests__/TableUtil-test.js
+++ b/src/firefly/js/tables/__tests__/TableUtil-test.js
@@ -170,13 +170,13 @@ describe('TableUtil: ', () => {
         //testing below - feel free to change values as needed
         //this is converted to 40 (400 - 360) -- but shouldn't be allowed to enter > 90 degrees for latitude, correct?
         //even on firefly if I enter "40 400" (40 for longitude, 400 for dms, 400 is converted to 40)
-        res = formatValue({type: 'float', precision: 'DMS5'}, "400"); //latitude
+        res = formatValue({type: 'float', precision: 'DMS5'}, "11.973"); //latitude
         console.log(res);
-        expect(res).toEqual('+40d00m00.0s');
+        expect(res).toEqual('+11d58m22.8s');
 
-        res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude
+        res = formatValue({type: 'float', precision: 'HMS'}, "11.973"); //longitude
         console.log(res);
-        expect(res).toEqual('21h37m40.80s');
+        expect(res).toEqual('0h47m53.52s');
 
         res = formatValue({type: 'float', precision: 'E3'}, 453.450664);
         expect(res).toEqual('4.535E+2');

--- a/src/firefly/js/tables/__tests__/TableUtil-test.js
+++ b/src/firefly/js/tables/__tests__/TableUtil-test.js
@@ -146,50 +146,77 @@ describe('TableUtil: ', () => {
         res = formatValue({format: 'cost $%.2f'}, 123.3432);
         expect(res).toEqual('cost $123.34');
 
-        // @Kartikeya Puri, adding tests for precision column meta here...
-        // for precision, column must be numeric.. i.e.  {type: 'float', precision: 'E3'}
-        // see TableUtil.js->formatValue function descriptions from details
-
         //for DMS, islat = true therefore latitude (dec)
-        res = formatValue({type: 'float', precision: 'DMS5'}, "+30.263");
+        res = formatValue({type: 'float', precision: 'DMS'}, '30.263'); //valid DMS range value
         expect(res).toEqual('+30d15m46.8s');
 
         //for HMS, islat = false therefore longitutde (ra)
-        res = formatValue({type: 'float', precision: 'HMS5'}, "+30.263");
+        res = formatValue({type: 'float', precision: 'HMS'}, '30.263'); //valid HMS range value
         expect(res).toEqual('2h01m03.12s');
 
-        res = formatValue({type: 'float', precision: 'DMS5'}, "-15.530694"); //latitude/dec
+        res = formatValue({type: 'float', precision: 'DMS5'}, '-15.530694'); //n=5 will be ignored
         expect(res).toEqual('-15d31m50.5s');
 
-        res = formatValue({type: 'float', precision: 'HMS'}, "324.42"); //longitude/ra
+        res = formatValue({type: 'float', precision: 'HMS3'}, '324.42'); //n=3 will be ignored
         expect(res).toEqual('21h37m40.80s');
 
-        //400, with DMS is converted to 40 (400 - 360) in dd2sex (CoordUtil.js)
-        res = formatValue({type: 'float', precision: 'DMS5'}, "400"); //latitude/dec
-        expect(res).toEqual('+40d00m00.0s');
+        //Testing out of range values for DMS [-90, 90] & HMS [0, 360]
+        //These should throw latitude out of range, longitude out of range
+        //and longitude cannot be negative errors respectively
+        //- uncomment these after ticket FIREFLY-1056 is closed
 
-        res = formatValue({type: 'float', precision: 'DMS5'}, "11.973"); //latitude/dec
-        expect(res).toEqual('+11d58m22.8s');
+        //res = formatValue({type: 'float', precision: 'DMS'}, '100.5');
+        //res = formatValue({type: 'float', precision: 'HMS'}, '370.2');
+        //res = formatValue({type: 'float', precision: 'HMS'}, '-10.0');
 
-        res = formatValue({type: 'float', precision: 'HMS'}, "11.973"); //longitude/ra
-        expect(res).toEqual('0h47m53.52s');
+        //non-numeric val=null returns '', precision/type does not matter here
+        res = formatValue({type: 'float', precision: 'E2'}, null);
+        expect(res).toEqual('');
 
         res = formatValue({type: 'float', precision: 'E3'}, 453.450664); //3 significant digits after decimal
         expect(res).toEqual('4.535E+2');
 
+        res = formatValue({type: 'double', precision: 'E1'}, 57.365); //1 significant digit after decimal
+        expect(res).toEqual('5.7E+1');
+
+        res = formatValue({type: 'double', precision: 'E0'}, 46.365); //rounds to 5E+1
+        expect(res).toEqual('5E+1');
+
+        res = formatValue({type: 'int', precision: 'E3'}, 453445.678); //post decimal value is truncated, as type=int
+        expect(res).toEqual('453445');
+
+        res = formatValue({type: 'long', precision: 'E3'}, 57345); //value should be unchanged for type=long
+        expect(res).toEqual('57345');
+
         res = formatValue({type: 'float', precision: 'G3'}, 43.450664); //3 significant digits
-        expect(res).toEqual('43.5');
+        expect(res).toEqual('43.5'); //rounding post decimal and truncating the rest
+
+        res = formatValue({type: 'float', precision: 'G2'}, 43.6); //2 significant digits
+        expect(res).toEqual('44'); //rounds to 44
+
+        res = formatValue({type: 'int', precision: 'G5'}, 43.5); //post decimal value is truncated, as type=int
+        expect(res).toEqual('43');
+
+        res = formatValue({type: 'long', precision: 'G1'}, 450); //value should be unchanged for type=long
+        expect(res).toEqual('450');
+
+        res = formatValue({type: 'double', precision: 'G5'}, 43); //5 significant digits
+        expect(res).toEqual('43.000');
 
         res = formatValue({type: 'float', precision: 'F2'}, 1.999); //2 significant digits after decimal
-        expect(res).toEqual('2.00'); //edge case
+        expect(res).toEqual('2.00'); //rounds to 2.00
 
-        res = formatValue({type: 'float', precision: 'F4'}, 1.999); //4 significant digits after decimal
-        //this should return 1.9990
-        expect(res).toEqual('1.9990');
+        res = formatValue({type: 'float', precision: 'F3'}, 43); //2 significant digits after decimal
+        expect(res).toEqual('43.000');
 
-        res = formatValue({type: 'float', precision: 'F3'}, 45.19256); //3 significant digits after decimal
+        res = formatValue({type: 'int', precision: 'F3'}, 99.87); //post decimal value is truncated, as type=int
+        expect(res).toEqual('99');
+
+        res = formatValue({type: 'long', precision: 'F3'}, 125); //value should be unchanged for type=long
+        expect(res).toEqual('125');
+
+        res = formatValue({type: 'double', precision: 'F3'}, 45.19256); //3 significant digits after decimal
         expect(res).toEqual('45.193');
-
     });
 
 });

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -625,7 +625,7 @@ const FileAnalysis = ({report, summaryModel, detailsModel, tablesOnly, isMoc}) =
                 <li style={liStyle}>Custom catalog in IPAC, CSV, TSV, VOTABLE, or FITS table format</li>
                 {!tablesOnly && <li style={liStyle}>Any FITS file with tables or images (including multiple HDUs)</li>}
                 {!tablesOnly && <li style={liStyle}>A Region file</li> }
-                {!tablesOnly && <li style={liStyle}>A MOC FITS file</li> }
+                {!tablesOnly && <li style={liStyle}>A MOC FITS file TEST!</li> }
             </ul>
         </div>);
 

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -625,7 +625,7 @@ const FileAnalysis = ({report, summaryModel, detailsModel, tablesOnly, isMoc}) =
                 <li style={liStyle}>Custom catalog in IPAC, CSV, TSV, VOTABLE, or FITS table format</li>
                 {!tablesOnly && <li style={liStyle}>Any FITS file with tables or images (including multiple HDUs)</li>}
                 {!tablesOnly && <li style={liStyle}>A Region file</li> }
-                {!tablesOnly && <li style={liStyle}>A MOC FITS file TEST!</li> }
+                {!tablesOnly && <li style={liStyle}>A MOC FITS file</li> }
             </ul>
         </div>);
 

--- a/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
@@ -79,6 +79,62 @@ public class StringUtilsTest extends ConfigTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(Integer.MIN_VALUE, result);
 
-        //System.out.println(result);
+        num = "21474836478"; //max int = 2147483647, so this should cause NumberFormatException and return Integer.MIN_VALUE
+        result = getInt(num);
+
+        Assert.assertNotNull(result);
+        System.out.println(result);
+        Assert.assertEquals(Integer.MIN_VALUE, result);
+
+        //test with sending null, floating point numbers etc. should all return Integer.MIN_VALUE
+    }
+
+    @Test
+    public void getLongFunc() {
+        String num = "273";
+
+        long result = getLong(num);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(273, result);
+
+        result = getLong("not a number");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.MIN_VALUE, result);
+
+        result = getLong("2958583");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(2958583, result);
+
+        result = getLong(null);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.MIN_VALUE, result);
+
+        result = getLong("6.54"); //float
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.MIN_VALUE, result);
+
+        System.out.println(result);
+    }
+
+    @Test
+    public void getDoubleFunc() {
+        String num = "273";
+
+        double result = getDouble(num);
+
+        Assert.assertNotNull(result);
+        //what's delta in floating point numbers? 
+        Assert.assertEquals(273.0, result, 0);
+
+        result = getDouble("not a number");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Double.NaN, result, 0);
+
+        result = getDouble("273");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(273.0, result, 0);
+
+        System.out.println(result);
     }
 }

--- a/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
@@ -64,29 +64,37 @@ public class StringUtilsTest extends ConfigTest {
         Assert.assertEquals("xyz=999", results[1]);
     }
 
-    // @Kartikeya Puri, please add a few more test here..
+    // @Kartikeya Puri, adding a few more tests here..
     // i.e getInt, getLong, getDouble, getFloat from edu.caltech.ipac.util.StringUtils
     @Test
     public void getIntFunc() {
         String num = "273";
 
         int result = getInt(num);
-
         Assert.assertNotNull(result);
         Assert.assertEquals(273, result);
+        Assert.assertNotEquals(273.0, result);
 
-        result = getInt("not a number");
+        result = getInt("not a number"); //not a valid number, should return Integer.MIN_VALUE
         Assert.assertNotNull(result);
         Assert.assertEquals(Integer.MIN_VALUE, result);
 
-        num = "21474836478"; //max int = 2147483647, so this should cause NumberFormatException and return Integer.MIN_VALUE
-        result = getInt(num);
-
+        //max int = 2147483647, so this should cause NumberFormatException and return Integer.MIN_VALUE
+        result = getInt("21474836478");
         Assert.assertNotNull(result);
-        System.out.println(result);
         Assert.assertEquals(Integer.MIN_VALUE, result);
 
-        //test with sending null, floating point numbers etc. should all return Integer.MIN_VALUE
+        result = getInt("-3147483648"); //min int is = -2,147,483,648, so this should also return Integer.MIN_VALUE
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Integer.MIN_VALUE, result);
+
+        result = getInt(null);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Integer.MIN_VALUE, result);
+
+        result = getInt("21.56"); //floating point -> NumberFormatException, should return Integer.MIN_VALUE
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Integer.MIN_VALUE, result);
     }
 
     @Test
@@ -94,11 +102,10 @@ public class StringUtilsTest extends ConfigTest {
         String num = "273";
 
         long result = getLong(num);
-
         Assert.assertNotNull(result);
         Assert.assertEquals(273, result);
 
-        result = getLong("not a number");
+        result = getLong("not a number"); //non-number, so this should return Long.MIN_VALUE
         Assert.assertNotNull(result);
         Assert.assertEquals(Long.MIN_VALUE, result);
 
@@ -110,11 +117,19 @@ public class StringUtilsTest extends ConfigTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(Long.MIN_VALUE, result);
 
-        result = getLong("6.54"); //float
+        result = getLong("6.54"); //floating point number, so this should return Long.MIN_VALUE
         Assert.assertNotNull(result);
         Assert.assertEquals(Long.MIN_VALUE, result);
 
-        System.out.println(result);
+        //Long.MAX_VALUE = 9223372036854775807
+        result = getLong("9223372036854775807");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.MAX_VALUE, result);
+
+        //This is > Long.MAX_VALUE so this should return Long.MIN_VALUE (NumberFormatException)
+        result = getLong("9223372036854775807999");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Long.MIN_VALUE, result);
     }
 
     @Test
@@ -122,19 +137,53 @@ public class StringUtilsTest extends ConfigTest {
         String num = "273";
 
         double result = getDouble(num);
-
         Assert.assertNotNull(result);
-        //what's delta in floating point numbers?
         Assert.assertEquals(273.0, result, 0);
 
-        result = getDouble("not a number");
+        result = getDouble("not a number"); //non-number, so getDouble will return Double.NaN
         Assert.assertNotNull(result);
         Assert.assertEquals(Double.NaN, result, 0);
 
-        result = getDouble("273");
+        result = getDouble("273.1425");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(273.0, result, 0.5); //testing delta, this should return true aas 273.1425 is within 0.5 of 273
+        Assert.assertNotEquals(272.0, result, 1); //outside of delta range
+
+        result = getDouble("1.7976931348623157E308"); //Double.MAX_VALUE
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1.7976931348623157E308, result, 0);
+
+        result = getDouble("4.9E-324"); //Double.MIN_VALUE
+        Assert.assertNotNull(result);
+        Assert.assertEquals(4.9E-324, result, 0);
+
+        result = getDouble(null); //null, should return Double.NaN
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Double.NaN, result, 0);
+    }
+
+    @Test
+    public void getFloatFunc() {
+        String num = "273";
+
+        double result = getFloat(num);
         Assert.assertNotNull(result);
         Assert.assertEquals(273.0, result, 0);
 
-        System.out.println(result);
+        result = getFloat("not a number"); //non-number, so getFloat will return Float.NaN
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Float.NaN, result, 0);
+
+        result = getFloat("273.1425");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(273.0, result, 0.5); //testing delta, this should return true aas 273.1425 is within 0.5 of 273
+
+        result = getFloat("1.4E-45"); //Float.MIN_VALUE
+        Assert.assertNotNull(result);
+        Assert.assertEquals(1.401298464324817E-45, result, 0);
+
+        result = getFloat(null); //null, should return Double.NaN
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Float.NaN, result, 0);
     }
 }

--- a/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
@@ -10,8 +10,7 @@ import org.junit.Test;
 
 import java.util.regex.Pattern;
 
-import static edu.caltech.ipac.util.StringUtils.groupFind;
-import static edu.caltech.ipac.util.StringUtils.groupMatch;
+import static edu.caltech.ipac.util.StringUtils.*;
 
 /**
  * Date: 8/5/22
@@ -67,4 +66,19 @@ public class StringUtilsTest extends ConfigTest {
 
     // @Kartikeya Puri, please add a few more test here..
     // i.e getInt, getLong, getDouble, getFloat from edu.caltech.ipac.util.StringUtils
+    @Test
+    public void getIntFunc() {
+        String num = "273";
+
+        int result = getInt(num);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(273, result);
+
+        result = getInt("not a number");
+        Assert.assertNotNull(result);
+        Assert.assertEquals(Integer.MIN_VALUE, result);
+
+        //System.out.println(result);
+    }
 }

--- a/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
@@ -64,8 +64,6 @@ public class StringUtilsTest extends ConfigTest {
         Assert.assertEquals("xyz=999", results[1]);
     }
 
-    // @Kartikeya Puri, adding a few more tests here..
-    // i.e getInt, getLong, getDouble, getFloat from edu.caltech.ipac.util.StringUtils
     @Test
     public void getIntFunc() {
         String num = "273";

--- a/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/StringUtilsTest.java
@@ -124,7 +124,7 @@ public class StringUtilsTest extends ConfigTest {
         double result = getDouble(num);
 
         Assert.assertNotNull(result);
-        //what's delta in floating point numbers? 
+        //what's delta in floating point numbers?
         Assert.assertEquals(273.0, result, 0);
 
         result = getDouble("not a number");


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1046


Taken from ticket:
StringUtilsTest is a JUnit test for StringUtils.  Most of the functions are not used anymore.  But, we still use a lot of the getters functions, i.e. getInt, getLong, getDouble, getFloat.
Added tests to verify it works as intended as well as to demonstrate its behaviors.

TableUtil-test.js is a JavaScript(Jest) test for TableUtil.js.  Added additional conditions to 'formatValue' test to capture Column's precision use cases (HMS, DMS, F, E, G). 