### PR TITLE
Firefly 1075 obs tap date update calendar dialog

### DIFF
--- a/src/firefly/js/ui/tap/ObsCore.jsx
+++ b/src/firefly/js/ui/tap/ObsCore.jsx
@@ -22,10 +22,15 @@ import {
     onChangeTimeMode,
     getTimeInfo,
     checkField,
-    updatePanelFields, isPanelChecked, getPanelPrefix, SmallFloatNumericWidth, SpatialLableSaptail
+    updatePanelFields,
+    isPanelChecked,
+    getPanelPrefix,
+    SmallFloatNumericWidth,
+    SpatialLableSaptail,
+    onChangeDateTimePicker
 } from 'firefly/ui/tap/TableSearchHelpers';
 import {ColsShape} from '../../charts/ui/ColumnOrExpression';
-import {convertISOToMJD, validateDateTime, validateMJD} from 'firefly/ui/DateTimePickerField';
+import {convertISOToMJD, convertMJDToISO, validateDateTime, validateMJD} from 'firefly/ui/DateTimePickerField';
 import {TimePanel} from 'firefly/ui/TimePanel';
 import {RadioGroupInputField} from 'firefly/ui/RadioGroupInputField';
 import {CheckboxGroupInputField} from 'firefly/ui/CheckboxGroupInputField';
@@ -503,9 +508,21 @@ export function ExposureDurationSearch({cols, groupKey, fields, useConstraintRed
     };
 
     const onChange = (inFields, action, rFields) => {
-        const {fieldKey, value} = action.payload;
+        const {fieldKey, value, timeMode} = action.payload;
+        let {timeOptions} = inFields;
+        timeOptions = {...timeOptions, value: timeMode}; /*FIXME: timeOptions' value shouldn't need to be manually updated here*/
         if (fieldKey === 'exposureTimeMode') {    // time mode changes => update timefrom and timeto value
             onChangeTimeMode(value, inFields, rFields, ['exposureMin', 'exposureMax']);
+        }
+        else {
+            const targetKey = fieldKey;
+            if (timeMode === 'mjd') {
+                //onChangeDateTimePicker expects an ISO value, so converting the MJD value to ISO here
+                onChangeDateTimePicker(convertMJDToISO(value), inFields, rFields, targetKey, fieldKey, timeOptions);
+            }
+            else {
+                onChangeDateTimePicker(value, inFields, rFields, targetKey, fieldKey, timeOptions);
+            }
         }
     };
 

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -488,7 +488,6 @@ function TemporalSearch({cols, columnsModel, groupKey, fields, useConstraintRedu
         const timeOptions = [{label: 'ISO', value: ISO},
                              {label: 'MJD', value: MJD}];
         const crtTimeMode = get(fields, [TimeOptions, 'value'], ISO);
-        const icon = crtTimeMode === ISO ? 'calendar' : '';
 
         //  radio field is styled with padding right in consistent with the label part of 'temporal columns' entry
         return (
@@ -506,7 +505,7 @@ function TemporalSearch({cols, columnsModel, groupKey, fields, useConstraintRedu
                     <TimePanel fieldKey={TimeFrom}
                                  groupKey={skey}
                                  timeMode={crtTimeMode}
-                                 icon={icon}
+                                 icon={'calendar'}
                                  onClickIcon={changeDatePickerOpenStatus(FROM, TimeFrom)}
                                  feedbackStyle={{height: 100}}
                                  inputWidth={Width_Column}
@@ -520,7 +519,7 @@ function TemporalSearch({cols, columnsModel, groupKey, fields, useConstraintRedu
                     <TimePanel fieldKey={TimeTo}
                                groupKey={skey}
                                timeMode={crtTimeMode}
-                               icon={icon}
+                               icon={'calendar'}
                                onClickIcon={changeDatePickerOpenStatus(TO, TimeTo)}
                                feedbackStyle={{height: 100}}
                                inputWidth={Width_Column}


### PR DESCRIPTION
#### [Firefly-1075](https://jira.ipac.caltech.edu/browse/FIREFLY-1075): Fixed: ISO & MJD feedback under input when selecting date/time from calendar dialog not showing up in ObsTAP 
 - added a call to onChangeDateTimePicker which now shows feedback under user input when selecting date/time from the calendar dialog
 - there was an issue with timeOptions.value not being updated to 'mjd' when the 'mjd' radio button was selected by the user. This resulted in the input field also changing its value to 'iso' format when using the calendar dialog to pick a date/time with the 'mjd' radio button selected. I manually set timeOptions.value = timeMode (which reflects the correctly selected radio button). There might be a better way to do this in the future (timeOptions.value should have already been updated to reflect the correct radio button selected). 
 - When doing temporal search and selecting 'mjd', the calendar icon was removed. I re-added it, allowing the user to use the calendar dialog here as well to pick a date/time. 

#### Testing
 -  https://fireflydev.ipac.caltech.edu/firefly-1075-obstap-date-update-calendar-dialog/firefly/
 - go to TAP -> service: CADC (or whichever one you prefer that has an ObsCore table or ObsTAP image search)-> Select Table -> Table Collection: IVOA -> Table: ivoa.ObsCore (or in 'Select Query Type' select 'Image Search (ObsTAP)') 
 - Timing -> Time of Observation -> Overlapping specified range 
 - Select both 'UTC date/times' and 'MJD values' and use the calendar dialog to pick different date/times for each, and monitor the live feedback of ISO/MJD values under the input box
 - Manually enter values  into the input box in each case as well 
 

#### Bug in Temporal Search (Not yet fixed, but might be important)   
- There seems to be an issue with timeOptions.value/timeMode not being updated correctly to reflect the user selected radio button (might be connected to the timeOptions.value not being updated correctly for ObsCore mentioned above as well). 
- go to CADC -> Single Table -> ivoa -> ivoa.ObsFile or ivoa.ObsPart (or IRSA, NED, etc.) -> Temporal
-  Enter some value in the 'Temporal Column' input field (**uri**, **ra**, etc.). The code won't throw "start time is greater than end time" errors until you enter something in this field. 
- Now, with the default "**ISO**" radio button selected, use the calendar dialog to pick start and end dates. This should work as expected. 
- Change the radio button to "**MJD**". This should convert the **ISO** values to **MJD** values. Use the calendar dialog to pick new dates with "**MJD**" selected. This should work as well. 
- Try and manually enter/change the **MJD** values in the start or end input fields. You will get an error that says "not a valid **ISO** value". To fix this, with the **MJD** radio button selected,  change the table to something else (say if you were on "ivoa.ObsFile", change it to "ivoa.ObsCore" and change it back to "ivoa.ObsFile"). Now if you try and edit the **MJD** values, if shouldn't throw an error (except the MJD out of range error, which works as expected). 
- If you change the radio button back to "**ISO**" now, and try and edit the values manually, you'll get an error saying "MJD Value is out range". 
- If you switch tables again, you'll be able to edit **ISO** values but will get the "not a valid ISO value" error again if you try and edit **MJD** values manually. 
- The issue here is that the timeMode value is not being updated when a user changes the radio button (this happens only in temporal search and not in exposure/ObsCore search). So when we try to validate, say, a **MJD** value but timeMode = '**ISO**' - we end up calling **validateDateTime** to validate a MJD value as opposed to calling **validateMJD** (and vice versa). 
- The timeMode value is updated when we switch tables but not when we simply change the selected radio button (the state is probably not getting updated). I think this is not a hard fix, but I noticed it after fixing the bug in ObsTAP/ObsCore search and couldn't get it working after spending some time on it. 
- I can create a ticket and re-visit this unless it needs to be fixed ASAP - in that case we can talk about this @robyww. 
- There are some other minor bugs that I noticed for which I can probably create a single ticket. 
 
