### PR TITLE
FIREFLY-1492: Timeseries Period Finder Layout Issues

### DIFF
--- a/src/firefly/js/templates/lightcurve/LCPanels.css
+++ b/src/firefly/js/templates/lightcurve/LCPanels.css
@@ -34,13 +34,6 @@
     cursor: auto;
 }
 
-.phaseFolded {
-    display: inline-flex;
-    width: 100%;
-    height: 100%;
-}
-
-
 .settingBox {
     margin-bottom: 3px;
     padding: 5px 10px 10px 5px;

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -20,12 +20,12 @@ import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import Validate from '../../util/Validate.js';
 import {dispatchActiveTableChanged} from '../../tables/TablesCntlr.js';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
-import FieldGroupCntlr, {dispatchValueChange, dispatchMultiValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
+import FieldGroupCntlr, {dispatchMultiValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {getActiveTableId, getColumnIdx, getTblById} from '../../tables/TableUtil.js';
 import {LC, updateLayoutDisplay, getValidValueFrom, getFullRawTable} from './LcManager.js';
 import {doPFCalculate, getPhase} from './LcPhaseTable.js';
 import {LcPeriodogram, cancelPeriodogram, popupId, startPeriodogramPopup} from './LcPeriodogram.jsx';
-import {ReadOnlyText, getTypeData} from './LcUtil.jsx';
+import {getTypeData} from './LcUtil.jsx';
 import {LO_VIEW, getLayouInfo,dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
 import {isDialogVisible, dispatchHideDialog} from '../../core/ComponentCntlr.js';
 import {updateSet} from '../../util/WebUtil.js';
@@ -47,8 +47,6 @@ export var isBetween = (a, b, c) => (c >= a && c <= b);
 
 const PanelResizableStyle = {
     width: 550,
-    minWidth: 400,
-    minHeight: 300,
     marginLeft: 15,
     overflow: 'auto',
     padding: '2px'
@@ -221,18 +219,23 @@ const PeriodStandardView = (props) => {
     // const aroundButton = {margin: space};
 
     return (
-        <FieldGroup groupKey={pfinderkey} style={{display: 'flex', flexDirection: 'column', position: 'relative', flexGrow: 1, minHeight: 500}}
+        <FieldGroup groupKey={pfinderkey} sx={{ display: 'flex', flexDirection: 'column', position: 'relative', flexGrow: 1, minHeight: 500 }}
                     reducerFunc={LcPFReducer(initState)}  keepState={true}>
             <div style={{flexGrow: 1, position: 'relative'}}>
                 <SplitPane split='horizontal' primary='second' maxSize={-100} minSize={100} defaultSize={400}>
                     <SplitContent>
-                        <div className='phaseFolded'>
-                            <Box {...{
-                                mr: 1/4, px: 1, width: 1, maxWidth: 540, overflow: 'auto' }}>
-                                <LcPFOptionsBox/>
-                            </Box>
-                            <PhaseFoldingChart/>
-                        </div>
+
+                        <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={565}>
+                            <SplitContent>
+                                <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow:'auto'}}>
+                                    <LcPFOptionsBox/>
+                                </Box>
+                            </SplitContent>
+                            <SplitContent>
+                                <PhaseFoldingChart/>
+                            </SplitContent>
+                        </SplitPane>
+
                     </SplitContent>
                     <LcPeriodogram displayMode={displayMode}/>
                 </SplitPane>
@@ -349,8 +352,8 @@ class PhaseFoldingChartInternal extends PureComponent {
                     exponentformat:'e'
                 },
                 margin: {
-                    l: 50,
-                    r: 5,
+                    l: 60,
+                    r: 30,
                     b: 50,
                     t: 50,
                     pad: 2
@@ -415,24 +418,25 @@ class PhaseFoldingChartInternal extends PureComponent {
 
     render() {
         const {dataUpdate} = this.state;
-        const {plotlyData, plotlyDivStyle, plotlyLayout}= this.chartingInfo;
+        const {plotlyData, plotlyDivStyle, plotlyLayout} = this.chartingInfo;
 
+        //original div below insted of stack: <div className='ChartPanel__chartresizer' >
         return (
-            <div className='ChartPanel__chartresizer' >
-                <PlotlyWrapper data={plotlyData} layout={plotlyLayout}  style={plotlyDivStyle}
+            <Stack sx={{height: '100%', width: '98%'}}>
+                <PlotlyWrapper data={plotlyData} layout={plotlyLayout} style={plotlyDivStyle}
                                dataUpdate={dataUpdate}
                                autoSizePlot={true}
                                autoDetectResizing={true}
-                               divUpdateCB={(div) => this.chart= div}
+                               divUpdateCB={(div) => this.chart = div}
                                newPlotCB={this.afterRedraw}
                 />
-            </div>
+            </Stack>
         );
     }
 
 }
 
-export const PhaseFoldingChart= wrapResizer(PhaseFoldingChartInternal);
+export const PhaseFoldingChart = wrapResizer(PhaseFoldingChartInternal);
 
 //<ReactHighcharts config={this.state.config} isPureConfig={true} ref='chart'/>
 
@@ -595,16 +599,17 @@ function LcPFOptions({fields}) {
     const offset = 16;
     const highlightW = PanelResizableStyle.width-panelSpace - offset;
     const hasPeriodgramData= Boolean(peridogramTbl?.isFetching===false && peridogramTbl?.tableData?.data?.length);
+
     return (
-        <Stack>
-            <Card>
-                <Stack {...{spacing:3}}>
-                    <Stack {...{spacing:1}}>
-                        <Stack direction='row' spacing={2} alignItems='flexStart'>
+        <Stack sx={{flexGrow: 1, p:2}}>
+            <Card sx={{ flexGrow: 1}}>
+                <Stack {...{spacing:3, sx:{flexGrow: 1}}}>
+                    <Stack {...{spacing:1,sx:{flexGrow: 1, justifyContent: 'space-evenly', alignItems:'stretch'}}}>
+                        <Stack direction='row' spacing={2} alignItems='flexStart' sx={{flexGrow: 1}}>
                             <Typography level='body-sm'> {PERIOD_FINDER_HELP} </Typography>
                             <HelpIcon helpId={'findpTSV.settings'}/>
                         </Stack>
-                        <Stack {...{direction:'row', spacing:3}}>
+                        <Stack {...{direction:'row', spacing:3, sx:{flexGrow:1}}}>
                             <Stack {...{direction:'row', spacing:1}}>
                                 <Typography >{defValues?.[fKeyDef.time.fkey]?.label}</Typography>
                                 <Typography color='warning'> {getVal(fKeyDef.time.fkey)} </Typography>
@@ -614,7 +619,7 @@ function LcPFOptions({fields}) {
                                 <Typography color='warning'> {getVal(fKeyDef.flux.fkey)} </Typography>
                             </Stack>
                         </Stack>
-                        <Stack>
+                        <Stack sx={{flexGrow: 1}}>
                             <Stack {...{direction:'row',spacing:1,alignItems:'center'}}>
                                 <Typography level='body-lg'>Set Period</Typography>
                                 <Typography level='body-sm'>(three ways)</Typography>
@@ -655,7 +660,7 @@ function LcPFOptions({fields}) {
 
                         <ValidationField fieldKey={fKeyDef.tz.fkey} label='Time Offset' sx={{width:'12rem'}}/>
                     </Stack>
-                    <Stack {...{direction: 'row', justifyContent:'space-between'}}>
+                    <Stack {...{direction: 'row', sx:{flexGrow: 1, justifyContent: 'space-between', alignItems:'flex-end'}}}>
                         <Stack {...{direction: 'row', spacing:2}}>
                             <CompleteButton groupKey={[pfinderkey]} onSuccess={setPFTableSuccess()} onFail={setPFTableFail()}
                                             text='Accept' includeUnmounted={true} />


### PR DESCRIPTION
**Ticket**: [FIREFLY-1492](https://jira.ipac.caltech.edu/browse/FIREFLY-1492)
- see screenshot in ticket for a quick summary existing layout issues
   - a lot of these issues occur due to resizing browser size, if you opened the browser with a small enough size and didn't resize, you may not even notice these 
- There are 4 major components on the page, tried to make them equally spaced out 
- The `LcPFOptionsBox` (the box on the top left) looked awkward when browser size is large enough, leaving whitespace between itself and the table below
  - I essentially used `flexGrow: 1` here to make it expand into and take up the whitespace
  - This may look a little awkward, but I tried to make the component internally spaced out as well. Open to better suggestions. 
- Made the top-right chart expand to the right (to use up the whitespace) and also expand/contract when you resize the browser size (earlier this chart would only grow/shrink in size vertically, not horizontally). 
- When you zoom into the top right chart, the increase in precision leads to increasing number of digits (decimals) for the y-axis, until you eventually don't see the beginning of these numbers 
  - this also affects our plotly chars in general, not just here in the `Period Finder...`
  - we could have a new ticket to address this

**Testing**: 
- **Timeseries**:  https://firefly-1492-timeseries-layout-bug.irsakudev.ipac.caltech.edu/irsaviewer/timeseries
- Upload a file, then click on `Period Finder...`
- Before clicking on `Calculate Periodogram`, notice the `LcPFOptionsBox` on the left and the chart on the right are the same height, make the browser size bigger/smaller. 
- Click on `Calculate Periodogram`
- As you make the browser size smaller, the `LcPFOptionsBox` (top left) will become scrollable (this is pre-existing behavior), but as you make it bigger, it'll keep expanding to take up the whitespace. 
  -  the top right chart also expands & shrinks vertically and horizontally as you resize the browser window 
- Also play around with the divider (SplitContent) both horizontally between the 2 top components and the 2 bottom ones, and also vertically (between the 2 left and 2 right components), resizing this way to ensure there are no issues with the layout. 
- Essentially, be sure to test with different browser sizes, the layout should remain consistent throughout. 