### PR TITLE
FIREFLY-1485: Clean up dark mode

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -532,3 +532,22 @@ div.rootStyle img {
 #app img {
     -webkit-user-drag: none;
 }
+
+/*------------------- generic-browser scrollbars ---------------------*/
+/* from https://developer.chrome.com/docs/css-ui/scrollbar-styling */
+/* Modern browsers with `scrollbar-*` support */
+@supports (scrollbar-width: auto) {
+    #app {
+        scrollbar-color: var(--joy-palette-neutral-solidBg) var(--joy-palette-background-level1); /*thumb-color track-color*/
+    }
+}
+
+/* Legacy browsers with `::-webkit-scrollbar-*` support */
+@supports selector(::-webkit-scrollbar) {
+    #app::-webkit-scrollbar-thumb {
+        background: var(--joy-palette-neutral-solidBg);
+    }
+    #app::-webkit-scrollbar-track {
+        background: var(--joy-palette-background-level1);
+    }
+}

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -685,7 +685,6 @@ export function applyDefaults(chartData={}, resetColor = true) {
         xaxis: {
             autorange:true,
             showgrid: false,
-            lineColor: '#e9e9e9',
             tickwidth: 1,
             ticklen: 5,
             title: {
@@ -702,7 +701,6 @@ export function applyDefaults(chartData={}, resetColor = true) {
         yaxis: {
             autorange:true,
             showgrid: !noXYAxis,
-            lineColor: '#e9e9e9',
             tickwidth: 1,
             ticklen: 5,
             title: {

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -123,10 +123,14 @@ function adjustLayout(layout={}, theme) {
     set(layout, 'margin.b', hasOppositeX ? MIN_MARGIN_PX: X_TICKLBL_PX);
     set(layout, 'margin.t', hasOppositeX ? X_TICKLBL_PX: MIN_MARGIN_PX + (hasTitle ? TITLE_PX: 0));
 
+    const getColorStr = (cssVarStr) => cssVarStr?.split(',')[1].slice(0,-1);  // plotly will only take a color string
+
     // make background same as app's background color
-    const bgSurface = theme?.palette?.background?.surface?.split(',')[1].slice(0,-1);     // plotly will only take a color string
+    const bgSurface = getColorStr(theme?.palette?.background?.surface);
     set(layout, 'paper_bgcolor', bgSurface);
     set(layout, 'plot_bgcolor', bgSurface);
+
+    set(layout, 'font.color', getColorStr(theme?.palette?.text?.tertiary));
 
     return layout;
 }

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -147,7 +147,10 @@ const BasicTableViewInternal = React.memo((props) => {
     };
 
     return (
-        <Box tabIndex='-1' onKeyDown={onKeyDown} sx={{lineHeight:1, flexGrow:1, minHeight:0, minWidth:0}}>
+        <Box tabIndex='-1' onKeyDown={onKeyDown} sx={{
+            lineHeight:1, flexGrow:1, minHeight:0, minWidth:0,
+            color: 'text.secondary' //otherwise parent's font color bleeds (which is not same in dark mode)
+        }}>
             {content()}
             <Status/>
         </Box>

--- a/src/firefly/js/tables/ui/TablePanel.css
+++ b/src/firefly/js/tables/ui/TablePanel.css
@@ -19,7 +19,6 @@
 }
 
 .TablePanel__table {
-    background-color: white;
     display: flex;
     position: absolute;
     bottom: 0;
@@ -122,6 +121,10 @@ Overriding default fixed-table css
     border-width: 0 1px 1px 0;
 }
 
+.public_fixedDataTable_main {
+    border-color: var(--joy-palette-neutral-outlinedBorder);
+}
+
 .fixedDataTableRowLayout_main div, .fixedDataTableCellLayout_main [role=columnheader]{
     background-color: var(--joy-palette-background-surface, #FBFCFE);
 }
@@ -149,12 +152,38 @@ Overriding default fixed-table css
     background-image: none;
     background-color: unset;
     font-weight: unset;
+    border-color: var(--joy-palette-neutral-outlinedBorder);
+}
+
+.public_fixedDataTableRow_fixedColumnsDivider {
+    border-color: var(--joy-palette-neutral-outlinedBorder);
 }
 
 .fixedDataTableCellLayout_columnResizerContainer, .public_fixedDataTable_scrollbarSpacer {
     background-color: unset !important;
 }
 
+.public_Scrollbar_main.public_Scrollbar_mainActive,
+.public_Scrollbar_main {
+    background-color: var(--joy-palette-background-surface);
+    border-color: var(--joy-palette-neutral-outlinedBorder);
+}
+
+.public_Scrollbar_mainOpaque,
+.public_Scrollbar_mainOpaque.public_Scrollbar_mainActive,
+.public_Scrollbar_mainOpaque:hover {
+    background-color: var(--joy-palette-background-surface);
+}
+
+.public_Scrollbar_face:after {
+    background-color: var(--joy-palette-neutral-softActiveBg);
+}
+
+.public_Scrollbar_main:hover .public_Scrollbar_face:after,
+.public_Scrollbar_mainActive .public_Scrollbar_face:after,
+.public_Scrollbar_faceActive:after {
+    background-color: var(--joy-palette-neutral-solidBg);
+}
 
 .public_fixedDataTableRow_columnsShadow {
     background-image: none;

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -78,7 +78,6 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
     const selectInfoCls = SelectInfo.newInstance(selectInfo, startIdx);
     const tstate = getTableState(tbl_id);
     logger.debug(`render.. state:[${tstate}] -- ${tbl_id}  ${tbl_ui_id}`);
-    const borderTop = showToolbar ? '1px solid #d3d3d3' : undefined;
 
     if ([TBL_STATE.ERROR,TBL_STATE.LOADING].includes(tstate))  return <NotReady {...{showTitle, tbl_id, title, removable, backgroundable, error}}/>;
 
@@ -101,8 +100,12 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
                        onMouseDown={stopPropagation}
                 >
                     <ToolBar {...{tbl_id, tbl_ui_id, connector, tblState, slotProps}}/>
-                    <Stack lineHeight={1} borderTop={borderTop} flexGrow={1} overflow='hidden'
-                            sx={{'& .fixedDataTableLayout_main': {border:'none'}}}
+                    <Stack lineHeight={1} flexGrow={1} overflow='hidden'
+                            sx={{
+                                '& .fixedDataTableLayout_main': {border:'none'},
+                                borderTop: showToolbar ? 1 : undefined,
+                                borderColor: 'neutral.outlinedBorder'
+                            }}
                            {...slotProps?.table}>
                         <BasicTableView
                             callbacks={connector}


### PR DESCRIPTION
Fixes [FIREFLY-1485](https://jira.ipac.caltech.edu/browse/FIREFLY-1485)

Note: This is a minimal cleanup of highly notable dark mode problems - we can do more nuanced cleanup in future.

Made following colors theme based:
- Chart fonts
  - Additional: cleaned up `lineColor` not being used becuase the plotly prop for it is called `linecolor`
- Table border
- Table fonts
- Table scrollbars (background as well as track/face)

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1485-dark-mode-cleanup/firefly/

Open any tiview search results in dark mode, it will be best to compare it side by side with a [nightly firefly build](https://fireflydev.ipac.caltech.edu/firefly/)

Also check light mode should look mostly same (there are only minor notable changes, instead of fixed-table css grey colors, we now are using greys from our palette)