### PR TITLE
IRSA-4877 SOFIA FORCAST GRISM product

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/SofiaAnalyzer.java
@@ -77,7 +77,7 @@ public class SofiaAnalyzer implements DataProductAnalyzer {
         if (inst.equals("FORCAST")) {
             if (level.equals("LEVEL_2") && (code.equals("rspspec") || code.equals("mrgspec"))) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
                 return  true;
-            } else if (level.equals("LEVEL_3") && (code.equals("combspec") || code.equals("calspec"))) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
+            } else if ((level.equals("LEVEL_3") && (code.equals("combspec"))) || (level.equals("LEVEL_3") && (code.equals("combined_spectrum")))  || code.equals("calspec")) { //params.containsKey("replace") && Boolean.parseBoolean(params.get("replace"))) {
                 return  true;
             }
         } else if (inst.equals("EXES") && level.equals("LEVEL_3")) {


### PR DESCRIPTION
View [tickedt](https://jira.ipac.caltech.edu/browse/IRSA-4877) for details.
Added logic for SOFIA Forcast grism product type "combined_spectrum" to be treated as spectra.
To test:
https://irsa-4877-sofia.irsakudev.ipac.caltech.edu/applications/sofia
1. pick All-Sky search, in Instrument Constraints select FORCAST, and Data Product Constraints pick Level3
2. in FORCAST result tab, filter on column "Product Type" with "combined_spectrum" and "combspec"
3. navigate product Type and view Data tab with Spectrum