### PR TITLE
IRSA-5492: Change Polygon input accept no comma pairs 

### DIFF
--- a/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
+++ b/src/firefly/js/ui/dynamic/DLGeneratedDropDown.js
@@ -465,7 +465,7 @@ const doSubmitSearch= (r,docRows,qAna,fdAry,searchObjFds,tabsKey) => {
     if (!hasValidSpacialSearch(r,fds)) {
         showInfoPopup( getSpacialSearchType(r,fds)===CONE_CHOICE_KEY ?
                 'Target is required' :
-                'Search Area is require and must have at least 3 point pairs, each separated by commas',
+                'Search Area is require and must have at least 3 point pairs, each optionally separated by commas',
             'Error');
         return false;
     }

--- a/src/firefly/js/ui/dynamic/DynComponents.jsx
+++ b/src/firefly/js/ui/dynamic/DynComponents.jsx
@@ -327,7 +327,7 @@ export function PolygonField({ fieldKey, desc = 'Coordinates', initValue = '', s
 
     const help = [
         'Each vertex is defined by a J2000 RA and Dec position pair',
-        '3 to 15 vertices is allowed, separated by a comma (,)',
+        '3 to 15 vertices is allowed, optionally separated by a comma (,)',
         isArray(targetPanelExampleRow1) ? targetPanelExampleRow1[0] :targetPanelExampleRow1,
         helpRow2
     ];

--- a/src/firefly/js/visualize/ui/VisualSearchUtils.js
+++ b/src/firefly/js/visualize/ui/VisualSearchUtils.js
@@ -127,12 +127,32 @@ export function makeRelativePolygonAry(plot, polygonAry) {
 export function convertStrToWpAry(str) {
     if (!str) return;
     if (!isString(str)) return [];
-    const ptStrAry = str?.split(',');
+   /* const ptStrAry = str?.split(',');
     if (!(ptStrAry?.length > 1)) return [];
     const wpAry = ptStrAry
         .map((s) => splitByWhiteSpace(s))
         .filter((sAry) => sAry.length === 2 && !isNaN(Number(sAry[0])) && !isNaN(Number(sAry[1])))
         .map((sAry) => makeWorldPt(sAry[0], sAry[1]));
+    return wpAry;*/
+
+    //this is the logic to handle polygon pairs with or without commas, just reduce the array into pairs
+    const normalizedInput = str.replace(/,/g, ' '); //replace every comma with a space
+    const ptStrAry = splitByWhiteSpace(normalizedInput);
+    if (!(ptStrAry?.length > 2)) return [];
+
+    const pairs = ptStrAry.reduce((acc, curr, index) => {
+        if (index % 2 === 0) {
+            acc.push([curr]);
+        } else {
+            acc[acc.length - 1].push(curr);
+        }
+        return acc;
+    }, []);
+
+    // Filter valid pairs and map to makeWorldPt
+    const wpAry = pairs
+        .filter((pair) => pair.length === 2 && !isNaN(Number(pair[0])) && !isNaN(Number(pair[1])))
+        .map((pair) => makeWorldPt(pair[0], pair[1]));
     return wpAry;
 }
 


### PR DESCRIPTION
**[IRSA-5492](https://jira.ipac.caltech.edu/browse/IRSA-5492)** 
- Enabling no comma Polygon pairs to be accepted now (while comma separated pairs will still work)
   - adjusted the error and help text accordingly, to indicate the use of comma is optional 
- IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/326

Testing: 
- DCE:  https://irsa-5492-euclid-upload-source.irsakudev.ipac.caltech.edu/irsaviewer/dce
- Euclid: https://irsa-5492-euclid-upload-source.irsakudev.ipac.caltech.edu/applications/euclid
  - test polygon inputs, with and without comma, and less than 3 pairs, etc.