### PR TITLE
FIREFLY-669: Fix offset in rotate image slider's handle 

### DIFF
--- a/src/firefly/js/ui/rc-slider.css
+++ b/src/firefly/js/ui/rc-slider.css
@@ -27,7 +27,7 @@
 }
 .rc-slider-handle {
   position: absolute;
-  margin-left: -4px;
+  margin-left: 0;
   /* margin-top: -5px; //original, edited by firefly */
   margin-top: -2px;
   /*


### PR DESCRIPTION
There was -4px margin-left set on handle that was causing this problem.

Also, I noticed this problem was in all other instances of range slider like color band panel too so this fix is for all.

## Testing
https://fireflydev.ipac.caltech.edu/firefly-669-rotate-slider-offset/firefly

Image search -> FITS Image, m81, WISE All -> toolbar in Image Grid:
1. Tools dropdown -> Rotate/flip -> enter 180 deg, the slider handle's center and marker's center should be on same vertical line (imaginary)
2. Color dropdown -> set color bar slider to 3, it should again vertically aligned with marker (which it wasn't earlier - [test here](https://fireflydev.ipac.caltech.edu/firefly/))