### PR TITLE
FIREFLY-1535: Chart fix for reversal of axes bug

### DIFF
--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -280,7 +280,7 @@ export class PlotlyWrapper extends Component {
                         this.restyle(this.div, Plotly, data, dataUpdate, dataUpdateTraces);
                         break;
                     case RenderType.RELAYOUT:
-                        Plotly.relayout(this.div, layout);
+                        Plotly.relayout(this.div, layoutUpdate);
                         break;
                     case RenderType.RESTYLE_AND_RELAYOUT:
                         this.restyle(this.div, Plotly, data, dataUpdate, dataUpdateTraces);
@@ -297,6 +297,8 @@ export class PlotlyWrapper extends Component {
                         break;
                     case RenderType.NEW_PLOT:
                         Plotly.newPlot(this.div, data, layout, config);
+                        //after Plotly.newPlot, the div is updated with a new layout, update this for the chart as well
+                        this.syncLayout(chartId, this.div.layout);
                         if (this.div.on) {
                             const chart = this.div;
                             // make sure clicked or selected chart is active


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1535
- The fix is just one line, but this will require some explanation of my findings. 
- Prerequisite to understanding the below is to understand what `autorange` and `range` represent within the `layout` object  in Plotly. 
   - Simply put, if you have a valid `range` entry, then `autorange` **_must_** be set to false. and if there is no valid range, `autorange` is either set to `true` (meaning plotly dynamically calculates axis range) or set to `reversed` (when reversing the axis). 
   - Issues arise when `autorange` is set to `true` while still having a valid `range`. 
- My initial suspect was the logic inside `evalChangesFromFields` in `BasicOptions.jsx` (which determines changes to the layout). Specifically, for this ticket, I was interested in the logic responsible for flipping the axes (~ lines 316-336). 
  - but after some debugging, I found this logic to be sound. It's doing exactly what Plotly expects (according to plotly docs).
     - If a `range` exists, it sets `autorange` to `false` and determines whether the range needs to be reversed. 
     - If a `range` does not exist, it sets `autorange` to either `true` or `reversed` (which may look confusing, but is also correct, per Plotly docs). 
- So then I started inspecting `PlotlyWrapper.jsx`:
   - Here, when you initially render a chart, we call `Plotly.newPlot` (the `RenderType.NEW_PLOT` case, ~line 298). That makes sense. 
   - After this, if a user makes changes to the layout (we'll only consider reversal of axes here), we enter the `RenderType.RELAYOUT` case, which calls `Plotly.relayout` on the current div with a `layoutUpdate` object. `layoutUpdate` is essentially the diff between the previous `layout` and the new `layout` after the user's changes. 
     - so I investigated what's going on with the `layout` object, and found the culprit: 
     - on an initial render (first time we call `PlotlyWrapper`, and then `newPlot`), the `layout` object looks something like this (this is an example from my testing - it has many entries, I'll only show two: xaxis and yaxis)
       -  ``` xaxis: { "autorange": true, .... } ```
       -  ``` yaxis: { "autorange": "reversed", .... } ```
       - both `layout.xaxis` and` layout.yaxis` have a bunch of other entries, but **_NO_** `range` entry. 
   - Now, compare that to the `xaxis` and `yaxis` entries in `this.div.layout` after we have called `Plotly.newPlot(this.div, data, layout, config);` : 
       - ``` xaxis: { "autorange": true, "range": [56651.536092026814, 57667.361874903174] .... } ```
       -  ``` yaxis: { "autorange": "reversed", "range":  [10.293014335577162, 9.897985664422837].... } ```
  - Notice how we now have valid entries for range. This is because the `data` object has arrays that include all entries for both the x-axis and y-axis, which I think determines the `range` when you call `Plotly.newPlot`, and hence our current div's layout that the chart is being displayed on gets this `range`. 
  - But the problem is that our `chart` object's layout is not the same as this new `this.div.layout`. So now when the user makes a change to the layout, like say reversing the x-axis, back in `evalChangesFromFields` in `BasicOptions.jsx`, when we call `getChartData(chartId, {})` (line 296) to get the `layout` object, this layout object still looks like the old one! Meaning it has no `range` entry. And so our code continues setting `autorange` to `true` or `reversed`
     - and so when we get the `layoutUpdate` object in `PlotlyWrapper`,   it's all wrong because the previous layout object has a valid `range`, whereas we just set it to `undefined` (which Plotly ignores) in `evalChangesFromFields` because we have the old `layout` object, which indeed did not have a `range` entry!

- in conclusion: the final fix, when we create a new plot, is to sync up the new plot (or div's) `layout` with our chart's `layout`. Once that is done, the next time user makes a change, with the updated `layout` object in `evalChangesFromFields`, our code immediately sets `autorange` to `false` (when there's a valid `range` available) and determines whether or not to reverse this `range`, which is the correct workflow.
  - then, we continue to call `Plotly.relayout(this.div, layoutUpdate)`, which updates the plot as expected. 



**Testing**: 
Firefly: https://fireflydev.ipac.caltech.edu/firefly-1535-chart-bugs/firefly
Timeseries: https://firefly-1535-chart-bugs.irsakudev.ipac.caltech.edu/irsaviewer/timeseries
- in both firefly and timeseries, perform any search (upload a file in timeseries) that yields some charts. Feel free to add new scatter or histogram or heatmap plots as well. 
  - reverse the x and y axis multiple times for each of the charts (this is the main bug - should be fixed in all cases now)
  - also pin charts multiple times and go to the pinned chart tab, make sure no issues with that. 