### PR TITLE
Firefly 1065 naif resolver (multiple results unrelated to input showing up)

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/net/HorizonsEphPairs.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/net/HorizonsEphPairs.java
@@ -40,14 +40,16 @@ public class HorizonsEphPairs {
                     s = idOrName.split("^[0-9]* "); // now get the rest
                     if (inParens(s[1])) {
                         idOrName = stripFirstLast(s[1]);
-                    } else {
-                        char[] cAry = s[1].toCharArray();
-                        boolean hasDigit = false;
-                        for (int i = 0; (i < cAry.length && !hasDigit); i++) {
-                            hasDigit = Character.isDigit(cAry[i]);
-                        }
-                        if (!hasDigit) idOrName = s[1];
                     }
+                        //do not delete this else block, might need it later to deal with inputs like '2020 Ukko'
+                        //else {
+                        //char[] cAry = s[1].toCharArray();
+                        //boolean hasDigit = false;
+                        //for (int i = 0; (i < cAry.length && !hasDigit); i++) {
+                        //    hasDigit = Character.isDigit(cAry[i]);
+                        //}
+                        //if (!hasDigit) idOrName = s[1];
+                    //}
                 } catch (NumberFormatException ignore) {
                 }
             }


### PR DESCRIPTION
#### [Firefly-1065](https://jira.ipac.caltech.edu/browse/FIREFLY-1065): naif resolver 
 - fixed code so that an input like "2020 AA" doesn't return multiple unrelated results (formerly it was querying the API with just "AA", for which we were getting multiple results)

#### Testing
 -  https://firefly-1065-naif-resolver-filter.irsakudev.ipac.caltech.edu/applications/wise/
 -  Search by Solar System Object/Orbit -> Object Name -> 2020 AA 
 - Other Object Names you should test with: 2020, 599994 (2011 EN), 2011 E, 599994, 2011 EN
 - 2011 E will return multiple results, and you should be able to scroll through all of them in the dropdown (previously, you were not able to scroll through the last few items for multiple results returned)
 - Note: If you search with the input "2020 Ukko" you will get no results (this was formerly supported). The reason is that querying the horizons lookup API with this input returns no results. Previously, we were only querying with the "Ukko" part of the input, which returned a result. But that won't work for an input like "2020 AA" (if we search with just "AA", we will get multiple results, so we want to query the API with the entire input string "2020 AA"). The only case in which we split the string to query the API is if the input is of format "599994 (2011 EN)". In this case we query with "2011 EN" (querying with "599994" or "2011 EN" will return the same result). 

