### PR TITLE
Firefly-1434: fixes: irsa 9, rubin-chart 2,3, empty FITS table

### DIFF
--- a/src/firefly/js/charts/ui/ColSelectView.jsx
+++ b/src/firefly/js/charts/ui/ColSelectView.jsx
@@ -20,7 +20,7 @@ const popupId = 'XYColSelect';
 const TBL_ID ='selectCol';
 
 
-export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonText,currentVal,multiSelect=false,colTblId) {
+export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonText,currentVal,multiSelect=false,colTblId,doQuoteNonAlphanumeric=true) {
 
    if (getTblById(TBL_ID)) {
        hideColSelectPopup();
@@ -79,7 +79,7 @@ export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonTe
     // 360 is the width of table options
     const minWidth = Math.max(columns.reduce((rval, c) => isFinite(c.prefWidth) ? rval+c.prefWidth : rval, 0), 360);
     const popup = (<PopupPanel title={popupTitle}>
-            {popupForm(tableModel,onColSelected,buttonText,popupId,minWidth,multiSelect)}
+            {popupForm(tableModel,onColSelected,buttonText,popupId,minWidth,multiSelect,doQuoteNonAlphanumeric)}
         </PopupPanel>
 
     );
@@ -94,7 +94,7 @@ export function hideColSelectPopup() {
     }
 }
 
-function popupForm(tableModel, onColSelected,buttonText,popupId, minWidth,multiSelect) {
+function popupForm(tableModel, onColSelected,buttonText,popupId, minWidth,multiSelect,doQuoteNonAlphanumeric) {
     const tblId = tableModel.tbl_id;
     const tbl_ui_id = (tableModel.tbl_id || 'ColSelectView') + '-ui';
     return (
@@ -120,7 +120,9 @@ function popupForm(tableModel, onColSelected,buttonText,popupId, minWidth,multiS
 
             <CompleteButton
                 text={buttonText}
-                onSuccess={()=> multiSelect? setSelectedColumns(tblId,onColSelected) : setXYColumns(tblId,onColSelected)}
+                onSuccess={()=> multiSelect?
+                    setSelectedColumns(tblId,onColSelected,doQuoteNonAlphanumeric) :
+                    setXYColumns(tblId,onColSelected,doQuoteNonAlphanumeric)}
                 dialogId={popupId}
             />
         </Stack>
@@ -130,18 +132,19 @@ function popupForm(tableModel, onColSelected,buttonText,popupId, minWidth,multiS
 
 
 //returns (calls the callback fn with) an array of selected column naes
-function setSelectedColumns(tblId,onColSelected) {
+function setSelectedColumns(tblId,onColSelected,doQuoteNonAlphanumeric) {
     getSelectedData(tblId).then((result) => {
-        const selectedColNames = getColumnValues(result, 'Name').map((col) => quoteNonAlphanumeric(col)); //create an array of col names
+        const selectedColNames = getColumnValues(result, 'Name').map((col) => doQuoteNonAlphanumeric? quoteNonAlphanumeric(col) : col); //create an array of col names
         onColSelected(selectedColNames);
     });
 }
 
 //returns (calls the callback fn with) the selected column name
-function setXYColumns(tblId,onColSelected) {
+function setXYColumns(tblId,onColSelected,doQuoteNonAlphanumeric) {
     const tableModel = getTblById(tblId);
     const hlRow = tableModel.highlightedRow || 0;
-    const selectedColName = quoteNonAlphanumeric(tableModel.tableData.data[hlRow][0]);
+    const selectedColName = doQuoteNonAlphanumeric ?
+        quoteNonAlphanumeric(tableModel.tableData.data[hlRow][0]) :tableModel.tableData.data[hlRow][0];
     onColSelected(selectedColName);
     hideColSelectPopup();
 }

--- a/src/firefly/js/charts/ui/ColumnOrExpression.jsx
+++ b/src/firefly/js/charts/ui/ColumnOrExpression.jsx
@@ -3,12 +3,9 @@
  */
 import React, {useContext} from 'react';
 import PropTypes, {object, shape} from 'prop-types';
-import {get} from 'lodash';
 import {Expression} from '../../util/expr/Expression.js';
-import {quoteNonAlphanumeric} from '../../util/expr/Variable.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {getFieldVal} from '../../fieldGroup/FieldGroupUtils.js';
-import {SuggestBoxInputField} from '../../ui/SuggestBoxInputField.jsx';
 import ColValuesStatistics from '../ColValuesStatistics.js';
 import {showColSelectPopup} from './ColSelectView.jsx';
 import MAGNIFYING_GLASS from 'html/images/icons-2014/magnifyingGlass.png';
@@ -67,7 +64,7 @@ export function ColumnOrExpression({colValStats,params,groupKey,fldPath,label,la
         <ColumnFld
             cols={colValStats.map((c)=>{return {name: c.name, units: c.unit, type: c.type, desc: c.descr};})}
             fieldKey={fldPath}
-            initValue={initValue || get(params, fldPath)}
+            initValue={initValue || params?.[fldPath]}
             canBeExpression={true}
             tooltip={`Column or expression for ${tooltip ? tooltip : name}.${EXPRESSION_TTIPS}`}
             {...{groupKey, label, labelWidth, name, nullAllowed, readOnly, slotProps, sx}} />
@@ -91,6 +88,7 @@ ColumnOrExpression.propTypes = {
 };
 
 export function ColumnFld({cols, groupKey, fieldKey, initValue, label, tooltip='Table column', slotProps, sx,
+                              doQuoteNonAlphanumeric,
                            name, nullAllowed, canBeExpression=false, readOnly, helper, required, validator,
                               placeholder, colTblId=null,onSearchClicked=null}) {
     const value = initValue || getFieldVal(groupKey, fieldKey);
@@ -111,7 +109,8 @@ export function ColumnFld({cols, groupKey, fieldKey, initValue, label, tooltip='
                            tip={`Select ${name} column`}
                            onClick={(e) => {
                                if (!onSearchClicked || onSearchClicked()) {
-                                   showColSelectPopup(cols, onColSelected, `Choose ${name}`, 'OK', val, false, colTblId);
+                                   showColSelectPopup(cols, onColSelected, `Choose ${name}`, 'OK',
+                                       val, false, colTblId,doQuoteNonAlphanumeric);
                                }
                            }}
             />
@@ -155,6 +154,7 @@ ColumnFld.propTypes = {
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
     helper: PropTypes.element,
+    doQuoteNonAlphanumeric: PropTypes.bool,
     colTblId: PropTypes.string,
     onSearchClicked: PropTypes.func,
     placeholder: PropTypes.string,

--- a/src/firefly/js/charts/ui/MultiChartToolbar.jsx
+++ b/src/firefly/js/charts/ui/MultiChartToolbar.jsx
@@ -7,14 +7,10 @@ import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
 import {Sheet, Stack, Typography} from '@mui/joy';
 import {AppPropertiesCtx} from '../../ui/AppPropertiesCtx.jsx';
+import {BeforeButton, DisplayTypeButtonGroup, NextButton} from '../../visualize/ui/Buttons.jsx';
 
 import {getChartData} from '../ChartsCntlr.js';
 import {dispatchChangeViewerLayout, dispatchUpdateCustom, getViewerItemIds, getViewer, getLayoutType, getMultiViewRoot} from '../../visualize/MultiViewCntlr.js';
-import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
-import ONE from 'html/images/icons-2014/Images-One.png';
-import GRID from 'html/images/icons-2014/Images-Tiled.png';
-import PAGE_RIGHT from 'html/images/icons-2014/20x20_PageRight.png';
-import PAGE_LEFT from 'html/images/icons-2014/20x20_PageLeft.png';
 
 import {PagingControl} from '../../visualize/iv/ExpandedTools.jsx';
 import {ChartToolbar} from './ChartPanel';
@@ -94,20 +90,23 @@ const MultiChartStd = ({viewerId, layoutType, activeItemId}) => {
     const nextIdx= cIdx===viewerItemIds.length-1 ? 0 : cIdx+1;
     const prevIdx= cIdx ? cIdx-1 : viewerItemIds.length-1;
 
+
     return (
-        <Stack direction='row'>
-            <ToolbarButton icon={ONE} tip={'Show single chart'}
-                           onClick={() => dispatchChangeViewerLayout(viewerId,'single')}/>
-            <ToolbarButton icon={GRID} tip={'Show all charts as tiles'}
-                           onClick={() => dispatchChangeViewerLayout(viewerId,'grid')}/>
+        <Stack direction='row' py={1/4}>
+            <DisplayTypeButtonGroup {...{value:getViewer(getMultiViewRoot(), viewerId)?.layout ?? 'single',
+                config:[
+                    { value:'single', title:'Show single chart',
+                        onClick: () => dispatchChangeViewerLayout(viewerId,'single')
+                    },
+                    { value:'grid', title:'Show all charts as tiles',
+                        onClick: () => dispatchChangeViewerLayout(viewerId,'grid')
+                    }
+                ]
+            }}/>
             {layoutType==='single' && viewerItemIds.length>2 &&
-            <img src={PAGE_LEFT}
-                 onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[prevIdx]})} />
-            }
+            <BeforeButton onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[prevIdx]})} /> }
             {layoutType==='single' && viewerItemIds.length>1 &&
-            <img src={PAGE_RIGHT}
-                 onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[nextIdx]})} />
-            }
+                <NextButton onClick={() => dispatchUpdateCustom(viewerId, {activeItemId: viewerItemIds[nextIdx]})} /> }
         </Stack>
     );
 };
@@ -134,12 +133,16 @@ const MultiChartExt = ({viewerId, layoutType, activeItemId}) => {
             </Typography>
             <Stack direction='row' sx={{whiteSpace:'nowrap'}}>
                 <Stack direction='row'>
-                    <ToolbarButton icon={ONE} tip={'Show single chart'}
-                                   imageStyle={{width:24,height:24, flex: '0 0 auto'}}
-                                   onClick={() => dispatchChangeViewerLayout(viewerId,'single')}/>
-                    <ToolbarButton icon={GRID} tip={'Show all charts as tiles'}
-                                   imageStyle={{width:24,height:24,  paddingLeft:5, flex: '0 0 auto'}}
-                                   onClick={() => dispatchChangeViewerLayout(viewerId,'grid')}/>
+                    <DisplayTypeButtonGroup {...{value:getViewer(getMultiViewRoot(), viewerId)?.layout ?? 'single',
+                        config:[
+                            { value:'single', title:'Show single chart',
+                                onClick: () => dispatchChangeViewerLayout(viewerId,'single')
+                            },
+                            { value:'grid', title:'Show all charts as tiles',
+                                onClick: () => dispatchChangeViewerLayout(viewerId,'grid')
+                            }
+                        ]
+                    }}/>
                 </Stack>
                 <Stack>
                     <PagingControl

--- a/src/firefly/js/charts/ui/PlotlyToolbar.jsx
+++ b/src/firefly/js/charts/ui/PlotlyToolbar.jsx
@@ -1,4 +1,4 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {IconButton, Stack, ToggleButtonGroup} from '@mui/joy';
 import {get, isEmpty} from 'lodash';
@@ -27,13 +27,13 @@ import {
 } from '../../visualize/ui/Buttons.jsx';
 
 import ZoomIco from 'html/images/icons-2014/24x24_ZoomIn.png';
-import PanIco from 'html/images/icons-2014/pan.png';
 import SelectIco from 'html/images/icons-2014/select.png';
 import TurntableIco from 'html/images/turntable-tmp.png';
 import OrbitalIco from 'html/images/orbital-tmp.png';
 import ApplySelectIco from 'html/images/icons-2014/24x24_Checkmark.png';
 import ApplyFilterIco from 'html/images/icons-2014/24x24_FilterAdd.png';
 import ResetZoomIco from 'html/images/icons-2014/Zoom1x-24x24-tmp.png';
+import PanToolRoundedIconIco from '@mui/icons-material/PanToolRounded';
 
 export function PlotlyToolbar({chartId, expandable}) {
     const {activeTrace} = getChartData(chartId);
@@ -218,8 +218,9 @@ function PanBtn({chartId}) {
     return (
         <IconButton value='pan'
                     onClick={() => dispatchChartUpdate({chartId, changes:{'layout.dragmode': 'pan', selection: undefined}})}
-                    title='Pan'
-        ><img className='old-ff-icon-img' src={PanIco}/></IconButton>
+                    title='Pan' >
+            <PanToolRoundedIconIco/>
+        </IconButton>
     );
 }
 
@@ -250,7 +251,7 @@ function SelectBtn({chartId}) {
     );
 }
 
-function ResetZoomBtn({style={}, chartId}) {
+function ResetZoomBtn({chartId}) {
     const doClick = () => {
         const {_original, layout} = getChartData(chartId) || {};
 
@@ -347,7 +348,7 @@ export function ActiveTraceSelect({sx={}, chartId, activeTrace}) {
     />);
 }
 
-function FilterSelection({style={}, chartId}) {
+function FilterSelection({chartId}) {
     return (
         <IconButton onClick={() => dispatchChartFilterSelection({chartId})}
              title='Filter on the selected points'

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -4,7 +4,7 @@
 
 import {Badge, Box, Button, Checkbox, Divider, IconButton, Stack, Tooltip} from '@mui/joy';
 import {isString} from 'lodash';
-import React, {memo, useRef, useEffect} from 'react';
+import React, {useRef, useEffect, forwardRef, useCallback, useImperativeHandle} from 'react';
 import {bool, element, func, node, number, object, oneOfType, shape, string} from 'prop-types';
 import {dispatchHideDialog} from '../core/ComponentCntlr.js';
 import {DROP_DOWN_KEY} from './DropDownToolbarButton.jsx';
@@ -39,11 +39,6 @@ function makeImage(icon,style={},className='') {
     }
 }
 
-export function IconButtonWrapper({icon,  title, ...rest }) {
-    const b = <IconButton {...{title,...rest}}> {makeImage(icon)} </IconButton>;
-    return title ? <Tooltip followCursor={true} title={title}>{b}</Tooltip> : b;
-}
-
 /**
  *
  * @param icon icon to display
@@ -60,7 +55,7 @@ export function IconButtonWrapper({icon,  title, ...rest }) {
  * @param style - a style to apply
  * @return {object}
  */
-export const ToolbarButton = memo((props) => {
+export const ToolbarButton = forwardRef((props,fRef) => {
     const {
         icon,text='',badgeCount=0,enabled=true, visible=true,
         imageStyle={}, iconButtonSize, shortcutKey='', color='neutral', variant='plain',
@@ -71,11 +66,13 @@ export const ToolbarButton = memo((props) => {
     const tip= props.tip || props.title || '';
     const buttonPressed= pressed || active;
     const {current:divElementRef}= useRef({divElement:undefined});
+    useImperativeHandle(fRef, () => divElementRef.divElement);
+    const setupRef  = useCallback((c) => divElementRef.divElement= c, [divElementRef]);
 
-    const handleClick= (ev) => {
+    const handleClick= useCallback((ev) => {
         onClick?.(divElementRef.divElement,ev);
         dropDownCB ? dropDownCB(divElementRef.divElement) : dispatchHideDialog(DROP_DOWN_KEY);
-    };
+    },[onClick,dropDownCB,divElementRef.divElement]);
 
     useEffect( () => {
         const {cnrl,meta,key,hasShortcut}= getShortCutInfo(shortcutKey);
@@ -91,7 +88,6 @@ export const ToolbarButton = memo((props) => {
     if (!visible) return false;
     const allowInput= disableHiding?'allow-input':'normal-button-hide';
 
-    const setupRef  = (c) => divElementRef.divElement= c;
 
     const image= makeImage(icon,imageStyle,allowInput);
     const iSize= iconButtonSize ? {'--IconButton-size': iconButtonSize} : {};
@@ -159,7 +155,7 @@ export const ToolbarButton = memo((props) => {
         </Tooltip>
     );
 
-    return !badgeCount ? b : <Badge {...{badgeContent:badgeCount}}> {b} </Badge>;
+    return !badgeCount ? b : <Badge {...{badgeContent:badgeCount, sx:{'& .MuiBadge-badge': {top:'.7rem', right:'.4rem'}}}}> {b} </Badge>;
 } );
 
 ToolbarButton.propTypes= {

--- a/src/firefly/js/ui/UploadTableSelector.jsx
+++ b/src/firefly/js/ui/UploadTableSelector.jsx
@@ -16,7 +16,7 @@ export function UploadTableSelector({uploadInfo, setUploadInfo, uploadTable=fals
     const UploadCenterLonColumns = 'uploadCenterLonColumns';
     const UploadCenterLatColumns = 'uploadCenterLatColumns';
 
-    const {groupKey,setVal, register, unregister}= useContext(FieldGroupCtx);
+    const {setVal, register, unregister}= useContext(FieldGroupCtx);
     const [getLon,setLon]= useFieldGroupValue(UploadCenterLonColumns);
     const [getLat,setLat]= useFieldGroupValue(UploadCenterLatColumns);
 
@@ -119,7 +119,7 @@ UploadTableSelector.propTypes = {
 };
 
 export function CenterColumns({lonCol,latCol, sx, cols, lonKey, latKey, openKey,
-                           headerTitle, headerPostTitle = '', openPreMessage=''}) {
+                                  doQuoteNonAlphanumeric, headerTitle, headerPostTitle = '', openPreMessage=''}) {
 
 
     const posHeader= (
@@ -144,11 +144,13 @@ export function CenterColumns({lonCol,latCol, sx, cols, lonKey, latKey, openKey,
                                name='longitude column'  // label that appears in column chooser
                                tooltip='Center longitude column for spatial search'
                                label='Lon Column'
+                               doQuoteNonAlphanumeric={doQuoteNonAlphanumeric}
                                validator={getColValidator(cols, true, false)} />
                     <ColumnFld fieldKey={latKey} cols={cols}
                                name='latitude column' // label that appears in column chooser
                                tooltip='Center latitude column for spatial search'
                                label='Lat Column'
+                               doQuoteNonAlphanumeric={doQuoteNonAlphanumeric}
                                validator={getColValidator(cols, true, false)} />
                 </Stack>
             </FieldGroupCollapsible>

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -1,4 +1,4 @@
-import {Box, Chip, FormLabel, Stack, Typography} from '@mui/joy';
+import {FormLabel, Stack} from '@mui/joy';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 import {ColsShape, getColValidator} from '../../charts/ui/ColumnOrExpression.jsx';
@@ -203,6 +203,7 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, columnsModel,
                     {!obsCoreEnabled &&
                         <CenterColumns {...{lonCol: getVal(CenterLonColumns), latCol: getVal(CenterLatColumns),
                             headerTitle:'Position Columns:', openKey:posOpenKey,
+                            doQuoteNonAlphanumeric:false,
                             headerPostTitle:'(from the selected table on the right)',
                             openPreMessage:posOpenMsg,
                             cols, lonKey:CenterLonColumns, latKey:CenterLatColumns}} />}
@@ -259,7 +260,6 @@ const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInf
     const layoutMode= getSpacialLayoutMode(spacialType,obsCoreEnabled,capabilities?.canUpload);
     const isCone= spatialMethod === 'Cone';
     const containsPoint= spatialRegOpValue === 'contains_point';
-    const style= {display:'flex', flexDirection:'column', flexWrap:'no-wrap', width: SpatialWidth, marginTop: 5};
 
     const radiusField= <RadiusField {...{radiusInArcSec:initArgs?.urlApi?.radiusInArcSec}}/>;
 

--- a/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
+++ b/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
@@ -6,7 +6,7 @@ import {getCellValue, getColumn, getColumns, getColumnValues, getTblById, watchT
 import {SelectInfo} from '../../tables/SelectInfo.js';
 import {dispatchTableFilter, dispatchTableAddLocal, TABLE_LOADED, TABLE_REPLACE, TABLE_SELECT} from '../../tables/TablesCntlr.js';
 import {ColumnConstraintsPanel, getTableConstraints} from './ColumnConstraintsPanel.jsx';
-import {ADQL_LINE_LENGTH} from './TapUtil.js';
+import {ADQL_LINE_LENGTH, maybeQuote} from './TapUtil.js';
 
 const COLS_TO_DISPLAY_FIRST = ['column_name','unit','ucd','description','datatype','arraysize','utype','xtype','principal'];
 
@@ -201,8 +201,9 @@ function reorganizeTableModel(tableModel, columnNames, reset) {
     return modifiedTableModel;
 }
 
-export function makeColsLines(selcolsArray, firstLineOffset=false) {
+export function makeColsLines(selcolsArrayIn, firstLineOffset=false) {
     const firstOff= firstLineOffset ? '       ' : '';
+    const selcolsArray= selcolsArrayIn.map( (c) => maybeQuote(c));
     const colSingleLine= selcolsArray?.join(',') ?? '';
     if (colSingleLine.length < ADQL_LINE_LENGTH) return `${firstOff}${colSingleLine}`;
 

--- a/src/firefly/js/ui/tap/TemporalSearch.jsx
+++ b/src/firefly/js/ui/tap/TemporalSearch.jsx
@@ -84,9 +84,9 @@ export function findTimeColumn(columnsTable) {
     const nIdx= getColumnIdx(columnsTable,'column_name',true);
     const unitIdx= getColumnIdx(columnsTable,'unit',true);
     if (ucdIdx===-1 || nIdx===-1) return;
-    const timeRows= columnsTable.tableData.data?.filter( (row) => row[ucdIdx]?.includes('time.epoch') && row[unitIdx].startsWith('d'));
+    const timeRows= columnsTable.tableData.data?.filter( (row) => row[ucdIdx]?.includes('time.epoch') && row[unitIdx]?.startsWith('d'));
     if (!timeRows?.length) return;
-    const mainRows= timeRows?.filter( (row) => row[ucdIdx]?.includes('meta.main') && row[unitIdx].startsWith('d'));
+    const mainRows= timeRows?.filter( (row) => row[ucdIdx]?.includes('meta.main') && row[unitIdx]?.startsWith('d'));
     return mainRows?.length ? mainRows[0][nIdx] : timeRows[0][nIdx];
 }
 

--- a/src/firefly/js/visualize/iv/ExpandedTools.jsx
+++ b/src/firefly/js/visualize/iv/ExpandedTools.jsx
@@ -10,7 +10,7 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {ExpandType, dispatchChangeExpandedMode, dispatchExpandedAutoPlay, visRoot } from '../ImagePlotCntlr.js';
 import {primePlot, getActivePlotView} from '../PlotViewUtil.js';
 import {CloseButton} from '../../ui/CloseButton.jsx';
-import {GridTileButton, ListViewButton, OneTileButton} from '../ui/Buttons.jsx';
+import {DisplayTypeButtonGroup, ListViewButton} from '../ui/Buttons.jsx';
 import {showExpandedOptionsPopup} from '../ui/ExpandedOptionsPopup.jsx';
 import {dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {getMultiViewRoot, getExpandedViewerItemIds} from '../MultiViewCntlr.js';
@@ -18,8 +18,8 @@ import {VisMiniToolbar} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
 
 import ACTIVE_DOT from 'html/images/green-dot-10x10.png';
 import INACTIVE_DOT from 'html/images/blue-dot-10x10.png';
-import NavigateNext from '@mui/icons-material/NavigateNext';
-import NavigateBefore from '@mui/icons-material/NavigateBefore';
+import NavigateNext from '@mui/icons-material/NavigateNextRounded';
+import NavigateBefore from '@mui/icons-material/NavigateBeforeRounded';
 
 function createOptions(expandedMode, singleAutoPlay, plotIdAry) {
     return (
@@ -62,7 +62,7 @@ export function ExpandedTools({closeFunc}) {
                 {!single &&
                     <Stack {...{direction:'column', justifyContent:'space-between', minHeight:25, className:'disable-select'}}>
                         <div style={{alignSelf:'flex-end', whiteSpace:'nowrap', display:'flex'}}>
-                            <WhichView/>
+                            <WhichView expandedMode={expandedMode}/>
                             {createOptions(expandedMode,singleAutoPlay, plotIdAry)}
                             <PagingControl
                                 viewerItemIds={getExpandedViewerItemIds(getMultiViewRoot())}
@@ -89,20 +89,24 @@ ExpandedTools.propTypes= {
 
 
 
-function WhichView() {
+function WhichView({expandedMode}) {
     const showViewButtons= getExpandedViewerItemIds(getMultiViewRoot()).length>1;
+    const value= expandedMode===ExpandType.SINGLE ? 'one' : 'grid';
     return (
-        <Stack direction='row' alignItems='center'>
+        <Stack direction='row' alignItems='center' pl={1}>
+            {showViewButtons && <DisplayTypeButtonGroup {...{value,
+                config:[
+                    { value:'one', title:'Show single image at full size',
+                        onClick: () => dispatchChangeExpandedMode(ExpandType.SINGLE)
+                    },
+                    { value:'grid', title:'Show all images as tiles',
+                        onClick: () => dispatchChangeExpandedMode(ExpandType.GRID)
+                    }
+                ]
+            }}/>}
             {showViewButtons &&
-                   <OneTileButton tip='Show single image at full size'
-                                  onClick={() => dispatchChangeExpandedMode(ExpandType.SINGLE)}/>}
-            {showViewButtons &&
-                   <GridTileButton tip='Show all images as tiles'
-                                  onClick={() => dispatchChangeExpandedMode(ExpandType.GRID)}/>
-            }
-            {showViewButtons &&
-                   <ListViewButton tip={'Choose which images to show'}
-                                  onClick={() =>showExpandedOptionsPopup() }/>
+                <ListViewButton title='Choose which images to show'
+                                onClick={() =>showExpandedOptionsPopup() }/>
             }
         </Stack>
     );

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -9,12 +9,15 @@ import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
 import {isEmpty,omit,isFunction} from 'lodash';
 import {getSearchActions} from '../../core/AppDataCntlr.js';
+import {getMultiViewRoot, IMAGE} from '../MultiViewCntlr.js';
 import {getPlotGroupById}  from '../PlotGroup.js';
 import {ExpandType, dispatchChangeActivePlotView, MOUSE_CLICK_REASON} from '../ImagePlotCntlr.js';
 import {ExpandButton} from '../ui/Buttons.jsx';
 import {VisCtxToolbarView, canConvertHipsAndFits, ctxToolbarBG} from '../ui/VisCtxToolbarView';
 import {VisInlineToolbarView} from '../ui/VisInlineToolbarView.jsx';
-import {primePlot, isActivePlotView, getAllDrawLayersForPlot, getPlotViewById} from '../PlotViewUtil.js';
+import {
+    primePlot, isActivePlotView, getAllDrawLayersForPlot, getPlotViewById,
+} from '../PlotViewUtil.js';
 import {ImageViewerLayout}  from '../ImageViewerLayout.jsx';
 import {isImage, isHiPS} from '../WebPlot.js';
 import {PlotAttribute} from '../PlotAttribute.js';
@@ -171,9 +174,13 @@ function contextToolbar(plotView,dlAry,extensionList, width) {
 
 
 function getBorderColor(theme, pv,visRoot) {
+    const containerList= getMultiViewRoot().filter( (v) => v.containerType===IMAGE && v.mounted);
+    const manyPlots= (containerList.length>1 || containerList[0]?.itemIdAry?.length>1);
     if (!pv?.plotId) return 'rgba(0,0,0,.4)';
     if (!pv.plotViewCtx.highlightFeedback) return 'rgba(0,0,0,.1)';
-    if (isActivePlotView(visRoot,pv.plotId)) return `rgba(${theme.vars.palette.warning.mainChannel} / 1)`;
+    if (isActivePlotView(visRoot,pv.plotId)) {
+        return manyPlots ? `rgba(${theme.vars.palette.warning.mainChannel} / 1)` : 'rgba(0,0,0,.1)';
+    }
     const group= getPlotGroupById(visRoot,pv.plotGroupId);
     if (group?.overlayColorLock) return 'rgba(0, 0, 0, .1)';
     else return 'rgba(0,0,0,.2)';

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -165,7 +165,7 @@ function handleCatalogUpdate(tbl_id) {
     if (totalRows > maxScatterRows) {
         const sreq = cloneRequest(sourceTable.request, {inclCols: `"${c1}","${c2}"`});
         req = makeTableFunctionRequest(sreq, 'DecimateTable', title,
-            {decimate: serializeDecimateInfo(c1, c2, 10000), pageSize: MAX_ROW});
+            {decimate: serializeDecimateInfo(c1, c2, maxScatterRows), pageSize: MAX_ROW});
         dataTooBigForSelection= true;
     }
 

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -4,6 +4,7 @@
 
 import Enum from 'enum';
 import {flattenDeep, isEmpty, isNil, isObject, isString, isUndefined, pick, values} from 'lodash';
+import {getMaxScatterRows} from '../../charts/ChartUtil.js';
 import {getAppOptions} from '../../core/AppDataCntlr';
 import {REINIT_APP} from '../../core/AppDataCntlr.js';
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
@@ -313,13 +314,14 @@ function updateCoverage(tbl_id, viewerId, preparedTables, options, tblCatIdMap, 
         };
 
         let req = cloneRequest(table.request, params);
-        if (table.totalRows > 10000) {
+        const maxScatterRows = getMaxScatterRows();
+        if (table.totalRows > maxScatterRows) {
             const cenCol = findTableCenterColumns(table);
             if (!cenCol) return;
             const sreq = cloneRequest(table.request, {inclCols: `"${cenCol.lonCol}","${cenCol.latCol}"`});
             req = makeTableFunctionRequest(sreq, 'DecimateTable', 'coverage',
                 {
-                    decimate: !isOrbitalPathTable(tbl_id) ? serializeDecimateInfo(cenCol.lonCol, cenCol.latCol, 10000) : undefined,
+                    decimate: !isOrbitalPathTable(tbl_id) ? serializeDecimateInfo(cenCol.lonCol, cenCol.latCol, maxScatterRows) : undefined,
                     pageSize: MAX_ROW
                 });
         }

--- a/src/firefly/js/visualize/ui/Buttons.jsx
+++ b/src/firefly/js/visualize/ui/Buttons.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Box} from '@mui/joy';
+import {Box, IconButton, ToggleButtonGroup} from '@mui/joy';
 
 // TODO: we should use icon from one type(filled, outlined, rounded, two-tone, sharp).  It will yield better consistency.
 
@@ -38,7 +38,6 @@ import FilterIco from '@mui/icons-material/FilterAltOutlined';
 import ClearFilterIco from '@mui/icons-material/FilterAltOffOutlined';
 import TextViewIco from '@mui/icons-material/TextFieldsOutlined';
 import TableViewIco from '@mui/icons-material/TableChartOutlined';
-import AddColumnIco from '@mui/icons-material/PostAddOutlined';
 import SettingsIco from '@mui/icons-material/SettingsOutlined';
 import PropertySheetIco from '@mui/icons-material/ReadMoreOutlined';
 import ResetIco from '@mui/icons-material/RestartAltOutlined';
@@ -49,9 +48,17 @@ import CombineChartIco from '@mui/icons-material/JoinInner';
 import UnfoldMoreOutlinedIcon from '@mui/icons-material/UnfoldMoreOutlined';
 import UnfoldLessOutlinedIcon from '@mui/icons-material/UnfoldLessOutlined';
 import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOutlined';
+import ViewComfyAltRoundedIcon from '@mui/icons-material/ViewComfyAltRounded';
+import ViewModuleRoundedIcon from '@mui/icons-material/ViewModuleRounded';
+import NavigateNext from '@mui/icons-material/NavigateNextRounded';
+import NavigateBefore from '@mui/icons-material/NavigateBeforeRounded';
+
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import Crop169Icon from '@mui/icons-material/Crop169';
 
 import INSERT_COLUMN from 'html/images/insert-col-right-24-24.png';
 
+// import AddColumnIco from '@mui/icons-material/PostAddOutlined';
 // import LockOpenTwoToneIcon from '@mui/icons-material/LockOpenTwoTone';
 // import LockTwoToneIcon from '@mui/icons-material/LockTwoTone';
 // import ReplayRoundedIcon from '@mui/icons-material/ReplayRounded';
@@ -93,6 +100,14 @@ import INSERT_COLUMN from 'html/images/insert-col-right-24-24.png';
 export const ExpandButton= ({expandGrid, ...props}) =>(
     <ToolbarButton {...{
         icon: (expandGrid? GRID_EXPAND : <OpenInFull sx={{transform: 'scale(1.1,-1.1)'}}/>), ...props }}/>);
+
+export const NextButton= (props) =>(
+    <ToolbarButton {...{
+        icon: (<NavigateNext sx={{transform: 'scale(1.6,1.6)'}}/>), ...props }}/>);
+
+export const BeforeButton= (props) =>(
+    <ToolbarButton {...{
+        icon: (<NavigateBefore sx={{transform: 'scale(1.6,1.6)'}}/>), ...props }}/>);
 
 
 // export const LockImages= ({locked, ...props}) =>{
@@ -189,9 +204,15 @@ export const TableViewButton = (props) => (
     <ToolbarButton {...{icon: <TableViewIco/>, tip: 'Table View', iconButtonSize:'38px', ...props}}/>
 );
 
-export const AddColumnButton = (props) => (
-    <ToolbarButton icon={INSERT_COLUMN} tip='Add a column' {...props}/>
-);
+export const AddColumnButton = (props) => {
+    const icon = (
+        <Box sx={{width: 24, height: 24}}>
+            <Crop169Icon sx={{position: 'absolute', top: 3, left:-1, transform: 'rotate(90deg) scale(1.3,1)'}}/>
+            <AddCircleOutlineIcon sx={{position: 'absolute', left: 11, top: 4, transform: 'scale(.75,.75)'}}/>
+        </Box>
+    );
+    return <ToolbarButton icon={icon} tip='Add a column' {...props}/>;
+}
 
 export const SettingsButton = (props) => (
     <ToolbarButton {...{icon: <SettingsIco/>, tip: 'Chart options and tools', iconButtonSize:'38px', ...props}}/>
@@ -228,9 +249,9 @@ export const RotateButton= (props) => ( <TB {...{ icon: <ThreeSixtyRoundedIcon/>
 export const SaveButton= (props) => ( <TB {...{ icon: <SaveOutlinedIcon/>, ...props}}/>);
 export const InfoButton= (props) => (<TB {...{ icon: <InfoOutlinedIcon/>, ...props}}/>);
 export const ColorButtonIcon= (props) => (<TB {...{ icon: <ColorLens/>, ...props}}/>);
-export const OneTileButton= (props) => ( <TB {...{ icon: <SquareRoundedIcon/>, ...props}}/>);
-export const GridTileButton= (props) => (<TB {...{ icon: <GridViewRoundedIcon/>, ...props}}/>);
-export const GridTileCompactButton= (props) => ( <TB {...{ icon: <ViewCompactIcon/>, ...props}}/>);
+// export const OneTileButton= (props) => ( <TB {...{ icon: <SquareRoundedIcon/>, ...props}}/>);
+// export const GridTileButton= (props) => (<TB {...{ icon: <GridViewRoundedIcon/>, ...props}}/>);
+// export const GridTileCompactButton= (props) => ( <TB {...{ icon: <ViewCompactIcon/>, ...props}}/>);
 export const ListViewButton= (props) => ( <TB {...{ icon: <FormatListBulletedRoundedIcon/>, ...props}}/>);
 export const CheckedButton= (props) => ( <TB {...{ icon: <DoneAllRoundedIcon/>, ...props,}}/>);
 export const CheckedClearButton= (props) => ( <TB {...{ icon: <RemoveDoneRoundedIcon/>, ...props}}/>);
@@ -245,3 +266,30 @@ export const FiltersOffButton= (props) => ( <TB {...{ icon: <ClearFilterIco/>, .
 // export const SettingsButton= (props) => ( <TB {...{ icon: <SettingsOutlinedIcon/>, ...props}}/>);
 
 const TB= ({icon, ...props}) => (<ToolbarButton {...{ icon, iconButtonSize:'42px', ...props}}/>);
+
+
+
+export function DisplayTypeButtonGroup({config, variant='outlined', size='sm', value, sx}) {
+
+    const lookup= (v) => {
+        switch (v) {
+            case 'one' :
+            case 'single' :
+                return <SquareRoundedIcon/>;
+            case 'grid' : return <GridViewRoundedIcon/>;
+            case 'gridFull' : return <ViewModuleRoundedIcon/>;
+            case 'gridRelated' : return <ViewComfyAltRoundedIcon/>;
+        }
+    };
+
+    return (
+        <ToggleButtonGroup {...{variant, size, value, sx}}>
+            {config.map( ({value,title,onClick}) =>
+                (<IconButton {...{value, title, onClick, key:value,
+                            sx:{ '--IconButton-size':'38px', minHeight:'unset', minWidth:'unset', p:1/4} }}>
+                    {lookup(value)}
+                </IconButton>)
+            )}
+        </ToggleButtonGroup>
+    );
+}

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
@@ -12,7 +12,7 @@ import {
     dispatchChangeViewerLayout, getViewer, getMultiViewRoot,
     GRID_FULL, GRID_RELATED, SINGLE, GRID, getLayoutDetails
 } from '../MultiViewCntlr.js';
-import {GridTileButton, GridTileCompactButton, OneTileButton} from './Buttons.jsx';
+import {DisplayTypeButtonGroup} from './Buttons.jsx';
 import {showColorBandChooserPopup} from './ColorBandChooserPopup.jsx';
 import {ImagePager} from './ImagePager.jsx';
 import {VisMiniToolbar} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
@@ -46,6 +46,33 @@ export function ImageMetaDataToolbarView({viewerId, viewerPlotIds=[], layoutType
         metaControls= false;
     }
 
+    const gridConfig=[];
+    const gridValue= layoutType===SINGLE ? 'one' : layoutType===GRID && layoutDetail!==GRID_RELATED ? 'gridFull' : 'gridRelated';
+
+    if (showMultiImageOps) {
+        gridConfig.push(
+            { value:'one', title:'Show single image at full size',
+                onClick: () => dispatchChangeViewerLayout(viewerId,SINGLE, undefined, activeTable?.tbl_id)
+            }
+        );
+    }
+    if (canGrid) {
+        gridConfig.push(
+            { value:'gridFull', title:'Tile all images in the search result table',
+                onClick: () => dispatchChangeViewerLayout(viewerId,GRID,GRID_FULL,activeTable?.tbl_id)
+            }
+        );
+    }
+
+    if (hasRelatedBands) {
+        gridConfig.push(
+            { value:'gridRelated', title:'Tile all data products associated with the highlighted table row',
+                onClick: () =>
+                    dispatchChangeViewerLayout(viewerId,GRID,GRID_RELATED,activeTable?.tbl_id)
+            }
+        );
+    }
+
 
     return (
         <Sheet>
@@ -53,17 +80,7 @@ export function ImageMetaDataToolbarView({viewerId, viewerPlotIds=[], layoutType
                 {makeDropDown && makeDropDown()}
                 {(metaControls&&(showMultiImageOps||canGrid||hasRelatedBands||showThreeColorButton))&& <Divider orientation='vertical' sx={{mx:1}}/> }
                 {metaControls && <Stack direction='row' alignItems='center' whiteSpace='nowrap'>
-                    {showMultiImageOps && <OneTileButton tip='Show single image at full size'
-                                                         onClick={() => dispatchChangeViewerLayout(viewerId,SINGLE, undefined, activeTable?.tbl_id)}/>}
-
-                    {canGrid && <GridTileButton tip='Tile all images in the search result table'
-                                               onClick={() => dispatchChangeViewerLayout(viewerId,GRID,GRID_FULL,activeTable?.tbl_id)}/>}
-
-                    {hasRelatedBands  &&
-                        <GridTileCompactButton tip='Tile all data products associated with the highlighted table row'
-                                       sx={{ml: 2}}
-                                       onClick={() => dispatchChangeViewerLayout(viewerId,GRID,GRID_RELATED,activeTable?.tbl_id)}/>
-                    }
+                    {showMultiImageOps && <DisplayTypeButtonGroup {...{value:gridValue, config:gridConfig }}/>}
                     {showThreeColorButton &&
                         <ToolbarButton icon={THREE_COLOR} tip='Create three color image'
                                        imageStyle={{width:24,height:24, flex: '0 0 auto'}}

--- a/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
+++ b/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
@@ -5,17 +5,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {IconButton, Sheet, Stack} from '@mui/joy';
-import {dispatchChangeViewerLayout} from '../MultiViewCntlr.js';
+import {Sheet, Stack} from '@mui/joy';
+import {dispatchChangeViewerLayout, getMultiViewRoot, getViewer} from '../MultiViewCntlr.js';
 import {dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
-import {GridTileButton, ListViewButton, OneTileButton} from './Buttons.jsx';
+import {
+    BeforeButton, DisplayTypeButtonGroup, ListViewButton, NextButton } from './Buttons.jsx';
 import {showExpandedOptionsPopup} from './ExpandedOptionsPopup.jsx';
 import {VisMiniToolbar} from './VisMiniToolbar.jsx';
 import {getActivePlotView} from '../PlotViewUtil.js';
-
-import PAGE_RIGHT from 'html/images/icons-2014/20x20_PageRight.png';
-import PAGE_LEFT from 'html/images/icons-2014/20x20_PageLeft.png';
-
 
 
 export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, toolbarVariant,
@@ -29,6 +26,7 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, tool
     const moreThanOne= viewerPlotIds.length>1;
     const nextIdx= cIdx===viewerPlotIds.length-1 ? 0 : cIdx+1;
     const prevIdx= cIdx ? cIdx-1 : viewerPlotIds.length-1;
+    const layout= getViewer(getMultiViewRoot(), viewerId)?.layout ?? 'grid';
 
 
     const {showImageToolbar=true}= getActivePlotView(visRoot)?.plotViewCtx.menuItemKeys ?? {};
@@ -36,25 +34,32 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, tool
 
     return (
         <Sheet variant={toolbarVariant}>
-            <Stack {...{direction:'row', flexWrap:'nowrap', alignItems: 'center', justifyContent: 'space-between',
+            <Stack {...{pl:1/2, direction:'row', flexWrap:'nowrap', alignItems: 'center', justifyContent: 'space-between',
                 width:'100%', height: 32, style:toolbarStyle}}>
                 <Stack {...{direction:'row', alignItems: 'center', flexWrap:'nowrap'}}>
-                    {moreThanOne && <OneTileButton tip='Show single image at full size'
-                                                   onClick={() => dispatchChangeViewerLayout(viewerId,'single')}/>}
-                    {moreThanOne && <GridTileButton tip='Show all images as tiles'
-                                                   onClick={() => dispatchChangeViewerLayout(viewerId,'grid')}/>}
+
+                    {moreThanOne && <DisplayTypeButtonGroup {...{value:layout,
+                        config:[
+                            { value:'single', title:'Show single image at full size',
+                                onClick: () => dispatchChangeViewerLayout(viewerId,'single')
+                            },
+                            { value:'grid', title:'Show all images as tiles',
+                                onClick: () => dispatchChangeViewerLayout(viewerId,'grid')
+                            }
+                        ]
+                    }}/>}
                     {useImageList && moreThanOne &&
                         <ListViewButton tip='Choose which images to show'
                                        onClick={() =>showExpandedOptionsPopup('Pinned Images', viewerId) }/>
                     }
                     {layoutType==='single' && moreThanOne &&
                         <>
-                            <IconButton {...{ onClick:() => dispatchChangeActivePlotView(viewerPlotIds[prevIdx])}}>
-                                <img src={PAGE_LEFT}/>
-                            </IconButton>
-                            <IconButton {...{ onClick:() => dispatchChangeActivePlotView(viewerPlotIds[nextIdx])}}>
-                                <img src={PAGE_RIGHT}/>
-                            </IconButton>
+                        <BeforeButton
+                            title='Previous Image'
+                            onClick= {() => dispatchChangeActivePlotView(viewerPlotIds[prevIdx])}/>
+                        <NextButton
+                            title='Next Image'
+                            onClick= {() => dispatchChangeActivePlotView(viewerPlotIds[nextIdx])}/>
                         </>
                     }
                     {makeDropDown?.()}

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {Checkbox, Divider, IconButton, Stack, Typography} from '@mui/joy';
+import {Checkbox, Divider, Stack, Tooltip, Typography} from '@mui/joy';
 import React, {memo,Fragment} from 'react';
 import PropTypes from 'prop-types';
 import {isEmpty, isString} from 'lodash';
@@ -31,7 +31,9 @@ import Validate from '../../util/Validate.js';
 import {CoordinateSys} from '../CoordSys.js';
 import {convertToHiPS, convertToImage, doHiPSImageConversionIfNecessary} from '../task/PlotHipsTask.js';
 import {
-    CenterOnSelection, CheckedButton, CheckedClearButton, CropButton, FilterAddButton, FiltersOffButton, StatsButton
+    BeforeButton,
+    CenterOnSelection, CheckedButton, CheckedClearButton, CropButton, FilterAddButton, FiltersOffButton, NextButton,
+    StatsButton
 } from './Buttons.jsx';
 import {
     clearFilterDrawingLayer, crop, filterDrawingLayer, recenterToSelection, selectDrawingLayer, stats,
@@ -41,8 +43,6 @@ import {isSpacialActionsDropVisible, ActionsDropDownButton} from '../../ui/Actio
 import {SingleColumnMenu} from '../../ui/DropDownMenu.jsx';
 import {DropDownToolbarButton} from 'firefly/ui/DropDownToolbarButton.jsx';
 
-import PAGE_RIGHT from 'html/images/icons-2014/20x20_PageRight.png';
-import PAGE_LEFT from 'html/images/icons-2014/20x20_PageLeft.png';
 import SELECTED_ZOOM from 'html/images/icons-2014/ZoomFitToSelectedSpace.png';
 
 const image24x24={width:24, height:24};
@@ -401,23 +401,25 @@ export function MultiImageControllerView({plotView:pv}) {
     if (cIdx<0) cIdx= 0;
 
     return (
-        <Stack {...{direction:'row', flexWrap:'wrap', alignItems:'center',  position:'relative', title:tooltip }}>
-            {startStr && <Typography {...{level:'body-sm', width: '13em', overflow: 'hidden',
-                textOverflow: 'ellipsis', pl:1, textAlign: 'end'} }>
-                <span style={{fontStyle: 'italic', fontWeight: 'bold'}}> {startStr} </span>
-                <span> {hduDesc} </span>
-            </Typography>}
+        <Tooltip title={tooltip} placement='top-end'>
+            <Stack {...{direction:'row', flexWrap:'wrap', alignItems:'center',  position:'relative' }}>
+                {startStr && <Typography {...{level:'body-sm', width: '13em', overflow: 'hidden',
+                    textOverflow: 'ellipsis', pl:1, textAlign: 'end'} }>
+                    <span style={{fontStyle: 'italic', fontWeight: 'bold'}}> {startStr} </span>
+                    <Typography level='body-sm' color='warning'> {hduDesc} </Typography>
+                </Typography>}
 
-            {multiHdu && <FrameNavigator {...{pv, currPlotIdx:cIdx, minForInput:4, displayType:'hdu',tooltip}} />}
-            <Stack {...{direction:'row', alignItems:'center'}}>
-                {cube && multiHdu && <Divider orientation='vertical' sx={{mx:.5}}  />}
-                {cube &&
-                    <Typography {...{level:'body-sm', fontWeight:'bold', fontStyle: 'italic',
-                        overflow: 'hidden', textOverflow: 'ellipsis', pl: 1}}>Plane: </Typography>}
-                {wlStr && <Typography {...{level:'body-sm', pl:.5}}>{wlStr}</Typography>}
-                {cube && <FrameNavigator {...{pv, currPlotIdx:cIdx, minForInput:6, displayType:image?'cube':'hipsCube',tooltip}} /> }
+                {multiHdu && <FrameNavigator {...{pv, currPlotIdx:cIdx, minForInput:4, displayType:'hdu',tooltip}} />}
+                <Stack {...{direction:'row', alignItems:'center'}}>
+                    {cube && multiHdu && <Divider orientation='vertical' sx={{mx:.5}}  />}
+                    {cube &&
+                        <Typography {...{level:'body-sm', fontWeight:'bold', fontStyle: 'italic',
+                            overflow: 'hidden', textOverflow: 'ellipsis', pl: 1}}>Plane: </Typography>}
+                    {wlStr && <Typography {...{level:'body-sm', color:'warning', pl:.5}}>{wlStr}</Typography>}
+                    {cube && <FrameNavigator {...{pv, currPlotIdx:cIdx, minForInput:6, displayType:image?'cube':'hipsCube'}} /> }
+                </Stack>
             </Stack>
-        </Stack>
+        </Tooltip>
     );
 }
 
@@ -451,7 +453,7 @@ function getEmLength(len) {
 }
 
 
-function FrameNavigator({pv, currPlotIdx, minForInput, displayType, tooltip}) {
+function FrameNavigator({pv, currPlotIdx, minForInput, displayType}) {
 
     const typeConvert= {
         hdu: {
@@ -508,17 +510,13 @@ function FrameNavigator({pv, currPlotIdx, minForInput, displayType, tooltip}) {
 
 
     return (
-        <Stack direction='row' alignItems='center' flexWrap='nowrap' title={tooltip} >
-            <IconButton aria-label={tooltip} onClick={() => changeFrameIdx({value:prevIdx+1}) }>
-                <img src={PAGE_LEFT}/>
-            </IconButton>
-            <IconButton aria-label={tooltip} onClick={() => changeFrameIdx({value:nextIdx+1}) }>
-                <img src={PAGE_RIGHT}/>
-            </IconButton>
+        <Stack direction='row' alignItems='center' flexWrap='nowrap'>
+            <BeforeButton title={'Next frame'} onClick={() => changeFrameIdx({value:prevIdx+1})}/>
+            <NextButton title={'Previous fraome'} onClick={() => changeFrameIdx({value:nextIdx+1})}/>
             {showNavControl ?
                 <StateInputField defaultValue={currStr} valueChange={changeFrameIdx}
                                  sx={{'& .MuiInput-root':{'minHeight':'3px', 'borderRadius':4, width:'5em'}}}
-                                 tooltip={`Enter frame number to jump to, right arrow goes forward, left arrow goes back\n${tooltip}`}
+                                 tooltip={'Enter frame number to jump to, right arrow goes forward, left arrow goes back'}
                                  style={{width:getEmLength(len), textAlign:'right'}}
                                  type='number'
                                  validator={validator} onKeyDown={handleKeyDown} />


### PR DESCRIPTION
#### [Firefly-1434](https://jira.ipac.caltech.edu/browse/FIREFLY-1434): multiple fixes

 - rubin chart 1: images and charts: arrows icon now material icon
 - rubin chart:2: images and charts: grouping display modes
 - irsa testing round 2: 9 - tap quoting
 - feedback: image viewer only show highlights when there is more then one showing
 - [Firefly-1435](https://jira.ipac.caltech.edu/browse/FIREFLY-1435): bug fix: reading an empty FITS table

#### Testing

 - https://fireflydev.ipac.caltech.edu/firefly-1434-several-fixes/firefly
 - fixes from feedback rubin chart 1 & 2, irsa testing round 2: 9
 - Upload a fits with an empty table HDU (example attached to ticket)
 - Image view will not show highlight when only on image or HiPS on screen

#### Confirmed fixed

- [x] rubin: chart: 1 : notes arrow are updated on both charts and images
- [x] rubin: chart: 2: note group implemented on both charts and images
- [x] irsa testing round 2: 9
- [x] firefly-1435
- [x] image viewer only highlights when multiple on screen