### PR TITLE
FIREFLY-1085: removing reducer from fitsDownloadDialog

### DIFF
--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -10,8 +10,8 @@ import {getWorkspaceList, getWorkspaceErrorMsg,
         dispatchWorkspaceUpdate, isAccessWorkspace} from '../visualize/WorkspaceCntlr.js';
 import {WorkspaceSave} from './WorkspaceViewer.jsx';
 import {useFieldGroupValue, useStoreConnector} from 'firefly/ui/SimpleComponent';
-
 import LOADING from 'html/images/gxt/loading.gif';
+
 export const LOCALFILE = 'isLocal';
 export const WORKSPACE = 'isWs';
 
@@ -57,7 +57,8 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
                              overflow: 'auto',
                              padding: 5,
                              border:'1px solid #a3aeb9'}}>
-                    <WorkspaceSave fieldKey={'wsSelect'} files={wsList} value={wsSelect}/>
+                    <WorkspaceSave fieldKey={'wsSelect'} files={wsList} value={wsSelect}
+                        tooltip='workspace file system'/>
                 </div>
         );
 
@@ -81,6 +82,9 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
                     options={[{label: 'Local File', value: LOCALFILE},
                               {label: 'Workspace', value: WORKSPACE }] }
                     fieldKey={'fileLocation'}
+                    label='File location:'
+                    labelWidth={100}
+                    tooltip='select the location where the file is downloaded to'
                 />
             </div>
     );
@@ -94,6 +98,12 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
                 wrapperStyle={{marginTop: 10}}
                 size={50}
                 fieldKey={'fileName'}
+                initialState= {{
+                    value: fileName
+                }}
+                label='File name:'
+                labelWidth={100}
+                tooltip='Please enter a filename, a default name will be used if it is blank'
             />
 
             {workspace && showLocation}

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -115,20 +115,13 @@ const MakeFileOptions = ({plot,colors,hasOperation,threeC}) => {
         </div>);
 };
 
-function getInitState()  {
+const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
     const pv= getActivePlotView(visRoot());
     const plot = primePlot(pv);
-    const colors= getColors(plot);
-    return {
-        plot, pv, colors,
-        threeC: isThreeColor(plot),
-        hasOperation: plot.plotState.hasOperation(Operation.CROP)
-    };
-}
-
-const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
-    const [{pv, plot, hasOperation, threeC, colors}] = useState(getInitState);
-    const [getBand]= useFieldGroupValue ('threeBandColor', groupKey);
+    const colors = getColors(plot);
+    const threeC = isThreeColor(plot);
+    const hasOperation = plot?.plotState.hasOperation(Operation.CROP) ?? false;
+    const [getBand] = useFieldGroupValue ('threeBandColor', groupKey);
     const band= threeC ? getBand() : Band.NO_BAND.key;
 
     const totalChildren = (isWs ? 3 : 2) + (hasOperation ? 1 : 0) + (threeC ? 1 : 0);// fileType + save as + (fileLocation)
@@ -142,6 +135,7 @@ const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
         const fileType = getFileType();
         const fileName = getFileName();
         const fileLocation = getLocation();
+        const band = getBand();
         let fName = '';
 
         // change the filename if a file is selected from the file picker
@@ -151,16 +145,16 @@ const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
         else { //FileLocation = isLocal: check for fileType change or fileName change. If fileType changes, replace file extension
             if (fileName) { //checking if filename is !empty string allows user to delete the input string (default fileName)
                 if (!isThreeColor(plot)) {
-                    fName = replaceExt(fileName, fileType);//replaceExt(fields.fileName.value, fType);
+                    fName = replaceExt(fileName, fileType);
                 } else {
                     fName = matchPossibleDefaultNames(plot, fileName) ?
-                        makeFileName(plot, fileName, fileType) :
+                        makeFileName(plot, band, fileType) :
                         replaceExt(fileName, fileType);
                 }
             }
         }
         setFileName(fName);
-    }, [getFileType, getFileName, getLocation]);
+    }, [getFileType, getFileName, getLocation, getBand]);
 
     return (
         <FieldGroup style={{height: 'calc(100% - 10px)', width: '100%'}} groupKey={groupKey}>


### PR DESCRIPTION
#### [Firefly-1085](https://jira.ipac.caltech.edu/browse/FIREFLY-1085): removing reducer from FitsDownloadDialog
 - Took a bit longer than I expected, but got rid of a lot of code and encountered a couple of bugs and partially fixed them (see below) 
 - Got rid of the reducer and and used useFieldGroupValue to get the file type, name and location and then monitor changes in any of those via a useEffect (which basically sets a new filename when the user changes the file name or extension/file type or picks a new filename from the workspace) 
 - made MakeFileOptions a react component

#### Testing
 -  https://firefly-1085-fitsdownloaddialog-remove-reducer.irsakudev.ipac.caltech.edu/irsaviewer/
 - go to TAP -> service: IRSA/NED -> Coordinates or Object Name: m1 -> Radius: 100 
 - open the fits download dialog by clicking on the **save** icon
 - ensure this works as expected. try changing file type, file name, and file location (the only thing I wasn't able to test was workspace - I am having trouble logging in on dev/ops so I haven't been able to mimic being logged in on the test build yet to test saving files to the workspace - if you can test this, please make sure it works - I'll try and test this myself too) 
 - go to Images ->  Create 3-Color Composite -> Select any image for at least one of red/green/blue and search
 - Now open the fits download dialog box again, you should see "**Color Band**" this time 
 - toggle between file types (if you select png or reg, the color band goes away - is this expected behavior? this is also related to the bug fix below) 

#### Bug Fixes
1. In irsadev or ops, open a fits download dialog box after searching for a 3-color composite image. You will not be able to switch any of the radio buttons or edit the file name (you'll get uncaught TypeError in your console)
- I was able to re-create this locally, and fixed it in the **makeFileName** function by checking that **req** exists before we try to access its properties (line 286) 
- In the test build, when you open a fits download dialog box from a 3-color composite image search, you should now be able to toggle the radio buttons and edit the file name (you'll not be able to backspace from the end, but you can select the entire string and delete and enter a new file name - this is related to the 2nd bug below) 
2. This is a partial fix: In irsadev or ops, open a fits download dialog box on a "View FITs Image" (not 3-color composite). 
- If you try to edit the file name here, you won't be able to backspace from the end but can select and edit the file name directly (before the extension). 
- But if you select the entire string and delete it, you'll still be left with the extension ("**.fits**" or "**.png**" or "**.reg**"). If you click "**Save**" a file named "fits.txt" will be saved if you had file type fits selected. This does not seem right. In the test build, I made it so that you can select and delete the entire string. If you try to save now (with the file name field completely empty), a file with a default name and the correct extension will be downloaded. e.g.: image_SEIP-MIPS24.fits 
- And if you start typing a new string, the appropriate extension is added at the end of the string. 
-  on the test build, open a fits download dialog box from a 3-color composite image search. Here, with "fits" selected as the file type, if you try to select and delete the existing file name, you'll be left with a ".fits" and if you click save, it'll be saved as "fits.txt". Essentially, this is similar to the existing bug on dev/ops for a regular FITS image search (or any non 3-color search). The fix for this wasn't as straightforward but I can spend some more time looking at it and fixing it, but I just wanted to check the behavior of the download dialog for a 3-color composite image search. Should the user still be able to switch to **png** and **reg** here? And when they switch to **png** or **reg**, should the "**Color Band**" field still be visible? I think yes for both - and in that case I can fix this and push again. But since on dev/ops you can't switch radio buttons at all (due to the TypeError), I wanted to check what the behavior should look like. 
  
