### PR TITLE
Firefly-1198:whole table search fix for TAP services not supporting uploads 

### DIFF
--- a/src/firefly/js/ui/DefaultSearchActions.js
+++ b/src/firefly/js/ui/DefaultSearchActions.js
@@ -139,7 +139,7 @@ export const makeDefTableSearchActions= () => {
             label: 'Upload Table',
             tip: 'Upload Whole Table',
             searchType: SearchTypes.wholeTable,
-            execute: (sa,table) => searchWholeTable(sa,table),
+            execute: (sa,table) => searchWholeTable(table),
             searchDesc: 'Use table as an upload to TAP search'
         })
 ];
@@ -181,7 +181,7 @@ export const makeExternalSearchActions = () => {
     ];
 };
 
-async function searchWholeTable(sa,table) {
+async function searchWholeTable(table) {
         const params ={
             [ServerParams.COMMAND]: ServerParams.TABLE_SAVE,
             [ServerParams.REQUEST]: JSON.stringify(table.request),

--- a/src/firefly/js/ui/tap/TableSearchHelpers.jsx
+++ b/src/firefly/js/ui/tap/TableSearchHelpers.jsx
@@ -74,7 +74,7 @@ export function makePanelStatusUpdater(panelActive,panelTitle,defErrorMessage) {
      */
     return (constraints, lastConstraintResult, setConstraintResult) => {
         const {valid:constraintsValid,errAry, adqlConstraintsAry, siaConstraints, siaConstraintErrors,
-            uploadFile, TAP_UPLOAD }= constraints;
+            uploadFile, TAP_UPLOAD}= constraints;
 
         const simpleError= constraintsValid ? '' : (errAry[0]|| defErrorMessage || '');
 

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -30,14 +30,14 @@ function HelperComponents({initArgs, cols, columnsModel, serviceUrl, serviceLabe
         (
             <React.Fragment>
                 <ObsCoreSearch {...{cols, serviceLabel, initArgs}} />
-                <SpatialSearch {...{cols, serviceUrl, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
+                <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <ExposureDurationSearch {...{initArgs}} />
                 <ObsCoreWavelengthSearch {...{initArgs, serviceLabel}} />
             </React.Fragment>
         ) :
         (
             <React.Fragment>
-                <SpatialSearch {...{cols, serviceUrl, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
+                <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <TemporalSearch {...{cols, columnsModel,}} />
             </React.Fragment>
         );


### PR DESCRIPTION
#### [Firefly-1198](https://jira.ipac.caltech.edu/browse/FIREFLY-1198)

- the  first bug/issue: if you did a whole table search with a TAP service selected that does not support upload, you would still see the table you just did a whole table search with on the TAP panel, leading to all sorts of issues. 
- This fixes that bug, by checking if this TAP service supports uploads or not, if it does not - don't show the table on the TAP panel for this service
  - instead, display a warning message. 
- **Updates 4/19** 
  - updated the warning message to be displayed after you do a click to action (whole table) search and switch to a service such as NED that does not support uploads
  - fixed the Position Column (from the uploaded table) bugs, see testing instructions below 

- **Updates 4/21** 
  - addressed PR comments, small fixes and using serviceLabel in the warning message now to show TAP service 
  - fixed a bug where if you load a table, and then switch over to a service like NED that doesn't support uploads, then its ADQL query would look incorrect. Reason is that we were adding a prefix to the ADQL query (which we normally do for other uploads, but in this case only the where clause of the ADQL would get the prefix and not the FROM clause - making the query look something like this: 
     - `FROM NEDTAP.objdir WHERE CONTAINS(POINT('ICRS', N.ra, N.dec)`
  - so I passed down **canUpload** (from capabilities to **makeSpatialConstraints** and only set prefix if canUpload is true as well 

Testing: https://fireflydev.ipac.caltech.edu/firefly-1198-whole-table-search-bugs/firefly
- select NED as TAP service 
- search m1 with a small radius 
- do a whole table search on the resulting table
- you should see the warning message next to "Spatial"
- if you switch back to a service that supports uploads (IRSA, CADC, etc.), you should see the table that you just did a whole table search on here
   - and if you switch back to NED, you should see the warning message again. 
- **Updates 4/19**: Instructions to test for position columns bug fixes
  - search for 2 tables (I suggest NED as TAP service and search for m1, and CADC as TAP service and search for m1 - but it can really be any 2 tables)
     - do a click to action whole table search on the first table. Take a note of the position columns. 
     - then, do a click to action whole table search on the second table, the position columns (from the uploaded table) should match the ones from this table and not the first table (that was the bug). 
     - also, in the input field of the position columns, attempt to type in the "**Lon Column**" and "**Lat Column**" values. As you start typing (say "ra"), pick one of the value from the suggestions and make sure that works as expected.
        - this was one of the other bugs with position columns. The column validator still had the columns from the previous table, so when you did a whole table search and manually typed in values in the input field, it wouldn't work as expected (because the column validator would check against the columns of the first table) - so I had to make sure to update the call to `getColValidator` before calling setUploadInfo with the uploadInfo object generated from the whole table search. 