### PR TITLE
Firefly-1124 hips tabs

### DIFF
--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -23,8 +23,6 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                 visible={true}
                 message={message}
                 onChange={onChange}
-                onBlur={() => onUrlAnalysis(value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') onUrlAnalysis(value); }}
                 type={isFromURL ? 'text' : 'file'}
                 label={label}
                 value={value}

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -23,6 +23,8 @@ function FileUploadView({fileType, isLoading, label, valid, wrapperStyle,  messa
                 visible={true}
                 message={message}
                 onChange={onChange}
+                onBlur={() => onUrlAnalysis(value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') onUrlAnalysis(value); }}
                 type={isFromURL ? 'text' : 'file'}
                 label={label}
                 value={value}

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -76,7 +76,7 @@ export function resultSuccess(request) {
         if (request.mocOp==='table') mocMeta[MetaConst.IGNORE_MOC]='true';
         //loadToUI = true if request.mocOp==='table', else loadToUI=false
         sendTableRequest(tableIndices, fileCacheKey, Boolean(request.tablesAsSpectrum==='spectrum'), currentReport, Boolean(request.mocOp==='table'), mocMeta);
-        //this will signal to showUploadDialog in FileUploadDropdown.jsx to hide the upload dialog (from a HiPs/MOC upload)
+        //this will signal HiPSImageSelect's 'Add MOC Layer dialog' to hide itself
         return true;
     } else if ( isLsstFootprintTable(currentDetailsModel) ) {
         sendLSSTFootprintRequest(fileCacheKey, request.fileName, tableIndices[0]);

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -89,7 +89,7 @@ export function showHiPSSurveysPopup(pv, moc= false) {
             if (rootUrl) {
                 const plot = pv ? primePlot(pv) : primePlot(visRoot());
                 // update the table highlight of the other one which is not shown in table panel
-                moc ? createHiPSMocLayer(getIvoaId(), getTitle(), rootUrl, primePlot(pv), true).then() :
+                moc ? createHiPSMocLayer(getIvoaId(), getTitle(), rootUrl, primePlot(pv), true) :
                     dispatchChangeHiPS({plotId: plot.plotId, hipsUrlRoot: rootUrl});
                 dispatchHideDialog(DIALOG_ID);
             }
@@ -109,7 +109,7 @@ export function showHiPSSurveysPopup(pv, moc= false) {
                             help_id='visualization.changehips'>
                     {moc &&
                         <FieldGroupTabs initialState= {{ value:'search' }} fieldKey='mocTabs'
-                                            style={{minWidth:600, minHeight:500, width:'100%', height: '100%'}}>
+                                            style={{minWidth:715, minHeight:500, width:'100%', height: '100%'}}>
                             <Tab name='Search' id='search'>
                                 <div className='ImageSearch__HipsPopup' style={{padding: '5px 0px 0px 0px'}}>
                                     <SourceSelect moc={moc}/>
@@ -118,14 +118,14 @@ export function showHiPSSurveysPopup(pv, moc= false) {
                             </Tab>
 
                             <Tab name='Use my MOC' id='uploadMoc'>
-                                <div style={{width: '100%'}} >
+                                <div style={{width:'100%', minWidth:715, minHeight:500}} >
                                     <FileUploadViewPanel acceptMoc={true}/>
                                 </div>
                             </Tab>
                         </FieldGroupTabs>}
 
                     {!moc &&
-                        <div className='ImageSearch__HipsPopup' style={{minWidth:600, minHeight:500}}>
+                        <div className='ImageSearch__HipsPopup' style={{minWidth:715, minHeight:500}}>
                             <SourceSelect moc={moc}/>
                             <HiPSSurveyTable groupKey={groupKey} moc={moc}/>
                         </div>}

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -29,9 +29,10 @@ import {primePlot} from '../visualize/PlotViewUtil.js';
 import {BLANK_HIPS_URL} from '../visualize/WebPlot.js';
 import {createHiPSMocLayer} from 'firefly/visualize/task/PlotHipsTask.js';
 import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
-import CompleteButton from 'firefly/ui/CompleteButton.jsx';
 import {getDefaultMOCList} from 'firefly/visualize/HiPSMocUtil.js';
-import {showUploadDialog} from 'firefly/ui/FileUploadDropdown.jsx';
+import {FieldGroupTabs, Tab} from 'firefly/ui/panel/TabPanel';
+import {FileUploadViewPanel} from 'firefly/visualize/ui/FileUploadViewPanel';
+import {resultSuccess} from 'firefly/ui/FileUploadProcessor';
 
 const useSourceHiPS = 'useSourceHiPS';
 const useSourceMOC = 'useSourceMOC';
@@ -69,7 +70,6 @@ HiPSImageSelect.propTypes = {
 
 const DIALOG_ID = 'HiPSImageSelectPopup';
 
-
 /**
  * show HiPS survey info table in popup panel
  * @param {PlotView} pv
@@ -80,38 +80,57 @@ export function showHiPSSurveysPopup(pv, moc= false) {
 
     const groupKey = activeGroupKey || DIALOG_ID;
 
-    const onSubmit = () => {
-        const rootUrl = getHipsUrl();
-        if (rootUrl) {
-            const plot = pv ? primePlot(pv) : primePlot(visRoot());
-            // update the table highlight of the other one which is not shown in table panel
-            moc ? createHiPSMocLayer(getIvoaId(), getTitle(), rootUrl, primePlot(pv), true).then() :
-                  dispatchChangeHiPS({plotId: plot.plotId, hipsUrlRoot: rootUrl});
-            dispatchHideDialog(DIALOG_ID);
+    const onSubmit = (request) => {
+        if (request.mocTabs === 'uploadMoc') {
+            if (resultSuccess(request)) dispatchHideDialog(DIALOG_ID);
+        }
+        else {
+            const rootUrl = getHipsUrl();
+            if (rootUrl) {
+                const plot = pv ? primePlot(pv) : primePlot(visRoot());
+                // update the table highlight of the other one which is not shown in table panel
+                moc ? createHiPSMocLayer(getIvoaId(), getTitle(), rootUrl, primePlot(pv), true).then() :
+                    dispatchChangeHiPS({plotId: plot.plotId, hipsUrlRoot: rootUrl});
+                dispatchHideDialog(DIALOG_ID);
+            }
         }
     };
 
     const popup = (
         <PopupPanel title={moc ? 'Add MOC Layer' : 'Change HiPS Image'} modal={true}>
-            <FormPanel  submitBarStyle = {{flexShrink: 0, padding: '0 6px 3px 6px'}}
-                        style={ {resize:'both', overflow: 'hidden', zIndex:1}}
-                        groupKey = {groupKey}
-                        submitText={moc ? 'Add MOC' : 'Change HiPS'}
-                        onSubmit = {onSubmit}
-                        onCancel = {() => dispatchHideDialog(DIALOG_ID)}
-                        params={{disabledDropdownHide: true}}
-                        help_id = 'visualization.changehips'>
-                <FieldGroup groupKey={groupKey} keepState={true} style={{width:'100%', height:'100%'}}>
-                    <div className='ImageSearch__HipsPopup'>
-                        <SourceSelect moc={moc}/>
-                        <HiPSSurveyTable groupKey={groupKey} moc={moc}/>
-                        {moc && <div style={{display:'flex', padding: '6px 15px 0 0', justifyContent:'flex-end'}}>
-                            <div style={{lineHeight:'25px', height: 25, paddingRight: 4, fontWeight:'bold'}}> To Upload a MOC: </div>
-                            <CompleteButton text='Upload' groupKey='' onSuccess={() => showUploadDialog(true, false, 'FileUploadHips')} />
+            <FieldGroup groupKey={groupKey} keepState={true} style={{width:'100%', height: '100%'}}>
+                <FormPanel submitBarStyle={{flexShrink: 0, padding: '0px 6px 3px 6px'}}
+                           style={ { resize:'both', overflow: 'hidden', zIndex:1}}
+                            groupKey={groupKey}
+                            submitText={moc ? 'Add MOC' : 'Change HiPS'}
+                            onSubmit={onSubmit}
+                            onCancel={() => dispatchHideDialog(DIALOG_ID)}
+                            params={{disabledDropdownHide: true}}
+                            help_id='visualization.changehips'>
+                    {moc &&
+                        <FieldGroupTabs initialState= {{ value:'search' }} fieldKey='mocTabs'
+                                            style={{minWidth:600, minHeight:500, width:'100%', height: '100%'}}>
+                            <Tab name='Search' id='search'>
+                                <div className='ImageSearch__HipsPopup' style={{padding: '5px 0px 0px 0px'}}>
+                                    <SourceSelect moc={moc}/>
+                                    <HiPSSurveyTable groupKey={groupKey} moc={moc}/>
+                                </div>
+                            </Tab>
+
+                            <Tab name='Use my MOC' id='uploadMoc'>
+                                <div style={{width: '100%'}} >
+                                    <FileUploadViewPanel acceptMoc={true}/>
+                                </div>
+                            </Tab>
+                        </FieldGroupTabs>}
+
+                    {!moc &&
+                        <div className='ImageSearch__HipsPopup' style={{minWidth:600, minHeight:500}}>
+                            <SourceSelect moc={moc}/>
+                            <HiPSSurveyTable groupKey={groupKey} moc={moc}/>
                         </div>}
-                    </div>
-                </FieldGroup>
-            </FormPanel>
+                </FormPanel>
+            </FieldGroup>
         </PopupPanel>
     );
 

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -78,7 +78,6 @@ export function FileUploadViewPanel({setSubmitText, acceptMoc}) {
     const {message, analysisResult, report, summaryModel, detailsModel, prevAnalysisResult} =
         useStoreConnector(() => {
             const loadingOp= getLoadingOp();
-            console.log('loadingOp: ' + loadingOp);
             const {analysisResult, message}= getField(groupKey, loadingOp) || {};
             const summaryTbl= getTblById(summaryTblId);
             return getNextState(summaryTblId, summaryTbl, detailsTblId, analysisResult, message, getUploadMetaInfo());

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -590,6 +590,11 @@ const FileAnalysis = ({report, summaryModel, detailsModel, tablesOnly, isMoc, UN
 
     else {
         const liStyle= {listStyleType:'circle'};
+        if (acceptMoc) {
+            return (<div style={{color:'gray', margin:'20px 0 0 200px', fontSize:'larger', lineHeight:'1.3em'}}>
+                Note: You can only load a MOC FITS file from this dialog
+            </div>);
+        }
         return (<div style={{color:'gray', margin:'20px 0 0 200px', fontSize:'larger', lineHeight:'1.3em'}}>
             You can load any of the following types of files:
             <ul>


### PR DESCRIPTION
#### [Firefly-1124](https://jira.ipac.caltech.edu/browse/FIREFLY-1124): 
  - added upload panel as a FieldGroupTab (alongside "Search" / "Featured MOC") in the HiPS/MOC **Add MOC Layer** dialog 
  - keepState for this FieldGroup is currently set to true. Should I change it to false? (it was false when we were launching the upload dialog separately from the HiPS/MOC **Add MOC Layer** dialog)

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1124-hips-tabs/firefly
 - open a HiPS image (search for m1, choose image type "View HiPS Image") 
 - From the **HiPS/MOC** dropdown, select **Add MOC Layer**. Toggle between "Search" and "Use my MOC" tabs. 
 - In the "Use my MOC" tab, attempt to upload a non-MOC file (should give you warning), and if you attempt to load it, you should get a popup error/warning. Now attempt to upload a moc fits file, this should work as expected. Make you selections and "Add MOC" (the dialog should close now). 
 - Add MOC from the "Search" tab as well. 
 - try and change the size of the dialog (for both tabs, the content should stretch and fit within the dialog)
 -  From the **HiPS/MOC** dropdown, select **Change HiPS**, this should work as expected as well (the only thing I changed for this one was its size - to make it consistent with the size of the **Add MOC Layer** dialog's size). 

**Bug fixes**
- There was a bug from my previous work on the upload panel, where switching to 'Upload from URL' would not work (it would show the same prompt as that for 'Upload file'. This is now fixed in the latest build (as of 12/7). 

**Updates 12/6**: 
- used acceptMoc in FileUploadViewPanel to restrict showing "Load as MOC Overlay" & "Load as Table" options, and also "Attempt to interpret tables as spectra" (if you attempt to upload a .tbl file)
    - I should perhaps change **acceptMoc** to **onlyMoc** or **acceptOnlyMoc** as I think that's more indicative of what we're trying to do here? 
- fixed the padding between "Search" and the Featured MOC checkbox under it 
- made the changes in FieldGroup and  setSubmitText as requested 
- **Testing**: 
    - Same build link 
    - Use the regular upload panel to make sure it works as expected (upload non-moc fits file, tbl file and moc fits file - you should see radio button options as expected). 
    - Attempt to do the same from the **Add MOC Layer** dialog, and you should only be able to upload a moc fits file (and you should not see any options here).  


**Updates 12/9**: 
- the "Add MOC Layer" dialog size is bigger and should not change much now even with the additional of the URL input and/or 'Clear File'. The same height/width have been applied to the "Change HiPS" dialog too to keep things consistent. 
   - there is a small issue: if the user tries to resize this dialog and make it smaller, we lose the "Add MOC" text (as it gets smaller than minHeight). This is a pre-existing issue, but with the default dialog size even bigger now, it's probably more likely that a user may try and resize the dialog to make it smaller. 
- In the "Use my MOC" tab, before you upload a file, the supported format list has been downsized to include only MOC FITS files 
- some cleanup based on feedback
- - **Testing**: 
    - Same build link 
    -  Upload moc fits and non-fits files from the **Add MOC Layer** dialog, and you should only be able to upload a moc fits file. Also attempt to upload from the URL (test URL you can use: https://irsa.ipac.caltech.edu/data/hips/ESAC/PACS-color/Moc.fits) 
