### PR TITLE
Firefly-1295: calling the URL API via firefly's getViewer() in the javascript api

### DIFF
--- a/src/firefly/html/test/tests-viewer.html
+++ b/src/firefly/html/test/tests-viewer.html
@@ -519,7 +519,7 @@
     </script>
 </template>
 
-<template title="External viewer to load image with title" class="tpl sm">
+<template title="TriView: External viewer to load image with title" class="tpl sm">
     <div id="expected" >
         <div>Click to load table
             <ul class='expected-list'>
@@ -545,6 +545,35 @@
                 url: 'https://irsa.ipac.caltech.edu/ibe//data/akari/akari_images/images/N60/l000.85_b+65.00_ecl_6deg_N60_fixstripe.fits'
 
             });
+        }
+    </script>
+</template>
+
+<template title="TriView: URL API External viewer to load image with title" class="tpl sm">
+    <div id="expected" >
+        <div>Click to load table
+            <ul class='expected-list'>
+                <li>load one image to Tri-view</li>
+            </ul>
+        </div>
+        <div style='padding-top: 10px;'><img style="width: 230px;" src="./images/triview-loaded-image.png"></div>
+    </div>
+    <div id="actual" style="width: 600px; display: flex; flex-direction: column">
+        <ul style='margin: 0 0 0 5px;'>
+            <li><a href="javascript:loadImageIntoTriViewUsingAPI()">Load 1 image to Tri-View</a></li>
+        </ul>
+
+    </div>
+    <script>
+        resizeIframeToHeight('280px');
+
+        function onFireflyLoaded(firefly) {
+            firefly.setViewerConfig(firefly.ViewerType.TriView, 'firefly.html');
+        }
+
+        function loadImageIntoTriViewUsingAPI() {
+            firefly.getViewer().urlApiLaunch(
+                   'api=image&url=https://irsa.ipac.caltech.edu/ibe//data/akari/akari_images/images/N60/l000.85_b%2b65.00_ecl_6deg_N60_fixstripe.fits' )
         }
     </script>
 </template>

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -26,7 +26,7 @@ import {getJsonProperty, notifyServerAppInit} from './rpc/CoreServices.js';
 import {getPropsWith, mergeObjectOnly, getProp, toBoolean, documentReady,uuid} from './util/WebUtil.js';
 import {dispatchChangeTableAutoScroll, dispatchWcsMatch, visRoot} from './visualize/ImagePlotCntlr.js';
 import {Logger} from './util/Logger.js';
-import {evaluateWebApi, isUsingWebApi, WebApiStat} from './api/WebApi.js';
+import {evaluateWebApi, initWebApi, isUsingWebApi, WebApiStat} from './api/WebApi.js';
 import {WebApiHelpInfoPage} from './ui/WebApiHelpInfoPage.jsx';
 import {dispatchOnAppReady} from './core/AppDataCntlr.js';
 import {getBootstrapRegistry} from './core/BootstrapRegistry.js';
@@ -386,6 +386,7 @@ function renderRoot(root, viewer, props, webApiCommands) {
     }
 
     const rootToUse = root ?? createRoot(e);
+    initWebApi(webApiCommands);
     const webApi= isUsingWebApi(webApiCommands);
     const doAppRender= () => {
         if (props.template === ROUTER) {

--- a/src/firefly/js/api/ApiViewer.js
+++ b/src/firefly/js/api/ApiViewer.js
@@ -26,6 +26,7 @@ import {getWsChannel, getWsConnId, getConnectionCount, makeViewerChannel,
 import {dispatchAddCell, dispatchEnableSpecialViewer, LO_VIEW} from '../core/LayoutCntlr.js';
 import {DEFAULT_FITS_VIEWER_ID, DEFAULT_PLOT2D_VIEWER_ID} from '../visualize/MultiViewCntlr.js';
 import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
+import {WEB_API_CMD} from './WebApi.js';
 
 const logger = Logger('ApiViewer');
 
@@ -100,7 +101,8 @@ export function getViewer(channel, file=defaultViewerFile, scriptUrl) {
             ...buildImagePart(channel,file,dispatch),
             ...buildTablePart(channel,file,dispatch),
             ...buildChartPart(channel,file,dispatch),
-            ...buildUtilPart(channel,file)
+            ...buildUrlApiLaunchPart(channel,file, dispatch),
+            ...buildUtilPart(channel,file),
         };
 
 
@@ -206,13 +208,23 @@ function buildSlateControl(channel,file,dispatcher) {
     return {addCell, showCoverage, showImageMetaDataViewer};
 }
 
+function buildUrlApiLaunchPart(channel,file, dispatch) {
+    const urlApiLaunch= (paramStr='') => {
+        const viewOp= makeViewerOp(channel,file);
+        viewOp('launching url api', () => {
+            dispatch({type:WEB_API_CMD, payload:{paramStr}});
+        });
+    };
+    return {urlApiLaunch};
+}
+
 
 function buildImagePart(channel,file,dispatch) {
     const viewOp= makeViewerOp(channel,file);
     let defP= {};
 
     /**
-     * @summary set the default params the will be add to image plot request
+     * @summary set the default params that will be added to image plot request
      * @param params
      * @memberof firefly.ApiViewer
      * @public

--- a/src/firefly/js/api/webApiCommands/ImageCommands.js
+++ b/src/firefly/js/api/webApiCommands/ImageCommands.js
@@ -1,5 +1,5 @@
 import WebPlotRequest, {findInvalidWPRKeys, WPConst} from '../../visualize/WebPlotRequest';
-import {isEmpty,isArray} from 'lodash';
+import {isEmpty,isArray,omit} from 'lodash';
 import {dispatchPlotHiPS, dispatchPlotImage} from '../../visualize/ImagePlotCntlr';
 import {RequestType} from '../../visualize/RequestType';
 import {DEFAULT_FITS_VIEWER_ID} from '../../visualize/MultiViewCntlr';
@@ -134,7 +134,7 @@ function showImage(cmd,inParams) {
         params[WPConst.SIZE_IN_DEG]= params[ReservedParams.SR.name];
         Reflect.deleteProperty(params, ReservedParams.SR.name);
     }
-    const r= WebPlotRequest.makeFromObj(params);
+    const r= WebPlotRequest.makeFromObj(omit(params,['callId']));
     if (!params[WPConst.PLOT_GROUP_ID]) r.setPlotGroupId('webApiGroup');
     const plotId= `${imageRootStr}-${nextId++}`;
     dispatchPlotImage({plotId, wpRequest:r});

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -7,7 +7,7 @@ import {flux} from './ReduxFlux';
 import {dispatchAddActionWatcher} from './MasterSaga';
 import {appDataReducer, menuReducer, alertsReducer} from './AppDataReducers.js';
 import Point, {isValidPoint} from '../visualize/Point.js';
-import {getModuleName, getProp, getRootURL} from '../util/WebUtil.js';
+import {getModuleName, getProp, getRootURL, isFullURL} from '../util/WebUtil.js';
 import {dispatchRemoteAction} from './JsonUtils.js';
 import {getWsConn} from './messaging/WebSocketClient';
 
@@ -173,13 +173,14 @@ export function dispatchOnAppReady(callback) {
 
 
 /**
- * Give a channel string return a version the will be the channel for a viewer
+ * Given a channel string return a version of the will be the channel for a viewer
  * @param {String} channel
  * @return {string}
  */
 export function makeViewerChannel(channel, file) {
-    file = file ? '-' + file.replaceAll('.', '_') : '';
-    return channel + CHANNEL_VIEWER_EXTENSION + file;
+    const endFile= isFullURL(file) ? new URL(file).pathname : file;
+    const cleanFile = endFile ? '-' + endFile.replaceAll('.', '_') : '';
+    return channel + CHANNEL_VIEWER_EXTENSION + cleanFile;
 }
 
 export function isAppReady() {

--- a/src/firefly/js/fieldGroup/FieldGroupCntlr.js
+++ b/src/firefly/js/fieldGroup/FieldGroupCntlr.js
@@ -92,8 +92,8 @@ export default {
  *                                after if is unmounted
  *                                if mounted parameter is false, then keepState defaults to the field groups value set
  *                                when mounted. If specified then it will override the previous setting.
- * @param {Function} reducerFunc
- * @param {string} wrapperGroupKey
+ * @param {Function} [reducerFunc]
+ * @param {string} [wrapperGroupKey]
  */
 export function dispatchMountFieldGroup(groupKey, mounted, keepState, reducerFunc= undefined, wrapperGroupKey) {
     flux.process({type: MOUNT_FIELD_GROUP, payload: {groupKey, mounted, reducerFunc, keepState, wrapperGroupKey} });

--- a/src/firefly/js/ui/CheckboxGroupInputField.jsx
+++ b/src/firefly/js/ui/CheckboxGroupInputField.jsx
@@ -99,7 +99,7 @@ CheckboxGroupInputField.propTypes= {
     }),
     forceReinit:  PropTypes.bool,
     fieldKey:   PropTypes.string,
-    labelStyle: PropTypes.string,
+    labelStyle: PropTypes.object,
     labelWidth: PropTypes.number,
 };
 

--- a/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
+++ b/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
@@ -88,7 +88,7 @@ const uiConfig= {
     hideTip: 'Hide data collections chooser',
     chooserTitle: 'Choose Data Collection',
     chooserDetails: 'Click on data collection to search; filter or sort table to find a data collection.',
-    sideBarWidth:460,
+    sideBarWidth:470,
     sideTransition: 'all .5s ease-in-out'
 };
 
@@ -99,15 +99,19 @@ function makeRegistryRequest(url, registryTblId) {
             pageSize: MAX_ROW,
             sortInfo: sortInfoString(['facility_name','obs_collection']),
             tbl_id: registryTblId,
+            inclCols: '"facility_name","collection_label","instrument_name","coverage","band","dataproduct_type","info_url"',
             META_INFO: {
                 'col.facility_name.PrefWidth':6,
-                'col.collection_label.PrefWidth':12,
+                'col.collection_label.PrefWidth':9,
                 'col.instrument_name.PrefWidth':9,
                 'col.coverage.PrefWidth':8,
-                'col.band.PrefWidth':13,
+                'col.band.PrefWidth':12,
                 'col.dataproduct_type.PrefWidth':5,
+                'col.info_url.PrefWidth':1,
 
-                'col.obs_collection.PrefWidth':15,
+                // eslint-disable-next-line quotes
+                'col.info_url.cellRenderer': 'ATag::href=${info_url},target="dce-doc"'+ `,label=<img src='images/info-16x16.png'/>`,
+
 
                 'col.facility_name.label':'Facility',
                 'col.instrument_name.label':'Inst.',
@@ -115,12 +119,13 @@ function makeRegistryRequest(url, registryTblId) {
                 'col.dataproduct_type.label':'Data',
                 'col.collection_label.label':'Collection',
                 'col.band.label':'Bands',
+                'col.info_url.label':'i',
 
+                // the hidden is not necssary anymore because of inclCols, but I am keeping it here for documentation
                 'col.obs_collection.visibility':'hidden',
                 'col.description.visibility':'hidden',
                 'col.desc_details.visibility':'hidden',
                 'col.access_url.visibility':'hide',
-                'col.info_url.visibility':'hidden',
                 'col.access_format.visibility':'hidden',
 
                 [MetaConst.IMAGE_SOURCE_ID] : 'FALSE'

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -734,7 +734,9 @@ export function getDevPixScaleDeg(plot) {
         const tmpPlot= changeProjectionCenter(plot, pt00);
         const cc= CysConverter.make(tmpPlot);
         const devP= cc.getDeviceCoords( pt00);
+        if (!devP) return 0;
         const pt2= cc.getWorldCoords( makeDevicePt(devP.x-1, devP.y), plot.imageCoordSys);
+        if (!pt2) return 0;
         return Math.abs(0-pt2.x);
     }
     return 0;


### PR DESCRIPTION
#### [Firefly-1295](https://jira.ipac.caltech.edu/browse/FIREFLY-1295): calling the URL API via firefly's getViewer() in the javascript api

 - the `firefly.getViewer()` now can be use to pass url api parameters to a running firefly



#### Testing
- DCE Test Page: https://firefly-1295-dce-multiload.irsakudev.ipac.caltech.edu/irsaviewer/test-dce-api.html
- click on links on test page to launch DCE
- Test Page: https://fireflydev.ipac.caltech.edu/firefly-1295-dce-multiload/firefly/test/tests-viewer.html?test=TriView%3A+URL+API+External+viewer+to+load+image+with+title
- click on link to see image load via url api using `getViewer()`