### PR TITLE
FIREFLY-1024: Pinning charts from extraction dialog 

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -13,11 +13,19 @@ import {assign, cloneDeep, flatten, get, has, isArray, isEmpty, isObject, isStri
 import shallowequal from 'shallowequal';
 
 import {getAppOptions} from '../core/AppDataCntlr.js';
-import { COL_TYPE, getColumnType, getMetaEntry, getTblById, isColumnType, isFullyLoaded, isTableLoaded,
-    stripColumnNameQuotes, watchTableChanges } from '../tables/TableUtil.js';
+import {
+    COL_TYPE, getColumnType, getMetaEntry, getTblById, isColumnType, isFullyLoaded, isTableLoaded,
+    stripColumnNameQuotes, watchTableChanges
+} from '../tables/TableUtil.js';
 import {TABLE_HIGHLIGHT, TABLE_LOADED, TABLE_SELECT, TABLE_SORT} from '../tables/TablesCntlr.js';
 import {dispatchLoadTblStats, getColValStats} from './TableStatsCntlr.js';
-import {dispatchChartHighlighted, dispatchChartSelect, dispatchChartUpdate, dispatchSetActiveTrace, getChartData} from './ChartsCntlr.js';
+import {
+    dispatchChartHighlighted,
+    dispatchChartSelect,
+    dispatchChartUpdate,
+    dispatchSetActiveTrace,
+    getChartData
+} from './ChartsCntlr.js';
 import {Expression} from '../util/expr/Expression.js';
 import {quoteNonAlphanumeric} from '../util/expr/Variable.js';
 import {flattenObject} from '../util/WebUtil.js';
@@ -517,6 +525,17 @@ export function setupTableWatcher(chartId, ts, idx) {
         [TABLE_LOADED, TABLE_HIGHLIGHT, TABLE_SELECT],
         (action) => updateChartData(chartId, idx, ts, action),
         uniqueId(`ucd-${ts.tbl_id}-trace`)); // watcher id for debugging
+}
+
+
+/**
+ * Get feedback as boolean on whether chart is fully loaded or not
+ * @param chartId - chartId of the current chart
+ */
+export function isChartLoading(chartId) {
+    const {fireflyData=[]} = getChartData(chartId);
+    const isChartLoading = fireflyData.some((e)=>  e.isLoading);
+    return isChartLoading; //true when chart is still loading
 }
 
 function tablesourcesEqual(newTS, oldTS) {

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -97,7 +97,6 @@ function doUpdateViewer(viewerId, tblGroup, chartId, useOnlyChartsInViewer) {
 export const ChartsContainer = (props)  =>{
     const {chartId, expandedMode} = props;
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     return expandedMode || chartId || !allowPinnedCharts() ?
         <DefaultChartsContainer {...props}/>:
         <PinnedChartPanel {...props}/> ;

--- a/src/firefly/js/charts/ui/PinnedChartPanel.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartPanel.jsx
@@ -150,20 +150,18 @@ export function pinChart({chartId, autoLayout=true }) {
         return;
     }
     // there are cases when chart is not fully loaded.  if so, wait before pinning the chart
-    else {
-        dispatchAddActionWatcher({actions:[CHART_UPDATE], callback: (action, cancelSelf) => {
-                const aChartId = action.payload?.chartId;
-                if (chartId !== aChartId) {
-                    cancelSelf?.();
-                    return;
-                }
-                if (!isChartLoading(chartId)) { //chart is fully loaded now
-                    cancelSelf?.();
-                    doPinChart({chartId, autoLayout});
-                }
+    dispatchAddActionWatcher({actions:[CHART_UPDATE], callback: (action, cancelSelf) => {
+            const aChartId = action.payload?.chartId;
+            if (chartId !== aChartId) {
+                cancelSelf?.();
+                return;
             }
-        });
-    }
+            if (!isChartLoading(chartId)) { //chart is fully loaded now
+                cancelSelf?.();
+                doPinChart({chartId, autoLayout});
+            }
+        }
+    });
 }
 
 

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -149,7 +149,7 @@ export class PlotlyChartArea extends Component {
         }
         const {chartWidth, chartHeight} = calculateChartSize(widthPx, heightPx, xyratio, stretch);
         //const playout = Object.assign({showlegend}, adjustLayout(layout), {width: chartWidth, height: chartHeight, annotations});
-        const playout = cloneDeep(Object.assign({showlegend}, adjustLayout(layout), {width: chartWidth, height: chartHeight, annotations}))
+        const playout = cloneDeep(Object.assign({showlegend}, adjustLayout(layout), {width: chartWidth, height: chartHeight, annotations}));
 
         const style = {float: 'left'};
         if (chartWidth > widthPx || chartHeight > heightPx) {
@@ -260,7 +260,7 @@ function onSelect(chartId) {
                     let activeTracePoints = points.filter(([, c]) => c === activeTrace);
                     if (activeTracePoints.length < 1) {
                         // find the curve with max points in the selection area
-                        const freqByCurveMap = {}
+                        const freqByCurveMap = {};
                         let curveWithMaxPts = activeTrace;
                         let maxPts = 0;
                         points.forEach(([, c]) => {
@@ -281,7 +281,7 @@ function onSelect(chartId) {
                     points = activeTracePoints;
                 }
                 const {data} = getChartData(chartId);
-                const traceData = data?.[newActiveTrace]
+                const traceData = data?.[newActiveTrace];
                 const type = traceData?.type || 'scatter';
                 // points are populated only for scatter2d, not for heatmap
                 if (isScatter2d(type)) {
@@ -294,7 +294,7 @@ function onSelect(chartId) {
                     if (traceData?.z && traceData.x && traceData.y) {
                         // check if at least one point is in the selection area
                         let ptInRange = false;
-                        const {x, y, z} = traceData
+                        const {x, y, z} = traceData;
                         for (let i=0; i<x.length; i++) {
                             if (z[i] != null &&
                                 xMin < x[i] && x[i] < xMax &&
@@ -314,7 +314,7 @@ function onSelect(chartId) {
                 if (newActiveTrace !== activeTrace) {
                     dispatchSetActiveTrace({chartId, activeTrace: newActiveTrace});
                 }
-                const selections = evData?.selections ?? []
+                const selections = evData?.selections ?? [];
                 dispatchChartUpdate({
                     chartId,
                     changes: {


### PR DESCRIPTION
#### [Firefly-1024](https://jira.ipac.caltech.edu/browse/FIREFLY-1024): 
  - the major changes are in ChartUtil.js. Added an ActionWatcher to watch for chart updates
  - the callback of this action watcher then ensures that the chart is fully loaded before calling pinChart to pin the chart 
  - temporarily commented out the call to DefaultChartsContainer in ChartsContainer.jsx and calling PinnedChartPanel directly, so that you can test pinning charts from both the extraction dialog and the pin chart button to ensure both work as expected 
  - some ESLint suggested cleanup in PlotlyChartArea.jsx 

**Updates 12/20**
- When allowPinnedCharts() is set to true, the extraction dialog button will read "Pin Chart/Table", otherwise it will just read "Pin Table" 
- Better code segmentation and separation of concern based on @loitly's feedback and code 

**Updates 12/21 - 1.0**
- determined isChartLoaded was not really needed, removed its usage
- clean up of imports (small change, please look at the last 2 commits for code changes) 
- test build updated (try pinning Zaxis, line and points from the extraction dialog; for Zaxis, use the file in the JIRA ticket) 

**Updates 12/21 - 2.0**
- added logic back for checking if chart is fully loaded (and modified it a bit to rather check if chart is *still* loading) 
- look at the last 2 commits, though the main changes are in the commit titled "readded logic for checking if chart is still loading" (the one after that was because I forgot to remove export from doPinChart function) 

**Updates 12/23**
- cleaned up and changed some code as per @robyww's comments
- moved doPinChart out of the ExtractionPanelView component, but instead of sending it the callKeepExtraction prop as an argument (resulting in some error messages), I called callKeepExtraction within the onSuccess of the CompleteButton, got the tbl_id from it, and sent the tbl_id as an argument instead 
- new error/warning message text and title updated (for max charts) 

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1024-ext-pin-plot/firefly
 - load a fits file (from image search, search for "m1") and use the extraction dialog (line & point) and try to pin charts 
 - upload the file from the ticket link above, and use this to test Z-axis extraction and pinning those charts as well 
 - try adding more than 12 charts, you should get a warning each time after that about not being able to pin any more charts but tables can still be added
 - the only thing I'm not sure if how you could test the extraction dialog to say "Pin Table" when allowPinnedCharts() is set to false (in the test build). You could go into my branch though to set it to false and test it locally. 