### PR TITLE
FIREFLY-1352: Implement property sheet feedback

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -99,7 +99,7 @@ export const Templates = {
  *                                  the catalog panel will show the polygon option as default when possible
  * @prop {Array.<string> } imageMasterSources -  default - ['ALL'], source to build image master data from
  * @prop {Array.<string> } imageMasterSourcesOrder - for the image dialog sort order of the projects, anything not listed is put on bottom
- * @prop {PROP_SHEET} table.propertySheet - specifies how to show propertySheet; set undefined to hide it
+ * @prop {PROP_SHEET} table.propertySheet - specifies how to show propertySheet
  */
 
 /** @type {AppProps} */
@@ -160,7 +160,10 @@ const defFireflyOptions = {
     },
     table : {
         pageSize: 100,
-        propertySheet: false     // by default, hide property sheet popup button; most applications have a dedicated property sheet component.
+        showPropertySheetButton: false,  // by default, hide it because most applications have a dedicated property sheet component
+        propertySheet: {
+            selectableRows: true   // will only take effect if property sheet is displayed as table
+        }
     },
     image : {
         defaultColorTable: 1,
@@ -236,8 +239,8 @@ function fireflyInit(props, appSpecificOptions={}, webApiCommands) {
         props.renderTreeId = undefined;
     }
     else {
-        // in API mode, show propertySheet button unless it's set.
-        set(appSpecificOptions, 'table.propertySheet', appSpecificOptions?.table?.propertySheet ?? true);
+        // in API mode, show propertySheet popup button unless it's set.
+        set(appSpecificOptions, 'table.showPropertySheetButton', appSpecificOptions?.table?.showPropertySheetButton ?? true);
     }
 
     installOptions(appSpecificOptions);

--- a/src/firefly/js/tables/TableConnector.js
+++ b/src/firefly/js/tables/TableConnector.js
@@ -49,6 +49,7 @@ export function onFilter(tbl_id, filterInfo) {
 export function onFilterSelected(tbl_id, selected) {
     if (isEmpty(selected)) return;
     const {request} = getTblInfoById(tbl_id);
+    request.tbl_id ??= tbl_id;  //request must have tbl_id; same as in applyFilterChanges()
     TblCntlr.dispatchTableFilterSelrow(request, selected);
 }
 

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1065,7 +1065,7 @@ export function tableDetailsView(tbl_id, highlightedRow, details_tbl_id) {
 
     const columns = [
         { key: 'name', name: 'Name', type: 'char', desc: 'Column name', dataGetter: (c) => c.label || c.name },
-        { key: 'value', name: 'Value', type: 'char', dataGetter: (c) => getCellValue(tableModel, highlightedRow, c.name) },
+        { key: 'value', name: 'Value', type: 'char', dataGetter: (c) => formatValue(c, getCellValue(tableModel, highlightedRow, c.name)) },
         { key: 'units', name: 'Units', type: 'char', dataGetter: (c) => c.units || '' },
         { key: 'desc', name: 'Description', type: 'char', dataGetter: (c) => c.desc || '' },
         { key: 'type', name: 'Type', type: 'char', dataGetter: (c) => getTypeLabel(c) },

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -287,7 +287,7 @@
  * @prop {boolean} [showAddColumn=true]  when true, allow add column to table
  * @prop {boolean} [showInfoButton=true] when true, shows additional information about table, if available
  * @prop {boolean} [showOptionButton=true]
- * @prop {boolean} [showPropertySheetButton]  uses firefly.options.table.propertySheet if not given.
+ * @prop {boolean} [showPropertySheetButton]  uses firefly.options.table.showPropertySheetButton if not given.
  * @prop {boolean} [showUnits]
  * @prop {boolean} [allowUnits=true] enable/disable the use of units in a table.
  * @prop {function[]}  [leftButtons]   an array of functions that returns a button-like component laid out on the left side of this table header.

--- a/src/firefly/js/tables/ui/PropertySheet.jsx
+++ b/src/firefly/js/tables/ui/PropertySheet.jsx
@@ -3,6 +3,7 @@ import {TablePanel} from 'firefly/tables/ui/TablePanel';
 import React, {useEffect} from 'react';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent';
 import {dispatchTableAddLocal, dispatchTableUiUpdate} from 'firefly/tables/TablesCntlr';
+import {getAppOptions} from 'firefly/core/AppDataCntlr';
 
 /**
  * A wrapper/watcher component for property sheet i.e., vertical display of all the data from a single table row, with additional metadata.
@@ -73,18 +74,19 @@ export function RowDetailsTable({tblOptions={}, tbl_id, highlightedRow}) {
         dispatchTableAddLocal(detailsTable, {
             tbl_group: detailsTblId,
             tbl_ui_id: detailsTblId,
-            selectable: false,
-            showToolbar: false,
+            selectable: getAppOptions()?.table?.propertySheet?.selectableRows ?? true,
+            showToolbar: true,
+            showInfoButton: false,
             removable: false,
             showFilters: true,
-            showTypes: false,
+            showTypes: true,
             showUnits: false,
             ...tblOptions
         });
     }, [tbl_id, highlightedRow]);
 
     useEffect(()=>{
-        dispatchTableUiUpdate({tbl_ui_id: detailsTblId, allowUnits: false, allowTypes: false});
+        dispatchTableUiUpdate({tbl_ui_id: detailsTblId, allowUnits: false, allowTypes: true});
     }, [detailsTblId]);
 
     return (<TablePanel tbl_id={detailsTblId} tbl_ui_id={detailsTblId} showTitle={false}/>);

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -81,7 +81,7 @@ export function TablePanel(props) {
     let {leftButtons, rightButtons, showAddColumn} = {...options, ...uiState};
 
     showAddColumn = isClientTable(tbl_id) ? false : showAddColumn;
-    const showPropertySheet = showPropertySheetButton ?? getAppOptions()?.table?.propertySheet ?? true;
+    const showPropertySheet = showPropertySheetButton ?? getAppOptions()?.table?.showPropertySheetButton ?? true;
 
     const connector = makeConnector(tbl_id, tbl_ui_id);
 


### PR DESCRIPTION
Fixes [FIREFLY-1352](https://jira.ipac.caltech.edu/browse/FIREFLY-1352)

- [x] 1. Fix the known bug in filtering selected rows in property sheet
- [x] 2. Expose row selection option in property sheet as an app-level property - ~I have set it false on app-level and true for TriViewPanel (that shows up in IrsaViewer) for now, can be changed once we have a decision.~ set it true on app-level to apply in all apps as per decision
- [x] 3. Add a "clear all filters" button in property sheet table too - ~filters can be cleared from table options, awaiting reply if this is really needed, if yes, how will it look?~ show table toolbar as per decision
- [x] 4. Show "type" in property sheet columns and show option to enable/disable "type" in options dialog
- [x] 6. Make property sheet respect precision & width
- [x] 7. Show NULL values in property sheet

5,8 doesn't seem to have any to-do for this PR 

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1307-propsheet-fixes/firefly/

Do Table search -> IRSA Catalogs -> m81, 100 arcsec. Go to details tab and confirm that:
- type appears in columns
- table options dialog show option to hide/show type
- format is respected: 1st row, w1rchi2 column: `4.873E+1` - same value appears in property sheet instead of `48.73`; 1st row,  w3sat column: `0.000` - same appears in property sheet instead of `0`
- null string shows up: 4th row, w4sigmpro column: `null` - same appears in property sheet instead of empty cell

Select some rows in property sheet table, and filter - changing row selection in source table should preserve the filter in property sheet. You can remove this row filter same as column filter, by opening table options dialog for property sheet table and clicking "remove all filters"

---

https://firefly-1307-propsheet-fixes.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/

Do any search and check that details tab doesn't have selectable rows aka no checkboxes appear. This is because on app-level `propertySheet.selectableRows` is set `false` but IrsaViewer (or any app using TriViewPanel) have `selectable` table option set to true explicitly.
