### PR TITLE
Firefly-1350: Add MOC outline style

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -156,7 +156,9 @@ const defFireflyOptions = {
         useForImageSearch: true,
         hipsSources: 'all',
         defHipsSources: {source: 'irsa', label: 'Featured'},
-        mergedListPriority: 'irsa'
+        mergedListPriority: 'irsa',
+        mocMaxDepth : 5,
+        mocDefaultStyle : 'DESTINATION_OUTLINE',
     },
     table : {
         pageSize: 100,

--- a/src/firefly/js/drawingLayers/HiPSMOCUI.jsx
+++ b/src/firefly/js/drawingLayers/HiPSMOCUI.jsx
@@ -8,33 +8,30 @@ import PropTypes from 'prop-types';
 import {RadioGroupInputFieldView} from '../ui/RadioGroupInputFieldView.jsx';
 import {dispatchModifyCustomField} from '../visualize/DrawLayerCntlr.js';
 import {Style} from '../visualize/draw/DrawingDef.js';
-import {get} from 'lodash';
 
-const options= [ {label: 'outline', value: 'outline'},
-                 {label: 'fill', value: 'fill'}];
+const options= [ {label: 'Outline', value: Style.DESTINATION_OUTLINE.key},
+                 {label: 'Fill', value: Style.FILL.key},
+                 {label: 'MOC Tile Outline', value: Style.STANDARD.key},
+];
 
 
 export const getUIComponent = (drawLayer,pv) => <HiPSMOCUI drawLayer={drawLayer} pv={pv}/>;
 
 function HiPSMOCUI({drawLayer,pv}) {
-    const {mocStyle={}} = drawLayer;
-    const style = mocStyle[pv.plotId] ?? drawLayer.drawingDef?.style ?? Style.STANDARD;
-    const fillStyle = (!style || style.key === 'STANDARD') ? 'outline' : 'fill';
+    const style = drawLayer?.mocStyle[pv.plotId] ?? drawLayer.drawingDef?.style ?? Style.DESTINATION_OUTLINE;
 
     return (
             <div style={{display: 'inline-flex', padding: '2px 3px 2px 3px',
                          border: '1px solid rgba(60,60,60,.2', borderRadius: '5px'}}>
-                <RadioGroupInputFieldView options={options}  value={fillStyle}
+                <RadioGroupInputFieldView options={options}  value={style.key}
                                           buttonGroup={true}
-                                          onChange={(ev) => changeMocPref(drawLayer,pv,ev.target.value, fillStyle)} />
+                                          onChange={(ev) => changeMocPref(drawLayer,pv,ev.target.value, style.key)} />
             </div>
     );
 }
 
-
-
-function changeMocPref(drawLayer,pv,value, preValue) {
-    if (preValue !== value) {
+function changeMocPref(drawLayer,pv,value, prevValue) {
+    if (prevValue !== value) {
         dispatchModifyCustomField(drawLayer.drawLayerId, {fillStyle: value, targetPlotId: pv.plotId}, pv.plotId);
     }
 }

--- a/src/firefly/js/util/Color.js
+++ b/src/firefly/js/util/Color.js
@@ -400,7 +400,7 @@ function getComplementaryColor(color) {
     return `rgba(${rgb[R]}, ${rgb[G]}, ${rgb[B]}, ${rgba[3]})`;
 }
 
-function toRGBAString(rgba) {
+export function toRGBAString(rgba) {
     const len = (!rgba || !isArray(rgba)) ? 0 : rgba.length;
     const val = len === 0 ? 255 : rgba[len-1];
 

--- a/src/firefly/js/visualize/draw/DrawingDef.js
+++ b/src/firefly/js/visualize/draw/DrawingDef.js
@@ -23,9 +23,9 @@ export const COLOR_DRAW_1 = '#ff0000'; // red
 export const COLOR_DRAW_2 = '#5500ff'; // purple
 
 /**
- *  a very long enum, look at code in DrawingDef.js
  * @typedef {Object} TextLocation
- * @type {Enum}
+ *  a very long enum, look at code in DrawingDef.js
+ *
  * @prop DEFAULT
  * @prop LINE_TOP
  * @prop LINE_BOTTOM
@@ -51,6 +51,8 @@ export const COLOR_DRAW_2 = '#5500ff'; // purple
  * @prop REGION_SW
  * @prop CENTER
  */
+
+/** @type TextLocation */
 export const TextLocation = new Enum([
     'DEFAULT', 'LINE_TOP', 'LINE_BOTTOM', 'LINE_MID_POINT', 'LINE_MID_POINT_OR_BOTTOM', 'LINE_MID_POINT_OR_TOP',
     'LINE_TOP_STACK', 'CIRCLE_NE', 'CIRCLE_NW', 'CIRCLE_SE', 'CIRCLE_SW', 'RECT_NE', 'RECT_NW', 'RECT_SE',
@@ -67,8 +69,10 @@ export const TextLocation = new Enum([
  * @prop ENDHANDLED
  * @prop LIGHT
  * @prop FILL
+ * @prop DESTINATION_OUTLINE
  */
-export const Style= new Enum(['STANDARD','HANDLED', 'STARTHANDLED', 'ENDHANDLED', 'LIGHT', 'FILL']);
+/** @type Style */
+export const Style= new Enum(['STANDARD','HANDLED', 'STARTHANDLED', 'ENDHANDLED', 'LIGHT', 'FILL', 'DESTINATION_OUTLINE']);
 
 export const DEFAULT_FONT_SIZE = '9pt';
 

--- a/src/firefly/js/visualize/draw/ShapeDataObj.js
+++ b/src/firefly/js/visualize/draw/ShapeDataObj.js
@@ -1122,7 +1122,7 @@ function drawRectangle(drawObj, ctx, plot, drawParams, onlyAddToPath) {
                 centerPt = makeDevicePt(x+w/2, y+h/2);
             }
 
-            if (style === Style.FILL) {
+            if ((style === Style.FILL || style === Style.DESTINATION_OUTLINE)) {
                 DrawUtil.fillRec(ctx, color, x, y, w, h, renderOptions, color);
             } else {
                 if (!onlyAddToPath || style === Style.HANDLED) {
@@ -1155,7 +1155,7 @@ function drawRectangle(drawObj, ctx, plot, drawParams, onlyAddToPath) {
 
         inView = true;
 
-        if (style === Style.FILL) {
+        if ((style === Style.FILL || style === Style.DESTINATION_OUTLINE)) {
             DrawUtil.fillRec(ctx, color, x, y, w, h, renderOptions, color);
         } else {
             if (!onlyAddToPath || style === Style.HANDLED) {
@@ -1400,7 +1400,7 @@ function getEdgePtOnGreatCircleFromCenterTo(pt, plot) {
 function drawPolygon(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
     const {style, color, lineWidth=1} = drawParams;
 
-    if (style !== Style.FILL && !isEmpty(drawObj.drawObjAry)) {
+    if ((style !== Style.FILL && style!==Style.DESTINATION_OUTLINE) && !isEmpty(drawObj.drawObjAry)) {
         drawCompositeObject(drawObj, ctx,  plot, drawParams, onlyAddToPath);
         return;
     }
@@ -1415,7 +1415,7 @@ function drawPolygon(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
             }
          }
 
-        if (style !== Style.FILL) return devPt;
+        if (style !== Style.FILL || style !== Style.DESTINATION_OUTLINE) return devPt;
 
         const {x,y}= devPt;
         const {width,height}= plot.viewDim;
@@ -1427,41 +1427,6 @@ function drawPolygon(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
         return retPt;
 
     };
-    // const isPolygonInDisplay = (pts, style, plot) => {
-    //     let wrapping= false;
-    //     const devPts = pts.map((onePt,idx) => {
-    //         const dPt= plot.getDeviceCoords(onePt);
-    //         if (idx===0 || !dPt) return dPt;
-    //         if (plot.coordsWrap(onePt, pts[idx-1])) {
-    //             wrapping= true;
-    //             return undefined;
-    //         }
-    //         return dPt;
-    //     });
-    //
-    //     const {width, height} = plot.viewDim;
-    //
-    //     // detect if none of the points are visible
-    //     const anyVisible = devPts.find((onePt) => {
-    //         return (onePt && (onePt.x >= 0) && (onePt.x < width) && (onePt.y >= 0) && (onePt.y < height));
-    //     });
-    //
-    //     if (!anyVisible) {
-    //         return {devPts, inDisplay: 0};
-    //     }
-    //
-    //     let inDisplay = 0;
-    //     const newPts = devPts.map((onePt, idx) => {
-    //         const newPt = adjustPointOnDisplay(pts[idx], onePt);
-    //         if (newPt) {
-    //             inDisplay++;
-    //         }
-    //         return newPt;
-    //     });
-    //
-    //
-    //     return {devPts:newPts, inDisplay, wrapping};
-    // };
 
     const isPolygonInDisplay = (pts, style, plot) => {
         let wrapping= false;
@@ -1512,7 +1477,7 @@ function drawPolygon(drawObj, ctx,  plot, drawParams, onlyAddToPath) {
 
         if (inDisplay <= 0 || wrapping) return;   // not visible
 
-        if ((style === Style.FILL)) {
+        if ((style === Style.FILL || style === Style.DESTINATION_OUTLINE)) {
             if (inDisplay < devPts.length) {
                 console.log('less visible');     // test if this may happen
             }


### PR DESCRIPTION
#### [Firefly-1350](https://jira.ipac.caltech.edu/browse/FIREFLY-1350): Add MOC outline style

 - Do outline with MOC
 - put in the right opacity
 - Moc default style
 - moc max depth to 5 with an appOption

Testing:
- https://firefly-1350-moc-outline.irsakudev.ipac.caltech.edu/irsaviewer/dce
- click around on display, all the MOCs should come up as outlines
- choose the drawing layers to change to other modes
- _note:_ sometime moc outlines seem like they are double for certain ones. This is really the best we can do.