### PR TITLE
FIREFLY-1536: Support for standalone dispatchTblResultsAdded to support reordering of tables

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -200,7 +200,7 @@ export function removeTablesFromGroup(tbl_group_id = 'main') {
 
 export function removeTablesByIDs(tblAry) {
     tblAry && tblAry.forEach((tbl_id) => {
-        TblCntlr.dispatchTableRemove(tbl_id, true);        
+        TblCntlr.dispatchTblResultsRemove(tbl_id, true);
     });
 }
 

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -198,12 +198,6 @@ export function removeTablesFromGroup(tbl_group_id = 'main') {
     });
 }
 
-export function removeTablesByIDs(tblAry) {
-    tblAry && tblAry.forEach((tbl_id) => {
-        TblCntlr.dispatchTblResultsRemove(tbl_id, true);
-    });
-}
-
 /**
  * returns an array of tbl_id for the given tbl_group_id
  * @param {string} tbl_group_id    table group name.  defaults to 'main' if not given

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -393,7 +393,6 @@ function tblResultsAdded(action) {
 
             options = Object.assign({tbl_group: 'main', removable: true, setAsActive:true}, options);
             if (options.pageSize)   options.pageSize = fixPageSize(options.pageSize);
-
             if (!TblUtil.getTableInGroup(tbl_id, options.tbl_group)) {
                 tbl_ui_id = tbl_ui_id || TblUtil.uniqueTblUiId();
                 dispatch({type: TBL_RESULTS_ADDED, payload: {tbl_id, title, tbl_ui_id, options}});

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -57,21 +57,11 @@ function handleTableUpdates(root, action, state) {
     const {tbl_ui_id, tbl_id} = action.payload;
     switch (action.type) {
         case (Cntlr.TABLE_REMOVE)    :
-        case (Cntlr.TBL_RESULTS_REMOVE)    :
             return removeTable(root, action);
 
         case (Cntlr.TBL_RESULTS_ADDED) :
-            const tblModel = get(state, ['data', tbl_id]);
             const options = onUiUpdate(get(action, 'payload.options', {}));
-            root = updateSet(root, [tbl_ui_id], {tbl_ui_id, tbl_id, triggeredBy: 'byTable', ...options});
-
-            //This handles the case where: if tblModel exists, and table is fully loaded, TBL_RESULTS_ADDED
-            //may have been called standalone (without a previous dispatchTableFetch), so update the ui state.
-            if (tblModel && isTableLoaded(tblModel)) {
-                console.log('just checking not in here');
-                root = uiStateReducer(root, get(state, ['data', tbl_id]), action.type);
-            }
-            return root;
+            return updateMerge(root, [tbl_ui_id], {tbl_ui_id, tbl_id, triggeredBy: 'byTable', ...options});
 
         case (Cntlr.TABLE_FETCH)      :
         case (Cntlr.TABLE_FILTER)      :

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -5,7 +5,7 @@
 import React, {useEffect} from 'react';
 import {Box, Stack, Typography, Sheet, ChipDelete, Tooltip, Button} from '@mui/joy';
 import PropTypes, {object, shape} from 'prop-types';
-import {defer, truncate, get, set, isUndefined, defaults, isString} from 'lodash';
+import {defer, truncate, get, set, defaults, isString} from 'lodash';
 import {getAppOptions, getSearchActions} from '../../core/AppDataCntlr.js';
 import {ActionsDropDownButton, isTableActionsDropVisible} from '../../ui/ActionsDropDownButton.jsx';
 
@@ -13,10 +13,8 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {ToolbarButton, ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
 import {ExpandButton, InfoButton, SaveButton, FilterButton, ClearFilterButton, TextViewButton, TableViewButton, SettingsButton, PropertySheetButton} from '../../visualize/ui/Buttons.jsx';
 import {dispatchTableRemove, dispatchTblExpanded, dispatchTableFetch, dispatchTableAddLocal, dispatchTableUiUpdate} from '../TablesCntlr.js';
-import {
-    uniqueTblId, getTableUiById, makeBgKey, getResultSetRequest, isClientTable, getTableState,
-    TBL_STATE, getMetaEntry, getTblById, parseError, isOverflow, getResultSetID
-} from '../TableUtil.js';
+import {uniqueTblId, getTableUiById, makeBgKey, getResultSetRequest, isClientTable, getTableState,
+    TBL_STATE, getMetaEntry, getTblById, parseError, isOverflow, getResultSetID} from '../TableUtil.js';
 import {TablePanelOptions} from './TablePanelOptions.jsx';
 import {BasicTableView} from './BasicTableView.jsx';
 import {TableInfo, MetaInfo} from './TableInfo.jsx';


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1536
**IFE-PR**: https://github.com/IPAC-SW/irsa-ife/pull/352

- This PR enables calling `dispatchTblResultsAdded` by itself, indirectly enabling re ordering tables 
    - by removing table from results view by calling `dispatchTblResultsRemove` and then by calling `dispatchTblResultsAdded` when you need to re-add this table in the order you want

**Testing**: 
- Euclid: https://firefly-1536-euclid-reorder-tbls.irsakudev.ipac.caltech.edu/applications/euclid
- Start by doing an Explore Regions search, Inspect Sources search & catalog searches 
- Click on the `Show Results` toggle buttons, if tables are being removed and added back to the results view as expected, then this is working. 