### PR TITLE
Firefly 1150 object id tap

### DIFF
--- a/src/firefly/js/ui/tap/ObjectIDSearch.jsx
+++ b/src/firefly/js/ui/tap/ObjectIDSearch.jsx
@@ -1,0 +1,241 @@
+import React, {useContext, useEffect, useState} from 'react';
+import {FieldGroupCtx} from 'firefly/ui/FieldGroup';
+import {ConstraintContext} from 'firefly/ui/tap/Constraints';
+import {useFieldGroupRerender, useFieldGroupValue} from 'firefly/ui/SimpleComponent';
+import {
+    getPanelPrefix, makeCollapsibleCheckHeader, makeFieldErrorList, makePanelStatusUpdater
+} from 'firefly/ui/tap/TableSearchHelpers';
+import {getAsEntryForTableName, makeUploadSchema, tapHelpId} from 'firefly/ui/tap/TapUtil';
+import PropTypes from 'prop-types';
+import {ExtraButton} from 'firefly/ui/FormPanel';
+import {showUploadTableChooser} from 'firefly/ui/UploadTableChooser';
+import {showColSelectPopup} from 'firefly/charts/ui/ColSelectView';
+import {getSizeAsString} from 'firefly/util/WebUtil';
+import {ColsShape, ColumnFld, getColValidator} from 'firefly/charts/ui/ColumnOrExpression';
+import {FieldGroupCollapsible} from 'firefly/ui/panel/CollapsiblePanel';
+
+const UploadObjectIDColumn = 'uploadObjectIDColumn';
+const ObjectIDColumn = 'objectIDColumn';
+const panelTitle = 'ObjectID Search';
+const panelValue = 'ObjectIDMatch';
+const TAB_COLUMNS_MSG = 'This will be matched against ObjectID selected from the uploaded table above';
+const panelPrefix = getPanelPrefix(panelValue);
+
+const checkHeaderCtl= makeCollapsibleCheckHeader(getPanelPrefix(panelValue));
+const {CollapsibleCheckHeader, collapsibleCheckHeaderKeys}= checkHeaderCtl;
+
+const fldListAry= [UploadObjectIDColumn, ObjectIDColumn];
+
+export function ObjectIDSearch({cols, initArgs={}, capabilities, tableName}) {
+    const [getUploadInfo, setUploadInfo]=  useFieldGroupValue('uploadInfoObjectID');
+    const {setConstraintFragment}= useContext(ConstraintContext);
+    const {canUpload=false}= capabilities ?? {};
+    const [openMsg, setOpenMsg]= useState(TAB_COLUMNS_MSG);
+    const {setVal,getVal,makeFldObj}= useContext(FieldGroupCtx);
+
+    useFieldGroupRerender([...fldListAry, ...collapsibleCheckHeaderKeys]); // force rerender on any change
+
+    const uploadInfo= getUploadInfo() || undefined;
+    const [constraintResult, setConstraintResult] = useState({});
+    const posOpenKey= 'objectID-column-selected-table';
+
+    const updatePanelStatus= makePanelStatusUpdater(checkHeaderCtl.isPanelActive(), 'ObjectID');
+
+    useEffect(() => {
+        const constraints= makeObjectIDConstraints(makeFldObj(fldListAry), uploadInfo, tableName, canUpload);
+        updatePanelStatus(constraints, constraintResult, setConstraintResult);
+    });
+
+    //setVal may be used in a useEffect (?) if we want to set default ObjectID cols
+
+    useEffect(() => {
+        setConstraintFragment(panelPrefix, constraintResult);
+        return () => setConstraintFragment(panelPrefix, '');
+    }, [constraintResult]);
+
+    if (!canUpload) return <div></div>; //this service does not support uploads
+
+    return (
+        <CollapsibleCheckHeader title={panelTitle} helpID={tapHelpId(panelPrefix)}
+                                message={constraintResult?.simpleError??''} initialStateOpen={false}>
+            <div style={{marginTop: 5}}>
+                <UploadTableSelectorObjectID {...{uploadInfo, setUploadInfo}}/>
+                <ObjectIDCol {...{
+                    objectCol: getVal(ObjectIDColumn), cols,
+                    headerTitle: 'ObjectID (from table):', openKey: posOpenKey,
+                    headerPostTitle: '(from the selected table on the right)',
+                    openPreMessage:openMsg,
+                    headerStyle:{paddingLeft:1},
+                    objectKey: ObjectIDColumn
+                }} />
+            </div>
+        </CollapsibleCheckHeader>
+    );
+}
+
+ObjectIDSearch.propTypes = {
+    initArgs: PropTypes.object,
+    cols: ColsShape,
+    capabilities: PropTypes.object,
+    tableName: PropTypes.string
+};
+
+function defaultColsEnabledObj() {
+    return {
+        colTypes: ['int','long','string'],
+        colCount: 3
+    };
+}
+
+function UploadTableSelectorObjectID({uploadInfo, setUploadInfo}) {
+    const {groupKey,setVal}= useContext(FieldGroupCtx); //keeping this for now as setVal may be used if we want to set default ObjectID cols
+    const [getObjectCol,setObjectCol]= useFieldGroupValue(UploadObjectIDColumn);
+    const {fileName,columns,totalRows,fileSize}= uploadInfo ?? {};
+    const columnsUsed= columns?.filter( ({use}) => use)?.length ?? 0;
+    const openKey= 'upload-objectID-column';
+
+    useEffect(() => {
+        //if user changes position column(s), make the new columns entries selectable in the columns/search
+        const columns = uploadInfo?.columns;
+        if (getObjectCol()) {
+            const cObj= columns.find((col) => col.name === getObjectCol());
+            if (cObj) cObj.use = true;
+        }
+        uploadInfo = {...uploadInfo, columns};
+        setUploadInfo(uploadInfo);
+    }, [getObjectCol]);
+
+    const preSetUploadInfo= (ui) => {
+        setObjectCol('');
+        setUploadInfo(ui);
+    };
+
+    const haveFile= Boolean(fileName && columns);
+
+    const onColsSelected = (selectedColNames) => {
+        //get rid of extra quotes within each selectedColNames - because non-alphanumeric entries may have
+        //been quoted by calling quoteNonAlphanumeric
+        // , e.g.: ['"Object Name"', 'RA', 'Notes']
+        selectedColNames = selectedColNames.map((col) => col.replace(/^"(.*)"$/, '$1'));
+        const columns = uploadInfo?.columns.map((col) => (
+            {...col, use:selectedColNames.includes((col.name))}));
+        uploadInfo = {...uploadInfo, columns};
+        setUploadInfo(uploadInfo);
+    };
+
+    return (
+        <div style={{margin: '10px 0 0 0'}}>
+            <div style={{display:'flex', alignItems:'center'}}>
+                <div style={{whiteSpace:'nowrap'}}>Upload Table:</div>
+                <div style={{display:'flex', alignItems:'center'}}>
+                    <ExtraButton text={fileName ? 'Change...' : 'Add...'}
+                                 onClick={() => showUploadTableChooser(preSetUploadInfo,'objectIDMatch',defaultColsEnabledObj())} style={{marginLeft: 42}} />
+                    {haveFile &&
+                        <div style={{width:200, overflow:'hidden', whiteSpace:'nowrap', fontSize:'larger',
+                            textOverflow:'ellipsis', lineHeight:'2em', paddingLeft:15}}>
+                            {`${fileName}`}
+                        </div>
+                    }
+                </div>
+            </div>
+            {haveFile &&
+                <div style={{display:'flex', flexDirection:'row', marginLeft: 195, justifyContent:'flex-start'}}>
+                    <div style={{whiteSpace:'nowrap'}}>
+                        <span>Rows: </span>
+                        <span>{totalRows},</span>
+                    </div>
+                    <div style={{paddingLeft: 8, whiteSpace:'nowrap'}}>
+                        <a className='ff-href'onClick={() => showColSelectPopup(columns, onColsSelected, 'Choose Columns', 'OK',
+                            null,true)}>
+                            <span>Columns: </span>
+                            <span>{columns.length} (using {columnsUsed})</span>
+                        </a>
+                        {fileSize &&<span>,</span>}
+                    </div>
+                    {fileSize && <div style={{paddingLeft: 8, whiteSpace:'nowrap'}}>
+                        <span>Size: </span>
+                        <span>{getSizeAsString(fileSize)}</span>
+                    </div>}
+                </div>
+            }
+            {haveFile &&
+            <ObjectIDCol {...{objectCol: getObjectCol(), cols:columns,
+                headerTitle:'Uploaded ObjectID:', openKey,
+                headerPostTitle:'(from the uploaded table)',
+                headerStyle:{paddingLeft:1},
+                style:{margin:'0 0 10px 195px'},
+                labelStyle:{paddingRight:10},
+                objectKey:UploadObjectIDColumn }} />
+            }
+        </div>
+    );
+}
+
+function ObjectIDCol({objectCol, style={},cols, objectKey, openKey, labelStyle,
+                           headerTitle, headerPostTitle = '', openPreMessage='', headerStyle}) {
+    const posHeader= (
+        <div style={{marginLeft:-8}}>
+            <span style={{fontWeight:'bold', ...headerStyle}}>
+                {(objectCol) ? `${objectCol || 'unset'}` : 'unset'}
+            </span>
+            <span style={{paddingLeft:12, whiteSpace:'nowrap'}}>
+                {headerPostTitle}
+            </span>
+        </div>
+    );
+
+    return (
+        <div style={{margin: '5px 0 0 0',...style}}>
+            <div style={{display:'flex'}}>
+                <div style={{width:140, marginTop:10, whiteSpace:'nowrap', ...labelStyle}}>
+                    {headerTitle}
+                </div>
+                <FieldGroupCollapsible header={posHeader} headerStyle={{paddingLeft:0}} contentStyle={{marginLeft:4}}
+                                       initialState={{value:'closed'}} fieldKey={openKey}>
+                    {openPreMessage && <div style={{padding:'0 0 10px 0'}}>
+                        {openPreMessage}
+                    </div>}
+                    <ColumnFld fieldKey={objectKey} cols={cols}
+                               name='ObjectID Column'  // label that appears in column chooser
+                               inputStyle={{overflow:'auto', height:12, width: 100}}
+                               tooltip={'ObjectID Column'}
+                               label='ObjectID:'
+                               labelWidth={62}
+                               validator={getColValidator(cols, true, false)} />
+                </FieldGroupCollapsible>
+
+            </div>
+        </div>
+    );
+}
+
+function makeObjectIDConstraints(fldObj, uploadInfo, tableName, canUpload) {
+    const {fileName,serverFile, columns:uploadColumns, totalRows, fileSize}= uploadInfo ?? {};
+    const {[UploadObjectIDColumn]:uploadObjectIDCol, [ObjectIDColumn]:objectIDCol }= fldObj;
+
+    let adqlConstraint = '';
+    const errList= makeFieldErrorList();
+    const uploadedObjectID = uploadObjectIDCol?.value;
+    const objectID = objectIDCol?.value;
+    const tabAs= 'ut';
+    errList.checkForError(uploadObjectIDCol);
+    errList.checkForError(objectIDCol);
+    if (!uploadedObjectID && !objectID) errList.addError('The Uploaded Table and Selected Table ObjectIDs are not set.');
+    else if (!uploadedObjectID) errList.addError('Uploaded Table ObjectID is not set');
+    else if (!objectID) errList.addError('Selected Table (on the right) ObjectID is not set');
+    const validUpload= Boolean(serverFile && canUpload);
+    const preFix= validUpload ? `${getAsEntryForTableName(tableName)}` : '';
+    adqlConstraint = `(${tabAs}.${uploadedObjectID} = ${preFix}.${objectID})`;
+
+    const errAry= errList.getErrors();
+    const retObj= {
+        valid:  errAry.length===0, errAry,
+        adqlConstraintsAry: adqlConstraint ? [adqlConstraint] : [],
+        siaConstraints:[],
+        siaConstraintErrors:[],
+        TAP_UPLOAD:  makeUploadSchema(fileName,serverFile,uploadColumns, totalRows, fileSize),
+        uploadFile: fileName
+    };
+
+    return retObj;
+}

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -93,10 +93,6 @@ export function SpatialSearch({cols, serviceUrl, serviceLabel, columnsModel, tab
     const updatePanelStatus= makePanelStatusUpdater(checkHeaderCtl.isPanelActive(), Spatial);
 
     useEffect(() => {
-        /*if (canUpload) {
-            if (uploadInfo) setVal(SPATIAL_TYPE,MULTI);
-            return;
-        }*/
         if (!canUpload) setVal(SPATIAL_TYPE,SINGLE);
     }, [serviceUrl,canUpload]);
 

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -93,11 +93,11 @@ export function SpatialSearch({cols, serviceUrl, serviceLabel, columnsModel, tab
     const updatePanelStatus= makePanelStatusUpdater(checkHeaderCtl.isPanelActive(), Spatial);
 
     useEffect(() => {
-        if (canUpload) {
+        /*if (canUpload) {
             if (uploadInfo) setVal(SPATIAL_TYPE,MULTI);
             return;
-        }
-        setVal(SPATIAL_TYPE,SINGLE);
+        }*/
+        if (!canUpload) setVal(SPATIAL_TYPE,SINGLE);
     }, [serviceUrl,canUpload]);
 
     useEffect(() => {

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -7,6 +7,7 @@ import {ExposureDurationSearch} from './ObsCoreExposureDuration.jsx';
 import {SpatialSearch} from './SpatialSearch.jsx';
 import {TemporalSearch} from './TemportalSearch.jsx';
 import {ObsCoreWavelengthSearch} from './WavelengthPanel.jsx';
+import {ObjectIDSearch} from 'firefly/ui/tap/ObjectIDSearch';
 
 const TAP_SEARCH_METHODS_GROUP= 'TAP_SEARCH_METHODS_GROUP';
 
@@ -28,18 +29,20 @@ export const TableSearchMethods = ({initArgs, obsCoreEnabled, columnsModel, serv
 function HelperComponents({initArgs, cols, columnsModel, serviceUrl, serviceLabel, obsCoreEnabled, tableName, capabilities}) {
     return obsCoreEnabled ?
         (
-            <React.Fragment>
+            <>
                 <ObsCoreSearch {...{cols, serviceLabel, initArgs}} />
                 <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <ExposureDurationSearch {...{initArgs}} />
                 <ObsCoreWavelengthSearch {...{initArgs, serviceLabel}} />
-            </React.Fragment>
+                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName}}/>
+            </>
         ) :
         (
-            <React.Fragment>
+            <>
                 <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
-                <TemporalSearch {...{cols, columnsModel,}} />
-            </React.Fragment>
+                <TemporalSearch {...{cols, columnsModel}} />
+                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName}}/>
+            </>
         );
 }
 

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -5,7 +5,7 @@ import {FieldGroup} from '../FieldGroup.jsx';
 import {ObsCoreSearch} from './ObsCore.jsx';
 import {ExposureDurationSearch} from './ObsCoreExposureDuration.jsx';
 import {SpatialSearch} from './SpatialSearch.jsx';
-import {TemporalSearch} from './TemportalSearch.jsx';
+import {TemporalSearch} from './TemporalSearch.jsx';
 import {ObsCoreWavelengthSearch} from './WavelengthPanel.jsx';
 import {ObjectIDSearch} from 'firefly/ui/tap/ObjectIDSearch';
 
@@ -34,14 +34,14 @@ function HelperComponents({initArgs, cols, columnsModel, serviceUrl, serviceLabe
                 <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <ExposureDurationSearch {...{initArgs}} />
                 <ObsCoreWavelengthSearch {...{initArgs, serviceLabel}} />
-                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName}}/>
+                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName, columnsModel}}/>
             </>
         ) :
         (
             <>
                 <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <TemporalSearch {...{cols, columnsModel}} />
-                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName}}/>
+                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName, columnsModel}}/>
             </>
         );
 }

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -108,6 +108,8 @@ export function TapSearchPanel({initArgs= {}, titleOn=true}) {
     const tapOps= getTapServiceOptions();
     const {current:clickFuncRef} = useRef({clickFunc:undefined});
     const [selectBy, setSelectBy]= useState(() => {
+        const val= getFieldVal(TAP_PANEL_GROUP_KEY,'selectBy');
+        if (val) return val;
         if (initArgs?.urlApi?.adql) return 'adql';
         return initArgs?.urlApi?.selectBy || 'basic';
     });

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -435,7 +435,7 @@ function getAdqlQuery(tapBrowserState, showErrors= true) {
         const entries = [...constraintFragments.values()];
         const matchingEntries = entries.filter((c) => Boolean(c.uploadFile && c.TAP_UPLOAD && c.adqlConstraint));
         if (matchingEntries.length > 1) {
-            if (showErrors) showInfoPopup('More than one upload is not supported at this moment.', 'Error');
+            if (showErrors) showInfoPopup('We currently do not support searches with more than one uploaded table.', 'Error');
             return;
         }
     }

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -427,6 +427,17 @@ function getAdqlQuery(tapBrowserState, showErrors= true) {
     const tableName = maybeQuote(tapBrowserState?.tableName, true);
     if (!tableName) return;
     const isUpload= isTapUpload(tapBrowserState);
+
+    if (isUpload) { //check for more than one upload file (in Spatial and in ObjectID col) - should this be a utility function in constraints.js?
+        const { constraintFragments } = tapBrowserState;
+        const entries = [...constraintFragments.values()];
+        const matchingEntries = entries.filter((c) => Boolean(c.uploadFile && c.TAP_UPLOAD && c.adqlConstraint));
+        if (matchingEntries.length > 1) {
+            if (showErrors) showInfoPopup('More than one upload is not supported at this moment.', 'Error');
+            return;
+        }
+    }
+
     const helperFragment = getHelperConstraints(tapBrowserState);
     const tableCol = tableColumnsConstraints(tapBrowserState.columnsModel,
         isUpload?getAsEntryForTableName(tableName):undefined);

--- a/src/firefly/js/ui/tap/TemporalSearch.jsx
+++ b/src/firefly/js/ui/tap/TemporalSearch.jsx
@@ -109,12 +109,16 @@ export function TemporalSearch({cols, columnsModel}) {
 
     useFieldGroupWatch([TemporalColumns],
         ([tcVal],isInit) => {
+            if (!isInit && !checkHeaderCtl.isPanelActive() && tcVal) {
+                checkHeaderCtl.setPanelActive(true);
+            }
+            if (!checkHeaderCtl.isPanelActive()) return;
             if (!tcVal) return;
             const timeColumns = tcVal.split(',').map( (c) => c.trim()) ?? [];
             if (timeColumns.length > 1) {
                 setFld(TemporalColumns, {value:tcVal, valid:false, message: 'you may only choose one column'});
             }
-        });
+        }, [checkHeaderCtl.isPanelActive()]);
 
     useEffect(() => {
         const constraints= makeTemporalConstraints(columnsModel, makeFldObj([TimeFrom,TimeTo,TemporalColumns]));
@@ -126,10 +130,6 @@ export function TemporalSearch({cols, columnsModel}) {
         return () => setConstraintFragment(panelPrefix, '');
     }, [constraintResult]);
 
-    useEffect(() => {
-        if (timeCol && timeCol != '') checkHeaderCtl.setPanelActive(true);
-    }, [timeCol]);
-
 
     useEffect(() => {
         const findTimeCol= findTimeColumn(columnsModel) ?? '';
@@ -140,7 +140,7 @@ export function TemporalSearch({cols, columnsModel}) {
         if (existingTimeCol) timeColExists = cols.some((c) => c.name === existingTimeCol);
         if (!timeColExists) existingTimeCol = findTimeCol;
         setVal(TemporalColumns, existingTimeCol, {validator: getColValidator(cols, true, false, errMsg), valid: true});
-        if (Boolean(timeCol)) checkHeaderCtl.setPanelOpen(true);
+        if (Boolean(findTimeCol)) checkHeaderCtl.setPanelOpen(true);
     }, [columnsModel]);
 
 

--- a/src/firefly/js/ui/tap/TemportalSearch.jsx
+++ b/src/firefly/js/ui/tap/TemportalSearch.jsx
@@ -64,6 +64,7 @@ function makeTemporalConstraints(columnsModel, fldObj) {
     }
 
     if (!timeFromField.value && !timeToField.value) errList.addError('Time is Required');
+    if (!temporalColumnsField.value) errList.addError('Temporal Columns required');
     errList.checkForError(timeFromField);
     errList.checkForError(timeToField);
     errList.checkForError(temporalColumnsField);
@@ -125,12 +126,21 @@ export function TemporalSearch({cols, columnsModel}) {
         return () => setConstraintFragment(panelPrefix, '');
     }, [constraintResult]);
 
+    useEffect(() => {
+        if (timeCol && timeCol != '') checkHeaderCtl.setPanelActive(true);
+    }, [timeCol]);
+
 
     useEffect(() => {
-        const timeCol= findTimeColumn(columnsModel) ?? '';
+        const findTimeCol= findTimeColumn(columnsModel) ?? '';
         const errMsg= 'Temporal searches require identifying a table column containing a time in MJD.  Please provide a column name.';
-        setVal(TemporalColumns, timeCol, {validator: getColValidator(cols, true, false, errMsg), valid: true});
-        checkHeaderCtl.setPanelOpen(Boolean(timeCol));
+        let existingTimeCol = timeCol; //get current val of TemporalColumns
+        let timeColExists = false;
+        //check if user has a previously selected Temporal Column, and if it exists in the currently selected table's cols
+        if (existingTimeCol) timeColExists = cols.some((c) => c.name === existingTimeCol);
+        if (!timeColExists) existingTimeCol = findTimeCol;
+        setVal(TemporalColumns, existingTimeCol, {validator: getColValidator(cols, true, false, errMsg), valid: true});
+        if (Boolean(timeCol)) checkHeaderCtl.setPanelOpen(true);
     }, [columnsModel]);
 
 


### PR DESCRIPTION
#### [Firefly-1150](https://jira.ipac.caltech.edu/browse/FIREFLY-1150)
- Added a new Search Helper (ObjectID Search) to the TAP panel under services that support uploads 
- allow user to upload a table and select a column from their uploaded table, and a column from the selected table on the right. This will lead to a new ADQL constraints of the format '`ut.objectID = a.objectID`' (ut = uploaded table, a = first char of the selected table in this case) 
- This is a draft PR because I need to fix one small style issue and at possibly this bug below:
- Bug Description 
  - This is a regression bug. Switching back from **multi-object** to **Single Shape** leads to some incorrect ADQL. For a service, like GAIA (and table is "public.hipparcos"), if under **Spatial** you select **Multi-object** and upload a table. Now if you select **Single Shape** and enter in, say, M31, and click on **Populate and Edit ADQL**. Notice that the **WHERE** clause includes "p.ra" and "p.de", even though the **FROM** clause is just: `FROM public.hipparcos` and not `FROM public.hipparcos as p` (as it would be if there were an uploaded table). 
      - If you try to do a search now, you'd get an error which would include "`Unknown column "p.ra"`" and "`Unknown column "p.de"`"...
      - for some reason, this same behavior does not affect some of the tables under IRSA/CADC. So will need to test this further, but the basic idea of the fix is that if you switch from multi-object to single shape and there's no uploaded table for that search, then "**p.ra**" and "**p.de**" should simply be **ra** and **de** 

**Updates 7/6**: 
   - The Temporal Column and Spatial Type bugs have been fixed
   - For bug description, see @loitly's main comment on this PR below 
       - **Spatial Search bug**
          - multi-object selection was very persistent. This is fixed now by commenting out a use-effect (I don't think there's any need for it anymore, but commented out just so reviewers can take a look at it). Whatever Spatial Type you select now (single shape or multi-object), the selection is respected when you switch services or go to `Edit ADQL` and back to `UI Assisted` mode.  
          - the **_exception_** to this bug is, if you do a whole table search (or "search TAP for row" from the table), then the useEffect that gets triggered (line 103 in `SpatialSearch.jsx`) has ones of its dependencies: _searchParams.uploadInfo_. _searchParams_ comes, as part of _initArgs_, all the way from defaultSearchActions.js (see the `searchWholeTable` function in this file as an example). This useEffect sets `SPATIAL_TYPE` to `MULTI`, which is good the first time a user does a search from a table. But after that, user may switch to single shape and go to `Edit ADQL` or a different service. And if you go back to the previous service or `UI Assisted` mode, multi-object is selected again. I am not really sure what a good fix for this is. 
      - **Temporal Search bug**
        - see my comment below for explanation of this commit 
  -  test build is updated, feel free to try it out!

**Updates 7/10**: 
- there will still some issues with Temporal and Spatial search bugs, as described by @loitly below. These are all fixed now and the test build is updated to reflect these changes. 
- Also includes @robyww's commit to fix `Edit ADQL` and make it sticky (if you select `Edit ADQL`, do a search and click on `TAP` again, it should take you to the `Edit ADQL` mode and not the UI Assisted mode). 

**Updates 7/10 Part 2**:
  - The UI changes to ObjectID Search Helper suggested by @robyww are in. Object ID Search helper is selected when you interact with it (upload a table, or change the column). And the Object ID columns are now open by default as well. 
  - There were a couple of bugs I noticed: The `Uploaded Object ID` field was not validating column entries. And the `Object ID (from the selected table on the right)` field was not updating its columnsModel for the column validator when you switched services/tables correctly. 
  - Fixed these and now the Object ID Search Helper is fully functional and has expected behavior (and bug free, from what I have tested). 

**Updates 7/11**:
- got some of the final PR comments in, involves some code cleanup. Using JSdoc/typdef, and simplifying a for loop to use filter instead, amongst other changes. 

**Testing**: 
- https://fireflydev.ipac.caltech.edu/firefly-1150-objectid-tap/firefly
- for any service that supports uploads (IRSA, CADC, etc.), upload a table using the ObjectID Search helper in the TAP panel and select an ObjecyID column for your uploaded table and for the selected table on the right. For testing purposes, this could be any column you want. 
  - Click on **Populate and edit ADQL**. Make sure the ADQL looks correct. 
  - Ideally, select a service and table that is not too big. This is an issue i've been running into for testing. Because of the `WHERE ut.objectID = a.objectID` type of query, I think every row of the selected table on the right is being checked, which makes sense. So even if you add a row limit, if the table is big enough, the search will be slow. I tried the **CADC's ivoa.ObsCore** table (which has  166,523 rows) and so far that gave me the fastest results... 
- Seelct IRSA as the TAP service. Upload a table under the **Spatial** search helper, and also the **ObjectID Search** helper (make sure both of these are selected as well). Click on **Populate and edit ADQL**. This should give you an error, because we don't support multiple uploads at this time. 
- switch to a service like NED, make sure the **ObjectID Search** helper doesn't show up here 