### PR TITLE
Firefly-1545: charts better handle large selections (alternative)

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -44,6 +44,7 @@ import {getColValidator} from './ui/ColumnOrExpression.jsx';
 export const DEFAULT_ALPHA = 0.5;
 
 export const SCATTER = 'scatter';
+export const SCATTERGL = 'scattergl';
 export const HEATMAP = 'heatmap';
 
 export const SELECTED_COLOR = 'rgba(255, 200, 0, 1)';
@@ -376,11 +377,12 @@ export function flattenAnnotations(annotations) {
 
 export function updateSelected(chartId, selectInfo) {
     const {data, activeTrace=0} = getChartData(chartId);
+
+    if (!data?.some((t) => isSelectionSupported(t?.type))) return;      // skip if no trace support selection
+
     const selectInfoCls = SelectInfo.newInstance(selectInfo);
     const selIndexes = getSelIndexes(data, selectInfoCls, activeTrace);
-              // added a check for very long selections, this will disable charts showing selection in this case.
-              // The application locks up without it.
-    if (selIndexes && selIndexes.length<getMaxScatterRows()) {
+    if (selIndexes) {
         dispatchChartSelect({chartId, selIndexes});
     }
 }
@@ -734,6 +736,10 @@ export function applyDefaults(chartData={}, resetColor = true) {
         // default dragmode is select if box selection is supported
         type && !chartData.layout.dragmode && (chartData.layout.dragmode = isBoxSelectionSupported(type) ? 'select' : 'zoom');
     });
+}
+
+export function isSelectionSupported(type) {
+    return [SCATTER, SCATTERGL].includes(type);
 }
 
 export function isBoxSelectionSupported(type) {

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -8,8 +8,10 @@
  * Created by tatianag on 3/17/16.
  */
 
-import {assign, cloneDeep, flatten, get, has, isArray, isEmpty, isObject, isString,
-    isUndefined, merge, pick, range, set, uniqueId} from 'lodash';
+import {
+    assign, flatten, get, has, isArray, isEmpty, isObject, isString,
+    isUndefined, merge, pick, range, set, uniqueId
+} from 'lodash';
 import shallowequal from 'shallowequal';
 
 import {getAppOptions} from '../core/AppDataCntlr.js';
@@ -248,7 +250,7 @@ export function makeHistogramParams(params) {
  */
 export function getRowIdx(traceData, pointIdx) {
     // firefly.rowIdx array in the trace data connects plotly points to table row indexes
-    return Number(get(traceData, `firefly.rowIdx.${pointIdx}`, pointIdx));
+    return get(traceData, `firefly.rowIdx.${pointIdx}`, pointIdx);
 }
 
 /**
@@ -322,19 +324,19 @@ export function combineAllTraceFrom(chartId, selIndexes, newTraceProps) {
 
 export function newTraceFrom(data, selIndexes, newTraceProps, traceAnnotations) {
 
-    const sdata = cloneDeep(pick(data, ['x', 'y', 'z', 'legendgroup', 'error_x', 'error_y', 'text', 'hovertext', 'marker', 'hoverinfo', 'firefly' ]));
+    const sdata = simpleCloneDeep(pick(data, ['x', 'y', 'z', 'legendgroup', 'error_x', 'error_y', 'text', 'hovertext', 'marker', 'hoverinfo', 'firefly' ]));
     Object.assign(sdata, {showlegend: false, type: get(data, 'type', 'scatter'), mode: 'markers'});
 
     // the rowIdx doesn't exist for generic plotly chart case
     if (isScatter2d(get(data, 'type', '')) &&
         !get(sdata, 'firefly.rowIdx') &&
         get(sdata, 'x.length', 0) !== 0) {
-        const rowIdx = range(get(sdata, 'x.length')).map(String);
+        const rowIdx = Array.from({ length: sdata.x.length }, (_, i) => i);
         set(sdata, 'firefly.rowIdx', rowIdx);
     }
 
     if (isArray(traceAnnotations) && traceAnnotations.length > 0) {
-        const annotations = cloneDeep(traceAnnotations);
+        const annotations = simpleCloneDeep(traceAnnotations);
         const color = get(newTraceProps, 'marker.color');
 
         flattenAnnotations(annotations).forEach((a) => {a && (a.arrowcolor = color);});
@@ -375,7 +377,7 @@ export function flattenAnnotations(annotations) {
     return [];
 }
 
-export function updateSelected(chartId, selectInfo) {
+export function updateSelection(chartId, selectInfo) {
     const {data, activeTrace=0} = getChartData(chartId);
 
     if (!data?.some((t) => isSelectionSupported(t?.type))) return;      // skip if no trace support selection
@@ -504,7 +506,7 @@ export function handleTableSourceConnections({chartId, data, fireflyData}) {
                     const tableModel = getTblById(traceTS.tbl_id);
                     const {highlightedRow, selectInfo={}} = tableModel;
                     updateHighlighted(chartId, idx, highlightedRow);
-                    updateSelected(chartId, selectInfo);
+                    updateSelection(chartId, selectInfo);
                 }
             }
             if (!traceTS._cancel) traceTS._cancel = setupTableWatcher(chartId, traceTS, idx);
@@ -577,7 +579,7 @@ function updateChartData(chartId, traceNum, tablesource, action={}) {
         const {activeTrace=0} = getChartData(chartId);
         if (traceNum !== activeTrace) return;
         const {selectInfo={}} = action.payload;
-        updateSelected(chartId, selectInfo);
+        updateSelection(chartId, selectInfo);
     } else {
         if (!isFullyLoaded(tbl_id)) return;
         const tableModel = getTblById(tbl_id);
@@ -1178,4 +1180,24 @@ export function hasTracesFromSameTable(chartId) {
     const {data=[], fireflyData=[]} = getChartData(chartId) || {};
     const tracesTblIds = data.map(({tbl_id}, traceIdx) => tbl_id ?? fireflyData?.[traceIdx]?.tbl_id);
     return tracesTblIds.every((traceTblId, idx, arr) => traceTblId===arr[0] && traceTblId);
+}
+
+/**
+ * This implementation prioritizes performance over robustness.
+ * It only handles plain objects and arrays, skipping more complex cases such as Map, Set, Date, RegExp, and others.
+ * Also, it does not include type checking or manage circular references.
+ * @param {object} obj
+ * @returns {object} a deep clone of the given object
+ */
+function simpleCloneDeep(obj) {
+    if (obj === null || typeof obj !== 'object') return obj;
+    if (Array.isArray(obj)) return obj.map(simpleCloneDeep);
+
+    const copy = {};
+    for (const key of Object.keys(obj)) {
+        if (obj.hasOwnProperty(key)) {
+            copy[key] = simpleCloneDeep(obj[key]);
+        }
+    }
+    return copy;
 }

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -395,18 +395,19 @@ function chartSelect(action) {
         // disable chart select in this case
         if (get(data, `${activeTrace}.hoverinfo`) === 'skip') { return; }
 
-        let selected = undefined;
-        if (!isEmpty(tablesources)) {
-            const {tbl_id} = tablesources[activeTrace] || {};
-            const {totalRows} = getTblById(tbl_id);
-            const selectInfoCls = SelectInfo.newInstance({rowCount: totalRows});
-
-            selIndexes.forEach(([ptIdx, traceIdx]) => selectInfoCls.setRowSelect(getRowIdx(data[traceIdx], ptIdx), true));
-            TablesCntlr.dispatchTableSelect(tbl_id, selectInfoCls.data);
-        }
         // avoid updating chart twice
         // don't update before table select
-        if (!chartTrigger) {
+        if (chartTrigger) {
+            if (!isEmpty(tablesources)) {
+                const {tbl_id} = tablesources[activeTrace] || {};
+                const {totalRows} = getTblById(tbl_id);
+                const selectInfoCls = SelectInfo.newInstance({rowCount: totalRows});
+
+                selIndexes.forEach(([ptIdx, traceIdx]) => selectInfoCls.setRowSelect(getRowIdx(data[traceIdx], ptIdx), true));
+                TablesCntlr.dispatchTableSelect(tbl_id, selectInfoCls.data);
+            }
+        } else {
+            let selected = undefined;
             const hasSelected = !isEmpty(selIndexes);
             if (isSpectralOrder(chartId)) {
                 selected = combineAllTraceFrom(chartId, selIndexes, SELECTED_PROPS);

--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -5,7 +5,7 @@ import {get, isArray, isUndefined, uniqueId, isNil} from 'lodash';
 import {getTblById, getColumns, getColumn, doFetchTable, stripColumnNameQuotes} from '../../tables/TableUtil.js';
 import {cloneRequest, makeSubQueryRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {dispatchChartUpdate, dispatchError, getChartData, getTraceSymbol, hasUpperLimits, hasLowerLimits} from '../ChartsCntlr.js';
-import {formatColExpr, getDataChangesForMappings, updateHighlighted, updateSelected, isScatter2d, getMaxScatterRows, getMinScatterGLRows} from '../ChartUtil.js';
+import {formatColExpr, getDataChangesForMappings, updateHighlighted, updateSelection, isScatter2d, getMaxScatterRows, getMinScatterGLRows} from '../ChartUtil.js';
 import {getTraceTSEntries as heatmapTSGetter} from './FireflyHeatmap.js';
 import {errorTypeFieldKey} from '../ui/options/Errors.jsx';
 
@@ -91,7 +91,7 @@ async function fetchData(chartId, traceNum, tablesource) {
         const {activeTrace} = getChartData(chartId);
         if (isUndefined(activeTrace) || activeTrace === traceNum) {
             updateHighlighted(chartId, traceNum, highlightedRow);
-            updateSelected(chartId, selectInfo);
+            updateSelection(chartId, selectInfo);
         }
     } else {
         dispatchError(chartId, traceNum, 'No data');

--- a/src/firefly/js/charts/dataTypes/FireflySpectrum.js
+++ b/src/firefly/js/charts/dataTypes/FireflySpectrum.js
@@ -6,7 +6,7 @@ import {isEmpty, pickBy, cloneDeep, set} from 'lodash';
 import {getTblById, getColumn, doFetchTable, getColumnIdx} from '../../tables/TableUtil.js';
 import {getSpectrumDM, REF_POS} from '../../voAnalyzer/SpectrumDM.js';
 import {dispatchChartUpdate, dispatchError} from '../ChartsCntlr.js';
-import {getDataChangesForMappings, updateHighlighted, updateSelected, getMinScatterGLRows, isSpectralOrder} from '../ChartUtil.js';
+import {getDataChangesForMappings, updateHighlighted, updateSelection, getMinScatterGLRows, isSpectralOrder} from '../ChartUtil.js';
 import {addOtherChanges, createChartTblRequest, getTraceTSEntries as genericTSGetter} from './FireflyGenericData.js';
 
 import {quoteNonAlphanumeric} from '../../util/expr/Variable.js';
@@ -68,7 +68,7 @@ async function fetchData(chartId, traceNum, tablesource) {
 
         dispatchChartUpdate({chartId, changes});
         updateHighlighted(chartId, traceNum, highlightedRow);
-        updateSelected(chartId, selectInfo);
+        updateSelection(chartId, selectInfo);
     } else {
         dispatchError(chartId, traceNum, 'No data');
     }

--- a/src/firefly/js/tables/SelectInfo.js
+++ b/src/firefly/js/tables/SelectInfo.js
@@ -93,6 +93,25 @@ export class SelectInfo {
         return this.data.selectAll + '-' + Array.from(this.data.exceptions).join(',') + '-' + this.data.rowCount;
     }
 
+    /**
+     * lodash isEqual is really slow when comparing huge Set and maybe array as well.
+     * This is a custom isEqual of the SelectInfos that perform reasonably well.
+     * @param si1  a SelectInfo data
+     * @param si2  another SelectInfo data to compare with
+     * @returns {boolean}
+     */
+    static isEqual(si1, si2) {
+        if (si1?.selectAll !== si2?.selectAll) return false;
+        if (si1?.rowCount !== si2?.rowCount) return false;
+        if (si1?.exceptions.size !== si2?.exceptions.size) return false;
+        for (const value of si1.exceptions) {
+            if (!si2.exceptions.has(value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     static parse(s) {
         var selecInfo = {};
         var parts = s.split('-');

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -1,7 +1,7 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
-import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, isEqual, unset, merge} from 'lodash';
+import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, unset, merge} from 'lodash';
 
 import {flux} from '../core/ReduxFlux.js';
 import * as TblUtil from './TableUtil.js';
@@ -19,6 +19,7 @@ import {REINIT_APP, getAppOptions} from '../core/AppDataCntlr.js';
 import {dispatchComponentStateChange} from '../core/ComponentCntlr.js';
 import {dispatchJobAdd} from '../core/background/BackgroundCntlr.js';
 import {fixPageSize} from './TableUtil.js';
+import {SelectInfo} from 'firefly/tables/SelectInfo';
 
 
 export const TABLE_SPACE_PATH = 'table_space';
@@ -472,7 +473,7 @@ function tableSelect(action) {
     return (dispatch) => {
         const {tbl_id, selectInfo={}} = action.payload;
         const cSelectInfo = get(TblUtil.getTblById(tbl_id), 'selectInfo', {});
-        if (!isEqual(selectInfo, cSelectInfo)) {
+        if (!SelectInfo.isEqual(selectInfo, cSelectInfo)) {
             dispatch(action);       // only dispatch action if changes are needed.
         }
     };


### PR DESCRIPTION
Alternative solution to PR https://github.com/Caltech-IPAC/firefly/pull/1629

[Firefly-1545](https://jira.ipac.caltech.edu/browse/FIREFLY-1545): charts better handle large selections

The first commit addresses two issues:
- Lodash's `_.isEqual` is slow when comparing large sets or arrays.
- Firefly should skip unnecessary selection updates.

These changes enable Firefly to handle scatter plots with up to 1 million rows, instead of crashing at a much smaller datasets. 
However, performance is noticeably slow beyond this point.  It turns out updating the highlighted row rather than selection updates that's slow.

The second commit attempt to optimizes chart highlighting:
- Reduced code execution time from 160ms to around 60ms.
- Unfortunately, the remaining execution time is due to Plotly.js, which I suggest we try  to optimize at a later time.

Test: https://fireflydev.ipac.caltech.edu/firefly-1545-charts-alternative/firefly/
- Upload a large table (over 50k rows).
- You should see coverage, chart(heat map), and table displayed.
- Test table selection; there should be no performance issues.
  - When the chart is not displaying a scatter plot, the table size has no impact on performance.
- Go to chart options -> Overplot New Trace -> select plot type = Scatter, set X and Y axes, then click OK.
- Now test both chart selection and table selection.
  - Performance begins to degrade at 500k rows.
  - It worsens significantly at 1 million rows.
  - 
We might need to consider limiting the size of scatter plots we support.