### PR TITLE
Firefly-1418: UI cleanup

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -274,7 +274,7 @@ function fireflyInit(props, appSpecificOptions={}, webApiCommands) {
  */
 export function startAsAppFromApi(divId, overrideProps={template: 'FireflySlate'}) {
 
-    const props = {...mergeObjectOnly({...window.firefly.originalAppProps}, overrideProps), div:divId};
+    const props = {...mergeObjectOnly({...window.firefly.originalAppProps}, overrideProps), div:divId, appFromApi:true};
     const viewer = Templates[props.template];
     if (!divId || !viewer) {
         !divId  && logger.error('required: divId');
@@ -285,6 +285,20 @@ export function startAsAppFromApi(divId, overrideProps={template: 'FireflySlate'
     props.disableDefaultDropDown && dispatchUpdateLayoutInfo({disableDefaultDropDown:true});
     props.readoutDefaultPref && dispatchChangeReadoutPrefs(props.readoutDefaultPref);
     props.wcsMatchType && dispatchWcsMatch({matchType:props.wcsMatchType, lockMatch:true});
+
+
+    if (!props.menu) {
+        const other= 'Other Searches';
+        const general= 'General Searches';
+        props.menu= [
+            { label: 'Upload', action: 'FileUploadDropDownCmd', primary:true },
+            { label: 'TAP Searches', action: 'TAPSearch', primary:true, category: general },
+            { label: 'IRSA Images', action: 'ImageSelectDropDownSlateCmd', category: other },
+            { label: 'IRSA Catalogs', action: 'IrsaCatalogDropDown', category: other },
+        ];
+    }
+
+
     const e= document.getElementById(divId);
 
     const makeControlObj= () => {

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -324,7 +324,10 @@ export const PINNED_VIEWER_ID = 'PINNED_CHARTS_VIEWER';
  * @return {{bgTableCnt: number, tableCnt: number, haveResults: boolean, imageCnt: number, pinChartCnt: number)}
  */
 export function getResultCounts() {
-    const haveResults = filter(pick(getLayouInfo(), ['showTables', 'showXyPlots', 'showImages'])).length>0;
+    const layoutInfo= getLayouInfo();
+    const haveResults = filter(pick(layoutInfo, ['showTables', 'showXyPlots', 'showImages'])).length>0 ||
+            !isEmpty(layoutInfo.gridViewsData)
+                         ;
     const tableCnt= getTblIdsByGroup('main')?.length ?? 0;
     const imageCnt= getViewer(getMultiViewRoot(), DEFAULT_FITS_VIEWER_ID)?.itemIdAry?.length ?? 0;
     const pinChartCnt= getViewer(getMultiViewRoot(), PINNED_VIEWER_ID)?.itemIdAry?.length ?? 0;

--- a/src/firefly/js/templates/common/FireflyLayout.jsx
+++ b/src/firefly/js/templates/common/FireflyLayout.jsx
@@ -17,6 +17,7 @@ import {AppConfigDrawer} from '../../ui/AppConfigDrawer.jsx';
  * <banner/>                // menu, icons, title, etc
  * <warning|alerts/>
  * <main>                   // main section of the application.  displays either dropdown, results or expandedView.
+ *     <drawer>
  *     <dropdown>
  *         <content>
  *         <footer + version>
@@ -27,10 +28,12 @@ import {AppConfigDrawer} from '../../ui/AppConfigDrawer.jsx';
  * @param props.footer
  * @param props.useDefaultExpandedView uses the default ExpandedView.  Default to false.
  * @param props.dropDownComponent uses a dropdown component, e.g. DropDownContainer.
+ * @param props.drawerComponent
  * @param props.sx
  * @param props.children
  */
-export function FireflyLayout({footer, useDefaultExpandedView, drawerComponent, dropDownComponent, sx, children, ...props}) {
+export function FireflyLayout({footer, useDefaultExpandedView, drawerComponent=<AppConfigDrawer/>,
+                                  dropDownComponent, sx, children, ...props}) {
 
     const menu = useStoreConnector(getMenu);
     const isReady = useStoreConnector(isAppReady);

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {isEmpty} from 'lodash';
-import React, {memo, useEffect} from 'react';
+import React, {memo, useContext, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
 import {flux} from '../../core/ReduxFlux.js';
@@ -14,6 +14,8 @@ import {getLayouInfo, dispatchSetLayoutMode, getGridView, getGridViewColumns,
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {getExpandedChartProps} from '../../charts/ChartsCntlr.js';
+import {AppConfigDrawer} from '../../ui/AppConfigDrawer.jsx';
+import {AppPropertiesCtx} from '../../ui/AppPropertiesCtx.jsx';
 import {visRoot} from '../../visualize/ImagePlotCntlr.js';
 import {getMultiViewRoot, findViewerWithItemId, PLOT2D} from '../../visualize/MultiViewCntlr.js';
 import {ImageExpandedMode} from '../../visualize/iv/ImageExpandedMode.jsx';
@@ -58,9 +60,12 @@ function getNextState(prevS, renderTreeId) {
  * @param props
  *
  */
-export const FireflySlate= memo(( {initLoadingMessage, appTitle= 'Firefly', appIcon=FFTOOLS_ICO,
-                                      renderTreeId, menu:menuItems, showBgMonitor=false}) => {
+export const FireflySlate= memo(( {initLoadingMessage, renderTreeId, menu:menuItems, showBgMonitor=false}) => {
+
+
+    const {appTitle, appIcon=FFTOOLS_ICO, appFromApi} = useContext(AppPropertiesCtx);
     const state= useStoreConnector( (prevState) => getNextState(prevState,renderTreeId));
+    const [appRef,setAppRef]= useState(undefined);
 
 
     const {mode={}, gridView= [], gridColumns=1, menu={}, layoutInfo, initLoadCompleted, ...appProps} = state;
@@ -74,11 +79,21 @@ export const FireflySlate= memo(( {initLoadingMessage, appTitle= 'Firefly', appI
     },[]);
 
     if (showBgMonitor) menu.showBgMonitor= showBgMonitor;
+
+
+    const drawerComponent= <AppConfigDrawer containerElement={appRef}/>;
+    
+
     return (
         <RenderTreeIdCtx.Provider value={{renderTreeId}}>
-            <App {...{enableVersionDialog:true, appTitle, appIcon, ...appProps}}>
+            <div {...{ref:(c) => {
+                    if (appFromApi) setAppRef(c);
+                }
+            }}>
+            <App {...{drawerComponent, enableVersionDialog:true, appTitle, appIcon, ...appProps}}>
                 {mainView({expanded, gridView, gridColumns, initLoadingMessage, initLoadCompleted})}
             </App>
+            </div>
         </RenderTreeIdCtx.Provider>
     );
 });

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -18,7 +18,7 @@ import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getMocWatcherDef} from '../../visualize/saga/MOCWatcher.js';
 import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
 import {layoutManager} from './FireflyViewerManager.js';
-import {LayoutChoice, LayoutChoiceAccordion} from './LayoutChoice.jsx';
+import {LayoutChoiceAccordion} from './LayoutChoice.jsx';
 import {TriViewPanel} from './TriViewPanel.jsx';
 import {getActionFromUrl} from '../../core/History.js';
 import {startImagesLayoutWatcher} from '../../visualize/ui/TriViewImageSection.jsx';
@@ -72,7 +72,7 @@ export function FireflyViewer ({menu, options, initLoadCompleted, initLoadingMes
 
     }, []);
     const drawerComponent= (
-        <AppConfigDrawer  appIcon={appProps.appIcon} appTitle={appProps.appTitle}>
+        <AppConfigDrawer>
             <LayoutChoiceAccordion/>
         </AppConfigDrawer>
     );

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -70,8 +70,7 @@ export const LcViewer = memo(({menu, dropdownPanels=[], appTitle, ...appProps}) 
     const subTitleStr= displayMode?.startsWith('period') ? '(Period Finder)' : '(Viewer)';
     const title = makeBannerTitle(appTitle || DEFAULT_TITLE, subTitleStr);
 
-    const drawerComponent= (
-        <AppConfigDrawer  appIcon={appProps.appIcon} appTitle={appTitle} allowMenuHide={false}/>);
+    const drawerComponent= (<AppConfigDrawer allowMenuHide={false}/>);
 
     return (
         <App drawerComponent={drawerComponent} dropdownPanels={[...dropdownPanels, <UploadPanel {...{fileLocation}}/>]}

--- a/src/firefly/js/ui/App.jsx
+++ b/src/firefly/js/ui/App.jsx
@@ -4,7 +4,6 @@ import {FireflyLayout} from 'firefly/templates/common/FireflyLayout.jsx';
 import {DropDownContainer} from 'firefly/ui/DropDownContainer.jsx';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 import {getLayouInfo} from 'firefly/core/LayoutCntlr.js';
-import {AppConfigDrawer} from './AppConfigDrawer.jsx';
 
 
 export  default function App({children, dropdownPanels, drawerComponent, watchInitArgs, selected, ...props}) {
@@ -22,9 +21,8 @@ export  default function App({children, dropdownPanels, drawerComponent, watchIn
         );
     }
 
-    const drawer= drawerComponent ?? <AppConfigDrawer  appIcon={props.appIcon} appTitle={props.appTitle}/>;
     return (
-        <FireflyLayout {...{dropDownComponent, drawerComponent:drawer, ...props}}>
+        <FireflyLayout {...{dropDownComponent, drawerComponent, ...props}}>
             {children}
         </FireflyLayout>
     );

--- a/src/firefly/js/ui/AppConfigDrawer.jsx
+++ b/src/firefly/js/ui/AppConfigDrawer.jsx
@@ -1,9 +1,10 @@
 
 import {DialogTitle, Divider, Drawer, ModalClose, Stack, Typography} from '@mui/joy';
-import {bool, number, oneOfType, string} from 'prop-types';
-import React, {useState} from 'react';
+import {object, bool, number, oneOfType, string} from 'prop-types';
+import React, {useContext, useState} from 'react';
 import {dispatchHideDialog, isDialogVisible, SIDE_BAR_ID} from '../core/ComponentCntlr.js';
 import {modifyURLToFull} from '../util/WebUtil.js';
+import {AppPropertiesCtx} from './AppPropertiesCtx.jsx';
 import {useColorMode} from './FireflyRoot.jsx';
 import {ListBoxInputFieldView} from './ListBoxInputField.jsx';
 import {SideBarMenu} from './Menu.jsx';
@@ -13,15 +14,19 @@ import {VersionInfo} from './VersionInfo.jsx';
 
 
 
-export function AppConfigDrawer({appTitle, appIcon, drawerWidth= '22rem', allowMenuHide= true, useSideBarMenu=true, children}) {
+export function AppConfigDrawer({containerElement, drawerWidth= '22rem', allowMenuHide= true, useSideBarMenu=true, children}) {
+
+    const {appTitle, appIcon} = useContext(AppPropertiesCtx);
     const visible= useStoreConnector(() => isDialogVisible(SIDE_BAR_ID));
     const closeSideBar= () => dispatchHideDialog(SIDE_BAR_ID);
     return (
-        <Drawer open={visible} onClose={() => closeSideBar()} sx={{ '--Drawer-horizontalSize': drawerWidth }} >
+        <Drawer container={containerElement} open={visible} onClose={() => closeSideBar()} sx={{ '--Drawer-horizontalSize': drawerWidth }} >
             <ModalClose/>
             <DialogTitle>
                 <Stack direction='row' spacing={1} alignItems='center'>
-                    <img style={{maxWidth:'50px'}} src={appIcon?.startsWith('data') ? appIcon : modifyURLToFull(appIcon)}/>
+                    <img style={{maxWidth:'50px'}} src={appIcon?.startsWith('data') ? appIcon : modifyURLToFull(appIcon)}
+                         onClick={() => closeSideBar()}
+                    />
                     <div>{appTitle}</div>
                 </Stack>
             </DialogTitle>
@@ -44,11 +49,10 @@ export function AppConfigDrawer({appTitle, appIcon, drawerWidth= '22rem', allowM
 }
 
 AppConfigDrawer.propTypes = {
-    appTitle: string,
-    appIcon: string,
     drawerWidth: oneOfType([string,number]),
     allowMenuHide: bool,
-    useSideBarMenu: bool
+    useSideBarMenu: bool,
+    containerElement: object
 };
 
 

--- a/src/firefly/js/ui/DialogRootContainer.jsx
+++ b/src/firefly/js/ui/DialogRootContainer.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {Sheet, Stack} from '@mui/joy';
-import React, {memo, useEffect, useState, PureComponent} from 'react';
+import React, {memo, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {createRoot} from 'react-dom/client';
 import {get, set} from 'lodash';

--- a/src/firefly/js/ui/DropDownDirContext.js
+++ b/src/firefly/js/ui/DropDownDirContext.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
-export const DropDownDirCTX = React.createContext({
-    dropdownDirection : ''
+export const DropDownDirCtx = React.createContext({
+    dropdownDirection : '',
+    dropdownVertical : 'below'
 });

--- a/src/firefly/js/ui/Menu.jsx
+++ b/src/firefly/js/ui/Menu.jsx
@@ -4,7 +4,7 @@
 
 import {
     Badge, Box, Button, Chip, CircularProgress, Divider, IconButton, ListItemDecorator,
-    Stack, Tab, TabList, Tabs, Tooltip, Typography
+    Stack, Tab, TabList, Tabs, Typography
 } from '@mui/joy';
 import {tabClasses} from '@mui/joy/Tab';
 import {debounce} from 'lodash';
@@ -75,14 +75,14 @@ export function Menu() {
         }
     }, [selected,ready]);
 
-    if (!ready || !menuItems?.length) return <div/>;
+    if (!ready) return <div/>;
 
     const menuTabItems = menuItems
-        .filter(({action,type}) => (action!=='app_data.helpLoad' && type!=='COMMAND'))
-        .filter(itemVisible)
-        .filter((item) => item.type!=='COMMAND');
+        ?.filter(({action,type}) => (action!=='app_data.helpLoad' && type!=='COMMAND'))
+        ?.filter(itemVisible)
+        ?.filter((item) => item.type!=='COMMAND');
 
-    const helpItem= menuItems.find(({action,type}) => (action==='app_data.helpLoad' && type==='COMMAND'));
+    const helpItem= menuItems?.find(({action,type}) => (action==='app_data.helpLoad' && type==='COMMAND'));
 
     const bCntAdd= showBgMonitor?2:1;
     const size= getButtonSize(menuTabItems.length+bCntAdd,windowWidth);
@@ -108,12 +108,13 @@ export function MenuItemButton({menuItem, icon, size='lg', clickHandler, isWorki
 
     const item=(
         icon ?
-            (<IconButton {...{ className: 'ff-MenuItem', sx:{whiteSpace:'nowrap', ...sx}, size:'lg', color, variant,
-                onClick: () => onClick(clickHandler,menuItem) , startDecorator,}}>
+            (<IconButton {...{ className: 'ff-MenuItem', size:'lg', color, variant,
+                onClick: () => onClick(clickHandler,menuItem)}}>
                 {icon}
             </IconButton>) :
-            (<Button {...{ className: 'ff-MenuItem', sx:{whiteSpace:'nowrap', ...sx}, size, color, variant,
-                onClick: () => onClick(clickHandler,menuItem) , startDecorator,}}>
+            (<Button {...{startDecorator, className: 'ff-MenuItem', size, color, variant,
+                sx:{whiteSpace:'nowrap', ...sx},
+                onClick: () => onClick(clickHandler,menuItem) }}>
                 {menuItem.label}
             </Button>)
     );
@@ -129,7 +130,7 @@ function tabDivider(activeBg,size) {
                 content: '""',
                 display: 'block',
                 position: 'absolute',
-                height: size==='lg'? '1.5rem' : size==='md' ? '1.25rem' : '.9rem',
+                height: size==='lg'? '1.8rem' : size==='md' ? '1.25rem' : '.9rem',
                 bottom: 6,
                 width: 1,
                 right: -3,
@@ -144,12 +145,9 @@ function tabDivider(activeBg,size) {
 
 function setupTabCss(theme,size) {
     return {
-        marginLeft:'1px',
+        ml:'1px',
         whiteSpace: 'nowrap',
-        borderTopLeftRadius: theme.radius[size],
-        borderTopRightRadius: theme.radius[size],
-        borderBottomRightRadius: 0,
-        borderBottomLeftRadius: 0,
+        borderRadius: `${theme.radius[size]} ${theme.radius[size]} 0 0`,
         borderBottomWidth:0,
     };
 }
@@ -168,18 +166,18 @@ function MenuTabBarJoyTabBased({menuTabItems, size, selected, dropDown}) {
             dispatchHideDropDown();
         }
         else {
-            const clickItem= menuTabItems.find( (i) => i.action===action) ;
-            onClick(clickItem.clickHandler,clickItem);
+            const clickItem= menuTabItems?.find( (i) => i.action===action) ;
+            if (clickItem) onClick(clickItem.clickHandler,clickItem);
         }
     };
 
 
-    const items= menuTabItems.map((item, idx) => (
+    const items= menuTabItems?.map((item, idx) => (
         <Tab {...{ key: idx, value:item.action, disableIndicator:true,
             sx: (theme) => ({ ...setupTabCss(theme,size) }) }} >
             {item.label}
         </Tab>
-    ));
+    )) ?? [];
 
     return (
         <Tabs {...{size, color, variant, value:tabSelected,
@@ -197,11 +195,14 @@ function MenuTabBarJoyTabBased({menuTabItems, size, selected, dropDown}) {
                 })
 
             }}>
-                <Tab {...{key: resultValue, color:'success', variant:'soft', value:resultValue, disableIndicator:true,
+                <Tab {...{key: resultValue, color, variant, value:resultValue, disableIndicator:true,
                     sx: (theme) => {
                         return ({
+                            mb: '1px',
                             ...setupTabCss(theme,size),
+                            color: theme.vars.palette.success.plainColor,
                             '&[aria-selected="true"]': { // apply this to the selected tab
+                                mb: 0,
                                 background: theme.vars.palette.background.surface,
                                 color: theme.vars.palette.success.plainColor,
                             }
@@ -242,7 +243,7 @@ function getButtonSize(buttonCnt,windowWidth) {
     if (buttonCnt<5 || windowWidth>1600) return 'lg';
     const offsetEst= 300;
     const lgButtonSizeEst=130;
-    const mdButtonSizeEst=100;
+    const mdButtonSizeEst=80;
     const width= windowWidth-offsetEst;
     if (width> buttonCnt*lgButtonSizeEst) return 'lg';
     if (width> buttonCnt*mdButtonSizeEst) return 'md';
@@ -276,7 +277,7 @@ export function SideBarMenu({closeSideBar, allowMenuHide}) {
     const selected= getSelected(menu,dropDown);
 
 
-    const categoryList= [...new Set(menuItems.map( (mi) => mi.category ?? ''))];
+    const categoryList= menuItems ? [...new Set(menuItems.map( (mi) => mi.category ?? ''))] : [];
 
     return (
         <SideBarView {...{menu,appTitle, closeSideBar,haveResults,selected,dropDown,
@@ -287,14 +288,15 @@ export function SideBarMenu({closeSideBar, allowMenuHide}) {
 
 function SideBarView({menu,appTitle,closeSideBar,haveResults,selected,dropDown,
                          uploadItem,menuItems,categoryList,allowMenuHide}) {
-    const noCatItems= menuItems.filter( ({category}) => !category);
+    const noCatItems= menuItems?.filter( ({category}) => !category) ?? [];
     return (
         <Stack >
             <Typography level='h4' sx={{ml:1}}>Choose Option</Typography>
             <Stack spacing={1} ml={5} mt={1}>
                 <Stack style={{marginLeft:-16}} sx={{'& .ff-toolbar-button' : {minWidth:'13rem', justifyContent:'flex-start'}}}>
                     <Stack direction='row'>
-                        <Typography color='success'  startDecorator={ <InsightsIcon /> }/>
+                        <Typography color='success'  startDecorator={ <InsightsIcon sx={{width:20}}/> }/>
+                        <Box ml={-1/2}/>
                         <ToolbarButton {...{
                             pressed: !selected && !dropDown.visible,
                             text: (
@@ -316,6 +318,7 @@ function SideBarView({menu,appTitle,closeSideBar,haveResults,selected,dropDown,
                     {uploadItem &&
                         <Stack direction='row'>
                             <FileUploadOutlinedIcon/>
+                            <Box ml={-1/4}/>
                             <SideBarItem {...{key:'UPLOAD', item:uploadItem,selected,
                                 menu,closeSideBar,allowMenuHide}}/>
                         </Stack>
@@ -357,6 +360,7 @@ function SideBarView({menu,appTitle,closeSideBar,haveResults,selected,dropDown,
 }
 
 function tabsUpdated(menu) {
+    if (!menu?.menuItems) return false;
     return menu.menuItems.some( (mi) => {
         return (mi.visible??mi.primary)!==mi.primary;
     });
@@ -375,7 +379,7 @@ function SideBarItem({item,selected,menu,closeSideBar,allowMenuHide,icon,sx, hid
 
     if (!item) return <div>missing</div>;
     return (
-        <Stack direction='row' alignItems='center' sx={sx}>
+        <Stack direction='row' alignItems='center' spacing={1} sx={sx}>
             <ToolbarButton icon={icon} pressed={selected===item.action} onClick= {() => onClick(item)} text={item.label} />
             {(allowMenuHide && (item.visible ?? item.primary)) &&
                 <Chip {...{

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -5,7 +5,7 @@
 import {Badge, Box, Button, Checkbox, Divider, IconButton, Stack, Tooltip} from '@mui/joy';
 import {isString} from 'lodash';
 import React, {memo, useRef, useEffect} from 'react';
-import PropTypes, {bool, element, func, node, number, object, oneOfType, shape, string} from 'prop-types';
+import {bool, element, func, node, number, object, oneOfType, shape, string} from 'prop-types';
 import {dispatchHideDialog} from '../core/ComponentCntlr.js';
 import {DROP_DOWN_KEY} from './DropDownToolbarButton.jsx';
 import DROP_DOWN_ICON from 'html/images/dd-narrow.png';
@@ -209,17 +209,9 @@ function TbCheckBox({hasCheckBox, CheckboxOnIcon, CheckboxOffIcon, checkBoxOn, o
     return <Checkbox {...{variant:'plain', checked:checkBoxOn, onClick}}/>;
 }
 
-function makeBorder(active, theme,color) {
-    // const color= active ? theme.vars.palette.warning.softActiveBg : 'transparent';
+function makeBorder(active,theme,color) {
     const borderC= active ? theme.vars.palette[color]?.softActiveBg : 'transparent';
-    // const color= active ? theme.vars.palette.primary.softActiveColor: 'transparent';
-    return {
-        borderTop: `1px solid ${borderC}`,
-        borderLeft: `1px solid ${borderC}`,
-        borderRight: `1px solid ${borderC}`,
-        borderBottomRightRadius: active ?0 : undefined,
-        borderBottomLeftRadius: active ?0 : undefined,
-    };
+    return { border: `1px solid ${borderC}` };
 }
 
 function makeFontSettings(theme) {

--- a/src/firefly/js/ui/UploadTableSelector.jsx
+++ b/src/firefly/js/ui/UploadTableSelector.jsx
@@ -127,8 +127,8 @@ export function CenterColumns({lonCol,latCol, sx, cols, lonKey, latKey, openKey,
              <Typography component='div'>
                  <Stack {...{direction:'row', alignItems:'baseline', spacing:1}}>
                      <span>{headerTitle}</span>
-                     <Typography color='warning'>{(lonCol || latCol) ? `${lonCol || 'unset'}, ${latCol || 'unset'}` : 'unset'}</Typography>
-                     <Typography level='body-sm'>{`${headerPostTitle}`}</Typography>
+                     <Typography level={'body-md'} sx={{fontWeight:'normal'}}>{(lonCol || latCol) ? `${lonCol || 'unset'}, ${latCol || 'unset'}` : 'unset'}</Typography>
+                     <Typography level='body-sm' sx={{fontWeight:'normal'}}>{`${headerPostTitle}`}</Typography>
                  </Stack>
              </Typography>
          </Box>

--- a/src/firefly/js/ui/dynamic/ServiceDefTools.js
+++ b/src/firefly/js/ui/dynamic/ServiceDefTools.js
@@ -307,6 +307,7 @@ export function makeSearchAreaInfo(cisxUI) {
 }
 
 let tblCnt=1;
+const CHECK_SORT= false;
 
 export function makeServiceDescriptorSearchRequest(request, serviceDescriptor, extraMeta={}) {
     const {standardID = '', accessURL, utype, serDefParams, title, cisxUI=[]} = serviceDescriptor;
@@ -318,11 +319,14 @@ export function makeServiceDescriptorSearchRequest(request, serviceDescriptor, e
     const hideObj= hiddenColumns ?
         Object.fromEntries(hiddenColumns.split(',').map((c) => [ `col.${c}.visibility`, 'hide'] )) : {};
 
-    const sAry= tblSortOrder?.split(',');
+    const sAry= tblSortOrder?.split(',',2);
     let sortObj= {};
-    if (sAry?.length>1) {
-        const dir= sAry.shift();
-        sortObj= {sortInfo: sortInfoString(sAry, dir?.toUpperCase()==='ASC')};
+    if (sAry?.length>1 && CHECK_SORT) {
+        const dir= sAry[0].toUpperCase();
+        sortObj= {sortInfo: sortInfoString(tblSortOrder.substring(dir.length+1), dir==='ASC')};
+        // console.log('from service def: '+tblSortOrder);
+        // console.log('using sortInfoString)(): '+sortObj.sortInfo);
+        // sortObj= {sortInfo: tblSortOrder};
     }
 
     const options= {...sortObj, META_INFO: { ...hideObj, ...extraMeta }};

--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -253,7 +253,7 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
                         <Stack {...{spacing:4}}>
                             <Stack {...{spacing:1}}>
                                 <Stack {...{direction: 'row', spacing:10, mr: 3, justifyContent: 'flex-start', alignItems: 'center'}}>
-                                    <Typography level='h4'>ADQL Query</Typography>
+                                    <Typography level='title-lg'>ADQL Query</Typography>
                                     <Stack {...{direction: 'row'}}>
                                         <Chip size='md' title='Reset to the initial query' style={{height: 24, marginRight: 5}} onClick={onReset}>Reset</Chip>
                                         <Chip size='md' title='Clear the query' style={{height: 24}} onClick={onClear}>Clear</Chip>

--- a/src/firefly/js/ui/tap/TableSearchHelpers.jsx
+++ b/src/firefly/js/ui/tap/TableSearchHelpers.jsx
@@ -199,7 +199,7 @@ export function NavButtons({setServicesShowing, servicesShowing, currentPanel, s
 
     return (
         <Stack {...{direction:'column', justifyContent:'center', spacing:.5, alignItems:'flex-end', mr:.2,
-            sx:{ 'button': {width:'100px'} }
+            sx:{ 'button': {width:'80px', maxHeight:22 } }
         }}>
             {!lockService && <ShowServicesButton {...{setServicesShowing,servicesShowing}}/>}
             <GotoPanelButton {...{setNextPanel,currentPanel}}/>
@@ -229,6 +229,7 @@ function ShowServicesButton({setServicesShowing, servicesShowing }) {
     return (
             <RadioGroupInputFieldView {...{
                 options, value:currState, label:'TAP Services: ', orientation:'horizontal', buttonGroup:true,
+                slotProps: {button: {sx: {'--Button-minHeight' : 22, '--Button-gap': '.2rem', }}},
                 onChange:() => setServicesShowing(!servicesShowing)
             }}/>
     );
@@ -254,6 +255,11 @@ export function TableTypeButton({sx, lockToObsCore, setLockToObsCore}) {
     return (
         <CheckboxGroupInputFieldView  {...{
             sx,
+            slotProps: {
+                input: {
+                    sx:{ '--Switch-trackWidth': '20px', '--Switch-trackHeight': '12px', }
+                }
+            },
             type:'switch',
             options,
             tooltip,value:lockToObsCore?OBSCORE:'', labelWidth:1,

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -5,7 +5,7 @@ import {Box, Button, Stack, Switch, Typography} from '@mui/joy';
 import {once} from 'lodash';
 import {shape, object, bool, string} from 'prop-types';
 import React, {useContext, useEffect, useRef, useState} from 'react';
-import FieldGroupUtils, {getFieldVal, setFieldValue} from 'firefly/fieldGroup/FieldGroupUtils.js';
+import FieldGroupUtils from 'firefly/fieldGroup/FieldGroupUtils.js';
 import {makeSearchOnce} from 'firefly/util/WebUtil.js';
 import {dispatchMultiValueChange} from 'firefly/fieldGroup/FieldGroupCntlr.js';
 import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
@@ -31,7 +31,7 @@ import {
     getMaxrecHardLimit, tapHelpId, getTapServices,
     loadObsCoreSchemaTables, maybeQuote, defTapBrowserState, TAP_UPLOAD_SCHEMA, getAsEntryForTableName,
 } from 'firefly/ui/tap/TapUtil.js';
-import {AdqlUI, BasicUI} from 'firefly/ui/tap/TableSelectViewPanel.jsx';
+import {TapViewType} from './TapViewType.jsx';
 import {useFieldGroupMetaState} from '../SimpleComponent.jsx';
 import {PREF_KEY} from 'firefly/tables/TablePref.js';
 
@@ -231,7 +231,7 @@ TapSearchPanel.propTypes= {
 function TapSearchPanelComponents({initArgs, serviceUrl, servicesShowing, setServicesShowing, onTapServiceOptionSelect,
                                       lockService, lockObsCore, tapOps, titleOn=true, selectBy, setSelectBy}) {
 
-    const label= getServiceLabel(serviceUrl);
+    const serviceLabel= getServiceLabel(serviceUrl);
     const [obsCoreTableModel, setObsCoreTableModel] = useState();
     const hasObsCoreTable = obsCoreTableModel?.tableData?.data?.length > 0;
 
@@ -251,11 +251,10 @@ function TapSearchPanelComponents({initArgs, serviceUrl, servicesShowing, setSer
                 {titleOn &&<Typography {...{level:'h3', sx:{m:1} }}> TAP Searches </Typography>}
                 <Services {...{serviceUrl, servicesShowing: (servicesShowing && !lockService),
                         tapOps, onTapServiceOptionSelect}}/>
-                { selectBy === 'adql' ?
-                    <AdqlUI {...{serviceUrl, servicesShowing, setServicesShowing, lockService, setSelectBy}}/> :
-                    <BasicUI  {...{serviceUrl, serviceLabel: label, selectBy, initArgs, lockService, lockObsCore, obsCoreTableModel,
-                        servicesShowing, setServicesShowing, hasObsCoreTable, setSelectBy}}/>
-                }
+                <TapViewType  {...{
+                    serviceUrl, serviceLabel, selectBy, initArgs, lockService, lockObsCore, obsCoreTableModel,
+                                            servicesShowing, setServicesShowing, hasObsCoreTable, setSelectBy
+                }} />
             </div>
         </Stack>
     );
@@ -277,12 +276,24 @@ function Services({serviceUrl, servicesShowing, tapOps, onTapServiceOptionSelect
     return (
         <div
             className={servicesShowing?'TapSearch__section':'TapSearch__section TapSearch__hide'}
-            style={{height: servicesShowing?62:0, justifyContent:'space-between', alignItems:'center',...extraStyle}}
+            style={{height: servicesShowing?'4rem':0, justifyContent:'space-between', alignItems:'center',...extraStyle}}
             title={SERVICE_TIP}>
             <div style={{display:'flex', alignItems:'center', width:'100%'}}>
-                <Typography {...{level:'h4', color:'primary', sx:{width:'14rem', mr:1} }}>
-                    Select TAP Service
-                </Typography>
+                <Stack alignItems='flex-start'>
+                    <Typography {...{level:'title-lg', color:'primary', sx:{width:'14rem', mr:1} }}>
+                        Select TAP Service
+                    </Typography>
+                    <Switch {...{ size:'sm', endDecorator: enterUrl? 'Enter URL' : 'Use TAP List', checked:enterUrl,
+                        sx: {
+                            alignSelf: 'flex-start',
+                            '--Switch-trackWidth': '20px',
+                            '--Switch-trackHeight': '12px',
+                        },
+                        onChange: (ev) => {
+                            setEnterUrl(ev.target.checked);
+                        },
+                    }} />
+                </Stack>
                 <Stack {...{direction:'row', spacing:2}}>
                     {enterUrl ? (
                             <InputField orientation='horizontal'
@@ -295,7 +306,7 @@ function Services({serviceUrl, servicesShowing, tapOps, onTapServiceOptionSelect
                             />
                     ) : (
                         <ListBoxInputFieldView {...{
-                            sx:{'& .MuiSelect-root':{width:'40rem'}},
+                            sx:{'& .MuiSelect-root':{width:'46.5rem'}},
                             options:tapOps, value:serviceUrl,
                             placeholder:'Choose TAP Service...',
                             startDecorator:!tapOps.length ? <Button loading={true}/> : undefined,
@@ -309,11 +320,6 @@ function Services({serviceUrl, servicesShowing, tapOps, onTapServiceOptionSelect
                                 (label,value) => (<ServiceOpRender {...{ ops: tapOps, value}}/>),
                         }} /> )}
 
-                    <Switch {...{ size:'sm', endDecorator: enterUrl? 'enter URL' : 'Use TAP List', checked:enterUrl,
-                        onChange: (ev) => {
-                            setEnterUrl(ev.target.checked);
-                        },
-                        }} />
 
                 </Stack>
             </div>
@@ -328,10 +334,10 @@ function ServiceOpRender({ops, value, sx}) {
     return (
         <Stack {...{alignItems:'flex-start', sx}}>
             <Stack {...{direction:'row', spacing:1, alignItems:'center'}}>
-                <Typography level='title-lg'>
+                <Typography level='title-md'>
                     {`${op.labelOnly}: `}
                 </Typography>
-                <Typography level='body-lg' >
+                <Typography level='body-md' >
                     {op.value}
                 </Typography>
             </Stack>

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -65,7 +65,7 @@ export const defTapBrowserState= {
     schemaOptions:undefined,
     schemaName:undefined,
     tableOptions:undefined,
-    lastServicesShowing: false,
+    lastServicesShowing: true,
     tableName:undefined,
     columnsModel:undefined,
     obsCoreEnabled:false,

--- a/src/firefly/js/visualize/ui/ImageCenterDropDown.jsx
+++ b/src/firefly/js/visualize/ui/ImageCenterDropDown.jsx
@@ -122,15 +122,17 @@ export function ImageCenterDropDown({visRoot:vr, visible, mi}) {
                            onClick={() => dispatchRecenter({plotId, centerOnImage:true})} />
 
             <DropDownVerticalSeparator useLine={true}/>
-            <FieldGroup style={{display:'flex', fontSize:'10pt', padding:'5px 0 0 0'}}
-                        groupKey='TARGET_DROPDOWN' keepState={false}>
-                <TargetPanel groupKey={'target-move-group'} labelWidth={80}
-                             label={'Center On:'} defaultToActiveTarget={false}
-                             showResolveSourceOp={false} showExample={false}/>
-                <Stack {...{direction:'column'}}>
-                    <CompleteButton text= 'Go' innerStyle={{width:'100%'}} onSuccess={moveToTarget} fireOnEnter={true} />
-                    <CompleteButton style={{ marginTop:4, whiteSpace:'nowrap' }} innerStyle={{width:'100%'}}
-                                    text= 'Go & Mark' onSuccess={createMarkerAndMoveToTarget} />
+            <FieldGroup groupKey='TARGET_DROPDOWN'>
+                <Stack direction='row' spacing={1}>
+                    <TargetPanel groupKey={'target-move-group'} labelWidth={80}
+                                 label={'<Enter position to center on>'} defaultToActiveTarget={false}
+                                 showResolveSourceOp={false} showExample={false}/>
+                    <Stack {...{alignItems:'stretch'}}>
+                        <CompleteButton text= 'Go' onSuccess={moveToTarget} fireOnEnter={true}
+                                        sx={{'& button': {width:1}}}/>
+                        <CompleteButton style={{ marginTop:4, whiteSpace:'nowrap' }} innerStyle={{width:'100%'}}
+                                        text= 'Go & Mark' onSuccess={createMarkerAndMoveToTarget} />
+                    </Stack>
                 </Stack>
             </FieldGroup>
             {recentAry.length>0 && <DropDownVerticalSeparator useLine={true}/>}


### PR DESCRIPTION
#### [Firefly-1418](https://jira.ipac.caltech.edu/browse/FIREFLY-1418): UI cleanup

 - dropdown should go up if no room down
 - tap
      -  general tap: show services by default
      - clean up layout for different modes
 - menu: small tweeks to make it look better
 - AppConfigDrawer will close when you click the app icon

#### Testing

 - https://firefly-1418-ui-cleanup.irsakudev.ipac.caltech.edu/irsaviewer
 - other tap stuff is mostly better spacing
 - do tap search, make table area small, click on microscope
 - close draw by clicking on app icon
 - There should be a little line under the results tab when it is not selected (like the other tabs)
 - the side bar result item is better aligned
