### PR TITLE
Firefly-1564: fix some bug found durring testing

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/SpectralCubeEval.java
@@ -47,18 +47,24 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
     }
 
 
-    public static List<TableHdu> findWaveTabHDU(BasicHDU<?>[] HDUs) {
+    private static List<TableHdu> findWaveTabHDU(BasicHDU<?>[] HDUs) {
         List<TableHdu> tableHduList = new ArrayList<>();
         for (int i = 0; (i < HDUs.length); i++) {
             var altProjList = FitsReadUtil.getAtlProjectionIDs(HDUs[i].getHeader());
             var tabHdu = findWaveTabHDU(HDUs, i, "");
-            if (tabHdu != null) tableHduList.add(tabHdu);
+            if (tabHdu != null) addTableHdu(tableHduList,tabHdu);
             for (String alt : altProjList) {
                 tabHdu = findWaveTabHDU(HDUs, i, alt);
-                if (tabHdu != null) tableHduList.add(tabHdu);
+                if (tabHdu != null) addTableHdu(tableHduList,tabHdu);
             }
         }
         return tableHduList;
+    }
+
+    private static void addTableHdu(List<TableHdu> tableHduList, TableHdu tabHdu) {
+        if (tableHduList.stream().noneMatch( (h) -> h.hduIdx==tabHdu.hduIdx)) {
+            tableHduList.add(tabHdu);
+        }
     }
 
     private record TableHdu(int hduIdx, String hduName, int hduVersion, int hduLevel) {}
@@ -66,7 +72,7 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
     private record ExtId(String extName, int extVer, int extLevel) {}
 
     /**
-     * If a FITS file contains multiple XTENSION HDUs (headerdata
+     * If a FITS file contains multiple XTENSION HDUs (header data
      * units) with the specified EXTNAME, EXTVER, and EXTLEVEL,
      * then the result of the WCS table lookup is undefined.
      * If the specified FITS BINTABLE contains no column, or multiple
@@ -113,7 +119,7 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
      * @param hduIdx image HDU
      * @return info lookup table
      */
-    public static TableHdu findWaveTabHDU(BasicHDU<?>[] HDUs, int hduIdx, String alt) {
+    private static TableHdu findWaveTabHDU(BasicHDU<?>[] HDUs, int hduIdx, String alt) {
 
         if (HDUs.length < 2) return null;
 
@@ -126,7 +132,7 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
 
         // check if -TAB coordinate is present in the hdu
         List<Integer> ctypeList = getCtypeWithWave(header, alt);
-        if (ctypeList.size() == 0) return null;
+        if (ctypeList.isEmpty()) return null;
 
         for (int idx : ctypeList) {
             TableHdu tableHdu = findWaveTabHDUForCtypeIdx(HDUs, header, alt, idx);
@@ -136,7 +142,7 @@ class SpectralCubeEval implements FitsEvaluation.Eval {
     }
 
 
-    public static TableHdu findWaveTabHDUForCtypeIdx(BasicHDU<?>[] HDUs, Header header, String alt, int idx) {
+    private static TableHdu findWaveTabHDUForCtypeIdx(BasicHDU<?>[] HDUs, Header header, String alt, int idx) {
 
         // parameter keywords used for the -TAB algorithm to find the extension with lookup table
         // PSi_0a table extension name (EXTNAME)

--- a/src/firefly/js/drawingLayers/WebGridUI.jsx
+++ b/src/firefly/js/drawingLayers/WebGridUI.jsx
@@ -37,7 +37,7 @@ function WebGridUI({drawLayer,pv}) {
            <ListBoxInputFieldView
                onChange={(ev,newValue) => onCoordinateChange( pv.plotId,drawLayer,newValue) }
                options={coordinateOptionArray}
-               value= {pref}
+               value= {pref || coordinateOptionArray[0].value }
                tooltip={'select a coordinate'}
            />
     );

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -183,9 +183,9 @@ export const dpdtMessageWithError= (message,detailMsgAry) => {
  * @return {DataProductsDisplayType}
  */
 export function dpdtImage({name, activate, extraction, menuKey='image-0', extractionText='Pin Image',
-                              request, override, interpretedData, requestDefault, enableCutout,
+                              request, override, interpretedData, requestDefault, enableCutout, pixelBasedCutout,
                               url, semantics,size, serDef }) {
-    return { displayType:DPtypes.IMAGE, name, activate, extraction, menuKey, extractionText, enableCutout,
+    return { displayType:DPtypes.IMAGE, name, activate, extraction, menuKey, extractionText, enableCutout, pixelBasedCutout,
         request, override, interpretedData, requestDefault,url, semantics,size,serDef};
 }
 

--- a/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
@@ -216,7 +216,7 @@ export function makeSingleDataProductWithMenu(dpId, primDPType, size, serviceDes
 
 
 
-function getObsCoreRowMetaInfo(table,row) {
+export function getObsCoreRowMetaInfo(table,row) {
     if (!table || row<0) return {};
     const titleStr= createObsCoreTitle(table,row);
     const dataSource= getObsCoreAccessURL(table,row);

--- a/src/firefly/js/ui/CutoutSizeDialog.jsx
+++ b/src/firefly/js/ui/CutoutSizeDialog.jsx
@@ -1,11 +1,13 @@
 /*
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
+import {isString} from 'lodash';
 import React, {useEffect} from 'react';
 import {
     dispatchShowDialog, dispatchHideDialog, getComponentState, dispatchComponentStateChange
 } from '../core/ComponentCntlr.js';
 import {SD_CUTOUT_KEY} from '../metaConvert/vo/ServDescProducts';
+import {intValidator} from '../util/Validate';
 import CompleteButton from './CompleteButton.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
 import {FieldGroup} from './FieldGroup';
@@ -15,15 +17,16 @@ import {SizeInputFields} from './SizeInputField';
 
 import HelpIcon from './HelpIcon.jsx';
 import {Stack} from '@mui/joy';
+import {ValidationField} from './ValidationField';
 
 const DIALOG_ID= 'cutoutSizeDialog';
 
 
-export function showCutoutSizeDialog(cutoutDefSizeDeg, dataProductsComponentKey) {
+export function showCutoutSizeDialog(cutoutDefSizeDeg, pixelBasedCutout, dataProductsComponentKey) {
     const popup = (
         <PopupPanel title={'Set Cutout Size'}>
             <FieldGroup groupKey={'cutout-size-dialog'} keepState={true}>
-                <CutoutSizePanel {...{cutoutDefSizeDeg,dataProductsComponentKey}}/>
+                <CutoutSizePanel {...{cutoutDefSizeDeg,pixelBasedCutout,dataProductsComponentKey}}/>
             </FieldGroup>
         </PopupPanel>
     );
@@ -34,11 +37,14 @@ export function showCutoutSizeDialog(cutoutDefSizeDeg, dataProductsComponentKey)
 
 
 
-function CutoutSizePanel({cutoutDefSizeDeg,dataProductsComponentKey}) {
+function CutoutSizePanel({cutoutDefSizeDeg,pixelBasedCutout,dataProductsComponentKey}) {
     const cutoutFieldKey= dataProductsComponentKey+'-'+SD_CUTOUT_KEY;
-    const cutoutValue= useStoreConnector( () => getComponentState(dataProductsComponentKey)[SD_CUTOUT_KEY] ?? cutoutDefSizeDeg);
+    let cutoutValue= useStoreConnector( () => getComponentState(dataProductsComponentKey)[SD_CUTOUT_KEY] ?? cutoutDefSizeDeg);
     const [getCutoutSize,setCutoutSize]= useFieldGroupValue(cutoutFieldKey);
 
+    if (isString(cutoutValue) && cutoutValue?.endsWith('px')) {
+       cutoutValue= cutoutValue.substring(0,cutoutValue.length-2);
+    }
 
     useEffect(() => {
         setCutoutSize(cutoutValue);
@@ -46,15 +52,30 @@ function CutoutSizePanel({cutoutDefSizeDeg,dataProductsComponentKey}) {
 
     return (
         <Stack justifyContent='space-between' alignItems='center' spacing={1}>
-            <SizeInputFields fieldKey={cutoutFieldKey} showFeedback={true} label='Cutout Size'
-                             initialState={{
-                                 value: (cutoutDefSizeDeg/3600).toString(),
-                                 tooltip: 'Set cutout size',
-                                 unit: 'arcsec', min:  1/3600, max:  5
-                             }} />
+            { pixelBasedCutout ?
+                <ValidationField {...{
+                    nullAllowed: false,
+                    placeholder:  'enter pixel value',
+                    label: 'Cutout Size in pixels',
+                    fieldKey: cutoutFieldKey,
+                    initialState: {
+                        value: Number(cutoutValue),
+                        validator: intValidator(0, undefined, 'cutout size in pixels')
+                    },
+                    tooltip: 'cutout size'
+                }} />
+                :
+                <SizeInputFields fieldKey={cutoutFieldKey} showFeedback={true} label='Cutout Size'
+                                 initialState={{
+                                     value: (cutoutDefSizeDeg/3600).toString(),
+                                     tooltip: 'Set cutout size',
+                                     unit: 'arcsec', min:  1/3600, max:  5
+                                 }} />
+
+            }
             <Stack {...{textAlign:'center', direction:'row', justifyContent:'space-between', width:1, px:1, pb:1}}>
                 <CompleteButton text='Update Cutout' dialogId={DIALOG_ID}
-                                onSuccess={(r) => updateCutout(r,cutoutFieldKey,dataProductsComponentKey)}/>
+                                onSuccess={(r) => updateCutout(r,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout)}/>
                 <HelpIcon helpId={'visualization.rotate'} />
             </Stack>
         </Stack>
@@ -62,6 +83,9 @@ function CutoutSizePanel({cutoutDefSizeDeg,dataProductsComponentKey}) {
 }
 
 
-function updateCutout(request,cutoutFieldKey,dataProductsComponentKey) {
-    dispatchComponentStateChange(dataProductsComponentKey,{[SD_CUTOUT_KEY]:request[cutoutFieldKey]});
+function updateCutout(request,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout) {
+    dispatchComponentStateChange(dataProductsComponentKey,
+        {
+            [SD_CUTOUT_KEY]:`${request[cutoutFieldKey]}${pixelBasedCutout?'px':''}`
+        });
 }

--- a/src/firefly/js/ui/dynamic/DynamicUISearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/DynamicUISearchPanel.jsx
@@ -5,6 +5,7 @@
 import {Box, Stack} from '@mui/joy';
 import React from 'react';
 import {CoordinateSys, parseWorldPt} from '../../api/ApiUtilImage.jsx';
+import {isDefined} from '../../util/WebUtil';
 import {standardIDs} from '../../voAnalyzer/VoConst.js';
 
 import {CONE_CHOICE_KEY, POLY_CHOICE_KEY} from '../../visualize/ui/CommonUIKeys.js';
@@ -85,6 +86,7 @@ export function convertRequest(request, fieldDefAry, standardIDType) {
                 out[key]= request[key];
                 return out;
             case UNKNOWN:
+                if (isDefined(request[key])) out[key]= request[key];
                 return out;
             case POLYGON:
                 if (standardIDType===standardIDs.sia) out[key]= 'POLYGON ' +cleanupPolygonString(request[polygonKey]);
@@ -291,7 +293,7 @@ function InsetDynSearchPanel({style={}, fieldDefAry, popupHiPS= false, plotId='d
             <div style={style}>
                 <Slot {...{
                     component: FormPanel,
-                    slotProps: slotProps.FormPanel,
+                    slotProps: slotProps?.FormPanel,
                     help_id: 'dynDefaultSearchPanelHelp',
                     onError:() => showInfoPopup('Fix errors and search again', 'Error'),
                     cancelText:'',

--- a/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
+++ b/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
@@ -53,26 +53,6 @@ export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDef, setSe
     };
 
 
-
-
-
-    const Wrapper= ({children}) => (
-        <Stack direction='column' alignItems='flex-start' p={.25}>
-            {children}
-            <Stack {...{direction:'row', justifyContent:'space-between', alignItems:'flex-start',
-                          pt:.5, pr:.5, width:'100%', alignSelf:'flex-start' }}>
-                <CompleteButton onSuccess={(r) => submitSearch(r)}
-                                onFail={() => showInfoPopup('Some field are not valid')}
-                                text={'Submit'} groupKey={GROUP_KEY} />
-                {hasAnySpacial(fieldDefAry) &&
-                    <Typography level='body-xs'>Enter search position or click on background HiPS</Typography>}
-            </Stack>
-        </Stack>
-    );
-
-
-
-
     return (
         <Stack {...{direction:'row', key:serviceDefRef, width:1, height:1}}>
             <Stack {...{direction:'column', p:.25, width:1}}>
@@ -83,8 +63,24 @@ export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDef, setSe
 
                 <FieldGroup groupKey={GROUP_KEY} keepState={false} style={{display:'flex', flexGrow:1}}>
                     <DynLayoutPanelTypes.Inset fieldDefAry={fieldDefAry} style={{width: '100%'}}
-                                               WrapperComponent={Wrapper}
-                                               plotId={plotId}/>
+                                               slotProps={{
+                                                   FormPanel: {
+                                                      onSuccess: (r) => submitSearch(r),
+                                                       onError: () => showInfoPopup('Some field are not valid')
+                                                   }
+                                               }}
+                                               plotId={plotId}>
+                        <Stack direction='column' alignItems='flex-start' p={.25}>
+                            <Stack {...{direction:'row', justifyContent:'space-between', alignItems:'flex-start',
+                                pt:.5, pr:.5, width:'100%', alignSelf:'flex-start' }}>
+                                {/*<CompleteButton onSuccess={(r) => submitSearch(r)}*/}
+                                {/*                onFail={() => showInfoPopup('Some field are not valid')}*/}
+                                {/*                text={'Submit'} groupKey={GROUP_KEY} />*/}
+                                {hasAnySpacial(fieldDefAry) &&
+                                    <Typography level='body-xs'>Enter search position or click on background HiPS</Typography>}
+                            </Stack>
+                        </Stack>
+                    </DynLayoutPanelTypes.Inset>
                 </FieldGroup>
             </Stack>
         </Stack>

--- a/src/firefly/js/ui/tap/TapViewType.jsx
+++ b/src/firefly/js/ui/tap/TapViewType.jsx
@@ -27,7 +27,7 @@ import MoreVertRoundedIcon from '@mui/icons-material/MoreVertRounded';
 import {TableMask} from 'firefly/ui/panel/MaskPanel.jsx';
 
 
-const SERVICE_EXIST_ERROR= 'TAP does not appear to exist or is not accessible';
+const SERVICE_EXIST_ERROR= 'TAP service does not appear to exist or is not accessible';
 
 const SCHEMA_TIP= 'Select a table collection (TAP ‘schema’); type to search the schema names and descriptions.';
 const TABLE_TIP= 'Select a table; type to search the table names and descriptions.';

--- a/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/ColorTableDropDownView.jsx
@@ -225,7 +225,7 @@ const AdvancedColorPanel= ({allowPopout}) => {
 
     const makeItems = () =>
         ctArray.map((ct) =>
-            (<ToolbarButton icon={<img src={ct.icon} style={{height:8, width:200}}/>}
+            (<ToolbarButton icon={ct.icon ? <img src={ct.icon} style={{height:8, width:200}}/> : undefined}
                             tip={ct.tip} style={{padding: '2px 0 2px 0'}}
                             text={ct.icon ? undefined : 'Default Color Map'}
                             enabled={true} horizontal={false} key={ct.id}

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
@@ -49,10 +49,10 @@ export class ImageMetaDataToolbar extends Component {
 
     render() {
         const {activeTable}= this.state;
-        const {visRoot, viewerId, viewerPlotIds, layoutType, dlAry, makeDropDown, serDef, factoryKey, enableCutout}= this.props;
+        const {visRoot, viewerId, viewerPlotIds, layoutType, dlAry, makeDropDown, serDef, factoryKey, enableCutout, pixelBasedCutout= false}= this.props;
         return (
             <ImageMetaDataToolbarView activePlotId={visRoot.activePlotId} viewerId={viewerId}  serDef={serDef}
-                                      enableCutout={enableCutout}
+                                      enableCutout={enableCutout} pixelBasedCutout={pixelBasedCutout}
                                       viewerPlotIds={viewerPlotIds} layoutType={layoutType} dlAry={dlAry}
                                       activeTable={activeTable} makeDataProductsConverter={makeDataProductsConverter}
                                       makeDropDown={makeDropDown} factoryKey={factoryKey} />
@@ -68,5 +68,8 @@ ImageMetaDataToolbar.propTypes= {
     viewerPlotIds : PropTypes.arrayOf(PropTypes.string).isRequired,
     tableId: PropTypes.string,
     factoryKey: PropTypes.string,
-    makeDropDown: PropTypes.func
+    makeDropDown: PropTypes.func,
+    enableCutout: PropTypes.bool,
+    pixelBasedCutout: PropTypes.bool,
+    serDef: PropTypes.object
 };

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbarView.jsx
@@ -27,7 +27,8 @@ import {VisMiniToolbar} from 'firefly/visualize/ui/VisMiniToolbar.jsx';
 import ContentCutRoundedIcon from '@mui/icons-material/ContentCutRounded';
 
 
-export function ImageMetaDataToolbarView({viewerId, viewerPlotIds=[], layoutType, factoryKey, serDef, enableCutout,
+export function ImageMetaDataToolbarView({viewerId, viewerPlotIds=[], layoutType, factoryKey, serDef,
+                                             enableCutout, pixelBasedCutout,
                                           activeTable, makeDataProductsConverter, makeDropDown}) {
 
     const converter= makeDataProductsConverter(activeTable,factoryKey) || {};
@@ -35,7 +36,16 @@ export function ImageMetaDataToolbarView({viewerId, viewerPlotIds=[], layoutType
     const cutoutValue= useStoreConnector( () => getComponentState(dataProductsComponentKey)[SD_CUTOUT_KEY]) ?? getObsCoreOption('cutoutDefSizeDeg') ?? .01;
 
     if (!converter) return <div/>;
-    const cSize= dataProductsComponentKey&&enableCutout ? makeFoVString(Number(cutoutValue)) : '';
+    let cSize='';
+    if (dataProductsComponentKey&&enableCutout) {
+        if (pixelBasedCutout) {
+            cSize= cutoutValue+'';
+        }
+        else {
+            cSize= makeFoVString(Number(cutoutValue));
+        }
+
+    }
 
 
     const layoutDetail= getLayoutDetails(getMultiViewRoot(), viewerId, activeTable?.tbl_id);
@@ -93,7 +103,7 @@ export function ImageMetaDataToolbarView({viewerId, viewerPlotIds=[], layoutType
                     {enableCutout &&
                         <ToolbarButton
                             icon={<ContentCutRoundedIcon/>}
-                            text={`${cSize}`} onClick={() => showCutoutSizeDialog(cutoutValue,dataProductsComponentKey)}/>
+                            text={`${cSize}`} onClick={() => showCutoutSizeDialog(cutoutValue,pixelBasedCutout,dataProductsComponentKey)}/>
                     }
                     {metaControls &&
                         <Stack direction='row' spacing={1} alignItems='center' whiteSpace='nowrap'>
@@ -121,6 +131,8 @@ ImageMetaDataToolbarView.propTypes= {
     makeDataProductsConverter: PropTypes.func,
     makeDropDown: PropTypes.func,
     serDef: PropTypes.object,
+    enableCutout: PropTypes.bool,
+    pixelBasedCutout: PropTypes.bool,
     factoryKey: PropTypes.string
 };
 

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
@@ -25,7 +25,7 @@ export function MultiProductChoice({ dataProductsState, dpId,
                                        makeDropDown, chartViewerId, imageViewerId, metaDataTableId,
                                        tableGroupViewerId, whatToShow, onChange, mayToggle = false, factoryKey
                                    }) {
-    const {serDef, enableCutout}= dataProductsState;
+    const {serDef, enableCutout, pixelBasedCutout=false}= dataProductsState;
     const primeIdx= useStoreConnector(() => getActivePlotView(visRoot())?.primeIdx ?? -1);
     const {current:showingStatus}= useRef({oldWhatToShow:undefined});
     const chartTableOptions = [{label: 'Table', value: SHOW_TABLE}, {label: 'Chart', value: SHOW_CHART}];
@@ -94,7 +94,7 @@ export function MultiProductChoice({ dataProductsState, dpId,
                 <Stack {...{direction: 'column', width:'100%', height:'100%'}}>
                     {mayToggle && toolbar}
                     <MultiImageViewer {...{
-                        viewerId:imageViewerId, insideFlex:true, serDef, enableCutout,
+                        viewerId:imageViewerId, insideFlex:true, serDef, enableCutout,pixelBasedCutout,
                         canReceiveNewPlots: NewPlotMode.none.key, tableId:metaDataTableId, controlViewerMounting:false,
                         makeDropDown: !mayToggle ? makeDropDown : undefined,
                         Toolbar:ImageMetaDataToolbar, factoryKey}} />

--- a/src/firefly/js/voAnalyzer/VoConst.js
+++ b/src/firefly/js/voAnalyzer/VoConst.js
@@ -106,6 +106,8 @@ export const UCDList = ['arith', 'arith.diff', 'arith.factor', 'arith.grad', 'ar
     'time.period.revolution', 'time.period.rotation', 'time.phase', 'time.processing', 'time.publiYear', 'time.relax', 'time.release', 'time.resolution', 'time.scale', 'time.start']; // Columns required for heuristic matching
 
 export const CUTOUT_UCDs= ['phys.size','phys.size.radius','phys.angSize', 'pos.spherical.r'];
+export const RA_UCDs= ['pos.eq.ra'];
+export const DEC_UCDs= ['pos.eq.dec'];
 
 export const OBSTAPCOLUMNS = [
     ['dataproduct_type', 'meta.id', 'ObsDataset.dataProductType'],


### PR DESCRIPTION
### [Firefly-1564](https://jira.ipac.caltech.edu/browse/FIREFLY-1564): fix some bug found during testing

 - redundant adds of related data HDUs in SpectralCubeEval.java (found during sphereX testing)
 - PlotImageTask.js improved logging of RelatedData errors (found during sphereX testing with  @alaity47)
 - WebGridUI.js showing empty options (found by NED)
 - MultiProductViewer
      - Better naming cutout services (found by @alaity47)
      - Better job in recognizing cutout services (found during sphereX testing a datalink table with  @alaity47)
      - Support pixel cutout service  (found during sphereX testing with  @alaity47)
 - Color dropdown in hips mode, empty image for default color option, should be none (found during testing)


#### Testing - Not every thing can be easily tested
- https://fireflydev.ipac.caltech.edu/firefly-1564-bugs/firefly
- Hips colors: 
  - show any HiPS image (Images -> View HiPS image)
  - The color dropdown, `Default Color Map` should look correct, before it was offset.
- Cutouts - recognizing pixel based cutout service descriptors
  - goto tap
  - set tap service to `https://irsadev.ipac.caltech.edu/TAP`
  - choose `Edit ADQL`
  - enter `select top 100 * from spherex.obscore` then search
  - choose data product
  - under `More` choose `Show Cutout: etc` (notice naming is improved and starts with `Show: Cutout`)
  - The cutout option on the toolbar will be pixel based and not degree based
  - change the size to 200 or something and it will update
  - Also notice the the console will log fits related data errors (there will be some)
