### PR TITLE
FIREFLY-1550: Save table in Parquet format

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/FileAnalysis.java
@@ -128,8 +128,7 @@ public class FileAnalysis {
 
     private static FileAnalysisReport analyzeDuckReadable(File infile, Format format, FileAnalysisReport.ReportType type) {
         try {
-            DuckDbReadable dbAdapter = (DuckDbReadable) DbAdapter.getAdapter(infile);
-            DataGroup header = dbAdapter.getInfo();
+            DataGroup header = DuckDbReadable.getInfo(format, infile.getAbsolutePath());
             FileAnalysisReport report = new FileAnalysisReport(type, format.name(), infile.length(), infile.getPath());
             FileAnalysisReport.Part part = new FileAnalysisReport.Part(FileAnalysisReport.Type.Table, String.format("%s (%d cols x %s rows)", format.name(), header.getDataDefinitions().length, header.size()));
             part.setTotalTableRows(header.size());
@@ -139,7 +138,6 @@ public class FileAnalysis {
                 meta.setCols(Arrays.asList(header.getDataDefinitions()));
                 part.setDetails(getDetails(0, meta));
             }
-            dbAdapter.close(true);
             return report;
         } catch (Exception e) {
             return makeReportFromException(e);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
@@ -31,7 +31,7 @@ import static edu.caltech.ipac.util.StringUtils.*;
  * @author loi
  * @version $Id: DbInstance.java,v 1.3 2012/03/15 20:35:40 loi Exp $
  */
-public class DuckDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterCreator {
+public class DuckDbAdapter extends BaseDbAdapter {
     public static final String NAME = "duckdb";
     public static final String DRIVER = "org.duckdb.DuckDBDriver";
     public static String maxMemory = AppProperties.getProperty("duckdb.max.memory");        // in GB; 2G, 5.5G, etc
@@ -63,6 +63,7 @@ public class DuckDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterC
 
     private static final List<String> SUPPORTS = List.of("duckdb");
 
+    public DuckDbAdapter(DbFileCreator dbFileCreator) { this(dbFileCreator.create(NAME)); }
     public DuckDbAdapter(File dbFile) { super(dbFile); }
 
     public String getName() { return NAME; }
@@ -235,7 +236,7 @@ public class DuckDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterC
     }
 
     public static DataGroup getDuckDbSettings() {
-        var db = new DuckDbAdapter(null);
+        var db = new DuckDbAdapter((File) null);
         try {
             return db.execQuery("SELECT * FROM duckdb_settings() WHERE name in ('external_threads','max_memory','memory_limit','threads', 'worker_threads','TimeZone')", null);
         } catch (DataAccessException e) {
@@ -244,13 +245,5 @@ public class DuckDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterC
         }
     }
 
-//====================================================================
-//
-//====================================================================
 
-    /* implement DbAdapterCreator */
-    public DuckDbAdapter() { super(null); }
-    public DbAdapter create(File dbFile) {
-        return canHandle(dbFile) ? new DuckDbAdapter(dbFile) : null;
-    }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/H2DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/H2DbAdapter.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @author loi
  * @version $Id: DbInstance.java,v 1.3 2012/03/15 20:35:40 loi Exp $
  */
-public class H2DbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterCreator {
+public class H2DbAdapter extends BaseDbAdapter {
     public static final String NAME = "mv.db";
 
     private static final List<String> SUPPORTS = List.of(NAME, "h2.db", "db");
@@ -18,19 +18,9 @@ public class H2DbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterCre
     /**
      * used by DbAdapterCreator only
      */
-    H2DbAdapter() {
-        super(null);
-    }
+    public H2DbAdapter (DbFileCreator dbFileCreator) { this(dbFileCreator.create(NAME)); }
     public H2DbAdapter(File dbFile) {
         super(dbFile);
-    }
-
-    public DbAdapter create(File dbFile) {
-        return canHandle(dbFile) ? new H2DbAdapter(dbFile) : null;
-    }
-
-    List<String> getSupportedExts() {
-        return  SUPPORTS;
     }
 
     public String getName() { return NAME; }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/HsqlDbAdapter.java
@@ -21,7 +21,7 @@ import static edu.caltech.ipac.util.StringUtils.groupMatch;
  * @author loi
  * @version $Id: DbInstance.java,v 1.3 2012/03/15 20:35:40 loi Exp $
  */
-public class HsqlDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterCreator {
+public class HsqlDbAdapter extends BaseDbAdapter {
     public static final String NAME = "hsql";
     public static final String DRIVER = "org.hsqldb.jdbc.JDBCDriver";
     private static final List<String> SUPPORTS = List.of(NAME);
@@ -45,18 +45,8 @@ public class HsqlDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterC
     /**
      * used by DbAdapterCreator only
      */
-    HsqlDbAdapter() {
-        super(null);
-    }
+    public HsqlDbAdapter(DbFileCreator dbFileCreator) { this(dbFileCreator.create(NAME)); }
     public HsqlDbAdapter(File dbFile) { super(dbFile); }
-
-    public DbAdapter create(File dbFile) {
-        return canHandle(dbFile) ? new HsqlDbAdapter(dbFile) : null;
-    }
-
-    List<String> getSupportedExts() {
-        return  SUPPORTS;
-    }
 
     public String getName() {
         return NAME;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/SqliteDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/SqliteDbAdapter.java
@@ -10,26 +10,12 @@ import java.util.List;
  * @author loi
  * @version $Id: DbInstance.java,v 1.3 2012/03/15 20:35:40 loi Exp $
  */
-public class SqliteDbAdapter extends BaseDbAdapter implements DbAdapter.DbAdapterCreator {
+public class SqliteDbAdapter extends BaseDbAdapter {
     public static final String NAME = "sqlite";
     private static final List<String> SUPPORTS = List.of(NAME);
 
-    /**
-     * used by DbAdapterCreator only
-     */
-    SqliteDbAdapter() {
-        super(null);
-    }
-
+    public SqliteDbAdapter(DbFileCreator dbFileCreator) { this(dbFileCreator.create(NAME)); }
     public SqliteDbAdapter(File dbFile) { super(dbFile); }
-
-    public DbAdapter create(File dbFile) {
-        return canHandle(dbFile) ? new SqliteDbAdapter(dbFile) : null;
-    }
-
-    List<String> getSupportedExts() {
-        return  SUPPORTS;
-    }
 
     public String getName() {
         return NAME;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -263,14 +263,20 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                                         .toArray(String[]::new);
                 treq.setInclColumns(cols);
             }
-            DataGroupPart page = getData(treq);
             switch(format) {
                 case CSV:
                     new DuckDbReadable.Csv(dbAdapter.getDbFile()).export(treq, out);
-                    break;
+                    return new FileInfo(dbAdapter.getDbFile());
                 case TSV:
                     new DuckDbReadable.Tsv(dbAdapter.getDbFile()).export(treq, out);
-                    break;
+                    return new FileInfo(dbAdapter.getDbFile());
+                case PARQUET:
+                    new DuckDbReadable.Parquet(dbAdapter.getDbFile()).export(treq, out);
+                    return new FileInfo(dbAdapter.getDbFile());
+            }
+
+            DataGroupPart page = getData(treq);
+            switch(format) {
                 case REGION:
                     RegionTableWriter.write(new OutputStreamWriter(out), page.getData(), request.getParam("center_cols"));
                     break;
@@ -297,7 +303,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     }
 
     public void prepareTableMeta(TableMeta defaults, List<DataType> columns, ServerRequest request) {
-        // This is part of the older api.  In the new API, you should update these info directly in fetchDataGroup().
+        // This is part of the older api.  Opportunity for SearchProcessor to add additonal TaIn the new API, you should update these info directly in fetchDataGroup().
     }
 
     public QueryDescResolver getDescResolver() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
@@ -69,8 +69,9 @@ public class ResourceProcessor extends EmbeddedDbProcessor {
      */
     public DbAdapter getDbAdapter(TableServerRequest treq) {
         String resourceID = getResourceID(treq);
-        String fname = String.format("%s/%s", SUBDIR_PATH, resourceID);
-        return DbAdapter.getDbCreator(treq).create(ServerContext.getHiPSDir(), fname);
+        return DbAdapter.getAdapter(treq, (ext) ->
+                new File(ServerContext.getHiPSDir(), "%s/%s.%s".formatted(SUBDIR_PATH, resourceID, ext))
+        );
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SharedDbProcessor.java
@@ -29,9 +29,12 @@ public abstract class SharedDbProcessor extends EmbeddedDbProcessor {
      * it can be easily cleared.
      */
     public DbAdapter getDbAdapter(TableServerRequest treq) {
-        String fname = String.format("%s_%s", treq.getRequestId(), ServerContext.getRequestOwner().getRequestAgent().getSessId());
-        return DbAdapter.getDbCreator(treq).create(QueryUtil.getTempDir(treq), fname);
+        String sessId = ServerContext.getRequestOwner().getRequestAgent().getSessId();
+        return DbAdapter.getAdapter(treq, (ext) ->
+                new File(QueryUtil.getTempDir(treq), "%s_%s.%s".formatted(treq.getRequestId(), sessId, ext))
+        );
     }
+
 
     public FileInfo ingestDataIntoDb(TableServerRequest treq, DbAdapter dbAdapter) throws DataAccessException {
         // nothing to do here.

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -95,7 +95,7 @@ public class IpacTableFromSource extends EmbeddedDbProcessor {
                 File srcFile = fetchSourceFile(req);
                 TableUtil.Format format = DuckDbReadable.guessFileFormat(srcFile.getAbsolutePath());
                 if (format != null && dbAdapter instanceof DuckDbAdapter duckdb) {
-                    return DuckDbReadable.castInto(format, duckdb).ingestDataDirectly(srcFile.getAbsolutePath());
+                    return DuckDbReadable.castInto(format, duckdb).ingestDataDirectly(srcFile.getAbsolutePath(), req);
                 } else {
                     return dbAdapter.ingestData(makeDgSupplier(req, () -> fetchDataFromFile(req, srcFile)), dbAdapter.getDataTable());
                 }
@@ -105,33 +105,6 @@ public class IpacTableFromSource extends EmbeddedDbProcessor {
             throw new DataAccessException(e);
         }
     }
-
-//    /**
-//     * Fetches the data file to determine if DuckDB can read it directly,
-//     * then returns the appropriate DbAdapter.
-//     * @param treq the table request
-//     * @return the DbAdapter for the corresponding data file
-//     */
-//    public DbAdapter getDbAdapter(TableServerRequest treq) {
-//        String id = getUniqueID(treq);
-//        var release = SOURCE_FILE_CHECKER.lock(id);
-//        try {
-//            DbAdapter adpt = adapters.get(id);
-//            if (adpt != null && adpt.hasTable(adpt.getDataTable())) return adpt;
-//            // no DB; create and load DB since we need sourcefile to determine the loading logic
-//            var srcFile = fetchSourceFile(treq);
-//            adpt = DbAdapter.getAdapter(srcFile) instanceof DuckDbReadable dr
-//                    ? dr.useDbFileFrom(getDbFileCreator(treq)) : super.getDbAdapter(treq);
-//            createDbFromRequest(treq, adpt);
-//            adapters.put(id, adpt);
-//            return adpt;
-//        } catch (DataAccessException e) {
-//            throw new RuntimeException(e);
-//        } finally {
-//            release.run();
-//        }
-//    }
-
     private File fetchSourceFile (TableServerRequest req) throws DataAccessException {
 
         String source = req.getParam(ServerParams.SOURCE);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -661,7 +661,7 @@ public class QueryUtil {
         columns[2] = new DataType("rowidx", Integer.class); // need it to tie highlighted and selected to table
         if (doDecimation) {
             columns[3] = new DataType("weight", Integer.class);
-            columns[4] = new DataType(DecimateKey.DECIMATE_KEY, String.class);
+            columns[4] = new DataType("dkey", String.class);
         }
         Class xColClass = columns[0].getDataType();
         Class yColClass = columns[1].getDataType();

--- a/src/firefly/java/edu/caltech/ipac/table/DataType.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataType.java
@@ -71,6 +71,8 @@ public class DataType implements Serializable, Cloneable {
 
     // database mapped types
     public static final String BIGINT = "bigint";      // IPAC table
+    public static final String TINYINT = "tinyint";
+    public static final String SMALLINT = "smallint";
 
     private static final List<Class<?>> FLOATING_TYPES = List.of(Double.class, Float.class);
     private static final List<Class<?>> INT_TYPES = List.of(Short.class, Integer.class, Long.class);
@@ -623,15 +625,15 @@ public class DataType implements Serializable, Cloneable {
 
     public static Class<?> descToType(String desc, Class<?> defaultVal) {
         return switch (desc.toLowerCase()) {
-            case DOUBLE, COMPLEX_DOUBLE, REAL -> Double.class;
-            case FLOAT, COMPLEX_FLOAT   -> Float.class;
-            case LONG, BIGINT           -> Long.class;
-            case INTEGER                -> Integer.class;
-            case SHORT, UNSIGNED_BYTE   -> Short.class;
-            case BOOLEAN, BIT           -> Boolean.class;
-            case BYTE                   -> Byte.class;
-            case DATE                   -> Date.class;
-            case UNI_CHAR, LOCATION, CHAR -> String.class;
+            case DOUBLE, COMPLEX_DOUBLE, REAL       -> Double.class;
+            case FLOAT, COMPLEX_FLOAT               -> Float.class;
+            case LONG, BIGINT                       -> Long.class;
+            case INTEGER                            -> Integer.class;
+            case SHORT, UNSIGNED_BYTE, SMALLINT     -> Short.class;
+            case BOOLEAN, BIT                       -> Boolean.class;
+            case BYTE, TINYINT                      -> Byte.class;
+            case DATE                               -> Date.class;
+            case UNI_CHAR, LOCATION, CHAR           -> String.class;
             default -> defaultVal;
         };
     }

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -229,7 +229,7 @@ public class TableUtil {
     }
 
     /**
-     * takes all of the TableMeta that is column's related and use it to set column's properties.
+     * takes all the TableMeta that is column's related and use it to set column's properties.
      * remove the TableMeta that was used.
      * @param dg
      * @param treq  if not null, merge META-INFO from this request into TableMeta before consuming

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -93,7 +93,7 @@ public class TableUtil {
             return Format.TAR;
         }
 
-        var fmt = DuckDbReadable.guessFileFormat(inf);      // test for files that DuckDb can import directly
+        var fmt = DuckDbReadable.guessFileFormat(inf.getAbsolutePath());      // test for files that DuckDb can import directly
         if (fmt != null) return fmt;
 
         // guess by sampling file content

--- a/src/firefly/java/edu/caltech/ipac/table/io/DataGroupStarTable.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DataGroupStarTable.java
@@ -37,7 +37,8 @@ public class DataGroupStarTable extends RandomStarTable {
 
     public ColumnInfo getColumnInfo(int idx) {
         String cname = columns.get(idx);
-        return convertToColumnInfo(dataGroup.getDataDefintion(cname), dataGroup.getData(cname, 0));
+        var sampleData = dataGroup.size() > 0 ? dataGroup.getData(cname, 0) : null ;
+        return convertToColumnInfo(dataGroup.getDataDefintion(cname), sampleData);
     }
 
     public Object getCell(long irow, int icol) throws IOException {

--- a/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
@@ -6,6 +6,8 @@ package edu.caltech.ipac.util;
 import edu.caltech.ipac.firefly.server.util.Logger;
 
 import javax.validation.constraints.NotNull;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -761,6 +763,17 @@ public class StringUtils {
         return null;
     }
 
+    /**
+     * Return a URL if the input can be successfully parsed as a URL; otherwise, return null.
+     * @param urlString  URL string
+     * @return
+     */
+    public static URL toUrl(String urlString) {
+        try {
+            new URL(urlString);
+        } catch (MalformedURLException ignored) {}
+        return null;
+    }
 
 
     //=========================================================================================

--- a/src/firefly/js/tables/ui/TableSave.jsx
+++ b/src/firefly/js/tables/ui/TableSave.jsx
@@ -45,7 +45,8 @@ const tableFormats = new Enum({ipac: 'IPAC Table (.tbl)',
                                tsv: 'Tab-separated values (.tsv)',
                                'votable-tabledata': 'VOTable - TABLEDATA (.vot)',
                                'votable-binary2-inline': 'VOTable - BINARY2 (.vot)',
-                               'votable-fits-inline': 'VOTable - FITS (.vot)'
+                               'votable-fits-inline': 'VOTable - FITS (.vot)',
+                               'parquet': 'Parquet file with VOTable metadata(.parquet)'
                                //'votable-binary-inline': 'votable-binary: inline BINARY-format VOTable',           // (deprecated) removed
                                //'votable-binary-href': 'votable-binary-href: External BINARY-format VOTable',
                                //'votable-binary2-href': 'votable-binary2-href: External BINAR2Y-format VOTable',
@@ -60,6 +61,7 @@ const tableFormatsExt = {
     'votable-tabledata': 'vot',
     'votable-binary2-inline': 'vot',
     'votable-fits-inline': 'vot',
+    'parquet': 'parquet'
 };
 
 const labelWidth = 100;

--- a/src/firefly/test/edu/caltech/ipac/table/DuckDbAdapterTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/DuckDbAdapterTest.java
@@ -199,7 +199,7 @@ public class DuckDbAdapterTest extends ConfigTest {
 		duckReq.setParam(SEARCH_REQUEST, JsonTableUtil.toJsonTableRequest(duck).toJSONString());
 		duckReq.setParam(DecimationProcessor.DECIMATE_INFO, new DecimateInfo("ra", "dec").toString());
 		duckReq.setPageSize(-1);
-		duckReq.setSortInfo(new SortInfo("decimate_key"));
+		duckReq.setSortInfo(new SortInfo("dkey"));
 
 		TableServerRequest hsqlReq = (TableServerRequest) duckReq.cloneRequest();
 		hsqlReq.setParam(SEARCH_REQUEST, JsonTableUtil.toJsonTableRequest(hsql).toJSONString());
@@ -240,7 +240,7 @@ public class DuckDbAdapterTest extends ConfigTest {
 		EmbeddedDbProcessor proc = (EmbeddedDbProcessor) SearchManager.getProcessor(IpacTableFromSource.PROC_ID);
 		DbAdapter dbAdapter = proc.getDbAdapter(treq);
 
-		assertEquals("DuckDB is used for parquet files", DuckDbReadable.Parquet.NAME, dbAdapter.getName());
+		assertEquals("DuckDB is used for parquet files", DuckDbReadable.NAME, dbAdapter.getName());
 
 		// load the data into the database; 4 tables will be created.  DATA, DATA_DD, DATA_META, and DATA_AUX
 		proc.getData(treq);
@@ -255,9 +255,7 @@ public class DuckDbAdapterTest extends ConfigTest {
 		assertEquals("Temp tables are removed", 4, dbAdapter.getTableNames().size());
 
 		dbAdapter.close(true);
-		DuckDbReadable duckDb = (DuckDbReadable) dbAdapter;
-		assertFalse("DuckDb file is deleted", duckDb.getDbFile().exists());
-		assertTrue("DuckDb data file is still there", duckDb.getSourceFile().exists());
+		assertFalse("DuckDb file is deleted", dbAdapter.getDbFile().exists());
 	}
 
 	@Test

--- a/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
@@ -44,9 +44,8 @@ public class EmbeddedDbUtilTest extends ConfigTest {
 		try {
 			// needed by test testGetSelectedData because it's dealing with code running in a server's context, ie  SearchProcessor, RequestOwner, etc.
 			setupServerContext(null);
-			var creator = DbAdapter.getDbCreator(null);  // get default
 			File tmp = new File(System.getProperty("java.io.tmpdir"));
-			var dbAdapter = creator.create(tmp, DigestUtils.md5Hex(System.currentTimeMillis()+""));
+			var dbAdapter = DbAdapter.getAdapter("", (ext) -> new File(tmp, "%d.%s".formatted(System.currentTimeMillis(), ext)));
 			dbFile = dbAdapter.initDbFile();
 
 			testFile = FileLoader.resolveFile(EmbeddedDbUtilTest.class, "/embedded_db_test.tbl");


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1550

Add support for saving a Firefly table in Parquet format. 
The file will be saved as a `parquet.votable` file, which is a Parquet file with  VOTable metadata. This will allow users to store table data in a highly efficient, columnar storage format while preserving the rich metadata associated with VOTables.

More details about the standard here: https://github.com/astropy/astropy/pull/16375
Sample files here: https://vizcat.cds.unistra.fr/hats:n=1000000/

While testing, I noticed Firefly fails to write out RESOURCES when they are present.  I file this as a bug [FIREFLY-1563](https://jira.ipac.caltech.edu/browse/FIREFLY-1563)

Also, I noticed many sample files with `unit=[]`.  Is this something Firefly need to interpret as empty string or null?

Test: https://fireflydev.ipac.caltech.edu/firefly-1550-save-parquet/firefly/
- Upload or query table data
- Save the table in Parquet format
- Upload the saved Parquet file to demonstrate a round-trip process