### PR TITLE
Firefly-1448 & Firefly-1462: multiple fixes

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
@@ -115,6 +115,11 @@ public class AnyFileUpload extends BaseHttpServlet {
             FileInfo statusFileInfo= result.statusFileInfo;
             int responseCode= statusFileInfo.getResponseCode();
 
+            if (responseCode>=400) {
+                res.sendError(statusFileInfo.getResponseCode(), statusFileInfo.getResponseCodeMsg());
+                return;
+            }
+
             if (FileUtil.isGZipFile(uploadFileInfo.getFile())) {
                 File f= uploadFileInfo.getFile();
                 String name= f.getName()+".gz";

--- a/src/firefly/java/edu/caltech/ipac/util/download/ResponseMessage.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/ResponseMessage.java
@@ -62,6 +62,7 @@ public class ResponseMessage {
             case 422 -> "Unprocessable Entity";
             case 423 -> "Locked";
             case 424 -> "Failed Dependency";
+            case 495 -> "SSL Certificate Error";
             case 500 -> "Internal Server Error";
             case 501 -> "Not Implemented";
             case 502 -> "Bad Gateway";

--- a/src/firefly/js/tables/SelectInfo.js
+++ b/src/firefly/js/tables/SelectInfo.js
@@ -112,10 +112,10 @@ export class SelectInfo {
     /**
      * Destructing of the SelectInfo's data.
      * @param {Object}  p
-     * @param {number}  p.rowCount   IMPORTANT!!. Total number of rows in the table. defaults to zero.
-     * @param {boolean} p.selectAll boolean. Indicates selectAll mode. defaults to false.
-     * @param {Set}     p.exceptions    A set of exceptions based on selectAll mode.
-     * @param {number} offset     All indices passed into this class's funtion will be offsetted by this given value.
+     * @param {number} p.rowCount   IMPORTANT!!. Total number of rows in the table. defaults to zero.
+     * @param {boolean} [p.selectAll] Indicates selectAll mode. defaults to false.
+     * @param {Set}     [p.exceptions] A set of exceptions based on selectAll mode.
+     * @param {number} [offset]     All indices passed into this class's function will be offsetted by this given value.
      * @returns {SelectInfo}
      */
     static newInstance({selectAll=false, exceptions=(new Set()), rowCount=0}={}, offset) {

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -841,7 +841,7 @@ export function processRequest(tableModel, tableRequest, hlRowIdx) {
 /**
  * collects all available table information given the tbl_id
  * @param {string} tbl_id
- * @param {number} aPageSize  use this pageSize instead of the one in the request.
+ * @param {number} [aPageSize]  use this pageSize instead of the one in the request.
  * @returns {{tableModel, tbl_id, title, totalRows, request, startIdx, endIdx, hlRowIdx, currentPage, pageSize, totalPages, highlightedRow, selectInfo, error, tableMeta, backgroundable}}
  * @public
  * @memberof firefly.util.table

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -10,7 +10,7 @@ import {getAppOptions, getSearchActions} from '../../core/AppDataCntlr.js';
 import {ActionsDropDownButton, isTableActionsDropVisible} from '../../ui/ActionsDropDownButton.jsx';
 
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
-import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
+import {ToolbarButton, ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
 import {ExpandButton, InfoButton, SaveButton, FilterButton, ClearFilterButton, TextViewButton, TableViewButton, SettingsButton, PropertySheetButton} from '../../visualize/ui/Buttons.jsx';
 import {dispatchTableRemove, dispatchTblExpanded, dispatchTableFetch, dispatchTableAddLocal, dispatchTableUiUpdate} from '../TablesCntlr.js';
 import {
@@ -372,11 +372,11 @@ function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons}) {
 
         const doclink = (
             <Stack direction='row' key={`doclink-${tbl_id}`}>
-                {leftButtons?.length && <Divider orientation='vertical'/>}
+                {leftButtons?.length && <ToolbarHorizontalSeparator/>}
                 <a href={doclinkUrl} target='doclink' title={doclinkDesc} key={doclinkUrl} style={{ textDecoration: 'none'}}>
                     <ToolbarButton text={doclinkLabel}/>
                 </a>
-                <Divider orientation='vertical'/>
+                <ToolbarHorizontalSeparator/>
             </Stack>
         );
         if (leftButtons) {

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -2,11 +2,11 @@ import React from 'react';
 import {cloneDeep, once} from 'lodash';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
 import {dispatchAddTableTypeWatcherDef} from '../../core/MasterSaga.js';
-import {dispatchTableUiUpdate} from '../../tables/TablesCntlr.js';
+import {dispatchTableUiUpdate, TABLE_LOADED} from '../../tables/TablesCntlr.js';
 import {getActiveTableId, getMetaEntry, getTableUiByTblId, getTblById} from '../../tables/TableUtil.js';
 import {DownloadButton, DownloadOptionPanel} from '../../ui/DownloadDialog.jsx';
 import {getTapObsCoreOptions, getTapObsCoreOptionsGuess} from '../../ui/tap/TableSearchHelpers.jsx';
-import {isObsCoreLike} from '../../voAnalyzer/TableAnalysis.js';
+import {hasObsCoreLikeDataProducts, isObsCoreLikeWithProducts} from '../../voAnalyzer/TableAnalysis.js';
 import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
 import {getActiveRowCenterDef } from '../../visualize/saga/ActiveRowCenterWatcher.js';
@@ -35,13 +35,18 @@ export function startTTFeatureWatchers(startIds=[
 export const getObsCoreWatcherDef= once(() => ({
     id : 'ObsCorePackage',
     watcher : watchForObsCoreTable,
-    testTable : isObsCoreLike,
-    actions: []
+    testTable : hasObsCoreLikeDataProducts,
+    actions: [TABLE_LOADED]
 }));
+
+
+const addedTblIds=[];
 
 function watchForObsCoreTable(tbl_id, action, cancelSelf) {
     if (action) return;
+    if (addedTblIds.includes(tbl_id)) return;
     setupObsCorePackaging(tbl_id);
+    addedTblIds.push(tbl_id);
     cancelSelf();
 }
 

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -2,6 +2,7 @@ import {Button, CircularProgress, Input, Stack, Tooltip, Typography} from '@mui/
 import React, {memo, useEffect} from 'react';
 import {object, bool, func, number, string, shape} from 'prop-types';
 import {has, isFunction, isNil, isString} from 'lodash';
+import {getStatusFromFetchError} from '../util/WebUtil.js';
 import {InputFieldView} from './InputFieldView.jsx';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 import {upload} from '../rpc/CoreServices.js';
@@ -186,13 +187,15 @@ function makeDoUpload(file, type, isFromURL, fileAnalysis) {
                     }
                 }
             }
+            else {
+                throw new Error(isFromURL ?
+                                        `Unable to upload file from ${file}, status ${status}` :
+                                        `Unable to upload file: ${file?.name}`);
+            }
 
             return {isLoading: false, valid, message, value: cacheKey, analysisResult};
-        }).catch(() => {
-            return {isLoading: false, valid: false,
-                    message: (isFromURL ?
-                        `Unable to upload file from ${file}` :
-                        `Unable to upload file: ${file?.name}`)};
+        }).catch((e) => {
+            return {isLoading: false, valid: false, message: e.message};
         });
     };
 }
@@ -207,7 +210,8 @@ function doUpload(fileOrUrl, fileAnalysis, params={}) {
             faFunction && faFunction?.(false);
             return results;
         })
-        .catch(() => {
+        .catch((e) => {
             faFunction && faFunction?.(false);
+            return {status:getStatusFromFetchError(e.message),message:e.message};
         });
 }

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -57,7 +57,7 @@ function makeImage(icon,style={},className='') {
  */
 export const ToolbarButton = forwardRef((props,fRef) => {
     const {
-        icon,text='',badgeCount=0,enabled=true, visible=true,
+        icon,text='',badgeCount=0,badgeAlert=false, enabled=true, visible=true,
         imageStyle={}, iconButtonSize, shortcutKey='', color='neutral', variant='plain',
         disableHiding, active, sx, CheckboxOnIcon, CheckboxOffIcon, value,
         useDropDownIndicator= false, hasCheckBox=false, checkBoxOn=false, pressed=false,
@@ -159,7 +159,9 @@ export const ToolbarButton = forwardRef((props,fRef) => {
         </Tooltip>
     );
 
-    return !badgeCount ? b : <Badge {...{badgeContent:badgeCount, sx:{'& .MuiBadge-badge': {top:'.7rem', right:'.4rem'}}}}> {b} </Badge>;
+    return (!badgeCount&&!badgeAlert) ? b : <Badge {...{badgeContent:badgeAlert?'!':badgeCount,
+        color:badgeAlert?'danger':undefined,
+        sx:{'& .MuiBadge-badge': {top:'.7rem', right:'.4rem'}}}}> {b} </Badge>;
 } );
 
 ToolbarButton.propTypes= {
@@ -255,8 +257,8 @@ function makeTextLabel(text,shortcutKey) {
 }
 
 
-export function ToolbarHorizontalSeparator({ style={}}) {
-    return <Divider orientation='vertical' style={style} sx={{mx:1}}/>;
+export function ToolbarHorizontalSeparator() {
+    return <Divider orientation='vertical' style={style} sx={{mx:1,my:1/2}}/>;
 }
 ToolbarHorizontalSeparator.propTypes= { style:object, top : number };
 

--- a/src/firefly/js/ui/tap/ObjectIDSearch.jsx
+++ b/src/firefly/js/ui/tap/ObjectIDSearch.jsx
@@ -1,4 +1,4 @@
-import {Chip, Link, Stack, Typography} from '@mui/joy';
+import {Box, Chip, Link, Stack, Typography} from '@mui/joy';
 import React, {useContext, useEffect, useState} from 'react';
 import {FieldGroupCtx} from 'firefly/ui/FieldGroup';
 import {ConstraintContext} from 'firefly/ui/tap/Constraints';
@@ -302,14 +302,14 @@ function UploadTableSelectorObjectID({uploadInfo, setUploadInfo, setSelectInObjL
 function ObjectIDCol({objectCol, style={},cols, objectKey, openKey,
                            headerTitle, headerPostTitle = '', openPreMessage='', headerStyle,colTblId=null}) {
     const posHeader= (
-        <div style={{marginLeft:-8}}>
-            <span style={{fontWeight:'bold', ...headerStyle}}>
+        <Box ml={-1}>
+            <Typography display='inline' color={!objectCol?'warning':undefined} level='title-md' style={{...headerStyle}}>
                 {(objectCol) ? `${objectCol || 'unset'}` : 'unset'}
-            </span>
-            <span style={{paddingLeft:12, whiteSpace:'nowrap'}}>
+            </Typography>
+            <Typography display='inline' level='body-sm' pl={3}  whiteSpace='nowrap'>
                 {headerPostTitle}
-            </span>
-        </div>
+            </Typography>
+        </Box>
     );
 
     const [clickingSelectCols, setClickingSelectCols] = useState(false);

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -869,6 +869,10 @@ export async function lowLevelDoFetch(url, options, doValidation, loggerFunc) {
     else throw new Error(`Request failed with status ${response.status}: ${url}`);
 }
 
+export function getStatusFromFetchError(eStr) {
+    return Number(eStr?.match(/status \d+:/)?.[0]?.match(/\d+/)?.[0]);
+}
+
 /*
   Works like lodash set.  However, it will only set if predicate returns true
   predicate is invoked with the current value at the path.  Defaults to isUndefined

--- a/src/firefly/js/visualize/ImViewFilterDisplay.js
+++ b/src/firefly/js/visualize/ImViewFilterDisplay.js
@@ -1,0 +1,224 @@
+import {isEmpty, uniq} from 'lodash';
+import {isDialogVisible} from '../core/ComponentCntlr.js';
+import { getExpandedMode, LO_VIEW, SET_LAYOUT, SET_LAYOUT_MODE, UPDATE_LAYOUT } from '../core/LayoutCntlr.js';
+import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
+import {SelectInfo} from '../tables/SelectInfo.js';
+import {dispatchTableAddLocal} from '../tables/TablesCntlr.js';
+import {getTblById, getTblInfoById, processRequest} from '../tables/TableUtil.js';
+import ImagePlotCntlr, { dispatchChangeActivePlotView, dispatchDeletePlotView, visRoot } from './ImagePlotCntlr.js';
+import {
+    DEFAULT_FITS_VIEWER_ID, EXPANDED_MODE_RESERVED, IMAGE,
+    dispatchAddViewer, dispatchAddViewerItems, dispatchReplaceViewerItems, getMultiViewRoot, getViewerItemIds,
+} from './MultiViewCntlr.js';
+import {PlotAttribute} from './PlotAttribute.js';
+import {
+    getFormattedWaveLengthUnits, getPlotViewAry, getPlotViewById, isImageExpanded, primePlot
+} from './PlotViewUtil.js';
+
+export const IMAGE_VIEW_TABLE_ID = 'active-image-view-list-table';
+export const EXPANDED_OPTIONS_DIALOG_ID= 'ExpandedOptionsPopup';
+export const HIDDEN='_HIDDEN';
+
+const [NAME_IDX, WAVE_LENGTH_UM, PID_IDX, STATUS, PROJ_TYPE_DESC, WAVE_TYPE, DATA_HELP_URL, ROW_IDX] = [0, 1, 2, 3, 4, 5, 6, 7];
+
+const columnsTemplate = [];
+columnsTemplate[NAME_IDX] = {name: 'Name', type: 'char', width: 22};
+columnsTemplate[PID_IDX] = {name: 'plotId', type: 'char', width: 10, visibility: 'hidden'};
+columnsTemplate[STATUS] = {name: 'Status', type: 'char', width: 10};
+columnsTemplate[PROJ_TYPE_DESC] = {name: 'Type', type: 'char', width: 8};
+columnsTemplate[WAVE_TYPE] = {name: 'Band', type: 'char', width: 9};
+columnsTemplate[WAVE_LENGTH_UM] = {
+    name: 'Wavelength',
+    type: 'double',
+    width: 8,
+    units: getFormattedWaveLengthUnits('um')
+};
+
+columnsTemplate[DATA_HELP_URL] = {
+    name: 'Help',
+    type: 'location',
+    width: 4,
+    cellRenderer: 'ATag::href=${Help},target="image-doc"'+ `,label=<img src='images/info-16x16.png'/>` // eslint-disable-line
+};
+
+
+const getAttribute = (attributes, attribute, def='') => attributes?.[attribute] ?? def;
+const makeEnumValues = (data, idx) => uniq(data.map((d) => d[idx]).filter((d) => d)).join(',');
+
+const hasFilters= (tbl_id) => Boolean(getTblById(tbl_id)?.request?.filters);
+
+const isSorted= (tbl_id) => Boolean(getTblById(tbl_id)?.request?.sortInfo);
+
+const getPlotIdAryFromTable= (tbl_id) => getTblById(tbl_id)?.tableData?.data?.map((d) => d[PID_IDX]) ?? [];
+
+export const removeImageViewDisplaySelected = () =>
+    getSelectedPlotIds().forEach((plotId) => dispatchDeletePlotView({plotId}) );
+
+
+export function getPvAryInViewer(viewerId) {
+    const itemIds = getViewerItemIds(getMultiViewRoot(), viewerId) ?? [];
+    return getPlotViewAry(visRoot()).filter((pv) => itemIds.includes(pv.plotId));
+}
+
+export function getCombinedItemIds(viewerId, hiddenViewerId) {
+    const itemIds= getViewerItemIds(getMultiViewRoot(),viewerId) ?? [];
+    const moreIds= getViewerItemIds(getMultiViewRoot(),hiddenViewerId) ?? [];
+    const allIds=
+        [...new Set([...itemIds,...moreIds])]
+            .filter((id) => Boolean(getPlotViewById(visRoot(),id)));
+    return allIds;
+}
+
+
+
+export function makeImViewDisplayModel(tbl_id, plotViewAry, allIds, oldModel) {
+    const pvAry= allIds.map( (id) => getPlotViewById(visRoot(),id));
+    const data = pvAry.map((pv) => {
+        const plot = primePlot(pv);
+        const attributes = plot ? plot.attributes : pv.request.getAttributes();
+        const {plotId, serverCall, plottingStatusMsg, request} = pv;
+        const title = plot ? plot.title : request.getTitle() || 'failed image';
+        const row = [];
+        let stat;
+        if (serverCall === 'success') stat = 'Success';
+        else if (serverCall === 'fail') stat = 'Fail';
+        else stat = plottingStatusMsg;
+        row[NAME_IDX] = title;
+        row[PID_IDX] = plotId;
+        row[STATUS] = stat;
+        row[PROJ_TYPE_DESC] = getAttribute(attributes, PlotAttribute.PROJ_TYPE_DESC);
+        row[WAVE_TYPE] = getAttribute(attributes, PlotAttribute.WAVE_TYPE);
+        row[WAVE_LENGTH_UM] = parseFloat(getAttribute(attributes, PlotAttribute.WAVE_LENGTH_UM, 0.0));
+        row[DATA_HELP_URL] = getAttribute(attributes, PlotAttribute.DATA_HELP_URL);
+        return row;
+    });
+
+    const columns = [...columnsTemplate];
+    columns[PROJ_TYPE_DESC].enumVals = makeEnumValues(data, PROJ_TYPE_DESC);
+    columns[WAVE_TYPE].enumVals = makeEnumValues(data, WAVE_TYPE);
+    columns[STATUS].enumVals = makeEnumValues(data, STATUS);
+    columns[WAVE_LENGTH_UM].enumVals = makeEnumValues(data, WAVE_LENGTH_UM);
+
+
+    const newSi = SelectInfo.newInstance({rowCount: data.length});
+    let request;
+    if (oldModel?.tableData?.data) {
+        const oldSi = SelectInfo.newInstance(oldModel.selectInfo);
+        const vr = visRoot();
+        let filterStr = '';
+        oldModel.tableData.data.forEach((row, idx) => {
+            const plotId = row[PID_IDX];
+            if (getPlotViewById(vr, plotId) && oldSi.isSelected(idx)) {
+                const newIdx = data.findIndex((r) => r[PID_IDX] === plotId);
+                newSi.setRowSelect(newIdx, true);
+                filterStr += filterStr ? ',' + newIdx : newIdx;
+            }
+        });
+        request = {...oldModel.request};
+        if (oldModel?.request?.filters && newSi.data.rowCount > 0) {
+            const {filters} = oldModel.request;
+            if (filters && filters.indexOf('ROW_IDX' > -1)) {
+                request.filters = filters.replace(/"ROW_IDX" IN \(.*\)/, `"ROW_IDX" IN (${filterStr})`);
+            }
+        }
+    }
+
+
+    const templateModel = {
+        tbl_id,
+        tableData: {columns, data},
+        totalRows: data.length, highlightedRow: 0,
+        selectInfo: newSi.data,
+        tableMeta: {},
+    };
+    const tableModel= request ? processRequest(templateModel, request, templateModel.highlightedRow) : templateModel;
+    dispatchTableAddLocal(tableModel, undefined, false);
+    return tableModel;
+}
+
+
+export function updateImageViewDisplay(tbl_id, viewerId) {
+    const model = getTblById(tbl_id);
+    if (!model) return;
+    const plotIdAry = model.tableData.data.map((d) => d[PID_IDX]);
+    if (isEmpty(plotIdAry)) return;
+
+    const currentPlotIdAry = getViewerItemIds(getMultiViewRoot(), viewerId);
+    if (plotIdAry.join('') === currentPlotIdAry.join('')) return;
+    if (!plotIdAry.includes(visRoot().activePlotId)) {
+        dispatchChangeActivePlotView(plotIdAry[0]);
+    }
+    dispatchReplaceViewerItems(viewerId, plotIdAry, IMAGE);
+}
+
+
+
+
+
+function getSelectedPlotIds(){
+    const {tableModel, selectInfo} = getTblInfoById(IMAGE_VIEW_TABLE_ID);
+
+    return selectInfo.selectAll ?
+        tableModel.tableData.data.map((row) => !selectInfo.exceptions.has(parseInt(row[ROW_IDX])) ? row[PID_IDX] : '')
+        : Array.from(selectInfo.exceptions).map((idx) => tableModel.tableData.data[idx][2]);
+}
+
+export function isPlotFilterOrSortOutOfSync(viewerId) {
+    if (isDialogVisible(EXPANDED_OPTIONS_DIALOG_ID)) return false;
+    const sorted= isSorted(IMAGE_VIEW_TABLE_ID);
+    const filtered= hasFilters(IMAGE_VIEW_TABLE_ID);
+    if (!sorted && !filtered) return false;
+    const itemIds= getViewerItemIds(getMultiViewRoot(),viewerId) ?? [];
+    const tblPlotIds= getPlotIdAryFromTable(IMAGE_VIEW_TABLE_ID);
+    return itemIds.join('') !== tblPlotIds.join('');
+}
+
+export function isOnlyPlotSortOutOfSync(viewerId) {
+    if (isDialogVisible(EXPANDED_OPTIONS_DIALOG_ID)) return false;
+    const filtered= hasFilters(IMAGE_VIEW_TABLE_ID);
+    const sorted= isSorted(IMAGE_VIEW_TABLE_ID);
+    if (!sorted || filtered) return false;
+    const itemIds= getViewerItemIds(getMultiViewRoot(),viewerId) ?? [];
+    const tblPlotIds= getPlotIdAryFromTable(IMAGE_VIEW_TABLE_ID);
+    return itemIds.join('') !== tblPlotIds.join('');
+}
+
+export function syncSort(viewerId) {
+    const plotViewAry = getPvAryInViewer(viewerId);
+    const oldModel = getTblById(IMAGE_VIEW_TABLE_ID);
+    const allIds = getCombinedItemIds(viewerId, viewerId + HIDDEN);
+    makeImViewDisplayModel(IMAGE_VIEW_TABLE_ID, plotViewAry, allIds, oldModel);
+    updateImageViewDisplay(IMAGE_VIEW_TABLE_ID, viewerId);
+}
+
+export function syncTableModelAndImagesToViewer(viewerId) {
+    if (!isPlotFilterOrSortOutOfSync(viewerId)) return;
+    const plotViewAry = getPvAryInViewer(viewerId);
+    dispatchAddViewer(viewerId + HIDDEN, true, IMAGE, false);
+    dispatchAddViewerItems(viewerId + HIDDEN, plotViewAry.map((pv) => pv.plotId), IMAGE);
+    const oldModel = getTblById(IMAGE_VIEW_TABLE_ID);
+    const allIds = getCombinedItemIds(viewerId, viewerId + HIDDEN);
+    makeImViewDisplayModel(IMAGE_VIEW_TABLE_ID, plotViewAry, allIds, oldModel);
+    updateImageViewDisplay(IMAGE_VIEW_TABLE_ID, viewerId);
+}
+
+
+
+let watcherAdded= false;
+
+export function addExpandFilterSyncWatcher() {
+    if (watcherAdded) return;
+    watcherAdded= true;
+    let lastState;
+    dispatchAddActionWatcher({ actions:[SET_LAYOUT_MODE, SET_LAYOUT,UPDATE_LAYOUT, ImagePlotCntlr.CHANGE_EXPANDED_MODE],
+        callback: () => {
+            const expandedMode= getExpandedMode();
+            const imageExpanded= isImageExpanded(visRoot().expandedMode);
+            const state= (expandedMode===LO_VIEW.images && imageExpanded) ? 'EXPANDED' :
+                (expandedMode===LO_VIEW.none && !imageExpanded) ? 'COLLAPSE' : 'IGNORE';
+            if (state==='IGNORE' || state===lastState) return;
+            syncTableModelAndImagesToViewer(state==='COLLAPSE' ? DEFAULT_FITS_VIEWER_ID : EXPANDED_MODE_RESERVED);
+            lastState= state;
+        }
+        ,} );
+}

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -1,7 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {ExpandType} from 'firefly/visualize/ImagePlotCntlr.js';
+import {dispatchDeletePlotView, ExpandType, visRoot} from 'firefly/visualize/ImagePlotCntlr.js';
 import {has, isArray, isEmpty, isObject, isString, isUndefined} from 'lodash';
 import shallowequal from 'shallowequal';
 import {memorizeLastCall} from '../util/WebUtil';
@@ -1138,3 +1138,13 @@ export function isDefaultCoverageActive(vr, mvr) {
 export const isImageExpanded = (expandedMode) => expandedMode === true ||
     expandedMode === ExpandType.GRID ||
     expandedMode === ExpandType.SINGLE;
+
+
+/**
+ * remove all the failed plots in the store
+ * @param {VisRoot} [vr]
+ */
+export const deleteAllFailedPlots = (vr= visRoot()) =>
+    getPlotViewAry(vr)
+        .filter((pv) => pv.serverCall === 'fail')
+        .forEach(({plotId}) => dispatchDeletePlotView({plotId}));

--- a/src/firefly/js/visualize/iv/ExpandedTools.jsx
+++ b/src/firefly/js/visualize/iv/ExpandedTools.jsx
@@ -5,18 +5,19 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Button, Checkbox, Divider, IconButton, Sheet, Stack, Switch, Tooltip, Typography} from '@mui/joy';
+import {Button, Checkbox, IconButton, Sheet, Stack, Switch, Tooltip, Typography} from '@mui/joy';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
 import {
     ExpandType, dispatchChangeExpandedMode, dispatchExpandedAutoPlay, visRoot,
 } from '../ImagePlotCntlr.js';
 import {primePlot, getActivePlotView} from '../PlotViewUtil.js';
 import {CloseButton} from '../../ui/CloseButton.jsx';
-import {DisplayTypeButtonGroup, ListViewButton} from '../ui/Buttons.jsx';
-import {showExpandedOptionsPopup} from '../ui/ExpandedOptionsPopup.jsx';
+import {DisplayTypeButtonGroup} from '../ui/Buttons.jsx';
+import {ViewOptionsButton} from '../ui/ExpandedOptionsPopup.jsx';
 import {dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {
-    getMultiViewRoot, getExpandedViewerItemIds, getViewer, EXPANDED_MODE_RESERVED, dispatchViewerScroll
+    getMultiViewRoot, getExpandedViewerItemIds, getViewer, EXPANDED_MODE_RESERVED, dispatchViewerScroll,
 } from '../MultiViewCntlr.js';
 import {VisMiniToolbar} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
 
@@ -25,28 +26,19 @@ import NavigateBefore from '@mui/icons-material/NavigateBeforeRounded';
 import ActiveDotIcon from '@mui/icons-material/FiberManualRecord';
 import InactiveDotIcon from '@mui/icons-material/FiberManualRecordOutlined';
 
+const viewerId= EXPANDED_MODE_RESERVED;
 
-const SCROLL_TIP=(
-    <Typography  level='body-sm' width='50rem'>
-        Use this mode when you have many images. When enabled...
-            <ul>
-                <li>You are able to use your browser to scroll through each image.</li>
-                <li>Images will remain larger and the whole image area can be scrolled</li>
-                <li>You may only zoom the active image in or out</li>
-            </ul>
-    </Typography>
-);
 
 function createOptions(expandedMode, singleAutoPlay, plotIdAry) {
     return (
         <Stack {...{direction:'row', alignItems: 'center', flexWrap:'nowrap'}}>
             {(expandedMode===ExpandType.SINGLE && plotIdAry.length>1) ?
                 <>
-                    <Divider orientation='vertical' sx={{mx:1}}/>
+                    <ToolbarHorizontalSeparator/>
                     <Checkbox {...{label:'Auto play', size:'sm', checked:singleAutoPlay,
                         onChange:() => dispatchExpandedAutoPlay(!singleAutoPlay)
                     }} />
-                    <Divider orientation='vertical' sx={{mx:1}}/>
+                    <ToolbarHorizontalSeparator/>
                 </>
                 : false
             }
@@ -62,12 +54,13 @@ function getState() {
 export function ExpandedTools({closeFunc}) {
 
     const {expandedMode,activePlotId, singleAutoPlay, plotViewAry}= useStoreConnector(getState);
-    const viewer= getViewer(getMultiViewRoot(), EXPANDED_MODE_RESERVED);
+    const viewer= getViewer(getMultiViewRoot(), viewerId);
     const scroll= viewer?.scroll ?? false;
     const plotIdAry= viewer.itemIdAry;
     const single= plotViewAry?.length===1;
 
     const getPlotTitle = (plotId) => primePlot(visRoot(),plotId)?.title ?? '';
+
 
     return (
         <Sheet>
@@ -79,14 +72,8 @@ export function ExpandedTools({closeFunc}) {
                             <WhichView expandedMode={expandedMode}/>
                             {!single && expandedMode===ExpandType.GRID &&
                                 <>
-                                    <Divider orientation='vertical' sx={{mx:1}}/>
-                                    <Tooltip title={SCROLL_TIP}>
-                                        <Switch size='md' endDecorator={scroll ? `Scrolling ${plotIdAry.length} images` : 'Scroll Images'}
-                                                checked={scroll}
-                                                onChange={() => {
-                                                    dispatchViewerScroll({viewerId:EXPANDED_MODE_RESERVED,scroll:!scroll});
-                                                }} />
-                                    </Tooltip>
+                                    <ToolbarHorizontalSeparator/>
+                                    <ViewerScroll {...{viewerId,checked:scroll,count:plotIdAry.length}}/>
                                 </>
                             }
                             {createOptions(expandedMode,singleAutoPlay, plotIdAry)}
@@ -112,7 +99,29 @@ ExpandedTools.propTypes= {
     closeFunc : PropTypes.func
 };
 
+const ViewerScrollTip=(
+    <Typography  level='body-sm' width='50rem' component='div'>
+        Use this mode when you have many images. When enabled...
+        <ul>
+            <li>You are able to use your browser to scroll through each image.</li>
+            <li>Images will remain larger and the whole image area can be scrolled</li>
+            <li>You may only zoom the active image in or out</li>
+        </ul>
+    </Typography>
+);
 
+export const ViewerScroll= ({viewerId,count,checked}) => (
+    <Tooltip title={ViewerScrollTip}>
+        <Switch size='sm'
+                endDecorator={
+                    <Typography sx={{textWrap:'nowrap'}} >
+                        {checked ? `Scrolling ${count} images` : 'Scroll Images'}
+                    </Typography>
+                }
+                checked={checked}
+                onChange={() => dispatchViewerScroll({viewerId,scroll:!checked})} />
+    </Tooltip>
+);
 
 
 function WhichView({expandedMode}) {
@@ -130,10 +139,7 @@ function WhichView({expandedMode}) {
                     }
                 ]
             }}/>}
-            {showViewButtons &&
-                <ListViewButton title='Choose which images to show'
-                                onClick={() =>showExpandedOptionsPopup() }/>
-            }
+            {showViewButtons && <ViewOptionsButton /> }
         </Stack>
     );
 }

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -112,6 +112,7 @@ function doParse(header, altWcs = '', zeroHeader, wlTableRelatedAry) {
     // If there are more than two, they are likely related to each other.
 
     const spectralWCSData = {
+        headerType: 'wavelength',
         spectralCoords,
         hasPlainOnlyCoordInfo: spectralCoords.some((c) => c.planeOnly),
         hasPixelLevelCoordInfo: spectralCoords.some((c) => !c.planeOnly),

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -36,23 +36,23 @@ import {updateTransform, makeTransform} from '../PlotTransformUtils.js';
  * array of WebPlots. The array length will only be one for normals fits files and n for multi image fits and cube fits
  * files. plots[primeIdx] refers to the plot currently showing in the plot view.
  *
- * @prop {String} plotId, immutable
- * @prop {String} plotGroupId, immutable
- * @prop {String} drawingSubGroupId, immutable
+ * @prop {String} plotId - immutable
+ * @prop {String} plotGroupId - immutable
+ * @prop {String} drawingSubGroupId - immutable
  * @prop {WebPlotRequest} request
  * @prop {boolean} visible true when we draw the base image
  * @prop {Array.<WebPlot>} plots all the plots that this plotView can show, usually the image in the fits file
- * @prop {String} plottingStatusMsg, end user description of the what is doing on
- * @prop {String} serverCall, one of 'success', 'working', 'fail'
- * @prop {number} primeIdx, which of the plots array is active
+ * @prop {String} plottingStatusMsg - end user description of the what is doing on
+ * @prop {String} serverCall - one of 'success', 'working', 'fail'
+ * @prop {number} primeIdx -  which of the plots array is active
  * @prop {number} scrollX scroll position X
  * @prop {number} scrollY scroll position Y
  * @prop {{width:number, height:number}} viewDim  size of viewable area  (div size: offsetWidth & offsetHeight)
  * @prop {Object} overlayPlotViews
  * @prop {Object} options
  * @prop {number} rotation if > 0 then the plot is rotated by this many degrees
- * @prop {boolean} flipY if true, the the plot is flipped on the Y axis
- * @prop {boolean} flipX - *not implemented*, if true, the the plot is flipped on the X axis
+ * @prop {boolean} flipY if true, the plot is flipped on the Y axis
+ * @prop {boolean} flipX - *not implemented*, if true, the plot is flipped on the X axis
  * @prop {PlotViewContextData} plotViewCtx
  */
 

--- a/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ExpandedOptionsPopup.jsx
@@ -3,178 +3,60 @@
  */
 
 import {Box, Button, Stack} from '@mui/joy';
-import React, {useState, useEffect} from 'react';
-import {isEmpty, uniq, isEqual} from 'lodash';
-import {useStoreConnector} from '../../ui/SimpleComponent';
-import CompleteButton from '../../ui/CompleteButton.jsx';
-import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
-import {PopupPanel} from '../../ui/PopupPanel.jsx';
-import {visRoot, dispatchChangeActivePlotView, dispatchDeletePlotView} from '../ImagePlotCntlr.js';
-import {primePlot} from '../PlotViewUtil.js';
-import {
-    getMultiViewRoot, dispatchReplaceViewerItems,
-    EXPANDED_MODE_RESERVED, IMAGE, dispatchAddViewer, dispatchAddViewerItems
-} from '../MultiViewCntlr.js';
+import {isEqual} from 'lodash';
+import React, {useEffect, useState} from 'react';
 import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
-import {TablePanel} from '../../tables/ui/TablePanel';
-import {dispatchTableAddLocal, TABLE_SORT} from '../../tables/TablesCntlr';
-import {getTblById, getTblInfoById, processRequest, watchTableChanges} from '../../tables/TableUtil';
-import {getFormattedWaveLengthUnits, getPlotViewAry, getPlotViewById, isPlotViewArysEqual} from '../PlotViewUtil';
-import {PlotAttribute} from '../PlotAttribute';
-import {TABLE_LOADED, TABLE_FILTER, TABLE_FILTER_SELROW} from '../../tables/TablesCntlr';
-import {getViewerItemIds} from '../MultiViewCntlr';
-import {HelpIcon} from '../../ui/HelpIcon';
-import {SelectInfo} from '../../tables/SelectInfo';
+import {TABLE_FILTER, TABLE_FILTER_SELROW, TABLE_LOADED, TABLE_SORT} from '../../tables/TablesCntlr.js';
+import {getTblById, watchTableChanges} from '../../tables/TableUtil.js';
+import {TablePanel} from '../../tables/ui/TablePanel.jsx';
+import {CompleteButton} from '../../ui/CompleteButton.jsx';
+import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
+import {HelpIcon} from '../../ui/HelpIcon.jsx';
+import {PopupPanel} from '../../ui/PopupPanel.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {
+    EXPANDED_OPTIONS_DIALOG_ID, HIDDEN, IMAGE_VIEW_TABLE_ID,
+    getCombinedItemIds, getPvAryInViewer, isOnlyPlotSortOutOfSync,
+    isPlotFilterOrSortOutOfSync, makeImViewDisplayModel, removeImageViewDisplaySelected, syncSort,
+    updateImageViewDisplay, addExpandFilterSyncWatcher
+} from '../ImViewFilterDisplay.js';
+import {dispatchAddViewer, dispatchAddViewerItems, EXPANDED_MODE_RESERVED, IMAGE} from '../MultiViewCntlr.js';
+import {deleteAllFailedPlots, isPlotViewArysEqual} from '../PlotViewUtil.js';
+import {ListViewButton} from './Buttons.jsx';
 
 
-const TABLE_ID = 'active-image-view-list-table';
+export function ViewOptionsButton({ title, viewerId=EXPANDED_MODE_RESERVED }) {
+    const outOfSyncTip= 'Click to re-add filters after image change';
+    const inSyncTip= 'Choose which images to show';
+    const outOfSync= isPlotFilterOrSortOutOfSync(viewerId);
+    const onlySortOutOfSync= isOnlyPlotSortOutOfSync(viewerId);
 
-const HIDDEN='_HIDDEN';
+    useEffect(() => {
+        addExpandFilterSyncWatcher();
+        onlySortOutOfSync && syncSort(viewerId);
+    }, [onlySortOutOfSync]);
 
+    useEffect(() => {
+    },[]);
 
-export function showExpandedOptionsPopup(title= 'Loaded Images', viewerId= EXPANDED_MODE_RESERVED) {
+    return (
+        <ListViewButton title= {outOfSync ? outOfSyncTip : inSyncTip}
+                        slotProps={ {tooltip: {color:outOfSync?'danger' : undefined}} }
+                        badgeAlert={outOfSync}
+                        onClick={() =>showExpandedOptionsPopup(title,viewerId) }/>
+    );
+}
+
+function showExpandedOptionsPopup(title= 'Loaded Images', viewerId= EXPANDED_MODE_RESERVED) {
     dispatchAddViewer(viewerId+HIDDEN, true, IMAGE, false);
     const popup = (
         <PopupPanel title={title}>
             <ImageViewOptionsPanel viewerId={viewerId}/>
         </PopupPanel>
     );
-    DialogRootContainer.defineDialog('ExpandedOptionsPopup', popup);
-    dispatchShowDialog('ExpandedOptionsPopup');
+    DialogRootContainer.defineDialog(EXPANDED_OPTIONS_DIALOG_ID, popup);
+    dispatchShowDialog(EXPANDED_OPTIONS_DIALOG_ID);
 }
-
-
-const [NAME_IDX, WAVE_LENGTH_UM, PID_IDX, STATUS, PROJ_TYPE_DESC, WAVE_TYPE, DATA_HELP_URL, ROW_IDX] = [0, 1, 2, 3, 4, 5, 6, 7];
-
-const columnsTemplate = [];
-columnsTemplate[NAME_IDX] = {name: 'Name', type: 'char', width: 22};
-columnsTemplate[PID_IDX] = {name: 'plotId', type: 'char', width: 10, visibility: 'hidden'};
-columnsTemplate[STATUS] = {name: 'Status', type: 'char', width: 15};
-columnsTemplate[PROJ_TYPE_DESC] = {name: 'Type', type: 'char', width: 8};
-columnsTemplate[WAVE_TYPE] = {name: 'Band', type: 'char', width: 8};
-columnsTemplate[WAVE_LENGTH_UM] = {
-    name: 'Wavelength',
-    type: 'double',
-    width: 10,
-    units: getFormattedWaveLengthUnits('um')
-};
-columnsTemplate[DATA_HELP_URL] = {name: 'Help', type: 'location', width: 7, links: [{href: '${Help}', value: 'help'}]};
-
-const getAttribute = (attributes, attribute, def='') => attributes?.[attribute] ?? def;
-
-const makeEnumValues = (data, idx) => uniq(data.map((d) => d[idx]).filter((d) => d)).join(',');
-
-function makeModel(tbl_id, plotViewAry, allIds, oldModel) {
-    const pvAry= allIds.map( (id) => getPlotViewById(visRoot(),id));
-    const data = pvAry.map((pv) => {
-        const plot = primePlot(pv);
-        const attributes = plot ? plot.attributes : pv.request.getAttributes();
-        const {plotId, serverCall, plottingStatusMsg, request} = pv;
-        const title = plot ? plot.title : request.getTitle() || 'failed image';
-        const row = [];
-        let stat;
-        if (serverCall === 'success') stat = 'Success';
-        else if (serverCall === 'fail') stat = 'Fail';
-        else stat = plottingStatusMsg;
-        row[NAME_IDX] = title;
-        row[PID_IDX] = plotId;
-        row[STATUS] = stat;
-        row[PROJ_TYPE_DESC] = getAttribute(attributes, PlotAttribute.PROJ_TYPE_DESC);
-        row[WAVE_TYPE] = getAttribute(attributes, PlotAttribute.WAVE_TYPE);
-        row[WAVE_LENGTH_UM] = parseFloat(getAttribute(attributes, PlotAttribute.WAVE_LENGTH_UM, 0.0));
-        row[DATA_HELP_URL] = getAttribute(attributes, PlotAttribute.DATA_HELP_URL);
-        return row;
-    });
-
-    const columns = [...columnsTemplate];
-    columns[PROJ_TYPE_DESC].enumVals = makeEnumValues(data, PROJ_TYPE_DESC);
-    columns[WAVE_TYPE].enumVals = makeEnumValues(data, WAVE_TYPE);
-    columns[STATUS].enumVals = makeEnumValues(data, STATUS);
-    columns[WAVE_LENGTH_UM].enumVals = makeEnumValues(data, WAVE_LENGTH_UM);
-
-
-    const newSi = SelectInfo.newInstance({rowCount: data.length});
-    let request;
-    if (oldModel) {
-        const oldSi = SelectInfo.newInstance(oldModel.selectInfo);
-        const vr = visRoot();
-        let filterStr = '';
-        oldModel.tableData.data.forEach((row, idx) => {
-            const plotId = row[PID_IDX];
-            if (getPlotViewById(vr, plotId) && oldSi.isSelected(idx)) {
-                const newIdx = data.findIndex((r) => r[PID_IDX] === plotId);
-                newSi.setRowSelect(newIdx, true);
-                filterStr += filterStr ? ',' + newIdx : newIdx;
-            }
-        });
-        request = {...oldModel.request};
-        if (oldModel?.request?.filters && newSi.data.rowCount > 0) {
-            const {filters} = oldModel.request;
-            if (filters && filters.indexOf('ROW_IDX' > -1)) {
-                request.filters = filters.replace(/"ROW_IDX" IN \(.*\)/, `"ROW_IDX" IN (${filterStr})`);
-            }
-        }
-
-
-    }
-
-
-    let newModel = {
-        tbl_id,
-        tableData: {columns, data},
-        totalRows: data.length, highlightedRow: 0,
-        selectInfo: newSi.data,
-        tableMeta: {},
-        request,
-    };
-    if (newModel.request) {
-        newModel = processRequest(newModel, newModel.request, newModel.highlightedRow);
-    }
-    dispatchTableAddLocal(newModel, undefined, false);
-    return newModel;
-}
-
-function dialogComplete(tbl_id, viewerId) {
-    const model = getTblById(tbl_id);
-    if (!model) return;
-    const plotIdAry = model.tableData.data.map((d) => d[PID_IDX]);
-    if (isEmpty(plotIdAry)) return;
-
-    const currentPlotIdAry = getViewerItemIds(getMultiViewRoot(), viewerId);
-    if (plotIdAry.join('') === currentPlotIdAry.join('')) return;
-    if (!plotIdAry.includes(visRoot().activePlotId)) {
-        dispatchChangeActivePlotView(plotIdAry[0]);
-    }
-    dispatchReplaceViewerItems(viewerId, plotIdAry, IMAGE);
-}
-
-const deleteFailed = () => {
-    getPlotViewAry(visRoot()).forEach((pv) => {
-        if (pv.serverCall === 'fail') {
-            dispatchDeletePlotView({plotId: pv.plotId});
-        }
-    });
-};
-
-
-const removeSelected = () => {
-    const selectedPlotIds = getSelectedPlotIds();
-    selectedPlotIds.forEach((plotId) => {
-        dispatchDeletePlotView({plotId});
-    });
-};
-
-
-function getSelectedPlotIds(){
-    const {tableModel, selectInfo} = getTblInfoById(TABLE_ID);
-
-    return selectInfo.selectAll ?
-        tableModel.tableData.data.map((row) => !selectInfo.exceptions.has(parseInt(row[ROW_IDX])) ? row[PID_IDX] : '')
-        :
-        Array.from(selectInfo.exceptions).map((idx) =>
-            tableModel.tableData.data[idx][2]);
-}
-
 
 
 const pvKeys = ['plotId', 'request', 'serverCall', 'plottingStatusMsg'];
@@ -182,94 +64,75 @@ const plotKeys = ['plotImageId'];
 
 
 function getPvAry(oldPvAry, viewerId) {
-    const itemIds= getViewerItemIds(getMultiViewRoot(),viewerId) ?? [];
-    const pvAry = getPlotViewAry(visRoot()).filter( (pv) => itemIds.includes(pv.plotId));
+    const pvAry= getPvAryInViewer(viewerId);
     if (!oldPvAry) return pvAry;
     return isPlotViewArysEqual(oldPvAry, pvAry, pvKeys, plotKeys) ? oldPvAry : pvAry;
 }
 
 function getAllViewerIds(oldIdAry,viewerId, hiddenViewerId) {
-    const itemIds= getViewerItemIds(getMultiViewRoot(),viewerId) ?? [];
-    const moreIds= getViewerItemIds(getMultiViewRoot(),hiddenViewerId) ?? [];
-    const allIds=
-        [...new Set([...itemIds,...moreIds])]
-        .filter((id) => Boolean(getPlotViewById(visRoot(),id)));
+    const allIds= getCombinedItemIds(viewerId,hiddenViewerId);
     return isEqual(oldIdAry, allIds) ? oldIdAry : allIds;
 }
 
-
 function ImageViewOptionsPanel({viewerId}) {
 
-    const tbl_ui_id = TABLE_ID + '-ui';
+    const tbl_ui_id = IMAGE_VIEW_TABLE_ID + '-ui';
 
 
     const plotViewAry = useStoreConnector((oldPvAry) => getPvAry(oldPvAry,viewerId));
     const allIds = useStoreConnector((old) => getAllViewerIds(old,viewerId, viewerId+HIDDEN));
-    const [model, setModel] = useState(undefined);
+    const [tableModel, setTableModel] = useState(undefined);
+    const [filterChangeCnt, setFilterChangeCnt] = useState(0);
 
 
     useEffect(() => {
-        const oldModel = getTblById(TABLE_ID);
-        if (!oldModel) {
-            watchTableChanges(TABLE_ID, [TABLE_LOADED, TABLE_FILTER, TABLE_FILTER_SELROW, TABLE_SORT],
-                () => dialogComplete(TABLE_ID, viewerId));
-        }
-        setModel(makeModel(TABLE_ID, plotViewAry, allIds, oldModel));
-    }, [plotViewAry, allIds]);
+        return watchTableChanges(IMAGE_VIEW_TABLE_ID, [TABLE_LOADED, TABLE_FILTER, TABLE_FILTER_SELROW, TABLE_SORT],
+            (action) => {
+                updateImageViewDisplay(IMAGE_VIEW_TABLE_ID, viewerId);
+                if (action.type===TABLE_FILTER || action.type===TABLE_FILTER_SELROW) setFilterChangeCnt(filterChangeCnt+1);
+            });
+    }, []);
+
+
+    useEffect(() => {
+        const oldModel = getTblById(IMAGE_VIEW_TABLE_ID);
+        setTableModel(makeImViewDisplayModel(IMAGE_VIEW_TABLE_ID, plotViewAry, allIds, oldModel));
+    }, [plotViewAry?.length, allIds?.length, filterChangeCnt]); // only fire effect when filter change or plot count changes
+
+
 
     useEffect(() => {
        dispatchAddViewerItems(viewerId+HIDDEN,allIds,IMAGE);
     }, [viewerId, allIds]);
 
-    if (!model) return null;
+    if (!tableModel) return null;
 
 
     return (
-        // <Stack sx={{resize: 'both',width: 625, height: 450, minWidth: 250, minHeight: 200}}>
-            <Stack {...{ spacing: 2, sx:{p:1, overflow: 'hidden', resize:'both', width: 625, height: 450, minWidth: 250, minHeight: 200} }}>
-                <div style={{position: 'relative', width: '100%', height: 'calc(100% - 30px)'}}>
-                    <div className='TablePanel'>
-                        <div className={'TablePanel__wrapper--border'}>
-                            <div className='TablePanel__table' style={{top: 0}}>
-                                <TablePanel
-                                    tbl_ui_id={tbl_ui_id}
-                                    tableModel={model}
-                                    showToolbar={true}
-                                    showFilters={true}
-                                    selectable={true}
-                                    showOptionButton={true}
-                                    border={false}
-                                    showTitle={false}
-                                    showPaging={false}
-                                    showSave={false}
-                                    showTypes={false}
-                                    showToggleTextView={false}
-                                    expandable={false}
-                                    showUnits={true}
-                                    rowHeight={23}
-                                />
-                            </div>
-                        </div>
-                    </div>
+        <Stack {...{ spacing: 2,
+            sx:{p:1, overflow: 'hidden', resize:'both', width: 660, height: 450, minWidth: 250, minHeight: 200} }}>
+            <Box {...{position: 'relative', width: 1, height: 1}}>
+                <div className='TablePanel__table' style={{top: 0}}>
+                    <TablePanel {...{
+                        tbl_ui_id, tableModel, rowHeight:23,
+                        showToolbar:true, showFilters:true, selectable:true, showOptionButton:true,
+                        border:false, showTitle:false, showPaging:false, showSave:false,
+                        showTypes:false, showToggleTextView:false, expandable:false, showUnits:true,
+                    }} />
                 </div>
+            </Box>
 
-
-                <Stack {...{direction: 'row', justifyContent:'space-between'}}>
-                    <CompleteButton
-                        text={'Done'}
-                        onSuccess={() => dialogComplete(model.tbl_id)}
-                        dialogId='ExpandedOptionsPopup'/>
-
-                    <Stack {...{direction: 'row', spacing:1, sx:{'& .MuiButton-root':{whiteSpace:'nowrap'}} }}>
-                        <Button onClick={() => removeSelected()} >Remove Selected </Button>
-                        <Button onClick={() => deleteFailed()}>Delete Failed </Button>
-                        <HelpIcon helpId={'visualization.loaded-images'} style={{padding: '8px 9px 0 0'}}/>
-                    </Stack>
-
+            <Stack {...{direction: 'row', justifyContent: 'space-between'}}>
+                <CompleteButton text='Done'
+                                onSuccess={() => updateImageViewDisplay(tableModel.tbl_id)}
+                                dialogId='ExpandedOptionsPopup'/>
+                <Stack {...{direction: 'row', spacing: 1, sx: {'& .MuiButton-root': {whiteSpace: 'nowrap'}}}}>
+                    <Button onClick={() => removeImageViewDisplaySelected()}>Remove Selected</Button>
+                    <Button onClick={() => deleteAllFailedPlots()}>Delete Failed</Button>
+                    <HelpIcon helpId={'visualization.loaded-images'} style={{padding: '8px 9px 0 0'}}/>
                 </Stack>
             </Stack>
-
-        // </Stack>
+        </Stack>
     );
 }
 

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -243,6 +243,7 @@ export function FileDropZone({dropEvent, setDropEvent, setLoadingOp, sx, childre
 const LoadingMessage= ({message}) => (
     <div style={{
         position: 'absolute',
+        zIndex:20,
         display:'flex',
         flexDirection: 'column',
         justifyContent:'center',

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
@@ -16,7 +16,7 @@ import {DisplayTypeButtonGroup} from './Buttons.jsx';
 import {showColorBandChooserPopup} from './ColorBandChooserPopup.jsx';
 import {ImagePager} from './ImagePager.jsx';
 import {VisMiniToolbar} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
-import {ToolbarButton} from '../../ui/ToolbarButton.jsx';
+import {ToolbarButton, ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
 
 import THREE_COLOR from 'html/images/icons-2014/28x28_FITS_Modify3Image.png';
 
@@ -89,7 +89,7 @@ export function ImageMetaDataToolbarView({viewerId, viewerPlotIds=[], layoutType
                     }
                 </Stack> }
                 {showPager && <ImagePager pageSize={maxPlots} tbl_id={activeTable.tbl_id} style={{marginLeft:10}}/>}
-                {showPager && <Divider orientation='vertical' sx={{mx:1}}/>}
+                {showPager && <ToolbarHorizontalSeparator/>}
                 <VisMiniToolbar viewerId={viewerId}/>
             </Stack>
         </Sheet>

--- a/src/firefly/js/visualize/ui/MouseReadoutBottomLine.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadoutBottomLine.jsx
@@ -23,9 +23,9 @@ export function MouseReadoutBottomLine({readout, readoutData, readoutShowing, st
     useEffect( () => {
         if (divref.element) {
             const w= divref.element.getBoundingClientRect()?.width;
-            setWidth(w);
+            w && setWidth(w);
         }
-    });
+    }, [divref?.element]);
 
     const {readoutType}= readoutData;
     if (!readoutData.readoutItems) return (<div style={{height: showOnInactive?20:0, width:showOnInactive?1:0}}/>);
@@ -41,7 +41,7 @@ export function MouseReadoutBottomLine({readout, readoutData, readoutShowing, st
     const sx= (theme) => ({
         justifyContent: 'space-between',
         alignItems:'center',
-        height: '1.3rem',
+        height: '1.5rem',
         borderRadius: '5px',
         overflow:'hidden',
         border: '2px solid rgba(0,0,0,.1)',

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -114,6 +114,7 @@ export class MultiImageViewer extends PureComponent {
                                   inlineTitle={true}
                                   handleToolbar={handleToolbar}
                                   aboveTitle={false}
+                                  scrollGrid={viewer?.scroll ?? false}
                                   visRoot={visRoot}
                                   ref={(c) => this.rootWidget= c}
                                   dlAry={dlAry}

--- a/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
@@ -31,7 +31,7 @@ export const MultiImageViewerView = forwardRef( (props, ref) => {
 
     const {readout, readoutData, readoutShowing}= useMouseStoreConnector(makeState);
     const {Toolbar, visRoot, viewerPlotIds=[], showWhenExpanded=false, mouseReadoutEmbedded=true,
-        handleToolbar=true, layoutType=GRID}= props;
+        handleToolbar=true, layoutType=GRID, scrollGrid}= props;
 
     const makeToolbar = Toolbar ? () => (<Toolbar {...props} />) : undefined;
 
@@ -71,6 +71,7 @@ export const MultiImageViewerView = forwardRef( (props, ref) => {
                                         slightlyTransparent={mouseReadoutEmbedded}
                                         readoutShowing={doReadoutAndShowing}
                                         showOnInactive={!mouseReadoutEmbedded}
+                                        scrollGrid={scrollGrid}
                                         radix={radix}
                                         style={mouseReadoutEmbedded? {position:'absolute', left:3, right:3, bottom:2}:{}} />
             </div>
@@ -81,9 +82,11 @@ export const MultiImageViewerView = forwardRef( (props, ref) => {
             <div style={style}>
                 <MultiItemViewerView {...{...newProps, ref, insideFlex:true, style:props.style}} />
                 <MouseReadoutBottomLine readout={readout} readoutData={readoutData}
-                                        style={mouseReadoutEmbedded?{position:'absolute', left:4, bottom:4, right:4}:{}}
+                                        style={
+                                          mouseReadoutEmbedded?{position:'absolute', left:1, bottom:1, right:scrollGrid?15:4}:{}}
                                         readoutShowing={doReadoutAndShowing}
                                         showOnInactive={!mouseReadoutEmbedded}
+                                        scrollGrid={scrollGrid}
                                         radix={radix}
                                         slightlyTransparent={mouseReadoutEmbedded}
                 />

--- a/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
+++ b/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
@@ -3,14 +3,16 @@
  */
 
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {Sheet, Stack} from '@mui/joy';
+import {Divider, Sheet, Stack} from '@mui/joy';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
+import {ViewerScroll} from '../iv/ExpandedTools.jsx';
 import {dispatchChangeViewerLayout, getMultiViewRoot, getViewer} from '../MultiViewCntlr.js';
-import {dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
-import {
-    BeforeButton, DisplayTypeButtonGroup, ListViewButton, NextButton } from './Buttons.jsx';
-import {showExpandedOptionsPopup} from './ExpandedOptionsPopup.jsx';
+import {dispatchChangeActivePlotView, ExpandType} from '../ImagePlotCntlr.js';
+import {BeforeButton, DisplayTypeButtonGroup, NextButton } from './Buttons.jsx';
+import {ViewOptionsButton} from './ExpandedOptionsPopup.jsx';
 import {VisMiniToolbar} from './VisMiniToolbar.jsx';
 import {getActivePlotView} from '../PlotViewUtil.js';
 
@@ -26,7 +28,9 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, tool
     const moreThanOne= viewerPlotIds.length>1;
     const nextIdx= cIdx===viewerPlotIds.length-1 ? 0 : cIdx+1;
     const prevIdx= cIdx ? cIdx-1 : viewerPlotIds.length-1;
-    const layout= getViewer(getMultiViewRoot(), viewerId)?.layout ?? 'grid';
+    const viewer= getViewer(getMultiViewRoot(), viewerId);
+    const layout= viewer?.layout ?? 'grid';
+    const scroll= viewer?.scroll ?? false;
 
 
     const {showImageToolbar=true}= getActivePlotView(visRoot)?.plotViewCtx.menuItemKeys ?? {};
@@ -34,8 +38,8 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, tool
 
     return (
         <Sheet variant={toolbarVariant}>
-            <Stack {...{pl:1/2, direction:'row', flexWrap:'nowrap', alignItems: 'center', justifyContent: 'space-between',
-                width:'100%', height: 32, style:toolbarStyle}}>
+            <Stack {...{pl:1/2, direction:'row', flexWrap:'wrap-reverse', alignItems: 'center', justifyContent: 'space-between',
+                width:'100%', minHeight: 32, style:toolbarStyle}}>
                 <Stack {...{direction:'row', alignItems: 'center', flexWrap:'nowrap'}}>
 
                     {moreThanOne && <DisplayTypeButtonGroup {...{value:layout,
@@ -48,9 +52,12 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, tool
                             }
                         ]
                     }}/>}
-                    {useImageList && moreThanOne &&
-                        <ListViewButton tip='Choose which images to show'
-                                       onClick={() =>showExpandedOptionsPopup('Pinned Images', viewerId) }/>
+                    {useImageList && moreThanOne && <ViewOptionsButton title='Pinned Images' viewerId={viewerId}/> }
+                    {moreThanOne && layout==='grid' &&
+                        <>
+                            <ToolbarHorizontalSeparator/>
+                            <ViewerScroll {...{viewerId,checked:scroll,count:viewerPlotIds.length}}/>
+                        </>
                     }
                     {layoutType==='single' && moreThanOne &&
                         <>

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -277,9 +277,9 @@ export const VisCtxToolbarView= memo((props) => {
         <Fragment>
             {canConvertHF && <HipsFitsConvertButton pv={pv}/>}
             {hips && !canConvertHF && <HipsProjConvertButton pv={pv}/>}
-            {hips && <Divider orientation='vertical' sx={{mx:.5}}/> }
+            {hips && <Divider orientation='vertical' sx={{m:.5}}/> }
             {hips && <HiPSCoordSelect plotId={plot?.plotId} imageCoordSys={plot?.imageCoordSys}/>}
-            {hips && <Divider orientation='vertical' sx={{mx:.5}}/> }
+            {hips && <Divider orientation='vertical' sx={{m:.5}}/> }
             {hips && makeHiPSImageTable(pv)}
             {isHiPSAitoff(plot) &&
                 <ToolbarButton text='Center Galactic' tip='Align Aitoff HiPS to Galactic 0,0'
@@ -324,7 +324,7 @@ export const VisCtxToolbarView= memo((props) => {
             <Stack {...{direction:'row', justifyContent:'space-between',  sx: makeTbSX }}>
                 <Stack {...{direction:'row', alignItems: 'center',flexWrap: 'wrap',}}>
                     {showMultiImageController && <MultiImageControllerView plotView={pv} />}
-                    {showMultiImageController && showOptions && <Divider orientation='vertical' sx={{mx:.5}}  />}
+                    {showMultiImageController && showOptions && <Divider orientation='vertical' sx={{m:.5}}  />}
                     {makeButtons()}
                     {makeHipsControls()}
                 </Stack>

--- a/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
@@ -127,7 +127,7 @@ VisMiniToolbar.propTypes= {
 };
 
 const rS= {
-    width: 'calc(100% - 2px)',
+    // width: 'calc(100% - 2px)',
     height: 34,
     display: 'flex',
     position: 'relative',

--- a/src/firefly/js/voAnalyzer/TableAnalysis.js
+++ b/src/firefly/js/voAnalyzer/TableAnalysis.js
@@ -143,8 +143,8 @@ function getObsCoreTableColumn(tableOrId, name) {
 export const getObsCoreProdTypeCol = (tableOrId) => getObsCoreTableColumn(tableOrId, 'dataproduct_type');
 
 /**
- * Return true this this table can be access as an ObsCore data
- * @param tableOrId
+ * Return true this table can be access as ObsCore data
+ * @param {TableModel|String} tableOrId
  * @return {boolean}
  */
 export function hasObsCoreLikeDataProducts(tableOrId) {
@@ -165,15 +165,16 @@ function columnMatches(table, cName) {
 }
 
 /**
- * Find the a data source column if is is defined in the metadata and a column exist with that name. The
- * meta data entry DataSource is case insensitive matched. The column name is also match case insensitive.
- * The meta data entry can have two forms 'abc' or '[abc,efe,hij]' if it is the second form the the first
+ * Find the data source column if it is defined in the metadata and a column exists with that name.
+ * The metadata entry 'DataSource' is case-insensitive matched.
+ * The column name is also match case-insensitive.
+ * The metadata entry can have two forms 'abc' or '[abc,efe,hij]' if it is the second form then the first
  * entry in the array to match a column is returned. The second form is useful when the code defining the DataSource
  * entry is handling a set of table where the data source could be one of several name such
  * as '[url,fileurl,file_url,data_url,data]'
  * @param {TableModel|String} tableOrId - a table model or a table id
- * @return {boolean|undefined|string} the column name if it exist, if the meta data is not included,
- *                                             false if defined but set to 'false' (case insensitive)
+ * @return {boolean|undefined|string} the column name if it exists, if the metadata is not included,
+ *                                             false if defined but set to 'false' (case-insensitive)
  */
 export function getDataSourceColumn(tableOrId) {
     const table = getTableModel(tableOrId);
@@ -300,7 +301,7 @@ export function getProdTypeGuess(tableOrId, rowIdx) {
  * Guess if this table has enough ObsCore attributes to be considered an ObsCore table.
  * - any column contains utype with 'obscore:' prefix
  * - matches 3 or more of ObsCore column names
- * @param tableModel
+ * @param {TableModel} tableModel
  * @returns {boolean}
  */
 export function isObsCoreLike(tableModel) {


### PR DESCRIPTION
#### [FIREFLY-1448](https://jira.ipac.caltech.edu/browse/FIREFLY-1448) & [FIREFLY-1462](https://jira.ipac.caltech.edu/browse/FIREFLY-1462) & Small fixes

1. [FIREFLY-1448](https://jira.ipac.caltech.edu/browse/FIREFLY-1448):  image sorting/filtering clean up and refactor
    - sorting/filtering syncs when moving between expanded and collapsed mode
    - images stay sorted when new ones are add or removed
    - Images don't stay filtered but button gives an alert to revisit and reset filtering
1. [FIREFLY-1462](https://jira.ipac.caltech.edu/browse/FIREFLY-1462): fixed: obscore download buttons showing up when no products
1. Small fixes
     - Toolbar separators do not have top/bottom margin
     - `Scroll Images` now available in `Pinned Images` tab
     - TAP Object Id search shows warning color when column is marked `unset`
     - a little JS Doc clean up
     - improve error message (response code) on hips loading and file upload
     -  fixed file upload mask issue

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1448-image-sorting/firefly
- Test sorting and filtering
- test adding table the is obscore like but has now download columns, example in ticket [FIREFLY-1462](https://jira.ipac.caltech.edu/browse/FIREFLY-1462)
