### PR TITLE
FIREFLY-1575: Simbad query returns duplicate columns

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
@@ -26,6 +26,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static edu.caltech.ipac.table.TableUtil.getAliasName;
 
 /**
  * @author loi
@@ -98,9 +101,10 @@ public abstract class DuckDbReadable extends DuckDbAdapter {
         StopWatch.getInstance().start("getInfo: " + source);
         String readSource = sqlReadSource(source);
         int count = JdbcFactory.getSimpleTemplate(getDbInstance()).queryForInt("SELECT count(*) from %s".formatted(readSource));
-        DataGroup table = execQuery("SELECT * from %s LIMIT 0".formatted(readSource), null);
+        DataGroup table = getTableMeta(source, null);
+        Arrays.stream(table.getDataDefinitions()).forEach(dt -> dt.setKeyName(getAliasName(dt)));  // show case-sensitive column names if exists
         table.setSize(count);
-        StopWatch.getInstance().printLog("getInfo: " + readSource);
+        StopWatch.getInstance().printLog("getInfo: " + source);
         return table;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -9,6 +9,8 @@ import edu.caltech.ipac.util.StringUtils;
 import java.io.Serializable;
 import java.util.*;
 
+import static edu.caltech.ipac.table.TableUtil.fixDuplicates;
+
 /**
  * Object representing tabular data.  For historic reason, DataObject represent a row and DataType represent a column.
  */
@@ -38,6 +40,7 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
 
     public DataGroup(String title, List<DataType> dataDefs) {
         this.title = title;
+        fixDuplicates(dataDefs);
         dataDefs.forEach(this::addDataDefinition);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/IpacTableUtil.java
@@ -487,7 +487,7 @@ public class IpacTableUtil {
                     int endoffset = Math.min(pci.endIdx, endOfLine);
                     String val = line.substring(pci.startIdx, endoffset).trim();
 
-                    if (!isKnownType(dt.getDataType())) {
+                    if (dt.getDataType() == null) {
                         IpacTableUtil.guessDataType(dt, val);
                     }
                     applyGuessLogic(dt, val, pci);

--- a/src/firefly/java/edu/caltech/ipac/table/io/DataGroupStarTable.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DataGroupStarTable.java
@@ -1,6 +1,8 @@
 package edu.caltech.ipac.table.io;
 
 import edu.caltech.ipac.table.DataGroup;
+
+import static edu.caltech.ipac.table.TableUtil.getAliasName;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
 
 import edu.caltech.ipac.util.StringUtils;
@@ -77,7 +79,8 @@ public class DataGroupStarTable extends RandomStarTable {
 
         // name, datatype, <DESCRIPTION>
         String desc = dt.getDesc();
-        ColumnInfo col = new ColumnInfo(dt.getKeyName(), dType, desc);
+        String cname = getAliasName(dt);
+        ColumnInfo col = new ColumnInfo(cname, dType, desc);
         // LINK child
         List<LinkInfo> links = dt.getLinkInfos();
         if (links.size() > 0 && !isEmpty(links.get(0).getHref())) {

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -48,6 +48,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static edu.caltech.ipac.table.TableUtil.getAliasName;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static uk.ac.starlink.table.StoragePolicy.PREFER_MEMORY;
@@ -602,6 +603,7 @@ public class VoTableReader {
             part.setIndex(parts.size());
             part.setFileLocationIndex(parts.size());
             DataGroup dg = getTableHeader(table);
+            Arrays.stream(dg.getDataDefinitions()).forEach(dt -> dt.setKeyName(getAliasName(dt)));  // show case-sensitive column names if exists
             List<ResourceInfo> resources = getResourcesForTable(docRoot, table);
             if (resources != null) dg.setResourceInfos(resources);
             String title = isEmpty(dg.getTitle()) ? "VOTable" : dg.getTitle().trim();


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1575
- The column names only differ in terms of case sensitivity (uppercase vs. lowercase).
- Add support for VOTable and Parquet formats.
- For other formats, duplicate column names will have '_idx' appended to ensure uniqueness.

Solution:
When a duplicate column is detected, we will append an index to the column name (e.g., col_a becomes col_a_1). 
The original name (col_a) will be saved as `column.label`, which will be displayed in the UI. If the column's `ID` doesn't already exist, we will assign the modified name (col_a_1) as the column's ID to indicate the uniqueness of the column.
These information will be used to accurately write back the file in its original format.

Test: https://fireflydev.ipac.caltech.edu/firefly-1575-simbad-dulicate-columns/firefly/
- Follow the steps in the ticket to ensure it is working correctly now.

For regression testing, I've attached two sample files to the ticket, simbad.vot and dup-cols.csv, to demonstrate the behavior of this change.

**CSV:**
- Upload the dup-cols.csv file.
- Observe that the second column name is appended with _1.

**VOTable:**
- Upload simbad.vot (a saved result from a Simbad query).
- In the file summary, filter the `name` column by typing 'filter' to display only column names containing 'filter.'
- You'll notice both `FILTER_NAME_U` and `FILTER_NAME_u` appear.
- Internally, `FILTER_NAME_u` is represented as `FILTER_NAME_u_1`, but it is displayed normally to the user.

The internal name is only relevant in the `Advanced Filter`:
- Load the simbad.vot table.
- Go to Table Settings (gear icon) -> Advanced Filter.
- On the left pane, click `FILTER_NAME_u`, and note that the internal name `FILTER_NAME_u_1` is used.

You can also test saving this table in VOTable or Parquet format to verify that the file is written back accurately.
