### PR TITLE
FIREFLY-1240: flipped y axis doesn't persist in chart thumbnail view

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -709,11 +709,11 @@ public class EmbeddedDbUtil {
                     List<Map<String, Object>> vals = JdbcFactory.getSimpleTemplate(dbAdapter.getDbInstance(dbFile))
                             .queryForList(String.format("SELECT distinct \"%s\" FROM data order by 1", cname));
 
-                    if (vals.size() <= MAX_COL_ENUM_COUNT) {
+                    DataType col = findColByName(inclCols, cname);
+                    if (col != null && vals.size() <= MAX_COL_ENUM_COUNT) {
                         String enumVals = vals.stream()
-                                .map(m -> m.get(cname) == null ? NULL_TOKEN : m.get(cname).toString())  // list of map to list of string(colname)
-                                .collect(Collectors.joining(","));                          // combine the names into comma separated string.
-                        DataType col = findColByName(inclCols, cname);
+                                .map(m -> m.get(cname) == null ? NULL_TOKEN : m.get(cname).toString())   // convert to list of value as string
+                                .collect(Collectors.joining(","));                              // combine the values into a comma separated values string.
                         if (col != null)  col.setEnumVals(enumVals);
                         // update dd table
                         JdbcFactory.getSimpleTemplate(dbAdapter.getDbInstance(dbFile))

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -182,7 +182,6 @@ PlotlyChartArea.propTypes = {
 
 function renderAsThumbnail(layout) {
     const axisOverride = {
-        autorange: true,
         showgrid: false,
         zeroline: false,
         showline: false,

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -9,7 +9,7 @@ import {set, get, isEqual, pick, omit, isEmpty, isString, toNumber} from 'lodash
 import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
 import {
     isColumnType, COL_TYPE, tblDropDownId, getTblById, getColumn, formatValue, getTypeLabel,
-    getColumnIdx, getRowValues, getCellValue, getTableUiByTblId, splitCols
+    getColumnIdx, getRowValues, getCellValue, getTableUiByTblId, splitCols, isOfType
 } from '../TableUtil.js';
 import {SortInfo} from '../SortInfo.js';
 import {InputField} from '../../ui/InputField.jsx';
@@ -166,7 +166,9 @@ function EnumSelect({col, tbl_id, filterInfoCls, onFilter}) {
     const options = enumVals.split(',')
                         .map( (s) => {
                             const value = s === '' ? '%EMPTY' : s;                  // because CheckboxGroupInputField does not support '' as an option, use '%EMPTY' as substitute
-                            const label = value === NULL_TOKEN ? '<NULL>' : value === '%EMPTY' ? '<EMPTY_STR>' : value;
+                            let label = value;
+                            if (value === NULL_TOKEN)       label = isOfType(col.type, COL_TYPE.BOOL) ? 'false' : '<NULL>';  // handle null value
+                            else if (value === '%EMPTY')    label = '<EMPTY_STR>';                                           // handle empty string
                             return {label, value};
                         } );
     let value;


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1240
Test:  https://firefly-1240-pinchart-flipy.irsakudev.ipac.caltech.edu/irsaviewer/

Also fix  #10 from Bugs found in 2023.1 RC to ticket: 
https://confluence.ipac.caltech.edu/display/IRSA/Bugs+found+in+2023.1+RC+%3A+IV%2C+DCE+testing+April+2023
> When you use the preset function to add a column, it appears in the newly created column as true and false. But when you go to try to filter on that newly created column from the filter pulldown at the top of the new column, it says true and <NULL>, not true and false. If you filter on <NULL>, it does what you expect it to do, e.g., just gives you the 'false' values
