### PR TITLE
Wise hotfix allow null ObsDate string

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
@@ -187,11 +187,17 @@ public class QueryMOS extends EmbeddedDbProcessor {
         return new URL(url);
     }
 
+    //Add check for empty date string
     private static String getObsDate(String obsDateParam) {
         try {
-            DateUtils.parseDate(obsDateParam, new String[]{"yyyy-MM-dd", "yyyy-MM-dd hh:mm:ss", "yyyy-MM-dd'T'hh:mm:ssX"});     // check for valid dates
-            return obsDateParam.replaceAll("[^0-9:-]", " ").trim();   // convert to format expected by MOST
-        } catch (ParseException e) {
+                if (StringUtils.isEmpty(obsDateParam)) {
+                return obsDateParam = null;
+            } else {
+                DateUtils.parseDate(obsDateParam, new String[]{"yyyy-MM-dd", "yyyy-MM-dd hh:mm:ss", "yyyy-MM-dd'T'hh:mm:ssX"});     // check for valid dates
+                return obsDateParam.replaceAll("[^0-9:-]", " ").trim();   // convert to format expected by MOST
+            }
+        }
+         catch (ParseException e) {
             return null;
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
@@ -187,17 +187,12 @@ public class QueryMOS extends EmbeddedDbProcessor {
         return new URL(url);
     }
 
-    //Add check for empty date string and allow null string for obsDateParam
+    //Using catch Exception including the empty ObsDate
     private static String getObsDate(String obsDateParam) {
         try {
-                if (StringUtils.isEmpty(obsDateParam)) {
-                    return null;
-            } else {
-                DateUtils.parseDate(obsDateParam, new String[]{"yyyy-MM-dd", "yyyy-MM-dd hh:mm:ss", "yyyy-MM-dd'T'hh:mm:ssX"});     // check for valid dates
-                return obsDateParam.replaceAll("[^0-9:-]", " ").trim();   // convert to format expected by MOST
-            }
-        }
-         catch (ParseException e) {
+            DateUtils.parseDate(obsDateParam, new String[]{"yyyy-MM-dd", "yyyy-MM-dd hh:mm:ss", "yyyy-MM-dd'T'hh:mm:ssX"});     // check for valid dates
+            return obsDateParam.replaceAll("[^0-9:-]", " ").trim();   // convert to format expected by MOST
+        } catch (Exception e) {
             return null;
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
@@ -191,7 +191,7 @@ public class QueryMOS extends EmbeddedDbProcessor {
     private static String getObsDate(String obsDateParam) {
         try {
                 if (StringUtils.isEmpty(obsDateParam)) {
-                return obsDateParam = null;
+                    return null;
             } else {
                 DateUtils.parseDate(obsDateParam, new String[]{"yyyy-MM-dd", "yyyy-MM-dd hh:mm:ss", "yyyy-MM-dd'T'hh:mm:ssX"});     // check for valid dates
                 return obsDateParam.replaceAll("[^0-9:-]", " ").trim();   // convert to format expected by MOST

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
@@ -187,7 +187,7 @@ public class QueryMOS extends EmbeddedDbProcessor {
         return new URL(url);
     }
 
-    //Add check for empty date string
+    //Add check for empty date string and allow null string for obsDateParam
     private static String getObsDate(String obsDateParam) {
         try {
                 if (StringUtils.isEmpty(obsDateParam)) {


### PR DESCRIPTION
Fix WISE MOS search. Allow blank ObsDate for MOS time range. 
To test enter a moving object, leave observation time range blank:
https://wise-fix.irsakudev.ipac.caltech.edu/applications/wise/