### PR TITLE
Firefly-1281: Fixing error in processing s_region values containing zeros 

### DIFF
--- a/src/firefly/js/util/ObsCoreSRegionParser.js
+++ b/src/firefly/js/util/ObsCoreSRegionParser.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import { isEmpty} from 'lodash';
+import {isEmpty, isNil} from 'lodash';
 import Enum from 'enum';
 import {CoordinateSys} from '../visualize/CoordSys.js';
 import PointDataObj from '../visualize/draw/PointDataObj.js';
@@ -32,8 +32,12 @@ const errorMessage = {[ErrorRegion.notSupportCoordSys.key]: 'coordinate system i
 
 
 function getPairCoord(sAry, pairIdx) {
+    //if pairIdx included indices that should have returned, for instance, [149,0], then we would only get [149]
+    //The filter() function in JavaScript removes elements that are "falsy" values, and 0 is considered falsy.
+    //That's why 0 was being ignored when we did filter((n) => n)....making the change below in filter fixes this issue
     return pairIdx.map((coord) => (isNaN(sAry[coord]) ? null : Number(sAry[coord])))
-                  .filter((n) => n);
+        .filter((n) => !isNil(n));
+
 }
 
 const makeWpt = (pCoord, coordSys, unit) => {


### PR DESCRIPTION
#### [Firefly-1281](https://jira.ipac.caltech.edu/browse/FIREFLY-1281)
- see the ticket for details of the issue
- see comment in the code for the fix 

Testing: 
- https://fireflydev.ipac.caltech.edu/firefly-1281-sregion-err/firefly
- use the table from the ticket above, upload it. From the tri-view, click on Coverage above the image and then click on the layers icon. The error that you see in the screenshot in the ticket should not be seen now, as all 0.0 and -0.0 values are read correctly as expected now. 
