### PR TITLE
Firelfy-1490: TAP catalogs can now be locked to a schema

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSTableReader.java
@@ -185,7 +185,7 @@ public final class FITSTableReader
 
                 //------------- here -------------------
 
-                String cName = (colNames.length > 1) ? colNames[1] : "data";
+                String cName = (colNames.length > 1) ? colNames[1] : "value";
                 DataType dataDT = new DataType(cName, cName, Double.class);
                 if (colUnits!=null && colUnits.length>1) idxDT.setUnits(colUnits[1]);
                 dataTypes.add(dataDT);

--- a/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
@@ -260,7 +260,7 @@ export function filterDLList(parsingAlgorithm, dataLinkData) {
         return dataLinkData.filter( ({dlAnalysis}) => dlAnalysis.isImage);
     }
     if (parsingAlgorithm===RELATED_IMAGE_GRID) {
-        return dataLinkData.filter( ({dlAnalysis}) => dlAnalysis.isThis && dlAnalysis.isGrid && dlAnalysis.isImage);
+        return dataLinkData.filter( ({dlAnalysis}) => dlAnalysis.isGrid && dlAnalysis.isImage);
     }
     if (parsingAlgorithm===SPECTRUM) {
         return dataLinkData.filter( ({dlAnalysis}) => dlAnalysis.isSpectrum);
@@ -312,17 +312,17 @@ function createDataLinkMenuRet({dlTableUrl, dataLinkData, sourceTable, sourceRow
     let primeCnt=0;
 
     const menu= filterDLList(parsingAlgorithm,dataLinkData)
-        .map( (dlData,idx) => {
+        .map( (dlData) => {
             const {semantics,url,error_message, dlAnalysis:{isAux,isThis}}= dlData;
             const name= makeName(semantics, url, auxTot, auxCnt, primeCnt, baseTitle);
             if (error_message) {
                 const edp= dpdtMessageWithError(error_message);
                 edp.complexMessage= false;
-                edp.menuKey='dlt-'+idx;
-                edp.name= `Error in related data (datalink) row ${idx}`;
+                edp.menuKey='dlt-'+dlData.rowIdx;
+                edp.name= `Error in related data (datalink) row ${dlData.rowIdx}`;
                 return edp;
             }
-            const menuEntry= makeMenuEntry({dlTableUrl,dlData,idx, baseTitle, sourceTable,
+            const menuEntry= makeMenuEntry({dlTableUrl,dlData,idx:dlData.rowIdx, baseTitle, sourceTable,
                 sourceRow, options, name, doFileAnalysis, activateParams});
             if (isAux) auxCnt++;
             if (isThis) primeCnt++;

--- a/src/firefly/js/metaConvert/vo/DatalinkProducts.js
+++ b/src/firefly/js/metaConvert/vo/DatalinkProducts.js
@@ -1,8 +1,6 @@
 import {getCellValue} from '../../tables/TableUtil.js';
-import {makeWorldPtUsingCenterColumns} from '../../voAnalyzer/TableAnalysis.js';
 import {getDataLinkData} from '../../voAnalyzer/VoDataLinkServDef.js';
 import {Band} from '../../visualize/Band.js';
-import {getSearchTarget} from '../../visualize/saga/CatalogWatcher.js';
 import {WPConst} from '../../visualize/WebPlotRequest.js';
 import {dpdtImage, dpdtMessageWithDownload, dpdtSimpleMsg, DPtypes} from '../DataProductsType.js';
 import {
@@ -31,7 +29,7 @@ export async function getDatalinkRelatedGridProduct({dlTableUrl, activateParams,
     try {
         const datalinkTable = await fetchDatalinkTable(dlTableUrl);
 
-        const gridData = getDataLinkData(datalinkTable).filter(({dlAnalysis}) => dlAnalysis.isThis && dlAnalysis.isGrid && dlAnalysis.isImage);
+        const gridData = getDataLinkData(datalinkTable).filter(({dlAnalysis}) => dlAnalysis.isGrid && dlAnalysis.isImage);
         if (!gridData.length) return dpdtSimpleMsg('no support for related grid in datalink file');
 
 

--- a/src/firefly/js/templates/router/RoutedApp.jsx
+++ b/src/firefly/js/templates/router/RoutedApp.jsx
@@ -59,7 +59,7 @@ FormWatcher:  Wrap around FormPanel.  Necessary whe the application feature more
 useDropdownRoute:  The hook marrying route behavior on top of Firefly's layout controller.
 
 */
-export  default function RoutedApp({slotProps, menu, mainPanel, children, ...props}) {
+export  default function RoutedApp({slotProps, menu, mainPanel, children, dropdownPanels, ...props}) {
 
     useEffect(() => {
         startTTFeatureWatchers();
@@ -82,7 +82,7 @@ export  default function RoutedApp({slotProps, menu, mainPanel, children, ...pro
     let dropDownComponent = null;
     if (visible && outlet) {
         dropDownComponent = (
-            <DropDownContainer visible={true} footer={<IrsaFooterSmall/>} {...mSlotProps?.dropdown}>
+            <DropDownContainer visible={true} dropdownPanels={dropdownPanels} footer={<IrsaFooterSmall/>} {...mSlotProps?.dropdown}>
                 {outlet}
             </DropDownContainer>
         );

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -118,18 +118,20 @@ export function getServiceHiPS(serviceUrl) {
 
 export function TapSearchPanel({initArgs= {}, titleOn=false,
                                    lockService=false, lockedServiceUrl, lockedServiceName, lockObsCore=false,
+                                   lockedSchemaName,
                                    obsCoreLockTitle,
                                    groupKey=DEFAULT_TAP_PANEL_GROUP_KEY }) {
 
     return (
         <FieldGroup groupKey={groupKey} keepState={true} key={groupKey} sx={{width: 1, height: 1}}>
             <TapSearchPanelImpl {...{initArgs, titleOn, lockService, obsCoreLockTitle, lockedServiceUrl,
-                lockedServiceName, lockObsCore}}/>
+                lockedSchemaName, lockedServiceName, lockObsCore}}/>
         </FieldGroup>
     );
 }
 
 function TapSearchPanelImpl({initArgs= {}, titleOn=true, lockService=false, lockedServiceUrl, lockedServiceName,
+                                lockedSchemaName,
                                 obsCoreLockTitle, lockObsCore}) {
     const {setVal,getVal,setFld,groupKey}= useContext(FieldGroupCtx);
     const [getTapBrowserState,setTapBrowserState]= useFieldGroupMetaState(defTapBrowserState);
@@ -215,6 +217,7 @@ function TapSearchPanelImpl({initArgs= {}, titleOn=true, lockService=false, lock
 
                     <TapSearchPanelComponents {...{
                         servicesShowing, setServicesShowing, lockService, lockObsCore, obsCoreLockTitle,
+                        lockedSchemaName,
                         initArgs, selectBy, setSelectBy, serviceUrl, onTapServiceOptionSelect, titleOn, tapOps, obsCoreEnabled}} />
                 </FormPanel>
             </ConstraintContext.Provider>
@@ -228,6 +231,7 @@ TapSearchPanel.propTypes= {
     groupKey: string,
     lockedServiceUrl: string,
     lockedServiceName: string,
+    lockedSchemaName: string,
     obsCoreLockTitle: string,
     lockService: bool,
     lockObsCore: bool,
@@ -240,7 +244,7 @@ TapSearchPanel.propTypes= {
 
 function TapSearchPanelComponents({initArgs, serviceUrl, servicesShowing, setServicesShowing, onTapServiceOptionSelect,
                                       lockService, lockObsCore, obsCoreLockTitle, tapOps,
-                                      titleOn=true, selectBy, setSelectBy}) {
+                                      lockedSchemaName, titleOn=true, selectBy, setSelectBy}) {
 
     const serviceLabel= getServiceLabel(serviceUrl);
     const [obsCoreTableModel, setObsCoreTableModel] = useState();
@@ -263,7 +267,7 @@ function TapSearchPanelComponents({initArgs, serviceUrl, servicesShowing, setSer
                     tapOps, onTapServiceOptionSelect}}/>
             <TapViewType  {...{
                 serviceUrl, serviceLabel, selectBy, initArgs, lockService,
-                lockObsCore, obsCoreLockTitle, obsCoreTableModel,
+                lockObsCore, obsCoreLockTitle, obsCoreTableModel, lockedSchemaName,
                 servicesShowing, setServicesShowing, hasObsCoreTable, setSelectBy
             }} />
         </Stack>

--- a/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
+++ b/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
@@ -24,7 +24,7 @@ export function analyzeDatalinkRow({semantics = '', localSemantics = '', content
     const locSemL = localSemantics.toLowerCase();
     const isThis = semL.includes('#this');
     const isAux = semL === '#auxiliary';
-    const isGrid = semL.includes('-grid') || (isThis && locSemL.includes('-grid') || (isThis && locSemL.includes('#grid')));
+    const isGrid = semL.includes('-grid') || (locSemL.includes('-grid') || ( locSemL.includes('#grid')));
     const isCutout = semL.includes('cutout') || semL.includes('#cutout') || semL.includes('-cutout') || locSemL.includes('cutout');
     const isSpectrum = locSemL.includes('spectrum');
     const rBand = semL.includes('-red') || locSemL.includes('-red');


### PR DESCRIPTION
#### [Firefly-1490](https://jira.ipac.caltech.edu/browse/FIREFLY-1490): Lock TAP pane to a schema

#### see also: https://github.com/IPAC-SW/irsa-ife/pull/339

#### Testing
- https://firefly-1490-lock-tap-schema.irsakudev.ipac.caltech.edu/applications/euclid/
- bring up euclid choose the sidebar option for Euclid catalogs
   - it will show only wise catalogs but can be changed to euclid in the future when we have some