### PR TITLE
Firefly-1180: improve table from fits image HDU uploads

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -2,12 +2,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 package edu.caltech.ipac.firefly.data;
-/**
- * User: roby
- * Date: 2/7/12
- * Time: 10:14 AM
- */
-
 
 /**
  * @author Trey Roby
@@ -187,7 +181,10 @@ public class ServerParams {
     public static final String TILE_SIZE = "tileSize";
     public static final String DATA_COMPRESS = "dataCompress";
     public static final String POINT_SIZE= "pointSize";
+    public static final String POINT_SIZE_X= "pointSizeX";
+    public static final String POINT_SIZE_Y= "pointSizeY";
     public static final String COMBINE_OP= "combineOp";
+    public static final String AXIS= "axis";
     public static final String EXTRACTION_TYPE= "extractionType";
     public static final String EXTRACTION_FLOAT_SIZE= "extractionFloatSize";
     public static final String HDU_NUM= "hduNum";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
@@ -6,12 +6,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 package edu.caltech.ipac.firefly.server;
-/**
- * User: roby
- * Date: 12/19/12
- * Time: 11:46 AM
- */
-
 
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.ServerParams;
@@ -24,7 +18,6 @@ import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.table.JsonTableUtil;
 import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.table.TableUtil.Format;
-import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.visualize.plot.ImagePt;
 import edu.caltech.ipac.visualize.plot.WorldPt;
 import org.json.simple.JSONArray;
@@ -41,6 +34,7 @@ import static edu.caltech.ipac.firefly.data.TableServerRequest.FF_SESSION_ID;
 /**
  * @author Trey Roby
  */
+
 public class SrvParam {
 
     private final Map<String, String[]> paramMap;
@@ -60,9 +54,9 @@ public class SrvParam {
     public int size() { return paramMap.size(); }
 
     /**
-     * Return any parameters that are not in ignore list. If the parameter has more then one entry, only return the first
+     * Return any parameters that are not in ignore list. If the parameter has more than one entry, only return the first
      * @param ignoreList an array list of parameters to ignore
-     * @return a map of the parameters that we not ignored
+     * @return a map of the parameters that are not ignored
      */
     public Map<String, String> getParamMapUsingExcludeList(List<String> ignoreList) {
         Map<String,String> retMap= new HashMap<>();
@@ -134,18 +128,18 @@ public class SrvParam {
     }
 
     public PlotState[] getStateAry() {
-        List<PlotState> stateList= new ArrayList<PlotState>();
+        List<PlotState> stateList= new ArrayList<>();
         PlotState state= getState(0,true);
         stateList.add(state);
         for(int i=1;(state!=null); i++) {
             state= getState(i,false);
             if (state!=null) stateList.add(state);
         }
-        return stateList.toArray(new PlotState[stateList.size()]);
+        return stateList.toArray(new PlotState[0]);
     }
 
     public List<WebPlotRequest> getRequestList() {
-        List<WebPlotRequest> reqList= new ArrayList<WebPlotRequest>();
+        List<WebPlotRequest> reqList= new ArrayList<>();
         WebPlotRequest wpr= getRequiredWebPlotRequest(ServerParams.REQUEST+"0");
         reqList.add(wpr);
         for(int i=1;(wpr!=null); i++) {
@@ -163,16 +157,8 @@ public class SrvParam {
      */
     public String getID() { return getRequired(ServerParams.ID); }
 
-    /**
-     * Look for the ServerParams.ID keys and a list of values
-     * Throw an exception if at least one is not found
-     * @return in ID values
-     */
-    public List<String> getIDList() { return getRequiredList(ServerParams.ID); }
-
-
     public String getRequired(String key) {
-        String ary[]= paramMap.get(key);
+        String[] ary = paramMap.get(key);
         if (ary != null && ary.length>0) {
             return ary[0];
         }
@@ -182,7 +168,7 @@ public class SrvParam {
     }
 
     public List<String> getRequiredList(String key) {
-        String ary[]= paramMap.get(key);
+        String[] ary = paramMap.get(key);
         if (ary != null && ary.length>0) {
             return Arrays.asList(ary);
         }
@@ -192,7 +178,7 @@ public class SrvParam {
     }
 
     public List<String> getOptionalList(String key) {
-        String ary[]= paramMap.get(key);
+        String[] ary = paramMap.get(key);
         if (ary != null && ary.length>0) {
             return Arrays.asList(ary);
         }
@@ -202,7 +188,7 @@ public class SrvParam {
     }
 
     public String getOptional(String key) {
-        String ary[]= paramMap.get(key);
+        String[] ary = paramMap.get(key);
         if (ary != null && ary.length>0) {
             return ary[0];
         }
@@ -217,7 +203,7 @@ public class SrvParam {
     }
 
     public float getOptionalFloat(String key, float defValue) {
-        String ary[]= paramMap.get(key);
+        String[] ary = paramMap.get(key);
         if (ary != null && ary.length>0) {
             try {
                 return Float.parseFloat(ary[0]);
@@ -231,7 +217,7 @@ public class SrvParam {
     }
 
     public int getOptionalInt(String key, int defValue) {
-        String ary[]= paramMap.get(key);
+        String[] ary = paramMap.get(key);
         if (ary != null && ary.length>0) {
             try {
                 return Integer.parseInt(ary[0]);
@@ -303,7 +289,7 @@ public class SrvParam {
         if (json==null) return null;
         JsonHelper helper= JsonHelper.parse(json);
         JSONArray list= helper.getValue(new JSONArray());
-        if (list==null || list.size()==0) return null;
+        if (list==null || list.isEmpty()) return null;
         ImagePt[] ptAry= new ImagePt[list.size()];
         for(int i=0;(i<ptAry.length);i++) {
             ptAry[i]= ImagePt.parse((String)list.get(i));
@@ -316,7 +302,7 @@ public class SrvParam {
         if (json==null) return null;
         JsonHelper helper= JsonHelper.parse(json);
         JSONArray list= helper.getValue(new JSONArray());
-        if (list==null || list.size()==0) return null;
+        if (list==null || list.isEmpty()) return null;
         WorldPt[] ptAry= new WorldPt[list.size()];
         for(int i=0;(i<ptAry.length);i++) {
             ptAry[i]= WorldPt.parse((String)list.get(i));
@@ -329,15 +315,17 @@ public class SrvParam {
         if (json==null) return null;
         JsonHelper helper= JsonHelper.parse(json);
         JSONArray list= helper.getValue(new JSONArray());
-        if (list==null || list.size()==0) return null;
+        if (list==null || list.isEmpty()) return null;
         double[] dAry= new double[list.size()];
         for(int i=0;(i<dAry.length);i++) {
             try{
                 Object v= list.get(i);
-                if (v instanceof Double) dAry[i]= (Double) v;
-                else if (v instanceof Long) dAry[i]= (Long) v;
-                else if (v instanceof Integer) dAry[i]= (Integer) v;
-                else dAry[i]= Double.NaN;
+                switch (v) {
+                    case Double aDouble -> dAry[i] = aDouble;
+                    case Long l -> dAry[i] = l;
+                    case Integer integer -> dAry[i] = integer;
+                    case null, default -> dAry[i] = Double.NaN;
+                }
             } catch (ClassCastException e) {
                 return null;
             }
@@ -349,7 +337,7 @@ public class SrvParam {
         if (json==null) return null;
         JsonHelper helper= JsonHelper.parse(json);
         JSONArray list= helper.getValue(new JSONArray());
-        if (list==null || list.size()==0) return null;
+        if (list==null || list.isEmpty()) return null;
         String[] sAry= new String[list.size()];
         for(int i=0;(i<sAry.length);i++) {
             Object v= list.get(i);
@@ -360,11 +348,11 @@ public class SrvParam {
 
     public boolean getOptionalBoolean(String key, boolean defval) {
         String v= getOptional(key);
-        return v==null ? defval : Boolean.valueOf(v);
+        return v==null ? defval : Boolean.parseBoolean(v);
     }
 
     public boolean getRequiredBoolean(String key) {
-        return Boolean.valueOf(getRequired(key));
+        return Boolean.parseBoolean(getRequired(key));
     }
 
     public WebPlotRequest getOptionalWebPlotRequest(String key) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ExtractFromImage.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ExtractFromImage.java
@@ -30,7 +30,8 @@ import java.util.Map;
                 @ParamDoc(name="fluxUnit", desc="flux units. if defined"),
                 @ParamDoc(name="filename", desc="filename on the server"),
                 @ParamDoc(name="refHDUNum", desc="hdu number to extract"),
-                @ParamDoc(name="extractionSize", desc="number of the square size of the extract, i.e. 4 would be 4x4"),
+                @ParamDoc(name="extractionSizeX", desc="number of the square size of the extract, i.e. 4 would be 4x4"),
+                @ParamDoc(name="extractionSizeY", desc="number of the square size of the extract, i.e. 4 would be 4x4"),
                 @ParamDoc(name="allMatchingHDUs", desc="extract every HDU that matches the refHDU")
         })
 public class ExtractFromImage extends EmbeddedDbProcessor {
@@ -39,14 +40,16 @@ public class ExtractFromImage extends EmbeddedDbProcessor {
     public static final String EXTRACTION_TYPE = "extractionType";
     public static final String FILENAME = "filename";
     public static final String REF_HDU_NUM = "refHDUNum";
-    public static final String EXTRACTION_SIZE = "extractionSize";
+    public static final String EXTRACTION_SIZE_X = "extractionSizeX";
+    public static final String EXTRACTION_SIZE_Y = "extractionSizeY";
     public static final String ALL_MATCHING_HDUS = "allMatchingHDUs";
 
     @Override
     public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
         String extType = req.getParam(EXTRACTION_TYPE);
         String filename = req.getParam(FILENAME);
-        int extractionSize = req.getIntParam(EXTRACTION_SIZE, 1);
+        int ptSizeX = req.getIntParam(EXTRACTION_SIZE_X, 1);
+        int ptSizeY = req.getIntParam(EXTRACTION_SIZE_Y, 1);
         int refHduNum = req.getIntParam(REF_HDU_NUM, -1);
         int plane = req.getIntParam(ServerParams.PLANE, -1);
         FitsExtract.CombineType ct= Enum.valueOf(FitsExtract.CombineType.class,req.getParam(ServerParams.COMBINE_OP,"AVG"));
@@ -60,20 +63,20 @@ public class ExtractFromImage extends EmbeddedDbProcessor {
                 checkZAxisParams(pt, filename, refHduNum);
                 Map<Integer,String> fluxUnit= makeMapOfUnitsFromParam(req);
                 return FITSExtractToTable.getCubeZaxisAsTable(pt, wpt, filename, refHduNum, allMatchingHDUs,
-                        extractionSize, ct, wlAry,wlUnit,fluxUnit);
+                        ptSizeX, ct, wlAry,wlUnit,fluxUnit);
             }
             else if (extType.equals("line")) {
                 ImagePt[] ptAry= SrvParam.getImagePtAryFromJson(req.getParam(ServerParams.PTARY));
                 WorldPt[] wptAry= SrvParam.getWorldPtAryFromJson(req.getParam(ServerParams.WPT_ARY));
                 checkPointParams(ptAry, plane, filename, refHduNum);
                 return FITSExtractToTable.getLineSelectAsTable(ptAry, wptAry, filename, refHduNum, plane, allMatchingHDUs,
-                        extractionSize, ct, wlAry, wlUnit);
+                        ptSizeX, ptSizeY, ct, wlAry, wlUnit);
             } else if (extType.equals("points")) {
                 ImagePt[] ptAry= SrvParam.getImagePtAryFromJson(req.getParam(ServerParams.PTARY));
                 WorldPt[] wptAry= SrvParam.getWorldPtAryFromJson(req.getParam(ServerParams.WPT_ARY));
                 checkPointParams(ptAry, plane, filename, refHduNum);
                 return FITSExtractToTable.getPointsAsTable(ptAry, wptAry, filename, refHduNum, plane,
-                        allMatchingHDUs, extractionSize, ct, wlAry, wlUnit);
+                        allMatchingHDUs, ptSizeX, ptSizeY, ct, wlAry, wlUnit);
             }
         } catch (IOException | FitsException e) {
             throw new IllegalArgumentException("Could not make a table from extracted data");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
@@ -133,6 +133,8 @@ public class VisServerCommands {
             String exType= sp.getRequired(ServerParams.EXTRACTION_TYPE);
             boolean useFloat = sp.getOptionalInt(ServerParams.EXTRACTION_FLOAT_SIZE,64)==32;
             int ptSize= sp.getOptionalInt(ServerParams.POINT_SIZE,1);
+            int ptSizeX= sp.getOptionalInt(ServerParams.POINT_SIZE_X,1);
+            int ptSizeY= sp.getOptionalInt(ServerParams.POINT_SIZE_Y,1);
             int hduNum= sp.getRequiredInt(ServerParams.HDU_NUM);
             FitsExtract.CombineType ct= Enum.valueOf(FitsExtract.CombineType.class,sp.getOptional(ServerParams.COMBINE_OP,"AVG"));
 
@@ -153,7 +155,7 @@ public class VisServerCommands {
                         VisServerOps.getPointDataAry(state,
                                 sp.getRequiredImagePtAry(ServerParams.PTARY),
                                 sp.getRequiredInt(ServerParams.PLANE),
-                                hduNum, ptSize, ct);
+                                hduNum, ptSizeX, ptSizeY, ct);
                 default -> throw new IllegalArgumentException(ServerParams.EXTRACTION_TYPE + " is not supported");
             };
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -155,9 +155,9 @@ public class VisServerOps {
     }
 
     public static List<Number> getPointDataAry(PlotState state, ImagePt[] ptAry, int plane, int hduNum,
-                                               int drillSize, FitsExtract.CombineType ct) {
+                                               int ptSizeX, int ptSizeY, FitsExtract.CombineType ct) {
         return getDataAry("line data", state,
-                (f) -> FitsExtract.getPointDataAryFromFile(ptAry, plane, f, hduNum, hduNum, drillSize, ct));
+                (f) -> FitsExtract.getPointDataAryFromFile(ptAry, plane, f, hduNum, hduNum, ptSizeX, ptSizeY, ct));
     }
 
     public static List<PixelValue.Result> getFlux(PlotState[] stateAry, ImagePt ipt) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -374,6 +374,7 @@ public class FitsReadUtil {
         return getBitPix(h) > 0 ? h.getDoubleValue("BLANK", Double.NaN) : Double.NaN;
     }
 
+    public static String getBUnit(Header h) { return h.getStringValue("BUNIT", ""); }
     public static String getExtName(Header h) { return h.getStringValue("EXTNAME"); }
     public static String getExtType(Header h, String defVal) { return h.getStringValue("EXTTYPE",defVal); }
     public static String getUtype(Header h) { return h.getStringValue("UTYPE"); }

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -205,7 +205,7 @@ const defFireflyOptions = {
     ],
     tap : {
         services: getTAPServices( ['IRSA', 'NED', 'NASA Exoplanet Archive', 'KOA', 'HEASARC', 'MAST Images',
-                                   'CADC', 'VizieR (CDS)', 'Simbad (CDS)', 'Gaia', 'GAVO', 'HSA'] ),
+                                   'CADC', 'VizieR (CDS)', 'Simbad (CDS)', 'Gaia', 'GAVO', 'HSA', 'NOIR Lab'] ),
         defaultMaxrec: 50000
     }
 };

--- a/src/firefly/js/data/ServerParams.js
+++ b/src/firefly/js/data/ServerParams.js
@@ -168,6 +168,8 @@ export const ServerParams = {
         TILE_SIZE: 'tileSize',
         DATA_COMPRESS: 'dataCompress',
         POINT_SIZE: 'pointSize',
+        POINT_SIZE_X: 'pointSizeX',
+        POINT_SIZE_Y: 'pointSizeY',
         COMBINE_OP: 'combineOp',
         EXTRACTION_TYPE: 'extractionType',
         HDU_NUM: 'hduNum',

--- a/src/firefly/js/rpc/PlotServicesJson.js
+++ b/src/firefly/js/rpc/PlotServicesJson.js
@@ -120,13 +120,14 @@ export async function callGetLineExtractionAry(plot, hduNum, plane, pt, pt2, ptS
         });
 }
 
-export async function callGetPointExtractionAry(plot, hduNum, plane, ptAry, ptSize, combineOp, relatedHDUS) {
+export async function callGetPointExtractionAry(plot, hduNum, plane, ptAry, ptSizeX, ptSizeY, combineOp, relatedHDUS) {
     return fetchExtraction(plot,
         {
             [ServerParams.EXTRACTION_TYPE]: 'points',
             [ServerParams.STATE]: plot.plotState.toJson(false),
             [ServerParams.PTARY] : JSON.stringify(ptAry.map( (pt) => pt.toString())),
-            [ServerParams.POINT_SIZE] : ptSize+'',
+            [ServerParams.POINT_SIZE_X] : ptSizeX+'',
+            [ServerParams.POINT_SIZE_Y] : ptSizeY+'',
             [ServerParams.COMBINE_OP] : combineOp,
             [ServerParams.PLANE] : plane+'',
             [ServerParams.HDU_NUM] : hduNum+'',

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -359,6 +359,8 @@ function sendRegionRequest(fileCacheKey,currentReport) {
     }
 }
 
+const hasExtName= (part) => Boolean(getTableHeaderFromAnalysis('EXTNAME', part));
+
 function getExtMarker(part, index) {
     return getTableHeaderFromAnalysis('EXTNAME', part) ??
         getTableHeaderFromAnalysis('UTYPE', part) ??
@@ -372,7 +374,10 @@ function sendTableRequest(tableIndices, fileCacheKey, treatAsSpectrum, currentRe
         const {index} = parts[idx];
         const fileRoot= fileName?.split('.')?.[0] ?? fileName;
         const extMarker= getExtMarker(parts[idx], idx);
-        const title = parts.length > 1 ? `${fileRoot}:${extMarker}` : fileRoot;
+        const title = parts.length > 1
+            ? hasExtName(parts[idx])
+                ? `${extMarker}:${fileRoot}`
+                : `${fileRoot}:${extMarker}` : fileRoot;
         const META_INFO= {...metaData};
         if (treatAsSpectrum) META_INFO[MetaConst.DATA_TYPE_HINT]= 'spectrum';
         const options=  {META_INFO};

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -111,8 +111,8 @@ export const ToolbarButton = forwardRef((props,fRef) => {
                              {minHeight:'unset', minWidth:'unset', p:1/4, backgroundColor:'transparent',
                                  '& svg' : {
                                      color: enabled?
-                                         theme.vars.palette.neutral?.plainColor :
-                                         theme.vars.palette.neutral?.softDisabledColor,
+                                         theme.vars.palette[color]?.plainColor :
+                                         theme.vars.palette[color]?.softDisabledColor,
                                  },
                                  opacity: enabled ? '1' : '0.3',
                                  ...makeBorder(active,theme,color),

--- a/src/firefly/js/ui/tap/TapKnownServices.js
+++ b/src/firefly/js/ui/tap/TapKnownServices.js
@@ -34,6 +34,7 @@ function makeServices() {
         tapEntry('Gaia', 'https://gea.esac.esa.int/tap-server/tap',undefined,undefined,undefined, undefined, gaiaExamples()),
         tapEntry('GAVO', 'https://dc.g-vo.org/tap'),
         tapEntry('HSA',  'https://archives.esac.esa.int/hsa/whsa-tap-server/tap'),
+        tapEntry('NOIR Lab',  'https://datalab.noirlab.edu/tap'),
     ];
 
 }

--- a/src/firefly/js/visualize/FitsHeaderUtil.js
+++ b/src/firefly/js/visualize/FitsHeaderUtil.js
@@ -23,6 +23,7 @@ export const HdrConst= {
     CTYPE3   : 'CTYPE3',
     BITPIX   : 'BITPIX',
     BSCALE   : 'BSCALE',
+    BUNIT   : 'BUNIT',
     BZERO    : 'BZERO',
     CRPIX1   : 'CRPIX1',
     CRPIX2   : 'CRPIX2',

--- a/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
+++ b/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
@@ -368,7 +368,7 @@ export function parseSpacialHeaderInfo(header, altWcs='', zeroHeader) {
 
 
 
-    p.bunit = parse.getValue('BUNIT');
+    p.bunit = parse.getValue(HdrConst.BUNIT);
     if (!p.bunit) p.bunit = 'DN';
     p.fluxUnits= getFluxUnits(parse, zeroHeader);
 
@@ -378,7 +378,7 @@ export function parseSpacialHeaderInfo(header, altWcs='', zeroHeader) {
 
 
 function getFluxUnits(parse, zeroHeader) {
-    let bunit = parse.getValue('BUNIT', 'NONE');
+    let bunit = parse.getValue(HdrConst.BUNIT, 'NONE');
     if (bunit==='NONE') {
         bunit= zeroHeader  ? getHeader(zeroHeader, 'BUNIT', 'DN') : 'DN';
     }

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -201,7 +201,7 @@ function updateHpxCatalogDrawingLayer(tbl_id, tableRequest, highlightedRow) {
     const catDL= dispatchCreateDrawLayer(HpxCatalog.TYPE_ID,
         {catalogId, tbl_id, title, highlightedRow, color, layersPanelLayoutId: catalogId});
     const plotIdAry= visRoot().plotViewAry
-        .filter( (pv) => pv.useForSearchResults)
+        .filter( (pv) => pv.plotViewCtx.useForSearchResults)
         .map( (pv) => pv.plotId);
     attachToPlot(catalogId,plotIdAry);
 

--- a/src/firefly/js/visualize/ui/Buttons.jsx
+++ b/src/firefly/js/visualize/ui/Buttons.jsx
@@ -1,3 +1,4 @@
+import PriorityHighRoundedIcon from '@mui/icons-material/PriorityHighRounded';
 import React from 'react';
 import {node} from 'prop-types';
 import {Box, Button, IconButton, ToggleButtonGroup} from '@mui/joy';
@@ -176,6 +177,11 @@ export const ToolsDropDown= (props) => (
 // Table and Chart buttons -->
 export const FilterButton = (props) => (
     <ToolbarButton {...{icon: <FilterIco/>, tip: 'Show/edit filters', iconButtonSize:'38px', ...props}}/>
+);
+
+export const WarningButton = (props) => (
+    <ToolbarButton {...{icon: <PriorityHighRoundedIcon />,
+        tip: 'warning', color:'danger', iconButtonSize:'38px', ...props}}/>
 );
 
 export const ClearFilterButton = (props) => (

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -28,7 +28,7 @@ import {isLsstFootprintTable} from '../task/LSSTFootprintTask.js';
 
 import {useFieldGroupMetaState, useFieldGroupValue, useStoreConnector} from '../../ui/SimpleComponent.jsx';
 
-import {getIntHeaderFromAnalysis, getTableHeaderFromAnalysis} from '../../metaConvert/PartAnalyzer';
+import {getIntHeaderFromAnalysis} from '../../metaConvert/PartAnalyzer';
 import {FileAnalysisType} from '../../data/FileAnalysis';
 import {Format} from '../../data/FileAnalysis';
 import {dispatchValueChange} from 'firefly/fieldGroup/FieldGroupCntlr.js';

--- a/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
@@ -22,7 +22,7 @@ import {showRegionFileUploadPanel} from 'firefly/visualize/region/RegionFileUplo
 import {findUnactivatedRelatedData} from 'firefly/visualize/RelatedDataUtil.js';
 import {ColorTableDropDownView, showColorDialog} from 'firefly/visualize/ui/ColorTableDropDownView.jsx';
 import {showDrawingLayerPopup} from 'firefly/visualize/ui/DrawLayerPanel.jsx';
-import {endExtraction, LINE, POINTS, showExtractionDialog, Z_AXIS} from 'firefly/visualize/ui/ExtractionDialog.jsx';
+import {endExtraction, LINE, POINTS, showExtractionDialog, Z_AXIS} from './extraction/ExtractionDialog.jsx';
 import {showImageSelPanel} from 'firefly/visualize/ui/ImageSearchPanelV2.jsx';
 import {MarkerDropDownView} from 'firefly/visualize/ui/MarkerDropDownView.jsx';
 import {showMaskDialog} from 'firefly/visualize/ui/MaskAddPanel.jsx';

--- a/src/firefly/js/visualize/ui/extraction/ExtractionChart.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionChart.jsx
@@ -1,0 +1,113 @@
+import {sprintf} from '../../../externalSource/sprintf';
+import {Band} from '../../Band.js';
+import {getExtName} from '../../FitsHeaderUtil.js';
+import {
+    getAllWaveLengthsForCube, getHDU, getPtWavelength, hasWCSProjection, hasWLInfo, primePlot
+} from '../../PlotViewUtil.js';
+import {getFluxUnits} from '../../WebPlot.js';
+
+const plotlyDivStyle = {border: '1px solid a5a5a5', borderRadius: 5, width: '100%', height: '100%'};
+
+function makePlotlyLayoutObj(title, xAxis, yAxis, reversed = false) {
+    const font = {size: 12};
+    return {
+        hovermode: 'closest',
+        title: {text: title, font},
+        showlegend: false,
+        xaxis: {
+            title: {text: xAxis, font},
+            gridLineWidth: 1,
+            type: 'linear',
+            lineColor: '#e9e9e9',
+            zeroline: false,
+            tickfont: font,
+            exponentformat: 'e',
+            autorange: reversed ? 'reversed' : true,
+        },
+        yaxis: {
+            title: {text: yAxis, font},
+            gridLineWidth: 1,
+            type: 'linear',
+            lineColor: '#e9e9e9',
+            exponentformat: 'e'
+        },
+        margin: {l: 50, r: 50, b: 50, t: 30, pad: 2}
+    };
+}
+
+const dataRoot = {displaylogo: false, mode: 'markers', hoverinfo: 'text', hovermode: 'closest'};
+
+function makePlotlyDataObj(xDataAry, yDataAry, x, y, ttXStr, ttYStr, makeXDesc = (i) => xDataAry[i], highlightXDesc = x + '') {
+    const result = [
+        {
+            ...dataRoot,
+            type: xDataAry?.length > 6000 ? 'scattergl' : 'scatter',
+            marker: {symbol: 'circle', size: 6, color: 'rgba(63, 127, 191, 0.5)'},
+            x: xDataAry,
+            y: yDataAry,
+            hovertext: Array.from(yDataAry).map((d, i) => `<span> ${ttXStr} = ${makeXDesc(i)}  <br> ${ttYStr}= ${d}   </span>`),
+            textfont: {color: 'rgba(31,119,180,0.5)'},
+        },
+        {
+            ...dataRoot,
+            type: 'scatter',
+            marker: {symbol: 'circle', size: 6, color: 'rgba(255, 200, 0, 1)'},
+            x: [x],
+            y: [y],
+            hovertext: [`<span> ${ttXStr} = ${highlightXDesc}  <br> ${ttYStr} = ${y}   </span>`],
+        }
+    ];
+    return result;
+}
+
+export function genSliceChartData(plot, ipt1, ipt2, xDataAry, yDataAry, x, y, pointSize, combineOp, title, reversed) {
+    const unitStr = hasWCSProjection(plot) ? ' (arcsec)' : '';
+    const yUnits = getFluxUnits(plot, Band.NO_BAND);
+    const yAxisLabel = getExtName(plot) || 'HDU# ' + getHDU(plot);
+    return {
+        plotlyDivStyle,
+        plotlyData: makePlotlyDataObj(xDataAry, yDataAry, x, y, 'Offset' + unitStr, yAxisLabel),
+        plotlyLayout: makePlotlyLayoutObj(title, 'Offset' + unitStr,
+            `${yAxisLabel} (${yUnits})${pointSize > 1 ? ` (${pointSize}x${pointSize} ${combineOp.toLowerCase()})` : ''}`, reversed),
+    };
+}
+
+export function genPointChartData(plot, dataAry, imPtAry, x, y, pointSize, combineOp, title, chartXAxis, activeIdx) {
+
+    const xAxis = chartXAxis === 'imageX' ? imPtAry.map((pt) => pt.x) : imPtAry.map((pt) => pt.y);
+    const xAxisTitle = chartXAxis === 'imageX' ? 'Image X' : 'Image Y';
+    const xLabel = (i) => `(${imPtAry[i].x},${imPtAry[i].y})`;
+    const yUnits = getFluxUnits(plot, Band.NO_BAND);
+    const yAxisLabel = getExtName(plot) || 'HDU# ' + getHDU(plot);
+
+    return {
+        plotlyDivStyle,
+        plotlyData: makePlotlyDataObj(xAxis, dataAry, x, y, xAxisTitle, yAxisLabel,
+            xLabel, xLabel(activeIdx)),
+        plotlyLayout: makePlotlyLayoutObj(title, xAxisTitle, `${yAxisLabel} (${yUnits})${pointSize > 1 ? ` (${pointSize}x${pointSize} ${combineOp.toLowerCase()})` : ''}`),
+    };
+}
+
+export function genZAxisChartData(imPt, pv, dataAry, x, y, pointSize, combineOp, title) {
+    const plot = primePlot(pv);
+    const hasWL = hasWLInfo(plot);
+    const xAry = hasWL ? getAllWaveLengthsForCube(pv, imPt) : dataAry.map((d, i) => i + 1);
+    const highlightX = hasWL ? getPtWavelength(primePlot(pv), imPt, x) : x + 1;
+    const highlightXLabel =
+        isNaN(highlightX) ?
+            `${highlightX + ''} (plane: ${x + 1})` :
+            `${sprintf('%5.4f', highlightX)} (plane: ${x + 1})`;
+
+    const format = (v) => isNaN(v) ? '' : sprintf('%5.4f', v);
+    const xLabel = (i) => `${format(getPtWavelength(primePlot(pv), imPt, x))} (plane: ${i + 1})`;
+
+    const plotlyData = hasWL ?
+        makePlotlyDataObj(xAry, dataAry, highlightX, y, 'Wavelength', 'z-azis', xLabel, highlightXLabel) :
+        makePlotlyDataObj(xAry, dataAry, highlightX, y, 'Plane', 'z-azis');
+
+    return {
+        plotlyDivStyle,
+        plotlyData,
+        plotlyLayout: makePlotlyLayoutObj(title, hasWL ? 'Wavelength' : 'cube plane', `Z-Axis${pointSize > 1 ? ` (${pointSize}x${pointSize} ${combineOp.toLowerCase()})` : ''}`),
+    };
+}

--- a/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
@@ -1,0 +1,173 @@
+import {MetaConst} from '../../../data/MetaConst';
+import {ServerParams} from '../../../data/ServerParams';
+import {makeTblRequest} from '../../../tables/TableRequestUtil';
+import {dispatchTableFetch, dispatchTableSearch} from '../../../tables/TablesCntlr';
+import {onTableLoaded} from '../../../tables/TableUtil';
+import {showTableDownloadDialog} from '../../../tables/ui/TableSave';
+import {showInfoPopup, showPinMessage} from '../../../ui/PopupUtil';
+import {Band} from '../../Band';
+import {CCUtil, CysConverter} from '../../CsysConverter';
+import {getExtName} from '../../FitsHeaderUtil';
+import {
+    getAllWaveLengthsForCube, getHDU, getHduPlotStartIndexes, getImageCubeIdx, getPtWavelength, getWaveLengthUnits,
+    hasPixelLevelWLInfo, hasWCSProjection, hasWLInfo, isImageCube, isMultiHDUFits
+} from '../../PlotViewUtil';
+import {getLinePointAry} from '../../VisUtil';
+import {getFluxUnits} from '../../WebPlot';
+import {addZAxisExtractionWatcher} from '../ExtractionWatchers';
+
+let idCnt = 0;
+const getNextTblId = () => 'extraction-table-' + (idCnt++);
+
+async function doDispatchTableSaving(req, doOverlay) {
+    const {tbl_id} = req;
+    const sendReq = {...req};
+    sendReq.META_INFO = !doOverlay ? {
+        ...sendReq.META_INFO,
+        [MetaConst.CATALOG_OVERLAY_TYPE]: 'FALSE'
+    } : {...sendReq.META_INFO};
+    dispatchTableFetch(sendReq, {tbl_group: 'main', backgroundable: false});
+    await onTableLoaded(tbl_id);
+    showTableDownloadDialog({tbl_id, tbl_ui_id: undefined})();
+}
+
+function doDispatchTable(req, doOverlay) {
+    showPinMessage('Pinning Extraction to Table Area');
+    const sendReq = {...req};
+    sendReq.META_INFO = !doOverlay ? {
+        ...sendReq.META_INFO,
+        [MetaConst.CATALOG_OVERLAY_TYPE]: 'FALSE'
+    } : {...sendReq.META_INFO};
+    dispatchTableSearch(sendReq, {
+        logHistory: false,
+        removable: true,
+        tbl_group: 'main',
+        backgroundable: false,
+        showFilters: true,
+        showInfoButton: true
+    });
+}
+
+let titleCnt = 1;
+
+export function keepZAxisExtraction(pt, pv, plot, filename, refHDUNum, extractionSize, combineOp, save = false, doOverlay = true) {
+    if (!pv || !plot || !filename) {
+        showInfoPopup('Plot no longer exist. Cannot extract.');
+        return;
+    }
+    const wlUnit = getWaveLengthUnits(plot);
+    const wpt = CCUtil.getWorldCoords(plot, pt);
+    const fluxUnit = getHduPlotStartIndexes(pv)
+        .map((idx) => ({hdu: getHDU(pv.plots[idx]), unit: getFluxUnits(pv.plots[idx], Band.NO_BAND)}))
+        .map(({hdu, unit}) => `${hdu}=${unit}`);
+
+    const tbl_id = getNextTblId();
+    addZAxisExtractionWatcher(tbl_id);
+    const dataTableReq = makeTblRequest('ExtractFromImage', `Extraction Z-Axis - ${titleCnt}`,
+        {
+            startIdx: 0,
+            extractionType: 'z-axis',
+            pt: pt.toString(),
+            wpt: wpt?.toString(),
+            wlAry: hasWLInfo(plot) ? JSON.stringify(getAllWaveLengthsForCube(pv, pt)) : undefined,
+            wlUnit,
+            fluxUnit: JSON.stringify(fluxUnit),
+            filename,
+            refHDUNum,
+            extractionSizeX: extractionSize,
+            extractionSizeY: extractionSize,
+            [ServerParams.COMBINE_OP]: combineOp,
+            allMatchingHDUs: true,
+        },
+        {tbl_id});
+    if (save) dataTableReq.pageSize = 0;
+    save ? doDispatchTableSaving(dataTableReq, doOverlay) : doDispatchTable(dataTableReq, doOverlay);
+    idCnt++;
+    titleCnt++;
+    return tbl_id;
+}
+
+export function keepLineExtraction(pt, pt2, pv, plot, filename, refHDUNum, plane, extractionSizeX, extractionSizeY, combineOp, save = false, doOverlay = true) {
+    if (!pv || !plot || !filename) {
+        showInfoPopup('Plot no longer exist. Cannot extract.');
+        return;
+    }
+    const tbl_id = getNextTblId();
+    const imPtAry = getLinePointAry(pt, pt2);
+    const cc = CysConverter.make(plot);
+
+    const wlAry = hasPixelLevelWLInfo(plot) ?
+        imPtAry.map((pt) => getPtWavelength(plot, pt, 0))
+        : undefined;
+
+    const wptStrAry = hasWCSProjection(plot) ?
+        imPtAry.map((pt) => cc.getWorldCoords(pt)).map((wpt) => wpt.toString()) : undefined;
+    const dataTableReq = makeTblRequest('ExtractFromImage', makePlaneTitle('Extract Line', pv, plot, titleCnt), {
+            startIdx: 0,
+            extractionType: 'line',
+            ptAry: JSON.stringify(imPtAry.map((pt) => pt.toString())),
+            wptAry: JSON.stringify(wptStrAry),
+            wlAry,
+            wlUnit: getWaveLengthUnits(plot),
+            filename,
+            refHDUNum,
+            plane,
+            extractionSizeX,
+            extractionSizeY,
+            [ServerParams.COMBINE_OP]: combineOp,
+            allMatchingHDUs: true,
+        },
+        {tbl_id});
+    save ? doDispatchTableSaving(dataTableReq, doOverlay) : doDispatchTable(dataTableReq, doOverlay);
+    idCnt++;
+    titleCnt++;
+    return tbl_id;
+}
+
+function makePlaneTitle(rootStr, pv, plot, cnt) {
+    let hduStr = '';
+    let cubeStr = '';
+    if (isMultiHDUFits(pv)) {
+        if (getExtName(plot)) hduStr = `- ${getExtName(plot)}`;
+        else hduStr = `- HDU#${getHDU(plot)} `;
+    }
+    if (isImageCube(plot)) cubeStr = `- Plane: ${getImageCubeIdx(plot) + 1}`;
+    return `${rootStr} ${cnt}${hduStr}${cubeStr}`;
+}
+
+export function keepPointsExtraction(ptAry, pv, plot, filename, refHDUNum, plane, extractionSize, combineOp, save = false, doOverlay = true) {
+    if (!pv || !plot || !filename) {
+        showInfoPopup('Plot no longer exist. Cannot extract.');
+        return;
+    }
+    const tbl_id = getNextTblId();
+    const cc = CysConverter.make(plot);
+    const wlAry = hasPixelLevelWLInfo(plot) ?
+        ptAry.map((pt) => getPtWavelength(plot, pt, 0))
+        : undefined;
+    const wptStrAry =
+        hasWCSProjection(plot) ?
+            ptAry.map((pt) => cc.getWorldCoords(pt)).map((pt) => pt.toString()) :
+            undefined;
+    const dataTableReq = makeTblRequest('ExtractFromImage', makePlaneTitle('Points', pv, plot, titleCnt),
+        {
+            startIdx: 0,
+            extractionType: 'points',
+            ptAry: JSON.stringify(ptAry.map((pt) => pt.toString())),
+            wptAry: JSON.stringify(wptStrAry),
+            wlAry,
+            wlUnit: getWaveLengthUnits(plot),
+            filename,
+            refHDUNum,
+            plane,
+            extractionSizeX: extractionSize,
+            extractionSizeY: extractionSize,
+            [ServerParams.COMBINE_OP]: combineOp,
+            allMatchingHDUs: true,
+        },
+        {tbl_id});
+    save ? doDispatchTableSaving(dataTableReq, doOverlay) : doDispatchTable(dataTableReq, doOverlay);
+    idCnt++;
+    titleCnt++;
+    return tbl_id;
+}


### PR DESCRIPTION
#### [Firefly-1180](https://jira.ipac.caltech.edu/browse/FIREFLY-1180): improve table from fits image HDU uploads
  
  - improve 1D image to table handling
  - [Firefly-1560](https://jira.ipac.caltech.edu/browse/FIREFLY-1560): add support of line or column to extraction
  - Improved chart line combine pixels extraction (1xn or nx1)

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1180-extract/firefly
- [Firefly-1180](https://jira.ipac.caltech.edu/browse/FIREFLY-1180)
   - upload panel `->` choose url `->` https://data.desi.lbl.gov/public/epo/example_files/coadd-0-100-thru20210505.fits
   - load one of the nx1 tables. The results has been updated according to the ticket
 - [Firefly-1560](https://jira.ipac.caltech.edu/browse/FIREFLY-1560)
   - load a fits
   - choose line extract
   - try to new option to choose only a line or column