### PR TITLE
FIREFLY-1412: Finish Charts conversion left over from FIREFLY-1408

### DIFF
--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -89,7 +89,7 @@ export const ChartToolbar = (props={}) => {
     // logic for PinnedChartContainer toolbar added here
     if (allowPinnedCharts()) {
         return (
-            <Stack id='chart-toolbar' direction='row' alignItems='center' spacing={1}>
+            <Stack id='chart-toolbar' direction='row' alignItems='center'>
                 <CombineChart {...{viewerId, tbl_group}} />
                 <ShowTable {...{viewerId, tbl_group}} />
                 <PinChart {...{viewerId, tbl_group}}/>

--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -17,6 +17,7 @@ import {CloseButton} from '../../ui/CloseButton.jsx';
 import {ChartPanel, ChartToolbar} from './ChartPanel.jsx';
 import {MultiChartViewer, getActiveViewerItemId} from './MultiChartViewer.jsx';
 import {PinnedChartContainer} from 'firefly/charts/ui/PinnedChartContainer.jsx';
+import {Stack} from '@mui/joy';
 
 
 
@@ -193,9 +194,9 @@ ActiveChartsPanel.propTypes = ChartsContainer.propTypes;
 function ExpandedView(props) {
     const {closeable, chartId, viewerId} = props;
     return (
-        <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+        <Stack height={1}>
             <ChartToolbarExt {...{chartId, closeable, viewerId}}/>
-            <div style={{position: 'relative', flexGrow: 1}}>
+            <Stack flexGrow={1}>
                 <ChartPanel {...{
                     key: 'expanded-'+chartId,
                     expandedMode: true,
@@ -203,8 +204,8 @@ function ExpandedView(props) {
                     chartId,
                     showToolbar: false
                 }}/>
-            </div>
-        </div>
+            </Stack>
+        </Stack>
     );
 }
 

--- a/src/firefly/js/charts/ui/ColSelectView.jsx
+++ b/src/firefly/js/charts/ui/ColSelectView.jsx
@@ -1,10 +1,12 @@
 /*
  */
 import React from 'react';
+import {Stack} from '@mui/joy';
+import {merge} from 'lodash';
+
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import {dispatchTableRemove}  from '../../tables/TablesCntlr';
-import {clone} from '../../util/WebUtil.js';
 
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 import {getTblById, calcColumnWidths, getSelectedData, getColumnValues} from '../../tables/TableUtil.js';
@@ -12,30 +14,10 @@ import {dispatchShowDialog, dispatchHideDialog, isDialogVisible} from '../../cor
 import CompleteButton from '../../ui/CompleteButton.jsx';
 import {quoteNonAlphanumeric}  from '../../util/expr/Variable.js';
 import {SelectInfo} from 'firefly/tables/SelectInfo';
-import {merge} from 'lodash';
 
 //import HelpIcon from '../../ui/HelpIcon.jsx';
 const popupId = 'XYColSelect';
 const TBL_ID ='selectCol';
-
-const popupPanelResizableStyle = {
-    width: 300,
-    minWidth: 560,
-    height: 450,
-    minHeight: 300,
-    resize: 'both',
-    overflow: 'hidden',
-    position: 'relative'
-};
-
-
-//define the table style only in the table div
-const tableStyle = {boxSizing: 'border-box', width: '100%', height: 'calc(100% - 40px)', overflow: 'hidden', resize:'none'};
-
-//define the complete button
-const closeButtonStyle = {'textAlign': 'center', display: 'inline-block', height:40, marginTop:10, width: '90%'};
-//define the helpButton
-//const helpIdStyle = {'textAlign': 'center', display: 'inline-block', height:40, marginRight: 20};
 
 
 export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonText,currentVal,multiSelect=false,colTblId) {
@@ -114,27 +96,17 @@ export function hideColSelectPopup() {
 
 function popupForm(tableModel, onColSelected,buttonText,popupId, minWidth,multiSelect) {
     const tblId = tableModel.tbl_id;
-    const style= clone(popupPanelResizableStyle, {minWidth: Math.min(minWidth, 560)});
-    return (
-        <div style={ style}>
-            { renderTable(tableModel,popupId,multiSelect)}
-            { renderCloseAndHelpButtons(tblId,onColSelected,buttonText,popupId,multiSelect)}
-        </div>
-    );
-
-}
-
-/**
- * display the data into a tabular format
- * @param tableModel
- * @param popupId
- * @param multiSelect
- * @return table section
- */
-function renderTable(tableModel,popupId,multiSelect=false) {
     const tbl_ui_id = (tableModel.tbl_id || 'ColSelectView') + '-ui';
     return (
-        <div style={tableStyle}>
+        <Stack spacing={1} sx={{
+            width: '20rem',
+            minWidth: Math.min(minWidth, '40rem'),
+            height: '32rem',
+            minHeight: '20rem',
+            resize: 'both',
+            overflow: 'hidden',
+            position: 'relative'
+        }}>
             <TablePanel
                 key={popupId}
                 tbl_ui_id={tbl_ui_id}
@@ -143,31 +115,19 @@ function renderTable(tableModel,popupId,multiSelect=false) {
                 showFilters={true}
                 selectable={multiSelect}
                 border={false}
+                onRowDoubleClick={() => setXYColumns(tblId,onColSelected)}
             />
-        </div>
-    );
 
-}
-
-function renderCloseAndHelpButtons(tblId,onColSelected,buttonText,popupId,multiSelect) {
-
-    return(
-    <div>
-        <div style={closeButtonStyle}>
             <CompleteButton
                 text={buttonText}
                 onSuccess={()=> multiSelect? setSelectedColumns(tblId,onColSelected) : setXYColumns(tblId,onColSelected)}
                 dialogId={popupId}
             />
-        </div>
-        {/* comment out the help button for now
-            <div style={helpIdStyle}>
-                <HelpIcon helpId={'catalogs.xyplots'}/>
-            </div>
-         */}
-    </div>
-);
+        </Stack>
+    );
+
 }
+
 
 //returns (calls the callback fn with) an array of selected column naes
 function setSelectedColumns(tblId,onColSelected) {
@@ -183,6 +143,7 @@ function setXYColumns(tblId,onColSelected) {
     const hlRow = tableModel.highlightedRow || 0;
     const selectedColName = quoteNonAlphanumeric(tableModel.tableData.data[hlRow][0]);
     onColSelected(selectedColName);
+    hideColSelectPopup();
 }
 
 function getHlRow(currentVal,colNames) {

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -17,7 +17,7 @@ import {getCellValue, getColumnValues, getSelectedDataSync, getTblById} from '..
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 import {getGroupFields} from '../../fieldGroup/FieldGroupUtils.js';
 import {getActiveViewerItemId} from './MultiChartViewer.jsx';
-import {CollapsiblePanel} from '../../ui/panel/CollapsiblePanel.jsx';
+import {CollapsibleGroup, CollapsibleItem, CollapsiblePanel} from '../../ui/panel/CollapsiblePanel.jsx';
 import {dispatchTableAddLocal} from '../../tables/TablesCntlr.js';
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
 import {showInfoPopup, showPopup} from '../../ui/PopupUtil.jsx';
@@ -26,6 +26,8 @@ import {canUnitConv} from '../dataTypes/SpectrumUnitConversion.js';
 import {SelectInfo} from '../../tables/SelectInfo.js';
 import {dispatchHideDialog} from '../../core/ComponentCntlr.js';
 import {CombineChartButton} from 'firefly/visualize/ui/Buttons.jsx';
+import {Button, Stack, Typography} from '@mui/joy';
+import CompleteButton from 'firefly/ui/CompleteButton.jsx';
 
 const POPUP_ID = 'CombineChart-popup';
 
@@ -137,30 +139,42 @@ const CombineChartDialog = ({onComplete}) => {
     const showAllHint = 'Show all charts even ones that may not combine well';
 
     return (
-        <div className='CombineChart__popup'>
-            {/*--- temporarily removed to only combine charts with similar axes
-            <div style={{display: 'inline-flex', alignItems: 'center'}}>
-                <label htmlFor='showAll'>Show All Charts: </label>
-                <input type='checkbox' id='showAll' title={showAllHint} value={showAll} onClick={(e) => setShowAll(e.target?.checked)}/>
-                <span className='CombineChart__hints'>({showAllHint})</span>
-            </div>
-            ----------*/}
-            <div className='CombineChart__popup--tbl'>
-                <TablePanel {...{tbl_id, showToolbar:false, showUnits:false, showTypes:false}}/>
-            </div>
-            <FieldGroup keepState={false} groupKey={groupKey} style={{overflow: 'hidden', display: 'flex', flexDirection: 'column'}}>
-                <Title initialState={{value: 'combined'}}/>
-                <div style={{marginTop:5}}>Choose trace names below.</div>
-                <div style={{overflow: 'auto', maxHeight: 400}}>
-                    <SelChartProps {...{tbl_id, groupKey}}/>
+        <FieldGroup groupKey={groupKey} sx={{
+            height: 500,
+            width: 700,
+            resize: 'both',
+            overflow: 'hidden',
+            position: 'relative'
+        }}>
+            <Stack spacing={1} height={1}>
+                {/*--- temporarily removed to only combine charts with similar axes
+                <div style={{display: 'inline-flex', alignItems: 'center'}}>
+                    <label htmlFor='showAll'>Show All Charts: </label>
+                    <input type='checkbox' id='showAll' title={showAllHint} value={showAll} onClick={(e) => setShowAll(e.target?.checked)}/>
+                    <span className='CombineChart__hints'>({showAllHint})</span>
                 </div>
-            </FieldGroup>
-            <div className='CombineChart__popup--tbar'>
-                <button type='button' className='button std' style={{marginRight: 5}} onClick={doApply}>Ok</button>
-                <button type='button' className='button std' onClick={closePopup}>Cancel </button>
-                <HelpIcon helpId={'chartarea.combineCharts'} style={{float: 'right', marginTop: 4}}/>
-            </div>
-        </div>
+                ----------*/}
+                <Stack spacing={1} overflow='auto' flexGrow={1}>
+                    <Stack height={125}>
+                        <TablePanel {...{tbl_id, showToolbar:false, showUnits:false, showTypes:false}}/>
+                    </Stack>
+
+                    <Title initialState={{value: 'combined'}}/>
+                    <Typography level='title-sm'>Choose trace names below.</Typography>
+                    <CollapsibleGroup>
+                        <SelChartProps {...{tbl_id, groupKey}}/>
+                    </CollapsibleGroup>
+                </Stack>
+
+                <Stack direction='row' justifyContent='space-between' alignItems='center'>
+                    <Stack direction='row' spacing={1}>
+                        <CompleteButton onSuccess={doApply}>Ok</CompleteButton>
+                        <Button variant='soft' onClick={closePopup}>Cancel</Button>
+                    </Stack>
+                    <HelpIcon helpId={'chartarea.combineCharts'} style={{float: 'right', marginTop: 4}}/>
+                </Stack>
+            </Stack>
+        </FieldGroup>
     );
 };
 
@@ -173,19 +187,16 @@ const SelChartOpt = ({chartId, groupKey, ctitle, traces, idx}) => {
         const {Name} = basicOptions({activeTrace: traceNum, groupKey});
         if (!title || title.toLowerCase().startsWith('trace '))  title = `trace ${traceNum}`;
 
-        return (
-            <div className='FieldGroup__vertical'>
-                <Name initialState={{value: title}}/>
-            </div>
-        ) ;
+        return <Name initialState={{value: title}}/>;
     };
     const isOpen = !isSpectralOrder(chartId);
     return (
-        <CollapsiblePanel componentKey={key} header={ctitle} isOpen={isOpen}>
-            {traces.map((title, idx) => <TraceOpt {...{key:idx, traceNum: totalTraces++, title}}/>)}
-        </CollapsiblePanel>
+        <CollapsibleItem componentKey={key} header={ctitle} isOpen={isOpen}>
+            <Stack spacing={1}>
+                {traces.map((title, idx) => <TraceOpt {...{key:idx, traceNum: totalTraces++, title}}/>)}
+            </Stack>
+        </CollapsibleItem>
     );
-
 };
 
 function SelChartProps ({tbl_id, groupKey}) {
@@ -210,14 +221,15 @@ function SelChartProps ({tbl_id, groupKey}) {
     }
 
     return (
-        <React.Fragment>
+        <>
             {
                 charts.map(([chartId, ctitle, traces], idx) => {
-                    if (idx === 0) ctitle = <b>{ctitle}</b>;
+                    if (idx === 0) ctitle = <Typography level='title-sm'>{ctitle}</Typography>;
+
                     return <SelChartOpt key={idx} {...{chartId, groupKey, ctitle, traces, idx}}/>;
                 })
             }
-        </React.Fragment>
+        </>
     );
 };
 

--- a/src/firefly/js/charts/ui/MultiChartToolbar.jsx
+++ b/src/firefly/js/charts/ui/MultiChartToolbar.jsx
@@ -50,7 +50,7 @@ export function MultiChartToolbarExpanded({viewerId, chartId, tbl_group, expanda
     activeItemId = activeItemId || getViewer(getMultiViewRoot(), viewerId)?.customData?.activeItemId;
 
     return (
-        <Stack direction='row' justifyContent='space-between'>
+        <Stack direction='row' justifyContent='space-between' alignItems='center'>
             {closeable && <CloseButton onClick={() => closeExpandedChart(viewerId)}/>}
             <MultiChartExt {...{viewerId, layoutType, activeItemId}}/>
             <ChartToolbar {...{chartId, tbl_group, expandable, expandedMode, viewerId}}/>

--- a/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
+++ b/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import {Button,Stack, Typography} from '@mui/joy';
+import {Button,Stack} from '@mui/joy';
 import {getWorkspaceConfig} from 'firefly/visualize/WorkspaceCntlr.js';
 import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
 import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
@@ -17,18 +17,6 @@ import {downloadBlob, makeDefaultDownloadFileName} from 'firefly/util/fetch.js';
 
 
 const DIALOG_ID= 'plotDownloadDialog';
-const dialogWidth = '32rem';
-const dialogHeight = '10rem';
-const labelWidth = '8rem';
-const popupPanelResizableStyle = {
-    width: dialogWidth,
-    height: dialogHeight,
-    minWidth: dialogWidth,
-    minHeight: dialogHeight,
-    resize: 'both',
-    overflow: 'hidden',
-    position: 'relative'
-};
 
 export function showPlotLySaveDialog(Plotly, chartDiv) {
     // if (fileLocation === WORKSPACE) dispatchWorkspaceUpdate(); //todo keep if we add workspace support, it probably goes somewhere else
@@ -36,9 +24,15 @@ export function showPlotLySaveDialog(Plotly, chartDiv) {
     const isWs = getWorkspaceConfig(); //todo - keep if we add workspace support
     const  popup = (
         <PopupPanel title={'Save Chart'}>
-            <div style={{...popupPanelResizableStyle}}>
+            <Stack sx={{
+                minWidth: '32rem',
+                minHeight: '10rem',
+                resize: 'both',
+                overflow: 'hidden',
+                position: 'relative'
+            }}>
                 <PlotLySavePanel {...{Plotly, chartDiv, isWs, filename:getDefaultFilename(chartDiv)}}/>
-            </div>
+            </Stack>
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(DIALOG_ID, popup);
@@ -69,31 +63,25 @@ async function saveFile(request, Plotly, chartDiv) {
 
 const PlotLySavePanel= function( {isWs,Plotly, chartDiv, filename}) {
     return (
-        <FieldGroup groupKey={'PlotLySaveField'} >
-            <Stack spacing={2}
-                sx={{px: 2, justifyContent: 'center', width: '95%', height: dialogHeight}}>
-                <Stack sx={{'.MuiFormLabel-root': {width: labelWidth}}}>
-                    <ValidationField
-                        fieldKey={'filename'}
-                        initialState= {{
-                            value: filename,
-                            tooltip: 'Enter filename of chart png',
-                            label: 'Chart Filename',
-                        }} />
-                </Stack>
-                <Stack mb={3} sx={{flexDirection: 'row', justifyContent: 'space-between'}}>
-                    <Stack spacing={1} direction='row' alignItems='center'>
-                        <CompleteButton text='Save' dialogId={DIALOG_ID}
-                            onSuccess={(request) => saveFile(request,Plotly, chartDiv)} />
-                        <CompleteButton text='Cancel' groupKey=''
-                            onSuccess={() => dispatchHideDialog(DIALOG_ID)} />
-                    </Stack>
-                    <Stack>
-                        <HelpIcon helpId={'chart.save'}/>
-                    </Stack>
-                </Stack>
-            </Stack>
+        <Stack p={1} flexGrow={1} justifyContent='space-between'>
+            <FieldGroup groupKey={'PlotLySaveField'} >
+                <ValidationField
+                    fieldKey={'filename'}
+                    initialState= {{
+                        value: filename,
+                        tooltip: 'Enter filename of chart png',
+                        label: 'Chart Filename',
+                    }} />
+            </FieldGroup>
 
-        </FieldGroup>
+            <Stack flexDirection='row' justifyContent='space-between'>
+                <Stack spacing={1} direction='row' alignItems='center'>
+                    <CompleteButton text='Save' dialogId={DIALOG_ID}
+                                    onSuccess={(request) => saveFile(request,Plotly, chartDiv)} />
+                    <Button onClick={() => dispatchHideDialog(DIALOG_ID)}>Cancel</Button>
+                </Stack>
+                <HelpIcon helpId={'chart.save'}/>
+            </Stack>
+        </Stack>
     );
 };

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -26,7 +26,6 @@ import PanIco from 'html/images/icons-2014/pan.png';
 import SelectIco from 'html/images/icons-2014/select.png';
 import TurntableIco from 'html/images/turntable-tmp.png';
 import OrbitalIco from 'html/images/orbital-tmp.png';
-import ClearSelectIco from 'html/images/icons-2014/24x24_CheckmarkOff_Circle.png';
 import ApplySelectIco from 'html/images/icons-2014/24x24_Checkmark.png';
 import ApplyFilterIco from 'html/images/icons-2014/24x24_FilterAdd.png';
 import ResetZoomIco from 'html/images/icons-2014/Zoom1x-24x24-tmp.png';
@@ -78,7 +77,7 @@ function ScatterToolbar({chartId, expandable}) {
         <Stack direction='row' alignItems='center'>
             <ActiveTraceSelect {...{chartId, activeTrace}}/>
             <SelectionPart {...{chartId, hasFilter, activeTrace, hasSelection, hasSelected, tbl_id}}/>
-            <DragModePart {...{chartId, tbl_id, dragmode, hasSelectionMode}}/>
+            <DragModePart {...{chartId, tbl_id, dragmode, hasSelectionMode, sx:{mx:1}}}/>
             <ResetZoomBtn {...{chartId}} />
             <SaveBtn {...{chartId}} />
             <RestoreBtn {...{chartId}} />
@@ -145,10 +144,10 @@ function BasicToolbar({chartId, expandable}) {
     const help_id = getChartData(chartId)?.help_id;
 
     const selectionPart = (
-        <Stack direction='row' spacing={1/2}>
+        <>
             {hasFilter && <ClearFilter {...{tbl_id}} /> }
             {hasSelection && <FilterSelection {...{chartId}} />}
-        </Stack>
+        </>
     );
 
     return (
@@ -157,7 +156,7 @@ function BasicToolbar({chartId, expandable}) {
             {showDragPart &&
                 <DragModePart {...{chartId, tbl_id, dragmode, hasSelectionMode: showSelectionPart, is3d}}/>}
             {showSelectionPart && selectionPart}
-            {showDragPart && <ResetZoomBtn style={{marginLeft: 10}} {...{chartId}} />}
+            {showDragPart && <ResetZoomBtn {...{chartId}} />}
             <SaveBtn {...{chartId}} />
             <RestoreBtn {...{chartId}} />
             {tbl_id && <FiltersBtn {...{chartId}} />}
@@ -179,33 +178,25 @@ function SelectionPart({chartId, hasFilter, hasSelection, hasSelected, tbl_id}) 
             && !get(getChartData(chartId), `data.${activeTrace}.type`, '').includes('heatmap');
     }
     return (
-        <Stack direction='row' spacing={1/2}>
+        <>
             {hasFilter    && <ClearFilter {...{tbl_id}} />}
             {hasSelected  && <ClearSelected {...{chartId}} />}
             {hasSelection && <FilterSelection {...{chartId}} />}
-            {showSelectSelection && <SelectSelection style={{marginRight:10}} {...{chartId}} />}
-        </Stack>
+            {showSelectSelection && <SelectSelection {...{chartId}} />}
+        </>
     );
 }
 
-function DragModePart({chartId, tbl_id, dragmode, hasSelectionMode, is3d}) {
+function DragModePart({chartId, tbl_id, dragmode, hasSelectionMode, is3d, sx}) {
 
     return (
-        <Stack direction='row' spacing={1/2}>
-            <Divider orientation='vertical'/>
-            <ToggleButtonGroup value={dragmode} variant='plain' size='sm'
-                               sx={{
-                                   mx:1/2,
-                                   '--ButtonGroup-connected': '0'
-                               }}>
-                <ZoomBtn {...{chartId}} />
-                <PanBtn {...{chartId}} />
-                {is3d && <OrbitBtn {...{chartId}} />}
-                {is3d && <TurntableBtn {...{chartId}} />}
-                {tbl_id && hasSelectionMode && <SelectBtn {...{chartId}} />}
-            </ToggleButtonGroup>
-            <Divider orientation='vertical'/>
-        </Stack>
+        <ToggleButtonGroup value={dragmode} variant='outlined' size='sm' sx={sx}>
+            <ZoomBtn {...{chartId}} />
+            <PanBtn {...{chartId}} />
+            {is3d && <OrbitBtn {...{chartId}} />}
+            {is3d && <TurntableBtn {...{chartId}} />}
+            {tbl_id && hasSelectionMode && <SelectBtn {...{chartId}} />}
+        </ToggleButtonGroup>
     );
 }
 

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -4,7 +4,7 @@
 
 import React, {useCallback, useEffect} from 'react';
 import {Box, Typography} from '@mui/joy';
-import PropTypes from 'prop-types';
+import PropTypes, {func} from 'prop-types';
 import {Column, Table} from 'fixed-data-table-2';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
 import {get, set, isEmpty, isUndefined, omitBy, pick} from 'lodash';
@@ -32,7 +32,7 @@ const BasicTableViewInternal = React.memo((props) => {
 
     const {width, height} = props.size;
     const {columns, data, hlRowIdx, renderers, selectInfoCls, callbacks, rowHeight, rowHeightGetter, showHeader=true,
-            error, tbl_ui_id=uniqueTblUiId(), currentPage, startIdx=0, highlightedRowHandler, cellRenderers} = props;
+            error, tbl_ui_id=uniqueTblUiId(), currentPage, startIdx=0, highlightedRowHandler, cellRenderers, onRowDoubleClick} = props;
 
     const uiStates = getTableUiById(tbl_ui_id) || {};
     const {tbl_id, columnWidths, scrollLeft=0, scrollTop=0, triggeredBy, showTypes, showFilters, showUnits, filterInfo,
@@ -122,6 +122,7 @@ const BasicTableViewInternal = React.memo((props) => {
                        isColumnResizing={false}
                        onColumnResizeEndCallback={onColumnResize}
                        onRowClick={(e, index) => callbacks.onRowHighlight && callbacks.onRowHighlight(index)}
+                       onRowDoubleClick={onRowDoubleClick}
                        rowClassNameGetter={rowClassNameGetter}
                        onScrollEnd={onScrollEnd}
                        scrollTop={adjScrollTop}
@@ -176,6 +177,7 @@ BasicTableViewInternal.propTypes = {
     error:  PropTypes.string,
     size: PropTypes.object.isRequired,
     highlightedRowHandler: PropTypes.func,
+    onRowDoubleClick: PropTypes.func,
     renderers: PropTypes.objectOf(
         PropTypes.shape({
             cellRenderer: PropTypes.func,

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -5,7 +5,7 @@
 import React, {PureComponent, useEffect, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import {Button, Link, Sheet, Stack, Typography} from '@mui/joy';
+import {Box, Button, Link, Sheet, Stack, Typography} from '@mui/joy';
 import {isEmpty, cloneDeep, get} from 'lodash';
 import SplitPane from 'react-split-pane';
 import Tree, { TreeNode } from 'rc-tree';
@@ -50,29 +50,24 @@ export class FilterEditor extends PureComponent {
         const renderers = makeRenderers(callbacks.onFilter, tbl_id);
         
         return (
-            <div style={{height: '100%', display: 'flex', flexDirection: 'column'}}>
-                <div style={{flexGrow: 1, position: 'relative'}}>
-                    <div style={{position: 'absolute', top:0, bottom:5, left:0, right:0, backgroundColor: 'white'}}>
-                        <BasicTableViewWithConnector
-                            columns={cols}
-                            rowHeight={24}
-                            selectable={selectable}
-                            {...{data, selectInfoCls, sortInfo, callbacks, renderers, tbl_ui_id: `${tbl_ui_id}_FilterEditor`}}
-                        />
-                    </div>
-                </div>
+            <Stack spacing={1} flexGrow={1} overflow='hidden'>
+                <BasicTableViewWithConnector
+                    columns={cols}
+                    rowHeight={26}
+                    selectable={selectable}
+                    {...{data, selectInfoCls, sortInfo, callbacks, renderers, tbl_ui_id: `${tbl_ui_id}_FilterEditor`}}
+                />
                 <InputAreaField
                     value={filterInfo}
                     label='Filters:'
                     validator={FilterInfo.validator.bind(null,columns)}
                     tooltip={FILTER_TTIPS}
                     minRows={3}
-                    maxRows={3}
                     onChange={callbacks.onAllFilter}
                     actOn={['blur', 'enter']}
                     showWarning={false}
                 />
-            </div>
+            </Stack>
         );
     }
 }
@@ -244,7 +239,7 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
     };
 
     const onNodeClick = (skeys, {node}) => {
-        const textArea = get(ReactDOM.findDOMNode(sqlEl.current), 'firstChild');
+        const textArea = document.getElementById('advFilterInput');
         const key = get(node, 'props.eventKey');
         insertAtCursor(textArea, ` "${key}" `, sqlKey, groupKey);
     };
@@ -261,11 +256,11 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
         <SplitPane split='vertical' defaultSize={200} style={{display: 'inline-flex', ...style}}>
             <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
                 <Typography level='title-md'>Columns (sorted)</Typography>
-                <div  style={{overflow: 'auto', flexGrow: 1}}>
+                <Box  style={{overflow: 'auto', flexGrow: 1}}>
                     <Tree defaultExpandAll showLine onSelect={onNodeClick} icon={iconGen} >
                         {treeNodes}
                     </Tree>
-                </div>
+                </Box>
             </SplitContent>
             <SplitContent style={{overflow: 'auto'}}>
                 <Stack height={1} spacing={1} overflow='hidden'>
@@ -291,13 +286,14 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
                     </Stack>
                     <InputAreaFieldConnected
                         ref={sqlEl}
-                        minRows={7}
-                        maxRows={7}
                         validator={FilterInfo.validator.bind(null,columns)}
                         groupKey={groupKey}
                         fieldKey={sqlKey}
                         tooltip='Additional filter to apply to the table'
                         placeholder={placeholder}
+                        slotProps={{
+                            textArea: {id: 'advFilterInput'}
+                        }}
                     />
                     {error && <li style={{color: 'red', fontStyle: 'italic'}}>{error}</li>}
                     <Stack spacing={1} overflow='auto'>

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -165,3 +165,7 @@ Overriding default fixed-table css
 }
 
 
+.public_fixedDataTableRow_columnsShadow {
+    background-image: none;
+    background-color: unset;
+}

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -3,7 +3,7 @@
  */
 
 import React, {useEffect} from 'react';
-import {Box, Stack, Typography, Sheet, Chip, Divider} from '@mui/joy';
+import {Box, Stack, Typography, Sheet, Divider, ChipDelete, Tooltip} from '@mui/joy';
 import PropTypes, {object, shape} from 'prop-types';
 import {defer, truncate, get, set} from 'lodash';
 import {getAppOptions, getSearchActions} from '../../core/AppDataCntlr.js';
@@ -68,7 +68,7 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
         showToolbar, showTitle, showMetaInfo,
         columns, showHeader, showUnits, allowUnits, showTypes, showFilters, textView,
         error, startIdx, hlRowIdx, currentPage, selectInfo, showMask,
-        filterInfo, sortInfo, data, backgroundable, highlightedRowHandler, cellRenderers} = tblState;
+        filterInfo, sortInfo, data, backgroundable, highlightedRowHandler, cellRenderers, onRowDoubleClick} = tblState;
 
     const connector = makeConnector(tbl_id, tbl_ui_id);
 
@@ -108,7 +108,7 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
                             { ...{columns, data, hlRowIdx, rowHeight, rowHeightGetter, selectable, showUnits,
                                 allowUnits, showTypes, showFilters, selectInfoCls, filterInfo, sortInfo, textView,
                                 showMask, currentPage, showHeader, renderers, tbl_ui_id, highlightedRowHandler,
-                                startIdx, cellRenderers} }
+                                startIdx, cellRenderers, onRowDoubleClick} }
                         />
                     </Stack>
                 </Stack>
@@ -120,7 +120,7 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
 function showTableOptionDialog(onChange, onOptionReset, clearFilter, tbl_ui_id, tbl_id) {
 
     const content = (
-         <Stack height={450} width={650} overflow='hidden' sx={{resize:'both', minWidth:550, minHeight:200}}>
+         <Stack height={550} width={700} overflow='hidden' sx={{resize:'both', minWidth:550, minHeight:200}}>
                <TablePanelOptions
                   onChange={onChange}
                   onOptionReset={onOptionReset}
@@ -156,7 +156,7 @@ function showTablePropSheetDialog(tbl_id) {
     const {title=''} = getTblById(tbl_id) || {};
     showOptionsPopup({show: false});   // hide the dialog if one is currently opened
     const content = (
-        <Stack height={450} width={650} overflow='hidden' sx={{resize:'both', minWidth:550, minHeight:200}}>
+        <Stack height={450} width={650} overflow='hidden' sx={{resize:'both', minWidth:'40rem', minHeight:'15rem'}}>
           <PropertySheetAsTable tbl_id={tbl_id}/>
         </Stack>
     );
@@ -279,10 +279,12 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
         return (
             <SettingsButton tip={TT_OPTIONS}
                             onClick={showOptionsDialog}
-                            iconButtonSize='30px'
+                            iconButtonSize='25px'
                             slotProps={{
                                 root: {
-                                    sx: {position:'absolute', top:-4, right:-4, zIndex: DDzIndex},
+                                    sx: {position:'absolute', top:-1, right:-2, zIndex: 2,
+                                        '& button': {p:0}
+                                    },
                                     component: Sheet,
                                     variant: 'plain'
                                 }
@@ -377,10 +379,9 @@ function Title({title, removable, tbl_id}) {
         <Stack direction='row' alignSelf='start' sx={{ml:1/4}}>
             <Typography level='body-sm' noWrap title={title}>{truncate(title)}</Typography>
             {removable &&
-            <Chip variant='soft'
-                 title='Remove Tab'
-                  onClick={() => dispatchTableRemove(tbl_id)}
-            >x</Chip>
+                <Tooltip title='Remove table'>
+                    <ChipDelete sx={{'--Chip-deleteSize': '1.2rem'}} onClick={() => dispatchTableRemove(tbl_id)}/>
+                </Tooltip>
             }
         </Stack>
     );

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -4,7 +4,7 @@
 
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {Button, Stack, ToggleButtonGroup, Typography} from '@mui/joy';
+import {Box, Button, Stack, ToggleButtonGroup, Typography} from '@mui/joy';
 import {badgeClasses} from '@mui/joy/Badge';
 
 import {cloneDeep, get, isEmpty} from 'lodash';
@@ -47,16 +47,16 @@ export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOpt
     const label = () => {
         if (!sql) return advFilterName;
         return (
-            <div style={{display: 'inline-flex'}}>
-                <div style={{marginRight: 10}}>{advFilterName}</div>
-                <div title='Advanced filter applied.  Click on tab to view details.'
-                    style={{
+            <Stack direction='row' spacing={1/2}>
+                {advFilterName}
+                <Box title='Advanced filter applied.  Click on tab to view details.'
+                    sx={{
                         position: 'absolute',
                         right: 2,
                         borderLeft: '10px solid transparent',
                         borderTop: '10px solid rgb(71, 138, 163)'
                     }}/>
-            </div>
+            </Stack>
         );
     };
 
@@ -154,6 +154,7 @@ function Options({uiState, tbl_id, tbl_ui_id, ctm_tbl_id, onOptionReset, onChang
                 <Typography level='title-md'>Show/Hide:</Typography>
                 <ToggleButtonGroup
                     variant='outlined'
+                    size='sm'
                     value={value}
                     onChange={(ev, val) => {
                         setValue(val);

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -36,7 +36,7 @@ import {TBL_CLZ_NAME} from './TablePanel.jsx';
 import infoIcon from 'html/images/info-icon.png';
 import {dd2sex} from '../../visualize/CoordUtil.js';
 
-export const DDzIndex = 110;   // 110 is the z-index of a dropdown
+export const DDzIndex = 111;   // 110 is the z-index of a dropdown
 
 const html_regex = /<.+>|&.+;/;           // A rough detection of html elements or entities
 const filterStyle = {width: '100%', boxSizing: 'border-box'};
@@ -228,11 +228,10 @@ function EnumSelect({col, tbl_id, filterInfoCls, onFilter}) {
     );
 }
 
-export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected, style, sx}) {
-    sx = {height: 1, justifyContent: 'space-around', ...style, ...sx};
+export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected, sx}) {
     return (
-        <Stack alignItems='center' sx={sx}>
-            <Checkbox size='sm' sx={{mt:'2px'}}
+        <Stack alignItems='center' height={1} justifyContent='space-between' pt='2px' sx={sx}>
+            <Checkbox size='sm'
                 tabIndex={-1}
                 checked={checked}
                 onChange={(e) => onSelectAll(e.target.checked)}/>

--- a/src/firefly/js/ui/AutoCompleteInput.jsx
+++ b/src/firefly/js/ui/AutoCompleteInput.jsx
@@ -1,0 +1,101 @@
+import React, {useState} from 'react';
+import {bool, string, object, shape, arrayOf, func, oneOf, element} from 'prop-types';
+import {Autocomplete, FormControl, FormLabel, Stack, Tooltip} from '@mui/joy';
+import {isEmpty, omit} from 'lodash';
+
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
+import {inputFieldTooltipProps} from 'firefly/ui/InputFieldView.jsx';
+
+
+export function AutoCompleteInput({slotProps, orientation, label, required, freeSolo=true, startDecorator, endDecorator, ...props}) {
+
+    const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmValue: confirmValue(freeSolo)});
+    const [open, setOpen] = useState(false);
+
+    const {value, valid} = viewProps;
+    const fixedOptions = viewProps.options?.map((v) => ({...v, label: v.label || v.value}));
+
+    const inputProps= omit(props, 'initialState', 'fieldKey', 'groupKey');
+    let {title, ...tooltipProps} = inputFieldTooltipProps(viewProps);
+    title = open ? '' : title;          // remove tooltips when popup is open
+
+    const onChange = (e,v) => {
+        const value = v.value ?? v;
+        fireValueChange({value});
+    };
+
+
+    return (
+        <Tooltip title={title} {...tooltipProps} {...slotProps?.tooltip}>
+            <FormControl className='ff-Input' orientation={orientation} error={!valid} required={required} {...slotProps?.control}>
+                {label && <FormLabel {...slotProps?.label}>{label}</FormLabel>}
+                <Autocomplete autoComplete={true}
+                              autoSelect={true}
+                              freeSolo={freeSolo}
+                              value={value}
+                              {...inputProps}
+                              title=''
+                              startDecorator={startDecorator && <Decorator setOpen={setOpen}>{startDecorator}</Decorator>}
+                              endDecorator={endDecorator && <Decorator setOpen={setOpen}>{endDecorator}</Decorator>}
+                              options={fixedOptions}
+                              open={open}
+                              onOpen={() => setOpen(true)}
+                              onClose={() => setOpen(false)}
+                              onInputChange={onChange}/>
+            </FormControl>
+        </Tooltip>
+    );
+
+}
+
+AutoCompleteInput.propTypes= {
+    fieldKey: string.isRequired,
+    fieldGroup: string,
+    initialState: shape({
+        value: string,
+        valid: bool,
+        message: string,
+        validator: func,
+        nullAllowed: bool,
+    }),
+    options: arrayOf(object),       // {value,label,...anything-else}
+    label: string,
+    title: string,
+    orientation: oneOf(['horizontal', 'vertical']),
+    required: bool,
+    freeSolo: bool,                 // allow values not in options
+    endDecorator: element,
+    startDecorator: element,
+    slotProps: shape({
+        control: object,
+        label: object,
+        tooltip: object
+    }),
+};
+
+AutoCompleteInput.defaultProps = {
+    orientation: 'horizontal'
+};
+
+// may not be needed
+function confirmValue(freeSolo) {
+    return (v,props) => {
+        const {options=[], defaultValue} = props;
+        const optionContain = (v) => Boolean(v && options.find((op) => op.value === v));
+        if (freeSolo || isEmpty(options) || optionContain(v)) {
+            return v;
+        } else {
+            return defaultValue ?? options[0].value;
+        }
+    };
+}
+
+
+function Decorator({children, setOpen}) {
+    return (
+        <Stack onClick={() => setOpen(false)}>
+            {children}
+        </Stack>
+
+    );
+}

--- a/src/firefly/js/ui/CloseButton.jsx
+++ b/src/firefly/js/ui/CloseButton.jsx
@@ -10,7 +10,7 @@ import ArrowBack from '@mui/icons-material/ArrowBackIosNew';
 export function CloseButton({text='Close', tip='Close', style={}, onClick}) {
     return (
         <Tooltip title={tip} style={style}>
-            <Button {...{color:'neutral', size:'sm', variant:'solid', onClick, sx:{whiteSpace:'nowrap',pl:0},
+            <Button {...{color:'neutral', size:'sm', variant:'solid', height:'1rem', onClick, sx:{whiteSpace:'nowrap',pl:0},
                     startDecorator:<ArrowBack/>}}>
                 {text}
             </Button>

--- a/src/firefly/js/ui/InputAreaField.jsx
+++ b/src/firefly/js/ui/InputAreaField.jsx
@@ -38,6 +38,5 @@ InputAreaFieldConnected.propTypes = {
         value: PropTypes.string,
     }),
     additionalClasses: PropTypes.string,
-    idName: PropTypes.string,
 };
 

--- a/src/firefly/js/ui/InputAreaFieldView.jsx
+++ b/src/firefly/js/ui/InputAreaFieldView.jsx
@@ -10,12 +10,12 @@ export const InputAreaFieldView= forwardRef( ({ visible=true,label,tooltip,value
                                                   button, valid=true,onChange, onBlur,
                                                   showWarning=true, connectedMarker=false,
                                                  placeholderHighlight,
-                                                  message='', type, placeholder, idName='', sx, slotProps,
-                                                  orientation='vertical', minRows=2, maxRows=4 }, ref ) => {
+                                                  message='', type, placeholder, sx, slotProps,
+                                                  orientation='vertical', minRows=2, maxRows}, ref ) => {
     const connectContext= useContext(ConnectionCtx);
     if (!visible) return null;
 
-    const tooltipProps = inputFieldTooltipProps(valid, message, showWarning, tooltip);
+    const tooltipProps = inputFieldTooltipProps({valid, message, showWarning, tooltip});
     const connectedStyle= connectedMarker||connectContext.controlConnected ? {bgcolor:'yellow'} : {};
 
     return (
@@ -28,7 +28,6 @@ export const InputAreaFieldView= forwardRef( ({ visible=true,label,tooltip,value
                               maxRows={maxRows}
                               slotProps={{
                                   textarea: {
-                                      id: idName,
                                       spellCheck: false,
                                       value: inputFieldValue(type, value),
                                       onChange: (ev) => onChange?.(ev),
@@ -65,7 +64,6 @@ InputAreaFieldView.propTypes= {
     maxRows: PropTypes.number,
     placeholder: PropTypes.string,
     connectedMarker: bool,
-    idName: PropTypes.string,
     orientation: PropTypes.string,
     slotProps: shape({
         control: object,

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -3,15 +3,15 @@ import React from 'react';
 import {bool, string, number, object, func, oneOfType, shape, element} from 'prop-types';
 
 
-export function inputFieldTooltipProps(valid, message, showWarning, tooltip) {
+export function inputFieldTooltipProps({valid, message, showWarning=true, tooltip}) {
     const showErrorTip= !valid && showWarning && message;
     const title= showErrorTip ?
         (
             <Stack direction='column'>
                 <Typography level='body-md' color={'danger'}> {message} </Typography>
-                <Typography level='body-md' color={'neutral'}> {tooltip} </Typography>
+                <Typography level='body-md' color={'neutral'} whiteSpace='pre'> {tooltip} </Typography>
             </Stack>
-        ) : tooltip && <div style={{whiteSpace:'pre'}}>{tooltip}</div>;
+        ) : tooltip && <Typography level='body-md' whiteSpace='pre'>{tooltip}</Typography>;
     const enterDelay = showErrorTip ? 700 : undefined;
     return {title, enterDelay};
 }
@@ -31,7 +31,7 @@ export function InputFieldView(props) {
     form = form || undefined;
 
     const currValue = inputFieldValue(type, value);
-    const tooltipProps = inputFieldTooltipProps(valid, message, showWarning, tooltip);
+    const tooltipProps = inputFieldTooltipProps({valid, message, showWarning, tooltip});
 
     return (
         <Stack {...{className:'ff-Input InputFieldView', sx}}>

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -8,7 +8,8 @@ import {
     Tab as JoyTab,
     Tabs as JoyTabs,
     TabPanel as JoyTabPanel,
-    TabList, ListItemDecorator, Box, Chip, Stack, Sheet} from '@mui/joy';
+    TabList, ListItemDecorator, Box, Chip, Stack, Sheet, ChipDelete, Tooltip
+} from '@mui/joy';
 import {tabClasses} from '@mui/joy/Tab';
 import sizeMe from 'react-sizeme';
 import {omit, isString, uniqueId, pick, isNumber} from 'lodash';
@@ -360,11 +361,14 @@ function getHeaderFromTab({name, value, label, startDecorator, removable, onTabR
             )}
             {label}
             {removable &&
-                <Chip variant='soft'
-                      onClick={(e) => {
-                          onTabRemove && onTabRemove(name);
-                          e.stopPropagation && e.stopPropagation();
-                }}>x</Chip>
+                <Tooltip title='Remove Tab'>
+                    <ChipDelete sx={{'--Chip-deleteSize': '1.2rem'}}
+                                onClick={(e) => {
+                                    onTabRemove && onTabRemove(name);
+                                    e.stopPropagation?.();
+                                }}
+                    />
+                </Tooltip>
             }
         </JoyTab>
     );

--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -3,15 +3,14 @@
  */
 
 import {Box, Chip, Divider, Stack, Switch, Tooltip, Typography} from '@mui/joy';
-import React, {useState, useRef, useEffect, Fragment, useContext, useCallback} from 'react';
+import React, {useState, useRef, useEffect, useContext, useCallback} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import SplitPane from 'react-split-pane';
 import Tree from 'rc-tree';
 import 'rc-tree/assets/index.css';
-import {cloneDeep, defer, isArray, isObject, groupBy, uniqBy, isUndefined} from 'lodash';
+import {cloneDeep, defer, isArray, isObject, groupBy, uniqBy} from 'lodash';
 import {getSizeAsString, updateSet} from '../../util/WebUtil.js';
-import {CheckboxGroupInputField} from '../CheckboxGroupInputField.jsx';
 import {FieldGroupCtx} from '../FieldGroup.jsx';
 import {ExtraButton} from '../FormPanel.jsx';
 
@@ -37,7 +36,6 @@ import '../../externalSource/prismLive/prism-live.js';
 import '../../externalSource/prismLive/prism.css';
 import '../../externalSource/prismLive/prism-live.css';
 
-import INFO_ICO from 'html/images/icons-2014/24x24_Info.png';
 import JOIN_ICO from 'html/images/join_16x16.png';
 const joinIcon = () => <img src={JOIN_ICO} style={{marginRight:2}}/> ;
 
@@ -282,10 +280,8 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
                                             tooltip='ADQL to submit to the selected TAP service'
                                             slotProps={{
                                                 input: {sx: {bgcolor: '#f5f2f0'}}, //the color defined on prism.css L59
-                                                textArea: {className: 'prism-live language-sql'}
+                                                textArea: {className: 'prism-live language-sql', id: 'adqlEditor'}
                                             }}
-                                            idName='adqlEditor'
-                                            maxRows={null} //to prevent default value getting assigned, we need no max limit on rows
                                         />
                                         <Typography level='body-sm' sx={{mt:-2}}>Type ADQL text; you can use the Schema Browser on the left to insert table and column names.</Typography>
                                     </Stack>

--- a/src/firefly/js/ui/tap/ObjectIDSearch.jsx
+++ b/src/firefly/js/ui/tap/ObjectIDSearch.jsx
@@ -252,7 +252,7 @@ function ObjectIDCol({objectCol, style={},cols, objectKey, openKey,
                 <Typography sx={{width:'14rem', pt:1, whiteSpace:'nowrap'}} component='div'>
                     {headerTitle}
                 </Typography>
-                <FieldGroupCollapsible header={posHeader} headerStyle={{paddingLeft:0}} contentStyle={{marginLeft:4}}
+                <FieldGroupCollapsible header={posHeader}
                                        initialState={{value:'open'}} fieldKey={openKey}>
                     {openPreMessage && <div style={{padding:'0 0 10px 0'}}>
                         {openPreMessage}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1412

Converted the listed files to JoyUI.

One significant piece is the addition of `AutoCompleteInput` to replace `SuggestBoxInputField`.  `SuggestBoxInputField` is still in used by other component.  The behavior may not be exactly the same.  But, using JoyUI's Autocomplete will allow us to add more features moving forward.

https://fireflydev.ipac.caltech.edu/firefly-1412-more-chart-ui/firefly/
Things to test:
- [ ] ColumnOrExpression:  Chart options: x/y/error/color map/ size map
- [ ] ColSelectView: popup to select column.  Added double-click to select then close dialog
- [ ] Chart save dialog
- [ ] ChartSelectDropdown:  from top menu button
- [ ] Combine chart popup
- [ ] Chart filter popup
- [ ] Fixed Table Advance Filter
- [ ] Other minor cleanup