### PR TITLE
Firefly 1420 cleanup items

### DIFF
--- a/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
+++ b/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
@@ -28,7 +28,6 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
 
 import MAGNIFYING_GLASS from 'images/icons-2014/magnifyingGlass.png';
-import INSERT_COLUMN from 'html/images/insert-col-right-24-24.png';
 import INFO from 'html/images/info-icon.png';
 import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
 import {setSelectInfo} from 'firefly/tables/TableRequestUtil.js';
@@ -36,6 +35,7 @@ import {dispatchHideDialog} from 'firefly/core/ComponentCntlr.js';
 import {FilterInfo} from 'firefly/tables/FilterInfo.js';
 import {AddColumnButton} from 'firefly/visualize/ui/Buttons.jsx';
 import {RequiredFieldMsg} from 'firefly/ui/InputField.jsx';
+import {Stacker} from 'firefly/ui/Stacker.jsx';
 
 
 let hideExpPopup;
@@ -128,14 +128,11 @@ export const AddOrUpdateColumn = React.memo(({tbl_ui_id, tbl_id, hidePopup, edit
                     ]}/>
                 {mode === 'Custom' ? <CustomFields {...{tbl_ui_id, tbl_id, groupKey, editColName}}/> : <PresetFields {...{tbl_id, editColName}}/>}
             </FieldGroup>
-            <Stack direction='row' justifyContent='space-between'>
-                <Stack direction='row' spacing={1} alignItems='center'>
-                    <Button color='primary' variant='solid' onClick={doUpdate}>{buttonLabel}</Button>
-                    {editColName && DelBtn}
-                    <Button onClick={() => hidePopup?.()}> Cancel</Button>
-                </Stack>
-                <HelpIcon helpId={'tables.addColumn'}/>
-            </Stack>
+            <Stacker endDecorator={<HelpIcon helpId={'tables.addColumn'}/>}>
+                <Button color='primary' variant='solid' onClick={doUpdate}>{buttonLabel}</Button>
+                {editColName && DelBtn}
+                <Button onClick={() => hidePopup?.()}> Cancel</Button>
+            </Stacker>
         </Stack>
     );
 

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -9,11 +9,11 @@ import {Column, Table} from 'fixed-data-table-2';
 import {wrapResizer} from '../../ui/SizeMeConfig.js';
 import {get, set, isEmpty, isUndefined, omitBy, pick} from 'lodash';
 
-import {calcColumnWidths, getCellValue, getColumns, getProprietaryInfo, getTableState, getTableUiById, getTblById, hasRowAccess, isClientTable, tableTextView, TBL_STATE, uniqueTblUiId} from '../TableUtil.js';
+import {calcColumnWidths, getCellValue, getColMaxValues, getColumns, getProprietaryInfo, getTableState, getTableUiById, getTblById, hasRowAccess, isClientTable, tableTextView, TBL_STATE, uniqueTblUiId} from '../TableUtil.js';
 import {SelectInfo} from '../SelectInfo.js';
 import {FilterInfo} from '../FilterInfo.js';
 import {SortInfo} from '../SortInfo.js';
-import {CellWrapper, HeaderCell, makeDefaultRenderer, SelectableCell, SelectableHeader} from './TableRenderer.js';
+import {CellWrapper, getPxWidth, HeaderCell, headerLevel, headerStyle, makeDefaultRenderer, SelectableCell, SelectableHeader} from './TableRenderer.js';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {dispatchTableUiUpdate, TBL_UI_UPDATE} from '../TablesCntlr.js';
 import {Logger} from '../../util/Logger.js';
@@ -325,8 +325,16 @@ function correctScrollLeftIfNeeded(totalColWidths, scrollLeft, width, triggeredB
 }
 
 function columnWidthsInPixel(columns, data) {
-    return calcColumnWidths(columns, data, {maxColWidth: 100, maxAryWidth: 30, useCnameMultiplier: true})      // set max width for array columns
-            .map( (w) =>  (w + 2) * 7);
+
+    const maxVals = getColMaxValues(columns, data, {maxColWidth: 100, maxAryWidth: 30});
+
+    const paddings = 8;
+    return maxVals.map((text, idx) => {
+        const header = columns[idx].label || columns[idx].name;
+        const style = header === text ? headerStyle : {fontSize:12};
+        text = text.replace(/[^a-zA-Z0-9]/g, 'O');    // some non-alphanum values can be very narrow.  use 'O' in place of them.
+        return getPxWidth({text, ...style}) + paddings;
+    });
 }
 
 function defHighlightedRowHandler(tbl_id, hlRowIdx, startIdx) {

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -23,8 +23,8 @@ export function TableInfo({tbl_id, tabsProps, ...props}) {
    const jobId = getJobIdFromTblId(tbl_id);
 
     return (
-        <Stack p={1} height={1} spacing={1} {...props}>
-            <StatefulTabs componentKey='TablePanelOptions' {...tabsProps}>
+        <Stack p={1} height={1} spacing={1} overflow='hidden' {...props}>
+            <StatefulTabs componentKey='TablePanelOptions' {...tabsProps} sx={{overflow:'auto'}}>
                 {jobId &&
                 <Tab name='Job Info'>
                     <JobInfo jobId={jobId}/>
@@ -36,7 +36,7 @@ export function TableInfo({tbl_id, tabsProps, ...props}) {
                     </div>
                 </Tab>
             </StatefulTabs>
-            <Stack alignItems='flex-end'>
+            <Stack alignItems='end' pr={1}>
                 <HelpIcon helpId='tables.info'/>
             </Stack>
         </Stack>

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -33,6 +33,7 @@ import {BY_SCROLL} from './BasicTableView.jsx';
 import EDIT from 'html/images/16x16_edit_icon.png';
 import {MAX_ROW} from 'firefly/tables/TableRequestUtil';
 import {ClearFilterButton} from 'firefly/visualize/ui/Buttons.jsx';
+import {Stacker} from 'firefly/ui/Stacker.jsx';
 
 
 export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOptionReset, clearFilter}) => {
@@ -98,14 +99,11 @@ export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOpt
                 }
             </StatefulTabs>
             {showTblPrefMsg && <TablePrefMsg/>}
-            <Stack direction='row' justifyContent='space-between'>
-                <Stack direction='row' alignItems='center' spacing={1}>
-                    <Button variant='solid' color='primary' onClick={onClose}>Close</Button>
-                    <Button onClick={onReset}>Reset column selection</Button>
-                    <Button onClick={onRemoveFilters}>Remove all filters</Button>
-                </Stack>
-                <HelpIcon helpId={'tables.options'}/>
-            </Stack>
+            <Stacker endDecorator={<HelpIcon helpId={'tables.options'}/>}>
+                <Button variant='solid' color='primary' onClick={onClose}>Close</Button>
+                <Button onClick={onReset}>Reset column selection</Button>
+                <Button onClick={onRemoveFilters}>Remove all filters</Button>
+            </Stacker>
         </Stack>
     );
 });

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -5,8 +5,7 @@
 import React, {useRef, useCallback, useState, useEffect} from 'react';
 import {Cell} from 'fixed-data-table-2';
 import {set, get, omit, isEmpty, isString, toNumber} from 'lodash';
-import {Typography, Checkbox, Stack, Box, Link, Sheet, Dropdown, Menu, MenuButton, MenuItem, IconButton, Button, Chip} from '@mui/joy';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import {Typography, Checkbox, Stack, Box, Link, Sheet, MenuItem, Button, Chip} from '@mui/joy';
 
 import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
 import {
@@ -21,7 +20,7 @@ import {toBoolean, copyToClipboard} from '../../util/WebUtil.js';
 import ASC_ICO from 'html/images/sort_asc.gif';
 import DESC_ICO from 'html/images/sort_desc.gif';
 import {CheckboxGroupInputField} from '../../ui/CheckboxGroupInputField';
-import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
+import DialogRootContainer, {DropDown} from '../../ui/DialogRootContainer.jsx';
 import {FieldGroup} from '../../ui/FieldGroup';
 import {getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
@@ -141,12 +140,9 @@ function Filter({cname, onFilter, filterInfo, tbl_id}) {
 
 
     const endDecorator = enumVals && (
-        <Dropdown onOpenChange={(_,v) => setDisableHoverListener(v) }>
-            <MenuButton slots={{ root: IconButton }} sx={{mr:-1}}><ArrowDropDownIcon/></MenuButton>
-            <Menu ref={dropdownEl}>
-                <EnumSelect {...{col, tbl_id, filterInfo, filterInfoCls, onFilter}} />
-            </Menu>
-        </Dropdown>
+        <DropDown onOpenChange={(v) => setDisableHoverListener(v) } slotProps={{button:{sx:{mr:-1}}}}>
+            <EnumSelect {...{col, tbl_id, filterInfo, filterInfoCls, onFilter}} />
+        </DropDown>
     );
 
     return (
@@ -329,7 +325,6 @@ export function ContentEllipsis({children, text, textAlign, sx, actions=[]}) {
 
 function ActionDropdown({text, actions, onChange}) {
     const popupID = 'actions--popup';
-    const [open, setOpen] = useState(false);
     const copyCB = () => {
         copyToClipboard(text);
     };
@@ -338,16 +333,18 @@ function ActionDropdown({text, actions, onChange}) {
         dispatchShowDialog(popupID);
     };
     return (
-        <Dropdown open={open} onOpenChange={(_, open) => setOpen(open) | onChange(open)}>
-            <MenuButton variant='soft' size='sm' sx={{position: 'absolute', right:0, paddingInline:'.25em'}}>
-                <MoreHorizIcon/>
-            </MenuButton>
-            <Menu>
-                <MenuItem onClick={copyCB}>Copy to clipboard</MenuItem>
-                <MenuItem onClick={viewAsText}>View as plain text</MenuItem>
-                {actions?.map((text, action) => <MenuItem onClick={action}>{text}</MenuItem>)}
-            </Menu>
-        </Dropdown>
+        <DropDown button={<MoreHorizIcon/>} onOpenChange={onChange} useIconButton={false}
+                  slotProps={{
+                      button: {
+                          variant:'soft',
+                          size:'sm',
+                          sx:{position: 'absolute', right:0, paddingInline:'.25em'}
+                  }}}
+        >
+            <MenuItem onClick={copyCB}>Copy to clipboard</MenuItem>
+            <MenuItem onClick={viewAsText}>View as plain text</MenuItem>
+            {actions?.map((text, action) => <MenuItem onClick={action}>{text}</MenuItem>)}
+        </DropDown>
     );
 };
 

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -37,6 +37,7 @@ import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import {FilterButton} from 'firefly/visualize/ui/Buttons.jsx';
 
 
+export const headerStyle = {fontSize:'var(--joy-fontSize-sm)', fontWeight:'var(--joy-fontWeight-md)'};  // maybe faulty becuase it's translated from Typography title-sm, which is dynamic.
 
 const html_regex = /<.+>|&.+;/;           // A rough detection of html elements or entities
 
@@ -399,7 +400,9 @@ function ViewAsText({text, ...rest}) {
                 <input id='doFormat' type='checkbox' title={label} onChange={onChange} checked={doFmt}/>
                 <label htmlFor='doFormat' style={{verticalAlign: ''}}>{label}</label>
             </div>
-            <textarea readOnly className='Actions__popup' value={text} style={{width: 650, height: 125}}/>
+            <Sheet variant='outlined' sx={{resize:'both', overflow:'auto', minWidth:'30em', minHeight:'15em',p:1}} >
+                <Typography whiteSpace='pre'>{text}</Typography>
+            </Sheet>
         </PopupPanel>
 
     );
@@ -782,7 +785,7 @@ const parseStyles = (styles='') =>  {
         .split(';')
         .filter((style) => style.split(':')[0] && style.split(':')[1])
         .map((style) => [
-            style.split(':')[0].trim().replace(/^-ms-/, 'ms-').replace(/-./g, c => c.substr(1).toUpperCase()),
+            style.split(':')[0].trim().replace(/^-ms-/, 'ms-').replace(/-./g, (c) => c.substr(1).toUpperCase()),
             style.split(':').slice(1).join(':').trim()
         ])
         .reduce((styleObj, style) => ({
@@ -791,3 +794,24 @@ const parseStyles = (styles='') =>  {
         }), {});
     // some
 };
+
+
+export function getPxWidth({text, fontSize, fontWeight}) {
+    const div = document.createElement('div');
+
+    // Set the style if given
+    if (fontSize)   div.style.fontSize = fontSize + 'px';
+    if (fontWeight) div.style.fontWeight = fontWeight + '';
+    div.style.fontFamily = 'var(--joy-fontFamily-body)';
+    div.textContent = text;
+
+    // Hide the element so it doesn't affect the layout
+    div.style.position = 'absolute';
+    div.style.visibility = 'hidden';
+
+    document.body.appendChild(div);
+    const width = div.getBoundingClientRect().width;
+    document.body.removeChild(div);
+
+    return width;
+}

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -30,6 +30,7 @@ import {getCmdSrvSyncURL} from '../../util/WebUtil';
 import {RadioGroupInputField} from 'firefly/ui/RadioGroupInputField.jsx';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 import {findTableCenterColumns} from 'firefly/voAnalyzer/TableAnalysis';
+import {Stacker} from 'firefly/ui/Stacker.jsx';
 
 const fKeyDef = {
     fileName: {fKey: 'fileName', label: 'File name'},
@@ -143,35 +144,32 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
         );
     };
     return (
-        <FieldGroup groupKey={tblDownloadGroupKey} reducerFunc={TableDLReducer(tbl_id)}>
-            <Stack spacing={2} justifyContent={'center'}
-                               sx={{px: 2}}>
-                <DownloadOptionsDialog fromGroupKey={tblDownloadGroupKey} style={{width: 'unset', height: 'unset'}}
-                                       children={fileFormatOptions()}
-                                       workspace={isWs}
-                                       dialogWidth='100%'
-                                       dialogHeight='100%'
-                />
-                <RadioGroupInputField fieldKey='mode' initialState={{value: 'displayed'}}
-                                      options={[{value:'displayed', label:'Save table as displayed'}, {value:'original', label:'Save table as originally retrieved'}]}/>
-                <Typography level='body-sm' sx={{textAlign: 'left'}}>
-                    {mode === 'original' ? asOriginalMsg : asDisplayedMsg}
-                </Typography>
-                <Stack sx={{flexDirection: 'row', justifyContent: 'space-between'}}>
-                    <Stack spacing={1} direction='row' alignItems='center'>
-                        <CompleteButton
-                            groupKey={tblDownloadGroupKey}
-                            onSuccess={resultSuccess(tbl_id, tbl_ui_id, onComplete, cenCols)}
-                            onFail={resultFail()}
-                            text={'Save'}/>
-                        <Button onClick={() => onComplete?.()}>Cancel</Button>
-                    </Stack>
-                    <Stack>
-                        <HelpIcon helpId={'tables.save'}/>
-                    </Stack>
+        <Stack spacing={1} height={1}>
+            <FieldGroup groupKey={tblDownloadGroupKey} reducerFunc={TableDLReducer(tbl_id)} sx={{flexGrow:1, display:'flex', alignItems:'start'}}>
+                <Stack spacing={2} justifyContent={'center'}
+                       sx={{px: 2}}>
+                    <DownloadOptionsDialog fromGroupKey={tblDownloadGroupKey} style={{width: 'unset', height: 'unset'}}
+                                           children={fileFormatOptions()}
+                                           workspace={isWs}
+                                           dialogWidth='100%'
+                                           dialogHeight='100%'
+                    />
+                    <RadioGroupInputField fieldKey='mode' initialState={{value: 'displayed'}}
+                                          options={[{value:'displayed', label:'Save table as displayed'}, {value:'original', label:'Save table as originally retrieved'}]}/>
+                    <Typography level='body-sm' sx={{textAlign: 'left'}}>
+                        {mode === 'original' ? asOriginalMsg : asDisplayedMsg}
+                    </Typography>
                 </Stack>
-            </Stack>
-        </FieldGroup>
+            </FieldGroup>
+            <Stacker endDecorator={<HelpIcon helpId={'tables.save'}/>}>
+                <CompleteButton
+                    groupKey={tblDownloadGroupKey}
+                    onSuccess={resultSuccess(tbl_id, tbl_ui_id, onComplete, cenCols)}
+                    onFail={resultFail()}
+                    text={'Save'}/>
+                <Button onClick={() => onComplete?.()}>Cancel</Button>
+            </Stacker>
+        </Stack>
     );
 }
 

--- a/src/firefly/js/ui/ImageSelect.jsx
+++ b/src/firefly/js/ui/ImageSelect.jsx
@@ -408,7 +408,7 @@ function DataProductList({filteredImageData, groupKey, multiSelect}) {
 
     return (
         <Stack flexGrow={1}>
-            <CollapsibleGroup disableDivider={true}>
+            <CollapsibleGroup disableDivider={true} sx={{'& button': {justifyContent: 'start'}}}>
                 {content}
             </CollapsibleGroup>
         </Stack>

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -240,3 +240,17 @@ export function useWatcher(actions, callback, params) {
        };
    },[]);
 }
+
+export function useDebugCycle({id, render=true, mount=true}) {
+
+    useEffect(() => {
+        mount && console.log(id, 'mounting');
+        return () => {
+            mount && console.log(id, 'unmounting');
+        };
+    },[]);
+
+    useEffect(() => {
+        render && console.log(id, 'rendering');
+    });
+}

--- a/src/firefly/js/ui/Stacker.jsx
+++ b/src/firefly/js/ui/Stacker.jsx
@@ -1,0 +1,27 @@
+import {Stack} from '@mui/joy';
+import React from 'react';
+import {node, shape, object, number} from 'prop-types';
+
+
+export function Stacker({endDecorator, startDecorator, gap=1, slotProps, children, ...props}) {
+
+    return (
+        <Stack direction='row' justifyContent='space-between' alignItems='center' spacing={gap} {...slotProps?.root}>
+            {startDecorator}
+            <Stack spacing={1} direction='row' alignItems='center' flexGrow={1} {...props}>
+                {children}
+            </Stack>
+            {endDecorator}
+        </Stack>
+    );
+}
+
+Stacker.propTypes = {
+    endDecorator: node,
+    startDecorator: node,
+    gap: number,            // spacing between decorators and the main child
+    slotProps: shape({
+        root: object,
+    })
+};
+

--- a/src/firefly/js/ui/Stacker.jsx
+++ b/src/firefly/js/ui/Stacker.jsx
@@ -1,22 +1,31 @@
-import {Stack} from '@mui/joy';
+import {Sheet, Stack} from '@mui/joy';
 import React from 'react';
-import {node, shape, object, number} from 'prop-types';
+import {node, shape, object, number, string} from 'prop-types';
 
-
-export function Stacker({endDecorator, startDecorator, gap=1, slotProps, children, ...props}) {
+/*
+ * A convenience component built around Sheet and Stack to provide a <start main end> layout
+ * with support for variant and color.  Use slopProps to customize
+ */
+export function Stacker({variant, color, endDecorator, startDecorator, gap=1, slotProps, children, ...props}) {
 
     return (
-        <Stack direction='row' justifyContent='space-between' alignItems='center' spacing={gap} {...slotProps?.root}>
+        <Sheet variant={variant} color={color} component={Stack}
+               direction='row' justifyContent='space-between' alignItems='center' spacing={gap}
+               {...slotProps?.root}>
+
             {startDecorator}
             <Stack spacing={1} direction='row' alignItems='center' flexGrow={1} {...props}>
                 {children}
             </Stack>
             {endDecorator}
-        </Stack>
+
+        </Sheet>
     );
 }
 
 Stacker.propTypes = {
+    variant: string,
+    color: string,
     endDecorator: node,
     startDecorator: node,
     gap: number,            // spacing between decorators and the main child

--- a/src/firefly/js/visualize/ui/Buttons.jsx
+++ b/src/firefly/js/visualize/ui/Buttons.jsx
@@ -50,6 +50,7 @@ import UnfoldMoreOutlinedIcon from '@mui/icons-material/UnfoldMoreOutlined';
 import UnfoldLessOutlinedIcon from '@mui/icons-material/UnfoldLessOutlined';
 import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOutlined';
 
+import INSERT_COLUMN from 'html/images/insert-col-right-24-24.png';
 
 // import LockOpenTwoToneIcon from '@mui/icons-material/LockOpenTwoTone';
 // import LockTwoToneIcon from '@mui/icons-material/LockTwoTone';
@@ -189,7 +190,7 @@ export const TableViewButton = (props) => (
 );
 
 export const AddColumnButton = (props) => (
-    <ToolbarButton {...{icon: <AddColumnIco/>, tip: 'Add a column', iconButtonSize:'38px', ...props}}/>
+    <ToolbarButton icon={INSERT_COLUMN} tip='Add a column' {...props}/>
 );
 
 export const SettingsButton = (props) => (


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1420

Converted DialogRootContainer.DropDown to JoyUI Dropdown.
Converted `View As Text`  popup
Added Stacker container

Also worked on issues from: https://confluence.ipac.caltech.edu/pages/viewpage.action?pageId=674536199
- [ ] 4: Too much padding in table Headers
- [x] 13:Image Search: move expand icon next to dataset label
- [x] 21: size of the save table pop-up is not big enough 
- [x] 22: revert to checkboxes
- [x] 23: use old add column icon.  does not support dark mode

Test: https://fireflydev.ipac.caltech.edu/firefly-1420-cleanup-items/firefly