### PR TITLE
FIREFLY-1387: UI Conversion: Additional core functionalities

### DIFF
--- a/src/firefly/html/firefly.html
+++ b/src/firefly/html/firefly.html
@@ -9,14 +9,6 @@
     <link rel=”apple-touch-startup-image” href=”images/fftools-ipad_splash_768x1004.png”>
     <meta name="viewport" content="initial-scale=1, width=device-width" />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
-    />
-
-
     <title>Firefly</title>
 
     <script>

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -4,7 +4,6 @@
  */
 
 import 'isomorphic-fetch';
-import '@fontsource/inter';
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {set, defer, once} from 'lodash';
@@ -131,6 +130,10 @@ const defFireflyOptions = {
         {id: 'vocat'},
         {id: 'nedcat'}
     ],
+    theme: {
+        customized: undefined,          // a function that returns a customized theme
+        colorMode: undefined,           // can be 'dark' or 'light'.  When not specified(default), it will use device's settings.
+    },
     MenuItemKeys: {},
     imageTabs: undefined,
     irsaCatalogFilter: undefined,

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -4,7 +4,6 @@
 
 import React, {useCallback, useEffect} from 'react';
 import {Box, Typography} from '@mui/joy';
-import { useColorScheme } from '@mui/joy/styles';
 import PropTypes from 'prop-types';
 import {Column, Table} from 'fixed-data-table-2';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
@@ -19,6 +18,7 @@ import {CellWrapper, HeaderCell, makeDefaultRenderer, SelectableCell, Selectable
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {dispatchTableUiUpdate, TBL_UI_UPDATE} from '../TablesCntlr.js';
 import {Logger} from '../../util/Logger.js';
+import { useColorMode } from '../../ui/FireflyRoot.jsx';
 
 import 'fixed-data-table-2/dist/fixed-data-table.css';
 import './TablePanel.css';
@@ -32,7 +32,7 @@ export const BY_SCROLL = 'byScroll';
 
 const BasicTableViewInternal = React.memo((props) => {
 
-    const { mode } = useColorScheme();
+    const { activeMode } = useColorMode();
 
     const {width, height} = props.size;
     const {columns, data, hlRowIdx, renderers, bgColor, selectInfoCls, callbacks, rowHeight, rowHeightGetter, showHeader=true,
@@ -149,7 +149,7 @@ const BasicTableViewInternal = React.memo((props) => {
         else return null;
     };
 
-    const hlColor = mode === 'dark' ? 'background.surface' : undefined;
+    const hlColor = activeMode === 'dark' ? 'background.surface' : undefined;
 
     return (
         <Box tabIndex='-1' onKeyDown={onKeyDown}

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -15,17 +15,16 @@ import {CopyToClipboard} from '../../visualize/ui/MouseReadout.jsx';
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
 
 
-export function TableInfo(props) {
+export function TableInfo({tbl_id, tabsProps, ...props}) {
 
-    const {tbl_id} = props;
     if (!tbl_id) {
         return <div>No additional Information</div>;
     }
    const jobId = getJobIdFromTblId(tbl_id);
 
     return (
-        <Stack p={1} height={1} boxSizing='border-box'>
-            <StatefulTabs componentKey='TablePanelOptions' defaultSelected={0} borderless={true} useFlex={true} style={{flex: '1 1 0'}}>
+        <Stack p={1} height={1} spacing={1} {...props}>
+            <StatefulTabs componentKey='TablePanelOptions' {...tabsProps}>
                 {jobId &&
                 <Tab name='Job Info'>
                     <JobInfo jobId={jobId}/>
@@ -45,7 +44,8 @@ export function TableInfo(props) {
 }
 
 TableInfo.propTypes = {
-    tbl_id: PropTypes.string
+    tbl_id: PropTypes.string,
+    tabsProps: PropTypes.object         // this get passed into TabPanel
 };
 
 

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -11,16 +11,6 @@
     align-items: center;
 }
 
-.TablePanel__meta {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 0;
-    border: 1px solid #c8c8c8;
-    background-color: #e6e6e6;
-    margin-bottom: 2px;
-    padding-bottom: 2px;
-}
-
 .TablePanel__error {
     margin-top: 10px;
     display: flex;
@@ -72,64 +62,6 @@
     flex-direction: column;
 }
 
-.TablePanelOptions__button {
-    width: 50px;
-    height: 20px;
-    border: solid 1px #bdbdbd;
-    font-weight: bold;
-    color: black;
-    border-radius: 4px;
-    background: none;
-}
-.TablePanelOptions__button:active {
-    background-color: #ffffff;
-}
-
-.TablePanelOptions__button:hover {
-    background-color: #f3f3f3;
-    cursor: pointer;
-}
-
-.TablePanelOptions__filters--box {
-}
-
-.TablePanelOptions__filters {
-    border: 1px solid #c7c7c7;
-    padding: 6px;
-    background-color: #eaeaea;
-    border-radius: 3px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-style: italic;
-    color: maroon;
-}
-
-.TablePanelOptions__pref {
-    display: inline-flex;
-    font-style: italic;
-    color: gray;
-    margin-top: 3px;
-}
-
-.TablePanel__mask {
-    box-sizing: content-box;
-    background-color: rgba(255,255,255,.8);
-    display: flex;
-    position: relative;
-    height: 100%;
-    align-items: center;
-    justify-content: center;
-}
-
-.TablePanel__mask--button {
-    z-index: 1;
-    margin-top: 80px;
-    border: 1px solid rgba(0, 0, 0, 0.4);
-    box-sizing: content-box;
-    background-color: rgba(255,255,255,.8);
-}
-
 .TablePanel__no-access div {
     background-color: #ffe8e8 !important;
 }
@@ -139,38 +71,6 @@
 }
 
 /** table's related styling */
-
-.Actions__anchor {
-    padding: 3px;
-    border: 1px solid #dadada;
-    background-color: #e8e8e8;
-    font-size: 9px;
-    color: #93aec5;
-    border-radius: 2px;
-    margin: 1px 1px 2px;
-    position: absolute;
-    right: 1px;
-}
-
-.Actions__dropdown {
-    display: flex;
-    flex-direction: column;
-    white-space: nowrap;
-    margin: 5px 0;
-}
-
-.Actions__item {
-    padding: 4px 8px;
-    margin: 3px 0;
-}
-
-.Actions__item:hover {
-    cursor: pointer;
-    background-color: #efefef;
-    margin: 2px 0;
-    border-top: 1px solid #e6e6e6;;
-    border-bottom: 1px solid #e6e6e6;;
-}
 
 .Actions__popup {
     min-width: 75px;
@@ -189,73 +89,6 @@
     background-color: white;
     padding: 5px 0;
 }
-
-.PagingBar__button {
-    height: 16px;
-    width: 16px;
-    margin: 1px 2px 0 0;
-}
-
-.PagingBar__button:hover {
-    background-color: rgba(0,0,0,.15);
-    cursor: pointer;
-}
-
-.PagingBar__button.first {
-    background-image: url("~images/icons-2014/16x16_BackwardToEnd.png");
-}
-
-.PagingBar__button.last {
-    background-image: url("~images/icons-2014/16x16_ForwardToEnd.png");
-}
-
-.PagingBar__button.next {
-    background-image: url("~images/icons-2014/16x16_Forward.png");
-}
-
-.PagingBar__button.previous {
-    background-image: url("~images/icons-2014/16x16_Backward.png");
-}
-
-.PanelToolbar__button.info {
-    background-image: url("~images/icons-2014/24x24_Info.png");
-}
-
-.PanelToolbar__button.options {
-    background-image: url("~images/icons-2014/24x24_GearsNEW.png");
-}
-
-.PanelToolbar__button.textView {
-    background-image: url("~images/icons-2014/24x24_TextView.png");
-}
-
-.PanelToolbar__button.tableView {
-    background-image: url("~images/icons-2014/24x24_TableView.png");
-}
-
-.PanelToolbar__button.save {
-    background-image: url("~images/icons-2014/24x24_Save.png");
-}
-
-.PanelToolbar__button.clearFilters {
-    background-image: url("~images/icons-2014/24x24_FilterOff_Circle.png");
-}
-
-.PanelToolbar__button.propSheet {
-    background-image: url("~images/icons-2014/36x36-data-info.png");
-    background-size: cover;
-}
-
-.TablePanelInfoWrapper {
-    min-width: 430px;
-    min-height: 200px;
-    height: 300px;
-    width: 550px;
-    overflow: auto;
-    position: relative;
-    resize: both;
-}
-
 
 .CellRenderer__numrange {
     line-height: normal;
@@ -312,11 +145,6 @@ Overriding default fixed-table css
     background-color: unset;
     font-weight: unset;
 }
-
-/*.fixedDataTableRowLayout_main.highlighted div {*/
-/*    background-color: #ffe8bf !important; !* #d3fad1 *!*/
-/*}*/
-
 
 .fixedDataTableRowLayout_main.related div {
     background-color: #faf4e5;

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -37,10 +37,16 @@ import {AddColumnBtn} from './AddOrUpdateColumn.jsx';
 
 import FILTER from 'html/images/icons-2014/24x24_Filter.png';
 import OUTLINE_EXPAND from 'html/images/icons-2014/24x24_ExpandArrowsWhiteOutline.png';
+import CLEAR_FILTER from 'html/images/icons-2014/24x24_FilterOff_Circle.png';
+import TEXT_VIEW from 'html/images/icons-2014/24x24_TextView.png';
+import TABLE_VIEW from 'html/images/icons-2014/24x24_TableView.png';
+import SAVE from 'html/images/icons-2014/24x24_Save.png';
+import PROP_SHEET from 'html/images/icons-2014/36x36-data-info.png';
+import INFO from 'html/images/icons-2014/24x24_Info.png';
 import OPTIONS from 'html/images/icons-2014/24x24_GearsNEW.png';
+
 import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
 import {META} from '../TableRequestUtil.js';
-import {useColorScheme} from '@mui/joy/styles';
 
 const logger = Logger('Tables').tag('TablePanel');
 
@@ -149,9 +155,16 @@ function showTableOptionDialog(onChange, onOptionReset, clearFilter, tbl_ui_id, 
 
 function showTableInfoDialog(tbl_id)  {
     const content = (
-        <div className='TablePanelInfoWrapper' style={{width: 500}}>
-            <TableInfo tbl_id={tbl_id}/>
-        </div>
+        <Box width={500} height={300} minWidth={450} minHeight={200}
+             sx={{resize:'both', overflow:'auto', position:'relative'}}>
+            <TableInfo tbl_id={tbl_id}
+                       p={0} height='unset'
+                       tabsProps={{
+                           variant:'plain',
+                           slotProps: {tabList: {sticky: 'top'}}
+                       }}
+            />
+        </Box>
     );
     showOptionsPopup({content, title: 'Table Info', modal: true, show: true});
 }
@@ -243,8 +256,6 @@ TablePanel.defaultProps = {
 
 function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
 
-    const { mode } = useColorScheme();
-
     const uiState = useStoreConnector(() => getTableUiById(tbl_ui_id) || {columns:[]}, [tbl_ui_id]);
     const searchActions= getSearchActions();
 
@@ -267,9 +278,6 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
         dispatchTblExpanded(tbl_ui_id, tbl_id);
         dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.tables);
     };
-
-    const viewIcoStyle = 'PanelToolbar__button ' + (textView ? 'tableView' : 'textView');
-    const TT_VIEW = textView ? TT_TABLE_VIEW : TT_TEXT_VIEW;
 
     let {leftButtons, rightButtons, showAddColumn} = tblState;
     showAddColumn = isClientTable(tbl_id) ? false : showAddColumn;
@@ -295,13 +303,8 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
 
     if (!showToolbar) return null;
 
-    const sx = mode === 'dark' ?                                            // temporary solution for dark-mode; need real icons
-                ({'& .PagingBar__button, .PanelToolbar__button': {
-                    backgroundColor: 'text.primary'
-                }}) : undefined;
-
     return (
-        <Sheet component={Stack} sx={sx} variant='soft' className='FF-Table-Toolbar' direction='row' justifyContent='space-between' width={1} {...slotProps?.toolbar}>
+        <Sheet component={Stack} variant='soft' className='FF-Table-Toolbar' direction='row' justifyContent='space-between' width={1} {...slotProps?.toolbar}>
             <LeftToolBar {...{tbl_id, title, removable, showTitle, leftButtons}}/>
             {showPaging && <PagingBar {...{currentPage, pageSize, showLoading, totalRows, callbacks:connector}} /> }
             <Stack direction='row' alignItems='center'>
@@ -310,43 +313,41 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
                 <ActionsDropDownButton {...{searchActions, tbl_id}}/>
                 }
                 {showFilterButton && filterCount > 0 &&
-                <div onClick={clearFilter}
-                     title={TT_CLEAR_FILTER}
-                     className='PanelToolbar__button clearFilters'/>}
+                <ToolbarButton icon={CLEAR_FILTER} tip={TT_CLEAR_FILTER}
+                               onClick={clearFilter}/>
+                }
                 {showFilterButton &&
                 <ToolbarButton icon={FILTER}
                                tip={TT_SHOW_FILTER}
-                               visible={true}
                                badgeCount={filterCount}
                                onClick={toggleFilter}/>
                 }
-                {showToggleTextView && <div onClick={toggleTextView}
-                                            title={TT_VIEW}
-                                            className={viewIcoStyle}/>}
+                {showToggleTextView &&
+                <ToolbarButton icon={textView ? TABLE_VIEW : TEXT_VIEW}
+                               tip={textView ? TT_TABLE_VIEW : TT_TEXT_VIEW}
+                               onClick={toggleTextView}/>
+                }
                 {showSave &&
-                <div onClick={showTableDownloadDialog({tbl_id, tbl_ui_id})}
-                     title={TT_SAVE}
-                     className='PanelToolbar__button save'/> }
+                <ToolbarButton icon={SAVE} tip={TT_SAVE}
+                               onClick={showTableDownloadDialog({tbl_id, tbl_ui_id})}/>
+                }
                 {showAddColumn && <AddColumnBtn tbl_id={tbl_id} tbl_ui_id={tbl_ui_id}/> }
                 {showInfoButton &&
-                <div style={{marginLeft: '4px'}}
-                     title={TT_INFO}
-                     onClick={showInfoDialog}
-                     className='PanelToolbar__button info'/> }
+                <ToolbarButton icon={INFO} tip={TT_INFO}
+                               onClick={showInfoDialog}/>
+                }
                 {showPropertySheet &&
-                <div style={{marginLeft: '4px'}}
-                     title={TT_PROPERTY_SHEET}
-                     onClick={() => showTablePropSheetDialog(tbl_id)}
-                     className='PanelToolbar__button propSheet'/> }
+                <ToolbarButton icon={PROP_SHEET} tip={TT_PROPERTY_SHEET}
+                               onClick={() => showTablePropSheetDialog(tbl_id)}/>
+                }
                 {showOptionButton &&
-                <div style={{marginLeft: '4px'}}
-                     title={TT_OPTIONS}
-                     onClick={showOptionsDialog}
-                     className='PanelToolbar__button options'/> }
+                <ToolbarButton icon={OPTIONS} tip={TT_OPTIONS}
+                               onClick={showOptionsDialog}/>
+                }
                 { expandable && !expandedMode &&
-                <div className='PanelToolbar__button' onClick={expandTable} title={TT_EXPAND}>
-                    <img src={OUTLINE_EXPAND}/>
-                </div>}
+                <ToolbarButton icon={OUTLINE_EXPAND} tip={TT_EXPAND}
+                               onClick={expandTable}/>
+                }
                 { help_id && <div style={{marginTop:-10}}> <HelpIcon helpId={help_id} /> </div>}
             </Stack>
         </Sheet>

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -393,7 +393,7 @@ export const CellWrapper =  React.memo( (props) => {
     const lineHeight = '2em';
 
     const content = (
-        <Stack textAlign={textAlign} lineHeight={lineHeight} p='2px' bgcolor='background.surface'>
+        <Stack textAlign={textAlign} lineHeight={lineHeight} px={1/4} bgcolor='background.surface'>
             <CellRenderer {...omit(props, 'Content')} cellInfo={cellInfo}/>
         </Stack>
     );
@@ -521,7 +521,7 @@ export const createInputCell = (tooltips, size = 10, validator, onChange, style)
             return null;
         } else {
             return (
-                <div style={{padding: '0 2px 0 2px', marginTop:'-2px'}}>
+                <Box px={1/4}>
                     <InputField
                         key={rowIndex + '-' +colIdx}
                         validator={(v) => validator(v, data, rowIndex, colIdx)}
@@ -534,7 +534,7 @@ export const createInputCell = (tooltips, size = 10, validator, onChange, style)
                         actOn={['blur','enter']}
                         showWarning={false}
                     />
-                </div>
+                </Box>
             );
         }
     };

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -14,7 +14,7 @@ import {
     dispatchOnAppReady, dispatchNotifyRemoteAppReady, getAppOptions,
 } from '../../core/AppDataCntlr.js';
 import {LO_VIEW, getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
-import {getTheme} from '../../ui/ThemeSetup.js';
+import {defaultTheme} from '../../ui/ThemeSetup.js';
 import {getActiveRowCenterDef} from '../../visualize/saga/ActiveRowCenterWatcher.js';
 import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getMocWatcherDef} from '../../visualize/saga/MOCWatcher.js';

--- a/src/firefly/js/ui/FireflyRoot.jsx
+++ b/src/firefly/js/ui/FireflyRoot.jsx
@@ -1,31 +1,68 @@
-import React from 'react';
-import {CssBaseline, ScopedCssBaseline, CssVarsProvider, useColorScheme, GlobalStyles} from '@mui/joy';
-import {getTheme} from './ThemeSetup.js';
+import React, {useEffect} from 'react';
+import {ScopedCssBaseline, extendTheme, CssVarsProvider, useColorScheme, GlobalStyles} from '@mui/joy';
 
+import {defaultTheme} from './ThemeSetup.js';
+import {getAppOptions} from '../core/AppDataCntlr.js';
+import {logger} from '../util/Logger.js';
 
-
-
+import '@fontsource/inter/200.css'; // Lighter
+import '@fontsource/inter/300.css'; // Light
+import '@fontsource/inter/400.css'; // Regular
+import '@fontsource/inter/500.css'; // Medium
+import '@fontsource/inter/600.css'; // Semi-Bold
+import '@fontsource/inter/700.css'; // Bold
+import '@fontsource/inter/800.css'; // Bolder
 
 export function FireflyRoot({children}) {
-    const newTheme= getTheme();
-    const useBaseline= false;
+
+    const customTheme = getAppOptions().theme?.customized?.();
+    const theme = extendTheme(customTheme || defaultTheme());
 
     return (
-        <CssVarsProvider theme={newTheme}>
-            {useBaseline && <CssBaseline/>}
+        <CssVarsProvider defaultMode='system' theme={theme}>
             <GlobalStyles styles={{
-                    // CSS object styles
-                    html: {fontSize:'87.5%'}
-                }}/>
-            <App>{children}</App>
+                html: {fontSize:'87.5%'}
+            }}/>
+            <ScopedCssBaseline>
+                <App>{children}</App>
+            </ScopedCssBaseline>
         </CssVarsProvider>
     );
 }
 
 function App({children}) { // provide a way to experiment with light and dark theme
-    const { mode, setMode } = useColorScheme();
-   // setMode('dark');
-    setMode('light');
+
+    // Firefly is setup to take the device's color mode
+    // To set device mode on your mac; AppleMenu -> System Settings -> Appearance
+
+    const { activeMode, setMode } = useColorMode();
+
+    const colorMode = getAppOptions().theme?.colorMode?.();
+    // if colorMode is set; must use this mode
+    // To add mode switching; make sure colorMode is not set.
+    // Then, add a component(Button) to trigger 'setMode'.
+    // setMode store the value in localStorage.  It will use this mode
+    // until that value is cleared or kill/restart browser.
+
+    logger.info({activeMode, colorMode});
+
+    useEffect(() => {
+        // only setMode when colorMode is different from the current activeMode
+        if (colorMode && colorMode !== activeMode) {
+            setMode(colorMode);
+        }
+    }, [colorMode, activeMode]);
     return ( children );
 }
 
+
+/**
+ * A wrapper around useColorScheme to return the current active mode, which should be either light or dark
+ * @return {object}
+ */
+export function useColorMode() {
+    const { mode, systemMode, ...rest } = useColorScheme();
+    const activeMode = mode === 'system' ? systemMode : mode;
+    return {activeMode, mode, systemMode, ...rest};
+
+}

--- a/src/firefly/js/ui/Menu.css
+++ b/src/firefly/js/ui/Menu.css
@@ -30,7 +30,9 @@
     text-decoration:none;
     text-shadow:1px 1px 0 #ADB9C5;
     white-space: nowrap;
-    padding:6px 5px;
+    padding: 5px;
+    align-items: center;
+    height: 26px;
     min-width: 75px;
 }
 

--- a/src/firefly/js/ui/PagingBar.jsx
+++ b/src/firefly/js/ui/PagingBar.jsx
@@ -6,6 +6,13 @@ import {InputField} from './InputField.jsx';
 import {intValidator} from '../util/Validate.js';
 import LOADING from 'html/images/gxt/loading.gif';
 import {MAX_ROW} from '../tables/TableRequestUtil.js';
+import {ToolbarButton} from 'firefly/ui/ToolbarButton.jsx';
+
+import FIRST from 'html/images/icons-2014/16x16_BackwardToEnd.png';
+import LAST from 'html/images/icons-2014/16x16_ForwardToEnd.png';
+import NEXT from 'html/images/icons-2014/16x16_Forward.png';
+import PREVIOUS from 'html/images/icons-2014/16x16_Backward.png';
+
 
 export function PagingBar(props) {
     const {currentPage, totalRows, pageSize, showLoading, callbacks} = props;
@@ -30,8 +37,8 @@ export function PagingBar(props) {
     } else {
         return (
             <Typography component='div' display='flex' alignItems='center' direction='row' level='body-sm' noWrap>
-                <div onClick={() => callbacks.onGotoPage(1)} className='PagingBar__button first' title='First Page'/>
-                <div onClick={() => callbacks.onGotoPage(currentPage - 1)} className='PagingBar__button previous' title='Previous Page'/>
+                <ToolbarButton icon={FIRST} tip='First Page' onClick={() => callbacks.onGotoPage(1)}/>
+                <ToolbarButton icon={PREVIOUS} tip='Previous Page' onClick={() => callbacks.onGotoPage(currentPage - 1)}/>
                 <Stack direction='row' alignItems='center' spacing={1/2}>
                     <InputField
                         slotProps={{ input: { size: 'sm', sx: {width:'3em'} } }}
@@ -44,8 +51,8 @@ export function PagingBar(props) {
                         showWarning={false}
                     /> <div> of {totalPages}</div>
                 </Stack>
-                <div onClick={() => callbacks.onGotoPage(currentPage + 1)} className='PagingBar__button next'  title='Next Page'/>
-                <div onClick={() => callbacks.onGotoPage(totalPages)} className='PagingBar__button last'  title='Last Page'/>
+                <ToolbarButton icon={NEXT} tip='Next Page' onClick={() => callbacks.onGotoPage(currentPage + 1)}/>
+                <ToolbarButton icon={LAST} tip='Last Page' onClick={() => callbacks.onGotoPage(totalPages)}/>
                 {showingLabel}
                 {showLoading ? <img style={{width:14,height:14,marginTop: '3px'}} src={LOADING}/> : false}
             </Typography>

--- a/src/firefly/js/ui/ThemeSetup.js
+++ b/src/firefly/js/ui/ThemeSetup.js
@@ -1,8 +1,14 @@
-import {extendTheme} from '@mui/joy';
+/**
+ * Returns the overrides portion of JoyUI's theme.
+ * This will be used to extend(extendTheme) JoyUI's default theme.
+ *
+ * To customize Firefly's theme, start with the defaultTheme.  Then, update or add as needed.
+ * Next, assign the customized theme to the application options.  e.g. firefly.theme.customized = () => ({<custom-theme>})
 
-
-export function getTheme() {
-    return extendTheme({
+ * @return {object}
+ */
+export function defaultTheme() {
+    return ({
         components: {
             JoyButton: {
                 defaultProps: {

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -2,13 +2,14 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {Badge, Button, Checkbox, Divider, IconButton, Stack, Tooltip, useColorScheme} from '@mui/joy';
+import {Badge, Button, Checkbox, Divider, IconButton, Stack, Tooltip} from '@mui/joy';
 import React, {memo, useRef, useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {dispatchHideDialog} from '../core/ComponentCntlr.js';
 import {DROP_DOWN_KEY} from './DropDownToolbarButton.jsx';
 import DROP_DOWN_ICON from 'html/images/dd-narrow.png';
 import BrowserInfo, {Platform} from 'firefly/util/BrowserInfo.js';
+import { useColorMode } from './FireflyRoot.jsx';
 
 
 export function makeBadge(cnt, style={}) {
@@ -54,7 +55,7 @@ export const ToolbarButton = memo((props) => {
         dropDownCB, onClick} = props;
 
     const {current:divElementRef}= useRef({divElement:undefined});
-    const doInvert= useColorScheme()?.mode==='dark';
+    const doInvert= useColorMode()?.activeMode==='dark';
 
     const handleClick= () => {
         onClick?.(divElementRef.divElement);

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -69,8 +69,12 @@ export function TabPanel ({value, onTabSelect, tabId=uniqueTabId(), showOpenTabs
 
     const showTabs = (ev) => handleOpenTabs({ev, doOpen: !isDropDownShowing(tabId), tabId, onSelect: onTabSelect, arrowEl, childrenAry});
     const onChange = useCallback((ev, val) => onTabSelect?.(val), []);
-    const tabListVar = slotProps?.tabList?.variant || 'soft';
 
+    // because we support additional actions to the right of the TabList, we need to implement some of TabList feature here.
+    const tlVar = slotProps?.tabList?.variant || 'soft';
+    const sticky = slotProps?.tabList?.sticky;
+    const tlSticky = sticky === 'top' ? {position: 'sticky', top:0} :
+                     sticky === 'bottom' ? {position: 'sticky', bottom:0} : {};
     return (
         <JoyTabs key={tabId}
                  size='sm'
@@ -81,10 +85,15 @@ export function TabPanel ({value, onTabSelect, tabId=uniqueTabId(), showOpenTabs
                  variant='outlined'
                  {...joyTabsProps}
         >
-            <Sheet component={Stack} direction='row' variant={tabListVar}
-                   sx={{boxShadow: 'inset 0 -1px var(--joy-palette-divider)', position: 'unset', justifyContent: 'space-between'}}
+            <Sheet component={Stack} direction='row' variant={tlVar}
+                   sx={{
+                       boxShadow: 'inset 0 -1px var(--joy-palette-divider)',
+                       position: 'unset',
+                       justifyContent: 'space-between',
+                       ...tlSticky
+                   }}
             >
-                <ResizeTabHeader children={children}/>
+                <ResizeTabHeader slotProps={slotProps} children={children}/>
                 <Stack direction='row' flexShrink={0}>
                     {actions && actions()}
                     {showOpenTabs && (


### PR DESCRIPTION
- Provide a way for application to override Firefly's default theme.
- Package google font as part of Firefly to avoid external linking of google font.
- Use device's colorMode as default.  Provide option to set colorMode as well as document how to enable mode switching in the future.
Read comments in FireflyRoot.jsx for details.  Please provide feedbacks if you see issues.

- Use CssBaseline
I enabled `ScopedCssBaseline`.  See https://mui.com/joy-ui/react-css-baseline/ for more details.

This is a good idea going forward.  However, because it changes box-sizing model, it may breaks places where we use offset to fix alignment where we should have set box-sizing to 'border-box'.  I saw and fixed a couple.  I don't know how many more places this may affect.  I am ok reverting this change.  But, if there's not many places, we should keep this.

Test: https://fireflydev.ipac.caltech.edu/firefly-1387-colormode/firefly/

Everything should work the same.  You will noticed a slight smoothing of the text applied by CssBaseline.
You can also test switching between dark/light using your device's mode.  
```
    // Firefly is setup to take the device's color mode
    // To set device mode on your mac; AppleMenu -> System Settings -> Appearance
```

Also, be aware when you use `sx` to apply styles using selectors.
```
<Sheet sx = {{'& .PagingBar__button' ...   // selects all elements with this class from THIS node down.

// without the '&', it is global to Sheet
<Sheet sx = {{'.PagingBar__button' ...   // selects all elements with this class from Sheet down.
```

I've already seen a few leaked styles.

