### PR TITLE
Firefly-1235: Adding region file format to table save when position columns are available

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.server.query;
 import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.table.io.IpacTableException;
 import edu.caltech.ipac.table.io.IpacTableWriter;
+import edu.caltech.ipac.table.io.RegionTableWriter;
 import edu.caltech.ipac.table.io.DsvTableIO;
 import edu.caltech.ipac.table.io.VoTableWriter;
 import edu.caltech.ipac.firefly.data.FileInfo;
@@ -289,6 +290,9 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                     break;
                 case TSV:
                     DsvTableIO.write(new OutputStreamWriter(out), page.getData(), CSVFormat.TDF);
+                    break;
+                case REGION:
+                    RegionTableWriter.write(new OutputStreamWriter(out), page.getData(), request.getParam("center_cols"));
                     break;
                 case VO_TABLE_TABLEDATA:
                 case VO_TABLE_BINARY:

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HttpServCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HttpServCommands.java
@@ -46,6 +46,11 @@ public class HttpServCommands {
             TableUtil.Format tblFormat = sp.getTableFormat();
             String fileNameExt = tblFormat.getFileNameExt();
 
+            if (fileNameExt.equalsIgnoreCase(".reg")) {
+                String cols = sp.getOptional("center_cols");
+                request.setParam("center_cols", sp.getOptional("center_cols"));
+            }
+
             if (isEmpty(fileName)) {
                 fileName = request.getRequestId();
             }

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -358,6 +358,7 @@ public class TableUtil {
         allFormats.put("pdf", Format.PDF);
         allFormats.put("png", Format.PNG);
         allFormats.put("uws", Format.UWS);
+        allFormats.put("reg", Format.REGION);
     }
 
     public static Map<String, Format> getAllFormats() { return allFormats; }

--- a/src/firefly/java/edu/caltech/ipac/table/io/RegionTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/RegionTableWriter.java
@@ -1,0 +1,48 @@
+package edu.caltech.ipac.table.io;
+
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataObject;
+import edu.caltech.ipac.table.IpacTableUtil;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+public class RegionTableWriter {
+    private static Logger.LoggerImpl LOG = Logger.getLogger();
+    public static void write(Writer writer, DataGroup data, String centerCols) throws IOException {
+
+        BufferedWriter outf = new BufferedWriter(writer, IpacTableUtil.FILE_IO_BUFFER_SIZE);
+        if (centerCols == null) {
+            throw new IOException("Unable to find center columns");
+        }
+        outf.write("J2000; color=blue");
+        String[] cols = centerCols.split(","); //center cols is of format "s_ra,s_dec"
+        try {
+            if (data != null && data.size() > 0) {
+                for (DataObject row : data.values()) {
+                    outf.newLine();
+                    Object ra = row.getDataElement(cols[0]);
+                    Object dec = row.getDataElement(cols[1]);
+                    if (cols[0].equals(cols[1])) {//single column with an array entry for RA and DEC
+                        Object singleCol = row.getDataElement(cols[0]);
+                        if (singleCol == null) continue;
+                        double[] entries = (double[]) singleCol;
+                        ra = entries[0];
+                        dec = entries[1];
+                    }
+                    if (ra == null || dec == null) continue;
+                    outf.write("point    " + ra + "    " + dec);
+                    outf.write(" # 10 point=circle");
+                }
+            }
+            outf.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new IOException(e);
+        } finally {
+            outf.close();
+        }
+    }
+}


### PR DESCRIPTION
#### [Firefly-1235](https://jira.ipac.caltech.edu/browse/FIREFLY-1235)
- adds option of file format for region file to table save when position columns are available 
- downloads region file if selected 
- @robyww as I mentioned in the standup, not a lot of changes here, I'll still work on some cleanup but if you could take a quick look at the code to make sure it makes sense overall (or point out if something stands out as incorrect)

**Updates 12/1**
- added support for saving files with one column array entry of ra,dec values (assuming entry arrays are always going to be type `double`), test build updated. 

**Updates 11/29**
  - Please see my comment in `TableAnalysis.js` line 34. Is there a table I can use to test and write code for single column entries for center columns? 
  - What should the behavior look like when users filter out the center columns (one or both), @robyww? as of now by adding a null check for either of the columns, I'm still writing and saving a file with just `J2000; color=blue` in it.  Should I throw an error instead?
  - I manually tested a table with no center columns (but edited client side to still show `Region (.reg)` as a file format) and tried to save it, got an error as expected. (although it's a generic error message`Request failed with status 500: http://localhost:8080/firefly/CmdSrv/sync?cmd=tableSave` but the exception on server side logs `Unable to find center columns`). This client side error message we get is from the `catch` statement on line 94-95 in` fetch.js` (I'm trying to figure out how to display the errors from the response object - so that it's more descriptive)...

**Testing**: 
- https://fireflydev.ipac.caltech.edu/firefly-1235-table-region/firefly
- do a TAP search that includes position columns in the resulting table (e.g.: ra,dec)
- try to save this table
- you should see .reg (or region) as one of the File Format options
- download the table as a region file and verify if the resulting file looks ok (should only have position column entries). 