### PR TITLE
FIREFLY-1463:  Add CorsFilter

### DIFF
--- a/config/web.xml
+++ b/config/web.xml
@@ -44,6 +44,15 @@
         <url-pattern>/sticky/firefly/events</url-pattern>
     </filter-mapping>
 
+    <!--CORS Filter-->
+    <filter>
+        <filter-name>CorsFilter</filter-name>
+        <filter-class>edu.caltech.ipac.firefly.server.filters.CorsFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>CorsFilter</filter-name>
+        <url-pattern>*.woff2</url-pattern>
+    </filter-mapping>
 
     <!-- Firefly servlet and its mappings -->
     <servlet>

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CorsFilter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CorsFilter.java
@@ -1,0 +1,47 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.filters;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+public class CorsFilter implements Filter {
+
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        if ( request instanceof HttpServletRequest req &&
+             response instanceof HttpServletResponse res) {
+
+            enableCors(req, res);
+            if (req.getMethod().equals("OPTIONS")) {
+                res.setStatus(HttpServletResponse.SC_ACCEPTED);
+                return;
+            }
+        }
+
+        filterChain.doFilter( request, response );
+    }
+
+    public void destroy() {}
+
+
+    public static void enableCors(HttpServletRequest req, HttpServletResponse resp) {
+        if (req.getHeader("Origin") != null) {
+            resp.setHeader("Access-Control-Allow-Credentials", "true");
+            resp.setHeader("Access-Control-Allow-Origin", req.getHeader("Origin"));
+            resp.setHeader("Access-Control-Allow-Headers", req.getHeader("Access-Control-Request-Headers"));
+            resp.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
+            resp.setHeader("Access-Control-Max-Age", "86400");      // cache for 1 day
+        }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/BaseHttpServlet.java
@@ -15,6 +15,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static edu.caltech.ipac.firefly.server.filters.CorsFilter.enableCors;
+
 /**
  * Date: Oct 27, 2008
  *
@@ -102,16 +104,6 @@ public abstract class BaseHttpServlet extends HttpServlet {
             handleException(req, res, e);
         } finally {
             StopWatch.getInstance().printLog(getClass().getSimpleName());
-        }
-    }
-
-    public static void enableCors(HttpServletRequest req, HttpServletResponse resp) {
-        if (req.getHeader("Origin") != null) {
-            resp.setHeader("Access-Control-Allow-Credentials", "true");
-            resp.setHeader("Access-Control-Allow-Origin", req.getHeader("Origin"));
-            resp.setHeader("Access-Control-Allow-Headers", req.getHeader("Access-Control-Request-Headers"));
-            resp.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
-            resp.setHeader("Access-Control-Max-Age", "86400");      // cache for 1 day
         }
     }
 


### PR DESCRIPTION
- apply CorsFilter to font files
- moved cors logic to this class

The way I tested it:
- change compose.yml to use port 8000 instead of 8080.
- run docker locally
- change src/firefly/html/test/template.html to load from 'http://localhost:8000/firefly_loader.js'

Then, I load `http://facade-local:8080/firefly/test/tests-table.html`.
`facade-local` is alias to localhost.  I think you can use localhost to achieve the same results.



![image](https://github.com/Caltech-IPAC/firefly/assets/11449642/e681a1da-a264-4944-a7f1-fec13779529b)



![image](https://github.com/Caltech-IPAC/firefly/assets/11449642/2cdf777f-d288-4743-bd2b-4341634773a3)
