### PR TITLE
Firefly 1119: Converted RangeSliderView to functional component

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -656,7 +656,7 @@ function LcPFOptions({fields, lastPeriod, periodList=[]}) {
                                  tooptip={'slide to set period value'}
                                  slideValue={period}
                                  defaultValue={minPerN}
-                                 wrapperStyle={{marginBottom: 20, marginLeft: 9, marginRight: 25, width: highlightW}}
+                                 style={{marginBottom: 20, marginLeft: 9, marginRight: 25, width: highlightW}}
                                  decimalDig={DEC_PHASE}
                     />
                     <ValidationField fieldKey={fKeyDef.max.fkey} style={{width: pSize}}/>

--- a/src/firefly/js/ui/FitsRotationDialog.jsx
+++ b/src/firefly/js/ui/FitsRotationDialog.jsx
@@ -107,7 +107,7 @@ function FitsRotationImmediatePanel() {
                     </div>
 
                     <RangeSliderView {...{
-                        wrapperStyle:{paddingTop: 15, width: 225},
+                        style:{paddingTop: 15, width: 225},
                         min:0,max:359, step:1,vertical:false, marks,
                         defaultValue:currRotation, slideValue:currRotation,
                         handleChange:(v) => changeRotation(v)}} />

--- a/src/firefly/js/ui/RangeSlider.jsx
+++ b/src/firefly/js/ui/RangeSlider.jsx
@@ -1,6 +1,6 @@
-import React, {memo, PureComponent} from 'react';
+import React, {memo} from 'react';
 import PropTypes from 'prop-types';
-import { has, isNaN} from 'lodash';
+import {isNaN} from 'lodash';
 import {RangeSliderView, checkMarksObject} from './RangeSliderView.jsx';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 
@@ -11,29 +11,19 @@ import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
  * @param {function} fireValueChange
  */
 function handleOnChange(value, params, fireValueChange){
-     fireValueChange&&fireValueChange({
-         value
-     });
+     fireValueChange?.({value});
 
-    const {min, max} = params;    //displayValue in string, min, max, step: number
-    const {minStop=min, maxStop=max} = params;
+    const {min, max, minStop=min, maxStop=max} = params;    //displayValue in string, min, max, step: number
     const val = parseFloat(value);
 
-    if (!isNaN(val) && val >= minStop && val <= maxStop) {
-        if (has(params, 'onValueChange')) {
-            params.onValueChange(val);
-        }
-    }
+    if (!isNaN(val) && val >= minStop && val <= maxStop) params?.onValueChange(val);
 }
-
-
-// export const RangeSlider = fieldGroupConnector(RangeSliderView, getProps, propTypes, null);
 
 
 export const RangeSlider= memo( (props) => {
     const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
     return (<RangeSliderView {...viewProps}
-                            handleChange={(value) => handleOnChange(value,viewProps, fireValueChange)}/>);
+                            handleChange={(value) => handleOnChange(value, viewProps, fireValueChange)}/>);
 });
 
 
@@ -43,7 +33,6 @@ RangeSlider.propTypes={
     associatedKey: PropTypes.string,
     label:       PropTypes.string,             // slider label
     slideValue:  PropTypes.oneOfType([PropTypes.string,PropTypes.number]).isRequired, // slider value
-    value:       PropTypes.oneOfType([PropTypes.string,PropTypes.number]),
     onValueChange: PropTypes.func,                  // callback on slider change
     min:         PropTypes.number,                  // minimum end of slider
     max:         PropTypes.number,                  // maximum end of slider
@@ -53,7 +42,7 @@ RangeSlider.propTypes={
     vertical:    PropTypes.bool,                         // slider is in vertical
     defaultValue: PropTypes.number,                      // default value of slider
     handle:      PropTypes.element,                      // custom made slider handle
-    wrapperStyle: PropTypes.object,                      // wrapper style for entire component
+    style: PropTypes.object,                             // style for entire component
     sliderStyle: PropTypes.object,                       // style for slider component
     labelWidth: PropTypes.number,                        // label width
     tooltip:  PropTypes.string,                          // tooltip on label

--- a/src/firefly/js/ui/RangeSliderView.jsx
+++ b/src/firefly/js/ui/RangeSliderView.jsx
@@ -1,78 +1,50 @@
-import React, {PureComponent} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {get, has, isNumber, isString, isObject, isNaN} from 'lodash';
+import {has, isNumber, isString, isObject, isNaN} from 'lodash';
 import Slider from 'rc-slider';
 import './rc-slider.css';
 
-/**
- * @summary slider component
- */
-export class RangeSliderView extends PureComponent {
-    constructor(props) {
-        super(props);
 
-        this.state = {value: parseFloat(props.slideValue)};
-        this.onSliderChange = this.onSliderChange.bind(this);
-        const d = get(props, 'decimalDig', 3);
-        this.decimalDig = (d < 0) ? 0 : (d > 20) ? 20 : d;
-    }
-
-    static getDerivedStateFromProps(props,state) {
-        return {value: parseFloat(props.slideValue)};
-    }
-
-    onSliderChange(v) {
-        const {handleChange, minStop, maxStop} = this.props;
-
-        if (minStop && v < minStop ) {
-            v = minStop;
-        } else if (maxStop && v > maxStop) {
-            v = maxStop;
-        }
-
-        this.setState({value: v});
-        v = parseFloat(v.toFixed(this.decimalDig));
-
-        if (handleChange) {
-            handleChange(`${v}`);      //value could be any number of decimal
-        }
-    }
-
-
-    render() {
-        const {wrapperStyle={}, sliderStyle={}, className, marks, vertical,
-             defaultValue, handle, label, labelWidth, tooltip, minStop, maxStop, min, max, step} = this.props;
-        const {value} = this.state;    //displayValue in string, min, max, step: number
-        let val = parseFloat(value);
-
+export function RangeSliderView({min=0, max=100, minStop, maxStop, className, marks, step=1, vertical=false,
+                                    defaultValue=0, slideValue, handle, style={}, sliderStyle={},
+                                    label='', labelWidth, tooltip, decimalDig=3, handleChange}){
+    const toRangeBound = (val) => {
         if (minStop && val < minStop ) {
             val = minStop;
         } else if (maxStop && val > maxStop) {
             val = maxStop;
         }
-        if (isNaN(val)) val= minStop || min || 0;
+        if (isNaN(val)) val = minStop || min;
+        return val;
+    };
 
-        return (
-            <div style={wrapperStyle}>
-                <div style={Object.assign({display: 'flex'}, sliderStyle)}>
-                    <div title={tooltip} style={{width: labelWidth, marginBottom: 5}}>{label}</div>
-                    <Slider min={min}
-                            max={max}
-                            className={className}
-                            marks={marks}
-                            step={step}
-                            vertical={vertical}
-                            defaultValue={defaultValue}
-                            value={val}
-                            handle={handle}
-                            tipFormatter={null}
-                            included={true}
-                            onChange={this.onSliderChange} />
-                </div>
+    const onSliderChange = (v) => {
+        const numDecimalDigits = (decimalDig < 0) ? 0 : (decimalDig > 20) ? 20 : decimalDig;
+
+        handleChange?.(toRangeBound(v).toFixed(numDecimalDigits));
+    };
+
+    return (
+        <div style={style}>
+            <div style={{display: 'flex', ...sliderStyle}}>
+                <div title={tooltip} style={{width: labelWidth, marginBottom: 5}}>{label}</div>
+                <Slider min={min}
+                        max={max}
+                        className={className}
+                        marks={marks}
+                        step={step}
+                        vertical={vertical}
+                        defaultValue={defaultValue}
+                        value={toRangeBound(parseFloat(slideValue))}
+                        handle={handle}
+                        tipFormatter={null}
+                        included={true}
+                        onChange={onSliderChange} />
             </div>
-        );
-    }
+        </div>
+    );
 }
+
 
 RangeSliderView.propTypes = {
     min:   PropTypes.number,
@@ -85,26 +57,14 @@ RangeSliderView.propTypes = {
     vertical: PropTypes.bool,
     defaultValue: PropTypes.number,
     slideValue: PropTypes.oneOfType([PropTypes.string,PropTypes.number]).isRequired,
-    value: PropTypes.oneOfType([PropTypes.string,PropTypes.number]),
     handle: PropTypes.element,
-    wrapperStyle: PropTypes.object,
+    style: PropTypes.object,
     sliderStyle: PropTypes.object,
     label: PropTypes.string,
     labelWidth: PropTypes.number,
     tooltip:  PropTypes.string,
     decimalDig: PropTypes.number,
     handleChange: PropTypes.func           // callback on slider change
-};
-
-RangeSliderView.defaultProps = {
-    min: 0,
-    max: 100,
-    step: 1,
-    vertical: false,
-    defaultValue: 0,
-    value: 0.0,
-    label: '',
-    decimalDig: 3
 };
 
 
@@ -122,4 +82,3 @@ export function checkMarksObject(props, propName, componentName) {
         return new Error('invalid ' + propName + ' supplied to ' + componentName + '. Validation failed');
     }
 }
-

--- a/src/firefly/js/visualize/ui/ColorBandPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorBandPanel.jsx
@@ -148,7 +148,7 @@ function suggestedValuesPanel( plot,band ) {
     const dataMaxStr = `Data Max: ${sprintf('%.6f',dataMax)} `;
     const dataMinStr = `Data Min: ${sprintf('%.6f', dataMin)}`;
 
-    if (!dataMin && !dataMax) return <div style={style}/>
+    if (!dataMin && !dataMax) return <div style={style}/>;
 
     return (
         <div style={style}>
@@ -321,7 +321,7 @@ export function renderAsinH(fields, renderRange, replot, wrapperStyle={paddingBo
                          slideValue={qvalue}
                          label={label}
                          labelWidth={60}
-                         wrapperStyle={{marginTop: 10, marginBottom: 20, marginRight: 15}}
+                         style={{marginTop: 10, marginBottom: 20, marginRight: 15}}
                          decimalDig={1}
                          onValueChange={replot}
             />

--- a/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
@@ -117,7 +117,7 @@ function renderScalingCoefficients(fields, replot) {
                         slideValue={value}
                         label={label}
                         labelWidth={100}
-                        wrapperStyle={{marginTop: 10, marginBottom: 20, marginRight: 15}}
+                        style={{marginTop: 10, marginBottom: 20, marginRight: 15}}
                         decimalDig={2}
                         onValueChange={replot}
                     />);

--- a/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
@@ -59,14 +59,14 @@ const colorTables=[
     { id: 5,  icon: ColorTable5, tip: 'For False Color - Reversed' },
     { id: 6,  icon: ColorTable6, tip: 'For False Color - Compressed' },
     { id: 7,  icon: ColorTable7, tip: 'For difference images' },
-    { id: 8,  icon: ColorTable8, tip: `DS9's a color bar` },
-    { id: 9,  icon: ColorTable9, tip: `DS9's b color bar` },
-    { id: 10, icon: ColorTable10, tip: `DS9's bb color bar` },
-    { id: 11, icon: ColorTable11, tip: `DS9's he color bar` },
-    { id: 12, icon: ColorTable12, tip: `DS9's i8 color bar` },
-    { id: 13, icon: ColorTable13, tip: `DS9's aips color bar` },
-    { id: 14, icon: ColorTable14, tip: `DS9's sls color bar` },
-    { id: 15, icon: ColorTable15, tip: `DS9's hsv color bar` },
+    { id: 8,  icon: ColorTable8, tip: 'DS9\'s a color bar' },
+    { id: 9,  icon: ColorTable9, tip: 'DS9\'s b color bar' },
+    { id: 10, icon: ColorTable10, tip: 'DS9\'s bb color bar' },
+    { id: 11, icon: ColorTable11, tip: 'DS9\'s he color bar' },
+    { id: 12, icon: ColorTable12, tip: 'DS9\'s i8 color bar' },
+    { id: 13, icon: ColorTable13, tip: 'DS9\'s aips color bar' },
+    { id: 14, icon: ColorTable14, tip: 'DS9\'s sls color bar' },
+    { id: 15, icon: ColorTable15, tip: 'DS9\'s hsv color bar' },
     { id: 16, icon: ColorTable16, tip: 'Heat (ds9)' },
     { id: 17, icon: ColorTable17, tip: 'Cool (ds9)' },
     { id: 18, icon: ColorTable18, tip: 'Rainbow (ds9)' },
@@ -194,7 +194,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
         setUseBlue(useBlue);
         const colorChangeParam=  {
                         plotId:plot.plotId,
-                        cbarId: colorTableId,
+                        cbarId: Number(colorTableId),
                         bias: band===Band.NO_BAND ? newBias : newBiasAry,
                         contrast: band===Band.NO_BAND ? newContrast : newContrastAry,
                         useRed, useBlue, useGreen,
@@ -219,7 +219,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
             <div style={{display:'flex', flexDirection: 'column', alignItems: 'center'}}>
                 <div style={{padding: '5px 0 0 0'}}>Color Bar</div>
                 <RangeSliderView {...{
-                    wrapperStyle:{paddingTop: 7, width: 200},
+                    style:{paddingTop: 7, width: 200},
                     min:image?0:-1,max:21, step:1,vertical:false, marks:ctMarks,
                     defaultValue:colorTableId, slideValue:colorTableId,
                     handleChange:(v) => changeBiasContrastColor(v, bias,contrast)}} />
@@ -228,7 +228,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
             {colorTableId!==-1 ? <div style={{display:'flex', flexDirection: 'column', alignItems: 'center'}}>
                 <div style={{padding: '30px 0 0 0'}}>Bias</div>
                 <RangeSliderView {...{
-                    wrapperStyle:{paddingTop: 7, width: 200},
+                    style:{paddingTop: 7, width: 200},
                     min:8,max:32, step:1,vertical:false, marks:biasMarks,
                     defaultValue:biasInt, slideValue:biasInt,
                     handleChange:(v) => changeBiasContrastColor(colorTableId, v/40,contrast)}} />
@@ -237,7 +237,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
             {colorTableId!==-1 ? <div style={{display:'flex', flexDirection: 'column', alignItems: 'center'}}>
                 <div style={{padding: '30px 0 0 0'}}>Contrast</div>
                 <RangeSliderView {...{
-                    wrapperStyle:{paddingTop: 7, width: 200},
+                    style:{paddingTop: 7, width: 200},
                     min:0,max:20, step:1,vertical:false, marks:contrastMarks,
                     defaultValue:contrastInt, slideValue:contrastInt,
                     handleChange:(v) => changeBiasContrastColor(colorTableId, bias,v/10)}} />
@@ -270,7 +270,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
                                             <span style={{color:b.key}}>{b.key}</span> Bias
                                         </div>
                                         <RangeSliderView {...{
-                                            wrapperStyle:{paddingTop: 7, width: 200},
+                                            style:{paddingTop: 7, width: 200},
                                             min:8,max:32, step:1,vertical:false, marks:biasMarks,
                                             defaultValue:biasInt[b.value], slideValue:biasInt[b.value],
                                             handleChange:(v) => changeBiasContrastColor(colorTableId, v/40,contrast[b.value],useRed,useGreen,useBlue,b)}} />
@@ -278,7 +278,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
                                     <div style={{display:'flex', flexDirection: 'column', alignItems: 'center'}}>
                                         <div style={{padding: '30px 0 0 0'}}><span style={{color:b.key}}>{b.key}</span> Contrast</div>
                                         <RangeSliderView {...{
-                                            wrapperStyle:{paddingTop: 7, width: 200},
+                                            style:{paddingTop: 7, width: 200},
                                             min:0,max:20, step:1,vertical:false, marks:contrastMarks,
                                             defaultValue:contrastInt[b.value], slideValue:contrastInt[b.value],
                                                         handleChange:(v) => changeBiasContrastColor(colorTableId, bias[b.value],v/10, useRed,useGreen,useBlue,b)}} />


### PR DESCRIPTION
Fixes [FIREFLY-1119](https://jira.ipac.caltech.edu/browse/FIREFLY-1119)

- This component doesn't really require state, so removed that and made it a pure functional component.
- Cleaned up code and removed unused `value` prop
- Replaced `wrapperStyle` with `style`

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1119-range-slider-func/firefly/

Go to Table Search > IRSA Catalogs > Search. Now on Image toolbar, go to:
- Color dropdown for testing all 3 sliders
- Tools > Rotate Image for testing rotation slider 

Go to Time Series tool, then:
- In the images panel (bottom), go to the toolbar and select stretch dropdown (4th icon) and then color stretch option (1st option). Make sure "Asinh" stretch type is selected, for testing the slider for setting Q
- Click the period finder button, test the slider to set period.