### PR TITLE
Firefly-1140: Add side bar that list the whole registry

### DIFF
--- a/src/firefly/js/api/webApiCommands/DatalinkUICommands.js
+++ b/src/firefly/js/api/webApiCommands/DatalinkUICommands.js
@@ -19,9 +19,16 @@ const idExamples= [
         }
     },
     {
-        desc:'load to UI more than one id',
+        desc:'load to UI using id',
         params:{
-            id: ['iras_issa','iras_iris']
+            id: 'wise_z0mgs',
+        }
+    },
+    {
+        desc:'load to UI using id and show the data set chooser',
+        params:{
+            id: 'dss',
+            showChooser: 'true'
         }
     },
 ];
@@ -57,8 +64,9 @@ function loadDLUITable(cmd,params, includeIdType) {
     }
 }
 
-async function getServerAndLoadTablesById(cmd,params) {
+async function getServerAndLoadTablesById(cmd,inParams) {
     const urlRootAry= await getJsonProperty('inventory.serverURLAry');
+    const params= {showChooser:false, ...inParams};
     const initArgs={urlApi:params};
     const urlRoot= urlRootAry[0];
     const makeUrl= (id) =>  urlRoot +'?'+ new URLSearchParams({collection:id}).toString();
@@ -80,9 +88,11 @@ export function getDatalinkUICommands(includeIdType) {
     const execute= (cmd,params) => loadDLUITable(cmd,params,includeIdType);
     const overview= [ 'Load Service Descriptor UI' ];
 
-    const urlOnlyParameters= { url: {desc:'url to datalink UI file'},
+    const urlOnlyParameters= {
+        url: {desc:'url to datalink UI file'},
         [ReservedParams.POSITION.name]: ['coordinates of the search',...ReservedParams.POSITION.desc],
         [ReservedParams.SR.name]: ['radius of search  (optional)',...ReservedParams.SR.desc],
+        showChooser: {desc:'show the dataset chooser'},
         execute: 'true or false - if true execute the search'
     };
     const bothParameters= {...urlOnlyParameters, id : {desc:'ID to predefined data link UI service'}};

--- a/src/firefly/js/api/webApiCommands/DatalinkUICommands.js
+++ b/src/firefly/js/api/webApiCommands/DatalinkUICommands.js
@@ -63,6 +63,7 @@ async function getServerAndLoadTablesById(cmd,params) {
     const urlRoot= urlRootAry[0];
     const makeUrl= (id) =>  urlRoot +'?'+ new URLSearchParams({collection:id}).toString();
     const urlAry=  (isArray(params.id)) ? params.id.map( (id) => makeUrl(id))  : [makeUrl(params.id)];
+    initArgs.urlApi.url= urlAry;
     urlAry.forEach( (url) =>  void fetchDatalinkUITable(url,0,initArgs));
 }
 

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -180,8 +180,8 @@ export function dispatchTableAddLocal(tableModel, options, addUI=true, dispatche
 /**
  * Fetch table data from the server.
  * @param request a table request params object.
- * @param hlRowIdx set the highlightedRow.  default to startIdx.
- * @param invokedBy used to indicate what trigger the fetch.
+ * @param [hlRowIdx] set the highlightedRow.  default to startIdx.
+ * @param [invokedBy] used to indicate what trigger the fetch.
  * @param {function} dispatcher only for special dispatching uses such as remote
  */
 export function dispatchTableFetch(request, hlRowIdx, invokedBy, dispatcher= flux.process) {

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -81,7 +81,7 @@ export function resultSuccess(request) {
             return true;
 
         case LOAD_DL:
-            tableIndices.forEach((idx) => void fetchDatalinkUITable(fileCacheKey,idx) );
+            tableIndices.forEach((idx) => void fetchDatalinkUITable(fileCacheKey,idx,{searchParams:{url:fileCacheKey}}) );
             return true;
 
         case LOAD_FOOTPRINT:

--- a/src/firefly/js/ui/TargetFeedback.jsx
+++ b/src/firefly/js/ui/TargetFeedback.jsx
@@ -1,3 +1,4 @@
+import {isArray} from 'lodash';
 import React from 'react';
 import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
 
@@ -16,8 +17,10 @@ const defExampleEntries= {
     };
 
 const defaultExamples= (targetPanelExampleRow1, targetPanelExampleRow2) => {
-    const row1Op= targetPanelExampleRow1 ?? getAppOptions()?.targetPanelExampleRow1 ?? defExampleEntries.row1;
-    const row2Op= targetPanelExampleRow2 ?? getAppOptions()?.targetPanelExampleRow2 ?? defExampleEntries.row2;
+    const tpR1= !targetPanelExampleRow1 || isArray(targetPanelExampleRow1) ? targetPanelExampleRow1 : [targetPanelExampleRow1];
+    const tpR2= !targetPanelExampleRow2 || isArray(targetPanelExampleRow2) ? targetPanelExampleRow2 : [targetPanelExampleRow2];
+    const row1Op= tpR1 ?? getAppOptions()?.targetPanelExampleRow1 ?? defExampleEntries.row1;
+    const row2Op= tpR2 ?? getAppOptions()?.targetPanelExampleRow2 ?? defExampleEntries.row2;
     return (
         <div style={{ display : 'inline-block', lineHeight : '1.2em'}}>
             {row1Op?.map( (s,idx) => <span key={s} style={{paddingLeft: (idx===0) ? 5 : 15}}>{s}</span> )}

--- a/src/firefly/js/ui/dynamic/DLGeneratedDropDown.css
+++ b/src/firefly/js/ui/dynamic/DLGeneratedDropDown.css
@@ -1,0 +1,7 @@
+
+
+.DLGeneratedDropDown__section--title {
+    color: #005da4;
+    font-size: large;
+    font-weight: bold;
+}

--- a/src/firefly/js/ui/dynamic/DynComponents.jsx
+++ b/src/firefly/js/ui/dynamic/DynComponents.jsx
@@ -58,11 +58,12 @@ export function getSpacialSearchType(request, fieldDefAry) {
  * @param inFieldDefAry
  * @param noLabels
  * @param popupHiPS
+ * @param plotId
  * @return {{opsInputAry, fieldsInputAry, checkBoxFields, polyPanel, spacialPanel, areaFields, fieldsInputAry, opsInputAry, useArea, useSpacial, useCirclePolyField}}
  */
-export const makeAllFields = (inFieldDefAry, noLabels=false, popupHiPS) => {
+export const makeAllFields = (inFieldDefAry, noLabels=false, popupHiPS, plotId='defaultHiPSTargetSearch') => {
 
-       // polygon is not created directly, we need to determine who will create creat a polygon field if it exist
+    // polygon is not created directly, we need to determine who will create creat a polygon field if it exist
     const fieldDefAry= inFieldDefAry.filter( ({hide}) => !hide);
     const hasPoly = Boolean(findType(fieldDefAry,POLYGON));
     const circle= findType(fieldDefAry,CIRCLE);
@@ -71,8 +72,8 @@ export const makeAllFields = (inFieldDefAry, noLabels=false, popupHiPS) => {
     const spacialManagesArea= hasSpacialAndArea && countType(fieldDefAry,AREA)===1;
 
     const panels = {
-        spacialPanel: popupHiPS ? makeDynSpacialPanel(fieldDefAry, true, popupHiPS) :
-                                  makeDynSpacialPanel(fieldDefAry, hasCircle && hasPoly, popupHiPS),
+        spacialPanel: popupHiPS ? makeDynSpacialPanel(fieldDefAry, true, popupHiPS, plotId) :
+                                  makeDynSpacialPanel(fieldDefAry, hasCircle && hasPoly, popupHiPS, plotId),
         areaFields: spacialManagesArea ? [] : makeAllAreaFields(fieldDefAry),
         checkBoxFields: makeCheckboxFields(fieldDefAry),
         ...makeInputFields(fieldDefAry, noLabels)
@@ -104,7 +105,7 @@ function makeInputFields(fieldDefAry, noLabels) {
     return {fieldsInputAry, opsInputAry};
 }
 
-function CircleAndPolyFieldPopup({fieldDefAry, typeForCircle= CIRCLE}) {
+function CircleAndPolyFieldPopup({fieldDefAry, typeForCircle= CIRCLE, plotId='defaultHiPSTargetSearch'}) {
     const polyType = findType(fieldDefAry, POLYGON);
     const cirType = findType(fieldDefAry, typeForCircle);
     const [getConeAreaOp] = useFieldGroupValue(CONE_AREA_KEY);
@@ -145,7 +146,7 @@ function CircleAndPolyFieldPopup({fieldDefAry, typeForCircle= CIRCLE}) {
             {taToggle}
             {getChoice() === CONE_CHOICE_KEY &&
                 <CircleField {...{
-                    hideHiPSPopupPanelOnDismount: false, fieldKey: targetKey, ...cirType,
+                    hideHiPSPopupPanelOnDismount: false, fieldKey: targetKey, ...cirType, plotId,
                     targetKey, sizeKey, polygonKey, initValue, minValue, maxValue,
                 }}/>}
             {getChoice() === POLY_CHOICE_KEY &&
@@ -158,7 +159,7 @@ function CircleAndPolyFieldPopup({fieldDefAry, typeForCircle= CIRCLE}) {
     );
 }
 
-function PositionAndPolyFieldEmbed({fieldDefAry}) {
+function PositionAndPolyFieldEmbed({fieldDefAry, plotId}) {
 
     const polyType = findType(fieldDefAry, POLYGON);
     const posType = findType(fieldDefAry, POSITION);
@@ -206,7 +207,7 @@ function PositionAndPolyFieldEmbed({fieldDefAry}) {
              style={{display: 'flex', flexDirection: 'column', alignItems: 'center', alignSelf: 'stretch', height:'100%',
                  paddingBottom:20}}>
             <HiPSTargetView {...{
-                hipsUrl, centerPt:initCenterPt, hipsFOVInDeg, mocList, coordinateSys, sRegion,
+                hipsUrl, centerPt:initCenterPt, hipsFOVInDeg, mocList, coordinateSys, sRegion, plotId,
                 minSize: minValue, maxSize: maxValue, whichOverlay: doGetConeAreaOp(),
                 targetKey, sizeKey, polygonKey, style: {minHeight: 300, alignSelf: 'stretch', flexGrow:1}
             }}/>
@@ -365,7 +366,7 @@ function PolygonField({ fieldKey, desc = 'Coordinates', initValue = '', style={}
     );
 }
 
-function makeDynSpacialPanel(fieldDefAry, manageAllSpacial= true, popupHiPS= false) {
+function makeDynSpacialPanel(fieldDefAry, manageAllSpacial= true, popupHiPS= false, plotId= 'defaultHiPSTargetSearch') {
     const posType = findType(fieldDefAry, POSITION);
     const areaType = findType(fieldDefAry, AREA);
     const circleType = findType(fieldDefAry, CIRCLE);
@@ -387,12 +388,12 @@ function makeDynSpacialPanel(fieldDefAry, manageAllSpacial= true, popupHiPS= fal
 
     if (manageAllSpacial && sizeKey) {
         return popupHiPS ?
-            <CircleAndPolyFieldPopup {...{fieldDefAry,typeForCircle:circleType?CIRCLE:POSITION}}/> : <PositionAndPolyFieldEmbed {...{fieldDefAry}}/>;
+            <CircleAndPolyFieldPopup {...{fieldDefAry,typeForCircle:circleType?CIRCLE:POSITION, plotId}}/> : <PositionAndPolyFieldEmbed {...{fieldDefAry, plotId}}/>;
     }
     else {
         if (popupHiPS) {
             return (<VisualTargetPanel {...{
-                hipsUrl, centerPt, hipsFOVInDeg, mocList, nullAllowed, coordinateSys, sizeKey,
+                hipsUrl, centerPt, hipsFOVInDeg, mocList, nullAllowed, coordinateSys, sizeKey, plotId,
                 minSize: minValue, maxSize: maxValue,
                 targetPanelExampleRow1, targetPanelExampleRow2 }} />);
         }
@@ -403,6 +404,7 @@ function makeDynSpacialPanel(fieldDefAry, manageAllSpacial= true, popupHiPS= fal
                     <HiPSTargetView {...{
                         hipsUrl, centerPt, hipsFOVInDeg, mocList, coordinateSys,
                         minSize: minValue, maxSize: maxValue,
+                        plotId,
                         targetKey: 'UserTargetWorldPt', sizeKey, style: {flexGrow:1, alignSelf: 'stretch'}
                     }}/>
                     <div style={{display: 'flex', flexDirection: 'column'}}>

--- a/src/firefly/js/ui/dynamic/DynamicUISearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/DynamicUISearchPanel.jsx
@@ -19,9 +19,9 @@ import './DynamicUI.css';
 
 const defaultOnError= () => showInfoPopup('One or more fields are not valid', 'Invalid Data');
 
-export const DynamicFieldGroupPanel = ({DynLayoutPanel, groupKey, fieldDefAry, keepState = true}) => (
+export const DynamicFieldGroupPanel = ({DynLayoutPanel, groupKey, fieldDefAry, keepState = true, plotId='defaultHiPSTargetSearch'}) => (
     <FieldGroup groupKey={groupKey} keepState={keepState}>
-        <DynLayoutPanel fieldDefAry={fieldDefAry} style={{margin: '8px 3px 15px 3px', width: '100%'}}/>
+        <DynLayoutPanel fieldDefAry={fieldDefAry} style={{margin: '8px 3px 15px 3px', width: '100%'}} plotId={plotId}/>
     </FieldGroup>
 );
 
@@ -111,10 +111,25 @@ export function convertRequest(request, fieldDefAry, treatAsSia= false) {
     return {...retReq,...hiddenFields};
 }
 
+export function findTargetFromRequest(request, fieldDefAry) {
+    let wp;
+    fieldDefAry?.forEach( ({key,type, targetDetails:{raKey,decKey, targetKey}={} }) => {
+        switch (type) {
+            case POSITION:
+                if (raKey && decKey) wp= convert(parseWorldPt(request[key]), CoordinateSys.EQ_J2000);
+                return;
+            case CIRCLE:
+                wp= convert(parseWorldPt(request[targetKey]), CoordinateSys.EQ_J2000);
+                return;
+        }
+    });
+    return wp;
+}
 
-function SimpleDynSearchPanel({style={}, fieldDefAry, popupHiPS= true}) {
+
+function SimpleDynSearchPanel({style={}, fieldDefAry, popupHiPS= true, plotId='defaultHiPSTargetSearch'}) {
     const { spacialPanel, areaFields, polyPanel, checkBoxFields, fieldsInputAry, opsInputAry,
-        useSpacial, useArea}= makeAllFields(fieldDefAry,false,popupHiPS);
+        useSpacial, useArea}= makeAllFields(fieldDefAry,false,popupHiPS, plotId);
 
     let iFieldLayout;
     if (fieldsInputAry.length || opsInputAry.length) {
@@ -151,7 +166,7 @@ function SimpleDynSearchPanel({style={}, fieldDefAry, popupHiPS= true}) {
     );
 }
 
-function GridDynSearchPanel({style={}, fieldDefAry, popupHiPS= true}) {
+function GridDynSearchPanel({style={}, fieldDefAry, popupHiPS= true, plotId='defaultHiPSTargetSearch'}) {
     const { spacialPanel, areaFields, checkBoxFields, fieldsInputAry, opsInputAry,
         useArea, useSpacial}= makeAllFields(fieldDefAry, true, popupHiPS);
 
@@ -190,6 +205,6 @@ function GridDynSearchPanel({style={}, fieldDefAry, popupHiPS= true}) {
 
 
 export const DynLayoutPanelTypes= {
-    'Simple': SimpleDynSearchPanel,
-    'Grid': GridDynSearchPanel,
+    Simple: SimpleDynSearchPanel,
+    Grid: GridDynSearchPanel,
 };

--- a/src/firefly/js/ui/dynamic/FetchDatalinkTable.js
+++ b/src/firefly/js/ui/dynamic/FetchDatalinkTable.js
@@ -9,18 +9,21 @@ import {DL_UI_LIST} from './DLGeneratedDropDown.js';
 
 function loadDatalinkUITable(tbl_id, url, initArgs={}) {
     const {fetchedTables={}}=  getComponentState(DL_UI_LIST) ?? {};
-    const {menuItems,selected,showBgMonitor}= getMenu();
+    const newFetchedTables= {...fetchedTables, [url]:tbl_id};
 
+    confirmDLMenuItem();
+    dispatchComponentStateChange(DL_UI_LIST, {currentTblId:tbl_id, fetchedTables:newFetchedTables});
+    dispatchShowDropDown( { view: 'DLGeneratedDropDownCmd', initArgs});
+}
+
+export function confirmDLMenuItem() {
+    const {menuItems,selected,showBgMonitor}= getMenu();
     if (!menuItems?.find(({action}) => action==='DLGeneratedDropDownCmd')) { // add the toolbar option
         const newMenuItems= [...menuItems];
         const dlDrop= {label:'Collections', action:'DLGeneratedDropDownCmd'};
         newMenuItems.splice(1,0,dlDrop);
         dispatchSetMenu({selected,showBgMonitor,menuItems:newMenuItems});
     }
-    const newFetchedTables= {...fetchedTables, [url]:tbl_id};
-
-    dispatchComponentStateChange(DL_UI_LIST, {currentTblId:tbl_id, fetchedTables:newFetchedTables});
-    dispatchShowDropDown( { view: 'DLGeneratedDropDownCmd', initArgs});
 }
 
 /**

--- a/src/firefly/js/ui/dynamic/FetchDatalinkTable.js
+++ b/src/firefly/js/ui/dynamic/FetchDatalinkTable.js
@@ -7,8 +7,8 @@ import {dispatchTableFetch} from '../../tables/TablesCntlr.js';
 import {onTableLoaded} from '../../tables/TableUtil.js';
 import {DL_UI_LIST} from './DLGeneratedDropDown.js';
 
-function loadDatalinkUITable(tbl_id, initArgs={}) {
-    const {tblIdList=[]}=  getComponentState(DL_UI_LIST);
+function loadDatalinkUITable(tbl_id, url, initArgs={}) {
+    const {fetchedTables={}}=  getComponentState(DL_UI_LIST) ?? {};
     const {menuItems,selected,showBgMonitor}= getMenu();
 
     if (!menuItems?.find(({action}) => action==='DLGeneratedDropDownCmd')) { // add the toolbar option
@@ -17,9 +17,9 @@ function loadDatalinkUITable(tbl_id, initArgs={}) {
         newMenuItems.splice(1,0,dlDrop);
         dispatchSetMenu({selected,showBgMonitor,menuItems:newMenuItems});
     }
+    const newFetchedTables= {...fetchedTables, [url]:tbl_id};
 
-    const newTblIdList= [... new Set([...tblIdList,tbl_id])];  // add the new tbl_id to list, insure list is unique
-    dispatchComponentStateChange(DL_UI_LIST, {currentTblId:tbl_id, tblIdList:newTblIdList});
+    dispatchComponentStateChange(DL_UI_LIST, {currentTblId:tbl_id, fetchedTables:newFetchedTables});
     dispatchShowDropDown( { view: 'DLGeneratedDropDownCmd', initArgs});
 }
 
@@ -36,5 +36,5 @@ export async function fetchDatalinkUITable(url, idx=0, initArgs={}) {
     const {tbl_id}= req.META_INFO;
     dispatchTableFetch(req);
     await onTableLoaded(tbl_id);
-    loadDatalinkUITable(tbl_id, initArgs);
+    loadDatalinkUITable(tbl_id, url, initArgs);
 }

--- a/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
+++ b/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
@@ -27,7 +27,8 @@ const titleStyle= {width: '100%', textAlign:'center', padding:'10px 0 5px 0', fo
 
 
 export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDefParams, setSearchParams,
-                                               title, makeDropDown, sRegion}) => {
+                                               title, makeDropDown, sRegion,
+                                               plotId= 'defaultHiPSTargetSearch'}) => {
 
     const fieldDefAry= makeFieldDefs(serDefParams, sRegion, undefined, true);
 
@@ -43,6 +44,7 @@ export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDefParams,
                 <div style= {titleStyle}> {title} </div>
                 <DynamicFieldGroupPanel groupKey={GROUP_KEY} keepState={false}
                                         DynLayoutPanel={DynLayoutPanelTypes.Simple}
+                                        plotId={plotId}
                                         fieldDefAry={fieldDefAry} />
                 <CompleteButton style={{padding: '20px 0 0 0'}}
                                    onSuccess={(r) => submitSearch(r)}

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -320,7 +320,7 @@ export async function createHiPSMocLayer(ivoid, title, hipsUrl, plot, visible=fa
             const isMocFits = isMOCFitsFromUploadAnalsysis(report);
             if (isMocFits.valid) {
                 dl = addNewMocLayer(tblId, title, cacheKey, mocUrl, isMocFits?.[MOCInfo]?.[UNIQCOL]);
-                if (dl && plot.plotId) {
+                if (dl && plot?.plotId) {
                     dispatchAttachLayerToPlot(dl.drawLayerId, plot.plotId, true, visible, true);
                 }
             }


### PR DESCRIPTION
#### [Firefly-1140](https://jira.ipac.caltech.edu/browse/FIREFLY-1140): Add side bar with whole registry

 - Add side bar using table
 - Any data set can be select



#### Testing
  - These are URL's that can be used to launch IrsaViewer from atlas type web pages.
  - Try different URLs:
      - https://firefly-1140-atlas-sidebar.irsakudev.ipac.caltech.edu/irsaviewer/?api=dl&id=iras_issa
      - https://firefly-1140-atlas-sidebar.irsakudev.ipac.caltech.edu/irsaviewer/?api=dl&id=wise_z0mgs
      - https://firefly-1140-atlas-sidebar.irsakudev.ipac.caltech.edu/irsaviewer/?api=dl&id=herschel_phpdp&showChooser
      - https://firefly-1140-atlas-sidebar.irsakudev.ipac.caltech.edu/irsaviewer/?api=dl&id=msx&showChooser=true
 - look at the URL doc
      - https://firefly-1140-atlas-sidebar.irsakudev.ipac.caltech.edu/irsaviewer/?api=dl
