### PR TITLE
Firelfy-1558: Save user add TAP servers as a preference and show it in the list.

### DIFF
--- a/src/firefly/html/test/test-hips-mocs.html
+++ b/src/firefly/html/test/test-hips-mocs.html
@@ -217,7 +217,7 @@
     </script>
 </template>
 
-<template title="Load a MOC" style='height: 400px' class="tpl lg " >
+<template title="Load a MOC as Fill" style='height: 400px' class="tpl lg " >
     <div id="expected" >
         <div class="source-code indent-3">
             - load a HiPS

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/Counters.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/Counters.java
@@ -11,6 +11,7 @@ package edu.caltech.ipac.firefly.server;
 
 import edu.caltech.ipac.firefly.server.security.SsoAdapter;
 import edu.caltech.ipac.firefly.server.util.VersionUtil;
+import edu.caltech.ipac.firefly.server.visualize.VisContext;
 import edu.caltech.ipac.util.ComparisonUtil;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
@@ -228,7 +229,9 @@ public class Counters {
         addMemStrToList(retList,"Free Active", FileUtil.getSizeAsString(sInfo.jvmFree()));
         addMemStrToList(retList,"Total Active", FileUtil.getSizeAsString(sInfo.jvmTotal()));
         retList.add("");
-        retList.add("Cores - "+ Runtime.getRuntime().availableProcessors());
+        retList.add("Limits");
+        addToList(retList, "Cores", Runtime.getRuntime().availableProcessors());
+        addToList(retList, "Max FITS File size", FileUtil.getSizeAsString(VisContext.FITS_MAX_SIZE));
         retList.add("");
     }
 
@@ -237,6 +240,7 @@ public class Counters {
         retList.add("Version Information");
         VersionUtil.getVersionInfo().forEach(verInfoKeyVal ->
                 addToList(retList, verInfoKeyVal.getKey(), verInfoKeyVal.getValue()));
+        addToList(retList,"Java Version", System.getProperty("java.version"));
         retList.add("");
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/VosiCapabilityRetrieve.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/VosiCapabilityRetrieve.java
@@ -39,7 +39,7 @@ public class VosiCapabilityRetrieve {
                 TapCapability tc=  h.getTapCapability();
                 return new Capabilities(tc);
             } catch (FailedRequestException | IOException | SAXException | ParserConfigurationException e) {
-                _log.warn(e, "Coule not parse capabilities");
+                _log.warn(e, "Could not parse capabilities");
             }
         } catch (IOException e) {
             _log.warn(e, "Could not parse capabilities");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -220,7 +220,7 @@ public class VisServerOps {
 
     public static WebPlotResult crop(PlotState[] stateAry, ImagePt c1, ImagePt c2, boolean cropMultiAll) {
         List<WebPlotResult> resultsList= Arrays.stream(stateAry).map((s) -> crop(s, c1, c2, cropMultiAll)).toList();
-        boolean success= resultsList.stream().filter(r -> !r.success()).toList().size()==0;
+        boolean success= resultsList.stream().filter(r -> !r.success()).toList().isEmpty();
         WebPlotResult result = WebPlotResult.make(WebPlotResult.RESULT_ARY, resultsList.toArray(new WebPlotResult[0]));
         return success ? result : resultsList.get(0);
     }

--- a/src/firefly/js/drawingLayers/HiPSMOC.js
+++ b/src/firefly/js/drawingLayers/HiPSMOC.js
@@ -111,10 +111,8 @@ function loadMocFitsWatcher(action, cancelSelf, params, dispatch, getState) {
  */
 function creator(initPayload) {
 
-    const defStyle= Style.get(getAppOptions().hips.mocDefaultStyle) ??Style.DESTINATION_OUTLINE;
     const drawingDef= makeDrawingDef(colorList[idCnt%colorN],
-                                     {style: defStyle,
-                                      textLoc: TextLocation.CENTER,
+                                     {textLoc: TextLocation.CENTER,
                                       canUseOptimization: true});
     idCnt++;
     const options= {
@@ -139,9 +137,23 @@ function creator(initPayload) {
 
     const preloadedTbl= tablePreloaded && getTblById(tbl_id);
     drawingDef.color = preloadedTbl?.tableMeta?.[MetaConst.DEFAULT_COLOR] ?? defColors[mocGroupDefColorId] ?? color;
-    drawingDef.style = Style.get(preloadedTbl?.tableMeta?.[MetaConst.MOC_DEFAULT_STYLE] ?? defStyle);
-
-
+    const defStyle= getAppOptions().hips.mocDefaultStyle ?? 'outline';
+    const inStyleStr= getMetaEntry(preloadedTbl, MetaConst.MOC_DEFAULT_STYLE, defStyle).toLowerCase();
+    switch (inStyleStr) {
+        case 'moc tile outline':
+        case 'tile outline':
+        case 'tile_outline':
+            drawingDef.style= Style.STANDARD;
+            break;
+        case 'fill':
+            drawingDef.style= Style.FILL;
+            break;
+        case 'outline':
+        case 'destination_outline':
+        default:
+            drawingDef.style= Style.DESTINATION_OUTLINE;
+            break;
+    }
 
     const dl = DrawLayer.makeDrawLayer( id, TYPE_ID, get(initPayload, 'title', MocPrefix +id.replace('_moc', '')),
                                         options, drawingDef, actionTypes);

--- a/src/firefly/js/drawingLayers/WebGrid.js
+++ b/src/firefly/js/drawingLayers/WebGrid.js
@@ -5,7 +5,7 @@
  */
 
 
-import  {get, isBoolean, isEmpty} from 'lodash';
+import  {get, isBoolean} from 'lodash';
 import {clone, isDefined} from '../util/WebUtil.js';
 import ImagePlotCntlr, {visRoot} from '../visualize/ImagePlotCntlr.js';
 import {makeDrawingDef} from '../visualize/draw/DrawingDef.js';
@@ -24,7 +24,7 @@ import CoordinateSys from '../visualize/CoordSys.js';
 
 export const COORDINATE_PREFERENCE = 'coordinate';
 
-const  coordinateArray = [
+const coordinateArray = [
      {coordName:'eq2000hms',        csys:CoordinateSys.EQ_J2000},
      {coordName:'eq2000dcm',        csys:CoordinateSys.EQ_J2000},
      {coordName:'eqb1950hms',       csys:CoordinateSys.EQ_B1950},
@@ -54,10 +54,10 @@ var idCnt=0;
  */
 function creator(params) {
 
-    var drawingDef= makeDrawingDef( DEF_GRID_COLOR);
+    const drawingDef= makeDrawingDef( DEF_GRID_COLOR);
     const useLabels= isBoolean(params.useLabels) ? params.useLabels : true;
     const id= params.drawLayerId || `${ID}-${idCnt}`;
-    var options= {
+    const options= {
         hasPerPlotData:true,
         isPointData:false,
         useLabels,
@@ -65,7 +65,7 @@ function creator(params) {
         destroyWhenAllDetached: true
     };
     
-    return DrawLayer.makeDrawLayer( id, TYPE_ID, 'grid', options , drawingDef, [ImagePlotCntlr.UPDATE_VIEW_SIZE, UPDATE_GRID ]);
+    return DrawLayer.makeDrawLayer( id, TYPE_ID, 'Grid', options , drawingDef, [ImagePlotCntlr.UPDATE_VIEW_SIZE, UPDATE_GRID ]);
 }
 
  /**
@@ -153,19 +153,12 @@ function getDrawData(dataType, plotId, drawLayer, action, lastDataRet){
   * @returns {{width: (dataWidth|*), height: (*|dataHeight), screenWidth: *, csys: *, labelFormat: string}}
   */
  export function getDrawLayerParameters(plot){
-     var width = plot.dataWidth;
-     var height = plot.dataHeight;
-     var screenWidth = plot.screenSize.width;
+     const prefCsysName = getPreference(COORDINATE_PREFERENCE);
+     const nameList= coordinateArray.map(({coordName}) => coordName);
+     const csysName= nameList.includes(prefCsysName) ? prefCsysName : 'eq2000hms';
 
-     var csysName = getPreference(COORDINATE_PREFERENCE);
-     if (!csysName || isEmpty(csysName) ) {
-         //set default
-         csysName = 'eq2000hms';
-     }
-     var csys=getCoordinateSystem(csysName);
-     var labelFormat=csysName.endsWith('hms')? 'hms':'dcm';
-
-     return {width, height, screenWidth, csys,labelFormat};
+     return {width:plot.dataWidth, height:plot.dataHeight, screenWidth:plot.screenSize.width,
+         csys:getCoordinateSystem(csysName),labelFormat:csysName.endsWith('hms')? 'hms':'dcm'};
  }
 
  /**

--- a/src/firefly/js/drawingLayers/hpx/HpxCatalog.js
+++ b/src/firefly/js/drawingLayers/hpx/HpxCatalog.js
@@ -264,7 +264,7 @@ function getHighlightData(dl) {
     if (!idxData) return [];
 
     const wpt= makeHpxWpt(idxData,dl.highlightedRow);
-    const s = dl.drawingDef.size || 5;
+    const s = dl.drawingDef.size+2 || 5;
     const s2 = DrawUtil.getSymbolSizeBasedOn(DrawSymbol.X, Object.assign({}, dl.drawingDef, {size: s}));
     const obj= PointDataObj.make(wpt, s, dl.drawingDef.symbol);
     const obj2= PointDataObj.make(wpt, s2, DrawSymbol.X);

--- a/src/firefly/js/tables/HpxIndexCntlr.js
+++ b/src/firefly/js/tables/HpxIndexCntlr.js
@@ -339,13 +339,15 @@ export function getFirstIndex(orderData, norder, tileNumber) {
  * @param {Number} idx
  * @return {WorldPt}
  */
-export const makeHpxWpt= (hpxIndexData, idx) =>
-    makeWorldPt(
+export function makeHpxWpt(hpxIndexData, idx) {
+    if (!hpxIndexData?.latAry || !hpxIndexData?.latAry) return;
+    return makeWorldPt(
         hpxIndexData.lonAry[idx]/UINT_SCALE,
         hpxIndexData.latAry[idx]/UINT_SCALE,
         hpxIndexData.csys,
         false,
         hpxIndexData.tableUsingRadians);
+}
 
 /**
  *

--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -71,7 +71,7 @@ function getExamples(serviceUrl) {
     );
 }
 
-export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, style={}}) {
+export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, style={}, setError}) {
 
     const [treeData, setTreeData] = useState([]);                               // using a useState hook
     const [displayedTreeData, setDisplayedTreeData] = useState((treeData));
@@ -113,6 +113,10 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
         const key = cFetchKey;
         // reload TAP schema when serviceUrl changes
         loadTapSchemas(serviceUrl).then(async (tm) => {
+            if (tm.error) {
+                setError(`Fail to retrieve schema for: ${serviceUrl}`);
+                return;
+            }
             if (key === cFetchKey) {
                 const tableData = tm?.tableData?.data ?? [];
                 const cidx = getColumnIdx(tm, 'schema_name');

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -757,6 +757,7 @@ export function flattenObject(object, prefix='', testFunc=isPlainObject) {
 
 
 export function hashCode(str) {
+    if (!str) return '';
     let hash = 5381;
     let i = str.length;
 

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -46,7 +46,7 @@ export const computeScreenDistance= function (x1, y1, x2, y2) {
  * @param p2 WorldPt
  * @return {number}
  */
-export const computeDistance= (p1, p2) => computeDistanceAngularDistance(p1.x, p1.y, p2.x, p2.y);
+export const computeDistance= (p1, p2) => (p1 && p2) ? computeDistanceAngularDistance(p1.x, p1.y, p2.x, p2.y) : 0;
 
 
 const computeDistanceAngularDistance= memorizeUsingMap( (lon1,lat1,lon2,lat2) => {

--- a/src/firefly/js/visualize/saga/CoverageWatcher.js
+++ b/src/firefly/js/visualize/saga/CoverageWatcher.js
@@ -200,6 +200,9 @@ function watchCoverage(tbl_id, action, cancelSelf, params) {
 
     if (paused) {
         paused= !(getViewer(getMultiViewRoot(), viewerId)?.mounted ?? false);
+        if (paused && (action?.type===TABLE_HIGHLIGHT || action?.type===TABLE_SELECT)) {
+            handleSelectOrHighlight(action,tblCatIdMap,tbl_id);
+        }
     }
     if (!action) {
         if (!paused) {
@@ -249,16 +252,9 @@ function watchCoverage(tbl_id, action, cancelSelf, params) {
             cancelSelf();
             break;
 
-        case TABLE_SELECT:
-            tblCatIdMap[tbl_id]?.forEach(( cId ) => {
-                dispatchModifyCustomField(cId, {selectInfo: action.payload.selectInfo});
-            });
-            break;
-
         case TABLE_HIGHLIGHT:
-            tblCatIdMap[tbl_id]?.forEach(( cId ) => {
-                dispatchModifyCustomField(cId, {highlightedRow: action.payload.highlightedRow});
-            });
+        case TABLE_SELECT:
+            handleSelectOrHighlight(action,tblCatIdMap,tbl_id);
             break;
 
         case MultiViewCntlr.VIEWER_UNMOUNTED:
@@ -277,6 +273,18 @@ function watchCoverage(tbl_id, action, cancelSelf, params) {
 }
 
 
+function handleSelectOrHighlight(action,tblCatIdMap,tbl_id) {
+    switch (action?.type) {
+        case TABLE_HIGHLIGHT:
+            tblCatIdMap[tbl_id]?.forEach((cId) =>
+                dispatchModifyCustomField(cId, {highlightedRow: action.payload.highlightedRow}));
+            return;
+        case TABLE_SELECT:
+            tblCatIdMap[tbl_id]?.forEach((cId) =>
+                dispatchModifyCustomField(cId, {selectInfo: action.payload.selectInfo}));
+            return;
+    }
+}
 
 function removeCoverage(tbl_id, preparedTables) {
     if (tbl_id) Reflect.deleteProperty(preparedTables, tbl_id);


### PR DESCRIPTION
#### Firefly-1558: Save user add TAP servers

 - saved via api
 - saved with "enter my URL" option
 - save as a preference
 - The option should remain through reloads until the user removes it.
 - improve bad server error handling

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1558-tap-service/firefly
- enter a alternate tap server (such as: https://irsadev.ipac.caltech.edu/TAP) 
- reload, it should still be in the list
- enter a bad one  (such as: https://abcdefg.edu/TAP) 
- The error handling has improved
- reload and they both should still be in the list. You can select them just like before.
- try out the `x` on the servers you entered

#### Clearing preferences
- _open_ developer tools
- _on top choose_: Application
- _on left choose_:  Local Storage -> the url
- _on right highlight_: `APP_PREFERENCES`
- click on the `X`