### PR TITLE
FIREFLY-1591: Directly import VOTable data into the database.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbDataIngestor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbDataIngestor.java
@@ -1,0 +1,47 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.firefly.server.db;
+
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.TableUtil;
+import edu.caltech.ipac.table.io.VoTableHandler;
+import edu.caltech.ipac.table.io.VoTableReader;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static edu.caltech.ipac.table.TableUtil.Format.*;
+import static edu.caltech.ipac.table.TableUtil.Format.VO_TABLE;
+
+/**
+ * Date: 10/24/24
+ *
+ * @author loi
+ * @version : $
+ */
+public class DbDataIngestor {
+
+    public static FileInfo ingestData(TableUtil.Format format, DbAdapter dbAdapter, String source, DataGroup meta) throws DataAccessException {
+        if (format == null) throw new DataAccessException("Unsupported format, file:" + source);
+
+        return switch (format) {
+            case VO_TABLE -> ingestVoTable(dbAdapter, source, meta);
+            case CSV, TSV, PARQUET -> DuckDbReadable.castInto(format, dbAdapter).ingestDataDirectly(source, meta);
+            default -> throw new DataAccessException("Unsupported format, file:" + source);
+        };
+    }
+
+    public static FileInfo ingestVoTable(DbAdapter dbAdapter, String source, DataGroup meta) throws DataAccessException {
+        try {
+            VoTableReader.parse(new VoTableHandler.DbIngest(dbAdapter, meta), source, 0);   // only the first table.
+        } catch (IOException e) {
+            throw new DataAccessException(e);
+        }
+        return new FileInfo(dbAdapter.getDbFile());
+    }
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
@@ -81,7 +81,7 @@ public abstract class DuckDbReadable extends DuckDbAdapter {
         return castInto(format, null);
     }
 
-    public static DuckDbReadable castInto(TableUtil.Format format, DuckDbAdapter dbAdapter) throws DataAccessException {
+    public static DuckDbReadable castInto(TableUtil.Format format, DbAdapter dbAdapter) throws DataAccessException {
         File dbFile = dbAdapter == null ? null : dbAdapter.getDbFile();
         return   switch (format) {
             case TSV -> new Tsv(dbFile);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -482,7 +482,7 @@ public class EmbeddedDbUtil {
         };
     }
 
-    static DataType[] makeDbCols(DataGroup dg) {
+    public static DataType[] makeDbCols(DataGroup dg) {
         DataType[] cols = new DataType[dg.getDataDefinitions().length + 2];
         if (dg.getDataDefintion(ROW_IDX) != null) {
             logger.error("Datagroup should not have ROW_IDX in it at the start.");
@@ -548,7 +548,7 @@ public class EmbeddedDbUtil {
      * @param cols columns to search
      * @return  a list of boolean indicating if a column contains array data type
      */
-    static List<Boolean> isColumnTypeArray(DataType[] cols) {
+    public static List<Boolean> isColumnTypeArray(DataType[] cols) {
         return Arrays.stream(cols).map(c -> c.isArrayType()).toList();
     }
 
@@ -556,7 +556,7 @@ public class EmbeddedDbUtil {
      * @param cols columns to search
      * @return  a list of
      */
-    static List<Integer> colIdxWithArrayData(DataType[] cols) {
+    public static List<Integer> colIdxWithArrayData(DataType[] cols) {
         return IntStream.range(0, cols.length)
                 .mapToObj(i -> cols[i].isArrayType() ? i : -1)
                 .filter(i -> i >= 0)

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableHandler.java
@@ -1,0 +1,151 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.table.io;
+
+import edu.caltech.ipac.firefly.server.db.DbAdapter;
+import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
+import edu.caltech.ipac.firefly.server.db.spring.JdbcFactory;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.ResourceInfo;
+import org.duckdb.DuckDBAppender;
+import org.duckdb.DuckDBConnection;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static edu.caltech.ipac.firefly.server.db.DuckDbAdapter.addRow;
+import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.colIdxWithArrayData;
+import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.serialize;
+
+/**
+ * Date: 10/23/24
+ *
+ * @author loi
+ * @version : $
+ */
+public interface VoTableHandler {
+    default void start() {};
+    default void end() {};
+    default void startTable(int url) throws DataAccessException {};
+    default void endTable(int url) throws DataAccessException {};
+    boolean headerOnly();
+    void resources(List<ResourceInfo> resourceInfo) throws DataAccessException;
+    void header(DataGroup header) throws DataAccessException;
+    void data(Object[] row ) throws DataAccessException;
+
+    abstract class Base implements VoTableHandler {
+        protected List<ResourceInfo> resourceInfo;
+        DataGroup meta;     // additional meta to include with along with the data
+        protected boolean headerOnly;
+        protected boolean searchForSpectrum;
+
+        public Base(DataGroup meta, boolean headerOnly, boolean searchForSpectrum) {
+            this.meta = meta;
+            this.headerOnly = headerOnly;
+            this.searchForSpectrum = searchForSpectrum;
+        }
+
+        public void resources(List<ResourceInfo> resourceInfo) throws DataAccessException {
+            this.resourceInfo = resourceInfo;
+        }
+
+        public void header(DataGroup header) throws DataAccessException {
+            header.addMetaFrom(meta);
+            header.setResourceInfos(resourceInfo);
+            if (searchForSpectrum) SpectrumMetaInspector.searchForSpectrum(header,true);
+        }
+
+        public boolean headerOnly() {
+            return headerOnly;
+        }
+    }
+
+    class DataGroups extends Base {
+        List<DataGroup> allTables = new ArrayList<>();
+
+        public DataGroups(boolean headerOnly, boolean searchForSpectrum) {
+            super(null, headerOnly, searchForSpectrum);
+        }
+
+        public void header(DataGroup header) throws DataAccessException {
+            super.header(header);
+            allTables.add(header);
+        }
+
+        public void data(Object[] row) throws DataAccessException {
+            allTables.getLast().add(row);
+        }
+
+        public DataGroup[] getAllTable() {
+            return allTables.toArray(new DataGroup[0]);
+        }
+
+        public DataGroup getTable(int index) {
+            return allTables.get(index);
+        }
+    }
+
+    class DbIngest extends Base {
+        DbAdapter dbAdapter;
+        DataGroup header;
+        DataType[] cols;
+        int rowCnt;
+        DuckDBAppender appender;
+        DuckDBConnection conn;
+        List<Integer> aryIdx;
+
+        public DbIngest(DbAdapter dbAdapter, DataGroup meta) {
+            super(meta, false, true);
+            this.dbAdapter = dbAdapter;
+        }
+
+        public void header(DataGroup header) throws DataAccessException {
+            super.header(header);
+            this.header = header;
+            cols = EmbeddedDbUtil.makeDbCols(header);
+            aryIdx = colIdxWithArrayData(cols);
+
+            dbAdapter.ingestData(() -> header, dbAdapter.getDataTable());
+
+            try {
+                // prepare to ingest data into database
+                conn = (DuckDBConnection) JdbcFactory.getDataSource(dbAdapter.getDbInstance()).getConnection();
+                conn.setAutoCommit(false);
+                appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, dbAdapter.getDataTable());
+            } catch (SQLException e) {
+                throw new DataAccessException(e);
+            }
+        }
+
+        public void data(Object[] row) throws DataAccessException {
+            try {
+                aryIdx.forEach(idx -> row[idx] = serialize(row[idx]));      // serialize array data if necessary
+                addRow(appender, row, ++rowCnt);
+            } catch (SQLException e) {
+                throw new DataAccessException(e);
+            }
+        }
+
+        public void end() {
+            try {
+                if(appender != null) {
+                    appender.flush();
+                    appender.close();
+                }
+                if(conn != null) {
+                    conn.commit();
+                    conn.close();
+                }
+            } catch (SQLException e) {
+                Logger.getLogger().warn(e);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1591
Changes include:
- Direct import of VOTable data into the database
- Refactoring of VoTable reading code

Optimizations for VOTable Ingestion:
- Switched from MEMORY-only to ADAPTIVE parsing, offloading excess data to disk.
- Enabled direct VOTable import, eliminating the Firefly table conversion.

Performance Summary:

Loading a 300MB VOTable file now requires less memory and time:
- Initially: 3.07s, JVM 1.1GB → Optimized: 2.67s, JVM 250MB

Database Ingestion now requires a tiny amount of memory because it does not need to load the full table.
- Initially: 6.76s, JVM 1.1GB → Optimized 5.25s with only **32MB** memory


https://fireflydev.ipac.caltech.edu/firefly-1591-votable-direct-ingest/firefly/
To test it out:
- Run a small IRSA catalog search and then expand the table.  This is to eliminate unnecessary network calls.
- Upload the same 300MB VOTable file from [this link](https://irsadev.ipac.caltech.edu:9201/test/table_1mil.vot).
- Open DevTools, monitor the sync?cmd=tableSearch network call, then click 'Load Table'.

Repeat these steps using the nightly build for comparison.
In my tests, my PR instance finished in 7s versus 12s it took for the nightly version.