### PR TITLE
FIREFLT-1535: Timeseries bug fix

### DIFF
--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -323,8 +323,7 @@ function chartUpdate(action) {
     return (dispatch) => {
         const {chartId, changes} = action.payload;
         // when selection  is undefined, selections layer must be removed
-        if (changes.hasOwnProperty('selection') && !changes.selection)
-            changes['layout.selections'] = []
+        if (changes.hasOwnProperty('selection') && !changes.selection) changes['layout.selections'] = [];
         // remove any table's mappings from changes because it will be applied by the connectors.
         const changesWithoutTblMappings = omitBy(changes, (v) => isString(v) && v.match(TBL_SRC_PATTERN));
         set(action, 'payload.changes', changesWithoutTblMappings);

--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -280,7 +280,7 @@ export class PlotlyWrapper extends Component {
                         this.restyle(this.div, Plotly, data, dataUpdate, dataUpdateTraces);
                         break;
                     case RenderType.RELAYOUT:
-                        Plotly.relayout(this.div, layoutUpdate);
+                        Plotly.relayout(this.div, layout);
                         break;
                     case RenderType.RESTYLE_AND_RELAYOUT:
                         this.restyle(this.div, Plotly, data, dataUpdate, dataUpdateTraces);
@@ -308,7 +308,7 @@ export class PlotlyWrapper extends Component {
                             chart.on('plotly_relayout', () => this.showMask(false));
                             chart.on('plotly_restyle', () => this.showMask(false));
                             chart.on('plotly_redraw', () => this.showMask(false));
-                            chart.on('plotly_relayout', (changes) => this.syncLayout(chartId, changes));
+                            chart.on('plotly_relayout', (changes) => {this.syncLayout(chartId, changes);});
                         }
                         else {
                             this.showMask(false);

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -73,7 +73,7 @@ export const LcViewer = memo(({menu, dropdownPanels=[], appTitle, slotProps, ...
 
     return (
         <App slotProps={mSlotProps}
-             dropdownPanels={[...dropdownPanels, <UploadPanel {...{fileLocation}}/>]}
+             dropdownPanels={[...dropdownPanels, <UploadPanel {...{fileLocation, name:'LCUpload'}}/>]}
              appTitle={appTitle}  {...appProps}
         >
             <MainView {...{error, displayMode, periodProps}}/>
@@ -154,8 +154,8 @@ function getUploadPanelState(oldState) {
 }
 
 
-export const UploadPanel = ({initArgs, name= 'LCUpload'}) =>{
-    const {missionOptions,fileLocation} = useStoreConnector(getUploadPanelState );
+export const UploadPanel = ({initArgs,name= 'LCUpload'}) =>{
+    const {missionOptions, fileLocation} = useStoreConnector(getUploadPanelState );
     const [,setUploadContainer]= useFieldGroupValue('uploadContainer', vFileKey);
     const externalDropEvent= initArgs?.searchParams?.dropEvent;
 
@@ -239,9 +239,8 @@ export const UploadPanel = ({initArgs, name= 'LCUpload'}) =>{
     );
 };
 
-
 UploadPanel.propTypes = {
-    name: PropTypes.oneOf(['LCUpload']),
+    name: PropTypes.string,
     initArgs: PropTypes.object
 };
 


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1535
- changes are very small, but this is my first time working with plotly, so took some time to figure out the workflow and the issue.
- So we currently update the chart when user applies one of 4 options (grid, top/right, reverse and log) using `Plotly.relayout`, and we send it a `layoutUpdate` (or `layoutDelta` object), which is just the difference of the current and old layout based on user selection instead of the entire layout context (which is the `layout` object)
   - from my research and understanding of this topic: `Plotly.relayout` is great for updates like grid, log, etc. but not for complex stuff like axes reversal. 
   - To fix this, I considered using `Plotly.react`, which re-renders the entire plot though. 
      - After some trial and error, I figured I could just send the entire `layout` context to `Plotly.relayout` instead. This fixes the axes reversal issue. And it is still theoretically better than doing a `Plotly.react` here, because even though I send the entire `layout` object and not just the `layoutDelta` / `layoutUpdate`, `Plotly.relayout` internally only attempts to update the properties that differ from the current layout. 
- Let me know your thoughts on this fix. 

**Testing**: 
Timeseries: https://firefly-1535-timeseries-bug.irsakudev.ipac.caltech.edu/irsaviewer/timeseries
- Test according to ticket (upload the file in the [ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-1535) to timeseries)
- Then click on chart settings -> `Chart Options` 
   - Select and deselect `reverse` for both X and Y axes and click on `Apply` multiple times
      - the bug was that after applying reverse once or twice, it would stop working (the other options: `grid`, `top` and `log` would still work as expected). This should be fixed now. 
  - also select and deselect other options for both axes like `grid`, `log` and `right`/`top`. 
  - essentially, try and play around with the `Options` selections under `Chart Options`.  