### PR TITLE
FIREFLY-1552: IpacTableFromSource processor unnecessarily re-fetches data

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -596,8 +596,8 @@ abstract public class BaseDbAdapter implements DbAdapter {
                 shutdown(db);
             } finally {
                 db.getLock().unlock();
+                getDbInstances().remove(db.getDbFile().getPath());
             }
-            getDbInstances().remove(db.getDbFile().getPath());
         }
         if (deleteFile) removeDbFile();
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbMonitor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbMonitor.java
@@ -119,8 +119,8 @@ class DbMonitor {
 
             // remove expired search results
             List<DbAdapter.EmbeddedDbInstance> toBeRemove = dbInstances.values().stream()
-                    .filter((db) -> db.hasExpired() || force).collect(Collectors.toList());
-            if (toBeRemove.size() > 0) {
+                    .filter((db) -> db.hasExpired() || force).toList();
+            if (!toBeRemove.isEmpty()) {
                 LOGGER.info("There are currently %d databases open.  Of which, %d will be closed.".formatted(dbInstances.size(), toBeRemove.size()));
                 toBeRemove.forEach((db) -> DbAdapter.getAdapter(db.getDbFile()).close(deleteFile));
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
@@ -114,8 +114,11 @@ public class DuckDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterC
 
     protected void shutdown(EmbeddedDbInstance db) {}
     protected void removeDbFile() {
-        if (!getDbFile().delete()) {
-            LOGGER.trace("Unable to remove duckdb file:" + getDbFile().getAbsolutePath());
+        var dbFile = getDbFile();
+        if (dbFile.exists()) {
+            if (!dbFile.delete()) {
+                LOGGER.trace("Unable to remove duckdb file:" + dbFile.getAbsolutePath());
+            }
         }
     }
     /*------------------*/

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
@@ -44,10 +44,11 @@ public abstract class DuckDbReadable extends DuckDbAdapter {
      * Convert this file name into duckdb file extension, then set it as this Adapter's dbFile
      * @param srcFile
      */
-    public void useDbFileFrom(File srcFile) {
+    public DuckDbReadable useDbFileFrom(File srcFile) {
         var ext = StringUtils.groupMatch("(.+)\\.(.+)$", srcFile.getName());
         String fname = (ext == null ? srcFile.getName() : ext[0]) + "." + DuckDbAdapter.NAME;
         this.dbFile = new File(srcFile.getParentFile(), fname);
+        return this;
     }
 
     public static TableUtil.Format guessFileFormat(File srcFile) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.SortedSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static edu.caltech.ipac.firefly.data.TableServerRequest.FF_SESSION_ID;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
@@ -92,12 +94,36 @@ public interface SearchProcessor<Type> {
         public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException;
     }
 
-
     /**
      * Date: 9/13/17
      *
      */
     interface CanGetDataFile {
         File getDataFile(TableServerRequest request) throws IpacTableException, IOException, DataAccessException;
+    }
+
+    class SynchronizedAccess {
+        private final ConcurrentHashMap<String, ReentrantLock> activeRequests = new ConcurrentHashMap<>();
+
+        /**
+         * Acquires a lock associated with the given ID. If the lock does not already exist, it is created.
+         *
+         * @param id the identifier for the lock
+         * @return a {@code Runnable} that, when executed, releases the lock and removes it from the active requests
+         */
+        public Runnable lock(String id) {
+            ReentrantLock lock = activeRequests.computeIfAbsent(id, k -> new ReentrantLock());
+            Logger.getLogger().trace("waiting %s: %s\n".formatted(id, lock));
+            lock.lock();
+            Logger.getLogger().trace("got lock %s: %s\n".formatted(id, lock));
+            return () -> {
+                try {
+                    lock.unlock();              // Ensure lock is released even if an exception occurs
+                } finally {
+                    if (!lock.isLocked()) activeRequests.remove(id);  // Remove the lock from activeRequests if no threads are using it
+                    Logger.getLogger().trace("unlock %s: %s\n".formatted(id, lock));
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1552

IpacTableFromSource was fetching data from the URL again, even though the database for this request already exists. This can be observed through network activity in Chrome DevTools or by checking the logs.

Test: https://firefly-1552-ipacfromsource-cache.irsakudev.ipac.caltech.edu/irsaviewer/dce
- Select a position, then click Submit.
