### PR TITLE
FIREFLY-1402: more chart related UI conversion changes

### DIFF
--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -31,7 +31,7 @@ export const BY_SCROLL = 'byScroll';
 const BasicTableViewInternal = React.memo((props) => {
 
     const {width, height} = props.size;
-    const {columns, data, hlRowIdx, renderers, bgColor, selectInfoCls, callbacks, rowHeight, rowHeightGetter, showHeader=true,
+    const {columns, data, hlRowIdx, renderers, selectInfoCls, callbacks, rowHeight, rowHeightGetter, showHeader=true,
             error, tbl_ui_id=uniqueTblUiId(), currentPage, startIdx=0, highlightedRowHandler, cellRenderers} = props;
 
     const uiStates = getTableUiById(tbl_ui_id) || {};
@@ -96,7 +96,7 @@ const BasicTableViewInternal = React.memo((props) => {
         }
     }, [columns, columnWidths, width, adjScrollLeft, adjScrollTop]);
 
-    const makeColumnsProps = {columns, data, selectable, selectInfoCls, renderers, bgColor,
+    const makeColumnsProps = {columns, data, selectable, selectInfoCls, renderers,
         columnWidths, filterInfo, sortInfo, showHeader, showUnits, showTypes, showFilters,
         onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected, startIdx, cellRenderers, tbl_id};
 
@@ -146,13 +146,7 @@ const BasicTableViewInternal = React.memo((props) => {
     };
 
     return (
-        <Box tabIndex='-1' onKeyDown={onKeyDown}
-              sx={{lineHeight:1, flexGrow:1, minHeight:0, minWidth:0,
-                  '& .fixedDataTableRowLayout_main.highlighted div': {
-                      backgroundColor: 'warning.softBg',
-                  }
-              }}
-        >
+        <Box tabIndex='-1' onKeyDown={onKeyDown} sx={{lineHeight:1, flexGrow:1, minHeight:0, minWidth:0}}>
             {content()}
             <Status/>
         </Box>
@@ -179,7 +173,6 @@ BasicTableViewInternal.propTypes = {
     showMask: PropTypes.bool,
     currentPage: PropTypes.number,
     startIdx: PropTypes.number,
-    bgColor: PropTypes.string,
     error:  PropTypes.string,
     size: PropTypes.object.isRequired,
     highlightedRowHandler: PropTypes.func,
@@ -204,7 +197,7 @@ BasicTableViewInternal.defaultProps = {
     selectable: false,
     showTypes: false,
     showMask: false,
-    rowHeight: 27,
+    rowHeight: 20,
     currentPage: -1
 };
 
@@ -355,7 +348,7 @@ function defHighlightedRowHandler(tbl_id, hlRowIdx, startIdx) {
     return (rowIndex) => {
         const absRowIndex = startIdx + rowIndex;
         if (hasProprietaryInfo && !hasRowAccess(tableModel, absRowIndex)) {
-            return hlRowIdx === rowIndex ? 'TablePanel__no-access--highlighted' : 'TablePanel__no-access';
+            return hlRowIdx === rowIndex ? 'no-access-highlighted' : 'no-access';
         }
         if (hlRowIdx === rowIndex) return 'highlighted';
         if (isRelated(rowIndex)) return 'related';
@@ -401,7 +394,7 @@ function makeColumnTag(props, col, idx) {
     );
 }
 
-function makeSelColTag({selectable, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected, bgColor='white', selectInfoCls, onRowSelect}) {
+function makeSelColTag({selectable, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected, selectInfoCls, onRowSelect}) {
 
     if (!selectable) return false;
 

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -118,14 +118,38 @@
 Overriding default fixed-table css
 */
 
+.public_fixedDataTableCell_main, .public_fixedDataTableCell_cellContent{
+    padding: 0 2px;
+}
+
 .fixedDataTableRowLayout_rowWrapper {
     font-size: 12px;
 }
 
-.public_fixedDataTableCell_cellContent {
-    padding: 2px;
+.fixedDataTableCellLayout_main {
+    border-style: solid;
+    border-width: 0 1px 1px 0;
 }
 
+.fixedDataTableRowLayout_main div {
+    background-color: var(--joy-palette-background-surface, #FBFCFE);
+}
+
+.fixedDataTableRowLayout_main.highlighted div {
+    background-color: var(--joy-palette-warning-softHoverBg, #FDF0E1);
+}
+
+.fixedDataTableRowLayout_main.related div {
+    background-color: var(--joy-palette-warning-softBg, #FDF0E1);
+}
+
+.fixedDataTableRowLayout_main.no-access div {
+    background-color: var(--joy-palette-danger-softBg, #FCE4E4);
+}
+
+.fixedDataTableRowLayout_main.no-access-highlighted div {
+    background-color: var(--joy-palette-danger-softHoverBg, #F7C5C5);
+}
 
 .public_fixedDataTableCell_main, .public_fixedDataTableRow_main, .public_fixedDataTable_scrollbarSpacer,
 .public_fixedDataTableRow_highlighted .public_fixedDataTableCell_main,
@@ -136,7 +160,8 @@ Overriding default fixed-table css
     font-weight: unset;
 }
 
-.fixedDataTableRowLayout_main.related div {
-    background-color: #faf4e5;
+.fixedDataTableCellLayout_columnResizerContainer, .public_fixedDataTable_scrollbarSpacer {
+    background-color: unset !important;
 }
+
 

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -279,6 +279,7 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
         return (
             <SettingsButton tip={TT_OPTIONS}
                             onClick={showOptionsDialog}
+                            iconButtonSize='30px'
                             sx={{position:'absolute', top:-4, right:-4, zIndex: DDzIndex}}  //
             />
         );

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -258,7 +258,7 @@ export const ColumnOptions = React.memo(({tbl_id, tbl_ui_id, ctm_tbl_id, onChang
                 showTypes={false}
                 showFilters={true}
                 selectable = {true}
-                rowHeight = {27}
+                rowHeight = {26}
                 highlightedRowHandler = {()=>undefined}
             />
         </div>

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -232,7 +232,7 @@ function EnumSelect({col, tbl_id, filterInfoCls, onFilter}) {
 export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected, style, sx}) {
     sx = {height: 1, justifyContent: 'space-around', ...style, ...sx};
     return (
-        <Stack alignItems='center' bgcolor='background.surface' sx={sx}>
+        <Stack alignItems='center' sx={sx}>
             <Checkbox size='sm' sx={{mt:'2px'}}
                 tabIndex={-1}
                 checked={checked}
@@ -251,7 +251,7 @@ export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, s
 
 export function SelectableCell ({rowIndex, selectInfoCls, onRowSelect, sx={}}) {
     return (
-        <Stack alignItems='center' justifyContent='center' height={1} bgcolor='background.surface' sx={sx}>
+        <Stack alignItems='center' justifyContent='center' height={1} sx={sx}>
             <Checkbox size='sm' mt='1x' mb='1px'
                       tabIndex={-1}
                       checked={selectInfoCls.isSelected(rowIndex)}
@@ -324,7 +324,7 @@ function findTableFor(element) {
     return cEl;
 }
 
-export function ContentEllipsis({children, text, sx, actions=[]}) {
+export function ContentEllipsis({children, text, textAlign, sx, actions=[]}) {
 
     const [hasActions, setHasActions] = useState(false);
     const actionsEl = useRef(null);
@@ -366,7 +366,7 @@ export function ContentEllipsis({children, text, sx, actions=[]}) {
     };
 
     return (
-        <Stack direction='row'  overflow='hidden' alignItems='center' sx={sx}
+        <Stack direction='row'  overflow='hidden' whiteSpace='nowrap' alignItems='center' justifyContent={textAlign} height={1} width={1} sx={sx}
                onMouseEnter={checkOverflow} onMouseLeave={() => setHasActions(false)}
         >
             {React.Children.only(children)}
@@ -392,14 +392,15 @@ export const CellWrapper =  React.memo( (props) => {
 
     const cellInfo = getCellInfo({columnKey, col, rowIndex, data, tbl_id, startIdx});
     const {textAlign, text} = cellInfo;
-    const lineHeight = '2em';
 
-    const content = (
-        <Stack textAlign={textAlign} lineHeight={lineHeight} px={1/4} bgcolor='background.surface'>
-            <CellRenderer {...omit(props, 'Content')} cellInfo={cellInfo}/>
+    const content = <CellRenderer {...omit(props, 'Content')} cellInfo={cellInfo}/>;
+    const contentWithWrapper = (
+        <Stack alignItems={textAlign} justifyContent='center' whiteSpace='nowrap' height={1} width={1}>
+            {content}
         </Stack>
     );
-    return CellRenderer?.allowActions ? <ContentEllipsis text={text}>{content}</ContentEllipsis> : content;
+
+    return CellRenderer?.allowActions ? <ContentEllipsis {...{textAlign, text}}>{content}</ContentEllipsis> : contentWithWrapper;
 
 }, skipCellRender);
 
@@ -486,7 +487,7 @@ export const createLinkCell = ({hrefColIdx, value}) => {
         if (href && href !== '#') {
             return (
                 <Cell {...{rowIndex, height, width, columnKey}}>
-                    <a target='_blank' href={href}>{val}</a>
+                    <Link target='_blank' href={href}>{val}</Link>
                 </Cell>
             );
         } else {
@@ -762,7 +763,7 @@ export const ATag = React.memo(({cellInfo, label, title, href, target, style={},
         label = html_regex.test(label) ? <div dangerouslySetInnerHTML={{__html: label}}/> : label;
     }
 
-    return <a {...{title, href, target, style}}> {label} </a>;
+    return <Link {...{title, href, target, style}}> {label} </Link>;
 });
 
 export const TextCell = React.memo(({cellInfo, text, ...rest}) => {

--- a/src/firefly/js/ui/FireflyRoot.jsx
+++ b/src/firefly/js/ui/FireflyRoot.jsx
@@ -29,7 +29,10 @@ export function FireflyRoot({sx, children}) {
             <ScopedCssBaseline sx={(theme) => ({
                 flexGrow:1 | (localTheme = theme),
                 height:1,
-                position:'relative', ...sx
+                position:'relative',
+                fontSmooth: 'unset',
+                WebkitFontSmoothing: 'unset',
+                ...sx
             })}>
                 <App>{children}</App>
             </ScopedCssBaseline>

--- a/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
+++ b/src/firefly/js/ui/tap/ColumnConstraintsPanel.jsx
@@ -33,7 +33,7 @@ export function ColumnConstraintsPanel({tableModel}) {
             key={uniqueId()} tbl_ui_id={tableModel.tbl_id + '-ui'}
             sx={{borderRadius:5}}
             tableModel={tableModel}
-            showToolbar={false} showFilters={true} rowHeight={24}
+            showToolbar={false} showFilters={true} rowHeight={26}
             renderers={{ constraints: { cellRenderer: newInputCell} }}
         />
     );

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -405,7 +405,7 @@ class ConstraintPanel extends PureComponent {
                                     currentPage={1}
                                     key={tableModel.tbl_id}
                                     error={tableModel.error}
-                                    rowHeight={24}
+                                    rowHeight={26}
                                     callbacks={{
                                         onRowSelect: updateRowSelected(tableModel.tbl_id, onTableChanged),
                                         onSelectAll: updateRowSelected(tableModel.tbl_id, onTableChanged)


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1402

Fixed so far:

Table UI:
Apply full borders to table cells, set the font size to 12px, reduce the row height to 20px(back to pre-Joy's height), and unset font smoothing.

13.5: 
VO TAP search, look at "Output Column Selection and Constraints" part of the screen. Scroll left and right. The part of the "Name" column that is not occupied by text is transparent! you can see the contents of the rest of the table as you scroll left/right.

18:
when in dark mode, the text color used for links is unreadable
(found in: iv image results, when many images loaded, list of images pop up)


Test: https://fireflydev.ipac.caltech.edu/firefly-1402-more-chart-conversion/firefly/

