### PR TITLE
FIREFLY-1245: handle undefined pageSize

### DIFF
--- a/src/firefly/html/test/tests-table.html
+++ b/src/firefly/html/test/tests-table.html
@@ -445,6 +445,44 @@ added in this test.  Open console, then
     </script>
 </template>
 
+
+<template title="Data Discovery NED" class="tpl">
+    <div id="expected" >
+        <div style="margin: 10px">
+            <p>
+                Even with bad pageSize placement, Firefly should default to MAX_ROWS and not fail.
+            </p>
+
+        </div>
+    </div>
+    <div id="actual"  class="box x3"/>
+    <script>
+        function onFireflyLoaded(firefly) {
+            firefly.action.dispatchAppOptions({"help.base.url": "/onlinehelp/discovery/"});
+            firefly.debug = true;
+
+            var tblReq = firefly.util.table.makeFileRequest(
+                'SED: raw',
+                'http://ned.ipac.caltech.edu/cgi-bin/datasearch?search_type=Photometry&objname=MESSIER+101&of=xml_main',
+                null,
+                {}
+            );
+
+            var wrapperReq = firefly.util.table.makeTblRequest(
+                'IpacTableFromSource',
+                'NED SED',
+                {searchRequest: tblReq},
+                {filters: '"NED Units" = \'Jy\''},
+                {pageSize: 50}
+            );
+
+            firefly.showTable('actual', wrapperReq, {setAsActive: false});
+        }
+    </script>
+</template>
+
+
+
 <!-- this is where test cases will be attached-->
 <div id="tst-container"/>
 

--- a/src/firefly/js/drawingLayers/Artifact.js
+++ b/src/firefly/js/drawingLayers/Artifact.js
@@ -21,6 +21,7 @@ import {getUIComponent} from './CatalogUI.jsx';
 import {findTableCenterColumns} from '../util/VOAnalyzer.js';
 import {dispatchAddActionWatcher} from '../core/MasterSaga';
 import {logger} from '../util/Logger.js';
+import {MAX_ROW} from 'firefly/tables/TableRequestUtil.js';
 
 const TYPE_ID= 'ARTIFACT_TYPE';
 
@@ -84,7 +85,7 @@ function retrieveArtifactsTable(drawLayer) {
 
     if (!rd) return;
 
-    const sendReq= clone(rd.searchParams,{ startIdx : 0, pageSize : 1000000 });
+    const sendReq= clone(rd.searchParams,{ startIdx : 0, pageSize : MAX_ROW });
 
     doFetchTable(sendReq).then(
         (tableModel) => {

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -4,7 +4,7 @@
 
 import {isEmpty, omitBy, isUndefined, cloneDeep, get, range, pick} from 'lodash';
 import * as TblCntlr from './TablesCntlr.js';
-import {getTblById, getTblInfoById} from './TableUtil.js';
+import {fixPageSize, getTblById, getTblInfoById} from './TableUtil.js';
 import {SelectInfo} from './SelectInfo.js';
 import {getTableUiById} from './TableUtil';
 import {setTblPref, clearTblPref} from './TablePref.js';
@@ -53,7 +53,7 @@ export function onFilterSelected(tbl_id, selected) {
 }
 
 export function onPageSizeChange(tbl_id, nPageSize) {
-    nPageSize = Number.parseInt(nPageSize);
+    nPageSize = fixPageSize(nPageSize);
     const {pageSize, highlightedRow} = getTblInfoById(tbl_id);
     if (Number.isInteger(nPageSize) && nPageSize !== pageSize) {
         const request = {tbl_id, pageSize: nPageSize};

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -761,7 +761,7 @@ export function processRequest(tableModel, tableRequest, hlRowIdx) {
     let {data, columns} = nTable.tableData;
 
     nTable.request = tableRequest;
-    pageSize = pageSize || data.length || MAX_ROW;
+    pageSize = pageSize > 0 ? pageSize : data.length || MAX_ROW;
 
     if (filters) {
         filterTable(nTable, filters);
@@ -847,7 +847,7 @@ export function getTblInfo(tableModel, aPageSize) {
     if (!tableModel) return {};
     var {tbl_id, request, highlightedRow=0, totalRows=0, tableMeta={}, selectInfo, error} = tableModel;
     const title = tableMeta.title || request?.META_INFO?.title;
-    const pageSize = aPageSize || get(request, 'pageSize', MAX_ROW);  // there should be a pageSize.. default to 1 in case of error.  pageSize cannot be 0 because it'll overflow.
+    const pageSize = aPageSize > 0 ? aPageSize : fixPageSize(request?.pageSize);
     if (highlightedRow < 0 ) {
         highlightedRow = 0;
     } else  if (highlightedRow >= totalRows-1) {
@@ -1401,6 +1401,12 @@ export function getTableState(tbl_id) {
     if (totalRows === 0 && (filters || sqlFilter)) return TBL_STATE.NO_MATCH;
 
     return TBL_STATE.OK;
+}
+
+export function fixPageSize(pageSize) {
+    if ( !Number.isInteger(pageSize) )                  pageSize = parseInt(pageSize);
+    if ( !Number.isInteger(pageSize) || pageSize <= 0)  pageSize = MAX_ROW;
+    return pageSize;
 }
 
 /**


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1245
```js
var wrapperReq = firefly.util.table.makeTblRequest( 
  'IpacTableFromSource', 
  'NED SED', 
  {searchRequest: tblReq}, 
  {filters: '"NED Units" = \'Jy\''}, 
  {pageSize: 50} 
);
```

Normally, Firefly is able to handle undefined pageSize.  However, when it's used in this way(wrapper request with bad pageSize), it defaults to -1 which break paging and cause unexpected exceptions.

Test: https://firefly-1245-handle-undefined-pagesize.irsakudev.ipac.caltech.edu/
Follow instructions in ticket to test.  Or,

TLDR:
`Search for Source` -> m101 -> Search
switch table tab to `NED NED`, then select a different row.

