### PR TITLE
FIREFLY-1116: Echo version information to console log and /admin/status panel

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/Version.java
@@ -22,7 +22,7 @@ public class Version implements Serializable {
     private String      _appName= "Web App";
     private int         _major= 0;
     private int         _minor= 0;
-    private int         _rev= 0;
+    private String      _rev= "0";
     private VersionType _vType= VersionType.Unknown;
     private int         _build = 0;
     private String      _buildDate= "Don't Know";
@@ -31,6 +31,7 @@ public class Version implements Serializable {
     private String      _buildCommit= "";
     private String      _buildCommitFirefly= "";
     private String      _buildFireflyTag = "";
+    private String      _buildFireflyBranch = "";
     private String      _devCycleTag = "";
     private long        _configLastModTime = 0;
 
@@ -51,7 +52,7 @@ public class Version implements Serializable {
     public void setMinor(int m) { _minor= m;}
     public void setVersionType(VersionType vt) { _vType= vt; }
     public void setBuildDate(String date) { _buildDate= date;}
-    public void setRev(int rev) { _rev = rev;  }
+    public void setRev(String rev) { _rev = rev;  }
     /**
      * The build number is only use if type is not final.  Finals should not have a build number
      * @param build build number, not used with final
@@ -75,6 +76,9 @@ public class Version implements Serializable {
     }
 
     public void setBuildFireflyTag(String buildFireflyTag) { this._buildFireflyTag = buildFireflyTag; }
+
+    public void setBuildFireflyBranch(String buildFireflyBranch) { this._buildFireflyBranch = buildFireflyBranch; }
+
     public void setDevCycleTag(String devCycleTag) { this._devCycleTag = devCycleTag; }
 
     public String getBuildTime() {
@@ -95,19 +99,20 @@ public class Version implements Serializable {
 
     public int getMajor() { return _major;}
     public int getMinor() { return _minor;}
-    public int getRev() { return _rev;}
+    public String getRev() { return _rev;}
     public VersionType getVersionType() { return _vType; }
     public String getBuildDate() { return _buildDate; }
     public int getBuildNumber() { return _build;  }
     public String getAppName() { return _appName; }
     public String getBuildFireflyTag() { return _buildFireflyTag; }
+    public String getBuildFireflyBranch() { return _buildFireflyBranch; }
     public String getDevCycleTag() { return _devCycleTag; }
 
     @Override
     public String toString() {
         String retval = _major + "." + _minor;
 
-        if (_rev > 0) {
+        if (!_rev.equals("0")) {
             retval += "." + _rev;
         }
         retval += " " + convertVersionType(_vType);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/Counters.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/Counters.java
@@ -10,6 +10,7 @@ package edu.caltech.ipac.firefly.server;
 
 
 import edu.caltech.ipac.firefly.server.security.SsoAdapter;
+import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.util.ComparisonUtil;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
@@ -154,8 +155,12 @@ public class Counters {
         addToList(retList, "Auth Token", (ssoAdapter != null && ssoAdapter.getAuthToken() != null) ? ssoAdapter.getAuthToken().getId() : null);
         addToList(retList, "Session ID", ServerContext.getRequestOwner().getRequestAgent().getSessId());
         addToList(retList, "User Key", ServerContext.getRequestOwner().getUserKey());
+
         retList.add("");
         addMemoryStatus(retList);
+
+        retList.add("");
+        addVersionInfo(retList);
 
         String pagesCat= Category.Pages.toString();
         List<String> pagesList= new ArrayList<String>(300);
@@ -226,6 +231,14 @@ public class Counters {
         addMemStrToList(retList,"Total Active", FileUtil.getSizeAsString(totMem));
         retList.add("");
         retList.add("Cores - "+ Runtime.getRuntime().availableProcessors());
+        retList.add("");
+    }
+
+
+    private void addVersionInfo(List<String> retList) {
+        retList.add("Version Information");
+        VersionUtil.getVersionInfo().forEach(verInfoKeyVal ->
+                addToList(retList, verInfoKeyVal.getKey(), verInfoKeyVal.getValue()));
         retList.add("");
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/VersionUtil.java
@@ -5,15 +5,19 @@ package edu.caltech.ipac.firefly.server.util;
 
 import edu.caltech.ipac.firefly.data.Version;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.util.KeyVal;
 import edu.caltech.ipac.util.StringUtils;
 
 import javax.servlet.ServletContext;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 /**
  * User: roby
  * Date: May 15, 2009
@@ -37,6 +41,7 @@ public class VersionUtil {
     private static final String BUILD_COMMIT  ="BuildCommit";
     private static final String BUILD_COMMIT_FIREFLY  ="BuildCommitFirefly";
     private static final String BUILD_FIREFLY_TAG ="BuildFireflyTag";
+    private static final String BUILD_FIREFLY_BRANCH ="BuildFireflyBranch";
     private static final String DEV_CYCLE_TAG ="DevCycleTag";
 
     private static final String VERSION_FILE = "version.tag";
@@ -54,6 +59,7 @@ public class VersionUtil {
         if (context!=null && !init) {
             init= true;
             ingestVersion(context);
+            logVersionInfo();
         }
     }
 
@@ -68,7 +74,7 @@ public class VersionUtil {
             props.load(new FileInputStream(new File(confDir, VERSION_FILE)));
             _version.setMajor(getNum(props.getProperty(MAJOR)));
             _version.setMinor(getNum(props.getProperty(MINOR)));
-            _version.setRev(getNum(props.getProperty(REV)));
+            _version.setRev(props.getProperty(REV));
             _version.setVersionType(Version.convertVersionType(props.getProperty(TYPE)));
             _version.setBuild(getNum(props.getProperty(BUILD_NUMBER)));
             _version.setBuildDate(props.getProperty(BUILD_DATE));
@@ -77,6 +83,7 @@ public class VersionUtil {
             _version.setBuildCommit(props.getProperty(BUILD_COMMIT));
             _version.setBuildCommitFirefly(props.getProperty(BUILD_COMMIT_FIREFLY));
             _version.setBuildFireflyTag(props.getProperty(BUILD_FIREFLY_TAG));
+            _version.setBuildFireflyBranch(props.getProperty(BUILD_FIREFLY_BRANCH));
             _version.setDevCycleTag(props.getProperty(DEV_CYCLE_TAG));
         } catch (IOException e) {
             // just ignore
@@ -119,6 +126,70 @@ public class VersionUtil {
         } catch (Exception e) {
             return unknownVersionUA;
         }
+    }
+
+    public static List<KeyVal<String, String>> getVersionInfo() {
+        Version v = getAppVersion();
+
+        List<KeyVal<String, String>> versionInfo = new ArrayList<>(6);
+        versionInfo.add(new KeyVal<>("Version", getVersionStr(v)));
+        versionInfo.add(new KeyVal<>("Built On", v.getBuildTime()));
+        versionInfo.add(new KeyVal<>("Git commit", v.getBuildCommit()));
+
+        if (v.getMajor()>0)
+            versionInfo.add(new KeyVal<>("Firefly Library Version", getFireflyVersionStr(v)));
+        if (!StringUtils.isEmpty(v.getBuildCommitFirefly()))
+            versionInfo.add(new KeyVal<>("Firefly Git Commit", v.getBuildCommitFirefly()));
+        if (!StringUtils.isEmpty(v.getBuildFireflyTag()))
+            versionInfo.add(new KeyVal<>("Firefly Git Tag", v.getBuildFireflyTag()));
+
+        return versionInfo;
+    }
+
+    private static String getVersionStr(Version v) {
+        Integer major = v.getMajor();
+
+        if (major>0) {
+            String versionStr = String.format("v%s.%s", major, v.getMinor());
+            String buildRev = v.getRev();
+            versionStr += buildRev.equals("0") ? "" : String.format(".%s", buildRev);
+            return versionStr;
+        }
+        else return getFireflyVersionStr(v);
+    }
+
+    private static String getFireflyVersionStr(Version v) {
+        String fireflyTag = v.getBuildFireflyTag();
+        String fireflyCommit = v.getBuildCommitFirefly();
+        String fireflyBranch = v.getBuildFireflyBranch();
+        if (StringUtils.isEmpty(fireflyBranch)) fireflyBranch = "unknown-branch";
+
+        Matcher formalReleaseMatcher = Pattern.compile("release-(\\d+(\\.\\d+)+)").matcher(fireflyTag);
+        if (formalReleaseMatcher.find()) return formalReleaseMatcher.group(1);
+
+        Matcher preReleaseMatcher = Pattern.compile("pre-(\\d+)-(\\d+(\\.\\d+)+)").matcher(fireflyTag);
+        if (preReleaseMatcher.find()) return String.format("%s-PRE-%s", preReleaseMatcher.group(2), preReleaseMatcher.group(1));
+
+        String devCycleTag = v.getDevCycleTag();
+        Matcher cycleMatcher = Pattern.compile("cycle-(\\d+\\.\\d+)").matcher(devCycleTag);
+        String devCycle = cycleMatcher.find() ? cycleMatcher.group(1) : "";
+        if (!StringUtils.isEmpty(devCycle)) {
+            String commit = StringUtils.isEmpty(fireflyCommit) ? v.getBuildCommit() : fireflyCommit;
+            return String.format("%s-DEV%s_%s",
+                    devCycle,
+                    fireflyBranch.equals("dev") ? "" : (":" + fireflyBranch),
+                    commit.substring(0, 4));
+        }
+
+        return String.format("0.0-%s-development", fireflyBranch);
+    }
+
+    private static void logVersionInfo() {
+        List<String> versionInfoStrings = VersionUtil.getVersionInfo().stream()
+                .map(verInfoKeyVal -> String.format("%-25s : %s", verInfoKeyVal.getKey(), verInfoKeyVal.getValue()))
+                .collect(Collectors.toList());
+        versionInfoStrings.add(0, ""); // so that log is properly formatted
+        Logger.info(versionInfoStrings.toArray(String[]::new)); // pass List as arguments of a single Logger.info call
     }
 }
 


### PR DESCRIPTION
Fixes [FIREFLY-1116](https://jira.ipac.caltech.edu/browse/FIREFLY-1116)

TODOs:
- [x] Print version info to console log and /admin/status panel
- [x] Parse build tags to generate version string
- [x] Debug why version info is empty on console log
- [x] Make info string nicely formatted like surrounding logs

## Testing
### /admin/status panel
https://firefly-1116-echo-version.irsakudev.ipac.caltech.edu/irsaviewer/admin/status

https://fireflydev.ipac.caltech.edu/firefly-1116-echo-version/firefly/admin/status

### console log
I couldn't find them on jenkins build console, hence attachin console logs at my local machine (see last 6 lines of each):

```
==> /Users/jsinghal/dev/server/tomcat/logs/irsaviewer.log <==
12/08 17:51:40  INFO   Thread: Catalina-utility-1  cache.EhcacheProvider#log:315
        shared cache manager config file: /Users/jsinghal/dev/server/tomcat/webapps/irsaviewer/WEB-INF/config/shared_ehcache.xml
12/08 17:51:40  INFO   Thread: Catalina-utility-1  server.ServerContext#log:315
        
    CACHE_PROVIDER : edu.caltech.ipac.firefly.server.cache.EhcacheProvider
    WORK_DIR       : /Users/jsinghal/dev/server/tomcat/temp/workarea/irsaviewer
    Available Cores: 10
12/08 17:51:40  INFO   Thread: Catalina-utility-1  server.ServerContext#log:315
        visualize.fits.search.path loaded: 
    
    
    /Library/WebServer/Documents
    /irsadata
    /stage/irsa-wise-links-public
    /irsadata/Planck
    /stage/irsa-ptf-links
    @ztf.filesystem_basepath@
    /stage/lco-data-dev/LCOGT/lco-link-001
    /irsadata/LSST/dr-s2012/sdss/coadd/rr1000/s4S
    All local loaded FITS files must resides in these directories or sub-directories
12/08 17:51:40 DEBUG   Thread: Catalina-utility-1  query.SearchProcessorFactory#log:315
        Getting search processors took 163ms
12/08 17:51:40  INFO   Thread: Catalina-utility-1  query.SearchProcessorFactory#log:315
        e service and first params. optional: almost never used
   "PtfProcImagesFileRetrieve" - edu.caltech.ipac.firefly.server.query.ptf.PtfProcimsFileRetrieve
   "StatisticsProcessor" - edu.caltech.ipac.firefly.server.query.StatisticsProcessor
   "GatorMOS" - edu.caltech.ipac.firefly.server.catquery.GatorMOS
   "TableFromExternalTask" - edu.caltech.ipac.firefly.server.query.IpacTableFromExternalTask
   "irsaCatalogMasterTable" - edu.caltech.ipac.firefly.server.catquery.CatMasterTableQuery
   "ExtractFromImage" - edu.caltech.ipac.firefly.server.query.ExtractFromImage
        param: extractionType       - should be one of z-axis, line, or points
        param: pt                   - image point
        param: wpt                  - world point
        param: pt2                  - second image point, if line
        param: ptAry                - for point selection
        param: wptAry               - for point selection, added to the created table
        param: wlAry                - an array of wavelength to add to the table, added to the created table
        param: wlUnit               - wavelength units. if defined
        param: fluxUnit             - flux units. if defined
        param: filename             - filename on the server
        param: refHDUNum            - hdu number to extract
        param: extractionSize       - number of the square size of the extract, i.e. 4 would be 4x4
        param: allMatchingHDUs      - extract every HDU that matches the refHDU
   "ZtfFileRetrieve" - edu.caltech.ipac.firefly.server.query.ztf.ZtfFileRetrieve
   "SubQueryProcessor" - edu.caltech.ipac.firefly.server.query.SubQueryProcessor
   "SDSSQuery" - edu.caltech.ipac.firefly.server.catquery.SDSSQuery
        param: radiusArcMin         - float, the radius in arcminutes
        param: UserTargetWorldPt    - WorldPt string: ra;dec;coord_sys
        param: filename             - for upload, not yet used
        param: nearest_only         - return only one match per target

12/08 17:51:40  INFO   Thread: Catalina-utility-1  server.AlertsMonitor#log:315
        alerts.dir is not a directory: 
    Use workarea/alerts instead
12/08 17:51:40  INFO   Thread: Catalina-utility-1  util.VersionUtil#log:315
        
    Version                   : v5.3.2021.3.2
    Built On                  : Thu Dec 08 17:51:27 PST 2022
    Git commit                : c688a82
    Firefly Library Version   : 2022.3-DEV:FIREFLY-1116-echo-version_3656
    Firefly Git Commit        : 365675264
```

```
==> /Users/jsinghal/dev/server/tomcat/logs/firefly.log <==
12/08 17:53:02  INFO   Thread: Catalina-utility-2  cache.EhcacheProvider#log:315
        shared cache manager config file: /Users/jsinghal/dev/server/tomcat/webapps/firefly/WEB-INF/config/shared_ehcache.xml
12/08 17:53:02  INFO   Thread: Catalina-utility-2  server.ServerContext#log:315
        
    CACHE_PROVIDER : edu.caltech.ipac.firefly.server.cache.EhcacheProvider
    WORK_DIR       : /Users/jsinghal/dev/server/tomcat/temp/workarea/firefly
    Available Cores: 10
12/08 17:53:02  INFO   Thread: Catalina-utility-2  server.ServerContext#log:315
        visualize.fits.search.path loaded: 
    /irsadata
    
    /firefly
    @wise.filesystem_basepath@
    @planck.filesystem_basepath@
    @ptf.filesystem_basepath@
    @ztf.filesystem_basepath@
    @lcogt.filesystem_basepath@
    @lsst.filesystem_basepath@
    All local loaded FITS files must resides in these directories or sub-directories
12/08 17:53:02 DEBUG   Thread: Catalina-utility-2  query.SearchProcessorFactory#log:315
        Getting search processors took 162ms
12/08 17:53:02  INFO   Thread: Catalina-utility-2  query.SearchProcessorFactory#log:315
         side for a box search
        param: radunits             - the units for the radius or side, must be arcsec,arcmin,degree, default arcsec
        param: catalog              - the catalog name to search
        param: RaDecJ2000           - the ra and dec in j2000 separated by a space
        param: filename             - for upload, not yet used
        param: posang               - pa for elliptical request
        param: ratio                - ratio for elliptical request
        param: polygon              - a set of coordinate pairs (up to 15), eg. 20.5 21.5, 20.5 20.5, 21.5 20.5
        param: selcols              - a comma separated list of columns to return, empty gives the default list
        param: constraints          - a where fragment of the column constrains
        param: database             - the database to search against
        param: server               - i am not sure what this one means
        param: ddfile               - the dd file to use
        param: onlist               - search catalog that is on list, optional: default true
        param: xpffile              - the xpf file to be used on the server when SearchMethod is Table, not used for other SearchMethods, optional when onlist is true, required when onlist is false.  example xpf file: /xpf/catupd.fp_psc.xpf
        param: GatorHost            - The hostname for the gator URL. optional: almost never used
        param: Service              - the part of the URL string that specifies the service and first params. optional: almost never used
        param: use                  - how this catalog will be used on the client: value: primary or overlay; default overlay.  if overlay then the meta value CatalogOverlayType is set otherwise it is not
   "StatisticsProcessor" - edu.caltech.ipac.firefly.server.query.StatisticsProcessor
   "catScan" - edu.caltech.ipac.firefly.server.catquery.CatScanQuery
   "ZtfLcDownload" - edu.caltech.ipac.firefly.server.query.lc.ZtfLCFileGroupsProcessor

12/08 17:53:02  INFO   Thread: Catalina-utility-2  server.AlertsMonitor#log:315
        alerts.dir is not a directory: null
    Use workarea/alerts instead
12/08 17:53:02  INFO   Thread: Catalina-utility-2  util.VersionUtil#log:315
        
    Version                   : 2022.3-DEV:FIREFLY-1116-echo-version_3656
    Built On                  : Thu Dec 08 17:52:46 PST 2022
    Git commit                : 365675264
```