### PR TITLE
IRSA-3356: Added validator in download dialog for SHA

### DIFF
--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -141,10 +141,10 @@ const preTitleCss = {
 let dlTitleIdx = 0;
 const newBgKey = () => 'DownloadOptionPanel-' + Date.now();
 
-export function DownloadOptionPanel (props) {
-    const {groupKey, cutoutSize, help_id, children, style, title, dlParams, updateSearchRequest=null, updateDownloadRequest=null} = props;
-    const { cancelText='Cancel', showZipStructure=true, showEmailNotify=true, showFileLocation=true, showTitle=true } = props;
-
+export function DownloadOptionPanel ({groupKey, cutoutSize, help_id, children, style, title, dlParams,
+                                         updateSearchRequest, updateDownloadRequest, validateOnSubmit,
+                                         cancelText='Cancel', showZipStructure=true, showEmailNotify=true,
+                                         showFileLocation=true, showTitle=true, ...props}) {
     const {tbl_id:p_tbl_id, checkSelectedRow} = React.useContext(OptionsContext);
     const tbl_id = props.tbl_id || p_tbl_id;
 
@@ -159,6 +159,12 @@ export function DownloadOptionPanel (props) {
         const selectInfoCls = SelectInfo.newInstance(selectInfo);
         if (checkSelectedRow && !selectInfoCls.getSelectedCount()) {
             return showInfoPopup('You have not chosen any data to download', 'No Data Selected');
+        }
+
+        const {valid, message} = validateOnSubmit?.(formInputs) ?? {valid : true};
+        if (!valid) {
+            showInfoPopup(message ?? 'Invalid form input(s)', 'Error in form inputs');
+            return false; // to prevent FormPanel to submit
         }
 
         formInputs.wsSelect = formInputs.wsSelect && formInputs.wsSelect.replace(WS_HOME, '');
@@ -256,6 +262,7 @@ DownloadOptionPanel.propTypes = {
     showFileLocation: PropTypes.bool,           // layout FileLocation field
     updateSearchRequest: PropTypes.func,   // customized parameters to be added or updated in request
     updateDownloadRequest:PropTypes.func,
+    validateOnSubmit: PropTypes.func,      // to validate form inputs on submit
     dlParams:   PropTypes.shape({               // these params should be used as defaults value if they appears as input fields
         TitlePrefix:    PropTypes.string,           // default title of the download..  an index number will be appended to this.
         FilePrefix:     PropTypes.string,           // packaged file prefix


### PR DESCRIPTION
Completes an outstanding task in https://github.com/IPAC-SW/irsa-ife/pull/252

In SHA, options for data files (checkbox group) can't be empty. And unlike field level validation, this requires validation on submit. So added prop validateOnSubmit in DownloadDialog and added a validator function in SHA.

## Testing
1. SHA: https://irsa-3356-download-validator.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/ - see instructions at https://github.com/IPAC-SW/irsa-ife/pull/257

2. Other apps: https://irsa-3356-download-validator.irsakudev.ipac.caltech.edu/applications/sofia/ 
    Make  a search, then select a row in "FORCAST" table and click prepare download, uncheck file type options and submit. Because there wasn't any validator passed in props, it should submit download options form as it used to.