### PR TITLE
FIREFLY-1427: Provide option for HydraViewer apps to use Menu instead of search panel.

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -528,3 +528,7 @@ div.rootStyle img {
 [data-joy-color-scheme="dark"] img.old-ff-icon-img {
     filter: invert(1);
 }
+
+#app img {
+    -webkit-user-drag: none;
+}

--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -2,14 +2,14 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
+import React from 'react';
 import {firefly} from './Firefly.js';
 import {mergeObjectOnly} from './util/WebUtil.js';
 import {getFireflyViewerWebApiCommands} from './api/webApiCommands/ViewerWebApiCommands';
 import {getLcCommands} from './api/webApiCommands/LcWebApiCommands.js';
 import {getDatalinkUICommands} from './api/webApiCommands/DatalinkUICommands.js';
 import {getDefaultMOCList} from 'firefly/visualize/HiPSMocUtil.js';
-import FFTOOLS_ICO from 'html/images/fftools-logo-offset-small-42x42.png';
-
+import APP_ICON from 'html/images/fftools-logo-offset-small-42x42.png';
 
 /**
  * @example
@@ -23,7 +23,7 @@ import FFTOOLS_ICO from 'html/images/fftools-logo-offset-small-42x42.png';
 const defProps = {
     appTitle: 'Firefly',
     initLoadingMessage: window?.firefly?.options?.initLoadingMessage,
-    appIcon : FFTOOLS_ICO
+    appIcon: <img src={APP_ICON}/>
 };
 
 const props = mergeObjectOnly(defProps, window?.firefly?.app ?? {});

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -330,14 +330,16 @@ function onlineHelpLoad( action )
 
 function loadSearches(action) {
     return function (dispatch) {
-        var {groups=[], activeSearch, ...rest} = action.payload;
+        var {groups=[], activeSearch, renderAsMenuItems=false, flow, ...rest} = action.payload;
         groups.forEach( (g) => {
             Object.entries(get(g, 'searchItems',{}))
                   .forEach(([k,v]) => v.name = k);      // insert key as name into the search object.
         });
         activeSearch = activeSearch || get(Object.values(get(groups, [0, 'searchItems'], {})), [0, 'name']);    // defaults to first searchItem
         const allSearchItems = Object.assign({}, ...map(groups, 'searchItems'));
-        Object.assign(searchInfo, rest, {allSearchItems, groups});
+        if (renderAsMenuItems) flow ??= 'hidden';
+
+        Object.assign(searchInfo, rest, {flow, renderAsMenuItems, allSearchItems, groups});
         dispatch({ type : APP_UPDATE, payload: {searches: {activeSearch}}});
     };
 }

--- a/src/firefly/js/core/AppDataReducers.js
+++ b/src/firefly/js/core/AppDataReducers.js
@@ -55,8 +55,8 @@ export function appDataReducer(state, action={}) {
 export function menuReducer(state={}, action={}) {
     switch (action.type) {
         case SHOW_DROPDOWN  :
-            const {visible, view=''} = action.payload;
-            const selected = visible ? view : '';
+            const {visible, view='', action:pAction} = action.payload;
+            const selected = visible ? pAction ?? view : '';
             return updateSet(state, ['menu', 'selected'], selected);
         case MENU_UPDATE:
             const {menu} = action.payload;

--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -190,11 +190,13 @@ export function dispatchSetLayoutInfo(layoutInfo) {
 
 /**
  * show the drop down container
- * @param view name of the component to display in the drop-down container
- * @param {Object} initArgs - init args to pass to the view
+ * @param {object} p     parameters
+ * @param {string} p.view name of the component to display in the drop-down container
+ * @param {string} [p.action] the action associated with this view
+ * @param {Object} p.initArgs - init args to pass to the view
  */
-export function dispatchShowDropDown({view, initArgs}) {
-    flux.process({type: SHOW_DROPDOWN, payload: {visible: true, view, initArgs}});
+export function dispatchShowDropDown({view, action, initArgs}) {
+    flux.process({type: SHOW_DROPDOWN, payload: {visible: true, view, action, initArgs}});
 }
 
 /**

--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -24,11 +24,12 @@
 /**
  * Information related to searches
  * @typedef {Object} SearchInfo
- * @prop {string} [title]    main title if any.  It will appears on top.
- * @prop {string} [flow]     'horizontal' or 'vertical'.  defaults to 'vertical'.
- * @prop {string} activeSearch    currently selected search.
- * @prop {Object.<string,Search>} allSearchItems  flatten maps of searches keyed by name
- * @prop {SearchGroup[]}          groups   search group
+ * @prop {string} [title]           main title if any.  It will appears on top.
+ * @prop {string} [flow]            'horizontal', 'vertical', or 'hidden'.  defaults to 'vertical'.
+ * @prop {string} activeSearch      currently selected search.
+ * @prop {boolean} renderAsMenuItems convert SearchInfo into MenuItems.  Defaults to false.  When this is true, flow is default to 'hidden', unless defined.
+ * @prop {Object.<string,Search>}   allSearchItems  flatten maps of searches keyed by name
+ * @prop {SearchGroup[]}            groups   search group
  */
 
 /**

--- a/src/firefly/js/templates/common/FireflyLayout.jsx
+++ b/src/firefly/js/templates/common/FireflyLayout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {object, bool, element} from 'prop-types';
+import {object, bool, element, shape, elementType} from 'prop-types';
 import {Stack, Sheet, LinearProgress} from '@mui/joy';
 import {pick} from 'lodash/object.js';
 
@@ -8,39 +8,58 @@ import {Alerts} from 'firefly/ui/DropDownContainer.jsx';
 import {Banner} from 'firefly/ui/Banner.jsx';
 import {Menu} from 'firefly/ui/Menu.jsx';
 import {getMenu, isAppReady} from 'firefly/core/AppDataCntlr.js';
-import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
+import {Slot, useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 import {MainPanel} from 'firefly/templates/common/MainPanel.jsx';
 import {AppConfigDrawer} from '../../ui/AppConfigDrawer.jsx';
 
+/*
+ __________________________________________
+|  ___________                             |
+| |           |       <banner/>            |
+|_|           |____________________________|
+| |           |                            |
+| |           |       <warning|alerts/>    |
+|_|           |____________________________|
+| |           |                            |
+| |           |          <main>            |
+| |           |     _________________      |
+| | <drawer>  |    |                 |     |
+| |  open     |    |     children    |     |
+| |  extent   |    |_________________|     |
+| |  from     |     _________________      |
+| |  top to   |    |                 |     |
+| |  bottom   |    |   <dropdown>    |     |
+| |           |    |  ____________   |     |
+| |           |    | |  content   |  |     |
+| |           |    | |____________|  |     |
+| |           |    |                 |     |
+| |           |    |  <footer/vers>  |     |
+| |___________|    |_________________|     |
+|__________________________________________|
+
+In the main section, if the dropdown component is not null, it will be displayed.
+Otherwise, this component's children will be displayed.
+At this level, there are three slots available: drawer, banner, and dropdown.
+Use slotProps to customize them.
+*/
+
 /**
  * Default Firefly application layout.
- * <banner/>                // menu, icons, title, etc
- * <warning|alerts/>
- * <main>                   // main section of the application.  displays either dropdown, results or expandedView.
- *     <drawer>
- *     <dropdown>
- *         <content>
- *         <footer + version>
- *     </dropdown>
- *     <results/>
- * </main>
  * @param props
  * @param props.footer
  * @param props.useDefaultExpandedView uses the default ExpandedView.  Default to false.
  * @param props.dropDownComponent uses a dropdown component, e.g. DropDownContainer.
- * @param props.drawerComponent
  * @param props.sx
+ * @param props.slotProps
  * @param props.children
  */
-export function FireflyLayout({footer, useDefaultExpandedView, drawerComponent=<AppConfigDrawer/>,
-                                  dropDownComponent, sx, children, ...props}) {
+export function FireflyLayout({footer, useDefaultExpandedView,
+                                  dropDownComponent, sx, children, slotProps, ...props}) {
 
     const menu = useStoreConnector(getMenu);
     const isReady = useStoreConnector(isAppReady);
 
-    const bannerProps = pick(props, [
-        'menu', 'appTitle', 'appIcon', 'altAppIcon', 'bannerLeftStyle','bannerMiddleStyle', 'enableVersionDialog', 'showTitleOnBanner'
-    ]);
+    const bannerProps = pick(props, ['appTitle', 'appIcon']);
 
     if (!isReady) {         // loading indicator.
         return (
@@ -55,10 +74,10 @@ export function FireflyLayout({footer, useDefaultExpandedView, drawerComponent=<
     return (
         <Sheet id='app-root' component={Stack} spacing={1} sx={{position:'absolute', inset:'0', ...sx}}>
             <Stack>
-                <BannerSection {...bannerProps} menu={menu}/>
+                <BannerSection {...bannerProps} menu={menu} {...slotProps?.banner}/>
                 <div id={warningDivId} data-decor='full' className='warning-div center'/>
                 <Alerts />
-                {drawerComponent}
+                <Slot component={AppConfigDrawer} slotProps={slotProps?.drawer}/>
             </Stack>
             <MainPanel {...{footer, useDefaultExpandedView, dropDownComponent}}>
                 {children}
@@ -71,9 +90,16 @@ export function FireflyLayout({footer, useDefaultExpandedView, drawerComponent=<
 FireflyLayout.propTypes = {
     useDefaultExpandedView: bool,
     footer: element,
-    drawerComponent: element,
     dropDownComponent: element,
-    sx: object
+    sx: object,
+    slotProps: shape({
+        drawer: shape({
+            component: elementType,         // defaults to AppConfigDrawer
+            ...AppConfigDrawer.propTypes,
+        }),
+        banner: object,
+        dropdown: object
+    })
 };
 
 
@@ -81,19 +107,18 @@ FireflyLayout.propTypes = {
 /**
  * Handles banner and login
  * @param p             props
+ * @param p.menu        menu info
  * @param p.appTitle    application title
  * @param p.appIcon     application icon
- * @param p.altAppIcon  alternative icon
- * @param p.bannerLeftStyle   style for the left portion of the banner
- * @param p.bannerMiddleStyle style for the middle portion of the banner
- * @param p.enableVersionDialog show version dialog when banner icon is clicked
+ * @param p.banner      banner props
  * @return {JSX.Element}
  */
-function BannerSection({menu, ...rest}) {
+function BannerSection({menu, banner, ...rest}) {
     return (
         <Banner key='banner'
-                menu={<Menu/> }
+                menu={<Menu/>}
                 {...rest}
+                {...banner}
         />
     );
 }

--- a/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
+++ b/src/firefly/js/templates/fireflyslate/FireflySlate.jsx
@@ -1,7 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {isEmpty} from 'lodash';
+import {isEmpty, set} from 'lodash';
 import React, {memo, useContext, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import shallowequal from 'shallowequal';
@@ -14,7 +14,6 @@ import {getLayouInfo, dispatchSetLayoutMode, getGridView, getGridViewColumns,
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {getExpandedChartProps} from '../../charts/ChartsCntlr.js';
-import {AppConfigDrawer} from '../../ui/AppConfigDrawer.jsx';
 import {AppPropertiesCtx} from '../../ui/AppPropertiesCtx.jsx';
 import {visRoot} from '../../visualize/ImagePlotCntlr.js';
 import {getMultiViewRoot, findViewerWithItemId, PLOT2D} from '../../visualize/MultiViewCntlr.js';
@@ -26,7 +25,6 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {startLayoutManager} from './FireflySlateManager.js';
 import {GridLayoutPanel} from './GridLayoutPanel.jsx';
 
-import FFTOOLS_ICO from 'html/images/fftools-logo-offset-small-75x75.png';
 import App from 'firefly/ui/App.jsx';
 
 
@@ -54,7 +52,7 @@ function getNextState(prevS, renderTreeId) {
  * <li><b>menu</b>:  menu is an array of menu items {label, action, icon, desc, type}.  Leave type blank for dropdown.
  * If type='COMMAND', it will fire the action without triggering dropdown.</li>
  * <li><b>appTitle</b>:  The title of the FireflyViewer.  It will appears at top left of the banner. Defaults to 'Firefly'. </li>
- * <li><b>appIcon</b>:  A url string to the icon to appear on the banner. </li>
+ * <li><b>appIcon</b>:  A react element rendered at where appIcon should appear. </li>
  * <li><b>footer</b>:   A react elements to place on the footer when the menu drop down. </li>
  * <li><b>dropdownPanels</b>:  An array of additional react elements which are mapped to a menu item's action. </li>
  * @param props
@@ -63,7 +61,7 @@ function getNextState(prevS, renderTreeId) {
 export const FireflySlate= memo(( {initLoadingMessage, renderTreeId, menu:menuItems, showBgMonitor=false}) => {
 
 
-    const {appTitle, appIcon=FFTOOLS_ICO, appFromApi} = useContext(AppPropertiesCtx);
+    const {appTitle, appIcon, appFromApi, slotProps={}} = useContext(AppPropertiesCtx);
     const state= useStoreConnector( (prevState) => getNextState(prevState,renderTreeId));
     const [appRef,setAppRef]= useState(undefined);
 
@@ -81,16 +79,15 @@ export const FireflySlate= memo(( {initLoadingMessage, renderTreeId, menu:menuIt
     if (showBgMonitor) menu.showBgMonitor= showBgMonitor;
 
 
-    const drawerComponent= <AppConfigDrawer containerElement={appRef}/>;
-    
-
+    set(slotProps, 'drawer.containerElement', appRef);
+    set(slotProps, 'banner.enableVersionDialog', true);
     return (
         <RenderTreeIdCtx.Provider value={{renderTreeId}}>
             <div {...{ref:(c) => {
                     if (appFromApi) setAppRef(c);
                 }
             }}>
-            <App {...{drawerComponent, enableVersionDialog:true, appTitle, appIcon, ...appProps}}>
+            <App slotProps={slotProps} {...{appTitle, appIcon, ...appProps}}>
                 {mainView({expanded, gridView, gridColumns, initLoadingMessage, initLoadCompleted})}
             </App>
             </div>
@@ -101,14 +98,13 @@ export const FireflySlate= memo(( {initLoadingMessage, renderTreeId, menu:menuIt
 /**
  * menu is an array of menu items {label, action, icon, desc, type}.
  * dropdownPanels is an array of additional react elements which are mapped to a menu item's action.
- * @type {{title: *, menu: *, appTitle: *, appIcon: *, altAppIcon: *, dropdownPanels: *}}
+ * @type {{title: *, menu: *, appTitle: *, appIcon: *, dropdownPanels: *}}
  */
 FireflySlate.propTypes = {
     title: PropTypes.string,
     menu: PropTypes.arrayOf(PropTypes.object),
     appTitle: PropTypes.string,
-    appIcon: PropTypes.string,
-    altAppIcon: PropTypes.string,
+    appIcon: PropTypes.element,
     footer: PropTypes.element,
     dropdownPanels: PropTypes.arrayOf(PropTypes.element),
     style: PropTypes.object,

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -5,6 +5,7 @@
 
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
+import {cloneDeep} from 'lodash/lang.js';
 
 import {flux} from '../../core/ReduxFlux.js';
 import {
@@ -28,6 +29,7 @@ import {getWorkspaceConfig, initWorkspace} from '../../visualize/WorkspaceCntlr.
 
 import {getAllStartIds, getObsCoreWatcherDef, startTTFeatureWatchers} from '../common/ttFeatureWatchers';
 import App from 'firefly/ui/App.jsx';
+import {setIf as setIfUndefined} from 'firefly/util/WebUtil.js';
 
 /**
  * This FireflyViewer is a generic application with some configurable behaviors.
@@ -38,14 +40,14 @@ import App from 'firefly/ui/App.jsx';
  * <li><b>title</b>:  This title will appears at center top of the results area. Defaults to 'FFTools'. </li>
  * <li><b>menu</b>:  menu is an array of menu items {label, action, icon, desc, type}.  Leave type blank for dropdown.  If type='COMMAND', it will fire the action without triggering dropdown.</li>
  * <li><b>appTitle</b>:  The title of the FireflyViewer.  It will appears at top left of the banner. Defaults to 'Firefly'. </li>
- * <li><b>appIcon</b>:  A url string to the icon to appear on the banner. </li>
+ * <li><b>appIcon</b>:  A react element rendered at where appIcon should appear. </li>
  * <li><b>footer</b>:   A react elements to place on the footer when the menu drop down. </li>
  * <li><b>dropdownPanels</b>:  An array of additional react elements which are mapped to a menu item's action. </li>
  * <li><b>views</b>:  The type of result view.  Choices are 'images', 'tables', and 'xyPlots'.  They can be combined with ' | ', i.e.  'images | tables'</li>
  *
  */
 export function FireflyViewer ({menu, options, initLoadCompleted, initLoadingMessage, views, showViewsSwitch, leftButtons,
-                                   centerButtons, rightButtons, normalInit=true, landingPage, ...appProps}){
+                                   centerButtons, rightButtons, normalInit=true, landingPage, slotProps, ...appProps}){
 
     useEffect(() => {
         getImageMasterData();
@@ -71,16 +73,19 @@ export function FireflyViewer ({menu, options, initLoadCompleted, initLoadingMes
         });
 
     }, []);
-    const drawerComponent= (
+
+    const FireflySidebar= () => (
         <AppConfigDrawer>
             <LayoutChoiceVisualAccordion/>
         </AppConfigDrawer>
     );
 
-
+    const mSlotProps = cloneDeep(slotProps || {});
+    setIfUndefined(mSlotProps, 'drawer.component', FireflySidebar);
+    setIfUndefined(mSlotProps, 'banner.enableVersionDialog', true);
 
     return (
-        <App {...{enableVersionDialog:true, views, drawerComponent, ...appProps}}>
+        <App slotProps={mSlotProps} {...{views, ...appProps}}>
             <DynamicResults {...{views, showViewsSwitch, landingPage, leftButtons, centerButtons,
                 rightButtons, initLoadingMessage, initLoadCompleted}}/>
         </App>
@@ -90,14 +95,13 @@ export function FireflyViewer ({menu, options, initLoadCompleted, initLoadingMes
 /**
  * menu is an array of menu items {label, action, icon, desc, type}.
  * dropdownPanels is an array of additional react elements which are mapped to a menu item's action.
- * @type {{title: *, menu: *, appTitle: *, appIcon: *, altAppIcon: *, dropdownPanels: *, views: *}}
+ * @type {{title: *, menu: *, appTitle: *, appIcon: *, dropdownPanels: *, views: *}}
  */
 FireflyViewer.propTypes = {
     title: PropTypes.string,
     menu: PropTypes.arrayOf(PropTypes.object),
     appTitle: PropTypes.string,
-    appIcon: PropTypes.string,
-    altAppIcon: PropTypes.string,
+    appIcon: PropTypes.element,
     showUserInfo: PropTypes.bool,
     footer: PropTypes.element,
     dropdownPanels: PropTypes.arrayOf(PropTypes.element),

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -95,7 +95,7 @@ TriViewPanel.propTypes = {
 
 function RightSide({expanded, closeable, showXyPlots, showMeta, showFits, dataProductTableId, coverageRight, imagesWithCharts }) {
 
-    const onTabSelect = (idx, id) => dispatchUpdateLayoutInfo({rightSide:{selectedTab:id}});
+    const onTabSelect = (id) => dispatchUpdateLayoutInfo({rightSide:{selectedTab:id}});
     const chartExpandedMode= expanded===LO_VIEW.xyPlots;
     const cov= imagesWithCharts || coverageRight;
     const meta= imagesWithCharts && showMeta;

--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -4,7 +4,9 @@
 
 
 import React, {useEffect} from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, {element, object, shape, string} from 'prop-types';
+import {Typography} from '@mui/joy';
+import {cloneDeep} from 'lodash/lang.js';
 
 import {flux} from '../../core/ReduxFlux.js';
 import {dispatchSetMenu, dispatchOnAppReady, dispatchNotifyRemoteAppReady, getSearchInfo} from '../../core/AppDataCntlr.js';
@@ -21,13 +23,17 @@ import {dispatchSetLayoutMode, LO_MODE} from '../../core/LayoutCntlr';
 import {getExpandedChartProps} from '../../charts/ChartsCntlr.js';
 import {DEFAULT_PLOT2D_VIEWER_ID} from '../../visualize/MultiViewCntlr.js';
 import App from 'firefly/ui/App.jsx';
-import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
+import {Slot, useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
+import {searchClickHandler, SearchPanel} from 'firefly/ui/SearchPanel.jsx';
+import {LandingPage} from 'firefly/templates/fireflyviewer/LandingPage.jsx';
+import {Stacker} from 'firefly/ui/Stacker.jsx';
+import {setIf as setIfUndefined} from 'firefly/util/WebUtil.js';
 
 
-/**
+/*
  * This is a viewer.
  */
-export function HydraViewer({menu, ...props}) {
+export function HydraViewer({menu, slotProps, ...props}) {
 
 
     useEffect(() => {
@@ -42,9 +48,23 @@ export function HydraViewer({menu, ...props}) {
         });
     }, []);
 
+    const mSlotProps = cloneDeep(slotProps || {});
+
+    // defaultView is used when the requested view does not match any of the predefined views in dropdown.
+    // with Hydra's SearchPanel, component(view) are defined by a search's renderer, i.g. renderStandardView
+    // this is a convenience way to direct all undefined requests to SearchPanel.
+    setIfUndefined(mSlotProps,'dropdown.defaultView', <SearchPanel/>);
+
+    // adjust banner for appIcon
+    setIfUndefined(mSlotProps,'banner.slotProps.icon.style.marginTop', -43);
+    setIfUndefined(mSlotProps,'banner.slotProps.tabs.pl', '120px');
+
+    setIfUndefined(mSlotProps,'landing.icon', props?.appIcon);
+    setIfUndefined(mSlotProps,'landing.title', props?.appTitle);
+
     return (
-        <App {...props}>
-            <ResultSection/>
+        <App slotProps={mSlotProps} {...props}>
+            <ResultSection slotProps={mSlotProps}/>
         </App>
     );
 }
@@ -52,29 +72,35 @@ export function HydraViewer({menu, ...props}) {
 /**
  * menu is an array of menu items {label, action, icon, desc, type}.
  * dropdownPanels is an array of additional react elements which are mapped to a menu item's action.
- * @type {{title: *, menu: *, appTitle: *, appIcon: *, altAppIcon: *, dropdownPanels: *, views: *}}
+ * @type {{title: *, menu: *, appTitle: *, appIcon: *, dropdownPanels: *, views: *}}
  */
 HydraViewer.propTypes = {
     title: PropTypes.string,
     menu: PropTypes.arrayOf(PropTypes.object),
     appTitle: PropTypes.string,
-    appIcon: PropTypes.string,
-    altAppIcon: PropTypes.string,
+    appIcon: PropTypes.element,
     footer: PropTypes.element,
     dropdownPanels: PropTypes.arrayOf(PropTypes.element),
     style: PropTypes.object,
     hasCoverage: PropTypes.bool,
-    hasDataProduct: PropTypes.bool
+    hasDataProduct: PropTypes.bool,
+    slotProps: shape({
+        drawer: object,         // use 'component' to define the drawer's ElementType.  the rest will be passed as drawer's props
+        banner: object,
+        dropdown: object,
+        landing: object
+    })
 };
 
 HydraViewer.defaultProps = {
     appTitle: 'Time Series Viewer'
 };
 
-function onReady({menu}) {
-    if (menu) {
-        dispatchSetMenu({menuItems: menu});
-    }
+function onReady({menu=[]}) {
+    const {renderAsMenuItems , allSearchItems, groups} = getSearchInfo();
+   const menuItems = renderAsMenuItems ? makeMenuItems(groups, allSearchItems).concat(menu) : menu;
+    dispatchSetMenu({menuItems});
+
     const {hasImages, hasTables, hasXyPlots} = getLayouInfo();
     if (!(hasImages || hasTables || hasXyPlots)) {
         const goto = getActionFromUrl() || {type: SHOW_DROPDOWN};
@@ -83,9 +109,13 @@ function onReady({menu}) {
     dispatchNotifyRemoteAppReady();
 }
 
-function ResultSection() {
+function ResultSection({slotProps}) {
 
     const layoutInfo = useStoreConnector(getLayouInfo);
+    const {showImages, showXyPlots, showTables} = layoutInfo;
+
+    if (!(showImages || showXyPlots || showTables)) return <Slot component={HydraLanding} {...slotProps?.landing}/>;
+
 
     const {currentSearch, images} = layoutInfo;
     const {expanded=LO_VIEW.none} = layoutInfo.mode || {};
@@ -135,3 +165,46 @@ function showExpandedView ({expanded}) {
 function closeExpanded() {
     dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);
 }
+
+
+function makeMenuItems(groups, allSearchItems) {
+    const menuItems=[];
+    if (groups.length > 0) {
+        groups.forEach((g) => {
+            const category = g.title;
+            Object.entries(g.searchItems).forEach(([k,v]) => {
+                menuItems.push({label: k, action:k, primary: !!v?.primary, category, clickHandler: searchClickHandler});
+            });
+        });
+    } else {
+        Object.entries(allSearchItems).forEach(([k,v]) => {
+            menuItems.push({label: k, action:k, primary: !!v?.primary, clickHandler: searchClickHandler});
+        });
+    }
+    return menuItems;
+}
+
+function HydraLanding({icon, title, desc, slotProps, ...props} ) {
+
+    const Greetings = () => (
+        <Stacker startDecorator={icon} direction='column' alignItems='start'>
+            <Typography level='h4'>{title || 'Welcome message here'}</Typography>
+            <Typography level='body-md'>{desc || 'Additional description of this application'}</Typography>
+        </Stacker>
+    );
+
+    const mSlotProps = cloneDeep(slotProps || {});
+    setIfUndefined(mSlotProps,'bgMonitorHint.sx.right', 50);
+    setIfUndefined(mSlotProps,'topSection.component', Greetings);      // use custom topSection
+    setIfUndefined(mSlotProps,'contentSection.sx', {maxWidth: '80em', mx: 'auto'});   // limit page's width
+
+    return <LandingPage slotProps={mSlotProps} {...props}/>;
+}
+
+HydraLanding.propTypes = {
+    icon: element,
+    title: string,
+    desc: string,
+    ...LandingPage.propTypes,
+};
+

--- a/src/firefly/js/ui/App.jsx
+++ b/src/firefly/js/ui/App.jsx
@@ -6,7 +6,16 @@ import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 import {getLayouInfo} from 'firefly/core/LayoutCntlr.js';
 
 
-export  default function App({children, dropdownPanels, drawerComponent, watchInitArgs, selected, ...props}) {
+/*
+A wrapper component that uses FireflyLayout with DropDownContainer as its dropdown component.
+This component is commonly used across Firefly-based applications.
+It relies on LayoutCntrl to determine the visibility of the dropdown.
+This abstraction is needed because route-base applications use route to
+determine what gets rendered.  Moving LayoutCntrl out of FireflyLayout allow route-based
+apps to use it while still having full control of when dropdown is rendered.
+*/
+
+export  default function App({children, dropdownPanels, watchInitArgs, selected, slotProps, ...props}) {
 
     const {dropDown} = useStoreConnector(getLayouInfo);
 
@@ -15,17 +24,20 @@ export  default function App({children, dropdownPanels, drawerComponent, watchIn
     let dropDownComponent = null;       // when dropDown is null, it will show children(results)
     if (visible && view) {
         dropDownComponent = (
-            <DropDownContainer visible={true} {...{dropdownPanels, selected, watchInitArgs}}>
+            <DropDownContainer visible={true} {...{dropdownPanels, selected, watchInitArgs, ...slotProps?.dropdown}}>
                 {view}
             </DropDownContainer>
         );
     }
 
     return (
-        <FireflyLayout {...{dropDownComponent, drawerComponent, ...props}}>
+        <FireflyLayout {...{dropDownComponent, slotProps, ...props}}>
             {children}
         </FireflyLayout>
     );
 }
 
 
+App.propTypes = {
+    ...FireflyLayout.propTypes
+};

--- a/src/firefly/js/ui/AppConfigDrawer.jsx
+++ b/src/firefly/js/ui/AppConfigDrawer.jsx
@@ -10,24 +10,28 @@ import {ListBoxInputFieldView} from './ListBoxInputField.jsx';
 import {SideBarMenu} from './Menu.jsx';
 import {AccordionPanelView} from './panel/AccordionPanel.jsx';
 import {useStoreConnector} from './SimpleComponent.jsx';
-import {VersionInfo} from './VersionInfo.jsx';
+import {showFullVersionInfoDialog, VersionInfo} from './VersionInfo.jsx';
 
 
 
-export function AppConfigDrawer({containerElement, drawerWidth= '20rem', allowMenuHide= true, useSideBarMenu=true, children}) {
+export function AppConfigDrawer({containerElement, drawerWidth= '20rem', allowMenuHide= true, useSideBarMenu=true, children, sx, ...props}) {
 
     const {appTitle, appIcon} = useContext(AppPropertiesCtx);
     const visible= useStoreConnector(() => isDialogVisible(SIDE_BAR_ID));
     const closeSideBar= () => dispatchHideDialog(SIDE_BAR_ID);
     const drawerTitleSx = {m: '0.5rem', height: '3rem'};
 
+    const appIconEl = appIcon && React.cloneElement(appIcon, {
+        style: {height: drawerTitleSx.height}
+    });
+
     return (
-        <Drawer container={containerElement} open={visible} onClose={() => closeSideBar()} sx={{ '--Drawer-horizontalSize': drawerWidth }} >
+        <Drawer container={containerElement} open={visible} onClose={() => closeSideBar()} sx={{ '--Drawer-horizontalSize': drawerWidth, ...sx}} {...props} >
             <ModalClose sx={{transform: 'translateY(-50%)', top: `calc(${drawerTitleSx.height} / 2 + ${drawerTitleSx.m})`}}/>
             <DialogTitle level='h4' sx={(theme) => ({m: drawerTitleSx.m, color: theme.vars.palette.text.tertiary, fontWeight: theme.vars.fontWeight.md})}>
                 <Stack direction='row' spacing={.5} alignItems='center'>
                     <IconButton onClick={() => closeSideBar()}>
-                        <img style={{height: drawerTitleSx.height}} src={appIcon?.startsWith('data') ? appIcon : modifyURLToFull(appIcon)} />
+                        {appIconEl}
                     </IconButton>
                     <span>{appTitle}</span>
                 </Stack>

--- a/src/firefly/js/ui/Banner.jsx
+++ b/src/firefly/js/ui/Banner.jsx
@@ -5,47 +5,45 @@
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded.js';
 import {Box, IconButton, Sheet, Stack, Typography} from '@mui/joy';
 import React, {memo, useContext} from 'react';
-import PropTypes from 'prop-types';
+import {bool, element, node, object, shape, string} from 'prop-types';
 import {dispatchShowDialog, SIDE_BAR_ID} from '../core/ComponentCntlr.js';
 import {AppPropertiesCtx} from './AppPropertiesCtx.jsx';
 import {getVersionInfoStr, showFullVersionInfoDialog} from 'firefly/ui/VersionInfo.jsx';
-import './Banner.css';
 import {menuTabsBorderSx} from 'firefly/ui/Menu';
+import {Slot} from 'firefly/ui/SimpleComponent.jsx';
 
 const getVersionTipStr= (appTitle) => `${appTitle?appTitle+' ':''}Version:\n${getVersionInfoStr(true,true)}`;
 
 // todo - evaluate if we want soft/primary as our banner color
 const variant='soft';
-// const variant='solid';
-// const variant='outlined';
 const color='primary';
 
-export const Banner = memo( ({menu, enableVersionDialog= false, appTitle:titleProp, showTitleOnBanner=false}) => {
+export const Banner = memo( ({menu, enableVersionDialog= false, appIcon:pAppIdon, appTitle:pAppTitle, title, slotProps, sx, ...props}) => {
     const ctx = useContext(AppPropertiesCtx);
-    const {appIcon, bannerMiddleStyle, bannerLeftStyle} = ctx;
-    const appTitle=  titleProp || ctx.appTitle;
+    const {appIcon=pAppIdon, appTitle=pAppTitle} = ctx;
+    const appIconEl = appIcon && React.cloneElement( appIcon, {
+                                        onClick: () => enableVersionDialog && showFullVersionInfoDialog(appTitle),
+                                        title: enableVersionDialog ? getVersionTipStr(appTitle) : ''
+                                    });
     return (
-        <Sheet {...{
-            className:'banner__main', variant, color, sx: (theme) => ({
+        <Sheet {...{variant, color,
+            sx: (theme) => ({
                 width:1, position:'relative',
-                ...menuTabsBorderSx(theme)
-            })
+                ...menuTabsBorderSx(theme),
+                ...sx
+            }),
+            ...props
         }}>
             <Stack {...{direction:'row', height:40, alignItems:'center', px:1, py: .5,
                 spacing: 0.5}}>
                 <AppConfigButton/>
 
-                <Box sx={{flexGrow:0, cursor: enableVersionDialog ? 'pointer' : 'inherit'}}
-                     style={bannerLeftStyle}>
-                    {appIcon ?
-                        <img src={appIcon} alt={`${appTitle} icon`}
-                             onClick={() => enableVersionDialog && showFullVersionInfoDialog(appTitle) }
-                             title={enableVersionDialog ? getVersionTipStr(appTitle) : ''}/> :
-                        <Box {...{width: 75}}/>}
+                <Box {...slotProps?.icon} sx={{flexGrow:0, cursor: enableVersionDialog ? 'pointer' : 'inherit', ...slotProps?.icon?.sx}} >
+                    {appIconEl || <Box width={75}/>}
                 </Box>
 
-                <Stack {...{flexGrow:1, direction:'row',  style:bannerMiddleStyle }}>
-                    {showTitleOnBanner && makeBannerTitle(appTitle)}
+                <Stack {...{flexGrow:1, direction:'row', ...slotProps?.tabs}}>
+                    {title}
                     <Stack {...{ flexGrow: 0, width: 1}}>
                         {menu}
                     </Stack>
@@ -56,18 +54,16 @@ export const Banner = memo( ({menu, enableVersionDialog= false, appTitle:titlePr
 });
 
 Banner.propTypes= {
-    menu: PropTypes.object,
-    readout: PropTypes.object,
-    appIcon: PropTypes.string,
-    visPreview: PropTypes.object,
-    appTitle: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.element
-    ]),
-    additionalTitleStyle: PropTypes.object,
-    showUserInfo: PropTypes.bool,
-    enableVersionDialog: PropTypes.bool,
-    showTitleOnBanner: PropTypes.bool
+    menu: object,
+    appIcon: element,
+    appTitle: string,
+    enableVersionDialog: bool,
+    title: node,
+    sx: object,
+    slotProps: shape({
+        icon: object,
+        tabs: object
+    })
 };
 
 function AppConfigButton({sx}) {

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -62,7 +62,7 @@ export const dropDownMap = {
  * Items in this container must have a 'name' property.  It will be used to
  * compare to the selected card.
  */
-export function DropDownContainer ({style={}, visible:defVisible, selected:defSelected, dropdownPanels, watchInitArgs= true, children}) {
+export function DropDownContainer ({style={}, visible:defVisible, selected:defSelected, dropdownPanels, defaultView, watchInitArgs= true, children}) {
 
     const visible   = useStoreConnector(() => getDropDownInfo()?.visible ?? defVisible);
     const selected  = useStoreConnector(() => getDropDownInfo()?.view ?? defSelected);       // the selected view name
@@ -70,6 +70,8 @@ export function DropDownContainer ({style={}, visible:defVisible, selected:defSe
     const [, setInit] = useState();
 
     let {view, layout} = dropDownMap[selected] || {};
+
+    view ??= defaultView;
 
     useEffect( () => {
         React.Children.forEach(children, (el) => {

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -85,8 +85,7 @@ export const FormPanel = function (props) {
             </Stack>
             <Stacker endDecorator={searchBarEnd} {...slotProps?.searchBar}
                      sx={{...submitBarStyle, ...slotProps?.searchBar?.sx}}>
-                <CompleteButton style={{display: 'inline-block', marginRight: 10}}
-                                includeUnmounted={includeUnmounted}
+                <CompleteButton includeUnmounted={includeUnmounted}
                                 groupKey={groupKey}
                                 requireAllValid={requireAllValid}
                                 getDoOnClickFunc={getDoOnClickFunc}

--- a/src/firefly/js/ui/Menu.jsx
+++ b/src/firefly/js/ui/Menu.jsx
@@ -41,7 +41,7 @@ function menuHandleAction (menuItem) {
     }
 }
 
-function onClick(clickHandler,menuItem) {
+function onClickHandler(clickHandler,menuItem) {
     clickHandler ??= menuHandleAction;
     clickHandler(menuItem);
 }
@@ -129,12 +129,12 @@ export function MenuItemButton({menuItem, icon, size='lg', clickHandler, isWorki
     const item=(
         icon ?
             (<IconButton {...{ className: 'ff-MenuItem', size:'lg', color, variant,
-                onClick: () => onClick(clickHandler,menuItem)}}>
+                onClick: () => onClickHandler(clickHandler,menuItem)}}>
                 {icon}
             </IconButton>) :
             (<Button {...{startDecorator, className: 'ff-MenuItem', size, color, variant,
                 sx:{whiteSpace:'nowrap', ...sx},
-                onClick: () => onClick(clickHandler,menuItem) }}>
+                onClick: () => onClickHandler(clickHandler,menuItem) }}>
                 {menuItem.label}
             </Button>)
     );
@@ -421,7 +421,7 @@ function doTabChange(action,menuTabItems) {
     }
     else {
         const clickItem= menuTabItems?.find( (i) => i.action===action) ;
-        if (clickItem) onClick(clickItem.clickHandler,clickItem);
+        if (clickItem) onClickHandler(clickItem.clickHandler,clickItem);
     }
 }
 
@@ -499,7 +499,7 @@ function SideBarItem({item,selected,menu,closeSideBar,allowMenuHide,icon,sx}) {
     const onClick= (menuItem) => {
         const newMenuItems= menu.menuItems.map( (mi) => mi===menuItem ? {...mi, visible:true} : mi);
         updateMenu(appTitle, {...menu, menuItems:newMenuItems});
-        menuHandleAction(menuItem);
+        onClickHandler(menuItem.clickHandler, menuItem);
         closeSideBar();
     };
 

--- a/src/firefly/js/ui/MultiSearchPanel.jsx
+++ b/src/firefly/js/ui/MultiSearchPanel.jsx
@@ -65,9 +65,9 @@ const getComponentAry= once(() => {
         .filter( (c) => c);
 } );
 
-const getDefTabIdx= once((initArgs) => getTabIdx(initArgs));
+const getDefTabId= once((initArgs) => getTabId(initArgs));
 
-function getTabIdx(args) {
+function getTabId(args) {
     return args.defaultSelectedId;
 }
 
@@ -88,7 +88,7 @@ export function MultiSearchPanel({initArgs={}}) {
             <Typography level='h4'>
                 Table Search
             </Typography>
-            <StatefulTabs componentKey='MultiCatalogTabs' defaultSelected={getDefTabIdx(initArgs)}>
+            <StatefulTabs componentKey='MultiCatalogTabs' defaultSelected={getDefTabId(initArgs)}>
                 {getComponentAry().map( ({id, title,tip,Component}) => (
                     <Tab name={tip} id={id} key={id} label={title}>
                         <Component initArgs={initArgs}/>

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -7,13 +7,13 @@ import PropTypes from 'prop-types';
 import {Sheet, Stack, Tooltip, Typography, Button, ToggleButtonGroup} from '@mui/joy';
 import {set} from 'lodash';
 
-import {dispatchUpdateAppData} from '../core/AppDataCntlr.js';
-import {getSearchInfo} from '../core/AppDataCntlr.js';
+import {dispatchUpdateAppData, getSearchInfo} from '../core/AppDataCntlr.js';
 import {FormPanel} from './FormPanel.jsx';
 import {useStoreConnector} from './SimpleComponent.jsx';
 import {StatefulTabs, Tab} from './panel/TabPanel.jsx';
 import {makeSearchOnce} from '../util/WebUtil';
 import {useNavigate, useInRouterContext} from 'react-router-dom';
+import {dispatchShowDropDown} from 'firefly/core/LayoutCntlr.js';
 
 const changeSearchOptionOnce= makeSearchOnce(); // setup options to immediately execute the search the first time
 
@@ -31,7 +31,7 @@ export function SearchPanel({style={}, initArgs={}}) {
             callId);
     });
 
-    const isSingleSearch = Object.keys(allSearchItems).length === 1;
+    const isSingleSearch = Object.keys(allSearchItems).length === 1 || flow === 'hidden';
     if (isSingleSearch) {
         return (
             <Stack id='search-vertical' flexGrow={1}>
@@ -73,6 +73,13 @@ SearchPanel.propTypes = {
     style:  PropTypes.object,
     initArgs: PropTypes.object
 };
+
+export function searchClickHandler(menuItem) {
+    dispatchShowDropDown( {view: 'Search', action: menuItem.action});
+    dispatchUpdateAppData({searches: {activeSearch: menuItem.action}});
+}
+
+
 
 function searchesAsTabs(allSearchItems, initArgs) {
     return allSearchItems &&

--- a/src/firefly/js/ui/Stacker.jsx
+++ b/src/firefly/js/ui/Stacker.jsx
@@ -1,31 +1,34 @@
 import {Sheet, Stack} from '@mui/joy';
 import React from 'react';
-import {node, shape, object, number, string} from 'prop-types';
+import {node, shape, object, number, string, oneOf} from 'prop-types';
 
 /*
  * A convenience component built around Sheet and Stack to provide a <start main end> layout
  * with support for variant and color.  Use slopProps to customize
  */
-export function Stacker({variant, color, endDecorator, startDecorator, gap=1, slotProps, children, ...props}) {
+export function Stacker({variant, color, orientation='horizontal', endDecorator, startDecorator, gap=1, slotProps, children, ...props}) {
 
+    const component = (variant || color) && Sheet;
+    const dir = orientation === 'horizontal' ? 'row' : 'column';
     return (
-        <Sheet variant={variant} color={color} component={Stack}
-               direction='row' justifyContent='space-between' alignItems='center' spacing={gap}
+        <Stack variant={variant} color={color} component={component}
+               direction={dir} spacing={gap}
                {...slotProps?.root}>
 
             {startDecorator}
-            <Stack spacing={1} direction='row' alignItems='center' flexGrow={1} {...props}>
+            <Stack spacing={1} direction={dir} flexGrow={1} {...props}>
                 {children}
             </Stack>
             {endDecorator}
 
-        </Sheet>
+        </Stack>
     );
 }
 
 Stacker.propTypes = {
     variant: string,
     color: string,
+    orientation: oneOf(['horizontal', 'vertical']),
     endDecorator: node,
     startDecorator: node,
     gap: number,            // spacing between decorators and the main child

--- a/src/firefly/js/ui/ThemeSetup.js
+++ b/src/firefly/js/ui/ThemeSetup.js
@@ -52,6 +52,7 @@ export function defaultTheme() {
             },
             JoyTooltip: {
                 defaultProps: {
+                    disableInteractive: true,
                     variant:'soft',
                     enterDelay:1500,
                     placement: 'bottom-start',

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -868,3 +868,12 @@ export async function lowLevelDoFetch(url, options, doValidation, loggerFunc) {
     else if (response.status === 401) throw new Error('You are no longer logged in');
     else throw new Error(`Request failed with status ${response.status}: ${url}`);
 }
+
+/*
+  Works like lodash set.  However, it will only set if predicate returns true
+  predicate is invoked with the current value at the path.  Defaults to isUndefined
+ */
+export function setIf(object, path, value, predicate=isUndefined) {
+    const cv = get(object, path);
+    if (predicate?.(cv)) set(object, path, value);
+}

--- a/src/firefly/js/visualize/ui/FitsHeaderView.jsx
+++ b/src/firefly/js/visualize/ui/FitsHeaderView.jsx
@@ -153,7 +153,7 @@ function showFitsHeaderPopup(plot, fitsHeaderInfo, element, initLeft, initTop, o
 
 // update table sort when table tab is changed
 const onBandSelected = (fitsHeaderInfo) => {
-    return (index, id, name) => {
+    return (name) => {
         const tableModel = fitsHeaderInfo[name];
         if (tableModel) updateTableSort(tableModel);   // already in store, then sort it if needed
     };

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -47,7 +47,7 @@ export function TriViewImageSection({showCoverage=false, showFits=false,
     if (imageExpandedMode) {
         return  ( <ImageExpandedMode key='results-plots-expanded' closeFunc={closeable ? closeExpanded : null}/> );
     }
-    const onTabSelect = (idx, id) => dispatchUpdateLayoutInfo({images:{selectedTab:id}});
+    const onTabSelect = (id) => dispatchUpdateLayoutInfo({images:{selectedTab:id}});
 
     const key= (showCoverage&&coverageSide==='LEFT') +'--'+ showFits +'--' + showMeta;
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1427
More changes here: 
https://github.com/IPAC-SW/irsa-ife/pull/311
https://github.com/lsst/suit/pull/51

Provide option for HydraViewer apps to use Menu instead of search panel.
- To enable, call dispatchLoadSearches with renderAsMenuItems=true.
- Add 'primary: true|false’ to SearchItem; this is then passed to MenuItem.


**Also:**
- Fix TabPanel's inconsistent usage of onTabSelect.

- Add slots/slotProps to the application-level component, e.g., FireflyLayout. The three slots are: drawer, banner, and dropdown. 
  - Maybe we should move landingPage into a slot as well, but not in this PR.

- Add meaningful slots to Banner. This makes it cleaner and more robust.

- Moved and cleaned up many app-level props, e.g., banner*Style, enableVersionDialog, showTitleOnBanner, drawerComponent.

- Fix appTitle so that it is now only a string. Replace TimeSeries usage with slotProps.banner.title, where it can be any renderable type.

- Made a small change to LandingPage after a discussion with Jaladh.

- Changes to HydraViewer to support many irsa-ui apps:

  - Apply banner/icon styling to support the new JoyUI banner.
  - Apply a fix to our non-theme-aware icons.
  - Customize EmptyResultSection.

**irsa-ui apps:**

Apply a generic fix to all of its appIcons and use a special fix for FinderChart.
Using WISE as an example, customize EmptyResults and render searches as menu items.

**Utility added:**

`setIf`: Deep set a value but only if the predicate returns true. Defaults to `isUndefined` to set only if it has not been set.
`<Slot/>`: A wrapper/renderer component that interprets/enforces our usage of slotProps.

Test for Firefly and Slate: 
https://fireflydev.ipac.caltech.edu/firefly-1427-search-panel-sidebar/firefly/

For SUIT:
https://firefly-1427-search-panel-sidebar.irsakudev.ipac.caltech.edu/suit/

For irsaviewer, finderchart, sofia, ztf, SHA, and WISE, go here then follow links:
https://firefly-1427-search-panel-sidebar.irsakudev.ipac.caltech.edu/

Because many core files were touched, we need regression testing.  
For irsa-ui apps, check to see that landing page is added and icons appeared okay in light and dark mode.
WISE is the only one where SearchPanel were replaced with sidebar MenuI items.  Use it to see how the flow is like if converted.

