### PR TITLE
FIREFLY-1187: Update TAP ObsCore.jsx to support more options

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCoreMetadataQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCoreMetadataQuery.java
@@ -1,0 +1,111 @@
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.server.util.QueryUtil;
+import edu.caltech.ipac.firefly.server.util.StopWatch;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataObject;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+import static edu.caltech.ipac.firefly.server.query.ObsCoreMetadataQuery.*;
+import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.getTableResult;
+
+
+@SearchProcessorImpl(id = ID, params = {
+        @ParamDoc(name = SVC_URL, desc = "base TAP url endpoint excluding '/sync'"),
+        @ParamDoc(name = OBSCORE_TNAME, desc = "obscore schema.table"),
+        @ParamDoc(name = COLUMNS, desc = "columns to retrieve metadata for"),
+})
+public class ObsCoreMetadataQuery extends EmbeddedDbProcessor {
+    public static final String ID = "ObsCoreMetadataQuery";
+    public static final String SVC_URL = "serviceUrl";
+    public static final String OBSCORE_TNAME = "obscoreTable";
+    public static final String COLUMNS = "columns";
+    public static final String QUERY_FRAGMENT = "/sync?REQUEST=doQuery&LANG=ADQL&QUERY=";
+    public static final Logger.LoggerImpl LOGGER = Logger.getLogger();
+
+
+    public DataGroup fetchDataGroup(TableServerRequest request) throws DataAccessException {
+        List<String> columns = StringUtils.asList(request.getParam(COLUMNS), ",");
+        List<Future<DataGroup>> futures = new ArrayList<>();
+        List<Throwable> exceptions = new ArrayList<>();
+        StopWatch timer = StopWatch.getInstance();
+
+        ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            timer.start("All queries");
+            // Submit queries for each column in parallel
+            for (String column : columns) {
+                Future<DataGroup> future = executor.submit(() -> {
+                    timer.start(column+" query");
+                    DataGroup columnMetaData = fetchColumnMetaData(request, column);
+                    timer.printLog(column+" query");
+                    return columnMetaData;
+                });
+                futures.add(future);
+            }
+
+            // Retrieve DataGroup from each future one by one
+            List<DataGroup> columnsMetadata = new ArrayList<>();
+            for (Future<DataGroup> future : futures) {
+                try {
+                    columnsMetadata.add(future.get());  // note: blocking main thread until completion of this future, will still lead to completion of the futures running in other threads
+                } catch (InterruptedException | ExecutionException e) {
+                    exceptions.add(e);
+                    columnsMetadata.add(null);
+                }
+            }
+            timer.printLog("All queries");
+
+            // If all futures failed, throw a combined exception; otherwise log exceptions (if occurred)
+            if (exceptions.size() == futures.size()) throw new DataAccessException(mergeErrorMsg(exceptions));
+            else if (exceptions.size() > 0) LOGGER.warn(mergeErrorMsg(exceptions));
+
+            return mergeColumnsMetadata(columns, columnsMetadata);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+
+    private DataGroup mergeColumnsMetadata(List<String> columns, List<DataGroup> columnsMetadata) {
+        DataGroup table = new DataGroup("ObsCore Metadata", new DataType[]{
+                new DataType("column_name", String.class),
+                new DataType("column_options", String.class)
+        });
+
+        for (int i=0; i<columns.size(); i++) {
+            String colName = columns.get(i);
+            DataGroup colMetadata = columnsMetadata.get(i);
+
+            if(colMetadata!=null) {
+                for (int j = 0; j < colMetadata.size(); j++) {
+                    DataObject row = new DataObject(table);
+                    row.setData(new Object[]{colName, colMetadata.getData(colName, j)});
+                    table.add(row);
+                }
+            }
+        }
+        table.trimToSize();
+        return table;
+    }
+
+    private DataGroup fetchColumnMetaData(TableServerRequest request, String columnName) throws DataAccessException {
+        String serviceUrl = request.getParam(SVC_URL);
+        String obscoreTable= request.getParam(OBSCORE_TNAME);
+        String query = "SELECT+DISTINCT+" + columnName + "+FROM+" + obscoreTable;
+        String url = serviceUrl + QUERY_FRAGMENT + query;
+        return getTableResult(url, QueryUtil.getTempDir(request));
+    }
+
+    private String mergeErrorMsg(List<Throwable> exceptions) {
+        return exceptions.stream().map(Throwable::getMessage).collect(Collectors.joining("\n"));
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -172,10 +172,6 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
         }
     }
 
-    static String getFilename(String urlStr) {
-        return urlStr.replace("(http:|https:)", "").replace("/", "");
-    }
-
 //====================================================================
 //  UWS utils
 //====================================================================
@@ -216,8 +212,7 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
     public static DataGroup getTableResult(String url, File workDir) throws DataAccessException {
         try {
             // download file first: failing to parse gaia results with topcat SAX parser from url
-            String filename = getFilename(url);
-            File outFile = File.createTempFile(filename, ".vot", workDir);
+            File outFile = File.createTempFile("results-", ".vot", workDir);
 
             // Must followRedirect because TAP specifically say this endpoint may be redirected.
             // Using 'getWithAuth' because it will handle credential when redirected

--- a/src/firefly/js/ui/tap/TableSearchMethods.jsx
+++ b/src/firefly/js/ui/tap/TableSearchMethods.jsx
@@ -13,7 +13,7 @@ import {ObjectIDSearch} from 'firefly/ui/tap/ObjectIDSearch';
 const TAP_SEARCH_METHODS_GROUP= 'TAP_SEARCH_METHODS_GROUP';
 
 export const TableSearchMethods = ({initArgs, obsCoreEnabled, columnsModel, serviceUrl, sx,
-                                       serviceLabel, tableName, capabilities}) => {
+                                       serviceLabel, tableName, capabilities, obsCoreMetadataModel}) => {
 
     const [controlConnected, setControlConnected] = useState(false);
 
@@ -21,7 +21,7 @@ export const TableSearchMethods = ({initArgs, obsCoreEnabled, columnsModel, serv
         <ConnectionCtx.Provider value={{controlConnected, setControlConnected}}>
             <Box sx={{...sx, height: '100%', overflow: 'auto'}} >
                 <HelperComponents {...{initArgs,cols:getAvailableColumns(columnsModel), tableName,
-                    columnsModel,serviceUrl,serviceLabel,obsCoreEnabled,capabilities}}/>
+                    columnsModel,serviceUrl,serviceLabel,obsCoreEnabled,capabilities,obsCoreMetadataModel}}/>
             </Box>
         </ConnectionCtx.Provider>
     );
@@ -29,11 +29,12 @@ export const TableSearchMethods = ({initArgs, obsCoreEnabled, columnsModel, serv
 
 const CompDivide= () => <Box sx={{my:1}}/>;
 
-function HelperComponents({initArgs, cols, columnsModel, serviceUrl, serviceLabel, obsCoreEnabled, tableName, capabilities}) {
+function HelperComponents({initArgs, cols, columnsModel, serviceUrl, serviceLabel, obsCoreEnabled, tableName,
+                              capabilities, obsCoreMetadataModel}) {
     return obsCoreEnabled ?
         (
             <>
-                <ObsCoreSearch {...{sx:{mt:1}, cols, serviceLabel, initArgs}} />
+                <ObsCoreSearch {...{sx:{mt:1}, cols, obsCoreMetadataModel, serviceLabel, initArgs}} />
                 <CompDivide/>
                 <SpatialSearch {...{cols, serviceUrl, serviceLabel, columnsModel, initArgs, obsCoreEnabled, tableName, capabilities}} />
                 <CompDivide/>


### PR DESCRIPTION
Fixes [FIREFLY-1187](https://jira.ipac.caltech.edu/browse/FIREFLY-1187)

- For ObsCore Instrument, Collection, and SubType, created a `ObsCoreInputField` that can render as ValidationField or multi-select AutocompleteInput, depending on the options supplied from AppOptions
- Updated ADQL generation code to allow parsing of options from ListBoxInput 
- Added a search processor `ObsCoreMetadataQuery` that fires queries for different obscore columns in parallel to retrieve metadata 
- Added client-side code in TAP root panel to fire the above query for each obscore capable service when selected, and then passes the resulting table metadata table to ObsCore panel. Also caches the results in same way as schema, tables, & columns 
- Enabled multiple mode in Autocomplete. Note: this requires disabling freeSolo for the reason mentioned in code comments

## Testing
For seeing autocomplete input field mode, check suit build (I updated SUIT.js to remove placeholders [this PR](https://github.com/lsst/suit/pull/52)): have to build locally with this branch name for both suit and firefly because of security token not working in jenkins.

DP0.2 Images tab -> the autocomplete for instrument, collection, subtype should have options. Then try instrument: LSSTCam, <NULL>; subtype: lsst.raw -> 
- check ADQL generated for it should have constraints for these fields
- submit and check that in results, the table should only have these values in their corresponding columns (use filters to inspect)


In firefly build: https://fireflydev.ipac.caltech.edu/firefly-1187-obscore-options/firefly/, check that:
- Column input field in chart options isn't broken because of changes in Autocomplete state logic
- Additionally, select TAP -> CADC -> ObsTAP: wait for 5.5 min for ObsCore options to populate, you can go to Networks tab in Devtools to see the query was fired. Once results are retrieved, ADQL should look ok and results should be as expected.