### PR TITLE
Euclid Spectra Bug:  fix for spectra not loading in euclid

### DIFF
--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -311,8 +311,7 @@ function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOn
 function getPartProdGuess(part,table,row) {
     const utype= part?.details?.tableMeta?.utype ?? part?.details?.tableMeta?.UTYPE;
     if (utype) return utype;
-    const foundUtypes= part?.details?.resources
-        .map( (r) => r.utype)
+    const foundUtypes= part?.details?.resources?.map( (r) => r.utype)
         .filter( (utype='') => utype.toLowerCase().includes('spec'));
     if (foundUtypes?.length) return foundUtypes?.[0];
     return getProdTypeGuess(table,row);


### PR DESCRIPTION
One char bug fix for spectra not loading in Euclid. 

**Testing**: 
- for some reason my test build is not getting built (I think jenkins or branch name issue), but I tested locally and this resolves the bug. 
- Try these IDs for a Search by ID (Object ID) search: 2360606233404805332