### PR TITLE
Firefly-1341: Enhanced EmeddedPositionSearchPanel for upload

### DIFF
--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -222,7 +222,10 @@ export const MetaConst = {
      */
     DATALINK_INITIAL_LAYOUT : 'DatalinkInitialLayout',
 
-
+    /**
+     * If defined and true, dispatchTableSearch will be called but prevent going to results view directly
+     */
+    UPLOAD_TABLE: 'UploadTable',
 
     /** @deprecated use CENTER_COLUMN */
     CATALOG_COORD_COLS : 'CatalogCoordColumns',

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -7,12 +7,13 @@ import {filter} from 'lodash';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
 
 import {LO_VIEW, SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo, dispatchUpdateLayoutInfo, dropDownManager} from '../../core/LayoutCntlr.js';
-import {smartMerge} from '../../tables/TableUtil.js';
+import {getTblById, smartMerge} from '../../tables/TableUtil.js';
 import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_ACTIVE, TBL_RESULTS_REMOVE} from '../../tables/TablesCntlr.js';
 import {CHART_ADD, CHART_REMOVE} from '../../charts/ChartsCntlr.js';
 
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
 import {REPLACE_VIEWER_ITEMS} from '../../visualize/MultiViewCntlr.js';
+import {MetaConst} from 'firefly/data/MetaConst';
 
 /**
  * this manager manages what main components get display on the screen.
@@ -78,10 +79,16 @@ function onAnyAction(layoutInfo, action, views) {
     const closeable = count > 1;
 
     switch (action.type) {
-        case TABLE_REMOVE:
         case TBL_RESULTS_ADDED:
-        case TBL_RESULTS_REMOVE:
         case TABLE_LOADED:
+        case TBL_RESULTS_ACTIVE:
+            const tbl = getTblById(action.payload.tbl_id);
+            if (tbl?.request?.META_INFO?.[MetaConst.UPLOAD_TABLE]) {
+                return layoutInfo;
+            }
+            //intentional fallthrough
+        case TABLE_REMOVE:
+        case TBL_RESULTS_REMOVE:
         case REPLACE_VIEWER_ITEMS:
         case ImagePlotCntlr.PLOT_IMAGE_START :
         case ImagePlotCntlr.DELETE_PLOT_VIEW:

--- a/src/firefly/js/templates/hydra/HydraManager.js
+++ b/src/firefly/js/templates/hydra/HydraManager.js
@@ -6,14 +6,16 @@ import {take, fork} from 'redux-saga/effects';
 import {SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo,
         dispatchSetLayoutInfo, dropDownManager} from '../../core/LayoutCntlr.js';
 import {removeChartsInGroup} from '../../charts/ChartsCntlr.js';
-import {TABLE_SEARCH, TBL_RESULTS_ADDED, TABLE_REMOVE} from '../../tables/TablesCntlr.js';
+import {TABLE_SEARCH, TBL_RESULTS_ADDED, TABLE_REMOVE, TABLE_LOADED, TBL_RESULTS_ACTIVE
+} from '../../tables/TablesCntlr.js';
 import {visRoot, dispatchDeletePlotView} from '../../visualize/ImagePlotCntlr.js';
-import {removeTablesFromGroup, getAllTableGroupIds, smartMerge} from '../../tables/TableUtil.js';
+import {removeTablesFromGroup, getAllTableGroupIds, smartMerge, getTblById} from '../../tables/TableUtil.js';
 import {getSearchInfo} from '../../core/AppDataCntlr.js';
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
 import {CHART_ADD} from '../../charts/ChartsCntlr.js';
 import {REPLACE_VIEWER_ITEMS} from '../../visualize/MultiViewCntlr.js';
 import {deleteAllDrawLayers} from '../../visualize/DrawLayerCntlr';
+import {MetaConst} from 'firefly/data/MetaConst';
 
 /**
  * Configurable part of this template
@@ -54,6 +56,13 @@ export function* hydraManager() {
         newLayoutInfo = smartMerge(layoutInfo, {showImages, showXyPlots, showTables});
 
         switch (action.type) {
+            case TBL_RESULTS_ADDED:
+            case TABLE_LOADED:
+            case TBL_RESULTS_ACTIVE:
+                const tbl = getTblById(action.payload.tbl_id);
+                if (tbl?.request?.META_INFO?.[MetaConst.UPLOAD_TABLE]) break; //to not change layoutInfo if it is an upload table
+                //intentional fallthrough
+            case CHART_ADD:
             case TABLE_SEARCH:
                 newLayoutInfo = handleNewSearch(newLayoutInfo, action);
                 break;

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -89,7 +89,7 @@ function searchesAsTabs(allSearchItems, initArgs) {
 
 const searchOnce= makeSearchOnce(); // setup options to immediately execute the search the first time
 
-function executeOK(clickFunc,initArgs,searchItem) {
+export function executeOK(clickFunc,initArgs,searchItem) {
     searchOnce(
         () => {
             if (!initArgs?.urlApi?.execute) return false;
@@ -104,15 +104,20 @@ function executeOK(clickFunc,initArgs,searchItem) {
 
 function SearchForm({searchItem, style, initArgs}) {
     const {name, form} = searchItem;
-    const {render:Render, ...rest} = form;
+    const {render:Render, useFormPanel:useFormPanel=true,...rest} = form;
 
     return (
-        <FormPanel groupKey={name} style={style}
-                   getDoOnClickFunc={(clickFunc) => executeOK(clickFunc,initArgs,searchItem) }
-                   {...rest}>
+        useFormPanel ? (
+            <FormPanel groupKey={name} style={style}
+                       getDoOnClickFunc={(clickFunc) => executeOK(clickFunc,initArgs,searchItem)}
+                       {...rest}>
+                <Render {...{searchItem, initArgs}} />
+            </FormPanel>
+        ) : (
             <Render {...{searchItem, initArgs}} />
-        </FormPanel>
+        )
     );
+
 }
 
 function SideBar({activeSearch, groups=[]}) {

--- a/src/firefly/js/ui/UploadTableSelector.jsx
+++ b/src/firefly/js/ui/UploadTableSelector.jsx
@@ -1,0 +1,177 @@
+import PropTypes from 'prop-types';
+import {FieldGroupCtx} from 'firefly/ui/FieldGroup';
+import {useFieldGroupValue} from 'firefly/ui/SimpleComponent';
+import {findTableCenterColumns} from 'firefly/voAnalyzer/TableAnalysis';
+import {ColumnFld, getColValidator} from 'firefly/charts/ui/ColumnOrExpression';
+import {ExtraButton} from 'firefly/ui/FormPanel';
+import {showUploadTableChooser} from 'firefly/ui/UploadTableChooser';
+import {showColSelectPopup} from 'firefly/charts/ui/ColSelectView';
+import {getSizeAsString} from 'firefly/util/WebUtil';
+import React, {useContext, useEffect} from 'react';
+import {FieldGroupCollapsible} from 'firefly/ui/panel/CollapsiblePanel';
+
+export function UploadTableSelector({uploadInfo, setUploadInfo, uploadTable=false}) {
+
+    const UploadCenterLonColumns = 'uploadCenterLonColumns';
+    const UploadCenterLatColumns = 'uploadCenterLatColumns';
+
+    const {groupKey,setVal, register, unregister}= useContext(FieldGroupCtx);
+    const [getLon,setLon]= useFieldGroupValue(UploadCenterLonColumns);
+    const [getLat,setLat]= useFieldGroupValue(UploadCenterLatColumns);
+
+    const {fileName,columns,totalRows,fileSize}= uploadInfo ?? {};
+    const columnsUsed= columns?.filter( ({use}) => use)?.length ?? 0;
+    //TODO: possibly remove this check if we want pos columns *ALWAYS* open for uploaded tables
+    const openKey= uploadTable ? 'open' : 'upload-pos-columns';
+
+    useEffect(() => {
+        //if user changes position column(s), make the new columns entries selectable in the columns/search
+        const columns = uploadInfo?.columns;
+        if (getLon()) {
+            const cObj= columns.find((col) => col.name === getLon());
+            if (cObj) cObj.use = true;
+        }
+        if (getLat()) {
+            const cObj= columns.find((col) => col.name === getLat());
+            if (cObj) cObj.use = true;
+        }
+        uploadInfo = {...uploadInfo, columns};
+        setUploadInfo(uploadInfo);
+        //when setting uploadInfo, also register, so it shows up in the request object
+        const additionalReqObjs = {uploadInfo};
+        register('additionalParams', () => additionalReqObjs);
+        return () => unregister('additionalParams');
+    }, [getLon, getLat]);
+
+    useEffect(() => {
+        if (!columns) return;
+        const centerCols = findTableCenterColumns({tableData:{columns}}) ?? {};
+        const {lonCol='', latCol=''}= centerCols;
+        if (!getLon()) setLon(lonCol);
+        if (!getLat()) setLat(latCol);
+        //TODO: this line can also be removed if we decide to always keep pos columns open for uplaoded tables
+        if (!uploadTable) setVal(openKey, (!lonCol || !latCol) ? 'open' : 'closed');
+    },[columns]);
+
+    const preSetUploadInfo= (ui) => {
+        setLon('', {validator: getColValidator(ui.columns, true, false), valid: true});
+        setLat('', {validator: getColValidator(ui.columns, true, false), valid: true});
+        setUploadInfo(ui);
+    };
+
+    const haveTable= Boolean(fileName && columns);
+
+    const onColsSelected = (selectedColNames) => {
+        //get rid of extra quotes within each selectedColNames - because non-alphanumeric entries may have
+        //been quoted by calling quoteNonAlphanumeric
+        // , e.g.: ['"Object Name"', 'RA', 'Notes']
+        selectedColNames = selectedColNames.map((col) => col.replace(/^"(.*)"$/, '$1'));
+        const columns = uploadInfo.columns.map((col) => (
+            {...col, use:selectedColNames.includes((col.name))}));
+        uploadInfo = {...uploadInfo, columns};
+        setUploadInfo(uploadInfo);
+    };
+
+    return (
+        <div style={{margin: '10px 0 0 0'}}>
+            <div style={{display:'flex', alignItems:'center'}}>
+                <div style={{whiteSpace:'nowrap'}}>Upload Table:</div>
+                <div style={{display:'flex', alignItems:'center'}}>
+                    <ExtraButton text={fileName ? 'Change...' : 'Add...'}
+                                 onClick={() => showUploadTableChooser(preSetUploadInfo)} style={{marginLeft: 42}} />
+                    {haveTable &&
+                        <div style={{width:200, overflow:'hidden', whiteSpace:'nowrap', fontSize:'larger',
+                            textOverflow:'ellipsis', lineHeight:'2em', paddingLeft:15}}>
+                            {`${fileName}`}
+                        </div>
+                    }
+                </div>
+            </div>
+            {haveTable &&
+                <div style={{display:'flex', flexDirection:'row', marginLeft: 195, justifyContent:'flex-start'}}>
+                    <div style={{whiteSpace:'nowrap'}}>
+                        <span>Rows: </span>
+                        <span>{totalRows},</span>
+                    </div>
+                    {!uploadTable && <div style={{paddingLeft: 8, whiteSpace:'nowrap'}}>
+                        <a className='ff-href'onClick={() => showColSelectPopup(columns, onColsSelected, 'Choose Columns', 'OK',
+                            null,true)}>
+                            <span>Columns: </span>
+                            <span>{columns.length} (using {columnsUsed})</span>
+                        </a>
+                        {fileSize &&<span>,</span>}
+                    </div>}
+                    {fileSize && <div style={{paddingLeft: 8, whiteSpace:'nowrap'}}>
+                        <span>Size: </span>
+                        <span>{getSizeAsString(fileSize)}</span>
+                    </div>}
+                </div>
+            }
+
+            {haveTable &&
+                <CenterColumns {...{lonCol: getLon(), latCol: getLat(), cols:columns,
+                    headerTitle:'Position Columns:', openKey,
+                    headerPostTitle:'(from the uploaded table)',
+                    headerStyle:{paddingLeft:1},
+                    style:{margin:'0 0 10px 195px'},
+                    labelStyle:{paddingRight:10},
+                    lonKey:UploadCenterLonColumns, latKey:UploadCenterLatColumns, initialState: uploadTable ? 'open' : 'closed'}} />
+            }
+        </div>
+    );
+}
+
+UploadTableSelector.propTypes = {
+    uploadInfo: PropTypes.object,
+    setUploadInfo: PropTypes.func,
+    uploadTable: PropTypes.bool
+};
+
+export function CenterColumns({lonCol,latCol, style={},cols, lonKey, latKey, openKey, labelStyle,
+                           headerTitle, headerPostTitle = '', openPreMessage='', headerStyle, initialState='closed'}) {
+
+
+    const posHeader= (
+        <div style={{marginLeft:-8}}>
+            <span style={{fontWeight:'bold', ...headerStyle}}>
+                {(lonCol || latCol) ? `${lonCol || 'unset'}, ${latCol || 'unset'}` : 'unset'}
+            </span>
+            <span style={{paddingLeft:12, whiteSpace:'nowrap'}}>
+                {headerPostTitle}
+            </span>
+        </div>
+    );
+
+    return (
+        <div style={{margin: '5px 0 0 0',...style}}>
+            <div style={{display:'flex'}}>
+                <div style={{width:140, marginTop:10, whiteSpace:'nowrap', ...labelStyle}}>
+                    {headerTitle}
+                </div>
+                <FieldGroupCollapsible header={posHeader} headerStyle={{paddingLeft:0}} contentStyle={{marginLeft:4}}
+                                       initialState={{value:initialState}} fieldKey={openKey}>
+                    {openPreMessage && <div style={{padding:'0 0 10px 0'}}>
+                        {openPreMessage}
+                    </div>}
+                    <ColumnFld fieldKey={lonKey} cols={cols}
+                               name='longitude column'  // label that appears in column chooser
+                               inputStyle={{overflow:'auto', height:12, width: 100}}
+                               tooltip={'Center longitude column for spatial search'}
+                               label='Lon Column:'
+                               labelWidth={62}
+                               validator={getColValidator(cols, true, false)} />
+                    <div style={{marginTop: 5}}>
+                        <ColumnFld fieldKey={latKey} cols={cols}
+                                   name='latitude column' // label that appears in column chooser
+                                   inputStyle={{overflow:'auto', height:12, width: 100}}
+                                   tooltip={'Center latitude column for spatial search'}
+                                   label='Lat Column:'
+                                   labelWidth={62}
+                                   validator={getColValidator(cols, true, false)} />
+                    </div>
+                </FieldGroupCollapsible>
+
+            </div>
+        </div>
+    );
+}

--- a/src/firefly/js/ui/dynamic/DynComponents.jsx
+++ b/src/firefly/js/ui/dynamic/DynComponents.jsx
@@ -20,7 +20,7 @@ import {SizeInputFields} from '../SizeInputField.jsx';
 import {TargetPanel} from '../TargetPanel.jsx';
 import {ValidationField} from '../ValidationField.jsx';
 import {
-    AREA, CHECKBOX, CIRCLE, CONE_AREA_KEY, ENUM, FLOAT, INT, POINT, POLYGON, POSITION, UNKNOWN
+    AREA, CHECKBOX, CIRCLE, CONE_AREA_KEY, ENUM, FLOAT, INT, POINT, POLYGON, POSITION, UNKNOWN, UPLOAD
 } from './DynamicDef.js';
 import {EmbeddedPositionSearchPanel} from './EmbeddedPositionSearchPanel.jsx';
 import {findFieldDefType} from './ServiceDefTools.js';

--- a/src/firefly/js/ui/dynamic/DynamicDef.js
+++ b/src/firefly/js/ui/dynamic/DynamicDef.js
@@ -12,6 +12,7 @@ export const FLOAT = 'float';
 export const UNKNOWN = 'unknown';
 export const AREA = 'area';
 export const POLYGON = 'polygon';
+export const UPLOAD = 'upload';
 export const RANGE = 'range';
 export const CIRCLE = 'circle';
 

--- a/src/firefly/js/ui/tap/Constraints.js
+++ b/src/firefly/js/ui/tap/Constraints.js
@@ -29,8 +29,6 @@ export const getUploadServerFile= (tapBrowserState) => getTapUploadSchemaEntry(t
 
 export const getUploadTableName= (tapBrowserState) => getTapUploadSchemaEntry(tapBrowserState).table;
 
-
-
 /**
  *
  * @param {TapBrowserState} tapBrowserState

--- a/src/firefly/js/visualize/ui/CommonUIKeys.js
+++ b/src/firefly/js/visualize/ui/CommonUIKeys.js
@@ -1,3 +1,7 @@
 export const CONE_CHOICE_KEY = 'CONE';
 export const POLY_CHOICE_KEY = 'POLY';
+export const UPLOAD_CHOICE_KEY = 'UPLOAD';
 export const CONE_AREA_OPTIONS = [{label: 'Cone', value: CONE_CHOICE_KEY}, {label: 'Polygon', value: POLY_CHOICE_KEY}];
+
+export const CONE_AREA_OPTIONS_UPLOAD = [{label: 'Cone', value: CONE_CHOICE_KEY}, {label: 'Polygon', value: POLY_CHOICE_KEY},
+    {label: 'Multi-object', value: UPLOAD_CHOICE_KEY}];


### PR DESCRIPTION
**[Firefly-1341](https://jira.ipac.caltech.edu/browse/FIREFLY-1341)**: 
**IRSA-IFE PR for Euclid**: https://github.com/IPAC-SW/irsa-ife/pull/303

- `UploadTableChooser` shows up and works with `EmbeddedPositionSearchPanel` (conditionally, because all components using EmbeddedPositionSearchPanel may not want an upload option, like Source Inspector in Euclid or some DCE tables)
- removed column selector for Euclid by passing in `uploadTable` flag (should change this name) to `UploadTableSelector` 
    - the flag enables showing column selector for an uploaded table on TAP, but not for Euclid (or other apps that call `UploadTableSelector` with this flag set to true) 

**Updates 1/31**:
- doing `dispatchTableSearch` on all table uploads and not going to results view directly. Made this work using initial approach suggested by @robyww. Important files to look at: `LayoutCntlr.js`, `HydraManager.js` and `FireflyViewerManager.js`
  - In LayoutCntlr.js, checking if the tbl_group of the uploaded table is main (as it's a different group for things like DataProduct layer, but we don't want to go to result view for those either) 
  - instead of `tbl?.request?.META_INFO?.UploadTable)` I would like to use @robyww's suggested `getBooleanMetaEntry`, but for some reason even when I call it with the correct table/tbl_id and MetaInfo keyword, it returned nothing (I'll try and fix this - only outstanding issue from my end before review feedback). 
- Added some conditional logic inside SearchPanel's `SearchForm` component based on @loitly's recommendation. This seems to work quite well. (for the `useFormPanel` call, look at `euclid.js` in the IFE PR). 
- @robyww the request object in RegionExplorer now has the `uploadInfo` object. (For some reason just `setUploadInfo` on the `uploadInfo` object did not work directly, so in `UploadTableChooser`, I made use of `register` (FieldGroupCtx) to add `uploadInfo` as part of `additionalParams` of the request object (similar to FileUpoadViewPanel). 
- Finally, an unrelated issue: 
  - **overlays** are still not showing up on Euclid when you upload a table (when I tested the uploads with DCE briefly, the overlays showed up as expected). 

**Test Build (updated 1/31 - some issue with the builds - will rebuild all three 2/1 morning):** 
  - Firefly: https://fireflydev.ipac.caltech.edu/firefly-1341-possearchpanelupload/firefly
  - Euclid: https://firefly-1341-possearchpanelupload.irsakudev.ipac.caltech.edu/applications/euclid
  - DCE: https://firefly-1341-possearchpanelupload.irsakudev.ipac.caltech.edu/irsaviewer/dce
- For **Firefly**, go to the TAP panel
    - upload a table form the Multi-Object popup panel (or multiple tables one after another)
    - `Load table` will now just close the popup but not go to the results view 
    - click on `Search` or `Cancel` and you should see this uploaded table in the results view 
    - click on search, and you should see the uploaded tables in the results view 
- For **Euclid**: 
   - In region explorer, click on **Multi-object** and attempt to upload a table (or multiple tables)
   - You should not see a column chooser here, and the position columns' collapsible panel should also be open by default
   - Click **Search** and you should see these upload tables in the results view 
- For **DCE**:
  - Make sure the search on DCE works as expected, and this work on EmbeddedPositionSearchPanel hasn't affected anything there 