### PR TITLE
FIREFLY-1084: converting Download Options Dialog to a functional component

### DIFF
--- a/src/firefly/js/ui/PointShapeSizePicker.jsx
+++ b/src/firefly/js/ui/PointShapeSizePicker.jsx
@@ -80,14 +80,15 @@ export function ShapePicker({drawingDef, displayGroupId, plotId, update, getColo
 
     const storeUpdate = () => {   // color change externally
         const dl = getDrawLayersByDisplayGroup(getDlAry(), displayGroupId);
-        const dlColor = getColor(dl);
+        return getColor(dl);
+    };
 
+    const dlColor = useStoreConnector(() => storeUpdate());
+    useEffect(() => {
         if (dlColor !== drawingDef.color) {
             setDrawingDef({...drawingDef, color: dlColor});
         }
-    };
-
-    useStoreConnector(() => storeUpdate()); //replaced flux.addListener()
+    }, [dlColor]);
 
     let setDrawingDef = () => {};
     [drawingDef, setDrawingDef] = useState(() => drawingDef);


### PR DESCRIPTION
#### [Firefly-1084](https://jira.ipac.caltech.edu/browse/FIREFLY-1084): converting the DownloadOptionsDialog class to a functional component 
 - converted DownloadOptionsDialog to a functional component 
 - used useStoreConnector instead of flux.addListener directly 
 - made changes to PointShapeSizePicker.jsx's ShapePicker functional component to update state in useEffect instead of (incorrectly) in useStoreConnector itself 

#### Testing
 -  https://firefly-1084-downloadoptionsdialog-functional.irsakudev.ipac.caltech.edu/irsaviewer/
 - go to Catalogs -> NED -> m1 -> Radius: 100 
 - Click on the "Save" icon for the image and for the table (chart save does not use this Download Options Dialog box) 
 - For image, try switching between FITS Image, PNG File and Region File and change the file name
 - For table, try changing the file format and file name
 - Click on "Save" to make sure it downloads the image/table in the selected format 
 - Switch between **Local File** and **Workspace** (**Workspace** may not work in this build and will give an error, since I don't think you can actually login here - but it behaves as it would in ops/dev when you're not logged in)
 - Click on "Save" after switching to **Workspace**, then switch back to **Local File** and make sure the 'Workspace access error' feedback goes away 
 
