### PR TITLE
Firefly-1324: Update multi product view to handle multiple spectrum at once

### DIFF
--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -87,7 +87,7 @@ export class MultiChartViewer extends PureComponent {
     }
 
     render() {
-        const {viewerId, expandedMode, closeable, noChartToolbar, label} = this.props;
+        const {viewerId, expandedMode, closeable, noChartToolbar, label, autoRowOriented=true} = this.props;
         const {viewer}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId);
         if (!viewer || isEmpty(viewer.itemIdAry)) {

--- a/src/firefly/js/data/FileAnalysis.js
+++ b/src/firefly/js/data/FileAnalysis.js
@@ -104,6 +104,9 @@ export const makeFileAnalysisPart= (index,fileLocationIndex=0) => (
  * @prop {string} xAxis
  * @prop {string} yAxis
  * @prop {Array.<FileAnalysisChartParams>} chartParamsAry
+ * @prop {boolean} useChartChooser
+ * @props {Array.<string>} [cUnits]
+ * @props {Array.<string>} [cNames]
  *
  */
 

--- a/src/firefly/js/drawingLayers/HiPSGrid.js
+++ b/src/firefly/js/drawingLayers/HiPSGrid.js
@@ -139,7 +139,7 @@ function computeDrawDataForId(plotId, gridType, gridLockLevel, projectionTypeCha
     }
 
     const {fov, centerWp}= getPointMaxSide(plot, plot.viewDim);
-    const cells= getVisibleHiPSCells(norder,desiredNorder, centerWp,fov, plot.dataCoordSys, aitoff);
+    const cells= getVisibleHiPSCells(norder,desiredNorder, centerWp,fov, plot.viewDim, plot.dataCoordSys, aitoff);
 
     const nonWrapCells= fov>=130 && aitoff ? cells.filter( (c) => !tileCoordsWrap(cc, c.wpCorners)) : cells;
 

--- a/src/firefly/js/metaConvert/AnalysisUtils.js
+++ b/src/firefly/js/metaConvert/AnalysisUtils.js
@@ -28,15 +28,15 @@ export function makeAnalysisGetSingleDataProduct(makeReq) {
     return async (table, row, activateParams, options, dataTypeHint = '') => {
         const reqObj = makeReq(table, row, true);
         const request = reqObj?.single ?? reqObj;
-        return uploadAndAnalyze({request, table, row, activateParams, dataTypeHint});
+        return uploadAndAnalyze({request, table, row, activateParams, dataTypeHint, options});
     };
 }
 
 
-export async function uploadAndAnalyze({request, table, row, activateParams, dataTypeHint = ''}) {
+export async function uploadAndAnalyze({request, table, row, activateParams, dataTypeHint = '', options}) {
     if (!hasRowAccess(table, row)) dpdtSimpleMsg('You do not have access to this data.');
     if (isNonAnalysisType(request)) return fileExtensionSingleProductAnalysis(request);
-    const analysisPromise = doUploadAndAnalysis({table, row, request, activateParams, dataTypeHint});
+    const analysisPromise = doUploadAndAnalysis({table, row, request, activateParams, dataTypeHint, options});
     return dpdtWorkingPromise(LOADING_MSG, analysisPromise, request);
 }
 
@@ -107,24 +107,26 @@ export function makeAnalysisGetGridDataProduct(makeReq) {
 /**
  * return an activate function that will upload and analyze the file then dispatch the new DataProductsDisplayType
  * as the active data product. This will be picked up by the MultiProductViewer
- * @param table
- * @param row
- * @param request
- * @param positionWP
- * @param activateParams
- * @param menuKey
- * @param dataTypeHint
- * @param {ServiceDescriptorDef} [serDef]
- * @param [originalTitle]
+ * @param {Object} obj
+ * @param obj.table
+ * @param obj.row
+ * @param obj.request
+ * @param obj.activateParams
+ * @param obj.menuKey
+ * @param obj.dataTypeHint
+ * @param {ServiceDescriptorDef} [obj.serDef]
+ * @param [obj.originalTitle]
+ * @param {DataProductsFactoryOptions} [obj.options]
  * @return {function}
  */
-export function makeAnalysisActivateFunc(table, row, request, positionWP, activateParams, menuKey, dataTypeHint, serDef, originalTitle) {
+export function makeAnalysisActivateFunc({table, row, request, activateParams, menuKey,
+                                             dataTypeHint, serDef, originalTitle, options}) {
     const analysisActivateFunc = async (menu, userInputParams) => {
         const {dpId}= activateParams;
         dispatchUpdateDataProducts(dpId, dpdtWorkingMessage(LOADING_MSG,menuKey));
         // do the uploading and analyzing
-        const dPDisplayType= await doUploadAndAnalysis({ table, row, request, activateParams, dataTypeHint, menu,
-            serDef, userInputParams, analysisActivateFunc, originalTitle });
+        const dPDisplayType= await doUploadAndAnalysis({ table, row, request, activateParams, dataTypeHint, options, menu,
+            serDef, userInputParams, analysisActivateFunc, originalTitle});
         // activate the result of the analysis
        dispatchResult(dPDisplayType, menu,menuKey,dpId, serDef, analysisActivateFunc);
     };

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -267,10 +267,38 @@ function initConverterTemplates() {
 }
 
 
+/**
+ * @typedef {Object} DataProductsFactoryOptions
+ *
+ * @prop {boolean} [allowImageRelatedGrid]
+ * @prop {boolean} [allowServiceDefGrid] - // todo: this is redundant, should remove
+ * @prop {boolean} [singleViewImageOnly] - if true, the view will only show the primary image product
+ * @prop {boolean} [singleViewTableOnly] - if true, the view will only show the primary table product
+ * @prop {String} [dataLinkInitialLayout] - determine how a datalink obscore table trys to show the data layout, must be 'single', 'gridRelated', 'gridFull';
+ * @prop {boolean} [activateServiceDef] - if possible then call the service def without giving option for user input
+ * @prop {boolean} [threeColor] - if true, then for images in related grid, show the threeColor option
+ * @prop {number} [maxPlots] - maximum number of plots in grid mode, this will override the factory default
+ * @prop {boolean} [canGrid] - some specific factories might have parameters that override this parameter (e.g. allowServiceDefGrid)
+ * @prop [initialLayout]
+ * @prop {string} [tableIdBase] - any tbl_id will use this string for its base
+ * @prop {string} [chartIdBase] - any chartId will use this string for its base
+ *
+ * @prop {string} [dataProductsComponentKey] - this is the key use when calling getComponentState() to get a key,value object.
+ *                The values in this object will override one or more parameters to a service descriptor.
+ *                The following are used with this prop by service descriptors to build the url to include input from the UI.
+ *                see- ServDescProducts.js getComponentInputs()
+ * @prop {Array.<string>} [paramNameKeys] - name of the parameters to put in the url from the getComponentState() return object
+ * @prop {Array.<string>} [ucdKeys] - same as above but can be specified by UCD
+ * @prop {Array.<string>} [utypeKeys] - same as above but can be specified by utype
+ */
+
+/**
+ * @return {DataProductsFactoryOptions}
+ */
 export const getDefaultFactoryOptions= once(() => ({
     dataProductsComponentKey: DEFAULT_DATA_PRODUCTS_COMPONENT_KEY,
     allowImageRelatedGrid: false,
-    allowServiceDefGrid: false,
+    allowServiceDefGrid: false, // todo: this is redundant, should remove
     singleViewImageOnly:false,
     singleViewTableOnly:false,
     dataLinkInitialLayout: 'single', //determine how a datalink obscore table trys to show the data layout, must be 'single', 'gridRelated', 'gridFull';
@@ -279,6 +307,8 @@ export const getDefaultFactoryOptions= once(() => ({
     maxPlots: undefined,
     canGrid: undefined, // some specific factories might have parameters that override this parameter (e.g. allowServiceDefGrid)
     initialLayout: undefined, //todo - an datalink use this?
+    tableIdBase: undefined,
+    chartIdBase: undefined,
     paramNameKeys: [],
     ucdKeys: [],
     utypeKeys: [],
@@ -302,8 +332,8 @@ function getConverterTemplates(factoryKey='DEFAULT_FACTORY')  {
 /**
  * Each list of factory templates can have a unique set of options. This options will come from a MultiProductViewer when
  * it starts the DataProductsWatcher.
- * @param options
  * @param factoryKey
+ * @param options
  */
 export function setFactoryTemplateOptions(factoryKey='DEFAULT_FACTORY', options)  {
     FACTORY_OPTIONS[factoryKey]= options;

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -21,9 +21,10 @@ import {createSingleImageActivate, createSingleImageExtraction} from './ImageDat
  * @param {String} dataTypeHint  stuff like 'spectrum', 'image', 'cube', etc
  * @param serverCacheFileKey
  * @param {ActivateParams} activateParams
+ * @param {DataProductsFactoryOptions} options
  * @return {{tableResult: DataProductsDisplayType|undefined, imageResult: DataProductsDisplayType|undefined}}
  */
-export function analyzePart(part, request, table, row, fileFormat, dataTypeHint, serverCacheFileKey, activateParams) {
+export function analyzePart(part, request, table, row, fileFormat, dataTypeHint, serverCacheFileKey, activateParams, options) {
 
     const {type,desc, fileLocationIndex}= part;
     const aTypes= findAvailableTypesForAnalysisPart(part, fileFormat);
@@ -35,7 +36,7 @@ export function analyzePart(part, request, table, row, fileFormat, dataTypeHint,
         analyzeImageResult(part, request, table, row, fileFormat, part.convertedFileName,desc,activateParams,fileLocationIndex);
 
     const tableResult= aTypes.includes(DPtypes.TABLE) &&
-        analyzeChartTableResult(false, table, row, part, fileFormat, fileOnServer,desc,dataTypeHint,activateParams,fileLocationIndex);
+        analyzeChartTableResult(false, table, row, part, fileFormat, fileOnServer,desc,dataTypeHint,activateParams,fileLocationIndex, options);
 
     return {imageResult, tableResult};
 }
@@ -106,7 +107,7 @@ const SPACITAL_C_COL2= ['dec','lat','c_dec','dec1'];
  * @param title
  * @param part
  * @param fileFormat
- * @return {{xCol:string,yCol:string,cNames:Array.<String>,cUnits:Array.<String>}|{}}
+ * @return {ChartInfo}
  */
 function getTableChartColInfo(title, part, fileFormat) {
     if (isImageAsTable(part,fileFormat)) {
@@ -189,9 +190,10 @@ function getTableDropTitleStr(title,part,fileFormat,tableOnly) {
  * @param {String} dataTypeHint  stuff like 'spectrum', 'image', 'cube', etc
  * @param {ActivateParams} activateParams
  * @param {number} tbl_index
+ * @param {DataProductsFactoryOptions} options
  * @return {DataProductsDisplayType|undefined}
  */
-function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOnServer, title, dataTypeHint='', activateParams, tbl_index=0) {
+function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOnServer, title, dataTypeHint='', activateParams, tbl_index=0, options) {
     const {uiEntry,uiRender,chartParamsAry, interpretedData=false, defaultPart:requestDefault= false}= part;
     const partFormat= part.convertedFileFormat||fileFormat;
     if (uiEntry===UIEntry.UseSpecified) {
@@ -211,7 +213,8 @@ function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOn
 
     if (tableOnly) {
         return dpdtTable(ddTitleStr,
-            createChartTableActivate({source:fileOnServer,titleInfo,activateParams, tbl_index, dataTypeHint, cNames, cUnits}),
+            createChartTableActivate({source:fileOnServer,titleInfo,activateParams, tbl_index, dataTypeHint, cNames, cUnits,
+                                     tbl_id:options.tableIdBase }),
             createTableExtraction(fileOnServer,titleInfo,tbl_index, cNames, cUnits, dataTypeHint),
             undefined, {extractionText: 'Pin Table', paIdx:tbl_index,requestDefault});
     }
@@ -235,7 +238,9 @@ function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOn
             const chartInfo= {xAxis:xCol, yAxis:yCol, chartParamsAry, useChartChooser};
             if (chartTableDefOption===AUTO) chartTableDefOption= imageAsTableColCnt===2 ? SHOW_CHART : SHOW_TABLE;
             return dpdtChartTable(ddTitleStr,
-                createChartTableActivate({chartAndTable:true, source:fileOnServer,titleInfo,activateParams,chartInfo,tbl_index,dataTypeHint, cNames,cUnits,connectPoints}),
+                createChartTableActivate({chartAndTable:true, source:fileOnServer,titleInfo,activateParams,chartInfo,
+                    tbl_index,dataTypeHint, colNames:cNames,colUnits:cUnits,connectPoints,
+                    tbl_id:options.tableIdBase, chartId:options.chartIdBase }),
                 createTableExtraction(fileOnServer,titleInfo,tbl_index, cNames, cUnits, dataTypeHint),
                 undefined, {extractionText: 'Pin Table', paIdx:tbl_index, chartTableDefOption, interpretedData, requestDefault});
         }

--- a/src/firefly/js/metaConvert/UploadAndAnalysis.js
+++ b/src/firefly/js/metaConvert/UploadAndAnalysis.js
@@ -35,6 +35,7 @@ const parseAnalysis= (serverCacheFileKey, analysisResult) =>
  * @param {WebPlotRequest} obj.request - used for image or just downloading files
  * @param {ActivateParams} obj.activateParams
  * @param {String} [obj.dataTypeHint]  stuff like 'spectrum', 'image', 'cube', etc
+ * @param {DataProductsFactoryOptions} obj.options
  * @param {Array.<Object>} [obj.menu]
  * @param {ServiceDescriptorDef} [obj.serDef]
  * @param {Object} [obj.userInputParams]
@@ -42,7 +43,7 @@ const parseAnalysis= (serverCacheFileKey, analysisResult) =>
  * @param {string} [obj.originalTitle]
  * @return {Promise.<DataProductsDisplayType>}
  */
-export async function doUploadAndAnalysis({ table, row, request, activateParams={}, dataTypeHint='',
+export async function doUploadAndAnalysis({ table, row, request, activateParams={}, dataTypeHint='', options,
                                  menu, serDef, userInputParams, analysisActivateFunc, originalTitle}) {
 
     const {dpId}= activateParams;
@@ -54,7 +55,7 @@ export async function doUploadAndAnalysis({ table, row, request, activateParams=
                                                   fileAnalysis.fileName&&'Download File', request.getURL());
         }
         return processAnalysisResult({ table, row, request, activateParams, serverCacheFileKey,
-            fileAnalysis, dataTypeHint, analysisActivateFunc, serDef, originalTitle});
+            fileAnalysis, dataTypeHint, analysisActivateFunc, serDef, originalTitle, options});
     };
 
 
@@ -189,11 +190,12 @@ function makeAllImageEntry(request, path, parts, imageViewerId,  tbl_id, row, im
  * @param {Function} obj.analysisActivateFunc
  * @param {ServiceDescriptorDef} obj.serDef
  * @param {String} obj.originalTitle
+ * @param {DataProductsFactoryOptions} obj.options
  * @return {DataProductsDisplayType}
  */
 function processAnalysisResult({table, row, request, activateParams,
                                    serverCacheFileKey, fileAnalysis, dataTypeHint,
-                                  analysisActivateFunc, serDef, originalTitle}) {
+                                  analysisActivateFunc, serDef, originalTitle, options}) {
 
     const {parts,fileName,fileFormat}= fileAnalysis;
     if (!parts) return makeErrorResult('',fileName,serverCacheFileKey);
@@ -207,14 +209,14 @@ function processAnalysisResult({table, row, request, activateParams,
     return deeperInspection({
         table, row, request, activateParams,
         serverCacheFileKey, fileAnalysis, dataTypeHint,
-        analysisActivateFunc, serDef, originalTitle, url,
+        analysisActivateFunc, serDef, originalTitle, url, options
     });
 }
 
 
 function deeperInspection({ table, row, request, activateParams,
                               serverCacheFileKey, fileAnalysis, dataTypeHint,
-                              analysisActivateFunc, serDef, originalTitle, url}) {
+                              analysisActivateFunc, serDef, originalTitle, url, options}) {
 
     const {parts,fileFormat, disableAllImageOption= false}= fileAnalysis;
     const {imageViewerId, dpId}= activateParams;
@@ -222,7 +224,7 @@ function deeperInspection({ table, row, request, activateParams,
     const activeItemLookupKey= hashCode(rStr);
     const fileMenu= {fileAnalysis, menu:[],activeItemLookupKey, activeItemLookupKeyOrigin:rStr};
 
-    const partAnalysis= parts.map( (p) => analyzePart(p,request, table, row, fileFormat, dataTypeHint, serverCacheFileKey,activateParams));
+    const partAnalysis= parts.map( (p) => analyzePart(p,request, table, row, fileFormat, dataTypeHint, serverCacheFileKey,activateParams, options));
     const imageParts= partAnalysis.filter( (pa) => pa.imageResult);
     let makeAllImageOption= !disableAllImageOption;
     if (makeAllImageOption) makeAllImageOption= imageParts.length>1 || (imageParts.length===1 && parts.length===1);

--- a/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
@@ -26,7 +26,7 @@ const DEF_MAX_PLOTS= 8;
  *
  * @param {TableModel} table
  * @param {DataProductsConvertType} converterTemplate
- * @param {Object} options
+ * @param {DataProductsFactoryOptions} options
  * @return {DataProductsConvertType}
  */
 export function makeObsCoreConverter(table,converterTemplate,options={}) {
@@ -76,7 +76,7 @@ function describeObsThreeColor(table, row, options) {
  * @param table
  * @param plotRows
  * @param activateParams
- * @param options
+ * @param {DataProductsFactoryOptions} options
  * @return {Promise.<DataProductsDisplayType>}
  */
 export function getObsCoreGridDataProduct(table, plotRows, activateParams, options) {
@@ -92,7 +92,7 @@ export function getObsCoreGridDataProduct(table, plotRows, activateParams, optio
  * @param threeColorOps
  * @param highlightPlotId
  * @param activateParams
- * @param options
+ * @param {DataProductsFactoryOptions} options
  * @return {Promise<DataProductsDisplayType>}
  */
 export async function getObsCoreRelatedDataProduct(table, row, threeColorOps, highlightPlotId, activateParams, options) {
@@ -150,7 +150,7 @@ function doErrorChecks(table, row, prodType, dataSource, isDataLink, isVoTable) 
  * @param {ActivateParams} activateParams
  * @param {Array.<DataProductsDisplayType>} serviceDescMenuList
  * @param {boolean} doFileAnalysis - if true the build a menu if possible
- * @param {Object} options
+ * @param {DataProductsFactoryOptions} options
  * @return {Promise.<DataProductsDisplayType>}
  */
 async function getObsCoreSingleDataProduct(table, row, activateParams, serviceDescMenuList, doFileAnalysis= true, options) {

--- a/src/firefly/js/metaConvert/vo/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/vo/ServDescConverter.js
@@ -18,7 +18,7 @@ const DEF_MAX_PLOTS= 8;
  *
  * @param {TableModel} table
  * @param {DataProductsConvertType} converterTemplate
- * @param {Object} options
+ * @param {DataProductsFactoryOptions} options
  * @return {DataProductsConvertType}
  */
 export function makeServDescriptorConverter(table,converterTemplate,options={}) {
@@ -58,7 +58,7 @@ function describeServDefThreeColor(table, row, options) {
  * @param table
  * @param row
  * @param {ActivateParams} activateParams
- * @param {Object} options
+ * @param {DataProductsFactoryOptions} options
  * @return {Promise.<DataProductsDisplayType>}
  */
 export async function getServiceDescSingleDataProduct(table, row, activateParams, options) {

--- a/src/firefly/js/metaConvert/vo/ServDescProducts.js
+++ b/src/firefly/js/metaConvert/vo/ServDescProducts.js
@@ -21,7 +21,7 @@ import {makeObsCoreRequest} from './VORequest.js';
  * @param p.idx
  * @param p.positionWP
  * @param p.activateParams
- * @param p.options
+ * @param {DataProductsFactoryOptions} p.options
  * @param p.titleStr
  * @param p.activeMenuLookupKey
  * @param p.menuKey
@@ -42,14 +42,15 @@ export function makeServiceDefDataProduct({
     if (activateServiceDef && noInputRequired) {
         const url= makeUrlFromParams(accessURL, serDef, idx, getComponentInputs(serDef,options));
         const request = makeObsCoreRequest(url, positionWP, titleStr, sourceTable, sourceRow);
-        const activate = makeAnalysisActivateFunc(sourceTable, sourceRow, request, positionWP, activateParams, menuKey, prodTypeHint);
+        const activate = makeAnalysisActivateFunc({table:sourceTable, row:sourceRow, request, activateParams,
+            menuKey, dataTypeHint:prodTypeHint, options});
         return dpdtAnalyze({
             name:'Show: ' + (titleStr || name), activate, url:request.getURL(), menuKey,
             activeMenuLookupKey, request, sRegion, prodTypeHint, semantics, size, serviceDefRef});
     } else {
         const request = makeObsCoreRequest(accessURL, positionWP, titleStr, sourceTable, sourceRow);
-        const activate = makeAnalysisActivateFunc(sourceTable, sourceRow, request, positionWP, activateParams, menuKey,
-            prodTypeHint ?? 'unknown', serDef, name);
+        const activate = makeAnalysisActivateFunc({table:sourceTable, row:sourceRow, request, activateParams, menuKey,
+            dataTypeHint:prodTypeHint ?? 'unknown', serDef, originalTitle:name,options});
         const entryName = `Show: ${titleStr || servDescTitle || `Service #${idx}: ${name}`} ${allowsInput ? ' (Input Required)' : ''}`;
         return dpdtAnalyze({
             name:entryName, activate, url:request.getURL(), serDef, menuKey,
@@ -60,6 +61,12 @@ export function makeServiceDefDataProduct({
     }
 }
 
+/**
+ * return a list of inputs from the user that will go into the service descriptor URL
+ * @param serDef
+ * @param {DataProductsFactoryOptions} options
+ * @return {{[p: string]: *}|{}}
+ */
 function getComponentInputs(serDef, options) {
     const key= options.dataProductsComponentKey ?? DEFAULT_DATA_PRODUCTS_COMPONENT_KEY;
     const valueObj= getComponentState(key,{});
@@ -94,7 +101,7 @@ function getComponentInputs(serDef, options) {
  * @param {number} p.row
  * @param {ActivateParams} p.activateParams
  * @param {String} p.activeMenuLookupKey
- * @param {boolean} p.options
+ * @param {DataProductsFactoryOptions} p.options
  * @return {Array.<DataProductsDisplayType>}
  */
 export function createServDescMenuRet({ descriptors, positionWP, table, row,
@@ -132,5 +139,3 @@ function logServiceDescriptor(baseUrl, sendParams, newUrl) {
     // Object.entries(sendParams).forEach(([k,v]) => console.log(`param: ${k}, value: ${v}`));
     console.log(`service descriptor new URL: ${newUrl}`);
 }
-
-

--- a/src/firefly/js/templates/router/RouteHelper.jsx
+++ b/src/firefly/js/templates/router/RouteHelper.jsx
@@ -1,9 +1,9 @@
 
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 import {RouterProvider, useNavigate, redirect, useLocation} from 'react-router-dom';
 import {dispatchNotifyRemoteAppReady, dispatchOnAppReady, dispatchSetMenu, FORM_CANCEL, FORM_SUBMIT} from '../../core/AppDataCntlr.js';
 import {dispatchSetLayoutInfo, getDropDownInfo} from '../../core/LayoutCntlr.js';
-import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../../core/MasterSaga.js';
+import {dispatchAddActionWatcher} from '../../core/MasterSaga.js';
 import {getMenuItems} from '../../ui/Menu.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 

--- a/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {oneOfType,oneOf,element,bool,string,number,arrayOf,object,func} from 'prop-types';
+import {oneOfType, oneOf, element, bool, string, number, arrayOf, object, func, shape} from 'prop-types';
 import CoordinateSys from '../../visualize/CoordSys.js';
 import {CONE_AREA_OPTIONS, CONE_CHOICE_KEY, POLY_CHOICE_KEY} from '../../visualize/ui/CommonUIKeys.js';
 import {HiPSTargetView} from '../../visualize/ui/TargetHiPSPanel.jsx';
@@ -22,7 +22,7 @@ import './EmbeddedPositionSearchPanel.css';
  * @param {String} [props.hipsUrl] - url for the hips url
  * @param [props.hipsFOVInDeg] - field of view of the initial HiPS display
  * @param {WorldPt} [props.initCenterPt] - center point of the initial HiPS display - string - 1.1;2.2;EQ_J2000
- * @param {Array.<Object>} [props.mocList] - a list of MOCS to display, an array of MOC URLs
+ * @param {Array.<{mocUrl:String, title:String}>} [props.mocList] - a list of MOCS to display, an array of MOC URLs
  * @param {String} [props.sRegion] - an sRegion to display
  * @param {String} [props.coordinateSys] - coordinate system of HiPS - must be 'EQ_J2000' or 'GALACTIC'
  * @param {String} [props.targetKey] - field group key for the target field
@@ -147,7 +147,7 @@ EmbeddedPositionSearchPanel.propTypes= {
     hipsUrl: string,
     hipsFOVInDeg: number,
     initCenterPt: object,
-    mocList: arrayOf(object),
+    mocList: arrayOf(shape( { mocUrl: string, title: string} )),
     sRegion: string,
     coordinateSys: oneOf(['EQ_J2000','GALACTIC']),
     targetKey: string,

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -573,8 +573,10 @@ const DrawingLayers= memo( ({plotView:pv, drawLayersIdAry:dlIdAry}) =>{
 
 },
 (p,np) => {
-    return np.plot===p.plot && isEmpty(xor(np.drawLayersIdAry,p.drawLayersIdAry)) &&
-        np.plotView.scrollX===p.plotView.scrollX && np.plotView.scrollY===p.plotView.scrollY;
+    return primePlot(p.plotView)===primePlot(np.plotView) &&
+        isEmpty(xor(np.drawLayersIdAry,p.drawLayersIdAry)) &&
+        np.plotView.scrollX===p.plotView.scrollX &&
+        np.plotView.scrollY===p.plotView.scrollY;
 });
 
 DrawingLayers.propTypes= {

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -80,6 +80,7 @@ const HIPS_DATA_HEIGHT= 10000000000;
  * @prop {Projection} projection - projection routines for this projections
  * @prop {Object} wlData - data object to wave length conversions, if defined then this conversion is available
  * @prop {Object} vradData - data object to vrad conversions, if defined then this conversion is available
+ * @prop {{width:number, height:number}} viewDim  size of viewable area  (div size: offsetWidth & offsetHeight)
  * @prop {Object} spectralData - data object to spectral wcs conversions, if defined then this conversion is available
  * @prop {Object} affTrans - the affine transform
  * @prop {Array.<RawData>} rawData

--- a/src/firefly/js/visualize/iv/HiPSCellFinder.js
+++ b/src/firefly/js/visualize/iv/HiPSCellFinder.js
@@ -33,7 +33,7 @@ import {CysConverter} from 'firefly/api/ApiUtilImage.jsx';
  * @return {Array.<HiPSDeviceTileData>}
  */
 export function findCellOnScreen(plot, viewDim, norder, fov,centerWp, desiredNorder) {
-    const cells= getVisibleHiPSCells(norder,desiredNorder??norder,centerWp, fov, plot.dataCoordSys, isHiPSAitoff(plot));
+    const cells= getVisibleHiPSCells(norder,desiredNorder??norder,centerWp, fov, plot.viewDim, plot.dataCoordSys, isHiPSAitoff(plot));
     const cc= CysConverter.make(plot);
 
     const retCells= [];

--- a/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
@@ -31,7 +31,7 @@ export const MultiItemViewerView=forwardRef( (props, ref) =>  {
     const {layoutType, activeItemId,
         viewerItemIds, forceRowSize, forceColSize, gridDefFunc,
         style, insideFlex=false, defaultDecoration=true, sparseGridTitleLocation= 'top',
-        makeToolbar, makeItemViewer, makeItemViewerFull}= props;
+        makeToolbar, makeItemViewer, makeItemViewerFull, autoRowOriented=true}= props;
     let wrapperStyle;
     if (insideFlex) {
         wrapperStyle= Object.assign({}, flexContainerStyle, {flex:'1 1 auto'});
@@ -61,7 +61,7 @@ export const MultiItemViewerView=forwardRef( (props, ref) =>  {
         container= makePackedGrid(viewerItemIds,rows,forceColSize,true,makeItemViewer);
     }
     else {                   // GRID automatic
-        const dim= findAutoGridDim(viewerItemIds.length);
+        const dim= findAutoGridDim(viewerItemIds.length, autoRowOriented);
         container= makePackedGrid(viewerItemIds,dim.rows,dim.cols,true,makeItemViewer);
     }
 
@@ -157,7 +157,7 @@ const renderItemViewerFull = (makeItemViewerFull, itemId) => (
         </div>
     );
 
-function findAutoGridDim(size) {
+function findAutoGridDim(size, rowOriented=true) {
     let rows=0 ,cols=0;
     if (size) {
         rows = 1;
@@ -168,17 +168,17 @@ function findAutoGridDim(size) {
             if (size/4 > rows) rows++;
             cols = 4;
         } else if (size === 5 || size === 6) {
-            rows = 2;
-            cols = 3;
+            rows = rowOriented ? 2 : 3;
+            cols = rowOriented ? 3 : 2;
         } else if (size === 4) {
             rows = 2;
             cols = 2;
         } else if (size === 3) {
-            rows = 1;
-            cols = 3;
+            rows = rowOriented ? 1 : 3;
+            cols = rowOriented ? 3 : 1;
         } else if (size === 2) {
-            rows = 1;
-            cols = 2;
+            rows = rowOriented ? 1 : 2;
+            cols = rowOriented ? 2 : 1;
         }
     }
     return {rows,cols};

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
@@ -47,6 +47,7 @@ export function MultiProductChoice({
                 <div style={chartChoiceTBStyle}>
                     {toolbar}
                     <MultiChartViewer viewerId={chartViewerId} closeable={false}
+                                      autoRowOriented={false}
                                       canReceiveNewItems={NewPlotMode.none.key}/>
                 </div>
             );

--- a/src/firefly/js/voAnalyzer/VoConst.js
+++ b/src/firefly/js/voAnalyzer/VoConst.js
@@ -29,6 +29,8 @@ export const standardIDs = {
     datalink: 'ivo://ivoa.net/std/DataLink',
 };
 
+export const VO_TABLE_CONTENT_TYPE= 'application/x-votable+xml';
+
 
 export const UCDSyntax = new Enum(['primary', 'secondary', 'any'], {ignoreCase: true});
 

--- a/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
+++ b/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
@@ -4,7 +4,8 @@
 import {isArray, isNil} from 'lodash';
 import {
     adhocServiceUtype, cisxAdhocServiceUtype,
-    ACCESS_URL, CONTENT_LENGTH, CONTENT_TYPE, DESCRIPTION, SEMANTICS, standardIDs } from './VoConst.js';
+    ACCESS_URL, CONTENT_LENGTH, CONTENT_TYPE, DESCRIPTION, SEMANTICS, standardIDs, VO_TABLE_CONTENT_TYPE
+} from './VoConst.js';
 import {columnIDToName, getColumnIdx, getTblRowAsObj} from '../tables/TableUtil.js';
 import {getTableModel} from './VoCoreUtils.js';
 
@@ -23,7 +24,7 @@ export function analyzeDatalinkRow({semantics = '', localSemantics = '', content
     const locSemL = localSemantics.toLowerCase();
     const isThis = semL.includes('#this');
     const isAux = semL === '#auxiliary';
-    const isGrid = semL.includes('-grid') || (isThis && locSemL.includes('-grid'));
+    const isGrid = semL.includes('-grid') || (isThis && locSemL.includes('-grid') || (isThis && locSemL.includes('#grid')));
     const isCutout = semL.includes('#cutout') || semL.includes('-cutout') || locSemL.includes('-cutout');
     const isSpectrum = locSemL.includes('spectrum');
     const rBand = semL.includes('-red') || locSemL.includes('-red');
@@ -45,6 +46,7 @@ export function analyzeDatalinkRow({semantics = '', localSemantics = '', content
 export const isTarType= (ct='') => ct.includes('tar');
 export const isGzipType= (ct='') => ct.includes('gz');
 export const isSimpleImageType= (ct='') => ct.includes('jpeg') || ct.includes('png') || ct.includes('jpg') || ct.includes('gif');
+export const isVoTable= (ct='') => ct===VO_TABLE_CONTENT_TYPE;
 export const isDownloadType= (ct='') => isTarType(ct) || isGzipType(ct) || ct.includes('octet-stream');
 
 /**


### PR DESCRIPTION
#### [Firefly-1324](https://jira.ipac.caltech.edu/browse/FIREFLY-1324)

- support recognizing and show multiple spectrum
- Note: this PR is based on `dev` the build has the same code but is based on PR https://github.com/Caltech-IPAC/firefly/pull/1438


#### Testing
- https://fireflydev.ipac.caltech.edu/test-spherex-multi-spectrum/firefly
- unzip the folder below and upload `multi-spec.vot` into firefly
- each click on the table will try to show two spectra and the two related table. Unfortunately the is some bug and one of the tables will not load. However, you can get the idea.
[multi-spec-folder.zip](https://github.com/Caltech-IPAC/firefly/files/13182248/multi-spec-folder.zip)
