### PR TITLE
Firefly-1234: Convert all non EQJ2000 coords to EQJ2000 coords

### DIFF
--- a/src/firefly/js/ui/PositionFieldDef.js
+++ b/src/firefly/js/ui/PositionFieldDef.js
@@ -3,6 +3,8 @@ import CoordinateSys from '../visualize/CoordSys.js';
 import CoordUtil from '../visualize/CoordUtil.js';
 
 import {sprintf} from '../externalSource/sprintf.js';
+import VisUtil from 'firefly/visualize/VisUtil';
+import {instanceOf} from "prop-types";
 
 const errMsgRoot= 'Error: ';
 
@@ -61,11 +63,24 @@ export function coordToString(csys) {
 export function formatTargetForHelp(wp) {
     if (!wp) return '';
     if (!wp.objName || !wp.resolver) return formatPosForHelp(wp);
-    return ' <b>' + wp.objName + '</b>' +
-        ' <i>resolved by</i> ' + wp.resolver.desc +
-        '<div  style=\"padding-top:6px;\">' +
-        formatPosForHelp(wp) +
-        '</div>';
+    return `<b>${wp.objName}</b> <i>resolved by</i> ${wp.resolver.desc}
+            <div style="padding-top:6px;">
+              ${formatPosForHelp(wp)}
+            </div>`;
+}
+
+function getEQJ2000(wp) {
+    const wpEQ = VisUtil.convert(wp, CoordinateSys.EQ_J2000);
+    if (typeof wpEQ === 'undefined') return '';
+    const [ra, dec] = [wpEQ.getLon().toFixed(5), wpEQ.getLat().toFixed(5)];
+    const hmsRa = CoordUtil.convertLonToString(ra,  CoordinateSys.EQ_J2000);
+    const hmsDec = CoordUtil.convertLatToString(dec,  CoordinateSys.EQ_J2000);
+    const res = `<div style="padding-top:6px;font-size:10px;">
+                  ${ra},&nbsp;${dec}&nbsp;Equ J2000
+                  &nbsp;&nbsp;&nbsp;<i>or</i> &nbsp;&nbsp;&nbsp;
+                  ${hmsRa},&nbsp;${hmsDec}&nbsp;&nbsp;Equ J2000
+                </div>`;
+    return res;
 }
 
 /**
@@ -80,19 +95,23 @@ export function formatPosForHelp(wp) {
     const latStr = sprintf('%.5f',wp.getLat());
     const csys = coordToString(wp.getCoordSys());
     if (wp.getCoordSys().isEquatorial()) {
-
         const hmsRa = CoordUtil.convertLonToString(wp.getLon(), wp.getCoordSys());
         const hmsDec = CoordUtil.convertLatToString(wp.getLat(), wp.getCoordSys());
 
-        s = '<div class=\"on-dialog-help faded-text\" style=\"font-size:10px;\">' +
-            lonStr + ',&nbsp;' + latStr + '&nbsp;&nbsp;' + csys +
-            ' &nbsp;&nbsp;&nbsp;<i>or</i> &nbsp;&nbsp;&nbsp;' +
-            hmsRa + ',&nbsp;' + hmsDec + '&nbsp;&nbsp;' + csys +
-            '</div>';
+        s = `<div class="on-dialog-help faded-text" style="font-size:10px;">
+              ${lonStr},&nbsp;${latStr}&nbsp;&nbsp;${csys}
+              &nbsp;&nbsp;&nbsp;<i>or</i> &nbsp;&nbsp;&nbsp;
+              ${hmsRa},&nbsp;${hmsDec}&nbsp;&nbsp;${csys}
+            </div>`;
+
+        if (wp.getCoordSys() != CoordinateSys.EQ_J2000) {
+            s += getEQJ2000(wp);
+        }
     }
     else {
-        s = '<div class=on-dialog-help>' +
-            lonStr + ',&nbsp;' + latStr + '&nbsp;&nbsp;' + csys + '</div>';
+        s = `<div class=\"on-dialog-help faded-text\" style=\"font-size:10px;\"> 
+            ${lonStr},&nbsp;${latStr}&nbsp;&nbsp;${csys}</div>`;
+        s += getEQJ2000(wp);
     }
     return s;
 


### PR DESCRIPTION
#### [Firefly-1234](https://jira.ipac.caltech.edu/browse/FIREFLY-1234)
- in the Target Panel feedback, show EQJ2000 coordinates for any non-EQJ2000 coordinates entered. See design ticket for more info: https://jira.ipac.caltech.edu/browse/FIREFLY-1184

Testing: 
- https://fireflydev.ipac.caltech.edu/firefly-1234-equatorial-coords/firefly
- in the target panel, enter any non-EQJ2000 coordinates. E.g.: "250, 5 Gal", "105, 5 B1950", "200, 80 ECL", etc. 
- ensure that the resulting EQJ2000 coordinates on a new line look correct. I used NED's calculator to cross check as well:  https://ned.ipac.caltech.edu/coordinate_calculator 