### PR TITLE
Firefly-1144: add better support tap search params for click-to-action

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -207,10 +207,12 @@ public class ServerContext {
             log.info(desc +  "; Using path from property: " + fromProp);
             File workDir = new File(fromProp);
             initDir(workDir);
-            if (!workDir.canWrite()) {
+            if (workDir.canWrite()) {
+                return workDir;
+            }
+            else {
                 log.info(desc + " failed. " + " Unable to write to directory: " + workDir.getPath());
             }
-            return workDir;
         }
 
         if (altDir == null) {

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, map, isUndefined} from 'lodash';
+import {get, map, isUndefined, isEmpty} from 'lodash';
 import {flux} from './ReduxFlux';
 import {dispatchAddActionWatcher} from './MasterSaga';
 import {appDataReducer, menuReducer, alertsReducer} from './AppDataReducers.js';
@@ -222,6 +222,14 @@ export function getAppOptions() {
 
 export function getUserInfo() {
     return flux.getState()[APP_DATA_PATH].userInfo;
+}
+
+export function getSearchActions() {
+    const {searchActions, searchActionsCmdMask}= getAppOptions() ?? {};
+    if (isEmpty(searchActions)) return undefined;
+    if (isEmpty(searchActionsCmdMask)) return searchActions;
+    const retSearchActions= searchActions.filter( ({cmd}) => searchActionsCmdMask.includes(cmd));
+    return retSearchActions;
 }
 
 /**

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -5,7 +5,7 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, truncate, get, set} from 'lodash';
-import {getAppOptions} from '../../api/ApiUtil.js';
+import {getSearchActions} from '../../core/AppDataCntlr.js';
 import {ActionsDropDownButton, isTableActionsDropVisible} from '../../ui/ActionsDropDownButton.jsx';
 
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
@@ -48,7 +48,7 @@ export function TablePanel(props) {
     tbl_ui_id = tbl_ui_id || `${tbl_id}-ui`;
 
     const uiState = useStoreConnector(() => getTableUiById(tbl_ui_id) || {columns:[]}, [tbl_ui_id]);
-    const searchActions= getAppOptions()?.searchActions;
+    const searchActions= getSearchActions();
 
     useEffect( () => {
         if (!getTableUiByTblId(tbl_id)) {

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -62,6 +62,7 @@ function getNextState(prevS, renderTreeId) {
  *
  */
 export const FireflySlate= memo(( {initLoadingMessage, appTitle= 'Firefly', appIcon=FFTOOLS_ICO, altAppIcon,
+                                      bannerLeftStyle, bannerMiddleStyle,
                                       footer, style, renderTreeId, menu:menuItems, showBgMonitor=false}) => {
     const state= useStoreConnector( (prevState) => getNextState(prevState,renderTreeId));
     const {isReady, mode={}, gridView= [], gridColumns=1, menu={}, dropDown={}, layoutInfo, initLoadCompleted, dropdownPanels} = state;
@@ -81,7 +82,7 @@ export const FireflySlate= memo(( {initLoadingMessage, appTitle= 'Firefly', appI
         <RenderTreeIdCtx.Provider value={{renderTreeId}}>
             <div id='App' className='rootStyle' style={style}>
                 <header>
-                    <BannerSection {...{menu, appTitle, appIcon, altAppIcon}}/>
+                    <BannerSection {...{menu, appTitle, appIcon, altAppIcon, bannerLeftStyle, bannerMiddleStyle}}/>
                     <div id={warningDivId} data-decor='full' className='warning-div center'/>
                     <DropDownContainer key='dropdown' footer={footer} visible={!!visible}
                         selected={view} initArgs={initArgs} {...{dropdownPanels} } />

--- a/src/firefly/js/ui/DefaultSearchActions.js
+++ b/src/firefly/js/ui/DefaultSearchActions.js
@@ -15,9 +15,9 @@ const dispatchShowDropDown= ({view, initArgs}) =>
     flux.process({type: 'layout.showDropDown', payload: {visible: true, view, initArgs}});
 //------------
 
-const showTap= (initArgs) => {
+export const showTapSearchPanel= (searchParams={}) => {
     const view= getAppOptions()?.multiTableSearchCmdOptions?.find(({id}) => id === 'tap') ? 'MultiTableSearchCmd' : 'TAPSearch';
-    dispatchShowDropDown({ view, initArgs});
+    dispatchShowDropDown({ view, initArgs:{defaultSelectedId: 'tap', searchParams}});
 };
 
 const showImage= (initArgs) => dispatchShowDropDown( { view: 'ImageSelectDropDownCmd', initArgs});
@@ -25,24 +25,18 @@ const showImage= (initArgs) => dispatchShowDropDown( { view: 'ImageSelectDropDow
 export const makeDefTapSearchActions = () => {
     return [
         makeSearchAction('tapRadius', 'tap', 'TAP ', 'Cone Search', SearchTypes.pointRadius, .001, 2.25,
-            (sa, cenWpt, radius) => {
-                showTap( {defaultSelectedId: 'tap', searchParams: {radiusInArcSec: radius, wp: cenWpt}});
-            }),
+            (sa, cenWpt, radius) => showTapSearchPanel( {radiusInArcSec: radius, wp: cenWpt}), ),
         makeSearchAction('tapArea', 'tap', 'TAP', 'Area Search', SearchTypes.area, undefined, undefined,
-            (sa, cenWpt, radius, corners) => {
-                showTap({defaultSelectedId: 'tap', searchParams: {corners}});
-            }),
-        makeSearchAction('tapRadius', 'tap', 'TAP ', 'Cone Search', SearchTypes.point_table_only, .001, 2.25,
-            (sa, cenWpt) => {
-                showTap({defaultSelectedId: 'tap', searchParams: {wp: cenWpt}});
-            }),
+            (sa, cenWpt, radius, corners) => showTapSearchPanel({corners}), ),
+        makeSearchAction('tableTapRadius', 'tap', 'TAP ', 'Cone Search', SearchTypes.point_table_only, .001, 2.25,
+            (sa, cenWpt) => showTapSearchPanel({wp: cenWpt}), ),
     ];
 };
 
 
 export const makeDefImageSearchActions = () => {
     return [
-        makeSearchAction('imageFits', 'image', 'FITS', 'Fits tip', SearchTypes.point, undefined, undefined,
+        makeSearchAction('imageFits', 'image', 'FITS', 'Load a FITS Image at this point', SearchTypes.point, undefined, undefined,
             (sa, wp) => showImage( {searchParams: {wp, type: 'singleChannel'}}) ),
         makeSearchAction('HiPS', 'image', 'HiPS', 'HiPS tip', SearchTypes.pointRadius, .0025, 180,
             (sa, wp, radius) => showImage( {searchParams: {wp, type: 'hipsImage', radius}}), 'Display HiPS at region center'),

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -14,7 +14,6 @@ import {SpatialPanelWidth} from './TableSearchHelpers.jsx';
 import {TableSearchMethods} from './TableSearchMethods.jsx';
 import { defTapBrowserState, loadTapColumns, loadTapSchemas, loadTapTables, tapHelpId, } from './TapUtil.js';
 
-
 import './TableSelectViewPanel.css';
 
 
@@ -26,23 +25,18 @@ export const SectionTitle= ({title,helpId,tip}) => (
     <div className='TapSearch__section--title' title={tip}>{title}<HelpIcon helpId={tapHelpId(helpId)}/></div>);
 
 export function AdqlUI({serviceUrl}) {
-
     return (
-
         <div className='TapSearch__section' style={{flexDirection: 'column', flexGrow: 1}}>
             <div style={{ display: 'inline-flex', alignItems: 'center'}}>
                 <div className='TapSearch__section--title'>3. Advanced ADQL  <HelpIcon helpId={tapHelpId('adql')}/> </div>
                 <div style={{color: 'brown', fontSize: 'larger'}}>ADQL edits below will not be reflected in <b>Single Table</b> view</div>
             </div>
-
-
             <div className='expandable'>
                 <div style={{flexGrow: 1}}>
                     <AdvancedADQL adqlKey='adqlQuery' defAdqlKey='defAdqlKey' tblNameKey='tableName' serviceUrl={serviceUrl}/>
                 </div>
             </div>
         </div>
-
     );
 }
 
@@ -57,37 +51,23 @@ function useStateRef(initialState){
 }
 
 export function BasicUI(props) {
-    const {initArgs}= props;
+    const {initArgs={}}= props;
+    const {urlApi={},searchParams={}}= initArgs;
     const [getTapBrowserState,setTapBrowserState]= useFieldGroupMetaState(defTapBrowserState);
+    const {selectBy, obsCoreTableModel}= props;
     const initState = getTapBrowserState();
     const [error, setError] = useState(undefined);
     const mountedRef = useRef(false);
     const {setVal}= useContext(FieldGroupCtx);
     const serviceLabel= props.serviceLabel ?? initState.serviceLabel;
     const [serviceUrl, serviceUrlRef, setServiceUrl] = useStateRef(initState.serviceUrl || props.serviceUrl);
-    const [schemaName, schemaRef, setSchemaName] = useStateRef(initState.schemaName || props.initArgs?.urlApi?.schema);
-    const [tableName, tableRef, setTableName] = useStateRef(initState.tableName || props.initArgs?.urlApi?.table);
-    const [obsCoreEnabled, setObsCoreEnabled] = useState(initState.obsCoreEnabled || props.initArgs?.urlApi?.selectBy === 'obscore');
+    const [schemaName, schemaRef, setSchemaName] = useStateRef(searchParams.schema || initState.schemaName || urlApi.schema);
+    const [tableName, tableRef, setTableName] = useStateRef(searchParams.table || initState.tableName || urlApi.table);
+    const [obsCoreEnabled, setObsCoreEnabled] = useState(initState.obsCoreEnabled || initArgs.urlApi?.selectBy === 'obscore');
     const [schemaOptions, setSchemaOptions] = useState();
     const [tableOptions, setTableOptions] = useState();
     const [columnsModel, setColumnsModel] = useState();
-    const selectBy = props.selectBy;
-    const obsCoreTableModel = props.obsCoreTableModel;
 
-    useEffect(() => {
-        const {table:t,schemaName:s}= initArgs?.searchParams ?? {};
-        if (s && (s!==schemaName)) {
-            setTimeout(() => {
-                setSchemaName(s);
-                setTableName(t);
-                loadSchemas(serviceUrl,s).then(() => {
-                    setTableName(t);
-                    loadTables(serviceUrl,s,t);
-                });
-            },5);
-        }
-        // t && (t!==tableName) && setTableName(initArgs?.searchParams?.table);
-    }, [initArgs?.searchParams?.schemaName]);
 
     const obsCoreSelected = selectBy === 'obscore';
     const tableSectionNumber = !obsCoreSelected ? '4' : '3';
@@ -105,7 +85,7 @@ export function BasicUI(props) {
         setVal('tableName',undefined);
         // update state for higher level components that might rely on obsCoreTables
 
-        return loadTapSchemas(requestServiceUrl).then((tableModel) => {
+        loadTapSchemas(requestServiceUrl).then((tableModel) => {
             if (!mountedRef.current) {
                 return;
             }

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -74,6 +74,21 @@ export function BasicUI(props) {
     const selectBy = props.selectBy;
     const obsCoreTableModel = props.obsCoreTableModel;
 
+    useEffect(() => {
+        const {table:t,schemaName:s}= initArgs?.searchParams ?? {};
+        if (s && (s!==schemaName)) {
+            setTimeout(() => {
+                setSchemaName(s);
+                setTableName(t);
+                loadSchemas(serviceUrl,s).then(() => {
+                    setTableName(t);
+                    loadTables(serviceUrl,s,t);
+                });
+            },5);
+        }
+        // t && (t!==tableName) && setTableName(initArgs?.searchParams?.table);
+    }, [initArgs?.searchParams?.schemaName]);
+
     const obsCoreSelected = selectBy === 'obscore';
     const tableSectionNumber = !obsCoreSelected ? '4' : '3';
 
@@ -90,7 +105,7 @@ export function BasicUI(props) {
         setVal('tableName',undefined);
         // update state for higher level components that might rely on obsCoreTables
 
-        loadTapSchemas(requestServiceUrl).then((tableModel) => {
+        return loadTapSchemas(requestServiceUrl).then((tableModel) => {
             if (!mountedRef.current) {
                 return;
             }

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -114,6 +114,11 @@ export function TapSearchPanel({initArgs= {}, titleOn=true}) {
     };
 
     useEffect(() => {
+        const {serviceUrl:u}= initArgs?.searchParams ?? {};
+        u && u!==serviceUrl && setServiceUrl(u);
+    }, [initArgs?.searchParams?.serviceUrl]);
+
+    useEffect(() => {
         return FieldGroupUtils.bindToStore( TAP_PANEL_GROUP_KEY, (fields) => {
             setSelectBy(getFieldVal(TAP_PANEL_GROUP_KEY,'selectBy',selectBy));
             const ts= getTapBrowserState();

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -7,7 +7,7 @@ import React, {memo, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
 import {isEmpty,omit,isFunction} from 'lodash';
-import {getAppOptions} from '../../api/ApiUtil.js';
+import {getSearchActions} from '../../core/AppDataCntlr.js';
 import {getPlotGroupById}  from '../PlotGroup.js';
 import {ExpandType, dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {VisCtxToolbarView, canConvertHipsAndFits} from '../ui/VisCtxToolbarView';
@@ -138,7 +138,7 @@ function contextToolbar(plotView,dlAry,extensionList, width) {
         const clearFilter= showClearFilter(plotView,dlAry);
         const selAry= extensionList.filter( (ext) => ext.extType===AREA_SELECT);
         const extensionAry= isEmpty(selAry) ? EMPTY_ARRAY : selAry;
-        const searchActions= getAppOptions()?.searchActions;
+        const searchActions= getSearchActions();
         return (
             <VisCtxToolbarView {...{plotView, extensionAry, width,
                 showSelectionTools:true, showCatSelect:select, showCatUnSelect:unselect, searchActions,


### PR DESCRIPTION
#### [Firefly-1144](https://jira.ipac.caltech.edu/browse/FIREFLY-1144)
  - added more parameter checking in TAP
  - Fixed a small bug in ServerContext with choosing working directory
  - added "click-to-search" masking to control which features are avilable.

#### Testing - can only test on suit data-int

- Test on https://data-int.lsst.cloud/
- search a table 
    - Use click to search feature
    - try searching the truth table or obscore from image after selecting an area
    - try searching the truth table or obscore  from table

