### PR TITLE
FIREFLY-1188: Firefly picks up the wrong host requested header when behind a reverse proxy

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
@@ -159,7 +159,7 @@ public class RequestAgent {
 
             // getting the base url including the application path is a bit tricky when behind reverse proxy(ies)
             String proto = getHeader("X-Forwarded-Proto", request.getScheme());
-            String host  = getHeader("X-Forwarded-Server", getHeader("X-Forwarded-Host", request.getServerName()));
+            String host  = getHeader("X-Forwarded-Host", getHeader("X-Forwarded-Server", request.getServerName()));
             String port  = getHeader("X-Forwarded-Port", String.valueOf(request.getServerPort()));
             port = port.matches("443|80") ? "" : ":" + port;
             String proxiedPath = getHeader("X-Forwarded-Path", request.getContextPath());


### PR DESCRIPTION
- should use 'X-Forwarded-Host' header first