### PR TITLE
FIREFLY-1559: Upgrade Java from version 17 to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@ There are several branches in the repository.  Here are the ones that you should
 ## Setup
 
 ### Prerequisites
- -  [Java 17] (https://jdk.java.net/17/)
+ -  [Java 21] (https://openjdk.org/projects/jdk/21/)
     This is the version we are using to compile and run Firefly.  
 
- -  [Gradle 7.4] (https://gradle.org/install/)
+ -  [Gradle 8.10] (https://gradle.org/install/)
     Gradle is an open source build automation system.
 
  -  [Tomcat 9] (https://tomcat.apache.org/download-90.cgi)
     Apache Tomcat is an open source software implementation of the Java Servlet and JavaServer Pages technologies.
 
- -  [Node v20] (https://nodejs.org/)
+ -  [Node v18] (https://nodejs.org/)
     Javascript interpreter for command line environment, used for development tools
 
 ### Prepare before the build

--- a/buildScript/app.gincl
+++ b/buildScript/app.gincl
@@ -38,7 +38,7 @@ war {
     duplicatesStrategy = 'exclude'
 
     doFirst {
-        archiveName = "${webapp.baseWarName}.war"
+        archiveFileName = "${webapp.baseWarName}.war"
     }
 }
 

--- a/buildScript/dependencies.gradle
+++ b/buildScript/dependencies.gradle
@@ -21,6 +21,7 @@ repositories {
 configurations {
     webappLib {
         description = 'web app runtime dependencies.'
+        canBeResolved = true
     }
     tests
 }

--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -273,15 +273,14 @@ task deploy (dependsOn: [loadConfig]) {
         if (!file(tomcat_home).exists()) {
             throw ProjectConfigurationException("Tomcat installation directory does not exists: $tomcat_home")
         }
-        if (!file("$war.destinationDir/${webapp.baseWarName}.war").exists()) {
+        if (!file("${war.destinationDirectory}/${webapp.baseWarName}.war").exists()) {
             println ">> ${webapp.baseWarName}.war not found.  Skipping deploy."
             throw new StopExecutionException("${webapp.baseWarName}.war not found.  Skipping deploy.")
         }
-
         copy {
-            println ">> deploying file:$war.destinationDir/${webapp.baseWarName}.war"
+            println ">> deploying file:$war.destinationDirectory/${webapp.baseWarName}.war"
             delete("$tomcat_home/webapps/${webapp.baseWarName}")
-            from("$war.destinationDir/${webapp.baseWarName}.war")
+            from("$war.destinationDirectory/${webapp.baseWarName}.war")
             into "$tomcat_home/webapps/"
         }
     }
@@ -792,7 +791,7 @@ task webapp {
     dependsOn buildClient, prepareWebapp
 
     outputs.upToDateWhen { false }
-    ext.baseWarName = jar.baseName
+    ext.baseWarName = jar.archiveBaseName.get()
 }
 
 task buildAndPublish( dependsOn: war ) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG target=firefly:warAll
 ARG env=local
 ARG BranchOverride=''
 
-FROM eclipse-temurin:17-jdk-jammy AS deps
+FROM eclipse-temurin:21-jdk-jammy AS deps
 
 RUN apt-get update && apt-get install -y curl git htmldoc unzip wget ca-certificates gnupg
 
@@ -13,12 +13,12 @@ RUN apt-get update \
     && bash nodesource_setup.sh \
     && apt-get install -y nodejs \
     && npm install yarn -g  \
-# gradle version 7.4  Not available via apt-get
+# gradle version 8.10  Not available via apt-get
     && cd /usr/local \
-    && wget  -q https://services.gradle.org/distributions/gradle-7.4-bin.zip \
-    && unzip -q gradle-7.4-bin.zip \
-    && ln -sf /usr/local/gradle-7.4/bin/gradle /usr/local/bin/  \
-    && rm gradle-7.4-bin.zip \
+    && wget  -q https://services.gradle.org/distributions/gradle-8.10-bin.zip \
+    && unzip -q gradle-8.10-bin.zip \
+    && ln -sf /usr/local/gradle-8.10/bin/gradle /usr/local/bin/  \
+    && rm gradle-8.10-bin.zip \
 # cleanup
     && rm -rf /var/lib/apt/lists/*;
 
@@ -38,7 +38,7 @@ RUN apt-get update \
 # cleanup
     && rm -rf /var/lib/apt/lists/*;
 
-COPY --from=tomcat:9.0-jre17 /usr/local/tomcat /usr/local/tomcat
+COPY --from=tomcat:9.0-jre21-temurin-jammy /usr/local/tomcat /usr/local/tomcat
 
 
 ENV CATALINA_HOME=/usr/local/tomcat \
@@ -106,7 +106,7 @@ RUN gradle -Penv=${env} -PBranchOverride=${BranchOverride} ${target}
 # /external                 : default external data directory visible to Firefly
 
 
-FROM tomcat:9.0-jre17
+FROM tomcat:9.0-jre21-temurin-jammy
 
 ARG build_dir
 ARG user=tomcat

--- a/src/firefly/build.gradle
+++ b/src/firefly/build.gradle
@@ -18,7 +18,8 @@ publishing {
 
 dependencies {
   implementation project(':firefly_data')
-  webappLib configurations.runtimeClasspath, ":firefly"
+  webappLib files(configurations.runtimeClasspath)
+  webappLib project(":firefly")
 }
 
 sourceSets {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1559
- main purpose is to avoid JVM crashing when loading big FITS images.
- required upgrading Gradle from v7.4 to v8.10
- upgrade Tomcat v9 on openjre17 to v9 on openjre21-jammy
- required upgrading Java and Gradle for firefly-help as well
- fix Gradle build scripts as part of upgrading Gradle
- update document to reflect changes

More changes here: 
https://github.com/IPAC-SW/irsa-ife/pull/358
https://github.com/Caltech-IPAC/firefly-help/pull/40
https://github.com/lsst/suit/pull/54

After merging firefly-help, I will also update irsa-ui-help and suit-help.

Requires regression testing.
Test builds:
https://fireflydev.ipac.caltech.edu/firefly-1559-java-21-upgrade/firefly/
https://firefly-1559-java-21-upgrade.irsakudev.ipac.caltech.edu/irsaviewer/
https://firefly-1559-java-21-upgrade.irsakudev.ipac.caltech.edu/applications/sofia/
https://firefly-1559-java-21-upgrade.irsakudev.ipac.caltech.edu/applications/finderchart/
https://firefly-1559-java-21-upgrade.irsakudev.ipac.caltech.edu/applications/euclid/

