### PR TITLE
Firefly 1063 PointShapeSizePicker class to functional component

### DIFF
--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -130,7 +130,7 @@ export function ShapePicker({drawingDef, displayGroupId, plotId, update, getColo
             const symbolSize = DrawUtil.getSymbolSize(isize, isize, drawingDef.symbol);
             const newDD = {...drawingDef, size: symbolSize};
 
-            setSize(size);
+            setSize(isize);
             setValidSize(validSize);
             setDrawingDef(newDD);
             const dl = getDrawLayersByDisplayGroup(getDlAry(), displayGroupId);

--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -2,10 +2,9 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {PureComponent} from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
-import {flux} from '../core/ReduxFlux.js';
 import {dispatchShowDialog} from '../core/ComponentCntlr.js';
 import {PopupPanel} from './PopupPanel.jsx';
 import {DrawSymbol} from '../visualize/draw/DrawSymbol.js';
@@ -18,9 +17,9 @@ import {RadioGroupInputFieldView} from './RadioGroupInputFieldView.jsx';
 import {InputFieldView} from './InputFieldView.jsx';
 import {SimpleCanvas} from '../visualize/draw/SimpleCanvas.jsx';
 import {getDrawLayersByDisplayGroup} from '../visualize/PlotViewUtil.js';
-import {clone} from '../util/WebUtil.js';
 import Color from '../util/Color.js';
 import {HelpIcon} from '../ui/HelpIcon.jsx';
+import {useStoreConnector} from 'firefly/ui/SimpleComponent';
 
 
 
@@ -30,7 +29,7 @@ const popupIdBase = 'ShapePickerDialog';
 const ARROW_UP = 38;
 const ARROW_DOWN = 40;
 
-var popupId;
+let popupId;
 
 
 
@@ -56,12 +55,12 @@ function defaultGetColor(drawLayer) {
  */
 export function showPointShapeSizePickerDialog(dl, plotId, drawingDef= undefined,
                                                update= defaultUpdate, getColor= defaultGetColor) {
-    var {isPointData=false} = dl;
+    const {isPointData=false} = dl;
 
     popupId = popupIdBase; //keep one dialog
     const popup= isPointData ? (
         <PopupPanel title={'Symbol Picker - ' + dl.drawLayerId } >
-            <ShapePickerWrapper
+            <ShapePicker
                 drawingDef={drawingDef || dl.drawingDef}
                 displayGroupId={dl.displayGroupId}
                 plotId={plotId}
@@ -77,84 +76,45 @@ export function showPointShapeSizePickerDialog(dl, plotId, drawingDef= undefined
     }
 }
 
-class ShapePickerWrapper extends PureComponent {
-    constructor(props) {
-        super(props);
+export function ShapePicker({drawingDef, displayGroupId, plotId, update, getColor}) {
 
-        var {size, symbol} = props.drawingDef;
-        var {width} = DrawUtil.getDrawingSize(size, symbol);
-        var validSize = (width >= MINSIZE) && (width <= MAXSIZE);
+    const storeUpdate = () => {   // color change externally
+        const dl = getDrawLayersByDisplayGroup(getDlAry(), displayGroupId);
+        const dlColor = getColor(dl);
 
-        this.state = {drawingDef: props.drawingDef, size: `${width}`, validSize}; // sizexsize: the overal size shown on UI
-        this.displayGroupId = props.displayGroupId;
-        this.plotId = props.plotId;
-        this.updateSymbol = this.updateSymbol.bind(this);
-        this.drawSymbol = this.drawSymbol.bind(this);
-        this.updateSize = this.updateSize.bind(this);
-        this.updateShape = this.updateShape.bind(this);
-        this.onArrowDown = this.onArrowDown.bind(this);
-        this.onArrowUp = this.onArrowUp.bind(this);
-    }
-
-
-    componentDidUpdate(prevProps) {
-        const {size, symbol} = this.props.drawingDef;
-        const {size:prevSize, symbol:prevSymbol} = prevProps.drawingDef;
-        const {width} = DrawUtil.getDrawingSize(size, symbol);
-        const {width:prevWidth} = DrawUtil.getDrawingSize(prevSize, prevSymbol);
-
-        if (size!==prevSize || symbol!==prevSymbol || width!==prevWidth) {
-            const validSize = (width >= MINSIZE) && (width <= MAXSIZE);
-            this.setState({drawingDef: this.props.drawingDef, size: `${width}`, validSize}); // sizexsize: the overal size shown on UI
+        if (dlColor !== drawingDef.color) {
+            setDrawingDef({...drawingDef, color: dlColor});
         }
-        this.displayGroupId = this.props.displayGroupId;
-        this.plotId = this.props.plotId;
+    };
 
-    }
+    useStoreConnector(() => storeUpdate()); //replaced flux.addListener()
 
-    componentDidMount() {
-        this.iAmMounted = true;
-        this.removeListener = flux.addListener(() => this.storeUpdate());
-    }
+    let setDrawingDef = () => {};
+    [drawingDef, setDrawingDef] = useState(() => drawingDef);
+    const  {symbol} = drawingDef;
+    const {width} = DrawUtil.getDrawingSize(drawingDef.size, symbol);
+    const [size, setSize] = useState(() => `${width}`);
+    const [validSize, setValidSize] = useState(() => (width >= MINSIZE) && (width <= MAXSIZE));
 
-    componentWillUnmount() {
-        this.iAmMounted = false;
-        this.removeListener && this.removeListener();
-    }
-
-    storeUpdate() {   // color change externally
-        if (this.iAmMounted) {
-            const {drawingDef} = this.state;
-            const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
-            const dlColor = this.props.getColor(dl);
-
-            if (dlColor !== drawingDef.color) {
-                this.setState({drawingDef: clone(drawingDef, {color: dlColor})});
-            }
-        }
-    }
-
-    updateSymbol(ev) {
+    const updateSymbol = (ev) => {
         const value = get(ev, 'target.value');
         const symbol = value&&DrawSymbol[value];
 
-        const {drawingDef} = this.state;
-
         const symbolSize = DrawUtil.getSymbolSizeBasedOn(symbol, drawingDef);
-        const newDD = (symbolSize === drawingDef.size) ? clone(drawingDef, {symbol}) :
-                                                         clone(drawingDef, {symbol, size: symbolSize});
 
-        const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
-        // dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
-        this.props.update(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
-        this.setState({drawingDef: newDD});
+        const newDD = (symbolSize === drawingDef.size) ? {...drawingDef, symbol} :
+                                                         {...drawingDef, symbol, size: symbolSize};
 
-    }
+        const dl = getDrawLayersByDisplayGroup(getDlAry(), displayGroupId);
+        update(displayGroupId, newDD, plotId, dl.titleMatching);
+        setDrawingDef(newDD);
 
-    updateSize(ev) {
+    };
+
+    const updateSize = (ev) => {
         const size = get(ev, 'target.value');
-        var validSize = true;
-        var isize;
+        let validSize = true;
+        let isize;
 
         if (isNaN(parseFloat(size))) {
             validSize = false;
@@ -164,49 +124,46 @@ class ShapePickerWrapper extends PureComponent {
         }
 
         if (!validSize) {
-            this.setState({size, validSize});
+            setSize(size);
+            setValidSize(validSize);
         } else {
-            const {drawingDef} = this.state;
             const symbolSize = DrawUtil.getSymbolSize(isize, isize, drawingDef.symbol);
-            const newDD = clone(drawingDef, {size: symbolSize});
+            const newDD = {...drawingDef, size: symbolSize};
 
-            this.setState({size, validSize, drawingDef: newDD});
-            const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
-            // dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
-            this.props.update(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
+            setSize(size);
+            setValidSize(validSize);
+            setDrawingDef(newDD);
+            const dl = getDrawLayersByDisplayGroup(getDlAry(), displayGroupId);
+            update(displayGroupId, newDD, plotId, dl.titleMatching);
         }
-    }
+    };
 
-    onArrowDown(ev) {
-        const {size, validSize} = this.state;
+    const onArrowDown = (ev) => {
         const isize = validSize && Math.floor(parseFloat(size));
 
         if (validSize) {
             if ((ev.keyCode === ARROW_UP) && (size < MAXSIZE)) { // arrow up
-                this.setState({size: `${isize + 1}`});
+                setSize(`${isize + 1}`);
             } else if ((ev.keyCode === ARROW_DOWN) && (size > MINSIZE)) { // arrow down
-                this.setState({size: `${isize - 1}`});
+                setSize(`${isize - 1}`);
             }
         }
-    }
+    };
 
-    onArrowUp(ev) {
-        var {size, validSize, drawingDef} = this.state;
+    const onArrowUp = (ev) => {
 
         if (validSize && ((ev.keyCode === ARROW_UP || ev.keyCode === ARROW_DOWN ))) { // arrow up or down
             const isize = Math.floor(parseFloat(size));
             const symbolSize = DrawUtil.getSymbolSize(isize, isize, drawingDef.symbol);
-            const newDD = clone(drawingDef, {size: symbolSize});
+            const newDD = {...drawingDef, size: symbolSize};
 
-            const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
-            // dispatchChangeDrawingDef(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
-            this.props.update(this.displayGroupId, newDD, this.plotId, dl.titleMatching);
-            this.setState({drawingDef: newDD});
+            const dl = getDrawLayersByDisplayGroup(getDlAry(), displayGroupId);
+            update(displayGroupId, newDD, plotId, dl.titleMatching);
+            setDrawingDef(newDD);
         }
-    }
+    };
 
-    updateShape() {
-        const {size, drawingDef, validSize} = this.state;
+    const updateShape = () => {
 
         if (!validSize) {
             return;
@@ -214,24 +171,22 @@ class ShapePickerWrapper extends PureComponent {
         const isize = Math.floor(parseFloat(size));
         const symbolSize = DrawUtil.getSymbolSize(isize, isize, drawingDef.symbol);
 
-        const dl = getDrawLayersByDisplayGroup(getDlAry(), this.props.displayGroupId);
-        // dispatchChangeDrawingDef(this.displayGroupId, clone(drawingDef, {symbol: drawingDef.symbol, size: symbolSize}),
-        //                                                      this.plotId, dl.titleMatching);
-        this.props.update(this.displayGroupId, clone(drawingDef, {symbol: drawingDef.symbol, size: symbolSize}),
-            this.plotId, dl.titleMatching);
+        const dl = getDrawLayersByDisplayGroup(getDlAry(), displayGroupId);
+        update(displayGroupId, {...drawingDef, symbol: drawingDef.symbol, size: symbolSize},
+            plotId, dl.titleMatching);
 
-    }
 
-    drawSymbol(df, validSize, size){
-        const {drawingDef} = this.state;
+    };
 
+    const drawSymbol = (df, validSize, size) => {
+        
         const maxSize = 30;
-        var canvasSize = validSize && (Math.floor(parseFloat(size)) + 2);
+        let canvasSize = validSize && (Math.floor(parseFloat(size)) + 2);
         const bkColor = getBackgroundColor(df.color);
         if (size > maxSize) {
             canvasSize = validSize && Math.floor(parseFloat(maxSize)) + 2;
             const symbolSize = DrawUtil.getSymbolSize(maxSize, maxSize, drawingDef.symbol);
-            df = clone(drawingDef, {size: symbolSize});
+            df = {...drawingDef, size: symbolSize};
         }
 
         if (validSize) {
@@ -254,72 +209,69 @@ class ShapePickerWrapper extends PureComponent {
                     </div>);
             }
         }
-    }
+    };
 
-    render() {
-        const PointOptions = [ DrawSymbol.CIRCLE, DrawSymbol.SQUARE, DrawSymbol.DIAMOND,
-            DrawSymbol.CROSS, DrawSymbol.X, DrawSymbol.ARROW, DrawSymbol.POINT_MARKER,
-            DrawSymbol.BOXCIRCLE, DrawSymbol.DOT];
-        const {drawingDef, size, validSize} = this.state;
-        const df = validSize&&drawingDef;
-        const labelW = 70;
-        const mLeft = 10;
-        const bkColor = getBackgroundColor(drawingDef.color);
-        const textColor = '#000000';
-        const options = PointOptions.map((p) => {
-                            return {value: p.key, label: drawShapeWithLabel(p, drawingDef, bkColor, textColor)};
-                        });
-        return (
-            <div style={{width: 320}}>
-                <div style={{margin: mLeft,
-                             border: '1px solid rgba(0, 0, 0, 0.298039)',
-                             borderRadius: 5,
-                             padding: '10px 5px'
-                             }}>
-                    <div style={{display: 'flex', marginLeft: mLeft}} >
-                        <div style={{width: labelW, color: textColor}} title={'pick a symbol'}>Symbols:</div>
-                        <RadioGroupInputFieldView
-                                                  onChange={this.updateSymbol}
-                                                  tooltip='available symbol shapes'
-                                                  options={options}
-                                                  value={drawingDef.symbol.key}
-                                                  alignment='vertical'/>
-                    </div>
-                    <div style={{marginLeft: mLeft, marginTop: mLeft, height: 26, display: 'flex', alignItems: 'center'}}>
-                        <InputFieldView  label={'Symbol Size (px):'}
-                                         labelStyle={{color: textColor}}
-                                         labelWidth={labelW+30}
-                                         valid={validSize}
-                                         onChange={this.updateSize}
-                                         onKeyDown={this.onArrowDown}
-                                         onKeyUp={this.onArrowUp}
-                                         value={size}
-                                         tooltip={'enter the symbol size or use the arrow up (or down) key in the field to increase (or decrease) the size number '}
-                                         type={'text'}
-                                         placeholder={`size 3 < ${MAXSIZE}`}
-                                         size={16}
-                                         message={`invalid data entry, size is within 3 & ${MAXSIZE}`}/>
-                        {validSize && this.drawSymbol(df, validSize, size)}
-                    </div>
-                    <div style={{marginLeft: mLeft, marginTop: mLeft, color: textColor}}>
-                        <i>Try up/down arrow keys  </i>
-                    </div>
-                    <div style={{display:'flex'}}>
-                        <HelpIcon
-                            helpId={'visualization.imageoptions'}/>
-                    </div>
+    const PointOptions = [ DrawSymbol.CIRCLE, DrawSymbol.SQUARE, DrawSymbol.DIAMOND,
+        DrawSymbol.CROSS, DrawSymbol.X, DrawSymbol.ARROW, DrawSymbol.POINT_MARKER,
+        DrawSymbol.BOXCIRCLE, DrawSymbol.DOT];
+    const df = validSize&&drawingDef;
+    const labelW = 70;
+    const mLeft = 10;
+    const bkColor = getBackgroundColor(drawingDef.color);
+    const textColor = '#000000';
+    const options = PointOptions.map((p) => {
+                        return {value: p.key, label: drawShapeWithLabel(p, drawingDef, bkColor, textColor)};
+                    });
+    return (
+        <div style={{width: 320}}>
+            <div style={{margin: mLeft,
+                         border: '1px solid rgba(0, 0, 0, 0.298039)',
+                         borderRadius: 5,
+                         padding: '10px 5px'
+                         }}>
+                <div style={{display: 'flex', marginLeft: mLeft}} >
+                    <div style={{width: labelW, color: textColor}} title={'pick a symbol'}>Symbols:</div>
+                    <RadioGroupInputFieldView
+                                              onChange={updateSymbol}
+                                              tooltip='available symbol shapes'
+                                              options={options}
+                                              value={drawingDef.symbol.key}
+                                              alignment='vertical'/>
                 </div>
-                <div style={{marginBottom: 10, marginLeft: mLeft}} >
-                    <CompleteButton  dialogId={popupId}
-                                     onSuccess={this.updateShape}
-                                     text={'OK'}/>
+                <div style={{marginLeft: mLeft, marginTop: mLeft, height: 26, display: 'flex', alignItems: 'center'}}>
+                    <InputFieldView  label={'Symbol Size (px):'}
+                                     labelStyle={{color: textColor}}
+                                     labelWidth={labelW+30}
+                                     valid={validSize}
+                                     onChange={updateSize}
+                                     onKeyDown={onArrowDown}
+                                     onKeyUp={onArrowUp}
+                                     value={size}
+                                     tooltip={'enter the symbol size or use the arrow up (or down) key in the field to increase (or decrease) the size number '}
+                                     type={'text'}
+                                     placeholder={`size 3 < ${MAXSIZE}`}
+                                     size={16}
+                                     message={`invalid data entry, size is within 3 & ${MAXSIZE}`}/>
+                    {validSize && drawSymbol(df, validSize, size)}
+                </div>
+                <div style={{marginLeft: mLeft, marginTop: mLeft, color: textColor}}>
+                    <i>Try up/down arrow keys  </i>
+                </div>
+                <div style={{display:'flex'}}>
+                    <HelpIcon
+                        helpId={'visualization.imageoptions'}/>
                 </div>
             </div>
-        );
-    }
+            <div style={{marginBottom: 10, marginLeft: mLeft}} >
+                <CompleteButton  dialogId={popupId}
+                                 onSuccess={updateShape}
+                                 text={'OK'}/>
+            </div>
+        </div>
+    );
 }
 
-ShapePickerWrapper.propTypes= {
+ShapePicker.propTypes= {
     drawingDef: PropTypes.object.isRequired,
     displayGroupId: PropTypes.string.isRequired,
     plotId: PropTypes.string.isRequired,
@@ -328,15 +280,16 @@ ShapePickerWrapper.propTypes= {
 };
 
 function drawShapeWithLabel(pointObj, drawingDef, bkColor, textColor) {
-    var   size = 16;
-    var   symbolSize = DrawUtil.getSymbolSize(size, size, pointObj);
+    let   size = 16;
+    let   symbolSize = DrawUtil.getSymbolSize(size, size, pointObj);
     const addSpace = 6;
 
     if (pointObj.key === 'DOT') {
         symbolSize /= 2;
     }
 
-    const df = clone(drawingDef, {symbol: pointObj, size: symbolSize});
+    const df = {...drawingDef, symbol: pointObj, size: symbolSize};
+
     size += 2;
 
     return (


### PR DESCRIPTION
#### [Firefly-1063](https://jira.ipac.caltech.edu/browse/FIREFLY-1063): converting the ShapePickerWrapper class to a functional component 
 - Converted the ShapePickerWrapper class to a functional component (ShapePicker) 
 - The **if** condition inside **componentDidUpdate** in the class component was never being reached (none of the 3 conditions were true for any of the cases I tested: size, symbol and width were always equal to their previous values), so I did not convert that using **useEffect** and only did so for **componentDidMount** and **componentWillUnmount**.  
 - The second **if** condition (dlColor !== drawingDef.color) inside the **storeUpdate** (which is called using useStoreConnector) is also never reached, but I have kept this code in place for now. It may come in handy if we modify a shape that is not using the draw layers DrawingDef (but I couldn't figure out how to test that). 

#### Testing
 -  https://fireflydev.ipac.caltech.edu/firefly-1063-pointshapesizepicker-functional/firefly/
 - go to TAP -> service: IRSA/NED -> Coordinates or Object Name: m1 -> Radius: 100 
 - Open the color/symbol picker dialog (4th from the right hand side) 
 - Click on Symbol
 - Change the Symbol shape, change the symbol size by manually entering values and using the up/down array to move through values and ensure size is changing for every symbol type
 - Test out of bound values (less than 3 and greater than 100) 
 - Ensure behavior of symbol picker and symbol size is the same as that on Firefly (as there have should not have been any  UI changes, only refactoring of code from class to functional component). 

#### Bug Fix 
- follow the testing steps above 
- Try to enter a number in the valid range [3,100] followed by a space or other non-numeric characters. This should be disallowed
- The fix: The updateSize function takes the user entered "**size**" and uses parseFloat followed by Math.floor on it to get "**isize**". But when updating the state, we were setting (setSize) **size** to **size**, as opposed to **isize**. Setting it to **isize** fixes this issue. Try copy pasting "100 abc" into the input field. **size** = "100 abc" gets converted to "100" which is what the user sees since we update the state with this value. 
- Caveat: Because of Math.floor and setting **size** to **isize**,  this also means that the user won't be able to enter numbers with decimal points (try entering **42.5**). Is this functionality acceptable?  
 
