### PR TITLE
FIREFLY-1516: The chart is not recognizing short as a numeric type

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -38,10 +38,10 @@ const local = {
 };
 export default local;
 
-const TEXT  = ['char', 'c', 's', 'str'];
-const INT   = ['long', 'l', 'int', 'i'];
-const FLOAT = ['double', 'd', 'float', 'f', 'real', 'r'];
-const BOOL  = ['boolean','bool', 'b'];
+const TEXT  = ['char'];
+const INT   = ['long', 'int', 'short', 'integer'];
+const FLOAT = ['double', 'float', 'real'];
+const BOOL  = ['boolean','bool'];
 const DATE  = ['date'];
 const NUMBER= [...INT, ...FLOAT];
 const USE_STRING = [...TEXT, ...DATE];


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1516
I added a test file to the ticket to show that the chart will recognize `short` as a numeric type. 
The test table also includes an `unsignedByte` column to address the question raised in the ticket.

Test: https://fireflydev.ipac.caltech.edu/firefly-1516-chart-numeric-columns/firefly/