### PR TITLE
FIREFLY-1129: Support UWS job file uploads via the upload panel

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -88,6 +88,9 @@ public class FileAnalysis {
             case PDF:
                 report =  analyzePDF(infile, mtype);
                 break;
+            case UWS:
+                report =  analyzeUWS(infile, mtype, params);
+                break;
             case TAR:
                 report =  analyzeTAR(infile, mtype);
                 break;
@@ -145,6 +148,7 @@ public class FileAnalysis {
                 putPartVal(h, p.getUiRender().name(), i, "uiRender");
 
                 putPartVal(h, p.getDesc(), i, "desc");
+                putPartVal(h, p.getUrl(), i, "url");
                 putPartVal(h, p.getConvertedFileName(),i,"convertedFileName");
                 putPartVal(h, p.getConvertedFileFormat(),i,"convertedFileFormat");
                 putPartVal(h, p.getTableColumnNames(),i,"tableColumnNames");
@@ -197,6 +201,14 @@ public class FileAnalysis {
     public static FileAnalysisReport analyzePDF(File infile, FileAnalysisReport.ReportType type) {
         FileAnalysisReport report = new FileAnalysisReport(type, TableUtil.Format.PDF.name(), infile.length(), infile.getPath());
         report.addPart(new FileAnalysisReport.Part(FileAnalysisReport.Type.PDF, "PDF File"));
+        return report;
+    }
+
+    public static FileAnalysisReport analyzeUWS(File infile, FileAnalysisReport.ReportType type, Map<String, String> params) {
+        FileAnalysisReport report = new FileAnalysisReport(type, TableUtil.Format.UWS.name(), infile.length(), infile.getPath());
+        FileAnalysisReport.Part part= new FileAnalysisReport.Part(FileAnalysisReport.Type.UWS, "UWS Job File");
+        part.setUrl(params.get("URL")); //make URL accessible on client side
+        report.addPart(part);
         return report;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysisReport.java
@@ -25,7 +25,7 @@ public class FileAnalysisReport {
         Normal,             // a report with all parts populated, but not details
         Details}            // a full report with details
 
-    public enum Type {Image, Table, Spectrum, HeaderOnly, PDF, TAR, REGION, PNG, ErrorResponse, LoadInBrowser, Unknown}
+    public enum Type {Image, Table, Spectrum, HeaderOnly, PDF, TAR, REGION, PNG, ErrorResponse, LoadInBrowser, UWS, Unknown}
     public enum UIRender {Table, Chart, Image, NotSpecified}
     public enum UIEntry {UseSpecified, UseGuess, UseAll}
     public enum ChartTableDefOption {auto, showChart, showTable, showImage};
@@ -182,7 +182,8 @@ public class FileAnalysisReport {
     public static class Part {
         private final Type type;
         private UIRender uiRender=UIRender.NotSpecified;
-        private UIEntry uiEntry= UIEntry.UseAll;;
+        private UIEntry uiEntry= UIEntry.UseAll;
+        private String url; //this is only used by UWS for now
         private int index= 0;
         private String desc;
         private int fileLocationIndex = -1;   // todo: populate: fits (hdu idx) or VO (table idx)
@@ -263,6 +264,9 @@ public class FileAnalysisReport {
         public UIEntry getUiEntry() { return uiEntry; }
         public void setUiEntry(UIEntry uiEntry) { this.uiEntry = uiEntry; }
 
+        public String getUrl() { return url; }
+        public void setUrl(String url) { this.url = url; }
+
         public ChartTableDefOption getChartTableDefOption() { return chartTableDefOption; }
         public void setChartTableDefOption(ChartTableDefOption chartTableDefOption) {
             this.chartTableDefOption = chartTableDefOption;
@@ -273,6 +277,7 @@ public class FileAnalysisReport {
             p.details= details;
             p.uiRender= uiRender;
             p.uiEntry= uiEntry;
+            p.url = url;
             p.index= index;
             p.fileLocationIndex = fileLocationIndex;
             p.convertedFileName= convertedFileName;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -20,6 +20,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.xml.crypto.Data;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayOutputStream;
@@ -42,14 +43,23 @@ import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase;
 @SearchProcessorImpl(id = UwsJobProcessor.ID, params = {
         @ParamDoc(name = UwsJobProcessor.JOB_URL, desc = "URL of a submitted UWS job")
 })
-public abstract class UwsJobProcessor extends EmbeddedDbProcessor {
+public class UwsJobProcessor extends EmbeddedDbProcessor {
     public static final String ID = "UwsJob";
     public static final String JOB_URL = "jobUrl";
 
     private static final Logger.LoggerImpl logger = Logger.getLogger();
     private String jobUrl;
 
-    abstract HttpServiceInput createInput(TableServerRequest request) throws DataAccessException;
+    /**
+     * override this method to be able to create a HttpServiceInput object
+     * @param request request info needed to create HttpServiceInput object
+     * @return HttpServiceInput object or null
+     * @throws DataAccessException
+     */
+     HttpServiceInput createInput(TableServerRequest request) throws DataAccessException {
+        return null;
+     }
+
 
     public Job.Type getType() { return Job.Type.UWS; }
 
@@ -106,6 +116,7 @@ public abstract class UwsJobProcessor extends EmbeddedDbProcessor {
      */
     String submitJob(TableServerRequest req) throws DataAccessException {
         HttpServiceInput input = createInput(req);
+        if (input == null) throw new DataAccessException("createInput returned null");
         final Ref<String> jobUrl = new Ref<>();
         input.setFollowRedirect(false);         // ensure redirect is off, although this is handled by HttpServices already.
         HttpServices.Status status = HttpServices.postData(input, (method) -> {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -21,7 +21,6 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.crypto.Data;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayOutputStream;
@@ -29,7 +28,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
@@ -73,7 +73,7 @@ public class AnyFileUpload extends BaseHttpServlet {
     private static final String FILE_ANALYSIS= "fileAnalysis";
 
     private static final List<String> allParams= Arrays.asList(
-            FILE_NAME, CACHE_KEY, WORKSPACE_PUT, WS_CMD, ANALYZER_ID, URL,HIPS_CACHE,
+            FILE_NAME, CACHE_KEY, WORKSPACE_PUT, WS_CMD, ANALYZER_ID,HIPS_CACHE,
             WEB_PLOT_REQUEST, FILE_ANALYSIS, ServerParams.COMMAND);
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/util/Ref.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/util/Ref.java
@@ -29,4 +29,16 @@ public class Ref<T> {
     public boolean has() {
         return source != null;
     }
+
+    public String toString() {
+        return source == null ? super.toString() : source.toString();
+    }
+
+    public boolean equals(Object obj) {
+        return source == null ? super.equals(obj) : source.equals(obj);
+    }
+
+    public int hashCode() {
+        return source == null ? super.hashCode() : source.hashCode();
+    }
 }

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -120,7 +120,7 @@ public class TableUtil {
                 } else if (line.startsWith("<VOTABLE") ||
                         (line.contains("<?xml") && line.contains("<VOTABLE "))) {
                     return Format.VO_TABLE;
-                } else if (line.trim().startsWith("<uws:job ")) {
+                } else if (isUwsEl(line)) {
                     return Format.UWS;
                 } else if (row == 0 && line.toLowerCase().indexOf("pdf") > 0) {
                     return Format.PDF;
@@ -170,6 +170,12 @@ public class TableUtil {
             FileUtil.silentClose(reader);
         }
 
+    }
+
+    private static boolean isUwsEl(String line) {
+        line = line.trim().toLowerCase();
+        boolean isUws = line.contains("www.ivoa.net/xml/uws");
+        return isUws && line.matches("<(.+:)?job .*");
     }
 
     private static int getColCount(CSVFormat format, String line) {

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -120,6 +120,8 @@ public class TableUtil {
                 } else if (line.startsWith("<VOTABLE") ||
                         (line.contains("<?xml") && line.contains("<VOTABLE "))) {
                     return Format.VO_TABLE;
+                } else if (line.trim().startsWith("<uws:job ")) {
+                    return Format.UWS;
                 } else if (row == 0 && line.toLowerCase().indexOf("pdf") > 0) {
                     return Format.PDF;
                 } else if (isRegLine(line)) {
@@ -310,7 +312,7 @@ public class TableUtil {
     public enum Format { TSV(CSVFormat.TDF, ".tsv"), CSV(CSVFormat.DEFAULT, ".csv"), IPACTABLE(".tbl"), UNKNOWN(null),
                          FIXEDTARGETS(".tbl"), FITS(".fits"), JSON(".json"), PDF(".pdf"), TAR(".tar"), HTML(".html"),
                          VO_TABLE(".xml"), VO_TABLE_TABLEDATA(".vot"), VO_TABLE_BINARY(".vot"), VO_TABLE_BINARY2(".vot"),
-                         VO_TABLE_FITS(".vot"), REGION(".reg"), PNG(".png");
+                         VO_TABLE_FITS(".vot"), REGION(".reg"), PNG(".png"), UWS(".xml");
         public CSVFormat type;
         String fileNameExt;
         Format(String ext) {this.fileNameExt = ext;}
@@ -335,6 +337,7 @@ public class TableUtil {
         allFormats.put("fits", Format.FITS);
         allFormats.put("pdf", Format.PDF);
         allFormats.put("png", Format.PNG);
+        allFormats.put("uws", Format.UWS);
     }
 
     public static Map<String, Format> getAllFormats() { return allFormats; }

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -96,7 +96,7 @@ function FinalMsg({phase, summary, error}) {
     } else return null;
 }
 
-export function UwsJobInfo({jobInfo, style}) {
+export function UwsJobInfo({jobInfo, style, isOpen=false}) {
 
     return (
         <div className='JobInfo__main' style={style}>
@@ -107,19 +107,19 @@ export function UwsJobInfo({jobInfo, style}) {
                         .map(([k,v]) => <KeywordBlock key={k} label={k} value={v}/>)
                 }</>
 
-                <OptionalBlock label='parameters' value={jobInfo.parameters}/>
-                <OptionalBlock label='results' value={jobInfo.results} asLink={true}/>
-                <OptionalBlock label='errorSummary' value={jobInfo.errorSummary}/>
+                <OptionalBlock label='parameters' value={jobInfo.parameters} isOpen={isOpen}/>
+                <OptionalBlock label='results' value={jobInfo.results} asLink={true} isOpen={isOpen}/>
+                <OptionalBlock label='errorSummary' value={jobInfo.errorSummary} isOpen={isOpen}/>
 
             </div>
         </div>
     );
 }
 
-function OptionalBlock({label, value, asLink}) {
+function OptionalBlock({label, value, asLink, isOpen}) {
     if (!value) return null;
     return (
-        <CollapsiblePanel componentKey={`JobInfo-${label}`} header={label} isOpen={false}>
+        <CollapsiblePanel componentKey={`JobInfo-${label}`} header={label} isOpen={isOpen}>
             <div className='JobInfo__items'>
                 <> {
                     Object.entries(value).map(([k,v]) => <KeywordBlock key={k} label={k} value={v} asLink={asLink}/>)

--- a/src/firefly/js/data/FileAnalysis.js
+++ b/src/firefly/js/data/FileAnalysis.js
@@ -12,7 +12,8 @@ export const FileAnalysisType = {
     Unknown: 'UNKNOWN',
     HTML: 'HTML',
     REGION: 'REGION',
-    PNG: 'PNG'
+    PNG: 'PNG',
+    UWS: 'UWS'
 };
 
 export const DataProductTypes = {

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -12,7 +12,7 @@ import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntl
 import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
 import {resultSuccess} from 'firefly/ui/FileUploadProcessor';
 import {FieldGroup} from 'firefly/ui/FieldGroup';
-import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES} from 'firefly/ui/FileUploadUtil';
+import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES, UWS} from 'firefly/ui/FileUploadUtil';
 
 const maskWrapper= { position:'absolute', left:0, top:0, width:'100%', height:'100%' };
 const panelKey = 'FileUploadAnalysis';
@@ -23,7 +23,8 @@ const defaultAcceptList = [
     DATA_LINK_TABLES,
     SPECTRUM_TABLES,
     MOC_TABLES,
-    IMAGES
+    IMAGES,
+    UWS
 ];
 
 const tableOnlyDefaultAcceptList = [

--- a/src/firefly/js/ui/FileUploadUtil.js
+++ b/src/firefly/js/ui/FileUploadUtil.js
@@ -4,9 +4,11 @@ export const SPECTRUM_TABLES = 'spectrum-tables';
 export const MOC_TABLES = 'moc-tables';
 export const DATA_LINK_TABLES = 'data-link-tables';
 export const IMAGES = 'Image';
+export const UWS = 'UWS';
 
 export const acceptImages = (acceptList) => acceptList.includes(IMAGES);
 export const acceptRegions = (acceptList) => acceptList.includes(REGIONS);
+export const acceptUWS = (acceptList) => acceptList.includes(UWS);
 export const acceptOnlyTables = (acceptList) =>  acceptList.includes(TABLES) && acceptList.length === 1;
 export const acceptMocTables = (acceptList) => acceptList.includes(MOC_TABLES);
 export const acceptDataLinkTables = (acceptList) => acceptList.includes(DATA_LINK_TABLES);

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -46,7 +46,7 @@ import {RegionFactory} from '../visualize/region/RegionFactory.js';
 import {NaifidPanel} from './NaifidPanel';
 
 import {showUploadDialog} from 'firefly/ui/FileUploadDropdown';
-import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES} from 'firefly/ui/FileUploadUtil';
+import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES, UWS} from 'firefly/ui/FileUploadUtil';
 
 const dynamic1Params= [
     makeTargetDef(
@@ -280,7 +280,7 @@ function uploadButtons() {
                 <b>MOC FITS Only</b>
             </button>
             <br/><br/>
-            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES,REGIONS,IMAGES],true,'FileUploadAnalysis_Everything',true)}>
+            <button type='button' className='button std hl' onClick={() => showUploadDialog([MOC_TABLES,DATA_LINK_TABLES,TABLES,SPECTRUM_TABLES,REGIONS,IMAGES,UWS],true,'FileUploadAnalysis_Everything',true)}>
                 <b>Accept Everything (Default)</b>
             </button>
             <br/>

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.css
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.css
@@ -35,6 +35,18 @@
     position: relative;
 }
 
+.FileUpload__uws {
+    width: 100%;
+    position: relative;
+    min-height: 100px;
+    min-width: 250px;
+    max-width: 1000px;
+    display: flex;
+    resize: both;
+    flex-direction: column;
+    overflow: hidden;
+}
+
 .FileUpload__noDetails {
     text-align: center;
     font-size: larger;

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -33,10 +33,14 @@ import {dispatchValueChange} from 'firefly/fieldGroup/FieldGroupCntlr.js';
 import {CompleteButton,NONE} from 'firefly/ui/CompleteButton.jsx';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from 'firefly/core/MasterSaga.js';
 import {CheckboxGroupInputField} from 'firefly/ui/CheckboxGroupInputField.jsx';
-import {getFileFormat, getFirstPartType, getSelectedRows, isRegion} from 'firefly/ui/FileUploadProcessor';
-import {acceptAnyTables, acceptDataLinkTables, acceptImages, acceptMocTables, acceptNonDataLinkTables,
-    acceptNonMocTables, acceptOnlyTables, acceptRegions, acceptTableOrSpectrum, DATA_LINK_TABLES,
-    IMAGES, REGIONS, SPECTRUM_TABLES, TABLES} from 'firefly/ui/FileUploadUtil';
+import {getFileFormat, getFirstPartType, getSelectedRows, isRegion, isUWS} from 'firefly/ui/FileUploadProcessor';
+import {
+    acceptAnyTables, acceptDataLinkTables, acceptImages, acceptMocTables, acceptNonDataLinkTables,
+    acceptNonMocTables, acceptOnlyTables, acceptRegions, acceptTableOrSpectrum, acceptUWS, DATA_LINK_TABLES,
+    IMAGES, REGIONS, SPECTRUM_TABLES, TABLES, UWS
+} from 'firefly/ui/FileUploadUtil';
+import {UwsJobInfo} from 'firefly/core/background/JobInfo';
+import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson';
 
 const  FILE_ID = 'fileUpload';
 const  URL_ID = 'urlUpload';
@@ -47,12 +51,15 @@ const REGION_MSG = 'A Region file';
 const IMAGE_MSG = 'Any FITS file with images (including multiple HDUs)';
 const MOC_MSG = 'A MOC FITS file';
 const DL_MSG = 'A Data Link Table file';
+const UWS_MSG = 'A UWS Job File';
+
 
 const SUPPORTED_TYPES=[
     FileAnalysisType.REGION,
     FileAnalysisType.Image,
     FileAnalysisType.Table,
-    FileAnalysisType.Spectrum
+    FileAnalysisType.Spectrum,
+    FileAnalysisType.UWS
 ];
 
 const TABLES_ONLY_SUPPORTED_TYPES=[
@@ -173,7 +180,8 @@ export function FileUploadViewPanel({setSubmitText, acceptList, acceptOneItem}) 
                                                        }}/> }
                         </div>
                     </div>
-                    <FileAnalysis {...{report, summaryModel, detailsModel, isMoc, UNKNOWN_FORMAT, acceptList, isDatalink, acceptOneItem}}/>
+                    <FileAnalysis {...{report, summaryModel, detailsModel, isMoc, UNKNOWN_FORMAT, acceptList,
+                        isDatalink, acceptOneItem, summaryTblId}}/>
                     <ImageDisplayOption {...{summaryTblId, currentReport:report, currentSummaryModel:summaryModel, acceptList}}/>
                     <TableDisplayOption {...{isMoc, isDatalink, summaryTblId, currentReport:report, currentSummaryModel:summaryModel,
                         acceptList, acceptOneItem}}/>
@@ -570,13 +578,17 @@ function AnalysisTable({summaryModel, detailsModel, report, isMoc, UNKNOWN_FORMA
 function SingleDataSet({type, desc, detailsModel, report, UNKNOWN_FORMAT, currentSummaryModel, acceptList}) {
     const supported = isSinglePartFileSupported(currentSummaryModel, acceptList);
     const showDetails= supported && detailsModel;
+    const isUWSJobFile = isUWS(report);
+    const jobUrl = report.parts[0].url;
+
     return (
         <div style={{display:'flex', flex:'1 1 auto', justifyContent: showDetails?'start':'center'}}>
             <div style={{padding:'30px 20px 0 0'}}>
                 <div style={{whiteSpace:'nowrap', fontSize:'larger', fontWeight:'bold', paddingBottom:40}}>
                     {type}{desc ? ` - ${desc}` : ''}
                 </div>
-                <AnalysisInfo report={report} supported={supported} UNKNOWN_FORMAT={UNKNOWN_FORMAT} />
+                <AnalysisInfo {...{report, supported, UNKNOWN_FORMAT}} />
+                {isUWSJobFile && <UWSInfoButton {...{jobUrl}}/>}
                 <div style={{paddingTop:15}}>No other detail about this file</div>
             </div>
             {  showDetails && <Details detailsModel={detailsModel}/>}
@@ -637,6 +649,7 @@ function buildAllowedTypes(acceptList) {
     acceptImages(acceptList) && allowedTypes.push(IMAGE_MSG);
     acceptMocTables(acceptList) && allowedTypes.push(MOC_MSG);
     acceptDataLinkTables(acceptList) && allowedTypes.push(DL_MSG);
+    acceptUWS(acceptList) && allowedTypes.push(UWS_MSG);
     return allowedTypes;
 }
 
@@ -673,6 +686,11 @@ const determineAccepted = (acceptList, uniqueTypes, isMoc, isDL) => {
     if (uniqueTypes.includes(REGIONS)) {
         if (!acceptRegions(acceptList)) {
             notAcceptedTypes.push('Region');
+        }
+    }
+    else if (uniqueTypes.includes(UWS)) {
+        if (!acceptUWS(acceptList)) {
+            notAcceptedTypes.push('UWS');
         }
     }
     else if (uniqueTypes.includes(IMAGES) && uniqueTypes.includes(TABLES)) { //possibly FITs
@@ -717,7 +735,27 @@ const warningMessage = (acceptList, uniqueTypes) => {
     }
 };
 
-const FileAnalysis = ({report, summaryModel, detailsModel, isMoc, UNKNOWN_FORMAT, acceptList, isDL, acceptOneItem}) => {
+function UWSInfoButton ({jobUrl}) {
+    const [jobInfo, setJobInfo] = useState('');
+    useEffect(  () => {
+        uwsJobInfo(jobUrl).then((info) => {
+            setJobInfo(info);
+        })
+            .catch((err) => {
+                showInfoPopup('Please upload UWS files via the \'Upload from URL\' option', 'Failed to fetch UWS Job Info');
+            });
+    },[]);
+
+    return (
+        <div className='FileUpload__uws'>
+            <UwsJobInfo jobInfo={jobInfo} isOpen={true}/>
+        </div>
+    );
+}
+
+
+const FileAnalysis = ({report, summaryModel, detailsModel, isMoc, UNKNOWN_FORMAT, acceptList,
+                          isDL, acceptOneItem}) => {
     //getting FieldGroup context and adding required params to the request object (used in resultSuccess in FileUploadProcessor)
     const {groupKey, register, unregister}= useContext(FieldGroupCtx);
 
@@ -739,7 +777,7 @@ const FileAnalysis = ({report, summaryModel, detailsModel, isMoc, UNKNOWN_FORMAT
         if  (accepted) { //no errors/warnings: show the AnalysisInfo
             return (
                 <div className='FileUpload__report'>
-                    {summaryModel.tableData.data.length>1 && <AnalysisInfo report={report} />}
+                    {summaryModel.tableData.data.length>1 && <AnalysisInfo {...{report}} />}
                     {warningMessage(acceptList, uniqueTypes)}
                     {getTableArea(report, summaryModel, detailsModel, isMoc, UNKNOWN_FORMAT, acceptList, acceptOneItem)}
                 </div>

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -582,13 +582,13 @@ function SingleDataSet({type, desc, detailsModel, report, UNKNOWN_FORMAT, curren
     const jobUrl = report.parts[0].url;
 
     return (
-        <div style={{display:'flex', flex:'1 1 auto', justifyContent: showDetails?'start':'center'}}>
-            <div style={{padding:'30px 20px 0 0'}}>
+        <div style={{display:'flex', flex:'1 1 auto', justifyContent: showDetails || isUWSJobFile?'start':'center'}}>
+            <div style={{padding:'30px 20px 0 0', marginLeft: isUWSJobFile?'30px':'0'}}>
                 <div style={{whiteSpace:'nowrap', fontSize:'larger', fontWeight:'bold', paddingBottom:40}}>
                     {type}{desc ? ` - ${desc}` : ''}
                 </div>
                 <AnalysisInfo {...{report, supported, UNKNOWN_FORMAT}} />
-                {isUWSJobFile && <UWSInfoButton {...{jobUrl}}/>}
+                {isUWSJobFile && <UWSInfo {...{jobUrl}}/>}
                 <div style={{paddingTop:15}}>No other detail about this file</div>
             </div>
             {  showDetails && <Details detailsModel={detailsModel}/>}
@@ -735,16 +735,26 @@ const warningMessage = (acceptList, uniqueTypes) => {
     }
 };
 
-function UWSInfoButton ({jobUrl}) {
+function UWSInfo ({jobUrl}) {
     const [jobInfo, setJobInfo] = useState('');
+    const [errMsg, setErrMsg] = useState(null);
     useEffect(  () => {
         uwsJobInfo(jobUrl).then((info) => {
             setJobInfo(info);
         })
             .catch((err) => {
-                showInfoPopup('Please upload UWS files via the \'Upload from URL\' option', 'Failed to fetch UWS Job Info');
+                setErrMsg('Error: Please upload UWS files via the \'Upload from URL\' option');
             });
-    },[]);
+    },[jobUrl]);
+
+    if (!jobUrl) { //user uploaded a UWS file from 'Upload file' option (instead of 'Upload from URL')
+        return (
+            <div className='FileUpload__uws'>
+                {errMsg && <div style={{color: 'gray', margin: '20px 0 0 0', fontSize: 'larger', lineHeight: '1.3em'}}>
+                    {errMsg}
+                </div>}
+            </div>);
+    }
 
     return (
         <div className='FileUpload__uws'>


### PR DESCRIPTION
#### [Firefly-1129](https://jira.ipac.caltech.edu/browse/FIREFLY-1129): Update FileUploadViewPanel to recognize a UWS job XML file
- added support for upload of UWS job files via the upload panel
- added a button to allow user to "Show UWS Job Info" after a successful upload 
- **Updates 2/16**:
   - changes in resultSuccess (in FileUploadProcessor) to allow user to "Load" the UWS job and get back table(s) 
   - changed uws job info from "Show UWS Job Info" button to just showing it directly in the upload panel after uploading a UWS job url 
       - the 'query' value for uws job info is really long, so I added some css to reel it in (see class 'FileUpload__uws' in FileUploadViewPanel.css)...there may be a better way to do this
- **Updates 2/21**:
  - improved error message when trying to upload a uws xml file (not from the "upload from URL" option)
     - also disabled loading in this case, giving an error dialog instead 
  - made css changes to left align uws job info in the upload panel (but gave it a margin of 30px) and fixed the "Accept Everything" button on https://fireflydev.ipac.caltech.edu/firefly-1129-uws/firefly/firefly-dev.html to now accept UWS as well  

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1129-uws/firefly
- Upload -> Upload from URL -> enter the URL of a UWS job file and click "Upload"
   - (Note: before you upload, in the list of allowed file types, you should also see "A UWS Job File" now). 
- the upload panel should recognize this as a UWS file. Additionally, you should see a "Show UWS Job Info" button. Click on this to see a dialog with the job info
- **Updates 2/21**
   - follow the steps above
   - the "Show UWS Job Info" button is replaced with directly showing the job info in the panel 
   - Click on "Load" to submit this UWS job and see the results 