### PR TITLE
FIREFLY-1310: Prototype of Drag Drop UI for file uploads 

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -453,6 +453,21 @@ div.rootStyle img {
     overflow: hidden;
 }
 
+.file-drop-zone {
+    border: none;
+    transition: border 0.3s ease-in-out;
+    position: relative;
+    top: 0;
+    left: 0;
+    z-index: 10; /* Adjust z-index to ensure it's above other FileUploadViewPanel content */
+}
+
+.file-drop-zone.dragging {
+    border: 2px dashed #007bff; /* Change border color when dragging over */
+    background-color: #f0f0f0; /* Add a background color when dragging over */
+    opacity: 65%;
+}
+
 .alerts__msg {
     color: #1A2739;
     text-align: center;

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -5,7 +5,7 @@
 import React, {useState} from 'react';
 import {FormPanel} from './FormPanel.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
-import { FileUploadViewPanel, resultFail} from '../visualize/ui/FileUploadViewPanel.jsx';
+import {FileUploadViewPanel, resultFail} from '../visualize/ui/FileUploadViewPanel.jsx';
 import {getAppOptions} from 'firefly/api/ApiUtil.js';
 import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr.js';
@@ -38,7 +38,6 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
     return (
-
         <div style={{width: '100%', ...style}}>
             <FieldGroup groupKey={groupKey} keepState={keepState} style={{height:'100%', width: '100%',
                 display: 'flex', alignItems: 'stretch', flexDirection: 'column'}}>
@@ -56,8 +55,6 @@ export const FileUploadDropdown= ({style={}, onCancel=dispatchHideDropDown, onSu
             </FieldGroup>
             {doMask && <div style={maskWrapper}> <div className='loading-mask'/> </div> }
         </div>
-
-
     );
 };
 

--- a/src/firefly/js/ui/RadioGroupInputField.jsx
+++ b/src/firefly/js/ui/RadioGroupInputField.jsx
@@ -1,8 +1,9 @@
 import React, {memo} from 'react';
-import {bool, array, string, number, object, any, shape} from 'prop-types';
+import {bool, array, string, number, object, shape, func} from 'prop-types';
 import {isEmpty, isUndefined, get}  from 'lodash';
 import {RadioGroupInputFieldView} from './RadioGroupInputFieldView.jsx';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
+import {FILE_ID, URL_ID} from 'firefly/visualize/ui/FileUploadViewPanel';
 
 
 const assureValue= (props) => {
@@ -31,11 +32,11 @@ function checkForUndefined(v,props) {
 
 export const RadioGroupInputField= memo( (props) => {
     const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmValue:checkForUndefined});
-    const value= assureValue(viewProps);
+    const value = assureValue(viewProps);
     if (isUndefined(value)) return <div/>;
     const newProps= {...viewProps,  value};
-    return <RadioGroupInputFieldView {...newProps}
-                                     onChange={(ev) => handleOnChange(ev,viewProps, fireValueChange)}/> ;
+    return (<RadioGroupInputFieldView {...newProps}
+                                     onChange={(ev) => handleOnChange(ev,viewProps, fireValueChange)}/>) ;
 });
 
 

--- a/src/firefly/js/ui/RadioGroupInputFieldView.jsx
+++ b/src/firefly/js/ui/RadioGroupInputFieldView.jsx
@@ -4,7 +4,7 @@ import InputFieldLabel from './InputFieldLabel.jsx';
 import './ButtonGroup.css';
 
 
-function makeRadioGroup(options,alignment ,value,onChange,tooltip, labelStyle) {
+function makeRadioGroup(options,alignment,value,onChange,tooltip,labelStyle) {
 
     return options.map((option) => (
         <span key={option.value}>


### PR DESCRIPTION
#### [Firefly-1310](https://jira.ipac.caltech.edu/browse/FIREFLY-1310)
- a simple drag drop UI for file uploads - probably just the first iteration of many, would like to iterate based on UI feedback received 
- We need to consider how big to make the space for drag & drop, and what happens to it after a user uploads a file, since we immediately display the file analysis results 
   - potentially make the entire window draggable/droppable for files? 

**Updates 10/10**
 - The entire window is draggable/droppable for files now 
 - added text that indicates you can choose a file from your OS's file explorer _or_ drag and drop a file
 - You can switch to **_Upload from URL_** and upload files from there too (this should switch the window back to **_Upload from file_** as well). 
    - To swtich the radio buttons back to **_Upload from file_**, I call **fireValueChange** in the **RadioGroupInputField** component (line 37)
    - This leads to some warnings in the console though (regarding updating a component while rendering a different component and updating state during an existing state transition). I am trying to fix it, but open to suggestions. 
  - The way this is handled now: The **FileDropZone** component sets state of some values on a file drop event. A useEffect in **FileUpload** component (in FileUpload.jsx) then handles the onDrop event. 
  - Finally, I discovered 3 existing bugs in our upload workflow during my work. I'll be creating a ticket for that. 
    - Here's that ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1332. I added short videos for each bug, haven't dived into them yet, let me know if you have any feedback. 

**Updates 10/20**
- Made some cleanup and other changes based on @robyww's feedback
  - especially for RadioGroupInputField, got rid of those changes by simply using useFieldGroupValue's setter, much simpler, and cleaner! 
  - also added the big drag and drop text that goes away when you upload a file. Make sure to test this on the TAP panel dialog (multi-object upload) as well as the Hips/MOC upload dialog. 
  

**Testing** (updated as of 10/10): 
- **Firefly**: https://fireflydev.ipac.caltech.edu/firefly-1310-drag-drop-file-ui/firefly
- **IrsaViewer**: https://firefly-1310-drag-drop-file-ui.irsakudev.ipac.caltech.edu/irsaviewer
- Go to "Upload" and test the drag and drop feature to upload a file 
- Switch to **Upload from URL** and attempt to drag and drop files here as well 
- From TAP searchers, select **Spatial type**: **Multi Object** and attempt to drag and drop files into this popup upload dialog 
- From Image Search, choose **Image Type**: **View HiPS Images** and search for m1. From the results view, from the **HiPS/MOC** menu dropdown, click on **Add MOC layer**, switch tabs to **Use my MOC** and attempt to drag/drop a MOC fits file here (or any other file - those will just not be accepted). 
    - this one is important to test as the HiPs upload popup dialog calls **FileUploadViewPanel** directly (instead of **FileUpoadDropdown**). For this reason, I had to move my drag and drop component (**FileDropZone**) inside **FileUploadViewPanel**.  