### PR TITLE
FIREFLY-1592: Directly import IPAC table data into the database

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbDataIngestor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbDataIngestor.java
@@ -5,17 +5,21 @@
 package edu.caltech.ipac.firefly.server.db;
 
 import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.TableUtil;
-import edu.caltech.ipac.table.io.VoTableHandler;
+import edu.caltech.ipac.table.io.FITSTableReader;
+import edu.caltech.ipac.table.io.IpacTableReader;
+import edu.caltech.ipac.table.io.SpectrumMetaInspector;
+import edu.caltech.ipac.table.io.TableParseHandler;
 import edu.caltech.ipac.table.io.VoTableReader;
 
+import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 
-import static edu.caltech.ipac.table.TableUtil.Format.*;
-import static edu.caltech.ipac.table.TableUtil.Format.VO_TABLE;
+import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
+import static edu.caltech.ipac.table.TableUtil.guessFormat;
 
 /**
  * Date: 10/24/24
@@ -25,23 +29,54 @@ import static edu.caltech.ipac.table.TableUtil.Format.VO_TABLE;
  */
 public class DbDataIngestor {
 
-    public static FileInfo ingestData(TableUtil.Format format, DbAdapter dbAdapter, String source, DataGroup meta) throws DataAccessException {
+    public static FileInfo ingestData(TableServerRequest req, DbAdapter dbAdapter, File srcFile, DataGroup meta, DbAdapter.DataGroupSupplier dataGroupSupplier) throws DataAccessException {
+
+        String source = srcFile.getAbsolutePath();
+        boolean searchForSpectrum = SpectrumMetaInspector.hasSpectrumHint(req);
+
+        TableUtil.Format format = null;
+        try {
+            format = DuckDbReadable.guessFileFormat(srcFile.getAbsolutePath());
+            if (format == null) format = guessFormat(srcFile);
+        } catch (IOException ignored) {}
+
         if (format == null) throw new DataAccessException("Unsupported format, file:" + source);
 
-        return switch (format) {
-            case VO_TABLE -> ingestVoTable(dbAdapter, source, meta);
-            case CSV, TSV, PARQUET -> DuckDbReadable.castInto(format, dbAdapter).ingestDataDirectly(source, meta);
-            default -> throw new DataAccessException("Unsupported format, file:" + source);
-        };
-    }
+        if (!(dbAdapter instanceof DuckDbAdapter)) {
+            // used to be the default, but is now only needed for testing
+            return dataGroupSupplier != null ? dbAdapter.ingestData(dataGroupSupplier, dbAdapter.getDataTable()) : null;
+        }
 
-    public static FileInfo ingestVoTable(DbAdapter dbAdapter, String source, DataGroup meta) throws DataAccessException {
+        int tblIdx = req.getIntParam(TBL_INDEX, 0);
+
         try {
-            VoTableReader.parse(new VoTableHandler.DbIngest(dbAdapter, meta), source, 0);   // only the first table.
+            return switch (format) {
+                case IPACTABLE -> ingestIpacTableDirectly(dbAdapter, srcFile, meta, searchForSpectrum);
+                case VO_TABLE -> ingestVoTableDirectly(dbAdapter, source, meta, tblIdx, searchForSpectrum);
+                case CSV, TSV, PARQUET -> DuckDbReadable.castInto(format, dbAdapter).ingestDataDirectly(source, meta);
+                case FITS -> ingestFitsTable(req, dbAdapter, source, tblIdx);
+                default -> throw new DataAccessException("Unsupported format, file:" + source);
+            };
         } catch (IOException e) {
             throw new DataAccessException(e);
         }
+    }
+
+    static FileInfo ingestVoTableDirectly(DbAdapter dbAdapter, String source, DataGroup meta, int tblIdx, boolean searchForSpectrum) throws IOException {
+        VoTableReader.parse(new TableParseHandler.DbIngest(dbAdapter, meta, searchForSpectrum), source, tblIdx);
         return new FileInfo(dbAdapter.getDbFile());
     }
+
+    static FileInfo ingestIpacTableDirectly(DbAdapter dbAdapter, File source, DataGroup meta, boolean searchForSpectrum) throws IOException {
+        IpacTableReader.parseTable(new TableParseHandler.DbIngest(dbAdapter, meta, searchForSpectrum), source);   // only the first table.
+        return new FileInfo(dbAdapter.getDbFile());
+    }
+
+    static FileInfo ingestFitsTable(TableServerRequest req, DbAdapter dbAdapter, String source, int tableIndex) throws IOException, DataAccessException {
+        var table = FITSTableReader.convertFitsToDataGroup(source, req, FITSTableReader.DEFAULT, tableIndex);
+        dbAdapter.ingestData(() -> table, dbAdapter.getDataTable());
+        return new FileInfo(dbAdapter.getDbFile());
+    }
+
 
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbReadable.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import javax.annotation.Nonnull;
 
 import static edu.caltech.ipac.table.TableUtil.getAliasName;
 
@@ -60,6 +61,7 @@ public abstract class DuckDbReadable extends DuckDbAdapter {
         }
         return null;
     }
+
     private static DataGroup getInfoOrNull(DuckDbReadable duckReadable, String srcFile) {
         try {
             return duckReadable.getInfo(srcFile);
@@ -81,6 +83,7 @@ public abstract class DuckDbReadable extends DuckDbAdapter {
         return castInto(format, null);
     }
 
+    @Nonnull
     public static DuckDbReadable castInto(TableUtil.Format format, DbAdapter dbAdapter) throws DataAccessException {
         File dbFile = dbAdapter == null ? null : dbAdapter.getDbFile();
         return   switch (format) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -230,16 +230,24 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             StopWatch.getInstance().start("fetchDataGroup: " + req.getRequestId());
             DataGroup dg = getter.get();
             StopWatch.getInstance().stop("fetchDataGroup: " + req.getRequestId()).printLog("fetchDataGroup: " + req.getRequestId());
-
             if (dg == null) throw new DataAccessException("Failed to retrieve data");
 
             jobExecIf(v -> v.progress(70, dg.size() + " rows of data found"));
 
+            dg.addMetaFrom(collectMeta(req));
             prepareTableMeta(dg.getTableMeta(), Arrays.asList(dg.getDataDefinitions()), req);
             TableUtil.consumeColumnMeta(dg, null);      // META-INFO in the request should only be pass-along and not persist.
 
             return dg;
         };
+    }
+
+    /**
+     * @param request   the table request
+     * @return  Additional meta info to add to the DataGroup before it's being ingested into the database
+     */
+    protected DataGroup collectMeta(TableServerRequest request) {
+        return null;
     }
 
     public File getDataFile(TableServerRequest request) throws IpacTableException, IOException, DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/table/io/TableParseHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/TableParseHandler.java
@@ -15,6 +15,7 @@ import edu.caltech.ipac.table.ResourceInfo;
 import org.duckdb.DuckDBAppender;
 import org.duckdb.DuckDBConnection;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,17 +30,17 @@ import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.serialize;
  * @author loi
  * @version : $
  */
-public interface VoTableHandler {
+public interface TableParseHandler {
     default void start() {};
     default void end() {};
-    default void startTable(int url) throws DataAccessException {};
-    default void endTable(int url) throws DataAccessException {};
+    default void startTable(int url) throws IOException {};
+    default void endTable(int url) throws IOException {};
     boolean headerOnly();
-    void resources(List<ResourceInfo> resourceInfo) throws DataAccessException;
-    void header(DataGroup header) throws DataAccessException;
-    void data(Object[] row ) throws DataAccessException;
+    void resources(List<ResourceInfo> resourceInfo) throws IOException;
+    void header(DataGroup header) throws IOException;
+    void data(Object[] row ) throws IOException;
 
-    abstract class Base implements VoTableHandler {
+    abstract class Base implements TableParseHandler {
         protected List<ResourceInfo> resourceInfo;
         DataGroup meta;     // additional meta to include with along with the data
         protected boolean headerOnly;
@@ -51,11 +52,11 @@ public interface VoTableHandler {
             this.searchForSpectrum = searchForSpectrum;
         }
 
-        public void resources(List<ResourceInfo> resourceInfo) throws DataAccessException {
+        public void resources(List<ResourceInfo> resourceInfo) throws IOException {
             this.resourceInfo = resourceInfo;
         }
 
-        public void header(DataGroup header) throws DataAccessException {
+        public void header(DataGroup header) throws IOException {
             header.addMetaFrom(meta);
             header.setResourceInfos(resourceInfo);
             if (searchForSpectrum) SpectrumMetaInspector.searchForSpectrum(header,true);
@@ -66,20 +67,25 @@ public interface VoTableHandler {
         }
     }
 
-    class DataGroups extends Base {
+    class Memory extends Base {
         List<DataGroup> allTables = new ArrayList<>();
 
-        public DataGroups(boolean headerOnly, boolean searchForSpectrum) {
+        public Memory(boolean headerOnly, boolean searchForSpectrum) {
             super(null, headerOnly, searchForSpectrum);
         }
 
-        public void header(DataGroup header) throws DataAccessException {
+        public void header(DataGroup header) throws IOException {
             super.header(header);
             allTables.add(header);
         }
 
-        public void data(Object[] row) throws DataAccessException {
+        public void data(Object[] row) throws IOException {
             allTables.getLast().add(row);
+        }
+
+        public void end() {
+            super.end();
+            allTables.forEach(DataGroup::trimToSize);
         }
 
         public DataGroup[] getAllTable() {
@@ -100,35 +106,35 @@ public interface VoTableHandler {
         DuckDBConnection conn;
         List<Integer> aryIdx;
 
-        public DbIngest(DbAdapter dbAdapter, DataGroup meta) {
-            super(meta, false, true);
+        public DbIngest(DbAdapter dbAdapter, DataGroup meta, boolean searchForSpectrum) {
+            super(meta, false, searchForSpectrum);
             this.dbAdapter = dbAdapter;
         }
 
-        public void header(DataGroup header) throws DataAccessException {
+        public void header(DataGroup header) throws IOException {
             super.header(header);
             this.header = header;
             cols = EmbeddedDbUtil.makeDbCols(header);
             aryIdx = colIdxWithArrayData(cols);
 
-            dbAdapter.ingestData(() -> header, dbAdapter.getDataTable());
-
             try {
+                dbAdapter.ingestData(() -> header, dbAdapter.getDataTable());
+
                 // prepare to ingest data into database
                 conn = (DuckDBConnection) JdbcFactory.getDataSource(dbAdapter.getDbInstance()).getConnection();
                 conn.setAutoCommit(false);
                 appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, dbAdapter.getDataTable());
-            } catch (SQLException e) {
-                throw new DataAccessException(e);
+            } catch (SQLException | DataAccessException e) {
+                throw new IOException(e);
             }
         }
 
-        public void data(Object[] row) throws DataAccessException {
+        public void data(Object[] row) throws IOException {
             try {
                 aryIdx.forEach(idx -> row[idx] = serialize(row[idx]));      // serialize array data if necessary
                 addRow(appender, row, ++rowCnt);
             } catch (SQLException e) {
-                throw new DataAccessException(e);
+                throw new IOException(e);
             }
         }
 

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -105,7 +105,7 @@ public class VoTableReader {
      * to the returned DataGroup(s) based on the hints provided by the given request.
      */
     public static DataGroup[] voToDataGroups(String location, TableServerRequest request, int ...indices) throws IOException {
-        VoTableHandler.DataGroups handler = new VoTableHandler.DataGroups(false, SpectrumMetaInspector.hasSpectrumHint(request));
+        TableParseHandler.Memory handler = new TableParseHandler.Memory(false, SpectrumMetaInspector.hasSpectrumHint(request));
         VOElement docRoot = getVoTableRoot(location, null);
         parse(handler, docRoot, indices);
         return handler.getAllTable();
@@ -155,7 +155,7 @@ public class VoTableReader {
     private static DataGroup[] voToDataGroups(VOElement docRoot,
                                              boolean headerOnly,
                                              int ...indices) throws IOException {
-        VoTableHandler.DataGroups handler = new VoTableHandler.DataGroups(headerOnly, false);
+        TableParseHandler.Memory handler = new TableParseHandler.Memory(headerOnly, false);
         parse(handler, docRoot, indices);
         return handler.getAllTable();
     }
@@ -307,14 +307,14 @@ public class VoTableReader {
      * @param indices  a list of table indices to parse. If no indices are specified, parse all tables.
      * @throws IOException if an I/O error occurs during parsing.
      */
-    public static void parse(VoTableHandler handler,
+    public static void parse(TableParseHandler handler,
                              String location,
                              int ...indices) throws IOException {
         VOElement docRoot = getVoTableRoot(location, FIREFLY);
         parse(handler, docRoot, indices);
     }
 
-    private static void parse(VoTableHandler handler,
+    private static void parse(TableParseHandler handler,
                               VOElement docRoot,
                               int ...indices) throws IOException {
         try {
@@ -339,7 +339,7 @@ public class VoTableReader {
         }
     }
 
-    private static void parseTable(VoTableHandler handler, TableElement tableEl, StarTable table) throws DataAccessException {
+    private static void parseTable(TableParseHandler handler, TableElement tableEl, StarTable table) throws DataAccessException {
 
         DataGroup header = getTableHeader(tableEl);
         List<DataType> cols = Arrays.asList(header.getDataDefinitions());
@@ -354,9 +354,9 @@ public class VoTableReader {
             header.addAttribute("POS_EQ_RA_MAIN", raCol.getKeyName());
             header.addAttribute("POS_EQ_DEC_MAIN", decCol.getKeyName());
         }
-
-        handler.header(header);
         try {
+            handler.header(header);
+
             // table data
             if (!handler.headerOnly()) {
                 RowSequence rs = table.getRowSequence();

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1183,7 +1183,7 @@ export function getColMaxVal(col, columnIndex, dataAry,
     let maxVal = '';
 
     // the 4 headers
-    [col.label || col.name, col.units, getTypeLabel(col), col.nullString].forEach( (v) => {
+    [col.label || col.name, col.units + '()', getTypeLabel(col), col.nullString].forEach( (v) => {
         if (v?.length > maxVal.length) maxVal = v;
     });
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
@@ -136,7 +136,7 @@ public class DataGroupReadTest {
             largeVoTableRead:  Memory Usage peak=1077.10MB  final:  0.02MB  elapsed:3.07secs  jvm:mx=1.1g
         Changes:
             FIREFLY-1591:   10/23/2024
-            - ADAPTIVE + VoTableHandler.DataGroups
+            - ADAPTIVE + TableParseHandler.Memory
                 smallVoTableRead:  Memory Usage peak=  4.00MB  final:  0.48MB  elapsed:0.06secs
                 largeVoTableRead:  Memory Usage peak=245.04MB  final:  0.10MB  elapsed:2.67secs     jvm:mx=250m
         */
@@ -165,10 +165,10 @@ public class DataGroupReadTest {
             largeVoTableRead:  elapsed:6.76secs     jvm:mx=1.1g
         Changes:
             FIREFLY-1591:   10/23/2024
-            - ADAPTIVE + VoTableHandler.Memory
+            - ADAPTIVE + TableParseHandler.Memory
                 smallVoTableRead:  elapsed:0.33secs
                 largeVoTableRead:  elapsed:6.36secs     jvm:mx=250m
-            - ADAPTIVE + VoTableHandler.DbIngest
+            - ADAPTIVE + TableParseHandler.DbIngest
                 smallVoTableRead: elapsed:0.38secs
                 largeVoTableRead: elapsed:5.25secs      jvm:mx=32m
         */
@@ -227,10 +227,13 @@ public class DataGroupReadTest {
             perfTestEmbeddedDB:  Memory Usage peak=1144.28MB  final:  4.75MB  elapsed:12.74secs
         FIREFLY-1471-table-null-val
             perfTestEmbeddedDB:  Memory Usage peak=1179.26MB  final:  4.74MB  elapsed:12.71secs
+        FIREFLY-1592: direct ingestion of IPAC table (10/28/2024)
+            Memory Usage peak= 42.28MB  final:  4.94MB  elapsed:10.22secs
+
         */
         logMemUsage(() -> {
             ConfigTest.setupServerContext(null);
-            Logger.setLogLevel(Level.TRACE);
+            Logger.setLogLevel(Level.INFO);
 
             TableServerRequest tsr = new TableServerRequest("IpacTableFromSource");
             tsr.setParam(ServerParams.SOURCE, "file://" + largeIpacTable.getPath());


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1592
See ticket for details.

In the past, handling large tables required more memory. This PR should improve that.
Test: https://fireflydev.ipac.caltech.edu/firefly-1592-ipactable-direct-ingest/firefly/
- Upload a large IPAC table

If you need a test file, you can use this one: a 3 million row, 25 column, 1.2GB IPAC table file. https://irsadev.ipac.caltech.edu:9201/test/3mil.tbl  (Upload via URL)

From DevTools, I see that my PR build takes 21.4s, compared to 28.2s for nightly. On the nightly build, it seems to crash (or possibly fails to load) on hips coverage, as it sometimes doesn't show up. Both PR and nightly are running with 4GB of memory.
