### PR TITLE
IRSA-6032: Make SearchPanel  preserving the search button at the bottom

### DIFF
--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -40,7 +40,7 @@ export function SearchPanel({style={}, initArgs={}}) {
         return (
             <Stack id='search-vertical' flexGrow={1}>
                 {title && <h2 style={{textAlign: 'center'}}>{title}</h2>}
-                <SearchForm style={{height: 'auto'}} searchItem={searchItem} initArgs={initArgs}/>
+                <SearchForm height='auto' searchItem={searchItem} initArgs={initArgs}/>
             </Stack>
         );
     }
@@ -142,7 +142,7 @@ export function executeOK(clickFunc,initArgs,searchItem) {
 }
 
 
-function SearchForm({searchItem, style, initArgs}) {
+function SearchForm({searchItem, initArgs, ...props}) {
     const {name, form} = searchItem;
     const {render:Render, useFormPanel:useFormPanel=true, title, action, params, ...formProps} = form;
 
@@ -160,20 +160,23 @@ function SearchForm({searchItem, style, initArgs}) {
     };
 
     const defProps = {
-        flexGrow:1,
-        sx:style,
+        flexGrow: 1,
         cancelText: '',
         slotProps: {
+            input: {position:'relative'},
             completeBtn: {
                 getDoOnClickFunc: (clickFunc) => executeOK(clickFunc,initArgs,searchItem),       // this is a bit awkward
             },
-        }
+        },
+        ...props
     };
 
     return (
         useFormPanel ? (
             <FormPanel groupKey={name} onSuccess={onSuccess} {...defaultsDeep(formProps, defProps)}>
-                <Render {...{searchItem, initArgs}} />
+                <Stack position='absolute' sx={{inset:0}} overflow='auto'>
+                    <Render {...{searchItem, initArgs}} />
+                </Stack>
             </FormPanel>
         ) : (
             <Render {...{searchItem, initArgs}} />

--- a/src/firefly/js/visualize/ui/ExtraIpacSearches.jsx
+++ b/src/firefly/js/visualize/ui/ExtraIpacSearches.jsx
@@ -22,8 +22,7 @@ import {showInfoPopup} from 'firefly/ui/PopupUtil.jsx';
 
 const FormTemplate= ({children, onSuccess,groupKey, help_id}) => (
         <Box sx={{width:1, height:1}} >
-            <FormPanel width='auto' height='auto'
-                       groupKey={groupKey}
+            <FormPanel groupKey={groupKey}
                        onSuccess={onSuccess}
                        cancelText=''
                        help_id = {help_id}


### PR DESCRIPTION
This PR address the `Search ` button on the SearchPanel, it should be preserved at the bottom while resizing the search panel. 
Related [IFE PR](https://github.com/IPAC-SW/irsa-ife/pull/325)

To test, try resize the search panel for the apps:
https://irsa-6032-wise.irsakudev.ipac.caltech.edu/applications/wise
https://irsa-6032-finderchart.irsakudev.ipac.caltech.edu/applications/finderchart
https://irsa-6032-ztf.irsakudev.ipac.caltech.edu/applications/ztf
