### PR TITLE
FIREFLY-1041: add feature to combine charts(spectra)

### DIFF
--- a/buildScript/webpack.config.js
+++ b/buildScript/webpack.config.js
@@ -35,7 +35,7 @@ export default function makeWebpackConfig(config) {
     const localBuild= BUILD_ENV === 'local';
 
     if (!process.env.NODE_ENV) {
-        process.env.NODE_ENV = localBuild ? 'development' : 'production';
+        process.env.NODE_ENV = ['local', 'dev'].includes(BUILD_ENV) ? 'development' : 'production';
     }
 
     console.log('ENV_DEV_MODE: ' + ENV_DEV_MODE);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN yarn install --ignore-platform --frozen-lockfile
 FROM node_module AS dev_env
 
 RUN apt-get update \
+    && apt-get install -y vim procps \
 # install tomcat9 for dev mode \
     && curl -O https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.65/bin/apache-tomcat-9.0.65.tar.gz \
     && mkdir /opt/tomcat && tar xzf apache-tomcat-9*tar.gz -C /opt/tomcat --strip-components=1 \

--- a/docker/devMode.sh
+++ b/docker/devMode.sh
@@ -4,5 +4,14 @@ cd /opt/work/${work_dir}
 gradle -Penv=${env} ${project}:bAD
 gradle -Penv=${env} ${project}:dev &
 
+# extract all war files into tomcat's webapps; mod log4j to have log sent to stdout as well
+cd ${CATALINA_HOME}/webapps
+for n in *.war; do \
+  war_dir=`basename $n .war`; \
+  mkdir -p $war_dir; \
+  unzip -oqd $war_dir $n; \
+  sed -E -i.bak 's/##out--//' $war_dir/WEB-INF/classes/log4j2.properties; \
+done
+
 cd ${CATALINA_HOME}
 /opt/tomcat/launchTomcat.sh

--- a/src/firefly/html/demo/table-api.html
+++ b/src/firefly/html/demo/table-api.html
@@ -217,7 +217,7 @@ There are additional information specific to each input field.  Click the top bu
 @prop {boolean} [showSave=true]
 @prop {boolean} [showOptionButton=true]
 @prop {boolean} [showFilterButton=true]
-@prop {boolean} [showInfoButton=false]
+@prop {boolean} [showInfoButton=true]
 @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.
 @prop {function[]}  [rightButtons]  an array of functions that returns a button-like component laid out on the right side of this table header.
                 </pre>

--- a/src/firefly/js/api/ApiHighlevelBuild.js
+++ b/src/firefly/js/api/ApiHighlevelBuild.js
@@ -156,7 +156,7 @@ function buildTablePart(llApi) {
      * @prop {boolean} showSave     defaults to true
      * @prop {boolean} showOptionButton    defaults to true
      * @prop {boolean} showFilterButton    defaults to true
-     * @prop {boolean} showInfoButton     defaults to false
+     * @prop {boolean} showInfoButton      defaults to true
      * @prop {boolean} border       defaults to true
      * @prop {boolean} help_id      link to help if applicable
      * @prop {function[]}  leftButtons   an array of functions that returns a button-like component laid out on the left side of this table header.  Function will be called with table's state.

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -122,24 +122,6 @@ export function getNumericCols(cols) {
 
 
 /**
- * @global
- * @public
- * @typedef {Object} XYPlotOptions - shallow object with XYPlot parameters
- * @prop {string}  [source]     location of the ipac table, url or file path; ignored when XY plot view is added to table
- * @prop {string}  [tbl_id]     table id of the table this plot is connected to
- * @prop {string}  [chartTitle] title of the chart
- * @prop {string}  xCol         column or expression to use for x values, can contain multiple column names ex. log(col) or (col1-col2)/col3
- * @prop {string}  yCol         column or expression to use for y values, can contain multiple column names ex. sin(col) or (col1-col2)/col3
- * @prop {string}  [plotStyle]  points, linepoints, line
- * @prop {string}  [xLabel]     label to use with x axis
- * @prop {string}  [yLabel]     label to use with y axis
- * @prop {string}  [xOptions]   comma separated list of x axis options: grid,flip,log
- * @prop {string}  [yOptions]   comma separated list of y axis options: grid,flip,log
- * @prop {string}  [xError]     column or expression for X error
- * @prop {string}  [yError]     column or expression for Y error
- */
-
-/**
  * @summary Convert shallow object with XYPlot parameters to scatter plot parameters object.
  * @param {XYPlotOptions} params - shallow object with XYPlot parameters
  * @returns {Object} - object, used to create Plotly chart
@@ -193,21 +175,6 @@ export function makeXYPlotParams(params) {
     return {data, layout};
 }
 
-
-/**
- * @global
- * @public
- * @typedef {Object} HistogramOptions
- * @summary shallow object with histogram parameters
- * @prop {string}  [source]     location of the ipac table, url or file path; ignored when histogram view is added to table
- * @prop {string}  [tbl_id]     table id of the table this plot is connected to
- * @prop {string}  [chartTitle] title of the chart
- * @prop {string}  col          column or expression to use for histogram, can contain multiple column names ex. log(col) or (col1-col2)/col3
- * @prop {number}  [numBins=50] number of bins for fixed bins algorithm (default)
- * @prop {number}  [falsePositiveRate] false positive rate for bayesian blocks algorithm
- * @prop {string}  [xOptions]   comma separated list of x axis options: flip,log
- * @prop {string}  [yOptions]   comma separated list of y axis options: flip,log
- */
 
 /**
  * @summary Convert shallow object with Histogram parameters to histogram plot parameters object.
@@ -475,6 +442,7 @@ export function handleBigInt(v) {
  * @param {object} p
  * @param {string} p.chartId
  * @param {object[]} p.data
+ * @param {object[]} p.fireflyData
  */
 export function handleTableSourceConnections({chartId, data, fireflyData}) {
     const tablesources = makeTableSources(chartId, data, fireflyData);
@@ -613,6 +581,11 @@ function updateChartData(chartId, traceNum, tablesource, action={}) {
 export function isSpectralOrder(chartId) {
     const {activeTrace=0, fireflyData} = getChartData(chartId) || {};
     return fireflyData?.[activeTrace]?.spectralOrder;
+}
+
+export function isSpectrum(chartId) {
+    const {activeTrace=0, fireflyData} = getChartData(chartId) || {};
+    return fireflyData?.[activeTrace]?.dataType === spectrumType;
 }
 
 
@@ -1161,4 +1134,11 @@ export function getChartProps(chartId, tbl_id, activeTrace) {
 
     return {activeTrace, data, fireflyData, layout, fireflyLayout, tablesources, tablesource, mappings, tbl_id, type, noXY,
         dataType, noColor, isYNotNumeric, isXNotNumeric, xNoLog, yNoLog, color, multiTrace, spectralAxis, fluxAxis};
+}
+
+
+export function getTblIdFromChart(chartId, traceNum) {
+    const {data, fireflyData, activeTrace} = getChartData(chartId) || {};
+    traceNum = traceNum ?? activeTrace;
+    return data?.[traceNum]?.tbl_id || fireflyData?.[traceNum].tbl_id;
 }

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -650,6 +650,7 @@ function reduceData(state={}, action={}) {
             }
             state = updateSet(state, chartId,
                 omitBy({
+                    chartId,
                     chartType,
                     mounted: nMounted,
                     ...rest

--- a/src/firefly/js/charts/chart-typedefs.jsdoc
+++ b/src/firefly/js/charts/chart-typedefs.jsdoc
@@ -1,0 +1,106 @@
+/**
+ * @global
+ */
+
+/**
+ * Top level store for chart related data.  It's mounted as 'charts' under the application state
+ * @typedef {object} ChartSpace
+ * @prop {Object.<string, ChartData>}   data    repository for chart model; keyed by chartId
+ * @prop {Object.<string, Object>}      ui      not used
+ *
+ * @global
+ * @public
+ */
+
+
+/**
+ * Chart model.  The top level chart data object including UI state.
+ * @typedef {object} ChartData
+ * @prop {string}   chartId
+ * @prop {string}   chartType       chart framework type.  default to plot.ly
+ * @prop {string}   groupId
+ * @prop {string}   viewerId
+ * @prop {number}   activeTrace
+ * @prop {boolean}  hasSelected
+ * @prop {boolean}  mounted
+ * @prop {number[]} curveNumberMap
+ * @prop {PlotlyData[]} data        plotly data object
+ * @prop {PlotlyLayout} layout      plotly layout info
+ * @prop {Object[]} fireflyData     firefly aux data.  mapped directly to plotly's data array
+ * @prop {TableSource[]} tablesources    chart to table relational data
+ * @prop {PlotlyData} highlighted   highlighted is implemented as a new trace on top of the original chart
+ * @prop {PlotlyData} selected      selected is implemented as a new trace on top of the original chart
+ * @prop {ChartData}  _original     original before any modification.  Used for reset.
+ *
+ * @global
+ * @public
+ */
+
+/**
+ * Chart to table related data
+ * @typedef {object} TableSource
+ * @prop {string}   tbl_id
+ * @prop {function} fetchData   function used to fetch the required data needed to complete plotly data
+ * @prop {object}   mappings    key/value pairs mapping table data to plotly data's attribute
+ * @prop {string}   resultSetID table's resultSetID.
+ * @prop {object}   options
+ * @prop {function} _cancel     used to unwatch table data change events
+ *
+ *
+ * @global
+ * @public
+ */
+
+/**
+ * Plotly data object representing a single trace.
+ * See https://plotly.com/javascript/reference/index/ for attributes details
+ * @typedef {object} PlotlyData
+ *
+ * @global
+ * @public
+ */
+
+/**
+ * Plotly layout info for the entire chart.
+ * See https://plotly.com/javascript/reference/index/ for attributes details
+ * @typedef {object} PlotlyLayout
+ *
+ * @global
+ * @public
+ */
+
+
+/**
+ * @typedef {Object} XYPlotOptions - shallow object with XYPlot parameters
+ * @prop {string}  [source]     location of the ipac table, url or file path; ignored when XY plot view is added to table
+ * @prop {string}  [tbl_id]     table id of the table this plot is connected to
+ * @prop {string}  [chartTitle] title of the chart
+ * @prop {string}  xCol         column or expression to use for x values, can contain multiple column names ex. log(col) or (col1-col2)/col3
+ * @prop {string}  yCol         column or expression to use for y values, can contain multiple column names ex. sin(col) or (col1-col2)/col3
+ * @prop {string}  [plotStyle]  points, linepoints, line
+ * @prop {string}  [xLabel]     label to use with x axis
+ * @prop {string}  [yLabel]     label to use with y axis
+ * @prop {string}  [xOptions]   comma separated list of x axis options: grid,flip,log
+ * @prop {string}  [yOptions]   comma separated list of y axis options: grid,flip,log
+ * @prop {string}  [xError]     column or expression for X error
+ * @prop {string}  [yError]     column or expression for Y error
+ *
+ * @global
+ * @public
+ */
+
+/**
+ * @typedef {Object} HistogramOptions
+ * @summary shallow object with histogram parameters
+ * @prop {string}  [source]     location of the ipac table, url or file path; ignored when histogram view is added to table
+ * @prop {string}  [tbl_id]     table id of the table this plot is connected to
+ * @prop {string}  [chartTitle] title of the chart
+ * @prop {string}  col          column or expression to use for histogram, can contain multiple column names ex. log(col) or (col1-col2)/col3
+ * @prop {number}  [numBins=50] number of bins for fixed bins algorithm (default)
+ * @prop {number}  [falsePositiveRate] false positive rate for bayesian blocks algorithm
+ * @prop {string}  [xOptions]   comma separated list of x axis options: flip,log
+ * @prop {string}  [yOptions]   comma separated list of y axis options: flip,log
+ *
+ * @global
+ * @public
+ */

--- a/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
+++ b/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
@@ -4,7 +4,16 @@
 import {get} from 'lodash';
 import {sprintf} from '../../externalSource/sprintf.js';
 
-
+/**
+ * Return true if 'from' unit can be converted to 'to'.
+ * @param p
+ * @param p.from
+ * @param p.to
+ * @returns {boolean}
+ */
+export function canUnitConv({from, to}) {
+    return !! get(UnitXref, [from, to]);
+}
 
 /**
  * Return the SQL-like expression for unit conversion use cases.

--- a/src/firefly/js/charts/ui/ChartPanel.css
+++ b/src/firefly/js/charts/ui/ChartPanel.css
@@ -220,6 +220,31 @@
     background-image: url("~images/icons-2014/24x24_Save.png");
 }
 
+.CombineChart__popup {
+    min-width: 450px;
+    min-height: 250px;
+    display: flex;
+    flex-direction: column;
+    padding: 4px;
+    resize: both;
+    overflow: hidden;
+}
+
+.CombineChart__popup > * {
+    margin-bottom: 5px;
+}
+
+.CombineChart__popup--tbl {
+    flex-grow: 1;
+    min-height: 100px;
+}
+
+.CombineChart__hints {
+    font-size: x-small;
+    font-style: italic;
+    color: grey;
+}
+
 
 /* hide the popup doubleclick tooltips since we turned it off */
 div.plotly-notifier {

--- a/src/firefly/js/charts/ui/ChartSelectPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartSelectPanel.jsx
@@ -1,7 +1,6 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {get} from 'lodash';
-import shallowequal from 'shallowequal';
 
 import {FormPanel} from './../../ui/FormPanel.jsx';
 import {getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
@@ -10,7 +9,7 @@ import {SimpleComponent, useStoreConnector} from './../../ui/SimpleComponent.jsx
 import {getChartData, dispatchChartTraceRemove, dispatchChartUpdate} from '../ChartsCntlr.js';
 import {NewTracePanel, getNewTraceType, getSubmitChangesFunc, addNewTrace} from './options/NewTracePanel.jsx';
 import {PopupPanel} from './../../ui/PopupPanel.jsx';
-import {isSpectralOrder, isScatter2d} from '../ChartUtil.js';
+import {isSpectralOrder, isScatter2d, getTblIdFromChart} from '../ChartUtil.js';
 import {basicOptions, BasicOptions} from './options/BasicOptions.jsx';
 import {ScatterOptions} from './options/ScatterOptions.jsx';
 import {HeatmapOptions} from './options/HeatmapOptions.jsx';
@@ -63,8 +62,11 @@ function getChartActions({chartId, tbl_id}) {
 }
 
 
-function onChartAction({chartAction, tbl_id, chartId, hideDialog, renderTreeId}) {
+function onChartAction({chartAction, chartId, hideDialog, renderTreeId}) {
     return (fields) => {
+        const {activeTrace, data, fireflyData} = getChartData(chartId);
+        const tbl_id = getTblIdFromChart(chartId, activeTrace);
+
         switch (chartAction) {
             case CHART_ADDNEW:
                 addNewTrace({fields, tbl_id, hideDialog, renderTreeId}); // no chart id
@@ -73,7 +75,6 @@ function onChartAction({chartAction, tbl_id, chartId, hideDialog, renderTreeId})
                 addNewTrace({fields, tbl_id, chartId, hideDialog});
                 break;
              case CHART_TRACE_MODIFY:
-                const {activeTrace, data, fireflyData} = getChartData(chartId);
                 const type = get(data, `${activeTrace}.type`, 'scatter');
                 let ftype = get(fireflyData, `${activeTrace}.dataType`);
                 const scatterOrHeatmap = get(fireflyData, [activeTrace, 'scatterOrHeatmap']);
@@ -84,8 +85,7 @@ function onChartAction({chartAction, tbl_id, chartId, hideDialog, renderTreeId})
                 break;
             case CHART_TRACE_REMOVE:
                 hideDialog();
-                const {activeTrace:traceNum} = getChartData(chartId);
-                dispatchChartTraceRemove(chartId, traceNum);
+                dispatchChartTraceRemove(chartId, activeTrace);
                 break;
             default:
                 console.log(`onChartAction - unsupported action ${chartAction}`);

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -1,0 +1,328 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {useEffect, useState} from 'react';
+import {cloneDeep, pick, set} from 'lodash';
+
+import {getMultiViewRoot, getViewerItemIds} from '../../visualize/MultiViewCntlr.js';
+import {dispatchChartAdd, getChartData} from '../ChartsCntlr.js';
+import {getTblIdFromChart, uniqueChartId} from '../ChartUtil.js';
+import {TextButton} from '../../ui/TextButton.jsx';
+import {PINNED_VIEWER_ID, PINNED_GROUP, PINNED_CHART_PREFIX} from './ChartWorkArea.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {FieldGroup} from '../../ui/FieldGroup.jsx';
+import {basicOptions} from './options/BasicOptions.jsx';
+import {getColumnValues, getSelectedDataSync, getTblById} from '../../tables/TableUtil.js';
+import {TablePanel} from '../../tables/ui/TablePanel.jsx';
+import {getGroupFields} from '../../fieldGroup/FieldGroupUtils.js';
+import {getActiveViewerItemId} from './MultiChartViewer.jsx';
+import {CollapsiblePanel} from '../../ui/panel/CollapsiblePanel.jsx';
+import {dispatchTableAddLocal} from '../../tables/TablesCntlr.js';
+import {HelpIcon} from '../../ui/HelpIcon.jsx';
+import {showInfoPopup, showOptionsPopup} from '../../ui/PopupUtil.jsx';
+import {getSpectrumDM} from '../../util/VOAnalyzer.js';
+import {applyUnitConversion} from './options/SpectrumOptions.jsx';
+import {canUnitConv} from '../dataTypes/SpectrumUnitConversion.js';
+
+
+/**
+ * This component is hard-wired to work with only PINNED_VIEWER_ID.  Will need to change if this ever changes.
+ * @returns {JSX.Element|null}
+ */
+export const CombineChart = () => {
+    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID);
+    const showCombine = chartIds?.length > 1;
+
+    const doCombine = async () => {
+        const {chartIds, props} = await getCombineChartParams();
+
+        const chartData = combineChart(chartIds, props);
+        dispatchChartAdd({
+            ...chartData,
+            chartId: uniqueChartId(PINNED_CHART_PREFIX),
+            groupId: PINNED_GROUP,
+            viewerId: PINNED_VIEWER_ID,
+            deletable: true,
+            mounted: true
+        });
+    };
+    return showCombine ? <TextButton onClick={doCombine} title='Combine chart'>Combine Chart</TextButton> : null;
+};
+
+function getChartTitle(cdata, defTitle) {
+    return cdata.layout?.title?.text || defTitle;
+}
+
+function addTracesTitle(chartId, current=[]) {
+    const {data=[], layout} = getChartData(chartId);
+    data.forEach((d, idx) => {
+        let title = d?.name;
+        if (!title && idx === 0) title = layout?.title?.text;
+        if (!title) title = `Trace ${current.length}`;
+        current.push(title);
+    });
+    return current;
+}
+
+/* returns the selected chartId as well as a table of matching charts to combine */
+function createTableModel(showAll, tbl_id) {
+
+    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID);
+    const selChartId = getSelChartId();
+
+    const columns = [
+        {name: 'Title'},
+        {name: 'Type'},
+        {name: 'From Table'},
+        {name: 'ChartId', visibility: 'hide'},
+    ];
+    const data = chartIds
+        ?.filter((id) => id !== selChartId)      // exclude already selected chart
+        ?.filter((id) => showAll || canCombine(id))     // filter out the charts that cannot be combined with the active chart
+        ?.map((id) => getChartData(id))
+        ?.map((cdata, idx) => {
+            const title = getChartTitle(cdata, `chart-${idx}`);
+            const type = cdata.data?.[0].type;
+            const table = getTblById(cdata.tablesources?.[0].tbl_id)?.title;
+            return [title, type, table, cdata.chartId];});
+
+    const table =  {title: 'Charts to combine', tableData:{columns, data}, totalRows: data.length};
+    table.tbl_id = tbl_id;
+    set(table, 'request.tbl_id', table.tbl_id);
+    return table;
+}
+
+const CombineChartDialog = ({onComplete}) => {
+
+    const [showAll, setShowAll] = useState(false);
+
+    const tbl_id = 'combinechart-tbl-id';
+    const groupKey = 'combinechart-props';
+
+    useEffect(() => {
+        const selTbl = createTableModel(showAll, tbl_id);
+        dispatchTableAddLocal(selTbl, undefined, false);
+    }, [showAll]);
+
+    const doApply = () => {
+        const selChartIds = getColumnValues(getSelectedDataSync(tbl_id), 'ChartId');
+        const fields = getGroupFields(groupKey);
+        const props = Object.fromEntries(
+            Object.entries(fields).map(([k,v]) => [k, v.value])
+        );
+        if (selChartIds?.length < 1) {
+            showInfoPopup('You must select at least one chart to combine with');
+        } else {
+            onComplete({chartIds:[getSelChartId(), ...selChartIds], props});
+            closePopup();
+        }
+    };
+    const closePopup = () => showOptionsPopup({show:false});
+
+    const {Title} = basicOptions({groupKey, fieldProps:{labelWidth: 50, size: 40}});
+    const showAllHint = 'Show all charts even ones that may not combine well';
+
+    return (
+        <div className='CombineChart__popup'>
+            <div style={{display: 'inline-flex', alignItems: 'center'}}>
+                <label htmlFor='showAll'>Show All Charts: </label>
+                <input type='checkbox' id='showAll' title={showAllHint} value={showAll} onClick={(e) => setShowAll(e.target?.checked)}/>
+                <span className='CombineChart__hints'>({showAllHint})</span>
+            </div>
+            <div className='CombineChart__popup--tbl'>
+                <TablePanel {...{tbl_id, showToolbar:false, showUnits:false, showTypes:false}}/>
+            </div>
+            <FieldGroup keepState={false} groupKey={groupKey}>
+                <Title initialState={{value: 'combined'}}/>
+                <SelChartProps {...{tbl_id, groupKey}}/>
+            </FieldGroup>
+            <div>
+                <button type='button' className='button std' style={{marginRight: 5}} onClick={doApply}>Apply</button>
+                <button type='button' className='button std' onClick={closePopup}>Close </button>
+                <HelpIcon helpId={'chartarea.combineCharts'} style={{float: 'right', marginTop: 4}}/>
+            </div>
+        </div>
+    );
+};
+
+const SelChartOpt = ({groupKey, ctitle, traces, idx, totalTraces}) => {
+    const key = `cOpt-${idx}`;
+
+    const ctraceIdx = totalTraces - traces.length;
+
+    const TraceOpt = ({traceNum, title}) => {
+        const {Name, Color} = basicOptions({activeTrace: traceNum, groupKey, fieldProps:{labelWidth: 32, size: 40}});
+        return (
+            <div className='FieldGroup__vertical'>
+                <Name initialState={{value: title}}/>
+                <Color/>
+            </div>
+        ) ;
+    };
+    
+    return (
+        <CollapsiblePanel componentKey={key} header={ctitle} initialState= {{ value:'closed' }}>
+            {traces.map((title, idx) => <TraceOpt {...{key:idx, traceNum: ctraceIdx+idx, title}}/>)}
+        </CollapsiblePanel>
+    );
+
+};
+
+const SelChartProps = ({tbl_id, groupKey}) => {
+
+    useStoreConnector(() => getTblById(tbl_id)?.selectInfo);     // rerender when selectInfo changes
+    const selChartId = getSelChartId();
+    const selectedData = getSelectedDataSync(tbl_id);       // this always return new objects.  that's why it's not used for useStoreConnector
+
+    const getSelCharInfo = (id) => {
+        const cTitle = getChartTitle(getChartData(id));
+        const traces = addTracesTitle(id);
+
+        return [selChartId, cTitle, traces];
+    };
+
+    const charts = [getSelCharInfo(selChartId)];
+
+    selectedData.tableData.data.map( (tr) => tr[3])         // get all selected chartId
+        .forEach((id) => charts.push(getSelCharInfo(id)));
+
+    let totalTraces=0;
+    return (
+        <React.Fragment>
+            {
+                charts.map(([chartId, ctitle, traces], idx) => {
+                    totalTraces += traces.length;
+                    return <SelChartOpt key={idx} {...{groupKey, ctitle, traces, idx, totalTraces}}/>;
+                })
+            }
+        </React.Fragment>
+    );
+};
+
+function getCombineChartParams() {
+    return new Promise((resolve) => {
+        const onComplete = (props) => resolve(props);
+        const content = <CombineChartDialog {...{onComplete}}/>;
+        showOptionsPopup({content, title: 'Combine Charts', modal: true, show: true});
+    });
+}
+
+
+function combineChart(chartIds, props={}) {
+
+    if (chartIds?.length <= 1) return;
+
+    const baseChartId = chartIds[0];
+    const baseChartData = cloneDeep(pick(getChartData(baseChartId), ['chartType', 'activeTrace', 'data', 'fireflyData', 'layout', 'tablesources', 'viewerId']));
+    const baseXUnit = baseChartData.fireflyData?.[baseChartData?.activeTrace]?.xUnit;
+    const baseYUnit = baseChartData.fireflyData?.[baseChartData?.activeTrace]?.yUnit;
+
+    baseChartData?.tablesources?.forEach((ts) => Reflect.deleteProperty(ts, '_cancel'));
+
+    for (let i = 1; i < chartIds.length; i++) {
+        const chartId = chartIds[i];
+        const pxIdx = i+1;      // plotly axis index starts from 1
+
+        const chartData = cloneDeep(getChartData(chartId));
+        chartData.activeTrace=0;        // hard-code to only use the first trace from each chart
+        const {data, fireflyData, tablesources, layout, activeTrace} = chartData;
+
+        tablesources?.forEach((ts) => Reflect.deleteProperty(ts, '_cancel'));
+
+        // apply unit conversion to xAxis if needed.
+        const xUnit = doUnitConversion({chartId, chartData, axisType:'x', to:baseXUnit});
+        if (baseXUnit !== xUnit) {
+            // create new x-axis
+            set(data, [activeTrace, 'xaxis'], 'x' + pxIdx);
+            set(baseChartData, ['layout', `xaxis${pxIdx}`], {
+                title: layout?.xaxis?.title || `xaxis${pxIdx}`,
+                // overlaying: 'x',
+                side: i % 2 === 1 ? 'top' : 'bottom'
+            });
+        }
+
+        // apply unit conversion to xAxis if needed.
+        const yUnit = doUnitConversion({chartId, chartData, axisType:'y', to:baseYUnit});
+
+        if (baseYUnit !== yUnit) {
+            // create new y-axis
+            set(data, [activeTrace, 'yaxis'], 'y'+pxIdx);
+            set(data, [activeTrace, 'name'], 'y'+pxIdx + ' data');
+            set(baseChartData, ['layout', `yaxis${pxIdx}`], {
+                title: layout?.yaxis?.title || `yaxis${pxIdx}`,
+                overlaying: 'y',
+                side: i%2 === 1 ? 'right' : 'left'
+            });
+        }
+
+        // failed when only one of the two are mapped(??).  apply map to both(workaround)
+        const xmapped = (data?.[activeTrace]?.x || '').startsWith?.('tables:');
+        const ymapped = (data?.[activeTrace]?.y || '').startsWith?.('tables:');
+        if (xmapped ^ ymapped) {
+            if (!ymapped) set(data, `${activeTrace}.y`, `tables::${tablesources?.[activeTrace]?.mappings?.y}`);
+            if (!xmapped) set(data, `${activeTrace}.x`, `tables::${tablesources?.[activeTrace]?.mappings?.x}`);
+        }
+
+        // merge selected chart data into new chart
+        data         && baseChartData.data.push(...data);
+        fireflyData  && baseChartData.fireflyData.push(...fireflyData);
+        tablesources && baseChartData.tablesources.push(...tablesources);
+
+    }
+
+    // override new baseChartData using lodash.set fashion
+    Object.entries(props).forEach(([key, val]) => {
+        set(baseChartData, key, val);
+    });
+
+    return baseChartData;
+}
+
+/* return unit for the give axisType */
+function doUnitConversion({chartId, chartData, axisType, to}) {
+    const {activeTrace, fireflyData, data} = chartData;
+
+    // apply unit conversion to axis if needed.
+    let unit = fireflyData?.[activeTrace]?.[`${axisType}Unit`];
+    if (to !== unit) {
+        if (canUnitConv({from: unit, to})) {
+            const tbl_id = getTblIdFromChart(chartId, activeTrace);
+            const axis = getSpectrumDM(getTblById(tbl_id))?.[axisType === 'x' ? 'spectralAxis' : 'fluxAxis'];
+            const changes = applyUnitConversion({
+                fireflyData,
+                data,
+                inFields: {},
+                axisType,
+                newUnit: to,
+                traceNum: activeTrace,
+                axis
+            });
+            Object.entries(changes).forEach(([key, val]) => {
+                set(chartData, key, val);
+            });
+            unit = to;
+            set(fireflyData, [activeTrace, `${axisType}Unit`], unit);
+        }
+    }
+    return unit;
+}
+
+
+/* return unit for the give axisType */
+function canCombine(chartId) {
+
+    const activeTrace = 0;          // hard-code to only use the first trace from each chart
+    const selChartId = getSelChartId();
+    const {xUnit, yUnit} = getChartData(selChartId)?.fireflyData?.[activeTrace];
+
+    const chartData = cloneDeep(getChartData(chartId));
+
+    const newXUnit = doUnitConversion({chartId, chartData, axisType:'x', to:xUnit});
+    const newYUnit = doUnitConversion({chartId, chartData, axisType:'y', to:yUnit});
+    return xUnit === newXUnit && yUnit === newYUnit;
+}
+
+function getSelChartId(viewerId=PINNED_VIEWER_ID) {
+    return  getActiveViewerItemId(viewerId, true);
+}

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -13,15 +13,17 @@ import {CloseButton} from '../../ui/CloseButton.jsx';
 import {ChartPanel} from './ChartPanel.jsx';
 import {MultiItemViewerView} from '../../visualize/ui/MultiItemViewerView.jsx';
 import {dispatchAddViewer, dispatchViewerUnmounted, dispatchUpdateCustom,
-        getMultiViewRoot, getViewer, getLayoutType,PLOT2D} from '../../visualize/MultiViewCntlr.js';
+        getMultiViewRoot, getViewer, getLayoutType, PLOT2D} from '../../visualize/MultiViewCntlr.js';
 import {getExpandedChartProps, getChartData} from '../ChartsCntlr.js';
 import {LO_VIEW, LO_MODE, dispatchSetLayoutMode} from '../../core/LayoutCntlr.js';
 
 import {MultiChartToolbarStandard, MultiChartToolbarExpanded} from './MultiChartToolbar.jsx';
 import {RenderTreeIdCtx} from '../../ui/RenderTreeIdCtx.jsx';
 
-export function getActiveViewerItemId(viewerId) {
-    return getViewer(getMultiViewRoot(), viewerId)?.customData?.activeItemId;
+export function getActiveViewerItemId(viewerId, useDefault) {
+    const viewer= getViewer(getMultiViewRoot(),viewerId);
+    const activeItemId = viewer?.customData?.activeItemId;
+    return activeItemId || (useDefault ? viewer?.itemIdAry?.[0] : undefined);
 }
 
 

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -29,6 +29,7 @@ const local = {
     getTblById,
     getTblInfoById,
     getColumn,
+    getColumns,
     getCellValue,
     getSelectedData
 };

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -271,7 +271,7 @@
  * @prop {boolean} [showPaging=true]    enable/disable paging feature.  When false, all data will be displayed.
  * @prop {boolean} [showSave=true]
  * @prop {boolean} [showFilterButton=true]
- * @prop {boolean} [showInfoButton=false] when true, shows additional information about table, if available
+ * @prop {boolean} [showInfoButton=true] when true, shows additional information about table, if available
  * @prop {boolean} [showOptionButton=true]
  * @prop {boolean} [showUnits]
  * @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -42,7 +42,7 @@ const TT_EXPAND = 'Expand this panel to take up a larger area';
 export function TablePanel(props) {
     let {tbl_id, tbl_ui_id, tableModel, ...options} = props;
     tbl_id = tbl_id || tableModel?.tbl_id || uniqueTblId();
-    tbl_ui_id = tbl_ui_id || uniqueTblUiId();
+    tbl_ui_id = tbl_ui_id || `${tbl_id}-ui`;
 
     const uiState = useStoreConnector(() => getTableUiById(tbl_ui_id) || {columns:[]}, [tbl_ui_id]);
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1041

Add the ability to combine multiple charts.  Limited to spectra with same axis unit.
Sample data added to the ticket.

To test: https://fireflydev.ipac.caltech.edu/firefly-1041-combine-spectrum/firefly/
Upload 2 or more spectra, then pin them.
Select a spectrum to combine, then click on `Combine Chart`.
A list of 'suitable' charts will appear.  Select 1 or more to continue.
If none show up, then there are no suitable charts to combine with the one you selected.  To test the ability to combine any chart(experimental), check the box `Show All Charts`.


Also added these small changes:
- create source map for both local and dev env
- Docker DevMode get verbose log
- update Table API doc to reflect showInfoButton now default to true
- move and define additional chart jsdoc into chart-typedefs.jsdoc