### PR TITLE
Firefly-1299: Fix pluto not resolving to 999 NAIF ID

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
@@ -21,8 +21,6 @@ import org.json.simple.JSONObject;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 import static edu.caltech.ipac.firefly.server.servlets.AnyFileUpload.ANALYZER_ID;
 
@@ -77,7 +75,7 @@ public class ResolveServerCommands {
                 HorizonsEphPairs.HorizonsResults[] horizons_results = TargetNetwork.getEphInfo(sp.getRequired(ServerParams.OBJ_NAME));
                 String naifIdFormat = sp.getOptional(ServerParams.NAIFID_FORMAT, "");
 
-                Map<String, Integer> values = new HashMap<>();
+                JSONArray dataAry= new JSONArray();
                 for (HorizonsEphPairs.HorizonsResults element : horizons_results) {
                     String naifID = element.getNaifID();
 
@@ -93,12 +91,13 @@ public class ResolveServerCommands {
                         }
                     }
 
-                    values.put(element.getName(), Integer.parseInt(naifID));
+                    JSONObject dataObj = new JSONObject();
+                    dataObj.put("name", element.getName());
+                    dataObj.put("naifID", Integer.parseInt(naifID));
+                    dataAry.add(dataObj);
                 }
 
-                JSONObject naifids = new JSONObject(values);
-
-                result.put("data", naifids);
+                result.put("data", dataAry);
                 result.put("success", true);
                 wrapperAry.add(result);
 

--- a/src/firefly/js/ui/NaifidPanel.jsx
+++ b/src/firefly/js/ui/NaifidPanel.jsx
@@ -23,20 +23,20 @@ function NaifidPanelView({showHelp, valid, message, examples, feedback, value, l
         if (!val) return [];
         if (naifIdFormat && !searchHistory[naifIdFormat]) searchHistory[naifIdFormat] = [];
 
-        const rval = resolveNaifidObj(val, naifIdFormat);
-        if (!rval.p) return [];
-
         const getResSuggestionsList = (suggestionsList) => {
             const resSuggestionsList = Object.values(suggestionsList).map((v) => ({name: v.naifName, naifid: v.naifId}));
             return sortBy(resSuggestionsList, 'naifid').reverse();
         };
 
-        //if value has been searched previously, no need to call the api again.
+        //if value has been searched previously, no need to request from server
         if (searchHistory[naifIdFormat].length > 0){
             const cachedSuggList = Object.values(searchHistory[naifIdFormat]).find((v) => (v.searchVal === val));
             if (cachedSuggList?.searchRes) return getResSuggestionsList(cachedSuggList.searchRes);
         }
 
+        //else request naif IDs from the server
+        const rval = resolveNaifidObj(val, naifIdFormat);
+        if (!rval.p) return [];
         return rval.p.then((response)=>{
             if (response.valid) {
                 const suggestionsList = response.data.map(({naifID, name}) => ({naifId: naifID, naifName: name}));

--- a/src/firefly/js/ui/NaifidPanel.jsx
+++ b/src/firefly/js/ui/NaifidPanel.jsx
@@ -39,7 +39,7 @@ function NaifidPanelView({showHelp, valid, message, examples, feedback, value, l
 
         return rval.p.then((response)=>{
             if (response.valid) {
-                const suggestionsList = Object.entries(response.data).map(([k,v]) => ({naifId: v, naifName: k}));
+                const suggestionsList = response.data.map(({naifID, name}) => ({naifId: naifID, naifName: name}));
                 searchHistory[naifIdFormat].push({searchVal: val, searchRes: suggestionsList});
                 return getResSuggestionsList(suggestionsList);
 


### PR DESCRIPTION
Fixes [FIREFLY-1299](https://jira.ipac.caltech.edu/browse/FIREFLY-1299)

Additionally, fixed excessive server calls - even when value was present in client-side searchHistory/cache (identified this problem from network inspector)

## Testing
https://firefly-1299-pluto-naifid-fix.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/

Go to Moving object search:
- type pluto: 3 suggestions should appear in dropdown, including 999 (two suggestions with same name)
- type Europa: again check that in suggestions, two suggestions can have same name but different IDs

https://firefly-1299-pluto-naifid-fix.irsakudev.ipac.caltech.edu/applications/sofia/

Check if everything is working as before.