### PR TITLE
Firefly-1279: TAP Object ID Search Cleanup

### DIFF
--- a/src/firefly/js/charts/ui/ColSelectView.jsx
+++ b/src/firefly/js/charts/ui/ColSelectView.jsx
@@ -38,7 +38,7 @@ const closeButtonStyle = {'textAlign': 'center', display: 'inline-block', height
 //const helpIdStyle = {'textAlign': 'center', display: 'inline-block', height:40, marginRight: 20};
 
 
-export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonText,currentVal,multiSelect=false) {
+export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonText,currentVal,multiSelect=false,colTblId) {
 
    if (getTblById(TBL_ID)) {
        hideColSelectPopup();
@@ -81,7 +81,7 @@ export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonTe
         columns[idx] = {name: 'Description', prefWidth: widths[idx], visibility: 'show'};
     }
 
-    const tableModel = {totalRows: data.length, tbl_id:TBL_ID, tableData: {columns,  data }, highlightedRow: hlRowNum};
+    const tableModel = {totalRows: data.length, tbl_id:colTblId ?? TBL_ID, tableData: {columns,  data}, highlightedRow: hlRowNum};
 
     if (multiSelect) { //select all columns where use:true
         const selectInfoCls = SelectInfo.newInstance({rowCount: tableModel.totalRows});

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -132,7 +132,8 @@ ColumnOrExpression.propTypes = {
 };
 
 export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidth, tooltip='Table column',
-                           name, nullAllowed, canBeExpression=false, inputStyle, readonly, helper, required, validator}) {
+                           name, nullAllowed, canBeExpression=false, inputStyle, readonly, helper, required, validator,
+                              colTblId=null,onSearchClicked=null}) {
     const value = initValue || getFieldVal(groupKey, fieldKey);
     const colValidator = getColValidator(cols, !nullAllowed, canBeExpression);
     const {valid=true, message=''} = value ? colValidator(value) : {};
@@ -151,7 +152,12 @@ export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidt
         helper = (
             <div style={{display: 'inline-block', cursor: 'pointer', paddingLeft: 2, verticalAlign: 'top'}}
                        title={`Select ${name} column`}
-                       onClick={() => showColSelectPopup(cols, onColSelected, `Choose ${name}`, 'OK', val)}>
+                         onClick={() => {
+                             if (!onSearchClicked || onSearchClicked()) {
+                                 showColSelectPopup(cols, onColSelected, `Choose ${name}`, 'OK', val, false, colTblId);
+                             }
+                         }
+                       }>
                 <ToolbarButton icon={MAGNIFYING_GLASS}/>
             </div>);
     }
@@ -197,6 +203,8 @@ ColumnFld.propTypes = {
     inputStyle: PropTypes.object,
     readonly: PropTypes.bool,
     required: PropTypes.bool,
-    helper: PropTypes.element
+    helper: PropTypes.element,
+    colTblId: PropTypes.string,
+    onSearchClicked: PropTypes.func
 };
 

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -34,14 +34,14 @@ function HelperComponents({initArgs, cols, columnsModel, serviceUrl, serviceLabe
                 <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <ExposureDurationSearch {...{initArgs}} />
                 <ObsCoreWavelengthSearch {...{initArgs, serviceLabel}} />
-                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName, columnsModel}}/>
+                <ObjectIDSearch {...{cols, capabilities, tableName, columnsModel}}/>
             </>
         ) :
         (
             <>
                 <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <TemporalSearch {...{cols, columnsModel}} />
-                <ObjectIDSearch {...{cols, initArgs, capabilities, tableName, columnsModel}}/>
+                <ObjectIDSearch {...{cols, capabilities, tableName, columnsModel}}/>
             </>
         );
 }


### PR DESCRIPTION
#### [Firefly-1279](https://jira.ipac.caltech.edu/browse/FIREFLY-1279)
- for the main table (selected table on the right), the Object ID column is populated with  `meta.id;meta.main` if available, or with the first `meta.id` if `meta.main` is not available. If both are not available, the column remains empty. 
   - _Note_: if a valid column name is found (say a UCD with `meta.id;meta.main` exists), then the `Object ID Search` helper is auto-selected by default. Is this behavior okay? **_Done_**. 
- Added the helpful text (from the ticket) right under the `Object ID Search` helper title (side note: we may also need to update the onlinehelp link next to the title for the Object ID, as this is a new feature so users may want to click on it to learn more about it). 

_Pending tasks_ (as time permits before release): 
- filtering the columns with all that have UCD set to meta.id (if there are multiple), so that user may first choose Object ID from these (and they should be able to remove this filter as well). 
- handling the selection of Object ID search when the user has chosen a file and unselected it. **_Done_**. 

**Updates 7/31:**
- Object ID search being selected when there's a file uploaded is now fixed based on PR comments below @robyww 
- addressed other change as well, Object ID search is now not auto selected (can test by switching over to CADC where the Object ID column is pre populated). 
- test build is updated with these 2 changes 

**Updates 7/31 Part 2: _Filtering_**
- With @loitly's help, was able to get filtering working. Had to use a workaround that doesn't feel super clean to ensure that the filtering is applied even when you change TAP service/tables or even re-open the column selector for the table that you're on multiple times. See my comment about this change below. 
- To test, you'll need to open a table that has more than one `meta.id` entries. I suggest switching over to CADC and choosing `Table Collection: ivoa` and table `ivoa.ObsCore`. 


**Testing**: 
- https://fireflydev.ipac.caltech.edu/firefly-1279-objectid-cleanup/firefly
- go to the TAP UI, make sure you see the new text under the Object ID Search title 
- Switch TAP service from IRSA to CADC. For the default table collection `ivoa` and the default table `ivoa.ObsCore`, the Object ID field should be populated with `obs_collection`. 
    - You can verify that this is correct by clicking on the column selector. There is no UCD with `meta.id;meta.main`, but the first UCD with `meta.id` in it is, indeed, the column selected here: `obs_collection`