### PR TITLE
Minor sha fix, take out "sha.ipac.caltech.edu"

### DIFF
--- a/src/firefly/js/metaConvert/ShaRequestList.js
+++ b/src/firefly/js/metaConvert/ShaRequestList.js
@@ -10,6 +10,7 @@ import {CoordinateSys} from '../visualize/CoordSys.js';
 import {WebPlotRequest} from '../visualize/WebPlotRequest.js';
 import {addCommonReqParams} from '../templates/lightcurve/LcConverterFactory.js';
 import {GRID_FULL, SINGLE} from '../visualize/MultiViewCntlr';
+import {getRootURL} from '../util/WebUtil.js';
 
 const colToUse= ['reqkey', 'heritgefilename', 'fname'];
 const rangeValues= RangeValues.makeRV({which:SIGMA, lowerValue:-2, upperValue:10, algorithm:STRETCH_LINEAR});
@@ -42,10 +43,10 @@ export function makeShaPlotRequest(table, row, includeSingle,includeStandard) {
             : getCellValue(table, row, 'heritagefilename');
 
     /*
-     const url = https://irsa.ipac.caltech.edu/data/SPITZER/SHA/archive/proc/MIPS003600/r5572864/ch2/bcd/SPITZER_M2_5572864_0007_0061_9_bcd.fits
+     example url = https://irsa.ipac.caltech.edu/data/SPITZER/SHA/archive/proc/MIPS003600/r5572864/ch2/bcd/SPITZER_M2_5572864_0007_0061_9_bcd.fits
      */
     const serverinfo = 'https://irsa.ipac.caltech.edu/data/SPITZER/';
-    const mosimgserver = 'https://sha.ipac.caltech.edu/applications/Spitzer/SHA/servlet/ProductDownload?DATASET=level1';
+    const shaservlet = '/applications/Spitzer/SHA/servlet/ProductDownload?DATASET=level1';
     let filepath = '';
     let url = '';
     let wp;
@@ -56,7 +57,8 @@ export function makeShaPlotRequest(table, row, includeSingle,includeStandard) {
     } else if (dataType === 'SEIP') {
         url = `${serverinfo}` + 'Enhanced/SEIP/' + `${dataFile}`;
     } else if (dataType === 'PRECOVERY') {
-        url = `${mosimgserver}` + '&ID=' + `${bcdId}`;
+        url += `${shaservlet}` + '&ID=' + `${bcdId}`;
+        url = new URL(url, getRootURL());
     } else {
         filepath = dataFile.replaceAll('/sha', 'SHA');
         url = `${serverinfo}/${filepath}`;


### PR DESCRIPTION
Take out `sha.ipac.caltech.edu` in the servlet url construction for Precovery image viewing.
To test:
https://sha-fix.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA

do Precovery search with Karin and using the example time range, view images in Data View tab.
