### PR TITLE
Firefly-1212: filter upload tbl columns down to user selected cols

### DIFF
--- a/src/firefly/js/ui/DefaultSearchActions.js
+++ b/src/firefly/js/ui/DefaultSearchActions.js
@@ -9,6 +9,7 @@ import {setMultiSearchPanelTab} from './MultiSearchPanel.jsx';
 import {Format} from 'firefly/data/FileAnalysis';
 import {doJsonRequest} from 'firefly/core/JsonUtils';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
+import {findTableCenterColumns} from 'firefly/util/VOAnalyzer';
 
 //note - these two redundant function are here because of circular dependencies.
 // this file is imported very early and webpack is creating errors
@@ -192,6 +193,8 @@ async function searchWholeTable(table) {
         const tbl = getTableUiByTblId(table?.tbl_id);
         const columns = tbl.columns.map((col) =>
             col.visibility === 'hide' || col.visibility === 'hidden'? ({...col, use:false}) :  ({...col, use:true}));
+        const {lonCol='', latCol=''}= findTableCenterColumns({tableData:{columns}}) ?? {};
+        const columnsSelected = columns.map((col) => col.name === lonCol || col.name === latCol? ({...col, use:true}) :  ({...col, use:false})); //select position cols
         const result = await doJsonRequest(ServerParams.TABLE_SAVE, params);
         if (!result.success) {
             showInfoPopup('Error loading this table', result.error);
@@ -202,7 +205,7 @@ async function searchWholeTable(table) {
             title: tbl.title,
             fileName: tbl.title,
             tbl_id: tbl.tbl_id,
-            columns,
+            columns: columnsSelected,
             totalRows: tbl.totalRows,
             tableSource: SEARCH_TBL_SOURCE,
         };

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -244,6 +244,15 @@ function UploadTableSelector({uploadInfo, setUploadInfo}) {
     const openKey= 'upload-pos-columns';
 
     useEffect(() => {
+        //if user changes position column(s), make the new columns entries selectable in the columns/search
+        const columns = uploadInfo?.columns;
+        if (getLon()) columns.find((col) => col.name === getLon()).use = true;
+        if (getLat()) columns.find((col) => col.name === getLat()).use = true;
+        uploadInfo = {...uploadInfo, columns};
+        setUploadInfo(uploadInfo);
+    }, [getLon, getLat]);
+
+    useEffect(() => {
         if (!columns) return;
         const centerCols = findTableCenterColumns({tableData:{columns}}) ?? {};
         const {lonCol='', latCol=''}= centerCols;
@@ -261,8 +270,12 @@ function UploadTableSelector({uploadInfo, setUploadInfo}) {
     const haveTable= Boolean(fileName && columns);
 
     const onColsSelected = (selectedColNames) => {
+        //get rid of extra quotes within each selectedColNames - because non-alphanumeric entries may have
+        //been quoted by calling quoteNonAlphanumeric
+        // , e.g.: ['"Object Name"', 'RA', 'Notes']
+        selectedColNames = selectedColNames.map((col) => col.replace(/^"(.*)"$/, '$1'));
         const columns = uploadInfo.columns.map((col) => (
-                {...col, use:selectedColNames.includes(col.name)}));
+                {...col, use:selectedColNames.includes((col.name))}));
         uploadInfo = {...uploadInfo, columns};
         setUploadInfo(uploadInfo);
     };
@@ -397,7 +410,6 @@ const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInf
     const radiusOrPolygon= isCone ?
         radiusField :
         renderPolygonDataArea({ cornerCalcTypeValue, hipsUrl, centerWP, fovDeg, labelWidth: polygonLabelWidth });
-
 
     switch (layoutMode) {
         case OBSCORE_SINGLE_LAYOUT:

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -343,6 +343,8 @@ function onTapSearchSubmit(request,serviceUrl,tapBrowserState) {
     let isUpload;
     let serverFile;
     let uploadTableName;
+    let schemaEntry;
+    let userColumns;
 
     if (isADQL) {
         adql = request.adqlQuery;
@@ -354,6 +356,9 @@ function onTapSearchSubmit(request,serviceUrl,tapBrowserState) {
     else {
         adql = getAdqlQuery(tapBrowserState);
         isUpload = isTapUpload(tapBrowserState);
+        schemaEntry = getTapUploadSchemaEntry(tapBrowserState);
+        const cols = schemaEntry.columns;
+        userColumns = cols?.filter((col) => col.use).map((col) => col.name).join(',');
         serverFile = isUpload && getUploadServerFile(tapBrowserState);
         uploadTableName = isUpload && getUploadTableName(tapBrowserState);
     }
@@ -368,6 +373,7 @@ function onTapSearchSubmit(request,serviceUrl,tapBrowserState) {
         if (isUpload) {
             params.UPLOAD= serverFile;
             params.adqlUploadSelectTable= uploadTableName;
+            if (!isADQL) params.UPLOAD_COLUMNS= userColumns;
         }
         if (hasMaxrec) params.MAXREC = maxrec;
         const treq = makeTblRequest('AsyncTapQuery', getTitle(adqlClean,serviceUrl), params);


### PR DESCRIPTION
#### [Firefly-1212](https://jira.ipac.caltech.edu/browse/FIREFLY-1212)
- for a table upload, filtered down user selected columns in the upload table 
  - @robyww I wasn't sure how to use the "INCL_COLUMNS" attribute of a TableServerRequest properly for this, but managed to get it working by editing the DataGroup object, let me know if this approach looks okay. 
  - **Updates 4/24**
     - updated code in AsyncTapQuery per @loitly's suggestions 
     - if you upload table/load table, or do a click to action whole table search, the selected columns by default will only be the same as position columns 
        - and if user changes position columns, any of these changes will be reflected by being selected in the columns (and therefore, also in the ADQL) 
     - confirmed table filtering works
     - confirmed **dg.removeDataDefinition** works as expected 
     - the small bug with selecting some columns but them still not being selected when you click "OK" is now fixed 
     - checked with backend team, IRSA does expect ra and dec in lowercase. So we can discuss how to (or if) resolve that if we receive ra/dec values that are capitalized. Either here or in the new ticket to fix the VO Tables <description> tag place: https://jira.ipac.caltech.edu/browse/FIREFLY-1228 

Testing: https://fireflydev.ipac.caltech.edu/firefly-1212-adql/firefly
- select CADC as the TAP service, search for m1
- from the resulting table, do a click to action whole table search (or load the table directly from the TAP panel using the multi object upload dialog)
- search again using this table *without* editing the column selection
  - you will probably get an error that reads something like "Column [dataproduct_type] is ambiguous." 
- now go back to the TAP panel and edit the column selection. Unselect all columns, then select only a few (say, "s_ra" and "s_dec")
   - now if you search again, it should not fail and you should get back a table (as the upload table only includes the columns you selected - and no bad columns (in this case, the **dataproduct_type** column - and possibly some other columns as well)
   - before this fix, if the table included a bad column such as **dataproduct_type** and you did a search even after unselecting this column, your search would still fail (since we upload the whole table anyway). this should now be fixed. 

**Updates for Testing 4/24**
- test build is updated
- change position columns (whatever you change it too, should be added as selected in the columns) 
- try selecting table from Loaded Tables dialog (from multi-object) and from click to action's whole table search. Also try uploading a table from the multi-object dialog. In all 3 cases, ensure that the columns selected by default are only the position columns 