### PR TITLE
Firefly-1515: fix deprecations to prepare for react 19

### DIFF
--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -17,7 +17,8 @@ import {CombineChart} from './CombineChart.jsx';
 
 function ChartPanelView(props) {
 
-    const {chartId, tbl_group, chartData, expandable, expandedMode, Toolbar, showToolbar, glass} = props;
+    const {chartId, Chart= PlotlyChartArea, tbl_group, chartData, expandable, expandedMode, Toolbar=PlotlyToolbar,
+        showToolbar=true, showChart=true, glass} = props;
 
     useEffect(() => {
         dispatchChartMounted(chartId);
@@ -34,14 +35,14 @@ function ChartPanelView(props) {
         // chart with toolbar
         return (
             <Stack id='chart-panel' height={1} overflow='hidden'>
-                <ChartToolbar {...{chartId, tbl_group, expandable, expandedMode, Toolbar}}/>
+                <ChartToolbar {...{Chart, chartId, tbl_group, expandable, expandedMode, Toolbar}}/>
                 <Divider orientation='horizontal'/>
                 <ChartArea glass={glass} {...props}/>
             </Stack>
         );
     } else {
         // chart only
-        return <ChartArea glass={glass} {...props}/>;
+        return <ChartArea glass={glass} {...{...props, showToolbar, showChart, Chart}}/>;
     }
 }
 
@@ -59,12 +60,6 @@ ChartPanelView.propTypes = {
     Toolbar: PropTypes.func
 };
 
-ChartPanelView.defaultProps = {
-    showToolbar: true,
-    showChart: true,
-    Chart: PlotlyChartArea,
-    Toolbar: PlotlyToolbar
-};
 
 const ResizableChartAreaInternal = React.memo((props) => {
     const {errors, Chart, size}= props;

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -98,9 +98,10 @@ export const NoDataTableView = ({sx, children}) => (
     </Box>
 );
 
-
-const BasicTableViewInternal = React.memo((props) => {
-
+const BasicTableViewInternal = React.memo(({ selectable:selectableIn= false, showTypes:showTypesIn= false,
+                                               showMask= false, rowHeight:rowHeightIn= 20, currentPage:currentPageIn= -1, ...rest }) => {
+    const props= { selectable:selectableIn, showTypes:showTypesIn, showMask, rowHeight:rowHeightIn,
+        currentPage:currentPageIn, ...rest} ;
     const {width, height} = props.size;
     const {columns, data, hlRowIdx, renderers, selectInfoCls, callbacks, rowHeight, rowHeightGetter, showHeader=true,
             error, tbl_ui_id=uniqueTblUiId(), currentPage, startIdx=0, highlightedRowHandler, cellRenderers, onRowDoubleClick} = props;

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -5,7 +5,7 @@
 import React, {useEffect} from 'react';
 import {Box, Stack, Typography, Sheet, ChipDelete, Tooltip, Button} from '@mui/joy';
 import PropTypes, {object, shape} from 'prop-types';
-import {defer, truncate, get, set} from 'lodash';
+import {defer, truncate, get, set, isUndefined, defaults} from 'lodash';
 import {getAppOptions, getSearchActions} from '../../core/AppDataCntlr.js';
 import {ActionsDropDownButton, isTableActionsDropVisible} from '../../ui/ActionsDropDownButton.jsx';
 
@@ -44,10 +44,32 @@ const TT_CLEAR_FILTER = 'Remove all filters';
 const TT_EXPAND = 'Expand this panel to take up a larger area';
 const TT_PROPERTY_SHEET = 'Show details for the selected row';
 
+const defaultOptions = {
+    showMetaInfo: false,
+    allowUnits: true,
+    showToolbar: true,
+    showTitle: true,
+    showPaging: true,
+    showSave: true,
+    showOptionButton: true,
+    showFilterButton: true,
+    showInfoButton: true,
+    showAddColumn: true,
+    showTypes: true,
+    selectable: true,
+    showSearchButton: true,
+    showHeader: true,
+    expandedMode: false,
+    expandable: true,
+    showToggleTextView: true,
+    border: true,
+};
+
 
 export const TBL_CLZ_NAME = 'FF-Table';
 
-export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', sx, slotProps, ...options}) {
+export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', sx, slotProps, ...inOptions}) {
+    const options= defaults({...inOptions},defaultOptions);
     tbl_id = tbl_id || tableModel?.tbl_id || uniqueTblId();
     tbl_ui_id = tbl_ui_id || `${tbl_id}-ui`;
 
@@ -171,27 +193,6 @@ TablePanel.propTypes = {
         table: object
     })
 
-};
-
-TablePanel.defaultProps = {
-    showMetaInfo: false,
-    allowUnits: true,
-    showToolbar: true,
-    showTitle: true,
-    showPaging: true,
-    showSave: true,
-    showOptionButton: true,
-    showFilterButton: true,
-    showInfoButton: true,
-    showAddColumn: true,
-    showTypes: true,
-    selectable: true,
-    showSearchButton: true,
-    showHeader: true,
-    expandedMode: false,
-    expandable: true,
-    showToggleTextView: true,
-    border: true,
 };
 
 export function OverflowMarker({tbl_id, showText}) {

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -21,9 +21,8 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 
 const logger = Logger('Tables').tag('TablesContainer');
 
-
 export function TablesContainer(props) {
-    const {mode, closeable, tableOptions, style, expandedMode:xMode} = props;
+    const {mode='both', closeable=true, tableOptions, style, expandedMode:xMode=false} = props;
     let {tbl_group} = props;
 
     const tables = useStoreConnector(() => TblUtil.getTableGroup(tbl_group)?.tables);
@@ -52,11 +51,6 @@ TablesContainer.propTypes = {
     style: PropTypes.object,
     tableOptions: PropTypes.object,
     mode: PropTypes.oneOf(['expanded', 'standard', 'both'])
-};
-TablesContainer.defaultProps = {
-    expandedMode: false,
-    closeable: true,
-    mode: 'both'
 };
 
 

--- a/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
+++ b/src/firefly/js/templates/fireflyviewer/FireflyViewer.js
@@ -45,8 +45,8 @@ import {handleInitialAppNavigation} from 'firefly/templates/common/FireflyLayout
  * <li><b>views</b>:  The type of result view.  Choices are 'images', 'tables', and 'xyPlots'.  They can be combined with ' | ', i.e.  'images | tables'</li>
  *
  */
-export function FireflyViewer ({menu, options, views, showViewsSwitch, leftButtons,
-                                   centerButtons, rightButtons, normalInit=true, appTitle,
+export function FireflyViewer ({menu, options, views='images | tables | xyplots', showViewsSwitch, leftButtons,
+                                   centerButtons, rightButtons, normalInit=true, appTitle='Firefly',
                                    landingPage, slotProps, apiHandlesExpanded, ...appProps}){
 
     useEffect(() => {
@@ -112,10 +112,6 @@ FireflyViewer.propTypes = {
     normalInit: PropTypes.bool
 };
 
-FireflyViewer.defaultProps = {
-    appTitle: 'Firefly',
-    views: 'images | tables | xyplots'
-};
 
 function onReady({menu, options={}, normalInit, appTitle}) {
     if (menu) {

--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -37,7 +37,7 @@ import {handleInitialAppNavigation} from 'firefly/templates/common/FireflyLayout
 /*
  * This is a viewer.
  */
-export function HydraViewer({menu, appTitle, slotProps, ...props}) {
+export function HydraViewer({menu, appTitle= 'Time Series Viewer', slotProps, ...props}) {
 
 
     useEffect(() => {
@@ -78,10 +78,6 @@ HydraViewer.propTypes = {
         dropdown: object,
         landing: object
     })
-};
-
-HydraViewer.defaultProps = {
-    appTitle: 'Time Series Viewer'
 };
 
 function onReady(menu, appTitle) {

--- a/src/firefly/js/templates/lightcurve/LcImageViewerContainer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcImageViewerContainer.jsx
@@ -23,7 +23,7 @@ import {LcImageToolbarView} from './LcImageToolbarView.jsx';
  * @returns {Object}
  * @constructor
  */
-export function LcImageViewerContainer({viewerId, imageExpandedMode=false, closeable=true, insideFlex=false,
+export function LcImageViewerContainer({viewerId=DEFAULT_FITS_VIEWER_ID, imageExpandedMode=false, closeable=true, insideFlex=false,
                                         forceRowSize, activeTableId, Toolbar= LcImageToolbarView}) {
     
     if (imageExpandedMode) {
@@ -64,6 +64,3 @@ LcImageViewerContainer.propTypes = {
     Toolbar: PropTypes.element
 };
 
-LcImageViewerContainer.defaultProps = {
-    viewerId: DEFAULT_FITS_VIEWER_ID
-};

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -118,7 +118,7 @@ const defPeriodogram = {
  * @returns {Element}
  */
 export function LcPeriodogram(props) {
-    const {displayMode, groupKey=pgfinderkey, expanded} = props;
+    const {displayMode='period', groupKey=pgfinderkey, expanded} = props;
     const resultProps = {expanded, groupKey};
 
     if (displayMode&&displayMode==='period') {
@@ -137,10 +137,6 @@ LcPeriodogram.propTypes = {
     displayMode: PropTypes.string.isRequired,
     expanded: PropTypes.object,
     groupKey: PropTypes.string
-};
-
-LcPeriodogram.defaultProps = {
-    displayMode: 'period'
 };
 
 /**

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -154,7 +154,7 @@ function getUploadPanelState(oldState) {
 }
 
 
-export const UploadPanel = ({initArgs}) =>{
+export const UploadPanel = ({initArgs, name= 'LCUpload'}) =>{
     const {missionOptions,fileLocation} = useStoreConnector(getUploadPanelState );
     const [,setUploadContainer]= useFieldGroupValue('uploadContainer', vFileKey);
     const externalDropEvent= initArgs?.searchParams?.dropEvent;
@@ -243,10 +243,6 @@ export const UploadPanel = ({initArgs}) =>{
 UploadPanel.propTypes = {
     name: PropTypes.oneOf(['LCUpload']),
     initArgs: PropTypes.object
-};
-
-UploadPanel.defaultProps = {
-    name: 'LCUpload'
 };
 
 function onSearchSubmit(request) {

--- a/src/firefly/js/ui/AutoCompleteInput.jsx
+++ b/src/firefly/js/ui/AutoCompleteInput.jsx
@@ -6,8 +6,7 @@ import {isArray, isEmpty, omit} from 'lodash';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 import {inputFieldTooltipProps} from 'firefly/ui/InputFieldView.jsx';
 
-
-export function AutoCompleteInput({slotProps, orientation, label, required, freeSolo=true, startDecorator, endDecorator, multiple, ...props}) {
+export function AutoCompleteInput({slotProps, orientation='horizontal', label, required, freeSolo=true, startDecorator, endDecorator, multiple, ...props}) {
 
     const {viewProps, fireValueChange}=  useFieldGroupConnector({...props, confirmValue: confirmValue(freeSolo)});
     const [open, setOpen] = useState(false);
@@ -101,9 +100,6 @@ AutoCompleteInput.propTypes= {
     }),
 };
 
-AutoCompleteInput.defaultProps = {
-    orientation: 'horizontal'
-};
 
 // may not be needed
 function confirmValue(freeSolo) {

--- a/src/firefly/js/ui/ChartSelectDropdown.jsx
+++ b/src/firefly/js/ui/ChartSelectDropdown.jsx
@@ -20,7 +20,7 @@ import {dispatchLoadTblStats, getColValStats} from '../charts/TableStatsCntlr.js
 const dropdownName = 'ChartSelectDropDownCmd';
 
 
-export function ChartSelectDropdown({tblGroup}) {
+export function ChartSelectDropdown({tblGroup,name=dropdownName}) {
 
     const tblId = useStoreConnector(() => getActiveTableId(tblGroup));
 
@@ -67,10 +67,6 @@ export function ChartSelectDropdown({tblGroup}) {
 ChartSelectDropdown.propTypes = {
     tblGroup: string, // if not present, default table group is used
     name: string
-};
-
-ChartSelectDropdown.defaultProps = {
-    name: dropdownName
 };
 
 function hideSearchPanel() {

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -81,7 +81,7 @@ const emailKey = 'Email';          // should match server DownloadRequest.EMAIL
  * @param props.makeButton
  * @returns {*}
  */
-export function DownloadButton({tbl_id:inTblId , tbl_grp, children, checkSelectedRow, makeButton}) {
+export function DownloadButton({tbl_id:inTblId , tbl_grp, children, checkSelectedRow=true, makeButton}) {
 
     const tblIdGetter = () => inTblId || getActiveTableId(tbl_grp);
     const selectInfoGetter = () => get(getTblById(tblIdGetter()), 'selectInfo');
@@ -123,17 +123,12 @@ DownloadButton.propTypes = {
     checkSelectedRow:PropTypes.bool
 };
 
-
-DownloadButton.defaultProps = {
-    checkSelectedRow:true
-};
-
 let dlTitleIdx = 0;
 const newBgKey = () => 'DownloadOptionPanel-' + Date.now();
 
 // TODO: showEmailNotify changed to default of false, when we make a notification plan we can change it back.
 
-export function DownloadOptionPanel ({groupKey, cutoutSize, help_id, children, style, title, dlParams,
+export function DownloadOptionPanel ({groupKey='DownloadDialog', cutoutSize, help_id, children, style, title, dlParams,
                                          updateSearchRequest, updateDownloadRequest, validateOnSubmit,
                                          cancelText='Cancel', showZipStructure=true, showEmailNotify=false,
                                          showFileLocation=true, showTitle=true, ...props}) {
@@ -256,11 +251,6 @@ DownloadOptionPanel.propTypes = {
         FileGroupProcessor: PropTypes.string.isRequired,
     })
 };
-
-DownloadOptionPanel.defaultProps= {
-    groupKey: 'DownloadDialog',
-};
-
 
 export function TitleField({style={}, labelWidth, value, label='Title:', size=30}) {
 

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -7,16 +7,16 @@ import PropTypes from 'prop-types';
 import {Alert, Stack} from '@mui/joy';
 
 import {getDropDownInfo} from '../core/LayoutCntlr.js';
-import {SearchPanel} from '../ui/SearchPanel.jsx';
+import {SearchPanel} from './SearchPanel';
 import {HiPSSearchPanel} from '../visualize/ui/HiPSSearchPanel.jsx';
 import {IrsaCatalogSearch} from '../visualize/ui/IrsaCatalogSearch.jsx';
 import {ClassicNedSearchPanel, ClassicVOCatalogPanel} from '../visualize/ui/ExtraIpacSearches.jsx';
 import {ImageSearchDropDown} from '../visualize/ui/ImageSearchPanelV2.jsx';
-import {TestSearchPanel} from '../ui/TestSearchPanel.jsx';
-import {TestQueriesPanel} from '../ui/TestQueriesPanel.jsx';
-import {ChartSelectDropdown} from '../ui/ChartSelectDropdown.jsx';
-import {FileUploadDropdown} from '../ui/FileUploadDropdown.jsx';
-import {WorkspaceDropdown} from '../ui/WorkspaceDropdown.jsx';
+import {TestSearchPanel} from './TestSearchPanel';
+import {TestQueriesPanel} from './TestQueriesPanel';
+import {ChartSelectDropdown} from './ChartSelectDropdown';
+import {FileUploadDropdown} from './FileUploadDropdown';
+import {WorkspaceDropdown} from './WorkspaceDropdown';
 import {getAlerts} from '../core/AppDataCntlr.js';
 import {MultiSearchPanel} from 'firefly/ui/MultiSearchPanel.jsx';
 import {TapSearchPanel} from 'firefly/ui/tap/TapSearchRootPanel.jsx';
@@ -63,7 +63,7 @@ export const dropDownMap = {
  * Items in this container must have a 'name' property.  It will be used to
  * compare to the selected card.
  */
-export function DropDownContainer ({style={}, visible:defVisible, selected:defSelected, dropdownPanels, defaultView, watchInitArgs= true, children}) {
+export function DropDownContainer ({style={}, visible:defVisible=false, selected:defSelected, dropdownPanels, defaultView, watchInitArgs= true, children}) {
 
     const visible   = useStoreConnector(() => getDropDownInfo()?.visible ?? defVisible);
     const selected  = useStoreConnector(() => getDropDownInfo()?.view ?? defSelected);       // the selected view name
@@ -103,9 +103,6 @@ DropDownContainer.propTypes = {
     dropdownPanels: PropTypes.arrayOf(PropTypes.element),
     alerts: PropTypes.node,
     watchInitArgs: PropTypes.bool
-};
-DropDownContainer.defaultProps = {
-    visible: false
 };
 
 export function Alerts() {

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -14,8 +14,8 @@ const DD_FILE_TXT= 'or drag & drop a file here';
 const DD_ANOTHER_FILE_TXT= 'or drag & drop another file';
 const NO_FILE_TXT= 'No file chosen';
 
-function FileUploadView({isLoading, label, valid, message, onChange, value,  sx, hasUploadedData,
-                         isFromURL, onUrlAnalysis, canDragDrop}) {
+function FileUploadView({isLoading=false, label, valid, message, onChange, value,  sx, hasUploadedData,
+                         isFromURL=false, onUrlAnalysis, canDragDrop}) {
     return (
         <Stack {...{ direction:'row', spacing:1, alignItems:'center', whiteSpace:'nowrap', sx}}>
             {isFromURL ?
@@ -79,34 +79,28 @@ const ChooseUploadFile= ({onChange, value, fileName, canDragDrop}) => (
 
 
 FileUploadView.propTypes = {
-    fileType: string.isRequired,
-    isLoading: bool.isRequired,
+    fileType: string,
+    isLoading: bool,
     message: string.isRequired,
     onChange: func.isRequired,
     value : string.isRequired,
     label: string,
-    labelWidth: number,
     valid: bool,
     sx: object,
-    isFromURL: bool.isRequired,
+    isFromURL: bool,
     onUrlAnalysis: func,
     canDragDrop: bool
 };
 
-FileUploadView.defaultProps = {
-    fileType: 'TABLE',
-    isLoading: false,
-    isFromURL: false,
-    labelWidth: 0
-};
 
 export const FileUpload= memo( (props) => {
     const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
+    const {fileType='TABLE'} = viewProps;
     let modViewProps;
 
     useEffect(() => {
         if (viewProps.dropEvent) {
-            handleChange(viewProps.dropEvent, fireValueChange, viewProps.fileType, viewProps.fileAnalysis);
+            handleChange(viewProps.dropEvent, fireValueChange, fileType, viewProps.fileAnalysis);
         }
     },[viewProps.dropEvent]);
 
@@ -115,14 +109,14 @@ export const FileUpload= memo( (props) => {
             ...viewProps,
             onChange: (ev) => onUrlChange(ev, viewProps, fireValueChange),
             value:  viewProps.displayValue,
-            onUrlAnalysis: (value) => doUrlAnalysis(value, fireValueChange, viewProps.fileType, viewProps.fileAnalysis)
+            onUrlAnalysis: (value) => doUrlAnalysis(value, fireValueChange, fileType, viewProps.fileAnalysis)
         };
     }
     else {
         modViewProps= {
             ...viewProps,
             value: viewProps.displayValue,
-            onChange: (ev) => handleChange(ev, fireValueChange, viewProps.fileType, viewProps.fileAnalysis)
+            onChange: (ev) => handleChange(ev, fireValueChange, fileType, viewProps.fileAnalysis)
         };
     }
     return <FileUploadView {...{...modViewProps, hasUploadedData:Boolean(modViewProps.analysisResult) }}/> ;
@@ -132,7 +126,6 @@ FileUpload.propTypes = {
     fieldKey : string.isRequired,
     isFromURL: bool,
     label: string,
-    labelWidth: number,
     sx: object,
     fileAnalysis: func,
     canDragDrop: bool,

--- a/src/firefly/js/ui/InputAreaField.jsx
+++ b/src/firefly/js/ui/InputAreaField.jsx
@@ -15,18 +15,12 @@ function onChange(ev, validator, fireValueChange) {
 }
 
 
-export const InputAreaFieldConnected = forwardRef( (props, ref) => {
-    const {viewProps, fireValueChange}=  useFieldGroupConnector(props);
-    return (<InputAreaFieldView ref={ref} {...viewProps} onChange={(ev) => onChange(ev,viewProps.validator, fireValueChange)}/>);
-});
+export const InputAreaFieldConnected =
+    forwardRef( ({showWarning=true, actOn=['changes'], visible=true ,...rest}, ref) => {
+        const {viewProps, fireValueChange}=  useFieldGroupConnector({showWarning,actOn,visible,...rest});
+        return (<InputAreaFieldView ref={ref} {...viewProps} onChange={(ev) => onChange(ev,viewProps.validator, fireValueChange)}/>);
+    });
 
-
-
-InputAreaFieldConnected.defaultProps = {
-    showWarning: true,
-    actOn: ['changes'],
-    visible: true,
-};
 
 InputAreaFieldConnected.propTypes = {
     ...omit(propTypes, ['value']),

--- a/src/firefly/js/ui/InputField.jsx
+++ b/src/firefly/js/ui/InputField.jsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import PropTypes from 'prop-types';
+import PropTypes, {number, oneOfType, string} from 'prop-types';
 
 import {InputFieldView, propTypes} from './InputFieldView.jsx';
 import {NOT_CELL_DATA} from '../tables/ui/TableRenderer.js';        // this is not right.. should revisit
@@ -16,7 +16,7 @@ function shouldAct(e, actOn) {
     }
 }
 
-export const InputFieldActOn = React.memo(({View, fieldKey, valid=true, value, onChange, validator, actOn, ...others}) => {
+export const InputFieldActOn = React.memo(({View, fieldKey, valid=true, value='', onChange, validator, actOn, ...others}) => {
     const [fieldState, setFieldState] = useState({valid, value, message:''});
 
     useEffect(() => {
@@ -53,26 +53,28 @@ export const InputFieldActOn = React.memo(({View, fieldKey, valid=true, value, o
     );
 });
 
-
-export const InputField = (props) => <InputFieldActOn View={InputFieldView} {...props}/>;
+export const InputField = ({
+                               fieldKey='undef',
+                               value= '',
+                               showWarning = true,
+                               actOn= ['changes'],
+                               labelWidth= 0,
+                               inline= false,
+                               visible= true,
+                               ...rest}) => (
+    <InputFieldActOn View={InputFieldView} {...{
+        fieldKey, value, showWarning, actOn, labelWidth, inline, visible, ...rest }}/>
+);
 
 InputField.propTypes = {
     ...propTypes,
+    value   : oneOfType([string, number]),
     fieldKey: PropTypes.string,
     onChange: PropTypes.func,
     actOn: PropTypes.arrayOf(PropTypes.oneOf(['blur', 'enter', 'changes'])),
     validator: PropTypes.func
 };
 
-InputField.defaultProps = {
-    fieldKey:'undef',
-    value: '',
-    showWarning : true,
-    actOn: ['changes'],
-    labelWidth: 0,
-    inline: false,
-    visible: true
-};
 
 
 

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -18,11 +18,13 @@ export function inputFieldTooltipProps({valid, message, showWarning=true, toolti
 
 export const inputFieldValue = (type, value) => (type==='file') ? '' : (value??'');
 
+
+
 export function InputFieldView(props) {
-    const {visible,label,tooltip,value,inputRef, slotProps,
-        valid,onChange, onBlur, onKeyPress, onKeyDown, onKeyUp, showWarning,
-        message, type, placeholder, sx, startDecorator, endDecorator,
-        readonly, required, orientation='vertical'}= props;
+    const {visible=true,label,tooltip,value,inputRef, slotProps,
+        valid=true,onChange, onBlur, onKeyPress, onKeyDown, onKeyUp, showWarning=true,
+        message='', type='text', placeholder, sx, startDecorator, endDecorator,
+        readonly=false, required=false, orientation='vertical'}= props;
     if (!visible) return null;
     let {form='__ignore'}= props;
     // form to relate this input field to.
@@ -91,16 +93,6 @@ InputFieldView.propTypes= {
         label: object,
         tooltip: object
     })
-};
-
-InputFieldView.defaultProps= {
-    showWarning : true,
-    valid : true,
-    visible : true,
-    message: '',
-    type: 'text',
-    readonly: false,
-    required: false
 };
 
 export const propTypes = InputFieldView.propTypes;

--- a/src/firefly/js/ui/PagingBar.jsx
+++ b/src/firefly/js/ui/PagingBar.jsx
@@ -13,9 +13,8 @@ import LastPage from '@mui/icons-material/LastPage';
 import NavigateNext from '@mui/icons-material/NavigateNext';
 import NavigateBefore from '@mui/icons-material/NavigateBefore';
 
-
 export function PagingBar(props) {
-    const {currentPage, totalRows, pageSize, showLoading, callbacks} = props;
+    const {currentPage=1, totalRows, pageSize=100, showLoading=false, callbacks} = props;
 
     const showAll = (totalRows === 0) || (pageSize === MAX_ROW);
     const startIdx = (currentPage-1) * pageSize;
@@ -70,9 +69,4 @@ PagingBar.propTypes = {
     })
 };
 
-PagingBar.defaultProps = {
-    currentPage: 1,
-    showLoading: false,
-    pageSize: 100
-};
 

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -37,7 +37,7 @@ const isSizeValid = (sizeDeg,  min, max) => (
 
 const isFieldValid= (valInDeg, nullAllowed, min, max) => (nullAllowed && !valInDeg) || isSizeValid(valInDeg, min, max);
 
-function updateSizeInfo({unit, value, nullAllowed, min, max, displayValue}) {
+function updateSizeInfo({unit='deg', value, nullAllowed, min, max, displayValue}) {
     return {
         unit: unit || 'deg',
         valid: isFieldValid(value, nullAllowed, min, max),
@@ -82,7 +82,7 @@ function getFeedback(unit, min, max, showFeedback) {
 const SizeInputFieldView= (props) => {
     const {nullAllowed, min, max, sx, inputStyle={}, connectedMarker= false,
         orientation='vertical', slotProps,
-        label, showFeedback, onChange} = props;
+        label='Size: ', showFeedback=false, onChange} = props;
     const [{value, valid, displayValue, unit},setState]= useState(() => updateSizeInfo(props));
     const {feedback, errmsg}= getFeedback(unit,min,max,showFeedback);
 
@@ -192,11 +192,6 @@ SizeInputFieldView.propTypes = {
     })
 };
 
-SizeInputFieldView.defaultProps = {
-    label: 'Size: ',
-    unit: 'deg',
-    showFeedback: false
-};
 
 
 export const SizeInputFields = memo( (props) => {

--- a/src/firefly/js/ui/SuggestBoxInputField.jsx
+++ b/src/firefly/js/ui/SuggestBoxInputField.jsx
@@ -15,11 +15,10 @@ import './SuggestBoxInputField.css';
 
 /**
  *  Make sure a component (like highlighted suggestion) is visible
- *  @param {ReactComponent} c
+ *  @param  el
  *  @param {Number} highlightedIdx
  */
-function ensureVisible(c, highlightedIdx) {
-    const el = ReactDOM.findDOMNode(c); //DOMElement
+function ensureVisible(el, highlightedIdx) {
     if (el && highlightedIdx) {
         const nSuggestions = el.children.length;
         if (nSuggestions>1) {

--- a/src/firefly/js/ui/WorkspaceViewer.jsx
+++ b/src/firefly/js/ui/WorkspaceViewer.jsx
@@ -43,8 +43,8 @@ import {Stacker} from 'firefly/ui/Stacker.jsx';
 
 export const WorkspaceView = memo( (props) => {
 
-    const {canCreateFolder, canCreateFiles, canRenameFolder, canRenameFile,
-        canDeleteFolder, canDeleteFile, onClickItem, files, wrapperStyle={width: '100%', height: '100%'},
+    const {canCreateFolder=false, canCreateFiles=false, canRenameFolder=false, canRenameFile=false,
+        canDeleteFolder=false, canDeleteFile=false, onClickItem, files=[], wrapperStyle={width: '100%', height: '100%'},
         keepSelect, folderLevel=1, selectedItem} = props;
     const eventHandlers = {
         onCreateFolder: canCreateFolder ? onCreateFolder : undefined,
@@ -73,16 +73,6 @@ export const WorkspaceView = memo( (props) => {
     );
 });
 
-WorkspaceView.defaultProps = {
-    canCreateFolder: false,
-    canCreateFiles: false,
-    canRenameFolder: false,
-    canRenameFile: false,
-    canDeleteFolder: false,
-    canDeleteFile: false,
-    onClickItem: null,
-    files: []
-};
 
 WorkspaceView.propTypes = {
     canCreateFolder: PropTypes.bool,
@@ -211,7 +201,7 @@ export function showWorkspaceDialog({onComplete, value, fieldKey}) {
 
 /*-----------------------------------------------------------------------------------------*/
 
-export function WorkspaceAsPopup({wrapperStyle, onComplete, value, isLoading, fieldKey}) {
+export function WorkspaceAsPopup({wrapperStyle, onComplete, value, isLoading=false, fieldKey}) {
     
     return (
         <Stack spacing={2} justifyContent={'center'} sx={{px: 2, wrapperStyle}}>
@@ -238,10 +228,6 @@ WorkspaceAsPopup.propTypes = {
     wrapperStyle: PropTypes.object,
     onComplete: PropTypes.func.isRequired,
     isLoading: PropTypes.bool.isRequired
-};
-
-WorkspaceAsPopup.defaultProps = {
-    isLoading: false
 };
 
 

--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -128,7 +128,7 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
 
     useEffect(() => {
         // We need to get prism-live to adopt to the textarea
-        const textArea = ReactDOM.findDOMNode(adqlEl.current)?.querySelector('textarea');
+        const textArea = adqlEl.current?.querySelector('textarea');
         // adopt textArea
         prismLiveRef.current = new Prism.Live(textArea);
     }, []);


### PR DESCRIPTION
#### [Firefly-1515](https://jira.ipac.caltech.edu/browse/FIREFLY-1515): fix deprecations to prepare for react 19
  
- removed `defaultProps` from functional components
- removed calls to `findDOMNode`


#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1515-prepare-for-19/firefly
- Everything should work as before
- Look closely at the table related components