### PR TITLE
Firefly 1056 Coordinates validation for latitude and longitude 

### DIFF
--- a/src/firefly/js/util/PositionParser.js
+++ b/src/firefly/js/util/PositionParser.js
@@ -54,21 +54,38 @@ export function parsePosition(s) {
         let validDec= true;
         try {
             ra=  isNaN(Number(raStr)) ? CoordUtil.convertStringToLon(raStr, coordSys) : Number(raStr);
+            if (Number(raStr)) {
+                if (ra >= 360 || ra < 0) {
+                    raParseErr = 'Longitude is out of range [0, 359]';
+                    validRa = false;
+                    //positionValidateInternal in PositionFieldDef.js expects ra to be NaN to throw an error
+                    ra = NaN; //set ra to NaN as it is out of bounds
+                }
+            }
         } catch (e) {
             raParseErr = e;
             validRa = false;
         }
         try {
             dec= isNaN(Number(decStr)) ? CoordUtil.convertStringToLat(decStr, coordSys) : Number(decStr);
+            if (Number(decStr)) {
+                if (dec > 90 || dec < -90) {
+                    decParseErr = 'Latitude is out of range [-90.0, +90.0]';
+                    //positionValidateInternal in PositionFieldDef.js expects dec to be NaN to throw an error
+                    dec = NaN; //set dec to NaN as it is out of bounds
+                    validDec = false;
+                }
+            }
         } catch (e) {
             decParseErr = e;
             validDec = false;
         }
         // determineType uses the first string to decide if the input is a position or object name.
         // "12 mus" (a valid object name in NED) would be classified as a position.
-        if (!validDec) {
+        if (!validDec && !Number(decStr)) {
+            //validDec may be false when dec is out of range [-90, 90] as well
             inputType = PositionParsedInputType.Name;
-            objName= s;
+            objName = s;
             valid = true;
         } else {
             valid = coordSys !== CoordinateSys.UNDEFINED && validRa && validDec;


### PR DESCRIPTION
#### [Firefly-1056](https://jira.ipac.caltech.edu/browse/FIREFLY-1056): coordinates validation for latitude/longitude (check for out of bounds) 
 - Added a check for latitude/longitude (dec/ra) being out of bounds
 - If either ra or dec is out of bounds, setting their value to NaN because the **positionValidateInternal** function in PositionFieldDef.js expects ra/dec to be NaN in order to throw an error message 

#### Testing
 -  https://fireflydev.ipac.caltech.edu/firefly-1056-coordinates-validation/firefly/
 -  go to Select Target -> Coordinates or Object Name -> Enter valid coordinates for longitude [0,359] and latitude [-90, 90], enter out of bounds coordinates to test error message (error message should specifically say whether longitude or latitude is out of bounds)
 - Finally, also enter all other coordinate/position types (name, DB_ID, HMS/DMS to make sure they work as expected)
 

