### PR TITLE
FIREFLY-1517: use SQL to create decimate data

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   firefly:
     image: ipac/firefly:${BUILD_TAG:-latest}  # value taken from shell, or latest
@@ -9,6 +8,7 @@ services:
       - "8080:8080"
     env_file:
       - ./firefly-docker.env
+
   test:
     build:
       context: ../

--- a/docker/launchTomcat.sh
+++ b/docker/launchTomcat.sh
@@ -103,6 +103,7 @@ fi
 export CATALINA_OPTS="\
   -XX:InitialRAMPercentage=${INIT_RAM_PERCENT:-10} \
   -XX:MaxRAMPercentage=${MAX_RAM_PERCENT:-80} \
+  -XX:+UnlockExperimentalVMOptions -XX:TrimNativeHeapInterval=30000 \
   -DADMIN_USER=${ADMIN_USER} \
   -DADMIN_PASSWORD=${ADMIN_PASSWORD} \
   -Dhost.name=${HOSTNAME} \
@@ -115,6 +116,10 @@ export CATALINA_OPTS="\
   -Dalerts.dir=/firefly/alerts \
   -Dvisualize.fits.search.path=${VIS_PATH} \
 	"
+
+#	This was added because the current version of DuckDB does not free up memory aggressively.
+# This causes it to use more than the designated limit.
+#  -XX:+UnlockExperimentalVMOptions -XX:TrimNativeHeapInterval=30000 \
 
 #----- remove ADMIN_PROTECTED path so it no longer restricted by basic auth
 if [ "${USE_ADMIN_AUTH,,}" = "false" ]; then export CATALINA_OPTS="${CATALINA_OPTS} -DADMIN_PROTECTED="; fi

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/DecimateInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/DecimateInfo.java
@@ -7,6 +7,8 @@ import edu.caltech.ipac.util.StringUtils;
 
 import java.io.Serializable;
 
+import static edu.caltech.ipac.firefly.server.util.QueryUtil.quotes;
+
 /**
  * Date: Jan 31, 2014
  *
@@ -27,6 +29,10 @@ public class DecimateInfo implements Serializable, Comparable {
     private double yMax = Double.NaN;
 
     private int deciEnableSize = -1;
+
+    // used when xColumnName is an expression;  compatible with old code.  should revisit
+    transient private String xExp;
+    transient private String yExp;
 
     public DecimateInfo() {
     }
@@ -165,6 +171,10 @@ public class DecimateInfo implements Serializable, Comparable {
         return s;
     }
 
+    public String getxExp() { return xExp == null ? quotes(xColumnName) : xExp; }
+    public void setxExp(String xExp) { this.xExp = quotes(xExp); }
+    public String getyExp() { return yExp == null ? quotes(yColumnName) : yExp; }
+    public void setyExp(String yExp) { this.yExp = quotes(yExp);}
 //====================================================================
 //  Implements Comparable
 //====================================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/TableServerRequest.java
@@ -123,7 +123,7 @@ public class TableServerRequest extends ServerRequest implements Serializable, C
 
     public String getInclColumns() { return getParam(INCL_COLUMNS); }
     public void setInclColumns(String ...cols) {
-        if (cols == null) {
+        if (cols == null || cols.length == 0) {
             removeParam(INCL_COLUMNS);
         } else {
             setParam(INCL_COLUMNS, StringUtils.toString(cols, ","));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -868,7 +868,7 @@ public class ServerContext {
         public void contextDestroyed(ServletContextEvent servletContextEvent) {
             try {
                 System.out.println("contextDestroyed...");
-                DbMonitor.cleanup(true, true);
+                DbMonitor.cleanup(true, false);
                 ((EhcacheProvider)CacheManager.getCacheProvider()).shutdown();
                 try {
                     SHORT_TASK_EXEC.shutdownNow();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbInstance.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbInstance.java
@@ -99,10 +99,11 @@ public class DbInstance {
     public String name() {
         return name;
     }
-
     public String getDbUrl() {
         return this.dbUrl;
     }
+    public boolean isPooled() { return isPooled; }
+    public void setPooled(boolean pooled) { isPooled = pooled;}
 
     @Override
     public boolean equals(Object obj) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbMonitor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbMonitor.java
@@ -40,14 +40,14 @@ class DbMonitor {
           - COMPACT_FACTOR: .5
           - MAX_MEMORY_ROWS:  1m rows for every 1GB of memory at startup. minimum of 2 million.
      */
-    public static long MAX_MEM_ROWS   = AppProperties.getLongProperty("dbTbl.maxMemRows", maxMemRows());
-    public static long MAX_MEMORY   = AppProperties.getLongProperty("dbTbl.maxMemory", maxMemory());
-
     public static final long MAX_IDLE_PROP  = AppProperties.getLongProperty("dbTbl.maxIdle", 15);                       // idle time before DB is shutdown.  Defaults to 15 minutes.
     public static final long MAX_IDLE_TIME_RSC = AppProperties.getLongProperty("dbRsc.maxIdle", MAX_IDLE_PROP) * 1000 * 60;  // same as dbTbl.maxIdle, but for Resource tables.
-    public static final long MAX_IDLE_TIME  = MAX_IDLE_PROP * 1000 * 60;                                                          // max idle time in ms
     public static final float COMPACT_FACTOR = AppProperties.getFloatProperty("dbTbl.compactFactor", 0.5f);             // when to compact the DB as a factor of MAX_IDLE.  defaults to 1/2 of MAX_IDLE_TIME
     public static final int  CLEANUP_INTVL  = 1000 * 60;        // check every 1 minutes
+
+    public static long MAX_MEM_ROWS   = AppProperties.getLongProperty("dbTbl.maxMemRows", maxMemRows());
+    public static long MAX_MEMORY   = AppProperties.getLongProperty("dbTbl.maxMemory", maxMemory());
+    public static long MAX_IDLE_TIME  = MAX_IDLE_PROP * 1000 * 60;                                                          // max idle time in ms
 
     /**
      * When met, system will aggressively shutdown DBs even before expiry time starting with the

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
@@ -174,13 +174,8 @@ public abstract class DuckDbReadable extends DuckDbAdapter {
         return dd.formatted(getSourceFile().getAbsolutePath());
     }
 
-    protected String metaSql() {
-        return null;
-    }
-
-    protected String auxSql() {
-        return null;
-    }
+    protected String metaSql() { return null; }
+    protected String auxSql() { return null; }
 
 //====================================================================
 //  Supported file types
@@ -211,9 +206,9 @@ public abstract class DuckDbReadable extends DuckDbAdapter {
         public DbAdapter create(File dbFile) {
             return canHandle(dbFile) ? new Parquet(dbFile) : null;
         }
-        protected String metaSql() {
-            return "select decode(key) as key, decode(value) as value, true as isKeyword from parquet_kv_metadata('%s')".formatted(getSourceFile().getAbsolutePath());
-        }
+//        protected String metaSql() {
+//            return "select decode(key) as key, decode(value) as value, true as isKeyword from parquet_kv_metadata('%s')".formatted(getSourceFile().getAbsolutePath());
+//        }
 
         String getSrcFileSql() {
             return "read_parquet('%s')".formatted(getSourceFile().getAbsolutePath());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -392,10 +392,10 @@ public class EmbeddedDbUtil {
     }
 
     public static Object deserialize(ResultSet rs, String cname) {
-        return getOrDefault(() -> deserialize(rs.getString(cname)), null);
+        return getSafe(() -> deserialize(rs.getString(cname)));
     }
     public static Object deserialize(ResultSet rs, int cidx) {
-        return getOrDefault(() -> deserialize(rs.getString(cidx)), null);
+        return getSafe(() -> deserialize(rs.getString(cidx)));
     }
 
     public static Object deserialize(String base64) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
@@ -6,10 +6,15 @@ package edu.caltech.ipac.firefly.server.query;
 import edu.caltech.ipac.firefly.data.DecimateInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.db.BaseDbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
+import edu.caltech.ipac.firefly.server.db.DuckDbAdapter;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.table.DataGroupPart;
 import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.util.decimate.DecimateKey;
+
+import static edu.caltech.ipac.firefly.server.util.QueryUtil.*;
 
 
 @SearchProcessorImpl(id = DecimationProcessor.ID)
@@ -23,7 +28,77 @@ public class DecimationProcessor extends TableFunctionProcessor {
     }
 
     protected DataGroup fetchData(TableServerRequest treq, DbAdapter dbAdapter) throws DataAccessException {
+        if (dbAdapter instanceof DuckDbAdapter) {
+            createDecimateTable(treq, dbAdapter);
+            return null;
+        } else {
+            return createDecimateData(treq, dbAdapter);
+        }
+    }
 
+    void createDecimateTable(TableServerRequest treq, DbAdapter dbAdapter) throws DataAccessException {
+        DecimateInfo deciInfo = getDecimateInfo(treq);
+        if (deciInfo == null)  return;
+
+        TableServerRequest sreq = QueryUtil.getSearchRequest(treq);
+        String[] inclCols = sreq.getInclColumns() == null ? new String[]{} : sreq.getInclColumns().split(",");
+        sreq.setInclColumns();      // used as a transport; should fix if we're no longer using old code.
+        // separate the expression from the column name
+        if ( inclCols.length == 1 ) {
+            String[] parts = inclCols[0].split(" as ");
+            if (parts.length == 2) {
+                deciInfo.setxExp(parts[0]);
+                deciInfo.setyExp(parts[0]);
+            }
+        } else if(inclCols.length == 2) {
+            String[] xParts = inclCols[0].split(" as ");
+            String[] yParts = inclCols[1].split(" as ");
+            if (xParts.length == 2) deciInfo.setxExp(xParts[0]);
+            if (yParts.length == 2) deciInfo.setyExp(yParts[0]);
+        } else if(inclCols.length > 2) {
+            // this is a parsing issue because we use ',' as a separator.  but, comma is often used in function argument.  need to revisit
+            throw new DataAccessException("Unsupported expression");
+        }
+
+        EmbeddedDbProcessor proc = (EmbeddedDbProcessor) SearchManager.getProcessor(sreq.getRequestId());
+        String dataTbl = proc.getResultSetID(sreq);
+        DecimateKey deciKey = getDeciKey(deciInfo, dbAdapter, dataTbl);
+        DecimateKey deciFunc = deciKey.clone();     // decimate_key function to execute over the dataTbl
+        deciFunc.setCols(deciInfo.getxExp(), deciInfo.getyExp());
+
+        int dataPoints = Math.min(deciKey.getxCount(), deciKey.getyCount());
+        int deciEnableSize = deciInfo.getDeciEnableSize() > 0 ? deciInfo.getDeciEnableSize() : DECI_ENABLE_SIZE;
+        String tblName = getResultSetTable(treq);
+        if (dataPoints < deciEnableSize) {
+            String sql = """
+                CREATE TABLE %s as (
+                SELECT %s as "%s", %s as "%s", ROW_NUM as "rowidx"
+                FROM %s
+                """.formatted(tblName, deciInfo.getxExp(), deciKey.getXCol(), deciInfo.getyExp(), deciKey.getYCol(), dataTbl);
+            dbAdapter.execUpdate(sql);
+        } else {
+            String sql = """
+                CREATE TABLE %s as (
+                SELECT FIRST(%s) as "%s", FIRST(%s) as "%s", FIRST(ROW_NUM) as "rowidx", count(*) as "weight", %s as "dkey"
+                FROM %s
+                GROUP BY "dkey" )
+                """.formatted(tblName, deciInfo.getxExp(), deciKey.getXCol(), deciInfo.getyExp(), deciKey.getYCol(), deciFunc, dataTbl);
+            dbAdapter.execUpdate(sql);
+
+            // add decimation info to the returned table
+            var minMax = dbAdapter.execQuery("""
+                            SELECT MIN("weight") as "minWeight", MAX("weight") as "maxWeight"
+                            FROM %s""".formatted(tblName),null);
+            long minW = (long) minMax.getData("minWeight", 0);
+            long maxW = (long) minMax.getData("maxWeight", 0);
+            DataGroup meta = new DataGroup();
+            insertDecimateInfo(meta, deciInfo, deciKey, minW, maxW);
+            ((BaseDbAdapter)dbAdapter).metaToDb(meta, tblName);
+        }
+    }
+
+    /* Old method of doing decimation */
+    DataGroup createDecimateData(TableServerRequest treq, DbAdapter dbAdapter) throws DataAccessException {
         DecimateInfo decimateInfo = getDecimateInfo(treq);
         TableServerRequest sreq = QueryUtil.getSearchRequest(treq);
         sreq.setPageSize(Integer.MAX_VALUE);        // we want all of the data.  no paging
@@ -34,7 +109,7 @@ public class DecimationProcessor extends TableFunctionProcessor {
             String [] requestedCols = x.equals(y) ? new String[]{"\""+x+"\""} : new String[]{"\""+x+"\",\""+y+"\""};
             sreq.setInclColumns(requestedCols);
         }
-        
+
         DataGroupPart sourceData = new SearchManager().getDataGroup(sreq);
         if (sourceData == null) {
             throw new DataAccessException("Unable to get source data");
@@ -49,6 +124,7 @@ public class DecimationProcessor extends TableFunctionProcessor {
         } else {
             return dg;
         }
+
     }
 
     public static DecimateInfo getDecimateInfo(ServerRequest req) {
@@ -63,7 +139,35 @@ public class DecimationProcessor extends TableFunctionProcessor {
         }
     }
 
+    public static DecimateKey getDeciKey(DecimateInfo deciInfo, DbAdapter dbAdapter, String tblName) throws DataAccessException {
+        String sql = """
+                SELECT MAX(%1$s) as "xMax", MIN(%1$s) as "xMin", COUNT(%1$s) as "xCount", MAX(%2$s) as "yMax", MIN(%2$s) as "yMin", COUNT(%2$s) as "yCount" from %3$s
+                """.formatted(deciInfo.getxExp(), deciInfo.getyExp(), tblName);
+
+        DataGroup stats = dbAdapter.execQuery(sql, null);
+
+        double xMin = toDouble(stats.getData("xMin", 0));
+        double xMax = toDouble(stats.getData("xMax", 0));
+        double yMin = toDouble(stats.getData("yMin", 0));
+        double yMax = toDouble(stats.getData("yMax", 0));
+        int xCount = toInt(stats.getData("xCount", 0));
+        int yCount = toInt(stats.getData("yCount", 0));
+
+        var deciKey = getDecimateKey(deciInfo, xMax, xMin, yMax, yMin);
+        deciKey.setxCount(xCount);
+        deciKey.setyCount(yCount);
+        return deciKey;
+    }
+
+    private static double toDouble(Object o) {
+        if (o instanceof Number n) {
+            return n.doubleValue();
+        } else return Double.NaN;
+    }
+
+    private static int toInt(Object o) {
+        if (o instanceof Number n) {
+            return n.intValue();
+        } else return Integer.MIN_VALUE;
+    }
 }
-
-
-

--- a/src/firefly/java/edu/caltech/ipac/util/decimate/DecimateKey.java
+++ b/src/firefly/java/edu/caltech/ipac/util/decimate/DecimateKey.java
@@ -5,6 +5,8 @@ package edu.caltech.ipac.util.decimate;
 
 import edu.caltech.ipac.util.StringUtils;
 
+import static edu.caltech.ipac.firefly.server.util.QueryUtil.quotes;
+
 /**
  * This is a class, which holds the information
  * necessary to calculate a unique cell key in
@@ -13,7 +15,7 @@ import edu.caltech.ipac.util.StringUtils;
  * and preserves one row per cell.
  * @author tatianag
  */
-public class DecimateKey {
+public class DecimateKey implements Cloneable {
     public final static String DECIMATE_KEY = "decimate_key";
     public final static String XY_SEPARATOR = ":";
 
@@ -28,6 +30,9 @@ public class DecimateKey {
 
     String xColNameOrExpr;
     String yColNameOrExpr;
+
+    int xCount;
+    int yCount;
 
     public DecimateKey(double xMin, double yMin, int nX, int nY, double xUnit, double yUnit) {
         this.xMin = xMin;
@@ -75,6 +80,11 @@ public class DecimateKey {
     public double getXUnit() {return xUnit; }
     public double getYUnit() {return yUnit; }
 
+    public int getxCount() { return xCount; }
+    public void setxCount(int xCount) { this.xCount = xCount;}
+
+    public int getyCount() { return yCount; }
+    public void setyCount(int yCount) { this.yCount = yCount; }
 
     public static DecimateKey parse(String str) {
         if (StringUtils.isEmpty(str)) return null;
@@ -105,7 +115,15 @@ public class DecimateKey {
 
     @Override
     public String toString() {
-        return DECIMATE_KEY+"(\""+xColNameOrExpr+"\",\""+yColNameOrExpr+"\","+
+        return DECIMATE_KEY+"(" + quotes(xColNameOrExpr) + "," + quotes(yColNameOrExpr) + ","+
                 xMin+","+yMin+","+nX+","+nY+","+xUnit+","+yUnit+")";
+    }
+
+    public DecimateKey clone() {
+        try {
+            return  (DecimateKey) super.clone();
+        } catch (CloneNotSupportedException e) {
+            return null;        // should not happen
+        }
     }
 }

--- a/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
@@ -201,7 +201,7 @@ public class EmbeddedDbUtilTest extends ConfigTest {
 		// test meta
 		Assert.assertEquals("ORIGIN value", data.getAttribute("ORIGIN"));
 		Assert.assertEquals("SQL value", data.getAttribute("SQL"));
-		Assert.assertEquals("repeated key will get overriden", data.getTableMeta().getKeywords().get(4).getValue());  // but, it's still in keywords
+		Assert.assertEquals("repeated key will get overriden", data.getTableMeta().getKeywords().get(5).getValue());  // but, it's still in keywords
 
 		// test column meta
 		DataType dt = data.getDataDefintion("dec");


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1517

Optimizes the memory usage of `DecimationProcessor`. It should work the same as before with one key difference: the represented point (highlighted row) is now taken from the first row of an `SQL GROUP BY` statement instead of a random row determined by Java logic. This change should not impact functionality. Open to feedback.

This approach eliminates the need to load the entire table into JVM memory, which previously could consume gigabytes of memory. It also significantly speeds up processing for larger tables for the same reason.

Test: https://fireflydev.ipac.caltech.edu/firefly-1517-decimation/firefly/
Load bigger tables, at least 5000 rows to trigger decimation.


