### PR TITLE
FIREFLY-1522: Extract jest config from firefly for reusing it in all ife apps

### DIFF
--- a/__jest__/jest.base.config.js
+++ b/__jest__/jest.base.config.js
@@ -1,0 +1,34 @@
+// Jest config that is shared by all the apps
+
+/* eslint-env node */
+
+module.exports = {
+    'verbose': true,
+    'clearMocks': true,
+    'collectCoverage': true,
+    'coverageDirectory': '../../build/dist/reports/firefly',
+    'coverageReporters': ['lcov'],
+    'moduleFileExtensions': [
+    'js',
+    'jsx'
+],
+    'moduleDirectories': [
+    'node_modules',
+    'js'
+],
+    'setupFiles': [
+    '<rootDir>/../../__jest__/InitTest.js'
+],
+    'moduleNameMapper': {
+    '^.+\\?raw$': '<rootDir>/../../__jest__/fileMock.js',
+        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/../../__jest__/fileMock.js',
+        '\\.(css|less)$': '<rootDir>/../../__jest__/styleMock.js',
+        '^firefly/(.*)$': '<rootDir>/js/$1'
+},
+    'transform': {
+    '^.+\\.jsx?$': '<rootDir>/../../__jest__/jest.transform.js'
+},
+    'globals': {
+    '__PROPS__': {}
+}
+};

--- a/src/firefly/jest.config.js
+++ b/src/firefly/jest.config.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+
+const baseConfig = require('../../__jest__/jest.base.config');
+
+module.exports = {
+    ...baseConfig,
+    //add overrides here (if any)
+};

--- a/src/firefly/package.json
+++ b/src/firefly/package.json
@@ -6,36 +6,6 @@
     "test-unit": "node ../../node_modules/jest/bin/jest --passWithNoTests",
     "test-debug": "node --inspect-brk ../../node_modules/jest/bin/jest --runInBand --passWithNoTests"
   },
-  "jest": {
-    "verbose": true,
-    "clearMocks": true,
-    "collectCoverage": true,
-    "coverageDirectory": "../../build/dist/reports/firefly",
-    "coverageReporters": ["lcov"],
-    "moduleFileExtensions": [
-      "js",
-      "jsx"
-    ],
-    "moduleDirectories": [
-      "node_modules",
-      "js"
-    ],
-    "setupFiles": [
-      "<rootDir>/../../__jest__/InitTest.js"
-    ],
-    "moduleNameMapper": {
-      "^.+\\?raw$": "<rootDir>/../../__jest__/fileMock.js",
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/../../__jest__/fileMock.js",
-      "\\.(css|less)$": "<rootDir>/../../__jest__/styleMock.js",
-      "^firefly/(.*)$": "<rootDir>/js/$1"
-    },
-    "transform": {
-      "^.+\\.jsx?$": "<rootDir>/../../__jest__/jest.transform.js"
-    },
-    "globals": {
-      "__PROPS__": {}
-    }
-  },
   "version": "0.0.0",
   "license": "SEE LICENSE IN License.txt"
 }


### PR DESCRIPTION
Fixes [FIREFLY-1522](https://jira.ipac.caltech.edu/browse/FIREFLY-1522)
Related PRs: https://github.com/IPAC-SW/irsa-ife/pull/346, https://github.com/lsst/suit/pull/53

- Moved jest config from the inline declaration in package.json to a dedicated file in `__jest__/jest.base.config` (gradle is setup already to copy everything under `__jest__` so it will become available to ife apps.
- Created a `jest.config.js` on same level as `package.json` to:
  - override base config if needed (firefly doesn't do it but ife apps do)
  - automatically get picked by jest command

## Testing
Ran `gradle app:test` for all apps: firefly, euclid, irsaviewer, etc. - tests are able to run successfully