### PR TITLE
Firefly-1407: response to some CCB-D feedback and #9, #10, #19, 24.5,…

### DIFF
--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -85,6 +85,7 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
     return (
         <Sheet {...{variant, ...slotProps?.tablePanel}}
                sx ={{
+                   borderRadius: variant==='outlined' ? '5px' : undefined,
                    position:'relative',
                    overflow: 'hidden',
                    boxSizing: 'border-box',

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -644,7 +644,7 @@ function LcPFOptions({fields}) {
                                 </li>
                                 <Typography component='li' display='list-item' sx={{mt:1/2}}>
                                     <Chip onClick={startPeriodogramPopup(LC.FG_PERIODOGRAM_FINDER)}
-                                          color='success' variant={hasPeriodgramData?'soft':'solid'}>
+                                          color='warning' variant={hasPeriodgramData?'soft':'solid'}>
                                         {hasPeriodgramData ? 'Recalculate Periodogram' : 'Calculate Periodogram'}
                                     </Chip>
                                 </Typography>

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -155,7 +155,7 @@ function  PeriodogramButton(props) {
         <div style={{height: '100%',
                      display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
             <Button  sx={{maxWidth: '50%'}}
-                     color='success'
+                     color='warning'
                      variant='solid'
                     onClick={startPeriodogramPopup(groupKey)}>Calculate Periodogram</Button>
             <div style={{marginLeft:10}}>

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -127,7 +127,7 @@ export function defaultDownloadPanel(mission='', cutoutSize, addtlParams={}) {
         <DownloadButton
             makeButton={(onClick,tbl_id,isRowSelected) => {
                 return (
-                    <Button {...{size: 'md', variant: isRowSelected ? 'solid' : 'soft', color: 'success', onClick}} >
+                    <Button {...{size: 'md', variant: isRowSelected ? 'solid' : 'soft', color: 'warning', onClick}} >
                         Prepare Download
                     </Button>
                 );

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -104,7 +104,7 @@ export function DownloadButton({tbl_id:inTblId , tbl_grp, children, checkSelecte
     const isRowSelected = selectInfoCls.getSelectedCount()>0;
 
     const defButton=
-        <ToolbarButton variant='soft' color='primary' onClick={() =>onClick()} text='Prepare Download'/>;
+        <ToolbarButton variant={isRowSelected?'solid':'soft'} color='warning' onClick={() =>onClick()} text='Prepare Download'/>;
 
     return (
         makeButton?.(onClick,tbl_id,isRowSelected) ?? defButton

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -49,7 +49,7 @@ const ChooseUploadFile= ({onChange, value, fileName, canDragDrop}) => (
         <Tooltip title={`Click to choose a file${canDragDrop ?' or just drag and drop a file':''}`}>
             <label htmlFor='upload-file'>
                 <Input id='upload-file' type='file' onChange={onChange} sx={{display:'none'}}/>
-                <Button color='success' variant={fileName?'soft':'solid'} aria-label='upload file' component='span'>
+                <Button color='warning' variant={fileName?'soft':'solid'} aria-label='upload file' component='span'>
                     {fileName?'Replace File':'Choose File'}
                 </Button>
             </label>

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -56,7 +56,7 @@ export const HiPSImageSelect= ({groupKey}) => {
         );
     } else {
         return (
-            <Sheet variant='outlined' sx={{mt:1/2, py:1, width:'100%', display:'flex', flexDirection:'column', flex:'1 1 auto'}}>
+            <Sheet variant='outlined' sx={{mt:1/2, py:1, width:'100%', display:'flex', flexDirection:'column', flex:'1 1 auto', borderRadius:'5px'}}>
                 <Stack {...{flexGrow:1, spacing:1, height:'100%', width:'100%'}}>
                     <Stack {...{direction:'row', spacing:2, alignItems:'center'}}>
                         <Typography {...{px:1, color:'primary', level:'title-md'}}>4. Select Data Set</Typography>

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -461,7 +461,7 @@ function Header({project, hrefInfo='', multiSelect}) {
                         options={[{label:project, value:'_all_'}]}
                         alignment='horizontal'
                         labelWidth={35}
-                        wrapperStyle={{whiteSpace: 'normal' /*cursor:'pointer'*/}}
+                        sx={{fontWeight: 'normal'}}
                     />
                 </div>
                 <InfoIcon/>

--- a/src/firefly/js/ui/InputAreaFieldView.jsx
+++ b/src/firefly/js/ui/InputAreaFieldView.jsx
@@ -9,6 +9,7 @@ import {inputFieldTooltipProps, inputFieldValue} from 'firefly/ui/InputFieldView
 export const InputAreaFieldView= forwardRef( ({ visible=true,label,tooltip,value,
                                                   button, valid=true,onChange, onBlur,
                                                   showWarning=true, connectedMarker=false,
+                                                 placeholderHighlight,
                                                   message='', type, placeholder, idName='', sx, slotProps,
                                                   orientation='vertical', minRows=2, maxRows=4 }, ref ) => {
     const connectContext= useContext(ConnectionCtx);
@@ -32,6 +33,10 @@ export const InputAreaFieldView= forwardRef( ({ visible=true,label,tooltip,value
                                       value: inputFieldValue(type, value),
                                       onChange: (ev) => onChange?.(ev),
                                       onBlur: (ev) => onBlur?.(ev),
+                                      sx: {
+                                          '--Textarea-placeholderColor': placeholderHighlight ?
+                                              'var(--joy-palette-warning-plainColor)' : 'inherit'
+                                      },
                                       ...slotProps?.textArea
                                   }
                               }}

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -1,6 +1,6 @@
 import {Divider, FormControl, FormHelperText, FormLabel, Stack} from '@mui/joy';
 import React, {useEffect, memo, useState, useContext} from 'react';
-import PropTypes, {bool, object} from 'prop-types';
+import PropTypes, {bool, object, shape} from 'prop-types';
 import {convertAngle} from '../visualize/VisUtil.js';
 import {ConnectionCtx} from './ConnectionCtx.js';
 import {InputFieldView} from './InputFieldView.jsx';
@@ -81,6 +81,7 @@ function getFeedback(unit, min, max, showFeedback) {
 
 const SizeInputFieldView= (props) => {
     const {nullAllowed, min, max, sx, inputStyle={}, connectedMarker= false,
+        orientation='vertical', slotProps,
         label, showFeedback, onChange} = props;
     const [{value, valid, displayValue, unit},setState]= useState(() => updateSizeInfo(props));
     const {feedback, errmsg}= getFeedback(unit,min,max,showFeedback);
@@ -125,44 +126,48 @@ const SizeInputFieldView= (props) => {
 
     return (
         <Stack sx={sx}>
-            <FormControl orientation='vertical'>
-                {label && <FormLabel>{label}</FormLabel>}
-                <Stack spacing={1} direction='row'>
-                    <InputFieldView {...{
-                        valid,
-                        inputStyle,
-                        onChange:onSizeChange,
-                        onBlur:onSizeChange,
-                        value:displayValue,
-                        message:errmsg,
-                        connectedMarker: connectedMarker || connectContext.controlConnected,
-                        endDecorator:(
-                            <Stack direction='row' alignItems='center'>
-                                <Divider orientation='vertical'/>
-                                <ListBoxInputFieldView
-                                    onChange={onUnitChange}
-                                    value={unit} multiple={false} label='' tooltip='unit of the size'
-                                    options={[
-                                        {label: 'degrees', value: 'deg'},
-                                        {label: 'arcminutes', value: 'arcmin'},
-                                        {label: 'arcseconds', value: 'arcsec'}
-                                    ]}
-                                    slotProps={{
-                                        input: {
-                                            variant:'plain',
-                                            sx:{minHeight:'unset'}
-                                            // sx:{'&:hover': { bgcolor: 'transparent' } }
-                                        }
-                                    }}
-                                />
-                            </Stack>
-                        ),
-                        sx:{'& .MuiInput-root':{ 'paddingInlineEnd': 0, }},
-                        tooltip:'enter size within the valid range'
-                    }} />
-                </Stack>
-                <FormHelperText>{feedback}</FormHelperText>
-            </FormControl>
+            <Stack>
+                <FormControl orientation={orientation}>
+                    {label && <FormLabel>{label}</FormLabel>}
+                    <Stack spacing={1} direction='row'>
+                        <InputFieldView {...{
+                            valid,
+                            inputStyle,
+                            onChange:onSizeChange,
+                            onBlur:onSizeChange,
+                            value:displayValue,
+                            message:errmsg,
+                            connectedMarker: connectedMarker || connectContext.controlConnected,
+                            endDecorator:(
+                                <Stack direction='row' alignItems='center'>
+                                    <Divider orientation='vertical'/>
+                                    <ListBoxInputFieldView
+                                        onChange={onUnitChange}
+                                        value={unit} multiple={false} label='' tooltip='unit of the size'
+                                        options={[
+                                            {label: 'degrees', value: 'deg'},
+                                            {label: 'arcminutes', value: 'arcmin'},
+                                            {label: 'arcseconds', value: 'arcsec'}
+                                        ]}
+                                        slotProps={{
+                                            input: {
+                                                variant:'plain',
+                                                sx:{minHeight:'unset'}
+                                                // sx:{'&:hover': { bgcolor: 'transparent' } }
+                                            }
+                                        }}
+                                    />
+                                </Stack>
+                            ),
+                            sx:{'& .MuiInput-root':{ 'paddingInlineEnd': 0, }},
+                            tooltip:'enter size within the valid range'
+                        }} />
+                    </Stack>
+                </FormControl>
+                <FormHelperText {...{...slotProps?.feedback}}>
+                    {feedback}
+                </FormHelperText>
+            </Stack>
         </Stack>
     );
 };
@@ -174,14 +179,17 @@ SizeInputFieldView.propTypes = {
     sx: object,
     displayValue: PropTypes.string,
     label:    PropTypes.string,
+    orientation: PropTypes.string,
     nullAllowed: PropTypes.bool,
     onChange: PropTypes.func,
     value: PropTypes.any,
     valid: PropTypes.bool,
     showFeedback: PropTypes.bool,
     inputStyle: PropTypes.object,
-    style: PropTypes.object,  // replaces wrapper style
     connectedMarker: bool,
+    slotProps: shape({
+        feedback: object,
+    })
 };
 
 SizeInputFieldView.defaultProps = {
@@ -221,6 +229,7 @@ SizeInputFields.propTypes={
     groupKey : PropTypes.string,
     connectedMarker: bool,
     sx: object,
+    orientation: PropTypes.string,
     initialState: PropTypes.shape({
         value: PropTypes.any,
         tooltip:  PropTypes.string,

--- a/src/firefly/js/ui/TargetFeedback.jsx
+++ b/src/firefly/js/ui/TargetFeedback.jsx
@@ -24,11 +24,11 @@ const defaultExamples= (targetPanelExampleRow1, targetPanelExampleRow2) => {
         );
 };
 
-export function TargetFeedback ({showHelp, feedback, style={}, targetPanelExampleRow1, targetPanelExampleRow2, examples}) {
+export function TargetFeedback ({showHelp, feedback, sx, targetPanelExampleRow1, targetPanelExampleRow2, examples}) {
     const minHeight= '3rem';
     if (!showHelp) {
         return (
-            <FormHelperText sx={{textAlign:'center', minHeight}}>
+            <FormHelperText sx={{textAlign:'center', minHeight, ...sx}}>
                 <Typography component='div'>
                     <span dangerouslySetInnerHTML={{ __html : feedback }}/>
                 </Typography>
@@ -36,7 +36,7 @@ export function TargetFeedback ({showHelp, feedback, style={}, targetPanelExampl
         );
     }
     return (
-            <FormHelperText sx={{textAlign:'center', minHeight}}>
+            <FormHelperText sx={{textAlign:'center', minHeight, ...sx}}>
                 <Typography level='body-sm'>
                     <i>Examples: </i>
                 </Typography>

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -4,7 +4,7 @@
 
 import {Box, Divider, Stack} from '@mui/joy';
 import React, {memo, useContext, useEffect} from 'react';
-import PropTypes, {bool} from 'prop-types';
+import PropTypes, {arrayOf, object, bool, number, string, shape} from 'prop-types';
 import {ConnectionCtx} from './ConnectionCtx.js';
 import {parseTarget} from './TargetPanelWorker.js';
 import {formatPosForTextField, formatTargetForHelp} from './PositionFieldDef.js';
@@ -19,16 +19,17 @@ import {isValidPoint, parseWorldPt} from '../visualize/Point.js';
 
 const TARGET= 'targetSource';
 const RESOLVER= 'resolverSource';
-const LABEL_DEFAULT='Coords or Obj Name:';
+const LABEL_DEFAULT='Coords or Obj Name';
 
 const nedThenSimbad= 'nedthensimbad';
 const simbadThenNed= 'simbadthenned';
 
 const TargetPanelView = (props) =>{
-    const {showHelp, feedback, valid, message, onChange, value, button,
+    const {showHelp, feedback, valid, message, onChange, value, button, slotProps,
         children, resolver, feedbackStyle, showResolveSourceOp= true, showExample= true,
+        label= LABEL_DEFAULT,
         targetPanelExampleRow1, targetPanelExampleRow2,
-        connectedMarker=false,
+        connectedMarker=false, placeholderHighlight=true,
         examples, onUnmountCB, sx}= props;
 
     useEffect(() => () => onUnmountCB(props),[]);
@@ -38,12 +39,20 @@ const TargetPanelView = (props) =>{
 
     const positionField = (
         <InputFieldView {...{valid, visible:true, message,
-            placeholder:'Coords or Obj Name',
+            placeholder:label,
             onChange: (ev) => onChange(ev.target.value, TARGET),
             endDecorator,
             sx : makeSx(showResolveSourceOp, Boolean(button),sx),
             value,
             tooltip:'Enter a target',
+            slotProps: {
+                input: {
+                    sx: {
+                        '--Input-placeholderColor': placeholderHighlight ?
+                            'var(--joy-palette-warning-plainColor)' : 'inherit'
+                    }
+                }
+            },
             connectedMarker:connectedMarker||connectContext.controlConnected,
             }}
         />);
@@ -54,8 +63,8 @@ const TargetPanelView = (props) =>{
     return (
         <Stack direction='column'>
             {positionInput}
-            {(showExample || !showHelp) && <TargetFeedback {...{showHelp, feedback, style:feedbackStyle,
-                targetPanelExampleRow1, targetPanelExampleRow2, examples}}/> }
+            {(showExample || !showHelp) && <TargetFeedback {...{showHelp, feedback,
+                targetPanelExampleRow1, targetPanelExampleRow2, examples, ...slotProps?.feedback}}/> }
         </Stack>
     );
 };
@@ -72,7 +81,6 @@ TargetPanelView.propTypes = {
     message: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     value : PropTypes.string.isRequired,
-    labelWidth : PropTypes.number,
     onUnmountCB : PropTypes.func,
     feedbackStyle: PropTypes.object,
     nullAllowed: PropTypes.bool,
@@ -80,7 +88,10 @@ TargetPanelView.propTypes = {
     targetPanelExampleRow1: PropTypes.arrayOf(PropTypes.string),
     targetPanelExampleRow2: PropTypes.arrayOf(PropTypes.string),
     connectedMarker: bool,
-    showExample: PropTypes.bool
+    showExample: PropTypes.bool,
+    slotProps: shape({
+        feedback: object,
+    })
 };
 
 function makeEndDecorator(showResolveSourceOp, onChange, resolver, button) {
@@ -219,19 +230,19 @@ export const TargetPanel = memo( ({fieldKey= DEF_TARGET_PANEL_KEY,initialState= 
 });
 
 TargetPanel.propTypes = {
-    sx: PropTypes.object,
-    fieldKey: PropTypes.string,
-    groupKey: PropTypes.string,
-    examples: PropTypes.object,
-    labelWidth : PropTypes.number,
-    nullAllowed: PropTypes.bool,
-    initialState: PropTypes.object,
-    showResolveSourceOp: PropTypes.bool,
-    targetPanelExampleRow1: PropTypes.arrayOf(PropTypes.string),
-    targetPanelExampleRow2: PropTypes.arrayOf(PropTypes.string),
-    showExample: PropTypes.bool,
+    sx: object,
+    fieldKey: string,
+    groupKey: string,
+    examples: object,
+    nullAllowed: bool,
+    initialState: object,
+    showResolveSourceOp: bool,
+    targetPanelExampleRow1: arrayOf(PropTypes.string),
+    targetPanelExampleRow2: arrayOf(PropTypes.string),
+    showExample: bool,
     connectedMarker: bool,
-    defaultToActiveTarget: PropTypes.bool,
+    placeholderHighlight: bool,
+    defaultToActiveTarget: bool,
 };
 
 
@@ -256,7 +267,7 @@ function computeProps(viewProps, componentProps, fieldKey, groupKey) {
     return {
         ...viewProps,
         visible: true,
-        label: 'Coords or Obj Name:',
+        label: 'Coords or Obj Name',
         tooltip: 'Enter a target',
         value,
         feedback,

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -206,6 +206,8 @@ function makeBorder(active, theme,color) {
         borderTop: `1px solid ${borderC}`,
         borderLeft: `1px solid ${borderC}`,
         borderRight: `1px solid ${borderC}`,
+        borderBottomRightRadius: active ?0 : undefined,
+        borderBottomLeftRadius: active ?0 : undefined,
     };
 }
 

--- a/src/firefly/js/ui/dynamic/DynComponents.jsx
+++ b/src/firefly/js/ui/dynamic/DynComponents.jsx
@@ -334,10 +334,10 @@ export function PolygonField({ fieldKey, desc = 'Coordinates', initValue = '', s
         <div key={fieldKey} style={style}>
             <VisualPolygonPanel {...{
                 fieldKey,
-                wrapperStyle: {display: 'flex', alignItems: 'center'},
                 style: {width: 350, maxWidth: 420},
                 initValue,
-                label: desc,
+                placeholder: desc,
+                placeholderHighlight: true,
                 labelStyle: {},
                 tooltip,
                 sRegion,

--- a/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
@@ -94,27 +94,31 @@ export function EmbeddedPositionSearchPanel({
                     tooltip: 'Chose type of search', initialState: {value: initToggle}, options: CONE_AREA_OPTIONS
                 }} />}
                 {doGetConeAreaOp() === CONE_CHOICE_KEY &&
-                    <Stack {...{pt:1/2, spacing:1}}>
+                    <Stack {...{pt:1/2}}>
                         <TargetPanel {...{
                             sx:{width:'34rem'},
                             fieldKey:targetKey, nullAllowed,
-                            targetPanelExampleRow1, targetPanelExampleRow2
+                            targetPanelExampleRow1, targetPanelExampleRow2,
+                            slotProps: {
+                                feedback:{sx: {alignSelf:'center'} },
+                            }
                         }}/>
                         <SizeInputFields {...{
-                            style:{paddingBottom:10},
                             fieldKey: sizeKey, showFeedback: true, labelWidth: 100, nullAllowed: false,
-                            labelStyle:{textAlign:'right', paddingRight:4},
+                            // orientation:'horizontal',
                             label: 'Search Radius',
+                            slotProps: {
+                                feedback:{sx: {alignSelf:'center'} },
+                            },
                             initialState: {unit: 'arcsec', value: searchAreaInDeg + '', min:minValue, max:maxValue}
                         }} />
                     </Stack>
                 }
                 {doGetConeAreaOp() === POLY_CHOICE_KEY &&
                     <PolygonField {...{
-                        style: {paddingTop:5},
                         hideHiPSPopupPanelOnDismount: false, fieldKey: polygonKey,
                         targetDetails: {targetPanelExampleRow1: polygonExampleRow1, targetPanelExampleRow2:polygonExampleRow2},
-                        desc: 'Coordinates',
+                        placeholder: 'Coordinates',
                         manageHiPS:false,
                     }} />}
             </Stack>
@@ -142,7 +146,7 @@ export function EmbeddedPositionSearchPanel({
                         borderRadius: '5px 5px 2px 2px',
                         border: `3px solid ${theme.vars.palette['neutral']?.softActiveBg}`,
                         position: 'absolute',
-                        p: 1/4,
+                        px: 1/2,
                         bottom: '1.5rem',
                         left: 3,
                     })

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -287,43 +287,45 @@ function TabHeader({children, slotProps}) {
     return (
         <TabList
             ref={toolbarEl}
-            sx={{
-                flexGrow: 1,
-                overflow: 'auto',
-                scrollSnapType: 'x mandatory',              // make tab snap to the nearest tab
-                '&::-webkit-scrollbar': { display: 'none' },
-                [`& .${tabClasses.root}`]: {
-                    '&[aria-selected="true"]': {            // apply this to the selected tab
-                        bgcolor: activeBg,                  // set tab background to active color
-                        borderColor: 'divider',
-                        '&::before': {                      // this is the strip under the tab to cover the border
-                            content: '""',
-                            display: 'block',
-                            position: 'absolute',
-                            height: 2,
-                            bottom: -2,
-                            left: 0,
-                            right: 0,
-                            bgcolor: activeBg,              // set this to the active color so that it look like it's part of the active tab
+            sx={ (theme) => ( {
+                    flexGrow: 1,
+                    overflow: 'auto',
+                    scrollSnapType: 'x mandatory',              // make tab snap to the nearest tab
+                    fontWeight: theme.fontWeight.md,
+                    '&::-webkit-scrollbar': { display: 'none' },
+                    [`& .${tabClasses.root}`]: {
+                        '&[aria-selected="true"]': {            // apply this to the selected tab
+                            bgcolor: activeBg,                  // set tab background to active color
+                            borderColor: 'divider',
+                            '&::before': {                      // this is the strip under the tab to cover the border
+                                content: '""',
+                                display: 'block',
+                                position: 'absolute',
+                                height: 2,
+                                bottom: -2,
+                                left: 0,
+                                right: 0,
+                                bgcolor: activeBg,              // set this to the active color so that it look like it's part of the active tab
+                            },
                         },
-                    },
-                    '&[aria-selected="false"]': {            // add pipes after non-selected tabs
-                        '&::after': {
-                            content: '""',
-                            display: 'block',
-                            position: 'absolute',
-                            height: '1.1rem',
-                            bottom: -2,
-                            left: 0,
-                            right: -2,
-                            zIndex:1,                      //zIndex necessary so the hover does not cover pipe
-                            borderRightColor: 'divider',
-                            borderRightStyle: 'solid',
-                            borderRightWidth: '1px'
+                        '&[aria-selected="false"]': {            // add pipes after non-selected tabs
+                            '&::after': {
+                                content: '""',
+                                display: 'block',
+                                position: 'absolute',
+                                height: '1.1rem',
+                                bottom: -2,
+                                left: 0,
+                                right: -2,
+                                zIndex: 1,                      //zIndex necessary so the hover does not cover pipe
+                                borderRightColor: 'divider',
+                                borderRightStyle: 'solid',
+                                borderRightWidth: '1px'
+                            },
                         },
-                    },
-                },
-            }}
+                    }
+            } )
+            }
             {...{variant:tabListVar, ...slotProps?.tabList}}
         >
             {tabHeaders}

--- a/src/firefly/js/visualize/iv/PlotTitle.jsx
+++ b/src/firefly/js/visualize/iv/PlotTitle.jsx
@@ -27,7 +27,7 @@ export const PlotTitle= memo(({plotView:pv, brief, working}) => {
 
         const tooltip= (
             <Stack direction='column'>
-                <Typography level={plot.title?.length > 30 ? 'body-xs' : 'body-md'}>{plot.title}</Typography>
+                <Typography level={plot.title?.length > 30 ? 'title-xs' : 'title-md'}>{plot.title}</Typography>
                 {world && tipEntry('Horizontal field of view:',zlRet.fovFormatted) }
                 {isImage(plot) && tipEntry('Zoom Level:', zlRet.zoomLevelFormatted)}
                 {Boolean(pv.rotation) && tipEntry('Rotation:', rotString)}
@@ -50,8 +50,8 @@ export const PlotTitle= memo(({plotView:pv, brief, working}) => {
         return (
             <Tooltip title={tooltip} placement='right-end'>
                 <Stack direction='row' alignItems='center' sx={plotTitleInlineTitleContainer}>
-                    <Typography {...{level:'body-sm', textOverflow: 'ellipsis', overflow: 'hidden', maxWidth: '35ch'}}>{plot.title}</Typography>
-                    <Typography {...{level:'body-sm', color:'warning', pl:.75, overflow: 'hidden', component:'div'}}>
+                    <Typography {...{level:'title-sm', textOverflow: 'ellipsis', overflow: 'hidden', maxWidth: '35ch'}}>{plot.title}</Typography>
+                    <Typography {...{level:'body-sm', pl:.75, overflow: 'hidden', component:'div'}}>
                         <div dangerouslySetInnerHTML={{__html:zlStr}}/>
                     </Typography>
                     {Boolean(!brief && rotString) && <Typography level='body-sm' color='warning'>{`, ${rotString}`}</Typography> }

--- a/src/firefly/js/visualize/region/RegionFileUploadView.jsx
+++ b/src/firefly/js/visualize/region/RegionFileUploadView.jsx
@@ -9,6 +9,7 @@ import {Box, Stack} from '@mui/joy';
 import React, {useState} from 'react';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
+import HelpIcon from '../../ui/HelpIcon.jsx';
 import {dispatchCreateRegionLayer, dispatchCreateFootprintLayer} from '../DrawLayerCntlr.js';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
@@ -145,13 +146,14 @@ const RegionUpload= () => {
                         {!upload && ( (message && `*${message}`) || '*region error')}
                     </div>
 
-                    <CompleteButton
-                        sx={{mt:5}}
-                        dialogId={popupId}
-                        groupKey={rgUploadGroupKey}
-                        onSuccess={(request) => uploadAndProcessRegion(request, setUpload, setMessage)}
-                        closeOnValid={false}
-                        text='Draw'/>
+                    <Stack {...{direction:'row', alignItems:'center', justifyContent:'space-between'}}>
+                        <CompleteButton
+                            dialogId={popupId}
+                            onSuccess={(request) => uploadAndProcessRegion(request, setUpload, setMessage)}
+                            closeOnValid={false}
+                            text='Draw'/>
+                        <HelpIcon helpId={'visualize.ds9.upload'}/>
+                    </Stack>
 
                 </Stack>
             </FieldGroup>

--- a/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
+++ b/src/firefly/js/visualize/ui/CatalogConstraintsPanel.jsx
@@ -390,10 +390,10 @@ class ConstraintPanel extends PureComponent {
         const totalCol = columns ? (columns.length-1) : 0;
 
         return (
-            <div style={{display:'flex', flex: '1 1 auto'}}>
-                <div style={{ display:'flex', flex: '1 1 auto', position: 'relative', width: '100%', height: '100%'}}>
-                    <div className='TablePanel' style={{minHeight:180, flex: '1 1 auto'}}>
-                        <div className={'TablePanel__wrapper--border'}>
+            <Stack sx={{direction:'row', flex: '1 1 auto',
+                '& .fixedDataTableLayout_main': {borderRadius:'5px'} }}>
+                <Stack {...{ direction:'row', flex: '1 1 auto', position: 'relative', width: 1, height: 1}}>
+                    <Box sx={{minHeight:180, flex: '1 1 auto'}}>
                             <div className='TablePanel__table' style={{top: 0}}>
                                 <BasicTableViewWithConnector
                                     tbl_ui_id={tbl_ui_id}
@@ -416,10 +416,9 @@ class ConstraintPanel extends PureComponent {
                                     }}
                                 />
                             </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                    </Box>
+                </Stack>
+            </Stack>
         );
     }
 }
@@ -569,17 +568,20 @@ function renderSqlArea() {
     //m31, cone search 10', w3snr>7 and (w2mpro-w3mpro)>1.5 on wise source catalog = 361
     return (
         <Stack spacing={.5}>
-            <Typography>Additional constraints (SQL)</Typography>
             <InputAreaFieldConnected fieldKey='txtareasql'
+                                     placeholder={'Add additional constraints here (SQL)'}
                                      tooltip='Enter SQL additional constraints here'
             />
             <Stack>
                 <Typography level='body-sm' component='div'>
-                    <em>Ex: w3snr&gt;7 and (w2mpro-w3mpro)&gt;1.5 and ra&gt;102.3 and ra&lt;112.3 and dec&lt;-5.5 and
+                    <span>
+                        <Typography component='span' level='title-sm'>Ex: </Typography>
+                        w3snr&gt;7 and (w2mpro-w3mpro)&gt;1.5 and ra&gt;102.3 and ra&lt;112.3 and dec&lt;-5.5 and
                         dec&gt;
-                        -15.5</em><br />
+                        -15.5
+                    </span>
                     (source_id_mf = '1861p075_ac51-002577')
-                    <br />
+                    <br/>
                 </Typography>
                 <Typography color='warning' level='body-sm'>The format for date type is yyyy-mm-dd</Typography>
             </Stack>

--- a/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
@@ -103,6 +103,7 @@ function makeHelpLine(helpLine) {
 }
 
 function makeDelete(canUserDelete,deleteLayer) {
+    if (!canUserDelete) return <Box sx={{width:23}}/>
     return (
         <Tooltip title='Close Layer'
             placement='right-start'>

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -147,7 +147,7 @@ export function ImageSearchDropDown({gridSupport, resizable=false, initArgs}) {
 
 function GridSupport() {
     return (
-        <Sheet {...{variant:'outlined', sx:{py:1}}}>
+        <Sheet {...{variant:'outlined', sx:{py:1,borderRadius: '5px'}}}>
             <FieldGroup groupKey={FG_KEYS.main} keepState={true} sx={{m:1}} >
                 <CheckboxGroupInputField fieldKey='createNewCell'
                     options={[{label: 'Add to new grid cell', value: 'newCell'}]}
@@ -326,7 +326,7 @@ function ImageType({}) {
         options.push({label: 'View HiPS Images', value: 'hipsImage'});
     }
     return (
-        <Sheet {...{variant:'outlined', sx:{mx:0,py:1}}}>
+        <Sheet {...{variant:'outlined', sx:{mx:0,py:1,borderRadius: '5px'}}}>
             <FieldGroup groupKey={FG_KEYS.main} keepState={true}>
                 <Stack {...{direction:'row', justifyContent:'flex-start', alignItems:'center', spacing:2}}>
                     <Typography {...{px:1, width:200, color:'primary', level:'title-md'}}>1. Choose Image Type</Typography>
@@ -370,7 +370,7 @@ function ImageSource({groupKey, imageMasterData, multiSelect, archiveName='Archi
 
     return (
         <Stack flexGrow={1} >
-            <Sheet {...{variant:'outlined', sx:{position:'static', mx:0,py:1,mt:1/2}}}>
+            <Sheet {...{variant:'outlined', sx:{position:'static', mx:0,py:1,mt:1/2,borderRadius: '5px'}}}>
                 <Stack {...{direction:'row', justifyContent:'flex-start', alignItems:'center', spacing:2}}>
                     <Typography {...{px:1, width:200, color:'primary', level:'title-md'}}>2. Select Image Source</Typography>
                     <RadioGroupInputField
@@ -408,13 +408,14 @@ function SelectArchive({groupKey,  imageMasterData, multiSelect, isHipsImgType, 
 
     return (
         <Sheet className='flex-full' sx={{position:'static',mt:1/2}}>
-            <Sheet {...{position:'static', variant:'outlined', sx:{py:1, flexGrow:0}}}>
+            <Sheet {...{position:'static', variant:'outlined', sx:{py:1, flexGrow:0,borderRadius: '5px'}}}>
                 <Stack direction={'row'} >
                     <Typography {...{px:1, width:200, color:'primary', level:'title-md'}}>3. Select Target</Typography>
                     <FieldGroup groupKey={FG_KEYS.targetSelect} keepState={true}>
                         <Stack spacing={2} direction='column'>
                             <TargetPanel labelWidth={isHips ? 150 : 100}
-                                         label={isHips ? 'Coordinates or Object Name (optional):' : 'Coordinates or Object Name:'}
+                                         label={isHips ? 'Coords or Obj Name (optional)' : 'Coords or Obj Name'}
+                                         placeholderHighlight={!isHips}
                                          nullAllowed={true}/>
                             <SizeInputFields fieldKey={sizeKey} showFeedback={true}
                                              feedbackStyle={{marginLeft: 185}}
@@ -434,7 +435,7 @@ function SelectArchive({groupKey,  imageMasterData, multiSelect, isHipsImgType, 
             </Sheet>
             {isHips ?
                 <HiPSImageSelect groupKey={groupKey} /> :
-                <Sheet {...{variant:'outlined', sx:{position:'static', mt:1/2,py:1 }}}>
+                <Sheet {...{variant:'outlined', sx:{position:'static', mt:1/2,py:1,borderRadius: '5px'}}}>
                     <Stack px={1}>
                         <Typography {...{color:'primary', level:'title-md'}}>4. Select Data Set</Typography>
                         <ImageSelect key={`ImageSelect_${groupKey}`} {...{groupKey, title, addChangeListener, imageMasterData, multiSelect,
@@ -449,7 +450,7 @@ function SelectArchive({groupKey,  imageMasterData, multiSelect, isHipsImgType, 
 
 function SelectUpload() {
     return (
-        <Sheet variant='outlined' sx={{mt: 1/2, py:1, width:'100%', display:'flex', flexDirection:'column', flex:'1 1 auto'}}>
+        <Sheet variant='outlined' sx={{mt: 1/2, py:1, width:'100%', display:'flex', flexDirection:'column', flex:'1 1 auto',borderRadius: '5px'}}>
             <Stack direction='row' spacing={2}>
                 <Typography {...{px:1, width:200, color:'primary', level:'title-md'}}>3. Select Image</Typography>
                 <FileUpload fieldKey='fileUpload' initialState= {{tooltip: 'Select a image to upload' }} />
@@ -473,7 +474,7 @@ function SelectWorkspace() {
 
 function SelectUrl() {
     return (
-        <Sheet variant='outlined' sx={{mt:1/2, py:1, width:'100%', display:'flex', flexDirection:'column', flex:'1 1 auto'}}>
+        <Sheet variant='outlined' sx={{mt:1/2, py:1, width:'100%', display:'flex', flexDirection:'column', flex:'1 1 auto',borderRadius: '5px'}}>
             <Stack direction='row' spacing={2}>
                 <Typography {...{px:1, color:'primary', level:'title-md'}}>3. Enter URL</Typography>
                 <ValidationField labelWidth={150} sx={{width: .8}} fieldKey='txURL' />

--- a/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
+++ b/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
@@ -71,14 +71,16 @@ const sharedPropTypes= {
     mocList: arrayOf( shape({ mocUrl: string, title: string }) ),
 };
 
-export function VisualPolygonPanel({label, initValue, tooltip, fieldKey, sx,
+export function VisualPolygonPanel({label, initValue, tooltip, fieldKey, sx, placeholder,
+                                       placeholderHighlight,
                                        manageHiPS=true, ...restOfProps}) {
 
     const button= manageHiPS &&
         ( <HiPSPanelPopupButton {...{polygonKey:fieldKey, whichOverlay:POLY_CHOICE_KEY, ...restOfProps}} /> );
     return (
         <InputAreaFieldConnected {...{
-            fieldKey, label, button, tooltip, initialState:{value:initValue}, sx
+            fieldKey, placeholder, label, button, tooltip, initialState:{value:initValue}, sx,
+            placeholderHighlight
         }} />
     );
 }


### PR DESCRIPTION
#### Firefly-1407: response to some CCB-D feedback and 9, 10, 19, 24.5, 28.5, 54 (partial), 61

 - 9, 10, 19, 24.5, 28.5, 54 (partial), 61
 - make checkboxes in image select panel normal text and not bold
 - target panel using warning color (brown) for the placeholder
 - File uploads will start using the warning color (brown) for buttons
 - plot image for images and hips will use a bolder font for title and normal font for FOV
 - more panels now use rounded borders (see Images panel, catalog panel, fits header, hips info, etc)
 - Tabs are bold

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1407-ccbd-feedback/firefly
- https://firefly-1407-ccbd-feedback.irsakudev.ipac.caltech.edu/irsaviewer
- https://firefly-1407-ccbd-feedback.irsakudev.ipac.caltech.edu/irsaviewer/dce

#### Check When confirmed
 

- [x] 9
- [ ] 10
- [x] 19
- [x] 24.5
- [x] 28.5
- [ ] 54 (partial)
- [x] 61

