### PR TITLE
IRSA-5479: return empty string is app options specifies empty productTitleTemplate string

### DIFF
--- a/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
@@ -211,6 +211,7 @@ function getObsCoreRowMetaInfo(table,row) {
 function createObsCoreTitle(table,row) {
  // 1. try a template
     const template= getAppOptions().tapObsCore?.productTitleTemplate;
+    if (!(template??'').trim()) return '';
     const templateColNames= template && getColNameFromTemplate(template);
     const columns= getColumns(table);
     if (templateColNames?.length && columns?.length) {


### PR DESCRIPTION
#### [[IRSA-5479]](https://jira.ipac.caltech.edu/browse/IRSA-5479)
- this change is to return an empty string for obs core title if app options specifies a an empty tapObsCore.productTitleTemplate as discussed (aimed at euclid - but generic and can apply to other apps as well) 

**Testing**: 
- tested it locally and it works ('`Euclid, `' is taken out from the cutouts title), don't have a test build available for this as I'm still working on other irsa-ife changes for euclid. once I push  a commit for that, I can create a test build as well. 
  - actually, pushed the irsa-ife change and created a test build here: https://irsa-5479-cutouts-title.irsakudev.ipac.caltech.edu/applications/euclid/search
  - you should be able to do a region explorer search and see that '`Euclid, `' is now taken out of the title. 