### PR TITLE
FIREFLY-1266: Fix Naif ID resolution conflicts for different formats

### DIFF
--- a/src/firefly/js/ui/NaifidPanel.jsx
+++ b/src/firefly/js/ui/NaifidPanel.jsx
@@ -12,13 +12,16 @@ import {TargetFeedback} from './TargetFeedback';
 
 
 const LABEL_DEFAULT = 'Moving Target Name:';
-const searchHistory = []; // defining as global to persist it throughout the lifetime of app
+const DEFAULT_FORMAT = 'default';
+const searchHistory = {[DEFAULT_FORMAT]: []}; // defining as global to persist it throughout the lifetime of app
 
 
 function NaifidPanelView({showHelp, valid, message, examples, feedback, value, labelWidth, feedbackStyle, popStyle,
-                             label= LABEL_DEFAULT, fireValueChange, updateNaifNameValue, naifIdFormat}){
+                             label= LABEL_DEFAULT, fireValueChange, updateNaifNameValue,
+                             naifIdFormat=DEFAULT_FORMAT}){
     const getSuggestions = (val= '') => {
         if (!val) return [];
+        if (naifIdFormat && !searchHistory[naifIdFormat]) searchHistory[naifIdFormat] = [];
 
         const rval = resolveNaifidObj(val, naifIdFormat);
         if (!rval.p) return [];
@@ -29,15 +32,15 @@ function NaifidPanelView({showHelp, valid, message, examples, feedback, value, l
         };
 
         //if value has been searched previously, no need to call the api again.
-        if (searchHistory.length > 0){
-            const cachedSuggList = Object.values(searchHistory).find((v) => (v.searchVal === val));
+        if (searchHistory[naifIdFormat].length > 0){
+            const cachedSuggList = Object.values(searchHistory[naifIdFormat]).find((v) => (v.searchVal === val));
             if (cachedSuggList?.searchRes) return getResSuggestionsList(cachedSuggList.searchRes);
         }
 
         return rval.p.then((response)=>{
             if (response.valid) {
                 const suggestionsList = Object.entries(response.data).map(([k,v]) => ({naifId: v, naifName: k}));
-                searchHistory.push({searchVal: val, searchRes: suggestionsList});
+                searchHistory[naifIdFormat].push({searchVal: val, searchRes: suggestionsList});
                 return getResSuggestionsList(suggestionsList);
 
             } else {


### PR DESCRIPTION
Fixes [FIREFLY-1266](https://jira.ipac.caltech.edu/browse/FIREFLY-1266)

- Made searchHistory aware of naifIdFormat by converting it to an object with keys for each format

## Testing
https://firefly-1266-naifid-conflict.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA

- Go to search by moving object, search Gaspra - check that naif ID is in 7-digit format, now go to Precovery, search Gaspra again and check that ID is in 8-digit (default) format (instead of 7 digit -- earlier behaviour)
- Go to precovery, search karin, check ID should be in 8-digit format. Now go to moving object, search karin, check ID should be in 7-digit format (instead of 8 digit -- earlier behaviour)
 
https://firefly-1266-naifid-conflict.irsakudev.ipac.caltech.edu/applications/sofia

Make sure this change didn't affect how solar system target or precovery search used to work in Sofia (which uses default naif ID format for both)