### PR TITLE
FIREFLY-1356: UI Conversion: convert TableView to Joy UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-sizeme": "~3.0",
     "react-split-pane": "~0.1",
     "react-router-dom": "^6.14.0",
-    "fixed-data-table-2": "~1.2",
+    "fixed-data-table-2": "~2.0.4",
     "prismjs": "~1.29",
     "blissfuljs": "~1.0",
     "json-bigint": "https://github.com/Caltech-IPAC/json-bigint",

--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -540,6 +540,7 @@ div.rootStyle img {
 }
 
 .arrow-down {
+    margin-right: 2px;
     width: 0;
     height: 0;
     border-left: 5px solid transparent;

--- a/src/firefly/js/api/ApiUtil.js
+++ b/src/firefly/js/api/ApiUtil.js
@@ -6,6 +6,8 @@
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {isArray, isElement, isString} from 'lodash';
+
+import {FireflyRoot} from '../ui/FireflyRoot.jsx';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../core/MasterSaga.js';
 import {Logger} from '../util/Logger.js';
 import {uniqueID} from '../util/WebUtil';
@@ -67,10 +69,12 @@ export function renderDOM(div, Component, props) {
 
     if (!isElement(divElement)) debug(`the div element ${isString(div)?div:''} is not defined in the html` );
     if (!Component) debug('Component must be defined');
-    divElement.classList.add('rootStyle');
+    // divElement.classList.add('rootStyle');       // this is probably not necessary
 
     const renderStuff= (
+        <FireflyRoot>
             <Component {...props} />
+        </FireflyRoot>
     );
     root.render(renderStuff);
 }

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import React, {useContext} from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, {object, shape} from 'prop-types';
 import {get} from 'lodash';
 import {Expression} from '../../util/expr/Expression.js';
 import {quoteNonAlphanumeric} from '../../util/expr/Variable.js';
@@ -132,7 +132,7 @@ ColumnOrExpression.propTypes = {
     inputStyle: PropTypes.object
 };
 
-export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidth, tooltip='Table column',
+export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidth, tooltip='Table column', slotProps,
                            name, nullAllowed, canBeExpression=false, inputStyle, readonly, helper, required, validator,
                               placeholder, colTblId=null,onSearchClicked=null}) {
     const value = initValue || getFieldVal(groupKey, fieldKey);
@@ -186,6 +186,7 @@ export function ColumnFld({cols, groupKey, fieldKey, initValue, label, labelWidt
                 readonly={readonly}
                 endDecorator= {!readonly && helper ? helper : undefined}
                 required={required}
+                slotProps={slotProps}
             />
         </div>
     );
@@ -209,5 +210,12 @@ ColumnFld.propTypes = {
     colTblId: PropTypes.string,
     onSearchClicked: PropTypes.func,
     placeholder: PropTypes.string,
+    slotProps: shape({
+        input: object,
+        control: object,
+        label: object,
+        tooltip: object
+    })
+
 };
 

--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -1,5 +1,6 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
+import {Button, Stack} from '@mui/joy';
 import shallowequal from 'shallowequal';
 
 import {dispatchJobAdd, dispatchJobCancel} from './BackgroundCntlr.js';
@@ -51,11 +52,11 @@ export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, style={}})
 
     const msg = jobInfo?.errorSummary?.message || jobInfo?.jobInfo?.progressDesc || 'Working...';
 
-    const Options = () => ( inProgress &&
-        <div className='BgMaskPanel__actions'>
-            <div className='button large' onClick={sendToBg}>Send to background</div>
-            <div className='button large' onClick={abort}>Cancel</div>
-        </div>
+    const Options = () => ( (inProgress || true) &&
+        <Stack direction='row' spacing={1}>
+            <Button variant='solid' color='primary' onClick={sendToBg}>Send to background</Button>
+            <Button onClick={abort}>Cancel</Button>
+        </Stack>
     );
 
     const errorInJob= ['ERROR', 'ABORTED'].includes(jobInfo?.phase);

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -10,6 +10,7 @@ import {HelpIcon} from '../../ui/HelpIcon.jsx';
 import {CollapsiblePanel} from 'firefly/ui/panel/CollapsiblePanel.jsx';
 import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson.js';
 import {TextButton} from 'firefly/ui/TextButton.jsx';
+import {Button} from '@mui/joy';
 
 
 export function showJobInfo(jobId) {
@@ -83,7 +84,7 @@ function DataOrigin({dataOrigin, type, jobId}) {
     return (
         <div style={{display: 'inline-flex'}}>
             <KeywordBlock style={{width: 425}} label={label} value={dataOrigin} asLink={true}/>
-            <TextButton text='Show' style={{marginLeft: 3}} onClick={() => showUwsJob({jobId})}/>
+            <Button ml={1/2} onClick={() => showUwsJob({jobId})}>Show</Button>
         </div>
     );
 }

--- a/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
+++ b/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
@@ -4,6 +4,7 @@
 
 import React, {useCallback, useState} from 'react';
 import PropTypes from 'prop-types';
+import {Button, Skeleton, Stack, Link, Sheet, Typography, Box} from '@mui/joy';
 import {delay} from 'lodash';
 import {UCDList} from '../../voAnalyzer/VoConst.js';
 
@@ -48,8 +49,6 @@ export const AddOrUpdateColumn = React.memo(({tbl_ui_id, tbl_id, hidePopup, edit
     const ref = useCallback((node) => delay(() => node?.focus(), 100), []);
     const cols = getAllColumns(getTblById(tbl_id));
     const colNames = cols.map((c) => c.name);
-
-    const fieldProps = {labelWidth: 75, style: {width: 200}};
 
     const doUpdate = () => {
         const {request, selectInfo} = getTblById(tbl_id);
@@ -96,31 +95,43 @@ export const AddOrUpdateColumn = React.memo(({tbl_ui_id, tbl_id, hidePopup, edit
     const buttonLabel = editColName ? 'Update Column' : 'Add Column';
     const DelBtn = (<button type='button' className='button std'onClick={doDelete}>Delete Column</button>);
 
+    if (isWorking) return <Skeleton className='loading-mask' style={{zIndex:1}}/>;
     return (
-        <div style={{position:'relative'}}>
-            {isWorking && <div className='loading-mask' style={{zIndex:1}}/>}
+        <Stack p={1} width={500}
+            sx={{
+                '.ff-Input':{mb:1},
+                '.MuiInput-endDecorator':{mr:-1},
+                label:{width:75},
+                input:{width:265}
+            }}>
             <div className='required-msg'/>
-            <FieldGroup groupKey={groupKey} className='AddColumn__form'>
-                <ValidationField fieldKey='cname' label='Name:' inputRef={ref} required={true} {...fieldProps} initialState={{
-                    value: editColName,
-                    validator:textValidator({min:1, max: 128,
-                        pattern: /^[a-z0-9_]+$/i,
-                        message:'Column name is required and must contain only A to Z, 0 to 9, and underscore (_) characters'})
-                }}/>
-                <RadioGroupInputField fieldKey='mode' initialState={{label: 'Mode:', value:mode}} options={[{value:'Custom', label:'Enter expression'}, {value:'Preset', label:'Use preset function'}]} {...fieldProps}/>
-                {mode === 'Custom' ? <CustomFields {...{tbl_ui_id, tbl_id, groupKey, fieldProps, editColName}}/> : <PresetFields {...{tbl_id, editColName, fieldProps}}/>}
+            <FieldGroup groupKey={groupKey}>
+                <ValidationField fieldKey='cname' label='Name:' inputRef={ref}
+                    required={true}
+                    orientation='horizontal'
+                    initialState={{
+                        value: editColName,
+                        validator:textValidator({min:1, max: 128,
+                            pattern: /^[a-z0-9_]+$/i,
+                            message:'Column name is required and must contain only A to Z, 0 to 9, and underscore (_) characters'})
+                    }}/>
+                <RadioGroupInputField fieldKey='mode'
+                    orientation='horizontal'
+                    sx={{'.MuiRadio-label':{width:115}}}
+                    initialState={{label: 'Mode:', value:mode}}
+                    options={[
+                        {value:'Custom', label:'Enter expression'},
+                        {value:'Preset', label:'Use preset function'}
+                    ]}/>
+                {mode === 'Custom' ? <CustomFields {...{tbl_ui_id, tbl_id, groupKey, editColName}}/> : <PresetFields {...{tbl_id, editColName}}/>}
             </FieldGroup>
-            <div className='AddColumn__actions'>
-                <button type='button' className='button std' style={{marginRight: 5}}
-                        onClick={doUpdate}>{buttonLabel}
-                </button>
+            <Stack direction='row' mt={2} spacing={1} alignItems='center'>
+                <Button color='primary' variant='solid' onClick={doUpdate}>{buttonLabel}</Button>
                 {editColName && DelBtn}
-                <button type='button' className='button std'
-                        onClick={() => hidePopup?.()}> Cancel
-                </button>
+                <Button onClick={() => hidePopup?.()}> Cancel</Button>
                 <HelpIcon helpId={'tables.addColumn'} style={{float: 'right', marginTop: 4}}/>
-            </div>
-        </div>
+            </Stack>
+        </Stack>
     );
 
 });
@@ -170,11 +181,10 @@ export const AddColumnBtn = ({tbl_ui_id, tbl_id}) => (
 );
 
 export function showAddOrUpdateColumn({tbl_ui_id, tbl_id, editColName, onChange}) {
-    let popup;
     const hidePopup = () => popup?.();
     const title =  editColName ? 'Edit a derived column' : 'Add a column';
 
-    popup = showPopup({ID:'addOrUpdateColumn', content: <AddOrUpdateColumn {...{tbl_id, tbl_ui_id, hidePopup, editColName, onChange}}/>, title, modal: true});
+    const popup = showPopup({ID:'addOrUpdateColumn', content: <AddOrUpdateColumn {...{tbl_id, tbl_ui_id, hidePopup, editColName, onChange}}/>, title, modal: true});
 }
 
 function getEditColInfo(tbl_id, editColName) {
@@ -186,28 +196,32 @@ function getEditColInfo(tbl_id, editColName) {
     return {col,desc,preset,expression};
 }
 
-function DescField ({desc, fieldProps}) {
-    return <ValidationField fieldKey='desc' label='Description:' initialState={{value:desc}}
-                            tooltip='A one-line description for the column heading tooltip and table options' {...fieldProps}/>;
+function DescField ({desc}) {
+    return (
+        <ValidationField fieldKey='desc' label='Description:'
+                         orientation='horizontal'
+                         initialState={{value:desc}}
+                         tooltip='A one-line description for the column heading tooltip and table options'/>
+    );
 }
 
-function PresetFields ({tbl_id, editColName, fieldProps}) {
+function PresetFields ({tbl_id, editColName}) {
     const {preset, desc} = getEditColInfo(tbl_id, editColName);
 
     return (
         <>
-            <ListBoxInputField fieldKey='preset' label='Select a preset:'
+            <ListBoxInputField fieldKey='preset' label='Select a preset:' orientation='horizontal'
                                options={[
                                    {value:'filtered', label:"Set filtered rows to 'true' and the rest to 'false'"},
                                    {value:'selected', label:"Set selected rows to 'true' and the rest to 'false'"},
                                    {value:'ROW_NUM', label:'Number rows in current sort order'}]}
-                               initialState={{value: preset}} {...fieldProps}/>
-            <DescField {...{desc, fieldProps}}/>
+                               initialState={{value: preset}}/>
+            <DescField {...{desc}}/>
         </>
     );
 }
 
-function CustomFields({tbl_ui_id, tbl_id, groupKey, fieldProps, editColName}) {
+function CustomFields({tbl_ui_id, tbl_id, groupKey, editColName}) {
 
     const dtype = useStoreConnector(() => getFieldVal(groupKey, 'dtype', 'double'));
     const exprKey = 'expression';
@@ -223,40 +237,58 @@ function CustomFields({tbl_ui_id, tbl_id, groupKey, fieldProps, editColName}) {
     return (
         <>
             <ColumnFld fieldKey={exprKey} name='Expression' cols={cols} label='Expression:' required={true} initValue={col.DERIVED_FROM}
-                       canBeExpression={true} nullAllowed={false} inputStyle={{width: 200}} validator={textValidator({min:1})}
-                       helper={<Helper {...{tbl_ui_id, tbl_id, onChange}}/>} tooltip={EXPRESSION_TTIPS} {...fieldProps}
+                       slotProps={{control:{orientation:'horizontal'}}}
+                       canBeExpression={true} nullAllowed={false} validator={textValidator({min:1})}
+                       helper={<Helper {...{tbl_ui_id, tbl_id, onChange}}/>} tooltip={EXPRESSION_TTIPS}
             />
             <div className='AddColumn__datatype'>
                 <ListBoxInputField fieldKey='dtype' label='Data Type:'
-                                   options={[{value:'double'}, {value:'long'}, {value:'char'}]} initialState={{value: col.type}} {...fieldProps}/>
+                                   options={[{value:'double'}, {value:'long'}, {value:'char'}]}
+                                   initialState={{value: col.type}}
+                />
                 {dtype === 'double' &&
-                <ValidationField fieldKey='precision' label='Precision:' labelWidth={50} style={{width:70}}
+                <ValidationField fieldKey='precision' label='Precision:'
+                                 sx={{
+                                     label:{width:50, ml:2},
+                                     input:{width: 100}
+                                 }}
+                                 orientation='horizontal'
                                  placeholder='e.g. F6'
                                  initialState={{ value: col.precision, validator:textValidator({pattern: /^$|^[FE]?[1-9]$/i,
                                          message:'Precision must be Fn or En. When Fn, n is the number of digits after the decimal.  ' +
                                              'And when En, n is the precision in scientific notation'
                                      })}}
-                />
-                }
+                />}
             </div>
-            <Info url='https://ivoa.net/documents/VOUnits'>
-                <ValidationField fieldKey='units' label='Units:' initialState={{value: col.units}} tooltip='Units of measurement, IVOA VOUnits preferred' {...fieldProps}/>
-            </Info>
-            <Info url='https://ivoa.net/documents/UCD1+'>
-                <SuggestBoxInputField fieldKey='ucd' label='UCD:' initialState={{value: col.UCD}} tooltip='IVOA Unified Content Descriptor, UCD1+ style'
-                                      getSuggestions={getSuggestions} valueOnSuggestion={valueOnSuggestion} inputStyle={{width:200}} {...fieldProps}/>
-            </Info>
-            <DescField {...{desc, fieldProps}}/>
+            <ValidationField fieldKey='units' label='Units:'
+                             slotProps={{
+                                 input:{endDecorator: <Info url='https://ivoa.net/documents/VOUnits'/>}
+                             }}
+                             orientation='horizontal'
+                             initialState={{value: col.units}}
+                             tooltip='Units of measurement, IVOA VOUnits preferred'
+            />
+            <SuggestBoxInputField fieldKey='ucd' label='UCD:'
+                              slotProps={{
+                                  control:{orientation:'horizontal'},
+                                  input:{endDecorator: <Info url='https://ivoa.net/documents/UCD1+'/>}
+                              }}
+                              initialState={{value: col.UCD}}
+                              tooltip='IVOA Unified Content Descriptor, UCD1+ style'
+                              getSuggestions={getSuggestions} valueOnSuggestion={valueOnSuggestion}
+            />
+            <DescField desc={desc}/>
         </>
     );
 }
 
 function Helper({tbl_ui_id, tbl_id, onChange}) {
     const content = (
-        <div style={{height: 425, width: 700, position: 'relative'}}>
+        <Box height={500} width={700} position='relative'>
             <SqlTableFilter inputLabel='Expression' placeholder='e.g. w3mpro - w4mpro'
-                            usages={<Usages/>} samples={<Samples/>} {...{tbl_ui_id, tbl_id, onChange}}/>
-        </div>
+                            usages={<Usages/>} samples={<Samples/>} {...{tbl_ui_id, tbl_id, onChange}}
+            />
+        </Box>
 
     );
     const onClick = () => hideExpPopup = showPopup({ID:'ExpressionCreator', title: 'Expression Creator', content});
@@ -267,39 +299,37 @@ function Helper({tbl_ui_id, tbl_id, onChange}) {
 
 const Usages = () => {
     return (
-        <>
-            <h4>Usage</h4>
-            <div style={{marginLeft: 5}}>
-                <div>Input should follow the syntax of an SQL expression.</div>
-                <div>Click on a Column name to insert the name into the Expression input box.</div>
-                <div style={{marginTop: 5}}>Standard SQL-like operators can be used where applicable.
-                    Supported operators are:
-                    <span {...code}>{'  +, -, *, /, =, >, <, >=, <=, !=, LIKE, IN, IS NULL, IS NOT NULL'}</span>
-                </div>
-                <div style={{marginTop: 5}}>
-                    You may use functions as well.  A few of the common functions are listed below.
-                    For a list of all available functions, click <a href='http://hsqldb.org/doc/2.0/guide/builtinfunctions-chapt.html' target='_blank'>here</a>
-                </div>
-                <div style={{marginLeft: 5}}>
-                    <li style={{whiteSpace: 'nowrap'}}>String functions: <span {...code}>CONCAT(s1,s2[,...]]) SUBSTR(s,offset,length)</span></li>
-                    <li style={{whiteSpace: 'nowrap'}}>Numeric functions: <span {...code}>LOG10(x) LN(x) DEGREES(x) COS(x) POWER(x,y)</span></li>
-                </div>
-            </div>
-        </>
+        <Sheet>
+            <Typography level='title-md'>Usage</Typography>
+            <Typography level='body-sm' sx={{code:{ml:1, whiteSpace:'nowrap'}}}>
+                Input should follow the syntax of an SQL expression. <br/>
+                Click on a Column name to insert the name into the Expression input box. <br/>
+                Standard SQL-like operators can be used where applicable. <br/>
+                Supported operators are: <br/>
+                <code>{'  +, -, *, /, =, >, <, >=, <=, !=, LIKE, IN, IS NULL, IS NOT NULL'}</code> <br/><br/>
+
+                You may use functions as well.  A few of the common functions are listed below. <br/>
+                For a list of all available functions, click <Link href='http://hsqldb.org/doc/2.0/guide/builtinfunctions-chapt.html' target='_blank'>here</Link> <br/>
+                String functions: <br/>
+                <code>CONCAT(s1,s2[,...]]) SUBSTR(s,offset,length)</code> <br/>
+                Numeric functions: <br/>
+                <code>LOG10(x) LN(x) DEGREES(x) COS(x) POWER(x,y)</code>
+            </Typography>
+        </Sheet>
     );
 };
 
 const Samples = () => {
     return (
-        <>
-            <h4>Sample Expressions</h4>
-            <div style={{marginLeft: 5}}>
-                <li style={{whiteSpace: 'nowrap'}}><div {...code}>{'"w3mpro" - "w4mpro"'}</div></li>
-                <li style={{whiteSpace: 'nowrap'}}><div {...code}>{'sqrt(power("w3sigmpro",2) + power("w4sigmpro",2))'}</div></li>
-                <li style={{whiteSpace: 'nowrap'}}><div {...code}>{'("ra"-82.0158188)*cos(radians("dec"))'}</div></li>
-                <li style={{whiteSpace: 'nowrap'}}><div {...code}>{'"phot_g_mean_mag"-(5*log10(1000/"parallax") - 5)'}</div></li>
-            </div>
-        </>
+        <Sheet>
+            <Typography level='title-md'>Sample Expressions</Typography>
+            <Typography level='body-sm' sx={{code:{ml:1, whiteSpace:'nowrap'}}}>
+                <code>{'"w3mpro" - "w4mpro"'}</code> <br/>
+                <code>{'sqrt(power("w3sigmpro",2) + power("w4sigmpro",2))'}</code> <br/>
+                <code>{'("ra"-82.0158188)*cos(radians("dec"))'}</code> <br/>
+                <code>{'"phot_g_mean_mag"-(5*log10(1000/"parallax") - 5)'}</code>
+            </Typography>
+        </Sheet>
     );
 };
 
@@ -331,12 +361,6 @@ function valueOnSuggestion(cval='', suggestion) {
     return suggestion;
 }
 
-function Info({url, target='info', style={}, children}) {
-    return (
-        <div style={{display:'inline-flex', alignItems:'center', ...style}}>
-            {children}
-            <a href={url} target={target} tabIndex='-1'><img src={INFO} style={{height: 16}} /></a>
-        </div>
-    );
-
+function Info({url, target='info'}) {
+    return <Link href={url} target={target} tabIndex={-1} startDecorator={<img src={INFO} style={{height: 16}}/>}/>;
 }

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -3,10 +3,12 @@
  */
 
 import React, {useCallback, useEffect} from 'react';
+import {Box, Typography} from '@mui/joy';
 import PropTypes from 'prop-types';
 import {Column, Table} from 'fixed-data-table-2';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
 import {get, set, isEmpty, isUndefined, omitBy, pick} from 'lodash';
+
 
 import {calcColumnWidths, getCellValue, getColumns, getProprietaryInfo, getTableState, getTableUiById, getTblById, hasRowAccess, isClientTable, tableTextView, TBL_STATE, uniqueTblUiId} from '../TableUtil.js';
 import {SelectInfo} from '../SelectInfo.js';
@@ -17,6 +19,7 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {dispatchTableUiUpdate, TBL_UI_UPDATE} from '../TablesCntlr.js';
 import {Logger} from '../../util/Logger.js';
 
+import 'fixed-data-table-2/dist/fixed-data-table.css';
 import './TablePanel.css';
 
 const logger = Logger('Tables').tag('BasicTable');
@@ -63,7 +66,7 @@ const BasicTableViewInternal = React.memo((props) => {
     const onFilter       = useCallback( doFilter.bind({callbacks, filterInfo}), [callbacks, filterInfo]);
     const onFilterSelected = useCallback( doFilterSelected.bind({callbacks, selectInfoCls}), [callbacks, selectInfoCls]);
 
-    const headerHeight = showHeader ? 22 + (showUnits && 8) + (showTypes && 8) + (showFilters && 22) : 0;
+    const headerHeight = showHeader ? 22 + (showUnits && 14) + (showTypes && 14) + (showFilters && 23) : 0;
     let totalColWidths = 0;
     if (!isEmpty(columns) && !isEmpty(columnWidths)) {
         totalColWidths = columns.reduce((pv, c, idx) => {
@@ -144,10 +147,10 @@ const BasicTableViewInternal = React.memo((props) => {
     };
 
     return (
-        <div tabIndex='-1' onKeyDown={onKeyDown} className='TablePanel__frame'>
+        <Box sx={{lineHeight:1, height:1}} tabIndex='-1' onKeyDown={onKeyDown}>
             {content()}
             <Status/>
-        </div>
+        </Box>
     );
 });
 
@@ -196,7 +199,7 @@ BasicTableViewInternal.defaultProps = {
     selectable: false,
     showTypes: false,
     showMask: false,
-    rowHeight: 20,
+    rowHeight: 27,
     currentPage: -1
 };
 
@@ -209,19 +212,6 @@ export const BasicTableViewWithConnector = React.memo((props) => {
 });
 
 /*---------------------------------------------------------------------------*/
-
-// function getTableState(props, uiStates) {
-//     const {columns, error, data, size, showMask} = props;
-//     const {tbl_id, columnWidths} = uiStates;
-//
-//     if (error) return 'ERROR';
-//     if (showMask || isEmpty(columns) || size.width === 0 || isEmpty(columnWidths)) {
-//         return 'LOADING';
-//     }
-//     if (hasNoData(tbl_id)) return 'NO_DATA_FOUND';
-//     if (isEmpty(data)) return 'META_ONLY';
-//     return 'OK';
-// }
 
 function doScrollEnd(scrollLeft, scrollTop) {
     const {tbl_ui_id} = this;
@@ -295,14 +285,14 @@ function doRowSelect(checked, rowIndex) {
 }
 
 
-const TextView = ({columns, data, showUnits, width, height}) => {
+const TextView = ({columns, data, width, height}) => {
     const text = tableTextView(columns, data);
     return (
-        <div style={{height, width,overflow: 'hidden'}}>
-            <div style={{height: '100%',overflow: 'auto'}}>
+        <Box sx={{height, width,overflow: 'hidden'}}>
+            <Typography level='body-sm' sx={{height: 1,overflow: 'auto'}}>
                 <pre>{text}</pre>
-            </div>
-        </div>
+            </Typography>
+        </Box>
     );
 };
 
@@ -362,8 +352,8 @@ function defHighlightedRowHandler(tbl_id, hlRowIdx, startIdx) {
         if (hasProprietaryInfo && !hasRowAccess(tableModel, absRowIndex)) {
             return hlRowIdx === rowIndex ? 'TablePanel__no-access--highlighted' : 'TablePanel__no-access';
         }
-        if (hlRowIdx === rowIndex) return 'tablePanel__Row_highlighted';
-        if (isRelated(rowIndex)) return 'tablePanel__Row_related';
+        if (hlRowIdx === rowIndex) return 'highlighted';
+        if (isRelated(rowIndex)) return 'related';
     };
 }
 

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -5,6 +5,7 @@
 import React, {PureComponent, useEffect, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import {Button, Link, Sheet, Stack, Typography} from '@mui/joy';
 import {isEmpty, cloneDeep, get} from 'lodash';
 import SplitPane from 'react-split-pane';
 import Tree, { TreeNode } from 'rc-tree';
@@ -265,7 +266,7 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
     return (
         <SplitPane split='vertical' defaultSize={200} style={{display: 'inline-flex', ...style}}>
             <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
-                <b>Columns (sorted)</b>
+                <Typography level='title-md'>Columns (sorted)</Typography>
                 <div  style={{overflow: 'auto', flexGrow: 1}}>
                     <Tree defaultExpandAll showLine onSelect={onNodeClick} icon={iconGen} >
                         {treeNodes}
@@ -273,15 +274,15 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
                 </div>
             </SplitContent>
             <SplitContent style={{overflow: 'auto'}}>
-                <div className='flex-full' style={{height: '100%', overflow: 'hidden'}}>
+                <Stack height={1} spacing={1} overflow='hidden'>
                     <ColumnFilter {...{colFilters, onChange}}/>
-                    <div style={{display: 'inline-flex', justifyContent: 'space-between', alignItems: 'center'}}>
-                        <h3>{inputLabel}</h3>
-                            <div style={{display: 'inline-flex', alignItems: 'center'}}>
-                            <button className='button std' title='Apply the constraints' style={{height: 24}} onClick={onApply}>Apply</button>
+                    <Stack direction='row' justifyContent='space-between' alignItems='center'>
+                        <Typography level='title-md'>{inputLabel}</Typography>
+                        <Stack direction='row' alignItems='center' spacing={1}>
+                            <Button title='Apply the constraints' onClick={onApply}>Apply</Button>
                             {colFilters &&
-                                <div style={{display: 'inline-flex', alignItems: 'center'}}>
-                                    <label style={{margin: '0 5px'}}> with: </label>
+                                <Stack direction='row' alignItems='center' spacing={1}>
+                                    <Typography> with: </Typography>
                                     <RadioGroupInputField
                                         fieldKey={opKey}
                                         groupKey={groupKey}
@@ -290,10 +291,10 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
                                             {label: 'AND', value: 'AND'},
                                             {label: 'OR', value: 'OR'}
                                         ]}/>
-                                </div>
+                                </Stack>
                             }
-                        </div>
-                    </div>
+                        </Stack>
+                    </Stack>
                     <InputAreaFieldConnected
                         ref={sqlEl}
                         style={{width: 'calc(100% - 9px)', resize: 'none', backgroundColor: 'white', ...errStyle}} rows={7}
@@ -304,11 +305,11 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
                         placeholder={placeholder}
                     />
                     {error && <li style={{color: 'red', fontStyle: 'italic'}}>{error}</li>}
-                    <div style={{color: '#4c4c4c', overflow: 'auto', flexGrow: 1}}>
+                    <Stack spacing={1} overflow='auto'>
                         {usages}
                         {samples}
-                    </div>
-                </div>
+                    </Stack>
+                </Stack>
             </SplitContent>
         </SplitPane>
     );
@@ -326,50 +327,51 @@ function ColumnFilter({colFilters, onChange}) {
 
     if (colFilters){
         return (
-            <div >
-                <div style={{fontWeight: 'bold', display: 'inline-flex', margin: '5px 0'}}>
-                    <div>Current Constraints: </div>
-                    <div style={{marginLeft: 5}} className='ff-href' onClick={clearFilters}>Clear</div>
-                    <CopyToClipboard style={{marginLeft:7}} value={colFilters}/>
-                </div>
-                <div className='TablePanelOptions__filters' title={colFilters}>{colFilters}</div>
-            </div>
+            <Stack>
+                <Stack direction='row' spacing={1}>
+                    <Typography level='title-md'>Current Constraints: </Typography>
+                    <Link onClick={clearFilters}
+                          endDecorator={<CopyToClipboard value={colFilters}/>}
+                    >Clear</Link>
+                </Stack>
+                <Sheet variant='soft' title={colFilters}>
+                    <Typography color='warning' level='body-sm'><code>{colFilters}</code></Typography>
+                </Sheet>
+            </Stack>
         );
     } else return null;
 }
 
 const Usages = () => {
     return (
-        <>
-            <h4>Usage</h4>
-            <div style={{marginLeft: 5}}>
-                <div>Input should follow the syntax of an SQL WHERE clause.</div>
-                <div>Click on a Column name to insert the name into the SQL Filter input box.</div>
-                <div style={{marginTop: 5}}>Standard SQL-like operators can be used where applicable.
-                    Supported operators are:
-                    <span {...code}>{'  +, -, *, /, =, >, <, >=, <=, !=, LIKE, IN, IS NULL, IS NOT NULL'}</span>
-                </div>
-                <div style={{marginTop: 5}}>
-                    You may use functions as well.  A few of the common functions are listed below.
-                    For a list of all available functions, click <a href='http://hsqldb.org/doc/2.0/guide/builtinfunctions-chapt.html' target='_blank'>here</a>
-                </div>
-                <div style={{marginLeft: 5}}>
-                    <li style={{whiteSpace: 'nowrap'}}>String functions: <span {...code}>CONCAT(s1,s2[,...]]) INSTR(s,pattern[,offset]) LENGTH(s) SUBSTR(s,offset,length)</span></li>
-                    <li style={{whiteSpace: 'nowrap'}}>Numeric functions: <span {...code}>LOG10(x)/LG(x) LN(x)/LOG(x) DEGREES(x) ABS(x) COS(x) SIN(x) TAN(x) POWER(x,y)</span></li>
-                </div>
-            </div>
-        </>
+        <Sheet>
+            <Typography level='title-md'>Usage</Typography>
+            <Typography level='body-sm' sx={{code:{ml:1, whiteSpace:'nowrap'}}}>
+                Input should follow the syntax of an SQL WHERE clause. <br/>
+                Click on a Column name to insert the name into the SQL Filter input box. <br/>
+                Standard SQL-like operators can be used where applicable. <br/>
+                Supported operators are: <br/>
+                <code>{'  +, -, *, /, =, >, <, >=, <=, !=, LIKE, IN, IS NULL, IS NOT NULL'}</code> <br/><br/>
+
+                You may use functions as well.  A few of the common functions are listed below. <br/>
+                For a list of all available functions, click <Link href='http://hsqldb.org/doc/2.0/guide/builtinfunctions-chapt.html' target='_blank'>here</Link> <br/>
+                String functions: <br/>
+                <code>CONCAT(s1,s2[,...]]) INSTR(s,pattern[,offset]) LENGTH(s) SUBSTR(s,offset,length)</code> <br/>
+                Numeric functions: <br/>
+                <code>LOG10(x)/LG(x) LN(x)/LOG(x) DEGREES(x) ABS(x) COS(x) SIN(x) TAN(x) POWER(x,y)</code>
+            </Typography>
+        </Sheet>
     );
 };
 
 const Samples = () => {
     return (
-        <>
-            <h4>Sample Filters</h4>
-            <div style={{marginLeft: 5}}>
-                <li style={{whiteSpace: 'nowrap'}}><div {...code}>{'("ra" > 185 AND "ra" < 185.1) OR ("dec" > 15 AND "dec" < 15.1) AND "band" IN (1,2)'}</div></li>
-                <li style={{whiteSpace: 'nowrap'}}><div {...code}>{'POWER("v",2) / POWER("err",2) > 4 AND "band" = 3'}</div></li>
-            </div>
-        </>
+        <Sheet>
+            <Typography level='title-md'>Sample Filters</Typography>
+            <Typography level='body-sm' sx={{code:{ml:1, whiteSpace:'nowrap'}}}>
+                <code>{'("ra" > 185 AND "ra" < 185.1) OR ("dec" > 15 AND "dec" < 15.1) AND "band" IN (1,2)'}</code> <br/>
+                <code>{'POWER("v",2) / POWER("err",2) > 4 AND "band" = 3'}</code>
+            </Typography>
+        </Sheet>
     );
 };

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {Typography, Box, Link, Stack} from '@mui/joy';
 
 import {isEmpty} from 'lodash';
 import {getTblById, hasAuxData} from '../TableUtil.js';
@@ -23,7 +24,7 @@ export function TableInfo(props) {
    const jobId = getJobIdFromTblId(tbl_id);
 
     return (
-        <div style={{padding: '10px 5px 5px', height: '100%', boxSizing: 'border-box', display: 'flex', flexDirection: 'column'}}>
+        <Stack p={1} height={1} boxSizing='border-box'>
             <StatefulTabs componentKey='TablePanelOptions' defaultSelected={0} borderless={true} useFlex={true} style={{flex: '1 1 0'}}>
                 {jobId &&
                 <Tab name='Job Info'>
@@ -39,7 +40,7 @@ export function TableInfo(props) {
             <div>
                 <HelpIcon helpId={'tables.info'} style={{float: 'right', marginRight: 10}}/>
             </div>
-        </div>
+        </Stack>
     );
 }
 
@@ -50,14 +51,14 @@ TableInfo.propTypes = {
 
 function MetaContent({tbl_id}) {
     if (hasAuxData(tbl_id)) {
-        return <MetaInfo tbl_id={tbl_id} isOpen={true} style={{ width: '100%', border: 'none', margin: 'unset', padding: 'unset'}} />;
+        return <MetaInfo tbl_id={tbl_id} isOpen={true} sx={{ w: 1, border: 'none', m: 'unset', p: 'unset'}} />;
     } else {
         return <div style={{margin: 20, fontWeight: 'bold'}}>No metadata available</div>;
     }
 }
 
 
-export function MetaInfo({tbl_id, style, isOpen=false}) {
+export function MetaInfo({tbl_id, sx, isOpen=false}) {
     const contentStyle={display: 'flex', flexDirection: 'column', overflow: 'hidden', paddingBottom: 1};
     const collapsiblePanelStyle={width: '100%'};
 
@@ -67,7 +68,7 @@ export function MetaInfo({tbl_id, style, isOpen=false}) {
     const {keywords, links, params, resources, groups} = getTblById(tbl_id);
 
     return (
-        <div className='TablePanel__meta' style={style}>
+        <Stack sx={sx}>
             { !isEmpty(keywords) &&
             <CollapsiblePanel componentKey={tbl_id + '-meta'} header='Table Meta' style={collapsiblePanelStyle} {...{isOpen, contentStyle}}>
                 {keywords.concat()                                             // make a copy so the original array does not mutate
@@ -140,7 +141,7 @@ export function MetaInfo({tbl_id, style, isOpen=false}) {
                 }
             </CollapsiblePanel>
             }
-        </div>
+        </Stack>
     );
 }
 
@@ -152,17 +153,17 @@ export function KeywordBlock({style={}, label, value, title, asLink}) {
     );
 }
 
-export function Keyword({style={}, label, value, title, asLink}) {
+export function Keyword({label, value, title, asLink}) {
     label = label && label + ':';
     if (label || value) {
         value = String(value);
         return (
-            <React.Fragment>
-                {label && <div title={title} className='keyword-label'>{label}</div>}
+            <>
+                {label && <Typography level='title-sm' title={title} mr={1/2}>{label}</Typography>}
                 { asLink ? <LinkTag title={value} href={value} /> :
-                    <ContentEllipsis text={value} style={{padding: 1, margin: 'unset'}}><div title={value} style={{whiteSpace: 'nowrap',...style}} className='keyword-value'>{value}</div></ContentEllipsis>
+                    <ContentEllipsis text={value} style={{padding: 1, margin: 'unset'}}><Typography level='body-xs' title={value} noWrap mr={1/2}>{value}</Typography></ContentEllipsis>
                 }
-            </React.Fragment>
+            </>
         );
     }
     return null;
@@ -173,11 +174,12 @@ export function LinkTag({href, title}) {
     title = title || href;
     if (href) {
         return (
-            <div style={{display: 'inline-flex', alignItems: 'center', overflow: 'hidden'}}>
-                <CopyToClipboard value={href} size={16} buttonStyle={{backgroundColor: 'unset'}}/>
-                <a className='ff-href' style={{padding: '0 3px', verticalAlign: 'middle', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', lineHeight: 1.5}}
-                   href={href} title={title} target='Links'>{title}</a>
-            </div>
+            <Box overflow='hidden'>
+                <Link level='body-xs' sx={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}
+                    href={href} title={title} target='Links'
+                    startDecorator={<CopyToClipboard value={href} size={16} buttonStyle={{backgroundColor: 'unset'}}/>}
+                >{title}</Link>
+            </Box>
         );
     } else return null;
 }

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -1,11 +1,3 @@
-.TablePanel {
-    display: flex;
-    height: 100%;
-    width: 100%;
-    flex-direction: column;
-    overflow: hidden;
-}
-
 .TablePanel__checkbox {
     display: flex;
     height: 100%;
@@ -26,21 +18,6 @@
     align-items: center;
 }
 
-.TablePanel__wrapper {
-    position: relative;
-    background-color: #c8c8c8;
-    padding: 0;
-    flex-grow: 1;
-}
-
-.TablePanel__wrapper--border {
-    position: relative;
-    background-color: #c8c8c8;
-    flex-grow: 1;
-    border: 1px solid #b3b3b3;
-    padding: 0 3px 3px 3px;
-}
-
 .TablePanel__meta {
     display: flex;
     flex-direction: column;
@@ -49,18 +26,6 @@
     background-color: #e6e6e6;
     margin-bottom: 2px;
     padding-bottom: 2px;
-}
-
-.TablePanel__frame {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    z-index: 0;
-}
-.TablePanel__frame:focus {
-    outline: rgb(91, 157, 217) auto 2px;
-    outline-offset: -1px;
 }
 
 .TablePanel__error {
@@ -97,22 +62,6 @@
     background-color: #E3E3E3;
     display: inline-block;
     align-self: start;
-}
-
-.TablePanel__header {
-    white-space: nowrap;
-    height: calc(100% - 1px);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: space-between;
-    padding: 2px;
-    box-sizing: border-box;
-    background-image: linear-gradient(#fff, #dcdcdc);
-}
-
-.TablePanel__header .derived {
-    color: maroon;
 }
 
 .TablePanel__options--small {
@@ -368,372 +317,28 @@
     justify-content: space-between;
 }
 
+/*
+Overriding default fixed-table css
+*/
 
-/** below are taken from FixedDataTable with some modifications */
-
-/**
- * FixedDataTable v0.6.0
- *
- * Copyright (c) 2015, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
-.public_Scrollbar_main.public_Scrollbar_mainActive, .public_Scrollbar_main:hover {
-    background-color: rgba(255, 255, 255, .8)
-}
-
-.public_Scrollbar_mainOpaque, .public_Scrollbar_mainOpaque.public_Scrollbar_mainActive, .public_Scrollbar_mainOpaque:hover {
-    background-color: #fff
-}
-
-.public_Scrollbar_face:after {
-    background-color: #c2c2c2
-}
-
-.public_Scrollbar_main:hover .public_Scrollbar_face:after, .public_Scrollbar_mainActive .public_Scrollbar_face:after, .public_Scrollbar_faceActive:after {
-    background-color: #7d7d7d
-}
-
-.public_fixedDataTable_main, .public_fixedDataTable_header, .public_fixedDataTable_hasBottomBorder {
-    border-color: #b5b5b5
-}
-
-.public_fixedDataTable_header .public_fixedDataTableCell_main {
-    font-weight: 700
-}
-
-.public_fixedDataTable_header, .public_fixedDataTable_header .public_fixedDataTableCell_main {
-    background-color: #f6f7f8;
-    text-align: center;
-}
-
-.public_fixedDataTable_footer .public_fixedDataTableCell_main {
-    background-color: #f6f7f8;
-    border-color: #d3d3d3
-}
-
-.public_fixedDataTable_topShadow {
-    background: 0 0 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAYAAABP2FU6AAAAF0lEQVR4AWPUkNeSBhHCjJoK2twgFisAFagCCp3pJlAAAAAASUVORK5CYII=) repeat-x
-}
-
-.public_fixedDataTable_bottomShadow {
-    background: 0 0 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAECAYAAABP2FU6AAAAHElEQVQI12MwNjZmZdAT1+Nm0JDWEGZQk1GTBgAWkwIeAEp52AAAAABJRU5ErkJggg==) repeat-x
-}
-
-.public_fixedDataTable_horizontalScrollbar .public_Scrollbar_mainHorizontal {
-    background-color: #fff;
-}
-
-.public_fixedDataTableCell_main {
-    border-color: #d3d3d3;
-}
-
-.public_fixedDataTableCell_highlighted {
-    background-color: #f4f4f4
+.fixedDataTableRowLayout_rowWrapper {
+    font-size: 12px;
 }
 
 .public_fixedDataTableCell_cellContent {
-    font-size: 11px;
-    white-space: nowrap;
-    padding: 3px;
-    overflow: hidden;
-    width: 100%;
-    box-sizing: border-box;
+    padding: 2px;
 }
 
-.public_fixedDataTableCell_cellContent.right_align {
-    text-align: right;
+
+.public_fixedDataTable_header, .public_fixedDataTable_scrollbarSpacer, .public_fixedDataTable_header .public_fixedDataTableCell_main {
+    background-image: none;
 }
 
-.public_fixedDataTableCell_columnResizerKnob {
-    background-color: #0284ff
-}
-
-.public_fixedDataTableColumnResizerLine_main {
-    border-color: #0284ff
-}
-
-.public_fixedDataTableRow_main {
-    /*background-color: #fff*/
-}
-
-.public_fixedDataTableRow_highlighted, .public_fixedDataTableRow_highlighted .public_fixedDataTableCell_main {
-}
-
-.public_fixedDataTableRow_fixedColumnsDivider {
-    border-color: #d3d3d3
-}
-
-.public_fixedDataTableRow_columnsShadow {
-    background: 0 0 url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAABCAYAAAD5PA/NAAAAFklEQVQIHWPSkNeSBmJhTQVtbiDNCgASagIIuJX8OgAAAABJRU5ErkJggg==) repeat-y
-}
-
-.ScrollbarLayout_main {
-    box-sizing: border-box;
-    outline: none;
-    overflow: hidden;
-    position: absolute;
-    -webkit-transition-duration: 250ms;
-    transition-duration: 250ms;
-    -webkit-transition-timing-function: ease;
-    transition-timing-function: ease;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none
-}
-
-.ScrollbarLayout_mainVertical {
-    bottom: 0;
-    right: 0;
-    top: 0;
-    -webkit-transition-property: background-color width;
-    transition-property: background-color width;
-    width: 15px
-}
-
-.ScrollbarLayout_mainVertical.public_Scrollbar_mainActive, .ScrollbarLayout_mainVertical:hover {
-    width: 17px
-}
-
-.ScrollbarLayout_mainHorizontal {
-    bottom: 0;
-    height: 15px;
-    left: 0;
-    -webkit-transition-property: background-color height;
-    transition-property: background-color height
-}
-
-.ScrollbarLayout_mainHorizontal.public_Scrollbar_mainActive, .ScrollbarLayout_mainHorizontal:hover {
-    height: 17px
-}
-
-.ScrollbarLayout_face {
-    left: 0;
-    overflow: hidden;
-    position: absolute;
-    z-index: 1
-}
-
-.ScrollbarLayout_face:after {
-    border-radius: 6px;
-    content: '';
-    display: block;
-    position: absolute;
-    -webkit-transition: background-color 250ms ease;
-    transition: background-color 250ms ease
-}
-
-.ScrollbarLayout_faceHorizontal {
-    bottom: 0;
-    left: 0;
-    top: 0
-}
-
-.ScrollbarLayout_faceHorizontal:after {
-    bottom: 4px;
-    left: 0;
-    top: 4px;
-    width: 100%
-}
-
-.ScrollbarLayout_faceVertical {
-    left: 0;
-    right: 0;
-    top: 0
-}
-
-.ScrollbarLayout_faceVertical:after {
-    height: 100%;
-    left: 4px;
-    right: 4px;
-    top: 0
-}
-
-.fixedDataTableCellGroupLayout_cellGroup {
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
-    left: 0;
-    overflow: hidden;
-    position: absolute;
-    top: 0;
-    white-space: nowrap
-}
-
-.fixedDataTableCellGroupLayout_cellGroup > .public_fixedDataTableCell_main {
-    display: inline-block;
-    vertical-align: top;
-    white-space: normal
-}
-
-.fixedDataTableCellGroupLayout_cellGroupWrapper {
-    position: absolute;
-    top: 0
-}
-
-.fixedDataTableCellLayout_main {
-    border-right-style: solid;
-    border-width: 0 1px 0 0;
-    box-sizing: border-box;
-    display: block;
-    overflow: hidden;
-    position: absolute;
-    white-space: normal
-}
-
-.fixedDataTableCellLayout_lastChild {
-    border-width: 0 1px 1px 0
-}
-
-.fixedDataTableCellLayout_alignRight {
-    text-align: right
-}
-
-.fixedDataTableCellLayout_alignCenter {
-    text-align: center
-}
-
-.fixedDataTableCellLayout_wrap1 {
-    display: table
-}
-
-.fixedDataTableCellLayout_wrap2 {
-    display: table-row
-}
-
-.fixedDataTableCellLayout_wrap3 {
-    display: table-cell;
-    vertical-align: middle
-}
-
-.fixedDataTableCellLayout_columnResizerContainer {
-    position: absolute;
-    right: 0;
-    width: 6px;
-    z-index: 1
-}
-
-.fixedDataTableCellLayout_columnResizerContainer:hover {
-    cursor: ew-resize
-}
-
-.fixedDataTableCellLayout_columnResizerContainer:hover .fixedDataTableCellLayout_columnResizerKnob {
-    visibility: visible
-}
-
-.fixedDataTableCellLayout_columnResizerKnob {
-    position: absolute;
-    right: 0;
-    visibility: hidden;
-    width: 4px
-}
-
-.fixedDataTableColumnResizerLineLayout_mouseArea {
-    cursor: ew-resize;
-    position: absolute;
-    right: -5px;
-    width: 12px
-}
-
-.fixedDataTableColumnResizerLineLayout_main {
-    border-right-style: solid;
-    border-right-width: 1px;
-    box-sizing: border-box;
-    position: absolute;
-    z-index: 10
-}
-
-body[dir="rtl"] .fixedDataTableColumnResizerLineLayout_main, .fixedDataTableColumnResizerLineLayout_hiddenElem {
-    display: none !important
-}
-
-.fixedDataTableLayout_main {
-    border-style: solid;
-    border-width: 1px;
-    box-sizing: border-box;
-    overflow: hidden;
-    position: relative
-}
-
-.fixedDataTableLayout_header, .fixedDataTableLayout_hasBottomBorder {
-    border-bottom-style: solid;
-    border-bottom-width: 1px
-}
-
-.fixedDataTableLayout_footer .public_fixedDataTableCell_main {
-    border-top-style: solid;
-    border-top-width: 1px
-}
-
-.fixedDataTableLayout_topShadow, .fixedDataTableLayout_bottomShadow {
-    height: 4px;
-    left: 0;
-    position: absolute;
-    right: 0;
-    z-index: 1
-}
-
-.fixedDataTableLayout_bottomShadow {
-    margin-top: -4px
-}
-
-.fixedDataTableLayout_rowsContainer {
-    overflow: hidden;
-    position: relative;
-    /*background-color: whitesmoke;*/
-}
-
-.fixedDataTableLayout_horizontalScrollbar {
-    bottom: 0;
-    position: absolute;
-    z-index: 1;
-}
-
-.fixedDataTableRowLayout_main {
-    box-sizing: border-box;
-    overflow: hidden;
-    position: absolute;
-    top: 0;
-    border-bottom-style: solid;
-    border-width: 0 0 1px 0;
-    border-color: #d3d3d3;
-}
-
-.fixedDataTableRowLayout_body {
-    left: 0;
-    position: absolute;
-    top: 0
-}
-
-.fixedDataTableRowLayout_fixedColumnsDivider {
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
-    border-left-style: solid;
-    border-left-width: 1px;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 0
-}
-
-.fixedDataTableRowLayout_columnsShadow {
-    width: 4px
-}
-
-.fixedDataTableRowLayout_rowWrapper {
-    position: absolute;
-    top: 0
-}
-
-.fixedDataTableRowLayout_rowWrapper .tablePanel__Row_highlighted div {
+.fixedDataTableRowLayout_main.highlighted div {
     background-color: #ffe8bf !important; /* #d3fad1 */
 }
 
-.fixedDataTableRowLayout_rowWrapper .tablePanel__Row_related div {
+.fixedDataTableRowLayout_main.related div {
     background-color: #faf4e5;
 }
 

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -4,6 +4,7 @@
 
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
+import {Button, Checkbox, Stack, ToggleButtonGroup, Typography} from '@mui/joy';
 import {cloneDeep, get, isEmpty} from 'lodash';
 
 import {setSqlFilter, SqlTableFilter} from './FilterEditor.jsx';
@@ -79,7 +80,7 @@ export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOpt
     const onSqlFilterChanged = ({op, sql}) =>  onChange({sqlFilter: sql ? `${op}::${sql}` : ''});
 
     return (
-        <div className='TablePanelOptions'>
+        <Stack height={1} p={1} pt={0} boxSizing='border-box'>
             <Options {...{uiState, tbl_id, tbl_ui_id, ctm_tbl_id, onOptionReset, onChange}} />
             <OptionsFilterStats tbl_id={ctm_tbl_id}/>
             <StatefulTabs componentKey='TablePanelOptions' defaultSelected={0} borderless={true} useFlex={true} style={{flex: '1 1 0'}}>
@@ -95,19 +96,13 @@ export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOpt
                 }
             </StatefulTabs>
             {showTblPrefMsg && <TablePrefMsg/>}
-            <div style={{margin: '5px 15px 0 0'}}>
-                <button type='button' className='button std' style={{marginRight: 5}}
-                        onClick={onReset}>Reset column selection
-                </button>
-                <button type='button' className='button std' style={{marginRight: 5}}
-                        onClick={onRemoveFilters}>Remove all filters
-                </button>
-                <button type='button' className='button std'
-                        onClick={onClose}>Close
-                </button>
+            <Stack direction='row' mt={1} sx={{'button':{mr:1}}} alignItems='center'>
+                <Button variant='solid' color='primary' onClick={onClose}>Close</Button>
+                <Button onClick={onReset}>Reset column selection</Button>
+                <Button onClick={onRemoveFilters}>Remove all filters</Button>
                 <HelpIcon helpId={'tables.options'} style={{float: 'right', marginTop: 4}}/>
-            </div>
-        </div>
+            </Stack>
+        </Stack>
     );
 });
 
@@ -141,45 +136,46 @@ function Options({uiState, tbl_id, tbl_ui_id, ctm_tbl_id, onOptionReset, onChang
             onChange && onChange({pageSize: pageSize.value});
         }
     };
-
-    const optStyle = {display: 'inline-flex', alignItems: 'center', marginLeft: 5};
-
+    const [value, setValue] = React.useState([
+                                    showUnits && 'showUnits',
+                                    showTypes && 'showTypes',
+                                    showFilters && 'showFilters'
+                                ].filter((v) => v));
     return (
-        <div style={{display: 'inline-flex', justifyContent: 'space-between', marginBottom: 10}}>
-            <div style={{display: 'inline-flex', alignItems: 'center'}}>
-                <div style={{marginLeft: 5, fontWeight: 'bold'}}>Show:</div>
-                {allowUnits &&
-                    <div style={optStyle}>
-                        <input type='checkbox'  checked={showUnits} onChange={(e) => onChange({showUnits: e.target.checked})}/>
-                        Units
-                    </div>
-                }
-                {allowTypes &&
-                    <div style={optStyle}>
-                        <input type='checkbox' checked={showTypes} onChange={(e) => onChange({showTypes: e.target.checked})}/>
-                        Data Type
-                    </div>
-                }
-                <div style={optStyle}>
-                    <input type='checkbox' checked={showFilters} onChange={(e) => onChange({showFilters: e.target.checked})} />
-                    Filters
-                </div>
-            </div>
-            <div>
-                {showPaging && pageSize!==MAX_ROW &&
-                <InputField
-                    validator={intValidator(1,10000)}
-                    tooltip='Set page size'
-                    label='Page Size:'
-                    labelStyle={{...optStyle, fontWeight: 'bold', width: 60}}
-                    size={5}
-                    value={pageSize+''}
-                    onChange={onPageSize}
-                    actOn={['blur','enter']}
-                />
-                }
-            </div>
-        </div>
+        <Stack direction='row' alignItems='center' justifyContent='space-between' mb={1}>
+            <Stack direction='row' spacing={1} alignItems='center'>
+                <Typography level='title-md'>Show/Hide:</Typography>
+                <ToggleButtonGroup
+                    variant='outlined'
+                    value={value}
+                    onChange={(ev, val) => {
+                        setValue(val);
+                        const bname = ev.target?.value;
+                        onChange({[bname]: val.includes(bname)});
+                    }}
+                >
+                    {allowUnits &&
+                    <Button value='showUnits' size='sm'>Units</Button>
+                    }
+                    {allowUnits &&
+                    <Button value='showTypes' size='sm'>Data Type</Button>
+                    }
+                    <Button value='showFilters' size='sm'>Filters</Button>
+                </ToggleButtonGroup>
+            </Stack>
+            {showPaging && pageSize !== MAX_ROW &&
+            <InputField
+                orientation='horizontal'
+                slotProps={{input: {size: 'sm', sx: {width: '5em'}}}}
+                validator={intValidator(1, 10000)}
+                tooltip='Set page size'
+                label='Page Size:'
+                value={pageSize + ''}
+                onChange={onPageSize}
+                actOn={['blur', 'enter']}
+            />
+            }
+        </Stack>
     );
 }
 
@@ -244,8 +240,8 @@ export const ColumnOptions = React.memo(({tbl_id, tbl_ui_id, ctm_tbl_id, onChang
     // filters state are kept in tablemodel
     // the rest of the state are kept in the source table ui data
     const renderers =  {
-                name: {cellRenderer: makeNameRenderer(tbl_id, tbl_ui_id, cmt_tbl_ui_id)},
-                filter:     {cellRenderer: makeFilterRenderer(tbl_id, ctm_tbl_id, onChange)},
+                name:   {cellRenderer: makeNameRenderer(tbl_id, tbl_ui_id, cmt_tbl_ui_id)},
+                filter: {cellRenderer: makeFilterRenderer(tbl_id, ctm_tbl_id, onChange)},
                 // format:  {cellRenderer: makePrecisionRenderer(tbl_ui_id, ctm_tbl_id, onChange)},
                 // null_string:   {cellRenderer: makeNullStringRenderer(tbl_ui_id, ctm_tbl_id, onChange)}
     };
@@ -272,9 +268,9 @@ export const ColumnOptions = React.memo(({tbl_id, tbl_ui_id, ctm_tbl_id, onChang
 function TablePrefMsg() {
 
     return (
-        <div className='TablePanelOptions__pref'>
+        <Typography level='body-sm' fontStyle='italic'>
             Column selection will apply to future searches of this table.
-        </div>
+        </Typography>
     );
 }
 

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import {Button} from '@mui/joy';
 import {get, set} from 'lodash';
 import Enum from 'enum';
 import {replaceExt, updateSet} from '../../util/WebUtil.js';
@@ -175,9 +176,7 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
                             text={'Save'}/>
                     </div>
                     <div>
-                        <button type='button' className='button std hl'
-                                onClick={() => onComplete?.()}>Cancel
-                        </button>
+                        <Button onClick={() => onComplete?.()}>Cancel</Button>
                     </div>
                 </div>
                 <div style={{ textAlign:'right', marginRight: 10}}>

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -125,7 +125,7 @@ function tablesAsTab(tables, tableOptions, expandedMode) {
             };
             return  (
                 <Tab key={tbl_ui_id} name={title} removable={removable} onTabRemove={onTabRemove}>
-                    <TablePanel key={tbl_id} border={false} showTitle={false} {...{tbl_id, tbl_ui_id, ...options, expandedMode}} />
+                    <TablePanel key={tbl_id} border={false} {...{tbl_id, tbl_ui_id, ...options, expandedMode, showTitle: false}} />
                 </Tab>
             );
         } );

--- a/src/firefly/js/ui/CheckboxGroupInputField.jsx
+++ b/src/firefly/js/ui/CheckboxGroupInputField.jsx
@@ -1,5 +1,5 @@
 import React, {memo} from 'react';
-import PropTypes, {object} from 'prop-types';
+import PropTypes, {object, shape} from 'prop-types';
 import {Checkbox, FormControl, FormLabel, Stack, Tooltip} from '@mui/joy';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 import {splitVals} from 'firefly/tables/TableUtil.js';
@@ -16,20 +16,20 @@ function convertValue(value,options) {
     else return value;
 }
 
-export function CheckboxGroupInputFieldView({fieldKey, onChange, label, tooltip:toggleBoxTip,
+export function CheckboxGroupInputFieldView({fieldKey, onChange, label, tooltip:toggleBoxTip, slotProps,
                                              options, alignment:orientation, value:fieldValue, sx}) {
 
     return (
-        <Tooltip title={toggleBoxTip} sx={sx}>
+        <Tooltip title={toggleBoxTip} sx={sx} {...slotProps?.tooltip}>
             <Stack orientation={orientation==='horizontal'?'row':'column'}>
                 {label && (
                     <FormControl>
-                        <FormLabel>{label}</FormLabel>
+                        <FormLabel {...slotProps?.label}>{label}</FormLabel>
                     </FormControl>
                 ) }
                 <Stack spacing={orientation==='vertical'?1:2} direction={orientation==='vertical' ? 'column' : 'row'}>
                     {options.map( ({value,label,tooltip}) => {
-                        const cb= (<Checkbox
+                        const cb= (<Checkbox {...slotProps?.input}
                             {...{ name:fieldKey, key:value, value, checked:isChecked(value,fieldValue), onChange, label, }} />);
                         return tooltip ? <Tooltip {...{title:toggleBoxTip, key:value}}> {cb} </Tooltip> : cb;
                     })}
@@ -48,6 +48,11 @@ CheckboxGroupInputFieldView.propTypes= {
     label:  PropTypes.string,
     tooltip:  PropTypes.string,
     sx: object,
+    slotProps: shape({
+        input: object,
+        label: object,
+        tooltip: object
+    })
 };
 
 
@@ -98,5 +103,6 @@ CheckboxGroupInputField.propTypes= {
     forceReinit:  PropTypes.bool,
     fieldKey:   PropTypes.string,
     sx: object,
+
 };
 

--- a/src/firefly/js/ui/CompleteButton.jsx
+++ b/src/firefly/js/ui/CompleteButton.jsx
@@ -109,7 +109,7 @@ export function CompleteButton ({onFail, onSuccess, groupKey=null, text='OK',
 
     return (
         <div style={style}>
-            <Button {...{size:'sm', variant: primary?'solid':'soft', color: primary?'primary':'neutral', onClick: onComplete}}>{text}</Button>
+            <Button {...{variant: primary?'solid':'soft', color: primary?'primary':'neutral', onClick: onComplete}}>{text}</Button>
         </div>
     );
 }

--- a/src/firefly/js/ui/FireflyRoot.jsx
+++ b/src/firefly/js/ui/FireflyRoot.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {CssBaseline, ScopedCssBaseline, CssVarsProvider, useColorScheme} from '@mui/joy';
+import {CssBaseline, ScopedCssBaseline, CssVarsProvider, useColorScheme, GlobalStyles} from '@mui/joy';
 import {getTheme} from './ThemeSetup.js';
 
 
@@ -13,6 +13,10 @@ export function FireflyRoot({children}) {
     return (
         <CssVarsProvider theme={newTheme}>
             {useBaseline && <CssBaseline/>}
+            <GlobalStyles styles={{
+                    // CSS object styles
+                    html: {fontSize:'87.5%'}
+                }}/>
             <App>{children}</App>
         </CssVarsProvider>
     );

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -144,7 +144,7 @@ FormPanel.propTypes = {
 export function ExtraButton(props) {
     const {text, onClick, style={}} = props;
     return (
-        <Button {...{size:'sm', variant: 'soft', color: 'neutral', onClick}}>{text}</Button>
+        <Button {...{variant: 'soft', color: 'neutral', onClick}}>{text}</Button>
     );
 }
 

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -4,11 +4,10 @@ import {pickBy} from 'lodash';
 import {bool, string, number, object, func, oneOfType, shape, element} from 'prop-types';
 
 
-
 export function InputFieldView(props) {
-    const {visible,disabled, label,tooltip,value,inputRef,
+    const {visible,disabled, label,tooltip,value,inputRef, slotProps,
         valid,onChange, onBlur, onKeyPress, onKeyDown, onKeyUp, showWarning,
-        message, type, placeholder, joyProps, sx, startDecorator, endDecorator,
+        message, type, placeholder, sx, startDecorator, endDecorator,
         readonly, required, orientation='vertical'}= props;
     if (!visible) return null;
     let {form='__ignore'}= props;
@@ -30,9 +29,9 @@ export function InputFieldView(props) {
 
     return (
         <Stack {...{className:'ff-Input InputFieldView', sx}}>
-            <Tooltip {...{title, enterDelay:showErrorTip?700:undefined, ...joyProps?.JoyTooltip}}>
-                <FormControl {...{orientation, error:!valid, ...joyProps?.JoyFormControl}}>
-                    {label && <FormLabel {...joyProps?.JoyFormLabel}>{label}</FormLabel>}
+            <Tooltip {...{title, enterDelay:showErrorTip?700:undefined, ...slotProps?.tooltip}}>
+                <FormControl {...{orientation, error:!valid, ...slotProps?.control}}>
+                    {label && <FormLabel {...slotProps?.label}>{label}</FormLabel>}
                     <Input {...{
                         value: currValue,
                         disabled:readonly,
@@ -40,7 +39,7 @@ export function InputFieldView(props) {
                         startDecorator, endDecorator,
                         type,
                         form,
-                        ...joyProps?.JoyInput,
+                        ...slotProps?.input,
                         placeholder,
                         required,
                         onChange:(ev) => onChange ? onChange(ev) : null,
@@ -55,8 +54,6 @@ export function InputFieldView(props) {
         </Stack>
     );
 }
-
-const joyPropsShape= shape({ sx: object, style: object});
 
 InputFieldView.propTypes= {
     valid   : bool,
@@ -81,11 +78,11 @@ InputFieldView.propTypes= {
     startDecorator: element,
     endDecorator: element,
     sx: object,
-    joyProps : shape({
-        JoyInput: joyPropsShape,
-        JoyFormControl: joyPropsShape,
-        JoyFormLabel: joyPropsShape,
-        JoyTooltip: joyPropsShape,
+    slotProps: shape({
+        input: object,
+        control: object,
+        label: object,
+        tooltip: object
     })
 };
 

--- a/src/firefly/js/ui/PagingBar.jsx
+++ b/src/firefly/js/ui/PagingBar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {Typography, Stack} from '@mui/joy';
 
 import {InputField} from './InputField.jsx';
 import {intValidator} from '../util/Validate.js';
@@ -23,19 +24,17 @@ export function PagingBar(props) {
 
     const pagestr = (totalRows === 0) ? '' :
                     `(${(startIdx+1).toLocaleString()} - ${endIdx.toLocaleString()} of ${totalRows?.toLocaleString()??''})`;
-    const showingLabel = (  <div style={{fontSize: 'smaller', marginLeft: 3, display: 'inline-flex', alignItems: 'center', width: `${3 * nchar + 7}ch`}} >
-                                {pagestr}
-                            </div>
-                        );
+    const showingLabel = (  <Typography level='body-sm' noWrap>{pagestr}</Typography> );
     if (showAll) {
         return showingLabel;
     } else {
         return (
-            <div className='PanelToolbar__group'>
+            <Typography display='flex' alignItems='center' direction='row' level='body-sm' noWrap>
                 <div onClick={() => callbacks.onGotoPage(1)} className='PagingBar__button first' title='First Page'/>
                 <div onClick={() => callbacks.onGotoPage(currentPage - 1)} className='PagingBar__button previous' title='Previous Page'/>
-                <div style={{display: 'inline-flex', alignItems: 'center'}}>
+                <Stack direction='row' alignItems='center' spacing={1/2}>
                     <InputField
+                        slotProps={{ input: { size: 'sm', sx: {width:'3em'} } }}
                         style={{textAlign: 'right', width: `${nchar+1}ch`}}
                         validator = {intValidator(1, totalPages, 'Page Number')}
                         tooltip = 'Jump to this page'
@@ -43,13 +42,13 @@ export function PagingBar(props) {
                         onChange = {onPageChange}
                         actOn={['blur','enter']}
                         showWarning={false}
-                    /> <div style={{fontSize: 'smaller', marginLeft: 3, width: `${nchar + 3}ch`}}> of {totalPages}</div>
-                </div>
+                    /> <div> of {totalPages}</div>
+                </Stack>
                 <div onClick={() => callbacks.onGotoPage(currentPage + 1)} className='PagingBar__button next'  title='Next Page'/>
                 <div onClick={() => callbacks.onGotoPage(totalPages)} className='PagingBar__button last'  title='Last Page'/>
                 {showingLabel}
                 {showLoading ? <img style={{width:14,height:14,marginTop: '3px'}} src={LOADING}/> : false}
-            </div>
+            </Typography>
         );
     }
 }

--- a/src/firefly/js/ui/RadioGroupInputFieldView.jsx
+++ b/src/firefly/js/ui/RadioGroupInputFieldView.jsx
@@ -6,14 +6,14 @@ import React from 'react';
 import {array, string, func, bool, object, oneOf, shape, oneOfType, element} from 'prop-types';
 
 
-function makeRadioGroup(options,orientation='horizontal',radioValue,onChange,radioTooltip,joyProps={}) {
+function makeRadioGroup(options,orientation='horizontal',radioValue,onChange,radioTooltip,slotProps={}) {
 
     return (
-        <RadioGroup {...{orientation, ...joyProps.JoyRadioGroup}}>
+        <RadioGroup {...{orientation, ...slotProps.group}}>
             {
                 options.map( ({label,value, disabled=false,tooltip }) => {
                     const radio= (<Radio
-                        {...{ key:value, checked:value===radioValue, onChange, value, label, disabled, ...joyProps.JoyRadio }} />);
+                        {...{ key:value, checked:value===radioValue, onChange, value, label, disabled, ...slotProps.radio }} />);
                     if (tooltip) {
                         return (
                             <Tooltip {...{key:value, title:tooltip ?? radioTooltip, placement:'top'}}>
@@ -32,17 +32,17 @@ function makeRadioGroup(options,orientation='horizontal',radioValue,onChange,rad
 
 
 
-function createButtons(options, joyProps={}) {
+function createButtons(options, slotProps={}) {
     return options.map(({value, disabled, tooltip, icon, label, startDecorator, endDecorator}, idx) => {
         let b;
         if (icon) {
-            b = (<IconButton {...{key: idx + '', value, disabled: disabled || false, ...joyProps.JoyIconButton}}>
+            b = (<IconButton {...{key: idx + '', value, disabled: disabled || false, ...slotProps.icon}}>
                 {icon}
             </IconButton>);
         } else {
             b = (<Button {...{key: idx + '', value, disabled: disabled || false,
                 startDecorator, endDecorator,
-                sx: {'--Button-minHeight' : 25}, ...joyProps.JoyButton}} >
+                sx: {'--Button-minHeight' : 25}, ...slotProps.button}} >
                 {label}
             </Button>);
         }
@@ -54,13 +54,13 @@ function fireOnChange(groupValue,newValue,onChange) {
     if (newValue && newValue!==groupValue) onChange({target: {value: newValue}});
 }
 
-function makeButtonGroup(options,groupValue,onChange,joyProps={}) {
+function makeButtonGroup(options,groupValue,onChange,slotProps={}) {
     return (
-        <ToggleButtonGroup {...{sz:'sm', value: groupValue,
+        <ToggleButtonGroup {...{value: groupValue,
             sx: {maxHeight: 25},
-            ...joyProps.JoyToggleButtonGroup,
+            ...slotProps.buttonGroup,
             onChange: (ev, newValue) => fireOnChange(groupValue,newValue,onChange) }}>
-            { createButtons(options,joyProps) }
+            { createButtons(options,slotProps) }
         </ToggleButtonGroup>
     );
 }
@@ -68,25 +68,23 @@ function makeButtonGroup(options,groupValue,onChange,joyProps={}) {
 export function RadioGroupInputFieldView({options,orientation='vertical',value,
                                              onChange,label,tooltip,
                                              buttonGroup= false,
-                                             sx, joyProps={}}) {
+                                             sx, slotProps={}}) {
 
     return (
-        <Box sx={sx}>
-            <Tooltip {...{key:value, title:tooltip, ...joyProps.JoyTooltip}}>
+        <Box className='ff-Input' sx={sx}>
+            <Tooltip {...{key:value, title:tooltip, ...slotProps.tooltip}}>
                 <FormControl orientation={orientation} style={{whiteSpace:'nowrap'}}>
-                    {label && <FormLabel {...{...joyProps.JoyFormLabel}}>{label}</FormLabel>}
+                    {label && <FormLabel {...{...slotProps.label}}>{label}</FormLabel>}
                     <Stack direction='row'>
                         {buttonGroup ?
-                            makeButtonGroup(options,value,onChange,joyProps) :
-                            makeRadioGroup(options,orientation,value,onChange,tooltip,joyProps)}
+                            makeButtonGroup(options,value,onChange,slotProps) :
+                            makeRadioGroup(options,orientation,value,onChange,tooltip,slotProps)}
                     </Stack>
                 </FormControl>
             </Tooltip>
         </Box>
     );
 }
-
-const joyPropsShape= shape({ sx: object, style: object});
 
 RadioGroupInputFieldView.propTypes= {
     options: array.isRequired,
@@ -98,12 +96,12 @@ RadioGroupInputFieldView.propTypes= {
     inline : bool,
     sx: object,
     buttonGroup : bool,
-    joyProps : shape({
-        JoyRadioGroup: joyPropsShape,
-        JoyRadio: joyPropsShape,
-        JoyButton: joyPropsShape,
-        JoyIconButton : joyPropsShape,
-        JoyToggleButtonGroup: joyPropsShape,
-        JoyTooltip: joyPropsShape
+    slotProps: shape({
+        group: object,
+        radio: object,
+        button: object,
+        icon : object,
+        buttonGroup: object,
+        tooltip: object
     })
 };

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -125,7 +125,7 @@ const SizeInputFieldView= (props) => {
 
     return (
         <Stack sx={sx}>
-            <FormControl orientation='vertical' size='sm'>
+            <FormControl orientation='vertical'>
                 {label && <FormLabel>{label}</FormLabel>}
                 <Stack spacing={1} direction='row'>
                     <InputFieldView {...{

--- a/src/firefly/js/ui/SuggestBoxInputField.jsx
+++ b/src/firefly/js/ui/SuggestBoxInputField.jsx
@@ -1,5 +1,5 @@
 import React, {memo, PureComponent} from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, {object, shape} from 'prop-types';
 import ReactDOM from 'react-dom';
 import {get, isArray, isUndefined, debounce} from 'lodash';
 import {dispatchHideDialog, dispatchShowDialog, isDialogVisible} from '../core/ComponentCntlr.js';
@@ -260,7 +260,7 @@ export class SuggestBoxInputFieldView extends PureComponent {
     render() {
 
         const {displayValue, valid, message, highlightedIdx, isOpen, inputWidth, suggestions, mouseTrigger } = this.state;
-        const {label, tooltip, inline, renderSuggestion, wrapperStyle, placeholder, sx,
+        const {label, tooltip, inline, renderSuggestion, wrapperStyle, placeholder, slotProps={},
             popStyle, popupIndex, readonly=false, required=false} = this.props;
 
         const leftOffset = 0;
@@ -298,7 +298,7 @@ export class SuggestBoxInputFieldView extends PureComponent {
                     message, label, tooltip, readonly, required,
                     onBlur: () => isOpen && this.changeValue(undefined),
                     endDecorator: this.props.endDecorator,
-                    joyProps: { JoyTooltip: {placement: 'right'} }
+                    slotProps: { tooltip: {placement: 'right'}, ...slotProps }
                 }} />
             </div>
         );
@@ -325,7 +325,14 @@ SuggestBoxInputFieldView.propTypes = {
     message: PropTypes.string,
     readonly: PropTypes.bool,
     validator: PropTypes.func,
-    required: PropTypes.bool
+    required: PropTypes.bool,
+    slotProps: shape({
+        input: object,
+        control: object,
+        label: object,
+        tooltip: object
+    })
+
 };
 
 

--- a/src/firefly/js/ui/ThemeSetup.js
+++ b/src/firefly/js/ui/ThemeSetup.js
@@ -1,61 +1,46 @@
 import {extendTheme} from '@mui/joy';
 
+
 export function getTheme() {
     return extendTheme({
         components: {
             JoyButton: {
                 defaultProps: {
-                    size:'sm' ,
                     variant:'soft' ,
                     color:'neutral'
                 }
             },
             JoyInput: {
-                defaultProps: { size:'sm' }
+                styleOverrides: {
+                    root: {
+                        minHeight: '1.75rem',
+                    },
+                },
             },
             JoyIconButton: {
                 defaultProps: {
-                    size:'sm' ,
                     variant:'plain',
                     color:'neutral',
                 }
             },
-            JoyFormControl: {
-                defaultProps: { size:'sm' }
-            },
             JoyFormLabel: {
-                // styleOverrides: {
-                //     root: ({theme}) => ({lineHeight:'50px'})
+                // defaultProps: {
+                //     sx : {
+                //         '--FormLabel-lineHeight' : 1.1
+                //     }
                 // }
-                defaultProps: {
-                    size:'sm',
-                    sx : {
-                        '--FormLabel-lineHeight' : 1.1
-                    }
-                }
-            },
-            JoySelect: {
-                defaultProps: { size:'sm' }
-            },
-            JoyRadio: {
-                defaultProps: { size:'sm' }
             },
             JoyRadioGroup: {
                 defaultProps: {
-                    size:'sm',
                     sx : {
                         '--unstable_RadioGroup-margin': '0.2rem 0 0.2rem 0'
                     }
                 },
             },
             JoyCheckbox: {
-                defaultProps: {
-                    size:'sm',
-                },
             },
             JoyToggleButtonGroup: {
                 defaultProps: {
-                    color:'primary',
                     variant:'soft',
                 },
             },
@@ -65,6 +50,7 @@ export function getTheme() {
                     enterDelay:1500,
                     placement: 'bottom-start',
                     arrow: true,
+
                 }
 
             },

--- a/src/firefly/js/ui/tap/ObsCoreExposureDuration.jsx
+++ b/src/firefly/js/ui/tap/ObsCoreExposureDuration.jsx
@@ -221,7 +221,7 @@ function ExposureLength({initArgs, panelActive, turnOnPanel}) {
 
 
     return (
-        <FormControl {...{orientation:'vertical', size:'sm'}}>
+        <FormControl {...{orientation:'vertical'}}>
             <FormLabel>Exposure Duration</FormLabel>
             <Stack direction='row' spacing={1} alignItems='center'>
                 <ValidationField {...{

--- a/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
+++ b/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
@@ -43,7 +43,7 @@ export function TableColumnsConstraintsToolbar({columnsModel}) {
 
     const resetButton = () => {
         return (
-            <Button variant='soft' color='neutral' size='sm'
+            <Button variant='soft' color='neutral'
                     title='Reset Column Selections & Constraints to the default columns and no constraints'
                     onClick={ () => {
                         const tblModel = reorganizeTableModel(columnsModel, COLS_TO_DISPLAY_FIRST, true);
@@ -57,7 +57,7 @@ export function TableColumnsConstraintsToolbar({columnsModel}) {
     return (
         <Stack direction='row' alignItems='center' spacing={1}>
             {!error && filterCount > 0 &&
-            <Button variant='soft' color='neutral' size='sm'
+            <Button variant='soft' color='neutral'
                     title='Remove column table filters to make all columns visible'
                     onClick={() => dispatchTableFilter({tbl_id: tableModel.tbl_id, filters: ''})}>
                 Remove

--- a/src/firefly/js/visualize/iv/ExpandedTools.jsx
+++ b/src/firefly/js/visualize/iv/ExpandedTools.jsx
@@ -134,7 +134,7 @@ export function PagingControl({viewerItemIds,activeItemId,isPagingMode,getItemTi
         const tip= active ? pTitle('Active Plot: ', getItemTitle(plotId)) : pTitle('Display: ', getItemTitle(plotId));
         return (
                 <Tooltip title={tip} key={idx} >
-                    <IconButton sz='sm' onClick={() => !active && onActiveItemChange(plotId)}
+                    <IconButton onClick={() => !active && onActiveItemChange(plotId)}
                                 sx={{minHeight:5, minWidth:5, p:'2px'}}>
                         <img src={active ? ACTIVE_DOT : INACTIVE_DOT}/>
                     </IconButton>
@@ -149,7 +149,7 @@ export function PagingControl({viewerItemIds,activeItemId,isPagingMode,getItemTi
         <Stack {...{direction:'column', alignItems:'center', sx:{button:{minHeight:10}} }}>
             <Stack {...{direction:'row', alignItems:'center'}}>
                 <Tooltip title={leftTip}>
-                    <Button {...{size:'sm', variant:'plain', color:'neutral',
+                    <Button {...{variant:'plain', color:'neutral',
                         onClick:() => onActiveItemChange(viewerItemIds[prevIdx]),
                         startDecorator:(<img src={PAGE_LEFT}/>)}}>
                         <span style={{maxWidth:'8em', textOverflow:'ellipsis', overflow:'hidden'}}>
@@ -159,7 +159,7 @@ export function PagingControl({viewerItemIds,activeItemId,isPagingMode,getItemTi
                 </Tooltip>
                 <div style={{flex: '1 1 auto'}}/>
                 <Tooltip title={rightTip}>
-                    <Button {...{size:'sm', variant:'plain', color:'neutral',
+                    <Button {...{variant:'plain', color:'neutral',
                         onClick:() => onActiveItemChange(viewerItemIds[nextIdx]),
                         endDecorator:(<img src={PAGE_RIGHT}/>)}}>
                         <span style={{maxWidth:'5em', textOverflow:'ellipsis', overflow:'hidden'}}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,6 +1528,16 @@
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.2.1.tgz#9403f51c17cae37edf870c6bc0c81c1ece5ccef8"
   integrity sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA==
 
+"@reduxjs/toolkit@^1.5.1":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.7.tgz#7fc07c0b0ebec52043f8cb43510cf346405f78a6"
+  integrity sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==
+  dependencies:
+    immer "^9.0.21"
+    redux "^4.2.1"
+    redux-thunk "^2.4.2"
+    reselect "^4.1.8"
+
 "@remix-run/router@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.13.0.tgz#7e29c4ee85176d9c08cb0f4456bff74d092c5065"
@@ -3567,14 +3577,16 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-fixed-data-table-2@~1.2:
-  version "1.2.22"
-  resolved "https://registry.yarnpkg.com/fixed-data-table-2/-/fixed-data-table-2-1.2.22.tgz#2bfb68100697da54fc22b3af8baeb2bba1e42583"
-  integrity sha512-JAw8Dae1kEDrGrmCT9P7fByHOhudbSb0ajTvtWKnyyAh+lqQ5PnDaTDGDI1fDFDPSdI/tHBKvfsI0d7X7LG8fw==
+fixed-data-table-2@~2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fixed-data-table-2/-/fixed-data-table-2-2.0.4.tgz#dce897b95d7e78fdb1089a39b0d2dca2e6df0225"
+  integrity sha512-LK9PCOZivJmfAbmCvWtkDqNUfxRmLzGuEHiczNxse1iVw1c7XuM9uRky3rrxYuKnOC4nbNGomX/1WcX3xxcw8g==
   dependencies:
+    "@reduxjs/toolkit" "^1.5.1"
     lodash "^4.17.4"
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
+    react-portal "^4.2.1"
     redux "^4.0.1"
     reselect "^4.0.0"
 
@@ -4002,6 +4014,11 @@ ignore@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
   integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+
+immer@^9.0.21:
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 immutability-helper@~3.1:
   version "3.1.1"
@@ -5994,7 +6011,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1, prop-types@~15.8:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1, prop-types@~15.8:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6185,6 +6202,13 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-portal@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.2.2.tgz#bff1e024147d6041ba8c530ffc99d4c8248f49fa"
+  integrity sha512-vS18idTmevQxyQpnde0Td6ZcUlv+pD8GTyR42n3CHUQq9OHi1C4jDE4ZWEbEsrbrLRhSECYiao58cvocwMtP7Q==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-resizable@^3.0.4:
   version "3.0.5"
@@ -6399,12 +6423,12 @@ redux-saga@~1.1:
   dependencies:
     "@redux-saga/core" "^1.1.3"
 
-redux-thunk@~2.4:
+redux-thunk@^2.4.2, redux-thunk@~2.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
   integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
 
-redux@^4.0.1, redux@^4.0.4:
+redux@^4.0.1, redux@^4.0.4, redux@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
@@ -6577,7 +6601,7 @@ requizzle@^0.2.3:
   dependencies:
     lodash "^4.17.21"
 
-reselect@^4.0.0:
+reselect@^4.0.0, reselect@^4.1.8:
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1356

Also:
- Add theme to API mode
- Scale down theme's font-size to our preferred size to avoid customizing every component's size.


What is converted…
- table and table toolbar
- table save dialog
- Add a column dialog
    - Including Expression Creator (search icon in Expression field)
- Table Info dialog
- Table Options dialog
    - both Column Options and Advanced Filter

What is not converted..
- TabPanel
- InputAreaField (Advanced Filter Dialog)
- CollapsiblePanel

Issues need resolving…
- Need to establish what is the default non-primary button should be
    - the current default is  too light, it bleeds into the background.
    - I suggest using ‘solid’ for dialog (ok/cancel) and ‘outlined’ for all others
- RadioGroupInputField label’s uses wrong font-family.
- InputField:  why label is one size down?
    - e.g. if size is ‘md’, label is ‘sm’.
- Standardize on..
    - Variant usage
    - Typography level
    - Color usage

To test: https://fireflydev.ipac.caltech.edu/firefly-1356-joyui-table/firefly
- Load a table, see the appearance of the new table.
- Click on every table's toolbar button to ensure they are also modified

Then, test API mode: https://fireflydev.ipac.caltech.edu/firefly-1356-joyui-table/firefly/test/tests-table.html
