### PR TITLE
Firefly-1292: TAP UI Crashes when selecting TAP_SCHEMA table

### DIFF
--- a/src/firefly/js/ui/tap/TemporalSearch.jsx
+++ b/src/firefly/js/ui/tap/TemporalSearch.jsx
@@ -83,10 +83,10 @@ export function findTimeColumn(columnsTable) {
     const nIdx= getColumnIdx(columnsTable,'column_name',true);
     const unitIdx= getColumnIdx(columnsTable,'unit',true);
     if (ucdIdx===-1 || nIdx===-1) return;
-    const timeRows= columnsTable.tableData.data.filter( (row) => row[ucdIdx]?.includes('time.epoch') && row[unitIdx].startsWith('d'));
-    if (!timeRows.length) return;
-    const mainRows= timeRows.filter( (row) => row[ucdIdx]?.includes('meta.main') && row[unitIdx].startsWith('d'));
-    return mainRows.length ? mainRows[0][nIdx] : timeRows[0][nIdx];
+    const timeRows= columnsTable.tableData.data?.filter( (row) => row[ucdIdx]?.includes('time.epoch') && row[unitIdx].startsWith('d'));
+    if (!timeRows?.length) return;
+    const mainRows= timeRows?.filter( (row) => row[ucdIdx]?.includes('meta.main') && row[unitIdx].startsWith('d'));
+    return mainRows?.length ? mainRows[0][nIdx] : timeRows[0][nIdx];
 }
 
 


### PR DESCRIPTION
#### [Firefly-1292](https://jira.ipac.caltech.edu/browse/FIREFLY-1292)
- fixes a bug causing a crash on irsaviewer when selecting the `TAP_SCHEMA` project with IRSA selected as the TAP service (presumably because the default table that shows up with `TAP_SCHEMA`: `TAP_SCHEMA.schemas` is empty - and that's a different issue that may need looking into as well). 

Testing: 
- Firefly: https://fireflydev.ipac.caltech.edu/firefly-1292-crash/firefly, IRSAViewer: https://firefly-1292-crash.irsakudev.ipac.caltech.edu/irsaviewer
- You can test using any of the 2 links above (firefly directly or irsaviewer) 
- go to the TAP UI from either 
- With IRSA selected as the TAP service, from `Project`, select `TAP_SCHEMA`. The default table that shows up here (`TAP_SCHEMA.schemas`) is empty (cause of the crash before the fix). Now you should just see this empty table, but the app shouldn't crash.
