### PR TITLE
Firefly-1483: change firefly_client to better support triview and plan to deprecate slate

### DIFF
--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -4,6 +4,7 @@
  */
 
 import 'isomorphic-fetch';
+import {Stack, Typography} from '@mui/joy';
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {set, defer, once} from 'lodash';
@@ -275,7 +276,27 @@ function fireflyInit(props, appSpecificOptions={}, webApiCommands) {
  */
 export function startAsAppFromApi(divId, overrideProps={template: 'FireflySlate'}) {
 
-    const props = {...mergeObjectOnly({...window.firefly.originalAppProps}, overrideProps), div:divId, appFromApi:true};
+
+    const Message = ({}) => (
+        <Stack alignItems='center'>
+            <Typography sx={{fontSize: 'xl4'}} color='neutral'> Welcome to Firefly Viewer for Python</Typography>
+        </Stack>
+    );
+
+    const landingPage= (<LandingPage slotProps={{
+        topSection: {component: Message},
+        bottomSection : {
+            actionItems: [
+                { text: 'Use API to send data', subtext: 'load data using Python API' },
+                { text: 'Search for data', subtext: 'using the tabs above or side menu' },
+                { text: 'Upload a file', subtext: 'drag & drop here' }
+            ]
+        }
+    }}/>);
+
+    const props = {
+        landingPage,
+        ...mergeObjectOnly({...window.firefly.originalAppProps}, overrideProps), div:divId, appFromApi:true};
     const viewer = Templates[props.template];
     if (!divId || !viewer) {
         !divId  && logger.error('required: divId');
@@ -286,7 +307,9 @@ export function startAsAppFromApi(divId, overrideProps={template: 'FireflySlate'
     props.disableDefaultDropDown && dispatchUpdateLayoutInfo({disableDefaultDropDown:true});
     props.readoutDefaultPref && dispatchChangeReadoutPrefs(props.readoutDefaultPref);
     props.wcsMatchType && dispatchWcsMatch({matchType:props.wcsMatchType, lockMatch:true});
+    props.apiHandlesExpanded= true;
 
+    dispatchAppOptions({ charts: { allowPinnedCharts: true}});
 
     if (!props.menu) {
         const other= 'Other Searches';

--- a/src/firefly/js/api/ApiExpandedView.jsx
+++ b/src/firefly/js/api/ApiExpandedView.jsx
@@ -4,9 +4,11 @@
 
 import {Sheet, Stack} from '@mui/joy';
 import React, {useRef} from 'react';
+import {PinnedChartPanel} from '../charts/ui/PinnedChartContainer.jsx';
 import {TablesContainer} from '../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../charts/ui/ChartsContainer.jsx';
 import {useStoreConnector} from '../ui/SimpleComponent.jsx';
+import {PINNED_CHART_VIEWER_ID} from '../visualize/MultiViewCntlr.js';
 import {ApiExpandedDisplay} from '../visualize/ui/ApiExpandedDisplay.jsx';
 import {FireflyRoot} from '../ui/FireflyRoot.jsx';
 import {isDefined} from '../util/WebUtil.js';
@@ -34,21 +36,15 @@ export function ApiExpandedView() {
 
     return (
         <FireflyRoot sx={{height:1, width:1}} ctxProperties={{jsApi:true}}>
-            <ApiExpandedViewInner/>
+            <ApiExpandedViewInner {...{expandType}}/>
         </FireflyRoot>
     );
 }
 
 
+
 function ApiExpandedViewInner({expandType}) {
     if (expandType===LO_VIEW.none) return false;
-    const {chartId} = expandType===LO_VIEW.xyPlots ? getExpandedChartProps() : {};
-    const view = expandType === LO_VIEW.tables ?
-        (<TablesContainer  mode='expanded' />)
-        : expandType === LO_VIEW.xyPlots ?
-            (<ChartsContainer {...{key:'api', expandedMode:true, closeable:true, chartId}}/>)
-            : (<ApiExpandedDisplay closeFunc={closeFunc}/>);
-
     return (
         <Sheet {...{variant:'soft',
             sx: (theme) => (
@@ -60,9 +56,26 @@ function ApiExpandedViewInner({expandType}) {
                 })
         }} >
             <Stack {...{p:1/4, width:1,height:1}}>
-                {view}
+                <ExpandedView {...{expandType}}/>
             </Stack>
         </Sheet>
     );
 }
 
+function ExpandedView({expandType}) {
+    if (expandType === LO_VIEW.tables) return <TablesContainer  mode='expanded' />;
+    if (expandType === LO_VIEW.xyPlots) {
+        const {chartId, expandedViewerId:viewerId} = expandType===LO_VIEW.xyPlots ? getExpandedChartProps() : {};
+        if (viewerId=== PINNED_CHART_VIEWER_ID) {
+            return (
+                <PinnedChartPanel {...{
+                    closeable:true, expandedMode:true, key:'api',
+                    useOnlyChartsInViewer:false, tbl_group:'main', addDefaultChart:true, }}/>
+            );
+        }
+        else {
+            return <ChartsContainer {...{key:'api', expandedMode:true, closeable:true, chartId}}/>;
+        }
+    }
+    return <ApiExpandedDisplay closeFunc={closeFunc}/>;
+}

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -5,11 +5,11 @@
 import React, {useEffect, useState} from 'react';
 import {cloneDeep, get, pick, set} from 'lodash';
 
-import {getMultiViewRoot, getViewerItemIds} from '../../visualize/MultiViewCntlr.js';
+import {getMultiViewRoot, getViewerItemIds, PINNED_CHART_VIEWER_ID} from '../../visualize/MultiViewCntlr.js';
 import {getSpectrumDM} from '../../voAnalyzer/SpectrumDM.js';
 import {dispatchChartAdd, getChartData} from '../ChartsCntlr.js';
 import {getNewTraceDefaults, getTblIdFromChart, isSpectralOrder, uniqueChartId} from '../ChartUtil.js';
-import {PINNED_VIEWER_ID, PINNED_GROUP, PINNED_CHART_PREFIX} from './PinnedChartContainer.jsx';
+import {PINNED_GROUP, PINNED_CHART_PREFIX} from './PinnedChartContainer.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {basicOptions, evalChangesFromFields} from './options/BasicOptions.jsx';
@@ -46,9 +46,9 @@ const POPUP_ID = 'CombineChart-popup';
  */
 export const CombineChart = ({viewerId}) => {
 
-    if (viewerId !== PINNED_VIEWER_ID) return null;
+    if (viewerId !== PINNED_CHART_VIEWER_ID) return null;
 
-    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID);
+    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_CHART_VIEWER_ID);
     const showCombine = chartIds?.length > 1;
 
     const doCombine = async () => {
@@ -59,7 +59,7 @@ export const CombineChart = ({viewerId}) => {
             ...chartData,
             chartId: uniqueChartId(PINNED_CHART_PREFIX),
             groupId: PINNED_GROUP,
-            viewerId: PINNED_VIEWER_ID,
+            viewerId: PINNED_CHART_VIEWER_ID,
             deletable: true,
             mounted: true
         });
@@ -84,7 +84,7 @@ function addTracesTitle(chartId, current=[]) {
 /* returns the selected chartId as well as a table of matching charts to combine */
 function createTableModel(showAll, tbl_id) {
 
-    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_VIEWER_ID);
+    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_CHART_VIEWER_ID);
     const selChartId = getSelChartId();
 
     const columns = [
@@ -430,6 +430,6 @@ function canCombine(chartId) {
     return xUnit === newXUnit && yUnit === newYUnit;
 }
 
-function getSelChartId(viewerId=PINNED_VIEWER_ID) {
+function getSelChartId(viewerId=PINNED_CHART_VIEWER_ID) {
     return  getActiveViewerItemId(viewerId, true);
 }

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -63,6 +63,7 @@
 
 
 export const DPtypes= {
+    ERROR: 'error',
     MESSAGE: 'message',
     SEND_TO_BROWSER: 'send-to-browser',
     PROMISE: 'promise',
@@ -97,6 +98,10 @@ export function dpdtMessage(message, menu= undefined, extra={}) {
 
 export function dpdtSimpleMsg(message) {
     return {displayType:DPtypes.MESSAGE, message, menuKey:'message-0'};
+}
+
+export function dpdtUploadError(url,e) {
+    return {displayType:DPtypes.ERROR, error:e, url};
 }
 
 /**

--- a/src/firefly/js/metaConvert/DefaultConverter.js
+++ b/src/firefly/js/metaConvert/DefaultConverter.js
@@ -90,7 +90,7 @@ export function makeRequestSimpleMoving(table, row, includeSingle, includeStanda
 
 }
 
-const defDataSourceGuesses = ['FILE', 'FITS', 'DATA', 'SOURCE', 'URL'];
+export const defDataSourceGuesses = ['FILE', 'FITS', 'DATA', 'SOURCE', 'URL', 'IMAGE_URL'];
 
 export function findADataSourceColumn(table) {
     if (!table || table.isFetching) return false;

--- a/src/firefly/js/metaConvert/UploadAndAnalysis.js
+++ b/src/firefly/js/metaConvert/UploadAndAnalysis.js
@@ -12,7 +12,9 @@ import {
     dataProductRoot, dispatchUpdateActiveKey, dispatchUpdateDataProducts,
     getActiveFileMenuKeyByKey, getDataProducts
 } from './DataProductsCntlr';
-import {dpdtImage, dpdtMessageWithDownload, dpdtMessageWithError, dpdtPNG, DPtypes,} from './DataProductsType';
+import {
+    dpdtImage, dpdtMessageWithDownload, dpdtMessageWithError, dpdtPNG, dpdtUploadError, DPtypes,
+} from './DataProductsType';
 import {dpdtSendToBrowser} from './DataProductsType.js';
 import {createSingleImageActivate, createSingleImageExtraction} from './ImageDataProductsUtil';
 import {analyzePart} from './PartAnalyzer';
@@ -101,6 +103,7 @@ export async function doUploadAndAnalysis({ table, row, request, activateParams=
         endUpdateWatcher(request.getURL());
         console.log('Call to Upload failed', e);
         dispatchUpdateDataProducts(dpId, {...makeErrorResult(e.message),menu, serDef, analysisActivateFunc});
+        return dpdtUploadError(request.getURL(),e);
     }
 }
 

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -19,7 +19,7 @@ import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getMocWatcherDef} from '../../visualize/saga/MOCWatcher.js';
 import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
 import {layoutManager} from './FireflyViewerManager.js';
-import {LayoutChoiceAccordion, LayoutChoiceVisualAccordion} from './LayoutChoice.jsx';
+import {LayoutChoiceVisualAccordion} from './LayoutChoice.jsx';
 import {TriViewPanel} from './TriViewPanel.jsx';
 import {getActionFromUrl} from '../../core/History.js';
 import {startImagesLayoutWatcher} from '../../visualize/ui/TriViewImageSection.jsx';
@@ -47,7 +47,8 @@ import {setIf as setIfUndefined} from 'firefly/util/WebUtil.js';
  *
  */
 export function FireflyViewer ({menu, options, views, showViewsSwitch, leftButtons,
-                                   centerButtons, rightButtons, normalInit=true, landingPage, slotProps, ...appProps}){
+                                   centerButtons, rightButtons, normalInit=true,
+                                   landingPage, slotProps, apiHandlesExpanded, ...appProps}){
 
     useEffect(() => {
         getImageMasterData();
@@ -63,7 +64,7 @@ export function FireflyViewer ({menu, options, views, showViewsSwitch, leftButto
             ]
         );
         if (eviews.has(LO_VIEW.images) ) startImagesLayoutWatcher();
-        dispatchAddSaga(layoutManager,{views});
+        dispatchAddSaga(layoutManager,{views,apiHandlesExpanded});
         if (getWorkspaceConfig()) { initWorkspace(); }
     }, []);
 

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewerManager.js
@@ -24,7 +24,7 @@ import {MetaConst} from 'firefly/data/MetaConst';
  * @param {string} [p.title] title to display
  * @param {string} [p.views] defaults to tri-view if not given.
  */
-export function* layoutManager({title, views='tables | images | xyplots'}) {
+export function* layoutManager({title, views='tables | images | xyplots', apiHandlesExpanded}) {
     views = LO_VIEW.get(views) || LO_VIEW.none;
 
     yield fork(dropDownManager);        // start the dropdown manager
@@ -56,7 +56,7 @@ export function* layoutManager({title, views='tables | images | xyplots'}) {
         var layoutInfo = getLayouInfo();
         var newLayoutInfo = layoutInfo;
 
-        newLayoutInfo = onAnyAction(newLayoutInfo, action, views);
+        newLayoutInfo = onAnyAction(newLayoutInfo, action, views, apiHandlesExpanded);
         // newLayoutInfo = dropDownHandler(newLayoutInfo, action);     // replaced with manager up above
         if (!newLayoutInfo.coverageSide) newLayoutInfo.coverageSide= getAppOptions()?.triViewCoverageSide;
 
@@ -66,7 +66,7 @@ export function* layoutManager({title, views='tables | images | xyplots'}) {
     }
 }
 
-function onAnyAction(layoutInfo, action, views) {
+function onAnyAction(layoutInfo, action, views, apiHandlesExpanded) {
     var {mode, hasXyPlots, hasTables, showImages, showXyPlots, showTables, autoExpand} = layoutInfo;
     var {expanded=LO_VIEW.none, standard=views} = mode || {};
 
@@ -102,7 +102,7 @@ function onAnyAction(layoutInfo, action, views) {
                     autoExpand = false;
                     expanded = LO_VIEW.none;
                 }
-            } else if (expanded === LO_VIEW.none && count === 1) {
+            } else if (expanded === LO_VIEW.none && count === 1 && !apiHandlesExpanded) {
                 // set mode into expanded view when there is only 1 component visible.
                 autoExpand = true;
                 expanded =  showImages ? LO_VIEW.images :

--- a/src/firefly/js/templates/fireflyviewer/LayoutChoice.jsx
+++ b/src/firefly/js/templates/fireflyviewer/LayoutChoice.jsx
@@ -5,7 +5,10 @@ import {func} from 'prop-types';
 import React, {useState} from 'react';
 import {Card, Stack, Typography} from '@mui/joy';
 import {
-    dispatchSetLayoutMode, dispatchUpdateLayoutInfo, getLayouInfo, getResultCounts, LO_MODE, LO_VIEW
+    BIVIEW_I_ChCov, BIVIEW_ICov_Ch,
+    BIVIEW_IChCov_T, BIVIEW_T_IChCov,
+    dispatchSetLayoutMode, dispatchTriviewLayout, dispatchUpdateLayoutInfo, getLayouInfo, getResultCounts, LO_MODE,
+    LO_VIEW, TRIVIEW_I_ChCov_T, TRIVIEW_ICov_Ch_T
 } from '../../core/LayoutCntlr.js';
 import {ListBoxInputFieldView} from '../../ui/ListBoxInputField.jsx';
 import {AccordionPanelView} from '../../ui/panel/AccordionPanel.jsx';
@@ -70,15 +73,6 @@ export function LayoutChoiceVisualAccordion({closeSideBar}) {
     );
 }
 
-
-const TRIVIEW_IC_C_T= 'TRIVIEW_IC_C_T';
-const TRIVIEW_I_CC_T= 'TRIVIEW_I_CC_T';
-const BIVIEW_IC_C= 'BIVIEW_IC_C';
-const BIVIEW_I_CC= 'BIVIEW_I_CC';
-const BIVIEW_T_ICC= 'BIVIEW_T_ICC';
-const BIVIEW_ICC_T= 'BIVIEW_ICC_T';
-
-
 export function LayoutChoiceLayoutVisual({closeSideBar}) {
     const {mode, showTables, showImages, showXyPlots, images={}, coverageSide=LEFT}=
         useStoreConnector(() => pick(getLayouInfo(), stateKeys));
@@ -88,7 +82,7 @@ export function LayoutChoiceLayoutVisual({closeSideBar}) {
     const currLayoutMode= getLayouInfo()?.mode?.standard?.toString() ?? triViewKey;
     const isTriViewPossible = (showImages||showCoverage) && showXyPlots && showTables;
 
-    if (mode.expanded && mode.expanded!==LO_VIEW.none) {
+    if (mode?.expanded && mode.expanded!==LO_VIEW.none) {
         return <Typography sx={{pt:1}}>Single View Expanded</Typography>;
     }
 
@@ -99,17 +93,17 @@ export function LayoutChoiceLayoutVisual({closeSideBar}) {
         switch (currLayoutMode) {
             case triViewKey:
                 if (showCoverage || showImages) {
-                    return (coverageRight) ? TRIVIEW_I_CC_T : TRIVIEW_IC_C_T;
+                    return (coverageRight) ? TRIVIEW_I_ChCov_T : TRIVIEW_ICov_Ch_T;
                 }
                 else {
-                    return BIVIEW_ICC_T;
+                    return BIVIEW_IChCov_T;
                 }
             case imgXyKey:
-                return (coverageRight && showImages) ? BIVIEW_I_CC : BIVIEW_IC_C;
-            case tblXyKey: return BIVIEW_T_ICC;
-            case xYTblKey: return BIVIEW_ICC_T;
+                return (coverageRight && showImages) ? BIVIEW_I_ChCov : BIVIEW_ICov_Ch;
+            case tblXyKey: return BIVIEW_T_IChCov;
+            case xYTblKey: return BIVIEW_IChCov_T;
         }
-        return TRIVIEW_I_CC_T;
+        return TRIVIEW_I_ChCov_T;
     };
 
 
@@ -138,45 +132,20 @@ export function LayoutChoiceLayoutVisual({closeSideBar}) {
 
 function getOptions(isTriViewPossible,showImages,showCoverage) {
     const layoutOps= [];
-    if (isTriViewPossible) layoutOps.push({label:'Tri-view (L:Cov,I  R: Charts  B: Tables)', value:TRIVIEW_IC_C_T});  // L:Cov,Images - R: Charts - B: Tables
+    if (isTriViewPossible) layoutOps.push({label:'Tri-view (L:Cov,I  R: Charts  B: Tables)', value:TRIVIEW_ICov_Ch_T});  // L:Cov,Images - R: Charts - B: Tables
     if (isTriViewPossible && (showImages&&showCoverage)) {
-        layoutOps.push({label:'Tri-view images (L:I  R: Charts,Cov   B: Tables)', value:TRIVIEW_I_CC_T}); // L:Images -  R: Cov,Charts - B: Tables
+        layoutOps.push({label:'Tri-view images (L:I  R: Charts,Cov   B: Tables)', value:TRIVIEW_I_ChCov_T}); // L:Images -  R: Cov,Charts - B: Tables
     }
 
-    if (showCoverage) layoutOps.push({label:'Bi-view Charts', value:BIVIEW_IC_C});   // L:I,Cov  R:Charts  (no tables)
-    if (showCoverage && showImages) layoutOps.push({label:'Bi-view images', value:BIVIEW_I_CC});  // L:I - R:Cov,Charts - (no tables)
-    layoutOps.push({label:'Bi-view Tables', value:BIVIEW_T_ICC});   // L:Tables -  R: Charts,Cov,Images
-    layoutOps.push({label:'Bi-view Tables', value:BIVIEW_ICC_T});   // L: Charts,Cov,Images - R:Tables
+    if (showCoverage) layoutOps.push({label:'Bi-view Charts', value:BIVIEW_ICov_Ch});   // L:I,Cov  R:Charts  (no tables)
+    if (showCoverage && showImages) layoutOps.push({label:'Bi-view images', value:BIVIEW_I_ChCov});  // L:I - R:Cov,Charts - (no tables)
+    layoutOps.push({label:'Bi-view Tables', value:BIVIEW_T_IChCov});   // L:Tables -  R: Charts,Cov,Images
+    layoutOps.push({label:'Bi-view Tables', value:BIVIEW_IChCov_T});   // L: Charts,Cov,Images - R:Tables
     return layoutOps;
 }
 
 function changeLayout(newVal)  {
-    switch (newVal) {
-        case TRIVIEW_IC_C_T:
-            dispatchSetLayoutMode(LO_MODE.standard, triViewKey);
-            dispatchUpdateLayoutInfo({coverageSide:LEFT});
-            break;
-        case TRIVIEW_I_CC_T:
-            dispatchSetLayoutMode(LO_MODE.standard, triViewKey);
-            dispatchUpdateLayoutInfo({coverageSide:RIGHT});
-            break;
-        case BIVIEW_IC_C:
-            dispatchSetLayoutMode(LO_MODE.standard, imgXyKey);
-            dispatchUpdateLayoutInfo({coverageSide:LEFT});
-            break;
-        case BIVIEW_I_CC:
-            dispatchSetLayoutMode(LO_MODE.standard, imgXyKey);
-            dispatchUpdateLayoutInfo({coverageSide:RIGHT});
-            break;
-        case BIVIEW_T_ICC:
-            dispatchSetLayoutMode(LO_MODE.standard, tblXyKey);
-            dispatchUpdateLayoutInfo({coverageSide:RIGHT});
-            break;
-        case BIVIEW_ICC_T:
-            dispatchSetLayoutMode(LO_MODE.standard, xYTblKey);
-            dispatchUpdateLayoutInfo({coverageSide:RIGHT});
-            break;
-    }
+    dispatchTriviewLayout({triviewLayout:newVal});
 }
 
 function getICDesc(showImages,showCoverage) {
@@ -189,18 +158,18 @@ function getICDesc(showImages,showCoverage) {
 function OpRender({value, width='12rem', useBorder=true, showImages, showCoverage}) {
     const left= getICDesc(showImages,showCoverage);
     switch (value) {
-        case TRIVIEW_IC_C_T:
+        case TRIVIEW_ICov_Ch_T:
             return <TriViewItems {...{useBorder, width, left, right: ['Charts'], bottom:['Tables']}}/>;
-        case TRIVIEW_I_CC_T:
+        case TRIVIEW_I_ChCov_T:
             return <TriViewItems {...{useBorder, width, left:['Images'] , right: ['Coverage', 'Charts'], bottom:['Tables']}}/>;
-        case BIVIEW_IC_C:
+        case BIVIEW_ICov_Ch:
             return <BiViewItems {...{useBorder, width, left, right: ['Charts']}} />;
-        case BIVIEW_I_CC:
+        case BIVIEW_I_ChCov:
             return <BiViewItems {...{useBorder, width, left:['Images'] , right: ['Coverage','Charts']}} />;
-        case BIVIEW_T_ICC:
+        case BIVIEW_T_IChCov:
             const right=  [...getICDesc(showImages,showCoverage),'Charts'];
             return <BiViewItems {...{useBorder, width, left:['Tables'] , right}} />;
-        case BIVIEW_ICC_T:
+        case BIVIEW_IChCov_T:
             return <BiViewItems {...{useBorder, width, left:[...getICDesc(showImages,showCoverage), 'Charts'], right:['Tables']}} />;
     }
     return <div>{value}</div>;

--- a/src/firefly/js/visualize/MultiViewCntlr.js
+++ b/src/firefly/js/visualize/MultiViewCntlr.js
@@ -49,6 +49,7 @@ export const PLOT2D='plot2d';
 export const WRAPPER='wrapper';
 export const DEFAULT_FITS_VIEWER_ID= 'DEFAULT_FITS_VIEWER_ID';
 export const DEFAULT_PLOT2D_VIEWER_ID= 'DEFAULT_PLOT2D_VIEWER_ID';
+export const PINNED_CHART_VIEWER_ID = 'PINNED_CHART_VIEWER_ID';
 export const EXPANDED_MODE_RESERVED= 'EXPANDED_MODE_RESERVED';
 export const GRID_RELATED='gridRelated';
 export const GRID_FULL='gridFull';
@@ -393,18 +394,7 @@ export function getAViewFromMultiView(multiViewRoot, containerType, renderTreeId
                                             !entry.customData.independentLayout &&
                                             entry.containerType===containerType &&
                                             (entry?.canReceiveNewPlots===NewPlotMode.create_replace.key)));
-    if (viewer.reservedContainer && renderTreeId) {
-        const newId= `${viewer.viewerId}_${renderTreeId}`;
-        const modViewer= getViewer(multiViewRoot, newId);
-        if (modViewer) return modViewer;
-        dispatchAddViewer(newId, NewPlotMode.create_replace.key,
-                      containerType,false,renderTreeId);
-
-        return getViewer(getMultiViewRoot(), newId);
-    }
-    else {
-        return viewer;
-    }
+    return viewer;
 }
 
 /**
@@ -528,12 +518,6 @@ const removeViewer= (state,action) => state.filter( (v) => v.viewId!==action.pay
  * @return {MultiViewerRoot}
  */
 function addItems(state,viewerId,itemIdAry, containerType, renderTreeId) {
-    if (renderTreeId) {
-        itemIdAry.forEach( (id) => {
-            const v= getViewer(state,findViewerWithItemId(state, id, containerType));
-            if (v && v.renderTreeId!==renderTreeId) state= deleteSingleItem(state,id,containerType);
-        });
-    }
     let viewer= state.find( (entry) => entry.viewerId===viewerId);
 
     if (!viewer) {

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -16,7 +16,7 @@ import {
 } from '../PlotViewUtil.js';
 import {callCrop} from '../../rpc/PlotServicesJson.js';
 import {WebPlotResult} from '../WebPlotResult.js';
-import {isHiPS, WebPlot} from '../WebPlot.js';
+import {isHiPS, isImage, WebPlot} from '../WebPlot.js';
 import {locateOtherIfMatched} from './WcsMatchTask';
 import {PlotAttribute} from '../PlotAttribute.js';
 import PlotState from '../PlotState.js';
@@ -37,6 +37,7 @@ export function requestLocalDataActionCreator(rawAction) {
         const {plotId, plotImageId, dataRequested= true, imageOverlayId}=rawAction.payload;
         const pv= getPlotViewById(visRoot(),plotId);
         const plot= imageOverlayId ? getOverlayById(pv,imageOverlayId)?.plot : findPlot(pv,plotImageId);
+        if (!isImage(plot)) return;
         if (dataRequested===false) {
             dispatcher(rawAction);
             return;

--- a/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
@@ -53,10 +53,10 @@ export const MultiImageViewerView = forwardRef( (props, ref) => {
 
     let style= {display:'flex', flexDirection:'column', position:'relative'};
     if (props.insideFlex) {
-        style= {...style, flex:'1 1 auto', maxWidth:'100%'};
+        style= {...style, flex:'1 1 auto', maxWidth:'100%', ...props.style};
     }
     else {
-        style=  {...style, width:'100%', height:'100%'};
+        style=  {...style, width:'100%', height:'100%', ...props.style};
     }
     
     const {readoutPref}= readoutRoot();

--- a/src/firefly/js/voAnalyzer/TableAnalysis.js
+++ b/src/firefly/js/voAnalyzer/TableAnalysis.js
@@ -2,6 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {get, intersection, isEmpty, isString} from 'lodash';
+import {defDataSourceGuesses} from '../metaConvert/DefaultConverter.js';
 import {ACCESS_FORMAT, ACCESS_URL, DEFAULT_TNAME_OPTIONS, obsPrefix, OBSTAP_CNAMES, S_REGION} from './VoConst.js';
 import {MetaConst} from '../data/MetaConst.js';
 import {getCornersColumns} from '../tables/TableInfoUtil.js';
@@ -219,10 +220,18 @@ export function isDataProductsTable(tableOrId) {
         dataSourceColumn ||
         hasObsCoreLikeDataProducts(table) ||
         hasServiceDescriptors(table) ||
+        hasGuessedDataProductsColumn(table) ||
         isTableWithRegion(tableOrId));
 }
 
 
+function hasGuessedDataProductsColumn(table) {
+    const columns= table?.tableData?.columns ?? [];
+
+    const found= defDataSourceGuesses.some( (n) => columns
+        .some( (c) => c.name.toUpperCase()===n));
+    return found;
+}
 
 /**
  * find the ObsCore defined 'access_url' column


### PR DESCRIPTION
#### [Firefly-1483](https://jira.ipac.caltech.edu/browse/FIREFLY-1483): change firefly_client to better support triview and plan to deprecate slate

see [firefly_client PR](https://github.com/Caltech-IPAC/firefly_client/pull/58)
see [jupyter_firefly_extension PR](https://github.com/Caltech-IPAC/jupyter_firefly_extensions/pull/29)

  - added a api view mode landing page
  - improved ApiExpandedView to handle pinned charts
  - TriViewPanel now better handles display modes
  - removed many uses of renderTreeId
  - js api viewer supports triview or slate

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1483-triview/firefly
 - see the [firefly_client PR](https://github.com/Caltech-IPAC/firefly_client/pull/58)