### PR TITLE
FIREFLY-1146: Fix target field not updating when searching at selected region in image viewer

### DIFF
--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -210,16 +210,13 @@ function ImageSearchPanelV2 ({archiveName='Search', title='Image Search', multiS
                 setShowError(true);
             });
     }, []);
+
     const {wp,type, radius}= initArgs?.searchParams ?? {};
-    const [, setTargetM]= useFieldGroupValue(DEF_TARGET_PANEL_KEY,FG_KEYS.main);
-    const [, setTargetS]= useFieldGroupValue(DEF_TARGET_PANEL_KEY,FG_KEYS.single);
-    const [, setTargetH]= useFieldGroupValue(DEF_TARGET_PANEL_KEY,FG_KEYS.hips);
+    const [, setTarget]= useFieldGroupValue(DEF_TARGET_PANEL_KEY,FG_KEYS.targetSelect);
     const [, setType]= useFieldGroupValue(FD_KEYS.type,FG_KEYS.main);
     useEffect(() => {
         if (!wp) return;
-        setTargetM(wp);
-        setTargetS(wp);
-        setTargetH(wp);
+        setTarget(wp);
     }, [wp]);
     useEffect(() => {
         (type) && setType(type);


### PR DESCRIPTION
Fixes [FIREFLY-1146](https://jira.ipac.caltech.edu/browse/FIREFLY-1146)

Since FIREFLY-250 was fixed, target is stored in its own field group. So updated the group key where target is set through intiArgs (by search actions)

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1146-image-search-selection-fix/firefly/

when you: show an image -> select an area -> click on binoculars dropdown -> Search FITS/HiPS at region center, it should bring up ImageSearchPanel with target set to the coordinates of the center of my selection (as shown in the dropdown in bold)