### PR TITLE
FIREFLY-1091: changed layers popup text to be consistent

### DIFF
--- a/src/firefly/js/drawingLayers/ImageRoot.js
+++ b/src/firefly/js/drawingLayers/ImageRoot.js
@@ -80,7 +80,7 @@ function getTitle(pv, plot, drawLayer) {
     const titleEmLen= Math.min(plot.title.length+2,24);
     const minWidth= showSize || !drawLayer.isPointData ? (titleEmLen+6)+'em' : titleEmLen+'em';
     const {blank=false}= plot;
-    const hipsStr= blank ? '': 'HiPS';
+    const hipsStr= blank ? '': 'Image (HiPS)';
     return () => {
        return  (
             <div style={{
@@ -93,7 +93,7 @@ function getTitle(pv, plot, drawLayer) {
             } }
                  title={plot.title}>
                 <div>{plot.title}</div>
-                <div style={{paddingLeft: 10, fontSize:'80%'}}>{`${isHiPS(plot) ? hipsStr : 'Image'}${showSize?',':''}`}</div>
+                <div style={{paddingLeft: 10, fontSize:'80%'}}>{`${isHiPS(plot) ? hipsStr : 'Image (FITS)'}${showSize?',':''}`}</div>
                 {showSize &&
                 <div  style={{paddingLeft: 5, fontSize:'80%'}}>
                     {`Search Size: ${sprintf('%.4f',r.getSizeInDeg())}${String.fromCharCode(176)}`}


### PR DESCRIPTION
#### [Firefly-1091](https://jira.ipac.caltech.edu/browse/FIREFLY-1091)
Design ticket:   [Firefly-758](https://jira.ipac.caltech.edu/browse/FIREFLY-758)

- changed HiPS and FITS text in layers popup to "Image (HiPS)" and "Image (FITS)" respectively
- in the code, I've hardcoded `showSize` to `false` and commented out the code next to it that determines if `showSize's` value. This is in case we ever decide to go back and show "Search Size" next to "Image (FITS)" in the layers popup as we previously did. I can get rid of this code if this is not needed. 

**Testing**: https://fireflydev.ipac.caltech.edu/firefly-1091-layers-popup-text/firefly
- Search for something that'll have both FITS / HiPS. From "TAP/Table Searches", under "IRSA Catalogs", I selected "Spitzer" and searched for "m1". 
- Then with "FITS" selected, open the layers popup, and you should see "Image (FITS)" next to the title on the first line (in this case "WISE Atlas W1")
- Switch to either "HiPS" or "HiPS/Aitoff" and click on the layers popup again. Now you should see "Image (HiPS)" on the first line next to the title ("DSS Colored" in this case) 

**Updates 11/21**: 
- Search size is back for FITS images in the layers popup. Test build updated. 
