### PR TITLE
FIREFLY-1599: cascade combining spectra is broken

### DIFF
--- a/buildScript/tasks.gincl
+++ b/buildScript/tasks.gincl
@@ -383,14 +383,15 @@ test {
     maxHeapSize = "2g"
     jvmArgs '-Djava.net.preferIPv4Stack=true'
 
-    // listen to events in the test execution lifecycle
-    beforeTest { descriptor ->
-        logger.lifecycle("Running test: " + descriptor)
-        // copy sources to jsdocs build directory
+    doFirst {
         copy {
             from ("${fireflyPath}/config/test")
             into "${warDir}/WEB-INF/config"
         }
+    }
+    // listen to events in the test execution lifecycle
+    beforeTest { descriptor ->
+        logger.lifecycle("Running test: " + descriptor)
     }
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/StatisticsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/StatisticsProcessor.java
@@ -66,8 +66,13 @@ public class StatisticsProcessor extends TableFunctionProcessor {
                 row.setDataElement(columns[0], cname);
                 row.setDataElement(columns[1], desc);
                 row.setDataElement(columns[2], units);
+
+                String maxExp = col.isWholeNumber() ?
+                        "max(\"%1$s\") as \"%1$s_max\"".formatted(cname) :
+                        "max(if(\"%1$s\" = 'nan', null, \"%1$s\")) as \"%1$s_max\"".formatted(cname);    // for duckdb, NaN is greater than any other floating point number; therefore, we will exclude it by setting to null
+
                 sqlCols.add("min(\"%1$s\") as \"%1$s_min\"".formatted(cname));
-                sqlCols.add("max(\"%1$s\") as \"%1$s_max\"".formatted(cname));
+                sqlCols.add(maxExp);
                 sqlCols.add("count(\"%1$s\") as \"%1$s_count\"".formatted(cname));
                 stats.add(row);
             }

--- a/src/firefly/js/charts/ui/CombineChart.jsx
+++ b/src/firefly/js/charts/ui/CombineChart.jsx
@@ -184,7 +184,7 @@ const ChartSelectionTable = ({tbl_id, chartIds, selectedChartId}) => {
     }, [showAll]);
 
     return (
-        <Stack height={125}>
+        <Stack height={125} flexShrink={0}>
             {/*--- temporarily removed to only combine charts with similar axes
                 <div style={{display: 'inline-flex', alignItems: 'center'}}>
                     <label htmlFor='showAll'>Show All Charts: </label>


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1599
- there were NaNs in the data which is a max value for stats.
- replaced NaNs with null so that it is not counted when collecting stats.

To test: https://fireflydev.ipac.caltech.edu/firefly-1599-comgine-cascade-spectra/firefly/
- upload sample fits file from the ticket -> Load Image
- using `Extract Z-axis from cube` tool to pin a few charts
- switch to `Pinned Charts` tab, then combine them
- remember to select `Apply cascading` option