### PR TITLE
Firefly 1320: Search Panel routes for Euclid SphereX

### DIFF
--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -9,7 +9,7 @@ import * as TablesCntlr from '../tables/TablesCntlr.js';
 import {HelpIcon} from './HelpIcon.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
 import {makeTblRequest} from '../tables/TableRequestUtil.js';
-import {get, isNil} from 'lodash';
+import {isNil} from 'lodash';
 import {dispatchFormCancel, dispatchFormSubmit} from 'firefly/core/AppDataCntlr.js';
 
 function handleFailure() {
@@ -46,8 +46,7 @@ function createSuccessHandler(action, params={}, title, onSubmit) {
 
 export const FormPanel = function (props) {
     const { children, onSuccess, onSubmit, onCancel=dispatchHideDropDown, onError, groupKey, groupsToUse,
-        action, params, title, getDoOnClickFunc,
-        submitText='Search',cancelText='Cancel', help_id, changeMasking,
+        action, params, title, getDoOnClickFunc, submitText='Search',cancelText='Cancel', help_id, changeMasking,
         includeUnmounted=false, extraWidgets=[], extraWidgetsRight=[]} = props;
     let { style, inputStyle, submitBarStyle, buttonStyle} = props;
 

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -11,6 +11,7 @@ import {FormPanel} from './FormPanel.jsx';
 import {useStoreConnector} from './SimpleComponent.jsx';
 import {StatefulTabs, Tab} from './panel/TabPanel.jsx';
 import {makeSearchOnce} from '../util/WebUtil';
+import {useNavigate, useInRouterContext} from 'react-router-dom';
 
 const changeSearchOptionOnce= makeSearchOnce(); // setup options to immediately execute the search the first time
 
@@ -31,7 +32,7 @@ export function SearchPanel({style={}, initArgs={}}) {
     const isSingleSearch = Object.keys(allSearchItems).length === 1;
     if (isSingleSearch) {
         return (
-            <div>
+            <div className='SearchPanel-box'>
                 {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
                 <SearchForm style={{height: 'auto'}} searchItem={searchItem} initArgs={initArgs}/>
             </div>
@@ -41,7 +42,7 @@ export function SearchPanel({style={}, initArgs={}}) {
     if (flow === 'vertical') {
         const sideBar = <SideBar {...{activeSearch, groups}}/> ;
         return (
-            <div>
+            <div className='SearchPanel-box'>
                 {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
                 <div className='SearchPanel' style={style}>
                     {sideBar}
@@ -56,7 +57,7 @@ export function SearchPanel({style={}, initArgs={}}) {
     } else {
         const onTabSelect = (index,id,name) => dispatchUpdateAppData(set({}, ['searches', 'activeSearch'], name));
         return (
-            <div>
+            <div className='SearchPanel-box'>
                 {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
                 <StatefulTabs componentKey={`SearchPanel_${title}`} onTabSelect={onTabSelect} resizable={true} useFlex={true} borderless={true} contentStyle={{backgroundColor: 'transparent'}}>
                     {searchesAsTabs(allSearchItems, initArgs)}
@@ -138,10 +139,21 @@ function SearchGroup({group, activeSearch}) {
     );
 }
 
+function RouterSearchItem({onClick, ttips, clsname, label, search}) {
+    const navigate = useNavigate();
+    const handleClick = () => {
+        onClick();
+        navigate(search.path);
+    };
+    return <div className='SearchPanel__searchItem' onClick={handleClick} title={ttips}><span className={clsname}>{label}</span></div>;
+}
+
 function SearchItem({search, activeSearch}) {
+    const isUsingRouter = useInRouterContext();
     const ttips = search.desc || search.title || search.name;
     const label = search.title || search.name;
     const clsname = search.name ===  activeSearch ? 'selected' : 'normal';
     const onClick = () => dispatchUpdateAppData(set({}, ['searches', 'activeSearch'], search.name));
-    return <div className='SearchPanel__searchItem' onClick={onClick} title={ttips}><span className={clsname}>{label}</span></div>;
+    if (isUsingRouter) return <RouterSearchItem {...{onClick, ttips, clsname, label, search}}/>;
+    else return <div className='SearchPanel__searchItem' onClick={onClick} title={ttips}><span className={clsname}>{label}</span></div>;
 }


### PR DESCRIPTION
#### [Firefly-1320](https://jira.ipac.caltech.edu/browse/FIREFLY-1320)
- irsa-ife PR: https://github.com/IPAC-SW/irsa-ife/pull/294
- React Router's `useNavigate()` may be used only in the context of a <Router> component which is why I had to separate the `SearchPanel` component into a new `SearchPanelRoutes` component (if I tried to use `useNavigate()` in the existing `SearchPanel` component, things would be fine for euclid and spherex apps, but would break for wise and other apps
- SearchPanelRoutes now works with the euclid app, which means we would have had two submit and two cancel buttons on the search page (since SearchPanel internally calls FormPanel, but the euclid search components - RegionExplorer, Source Inspector also call FormPanel)
   - So I had to add a conditional in FormPanel component whose default value is always true to display the Search/Cancel buttons, and only false from SearchPanelRoutes (for Euclid, SphereX). So the rest of the app should be unaffected but there may still be a better way to do this instead of modifying FormPanel directly? 
- **_ToDo_**: if user enters a path like `euclid/search/region-explorer`, then the search page should be displayed with Region Explorer selected as the search. Right now though, going to a route like `euclid/search/region-explorer` yields nothing at all, so this may be a irsa-ife change with react router needed to make this work. 

**Update 10/30**: 
- Got rid of SearchPanelRoutes component based on @loitly's feedback 

**Update 11/3**
- Got rid of making conditional changes *inside* the `FormPanel` component though, to not display the Search/Cancel buttons when it's a route based app. Instead, I was able to just conditionally not render the `FormPanel` for route based apps in SearchPanel.jsx's `SearchForm` component (see irsa-ife PR for more details on why I chose to do this)

**Update 11/10**
- removed `routerStyle`, just using `SearchPanel's` default style 
- after some testing, to make the MOCs for these route based apps take up the entire width available, I had to add the following style `style={{width: '100%', height: '100%'}}` to the parent div of the `<div className='SearchPanel' style={style}>` (~line 45 in SearchPanel.jsx)
  - this and the change in the menu.css for `.SearchPanel` allows the mocs to take up the entire width available. Even though this is a change that shouldn't affect other apps (as width and height are set to 100% instead of hardcoded values), I still built and tested the following apps (apps that use `SearchPanel`) to ensure this change didn't affect their look: ztf, SHA, Sofia, FinderChart and wise. 
- not conditionally rendering `FormPanel` anymore (instead removed the `FormPanel` calls from the individual search components in euclid, so that `SearchPanel` pretty much remains the same as before)
- not using the watcher in `RouterChange` anymore (and changed its name to `RouterSearchItem` instead). Instead, using searchInfo (`search`) available from `SearchItem` directly as @loitly suggested
- general cleanup 

**Testing**: 
- **Euclid**: https://firefly-1320-searchpanel-routes.irsakudev.ipac.caltech.edu/applications/euclid
- select one of 3 different search options, click search. Click on the "Search" tab from the nav bar to go back to the search page. Your previous search should be selected here. Proof of concept for `SearchPanel` (or rather `SearchPanelRoutes`) working with route based app. 