### PR TITLE
FIREFLY-1304: Implement spectral redshift correction

### DIFF
--- a/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
+++ b/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
@@ -176,3 +176,16 @@ const UnitXref = {
     }
 
 };
+
+/**
+ * returns X axis label using the required information like unit, spectral frame options, redshift, etc.
+ * @param {string} cname         the name of the column being evaluated
+ * @param {string} unit          the unit to get the info for
+ * @param {string} sfLabel       the label of spectral frame selected
+ * @param {string} redshiftLabel the label of redshift if rest frame, optional
+ * @returns {string}
+ */
+export const getXLabel = (cname, unit, sfLabel, redshiftLabel='') => {
+    const unitLabel = getUnitInfo(unit, cname).label;
+    return `${sfLabel} ${unitLabel}${redshiftLabel ? `<br>(${redshiftLabel})` : ''}`;
+};

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -104,7 +104,7 @@ function getValueOnSuggestion(cols, canBeExpression=true) {
     };
 }
 
-export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,labelWidth=30,name,tooltip,nullAllowed,readonly,initValue}) {
+export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,labelWidth=30,name,tooltip,nullAllowed,readonly,initValue,inputStyle}) {
     if (!colValStats) return <div/>;
     return (
         <ColumnFld
@@ -113,7 +113,7 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
             initValue={initValue || get(params, fldPath)}
             canBeExpression={true}
             tooltip={`Column or expression for ${tooltip ? tooltip : name}.${EXPRESSION_TTIPS}`}
-            {...{groupKey, label, labelWidth, name, nullAllowed, readonly}} />
+            {...{groupKey, label, labelWidth, name, nullAllowed, readonly, inputStyle}} />
     );
 }
 
@@ -128,7 +128,8 @@ ColumnOrExpression.propTypes = {
     tooltip: PropTypes.string,
     nullAllowed: PropTypes.bool,
     readonly: PropTypes.bool,
-    initValue: PropTypes.string
+    initValue: PropTypes.string,
+    inputStyle: PropTypes.object
 };
 
 export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidth, tooltip='Table column',

--- a/src/firefly/js/voAnalyzer/vo-typedefs.jsdoc
+++ b/src/firefly/js/voAnalyzer/vo-typedefs.jsdoc
@@ -9,6 +9,9 @@
  * @prop {DataAxis}  spectralAxis
  * @prop {DataAxis}  fluxAxis
  * @prop {DataAxis}  timeAxis
+ * @prop {Object} spectralFrame
+ * @prop {Object} derivedRedshift
+ * @prop {Object} target
  */
 
 


### PR DESCRIPTION
Implements [FIREFLY-1304](https://jira.ipac.caltech.edu/browse/FIREFLY-1304)

On a high-level:
- Made spectral frame data in the table available to the chart data as `fireflyData`
- Added UI for spectral frame and redshift input in Spectrum options
  -  Also updated it based on early feedback from scientists
- Made changes in spectral frame UI inputs trigger changes in X ColumnOrExpression and X Label - aka redshift correction
  - Also apply those changes to other traces of the chart
- [x] Combine expressions for unit conversion and redshift correction, also fix label combination
- [x] Make it work for CUSTOM or other ref pos too
- [x] Chart should be initialized based on initial state of spectral frame options

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1304-redshift-correction/firefly/

Created test files for each of the following 3 case available at https://github.com/jaladh-singhal/z-correction-data/

1. TOPOCENTER - Download [Spitzer_IRS_SL_PBCD-topocenter.vot](https://github.com/jaladh-singhal/z-correction-data/blob/main/Spitzer_IRS_SL_PBCD-topocenter.vot) and upload it to firefly. Open chart options, change spectral frame to rest frame and then in resulting options, choose user-specifed one. Enter 0.5, and apply, check that x axis data and label changed in the chart for all traces.

   Also note that the rest frame options have values that are present in table metadata (retrievable via clicking info button in table). And changing value in dropdown (rest/observed) preserves selection in rest frame radio group options as well as input field.

   Stress test it for other edge cases that can occur due to selection in other fields in spectrum options.

2. CUSTOM - Download [Spitzer_IRS_SL_PBCD-custom.vot](https://github.com/jaladh-singhal/z-correction-data/blob/main/Spitzer_IRS_SL_PBCD-custom.vot) and upload it to firefly. Open chart options, spectral frame should have a custom redshift option selected by default. Change options and play around like in TOPOCENTER case. Also note that formula has multiplication factor in this case.

3. Other - Download [Spitzer_IRS_SL_PBCD-barycenter.vot](https://github.com/jaladh-singhal/z-correction-data/blob/main/Spitzer_IRS_SL_PBCD-barycenter.vot) and upload it to firefly. Open chart options, spectral frame shouldn't be editable as per design and x-axis label in the chart should show the spectral frame.