### PR TITLE
IRSA-6134: Fix blinking "choose tab" hint in finder chart and other apps

### DIFF
--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -71,6 +71,7 @@
  * @prop {string} title     tooltips
  * @prop {string} category  category/group of the given menu item
  * @prop {bool} primary     shown as tab on init; defaults to false
+ * @prop {bool} landing     whether the app starts with this tab; defaults to false
  * @prop {string} path      used by routed-app for navigation
  * @prop {bool} visible     shown on tab menu
  */

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -7,12 +7,11 @@ import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {cloneDeep} from 'lodash/lang.js';
 
-import {flux} from '../../core/ReduxFlux.js';
 import {
     dispatchSetMenu,
-    dispatchOnAppReady, dispatchNotifyRemoteAppReady, getAppOptions, dispatchAddPreference,
+    dispatchOnAppReady, dispatchNotifyRemoteAppReady, getAppOptions,
 } from '../../core/AppDataCntlr.js';
-import {LO_VIEW, getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
+import {LO_VIEW, getLayouInfo} from '../../core/LayoutCntlr.js';
 import {AppConfigDrawer} from '../../ui/AppConfigDrawer.jsx';
 import {getActiveRowCenterDef} from '../../visualize/saga/ActiveRowCenterWatcher.js';
 import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
@@ -21,7 +20,6 @@ import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
 import {layoutManager} from './FireflyViewerManager.js';
 import {LayoutChoiceVisualAccordion} from './LayoutChoice.jsx';
 import {TriViewPanel} from './TriViewPanel.jsx';
-import {getActionFromUrl} from '../../core/History.js';
 import {startImagesLayoutWatcher} from '../../visualize/ui/TriViewImageSection.jsx';
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
 import {getImageMasterData} from '../../visualize/ui/AllImageSearchConfig.js';
@@ -30,7 +28,7 @@ import {getWorkspaceConfig, initWorkspace} from '../../visualize/WorkspaceCntlr.
 import {getAllStartIds, getObsCoreWatcherDef, startTTFeatureWatchers} from '../common/ttFeatureWatchers';
 import App from 'firefly/ui/App.jsx';
 import {setIf as setIfUndefined} from 'firefly/util/WebUtil.js';
-import {APP_HINT_IDS, appHintPrefName} from 'firefly/templates/fireflyviewer/LandingPage';
+import {handleInitialAppNavigation} from 'firefly/templates/common/FireflyLayout';
 
 /**
  * This FireflyViewer is a generic application with some configurable behaviors.
@@ -126,20 +124,7 @@ function onReady({menu, options={}, normalInit, appTitle}) {
     }
     const {hasImages, hasTables, hasXyPlots} = getLayouInfo();
     if (normalInit && (!(hasImages || hasTables || hasXyPlots))) {
-        let goto = getActionFromUrl();
-
-        const landingItem= menu.find( (item) => item.landing);
-        if (!goto && landingItem) {
-            goto = {type:SHOW_DROPDOWN, payload: { view: landingItem.action }};
-        }
-
-        if (goto) {
-            flux.process(goto);
-            // if app didn't start with Results view, app hint for tabs menu is not needed
-            if (goto?.type === SHOW_DROPDOWN && (!goto?.payload?.view || goto?.payload?.view !== landingItem?.action)) {
-                dispatchAddPreference(appHintPrefName(appTitle, APP_HINT_IDS.TABS_MENU), false);
-            }
-        }
+        handleInitialAppNavigation({menu, appTitle});
     }
     dispatchNotifyRemoteAppReady();
 }

--- a/src/firefly/js/templates/fireflyviewer/LandingPage.jsx
+++ b/src/firefly/js/templates/fireflyviewer/LandingPage.jsx
@@ -11,14 +11,19 @@ import {Slot, useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {FileDropZone} from '../../visualize/ui/FileUploadViewPanel.jsx';
 import {dispatchAddPreference, getPreference} from 'firefly/core/AppDataCntlr';
 
+export const APP_HINT_IDS = {
+    TABS_MENU: 'tabsMenu',
+    BG_MONITOR: 'bgMonitor'
+};
+
 
 export function LandingPage({slotProps={}, sx, ...props}) {
     const {appTitle,footer,
         fileDropEventAction='FileUploadDropDownCmd'} = useContext(AppPropertiesCtx);
 
     const defSlotProps = {
-        tabsMenuHint: {appTitle, id: 'tabsMenu', hintText: 'Choose a tab to search for or upload data.', sx: { left: '16rem' }},
-        bgMonitorHint: {appTitle, id: 'bgMonitor', hintText: 'Load job results from background monitor', tipPlacement: 'end', sx: { right: 8 }},
+        tabsMenuHint: {appTitle, id: APP_HINT_IDS.TABS_MENU, hintText: 'Choose a tab to search for or upload data.', sx: { left: '16rem' }},
+        bgMonitorHint: {appTitle, id: APP_HINT_IDS.BG_MONITOR, hintText: 'Load job results from background monitor', tipPlacement: 'end', sx: { right: 8 }},
         topSection: { appTitle },
         bottomSection: {
                 icon: <QueryStats sx={{ width: '6rem', height: '6rem' }} />,
@@ -112,11 +117,11 @@ function EmptyResults({icon, text, subtext, summaryText, actionItems}) {
     );
 }
 
+// An app hint needs to be shown only the first time user loads an app. So this is controlled by a flag saved as app preference
+export const appHintPrefName = (appTitle, hintId) => `showAppHint__${appTitle}--${hintId}`;
 
 function AppHint({appTitle, id, hintText, tipPlacement='middle', sx={}}) {
-    // An app hint needs to be shown only the first time user loads an app. So this is controlled by a flag saved as app preference
-    const appHintPrefName = `showAppHint__${appTitle}--${id}`;
-    const showAppHint = useStoreConnector(() => getPreference(appHintPrefName, true));
+    const showAppHint = useStoreConnector(() => getPreference(appHintPrefName(appTitle, id), true));
 
     const arrowTip = {
         '&::before': {
@@ -151,13 +156,13 @@ function AppHint({appTitle, id, hintText, tipPlacement='middle', sx={}}) {
                   onClose={(e, reason)=> {
                       //don't close a hint if the click made outside it (clickaway) originated from another hint
                       if (reason==='clickaway' && e?.target?.closest('.MuiSnackbar-root')) return;
-                      dispatchAddPreference(appHintPrefName, false);
+                      dispatchAddPreference(appHintPrefName(appTitle, id), false);
                   }}
                   sx={{...positioningSx, ...sx, ...arrowTip}}
                   startDecorator={<TipsAndUpdates/>}
                   endDecorator={
                       <Button
-                          onClick={() => dispatchAddPreference(appHintPrefName, false)}
+                          onClick={() => dispatchAddPreference(appHintPrefName(appTitle, id), false)}
                           variant='outlined'
                           color='primary'>
                           Got it

--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -8,17 +8,14 @@ import PropTypes, {element, node, object, shape, string} from 'prop-types';
 import {Typography} from '@mui/joy';
 import {cloneDeep} from 'lodash/lang.js';
 
-import {flux} from '../../core/ReduxFlux.js';
 import {
     dispatchSetMenu,
     dispatchOnAppReady,
     dispatchNotifyRemoteAppReady,
     getSearchInfo,
-    dispatchAddPreference
 } from '../../core/AppDataCntlr.js';
-import {getLayouInfo, SHOW_DROPDOWN, LO_VIEW} from '../../core/LayoutCntlr.js';
+import {getLayouInfo, LO_VIEW} from '../../core/LayoutCntlr.js';
 import {hydraManager} from './HydraManager';
-import {getActionFromUrl} from '../../core/History.js';
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
 
 import {ImageExpandedMode} from '../../visualize/iv/ImageExpandedMode.jsx';
@@ -31,9 +28,10 @@ import {DEFAULT_PLOT2D_VIEWER_ID} from '../../visualize/MultiViewCntlr.js';
 import App from 'firefly/ui/App.jsx';
 import {Slot, useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 import {makeMenuItems, SearchPanel} from 'firefly/ui/SearchPanel.jsx';
-import {APP_HINT_IDS, appHintPrefName, LandingPage} from 'firefly/templates/fireflyviewer/LandingPage.jsx';
+import {LandingPage} from 'firefly/templates/fireflyviewer/LandingPage.jsx';
 import {Stacker} from 'firefly/ui/Stacker.jsx';
 import {setIf as setIfUndefined} from 'firefly/util/WebUtil.js';
+import {handleInitialAppNavigation} from 'firefly/templates/common/FireflyLayout';
 
 
 /*
@@ -91,12 +89,7 @@ function onReady(menu, appTitle) {
 
     const {hasImages, hasTables, hasXyPlots} = getLayouInfo();
     if (!(hasImages || hasTables || hasXyPlots)) {
-        const goto = getActionFromUrl() || {type: SHOW_DROPDOWN};
-        if (goto) {
-            flux.process(goto);
-            // if app didn't start with Results view, app hint for tabs menu is not needed
-            goto?.type === SHOW_DROPDOWN && dispatchAddPreference(appHintPrefName(appTitle, APP_HINT_IDS.TABS_MENU), false);
-        }
+        handleInitialAppNavigation({menu, appTitle, defaultToShowDropdown: true});
     }
     dispatchNotifyRemoteAppReady();
 }


### PR DESCRIPTION
Fixes [IRSA-6134](https://jira.ipac.caltech.edu/browse/IRSA-6134)

When a FireflyViewer or HydraViewer app gets ready (for the first time) with a tab other than Results view, we don't need to show hint about choose tabs.

> Note: working more on it, I think a long-term cleaner solution will be to lift up `AppHint` in component tree to `App` level (instead of `LandingPage`) - making it possible to show on any tab an app starts with for first time 

## Testing
https://irsa-6134-blinking-hint-fix.irsakudev.ipac.caltech.edu/applications/finderchart/ - switch to results tab, hint shouldn't appear

https://irsa-6134-blinking-hint-fix.irsakudev.ipac.caltech.edu/irsaviewer/ - hint should appear

Clean browser local storage and then go to https://irsa-6134-blinking-hint-fix.irsakudev.ipac.caltech.edu/irsaviewer/?__action=layout.showDropDown - switch to results, hint shouldn't appear
