### PR TITLE
Firefly-1089: fix for nan/inf plot errors 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -602,7 +602,7 @@ public class QueryUtil {
             double xval = xValGetter.getValue(row);
             double yval = yValGetter.getValue(row);
 
-            if (Double.isNaN(xval) || Double.isNaN(yval)) {
+            if (Double.isNaN(xval) || Double.isNaN(yval) || Double.isInfinite(xval) || Double.isInfinite(yval)) {
                 outRows--;
                 continue;
             }


### PR DESCRIPTION
#### [Firefly-1089](https://jira.ipac.caltech.edu/browse/FIREFLY-1089):
- see video on ticket link for description of the bug
- took some time to track this down, but I think this fixes the issue with doing stuff like **1/col_name** (if col_name has any zero values - that would result in infinity) 
     - if you want to track down the issue on the client: see, for example, line 141 in FireflyHeatmap.js
       - Here, **decimateKey** (from the tableMeta) results in **yUnit/dy** = **infinity** (for the example provided in the ticket video, where the Y axis is set to 1/parallax) 
       - and subsequently, all calls to **getCenter(xval, yval)** (line 162) result in the **y** value = **infinity** 
  - So, added a check to skip any rows in **doDecimation** function where xval or yval is infinite 

#### Testing:  
- https://fireflydev.ipac.caltech.edu/firefly-1089-nan-plot-err/firefly
- load a table, with at least 1 column having some 0 entries (you can use the file in the ticket link - it's the same as the one in the video) 
- open the Plot Parameters dialog (gears icon) 
- under modify trace, select either the x or y column as 1/**col_name** (where **col_name** has some 0 entries - you can use parallax here if you're using the file from the ticket) 
- this should now still plot the rest of the chart, skipping over any entries resulting in infinite/nan 
- to compare against ops, either see the video on the ticket, or try re-creating the above steps on ops: https://irsa.ipac.caltech.edu/frontpage/
 