### PR TITLE
FIREFLY-1419: Package download is no longer working

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static edu.caltech.ipac.util.StringUtils.groupFind;
+
 
 /**
  * Date: May 14, 2009
@@ -316,11 +318,12 @@ public class TableUtil {
     }
 
     /**
-     * @param cnames a string of column name(s)
-     * @return an array of column names split from a comma separated string, ignoring commas inside double-quotes
+     * @param cnames a string of column name(s).  It can also be expression including functions.
+     *               ignore commas inside double-quotes or parentheses(e.g. function parameters) when parsing
+     * @return an array of column names.
      */
     public static String[] splitCols(String cnames) {
-        return cnames == null ? new String[0] : cnames.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
+        return cnames == null ? new String[0] : cnames.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)(?![^(]*\\))");
     }
 
 //====================================================================

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -198,8 +198,7 @@ function bgPackage(action) {
                         showInfoPopup(msg, 'Multipart download');
 
                     } else {
-                        const result= jobInfo?.results?.[0];
-                        const url= isObject(result) ? result?.href : result;
+                        const url= jobInfo?.results?.[0]?.href;
                         download(url);
                     }
                 }

--- a/src/firefly/js/core/background/BackgroundMonitor.jsx
+++ b/src/firefly/js/core/background/BackgroundMonitor.jsx
@@ -223,7 +223,7 @@ function PackageItem({SINGLE, jobId, index}) {
     const dlState = downloadState?.[index];
 
     const doDownload = () => {
-        const url = jobInfo?.results?.[index];
+        const url = jobInfo?.results?.[index]?.href;
         if (!url) {
             showInfoPopup('Bad URL. Cannot download');
             return;

--- a/src/firefly/js/tables/SortInfo.js
+++ b/src/firefly/js/tables/SortInfo.js
@@ -60,7 +60,8 @@ export function sortInfoString(colName, isAscending=true) {
     }
 
     serialize() {
-        return this.direction === UNSORTED ? '' : `${this.direction},${this.sortColumns.map( (c) => `"${c}"`).join()}`;
+        return this.direction === UNSORTED ? '' :
+            `${this.direction},${this.sortColumns.map( (c) => c.includes('"') ? c : `"${c}"`).join()}`;         // if there's quotes in column name, don't add quotes.
     }
 
     static parse(sortInfo) {

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -196,7 +196,7 @@ export function DownloadOptionPanel ({groupKey, cutoutSize, help_id, children, s
         setBgKey(akey);
     }, [cutoutSize, dlParams, tbl_id]);
 
-    const showWarnings = hasProprietaryData(getTblById(tbl_id));
+    // const showWarnings = hasProprietaryData(getTblById(tbl_id)); // it feature is not working correctly
 
     const maskStyle = {
         position: 'absolute',
@@ -229,7 +229,6 @@ export function DownloadOptionPanel ({groupKey, cutoutSize, help_id, children, s
                 onCancel = {() => dispatchHideDialog(DOWNLOAD_DIALOG_ID)}
                 help_id  = {help_id}>
                 <FieldGroup groupKey={groupKey} keepState={true}>
-                    {showWarnings && <div style={noticeCss}>This table contains proprietary data. Only data to which you have access will be downloaded.</div>}
                     {preTitleMessage && <div style={preTitleCss}>{preTitleMessage}</div>}
                     <div className='FieldGroup__vertical--more'>
                         {showTitle && <TitleField {...{labelWidth, value:dlTitle }}/>}

--- a/src/firefly/js/ui/dynamic/ServiceDefTools.js
+++ b/src/firefly/js/ui/dynamic/ServiceDefTools.js
@@ -323,8 +323,6 @@ export function makeServiceDescriptorSearchRequest(request, serviceDescriptor, e
     if (sAry) {
         const [,dir,sortBy] = sAry;
         sortObj= {sortInfo: sortInfoString(sortBy, dir?.toUpperCase()==='ASC')};
-        // console.log('from service def: '+tblSortOrder);
-        // console.log('using sortInfoString)(): '+sortObj.sortInfo);
     }
 
     const options= {...sortObj, META_INFO: { ...hideObj, ...extraMeta }};

--- a/src/firefly/js/ui/dynamic/ServiceDefTools.js
+++ b/src/firefly/js/ui/dynamic/ServiceDefTools.js
@@ -307,7 +307,6 @@ export function makeSearchAreaInfo(cisxUI) {
 }
 
 let tblCnt=1;
-const CHECK_SORT= false;
 
 export function makeServiceDescriptorSearchRequest(request, serviceDescriptor, extraMeta={}) {
     const {standardID = '', accessURL, utype, serDefParams, title, cisxUI=[]} = serviceDescriptor;
@@ -319,14 +318,13 @@ export function makeServiceDescriptorSearchRequest(request, serviceDescriptor, e
     const hideObj= hiddenColumns ?
         Object.fromEntries(hiddenColumns.split(',').map((c) => [ `col.${c}.visibility`, 'hide'] )) : {};
 
-    const sAry= tblSortOrder?.split(',',2);
+    const sAry= tblSortOrder?.match(/([^,]+),(.+)/);
     let sortObj= {};
-    if (sAry?.length>1 && CHECK_SORT) {
-        const dir= sAry[0].toUpperCase();
-        sortObj= {sortInfo: sortInfoString(tblSortOrder.substring(dir.length+1), dir==='ASC')};
+    if (sAry) {
+        const [,dir,sortBy] = sAry;
+        sortObj= {sortInfo: sortInfoString(sortBy, dir?.toUpperCase()==='ASC')};
         // console.log('from service def: '+tblSortOrder);
         // console.log('using sortInfoString)(): '+sortObj.sortInfo);
-        // sortObj= {sortInfo: tblSortOrder};
     }
 
     const options= {...sortObj, META_INFO: { ...hideObj, ...extraMeta }};


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1419

Also, allow quotes and commas in table sortInfo.  This allow DCE to use 
```table_sort_order=ASC,substring("dataproduct_subtype",2)```

Test: https://firefly-1419-download-broken.irsakudev.ipac.caltech.edu/irsaviewer/dce

To test download probem:
- load DCE
- pick DeepDrill from menu on left
- search on anything where there is data (i used the example target
- pick any data to download (I used one or two of the science mosaics)
- click on “prepare download”
- wait for it to finish packaging
- click on “Download now”

To test sortInfo problem:
- load DCE
- search on anything where this is data
In the results column `dataproduct_subtype`, `science` should be on top.
