### PR TITLE
Firelfy-1597: fixes: things with null ra/dec shouldn't be plotted on coverage map

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
@@ -145,9 +145,11 @@ public class SearchServerCommands {
             else {
                 for(int i=0; (i<len);i++) {
                     obj= dg.get(i);
-                    long raVal= (long)((obj.getDouble(raName,0))*pow);
+                    double raD= obj.getDouble(decName,Double.NaN);
+                    long raVal= Double.isNaN(raD) ?Integer.MAX_VALUE : (long)((obj.getDouble(raName,0))*pow);
                     populateToLittleEndianByte(raVal,raByteAry,i*4);
-                    decAry[i]= (int)((obj.getDouble(decName,0))*pow);
+                    double decD= obj.getDouble(decName,Double.NaN);
+                    decAry[i]= Double.isNaN(decD) ? Integer.MAX_VALUE : (int)(decD*pow);;
                 }
             }
 

--- a/src/firefly/js/tables/HpxIndexCntlr.js
+++ b/src/firefly/js/tables/HpxIndexCntlr.js
@@ -351,6 +351,7 @@ export function getFirstIndex(orderData, norder, tileNumber) {
  */
 export function makeHpxWpt(hpxIndexData, idx) {
     if (!hpxIndexData?.latAry || !hpxIndexData?.latAry) return;
+    if (hpxIndexData.lonAry[idx]===0x7fffffff || hpxIndexData.latAry[idx]===0x7fffffff) return null;
     return makeWorldPt(
         hpxIndexData.lonAry[idx]/UINT_SCALE,
         hpxIndexData.latAry[idx]/UINT_SCALE,
@@ -545,7 +546,9 @@ function initOrderData() {
 }
 
 function addOrderRow(orderData,lonAry,latAry,rowIdx,csys) {
+    if (lonAry[rowIdx]===0x7fffffff || latAry[rowIdx]===0x7fffffff) return;
     const wp= convertCelestial(makeWorldPt( lonAry[rowIdx]/UINT_SCALE, latAry[rowIdx]/UINT_SCALE, csys));
+    if (!wp) return;
     const pixel= getIpixForWp(wp,DATA_NSIDE);
     const tileEntry= getTile(orderData,DATA_NORDER,pixel);
     if (tileEntry) {


### PR DESCRIPTION
#### [Firefly-1597](https://jira.ipac.caltech.edu/browse/FIREFLY-1597): fixes: things with null ra/dec shouldn't be plotted on coverage map

  - also fixed: [Firefly-1614](https://jira.ipac.caltech.edu/browse/FIREFLY-1614): coverage map zoom issues (again. still.)


#### Testing
 - [Firefly-1597](https://jira.ipac.caltech.edu/browse/FIREFLY-1597)
      - https://fireflydev.ipac.caltech.edu/firefly-1597-null/firefly
      -  load file from ticket
 - [Firefly-1614](https://jira.ipac.caltech.edu/browse/FIREFLY-1614): 
     - https://firefly-1597-null.irsakudev.ipac.caltech.edu/applications/Gator/
     - do a small tap search- wise,m31, 10 arcsec
