### PR TITLE
Firefly-1641: new FIREFLY_OPTIONS aproach

### DIFF
--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -29,6 +29,23 @@
 #PROPS_DbAdapter__type=hsql
 #PROPS_logger__level=trace
 
+## example setting APP_PROPERTIES with OP syntax, an alternative to using the JSON
+## - path separator is the underscore
+## - any AppProperties entry begins with OP_
+## - this example
+##     - set irsa tap to be irsadev
+##     - irsa tap defaults to using SDSS for hips
+##     - non-IRSA TAP or IRSA Catalogs use ALLWISE band 4 for the coverage HiPS
+##     - when using TAP and IRSA the target panel popup hips will us SDSS and center on 5,5 and be 2 degrees wide
+#PROPS_OP_tap_additional_services_0_label=IRSA
+#PROPS_OP_tap_additional_services_0_value=https://irsadev.ipac.caltech.edu/TAP
+#PROPS_OP_tap_additional_services_0_hipsUrl=ivo://CDS/P/SDSS9/color
+#PROPS_OP_tap_additional_services_0_fovDeg=2D
+#PROPS_OP_tap_additional_services_0_centerWP="\'5;5;EQ_J2000\'"
+#PROPS_OP_coverage_hipsSourceURL=ivo://CDS/P/allWISE/W4
+#PROPS_OP_coverage_hipsSource360URL=ivo://CDS/P/allWISE/W4
+
+
 
 ##---- Empty declarations: values will come from the shell's environment
 ADMIN_PASSWORD

--- a/src/firefly/java/edu/caltech/ipac/firefly/messaging/JsonHelper.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/messaging/JsonHelper.java
@@ -93,6 +93,10 @@ public class JsonHelper {
         return this;
     }
 
+    public JsonHelper setValueFromPath(Object value, String path, String pathDelim) {
+        return setValue(value, path.split(pathDelim));
+    }
+
     private Consumer getContainer(String[] paths) {
 
         Object cCont = root = ensureCont(root, paths[0]);;

--- a/src/firefly/java/edu/caltech/ipac/util/AppProperties.java
+++ b/src/firefly/java/edu/caltech/ipac/util/AppProperties.java
@@ -10,6 +10,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -49,7 +50,7 @@ public class AppProperties {
     /**
      * all the application level set properties are kept here.
      */
-    private final static Properties _mainProperties=new Properties();
+    private final static Properties mainProperties =new Properties();
 
 
 
@@ -221,7 +222,7 @@ public class AppProperties {
           try {
                retval= System.getProperty(key, def);
           } catch (Exception e) { /*do nothing*/ }
-          if (retval==def) retval= _mainProperties.getProperty(key, def);
+          if (retval==def) retval= mainProperties.getProperty(key, def);
       }
       else {
           retval= overridePDB.getProperty(key, def);
@@ -229,6 +230,19 @@ public class AppProperties {
       return retval;
   }
 
+    public static Map<String,String> getWithStartingMatch(String startOfKey) {
+        var retMap= new HashMap<String,String>();
+        for(Map.Entry<Object,Object>  entry : System.getProperties().entrySet()) {
+            var key= entry.getKey().toString();
+            if (key.startsWith(startOfKey)) retMap.put(key,(String)entry.getValue());
+        }
+
+        for(Map.Entry<Object,Object>  entry : mainProperties.entrySet()) {
+            var key= entry.getKey().toString();
+            if (key.startsWith(startOfKey)) retMap.put(key,(String)entry.getValue());
+        }
+        return retMap;
+    }
 
 
 
@@ -241,7 +255,7 @@ public class AppProperties {
                                                 boolean    ignoreFileNotFound,
                                                 Properties loadToPDB)
             throws IOException {
-        if (_mainProperties==null) {
+        if (mainProperties ==null) {
             return;  // if _mainProperties is null then most probably we are using a server (tomcat) that has
             // done some sort of static unload during shutdown, in any normal mode of
             // operation _mainProperties is never null
@@ -249,7 +263,7 @@ public class AppProperties {
         try {
             // need to add notLoaded support
             InputStream fs= new FileInputStream( f );
-            if(loadToPDB==null) loadToPDB=_mainProperties;
+            if(loadToPDB==null) loadToPDB= mainProperties;
             addPropertiesFromStream(fs, loadToPDB);
         } catch (FileNotFoundException e) {
             if (!ignoreFileNotFound) throw e;
@@ -374,12 +388,12 @@ public class AppProperties {
     }
 
     public static void setProperty(String key, String value) {
-           if (_mainProperties==null) {
+           if (mainProperties ==null) {
                return;  // if _mainProperties is null then most probably we are using a server (tomcat) that has
                // done some sort of static unload during shutdown, in any normal mode of
                // operation _mainProperties is never null
            }
-           _mainProperties.setProperty(key, value);
+           mainProperties.setProperty(key, value);
        }
 
     public static boolean loadClassPropertiesFromFileToPdb(File file, Properties loadToPDB) {


### PR DESCRIPTION
#### [Firefly-1641](https://jira.ipac.caltech.edu/browse/FIREFLY-1641): Define an alternative and easier way to setting FIREFLY_OPTIONS without using json

- every value will be a separate property
- set a path with an underscore divider
- example- PROPS_OP_coverage_hipsSourceURL=ivo://CDS/P/allWISE/W4

#### Testing 
  - checkout branch
  - modify firefly-docker.env to set any properties
  - use `docker-compose` to build and run