### PR TITLE
FIREFLY-987 Identify tables by EXTNAME, EXTVERSION, EXTLEVEL 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
@@ -28,6 +28,8 @@ public class RelatedData implements Serializable, HasSizeOf {
     private Map<String,String> searchParams= new HashMap<>();
     private Map<String,String> availableMask= new HashMap<>();
     private String hduName= null;
+    private int hduVersion= 1;
+    private int hduLevel= 1;
     private int hduIdx= -1;
     private long size= 0;
 
@@ -113,11 +115,14 @@ public class RelatedData implements Serializable, HasSizeOf {
 
     public static RelatedData makeWavelengthTabularRelatedData(Map<String,String> searchParams,
                                                                String dataKey, String desc,
-                                                               String hduName, int hduIdx ) {
+                                                               String hduName, int hduVersion, int hduLevel,
+                                                               int hduIdx ) {
         RelatedData d= new RelatedData(WAVELENGTH_TABLE, dataKey, desc);
         d.searchParams= searchParams;
         d.hduIdx= hduIdx;
         d.hduName= hduName;
+        d.hduVersion= hduVersion;
+        d.hduLevel= hduLevel;
         return d;
     }
 
@@ -140,6 +145,8 @@ public class RelatedData implements Serializable, HasSizeOf {
     public String getDesc() { return desc;}
     public Map<String,String> getSearchParams() { return searchParams;}
     public String getHduName() { return hduName;}
+    public int getHduVersion() { return hduVersion;}
+    public int getHduLevel() {return hduLevel;}
     public int getHduIdx() { return hduIdx;}
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -245,7 +245,11 @@ public class VisJsonSerializer {
         putStr(retObj, "desc", rData.getDesc());
         putStr(retObj, "dataKey", rData.getDataKey());
         putStrNotNull(retObj, "hduName", rData.getHduName());
-        if (rData.getHduIdx()>-1) putNum(retObj, "hduIdx", rData.getHduIdx());
+        if (rData.getHduIdx()>-1) {
+            putNum(retObj, "hduIdx", rData.getHduIdx());
+            putNum(retObj, "hduVersion", rData.getHduVersion());
+            putNum(retObj, "hduLevel", rData.getHduLevel());
+        }
         return retObj;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
@@ -40,7 +40,6 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
             relatedDataList.add(
                     RelatedData.makeWavelengthTabularRelatedData(params, "WAVE-TAB", "Table Wavelength information",
                             tableHdu.hduName, tableHdu.hduVersion, tableHdu.hduLevel, tableHdu.hduIdx));
-
         }
         return relatedDataList;
     }
@@ -75,7 +74,7 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
      *
      * @param HDUs FITS HDUs
      * @param tabExtId Extension ID of the table lookup extension
-     * @return matching tab extension null if it can not be found
+     * @return matching tab extension; null if it can not be found or there are more than one matching extension
      */
     private static TableHdu findTabExtension(BasicHDU<?>[] HDUs, ExtId tabExtId) {
 
@@ -90,10 +89,10 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
                 if (extId.equals(tabExtId)) {
                     if (tabExtHdu == null) {
                         tabExtHdu = new TableHdu(i, extId.extName, extId.extVer, extId.extLevel);
-                    }
                     } else {
                         // duplicate extension ids - the result of table lookup is undefined
                         return null;
+                    }
                 }
             }
         }

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -222,7 +222,7 @@ const HIPS_DATA_HEIGHT= 10000000000;
  * @prop desc
  * @prop dataDesc
  * @prop {Array.<Header>} headerAry passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
- * @prop {Header} zeroHeaderAry  passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
+ * @prop {Array.<Header>} zeroHeaderAry  passed with non-cube images, length 1 for normal images, up to 3 for 3 color images
  * @prop {Array.<RelatedData>} relatedData
  */
 

--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -71,7 +71,6 @@ export function getWavelength(pt, cubeIdx, wlData) {
     const {algorithm, wlType} = wlData;
     if (wlTypes[algorithm] && wlTypes[algorithm].implemented && wlTypes[algorithm].getWaveLength) {
         const wl = wlTypes[algorithm].getWaveLength(pt, cubeIdx, wlData);
-        if (wlType === WAVE || wlType === VRAD) return wl;
         if (wlType === AWAV) return convertAirToVacuum(wl);
         return wl;
     }

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -133,11 +133,11 @@ function getRelatedData(successAry) {
     successAry.forEach( (s) => s.PlotCreate.forEach( (pc) => {
         const tTypeAry= pc.relatedData && pc.relatedData.filter( (r) => r.dataType==='WAVELENGTH_TABLE');
         if (tTypeAry?.length) {
-            tTypeAry.forEach( ({searchParams,dataKey,hduIdx,hduName}) => {
+            tTypeAry.forEach( ({searchParams, dataKey, hduIdx, hduName, hduVersion, hduLevel}) => {
                 const p= doFetchTable(searchParams).then( (wlTable) => {
                     pc.relatedData.push({
-                        dataType:RDConst.WAVELENGTH_TABLE_RESOLVED,dataKey:dataKey+'-resolved',
-                        table:wlTable, hduIdx, hduName
+                        dataType:RDConst.WAVELENGTH_TABLE_RESOLVED, dataKey:dataKey+'-resolved',
+                        table:wlTable, hduIdx, hduName, hduVersion, hduLevel
                     });
                 });
                 promiseAry.push(p);


### PR DESCRIPTION
XXXX-TAB algorithm for computing spectral coordinates requires that the combination of EXTNAME, EXTVERSION, and EXTLEVEL is used to identify the extensions with lookup tables. This PR makes sure that the values of these 3 headers are passed with the WAVELENGTH_TABLE related data to the client.

Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-987
Test deployment: https://fireflydev.ipac.caltech.edu/firefly-987-extid/firefly

To test, check that the displayed wavelength is not NaN for the test files from https://jira.ipac.caltech.edu/browse/FIREFLY-989