### PR TITLE
FIREFLY-1548 fix-irsa-app-search-cleanup-issue

### DIFF
--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -10,6 +10,7 @@ import Point, {isValidPoint} from '../visualize/Point.js';
 import {getModuleName, getProp, getRootURL, isFullURL} from '../util/WebUtil.js';
 import {dispatchRemoteAction} from './JsonUtils.js';
 import {getWsConn} from './messaging/WebSocketClient';
+import {getLayouInfo} from 'firefly/core/LayoutCntlr';
 
 export const APP_DATA_PATH = 'app_data';
 export const COMMAND = 'COMMAND';
@@ -211,6 +212,11 @@ export function getSearchInfo() {
     return Object.assign({}, searchInfo, {activeSearch});
 }
 
+export function getSearchByName(name) {
+    const {allSearchItems={}} = getSearchInfo();
+    return allSearchItems[name];
+}
+
 export function getMenu() {
     return get(flux.getState(), [APP_DATA_PATH, 'menu']);
 }
@@ -294,6 +300,23 @@ export function getWsChannel(baseUrl) {
  */
 export function getWsConnId(baseUrl) {
     return getWsConn(baseUrl)?.connId;
+}
+
+/**
+ * Returns the name/action of the select menu item.  If not set, it will determine what it should be
+ * @param {object} menu
+ * @param {object} dropDown
+ * @returns {string} the name/action selected menu item
+ */
+export function getSelectedMenuItem(menu,dropDown) {
+    menu ??= getMenu();
+    dropDown ??= getLayouInfo()?.dropDown;
+    // if (!menu || !dropDown?.visible) return '';
+    if (!menu) return '';
+    if (menu.selected) return menu.selected;
+    let selected = menu.menuItems?.find(({action}) => (action===dropDown?.view))?.action;
+    if (!selected && dropDown?.visible) selected = menu.menuItems[0].action;
+    return selected;
 }
 
 

--- a/src/firefly/js/templates/hydra/HydraManager.js
+++ b/src/firefly/js/templates/hydra/HydraManager.js
@@ -3,19 +3,20 @@
  */
 import {take, fork} from 'redux-saga/effects';
 
-import {SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo,
-        dispatchSetLayoutInfo, dropDownManager} from '../../core/LayoutCntlr.js';
+import {
+    SHOW_DROPDOWN, SET_LAYOUT_MODE, getLayouInfo,
+    dispatchSetLayoutInfo, dropDownManager, getResultCounts
+} from '../../core/LayoutCntlr.js';
 import {removeChartsInGroup} from '../../charts/ChartsCntlr.js';
-import {TABLE_SEARCH, TBL_RESULTS_ADDED, TABLE_REMOVE, TABLE_LOADED, TBL_RESULTS_ACTIVE
+import {TABLE_SEARCH, TBL_RESULTS_ADDED, TABLE_REMOVE
 } from '../../tables/TablesCntlr.js';
 import {visRoot, dispatchDeletePlotView} from '../../visualize/ImagePlotCntlr.js';
-import {removeTablesFromGroup, getAllTableGroupIds, smartMerge, getTblById} from '../../tables/TableUtil.js';
-import {getSearchInfo} from '../../core/AppDataCntlr.js';
+import {removeTablesFromGroup, getAllTableGroupIds, smartMerge} from '../../tables/TableUtil.js';
+import {getSearchByName, getSearchInfo, getSelectedMenuItem} from '../../core/AppDataCntlr.js';
 import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
 import {CHART_ADD} from '../../charts/ChartsCntlr.js';
 import {REPLACE_VIEWER_ITEMS} from '../../visualize/MultiViewCntlr.js';
 import {deleteAllDrawLayers} from '../../visualize/DrawLayerCntlr';
-import {MetaConst} from 'firefly/data/MetaConst';
 
 /**
  * Configurable part of this template
@@ -56,13 +57,13 @@ export function* hydraManager() {
         newLayoutInfo = smartMerge(layoutInfo, {showImages, showXyPlots, showTables});
 
         switch (action.type) {
-            case TBL_RESULTS_ADDED:
-            case TABLE_LOADED:
-            case TBL_RESULTS_ACTIVE:
-                const tbl = getTblById(action.payload.tbl_id);
-                if (tbl?.request?.META_INFO?.[MetaConst.UPLOAD_TABLE]) break; //to not change layoutInfo if it is an upload table
-                //intentional fallthrough
-            case CHART_ADD:
+            // case TBL_RESULTS_ADDED:
+            // case TABLE_LOADED:
+            // case TBL_RESULTS_ACTIVE:
+            //     const tbl = getTblById(action.payload.tbl_id);
+            //     if (tbl?.request?.META_INFO?.[MetaConst.UPLOAD_TABLE]) break; //to not change layoutInfo if it is an upload table
+            //     //intentional fallthrough
+            // case CHART_ADD:
             case TABLE_SEARCH:
                 newLayoutInfo = handleNewSearch(newLayoutInfo, action);
                 break;
@@ -86,22 +87,28 @@ export function* hydraManager() {
 function handleNewSearch(layoutInfo, action) {
 
     const {currentSearch} = layoutInfo;
-    const {activeSearch} = getSearchInfo();
-    var {showTables=true, showXyPlots=true, showImages=true, images={}} = layoutInfo;
 
-    // checking the table search is IRSA catalog search or External search
-    // only do cleanup for new app searches
-    if (currentSearch && currentSearch !== activeSearch &&
-        layoutInfo.dropDown.menuItem.category !== 'IRSA search tabs'
-        && layoutInfo.dropDown.menuItem.category !== 'External archive search tabs') {
+    if (!getResultCounts()?.haveResults) {
+        // if no results, setup layout with init values;
+        layoutInfo = { ...layoutInfo, showTables:true, showXyPlots:true, showImages:true, currentSearch: getSearchInfo()?.activeSearch};
+    }
+    //reset image object for every new search
+    layoutInfo = { ...layoutInfo, images: undefined};
+
+    // below logic applies only to searches that uses Hydra's SearchInfo
+    // ignore if selectedMenuItem is not one of SearchInfo
+    const selectMenuItem = getSelectedMenuItem();
+    const isSearchCmdSelected = !!getSearchByName(selectMenuItem);
+    if (! isSearchCmdSelected) return layoutInfo;
+
+    if (currentSearch && currentSearch !== selectMenuItem ) {
         cleanup();
         // remove all charts
         removeChartsInGroup();
-        showTables=showXyPlots=showImages=true;
+        layoutInfo = { ...layoutInfo, showTables:true, showXyPlots:true, showImages:true};
     }
-    //reset image object for every new search
-    images= undefined;
-    layoutInfo = Object.assign({}, layoutInfo, {showTables, showXyPlots, showImages, currentSearch:activeSearch, images});
+
+    layoutInfo = { ...layoutInfo, currentSearch:selectMenuItem};
     return layoutInfo;
 }
 

--- a/src/firefly/js/templates/hydra/HydraManager.js
+++ b/src/firefly/js/templates/hydra/HydraManager.js
@@ -89,7 +89,11 @@ function handleNewSearch(layoutInfo, action) {
     const {activeSearch} = getSearchInfo();
     var {showTables=true, showXyPlots=true, showImages=true, images={}} = layoutInfo;
 
-    if (currentSearch && currentSearch !== activeSearch ) {
+    // checking the table search is IRSA catalog search or External search
+    // only do cleanup for new app searches
+    if (currentSearch && currentSearch !== activeSearch &&
+        layoutInfo.dropDown.menuItem.category !== 'IRSA search tabs'
+        && layoutInfo.dropDown.menuItem.category !== 'External archive search tabs') {
         cleanup();
         // remove all charts
         removeChartsInGroup();

--- a/src/firefly/js/ui/Menu.jsx
+++ b/src/firefly/js/ui/Menu.jsx
@@ -11,8 +11,10 @@ import {tabClasses} from '@mui/joy/Tab';
 import {debounce} from 'lodash';
 import React, {forwardRef, memo, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import shallowequal from 'shallowequal';
-import { COMMAND, dispatchAddPreference, dispatchSetMenu,
-    getMenu, getPreference, getUserInfo } from '../core/AppDataCntlr.js';
+import {
+    COMMAND, dispatchAddPreference, dispatchSetMenu,
+    getMenu, getPreference, getSelectedMenuItem, getUserInfo
+} from '../core/AppDataCntlr.js';
 import {getBackgroundInfo, isActive} from '../core/background/BackgroundUtil.js';
 import {flux} from '../core/ReduxFlux.js';
 import {dispatchHideDropDown, dispatchShowDropDown, getLayouInfo, getResultCounts} from '../core/LayoutCntlr.js';
@@ -59,7 +61,7 @@ export function Menu() {
     const {menuItems=[], showBgMonitor=true} = menu;
     const layoutInfo= getLayouInfo() ?? {};
     const {dropDown={}}=  layoutInfo;
-    const selected= getSelected(menu,dropDown);
+    const selected= getSelectedMenuItem(menu,dropDown);
 
     useEffect(() => {
         const doResize= () => setWindowWidth(window.innerWidth);
@@ -269,15 +271,6 @@ function itemVisible(menuItem) {
     return visible ?? primary;
 }
 
-function getSelected(menu,dropDown) {
-    // if (!menu || !dropDown?.visible) return '';
-    if (!menu) return '';
-    if (menu.selected) return menu.selected;
-    let selected = menu.menuItems?.find(({action}) => (action===dropDown?.view))?.action;
-    if (!selected && dropDown?.visible) selected = menu.menuItems[0].action;
-    return selected;
-}
-
 function updateMenu(appTitle, menu) {
     const pref= menu.menuItems
         .map( (mi)  => [mi.action, Boolean(mi.visible ?? mi.primary)] );
@@ -390,7 +383,7 @@ export function SideBarMenu({closeSideBar, allowMenuHide}) {
     const uploadItem= menu.menuItems?.find(({action}) => action===UploadCmd);
     const menuItems= menu.menuItems?.filter(({type,action}) => type !== COMMAND && action!==UploadCmd);
     const {dropDown={visible:false}}= getLayouInfo() ?? {};
-    const selected= getSelected(menu,dropDown);
+    const selected= getSelectedMenuItem(menu,dropDown);
     const categoryList= menuItems ? [...new Set(menuItems.map( (mi) => mi.category ?? ''))] : [];
 
     return (


### PR DESCRIPTION
View [ ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-1548) for details.
By adding checks for none app searches from: `IRSA search tabs` and `External archive search tabs`, the previous search results are cleaned out for new app search only.
To test:
https://firefly-1548-sofia.irsakudev.ipac.caltech.edu/applications/sofia
https://firefly-1548-wiseirsakudev.ipac.caltech.edu/applications/wise
https://firefly-1548-ztf.ipac.caltech.edu/applications/ztf
https://firefly-1548-sha.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/
https://firefly-1548-euclid.irsakudev.ipac.caltech.edu/applications/euclid/

go to any of above IRSA app, ie. sofia, wise, ztf,
* make a position search (or any app search)
* navigate to a different search (without submit search), then go do a Catalog search (or any none app search), your catalog search result should be added as a tab to your previous search result.
* if you do a different app search, the results are for the new search, previous results are cleaned out.