### PR TITLE
FIREFLY-712: Table upload not accepting compliant IPAC tables

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -297,7 +297,7 @@ public class IpacTableUtil {
         if (line != null && line.startsWith("|")) {
             String[] types = parseHeadings(line.trim());
             for (int i = 0; i < types.length; i++) {
-                String typeDesc = types[i].trim();
+                String typeDesc = types[i].trim().toLowerCase();
                 cols.get(i).setTypeDesc(typeDesc);
                 cols.get(i).setDataType(DataType.descToType(typeDesc));
             }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-712
- IPAC table requires column type to be lower case.  Convert types to lower case when reading in.

Test: https://fireflydev.ipac.caltech.edu/firefly-712-ipac-type/firefly
Upload the attached sample table file from the ticket.  All column types appeared in lower case and recognized as it should.