### PR TITLE
Firefly-1495: sd parsing and extraction fixes

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -16,6 +16,8 @@ import edu.caltech.ipac.table.io.IpacTableReader;
 import edu.caltech.ipac.table.io.VoTableReader;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.FitsHDUUtil;
+import edu.caltech.ipac.util.download.FailedRequestException;
+import edu.caltech.ipac.util.download.ResponseMessage;
 import nom.tam.fits.FitsException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -236,7 +238,10 @@ public class FileAnalysis {
                 FileAnalysisReport.ReportType.Details, Format.UNKNOWN.name(),
                 infile.length(), infile.getPath());
         FileAnalysisReport.Part part= new FileAnalysisReport.Part(FileAnalysisReport.Type.ErrorResponse, "Error");
-        part.setDesc("Error in File Retrieve: " + responseCode);
+
+        String desc= "Error in File Retrieve: " + ResponseMessage.getHttpResponseMessage(responseCode) +
+                " (response code: "+ responseCode + ")";
+        part.setDesc(desc);
         if (infile.length()<500 && contentType!=null && contentType.toLowerCase().contains("text/plain")) {
             try {
                 String content = FileUtil.readFile(infile);
@@ -272,7 +277,14 @@ public class FileAnalysis {
         FileAnalysisReport report = new FileAnalysisReport( FileAnalysisReport.ReportType.Details,
                 Format.UNKNOWN.name(), 0, "");
         FileAnalysisReport.Part part= new FileAnalysisReport.Part(FileAnalysisReport.Type.ErrorResponse, "Error");
-        part.setDesc("Error in File Retrieve: " + e.getMessage());
+        String desc;
+        if (e instanceof FailedRequestException fre) {
+            desc= "Error in File Retrieve: " + e.getMessage() + " (response code: "+ fre.getResponseCode() + ")";
+        }
+        else {
+            desc= "Error in File Retrieve: " + e.getMessage();
+        }
+        part.setDesc(desc);
         report.addPart(part);
         return report;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/table/MetaConst.java
@@ -44,6 +44,11 @@ public class MetaConst {
     public static final String IMAGE_AS_TABLE_UNITS= "IMAGE_AS_TABLE_UNITS";
 
     /*
+     * plane of cube to extract
+     */
+    public static final String IMAGE_AS_TABLE_PLANE= "IMAGE_AS_TABLE_PLANE";
+
+    /*
      * a string the default says what this data type might be such as 'spectrum', 'sed', 'timeseries', etc
      */
     public static final String DATA_TYPE_HINT = "DATA_TYPE_HINT";

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
@@ -108,6 +108,8 @@ public class FitsExtract {
         if (y<0) y= 0;
         if (x+ptSize>=naxis1) x-= (x+ptSize-naxis1+1);
         if (y+ptSize>=naxis2) y-= (y+ptSize-naxis2+1);
+        if (x<0) x= 0;
+        if (y<0) y= 0;
 
         Class<?> arrayType= switch (bitpix) {
             case -32 -> Float.TYPE;

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -151,6 +151,11 @@ export const MetaConst = {
     IMAGE_AS_TABLE_UNITS: 'IMAGE_AS_TABLE_UNITS',
 
     /*
+     * plane of cube to extract
+     */
+    IMAGE_AS_TABLE_PLANE: 'IMAGE_AS_TABLE_PLANE',
+
+    /*
      * a string the default says what this data type might be such as 'spectrum', 'sed', 'timeseries', etc
      */
     DATA_TYPE_HINT: 'DATA_TYPE_HINT',

--- a/src/firefly/js/metaConvert/AnalysisUtils.js
+++ b/src/firefly/js/metaConvert/AnalysisUtils.js
@@ -33,10 +33,10 @@ export function makeAnalysisGetSingleDataProduct(makeReq) {
 }
 
 
-export async function uploadAndAnalyze({request, table, row, activateParams, dataTypeHint = '', options}) {
+export async function uploadAndAnalyze({request, table, row, activateParams, dataTypeHint = '', options, serviceDescMenuList}) {
     if (!hasRowAccess(table, row)) dpdtSimpleMsg('You do not have access to this data.');
     if (isNonAnalysisType(request)) return fileExtensionSingleProductAnalysis(request);
-    const analysisPromise = doUploadAndAnalysis({table, row, request, activateParams, dataTypeHint, options});
+    const analysisPromise = doUploadAndAnalysis({table, row, request, activateParams, dataTypeHint, options, serviceDescMenuList});
     return dpdtWorkingPromise(LOADING_MSG, analysisPromise, request);
 }
 
@@ -126,7 +126,7 @@ export function makeAnalysisActivateFunc({table, row, request, activateParams, m
         dispatchUpdateDataProducts(dpId, dpdtWorkingMessage(LOADING_MSG,menuKey));
         // do the uploading and analyzing
         const dPDisplayType= await doUploadAndAnalysis({ table, row, request, activateParams, dataTypeHint, options, menu,
-            serDef, userInputParams, analysisActivateFunc, originalTitle});
+            serDef, userInputParams, analysisActivateFunc, originalTitle, menuKey});
         // activate the result of the analysis
        dispatchResult(dPDisplayType, menu,menuKey,dpId, serDef, analysisActivateFunc);
     };

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -365,6 +365,8 @@ function activateMenuItem(state,action) {
                 break;
             case DPtypes.ANALYZE:
                 dpData.dataProducts= {...aMenuItem, menuKey, menu, activeMenuKey:menuKey, activeMenuLookupKey};
+            case DPtypes.MESSAGE:
+                dpData.dataProducts= {...aMenuItem, menuKey, menu, activeMenuKey:menuKey, activeMenuLookupKey};
         }
 
     }

--- a/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
@@ -7,7 +7,8 @@ import {getSearchTarget} from '../../visualize/saga/CatalogWatcher.js';
 import {makeAnalysisActivateFunc} from '../AnalysisUtils.js';
 import {dispatchUpdateActiveKey, getActiveMenuKey, getCurrentActiveKeyID} from '../DataProductsCntlr.js';
 import {
-    dpdtAnalyze, dpdtChartTable, dpdtDownload, dpdtDownloadMenuItem, dpdtFromMenu, dpdtImage, dpdtMessage, dpdtPNG,
+    dpdtAnalyze, dpdtChartTable, dpdtDownload, dpdtDownloadMenuItem, dpdtFromMenu, dpdtImage, dpdtMessage,
+    dpdtMessageWithError, dpdtPNG,
     dpdtTable, DPtypes
 } from '../DataProductsType.js';
 import {createSingleImageActivate, createSingleImageExtraction} from '../ImageDataProductsUtil.js';
@@ -17,8 +18,6 @@ import {
 } from '../TableDataProductUtils.js';
 import {makeServiceDefDataProduct} from './ServDescProducts.js';
 import {makeObsCoreRequest} from './VORequest.js';
-import {isSpectrum} from "firefly/charts/ChartUtil";
-
 
 export const USE_ALL= 'useAllAlgorithm';
 export const RELATED_IMAGE_GRID= 'relatedImageGridAlgorithm';
@@ -314,8 +313,15 @@ function createDataLinkMenuRet({dlTableUrl, dataLinkData, sourceTable, sourceRow
 
     const menu= filterDLList(parsingAlgorithm,dataLinkData)
         .map( (dlData,idx) => {
-            const {semantics,url, dlAnalysis:{isAux,isThis}}= dlData;
+            const {semantics,url,error_message, dlAnalysis:{isAux,isThis}}= dlData;
             const name= makeName(semantics, url, auxTot, auxCnt, primeCnt, baseTitle);
+            if (error_message) {
+                const edp= dpdtMessageWithError(error_message);
+                edp.complexMessage= false;
+                edp.menuKey='dlt-'+idx;
+                edp.name= `Error in related data (datalink) row ${idx}`;
+                return edp;
+            }
             const menuEntry= makeMenuEntry({dlTableUrl,dlData,idx, baseTitle, sourceTable,
                 sourceRow, options, name, doFileAnalysis, activateParams});
             if (isAux) auxCnt++;

--- a/src/firefly/js/metaConvert/vo/DatalinkProducts.js
+++ b/src/firefly/js/metaConvert/vo/DatalinkProducts.js
@@ -1,3 +1,4 @@
+import {getCellValue} from '../../tables/TableUtil.js';
 import {makeWorldPtUsingCenterColumns} from '../../voAnalyzer/TableAnalysis.js';
 import {getDataLinkData} from '../../voAnalyzer/VoDataLinkServDef.js';
 import {Band} from '../../visualize/Band.js';
@@ -178,4 +179,14 @@ function get3CBandIdxes(datalinkTable) {
         g: bandAry.findIndex( (v) => v===Band.GREEN),
         b: bandAry.findIndex( (v) => v===Band.BLUE),
     };
+}
+
+export function makeDlUrl(dlServDesc, table, row) {
+    if (!dlServDesc) return undefined;
+    const {serDefParams, accessURL}= dlServDesc;
+    const sendParams={};
+    serDefParams?.filter( ({ref}) => ref).forEach( (p) => sendParams[p.name]= getCellValue(table, row, p.colName));
+    const newUrl= new URL(accessURL);
+    Object.entries(sendParams).forEach( ([k,v]) => newUrl.searchParams.append(k,v));
+    return newUrl.toString();
 }

--- a/src/firefly/js/metaConvert/vo/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/vo/ServDescConverter.js
@@ -1,12 +1,12 @@
 import {isEmpty} from 'lodash';
-import {getCellValue, hasRowAccess} from '../../tables/TableUtil.js';
+import {hasRowAccess} from '../../tables/TableUtil.js';
 import {makeWorldPtUsingCenterColumns} from '../../voAnalyzer/TableAnalysis.js';
 import {getServiceDescriptors, isDataLinkServiceDesc} from '../../voAnalyzer/VoDataLinkServDef.js';
 import {getSearchTarget} from '../../visualize/saga/CatalogWatcher.js';
 import {getActiveMenuKey} from '../DataProductsCntlr.js';
 import {dpdtFromMenu, dpdtSimpleMsg} from '../DataProductsType.js';
 import {
-    createGridResult, datalinkDescribeThreeColor, getDatalinkRelatedGridProduct, getDatalinkSingleDataProduct
+    createGridResult, datalinkDescribeThreeColor, getDatalinkRelatedGridProduct, getDatalinkSingleDataProduct, makeDlUrl
 } from './DatalinkProducts.js';
 import {createServDescMenuRet} from './ServDescProducts.js';
 
@@ -106,15 +106,6 @@ export async function getServiceDescRelatedDataProduct(table, row, threeColorOps
 
 
 
-function makeDlUrl(dlServDesc, table, row) {
-    if (!dlServDesc) return undefined;
-    const {serDefParams, accessURL}= dlServDesc;
-    const sendParams={};
-    serDefParams?.filter( ({ref}) => ref).forEach( (p) => sendParams[p.name]= getCellValue(table, row, p.colName));
-    const newUrl= new URL(accessURL);
-    Object.entries(sendParams).forEach( ([k,v]) => newUrl.searchParams.append(k,v));
-    return newUrl.toString();
-}
 
 
 const findDataLinkServeDescs= (sdAry) => sdAry?.filter( (serDef) => isDataLinkServiceDesc(serDef));

--- a/src/firefly/js/metaConvert/vo/VORequest.js
+++ b/src/firefly/js/metaConvert/vo/VORequest.js
@@ -5,6 +5,7 @@ import {PlotAttribute} from '../../visualize/PlotAttribute.js';
 import RangeValues from '../../visualize/RangeValues.js';
 import {TitleOptions, WebPlotRequest} from '../../visualize/WebPlotRequest.js';
 import {ZoomType} from '../../visualize/ZoomType.js';
+import {getSSATitle, isSSATable} from '../../voAnalyzer/TableAnalysis.js';
 
 /**
  *
@@ -19,10 +20,13 @@ export function makeObsCoreRequest(dataSource, positionWP, titleStr, table, row)
     if (!dataSource) return undefined;
     const r = WebPlotRequest.makeURLPlotRequest(dataSource, 'DataProduct');
     r.setZoomType(ZoomType.FULL_SCREEN);
-    if (titleStr.length > 7) {
+    const ssa= isSSATable(table);
+    const titleStringToUse= ssa ? getSSATitle(table,row) ?? 'spectrum' : titleStr;
+    if (titleStringToUse?.length > 7) {
         r.setTitleOptions(TitleOptions.NONE);
-        r.setTitle(titleStr);
-    } else {
+        r.setTitle(titleStringToUse);
+    }
+    else {
         r.setTitleOptions(TitleOptions.FILE_NAME);
     }
     r.setPlotId(uniqueId('obscore-'));

--- a/src/firefly/js/ui/ColorPicker.jsx
+++ b/src/firefly/js/ui/ColorPicker.jsx
@@ -5,7 +5,7 @@
 import {Stack, Tooltip, Typography} from '@mui/joy';
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {dispatchShowDialog} from '../core/ComponentCntlr.js';
+import {dispatchHideDialog, dispatchShowDialog} from '../core/ComponentCntlr.js';
 import {PopupPanel} from './PopupPanel.jsx';
 import CompleteButton from './CompleteButton.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
@@ -80,9 +80,12 @@ function ColorPickerWrapper ({callback,color,callbackOnOKOnly, callbackOnBoth,
                               onChangeComplete={updateColor}
                               onChange={(ev) => updateStateFromRGBA(ev.rgb)}/>
                 <Stack {...{ direction:'row', justifyContent: 'space-between', alignItems: 'center'}}>
-                    <CompleteButton onSuccess={() => (callbackOnOKOnly||callbackOnBoth) && callback(lastEv,true)}
-                                    text={(callbackOnOKOnly||callbackOnBoth)? 'OK' : 'Close'}
-                                    dialogId='ColorPickerDialog'/>
+                    <CompleteButton
+                        text={(callbackOnOKOnly||callbackOnBoth)? 'OK' : 'Close'}
+                        onSuccess={() => {
+                        (callbackOnOKOnly||callbackOnBoth) && callback(lastEv,true);
+                        dispatchHideDialog('ColorPickerDialog');
+                    }} />
                     <div style={{ textAlign:'center'}}>
                         <HelpIcon helpId={helpId} />
                     </div>

--- a/src/firefly/js/visualize/ImageViewerLayout.jsx
+++ b/src/firefly/js/visualize/ImageViewerLayout.jsx
@@ -22,7 +22,7 @@ import {
     isImageViewerSingleLayout, getMultiViewRoot, findViewerWithItemId, IMAGE, getViewer, getExpandedViewerItemIds,
     EXPANDED_MODE_RESERVED
 } from './MultiViewCntlr.js';
-import {contains, intersects} from './VisUtil.js';
+import {contains, getBoundingBox, intersects} from './VisUtil.js';
 import BrowserInfo from '../util/BrowserInfo.js';
 
 import {
@@ -396,7 +396,11 @@ function isImageOnScreen(plotView) {
 
     if (!found) {
         found= screenAsDevAry.some( (pt) => pt && (contains(0,0,viewDim.width, viewDim.height,pt.x,pt.y) ||
-                                            intersects(0,0,viewDim.width, viewDim.height,pt.x,pt.y,1,1)));
+            intersects(0,0,viewDim.width, viewDim.height,pt.x,pt.y,1,1) ));
+        if (!found) {
+            const {x,y,w,h}= getBoundingBox(screenAsDevAry);
+            found= !found && intersects(0,0,viewDim.width, viewDim.height,x,y,w,h);
+        }
     }
     return found;
 }

--- a/src/firefly/js/visualize/ui/Buttons.jsx
+++ b/src/firefly/js/visualize/ui/Buttons.jsx
@@ -66,18 +66,31 @@ import OneXIcon from '@mui/icons-material/TimesOneMobiledataOutlined';
 
 import FiberManualRecordRoundedIcon from '@mui/icons-material/FiberManualRecordRounded';
 
+const ThreeCIcon = () => (
+    <Box sx={{width: 24, height: 24}}>
+        <FiberManualRecordRoundedIcon style={{color:'red'}} sx={{position: 'absolute', left: 7, top: -4,  transform: 'scale(.5)'}}/>
+        <FiberManualRecordRoundedIcon style={{color:'green'}} sx={{position: 'absolute', left: -2, top: 0,  transform: 'scale(.5)'}}/>
+        <FiberManualRecordRoundedIcon style={{color:'blue'}} sx={{position: 'absolute', left: -4, top: 10,  transform: 'scale(.5)'}}/>
+        <AddCircleOutlineIcon sx={{position: 'absolute', left: 8, top: 8, transform: 'scale(.85)'}}/>
+    </Box>
+);
 
 export const ThreeColor = (props) => {
-    const icon = (
-        <Box sx={{width: 24, height: 24}}>
-            <FiberManualRecordRoundedIcon style={{color:'red'}} sx={{position: 'absolute', left: 7, top: -4,  transform: 'scale(.5)'}}/>
-            <FiberManualRecordRoundedIcon style={{color:'green'}} sx={{position: 'absolute', left: -2, top: 0,  transform: 'scale(.5)'}}/>
-            <FiberManualRecordRoundedIcon style={{color:'blue'}} sx={{position: 'absolute', left: -4, top: 10,  transform: 'scale(.5)'}}/>
-            <AddCircleOutlineIcon sx={{position: 'absolute', left: 8, top: 8, transform: 'scale(.85)'}}/>
-        </Box>
-    );
-    return <ToolbarButton icon={icon} tip='Three Color' {...props}/>;
+    return <ToolbarButton icon={<ThreeCIcon/>} tip='Three Color' {...props}/>;
 };
+
+
+export const ThreeColorOnOff= ({isIconOn, sx, ...props}) => {
+    const sxToUse= (theme) => ({
+        'button' :{
+            background: isIconOn ? theme.vars.palette.primary?.softDisabledColor : undefined,
+        },
+        ...sx
+    });
+    return (<ToolbarButton {...{sx:sxToUse, icon: <ThreeCIcon/>, isIconOn, ...props}}/>);
+};
+
+
 
 export const ExpandButton= ({expandGrid, ...props}) =>(
     <ToolbarButton {...{

--- a/src/firefly/js/visualize/ui/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/ExtractionDialog.jsx
@@ -329,6 +329,7 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     const hduNum= getHDU(plot);
     const plane= getImageCubeIdx(plot)>-1 ? getImageCubeIdx(plot) : 0;
     const {x:chartX,y:chartY}=plot?.attributes?.[PlotAttribute.SELECT_ACTIVE_CHART_PT] ?? {};
+    const singleLine= plot.dataWidth===1 || plot.dataHeight===1;
 
     useEffect(() => {
         const getData= async () => {
@@ -366,6 +367,23 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
                 <Box>
                     <Typography> Draw line on image to extract point on line and show chart. </Typography>
                     {pvCnt>1 && <Typography {...{mt:3}}> Shift-click will change the selected image without selecting a new line. </Typography>}
+                    {singleLine &&
+                        <Stack pt={2} spacing={1}>
+                           <Typography>
+                               {`This is a ${plot.dataWidth}x${plot.dataHeight} image, would you like to extract the whole line?`}
+                           </Typography>
+                            <CompleteButton style={{paddingLeft: 15}} text='Extract whole line'
+                                            onSuccess={()=> {
+                                                const sel= {
+                                                    pt0:makeImagePt( makeImagePt(0,0)),
+                                                    pt1:makeImagePt( plot.dataHeight===1 ? makeImagePt(plot.dataWidth-1,0) : makeImagePt(0,plot.dataHeight-1) )
+                                                };
+                                                dispatchAttributeChange({plotId:plot.plotId, toAllPlotsInPlotView:true, overlayColorScope:false,
+                                                    changes: { [PlotAttribute.ACTIVE_DISTANCE]: sel, [PlotAttribute.EXTRACTION_DATA]: true, }
+                                                });
+                                            }} />
+                        </Stack>
+                    }
                 </Box>
             ),
             afterRedraw: (chart,pl) => afterLineChartRedraw(pv,chart,pl,imPtAry,makeImagePt(x1,y1), makeImagePt(x2,y2)),

--- a/src/firefly/js/visualize/ui/multiProduct/DPDropdown.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/DPDropdown.jsx
@@ -85,7 +85,7 @@ const OtherOptionsDropDown= ({menu, dpId, activeMenuLookupKey}) => {
     return (
         <SingleColumnMenu>
             {menu.map( (menuItem, idx) => (
-                <ToolbarButton text={menuItem.name} tip={`${menuItem.semantics} - ${menuItem.url}`}
+                <ToolbarButton text={menuItem.name??menuItem.message} tip={`${menuItem.semantics} - ${menuItem.url}`}
                                horizontal={false} key={'otherOptions-'+idx} hasCheckBox={true}
                                checkBoxOn={menuItem.menuKey===getActiveMenuKey(dpId, activeMenuLookupKey)}
                                onClick={() => {

--- a/src/firefly/js/voAnalyzer/TableAnalysis.js
+++ b/src/firefly/js/voAnalyzer/TableAnalysis.js
@@ -3,11 +3,14 @@
  */
 import {get, intersection, isEmpty, isString} from 'lodash';
 import {defDataSourceGuesses} from '../metaConvert/DefaultConverter.js';
-import {ACCESS_FORMAT, ACCESS_URL, DEFAULT_TNAME_OPTIONS, obsPrefix, OBSTAP_CNAMES, S_REGION} from './VoConst.js';
+import {
+    ACCESS_FORMAT, ACCESS_URL, DEFAULT_TNAME_OPTIONS, obsPrefix, OBSTAP_CNAMES, POS_EQ_UCD, S_REGION, SSA_COV_UTYPE,
+    SSA_TTTLE_UTYPE
+} from './VoConst.js';
 import {MetaConst} from '../data/MetaConst.js';
 import {getCornersColumns} from '../tables/TableInfoUtil.js';
 import {
-    getBooleanMetaEntry, getCellValue, getColumn, getColumns, getMetaEntry, isTableUsingRadians
+    getBooleanMetaEntry, getCellValue, getColumn, getColumns, getMetaEntry, getTblRowAsObj, isTableUsingRadians
 } from '../tables/TableUtil.js';
 import CoordinateSys from '../visualize/CoordSys.js';
 import {makeAnyPt, makeWorldPt} from '../visualize/Point.js';
@@ -370,3 +373,25 @@ export function getObsCoreCellValue(tableOrId, rowIdx, obsColName) {
 }
 // moved from java, if we decide to use it this is what we had before
 export const findTargetName = (columns) => columns.find( (c) => DEFAULT_TNAME_OPTIONS.includes(c));
+
+
+export function isSSATable(tableOrId) {
+    const table= getTableModel(tableOrId);
+    if (!table) return false;
+    const foundParts= table.tableData.columns
+        .filter((c) => {
+            if (c?.utype?.toLowerCase().includes(SSA_COV_UTYPE)) return true;
+            if (c?.utype?.toLowerCase().includes(SSA_TTTLE_UTYPE )) return true;
+        });
+    return foundParts.length>=2;
+}
+
+export function getSSATitle(tableOrId,row) {
+    const table= getTableModel(tableOrId);
+    if (!table) return false;
+    const foundCol= table.tableData.columns
+        .filter((c) => {
+            if (c?.utype?.toLowerCase().includes(SSA_TTTLE_UTYPE )) return true;
+        });
+    return foundCol.length>0 ? getCellValue(table,row,foundCol[0].name) : undefined;
+}

--- a/src/firefly/js/voAnalyzer/VoConst.js
+++ b/src/firefly/js/voAnalyzer/VoConst.js
@@ -135,6 +135,8 @@ export const OBSTAPCOLUMNS = [
     ['instrument_name', 'meta.id;instr', 'Provenance.ObsConfig.Instrument.name']
 ];
 export const SSA_COV_UTYPE = 'char.spatialaxis.coverage.location.value';
+export const SSA_TTTLE_UTYPE = 'dataid.title';
+export const POS_EQ_UCD = 'pos.eq';
 
 const OBSTAP_OPTIONAL_CNAMES = [
     'dataproduct_subtype', 'target_class', 'obs_title', 'obs_creation_date', 'obs_creator_name',

--- a/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
+++ b/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
@@ -140,7 +140,7 @@ export function getDataLinkData(dataLinkTableOrId) {
             const {
                 semantics, local_semantics: localSemantics, service_def: serviceDefRef,
                 content_type: contentType, content_qualifier: contentQualifier,
-                access_url: url, description, content_length: size,
+                access_url: url, description, content_length: size, error_message,
             } = rowObj;
 
             const idKey= Object.keys(rowObj).find((k) => k.toLowerCase()==='id');
@@ -148,11 +148,12 @@ export function getDataLinkData(dataLinkTableOrId) {
             const dlAnalysis= analyzeDatalinkRow({semantics, localSemantics, contentType, contentQualifier});
             return {
                 id: rowObj[idKey],
-                contentType, contentQualifier, semantics, localSemantics, url,
+                contentType, contentQualifier, semantics, localSemantics, url, error_message,
                 description, size, serviceDefRef, serDef, rowIdx: idx, dlAnalysis,
             };
         })
-        .filter(({url, serviceDefRef}) => serviceDefRef || url?.startsWith('http') || url?.startsWith('ftp'));
+        .filter(({url='', serviceDefRef, error_message}) =>
+            serviceDefRef || error_message || url.startsWith('http') || url.startsWith('ftp'));
 }
 
 function getServiceDescriptorForId(table, matchId, dataLinkTableRowIdx) {

--- a/src/firefly/js/voAnalyzer/VoTableRecognizer.js
+++ b/src/firefly/js/voAnalyzer/VoTableRecognizer.js
@@ -6,7 +6,7 @@ import {MetaConst} from '../data/MetaConst.js';
 import {getColumn, getColumnIdx, getColumns, getMetaEntry} from '../tables/TableUtil.js';
 import CoordinateSys from '../visualize/CoordSys.js';
 import {
-    alternateMainPos, ColNameIdx, mainMeta, obsCorePosColumns, OBSTAPCOLUMNS, posCol, S_REGION,
+    alternateMainPos, ColNameIdx, mainMeta, obsCorePosColumns, OBSTAPCOLUMNS, POS_EQ_UCD, posCol, S_REGION,
     SSA_COV_UTYPE, UCDCoord, ucdSyntaxMap, UtypeColIdx
 } from './VoConst.js';
 import {getObsTabColEntry, isUCDWith} from './VoCoreUtils.js';
@@ -408,8 +408,9 @@ export class VoTableRecognizer {
         if (centerColumnInfo) return centerColumnInfo;
 
         const c = getColumn(this.tableModel, 'coord_obs');
-        if (acceptArrayCol && c?.utype?.toLowerCase().includes(SSA_COV_UTYPE) && c?.arraySize &&
-            (c?.type === 'double' || c?.type === 'float')) {
+        if (acceptArrayCol && c?.arraySize &&
+            (c?.type === 'double' || c?.type === 'float')
+            (c?.utype?.toLowerCase().includes(SSA_COV_UTYPE) || c?.UCD?.toLowerCase().includes(POS_EQ_UCD) ) ) {
             return this.setCenterColumnsInfo([c, c]);
         }
         return undefined;


### PR DESCRIPTION
####  [Firefly-1495](https://jira.ipac.caltech.edu/browse/FIREFLY-1495): sd parsing and extraction fixes

 - Improve service descriptor parsing for the following complex case 
      - data has data product
      - table has non-datalink service descriptor 
      - table also has datalink service descriptor
 - Improve error handling
 - Improve SSA data recognition: recognize DataID.Title utype
 - Fix "Center Plot / Recenter" for large 1xN fits data
 - For 1xN data give a line extract option to extract whole line
 - fix color color picker close but
 - fix finder chart 3C button

#### IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/329

#### Testing 
   - finder chart: https://firefly-1495-sd-parsing.irsakudev.ipac.caltech.edu/applications/finderchart
   - Three color button updated
   - close works on the color panel
- Firefly: https://fireflydev.ipac.caltech.edu/firefly-1495-sd-parsing/firefly
    - use file: [text.xml.zip](https://github.com/user-attachments/files/15571218/text.xml.zip)
    - Upload the file
         - besides the image (the 1st option), the second option will allow you to do a search, which will fail
         - the reset button should work
         - The third option should show an error message
         - The forth and fifth are related to the now found datalink service descriptor
    - line extract the file
        - the line extract should have a button to extract the while file since it is 1xN
   - Recenter should work correctly
