### PR TITLE
FIREFLY-1627: filtering on spectral plots with >1 order causes chaos

### DIFF
--- a/src/firefly/js/charts/ui/ChartPanel.jsx
+++ b/src/firefly/js/charts/ui/ChartPanel.jsx
@@ -60,16 +60,20 @@ ChartPanelView.propTypes = {
 };
 
 
+
+
 const ResizableChartAreaInternal = React.memo((props) => {
-    const {errors, Chart, size}= props;
+    const {errors, Chart, size, chartData}= props;
     const {width:widthPx, height:heightPx}= size;
     const knownSize = widthPx && heightPx;
 
     if (!knownSize) return <div/>;
 
+    const hasData = chartData?.data?.length > errors?.length;
+
     return (
         <Stack id='chart-resizer' height={1} width={1} sx={{flexGrow:1, position:'absolute', overflow:'hidden', inset:0}}>
-            {errors.length || isUndefined(Chart) ?
+            {!hasData || isUndefined(Chart) ?
                 <ErrorPanel errors={errors}/> :
                 <Chart {...Object.assign({}, props, {widthPx, heightPx})}/>
             }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1627

https://firefly-1627-filter-order-plot.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/
To test, follow the description in the ticket.
