### PR TITLE
FIREFLY-1138: Make help base URL a runtime configuratable property

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -23,7 +23,7 @@ ehcache.multicast.address = "239.255.0.1"
 
 sso.server.url = "https://irsa.ipac.caltech.edu/account/"
 sso.user.profile.url = "https://irsa.ipac.caltech.edu/account/uman/uman.html//id=profile"
-__$help.base.url = "onlinehelp/"
+help.base.url = "onlinehelp/"
 
 
 visualize.fits.MaxSizeInBytes= 21474836480

--- a/config/common.prop
+++ b/config/common.prop
@@ -60,7 +60,7 @@ mail.smtp.starttls.enable = @mail.smtp.starttls.enable@
 sso.server.url=@sso.server.url@
 sso.user.profile.url=@sso.user.profile.url@
 
-help.base.url=@__$help.base.url@
+help.base.url=@help.base.url@
 
 tap.maxrec.maxval=@__$tap.maxrec.hardlimit@
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,15 +34,13 @@ FROM node_module AS dev_env
 
 RUN apt-get update \
     && apt-get install -y vim procps \
-# install tomcat9 for dev mode \
-    && curl -O https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.68/bin/apache-tomcat-9.0.68.tar.gz \
-    && mkdir /opt/tomcat && tar xzf apache-tomcat-9*tar.gz -C /opt/tomcat --strip-components=1 \
-    && sed -i -E 's/allow=".*"/allow=".*"/' /opt/tomcat/webapps/manager/META-INF/context.xml \
 # cleanup
-    && rm apache-tomcat-9*tar.gz \
     && rm -rf /var/lib/apt/lists/*;
 
-ENV CATALINA_HOME=/opt/tomcat \
+COPY --from=tomcat:9.0-jre17 /usr/local/tomcat /usr/local/tomcat
+
+
+ENV CATALINA_HOME=/usr/local/tomcat \
     USE_ADMIN_AUTH=false \
     DEBUG=true
 

--- a/docker/devMode.sh
+++ b/docker/devMode.sh
@@ -14,4 +14,4 @@ for n in *.war; do \
 done
 
 cd ${CATALINA_HOME}
-/opt/tomcat/launchTomcat.sh
+${CATALINA_HOME}/launchTomcat.sh

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
+
 public class AppServerCommands {
     private static final String SPA_NAME = "spaName";
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
@@ -39,12 +41,12 @@ public class AppServerCommands {
 
     public static class JsonProperty extends ServCommand {
         static final String INVENTORY_PROP = "inventory.serverURLAry";
-        static final String JSON_OPTIONS = "FIREFLY_OPTIONS";
+        static final String FIREFLY_OPTIONS = "FIREFLY_OPTIONS";
         static final Map<String, String> map = new HashMap<>();
         static final List<String> validatedList = new ArrayList<>();
 
         static {
-            map.put(JSON_OPTIONS, AppProperties.getProperty(JSON_OPTIONS, "{}"));
+            map.put(FIREFLY_OPTIONS, getAppOptions());
             map.put(INVENTORY_PROP, AppProperties.getProperty(INVENTORY_PROP, "[]"));
             validateAll();
         }
@@ -132,4 +134,24 @@ public class AppServerCommands {
             return map.toString();
         }
     }
+
+
+    private static final String HELP_BASE_URL = "help.base.url";
+    private static String getAppOptions() {
+        Map appOpts;
+        String def = "{}";
+        String appOptStr = AppProperties.getProperty(JsonProperty.FIREFLY_OPTIONS, def);
+        try{
+            appOpts = (Map) new JSONParser().parse(appOptStr);
+            // additional props as FIREFLY_OPTIONS
+            applyIfNotEmpty(AppProperties.getProperty(HELP_BASE_URL), v -> appOpts.put(HELP_BASE_URL, v));
+
+            return new JSONObject(appOpts).toJSONString();
+        }catch(ParseException pe){
+            Logger.getLogger().error(String.format("Failed parsing %s", appOptStr));
+            return def;
+        }
+    }
+
+
 }

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -139,7 +139,7 @@ const defFireflyOptions = {
     wcsMatchType: false,
     imageScrollsToHighlightedTableRow: true,
     imageScrollsToActiveTableOnLoadOrSelect: true,
-    'help.base.url': undefined,                     // this overrides property set during build time.
+    'help.base.url': undefined,                     // onlinehelp base URL
 
     charts: {
         defaultDeletable: undefined,    // by default if there are more than one chart in container, all charts are deletable

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -7,7 +7,7 @@ import {flux} from './ReduxFlux';
 import {dispatchAddActionWatcher} from './MasterSaga';
 import {appDataReducer, menuReducer, alertsReducer} from './AppDataReducers.js';
 import Point, {isValidPoint} from '../visualize/Point.js';
-import {getModuleName, getProp} from '../util/WebUtil.js';
+import {getModuleName, getProp, getRootURL} from '../util/WebUtil.js';
 import {dispatchRemoteAction} from './JsonUtils.js';
 import {getWsConn} from './messaging/WebSocketClient';
 
@@ -289,21 +289,14 @@ function grabWindowFocus() {
 function onlineHelpLoad( action )
 {
     return () => {
-        var url = getAppOptions()?.['help.base.url'] || getProp('help.base.url', '');
-        var windowName = 'onlineHelp';
-        var moduleName = getProp('help.subpath', getModuleName());
-
-        if (moduleName) {
-            windowName += '-' + moduleName;
-        }
+        let url = getAppOptions()?.['help.base.url'] || '';
         url = url.endsWith('/') ? url : url + '/';
-        if (action.payload && action.payload.helpId) {
-            url += '#id=' + action.payload.helpId;
-        }
+        url += action?.payload?.helpId ? '#id=' + action.payload.helpId : '';
+        url = new URL(url, getRootURL());                   // use rootURL instead of document.baseURI if relative
 
-        if (url) {
-            window.open(url, windowName);
-        }
+        const moduleName = getProp('help.subpath', getModuleName());
+        const windowName = `onlineHelp-${moduleName}`;
+        window.open(url.href, windowName);
     };
 }
 

--- a/src/firefly/js/tables/ui/AddColumn.jsx
+++ b/src/firefly/js/tables/ui/AddColumn.jsx
@@ -107,7 +107,7 @@ export const AddColumn = React.memo(({tbl_ui_id, tbl_id}) => {
                 <button type='button' className='button std'
                         onClick={() => hideDialogPopup?.()}>Cancel
                 </button>
-                <HelpIcon helpId={'tables.options'} style={{float: 'right', marginTop: 4}}/>
+                <HelpIcon helpId={'tables.addColumn'} style={{float: 'right', marginTop: 4}}/>
             </div>
         </div>
     );


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1138
`help.base.url` used to be compiled into JavaScripted.   Make it an application property so that it can be overridden by environment variable.

Additional changes here: 
https://github.com/lsst/suit/pull/46
https://github.com/IPAC-SW/irsa-ife/pull/239

Also:
- set add-column helpId
- cleanup work-dir init and logging
- change how tomcat is install in dev-mode

Test: https://firefly-1138-base-help-url.irsakudev.ipac.caltech.edu/suit
*** Manually added to `env` after deployed via `kubectl`.
```yaml
        - name: PROPS_help__base__url
          value: https://irsa.ipac.caltech.edu/onlinehelp/wise
```
When clicking on help icon(?), it will go to IRSA WISE help.

** NOTE:  @robyww pay attention to how this is added to `FIREFLY_OPTIONS` in `AppServerCommands.java`.  A slight change to your existing logic.