### PR TITLE
FIREFLY-1396: Display overflow indicator when present in VOTable.

### DIFF
--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -9,7 +9,8 @@ import {dispatchShowDialog} from '../ComponentCntlr.js';
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
 import {CollapsiblePanel} from 'firefly/ui/panel/CollapsiblePanel.jsx';
 import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson.js';
-import {Button} from '@mui/joy';
+import {Button, Stack} from '@mui/joy';
+import {OverflowMarker} from 'firefly/tables/ui/TablePanel.jsx';
 
 
 export function showJobInfo(jobId) {
@@ -58,7 +59,7 @@ export async function showUwsJob({jobUrl, jobId}) {
 }
 
 
-export function JobInfo({jobId, style}) {
+export function JobInfo({jobId, style, tbl_id}) {
     const {phase, startTime, endTime, results, errorSummary, jobInfo={}} = useStoreConnector(() => getJobInfo(jobId) || {});
     const {dataOrigin, summary, type} = jobInfo;
     return (
@@ -68,7 +69,7 @@ export function JobInfo({jobId, style}) {
                 <KeywordBlock label='Start Time' value={startTime}/>
                 {endTime && <KeywordBlock label='End Time' value={endTime}/>}
                 <DataOrigin {...{dataOrigin, type, jobId}}/>
-                <FinalMsg {...{phase, results, errorSummary, summary}}/>
+                <FinalMsg {...{phase, results, errorSummary, summary, tbl_id}}/>
                 <KeywordBlock label='ID' value={jobId} title='Internal query identifier, usable for diagnostics'/>
             </div>
         </div>
@@ -88,9 +89,14 @@ function DataOrigin({dataOrigin, type, jobId}) {
     );
 }
 
-function FinalMsg({phase, summary, error}) {
+function FinalMsg({phase, summary, error, tbl_id}) {
     if (phase === 'COMPLETED') {
-        return <KeywordBlock label='Summary' value={summary}/>;
+        return (
+            <Stack direction='row' spacing={1} alignItems='center'>
+                <KeywordBlock label='Summary' value={summary}/>
+                <OverflowMarker tbl_id={tbl_id}/>
+            </Stack>
+        );
     } else if(phase === 'ERROR') {
         return <KeywordBlock label='Error' value={error}/>;
     } else return null;

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1493,6 +1493,15 @@ export function parseError(error) {
     }
 }
 
+export function isOverflow(tbl_id) {
+    const {resources, tableMeta} = getTblById(tbl_id) || {};
+
+    if (tableMeta?.QUERY_STATUS?.toUpperCase() === 'OVERFLOW') return true;
+
+    const results = resources?.find((r) => r.type === 'results');
+    return !!results?.params?.find((p) => p.QUERY_STATUS === 'OVERFLOW');
+}
+
 /*-------------------------------------private------------------------------------------------*/
 
 /**

--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -19,7 +19,6 @@
  * @typedef {object} TableModel
  * @prop {string}   tbl_id    unique ID of this table.
  * @prop {string}   title     title, used on label.
- * @prop {Object} resources votable resources
  * @prop {TableRequest} request  the request used to create this table
  * @prop {TableKeywords} keywords  a list of all meta from the original source, including comments and duplicates
  * @prop {TableMeta} tableMeta     additional meta added and keywords as key/value pair.  comments and duplicates are no longer here.

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -27,7 +27,7 @@ export function TableInfo({tbl_id, tabsProps, ...props}) {
             <StatefulTabs componentKey='TablePanelOptions' {...tabsProps} sx={{overflow:'auto'}}>
                 {jobId &&
                 <Tab name='Job Info'>
-                    <JobInfo jobId={jobId}/>
+                    <JobInfo jobId={jobId} tbl_id={tbl_id}/>
                 </Tab>
                 }
                 <Tab name='Table Metadata'>

--- a/src/firefly/js/ui/PagingBar.jsx
+++ b/src/firefly/js/ui/PagingBar.jsx
@@ -31,7 +31,7 @@ export function PagingBar(props) {
 
     const pagestr = (totalRows === 0) ? '' :
                     `(${(startIdx+1).toLocaleString()} - ${endIdx.toLocaleString()} of ${totalRows?.toLocaleString()??''})`;
-    const showingLabel = (  <Typography level='body-sm' noWrap lineHeight={2}>{pagestr}</Typography> );
+    const showingLabel = (  <Typography level='body-sm' noWrap lineHeight={1}>{pagestr}</Typography> );
     if (showAll) {
         return showingLabel;
     } else {

--- a/src/firefly/js/ui/Stacker.jsx
+++ b/src/firefly/js/ui/Stacker.jsx
@@ -12,7 +12,7 @@ export function Stacker({variant, color, orientation='horizontal', endDecorator,
     const dir = orientation === 'horizontal' ? 'row' : 'column';
     return (
         <Stack variant={variant} color={color} component={component}
-               direction={dir} spacing={gap}
+               direction={dir} spacing={gap} alignItems='center'
                {...slotProps?.root}>
 
             {startDecorator}


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1396

Although ticket said 'TAP', it can be applied to any VOTABLE with a QUERY_STATUS of OVERFLOW.

Test: https://fireflydev.ipac.caltech.edu/firefly-1396-votable-overflow/firefly/demo/table-api.html
Since there aren't any services providing this status, use this test page to mimic its return. 
Include this JSON value in the META_INFO field.
```json
{
"QUERY_STATUS" : "OVERFLOW",
"backgroundable": true
}
```
Or, edit a VOTABLE with this status, then upload.