### PR TITLE
FIREFLY-1285: SPHEREx photometry table sample fails to load

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -780,7 +780,9 @@ public class EmbeddedDbUtil {
             case LONGVARCHAR:
                 return String.class;
             case TINYINT:
+                return Byte.class;
             case SMALLINT:
+                return Short.class;
             case INTEGER:
                 return Integer.class;
             case BIGINT:

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -442,7 +442,7 @@ public class IpacTableUtil {
                     int endoffset = Math.min(pci.endIdx, endOfLine);
                     String val = line.substring(pci.startIdx, endoffset).trim();
 
-                    if (!dt.isKnownType()) {
+                    if (!isKnownType(dt.getDataType())) {
                         IpacTableUtil.guessDataType(dt, val);
                     }
                     applyGuessLogic(dt, val, pci);
@@ -490,6 +490,23 @@ public class IpacTableUtil {
 
     public static IpacTableDef getMetaInfo(BufferedReader reader) throws IOException {
         return doGetMetaInfo(reader, null);
+    }
+
+    public static boolean isKnownType(Class type) {
+        return (type == String.class  ||
+                type == Double.class  ||
+                type == Float.class   ||
+                type == Integer.class ||
+                type == Long.class
+        );
+    }
+
+    public static Class mapToIpac(Class type) {
+        if (type == Short.class)    return Integer.class;
+        if (type == Boolean.class)  return String.class;
+        if (type == Byte.class)     return Integer.class;
+
+        return type;
     }
 
     private static IpacTableDef doGetMetaInfo(BufferedReader reader, File src) throws IOException {

--- a/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DsvTableIO.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import static edu.caltech.ipac.table.IpacTableUtil.isKnownType;
+
 /**
  * This is a utility class used to read/write Delimiter-separated values(DSV)
  * file into/from a DataGroup object.
@@ -131,7 +133,7 @@ public class DsvTableIO {
                 for (int i = 0; i < headers.length; i++) {
                     DataType type = headers[i];
                     val = StringUtils.isEmpty(line.get(i)) ? null : line.get(i).trim();
-                    if (!type.isKnownType()) {
+                    if (!isKnownType(type.getDataType())) {
                         IpacTableUtil.guessDataType(type,val);
                     }
                     row.setDataElement(type, type.convertStringToData(val));

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
@@ -3,17 +3,16 @@
  */
 package edu.caltech.ipac.table.io;
 import edu.caltech.ipac.table.*;
+
+import static edu.caltech.ipac.table.DataType.*;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.Date;
 import edu.caltech.ipac.table.TableUtil;
 
 import edu.caltech.ipac.util.StringUtils;
@@ -67,27 +66,22 @@ public class VoTableWriter {
         FitsFactory.useThreadLocalSettings(false);
     }
 
+    /**
+     * @param typeDesc  String description of column's data type
+     * @return VoTable type for the given Firefly's Type
+     */
+    private static String mapToVoType(String typeDesc) {
+        if (typeDesc.equals(DATE))      return "char";
+        if (typeDesc.equals(LOCATION))  return "char";
+        if (typeDesc.equals(REAL))      return "double";
+
+        return typeDesc;
+    }
 
     private static class DataGroupXML {
         private List<DataGroup.Attribute> tableMeta;
         private DataGroup dataGroup;
         private String tagDesc = "DESCRIPTION";
-        private static final Map<Class, String> dataTypeMap = new HashMap<>();
-
-        // not included: "bit", "unicodeCode", "floatComplex", "doubleComplex"
-        static {
-            dataTypeMap.put(Boolean.class, "boolean");
-            dataTypeMap.put(Byte.class, "unsignedByte");
-            dataTypeMap.put(Short.class, "short");
-            dataTypeMap.put(Integer.class, "int");
-            dataTypeMap.put(Long.class, "long");
-            dataTypeMap.put(String.class, "char");
-            dataTypeMap.put(Character.class, "char");
-            dataTypeMap.put(Float.class, "float");
-            dataTypeMap.put(Double.class, "double");
-            dataTypeMap.put(Date.class, "char");
-        }
-
 
         DataGroupXML(DataGroup dg) {
             this.dataGroup = dg;
@@ -186,7 +180,7 @@ public class VoTableWriter {
             String atts = elementAtt(TableMeta.ID, dt.getID()) +
                           elementAtt(TableMeta.NAME, dt.getKeyName()) +
                           elementAtt(TableMeta.UCD, dt.getUCD()) +
-                          elementAtt("datatype", dataTypeMap.get(dt.getDataType())) +
+                          elementAtt("datatype", mapToVoType(dt.getTypeDesc())) +
                           elementAtt("width", width) +
                           elementAtt("precision",
                                      (!isEmpty(prec) && prec.startsWith("G")) ? prec.substring(1) : prec) +


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1285
- complete TODO item in DataType that maps the remaining VoTable types to Firefly
- remove useShortDesc in DataType.
- add round trip support for VoTable to IPAC to VoTable when VoTable contains types not supported by IPAC table.

From ticket:

> Due to incomplete mappings, it was mapping the missing types to String which causes the Type mismatch exception.  I fixed that as well as cleaning up some old code.  I also added round-trip support for VoTable -> IPAC table -> VoTable even though IPAC table do not support these types.  To do this, I added the type mappings info into the IPAC Table's meta

Test: https://fireflydev.ipac.caltech.edu/firefly-1285-spherex-table-load-fail/firefly
See ticket for link to test table.

-> Upload test table.  It should load fine.  Then, Save as IPAC table
-> Upload IPAC table, content should still look good.  Now, Save as VOTABLE
-> Uploaded saved VOTable.  Table should still look good.

