### PR TITLE
FIREFLY-1353: Add arrow buttons for image scrolling in ImageTableRowViewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "prismjs": "~1.29",
     "blissfuljs": "~1.0",
     "json-bigint": "https://github.com/Caltech-IPAC/json-bigint",
-    "md5": "~2.3.0"
+    "md5": "~2.3.0",
+    "react-slick": "^0.29.0",
+    "slick-carousel": "^1.8.1"
   },
   "devDependencies": {
     "@babel/core": "~7.16",

--- a/src/firefly/js/visualize/ui/ImageTableRowViewer.css
+++ b/src/firefly/js/visualize/ui/ImageTableRowViewer.css
@@ -1,0 +1,21 @@
+.ImageTableRowViewer {
+    width: calc(100% - 50px); /* each slider arrow is 25px wide */
+    height: 100%;
+    margin: auto;
+}
+
+.ImageTableRowViewer .slick-list, .ImageTableRowViewer .slick-track {
+    height: 100%;
+}
+
+.ImageTableRowViewer .slick-slide {
+    position: relative;
+}
+
+.ImageTableRowViewer__item {
+    display: inline-block;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+}

--- a/src/firefly/js/visualize/ui/ImageTableRowViewer.css
+++ b/src/firefly/js/visualize/ui/ImageTableRowViewer.css
@@ -19,3 +19,7 @@
     height: 100%;
     top: 0;
 }
+
+.ImageTableRowViewer .slick-disabled:before {
+    cursor: auto;
+}

--- a/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
@@ -29,7 +29,7 @@ const flexToolbarStyle= {
 export const MultiItemViewerView=forwardRef( (props, ref) =>  {
 
     const {layoutType, activeItemId,
-        viewerItemIds, forceRowSize, forceColSize, gridDefFunc,
+        viewerItemIds, forceRowSize, forceColSize, makeCustomLayout, gridDefFunc,
         style, insideFlex=false, defaultDecoration=true, sparseGridTitleLocation= 'top',
         makeToolbar, makeItemViewer, makeItemViewerFull, autoRowOriented=true}= props;
     let wrapperStyle;
@@ -46,6 +46,9 @@ export const MultiItemViewerView=forwardRef( (props, ref) =>  {
     else if (layoutType==='single' || viewerItemIds.length===1) {  // SINGLE VIEW
         const id= viewerItemIds.includes(activeItemId) ? activeItemId : viewerItemIds[0];
         container= renderItemViewerFull(makeItemViewerFull,id);
+    }
+    else if (makeCustomLayout) {  // CUSTOM layout defined by a function
+        container = makeCustomLayout(viewerItemIds, makeItemViewer);
     }
     else if (gridDefFunc) {  // GRID computed by a function
         const gridDef= gridDefFunc(viewerItemIds);
@@ -90,6 +93,7 @@ MultiItemViewerView.propTypes= {
     layoutType : PropTypes.oneOf([GRID,SINGLE]),
     forceRowSize : PropTypes.number,   //optional - force a certain number of rows
     forceColSize : PropTypes.number,  //optional - force a certain number of columns
+    makeCustomLayout : PropTypes.func,  //optional - a function to present the items in a custom layout
     gridDefFunc : PropTypes.func,  // optional - a function to return the grid definition
     gridComponent : PropTypes.object,  // a react element to define the grid - not implemented, just an idea
     insideFlex :  PropTypes.bool,

--- a/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiItemViewerView.jsx
@@ -43,12 +43,12 @@ export const MultiItemViewerView=forwardRef( (props, ref) =>  {
     if (!viewerItemIds.length && !gridDefFunc) {
         container= false;
     }
+    else if (makeCustomLayout) {  // CUSTOM layout defined by a function
+        container = makeCustomLayout(viewerItemIds, makeItemViewer);
+    }
     else if (layoutType==='single' || viewerItemIds.length===1) {  // SINGLE VIEW
         const id= viewerItemIds.includes(activeItemId) ? activeItemId : viewerItemIds[0];
         container= renderItemViewerFull(makeItemViewerFull,id);
-    }
-    else if (makeCustomLayout) {  // CUSTOM layout defined by a function
-        container = makeCustomLayout(viewerItemIds, makeItemViewer);
     }
     else if (gridDefFunc) {  // GRID computed by a function
         const gridDef= gridDefFunc(viewerItemIds);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2836,6 +2836,11 @@ enhanced-resolve@^5.8.3:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+enquire.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
+  integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
+
 enquirer@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
@@ -4757,6 +4762,13 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==
+  dependencies:
+    string-convert "^0.2.0"
+
 json5@^2.1.2, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -6055,6 +6067,17 @@ react-sizeme@~3.0:
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
 
+react-slick@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.29.0.tgz#0bed5ea42bf75a23d40c0259b828ed27627b51bb"
+  integrity sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==
+  dependencies:
+    classnames "^2.2.5"
+    enquire.js "^2.1.6"
+    json2mq "^0.2.0"
+    lodash.debounce "^4.0.8"
+    resize-observer-polyfill "^1.5.0"
+
 react-split-pane@~0.1:
   version "0.1.92"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.92.tgz#68242f72138aed95dd5910eeb9d99822c4fc3a41"
@@ -6400,7 +6423,7 @@ reselect@^4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
 
-resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
@@ -6696,6 +6719,11 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
+slick-carousel@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.8.1.tgz#a4bfb29014887bb66ce528b90bd0cda262cc8f8d"
+  integrity sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==
+
 slug@~8.2:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/slug/-/slug-8.2.2.tgz#33b019a857a11fc4773c1e9a9f60e3da651a9e5d"
@@ -6854,6 +6882,11 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
 string-editor@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
Fixes [FIREFLY-1353](https://jira.ipac.caltech.edu/browse/FIREFLY-1353)

- Added react-slick slider to use in ImageTableRowViewer. slick-carousel package is also added for the css needed for react-slick
- Expose layout/container creating function in MultiItemViewerView so that items (images) can be rendered inside slider
- Synchronized changes in slide with change in highlighted row and vice versa (note: this is where logic gets bit complicated because we have to prevent it from looping)
- Created a custom slider arrow button for above purpose and to cancel the event when slider is hitting the left edge or right edge (so that it doesn't slide and active image moves to center)
- Made change in active plot through UI, change the highlighted row 
- Make height of slider (and inner components) take height of its parent container - that's why CSS sheet was added to override default slick styles

## Testing
https://firefly-1353-arrow-btn-imagerowviewer.irsakudev.ipac.caltech.edu/applications/spherex/

Make sure spectrum table is open - it's easier to test that way

- Click arrows, it should change the highlighted row. Note that slider won't really move until the active image comes to centre. Afterwards it will slide the slider along with moving the active image by one.
- Click on any row in table (or point in plot), it should change the slider position and active image. Also try changing the table pages.
-  Click on any image that is not active, it should change the highlighted row ~and move the slider to bring to center.~ preserving the slider position. On subsequent arrow clicks, test that it will move active plot/row or slider to bring it to center. 


