### PR TITLE
FIREFLY-1297: Add support for null values to all table's data types.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
+++ b/src/firefly/java/edu/caltech/ipac/table/PrimitiveList.java
@@ -31,10 +31,11 @@ public interface PrimitiveList {
         }
     }
 
-    default int getIntValue(Object val) {
-        if (val instanceof Integer) return (int)val;
-        else if (val instanceof Byte) return (int)(Byte)val;
-        else if (val instanceof Short) return (int)(Short)val;
+    default Integer getIntValue(Object val) {
+        if (val == null) return null;
+        if (val instanceof Integer) return (Integer)val;
+        else if (val instanceof Byte) return ((Byte)val).intValue();
+        else if (val instanceof Short) return ((Short)val).intValue();
         throw new RuntimeException(String.format("%s is with type %s, can not be assigned to Integer", val, getDataClass()));
     }
 
@@ -85,6 +86,10 @@ public interface PrimitiveList {
         public void trimToSize() { data.trimToSize(); }
     }
 
+    /**
+     * This class treats NaN, -Infinity, and +Infinity as equivalent to NULL, returning NULL in such cases.
+     * This is due to the fact that standard JSON does not provide direct support for representing these special values.
+     */
     public static class Doubles implements PrimitiveList {
         private double[] data;
         private int size;
@@ -100,7 +105,7 @@ public interface PrimitiveList {
         }
 
         public Object get(int idx) {
-            return Double.isNaN(data[idx]) ? null : data[idx];
+            return Double.isNaN(data[idx]) || Double.isInfinite(data[idx]) ? null : data[idx];
         }
 
         public void set(int idx, Object val) {
@@ -136,6 +141,10 @@ public interface PrimitiveList {
         }
     }
 
+    /**
+     * This class treats NaN, -Infinity, and +Infinity as equivalent to NULL, returning NULL in such cases.
+     * This is due to the fact that standard JSON does not provide direct support for representing these special values.
+     */
     public static class Floats implements PrimitiveList {
         private float[] data;
         private int size;
@@ -151,7 +160,7 @@ public interface PrimitiveList {
         }
 
         public Object get(int idx) {
-            return Float.isNaN(data[idx]) ? null : data[idx];
+            return Float.isNaN(data[idx]) || Float.isInfinite(data[idx]) ? null : data[idx];
         }
 
         public void set(int idx, Object val) {
@@ -184,27 +193,25 @@ public interface PrimitiveList {
     }
 
     public static class Longs implements PrimitiveList {
-        private long[] data;
+        private Long[] data;
         private int size;
 
         public Longs() { this(1000); }
 
-        public Longs(int initCapacity) {
-            data  = new long[initCapacity];
-        }
+        public Longs(int initCapacity) { data  = new Long[initCapacity]; }
 
         public Class getDataClass() {
             return Long.class;
         }
 
         public Object get(int idx) {
-            return data[idx] == Long.MIN_VALUE ? null : data[idx];
+            return data[idx];
         }
 
         public void set(int idx, Object val) {
             checkType(val);
             ensureCapacity(idx);
-            data[idx] = val == null ? Long.MIN_VALUE : (long) val;
+            data[idx] = (Long) val;
             if (idx >= size()) size = idx+1;
         }
 
@@ -231,25 +238,23 @@ public interface PrimitiveList {
     }
 
     public static class Integers implements PrimitiveList {
-        private int[] data = null;
+        private Integer[] data = null;
         private int size;
 
         public Integers() { this(1000); }
 
-        public Integers(int initCapacity) {
-            data  = new int[initCapacity];
-        }
+        public Integers(int initCapacity) { data  = new Integer[initCapacity]; }
 
         public Class getDataClass() {
             return Integer.class;
         }
 
         public Object get(int idx) {
-            return data[idx] == Integer.MIN_VALUE ? null : data[idx];
+            return data[idx];
         }
 
         public void set(int idx, Object val) {
-            int ival = val == null ? Integer.MIN_VALUE : getIntValue(val);
+            Integer ival = getIntValue(val);
             ensureCapacity(idx);
             data[idx] = ival;
             if (idx >= size()) size = idx+1;
@@ -278,13 +283,13 @@ public interface PrimitiveList {
     }
 
     public static class Booleans implements PrimitiveList {
-        private boolean[] data = null;
+        private Boolean[] data = null;
         private int size;
 
         public Booleans() { this(1000); }
 
         public Booleans(int initCapacity) {
-            data  = new boolean[initCapacity];
+            data  = new Boolean[initCapacity];
         }
 
 
@@ -299,7 +304,7 @@ public interface PrimitiveList {
         public void set(int idx, Object val) {
             checkType(val);
             ensureCapacity(idx);
-            data[idx] = val != null && (boolean) val;
+            data[idx] = (Boolean) val;
             if (idx >= size()) size = idx+1;
         }
 


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1297
Fixed: Firefly incorrectly interprets null values as 'false' when a column is specified as a Boolean.
This also expand NULL support to all data types. 

Test: https://firefly-1297-table-support-null-primitives.irsakudev.ipac.caltech.edu/irsaviewer/dce
- Select Facility: MSX
- Search on any covered area with 300 arcsec radius.

In the result table, `environment_photometric` column should be all NULLs instead of `false`.