### PR TITLE
FIREFLY-1519: fix table tab switcher not showing table title as a string

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -866,7 +866,7 @@ export function getTblInfoById(tbl_id, aPageSize) {
 export function getTblInfo(tableModel, aPageSize) {
     if (!tableModel) return {};
     var {tbl_id, request, highlightedRow=0, totalRows=0, tableMeta={}, selectInfo, error} = tableModel;
-    const title = tableMeta.title || request?.META_INFO?.title;
+    const title = tableMeta.title || request?.META_INFO?.title || 'untitled';
     const pageSize = aPageSize > 0 ? aPageSize : fixPageSize(request?.pageSize);
     if (highlightedRow < 0 ) {
         highlightedRow = 0;

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -371,7 +371,7 @@ function fixClientTable(tableModel) {
         tableModel.tbl_id = get(tableModel, 'request.tbl_id') || TblUtil.uniqueTblId();
     }
     if (!tableModel.title) {
-        tableModel.title  = get(tableModel, 'request.META_INFO.title') || 'untitled';
+        tableModel.title  = get(tableModel, 'request.META_INFO.title');
     }
 
     tableModel.totalRows = tableModel?.tableData?.data?.length ?? 0;

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -18,7 +18,7 @@ import {CloseButton} from '../../ui/CloseButton.jsx';
 
 import {Logger} from '../../util/Logger.js';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
-import {getTableUiById} from '../TableUtil.js';
+import {getTableUiById, getTblInfo} from '../TableUtil.js';
 
 const logger = Logger('Tables').tag('TablesContainer');
 
@@ -111,13 +111,14 @@ function tablesAsTab(tables, tableOptions, expandedMode) {
     return tables &&
         Object.keys(tables).map( (key) => {
             var {tbl_id, removable, tbl_ui_id, options={}} = tables[key];
-            const {title='untitled'} = getTableUiById(tbl_ui_id) || {};
+            const {title} = getTblInfo(tbl_id);
+            const {title:titleUI} = getTableUiById(tbl_ui_id) || {};
             options = Object.assign({}, options, tableOptions);
             const onTabRemove = () => {
                 dispatchTableRemove(tbl_id);
             };
             return  (
-                <Tab key={tbl_id} id={tbl_id} label={title} removable={removable} onTabRemove={onTabRemove}>
+                <Tab key={tbl_id} id={tbl_id} label={titleUI} name={title} removable={removable} onTabRemove={onTabRemove}>
                     <TablePanel key={tbl_id}
                                 slotProps={{ toolbar:{variant:'plain'}, root:{variant: 'plain'} }}
                                 {...{tbl_id, tbl_ui_id, ...options, expandedMode, showTitle: false}} />


### PR DESCRIPTION
A patch to previous Pull Request: https://github.com/Caltech-IPAC/firefly/pull/1594
- fix table tab switcher not showing table title as a string