### PR TITLE
Firefly-1451: Embedded Position Search Panel Enhancements

### DIFF
--- a/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
+++ b/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
@@ -299,7 +299,7 @@ function ServDescPanel({fds, sx, desc, groupKey, setSideBarShowing, sideBarShowi
         <Stack {...{justifyContent:'space-between', sx}}>
             <DLSearchTitle {...{desc,isAllSky,sideBarShowing,setSideBarShowing,...slotProps.searchTitle}}/>
             <DynLayoutPanelTypes.Inset fieldDefAry={fds} plotId={HIPS_PLOT_ID} style={{height:'100%', marginTop:4}}
-                                       WrapperComponent={SearchPanelWrapper} toolbarHelpId={'dlGenerated.VisualSelection'} />
+                                       WrapperComponent={SearchPanelWrapper} toolbarHelpId={'dlGenerated.VisualSelection'} submitSearch={submitSearch} />
         </Stack>
     );
 }

--- a/src/firefly/js/ui/dynamic/DynComponents.jsx
+++ b/src/firefly/js/ui/dynamic/DynComponents.jsx
@@ -70,7 +70,7 @@ export function getSpacialSearchType(request, fieldDefAry) {
  * @returns {{}}
  */
 export function makeAllFields({fieldDefAry, noLabels=false, popupHiPS, toolbarHelpId,
-                                  plotId='defaultHiPSTargetSearch', insetSpacial=false} )  {
+                                  plotId='defaultHiPSTargetSearch', insetSpacial=false, submitSearch} )  {
 
     // polygon is not created directly, we need to determine who will create creat a polygon field
     const workingFieldDefAry= fieldDefAry.filter( ({hide}) => !hide);
@@ -89,7 +89,7 @@ export function makeAllFields({fieldDefAry, noLabels=false, popupHiPS, toolbarHe
         dynSpacialPanel= popupHiPS ?
                         makeDynSpacialPanel({fieldDefAry:workingFieldDefAry, popupHiPS, manageAllSpacial, plotId, toolbarHelpId}) :
                         makeDynSpacialPanel({fieldDefAry:workingFieldDefAry, popupHiPS,
-                            plotId,toolbarHelpId, insetSpacial});
+                            plotId,toolbarHelpId, insetSpacial, submitSearch});
     }
 
     const panels = {
@@ -175,7 +175,7 @@ function CircleAndPolyFieldPopup({fieldDefAry, typeForCircle= CIRCLE, plotId='de
 
 
 export function PositionAndPolyFieldEmbed({fieldDefAry, plotId, toolbarHelpId, insetSpacial,
-                                       otherComponents, WrapperComponent}) {
+                                       otherComponents, WrapperComponent, submitSearch}) {
 
     const polyType = findFieldDefType(fieldDefAry, POLYGON);
     const posType = findFieldDefType(fieldDefAry, POINT) ?? findFieldDefType(fieldDefAry, POSITION);
@@ -226,6 +226,7 @@ export function PositionAndPolyFieldEmbed({fieldDefAry, plotId, toolbarHelpId, i
             nullAllowed,
             insetSpacial,
             otherComponents,
+            doSearch:submitSearch
             }}/>
 
     );
@@ -356,7 +357,7 @@ export function PolygonField({ fieldKey, desc = 'Coordinates', initValue = '', s
 }
 
 function makeDynSpacialPanel({fieldDefAry, manageAllSpacial= true, popupHiPS= false,
-                             plotId= 'defaultHiPSTargetSearch', toolbarHelpId, insetSpacial}) {
+                             plotId= 'defaultHiPSTargetSearch', toolbarHelpId, insetSpacial, submitSearch}) {
     const DynSpacialPanel= ({otherComponents, WrapperComponent}) => {
         const posType = findFieldDefType(fieldDefAry, POINT) ?? findFieldDefType(fieldDefAry, POSITION) ;
         const areaType = findFieldDefType(fieldDefAry, AREA);
@@ -379,7 +380,7 @@ function makeDynSpacialPanel({fieldDefAry, manageAllSpacial= true, popupHiPS= fa
         if (manageAllSpacial && sizeKey) {
             return popupHiPS ?
                 <CircleAndPolyFieldPopup {...{fieldDefAry,typeForCircle:circleType?CIRCLE:POSITION, plotId, toolbarHelpId}}/> :
-                <PositionAndPolyFieldEmbed {...{fieldDefAry, plotId, insetSpacial, otherComponents, WrapperComponent, toolbarHelpId}}/>;
+                <PositionAndPolyFieldEmbed {...{fieldDefAry, plotId, insetSpacial, otherComponents, WrapperComponent, toolbarHelpId, submitSearch}}/>;
         }
         else {
             if (popupHiPS) {

--- a/src/firefly/js/ui/dynamic/DynamicUISearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/DynamicUISearchPanel.jsx
@@ -245,9 +245,9 @@ function SimpleDynSearchPanel({style={}, fieldDefAry, popupHiPS= true, plotId='d
 }
 
 function InsetDynSearchPanel({style={}, fieldDefAry, popupHiPS= false, plotId='defaultHiPSTargetSearch', toolbarHelpId,
-                                 childComponents, WrapperComponent}) {
+                                 childComponents, WrapperComponent, submitSearch}) {
     const { DynSpacialPanel, areaFields, polyPanel, checkBoxFields, fieldsInputAry, opsInputAry,
-        useSpacial, useArea}= makeAllFields({ fieldDefAry,popupHiPS, plotId, toolbarHelpId, insetSpacial:true});
+        useSpacial, useArea}= makeAllFields({ fieldDefAry,popupHiPS, plotId, toolbarHelpId, insetSpacial:true, submitSearch});
 
     let iFieldLayout;
     if (fieldsInputAry.length || opsInputAry.length) {

--- a/src/firefly/js/ui/panel/CollapsiblePanel.jsx
+++ b/src/firefly/js/ui/panel/CollapsiblePanel.jsx
@@ -4,7 +4,7 @@
 
 import './CollapsiblePanel.css';
 import React from 'react';
-import PropTypes, {bool, element, func, object, oneOfType, shape, string} from 'prop-types';
+import PropTypes, {bool, func, node, object, oneOfType, shape, string} from 'prop-types';
 import {isFunction, omit} from 'lodash';
 import {Tooltip, Accordion, AccordionGroup} from '@mui/joy';
 import AccordionDetails, {accordionDetailsClasses} from '@mui/joy/AccordionDetails';
@@ -132,7 +132,7 @@ export function CollapsibleGroup({sx, children, ...props}) {
  */
 export function CollapsibleItemView({isOpen, header, title, onToggle, slotProps, children, ...props}) {
 
-    header = isFunction(header) ? header() : header;
+    header = isFunction(header) ? header(isOpen) : header;
     const onChange = (e,v) => {
         onToggle?.(v);
     };
@@ -156,12 +156,12 @@ export function CollapsibleItemView({isOpen, header, title, onToggle, slotProps,
 CollapsibleItemView.propTypes = {
     componentKey: string,
     isOpen: bool,
-    header: oneOfType([string, func, element]),
+    header: oneOfType([node, func]),
     title: string,
     slotProps: shape({  // consult JoyUI doc for details.
-        header: object,     // passed to AccordionSummary
-        content: object,    // passed to AccordionDetails
-        tooltip: object     // passed to Tooltip
+        header: object,         // passed to AccordionSummary
+        content: object,        // passed to AccordionDetails
+        tooltip: object         // passed to Tooltip
     })
 };
 


### PR DESCRIPTION
**[FIREFLY-1451](https://jira.ipac.caltech.edu/browse/FIREFLY-1451)**: 

- see ticket details
- made header as small as possible when search panel is open, and when collapsed, display a search summary. 
- reduced opacity of search panel on mouse click anywhere outside the search panel, but hover/mouseover the search panel brings it back to 100% opacity

- corresponding irsa-ife PR: https://github.com/IPAC-SW/irsa-ife/pull/323

**Testing**: 
- Euclid: https://firefly-1451-embed-panel-enhanced.irsakudev.ipac.caltech.edu/applications/euclid
   - Play around with the searches, collapse the panel for cone and multi-object (before and uploading a file - should work in both cases). 
- DCE: https://firefly-1451-embed-panel-enhanced.irsakudev.ipac.caltech.edu/irsaviewer/dce
   - the search panel will be a bit buggy for DCE right now when collapsed, since there's no groupKey being sent to `EmbeddedPositionSearchPanel`
   - but if we wrap the call to `EmbeddedPositionSearchPanel` in a FieldGroup with a groupKey, then this may work as well (or if we decide not to make it collapsible for DCE, then the collapse behavior can be made conditional in `EmbeddedPositionSearchPanel`). 