### PR TITLE
FIREFLY-1072: Fix ADQL text-entry field swallowing "(Command)-`"

### DIFF
--- a/src/firefly/js/externalSource/prismLive/prism-live.js
+++ b/src/firefly/js/externalSource/prismLive/prism-live.js
@@ -144,7 +144,7 @@ var _ = Prism.Live = class PrismLive {
 						}
 					}
 				}
-				else if (_.pairs[evt.key]) {
+				else if (_.pairs[evt.key] && !evt[superKey]) {
 					var other = _.pairs[evt.key];
 					this.wrapSelection({
 						before: evt.key,


### PR DESCRIPTION
Fixes [FIREFLY-1072](https://jira.ipac.caltech.edu/browse/FIREFLY-1072)

This is a problem with [PrismJS Live](https://github.com/PrismJS/live) we're using. Made a patch to them as well: https://github.com/PrismJS/live/pull/38

On some `keydown` events like characters which need auto-completing pairs (like ', ",  (, \`, etc.), prism-live does custom handling. They prevent default browser handling of the `keydown` event at the end which is necessary for window switching. So fixed the condition to make sure it only happens if `keydown` of such pair characters was not in combination of `keydown` of `superKey` (which is "Cmd" in case of Mac).

> Why this bug is only in safari? Chrome didn't have this problem with "Cmd + \`" shortcut because it doesn't allow JS running in browser to catch "\`" key press event if it was pressed after "Cmd", only "Cmd" is caught. But safari allows JS to catch both - "Cmd" keypress and then "\`" keypress (even when it was pressed in combination).

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1072-adql-fix/firefly/

In safari, open atleast 2 windows. Go to TAP Search -> Edit ADQL, pressing "Cmd+\`" should switch windows instead of getting swallowed.