### PR TITLE
IRSA-6111: Make a compare sources tab in Euclid

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -1165,3 +1165,9 @@ export function getTblIdFromChart(chartId, traceNum) {
     traceNum = traceNum ?? activeTrace;
     return data?.[traceNum]?.tbl_id || fireflyData?.[traceNum]?.tbl_id;
 }
+
+export function hasTracesFromSameTable(chartId) {
+    const {data=[], fireflyData=[]} = getChartData(chartId) || {};
+    const tracesTblIds = data.map(({tbl_id}, traceIdx) => tbl_id ?? fireflyData?.[traceIdx]?.tbl_id);
+    return tracesTblIds.every((traceTblId, idx, arr) => traceTblId===arr[0] && traceTblId);
+}

--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -9,10 +9,9 @@ import {PlotlyToolbar} from './PlotlyToolbar.jsx';
 import {dispatchChartMounted, dispatchChartRemove, dispatchChartUnmounted, getChartData, getErrors} from '../ChartsCntlr.js';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 
-import DELETE from 'html/images/blue_delete_10x10.png';
 import {allowPinnedCharts} from '../ChartUtil.js';
 import {PinChart, ShowTable} from './PinnedChartContainer.jsx';
-import {CombineChart} from './CombineChart.jsx';
+import {CombinePinnedCharts} from './CombineChart.jsx';
 
 
 function ChartPanelView(props) {
@@ -85,7 +84,7 @@ export const ChartToolbar = (props={}) => {
     if (allowPinnedCharts()) {
         return (
             <Stack id='chart-toolbar' direction='row' alignItems='center'>
-                <CombineChart {...{viewerId, tbl_group}} />
+                <CombinePinnedCharts {...{viewerId, tbl_group}} />
                 <ShowTable {...{viewerId, tbl_group}} />
                 <PinChart {...{viewerId, tbl_group}}/>
                 <Toolbar {...{chartId, expandable, expandedMode}}/>

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -13,7 +13,7 @@ import {PINNED_GROUP, PINNED_CHART_PREFIX} from './PinnedChartContainer.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {basicOptions, evalChangesFromFields} from './options/BasicOptions.jsx';
-import {getCellValue, getColumnValues, getSelectedDataSync, getTblById} from '../../tables/TableUtil.js';
+import {getColumnValues, getSelectedDataSync, getTblById} from '../../tables/TableUtil.js';
 import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 import {getFieldVal, getGroupFields} from '../../fieldGroup/FieldGroupUtils.js';
 import {getActiveViewerItemId} from './MultiChartViewer.jsx';
@@ -33,39 +33,85 @@ import {quoteNonAlphanumeric} from 'firefly/util/expr/Variable';
 import {ValidationField} from 'firefly/ui/ValidationField';
 import Validate from 'firefly/util/Validate';
 import {SwitchInputField} from 'firefly/ui/SwitchInputField';
+import PropTypes from 'prop-types';
+import {flux} from 'firefly/core/ReduxFlux';
+import {FormMask} from 'firefly/ui/panel/MaskPanel';
 
 const POPUP_ID = 'CombineChart-popup';
 
 
 /**
- * This component is hard-wired to work with only PINNED_VIEWER_ID.  Will need to change if this ever changes.
+ * A generic component that takes two or more charts as input (along with other parameters) and creates a combined
+ * chart (if possible) in the pinned-charts viewer.
+ *
  * @param p
- * @param p.viewerId
+ * @param {Array.<string> | Array.<Promise>} p.chartIds ids of all charts to combine
+ * @param {string} p.selectedChartId id of the chart selected to combine other charts with. If undefined, it's chartIds[0]
+ * @param {boolean} p.allowChartSelection whether to allow user to select the input chartIds through UI dialog
+ * @param {function} p.onCombineComplete callback function to run after combined chart is added
+ * @param {Object} p.slotProps
  * @return {JSX.Element|null}
  * @constructor
  */
-export const CombineChart = ({viewerId}) => {
-
-    if (viewerId !== PINNED_CHART_VIEWER_ID) return null;
-
-    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_CHART_VIEWER_ID);
-    const showCombine = chartIds?.length > 1;
-
+export const CombineChart = ({chartIds, selectedChartId, allowChartSelection=true, onCombineComplete, slotProps}) => {
     const doCombine = async () => {
-        const {chartIds, props} = await getCombineChartParams();
+        const params = await getParamsFromDialog({chartIds, selectedChartId, allowChartSelection, slotProps});
+        const combinedChartData = combineChart(params);
 
-        const chartData = combineChart(chartIds, props);
         dispatchChartAdd({
-            ...chartData,
+            ...combinedChartData,
             chartId: uniqueChartId(PINNED_CHART_PREFIX),
             groupId: PINNED_GROUP,
             viewerId: PINNED_CHART_VIEWER_ID,
             deletable: true,
             mounted: true
         });
+
+        onCombineComplete?.(); // post-combination callback
     };
-    return showCombine ? <CombineChartButton onClick={doCombine}/> : null;
+
+    return (chartIds?.length > 1)
+        ? <CombineChartButton onClick={doCombine} {...slotProps?.button}/>
+        : null;
 };
+
+CombineChart.propTypes = {
+    chartIds: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.string),
+        PropTypes.arrayOf(PropTypes.instanceOf(Promise)),
+    ]).isRequired,
+    selectedChartId: PropTypes.string,
+    allowChartSelection: PropTypes.bool,
+    onCombineComplete: PropTypes.func,
+    slotProps: PropTypes.shape({
+        button: PropTypes.object,
+        dialog: PropTypes.object,
+    }),
+};
+
+
+/**
+ * Retrieves charts from the pinned-charts container and creates a combined chart there.
+ *
+ * @param p
+ * @param {string} p.viewerId ID of the viewer where this component is placed
+ * @param {Object} p.slotProps
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export const CombinePinnedCharts = ({viewerId, slotProps}) => {
+    if (viewerId !== PINNED_CHART_VIEWER_ID) return null;
+
+    const chartIds = getViewerItemIds(getMultiViewRoot(), viewerId);
+    const selectedChartId = getActiveViewerItemId(viewerId, true);
+    return <CombineChart {...{chartIds, selectedChartId, slotProps}} />;
+};
+
+CombinePinnedCharts.propTypes = {
+    viewerId: PropTypes.string,
+    slotProps: CombineChart.propTypes.slotProps,
+};
+
 
 function getChartTitle(cdata, defTitle) {
     return cdata.layout?.title?.text || defTitle;
@@ -82,19 +128,15 @@ function addTracesTitle(chartId, current=[]) {
 }
 
 /* returns the selected chartId as well as a table of matching charts to combine */
-function createTableModel(showAll, tbl_id) {
-
-    const chartIds = getViewerItemIds(getMultiViewRoot(), PINNED_CHART_VIEWER_ID);
-    const selChartId = getSelChartId();
-
+function createTableModel(chartIds, selectedChartId, showAll, tbl_id) {
     const columns = [
         {name: 'Title', width: 30},
         {name: 'From Table'},
         {name: 'ChartId', visibility: 'hidden'},
     ];
     const data = chartIds
-        ?.filter((id) => id !== selChartId)      // exclude already selected chart
-        ?.filter((id) => showAll || canCombine(id))     // filter out the charts that cannot be combined with the active chart
+        ?.filter((id) => id !== selectedChartId)      // exclude already selected chart
+        ?.filter((id) => showAll || canCombine(id, selectedChartId))     // filter out the charts that cannot be combined with the active chart
         ?.map((id) => getChartData(id))
         ?.map((cdata, idx) => {
             const title = getChartTitle(cdata, `chart-${idx}`);
@@ -113,39 +155,75 @@ function createTableModel(showAll, tbl_id) {
     return table;
 }
 
-const CombineChartDialog = ({onComplete}) => {
-
+const ChartSelectionTable = ({tbl_id, chartIds, selectedChartId}) => {
     const [showAll, setShowAll] = useState(false);
-
-    const tbl_id = 'combinechart-tbl-id';
-    const groupKey = 'combinechart-props';
-
-    const doCascading = useStoreConnector(()=>getFieldVal(groupKey, 'doCascading'));
+    const showAllHint = 'Show all charts even ones that may not combine well';
 
     useEffect(() => {
-        const selTbl = createTableModel(showAll, tbl_id);
+        const selTbl = createTableModel(chartIds, selectedChartId ?? chartIds[0], showAll, tbl_id);
         dispatchTableAddLocal(selTbl, undefined, false);
     }, [showAll]);
 
+    return (
+        <Stack height={125}>
+            {/*--- temporarily removed to only combine charts with similar axes
+                <div style={{display: 'inline-flex', alignItems: 'center'}}>
+                    <label htmlFor='showAll'>Show All Charts: </label>
+                    <input type='checkbox' id='showAll' title={showAllHint} value={showAll} onClick={(e) => setShowAll(e.target?.checked)}/>
+                    <span className='CombineChart__hints'>({showAllHint})</span>
+                </div>
+                ----------*/}
+            <TablePanel {...{tbl_id, showToolbar: false, showUnits: false, showTypes: false}}/>
+        </Stack>
+    );
+};
+
+
+const CombineChartDialog = ({onComplete, chartIds, selectedChartId, allowChartSelection}) => {
+    const tbl_id = 'combinechart-tbl-id';
+    const groupKey = 'combinechart-props';
+
+    const [resolvedChartIds, setResolvedChartIds] = React.useState([]);
+    const doCascading = useStoreConnector(()=>getFieldVal(groupKey, 'doCascading'));
+    const tblSelectedChartIds = useStoreConnector(()=>
+        getColumnValues(getSelectedDataSync(tbl_id), 'ChartId'));
+
+    useEffect(() => {
+        if (chartIds[0] instanceof Promise) {
+            Promise.all(chartIds)
+                .then(setResolvedChartIds)
+                .catch((err) => {
+                    console.error(err);
+                }).finally(()=>console.log(flux.getState()));
+        } else {
+            setResolvedChartIds(chartIds);
+        }
+    }, [chartIds]);
+
+
+    const chartIdsToCombine = allowChartSelection
+        ? [selectedChartId ?? chartIds[0], ...tblSelectedChartIds] //selectedChartId isn't present in table
+        : resolvedChartIds; //TODO: run chartIds through canCombine() and show warning if not?
+
     const doApply = () => {
-        const selChartIds = getColumnValues(getSelectedDataSync(tbl_id), 'ChartId');
         const fields = getGroupFields(groupKey);
         const props = Object.fromEntries(
             Object.entries(fields).map(([k,v]) => [k, v.value])
         );
 
-        if (selChartIds?.length < 1) {
+        if (allowChartSelection && tblSelectedChartIds?.length < 1) {
             showInfoPopup('You must select at least one chart to combine with');
         } else {
-            onComplete({chartIds:[getSelChartId(), ...selChartIds], props});
+            onComplete({chartIds: chartIdsToCombine, ...props});
             closePopup();
         }
     };
     const closePopup = () => dispatchHideDialog(POPUP_ID);
 
     const {Title} = basicOptions({groupKey});
-    const showAllHint = 'Show all charts even ones that may not combine well';
 
+    // TODO: fix styling and content of mask
+    if (resolvedChartIds?.length === 0) return <FormMask/>; //still loading chart ids
     return (
         <FieldGroup groupKey={groupKey} sx={{
             height: 500,
@@ -155,20 +233,11 @@ const CombineChartDialog = ({onComplete}) => {
             position: 'relative'
         }}>
             <Stack spacing={1} height={1}>
-                {/*--- temporarily removed to only combine charts with similar axes
-                <div style={{display: 'inline-flex', alignItems: 'center'}}>
-                    <label htmlFor='showAll'>Show All Charts: </label>
-                    <input type='checkbox' id='showAll' title={showAllHint} value={showAll} onClick={(e) => setShowAll(e.target?.checked)}/>
-                    <span className='CombineChart__hints'>({showAllHint})</span>
-                </div>
-                ----------*/}
                 <Stack spacing={2} overflow='auto' flexGrow={1}>
-                    <Stack height={125}>
-                        <TablePanel {...{tbl_id, showToolbar:false, showUnits:false, showTypes:false}}/>
-                    </Stack>
+                    {allowChartSelection && <ChartSelectionTable {...{chartIds: resolvedChartIds, selectedChartId, tbl_id}} />}
                     <Title initialState={{value: 'combined'}}/>
                     <CascadePlots {...{doCascading}}/>
-                    <SelChartProps {...{tbl_id, groupKey, showOrder: doCascading}}/>
+                    <SelChartProps {...{chartIds: chartIdsToCombine, groupKey, showOrder: doCascading}}/>
                 </Stack>
 
                 <Stack direction='row' justifyContent='space-between' alignItems='center'>
@@ -225,36 +294,25 @@ const SelChartOpt = ({chartId, groupKey, header, traces, idx}) => {
     );
 };
 
-function SelChartProps ({tbl_id, groupKey, showOrder}) {
-
-    useStoreConnector(() => getTblById(tbl_id)?.selectInfo);     // rerender when selectInfo changes
-    const selChartId = getSelChartId();
-    const selectedData = getSelectedDataSync(tbl_id, ['ChartId']);       // this always return new objects.  that's why it's not used for useStoreConnector
-
+function SelChartProps ({chartIds, groupKey, showOrder}) {
     const getSelCharInfo = (id) => {
         const cTitle = getChartTitle(getChartData(id));
         const traces = addTracesTitle(id);
 
-        return [selChartId, cTitle, traces];
+        return [id, cTitle, traces];
     };
 
-    const charts = [getSelCharInfo(selChartId)];
     totalTraces = 0;
-
-    for(let idx = 0; idx < selectedData.totalRows; idx++) {
-        const cid = getCellValue(selectedData, idx, 'ChartId');
-        charts.push(getSelCharInfo(cid));
-    }
 
     return (
         <Stack spacing={1}>
             <Typography level='title-sm'>Choose trace names below:</Typography>
             <CollapsibleGroup>
                 {
-                    charts.map(([chartId, ctitle, traces], idx) => {
+                    chartIds.map(getSelCharInfo).map(([chartId, ctitle, traces], idx) => {
                         const header = (
                             <Stack direction='row' spacing={1} alignItems='baseline'>
-                                <Typography {...(idx===0 && {fontWeight: 'var(--joy-fontWeight-lg)'})}>{ctitle}</Typography>
+                                <Typography {...(idx===0 && {fontWeight: 'lg'})}>{ctitle}</Typography>
                                 {showOrder && <Typography level='body-sm'>(i={idx})</Typography>}
                             </Stack>
                         );
@@ -266,16 +324,17 @@ function SelChartProps ({tbl_id, groupKey, showOrder}) {
     );
 }
 
-function getCombineChartParams() {
+function getParamsFromDialog(props) {
     return new Promise((resolve) => {
-        const onComplete = (props) => resolve(props);
-        const content = <CombineChartDialog {...{onComplete}}/>;
-        showPopup({ID: POPUP_ID, content, title: 'Add charts to current chart', modal: true});
+        const onComplete = (params) => resolve(params);
+        const content = <CombineChartDialog {...{onComplete, ...props}}/>;
+        showPopup({ID: POPUP_ID, content, title: 'Add charts to current chart', modal: true,
+            ...props?.slotProps?.dialog});
     });
 }
 
 
-function combineChart(chartIds, props={}) {
+function combineChart({chartIds, doCascading, cascadePadding, ...plottingProps}) {
 
     if (chartIds?.length <= 1) return;
 
@@ -287,7 +346,6 @@ function combineChart(chartIds, props={}) {
 
     baseChartData?.tablesources?.forEach((ts) => Reflect.deleteProperty(ts, '_cancel'));
 
-    const {doCascading, cascadePadding, ...plottingProps} = props;
     doCascading && applyCascadingAlgo(baseChartId, baseChartData, 0, cascadePadding);
 
     for (let i = 1; i < chartIds.length; i++) {
@@ -414,13 +472,13 @@ function applyCascadingAlgo(chartId, chartData, idx, padding) {
 
 /**
  * @param chartId  chart ID of the chart to combine
+ * @param selectedChartId chart ID of the selected chart with which the given chart will be combined
  * @return {boolean} true if the selected chart and the given chart have the same unit for its x-axis and y-axis.
  */
-function canCombine(chartId) {
+function canCombine(chartId, selectedChartId) {
 
     const activeTrace = 0;          // hard-code to only use the first trace from each chart
-    const selChartId = getSelChartId();
-    const {xUnit, yUnit} = getChartData(selChartId)?.fireflyData?.[activeTrace];
+    const {xUnit, yUnit} = getChartData(selectedChartId)?.fireflyData?.[activeTrace];
     if (!xUnit || !yUnit) return false;
 
     const chartData = cloneDeep(getChartData(chartId));
@@ -428,8 +486,4 @@ function canCombine(chartId) {
     const newXUnit = doUnitConversion({chartId, chartData, axisType:'x', to:xUnit});
     const newYUnit = doUnitConversion({chartId, chartData, axisType:'y', to:yUnit});
     return xUnit === newXUnit && yUnit === newYUnit;
-}
-
-function getSelChartId(viewerId=PINNED_CHART_VIEWER_ID) {
-    return  getActiveViewerItemId(viewerId, true);
 }

--- a/src/firefly/js/charts/ui/CompareRowCharts.jsx
+++ b/src/firefly/js/charts/ui/CompareRowCharts.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {getActiveTableId, getTblInfoById} from 'firefly/tables/TableUtil';
+import {SelectInfo} from 'firefly/tables/SelectInfo';
+import {CombineChart} from 'firefly/charts/ui/CombineChart';
+import {useStoreConnector} from 'firefly/ui/SimpleComponent';
+
+/**
+ * Retrieves charts from the rows selected in a table and creates a combined chart in the pinned-charts container.
+ *
+ * @param p
+ * @param {function} p.fetchRowChart an async function that takes tableModel and row index and returns a Promise<string|undefined> of chart ID.
+ * @param {function} p.activatePinnedCharts a function to activate pinned-charts container after combination is complete
+ * @param {Object} p.slotProps
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export function CompareRowCharts({fetchRowChart, activatePinnedCharts, slotProps}) {
+    const {tableModel, selectInfo} = useStoreConnector(() => getTblInfoById(getActiveTableId()));
+    const selectedRowIdxs = Array.from(SelectInfo.newInstance(selectInfo).getSelected());
+    const selectedRowChartIds = selectedRowIdxs.map((row) => fetchRowChart(tableModel, row));
+
+    return (
+        <CombineChart
+            chartIds={selectedRowChartIds}
+            allowChartSelection={false} //because user already selected rows before opening dialog
+            onCombineComplete={activatePinnedCharts}
+            slotProps={{
+                button: {tip: 'Compare selected rows'},
+                dialog: {title: 'Combine charts in the selected rows'},
+                ...slotProps
+            }}/>
+    );
+}
+
+CompareRowCharts.propTypes = {
+    fetchRowChart: PropTypes.func,
+    activatePinnedCharts: PropTypes.func,
+    slotProps: CombineChart.propTypes.slotProps,
+};

--- a/src/firefly/js/charts/ui/CompareRowCharts.jsx
+++ b/src/firefly/js/charts/ui/CompareRowCharts.jsx
@@ -1,33 +1,57 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
+import {set} from 'lodash';
 
-import {getActiveTableId, getTblInfoById} from 'firefly/tables/TableUtil';
+import {getActiveTableId, getTblById, getTblInfoById} from 'firefly/tables/TableUtil';
 import {SelectInfo} from 'firefly/tables/SelectInfo';
 import {CombineChart} from 'firefly/charts/ui/CombineChart';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent';
+import {showInfoPopup} from 'firefly/ui/PopupUtil';
+import {CombineChartButton} from 'firefly/visualize/ui/Buttons';
+
+const ROW_LIMIT = 8;
 
 /**
  * Retrieves charts from the rows selected in a table and creates a combined chart in the pinned-charts container.
  *
  * @param p
- * @param {function} p.fetchRowChart an async function that takes tableModel and row index and returns a Promise<string|undefined> of chart ID.
- * @param {function} p.activatePinnedCharts a function to activate pinned-charts container after combination is complete
+ * @param {function(TableModel,number): Promise<string>} p.fetchRowChart an async function that takes tableModel and row index and returns a promise of chart ID.
+ * @param {function():void} p.activatePinnedCharts a function to activate pinned-charts container after combination is complete
+ * @param {number} p.rowLimit maximum number of rows that can be combined.
+ * @param {function(string):string} p.deriveTraceTitle function to create trace title from the title of chart. Default is to use first 10 characters.
  * @param {Object} p.slotProps
  * @returns {JSX.Element}
  * @constructor
  */
-export function CompareRowCharts({fetchRowChart, activatePinnedCharts, slotProps}) {
-    const {tableModel, selectInfo} = useStoreConnector(() => getTblInfoById(getActiveTableId()));
-    const selectedRowIdxs = Array.from(SelectInfo.newInstance(selectInfo).getSelected());
-    const selectedRowChartIds = selectedRowIdxs.map((row) => fetchRowChart(tableModel, row));
+export function CompareRowCharts({fetchRowChart, activatePinnedCharts, rowLimit=ROW_LIMIT, deriveTraceTitle, slotProps}) {
+    const {tblId, selectedRowIdxs} = useStoreConnector(() => {
+        const tblId = getActiveTableId();
+        const {selectInfo} = getTblInfoById(tblId);
+        const selectedRowIdxs = Array.from(SelectInfo.newInstance(selectInfo).getSelected());
+        return {tblId, selectedRowIdxs};
+    });
+
+    const [selectedRowChartIds, setSelectedRowChartIds] = useState([]);
+    useEffect(()=>{
+        if (selectedRowIdxs.length <= rowLimit) {
+            setSelectedRowChartIds(selectedRowIdxs.map((row) => getRowChart(tblId, row, fetchRowChart))); //promised chartIds
+        }
+    }, [tblId, selectedRowIdxs]);
+
+    const buttonTip = 'Compare selected rows';
+    if (selectedRowIdxs.length > rowLimit) {
+        const content = `Number of rows selected for chart comparison exceeds the limit! Please select ${rowLimit} rows or lesser.`;
+        return (<CombineChartButton onClick={()=>showInfoPopup(content)} tip={buttonTip} {...slotProps?.button}/>);
+    }
 
     return (
         <CombineChart
             chartIds={selectedRowChartIds}
-            allowChartSelection={false} //because user already selected rows before opening dialog
+            showChartSelectionTable={false} //because user already selected rows before opening dialog
             onCombineComplete={activatePinnedCharts}
+            deriveTraceTitle={deriveTraceTitle}
             slotProps={{
-                button: {tip: 'Compare selected rows'},
+                button: {tip: buttonTip},
                 dialog: {title: 'Combine charts in the selected rows'},
                 ...slotProps
             }}/>
@@ -37,5 +61,22 @@ export function CompareRowCharts({fetchRowChart, activatePinnedCharts, slotProps
 CompareRowCharts.propTypes = {
     fetchRowChart: PropTypes.func,
     activatePinnedCharts: PropTypes.func,
+    rowLimit: PropTypes.number,
+    deriveTraceTitle: PropTypes.func,
     slotProps: CombineChart.propTypes.slotProps,
+};
+
+// Local cache of promised chartIds
+const allPromisedChartIds = {};
+
+// Retrieve row chart id from cache if possible because fetching from server is expensive and
+// causes side effects in the UI (like pinned chart viewer may re-render if fetchRowChart adds a chart in the store)
+const getRowChart = (tblId, row, fetchRowChart) => {
+    let promisedChartId = allPromisedChartIds?.[tblId]?.[`rowNum-${row}`];
+    if (!promisedChartId) {
+        const tableModel = getTblById(tblId);
+        promisedChartId = fetchRowChart(tableModel, row);
+        set(allPromisedChartIds, [tblId, `rowNum-${row}`], promisedChartId);
+    }
+    return promisedChartId;
 };

--- a/src/firefly/js/charts/ui/PinnedChartContainer.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartContainer.jsx
@@ -26,7 +26,7 @@ import {useStoreConnector} from '../../ui/SimpleComponent';
 import {Logger} from '../../util/Logger.js';
 import {findGroupByTblId, getActiveTableId, getTblById, monitorChanges} from '../../tables/TableUtil';
 import {TABLE_LOADED, TBL_RESULTS_ACTIVE, TABLE_REMOVE, dispatchActiveTableChanged} from '../../tables/TablesCntlr';
-import {getTblIdFromChart, isChartLoading, uniqueChartId} from '../ChartUtil';
+import {getTblIdFromChart, hasTracesFromSameTable, isChartLoading, uniqueChartId} from '../ChartUtil';
 import {getActiveViewerItemId} from './MultiChartViewer';
 import {ActiveChartsPanel} from './ChartsContainer';
 import {StatefulTabs, switchTab, Tab} from '../../ui/panel/TabPanel';
@@ -220,12 +220,14 @@ function doPinChart({chartId, autoLayout=true }) {
 export const ShowTable = ({viewerId, tbl_group}) => {
 
     const activeTblId = useStoreConnector(() => getActiveTableId());
-    const activeChartTblId = useStoreConnector(() => {
+    const {chartId, activeChartTblId} = useStoreConnector(() => {
         const chartId = getActiveViewerItemId(PINNED_CHART_VIEWER_ID, true);
-        return getTblIdFromChart(chartId);
+        const activeChartTblId = getTblIdFromChart(chartId);
+        return {chartId, activeChartTblId};
     });
 
-    if (viewerId !== PINNED_CHART_VIEWER_ID) return null;
+    // this button should only appear inside pinned charts viewer and when the selected chart has traces' data in the same table
+    if (viewerId !== PINNED_CHART_VIEWER_ID || !hasTracesFromSameTable(chartId)) return null;
 
     const showTable = () => dispatchActiveTableChanged(activeChartTblId, tbl_group);
     const enabled = activeChartTblId !== activeTblId;

--- a/src/firefly/js/metaConvert/vo/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/vo/ServDescConverter.js
@@ -108,5 +108,5 @@ export async function getServiceDescRelatedDataProduct(table, row, threeColorOps
 
 
 
-const findDataLinkServeDescs= (sdAry) => sdAry?.filter( (serDef) => isDataLinkServiceDesc(serDef));
+export const findDataLinkServeDescs= (sdAry) => sdAry?.filter( (serDef) => isDataLinkServiceDesc(serDef));
 


### PR DESCRIPTION
Fixes [IRSA-6111](https://jira.ipac.caltech.edu/browse/IRSA-6111)
Also see: https://github.com/IPAC-SW/irsa-ife/pull/351

- Refactored CombineChart to make it:
   - independent of PinnedChartsContainer, and accept `chartIds` instead
   - handle promises of chartIds (because async fetching of charts is required in Euclid) as well as the loading and error states
   - generic overall and more meaningful names of variables
- Created two specific HOCs of CombineChart:
  1. `CombinePinnedCharts` - to allow existing functionality
  2. `CombineRowCharts` - to allow fetching charts from the selected rows in active table (Euclid's compare sources functionality)
- Bonus: Improved trace titles creation in combined chart - added chart title to trace titles. Old titles that just rely on trace numbering were meaningless because it flattens the traces list nested in charts list so there's no way of telling which trace belong to which chart.

## Testing
### Euclid
https://irsa-6111-compare-sources.irsakudev.ipac.caltech.edu/applications/euclid/

Search by ID -> select Object ID -> Enter `2354019577405107692 2353963395405226961 2353684508405256537 2353952946405260405 2353677340405271646 2354322758405276511 2354215274405166151 2354251826405010397 2353704547404873714 2353721932404932508 2353809153405305199 2353776897404952855 2354281144404971534 2360659649405341842 2360734814404968938 2360651232404669390 2360358793404978811 2360588190404979321 2360776044404861072 2360598910405204293 2360764117405221817 2360527606404894927 2360545771404908021 2360231177404684196 2360503632404903443 2360507038404979260 2360725058404914991 2360357456404777107 2360787580404802683 2360367420404806206 2360734420405222743 2360352268405250703 2360826047404674311 2360513182404968897 2360526211404698268 2360452114404699115 2360882651404702544 2360483160404710523 2360319015404906941 2360582403405020934 2360913088405117008 2360886985404772880 2360311475404993722 2360349765404996732 2360842141405003125 2360238622405013008 2360542602405014725 2360332198405018273 2360625161405264547 2360437631405268102` -> search

#### Main functionality
Select 4-5 rows randomly, and click on venn-diagram button in the table toolbar -> dialog should open with cascading and chart options -> enable cascading -> "ok" should create a combined spectrum in the pinned charts tab. 

#### Edge cases:
- Select all rows in table and click on the compare sources button - it should show an info popup about limit exceeded.
- Add a source ID to the search that doesn't have spectrum associated (I don't know specific example), it should show alert in combine chart dialog that it can't retrieve spectrum (tested this locally)

### Firefly
https://fireflydev.ipac.caltech.edu/irsa-6111-compare-sources/firefly/

Regression test the combine pinned charts functionality: Follow the instructions in https://github.com/Caltech-IPAC/firefly/pull/1499 

Bonus: when switching to single chart view, you can see the trace titles are much clearer than they used to be.