### PR TITLE
FIREFLY-1125: fixed csv file with bad colum names

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/SortInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/SortInfo.java
@@ -9,6 +9,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import static edu.caltech.ipac.table.TableUtil.splitCols;
+
 /**
  * Date: Feb 11, 2009
  *
@@ -58,7 +60,7 @@ public class SortInfo implements Serializable, Comparable {
     public static SortInfo parse(String str) {
         if (StringUtils.isEmpty(str)) return null;
         str = str.replaceFirst("SortInfo=", "");  // to support old format used by external code.
-        String[] values = str.split(",");
+        String[] values = splitCols(str);
         if (values.length > 1) {
             if (values[0] != null) {
                 Direction dir = values[0].equals(Direction.ASC.name()) ? Direction.ASC : Direction.DESC;

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -74,7 +74,7 @@ public class TableUtil {
 
     private static boolean isRegLine(String line) {
         if (StringUtils.isEmpty(line)) return false;
-        line= StringUtils.trim(line).toLowerCase();
+        line= line.trim().toLowerCase();
         for(String sw : regStartWith) {
             if (line.startsWith(sw)) return true;
         }
@@ -309,6 +309,14 @@ public class TableUtil {
             }
         }
         return Arrays.asList(val);
+    }
+
+    /**
+     * @param cnames a string of column name(s)
+     * @return an array of column names split from a comma separated string, ignoring commas inside double-quotes
+     */
+    public static String[] splitCols(String cnames) {
+        return cnames == null ? new String[0] : cnames.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
     }
 
 //====================================================================

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -116,7 +116,7 @@ public class DsvTableIO {
                 s = s.substring(1);//LZ fixed the issue with the BOM character
             }
             if (!StringUtils.isEmpty(s)) {
-                columns.add(new DataType(s, null)); // unknown type
+                columns.add(new DataType(s.trim(), null)); // unknown type
             }
         }
         return columns;

--- a/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
@@ -315,7 +315,7 @@ public class StringUtils {
      * @return Returns true is the given string is either null, or an empty string.
      */
     public static boolean isEmpty(String s) {
-        return s == null || trim(s).length() == 0;
+        return s == null || s.trim().length() == 0;
     }
 
     public static boolean isAnyEmpty(String... sAry) {
@@ -462,19 +462,12 @@ public class StringUtils {
     }
 
     public static String[] split(String source, String delimiter) {
-        return split(source, delimiter, Integer.MAX_VALUE);
+        return split(source, delimiter, 0);
     }
 
     public static String[] split(String source, String delimiter, int limit) {
-        ArrayList<String> rvals = new ArrayList<String>();
-        StringTokenizer vals = new StringTokenizer(source, delimiter);
-        while (vals.hasMoreToken()) {
-            if (rvals.size() >= limit) {
-                break;
-            }
-            rvals.add(trim(vals.nextToken()));
-        }
-        return rvals.toArray(new String[rvals.size()]);
+        return Arrays.stream(source.split(delimiter, limit))
+                .map(String::trim).toArray(String[]::new);
     }
 
     public static List<String> split(String source, int chunkSize) {
@@ -483,39 +476,7 @@ public class StringUtils {
                 .mapToObj(index -> source.substring(index * chunkSize, Math.min((index + 1) * chunkSize, source.length())))
                 .collect(Collectors.toList());
     }
-
-
-    /**
-     * this implementation is much faster than GWt's String.trim() once
-     * compiled into javascript, especially in Firefox
-     * @param str
-     * @return
-     */
-    public static String trim(String str) {
-        if (str == null || str.length() == 0) return str;
-
-        String whitespace = " \t\n\f\r";
-        int i = 0; int len = str.length();
-        for (; i < str.length(); i++) {
-            if (whitespace.indexOf(str.charAt(i)) == -1) {
-                str = str.substring(i);
-                break;
-            }
-        }
-        if (i == len) {
-            // empty string...
-            return "";
-        }
-
-        for (i = str.length() - 1; i >= 0; i--) {
-            if (whitespace.indexOf(str.charAt(i)) == -1) {
-                str = str.substring(0, i + 1);
-                break;
-            }
-        }
-        return str;
-    }
-
+    
     /**
      * returns the length of the given string.
      * 0 if str is null

--- a/src/firefly/js/tables/SortInfo.js
+++ b/src/firefly/js/tables/SortInfo.js
@@ -1,4 +1,5 @@
 import {isArray} from 'lodash';
+import {splitCols} from 'firefly/tables/TableUtil.js';
 
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
@@ -45,16 +46,16 @@ export function sortInfoString(colName, isAscending=true) {
     }
 
     /**
-     * returns the sortInfo string of the next toggle state.
-     * @param colName
-     * @returns {string}
+     * returns the sortInfo of the next toggle state.
+     * @param {string[]} cnames an array of the column(s) to sort
+     * @returns {SortInfo}
      */
-    toggle(colName) {
-        const name = colName.split(',')[0].trim();
-        const dir = this.getDirection(name);
+    toggle(cnames=[]) {
+        if (cnames.length === 0) return;
+        const dir = this.getDirection(cnames[0]);
         const direction = dir === UNSORTED ? SORT_ASC :
                           dir === SORT_ASC ? SORT_DESC : UNSORTED;
-        const sortColumns = direction === UNSORTED ? [] : colName.split(',').map((cn) => cn?.trim());
+        const sortColumns = direction === UNSORTED ? [] : cnames;
         return new SortInfo(direction, sortColumns).serialize();
     }
 
@@ -64,7 +65,7 @@ export function sortInfoString(colName, isAscending=true) {
 
     static parse(sortInfo) {
         if (sortInfo) {
-            const parts = sortInfo.split(',').map((s) => s.trim());
+            const parts = splitCols(sortInfo).map((s) => s.trim());
             if (parts) {
                 const direction = parts[0] && parts[0].toUpperCase();
                 const sortColumns = parts[1] && parts.slice(1).map( (c) => c.replace(/^"(.+)"$/, '$1'));           // strip quotes if any

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1403,6 +1403,14 @@ export function getTableState(tbl_id) {
     return TBL_STATE.OK;
 }
 
+/**
+ * @param {string} cnames
+ * @return {string[]} array of column names split from a comma separated string, ignoring commas inside double-quotes
+ */
+export function splitCols(cnames='') {
+    return cnames.split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/);
+}
+
 /*-------------------------------------private------------------------------------------------*/
 
 /**

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -7,8 +7,10 @@ import {Cell} from 'fixed-data-table-2';
 import {set, get, isEqual, pick, omit, isEmpty, isString, toNumber} from 'lodash';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
-import {isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue, getTypeLabel,
-        getColumnIdx, getRowValues, getCellValue, getTableUiByTblId} from '../TableUtil.js';
+import {
+    isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue, getTypeLabel,
+    getColumnIdx, getRowValues, getCellValue, getTableUiByTblId, splitCols
+} from '../TableUtil.js';
 import {SortInfo} from '../SortInfo.js';
 import {InputField} from '../../ui/InputField.jsx';
 import {SORT_ASC, UNSORTED} from '../SortInfo';
@@ -74,7 +76,7 @@ export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, 
     const {label, name, desc, sortByCols, sortable} = col || {};
     const cdesc = desc || label || name;
     const sortDir = SortInfo.parse(sortInfo).getDirection(name);
-    const sortCol = sortByCols || name;
+    const sortCol = sortByCols ? splitCols(sortByCols) : [name];
     const typeVal = getTypeLabel(col);
     const unitsVal = col.units ? `(${col.units})`: '';
     let  className = toBoolean(sortable, true) ? 'clickable' : undefined;


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1125
- trim column names when reading in csv files
- fix sorting when column namne contains comma

Test: https://fireflydev.ipac.caltech.edu/firefly-1125-fix-csv-table/firefly
Upload attached imperfect_u.csv file from ticket.
Follow instructions in ticket to confirm that the reported issues are fixed.