### PR TITLE
FIREFLY-1256: Fix property sheet causing error in loading IrsaViewer

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -39,7 +39,7 @@ import {loadAllJobs} from './core/background/BackgroundUtil.js';
 import {
     makeDefImageSearchActions, makeDefTableSearchActions, makeDefTapSearchActions, makeExternalSearchActions
 } from './ui/DefaultSearchActions.js';
-import {PROP_SHEET} from 'firefly/tables/TableUtil';
+import {PROP_SHEET} from 'firefly/tables/ui/PropertySheet';
 
 let initDone = false;
 const logger = Logger('Firefly-init');

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -47,7 +47,6 @@ const USE_STRING = [...TEXT, ...DATE];
 // export const COL_TYPE = new Enum(['ALL', 'NUMBER', 'TEXT', 'INT', 'FLOAT']);
 export const COL_TYPE = new Enum({ANY:[],TEXT, INT, FLOAT, BOOL, DATE, NUMBER, USE_STRING});
 export const TBL_STATE = new Enum(['ERROR', 'LOADING', 'NO_DATA', 'NO_MATCH', 'OK']);
-export const PROP_SHEET = new Enum(['INTEGRATED', 'POPUP']);
 
 /**
  * @param {TableColumn} col

--- a/src/firefly/js/tables/ui/PropertySheet.jsx
+++ b/src/firefly/js/tables/ui/PropertySheet.jsx
@@ -3,6 +3,9 @@ import {TablePanel} from 'firefly/tables/ui/TablePanel';
 import React, {useEffect} from 'react';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent';
 import {dispatchTableAddLocal, dispatchTableUiUpdate} from 'firefly/tables/TablesCntlr';
+import Enum from 'enum';
+
+export const PROP_SHEET = new Enum(['INTEGRATED', 'POPUP']);
 
 /**
  * A wrapper/watcher component for property sheet i.e., vertical display of all the data from a single table row, with additional metadata.

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -18,8 +18,7 @@ import {
     getResultSetRequest,
     isClientTable,
     getTableState,
-    TBL_STATE,
-    PROP_SHEET
+    TBL_STATE
 } from '../TableUtil.js';
 import {TablePanelOptions} from './TablePanelOptions.jsx';
 import {BasicTableView} from './BasicTableView.jsx';
@@ -39,7 +38,7 @@ import {AddColumnBtn} from './AddOrUpdateColumn.jsx';
 import FILTER from 'html/images/icons-2014/24x24_Filter.png';
 import OUTLINE_EXPAND from 'html/images/icons-2014/24x24_ExpandArrowsWhiteOutline.png';
 import OPTIONS from 'html/images/icons-2014/24x24_GearsNEW.png';
-import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
+import {PropertySheetAsTable, PROP_SHEET} from 'firefly/tables/ui/PropertySheet';
 
 const logger = Logger('Tables').tag('TablePanel');
 

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -22,9 +22,8 @@ import {getExpandedChartProps} from '../../charts/ChartsCntlr.js';
 import {DEFAULT_PLOT2D_VIEWER_ID} from '../../visualize/MultiViewCntlr.js';
 import {usePinnedChartInfo, PinnedChartPanel, PINNED_VIEWER_ID, BadgeLabel} from 'firefly/charts/ui/PinnedChartContainer.jsx';
 import {allowPinnedCharts} from '../../charts/ChartUtil.js';
-import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
+import {PropertySheetAsTable, PROP_SHEET} from 'firefly/tables/ui/PropertySheet';
 import {getAppOptions} from 'firefly/core/AppDataCntlr';
-import {PROP_SHEET} from 'firefly/tables/TableUtil';
 
 const stateKeys= ['title', 'mode', 'showTables', 'showImages', 'showXyPlots', 'images'];
 const LEFT= 'LEFT';


### PR DESCRIPTION
Since #1404 got merged, irsaviewer is unable to load likely due to circular dependencies in accessing `PROP_SHEET` constant.

Moved it from `TableUtil.js` to `PropertySheet.jsx` to fix this. Also `PROP_SHEET` belongs to that module so it seems like a better place to put it.

## Testing
Testing instructions in linked PR

IRSAViewer: https://firefly-1256-prop-sheet.irsakudev.ipac.caltech.edu/irsaviewer/

Also test if everything else is working as expected:
- IFE apps: 
  - https://firefly-1256-prop-sheet.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/ 
  - https://firefly-1256-prop-sheet.irsakudev.ipac.caltech.edu/applications/sofia/
- API mode: https://fireflydev.ipac.caltech.edu/firefly-1256-prop-sheet/firefly/test/tests-main.html

