### PR TITLE
Firefly-1246: Fixed: obs_title not showing up for datalink. wavelength wrong my order of magnitude

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
@@ -80,10 +80,6 @@ public class URLFileRetriever implements FileRetriever {
                     params.addCookie(name, cookies.get(name));
                 }
             }
-            if (!ro.getUserInfo().isGuestUser()) {
-                params.setLoginName(ro.getUserInfo().getLoginName());
-                params.setSecurityCookie(ro.getRequestAgent().getAuthKey());
-            }
             params.setCheckForNewer(request.getUrlCheckForNewer());
             params.setLocalFileExtensions(extsList);
             params.setMaxSizeToDownload(VisContext.FITS_MAX_SIZE);

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -363,6 +363,7 @@ public class URLDownload {
             int responseCode= getResponseCode(conn);
             outFileData = new FileInfo(outfile, getSugestedFileName(conn), responseCode,
                     ResponseMessage.getHttpResponseMessage(responseCode), conn.getContentType());
+            if (conn.getContentEncoding()!=null) outFileData.putAttribute("content-encoding", conn.getContentEncoding());
             logDownload(outFileData, conn.getURL().toString(), elapse );
 
             if (responseCode>=300 && responseCode<400) {

--- a/src/firefly/js/drawingLayers/SearchSelectTool.js
+++ b/src/firefly/js/drawingLayers/SearchSelectTool.js
@@ -123,16 +123,19 @@ function drawSearchSelectionCircle(plot, drawLayer) {
     const radius= plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG];
     const drawAry= [];
     const drawRadius= radius<=maxSize ? (radius >= minSize ? radius : minSize) : maxSize;
+    const shadow={offX:1,offY:1,color:'black',blur:1};
     if (drawLayer.isInteractive) {
-        drawAry.push(PointDataObj.make(wp,7, DrawSymbol.EMP_SQUARE_X));
-        radius && drawAry.push( {...ShapeDataObj.makeCircleWithRadius(wp, drawRadius*3600,UnitType.ARCSEC), lineWidth:3} );
+        const x= PointDataObj.make(wp,7, DrawSymbol.EMP_SQUARE_X,undefined,{shadow});
+        drawAry.push(x);
+        radius && drawAry.push( {...ShapeDataObj.makeCircleWithRadius(wp, drawRadius*3600,UnitType.ARCSEC), lineWidth:3, renderOptions:{shadow}} );
     }
     else {
-        drawAry.push(PointDataObj.make(wp,3, DrawSymbol.CROSS));
+        const cross= PointDataObj.make(wp,3, DrawSymbol.CROSS, undefined, {shadow});
+        drawAry.push(cross);
         radius && drawAry.push(
             {...ShapeDataObj.makeCircleWithRadius(wp, drawRadius*3600,UnitType.ARCSEC),
                 lineWidth:2,
-                renderOptions:{lineDash:[7,3]}
+                renderOptions:{lineDash:[7,3], shadow}
             });
     }
     return drawAry;

--- a/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
+++ b/src/firefly/js/metaConvert/MultiProductFileAnalyzer.js
@@ -1,5 +1,4 @@
 import {FileAnalysisType} from '../data/FileAnalysis';
-import {Logger} from '../util/Logger.js';
 import {
     createGridImagesActivate,
     createSingleImageActivate,

--- a/src/firefly/js/metaConvert/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/ServDescConverter.js
@@ -36,8 +36,8 @@ export async function getServiceDescSingleDataProduct(table, row, activateParams
         try {
             const datalinkTable= await doFetchTable(makeFileRequest('dl table', dlUrl));
             const positionWP= makeWorldPtUsingCenterColumns(table,row);
-            return processDatalinkTable(table,row,datalinkTable,positionWP,activateParams,
-                !isEmpty(menu)?menu:undefined);
+            return processDatalinkTable({sourceTable:table,row,datalinkTable,positionWP,activateParams,
+                additionalServiceDescMenuList:!isEmpty(menu)?menu:undefined});
         }
         catch (reason) {
             return isEmpty(menu) ?

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -126,6 +126,7 @@ const OBSTAPCOLUMNS = [
     ['pol_states',        'meta.code;phys.polarization','Char.PolarizationAxis.stateList'],
     ['pol_xel',           'meta.number',                'Char.PolarizationAxis.numBins'],
     ['facility_name',     'meta.id;instr.tel',          'Provenance.ObsConfig.Facility.name'],
+    ['obs_title',         'meta.title;obs',             'DataID.title'],
     ['instrument_name',   'meta.id;instr',              'Provenance.ObsConfig.Instrument.name']
 ];
 
@@ -1277,7 +1278,9 @@ export const getObsCoreSRegion= (tableOrId, rowIdx) => getObsCoreCellValue(table
  * @param rowIdx
  * @return {string}
  */
-export const getObsTitle= (tableOrId, rowIdx) => getObsCoreCellValue(tableOrId,rowIdx, 'obs_title');
+export const getObsTitle= (tableOrId, rowIdx) => {
+   return  getObsCoreCellValue(tableOrId,rowIdx, 'obs_title');
+};
 
 
 /**

--- a/src/firefly/js/visualize/draw/PointDataObj.js
+++ b/src/firefly/js/visualize/draw/PointDataObj.js
@@ -29,18 +29,20 @@ const DEFAULT_SYMBOL = DrawSymbol.X;
  * @param {number} [size]
  * @param {Enum} [symbol]
  * @param {string} [text]
+ * @param {Object} [renderOptions]
  * @return {object}
  */
-export function make(pt,size,symbol,text) {
+export function make(pt,size,symbol,text, renderOptions) {
     if (!pt) return null;
 
-    var obj= DrawObj.makeDrawObj();
+    const obj= DrawObj.makeDrawObj();
     obj.type= POINT_DATA_OBJ;
     obj.pt= pt;
 
     if (size) obj.size= size;
     if (symbol) obj.symbol= symbol;
     if (text) obj.text= text;
+    if (renderOptions) obj.renderOptions= renderOptions;
     return obj;
 }
 

--- a/src/firefly/js/visualize/ui/multiProduct/MPMessages.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MPMessages.jsx
@@ -5,8 +5,8 @@ import {CompleteButton} from '../../../ui/CompleteButton.jsx';
 
 
 
-export function AdvancedMessage({dpId, dataProductsState, noProductMessage, doResetButton}) {
-    const {complexMessage, menu, makeDropDown, message, noProductsAvailable= false, isWorkingState,
+export function AdvancedMessage({dpId, dataProductsState, noProductMessage, doResetButton, makeDropDown}) {
+    const {complexMessage, menu, message, noProductsAvailable= false, isWorkingState,
         singleDownload, activeMenuLookupKey, detailMsgAry, badUrl, resetMenuKey}= dataProductsState;
 
 

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductViewer.jsx
@@ -128,7 +128,7 @@ function ViewerRender({dpId, dataProductsState, noProductMessage, metaDataTableI
             }} />);
         case DPtypes.MESSAGE :
         case DPtypes.PROMISE :
-            return <AdvancedMessage {...{dpId, dataProductsState, noProductMessage, doResetButton }}/>;
+            return <AdvancedMessage {...{dpId, dataProductsState, noProductMessage, doResetButton, makeDropDown}}/>;
         case DPtypes.DOWNLOAD_MENU_ITEM :
             return (<ProductMessage {...{menu, singleDownload, makeDropDown, message}} />);
         case DPtypes.IMAGE :


### PR DESCRIPTION
#### [Firefly-1246](https://jira.ipac.caltech.edu/browse/FIREFLY-1246): Fixed: obs_title not showing up for datalink. wavelength wrong order of magnitude

 - new using same approach in datalink table as will normal access_url type tables
 - averaging em_min and em_max for table of loaded images
 - fixed: magnitude of conversion
 - fixed: dropdown menu not showing in service descriptor error case
 - fixed: added small shadown to target selection marker

#### Testing
- https://firefly-1246.irsakudev.ipac.caltech.edu/irsaviewer/dce
- pin a few images and look at look at TLI dialog, The microns should be correct
- The `obs_title` support is very hard to test outside of the LSST environment
   - Most of this PR work is related to `obs_title` and titling obscore with datalink images correctly 