### PR TITLE
Firefly-1406: fixes 1, 29, 54 (partial, not all tables), 62, 64

### DIFF
--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -36,7 +36,7 @@ const tblXyKey= 'tables | xyplots';
 export const TriViewPanel= memo(( {showViewsSwitch=true, leftButtons, centerButtons, rightButtons,
                                       initLoadingMessage, initLoadCompleted} ) => {
     const state= useStoreConnector(() => pick(getLayouInfo(), stateKeys));
-    const {title, mode, showTables:showTablesInState, showImages, showXyPlots, images={}, coverageSide=LEFT} = state;
+    const {title, mode, showTables, showImages, showXyPlots, images={}, coverageSide=LEFT} = state;
     const {expanded, standard, closeable} = mode ?? {};
     const content = {};
     const {showMeta, showFits, dataProductTableId, showCoverage} = images;
@@ -46,7 +46,7 @@ export const TriViewPanel= memo(( {showViewsSwitch=true, leftButtons, centerButt
     const imagesWithCharts= currLayoutMode===tblXyKey;
 
     if (initLoadingMessage && !initLoadCompleted) return (<AppInitLoadingMessage message={initLoadingMessage}/>);
-    if (!showImages && !showXyPlots && !showTablesInState) return <div/>;
+    if (!showImages && !showXyPlots && !showTables) return <div/>;
 
     if (!imagesWithCharts && (showImages || coverageLeft)) {
         content.imagePlot = (<TriViewImageSection key='res-tri-img'
@@ -60,18 +60,18 @@ export const TriViewPanel= memo(( {showViewsSwitch=true, leftButtons, centerButt
             dataProductTableId, coverageRight, imagesWithCharts}}/>);
         if (expanded===LO_VIEW.xyPlots) content.xyPlot= content.rightSide;
     }
-    const showTables= showTablesInState && currLayoutMode?.includes('tables');
-    if (showTables && currLayoutMode?.includes('tables')) {
+    const renderTables= showTables && currLayoutMode?.includes('tables');
+    if (renderTables) {
         content.tables = (<TablesContainer key='res-tables'
                                            mode='both'
                                            closeable={closeable}
                                            expandedMode={expanded===LO_VIEW.tables}/>);
     }
 
-    const isTriView = (showImages||coverageLeft) && (showXyPlots||coverageRight) && showTables;
+    const isTriViewPossible = (showImages||coverageLeft) && (showXyPlots||coverageRight) && showTables;
     return (
         <ResultsPanel {...{key:'results', title,
-                      searchDesc:searchDesc({showViewsSwitch, showImages, isTriView, leftButtons, centerButtons,
+                      searchDesc:searchDesc({showViewsSwitch, showImages, isTriViewPossible, leftButtons, centerButtons,
                           rightButtons, showCoverage:images.showCoverage, coverageSide, currLayoutMode}),
                       expanded, standard}}
                       { ...content} />
@@ -155,7 +155,7 @@ function getCovSideOptions(currLayoutMode, showImages) {
 }
 
 
-function searchDesc({showViewsSwitch, showImages, isTriView, showCoverage, leftButtons, centerButtons, rightButtons, coverageSide, currLayoutMode}) {
+function searchDesc({showViewsSwitch, showImages, isTriViewPossible, showCoverage, leftButtons, centerButtons, rightButtons, coverageSide, currLayoutMode}) {
 
     const hasContent = showViewsSwitch || leftButtons || centerButtons || rightButtons;
     if (!hasContent) return  <div/>;
@@ -190,7 +190,7 @@ function searchDesc({showViewsSwitch, showImages, isTriView, showCoverage, leftB
                                 orientation:'horizontal',
                                 onChange:(ev) => dispatchUpdateLayoutInfo({coverageSide:ev.target.value}),
                             }} /> }
-                        {isTriView &&
+                        {isTriViewPossible &&
                             <RadioGroupInputFieldView
                                 {...{
                                     sx:{pl: 1, width:420, display:'inline-flex', alignItems:'center'},

--- a/src/firefly/js/ui/PopupPanel.jsx
+++ b/src/firefly/js/ui/PopupPanel.jsx
@@ -137,9 +137,7 @@ function PopupHeaderTop({modal,zIndex,left,top,visibility,ctxRef,dialogMoveStart
                         whiteSpace:'nowrap', overflow:'hidden'}} >
                         {title}
                     </DialogTitle>
-                    <Tooltip placement='left' title='Close'>
-                        <ChipDelete onClick={askParentToClose}/>
-                    </Tooltip>
+                    <ChipDelete onClick={askParentToClose}/>
                 </Stack>
                 <Box className='ff-dialog-content' sx={{ml:.5}}>
                     {children}

--- a/src/firefly/js/ui/PositionFieldDef.js
+++ b/src/firefly/js/ui/PositionFieldDef.js
@@ -100,7 +100,7 @@ export function formatPosForHelp(wp) {
 
         s = `<div style="font-size:10px;">
               ${lonStr},&nbsp;${latStr}&nbsp;&nbsp;${csys}
-              &nbsp;&nbsp;&nbsp;<i>or</i> &nbsp;&nbsp;&nbsp;
+              &nbsp;&nbsp;&nbsp;or&nbsp;&nbsp;&nbsp;
               ${hmsRa},&nbsp;${hmsDec}&nbsp;&nbsp;${csys}
             </div>`;
 

--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -31,6 +31,7 @@ export function ColumnConstraintsPanel({tableModel}) {
     return (
         <TablePanel
             key={uniqueId()} tbl_ui_id={tableModel.tbl_id + '-ui'}
+            sx={{borderRadius:5}}
             tableModel={tableModel}
             showToolbar={false} showFilters={true} rowHeight={24}
             renderers={{ constraints: { cellRenderer: newInputCell} }}

--- a/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
+++ b/src/firefly/js/ui/tap/TableSelectViewPanel.jsx
@@ -353,7 +353,7 @@ export function BasicUI(props) {
                         </SplitContent>
                         <SplitContent>
                             { columnsModel ?
-                                <div style={{height:'100%', display:'flex', flexDirection:'column'}}>
+                                <Stack {...{height:1}}>
                                     <Typography title='Number of columns to be selected' color='neutral'  level='body-xs'>
                                         Output Column Selection and Constraints
                                     </Typography>
@@ -362,7 +362,7 @@ export function BasicUI(props) {
                                         fieldKey={'tableconstraints'}
                                         columnsModel={columnsModel}
                                     />
-                                </div>
+                                </Stack>
                                 : <div className='loading-mask'/>
                             }
                         </SplitContent>

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -275,7 +275,8 @@ const ImageViewerDecorate= memo((props) => {
         position: 'absolute',
         borderStyle: 'solid',
         borderWidth: expandedToSingle ? '0 0 0 0' : '3px 2px 2px 2px',
-        borderColor: getBorderColor(theme, pv,visRoot)
+        borderRadius: '5px',
+        borderColor: getBorderColor(theme, pv,visRoot),
     });
 
     const makeActive= () => pv?.plotId && dispatchChangeActivePlotView(pv.plotId,MOUSE_CLICK_REASON);

--- a/src/firefly/js/visualize/ui/CatalogTableListField.css
+++ b/src/firefly/js/visualize/ui/CatalogTableListField.css
@@ -1,7 +1,4 @@
 /*right list of table with catalog names to be selected*/
-.catalogtable {
-    overflow: auto;
-}
 
 .marked-text {
     color: #49a344;

--- a/src/firefly/js/visualize/ui/CatalogTableListField.jsx
+++ b/src/firefly/js/visualize/ui/CatalogTableListField.jsx
@@ -2,6 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
+import {Box} from '@mui/joy';
 import React, {PureComponent, Component, memo} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, get} from 'lodash';
@@ -59,15 +60,16 @@ export class CatalogTableView extends Component {
         });
 
         return (
-            <div style={{overflow:'auto', border:'1px solid rgba(0,0,0,.1'}}>
-                <div className='catalogtable'>
+            <Box sx={{overflow:'auto', borderColor: 'divider',
+                borderStyle: 'solid', borderWidth: '1px', borderRadius:5}}>
+                <Box sx={{overflow:'auto'}}>
                     <table style={{width:'100%'}}>
                         <tbody>
                         {items}
                         </tbody>
                     </table>
-                </div>
-            </div>
+                </Box>
+            </Box>
         );
     }
 }

--- a/src/firefly/js/visualize/ui/ColorDialog.jsx
+++ b/src/firefly/js/visualize/ui/ColorDialog.jsx
@@ -132,7 +132,7 @@ function renderStandardThreeColorView(plot,rFields,gFields,bFields) {
     return (
         <Box sx={{pt:.5}}>
             <FieldGroup groupKey={'colorDialogTabs'} keepState={false}>
-                <FieldGroupTabs initialState= {{ value:'red' }} fieldKey='colorTabs'>
+                <FieldGroupTabs initialState= {{ value:'red' }} tabId='colorTabs' fieldKey='colorTabs'>
                     {plotState.isBandUsed(Band.RED) &&
                     <Tab name='Red' id='red'>
                         <FieldGroup groupKey={RED_PANEL} keepState={true} reducerFunc={colorPanelRedReducer}>

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -11,7 +11,7 @@ import {dispatchHideDialog, dispatchShowDialog} from '../../core/ComponentCntlr.
 import {dispatchHideDropDown} from '../../core/LayoutCntlr.js';
 import {MetaConst} from '../../data/MetaConst';
 import {ServerParams} from '../../data/ServerParams.js';
-import {getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
+import {getFieldVal, setFieldValue} from '../../fieldGroup/FieldGroupUtils.js';
 import {makeFileRequest} from '../../tables/TableRequestUtil';
 import {dispatchTableSearch} from '../../tables/TablesCntlr';
 import {CheckboxGroupInputField} from '../../ui/CheckboxGroupInputField.jsx';
@@ -212,14 +212,14 @@ function ImageSearchPanelV2 ({archiveName='Search', title='Image Search', multiS
     }, []);
 
     const {wp,type}= initArgs?.searchParams ?? {};
-    const [, setTarget]= useFieldGroupValue(DEF_TARGET_PANEL_KEY,FG_KEYS.targetSelect);
-    const [, setType]= useFieldGroupValue(FD_KEYS.type,FG_KEYS.main);
+
     useEffect(() => {
         if (!wp) return;
-        setTarget(wp);
+        setFieldValue(FG_KEYS.targetSelect,DEF_TARGET_PANEL_KEY,wp);
     }, [wp]);
     useEffect(() => {
-        (type) && setType(type);
+        if (!type) return;
+        setFieldValue(FG_KEYS.type,FG_KEYS.main,type);
     }, [type]);
 
     const imageType = useStoreConnector(() => getFieldVal(FG_KEYS.main, FD_KEYS.type));
@@ -413,7 +413,7 @@ function SelectArchive({groupKey,  imageMasterData, multiSelect, isHipsImgType, 
                     <Typography {...{px:1, width:200, color:'primary', level:'title-md'}}>3. Select Target</Typography>
                     <FieldGroup groupKey={FG_KEYS.targetSelect} keepState={true}>
                         <Stack spacing={2} direction='column'>
-                            <TargetPanel labelWidth={isHips ? 150 : 100} feedbackStyle={targetStyle}
+                            <TargetPanel labelWidth={isHips ? 150 : 100}
                                          label={isHips ? 'Coordinates or Object Name (optional):' : 'Coordinates or Object Name:'}
                                          nullAllowed={true}/>
                             <SizeInputFields fieldKey={sizeKey} showFeedback={true}


### PR DESCRIPTION
#### [Firefly-1406](https://jira.ipac.caltech.edu/browse/FIREFLY-1406): fixes 1, 29, 54 (partial, not all tables), 62, 64

 - from: https://confluence.ipac.caltech.edu/display/IRSA/Testing+Feb+2024+-+Joy+UI%2C+mostly
 - fixes three color tab infinate loop
 - add pipes between tabs
 - tab panel fixes

#### Testing
- https://firefly-1406-fixes.irsakudev.ipac.caltech.edu/irsaviewer
- https://firefly-1406-fixes.irsakudev.ipac.caltech.edu/irsaviewer/dce
- https://fireflydev.ipac.caltech.edu/firefly-1406-fixes/firefly
- image borders and some table border are round
- tabs have pipes between 



check when confirmed:

- [x] 1
- [x] 29
- [ ] 54 (partial)
- [x] 62
- [x] not 64, 63
- [x] tabs have pipes between
- [ ] 3 color panel works

