### PR TITLE
Firefly-1570: fix 7(41),10,17

### DIFF
--- a/docs/next-release-details.md
+++ b/docs/next-release-details.md
@@ -6,15 +6,15 @@
 
 
 ### _Notes_
-#### This is probably one of new most new feature pack releases of firefly in several years. It also includes a many, many bug fixes, clean up and optimization (not all list below). 
-                                                                                                           `
+This Firefly release has a lot of new features, probably among the most new features packed into one release over the past several years. 
+It also includes many, many bug fixes, clean up, and optimization (not all are listed below).
 
 #### Major Features
 - Tables: parquet support- Firefly-1477 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1582)) 
 - Tables: save table as parquet using `parquet.votable`- Firefly-1550 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1633)) 
 - Tables: internal data optimization using duckdb - Firefly-1477 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1582)) 
 - Tables: Drawing Overlay Color in table tabs- Firefly-1510 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1600)) 
-- Images/HiPS: hierarchical catalogs- Firefly-1437 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1607)) 
+- Images/HiPS: hierarchical catalogs- Firefly-1457 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1607)) 
 - Data product viewer: recognizes service descriptor defined cutouts- Firefly-1491 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1580)) 
 
 #### New Features
@@ -27,7 +27,7 @@
 
 #### Bug fix / cleanup
 - Fixed: Firefly-1535, reversal of axes bug ([PR](https://github.com/Caltech-IPAC/firefly/pull/1632))
-- Fixed: Dialog sizing: Firefly-1555 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1626)), Firefly-1553 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1624))
+- Fixed: Dialog sizing- Firefly-1555 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1626)), Firefly-1553 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1624))
 - Fixed: Chart related bugs- Firefly-1521 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1614))
 - Fixed: Images: Color dropdown color wrongly invert in dark mode- Firefly-1547 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1612))
 - Fixed: Charts: changing x/y axis does not work- IRSA-6084 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1608))

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/Histogram.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/Histogram.java
@@ -2,9 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 package edu.caltech.ipac.visualize.plot;
-
 import edu.caltech.ipac.firefly.data.HasSizeOf;
-import edu.caltech.ipac.util.SUTDebug;
 
 import java.util.Arrays;
 
@@ -12,7 +10,6 @@ import java.util.Arrays;
  * Creates a histogram of an image
  *
  * @author Booth Hartley
- *
  * Edit history
  * LZ 6/15/15
  *         - Renamed and rewrote the getTblArray method and commented out the eq_tbl and deq_dtbl
@@ -21,8 +18,9 @@ import java.util.Arrays;
 
 
 public class Histogram implements HasSizeOf {
-    private static int HISTSIZ2 = 4096;  /* full size of hist array */
-    private static int HISTSIZ = 2048;     /* half size of hist array */
+    private static final int HISTSIZ2 = 4096;  /* full size of hist array */
+    private static final int HISTSIZ = 2048;     /* half size of hist array */
+    private static final boolean debug= false;
 
     private final int[] hist;
     private double histMin;
@@ -42,7 +40,6 @@ public class Histogram implements HasSizeOf {
             datamax = -Double.MAX_VALUE;
             datamin = Double.MAX_VALUE;
             for (int k = 0; k < float1dArray.length; k++) {
-
                 if (!Double.isNaN(float1dArray[k])) {
                     if (float1dArray[k] < datamin)
                         datamin = float1dArray[k];
@@ -74,29 +71,22 @@ public class Histogram implements HasSizeOf {
                 if (!Double.isNaN(float1dArray[k]))
                 {
                    int i = (int) ((float1dArray[k] - histMin) / histBinsize);
-                      if (i<0)
-                    {
-                        //redo_flag = true;   /* hist_min was bad */
+                    if (i<0) {
                         underflowCount++;
                     }
-                    else if (i>HISTSIZ2)
-                    {
-                        //redo_flag = true;   /* hist_max was bad */
+                    else if (i>HISTSIZ2) {
                         overflowCount++;
                     }
-                    else
-                    {
+                    else {
                         hist[i] ++;
                     }
-                    if (float1dArray[k] < histDatamin)
-                        histDatamin = float1dArray[k];
-                    if (float1dArray[k] > histDatamax)
-                        histDatamax = float1dArray[k];
+                    if (float1dArray[k] < histDatamin) histDatamin = float1dArray[k];
+                    if (float1dArray[k] > histDatamax) histDatamax = float1dArray[k];
                 }
             }
 
 
-            printeDebugInfo(histMax, underflowCount, overflowCount);
+            printDebugInfo(histMax, underflowCount, overflowCount);
             datamin = histDatamin;
             datamax = histDatamax;
 
@@ -138,13 +128,10 @@ public class Histogram implements HasSizeOf {
             }
 
 
-            if (SUTDebug.isDebug())
-                System.out.println("done");
+            if (debug) System.out.println("done");
 
             if ( !doing_redo  &&  redo_flag ) {
-
-                if (SUTDebug.isDebug())
-                    System.out.println("rebuilding histogram . . ");
+                if (debug) System.out.println("rebuilding histogram . . ");
                 doing_redo = true;
             } else
                 break;
@@ -181,8 +168,6 @@ public class Histogram implements HasSizeOf {
 
     private int getHighSumIndex(int lowLimit) {
         int highSum = 0;
-
-
         for (int i = HISTSIZ2; i >= 0; i--) {
             highSum += hist[i];
             if (highSum > lowLimit) {
@@ -200,17 +185,12 @@ public class Histogram implements HasSizeOf {
         return (int) (goodpix * 0.0005);
     }
 
-    private void printeDebugInfo(double hist_max, int underFlowCount, int overFlowCount) {
-        if (SUTDebug.isDebug()) {
+    private void printDebugInfo(double hist_max, int underFlowCount, int overFlowCount) {
+        if (debug) {
             System.out.println("histMin = " + histMin);
             System.out.println("hist_max = " + hist_max);
             System.out.println("histBinsize = " + histBinsize);
-
-
-            System.out.println("underFlowCount = " + underFlowCount +
-                    "  overFlowCount = " + overFlowCount);
-
-
+            System.out.println("underFlowCount = " + underFlowCount + "  overFlowCount = " + overFlowCount);
         }
     }
 
@@ -258,7 +238,7 @@ public class Histogram implements HasSizeOf {
             i++;
             sum = sum + hist[i];
         } while (sum < goal);
-        if (SUTDebug.isDebug()) {
+        if (debug) {
             System.out.println("goodpix = " + goodpix
                     + "   goal = " + goal
                     + "   i = " + i
@@ -404,9 +384,7 @@ public class Histogram implements HasSizeOf {
         return tbl;
     }
 
-    public long getSizeOf() {
-        return hist.length*4L + 32L;
-    }
+    public long getSizeOf() { return hist.length*4L + 40L; }
 
     public double getLargeBinPercent() { return largeBinPercent; }
 }

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -253,8 +253,7 @@ function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOn
     else {
 
         let {chartTableDefOption}= part;
-        if (getRowCnt(part,partFormat)===1) {
-            if (!xCol || !yCol) return;
+        if (getRowCnt(part,partFormat)===1 && xCol && yCol) {
             if (chartTableDefOption===AUTO) chartTableDefOption= SHOW_TABLE;
             return dpdtChartTable(ddTitleStr,
                 createChartSingleRowArrayActivate(fileOnServer,'Row 1 Chart',activateParams,xCol,yCol,0,tbl_index, dataTypeHint),

--- a/src/firefly/js/metaConvert/UploadAndAnalysis.js
+++ b/src/firefly/js/metaConvert/UploadAndAnalysis.js
@@ -14,7 +14,7 @@ import {
     getActiveFileMenuKeyByKey, getDataProducts
 } from './DataProductsCntlr';
 import {
-    dpdtImage, dpdtMessageWithDownload, dpdtMessageWithError, dpdtPNG, dpdtUploadError, DPtypes,
+    dpdtImage, dpdtMessage, dpdtMessageWithDownload, dpdtMessageWithError, dpdtPNG, dpdtUploadError, DPtypes,
 } from './DataProductsType';
 import {dpdtSendToBrowser} from './DataProductsType.js';
 import {createSingleImageActivate, createSingleImageExtraction} from './ImageDataProductsUtil';
@@ -281,8 +281,7 @@ function deeperInspection({ table, row, request, activateParams,
         if (actIdx<0) actIdx= fileMenu.initialDefaultIndex;
     }
     else {// error case
-        const msg= makeErrorMsg(parts,fileFormat);
-        return dpdtMessageWithDownload(msg, 'Download File', url, fileFormat==='FITS'&&'FITS');
+        return makeErrorDP(parts,fileFormat);
     }
     dispatchUpdateActiveKey({dpId, activeFileMenuKeyChanges:{[fileMenu.activeItemLookupKey]:fileMenu.menu[actIdx].menuKey}});
     return {...fileMenu.menu[actIdx],fileMenu};
@@ -290,12 +289,13 @@ function deeperInspection({ table, row, request, activateParams,
 }
 
 
-function makeErrorMsg(parts, fileFormat) {
+function makeErrorDP(parts, fileFormat, url) {
     if (parts.every( (p) => p.type===FileAnalysisType.HeaderOnly) && fileFormat==='FITS') {
-        return 'You may only download this File - Nothing to display - FITS file has only header HDUs';
+        const msg= 'You may only download this File - Nothing to display - FITS file has only header HDUs';
+        return dpdtMessageWithDownload(msg, 'Download File', url, fileFormat==='FITS'&&'FITS');
     }
     else {
-        return 'Cannot analyze file';
+        return dpdtMessage('Cannot analyze file');
     }
 }
 

--- a/src/firefly/js/ui/InputFieldView.jsx
+++ b/src/firefly/js/ui/InputFieldView.jsx
@@ -41,7 +41,7 @@ export function InputFieldView(props) {
                 <FormControl {...{orientation, required, error:!valid, ...slotProps?.control}}>
                     {label && <FormLabel {...slotProps?.label}>{label}</FormLabel>}
                     <Input {...{
-                        value: currValue,
+                        value: currValue??'',
                         disabled:readonly,
                         ref: inputRef,
                         startDecorator, endDecorator,

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -385,7 +385,8 @@ function Services({serviceUrl, servicesShowing, tapOps, onTapServiceOptionSelect
                                     (<ServiceOpRender {...{ ops: tapOps, value,
                                         onTapServiceOptionSelect, clearServiceOnDelete:true}}/>),
                             decorator:
-                                (label,value) => (<ServiceOpRender {...{ ops: tapOps, value, onTapServiceOptionSelect}}/>),
+                                (label,value) => (<ServiceOpRender {...{ ops: tapOps, value,
+                                    onTapServiceOptionSelect, clearServiceOnDelete:value===serviceUrl}}/>),
                         }} /> )}
                     <FormHelperText sx={{m: .25}}>
                         {enterUrl ? 'Type the url of a TAP service & press enter' : 'Choose a TAP service from the list'}

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -434,6 +434,7 @@ function isOldTap(serviceUrl) {
 export const loadSchemaDef = memoize(async (serviceUrl) => {
 
     try {
+        if (!serviceUrl) return;
         const tableModel= supportJoin(serviceUrl)
                 ? await loadSchemaDefJoin(serviceUrl)
                 : await loadSchemaDefNoJoin(serviceUrl);

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -1025,7 +1025,7 @@ export function getLinePointAry(pt1, pt2) {
         }
         return pts;
     }
-    return null;
+    return;
 }
 
 function getEllipsePointForAngle(cx, cy, rx, ry, rotationAngle, theta) {

--- a/src/firefly/js/visualize/ui/multiProduct/MPMessages.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MPMessages.jsx
@@ -23,8 +23,8 @@ export function AdvancedMessage({dpId, dataProductsState, noProductMessage, doRe
 
 
 export function ProductMessage({menu, singleDownload, makeDropDown, isWorkingState=false, message, url}) {
-    let dMsg = singleDownload && menu[0].name;
-    if (dMsg && menu[0].fileType) dMsg = `${dMsg}, type: ${menu[0].fileType}`;
+    let dMsg = singleDownload && (menu?.[0].name ?? '');
+    if (dMsg && menu?.[0].fileType) dMsg = `${dMsg}, type: ${menu[0].fileType}`;
     let actionUrl = url;
     if (singleDownload && !url) actionUrl = isArray(menu) && menu.length && menu[0].url;
 
@@ -39,7 +39,7 @@ export function ProductMessage({menu, singleDownload, makeDropDown, isWorkingSta
                 <Typography level='title-lg' sx={{alignSelf: 'center', textAlign:'center'}}>{message}</Typography>
             </Stack>
             {
-                singleDownload && <CompleteButton sx={{alignSelf: 'center', pt: 3}} text={dMsg}
+                actionUrl && singleDownload && <CompleteButton sx={{alignSelf: 'center', pt: 3}} text={dMsg}
                                                   onSuccess={() => doDownload(actionUrl)}/>
             }
         </Stack>


### PR DESCRIPTION
#### [Firefly-1570](https://jira.ipac.caltech.edu/browse/FIREFLY-1570): Fix the bugs from testing document: https://confluence.ipac.caltech.edu/display/IRSA/Testing+Sep-Oct+2024

- line 7,41
   - can't choose free initially
   - flip between column and line lock, it moves the line but doesn't refresh the plot. and it doesn't go back to the line i had before.
   - random clicking (as i'm frustrated and trying to sort it out) makes it behave strangely. ideally give an error message. but at least don't behave like point extraction
   - name selection options more clearly
- line 10 - removing user added TAP service
- line 17 - loading datalink xml file
- clean up release notes per @lrebull 's sugestions

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1570-7-10-17/firefly


#### Tested
- [x] 7 - Fixed: can't choose free initially
- [x] 7 - Fixed: flip between column and line lock, it moves the line but doesn't refresh the plot. and it doesn't go back to the line i had before.
- [x] 7 - Fixed: random clicking (as i'm frustrated and trying to sort it out) makes it behave strangely. ideally give an error message. but at least don't behave like point extraction
- [x] 7 - Fixed: name selection options more clearly
- [x] 10 - Fixed: removing user added TAP service
- [x] 17 - Fixed: loading datalink xml file

