### PR TITLE
FIREFLY-1364 more updates and cleanup

### DIFF
--- a/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
+++ b/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import {Button,Stack, Typography} from '@mui/joy';
 import {getWorkspaceConfig} from 'firefly/visualize/WorkspaceCntlr.js';
 import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
 import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
@@ -16,6 +17,18 @@ import {downloadBlob, makeDefaultDownloadFileName} from 'firefly/util/fetch.js';
 
 
 const DIALOG_ID= 'plotDownloadDialog';
+const dialogWidth = '32rem';
+const dialogHeight = '10rem';
+const labelWidth = '8rem';
+const popupPanelResizableStyle = {
+    width: dialogWidth,
+    height: dialogHeight,
+    minWidth: dialogWidth,
+    minHeight: dialogHeight,
+    resize: 'both',
+    overflow: 'hidden',
+    position: 'relative'
+};
 
 export function showPlotLySaveDialog(Plotly, chartDiv) {
     // if (fileLocation === WORKSPACE) dispatchWorkspaceUpdate(); //todo keep if we add workspace support, it probably goes somewhere else
@@ -23,7 +36,9 @@ export function showPlotLySaveDialog(Plotly, chartDiv) {
     const isWs = getWorkspaceConfig(); //todo - keep if we add workspace support
     const  popup = (
         <PopupPanel title={'Save Chart'}>
+            <div style={{...popupPanelResizableStyle}}>
                 <PlotLySavePanel {...{Plotly, chartDiv, isWs, filename:getDefaultFilename(chartDiv)}}/>
+            </div>
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(DIALOG_ID, popup);
@@ -54,26 +69,31 @@ async function saveFile(request, Plotly, chartDiv) {
 
 const PlotLySavePanel= function( {isWs,Plotly, chartDiv, filename}) {
     return (
-        <FieldGroup groupKey={'PlotLySaveField'} style={{display:'flex', flexDirection:'column'}}>
-            <div style={ {padding: 10}}>
-                <ValidationField
-                    wrapperStyle={{marginTop: 10}} size={50} fieldKey={'filename'}
-                    initialState= {{
-                        value: filename,
-                        tooltip: 'Enter filename of chart png',
-                        label: 'Chart Filename:',
-                        labelWidth: 80
-                    }} />
-            </div>
-            <div style={{textAlign:'center', display:'flex', justifyContent:'space-between', padding: '15px 15px 7px 8px'}}>
-                <div style={{display:'flex', justifyContent:'space-between'}}>
-                    <CompleteButton text='Save' dialogId={DIALOG_ID}
-                                    onSuccess={(request) => saveFile(request,Plotly, chartDiv)} />
-                    <CompleteButton text='Cancel' groupKey='' style={{paddingLeft:10}}
-                                    onSuccess={() => dispatchHideDialog(DIALOG_ID)} />
-                </div>
-                <HelpIcon helpId='charts.save' style={{display:'flex', alignItems:'center'}}/>
-            </div>
+        <FieldGroup groupKey={'PlotLySaveField'} >
+            <Stack spacing={2}
+                sx={{px: 2, justifyContent: 'center', width: '95%', height: dialogHeight}}>
+                <Stack sx={{'.MuiFormLabel-root': {width: labelWidth}}}>
+                    <ValidationField
+                        fieldKey={'filename'}
+                        initialState= {{
+                            value: filename,
+                            tooltip: 'Enter filename of chart png',
+                            label: 'Chart Filename',
+                        }} />
+                </Stack>
+                <Stack mb={3} sx={{flexDirection: 'row', justifyContent: 'space-between'}}>
+                    <Stack spacing={1} direction='row' alignItems='center'>
+                        <CompleteButton text='Save' dialogId={DIALOG_ID}
+                            onSuccess={(request) => saveFile(request,Plotly, chartDiv)} />
+                        <CompleteButton text='Cancel' groupKey=''
+                            onSuccess={() => dispatchHideDialog(DIALOG_ID)} />
+                    </Stack>
+                    <Stack>
+                        <HelpIcon helpId={'chart.save'}/>
+                    </Stack>
+                </Stack>
+            </Stack>
+
         </FieldGroup>
     );
 };

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -32,8 +32,8 @@ import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 import {findTableCenterColumns} from 'firefly/voAnalyzer/TableAnalysis';
 
 const fKeyDef = {
-    fileName: {fKey: 'fileName', label: 'File name:'},
-    fileFormat: {fKey: 'fileFormat', label: 'File format:'},
+    fileName: {fKey: 'fileName', label: 'File name'},
+    fileFormat: {fKey: 'fileFormat', label: 'File format'},
     location: {fKey: 'fileLocation', label: 'File location:'},
     wsSelect: {fKey: 'wsSelect', label: ''},
     overWritable: {fKey: 'fileOverwritable', label: 'File overwritable: '}
@@ -63,7 +63,7 @@ const tableFormatsExt = {
 
 const dialogWidth = '32rem';
 const dialogHeight = '22rem';
-const labelWidth = '6rem';
+const labelWidth = 100;
 const defValues = {
     [fKeyDef.fileName.fKey]: Object.assign(getTypeData(fKeyDef.fileName.fKey, '',
         'Please enter a filename, a default name will be used if it is blank', fKeyDef.fileName.label, labelWidth), {validator: null}),
@@ -138,6 +138,7 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
                 options={ fileOptions}
                 fieldKey = {fKeyDef.fileFormat.fKey}
                 multiple={false}
+                orientation={'vertical'}
             />
         );
     };
@@ -156,17 +157,19 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
                 <Typography level='body-sm' sx={{textAlign: 'left'}}>
                     {mode === 'original' ? asOriginalMsg : asDisplayedMsg}
                 </Typography>
-                <Stack spacing={1} mb={3} direction='row' alignItems='center'>
-                    <CompleteButton
-                        groupKey={tblDownloadGroupKey}
-                        onSuccess={resultSuccess(tbl_id, tbl_ui_id, onComplete, cenCols)}
-                        onFail={resultFail()}
-                        text={'Save'}/>
-                    <Button onClick={() => onComplete?.()}>Cancel</Button>
-
-                    <HelpIcon helpId={'tables.save'}/>
+                <Stack sx={{flexDirection: 'row', justifyContent: 'space-between'}}>
+                    <Stack spacing={1} direction='row' alignItems='center'>
+                        <CompleteButton
+                            groupKey={tblDownloadGroupKey}
+                            onSuccess={resultSuccess(tbl_id, tbl_ui_id, onComplete, cenCols)}
+                            onFail={resultFail()}
+                            text={'Save'}/>
+                        <Button onClick={() => onComplete?.()}>Cancel</Button>
+                    </Stack>
+                    <Stack>
+                        <HelpIcon helpId={'tables.save'}/>
+                    </Stack>
                 </Stack>
-
             </Stack>
         </FieldGroup>
     );

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import {Button} from '@mui/joy';
+import {Button,Stack, Typography} from '@mui/joy';
 import {get, set} from 'lodash';
 import Enum from 'enum';
 import {replaceExt, updateSet} from '../../util/WebUtil.js';
@@ -136,54 +136,48 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
         if (cenCols) fileOptions.push({label: 'Region (.reg)', value: 'reg'});
 
         return (
-            <div style={{display: 'flex', marginTop: mTop}}>
-                <div>
-                    <ListBoxInputField
-                        options={ fileOptions}
-                        fieldKey = {fKeyDef.fileFormat.fKey}
-                        multiple={false}
-                    />
-                </div>
-            </div>
+            <ListBoxInputField
+                options={ fileOptions}
+                fieldKey = {fKeyDef.fileFormat.fKey}
+                multiple={false}
+            />
         );
     };
     return (
-        <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
-            <FieldGroup style={{ boxSizing: 'border-box', paddingLeft:5, paddingRight:5, flexGrow: 1}}
-                        groupKey={tblDownloadGroupKey}
-                        reducerFunc={TableDLReducer(tbl_id)}>
+        <FieldGroup groupKey={tblDownloadGroupKey} reducerFunc={TableDLReducer(tbl_id)}>
+            <Stack spacing={2} justifyContent={'center'}
+                               sx={{
+                                     width: 400,
+                                     mx: '0,auto',
+                                     px: 2,
+                                     display: 'flex',
+                                     flexDirection: 'column'
+                                   }}>
                 <DownloadOptionsDialog fromGroupKey={tblDownloadGroupKey} style={{width: 'unset', height: 'unset'}}
                                        children={fileFormatOptions()}
                                        workspace={isWs}
                                        dialogWidth='100%'
                                        dialogHeight='300px'
                 />
-                <RadioGroupInputField fieldKey='mode' initialState={{value: 'displayed'}} wrapperStyle={{marginTop:10}}
+                <RadioGroupInputField fieldKey='mode' initialState={{value: 'displayed'}}
                                       options={[{value:'displayed', label:'Save table as displayed'}, {value:'original', label:'Save table as originally retrieved'}]}/>
-                <div style={{margin: '5px 22px', color: 'gray'}}>
+                <Typography level='body-sm' sx={{textAlign: 'left'}}>
                     {mode === 'original' ? asOriginalMsg : asDisplayedMsg}
-                </div>
+                </Typography>
+                <Stack spacing={1} mb={3} direction='row' alignItems='center'>
+                    <CompleteButton
+                        groupKey={tblDownloadGroupKey}
+                        onSuccess={resultSuccess(tbl_id, tbl_ui_id, onComplete, cenCols)}
+                        onFail={resultFail()}
+                        text={'Save'}/>
+                    <Button onClick={() => onComplete?.()}>Cancel</Button>
 
-            </FieldGroup>
-            <div style={{display: 'flex', justifyContent: 'space-between',
-                marginTop: 30, marginBottom: 10, marginLeft: 5, marginRight: 5}}>
-                <div style={{display: 'flex', width: '60%', alignItems: 'flex-end'}}>
-                    <div style={{marginRight: 10}}>
-                        <CompleteButton
-                            groupKey={tblDownloadGroupKey}
-                            onSuccess={resultSuccess(tbl_id, tbl_ui_id, onComplete, cenCols)}
-                            onFail={resultFail()}
-                            text={'Save'}/>
-                    </div>
-                    <div>
-                        <Button onClick={() => onComplete?.()}>Cancel</Button>
-                    </div>
-                </div>
-                <div style={{ textAlign:'right', marginRight: 10}}>
                     <HelpIcon helpId={'tables.save'}/>
-                </div>
-            </div>
-        </div>
+
+                </Stack>
+
+            </Stack>
+        </FieldGroup>
     );
 }
 

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -61,8 +61,9 @@ const tableFormatsExt = {
     'votable-fits-inline': 'vot',
 };
 
-
-const labelWidth = 100;
+const dialogWidth = '32rem';
+const dialogHeight = '22rem';
+const labelWidth = '6rem';
 const defValues = {
     [fKeyDef.fileName.fKey]: Object.assign(getTypeData(fKeyDef.fileName.fKey, '',
         'Please enter a filename, a default name will be used if it is blank', fKeyDef.fileName.label, labelWidth), {validator: null}),
@@ -78,14 +79,11 @@ const defValues = {
 
 const tblDownloadGroupKey = 'TABLE_DOWNLOAD_FORM';
 
-const dialogWidth = 500;
-const dialogHeightWS = 500;
-const dialogHeightLOCAL = 400;
-const mTop = 10;
-
 const popupPanelResizableStyle = {
     width: dialogWidth,
+    height: dialogHeight,
     minWidth: dialogWidth,
+    minHeight: dialogHeight,
     resize: 'both',
     overflow: 'hidden',
     position: 'relative'
@@ -146,18 +144,12 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
     return (
         <FieldGroup groupKey={tblDownloadGroupKey} reducerFunc={TableDLReducer(tbl_id)}>
             <Stack spacing={2} justifyContent={'center'}
-                               sx={{
-                                     width: 400,
-                                     mx: '0,auto',
-                                     px: 2,
-                                     display: 'flex',
-                                     flexDirection: 'column'
-                                   }}>
+                               sx={{px: 2}}>
                 <DownloadOptionsDialog fromGroupKey={tblDownloadGroupKey} style={{width: 'unset', height: 'unset'}}
                                        children={fileFormatOptions()}
                                        workspace={isWs}
                                        dialogWidth='100%'
-                                       dialogHeight='300px'
+                                       dialogHeight='100%'
                 />
                 <RadioGroupInputField fieldKey='mode' initialState={{value: 'displayed'}}
                                       options={[{value:'displayed', label:'Save table as displayed'}, {value:'original', label:'Save table as originally retrieved'}]}/>
@@ -173,7 +165,6 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
                     <Button onClick={() => onComplete?.()}>Cancel</Button>
 
                     <HelpIcon helpId={'tables.save'}/>
-
                 </Stack>
 
             </Stack>

--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -16,7 +16,7 @@ import LOADING from 'html/images/gxt/loading.gif';
 export const LOCALFILE = 'isLocal';
 export const WORKSPACE = 'isWs';
 
-export function getTypeData(key, val='', tip = '', labelV='', labelW) {
+export function getTypeData(key, val='', tip = '', labelV='', labelW='') {
     return {
         fieldKey: key,
         label: labelV,
@@ -27,7 +27,7 @@ export function getTypeData(key, val='', tip = '', labelV='', labelW) {
 }
 
 
-export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWidth, style={}, dialogWidth=500, dialogHeight=300,
+export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWidth, style={}, dialogWidth, dialogHeight,
                                       workspace}) {
 
     const isUpdating = useStoreConnector(isAccessWorkspace);
@@ -96,10 +96,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
     return (
         <Stack spacing={2} justifyContent={'center'}
                sx={{
-                 width: 400,
-                 mx: '0,auto',
-                 display: 'flex',
-                 flexDirection: 'column',
+                 width: '80%',
                }}>
             <div>
                 {children}
@@ -109,7 +106,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
                 initialState= {{
                     value: fileName
                 }}
-                label='File name:'
+                label='File name'
                 tooltip='Please enter a filename, a default name will be used if it is blank'
             />
 
@@ -124,9 +121,9 @@ DownloadOptionsDialog.propTypes = {
     fromGroupKey: PropTypes.string,
     children: PropTypes.object,
     fileName: PropTypes.string,
-    labelWidth: PropTypes.number,
-    dialogWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    dialogHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    labelWidth: PropTypes.string,
+    dialogWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.string]),
+    dialogHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.string]),
     workspace: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
 };
 

--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -1,6 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
+import {Stack} from '@mui/joy';
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty} from 'lodash';
@@ -42,6 +43,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
         }
     }, [where]);
 
+   //Todo: for workspace related components, they will be included in another ticket Firefly-1400
     const ShowWorkspace = () => {
 
         const loading  = (
@@ -79,39 +81,42 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
     };
 
     const showLocation = (
-            <div style={{marginTop: 10}}>
+        <Stack spacing={2} sx={{'.MuiFormLabel-root': {width: labelWidth}}}>
                 <RadioGroupInputField
                     options={[{label: 'Local File', value: LOCALFILE},
                               {label: 'Workspace', value: WORKSPACE }] }
                     fieldKey={'fileLocation'}
+                    orientation='horizontal'
                     label='File location:'
-                    labelWidth={100}
                     tooltip='select the location where the file is downloaded to'
                 />
-            </div>
+        </Stack>
     );
 
     return (
-        <div style={{height: '100%', width: '100%', ...style}}>
+        <Stack spacing={2} justifyContent={'center'}
+               sx={{
+                 width: 400,
+                 mx: '0,auto',
+                 display: 'flex',
+                 flexDirection: 'column',
+               }}>
             <div>
                 {children}
             </div>
             <ValidationField
-                wrapperStyle={{marginTop: 10}}
-                size={50}
                 fieldKey={'fileName'}
                 initialState= {{
                     value: fileName
                 }}
                 label='File name:'
-                labelWidth={100}
                 tooltip='Please enter a filename, a default name will be used if it is blank'
             />
 
             {workspace && showLocation}
 
             {where === WORKSPACE && <ShowWorkspace/>}
-        </div>
+        </Stack>
     );
 }
 

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -79,41 +79,39 @@ function closePopup(popupId) {
 }
 
 const getColors= (plot) => isThreeColor(plot) ? plot.plotState.getBands().map( (b) => capitalize(b.key)) : ['NO_BAND'];
-
 const renderOperationOption= () => (
-        <div style={{display: 'flex', marginTop: mTOP}}>
-            <div>
-                <RadioGroupInputField
+        <Stack spacing={2} sx={{'.MuiFormLabel-root': {width: labelWidth}}}>
+            <RadioGroupInputField
                     options={[ { label:'Original', value:'fileTypeOrig'}, { label:'Cropped', value:'fileTypeCrop'} ]}
-                    fieldKey='operationOption' tooltip='Please select an option'/>
-            </div>
-        </div> );
+                    fieldKey='operationOption'
+                    tooltip='Please select an option'/>
+        </Stack> );
 
 const RenderThreeBand = ({colors}) => {
     const [ft] = useFieldGroupValue ('fileType', fitsDownGroup);
     if (ft()==='png' || ft()==='reg') return false;
     return (
-        <div style={{display: 'flex', marginTop: mTOP}}>
-            <div>
-                <RadioGroupInputField options={colors.map( (c) => ({label: c, value: c}))} fieldKey='threeBandColor'
-                    label='Color Band:' labelWidth={100} tooltip='Please select a color option'/>
-            </div>
-        </div> );
+        <Stack spacing={2} sx={{'.MuiFormLabel-root': {width: labelWidth}}}>
+            <RadioGroupInputField
+                options={colors.map( (c) => ({label: c, value: c}))}
+                fieldKey='threeBandColor'
+                orientation='horizontal'
+                label='Color Band:'
+                tooltip='Please select a color option'/>
+        </Stack> );
 };
-
 const MakeFileOptions = ({plot,colors,hasOperation,threeC}) => {
      return (
-        <div>
-            <div style={{display: 'flex', marginTop: mTOP}}>
-                <div>
-                    <RadioGroupInputField options={isImage(plot) ? imageFileTypeOps : hipsFileTypeOps} fieldKey='fileType'
-                                          orientation='horizontal'
-                      label='Type of files:' labelWidth={100} tooltip='Please select a file type' />
-                </div>
-            </div>
+        <Stack spacing={2} sx={{'.MuiFormLabel-root': {width: labelWidth}}}>
+            <RadioGroupInputField
+                options={isImage(plot) ? imageFileTypeOps : hipsFileTypeOps}
+                fieldKey='fileType'
+                orientation='horizontal'
+                label='Type of files:'
+                tooltip='Please select a file type' />
             {hasOperation && renderOperationOption()}
             {threeC && <RenderThreeBand {...{colors}}/>}
-        </div>);
+        </Stack>);
 };
 
 const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
@@ -158,23 +156,28 @@ const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
     }, [getFileType, getFileName, getLocation, getBand]);
 
     return (
-        <FieldGroup style={{height: 'calc(100% - 10px)', width: '100%'}} groupKey={groupKey}>
-            <div style={{boxSizing: 'border-box', paddingLeft:5, paddingRight:5, width: '100%', height: 'calc(100% - 70px)'}}>
+        <FieldGroup groupKey={groupKey}>
+            <Stack spacing={2} justifyContent={'center'}
+                   sx={{
+                         width: 400,
+                         mx: '0,auto',
+                         px: 2,
+                         display: 'flex',
+                         flexDirection: 'column'
+                       }}>
                 <DownloadOptionsDialog {...{
                     fromGroupKey:groupKey, fileName: makeFileName(plot,band,'fits'), workspace:isWs,
                     labelWidth, dialogWidth:'100%', dialogHeight:`calc(100% - ${childH}pt)`,
                 }}>
                     <MakeFileOptions {...{plot, colors, hasOperation, threeC}}/>
                 </DownloadOptionsDialog>
-            </div>
-            <div style={{display:'flex', width:'calc(100% - 20px)', margin: '20px 10px 10px 10px', justifyContent:'space-between'}}>
-                <Stack spacing={1} direction='row'>
+                <Stack spacing={1} mb={3} direction='row' alignItems='center'>
                     <CompleteButton text='Save' onSuccess={ (request) => resultsSuccess(request, pv, popupId )}
                                     onFail={resultsFail} />
                     <CompleteButton text='Cancel' groupKey='' primary={false} onSuccess={() => closePopup(popupId)} />
+                    <HelpIcon helpId={'visualization.saveimage'}/>
                 </Stack>
-                <HelpIcon helpId={'visualization.saveimage'}/>
-            </div>
+            </Stack>
         </FieldGroup>
     );
 });

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -157,19 +157,27 @@ const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
 
     return (
         <FieldGroup groupKey={groupKey}>
-            <Stack spacing={2}
-                   sx={{px: 2}}>
-                <DownloadOptionsDialog {...{
-                    fromGroupKey:groupKey, fileName: makeFileName(plot,band,'fits'), workspace:isWs,
-                    labelWidth, dialogWidth:'100%', dialogHeight:'100%',
-                }}>
-                    <MakeFileOptions {...{plot, colors, hasOperation, threeC}}/>
-                </DownloadOptionsDialog>
-                <Stack spacing={1} mb={3} direction='row' alignItems='center'>
-                    <CompleteButton text='Save' onSuccess={ (request) => resultsSuccess(request, pv, popupId )}
-                                    onFail={resultsFail} />
-                    <CompleteButton text='Cancel' groupKey='' primary={false} onSuccess={() => closePopup(popupId)} />
-                    <HelpIcon helpId={'visualization.saveimage'}/>
+            <Stack spacing={2} style={{height: mindialogHeightLOCAL}}
+                   sx={{px: 2, justifyContent: 'space-between'}}>
+                <Stack>
+                    <DownloadOptionsDialog {...{
+                        fromGroupKey:groupKey, fileName: makeFileName(plot,band,'fits'), workspace:isWs,
+                        labelWidth, dialogWidth:'100%', dialogHeight:'100%',
+                    }}>
+                        <MakeFileOptions {...{plot, colors, hasOperation, threeC}}/>
+                    </DownloadOptionsDialog>
+                </Stack>
+                <Stack>
+                    <Stack mb={3} sx={{flexDirection: 'row', justifyContent: 'space-between'}}>
+                        <Stack spacing={1} direction='row' alignItems='center'>
+                            <CompleteButton text='Save' onSuccess={ (request) => resultsSuccess(request, pv, popupId )}
+                                            onFail={resultsFail} />
+                            <CompleteButton text='Cancel' groupKey='' primary={false} onSuccess={() => closePopup(popupId)} />
+                        </Stack>
+                        <Stack>
+                            <HelpIcon helpId={'visualization.saveimage'}/>
+                        </Stack>
+                    </Stack>
                 </Stack>
             </Stack>
         </FieldGroup>

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -32,13 +32,13 @@ import {useFieldGroupValue} from './SimpleComponent.jsx';
 import HelpIcon from './HelpIcon.jsx';
 
 const STRING_SPLIT_TOKEN= '--STR--';
-const dialogWidth = 500;
-const dialogHeightWS = 500;
-const dialogHeightLOCAL = 400;
-const mTOP = 10;
+const dialogWidth ='32rem';
+const dialogHeightWS = '32rem';
+const dialogHeightLOCAL = '25rem';
+const mindialogHeightLOCAL ='19rem';
 const dialogPopupId = 'fitsDownloadDialog';
 const fitsDownGroup = 'FITS_DOWNLOAD_FORM';
-const labelWidth = 100;
+const labelWidth = '6rem';
 const hipsFileTypeOps= [
     {label: 'PNG File', value: 'png', tooltip: 'Download as PNG image' },
     {label: 'Region File', value: 'reg', tooltip: 'Download all overlays as a region File'} ];
@@ -60,8 +60,8 @@ export function showFitsDownloadDialog() {
 
     const isWs = getWorkspaceConfig();
     const adHeight = (fileLocation === WORKSPACE) ? dialogHeightWS
-                                                         : (isWs ? dialogHeightLOCAL : dialogHeightLOCAL - 100);
-    const minHeight = (fileLocation === LOCALFILE) && (!isWs) ? dialogHeightLOCAL-100 : dialogHeightLOCAL;
+                                                         : (isWs ? dialogHeightLOCAL : mindialogHeightLOCAL);
+    const minHeight = (fileLocation === LOCALFILE) && (!isWs) ? mindialogHeightLOCAL : dialogHeightLOCAL;
     const  popup = (
         <PopupPanel title={'Save Image'}>
             <div style={{...popupPanelResizableStyle, height: adHeight, minHeight}}>
@@ -107,7 +107,7 @@ const MakeFileOptions = ({plot,colors,hasOperation,threeC}) => {
                 options={isImage(plot) ? imageFileTypeOps : hipsFileTypeOps}
                 fieldKey='fileType'
                 orientation='horizontal'
-                label='Type of files:'
+                label='Type of files'
                 tooltip='Please select a file type' />
             {hasOperation && renderOperationOption()}
             {threeC && <RenderThreeBand {...{colors}}/>}
@@ -124,7 +124,7 @@ const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
     const band= threeC ? getBand() : Band.NO_BAND.key;
 
     const totalChildren = (isWs ? 3 : 2) + (hasOperation ? 1 : 0) + (threeC ? 1 : 0);// fileType + save as + (fileLocation)
-    const childH = (totalChildren * (20 + mTOP));
+    const childH = (totalChildren * (2)).toString;
 
     const [getFileType] = useFieldGroupValue ('fileType', groupKey);
     const [getFileName, setFileName] = useFieldGroupValue('fileName', groupKey);
@@ -157,17 +157,11 @@ const FitsDownloadDialogForm= memo( ({isWs, popupId, groupKey}) => {
 
     return (
         <FieldGroup groupKey={groupKey}>
-            <Stack spacing={2} justifyContent={'center'}
-                   sx={{
-                         width: 400,
-                         mx: '0,auto',
-                         px: 2,
-                         display: 'flex',
-                         flexDirection: 'column'
-                       }}>
+            <Stack spacing={2}
+                   sx={{px: 2}}>
                 <DownloadOptionsDialog {...{
                     fromGroupKey:groupKey, fileName: makeFileName(plot,band,'fits'), workspace:isWs,
-                    labelWidth, dialogWidth:'100%', dialogHeight:`calc(100% - ${childH}pt)`,
+                    labelWidth, dialogWidth:'100%', dialogHeight:'100%',
                 }}>
                     <MakeFileOptions {...{plot, colors, hasOperation, threeC}}/>
                 </DownloadOptionsDialog>


### PR DESCRIPTION
UI-conversion [FIREFLY-1364](https://jira.ipac.caltech.edu/browse/FIREFLY-1364).
Updated following popup dialogs:
- FitsDownloadDialog.jsx
- TableSave.jsx
- DownloadOptionsDialog.jsx
- PlotlySaveDialog.jsx

There are more cleanups needed in the DownloadOptionsDialog related to workspaces, which will be done in Firefly-1400.
To test: https://fireflydev.ipac.caltech.edu/firefly-1364/firefly/
1. do  a image search with wise and make 3 color image, and go to download image/3-color image
2. try a catalog search and in the table panel click save table

p.s `ZoomOptionsPopup` has been refactored already


#### Addresses: https://confluence.ipac.caltech.edu/display/IRSA/Testing+Feb+2024+-+Joy+UI%2C+mostly

Check when confirmed
- [ ] 20
- [ ] 46


