### PR TITLE
FIREFLY-613: remember table options selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "fixed-data-table-2": "~1.2",
     "prismjs": "~1.26",
     "blissfuljs": "~1.0",
-    "json-bigint": "https://github.com/Caltech-IPAC/json-bigint"
+    "json-bigint": "https://github.com/Caltech-IPAC/json-bigint",
+    "md5": "~2.3.0"
   },
   "devDependencies": {
     "@babel/core": "~7.16",

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -216,17 +216,19 @@ public class ServerContext {
         }
 
         if (altDir == null) {
-            log.info(desc + " failed. " + " alternate directory is null");
+            log.error(desc + " failed. " + " no alternate directory is given");
             return null;
         }
 
         // using altDir
         log.info(desc +  "; Using alternate path: " + altDir.getPath());
         initDir(altDir);
-        if (!altDir.canWrite()) {
-            log.info(desc + " failed. " + " Unable to write to alternate directory: " + altDir.getPath());
+        if (altDir.canWrite()) {
+            return altDir;
+        } else {
+            log.error(desc + " failed. " + " Unable to write to alternate directory: " + altDir.getPath());
+            return null;
         }
-        return altDir;
     }
 
 

--- a/src/firefly/js/tables/TablePref.js
+++ b/src/firefly/js/tables/TablePref.js
@@ -1,0 +1,82 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+
+import md5 from 'md5';
+import {getColumns, getTableUiById, getTblById} from './TableUtil.js';
+import BrowserCache from '../util/BrowserCache.js';
+import {dispatchTableUiUpdate} from './TablesCntlr.js';
+import {getModuleName} from 'firefly/util/WebUtil.js';
+
+export const PREF_KEY = 'tbl_pref_key';
+export const PREF_APPLIED = 'prefApplied';
+
+/**
+ *
+ * @param tbl_ui_id
+ * @param uiData
+ * @return {boolean} returns true if column preferences were applied
+ */
+export function applyTblPref(tbl_ui_id, uiData) {
+    const prefKey = getTblPrefKey(tbl_ui_id);
+    if (!prefKey) return false;
+
+    const cached = BrowserCache.get(prefKey);
+    if (cached?.colPref) {
+        const colPref = new Map(JSON.parse(cached.colPref));
+        uiData.columns?.filter((c) => c.visibility !== 'hidden')
+            .forEach((c) => {
+                if (colPref.has(c.name))    c.visibility = colPref.get(c.name);
+            });
+        uiData[PREF_APPLIED] = true;
+    }
+    return uiData[PREF_APPLIED];
+}
+
+/**
+ * set the visible columns in this table as the preferred visible columns
+ * @param {string} tbl_ui_id
+ */
+export function setTblPref(tbl_ui_id) {
+    const prefKey = getTblPrefKey(tbl_ui_id);
+    if (!prefKey) return;
+
+    const {columns=[]} = getTableUiById(tbl_ui_id) || {};
+    const colPref = JSON.stringify(columns.map((c) => [c.name, c.visibility || 'show']));  //
+
+    BrowserCache.put(prefKey, {colPref});
+}
+
+/**
+ * clear this table preferences
+ * @param {string} tbl_ui_id
+ */
+export function clearTblPref(tbl_ui_id) {
+    const prefKey = getTblPrefKey(tbl_ui_id);
+    if (!prefKey) return;
+
+    BrowserCache.remove(prefKey);
+    dispatchTableUiUpdate({tbl_ui_id, [PREF_APPLIED]:false});
+}
+
+/**
+ * @param tbl_ui_id
+ * @return {string} the key used to get column's preferences for the given table.  If a PREF_KEY is not
+ * in TableMeta, then return undefined to indicate Preferences is not used for this table.
+ */
+export function getTblPrefKey(tbl_ui_id) {
+    const {tbl_id} = getTableUiById(tbl_ui_id) || {};
+    const tableModel = getTblById(tbl_id);
+    if (!tableModel) return undefined;
+
+    const prefKey = tableModel.tableMeta?.[PREF_KEY];
+        // disable default impl.  will only apply to table with PREF_KEY
+        // md5(getColumns(tableModel)
+        //     .map( (c) => c.name)
+        //     .join('|')
+        // );
+    return prefKey && `colPref-${getModuleName()}-${prefKey}`;
+}
+
+

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -404,7 +404,7 @@ export function getFilterCount(tableModel) {
 
 export function clearFilters(tableModel) {
     const {request, tbl_id} = tableModel || {};
-    if (request && request.filters) {
+    if (request && (request.filters || request.sqlFilters)) {
         TblCntlr.dispatchTableFilter({tbl_id, filters: '', sqlFilters: ''});
     }
 }

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -6,7 +6,7 @@ import React, {useCallback, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {Column, Table} from 'fixed-data-table-2';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
-import {get, isEmpty, isUndefined, omitBy, pick} from 'lodash';
+import {get, set, isEmpty, isUndefined, omitBy, pick} from 'lodash';
 
 import {calcColumnWidths, getCellValue, getProprietaryInfo, getTableUiById, getTblById, hasNoData, hasRowAccess, isClientTable, tableTextView, uniqueTblUiId} from '../TableUtil.js';
 import {SelectInfo} from '../SelectInfo.js';
@@ -39,12 +39,15 @@ const BasicTableViewInternal = React.memo((props) => {
     useEffect( () => {
         if (!isEmpty(columns)) {
             const changes = omitBy(pick(props, 'showTypes', 'showFilters', 'showUnits', 'filterInfo','selectable', 'sortInfo', 'textView'), isUndefined);
-            if (isUndefined(changes.showUnits)) {
-                changes.showUnits = !!columns.find?.((col) => col?.units);
-            }
-            if (isUndefined(changes.showFilters)) {
-                changes.showFilters = !!tbl_id && !isClientTable(tbl_id);    // false if no tbl_id or is a client table
-            }
+
+            const showUnits = !!columns.find?.((col) => col?.units);
+            if (isUndefined(changes.showUnits)) changes.showUnits = showUnits;
+            if (isUndefined(changes.options?.showUnits)) set(changes,'options.showUnits', showUnits);
+
+            const showFilters = !(!tbl_id || isClientTable(tbl_id));    // false if no tbl_id or is a client table
+            if (isUndefined(changes.showFilters)) changes.showFilters = showFilters;
+            if (isUndefined(changes.options?.showFilters)) set(changes,'options.showFilters', showFilters);
+
             if (!isEmpty(changes)) {
                 dispatchTableUiUpdate({tbl_ui_id, ...changes});
             }

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -181,6 +181,13 @@
     color: maroon;
 }
 
+.TablePanelOptions__pref {
+    display: inline-flex;
+    font-style: italic;
+    color: gray;
+    margin-top: 3px;
+}
+
 .TablePanel__mask {
     box-sizing: content-box;
     background-color: rgba(255,255,255,.8);

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -51,15 +51,16 @@ export function TablePanel(props) {
     const searchActions= getSearchActions();
 
     useEffect( () => {
-        if (!getTableUiByTblId(tbl_id)) {
-            dispatchTableUiUpdate({tbl_ui_id, tbl_id, options});
-        }
+        dispatchTableUiUpdate({tbl_ui_id, tbl_id, options});
+    }, [tbl_id, tbl_ui_id]);
+
+    useEffect( () => {
         if (tableModel && !tableModel.origTableModel) {
             tableModel.tbl_id = tbl_id;
             set(tableModel, 'request.tbl_id', tbl_id);
             dispatchTableAddLocal(tableModel, undefined, false);
         }
-    }, [tbl_id, tbl_ui_id, tableModel]);
+    }, [tbl_id, tableModel]);
 
     const {selectable, expandable, expandedMode, border, renderers, title, removable, rowHeight, help_id,
         showToolbar, showTitle, showInfoButton, showMetaInfo, showOptions,
@@ -78,7 +79,7 @@ export function TablePanel(props) {
     const clearFilter = () => connector.applyFilterChanges({filterInfo: '', sqlFilter: ''});
     const toggleOptions = () => connector.onToggleOptions(!showOptions);
     const onOptionUpdate = (value) => connector.onOptionUpdate(value);
-    const onOptionReset = () => connector.onOptionReset(props);
+    const onOptionReset = () => connector.onOptionReset();
 
     const expandTable = () => {
         dispatchTblExpanded(tbl_ui_id, tbl_id);
@@ -99,7 +100,7 @@ export function TablePanel(props) {
         .map((f) => f(uiState))
         .map( (c, idx) => get(c, 'props.key') ? c : React.cloneElement(c, {key: idx})); // insert key prop if missing
 
-    const showOptionsDialog = () => showTableOptionDialog(onOptionUpdate, onOptionReset, tbl_ui_id, tbl_id);
+    const showOptionsDialog = () => showTableOptionDialog(onOptionUpdate, onOptionReset, clearFilter, tbl_ui_id, tbl_id);
     const showInfoDialog = () => showTableInfoDialog(tbl_id);
 
     const tstate = getTableState(uiState);
@@ -191,13 +192,14 @@ function getTableState(state) {
 }
 
 
-function showTableOptionDialog(onChange, onOptionReset, tbl_ui_id, tbl_id) {
+function showTableOptionDialog(onChange, onOptionReset, clearFilter, tbl_ui_id, tbl_id) {
 
     const content = (
          <div className='TablePanelOptionsWrapper'>
                <TablePanelOptions
                   onChange={onChange}
                   onOptionReset={onOptionReset}
+                  clearFilter={clearFilter}
                   tbl_ui_id={tbl_ui_id}
                   tbl_id={tbl_id}
                />

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -1,7 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {once} from 'lodash';
+import {once, set} from 'lodash';
 import React, {useEffect, useRef, useState} from 'react';
 import FieldGroupUtils, {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils.js';
 import {makeSearchOnce} from 'firefly/util/WebUtil.js';
@@ -28,6 +28,7 @@ import {
 } from 'firefly/ui/tap/TapUtil.js';
 import { SectionTitle, AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
 import {useFieldGroupMetaState} from '../SimpleComponent.jsx';
+import {PREF_KEY} from 'firefly/tables/TablePref.js';
 
 
 
@@ -322,6 +323,8 @@ function onTapSearchSubmit(request,serviceUrl,tapBrowserState) {
 
             const treq = makeTblRequest('AsyncTapQuery', getTitle(adql,serviceUrl), params, options);
             setNoCache(treq);
+
+            if (!isADQL) set(treq, `META_INFO.${PREF_KEY}`, `${tapBrowserState.schemaName}-${tapBrowserState.tableName}`);
             dispatchTableSearch(treq, {backgroundable: true, showFilters: true, showInfoButton: true});
 
         };

--- a/src/firefly/js/util/BrowserCache.js
+++ b/src/firefly/js/util/BrowserCache.js
@@ -41,6 +41,10 @@ class BrowserCache {
     static put(key, data, lifespanInSecs= 0) {
         ls.set(key, makeCacheEntry(data, lifespanInSecs));
     }
+
+    static remove(key) {
+        ls.remove(key);
+    }
 }
 
 export default BrowserCache;

--- a/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogSelectViewPanel.jsx
@@ -5,7 +5,7 @@
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {FormPanel} from '../../ui/FormPanel.jsx';
-import { get, merge, isEmpty, isFunction} from 'lodash';
+import {set, get, merge, isEmpty, isFunction} from 'lodash';
 import {updateMerge} from '../../util/WebUtil.js';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
 import {doFetchTable} from '../../tables/TableUtil.js';
@@ -27,6 +27,7 @@ import {getAppOptions} from '../../core/AppDataCntlr.js';
 
 import './CatalogTableListField.css';
 import './CatalogSelectViewPanel.css';
+import {PREF_KEY} from 'firefly/tables/TablePref.js';
 
 /**
  * group key for fieldgroup comp
@@ -210,6 +211,8 @@ function doCatalog(request) {
         tReq.selcols = colsSearched;
     }
     //console.log('final request: ' + JSON.stringify(tReq));
+
+    set(tReq, `META_INFO.${PREF_KEY}`, `${tReq.catalogProject}-${tReq.catalog}`);
     dispatchTableSearch(tReq, {backgroundable:true});
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2278,6 +2278,11 @@ change-emitter@^0.1.2:
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
   integrity sha512-YXzt1cQ4a2jqazhcuSWEOc1K2q8g9H6eWNsyZgi640LDzRWVQ2eDe+Y/kVdftH+vYdPF2rgDb3dLdpxE1jvAxw==
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
@@ -2500,6 +2505,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
 
 css-loader@~6.5:
   version "6.5.1"
@@ -3872,7 +3882,7 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -4958,6 +4968,15 @@ material-colors@^1.2.1:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
   integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
+
+md5@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 mdurl@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-613
Test: https://fireflydev.ipac.caltech.edu/firefly-613-table-col-sticky/firefly/


Remember user's selection from Table Options, then apply the same settings to the same table.  This includes columns, showUnits, showFilters, and showTypes.
`same` is defined with a `tbl_pref_key` tableMeta key, or the uniqueness of the combined column names in the same order.  
When previous settings(preferences) are applied to a table, show an option to clear it.

What is the difference between `Reset` and `clear preferences`.  Both will clear preferences and reset columns, showUnits, showFilters, and showTypes to default settings.  `Reset` also reset the `Page Size` and any filters added to the table.

Things to consider:
- Is there another way of separating `clear` from `Reset`?
- Currently, this feature is apply to all table across all applications.  Meaning, if you change Table Options to an `AllWISE Source Catalog` in IRSAViewer, it will be remembered when you open the same table in SOFIA.  Is this desirable?
- Always on.  Is this a good thing?  Do we need to add a flag so that it can be disabled?
- `tbl_pref_key` tableMeta can be used to pin down a specific table.  Are there any table we need to add this to?
    - Take HiPS image table.  Do we want to remember preferences here?
