### PR TITLE
IRSA-5027: Fixed search-by-naifID not working when using name over id field

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -114,6 +114,7 @@ public class ServerParams {
 
     public static final String GEOSHAPE = "shape";
     public static final String ROTATION = "rotation";
+    public static final String NAIFID_FORMAT = "naifIdFormat";
 
     // commands
     public static final String FILE_FLUX = "CmdFileFlux";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
@@ -75,10 +75,25 @@ public class ResolveServerCommands {
 
             try {
                 HorizonsEphPairs.HorizonsResults[] horizons_results = TargetNetwork.getEphInfo(sp.getRequired(ServerParams.OBJ_NAME));
+                String naifIdFormat = sp.getOptional(ServerParams.NAIFID_FORMAT, "");
 
                 Map<String, Integer> values = new HashMap<>();
                 for (HorizonsEphPairs.HorizonsResults element : horizons_results) {
-                    values.put(element.getName(), Integer.parseInt(element.getNaifID()));
+                    String naifID = element.getNaifID();
+
+                    if (naifIdFormat.equals("7digit") && naifID.length() > 7) {
+                        for (String alias : element.getAliases()) {
+                            try {
+                                Integer.parseInt(alias);
+                                if (naifID.equals(alias.charAt(0) + "0" + alias.substring(1))) {
+                                    naifID = alias;
+                                    break;
+                                }
+                            } catch (NumberFormatException ignore) { }
+                        }
+                    }
+
+                    values.put(element.getName(), Integer.parseInt(naifID));
                 }
 
                 JSONObject naifids = new JSONObject(values);

--- a/src/firefly/js/ui/NaifidPanel.jsx
+++ b/src/firefly/js/ui/NaifidPanel.jsx
@@ -16,11 +16,11 @@ const searchHistory = []; // defining as global to persist it throughout the lif
 
 
 function NaifidPanelView({showHelp, valid, message, examples, feedback, value, labelWidth, feedbackStyle, popStyle,
-                             label= LABEL_DEFAULT, fireValueChange, updateNaifNameValue}){
+                             label= LABEL_DEFAULT, fireValueChange, updateNaifNameValue, naifIdFormat}){
     const getSuggestions = (val= '') => {
         if (!val) return [];
 
-        const rval = resolveNaifidObj(val);
+        const rval = resolveNaifidObj(val, naifIdFormat);
         if (!rval.p) return [];
 
         const getResSuggestionsList = (suggestionsList) => {
@@ -99,7 +99,8 @@ NaifidPanelView.propTypes = {
     onUnmountCB : PropTypes.func,
     feedbackStyle: PropTypes.object,
     fireValueChange: PropTypes.func,
-    updateNaifNameValue: PropTypes.func
+    updateNaifNameValue: PropTypes.func,
+    naifIdFormat: PropTypes.string
 };
 
 

--- a/src/firefly/js/ui/NaifidPanelWorker.js
+++ b/src/firefly/js/ui/NaifidPanelWorker.js
@@ -8,7 +8,7 @@ import {getCmdSrvSyncURL, toBoolean} from '../util/WebUtil';
 import {fetchUrl} from '../util/fetch';
 
 
-function makeResolverPromise(objName) {
+function makeResolverPromise(objName, naifIdFormat) {
     let ignoreSearchResults= null;
     let aborted= false;
 
@@ -24,7 +24,7 @@ function makeResolverPromise(objName) {
                     reject();
                 }
                 else {
-                    const {p, rejectFunc}= makeSearchPromise(objName);
+                    const {p, rejectFunc}= makeSearchPromise(objName, naifIdFormat);
                     ignoreSearchResults= rejectFunc;
                     resolve(p);
                 }
@@ -37,9 +37,10 @@ function makeResolverPromise(objName) {
 
 
 
-function makeSearchPromise(objName) {
+function makeSearchPromise(objName, naifIdFormat) {
     let rejectFunc= null;
-    const url= `${getCmdSrvSyncURL()}?objName=${objName}&cmd=${ServerParams.RESOLVE_NAIFID}`;
+    let url= `${getCmdSrvSyncURL()}?objName=${objName}&cmd=${ServerParams.RESOLVE_NAIFID}`;
+    if (naifIdFormat) url += `&naifIdFormat=${naifIdFormat}`;
     const searchPromise= new Promise(
         function(resolve, reject) {
             let fetchOptions = {};
@@ -71,15 +72,15 @@ function makeSearchPromise(objName) {
 }
 
 
-export function resolveNaifidObj(object){
-    let result = resolveObject(object);
+export function resolveNaifidObj(object, naifIdFormat){
+    let result = resolveObject(object, naifIdFormat);
     return result;
 }
 
 
 
 
-function resolveObject(objName) {
+function resolveObject(objName, naifIdFormat) {
     if (!objName) {
         return {
             showHelp: true,
@@ -88,7 +89,7 @@ function resolveObject(objName) {
         };
     }
 
-    let {p}= makeResolverPromise(objName);
+    let {p}= makeResolverPromise(objName, naifIdFormat);
     p= p.then( (results) =>
         {
             if (results) {


### PR DESCRIPTION
Added naifIdFormat to NaifIdPanel component and server-side NaifIdresolver to be able to resolve naif IDs in 7 digit (old) format if specified.

## Testing
1. https://irsa-5027-search-by-naifid-fix.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA

   In search by moving object, typing Gaspra (an asteroid) should lead to naif Id = `2000951` instead of `20000951` 

2. https://irsa-5027-search-by-naifid-fix.irsakudev.ipac.caltech.edu/applications/sofia/

   In precovery, typing Gaspra should lead to `20000951` (original 8-digit format naif ID returned by horizons)
