### PR TITLE
Firefly-1147: Modify upload panel to accept/allow one item

### DIFF
--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -23,8 +23,6 @@ import {MultiSearchPanel} from 'firefly/ui/MultiSearchPanel.jsx';
 import {TapSearchPanel} from 'firefly/ui/tap/TapSearchRootPanel.jsx';
 import {VersionInfo} from 'firefly/ui/VersionInfo.jsx';
 import {DLGeneratedDropDown} from './dynamic/DLGeneratedDropDown.js';
-import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES
-}  from 'firefly/visualize/ui/FileUploadViewPanel';
 
 const flexGrowWithMax = {width: '100%', maxWidth: 1400};
 

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -32,7 +32,7 @@ const tableOnlyDefaultAcceptList = [
 
 export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSubmit=resultSuccess, keepState=true,
                                       groupKey=panelKey, acceptList= getAppOptions()?.uploadPanelLimit==='tablesOnly'?
-        tableOnlyDefaultAcceptList: defaultAcceptList}) =>{
+        tableOnlyDefaultAcceptList: defaultAcceptList, acceptOneItem=false}) =>{
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
@@ -50,7 +50,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
                     changeMasking={changeMasking}
                     inputStyle={{height:'100%'}}
                     submitBarStyle={{padding: '2px 3px 3px'}} help_id={helpId}>
-                    <FileUploadViewPanel setSubmitText={setSubmitText} acceptList={acceptList}/>
+                    <FileUploadViewPanel {...{setSubmitText, acceptList, acceptOneItem}}/>
                 </FormPanel>
             </FieldGroup>
             {doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
@@ -62,7 +62,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
 
 const DIALOG_ID= 'FileUploadDialog';
 
-export function showUploadDialog(acceptList, keepState, groupKey) {
+export function showUploadDialog(acceptList, keepState, groupKey, acceptOneItem) {
 
     DialogRootContainer.defineDialog(DIALOG_ID,
         <PopupPanel title={'Upload'}
@@ -82,6 +82,7 @@ export function showUploadDialog(acceptList, keepState, groupKey) {
                     keepState={keepState}
                     groupKey={groupKey}
                     acceptList={acceptList}
+                    acceptOneItem={acceptOneItem}
                 />
             </div>
         </PopupPanel>

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -257,34 +257,32 @@ function uploadButtons() {
     return (
         <div style={{padding:10}}>
 
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([TABLES],true,'FileUploadAnalysis_Only_Table')}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([TABLES],true,'FileUploadAnalysis_Only_Table',true)}>
                 <b>Tables Only Upload</b>
             </button>
 
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES],true,'FileUploadAnalysis_All_Tables')}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES],true,'FileUploadAnalysis_All_Tables',true)}>
                 <b>All Tables Upload</b>
             </button>
             <br/><br/>
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([REGIONS],true,'FileUploadAnalysis_Region')}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([REGIONS],true,'FileUploadAnalysis_Region',true)}>
                 <b>Region Upload</b>
             </button>
 
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([IMAGES],true,'FileUploadAnalysis_Image')}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([IMAGES],true,'FileUploadAnalysis_Image',true)}>
                 <b>Image Upload</b>
             </button>
             <br/><br/>
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([DATA_LINK_TABLES],true,'FileUploadAnalysis_DataLink_Only')}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([DATA_LINK_TABLES],true,'FileUploadAnalysis_DataLink_Only',true)}>
                 <b>DataLink Tables Only</b>
             </button>
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES],true,'FileUploadAnalysis_MocFits_Only')}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES],true,'FileUploadAnalysis_MocFits_Only',true)}>
                 <b>MOC FITS Only</b>
             </button>
             <br/><br/>
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES,REGIONS,IMAGES],true,'FileUploadAnalysis_Region')}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES,REGIONS,IMAGES],true,'FileUploadAnalysis_Everything',true)}>
                 <b>Accept Everything (Default)</b>
             </button>
-
-
             <br/>
 
 


### PR DESCRIPTION
#### [Firefly-1147](https://jira.ipac.caltech.edu/browse/FIREFLY-1147): Modify upload panel to allow/accept only one item 
- added a new prop in FileUploadViewPanel: acceptOneItem (when it's true, we only allow user to select and load with one entry) 
- Default value of acceptOneItem is false (so we accept any number of entries) but FileUploadDropdown can be called with acceptOneItem set to true 
- some small changes to in FileUploadViewPanel and FileUploadProcessor to accommodate for acceptOneItem being true
   - To hide checkboxes, I call TabelPanel with selectable={false} when acceptOneItem is true

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1147-acceptonlyoneitem/firefly/firefly-dev.html
-  Go to Test Searches -> Uploads
   - All of the buttons here call the upload panel with acceptOneItem set to true 
- Click on "Tables Only" or "All Tables" upload, and upload a FITS file with both tables and images
    - ensure that checkboxes are hidden
    - first highlighted entry should be a table 
    - if you attempt to select an Image or HeaderOnly and "Load", you should get an error dialog 
- Repeat the above step from the "Image Upload" button (image should be the first highlighted item here) 
- From the MOC/DataLink buttons, attempt to upload a non-MOC/non-DataLink file and "Load" - this should give you an error dialog 
- Test uploading a MOC fits file from the "Moc FITS Only" button - you should not see any options here ("Load as MOC" / "Load as Table")
    - if you upload a MOC fits file from the "Tables Only" or "All Tables" upload button, though, you should see these 2 options show up  
-  Make sure other uploads work as expected (e.g.: region)  