### PR TITLE
IRSA-3143: SHA migration: Add search by Program, Campaign, Observer, and Observation Date

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/JsonStringProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/JsonStringProcessor.java
@@ -1,0 +1,166 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.Param;
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.RequestOwner;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.firefly.server.util.StopWatch;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.TableMeta;
+import edu.caltech.ipac.util.FileUtil;
+import edu.caltech.ipac.util.StringUtils;
+import edu.caltech.ipac.util.cache.Cache;
+import edu.caltech.ipac.util.cache.CacheManager;
+import edu.caltech.ipac.util.cache.StringKey;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static edu.caltech.ipac.firefly.data.TableServerRequest.FF_SESSION_ID;
+import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
+
+
+/**
+ * Base class for a SearchProcessor that returns a JSON string.
+ * It provides default implementation for SearchProcessor interface
+ * as well as these features:
+ * - duplicate requests lock/wait mechanism
+ * - caching
+ * - logging
+ */
+abstract public class JsonStringProcessor implements SearchProcessor<String> {
+    private static final Map<String, ReentrantLock> activeRequests = new HashMap<>();
+    private static final ReentrantLock lockChecker = new ReentrantLock();
+    private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
+
+    /**
+     * Fetches the data for the given request.  This method should perform a fetch for fresh
+     * data.  Caching should not be performed here.
+     * @param req
+     * @return
+     * @throws DataAccessException
+     */
+    abstract public String fetchData(ServerRequest req) throws DataAccessException;
+
+    public String getData(ServerRequest request) throws DataAccessException {
+
+        if (!doCache()) {
+            String results = fetchData(request);
+            doLogging(request, results);
+        }
+
+        // when caching is supported, use lock/wait to avoid multiple duplicated requests
+
+        String unigueReqID = this.getUniqueID(request);
+
+        lockChecker.lock();
+        ReentrantLock lock = null;
+        try {
+            lock = activeRequests.get(unigueReqID);
+            if (lock == null) {
+                lock = new ReentrantLock();
+                activeRequests.put(unigueReqID, lock);
+            }
+        } finally {
+            lockChecker.unlock();
+        }
+
+        // make sure multiple requests for the same data waits for the first one to create before accessing.
+        lock.lock();
+        try {
+            String results = getCachedData(request);
+            if (results == null) {
+                results = fetchData(request);
+                cacheData(request, results);
+            }
+            doLogging(request, results);
+            return results;
+        } finally {
+            activeRequests.remove(unigueReqID);
+            lock.unlock();
+        }
+    }
+
+    private void doLogging(ServerRequest request, String results) {
+        if (doLogging()) {
+            SearchProcessor.logStats(request.getRequestId(), 0, results.length(), false, getDesc(request));
+        }
+    }
+
+//====================================================================
+//  Simple cache implementation
+//====================================================================
+
+    protected void cacheData(ServerRequest request, String results) {
+        if (!isEmpty(results)) {
+            File jsonFile = null;
+            try {
+                jsonFile = File.createTempFile("tmp-", ".json", QueryUtil.getTempDir());
+                FileUtil.writeStringToFile(jsonFile, results);
+                CacheManager.getCache(Cache.TYPE_TEMP_FILE)
+                        .put(new StringKey(getUniqueID(request)), jsonFile);
+            } catch (IOException e) {
+                LOGGER.error("Cannot create temp file: " + e.getMessage());
+            }
+        }
+    }
+
+    protected String getCachedData(ServerRequest request) {
+        Cache cache = CacheManager.getCache(Cache.TYPE_TEMP_FILE);
+        File jsonFile = (File)cache.get(new StringKey(getUniqueID(request)));
+        if (jsonFile != null) {
+            try {
+                return FileUtil.readFile(jsonFile);
+            } catch (IOException e) {
+                LOGGER.error("Cannot read file: " + jsonFile.getPath());
+            }
+        }
+        return null;
+    }
+
+//====================================================================
+//  Default implementation of SearchProcessor
+//====================================================================
+
+    public String getUniqueID(ServerRequest request) {
+        RequestOwner ro = ServerContext.getRequestOwner();
+        TreeSet<Param> params = new TreeSet<>(request.getParams());
+        applyIfNotEmpty(request.getParam(FF_SESSION_ID),   v -> params.add(new Param(FF_SESSION_ID, v)));
+        if (ro.isAuthUser()) {
+            params.add( new Param("userID", ro.getUserInfo().getLoginName()));
+        }
+        return StringUtils.toString(params, "|");
+    }
+
+    public QueryDescResolver getDescResolver() {
+        return new QueryDescResolver() {
+            public String getTitle(ServerRequest req) { return "not used"; }
+            public String getDesc(ServerRequest req) { return getUniqueID(req);}
+        };
+    }
+
+    public String getDesc(ServerRequest req) {
+        return getDescResolver().getDesc(req);
+    }
+
+    public boolean doCache() { return false; }
+
+    public void onComplete(ServerRequest request, String results) throws DataAccessException {}
+
+    public boolean doLogging() { return false; }
+
+    public void prepareTableMeta(TableMeta defaults, List<DataType> columns, ServerRequest request) {}
+
+}
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
@@ -34,23 +34,16 @@ public class SearchManager {
      * For SearchProcessor's interface, see JsonSearchServices.
      */
     public String getJSONData(ServerRequest request) throws DataAccessException {
+
+        if (request == null) throw new DataAccessException("Operation failed because request parameter is null.");
+
         SearchProcessor processor = getProcessor(request.getRequestId());
-        if (request != null) {
-            String jsonText = (String) processor.getData(request);
-            // validate JSON and replace file paths with prefixes
-            JSONParser parser = new JSONParser();
-            try{
-                Object obj = parser.parse(jsonText);
-                Object json = ServerContext.replaceWithPrefixes(obj);
-                jsonText = JSONValue.toJSONString(json);
-                return jsonText;
-            }
-            catch(ParseException pe){
-                LOGGER.error(processor.getUniqueID(request) + " Can not parse returned JSON: " + pe.toString() + "\n" + jsonText);
-                throw new DataAccessException(request.getRequestId()+" Can not parse returned JSON: " + pe.toString());
-            }
+        if (processor instanceof JsonStringProcessor) {
+            String jsonText = ((JsonStringProcessor)processor).getData(request);
+            return jsonText;
         } else {
-            throw new DataAccessException("Request fail inspection.  Operation aborted.");
+            throw new DataAccessException("Unexpected Exception: request id: " + request.getRequestId()
+                    + " resolves to a search processor that is not an instance of JsonStringProcessor");
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -86,14 +86,28 @@ public class QueryUtil {
      * @return
      */
     public static File getTempDir(TableServerRequest tsr) {
-        String sessId = ServerContext.getRequestOwner().getRequestAgent().getSessId();
-        if (tsr != null && tsr.getParam(FF_SESSION_ID) != null) {
-            sessId = Math.abs(tsr.getParam(FF_SESSION_ID).hashCode()) + "";
-        }
         File rootDir = tsr == null || tsr.getJobId() == null ? ServerContext.getTempWorkDir() : ServerContext.getPermWorkDir();
-        File tempDir = new File(rootDir, sessId.substring(0, 3));
+        File tempDir = new File(rootDir, getSessPrefix(tsr));
         if (!tempDir.exists()) tempDir.mkdirs();
         return tempDir;
+    }
+
+    /**
+     * returns a hierarchical temporary directory.
+     * @return
+     */
+    public static File getTempDir(ServerRequest req) {
+        File tempDir = new File(ServerContext.getTempWorkDir(), getSessPrefix(req));
+        if (!tempDir.exists()) tempDir.mkdirs();
+        return tempDir;
+    }
+
+    private static String getSessPrefix(ServerRequest req) {
+        String sessId = ServerContext.getRequestOwner().getRequestAgent().getSessId();
+        if (req != null && req.getParam(FF_SESSION_ID) != null) {
+            sessId = Math.abs(req.getParam(FF_SESSION_ID).hashCode()) + "";
+        }
+        return sessId.substring(0, 3);
     }
 
     public static DownloadRequest convertToDownloadRequest(String dlReqStr, String searchReqStr, String selInfoStr) {

--- a/src/firefly/js/ui/TimeUIUtil.js
+++ b/src/firefly/js/ui/TimeUIUtil.js
@@ -139,10 +139,13 @@ export function getTimeInfo(timeMode, value, valid, message) {
 }
 
 export function formFeedback(utc, mjd)  {
-    return isTimeUndefined(utc, mjd) ? '' :
-        '<div style="font-size:11px">' +
-        `<i>UTC:&nbsp</i>${utc}<br/>` +
-        `<div style="padding-top: 6px"><i>MJD:&nbsp</i>${mjd}</div>` + '</div>';
+    if (isTimeUndefined(utc, mjd)) return '';
+    else {
+        const feedbackHtmlStr = utc && !mjd ? `<i>UTC:&nbsp</i>${utc}`
+            : (!utc && mjd ? `<i>MJD:&nbsp</i>${mjd}`
+                : `<i>UTC:&nbsp</i>${utc}<br/> <div style="padding-top: 6px"> <i>MJD:&nbsp</i>${mjd} </div>`)
+        return '<div style="font-size:11px">' + feedbackHtmlStr + '</div>';
+    }
 }
 
 export const isTimeUndefined = (utc, mjd) => !utc && !mjd;

--- a/src/firefly/js/ui/tap/ObsCoreExposureDuration.jsx
+++ b/src/firefly/js/ui/tap/ObsCoreExposureDuration.jsx
@@ -153,7 +153,7 @@ export function ExposureDurationSearch({initArgs}) {
                                 <TimeRangePanel {...{initArgs, turnOnPanel, panelActive:checkHeaderCtl.isPanelActive(),
                                     fromTip:"'Exposure start from' time (t_min)",
                                     toTip:"'Exposure end to' time (t_min)",
-                                    style:{marginLeft: LeftInSearch, marginTop: 10}}}/> :
+                                    style:{marginLeft: LeftInSearch, marginTop: 12, marginBottom: 12}}}/> :
                                 <ExposureSince {...{initArgs, turnOnPanel, panelActive:checkHeaderCtl.isPanelActive()}} /> }
                             <ExposureLength {...{initArgs, turnOnPanel, panelActive:checkHeaderCtl.isPanelActive()}}/>
                         </div>

--- a/src/firefly/js/ui/tap/TemportalSearch.jsx
+++ b/src/firefly/js/ui/tap/TemportalSearch.jsx
@@ -140,7 +140,7 @@ export function TemporalSearch({cols, columnsModel}) {
             minKey:TimeFrom, maxKey:TimeTo, columnsForTip:[getVal(TemporalColumns)],
             fromTip:`'from' time ${timeColStr}`,
             toTip:`'to' time ${timeColStr}`,
-            style:{marginLeft: LeftInSearch, marginTop: 5}}}/>
+            style:{marginLeft: LeftInSearch, marginTop: 16, marginBottom: 16}}}/>
     );
 
     return (


### PR DESCRIPTION
Changes in firefly as per https://github.com/IPAC-SW/irsa-ife/pull/241

-  @loitly added JSON String Search Processor to simplify simple JSON requests - was needed to query suggestion list of observers for SHA "search by observers" panel
- Made changes in TimeRangePanel component so that it can be used in SHA "search by date":
  - time mode can now be specified as fixed (no radio group selection)
  - time panel feedback is shown as per fixed or unfixed time mode 
  - labels, examples, and styles are customizable

# Testing
In context of SHA: https://irsa-3143-sha-search-by-program.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA

In general: https://fireflydev.ipac.caltech.edu/irsa-3143-sha-search-by-program/firefly