### PR TITLE
Firefly-1507: Adding search radius to multi object uploads

### DIFF
--- a/src/firefly/js/ui/UploadTableSelectorPosCol.jsx
+++ b/src/firefly/js/ui/UploadTableSelectorPosCol.jsx
@@ -11,7 +11,7 @@ import {getSizeAsString} from 'firefly/util/WebUtil';
 import React, {useContext, useEffect} from 'react';
 import {FieldGroupCollapsible} from 'firefly/ui/panel/CollapsiblePanel';
 
-export function UploadTableSelector({uploadInfo, setUploadInfo, uploadTable=false}) {
+export function UploadTableSelectorPosCol({uploadInfo, setUploadInfo, uploadTable=false, slotProps}) {
 
     const UploadCenterLonColumns = 'uploadCenterLonColumns';
     const UploadCenterLatColumns = 'uploadCenterLatColumns';
@@ -74,7 +74,7 @@ export function UploadTableSelector({uploadInfo, setUploadInfo, uploadTable=fals
     };
 
     return (
-        <div>
+        <Box>
             <Stack {...{direction:'row', alignItems:'center'}}>
                 <TextButton text={(fileName&&haveTable) ? 'Change Upload Table...' : 'Add Upload Table...'}
                              onClick={() => showUploadTableChooser(preSetUploadInfo)} />
@@ -106,20 +106,23 @@ export function UploadTableSelector({uploadInfo, setUploadInfo, uploadTable=fals
                     sx:{ml:22},
                     headerTitle:'Position Columns:', openKey,
                     headerPostTitle:'(from the uploaded table)',
-                    lonKey:UploadCenterLonColumns, latKey:UploadCenterLatColumns}} />
+                    lonKey:UploadCenterLonColumns, latKey:UploadCenterLatColumns, slotProps}} />
             }
-        </div>
+        </Box>
     );
 }
 
-UploadTableSelector.propTypes = {
+UploadTableSelectorPosCol.propTypes = {
     uploadInfo: PropTypes.object,
     setUploadInfo: PropTypes.func,
-    uploadTable: PropTypes.bool
+    uploadTable: PropTypes.bool,
+    slotProps: PropTypes.shape({
+        centerColsInnerStack: PropTypes.object, // Define the specific prop for the inner Stack
+    })
 };
 
 export function CenterColumns({lonCol,latCol, sx, cols, lonKey, latKey, openKey,
-                                  doQuoteNonAlphanumeric, headerTitle, headerPostTitle = '', openPreMessage=''}) {
+                                  doQuoteNonAlphanumeric, headerTitle, headerPostTitle = '', openPreMessage='', slotProps}) {
 
 
     const posHeader= (
@@ -139,7 +142,7 @@ export function CenterColumns({lonCol,latCol, sx, cols, lonKey, latKey, openKey,
             <FieldGroupCollapsible header={posHeader}
                                    initialState={{value:'closed'}} fieldKey={openKey}>
                 {openPreMessage && <Typography sx={{pb:1}}> {openPreMessage} </Typography>}
-                <Stack {...{direction:'row', spacing:1, sx:{'& .ff-Input': {width:'11rem'}} }}>
+                <Stack {...{direction:'row', spacing:1, sx:{'& .ff-Input': {width:'11rem'}, ...slotProps?.centerColsInnerStack?.sx} }}>
                     <ColumnFld fieldKey={lonKey} cols={cols}
                                name='longitude column'  // label that appears in column chooser
                                tooltip='Center longitude column for spatial search'

--- a/src/firefly/js/ui/UploadTableSelectorSingleCol.jsx
+++ b/src/firefly/js/ui/UploadTableSelectorSingleCol.jsx
@@ -1,0 +1,184 @@
+import {useFieldGroupValue} from 'firefly/ui/SimpleComponent';
+import {Box, Chip, Stack, Typography} from '@mui/joy';
+import {ColumnFld, getColValidator} from 'firefly/charts/ui/ColumnOrExpression';
+import {TextButton} from 'firefly/visualize/ui/Buttons';
+import {showUploadTableChooser} from 'firefly/ui/UploadTableChooser';
+import {showColSelectPopup} from 'firefly/charts/ui/ColSelectView';
+import {getSizeAsString} from 'firefly/util/WebUtil';
+import React, {useEffect, useState} from 'react';
+import {onTableLoaded} from 'firefly/tables/TableUtil';
+import {FieldGroupCollapsible} from 'firefly/ui/panel/CollapsiblePanel';
+import {FilterInfo} from 'firefly/tables/FilterInfo';
+import {dispatchTableFilter} from 'firefly/tables/TablesCntlr';
+
+const UploadSingleColumn = 'uploadSingleColumn';
+const defaultTblId = 'singleColTable';
+
+/**
+ * This component may be used for any multi-object uploads, where we want user to only select one column
+ * from the uploaded file.
+ *
+ * As of 7/12/2024, ObjectIDSearch on TAP and Search by ID in Euclid make use of this.
+ *
+ * If you just want a regular UploadTableSelector that'll have 2 Position Columns (ra and dec) from the uploadd file,
+ * please use the UploadTableSelectorPosCol component
+ * @param props
+ * @param props.uploadInfo
+ * @param props.setUploadInfo
+ * @param props.headerTitle
+ * @param props.colName
+ * @param props.getUseSelectIn used for ObjectID on TAP
+ * @returns {JSX.Element}
+ */
+export function UploadTableSelectorSingleCol({uploadInfo, setUploadInfo,
+                                                 headerTitle='Uploaded Column:',
+                                                 colName = '',
+                                                 getUseSelectIn = () => {} }) {
+    const [getSingleCol,setSingleCol]= useFieldGroupValue(UploadSingleColumn);
+    const {fileName,columns,totalRows,fileSize}= uploadInfo ?? {};
+    const columnsUsed= columns?.filter( ({use}) => use)?.length ?? 0;
+    const openKey= 'upload-single-column';
+
+    const preSetUploadInfo= (ui) => {
+        setSingleCol('', {validator: getColValidator(ui.columns, true, false), valid: true});
+        setUploadInfo(ui);
+    };
+
+    const haveFile= Boolean(fileName && columns);
+
+    const onColsSelected = (selectedColNames) => {
+        //get rid of extra quotes within each selectedColNames - because non-alphanumeric entries may have
+        //been quoted by calling quoteNonAlphanumeric
+        // , e.g.: ['"Object Name"', 'RA', 'Notes']
+        selectedColNames = selectedColNames.map((col) => col.replace(/^"(.*)"$/, '$1'));
+        const columns = uploadInfo?.columns.map((col) => (
+            {...col, use:selectedColNames.includes((col.name))}));
+        uploadInfo = {...uploadInfo, columns};
+        setUploadInfo(uploadInfo);
+    };
+
+    return (
+        <Stack mt={2} pl={1}>
+            <Stack direction='row' alignItems='center'>
+                <TextButton text={fileName ? 'Change Upload Table...' : 'Add Upload Table...'}
+                            onClick={() => showUploadTableChooser(preSetUploadInfo,'singleColSelect',{colTypes: ['int','long','string'],colCount: 3})} style={{marginLeft: 42}} />
+                {haveFile && (
+                    <Typography pl={2} sx={{fontSize:'larger'}}>
+                        {`${fileName}`}
+                    </Typography>
+                )}
+            </Stack>
+            {haveFile && (
+                <Stack direction='row' ml={24} justifyContent='flex-start'>
+                    <Typography>
+                        Rows: {totalRows},
+                    </Typography>
+                    <Box pl={1} sx={{whiteSpace: 'nowrap'}}>
+                        {getUseSelectIn() !== 'use' && (
+                            <>
+                                <Chip
+                                    onClick={() =>
+                                        showColSelectPopup(columns, onColsSelected, 'Choose Columns', 'OK', null, true)
+                                    }
+                                >
+                                    <Typography level={'body-xs'}>
+                                        Columns: {columns.length} (using {columnsUsed})
+                                    </Typography>
+                                </Chip>
+                                {fileSize && <span>,</span>}
+                            </>
+                        )}
+                    </Box>
+                    {fileSize && (
+                        <Typography pl={1}>
+                            Size: {getSizeAsString(fileSize)}
+                        </Typography>
+                    )}
+                </Stack>
+            )}
+            {haveFile && (
+                <SingleCol
+                    singleCol={getSingleCol()}
+                    cols={columns}
+                    headerTitle={headerTitle}
+                    openKey={openKey}
+                    headerPostTitle='(from the uploaded table)'
+                    headerStyle={{ paddingLeft: 1 }}
+                    sx={{ mb: 1, ml: 24 }}
+                    colKey={UploadSingleColumn}
+                    colName={colName}
+                />
+            )}
+        </Stack>
+    );
+}
+
+export function SingleCol({singleCol, sx={},cols, colKey, openKey, colName='',
+                         headerTitle, headerPostTitle = '', openPreMessage='', headerStyle,colTblId=null}) {
+    const posHeader= (
+        <Box ml={-1}>
+            <Typography display='inline' color={!singleCol?'warning':undefined} level='title-md' style={{...headerStyle}}>
+                {(singleCol) ? `${singleCol || 'unset'}` : 'unset'}
+            </Typography>
+            <Typography display='inline' level='body-sm' pl={2}  whiteSpace='nowrap'>
+                {headerPostTitle}
+            </Typography>
+        </Box>
+    );
+
+    const [clickingSelectCols, setClickingSelectCols] = useState(false);
+
+    //clickingSelectCols is toggled each time user clicks on the 'magnifying glass' to select cols, rendering this useEffect
+    useEffect(() => {
+        onTableLoaded(defaultTblId).then((tbl) => {
+            filterTable(cols,tbl);
+        });
+    }, [clickingSelectCols]);
+
+    return (
+        <Box mt={1} sx={{...sx }}>
+            <Stack {...{direction:'row', spacing:1}}>
+                <Typography pt={1} sx={{width:'14rem', whiteSpace:'nowrap'}} component='div'>
+                    {headerTitle}
+                </Typography>
+                <FieldGroupCollapsible header={posHeader}
+                                       initialState={{value:'open'}} fieldKey={openKey}>
+                    {openPreMessage && <Typography pb={1}>
+                        {openPreMessage}
+                    </Typography>}
+                    <ColumnFld fieldKey={colKey} cols={cols}
+                               name={`${colName} Column`} // label that appears in column chooser
+                               tooltip={`${colName} Column`}
+                               label={colName}
+                               placeholder={`choose ${colName} column`}
+                               validator={getColValidator(cols, true, false)}
+                               colTblId={colTblId}
+                               onSearchClicked= {() => {
+                                   if (clickingSelectCols) setClickingSelectCols(false);
+                                   else setClickingSelectCols?.(true);
+                                   return true;
+                               }}
+                    />
+                </FieldGroupCollapsible>
+
+            </Stack>
+        </Box>
+    );
+}
+
+function filterTable(cols, tbl) {
+    const colsWithMetaID = cols.filter((col) => { if (col.ucd) {return col.ucd.includes('meta.id');}  });
+    if (colsWithMetaID.length > 1) {
+        if (!tbl) return;
+        const filterInfo = tbl?.request?.filters;
+        const filterInfoCls = FilterInfo.parse(filterInfo);
+        const meta = 'meta.id';
+        const filter = `like '%${meta}%'`;
+        filterInfoCls.setFilter('UCD', filter);
+        const newRequest = {tbl_id: tbl.tbl_id, filters: filterInfoCls.serialize()};
+        dispatchTableFilter(newRequest);
+    }
+}
+
+
+

--- a/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
@@ -13,7 +13,7 @@ import {DEF_TARGET_PANEL_KEY, TargetPanel} from '../TargetPanel.jsx';
 import {CONE_AREA_KEY} from './DynamicDef.js';
 import {DEF_AREA_EXAMPLE, PolygonField} from './DynComponents.jsx';
 
-import {UploadTableSelector} from 'firefly/ui/UploadTableSelector';
+import {UploadTableSelectorPosCol} from 'firefly/ui/UploadTableSelectorPosCol';
 import {showUploadTableChooser} from 'firefly/ui/UploadTableChooser';
 import {CollapsibleGroup, CollapsibleItem} from 'firefly/ui/panel/CollapsiblePanel';
 import {FormPanel} from 'firefly/ui/FormPanel';
@@ -155,10 +155,25 @@ export function EmbeddedPositionSearchPanel({
                     placeholder: 'Coordinates',
                     manageHiPS:false,
                 }} />}
-            {isFunction(otherComponents) ? otherComponents() : otherComponents}
             {doGetConeAreaOp() === UPLOAD_CHOICE_KEY &&
-                <UploadTableSelector {...{uploadInfo, setUploadInfo, uploadTable:true}}/>
-            }
+                <Stack pb={0.5}>
+                    <UploadTableSelectorPosCol {...{uploadInfo, setUploadInfo,
+                        slotProps: {
+                            centerColsInnerStack: {sx: {ml: 1, pt: 1.5}}
+                        }
+                    }}/>
+                    <SizeInputFields {...{
+                        fieldKey: sizeKey, showFeedback: true, labelWidth: 100, nullAllowed: false,
+                        // orientation:'horizontal',
+                        label: 'Search Radius',
+                        initialState: {unit: 'arcsec', value: searchAreaInDeg + '', min:minValue, max:maxValue},
+                        sx: {'.ff-Input': {width: 1}, pt:0.5},
+                        slotProps: {
+                            feedback:{sx: {alignSelf:'center'} },
+                        }
+                    }} />
+                </Stack>}
+                {isFunction(otherComponents) ? otherComponents() : otherComponents}
         </Stack>
     );
 

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -29,7 +29,7 @@ import {showUploadTableChooser} from '../UploadTableChooser.js';
 import {
     getAsEntryForTableName, getColumnAttribute, getTapServices, makeUploadSchema, maybeQuote, tapHelpId
 } from './TapUtil.js';
-import {CenterColumns, UploadTableSelector} from 'firefly/ui/UploadTableSelector';
+import {CenterColumns, UploadTableSelectorPosCol} from 'firefly/ui/UploadTableSelectorPosCol';
 
 const CenterLonColumns = 'centerLonColumns';
 const CenterLatColumns = 'centerLatColumns';
@@ -293,7 +293,7 @@ const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInf
             return (
                 <Stack spacing={1} direction='column'>
                     <RegionOpField {...{initArgs, capabilities}}/>
-                    <UploadTableSelector {...{uploadInfo, setUploadInfo}}/>
+                    <UploadTableSelectorPosCol {...{uploadInfo, setUploadInfo}}/>
                     {!containsPoint && radiusOrPolygon}
                 </Stack>
             );
@@ -308,7 +308,7 @@ const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInf
         case NORMAL_UPLOAD_LAYOUT:
             return (
                 <Stack spacing={1} direction='column'>
-                    <UploadTableSelector {...{uploadInfo, setUploadInfo}}/>
+                    <UploadTableSelectorPosCol {...{uploadInfo, setUploadInfo}}/>
                     {radiusField}
                 </Stack>
             );


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1507
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/340

- I added a `search by radius` option to multi-object uploads, as the API takes this as a param. 
- did some refactoring, so now we have `UploadTableSelectorSingleCol` (user uploads a file, and we let them pick one column from the file - this is used by `Object ID Search` and `Search by ID` in Euclid) and `UploadTableSelectorPosCol` (this is the old and original `UploadTableSelector`, just renamed it to indicate selecting position columns - ra and dec - from the uploaded file as opposed to a single column) 

**Testing**:
- https://firefly-1507-search-processor-euclid.irsakudev.ipac.caltech.edu/applications/euclid
  - In Inspect Sources, test by changing the size/radius for the same upload file, you should get different (more or less) results. See additional instructions (and upload files to use) in the IFE PR. 
[source_search_coords.txt](https://github.com/user-attachments/files/16135792/source_search_coords.txt)
- Firefly: https://fireflydev.ipac.caltech.edu/firefly-1507-search-processor-euclid/firefly
  - test Object ID Search (via uploads) to ensure nothing's broken there with these changes
  - also test regular file uploads on TAP (spatial search) 
