### PR TITLE
Firefly 1104 file upload view panel reusability

### DIFF
--- a/src/firefly/js/ui/FieldGroup.jsx
+++ b/src/firefly/js/ui/FieldGroup.jsx
@@ -30,7 +30,7 @@ export const FieldGroup = memo( ({keepMounted, reducerFunc=undefined, groupKey, 
         }
     };
 
-    const ctx= {groupKey,register, unregister, registeredComponents:wrapperRegisteredComponents??registeredComponents};
+    const ctx= {groupKey, register, unregister, registeredComponents:wrapperRegisteredComponents??registeredComponents, keepState};
 
     useLayoutEffect(() => {
         dispatchMountFieldGroup(groupKey, true, keepState, reducerFunc, wrapperGroupKey);

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -5,7 +5,13 @@
 import React, {useState} from 'react';
 import {FormPanel} from './FormPanel.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
-import {panelKey, FileUploadViewPanel, resultSuccess, resultFail} from '../visualize/ui/FileUploadViewPanel.jsx';
+import {
+    panelKey,
+    FileUploadViewPanel,
+    resultSuccess,
+    resultFail,
+    resultsTEMPSuccess
+} from '../visualize/ui/FileUploadViewPanel.jsx';
 import {getAppOptions} from 'firefly/api/ApiUtil.js';
 import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr.js';
@@ -28,7 +34,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
                 changeMasking={changeMasking}
                 inputStyle={{height:'100%'}}
                 submitBarStyle={{padding: '2px 3px 3px'}} help_id={helpId}>
-                <FileUploadViewPanel setSubmitText={setSubmitText}/>
+                <FileUploadViewPanel submitText={submitText} setSubmitText={setSubmitText} showCompleteButton={true}/>
             </FormPanel>
             {doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
         </div>
@@ -39,6 +45,9 @@ const DIALOG_ID= 'FileUploadDialog';
 
 export function showUploadDialog() {
 
+    //removing the onCancel and onSubmit below from the call to FileUploadDropdown fixes it so that the  req obj
+    //is not empty when resultSuccess is called from FileUploadDropdown
+    //but showUploadDialog is only called from HiPsImageSelect.jsx if (visRoot().apiToolsView) -> what is that if condition?
     DialogRootContainer.defineDialog(DIALOG_ID,
         <PopupPanel title={'Upload'}
                     closeCallback={

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -53,7 +53,6 @@ const DIALOG_ID= 'FileUploadDialog';
 
 export function showUploadDialog() {
 
-    //can call this showUploadDialog from within the "Add MOC layer" popup dialog for HiPS/MOC upload...
     //removing the onCancel and onSubmit below from the call to FileUploadDropdown fixes it so that the  req obj
     //is not empty when resultSuccess is called from FileUploadDropdown
     //but showUploadDialog is only called from HiPsImageSelect.jsx if (visRoot().apiToolsView) -> what is that if condition?
@@ -70,7 +69,7 @@ export function showUploadDialog() {
                     onCancel={() => dispatchHideDialog(DIALOG_ID)}
                     onSubmit={() => {
                         dispatchHideDialog(DIALOG_ID);
-                        resultSuccess();
+                        //resultSuccess();
                     }}
                 />
             </div>

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {useContext, useState} from 'react';
+import React, {useState} from 'react';
 import {FormPanel} from './FormPanel.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
 import {
@@ -19,17 +19,18 @@ import {FieldGroup} from 'firefly/ui/FieldGroup';
 const maskWrapper= { position:'absolute', left:0, top:0, width:'100%', height:'100%' };
 const panelKey = 'FileUploadAnalysis';
 
-export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess, acceptMoc=false}) =>{ //onSubmit=resultSuccess
+export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, acceptMoc=false, onSubmit=resultSuccess, keepState=true,
+                                      groupKey=panelKey}) =>{
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
     return (
 
         <div style={{width: '100%', ...style}}>
-            <FieldGroup groupKey={panelKey} keepState={true} style={{height:'100%', width: '100%',
+            <FieldGroup groupKey={groupKey} keepState={keepState} style={{height:'100%', width: '100%',
                 display: 'flex', alignItems: 'stretch', flexDirection: 'column'}}>
                 <FormPanel
-                    width='auto' height='auto' groupKey={panelKey} onSubmit={onSubmit}
+                    width='auto' height='auto' groupKey={groupKey} onSubmit={onSubmit}
                     onError={resultFail}
                     onCancel={onCancel}
                     submitText={submitText}
@@ -49,7 +50,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
 
 const DIALOG_ID= 'FileUploadDialog';
 
-export function showUploadDialog(acceptMoc) {
+export function showUploadDialog(acceptMoc, keepState, groupKey) {
 
     DialogRootContainer.defineDialog(DIALOG_ID,
         <PopupPanel title={'Upload'}
@@ -62,10 +63,13 @@ export function showUploadDialog(acceptMoc) {
                     style={{height: '100%'}}
                     onCancel={() => dispatchHideDialog(DIALOG_ID)}
                     acceptMoc={acceptMoc}
-                    /*onSubmit={() => {
-                        dispatchHideDialog(DIALOG_ID);
-                        resultSuccess;
-                    }}*/
+                    onSubmit={
+                        (request) => {
+                            if (resultSuccess(request)) dispatchHideDialog(DIALOG_ID);
+                        }
+                    }
+                    keepState={keepState}
+                    groupKey={groupKey}
                 />
             </div>
         </PopupPanel>

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -6,7 +6,6 @@ import React, {useContext, useState} from 'react';
 import {FormPanel} from './FormPanel.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
 import {
-    panelKey,
     FileUploadViewPanel,
     resultFail
 } from '../visualize/ui/FileUploadViewPanel.jsx';
@@ -15,32 +14,31 @@ import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr.js';
 import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
 import {resultSuccess} from 'firefly/ui/FileUploadProcessor';
-import {FieldGroup, FieldGroupCtx} from 'firefly/ui/FieldGroup';
+import {FieldGroup} from 'firefly/ui/FieldGroup';
 
 const maskWrapper= { position:'absolute', left:0, top:0, width:'100%', height:'100%' };
+const panelKey = 'FileUploadAnalysis';
 
-export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess}) =>{ //onSubmit=resultSuccess
+export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess, acceptMoc}) =>{ //onSubmit=resultSuccess
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
-    //onSubmit={onSubmit}
     return (
 
         <div style={{width: '100%', ...style}}>
             <FieldGroup groupKey={panelKey} keepState={true} style={{height:'100%', width: '100%',
                 display: 'flex', alignItems: 'stretch', flexDirection: 'column'}}>
-            <FormPanel
-                width='auto' height='auto' groupKey={panelKey} onSubmit={onSubmit}
-                onError={resultFail}
-                onCancel={onCancel}
-                submitText={submitText}
-                params={{hideOnInvalid: false}}
-                changeMasking={changeMasking}
-                inputStyle={{height:'100%'}}
-                submitBarStyle={{padding: '2px 3px 3px'}} help_id={helpId}>
-
-                    <FileUploadViewPanel setSubmitText={setSubmitText}/>
-            </FormPanel>
+                <FormPanel
+                    width='auto' height='auto' groupKey={panelKey} onSubmit={onSubmit}
+                    onError={resultFail}
+                    onCancel={onCancel}
+                    submitText={submitText}
+                    params={{hideOnInvalid: false}}
+                    changeMasking={changeMasking}
+                    inputStyle={{height:'100%'}}
+                    submitBarStyle={{padding: '2px 3px 3px'}} help_id={helpId}>
+                    <FileUploadViewPanel setSubmitText={setSubmitText} acceptMoc={acceptMoc}/>
+                </FormPanel>
             </FieldGroup>
             {doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
         </div>
@@ -51,11 +49,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
 
 const DIALOG_ID= 'FileUploadDialog';
 
-export function showUploadDialog() {
-
-    //removing the onCancel and onSubmit below from the call to FileUploadDropdown fixes it so that the  req obj
-    //is not empty when resultSuccess is called from FileUploadDropdown
-    //but showUploadDialog is only called from HiPsImageSelect.jsx if (visRoot().apiToolsView) -> what is that if condition?
+export function showUploadDialog(acceptMoc) {
 
     DialogRootContainer.defineDialog(DIALOG_ID,
         <PopupPanel title={'Upload'}
@@ -67,10 +61,11 @@ export function showUploadDialog() {
                 <FileUploadDropdown
                     style={{height: '100%'}}
                     onCancel={() => dispatchHideDialog(DIALOG_ID)}
-                    onSubmit={() => {
+                    acceptMoc={acceptMoc}
+                    /*onSubmit={() => {
                         dispatchHideDialog(DIALOG_ID);
-                        //resultSuccess();
-                    }}
+                        resultSuccess;
+                    }}*/
                 />
             </div>
         </PopupPanel>

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -2,29 +2,33 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 import {FormPanel} from './FormPanel.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
 import {
     panelKey,
     FileUploadViewPanel,
-    resultSuccess,
-    resultFail,
-    resultsTEMPSuccess
+    resultFail
 } from '../visualize/ui/FileUploadViewPanel.jsx';
 import {getAppOptions} from 'firefly/api/ApiUtil.js';
 import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr.js';
 import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
+import {resultSuccess} from 'firefly/ui/FileUploadProcessor';
+import {FieldGroup, FieldGroupCtx} from 'firefly/ui/FieldGroup';
 
 const maskWrapper= { position:'absolute', left:0, top:0, width:'100%', height:'100%' };
 
-export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess}) =>{
+export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess}) =>{ //onSubmit=resultSuccess
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
+    //onSubmit={onSubmit}
     return (
+
         <div style={{width: '100%', ...style}}>
+            <FieldGroup groupKey={panelKey} keepState={true} style={{height:'100%', width: '100%',
+                display: 'flex', alignItems: 'stretch', flexDirection: 'column'}}>
             <FormPanel
                 width='auto' height='auto' groupKey={panelKey} onSubmit={onSubmit}
                 onError={resultFail}
@@ -34,10 +38,14 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
                 changeMasking={changeMasking}
                 inputStyle={{height:'100%'}}
                 submitBarStyle={{padding: '2px 3px 3px'}} help_id={helpId}>
-                <FileUploadViewPanel submitText={submitText} setSubmitText={setSubmitText} showCompleteButton={true}/>
+
+                    <FileUploadViewPanel setSubmitText={setSubmitText}/>
             </FormPanel>
+            </FieldGroup>
             {doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
         </div>
+
+
     );
 };
 
@@ -45,9 +53,11 @@ const DIALOG_ID= 'FileUploadDialog';
 
 export function showUploadDialog() {
 
+    //can call this showUploadDialog from within the "Add MOC layer" popup dialog for HiPS/MOC upload...
     //removing the onCancel and onSubmit below from the call to FileUploadDropdown fixes it so that the  req obj
     //is not empty when resultSuccess is called from FileUploadDropdown
     //but showUploadDialog is only called from HiPsImageSelect.jsx if (visRoot().apiToolsView) -> what is that if condition?
+
     DialogRootContainer.defineDialog(DIALOG_ID,
         <PopupPanel title={'Upload'}
                     closeCallback={

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -19,7 +19,7 @@ import {FieldGroup} from 'firefly/ui/FieldGroup';
 const maskWrapper= { position:'absolute', left:0, top:0, width:'100%', height:'100%' };
 const panelKey = 'FileUploadAnalysis';
 
-export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess, acceptMoc}) =>{ //onSubmit=resultSuccess
+export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess, acceptMoc=false}) =>{ //onSubmit=resultSuccess
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -1,0 +1,47 @@
+import {FileAnalysisType} from 'firefly/data/FileAnalysis';
+import {showInfoPopup} from 'firefly/ui/PopupUtil';
+import {getAppHiPSForMoc, isMOCFitsFromUploadAnalsysis} from 'firefly/visualize/HiPSMocUtil';
+import {MetaConst} from 'firefly/data/MetaConst';
+import {isLsstFootprintTable} from 'firefly/visualize/task/LSSTFootprintTask';
+import {TableCtx} from '../visualize/ui/FileUploadViewPanel.jsx';
+import { useContext } from 'react';
+
+
+export function ResultSuccess(request) {
+    //const tabCtx = useContext(TableCtx);
+    /* if (tabCtx) return tablesOnlyResultSuccess(request);
+     const fileCacheKey = getFileCacheKey();
+
+     const tableIndices = getSelectedRows(FileAnalysisType.Table);
+     const imageIndices = getSelectedRows(FileAnalysisType.Image);
+
+     if (!isFileSupported()) {
+         showInfoPopup(getFirstPartType() ? `File type of ${getFirstPartType()} is not supported.`: 'Could not recognize the file type');
+         return false;
+     }
+
+     if (!isRegion() && tableIndices.length + imageIndices.length === 0) {
+         if (getSelectedRows('HeaderOnly')?.length) {
+             showInfoPopup('FITS HDU type of HeaderOnly is not supported. A header-only HDU contains no additional data.', 'Validation Error');
+         }
+         else {
+             showInfoPopup('No extension is selected', 'Validation Error');
+         }
+         return false;
+     }
+
+     const isMocFits =  isMOCFitsFromUploadAnalsysis(currentReport);
+     if (isRegion()) {
+         sendRegionRequest(fileCacheKey);
+     }
+     else if (isMocFits.valid) {
+         const mocMeta= {[MetaConst.PREFERRED_HIPS]: getAppHiPSForMoc()};
+         if (request.mocOp==='table') mocMeta[MetaConst.IGNORE_MOC]='true';
+         sendTableRequest(tableIndices, fileCacheKey, false, mocMeta, request.mocOp==='table');
+     } else if ( isLsstFootprintTable(currentDetailsModel) ) {
+         sendLSSTFootprintRequest(fileCacheKey, request.fileName, tableIndices[0]);
+     } else {
+         sendTableRequest(tableIndices, fileCacheKey, Boolean(request.tablesAsSpectrum==='spectrum'));
+         sendImageRequest(imageIndices, request, fileCacheKey);
+     }*/
+}

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -1,47 +1,230 @@
-import {FileAnalysisType} from 'firefly/data/FileAnalysis';
+import {FileAnalysisType, Format} from 'firefly/data/FileAnalysis';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {getAppHiPSForMoc, isMOCFitsFromUploadAnalsysis} from 'firefly/visualize/HiPSMocUtil';
 import {MetaConst} from 'firefly/data/MetaConst';
 import {isLsstFootprintTable} from 'firefly/visualize/task/LSSTFootprintTask';
-import {TableCtx} from '../visualize/ui/FileUploadViewPanel.jsx';
-import { useContext } from 'react';
+import {makeFileRequest, makeTblRequest} from 'firefly/tables/TableRequestUtil';
+import {getAppOptions} from 'firefly/core/AppDataCntlr';
+import {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils';
+//import {getFileFormat, getFirstPartType, getSelectedRows, isRegion, panelKey} from 'firefly/visualize/ui/FileUploadViewPanel';
+import {createNewRegionLayerId} from 'firefly/drawingLayers/RegionPlot';
+import {dispatchCreateImageLineBasedFootprintLayer, dispatchCreateRegionLayer, getDlAry} from 'firefly/visualize/DrawLayerCntlr';
+import {getDrawLayersByType, getPlotViewAry, primePlot} from 'firefly/visualize/PlotViewUtil';
+import {dispatchPlotImage, visRoot} from 'firefly/visualize/ImagePlotCntlr';
+import {dispatchTableFetch, dispatchTableSearch} from 'firefly/tables/TablesCntlr';
+import {getSelectedDataSync, uniqueTblId} from 'firefly/tables/TableUtil';
+import LSSTFootprint from 'firefly/drawingLayers/ImageLineBasedFootprint';
+import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
+import RangeValues from 'firefly/visualize/RangeValues';
+import {getAViewFromMultiView, getMultiViewRoot, IMAGE} from 'firefly/visualize/MultiViewCntlr';
+import {PlotAttribute} from 'firefly/visualize/PlotAttribute';
+import * as TablesCntlr from 'firefly/tables/TablesCntlr';
+import {useContext} from "react";
+import {FieldGroupCtx} from "firefly/ui/FieldGroup";
+
+const FILE_ID = 'fileUpload';
+const uploadOptions = 'uploadOptions';
+
+const SUPPORTED_TYPES=[
+    FileAnalysisType.REGION,
+    FileAnalysisType.Image,
+    FileAnalysisType.Table,
+    FileAnalysisType.Spectrum,
+    FileAnalysisType.REGION,
+];
+
+export function resultSuccess(request) {
+
+    //request = Object.assign({}, makeTblRequest(request.id, request.title, request), request);//makeTblRequest(request.id, request.title, request)
+    //will need to bring over remaining logic from FormPanel's createSuccessHandler here because rn
+    //selecting and loading tables is not working! 
+    //TablesCntlr.dispatchTableSearch(request);
+
+    const currentReport = request.additionalParams?.currentReport;
+    const currentDetailsModel = request.additionalParams?.currentDetailsModel;
+    const summaryModel = request.additionalParams?.summaryModel;
+    const groupKey = request.additionalParams?.groupKey;
+    console.log('groupKey in resultSuccess: ' + groupKey);
+    const SUMMARY_TBL_ID = groupKey; //FileUploadAnalysis
+
+    const isTablesOnly= () => getAppOptions()?.uploadPanelLimit==='tablesOnly';
+    if (isTablesOnly()) return tablesOnlyResultSuccess(request, SUMMARY_TBL_ID, currentReport, summaryModel, groupKey);
+    const fileCacheKey = getFileCacheKey(groupKey);
+
+    const tableIndices = getSelectedRows(FileAnalysisType.Table, SUMMARY_TBL_ID, currentReport, summaryModel);
+    const imageIndices = getSelectedRows(FileAnalysisType.Image, SUMMARY_TBL_ID, currentReport, summaryModel);
+
+    console.log('imageIndices: ' + imageIndices);
+
+    if (!isFileSupported(summaryModel, currentReport)) {
+        showInfoPopup(getFirstPartType(summaryModel) ? `File type of ${getFirstPartType(summaryModel)} is not supported.`: 'Could not recognize the file type');
+        return false;
+    }
+
+    if (!isRegion(summaryModel) && tableIndices.length + imageIndices.length === 0) {
+        if (getSelectedRows('HeaderOnly', SUMMARY_TBL_ID, currentReport, summaryModel)?.length) {
+            showInfoPopup('FITS HDU type of HeaderOnly is not supported. A header-only HDU contains no additional data.', 'Validation Error');
+        }
+        else {
+            showInfoPopup('No extension is selected', 'Validation Error');
+        }
+        return false;
+    }
+
+    const isMocFits =  isMOCFitsFromUploadAnalsysis(currentReport);
+    if (isRegion(summaryModel)) {
+        sendRegionRequest(fileCacheKey, currentReport);
+    }
+    else if (isMocFits.valid) {
+        const mocMeta= {[MetaConst.PREFERRED_HIPS]: getAppHiPSForMoc()};
+        if (request.mocOp==='table') mocMeta[MetaConst.IGNORE_MOC]='true';
+        sendTableRequest(tableIndices, fileCacheKey, request.mocOp==='table', currentReport, false, mocMeta);
+    } else if ( isLsstFootprintTable(currentDetailsModel) ) {
+        sendLSSTFootprintRequest(fileCacheKey, request.fileName, tableIndices[0]);
+    } else {
+        sendTableRequest(tableIndices, fileCacheKey, Boolean(request.tablesAsSpectrum==='spectrum'), currentReport);
+        sendImageRequest(imageIndices, request, fileCacheKey, currentReport);
+    }
+}
+
+function tablesOnlyResultSuccess(request, SUMMARY_TBL_ID, currentReport, currentSummaryModel, groupKey) {
+    const tableIndices = getSelectedRows(FileAnalysisType.Table, SUMMARY_TBL_ID, currentReport, currentSummaryModel);
+    const imageIndices = getSelectedRows(FileAnalysisType.Image, SUMMARY_TBL_ID, currentReport, currentSummaryModel);
+
+    if (tableIndices.length>0) {
+        imageIndices.length>0 && showInfoPopup('Only loading the tables, ignoring the images.');
+        console.log('groupKey 2: ' + groupKey);
+        sendTableRequest(tableIndices, getFileCacheKey(groupKey), Boolean(request.tablesAsSpectrum==='spectrum'), currentReport);
+        return true;
+    }
+    else {
+        showInfoPopup('You may only upload tables.');
+        return false;
+    }
+}
+
+function getFileCacheKey(groupKey) {
+    // because this value is stored in different fields.. so we have to check on what options were selected to determine the active value
+    console.log('groupKey 3: ' + groupKey);
+    const uploadSrc = getFieldVal(groupKey, uploadOptions) || FILE_ID;
+    return getFieldVal(groupKey, uploadSrc);
+}
+
+export const getPartCnt= (currentReport) => currentReport?.parts?.length ?? 1;
+export const getFirstPartType= (currentSummaryModel) => currentSummaryModel?.tableData.data[0]?.[1];
+export const getFileFormat= (currentReport) => currentReport?.fileFormat;
+export const isRegion= (currentSummaryModel) => getFirstPartType(currentSummaryModel)===FileAnalysisType.REGION;
+
+function isFileSupported(summaryModel, currentReport) {
+    return getFirstPartType(summaryModel) && (SUPPORTED_TYPES.includes(getFirstPartType(summaryModel)) || getFileFormat(currentReport)===Format.FITS);
+}
+
+function sendRegionRequest(fileCacheKey,currentReport) {
+    const drawLayerId = createNewRegionLayerId();
+    const title= currentReport.fileName ?? 'Region File';
+    dispatchCreateRegionLayer(drawLayerId, title, fileCacheKey, null);
+    if (!getPlotViewAry(visRoot())?.length) {
+        showInfoPopup('The region file is loaded but you will not be able to see it until you load an image (FITS or HiPS)', 'Warning');
+    }
+}
+
+function sendTableRequest(tableIndices, fileCacheKey, loadToUI= true, currentReport, treatAsSpectrum, metaData={}) {
+    const {fileName, parts=[]} = currentReport;
+
+    tableIndices.forEach((idx) => {
+        const {index} = parts[idx];
+        const title = parts.length > 1 ? `${fileName}-${index}` : fileName;
+        const META_INFO= {...metaData};
+        if (treatAsSpectrum) META_INFO[MetaConst.DATA_TYPE_HINT]= 'spectrum';
+        const options=  {META_INFO};
+        const tblReq = makeFileRequest(title, fileCacheKey, null, options);
+        tblReq.tbl_index = index;
+        loadToUI ? dispatchTableSearch(tblReq) : dispatchTableFetch(tblReq);
+
+    });
+}
+
+function sendLSSTFootprintRequest(uploadPath, displayValue, tblIdx) {
+    const dl_id = getLSSTFootprintId();
+    const pv = primePlot(visRoot());
+    const pIds = pv ? [pv.plotId]: [];
+
+    dispatchCreateImageLineBasedFootprintLayer(dl_id, displayValue,
+        null, pIds,
+        uploadPath, null, tblIdx);
+}
 
 
-export function ResultSuccess(request) {
-    //const tabCtx = useContext(TableCtx);
-    /* if (tabCtx) return tablesOnlyResultSuccess(request);
-     const fileCacheKey = getFileCacheKey();
+function getLSSTFootprintId() {
+    const dlId = uniqueTblId();
+    let   idx = 1;
+    let   fpLayerId = dlId;
+    const dls = getDrawLayersByType(getDlAry(), LSSTFootprint.TYPE_ID);
 
-     const tableIndices = getSelectedRows(FileAnalysisType.Table);
-     const imageIndices = getSelectedRows(FileAnalysisType.Image);
+    while (true) {
+        const dl = dls.find((oneLayer) => oneLayer.drawLayerId === fpLayerId);
 
-     if (!isFileSupported()) {
-         showInfoPopup(getFirstPartType() ? `File type of ${getFirstPartType()} is not supported.`: 'Could not recognize the file type');
-         return false;
-     }
+        if (!dl) return dlId;
+        fpLayerId = dlId + `${idx++}`;
+    }
+}
 
-     if (!isRegion() && tableIndices.length + imageIndices.length === 0) {
-         if (getSelectedRows('HeaderOnly')?.length) {
-             showInfoPopup('FITS HDU type of HeaderOnly is not supported. A header-only HDU contains no additional data.', 'Validation Error');
-         }
-         else {
-             showInfoPopup('No extension is selected', 'Validation Error');
-         }
-         return false;
-     }
+/**
+ * send request to get the data of image unit, the extension index is mapped to be that at
+ * the server side
+ * @param imageIndices
+ * @param request
+ * @param fileCacheKey
+ * @param currentReport
+ */
+function sendImageRequest(imageIndices, request, fileCacheKey, currentReport) {
 
-     const isMocFits =  isMOCFitsFromUploadAnalsysis(currentReport);
-     if (isRegion()) {
-         sendRegionRequest(fileCacheKey);
-     }
-     else if (isMocFits.valid) {
-         const mocMeta= {[MetaConst.PREFERRED_HIPS]: getAppHiPSForMoc()};
-         if (request.mocOp==='table') mocMeta[MetaConst.IGNORE_MOC]='true';
-         sendTableRequest(tableIndices, fileCacheKey, false, mocMeta, request.mocOp==='table');
-     } else if ( isLsstFootprintTable(currentDetailsModel) ) {
-         sendLSSTFootprintRequest(fileCacheKey, request.fileName, tableIndices[0]);
-     } else {
-         sendTableRequest(tableIndices, fileCacheKey, Boolean(request.tablesAsSpectrum==='spectrum'));
-         sendImageRequest(imageIndices, request, fileCacheKey);
-     }*/
+    if (imageIndices.length === 0) return;
+
+    const {fileName, parts=[]} = currentReport;
+
+    const wpRequest = WebPlotRequest.makeFilePlotRequest(fileCacheKey);
+    wpRequest.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
+    const {viewerId=''} = getAViewFromMultiView(getMultiViewRoot(), IMAGE) || {};
+
+    if (viewerId) {
+        wpRequest.setPlotGroupId(viewerId);
+
+        if (request.imageDisplay === 'mulWindow') {
+            // plot each image separately
+
+            imageIndices.forEach( (idx) => {
+                const plotId = `${fileName}-${idx}`;
+                const {index} = parts[idx];
+
+                // if (index !== -1)  wpRequest.setPostTitle(`- ext. ${idx}`); // not primary
+                if (index !== -1)  wpRequest.setAttributes({[PlotAttribute.POST_TITLE]:`- ext. ${idx}`}); // not primary
+
+                wpRequest.setMultiImageExts(`${index}`);
+                dispatchPlotImage({plotId, wpRequest, viewerId});
+            });
+        } else {
+            const extList = imageIndices.map((idx) => parts?.[idx]?.index).join();
+
+            wpRequest.setMultiImageExts(extList);
+            if (!extList.includes('-1')) wpRequest.setAttributes({[PlotAttribute.POST_TITLE]:`- ext. ${extList}`});
+
+            const plotId = `${fileName.replace('.', '_')}-${imageIndices.join('_')}`;
+            dispatchPlotImage({plotId, wpRequest, viewerId});
+        }
+    }
+}
+
+export function getSelectedRows(type, SUMMARY_TBL_ID, currentReport, currentSummaryModel) {
+    if (getPartCnt(currentReport)===1) {
+        if (type===getFirstPartType(currentSummaryModel)) {
+            return [0];
+        }
+        return [];
+    }
+    const {totalRows=0, tableData} = getSelectedDataSync(SUMMARY_TBL_ID, ['Index', 'Type']);
+    if (totalRows === 0) return [];
+    const selectedRows = tableData.data;
+    return selectedRows.filter((row) => row[1] === type)            // take only rows with the right type
+        .map((row) => row[0]);                       // returns only the index
 }

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -66,7 +66,8 @@ export function resultSuccess(request) {
     else if (isMocFits.valid) {
         const mocMeta= {[MetaConst.PREFERRED_HIPS]: getAppHiPSForMoc()};
         if (request.mocOp==='table') mocMeta[MetaConst.IGNORE_MOC]='true';
-        sendTableRequest(tableIndices, fileCacheKey, request.mocOp==='table', currentReport, false, mocMeta);
+        //loadToUI = true if request.mocOp==='table', else loadToUI=false
+        sendTableRequest(tableIndices, fileCacheKey, Boolean(request.tablesAsSpectrum==='spectrum'), currentReport, Boolean(request.mocOp==='table'), mocMeta);
     } else if ( isLsstFootprintTable(currentDetailsModel) ) {
         sendLSSTFootprintRequest(fileCacheKey, request.fileName, tableIndices[0]);
     } else {

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -122,7 +122,7 @@ export function showHiPSSurveysPopup(pv, moc= false) {
                         <HiPSSurveyTable groupKey={groupKey} moc={moc}/>
                         {moc && <div style={{display:'flex', padding: '6px 15px 0 0', justifyContent:'flex-end'}}>
                             <div style={{lineHeight:'25px', height: 25, paddingRight: 4, fontWeight:'bold'}}> To Upload a MOC: </div>
-                            <CompleteButton text='Upload' groupKey='' onSuccess={() => showUploadDialog()} />
+                            <CompleteButton text='Upload' groupKey='' onSuccess={() => showUploadDialog(true)} />
                         </div>}
                     </div>
                 </FieldGroup>

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -122,7 +122,7 @@ export function showHiPSSurveysPopup(pv, moc= false) {
                         <HiPSSurveyTable groupKey={groupKey} moc={moc}/>
                         {moc && <div style={{display:'flex', padding: '6px 15px 0 0', justifyContent:'flex-end'}}>
                             <div style={{lineHeight:'25px', height: 25, paddingRight: 4, fontWeight:'bold'}}> To Upload a MOC: </div>
-                            <CompleteButton text='Upload' groupKey='' onSuccess={() => showUpload()} />
+                            <CompleteButton text='Upload' groupKey='' onSuccess={() => showUploadDialog()} />
                         </div>}
                     </div>
                 </FieldGroup>

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -30,8 +30,6 @@ import {BLANK_HIPS_URL} from '../visualize/WebPlot.js';
 import {createHiPSMocLayer} from 'firefly/visualize/task/PlotHipsTask.js';
 import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
 import CompleteButton from 'firefly/ui/CompleteButton.jsx';
-import {dispatchShowDropDown} from 'firefly/core/LayoutCntlr.js';
-import {setMultiSearchPanelTab} from 'firefly/ui/MultiSearchPanel.jsx';
 import {getDefaultMOCList} from 'firefly/visualize/HiPSMocUtil.js';
 import {showUploadDialog} from 'firefly/ui/FileUploadDropdown.jsx';
 
@@ -71,19 +69,6 @@ HiPSImageSelect.propTypes = {
 
 const DIALOG_ID = 'HiPSImageSelectPopup';
 
-function showUpload()  {
-    if (visRoot().apiToolsView) {
-        showUploadDialog();
-    }
-    else {
-        const view= getAppOptions()?.multiTableSearchCmdOptions
-            ?.find( ({id}) => id==='upload') ? 'MultiTableSearchCmd' : 'FileUploadDropDownCmd';
-        dispatchHideDialog(DIALOG_ID);
-        if (view==='MultiTableSearchCmd') setMultiSearchPanelTab('upload');
-        dispatchShowDropDown({view, initArgs:{defaultSelectedId:'upload', always:true}});
-    }
-}
-
 
 /**
  * show HiPS survey info table in popup panel
@@ -122,7 +107,7 @@ export function showHiPSSurveysPopup(pv, moc= false) {
                         <HiPSSurveyTable groupKey={groupKey} moc={moc}/>
                         {moc && <div style={{display:'flex', padding: '6px 15px 0 0', justifyContent:'flex-end'}}>
                             <div style={{lineHeight:'25px', height: 25, paddingRight: 4, fontWeight:'bold'}}> To Upload a MOC: </div>
-                            <CompleteButton text='Upload' groupKey='' onSuccess={() => showUploadDialog(true)} />
+                            <CompleteButton text='Upload' groupKey='' onSuccess={() => showUploadDialog(true, false, 'FileUploadHips')} />
                         </div>}
                     </div>
                 </FieldGroup>

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -276,7 +276,7 @@ function getNextState(oldState, groupKey) {
 
         }
     }
-    detailsModel = getDetailsModel( modelToUseForDetails,currentReport,DETAILS_TBL_ID,UNKNOWN_FORMAT);
+    let detailsModel = getDetailsModel( modelToUseForDetails,currentReport,DETAILS_TBL_ID,UNKNOWN_FORMAT);
     if (shallowequal(detailsModel, currentDetailsModel)) {
         detailsModel = currentDetailsModel;
     }
@@ -570,7 +570,18 @@ const FileAnalysis = ({report, summaryModel, detailsModel, tablesOnly, isMoc, UN
         return () => unregister('additionalParams');
     }, [report]);
 
-    if (acceptMoc && !isMoc) {
+    if (report && acceptMoc && !isMoc) {
+        const msgTitle = 'Warning: ';
+        const msgDesc = 'You are attempting to upload a non-MOC file.';
+        const renderContent = (
+            <div>
+                {msgTitle} <br></br> <br></br>
+                <div style={{padding: '5', whiteSpace: 'normal', letterSpacing: '1', lineHeight: '1.5'}}>
+                    {msgDesc}
+                </div>
+            </div>);
+        showInfoPopup(renderContent, 'Warning');
+
         return (<div style={{color:'gray', margin:'20px 0 0 200px', fontSize:'larger', lineHeight:'1.3em'}}>
             Warning: You are attempting to upload a non-MOC file.
         </div>);

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -39,7 +39,7 @@ import {
     getFileFormat,
     getFirstPartType,
     getPartCnt,
-    getSelectedRows,
+    getSelectedRows, getSelectedRowsforImageDisplayOption,
     isRegion,
     resultSuccess
 } from 'firefly/ui/FileUploadProcessor';
@@ -153,7 +153,6 @@ export function FileUploadViewPanel({setSubmitText}) {
     ].concat(workspace ? [{value: WS_ID, label: 'Upload from workspace'}] : []);
 
     const clearReport= () => {
-        //currentReport= undefined;
         dispatchValueChange({fieldKey:getLoadingFieldName(groupKey), groupKey:groupKey, value:'', displayValue:'', analysisResult:undefined});
     };
 
@@ -260,9 +259,12 @@ function getNextState(oldState, groupKey) {
     currentReport = oldState?.report;
     currentSummaryModel = oldState?.summaryModel;
     currentDetailsModel = oldState?.detailsModel;
-    const fieldState = getField(groupKey, getLoadingFieldName()) || {};
+    const fieldState = getField(groupKey, getLoadingFieldName(groupKey)) || {};
 
     const {analysisResult, message} = fieldState;
+    if (!analysisResult) { //clearReport sets analysisResult:undefined, so set currentReport=undefined to clear the file
+        currentReport = undefined;
+    }
     let modelToUseForDetails= getTblById(SUMMARY_TBL_ID)?? currentSummaryModel;
 
     if (message) {


### PR DESCRIPTION
#### [Firefly-1104](https://jira.ipac.caltech.edu/browse/FIREFLY-1104)  
**Updates** **(11/9)**: 
- Fixed code post PR comments
- moved FieldGroup over to FileUploadDropdown. 
- showing the upload panel as a dialog from the "Add MOC" dialog by calling showUploadDialog() with acceptMoc = true. FileAnalysis in FileUploadViewPanel checks if the file **isMoc** and if acceptMoc = true, if it's not moc, display a warning (although right now the warning is displayed even before you try and upload a file - need to fix this). 
- After loading MOC from the upload panel, the upload panel still stays in place (showUploadDialog's onSubmit would ideally call dispatchHideDialog - but I've commented it out for now since that was interfering with resultSuccess's request object being undefined for some reason - looking into this as well). 
- ImageDisplayOption's selectedImages stays empty the first time you try and select multiple images after a file upload (which is why you don't see the two radio button options for loading "All images in one window" or "One extension image per window"). If you load the images, though, and go back to the upload panel and select multiple images now, the options show up. I've tried debugging this, but it hasn't worked yet. 
- Because of the pending issues/bugs described above, I have still not created an actual PR, but please let me know if you have any comments on these new changes @robyww @loitly 

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1104-fileuploadviewpanel-reusability/firefly/
 - go to "Upload" and upload a FITS image. 
 - **_Fixed_**: Select 1 or more images (selecting and loading tables doesn't work - I am looking into this). 
 - From Image search, choose image type: View HiPS Images and target: m1. 
 - Try and add a MOC layer, and click on the upload button. This should open as a new dialog. Try and upload a moc fits file as well as a non-MOC fits file (you should see a warning even after you try to upload this). Working on fixing the warning you see before uploading. 

**Updates (11/11)**: 
- Test build is the same: https://fireflydev.ipac.caltech.edu/firefly-1104-fileuploadviewpanel-reusability/firefly/
- In FileUploadViewPanel, I was able to dispatch values to the store to be able to use them in getNextState. This has fixed the problem of user going back after loading images/tables to the upload panel and the upload panel not remembering the user's selected images/tables. Now this works. 
- Added a text warning in the upload panel itself for user trying to upload a non-MOC file when they get to the upload panel from "Add MOC Layer". Would a popup warning be better? (to test this, from a HiPs/MOC image, click on "Add MOC Layer", and then attempt to upload a non-MOC file. Also upload a MOC file to test it works as expected and doesn't throw a warning). 
- Fixed the issue with dispatchHideDialog not working in conjunction with resultSuccess (the request object was empty). Now after loading MOC, the upload panel should close and your MOC/table will be loaded in the background as expected. 
- The issue with ImageDisplayOption and TableDisplayOption options not showing up on the first render (but if you load and go back to upload panel, the options show up) was fixed by removing useStoreConnector and calling getSelectedRows (for ImageDisplayOption) and getFileFormat (for TableDisplayOption) directly. I'm not entirely sure why, would like to discuss it @robyww. 
- Other than that, I think this ticket is nearly done. Pending any review comments, I can go ahead and create a PR. 

**Updates (11/17)**:
- cleaned up more of the code based on comments, using useFieldGroupMetaState and useFieldGroupValue now, got rid of some of the useEffects and dispatchComponentStateChange completely. Removed the use of groupKey where I could (but it's still being used in getNextState and also in the FileAnalysis component) 
- I had to continue using useStoreConnector while calling getNextState (even with useFieldGroupMetaState in place), because without useStoreConnector, getNextState wasn't being called on re-renders. 
-  clearReport() still makes use of dispatchValueChange (I tried using setUploadMetaInfo here, it didn't really work, but I may have used it incorrectly). Let me know if this still needs to be looked at. 
- Note the lack of use of useStoreConnector in both ImageDisplayOption and TableDisplayOption (I have commented out the lines where we were using useStoreConnector). This is what I had mentioned when we last spoke, if I use useStoreConnector while calling the getSelectedRows function, the options are not displayed the first time a user makes multiple selections in the upload panel. But if they load images/tables and go back to the upload panel and make multiple selections, the options are now displayed. Removing useStoreConnector fixed this issue (I am not sure why). 
- Also note the use of `acceptMoc` as an option now. This starts all the way in HiPSImageSelect.jsx, where showUploadDialog (in FileUploadDropdown.jsx) is called with `acceptMoc` set to `true`. Eventually, the FileAnalysis component is passed down the acceptMoc parameter in FileUploadViewPanel, and it checks if acceptMoc is true and if the uploaded file is a MOC file (using isMOCFitsFromUploadAnalsysis). 

- **Testing**: https://fireflydev.ipac.caltech.edu/firefly-1104-fileuploadviewpanel-reusability/firefly/
   - Test uploading a MOC (search for a HiPs image first) and uploading moc and non-moc files from the upload panel dialog
   - trying to upload non-moc files should give you a warning in the upload panel 
   - try uploading fits files from the regular upload panel, make multiple selections of images/tables. Load them. Go back to the upload panel to make sure your selections are still there, edit them as needed and Load again. Make sure everything works as expected. 

**Updates (11/29)**:
- Lots of new changes. Changed the call to getNextState based on your comments here @robyww. Also small changes like getting rid of table ui id's, changing uppercase variable names of non-constants to lowercase. 
- Added keepState to FieldGroup's context. Passing keepState=false for the HiPS upload dialog. 
- removing tables in useEffect cleanup in FileUploadViewPanel 
- In FileUploadProcessor's sendImageRequest function, I commented out the line that appends the extension list to a file name (e.g.: 3emus-1-01_r99_fe55_test_1,3,4,6). Is it okay, though, that now windows with the different number of images (all loaded into one window) will have the same name in the layers popup? 
- added a popup warning when you try to load a non-moc fits file from a HiPs/MOC upload dialog (the only issue here is - there's also a warning in the upload dialog when the user uploads a non-moc fits file (this warning comes from the FileAnalysis component). But there's a bit of a lag for the warning to show up, ~1-3 seconds. I am trying to see if there's a better way to display this warning). To test this, upload a non-moc fits file from the HiPs/MOC upload dialog. And then attempt to load it. 
- The HiPs/MOC upload dialog stays up after the warning (if you attempt to load a non-MOC fits file). 
- got rid of the old showUpload function in HiPSImageSelect.jsx 

- **Testing (11/29)**: https://fireflydev.ipac.caltech.edu/firefly-1104-fileuploadviewpanel-reusability/firefly/
   - Make sure the regular upload panel works as expected. 
   - Upload a fits moc file, non-moc fits file, load multiple images/table, go back to the upload panel to make sure your previous selections show up. 
   - Then attempt to upload a non-MOC fits file from the HiPS/Moc upload dialog (should give a warning in the dialog itself). If you attempt to load this, you should get a new popup warning. 