### PR TITLE
IRSA-6351: Euclid feedback changes

### DIFF
--- a/src/firefly/js/ui/UploadTableSelectorSingleCol.jsx
+++ b/src/firefly/js/ui/UploadTableSelectorSingleCol.jsx
@@ -10,6 +10,7 @@ import {onTableLoaded} from 'firefly/tables/TableUtil';
 import {FieldGroupCollapsible} from 'firefly/ui/panel/CollapsiblePanel';
 import {FilterInfo} from 'firefly/tables/FilterInfo';
 import {dispatchTableFilter} from 'firefly/tables/TablesCntlr';
+import PropTypes from 'prop-types';
 
 const UploadSingleColumn = 'uploadSingleColumn';
 const defaultTblId = 'singleColTable';
@@ -28,12 +29,13 @@ const defaultTblId = 'singleColTable';
  * @param props.headerTitle
  * @param props.colName
  * @param props.getUseSelectIn used for ObjectID on TAP
+ * @param props.slotProps
  * @returns {JSX.Element}
  */
 export function UploadTableSelectorSingleCol({uploadInfo, setUploadInfo,
                                                  headerTitle='Uploaded Column:',
                                                  colName = '',
-                                                 getUseSelectIn = () => {} }) {
+                                                 getUseSelectIn = () => {}, slotProps }) {
     const [getSingleCol,setSingleCol]= useFieldGroupValue(UploadSingleColumn);
     const {fileName,columns,totalRows,fileSize}= uploadInfo ?? {};
     const columnsUsed= columns?.filter( ({use}) => use)?.length ?? 0;
@@ -63,13 +65,14 @@ export function UploadTableSelectorSingleCol({uploadInfo, setUploadInfo,
                 <TextButton text={fileName ? 'Change Upload Table...' : 'Add Upload Table...'}
                             onClick={() => showUploadTableChooser(preSetUploadInfo,'singleColSelect',{colTypes: ['int','long','string'],colCount: 3})} style={{marginLeft: 42}} />
                 {haveFile && (
-                    <Typography pl={2} sx={{fontSize:'larger'}}>
+                    <Typography level='title-lg' sx={{width:200, overflow:'hidden', whiteSpace:'nowrap',
+                        textOverflow:'ellipsis', pl:1.5}}>
                         {`${fileName}`}
                     </Typography>
                 )}
             </Stack>
             {haveFile && (
-                <Stack direction='row' ml={24} justifyContent='flex-start'>
+                <Stack direction='row' ml={24} justifyContent='flex-start' sx={slotProps?.fileInfo?.sx}>
                     <Typography>
                         Rows: {totalRows},
                     </Typography>
@@ -107,14 +110,28 @@ export function UploadTableSelectorSingleCol({uploadInfo, setUploadInfo,
                     sx={{ mb: 1, ml: 24 }}
                     colKey={UploadSingleColumn}
                     colName={colName}
+                    slotProps={slotProps}
                 />
             )}
         </Stack>
     );
 }
 
+UploadTableSelectorSingleCol.propTypes = {
+    uploadInfo: PropTypes.object,
+    setUploadInfo: PropTypes.func,
+    headerTitle: PropTypes.string,
+    colName: PropTypes.string,
+    getUseSelectIn: PropTypes.func,
+    slotProps: PropTypes.shape({
+        singleColInnerStack: PropTypes.object,
+        singleColHeader: PropTypes.object,
+        fileInfo: PropTypes.object
+    })
+};
+
 export function SingleCol({singleCol, sx={},cols, colKey, openKey, colName='',
-                         headerTitle, headerPostTitle = '', openPreMessage='', headerStyle,colTblId=null}) {
+                         headerTitle, headerPostTitle = '', openPreMessage='', headerStyle,colTblId=null, slotProps}) {
     const posHeader= (
         <Box ml={-1}>
             <Typography display='inline' color={!singleCol?'warning':undefined} level='title-md' style={{...headerStyle}}>
@@ -137,8 +154,8 @@ export function SingleCol({singleCol, sx={},cols, colKey, openKey, colName='',
 
     return (
         <Box mt={1} sx={{...sx }}>
-            <Stack {...{direction:'row', spacing:1}}>
-                <Typography pt={1} sx={{width:'14rem', whiteSpace:'nowrap'}} component='div'>
+            <Stack {...{direction:'row', spacing:1, sx:{...slotProps?.singleColInnerStack?.sx} }}>
+                <Typography pt={1} sx={{width:'14rem', whiteSpace:'nowrap', ...slotProps?.singleColHeader?.sx}} component='div'>
                     {headerTitle}
                 </Typography>
                 <FieldGroupCollapsible header={posHeader}

--- a/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
@@ -3,8 +3,10 @@ import React, {Fragment, useContext, useEffect, useState} from 'react';
 import {oneOf, bool, string, number, arrayOf, object, func, shape, elementType} from 'prop-types';
 import {defaultsDeep} from 'lodash';
 import CoordinateSys from '../../visualize/CoordSys.js';
-import {CONE_AREA_OPTIONS, CONE_AREA_OPTIONS_ID, CONE_AREA_OPTIONS_UPLOAD_ID, CONE_CHOICE_KEY,
-    ID_CHOICE_KEY, POLY_CHOICE_KEY, UPLOAD_CHOICE_KEY} from '../../visualize/ui/CommonUIKeys.js';
+import {
+    CONE_AREA_OPTIONS, CONE_AREA_OPTIONS_ID, CONE_AREA_OPTIONS_UPLOAD, CONE_AREA_OPTIONS_UPLOAD_ID, CONE_CHOICE_KEY,
+    ID_CHOICE_KEY, POLY_CHOICE_KEY, UPLOAD_CHOICE_KEY
+} from '../../visualize/ui/CommonUIKeys.js';
 import {HiPSTargetView} from '../../visualize/ui/TargetHiPSPanel.jsx';
 import {showInfoPopup} from '../PopupUtil';
 import {RadioGroupInputField} from '../RadioGroupInputField.jsx';
@@ -380,7 +382,7 @@ function SpatialSearch({rootSlotProps: slotProps, insetSpacial, uploadInfo, setU
                 fieldKey: searchTypeKey, orientation: 'horizontal',
                 tooltip: 'Chose type of search', initialState: {value: initToggle},
                 options: useUpload || useId
-                    ? (useId && !useUpload ? CONE_AREA_OPTIONS_ID : CONE_AREA_OPTIONS_UPLOAD_ID)
+                    ? (useId && !useUpload ? CONE_AREA_OPTIONS_ID : (!useId ? CONE_AREA_OPTIONS_UPLOAD : CONE_AREA_OPTIONS_UPLOAD_ID))
                     : CONE_AREA_OPTIONS
             }} />}
             {searchTypeOp === CONE_CHOICE_KEY && <ConeOp {...{slotProps,nullAllowed}}/> }

--- a/src/firefly/js/visualize/ui/CommonUIKeys.js
+++ b/src/firefly/js/visualize/ui/CommonUIKeys.js
@@ -1,7 +1,14 @@
 export const CONE_CHOICE_KEY = 'CONE';
 export const POLY_CHOICE_KEY = 'POLY';
 export const UPLOAD_CHOICE_KEY = 'UPLOAD';
+export const ID_CHOICE_KEY = 'ID';
 export const CONE_AREA_OPTIONS = [{label: 'Cone', value: CONE_CHOICE_KEY}, {label: 'Polygon', value: POLY_CHOICE_KEY}];
 
 export const CONE_AREA_OPTIONS_UPLOAD = [{label: 'Cone', value: CONE_CHOICE_KEY}, {label: 'Polygon', value: POLY_CHOICE_KEY},
     {label: 'Multi-object', value: UPLOAD_CHOICE_KEY}];
+
+export const CONE_AREA_OPTIONS_ID = [{label: 'Cone', value: CONE_CHOICE_KEY}, {label: 'Polygon', value: POLY_CHOICE_KEY},
+    {label: 'ID', value: ID_CHOICE_KEY}];
+
+export const CONE_AREA_OPTIONS_UPLOAD_ID = [{label: 'Cone', value: CONE_CHOICE_KEY}, {label: 'Polygon', value: POLY_CHOICE_KEY},
+    {label: 'Multi-object', value: UPLOAD_CHOICE_KEY}, {label: 'ID', value: ID_CHOICE_KEY}];


### PR DESCRIPTION
**Ticket**: [IRSA-6351](https://jira.ipac.caltech.edu/browse/IRSA-6351)
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/368
- **Update 12/11**: The changes described below can be left as is if we decide to implement  a 4th `ID` Search (`Search by ID` in the case of Euclid) as part of `EmbeddedPositionSearchPanel` in the future. 
- **2.3** and **3.1, Done**: Added a 4th option (`ID` Search) to `EmbeddedPositionSearchPanel`, as scientists wanted to get rid of `Search by ID` tab altogether, and just provide `ID` search as an option in the `Images` and `Inspect Objects` tabs itself
     - Since this is only used by Euclid (for Tile & Object ID search) for now, I tried to keep it generic.
     - Added `ID` as an option within multi-object search too in the EmbeddedPositionSearchPanel, when passed via `slotProps`. 
       - So this won’t affect multi-object if used elsewhere (the default behavior will be a position search upload file)
     - The overall defaults for `EmbeddedPositionSearchPanel` are only `Cone` and `Polygon` (as used in both `DCE` & `SphereX`)
         - Currently, only Euclid makes use of the 2 additional search options (multi-object and ID)
            - Please see relevant changes in `CommonUIKeys.js`. My reason for these was to allow Upload & ID to be coupled with “Cone & Polygon” individually or together (as is the case with Euclid for now), but allowing EmebeddedPositionSearchPanel to be flexible in the future. 
                - This logic is based on Multi-Object & ID searches being optional and mutually exclusive search options in `EmbeddedPositionSearchPanel`. 

**Testing**: 
 - `Euclid`: see IFE PR for testing instructions 
 - `SphereX`: https://irsa-6351-euclid-feedback-more-changes.irsakudev.ipac.caltech.edu/applications/spherex
 - `DCE`: https://irsa-6351-euclid-feedback-more-changes.irsakudev.ipac.caltech.edu/irsaviewer/dce
 - Test `SphereX` and `DCE` to make sure nothing broke in those apps after changes made to `EmbeddedPositionSearchPanel`, which is used in both apps. 