### PR TITLE
[FIREFLY-1095] Combine Spectra with unit conversion

### DIFF
--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -88,8 +88,11 @@ async function fetchData(chartId, traceNum, tablesource) {
         addOtherChanges({changes, chartId, traceNum, tablesource, tableModel: originalTableModel});
 
         dispatchChartUpdate({chartId, changes});
-        updateHighlighted(chartId, traceNum, highlightedRow);
-        updateSelected(chartId, selectInfo);
+        const {activeTrace} = getChartData(chartId);
+        if (isUndefined(activeTrace) || activeTrace === traceNum) {
+            updateHighlighted(chartId, traceNum, highlightedRow);
+            updateSelected(chartId, selectInfo);
+        }
     } else {
         dispatchError(chartId, traceNum, 'No data');
     }

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -303,19 +303,11 @@ function doUnitConversion({chartId, chartData, axisType, to}) {
                 traceNum: activeTrace,
                 axis
             });
-            // changes for fields must be converted to changes for state
+            // field changes must be converted to state changes
             changes = evalChangesFromFields(chartId, tbl_id, changes);
             Object.entries(changes).forEach(([key, val]) => {
                 set(chartData, key, val);
             });
-            // for (let [k, v] of Object.entries(changes)) {
-            //     if (k.startsWith('_tables')) {
-            //         // the unit conversion applies to chart state, not to input fields
-            //         k = k.replace('_tables.', '');
-            //         v = `tables::${v}`;
-            //     }
-            //     set(chartData, k, v);
-            // }
             unit = to;
             set(fireflyData, [activeTrace, `${axisType}Unit`], unit);
         }

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -3,7 +3,7 @@
  */
 
 import React, {useEffect, useState} from 'react';
-import {cloneDeep, pick, set} from 'lodash';
+import {cloneDeep, get, pick, set} from 'lodash';
 
 import {getMultiViewRoot, getViewerItemIds} from '../../visualize/MultiViewCntlr.js';
 import {dispatchChartAdd, getChartData} from '../ChartsCntlr.js';
@@ -12,7 +12,7 @@ import {TextButton} from '../../ui/TextButton.jsx';
 import {PINNED_VIEWER_ID, PINNED_GROUP, PINNED_CHART_PREFIX} from './ChartWorkArea.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
-import {basicOptions} from './options/BasicOptions.jsx';
+import {basicOptions, evalChangesFromFields} from './options/BasicOptions.jsx';
 import {getColumnValues, getSelectedDataSync, getTblById} from '../../tables/TableUtil.js';
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 import {getGroupFields} from '../../fieldGroup/FieldGroupUtils.js';
@@ -242,7 +242,7 @@ function combineChart(chartIds, props={}) {
             });
         }
 
-        // apply unit conversion to xAxis if needed.
+        // apply unit conversion to yAxis if needed.
         const yUnit = doUnitConversion({chartId, chartData, axisType:'y', to:baseYUnit});
 
         if (baseYUnit !== yUnit) {
@@ -256,12 +256,16 @@ function combineChart(chartIds, props={}) {
             });
         }
 
-        // failed when only one of the two are mapped(??).  apply map to both(workaround)
         const xmapped = (data?.[activeTrace]?.x || '').startsWith?.('tables:');
         const ymapped = (data?.[activeTrace]?.y || '').startsWith?.('tables:');
         if (xmapped ^ ymapped) {
-            if (!ymapped) set(data, `${activeTrace}.y`, `tables::${tablesources?.[activeTrace]?.mappings?.y}`);
-            if (!xmapped) set(data, `${activeTrace}.x`, `tables::${tablesources?.[activeTrace]?.mappings?.x}`);
+            // all mapped fields should be handled: x, y, error_y.array, etc.
+            Object.entries(tablesources?.[activeTrace]?.mappings || {}).forEach(([key, val]) => {
+                // need get to handle compound keys, like 'error_y.array'
+                if (!get(data, `${activeTrace}.${key}`)?.startsWith?.('tables:')) {
+                    set(data, `${activeTrace}.${key}`, `tables::${val}`);
+                }
+            });
         }
 
         // merge selected chart data into new chart
@@ -279,7 +283,7 @@ function combineChart(chartIds, props={}) {
     return baseChartData;
 }
 
-/* return unit for the give axisType */
+/* return unit for the given axisType */
 function doUnitConversion({chartId, chartData, axisType, to}) {
     const {activeTrace, fireflyData, data} = chartData;
 
@@ -289,7 +293,8 @@ function doUnitConversion({chartId, chartData, axisType, to}) {
         if (canUnitConv({from: unit, to})) {
             const tbl_id = getTblIdFromChart(chartId, activeTrace);
             const axis = getSpectrumDM(getTblById(tbl_id))?.[axisType === 'x' ? 'spectralAxis' : 'fluxAxis'];
-            const changes = applyUnitConversion({
+            // unit conversion changes for input fields
+            let changes = applyUnitConversion({
                 fireflyData,
                 data,
                 inFields: {},
@@ -298,9 +303,19 @@ function doUnitConversion({chartId, chartData, axisType, to}) {
                 traceNum: activeTrace,
                 axis
             });
+            // changes for fields must be converted to changes for state
+            changes = evalChangesFromFields(chartId, tbl_id, changes);
             Object.entries(changes).forEach(([key, val]) => {
                 set(chartData, key, val);
             });
+            // for (let [k, v] of Object.entries(changes)) {
+            //     if (k.startsWith('_tables')) {
+            //         // the unit conversion applies to chart state, not to input fields
+            //         k = k.replace('_tables.', '');
+            //         v = `tables::${v}`;
+            //     }
+            //     set(chartData, k, v);
+            // }
             unit = to;
             set(fireflyData, [activeTrace, `${axisType}Unit`], unit);
         }

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -1,11 +1,11 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {isArray, get, isUndefined, isEmpty, reverse, set, isString} from 'lodash';
+import {get, isArray, isEmpty, isString, isUndefined, reverse, set} from 'lodash';
 
-import {dispatchChartUpdate, dispatchChartAdd, getChartData} from '../../ChartsCntlr.js';
+import {dispatchChartAdd, dispatchChartUpdate, getChartData} from '../../ChartsCntlr.js';
 import {FieldGroup} from '../../../ui/FieldGroup.jsx';
-import {getFieldVal, getField} from '../../../fieldGroup/FieldGroupUtils.js';
-import {dispatchValueChange, VALUE_CHANGE, MULTI_VALUE_CHANGE} from '../../../fieldGroup/FieldGroupCntlr.js';
+import {getField, getFieldVal} from '../../../fieldGroup/FieldGroupUtils.js';
+import {dispatchValueChange, MULTI_VALUE_CHANGE, VALUE_CHANGE} from '../../../fieldGroup/FieldGroupCntlr.js';
 import {FieldGroupCollapsible} from '../../../ui/panel/CollapsiblePanel.jsx';
 
 import {showColorPickerDialog} from '../../../ui/ColorPicker.jsx';
@@ -18,7 +18,7 @@ import {useStoreConnector} from '../../../ui/SimpleComponent.jsx';
 import {updateSet} from '../../../util/WebUtil.js';
 import {hideColSelectPopup} from '../ColSelectView.jsx';
 import {addColorbarChanges} from '../../dataTypes/FireflyHeatmap.js';
-import {uniqueChartId, TRACE_COLORS, toRGBA, colorsOnTypes, getChartProps} from '../../ChartUtil.js';
+import {colorsOnTypes, getChartProps, toRGBA, TRACE_COLORS, uniqueChartId} from '../../ChartUtil.js';
 import {colorscaleNameToVal} from '../../Colorscale.js';
 import {DEFAULT_PLOT2D_VIEWER_ID} from '../../../visualize/MultiViewCntlr.js';
 
@@ -264,7 +264,7 @@ function XyRatio({groupKey, Xyratio, Stretch, xNoLog}) {
  * It assume the fieldId is the 'path' to the chart data and the value of the field is the value you want to change.
  * For fields that are mapped to tables, it assumes that they starts with '_tables'.  In this case, it will prepend
  * 'tables::' to the value.
- * @param {pbject} p
+ * @param {object} p
  * @param {string} p.chartId
  * @param {object} p.fields
  * @param {string} p.tbl_id
@@ -298,7 +298,10 @@ export function evalChangesFromFields(chartId, tbl_id, fields) {
     Object.entries(fields).forEach( ([k,v]) => {
         if (tbl_id && k.startsWith('_tables.')) {
             const [,activeTrace] = /^_tables.data.(\d)/.exec(k) || [];
-            if (!isUndefined(activeTrace)) set(changes, [`data.${activeTrace}.tbl_id`], tbl_id);
+            if (!isUndefined(activeTrace)) {
+                // table id must be set for a data change
+                changes[`data.${activeTrace}.tbl_id`] = data[activeTrace]?.tbl_id || tbl_id;
+            }
             k = k.replace('_tables.', '');
             v = v ? `tables::${v}` : undefined;
         } else if (k.startsWith('__')) {
@@ -576,4 +579,4 @@ export function basicOptions ({activeTrace:pActiveTrace, chartId, tbl_id, groupK
             );
         },
     };
-};
+}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1095
Test deployment: https://fireflydev.ipac.caltech.edu/firefly-1095-combinedunits/firefly/

- On combined chart creation, the units are converted to the unit of the base trace for all traces with compatible units
- On combined chart update, the units are applied to all traces with compatible units 
- Errors in non-active traces are preserved.