### PR TITLE
FIREFLY-1148: table chooser to load existing table into tap panel

### DIFF
--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -43,7 +43,7 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
             <FieldGroup groupKey={groupKey} keepState={keepState} style={{height:'100%', width: '100%',
                 display: 'flex', alignItems: 'stretch', flexDirection: 'column'}}>
                 <FormPanel
-                    width='auto' height='auto' groupKey={groupKey} onSubmit={onSubmit}
+                    groupKey={groupKey} onSubmit={onSubmit}
                     onError={resultFail}
                     onCancel={onCancel}
                     submitText={submitText}

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -418,8 +418,8 @@ function getAdqlQuery(tapBrowserState, showErrors= true) {
     let selcols = tableCol.selcols || (isUpload ? `${tableName}.*` : '*');
     if (isUpload) {
         const ut= uploadAsTable ?? uploadTable ?? '';
-        const tCol= uploadColumns.map( ({name}) => ut+'.'+name);
-        selcols+= ',\n' + makeColsLines(tCol,true);
+        const tCol= uploadColumns.filter(({use}) => use).map( ({name}) => ut+'.'+name);
+        selcols+= tCol.length ? ',\n' + makeColsLines(tCol,true) : '';
     }
 
     // build up constraints


### PR DESCRIPTION
#### [Firefly-1148](https://jira.ipac.caltech.edu/browse/FIREFLY-1148):
- created a new tab "Loaded Tables" in the upload table chooser dialog next to the "Upload Table" tab
- this "Loaded Tables" tab displays all existing tables
- user can select and load one of these into the tap panel
- **Updates 3/14**
  - made some small changes per @loitly's comments, including a small cleanup in FileUploadDropdown.jsx as well. Test build is also updated. 
- **Updates 3/20**
  - added 2 new columns (number of columns, number of rows) and changed title of "Loaded Tables" to "Table Title" 
  - using 'use' column to filter in ADQL query in TapSearchPanel 
  - fixed the issue where I was grabbing tables from "getTableGroup().tables". Now filtering should work and still grab the correct currently selected table and load it into the tap panel. @loitly 
  - test build below is updated

#### Testing:  
  - https://fireflydev.ipac.caltech.edu/firefly-1148-table-chooser/firefly
  - go the TAP panel, select source as IRSA or CADC 
  - without any tables loaded, in the Constraints input, select Sptial type "Multi Object". Go to the "Loaded Tables" tab. This should give you a warning: "No tables available to load." 
  - load any number of tables, and go back to the "Loaded Tables" tab now. You should see a list of all existing table(s). Select and "Load" any one of these. You should see table info (filename, columns, etc. in the TAP panel now). 
  - Search using this selected table  