### PR TITLE
FIREFLY-1347: showPropertySheetButton option should be consistent with other table's options

### DIFF
--- a/src/firefly/html/demo/table-api.html
+++ b/src/firefly/html/demo/table-api.html
@@ -218,6 +218,7 @@ There are additional information specific to each input field.  Click the top bu
 @prop {boolean} [showOptionButton=true]
 @prop {boolean} [showFilterButton=true]
 @prop {boolean} [showInfoButton=true]
+@prop {boolean} [showPropertySheetButton]  uses firefly.options.table.propertySheet if not given.
 @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.
 @prop {function[]}  [rightButtons]  an array of functions that returns a button-like component laid out on the right side of this table header.
 @prop {boolean} [showHeader=true]  true if this table can show header row

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -39,7 +39,6 @@ import {loadAllJobs} from './core/background/BackgroundUtil.js';
 import {
     makeDefImageSearchActions, makeDefTableSearchActions, makeDefTapSearchActions, makeExternalSearchActions
 } from './ui/DefaultSearchActions.js';
-import {PROP_SHEET} from 'firefly/tables/ui/PropertySheet';
 
 let initDone = false;
 const logger = Logger('Firefly-init');
@@ -76,7 +75,7 @@ export const Templates = {
  * @prop {boolean} [showUserInfo=false] - show user information.  This is used when authentication is available
  * @prop {boolean} [showViewsSwitch] - show/hide the swith views buttons
  * @prop {Array.<function>} [rightButtons]    - function(s) returning a button to be displayed on the top-right of the result page.
- * 
+ *
  *
  * @prop {Object} menu         custom menu bar
  * @prop {string} menu.label   button's label
@@ -161,7 +160,7 @@ const defFireflyOptions = {
     },
     table : {
         pageSize: 100,
-        propertySheet: PROP_SHEET.INTEGRATED // by default, show property sheet integrated (as tab)
+        propertySheet: false     // by default, hide property sheet popup button; most applications have a dedicated property sheet component.
     },
     image : {
         defaultColorTable: 1,
@@ -232,10 +231,13 @@ function fireflyInit(props, appSpecificOptions={}, webApiCommands) {
     props = mergeObjectOnly(defAppProps, props);
     const viewer = Templates[props.template];
 
-    if (viewer) props.renderTreeId = undefined; // in non API usages, renderTreeId is not used, this line is just for clarity
-    else if (!appSpecificOptions?.table?.propertySheet) {
-        // in API usages, propertySheet should show as popup if not specified otherwise
-        set(appSpecificOptions, 'table.propertySheet', PROP_SHEET.POPUP);
+    if (viewer) {
+        // in non API usages, renderTreeId is not used, this line is just for clarity
+        props.renderTreeId = undefined;
+    }
+    else {
+        // in API mode, show propertySheet button unless it's set.
+        set(appSpecificOptions, 'table.propertySheet', appSpecificOptions?.table?.propertySheet ?? true);
     }
 
     installOptions(appSpecificOptions);

--- a/src/firefly/js/tables/FilterInfo.js
+++ b/src/firefly/js/tables/FilterInfo.js
@@ -553,8 +553,8 @@ function createOneComparator(filterStr, tableModel) {
 
         if (op !== 'like' && colType.match(/^[dfil]/)) {      // int, float, double, long .. or their short form.
             compareTo = compareTo ? Number(compareTo) : compareTo;
-        } else {
-            compareTo = compareTo ? compareTo.toLowerCase() : compareTo;
+        } else if (colType.includes('char')) {
+            compareTo = `${compareTo}`.toLowerCase();
         }
 
         switch (op) {

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -284,6 +284,7 @@
  * @prop {boolean} [showAddColumn=true]  when true, allow add column to table
  * @prop {boolean} [showInfoButton=true] when true, shows additional information about table, if available
  * @prop {boolean} [showOptionButton=true]
+ * @prop {boolean} [showPropertySheetButton]  uses firefly.options.table.propertySheet if not given.
  * @prop {boolean} [showUnits]
  * @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.
  * @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.

--- a/src/firefly/js/tables/ui/PropertySheet.jsx
+++ b/src/firefly/js/tables/ui/PropertySheet.jsx
@@ -3,13 +3,11 @@ import {TablePanel} from 'firefly/tables/ui/TablePanel';
 import React, {useEffect} from 'react';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent';
 import {dispatchTableAddLocal, dispatchTableUiUpdate} from 'firefly/tables/TablesCntlr';
-import Enum from 'enum';
-
-export const PROP_SHEET = new Enum(['INTEGRATED', 'POPUP']);
 
 /**
  * A wrapper/watcher component for property sheet i.e., vertical display of all the data from a single table row, with additional metadata.
- * It watches active table id in the given table group and if data is present, it passes the table id and highlighted row in it to its children
+ * When tbl_id is not given, it will use the active table id in the given table group.
+ * If data is present, it passes the table id and highlighted row in it to its children
  * for them to process and display the table row data as needed. If data is not ready, it also handles different states like loading, no data, etc.
  *
  * Note: Only pass tbl_id prop if you want to show property sheet for only the passed table ID, bypassing the active table watching.
@@ -22,13 +20,16 @@ export const PROP_SHEET = new Enum(['INTEGRATED', 'POPUP']);
  * @returns {JSX.Element}
  */
 export function PropertySheet({tbl_group='main', tbl_id, children, fetcher}){
-    const {activeTblId, tableModel} = useStoreConnector(() => {
+    const {watchTblId, highlightedRow , isFetching, totalRows} = useStoreConnector(() => {
         const tblId = tbl_id || getActiveTableId(tbl_group);
-        return {activeTblId: tblId, tableModel: getTblById(tblId)};
-    });
+        const tableModel = getTblById(tblId);
+        if (!tableModel) return {watchTblId: tblId, totalRows: -1};
+        const {highlightedRow=0,isFetching,totalRows} = tableModel;
 
-    if(!tableModel) return false;
-    const {highlightedRow,isFetching,totalRows} = tableModel;
+        return {watchTblId: tblId, highlightedRow,isFetching, totalRows};
+    }, [tbl_id, tbl_group]);
+
+    if(totalRows === -1) return false;
 
     // TODO: use fetcher if defined
 
@@ -48,7 +49,7 @@ export function PropertySheet({tbl_group='main', tbl_id, children, fetcher}){
         return <div className='TablePanel_NoData'>No currently selected row</div>;
     }
     else {
-        return React.cloneElement(children, {...{tbl_id: activeTblId, highlightedRow}});
+        return React.cloneElement(children, {...{tbl_id: watchTblId, highlightedRow}});
     }
 }
 
@@ -57,13 +58,15 @@ export function PropertySheet({tbl_group='main', tbl_id, children, fetcher}){
  * The table produced is a client-side table which is capable of processing requests in the previous renders, including filters.
  *
  * @param props
- * @param props.detailsTblId ID of the table produced
  * @param {TblOptions} props.tblOptions
  * @param props.tbl_id [passed implicitly if child of PropertySheet] ID of the active table in property sheet
  * @param props.highlightedRow [passed implicitly if child of PropertySheet] index of highlighted row in the active table
  * @returns {JSX.Element}
  */
-export function RowDetailsTable({detailsTblId, tblOptions={}, tbl_id, highlightedRow}) {
+export function RowDetailsTable({tblOptions={}, tbl_id, highlightedRow}) {
+
+    const detailsTblId = `${tbl_id}-RowDetailsTable`;
+
     useEffect(()=>{
         const detailsTable = tableDetailsView(tbl_id, highlightedRow, detailsTblId);
 
@@ -95,13 +98,12 @@ export function RowDetailsTable({detailsTblId, tblOptions={}, tbl_id, highlighte
  * @param props refer to the documentation of above 2 components.
  * @param props.tbl_group
  * @param props.tbl_id
- * @param props.detailsTblId
  * @param props.tblOptions
  */
-export function PropertySheetAsTable({tbl_group, tbl_id, detailsTblId, tblOptions}) {
+export function PropertySheetAsTable({tbl_group, tbl_id, tblOptions}) {
     return (
         <PropertySheet {...{tbl_group, tbl_id}}>
-            <RowDetailsTable {...{detailsTblId, tblOptions}}/>
+            <RowDetailsTable {...{tblOptions}}/>
         </PropertySheet>
     );
 }

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -22,8 +22,7 @@ import {getExpandedChartProps} from '../../charts/ChartsCntlr.js';
 import {DEFAULT_PLOT2D_VIEWER_ID} from '../../visualize/MultiViewCntlr.js';
 import {usePinnedChartInfo, PinnedChartPanel, PINNED_VIEWER_ID, BadgeLabel} from 'firefly/charts/ui/PinnedChartContainer.jsx';
 import {allowPinnedCharts} from '../../charts/ChartUtil.js';
-import {PropertySheetAsTable, PROP_SHEET} from 'firefly/tables/ui/PropertySheet';
-import {getAppOptions} from 'firefly/core/AppDataCntlr';
+import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
 
 const stateKeys= ['title', 'mode', 'showTables', 'showImages', 'showXyPlots', 'images'];
 const LEFT= 'LEFT';
@@ -95,7 +94,7 @@ function RightSide({expanded, closeable, showXyPlots, showMeta, showFits, dataPr
     const cov= imagesWithCharts || coverageRight;
     const meta= imagesWithCharts && showMeta;
     const fits= imagesWithCharts && showFits;
-    const showPropertySheet = getAppOptions()?.table?.propertySheet === PROP_SHEET.INTEGRATED;
+    const showPropertySheet = true;             // this should be true.  We always want to show it.
     const {expandedViewerId}= getExpandedChartProps();
     const viewerId = DEFAULT_PLOT2D_VIEWER_ID;
 
@@ -208,7 +207,7 @@ function searchDesc({showViewsSwitch, showImages, isTriView, showCoverage, leftB
 function makePropertySheetTab() {
     return (
         <Tab key='rowDetails' name='Details' removable={false} id='rowDetails'>
-            <PropertySheetAsTable detailsTblId='rowDetailsTbl'/>
+            <PropertySheetAsTable/>
         </Tab>
     );
 }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1347
Also, 
- fixes property sheet popup in API mode
- fixes a bug in FIREFLY-1307 in which the Details table crashes when filtering on the Value column.
  - Note:  Value column is type 'char'.  The values are converted to string during the comparison process.

More changes here: https://github.com/IPAC-SW/irsa-ife/pull/297


Test: https://fireflydev.ipac.caltech.edu/firefly-1347-propertysheet/firefly/
and:  https://firefly-1347-propertysheet.irsakudev.ipac.caltech.edu/irsaviewer/
Ensure 'Details' tab in tri-view still works as expected.

Test: https://fireflydev.ipac.caltech.edu/firefly-1347-propertysheet/firefly/test/ 
Ensure popup button 'Show details for the selected row' work as expected.  It should show the content of the current table's highlighted row.

Test: https://firefly-1347-propertysheet.irsakudev.ipac.caltech.edu/applications/wise/
There should be a 'Details' tab on the right side that display the details of the active table highlighted row.
There should not be a 'Show details...' button on the table's toolbar.
