### PR TITLE
FIREFLY-1333: Add support for enumerated column's values with comma.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -712,9 +712,10 @@ public class EmbeddedDbUtil {
                     DataType col = findColByName(inclCols, cname);
                     if (col != null && vals.size() <= MAX_COL_ENUM_COUNT) {
                         String enumVals = vals.stream()
-                                .map(m -> m.get(cname) == null ? NULL_TOKEN : m.get(cname).toString())   // convert to list of value as string
-                                .collect(Collectors.joining(","));                              // combine the values into a comma separated values string.
-                        if (col != null)  col.setEnumVals(enumVals);
+                                .map(m -> m.get(cname) == null ? NULL_TOKEN : m.get(cname).toString())  // convert to list of value as string
+                                .map(cn -> cn.contains(",") ? "'" + cn + "'" : cn)                      // if there's comma in the column name, enclose it with single quotes
+                                .collect(Collectors.joining(","));                             // combine the values into a comma separated values string.
+                        col.setEnumVals(enumVals);
                         // update dd table
                         JdbcFactory.getSimpleTemplate(dbAdapter.getDbInstance(dbFile))
                                 .update("UPDATE data_dd SET enumVals = ? WHERE cname = ?", enumVals, cname);

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1442,6 +1442,14 @@ export function splitCols(cnames='') {
     return cnames.split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/);
 }
 
+/**
+ * @param {string} values
+ * @return {string[]} array of values split from a comma separated string, ignoring commas inside single-quotes
+ */
+export function splitVals(values='') {
+    return values.split(/,(?=(?:[^']*'[^']*')*[^']*$)/);
+}
+
 /*-------------------------------------private------------------------------------------------*/
 
 /**

--- a/src/firefly/js/ui/CheckboxGroupInputField.jsx
+++ b/src/firefly/js/ui/CheckboxGroupInputField.jsx
@@ -2,11 +2,12 @@ import React, {memo} from 'react';
 import PropTypes from 'prop-types';
 import {InputFieldLabel} from './InputFieldLabel.jsx';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
+import {splitVals} from 'firefly/tables/TableUtil.js';
 
 
-const isChecked= (val,fieldValue) => (fieldValue.split(',').indexOf(val) > -1);
+const isChecked= (val,fieldValue) => (splitVals(fieldValue).indexOf(val) > -1);
 
-const getCurrentValueArr= (v) => v ? v.split(',') : [];
+const getCurrentValueArr= (v) => v ? splitVals(v) : [];
 
 
 function convertValue(value,options) {


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1333
Table column filter by dropdown list failed to handle values with comma(s) in them.

Test: https://firefly-1333-filter-enumeration-comma.irsakudev.ipac.caltech.edu/irsaviewer/dce
Trying filtering `Bands` and `Inst.` using the dropdown list.  They should work now.