### PR TITLE
Firefly-1643: improve cutouts

### DIFF
--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -35,9 +35,19 @@ export const MetaConst = {
     FITS_EXTRACTION_TYPE: 'FitsExtractionType',
 
     /**
-     * Search Target - the search target associated with this table
+     * Search Target - the search target associated with this table, used with extracting datalink
      */
     SEARCH_TARGET: 'SearchTarget',
+
+    /**
+     * S_REGION the would defined the whole table, used with extracting datalink
+     */
+    S_REGION: 'S_REGION',
+
+    /**
+     * the center point for a row from the source table, used with extracting datalink
+     */
+    ROW_TARGET: 'ROW_TARGET',
 
     /**
      * An world point in a fits FILE that is associated with this table
@@ -191,6 +201,11 @@ export const MetaConst = {
      * any ID can be added to a table search to identify the source for the purpose of getting source specific obscore preferences
      */
     OBSCORE_SOURCE_ID: 'OBSCORE_SOURCE_ID',
+
+    /**
+     * If we are doing cutout, this is the default type, either: ROW_POSITION or SEARCH_POSITION
+     */
+    OBSCORE_CUTOUT_TYPE: 'OBSCORE_CUTOUT_TYPE',
 
     /**
      * if defined this table container a moving object, setting this will override any catalog evaluation

--- a/src/firefly/js/metaConvert/TableDataProductUtils.js
+++ b/src/firefly/js/metaConvert/TableDataProductUtils.js
@@ -18,7 +18,7 @@ import {getActiveTableId, getTblById, onTableLoaded} from '../tables/TableUtil';
 import {getCellValue, getTblInfo} from '../tables/TableUtil.js';
 import MultiViewCntlr, {dispatchUpdateCustom, getMultiViewRoot, getViewer} from '../visualize/MultiViewCntlr.js';
 import {
-    getObsCoreAccessURL, getSearchTarget, isFormatDataLink, makeWorldPtUsingCenterColumns
+    getObsCoreAccessURL, getObsCoreSRegion, getSearchTarget, isFormatDataLink, makeWorldPtUsingCenterColumns
 } from '../voAnalyzer/TableAnalysis';
 import {getServiceDescriptors} from '../voAnalyzer/VoDataLinkServDef';
 import {makeDlUrl} from './vo/DatalinkProducts';
@@ -162,11 +162,15 @@ export function extractDatalinkTable(table,row,title,setAsActive=true) {
     }
     if (!url) return;
 
-    const positionWP = getSearchTarget(table?.request, table) ?? makeWorldPtUsingCenterColumns(table, row);
+    const positionWP = getSearchTarget(table?.request, table)
+    const sRegion= getObsCoreSRegion(table,row);
+    const rowWP=  makeWorldPtUsingCenterColumns(table, row);
 
 
     const dataTableReq= makeTableRequest(url,{titleStr:title},undefined,0,undefined,undefined,undefined,undefined,true);
     if (positionWP) dataTableReq.META_INFO[MetaConst.SEARCH_TARGET]= positionWP.toString();
+    if (sRegion) dataTableReq.META_INFO[MetaConst.S_REGION]= sRegion;
+    if (rowWP) dataTableReq.META_INFO[MetaConst.ROW_TARGET]= rowWP.toString();
 
     dispatchTableSearch(dataTableReq, {setAsActive, logHistory: false, showFilters: true, showInfoButton: true});
     showPinMessage('Pinning to Table Area');

--- a/src/firefly/js/metaConvert/vo/DataLinkStandAloneConverter.js
+++ b/src/firefly/js/metaConvert/vo/DataLinkStandAloneConverter.js
@@ -32,5 +32,5 @@ export async function getDatalinkStandAlineDataProduct(table, row, activateParam
             dlData = !isCutout ? dlData : dlData.relatedDLEntries.fullImage;
         }
     }
-    return createDataLinkSingleRowItem({dlData, activateParams, baseTitle:'Datalink data', options});
+    return createDataLinkSingleRowItem({dlData, activateParams, options});
 }

--- a/src/firefly/js/ui/CutoutSizeDialog.jsx
+++ b/src/firefly/js/ui/CutoutSizeDialog.jsx
@@ -5,11 +5,19 @@ import {isString} from 'lodash';
 import React, {useEffect} from 'react';
 import {Chip, Stack, Typography} from '@mui/joy';
 import {dispatchShowDialog, dispatchHideDialog} from '../core/ComponentCntlr.js';
+import {MetaConst} from '../data/MetaConst';
+import {getMetaEntry} from '../tables/TableUtil';
 import {dispatchChangePointSelection, visRoot} from '../visualize/ImagePlotCntlr';
 import {PlotAttribute} from '../visualize/PlotAttribute';
-import {getActivePlotView, primePlot} from '../visualize/PlotViewUtil';
+import {primePlot} from '../visualize/PlotViewUtil';
+import {parseWorldPt} from '../visualize/Point';
+import {getSearchTargetFromTable, isRowTargetCapable} from '../voAnalyzer/TableAnalysis';
 import {FieldGroupCollapsible} from './panel/CollapsiblePanel';
-import { getCutoutSize, setAllCutoutParams, setPreferCutout } from './tap/ObsCoreOptions';
+import {RadioGroupInputField} from './RadioGroupInputField';
+import {
+    getCutoutSize, getCutoutTargetType, ROW_POSITION, SEARCH_POSITION, setAllCutoutParams, setPreferCutout,
+    USER_ENTERED_POSITION
+} from './tap/ObsCoreOptions';
 import {intValidator} from '../util/Validate';
 import CompleteButton from './CompleteButton.jsx';
 import DialogRootContainer from './DialogRootContainer.jsx';
@@ -22,18 +30,21 @@ import {useFieldGroupValue, useStoreConnector} from './SimpleComponent.jsx';
 import {SizeInputFields} from './SizeInputField.jsx';
 
 import HelpIcon from './HelpIcon.jsx';
+import ReadMoreRoundedIcon from '@mui/icons-material/ReadMoreRounded';
+import CrisisAlertRoundedIcon from '@mui/icons-material/CrisisAlertRounded';
+import AccessibilityRoundedIcon from '@mui/icons-material/AccessibilityRounded';
 
 const DIALOG_ID= 'cutoutSizeDialog';
 const OVERRIDE_TARGET= 'OverrideTarget';
 
 
 
-export function showCutoutSizeDialog({showingCutout, cutoutDefSizeDeg, pixelBasedCutout, tbl_id, cutoutCenterWP,
+export function showCutoutSizeDialog({showingCutout, cutoutDefSizeDeg, pixelBasedCutout, tbl_id, serDef, cutoutCenterWP,
                                      dataProductsComponentKey, enableCutoutFullSwitching, cutoutToFullWarning}) {
     const popup = (
         <PopupPanel title={'Cutout Settings'} closeCallback={hideDialog} >
             <FieldGroup groupKey={'cutout-size-dialog'} keepState={true}>
-                <CutoutSizePanel {...{showingCutout, cutoutDefSizeDeg,pixelBasedCutout, tbl_id, cutoutCenterWP,
+                <CutoutSizePanel {...{showingCutout, cutoutDefSizeDeg,pixelBasedCutout, tbl_id, serDef, cutoutCenterWP,
                     dataProductsComponentKey,enableCutoutFullSwitching, cutoutToFullWarning}}/>
             </FieldGroup>
         </PopupPanel>
@@ -54,13 +65,17 @@ function hideDialog() {
 }
 
 
-function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataProductsComponentKey, tbl_id,
+function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataProductsComponentKey, tbl_id, serDef,
                              cutoutCenterWP, enableCutoutFullSwitching, cutoutToFullWarning}) {
     const cutoutFieldKey= dataProductsComponentKey+'-CutoutSize';
+    const cutoutTypeFieldKey= dataProductsComponentKey+'-CutoutType';
     let cutoutValue= useStoreConnector( () => getCutoutSize(dataProductsComponentKey));
     const [getCutoutFieldSize,setCutoutFieldSize]= useFieldGroupValue(cutoutFieldKey);
     const [getOverrideTarget,setOverrideTarget]= useFieldGroupValue(OVERRIDE_TARGET);
     const [getEnteredTarget,setEnteredTarget]= useFieldGroupValue(DEF_TARGET_PANEL_KEY);
+    const [getCutoutType,setCutoutType]= useFieldGroupValue(cutoutTypeFieldKey);
+    // const wpOverride= getOverrideTarget();
+    const cutoutType= getCutoutType();
 
     const activeWp= useStoreConnector(() => {
         const plot= primePlot(visRoot());
@@ -69,10 +84,18 @@ function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataPr
         return pt;
     });
 
+    const hasSearchTarget= Boolean(getSearchTargetFromTable(tbl_id));
+    const rowCapable= isRowTargetCapable(tbl_id) || Boolean(parseWorldPt(getMetaEntry(tbl_id,MetaConst.ROW_TARGET)));
+
+    useEffect(() => {
+        setCutoutType(getModifiedCutoutTargetType(dataProductsComponentKey,tbl_id, serDef,hasSearchTarget,rowCapable));
+    }, [hasSearchTarget,rowCapable]);
+
     useEffect(() => {
         if (activeWp) {
             setOverrideTarget(activeWp);
             setEnteredTarget(activeWp);
+            setCutoutType(USER_ENTERED_POSITION);
         }
     }, [activeWp]);
 
@@ -86,8 +109,40 @@ function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataPr
         setCutoutFieldSize(cutoutValue);
     },[cutoutFieldKey]);
 
+    const options=[
+        {label: (
+                <Stack direction='row' spacing={1}>
+                    <AccessibilityRoundedIcon/>
+                    <Typography>Entered Position</Typography>
+                </Stack>
+            ),
+            value:USER_ENTERED_POSITION},
+    ];
+    if (rowCapable) {
+        options.unshift(
+            {label: (
+                    <Stack direction='row' spacing={1}>
+                        <ReadMoreRoundedIcon/>
+                        <Typography>Table Row Position</Typography>
+                    </Stack>
+                ),
+                value:ROW_POSITION}
+        );
+    }
+    if (hasSearchTarget) {
+        options.unshift(
+            {
+                label: (
+                    <Stack direction='row' spacing={1}>
+                        <CrisisAlertRoundedIcon/>
+                        <Typography>Search Target Center</Typography>
+                    </Stack>
+                ),
+                value:SEARCH_POSITION,
+            });
+    }
     return (
-        <Stack justifyContent='space-between' alignItems='center' spacing={1} minWidth='25rem'>
+        <Stack justifyContent='space-between' alignItems='center' spacing={1} minWidth='25rem' ml={1}>
             <Stack spacing={4} minWidth={'40rem'}>
                 { pixelBasedCutout ?
                     <ValidationField {...{
@@ -106,16 +161,31 @@ function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataPr
                                      initialState={{
                                          value: (cutoutDefSizeDeg/3600).toString(),
                                          tooltip: 'Set cutout size',
-                                         unit: 'arcsec', min:  1/3600, max:  5
-                                     }} />
-
+                                         unit: 'arcsec', min:  1/3600, max:  5 }} />
                 }
-                <OptionalTarget cutoutCenterWP={cutoutCenterWP} activePt/>
+                <RadioGroupInputField {...{
+                    fieldKey:cutoutTypeFieldKey, orientation: 'horizontal', options,
+                    initialState:{ value: getCutoutTargetType(dataProductsComponentKey,tbl_id, serDef) }
+                }}/>
+                {cutoutType===SEARCH_POSITION &&
+                    <Typography color='warning'  level='body-sm'>
+                        Warning: If search position is not on the source image then the cutout will use row position
+                    </Typography>
+                }
+                {cutoutType!==USER_ENTERED_POSITION &&
+                    <Typography level='body-sm'>
+                         You may also click on the image to change position
+                    </Typography>
+                }
+                <OptionalTarget cutoutCenterWP={cutoutCenterWP}
+                                sx={{visibility: cutoutType===USER_ENTERED_POSITION?'visible':'hidden'}} />
             </Stack>
-            <Stack {...{textAlign:'center', direction:'row', justifyContent:'space-between', width:1, px:1, pb:1}}>
+
+            <Stack {...{textAlign:'center', direction:'row', justifyContent:'space-between', width:1, pb:1, pt:1}}>
                 <Stack {...{textAlign:'center', direction:'row', spacing:1}}>
                     <CompleteButton text={showingCutout?'Update Cutout':'Show Cutout'} dialogId={DIALOG_ID}
-                                    onSuccess={(r) => updateCutout(r,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout,getOverrideTarget(),tbl_id)}/>
+                                    onSuccess={(r) => updateCutout(r,cutoutFieldKey,dataProductsComponentKey,
+                                        cutoutType,pixelBasedCutout,getOverrideTarget(),tbl_id,serDef)}/>
                     {showingCutout && enableCutoutFullSwitching &&
                         <CompleteButton text='Show Full Image'
                                         onSuccess={(r) =>
@@ -129,7 +199,7 @@ function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataPr
     );
 }
 
-function OptionalTarget({cutoutCenterWP}) {
+function OptionalTarget({cutoutCenterWP,sx}) {
 
     const [getEnteredTarget,setEnteredTarget]= useFieldGroupValue(DEF_TARGET_PANEL_KEY);
     const [getOverrideTarget,setOverrideTarget]= useFieldGroupValue(OVERRIDE_TARGET);
@@ -147,7 +217,7 @@ function OptionalTarget({cutoutCenterWP}) {
     }, [getEnteredTarget]);
 
     const header= (
-        <Stack direction='row' justifyContent='space-between' alignItems='baseline' width={1}>
+        <Stack {...{direction:'row', justifyContent:'space-between', alignItems:'baseline', width:1}}>
             <Stack direction='row' spacing={1}>
                 <Typography level='title-md'>
                     Change Cutout Center:
@@ -164,9 +234,9 @@ function OptionalTarget({cutoutCenterWP}) {
     );
 
     return (
-        <FieldGroupCollapsible header={header}
-                               initialState= {{ value:'closed' }}
-                               fieldKey='optionalTarget'>
+        <FieldGroupCollapsible {...{header,
+                               initialState: { value:'closed' },
+                               fieldKey:'optionalTarget', sx }}>
             <Stack spacing={2}>
                 <TargetPanel
                     defaultToActiveTarget={false}
@@ -189,10 +259,11 @@ function OptionalTarget({cutoutCenterWP}) {
 };
 
 
-function updateCutout(request,cutoutFieldKey,dataProductsComponentKey,pixelBasedCutout,overrideTarget,tbl_id) {
+function updateCutout(request,cutoutFieldKey,dataProductsComponentKey,cutoutType,
+                      pixelBasedCutout,overrideTarget,tbl_id,serDef) {
     hideDialog();
     const size= `${request[cutoutFieldKey]}${pixelBasedCutout?'px':''}`;
-    setAllCutoutParams( dataProductsComponentKey, tbl_id, size, overrideTarget, true);
+    setAllCutoutParams( dataProductsComponentKey, tbl_id, serDef, cutoutType, size, overrideTarget);
 
 }
 
@@ -208,6 +279,7 @@ function showFullImage(request,cutoutFieldKey,dataProductsComponentKey,cutoutToF
                     hideDialog();
                     setPreferCutout(dataProductsComponentKey,tbl_id,false);
                 }
+                dispatchHideDialog(id);
                 hideDialog();
             },
             'Very large image',
@@ -219,4 +291,21 @@ function showFullImage(request,cutoutFieldKey,dataProductsComponentKey,cutoutToF
         setPreferCutout(dataProductsComponentKey,tbl_id,false);
     }
 
+}
+
+function getModifiedCutoutTargetType(dataProductsComponentKey,tbl_id, setDef, hasSearchTarget, rowCapable) {
+    const cType= getCutoutTargetType(dataProductsComponentKey,tbl_id, setDef);
+    switch (cType) {
+        case ROW_POSITION:
+            if (rowCapable) return ROW_POSITION;
+            if (hasSearchTarget) return SEARCH_POSITION;
+            return USER_ENTERED_POSITION;
+        case SEARCH_POSITION:
+            if (hasSearchTarget) return SEARCH_POSITION;
+            if (rowCapable) return ROW_POSITION;
+            return USER_ENTERED_POSITION;
+        case USER_ENTERED_POSITION:
+            return cType;
+    }
+    return cType;
 }

--- a/src/firefly/js/ui/ToolbarButton.jsx
+++ b/src/firefly/js/ui/ToolbarButton.jsx
@@ -169,7 +169,7 @@ ToolbarButton.propTypes= {
     text : oneOfType([element,string]),
     tip : string,
     value: string,
-    title: string,
+    title: oneOfType([element,string]),
     pressed: bool,
     shortcutHelp : bool,
     badgeCount : number,

--- a/src/firefly/js/ui/panel/CollapsiblePanel.jsx
+++ b/src/firefly/js/ui/panel/CollapsiblePanel.jsx
@@ -33,9 +33,9 @@ CollapsiblePanel.propTypes = {
 };
 
 
-export function FieldGroupCollapsible({slotProps, ...props}) {
+export function FieldGroupCollapsible({slotProps, sx, ...props}) {
     return (
-        <CollapsibleGroup {...slotProps?.root}>
+        <CollapsibleGroup {...{...slotProps?.root, sx}}>
             <FieldGroupCollapsibleItem slotProps={slotProps} {...props} />
         </CollapsibleGroup>
     );

--- a/src/firefly/js/ui/tap/ObsCoreOptions.js
+++ b/src/firefly/js/ui/tap/ObsCoreOptions.js
@@ -3,15 +3,27 @@ import {getAppOptions} from '../../core/AppDataCntlr';
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr';
 import {MetaConst} from '../../data/MetaConst';
 import {getMetaEntry} from '../../tables/TableUtil';
+import {parseObsCoreRegion} from '../../util/ObsCoreSRegionParser';
 import {parseWorldPt} from '../../visualize/Point';
-import {getSearchTarget, makeWorldPtUsingCenterColumns} from '../../voAnalyzer/TableAnalysis';
+import {pointIn} from '../../visualize/projection/Projection';
+import {
+    getObsCoreSRegion, getSearchTargetFromTable, isRowTargetCapable,
+    makeWorldPtUsingCenterColumns
+} from '../../voAnalyzer/TableAnalysis';
 import {findWorldPtInServiceDef} from '../../voAnalyzer/VoDataLinkServDef';
 
 const PREFER_CUTOUT_KEY = 'preferCutout';
 const SD_CUTOUT_SIZE_KEY = 'sdCutoutSize';
 const SD_CUTOUT_WP_OVERRIDE = 'sdCutoutWpOverride';
+const SD_CUTOUT_TYPE = 'sdCutoutType';
 const SD_DEFAULT_SPACIAL_CUTOUT_SIZE = .01;
 const SD_DEFAULT_PIXEL_CUTOUT_SIZE = 200;
+
+export const ROW_POSITION= 'ROW_POSITION';
+export const SEARCH_POSITION= 'SEARCH_POSITION';
+export const USER_ENTERED_POSITION= 'USER_ENTERED_POSITION';
+const NOT_ROW_CAPABLE= 'NOT_ROW_CAPABLE';
+const ROW_CAPABLE= 'ROW_CAPABLE';
 
 
 
@@ -78,13 +90,18 @@ export const setCutoutSize= (dataProductsComponentKey, cutoutSize) =>
  *  equivalent to setPreferCutout, setCutoutSize, setCutoutTargetOverride
  * @param dataProductsComponentKey
  * @param tbl_id
+ * @param serDef
+ * @param cutoutType
  * @param cutoutSize
  * @param overrideTarget
  * @param preferCutout
  */
-export function setAllCutoutParams(dataProductsComponentKey, tbl_id, cutoutSize, overrideTarget = undefined, preferCutout) {
-    const result = getComponentState(dataProductsComponentKey)[PREFER_CUTOUT_KEY] ?? {};
-    const newPreferState = {...result, [tbl_id]: preferCutout, LAST_PREF: preferCutout};
+export function setAllCutoutParams(dataProductsComponentKey, tbl_id, serDef, cutoutType, cutoutSize, overrideTarget = undefined, preferCutout=true) {
+    const result = getComponentState(dataProductsComponentKey);
+    const newPreferState = {...result[PREFER_CUTOUT_KEY], [tbl_id]: preferCutout, LAST_PREF: preferCutout};
+
+    const {lookupTblId}= getIdForCutoutType(tbl_id,serDef);
+    const newCutoutTypeState= {...result[SD_CUTOUT_TYPE], [lookupTblId]:cutoutType};
     let wp= overrideTarget;
     if (overrideTarget && isString(overrideTarget)) {
         wp= parseWorldPt(overrideTarget);
@@ -94,6 +111,7 @@ export function setAllCutoutParams(dataProductsComponentKey, tbl_id, cutoutSize,
             [PREFER_CUTOUT_KEY]: newPreferState,
             [SD_CUTOUT_SIZE_KEY]: cutoutSize,
             [SD_CUTOUT_WP_OVERRIDE]: wp,
+            [SD_CUTOUT_TYPE]: newCutoutTypeState,
         });
 }
 
@@ -103,9 +121,94 @@ export const setCutoutTargetOverride= (dataProductsComponentKey, wp)=>
 export const getCutoutTargetOverride= (dataProductsComponentKey) =>
     getComponentState(dataProductsComponentKey, {})[SD_CUTOUT_WP_OVERRIDE];
 
+
+
+
+function getIdForCutoutType(tbl_id,serDef) {
+    let lookupTblId= tbl_id;
+    let canDoRow= false;
+    if (tbl_id) canDoRow= isRowTargetCapable(tbl_id);
+
+    if (!canDoRow && serDef) {
+        canDoRow= Boolean(serDef?.rowWP);
+        lookupTblId= canDoRow ? ROW_CAPABLE : NOT_ROW_CAPABLE;
+    }
+    return {lookupTblId,canDoRow};
+}
+
+
+export function getCutoutTargetType(dataProductsComponentKey, tbl_id, serDef) {
+
+    const {lookupTblId,canDoRow}= getIdForCutoutType(tbl_id,serDef);
+    const cutoutTypeObj = getComponentState(dataProductsComponentKey, {})[SD_CUTOUT_TYPE];
+    if (cutoutTypeObj?.[lookupTblId]) return cutoutTypeObj[lookupTblId];
+
+
+    // compute fallback from table
+    const tableCutoutPref = getMetaEntry(tbl_id, MetaConst.OBSCORE_CUTOUT_TYPE);
+    if (tableCutoutPref===SEARCH_POSITION) return SEARCH_POSITION;
+    if (tableCutoutPref===ROW_POSITION && canDoRow) return ROW_POSITION;
+
+    // compute fallback from obscore options
+    const typeFromOptions= getObsCoreOption(SD_CUTOUT_TYPE, getMetaEntry(tbl_id, MetaConst.OBSCORE_SOURCE_ID), );
+    if (typeFromOptions===SEARCH_POSITION) return SEARCH_POSITION;
+    if (typeFromOptions===ROW_POSITION && canDoRow) return ROW_POSITION;
+
+    // compute fallback from the default based on if a search target exist
+    if (canDoRow) return Boolean(getSearchTargetFromTable(tbl_id)) ? SEARCH_POSITION : ROW_POSITION;
+
+    // fallback to SEARCH_POSITION
+    return SEARCH_POSITION;
+}
+
 export function findCutoutTarget(dataProductsComponentKey, serDef, table, row) {
-    let positionWP = getSearchTarget(table?.request, table) ?? makeWorldPtUsingCenterColumns(table, row);
-    if (!positionWP) positionWP= serDef?.positionWP;
-    if (getCutoutTargetOverride(dataProductsComponentKey)) return getCutoutTargetOverride(dataProductsComponentKey);
-    return positionWP ?? findWorldPtInServiceDef(serDef, row);
+    const result= findPreferredCutoutTarget(dataProductsComponentKey, serDef, table, row);
+    const {positionWP}= result;
+    const sRegion= getObsCoreSRegion(table,row);
+    if (!sRegion) return result;
+
+    const {valid,drawObj}= parseObsCoreRegion(sRegion) ?? {valid:false};
+    if (!valid) return result;
+
+    if (pointIn(drawObj.pts,positionWP)) return result;
+    const fallback=  makeWorldPtUsingCenterColumns(table, row);
+    return {requestedType:result.requestedType, foundType: fallback?ROW_POSITION:undefined, positionWP:fallback};
+}
+
+export function findPreferredCutoutTarget(dataProductsComponentKey, serDef, table, row) {
+    const cutoutType= getCutoutTargetType(dataProductsComponentKey, table?.tbl_id, serDef);
+    let positionWP;
+    let foundType;
+    const requestedType= cutoutType;
+    if (cutoutType===SEARCH_POSITION) {
+        positionWP= getSearchTargetFromTable(table);
+        if (!positionWP) positionWP= serDef?.positionWP;
+        if (positionWP) {
+            foundType= SEARCH_POSITION;
+        }
+        else {
+            positionWP=  makeWorldPtUsingCenterColumns(table, row);
+            foundType= ROW_POSITION;
+        }
+    }
+    else if (cutoutType===ROW_POSITION) {
+        positionWP= makeWorldPtUsingCenterColumns(table, row);
+        if (!positionWP) positionWP= serDef?.rowWP;
+        if (positionWP) foundType= ROW_POSITION;
+
+    }
+    else if (getCutoutTargetOverride(dataProductsComponentKey)) {
+        positionWP= getCutoutTargetOverride(dataProductsComponentKey);
+        if (positionWP) foundType= USER_ENTERED_POSITION;
+    }
+    return {requestedType, foundType, positionWP:positionWP ?? findWorldPtInServiceDef(serDef, row)};
+}
+
+export function getCutoutErrorStr(foundType,requestedType) {
+    if (foundType===requestedType) return '';
+    return (foundType===ROW_POSITION && requestedType===SEARCH_POSITION) ?
+        'Warning: Search position is not on this image, using position from row':
+        (foundType===ROW_POSITION && requestedType===USER_ENTERED_POSITION) ?
+            'Warning: User entered cutout position is not on this image, using position from row':
+            'Target is not on cutout, using position from row';
 }

--- a/src/firefly/js/ui/tap/SIASearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/SIASearchRootPanel.jsx
@@ -398,6 +398,11 @@ const noRowLimitMsg = (
     </div>
 );
 
+function getCutoutType(siaState) {
+    return siaState?.constraintFragments?.get('spatial')?.cutoutType ??
+        siaState?.constraintFragments?.get('location')?.cutoutType;
+}
+
 
 function onSIAv2SearchSubmit(request, serviceUrl, siaMeta, siaState, showErrors=true) {
 
@@ -430,6 +435,7 @@ function onSIAv2SearchSubmit(request, serviceUrl, siaMeta, siaState, showErrors=
 
         const url= `${baseRequestUrl}${hasMaxrec?'&MAXREC='+maxrec : ''}`;
         const additionalSiaMeta= {serviceLabel: getSiaServiceLabel(serviceUrl)};
+        if (getCutoutType(siaState)) additionalSiaMeta[MetaConst.OBSCORE_CUTOUT_TYPE]= getCutoutType(siaState);
         const hips= getServiceHiPS(serviceUrl);
         if (hips) additionalSiaMeta[MetaConst.COVERAGE_HIPS]= hips;
         const title= makeNumberedTitle(userTitle || 'SIA Search');

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -22,6 +22,7 @@ import {useFieldGroupRerender, useFieldGroupValue, useFieldGroupWatch} from '../
 import {SizeInputFields} from '../SizeInputField.jsx';
 import {DEF_TARGET_PANEL_KEY} from '../TargetPanel.jsx';
 import {ConstraintContext} from './Constraints.js';
+import {ROW_POSITION, SEARCH_POSITION} from './ObsCoreOptions';
 import {
     DebugObsCore, getPanelPrefix, makeCollapsibleCheckHeader, makeFieldErrorList, makePanelStatusUpdater,
     } from './TableSearchHelpers.jsx';
@@ -599,6 +600,17 @@ function makeUserAreaConstraint(regionOp, userArea, adqlCoordSys ) {
     }
 }
 
+function getCutoutTypeFromRegionOp(regionOp) {
+    switch (regionOp) {
+        case 'contains_point': return SEARCH_POSITION;
+        case 'contains_shape': return SEARCH_POSITION;
+        case 'contained_by_shape': return ROW_POSITION;
+        case 'intersects': return ROW_POSITION;
+        case 'center_contained': return SEARCH_POSITION;
+    }
+    return SEARCH_POSITION;
+}
+
 
 function makeSpatialConstraints(columnsModel, obsCoreEnabled, fldObj, uploadInfo, tableName, canUpload, useSIAv2) {
     const {fileName,serverFile, columns:uploadColumns, totalRows, fileSize}= uploadInfo ?? {};
@@ -696,6 +708,7 @@ function makeSpatialConstraints(columnsModel, obsCoreEnabled, fldObj, uploadInfo
         valid:  errAry.length===0, errAry,
         adqlConstraintsAry: adqlConstraint ? [adqlConstraint] : [],
         siaConstraints:siaConstraint ? [siaConstraint] : [],
+        cutoutType: getCutoutTypeFromRegionOp(regionOp),
     };
     if (spatialType===MULTI) {
         retObj.TAP_UPLOAD= makeUploadSchema(fileName,serverFile,uploadColumns, totalRows, fileSize);

--- a/src/firefly/js/ui/tap/TableSearchHelpers.jsx
+++ b/src/firefly/js/ui/tap/TableSearchHelpers.jsx
@@ -80,15 +80,14 @@ export function makePanelStatusUpdater(panelActive,panelTitle,defErrorMessage) {
      * @String string - panel message
      */
     return (constraints, lastConstraintResult, setConstraintResult, useSIAv2= false) => {
-        const {valid:constraintsValid,errAry, adqlConstraintsAry,
+        const {valid:constraintsValid,errAry, adqlConstraintsAry, cutoutType= undefined,
             uploadFile, TAP_UPLOAD}= constraints;
 
         const simpleError= constraintsValid ? '' : (errAry[0]|| defErrorMessage || '');
 
         const {adqlConstraint, constraintErrors, siaConstraints}=
             getPanelAdqlConstraint(panelActive,panelTitle, constraintsValid,adqlConstraintsAry,constraints.siaConstraints, errAry[0], defErrorMessage, useSIAv2);
-        const cr = { adqlConstraint, constraintErrors, siaConstraints, simpleError,
-            uploadFile, TAP_UPLOAD};
+        const cr = { adqlConstraint, constraintErrors, siaConstraints, simpleError, uploadFile, TAP_UPLOAD, cutoutType};
         if (constraintResultDiffer(cr, lastConstraintResult)) setConstraintResult(cr);
 
         return simpleError;

--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -70,11 +70,10 @@ export function onTapSearchSubmit(request, serviceUrl, tapBrowserState, addition
         const title= makeNumberedTitle(userTitle || makeTapSearchTitle(adqlClean,serviceUrl));
         const treq = makeTblRequest('AsyncTapQuery', title, params);
         setNoCache(treq);
-        const additionalTapMeta= {};
-        if (!isUserEnteredADQL) {
-            additionalTapMeta[PREF_KEY]= `${tapBrowserState.schemaName}-${tapBrowserState.tableName}`;
-        }
-        additionalTapMeta.serviceLabel= serviceLabel;
+        const cutoutType= getCutoutType(tapBrowserState);
+        const additionalTapMeta= {serviceLabel};
+        if (!isUserEnteredADQL) additionalTapMeta[PREF_KEY]= `${tapBrowserState.schemaName}-${tapBrowserState.tableName}`;
+        if (cutoutType) additionalTapMeta[MetaConst.OBSCORE_CUTOUT_TYPE]= cutoutType;
         if (hips) additionalTapMeta[MetaConst.COVERAGE_HIPS]= hips;
 
         treq.META_INFO= {
@@ -101,6 +100,9 @@ export function onTapSearchSubmit(request, serviceUrl, tapBrowserState, addition
     return false;
 }
 
+function getCutoutType(tapBrowserState) {
+  return tapBrowserState?.constraintFragments?.get('spatial')?.cutoutType;
+}
 
 
 /**

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -870,6 +870,22 @@ export function segmentIntersectRect(point1, point2,  view_corners) {
     return false;
 }
 
+/**
+ * Determine if a point is in a rectangle
+ * assume a non-slanted rectangular area
+ * @param point1
+ * @param view_corners
+ * @return {boolean}
+ */
+export function pointInRec(point1, view_corners) {
+    const xAry = view_corners.map((one_corner) => one_corner.x);
+    const yAry = view_corners.map((one_corner) => one_corner.y);
+    const xMin = Math.min(...xAry);
+    const xMax = Math.max(...xAry);
+    const yMin = Math.min(...yAry);
+    const yMax = Math.max(...yAry);
+    return (point1.x >= xMin && point1.y >= yMin && point1.x <= xMax && point1.y <= yMax);
+}
 
 
 /**

--- a/src/firefly/js/visualize/projection/Projection.js
+++ b/src/firefly/js/visualize/projection/Projection.js
@@ -5,7 +5,7 @@
 import {Projection as AladinProjection} from '../../externalSource/aladinProj/AladinProjections.js';
 import {CoordinateSys} from '../CoordSys.js';
 import {makeImagePt, makeProjectionPt, makeWorldPt} from '../Point.js';
-import {computeDistance, convertAngle, isAngleUnit} from '../VisUtil.js';
+import {computeDistance, convertAngle, isAngleUnit, pointInRec} from '../VisUtil.js';
 import {AitoffProjection} from './AitoffProjection.js';
 import {ARCProjection} from './ARCProjection.js';
 import {CartesianProjection} from './CartesianProjection.js';
@@ -364,4 +364,19 @@ export function makeHiPSProjection(coordinateSys, lon = 0, lat = 0, fullSky = fa
 		crval2: lat
 	};
 	return makeProjection({header, coorindateSys: coordinateSys.toString()});
+}
+
+/**
+ * User world coordinates determine if a point is in a rectangle,
+ * This function will create a transformation for the test. It does not require a plot
+ * @param {Array.<WorldPt>} wpAry - Point that make up the rectangle, array length should be 4
+ * @param {WorldPt} testWp
+ * @return {boolean} true if the world point in the rectangle
+ */
+export function pointIn(wpAry, testWp) {
+	if (!testWp || !wpAry?.length) return false;
+	const projection= makeHiPSProjection(CoordinateSys.EQ_J2000, wpAry[0].x, wpAry[0].y, true);
+	const testIm= projection.getImageCoords(testWp.x,testWp.y);
+	const imageAry= wpAry.map( (wp) => projection.getImageCoords(wp.x,wp.y));
+	return pointInRec(testIm,imageAry);
 }

--- a/src/firefly/js/visualize/ui/VisInlineToolbarView.jsx
+++ b/src/firefly/js/visualize/ui/VisInlineToolbarView.jsx
@@ -53,6 +53,9 @@ export const VisInlineToolbarView = memo( (props) => {
 
 function getWarningsAry(pv) {
     const warnings= primePlot(visRoot(),pv.plotId)?.attributes[PlotAttribute.USER_WARNINGS] ?? {};
+    if (isString(warnings)) {
+        return [<Typography>{warnings}</Typography>];
+    }
     return Object.entries(warnings ?? {})
         .filter(([k]) => (k!=='title' && k!=='tooltip'))
         .map(([,v]) => v);
@@ -62,12 +65,13 @@ function getWarningsAry(pv) {
 
 function WarningsAlert({pv}) {
     const warnings= primePlot(visRoot(),pv.plotId)?.attributes[PlotAttribute.USER_WARNINGS] ?? {};
+    const defaultTip= isString(warnings) ? warnings : 'click for warnings';
     const warnAry= getWarningsAry(pv);
     if (!warnAry?.length) return;
 
     return (
         <WarningButton {...{
-            tip:warnings.tooltip ?? 'warnings',
+            tip:warnings.tooltip ?? defaultTip,
             onClick: () => {
                 const wc= (
                     <Stack {...{spacing:1, width:1}}>

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
@@ -23,8 +23,8 @@ export function MultiProductChoice({ dataProductsState, dpId,
                                        makeDropDown, chartViewerId, imageViewerId, metaDataTableId,
                                        tableGroupViewerId, whatToShow, onChange, mayToggle = false, factoryKey
                                    }) {
-    const {serDef, enableCutout, pixelBasedCutout=false}= dataProductsState;
-    const {cutoutToFullWarning, dlAnalysis:{cutoutFullPair=false}={}}= dataProductsState.dlData ?? {};
+    const {enableCutout, pixelBasedCutout=false}= dataProductsState;
+    const {serDef, cutoutToFullWarning, dlAnalysis:{cutoutFullPair=false}={}}= dataProductsState.dlData ?? {};
     const primeIdx= useStoreConnector(() => getActivePlotView(visRoot())?.primeIdx ?? -1);
     const {current:showingStatus}= useRef({oldWhatToShow:undefined});
     const chartTableOptions = [{label: 'Table', value: SHOW_TABLE}, {label: 'Chart', value: SHOW_CHART}];

--- a/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
+++ b/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
@@ -109,6 +109,7 @@ export function getServiceDescriptors(tableOrId, removeAsync = true) {
             utype,
             sdSourceTable: table,
             positionWP: parseWorldPt(getMetaEntry(table, MetaConst.SEARCH_TARGET, undefined)),
+            rowWP: parseWorldPt(getMetaEntry(table, MetaConst.ROW_TARGET, undefined)),
             title: desc ?? getSDDescription(table, ID) ?? 'Service Descriptor ' + idx,
             accessURL: params.find(({name}) => name==='accessURL')?.value,
             standardID: params.find(({name}) => name==='standardID')?.value,
@@ -146,6 +147,8 @@ export function getDataLinkData(dataLinkTableOrId, sourceObsCoreTbl=undefined, s
     if (!data) return [];
     const sourceObsCoreData= getObsCoreData(sourceObsCoreTbl,sourceObsCoreRow);
     const positionWP= parseWorldPt(getMetaEntry(dataLinkTable, MetaConst.SEARCH_TARGET, undefined));
+    const rowWP= parseWorldPt(getMetaEntry(dataLinkTable, MetaConst.ROW_TARGET, undefined));
+    const sRegion= getMetaEntry(dataLinkTable, MetaConst.S_REGION, undefined);
 
     const dlDataAry=  data
         .map((r, idx) => {
@@ -167,7 +170,7 @@ export function getDataLinkData(dataLinkTableOrId, sourceObsCoreTbl=undefined, s
                 id: rowObj[idKey],
                 contentType, contentQualifier, semantics, localSemantics, url, error_message,
                 description, size, serviceDefRef, serDef, rowIdx: idx, dlAnalysis, prodTypeHint,
-                sourceObsCoreData, relatedDLEntries: {}, positionWP,
+                sourceObsCoreData, relatedDLEntries: {}, positionWP, rowWP, sRegion,
             };
         })
         .filter(({url='', serviceDefRef, serDef, error_message}) =>

--- a/src/firefly/js/voAnalyzer/vo-typedefs.jsdoc
+++ b/src/firefly/js/voAnalyzer/vo-typedefs.jsdoc
@@ -74,6 +74,9 @@
  * @prop {Object} relatedDLEntries
  * @prop {object} relatedRows
  * @prop {ObsCoreData} sourceObsCoreData
+ * @prop {WorldPt} positionWP if there is a MetaConst.SEARCH_TARGET in datalink table it is propagated here
+ * @prop {WorldPt} rowWP if there is a MetaConst.ROW_TARGET in datalink table it is propagated here
+ * @prop {String} sRegion if there is a MetaConst.S_REGION in datalink table it is propagated here
  */
 
 
@@ -154,6 +157,8 @@
  * @prop {CISXui} [cisxUI] - names should be one of: HiPS, FOV, hips_initial_ra, hips_initial_dec, moc, examples, hipsCtype1, hipsCtype2
  * @prop {Array.<ServiceDescriptorInputParam>} [cisxTokenSub]
  * @prop {Array.<ServiceDescriptorInputParam>} serDefParams
+ * @prop {WorldPt} positionWP if there is a MetaConst.SEARCH_TARGET in datalink table it is propagated here
+ * @prop {WorldPt} rowWP if there is a MetaConst.ROW_TARGET in datalink table it is propagated here
  */
 
 /**


### PR DESCRIPTION
#### [Firefly-1643](https://jira.ipac.caltech.edu/browse/FIREFLY-1643): improve cutouts

 - add support of types of cutout - user, search position, row position
 - improve UI for better selection and feedback
 - ife PR: https://github.com/IPAC-SW/irsa-ife/pull/376

#### Testing
- https://firefly-1643-improve-cutouts.irsakudev.ipac.caltech.edu/applications/euclid
- do a search of `Images`, and play with different types of cutouts
  - I did 3h54m50.91s -50d42m08.0s Equ J2000
  - for radius 5400
- choose table (magnifier) options `Show table of all Euclid products for this row`
   - the cutout will work for the row that support them otherwise it will show full images
   - cutouts work for `#this`, `#cutout`, `#counterpart`
   - note- this is the full datalink table of everything