### PR TITLE
Firefly-1596: disable showing radius

### DIFF
--- a/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
@@ -151,6 +151,7 @@ export function EmbeddedPositionSearchPanel({
         overflow: 'auto',
     };
 
+    const sizeEnabled= slotProps?.sizeInput?.enabled ?? true;
     return (
         <Stack key='targetGroup' alignItems='center' height='100%' paddingBottom={insetSpacial ? 0 : 20}
            onMouseDown={() => {
@@ -164,7 +165,9 @@ export function EmbeddedPositionSearchPanel({
                     sRegion, plotId,
                     minSize: min, maxSize: max, toolbarHelpId,
                     whichOverlay: doGetSearchTypeOp(), setWhichOverlay: doToggle ? setSearchTypeOp : undefined,
-                    targetKey, sizeKey, polygonKey,
+                    targetKey,
+                    sizeKey: sizeEnabled ? sizeKey : undefined,
+                    polygonKey,
                     sx: {minHeight: 300, alignSelf: 'stretch', flexGrow:1, ...hipsTargetViewSx}
                 }}/>
             <Sheet
@@ -383,7 +386,8 @@ function ConeOp({slotProps,nullAllowed}) {
         sizeKey= DEFAULT_SIZE_KEY,
         min= 1 / 3600,
         max= 1,
-        initValue= DEFAULT_INIT_SIZE_VALUE
+        initValue= DEFAULT_INIT_SIZE_VALUE,
+        enabled= true,
     }= slotProps.sizeInput ?? {};
     const {
         targetKey=DEF_TARGET_PANEL_KEY,
@@ -400,7 +404,7 @@ function ConeOp({slotProps,nullAllowed}) {
                     feedback:{sx: {alignSelf:'center'} },
                 }
             }}/>
-            <SizeInputFields {...{
+            {enabled && <SizeInputFields {...{
                 fieldKey: sizeKey, showFeedback: true, nullAllowed: false,
                 label: 'Search Radius',
                 initialState: {unit: 'arcsec', value: initValue+'', min, max},
@@ -408,7 +412,7 @@ function ConeOp({slotProps,nullAllowed}) {
                 slotProps: {
                     feedback:{sx: {alignSelf:'center'} },
                 }
-            }} />
+            }} />}
         </Stack>
     );
 }

--- a/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
+++ b/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
@@ -54,6 +54,7 @@ import AdsClickIcon from '@mui/icons-material/AdsClick';
 const DIALOG_ID= 'HiPSPanelPopup';
 const DEFAULT_HIPS= 'ivo://CDS/P/DSS2/color';
 const DEFAULT_FOV= 340;
+const RADIUS_DISABLED_KEY= 'none---Size';
 
 const sharedPropTypes= {
     hipsUrl: string,
@@ -106,7 +107,7 @@ VisualTargetPanel.propTypes= {
 
 export const HiPSTargetView = ({sx, hipsDisplayKey='none',
                                    hipsUrl=DEFAULT_HIPS, hipsFOVInDeg= DEFAULT_FOV, centerPt=makeWorldPt(0,0, CoordinateSys.GALACTIC),
-                                   targetKey=DEF_TARGET_PANEL_KEY, sizeKey='none---Size', polygonKey='non---Polygon',
+                                   targetKey=DEF_TARGET_PANEL_KEY, sizeKey=RADIUS_DISABLED_KEY, polygonKey='non---Polygon',
                                    whichOverlay= CONE_CHOICE_KEY, toolbarHelpId,
                                    setWhichOverlay, sRegion, coordinateSys, mocList, minSize=1/3600, maxSize=100,
                                    plotId='defaultHiPSTargetSearch', cleanup= false, groupKey}) => {
@@ -169,8 +170,10 @@ export const HiPSTargetView = ({sx, hipsDisplayKey='none',
              const wp = primePlot(visRoot(), plotId)?.attributes[PlotAttribute.USER_SEARCH_WP];
              wp && setTargetWp(wp.toString());
          }
+        const radius= sizeKey!==RADIUS_DISABLED_KEY ? userEnterSearchRadius() : undefined;
+
         updatePlotOverlayFromUserInput(plotId, whichOverlay, userEnterWorldPt(),
-            userEnterSearchRadius(), userEnterPolygon(), false, canGenerate);
+            radius, userEnterPolygon(), false, canGenerate);
         lastWhichOverlay.lastValue= whichOverlay;
     }, [getTargetWp, getHiPSRadius, getPolygon, whichOverlay]);
 


### PR DESCRIPTION
#### [Firefly-1596](https://jira.ipac.caltech.edu/browse/FIREFLY-1596): Disable radius on for TargetHiPSPanel



#### Testing
- https://firefly-1596-radius.irsakudev.ipac.caltech.edu/applications/euclid/search-region-pos
- when you choose `image contains target` you should not see a radius on the HiPS image

#### Note
- The build was against the irsa-ife branch `tmp-test-for-FIREFLY-1596`



