### PR TITLE
IRSA-6431: Firefly tables in expanded mode was unable to switch tabs.

### DIFF
--- a/src/firefly/html/test/tests-table.html
+++ b/src/firefly/html/test/tests-table.html
@@ -507,7 +507,7 @@ added in this test.  Open console, then
             const table2 = { tbl_id: 'table2', tableData: { columns, data } };
             const table3 = { tbl_id: 'table3', tableData: { columns, data } };
             firefly.showClientTable('single', table1);
-            firefly.showClientTable('single', table2);
+            firefly.showClientTable('tabs', table2);
             firefly.showClientTable('tabs', table3);
             [2,3].forEach(i => {
                 const {tbl_ui_id} = firefly.util.table.getTableUiByTblId("table"+i);

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -24,22 +24,16 @@ const logger = Logger('Tables').tag('TablesContainer');
 
 export function TablesContainer(props) {
     const {mode='both', closeable=true, tableOptions, style, expandedMode:xMode=false} = props;
-    let {tbl_group} = props;
+    const expandedMode = useStoreConnector(() => xMode || getExpandedMode() === LO_VIEW.tables);
+    const tbl_group = expandedMode && mode !== 'standard' ? TblUtil.getTblExpandedInfo().tbl_group : props.tbl_group;
 
     const tables = useStoreConnector(() => TblUtil.getTableGroup(tbl_group)?.tables);
     const active = useStoreConnector(() => TblUtil.getTableGroup(tbl_group)?.active);
-    const expandedMode = useStoreConnector(() => xMode || getExpandedMode() === LO_VIEW.tables);
     useStoreConnector((lastTitles) => {// force a rerender if any title ui changes
         const titles= getTblIdsByGroup().map( (tbl_id) => getTableUiByTblId(tbl_id)?.title);
         if (!lastTitles) return titles;
         return (union(titles,lastTitles).length === titles?.length) ? lastTitles : titles;
     });
-
-    useEffect(() => {
-        if (expandedMode && mode !== 'standard') {
-            tbl_group = TblUtil.getTblExpandedInfo().tbl_group;
-        }
-    }, [expandedMode, mode]);
 
     logger.debug('render... tbl_group: ' + tbl_group);
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/IRSA-6431

When multiple `tbl_groups` were used, tables in the second group were unable to switch tabs in expanded mode.

Test: https://fireflydev.ipac.caltech.edu/irsa-6431-switch-tabs-expanded-mode/firefly/test/tests-table.html?test=Custom+Table+Title
- Expand the second table tabs
- Ensure you are able to switch tabs
  - The drop-down Open Tabs selector should also work

@cwang2016 It would be nice if you can try and test this version to see that it actually fixes the bug you found.