### PR TITLE
FIREFLY-1061: Fix "Page size" appearing in client-table gears dialogs

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -378,6 +378,8 @@ function fixClientTable(tableModel) {
         tableModel = TblUtil.cloneClientTable(tableModel);
     }
 
+    if (!tableModel?.request?.pageSize) set(tableModel, 'request.pageSize', MAX_ROW);
+
     return tableModel;
 }
 

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -28,6 +28,7 @@ import {showAddOrUpdateColumn} from './AddOrUpdateColumn.jsx';
 import {BY_SCROLL} from './BasicTableView.jsx';
 
 import EDIT from 'html/images/16x16_edit_icon.png';
+import {MAX_ROW} from 'firefly/tables/TableRequestUtil';
 
 
 export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOptionReset, clearFilter}) => {
@@ -163,7 +164,7 @@ function Options({uiState, tbl_id, tbl_ui_id, ctm_tbl_id, onOptionReset, onChang
                 </div>
             </div>
             <div>
-                {showPaging &&
+                {showPaging && pageSize!==MAX_ROW &&
                 <InputField
                     validator={intValidator(1,10000)}
                     tooltip='Set page size'

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -29,6 +29,7 @@ import {dispatchChartAdd} from '../../charts/ChartsCntlr.js';
 import {logger} from '../../util/Logger.js';
 
 
+const MAX_ROW = Math.pow(2,31) - 1; // same as in '../../tables/TableRequestUtil.js', couldn't import from there
 
 export const LC = {
     RAW_TABLE: 'raw_table',          // raw table id
@@ -72,7 +73,7 @@ export const LC = {
     MISSION_DATA: 'missionEntries',
     GENERAL_DATA:'generalEntries',
 
-    TABLE_PAGESIZE: 30000
+    TABLE_PAGESIZE: MAX_ROW
 };
 
 const plotIdRoot= 'LC_FRAME-';


### PR DESCRIPTION
Fixes [FIREFLY-1061](https://jira.ipac.caltech.edu/browse/FIREFLY-1061)

- ~Simply removed the Page size element~ remove page element when it is equal to max rows

## Testing 
https://fireflydev.ipac.caltech.edu/firefly-1061-remove-page-size/firefly/?__action=layout.showDropDown&

Go to TAP, click gear icon in "Output Column Selection and Constraints" table, there shouldn't be any page size in top right and everything else should work as expected.

Do a catalog search, the page size should appear on clicking gear icon