### PR TITLE
FIREFLY-1136: embedded DB customization via props

### DIFF
--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -5,15 +5,28 @@
 #CLEANUP_INTERVAL=3h
 #baseURL=/my/version/             # setting a base path.  From the example, firefly will deployed to http://localhost:8080/my/version/firefly
 
+## timezone.  Useful for all date/time related things, like logging.
+#TZ=US/Pacific
+
+
 ## Use Tomcat Admin basic auth on protected resources under .../admin/*. Defaults to true.
 ## May be disabled in deployments where authorization is handled externally, e.g., by applying authorization-dependent redirects in a Kubernetes environment.
 #USE_ADMIN_AUTH=false
 
 # to set up personal access tokens
 #PROPS_sso__framework__name=PAT
-#ROPS_sso__req__auth__hosts=.ncsa.illinois.edu,.lsst.cloud
-#ROPS_sso__access__token=xxx
+#PROPS_sso__req__auth__hosts=.ncsa.illinois.edu,.lsst.cloud
+#PROPS_sso__access__token=xxx
 
-##---- Empty declarations: environment will come from the shell
+## Embedded DB customization.  see edu.caltech.ipac.firefly.server.db.DbAdapter for cleanup policy.
+## maxIdle time is in minutes. dbRsc is for 'resource' tables.  It defaults to dbTbl when not set.
+#PROPS_dbTbl__maxIdle=30
+#PROPS_dbRsc__maxIdle=600
+#PROPS_dbTbl__maxMemRows=80000000
+## when to compact the DB as a factor maxIdle.  defaults to .5.
+#PROPS_dbTbl__compactFactor=.25
+
+##---- Empty declarations: values will come from the shell's environment
 ADMIN_PASSWORD
 env
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -84,9 +84,15 @@ public class JobInfo implements Serializable {
 
     public void setPhase(Phase phase) {
         this.phase = phase;
-        if (phase == Phase.COMPLETED) {
-            endTime = Instant.now();
-            progress = 100;
+        switch (phase) {
+            case UNKNOWN:
+            case ERROR:
+            case ABORTED:
+                endTime = Instant.now();
+                break;
+            case COMPLETED:
+                endTime = Instant.now();
+                progress = 100;
         }
     }
 
@@ -95,7 +101,7 @@ public class JobInfo implements Serializable {
     }
 
     public void setError(Error error) {
-        if (error != null) this.phase = Phase.ERROR;
+        if (error != null) setPhase(Phase.ERROR);
         this.error = error;
     }
 
@@ -136,9 +142,7 @@ public class JobInfo implements Serializable {
     public Instant getEndTime() {
         return endTime;
     }
-    public void setEndTime(Instant time) {
-        endTime = time;
-    }
+    public void setEndTime(Instant time) { endTime = time; }
 
     public Instant getDestruction() { return destruction; }
     public void setDestruction(Instant time) { destruction = time; }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
@@ -48,6 +48,7 @@ import static edu.caltech.ipac.util.FileUtil.writeStringToFile;
         })
 public class ResourceProcessor extends EmbeddedDbProcessor {
     public static final String PROC_ID = "ResourceProcessor";
+    public static final String SUBDIR_PATH = "resource-db";
 
     public static final String ACTION = "action";
     public static final String SCOPE = "scope";
@@ -69,7 +70,7 @@ public class ResourceProcessor extends EmbeddedDbProcessor {
     public File getDbFile(TableServerRequest treq) {
         DbAdapter dbAdapter = DbAdapter.getAdapter(treq);
         String resourceID = getResourceID(treq);
-        String fname = String.format("resources/%s.%s", resourceID, dbAdapter.getName());
+        String fname = String.format("%s/%s.%s", SUBDIR_PATH, resourceID, dbAdapter.getName());
         return new File(ServerContext.getHiPSDir(), fname);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -8,6 +8,7 @@ import edu.caltech.ipac.firefly.messaging.Messenger;
 import edu.caltech.ipac.firefly.server.Counters;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
+import edu.caltech.ipac.firefly.server.db.BaseDbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
 import edu.caltech.ipac.util.FileUtil;
@@ -151,27 +152,28 @@ public class ServerStatus extends BaseHttpServlet {
 
     private static void showDatabaseStatus(PrintWriter writer) {
 
-        DbAdapter.EmbeddedDbStats stats = DbAdapter.getAdapter().getRuntimeStats();
+        DbAdapter.EmbeddedDbStats stats = DbAdapter.getAdapter().getRuntimeStats(true);
         writer.println("DATABASE INFORMATION");
         writer.println("--------------------");
-        writer.printf("CHECK_INTVL(secs): %,10d  MAX_IDLE(min):       %,10d\n", DbAdapter.CLEANUP_INTVL/1000, DbAdapter.MAX_IDLE_TIME/1000/60);
+        writer.printf("MAX_IDLE(min):     %,10d  MAX_IDLE_RSC(min):   %,10d\n", DbAdapter.MAX_IDLE_TIME/1000/60, DbAdapter.MAX_IDLE_TIME_RSC/1000/60);
+        writer.printf("MAX_MEM_ROWS:      %,10d  COMPACT_FACTOR:      %10.2f\n", stats.maxMemRows, stats.compactFactor);
         writer.printf("DB In Memory:      %,10d  Total DB count:      %,10d\n", stats.memDbs, stats.totalDbs);
-        writer.printf("MAX_MEM_ROWS:      %,10d  PEAK_MAX_MEM_ROWS:   %,10d\n", stats.maxMemRows, stats.peakMaxMemRows);
         writer.printf("Rows In Memory:    %,10d  Peak Rows In Memory: %,10d\n", stats.memRows, stats.peakMemRows);
         writer.println(              "Cleanup Last Ran:  " + new SimpleDateFormat("HH:mm:ss").format(stats.lastCleanup));
         writer.println("");
-        writer.println("Idled   Age     Tables  Rows        Columns  File Path         (elapsed time are in min:sec)");
-        writer.println("------  ------  ------  ----------  -------  ---------");
-        Collections.unmodifiableCollection(DbAdapter.getAdapter().getDbInstances().values()).stream()
-                    .sorted((db1, db2) -> Long.compare(db2.getLastAccessed(), db1.getLastAccessed()))
-                    .forEach((db) -> writer.printf("%5$tM:%5$tS   %6$tM:%6$tS   %6d  %,10d  %,7d  %s\n",
-                                                        db.getTblCount(),
-                                                        db.getRowCount(),
-                                                        db.getColCount(),
-                                                        db.getDbFile().getPath(),
-                                                        System.currentTimeMillis() - db.getLastAccessed(),
-                                                        System.currentTimeMillis() - db.getCreated()
-                    ));
+        writer.println("Idled   Age     Rows        Columns  Tables  Total Rows   File Path         (elapsed time are in min:sec)");
+        writer.println("------  ------  ----------  -------  ------  ----------   ---------");
+        DbAdapter.getAdapter().getDbInstances().values().stream()
+            .sorted((db1, db2) -> Long.compare(db2.getLastAccessed(), db1.getLastAccessed()))
+            .forEach((db) -> writer.printf("%6$tM:%6$tS   %7$tM:%7$tS   %,10d  %7d  %6d  %,10d  %s\n",
+                db.getDbStats().rowCnt(),
+                db.getDbStats().colCnt(),
+                db.getDbStats().tblCnt(),
+                db.getDbStats().totalRows(),
+                db.getDbFile().getPath(),
+                System.currentTimeMillis() - db.getLastAccessed(),
+                System.currentTimeMillis() - db.getCreated()
+        ));
     }
 
     private static String getStats(Ehcache c) {


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1136
- define cleanup parameters as props
- fine tune cleanup policy
- added better visibility via /admin/status

Not much to test.  Review policy and cleanup parameters to make sure it's sensible.
`1 million max memory rows for every 1GB of memory at startup.` is a conservative default setting.  The idea is to use custom props for special use case. 