### PR TITLE
FIREFLY-1218: Allow onlinehelp base URL to be overridden as firefly options on the client

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -23,7 +23,7 @@ ehcache.multicast.address = "239.255.0.1"
 
 sso.server.url = "https://irsa.ipac.caltech.edu/account/"
 sso.user.profile.url = "https://irsa.ipac.caltech.edu/account/uman/uman.html//id=profile"
-help.base.url = "onlinehelp/"
+__$help.base.url = "onlinehelp/"
 
 
 visualize.fits.MaxSizeInBytes= 21474836480

--- a/config/common.prop
+++ b/config/common.prop
@@ -60,7 +60,7 @@ mail.smtp.starttls.enable = @mail.smtp.starttls.enable@
 sso.server.url=@sso.server.url@
 sso.user.profile.url=@sso.user.profile.url@
 
-help.base.url=@help.base.url@
+__$help.base.url=@__$help.base.url@
 
 tap.maxrec.maxval=@__$tap.maxrec.hardlimit@
 

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -297,7 +297,7 @@ function grabWindowFocus() {
 function onlineHelpLoad( action )
 {
     return () => {
-        let url = getAppOptions()?.['help.base.url'] || '';
+        let url = getAppOptions()?.['help.base.url'] || getProp('help.base.url');
         url = url.endsWith('/') ? url : url + '/';
         url += action?.payload?.helpId ? '#id=' + action.payload.helpId : '';
         url = new URL(url, getRootURL());                   // use rootURL instead of document.baseURI if relative


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1218
More changes here:
https://github.com/IPAC-SW/irsa-ife/pull/254
https://github.com/lsst/suit/pull/48

Moved server-side declaration to global_vars(__$HELP_BASE_URL) so that it can be overridden as a firefly option on the client.  Everything should work as it did before.

Test:
https://fireflydev.ipac.caltech.edu/firefly-1218-help-base-url/firefly/
https://firefly-1218-help-base-url.irsakudev.ipac.caltech.edu/applications/sofia/
https://firefly-1218-help-base-url.irsakudev.ipac.caltech.edu/suit/
