### PR TITLE
Firefly 1424 more UI conversion fix

### DIFF
--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -105,7 +105,7 @@ const ChartArea = (props) => {
     const deletable = isUndefined(get(chartData, 'deletable')) ? deletableProp : get(chartData, 'deletable');
     const errors  = getErrors(chartId);
     return (
-        <Stack id='chart-area' sx={{inset:0, position:'absolute'}}>
+        <Stack id='chart-area' flexGrow={1}>
             <ResizableChartArea
                 {...Object.assign({}, props, {errors})} />
             {glass && <Stack flexGrow={1} sx={{backgroundColor:'transparent'}}/>}

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -119,7 +119,7 @@ export class MultiChartViewer extends PureComponent {
         const glass = Boolean(noChartToolbar);
 
         const makeItemViewer = (chartId) => (
-            <Sheet id='chart-item' sx={{height:1, width:1}}
+            <Sheet id='chart-item' sx={{height:1, width:1, display:'flex'}}
                    variant='outlined'
                    color={ chartId === activeItemId ? 'warning' : 'neutral'}
                    onClick={(ev)=>onChartSelect(ev,chartId)}
@@ -130,7 +130,7 @@ export class MultiChartViewer extends PureComponent {
         );
 
         const makeItemViewerFull = (chartId) => (
-            <Stack id='chart-itemFull' onClick={stopPropagation}
+            <Stack id='chart-itemFull' onClick={stopPropagation} sx={{height:1, width:1}}
                  onTouchStart={stopPropagation}
                  onMouseDown={stopPropagation}>
                 <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable} glass={glass}/>

--- a/src/firefly/js/charts/ui/PinnedChartContainer.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartContainer.jsx
@@ -82,7 +82,7 @@ export const PinnedChartContainer = (props) => {
     } else {
         return (
             <Stack id='chart-pinned-tabs' overflow='hidden' height={1}>
-                <StatefulTabs componentKey={PINNED_VIEWER_ID} defaultSelected={0} useFlex={true} style={{flex: '1 1 0', marginTop: 1}}>
+                <StatefulTabs componentKey={PINNED_VIEWER_ID}>
                     <Tab name={activeLabel}>
                         <ActiveChartsPanel {...props}/>
                     </Tab>

--- a/src/firefly/js/charts/ui/PinnedChartContainer.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartContainer.jsx
@@ -313,7 +313,7 @@ export const PinnedChartPanel = (props) => {
     };
 
     const makeItemViewer = (chartId) => (
-        <Sheet id='chart-item' sx={{height:1, width:1}}
+        <Sheet id='chart-item' sx={{height:1, width:1, display:'flex'}}
                variant='outlined'
                color={ chartId === activeItemId ? 'warning' : 'neutral'}
                onClick={(ev)=>onChartSelect(ev,chartId)}
@@ -324,7 +324,7 @@ export const PinnedChartPanel = (props) => {
     );
 
     const makeItemViewerFull = (chartId) => (
-        <Stack id='chart-itemFull' onClick={stopPropagation}
+        <Stack id='chart-itemFull' onClick={stopPropagation} sx={{height:1, width:1}}
                onTouchStart={stopPropagation}
                onMouseDown={stopPropagation}>
             <ChartPanel key={chartId} showToolbar={false} chartId={chartId} deletable={deletable}/>

--- a/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
+++ b/src/firefly/js/tables/ui/AddOrUpdateColumn.jsx
@@ -4,7 +4,7 @@
 
 import React, {useCallback, useState} from 'react';
 import PropTypes from 'prop-types';
-import {Button, Skeleton, Stack, Link, Sheet, Typography, Box} from '@mui/joy';
+import {Button, Stack, Link, Sheet, Typography, Box} from '@mui/joy';
 import {delay} from 'lodash';
 import {UCDList} from '../../voAnalyzer/VoConst.js';
 
@@ -97,7 +97,6 @@ export const AddOrUpdateColumn = React.memo(({tbl_ui_id, tbl_id, hidePopup, edit
     const buttonLabel = editColName ? 'Update Column' : 'Add Column';
     const DelBtn = (<button type='button' className='button std'onClick={doDelete}>Delete Column</button>);
 
-    if (isWorking) return <Skeleton className='loading-mask' style={{zIndex:1}}/>;
     return (
         <Stack p={1} width={500} spacing={1}
             sx={{
@@ -106,6 +105,7 @@ export const AddOrUpdateColumn = React.memo(({tbl_ui_id, tbl_id, hidePopup, edit
                 label:{width:80},
                 input:{width:265}
             }}>
+            {isWorking && <div className='loading-mask' style={{zIndex:1}}/>}
             <RequiredFieldMsg/>
             <FieldGroup groupKey={groupKey}>
                 <ValidationField fieldKey='cname' label='Name:' inputRef={ref}

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -3,12 +3,11 @@
  */
 
 import React, {PureComponent, useEffect, useRef} from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import {Box, Button, Link, Sheet, Stack, Typography} from '@mui/joy';
 import {isEmpty, cloneDeep, get} from 'lodash';
 import SplitPane from 'react-split-pane';
-import Tree, { TreeNode } from 'rc-tree';
+import Tree from 'rc-tree';
 import 'rc-tree/assets/index.css';
 
 import {BasicTableViewWithConnector} from './BasicTableView.jsx';
@@ -197,10 +196,6 @@ function makeRenderers(onFilter, tbl_id) {
 }
 
 
-
-
-
-
 /*----------------------------------------------  Advanced Filter panel -----------------------------------------------*/
 
 export const code = {style: {color: 'green', whiteSpace: 'pre', fontFamily: 'monospace', display: 'inline-block'}};
@@ -227,10 +222,15 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
     }, [tbl_id]);     // run only once
 
     const {columns, error} = uiState;
-    const treeNodes = cloneDeep(columns)
+    const treeData = cloneDeep(columns)
                         .filter( (c) => c.visibility !== 'hidden')
                         .sort( (c1,c2) => (c1.label || c1.name).localeCompare(c2.label || c2.name) )
-                        .map((c) => <TreeNode style={{marginLeft: -10}} key={c.name} title={`  ${c.label || c.name} (${c.type || '---'})`} isLeaf={true}/>);
+                        .map((c) => ({
+                            style:{marginLeft: -10},
+                            key:c.name,
+                            title:`  ${c.label || c.name} (${c.type || '---'})`,
+                            isLeaf:true
+                        }));
 
     const onApply = () => {
         const sql = getFieldVal(groupKey, sqlKey);
@@ -257,9 +257,7 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
             <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
                 <Typography level='title-md'>Columns (sorted)</Typography>
                 <Box  style={{overflow: 'auto', flexGrow: 1}}>
-                    <Tree defaultExpandAll showLine onSelect={onNodeClick} icon={iconGen} >
-                        {treeNodes}
-                    </Tree>
+                    <Tree defaultExpandAll showLine onSelect={onNodeClick} icon={iconGen} treeData={treeData}/>
                 </Box>
             </SplitContent>
             <SplitContent style={{overflow: 'auto'}}>

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -31,9 +31,9 @@ export function TableInfo({tbl_id, tabsProps, ...props}) {
                 </Tab>
                 }
                 <Tab name='Table Metadata'>
-                    <div style={{width: '100%', height: '100%', overflow: 'auto'}}>
+                    <Stack p={1} overflow='auto'>
                         <MetaContent tbl_id={tbl_id}/>
-                    </div>
+                    </Stack>
                 </Tab>
             </StatefulTabs>
             <Stack alignItems='end' pr={1}>

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -88,8 +88,8 @@ export const TablePanelOptions = React.memo(({tbl_ui_id, tbl_id, onChange, onOpt
         <Stack height={1} p={1} pt={0} spacing={1}>
             <Options {...{uiState, tbl_id, tbl_ui_id, ctm_tbl_id, onOptionReset, onChange}} />
             <Stack flexGrow={1} overflow='hidden'>
-                <StatefulTabs componentKey={`${tbl_id}-options`} defaultSelected={0} actions={actions}>
-                    <Tab name='Column Options'>
+                <StatefulTabs componentKey={`${tbl_id}-options`} actions={actions}>
+                    <Tab name='Column Options' sx={{p:1}}>
                         <ColumnOptions {...{tbl_id, tbl_ui_id, ctm_tbl_id, onChange}} />
                     </Tab>
                     {showAdvFilter &&

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -91,8 +91,8 @@ export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, 
     sx = {height: 1, pb: '2px', ...sx};
     return (
         <Sheet variant='plain' color={color} sx={sx} title={cdesc}>
-            <Stack width={1} height={1} spacing='2px' {...centerIt}>
-                <Stack width={1} height={1} spacing='2px' {...centerIt} className={clickable} onClick={onClick}>
+            <Stack width={1} height={1} {...centerIt}>
+                <Stack width={1} height={1} {...centerIt} className={clickable} onClick={onClick}>
                     <Stack direction='row' {...centerIt}>
                         <Stack textOverflow='ellipsis' overflow='hidden'>
                             <HeaderText val={label || name} level='title-sm'/>
@@ -110,7 +110,7 @@ export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, 
 
 export function HeaderText({val, level='body-sm', sx, ...rest}) {
     return (
-        <Typography component='div' level={level} {...rest} sx={{lineHeight:1.1, height:'1em', ...sx}}>
+        <Typography component='div' level={level} {...rest} sx={{lineHeight:1.2, height:'1.2em', ...sx}}>
             {val || ''}
         </Typography>
     );

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -2,20 +2,17 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import React, {useRef, useCallback, useState, useEffect} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Cell} from 'fixed-data-table-2';
-import {set, get, omit, isEmpty, isString, toNumber} from 'lodash';
-import {Typography, Checkbox, Stack, Box, Link, Sheet, MenuItem, Button, Chip} from '@mui/joy';
+import {get, isEmpty, isString, omit, set, toNumber} from 'lodash';
+import {Box, Button, Checkbox, Chip, Link, MenuItem, Sheet, Stack, Tooltip, Typography} from '@mui/joy';
 
-import {FilterInfo, FILTER_CONDITION_TTIPS, NULL_TOKEN} from '../FilterInfo.js';
-import {
-    isColumnType, COL_TYPE, getTblById, getColumn, formatValue, getTypeLabel,
-    getColumnIdx, getRowValues, getCellValue, splitCols, isOfType, splitVals
-} from '../TableUtil.js';
+import {FILTER_CONDITION_TTIPS, FilterInfo, NULL_TOKEN} from '../FilterInfo.js';
+import {COL_TYPE, formatValue, getCellValue, getColumn, getColumnIdx, getRowValues, getTblById, getTypeLabel, isColumnType, isOfType, splitCols, splitVals} from '../TableUtil.js';
 import {SortInfo} from '../SortInfo.js';
 import {InputField} from '../../ui/InputField.jsx';
 import {SORT_ASC, UNSORTED} from '../SortInfo';
-import {toBoolean, copyToClipboard} from '../../util/WebUtil.js';
+import {copyToClipboard, toBoolean} from '../../util/WebUtil.js';
 
 import ASC_ICO from 'html/images/sort_asc.gif';
 import DESC_ICO from 'html/images/sort_desc.gif';
@@ -90,18 +87,20 @@ export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, 
 
     sx = {height: 1, pb: '2px', ...sx};
     return (
-        <Sheet variant='plain' color={color} sx={sx} title={cdesc}>
+        <Sheet variant='plain' color={color} sx={sx}>
             <Stack width={1} height={1} {...centerIt}>
-                <Stack width={1} height={1} {...centerIt} className={clickable} onClick={onClick}>
-                    <Stack direction='row' {...centerIt}>
-                        <Stack textOverflow='ellipsis' overflow='hidden'>
-                            <HeaderText val={label || name} level='title-sm'/>
+                <Tooltip title={cdesc} sx={{maxWidth:'20em'}}>
+                    <Stack width={1} height={1} {...centerIt} className={clickable} onClick={onClick}>
+                        <Stack direction='row' {...centerIt}>
+                            <Stack textOverflow='ellipsis' overflow='hidden'>
+                                <HeaderText val={label || name} level='title-sm'/>
+                            </Stack>
+                            <SortSymbol sortDir={sortDir}/>
                         </Stack>
-                        <SortSymbol sortDir={sortDir}/>
+                        { showUnits && <HeaderText val={unitsVal}/> }
+                        { showTypes && <HeaderText val={typeVal}/> }
                     </Stack>
-                    { showUnits && <HeaderText val={unitsVal}/> }
-                    { showTypes && <HeaderText val={typeVal}/> }
-                </Stack>
+                </Tooltip>
                 {showFilters && (<Filter {...{cname:name, onFilter, filterInfo, tbl_id}}/>)}
             </Stack>
         </Sheet>
@@ -122,7 +121,7 @@ function Filter({cname, onFilter, filterInfo, tbl_id}) {
 
     const colGetter= () => getColumn(getTblById((tbl_id)), cname) ?? {};
     const col = useStoreConnector(colGetter);
-    const [disableHoverListener, setDisableHoverListener] = useState(false);
+    const [showTooltip, setShowTooltip] = useState(true);
     const dropdownEl = useRef(null);
 
     useEffect(() => {
@@ -139,9 +138,11 @@ function Filter({cname, onFilter, filterInfo, tbl_id}) {
 
     const filterInfoCls = FilterInfo.parse(filterInfo);
 
-
     const endDecorator = enumVals && (
-        <DropDown onOpenChange={(v) => setDisableHoverListener(v) } slotProps={{button:{sx:{mr:-1}}}}>
+        <DropDown onFocusChange={(v) => setShowTooltip(!v)}     // only show input tooltip when dropdown is not active
+                  slotProps={{button: {sx: {mr: -1}}}}
+                  title='Filter to a subset of values in this column'
+        >
             <EnumSelect {...{col, tbl_id, filterInfo, filterInfoCls, onFilter}} />
         </DropDown>
     );
@@ -151,14 +152,13 @@ function Filter({cname, onFilter, filterInfo, tbl_id}) {
             validator={validator}
             fieldKey={name}
             sx={{width: 1, '--Input-radius': ''}}
-            tooltip={FILTER_CONDITION_TTIPS}
+            tooltip={showTooltip && FILTER_CONDITION_TTIPS}
             value={filterInfoCls.getFilter(name)}
             onChange={onFilter}
             actOn={blurEnter}
             showWarning={false}
             slotProps={{
-                input: {size:'sm', endDecorator },
-                tooltip: {disableHoverListener}
+                input: {size:'sm', endDecorator }
             }}
         />
     );

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -109,7 +109,8 @@ export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, 
 
 export function HeaderText({val, level='body-sm', sx, ...rest}) {
     return (
-        <Typography component='div' level={level} {...rest} sx={{lineHeight:1.2, height:'1.2em', ...sx}}>
+        <Typography component='div' level={level} {...rest}
+                    sx={{lineHeight:1.2, height:'1.2em', whiteSpace:'nowrap', ...sx}}>
             {val || ''}
         </Typography>
     );

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -100,8 +100,9 @@ export function showTableDownloadDialog({tbl_id, tbl_ui_id}) {
 
 function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
     const isWs = getWorkspaceConfig();
-    const currentFileLocation = getFieldVal(tblDownloadGroupKey, 'fileLocation', LOCALFILE);
-    if (currentFileLocation === WORKSPACE) {
+    const currentFileLocation = useStoreConnector(() => getFieldVal(tblDownloadGroupKey, 'fileLocation', LOCALFILE));
+    const wsSelected = currentFileLocation === WORKSPACE;
+    if (wsSelected) {
         dispatchWorkspaceUpdate();
     }
 
@@ -113,7 +114,7 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
     const cenCols = findTableCenterColumns(table, true);
 
     const fileFormatOptions = () => {
-        let fileOptions = tableFormats.enums.reduce((options, eItem) => {
+        const fileOptions = tableFormats.enums.reduce((options, eItem) => {
             options.push({label: eItem.value, value: eItem.key});
             return options;
         }, []);
@@ -129,8 +130,11 @@ function TableSavePanel({tbl_id, tbl_ui_id, onComplete}) {
             />
         );
     };
+
+    const sizing = wsSelected ? {height:'60vh', minHeight:'28em', resize:'both'} :
+                   isWs ? {height:'20em'} : {height:'19em'};
     return (
-        <Stack spacing={1} p={1} height='60vh' minWidth='40em' minHeight='28em' sx={{resize:'both', overflow:'hidden'}}>
+        <Stack spacing={1} p={1} overflow='hidden' minWidth='40em' sx={sizing}>
             <FieldGroup groupKey={tblDownloadGroupKey} reducerFunc={TableDLReducer(tbl_id)}
                         sx={{display:'flex', overflow:'hidden', flexGrow:1}}>
                 <Stack spacing={1} flexGrow={1}>

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -65,9 +65,9 @@ const tableFormatsExt = {
 const labelWidth = 100;
 const defValues = {
     [fKeyDef.fileName.fKey]: Object.assign(getTypeData(fKeyDef.fileName.fKey, '',
-        'Please enter a filename, a default name will be used if it is blank', fKeyDef.fileName.label, labelWidth), {validator: null}),
+        'Please enter a filename; a default name will be used if left blank.', fKeyDef.fileName.label, labelWidth), {validator: null}),
     [fKeyDef.fileFormat.fKey]: Object.assign(getTypeData(fKeyDef.fileFormat.fKey, tableFormats.ipac.key,
-        'Please select a format option, the default is ipac', fKeyDef.fileFormat.label, labelWidth)),
+        'Please select a format option; the default is ipac', fKeyDef.fileFormat.label, labelWidth)),
     [fKeyDef.location.fKey]: Object.assign(getTypeData(fKeyDef.location.fKey, 'isLocal',
         'select the location where the file is downloaded to', fKeyDef.location.label, labelWidth), {validator: null}),
     [fKeyDef.wsSelect.fKey]: Object.assign(getTypeData(fKeyDef.wsSelect.fKey, '',

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -84,10 +84,7 @@ function ExpandedView(props) {
 function StandardView(props) {
     const {tables, tableOptions, expandedMode, active, tbl_group, style={}} = props;
 
-    var activeIdx = Object.keys(tables).findIndex( (tbl_ui_id) => get(tables,[tbl_ui_id,'tbl_id']) === active);
-    activeIdx = activeIdx === -1 ? 0 : activeIdx;
-    const onTabSelect = (idx) => {
-        const tbl_id = get(tables, [Object.keys(tables)[idx], 'tbl_id']);
+    const onTabSelect = (tbl_id) => {
         tbl_id && dispatchActiveTableChanged(tbl_id, tbl_group);
     };
     const keys = Object.keys(tables);
@@ -96,9 +93,8 @@ function StandardView(props) {
     } else {
         const uid = hashCode(keys.join());
         return (
-            <TabPanel key={uid} sx={style} value={activeIdx}
-                      slotProps={{ panel:{sx:{p:0}} }}
-                      onTabSelect={onTabSelect} resizable={true} showOpenTabs={true} tabId={'TableContainers-' + (tbl_group||'main')}>
+            <TabPanel key={uid} sx={style} value={active}
+                      onTabSelect={onTabSelect} resizable={true} showOpenTabs={true}>
                 {tablesAsTab(tables, tableOptions, expandedMode)}
             </TabPanel>
         );
@@ -125,7 +121,7 @@ function tablesAsTab(tables, tableOptions, expandedMode) {
                 dispatchTableRemove(tbl_id);
             };
             return  (
-                <Tab key={tbl_ui_id} label={title} removable={removable} onTabRemove={onTabRemove}>
+                <Tab key={tbl_id} id={tbl_id} label={title} removable={removable} onTabRemove={onTabRemove}>
                     <TablePanel key={tbl_id}
                                 slotProps={{ toolbar:{variant:'plain'}, tablePanel:{variant: 'plain'} }}
                                 {...{tbl_id, tbl_ui_id, ...options, expandedMode, showTitle: false}} />

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -118,7 +118,7 @@ function RightSide({expanded, closeable, showXyPlots, showMeta, showFits, dataPr
     const defaultSelected= coverageRight ? 'coverage' : showXyPlots ? 'activeCharts' : 'fits';
     const key= `${showXyPlots&&'xyplot'}-${cov&&'cov'}-${meta&&'meta'}-${fits&&'fits'}`;
     return(
-        <Tabs {...{key, style, onTabSelect, defaultSelected, slotProps:{panel:{sx:{p:0}}}} } >
+        <Tabs {...{key, style, onTabSelect, defaultSelected} } >
             {showXyPlots && makeActiveChartTab({activeLabel, chartExpandedMode, closeable, asTab:true}) }
             {showPinnedTab && makePinnedChartTab({pinnedLabel, chartExpandedMode, closeable, asTab:true}) }
             {cov && makeCoverageTab()}

--- a/src/firefly/js/ui/DownloadOptionsDialog.jsx
+++ b/src/firefly/js/ui/DownloadOptionsDialog.jsx
@@ -88,7 +88,7 @@ export function DownloadOptionsDialog({fromGroupKey, children, fileName, labelWi
                     value: fileName
                 }}
                 label='File name'
-                tooltip='Please enter a filename, a default name will be used if it is blank'
+                tooltip='Please enter a filename; a default name will be used if it is blank'
             />
             {workspace && showLocation}
 

--- a/src/firefly/js/ui/ExampleDialog.jsx
+++ b/src/firefly/js/ui/ExampleDialog.jsx
@@ -201,7 +201,7 @@ function FieldGroupWithMasterDependent() {
 const AllTest= () => (
         <div style={{padding:'5px', minWidth: 480}}>
             <div>
-                <StatefulTabs componentKey='exampleOuterTabs' defaultSelected={0} useFlex={true}>
+                <StatefulTabs componentKey='exampleOuterTabs' useFlex={true}>
                     <Tab name='First'>
                         <FieldGroupTest />
                     </Tab>

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -45,7 +45,7 @@ const imageFileTypeOps=  [
 
 export function showFitsDownloadDialog() {
 
-    const Popup = () => {
+    const Popup = (props) => {
         const fileLocation = useStoreConnector(() => getFieldVal(fitsDownGroup, 'fileLocation', LOCALFILE));
         const wsSelected = fileLocation === WORKSPACE;
         if (wsSelected) dispatchWorkspaceUpdate();
@@ -54,7 +54,7 @@ export function showFitsDownloadDialog() {
         const sizing = wsSelected ? {height:'60vh', minHeight:'28em', resize:'both'} :
                        isWs ? {height:'12em'} : {height:'11em'};
         return (
-            <PopupPanel title={'Save Image'}>
+            <PopupPanel title={'Save Image'} {...props}>
                 <Stack overflow='hidden' minWidth='40em' sx={sizing}>
                     <FitsDownloadDialogForm groupKey={fitsDownGroup} popupId={dialogPopupId} isWs={isWs}/>
                 </Stack>

--- a/src/firefly/js/ui/FitsDownloadDialog.jsx
+++ b/src/firefly/js/ui/FitsDownloadDialog.jsx
@@ -28,7 +28,7 @@ import {INFO_POPUP, showInfoPopup} from './PopupUtil.jsx';
 import {getWorkspaceConfig} from '../visualize/WorkspaceCntlr.js';
 import {upload} from '../rpc/CoreServices.js';
 import {download, downloadBlob, makeDefaultDownloadFileName} from '../util/fetch.js';
-import {useFieldGroupValue} from './SimpleComponent.jsx';
+import {useFieldGroupValue, useStoreConnector} from './SimpleComponent.jsx';
 import HelpIcon from './HelpIcon.jsx';
 import {Stacker} from 'firefly/ui/Stacker.jsx';
 
@@ -44,19 +44,25 @@ const imageFileTypeOps=  [
     ...hipsFileTypeOps];
 
 export function showFitsDownloadDialog() {
-    const fileLocation = getFieldVal(fitsDownGroup, 'fileLocation', LOCALFILE);
-    if (fileLocation === WORKSPACE) dispatchWorkspaceUpdate();
 
-    const isWs = getWorkspaceConfig();
+    const Popup = () => {
+        const fileLocation = useStoreConnector(() => getFieldVal(fitsDownGroup, 'fileLocation', LOCALFILE));
+        const wsSelected = fileLocation === WORKSPACE;
+        if (wsSelected) dispatchWorkspaceUpdate();
+        const isWs = getWorkspaceConfig();
 
-    const  popup = (
-        <PopupPanel title={'Save Image'}>
-            <Stack minWidth='40em' minHeight='28em' height='60vh' sx={{resize:'both', overflow:'hidden'}}>
-                <FitsDownloadDialogForm groupKey={fitsDownGroup} popupId={dialogPopupId} isWs={isWs}/>
-            </Stack>
-        </PopupPanel>
-    );
-    DialogRootContainer.defineDialog(dialogPopupId , popup);
+        const sizing = wsSelected ? {height:'60vh', minHeight:'28em', resize:'both'} :
+                       isWs ? {height:'12em'} : {height:'11em'};
+        return (
+            <PopupPanel title={'Save Image'}>
+                <Stack overflow='hidden' minWidth='40em' sx={sizing}>
+                    <FitsDownloadDialogForm groupKey={fitsDownGroup} popupId={dialogPopupId} isWs={isWs}/>
+                </Stack>
+            </PopupPanel>
+        );
+    };
+
+    DialogRootContainer.defineDialog(dialogPopupId , <Popup/>);
     dispatchShowDialog(dialogPopupId);
 }
 

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -66,7 +66,7 @@ InputFieldView.propTypes= {
     visible : bool,
     disabled : bool,
     message : string,
-    tooltip : string,
+    tooltip : oneOfType([string, bool]),
     label : string,
     inline : bool,
     value   : oneOfType([string, number]).isRequired,

--- a/src/firefly/js/ui/MultiSearchPanel.jsx
+++ b/src/firefly/js/ui/MultiSearchPanel.jsx
@@ -68,9 +68,7 @@ const getComponentAry= once(() => {
 const getDefTabIdx= once((initArgs) => getTabIdx(initArgs));
 
 function getTabIdx(args) {
-    if (!args.defaultSelectedId) return 0;
-    const idx= getComponentAry().findIndex( ({id}) => id===args.defaultSelectedId);
-    return idx>-1 ? idx : 0;
+    return args.defaultSelectedId;
 }
 
 const makeTabLabel= (str) => (<div style={tabStyle}>{str}</div>);

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -61,7 +61,7 @@ export function SearchPanel({style={}, initArgs={}}) {
         return (
             <Stack id='search-tabs' flexGrow={1}>
                 {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
-                <StatefulTabs componentKey={`SearchPanel_${title}`} onTabSelect={onTabSelect} resizable={true} useFlex={true} borderless={true} contentStyle={{backgroundColor: 'transparent'}}>
+                <StatefulTabs componentKey={`SearchPanel_${title}`} onTabSelect={onTabSelect}>
                     {searchesAsTabs(allSearchItems, initArgs)}
                 </StatefulTabs>
             </Stack>

--- a/src/firefly/js/ui/TestQueriesPanel.jsx
+++ b/src/firefly/js/ui/TestQueriesPanel.jsx
@@ -139,7 +139,7 @@ export class TestQueriesPanel extends PureComponent {
                     <FieldGroup groupKey='TEST_CAT_PANEL' keepState={true}
                                 style={{height:'100%', display:'flex', flexDirection:'column'}}>
                         <FieldGroupTabs initialState={{ value:'2massImage' }} fieldKey='Tabs' style={{flexGrow:1}} >
-                            <Tab name='2Mass Search' id='2massImage'>
+                            <Tab name='2Mass Search' id='2massImage' sx={{p:1}}>
                                 <div>{render2MassSearch(fields)}</div>
                             </Tab>
                             <Tab name='Inset Example' id='inset1'>

--- a/src/firefly/js/ui/UploadTableChooser.js
+++ b/src/firefly/js/ui/UploadTableChooser.js
@@ -272,7 +272,7 @@ const TapUploadPanel= ({setUploadInfo,groupKey= 'table-chooser',defaultColsEnabl
         <Stack style={{ resize: 'both', overflow: 'hidden', zIndex: 1, pt:1, minWidth: 600, minHeight: 500}}>
             <FieldGroupTabs initialState={{value: 'upload'}} fieldKey='upload-type-tabs' groupKey={groupKey}
                             sx={{width: 1,  flex: '1 1 auto'}}>
-                <Tab name='Upload Tables' id='upload' style={{fontSize:'larger'}}>
+                <Tab name='Upload Tables' id='upload' sx={{fontSize:'larger'}}>
                     <FileUploadDropdown {...{
                         sx:{height:1,
                             '.ff-FileUploadViewPanel-file':{ml:3},
@@ -283,7 +283,7 @@ const TapUploadPanel= ({setUploadInfo,groupKey= 'table-chooser',defaultColsEnabl
                         onSubmit:(request) => uploadSubmit(request,setUploadInfo,defaultColsEnabledObj),
                     }}/>
                 </Tab>
-                <Tab name='Loaded Tables' id='tableLoad' style={{fontSize:'larger'}}>
+                <Tab name='Loaded Tables' id='tableLoad' sx={{fontSize:'larger'}}>
                         <LoadedTables {...{
                             style:{height: '100%', width:'100%'}, keepState: true, groupKey:groupKey+'-tableLoad',
                             onCancel:() => dispatchHideDialog(dialogId),

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -3,7 +3,7 @@
  */
 
 import React, {memo, useEffect, useState, useCallback, useRef} from 'react';
-import PropTypes, {object, shape} from 'prop-types';
+import {bool, node, func, number, object, oneOfType, shape, string} from 'prop-types';
 import {
     Tab as JoyTab,
     Tabs as JoyTabs,
@@ -12,16 +12,16 @@ import {
 } from '@mui/joy';
 import {tabClasses} from '@mui/joy/Tab';
 import sizeMe from 'react-sizeme';
-import {omit, isString, uniqueId, pick, isNumber} from 'lodash';
+import {omit, isString, pick} from 'lodash';
 
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
-import {isDefined} from '../../util/WebUtil.js';
 import {useFieldGroupConnector} from '../FieldGroupConnector.jsx';
 import {useStoreConnector} from '../SimpleComponent.jsx';
 import {DropDown} from '../DialogRootContainer.jsx';
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 import {getCellValue, getTblById, watchTableChanges} from '../../tables/TableUtil.js';
 import {TABLE_FILTER, TABLE_HIGHLIGHT, TABLE_SORT} from '../../tables/TablesCntlr.js';
+import {hashCode} from 'firefly/util/WebUtil.js';
 
 /*---------------------------------------------------------------------------------------------
 There are several type of Tab panels, each with slightly different behavior and use case.
@@ -32,7 +32,7 @@ TabPanel:   TabPanel is a basic functional component designed to work exclusivel
 Tabs:       A TabPanel with internal state.  State will be lost after unmount.
 
 StatefulTabs:  TabPanel with state backed by ComponentCntlr.
-               Selected state is stored as <componentKey>.selectedIdx.
+               Selected state is stored as <componentKey>.selected.
 
 FieldGroupTabs:  TabPanel with state backed by FieldGroup
                  The selected index is saved as the value of the field named by fieldKey
@@ -43,7 +43,6 @@ FieldGroupTabs:  TabPanel with state backed by FieldGroup
  * @param {object} p
  * @param p.value           value of ID of the selected tab
  * @param p.onTabSelect     callback function on tab select change
- * @param p.tabId           unique ID to identify this tab panel
  * @param p.showOpenTabs    true to render a dropdown that display all tabs with the ability to switch between them
  * @param p.actions         additional actions rendered as a button at the right end of the tab panel
  * @param p.slotProps       properties to insert into predefined slots of this tab panel
@@ -53,25 +52,21 @@ FieldGroupTabs:  TabPanel with state backed by FieldGroup
  * @return {node}
  * @constructor
  */
-export function TabPanel ({value, onTabSelect, tabId=uniqueTabId(), showOpenTabs, actions, slotProps, sx, children, ...rest}) {
+export function TabPanel ({value, onTabSelect, showOpenTabs, actions, slotProps, sx, children, ...rest}) {
 
     const {useFlex, resizable, borderless,
         style={}, headerStyle, contentStyle={}, label, size, ...joyTabsProps} = rest;     // these are deprecated.  the rest(joyTabsProps) are pass-along props to Tabs.
 
-    // get the content(JoyTabPanel)
-    const childrenAry = React.Children.toArray(children);
-    const tabContents = childrenAry.map((c, idx) => getContentFromTab(c.props, idx, slotProps));
-
-    const onChange = useCallback((ev, val) => onTabSelect?.(val), []);
+    const onChange = (ev, val) => onTabSelect?.(val);
 
     // because we support additional actions to the right of the TabList, we need to implement some of TabList feature here.
     const tlVar = slotProps?.tabList?.variant || 'soft';
     const sticky = slotProps?.tabList?.sticky;
     const tlSticky = sticky === 'top' ? {position: 'sticky', top:0, zIndex:1} :
                      sticky === 'bottom' ? {position: 'sticky', bottom:0, zIndex:1} : {};
+
     return (
-        <JoyTabs key={tabId}
-                 size='sm'
+        <JoyTabs size='sm'
                  sx={{height: 1, boxSizing: 'border-box', ...sx}}
                  aria-label='tabs'
                  value={value}
@@ -92,94 +87,69 @@ export function TabPanel ({value, onTabSelect, tabId=uniqueTabId(), showOpenTabs
                     {actions && actions()}
                     {showOpenTabs && (
                         <DropDown title='Search open tabs'>
-                            <OpenTabs onSelect={onTabSelect} tabId={tabId} childrenAry={childrenAry}/>
+                            <OpenTabs onSelect={onTabSelect} selTabId={value}>{children}</OpenTabs>
                         </DropDown>
                     )}
                 </Stack>
             </Sheet>
-            {tabContents}
+            {children}
         </JoyTabs>
     );
 }
 
 TabPanel.propTypes = {
-    tabId: PropTypes.string,            // a unique identifier used as an ID for this component
-    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    onTabSelect: PropTypes.func,
-    showOpenTabs: PropTypes.bool,
-    actions: PropTypes.elementType,
-    sx: PropTypes.object,
+    value: oneOfType([number, string]),
+    onTabSelect: func,
+    showOpenTabs: bool,
+    actions: func,
+    sx: object,
     slotProps: shape({
         tabList: object,
         tab: object,            // will inject into each one
-        panel: object        // will inject into each one
     })
 };
 
 
-/**
+/*
  * Tab panel with internal state
  * State will be lost after unmount.
  */
-export const Tabs = React.memo( ({defaultSelected, onTabSelect, ...rest}) => {
+export const Tabs =  ({defaultSelected, onTabSelect, ...rest}) => {
 
-    defaultSelected = convertToTabValue(rest.children, defaultSelected);
-    const [selectedIdx, setSelectedIdx] = useState(defaultSelected);
+    const [selected, setSelected] = useState(defaultSelected ?? getDefaultTab(rest.children));
 
-    let localSelectIdx= selectedIdx; // keep a closure variable because useCallback if memorized not recreated on every render
-                                     // I am not sure why we need a memorized callback here but i don't want to change that.
-    const onSelect = useCallback( (index,id,name) => {
-        if (index !== localSelectIdx) {
-            setSelectedIdx(index);
-            localSelectIdx= index;
-            onTabSelect && onTabSelect(index,id,name);
-        }
-    });
+    const onSelect = (val) => {
+        setSelected(val);
+        onTabSelect && onTabSelect(val);
+    };
 
-    return (<TabPanel {...rest} value={selectedIdx} onTabSelect={onSelect} />);
-});
+    return (<TabPanel {...rest} value={selected} onTabSelect={onSelect} />);
+};
 
 Tabs.propTypes = {
-    defaultSelected:  PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    defaultSelected:  oneOfType([number, string]),
     ...omit(TabPanel.propTypes, 'value'),
 };
 
 
-/**
+/*
  * Tab panel with ComponentCntlr supported state
- * Selected state is stored as <componentKey>.selectedIdx
+ * Selected state is stored as <componentKey>.selected
  */
-export const StatefulTabs = React.memo( ({defaultSelected, onTabSelect, componentKey, ...rest}) => {
+export const StatefulTabs = ({defaultSelected, onTabSelect, componentKey, ...rest}) => {
 
-    defaultSelected = convertToTabValue(rest.children, defaultSelected);
-    let selectedIdx = useStoreConnector( () => getComponentState(componentKey)?.selectedIdx ?? defaultSelected);
+    const selected = useStoreConnector( () => getComponentState(componentKey)?.selected ?? defaultSelected ?? getDefaultTab(rest.children));
 
-    const onSelect = useCallback( (index,id,name) => {
-        dispatchComponentStateChange(componentKey, {selectedIdx: index});
-        onTabSelect && onTabSelect(index,id,name);
-    }, []);
+    const onSelect = (val) => {
+        dispatchComponentStateChange(componentKey, {selected: val});
+        onTabSelect && onTabSelect(val);
+    };
 
-    useEffect( ()=> {
-        if (!isNumber(selectedIdx)) { // selectedIdx is an id
-            const idAry= getTabIds(rest.children);
-            if (!idAry.includes(selectedIdx)) {
-                dispatchComponentStateChange(componentKey, {selectedIdx:idAry[idAry.length-1]});
-            }
-        }
-        else if (selectedIdx >= rest.children.length) {
-            // selectedIdx is greater than the number of tabs.. update store's state
-            selectedIdx = rest.children.length-1;
-            dispatchComponentStateChange(componentKey, {selectedIdx});
-        }
-    });
-
-    const selectedTab = convertToTabValue(rest.children, selectedIdx);
-    return (<TabPanel {...rest} onTabSelect={onSelect} value={selectedTab} />);
-
-});
+    return (<TabPanel {...rest} onTabSelect={onSelect} value={selected} />);
+};
 
 StatefulTabs.propTypes = {
-    componentKey: PropTypes.string,
+    componentKey: string,
     ...Tabs.propTypes
 };
 
@@ -189,7 +159,6 @@ StatefulTabs.propTypes = {
  */
 export const FieldGroupTabs = memo( ({children, ...props}) => {
     const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
-    viewProps.value = convertToTabValue(props.children, viewProps.value);
 
     const onChange = useCallback((idx, id, name) => {
         let value= id||name;
@@ -208,16 +177,14 @@ export const FieldGroupTabs = memo( ({children, ...props}) => {
         onTabSelect: onChange
     };
 
-
-
     return (<Tabs {...newProps}/>);
 });
 
 FieldGroupTabs.propTypes = {
-    fieldKey: PropTypes.string,
-    forceReinit: PropTypes.bool,
-    initialState: PropTypes.shape({
-        value: PropTypes.string,
+    fieldKey: string,
+    forceReinit: bool,
+    initialState: shape({
+        value: string,
     }),
     ...omit(Tabs.propTypes, 'defaultSelected')     //  defaultSelected is not used.. use value for defaultSelected.
 };
@@ -226,28 +193,38 @@ FieldGroupTabs.propTypes = {
  Exported function and components
 ----------------------------------------------------------------------------------------------*/
 
-/**
+/*
  * For backward compatibility, this is a composite of JoyUI's Tab and TabPanel
  * 'label' is converted to Tab, and 'children' are wrapped inside a Joy TabPanel
  * It is designed to be used with TabPanel.
  */
-export const Tab = React.memo( ({label, name, value, startDecorator, removable, onTabRemove}) => {
-    // maxTitleWidth:  deprecated.  default to 400
-    return;
+export const Tab = React.memo(({id, children, value, sx, removable, onTabRemove, label, name, ...props}) => {
+    // removable, onTabRemove;  not used by JoyTabPanel
+    value ??= getTabId({id, name, label});
+    return (
+        <JoyTabPanel value={value} sx={{p:0, overflow:'hidden', ...sx}} {...props}>
+            <Stack height={1} width={1}>
+                {children}
+            </Stack>
+        </JoyTabPanel>
+    );
 });
 
+
 Tab.propTypes = {
-    label:  PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    name: PropTypes.string,
-    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    startDecorator: PropTypes.node,
-    removable: PropTypes.bool,
-    onTabRemove: PropTypes.func,
+    id: string,           // ID for this tab; otherwises index will be used.
+    label:  oneOfType([string, node]),
+    name: string,
+    value: oneOfType([number, string]),
+    sx: object,
+    startDecorator: node,
+    removable: bool,
+    onTabRemove: func,
 };
 
 
-export function switchTab(componentKey, selectedIdx) {
-    dispatchComponentStateChange(componentKey, {selectedIdx});
+export function switchTab(componentKey, selected) {
+    dispatchComponentStateChange(componentKey, {selected});
 }
 
 
@@ -331,7 +308,7 @@ function getHeaderFromTab({name, value, label, startDecorator, removable, onTabR
 
     // to support deprecated props
     label ??= name;
-    value ??= id ?? idx;
+    value ??= getTabId({id, name, label, idx});
 
 
     if (isString(label)) {
@@ -366,74 +343,65 @@ function getHeaderFromTab({name, value, label, startDecorator, removable, onTabR
     );
 }
 
-function getContentFromTab({value, id, children}, idx, slotProps) {
-    value ??= id ?? idx;
-    const {sx, ...props} = slotProps?.panel || {};
-
-    return (
-        <JoyTabPanel key={idx} value={value} sx={{p:1, overflow:'hidden', ...sx}} {...props}>
-            <Stack height={1} width={1}>
-                {children}
-            </Stack>
-        </JoyTabPanel>
-    );
-}
-
-
 /*----------------------------------------------------------------------------------------------*/
 
-function OpenTabs({tabId, onSelect, childrenAry}) {
 
-    useEffect(() => {
-        // monitor for changes
-        return watchTableChanges(tabId, [TABLE_HIGHLIGHT, TABLE_SORT, TABLE_FILTER], () => {
-            const tbl = getTblById(tabId) || {};
+
+
+function OpenTabs({onSelect, selTabId, children}) {
+
+    const [tableModel, setTableModel] = useState();
+    const tbl_id = hashCode(getAllTabId(children).join('|'));
+
+    useEffect(() => {       //
+        // create table model for the drop down
+        const childrenAry = React.Children.toArray(children);
+        const columns = [
+            {name: 'OPEN TABS', width: 50},
+            {name: 'tabID', visibility: 'hidden'}
+        ];
+        const highlightedRow = childrenAry.findIndex((child) => getTabId(child.props) === selTabId);
+        const data = makeOpenTabsData(childrenAry);
+        setTableModel({tbl_id, tableData: {columns, data}, highlightedRow, totalRows: data.length});
+
+        return watchTableChanges(tbl_id, [TABLE_HIGHLIGHT, TABLE_SORT, TABLE_FILTER], () => {
+            const tbl = getTblById(tbl_id) || {};
             const {highlightedRow} = tbl;
-            const selRowIdx = getCellValue(tbl, highlightedRow, 'ROW_IDX');
-            if (selRowIdx >= 0) onSelect(selRowIdx);
-        }, tabId);          // make watcherId same as tabId so there can only be one watcher per tabpanel
-    }, [tabId]);
-
-    // create table model for the drop down
-    const columns = [{name: 'OPEN TABS', width: 50}];
-    const highlightedRow = childrenAry.findIndex((child) => child?.props?.selected);
-    const tbl_id = tabId;
-    const data = getTabTitles(childrenAry);
-    const tableModel = {tbl_id, tableData: {columns, data}, highlightedRow, totalRows: data.length};
+            const newSelTabId = getCellValue(tbl, highlightedRow, 'tabID');
+            selTabId && onSelect(newSelTabId);
+        }, tbl_id);          // make watcherId same as tbl_id so there can only be one watcher per tabpanel
+    }, [tbl_id]);
 
     const width = 381;
     return  (
         <Stack width={width} height={200} position='relative'>
-            <TablePanel tbl_ui_id={tabId+'-ui'} tableModel={tableModel} showTypes={false} slotProps={{tablePanel: {variant:'plain'}}}
+            <TablePanel tbl_ui_id={tbl_id+'-ui'} tableModel={tableModel} showTypes={false} slotProps={{tablePanel: {variant:'plain'}}}
                         showToolbar={false} showFilters={true} selectable={false} showOptionButton={false}/>
         </Stack>
     );
 }
 
-function getTabTitles(childrenAry) {
+function makeOpenTabsData(childrenAry) {
     return childrenAry.map((child, idx) => {
-        const p = child?.props;
-        return [isString(p.label) ? p.label : p.name || `[blank]-${idx}`];
+        const p = child?.props || {};
+        const title = isString(p.label) ? p.label : p.name || `[blank]-${idx}`;
+        const tabId = getTabId(p);
+        return [title, tabId];
     });
 
 }
 
-/**
- * Old API uses only tab index.  So, this is needed to return the value of the tab defined by `id`.
- * @param children  the tabs to search
- * @param value     index of the Tab or the value of that Tab
- * @return {string|number} the value of the Tab.
- */
-function convertToTabValue(children, value=0) {
-    return React.Children.toArray(children)[value]?.props.id ?? value;
+function getTabId({id, name, label, idx}) {
+    return id ?? name ?? label ?? idx;
 }
 
-function getTabIds(children) {
-    return React.Children.toArray(children).map( ({props}) => props?.id).filter( (id) => isDefined(id));
+function getDefaultTab(children) {
+    return getAllTabId(children)[0];
 }
 
-function uniqueTabId() {
-    return `TapPanel-${uniqueId()}`;
+function getAllTabId(children) {
+    return React.Children.toArray(children).map((c) => getTabId(c.props)).filter((id) => id);
 }
+
 
 

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -67,7 +67,7 @@ export function TabPanel ({value, onTabSelect, showOpenTabs, actions, slotProps,
 
     return (
         <JoyTabs size='sm'
-                 sx={{height: 1, boxSizing: 'border-box', ...sx}}
+                 sx={{height: 1, overflow: 'hidden', borderRadius:5, ...sx}}
                  aria-label='tabs'
                  value={value}
                  onChange={onChange}
@@ -76,6 +76,7 @@ export function TabPanel ({value, onTabSelect, showOpenTabs, actions, slotProps,
         >
             <Sheet component={Stack} direction='row' variant={tlVar}
                    sx={{
+                       pl:1,
                        boxShadow: 'inset 0 -1px var(--joy-palette-divider)',
                        position: 'unset',
                        justifyContent: 'space-between',

--- a/src/firefly/js/visualize/ui/ColorDialog.jsx
+++ b/src/firefly/js/visualize/ui/ColorDialog.jsx
@@ -132,7 +132,7 @@ function renderStandardThreeColorView(plot,rFields,gFields,bFields) {
     return (
         <Box sx={{pt:.5}}>
             <FieldGroup groupKey={'colorDialogTabs'} keepState={false}>
-                <FieldGroupTabs initialState= {{ value:'red' }} tabId='colorTabs' fieldKey='colorTabs'>
+                <FieldGroupTabs initialState= {{ value:'red' }} fieldKey='colorTabs'>
                     {plotState.isBandUsed(Band.RED) &&
                     <Tab name='Red' id='red'>
                         <FieldGroup groupKey={RED_PANEL} keepState={true} reducerFunc={colorPanelRedReducer}>

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -177,8 +177,7 @@ function renderColorBandsFitsHeaders(plot, fitsHeaderInfo, popupId) {
     return (
         <Stack sx={ popupPanelResizableSx} >
           <Stack {...{width:1, height:1, direction: 'row', resize:'none'}}>
-              <Tabs {...{sx:{width:1}, slotProps:{panel:{sx:{p:0}}}, defaultSelected:0, useFlex:true,
-                    onTabSelect:onBandSelected(fitsHeaderInfo) }}>
+              <Tabs {...{sx:{width:1}, onTabSelect:onBandSelected(fitsHeaderInfo) }}>
                   {renderSingleTab(plot, bands[0],fitsHeaderInfo )}
                   {renderSingleTab(plot, bands[1],fitsHeaderInfo )}
                   {bands.length===3 && renderSingleTab(plot, bands[2],fitsHeaderInfo )}

--- a/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
+++ b/src/firefly/js/visualize/ui/ImageSearchPanelV2.jsx
@@ -289,10 +289,7 @@ function SingleChannel({groupKey, imageMasterData, multiSelect, archiveName, noS
 function ThreeColor({imageMasterData, multiSelect, archiveName, noScroll}) {
     return (
         <div className='flex-full' style={{marginTop: 5}}>
-            <StatefulTabs componentKey='ImageSearchPanelV2' resizable={false} useFlex={true} borderless={true}
-                  style={{flexGrow: 1, overflow: 'unset'}}
-                  contentStyle={{backgroundColor: 'rgb(202, 202, 202)', paddingBottom: 2, overflow: 'unset'}}
-                  headerStyle={{display:'inline-flex', marginLeft: 185}}>
+            <StatefulTabs componentKey='ImageSearchPanelV2'>
                 <Tab key='ImageSearchRed' name='red' label={<div style={{width:40, color:'red'}}>Red</div>}>
                     <SingleChannel {...{key: FG_KEYS.red, groupKey: FG_KEYS.red, imageMasterData, multiSelect, archiveName, noScroll}}/>
                 </Tab>

--- a/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
@@ -119,7 +119,7 @@ function ImageStatsTab({statsResult, plotId})
 
     return (
         <Stack pt={1}>
-            <Tabs useFlex={true}>
+            <Tabs>
                 {allTabs}
             </Tabs>
             <ImageAreaStatsClose plotId={plotId}/>

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -40,9 +40,9 @@ import {getPlotViewAry} from 'firefly/visualize/PlotViewUtil.js';
  * @param p.dataProductTableId
  * @constructor
  */
-export function TriViewImageSection({showCoverage=false, showFits=false, selectedTab='fits',
+export function TriViewImageSection({showCoverage=false, showFits=false,
                                      showMeta=false, imageExpandedMode=false, closeable=true,
-                                     coverageSide= 'LEFT', dataProductTableId, style={}}) {
+                                     coverageSide= 'LEFT', dataProductTableId, }) {
 
     if (imageExpandedMode) {
         return  ( <ImageExpandedMode key='results-plots-expanded' closeFunc={closeable ? closeExpanded : null}/> );
@@ -53,10 +53,8 @@ export function TriViewImageSection({showCoverage=false, showFits=false, selecte
 
     if (showCoverage || showFits || showMeta) {
         return (
-            <Tabs key={key} style={{height: '100%', ...style}} onTabSelect={onTabSelect}
-                  slotProps={{ panel:{sx:{p:0}} }}
-                  defaultSelected={getDefSelected(showCoverage,showFits,showMeta)}
-                  useFlex={true} resizable={true}>
+            <Tabs key={key} onTabSelect={onTabSelect}
+                  defaultSelected={getDefSelected(showCoverage,showFits,showMeta)}>
                 { showCoverage && coverageSide==='LEFT' && makeCoverageTab() }
                 { showMeta && makeMultiProductViewerTab({dataProductTableId}) }
                 { showFits && makeFitsPinnedTab() }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1424

From doc: https://confluence.ipac.caltech.edu/pages/viewpage.action?pageId=674536199
- [x] 1. Pull up the table options.  "show/hide" choice cause blinking/rerendering...
- [x] 7. Add column reset on error
- [x] 11. Gator expanded chart missing 'back' button
- [x] 48. Table header cut off at the bottom

From doc: https://confluence.lsstcorp.org/pages/viewpage.action?pageId=250480825
- [x] 2. Add tooltip to category dropdown filter.  Ensure column-filter tooltip does not show.
- [x] 3. Convert column description tooltip to JoyUI and ensure only one of the tooltip appear at a time.

Also:
- Refactor and cleanup TabPanel
- Fix sizing issues with table and image save dialog
  - There should not be empty white area unless the user resize the dialog in workspace mode.
- Set TabPanel's default borderRadius to 5px.  Can be overridden by `sx={{borderRadius}}`

Test: 
https://firefly-1424-more-ui-conversion-fix.irsakudev.ipac.caltech.edu/irsaviewer/
https://fireflydev.ipac.caltech.edu/firefly-1424-more-ui-conversion-fix/firefly/
