### PR TITLE
firefly-1103: Fix firefly fITS reader so it can read Multiple large HDUs for a 14G file

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -26,7 +26,7 @@ sso.user.profile.url = "https://irsa.ipac.caltech.edu/account/uman/uman.html//id
 __$help.base.url = "onlinehelp/"
 
 
-visualize.fits.MaxSizeInBytes= 10737418240
+visualize.fits.MaxSizeInBytes= 21474836480
 visualize.fits.search.path = "/irsadata"
 visualize.fits.Security= true
 

--- a/docs/server-settings-for-fits-files.md
+++ b/docs/server-settings-for-fits-files.md
@@ -19,7 +19,7 @@ visualize.fits.Security= true
 By default Firefly will only read FITS files that are a maximum of 1.5 gigabytes. This can be changed with the `visualize.fits.MaxSizeInBytes` property.
 
 ```
-visualize.fits.MaxSizeInBytes= 10737418240     // 10 gigs, if not there it defaults to 1.5 gigs
+visualize.fits.MaxSizeInBytes= 21474836480     // 20 gigs
 ```
 
 You will need to make sure that tomcat is started with enough memory to support reading large FITS files. Here are guide lines for selecting your server memory size.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisContext.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class VisContext {
 
     public static final String PLOT_ABORTED= "Plot aborted by client";
-    public static final long FITS_MAX_SIZE = AppProperties.getLongProperty("visualize.fits.MaxSizeInBytes", FileUtil.GIG*10);
+    public static final long FITS_MAX_SIZE = AppProperties.getLongProperty("visualize.fits.MaxSizeInBytes", FileUtil.GIG*20);
     private static boolean _initialized= false;
     private static final Map<String,String> footprintMap= new HashMap<>();
 

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -9,6 +9,7 @@ import edu.caltech.ipac.table.io.DsvTableIO;
 import edu.caltech.ipac.table.io.FITSTableReader;
 import edu.caltech.ipac.table.io.IpacTableReader;
 import edu.caltech.ipac.table.io.VoTableReader;
+import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import org.apache.commons.csv.CSVFormat;
 
@@ -89,7 +90,11 @@ public class TableUtil {
             return Format.TAR;
         }
 
-        BufferedReader reader = new BufferedReader(new FileReader(inf), IpacTableUtil.FILE_IO_BUFFER_SIZE);
+        BufferedReader subsetReader = new BufferedReader(new FileReader(inf), IpacTableUtil.FILE_IO_BUFFER_SIZE);
+        char[] charAry= new char[(int)FileUtil.K];
+        int len= subsetReader.read(charAry,0,(int)FileUtil.K); //limit the amount for the guess to 1 K
+        var testStr= len>-1 ? new String(charAry,0,len) : "";
+        BufferedReader reader= new BufferedReader(new StringReader(testStr));
         try {
             String line = reader.readLine();
             if (line.startsWith("{")) {
@@ -159,7 +164,8 @@ public class TableUtil {
         } catch (Exception e){
             return Format.UNKNOWN;
         } finally {
-            try {reader.close();} catch (Exception e) {e.printStackTrace();}
+            FileUtil.silentClose(subsetReader);
+            FileUtil.silentClose(reader);
         }
 
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -98,7 +98,7 @@ public class FitsRead implements Serializable, HasSizeOf {
         this.planeNumber = cube ? planeNumber : 0;
         this.cube = cube;
         this.hduNumber = header.getIntValue(SPOT_EXT, 0);
-        long HDUOffset= header.getIntValue(SPOT_OFF, 0);
+        long HDUOffset= header.getLongValue(SPOT_OFF, 0);
         this.bunit= hdu.getBUnit()!=null ? hdu.getBUnit() : "DN";
 
         ImageHeader imageHeader = new ImageHeader(header, HDUOffset, planeNumber);


### PR DESCRIPTION
#### [Firefly-1103](https://jira.ipac.caltech.edu/browse/FIREFLY-1103) Allows firefly fits ready to read even bigger files

- fix the `TableUtil.guessFormat()` so it only looks ahead 1k
- work with longs for the file offset header `SPOT_OFF`
- change property to increate the max fits file size

This is a small PR. You can really test it unless you start you server at about 20G and have a 14G fits file. So, just look at the code.
