### PR TITLE
IRSA-5175: Fix the right-side of the tri-view to accommodate both Charts and Coverage

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -93,7 +93,7 @@ export function getMinScatterGLRows() {
 }
 
 /**
- * @returns {boolean} return true if PinnedChartPanel is used.
+ * @returns {boolean} return true if Pin Charts feature is enabled
  */
 export function allowPinnedCharts() {
     return getAppOptions()?.charts?.allowPinnedCharts ?? false;

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -10,7 +10,7 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 
 import DELETE from 'html/images/blue_delete_10x10.png';
 import {allowPinnedCharts} from '../ChartUtil.js';
-import {PinChart, ShowTable} from './PinnedChartPanel.jsx';
+import {PinChart, ShowTable} from './PinnedChartContainer.jsx';
 import {CombineChart} from './CombineChart.jsx';
 
 
@@ -82,7 +82,7 @@ const ResizableChartAreaInternal = React.memo((props) => {
 export const ChartToolbar = (props={}) => {
     const {Toolbar=PlotlyToolbar, chartId, expandable, expandedMode, viewerId, tbl_group} = props;
 
-    // logic for PinnedChartPanel toolbar added here
+    // logic for PinnedChartContainer toolbar added here
     if (allowPinnedCharts()) {
         return (
             <div className='ChartToolbar container'>

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -16,7 +16,7 @@ import {getDefaultChartProps, allowPinnedCharts} from '../ChartUtil.js';
 import {CloseButton} from '../../ui/CloseButton.jsx';
 import {ChartPanel, ChartToolbar} from './ChartPanel.jsx';
 import {MultiChartViewer, getActiveViewerItemId} from './MultiChartViewer.jsx';
-import {PinnedChartPanel} from 'firefly/charts/ui/PinnedChartPanel.jsx';
+import {PinnedChartContainer} from 'firefly/charts/ui/PinnedChartContainer.jsx';
 
 
 
@@ -106,8 +106,8 @@ export const ChartsContainer = (props)  =>{
     const {chartId, expandedMode} = props;
 
     return expandedMode || chartId || !allowPinnedCharts() ?
-        <DefaultChartsContainer {...props}/>:
-        <PinnedChartPanel {...props}/> ;
+        <ActiveChartsPanel {...props}/>:
+        <PinnedChartContainer {...props}/> ;
 };
 
 ChartsContainer.propTypes = {
@@ -128,7 +128,7 @@ ChartsContainer.propTypes = {
  * When addDefaultChart is true, a default chart is created for each table in the group
  * @param props properties for this component
  */
-export const DefaultChartsContainer = (props) => {
+export const ActiveChartsPanel = (props) => {
 
     const {viewerId=DEFAULT_PLOT2D_VIEWER_ID, tbl_group, addDefaultChart, chartId, useOnlyChartsInViewer, expandedMode, closeable, noChartToolbar} = props;
 
@@ -187,16 +187,8 @@ export const DefaultChartsContainer = (props) => {
     }
 };
 
-ChartsContainer.propTypes = {
-    expandedMode: PropTypes.bool,
-    closeable: PropTypes.bool,
-    chartId: PropTypes.string,
-    viewerId : PropTypes.string,
-    tbl_group : PropTypes.string,
-    addDefaultChart : PropTypes.bool,
-    noChartToolbar : PropTypes.bool,
-    useOnlyChartsInViewer :PropTypes.bool
-};
+ActiveChartsPanel.propTypes = ChartsContainer.propTypes;
+
 
 function ExpandedView(props) {
     const {closeable, chartId, viewerId} = props;

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -9,7 +9,7 @@ import {getMultiViewRoot, getViewerItemIds} from '../../visualize/MultiViewCntlr
 import {dispatchChartAdd, getChartData} from '../ChartsCntlr.js';
 import {getNewTraceDefaults, getTblIdFromChart, isSpectralOrder, uniqueChartId} from '../ChartUtil.js';
 import {TextButton} from '../../ui/TextButton.jsx';
-import {PINNED_VIEWER_ID, PINNED_GROUP, PINNED_CHART_PREFIX} from './PinnedChartPanel.jsx';
+import {PINNED_VIEWER_ID, PINNED_GROUP, PINNED_CHART_PREFIX} from './PinnedChartContainer.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {basicOptions, evalChangesFromFields} from './options/BasicOptions.jsx';

--- a/src/firefly/js/visualize/ui/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/ExtractionDialog.jsx
@@ -50,7 +50,7 @@ import {showInfoPopup, showPinMessage} from 'firefly/ui/PopupUtil.jsx';
 import {MetaConst} from 'firefly/data/MetaConst.js';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from 'firefly/core/MasterSaga.js';
 import {allowPinnedCharts} from 'firefly/charts/ChartUtil';
-import {pinChart} from 'firefly/charts/ui/PinnedChartPanel.jsx';
+import {pinChart} from 'firefly/charts/ui/PinnedChartContainer.jsx';
 import {ensureDefaultChart} from 'firefly/charts/ui/ChartsContainer.jsx';
 
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/IRSA-5175
```
When IRSAViewer is in DCE mode and Coverage appears on the right-hand side of the tri-view, 
it creates a tab-in-tab look which is wrong.  We need to fix it so that Coverage and Charts can coexist in that area.
```
Test: https://fireflydev.ipac.caltech.edu/irsa-5175-triview-top-right/firefly
The feature allowing Coverage to be moved to Chart area is now enabled for Firefly, not just DCE.
To test, search or load a table.  Then, toggle `Coverage: Left/Right/Coverage w/Charts`.  Pin Chart should work as it did before as well.