### PR TITLE
Firefly-1229: Clean up and fix bug related to Rubin

### DIFF
--- a/docs/older-release-notes-2022.md
+++ b/docs/older-release-notes-2022.md
@@ -1,0 +1,164 @@
+# Firefly older Release Notes - 2022
+
+
+
+## Version 2022.3
+- 2022.3.2 (March 2023)
+  - docker tag: `2022.3`, `2022.3.2`
+- 2022.3.1 (Jan 2023)
+  - docker tag: `2022.3`, `2022.3.1`
+- 2022.3.0 - (Dec 2022)
+  - docker tag: `2022.3.0`
+
+### _Notes_
+#### This release some significant new features and code clean up
+
+#### New Features
+- Spectral Charts support combining spectra [Firefly-1041](https://github.com/Caltech-IPAC/firefly/pull/1274)
+- Click to Search: [Firefly-1086](https://github.com/Caltech-IPAC/firefly/pull/1275)
+- Derived columns in tables: [Firefly-1042](https://github.com/Caltech-IPAC/firefly/pull/1283)
+
+#### UI Enhancements
+- Improvements to extraction: [Firefly-1060](https://github.com/Caltech-IPAC/firefly/pull/1280)
+- Improved MOC uploading: [Firefly-1124](https://github.com/Caltech-IPAC/firefly/pull/1294)
+- Datalink driven searchform: [Firefly-993](https://github.com/Caltech-IPAC/firefly/pull/1298)
+- Improving chart/table pinning: [Firefly-1024](https://github.com/Caltech-IPAC/firefly/pull/1299)
+- Improved mask layer UI: [Firefly-1033](https://github.com/Caltech-IPAC/firefly/pull/1304)
+- TAP panel stability and features: [Firefly-1115](https://github.com/Caltech-IPAC/firefly/pull/1286)
+
+#### Infrastructure Enhancements
+- Plot.ly updated to 2.18.0 [Firefly-1079](https://github.com/Caltech-IPAC/firefly/pull/1272)
+- Improved status page with version [Firefly-1116](https://github.com/Caltech-IPAC/firefly/pull/1295)
+
+##### _Patches 2022.3_
+- 2022.3.1
+  - fixed an undefined exception when SearchActions are empty
+- 2022.3.2
+  - Updates for neowise year 9 release [PR](https://github.com/Caltech-IPAC/firefly/pull/1329)
+  - fixed: in certain cases multi-product view navigation not working when non-dataproduct tables are showing [Firefly-1182](https://github.com/Caltech-IPAC/firefly/pull/1329)
+
+##### _Pull Requests in this release_
+- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2022.3+label%3abug)
+- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2022.3+)
+
+
+## Version 2022.2
+- 2022.2.6 (Dec 2022)
+  - docker tag: `2022.2`, `2022.2.6`
+- 2022.2.5 (Oct 2022)
+  - docker tag: `2022.2.5`
+- 2022.2.4 (Sept 2022)
+  - docker tag: `2022.2.4`
+- 2022.2.3 (Sept 2022)
+  - docker tag: `2022.2.3`
+- 2022.2.2 (Aug 2022)
+  - docker tag: `2022.2.2`
+- 2022.2.1 (July 2022)
+  - docker tag: `2022.2.1`
+- 2022.2 - (July 2022)
+  - docker tag: `2022.2.0`
+
+### _Notes_
+#### This release has notable UI, Infrastructure, and  API enhancements
+
+#### UI Enhancements
+- Charts support multiple charts from different tables [Firefly-994](https://github.com/Caltech-IPAC/firefly/pull/1229)
+- Aitoff HiPS [Firefly-978](https://github.com/Caltech-IPAC/firefly/pull/1207)
+- Improved dynamic field generation in service descriptors [Firefly-997](https://github.com/Caltech-IPAC/firefly/pull/1226)
+- Support HiPs based target selection [Firefly-980](https://github.com/Caltech-IPAC/firefly/pull/1227)
+- Filters are on for all search tables [Firefly-971](https://github.com/Caltech-IPAC/firefly/pull/1213)
+- Improved large table loading performance [Firefly-978](https://github.com/Caltech-IPAC/firefly/pull/1206)
+
+#### API Enhancements
+- API: Add the capability to a create persistent resource from a table request [Firefly-982](https://github.com/Caltech-IPAC/firefly/pull/1214)
+
+#### Infrastructure Enhancements
+- Docker support passing firefly client options on startup [Firefly-885](https://github.com/Caltech-IPAC/firefly/pull/1227)
+- Improved passing properties to docker [Firefly-996](https://github.com/Caltech-IPAC/firefly/pull/1225)
+- Improved status page [Firefly-992](https://github.com/Caltech-IPAC/firefly/pull/1218)
+
+#### Notable Bug fixes
+- Fixed: WAVE_TAB: The algorithm is producing incorrect results [Firefly-989](https://github.com/Caltech-IPAC/firefly/pull/1224)
+- Multiple table related bugs
+
+
+##### _Patches 2022.2_
+- 2022.2.1
+  - Added IPAC Logo to version dialog ([Firefly-1037](https://github.com/Caltech-IPAC/firefly/pull/1225))
+  - Stretch dropdown shows checkbox if stretch selected ([Firefly-1029](https://github.com/Caltech-IPAC/firefly/pull/1225))
+  - Fixed: TAP column table showing filters (Firefly-1036, [PR](https://github.com/Caltech-IPAC/firefly/pull/1244))
+  - Fixed: Cube planes all change stretch ([Firefly-1038](https://github.com/Caltech-IPAC/firefly/pull/1225))
+- 2022.2.2
+  - Chart functions: now support `radians()` and `degrees()` ([Firefly-1047](https://github.com/Caltech-IPAC/firefly/pull/1254))
+  - Fixed: Table: Filter by selected row returned more than it should ([Firefly-1049](https://github.com/Caltech-IPAC/firefly/pull/1250))
+  - Multiple issues: ([Firefly-1045](https://github.com/Caltech-IPAC/firefly/pull/1248))
+    - Fixed: Expanding/restoring an image in MultiProductViewer causes reload: stretch and color are reset
+    - Fixed: draw layer panel is hidden at times (zIndex was not correct)
+    - Fixed: on resize or when popping up mouse readout: display wrongly zoomed to fit
+    - Fixed: Moc validation was not accepting a valid FITs TFORM header
+    - Fixed: Better support for authorization in URLDownload.java
+    - Fixed: Expose MOC in Target Hips Panel
+    - Fixed: TAP search api did not init table correctly, some bugs in the examples
+    - Stretch should be sticky: on MultiProductViewer, for multi HDU images, if the same extension type
+- 2022.2.3
+  - Fixed: Naif resolver too many results ([Firefly-1065](https://github.com/Caltech-IPAC/firefly/pull/1264))
+  - Fixed: Rendering of service-descriptor-based searches on TAP results (Rubin) ([Firefly-1066](https://github.com/Caltech-IPAC/firefly/pull/1263))
+  - Fixed: Navigation icons sometimes do not show up in IRSA apps ([IRSA-4769](https://github.com/Caltech-IPAC/firefly/pull/1263))
+  - Improved: Recognize a "flux" column with charts in DataProduct Viewer ([Firefly-1068](https://github.com/Caltech-IPAC/firefly/pull/1265))
+- 2022.2.4
+  - Improved: Grouping in multi-product viewer is not per table ([IRSA-4815](https://github.com/Caltech-IPAC/firefly/pull/1270))
+  - Fixed: tap date selection feedback not updating ([Firefly-1075](https://github.com/Caltech-IPAC/firefly/pull/1271))
+  - Fixed: regression issue, pixel readout re-enabled for images ([DM-36291](https://jira.lsstcorp.org/browse/DM-36291))
+- 2022.2.5
+  - Fixed: null pointer exception in `BaseIUbeDataSource.java`
+- 2022.2.6
+  - Fixed: some service descriptors without a `standardID` would not load correctly
+
+
+
+##### _Pull Requests in this release_
+- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2022.2+label%3abug)
+- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2022.2+)
+
+
+## Version 2022.1
+- 2022.1.1 (April 2022)
+  - docker tag: `latest`, `2022.1`, `2022.1.1`
+- 2022.1.0 (March 2022)
+  - docker tag: `2022.1.0`
+
+### _Notes_
+#### This release is focused on small enhancements, fixing bugs, and updating infrastructure. There are no new UI changes in this release.
+
+#### Enhancements
+- API: provide way to disable extraction [Firefly-907](https://github.com/Caltech-IPAC/firefly/pull/1175)
+- Extraction no longer turns off when new images are added [Firefly-908](https://github.com/Caltech-IPAC/firefly/pull/1174)
+- More image dataset added [IRSA-4468](https://github.com/Caltech-IPAC/firefly/pull/1191)
+- FITS and HiPS info dialogs better integrated [Firefly-323](https://github.com/Caltech-IPAC/firefly/pull/1185)
+- TAP: Automatic quoting of non-standard TAP columns, especially helpful when searching VizieR [Firefly-935](https://github.com/Caltech-IPAC/firefly/pull/1182)
+- Tables: Turn on units by default; raise category-column threshold [Firefly-969, Firefly-970](https://github.com/Caltech-IPAC/firefly/pull/1201)
+
+#### Notable Bug fixes
+- Fixed: Some TAP entries truncated [Firefly-719](https://github.com/Caltech-IPAC/firefly/pull/1178)
+- Fixed: repeating headers are not showing [Firefly-926](https://github.com/Caltech-IPAC/firefly/pull/1173)
+- Fixed: Saving filtered tables [Firefly-931](https://github.com/Caltech-IPAC/firefly/pull/1180)
+- Fixed: occasionally images get stuck a loading state  [Firefly-933](https://github.com/Caltech-IPAC/firefly/pull/1202)
+
+#### Infrastructure updates
+- Java updated to v `17`  [Firefly-932](https://github.com/Caltech-IPAC/firefly/pull/1192)
+- log2j updated to `2.17.1` [Firefly-933](https://github.com/Caltech-IPAC/firefly/pull/1188)
+- Most javascript libraries updated [Firefly-917](https://github.com/Caltech-IPAC/firefly/pull/1166)
+- _Build_: Gradle updated to `7.4` [Firefly-932](https://github.com/Caltech-IPAC/firefly/pull/1192)
+- _Build_: Webpack updated to `5.6`, build now required node `12+` [Firefly-917](https://github.com/Caltech-IPAC/firefly/pull/1166)
+- _Build_: Improved docker environment [Firefly-924](https://github.com/Caltech-IPAC/firefly/pull/1166)
+
+
+##### _Pull Requests in this release_
+- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2022.1+label%3abug)
+- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2022.1+)
+
+##### _Patches 2022.1_
+- 2022.1.1
+  - Fixed: Not packaging proprietary data correctly ([IRSA-4570,IRSA-4571](https://github.com/Caltech-IPAC/firefly/pull/1209))
+     
+

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,12 +6,7 @@
   - use docker tag: `nightly`
   - [Notes on next version](next-release-details.md)
 
-
-## Version 2022.3 
-- 2022.3.2 (March 2023)
-  - docker tag: `2022.3`, `2022.3.2`
-- 2022.3.1 (Jan 2023)
-  - docker tag: `2022.3`, `2022.3.1`
+## Version 2023.1
 - 2022.3.0 - (Dec 2022)
   - docker tag: `latest`, `2022.3`, `2022.3.0`
 
@@ -19,155 +14,24 @@
 #### This release some significant new features and code clean up
 
 #### New Features
-- Spectral Charts support combining spectra [Firefly-1041](https://github.com/Caltech-IPAC/firefly/pull/1274)
-- Click to Search: [Firefly-1086](https://github.com/Caltech-IPAC/firefly/pull/1275)
-- Derived columns in tables: [Firefly-1042](https://github.com/Caltech-IPAC/firefly/pull/1283)
-
-#### UI Enhancements
-- Improvements to extraction: [Firefly-1060](https://github.com/Caltech-IPAC/firefly/pull/1280)
-- Improved MOC uploading: [Firefly-1124](https://github.com/Caltech-IPAC/firefly/pull/1294)
-- Datalink driven searchform: [Firefly-993](https://github.com/Caltech-IPAC/firefly/pull/1298) 
-- Improving chart/table pinning: [Firefly-1024](https://github.com/Caltech-IPAC/firefly/pull/1299) 
-- Improved mask layer UI: [Firefly-1033](https://github.com/Caltech-IPAC/firefly/pull/1304) 
-- TAP panel stability and features: [Firefly-1115](https://github.com/Caltech-IPAC/firefly/pull/1286) 
-
-#### Infrastructure Enhancements
-- Plot.ly updated to 2.18.0 [Firefly-1079](https://github.com/Caltech-IPAC/firefly/pull/1272)
-- Improved status page with version [Firefly-1116](https://github.com/Caltech-IPAC/firefly/pull/1295)
-
-##### _Patches 2022.3_
-- 2022.3.1
-  - fixed an undefined exception when SearchActions are empty
-- 2022.3.2
-  - Updates for neowise year 9 release [PR](https://github.com/Caltech-IPAC/firefly/pull/1329)
-  - fixed: in certain cases multi-product view navigation not working when non-dataproduct tables are showing [Firefly-1182](https://github.com/Caltech-IPAC/firefly/pull/1329)
+- TAP Upload: [Firefly-1142](https://github.com/Caltech-IPAC/firefly/pull/1317), [Firefly-1148](https://github.com/Caltech-IPAC/firefly/pull/1331), [Firefly-1189](https://github.com/Caltech-IPAC/firefly/pull/1340)
+- Improve TAP UI: [Firefly-1215](https://github.com/Caltech-IPAC/firefly/pull/1354)
+- Improved Click to search UI:  [Firefly-1152](https://github.com/Caltech-IPAC/firefly/pull/1326)
+- Improved Derived columns UI:  [Firefly-1153](https://github.com/Caltech-IPAC/firefly/pull/1330)
+- Improved Charting and Spectral UI layout: [Firefly-1183](https://github.com/Caltech-IPAC/firefly/pull/1348)
+- Improve 3-color selection: [Firefly-1134](https://github.com/Caltech-IPAC/firefly/pull/1310)
+- UCS support: [Firefly-1128](https://github.com/Caltech-IPAC/firefly/pull/1308), [Firefly-1129](https://github.com/Caltech-IPAC/firefly/pull/1319)
+- Faster image loading: [Firefly-1190](https://github.com/Caltech-IPAC/firefly/pull/1338)
+- Table of loaded image available in pinned image section: [Firefly-1081](https://github.com/Caltech-IPAC/firefly/pull/1344)
+- Obscore table packaging: [Firefly-1193](https://github.com/Caltech-IPAC/firefly/pull/1351)
+- Embedded spacial search UI in Hips: [Firefly-1177](https://github.com/Caltech-IPAC/firefly/pull/1328) 
 
 ##### _Pull Requests in this release_
-- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2022.3+label%3abug)
-- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2022.3+)
-
-
-## Version 2022.2 
-- 2022.2.6 (Dec 2022)
-  - docker tag: `2022.2`, `2022.2.6`
-- 2022.2.5 (Oct 2022)
-  - docker tag: `2022.2.5`
-- 2022.2.4 (Sept 2022)
-  - docker tag: `2022.2.4`
-- 2022.2.3 (Sept 2022)
-  - docker tag: `2022.2.3`
-- 2022.2.2 (Aug 2022)
-  - docker tag: `2022.2.2`
-- 2022.2.1 (July 2022)
-  - docker tag: `2022.2.1`
-- 2022.2 - (July 2022)
-  - docker tag: `2022.2.0`
-
-### _Notes_
-#### This release has notable UI, Infrastructure, and  API enhancements
-
-#### UI Enhancements
-- Charts support multiple charts from different tables [Firefly-994](https://github.com/Caltech-IPAC/firefly/pull/1229)
-- Aitoff HiPS [Firefly-978](https://github.com/Caltech-IPAC/firefly/pull/1207)
-- Improved dynamic field generation in service descriptors [Firefly-997](https://github.com/Caltech-IPAC/firefly/pull/1226)
-- Support HiPs based target selection [Firefly-980](https://github.com/Caltech-IPAC/firefly/pull/1227)
-- Filters are on for all search tables [Firefly-971](https://github.com/Caltech-IPAC/firefly/pull/1213)
-- Improved large table loading performance [Firefly-978](https://github.com/Caltech-IPAC/firefly/pull/1206)
-
-#### API Enhancements
-- API: Add the capability to a create persistent resource from a table request [Firefly-982](https://github.com/Caltech-IPAC/firefly/pull/1214)
-
-#### Infrastructure Enhancements
-- Docker support passing firefly client options on startup [Firefly-885](https://github.com/Caltech-IPAC/firefly/pull/1227)
-- Improved passing properties to docker [Firefly-996](https://github.com/Caltech-IPAC/firefly/pull/1225)
-- Improved status page [Firefly-992](https://github.com/Caltech-IPAC/firefly/pull/1218)
-
-#### Notable Bug fixes
-- Fixed: WAVE_TAB: The algorithm is producing incorrect results [Firefly-989](https://github.com/Caltech-IPAC/firefly/pull/1224)
-- Multiple table related bugs
-
-
-##### _Patches 2022.2_
-- 2022.2.1
-  - Added IPAC Logo to version dialog ([Firefly-1037](https://github.com/Caltech-IPAC/firefly/pull/1225))
-  - Stretch dropdown shows checkbox if stretch selected ([Firefly-1029](https://github.com/Caltech-IPAC/firefly/pull/1225))
-  - Fixed: TAP column table showing filters (Firefly-1036, [PR](https://github.com/Caltech-IPAC/firefly/pull/1244))
-  - Fixed: Cube planes all change stretch ([Firefly-1038](https://github.com/Caltech-IPAC/firefly/pull/1225))
-- 2022.2.2
-  - Chart functions: now support `radians()` and `degrees()` ([Firefly-1047](https://github.com/Caltech-IPAC/firefly/pull/1254))
-  - Fixed: Table: Filter by selected row returned more than it should ([Firefly-1049](https://github.com/Caltech-IPAC/firefly/pull/1250))
-  - Multiple issues: ([Firefly-1045](https://github.com/Caltech-IPAC/firefly/pull/1248))
-    - Fixed: Expanding/restoring an image in MultiProductViewer causes reload: stretch and color are reset
-    - Fixed: draw layer panel is hidden at times (zIndex was not correct)
-    - Fixed: on resize or when popping up mouse readout: display wrongly zoomed to fit 
-    - Fixed: Moc validation was not accepting a valid FITs TFORM header
-    - Fixed: Better support for authorization in URLDownload.java
-    - Fixed: Expose MOC in Target Hips Panel
-    - Fixed: TAP search api did not init table correctly, some bugs in the examples
-    - Stretch should be sticky: on MultiProductViewer, for multi HDU images, if the same extension type
-- 2022.2.3
-  - Fixed: Naif resolver too many results ([Firefly-1065](https://github.com/Caltech-IPAC/firefly/pull/1264))
-  - Fixed: Rendering of service-descriptor-based searches on TAP results (Rubin) ([Firefly-1066](https://github.com/Caltech-IPAC/firefly/pull/1263))
-  - Fixed: Navigation icons sometimes do not show up in IRSA apps ([IRSA-4769](https://github.com/Caltech-IPAC/firefly/pull/1263))
-  - Improved: Recognize a "flux" column with charts in DataProduct Viewer ([Firefly-1068](https://github.com/Caltech-IPAC/firefly/pull/1265))
-- 2022.2.4
-  - Improved: Grouping in multi-product viewer is not per table ([IRSA-4815](https://github.com/Caltech-IPAC/firefly/pull/1270))
-  - Fixed: tap date selection feedback not updating ([Firefly-1075](https://github.com/Caltech-IPAC/firefly/pull/1271))
-  - Fixed: regression issue, pixel readout re-enabled for images ([DM-36291](https://jira.lsstcorp.org/browse/DM-36291))
-- 2022.2.5
-  - Fixed: null pointer exception in `BaseIUbeDataSource.java`
-- 2022.2.6
-  - Fixed: some service descriptors without a `standardID` would not load correctly
+- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2023.1+label%3abug)
+- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2023.1+)
 
 
 
-##### _Pull Requests in this release_
-- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2022.2+label%3abug)
-- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2022.2+)
-
-
-## Version 2022.1
-- 2022.1.1 (April 2022)
-  - docker tag: `latest`, `2022.1`, `2022.1.1`
-- 2022.1.0 (March 2022)
-  - docker tag: `2022.1.0`
-
-### _Notes_
-#### This release is focused on small enhancements, fixing bugs, and updating infrastructure. There are no new UI changes in this release.
-
-#### Enhancements
-- API: provide way to disable extraction [Firefly-907](https://github.com/Caltech-IPAC/firefly/pull/1175)
-- Extraction no longer turns off when new images are added [Firefly-908](https://github.com/Caltech-IPAC/firefly/pull/1174)
-- More image dataset added [IRSA-4468](https://github.com/Caltech-IPAC/firefly/pull/1191)
-- FITS and HiPS info dialogs better integrated [Firefly-323](https://github.com/Caltech-IPAC/firefly/pull/1185)
-- TAP: Automatic quoting of non-standard TAP columns, especially helpful when searching VizieR [Firefly-935](https://github.com/Caltech-IPAC/firefly/pull/1182)
-- Tables: Turn on units by default; raise category-column threshold [Firefly-969, Firefly-970](https://github.com/Caltech-IPAC/firefly/pull/1201)
-
-#### Notable Bug fixes
-- Fixed: Some TAP entries truncated [Firefly-719](https://github.com/Caltech-IPAC/firefly/pull/1178)
-- Fixed: repeating headers are not showing [Firefly-926](https://github.com/Caltech-IPAC/firefly/pull/1173)
-- Fixed: Saving filtered tables [Firefly-931](https://github.com/Caltech-IPAC/firefly/pull/1180)
-- Fixed: occasionally images get stuck a loading state  [Firefly-933](https://github.com/Caltech-IPAC/firefly/pull/1202)
-  
-#### Infrastructure updates
-- Java updated to v `17`  [Firefly-932](https://github.com/Caltech-IPAC/firefly/pull/1192)
-- log2j updated to `2.17.1` [Firefly-933](https://github.com/Caltech-IPAC/firefly/pull/1188)
-- Most javascript libraries updated [Firefly-917](https://github.com/Caltech-IPAC/firefly/pull/1166)
-- _Build_: Gradle updated to `7.4` [Firefly-932](https://github.com/Caltech-IPAC/firefly/pull/1192)
-- _Build_: Webpack updated to `5.6`, build now required node `12+` [Firefly-917](https://github.com/Caltech-IPAC/firefly/pull/1166)
-- _Build_: Improved docker environment [Firefly-924](https://github.com/Caltech-IPAC/firefly/pull/1166)
-
-
-##### _Pull Requests in this release_
-- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2022.1+label%3abug)
-- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2022.1+)
-
-##### _Patches 2022.1_
-- 2022.1.1
-  - Fixed: Not packaging proprietary data correctly ([IRSA-4570,IRSA-4571](https://github.com/Caltech-IPAC/firefly/pull/1209))
-     
-
-
-# Older Releases 2019 - 2021
-
+# Older Releases 2019 - 2022
+See [Older release notes 2022](older-release-notes-2022.md)
 See [Older release notes 2019-2021](older-release-notes-2019-2021.md)

--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -257,6 +257,10 @@ div.rootStyle img {
     align-items: center;
 }
 
+.ComponentBackground {
+    background-color: #c8c8c8;
+}
+
 .PanelToolbar__button {
     width: 24px;
     height: 24px;

--- a/src/firefly/html/firefly-dev.html
+++ b/src/firefly/html/firefly-dev.html
@@ -58,6 +58,8 @@
                     defaultColorTable : 5
                 },
                 tapObsCore: {
+                    productTitleTemplate: '${obs_collection}-${instrument_name}: ${obs_id}',
+                    enableObsCoreDownload: true,
                     filterDefinitions: [
                         {
                             name: 'LSSTCam',

--- a/src/firefly/java/edu/caltech/ipac/table/io/SpectrumMetaInspector.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/SpectrumMetaInspector.java
@@ -75,12 +75,18 @@ class SpectrumMetaInspector {
         String utype;
         if (hdu!=null) {
             Header h= hdu.getHeader();
-            utype= FitsReadUtil.getUtype(h);
             String voclass= h.getStringValue(VOCLASS);
             if (voclass==null) voclass= "";
+            utype= FitsReadUtil.getUtype(h);
             if (utype==null && !spectrumHint &&
                     !voclass.equals(spec10Version) &&
-                    !voclass.toLowerCase().startsWith("spectrum") ) return;
+                    !voclass.toLowerCase().startsWith("spectrum") ) {
+                utype= SPEC_SPECTRUM;
+            }
+            if (utype!=null) {
+                dg.getTableMeta().addKeyword(TableMeta.UTYPE,utype);
+                return;
+            }
         }
         else {
             utype= dg.getAttribute(TableMeta.UTYPE);

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -85,6 +86,8 @@ public class URLDownload {
         if (conn==null) return -1;
         try {
             return (conn instanceof HttpURLConnection) ? ((HttpURLConnection)conn).getResponseCode() : 200;
+        } catch (SocketTimeoutException e) {
+            return 408;
         } catch (IOException e) {
             return -1;
         }
@@ -338,6 +341,9 @@ public class URLDownload {
                     if (ops.onlyIfModified) {
                         outFileData = checkAlreadyDownloaded(conn, outfile);
                         if (outFileData != null) return outFileData;
+                        if (getResponseCode(conn)==408) {
+                            throw new FailedRequestException("Timeout", "Timeout", 408);
+                        }
                     }
                 }
                 else if (postData!=null) {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -163,6 +163,9 @@ const defFireflyOptions = {
         defaultColorTable: 1,
         canCreateExtractionTable: false,
     },
+    tapObsCore: {
+        enableObsCoreDownload: true,
+    },
     coverage : {
         // TODO: need to define all options with defaults here.  used in FFEntryPoint.js
     },

--- a/src/firefly/js/fieldGroup/FieldGroupUtils.js
+++ b/src/firefly/js/fieldGroup/FieldGroupUtils.js
@@ -167,8 +167,10 @@ export function setField(groupKey,fieldKey,fieldUpdates) {
     if (!fieldUpdates) return;
     const cField= getField(groupKey,fieldKey) ?? {};
     if (!fieldUpdates) return;
-    const originObj= pick(cField,Object.keys(fieldUpdates));
-    if (shallowequal(originObj,fieldUpdates)) return;
+
+    const forComparison= {displayValue:'',...fieldUpdates};
+    const originObj= pick({displayValue:'',...cField},Object.keys(forComparison));
+    if (shallowequal(originObj,forComparison)) return;
     dispatchValueChange({...cField, ...fieldUpdates, groupKey, fieldKey});
 }
 

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -10,9 +10,13 @@ import {pickBy} from 'lodash';
 import {flux} from '../../core/ReduxFlux.js';
 import {
     getMenu, isAppReady, dispatchSetMenu,
-    dispatchOnAppReady, dispatchNotifyRemoteAppReady, getAppOptions
+    dispatchOnAppReady, dispatchNotifyRemoteAppReady, getAppOptions,
 } from '../../core/AppDataCntlr.js';
 import {LO_VIEW, getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
+import {getActiveRowCenterDef} from '../../visualize/saga/ActiveRowCenterWatcher.js';
+import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
+import {getMocWatcherDef} from '../../visualize/saga/MOCWatcher.js';
+import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
 import {layoutManager} from './FireflyViewerManager.js';
 import {Menu} from '../../ui/Menu.jsx';
 import {Banner} from '../../ui/Banner.jsx';
@@ -26,7 +30,7 @@ import {getWorkspaceConfig, initWorkspace} from '../../visualize/WorkspaceCntlr.
 import {warningDivId} from '../../ui/LostConnection.jsx';
 
 import FFTOOLS_ICO from 'html/images/fftools-logo-offset-small-42x42.png';
-import {getAllStartIds, startTTFeatureWatchers} from '../common/ttFeatureWatchers';
+import {getAllStartIds, getObsCoreWatcherDef, startTTFeatureWatchers} from '../common/ttFeatureWatchers';
 
 /**
  * This FireflyViewer is a generic application with some configurable behaviors.
@@ -51,6 +55,15 @@ export class FireflyViewer extends PureComponent {
         const views = LO_VIEW.get(props.views) || LO_VIEW.none;
         this.state = this.getNextState();
         startTTFeatureWatchers(getAllStartIds());
+        startTTFeatureWatchers(
+            [
+                getMocWatcherDef().id,
+                getCatalogWatcherDef().id,
+                getUrlLinkWatcherDef().id,
+                getActiveRowCenterDef().id,
+                getAppOptions().enableObsCoreDownload && getObsCoreWatcherDef().id,
+            ]
+        );
         if (views.has(LO_VIEW.images) ) startImagesLayoutWatcher();
         dispatchAddSaga(layoutManager,{views: props.views});
         if (getWorkspaceConfig()) { initWorkspace(); }

--- a/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
+++ b/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
@@ -25,8 +25,9 @@ import {pointEquals} from '../../visualize/Point.js';
 import {isHiPS} from '../../visualize/WebPlot.js';
 import {UserZoomTypes} from '../../visualize/ZoomUtil.js';
 import {confirmDLMenuItem} from './FetchDatalinkTable.js';
-import { ingestInitArgs,
-    isSIAStandardID, makeFieldDefs, makeSearchAreaInfo, makeServiceDescriptorSearchRequest
+import {
+    getStandardIdType, ingestInitArgs,
+    makeFieldDefs, makeSearchAreaInfo, makeServiceDescriptorSearchRequest
 } from './ServiceDefTools.js';
 import {convertRequest, DynLayoutPanelTypes, findTargetFromRequest} from './DynamicUISearchPanel.jsx';
 import {CIRCLE, POSITION, RANGE} from './DynamicDef.js';
@@ -510,7 +511,7 @@ function DLGeneratedTableSearch({currentTblId, initArgs, sideBar, regHasUrl, url
 
     const submitSearch= (r) => {
         const {fds, standardID, idx}= findFieldDefInfo(r);
-        const convertedR= convertRequest(r,fds,isSIAStandardID(standardID));
+        const convertedR= convertRequest(r,fds,getStandardIdType(standardID));
 
         const numKeys= [...new Set(fds.map( ({key}) => key))].length;
         if (Object.keys(convertedR).length<numKeys) {

--- a/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
+++ b/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
@@ -4,10 +4,15 @@
 
 import {arrayOf, func, object, string} from 'prop-types';
 import React, {memo} from 'react';
+import {getAppOptions} from '../../core/AppDataCntlr.js';
+import {parseObsCoreRegion} from '../../util/ObsCoreSRegionParser.js';
+import {computeCentralPtRadiusAverage} from '../../visualize/VisUtil.js';
 import CompleteButton from '../CompleteButton.jsx';
-import {convertRequest, DynamicFieldGroupPanel, DynLayoutPanelTypes} from './DynamicUISearchPanel.jsx';
+import {FieldGroup} from '../FieldGroup.jsx';
+import {convertRequest, DynLayoutPanelTypes} from './DynamicUISearchPanel.jsx';
 import {showInfoPopup} from '../PopupUtil.jsx';
-import {isSIAStandardID, makeFieldDefs} from './ServiceDefTools.js';
+import {getStandardIdType, hasAnySpacial, makeFieldDefs} from './ServiceDefTools.js';
+import ShapeDataObj from '../../visualize/draw/ShapeDataObj.js';
 
 /**
  * @typedef {Object} SearchAreaInfo
@@ -17,39 +22,74 @@ import {isSIAStandardID, makeFieldDefs} from './ServiceDefTools.js';
  * @prop {String} mocDesc
  * @prop {String} HiPS
  * @prop {String} hips_initial_fov
+ * @prop {String} standardID
  * @prop {WorldPt} centerWp
  * @prop {CoordinateSys} coordinateSys
  */
 
 const GROUP_KEY= 'ActivateMenu';
 
-const titleStyle= {width: '100%', textAlign:'center', padding:'10px 0 5px 0', fontSize:'larger', fontWeight:'bold'};
+const titleStyle= {textAlign:'center', padding:'0 0 0 50px', fontSize:'larger', fontWeight:'bold'};
 
 
 export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDefParams, setSearchParams,
-                                               title, makeDropDown, sRegion,
+                                               title, makeDropDown, sRegion, standardID,
                                                plotId= 'defaultHiPSTargetSearch'}) => {
 
-    const fieldDefAry= makeFieldDefs(serDefParams, sRegion, undefined, true);
+    const {valid,drawObj}= parseObsCoreRegion(sRegion) ?? {valid:false};
+    let fovSize;
+    if (valid) {
+        const wp= ShapeDataObj.draw.getCenterPt(drawObj);
+        const validPts = drawObj.pts.filter( (pt) => pt);
+        const results= computeCentralPtRadiusAverage([validPts],.11);
+        fovSize= results.fovSize * 2.4;
+        console.log(wp);
+    }
+
+    const fieldDefAry= makeFieldDefs(serDefParams, sRegion, undefined, true,
+        getAppOptions()?.coverage?.hipsSourceURL, fovSize);
 
     const submitSearch= (r) => {
-        const convertedR= convertRequest(r,fieldDefAry,isSIAStandardID(serDefParams.standardID));
+        const convertedR= convertRequest(r,fieldDefAry,getStandardIdType(standardID));
         setSearchParams(convertedR);
     };
 
+
+
+
+
+    const Wrapper= ({children}) => (
+        <div style={{ display:'flex', flexDirection:'column', alignItems:'center', paddingBottom:2}}>
+            {children}
+            <div style={{display:'flex', flexDirection:'row', padding: '5px 5px 0 0', width:'100%',
+                alignSelf:'flex-start', justifyContent:'space-between', alignItems:'center'}}>
+                <CompleteButton onSuccess={(r) => submitSearch(r)}
+                                onFail={() => showInfoPopup('Some field are not valid')}
+                                text={'Submit'} groupKey={GROUP_KEY} />
+                {hasAnySpacial(fieldDefAry) &&
+                    <div style={{fontStyle:'italic'}}>
+                        Enter search position or click on background HiPS
+                    </div>}
+            </div>
+        </div>
+    );
+
+
+
+
     return (
-        <div key={serviceDefRef}>
-            {makeDropDown?.()}
-            <div style={{padding: '5px 5px 5px 5px'}}>
-                <div style= {titleStyle}> {title} </div>
-                <DynamicFieldGroupPanel groupKey={GROUP_KEY} keepState={false}
-                                        DynLayoutPanel={DynLayoutPanelTypes.Simple}
-                                        plotId={plotId}
-                                        fieldDefAry={fieldDefAry} />
-                <CompleteButton style={{padding: '20px 0 0 0'}}
-                                   onSuccess={(r) => submitSearch(r)}
-                                   onFail={() => showInfoPopup('Some field are not valid')}
-                                   text={'Submit'} groupKey={GROUP_KEY} />
+        <div key={serviceDefRef} style={{display:'flex', width:'100%'}}>
+            <div style={{padding: '1px 1px 1px 1px', display:'flex', flexDirection:'column', width:'100%'}}>
+                <div className='ComponentBackground' style={{display:'flex', flexDirection:'row', justifyContent:'flex-start', alignItems:'center'}}>
+                    {makeDropDown?.()}
+                    <div style= {titleStyle}> {title} </div>
+                </div>
+
+                <FieldGroup groupKey={GROUP_KEY} keepState={false} style={{display:'flex', flexGrow:1}}>
+                    <DynLayoutPanelTypes.Inset fieldDefAry={fieldDefAry} style={{width: '100%'}}
+                                               WrapperComponent={Wrapper}
+                                               plotId={plotId}/>
+                </FieldGroup>
             </div>
         </div>
     );
@@ -61,7 +101,9 @@ ServiceDescriptorPanel.propTypes= {
     serviceDefRef: string,
     setSearchParams: func,
     makeDropDown: func,
-    sRegion: string
+    sRegion: string,
+    standardID: string,
+    plotId: string,
 };
 
 

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -223,6 +223,8 @@ SpatialSearch.propTypes = {
     obsCoreEnabled: PropTypes.bool,
     serviceUrl: PropTypes.string,
     columnsModel: PropTypes.object,
+    serviceLabel: PropTypes.string,
+    tableName: PropTypes.string,
 };
 
 const warningMsg = (msg) => {
@@ -246,8 +248,14 @@ function UploadTableSelector({uploadInfo, setUploadInfo}) {
     useEffect(() => {
         //if user changes position column(s), make the new columns entries selectable in the columns/search
         const columns = uploadInfo?.columns;
-        if (getLon()) columns.find((col) => col.name === getLon()).use = true;
-        if (getLat()) columns.find((col) => col.name === getLat()).use = true;
+        if (getLon()) {
+            const cObj= columns.find((col) => col.name === getLon());
+            if (cObj) cObj.use = true;
+        }
+        if (getLat()) {
+            const cObj= columns.find((col) => col.name === getLat());
+            if (cObj) cObj.use = true;
+        }
         uploadInfo = {...uploadInfo, columns};
         setUploadInfo(uploadInfo);
     }, [getLon, getLat]);
@@ -305,13 +313,14 @@ function UploadTableSelector({uploadInfo, setUploadInfo}) {
                         <a className='ff-href'onClick={() => showColSelectPopup(columns, onColsSelected, 'Choose Columns', 'OK',
                             null,true)}>
                             <span>Columns: </span>
-                            <span>{columns.length} (using {columnsUsed}),</span>
+                            <span>{columns.length} (using {columnsUsed})</span>
                         </a>
+                        {fileSize &&<span>,</span>}
                     </div>
-                    <div style={{paddingLeft: 8, whiteSpace:'nowrap'}}>
+                    {fileSize && <div style={{paddingLeft: 8, whiteSpace:'nowrap'}}>
                         <span>Size: </span>
                         <span>{getSizeAsString(fileSize)}</span>
-                    </div>
+                    </div>}
                 </div>
             }
             {haveTable &&

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -237,6 +237,11 @@ export function BasicUI(props) {
         tableName && loadColumns(serviceUrl, schemaName, tableName);
     }, [serviceUrl, schemaName, tableName]);
 
+    useEffect(() => {
+        if (error) setServicesShowing(true);
+    }, [error]);
+
+
     if (error) {
         return (
             <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', margin: '10px 5px'}}>

--- a/src/firefly/js/util/ObsCoreSRegionParser.js
+++ b/src/firefly/js/util/ObsCoreSRegionParser.js
@@ -105,6 +105,7 @@ const resetPos = (count) => {
  * @returns {object}
  */
 export function parseObsCoreRegion(sRegionVal, unit='deg', isCorners=false) {
+    if (!sRegionVal) return {valid:false};
     let  shapeObj = null;
     let  valid = true;
     let  message = '';

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -27,7 +27,8 @@ export const cisxAdhocServiceUtype= 'cisx:adhoc:service';
 
 export const standardIDs = {
     tap: 'ivo://ivoa.net/std/tap',
-    sia: 'ivo://ivoa.net/std/sia'
+    sia: 'ivo://ivoa.net/std/sia',
+    soda: 'ivo://ivoa.net/std/soda',
 };
 
 // known service IDs from service descriptor's standardId field (so far just one)

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -189,7 +189,7 @@ export function computeCentralPointAndRadius(inPoints) {
  *
  * @param {Array.<Array.<WorldPt>>} inPoints2dAry  a 2d array of world points. Each array represents a group of points
  * @param {number} minSizeDeg
- * @return {{centralPoint:WorldPt, maxRadius:number, avgOfCenters:WorldPt}}
+ * @return {{centralPoint:WorldPt, avgOfCenters:WorldPt, fovSize:number}}
  */
 export function computeCentralPtRadiusAverage(inPoints2dAry,minSizeDeg=.11) {
 

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -300,6 +300,7 @@ function extractCircleFromPOS(circleStr) {
 function extractCircleFromADQL(adql) {
     const regEx= /CIRCLE\s?\(.*\)/;
     const result= regEx.exec(adql);
+    if (!result) return;
     const circle= result[0];
     const parts= circle.split(',');
     if (parts.length<4) return;

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -82,6 +82,7 @@ const COVERAGE_FOV = 'COVERAGE_FOV';
  * @prop {number} fovDegFallOver - the field of view size to determine when to move between and HiPS and an image
  * @prop {boolean} multiCoverage - overlay more than one table  on the coverage
  * @prop {string} gridOn - one of 'FALSE','TRUE','TRUE_LABELS_FALSE'
+ * @prop {boolean} exclusiveHiPS - only show hips for coverage, never fits
  */
 
 
@@ -100,7 +101,7 @@ const defOptions= {
     fitType : FitType.WIDTH_HEIGHT,
     ignoreCatalogs:false,
 
-    useHiPS: true,
+    exclusiveHiPS: false,
     hipsSourceURL : 'ivo://CDS/P/2MASS/color', // url
     hipsSource360URL : 'ivo://ov-gso/P/DIRBE/ZSMA1', // url
     imageSourceParams: {
@@ -426,6 +427,13 @@ function updateCoverageWithData(viewerId, table, options, tbl_id, allRowsTable, 
         dispatchPlotHiPS({plotId: DEFAULT_COVERAGE_PLOT_ID, viewerId, wpRequest:hipsRequest, attributes,
             pvOptions: {userCanDeletePlots:false, displayFixedTarget:false, useForCoverage:true}
         });
+    }
+    else if (options.exclusiveHiPS) {
+        dispatchPlotHiPS({
+            plotId: DEFAULT_COVERAGE_PLOT_ID, viewerId, wpRequest:hipsRequest, attributes,
+            pvOptions: {userCanDeletePlots:false, displayFixedTarget:false, useForCoverage:true},
+        });
+
     }
     else {
         dispatchPlotImageOrHiPS({

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -81,7 +81,7 @@ const PROXY= true;
 
 function parseProperties(str) {
     if (!str) {
-        throw new Error('Could not retrieve HiPS properties file');
+        throw new Error('Could not parse HiPS properties file');
     }
     const hipsProperties= str.split('\n')
         .map( (s) => s.trim())
@@ -97,7 +97,7 @@ function parseProperties(str) {
 
 function validateProperties(hipsProperties) {
     if (isEmpty(hipsProperties)) {
-        throw new Error('Could not retrieve HiPS properties file');
+        throw new Error('Could not validate HiPS properties file');
     }
     const {dataproduct_type= 'image'}= hipsProperties;
     if (dataproduct_type!=='image' && dataproduct_type!=='cube') {

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -87,7 +87,7 @@ export function CoverageViewer({viewerId=DEFAULT_COVERAGE_VIEWER_ID,insideFlex=t
             msg= makeNovCovMsg(covState, noCovMessage,tbl_id);
         }
         return (
-            <div style={{...{background: '#c8c8c8', paddingTop:35, width:'100%',textAlign:'center',fontSize:'14pt'},...noCovStyle}}>
+            <div className='ComponentBackground' style={{...{paddingTop:35, width:'100%',textAlign:'center',fontSize:'14pt'},...noCovStyle}}>
                 {msg}</div>
         );
     }

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -199,10 +199,10 @@ function makeDrawing(pv,width,height) {
     const spt3= cc.getScreenCoords(wpt3);
     // don't use spt3 because of funny effects near the celestial poles
     // the sign of the cross product of compass vectors tells us if the image is mirror-reversed from the sky
-    const cross_product= (spt3.x - sptC.x)*(sptN.y - sptC.y) -
-                       (spt3.y - sptC.y)*(sptN.x - sptC.x);
-    const [x, y] = [Math.sign(cross_product)*(sptN.y - sptC.y) + sptC.x,
-                    Math.sign(cross_product)*(-sptN.x + sptC.x)+sptC.y];
+    const cross_product= spt3 ? ((spt3.x - sptC.x)*(sptN.y - sptC.y) - (spt3.y - sptC.y)*(sptN.x - sptC.x)) : 1;
+    const sign= Math.sign(cross_product);
+
+    const [x, y] = [sign*(sptN.y - sptC.y) + sptC.x, sign*(-sptN.x + sptC.x)+sptC.y];
     const wptE2 = cc.getWorldCoords(makeScreenPt(x, y));
 
     const spt1= cc.getDeviceCoords(wpt1, thumbZoomFact, thumbnailTrans);

--- a/src/firefly/js/visualize/ui/VisualSearchUtils.js
+++ b/src/firefly/js/visualize/ui/VisualSearchUtils.js
@@ -26,6 +26,7 @@ import {
 
 
 export const SEARCH_REFINEMENT_DIALOG_ID = 'SEARCH_REFINEMENT_DIALOG';
+const SEARCH_REFINEMENT_SELECTION_SOURCE= 'SearchRefinementTool';
 const radians= [Math.PI/4, 2*Math.PI/4, 3*Math.PI/4, 4*Math.PI/4, 5*Math.PI/4, 6*Math.PI/4, 7*Math.PI/4, 8*Math.PI/4];
 
 function getInscribedCorners(cc,cen,rx,ry) {
@@ -78,7 +79,9 @@ export function getDetailsFromSelection(plot) {
     const sideWPy= cc.getWorldCoords( makeDevicePt( cen.x,dPt0.y));
     if (!cenWpt || !sideWPx || !sideWPy) return {};
     const radiusInit= Math.min(computeDistance(sideWPx,cenWpt), computeDistance(sideWPy,cenWpt));
-    const radius= plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG] ?? Math.trunc(radiusInit*3600)/3600;
+    const radius= plot.attributes[PlotAttribute.SELECTION_SOURCE]===SEARCH_REFINEMENT_SELECTION_SOURCE &&
+                  plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG] ?
+               plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG] : Math.trunc(radiusInit*3600)/3600;
     let corners;
     const rx= cen.x-dPt0.x;
     const ry= cen.y-dPt0.y;
@@ -185,7 +188,9 @@ export function updateUIFromPlot({plotId, setWhichOverlay, whichOverlay, setTarg
     const plotSelType= plot.attributes[PlotAttribute.SELECTION_TYPE];
     if (setWhichOverlay && plotSelType) {
         isCone= plotSelType!==SelectedShape.rect.key; // if future, if something not supported just default to cone
-        setWhichOverlay(isCone ? CONE_CHOICE_KEY : POLY_CHOICE_KEY);
+        if (plot.attributes[PlotAttribute.SELECTION_SOURCE]!==SEARCH_REFINEMENT_SELECTION_SOURCE) {
+            setWhichOverlay(isCone ? CONE_CHOICE_KEY : POLY_CHOICE_KEY);
+        }
     }
 
     if (isCone) {
@@ -248,9 +253,10 @@ function convertConeToSelection(plot,wp,radius) {
         [PlotAttribute.SELECTION]: sel,
         [PlotAttribute.SELECTION_TYPE]: SelectedShape.circle.key,
         [PlotAttribute.IMAGE_BOUNDS_SELECTION]: imBoundSel,
-        [PlotAttribute.SELECTION_SOURCE]: 'SearchRefinementTool'
+        [PlotAttribute.SELECTION_SOURCE]: SEARCH_REFINEMENT_SELECTION_SOURCE,
     };
 }
+
 
 function convertPolygonToSelection(plot,polygonAry) {
     if (!polygonAry?.length) return {};
@@ -272,7 +278,7 @@ function convertPolygonToSelection(plot,polygonAry) {
         [PlotAttribute.SELECTION]: sel,
         [PlotAttribute.SELECTION_TYPE]: SelectedShape.rect.key,
         [PlotAttribute.IMAGE_BOUNDS_SELECTION]: imBoundSel,
-        [PlotAttribute.SELECTION_SOURCE]: 'SearchRefinementTool'
+        [PlotAttribute.SELECTION_SOURCE]: SEARCH_REFINEMENT_SELECTION_SOURCE,
     };
     
 }

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductViewer.jsx
@@ -117,13 +117,13 @@ const MultiProductViewerImpl= memo(({ dpId, activateParams, metaDataTableId, noP
 function ViewerRender({dpId, dataProductsState, noProductMessage, metaDataTableId, makeDropDown, activateParams,
                           setCurrentCTIChoice, ctiChoice, ctLookupKey, getInput, doResetButton}) {
     const {displayType='unsupported', menu, singleDownload, isWorkingState, message, activeMenuLookupKey,
-        menuKey, imageActivate, url, serDefParams, serviceDefRef, sRegion, name:title }= dataProductsState;
+        menuKey, imageActivate, url, serDefParams, serviceDefRef, sRegion, name:title, standardID }= dataProductsState;
     const {imageViewerId,chartViewerId,tableGroupViewerId}=  activateParams;
     switch (displayType) {
         case DPtypes.ANALYZE :
             if (!getInput) return (<ProductMessage {...{menu, singleDownload, makeDropDown, isWorkingState, message}}/>);
             return (<ServiceDescriptorPanel {...{
-                serDefParams, serviceDefRef, title, makeDropDown, sRegion,
+                serDefParams, serviceDefRef, title, makeDropDown, sRegion, standardID,
                 setSearchParams: (params) => dispatchSetSearchParams({dpId,activeMenuLookupKey,menuKey,params}),
             }} />);
         case DPtypes.MESSAGE :
@@ -161,7 +161,7 @@ function ViewerRender({dpId, dataProductsState, noProductMessage, metaDataTableI
 }
 
 const ProductPNG = ( {makeDropDown, url}) => (
-    <div style={{display:'flex', flexDirection: 'column', background: '#c8c8c8', width:'100%', height:'100%'}}>
+    <div className='ComponentBackground' style={{display:'flex', flexDirection: 'column', background: '#c8c8c8', width:'100%', height:'100%'}}>
         {makeDropDown &&  <div style={{height:30, width:'100%'}}>
             {makeDropDown()}
         </div>}


### PR DESCRIPTION
#### [Firefly-1229](https://jira.ipac.caltech.edu/browse/FIREFLY-1229): Testing and Fixes needed for SUIT deployment

- Clean up service descriptor input after DCE work 
- use embedded spacial selection
- Fixed:  issue with embedded selection not working with service descriptions
- Fixed: TAP Upload: size no longer show if upload is from a table (size not known)
- Fixed: TAP Upload: fixed crash in editing columns name when not column exist
- Fixed: SpectrumMetaInspector did not insert the utype when found in FITS
- Fixed: CoverageWatcher crash when looking for the center in ADQL an not there
- Fixed: Change UwsJobProcess rebuild credentials on first redirect
- Fixed: service def panel new show the default HiPS used for coverage and sizes fov on s_region
- Improved: You can now scroll coverage around without if affecting the select point or shape
-  Fixed: service def panel gives correct hips and fov size
- Fixed: check for undefined in ThumbnailView
- Fixed: bad table service always leaves services visible
- coverage settable to show hips only
- obscore table download settable
- Release notes updates

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1229-servdev-panel/firefly
- Rubin: SUIT: data-int (https://data-int.lsst.cloud/portal/app/)
