### PR TITLE
FIREFLY-1464: Cleanup Table Info dialog, metadata

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/JsonTableUtil.java
@@ -540,7 +540,7 @@ public class JsonTableUtil {
             if (ri.getParams().size() > 0) json.put("params", toJsonParamInfos(ri.getParams()));
             if (ri.getInfos().size() > 0)  json.put("infos", ri.getInfos());
             return json;
-        }).collect(Collectors.toList());
+        }).filter(json -> !json.isEmpty()).collect(Collectors.toList());
     }
 
     /**

--- a/src/firefly/js/core/background/BackgroundMonitor.css
+++ b/src/firefly/js/core/background/BackgroundMonitor.css
@@ -2,37 +2,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-.JobInfo__main {
-    display: flex;
-    flex-direction: column;
-    padding: 10px;
-    overflow: hidden;
-}
-
-.JobInfo__popup {
-    width: 500px;
-    height: 150px;
-    min-height: 100px;
-    min-width: 250px;
-    resize: both;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-}
-.JobInfo__popup.uws {
-    position: relative;
-    height: 200px;
-}
-
-.JobInfo__items {
-    display: flex;
-    flex-direction: column;
-}
-
-.JobInfo__items > * {
-    margin: 2px 0;
-}
 
 .JobInfo__items--link {
     height: 16px;

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -7,22 +7,23 @@ import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {dispatchShowDialog} from '../ComponentCntlr.js';
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
-import {CollapsiblePanel} from 'firefly/ui/panel/CollapsiblePanel.jsx';
+import {CollapsibleItem, CollapsibleGroup} from 'firefly/ui/panel/CollapsiblePanel.jsx';
 import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson.js';
-import {Button, Stack, Typography} from '@mui/joy';
+import {Box, Button, Stack} from '@mui/joy';
 import {OverflowMarker} from 'firefly/tables/ui/TablePanel.jsx';
 
+
+const popupSx = {justifyContent: 'space-between', resize: 'both', overflow: 'auto',
+    minHeight: 200, minWidth: 450};
 
 export function showJobInfo(jobId) {
     const ID = 'show-job-info';
     const popup = (
         <PopupPanel title='Job Information' >
-            <div key={jobId} className='JobInfo__popup'>
-                <JobInfo jobId={jobId}/>
-                <div style={{margin: '2px 19px 6px'}}>
-                    <HelpIcon helpId={'basics.bgJobInfo'} style={{float: 'right'}}/>
-                </div>
-            </div>
+            <Stack key={jobId} sx={popupSx}>
+                <JobInfo jobId={jobId} sx={{overflow: 'auto'}}/>
+                <HelpIcon helpId={'basics.bgJobInfo'} sx={{ml: 'auto'}}/>
+            </Stack>
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(ID, popup);
@@ -34,9 +35,9 @@ export async function showUwsJob({jobUrl, jobId}) {
     const id = 'show-uws-job-info';
     const mask = (
         <PopupPanel title='UWS Job' >
-            <div key={jobId} className='JobInfo__popup uws'>
+            <Box key={jobId} sx={{...popupSx, position: 'relative'}}>
                 <div className='loading-mask'/>
-            </div>
+            </Box>
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(id, mask);
@@ -45,12 +46,10 @@ export async function showUwsJob({jobUrl, jobId}) {
     const jobInfo = await uwsJobInfo(jobUrl, jobId);
     const popup = (
         <PopupPanel title='UWS Job' >
-            <div key={jobId} className='JobInfo__popup uws'>
-                <UwsJobInfo jobInfo={jobInfo}/>
-                <div style={{margin: '2px 19px 6px'}}>
-                    <HelpIcon helpId={'basics.uwsJob'} style={{float: 'right'}}/>
-                </div>
-            </div>
+            <Stack key={jobId} sx={popupSx}>
+                <UwsJobInfo jobInfo={jobInfo} sx={{overflow: 'auto'}}/>
+                <HelpIcon helpId={'basics.uwsJob'} sx={{ml: 'auto'}}/>
+            </Stack>
         </PopupPanel>
     );
 
@@ -59,20 +58,18 @@ export async function showUwsJob({jobUrl, jobId}) {
 }
 
 
-export function JobInfo({jobId, style, tbl_id}) {
+export function JobInfo({jobId, sx, tbl_id}) {
     const {phase, startTime, endTime, results, errorSummary, jobInfo={}} = useStoreConnector(() => getJobInfo(jobId) || {});
     const {dataOrigin, summary, type} = jobInfo;
     return (
-        <div className='JobInfo__main' style={style}>
-            <div className='JobInfo__items'>
-                <KeywordBlock label='Phase' value={phase}/>
-                <KeywordBlock label='Start Time' value={startTime}/>
-                {endTime && <KeywordBlock label='End Time' value={endTime}/>}
-                <DataOrigin {...{dataOrigin, type, jobId}}/>
-                <FinalMsg {...{phase, results, errorSummary, summary, tbl_id}}/>
-                <KeywordBlock label='ID' value={jobId} title='Internal query identifier, usable for diagnostics'/>
-            </div>
-        </div>
+        <Stack spacing={.5} p={1} sx={sx}>
+            <KeywordBlock label='Phase' value={phase}/>
+            <KeywordBlock label='Start Time' value={startTime}/>
+            {endTime && <KeywordBlock label='End Time' value={endTime}/>}
+            <DataOrigin {...{dataOrigin, type, jobId}}/>
+            <FinalMsg {...{phase, results, errorSummary, summary, tbl_id}}/>
+            <KeywordBlock label='ID' value={jobId} title='Internal query identifier, usable for diagnostics'/>
+        </Stack>
     );
 }
 
@@ -83,8 +80,8 @@ function DataOrigin({dataOrigin, type, jobId}) {
     if (!isUws) return <KeywordBlock label={label} value={dataOrigin} asLink={true}/>;
     return (
         <div style={{display: 'inline-flex'}}>
-            <KeywordBlock style={{width: 425, alignItems:'center'}} label={label} value={dataOrigin} asLink={true}/>
-            <Button ml={1/2} onClick={() => showUwsJob({jobId})}>Show</Button>
+            <KeywordBlock sx={{width: 425, alignItems:'center'}} label={label} value={dataOrigin} asLink={true}/>
+            <Button ml={1/2} size='sm' onClick={() => showUwsJob({jobId})}>Show</Button>
         </div>
     );
 }
@@ -102,35 +99,32 @@ function FinalMsg({phase, summary, error, tbl_id}) {
     } else return null;
 }
 
-export function UwsJobInfo({jobInfo, style, isOpen=false}) {
+export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
     const hrefs = jobInfo?.results?.map((r) => r.href);
     return (
-        <div className='JobInfo__main' style={style}>
-            <div className='JobInfo__items uws' style={{overflowY: 'auto'}}>
-                <> {
-                    Object.entries(jobInfo)
-                        .filter(([k]) => !['parameters', 'results', 'errorSummary', 'jobInfo'].includes(k))
-                        .map(([k,v]) => <KeywordBlock key={k} label={k} value={v}/>)
-                }</>
+        <Stack spacing={.5} p={1} sx={sx}>
+            {Object.entries(jobInfo)
+                    .filter(([k]) => !['parameters', 'results', 'errorSummary', 'jobInfo'].includes(k))
+                    .map(([k,v]) => <KeywordBlock key={k} label={k} value={v}/>)
+            }
 
+            <CollapsibleGroup>
                 <OptionalBlock label='parameters' value={jobInfo.parameters} isOpen={isOpen}/>
                 <OptionalBlock label='results' value={hrefs} asLink={true} isOpen={isOpen}/>
                 <OptionalBlock label='errorSummary' value={jobInfo.errorSummary} isOpen={isOpen}/>
+            </CollapsibleGroup>
 
-            </div>
-        </div>
+        </Stack>
     );
 }
 
 function OptionalBlock({label, value, asLink, isOpen}) {
     if (!value) return null;
     return (
-        <CollapsiblePanel componentKey={`JobInfo-${label}`} header={label} isOpen={isOpen}>
-            <div className='JobInfo__items'>
-                <> {
-                    Object.entries(value).map(([k,v]) => <KeywordBlock key={k} label={k} value={v} asLink={asLink}/>)
-                }</>
-            </div>
-        </CollapsiblePanel>
+        <CollapsibleItem componentKey={`JobInfo-${label}`} header={label} isOpen={isOpen}>
+            <Stack spacing={.5}>
+                {Object.entries(value).map(([k, v]) => <KeywordBlock key={k} label={k} value={v} asLink={asLink}/>)}
+            </Stack>
+        </CollapsibleItem>
     );
 }

--- a/src/firefly/js/tables/ui/ObjectTree.jsx
+++ b/src/firefly/js/tables/ui/ObjectTree.jsx
@@ -4,10 +4,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {set, get, isObject} from 'lodash';
+import {set, get, isObject, isString} from 'lodash';
 
 import Tree from 'rc-tree';
 import 'rc-tree/assets/index.css';
+import {Sheet, Stack, Typography} from '@mui/joy';
 
 
 /**
@@ -16,12 +17,13 @@ import 'rc-tree/assets/index.css';
  * Based on rc-tree:  http://react-component.github.io/tree/
  *
  */
-export const ObjectTree = React.memo(({data, defaultExpandAll=true, selectable=false, onSelect, nodeClassName, className, style, title}) => {
+export const ObjectTree = React.memo(({data, defaultExpandAll=true, selectable=false, onSelect, nodeClassName, sx, title}) => {
     const treeData = transformToTreeNodes(data, nodeClassName);
     return (
-        <div className={className} style={style}> {title || ''}
+        <Sheet component={Stack} spacing={.5} variant='outlined' sx={{fontSize: 'sm', p: 1, ...sx}}>
+            {isString(title) ? <Typography level='title-md'>{title}</Typography> : (title || false)}
             <Tree {...{defaultExpandAll,onSelect,selectable }} treeData={get(treeData, [0, 'children'])}/>
-        </div>
+        </Sheet>
     );
 });
 
@@ -30,10 +32,9 @@ ObjectTree.propTypes = {
     defaultExpandAll:   PropTypes.bool,
     onSelect:           PropTypes.func,
     selectable:         PropTypes.bool,
-    className:          PropTypes.string,
     nodeClassName:      PropTypes.string,
-    style:              PropTypes.object,
-    title:              PropTypes.node
+    sx:                 PropTypes.object,
+    title:              PropTypes.oneOfType([PropTypes.element, PropTypes.string])
 };
 
 

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Typography, Box, Link, Stack} from '@mui/joy';
+import {Typography, Link, Stack, Chip} from '@mui/joy';
 
 import {isEmpty} from 'lodash';
 import {getTblById, hasAuxData} from '../TableUtil.js';
@@ -64,6 +64,7 @@ export function MetaInfo({tbl_id, isOpen=false, ...props}) {
         return null;
     }
     const {keywords, links, params, resources, groups} = getTblById(tbl_id);
+    const keywordBlocksRowProps = { direction: 'row', alignItems: 'baseline', spacing: .5 };
 
     return (
         <Stack {...props}>
@@ -88,18 +89,14 @@ export function MetaInfo({tbl_id, isOpen=false, ...props}) {
                 { !isEmpty(groups) &&
                 <CollapsibleItem componentKey={tbl_id + '-groups'} header='Groups' isOpen={isOpen}>
                     {groups.map((rs, idx) => {
-                        const showValue = () => showInfoPopup(
-                            <div style={{whiteSpace: 'pre'}}>
-                                <ObjectTree data={rs} title={<b>Group</b>} className='MetaInfo__tree'/>
-                            </div> );
                         return (
-                            <div key={'groups-' + idx} style={{display: 'inline-flex', alignItems: 'center'}}>
-                                { rs.ID && <Keyword label='ID' value={rs.ID}/> }
-                                { rs.name && <Keyword label='name' value={rs.name}/> }
-                                { rs.UCD && <Keyword label='UCD' value={rs.UCD}/> }
-                                { rs.utype && <Keyword label='utype' value={rs.utype}/> }
-                                <Link onClick={showValue}> show value</Link>
-                            </div>
+                            <Stack key={'groups-' + idx} {...keywordBlocksRowProps}>
+                                { rs.ID && <KeywordBlock label='ID' value={rs.ID}/> }
+                                { rs.name && <KeywordBlock label='name' value={rs.name}/> }
+                                { rs.UCD && <KeywordBlock label='UCD' value={rs.UCD}/> }
+                                { rs.utype && <KeywordBlock label='utype' value={rs.utype}/> }
+                                <ShowObjectTreeBtn data={rs} title={'Group'}/>
+                            </Stack>
                         );
                     })
                     }
@@ -109,12 +106,12 @@ export function MetaInfo({tbl_id, isOpen=false, ...props}) {
                 <CollapsibleItem componentKey={tbl_id + '-links'} header='Links' isOpen={isOpen}>
                     {links.map((l, idx) => {
                         return (
-                            <div key={'links-' + idx} style={{display: 'inline-flex', alignItems: 'center'}}>
-                                { l.ID && <Keyword label='ID' value={l.ID}/> }
-                                { l.role && <Keyword label='role' value={l.role}/> }
-                                { l.type && <Keyword label='type' value={l.type}/> }
+                            <Stack key={'links-' + idx} {...keywordBlocksRowProps}>
+                                { l.ID && <KeywordBlock label='ID' value={l.ID}/> }
+                                { l.role && <KeywordBlock label='role' value={l.role}/> }
+                                { l.type && <KeywordBlock label='type' value={l.type}/> }
                                 { l.href && <LinkTag {...l}/>}
-                            </div>
+                            </Stack>
                         );
                     })
                     }
@@ -123,17 +120,13 @@ export function MetaInfo({tbl_id, isOpen=false, ...props}) {
                 { !isEmpty(resources) &&
                 <CollapsibleItem componentKey={tbl_id + '-resources'} header='Resources' isOpen={isOpen}>
                     {resources.map((rs, idx) => {
-                        const showValue = () => showInfoPopup(
-                            <div style={{whiteSpace: 'pre'}}>
-                                <ObjectTree data={rs} title={<b>Resource</b>} className='MetaInfo__tree'/>
-                            </div> );
                         return (
-                            <Stack direction='row' key={'resources-' + idx}>
-                                { rs.ID && <Keyword label='ID' value={rs.ID}/> }
-                                { rs.name && <Keyword label='name' value={rs.name}/> }
-                                { rs.type && <Keyword label='type' value={rs.type}/> }
-                                { rs.utype && <Keyword label='utype' value={rs.utype}/> }
-                                <Link onClick={showValue}> show value</Link>
+                            <Stack key={'resources-' + idx} {...keywordBlocksRowProps}>
+                                { rs.ID && <KeywordBlock label='ID' value={rs.ID}/> }
+                                { rs.name && <KeywordBlock label='name' value={rs.name}/> }
+                                { rs.type && <KeywordBlock label='type' value={rs.type}/> }
+                                { rs.utype && <KeywordBlock label='utype' value={rs.utype}/> }
+                                <ShowObjectTreeBtn data={rs} title={'Resource'}/>
                             </Stack>
                         );
                     })
@@ -146,11 +139,29 @@ export function MetaInfo({tbl_id, isOpen=false, ...props}) {
     );
 }
 
-export function KeywordBlock({style={}, label, value, title, asLink}) {
+
+const ShowObjectTreeBtn = ({data, title}) => {
+    const popupSx = {
+        '.FF-Popup-Content-root': {
+            overflow: 'auto', resize: 'both', justifyContent: 'space-between',
+            height: '50vh', minHeight: 200,
+            width: '60vh', minWidth: 200,
+        },
+        '.FF-Popup-Content': {height: 1, maxWidth: 'unset', minWidth: 'unset'} //unset width bounds because controlled by resizable parent (-root)
+    };
+    const sx = {overflow: 'auto', width: 1, height: 1};
+
     return (
-        <div style={{display: 'inline-flex', alignItems: 'baseline', ...style}}>
+        <Chip onClick={() => showInfoPopup(<ObjectTree {...{data, title, sx}}/>, undefined, popupSx)}
+              color='primary' sx={{alignSelf: 'center'}}> show </Chip>
+    );
+};
+
+export function KeywordBlock({sx={}, label, value, title, asLink}) {
+    return (
+        <Stack direction='row' display='inline-flex' alignItems='baseline' sx={sx}>
             <Keyword {...{label, value, title, asLink}}/>
-        </div>
+        </Stack>
     );
 }
 
@@ -162,7 +173,7 @@ export function Keyword({label, value, title, asLink}) {
             <>
                 {label && <Typography level='title-sm' title={title} mr={1/2}>{label}</Typography>}
                 { asLink ? <LinkTag title={value} href={value} /> :
-                    <ContentEllipsis text={value} sx={{p: '1px', margin: 'unset'}}><Typography level='body-xs' title={value} noWrap mr={1/2}>{value}</Typography></ContentEllipsis>
+                    <ContentEllipsis text={value} sx={{p: '1px', margin: 'unset'}}><Typography level='body-sm' title={value} noWrap mr={1/2}>{value}</Typography></ContentEllipsis>
                 }
             </>
         );
@@ -175,9 +186,9 @@ export function LinkTag({href, title}) {
     title = title || href;
     if (href) {
         return (
-            <Stack overflow='hidden' direction='row' spacing={1} alignItems='center'>
-                <CopyToClipboard value={href} size={16} buttonStyle={{backgroundColor: 'unset'}}/>
-                <Link level='body-xs' href={href} title={title} target='Links'
+            <Stack overflow='hidden' direction='row' spacing={.75} alignItems='baseline'>
+                <CopyToClipboard value={href} size={16} buttonStyle={{backgroundColor: 'unset'}} style={{alignSelf: 'end'}}/>
+                <Link level='body-sm' href={href} title={title} target='Links'
                       sx={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>
                     {title}
                 </Link>

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -71,15 +71,6 @@
     resize: both;
 }
 
-.MetaInfo__tree {
-    overflow: auto;
-    max-width: 400px;
-    max-height: 300px;
-    border: 1px solid #b3b3b3;
-    background-color: white;
-    padding: 5px 0;
-}
-
 .CellRenderer__numrange {
     line-height: normal;
     display: flex;

--- a/src/firefly/js/ui/PopupUtil.jsx
+++ b/src/firefly/js/ui/PopupUtil.jsx
@@ -102,7 +102,7 @@ export function hideInfoPopup() {
 
 function makeContent(content) {
     return (
-        <Stack {...{px:2, py:1, spacing:2}}>
+        <Stack {...{px:2, py:1, spacing:2, className:'FF-Popup-Content-root'}}>
             <Stack {...{className:'FF-Popup-Content', minWidth:350, maxWidth: 500, overflow: 'hidden'}}>
                 {isString(content) ? ( <Typography level='body-md'>{content}</Typography> ) : content}
             </Stack>


### PR DESCRIPTION
Fixes [FIREFLY-1464](https://jira.ipac.caltech.edu/browse/FIREFLY-1464)

- Made font sizes same, aligned their baselines (note: everything is sm now, key value pairs have different font-weights to disambiguate)
- Replace "show more" link by chip "show"
- Made metadata info popup resizable
- Removed css styles and cleaned up redundant code & layout a bit

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1464-metadata/firefly/

Go to TAP -> m81, 100 arcsec -> table info.
- compare font sizes and alignment with nightly build in both Job info and metadata tab 
- click on "show" chip button in "table metadata" tab
   - the popup should be resizable 
   - when popup size is reduced below content dimensions, the content should be scrollable
- click on "show" button in "job info" tab, the popup should be as before with minor improvements (to test css replaced by sx)