### PR TITLE
FIREFLY-1118: Update recenter action to allow coordinate system to be a string

### DIFF
--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {isNumber, isArray} from 'lodash';
+import {isNumber, isArray, set} from 'lodash';
 import {logger} from '../../util/Logger.js';
 import ImagePlotCntlr, { IMAGE_PLOT_KEY, dispatchWcsMatch, ActionScope, visRoot} from '../ImagePlotCntlr.js';
 import {
@@ -25,6 +25,7 @@ import {loadStretchData, queueChangeLocalRawDataColor} from '../rawData/RawDataO
 import {dispatchAddTaskCount, dispatchRemoveTaskCount} from '../../core/AppDataCntlr.js';
 import {Band} from '../Band.js';
 import {makeCubeCtxAry, populateFromHeader} from 'firefly/visualize/task/CreateTaskUtil.js';
+import {parseAnyPt} from 'firefly/visualize/Point';
 
 
 //=======================================================================
@@ -64,7 +65,11 @@ const dispatchAndMaybeMatch= (rawAction) => (dispatcher,getState) => {
     };
 
 
-export const recenterActionCreator= (rawAction) => dispatchAndMaybeMatch(rawAction);
+export const recenterActionCreator = (rawAction) => {
+    // `recenter` reducer expects centerPt to be a Point object, so parse centrePt because it may be a serialised string
+    return dispatchAndMaybeMatch(set(rawAction,'payload.centerPt', parseAnyPt(rawAction.payload.centerPt)));
+};
+
 export const processScrollActionCreator= (rawAction) => dispatchAndMaybeMatch(rawAction);
 export const rotateActionCreator= (rawAction) => dispatchAndMaybeMatch(rawAction);
 


### PR DESCRIPTION
Fixes [FIREFLY-1118](https://jira.ipac.caltech.edu/browse/FIREFLY-1118)

`recenterActionCreator` expects `centrePt` field in payload to be a `WorldPtObj` for `WorldPt` type. This works as long as payload is coming from the UI (because things are in the same JS world) but it will fail if payload comes through `WebSocketListener` i.e. used when calling it from FF python client.

Using `makeWorldPt` also encouraged me to use `CoordSys.parse` which is smart enough to parse any `cSys` string in the payload, giving more flexibility overall.

## Testing 
Make sure this doesn't break existing recenter option in image toolbar

Testing instruction for firefly python client in https://github.com/Caltech-IPAC/firefly_client/pull/53

