### PR TITLE
IRSA-5077: Broken 'info' and 'Column Def' links under catalog listing

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatMasterTableQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/CatMasterTableQuery.java
@@ -36,9 +36,11 @@ import static edu.caltech.ipac.firefly.server.db.DbAdapter.MAIN_DB_TBL;
 public class CatMasterTableQuery extends EmbeddedDbProcessor {
 
     private static final String MASTER_LOC = QueryUtil.makeUrlBase(BaseGator.DEF_HOST) + "/cgi-bin/Gator/nph-scan?mode=ascii";
-    private static final String IRSA_HOST = AppProperties.getProperty("irsa.base.url", "https://irsa.ipac.caltech.edu");
-    private static final String IRSA_BASE_URL = QueryUtil.makeUrlBase(IRSA_HOST);
 
+    static String getIrsaBaseUrl() {
+        String baseUrl = AppProperties.getProperty("irsa.base.url", "https://irsa.ipac.caltech.edu");
+        return baseUrl.contains("irsasearchops") ? "https://irsa.ipac.caltech.edu" : baseUrl;
+    }
 
     public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
 
@@ -104,7 +106,7 @@ public class CatMasterTableQuery extends EmbeddedDbProcessor {
             // create <a> with linkDesc
             if (!href.toLowerCase().startsWith("http")) {
                 href = href.startsWith("/") ? href : "/" + href;
-                href = IRSA_BASE_URL + href;
+                href = getIrsaBaseUrl() + href;
             }
             String url = "<a href='" + href + "' target='" + linkDesc + "'>" + linkDesc + "</a>";
             row.setDataElement(col, url);
@@ -146,7 +148,7 @@ public class CatMasterTableQuery extends EmbeddedDbProcessor {
                         String replaceStr= s.substring(start,end);
                         if (!replaceStr.toLowerCase().startsWith("http")) {
                             url = replaceStr.startsWith("/") ? replaceStr : "/" + replaceStr;
-                            url = IRSA_BASE_URL + url;
+                            url = getIrsaBaseUrl() + url;
                             retval= inStr.replace(replaceStr,url);
                         }
 

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -447,18 +447,18 @@ export const createLinkCell = ({hrefColIdx, value}) => {
 
     return ({rowIndex, data, colIdx, height, width, columnKey}) => {
         hrefColIdx = hrefColIdx || colIdx;
-        const href = get(data, [rowIndex, hrefColIdx], 'undef');
-        const val = value || get(data, [rowIndex, colIdx], 'undef');
-        if (href === 'undef' || href === '#') {
+        const href = get(data, [rowIndex, hrefColIdx], '#');
+        const val = value || get(data, [rowIndex, colIdx], '#');
+        if (href && href !== '#') {
             return (
                 <Cell {...{rowIndex, height, width, columnKey}}>
-                    {val}
+                    <a target='_blank' href={href}>{val}</a>
                 </Cell>
             );
         } else {
             return (
                 <Cell {...{rowIndex, height, width, columnKey}}>
-                    <a target='_blank' href={href}>{val}</a>
+                    {val}
                 </Cell>
             );
         }

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -180,11 +180,12 @@ export class CatalogConstraintsPanel extends PureComponent {
         }
 
         const request = createDDRequest(); //Fetch DD master table
-        const urlDef = get(FieldGroupUtils.getGroupFields(groupKey), ['cattable', 'coldef'], 'null');
 
         fetchTable(request).then((tableModel) => {
-            const tableModelFetched = tableModel;
 
+            const urlDef = get(FieldGroupUtils.getGroupFields(groupKey), ['cattable', 'coldef'], 'null');
+
+            const tableModelFetched = tableModel;
             tableModelFetched.tbl_id = tblid;
             addConstraintColumn(tableModelFetched, groupKey);
             addColumnDef(tableModelFetched, urlDef);
@@ -300,10 +301,10 @@ function addSelColumn(tableModelFetched, filterAry, errors) {
  */
 function addColumnDef(tableModelFetched, urlDef) {
     const nCols = tableModelFetched.tableData.columns.length;
-    const u = (isEmpty(urlDef) || urlDef === 'null') ? '#' : urlDef.match(/href='([^']+)'/)[1] + '#';
+    const u = urlDef ? urlDef.match(/href='([^']+)'/)[1] + '#' : null;
     tableModelFetched.tableData.columns.splice(nCols, 0, {visibility: 'hide', name: 'coldef', type: 'char'});
     tableModelFetched.tableData.data.map((e) => {
-        e.splice(nCols, 0, u + e[0]);
+        e.splice(nCols, 0, (u ? u + e[0] : null));
     });
 }
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/IRSA-5077

`info` and `ColumnDef` links are broken in IRSA ops.
- Also fixed broken 'Table Selection' links under `name` column
This happens on first load as well as when `Column Def` does not exists

Test URL: https://irsa-5077-info-link.irsakudev.ipac.caltech.edu/irsaviewer/
This is built with `ops` env and uses IRSA ops backend.  It should appear as if it's in ops.

To test when there's no `ColumnDef`, select project = `IRAS`. 
