### PR TITLE
FIREFLY-1282: Add multi-results support for UWS jobs

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
@@ -63,7 +63,7 @@ public interface Job extends Callable<String> {
         });
     }
 
-    default void addResult(String result) {
+    default void addResult(JobInfo.Result result) {
         setIf(getJobInfo(), v -> v.addResult(result));
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -39,7 +39,7 @@ public class JobInfo implements Serializable {
     private int executionDuration = LIFE_SPAN;
     private Instant destruction;
     private Map<String, String> params = new HashMap<>();
-    private List<String> results = new ArrayList<>();
+    private List<Result> results = new ArrayList<>();
     private Error error;
 
     // these are additional info that's not in uws:job defined props
@@ -105,11 +105,11 @@ public class JobInfo implements Serializable {
         this.error = error;
     }
 
-    public List<String> getResults() {
+    public List<Result> getResults() {
         return results;
     }
 
-    public void setResults(List<String> results) {
+    public void setResults(List<Result> results) {
         this.results = new ArrayList<>(results);
     }
 
@@ -176,7 +176,7 @@ public class JobInfo implements Serializable {
     public String getProgressDesc() { return progressDesc; }
     public void setProgressDesc(String progressDesc) { this.progressDesc = progressDesc;}
 
-    public void addResult(String result) { results.add(result);}
+    public void addResult(Result result) { results.add(result);}
 
     /**
      * @return how long this job may run in seconds.  zero implies unlimited execution duration.
@@ -204,6 +204,7 @@ public class JobInfo implements Serializable {
 //====================================================================
 
     public static record Error ( int code, String msg){}
+    public static record Result(String href, String hrefType, String mimeType, String size){};
 
 }
 /*

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -19,7 +19,6 @@ import org.json.simple.JSONObject;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -31,7 +30,6 @@ import static edu.caltech.ipac.firefly.data.ServerParams.EMAIL;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static edu.caltech.ipac.firefly.core.background.Job.Type.PACKAGE;
-import static edu.caltech.ipac.firefly.core.background.Job.Type.SEARCH;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase.*;
 
 
@@ -196,9 +194,9 @@ public class JobManager {
         rval.put("parameters", info.getParams());
 
         if (info.getPhase() == COMPLETED && info.getResults().size() == 0) {
-            rval.put("results", Arrays.asList(asyncUrl + info.getJobId() + "/results/result"));
+            rval.put("results", Arrays.asList(toResult(asyncUrl + info.getJobId() + "/results/result", null, null)));
         } else if (info.getResults().size() > 0) {
-            rval.put("results", info.getResults());
+            rval.put("results", toResults(info.getResults()));
         }
         applyIfNotEmpty(info.getError(),   v -> {
             JSONObject errSum = new JSONObject();
@@ -219,6 +217,19 @@ public class JobManager {
         applyIfNotEmpty(info.getSummary(),   v -> addtlInfo.put("summary", v));
 
         return rval;
+    }
+
+    public static List<JSONObject> toResults(List<JobInfo.Result> results) {
+        return results.stream().map(r -> toResult(r.href(), r.mimeType(), r.size()))
+                .collect(Collectors.toList());
+    }
+
+    private static JSONObject toResult(String href, String mimeType, String size) {
+        JSONObject ro = new JSONObject();
+        applyIfNotEmpty(href,   v -> ro.put("href", v));
+        applyIfNotEmpty(mimeType,   v -> ro.put("mimeType", v));
+        applyIfNotEmpty(size,   v -> ro.put("size", v));
+        return ro;
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagedEmail.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagedEmail.java
@@ -121,7 +121,8 @@ public class PackagedEmail {
             }
 
             // print out result url
-            sw.append(String.join("\n\n", jobInfo.getResults()));
+            sw.append("\n\n");
+            jobInfo.getResults().forEach(result -> sw.append("\n").append(result.href()));
 
 
             if (jobInfo.getResults().size() > 1) {
@@ -149,9 +150,9 @@ public class PackagedEmail {
 
         String scriptUrl = null;
         List<URL> urlList= new ArrayList<>(jobInfo.getResults().size());
-        for(String part : jobInfo.getResults()) {
+        for(JobInfo.Result part : jobInfo.getResults()) {
             try {
-                urlList.add(new URL(part));
+                urlList.add(new URL(part.href()));
             } catch (MalformedURLException e) {
                 logger.warn("Bad url for download script: " + part + "Background ID: " + jobInfo.getJobId());
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
@@ -4,6 +4,7 @@
 
 package edu.caltech.ipac.firefly.server.packagedata;
 
+import com.google.common.net.MediaType;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.ServerContext;
@@ -160,7 +161,7 @@ public final class PackagingWorker implements Job.Worker {
             int zippedFiles = curFileInfoIdx - startFileInfoIdx;
             ZipHandler.addReadmeZipEntry(zout,zipMessage(zippedFiles, zippedBytes, failed, denied));
             zout.setComment(String.format("Files %s-%s", startFileInfoIdx, curFileInfoIdx));
-            getJob().addResult(makeDownloadUrl(zipFile, suggestedName));
+            getJob().addResult(new JobInfo.Result(makeDownloadUrl(zipFile, suggestedName), null, MediaType.ZIP.toString(), zipFile.length()+""));
             failed.clear();
             denied.clear();
             zippedBytes = 0;

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -97,7 +97,7 @@ function FinalMsg({phase, summary, error}) {
 }
 
 export function UwsJobInfo({jobInfo, style, isOpen=false}) {
-
+    const hrefs = jobInfo?.results?.map((r) => r.href);
     return (
         <div className='JobInfo__main' style={style}>
             <div className='JobInfo__items uws' style={{overflowY: 'auto'}}>
@@ -108,7 +108,7 @@ export function UwsJobInfo({jobInfo, style, isOpen=false}) {
                 }</>
 
                 <OptionalBlock label='parameters' value={jobInfo.parameters} isOpen={isOpen}/>
-                <OptionalBlock label='results' value={jobInfo.results} asLink={true} isOpen={isOpen}/>
+                <OptionalBlock label='results' value={hrefs} asLink={true} isOpen={isOpen}/>
                 <OptionalBlock label='errorSummary' value={jobInfo.errorSummary} isOpen={isOpen}/>
 
             </div>


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1282

Generalize Firefly's UWS support  to accommodate multiple results being returned.
In this case, it should return an ObsCore-like table.

Currently, there isn't an existing UWS service with results like this.  Therefore, I added a mock-tap service that can return tap result at `/results/result`, but multiple results at the `/results` endpoint.  
This mock service has been deployed to https://nightly.irsakudev.ipac.caltech.edu/mock-tap

To test, go to: https://fireflydev.ipac.caltech.edu/firefly-1282-uws-multi-results/firefly
- Upload -> Upload from URL
  - Enter URL:  https://nightly.irsakudev.ipac.caltech.edu/mock-tap/async/45
  - Click Upload and then Load

You can use any integer instead of 45.  The mock service provides two sets of data, one for odd-numbered jobs and the other for even-numbered jobs.

Also, you can use `https://nightly.irsakudev.ipac.caltech.edu/mock-tap` as a TAP service within the TAP Panel.  This approach can be valuable when you need to mock TAP data for testing purposes in the future.
 

