### PR TITLE
Firefly-1092 no WCS warning when trying to align by WCS

### DIFF
--- a/src/firefly/js/visualize/ui/MatchLockDropDown.jsx
+++ b/src/firefly/js/visualize/ui/MatchLockDropDown.jsx
@@ -6,14 +6,32 @@ import {PlotAttribute} from '../PlotAttribute';
 import {SingleColumnMenu} from '../../ui/DropDownMenu.jsx';
 import {DropDownVerticalSeparator, ToolbarButton} from '../../ui/ToolbarButton.jsx';
 import {DropDownToolbarButton} from '../../ui/DropDownToolbarButton.jsx';
-
 import MATCH_LOCKED from 'html/images/28x28_Match_Locked.png';
 import MATCH_UNLOCKED from 'html/images/28x28_Match_Unlocked.png';
 import {isImage} from '../WebPlot';
+import {showInfoPopup} from '../../ui/PopupUtil';
 
 function changeMatchType(vr, matchType, lockMatch) {
     const plot= primePlot(vr);
     if (!plot) return;
+    //check for images without WCS when aligning by WCS or Target, and display appropriate warning
+    if(matchType.key === 'Standard' || matchType.key === 'Target') {
+        const warningTitles= getPlotViewAry(vr)
+                .filter( (pv) => !hasWCSProjection(primePlot(pv)) )
+                .map ( (pv) => primePlot(pv).title);
+        if (warningTitles.length !== 0) { //at least one image without WCS
+            const msgTitle = 'The following image(s) do not have WCS:';
+            const msgDesc = warningTitles.join(', ');
+            const renderContent = (
+                <div>
+                    {msgTitle} <br></br> <br></br>
+                    <div style={{padding: '5', whiteSpace: 'normal', letterSpacing: '1', lineHeight: '1.5'}}>
+                        {msgDesc}
+                    </div>
+                </div>);
+            showInfoPopup(renderContent, 'Warning');
+        }
+    }
     dispatchWcsMatch({matchType, plotId:plot.plotId, lockMatch});
 }
 


### PR DESCRIPTION
#### [Firefly-1092](https://jira.ipac.caltech.edu/browse/FIREFLY-1092): 
 - Related design ticket: [Firefly-275](https://jira.ipac.caltech.edu/browse/FIREFLY-275)
 - in MatchLockDropDown.jsx, added a warning when user tries to align by WCS or Target and if one or more images don't have WCS
 - Warning shows the plot titles for all of the image(s) without WCS 
 - If multiple images don't have WCS, the warning popup looks a bit messy. Tried to clean it by adding some letter-spacing and line-height with CSS, but taking recommendations on how to make it look even better. 

#### Testing
 -   https://fireflydev.ipac.caltech.edu/firefly-1092-no-wcs-warning/firefly/
 -  add/upload some FITS images with and without WCS
 - Try aligning by WCS/Target with an image with WCS selected 
 - Also try aligning by pixel origins and by pixel at image centers to make sure those work as expected 