### PR TITLE
FIREFLY-1222 Bug fix in the readout of pixels with value 0.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/ClientFitsHeader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/ClientFitsHeader.java
@@ -81,7 +81,7 @@ public class ClientFitsHeader implements Serializable, Iterable<String> {
     public double getCDelt2() { return getDoubleHeader(CDELT2); }
     public double getBScale() { return getDoubleHeader(BSCALE); }
     public double getBZero() { return getDoubleHeader(BZERO); }
-    public double getBlankValue() { return getDoubleHeader(BLANK_VALUE); }
+    public double getBlankValue() { return getDoubleHeader(BLANK_VALUE, Double.NaN); }
     public long getDataOffset() { return getLongHeader(DATA_OFFSET); }
 
     public int getIntHeader(String key) { return getIntHeader(key,0); }

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/ClientFitsHeader.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/ClientFitsHeader.java
@@ -75,13 +75,18 @@ public class ClientFitsHeader implements Serializable, Iterable<String> {
     }
 
     public int getPlaneNumber() { return getIntHeader(PLANE_NUMBER); }
-    public int getBixpix() { return getIntHeader(BITPIX); }
+    public int getBitpix() { return getIntHeader(BITPIX); }
     public int getNaxis1() { return getIntHeader(NAXIS1); }
     public int getNaxis2() { return getIntHeader(NAXIS2); }
     public double getCDelt2() { return getDoubleHeader(CDELT2); }
     public double getBScale() { return getDoubleHeader(BSCALE); }
     public double getBZero() { return getDoubleHeader(BZERO); }
-    public double getBlankValue() { return getDoubleHeader(BLANK_VALUE, Double.NaN); }
+
+    public double getBlankValue() {
+        // blank value is only applicable to integer values (BITPIX > 0)
+        return this.getBitpix() > 0 ? getDoubleHeader(BLANK_VALUE, Double.NaN) : Double.NaN;
+    }
+
     public long getDataOffset() { return getLongHeader(DATA_OFFSET); }
 
     public int getIntHeader(String key) { return getIntHeader(key,0); }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
@@ -348,7 +348,7 @@ public class ImageHeader implements Serializable
 
 
 
-	blank_value = header.getDoubleValue("BLANK", Double.NaN);
+	blank_value = bitpix > 0 ? header.getDoubleValue("BLANK", Double.NaN) : Double.NaN;
 	if (SUTDebug.isDebug())
 	    System.out.println("blank_value = " + blank_value);
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
@@ -88,7 +88,7 @@ public class PixelValue {
 			case  64 -> fits_file.readLong();
 			default ->  blank_value;
 		};
-		if (value == blank_value) return Double.NaN;
+		if (bitpix > 0 && value == blank_value) return Double.NaN;
 		return value;
 	}
 
@@ -143,7 +143,7 @@ public class PixelValue {
 			double bscale = header.getDoubleValue("BSCALE", 1);
 			double bzero = header.getDoubleValue("BZERO", 0);
 			double cdelt2 = header.getDoubleValue("CDELT2", 0);
-			double blank_value = header.getDoubleValue("BLANK", Double.NaN);
+			double blank_value = bitpix > 0 ? header.getDoubleValue("BLANK", Double.NaN) : Double.NaN;
 			System.out.println("naxis3 = " + naxis3);
 			RandomAccessFile fits_file = null;
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
@@ -27,7 +27,7 @@ public class PixelValue {
 
 	static public double pixelVal(RandomAccessFile fits_file, int x, int y, ClientFitsHeader header) throws IOException{
 		int plane_number   = header.getPlaneNumber();
-		int bitpix         = header.getBixpix();
+		int bitpix         = header.getBitpix();
 		long naxis1        = header.getNaxis1();
 		long naxis2        = header.getNaxis2();
 		double cdelt2      = header.getCDelt2();

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/PixelValue.java
@@ -45,7 +45,11 @@ public class PixelValue {
 
 		if (!isPalomar(header)) return file_value * bscale + bzero; // normal case
 
-		 // if we are a palomar fits file then to special things to it, todo- can we generalize?
+		 // If this is a Palomar Transient Factory single-epoch FITS image, then
+		 // convert pixel values to magnitudes and apply photometric and airmass corrections.
+		 // (200x-era request from PTF scientists)
+		 // See other uses of PALOMAR_ID elsewhere in Firefly for other pieces of this.
+		 // TODO- generalize or retire?
 		double airmass= header.getDoubleHeader(ImageHeader.AIRMASS);
 		double extinct= header.getDoubleHeader(ImageHeader.EXTINCT);
 		double imagezpt= header.getDoubleHeader(ImageHeader.IMAGEZPT);
@@ -55,6 +59,7 @@ public class PixelValue {
 	}
 
 	private static boolean isPalomar(ClientFitsHeader h) {
+		// Identify Palomar Transient Factory single-epoch images based on FITS headers
 		return
 				h.getStringHeader(ImageHeader.ORIGIN).startsWith(ImageHeader.PALOMAR_ID)  &&
 				h.containsKey(ImageHeader.AIRMASS) && h.containsKey(ImageHeader.EXTINCT) &&

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/Zscale.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/Zscale.java
@@ -574,7 +574,7 @@ public static void main(String args[])
 	int naxis = header.getIntValue("NAXIS");
 	int naxis1 = header.getIntValue("NAXIS1");
 	int naxis2 = header.getIntValue("NAXIS2");
-	double blank_value = header.getDoubleValue("BLANK", Double.NaN);
+	double blank_value = bitpix > 0 ? header.getDoubleValue("BLANK", Double.NaN) : Double.NaN;
 
     contrast = 0.25;
     opt_size = 600;    /* desired number of pixels in sample   */

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
@@ -128,7 +128,7 @@ public class FitsExtract {
 
         if (bscale==1.0D && bzero==0D && !isNaN(aveValue) && aveValue.doubleValue()!=blankValue) return aveValue;
 
-        double newValue= ImageStretch.getFluxStandard( aveValue.doubleValue(), blankValue, bscale, bzero);
+        double newValue= ImageStretch.getFluxStandard( aveValue.doubleValue(), blankValue, bscale, bzero, bitpix);
         if (Double.isNaN(newValue)) return newValue;
 
         return switch (arrayType.toString()) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -211,7 +211,7 @@ public class FitsRead implements Serializable, HasSizeOf {
         double raw_dn = getRawFloatAry()[index];
 
         return (!getOrigin().startsWith(ImageHeader.PALOMAR_ID)) ?
-                ImageStretch.getFluxStandard(raw_dn,getBlankValue(),getBscale(),getBzero()) :
+                ImageStretch.getFluxStandard(raw_dn, getBlankValue(), getBscale(), getBzero(), getBitPix()) :
                 ImageStretch.getFluxPalomar(raw_dn,getBlankValue(), this.header);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -501,7 +501,10 @@ public class FitsReadUtil {
     public static int getNaxis4(Header h) { return (getNaxis3(h) > 2) ? h.getIntValue("NAXIS4") : 1; }
     public static double getBscale(Header h) { return h.getDoubleValue("BSCALE", 1.0); }
     public static double getBzero(Header h) { return h.getDoubleValue("BZERO", 0.0); }
-    public static double getBlankValue(Header h) { return h.getDoubleValue("BLANK", Double.NaN); }
+    public static double getBlankValue(Header h) {
+        // blank value is only applicable to integer values (BITPIX > 0)
+        return getBitPix(h) > 0 ? h.getDoubleValue("BLANK", Double.NaN) : Double.NaN;
+    }
     public static String getExtName(Header h) { return h.getStringValue("EXTNAME"); }
     public static String getExtType(Header h) { return h.getStringValue("EXTTYPE"); }
     public static String getUtype(Header h) { return h.getStringValue("UTYPE"); }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
@@ -245,7 +245,8 @@ public class ImageStretch {
      * @return flux value to display
      */
     public static double getFluxPalomar(double  raw_dn, double blank_value, Header header) {
-        if ((raw_dn == blank_value) || (Double.isNaN(raw_dn))) {
+        int bitpix = header.getIntValue("BITPIX");
+        if ((bitpix > 0 && raw_dn == blank_value) || (Double.isNaN(raw_dn))) {
             return Double.NaN;
         }
         double exptime = header.getDoubleValue(ImageHeader.EXPTIME, 0.0);
@@ -260,8 +261,8 @@ public class ImageStretch {
 
 
 
-    public static double getFluxStandard(double  raw_dn, double blank_value, double bscale, double bzero){
-        if ((raw_dn == blank_value) || (Double.isNaN(raw_dn))) {
+    public static double getFluxStandard(double  raw_dn, double blank_value, double bscale, double bzero, int bitpix){
+        if ((bitpix > 0 && raw_dn == blank_value) || (Double.isNaN(raw_dn))) {
             return Double.NaN;
         }
         return raw_dn * bscale + bzero;

--- a/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
+++ b/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
@@ -67,14 +67,17 @@ const startsWithAny= (s,strAry) => Boolean(strAry.find( (sTest) => s.startsWith(
 
 function getBasicHeaderValues(parse) {
 
+    const bitpix = parse.getIntValue('BITPIX');
+    // blank value is only applicable to integer values (BITPIX > 0)
+    const blank_value = bitpix > 0 ? parse.getDoubleValue('BLANK', NaN) : NaN;
     return {
         naxis1: parse.getIntValue('NAXIS1'),
         naxis2: parse.getIntValue('NAXIS2'),
         cdelt2: parse.getDoubleValue('CDELT2', 0),
         bscale: parse.getDoubleValue('BSCALE', 1.0),
         bzero: parse.getDoubleValue('BZERO', 0.0),
-        blank_value: parse.getDoubleValue('BLANK', NaN),
-        bitpix: parse.getIntValue('BITPIX'),
+        blank_value,
+        bitpix,
     };
 }
 


### PR DESCRIPTION
This is one line bug fix for incorrect `NaN` values in place of zeros in pixel value display.

Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1222
Test URL: https://fireflydev.ipac.caltech.edu/firefly-1222-zero-val/firefly

To test, upload the FITS image attached to the ticket. Note, that zero values for both float and integer values are now displayed correctly. (They are displayed as `NaN` in https://fireflydev.ipac.caltech.edu/firefly)
