### PR TITLE
FIREFLY-1449: Fix 2 pushpin in DCE and other chart bugs

### DIFF
--- a/src/firefly/js/charts/ui/ChartsContainer.jsx
+++ b/src/firefly/js/charts/ui/ChartsContainer.jsx
@@ -148,7 +148,7 @@ export const ActiveChartsPanel = (props) => {
 
         if (!useOnlyChartsInViewer) {
             return watchTblGroup(viewerId, tbl_group, addDefaultChart, useOnlyChartsInViewer);
-        };
+        }
 
     }, [tbl_group, viewerId, chartId, useOnlyChartsInViewer]);
 
@@ -182,7 +182,8 @@ export const ActiveChartsPanel = (props) => {
                     viewerId,
                     tbl_group,
                     expandedMode,
-                    noChartToolbar}}
+                    noChartToolbar,
+                    showAddChart: true}}
                 />
             );
     }

--- a/src/firefly/js/charts/ui/MultiChartToolbar.jsx
+++ b/src/firefly/js/charts/ui/MultiChartToolbar.jsx
@@ -19,7 +19,7 @@ import {closeExpandedChart} from 'firefly/charts/ui/ChartsContainer.jsx';
 import {AddBtn} from './PlotlyToolbar.jsx';
 
 
-export function MultiChartToolbarStandard({viewerId, chartId, tbl_group, expandable, expandedMode,
+export function MultiChartToolbarStandard({viewerId, chartId, tbl_group, expandable, expandedMode, showAddChart,
     layoutType=getLayoutType(getMultiViewRoot(), viewerId),
     activeItemId=getViewer(getMultiViewRoot(), viewerId).customData.activeItemId}) {
 
@@ -28,7 +28,7 @@ export function MultiChartToolbarStandard({viewerId, chartId, tbl_group, expanda
     return (
         <Stack direction='row' justifyContent='space-between'>
             <Stack direction='row' spacing={3}>
-                {!jsApi && <AddBtn/>}
+                {!jsApi && showAddChart && <AddBtn/>}
                 <MultiChartStd {...{viewerId, layoutType, activeItemId}}/>
             </Stack>
             <ChartToolbar {...{chartId, tbl_group, viewerId, expandable, expandedMode}}/>
@@ -43,11 +43,13 @@ MultiChartToolbarStandard.propTypes= {
     chartId: PropTypes.string.isRequired,
     tbl_group: PropTypes.string,
     expandable: PropTypes.bool,
-    expandedMode: PropTypes.bool
+    expandedMode: PropTypes.bool,
+    showAddChart: PropTypes.bool
 };
 
 
-export function MultiChartToolbarExpanded({viewerId, chartId, tbl_group, expandable, expandedMode, closeable, layoutType, activeItemId}) {
+export function MultiChartToolbarExpanded({viewerId, chartId, tbl_group, expandable, expandedMode, closeable,
+                                              layoutType, activeItemId, showAddChart}) {
 
     const {jsApi=false}= useContext(AppPropertiesCtx);
     layoutType = layoutType || getLayoutType(getMultiViewRoot(), viewerId);
@@ -57,7 +59,7 @@ export function MultiChartToolbarExpanded({viewerId, chartId, tbl_group, expanda
         <Stack direction='row' justifyContent='space-between' alignItems='center'>
             {closeable && <CloseButton onClick={() => closeExpandedChart(viewerId)}/>}
             <Stack direction='row' spacing={3}>
-                {!jsApi && <AddBtn/>}
+                {!jsApi && showAddChart && <AddBtn/>}
                 <MultiChartExt {...{viewerId, layoutType, activeItemId}}/>
             </Stack>
             <ChartToolbar {...{chartId, tbl_group, expandable, expandedMode, viewerId}}/>
@@ -74,7 +76,8 @@ MultiChartToolbarExpanded.propTypes= {
     chartId: PropTypes.string.isRequired,
     expandable: PropTypes.bool,
     expandedMode: PropTypes.bool,
-    closeable: PropTypes.bool
+    closeable: PropTypes.bool,
+    showAddChart: PropTypes.bool
 };
 
 const MultiChartStd = ({viewerId, layoutType, activeItemId}) => {

--- a/src/firefly/js/charts/ui/MultiChartViewer.jsx
+++ b/src/firefly/js/charts/ui/MultiChartViewer.jsx
@@ -86,7 +86,7 @@ export class MultiChartViewer extends PureComponent {
     }
 
     render() {
-        const {viewerId, expandedMode, closeable, noChartToolbar, label, autoRowOriented=true} = this.props;
+        const {viewerId, expandedMode, closeable, noChartToolbar, label, showAddChart=false} = this.props;
         const {viewer}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId);
         if (!viewer || isEmpty(viewer.itemIdAry)) {
@@ -160,7 +160,8 @@ export class MultiChartViewer extends PureComponent {
                             closeable,
                             viewerId,
                             layoutType,
-                            activeItemId
+                            activeItemId,
+                            showAddChart
                         }}/>
                         <Divider orientation='horizontal'/>
                     </>
@@ -185,6 +186,6 @@ MultiChartViewer.propTypes= {
     insideFlex : PropTypes.bool,
     closeable : PropTypes.bool,
     expandedMode: PropTypes.bool,
-    noChartToolbar: PropTypes.bool
-
+    noChartToolbar: PropTypes.bool,
+    showAddChart: PropTypes.bool
 };

--- a/src/firefly/js/charts/ui/PinnedChartContainer.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartContainer.jsx
@@ -124,10 +124,12 @@ const Help = () => <HelpIcon helpId={'chartarea.info'} style={{marginLeft:10}}/>
 
 export const PinChart = ({viewerId, tbl_group}) => {
 
-    if (viewerId === PINNED_VIEWER_ID) return null;
+    // don't show pin chart button in pinned chart panel
+    // and in data product viewer because pinning functionality requires chart data table to persist in store
+    if (viewerId === PINNED_VIEWER_ID || viewerId.startsWith('DPC')) return null;
 
     const doPinChart = () => {
-        let chartId = getActiveViewerItemId(viewerId);      // viewerId is Active Charts viewer
+        let chartId = getActiveViewerItemId(viewerId, true);      // viewerId is Active Charts viewer
         if (!chartId) {
             const tblId = getActiveTableId(tbl_group);
             chartId = getChartIdsInGroup(tblId)?.[0] ?? getChartIdsInGroup('default')?.[0];

--- a/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
+++ b/src/firefly/js/charts/ui/options/HeatmapOptions.jsx
@@ -10,15 +10,12 @@ import {ValidationField} from '../../../ui/ValidationField.jsx';
 import {ListBoxInputField} from '../../../ui/ListBoxInputField.jsx';
 import {CheckboxGroupInputField} from '../../../ui/CheckboxGroupInputField.jsx';
 import {useStoreConnector} from '../../../ui/SimpleComponent.jsx';
-import {LayoutOptions, basicFieldReducer, submitChanges, basicOptions} from './BasicOptions.jsx';
+import {basicFieldReducer, basicOptions, LayoutOptions, submitChanges} from './BasicOptions.jsx';
 import {getColValStats} from '../../TableStatsCntlr.js';
 import {ColumnOrExpression} from '../ColumnOrExpression.jsx';
 import {ALL_COLORSCALE_NAMES, PlotlyCS} from '../../Colorscale.js';
 import {getChartProps} from '../../ChartUtil.js';
-import {
-    CollapsibleGroup,
-    FieldGroupCollapsibleItem
-} from '../../../ui/panel/CollapsiblePanel.jsx';
+import {CollapsibleGroup, FieldGroupCollapsibleItem} from '../../../ui/panel/CollapsiblePanel.jsx';
 import {Stack, Typography} from '@mui/joy';
 
 
@@ -65,11 +62,9 @@ export function fieldReducer({chartId, activeTrace}) {
     const basicReducer = basicFieldReducer({chartId, activeTrace});
 
     const getFields = () => {
-        const {data, fireflyData, tablesources = {}} = getChartData(chartId);
-        const tablesourceMappings = tablesources?.[activeTrace]?.mappings;
+        const {data, fireflyData} = getChartData(chartId);
 
-        const fields = {
-
+        return {
             [`fireflyData.${activeTrace}.nbins.x`]: {
                 fieldKey: `fireflyData.${activeTrace}.nbins.x`,
                 value: get(fireflyData, `${activeTrace}.nbins.x`),
@@ -98,21 +93,6 @@ export function fieldReducer({chartId, activeTrace}) {
             },
             ...basicReducer(null)
         };
-        const tblRelFields = {
-            [`_tables.data.${activeTrace}.x`]: {
-                fieldKey: `_tables.data.${activeTrace}.x`,
-                value: get(tablesourceMappings, 'x', ''),
-                //tooltip: 'X axis',
-                label: 'X:'
-            },
-            [`_tables.data.${activeTrace}.y`]: {
-                fieldKey: `_tables.data.${activeTrace}.y`,
-                value: get(tablesourceMappings, 'y', ''),
-                //tooltip: 'Y axis',
-                label: 'Y:'
-            }
-        };
-        return tablesourceMappings? Object.assign({}, fields, tblRelFields) : fields;
     };
     return (inFields, action) => {
         if (!inFields) {
@@ -129,8 +109,11 @@ export function TableSourcesOptions({tablesource={}, activeTrace, groupKey, char
     // _tables.  is prefixed the fieldKey.  it will be replaced with 'tables::val' on submitChanges.
     const tbl_id = get(tablesource, 'tbl_id');
     const colValStats = getColValStats(tbl_id);
+
     const xyProps = (xOrY) => ({fldPath:`_tables.data.${activeTrace}.${xOrY}`, label: `${xOrY.toUpperCase()}:`,
-        name: xOrY.toUpperCase(), nullAllowed: false, colValStats, groupKey, slotProps: {control: {orientation}}});
+        name: xOrY.toUpperCase(), nullAllowed: false, colValStats, groupKey, slotProps: {control: {orientation}},
+        initValue: tablesource?.mappings?.[xOrY] ?? ''
+    });
 
     const {setVal} = useContext(FieldGroupCtx);
 


### PR DESCRIPTION
Fixes [FIREFLY-1449](https://jira.ipac.caltech.edu/browse/FIREFLY-1449)

- Made PinChart to not show up when viewer is Data Product Viewer 
   - because current pinning functionality is designed to handle only charts that have their data tables in store (DP viewer's chart data gets replaced each time row is changed). To pin chart shown in DP Viewer, first pin its table and then from active charts, pin it.
   - this was also a bug in ops and the two pin buttons should have never existed until chart pinning can handle DP viewer - @lrebull agrees to remove it
- Exposed showAddChart as a prop in MultiChartViewer and set it false by default, and true only for ActiveChartsPanel
- Moved x, y mappings from first call of reducer to initial state of components to prevent it setting x, y axes options as undefined.

## Testing 
https://firefly-1449-2pins-chart-bugs.irsakudev.ipac.caltech.edu/irsaviewer/

- Follow the steps in ticket, check that pushpin only appears next to table|spectrum, and not in chart toolbar
- Check toolbars of Data Product Viewer, Pinned Chart Viewer, there shouldn't be "add chart" icon button present there. It should only be present in Active Chart Viewer
- Catalogs -> m81, 3600 arcsec -> active chart -> heatmap options (gear icon) -> chart options expand -> x and y axes title should be prefilled. Also change any field there, apply -> close -> reopen, the entries should persist.