### PR TITLE
FIREFLY-1480: Fix binned plot and chart-saving bugs

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -578,7 +578,9 @@ function updateChartData(chartId, traceNum, tablesource, action={}) {
     } else {
         if (!isFullyLoaded(tbl_id)) return;
         const tableModel = getTblById(tbl_id);
-        dispatchLoadTblStats(tableModel.request);
+        if (!getColValStats(tbl_id)) {
+            dispatchLoadTblStats(tableModel.request);
+        }
 
         const changes = getDataChangesForMappings({mappings, traceNum});
 
@@ -1101,10 +1103,14 @@ function isNonNumColumn(tbl_id, colExp) {
     if (colType) {
         return !numTypes.includes(colType);
     } else {
-        const colValidator = getColValidator(getColValStats(tbl_id));
-        const {valid} = colValidator(colExp);
-
-        return !valid;
+        const colValStats = getColValStats(tbl_id);
+        if (colValStats) {
+            const colValidator = getColValidator(colValStats);
+            const {valid} = colValidator(colExp);
+            return !valid;
+        } else {
+            return false;
+        }
     }
 }
 

--- a/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
+++ b/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
@@ -73,7 +73,7 @@ const PlotLySavePanel= function( {isWs,Plotly, chartDiv, filename}) {
                         tooltip: 'Enter filename of chart png',
                         label: 'Chart Filename',
                     }} />
-                <Stack flexDirection='row' justifyContent='space-between'>
+                <Stack direction='row' justifyContent='space-between'>
                     <Stack spacing={1} direction='row' alignItems='center'>
                         <CompleteButton text='Save' dialogId={DIALOG_ID}
                                         onSuccess={(request) => saveFile(request,Plotly, chartDiv)} />

--- a/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
+++ b/src/firefly/js/charts/ui/PlotlySaveDialog.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import {Button,Stack} from '@mui/joy';
+import {Box, Button, Stack} from '@mui/joy';
 import {getWorkspaceConfig} from 'firefly/visualize/WorkspaceCntlr.js';
 import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
 import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
@@ -24,15 +24,16 @@ export function showPlotLySaveDialog(Plotly, chartDiv) {
     const isWs = getWorkspaceConfig(); //todo - keep if we add workspace support
     const  popup = (
         <PopupPanel title={'Save Chart'}>
-            <Stack sx={{
+            <Box sx={{
                 minWidth: '32rem',
                 minHeight: '10rem',
+                height: '10rem',
                 resize: 'both',
                 overflow: 'hidden',
                 position: 'relative'
             }}>
                 <PlotLySavePanel {...{Plotly, chartDiv, isWs, filename:getDefaultFilename(chartDiv)}}/>
-            </Stack>
+            </Box>
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(DIALOG_ID, popup);
@@ -63,8 +64,8 @@ async function saveFile(request, Plotly, chartDiv) {
 
 const PlotLySavePanel= function( {isWs,Plotly, chartDiv, filename}) {
     return (
-        <Stack p={1} flexGrow={1} justifyContent='space-between'>
-            <FieldGroup groupKey={'PlotLySaveField'} >
+        <FieldGroup groupKey={'PlotLySaveField'} sx={{height: 1}}>
+            <Stack p={1} justifyContent='space-between' spacing={2} height={1}>
                 <ValidationField
                     fieldKey={'filename'}
                     initialState= {{
@@ -72,16 +73,15 @@ const PlotLySavePanel= function( {isWs,Plotly, chartDiv, filename}) {
                         tooltip: 'Enter filename of chart png',
                         label: 'Chart Filename',
                     }} />
-            </FieldGroup>
-
-            <Stack flexDirection='row' justifyContent='space-between'>
-                <Stack spacing={1} direction='row' alignItems='center'>
-                    <CompleteButton text='Save' dialogId={DIALOG_ID}
-                                    onSuccess={(request) => saveFile(request,Plotly, chartDiv)} />
-                    <Button onClick={() => dispatchHideDialog(DIALOG_ID)}>Cancel</Button>
+                <Stack flexDirection='row' justifyContent='space-between'>
+                    <Stack spacing={1} direction='row' alignItems='center'>
+                        <CompleteButton text='Save' dialogId={DIALOG_ID}
+                                        onSuccess={(request) => saveFile(request,Plotly, chartDiv)} />
+                        <Button onClick={() => dispatchHideDialog(DIALOG_ID)}>Cancel</Button>
+                    </Stack>
+                    <HelpIcon helpId={'chart.save'}/>
                 </Stack>
-                <HelpIcon helpId={'chart.save'}/>
             </Stack>
-        </Stack>
+        </FieldGroup>
     );
 };


### PR DESCRIPTION
Fixes [FIREFLY-1480](https://jira.ipac.caltech.edu/browse/FIREFLY-1480)

Three bugs in ticket:
1. no longer reproducible
2. when an expression is given to X, Y to heatmap options it was closing the dialog after "apply". It was requesting table stats even when they were already available - which takes time and was causing isNonNumColumn() to throw errors.
3. Plot saving wasn't working because CompleteButton wasn't connected to FieldGroup (this got taken out during joy-ui refactor)

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1480-binned-plot-bugs/firefly/

Select 2MASS catalog, do m81, 1deg -> open heatmap options -> change x: j_m-h_m, y: h_m-k_m -> apply. Chart should update without closing. 

[For regression testing] Do another search, 2MASS, m81, 1arcmin -> open scatter options -> change x,y as above -> apply. Chart should behave like before.

Click on plot save button, and click save - it should download a png for chart.