### PR TITLE
FIREFLY-1355: Convert TabPanel to Joy UI

### DIFF
--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -58,7 +58,7 @@ function MetaContent({tbl_id}) {
 }
 
 
-export function MetaInfo({tbl_id, sx, isOpen=false}) {
+export function MetaInfo({tbl_id, isOpen=false, ...props}) {
     const contentStyle={display: 'flex', flexDirection: 'column', overflow: 'hidden', paddingBottom: 1};
     const collapsiblePanelStyle={width: '100%'};
 
@@ -68,7 +68,7 @@ export function MetaInfo({tbl_id, sx, isOpen=false}) {
     const {keywords, links, params, resources, groups} = getTblById(tbl_id);
 
     return (
-        <Stack sx={sx}>
+        <Stack {...props}>
             { !isEmpty(keywords) &&
             <CollapsiblePanel componentKey={tbl_id + '-meta'} header='Table Meta' style={collapsiblePanelStyle} {...{isOpen, contentStyle}}>
                 {keywords.concat()                                             // make a copy so the original array does not mutate
@@ -161,7 +161,7 @@ export function Keyword({label, value, title, asLink}) {
             <>
                 {label && <Typography level='title-sm' title={title} mr={1/2}>{label}</Typography>}
                 { asLink ? <LinkTag title={value} href={value} /> :
-                    <ContentEllipsis text={value} style={{padding: 1, margin: 'unset'}}><Typography level='body-xs' title={value} noWrap mr={1/2}>{value}</Typography></ContentEllipsis>
+                    <ContentEllipsis text={value} sx={{p: '1px', margin: 'unset'}}><Typography level='body-xs' title={value} noWrap mr={1/2}>{value}</Typography></ContentEllipsis>
                 }
             </>
         );

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -335,6 +335,12 @@ Overriding default fixed-table css
     font-weight: unset;
 }
 
+.fixedDataTableLayout_main {
+    border-bottom: none;
+    border-left: none;
+    border-right: none;
+}
+
 .fixedDataTableRowLayout_main.highlighted div {
     background-color: #ffe8bf !important; /* #d3fad1 */
 }

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -3,8 +3,8 @@
  */
 
 import React, {useEffect} from 'react';
-import {Box, Link, Stack, Typography, Sheet} from '@mui/joy';
-import PropTypes from 'prop-types';
+import {Box, Stack, Typography, Sheet, Chip} from '@mui/joy';
+import PropTypes, {object, shape} from 'prop-types';
 import {defer, truncate, get, set} from 'lodash';
 import {getAppOptions, getSearchActions} from '../../core/AppDataCntlr.js';
 import {ActionsDropDownButton, isTableActionsDropVisible} from '../../ui/ActionsDropDownButton.jsx';
@@ -56,8 +56,7 @@ const TT_PROPERTY_SHEET = 'Show details for the selected row';
 
 export const TBL_CLZ_NAME = 'FF-Table';
 
-export function TablePanel(props) {
-    let {tbl_id, tbl_ui_id, tableModel, sx, ...options} = props;
+export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', sx, slotProps, ...options}) {
     tbl_id = tbl_id || tableModel?.tbl_id || uniqueTblId();
     tbl_ui_id = tbl_ui_id || `${tbl_id}-ui`;
 
@@ -94,16 +93,16 @@ export function TablePanel(props) {
     if ([TBL_STATE.ERROR,TBL_STATE.LOADING].includes(tstate))  return <NotReady {...{showTitle, tbl_id, title, removable, backgroundable, error}}/>;
 
     return (
-        <Box sx={sx} position='relative' width={1} height={1}>
+        <Sheet {...{variant, sx:{boxSizing: 'border-box', position:'relative', width:1, height:1, ...sx}, ...slotProps?.tablePanel}}>
             <Stack height={1}>
-                {showMetaInfo && <MetaInfo tbl_id={tbl_id} /> }
+                {showMetaInfo && <MetaInfo tbl_id={tbl_id} {...slotProps?.meta}/> }
                 <Stack className={TBL_CLZ_NAME} flexGrow={1}
                        onClick={stopPropagation}
                        onTouchStart={stopPropagation}
                        onMouseDown={stopPropagation}
                 >
-                    <ToolBar {...{tbl_id, tbl_ui_id, connector, tblState}}/>
-                    <Box flexGrow={1}>
+                    <ToolBar {...{tbl_id, tbl_ui_id, connector, tblState, slotProps}}/>
+                    <Box flexGrow={1} {...slotProps?.table}>
                         <BasicTableView
                             callbacks={connector}
                             { ...{columns, data, hlRowIdx, rowHeight, rowHeightGetter, selectable, showUnits,
@@ -114,7 +113,7 @@ export function TablePanel(props) {
                     </Box>
                 </Stack>
             </Stack>
-        </Box>
+        </Sheet>
     );
 }
 
@@ -199,7 +198,15 @@ TablePanel.propTypes = {
             headRenderer: PropTypes.func
         })
     ),
-    rowHeightGetter: PropTypes.func
+    rowHeightGetter: PropTypes.func,
+    sx: PropTypes.object,
+    slotProps: shape({
+        tablePanel: object,
+        meta: object,
+        toolbar: object,
+        table: object
+    })
+
 };
 
 TablePanel.defaultProps = {
@@ -223,7 +230,7 @@ TablePanel.defaultProps = {
     border: true,
 };
 
-function ToolBar({tbl_id, tbl_ui_id, connector, tblState}) {
+function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
 
     const uiState = useStoreConnector(() => getTableUiById(tbl_ui_id) || {columns:[]}, [tbl_ui_id]);
     const searchActions= getSearchActions();
@@ -276,7 +283,7 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState}) {
     if (!showToolbar) return null;
 
     return (
-        <Sheet component={Stack} variant='soft' className='FF-Table-Toolbar' direction='row' justifyContent='space-between' width={1}>
+        <Sheet component={Stack} variant='soft' className='FF-Table-Toolbar' direction='row' justifyContent='space-between' width={1} {...slotProps?.toolbar}>
             <LeftToolBar {...{tbl_id, title, removable, showTitle, leftButtons}}/>
             {showPaging && <PagingBar {...{currentPage, pageSize, showLoading, totalRows, callbacks:connector}} /> }
             <Stack direction='row' alignItems='center'>
@@ -355,14 +362,15 @@ function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons}) {
 
 function Title({title, removable, tbl_id}) {
     return (
-        <Sheet component={Stack} direction='row' alignSelf='start' sx={{ml:1/4}}>
+        <Stack direction='row' alignSelf='start' sx={{ml:1/4}}>
             <Typography level='body-sm' noWrap title={title}>{truncate(title)}</Typography>
             {removable &&
-            <Link className='btn-close'
+            <Chip variant='soft'
                  title='Remove Tab'
-                 onClick={() => dispatchTableRemove(tbl_id)}/>
+                  onClick={() => dispatchTableRemove(tbl_id)}
+            >x</Chip>
             }
-        </Sheet>
+        </Stack>
     );
 }
 

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -5,7 +5,7 @@
 import React, {useRef, useCallback, useState, useEffect} from 'react';
 import {Cell} from 'fixed-data-table-2';
 import {set, get, omit, isEmpty, isString, toNumber} from 'lodash';
-import {Typography, Checkbox, Stack, Box, Link, Sheet} from '@mui/joy';
+import {Typography, Checkbox, Stack, Box, Link, Sheet, Button} from '@mui/joy';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
 import {
@@ -323,7 +323,7 @@ function findTableFor(element) {
     return cEl;
 }
 
-export function ContentEllipsis({children, text, style={}, actions=[]}) {
+export function ContentEllipsis({children, text, sx, actions=[]}) {
 
     const [hasActions, setHasActions] = useState(false);
     const actionsEl = useRef(null);
@@ -349,12 +349,13 @@ export function ContentEllipsis({children, text, style={}, actions=[]}) {
         hideDropDown(dropDownID);
     };
 
+    const buttonProps = {variant:'plain', size:'sm', fullWidth:true, color:'neutral', sx:{whiteSpace:'nowrap'}};
     const dropDown =  (
-        <div className='Actions__dropdown'>
-            <div className='Actions__item' onClick={copyCB}>Copy to clipboard</div>
-            <div className='Actions__item' onClick={viewAsText}>View as plain text</div>
-            {actions?.map((text, action) => <div className='Actions__item' onClick={action}>{text}</div>)}
-        </div>
+        <Stack p={1/4} spacing={1/4}>
+            <Button {...buttonProps} onClick={copyCB}>Copy to clipboard</Button>
+            <Button {...buttonProps} onClick={viewAsText}>View as plain text</Button>
+            {actions?.map((text, action) => <Button {...buttonProps} onClick={action}>{text}</Button>)}
+        </Stack>
     );
 
     const checkOverflow = (ev) => {
@@ -364,10 +365,20 @@ export function ContentEllipsis({children, text, style={}, actions=[]}) {
     };
 
     return (
-        <div onMouseEnter={checkOverflow} onMouseLeave={() => setHasActions(false)} style={{display: 'flex', position: 'relative', overflow: 'hidden', ...style}}>
+        <Stack direction='row'  overflow='hidden' alignItems='center' sx={sx}
+               onMouseEnter={checkOverflow} onMouseLeave={() => setHasActions(false)}
+        >
             {React.Children.only(children)}
-            {hasActions && <div ref={actionsEl} className='Actions__anchor clickable' style={style} onClick={onActionsClicked} title='Display full cell contents'>&#x25cf;&#x25cf;&#x25cf;</div>}
-        </div>
+            {hasActions &&
+                <Link ref={actionsEl}
+                      variant='soft'
+                      level='body-xs'
+                      underline='none'
+                      sx={{position: 'absolute', right:1}}
+                      onClick={onActionsClicked} title='Display full cell contents'
+                >&#x25cf;&#x25cf;&#x25cf;</Link>
+            }
+        </Stack>
     );
 }
 

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -8,7 +8,7 @@ import {isEmpty, get} from 'lodash';
 
 import * as TblUtil from '../TableUtil.js';
 import {TablePanel} from './TablePanel.jsx';
-import {TabsView, Tab} from '../../ui/panel/TabPanel.jsx';
+import {Tab, TabPanel} from '../../ui/panel/TabPanel.jsx';
 import {dispatchTableRemove, dispatchActiveTableChanged} from '../TablesCntlr.js';
 import {hashCode} from '../../util/WebUtil.js';
 
@@ -96,10 +96,11 @@ function StandardView(props) {
     } else {
         const uid = hashCode(keys.join());
         return (
-            <TabsView key={uid} style={{height: '100%', width: '100%', ...style}} defaultSelected={activeIdx}
+            <TabPanel key={uid} sx={style} value={activeIdx}
+                      slotProps={{ tabPanel:{sx:{p:0}} }}
                       onTabSelect={onTabSelect} resizable={true} showOpenTabs={true} tabId={'TableContainers-' + (tbl_group||'main')}>
                 {tablesAsTab(tables, tableOptions, expandedMode)}
-            </TabsView>
+            </TabPanel>
         );
     }
 }
@@ -110,7 +111,7 @@ function SingleTable({table, tableOptions, expandedMode}) {
     options = Object.assign({}, options, tableOptions);
 
     return  (
-        <TablePanel key={tbl_id} border={true} {...{title, removable, tbl_id, tbl_ui_id, ...options, expandedMode}} />
+        <TablePanel key={tbl_id} {...{title, removable, tbl_id, tbl_ui_id, ...options, expandedMode}} />
     );
 }
 
@@ -124,8 +125,10 @@ function tablesAsTab(tables, tableOptions, expandedMode) {
                 dispatchTableRemove(tbl_id);
             };
             return  (
-                <Tab key={tbl_ui_id} name={title} removable={removable} onTabRemove={onTabRemove}>
-                    <TablePanel key={tbl_id} border={false} {...{tbl_id, tbl_ui_id, ...options, expandedMode, showTitle: false}} />
+                <Tab key={tbl_ui_id} label={title} removable={removable} onTabRemove={onTabRemove}>
+                    <TablePanel key={tbl_id}
+                                slotProps={{ toolbar:{variant:'plain'}, tablePanel:{variant: 'plain'} }}
+                                {...{tbl_id, tbl_ui_id, ...options, expandedMode, showTitle: false}} />
                 </Tab>
             );
         } );

--- a/src/firefly/js/ui/DialogRootContainer.jsx
+++ b/src/firefly/js/ui/DialogRootContainer.jsx
@@ -1,7 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {Sheet} from '@mui/joy';
+import {Sheet, Stack} from '@mui/joy';
 import React, {memo, useEffect, useState, PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import {createRoot} from 'react-dom/client';
@@ -54,7 +54,7 @@ export function showDropDown({id='',content, style={}, atElRef, locDir, wrapperS
     reactRoots.set(divElement,root);
 
     const rootZindex= atElRef && computeZIndex(atElRef);
-    if (rootZindex) ddDiv.style.zIndex= rootZindex;
+    if (rootZindex) ddDiv.style.zIndex ??= rootZindex;
     root.render(
         <FireflyRoot>
             <DropDown {...{id, content, style, atElRef, locDir, boxEl}}/>
@@ -113,10 +113,7 @@ function DropDown ({id, content, style={}, locDir, atElRef, boxEl}) {
 
     const myStyle = Object.assign({ backgroundColor: '#FBFBFB',
             ...pos,
-            padding: 3,
             boxShadow: '#c1c1c1 1px 1px 5px 0px',
-            borderRadius: '0 3px',
-            border: '1px solid #c1c1c1',
             position: 'absolute'},
         style);
     const stopEvent = (e) => {
@@ -125,9 +122,9 @@ function DropDown ({id, content, style={}, locDir, atElRef, boxEl}) {
     };
 
     return (
-        <div className='rootStyle' style={myStyle} onClick={stopEvent}>
+        <Stack style={myStyle} onClick={stopEvent}>
             {content}
-        </div>
+        </Stack>
     );
 }
 

--- a/src/firefly/js/ui/MultiSearchPanel.jsx
+++ b/src/firefly/js/ui/MultiSearchPanel.jsx
@@ -11,6 +11,7 @@ import {CatalogSelectViewPanel} from 'firefly/visualize/ui/CatalogSelectViewPane
 import {FileUploadDropdown} from 'firefly/ui/FileUploadDropdown.jsx';
 import {getAppOptions} from 'firefly/api/ApiUtil.js';
 import {dispatchComponentStateChange} from 'firefly/core/ComponentCntlr.js';
+import {Sheet, Stack, Typography} from '@mui/joy';
 
 const multiSearchComponents= [
     {
@@ -85,19 +86,17 @@ export function setMultiSearchPanelTab(setId) {
 export function MultiSearchPanel({initArgs={}}) {
 
     return (
-        <div style={{padding: '15px 5px 0 5px', flex:'1 1 0', position:'relative'}}>
-            <div style={{fontSize:'large', fontWeight: 'bold', position:'absolute', left: 5, top: 6, alignSelf: 'center' }}>
+        <Stack flexGrow={1}>
+            <Typography color='neutral' level='h3'>
                 Table Search
-            </div>
-            <StatefulTabs componentKey='MultiCatalogTabs' defaultSelected={getDefTabIdx(initArgs)}
-                          borderless={true} useFlex={true} style={{flex: '1 1 0', height: '100%'}}
-                          label={<div style={{paddingLeft: 150}}/>}>
+            </Typography>
+            <StatefulTabs componentKey='MultiCatalogTabs' defaultSelected={getDefTabIdx(initArgs)}>
                 {getComponentAry().map( ({id, title,tip,Component}) => (
-                    <Tab name={tip} id={id} key={id} label={makeTabLabel(title)}>
+                    <Tab name={tip} id={id} key={id} label={title}>
                         <Component initArgs={initArgs}/>
                     </Tab>
                 )) }
             </StatefulTabs>
-        </div>
+        </Stack>
     );
 }

--- a/src/firefly/js/ui/PagingBar.jsx
+++ b/src/firefly/js/ui/PagingBar.jsx
@@ -24,12 +24,12 @@ export function PagingBar(props) {
 
     const pagestr = (totalRows === 0) ? '' :
                     `(${(startIdx+1).toLocaleString()} - ${endIdx.toLocaleString()} of ${totalRows?.toLocaleString()??''})`;
-    const showingLabel = (  <Typography level='body-sm' noWrap>{pagestr}</Typography> );
+    const showingLabel = (  <Typography level='body-sm' noWrap lineHeight={2}>{pagestr}</Typography> );
     if (showAll) {
         return showingLabel;
     } else {
         return (
-            <Typography display='flex' alignItems='center' direction='row' level='body-sm' noWrap component='div'>
+            <Typography component='div' display='flex' alignItems='center' direction='row' level='body-sm' noWrap>
                 <div onClick={() => callbacks.onGotoPage(1)} className='PagingBar__button first' title='First Page'/>
                 <div onClick={() => callbacks.onGotoPage(currentPage - 1)} className='PagingBar__button previous' title='Previous Page'/>
                 <Stack direction='row' alignItems='center' spacing={1/2}>

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -32,6 +32,7 @@ import {
 import {SectionTitle, AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
 import {useFieldGroupMetaState} from '../SimpleComponent.jsx';
 import {PREF_KEY} from 'firefly/tables/TablePref.js';
+import {Box} from '@mui/joy';
 
 
 
@@ -168,7 +169,7 @@ export function TapSearchPanel({initArgs= {}, titleOn=true}) {
     };
 
     return (
-        <div style={{width: '100%'}}>
+        <Box width={1} height={1}>
             <ConstraintContext.Provider value={ctx}>
                 <FormPanel  inputStyle = {{display: 'flex', flexDirection: 'column', backgroundColor: 'transparent', padding: 'none', border: 'none'}}
                             groupKey={TAP_PANEL_GROUP_KEY}
@@ -186,7 +187,7 @@ export function TapSearchPanel({initArgs= {}, titleOn=true}) {
                         initArgs, selectBy, setSelectBy, serviceUrl, onTapServiceOptionSelect, titleOn, tapOps, obsCoreEnabled}} />
                 </FormPanel>
             </ConstraintContext.Provider>
-        </div>
+        </Box>
     );
 
 }

--- a/src/firefly/js/visualize/ui/CoveraeViewer.jsx
+++ b/src/firefly/js/visualize/ui/CoveraeViewer.jsx
@@ -68,7 +68,7 @@ export function CoverageViewer({viewerId=DEFAULT_COVERAGE_VIEWER_ID,noCovMessage
 
     if (hasPlots && (tblHasCoverage || forceShow)) {
         return (
-            <Stack {...{direction:'column', width:'100%'}}>
+            <Stack height={1} width={1}>
                 <MultiImageViewer viewerId={viewerId}
                                   insideFlex={true}
                                   canReceiveNewPlots={NewPlotMode.replace_only.key}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1355
- added scrolling to tabs.
- convert table content overflow drop-down (...)

Test: https://fireflydev.ipac.caltech.edu/firefly-1355-joyui-tabpanel/firefly/
Test wherever tabs are used.  
Keep in mind these features of TabPanel:
- Tab may be removable
- Tab will resize itself as more tabs are added.  It will also resizes as more spaces are mad available

Added Feature:
- A `min-width=100` is set on the tabs.  When there are too many to fit, it will overflow.  They become scrollable at this point.  To scroll, hover over the tab headers, press the Shift key, and then use the scroll wheel.
