### PR TITLE
Firefly 1533 runid jobname

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -51,6 +51,7 @@ public class JobInfo implements Serializable {
     private String dataOrigin;
     private boolean monitored;
     private String label;
+    private String localRunId;
 
     // not sent to client
     private String eventConnId;
@@ -151,30 +152,29 @@ public class JobInfo implements Serializable {
     public void setQuote(Instant time) { quote = time; }
 
     public Job.Type getType() { return type; }
-
     public void setType(Job.Type type) { this.type = type; }
 
     public String getEventConnId() { return eventConnId; }
-
     public void setEventConnId(String eventConnId) { this.eventConnId = eventConnId; }
 
     public boolean isMonitored() { return monitored;}
-
     public void setMonitored(boolean monitored) {
         this.monitored = monitored;
     }
-
-
-    public int getProgress() { return progress; }
 
     /**
      * a number between 0 and 100 representing the job's percentage of completion.
      * @param progress
      */
     public void setProgress(int progress) { this.progress = Math.min(Math.max(progress, 0), 100); }
+    public int getProgress() { return progress; }
 
     public String getProgressDesc() { return progressDesc; }
     public void setProgressDesc(String progressDesc) { this.progressDesc = progressDesc;}
+
+    // Not all services support UWS RUNID.  Store info here instead.
+    public String getLocalRunId() { return localRunId; }
+    public void setLocalRunId(String localRunId) { this.localRunId = localRunId;}
 
     public void addResult(Result result) { results.add(result);}
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -215,6 +215,7 @@ public class JobManager {
         applyIfNotEmpty(info.getProgressDesc(),   v -> addtlInfo.put("progressDesc", v));
         applyIfNotEmpty(info.getDataOrigin(), v -> addtlInfo.put("dataOrigin", v));
         applyIfNotEmpty(info.getSummary(),   v -> addtlInfo.put("summary", v));
+        applyIfNotEmpty(info.getLocalRunId(),   v -> addtlInfo.put("localRunId", v));
 
         return rval;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/IpacTableHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/IpacTableHandler.java
@@ -9,6 +9,8 @@ import edu.caltech.ipac.table.io.IpacTableReader;
 import org.apache.commons.httpclient.HttpMethod;
 import edu.caltech.ipac.firefly.server.network.HttpServices.Status;
 
+import static edu.caltech.ipac.firefly.server.network.HttpServices.getResponseBodyAsStream;
+
 /**
  * Date: 7/7/22
  *
@@ -21,7 +23,7 @@ public class IpacTableHandler implements HttpServices.Handler {
     public HttpServices.Status handleResponse(HttpMethod method) {
         if (HttpServices.isOk(method)) {
             try {
-                results = IpacTableReader.read(method.getResponseBodyAsStream());
+                results = IpacTableReader.read(getResponseBodyAsStream(method));
             } catch (Exception e) {
                 return new Status(400, String.format("Error reading IPAC table: %s", e.getMessage()));
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
@@ -33,14 +33,14 @@ public class AsyncTapQuery extends UwsJobProcessor {
 
     // links taken from src/firefly/js/ui/tap/TapKnownServices.js#makeServices
     private static final List<String> SVC_RUNID_NOT_SUPPORTED = Arrays.asList(
-            "https://irsa.ipac.caltech.edu/TAP",                // Return exception, BAD_REQUEST: RUNID not implemented
-            "https://exoplanetarchive.ipac.caltech.edu/TAP/",   // Bad implementation. it replaces it with its own identifier, e.g. 109294
-            "https://koa.ipac.caltech.edu/TAP/",                // Bad implementation. it replaces it with its own identifier, e.g. 109294
-            "https://heasarc.gsfc.nasa.gov/xamin/vo/tap",       // Accepted the parameter, but did not return its value
-            "https://vao.stsci.edu/CAOMTAP/TapService.aspx",    // Accepted the parameter, but did not return its value
-            "https://gea.esac.esa.int/tap-server/tap",          // Accepted the parameter, but did not return its value
-            "https://dc.g-vo.org/tap",                          // Accepted the parameter, but did not return its value
-            "https://archives.esac.esa.int/hsa/whsa-tap-server/tap"     // Accepted the parameter, but did not return its value
+            "https://irsa.ipac.caltech.edu/TAP"                // Return exception, BAD_REQUEST: RUNID not implemented
+//            "https://exoplanetarchive.ipac.caltech.edu/TAP/",   // Bad implementation. it replaces it with its own identifier, e.g. 109294
+//            "https://koa.ipac.caltech.edu/TAP/",                // Bad implementation. it replaces it with its own identifier, e.g. 109294
+//            "https://heasarc.gsfc.nasa.gov/xamin/vo/tap",       // Accepted the parameter, but did not return its value
+//            "https://vao.stsci.edu/CAOMTAP/TapService.aspx",    // Accepted the parameter, but did not return its value
+//            "https://gea.esac.esa.int/tap-server/tap",          // Accepted the parameter, but did not return its value
+//            "https://dc.g-vo.org/tap",                          // Accepted the parameter, but did not return its value
+//            "https://archives.esac.esa.int/hsa/whsa-tap-server/tap"     // Accepted the parameter, but did not return its value
     );
 
     public HttpServiceInput createInput(TableServerRequest request) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
@@ -8,10 +8,12 @@ import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.table.DataGroup;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static edu.caltech.ipac.firefly.server.query.AsyncTapQuery.*;
 import static edu.caltech.ipac.firefly.server.query.DaliUtil.*;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
-
 
 @SearchProcessorImpl(id = AsyncTapQuery.ID, params = {
         @ParamDoc(name = SVC_URL, desc = "base TAP url endpoint excluding '/async'"),
@@ -29,19 +31,38 @@ public class AsyncTapQuery extends UwsJobProcessor {
     public static final String SVC_URL = "serviceUrl";
     public static final String UPLOAD_TNAME = "adqlUploadSelectTable";
 
-
+    // links taken from src/firefly/js/ui/tap/TapKnownServices.js#makeServices
+    private static final List<String> SVC_RUNID_NOT_SUPPORTED = Arrays.asList(
+            "https://irsa.ipac.caltech.edu/TAP",                // Return exception, BAD_REQUEST: RUNID not implemented
+            "https://exoplanetarchive.ipac.caltech.edu/TAP/",   // Bad implementation. it replaces it with its own identifier, e.g. 109294
+            "https://koa.ipac.caltech.edu/TAP/",                // Bad implementation. it replaces it with its own identifier, e.g. 109294
+            "https://heasarc.gsfc.nasa.gov/xamin/vo/tap",       // Accepted the parameter, but did not return its value
+            "https://vao.stsci.edu/CAOMTAP/TapService.aspx",    // Accepted the parameter, but did not return its value
+            "https://gea.esac.esa.int/tap-server/tap",          // Accepted the parameter, but did not return its value
+            "https://dc.g-vo.org/tap",                          // Accepted the parameter, but did not return its value
+            "https://archives.esac.esa.int/hsa/whsa-tap-server/tap"     // Accepted the parameter, but did not return its value
+    );
 
     public HttpServiceInput createInput(TableServerRequest request) throws DataAccessException {
         var serviceUrl = request.getParam(SVC_URL);
         var uploadTable= request.getParam(UPLOAD_TNAME);
+        boolean runIdSupported = !SVC_RUNID_NOT_SUPPORTED.contains(serviceUrl);
 
         HttpServiceInput inputs = HttpServiceInput.createWithCredential(serviceUrl + "/async");
         DaliUtil.handleMaxrec(inputs, request);
         DaliUtil.handleUpload(inputs, request, uploadTable);
 
         applyIfNotEmpty(request.getParam(QUERY), (v) -> inputs.setParam(QUERY, v));
+        // use table's title as RUNID.  RUNID is limited to 64 chars.  If more than 64, truncate then add '...' to indicate it was truncated.
+        applyIfNotEmpty(request.getMeta("title"), (v) -> {
+            String runId = v.length() > 64 ? v.substring(0, 61) + "..." : v;
+            // only send RUNID if it's supported.
+            if (runIdSupported)     inputs.setParam(RUNID, runId);
+            getJob().getJobInfo().setLocalRunId(runId);        // save the value locally for display
+        });
         inputs.setParam(LANG, request.getParam(LANG, "ADQL"));
         inputs.setParam(REQUEST, "doQuery");
+
         return inputs;
     }
 

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -18,8 +18,8 @@ const popupSx = {
     justifyContent: 'space-between',
     resize: 'both',
     overflow: 'auto',
-    minHeight: 200, minWidth: 450,
-    width: '45vh', height: '45wh'
+    minHeight: 200, minWidth: 500,
+    width: '45vh'
 };
 
 export function showJobInfo(jobId) {
@@ -92,7 +92,7 @@ function DataOrigin({dataOrigin, type, jobId}) {
     return (
         <Stack direction='row' spacing={1}>
             <KeywordBlock sx={{width: 425, alignItems:'center'}} label={label} value={dataOrigin} asLink={true}/>
-            <Button ml={1/2} size='sm' onClick={() => showUwsJob({jobId})}>Show</Button>
+            <Button ml={1/2} size='sm' onClick={() => showUwsJob({jobId, jobUrl:dataOrigin})}>Show</Button>
         </Stack>
     );
 }

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -159,7 +159,7 @@ const ShowObjectTreeBtn = ({data, title}) => {
 
 export function KeywordBlock({sx={}, label, value, title, asLink}) {
     return (
-        <Stack direction='row' display='inline-flex' alignItems='baseline' sx={sx}>
+        <Stack direction='row' whiteSpace='nowrap' alignItems='baseline' sx={sx}>
             <Keyword {...{label, value, title, asLink}}/>
         </Stack>
     );

--- a/src/firefly/js/ui/PopupPanel.jsx
+++ b/src/firefly/js/ui/PopupPanel.jsx
@@ -120,7 +120,7 @@ function PopupLayout({modal,zIndex,left,top,visibility,ctxRef,dialogMoveStart,di
                         position: 'absolute',
                         p:.5,
                         visibility,
-                        userSelect : 'none',
+                        // userSelect : 'none',                                         // not sure why this was needed.  we'll comment out until it becomes a problem.
                         boxShadow: `1px 1px 5px ${theme.vars.palette.primary.softActiveColor}`,
                         '& .ff-dialog-title-bar' : { cursor:'grab' },
                         '& .ff-dialog-title-bar:active' : { cursor:'grabbing' }

--- a/src/firefly/js/ui/tap/TapKnownServices.js
+++ b/src/firefly/js/ui/tap/TapKnownServices.js
@@ -28,11 +28,11 @@ function makeServices() {
         tapEntry('MAST Images', 'https://vao.stsci.edu/CAOMTAP/TapService.aspx'),
         tapEntry('CADC', 'https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/argus/'),
         // CDS???
-        tapEntry('VizieR (CDS)', 'http://tapvizier.u-strasbg.fr/TAPVizieR/tap/'),
+        tapEntry('VizieR (CDS)', 'https://tapvizier.u-strasbg.fr/TAPVizieR/tap/'),
         tapEntry('Simbad (CDS)', 'https://simbad.u-strasbg.fr/simbad/sim-tap'),
         // more ESA??
         tapEntry('Gaia', 'https://gea.esac.esa.int/tap-server/tap',undefined,undefined,undefined, undefined, gaiaExamples()),
-        tapEntry('GAVO', 'http://dc.g-vo.org/tap'),
+        tapEntry('GAVO', 'https://dc.g-vo.org/tap'),
         tapEntry('HSA',  'https://archives.esac.esa.int/hsa/whsa-tap-server/tap'),
     ];
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1533

- attaching a RUNID to the submission when TAP service supports it.
- save information local for display
- filling it in with the user-specified value
- displaying it in the job-status dialog
- displaying it in the table-info dialog

Test: https://fireflydev.ipac.caltech.edu/firefly-1533-runid-jobname/firefly/
- do a TAP search
- [optional] enter a custom title.  (bottom of form next to Search and Row Limit)
- while in progress, click on 'i' icon to see Job Information, then 'Show' to see UWS Job info.
- once table results returned, click on 'i' table info to see 'Job Info', then 'Show' to see UWS Job info.

Notes:
- most of the predefined TAP services do not properly support this.
- RUNID is limited to 64 chars.  If more than 64, truncate then add '...' to indicate it was truncated.
- when it is not supported, our UWS Job popup may show a different value than if you click the link that takes you to their job info url.
