### PR TITLE
FIREFLY-1340: noChartToolbar parameter for showChart not working

### DIFF
--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -16,7 +16,7 @@ import {CombineChart} from './CombineChart.jsx';
 
 function ChartPanelView(props) {
 
-    const {chartId, tbl_group, chartData, expandable, expandedMode, Toolbar, showToolbar} = props;
+    const {chartId, tbl_group, chartData, expandable, expandedMode, Toolbar, showToolbar, glass} = props;
 
     useEffect(() => {
         dispatchChartMounted(chartId);
@@ -34,12 +34,12 @@ function ChartPanelView(props) {
         return (
             <div className='ChartPanel__container'>
                 <ChartToolbar {...{chartId, tbl_group, expandable, expandedMode, Toolbar}}/>
-                <ChartArea glass={true} {...props}/>
+                <ChartArea glass={glass} {...props}/>
             </div>
         );
     } else {
         // chart only
-        return <ChartArea glass={false} {...props}/>;
+        return <ChartArea glass={glass} {...props}/>;
     }
 }
 

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -124,7 +124,7 @@ export class MultiChartViewer extends PureComponent {
                  onClick={(ev)=>onChartSelect(ev,chartId)}
                  onTouchStart={stopPropagation}
                  onMouseDown={stopPropagation}>
-                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
+                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable} glass={glass}/>
             </div>
         );
 
@@ -132,7 +132,7 @@ export class MultiChartViewer extends PureComponent {
             <div onClick={stopPropagation}
                  onTouchStart={stopPropagation}
                  onMouseDown={stopPropagation}>
-                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>
+                <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable} glass={glass}/>
             </div>
         );
 
@@ -148,10 +148,19 @@ export class MultiChartViewer extends PureComponent {
         //console.log('Active chart ID: '+activeItemId);
 
         const ToolBar = expandedMode ? MultiChartToolbarExpanded : MultiChartToolbarStandard;
+        const showChartToolbar = !Boolean(noChartToolbar);
 
         return (
             <div className='ChartPanel__wrapper' style={{width: '100%', height: '100%', boxSizing: 'border-box'}}>
-                <ToolBar chartId={activeItemId} expandable={!expandedMode} {...{expandedMode, closeable, viewerId, layoutType, activeItemId}}/>
+                {showChartToolbar &&
+                    <ToolBar chartId={activeItemId} expandable={!expandedMode} {...{
+                        expandedMode,
+                        closeable,
+                        viewerId,
+                        layoutType,
+                        activeItemId
+                    }}/>
+                }
                 <MultiItemViewerView {...this.props} {...newProps}/>
             </div>
         );


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1340

`noChartToolbar` parameter stopped working.

To test:  https://fireflydev.ipac.caltech.edu/firefly-1340-nocharttoolbar/firefly/test/tests-main.html?test=Table+group+with+default+charts

The chart should non-interactive without toolbar.
 