### PR TITLE
Firefly-1060: Support datatype and other features in extract

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -176,6 +176,7 @@ public class ServerParams {
     public static final String TILE_SIZE = "tileSize";
     public static final String DATA_COMPRESS = "dataCompress";
     public static final String POINT_SIZE= "pointSize";
+    public static final String COMBINE_OP= "combineOp";
     public static final String EXTRACTION_TYPE= "extractionType";
     public static final String EXTRACTION_FLOAT_SIZE= "extractionFloatSize";
     public static final String HDU_NUM= "hduNum";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
@@ -149,10 +149,12 @@ public class LockingVisNetwork {
         public void dataDownloading(DownloadEvent ev) {
             if (_key == null) return;
             String offStr = "";
-            if (ev.getMax() > 0) {
+            long current= ev.getCurrent();
+            long max= ev.getMax();
+            if (max > 0 && current<max) {
                 offStr = " of " + FileUtil.getSizeAsString(ev.getMax(),true);
             }
-            String messStr = "Retrieved " + FileUtil.getSizeAsString(ev.getCurrent(),true) + offStr;
+            String messStr = "Retrieved " + FileUtil.getSizeAsString(current,true) + offStr;
             PlotServUtils.updatePlotCreateProgress(_key, _plotId, ProgressStat.PType.DOWNLOADING, messStr);
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -157,13 +157,13 @@ public class VisServerOps {
     public static List<Number> getLineDataAry(PlotState state, ImagePt pt, ImagePt pt2, int plane, int hduNum,
                                               int drillSize, FitsExtract.CombineType ct) {
         return getDataAry("point data", state, (f) ->
-                     FitsExtract.getLineDataAryFromFile(pt, pt2, plane, f, hduNum, drillSize, ct));
+                     FitsExtract.getLineDataAryFromFile(pt, pt2, plane, f, hduNum, hduNum, drillSize, ct));
     }
 
     public static List<Number> getPointDataAry(PlotState state, ImagePt[] ptAry, int plane, int hduNum,
                                                int drillSize, FitsExtract.CombineType ct) {
         return getDataAry("line data", state, (f) ->
-                FitsExtract.getPointDataAryFromFile(ptAry, plane, f, hduNum, drillSize, ct));
+                FitsExtract.getPointDataAryFromFile(ptAry, plane, f, hduNum, hduNum, drillSize, ct));
     }
 
     public static List<String> getFlux(PlotState[] stateAry, ImagePt ipt) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -37,6 +37,7 @@ import edu.caltech.ipac.visualize.plot.CropFile;
 import edu.caltech.ipac.visualize.plot.Histogram;
 import edu.caltech.ipac.visualize.plot.ImagePt;
 import edu.caltech.ipac.visualize.plot.PixelValue;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsExtract;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsReadUtil;
 import nom.tam.fits.Fits;
@@ -134,32 +135,35 @@ public class VisServerOps {
         }
     }
 
-    interface Extractor { double[] getData(File fitsFile) throws Exception; }
+    interface Extractor { List<Number> getData(File fitsFile) throws Exception; }
 
-    public static double[] getDataAry(String desc, PlotState state, Extractor extractor) {
+    public static List<Number> getDataAry(String desc, PlotState state, Extractor extractor) {
         try {
             CtxControl.confirmFiles(state);
             PlotServUtils.statsLog(desc);
             File fitsFile= ServerContext.convertToFile(state.getWorkingFitsFileStr(NO_BAND));
             return extractor.getData(fitsFile);
         } catch (Exception e) {
-            return new double[] {};
+            return new ArrayList<>();
         }
 
     }
-    public static double[] getZAxisAry(PlotState state, ImagePt pt, int hduNum, int ptSize) {
+    public static List<Number> getZAxisAry(PlotState state, ImagePt pt, int hduNum,
+                                           int ptSize, FitsExtract.CombineType ct) {
         return getDataAry("z-axis drilldown", state, (f) ->
-                FitsReadUtil.getZAxisAryFromCube(pt, f, hduNum, ptSize));
+                FitsExtract.getZAxisAryFromCube(pt, f, hduNum, ptSize, ct));
     }
 
-    public static double[] getLineDataAry(PlotState state, ImagePt pt, ImagePt pt2, int plane, int hduNum, int drillSize) {
+    public static List<Number> getLineDataAry(PlotState state, ImagePt pt, ImagePt pt2, int plane, int hduNum,
+                                              int drillSize, FitsExtract.CombineType ct) {
         return getDataAry("point data", state, (f) ->
-                     FitsReadUtil.getLineDataAryFromFile(pt, pt2, plane, f, hduNum, drillSize));
+                     FitsExtract.getLineDataAryFromFile(pt, pt2, plane, f, hduNum, drillSize, ct));
     }
 
-    public static double[] getPointDataAry(PlotState state, ImagePt[] ptAry, int plane, int hduNum, int drillSize) {
+    public static List<Number> getPointDataAry(PlotState state, ImagePt[] ptAry, int plane, int hduNum,
+                                               int drillSize, FitsExtract.CombineType ct) {
         return getDataAry("line data", state, (f) ->
-                FitsReadUtil.getPointDataAryFromFile(ptAry, plane, f, hduNum, drillSize));
+                FitsExtract.getPointDataAryFromFile(ptAry, plane, f, hduNum, drillSize, ct));
     }
 
     public static List<String> getFlux(PlotState[] stateAry, ImagePt ipt) {

--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSExtractToTable.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSExtractToTable.java
@@ -1,0 +1,265 @@
+package edu.caltech.ipac.table.io;
+/**
+ * User: roby
+ * Date: 10/13/22
+ * Time: 4:18 PM
+ */
+
+
+import edu.caltech.ipac.firefly.data.table.MetaConst;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.visualize.VisUtil;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataObject;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.TableMeta;
+import edu.caltech.ipac.visualize.plot.ImagePt;
+import edu.caltech.ipac.visualize.plot.WorldPt;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsExtract;
+import nom.tam.fits.FitsException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Trey Roby
+ */
+public class FITSExtractToTable {
+
+
+    private static String makeKeyforHDUTab(FitsExtract.ExtractionResults result) {
+        return result.extName()!=null ? result.extName() : "HDU#"+result.hduNum();
+    }
+
+    private static String makeMetaEntryForHDUs(List<FitsExtract.ExtractionResults> results) {
+        StringBuilder str= new StringBuilder();
+        for(FitsExtract.ExtractionResults r : results) {
+           if (str.length()>0) str.append(";");
+           str.append(makeKeyforHDUTab(r)).append("=").append(r.hduNum());
+        }
+        return str.toString();
+    }
+
+    private static Number getFistNonNaN(List<Number> valueList) {
+        for(Number v: valueList) { // find first  non nan entry
+            if (!Double.isNaN(v.doubleValue())) return v;
+        }
+        return valueList.get(0);
+    }
+
+    private static String addSize(String desc, int drillSize, FitsExtract.CombineType ct) {
+        if (drillSize<2) return desc;
+        return desc+ " ("+drillSize+"x"+drillSize+","+ct.toString()+")";
+    }
+
+    private static Class<?> getDataType(List<Number> valueList) {
+        Number n= getFistNonNaN(valueList);
+        if (n instanceof Double) return Double.class;
+        if (n instanceof Float) return Float.class;
+        if (n instanceof Integer) return Integer.class;
+        if (n instanceof Long) return Long.class;
+        return Double.class;
+    }
+
+    private static double rnd(double d, int decimalPlaces) {
+        double factor= Math.pow(10,decimalPlaces);
+        return Math.round(d*factor)/factor;
+    }
+
+    private static void insertZaxisSpectrumMeta(DataGroup dataGroup,
+                                                List<FitsExtract.ExtractionResults> results,
+                                                String wavelengthColName,
+                                                String fluxColName ) {
+
+        // guess an error
+        String errCol= null;
+        for(FitsExtract.ExtractionResults result: results) {
+            String extName= result.extName();
+            if (extName!=null && extName.toLowerCase().startsWith("err")) {
+                errCol= makeKeyforHDUTab(result);
+                break;
+            }
+        }
+        SpectrumMetaInspector.createSpectrumMeta(dataGroup,wavelengthColName,fluxColName,errCol);
+    }
+
+    private static void insertZaxisGenericChartMeta(DataGroup dataGroup,
+                                                    List<FitsExtract.ExtractionResults> results,
+                                                    String xColName ) {
+        String defYCol= "";
+        for(FitsExtract.ExtractionResults result : results) {
+            if (result.refHDU()) defYCol= makeKeyforHDUTab(result);
+        }
+        TableMeta meta= dataGroup.getTableMeta();
+        meta.addKeyword(MetaConst.DEFAULT_CHART_X_COL, xColName);
+        meta.addKeyword(MetaConst.DEFAULT_CHART_Y_COL, defYCol);
+    }
+
+    public static DataGroup getCubeZaxisAsTable(ImagePt pt, WorldPt wpt, String filename, int refHduNum,
+                                                boolean allMatchingHDUs, int drillSize, FitsExtract.CombineType ct,
+                                                double[] wlAry, String wlUnit, Map<Integer,String> fluxUnit)
+            throws IOException, FitsException {
+        File f= ServerContext.convertToFile(filename);
+        List<FitsExtract.ExtractionResults> results= FitsExtract.getAllZAxisAryFromRelatedCubes(
+                pt, f, refHduNum, allMatchingHDUs, drillSize, ct);
+        ArrayList<DataType> dataTypes = new ArrayList<>();
+        int len= results.get(0).aryData().size();
+        dataTypes.add(new DataType("plane","Plane", Integer.class));
+        if (wlAry!=null) {
+            DataType wlDt= new DataType("wavelength",Double.class, "Wavelength", wlUnit, null, null);
+            dataTypes.add(wlDt);
+        }
+        String refKey= null;
+        for(FitsExtract.ExtractionResults result : results) {
+            String desc= result.extName()!=null ? result.extName() : "HDU# "+result.hduNum();
+            desc= addSize(desc,drillSize,ct);
+            String key= makeKeyforHDUTab(result);
+            String u= fluxUnit.get(result.hduNum());
+            Class<?> dataType= getDataType(result.aryData());
+            DataType dt = new DataType(key,dataType, desc, u, null, null);
+            if (result.refHDU()) refKey= key;
+
+            dataTypes.add(dt);
+        }
+        DataGroup dataGroup = new DataGroup("Cube Z-Axis", dataTypes);
+        for (int i = 0; (i < len); i++) {
+            DataObject aRow = new DataObject(dataGroup);
+            aRow.setDataElement("plane",i+1);
+            if (wlAry!=null) aRow.setDataElement("wavelength",rnd(wlAry[i],7));
+            for(FitsExtract.ExtractionResults result : results) {
+                aRow.setDataElement(makeKeyforHDUTab(result),result.aryData().get(i));
+            }
+            dataGroup.add(aRow);
+        }
+        TableMeta meta= dataGroup.getTableMeta();
+        meta.addKeyword(MetaConst.FITS_IM_PT, pt.toString());
+        if (wpt!=null) meta.addKeyword(MetaConst.FITS_WORLD_PT, wpt.toString());
+        meta.addKeyword(MetaConst.FITS_IMAGE_HDU, makeMetaEntryForHDUs(results));
+        meta.addKeyword(MetaConst.FITS_FILE_PATH, ServerContext.replaceWithPrefix(f));
+        meta.addKeyword(MetaConst.FITS_EXTRACTION_TYPE, "z-axis");
+        if (wlAry!=null && wlAry.length>0) {
+            insertZaxisSpectrumMeta(dataGroup, results, "wavelength", refKey);
+        }
+        else {
+            insertZaxisGenericChartMeta(dataGroup, results, wlAry!=null?"wavelength":"plane");
+        }
+        return dataGroup;
+    }
+
+    public static DataGroup getPointsAsTable(ImagePt[] ptAry, WorldPt[] wptAry, String filename, int refHduNum, int plane,
+                                             boolean allMatchingHDUs, int drillSize, FitsExtract.CombineType ct) throws IOException, FitsException {
+        File f= ServerContext.convertToFile(filename);
+        List<FitsExtract.ExtractionResults> results= FitsExtract.getAllPointsFromRelatedHDUs(
+                ptAry, f, refHduNum, plane, allMatchingHDUs, drillSize, ct );
+        ArrayList<DataType> dataTypes = new ArrayList<>();
+        int len= results.get(0).aryData().size();
+        dataTypes.add(new DataType("x", Integer.class, "x", "pixel", null, null));
+        dataTypes.add(new DataType("y", Integer.class, "y", "pixel", null, null));
+        boolean hasWpt= wptAry!=null && wptAry.length==ptAry.length;
+        if (hasWpt) {
+            dataTypes.add(new DataType("ra",Double.class, "ra", "deg", null, null));
+            dataTypes.add(new DataType("dec",Double.class, "dec","deg", null, null ));
+        }
+        String defYCol= "";
+        for(FitsExtract.ExtractionResults result : results) {
+            String desc= result.extName()!=null ? result.extName() : "HDU# "+result.hduNum();
+            desc= addSize(desc,drillSize,ct);
+            String key= makeKeyforHDUTab(result);
+            String bunit= result.header().getStringValue("BUNIT");
+            Class dataType= getDataType(result.aryData());
+            DataType dt = new DataType(key,dataType, desc, bunit, null,null);
+            if (result.refHDU()) defYCol= key;
+            dataTypes.add(dt);
+        }
+        DataGroup dataGroup = new DataGroup("Cube Z-Axis", dataTypes);
+        for (int i = 0; (i < len); i++) {
+            DataObject aRow = new DataObject(dataGroup);
+            aRow.setDataElement("x",(int)Math.rint(ptAry[i].getX()));
+            aRow.setDataElement("y",(int)Math.rint(ptAry[i].getY()));
+            if (hasWpt) {
+                aRow.setDataElement("ra",rnd(wptAry[i].getX(),7));
+                aRow.setDataElement("dec",rnd(wptAry[i].getY(),7));
+            }
+            for(FitsExtract.ExtractionResults result : results) {
+                aRow.setDataElement(makeKeyforHDUTab(result),result.aryData().get(i));
+            }
+            dataGroup.add(aRow);
+        }
+        TableMeta meta= dataGroup.getTableMeta();
+        meta.addKeyword(MetaConst.FITS_IMAGE_HDU, makeMetaEntryForHDUs(results));
+        if (plane>0) meta.addKeyword(MetaConst.FITS_IMAGE_HDU_CUBE_PLANE, plane+"");
+        if (hasWpt) meta.addKeyword(MetaConst.CENTER_COLUMN, "ra;dec;J2000");
+        meta.addKeyword(MetaConst.IMAGE_COLUMN, "x;y");
+        meta.addKeyword(MetaConst.CATALOG_OVERLAY_TYPE, hasWpt ? "TRUE" : "IMAGE_PTS");
+        meta.addKeyword(MetaConst.FITS_FILE_PATH, ServerContext.replaceWithPrefix(f));
+        meta.addKeyword(MetaConst.FITS_EXTRACTION_TYPE, "points");
+        meta.addKeyword(MetaConst.DEFAULT_CHART_X_COL, "x");
+        meta.addKeyword(MetaConst.DEFAULT_CHART_Y_COL, defYCol);
+        dataGroup.trimToSize();
+        return dataGroup;
+    }
+
+
+    public static DataGroup getLineSelectAsTable(ImagePt[] ptAry, WorldPt[] wptAry, String filename, int refHduNum, int plane,
+                                                 boolean allMatchingHDUs, int drillSize, FitsExtract.CombineType ct)
+            throws IOException, FitsException {
+        File f= ServerContext.convertToFile(filename);
+        List<FitsExtract.ExtractionResults> results= FitsExtract.getAllPointsFromRelatedHDUs(
+                ptAry, f, refHduNum, plane, allMatchingHDUs, drillSize, ct);
+        ArrayList<DataType> dataTypes = new ArrayList<>();
+        int len= results.get(0).aryData().size();
+        boolean hasWpt= wptAry!=null && wptAry.length==ptAry.length;
+        if (hasWpt) {
+            dataTypes.add(new DataType("offset", Double.class, "offset", "arcsec", null, null));
+            dataTypes.add(new DataType("ra",Double.class, "ra", "deg", null, null));
+            dataTypes.add(new DataType("dec",Double.class, "dec","deg", null, null ));
+        }
+        dataTypes.add(new DataType("pixOffset",Double.class, "pixOffset", "pixel",null, null ));
+        dataTypes.add(new DataType("x", Integer.class, "x", "pixel", null, null));
+        dataTypes.add(new DataType("y", Integer.class, "y", "pixel", null, null));
+        String defYCol= "";
+        for(FitsExtract.ExtractionResults result : results) {
+            String desc= result.extName()!=null ? result.extName() : "HDU# "+result.hduNum();
+            desc= addSize(desc,drillSize,ct);
+            String key= makeKeyforHDUTab(result);
+            String bunit= result.header().getStringValue("BUNIT");
+            Class dataType= getDataType(result.aryData());
+            DataType dt = new DataType(key,dataType, desc, bunit, null,null);
+            if (result.refHDU()) defYCol= key;
+            dataTypes.add(dt);
+        }
+        DataGroup dataGroup = new DataGroup("Cube Z-Axis", dataTypes);
+        for (int i = 0; (i < len); i++) {
+            DataObject aRow = new DataObject(dataGroup);
+            aRow.setDataElement("pixOffset",rnd(VisUtil.computeDistance(ptAry[0],ptAry[i]), 1));
+            aRow.setDataElement("x",(int)Math.rint(ptAry[i].getX()));
+            aRow.setDataElement("y",(int)Math.rint(ptAry[i].getY()));
+            if (hasWpt) {
+                aRow.setDataElement("offset",rnd(VisUtil.computeDistance(wptAry[0],wptAry[i])*3600,3));
+                aRow.setDataElement("ra",rnd(wptAry[i].getX(),7));
+                aRow.setDataElement("dec",rnd(wptAry[i].getY(),7));
+            }
+            for(FitsExtract.ExtractionResults result : results) {
+                aRow.setDataElement(makeKeyforHDUTab(result),result.aryData().get(i));
+            }
+            dataGroup.add(aRow);
+        }
+        TableMeta meta= dataGroup.getTableMeta();
+        meta.addKeyword(MetaConst.FITS_IM_PT, ptAry[0].toString());
+        meta.addKeyword(MetaConst.FITS_IM_PT2, ptAry[ptAry.length-1].toString());
+        meta.addKeyword(MetaConst.FITS_IMAGE_HDU, makeMetaEntryForHDUs(results));
+        if (plane>0) meta.addKeyword(MetaConst.FITS_IMAGE_HDU_CUBE_PLANE, plane+"");
+        meta.addKeyword(MetaConst.FITS_FILE_PATH, ServerContext.replaceWithPrefix(f));
+        meta.addKeyword(MetaConst.FITS_EXTRACTION_TYPE, "line");
+        meta.addKeyword(MetaConst.DEFAULT_CHART_X_COL, wptAry!=null ? "offset" : "pixOffset");
+        meta.addKeyword(MetaConst.DEFAULT_CHART_Y_COL, defYCol);
+        meta.addKeyword(MetaConst.IMAGE_COLUMN, "x;y");
+        meta.addKeyword(MetaConst.CATALOG_OVERLAY_TYPE, hasWpt ? "TRUE" : "IMAGE_PTS");
+
+        dataGroup.trimToSize();
+        return dataGroup;
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
@@ -1,0 +1,329 @@
+package edu.caltech.ipac.visualize.plot.plotdata;
+
+import edu.caltech.ipac.visualize.plot.ImagePt;
+import nom.tam.fits.BasicHDU;
+import nom.tam.fits.Fits;
+import nom.tam.fits.FitsException;
+import nom.tam.fits.Header;
+import nom.tam.fits.ImageHDU;
+import nom.tam.image.compression.hdu.CompressedImageHDU;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Trey Roby
+ */
+public class FitsExtract {
+
+    public enum CombineType {AVG, SUM, OR}
+
+    private static  Number combineArray(List<Number> aryList, CombineType ct, Class<?> type) {
+        if (aryList.size() == 0) return Double.NaN;
+        if (aryList.size() == 1) return aryList.get(0);
+        double cnt = 0;
+        var realCt=  (ct==CombineType.OR && (type==Float.TYPE || type==Double.TYPE)) ? CombineType.AVG : ct;
+        if (realCt==CombineType.AVG || realCt==CombineType.SUM) {
+            double sum = 0;
+            for (Number v : aryList) {
+                if (!isNaN(v)) {
+                    sum += v.doubleValue();
+                    cnt++;
+                }
+            }
+            var result= (cnt==0||ct==CombineType.SUM) ? sum : sum/cnt;
+            return cnt > 0 ? result : Double.NaN;
+        } else if (ct == CombineType.OR) {
+            long anded=0;
+            for (Number v : aryList) {
+                if (!isNaN(v)) {
+                    anded |= v.longValue();
+                    cnt++;
+                }
+            }
+            Number n;
+            if (type==Long.TYPE) n= anded;
+            else n= (int)anded;
+            return cnt > 0 ? n : Double.NaN;
+        }
+        else  {
+            return Double.NaN;
+        }
+    }
+
+
+    private static Number getNan(Number v) {
+        if (v instanceof Double) return Double.NaN;
+        if (v instanceof Float) return Float.NaN;
+        return Double.NaN;
+    }
+    private static boolean isNaN(Number v) {
+        if (v instanceof Double) return ((Double) v).isNaN();
+        if (v instanceof Float) return ((Float) v).isNaN();
+        return false;
+    }
+
+    private static List<Number> objToNumberAry(Object obj, Class<?> type) {
+        List<Number> list= new ArrayList<>();
+
+        if (type == Double.TYPE) {
+            double[] ary= (double[])obj;
+            for (double v : ary) list.add(v);
+        }
+        else if (type == Float.TYPE) {
+            float[] ary= (float[])obj;
+            for (float v : ary) list.add(v);
+        }
+        else if (type == Integer.TYPE) {
+            int[] ary= (int[])obj;
+            for (int v : ary) list.add(v);
+        }
+        else if (type == Long.TYPE) {
+            long[] ary= (long[])obj;
+            for (long v : ary) list.add(v);
+        }
+
+        return list;
+    }
+
+
+
+    /**
+     *
+     * @throws IOException if it can't read the fits file
+     */
+    static Number valueFromFitsFile(ImageHDU hdu, int x, int y, int plane, int ptSize, CombineType ct) throws IOException {
+        Header header= hdu.getHeader();
+        int naxis1= FitsReadUtil.getNaxis1(header);
+        int naxis2= FitsReadUtil.getNaxis2(header);
+        int bitpix= FitsReadUtil.getBitPix(header);
+        if (ptSize<1) ptSize= 1;
+        else if (ptSize>5) ptSize= 5;
+        int adjust= (int)Math.floor((ptSize-1) / 2.0);
+        x= x - adjust;
+        y= y - adjust;
+        if (x<0) x= 0;
+        if (y<0) y= 0;
+        if (x+ptSize>=naxis1) x-= (x+ptSize-naxis1+1);
+        if (y+ptSize>=naxis2) y-= (y+ptSize-naxis2+1);
+
+        Class arrayType= switch (bitpix) {
+            case -32 -> Float.TYPE;
+            case 8, 16, 32 -> Integer.TYPE;
+            case 64 -> Long.TYPE;
+            default -> Double.TYPE;
+        };
+
+        Object ary= FitsReadUtil.dataArrayFromFitsFile(hdu,x,y,ptSize,ptSize,plane,arrayType);
+        Number aveValue= combineArray(objToNumberAry(ary,arrayType), ct, arrayType);
+
+        var bscale= FitsReadUtil.getBscale(header);
+        var bzero= FitsReadUtil.getBzero(header);
+        var blankValue= FitsReadUtil.getBlankValue(header);
+
+        if (bscale==1.0D && bzero==0D && !isNaN(aveValue) && aveValue.doubleValue()!=blankValue) return aveValue;
+
+        double newValue= ImageStretch.getFluxStandard( aveValue.doubleValue(), blankValue, bscale, bzero);
+        if (Double.isNaN(newValue)) return newValue;
+
+        return switch (arrayType.toString()) {
+            case "float" -> (float)newValue;
+            case "int" -> (int)newValue;
+            case "long" -> (bscale==1.0D) ? (long)newValue : aveValue.longValue() + bzero;
+            default -> newValue;
+        };
+    }
+
+    static ImageHDU getImageHDU(BasicHDU<?>[] hdus, int idx) throws FitsException {
+        if ( !(hdus[idx] instanceof ImageHDU) && !(hdus[idx] instanceof CompressedImageHDU) ) {
+            throw new FitsException(idx + " is not a cube");
+        }
+        return (hdus[idx] instanceof CompressedImageHDU) ?
+                        ((CompressedImageHDU) hdus[idx]).asImageHDU() : (ImageHDU) hdus[idx];
+    }
+
+    public static List<Number> getPointDataAry(ImagePt[] ptAry, int plane, BasicHDU<?>[] hdus, int hduNum, int ptSize, CombineType ct)
+            throws FitsException, IOException {
+        ImageHDU hdu= getImageHDU(hdus,hduNum);
+        var pts= new ArrayList<Number>(ptAry.length);
+        for(int i=0;(i<ptAry.length);i++) {
+            ImagePt pt= ptAry[i];
+            pts.add(valueFromFitsFile(hdu, (int)pt.getX(),(int)pt.getY(),plane,ptSize,ct));
+        }
+        return pts;
+    }
+
+    public static List<Number> getLineDataAry(ImagePt pt1, ImagePt pt2, int plane, BasicHDU<?>[] hdus,
+                                              int hduNum, int ptSize, CombineType ct)
+            throws FitsException, IOException {
+        ImageHDU hdu= getImageHDU(hdus,hduNum);
+        double x1 = pt1.getX();
+        double y1 = pt1.getY();
+        double x2 = pt2.getX();
+        double y2 = pt2.getY();
+
+        // delta X and Y in image pixels
+        double deltaX = Math.abs(pt2.getX() - pt1.getX());
+        double deltaY = Math.abs(pt2.getY() - pt1.getY());
+        double slope;
+        double yIntercept;
+
+        int x, y;
+        if (deltaX > deltaY) {
+            slope = (y2-y1)/(x2-x1);
+            yIntercept = y1-slope*x1;
+
+            int minX = (int)Math.min(x1, x2);
+            int maxX = (int)Math.max(x1, x2) ;
+            int n = (int)Math.rint(Math.ceil(maxX-minX))+1;
+            List<Number> pts= new ArrayList<>(n);
+            for (x=minX; x<=maxX; x+=1) {
+                y = (int)(slope*x + yIntercept);
+                pts.add(valueFromFitsFile(hdu, x,y,plane,ptSize,ct));
+            }
+            return pts;
+        } else if (y1 != y2) {
+            double  islope = (x2-x1)/(y2-y1);
+            double xIntercept = x1-islope*y1;
+
+            int minY = (int)Math.min(y1, y2);
+            int maxY = (int)Math.max(y1, y2);
+            int n = (int)Math.rint(Math.ceil(maxY - minY))+1;
+            List<Number> pts= new ArrayList<>(n);
+
+            for (y=minY; y<=maxY; y+=1) {
+                x = (int)(islope*y + xIntercept);
+                pts.add(valueFromFitsFile(hdu, x,y,plane,ptSize,ct));
+            }
+            return pts;
+        }
+        return null;
+    }
+
+    public static List<ExtractionResults> extractFromRelatedHDUs(File fitsFile, int refHduNum,
+                                                                 boolean allMatchingHDUs, Extractor extractor)
+            throws FitsException, IOException {
+        Fits fits = null;
+        try {
+            fits = new Fits(fitsFile);
+            BasicHDU<?>[] hdus = FitsReadUtil.readHDUs(fits);
+            BasicHDU<?> hdu = hdus[refHduNum];
+            validateImageAtHDU(hdus, refHduNum);
+            Header refHeader = hdu.getHeader();
+            int dims = FitsReadUtil.getNaxis(refHeader);
+            int xLen = FitsReadUtil.getNaxis1(refHeader);
+            int yLen = FitsReadUtil.getNaxis2(refHeader);
+            int zLen = FitsReadUtil.getNaxis3(refHeader);
+            List<ExtractionResults> retList = new ArrayList<>();
+
+            if (allMatchingHDUs) {
+                for (int i = 0; (i < hdus.length); i++) {
+                    Header h = hdus[i].getHeader();
+                    if (FitsReadUtil.getNaxis(h) == dims && FitsReadUtil.getNaxis1(h) == xLen && FitsReadUtil.getNaxis2(h) == yLen && FitsReadUtil.getNaxis3(h) == zLen) {
+                        var list = extractor.extractAry(hdus, i);
+                        retList.add(new ExtractionResults(i, FitsReadUtil.getExtName(h), list, i == refHduNum, h));
+                    }
+                }
+            } else {
+                var list = extractor.extractAry(hdus, refHduNum);
+                retList.add(new ExtractionResults(refHduNum, FitsReadUtil.getExtName(refHeader), list,true, refHeader));
+            }
+            return retList;
+        } finally {
+            FitsReadUtil.closeFits(fits);
+        }
+    }
+
+    public static List<Number> extractFromHDU(File fitsFile, int hduNum, Extractor extractor)
+            throws FitsException, IOException {
+        Fits fits= null;
+        try {
+            fits = new Fits(fitsFile);
+            return extractor.extractAry(FitsReadUtil.readHDUs(fits), hduNum);
+        }
+        finally {
+            FitsReadUtil.closeFits(fits);
+        }
+    }
+
+    public static List<ExtractionResults> getAllPointsFromRelatedHDUs(ImagePt[] ptAry, File fitsFile,
+                                                                      int refHduNum, int plane,
+                                                                      boolean allMatchingHDUs, int ptSize,
+                                                                      CombineType ct)
+            throws FitsException, IOException {
+        return extractFromRelatedHDUs(fitsFile, refHduNum, allMatchingHDUs,
+                (hdus, hduNum) -> getPointDataAry(ptAry, plane, hdus, hduNum, ptSize, ct));
+    }
+
+    public static List<ExtractionResults> getAllLinesFromRelatedHDUs(ImagePt pt, ImagePt pt2, File fitsFile,
+                                                                     int refHduNum, int plane,
+                                                                     boolean allMatchingHDUs, int ptSize,
+                                                                     CombineType ct)
+            throws FitsException, IOException {
+        return extractFromRelatedHDUs(fitsFile, refHduNum, allMatchingHDUs,
+                (hdus, hduNum) -> getLineDataAry(pt, pt2, plane, hdus, hduNum, ptSize, ct));
+    }
+
+    public static List<ExtractionResults> getAllZAxisAryFromRelatedCubes(ImagePt pt, File fitsFile, int refHduNum,
+                                                                         boolean allMatchingHDUs, int ptSize,
+                                                                         CombineType ct)
+            throws FitsException, IOException {
+        return extractFromRelatedHDUs(fitsFile, refHduNum, allMatchingHDUs,
+                (hdus,hduNum) -> getZAxisAry(pt,hdus,hduNum,ptSize,ct) );
+    }
+
+    public static List<Number> getPointDataAryFromFile(ImagePt[] ptAry, int plane, File fitsFile, int hduNum,
+                                                       int ptSize, CombineType ct)
+            throws FitsException, IOException {
+        return extractFromHDU(fitsFile,hduNum, (hdus,num) -> getPointDataAry(ptAry,plane, hdus,num,ptSize,ct));
+    }
+
+    public static List<Number> getLineDataAryFromFile(ImagePt pt, ImagePt pt2, int plane, File fitsFile, int hduNum,
+                                                      int ptSize, CombineType ct)
+            throws FitsException, IOException {
+        return extractFromHDU(fitsFile,hduNum, (hdus,num) -> getLineDataAry(pt,pt2,plane, hdus,num,ptSize,ct));
+    }
+
+    public static List<Number> getZAxisAryFromCube(ImagePt pt, File fitsFile, int hduNum, int ptSize, CombineType ct)
+            throws FitsException, IOException {
+        return extractFromHDU(fitsFile,hduNum, (hdus,num) -> getZAxisAry(pt,hdus,num,ptSize,ct));
+    }
+
+    public static List<Number> getZAxisAry(ImagePt pt, BasicHDU<?>[] hdus, int hduNum, int ptSize, CombineType ct)
+            throws FitsException, IOException {
+        validateCubeAtHDU(hdus,hduNum);
+        ImageHDU hdu= getImageHDU(hdus,hduNum);
+        Header header= hdu.getHeader();
+        int zLen= FitsReadUtil.getNaxis3(header);
+        List<Number> retList= new ArrayList<>(zLen);
+        for(int i=0;i<zLen; i++) {
+            retList.add(valueFromFitsFile(hdu,(int)pt.getX(), (int)pt.getY(),i,ptSize, ct));
+        }
+        return retList;
+    }
+
+    private static void validateCubeAtHDU(BasicHDU<?>[] hdus, int hduNum) throws FitsException {
+        validateImageAtHDU(hdus,hduNum);
+        BasicHDU<?> basicHDU= hdus[hduNum];
+        Header header= basicHDU.getHeader();
+        String hduNumStr= "HDU #"+hduNum;
+        int nAxis= FitsReadUtil.getNaxis(header);
+        if (nAxis<3) throw new FitsException(hduNumStr + " is not a cube");
+        if (nAxis==4 && FitsReadUtil.getNaxis4(header)!=1) throw new FitsException(hduNumStr + " is not a cube, 4 axes");
+    }
+
+    private static void validateImageAtHDU(BasicHDU<?>[] hdus, int hduNum) throws FitsException {
+        String hduNumStr= "HDU #"+hduNum;
+        if (hduNum>=hdus.length) throw new FitsException("no "+hduNumStr);
+        BasicHDU<?> basicHDU= hdus[hduNum];
+        if ( !(basicHDU instanceof ImageHDU) && !(basicHDU instanceof CompressedImageHDU) ) {
+            throw new FitsException(hduNumStr+ " is not a image HDU");
+        }
+    }
+
+    interface Extractor { List<Number> extractAry(BasicHDU<?>[] hdus, int hduNum) throws FitsException, IOException; }
+
+    public record ExtractionResults(int hduNum, String extName, List<Number> aryData, boolean refHDU, Header header) { }
+}

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -124,7 +124,7 @@ public class FitsRead implements Serializable, HasSizeOf {
     public double getBzero() { return FitsReadUtil.getBzero(header); }
     public double getCdelt1() { return this.cdelt1; }
     public double getBlankValue() {return FitsReadUtil.getBlankValue(header); }
-    public int getBitPix() {return header.getIntValue("BITPIX"); }
+    public int getBitPix() {return FitsReadUtil.getBitPix(header); }
 
     public boolean isDeferredRead() { return deferredRead; }
 
@@ -147,7 +147,7 @@ public class FitsRead implements Serializable, HasSizeOf {
             fits = new Fits(this.file);
             BasicHDU<?> hdu= FitsReadUtil.readHDUs(fits)[this.hduNumber];
             if (!(hdu instanceof ImageHDU)) return null;
-            float1d= (float [])dataArrayFromFitsFile((ImageHDU)hdu, 0,0,getNaxis1(),getNaxis2(), planeNumber,false);
+            float1d= (float [])dataArrayFromFitsFile((ImageHDU)hdu, 0,0,getNaxis1(),getNaxis2(), planeNumber,Float.TYPE);
             return float1d;
         }
         catch (FitsException|IOException|ArrayIndexOutOfBoundsException e) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -503,7 +503,9 @@ public class FitsReadUtil {
     public static double getBzero(Header h) { return h.getDoubleValue("BZERO", 0.0); }
     public static double getBlankValue(Header h) { return h.getDoubleValue("BLANK", Double.NaN); }
     public static String getExtName(Header h) { return h.getStringValue("EXTNAME"); }
+    public static String getExtType(Header h) { return h.getStringValue("EXTTYPE"); }
     public static String getUtype(Header h) { return h.getStringValue("UTYPE"); }
+    public static String getExtNameOrType(Header h) { return getExtName(h)!=null ? getExtName(h) : getExtType(h);}
 
 
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -7,7 +7,6 @@ package edu.caltech.ipac.visualize.plot.plotdata;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.visualize.plot.CoordinateSys;
 import edu.caltech.ipac.visualize.plot.ImageHeader;
-import edu.caltech.ipac.visualize.plot.ImagePt;
 import edu.caltech.ipac.visualize.plot.Plot;
 import edu.caltech.ipac.visualize.plot.ProjectionException;
 import edu.caltech.ipac.visualize.plot.WorldPt;
@@ -494,6 +493,7 @@ public class FitsReadUtil {
         }
     }
 
+    public static int getBitPix(Header h) {return h.getIntValue("BITPIX"); }
     public static int getNaxis(Header h) { return h.getIntValue("NAXIS", 0); }
     public static int getNaxis1(Header h) { return h.getIntValue("NAXIS1", 0); }
     public static int getNaxis2(Header h) { return h.getIntValue("NAXIS2", 0); }
@@ -538,135 +538,11 @@ public class FitsReadUtil {
         }
     }
 
-    private static double averageArray(double[] ary) {
-        if (ary.length == 0) return Double.NaN;
-        if (ary.length == 1) return ary[0];
-        float sum = 0;
-        float cnt = 0;
-        for (double v : ary) {
-            if (!Double.isNaN(v)) {
-                sum += v;
-                cnt++;
-            }
-        }
-        return cnt > 0 ? sum / cnt : Float.NaN;
-    }
-
-
-
-    interface Extractor { double[] extractAry(BasicHDU<?>[] hdus, int hduNum) throws FitsException, IOException; }
-
-
-    public static List<ExtractionResults> extractFromRelatedHDUs(File fitsFile, int refHduNum,
-                                                                 boolean allMatchingHDUs, Extractor extractor)
-            throws FitsException, IOException {
-        Fits fits = null;
-        try {
-            fits = new Fits(fitsFile);
-            BasicHDU<?>[] hdus = readHDUs(fits);
-            BasicHDU<?> hdu = hdus[refHduNum];
-            validateImageAtHDU(hdus, refHduNum);
-            Header refHeader = hdu.getHeader();
-            int dims = getNaxis(refHeader);
-            int xLen = getNaxis1(refHeader);
-            int yLen = getNaxis2(refHeader);
-            int zLen = getNaxis3(refHeader);
-            List<ExtractionResults> retList = new ArrayList<>();
-
-            if (allMatchingHDUs) {
-                for (int i = 0; (i < hdus.length); i++) {
-                    Header h = hdus[i].getHeader();
-                    if (getNaxis(h) == dims && getNaxis1(h) == xLen && getNaxis2(h) == yLen && getNaxis3(h) == zLen) {
-                        double[] ary = extractor.extractAry(hdus, i);
-                        retList.add(new ExtractionResults(i, getExtName(h), ary, i == refHduNum, h));
-                    }
-                }
-            } else {
-                double[] ary = extractor.extractAry(hdus, refHduNum);
-                retList.add(new ExtractionResults(refHduNum, getExtName(refHeader), ary, true, refHeader));
-            }
-            return retList;
-        } finally {
-            closeFits(fits);
-        }
-    }
-
-    public static double[] extractFromHDU(File fitsFile, int hduNum, Extractor extractor)
-            throws FitsException, IOException {
-        Fits fits= null;
-        try {
-            fits = new Fits(fitsFile);
-            return extractor.extractAry(readHDUs(fits), hduNum);
-        }
-        finally {
-            closeFits(fits);
-        }
-    }
-
-    public static List<ExtractionResults> getAllPointsFromRelatedHDUs(ImagePt[] ptAry, File fitsFile,
-                                                                      int refHduNum, int plane,
-                                                                      boolean allMatchingHDUs, int ptSize)
-            throws FitsException, IOException {
-        return extractFromRelatedHDUs(fitsFile, refHduNum, allMatchingHDUs,
-                (hdus, hduNum) -> getPointDataAry(ptAry, plane, hdus, hduNum, ptSize));
-    }
-
-    public static List<ExtractionResults> getAllLinesFromRelatedHDUs(ImagePt pt, ImagePt pt2, File fitsFile,
-                                                                     int refHduNum, int plane,
-                                                                     boolean allMatchingHDUs, int ptSize)
-            throws FitsException, IOException {
-        return extractFromRelatedHDUs(fitsFile, refHduNum, allMatchingHDUs,
-                (hdus, hduNum) -> getLineDataAry(pt, pt2, plane, hdus, hduNum, ptSize));
-    }
-
-    public static List<ExtractionResults> getAllZAxisAryFromRelatedCubes(ImagePt pt, File fitsFile, int refHduNum,
-                                                                         boolean allMatchingHDUs, int ptSize)
-            throws FitsException, IOException {
-        return extractFromRelatedHDUs(fitsFile, refHduNum, allMatchingHDUs,
-                (hdus,hduNum) -> getZAxisAry(pt,hdus,hduNum,ptSize) );
-    }
-
-    public static double[] getPointDataAryFromFile(ImagePt[] ptAry, int plane, File fitsFile, int hduNum, int ptSize)
-            throws FitsException, IOException {
-        return extractFromHDU(fitsFile,hduNum, (hdus,num) -> getPointDataAry(ptAry,plane, hdus,num,ptSize));
-    }
-
-    public static double[] getLineDataAryFromFile(ImagePt pt, ImagePt pt2, int plane, File fitsFile, int hduNum, int ptSize)
-            throws FitsException, IOException {
-        return extractFromHDU(fitsFile,hduNum, (hdus,num) -> getLineDataAry(pt,pt2,plane, hdus,num,ptSize));
-    }
-
-    public static double[] getZAxisAryFromCube(ImagePt pt, File fitsFile, int hduNum, int ptSize)
-            throws FitsException, IOException {
-        return extractFromHDU(fitsFile,hduNum, (hdus,num) -> getZAxisAry(pt,hdus,num,ptSize));
-    }
-
-
-
-    private static double valueFromFitsFile(ImageHDU hdu, int x, int y, int plane, int ptSize) throws IOException {
-        Header header= hdu.getHeader();
-        int naxis1= getNaxis1(header);
-        int naxis2= getNaxis2(header);
-        if (ptSize<1) ptSize= 1;
-        else if (ptSize>5) ptSize= 5;
-        int adjust= (int)Math.floor((ptSize-1) / 2.0);
-        x= x - adjust;
-        y= y - adjust;
-        if (x<0) x= 0;
-        if (y<0) y= 0;
-        if (x+ptSize>=naxis1) x-= (x+ptSize-naxis1+1);
-        if (y+ptSize>=naxis2) y-= (y+ptSize-naxis2+1);
-        double[] doubleAry= (double[]) dataArrayFromFitsFile(hdu,x,y,ptSize,ptSize,plane,true);
-        double aveValue= averageArray(doubleAry);
-        return ImageStretch.getFluxStandard( aveValue, getBlankValue(header), getBscale(header), getBzero(header));
-    }
-
     /**
      *
-     * @param doDouble true for double array, false for float ary
      * @return an Object that will be a double array or an float array
      */
-    public static Object dataArrayFromFitsFile(ImageHDU hdu, int x, int y, int width, int height, int plane, boolean doDouble) throws IOException {
+    public static Object dataArrayFromFitsFile(ImageHDU hdu, int x, int y, int width, int height, int plane, Class<?> arrayType) throws IOException {
         Header header= hdu.getHeader();
         int naxis= getNaxis(header);
         if (naxis==4 && getNaxis4(header)!=1) throw new IllegalArgumentException("naxis 4 must has naxis 4 as dimension 1");
@@ -689,113 +565,9 @@ public class FitsReadUtil {
                 break;
         }
         Object value= tiler.getTile(loc, tileSize);
-        return ArrayFuncs.convertArray(value, doDouble ? Double.TYPE : Float.TYPE, true);
+        return ArrayFuncs.convertArray(value, arrayType, true);
     }
 
-
-    public static double[] getZAxisAry(ImagePt pt, BasicHDU<?>[] hdus, int hduNum, int ptSize)
-            throws FitsException, IOException {
-        validateCubeAtHDU(hdus,hduNum);
-        ImageHDU hdu= getImageHDU(hdus,hduNum);
-        Header header= hdu.getHeader();
-        int zLen= getNaxis3(header);
-        double[] retAry= new double[zLen];
-        for(int i=0;i<zLen; i++) {
-            retAry[i]=valueFromFitsFile(hdu,(int)pt.getX(), (int)pt.getY(),i,ptSize);
-        }
-        return retAry;
-    }
-
-    private static ImageHDU getImageHDU(BasicHDU<?>[] hdus, int idx) throws FitsException {
-        if ( !(hdus[idx] instanceof ImageHDU) && !(hdus[idx] instanceof CompressedImageHDU) ) {
-            throw new FitsException(idx + " is not a cube");
-        }
-        return (hdus[idx] instanceof CompressedImageHDU) ?
-                        ((CompressedImageHDU) hdus[idx]).asImageHDU() : (ImageHDU) hdus[idx];
-    }
-
-    private static void validateCubeAtHDU(BasicHDU<?>[] hdus, int hduNum) throws FitsException {
-        validateImageAtHDU(hdus,hduNum);
-        BasicHDU<?> basicHDU= hdus[hduNum];
-        Header header= basicHDU.getHeader();
-        String hduNumStr= "HDU #"+hduNum;
-        int nAxis= getNaxis(header);
-        if (nAxis<3) throw new FitsException(hduNumStr + " is not a cube");
-        if (nAxis==4 && getNaxis4(header)!=1) throw new FitsException(hduNumStr + " is not a cube, 4 axes");
-    }
-
-    private static void validateImageAtHDU(BasicHDU<?>[] hdus, int hduNum) throws FitsException {
-        String hduNumStr= "HDU #"+hduNum;
-        if (hduNum>=hdus.length) throw new FitsException("no "+hduNumStr);
-        BasicHDU<?> basicHDU= hdus[hduNum];
-        if ( !(basicHDU instanceof ImageHDU) && !(basicHDU instanceof CompressedImageHDU) ) {
-            throw new FitsException(hduNumStr+ " is not a image HDU");
-        }
-    }
-
-
-    public static double[] getPointDataAry(ImagePt[] ptAry, int plane, BasicHDU<?>[] hdus, int hduNum, int ptSize)
-            throws FitsException, IOException {
-        ImageHDU hdu= getImageHDU(hdus,hduNum);
-        double[] pts= new double[ptAry.length];
-        for(int i=0;(i<ptAry.length);i++) {
-            ImagePt pt= ptAry[i];
-            pts[i] = valueFromFitsFile(hdu, (int)pt.getX(),(int)pt.getY(),plane,ptSize);
-        }
-        return pts;
-    }
-
-
-
-    public static double[] getLineDataAry(ImagePt pt1, ImagePt pt2, int plane, BasicHDU<?>[] hdus, int hduNum, int ptSize)
-            throws FitsException, IOException {
-        ImageHDU hdu= getImageHDU(hdus,hduNum);
-        double x1 = pt1.getX();
-        double y1 = pt1.getY();
-        double x2 = pt2.getX();
-        double y2 = pt2.getY();
-
-        // delta X and Y in image pixels
-        double deltaX = Math.abs(pt2.getX() - pt1.getX());
-        double deltaY = Math.abs(pt2.getY() - pt1.getY());
-        double slope;
-        double yIntercept;
-
-        int x, y;
-        if (deltaX > deltaY) {
-            slope = (y2-y1)/(x2-x1);
-            yIntercept = y1-slope*x1;
-
-            int minX = (int)Math.min(x1, x2);
-            int maxX = (int)Math.max(x1, x2) ;
-            int n = (int)Math.rint(Math.ceil(maxX-minX))+1;
-            double [] pts = new double[n];
-            int idx = 0;
-            for (x=minX; x<=maxX; x+=1) {
-                y = (int)(slope*x + yIntercept);
-                pts[idx] = valueFromFitsFile(hdu, x,y,plane,ptSize);
-                idx++;
-            }
-            return pts;
-        } else if (y1 != y2) {
-            double  islope = (x2-x1)/(y2-y1);
-            double xIntercept = x1-islope*y1;
-
-            int minY = (int)Math.min(y1, y2);
-            int maxY = (int)Math.max(y1, y2);
-            int n = (int)Math.rint(Math.ceil(maxY - minY))+1;
-            double [] pts = new double[n];
-
-            int idx = 0;
-            for (y=minY; y<=maxY; y+=1) {
-                x = (int)(islope*y + xIntercept);
-                pts[idx] = valueFromFitsFile(hdu, x,y,plane,ptSize);
-                idx++;
-            }
-            return pts;
-        }
-        return null;
-    }
 
     public static Class<?> getDataType(int bitPix){
         return switch (bitPix) {
@@ -810,5 +582,4 @@ public class FitsReadUtil {
     }
 
 
-    public record ExtractionResults(int hduNum, String extName, double[] aryData, boolean refHDU, Header header) { }
 }

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -159,6 +159,7 @@ export const ServerParams = {
         TILE_SIZE: 'tileSize',
         DATA_COMPRESS: 'dataCompress',
         POINT_SIZE: 'pointSize',
+        COMBINE_OP: 'combineOp',
         EXTRACTION_TYPE: 'extractionType',
         HDU_NUM: 'hduNum',
         RELATED_HDUS: 'relatedHDUs',

--- a/src/firefly/js/rpc/PlotServicesJson.js
+++ b/src/firefly/js/rpc/PlotServicesJson.js
@@ -12,7 +12,7 @@ import {doJsonRequest} from '../core/JsonUtils.js';
 import {SelectedShape} from '../drawingLayers/SelectedShape';
 import {getCmdSrvSyncURL} from 'firefly/util/WebUtil.js';
 import {fetchUrl} from 'firefly/api/ApiUtil.js';
-import {getNumberHeader, HdrConst} from 'firefly/visualize/FitsHeaderUtil.js';
+import {getBixPix, getNumberHeader, HdrConst} from 'firefly/visualize/FitsHeaderUtil.js';
 
 
 /**
@@ -81,7 +81,7 @@ export function callGetFileFlux(stateAry, pt) {
 }
 
 async function fetchExtraction(plot, inParams, cmd= ServerParams.FITS_EXTRACTION) {
-    const use64Bit= getNumberHeader(plot,HdrConst.BITPIX,-64)===-64;
+    const use64Bit= getBixPix(plot)===-64;
     const params= {...inParams, [ServerParams.EXTRACTION_FLOAT_SIZE]: use64Bit ? 64 : 32};
     const response= await fetchUrl(getCmdSrvSyncURL()+`?${ServerParams.COMMAND}=${cmd}`,{method:'POST', params },false);
     if (!response.ok) {
@@ -91,19 +91,20 @@ async function fetchExtraction(plot, inParams, cmd= ServerParams.FITS_EXTRACTION
     return use64Bit ? new Float64Array(arrayBuffer) : new Float32Array(arrayBuffer);
 }
 
-export async function callGetCubeDrillDownAry(plot, hduNum, pt, ptSize, relatedCubes) {
+export async function callGetCubeDrillDownAry(plot, hduNum, pt, ptSize, combineOp, relatedCubes) {
     return fetchExtraction(plot,
         {
             [ServerParams.EXTRACTION_TYPE]: 'z-axis',
             [ServerParams.STATE]: plot.plotState.toJson(false),
             [ServerParams.PT] : pt.toString(),
             [ServerParams.POINT_SIZE] : ptSize+'',
+            [ServerParams.COMBINE_OP] : combineOp,
             [ServerParams.HDU_NUM] : hduNum+'',
             [ServerParams.RELATED_HDUS] : relatedCubes+'',
         });
 }
 
-export async function callGetLineExtractionAry(plot, hduNum, plane, pt, pt2, ptSize, relatedHDUS) {
+export async function callGetLineExtractionAry(plot, hduNum, plane, pt, pt2, ptSize, combineOp, relatedHDUS) {
     return fetchExtraction(plot,
         {
             [ServerParams.EXTRACTION_TYPE]: 'line',
@@ -111,19 +112,21 @@ export async function callGetLineExtractionAry(plot, hduNum, plane, pt, pt2, ptS
             [ServerParams.PT] : pt.toString(),
             [ServerParams.PT2] : pt2.toString(),
             [ServerParams.POINT_SIZE] : ptSize+'',
+            [ServerParams.COMBINE_OP] : combineOp,
             [ServerParams.PLANE] : plane+'',
             [ServerParams.HDU_NUM] : hduNum+'',
             [ServerParams.RELATED_HDUS] : relatedHDUS+'',
         });
 }
 
-export async function callGetPointExtractionAry(plot, hduNum, plane, ptAry, ptSize, relatedHDUS) {
+export async function callGetPointExtractionAry(plot, hduNum, plane, ptAry, ptSize, combineOp, relatedHDUS) {
     return fetchExtraction(plot,
         {
             [ServerParams.EXTRACTION_TYPE]: 'points',
             [ServerParams.STATE]: plot.plotState.toJson(false),
             [ServerParams.PTARY] : JSON.stringify(ptAry.map( (pt) => pt.toString())),
             [ServerParams.POINT_SIZE] : ptSize+'',
+            [ServerParams.COMBINE_OP] : combineOp,
             [ServerParams.PLANE] : plane+'',
             [ServerParams.HDU_NUM] : hduNum+'',
             [ServerParams.RELATED_HDUS] : relatedHDUS+'',

--- a/src/firefly/js/visualize/FitsHeaderUtil.js
+++ b/src/firefly/js/visualize/FitsHeaderUtil.js
@@ -23,6 +23,7 @@ export const HdrConst= {
     CTYPE3   : 'CTYPE3',
     BITPIX   : 'BITPIX',
     BSCALE   : 'BSCALE',
+    BZERO    : 'BZERO',
     CRPIX1   : 'CRPIX1',
     CRPIX2   : 'CRPIX2',
     CRVAL1   : 'CRVAL1',
@@ -220,8 +221,15 @@ export function getAllValuesOfHeader(plotOrHeader, headerKey) {
  * @return {string}
  */
 export const getExtName= (plotOrHeader) => getHeader(plotOrHeader,HdrConst.EXTNAME,'');
-
 export const getExtType= (plotOrHeader) => getHeader(plotOrHeader,HdrConst.EXTTYPE,'');
+export const getBixPix= (plotOrHeader) => getNumberHeader(plotOrHeader,HdrConst.BITPIX,-32);
+export const getBScale= (plotOrHeader) => getNumberHeader(plotOrHeader,HdrConst.BSCALE,1);
+export const getBZero= (plotOrHeader) => getNumberHeader(plotOrHeader,HdrConst.BZERO,0);
+
+export function hasFloatingData(plotOrHeader) {
+    const bitpix= getBixPix(plotOrHeader);
+    return bitpix===-64 || bitpix===-32;
+}
 
 /**
  * return a header number value given a header key

--- a/src/firefly/js/visualize/saga/MouseReadoutWatch.js
+++ b/src/firefly/js/visualize/saga/MouseReadoutWatch.js
@@ -18,7 +18,7 @@ import {
     primePlot, getPlotStateAry, getPlotViewById, getImageCubeIdx, getPtWavelength,
     getWavelengthParseFailReason, getWaveLengthUnits, hasPixelLevelWLInfo, hasPlaneOnlyWLInfo,
     isImageCube, wavelengthInfoParsedSuccessfully, } from '../PlotViewUtil';
-import {getNumberHeader, HdrConst} from '../FitsHeaderUtil.js';
+import {getBixPix, getBScale, getNumberHeader, HdrConst} from '../FitsHeaderUtil.js';
 
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -244,8 +244,8 @@ function makeImagePlotAsyncReadout(plotView, worldPt, screenPt, imagePt, threeCo
 function isFluxInt(plot,band) {
     const h= plot.headerAry[band.value];
     if (!h) return false;
-    const bp= getNumberHeader(h,HdrConst.BITPIX);
-    const bscale= getNumberHeader(h,HdrConst.BSCALE);
+    const bp= getBixPix(h);
+    const bscale= getBScale(h);
     if (isNaN(bscale)) return false;
     return (bp>0) && Number.isInteger(bscale);
 }

--- a/src/firefly/js/visualize/ui/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/ExtractionDialog.jsx
@@ -442,7 +442,7 @@ function ZAxisExtractionPanel({canCreateExtractionTable, pv}) {
     );
 }
 
-const pointSizeTip= 'Extract the average pixel values in the specifed aperture centered on the pixel closest to where you clicked.';
+const pointSizeTip= 'Extract and manipulate the pixel values in the specified aperture centered on the pixel closest to where you clicked.';
 
 function ExtractionPanelView({pointSize, setPointSize, afterRedraw, plotlyDivStyle,
                                  plotlyData, canCreateExtractionTable,
@@ -455,14 +455,12 @@ function ExtractionPanelView({pointSize, setPointSize, afterRedraw, plotlyDivSty
             <div style={{
                 display:'flex', flexDirection:'row', height: 30, maxHeight:30}}>
                 <div style={{margin: '2px 0 10px 0'}}>
-                    <span title={pointSizeTip}>
-                        Aperture (Values will be combined)</span>
+                    <span title={pointSizeTip}> Aperture (Values will be combined)</span>
                     <ListBoxInputFieldView
                         inline={true} value={pointSize} onChange={(ev) => setPointSize(ev.target.value)}
                         labelWidth={10} label={' '} tooltip={ pointSizeTip} options={sizeOp} multiple={false} />
                 </div>
                 <div style={{margin: '2px 0 10px 0', width:'8em'}}>
-                    {/*<span title={pointSizeTip}> Combine Type</span>*/}
                     {pointSize>1 && <ListBoxInputFieldView
                         inline={true} value={combineOp} onChange={(ev) => setCombineOp(ev.target.value)}
                         labelWidth={10} label={' '} tooltip={pointSizeTip}

--- a/src/firefly/js/visualize/ui/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/ExtractionDialog.jsx
@@ -27,7 +27,7 @@ import {CCUtil, CysConverter} from 'firefly/visualize/CsysConverter.js';
 import {ListBoxInputFieldView} from 'firefly/ui/ListBoxInputField.jsx';
 import {callGetCubeDrillDownAry, callGetPointExtractionAry } from 'firefly/rpc/PlotServicesJson.js';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
-import {getExtName} from 'firefly/visualize/FitsHeaderUtil.js';
+import {getExtName, hasFloatingData} from 'firefly/visualize/FitsHeaderUtil.js';
 import {dispatchTableFetch, dispatchTableSearch} from 'firefly/tables/TablesCntlr.js';
 import {makeTblRequest} from 'firefly/tables/TableRequestUtil.js';
 import ExtractLineTool from 'firefly/drawingLayers/ExtractLineTool.js';
@@ -45,7 +45,7 @@ import {getFluxUnits} from 'firefly/visualize/WebPlot.js';
 import {Band} from 'firefly/visualize/Band.js';
 import {onTableLoaded} from 'firefly/tables/TableUtil.js';
 import {showTableDownloadDialog} from 'firefly/tables/ui/TableSave.jsx';
-import {getAppOptions} from 'firefly/api/ApiUtil.js';
+import {getAppOptions, ServerParams} from 'firefly/api/ApiUtil.js';
 import {showInfoPopup, showPinMessage} from 'firefly/ui/PopupUtil.jsx';
 import {MetaConst} from 'firefly/data/MetaConst.js';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from 'firefly/core/MasterSaga.js';
@@ -143,6 +143,17 @@ function getStoreState(prevResult) {
 const sizeOp=[];
 for(let i= 1; i<=7;i+=2) sizeOp.push({label:`${i}x${i}`, value:i});
 
+const AVG= 'AVG';
+const combineOps= [
+    {label: 'Average', value: AVG},
+    {label: 'Sum', value: 'SUM'}
+];
+const combineIntOps= [
+    ...combineOps,
+    {label: 'Logical OR', value: 'OR'}
+];
+
+
 function afterZAxisChartRedraw(imPt, pv, chart) {
     chart.on('plotly_click', (ev) => {
         setTimeout( () => {
@@ -224,6 +235,7 @@ function makeLineExtractionTitle(pv,x1,y1,x2,y2) {
 function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     const [{plotlyDivStyle, plotlyData, plotlyLayout},setChartParams]= useState({});
     const [pointSize,setPointSize]= useState(1);
+    const [combineOp,setCombineOp]= useState(AVG);
     const [allRelatedHDUS,setAllRelatedHDUS]= useState(true);
     const [chartXAxis,setChartXAxis]= useState('imageX');
     const plot= primePlot(pv);
@@ -249,7 +261,7 @@ function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     useEffect(() => {
         const getData= async () => {
             if (imPtAry && imPtAry.length && plot) {
-                const dataAry= await callGetPointExtractionAry(plot, hduNum, plane, imPtAry, pointSize, allRelatedHDUS);
+                const dataAry= await callGetPointExtractionAry(plot, hduNum, plane, imPtAry, pointSize, combineOp, allRelatedHDUS);
                 const chartTitle= 'Point Extract Preview';
                 let activeIdx= 0;
                 const key= lastChartChartXAxis==='imageX' ? 'x' : 'y';
@@ -259,18 +271,19 @@ function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
                 }
                 const chartData=
                     genPointChartData(plot, dataAry,imPtAry, imPtAry[activeIdx][key], dataAry[activeIdx],
-                        pointSize,chartTitle, chartXAxis, activeIdx);
+                        pointSize,combineOp, chartTitle, chartXAxis, activeIdx);
                 setChartParams(chartData);
             }
             // if (!pv) cancelPointExtraction();
         };
         getData();
-    },[ptAry.length,hduNum,plotId,plotImageId,pointSize,chartX,chartY,chartXAxis]);
+    },[ptAry.length,hduNum,plotId,plotImageId,pointSize,combineOp,chartX,chartY,chartXAxis]);
 
     return (
         <ExtractionPanelView {...{
-            allRelatedHDUS, setAllRelatedHDUS, pointSize, setPointSize,
+            allRelatedHDUS, setAllRelatedHDUS, pointSize, setPointSize, combineOp, setCombineOp,
             plotlyDivStyle, plotlyData, plotlyLayout, canCreateExtractionTable,
+            hasFloatingData:hasFloatingData(plot),
             startUpHelp: (
                 <div>
                     <div> Click on an image to extract a point, continue clicking to extract more points. </div>
@@ -278,7 +291,10 @@ function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
                 </div>
             ),
             afterRedraw: (chart,pl) => afterPointsChartRedraw(pv,chart,pl,chartXAxis, imPtAry),
-            callKeepExtraction: (download, doOverlay) => keepPointsExtraction(imPtAry, pv, plot, plot.plotState.getWorkingFitsFileStr(), hduNum, plane, pointSize,download, doOverlay),
+            callKeepExtraction: (download, doOverlay) =>
+                keepPointsExtraction(imPtAry, pv, plot,
+                    plot.plotState.getWorkingFitsFileStr(), hduNum, plane,
+                    pointSize,combineOp, download, doOverlay),
         }} /> );
 }
 
@@ -288,6 +304,7 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     const [{plotlyDivStyle, plotlyData, plotlyLayout},setChartParams]= useState({});
     const [imPtAry,setImPtAry]= useState(undefined);
     const [pointSize,setPointSize]= useState(1);
+    const [combineOp,setCombineOp]= useState(AVG);
     const [allRelatedHDUS,setAllRelatedHDUS]= useState(true);
     const plot= primePlot(pv);
     const {pt0:pt1,pt1:pt2}=plot?.attributes?.[PlotAttribute.ACTIVE_DISTANCE] ?? {};
@@ -318,14 +335,14 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
                 }
                 const cc= CysConverter.make(plot);
 
-                const dataAry= await callGetPointExtractionAry(plot, hduNum, plane, newImPtAry, pointSize, allRelatedHDUS);
+                const dataAry= await callGetPointExtractionAry(plot, hduNum, plane, newImPtAry, pointSize, combineOp, allRelatedHDUS);
                 const chartTitle= makeLineExtractionTitle(pv,x1,y1,x2,y2);
                 const pt0= hasWCSProjection(plot) ? cc.getWorldCoords(newImPtAry[0]) : newImPtAry[0];
                 const xOffAry= hasWCSProjection(plot) ?
                     newImPtAry.map( (pt) => computeDistance(pt0,cc.getWorldCoords(pt))*3600) :
                     newImPtAry.map( (pt) => computeScreenDistance(pt0.x,pt0.y,pt.x,pt.y));
                 const chartData=
-                    genSliceChartData(plot, ipt1,ipt2,xOffAry, dataAry, chartX, chartY, pointSize, chartTitle, direction<0);
+                    genSliceChartData(plot, ipt1,ipt2,xOffAry, dataAry, chartX, chartY, pointSize, combineOp, chartTitle, direction<0);
                 ReactDOM.unstable_batchedUpdates( () => {
                         setChartParams(chartData);
                         setImPtAry(newImPtAry);
@@ -334,12 +351,12 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
             if (!pv) cancelLineExtraction();
         };
         if (extractionData) getData();
-    },[x1,y1,x2,y2,hduNum,plotId,plotImageId,pointSize,chartX,chartY]);
+    },[x1,y1,x2,y2,hduNum,plotId,plotImageId,pointSize,combineOp,chartX,chartY]);
 
     return (
         <ExtractionPanelView {...{
-            allRelatedHDUS, setAllRelatedHDUS, pointSize, setPointSize, canCreateExtractionTable,
-            plotlyDivStyle, plotlyData: extractionData&&plotlyData, plotlyLayout,
+            allRelatedHDUS, setAllRelatedHDUS, pointSize, setPointSize, combineOp, setCombineOp, canCreateExtractionTable,
+            plotlyDivStyle, plotlyData: extractionData&&plotlyData, plotlyLayout, hasFloatingData:hasFloatingData(plot),
             startUpHelp: (
                 <div>
                     <div> Draw line on image to extract point on line and show chart. </div>
@@ -347,7 +364,9 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
                 </div>
             ),
             afterRedraw: (chart,pl) => afterLineChartRedraw(pv,chart,pl,imPtAry,makeImagePt(x1,y1), makeImagePt(x2,y2)),
-            callKeepExtraction: (download, doOverlay) => keepLineExtraction(ipt1,ipt2, pv, plot, plot.plotState.getWorkingFitsFileStr(), hduNum, plane, pointSize, download, doOverlay),
+            callKeepExtraction: (download, doOverlay) =>
+                keepLineExtraction(ipt1,ipt2, pv, plot, plot.plotState.getWorkingFitsFileStr(),
+                    hduNum, plane, pointSize, combineOp, download, doOverlay),
         }} /> );
 }
 
@@ -379,6 +398,7 @@ function usingXAxis(pt1,pt2) {
 function ZAxisExtractionPanel({canCreateExtractionTable, pv}) {
     const [pointSize,setPointSize]= useState(1);
     const [allRelatedHDUS,setAllRelatedHDUS]= useState(true);
+    const [combineOp,setCombineOp]= useState(AVG);
     const [{plotlyDivStyle, plotlyData, plotlyLayout},setChartParams]= useState({});
     const plot= primePlot(pv);
     const {pt}=plot?.attributes?.[PlotAttribute.ACTIVE_POINT] ?? {};
@@ -396,43 +416,59 @@ function ZAxisExtractionPanel({canCreateExtractionTable, pv}) {
                     setChartParams({});
                     return;
                 }
-                const dataAry = await callGetCubeDrillDownAry(plot, hduNum, ipt, pointSize, allRelatedHDUS);
+                const dataAry = await callGetCubeDrillDownAry(plot, hduNum, ipt, pointSize, combineOp, allRelatedHDUS);
                 const plane=getImageCubeIdx(plot);
                 const chartTitle= `Z Axis Preview - ${extName?extName+',':''} HDU #${hduNum}, Point: (${x},${y})`;
-                setChartParams(genZAxisChartData(makeImagePt(x,y), pv, dataAry, plane , dataAry[plane] , pointSize, chartTitle));
+                setChartParams(genZAxisChartData(makeImagePt(x,y), pv, dataAry, plane , dataAry[plane] , pointSize, combineOp, chartTitle));
             }
             // if (!pv) cancelZaxisExtraction();
         };
         void updateChart();
-    },[x,y,hduNum,plotId,pointSize,plotImageId]);
+    },[x,y,hduNum,plotId,pointSize,combineOp,plotImageId]);
 
     return (
         <ExtractionPanelView {...{
-            allRelatedHDUS, setAllRelatedHDUS, pointSize, setPointSize,
+            allRelatedHDUS, setAllRelatedHDUS, pointSize, setPointSize, combineOp, setCombineOp,
+            hasFloatingData:hasFloatingData(plot),
             plotlyDivStyle, plotlyData, plotlyLayout, canCreateExtractionTable,
             startUpHelp: isImageCube(plot) ?
                 'Click on a pixel to extract data from all planes of the cube' :
                 'Please choose a cube to extract z-axis data',
             afterRedraw: (chart,pl) => afterZAxisChartRedraw(makeImagePt(x,y), pv,chart,pl),
-            callKeepExtraction: (download, doOverlay) => keepZAxisExtraction(makeImagePt(x,y), pv, plot, plot?.plotState.getWorkingFitsFileStr(), hduNum, pointSize, download,doOverlay),
+            callKeepExtraction: (download, doOverlay) =>
+                keepZAxisExtraction(makeImagePt(x,y), pv, plot, plot?.plotState.getWorkingFitsFileStr(),
+                    hduNum, pointSize, combineOp, download,doOverlay),
         }} />
     );
 }
 
 const pointSizeTip= 'Extract the average pixel values in the specifed aperture centered on the pixel closest to where you clicked.';
 
-function ExtractionPanelView({pointSize, setPointSize, afterRedraw, plotlyDivStyle, plotlyData, canCreateExtractionTable,
-                                 plotlyLayout, startUpHelp, callKeepExtraction, bottomUI}) {
+function ExtractionPanelView({pointSize, setPointSize, afterRedraw, plotlyDivStyle,
+                                 plotlyData, canCreateExtractionTable,
+                                 plotlyLayout, startUpHelp, callKeepExtraction,
+                                 bottomUI, combineOp, setCombineOp, hasFloatingData}) {
     return (
         <div style={{
             padding: 3, display:'flex', flexDirection:'column',
             alignItems:'center', resize:'both', overflow: 'hidden', zIndex:1}}>
-            <div style={{margin: '2px 0 10px 0'}}>
-                <span title={pointSizeTip}>
-                    Aperture (Values will be averaged)</span>
-                <ListBoxInputFieldView
-                    inline={true} value={pointSize} onChange={(ev) => setPointSize(ev.target.value)}
-                    labelWidth={10} label={' '} tooltip={ pointSizeTip} options={sizeOp} multiple={false} />
+            <div style={{
+                display:'flex', flexDirection:'row', height: 30, maxHeight:30}}>
+                <div style={{margin: '2px 0 10px 0'}}>
+                    <span title={pointSizeTip}>
+                        Aperture (Values will be combined)</span>
+                    <ListBoxInputFieldView
+                        inline={true} value={pointSize} onChange={(ev) => setPointSize(ev.target.value)}
+                        labelWidth={10} label={' '} tooltip={ pointSizeTip} options={sizeOp} multiple={false} />
+                </div>
+                <div style={{margin: '2px 0 10px 0', width:'8em'}}>
+                    {/*<span title={pointSizeTip}> Combine Type</span>*/}
+                    {pointSize>1 && <ListBoxInputFieldView
+                        inline={true} value={combineOp} onChange={(ev) => setCombineOp(ev.target.value)}
+                        labelWidth={10} label={' '} tooltip={pointSizeTip}
+                        options={hasFloatingData?combineOps:combineIntOps}
+                        multiple={false} />}
+                </div>
             </div>
             <div style={{minWidth:440, minHeight:200, width:'100%', height:'100%',
                 flex: '1 1 auto', boxSizing: 'border-box',
@@ -520,7 +556,7 @@ function doDispatchTable(req, doOverlay) {
 
 let titleCnt= 1;
 
-function keepZAxisExtraction(pt,pv, plot, filename,refHDUNum,extractionSize, save=false, doOverlay=true) {
+function keepZAxisExtraction(pt,pv, plot, filename,refHDUNum,extractionSize, combineOp, save=false, doOverlay=true) {
     if (!pv || !plot  || !filename) {
         showInfoPopup('Plot no longer exist. Cannot extract.');
         return;
@@ -545,6 +581,7 @@ function keepZAxisExtraction(pt,pv, plot, filename,refHDUNum,extractionSize, sav
             filename,
             refHDUNum,
             extractionSize,
+            [ServerParams.COMBINE_OP]: combineOp,
             allMatchingHDUs: true,
         },
         {tbl_id});
@@ -554,7 +591,7 @@ function keepZAxisExtraction(pt,pv, plot, filename,refHDUNum,extractionSize, sav
     titleCnt++;
 }
 
-function keepLineExtraction(pt, pt2,pv, plot, filename,refHDUNum,plane,extractionSize,save=false,doOverlay=true) {
+function keepLineExtraction(pt, pt2,pv, plot, filename,refHDUNum,plane,extractionSize, combineOp, save=false,doOverlay=true) {
     if (!pv || !plot  || !filename) {
         showInfoPopup('Plot no longer exist. Cannot extract.');
         return;
@@ -574,6 +611,7 @@ function keepLineExtraction(pt, pt2,pv, plot, filename,refHDUNum,plane,extractio
             refHDUNum,
             plane,
             extractionSize,
+            [ServerParams.COMBINE_OP]: combineOp,
             allMatchingHDUs: true,
         },
         {tbl_id});
@@ -593,7 +631,7 @@ function makePlaneTitle(rootStr, pv,plot,cnt) {
     return `${rootStr} ${cnt}${hduStr}${cubeStr}`;
 }
 
-function keepPointsExtraction(ptAry,pv, plot, filename,refHDUNum,plane,extractionSize,save=false,doOverlay=true) {
+function keepPointsExtraction(ptAry,pv, plot, filename,refHDUNum,plane,extractionSize, combineOp, save=false,doOverlay=true) {
     if (!pv || !plot  || !filename) {
         showInfoPopup('Plot no longer exist. Cannot extract.');
         return;
@@ -614,6 +652,7 @@ function keepPointsExtraction(ptAry,pv, plot, filename,refHDUNum,plane,extractio
             refHDUNum,
             plane,
             extractionSize,
+            [ServerParams.COMBINE_OP]: combineOp,
             allMatchingHDUs: true,
         },
         {tbl_id});
@@ -679,7 +718,7 @@ function makePlotlyDataObj(xDataAry, yDataAry,x,y,ttXStr,ttYStr, makeXDesc= (i)=
 }
 
 
-function genSliceChartData(plot, ipt1,ipt2, xDataAry,yDataAry,x,y, pointSize, title, reversed) {
+function genSliceChartData(plot, ipt1,ipt2, xDataAry,yDataAry,x,y, pointSize, combineOp, title, reversed) {
     const unitStr= hasWCSProjection(plot) ? ' (arcsec)' : '';
     const yUnits= getFluxUnits(plot,Band.NO_BAND);
     const yAxisLabel= getExtName(plot) || 'HDU# '+getHDU(plot);
@@ -687,11 +726,11 @@ function genSliceChartData(plot, ipt1,ipt2, xDataAry,yDataAry,x,y, pointSize, ti
         plotlyDivStyle,
         plotlyData: makePlotlyDataObj(xDataAry, yDataAry, x, y, 'Offset'+unitStr, yAxisLabel),
         plotlyLayout: makePlotlyLayoutObj(title, 'Offset'+unitStr,
-            `${yAxisLabel} (${yUnits})${pointSize > 1 ? ` (${pointSize}x${pointSize} avg)` : ''}`, reversed),
+            `${yAxisLabel} (${yUnits})${pointSize > 1 ? ` (${pointSize}x${pointSize} ${combineOp.toLowerCase()})` : ''}`, reversed),
     };
 }
 
-function genPointChartData(plot, dataAry,imPtAry, x,y, pointSize, title, chartXAxis, activeIdx) {
+function genPointChartData(plot, dataAry,imPtAry, x,y, pointSize, combineOp, title, chartXAxis, activeIdx) {
 
     const xAxis= chartXAxis==='imageX' ? imPtAry.map( (pt) => pt.x) : imPtAry.map( (pt) => pt.y);
     const xAxisTitle= chartXAxis==='imageX' ? 'Image X': 'Image Y';
@@ -703,13 +742,13 @@ function genPointChartData(plot, dataAry,imPtAry, x,y, pointSize, title, chartXA
         plotlyDivStyle,
         plotlyData: makePlotlyDataObj(xAxis, dataAry, x, y, xAxisTitle, yAxisLabel,
           xLabel , xLabel(activeIdx)),
-        plotlyLayout: makePlotlyLayoutObj(title, xAxisTitle, `${yAxisLabel} (${yUnits})${pointSize > 1 ? ` (${pointSize}x${pointSize} avg)` : ''}`),
+        plotlyLayout: makePlotlyLayoutObj(title, xAxisTitle, `${yAxisLabel} (${yUnits})${pointSize > 1 ? ` (${pointSize}x${pointSize} ${combineOp.toLowerCase()})` : ''}`),
     };
 }
 
 
 
-function genZAxisChartData(imPt, pv, dataAry,x,y, pointSize, title) {
+function genZAxisChartData(imPt, pv, dataAry,x,y, pointSize, combineOp, title) {
     const plot= primePlot(pv);
     const hasWL= hasWLInfo(plot);
     const xAry= hasWL ? getAllWaveLengthsForCube(pv,imPt) : dataAry.map( (d,i) => i+1);
@@ -726,7 +765,7 @@ function genZAxisChartData(imPt, pv, dataAry,x,y, pointSize, title) {
     return {
         plotlyDivStyle,
         plotlyData,
-        plotlyLayout: makePlotlyLayoutObj(title,hasWL?'Wavelength':'cube plane', `Z-Axis${pointSize>1?` (${pointSize}x${pointSize} avg)`:''}`),
+        plotlyLayout: makePlotlyLayoutObj(title,hasWL?'Wavelength':'cube plane', `Z-Axis${pointSize>1?` (${pointSize}x${pointSize} ${combineOp.toLowerCase()})`:''}`),
     };
 }
 


### PR DESCRIPTION
#### [Firefly-1060](https://jira.ipac.caltech.edu/browse/FIREFLY-1060): clean and support datatype in extract
  - Also added some features mentioned in firefly-1059, combinations types average, add and bitwise OR
  - Some general clean up, refactored some code around to make it cleaner
     - new files: `FitsExtract.java` and `FITSExtractToTable.java`

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1060-extract/firefly/
 - Do an extraction and pin a table - notice the unit type should be correct with you FITS
 - For a over `1x1` size you have access to `average`, `add`, or `OR` (`OR` only available to int or long HDUs)
 