### PR TITLE
Firefly-1587: improving overlays

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,8 +8,8 @@
 
 
 ## Version 2024.3
-- 2024.3.0 - (Oct 18, 2024),  _docker tag_: `latest`, `2024.3`, `2024.3.0`
-
+- 2024.3.1 - (Oct 24, 2024),  _docker tag_: `latest`, `2024.3`, `2024.3.1`
+- 2024.3.0 - (Oct 18, 2024),  _docker tag_: `2024.3.0`
 
 ### _Notes_
 This Firefly release has a lot of new features, probably among the most new features packed into one release over the past several years.
@@ -46,7 +46,7 @@ It also includes many, many bug fixes, clean up, and optimization (not all are l
 - Fixed: chart is not recognizing short- Firefly-1516 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1595))
 - Fixed: popup not closing until second click- Firefly-1514 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1589))
 - Fixed: firefly not supporting ellipse in the region save- Firefly-1582 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1654))
-- Fixed: import JWST footprint- IRSA-6024 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1643))
+- Fixed: import JWST footprint- IRSA-6024 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1660))
 - Cleanup: Better recognition of VO table Utype- Firefly-1534 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1636))
 - Cleanup: Better tap sizing- Firefly-1562 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1634))
 - Cleanup: TAP: ADQL dark mode screen- Firefly-1509 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1590))
@@ -61,6 +61,18 @@ It also includes many, many bug fixes, clean up, and optimization (not all are l
 - plot.ly 2.32-  Firefly-1504 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1579))
 - nom.tam.fits 1.20-  Firefly-1512 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1585))
 - other package updates- Firefly-1513 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1587)), Firefly-1503 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1581))
+
+### _Patches 2024.3_
+
+- 2024.3.1
+  - Bug fix: lock by click not changing images with shift-click and updating correct value ([PR](https://github.com/Caltech-IPAC/firefly/pull/1660))
+  - Bug fix: data product viewer will use a scrollbar with pngs- Firefly-1589 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1660))
+  - Bug fix: more drawing layers are now sticky until user remove them-  Firefly-1587 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1660))
+  - Bug fix: coordinate system options for mouse readout and grid are consistent-  Firefly-1584 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1660))
+  - Bug fix: JS API: table in expanded more not switching tabs- -  IRSA-6431 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1661))
+  - Bug fix: Catalogs were not load with certain type of table uploads: Firefly-1583 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1657))
+  - Bug fix: Upload panel not showing table summary in certain cases: Firefly-1584 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1659))
+  - When looking for center ra/dec columns in a table, if more than one column has the same UCD, the parser will prefer a floating column over a string 
 
 ##### _Pull Requests in this release_
 - [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2024.3+label%3abug)

--- a/src/firefly/js/drawingLayers/FixedPtControl.jsx
+++ b/src/firefly/js/drawingLayers/FixedPtControl.jsx
@@ -10,6 +10,7 @@ import {convertCelestial} from '../visualize/VisUtil.js';
 import GpsFixedIcon from '@mui/icons-material/GpsFixed';
 
 export function FixedPtControl({pv, wp, sx = {}}) {
+    if (!wp) return <div/>;
     const llStr = wp.type === Point.W_PT ?
         formatLonLatToString(convertCelestial(wp, CoordinateSys.EQ_J2000)) : `${Math.round(wp.x)},${Math.round(wp.y)}`;
 
@@ -27,6 +28,6 @@ export function FixedPtControl({pv, wp, sx = {}}) {
 
 FixedPtControl.propTypes = {
     pv: PropTypes.object,
-    wp: PropTypes.object.isRequired,
+    wp: PropTypes.object,
     sx: PropTypes.object
 };

--- a/src/firefly/js/drawingLayers/MarkerTool.js
+++ b/src/firefly/js/drawingLayers/MarkerTool.js
@@ -32,7 +32,7 @@ export const getMarkerToolUIComponent = (drawLayer,pv) => <MarkerToolUI drawLaye
 const ID= 'OVERLAY_MARKER';
 const TYPE_ID= 'OVERLAY_MARKER_TYPE';
 const factoryDef= makeFactoryDef(TYPE_ID,creator, null, getLayerChanges,null,getMarkerToolUIComponent);
-const MarkerStatus = new Enum(['attached', 'select', 'attached_relocate', 'relocate', 'resize']);
+export const MarkerStatus = new Enum(['attached', 'select', 'attached_relocate', 'relocate', 'resize']);
 
 export const markerInterval = 3000; // time interval for showing marker with handlers and no handlers
 export default {factoryDef, TYPE_ID}; // every draw layer must default export with factoryDef and TYPE_ID
@@ -511,21 +511,20 @@ function showMarkersByTimer(dispatcher, actionType, plotId, doneStatus, timer, d
  * calculate vertex distance for catching the marker
  * @param markObj
  * @param plotId
- * @param dl
  * @param dlObj
  * @returns {{vertexDef: *, exclusiveDef: *}}
  */
-export function updateVertexInfo(markObj, plotId, dl, dlObj) {
-    var markerStatus = markObj.sType === MarkerType.Marker ? get(markObj, ['actionInfo', 'markerStatus']) :
-                                                             get(markObj, ['actionInfo', 'footprintStatus']);
-    var exclusiveDef, vertexDef;
+export function updateVertexInfo(markObj, plotId, dlObj) {
+    const markerStatus = markObj.sType === MarkerType.Marker ?
+        markObj.actionInfo?.markerStatus : markObj.actionInfo?.footprintStatus;
+    let exclusiveDef, vertexDef;
 
     if (markerStatus) {
         if (markerStatus.key === MarkerStatus.attached.key) {
             exclusiveDef = {exclusiveOnDown: true, type: 'anywhere'};
             vertexDef = {points: {[plotId]: []}, pointDist: {[plotId]: MARKER_DISTANCE}};
         } else {
-            var cc = CsysConverter.make(primePlot(visRoot(), plotId));
+            const cc = CsysConverter.make(primePlot(visRoot(), plotId));
             const {dist, centerPt} = getVertexDistance(markObj, cc);
 
             exclusiveDef = {exclusiveOnDown: true, type: 'vertexOnly'};
@@ -634,7 +633,7 @@ function createMarkerObjs(action, dl, plotId, wpt, size, prevRet, unitT) {
     var dlObj = {drawData: dl.drawData, helpLine: editHelpText};
 
     if (markerStatus) {
-        var {exclusiveDef, vertexDef} = updateVertexInfo(markObj, plotId, dl, prevRet);
+        var {exclusiveDef, vertexDef} = updateVertexInfo(markObj, plotId, prevRet);
 
         if (exclusiveDef && vertexDef) {
             return clone(dlObj, {markerStatus, vertexDef, exclusiveDef});
@@ -818,7 +817,7 @@ function attachToNewPlot(drawLayer, newPlotId) {
 
     const dlObj = {drawData: drawLayer.drawData, helpLine: editHelpText};
     if (aInfo.markerStatus) {
-        const {exclusiveDef, vertexDef} = updateVertexInfo(markerObj, newPlotId, drawLayer, drawLayer);
+        const {exclusiveDef, vertexDef} = updateVertexInfo(markerObj, newPlotId, drawLayer);
 
         if (exclusiveDef && vertexDef) {
             return clone(dlObj, {markerStatus: aInfo.markerStatus, vertexDef, exclusiveDef});

--- a/src/firefly/js/drawingLayers/WebGrid.js
+++ b/src/firefly/js/drawingLayers/WebGrid.js
@@ -62,7 +62,8 @@ function creator(params) {
         isPointData:false,
         useLabels,
         canUserChangeColor: ColorChangeType.DYNAMIC,
-        destroyWhenAllDetached: true
+        destroyWhenAllDetached: false,
+        destroyWhenAllUserDetached: true,
     };
     
     return DrawLayer.makeDrawLayer( id, TYPE_ID, 'Grid', options , drawingDef, [ImagePlotCntlr.UPDATE_VIEW_SIZE, UPDATE_GRID ]);
@@ -107,7 +108,7 @@ function getDrawData(dataType, plotId, drawLayer, action, lastDataRet){
      let drawData;
      switch (action.type){
          case ImagePlotCntlr.ANY_REPLOT:
-             if (drawLayer.drawData.data  ) {
+             if (drawLayer.drawData?.data  ) {
                  if (action.payload.plotIdAry){
                     const data= clone(drawLayer.drawData.data);
                     action.payload.plotIdAry.forEach( (plotId) => data[plotId]= null);
@@ -126,7 +127,7 @@ function getDrawData(dataType, plotId, drawLayer, action, lastDataRet){
              break;
          case UPDATE_GRID:
          case ImagePlotCntlr.CHANGE_CENTER_OF_PROJECTION:
-             if (drawLayer.drawData.data ) {
+             if (drawLayer.drawData?.data ) {
                  const data = Object.keys(drawLayer.drawData.data).reduce((d, plotId) => {
                      d[plotId] = isImage(primePlot(visRoot(), plotId)) ? drawLayer.drawData.data[plotId] : null;
                      return d;

--- a/src/firefly/js/drawingLayers/WebGridUI.jsx
+++ b/src/firefly/js/drawingLayers/WebGridUI.jsx
@@ -13,9 +13,9 @@ import {COORDINATE_PREFERENCE} from './WebGrid.js';
 export const getUIComponent = (drawLayer,pv) => < WebGridUI drawLayer={drawLayer} pv={pv}/>;
 
 const coordinateOptionArray = [
-    {label:'Equatorial J2000',         value:'eq2000hms'},
+    {label:'Equatorial J2000 HMS',         value:'eq2000hms'},
     {label: 'Equatorial J2000 Decimal',value:'eq2000dcm'},
-    {label: 'Equatorial B1950',        value:'eqb1950hms'},
+    {label: 'Equatorial B1950 HMS',        value:'eqb1950hms'},
     {label:'Equatorial B1950 Decimal', value:'eqb1950dcm'},
     {label:'Galactic',          value:'galactic'},
     {label: 'Super Galactic',   value:'superGalactic'},

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -166,7 +166,7 @@ export const ToolbarButton = forwardRef((props,fRef) => {
 
 ToolbarButton.propTypes= {
     icon : oneOfType([element,string]),
-    text : node,
+    text : oneOfType([element,string]),
     tip : string,
     value: string,
     title: string,

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -1,4 +1,4 @@
-import {FormLabel, Stack, Typography} from '@mui/joy';
+import {Box, FormLabel, Stack, Typography} from '@mui/joy';
 import {object, bool, string, func, number, shape} from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 import {ColsShape, getColValidator} from '../../charts/ui/ColumnOrExpression.jsx';
@@ -210,11 +210,12 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, columnsModel,
                 <ForceFieldGroupValid forceValid={!checkHeaderCtl.isPanelActive()}>
 
                     {!canUpload && (searchParams?.uploadInfo || uploadInfo) &&
-                        <div>
+                        <Box>
                             {<FormLabel>Spatial Type</FormLabel>}
-                            {warningMsg(`Single Shape selected: ${serviceLabel || 'This service'} does not support upload`)}
-                        </div>
-
+                            <Typography color={'warning'}>
+                                {`Upload option unavailable: ${serviceLabel || 'This service'} does not support upload`}
+                            </Typography>
+                        </Box>
                     }
                     {canUpload &&
                         <RadioGroupInputField {...{
@@ -239,14 +240,6 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, columnsModel,
         </CollapsibleCheckHeader>
     );
 }
-
-const warningMsg = (msg) => {
-    return (
-        <div style={{display : 'inline-block'}}>
-            <i>{msg}</i>
-        </div>
-    );
-};
 
 const OBSCORE_UPLOAD_LAYOUT= 0;
 const OBSCORE_SINGLE_LAYOUT= 1;

--- a/src/firefly/js/visualize/draw/DrawLayer.js
+++ b/src/firefly/js/visualize/draw/DrawLayer.js
@@ -172,6 +172,7 @@ function makeDrawLayer(drawLayerId,
         canUserDelete: true,
         canUserHide: true,
         destroyWhenAllDetached : false, // hint to controller, when all plots have been detached, destroy this layer
+        destroyWhenAllUserDetached : false, // hint to controller, when all plots have been detached, destroy this layer
         helpLine : '',
         decimate: false, // enable decimation
         canAttachNewPlot: true,

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -3,7 +3,6 @@
  */
 
 import {flatten, isArray, uniqBy} from 'lodash';
-import shallowequal from 'shallowequal';
 import {getExtName, getExtType} from '../FitsHeaderUtil.js';
 import {getCenterPtOfPlot} from '../WebPlotAnalysis';
 import {DEFAULT_THUMBNAIL_SIZE, WebPlotRequest, WPConst} from '../WebPlotRequest.js';

--- a/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
@@ -234,7 +234,7 @@ function modifyShape(dl, plotId) {
 }
 
 function deleteLayer(dl,plotId) {
-    dispatchDetachLayerFromPlot(dl.displayGroupId,plotId,true, dl.destroyWhenAllDetached);
+    dispatchDetachLayerFromPlot(dl.displayGroupId,plotId,true, dl.destroyWhenAllDetached||dl.destroyWhenAllUserDetached);
 }
 
 function deleteMaskLayer(opv) {

--- a/src/firefly/js/visualize/ui/MouseReadoutOptionPopups.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadoutOptionPopups.jsx
@@ -27,9 +27,11 @@ import {isCelestialImage, isHiPS} from '../WebPlot.js';
 //define the labels and values for the radio options
 const celestialCoordOptions= [
 	{label: 'Equatorial J2000 HMS', value: 'eqj2000hms'},
-	{label: 'Equatorial J2000 decimal', value: 'eqj2000DCM' },
+	{label: 'Equatorial J2000 Decimal', value: 'eqj2000DCM' },
+	{label: 'Equatorial B1950 HMS', value: 'eqb1950'},
+	{label: 'Equatorial B1950 Decimal', value: 'eqb1950DCM'},
 	{label: 'Galactic', value: 'galactic'},
-	{label: 'Equatorial B1950', value: 'eqb1950'},
+	{label: 'Super Galactic', value: 'superGalactic'},
 	{label: 'Ecliptic J2000', value: 'eclJ2000'},
 	{label: 'Ecliptic B1950', value: 'eclB1950'},
 	{label: 'FITS Image Pixel', value: 'fitsIP'},
@@ -37,10 +39,12 @@ const celestialCoordOptions= [
 ];
 
 const hipsCoordOptions= [
-    {label: 'Equatorial J2000 HMS', value: 'eqj2000hms'},
-    {label: 'Equatorial J2000 decimal', value: 'eqj2000DCM' },
-    {label: 'Galactic', value: 'galactic'},
-    {label: 'Equatorial B1950', value: 'eqb1950'},
+	{label: 'Equatorial J2000 HMS', value: 'eqj2000hms'},
+	{label: 'Equatorial J2000 Decimal', value: 'eqj2000DCM' },
+	{label: 'Equatorial B1950 HMS', value: 'eqb1950'},
+	{label: 'Equatorial B1950 Decimal', value: 'eqb1950DCM'},
+	{label: 'Galactic', value: 'galactic'},
+	{label: 'Super Galactic', value: 'superGalactic'},
 	{label: 'Ecliptic J2000', value: 'eclJ2000'},
 	{label: 'Ecliptic B1950', value: 'eclB1950'},
 ];

--- a/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
+++ b/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
@@ -26,7 +26,9 @@ const labelMap = {
     eclJ2000: 'ECL-J2000:',
     eclB1950: 'ECL-B1950:',
     galactic: 'Gal:',
+    superGalactic: 'SGal:',
     eqb1950: 'Eq-B1950:',
+    eqb1950DCM: 'Eq-B1950:',
     wcsCoords: 'WCS-Coords:',
     fitsIP: 'Image Pixel:',
     zeroIP: '0 Based Pix:',
@@ -145,10 +147,14 @@ export function getReadoutElement(readoutItems, readoutKey, plotId) {
             return makeCoordReturn(wp, CoordinateSys.EQ_J2000);
         case 'galactic' :
             return makeCoordReturn(wp, CoordinateSys.GALACTIC);
+        case 'superGalactic' :
+            return makeCoordReturn(wp, CoordinateSys.SUPERGALACTIC);
         case 'supergalactic' :
             return makeCoordReturn(wp, CoordinateSys.SUPERGALACTIC);
         case 'eqb1950' :
             return makeCoordReturn(wp, CoordinateSys.EQ_B1950, true);
+        case 'eqb1950DCM':
+            return makeCoordReturn(wp, CoordinateSys.EQ_B1950);
         case 'eclJ2000' :
             return makeCoordReturn(wp, CoordinateSys.ECL_J2000, false);
         case 'eclB1950' :

--- a/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/SelectAreaDropDownView.jsx
@@ -82,7 +82,7 @@ function updateSelect(pv, value, allPlots=true, modalEndInfo) {
             }
             setModalEndInfo({
                 closeText:'End Select',
-                closeLayer: () => onOff(pv,SelectArea.TYPE_ID,allPlots,false,modalEndInfo,'',true),
+                closeLayer: () => onOff(pv,SelectArea.TYPE_ID,allPlots,false,false,modalEndInfo,'',true),
                 offOnNewPlot: true,
                 key: 'SelectArea'
             });

--- a/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
+++ b/src/firefly/js/visualize/ui/SimpleLayerOnOffButton.jsx
@@ -88,11 +88,23 @@ SimpleLayerOnOffButton.propTypes= {
     sx : PropTypes.object,
 };
 
+function off(dl, pv,typeId,allPlots) {
+    dispatchDetachLayerFromPlot(typeId,pv.plotId,allPlots,dl?.destroyWhenAllDetached||dl?.destroyWhenAllUserDetached);
+    clearModalEndInfo();
+}
 
-export function onOff(pv,typeId,allPlots, plotTypeMustMatch, modalEndInfo, endText, modalLayer= false) {
+
+export function onOff(pv,typeId,allPlots, plotTypeMustMatch, modalEndInfo, endText, modalLayer= false, forceOff) {
     if (!pv || !typeId) return;
 
     const dl= getDrawLayerByType(getDlAry(), typeId);
+
+    if (forceOff) {
+        off(dl, pv,typeId,allPlots);
+        return;
+    }
+
+
     if (!dl) {
         dispatchCreateDrawLayer(typeId);
     }
@@ -103,7 +115,7 @@ export function onOff(pv,typeId,allPlots, plotTypeMustMatch, modalEndInfo, endTe
             modalEndInfo?.closeLayer?.();
             setModalEndInfo?.({
                 closeLayer: () => {
-                    onOff(pv,typeId,allPlots,plotTypeMustMatch,modalEndInfo, endText, modalLayer);
+                    onOff(pv,typeId,allPlots,plotTypeMustMatch,modalEndInfo, endText, modalLayer, true);
                 },
                 closeText: endText,
                 offOnNewPlot: true,
@@ -111,8 +123,7 @@ export function onOff(pv,typeId,allPlots, plotTypeMustMatch, modalEndInfo, endTe
         }
     }
     else {
-        dispatchDetachLayerFromPlot(typeId,pv.plotId,allPlots,dl.destroyWhenAllDetached);
-        clearModalEndInfo();
+        off(dl, pv,typeId,allPlots, plotTypeMustMatch);
     }
 }
 

--- a/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
+++ b/src/firefly/js/visualize/ui/VisMiniToolbar.jsx
@@ -134,12 +134,10 @@ const rS= {
     justifyContent: 'flex-end'
 };
 
-function getCorrectPlotView(visRoot, viewerId) {
+function getCorrectPlotView(visRoot, viewer) {
     const pv= getActivePlotView(visRoot);
-    if (!viewerId || !pv) return pv;
-    const v= getViewer(getMultiViewRoot(), viewerId);
-    if (!v) return pv;
-    const itemIdAry= v.itemIdAry ?? [];
+    if (!viewer || !pv) return pv;
+    const itemIdAry= viewer.itemIdAry ?? [];
     if (itemIdAry.includes(pv.plotId)) return pv;
     if (!itemIdAry.length) return undefined;
     return getPlotViewById(visRoot,itemIdAry[0]);
@@ -150,6 +148,7 @@ const VisMiniToolbarView= memo( ({visRoot,dlCount,manageExpand, expandGrid, moda
     const {apiToolsView}= visRoot;
     const {current:divref}= useRef({element:undefined});
     const [colorDrops,setColorDrops]= useState(true);
+    const viewer= getViewer(getMultiViewRoot(), viewerId);
 
     useEffect(() => {
         if (divref.element) {
@@ -161,9 +160,9 @@ const VisMiniToolbarView= memo( ({visRoot,dlCount,manageExpand, expandGrid, moda
             const modalEndInfo= getModalEndInfo();
             if (modalEndInfo.offOnNewPlot) closeToolbarModalLayers();
         };
-    }, []);
+    }, [viewer?.layout,viewer?.layoutDetail]);
 
-    const pv= getCorrectPlotView(visRoot, viewerId);
+    const pv= getCorrectPlotView(visRoot, viewer);
     const plot= primePlot(pv);
     const image= !isHiPS(plot);
     const hips= isHiPS(plot);
@@ -191,7 +190,9 @@ const VisMiniToolbarView= memo( ({visRoot,dlCount,manageExpand, expandGrid, moda
                     <ToolbarButton
                         color='warning'
                         text={modalEndInfo.closeText} tip={modalEndInfo.closeText}
-                        onClick={() => modalEndInfo.closeLayer(modalEndInfo.key)}/>
+                        onClick={() => {
+                            modalEndInfo.closeLayer(modalEndInfo.key);
+                        }}/>
                     <ToolbarHorizontalSeparator/>
                 </React.Fragment>
             }

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductViewer.jsx
@@ -176,7 +176,7 @@ const ProductPNG = ( {makeDropDown, url}) => (
     <Stack {...{direction:'column', width:'100%', height:'100%'}}>
         {makeDropDown &&
             <Box style={{height:30, width:'100%'}}> {makeDropDown()} </Box>}
-        <Stack direction='row' alignItems='center' justifyContent='center'>
+        <Stack direction='row' alignItems='center' justifyContent='center' overflow='auto'>
             <img src={url} alt={url} style={{maxWidth:'100%', flexGrow:0, flexShrink:0, objectFit: 'contain' }}/>
         </Stack>
     </Stack> );

--- a/src/firefly/js/voAnalyzer/VoTableRecognizer.js
+++ b/src/firefly/js/voAnalyzer/VoTableRecognizer.js
@@ -190,8 +190,16 @@ export class VoTableRecognizer {
                 }
             }
         } else if (posPairs[0].length > 0 && posPairs[1].length > 0) {
-            // find first exact match
-            const basicPair = posPairs.map((cols, i) => cols.find((c) => c.UCD === centerColUCDs[0][i]));
+            // find first exact match, that is a double, if not found the try first exact match
+            let basicPair = posPairs
+                .map((cols, i) => cols
+                    .find((c) => c.UCD === centerColUCDs[0][i] && (c.type==='double' || c.type==='float') ));
+            if (!basicPair[0] || !basicPair[1]) {
+                basicPair = posPairs
+                    .map((cols, i) => cols
+                        .find((c) => c.UCD === centerColUCDs[0][i]));
+            }
+
             if (basicPair[0] && basicPair[1]) {
                 pairs.push(basicPair);
             } else if (posPairs[0].length === posPairs[1].length) {


### PR DESCRIPTION
#### [Firefly-1587](https://jira.ipac.caltech.edu/browse/FIREFLY-1587): improving overlays

  - [Firefly-1589](https://jira.ipac.caltech.edu/browse/FIREFLY-1589): add scroll bar to MultiProduct jpg viewer
  - [Firefly-1584](https://jira.ipac.caltech.edu/browse/FIREFLY-1584): options consistent
  - Fixed bug in draw layer end button
  - Grid overlay: can be turned on and off, sticky when on
  - Footprint overlay:can be turned on and off, sticky when on
  - Mouse readout "Lock by Click" will support choosing a point and then shift-clicking on other image and keeping the same point
  - When looking for center ra/dec columns in a table, if more than one column has the same UCD, the parser will prefer a floating column over a string

#### Testing
- Firefly: https://fireflydev.ipac.caltech.edu/firefly-1587-overlays/firefly
- irsaViewer: https://firefly-1587-overlays.irsakudev.ipac.caltech.edu/irsaviewer/dce
- [Firefly-1587](https://jira.ipac.caltech.edu/browse/FIREFLY-1587)
  - Use [firefly](https://fireflydev.ipac.caltech.edu/firefly-1587-overlays/firefly)
  - load 1 or more images, add a footprint and turn on grid
  - add more images, the footprint and grid should still be there
  - delete all the images and load more
  - the the footprint and grid should still be there
- [Firefly-1589](https://jira.ipac.caltech.edu/browse/FIREFLY-1589)
   - use [DCE](https://firefly-1587-overlays.irsakudev.ipac.caltech.edu/irsaviewer/dce), test according to the ticket.
- [Firefly-1584](https://jira.ipac.caltech.edu/browse/FIREFLY-1584)
   - use [firefly](https://fireflydev.ipac.caltech.edu/firefly-1587-overlays/firefly)
   - turn on grid, look at the grid options and look at the mouse readout options. They should be consistent


#### mark as tested
- [x] [Firefly-1587](https://jira.ipac.caltech.edu/browse/FIREFLY-1587)
- [x] [Firefly-1589](https://jira.ipac.caltech.edu/browse/FIREFLY-1589)
- [x] [Firefly-1584](https://jira.ipac.caltech.edu/browse/FIREFLY-1584)