### PR TITLE
Firefly-1241: Fix: Search search showing fits in wrong viewer

### DIFF
--- a/src/firefly/js/ui/DefaultSearchActions.js
+++ b/src/firefly/js/ui/DefaultSearchActions.js
@@ -5,6 +5,7 @@ import {sprintf} from '../externalSource/sprintf.js';
 import {getTableUiByTblId, makeFileRequest} from '../api/ApiUtilTable.jsx';
 import {makeVOCatalogRequest} from '../tables/TableRequestUtil.js';
 import {dispatchTableSearch} from '../tables/TablesCntlr.js';
+import {DEFAULT_FITS_VIEWER_ID} from '../visualize/MultiViewCntlr.js';
 import {setMultiSearchPanelTab} from './MultiSearchPanel.jsx';
 import {Format} from 'firefly/data/FileAnalysis';
 import {doJsonRequest} from 'firefly/core/JsonUtils';
@@ -28,7 +29,10 @@ export const showTapSearchPanel= (searchParams={}) => {
     if (view==='MultiTableSearchCmd') setMultiSearchPanelTab('tap');
 };
 
-const showImage= (initArgs) => dispatchShowDropDown( { view: 'ImageSelectDropDownCmd', initArgs});
+const showImage= (initArgs) => {
+    const modInitArgs= {...initArgs, searchParams: {...initArgs.searchParams, viewerId:DEFAULT_FITS_VIEWER_ID}};
+    dispatchShowDropDown( { view: 'ImageSelectDropDownCmd', initArgs:modInitArgs});
+};
 
 export const makeDefTapSearchActions = () => {
     return [

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -615,10 +615,16 @@ class TableRecognizer {
             let lonCol;
             let latCol;
             if (useReg) {
-                const reLon= new RegExp(`^[A-z]*[-_]?(${lon})[1-9]*$`);
-                const reLat= new RegExp(`^[A-z]*[-_]?(${lat})[1-9]*$`);
+                let reLon= new RegExp(`^[A-z]*[-_]?(${lon})[1-9]*$`);
+                let reLat= new RegExp(`^[A-z]*[-_]?(${lat})[1-9]*$`);
                 lonCol = findColumn(lon,reLon);
                 latCol = findColumn(lat,reLat);
+                if (!lonCol || !latCol) {
+                    reLon= new RegExp(`^${lon}[-_].*$`);
+                    reLat= new RegExp(`^${lat}[-_].*$`);
+                    lonCol = findColumn(lon,reLon);
+                    latCol = findColumn(lat,reLat);
+                }
                 if (lonCol && latCol) {
                     if (lonCol.name.replace(lon,'') !== latCol.name.replace(lat,'')) return undefined;
                 }

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -74,13 +74,14 @@ export const genHiPSPlotId = getHiPSPlotId();
 /**
  * returns the context information
  * @param [renderTreeId]
+ * @param [presetViewerId] if defined, then use as viewerId
  * @returns {ContextInfo}
  */
-function getContexInfo(renderTreeId) {
+function getContexInfo(renderTreeId, presetViewerId) {
     const mvroot = getMultiViewRoot();
-    let plotId = get(visRoot(), 'activePlotId');
-    let viewerId = plotId && findViewerWithItemId(mvroot, plotId, IMAGE);
-    let viewer = viewerId && getViewer(mvroot, viewerId);
+    let plotId = visRoot()?.activePlotId;
+    let viewerId= presetViewerId ? presetViewerId : (plotId && findViewerWithItemId(mvroot, plotId, IMAGE));
+    let viewer = getViewer(mvroot, viewerId);
 
     if (viewer && renderTreeId && viewer.renderTreeId && renderTreeId!==viewer.renderTreeId) {
         viewer = getAViewFromMultiView(mvroot, IMAGE, renderTreeId);
@@ -136,7 +137,8 @@ function ImageSearchPanel({resizable=true, onSubmit, gridSupport = false, multiS
 
 export function ImageSearchDropDown({gridSupport, resizable=false, initArgs}) {
     const {renderTreeId} = useContext(RenderTreeIdCtx);
-    const {plotId, viewerId, multiSelect} = getContexInfo(renderTreeId);
+    const {viewerId:presetViewerId}= initArgs?.searchParams ?? {viewerId:undefined};
+    const {plotId, viewerId, multiSelect} = getContexInfo(renderTreeId, presetViewerId);
     const onSubmit = (request) => onSearchSubmit({request, plotId, viewerId, gridSupport, renderTreeId});
     return <ImageSearchPanel {...{resizable, gridSupport, onSubmit, multiSelect, onCancel:dispatchHideDropDown, initArgs}}/>;
 }


### PR DESCRIPTION
#### [Firefly-1241](https://jira.ipac.caltech.edu/browse/FIREFLY-1241): Fix: Search search showing fits in wrong viewer 

 - also: improved center column guessing columns such as `ra_obj` and `dec_obj` (common in irsa moving target tables)


#### Testing
 - https://firefly-1241-coverage-replace.irsakudev.ipac.caltech.edu/irsaviewer
 - Test according to ticket