### PR TITLE
FIREFLY-1155: fixed crash on tap search in finderchart

### DIFF
--- a/src/firefly/js/core/background/BgMonitorButton.jsx
+++ b/src/firefly/js/core/background/BgMonitorButton.jsx
@@ -16,7 +16,7 @@ export function BgMonitorButton () {
 
     const {jobs={}} = useStoreConnector(() => getBackgroundInfo());
 
-    const monitoredJobs = Object.values(jobs).filter( (info) => info.jobInfo?.monitored );
+    const monitoredJobs = Object.values(jobs).filter( (info) => info?.jobInfo?.monitored );
     const working = monitoredJobs.some( (info) => isActive(info) );
 
     return makeMenuItem(showBgMonAction, false, working, monitoredJobs.length);


### PR DESCRIPTION
#### [Firefly-1155](https://jira.ipac.caltech.edu/browse/FIREFLY-1155):
- Investigated the bug causing the crash, eventually a one character fix in BgMonitorButton.jsx checking if "**info**" exists before accessing its **jobInfo** attribute. 
- the irsa-ife PR (which most likely needs to be deleted now): https://github.com/IPAC-SW/irsa-ife/pull/247 

**Updates 3/16**
 - Removed fits and hips options from the click to search (binocular) tool for finderchart

#### Testing:  
  - https://firefly-1155-finderchart-tap-bug.irsakudev.ipac.caltech.edu/applications/finderchart
  - @lrebull I didn't test this extensively, but I tested tap search from the binocular/click on search (cone/rectangular) tool and from catalogs as well. I believe this fixes the crash issue. 
  - See Luisa's video on [Firefly-1155](https://jira.ipac.caltech.edu/browse/FIREFLY-1155) 
  - Go to the "Multiple Positions" tab -> upload a table file -> search
     - Use cone or rectangular selection tool and make a selection on an image 
     - Click on the binocular tool. None of the options in this dropdown should include "TAP". and any of the options that you do select, should not give you an error (or crash finderchart like with TAP search) 