### PR TITLE
FIREFLY 1073: Support for 'POINT' type s_region and prevent coverage from failing

### DIFF
--- a/src/firefly/js/util/ObsCoreSRegionParser.js
+++ b/src/firefly/js/util/ObsCoreSRegionParser.js
@@ -11,7 +11,7 @@ import {convertAngle} from '../visualize/VisUtil.js';
 import ShapeDataObj from '../visualize/draw/ShapeDataObj.js';
 import VisUtil from '../visualize/VisUtil.js';
 
-const regionShape = new Enum(['circle', 'box', 'polygon', 'position']);
+const regionShape = new Enum(['circle', 'box', 'polygon', 'position', 'point']);
 const CoordSys = new Enum(['ECLIPTIC', 'FK4', 'FK5', 'J2000', 'GALACTIC', 'ICRS', 'UNKNOWNFRAME']);
 const RefPos = new Enum(['BARYCENTER', 'GEOCENTER', 'HELIOCENTER', 'LSR', 'TOPOCENTER', 'RELOCATABLE', 'UNKNOWNREFPOS']);
 const Flavor = new Enum(['CARTESIAN2', 'CARTESIAN3', 'SPHERICAL2']);
@@ -130,7 +130,8 @@ export function parseObsCoreRegion(sRegionVal, unit='deg', isCorners=false) {
     let  pairCoord;
 
     switch(sAry[0].toLowerCase()) {
-        case regionShape.position.key:
+        case regionShape.position.key :
+        case regionShape.point.key :
             if (sAry.length === coord2 + 1) {
                 pairCoord = getPairCoord(sAry, [coord1, coord2]);
 

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -28,7 +28,8 @@ const startWatcher= once((viewerId) => {
     },1);
 });
 
-const isCoverageFail= (covState,tbl_id) => covState.find( (e) => e.tbl_id===tbl_id)?.status===COVERAGE_FAIL;
+const isCoverageFail= (covState,tbl_id) => covState.find((e) => e.tbl_id === tbl_id)?.status === COVERAGE_FAIL;
+
 
 const getActiveOrFirstTblId= () => getActiveTableId() || getTblIdsByGroup()[0];
 
@@ -78,13 +79,13 @@ export function CoverageViewer({viewerId=DEFAULT_COVERAGE_VIEWER_ID,insideFlex=t
     else {
         let msg;
         if (tblHasCoverage || isFetching) {
-            msg= isCoverageFail(covState,tbl_id) ? makeNovCovMsg(noCovMessage,tbl_id) : workingMessage;
+            msg= isCoverageFail(covState,tbl_id) ? makeNovCovMsg(covState,noCovMessage,tbl_id) : workingMessage;
         }
         else if (forceShow) {
-            msg= anyTblHasCoverage(covState) ? workingMessage : makeNovCovMsg(covState, noCovMessage,tbl_id);
+            msg= anyTblHasCoverage(covState) ? workingMessage : makeNovCovMsg(covState,noCovMessage,tbl_id);
         }
         else {
-            msg= makeNovCovMsg(covState, noCovMessage,tbl_id);
+            msg= makeNovCovMsg(covState,noCovMessage,tbl_id);
         }
         return (
             <div className='ComponentBackground' style={{...{paddingTop:35, width:'100%',textAlign:'center',fontSize:'14pt'},...noCovStyle}}>


### PR DESCRIPTION
#### [Firefly-1073](https://jira.ipac.caltech.edu/browse/FIREFLY-1073)
- This ticket addresses a few small issues (also see related ticket https://jira.ipac.caltech.edu/browse/IRSA-4866) 
   - Treating **POINT** type s_regions the same as **POSITION** type s_regions fixes this specific issue, and the coverage map loads as expected (see changes in ObsCoreSRegionParser's `parseObsCoreRegion` function).  
   - If s_region wasn't parsed correctly in **ObsCoreSRegionParser.js** (the switch statement on line 132 leads to the default case), then the coverage would fail and the app would crash. Reason for this is that when s_region exists but is parsed as invalid, then the **isCoverageFail** function of **CoveraeViewer.jsx** gets a **covState** value that is a string ('_No coverage available_') instead of an array, which is why `covState.find` fails. Adding a check fixed this. 
   -  Even after the above fix, if you have a s_region value that isn't parsed (let's say if the format of s_region is changed in the future), we should still be able to load coverage map if ra,dec exist. For this, we need to drop (or ignore) s_region if it was parsed as an invalid value. Hence, in CoverageWatcher.js, alongside the check for `isTableWithRegion(table)`, I also added a check for `getRegionAryFromTable(options, table)` returning an empty array (this function calls `parseObsCoreRegion`. If it returns an invalid s_region value,  `getRegionAryFromTable` returns an empty array).  So even if s_region exists but regionAry is empty, we'll not assign **CoverageType** as **REGION**. Which make sure coverage map still loads correctly even if s_region exists but isn't parsed as valid. 
        - I tested this by using the table in the IRSA ticket above, and removing my "**regionShape.point.key**" switch statement in `parseObsCoreRegion` function (while keeping all other changes), and the coverage map still loaded

**Updates 7/5**:
  - fixed a bug which allows isCoverageFail function to go back to its previous state
  - added a console.log note for the user/developer when s_region exists but isn't parsed as valid (possibly because we don't support its format). This will let the developer know we have not displayed s_region on the coverage map. 
     - @ejoliet or anyone else: if you would like to test this locally: Pull my branch, comment out line 134 in ObsCoreSRegionParser.js (`case regionShape.point.key`) and upload the file from the IRSA-4866 ticket above. Then click on coverage map. You should see a message in your console notifying you we didn't pick s_region for the coverage map. 

Testing: 
- https://fireflydev.ipac.caltech.edu/firefly-1073-sregion/firefly
- use the table in the IRSA-4866 ticket above, and load it from the Upload tab. 
- Click on Coverage and make sure the coverage map loads.
