### PR TITLE
FIREFLY-1635: bug fix for CADC prepare download

### DIFF
--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -71,12 +71,9 @@ function setupObsCorePackaging(tbl_id) {
 }
 
 function updateSearchRequest( tbl_id='', dlParams='', sRequest=null) {
-    const hostname= new URL(sRequest.source)?.hostname;
-
+    const hostname= new URL(sRequest.source ? sRequest.source : sRequest.serviceUrl)?.hostname;
     const template= getTapObsCoreOptionsGuess(hostname)?.productTitleTemplate;
     const useSourceUrlFileName= getTapObsCoreOptionsGuess(hostname)?.packagerUsesSourceUrlFileName;
-
-
     const templateColNames= template && getColNameFromTemplate(template);
     const searchRequest = cloneDeep( sRequest);
     searchRequest.template = template;


### PR DESCRIPTION
**Ticket**: [FIREFLY-1635](https://jira.ipac.caltech.edu/browse/FIREFLY-1635)
- there's a regression bug in `ttFeatureWatchers.js`, in some cases the request object does not have a `source` entry, but will have a `serviceUrl` entry instead (from TAP). 
- this fix uses that value when `source` is undefined, fixing the `Prepare Download` not working for CADC bug 

**Testing**: 
Firefly: https://fireflydev.ipac.caltech.edu/firefly-1635-prepare-download-bug/firefly
DCE: https://firefly-1635-prepare-download-bug.irsakudev.ipac.caltech.edu/irsaviewer/dce
- do a CADC search and select one or more rows, click on `Prepare Download` to make sure it works 
   -  the search i do is: select IVOA from the CADC tables, and search for 'm81', 10 rows.
- do a DCE search and repeat the same step (click on `Prepare Download` having selected one or more rows). 
  - i searched the MSX collection, click on a point (or, use this: 2h44m14.43s +57d57m24.8s Equ J2000) and search