### PR TITLE
Firefly-1633: Multi Product viewer improvements

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/io/SpectrumMetaInspector.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/SpectrumMetaInspector.java
@@ -76,7 +76,7 @@ public class SpectrumMetaInspector {
     private static final String SPEC_TI_AXIS_ACCURACY= SPEC_TI_AXIS+ACCURACY;
     private static final String SPEC_ORDER = "spec:Data.SpectralAxis.Order";
     private static final String SPEC_REL_ORDER= "spec:Data.SpectralAxis.RelOrder";
-    private static final String spec10Version= "Spectrum v1.0";
+    private static final String spec10Version= "spectrum v1.0";
     private static final String VOCLASS= "VOCLASS";
 
     private static final String SPEC_SPECTRUM= "spec:Spectrum";
@@ -116,12 +116,9 @@ public class SpectrumMetaInspector {
         String utype;
         if (hdu!=null) {
             Header h= hdu.getHeader();
-            String voclass= h.getStringValue(VOCLASS);
-            if (voclass==null) voclass= "";
+            String voclass= h.getStringValue(VOCLASS,"").toLowerCase();
             utype= FitsReadUtil.getUtype(h);
-            if (utype==null && !spectrumHint &&
-                    !voclass.equals(spec10Version) &&
-                    !voclass.toLowerCase().startsWith("spectrum") ) {
+            if (utype==null && !spectrumHint && (voclass.equals(spec10Version) || voclass.startsWith("spectrum") )) {
                 utype= SPEC_SPECTRUM;
             }
             if (utype!=null) {

--- a/src/firefly/js/core/ClickToAction.js
+++ b/src/firefly/js/core/ClickToAction.js
@@ -55,13 +55,13 @@ export function makeSearchActionObj({ cmd, groupId, label='', tip, searchType, m
     return {cmd, label, tip, searchType, min, max, supported, execute, verb, searchDesc, groupId};
 }
 
-export function getSearchTypeDesc(sa, wp, size, areaPtsLength) {
+export function getSearchTypeDesc({sa, wp, size, areaPtsLength,tbl_id}) {
 
     const {searchDesc, searchType, verb, label, min, max}= sa;
     if (searchDesc) {
         if (isString(searchDesc)) return searchDesc;
         if (isFunction(searchDesc)) {
-            const title= searchDesc(wp,size,areaPtsLength);
+            const title= searchDesc({wp,size,areaPtsLength,tbl_id});
             if (isString(title)) return title;
         }
     }

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -35,6 +35,11 @@ export const MetaConst = {
     FITS_EXTRACTION_TYPE: 'FitsExtractionType',
 
     /**
+     * Search Target - the search target associated with this table
+     */
+    SEARCH_TARGET: 'SearchTarget',
+
+    /**
      * An world point in a fits FILE that is associated with this table
      */
     FITS_WORLD_PT: 'FitsWorldPoint',
@@ -183,6 +188,11 @@ export const MetaConst = {
     RELEASE_DATE_COL : 'RELEASE_DATE_COL',
 
     /**
+     * any ID can be added to a table search to identify the source for the purpose of getting source specific obscore preferences
+     */
+    OBSCORE_SOURCE_ID: 'OBSCORE_SOURCE_ID',
+
+    /**
      * if defined this table container a moving object, setting this will override any catalog evaluation
      * value can me true or false, if true then evaluate this table as a moving obj, if false then ignore
      */
@@ -228,6 +238,12 @@ export const MetaConst = {
      * If defined and true, dispatchTableSearch will be called but prevent going to results view directly
      */
     UPLOAD_TABLE: 'UploadTable',
+
+    /**
+     * if defined and an object, Then this will be table specific DataProductsFactory options
+     * @see DataProductsFactoryOptions
+     */
+    DATA_PRODUCTS_FACTORY_OPTIONS: 'DataProductFactoryOptions',
 
     /** @deprecated use CENTER_COLUMN */
     CATALOG_COORD_COLS : 'CatalogCoordColumns',

--- a/src/firefly/js/drawingLayers/HiPSMOC.js
+++ b/src/firefly/js/drawingLayers/HiPSMOC.js
@@ -61,15 +61,20 @@ function loadMocFitsWatcher(action, cancelSelf, params, dispatch, getState) {
         if (!dl) return;
         const preloadedTbl= tablePreloaded && getTblById(tbl_id);
 
+        const filterObj= dl.maxFetchDepth ? {filters : `"${mocFitsInfo.uniqColName}" < ${4*(4**(dl.maxFetchDepth+1))}`} : {};
         if (!dl.mocTable) { // moc table is not yet loaded
             let tReq;
             if (preloadedTbl){ //load by getting the full version of a already loaded table
                 tReq= cloneRequest(preloadedTbl.request,
-                    { startIdx : 0, pageSize : MAX_ROW, inclCols: mocFitsInfo.uniqColName });
+                    { startIdx : 0, pageSize : MAX_ROW, inclCols: mocFitsInfo.uniqColName, ...filterObj});
             }
             else if (fitsPath) {       // load by getting file on server
+
                 tReq = makeTblRequest('userCatalogFromFile', 'Table Upload',
-                    {filePath: fitsPath, sourceFrom: 'isLocal'},
+                    {
+                        filePath: fitsPath, sourceFrom: 'isLocal',
+                        ...filterObj,
+                    },
                     {tbl_id: mocFitsInfo.tbl_id, pageSize: MAX_ROW, inclCols: mocFitsInfo.uniqColName});
             }
             if (!tReq) return;
@@ -162,6 +167,7 @@ function creator(initPayload) {
     dl.mocTable= undefined;
     dl.rootTitle= dl.title;
     dl.mocGroupDefColorId= mocGroupDefColorId;
+    dl.maxFetchDepth= initPayload.maxFetchDepth;
 
     dispatchAddActionWatcher({
         callback:loadMocFitsWatcher,

--- a/src/firefly/js/drawingLayers/PointSelection.js
+++ b/src/firefly/js/drawingLayers/PointSelection.js
@@ -45,7 +45,7 @@ function dispatchSelectPoint(mouseStatePayload) {
 
 function onDetach(drawLayer,action) {
     const {plotIdAry}= action.payload;
-    plotIdAry.forEach( (plotId) => {
+    plotIdAry?.forEach( (plotId) => {
         const plot= primePlot(visRoot(),plotId);
         if (plot && plot.attributes[PlotAttribute.ACTIVE_POINT]) {
             dispatchAttributeChange(

--- a/src/firefly/js/metaConvert/AnalysisUtils.js
+++ b/src/firefly/js/metaConvert/AnalysisUtils.js
@@ -115,18 +115,19 @@ export function makeAnalysisGetGridDataProduct(makeReq) {
  * @param obj.menuKey
  * @param obj.dataTypeHint
  * @param {ServiceDescriptorDef} [obj.serDef]
+ * @param {DatalinkData} [obj.dlData]
  * @param [obj.originalTitle]
  * @param {DataProductsFactoryOptions} [obj.options]
  * @return {function}
  */
 export function makeAnalysisActivateFunc({table, row, request, activateParams, menuKey,
-                                             dataTypeHint, serDef, originalTitle, options}) {
+                                             dataTypeHint, serDef, originalTitle, options, dlData}) {
     const analysisActivateFunc = async (menu, userInputParams) => {
         const {dpId}= activateParams;
         dispatchUpdateDataProducts(dpId, dpdtWorkingMessage(LOADING_MSG,menuKey));
         // do the uploading and analyzing
         const dPDisplayType= await doUploadAndAnalysis({ table, row, request, activateParams, dataTypeHint, options, menu,
-            serDef, userInputParams, analysisActivateFunc, originalTitle, menuKey});
+            serDef, dlData, userInputParams, analysisActivateFunc, originalTitle, menuKey});
         // activate the result of the analysis
        dispatchResult(dPDisplayType, menu,menuKey,dpId, serDef, analysisActivateFunc);
     };

--- a/src/firefly/js/metaConvert/DataProductsCntlr.js
+++ b/src/firefly/js/metaConvert/DataProductsCntlr.js
@@ -47,6 +47,7 @@ function activateMenuItemActionCreator(rawAction) {
         const menuItem= menu.find( (m) => m.menuKey===menuKey);
         if (!menuItem) return;
         if (menuItem.displayType===DPtypes.DOWNLOAD) doDownload(menuItem.url);
+        else if (menuItem.displayType===DPtypes.EXTRACT) doExtract(menuItem);
         else dispatcher(rawAction);
     };
 }
@@ -64,6 +65,10 @@ function activateFileMenuItemActionCreator(rawAction) {
         }
         if (doDispatch) dispatcher(rawAction);
     };
+}
+
+function doExtract(menuItem) {
+    menuItem?.activate();
 }
 
 export function doDownload(url) {

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -4,7 +4,7 @@
 
 import {isArray, once} from 'lodash';
 import {MetaConst} from '../data/MetaConst.js';
-import {getMetaEntry} from '../tables/TableUtil';
+import {getMetaEntry, getObjectMetaEntry} from '../tables/TableUtil';
 import {hasObsCoreLikeDataProducts, isDatalinkTable} from '../voAnalyzer/TableAnalysis.js';
 import {hasServiceDescriptors} from '../voAnalyzer/VoDataLinkServDef.js';
 import {Band} from '../visualize/Band';
@@ -284,14 +284,13 @@ function initConverterTemplates() {
  * @typedef {Object} DataProductsFactoryOptions
  *
  * @prop {boolean} [allowImageRelatedGrid]
- * @prop {boolean} [allowServiceDefGrid] - // todo: this is redundant, should remove
  * @prop {boolean} [singleViewImageOnly] - if true, the view will only show the primary image product
  * @prop {boolean} [singleViewTableOnly] - if true, the view will only show the primary table product
  * @prop {String} [dataLinkInitialLayout] - determine how a datalink obscore table trys to show the data layout, must be 'single', 'gridRelated', 'gridFull';
  * @prop {boolean} [activateServiceDef] - if possible then call the service def without giving option for user input
  * @prop {boolean} [threeColor] - if true, then for images in related grid, show the threeColor option
  * @prop {number} [maxPlots] - maximum number of plots in grid mode, this will override the factory default
- * @prop {boolean} [canGrid] - some specific factories might have parameters that override this parameter (e.g. allowServiceDefGrid)
+ * @prop {boolean} [canGrid] - some specific factories might have parameters that override this parameter
  * @prop [initialLayout]
  * @prop {string} [tableIdBase] - any tbl_id will use this string for its base
  * @prop {string} [chartIdBase] - any chartId will use this string for its base
@@ -302,6 +301,7 @@ function initConverterTemplates() {
  *                The values in this object will override one or more parameters to a service descriptor.
  *                The following are used with this prop by service descriptors to build the url to include input from the UI.
  *                see- ServDescProducts.js getComponentInputs()
+ * @prop {object} datalinkTblRequestOptions = add addition options to table request
  * @prop {Array.<string>} [paramNameKeys] - name of the parameters to put in the url from the getComponentState() return object
  * @prop {Array.<string>} [ucdKeys] - same as above but can be specified by UCD
  * @prop {Array.<string>} [utypeKeys] - same as above but can be specified by utype
@@ -313,19 +313,19 @@ function initConverterTemplates() {
 export const getDefaultFactoryOptions= once(() => ({
     dataProductsComponentKey: DEFAULT_DATA_PRODUCTS_COMPONENT_KEY,
     allowImageRelatedGrid: false,
-    allowServiceDefGrid: false, // todo: this is redundant, should remove
     singleViewImageOnly:false,
     singleViewTableOnly:false,
     dataLinkInitialLayout: 'single', //determine how a datalink obscore table trys to show the data layout, must be 'single', 'gridRelated', 'gridFull';
     activateServiceDef: false,
     threeColor: undefined,
     maxPlots: undefined,
-    canGrid: undefined, // some specific factories might have parameters that override this parameter (e.g. allowServiceDefGrid)
+    canGrid: undefined, // some specific factories might have parameters that override this parameter
     initialLayout: undefined, //todo - an datalink use this?
     tableIdBase: undefined,
     chartIdBase: undefined,
     tableIdList: [], // list of ids
     chartIdList: [],// list of ids
+    datalinkTblRequestOptions: {},
     paramNameKeys: [],
     ucdKeys: [],
     utypeKeys: [],
@@ -386,9 +386,9 @@ export function makeDataProductsConverter(table, factoryKey= undefined) {
         threeColor: options.threeColor ?? t.threeColor ?? false,
         dataProductsComponentKey: options.dataProductsComponentKey
     };
-    const retObj= t.create(table,pT, options);
+    const metaOptions= getObjectMetaEntry(table, MetaConst.DATA_PRODUCTS_FACTORY_OPTIONS, {});
+    const retObj= t.create(table,pT, {...options, ...metaOptions});
     return {options, ...retObj};
-        
 }
 
 

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -74,6 +74,7 @@ export const DPtypes= {
     CHOICE_CTI: 'chartTable',
     DOWNLOAD: 'download',
     DOWNLOAD_MENU_ITEM: 'download-menu-item',
+    EXTRACT: 'extract',
     PNG: 'png',
     ANALYZE: 'analyze',
     UNSUPPORTED: 'unsupported',
@@ -184,9 +185,9 @@ export const dpdtMessageWithError= (message,detailMsgAry) => {
  */
 export function dpdtImage({name, activate, extraction, menuKey='image-0', extractionText='Pin Image',
                               request, override, interpretedData, requestDefault, enableCutout, pixelBasedCutout,
-                              url, semantics,size, serDef }) {
+                              url, semantics,size, serDef, dlData }) {
     return { displayType:DPtypes.IMAGE, name, activate, extraction, menuKey, extractionText, enableCutout, pixelBasedCutout,
-        request, override, interpretedData, requestDefault,url, semantics,size,serDef};
+        request, override, interpretedData, requestDefault,url, semantics,size,serDef, dlData};
 }
 
 /**
@@ -234,6 +235,7 @@ export function dpdtChartTable(name, activate, extraction, menuKey='chart-table-
  * @param {boolean} [p.allowsInput]
  * @param {String} [p.standardID]
  * @param {String} [p.ID]
+ * @param {DatalinkData} [dlData]
  * @return {DataProductsDisplayType}
  */
 export function dpdtAnalyze({
@@ -251,11 +253,13 @@ export function dpdtAnalyze({
                              serviceDefRef,
                              allowsInput= false,
                              standardID,
-                             ID }) {
+                             ID,
+                             cutoutToFullWarning,
+                             dlData}) {
     return { displayType:DPtypes.ANALYZE,
         name, url, activate, serDef, menuKey, semantics,
         size, activeMenuLookupKey, request, sRegion, prodTypeHint,
-        serviceDefRef, allowsInput, standardID, ID,
+        cutoutToFullWarning, serviceDefRef, allowsInput, standardID, ID, dlData
     };
 }
 
@@ -270,6 +274,10 @@ export function dpdtAnalyze({
  */
 export function dpdtDownload(name, url, menuKey='download-0', fileType, extra={}) {
     return { displayType:DPtypes.DOWNLOAD, name, url, menuKey, fileType, ...extra};
+}
+
+export function dpdtExtract(name, activate, menuKey='extract-0') {
+    return { displayType:DPtypes.EXTRACT, name, activate, menuKey};
 }
 
 export function dpdtDownloadMenuItem(name, url, menuKey='download-0', fileType, extra={}) {

--- a/src/firefly/js/metaConvert/DataProductsWatcher.js
+++ b/src/firefly/js/metaConvert/DataProductsWatcher.js
@@ -255,8 +255,16 @@ function updateDataProducts(factoryKey, action, firstTime, tbl_id, activateParam
     const {highlightedRow}= tableState;
 
     // keep the plotId array for 'single' layout
-    const layout= getLayoutType(getMultiViewRoot(), imageViewerId, tbl_id);
+    let layout= getLayoutType(getMultiViewRoot(), imageViewerId, tbl_id);
     const layoutDetail= getLayoutDetails(getMultiViewRoot(), imageViewerId, tbl_id);
+
+
+    if (layout===GRID && !converter.canGrid) {
+        dispatchChangeViewerLayout(viewer.viewerId,SINGLE,undefined,tbl_id);
+        layout= getLayoutType(getMultiViewRoot(), imageViewerId, tbl_id);
+    }
+
+
 
     let resultPromise;
     if (layout===SINGLE) {

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -18,9 +18,7 @@ import {getPlotGroupById} from '../visualize/PlotGroup.js';
 import {
     getActivePlotView, getPlotViewAry, getPlotViewById, isDefaultCoverageActive, isImageExpanded, primePlot
 } from '../visualize/PlotViewUtil.js';
-import {
-    AnnotationOps, getDefaultImageColorTable, isImageDataRequestedEqual, WebPlotRequest
-} from '../visualize/WebPlotRequest.js';
+import { getDefaultImageColorTable, isImageDataRequestedEqual, WebPlotRequest } from '../visualize/WebPlotRequest.js';
 import {ZoomType} from '../visualize/ZoomType.js';
 
 
@@ -101,22 +99,27 @@ function copyRequest(inR) {
 /**
  * pass a request or array of request and return an extraction function
  * @param {WebPlotRequest|Array.<WebPlotRequest>} request
+ * @param {ObsCoreData} [sourceObsCoreData]
+ * @param {DatalinkData} [dlData]
  * @return {Function}
  */
-export function createSingleImageExtraction(request) {
+export function createSingleImageExtraction(request, sourceObsCoreData, dlData) {
     if (!request) return undefined;
     const wpRequest= isArray(request) ? request.map( (r) => copyRequest(r)) : copyRequest(request);
     const plotIds= isArray(request) ? request.map( (r) => r.getPlotId()) : copyRequest(request);
+    const attributes= {};
+    if (sourceObsCoreData) attributes.sourceObsCoreData= sourceObsCoreData;
+    if (dlData) attributes.dlData= dlData;
     return () => {
         if (isArray(wpRequest)) {
             const activePlotId= getActivePlotView(visRoot())?.plotId;
             const idx= plotIds.findIndex( (id) => id===activePlotId);
             if (idx<0) return;
             dispatchPlotImage({ viewerId:DEFAULT_FITS_VIEWER_ID,
-                plotId:wpRequest[idx].getPlotId(),wpRequest:wpRequest[idx]});
+                plotId:wpRequest[idx].getPlotId(),wpRequest:wpRequest[idx], attributes});
         }
         else {
-            dispatchPlotImage({ viewerId:DEFAULT_FITS_VIEWER_ID, wpRequest});
+            dispatchPlotImage({ viewerId:DEFAULT_FITS_VIEWER_ID, wpRequest, attributes});
         }
         showPinMessage('Pinning to Image Area');
     };

--- a/src/firefly/js/metaConvert/vo/DataLinkStandAloneConverter.js
+++ b/src/firefly/js/metaConvert/vo/DataLinkStandAloneConverter.js
@@ -1,4 +1,6 @@
+import {getPreferCutout} from '../../ui/tap/ObsCoreOptions';
 import {getDataLinkData} from '../../voAnalyzer/VoDataLinkServDef.js';
+import {DEFAULT_DATA_PRODUCTS_COMPONENT_KEY} from '../DataProductsCntlr';
 import {createDataLinkSingleRowItem} from './DataLinkProcessor.js';
 
 /**
@@ -16,8 +18,19 @@ export function makeDatalinkStaneAloneConverter(table,converterTemplate,options=
 
 export async function getDatalinkStandAlineDataProduct(table, row, activateParams, options) {
     const dataLinkData= getDataLinkData(table);
-    const dlData= dataLinkData?.[row];
+    const {dataProductsComponentKey=DEFAULT_DATA_PRODUCTS_COMPONENT_KEY}= options;
+    const preferCutout= getPreferCutout(dataProductsComponentKey,table?.tbl_id);
 
-    const item= createDataLinkSingleRowItem({dlData, activateParams, baseTitle:'Datalink data', options});
-    return item;
+    let dlData= dataLinkData?.[row];
+    const {isCutout,cutoutFullPair}= dlData.dlAnalysis;
+
+    if (cutoutFullPair) {
+        if (preferCutout) {
+            dlData = isCutout ? dlData : dlData.relatedDLEntries.cutout;
+        }
+        else {
+            dlData = !isCutout ? dlData : dlData.relatedDLEntries.fullImage;
+        }
+    }
+    return createDataLinkSingleRowItem({dlData, activateParams, baseTitle:'Datalink data', options});
 }

--- a/src/firefly/js/metaConvert/vo/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/vo/ServDescConverter.js
@@ -27,14 +27,13 @@ export function makeServDescriptorConverter(table,converterTemplate,options={}) 
 
     const canRelatedGrid= options.allowImageRelatedGrid?? false;
     const threeColor= converterTemplate.threeColor && options?.allowImageRelatedGrid;
-    const allowServiceDefGrid= options.allowServiceDefGrid?? false;
     //------
     const baseRetOb = {
         ...converterTemplate,
         initialLayout: options?.dataLinkInitialLayout ?? 'single',
         describeThreeColor: (threeColor) ? describeServDefThreeColor : undefined,
         threeColor,
-        canGrid: canRelatedGrid || allowServiceDefGrid,
+        canGrid: canRelatedGrid,
         maxPlots: canRelatedGrid ? DEF_MAX_PLOTS : 1,
         hasRelatedBands: canRelatedGrid,
         converterId: `ServiceDef-${table.tbl_id}`

--- a/src/firefly/js/metaConvert/vo/VORequest.js
+++ b/src/firefly/js/metaConvert/vo/VORequest.js
@@ -3,13 +3,14 @@ import {sprintf} from '../../externalSource/sprintf.js';
 import {getCellValue, getColumn, getMetaEntry} from '../../tables/TableUtil.js';
 import {PlotAttribute} from '../../visualize/PlotAttribute.js';
 import RangeValues from '../../visualize/RangeValues.js';
+import {RequestType} from '../../visualize/RequestType';
 import {TitleOptions, WebPlotRequest} from '../../visualize/WebPlotRequest.js';
 import {ZoomType} from '../../visualize/ZoomType.js';
 import {getSSATitle, isSSATable} from '../../voAnalyzer/TableAnalysis.js';
 
 /**
  *
- * @param dataSource
+ * @param dataSourc
  * @param positionWP
  * @param titleStr
  * @param {TableModel} table
@@ -30,6 +31,8 @@ export function makeObsCoreRequest(dataSource, positionWP, titleStr, table, row)
         r.setTitleOptions(TitleOptions.FILE_NAME);
     }
     r.setPlotId(uniqueId('obscore-'));
+    r.setWorldPt(positionWP);
+    r.setRequestType(RequestType.URL);
 
     const emMinCol = getColumn(table, 'em_max', true);
     const emMaxCol = getColumn(table, 'em_max', true);

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1462,7 +1462,7 @@ function getTM(tableOrId) {
  * @return {String|undefined|*} value or the meta data or the defVal
  */
 export function getMetaEntry(tableOrId,metaKey,defVal= undefined) {
-    const tableMeta= get(getTM(tableOrId),'tableMeta');
+    const tableMeta= getTM(tableOrId)?.tableMeta;
     if (!tableMeta || !isString(metaKey)) return defVal;
     const keyUp = metaKey.toUpperCase();
     const [foundKey,value]= Object.entries(tableMeta).find( ([k]) => k.toUpperCase()===keyUp) || [];
@@ -1470,7 +1470,7 @@ export function getMetaEntry(tableOrId,metaKey,defVal= undefined) {
 }
 
 /**
- * case insensitive search of meta data for boolean a entry, if not found return the defVal
+ * Case insensitive search of meta data for a boolean entry, if not found return the defVal
  * @param {TableModel|String} tableOrId - parameters accepts the table model or tha table id
  * @param {String} metaKey - the metadata key
  * @param {boolean} [defVal= false] - the defVal to return if not found, defaults to false
@@ -1478,6 +1478,22 @@ export function getMetaEntry(tableOrId,metaKey,defVal= undefined) {
  */
 export function getBooleanMetaEntry(tableOrId,metaKey,defVal= false) {
     return toBoolean(getMetaEntry(tableOrId,metaKey,undefined),Boolean(defVal),['true','t','yes','y']);
+}
+
+/**
+ * Case insensitive search of meta data for an object entry, if not found return the defVal
+ * @param {TableModel|String} tableOrId - parameters accepts the table model or tha table id
+ * @param {String} metaKey - the metadata key
+ * @param {Object} [defVal= undefined] - the defVal to return if not found, defaults to undefined
+ * @return {Object} value or the meta data or the defVal
+ */
+export function getObjectMetaEntry(tableOrId,metaKey,defVal= undefined) {
+    try {
+        return JSON.parse(getMetaEntry(tableOrId,metaKey));
+    }
+    catch {
+        return defVal;
+    }
 }
 
 /**

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -5,7 +5,7 @@ import {dispatchAddTableTypeWatcherDef} from '../../core/MasterSaga.js';
 import {dispatchTableUiUpdate, TABLE_LOADED} from '../../tables/TablesCntlr.js';
 import {getActiveTableId, getMetaEntry, getTableUiByTblId, getTblById} from '../../tables/TableUtil.js';
 import {DownloadButton, DownloadOptionPanel} from '../../ui/DownloadDialog.jsx';
-import {getTapObsCoreOptions, getTapObsCoreOptionsGuess} from '../../ui/tap/TableSearchHelpers.jsx';
+import {getTapObsCoreOptions, getTapObsCoreOptionsGuess} from '../../ui/tap/ObsCoreOptions';
 import {hasObsCoreLikeDataProducts, isObsCoreLikeWithProducts} from '../../voAnalyzer/TableAnalysis.js';
 import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';

--- a/src/firefly/js/ui/ActionsDropDownButton.jsx
+++ b/src/firefly/js/ui/ActionsDropDownButton.jsx
@@ -62,9 +62,9 @@ function isSupported(sa,cenWpt,radius,cornerStr,table) {
             return sa.supported(sa, cenWpt, getValidSize(sa, radius), cornerStr);
         case SearchTypes.point:
         case SearchTypes.point_table_only:
-            return sa.supported(sa, cenWpt);
+            return sa.supported(table);
         case SearchTypes.wholeTable:
-            return sa.supported(sa, table);
+            return sa.supported(table);
     }
 }
 
@@ -98,7 +98,7 @@ function SearchDropDown({searchActions, buttonRef, spacial, tbl_id}) {
     const makePartialList= (sActions, cenWpt, asCone) => {
 
         const buttons= sActions.map((sa,idx) => {
-            const text = getSearchTypeDesc(sa, cenWpt, radius, corners?.length);
+            const text = getSearchTypeDesc({sa, wp:cenWpt, size:radius, areaPtsLength:corners?.length, tbl_id});
             let useSep = false;
             if (lastGroupId && sa.groupId !== lastGroupId && idx!==sActions.length-1) {
                 lastGroupId = sa.groupId;
@@ -107,7 +107,6 @@ function SearchDropDown({searchActions, buttonRef, spacial, tbl_id}) {
             if (!lastGroupId) lastGroupId = sa.groupId;
             return (
                 <React.Fragment key={'frag=' + idx}>
-                    {/*{useSep && <DropDownVerticalSeparator key={sa.cmd + '---separator'} useLine={true} style={{marginLeft:30}}/>}*/}
                     <ToolbarButton text={text} tip={`${sa.tip} for\n${text}`}
                                    style={{paddingLeft:30}}
                                    enabled={true} horizontal={false} key={sa.cmd+text}
@@ -145,17 +144,14 @@ function SearchDropDown({searchActions, buttonRef, spacial, tbl_id}) {
 
     return (
         <SingleColumnMenu key='searchMenu'>
-            {doWholeTable &&
-                <Typography color='warning' level='body-sm'> Whole table actions </Typography>
-            }
+            {doWholeTable && <Typography color='warning' level='body-sm'> Whole table actions </Typography> }
             { doWholeTable && wholeTableSearchActions.map((sa) => {
-                const text = getSearchTypeDesc(sa, cenWpt, radius, corners?.length);
+                const text = getSearchTypeDesc({sa, wp:cenWpt, size:radius, areaPtsLength:corners?.length, tbl_id});
+                const tip= sa.tip ? `${sa.tip} for\n${text}` : text;
                 return (
-                    <ToolbarButton text={text} tip={`${sa.tip} for\n${text}`}
-                                   style={{paddingLeft:30}}
-                                   enabled={true} horizontal={false} key={sa.cmd+sa.tip}
-                                   visible={isSupported(sa, cenWpt, radius, cornerStr, table)}
-                                   onClick={() => doExecute(sa, cenWpt, radius, cornerStr, table)}/>
+                    <ToolbarButton {...{text, tip, horizontal:false, key:sa.cmd+sa.tip,
+                                   visible:isSupported(sa, cenWpt, radius, cornerStr, table),
+                                   onClick:() => doExecute(sa, cenWpt, radius, cornerStr, table) }}/>
                 );
             })}
             {
@@ -164,7 +160,6 @@ function SearchDropDown({searchActions, buttonRef, spacial, tbl_id}) {
                     if (idx===1 && saOrder[0].length>0 && saList.length>0) {
                         return (
                             <React.Fragment key={'frag-part-'+idx}>
-                                {/*<DropDownVerticalSeparator key={'parts'+idx+'---separator'} useLine={false} style={{marginBottom:8}}/>*/}
                                 {pList}
                             </React.Fragment>
                         );

--- a/src/firefly/js/ui/CutoutSizeDialog.jsx
+++ b/src/firefly/js/ui/CutoutSizeDialog.jsx
@@ -3,89 +3,220 @@
  */
 import {isString} from 'lodash';
 import React, {useEffect} from 'react';
-import {
-    dispatchShowDialog, dispatchHideDialog, getComponentState, dispatchComponentStateChange
-} from '../core/ComponentCntlr.js';
-import {SD_CUTOUT_KEY} from '../metaConvert/vo/ServDescProducts';
+import {Chip, Stack, Typography} from '@mui/joy';
+import {dispatchShowDialog, dispatchHideDialog} from '../core/ComponentCntlr.js';
+import {dispatchChangePointSelection, visRoot} from '../visualize/ImagePlotCntlr';
+import {PlotAttribute} from '../visualize/PlotAttribute';
+import {getActivePlotView, primePlot} from '../visualize/PlotViewUtil';
+import {FieldGroupCollapsible} from './panel/CollapsiblePanel';
+import { getCutoutSize, setAllCutoutParams, setPreferCutout } from './tap/ObsCoreOptions';
 import {intValidator} from '../util/Validate';
 import CompleteButton from './CompleteButton.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
-import {FieldGroup} from './FieldGroup';
+import {FieldGroup} from './FieldGroup.jsx';
 import {PopupPanel} from './PopupPanel.jsx';
-import {useFieldGroupValue, useStoreConnector} from './SimpleComponent';
-import {SizeInputFields} from './SizeInputField';
+import {DEF_TARGET_PANEL_KEY, TargetPanel} from './TargetPanel';
+import {ValidationField} from './ValidationField.jsx';
+import {showYesNoPopup} from './PopupUtil.jsx';
+import {useFieldGroupValue, useStoreConnector} from './SimpleComponent.jsx';
+import {SizeInputFields} from './SizeInputField.jsx';
 
 import HelpIcon from './HelpIcon.jsx';
-import {Stack} from '@mui/joy';
-import {ValidationField} from './ValidationField';
 
 const DIALOG_ID= 'cutoutSizeDialog';
+const OVERRIDE_TARGET= 'OverrideTarget';
 
 
-export function showCutoutSizeDialog(cutoutDefSizeDeg, pixelBasedCutout, dataProductsComponentKey) {
+
+export function showCutoutSizeDialog({showingCutout, cutoutDefSizeDeg, pixelBasedCutout, tbl_id, cutoutCenterWP,
+                                     dataProductsComponentKey, enableCutoutFullSwitching, cutoutToFullWarning}) {
     const popup = (
-        <PopupPanel title={'Set Cutout Size'}>
+        <PopupPanel title={'Cutout Settings'} closeCallback={hideDialog} >
             <FieldGroup groupKey={'cutout-size-dialog'} keepState={true}>
-                <CutoutSizePanel {...{cutoutDefSizeDeg,pixelBasedCutout,dataProductsComponentKey}}/>
+                <CutoutSizePanel {...{showingCutout, cutoutDefSizeDeg,pixelBasedCutout, tbl_id, cutoutCenterWP,
+                    dataProductsComponentKey,enableCutoutFullSwitching, cutoutToFullWarning}}/>
             </FieldGroup>
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(DIALOG_ID, popup);
-    dispatchShowDialog(DIALOG_ID);
+    showDialog();
 }
 
 
+function showDialog() {
+    dispatchChangePointSelection('cutoutDialog', true);
+    dispatchShowDialog(DIALOG_ID);
+}
+
+function hideDialog() {
+    dispatchChangePointSelection('cutoutDialog', false);
+    dispatchHideDialog(DIALOG_ID);
+}
 
 
-function CutoutSizePanel({cutoutDefSizeDeg,pixelBasedCutout,dataProductsComponentKey}) {
-    const cutoutFieldKey= dataProductsComponentKey+'-'+SD_CUTOUT_KEY;
-    let cutoutValue= useStoreConnector( () => getComponentState(dataProductsComponentKey)[SD_CUTOUT_KEY] ?? cutoutDefSizeDeg);
-    const [getCutoutSize,setCutoutSize]= useFieldGroupValue(cutoutFieldKey);
+function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataProductsComponentKey, tbl_id,
+                             cutoutCenterWP, enableCutoutFullSwitching, cutoutToFullWarning}) {
+    const cutoutFieldKey= dataProductsComponentKey+'-CutoutSize';
+    let cutoutValue= useStoreConnector( () => getCutoutSize(dataProductsComponentKey));
+    const [getCutoutFieldSize,setCutoutFieldSize]= useFieldGroupValue(cutoutFieldKey);
+    const [getOverrideTarget,setOverrideTarget]= useFieldGroupValue(OVERRIDE_TARGET);
+    const [getEnteredTarget,setEnteredTarget]= useFieldGroupValue(DEF_TARGET_PANEL_KEY);
+
+    const activeWp= useStoreConnector(() => {
+        const plot= primePlot(visRoot());
+        if (!plot) return;
+        const {pt}=plot.attributes[PlotAttribute.ACTIVE_POINT] ?? {};
+        return pt;
+    });
+
+    useEffect(() => {
+        if (activeWp) {
+            setOverrideTarget(activeWp);
+            setEnteredTarget(activeWp);
+        }
+    }, [activeWp]);
+
+
 
     if (isString(cutoutValue) && cutoutValue?.endsWith('px')) {
        cutoutValue= cutoutValue.substring(0,cutoutValue.length-2);
     }
 
     useEffect(() => {
-        setCutoutSize(cutoutValue);
+        setCutoutFieldSize(cutoutValue);
     },[cutoutFieldKey]);
 
     return (
-        <Stack justifyContent='space-between' alignItems='center' spacing={1}>
-            { pixelBasedCutout ?
-                <ValidationField {...{
-                    nullAllowed: false,
-                    placeholder:  'enter pixel value',
-                    label: 'Cutout Size in pixels',
-                    fieldKey: cutoutFieldKey,
-                    initialState: {
-                        value: Number(cutoutValue),
-                        validator: intValidator(0, undefined, 'cutout size in pixels')
-                    },
-                    tooltip: 'cutout size'
-                }} />
-                :
-                <SizeInputFields fieldKey={cutoutFieldKey} showFeedback={true} label='Cutout Size'
-                                 initialState={{
-                                     value: (cutoutDefSizeDeg/3600).toString(),
-                                     tooltip: 'Set cutout size',
-                                     unit: 'arcsec', min:  1/3600, max:  5
-                                 }} />
+        <Stack justifyContent='space-between' alignItems='center' spacing={1} minWidth='25rem'>
+            <Stack spacing={4} minWidth={'40rem'}>
+                { pixelBasedCutout ?
+                    <ValidationField {...{
+                        nullAllowed: false,
+                        placeholder:  'enter pixel value',
+                        label: 'Cutout Size in pixels',
+                        fieldKey: cutoutFieldKey,
+                        initialState: {
+                            value: Number(cutoutValue),
+                            validator: intValidator(0, undefined, 'cutout size in pixels')
+                        },
+                        tooltip: 'cutout size'
+                    }} />
+                    :
+                    <SizeInputFields fieldKey={cutoutFieldKey} showFeedback={true} label='Cutout Size'
+                                     initialState={{
+                                         value: (cutoutDefSizeDeg/3600).toString(),
+                                         tooltip: 'Set cutout size',
+                                         unit: 'arcsec', min:  1/3600, max:  5
+                                     }} />
 
-            }
+                }
+                <OptionalTarget cutoutCenterWP={cutoutCenterWP} activePt/>
+            </Stack>
             <Stack {...{textAlign:'center', direction:'row', justifyContent:'space-between', width:1, px:1, pb:1}}>
-                <CompleteButton text='Update Cutout' dialogId={DIALOG_ID}
-                                onSuccess={(r) => updateCutout(r,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout)}/>
+                <Stack {...{textAlign:'center', direction:'row', spacing:1}}>
+                    <CompleteButton text={showingCutout?'Update Cutout':'Show Cutout'} dialogId={DIALOG_ID}
+                                    onSuccess={(r) => updateCutout(r,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout,getOverrideTarget(),tbl_id)}/>
+                    {showingCutout && enableCutoutFullSwitching &&
+                        <CompleteButton text='Show Full Image'
+                                        onSuccess={(r) =>
+                                            showFullImage(r,cutoutFieldKey,dataProductsComponentKey,
+                                                cutoutToFullWarning,tbl_id)}/>
+                    }
+                </Stack>
                 <HelpIcon helpId={'visualization.rotate'} />
             </Stack>
         </Stack>
     );
 }
 
+function OptionalTarget({cutoutCenterWP}) {
 
-function updateCutout(request,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout) {
-    dispatchComponentStateChange(dataProductsComponentKey,
-        {
-            [SD_CUTOUT_KEY]:`${request[cutoutFieldKey]}${pixelBasedCutout?'px':''}`
-        });
+    const [getEnteredTarget,setEnteredTarget]= useFieldGroupValue(DEF_TARGET_PANEL_KEY);
+    const [getOverrideTarget,setOverrideTarget]= useFieldGroupValue(OVERRIDE_TARGET);
+    const wpOverride= getOverrideTarget();
+
+    useEffect(() => {
+        const newWp= getEnteredTarget();
+        if (newWp?.then) return; // ignore promises
+        if (!newWp || newWp?.toString()===cutoutCenterWP?.toString()) {
+            setOverrideTarget(undefined);
+        }
+        else {
+            setOverrideTarget(newWp);
+        }
+    }, [getEnteredTarget]);
+
+    const header= (
+        <Stack direction='row' justifyContent='space-between' alignItems='baseline' width={1}>
+            <Stack direction='row' spacing={1}>
+                <Typography level='title-md'>
+                    Change Cutout Center:
+                </Typography>
+                <Typography level='body-md'>
+                    Enter new point or click on image
+                </Typography>
+            </Stack>
+            <Typography level='body-sm'>
+                {`(${wpOverride?'Using Custom':'Using Default'})`}
+            </Typography>
+        </Stack>
+
+    );
+
+    return (
+        <FieldGroupCollapsible header={header}
+                               initialState= {{ value:'closed' }}
+                               fieldKey='optionalTarget'>
+            <Stack spacing={2}>
+                <TargetPanel
+                    defaultToActiveTarget={false}
+                    initialState={{
+                        value: wpOverride ?? cutoutCenterWP
+                    }}
+                />
+                <Chip onClick={() => {
+                    setOverrideTarget(undefined);
+                    setEnteredTarget(cutoutCenterWP);
+                }}>
+                    reset to default
+                </Chip>
+                <Typography color='warning'  level='body-sm'>
+                    Warning: Changing the center could cause search to fail if new center is off of the tile
+                </Typography>
+            </Stack>
+        </FieldGroupCollapsible>
+    );
+};
+
+
+function updateCutout(request,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout,overrideTarget,tbl_id) {
+    hideDialog();
+    const size= `${request[cutoutFieldKey]}${pixelBasedCutout?'px':''}`;
+    setAllCutoutParams( dataProductsComponentKey, tbl_id, size, overrideTarget, true);
+
+}
+
+function showFullImage(request,cutoutFieldKey,dataProductsComponentKey,cutoutToFullWarning,tbl_id) {
+    if (cutoutToFullWarning) {
+        showYesNoPopup(
+            <Stack minWidth='30em' spacing={2} m={1}>
+                <Typography>{cutoutToFullWarning}</Typography>
+                <Typography>Show full image?</Typography>
+            </Stack>,
+            (id, yes) => {
+                if (yes) {
+                    hideDialog();
+                    setPreferCutout(dataProductsComponentKey,tbl_id,false);
+                }
+                hideDialog();
+            },
+            'Very large image',
+            {maxWidth:'50rem'}
+        );
+    }
+    else {
+        hideDialog();
+        setPreferCutout(dataProductsComponentKey,tbl_id,false);
+    }
+
 }

--- a/src/firefly/js/ui/PopupUtil.jsx
+++ b/src/firefly/js/ui/PopupUtil.jsx
@@ -111,20 +111,20 @@ function makeContent(content) {
     );
 }
 
-export function showYesNoPopup(content, clickSelection,  title='Information') {
+export function showYesNoPopup(content, clickSelection,  title='Information', sx) {
     const results= (
         <PopupPanel title={title} >
-            {makeYesNoContent(content, clickSelection)}
+            {makeYesNoContent(content, clickSelection, sx)}
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(INFO_POPUP, results);
     dispatchShowDialog(INFO_POPUP);
 }
 
-function makeYesNoContent(content, clickSelection) {
+function makeYesNoContent(content, clickSelection, sx) {
     return (
         <Stack direction='column' p={1} spacing={2}>
-            <Sheet style={{minWidth:190, maxWidth: 400, p:1}}>
+            <Sheet style={{minWidth:190, maxWidth: 400, p:1, ...sx}}>
                 {content}
             </Sheet>
             <Stack direction='row' spacing={1}>

--- a/src/firefly/js/ui/tap/ObsCore.jsx
+++ b/src/firefly/js/ui/tap/ObsCore.jsx
@@ -5,7 +5,7 @@ import {CheckboxGroupInputField} from 'firefly/ui/CheckboxGroupInputField';
 import {ListBoxInputField} from 'firefly/ui/ListBoxInputField';
 import {
     makeFieldErrorList, getPanelPrefix, LableSaptail, makePanelStatusUpdater,
-    Width_Column, DebugObsCore, makeCollapsibleCheckHeader, getTapObsCoreOptions, SpatialWidth
+    Width_Column, DebugObsCore, makeCollapsibleCheckHeader, SpatialWidth
 } from 'firefly/ui/tap/TableSearchHelpers';
 import {tapHelpId} from 'firefly/ui/tap/TapUtil';
 import {ValidationField} from 'firefly/ui/ValidationField';
@@ -17,6 +17,7 @@ import {useFieldGroupRerender, useFieldGroupValue, useFieldGroupWatch} from '../
 import {ConstraintContext} from './Constraints.js';
 import {AutoCompleteInput} from 'firefly/ui/AutoCompleteInput';
 import {omit} from 'lodash';
+import {getTapObsCoreOptions} from './ObsCoreOptions';
 
 const panelTitle = 'Observation Type and Source';
 const panelValue = 'ObsCore';

--- a/src/firefly/js/ui/tap/ObsCoreOptions.js
+++ b/src/firefly/js/ui/tap/ObsCoreOptions.js
@@ -1,0 +1,111 @@
+import {isObject, isString} from 'lodash';
+import {getAppOptions} from '../../core/AppDataCntlr';
+import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr';
+import {MetaConst} from '../../data/MetaConst';
+import {getMetaEntry} from '../../tables/TableUtil';
+import {parseWorldPt} from '../../visualize/Point';
+import {getSearchTarget, makeWorldPtUsingCenterColumns} from '../../voAnalyzer/TableAnalysis';
+import {findWorldPtInServiceDef} from '../../voAnalyzer/VoDataLinkServDef';
+
+const PREFER_CUTOUT_KEY = 'preferCutout';
+const SD_CUTOUT_SIZE_KEY = 'sdCutoutSize';
+const SD_CUTOUT_WP_OVERRIDE = 'sdCutoutWpOverride';
+const SD_DEFAULT_SPACIAL_CUTOUT_SIZE = .01;
+const SD_DEFAULT_PIXEL_CUTOUT_SIZE = 200;
+
+
+
+export const getTapObsCoreOptions = (obsCoreSource) =>
+    getAppOptions().tapObsCore?.[obsCoreSource] ?? getAppOptions().tapObsCore ?? {};
+
+/**
+ * @param key
+ * @param [obsCoreSource]
+ * @param [defVal]
+ * @return {*}
+ */
+export function getObsCoreOption(key, obsCoreSource = undefined, defVal) {
+    const slOps = obsCoreSource ? getAppOptions().tapObsCore?.[obsCoreSource] ?? {} : {};
+    const ops = getAppOptions().tapObsCore ?? {};
+    return slOps[key] ?? ops[key] ?? defVal;
+}
+
+export function getTapObsCoreOptionsGuess(serviceLabelGuess) {
+    const {tapObsCore = {}} = getAppOptions();
+    if (!serviceLabelGuess) return tapObsCore;
+    const guessKey = Object.entries(tapObsCore)
+        .find(([key, value]) => isObject(value) && serviceLabelGuess.includes(key))?.[0];
+    return getTapObsCoreOptions(guessKey);
+}
+
+/**
+ *
+ * @param {String} dataProductsComponentKey
+ * @param {String} tbl_id
+ * @return {boolean}
+ */
+export function getPreferCutout(dataProductsComponentKey, tbl_id) {
+    const obsCoreSource = getMetaEntry(tbl_id, MetaConst.OBSCORE_SOURCE_ID);
+    const DEF_PREFER_CUTOUT = getObsCoreOption(PREFER_CUTOUT_KEY, obsCoreSource, true);
+    const result = getComponentState(dataProductsComponentKey)[PREFER_CUTOUT_KEY];
+    if (!result) return DEF_PREFER_CUTOUT;
+    if (!isObject(result)) return DEF_PREFER_CUTOUT;
+    return result[tbl_id] ?? result.LAST_PREF ?? DEF_PREFER_CUTOUT;
+}
+
+/**
+ *
+ * @param {String} dataProductsComponentKey
+ * @param {String} tbl_id
+ * @param {boolean} preferCutout
+ */
+export function setPreferCutout(dataProductsComponentKey, tbl_id, preferCutout) {
+    const result = getComponentState(dataProductsComponentKey)[PREFER_CUTOUT_KEY] ?? {};
+    const newState = {...result, [tbl_id]: preferCutout, LAST_PREF: preferCutout};
+    dispatchComponentStateChange(dataProductsComponentKey, {[PREFER_CUTOUT_KEY]: newState});
+}
+
+export function getCutoutSize(dataProductsComponentKey, tbl_id) {
+    const obsCoreSource = getMetaEntry(tbl_id, MetaConst.OBSCORE_SOURCE_ID);
+    return getComponentState(dataProductsComponentKey, {})[SD_CUTOUT_SIZE_KEY] ??
+        getObsCoreOption('cutoutDefSizeDeg', obsCoreSource, SD_DEFAULT_SPACIAL_CUTOUT_SIZE);
+}
+
+export const setCutoutSize= (dataProductsComponentKey, cutoutSize) =>
+    dispatchComponentStateChange(dataProductsComponentKey, { [SD_CUTOUT_SIZE_KEY]: cutoutSize});
+
+/**
+ *  equivalent to setPreferCutout, setCutoutSize, setCutoutTargetOverride
+ * @param dataProductsComponentKey
+ * @param tbl_id
+ * @param cutoutSize
+ * @param overrideTarget
+ * @param preferCutout
+ */
+export function setAllCutoutParams(dataProductsComponentKey, tbl_id, cutoutSize, overrideTarget = undefined, preferCutout) {
+    const result = getComponentState(dataProductsComponentKey)[PREFER_CUTOUT_KEY] ?? {};
+    const newPreferState = {...result, [tbl_id]: preferCutout, LAST_PREF: preferCutout};
+    let wp= overrideTarget;
+    if (overrideTarget && isString(overrideTarget)) {
+        wp= parseWorldPt(overrideTarget);
+    }
+    dispatchComponentStateChange(dataProductsComponentKey,
+        {
+            [PREFER_CUTOUT_KEY]: newPreferState,
+            [SD_CUTOUT_SIZE_KEY]: cutoutSize,
+            [SD_CUTOUT_WP_OVERRIDE]: wp,
+        });
+}
+
+export const setCutoutTargetOverride= (dataProductsComponentKey, wp)=>
+    dispatchComponentStateChange(dataProductsComponentKey, {[SD_CUTOUT_WP_OVERRIDE]: wp});
+
+export const getCutoutTargetOverride= (dataProductsComponentKey) =>
+    getComponentState(dataProductsComponentKey, {})[SD_CUTOUT_WP_OVERRIDE];
+
+export function findCutoutTarget(dataProductsComponentKey, serDef, table, row) {
+    let positionWP = getSearchTarget(table?.request, table) ?? makeWorldPtUsingCenterColumns(table, row);
+    if (!positionWP) positionWP= serDef?.positionWP;
+    if (getCutoutTargetOverride(dataProductsComponentKey)) return getCutoutTargetOverride(dataProductsComponentKey);
+    return positionWP ?? findWorldPtInServiceDef(serDef, row);
+}

--- a/src/firefly/js/ui/tap/SIASearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/SIASearchRootPanel.jsx
@@ -424,8 +424,7 @@ function onSIAv2SearchSubmit(request, serviceUrl, siaMeta, siaState, showErrors=
     const cStr= constraints.join('&');
     const hasMaxrec = !isNaN(parseInt(request.maxrec));
     const maxrec = parseInt(request.maxrec);
-    var baseRequestUrl= `${serviceUrl}?${cStr}`;
-
+    const baseRequestUrl= `${serviceUrl}?${cStr}`;
 
     const doSubmit = () => {
 
@@ -435,7 +434,11 @@ function onSIAv2SearchSubmit(request, serviceUrl, siaMeta, siaState, showErrors=
         if (hips) additionalSiaMeta[MetaConst.COVERAGE_HIPS]= hips;
         const title= makeNumberedTitle(userTitle || 'SIA Search');
         const treq= makeFileRequest(title,new URL(url).toString());
-        treq.META_INFO= {...treq.META_INFO, ...additionalSiaMeta};
+        treq.META_INFO= {
+            ...treq.META_INFO,
+            ...additionalSiaMeta,
+            [MetaConst.OBSCORE_SOURCE_ID] : getSiaServiceLabel(serviceUrl),
+        };
         console.log('sia search: ' + url, new URL(url).toString());
         dispatchTableSearch(treq, {backgroundable: true, showFilters: true, showInfoButton: true});
     };

--- a/src/firefly/js/ui/tap/SiaUtil.js
+++ b/src/firefly/js/ui/tap/SiaUtil.js
@@ -34,7 +34,6 @@ function getMetaFromTable(table) {
     return inputParams;
 }
 
-
 export async function loadSiaV2Meta(serviceUrl) {
     if (serviceMetaCache[serviceUrl]) return serviceMetaCache[serviceUrl];
     serviceMetaCache[serviceUrl]= await doLoadSiaV2Meta(serviceUrl);

--- a/src/firefly/js/ui/tap/TableSearchHelpers.jsx
+++ b/src/firefly/js/ui/tap/TableSearchHelpers.jsx
@@ -1,11 +1,11 @@
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import KeyboardDoubleArrowDown from '@mui/icons-material/KeyboardDoubleArrowDown';
 
 import KeyboardDoubleArrowUp from '@mui/icons-material/KeyboardDoubleArrowUp';
-import ReceiptLongOutlinedIcon from '@mui/icons-material/ReceiptLongOutlined';
-import {Box, Button, IconButton, Stack, Typography} from '@mui/joy';
+import {Box, IconButton, Stack, Typography} from '@mui/joy';
 import HelpIcon from 'firefly/ui/HelpIcon';
 import {SwitchInputFieldView} from 'firefly/ui/SwitchInputField';
-import {isEqual, isObject} from 'lodash';
+import {isEqual} from 'lodash';
 import Prism from 'prismjs';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef} from 'react';
@@ -16,7 +16,6 @@ import {RadioGroupInputFieldView} from '../RadioGroupInputFieldView.jsx';
 import {useFieldGroupValue} from '../SimpleComponent.jsx';
 import {showResultTitleDialog} from './ResultTitleDialog';
 import {ADQL_QUERY_KEY, makeTapSearchTitle, USER_ENTERED_TITLE} from './TapUtil';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 
 export const HeaderFont = {fontSize: 12, fontWeight: 'bold', alignItems: 'center'};
 
@@ -31,30 +30,6 @@ export const Width_Time_Wrapper = Width_Column + 30;
 export const SpatialPanelWidth = Math.max(Width_Time_Wrapper * 2, SpatialWidth) + LabelWidth + 10;
 
 const DEF_ERR_MSG= 'Constraints Error';
-
-
-export const getTapObsCoreOptions= (serviceLabel) =>
-    getAppOptions().tapObsCore?.[serviceLabel] ?? getAppOptions().tapObsCore ?? {};
-
-/**
- * @param key
- * @param [serviceLabel]
- * @return {*}
- */
-export function getObsCoreOption(key,serviceLabel=undefined) {
-    const slOps= serviceLabel ? getAppOptions().tapObsCore?.[serviceLabel] ?? {} : {};
-    const ops= getAppOptions().tapObsCore ?? {};
-    return slOps[key] ?? ops[key];
-}
-
-
-export function getTapObsCoreOptionsGuess(serviceLabelGuess) {
-    const {tapObsCore={}}=  getAppOptions();
-    if (!serviceLabelGuess) return tapObsCore;
-    const guessKey= Object.entries(tapObsCore)
-        .find( ([key,value]) => isObject(value) && serviceLabelGuess.includes(key))?.[0];
-    return getTapObsCoreOptions(guessKey);
-}
 
 
 /**
@@ -101,6 +76,7 @@ export function makePanelStatusUpdater(panelActive,panelTitle,defErrorMessage) {
      * @param {InputConstraints} constraints
      * @param {ConstraintResult} lastConstraintResult
      * @param {Function} setConstraintResult - a function to set the constraint result setConstraintResult(ConstraintResult)
+     * @param {boolean} useSIAv2
      * @String string - panel message
      */
     return (constraints, lastConstraintResult, setConstraintResult, useSIAv2= false) => {

--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -77,7 +77,12 @@ export function onTapSearchSubmit(request, serviceUrl, tapBrowserState, addition
         additionalTapMeta.serviceLabel= serviceLabel;
         if (hips) additionalTapMeta[MetaConst.COVERAGE_HIPS]= hips;
 
-        treq.META_INFO= {...treq.META_INFO, ...additionalTapMeta, ...metaInfo };
+        treq.META_INFO= {
+            ...treq.META_INFO,
+            ...additionalTapMeta,
+            ...metaInfo,
+            [MetaConst.OBSCORE_SOURCE_ID] : serviceLabel,
+        };
         dispatchTableSearch(treq, {backgroundable: true, showFilters: true, showInfoButton: true});
     };
 

--- a/src/firefly/js/ui/tap/TapViewType.jsx
+++ b/src/firefly/js/ui/tap/TapViewType.jsx
@@ -11,11 +11,12 @@ import {ListBoxInputFieldView} from '../ListBoxInputField.jsx';
 import {SplitContent} from '../panel/DockLayoutPanel';
 import {useFieldGroupMetaState} from '../SimpleComponent.jsx';
 import {AdvancedADQL} from './AdvancedADQL.jsx';
+import {getTapObsCoreOptions} from './ObsCoreOptions';
 import {showTableSelectPopup} from './TableChooser.jsx';
 
 import {TableColumnsConstraints, TableColumnsConstraintsToolbar} from './TableColumnsConstraints.jsx';
 import {
-    ADQL, SINGLE, SpatialPanelWidth, NavButtons, TableTypeButton, getTapObsCoreOptions
+    ADQL, SINGLE, SpatialPanelWidth, NavButtons, TableTypeButton
 } from './TableSearchHelpers.jsx';
 import {TableSearchMethods} from './TableSearchMethods.jsx';
 import {

--- a/src/firefly/js/ui/tap/WavelengthPanel.jsx
+++ b/src/firefly/js/ui/tap/WavelengthPanel.jsx
@@ -9,8 +9,9 @@ import {RadioGroupInputField} from '../RadioGroupInputField.jsx';
 import {useFieldGroupRerender, useFieldGroupWatch} from '../SimpleComponent.jsx';
 import {ValidationField} from '../ValidationField.jsx';
 import {makeAdqlQueryRangeFragment, ConstraintContext, siaQueryRange} from './Constraints.js';
+import {getTapObsCoreOptions} from './ObsCoreOptions';
 import {
-    DebugObsCore, getPanelPrefix, getTapObsCoreOptions, LeftInSearch, makeCollapsibleCheckHeader,
+    DebugObsCore, getPanelPrefix, LeftInSearch, makeCollapsibleCheckHeader,
     makeFieldErrorList,
     makePanelStatusUpdater, SmallFloatNumericWidth, SpatialWidth,
 } from './TableSearchHelpers.jsx';

--- a/src/firefly/js/visualize/HiPSMocUtil.js
+++ b/src/firefly/js/visualize/HiPSMocUtil.js
@@ -185,10 +185,11 @@ export function getMocOrderIndex(Nuniq) {
  * @param {string} params.uniqColName column name for uniq number
  * @param {boolean} params.tablePreloaded - true if the MOC table has already been loaded
  * @param {string} [params.color] - color string
+ * @param {string} [params.maxFetchDepth] - maximum healpix order to fetch
  * @param {string} [params.mocGroupDefColorId ] - group color id
  * @returns {T|SelectInfo|*|{}}
  */
-export function addNewMocLayer({tbl_id, title, fitsPath, mocUrl, uniqColName = 'NUNIQ',
+export function addNewMocLayer({tbl_id, title, fitsPath, mocUrl, uniqColName = 'NUNIQ', maxFetchDepth,
                                    tablePreloaded=false, color, mocGroupDefColorId }) {
     const dls = getDrawLayersByType(getDlAry(), HiPSMOC.TYPE_ID);
     let   dl = dls.find((oneLayer) => oneLayer.drawLayerId === tbl_id);
@@ -198,7 +199,7 @@ export function addNewMocLayer({tbl_id, title, fitsPath, mocUrl, uniqColName = '
         if (title) title= 'MOC - ' + title;
         const mocFitsInfo = {fitsPath, mocUrl, uniqColName, tbl_id, tablePreloaded};
         dl = dispatchCreateDrawLayer(HiPSMOC.TYPE_ID,
-            {mocFitsInfo,title,layersPanelLayoutId:'mocUIGroup', color, mocGroupDefColorId });
+            {mocFitsInfo,title,layersPanelLayoutId:'mocUIGroup', color, mocGroupDefColorId,maxFetchDepth});
     }
     return dl;
 }

--- a/src/firefly/js/visualize/ImViewFilterDisplay.js
+++ b/src/firefly/js/visualize/ImViewFilterDisplay.js
@@ -19,7 +19,16 @@ export const IMAGE_VIEW_TABLE_ID = 'active-image-view-list-table';
 export const EXPANDED_OPTIONS_DIALOG_ID= 'ExpandedOptionsPopup';
 export const HIDDEN='_HIDDEN';
 
-const [NAME_IDX, WAVE_LENGTH_UM, PID_IDX, STATUS, PROJ_TYPE_DESC, WAVE_TYPE, DATA_HELP_URL, ROW_IDX] = [0, 1, 2, 3, 4, 5, 6, 7];
+const [NAME_IDX, WAVE_LENGTH_UM, PID_IDX, STATUS, PROJ_TYPE_DESC, WAVE_TYPE, DATA_HELP_URL,
+    OBS_TITLE_IDX, S_RA_IDX, S_DEC_IDX,
+    T_MIN_IDX, T_MAX_IDX, EM_MIN_IDX, EM_MAX_IDX, CALIB_LEVEL_IDX, DATAPRODUCT_TYPE_IDX, DATAPRODUCT_SUBTYPE_IDX,
+    FACILITY_NAME_IDX, INSTRUMENT_NAME_IDX,
+    OBS_COLLECTION_IDX, S_REGION_IDX, ROW_IDX] = [...Array(22).keys()];
+
+
+
+
+const wlUnits= getFormattedWaveLengthUnits('um');
 
 const columnsTemplate = [];
 columnsTemplate[NAME_IDX] = {name: 'Name', type: 'char', width: 22};
@@ -27,12 +36,7 @@ columnsTemplate[PID_IDX] = {name: 'plotId', type: 'char', width: 10, visibility:
 columnsTemplate[STATUS] = {name: 'Status', type: 'char', width: 10};
 columnsTemplate[PROJ_TYPE_DESC] = {name: 'Type', type: 'char', width: 8};
 columnsTemplate[WAVE_TYPE] = {name: 'Band', type: 'char', width: 9};
-columnsTemplate[WAVE_LENGTH_UM] = {
-    name: 'Wavelength',
-    type: 'double',
-    width: 8,
-    units: getFormattedWaveLengthUnits('um')
-};
+columnsTemplate[WAVE_LENGTH_UM] = { name: 'Wavelength', type: 'double', width: 8, units: wlUnits };
 
 columnsTemplate[DATA_HELP_URL] = {
     name: 'Help',
@@ -40,6 +44,34 @@ columnsTemplate[DATA_HELP_URL] = {
     width: 4,
     cellRenderer: 'ATag::href=${Help},target="image-doc"'+ `,label=<img src='images/info-16x16.png'/>` // eslint-disable-line
 };
+
+
+columnsTemplate[OBS_TITLE_IDX] = {name: 'obs_title', type: 'show', width: 20};
+columnsTemplate[S_RA_IDX] = {name: 's_ra', type: 'double', width: 9};
+columnsTemplate[S_DEC_IDX] = {name: 's_dec', type: 'double', width: 9};
+columnsTemplate[EM_MIN_IDX] = {name: 'em_min', type: 'double', width: 8, units: wlUnits};
+columnsTemplate[EM_MAX_IDX] = {name: 'em_max', type: 'double', width: 8, units: wlUnits};
+columnsTemplate[T_MAX_IDX] = {name: 't_max', type: 'double', width: 9};
+columnsTemplate[T_MIN_IDX] = {name: 't_min', type: 'double', width: 9};
+columnsTemplate[T_MAX_IDX] = {name: 't_max', type: 'double', width: 9};
+columnsTemplate[CALIB_LEVEL_IDX] = {name: 'calib_level', type: 'show', width: 6};
+columnsTemplate[DATAPRODUCT_TYPE_IDX] = {name: 'dataproduct_type', type: 'show', width: 20};
+columnsTemplate[DATAPRODUCT_SUBTYPE_IDX] = {name: 'dataproduct_subtype', type: 'show', width: 20};
+columnsTemplate[OBS_COLLECTION_IDX] = {name: 'obs_collection', type: 'show', width: 20};
+columnsTemplate[FACILITY_NAME_IDX] = {name: 'facility_name', type: 'show', width: 20};
+columnsTemplate[INSTRUMENT_NAME_IDX] = {name: 'instrument_name', type: 'show', width: 20};
+columnsTemplate[S_REGION_IDX] = {name: 's_region', type: 'show', width: 10};
+
+
+
+
+
+
+
+
+
+
+
 
 
 const getAttribute = (attributes, attribute, def='') => attributes?.[attribute] ?? def;
@@ -90,6 +122,25 @@ export function makeImViewDisplayModel(tbl_id, plotViewAry, allIds, oldModel) {
         row[WAVE_TYPE] = getAttribute(attributes, PlotAttribute.WAVE_TYPE);
         row[WAVE_LENGTH_UM] = parseFloat(getAttribute(attributes, PlotAttribute.WAVE_LENGTH_UM, 0.0));
         row[DATA_HELP_URL] = getAttribute(attributes, PlotAttribute.DATA_HELP_URL);
+
+        const {sourceObsCoreData}= plot.attributes;
+        if (sourceObsCoreData) {
+            row[S_RA_IDX]= sourceObsCoreData.s_ra;
+            row[S_DEC_IDX]= sourceObsCoreData.s_dec;
+            row[T_MAX_IDX]= sourceObsCoreData.t_max;
+            row[T_MIN_IDX]= sourceObsCoreData.t_min;
+            row[T_MAX_IDX]= sourceObsCoreData.t_max;
+            row[EM_MIN_IDX]= sourceObsCoreData.em_min;
+            row[EM_MAX_IDX]= sourceObsCoreData.em_max;
+            row[CALIB_LEVEL_IDX]= sourceObsCoreData.calib_level;
+            row[DATAPRODUCT_TYPE_IDX]= sourceObsCoreData.dataproduct_type;
+            row[DATAPRODUCT_SUBTYPE_IDX]= sourceObsCoreData.dataproduct_subtype;
+            row[OBS_COLLECTION_IDX]= sourceObsCoreData.obs_collection;
+            row[FACILITY_NAME_IDX]= sourceObsCoreData.facility_name;
+            row[OBS_TITLE_IDX]= sourceObsCoreData.obs_title;
+            row[INSTRUMENT_NAME_IDX]= sourceObsCoreData.instrument_name;
+            row[S_REGION_IDX]=  sourceObsCoreData.s_region;
+        }
         return row;
     });
 

--- a/src/firefly/js/visualize/SearchRefinementTool.jsx
+++ b/src/firefly/js/visualize/SearchRefinementTool.jsx
@@ -210,7 +210,7 @@ function SearchDropDown({searchActions, cenWpt, size, polyStr, whichOverlay}) {
                 .filter( (sa) =>
                    searchMatches(sa, whichOverlay===CONE_CHOICE_KEY, whichOverlay===POLY_CHOICE_KEY, whichOverlay===CONE_CHOICE_KEY) )
                 .map( (sa) => {
-                    const text= getSearchTypeDesc(sa,cenWpt,Number(size),polyStrLen);
+                    const text= getSearchTypeDesc({sa,wp:cenWpt,size:Number(size),areaPtsLength:polyStrLen });
                     return (
                         <ToolbarButton text={text} tip={`${sa.tip} for\n${text}`}
                                        enabled={true} horizontal={false} key={sa.cmd+sa.tip}

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -9,9 +9,11 @@ import {
     getRotationAngle, isCsysDirMatching, isEastLeftOfNorth, isPlotNorth
 } from '../WebPlotAnalysis';
 import {RotateType} from '../PlotState';
-import {replacePlotView, replacePrimaryPlot, changePrimePlot, updatePlotViewScrollXY,
-        findScrollPtToCenterImagePt, findScrollPtToPlaceOnDevPt,
-        updateScrollToWcsMatch, updatePlotGroupScrollXY} from './PlotView.js';
+import {
+    replacePlotView, replacePrimaryPlot, changePrimePlot, updatePlotViewScrollXY,
+    findScrollPtToCenterImagePt, findScrollPtToPlaceOnDevPt,
+    updateScrollToWcsMatch, updatePlotGroupScrollXY, getNextStaticPlotCount
+} from './PlotView.js';
 import {
     WebPlot, clonePlotWithZoom, isHiPS, isImage,
     replaceHiPSProjectionUsingProperties, getHiPsTitleFromProperties, DEFAULT_BLANK_HIPS_TITLE,
@@ -369,7 +371,7 @@ function changeHiPS(state,action) {
     if (!isUndefined(blankColor)) plot.blankColor= blankColor;
 
     if (hipsProperties || hipsUrlRoot || !isUndefined(cubeIdx)) {
-        plot.plotImageId= `${pv.plotId}--${pv.plotViewCtx.plotCounter}`;
+        plot.plotImageId= `${pv.plotId}--${pv.plotViewCtx.plotCounter}--${getNextStaticPlotCount()}`;
         const hipsImageConversion=(hipsUrlRoot && plotViewCtx.hipsImageConversion) ?
             {...plotViewCtx.hipsImageConversion,
                 hipsRequestRoot: plotViewCtx.hipsImageConversion.hipsRequestRoot?.makeCopy({[WPConst.HIPS_ROOT_URL]:hipsUrlRoot})} :

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -227,6 +227,12 @@ export function changePrimePlot(pv, nextIdx) {
     return updateTransform(pv);
 }
 
+let staticPlotCount=0;
+
+export function getNextStaticPlotCount() {
+    return ++staticPlotCount;
+}
+
 /**
  * Replace the plotAry and overlayPlotViews into the PlotView, return a new PlotView
  * @param {PlotView} pv
@@ -259,7 +265,7 @@ export function replacePlots(pv, plotAry, overlayPlotViews, expandedMode, newPlo
 
     pv.plots.forEach( (plot) => {
         plot.attributes= {...plot.attributes, ...getNewAttributes(plot)};
-        plot.plotImageId= `${pv.plotId}--${pv.plotViewCtx.plotCounter}`;
+        plot.plotImageId= `${pv.plotId}--${pv.plotViewCtx.plotCounter}--${getNextStaticPlotCount()}`;
         pv.plotViewCtx.plotCounter++;
     });
 

--- a/src/firefly/js/visualize/task/PlotAdminTask.js
+++ b/src/firefly/js/visualize/task/PlotAdminTask.js
@@ -9,8 +9,10 @@ import ImagePlotCntlr, {dispatchChangeActivePlotView, dispatchPlotHiPS,
 import {getExpandedViewerItemIds, findViewerWithItemId,
     getMultiViewRoot, IMAGE} from '../MultiViewCntlr.js';
 import PointSelection from '../../drawingLayers/PointSelection.js';
-import {dispatchAttachLayerToPlot, dispatchCreateDrawLayer,
-    dispatchDetachLayerFromPlot, DRAWING_LAYER_KEY} from '../DrawLayerCntlr.js';
+import {
+    dispatchAttachLayerToPlot, dispatchCreateDrawLayer, dispatchDestroyDrawLayer,
+    dispatchDetachLayerFromPlot, DRAWING_LAYER_KEY
+} from '../DrawLayerCntlr.js';
 import { getPlotViewById, applyToOnePvOrAll, isDrawLayerAttached,
     primePlot, getDrawLayerByType, removeRawDataByPlotView } from '../PlotViewUtil.js';
 import {isImage} from '../WebPlot.js';
@@ -84,6 +86,7 @@ export function changePointSelectionActionCreator(rawAction) {
         }
         else if (!enabled) {
             detachAll(plotViewAry,dl);
+            if (dl) dispatchDestroyDrawLayer(dl.drawLayerId);
         }
     };
 }

--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -284,11 +284,12 @@ async function makeHiPSPlot(rawAction, dispatcher) {
 
 
 export function createHiPSMocLayerFromPreloadedTable({tbl_id,title, fitsPath, mocUrl, plotId, visible=false,
-                                                         color, mocGroupDefColorId, attachAllPlot=false} ) {
+                                                         maxFetchDepth, color, mocGroupDefColorId, attachAllPlot=false} ) {
     const table= getTblById(tbl_id);
     if (!table) return;
     const uniqColName= table.tableData.columns[0].name;
-    const dl = addNewMocLayer({ tbl_id, title, fitsPath, mocUrl, uniqColName, color, tablePreloaded:true,  mocGroupDefColorId });
+    const dl = addNewMocLayer({ tbl_id, title, fitsPath, mocUrl, uniqColName,
+        color, tablePreloaded:true,  maxFetchDepth, mocGroupDefColorId });
     if (dl && plotId) {
         dispatchAttachLayerToPlot(dl.drawLayerId, plotId, attachAllPlot, visible, true);
     }

--- a/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
+++ b/src/firefly/js/visualize/ui/ImageMetaDataToolbar.jsx
@@ -49,10 +49,14 @@ export class ImageMetaDataToolbar extends Component {
 
     render() {
         const {activeTable}= this.state;
-        const {visRoot, viewerId, viewerPlotIds, layoutType, dlAry, makeDropDown, serDef, factoryKey, enableCutout, pixelBasedCutout= false}= this.props;
+        const {visRoot, viewerId, viewerPlotIds, layoutType, dlAry, makeDropDown, serDef, factoryKey, enableCutout,
+            cutoutToFullWarning,
+            enableCutoutFullSwitching= false, pixelBasedCutout= false}= this.props;
         return (
             <ImageMetaDataToolbarView activePlotId={visRoot.activePlotId} viewerId={viewerId}  serDef={serDef}
                                       enableCutout={enableCutout} pixelBasedCutout={pixelBasedCutout}
+                                      cutoutToFullWarning={cutoutToFullWarning}
+                                      enableCutoutFullSwitching={enableCutoutFullSwitching}
                                       viewerPlotIds={viewerPlotIds} layoutType={layoutType} dlAry={dlAry}
                                       activeTable={activeTable} makeDataProductsConverter={makeDataProductsConverter}
                                       makeDropDown={makeDropDown} factoryKey={factoryKey} />
@@ -70,6 +74,8 @@ ImageMetaDataToolbar.propTypes= {
     factoryKey: PropTypes.string,
     makeDropDown: PropTypes.func,
     enableCutout: PropTypes.bool,
+    enableCutoutFullSwitching: PropTypes.bool,
     pixelBasedCutout: PropTypes.bool,
+    cutoutToFullWarning: PropTypes.string,
     serDef: PropTypes.object
 };

--- a/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
+++ b/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
@@ -440,7 +440,7 @@ function loadMocWithAbort(mocList, plotId,setMocError) {
 
         try {
             for(let i=0; (i<mocAddList.length); i++) {
-                const {mocUrl,title,mocColor}= mocAddList[i];
+                const {mocUrl,title,mocColor,maxFetchDepth}= mocAddList[i];
 
                 const tbl_id= 'MOC---'+mocUrl;
                 let add= true;
@@ -469,6 +469,7 @@ function loadMocWithAbort(mocList, plotId,setMocError) {
                     createHiPSMocLayerFromPreloadedTable({
                         plotId,
                         tbl_id,
+                        maxFetchDepth,
                         visible: true,
                         fitsPath: mocUrl,
                         title,

--- a/src/firefly/js/visualize/ui/multiProduct/DPDropdown.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/DPDropdown.jsx
@@ -40,8 +40,7 @@ function DropDown({dataProductsState, menuKey, originalTitle, hasMenu, menu, dpI
     return (
         <Stack {...{direction:'row', alignItems:'center', height: 30}}
             divider={<ToolbarHorizontalSeparator/>}>
-            {!hasMenu ?
-                <div style={{width: 50, height: 1}}/> :
+            {hasMenu &&
                 <DropDownToolbarButton
                     text='More' tip='Other data to display' useDropDownIndicator={true}
                     sx={{pr: 2}}

--- a/src/firefly/js/visualize/ui/multiProduct/MetaDataMultiProductViewer.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MetaDataMultiProductViewer.jsx
@@ -4,11 +4,8 @@
 
 import {bool, string, object} from 'prop-types';
 import React, {memo} from 'react';
-import {dispatchComponentStateChange, getComponentState} from '../../../core/ComponentCntlr';
 import {setFactoryTemplateOptions, getDefaultFactoryOptions} from '../../../metaConvert/DataProductsFactory.js';
 import {startDataProductsWatcher} from '../../../metaConvert/DataProductsWatcher.js';
-import {SD_CUTOUT_KEY, SD_DEFAULT_SPACIAL_CUTOUT_SIZE} from '../../../metaConvert/vo/ServDescProducts';
-import {getObsCoreOption} from '../../../ui/tap/TableSearchHelpers';
 import {MultiProductViewer} from './MultiProductViewer.jsx';
 
 const startedWatchers=[];
@@ -18,13 +15,6 @@ function startWatcher(dpId, options) {
     setFactoryTemplateOptions(dpId, options);
     startDataProductsWatcher({ dataTypeViewerId:dpId, factoryKey:dpId});
     startedWatchers.push(dpId);
-    const defOps= getDefaultFactoryOptions();
-    const key= options.dataProductsComponentKey ?? defOps.dataProductsComponentKey;
-    if (!getComponentState(key,{})[SD_CUTOUT_KEY]) {
-        dispatchComponentStateChange(key,{
-            [SD_CUTOUT_KEY]: (getObsCoreOption('cutoutDefSizeDeg') ?? SD_DEFAULT_SPACIAL_CUTOUT_SIZE)
-        } );
-    }
 }
 
 

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
@@ -9,9 +9,7 @@ import {RadioGroupInputFieldView} from '../../../ui/RadioGroupInputFieldView.jsx
 import {useStoreConnector} from '../../../ui/SimpleComponent';
 import {dispatchChangePrimePlot, visRoot} from '../../ImagePlotCntlr';
 import {NewPlotMode} from '../../MultiViewCntlr.js';
-import {
-    convertHDUIdxToImageIdx, getActivePlotView, getHDUIndex, getImageCubeIdx, getPlotViewById, hasImageCubes, primePlot
-} from '../../PlotViewUtil';
+import { convertHDUIdxToImageIdx, getActivePlotView, getHDUIndex, hasImageCubes} from '../../PlotViewUtil';
 import {ImageMetaDataToolbar} from '../ImageMetaDataToolbar.jsx';
 import {MultiImageViewer} from '../MultiImageViewer.jsx';
 
@@ -26,6 +24,7 @@ export function MultiProductChoice({ dataProductsState, dpId,
                                        tableGroupViewerId, whatToShow, onChange, mayToggle = false, factoryKey
                                    }) {
     const {serDef, enableCutout, pixelBasedCutout=false}= dataProductsState;
+    const {cutoutToFullWarning, dlAnalysis:{cutoutFullPair=false}={}}= dataProductsState.dlData ?? {};
     const primeIdx= useStoreConnector(() => getActivePlotView(visRoot())?.primeIdx ?? -1);
     const {current:showingStatus}= useRef({oldWhatToShow:undefined});
     const chartTableOptions = [{label: 'Table', value: SHOW_TABLE}, {label: 'Chart', value: SHOW_CHART}];
@@ -95,7 +94,9 @@ export function MultiProductChoice({ dataProductsState, dpId,
                     {mayToggle && toolbar}
                     <MultiImageViewer {...{
                         viewerId:imageViewerId, insideFlex:true, serDef, enableCutout,pixelBasedCutout,
+                        enableCutoutFullSwitching:cutoutFullPair,
                         canReceiveNewPlots: NewPlotMode.none.key, tableId:metaDataTableId, controlViewerMounting:false,
+                        cutoutToFullWarning,
                         makeDropDown: !mayToggle ? makeDropDown : undefined,
                         Toolbar:ImageMetaDataToolbar, factoryKey}} />
                 </Stack>

--- a/src/firefly/js/voAnalyzer/TableAnalysis.js
+++ b/src/firefly/js/voAnalyzer/TableAnalysis.js
@@ -322,6 +322,7 @@ export function getProdTypeGuess(tableOrId, rowIdx) {
  * @returns {boolean}
  */
 export function isObsCoreLike(tableModel) {
+    if (!tableModel) return false;
     const cols = getColumns(tableModel);
     if (cols.findIndex((c) => get(c, 'utype', '').startsWith(obsPrefix)) >= 0) {
         return true;

--- a/src/firefly/js/voAnalyzer/vo-typedefs.jsdoc
+++ b/src/firefly/js/voAnalyzer/vo-typedefs.jsdoc
@@ -39,6 +39,7 @@
 /**
  * @typedef DlAnalysisData
  * @prop {boolean} isThis
+ * @prop {boolean} isCounterpart
  * @prop {boolean} isImage
  * @prop {boolean} isGrid
  * @prop {boolean} isAux
@@ -53,6 +54,7 @@
  * @prop {boolean} isGzip
  * @prop {boolean} isSimpleImage
  * @prop {boolean} isDownloadOnly
+ * @prop {boolean} cutoutFullPair
  */
 
 
@@ -69,9 +71,25 @@
  * @prop {String} serviceDefRef
  * @prop {ServiceDescriptorDef} serDef
  * @prop {DlAnalysisData} dlAnalysis
+ * @prop {Object} relatedDLEntries
+ * @prop {object} relatedRows
+ * @prop {ObsCoreData} sourceObsCoreData
  */
 
 
+/**
+ * @typedef ObsCoreData
+ *
+ * @prop {string} access_format
+ * @prop {string} access_url
+ * @prop {string} dataproduct_subtype
+ * @prop {string} dataproduct_type
+ * @prop {string} obs_collection
+ * @prop {string} obs_title
+ * @prop {string} s_ra
+ * @prop {string} s_dec
+ * @prop {string} s_region
+ */
 
 
 


### PR DESCRIPTION
#### [Firefly-1633](https://jira.ipac.caltech.edu/browse/FIREFLY-1633): Multi Product viewer improvements
  - Managing full and cutout as one item
  - Flipping between full and cutout
  - Adding obscore information to image attributes
  - MOC: add support for MAX norder for MOC request
  - Cutout dialog can change target
  - Try to get title from ID if begins with ivo: (a uri)
  - Add working message for datalink
  - extract full datalink table now in table menu
  - DataProductFactory options can be set to table metadata
  - Datalink table request settable as DataProductFactory option, used to preset table filters

#### IFE PR
https://github.com/IPAC-SW/irsa-ife/pull/374

#### Testing
  - Firefly: https://fireflydev.ipac.caltech.edu/firefly-1633-mpv-features/firefly
    - do a CADC search, the cutout and full image should be integrated together
  - Euclid: https://firefly-1633-mpv-features.irsakudev.ipac.caltech.edu/applications/euclid
    - Any pixel overlap search region: will show only 1 full image
    - other show cutouts
    - grid works better with cutouts