### PR TITLE
FIREFLY-1214: fix '...'(more actions) drop-down will not go away.

### DIFF
--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -52,6 +52,8 @@ const TT_EXPAND = 'Expand this panel to take up a larger area';
 const TT_PROPERTY_SHEET = 'Show details for the selected row';
 
 
+export const TBL_CLZ_NAME = 'TablePanel__table';
+
 export function TablePanel(props) {
     let {tbl_id, tbl_ui_id, tableModel, ...options} = props;
     tbl_id = tbl_id || tableModel?.tbl_id || uniqueTblId();
@@ -175,7 +177,7 @@ export function TablePanel(props) {
                         </div>
                     </div>
                     }
-                    <div className='TablePanel__table' style={{top: tableTopPos}}
+                    <div className={TBL_CLZ_NAME} style={{top: tableTopPos}}
                          onClick={stopPropagation}
                          onTouchStart={stopPropagation}
                          onMouseDown={stopPropagation}

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -30,6 +30,7 @@ import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 import {dispatchTableUiUpdate, dispatchTableUpdate} from '../TablesCntlr.js';
 import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
+import {TBL_CLZ_NAME} from './TablePanel.jsx';
 
 import infoIcon from 'html/images/info-icon.png';
 import {dd2sex} from '../../visualize/CoordUtil.js';
@@ -327,6 +328,14 @@ export function makeDefaultRenderer(col={}) {
     return renderer;
 }
 
+function findTableFor(element) {
+    let cEl = element;
+    while (cEl && !cEl.classList.contains(TBL_CLZ_NAME)) {
+        cEl = cEl.parentNode;
+    }
+    return cEl;
+}
+
 export function ContentEllipsis({children, text, style={}, actions=[]}) {
 
     const [hasActions, setHasActions] = useState(false);
@@ -337,7 +346,8 @@ export function ContentEllipsis({children, text, style={}, actions=[]}) {
 
     const onActionsClicked = (ev) => {
         ev.stopPropagation();
-        showDropDown({id: dropDownID, content: dropDown, atElRef: actionsEl.current, locDir: 33, style: {marginLeft: -10},
+        const boxEl = findTableFor(actionsEl.current);
+        showDropDown({id: dropDownID, content: dropDown, boxEl, atElRef: actionsEl.current, locDir: 33, style: {marginLeft: -10},
             wrapperStyle: {zIndex: 110}}); // 110 is the z-index of a dropdown
     };
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
@@ -149,7 +149,7 @@ public class HttpServicesTest extends ConfigTest {
 	@Test
 	public void testGetWithAuthRedirected(){
 		HttpServiceInput nInput = input.setRequestUrl(REDIRECT_URL)
-				.setParam("url", "http://www.acme.org")
+				.setParam("url", "https://irsa.ipac.caltech.edu/docs/help_desk.html")
 				.setParam("status_code", "301");
 
 		HttpServices.Status status = HttpServices.getWithAuth(nInput, 3, method -> HttpServices.Status.ok());


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1214
```
on the search screen for DCE, if you click on the '...' in a cell to see what is in the cell, 
you can't make the pop-up window go away, except by clicking in it. 
```
This is true for any table where the cell's value overflows.  To observe this behavior, resize the column.

With this fix, click anywhere in the table to hide the dropdown.

Test: https://firefly-1214-more-actions.irsakudev.ipac.caltech.edu/irsaviewer


