### PR TITLE
FIREFLY-1091 increased maxWidth of layers popup

### DIFF
--- a/src/firefly/js/drawingLayers/ImageRoot.js
+++ b/src/firefly/js/drawingLayers/ImageRoot.js
@@ -79,6 +79,7 @@ function getTitle(pv, plot, drawLayer) {
     const showSize= Boolean(r.getSizeInDeg() && isImage(plot) );
     const titleEmLen= Math.min(plot.title.length+2,24);
     const minWidth= showSize || !drawLayer.isPointData ? (titleEmLen+6)+'em' : titleEmLen+'em';
+    const maxWidth=450;
     const {blank=false}= plot;
     const hipsStr= blank ? '': 'Image (HiPS)';
     return () => {
@@ -86,19 +87,19 @@ function getTitle(pv, plot, drawLayer) {
             <div style={{
                 display: 'inline-flex',
                 alignItems: 'center',
-                width: 100,
+                maxWidth,
                 minWidth,
                 overflow: 'hidden',
                 textOverflow: 'ellipsis'
             } }
                  title={plot.title}>
-                <div>{plot.title}</div>
-                <div style={{paddingLeft: 10, fontSize:'80%'}}>{`${isHiPS(plot) ? hipsStr : 'Image (FITS)'}${showSize?',':''}`}</div>
-                {showSize &&
-                <div  style={{paddingLeft: 5, fontSize:'80%'}}>
-                    {`Search Size: ${sprintf('%.4f',r.getSizeInDeg())}${String.fromCharCode(176)}`}
-                </div>
-                }
+                 <div>{plot.title}</div>
+                 <div style={{paddingLeft: 10, fontSize:'80%'}}>{`${isHiPS(plot) ? hipsStr : 'Image (FITS)'}${showSize?',':''}`}</div>
+                 {showSize &&
+                 <div  style={{paddingLeft: 5, fontSize:'80%'}}>
+                   {`Search Size: ${sprintf('%.4f',r.getSizeInDeg())}${String.fromCharCode(176)}`}
+                 </div>
+                 }
             </div>
         );
     };


### PR DESCRIPTION
#### [Firefly-1091](https://jira.ipac.caltech.edu/browse/FIREFLY-1091)  
- Increased max width of the layers popup to compensate for longer file names 

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1091-layerswidth/firefly
 - go to the Upload panel and upload a fits file (ideally one with multiple images) and select all images. Select the default option "All images in one window" and load all images. 
 - Go back to the upload panel, and load just one or two images this time. 
 - Then bring up the layers popup and switch between the images and notice how the width of the layers popup changes (increases for the one with multiple images because of the current naming convention - this will be changed in my other ticket **Firefly-1104**, but for now this serves as a good way to test long file names - the other option is to just use a file with a really long name). 

Possible bug: 
I noticed that, while switching between images with the layers popup open, sometimes the sub plot title (the plot title inside the layers popup, not in its header) doesn't change. The header plot title still changes as expected when you switch between images. Noticed this bug on ops too, though. 