### PR TITLE
Firefly-1296: SearchPanel.jsx api updates & coverage vs catalog updates

### DIFF
--- a/src/firefly/js/drawingLayers/Catalog.js
+++ b/src/firefly/js/drawingLayers/Catalog.js
@@ -484,7 +484,7 @@ function computePointHighlightLayer(drawLayer, columns) {
 
     const useImagePts= catalogType===CatalogType.POINT_IMAGE_PT;
     let ra, dec;
-    if (!useImagePts && columns.latCol===columns.latCol) {
+    if (!useImagePts && columns.lonCol===columns.latCol) {
         const valueAry= getCellValue(tbl,drawLayer.highlightedRow, columns.lonCol);
         ra= valueAry[0];
         dec= valueAry[1];

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -80,7 +80,7 @@ export function createSingleImageActivate(request, imageViewerId, tbl_id, highli
         // const covViewer= ;
         const makeActive= !isDefaultCoverageActive(visRoot(),getMultiViewRoot());
         replotImageDataProducts(request.getPlotId(), makeActive, imageViewerId, tbl_id, [request]);
-    }
+    };
 }
 
 let extractedPlotId= 1;
@@ -174,7 +174,7 @@ export function resetImageFullGridActivePlot(tbl_id, plotIdAry) {
     });
 }
 
-export function changeActivePlotView(plotId,tbl_id) {
+export function changeTableHighlightToMatchPlotView(plotId, tbl_id) {
     const plot= primePlot(visRoot(), plotId);
     if (!plot) return;
     const row= Number(get(plot.attributes, PlotAttribute.DATALINK_TABLE_ROW, -1));
@@ -189,7 +189,7 @@ export function changeActivePlotView(plotId,tbl_id) {
 /**
  *
  * @param {string} activePlotId the new active plot id after the replot
- * @param {string} if true, make the plotId active
+ * @param {string} makeActive if true, make the plotId active
  * @param {string} imageViewerId the id of the viewer
  * @param {string} tbl_id table id of the table with the data products
  * @param {Array.<WebPlotRequest>} reqAry an array of request to execute

--- a/src/firefly/js/util/VOAnalyzer.js
+++ b/src/firefly/js/util/VOAnalyzer.js
@@ -1012,7 +1012,7 @@ export function isCatalog(tableOrId) {
     if (isTableWithRegion(table)) return false;
     const {tableMeta, tableData}= table;
     if (!get(tableData, 'columns') || !tableMeta) return false;
-    if (getBooleanMetaEntry(table,MetaConst.COVERAGE_SHOWING,false)) return false;
+    // if (getBooleanMetaEntry(table,MetaConst.COVERAGE_SHOWING,false)) return false;
 
     if (isOrbitalPathTable(table)) return false;
 

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -599,6 +599,7 @@ export function mergeObjectOnly(target, sources) {
  * When validateSearch search returns true then doSearch is called and search is considered done for that id
  * To mark the search as done without actually doing it then just pass true as first parameter
  * makeSearchOnce is similar to lodash once but includes a validate as a way to make it done.
+ * It also includes an id so that it runs once per id
  * Note that the execution of the doSearch function is deferred.
  * @param {boolean } defer - if true run the search deferred
  * @return {Function} a function with the signature f(validateSearch,doSearch)

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -166,6 +166,9 @@ const API_TOOLS_VIEW= `${PLOTS_PREFIX}.apiToolsView`;
 /** Action Type: enable/disable wcs matching*/
 export const IMAGE_PLOT_KEY= 'allPlots';
 
+export const MOUSE_CLICK_REASON= 'mouseClickReason';
+export const OTHER_REASON= 'otherReason';
+
 /**
  * @returns {VisRoot}
  *
@@ -905,11 +908,12 @@ export function dispatchZoomLocking(plotId,zoomLockingEnabled, zoomLockingType) 
 /**
  * Set the plotId of the active plot view
  * @param {string} plotId
+ * @param {string} reason
  */
 
-export function dispatchChangeActivePlotView(plotId) {
+export function dispatchChangeActivePlotView(plotId,reason=OTHER_REASON) {
     if (!isActivePlotView(visRoot(),plotId)) {
-        flux.process({ type: CHANGE_ACTIVE_PLOT_VIEW, payload: {plotId} });
+        flux.process({ type: CHANGE_ACTIVE_PLOT_VIEW, payload: {plotId,reason} });
     }
 }
 

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -20,9 +20,11 @@ import {isImageViewerSingleLayout, getMultiViewRoot} from './MultiViewCntlr.js';
 import {contains, intersects} from './VisUtil.js';
 import BrowserInfo from '../util/BrowserInfo.js';
 
-import { visRoot, ActionScope, dispatchPlotProgressUpdate, dispatchZoom, dispatchRecenter, dispatchProcessScroll,
+import {
+    visRoot, ActionScope, dispatchPlotProgressUpdate, dispatchZoom, dispatchRecenter, dispatchProcessScroll,
     dispatchChangeCenterOfProjection, dispatchChangeActivePlotView,
-    dispatchUpdateViewSize, dispatchRequestLocalData } from './ImagePlotCntlr.js';
+    dispatchUpdateViewSize, dispatchRequestLocalData, MOUSE_CLICK_REASON
+} from './ImagePlotCntlr.js';
 import {fireMouseCtxChange, makeMouseStatePayload, MouseState} from './VisMouseSync.js';
 import {isHiPS, isHiPSAitoff, isImage} from './WebPlot.js';
 import {plotMove} from './PlotMove';
@@ -262,7 +264,7 @@ export class ImageViewerLayout extends PureComponent {
 
          switch (mouseState) {
              case DOWN :
-                 dispatchChangeActivePlotView(plotId);
+                 dispatchChangeActivePlotView(plotId,MOUSE_CLICK_REASON);
                  const {scrollX, scrollY}= plotView;
                  this.plotDrag= plotMove(screenX,screenY,makeScreenPt(scrollX,scrollY), mouseDownScreenPt, plotView);
                  break;

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -9,7 +9,7 @@ import shallowequal from 'shallowequal';
 import {isEmpty,omit,isFunction} from 'lodash';
 import {getSearchActions} from '../../core/AppDataCntlr.js';
 import {getPlotGroupById}  from '../PlotGroup.js';
-import {ExpandType, dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
+import {ExpandType, dispatchChangeActivePlotView, MOUSE_CLICK_REASON} from '../ImagePlotCntlr.js';
 import {VisCtxToolbarView, canConvertHipsAndFits} from '../ui/VisCtxToolbarView';
 import {VisInlineToolbarView} from '../ui/VisInlineToolbarView.jsx';
 import {primePlot, isActivePlotView, getAllDrawLayersForPlot, getPlotViewById} from '../PlotViewUtil.js';
@@ -91,7 +91,7 @@ function showClearFilter(pv,dlAry) {
 function showUnselect(pv,dlAry) {
     return getAllDrawLayersForPlot(dlAry, pv.plotId,true)
         .filter( (dl) => {
-            return (dl.drawLayerTypeId===Catalog.TYPE_ID && dl.catalog) ||
+            return (dl.drawLayerTypeId===Catalog.TYPE_ID && dl.catalogType===CatalogType.POINT) ||
                    (dl.drawLayerTypeId===LSSTFootprint.TYPE_ID);
         })
         .some( (dl) => {
@@ -295,7 +295,7 @@ const ImageViewerDecorate= memo((props) => {
         innerStyle.width= 'calc(100% - 10px)';
     }
 
-    const makeActive= () => pv?.plotId && dispatchChangeActivePlotView(pv.plotId);
+    const makeActive= () => pv?.plotId && dispatchChangeActivePlotView(pv.plotId,MOUSE_CLICK_REASON);
     const showZoom= mousePlotId===pv?.plotId;
     const showDel= showDelAnyway || mousePlotId===pv?.plotId || !plot || pv.nonRecoverableFail;
 

--- a/src/firefly/js/visualize/saga/DataProductsWatcher.js
+++ b/src/firefly/js/visualize/saga/DataProductsWatcher.js
@@ -5,7 +5,9 @@
 import {get, isArray, isEmpty} from 'lodash';
 import {Band} from '../Band.js';
 import {TABLE_SELECT,TABLE_HIGHLIGHT, TABLE_REMOVE,TABLE_UPDATE, TBL_RESULTS_ACTIVE} from '../../tables/TablesCntlr.js';
-import ImagePlotCntlr, {visRoot, dispatchDeletePlotView, dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
+import ImagePlotCntlr, {
+    visRoot, dispatchDeletePlotView, dispatchChangeActivePlotView, MOUSE_CLICK_REASON
+} from '../ImagePlotCntlr.js';
 import {REINIT_APP} from '../../core/AppDataCntlr.js';
 import {getTblById,getTblInfo,getActiveTableId,isTblDataAvail} from '../../tables/TableUtil.js';
 import {isDefaultCoverageActive, primePlot} from '../PlotViewUtil.js';
@@ -18,7 +20,7 @@ import {findGridTableRows} from '../../metaConvert/converterUtils.js';
 import {PlotAttribute} from '../PlotAttribute.js';
 import {dispatchAddTableTypeWatcherDef} from '../../core/MasterSaga.js';
 import {isDataProductsTable} from '../../util/VOAnalyzer.js';
-import {zoomPlotPerViewSize, resetImageFullGridActivePlot, changeActivePlotView} from '../../metaConvert/ImageDataProductsUtil.js';
+import {zoomPlotPerViewSize, resetImageFullGridActivePlot, changeTableHighlightToMatchPlotView} from '../../metaConvert/ImageDataProductsUtil.js';
 import {
     dataProductRoot,
     dispatchUpdateDataProducts,
@@ -161,7 +163,14 @@ function watchDataProductsTable(tbl_id, action, cancelSelf, params) {
             break;
 
         case ImagePlotCntlr.CHANGE_ACTIVE_PLOT_VIEW:
-            if (!paused) changeActivePlotView(action.payload.plotId,tbl_id, true);
+            if (!paused && action.payload.reason===MOUSE_CLICK_REASON) {
+                // const layout= getLayoutType(getMultiViewRoot(), imageViewerId, tbl_id);
+                // if (layout===GRID) {
+                //     if () {
+                        changeTableHighlightToMatchPlotView(action.payload.plotId,tbl_id);
+                    // }
+                // }
+            }
             break;
 
         case ImagePlotCntlr.ANY_REPLOT:


### PR DESCRIPTION
#### [Firefly-1296](https://jira.ipac.caltech.edu/browse/FIREFLY-1296): make SearchPanel.jsx support url api searchoption parameter

  - coverage and catalog watcher shoutld not compete
  - catalog will not add overlays on coverage anymore
  - coverage only adds overlays on coverage
  - this approach is a deoptimzation for large tables, both will have to load the table

#### Testing
- https://firefly-1296-urlapi-searchpanel.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/?api
- build against `IRSA-5419-sha-web-api`
- try second option in SHA API help page