### PR TITLE
add base path settings to Firefly docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -159,22 +159,13 @@ COPY firefly/docker/tomcat-users.xml firefly/docker/java.security.override conf/
 COPY firefly/docker/local.xml conf/Catalina/localhost
 
 #copy all wars, typically there should only be one
-COPY --from=builder /opt/work/${build_dir}/build/dist/*.war ${CATALINA_HOME}/webapps/
-
-# extract all war files into tomcat's webapps; mod log4j to have log sent to stdout as well
-WORKDIR ${CATALINA_HOME}/webapps
-RUN for n in *.war; do \
-    war_dir=`basename $n .war`; \
-    mkdir -p $war_dir; \
-    unzip -oqd $war_dir $n; \
-    sed -E -i.bak 's/##out--//' $war_dir/WEB-INF/classes/log4j2.properties; \
-    done
+COPY --from=builder /opt/work/${build_dir}/build/dist/*.war ${CATALINA_HOME}/webapps-ref/
 
 # Add permission to files and directories needed for runtime
 # increase max header size to avoid failing on large auth token
 WORKDIR ${CATALINA_HOME}
 RUN chmod a+x *.sh \
-  && chmod -R a+w *.txt temp work /local/www /firefly \
+  && chmod -R a+w *.txt temp work /local/www /firefly ${CATALINA_HOME}/webapps \
   && sed -i 's/Connector port="8080"/Connector maxHttpHeaderSize="24576" port="8080"/g' ${CATALINA_HOME}/conf/server.xml
 
 # 8080 - http,  5050 - debug

--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -3,6 +3,7 @@
 #PROPS_FIREFLY_OPTIONS=$'{ "coverage":  {"hipsSourceURL" : "ivo://CDS/P/2MASS/color"} }'
 #ADMIN_PASSWORD=reset-me
 #CLEANUP_INTERVAL=3h
+#baseURL=/my/version/             # setting a base path.  From the example, firefly will deployed to http://localhost:8080/my/version/firefly
 
 ## Use Tomcat Admin basic auth on protected resources under .../admin/*. Defaults to true.
 ## May be disabled in deployments where authorization is handled externally, e.g., by applying authorization-dependent redirects in a Kubernetes environment.


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1121

Add Firefly docker support for setting a base deployed path(baseURL).
`baseURL` is passed into the container as an environment variable.  It will be picked up on first start and cannot be changed for the duration of the container's lifetime.

To test, 
- checkout this branch
- uncomment `#baseURL=/my/version/` at firefly-docker.env:6
```bash
cd ./firefly
docker compose up firefly --build
```
Then, goto http://localhost:8080/my/version/firefly/ to see Firefly deployed at the defined baseURL.