### PR TITLE
FIREFLY-1553: Upload table chooser popup UI bug fixes

### DIFF
--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -398,7 +398,7 @@ function makeSummaryModel(report, summaryTblId, acceptList) {
     const columns = [
         {name: 'Index', type: 'int', desc: 'Extension Index'},
         {name: 'Type', type: 'char', desc: 'Data Type'},
-        {name: 'Description', type: 'char', desc: 'Extension Description', width: 60},
+        {name: 'Description', type: 'char', desc: 'Extension Description', width: 30},
         {name: 'AllowedType', type: 'boolean', desc: 'Type in AcceptList', visibility: 'hidden'}
     ];
     const {parts=[]} = report;
@@ -619,7 +619,7 @@ function AnalysisTable({summaryModel, detailsModel, report, isMoc, UNKNOWN_FORMA
 
     // Details table needs to render first to create a stub to collect data when Summary table is loaded.
     return (
-        <Stack {...{direction:'row', flexGrow:1, position:'relative', minHeight:'22rem'}}>
+        <Stack {...{direction:'row', flexGrow:1, position:'relative', minHeight:'1rem'}}>
             {(summaryModel.tableData.data.length>1) ?
                 <MultiDataSet summaryModel={summaryModel} detailsModel={detailsModel} isMoc={isMoc}
                               acceptOneItem={acceptOneItem}/> :
@@ -667,7 +667,7 @@ function MultiDataSet({summaryModel, detailsModel, isMoc, acceptOneItem}) {
                 </Typography>
             }
             <Box sx={{height:1, position:'relative'}}>
-                <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={550}>
+                <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={350}>
                     {acceptOneItem && <TablePanel {...{showTypes:false, title:'File Summary', tableModel:summaryModel,
                         ...tblOptions, selectable:false, }} />}
                     {!acceptOneItem && <TablePanel {...{sx:{mr:1}, showTypes:false, title:'File Summary', tableModel:summaryModel,
@@ -692,7 +692,7 @@ function Details({detailsModel}) {
     return (
         <TablePanel showTypes={false}  title='File Details'
                     tableModel={detailsModel}
-                    sx={{ml:1, position:'absolute', inset:0}}
+                    sx={{ml:1, position:'relative', inset:0}}
                     {...tblOptions} showMetaInfo={true} selectable={false}/>
     );
 


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1553
- The changes are very small, but they fix some existing issues mentioned in the ticket, a quick summary:   
  - When you upload a `moc fits` file via the `UploadTableChooser` popup (Multi-object search), the `Load/Cancel` buttons were not visible unless you resized the dialog to make it bigger. 
  - Also, the `Details` model table on the right was either not visible or just barely visible in the `UploadTableChooser` popup. 
  - This PR fixes both issues. 
- **_Note_**: The styling is applied directly within `FileUploadViewPanel`, so this affects the `Upload` tab as well. I chose to do it this way because it makes the `Upload` tab cleaner as well. 
   - it makes the summary model (the table on the left when you upload a file like `moc fits` file) narrower.
   - since we use is a SplitPane, the user can still make either table narrower or wider.
   - if we want to apply some specific styling to the `FileUploadDropdown` / `FileUploadViewPanel` when called from `UploadTableChooser` instead, perhaps slotProps approach can be used, but I didn't find that necessary in this case. 

**Testing**: 
- **firefly**: https://fireflydev.ipac.caltech.edu/firefly-1553-upload-popup-bug/firefly
- use multi object upload from the TAP panel to test the UploadTableChooser popup 
    - upload a non moc fits file, observe the summary / details tables. 
    - upload a moc fits file. Make sure you see both the Summary and Details model tables, and that you can resize either. 
       - make sure you also see the `Load/Cancel` buttons. 
- Repeat the steps above on the Upload tab directly. 
  - make sure it looks clean, you can resize both tables when there's summary table on the left. 