### PR TITLE
Firefly-1500,1501: Fixes multiple tickets

### DIFF
--- a/src/firefly/js/drawingLayers/ExtractLineTool.js
+++ b/src/firefly/js/drawingLayers/ExtractLineTool.js
@@ -203,7 +203,6 @@ function start(drawLayer, action) {
     const mode= getMode(plot);
     if (!plot || shiftDown) return;
     const cc= CsysConverter.make(plot);
-    if (!cc.pointInData(imagePt)) return;
     let retObj= {};
     if (mode==='select' || shiftDown) {
         retObj= setupSelect(imagePt);

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -176,7 +176,7 @@ export function getTableGroup(tbl_group='main') {
  * returns the table group name given a tbl_id.  it will return undefined if
  * the given tbl_id is not in a group.
  * @param {string} tbl_id    table id
- * @returns {TableGroup}
+ * @returns {String}
  * @public
  * @memberof firefly.util.table
  * @func findGroupByTblId

--- a/src/firefly/js/visualize/iv/PlotTitle.jsx
+++ b/src/firefly/js/visualize/iv/PlotTitle.jsx
@@ -50,7 +50,10 @@ export const PlotTitle= memo(({plotView:pv, brief, working}) => {
         return (
             <Tooltip title={tooltip} placement='right-end'>
                 <Stack direction='row' alignItems='center' sx={plotTitleInlineTitleContainer}>
-                    <Typography {...{level:'title-sm', textOverflow: 'ellipsis', overflow: 'hidden', maxWidth: '35ch'}}>{plot.title}</Typography>
+                    <Typography {...{component:'div', level:'title-sm', textOverflow: 'ellipsis', overflow: 'hidden', maxWidth: '35ch'}}>
+                        <div/>
+                        {plot.title}
+                    </Typography>
                     <Typography {...{level:'body-sm', pl:.75, overflow: 'hidden', component:'div'}}>
                         <div dangerouslySetInnerHTML={{__html:zlStr}}/>
                     </Typography>

--- a/src/firefly/js/visualize/ui/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/ExtractionDialog.jsx
@@ -334,8 +334,10 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     useEffect(() => {
         const getData= async () => {
             if (ipt1 && ipt2 && plot) {
+                const {dataWidth,dataHeight}= plot;
                 const {direction}= xLineData(ipt1,ipt2);
-                const newImPtAry= getLinePointAry(ipt1,ipt2);
+                const newImPtAry= getLinePointAry(ipt1,ipt2)
+                    .filter( ({x,y}) => x>=0 && y>=0 && x<dataWidth && y<dataHeight);
                 if (!newImPtAry?.length) {
                     setImPtAry(undefined);
                     setChartParams({});

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -179,7 +179,7 @@ function layoutHandler(action) {
             newLayoutInfo = onPlotDelete(newLayoutInfo, action);
             break;
         case TABLE_LOADED:
-            if (!action.payload.tbl_id) return;
+            if (!action.payload.tbl_id || findGroupByTblId(action.payload.tbl_id)!=='main') return;
             newLayoutInfo = handleNewTable(newLayoutInfo, action);
             break;
         case TBL_RESULTS_ADDED:

--- a/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisCtxToolbarView.jsx
@@ -425,8 +425,11 @@ export function MultiImageControllerView({plotView:pv}) {
     return (
         <Tooltip title={tooltip} placement='top-end'>
             <Stack {...{direction:'row', flexWrap:'wrap', alignItems:'center',  position:'relative' }}>
-                {startStr && <Typography {...{level:'body-sm', width: '13em', overflow: 'hidden',
+                {startStr && <Typography {...{
+                    component:'div',
+                    level:'body-sm', width: '13em', overflow: 'hidden',
                     textOverflow: 'ellipsis', pl:1, textAlign: 'end'} }>
+                    <div/>
                     <span style={{fontStyle: 'italic', fontWeight: 'bold'}}> {startStr} </span>
                     <Typography level='body-sm' color='warning'> {hduDesc} </Typography>
                 </Typography>}


### PR DESCRIPTION
#### Fixes multiple tickets

   - [Firefly-1500](https://jira.ipac.caltech.edu/browse/FIREFLY-1500): Fixed: Data product view appears when changing hips
   - [Firefly-1501](https://jira.ipac.caltech.edu/browse/FIREFLY-1501): Fixed: Some components of double tooltips on safari
   - Bug fix: line extraction does not work if you click first outside of the image

#### Testing
   - https://fireflydev.ipac.caltech.edu/firefly-1500-multi-tickets/firefly
   - [Firefly-1500](https://jira.ipac.caltech.edu/browse/FIREFLY-1500): test according to ticket
   - [Firefly-1501](https://jira.ipac.caltech.edu/browse/FIREFLY-1501): use safari and put mouse over plot title of image
   - Use line extraction on an image and start outside of the image
