### PR TITLE
FIREFLY-1415: Table options default size is too small

### DIFF
--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -5,7 +5,7 @@ import {Typography, Box, Link, Stack} from '@mui/joy';
 import {isEmpty} from 'lodash';
 import {getTblById, hasAuxData} from '../TableUtil.js';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
-import {CollapsiblePanel} from '../../ui/panel/CollapsiblePanel.jsx';
+import {CollapsibleGroup, CollapsibleItem} from '../../ui/panel/CollapsiblePanel.jsx';
 import {ContentEllipsis} from './TableRenderer.js';
 import {ObjectTree} from './ObjectTree.jsx';
 import {StatefulTabs, Tab} from '../../ui/panel/TabPanel.jsx';
@@ -53,7 +53,7 @@ function MetaContent({tbl_id}) {
     if (hasAuxData(tbl_id)) {
         return <MetaInfo tbl_id={tbl_id} isOpen={true} sx={{ w: 1, border: 'none', m: 'unset', p: 'unset'}} />;
     } else {
-        return <div style={{margin: 20, fontWeight: 'bold'}}>No metadata available</div>;
+        return <Stack><Typography level='title-md'>No metadata available</Typography></Stack>;
     }
 }
 
@@ -67,78 +67,81 @@ export function MetaInfo({tbl_id, isOpen=false, ...props}) {
 
     return (
         <Stack {...props}>
-            { !isEmpty(keywords) &&
-            <CollapsiblePanel componentKey={tbl_id + '-meta'} header='Table Meta' isOpen={isOpen}>
-                {keywords.concat()                                             // make a copy so the original array does not mutate
-                    .filter( ({key}) => key)
-                    .sort(({key:k1}, {key:k2}) => (k1+'').localeCompare(k2+''))        // sort it by key
-                    .map(({value, key}, idx) => <KeywordBlock key={'keywords-' + idx} label={key} value={value}/>)
+            <CollapsibleGroup size='sm'>
+                { !isEmpty(keywords) &&
+                <CollapsibleItem componentKey={tbl_id + '-meta'} header='Table Meta' isOpen={isOpen}>
+                    {keywords.concat()                                             // make a copy so the original array does not mutate
+                        .filter( ({key}) => key)
+                        .sort(({key:k1}, {key:k2}) => (k1+'').localeCompare(k2+''))        // sort it by key
+                        .map(({value, key}, idx) => <KeywordBlock key={'keywords-' + idx} label={key} value={value}/>)
+                    }
+                </CollapsibleItem>
                 }
-            </CollapsiblePanel>
-            }
-            { !isEmpty(params) &&
-            <CollapsiblePanel componentKey={tbl_id + '-params'} header='Table Params' isOpen={isOpen}>
-                {params.concat()                                                          // same logic as keywords, but sort by name
-                    .sort(({name:k1}, {name:k2}) => k1.localeCompare(k2))
-                    .map(({name, value, type='N/A'}, idx) => <KeywordBlock key={'params-' + idx} label={`${name}(${type})`} value={value}/>)
+                { !isEmpty(params) &&
+                <CollapsibleItem componentKey={tbl_id + '-params'} header='Table Params' isOpen={isOpen}>
+                    {params.concat()                                                          // same logic as keywords, but sort by name
+                        .sort(({name:k1}, {name:k2}) => k1.localeCompare(k2))
+                        .map(({name, value, type='N/A'}, idx) => <KeywordBlock key={'params-' + idx} label={`${name}(${type})`} value={value}/>)
+                    }
+                </CollapsibleItem>
                 }
-            </CollapsiblePanel>
-            }
-            { !isEmpty(groups) &&
-            <CollapsiblePanel componentKey={tbl_id + '-groups'} header='Groups' isOpen={isOpen}>
-                {groups.map((rs, idx) => {
-                    const showValue = () => showInfoPopup(
-                        <div style={{whiteSpace: 'pre'}}>
-                            <ObjectTree data={rs} title={<b>Group</b>} className='MetaInfo__tree'/>
-                        </div> );
-                    return (
-                        <div key={'groups-' + idx} style={{display: 'inline-flex', alignItems: 'center'}}>
-                            { rs.ID && <Keyword label='ID' value={rs.ID}/> }
-                            { rs.name && <Keyword label='name' value={rs.name}/> }
-                            { rs.UCD && <Keyword label='UCD' value={rs.UCD}/> }
-                            { rs.utype && <Keyword label='utype' value={rs.utype}/> }
-                            <a className='ff-href' onClick={showValue}> show value</a>
-                        </div>
-                    );
-                })
+                { !isEmpty(groups) &&
+                <CollapsibleItem componentKey={tbl_id + '-groups'} header='Groups' isOpen={isOpen}>
+                    {groups.map((rs, idx) => {
+                        const showValue = () => showInfoPopup(
+                            <div style={{whiteSpace: 'pre'}}>
+                                <ObjectTree data={rs} title={<b>Group</b>} className='MetaInfo__tree'/>
+                            </div> );
+                        return (
+                            <div key={'groups-' + idx} style={{display: 'inline-flex', alignItems: 'center'}}>
+                                { rs.ID && <Keyword label='ID' value={rs.ID}/> }
+                                { rs.name && <Keyword label='name' value={rs.name}/> }
+                                { rs.UCD && <Keyword label='UCD' value={rs.UCD}/> }
+                                { rs.utype && <Keyword label='utype' value={rs.utype}/> }
+                                <a className='ff-href' onClick={showValue}> show value</a>
+                            </div>
+                        );
+                    })
+                    }
+                </CollapsibleItem>
                 }
-            </CollapsiblePanel>
-            }
-            { !isEmpty(links) &&
-            <CollapsiblePanel componentKey={tbl_id + '-links'} header='Links' isOpen={isOpen}>
-                {links.map((l, idx) => {
-                    return (
-                        <div key={'links-' + idx} style={{display: 'inline-flex', alignItems: 'center'}}>
-                            { l.ID && <Keyword label='ID' value={l.ID}/> }
-                            { l.role && <Keyword label='role' value={l.role}/> }
-                            { l.type && <Keyword label='type' value={l.type}/> }
-                            { l.href && <LinkTag {...l}/>}
-                        </div>
-                    );
-                })
+                { !isEmpty(links) &&
+                <CollapsibleItem componentKey={tbl_id + '-links'} header='Links' isOpen={isOpen}>
+                    {links.map((l, idx) => {
+                        return (
+                            <div key={'links-' + idx} style={{display: 'inline-flex', alignItems: 'center'}}>
+                                { l.ID && <Keyword label='ID' value={l.ID}/> }
+                                { l.role && <Keyword label='role' value={l.role}/> }
+                                { l.type && <Keyword label='type' value={l.type}/> }
+                                { l.href && <LinkTag {...l}/>}
+                            </div>
+                        );
+                    })
+                    }
+                </CollapsibleItem>
                 }
-            </CollapsiblePanel>
-            }
-            { !isEmpty(resources) &&
-            <CollapsiblePanel componentKey={tbl_id + '-resources'} header='Resources' isOpen={isOpen}>
-                {resources.map((rs, idx) => {
-                    const showValue = () => showInfoPopup(
-                        <div style={{whiteSpace: 'pre'}}>
-                            <ObjectTree data={rs} title={<b>Resource</b>} className='MetaInfo__tree'/>
-                        </div> );
-                    return (
-                        <div key={'resources-' + idx} style={{display: 'inline-flex', alignItems: 'center'}}>
-                            { rs.ID && <Keyword label='ID' value={rs.ID}/> }
-                            { rs.name && <Keyword label='name' value={rs.name}/> }
-                            { rs.type && <Keyword label='type' value={rs.type}/> }
-                            { rs.utype && <Keyword label='utype' value={rs.utype}/> }
-                            <a className='ff-href' onClick={showValue}> show value</a>
-                        </div>
-                    );
-                })
+                { !isEmpty(resources) &&
+                <CollapsibleItem componentKey={tbl_id + '-resources'} header='Resources' isOpen={isOpen}>
+                    {resources.map((rs, idx) => {
+                        const showValue = () => showInfoPopup(
+                            <div style={{whiteSpace: 'pre'}}>
+                                <ObjectTree data={rs} title={<b>Resource</b>} className='MetaInfo__tree'/>
+                            </div> );
+                        return (
+                            <Stack direction='row' key={'resources-' + idx}>
+                                { rs.ID && <Keyword label='ID' value={rs.ID}/> }
+                                { rs.name && <Keyword label='name' value={rs.name}/> }
+                                { rs.type && <Keyword label='type' value={rs.type}/> }
+                                { rs.utype && <Keyword label='utype' value={rs.utype}/> }
+                                <Link onClick={showValue}> show value</Link>
+                            </Stack>
+                        );
+                    })
+                    }
+                </CollapsibleItem>
                 }
-            </CollapsiblePanel>
-            }
+
+            </CollapsibleGroup>
         </Stack>
     );
 }

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -98,7 +98,7 @@ export function MetaInfo({tbl_id, isOpen=false, ...props}) {
                                 { rs.name && <Keyword label='name' value={rs.name}/> }
                                 { rs.UCD && <Keyword label='UCD' value={rs.UCD}/> }
                                 { rs.utype && <Keyword label='utype' value={rs.utype}/> }
-                                <a className='ff-href' onClick={showValue}> show value</a>
+                                <Link onClick={showValue}> show value</Link>
                             </div>
                         );
                     })

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -31,7 +31,6 @@ import {AddColumnBtn} from './AddOrUpdateColumn.jsx';
 
 import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
 import {META} from '../TableRequestUtil.js';
-import {DDzIndex} from 'firefly/tables/ui/TableRenderer.js';
 
 const logger = Logger('Tables').tag('TablePanel');
 
@@ -120,7 +119,7 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
 function showTableOptionDialog(onChange, onOptionReset, clearFilter, tbl_ui_id, tbl_id) {
 
     const content = (
-         <Stack height={550} width={700} overflow='hidden' sx={{resize:'both', minWidth:550, minHeight:200}}>
+         <Stack height='65vh' width='65vw' overflow='hidden' sx={{resize:'both', minWidth:550, minHeight:200}}>
                <TablePanelOptions
                   onChange={onChange}
                   onOptionReset={onOptionReset}
@@ -138,10 +137,10 @@ function showTableOptionDialog(onChange, onOptionReset, clearFilter, tbl_ui_id, 
 
 function showTableInfoDialog(tbl_id)  {
     const content = (
-        <Box width={500} height={300} minWidth={450} minHeight={200}
+        <Box width='65vw' height='65vh' minWidth={450} minHeight={200}
              sx={{resize:'both', overflow:'auto', position:'relative'}}>
             <TableInfo tbl_id={tbl_id}
-                       p={0} height='unset'
+                       p={0}
                        tabsProps={{
                            variant:'plain',
                            slotProps: {tabList: {sticky: 'top'}}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1415

- [x] Changed popup size to 65% of viewport for table options and table info(i-icon).
- [ ] Table info: fixed layout issue; grouped collapsible panels for cleaner look.
- [ ] Replaced table cell ‘more’ (…) popup with JoyUI DropDown.  Beside it being a better solution, it also fixes the issue where the old popup appeared cropped at the edges.
- [ ] Converted column dropdown filter(down arrow button) to JoyUI Dropdown and revamp its buttons.

Test: https://fireflydev.ipac.caltech.edu/firefly-1415-tableoptions/firefly