### PR TITLE
IRSA-6112: Support Euclid combine results

### DIFF
--- a/src/firefly/js/metaConvert/DataProductsWatcher.js
+++ b/src/firefly/js/metaConvert/DataProductsWatcher.js
@@ -8,19 +8,17 @@ import {getHttpErrorMessage} from '../util/HttpErrorMessage.js';
 import {getStatusFromFetchError} from '../util/WebUtil.js';
 import {isDataProductsTable} from '../voAnalyzer/TableAnalysis.js';
 import {Band} from '../visualize/Band.js';
-import {TABLE_SELECT,TABLE_HIGHLIGHT, TABLE_REMOVE,TABLE_UPDATE, TBL_RESULTS_ACTIVE} from '../tables/TablesCntlr.js';
-import ImagePlotCntlr, {
-    visRoot, dispatchDeletePlotView, MOUSE_CLICK_REASON
-} from '../visualize/ImagePlotCntlr.js';
+import {TABLE_SELECT, TABLE_HIGHLIGHT, TABLE_REMOVE, TABLE_UPDATE, TBL_RESULTS_ACTIVE} from '../tables/TablesCntlr.js';
+import ImagePlotCntlr, {visRoot, dispatchDeletePlotView, MOUSE_CLICK_REASON} from '../visualize/ImagePlotCntlr.js';
 import {REINIT_APP} from '../core/AppDataCntlr.js';
 import {getTblById,getTblInfo,getActiveTableId,isTblDataAvail} from '../tables/TableUtil.js';
 import {isDefaultCoverageActive} from '../visualize/PlotViewUtil.js';
 import MultiViewCntlr, {
     getViewerItemIds, dispatchChangeViewerLayout,
-    getMultiViewRoot, getViewer, GRID, GRID_FULL, SINGLE, getLayoutType, getLayoutDetails, dispatchUpdateCustom
+    getMultiViewRoot, getViewer, GRID, GRID_FULL, SINGLE, getLayoutType, getLayoutDetails
 } from '../visualize/MultiViewCntlr.js';
 import {
-    makeDataProductsConverter, initImage3ColorDisplayManagement, getFactoryTemplateOptions
+    makeDataProductsConverter, getFactoryTemplateOptions
 } from './DataProductsFactory.js';
 import {findGridTableRows} from './TableDataProductUtils.js';
 import {dispatchAddTableTypeWatcherDef} from '../core/MasterSaga.js';

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -198,6 +198,12 @@ export function removeTablesFromGroup(tbl_group_id = 'main') {
     });
 }
 
+export function removeTablesByIDs(tblAry) {
+    tblAry && tblAry.forEach((tbl_id) => {
+        TblCntlr.dispatchTableRemove(tbl_id, true);        
+    });
+}
+
 /**
  * returns an array of tbl_id for the given tbl_group_id
  * @param {string} tbl_group_id    table group name.  defaults to 'main' if not given


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/IRSA-6112
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/348
- added support for removing and re-adding tables to Euclid results view when user selects only Explore Regions ***_or_*** Inspect Sources tables (catalog results will always show) 

**Testing**:
- Euclid: https://irsa-6112-euclid-combine-results.irsakudev.ipac.caltech.edu/applications/euclid
- test selecting ***All Results***, ***Explore Regions***, and ***Inspect Sources*** after performing a search in Euclid
- Firefly: https://fireflydev.ipac.caltech.edu/irsa-6112-euclid-combine-results/firefly
  - this is just to do a few searches to make sure nothing broke on firefly
