### PR TITLE
Firefly 1130 Modify FileUploadViewPanel to take an accept list

### DIFF
--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -23,6 +23,8 @@ import {MultiSearchPanel} from 'firefly/ui/MultiSearchPanel.jsx';
 import {TapSearchPanel} from 'firefly/ui/tap/TapSearchRootPanel.jsx';
 import {VersionInfo} from 'firefly/ui/VersionInfo.jsx';
 import {DLGeneratedDropDown} from './dynamic/DLGeneratedDropDown.js';
+import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES
+}  from 'firefly/visualize/ui/FileUploadViewPanel';
 
 const flexGrowWithMax = {width: '100%', maxWidth: 1400};
 
@@ -46,7 +48,8 @@ export const dropDownMap = {
     DLGeneratedDropDownCmd: {view: <DLGeneratedDropDown/>, layout: {width: '100%'}},
     // --- testing
     TestSearch: {view: <TestSearchPanel />},
-    TestSearches: {view: <TestQueriesPanel />},
+    TestSearches: {view: <TestQueriesPanel />}
+
 };
 
 

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -5,22 +5,34 @@
 import React, {useState} from 'react';
 import {FormPanel} from './FormPanel.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
-import {
-    FileUploadViewPanel,
-    resultFail
-} from '../visualize/ui/FileUploadViewPanel.jsx';
+import { FileUploadViewPanel, resultFail} from '../visualize/ui/FileUploadViewPanel.jsx';
 import {getAppOptions} from 'firefly/api/ApiUtil.js';
 import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr.js';
 import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
 import {resultSuccess} from 'firefly/ui/FileUploadProcessor';
 import {FieldGroup} from 'firefly/ui/FieldGroup';
+import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES} from 'firefly/ui/FileUploadUtil';
 
 const maskWrapper= { position:'absolute', left:0, top:0, width:'100%', height:'100%' };
 const panelKey = 'FileUploadAnalysis';
 
-export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, acceptMoc=false, onSubmit=resultSuccess, keepState=true,
-                                      groupKey=panelKey}) =>{
+const defaultAcceptList = [
+    TABLES,
+    REGIONS,
+    DATA_LINK_TABLES,
+    SPECTRUM_TABLES,
+    MOC_TABLES,
+    IMAGES
+];
+
+const tableOnlyDefaultAcceptList = [
+    TABLES
+];
+
+export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess, keepState=true,
+                                      groupKey=panelKey, acceptList= getAppOptions()?.uploadPanelLimit==='tablesOnly'?
+        tableOnlyDefaultAcceptList: defaultAcceptList}) =>{
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
@@ -38,7 +50,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, acce
                     changeMasking={changeMasking}
                     inputStyle={{height:'100%'}}
                     submitBarStyle={{padding: '2px 3px 3px'}} help_id={helpId}>
-                    <FileUploadViewPanel setSubmitText={setSubmitText} acceptMoc={acceptMoc}/>
+                    <FileUploadViewPanel setSubmitText={setSubmitText} acceptList={acceptList}/>
                 </FormPanel>
             </FieldGroup>
             {doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
@@ -50,7 +62,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, acce
 
 const DIALOG_ID= 'FileUploadDialog';
 
-export function showUploadDialog(acceptMoc, keepState, groupKey) {
+export function showUploadDialog(acceptList, keepState, groupKey) {
 
     DialogRootContainer.defineDialog(DIALOG_ID,
         <PopupPanel title={'Upload'}
@@ -62,7 +74,6 @@ export function showUploadDialog(acceptMoc, keepState, groupKey) {
                 <FileUploadDropdown
                     style={{height: '100%'}}
                     onCancel={() => dispatchHideDialog(DIALOG_ID)}
-                    acceptMoc={acceptMoc}
                     onSubmit={
                         (request) => {
                             if (resultSuccess(request)) dispatchHideDialog(DIALOG_ID);
@@ -70,6 +81,7 @@ export function showUploadDialog(acceptMoc, keepState, groupKey) {
                     }
                     keepState={keepState}
                     groupKey={groupKey}
+                    acceptList={acceptList}
                 />
             </div>
         </PopupPanel>

--- a/src/firefly/js/ui/FileUploadUtil.js
+++ b/src/firefly/js/ui/FileUploadUtil.js
@@ -1,0 +1,20 @@
+export const REGIONS = 'REGION';
+export const TABLES = 'Table';
+export const SPECTRUM_TABLES = 'spectrum-tables';
+export const MOC_TABLES = 'moc-tables';
+export const DATA_LINK_TABLES = 'data-link-tables';
+export const IMAGES = 'Image';
+
+export const acceptImages = (acceptList) => acceptList.includes(IMAGES);
+export const acceptRegions = (acceptList) => acceptList.includes(REGIONS);
+export const acceptOnlyTables = (acceptList) =>  acceptList.includes(TABLES) && acceptList.length === 1;
+export const acceptMocTables = (acceptList) => acceptList.includes(MOC_TABLES);
+export const acceptDataLinkTables = (acceptList) => acceptList.includes(DATA_LINK_TABLES);
+export const acceptNonMocTables = (acceptList) =>
+    [TABLES,SPECTRUM_TABLES,DATA_LINK_TABLES].some( (type) => acceptList.includes(type));
+export const acceptNonDataLinkTables = (acceptList) =>
+    [TABLES,SPECTRUM_TABLES,MOC_TABLES].some( (type) => acceptList.includes(type));
+export const acceptAnyTables = (acceptList) =>
+    [TABLES,SPECTRUM_TABLES,MOC_TABLES,DATA_LINK_TABLES].some( (type) => acceptList.includes(type));
+export const acceptTableOrSpectrum = (acceptList) =>
+    [TABLES,SPECTRUM_TABLES].some( (type) => acceptList.includes(type));

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -33,6 +33,7 @@ import {getDefaultMOCList} from 'firefly/visualize/HiPSMocUtil.js';
 import {FieldGroupTabs, Tab} from 'firefly/ui/panel/TabPanel';
 import {FileUploadViewPanel} from 'firefly/visualize/ui/FileUploadViewPanel';
 import {resultSuccess} from 'firefly/ui/FileUploadProcessor';
+import {MOC_TABLES} from 'firefly/ui/FileUploadUtil';
 
 const useSourceHiPS = 'useSourceHiPS';
 const useSourceMOC = 'useSourceMOC';
@@ -119,7 +120,7 @@ export function showHiPSSurveysPopup(pv, moc= false) {
 
                             <Tab name='Use my MOC' id='uploadMoc'>
                                 <div style={{width:'100%', minWidth:715, minHeight:500}} >
-                                    <FileUploadViewPanel acceptMoc={true}/>
+                                    <FileUploadViewPanel acceptList={[MOC_TABLES]}/>
                                 </div>
                             </Tab>
                         </FieldGroupTabs>}

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -45,6 +45,9 @@ import {getDS9Region} from '../rpc/PlotServicesJson.js';
 import {RegionFactory} from '../visualize/region/RegionFactory.js';
 import {NaifidPanel} from './NaifidPanel';
 
+import {showUploadDialog} from 'firefly/ui/FileUploadDropdown';
+import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES} from 'firefly/ui/FileUploadUtil';
+
 const dynamic1Params= [
     makeTargetDef(
         {hipsUrl:'ivo://CDS/P/DSS2/color', centerPt:makeWorldPt(10,10), hipsFOVInDeg:10, raKey:'ra', decKey:'dec'}),
@@ -170,6 +173,9 @@ export class TestQueriesPanel extends PureComponent {
                             <Tab name='Dynamic 3' id='dynamic3'>
                                 {makeDynamic3()}
                             </Tab>
+                            <Tab name='Uploads' id='upload'>
+                                {uploadButtons()}
+                            </Tab>
                         </FieldGroupTabs>
 
                     </FieldGroup>
@@ -243,6 +249,46 @@ function makeDynamic3() {
                                style={{margin: 3}}
                                fieldDefAry={dynamic3Params}
                                onSuccess={(request) => showDymResult(request)}/>
+        </div>
+    );
+}
+
+function uploadButtons() {
+    return (
+        <div style={{padding:10}}>
+
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([TABLES],true,'FileUploadAnalysis_Only_Table')}>
+                <b>Tables Only Upload</b>
+            </button>
+
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES],true,'FileUploadAnalysis_All_Tables')}>
+                <b>All Tables Upload</b>
+            </button>
+            <br/><br/>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([REGIONS],true,'FileUploadAnalysis_Region')}>
+                <b>Region Upload</b>
+            </button>
+
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([IMAGES],true,'FileUploadAnalysis_Image')}>
+                <b>Image Upload</b>
+            </button>
+            <br/><br/>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([DATA_LINK_TABLES],true,'FileUploadAnalysis_DataLink_Only')}>
+                <b>DataLink Tables Only</b>
+            </button>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES],true,'FileUploadAnalysis_MocFits_Only')}>
+                <b>MOC FITS Only</b>
+            </button>
+            <br/><br/>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES,REGIONS,IMAGES],true,'FileUploadAnalysis_Region')}>
+                <b>Accept Everything (Default)</b>
+            </button>
+
+
+            <br/>
+
+
+            <br/>
         </div>
     );
 }


### PR DESCRIPTION
#### [Firefly-1130](https://jira.ipac.caltech.edu/browse/FIREFLY-1130):
- really a draft PR, more work needs to be done but wanted to check if it looks okay so far
- most of the work that's left is for **FileUploadProcessor** (**FileAnalysis** in **FileUploadViewPanel** takes care of giving users warnings for file types not allowed - but they're still able to load files of types not in acceptList - that'll need to be taken care of in the **resultSuccess** function of **FileUpoadProcessor**)
- added checks in **ImageDisplayOption** and **TableDisplayOption** to show appropriate checkboxes (for spectra, moc, images, etc.) based on what's in acceptList 
- Currently in **FileUploadViewPanel's** **getLoadButtonText** function, I added warnings for when the user attempts to select tables and images (when either one is not present in the acceptList) 
    - this is not ideal. As long as the user is allowed to select items that are not in acceptList, my current check will throw warnings even if you pick images (and say, in this instance, images are allowed but tables are not) because tblCnt will be >= 1 if you have previously selected any 
      - I'll work on improving this
- I used **summaryModel** to check the fileTypes of the uploaded file (and not report.parts.dataTypes - reason being that the latter classifies even Table entries as Images - this is taken care of in **makeSummaryModel** function by looking at the number of axes to decide if an entry is Table or Image - which is why I decided to use summaryModel to get uniqueTypes) 
- The types I checked for were **REGION**, **Image** and **Table** (from the various fits, vot, moc fits, reg, etc. files that I had, I only saw these and "**HeaderOnly**" show up as types)
  - then added further checks for spectrum-tabels, moc-tables, and data-link-tables under Table
  - the only thing I wasn't sure about was if "**Spectrum**" needs a separate check? Are there fileTypes where it could show up as a type? If so, I can add a check for that as well..
  
**Updates 1/30**
- PR is now ready for review 
- Based on feedback, separated out some of the logic into functions (such as determineAccepted, buildAllowedTypes) 
- On firefly-dev, moved the buttons created for different acceptLists from the top navigation bar to the tabs within 'Test Searches' (new tab is called 'Uploads') 
- Added checks in FileUploadProcessor's resultSuccess to make sure even if user uploads a file type that is not allowed (FileAnalysis will show warning text and not upload the file), they still shouldn't be able to "Load" the file 
- If either tables or images or not allowed, and the uploaded file type has both tables and images as entries, then either tables or images will be pinked out. Additionally, added a warning line that reads "Any selected entries with highlighted pink lines will not be loaded."
   - If, for instance, images are not in the defaultAcceptList, but the user selects a few, the load button text will not change to reflect any selected images. 
   - Also, if the user tries to load this file with any images selected, we'll still load any selected tables but give a warning dialog that'll let the user know we're only loading tables 
- made some changes to the **getFirstExtWithData** function in FileUploadViewPanel. It would not have worked previously because we were checking for reports.parts.type, but having tested that I realized it always returns 'Image' for any FITS file (even for 'Table' entries). Fixed it to now look for type in summaryModel.tableData.data, which returns 'Image' or 'Table' accurately (makeSummaryModel takes care of that by looking at the number of axes for each entry to determine whether it's a 'Table' or 'Image'). 

**Updates 1/31**
- Cleaned up FileUploadProcessor - moved all showInfoPopup's from resultSuccess to a new determineValidity function
    - I tried hard to see if I could re-use determineAccepted from FileUploadViewPanel with a few tweaks instead, but it was getting a lot more complicated since the logic to determine validity before loading a file is a bit more complex (relies on tableIndices, imageIndices to check what selections the user made, etc.) than determining if the file type uploaded is allowed or not
- added a showYesNoPopup dialog for when user selects any image(s) or table(s) when either is not allowed - this will allow user to click Yes/No to proceed or cancel loading if they have some incorrect selections made that they'd like to edit per @loitly's suggestion  
- got rid of the tablesOnlyResultSuccess function as it's been made redundant now by the other checks we have in place  

**Updates 2/2**
- note: some of these changes that haven't been fully reviewed are from **Updates 3/31** above, if it helps 
- quite a few changes, further separation of logic into functions in FileUploadProcessor (determineValidity and determineLoadType do most of the work here) 
- also accounted for separation of logic when accept list has something like *only* DATA_LINK_TABLES or *only* MOC_TABLES...or when accept list includes either TABLES or SPECTRUM_TABLES (either of those indicate that we accept *all* tables - including data link and moc tables) 
    - had to make changes for this in FileUploadProcessor, but also in FileUploadViewPanel (for the text displayed before user uploads a file, and also after they upload it - to account for difference in rows being highlighted *pink* - we don't want to do that for moc/DL tables - so added a check for that as well) 

#### Bugs (some pre-existing):
- if you upload a moc fits file (in the regular upload panel, not the HiPs/MOC dialog), you'll see 2 radio button options: "Load as MOC Overlay" and "Load as Table". The Load button text reads "Load MOC" - and it doesn't change when you switch to "Load as Table" either (I'm not sure that it should, but if it needs to change to, say, "Load Table" - then this is a bug). 
- If you upload a file with only tables (like this one: http://web.ipac.caltech.edu/staff/roby/data-products-test/objsearch_ext.xml), then the load button text reads "Load Table", and it does not change when you start selecting more than 1 table. 
- Select a few tables/images in a fits file. If you then attempt to unselect an already selected/highlighted row, the load button text does not change to reflect this. In fact, you can now attempt to select and unselect this highlighted row multiple times, but the load button text will not change. it'll only be updated when you select/unselect a new row. 
- Looking into these bugs - and trying to see if I can fix them within this ticket. Let me know which ones (or all) seem most pressing. 

#### Testing (Updated 2/2): 
  - https://fireflydev.ipac.caltech.edu/firefly-1130-fuvp-acceptlist/firefly and https://fireflydev.ipac.caltech.edu/firefly-1130-fuvp-acceptlist/firefly/firefly-dev.html
  - **Testing Changes from 2/2**: Note: follow the steps below, but I also added 2 new buttons on the firefly-dev test build link: one for MOC_TABLES only and one for DATA_LINK_TABLES only 
  - on the firefly-dev testing link, under the "Test Searches" tab, theres'a new "Uploads" tab. The Uploads tab has 4 options: 'Tables Only Upload', 'All Tables Upload', 'Region Upload', 'Image Upload' and 'Accept Everything (Default)'. 
  - click on each one of those, make sure the text for what types of files the user is allowed to upload from each looks good
  - After changes on **1/31**: for files with multiple parts (fits or table files), attempt to select nothing and click on 'Load'. You should get a popup warning saying no extension was selected. Also attempt to select only the 'HeaderOnly' extension and load, this should give a popup warning as well. 
  - attempt to upload the allowed file type, and also file types not allowed from each. Attempt to 'Load' in both cases (should work if file type is allowed, and should give a warning if file type is not allowed). Example: On firefly-dev, under 'Test Searches' -> 'Uploads', click on 'Region Only' - and attempt to upload and load any non-region file type here. 
  - From the upload panel, also attempt to upload and load a file type that is not allowed/supported. Eg: try a PDF file. You should get a popup warning when you try to load. 
  - From the 'Tables Only Upload', upload a fits file with both tables and images (image entries should be pinked out - and a warning should show up right above the table) 
     - The first table entry should be the one selected by default (and not the first image entry) 
     - select a few images and tables and 'Load' - make sure the load button text changes only for tables, and upon loading you should see a warning dialog that says only tables will be loaded
     - if you select only images and unselect all table entries and then attempt to load, you should get a warning dialog that prompts you to select at least one table 
 - Repeat this process on the 'Image Upload' tab (here, the table entries should be pinked out)  
- Repeat this process from the Hips/Moc dialog (from "Images", choose Image Type: View HiPS Images - search for target m1, then click on "Add MOC" and go to the upload panel tab - repeat the same steps as above - attempt to upload both a moc fits file, and any non-moc fits file as well). 