### PR TITLE
IRSA-5919: Testing Euclid API service and integrating Region Explorer/Source Inspector with it

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -42,12 +42,17 @@ public class AppServerCommands {
     public static class JsonProperty extends ServCommand {
         static final String INVENTORY_PROP = "inventory.serverURLAry";
         static final String FIREFLY_OPTIONS = "FIREFLY_OPTIONS";
+        static final String IRSA_REGION_URL = "irsa.regionURL";
+        static final String IRSA_MER_URL = "irsa.merURL";
+
         static final Map<String, String> map = new HashMap<>();
         static final List<String> validatedList = new ArrayList<>();
 
         static {
             map.put(FIREFLY_OPTIONS, getAppOptions());
             map.put(INVENTORY_PROP, AppProperties.getProperty(INVENTORY_PROP, "[]"));
+            map.put(IRSA_REGION_URL, AppProperties.getProperty(IRSA_REGION_URL, "[]"));
+            map.put(IRSA_MER_URL, AppProperties.getProperty(IRSA_MER_URL, "[]"));
             validateAll();
         }
 


### PR DESCRIPTION
Addresses both these tickets: 
**[IRSA-5919](https://jira.ipac.caltech.edu/browse/IRSA-5919)** & **[IRSA-5920](https://jira.ipac.caltech.edu/browse/IRSA-5920)**: 
- IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/320
- This one just enables access to URLs in for Region Explorer & Source Inspector `AppServerCommands`
- remember to use coordinates in the IFE PR files (e.g.: 235.167403, 40.509436015) `tile_positional_search.txt `and `source_search_coords.txt`


Testing: 
- https://irsa-5919-euclid-api.irsakudev.ipac.caltech.edu/applications/euclid
  - note: if results are not desired, check if the API middleware service may be down: http://irsawebdev1.ipac.caltech.edu:8428/