### PR TITLE
Firefly-1228: fix position of desc tag when writing to VOTable

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
@@ -114,6 +114,29 @@ public class VoTableWriter {
             return isEmpty(descVal) ? "" : "<"+tagDesc+">" + descVal + "</"+tagDesc+">";
         }
 
+        private String xmlTABLE() {
+            long nrow = dataGroup.size();
+            String tname = dataGroup.getTableMeta().getAttribute(TableMeta.NAME);
+            String res = "<TABLE";
+            String ucd = dataGroup.getTableMeta().getAttribute(TableMeta.UCD);
+            String utype = dataGroup.getTableMeta().getAttribute(TableMeta.UTYPE);
+
+            if (!StringUtils.isEmpty(tname)) {
+                res += VOSerializer.formatAttribute(TableMeta.NAME, tname.trim());
+            }
+            if (nrow > 0) {
+                res += VOSerializer.formatAttribute("nrows", Long.toString(nrow));
+            }
+            if (ucd != null) {
+                res += VOSerializer.formatAttribute(TableMeta.UCD, ucd);
+            }
+            if (utype != null) {
+                res += VOSerializer.formatAttribute(TableMeta.UTYPE, utype);
+            }
+            res += ">";
+            return res;
+        }
+
         private String xmlLINK(LinkInfo link) {
             List<String> atts = new ArrayList<>();
 
@@ -346,12 +369,12 @@ public class VoTableWriter {
 
                 VOSerializer serializer = VOSerializer.makeSerializer( getDataFormat(), getVotableVersion(), startab );
 
-                /* Begin TABLE element including FIELDs etc. */
-                serializer.writePreDataXML( writer );
-
                 /* Now add our additional info */
-                DataGroupXML dgXML = new DataGroupXML( dataGroup);
+                DataGroupXML dgXML = new DataGroupXML(dataGroup);
+                //note: in accordance with the IVOA standard for VOTable, the order of the tags below needs to be maintained
+                outputElement(writer, dgXML.xmlTABLE());     // TABLE tag
                 outputElement(writer, dgXML.xmlDESCRIPTION());     // DESCRIPTION tag
+                serializer.writeFields(writer);     // FIELDS tags
                 outputElement(writer, dgXML.xmlGROUPs(dataGroup.getGroupInfos()));          // GROUP
                 outputElement(writer, dgXML.xmlPARAMs(dataGroup.getParamInfos())); // PARAM
                 outputElement(writer, dgXML.xmlLINKs(dataGroup.getLinkInfos()));


### PR DESCRIPTION
#### [Firefly-1228](https://jira.ipac.caltech.edu/browse/FIREFLY-1228)
- We were writing` <DESCRIPTION> `after `<FIELD>` tags, but as per IVOA convention for VO tables, `<DESCRIPTION>` needs to come before `<FIELD>` tags (see: https://ivoa.net/documents/VOTable/20191021/REC-VOTable-1.4-20191021.html#ToC46) 
- I wanted to make sure I got this right, and it looks correct, but since this is something that could potentially break searches, let me know if anything looks off, I suggest looking at the temp file created as well (I tested it plenty - but could still use feedback)  
- Code explanation: 
   - earlier, we were calling VOSerializer's writePreDataXML
   - writePreDataXML attempts to write the `<TABLE>, <DESCRIPTION> and <PARAMS> and <FIELD>` tags. But for some reason, it did not get and hence did not write the description tag. 
   - I wrote a helper function called xmlTABLE in the DataGroupXML class. This function writes *only* the `<TABLE>` tag. VoSerializer apparently does not have a function that only does this. I tried to follow exactly what writePreDataXML does, except for writing the additional tags here after the `<TABLE>` tag. 
     - Note: I even looked for UCD, UTYPE attributes (in case they exist) here. 
     - for the "nrow" attribute, I got it from dataGroup.size(). Would this work reliably in every case? 

Testing: 
- https://fireflydev.ipac.caltech.edu/firefly-1228-vo-descriptoin-tag/firefly
  - I've laid out 2 example searches. The first one generally doesn't include a `<DESCRIPTION>` tag in the resulting VOTable file. The second one does. 
  1. select NED as TAP service. Search for m1. Do a click to action whole table search on the resulting table, select CADC as TAP service and search on this table. This should work. If you look at the temp file, for this example - it shouldn't even have a description tag, just ensure the search works. 
  2. from the m1 search above in NED, on the resulting HIPS image: do a cone selection (of, say, 100 arcseconds). From the click to action (binocular icon) here, click on "Search (cone) using NED" option. Now, on the resulting table, do a click to action whole table search again. 
       - on TAP, select CADC. And search against this table resulting from the cone search. Ensure the search works. If you look at the temp file, the order of `<TABLE>, <DESCRIPTION> and <FIELD>` tags should look correct. 
- Before the fix, the second search above would fail for CADC (because of the position of the `<DESCRIPTION>` tag. The first would still be working because there was no `<DESCRIPTION>` tag). In fact, the second search will still fail if you try the search with IRSA (this is the capital RA and DEC parsing issue). 
- If you run this code locally, in order to look at the temp file (should be in your `dev/server/tomcat/workarea/firefly/temp_files` path), you can add a breakpoint at line 73 of AsyncTapQuery.java. Here you should be able to see the "tempXML" file location/name directly as well. 