### PR TITLE
FIREFLY-1156: better SQL error message for added column failure

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
@@ -31,11 +31,11 @@ public class ObsCorePackager extends FileGroupsProcessor {
             return computeFileGroup((DownloadRequest) request);
         } catch (Exception e) {
             LOGGER.error(e);
-            throw new DataAccessException(e.getMessage());
+            throw e;
         }
     }
 
-    private List<FileGroup> computeFileGroup(DownloadRequest request) {
+    private List<FileGroup> computeFileGroup(DownloadRequest request) throws DataAccessException{
         var selectedRows = new ArrayList<>(request.getSelectedRows());
 
         List<FileInfo> fileInfos = new ArrayList<>();

--- a/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
+++ b/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
@@ -10,7 +10,7 @@ import {SqlTableFilter, code} from './FilterEditor.jsx';
 import {addOrUpdateColumn, deleteColumn} from '../../rpc/SearchServicesJson.js';
 import {getGroupFields, validateFieldGroup, getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
 import {ValidationField} from '../../ui/ValidationField.jsx';
-import {getAllColumns, getColumn, getTableUiById, getTblById} from '../TableUtil.js';
+import {getAllColumns, getColumn, getTblById} from '../TableUtil.js';
 import {showPopup, showInfoPopup, showYesNoPopup} from '../../ui/PopupUtil.jsx';
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
 import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
@@ -304,15 +304,16 @@ const Samples = () => {
 };
 
 
-function parseError(err, params={}) {
-    // samples: "StatementCallback; bad SQL grammar [ALTER TABLE DATA ADD COLUMN newCol double]; nested exception is java.sql.SQLSyntaxErrorException: object name already exists in statement [ALTER TABLE DATA ADD COLUMN newCol double]"
-    //          "StatementCallback; bad SQL grammar [ALTER TABLE DATA ADD COLUMN newCol-2 double]; nested exception is java.sql.SQLSyntaxErrorException: unexpected token: -"
-    const {cname, expression} = params;
-    // column exists in table
-    if (err?.message?.match(/name already exists/)) return `ERROR: A column with the name "${cname}" already exists in the table`;
-
-    // unexpected error
-    return err?.message;
+function parseError(err) {
+    if (err) {
+        const [main, details] = err.message.split(';');
+        return  (
+            <div>
+                <div style={{fontWeight: 'bold', marginBottom: 5}}>{main}</div>
+                <code>{details}</code>
+            </div>
+        );
+    } else return 'Operation failed with unexpected error.';
 }
 
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1156

Test: https://fireflydev.ipac.caltech.edu/firefly-1156-sql-errors/firefly
Load table, then try to make 'Add Column' fail to see error message.  One way is to reference a bad column name in the expression field.  Or, create a type mismatch by picking a data type that's inconsistent with the results of the expression.

You can also look at tests to see several different type of messages.
https://github.com/Caltech-IPAC/firefly/blob/FIREFLY-1156_sql_errors/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java#L239
https://github.com/Caltech-IPAC/firefly/blob/FIREFLY-1156_sql_errors/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java#L270

@lrebull It takes a lot of work to construct a precise error message.  And even then, it may not cover all cases.  Are these messages good enough?   If not, can you suggest what I should show?