### PR TITLE
FIREFLY-1236: fixed Save table dialog badly rendered when Workspace is chosen

### DIFF
--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -140,14 +140,16 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
         );
     };
     return (
-        <div style={{display: 'flex', flexDirection: 'column'}}>
-            <FieldGroup style={{ boxSizing: 'border-box', paddingLeft:5, paddingRight:5}}
+        <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+            <FieldGroup style={{ boxSizing: 'border-box', paddingLeft:5, paddingRight:5, flexGrow: 1}}
                         groupKey={tblDownloadGroupKey}
                         reducerFunc={TableDLReducer(tbl_id)}>
-                <DownloadOptionsDialog fromGroupKey={tblDownloadGroupKey}
+                <DownloadOptionsDialog fromGroupKey={tblDownloadGroupKey} style={{width: 'unset', height: 'unset'}}
                                        children={fileFormatOptions()}
                                        workspace={isWs}
-                                       dialogHeight={0}/>
+                                       dialogWidth='100%'
+                                       dialogHeight='300px'
+                />
                 <RadioGroupInputField fieldKey='mode' initialState={{value: 'displayed'}} wrapperStyle={{marginTop:10}}
                                       options={[{value:'displayed', label:'Save table as displayed'}, {value:'original', label:'Save table as originally retrieved'}]}/>
                 <div style={{margin: '5px 22px', color: 'gray'}}>

--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -26,7 +26,7 @@ export function getTypeData(key, val='', tip = '', labelV='', labelW) {
 }
 
 
-export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWidth, dialogWidth=500, dialogHeight=300,
+export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWidth, style={}, dialogWidth=500, dialogHeight=300,
                                       workspace}) {
 
     const isUpdating = useStoreConnector(isAccessWorkspace);
@@ -51,6 +51,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
         );
 
         const showSave = (
+            <div  style={{width: dialogWidth, height: dialogHeight}}>
                 <div style={{marginTop: 10,
                              boxSizing: 'border-box',
                              width: 'calc(100%)', height: 'calc(100% - 10px)',
@@ -60,6 +61,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
                     <WorkspaceSave fieldKey={'wsSelect'} files={wsList} value={wsSelect}
                         tooltip='workspace file system'/>
                 </div>
+            </div>
         );
 
         const showNoWSFiles = (
@@ -90,7 +92,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
     );
 
     return (
-        <div style={{height: '100%', width: '100%'}}>
+        <div style={{height: '100%', width: '100%', ...style}}>
             <div>
                 {children}
             </div>
@@ -108,9 +110,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
 
             {workspace && showLocation}
 
-            <div  style={{width: dialogWidth, height: dialogHeight}}>
-                {where === WORKSPACE && <ShowWorkspace/>}
-            </div>
+            {where === WORKSPACE && <ShowWorkspace/>}
         </div>
     );
 }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1236

Rendering is fixed.  Not sure why workspace is not working.

Test: https://firefly-1236-save-table-render.irsakudev.ipac.caltech.edu/irsaviewer/
See ticket for testing instruction.

@lrebull Please test at your convenience.