### PR TITLE
Firefly-1545: charts better handle large selections

### DIFF
--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -396,7 +396,7 @@ function chartSelect(action) {
         if (get(data, `${activeTrace}.hoverinfo`) === 'skip') { return; }
 
         let selected = undefined;
-        if (!isEmpty(tablesources)) {
+        if (chartTrigger && !isEmpty(tablesources)) {
             const {tbl_id} = tablesources[activeTrace] || {};
             const {totalRows} = getTblById(tbl_id);
             const selectInfoCls = SelectInfo.newInstance({rowCount: totalRows});

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -5,7 +5,7 @@ import {get, isArray, isUndefined, uniqueId, isNil} from 'lodash';
 import {getTblById, getColumns, getColumn, doFetchTable, stripColumnNameQuotes} from '../../tables/TableUtil.js';
 import {cloneRequest, makeSubQueryRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {dispatchChartUpdate, dispatchError, getChartData, getTraceSymbol, hasUpperLimits, hasLowerLimits} from '../ChartsCntlr.js';
-import {formatColExpr, getDataChangesForMappings, updateHighlighted, updateSelected, isScatter2d, getMaxScatterRows, getMinScatterGLRows} from '../ChartUtil.js';
+import {formatColExpr, getDataChangesForMappings, updateHighlighted, updateScatterChartSelected, isScatter2d, getMaxScatterRows, getMinScatterGLRows} from '../ChartUtil.js';
 import {getTraceTSEntries as heatmapTSGetter} from './FireflyHeatmap.js';
 import {errorTypeFieldKey} from '../ui/options/Errors.jsx';
 
@@ -91,7 +91,7 @@ async function fetchData(chartId, traceNum, tablesource) {
         const {activeTrace} = getChartData(chartId);
         if (isUndefined(activeTrace) || activeTrace === traceNum) {
             updateHighlighted(chartId, traceNum, highlightedRow);
-            updateSelected(chartId, selectInfo);
+            updateScatterChartSelected(chartId, selectInfo);
         }
     } else {
         dispatchError(chartId, traceNum, 'No data');

--- a/src/firefly/js/charts/dataTypes/FireflySpectrum.js
+++ b/src/firefly/js/charts/dataTypes/FireflySpectrum.js
@@ -6,7 +6,7 @@ import {isEmpty, pickBy, cloneDeep, set} from 'lodash';
 import {getTblById, getColumn, doFetchTable, getColumnIdx} from '../../tables/TableUtil.js';
 import {getSpectrumDM, REF_POS} from '../../voAnalyzer/SpectrumDM.js';
 import {dispatchChartUpdate, dispatchError} from '../ChartsCntlr.js';
-import {getDataChangesForMappings, updateHighlighted, updateSelected, getMinScatterGLRows, isSpectralOrder} from '../ChartUtil.js';
+import {getDataChangesForMappings, updateHighlighted, updateScatterChartSelected, getMinScatterGLRows, isSpectralOrder} from '../ChartUtil.js';
 import {addOtherChanges, createChartTblRequest, getTraceTSEntries as genericTSGetter} from './FireflyGenericData.js';
 
 import {quoteNonAlphanumeric} from '../../util/expr/Variable.js';
@@ -68,7 +68,7 @@ async function fetchData(chartId, traceNum, tablesource) {
 
         dispatchChartUpdate({chartId, changes});
         updateHighlighted(chartId, traceNum, highlightedRow);
-        updateSelected(chartId, selectInfo);
+        updateScatterChartSelected(chartId, selectInfo);
     } else {
         dispatchError(chartId, traceNum, 'No data');
     }

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -111,8 +111,8 @@ export const ToolbarButton = forwardRef((props,fRef) => {
                              {minHeight:'unset', minWidth:'unset', p:1/4, backgroundColor:'transparent',
                                  '& svg' : {
                                      color: enabled?
-                                         theme.vars.palette.neutral?.plainColor :
-                                         theme.vars.palette.neutral?.softDisabledColor,
+                                         theme.vars.palette[color]?.plainColor :
+                                         theme.vars.palette[color]?.softDisabledColor,
                                  },
                                  opacity: enabled ? '1' : '0.3',
                                  ...makeBorder(active,theme,color),

--- a/src/firefly/js/visualize/ui/Buttons.jsx
+++ b/src/firefly/js/visualize/ui/Buttons.jsx
@@ -1,3 +1,4 @@
+import PriorityHighRoundedIcon from '@mui/icons-material/PriorityHighRounded';
 import React from 'react';
 import {node} from 'prop-types';
 import {Box, Button, IconButton, ToggleButtonGroup} from '@mui/joy';
@@ -176,6 +177,11 @@ export const ToolsDropDown= (props) => (
 // Table and Chart buttons -->
 export const FilterButton = (props) => (
     <ToolbarButton {...{icon: <FilterIco/>, tip: 'Show/edit filters', iconButtonSize:'38px', ...props}}/>
+);
+
+export const WarningButton = (props) => (
+    <ToolbarButton {...{icon: <PriorityHighRoundedIcon />,
+        tip: 'warning', color:'danger', iconButtonSize:'38px', ...props}}/>
 );
 
 export const ClearFilterButton = (props) => (


### PR DESCRIPTION
#### [Firefly-1545](https://jira.ipac.caltech.edu/browse/FIREFLY-1545): charts better handle large selections

 - charts now give warning when selection over 30000 and will not show the selection

#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1545-charts/firefly
 - Load a big file (over 30000 rows)
 - it will show a heatmap so make a scatter chart
 - Select a large area and click check icon
 - A warning dialog will appear only the first time
 - The toolbar will show a warning icon when scatter selection is over 30000