### PR TITLE
FIREFLY-1534: Check for utype in the table's resources if one does not exist in the table.

### DIFF
--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -148,9 +148,10 @@
  */
 
 /**
- * Table resources
+ * The first resource (index 0) belongs to this table. The remaining resources are from the same table set,
+ * where no table data exists, only metadata.
  * @typedef {object} RESOURCE
- * @prop {string} ID     ID used to reference this LINK.
+ * @prop {string} ID     ID used to reference this RESOURCE.
  * @prop {string} name
  * @prop {string} type
  * @prop {string} utype
@@ -165,7 +166,7 @@
 /**
  * Table group info
  * @typedef {object} GROUP
- * @prop {string} ID     ID used to reference this LINK.
+ * @prop {string} ID     ID used to reference this GROUP.
  * @prop {string} name
  * @prop {string} ucd
  * @prop {string} utype

--- a/src/firefly/js/voAnalyzer/SpectrumDM.js
+++ b/src/firefly/js/voAnalyzer/SpectrumDM.js
@@ -81,9 +81,10 @@ export const REF_POS = {
  * @returns {SpectrumDM|undefined}
  */
 export function getSpectrumDM(tableModel) {
-    const utype = tableModel?.tableMeta?.utype?.toLowerCase();
-    const isSpectrum = utype === 'spec:Spectrum'.toLowerCase();
+    let utype = tableModel?.tableMeta?.utype?.toLowerCase();
+    utype ??= tableModel?.resources?.[0]?.utype?.toLowerCase();      // If the table doesn't have a utype, use the utype from its resources, which is at index 0.
 
+    const isSpectrum = utype === 'spec:Spectrum'.toLowerCase();
     const isSED = utype === 'ipac:Spectrum.SED'.toLowerCase();
 
     if (!isSpectrum && !isSED) return;


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1534

> should work like this:
> 
> If the table has a Utype, use it.
> If the table does not have a Utype, search "outwards" in the enclosing elements in the XML and use the first one you find.  Thus, in the typical nesting:` <VOTABLE><RESOURCE><TABLE></TABLE></RESOURCE></VOTABLE>` , you would start with the TABLE, and then check the RESOURCE containing it.
 

Test: https://fireflydev.ipac.caltech.edu/firefly-1534-spectrum-utype/firefly/
- Load a spectrum where `utype` is not from `<TABLE>` but from `<RESOURCE>`

