### PR TITLE
FIREFLY-1568: Periodogram Render bug fix

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -505,7 +505,6 @@ function periodogramSuccess(popupId, hideDropDown = false) {
             /*sortInfo: sortInfoString('Power', false)*/
         }, {tbl_id: LC.PERIODOGRAM_TABLE, inclCols : '"Period", "Power"'});
 
-
         if (tReq !== null) {
             dispatchTableSearch(tReq, {removable: true, tbl_group: LC.PERIODOGRAM_GROUP});
             const dispatchParams= {
@@ -523,7 +522,8 @@ function periodogramSuccess(popupId, hideDropDown = false) {
                     title: {text: 'Periodogram'},
                     xaxis: {type: 'log', showgrid: true},
                     yaxis: {showgrid: true, range: [0, undefined]}
-                }
+                },
+                mounted: true
             };
             dispatchChartAdd(dispatchParams);
         }


### PR DESCRIPTION
**Ticket**: [FIREFLY-1568](https://jira.ipac.caltech.edu/browse/FIREFLY-1568)
- see ticket for bug description
- Fix: just set `mounted: true` when calling `dispatchChartAdd`. 
  - That fixes the bug in the ticket, but there may need to be further discussion (or new ticket) to clean up our general mounting/unmounting logic. 
- ~~Fix: when recalculating periodogram, the `chartId: 'periodogram'` is the same as before, but to mount a chart, we rely on a useEffect in `ChartPanelView` (`ChartPanel.jsx` line 22) that's triggered by a `chartId`. 
   this is the reason why changing table tabs (to `peaks table` and back to `periodogram` makes the chart show up)
   therefore, when recalculating periodogram, I appended a counter to the `chartId` so that it's changed and triggers this `useEffect`~~
- ~~I'm not convinced this is the best way to address this bug, and I'd spent some time looking at ChartsCntlr as well. Open to other suggestions as well.~~

Testing: 
- Timeseries: https://firefly-1568-periodogram-render-bug.irsakudev.ipac.caltech.edu/irsaviewer/timeseries
- Firefly (charts should be unaffected): https://fireflydev.ipac.caltech.edu/firefly-1568-periodogram-render-bug/firefly
- in timeseries, upload a file: 
  - go to `Period Finder`, then click `Calculate Periodogram`
  - now, click on `recalculate periodogram` (from the top left LcPfOptions component)
  - you should see the new chart (it shouldn't be empty now, as described in the ticket). 