### PR TITLE
FIREFLY-1468 Non-celestial coordinate readout.

### DIFF
--- a/src/firefly/js/ui/PositionFieldDef.js
+++ b/src/firefly/js/ui/PositionFieldDef.js
@@ -4,7 +4,6 @@ import CoordUtil from '../visualize/CoordUtil.js';
 
 import {sprintf} from '../externalSource/sprintf.js';
 import VisUtil from 'firefly/visualize/VisUtil';
-import {instanceOf} from "prop-types";
 
 const errMsgRoot= 'Error: ';
 
@@ -104,7 +103,7 @@ export function formatPosForHelp(wp) {
               ${hmsRa},&nbsp;${hmsDec}&nbsp;&nbsp;${csys}
             </div>`;
 
-        if (wp.getCoordSys() != CoordinateSys.EQ_J2000) {
+        if (wp.getCoordSys() !== CoordinateSys.EQ_J2000) {
             s += getEQJ2000(wp);
         }
     }

--- a/src/firefly/js/visualize/ChangePrime.js
+++ b/src/firefly/js/visualize/ChangePrime.js
@@ -5,6 +5,7 @@
 import ImagePlotCntlr, {IMAGE_PLOT_KEY, dispatchZoom, dispatchProcessScroll} from './ImagePlotCntlr.js';
 import {getPlotViewById, primePlot} from './PlotViewUtil.js';
 import {getPixScaleArcSec, getScreenPixScaleArcSec} from './WebPlot.js';
+import {hasWCSProjection} from './PlotViewUtil.js';
 import {UserZoomTypes, getZoomLevelForScale} from './ZoomUtil.js';
 import {CysConverter} from './CsysConverter.js';
 import {makeScreenPt} from './Point.js';
@@ -14,10 +15,9 @@ function matcher(oldP,newP) {
     return {
         isSameZoomLevel: oldP.zoomFactor===newP.zoomFactor,
         isSameSize: oldP.dataWidth===newP.dataWidth && oldP.dataHeight===newP.dataHeight,
-        isProjection: oldP.projection.isSpecified() && newP.projection.isSpecified(),
-        isSameScale: oldP.projection && oldP.projection.isSpecified() &&
-                     newP.projection && newP.projection.isSpecified() &&
-                     getPixScaleArcSec(oldP)===getPixScaleArcSec(newP)
+        isProjection: hasWCSProjection(oldP) && hasWCSProjection(newP),
+        isSameScale: hasWCSProjection(oldP) && hasWCSProjection(newP) &&
+            getPixScaleArcSec(oldP)===getPixScaleArcSec(newP)
     };
 }
 

--- a/src/firefly/js/visualize/CoordSys.js
+++ b/src/firefly/js/visualize/CoordSys.js
@@ -10,15 +10,18 @@ export const GALACTIC_JSYS     = 2;
 export const ECLIPTIC_B   = 3;
 export const SUPERGALACTIC_JSYS   = 4;
 export const ECLIPTIC_J   = 13;
+export const NONCELESTIAL = -999;
 
 
 /**
  * @typedef {Object} CoordinateSys
  * @summary coordinate system
- * @description value is one of the following constants; EQ_J2000, EQ_B2000, EQ_B1950, GALACTIC,
- * SUPERGALACTIC, ECL_J2000, ECL_B1950, PIXEL, SCREEN_PIXEL, UNDEFINED,
+ * @description value is one of the following constants;
+ * EQ_J2000, EQ_B2000, EQ_B1950, GALACTIC, SUPERGALACTIC, ECL_J2000, ECL_B1950,
+ * PIXEL, SCREEN_PIXEL, ZERO_BASED, FITSPIXEL, UNDEFINED
  *
- * @prop {Function} isEquatorial
+ * @prop {Function} isEquatorial - True, if coordinate system is Equatorial
+ * @prop {Function} isCelestial - True, if coordinate system is a recognized celestial system
  * @prop {Function} getJsys
  * @prop {Function} getEquinox
  * @global
@@ -31,11 +34,13 @@ export const CoordinateSys = function () {
         return {
             toString() { return desc; },
             isEquatorial() { return equatorial; },
+            isCelestial() { return jsys !== NONCELESTIAL; },
             getJsys() { return jsys; },
             getEquinox() { return equinox; }
         };
     };
 
+    // recognized celestial coordinate systems
     const EQ_J2000 = init('EQ_J2000', true, EQUATORIAL_J, 2000 );
     const EQ_B2000 = init('EQ_B2000', true, EQUATORIAL_B, 2000);
     const EQ_B1950 = init('EQ_B1950', true, EQUATORIAL_B, 1950);
@@ -44,12 +49,12 @@ export const CoordinateSys = function () {
     const ECL_J2000 = init('EC_J2000', false, ECLIPTIC_J, 2000);
     const ECL_B1950 = init('EC_B1950', false, ECLIPTIC_B, 1950);
 
-    const PIXEL = init('PIXEL', false,-999, 0);
-    const SCREEN_PIXEL = init('SCREEN_PIXEL', false,-999, 0);
-    const UNDEFINED = init('UNDEFINED', false,-999, 0);
-    const ZEROBASED = init('ZERO-BASED', false, -999, 0);
-    const FITSPIXEL = init('FITSPIXEL', false, -999, 0);
+    const PIXEL = init('PIXEL', false, NONCELESTIAL, 0);
+    const SCREEN_PIXEL = init('SCREEN_PIXEL', false, NONCELESTIAL, 0);
+    const ZEROBASED = init('ZERO-BASED', false, NONCELESTIAL, 0);
+    const FITSPIXEL = init('FITSPIXEL', false, NONCELESTIAL, 0);
 
+    const UNDEFINED = init('UNDEFINED', false, NONCELESTIAL, 0);
 
     const parse= (desc) => {
         if (!desc) return undefined;

--- a/src/firefly/js/visualize/MouseReadoutCntlr.js
+++ b/src/firefly/js/visualize/MouseReadoutCntlr.js
@@ -113,6 +113,7 @@ const initState= () =>
             imageMouseReadout1:'eqj2000hms',
             imageMouseReadout2: 'fitsIP',
             imageMouseNoncelestialReadout1: 'wcsCoords',
+            imageMouseNoncelestialReadout2: 'fitsIP',
             pixelSize: 'pixelSize',
             hipsMouseReadout1:'eqj2000hms',
             hipsMouseReadout2:'galactic',

--- a/src/firefly/js/visualize/MouseReadoutCntlr.js
+++ b/src/firefly/js/visualize/MouseReadoutCntlr.js
@@ -112,6 +112,7 @@ const initState= () =>
         readoutPref :{
             imageMouseReadout1:'eqj2000hms',
             imageMouseReadout2: 'fitsIP',
+            imageMouseNoncelestialReadout1: 'wcsCoords',
             pixelSize: 'pixelSize',
             hipsMouseReadout1:'eqj2000hms',
             hipsMouseReadout2:'galactic',

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -99,12 +99,15 @@ export function getPlotGroupIdxById(ref,plotGroupId) {
 
 /**
  * @param {PlotView[]|PlotView|VisRoot|CysConverter|WebPlot} ref this can be the visRoot or the plotViewAry, or a plotView Object.
- * @return {boolean} true if there is a projection
+ * @param {Boolean} includeNoncelestial if True include non-celestial coordinate systems into consideration
+ * @return {boolean} true if there is a projection for recognized celestial system by default or,
+ *  if unrecognizedCelestial is true, for any coordinate system with recognized projection algorithm.
  */
-export function hasWCSProjection(ref) {
+export function hasWCSProjection(ref, includeNoncelestial=false) {
     if (!ref) return false;
     const projection= ref.projection ?? primePlot(ref)?.projection;
-    return Boolean(projection?.isSpecified() && projection?.isImplemented());
+    const hasProjection = Boolean(projection?.isSpecified() && projection?.isImplemented());
+    return hasProjection && projection?.coordSys?.isCelestial() || includeNoncelestial;
 }
 
 /**
@@ -469,7 +472,7 @@ export function matchPlotViewByPositionGroup(vr, sourcePv, plotViewAry, matchAny
 
 /**
  * perform an operation on a plotView or its related group depending on the lock state.
- * Typically used inside of reducer
+ * Typically, used inside of reducer.
  * @param {boolean} toAll
  * @param {Array.<PlotView>} plotViewAry plotViewAry
  * @param {string} plotId the that is primary.

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -105,16 +105,16 @@ export function getLatDist(lat1,lat2) {
 }
 
 /**
- * Convert from one coordinate system to another.
+ * Convert from one coordinate system to another. No action, if the world point coordinate system is non-celestial.
  *
  * @param {WorldPt} wpt the world point to convert
- * @param {CoordinateSys} to CoordSys, the coordinate system to convert to
- * @return {WorldPt} the world point in the new coordinate system
+ * @param {CoordinateSys} to CoordSys, the coordinate system to convert to; defaults to J2000, ignored for non-celestial world points
+ * @return {WorldPt|undefined} the world point in the new coordinate system
  */
 export function convert(wpt, to= CoordinateSys.EQ_J2000) {
     if (!wpt) return;
     const from = wpt.getCoordSys();
-    if (!to || from===to) return wpt;
+    if (!to || !from.isCelestial() || from===to) return wpt;
 
     const tobs=  (from===CoordinateSys.EQ_B1950) ? 1983.5 : 0;
     const ll = doConv(
@@ -441,7 +441,7 @@ export function isPlotRotatedNorth(plot, csys= CoordinateSys.EQ_J2000) {
  */
 export function isEastLeftOfNorth(plot) {
     if (!plot?.projection) return true;
-    if (!plot.projection.isSpecified() || !plot.projection.isImplemented()) return true;
+    if (!plot.projection.isSpecified() || !plot.projection.isImplemented() || !plot.projection?.coordSys?.isCelestial()) return true;
 
     const mx = plot.dataWidth/2;
     const my = plot.dataHeight/2;

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -8,9 +8,8 @@ import {isImage, isHiPS} from '../WebPlot.js';
 import {WPConst} from '../WebPlotRequest';
 import {makeScreenPt, makeDevicePt, makeImagePt, makeWorldPt} from '../Point';
 import {getActiveTarget} from '../../core/AppDataCntlr.js';
-import { getCenterPtOfPlot, getLatDist, getLonDist } from '../VisUtil.js';
-import {
-    getPlotViewById, matchPlotViewByPositionGroup, primePlot, findCurrentCenterPoint } from '../PlotViewUtil.js';
+import {getCenterPtOfPlot, getLatDist, getLonDist } from '../VisUtil.js';
+import {findCurrentCenterPoint, getPlotViewById, hasWCSProjection, matchPlotViewByPositionGroup, primePlot} from '../PlotViewUtil.js';
 import {changeProjectionCenter} from '../HiPSUtil.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
 import {ZoomType} from '../ZoomType.js';
@@ -350,6 +349,12 @@ export function updatePlotGroupScrollXY(visRoot, plotId,plotViewAry, plotGroupAr
 export function updateScrollToWcsMatch(wcsMatchType, masterPv, matchToPv) {
     if (!masterPv || !matchToPv || masterPv===matchToPv) return matchToPv;
     if (masterPv.plotId===matchToPv.plotId || !primePlot(masterPv)|| !primePlot(matchToPv)) return matchToPv;
+
+    // celestial WCS match should not affect non-celestial plots
+    if ((wcsMatchType === WcsMatchType.Standard || wcsMatchType === WcsMatchType.Target) &&
+        (!hasWCSProjection(primePlot(masterPv)) || !hasWCSProjection(primePlot(matchToPv)))) {
+        return matchToPv;
+    }
 
     const newScrollPoint= findWCSMatchScrollPosition(wcsMatchType, masterPv, matchToPv);
     return updatePlotViewScrollXY(matchToPv, newScrollPoint);

--- a/src/firefly/js/visualize/saga/MouseReadoutWatch.js
+++ b/src/firefly/js/visualize/saga/MouseReadoutWatch.js
@@ -14,14 +14,14 @@ import {callGetFileFlux} from '../../rpc/PlotServicesJson.js';
 import {Band} from '../Band.js';
 import {MouseState} from '../VisMouseSync.js';
 import {CysConverter} from '../CsysConverter.js';
-import {getPixScaleArcSec, getScreenPixScaleArcSec, isImage, isHiPS, getFluxUnits} from '../WebPlot.js';
+import {getPixScale, getScreenPixScale, getScreenPixScaleArcSec, isImage, isHiPS, getFluxUnits} from '../WebPlot.js';
 import {getPlotTilePixelAngSize} from '../HiPSUtil.js';
 import {mouseUpdatePromise, fireMouseReadoutChange} from '../VisMouseSync';
 import {
     primePlot, getPlotStateAry, getPlotViewById, getImageCubeIdx, getPtWavelength,
     getWavelengthParseFailReason, getWaveLengthUnits, hasPixelLevelWLInfo, hasPlaneOnlyWLInfo,
     isImageCube, wavelengthInfoParsedSuccessfully, } from '../PlotViewUtil';
-import {getBixPix, getBScale, getNumberHeader, HdrConst} from '../FitsHeaderUtil.js';
+import {getBixPix} from '../FitsHeaderUtil.js';
 
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -408,6 +408,8 @@ function makeWLResult(plot,imagePt= undefined) {
 function makeReadout(plot, worldPt, screenPt, imagePt) {
     const csys= CysConverter.make(plot);
     if (csys.pointInPlot(imagePt)) {
+        const pixScale = getPixScale(plot);
+        const screenPixScale = getScreenPixScale(plot);
         return {
             worldPt: makePointReadoutItem('World Point', worldPt),
             screenPt: makePointReadoutItem('Screen Point', screenPt),
@@ -416,8 +418,8 @@ function makeReadout(plot, worldPt, screenPt, imagePt) {
             fitsImagePt: makePointReadoutItem('FITS Standard Image Point', csys.getFitsStandardImagePtFromInternal(imagePt)),
             zeroBasedImagePt: makePointReadoutItem('FITS Standard Image Point', csys.getZeroBasedImagePtFromInternal(imagePt)),
             title: makeDescriptionItem(plot.title),
-            pixel: makeValueReadoutItem('Pixel Size',getPixScaleArcSec(plot),'arcsec', 3),
-            screenPixel:makeValueReadoutItem('Screen Pixel Size',getScreenPixScaleArcSec(plot),'arcsec', 3),
+            pixel: makeValueReadoutItem('Pixel Size', pixScale.value, pixScale.unit, 3),
+            screenPixel:makeValueReadoutItem('Screen Pixel Size', screenPixScale.value, screenPixScale.unit, 3),
             wl: makeWLResult(plot,imagePt)
         };
     }

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -16,7 +16,7 @@ import {Band} from '../Band.js';
 import {PlotPref} from '../PlotPref.js';
 import {makePostPlotTitle} from '../reducer/PlotTitle.js';
 import {dispatchAddViewerItems, EXPANDED_MODE_RESERVED, IMAGE} from '../MultiViewCntlr.js';
-import {getPlotViewById, getPlotViewIdListInOverlayGroup} from '../PlotViewUtil.js';
+import {getPlotViewById, getPlotViewIdListInOverlayGroup, hasWCSProjection} from '../PlotViewUtil.js';
 import {enableMatchingRelatedData} from '../RelatedDataUtil.js';
 import {doFetchTable} from '../../tables/TableUtil.js';
 import {callGetWebPlot, callGetWebPlot3Color, callGetWebPlotGroup} from '../../rpc/PlotServicesJson.js';
@@ -283,7 +283,7 @@ function createPlots(plotCreate, plotCreateHeader, payload, requestKey) {
  * @param {WebPlot} plot
  */
 function updateActiveTarget(plot) {
-    if (!plot) return;
+    if (!plot || !hasWCSProjection(plot)) return;
     const req= plot.plotState.getWebPlotRequest();
     if (!req) return;
     let activeTarget;

--- a/src/firefly/js/visualize/task/WcsMatchTask.js
+++ b/src/firefly/js/visualize/task/WcsMatchTask.js
@@ -116,7 +116,7 @@ export function wcsMatchActionCreator(action) {
         visRoot= getState()[IMAGE_PLOT_KEY];
         masterPv= getPlotViewById(visRoot, plotId);
         const masterPlot= primePlot(masterPv);
-        if (!masterPlot) return;
+        if (!masterPlot || !hasWCSProjection(masterPlot)) return;
 
         if (image) {
             const level = matchType ?

--- a/src/firefly/js/visualize/ui/MatchLockDropDown.jsx
+++ b/src/firefly/js/visualize/ui/MatchLockDropDown.jsx
@@ -19,7 +19,7 @@ function changeMatchType(vr, matchType, lockMatch) {
                 .filter( (pv) => !hasWCSProjection(primePlot(pv)) )
                 .map ( (pv) => primePlot(pv)?.title ?? '');
         if (warningTitles.length !== 0) { //at least one image without WCS
-            const msgTitle = 'The following image(s) do not have WCS:';
+            const msgTitle = 'The following image(s) do not have celestial WCS:';
             const msgDesc = warningTitles.join(', ');
             const renderContent = (
                 <Box>

--- a/src/firefly/js/visualize/ui/MouseReadPopoutAll.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadPopoutAll.jsx
@@ -13,7 +13,6 @@ import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
 import {ThumbnailView} from 'firefly/visualize/ui/ThumbnailView.jsx';
 import {MagnifiedView} from 'firefly/visualize/ui/MagnifiedView.jsx';
 import {getActivePlotView, getPlotViewById, primePlot} from 'firefly/visualize/PlotViewUtil.js';
-import {get} from 'lodash';
 import {getFluxInfo, getNonFluxDisplayElements} from 'firefly/visualize/ui/MouseReadoutUIUtil.js';
 import {DataReadoutItem, MouseReadoutLock} from 'firefly/visualize/ui/MouseReadout.jsx';
 import {isImage} from 'firefly/visualize/WebPlot.js';
@@ -81,8 +80,8 @@ function Readout({readout, readoutData, showHealpixPixel=false, radix}){
     const isHiPS= readoutType===HIPS_STANDARD_READOUT;
     const image= readoutType===STANDARD_READOUT;
 
-    if (!get(readoutData,'readoutItems')) return <Box style={rS}/>;
-    const displayEle= getNonFluxDisplayElements(readoutData.readoutItems,  readout.readoutPref, isHiPS);
+    if (!readoutData?.readoutItems) return <Box style={rS}/>;
+    const displayEle= getNonFluxDisplayElements(readoutData,  readout.readoutPref, isHiPS);
     const {pixelSize, showPixelPrefChange, healpixPixelReadout, healpixNorderReadout}= displayEle;
     const fluxArray = getFluxInfo(readoutData, radix);
     const hipsPixel= showHealpixPixel && isHiPS;

--- a/src/firefly/js/visualize/ui/MouseReadoutBottomLine.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadoutBottomLine.jsx
@@ -30,7 +30,7 @@ export function MouseReadoutBottomLine({readout, readoutData, readoutShowing, st
     const {readoutType}= readoutData;
     if (!readoutData.readoutItems) return (<div style={{height: showOnInactive?20:0, width:showOnInactive?1:0}}/>);
 
-    const displayEle= getNonFluxDisplayElements(readoutData.readoutItems,  readout.readoutPref, false);
+    const displayEle= getNonFluxDisplayElements(readoutData,  readout.readoutPref, false);
     const {readout1, showReadout1PrefChange, showWavelengthFailed, waveLength}= displayEle;
     const {lockByClick=false}= readout??{};
     const showCopy= lockByClick;

--- a/src/firefly/js/visualize/ui/MouseReadoutOptionPopups.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadoutOptionPopups.jsx
@@ -55,7 +55,8 @@ const groupKeys={
 	imageMouseReadout1:'COORDINATE_OPTION_FORM',
 	imageMouseNoncelestialReadout1:'COORDINATE_OPTION_FORM',
 	imageMouseReadout2:'COORDINATE_OPTION_FORM',
-    hipsMouseReadout1:'COORDINATE_OPTION_FORM',
+	imageMouseNoncelestialReadout2:'COORDINATE_OPTION_FORM',
+	hipsMouseReadout1:'COORDINATE_OPTION_FORM',
     hipsMouseReadout2:'COORDINATE_OPTION_FORM',
 	pixelSize: 'PIXEL_OPTION_FORM'
 };

--- a/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
+++ b/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
@@ -42,8 +42,8 @@ const coordOpTitle= 'Choose readout coordinates';
 export function getNonFluxDisplayElements(readoutData, readoutPref, isHiPS= false) {
     const objList= getNonFluxReadoutElements(readoutData,  readoutPref, isHiPS);
 
-    const {imageMouseReadout1, imageMouseReadout2, imageMouseNoncelestialReadout1, hipsMouseReadout1,
-                     hipsMouseReadout2, pixelSize, healpixPixel, healpixNorder, wl} = objList;
+    const {imageMouseReadout1, imageMouseReadout2, imageMouseNoncelestialReadout1, imageMouseNoncelestialReadout2,
+        hipsMouseReadout1, hipsMouseReadout2, pixelSize, healpixPixel, healpixNorder, wl} = objList;
 
 
     let readout1, readout2, healpixPixelReadout, healpixNorderReadout, waveLength;
@@ -80,12 +80,12 @@ export function getNonFluxDisplayElements(readoutData, readoutPref, isHiPS= fals
             readout1 = {...imageMouseNoncelestialReadout1, label: label1 || labelMap[readoutPref.imageMouseNoncelestialReadout1]};
 
             let label2 = undefined;
-            if (readoutPref.imageMouseReadout2 === 'wcsCoords') {
+            if (readoutPref.imageMouseNoncelestialReadout2 === 'wcsCoords') {
                 label2 = wcsCoordLabel;
             }
-            readout2= {...imageMouseReadout2, label: label2 || labelMap[readoutPref.imageMouseReadout2]};
+            readout2= {...imageMouseNoncelestialReadout2, label: label2 || labelMap[readoutPref.imageMouseNoncelestialReadout2]};
             showReadout1PrefChange= () => showMouseReadoutOptionDialog('imageMouseNoncelestialReadout1', readoutPref.imageMouseNoncelestialReadout1, coordOpTitle, wcsCoordOptionTitle);
-            showReadout2PrefChange= () => showMouseReadoutOptionDialog('imageMouseReadout2', readoutPref.imageMouseReadout2, coordOpTitle, wcsCoordOptionTitle);
+            showReadout2PrefChange= () => showMouseReadoutOptionDialog('imageMouseNoncelestialReadout2', readoutPref.imageMouseNoncelestialReadout2, coordOpTitle, wcsCoordOptionTitle);
         }
 
 

--- a/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
+++ b/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
@@ -5,14 +5,15 @@
 import {fill, isString} from 'lodash';
 import {sprintf} from '../../externalSource/sprintf';
 import {
-    STATUS_NAN, STATUS_UNAVAILABLE, STATUS_UNDEFINED, STATUS_VALUE, TYPE_BASE16, TYPE_BASE_OTHER, TYPE_DECIMAL_INT,
-    TYPE_EMPTY, TYPE_FLOAT
+    STATUS_NAN, STATUS_UNAVAILABLE, STATUS_UNDEFINED, STATUS_VALUE, TYPE_DECIMAL_INT, TYPE_EMPTY, TYPE_FLOAT
 } from '../MouseReadoutCntlr.js';
+import {visRoot} from '../ImagePlotCntlr.js';
+import {isCelestialImage} from '../WebPlot.js';
 import VisUtil from '../VisUtil.js';
 import CoordUtil from '../CoordUtil.js';
 import CoordinateSys from '../CoordSys.js';
 import {showMouseReadoutOptionDialog} from './MouseReadoutOptionPopups.jsx';
-import {getFormattedWaveLengthUnits} from '../PlotViewUtil';
+import {getFormattedWaveLengthUnits, primePlot} from '../PlotViewUtil';
 import {showInfoPopup} from '../../ui/PopupUtil';
 
 
@@ -26,6 +27,7 @@ const labelMap = {
     eclB1950: 'ECL-B1950:',
     galactic: 'Gal:',
     eqb1950: 'Eq-B1950:',
+    wcsCoords: 'WCS-Coords:',
     fitsIP: 'Image Pixel:',
     zeroIP: '0 Based Pix:',
     pixelSize: 'Pixel Size:',
@@ -37,10 +39,10 @@ const labelMap = {
 
 const coordOpTitle= 'Choose readout coordinates';
 
-export function getNonFluxDisplayElements(readoutItems, readoutPref, isHiPS= false) {
-    const objList= getNonFluxReadoutElements(readoutItems,  readoutPref, isHiPS);
+export function getNonFluxDisplayElements(readoutData, readoutPref, isHiPS= false) {
+    const objList= getNonFluxReadoutElements(readoutData,  readoutPref, isHiPS);
 
-    const {imageMouseReadout1, imageMouseReadout2, hipsMouseReadout1,
+    const {imageMouseReadout1, imageMouseReadout2, imageMouseNoncelestialReadout1, hipsMouseReadout1,
                      hipsMouseReadout2, pixelSize, healpixPixel, healpixNorder, wl} = objList;
 
 
@@ -56,14 +58,41 @@ export function getNonFluxDisplayElements(readoutItems, readoutPref, isHiPS= fal
         healpixNorderReadout= {...healpixNorder, label: labelMap.healpixNorder};
     }
     else {
-        readout1= {...imageMouseReadout1, label: labelMap[readoutPref.imageMouseReadout1]};
-        readout2= {...imageMouseReadout2, label: labelMap[readoutPref.imageMouseReadout2]};
+        const readoutItems = readoutData.readoutItems;
+
+        // outside image use active plot (plotId=undefined)
+        const csys = readoutItems.worldPt?.value?.cSys;
+        const plotId = csys ? readoutData.plotId : undefined;
+        const isCelestial = isCelestialImage(primePlot(visRoot(), plotId));
+
+        if (isCelestial) {
+            readout1 = {...imageMouseReadout1, label: labelMap[readoutPref.imageMouseReadout1]};
+            readout2= {...imageMouseReadout2, label: labelMap[readoutPref.imageMouseReadout2]};
+            showReadout1PrefChange= () => showMouseReadoutOptionDialog('imageMouseReadout1', readoutPref.imageMouseReadout1, coordOpTitle);
+            showReadout2PrefChange= () => showMouseReadoutOptionDialog('imageMouseReadout2', readoutPref.imageMouseReadout2, coordOpTitle);
+        } else {
+            const wcsCoordLabel = createWCSCoordsLabel(plotId);
+            const wcsCoordOptionTitle = wcsCoordLabel && wcsCoordLabel.substring(0, wcsCoordLabel.length - 1);
+            let label1 = undefined;
+            if (readoutPref.imageMouseNoncelestialReadout1 === 'wcsCoords') {
+                label1 = wcsCoordLabel;
+            }
+            readout1 = {...imageMouseNoncelestialReadout1, label: label1 || labelMap[readoutPref.imageMouseNoncelestialReadout1]};
+
+            let label2 = undefined;
+            if (readoutPref.imageMouseReadout2 === 'wcsCoords') {
+                label2 = wcsCoordLabel;
+            }
+            readout2= {...imageMouseReadout2, label: label2 || labelMap[readoutPref.imageMouseReadout2]};
+            showReadout1PrefChange= () => showMouseReadoutOptionDialog('imageMouseNoncelestialReadout1', readoutPref.imageMouseNoncelestialReadout1, coordOpTitle, wcsCoordOptionTitle);
+            showReadout2PrefChange= () => showMouseReadoutOptionDialog('imageMouseReadout2', readoutPref.imageMouseReadout2, coordOpTitle, wcsCoordOptionTitle);
+        }
+
+
         if (wl?.value) {
             waveLength= {...wl, label:labelMap.wl};
             showWavelengthFailed= readoutItems.wl.failReason ? () => showInfoPopup(readoutItems.wl.failReason) : undefined;
         }
-        showReadout1PrefChange= () => showMouseReadoutOptionDialog('imageMouseReadout1', readoutPref.imageMouseReadout1, coordOpTitle);
-        showReadout2PrefChange= () => showMouseReadoutOptionDialog('imageMouseReadout2', readoutPref.imageMouseReadout2, coordOpTitle);
     }
 
     return {
@@ -75,7 +104,10 @@ export function getNonFluxDisplayElements(readoutItems, readoutPref, isHiPS= fal
 }
 
 
-export function getNonFluxReadoutElements(readoutItems, readoutPref, isHiPS= false) {
+export function getNonFluxReadoutElements(readoutData, readoutPref, isHiPS= false) {
+    const readoutItems = readoutData.readoutItems;
+    const plotId = readoutData.plotId;
+
     const keysToUse= Object.keys(readoutPref).filter( (key) =>
         isHiPS ?
             key.startsWith('hips') || !key.startsWith('image') :
@@ -83,7 +115,7 @@ export function getNonFluxReadoutElements(readoutItems, readoutPref, isHiPS= fal
 
     const retList={};
     keysToUse.forEach( (key) =>  {
-        retList[key]=getReadoutElement(readoutItems,  readoutPref[key] );
+        retList[key]=getReadoutElement(readoutItems, readoutPref[key], plotId);
     });
     return retList;
 }
@@ -94,9 +126,10 @@ export function getNonFluxReadoutElements(readoutItems, readoutPref, isHiPS= fal
  * Get the mouse readouts from the standard readout and convert to the values based on the toCoordinaeName
  * @param readoutItems
  * @param readoutKey
+ * @param plotId
  * @returns {*}
  */
-export function getReadoutElement(readoutItems, readoutKey) {
+export function getReadoutElement(readoutItems, readoutKey, plotId) {
 
     if (!readoutItems) return {value:''};
 
@@ -120,6 +153,10 @@ export function getReadoutElement(readoutItems, readoutKey) {
             return makeCoordReturn(wp, CoordinateSys.ECL_J2000, false);
         case 'eclB1950' :
             return makeCoordReturn(wp, CoordinateSys.ECL_B1950, false);
+        case 'wcsCoords' :
+            const plot = primePlot(visRoot(), plotId);
+            const unit = plot?.projection?.header?.cunit1 || '';
+            return {value:makeNoncelestialCoordReturn(wp, unit)};
         case 'fitsIP' :
             return {value:makeImagePtReturn(readoutItems?.fitsImagePt?.value)};
         case 'zeroIP' :
@@ -139,6 +176,23 @@ export function getReadoutElement(readoutItems, readoutKey) {
     return {value:''};
 }
 
+/**
+ * Label for non-celestial coordinates readout item.
+ * @param plotId
+ */
+function createWCSCoordsLabel(plotId) {
+    const plot = primePlot(visRoot(), plotId);
+    const header = plot?.projection?.header;
+    if (!header) return undefined;
+
+    const {ctype1, ctype2} = header;
+
+    if (ctype1 && ctype2) {
+        // CTYPE=LINEAR is a special case
+        if (ctype1 !== 'LINEAR') return ctype1?.split('-')?.[0] + ', ' + ctype2?.split('-')?.[0] + ':';
+    }
+    return undefined;
+}
 
 function getFluxValueByType(readoutType,radix,valueBase10,valueBase16,unit,label,precision) {
     const is16= radix===16;
@@ -213,7 +267,11 @@ function makeCoordReturn(wp, toCsys, hms= false) {
         str=  sprintf('%.7f, %.7f',p.getLon(), p.getLat());
     }
     return {value:str, copyValue:`${str} ${toCsys.toString()}`};
+}
 
+function makeNoncelestialCoordReturn(wp, unit = '') {
+    if (!wp) return '';
+    return sprintf('%.7f, %.7f %s', wp.getLon(), wp.getLat(), unit);
 }
 
 function makeImagePtReturn(imagePt) {

--- a/src/firefly/js/visualize/ui/ThumbnailView.jsx
+++ b/src/firefly/js/visualize/ui/ThumbnailView.jsx
@@ -19,7 +19,7 @@ import {dispatchProcessScroll} from '../ImagePlotCntlr.js';
 import {makeMouseStatePayload,fireMouseCtxChange} from '../VisMouseSync.js';
 import {makeTransform,makeThumbnailTransformCSS} from '../PlotTransformUtils.js';
 import {findScrollPtToCenterImagePt} from '../reducer/PlotView.js';
-import {getPixScaleDeg, isHiPS} from '../WebPlot.js';
+import {getPixScaleDeg, isCelestialImage, isHiPS} from '../WebPlot.js';
 import {getEntry} from '../rawData/RawDataCache.js';
 import {SimpleCanvas} from '../draw/SimpleCanvas.jsx';
 
@@ -182,6 +182,19 @@ function makeDrawing(pv,width,height) {
     const wptC= getCenterPtOfPlot(plot);
     if (!wptC) return null;
 
+    const fp= getScrollBoxInfo(pv, width, height);
+    const scrollBox= FootprintObj.make([fp]);
+    scrollBox.renderOptions= {
+        shadow: {blur: 2, color: 'white', offX: 1, offY: 1}
+    };
+    scrollBox.style= Style.LIGHT;
+    scrollBox.color= COLOR_DRAW_2;
+
+    if (!isCelestialImage(plot)) {
+        return [undefined, undefined, scrollBox];
+    }
+
+    // E and N arrows
     const arrowLength= (Math.min(width,70)+Math.min(height,70))/3;
     const thumbZoomFact= getThumbZoomFact(plot,width,height);
     const cdelt1 = getPixScaleDeg(plot);
@@ -239,13 +252,5 @@ function makeDrawing(pv,width,height) {
     dataN.color= COLOR_DRAW_1;
     dataE.color= COLOR_DRAW_1;
 
-
-    const fp= getScrollBoxInfo(pv, width, height);
-    const scrollBox= FootprintObj.make([fp]);
-    scrollBox.renderOptions= {
-        shadow: {blur: 2, color: 'white', offX: 1, offY: 1}
-    };
-    scrollBox.style= Style.LIGHT;
-    scrollBox.color= COLOR_DRAW_2;
     return [dataN,dataE,scrollBox];
 }


### PR DESCRIPTION
[Jira ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-1468)

Build: https://fireflydev.ipac.caltech.edu/firefly-1468-coordreadout/firefly

- Separated readout options for celestial and non-celestial images
- Added units to projection information
- Added handling for non-degree units when displaying pixel scale
- Added convenience methods to separate all images with projection info into celestial and non-celestial
- For non-celestial coordinates the readout is displayed as `<CTYPE1>, <CTYPE2>: val1, val2 <CUNIT1>`