### PR TITLE
FIREFLY-1606-links-missing-port

### DIFF
--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -264,8 +264,9 @@ export const encodeUrlString= (urlString, baseUrl = getRootURL()) => {
         const url = new URL(urlString, baseUrl);
         let query = url.searchParams.toString();
             query = query ? '?' + query : '';
+        const port = url.port ? `:${url.port}` : '';
         const hash = url.hash ? '#' + encodeURIComponent(url.hash.substring(1)) : '';
-        return `${url.protocol}//${url.hostname}${url.pathname}${query}${hash}`;
+        return `${url.protocol}//${url.hostname}${port}${url.pathname}${query}${hash}`;
     } catch (e) {
         return urlString;
     }

--- a/src/firefly/js/util/__tests__/WebUtil-test.js
+++ b/src/firefly/js/util/__tests__/WebUtil-test.js
@@ -19,8 +19,8 @@ describe('A test suite for WebUtil.js', () => {
 
     test('encodeUrlString', () => {
         // use baseUrl for relative link
-        expect(encodeUrlString('/relative-path/ref', 'http://localhost'))
-                        .toBe('http://localhost/relative-path/ref');
+        expect(encodeUrlString('/relative-path/ref', 'http://localhost:8080'))
+                        .toBe('http://localhost:8080/relative-path/ref');
         // ignore baseUrl if full url is given
         expect(encodeUrlString('http://acme.org/relative-path/ref', 'http://localhost'))
                         .toBe('http://acme.org/relative-path/ref');


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1606

Just a small fix. As mentioned in the ticket, after the links in the table are resolved, the port portion of the URL is missing.
Run WebUtil-test.js to test.