### PR TITLE
FIREFLY-1610: Store Job information in Redis to support clustered deployment

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/api/Async.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/api/Async.java
@@ -4,6 +4,7 @@
 
 package edu.caltech.ipac.firefly.api;
 
+import edu.caltech.ipac.firefly.core.background.JobUtil;
 import edu.caltech.ipac.firefly.server.RequestOwner;
 import edu.caltech.ipac.firefly.server.ServerCommandAccess;
 import edu.caltech.ipac.firefly.server.ServerContext;
@@ -21,7 +22,6 @@ import java.util.List;
 
 import static edu.caltech.ipac.firefly.data.ServerParams.JOB_ID;
 import static edu.caltech.ipac.util.StringUtils.*;
-import static edu.caltech.ipac.firefly.core.background.JobManager.toJson;
 
 /**
  * Follows UWS pattern for async job processing.
@@ -96,7 +96,7 @@ public class Async extends BaseHttpServlet {
     private static void listUserJob(HttpServletResponse res) throws Exception {
         // list all jobs for current user; /CmdSrv/async
         List<JobInfo> list = JobManager.list();
-        sendResponse(JobManager.toJsonJobList(list), res);
+        sendResponse(JobUtil.toJsonJobList(list), res);
     }
 
     private static void submitJob(HttpServletResponse res, SrvParam params) throws Exception {
@@ -111,7 +111,7 @@ public class Async extends BaseHttpServlet {
     }
 
     private static void getJobInfo(HttpServletResponse res, String jobId) throws Exception {
-        sendResponse(toJson(JobManager.getJobInfo(jobId)), res);
+        sendResponse(JobUtil.toJson(JobManager.getJobInfo(jobId)), res);
     }
 
     private static void updateJob(HttpServletResponse res, SrvParam params, String jobId) throws Exception {
@@ -129,7 +129,7 @@ public class Async extends BaseHttpServlet {
         String phase = req.getParameter("PHASE");
         if (String.valueOf(phase).equals("ABORT")) {
             JobInfo fi = JobManager.abort(jobId, "Abort by user");
-            sendResponse(toJson(fi), res);
+            sendResponse(JobUtil.toJson(fi), res);
         }
     }
 
@@ -154,8 +154,9 @@ public class Async extends BaseHttpServlet {
             info = new JobInfo("NULL");
         }
         res.setStatus(code);
+        info.setPhase(JobInfo.Phase.ERROR);
         info.setError(new JobInfo.Error(code, message));
-        sendResponse(toJson(info), res);
+        sendResponse(JobUtil.toJson(info), res);
     }
 
     private static void sendResponse(String json, HttpServletResponse res) throws Exception {

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
@@ -199,6 +199,6 @@ public class RedisService {
         if(!isOffline()) {
             return jedisPool.getResource();
         }
-        throw new ConnectException("Unable to connect to Redis at " + REDIS_HOST + ":" + REDIS_PORT);
+        throw new ConnectException("Unable to connect to Redis at " + redisHost + ":" + REDIS_PORT);
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/Util.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/Util.java
@@ -17,6 +17,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
@@ -207,6 +208,12 @@ public class Util {
         }
     }
 
+    /**
+     * A lightweight optional wrapper that allows conditional execution of functions
+     * based on the input value.
+     * @see edu.caltech.ipac.firefly.core.UtilTest for sample usage
+     * @param <T> The type of the value contained in this Opt instance.
+     */
     public static class Opt<T> {
         private final T val;
         private Predicate<T> test;
@@ -216,33 +223,127 @@ public class Util {
             this.test = test;
         }
 
-        public Opt<T> then(Consumer<T> func) {
+        /**
+         * Applies the given function if the value passes the predicate check and returns a new Opt instance for chaining.
+         * @param func The function to apply.
+         * @param <R>  The return type of the function.
+         * @return A new Opt containing the function result if the value is valid, otherwise an empty Opt.
+         */
+        public <R> Opt<R> then(Function<T, R> func) {
             if (test.test(val)) {
-                func.accept(val);
+                return  new Opt<>(func.apply(val), (v)->true);
+            } else {
+                return new Opt<>(null, (v)->false);
             }
-            return this;
         }
 
-        public Opt<T> orElse(Consumer<T> func) {
+        /**
+         * Applies the given function if the value does not pass the predicate check and returns a new Opt instance for chaining.
+         * @param func The function to apply.
+         * @param <R>  The return type of the function.
+         * @return A new Opt containing the function result if the value is invalid, otherwise an empty Opt.
+         */
+        public <R> Opt<R> orElse(Function<T, R> func) {
             if (!test.test(val)) {
+                return  new Opt<>(func.apply(val), (v)->true);
+            } else {
+                return (Opt<R>)this;
+            }
+        }
+
+        /**
+         * Returns an Opt containing the default value if the value does not pass the predicate check for chaining
+         * @param defVal The default value.
+         * @param <R>    The type of the default value.
+         * @return A new Opt containing the default value if the original value is invalid, otherwise returns this instance.
+         */
+        public <R> Opt<R> orElse(R defVal) {
+            if (!test.test(val)) {
+                return  new Opt<>(defVal, (v)->true);
+            } else {
+                return (Opt<R>)this;
+            }
+        }
+
+        /**
+         * Call the given function if the value is valid.
+         * @param func The function to call.
+         */
+        public void apply(Consumer<T> func) {
+            if (test.test(val)) {
                 func.accept(val);
             }
-            return this;
         }
 
-        public <R> R eval(Function<T, R> func) {
+        /**
+         * @return Returns the value if valid, otherwise returns null.
+         */
+        public T get() {
             if (test.test(val)) {
-                return func.apply(val);
+                return val;
+            } else {
+                return null;
             }
-            return null;
         }
 
+        /**
+         * @param defVal The default value to return if the value is invalid.
+         * @return Returns the value if valid, otherwise returns the specified default value.
+         */
+        public T get(T defVal) {
+            if (test.test(val)) {
+                return val;
+            } else {
+                return defVal;
+            }
+        }
+
+        /**
+         * Applies the given function to the value if valid and returns the result.
+         * @param func The function to apply.
+         * @param <R>  The return type of the function.
+         * @return The function result or null if the value is invalid.
+         */
+        public <R> R get(Function<T, R> func) {
+            if (test.test(val)) {
+                return  func.apply(val);
+            } else {
+                return null;
+            }
+        }
+
+        /**
+         * Creates an Opt instance if the provided value is not empty (null or empty-string).
+         * @param val The value to check.
+         * @param <T> The type of the value.
+         * @return A new Opt instance if the value is not empty, otherwise an empty Opt.
+         */
         public static <T> Opt<T> ifNotEmpty(T val) {
             return new Opt<>(val, (v) -> !isEmpty(v));
         }
 
+        /**
+         * Creates an Opt instance if the provided value is not null.
+         * @param val The value to check.
+         * @param <T> The type of the value.
+         * @return A new Opt instance if the value is not null, otherwise an empty Opt.
+         */
         public static <T> Opt<T> ifNotNull(T val) {
             return new Opt<>(val, Objects::nonNull);
+        }
+
+        /**
+         * Creates an Opt instance from a value returned by a function.
+         * @param val The function providing the value.
+         * @param <T> The type of the value.
+         * @return A new Opt instance if the function returns a non-null value, otherwise an empty Opt.
+         */
+        public static <T> Opt<T> ifNotNull(Supplier<T> val) {
+            try {
+                return new Opt<>(val.get(), Objects::nonNull);
+            } catch (Exception e) {
+                return new Opt<>(null, (v)->false);
+            }
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -6,10 +6,13 @@ package edu.caltech.ipac.firefly.core.background;
 
 import edu.caltech.ipac.firefly.server.SrvParam;
 import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.StringUtils;
 
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +30,38 @@ public class JobInfo implements Serializable {
 
     public enum Phase {PENDING, QUEUED, EXECUTING, COMPLETED, ERROR, ABORTED, HELD, SUSPENDED, ARCHIVED, UNKNOWN}
     private static final int LIFE_SPAN = AppProperties.getIntProperty("job.lifespan", 60*60*24);        // default lifespan in seconds; kill job if exceed
+
+    // these are uws:job defined properties
+    public static final String JOB_ID = "jobId";
+    public static final String RUN_ID = "runId";
+    public static final String OWNER_ID = "ownerId";
+    public static final String PHASE = "phase";
+    public static final String QUOTE = "quote";
+    public static final String CREATION_TIME = "creationTime";
+    public static final String START_TIME = "startTime";
+    public static final String END_TIME = "endTime";
+    public static final String EXECUTION_DURATION = "executionDuration";
+    public static final String DESTRUCTION = "destruction";
+    public static final String PARAMETERS = "parameters";
+    public static final String PARAMETER = "parameter";
+    public static final String RESULTS = "results";
+    public static final String RESULT = "result";
+    public static final String ERROR_SUMMARY = "errorSummary";
+    public static final String ERROR_TYPE = "type";
+    public static final String ERROR_MSG = "message";
+    public static final String JOB_INFO = "jobInfo";
+
+    // these are additional info that's not in uws:job defined props
+    // in serialized form, it will go under uws:jobInfo block
+    public static final String PROGRESS = "progress";
+    public static final String PROGRESS_DESC = "progressDesc";
+    public static final String JOB_TYPE = "type";
+    public static final String SUMMARY = "summary";
+    public static final String DATA_ORIGIN = "dataOrigin";
+    public static final String MONITORED = "monitored";
+    public static final String LABEL = "label";
+    public static final String LOCAL_RUN_ID = "localRunId";
+
 
     private String jobId;
     private String runId;
@@ -102,7 +137,6 @@ public class JobInfo implements Serializable {
     }
 
     public void setError(Error error) {
-        if (error != null) setPhase(Phase.ERROR);
         this.error = error;
     }
 
@@ -114,6 +148,7 @@ public class JobInfo implements Serializable {
         this.results = new ArrayList<>(results);
     }
 
+    @Nonnull
     public Map<String, String> getParams() {
         return params;
     }
@@ -203,29 +238,7 @@ public class JobInfo implements Serializable {
 //
 //====================================================================
 
-    public static record Error ( int code, String msg){}
+    public static record Error ( int code, String msg) implements Serializable {}
     public static record Result(String href, String hrefType, String mimeType, String size){};
 
 }
-/*
- * THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE CALIFORNIA
- * INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S. GOVERNMENT CONTRACT WITH
- * THE NATIONAL AERONAUTICS AND SPACE ADMINISTRATION (NASA). THE SOFTWARE
- * IS TECHNOLOGY AND SOFTWARE PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS
- * AND IS PROVIDED AS-IS TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND,
- * INCLUDING ANY WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR
- * A PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC 2312-2313)
- * OR FOR ANY PURPOSE WHATSOEVER, FOR THE SOFTWARE AND RELATED MATERIALS,
- * HOWEVER USED.
- *
- * IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA BE LIABLE
- * FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT LIMITED TO, INCIDENTAL
- * OR CONSEQUENTIAL DAMAGES OF ANY KIND, INCLUDING ECONOMIC DAMAGE OR INJURY TO
- * PROPERTY AND LOST PROFITS, REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE
- * ADVISED, HAVE REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
- *
- * RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF THE SOFTWARE
- * AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY CALTECH AND NASA FOR
- * ALL THIRD-PARTY CLAIMS RESULTING FROM THE ACTIONS OF RECIPIENT IN THE USE
- * OF THE SOFTWARE.
- */

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -5,6 +5,10 @@
 package edu.caltech.ipac.firefly.core.background;
 
 import edu.caltech.ipac.firefly.data.ServerEvent;
+import edu.caltech.ipac.firefly.data.userdata.UserInfo;
+import edu.caltech.ipac.firefly.messaging.Message;
+import edu.caltech.ipac.firefly.messaging.Messenger;
+import edu.caltech.ipac.firefly.messaging.Subscriber;
 import edu.caltech.ipac.firefly.server.RequestOwner;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.events.FluxAction;
@@ -13,8 +17,11 @@ import edu.caltech.ipac.firefly.server.events.WebsocketConnector;
 import edu.caltech.ipac.firefly.server.packagedata.PackagedEmail;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.cache.Cache;
+import edu.caltech.ipac.util.cache.CacheKey;
+import edu.caltech.ipac.util.cache.CacheManager;
+import edu.caltech.ipac.util.cache.StringKey;
 import org.apache.commons.lang.text.StrBuilder;
-import org.json.simple.JSONObject;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -22,10 +29,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.*;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
 
-import static edu.caltech.ipac.firefly.api.Async.getAsyncUrl;
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.core.background.JobUtil.logJobInfo;
 import static edu.caltech.ipac.firefly.data.ServerParams.EMAIL;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
@@ -45,19 +54,16 @@ public class JobManager {
     private static final int WAIT_COMPLETE = AppProperties.getIntProperty("job.wait.complete", 1);                // wait for complete after submit in seconds
     private static final int MAX_PACKAGERS = AppProperties.getIntProperty("job.max.packagers", 10);               // maximum number of simultaneous packaging threads
 
-    private static Logger.LoggerImpl LOG = Logger.getLogger();
-    private static ExecutorService packagers = Executors.newFixedThreadPool(MAX_PACKAGERS);
-    private static ExecutorService searches = Executors.newCachedThreadPool();
-    private static HashMap<String, JobEntry> runningJobs = new HashMap<>();
-    private static HashMap<String, JobInfo> allJobInfos = new HashMap<>();
+    private static final Logger.LoggerImpl LOG = Logger.getLogger();
+    private static final ExecutorService packagers = Executors.newFixedThreadPool(MAX_PACKAGERS);
+    private static final ExecutorService searches = Executors.newCachedThreadPool();
+    private static final HashMap<String, JobEntry> runningJobs = new HashMap<>();
+    private static final Cache<JobInfo> allJobInfos = CacheManager.getDistributedMap("ALL_JOB_INFOS");
 
     static {
+        Messenger.subscribe(JobEvent.TOPIC, new JobEventHandler());
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
                     JobManager::checkJobs, KEEP_ALIVE_INTERVAL, KEEP_ALIVE_INTERVAL, TimeUnit.SECONDS);   // check every 30 seconds
-    }
-
-    private static String nextJobId() {
-        return String.valueOf(System.currentTimeMillis());
     }
 
     /**
@@ -65,70 +71,71 @@ public class JobManager {
      */
     public static List<JobInfo> list() {
         String owner = ServerContext.getRequestOwner().getUserKey();
-        return allJobInfos.values().stream()
+        return getAllJobs().stream()
                   .filter(info -> info != null && owner.equals(info.getOwner()))
-                  .collect(Collectors.toList());
-    }
-
-    public static JobInfo getJobInfo(String jobId) {
-        return allJobInfos.get(jobId);
-    }
-
-
-    public static void sendUpdate(JobInfo jobInfo) {
-        if (jobInfo.getPhase() == COMPLETED) {
-            runningJobs.remove(jobInfo.getJobId());
-        }
-        // send updated jobInfo to client
-        FluxAction addAction = new FluxAction(FluxAction.JOB_INFO, toJsonObject(jobInfo));
-        ServerEventManager.fireAction(addAction, ServerEvent.Scope.USER);
+                  .toList();
     }
 
     public static JobInfo submit(Job job) {
         RequestOwner reqOwner = ServerContext.getRequestOwner();
-        JobInfo info = new JobInfo(nextJobId());
-        Instant start = Instant.now();
-        info.setStartTime(start);
-        info.setCreationTime(start);
-        info.setDestruction(start.plus(7, ChronoUnit.DAYS));
-        info.setOwner(reqOwner.getUserKey());
-        info.setPhase(QUEUED);
-        info.setEventConnId(reqOwner.getEventConnID());
-        info.setType(job.getType());
-        allJobInfos.put(info.getJobId(), info);
+        String jobId = JobUtil.nextJobId();
+        updateJobInfo(jobId, true, ji -> {      // setting 'true' to add this jobInfo into the datastore
+            Instant start = Instant.now();
+            ji.setStartTime(start);
+            ji.setCreationTime(start);
+            ji.setDestruction(start.plus(7, ChronoUnit.DAYS));
+            ji.setOwner(reqOwner.getUserKey());
+            ji.setPhase(QUEUED);
+            ji.setEventConnId(reqOwner.getEventConnID());
+            ji.setType(job.getType());
+        });
 
         job.runAs(reqOwner);
-        job.setJobId(info.getJobId());
+        job.setJobId(jobId);
 
-        logJobInfo(info);
-        Future future = job.getType() == PACKAGE ? packagers.submit(job) : searches.submit(job);
+        Future<String> future = job.getType() == PACKAGE ? packagers.submit(job) : searches.submit(job);
+        runningJobs.put(jobId, new JobEntry(future, job));
 
         try {
             future.get(WAIT_COMPLETE, TimeUnit.SECONDS);        // wait in seconds for a job to complete
         } catch (InterruptedException e) {
-            info.setPhase(ABORTED);
-            logJobInfo(info);
+            updateJobInfo(jobId, (ji) -> {
+                ji.setPhase(ABORTED);
+            });
         } catch (TimeoutException e) {
-            // it's ok.. job may take longer to complete
+            // it's ok; job may take longer to complete
         } catch (Exception e) {
-            if (info.getPhase() != ERROR) {
-                job.setError(500, e.getMessage());
-            }
-            logJobInfo(info);
+            ifNotNull(getJobInfo(jobId)).then(ji -> {
+                if (ji.getPhase() != ERROR) {
+                    job.setError(500, e.getMessage());
+                }
+            });
             LOG.error(e);
         }
 
-        if (future.isDone() && info.getPhase() != ERROR && info.getPhase() != ABORTED) {
-            info.setPhase(COMPLETED);
+        JobInfo.Phase phase = ifNotNull(getJobInfo(jobId)).eval(JobInfo::getPhase);
+        if (future.isDone() && phase != ERROR && phase != ABORTED) {
+            sendUpdate(jobId, (ji) -> ji.setPhase(COMPLETED));
         } else {
-            runningJobs.put(job.getJobId(), new JobEntry(future, job));
+            sendUpdate(jobId, (ji) -> ji.setPhase(phase));      // make sure job info is sent to client
         }
-        sendUpdate(info);
-        return job.getJobInfo();
+        return getJobInfo(jobId);
     }
 
     public static JobInfo abort(String jobId, String reason) {
-        JobEntry jobEntry = runningJobs.get(jobId);
+        JobInfo info = updateJobInfo(jobId, (ji) -> {
+            ji.setError(new JobInfo.Error(410, reason));
+            ji.setPhase(ABORTED);
+        });
+        if (info != null) {
+            Messenger.publish(new JobEvent(JobEvent.EventType.ABORTED, info));      // notify all instances AFTER jobInfo is updated
+        }
+        return info;
+    }
+
+    static void handleAborted(JobInfo jobInfo) {
+        if (jobInfo == null) return;
+        JobEntry jobEntry = runningJobs.get(jobInfo.getJobId());
         if (jobEntry != null) {
             if (jobEntry.job != null) {
                 if (jobEntry.job.getWorker() != null) {
@@ -136,132 +143,118 @@ public class JobManager {
                 }
             }
             if (jobEntry.future != null) jobEntry.future.cancel(true);
+            runningJobs.remove(jobInfo.getJobId());
+        }
+    }
 
-            runningJobs.remove(jobId);
-            JobInfo info = getJobInfo(jobId);
-            info.setError(new JobInfo.Error(410, reason));
-            info.setPhase(ABORTED);
-            sendUpdate(info);
+    public static JobInfo setMonitored(String jobId, boolean isMonitored) {
+        JobInfo jobInfo = updateJobInfo(jobId, ji -> {
+            if (ji.isMonitored() != isMonitored) {
+                ji.setMonitored(isMonitored);
+            }
+        });
+        if (jobInfo != null ) {
+            Messenger.publish(new JobEvent(JobEvent.EventType.MONITORED, jobInfo));      // notify all instances AFTER jobInfo is updated
         }
         return getJobInfo(jobId);
     }
 
-    public static JobInfo setMonitored(String jobId, boolean isMonitored) {
-        JobInfo info = getJobInfo(jobId);
-        if (info != null && info.isMonitored() != isMonitored) {
-            info.setMonitored(isMonitored);
-            sendUpdate(info);
-        }
-        return info;
-    }
-
     public static JobInfo sendEmail(String jobId, String email) {
-        JobInfo info = getJobInfo(jobId);
-        if (!isEmpty(email)) info.getParams().put(EMAIL, email);
-        PackagedEmail.send(info);
-        return info;
+        updateJobInfo(jobId, (ji) -> ji.getParams().put(EMAIL, email));
+        PackagedEmail.send(jobId);
+        return getJobInfo(jobId);
     }
 
     public static String results(String jobId) {
-        return toJsonResults(getJobInfo(jobId));
+        return ifNotNull(getJobInfo(jobId)).eval(JobUtil::toJsonResults);
+    }
+
+//====================================================================
+//  Getter/Setter
+//====================================================================
+
+    /**
+     * Retrieves the stored JobInfo with the given jobId.
+     * Returned value is read-only.  Use updateJobInfo to update the JobInfo.
+     * @param jobId the ID of the job
+     * @return the JobInfo with the jobId, or null not found
+     */
+    public static JobInfo getJobInfo(String jobId) {
+        if (isEmpty(jobId)) return null;
+        return allJobInfos.get(cacheKey(jobId));
+    }
+
+    /**
+     *  see {@link #updateJobInfo(String, boolean, Consumer)}
+     */
+    public static JobInfo updateJobInfo(String jobId, Consumer<JobInfo> func) {
+        return updateJobInfo(jobId, false, func);
+    }
+
+    /**
+     * Retrieves the stored JobInfo, applies the updates, and returns the updated JobInfo.
+     * This is done only when there is a JobInfo with the given jobId.
+     * @param jobId the job ID
+     * @param addIfNoFound if true, a new JobInfo will be created and stored if no JobInfo is found with the given jobId
+     * @param func the update function to apply to the JobInfo
+     * @return the updated JobInfo, or null if no JobInfo is found
+     */
+    public static JobInfo updateJobInfo(String jobId, boolean addIfNoFound, Consumer<JobInfo> func) {
+        JobInfo info = getJobInfo(jobId);
+        if (info == null && addIfNoFound) {
+            info = new JobInfo(jobId);
+        }
+        if (info == null || func == null) return null;
+        func.accept(info);
+        updateJobInfo(info);
+        return info;
+    }
+
+    /**
+     * This method updates the JobInfo using the provided function and publishes an update event.
+     * @param jobId the ID of the job to update
+     * @param func the function to apply to the JobInfo
+     */
+    public static void sendUpdate(String jobId, Consumer<JobInfo> func) {
+        JobInfo jobInfo = updateJobInfo(jobId, func);
+        if (jobInfo != null) {
+            Messenger.publish(new JobEvent(JobEvent.EventType.UPDATED, jobInfo));
+        }
+    }
+
+    /**
+     * internal method to update the JobInfo in the datastore
+     * @param info
+     */
+    private static void updateJobInfo(JobInfo info) {
+        CacheKey key = cacheKey(info);
+        if (key != null) {
+            allJobInfos.put(key, info);
+            if (info.getPhase() == COMPLETED) {
+                runningJobs.remove(info.getJobId());
+                Messenger.publish(new JobCompleted(info));       // notify all instances this job is completed
+            }
+            logJobInfo(info);
+        }
+    }
+
+    /**
+     * internal method to notify all clients with the updated jobInfo
+     * @param jobInfo
+     */
+    static void updateClient(JobInfo jobInfo) {
+        if (jobInfo == null) return;
+        // send updated jobInfo to client
+        FluxAction addAction = new FluxAction(FluxAction.JOB_INFO, JobUtil.toJsonObject(jobInfo));
+        ServerEvent.EventTarget evt = new ServerEvent.EventTarget(ServerEvent.Scope.USER);
+        evt.setUserKey(jobInfo.getOwner());
+        ServerEventManager.fireAction(addAction, evt);
     }
 
 
 //====================================================================
 //
 //====================================================================
-
-    public static String toJson(JobInfo info) {
-        JSONObject jsonObject = toJsonObject(info);
-        return jsonObject == null ? "null" : jsonObject.toJSONString();
-    }
-
-    public static JSONObject toJsonObject(JobInfo info) {
-        if (info == null) return null;
-        String asyncUrl = getAsyncUrl();
-
-        JSONObject rval = new JSONObject();
-        rval.put("jobId", info.getJobId());
-        applyIfNotEmpty(info.getRunId(), v -> rval.put("runId", v));
-        applyIfNotEmpty(info.getOwner(), v -> rval.put("ownerId", v));
-        applyIfNotEmpty(info.getPhase(), v -> rval.put("phase", v.toString()));
-        applyIfNotEmpty(info.getQuote(),   v -> rval.put("quote", v.toString()));
-        applyIfNotEmpty(info.getCreationTime(),   v -> rval.put("creationTime", v.toString()));
-        applyIfNotEmpty(info.getStartTime(),   v -> rval.put("startTime", v.toString()));
-        applyIfNotEmpty(info.getEndTime(),   v -> rval.put("endTime", v.toString()));
-        applyIfNotEmpty(info.executionDuration(),   v -> rval.put("executionDuration", v.toString()));
-        applyIfNotEmpty(info.getDestruction(), v -> rval.put("destruction", v.toString()));
-        rval.put("parameters", info.getParams());
-
-        if (info.getPhase() == COMPLETED && info.getResults().size() == 0) {
-            rval.put("results", Arrays.asList(toResult(asyncUrl + info.getJobId() + "/results/result", null, null)));
-        } else if (info.getResults().size() > 0) {
-            rval.put("results", toResults(info.getResults()));
-        }
-        applyIfNotEmpty(info.getError(),   v -> {
-            JSONObject errSum = new JSONObject();
-            errSum.put("message", v.msg());
-            errSum.put("type", v.code() < 500 ? "fatal" : "transient");     // 5xx are typically system error, e.g. server down.
-            rval.put("errorSummary", errSum);
-        });
-
-
-        JSONObject addtlInfo = new JSONObject();
-        rval.put("jobInfo", addtlInfo);
-        applyIfNotEmpty(info.getType(),   v -> addtlInfo.put("type", v.toString()));
-        applyIfNotEmpty(info.getLabel(), v -> addtlInfo.put("label", v));
-        applyIfNotEmpty(info.getProgress(),   v -> addtlInfo.put("progress", v));
-        applyIfNotEmpty(info.isMonitored(),   v -> addtlInfo.put("monitored", v));
-        applyIfNotEmpty(info.getProgressDesc(),   v -> addtlInfo.put("progressDesc", v));
-        applyIfNotEmpty(info.getDataOrigin(), v -> addtlInfo.put("dataOrigin", v));
-        applyIfNotEmpty(info.getSummary(),   v -> addtlInfo.put("summary", v));
-        applyIfNotEmpty(info.getLocalRunId(),   v -> addtlInfo.put("localRunId", v));
-
-        return rval;
-    }
-
-    public static List<JSONObject> toResults(List<JobInfo.Result> results) {
-        return results.stream().map(r -> toResult(r.href(), r.mimeType(), r.size()))
-                .collect(Collectors.toList());
-    }
-
-    private static JSONObject toResult(String href, String mimeType, String size) {
-        JSONObject ro = new JSONObject();
-        applyIfNotEmpty(href,   v -> ro.put("href", v));
-        applyIfNotEmpty(mimeType,   v -> ro.put("mimeType", v));
-        applyIfNotEmpty(size,   v -> ro.put("size", v));
-        return ro;
-    }
-
-    /**
-     * @param infos
-     * @return an array of job IDs under the 'jobs' prop as a json string
-     */
-    public static String toJsonJobList(List<JobInfo> infos) {
-        JSONObject rval = new JSONObject();
-        if (infos != null && infos.size() > 0) {
-            // object with "jobs": array of JobInfo urls
-            List<String> urls = infos.stream().map(i ->i.getJobId()).collect(Collectors.toList());
-            rval.put("jobs", urls);
-        }
-        return rval.toJSONString();
-    }
-
-    /**
-     * @param info
-     * @return an array of result URLs for the given job
-     */
-    public static String toJsonResults(JobInfo info) {
-        JSONObject rval = new JSONObject();
-        if (info.getPhase() == COMPLETED) {
-            if (info.getResults().size() == 0) {
-                rval.put("results", Arrays.asList(getAsyncUrl() + info.getJobId() + "/results/result"));
-            } else {
-                rval.put("results", info.getResults());
-            }
-        }
-        return rval.toJSONString();
-    }
 
     /**
      * Print job statistics info
@@ -275,89 +268,121 @@ public class JobManager {
         sb.append        ("          |------------ ------------ ------------\n");
 
         Arrays.stream(Job.Type.values()).forEach(type -> {
-            long total = allJobInfos.values().stream().filter(v -> v.getType() == type).count();
-            long active = allJobInfos.values().stream().filter(v -> v.getPhase() == EXECUTING && v.getType() == type).count();
-            long error = allJobInfos.values().stream().filter(v -> v.getPhase() == ERROR && v.getType() == type).count();
+            long total = getAllJobs().stream().filter(v -> v.getType() == type).count();
+            long active = getAllJobs().stream().filter(v -> v.getPhase() == EXECUTING && v.getType() == type).count();
+            long error = getAllJobs().stream().filter(v -> v.getPhase() == ERROR && v.getType() == type).count();
 
             sb.append(String.format("%9s |%,12d %,12d %,12d\n", type, total, active, error));
         });
 
         if (details) {
             sb.append("\n");
-            sb.append("JOB ID          PHASE       startTime              elapsedTime(s) progress\n");
-            sb.append("--------------- ----------- ---------------------- -------------- --------\n");
-            allJobInfos.forEach((k, v) -> {
-                Instant endT = v.getEndTime() != null ? v.getEndTime() : Instant.now();
-                sb.append(String.format("%15s %11s %22s %,14d %8d\n",
-                        v.getJobId(), v.getPhase(), v.getStartTime().truncatedTo(ChronoUnit.SECONDS), Duration.between(v.getStartTime(), endT).toSeconds(), v.getProgress()));
+            sb.append("JOB ID               PHASE       startTime              elapsedTime(s) progress monitored owner                                \n");
+            sb.append("-------------------- ----------- ---------------------- -------------- -------- --------- -------------------------------------\n");
+            getAllJobs().forEach((ji) -> {
+                Instant endT = ji.getEndTime() != null ? ji.getEndTime() : Instant.now();
+                sb.append(String.format("%-20s %-11s %-22s %,14d %8d %9s %-37s\n",
+                        ji.getJobId(), ji.getPhase(), ji.getStartTime().truncatedTo(ChronoUnit.SECONDS), Duration.between(ji.getStartTime(), endT).toSeconds(), ji.getProgress(), ji.isMonitored(), ji.getOwner()));
             });
         }
         return sb.toString();
     }
 
-    static void logJobInfo(JobInfo info) {
-        LOG.debug(String.format("JOB:%s  owner:%s  phase:%s  msg:%s", info.getJobId(), info.getOwner(), info.getPhase(), info.getSummary()));
-        LOG.trace(String.format("JOB: %s details: %s", info.getJobId(), toJson(info)));
+    static List<JobInfo> getRunningJobs() {
+        return runningJobs.values().stream()
+                .map(je -> getJobInfo(je.job.getJobId()))               // convert JobEntry to JobInfo
+                .filter(Objects::nonNull).toList();                     // return only non-null JobInfo
     }
 
-
+    static List<JobInfo> getAllJobs() {
+        return allJobInfos.getKeys().stream()
+                .map(allJobInfos::get)
+                .filter(Objects::nonNull).toList();
+    }
 
 //====================================================================
 //
 //====================================================================
 
+    private static CacheKey cacheKey(JobInfo jobInfo) {
+        return cacheKey(jobInfo.getJobId());
+    }
+
+    private static CacheKey cacheKey(String jobId) {
+        return isEmpty(jobId) ? null : new StringKey(jobId);
+    }
+
     private static void checkJobs() {
 
         // ping clients with active(EXECUTING) job
-        List<String> activeClients = runningJobs.values().stream().map(jobEntry -> jobEntry.job.getJobInfo())
-                                    .filter(info -> info != null && info.getPhase() == EXECUTING)
-                                    .map(info -> info.getOwner() + "||" + info.getEventConnId())
-                                    .distinct()
-                                    .collect(Collectors.toList());
-        activeClients.forEach(client -> {
-            String[] ownerConnId = client.split("||");
-            WebsocketConnector.pingClient(ownerConnId[0], ownerConnId[1]);
-        });
+        getAllJobs().stream().filter(fi -> fi != null && fi.getPhase() == EXECUTING)     // all running jobs
+                .map(fi -> fi.getOwner() + "::" + fi.getEventConnId()).distinct()       // get distinct list of owner and connId
+                .forEach(client -> {                                                    // ensure it gets pinged only once, regardless of the number of jobs it has.
+                    String[] ownerConnId = client.split("::");
+                    WebsocketConnector.pingClient(ownerConnId[0], ownerConnId[1]);      // this will only ping client with the given owner/connId
+                });
 
         // kill expired jobs
-        runningJobs.values().forEach(je -> {
-            JobInfo info = je.job.getJobInfo();
-            long duration = info.executionDuration();
-            if (duration != 0 && info.getStartTime().plus(duration, ChronoUnit.SECONDS).isBefore(Instant.now())) {
-                abort(info.getJobId(), "Exceeded execution duration");
-            }
-        });
+        getRunningJobs().forEach(fi -> {
+                    long duration = fi.executionDuration();
+                    if (duration != 0 && fi.getStartTime().plus(duration, ChronoUnit.SECONDS).isBefore(Instant.now())) {
+                        abort(fi.getJobId(), "Exceeded execution duration");
+                    }
+                });
     }
 
     private static class JobEntry {
-        Future future;
+        Future<String> future;
         Job job;
 
-        public JobEntry(Future future, Job job) {
+        public JobEntry(Future<String> future, Job job) {
             this.future = future;
             this.job = job;
         }
     }
+
+    private static class JobEventHandler implements Subscriber {
+        public void onMessage(Message msg) {
+            JobEvent.EventType type = JobEvent.EventType.valueOf(msg.getValue(null, JobEvent.TYPE));
+            JobInfo jobInfo = JobUtil.fromMsg(msg);
+            updateClient(jobInfo);        // update jobInfo to client
+            if (type == JobEvent.EventType.ABORTED) {
+                handleAborted(jobInfo);
+            }
+        }
+    }
+
+    public static class JobEvent extends Message {
+        public static final String TOPIC = "JobEvent";
+        public enum EventType { UPDATED, COMPLETED, ABORTED, MONITORED }
+        public static final String JOB = "job";
+        public static String TYPE = "type";
+
+        public JobEvent(EventType type, JobInfo jobInfo) {
+            setTopic(TOPIC);
+            setValue(type.toString(), TYPE);
+            setValue(JobUtil.toJsonObject(jobInfo), JOB);
+        }
+    }
+
+    /**
+     * Published event notifying that a job has completed.
+     * It contains all necessary information for a COMPLETED handler to perform its task.
+     */
+    public static final class JobCompleted extends JobEvent {
+        public static final String TOPIC = "JobCompleted";
+//        static final String FROM = AppProperties.getProperty("mail.smtp.from", "donotreply@ipac.caltech.edu");
+        public JobCompleted(JobInfo jobInfo) {
+            super(EventType.COMPLETED, jobInfo);
+            setTopic(TOPIC);
+            setValue(JobUtil.toJsonObject(jobInfo), JOB);
+            UserInfo user = ServerContext.getRequestOwner().getUserInfo();
+            if (!user.isGuestUser()) {
+                setValue(user.getName(), "user", "name");
+                setValue(user.getEmail(), "user", "email");
+                setValue(user.getLoginName(), "user", "loginName");
+            }
+            applyIfNotEmpty(ServerContext.getRequestOwner().getSsoAdapter(), adpt -> setValue(adpt.getAuthToken(), "auth_info"));
+        }
+    }
 }
-/*
- * THIS SOFTWARE AND ANY RELATED MATERIALS WERE CREATED BY THE CALIFORNIA
- * INSTITUTE OF TECHNOLOGY (CALTECH) UNDER A U.S. GOVERNMENT CONTRACT WITH
- * THE NATIONAL AERONAUTICS AND SPACE ADMINISTRATION (NASA). THE SOFTWARE
- * IS TECHNOLOGY AND SOFTWARE PUBLICLY AVAILABLE UNDER U.S. EXPORT LAWS
- * AND IS PROVIDED AS-IS TO THE RECIPIENT WITHOUT WARRANTY OF ANY KIND,
- * INCLUDING ANY WARRANTIES OF PERFORMANCE OR MERCHANTABILITY OR FITNESS FOR
- * A PARTICULAR USE OR PURPOSE (AS SET FORTH IN UNITED STATES UCC 2312-2313)
- * OR FOR ANY PURPOSE WHATSOEVER, FOR THE SOFTWARE AND RELATED MATERIALS,
- * HOWEVER USED.
- *
- * IN NO EVENT SHALL CALTECH, ITS JET PROPULSION LABORATORY, OR NASA BE LIABLE
- * FOR ANY DAMAGES AND/OR COSTS, INCLUDING, BUT NOT LIMITED TO, INCIDENTAL
- * OR CONSEQUENTIAL DAMAGES OF ANY KIND, INCLUDING ECONOMIC DAMAGE OR INJURY TO
- * PROPERTY AND LOST PROFITS, REGARDLESS OF WHETHER CALTECH, JPL, OR NASA BE
- * ADVISED, HAVE REASON TO KNOW, OR, IN FACT, SHALL KNOW OF THE POSSIBILITY.
- *
- * RECIPIENT BEARS ALL RISK RELATING TO QUALITY AND PERFORMANCE OF THE SOFTWARE
- * AND ANY RELATED MATERIALS, AND AGREES TO INDEMNIFY CALTECH AND NASA FOR
- * ALL THIRD-PARTY CLAIMS RESULTING FROM THE ACTIONS OF RECIPIENT IN THE USE
- * OF THE SOFTWARE.
- */

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -105,7 +105,7 @@ public class JobManager {
         } catch (TimeoutException e) {
             // it's ok; job may take longer to complete
         } catch (Exception e) {
-            ifNotNull(getJobInfo(jobId)).then(ji -> {
+            ifNotNull(getJobInfo(jobId)).apply(ji -> {
                 if (ji.getPhase() != ERROR) {
                     job.setError(500, e.getMessage());
                 }
@@ -113,7 +113,7 @@ public class JobManager {
             LOG.error(e);
         }
 
-        JobInfo.Phase phase = ifNotNull(getJobInfo(jobId)).eval(JobInfo::getPhase);
+        JobInfo.Phase phase = ifNotNull(getJobInfo(jobId)).get(JobInfo::getPhase);
         if (future.isDone() && phase != ERROR && phase != ABORTED) {
             sendUpdate(jobId, (ji) -> ji.setPhase(COMPLETED));
         } else {
@@ -166,7 +166,7 @@ public class JobManager {
     }
 
     public static String results(String jobId) {
-        return ifNotNull(getJobInfo(jobId)).eval(JobUtil::toJsonResults);
+        return ifNotNull(getJobInfo(jobId)).get(JobUtil::toJsonResults);
     }
 
 //====================================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -1,0 +1,187 @@
+package edu.caltech.ipac.firefly.core.background;
+
+import edu.caltech.ipac.firefly.api.Async;
+import edu.caltech.ipac.firefly.core.Util;
+import edu.caltech.ipac.firefly.messaging.Message;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import edu.caltech.ipac.firefly.core.background.JobManager.JobEvent;
+import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
+import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase.COMPLETED;
+import static edu.caltech.ipac.util.StringUtils.*;
+
+public class JobUtil {
+    private static final Logger.LoggerImpl LOG = Logger.getLogger();
+    private static final long yearMs = 365*24*60*60*1000L;  // one year in milliseconds
+
+    public static void logJobInfo(JobInfo info) {
+        if (info == null) return;
+        LOG.debug(String.format("JOB:%s  owner:%s  phase:%s  msg:%s", info.getJobId(), info.getOwner(), info.getPhase(), info.getSummary()));
+        LOG.trace(String.format("JOB: %s details: %s", info.getJobId(), toJson(info)));
+    }
+
+    /**
+     * Generates a unique Job ID for a job. In a clustered environment, this ID is unique across all instances.
+     * The ID consists of up to 8 characters from the host name and the current time in milliseconds,
+     * limited to a one-year range. The resulting format is "HOSTNAME_TIMESTAMP", with a maximum of 20 characters.
+     * @return the next unique job ID for this host
+     */
+    static String nextJobId() {
+        String hname = Util.Try.it(() -> InetAddress.getLocalHost().getHostName()).getOrElse("SYS").split("\\.")[0];
+        hname = hname.length() < 9 ? hname : hname.substring(hname.length() - 8);
+        return "%s_%d".formatted(hname, System.currentTimeMillis() % yearMs);
+    }
+
+    public static String jobIdToDir(String jobId) {
+        if (isEmpty(jobId)) return jobId;
+        String[] parts = jobId.split("_");
+        return isEmpty(parts[1]) ? jobId : parts[0] + "_" + parts[1].substring(0, 4);       // keeping 7 digits in ms(2.78hrs) within the same directory;
+    }
+
+    public static String toJson(JobInfo info) {
+        JSONObject jsonObject = toJsonObject(info);
+        return jsonObject == null ? "null" : jsonObject.toJSONString();
+    }
+
+//====================================================================
+//  JSON serialization
+//====================================================================
+    public static JobInfo fromMsg(Message msg) {
+        JobInfo info = new JobInfo(msg.getValue(null, JobEvent.JOB, JOB_ID));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, RUN_ID), info::setRunId);
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, OWNER_ID), info::setOwner);
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, PHASE), v -> info.setPhase(Phase.valueOf(v.toString())));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, QUOTE), v -> info.setQuote(Instant.parse(v.toString())));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, CREATION_TIME), v -> info.setCreationTime(Instant.parse(v.toString())));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, START_TIME), v -> info.setStartTime(Instant.parse(v.toString())));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, END_TIME), v -> info.setEndTime(Instant.parse(v.toString())));
+        applyIfNotEmpty(msg.<Long>getValue(null, JobEvent.JOB, EXECUTION_DURATION), (v) -> info.setExecutionDuration(v.intValue()));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, DESTRUCTION), v -> info.setDestruction(Instant.parse(v.toString())));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, PARAMETERS), info::setParams);
+        applyIfNotEmpty(msg.<JSONArray>getValue(null, JobEvent.JOB, RESULTS), (v) -> {
+            List<Result> results = v.stream().map(o -> toResult((JSONObject) o)).toList();
+            info.setResults(results);
+        });
+        applyIfNotEmpty(msg.<JSONObject>getValue(null, JobEvent.JOB, ERROR_SUMMARY), v -> {
+            info.setError(new JobInfo.Error(getInt(v.get(ERROR_TYPE), 500), v.get(ERROR_MSG).toString()));
+        });
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, JOB_INFO, JOB_TYPE), (v) -> info.setType(Job.Type.valueOf(v.toString())));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, JOB_INFO, LABEL), info::setLabel);
+        applyIfNotEmpty(msg.<Long>getValue(null, JobEvent.JOB, JOB_INFO, PROGRESS), (v) -> info.setProgress(v.intValue()));
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, JOB_INFO, MONITORED), info::setMonitored);
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, JOB_INFO, PROGRESS_DESC), info::setProgressDesc);
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, JOB_INFO, DATA_ORIGIN), info::setDataOrigin);
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, JOB_INFO, SUMMARY), info::setSummary);
+        applyIfNotEmpty(msg.getValue(null, JobEvent.JOB, JOB_INFO, LOCAL_RUN_ID), info::setLocalRunId);
+        return info;
+    }
+
+    public static JSONObject toJsonObject(JobInfo info) {
+        return toJsonObject(info, true);
+    }
+
+    public static JSONObject toJsonObject(JobInfo info, boolean inclInternProps) {
+        if (info == null) return null;
+        String asyncUrl = Async.getAsyncUrl();
+
+        JSONObject rval = new JSONObject();
+        rval.put(JOB_ID, info.getJobId());
+        applyIfNotEmpty(info.getRunId(), v -> rval.put(RUN_ID, v));
+        applyIfNotEmpty(info.getOwner(), v -> rval.put(OWNER_ID, v));
+        applyIfNotEmpty(info.getPhase(), v -> rval.put(PHASE, v.toString()));
+        applyIfNotEmpty(info.getQuote(), v -> rval.put(QUOTE, v.toString()));
+        applyIfNotEmpty(info.getCreationTime(), v -> rval.put(CREATION_TIME, v.toString()));
+        applyIfNotEmpty(info.getStartTime(), v -> rval.put(START_TIME, v.toString()));
+        applyIfNotEmpty(info.getEndTime(), v -> rval.put(END_TIME, v.toString()));
+        applyIfNotEmpty(info.executionDuration(), v -> rval.put(EXECUTION_DURATION, v));
+        applyIfNotEmpty(info.getDestruction(), v -> rval.put(DESTRUCTION, v.toString()));
+        if (!info.getParams().isEmpty()) rval.put(PARAMETERS, info.getParams());
+
+        if (info.getPhase() == COMPLETED && info.getResults().isEmpty()) {
+            rval.put(RESULTS, Arrays.asList(toJsonResult(asyncUrl + info.getJobId() + "/results/result", null, null)));
+        } else if (!info.getResults().isEmpty()) {
+            rval.put(RESULTS, toResults(info.getResults()));
+        }
+        applyIfNotEmpty(info.getError(), v -> {
+            JSONObject errSum = new JSONObject();
+            errSum.put(ERROR_MSG, v.msg());
+            errSum.put(ERROR_TYPE, v.code() < 500 ? "fatal" : "transient");     // 5xx are typically system error, e.g. server down.
+            rval.put(ERROR_SUMMARY, errSum);
+        });
+
+        if (inclInternProps) {
+            JSONObject addtlInfo = new JSONObject();
+            rval.put(JOB_INFO, addtlInfo);
+            applyIfNotEmpty(info.getType(), v -> addtlInfo.put(JOB_TYPE, v.toString()));
+            applyIfNotEmpty(info.getLabel(), v -> addtlInfo.put(LABEL, v));
+            applyIfNotEmpty(info.getProgress(), v -> addtlInfo.put(PROGRESS, v));
+            applyIfNotEmpty(info.isMonitored(), v -> addtlInfo.put(MONITORED, v));
+            applyIfNotEmpty(info.getProgressDesc(), v -> addtlInfo.put(PROGRESS_DESC, v));
+            applyIfNotEmpty(info.getDataOrigin(), v -> addtlInfo.put(DATA_ORIGIN, v));
+            applyIfNotEmpty(info.getSummary(), v -> addtlInfo.put(SUMMARY, v));
+            applyIfNotEmpty(info.getLocalRunId(), v -> addtlInfo.put(LOCAL_RUN_ID, v));
+        }
+
+        return rval;
+    }
+
+    public static List<JSONObject> toResults(List<JobInfo.Result> results) {
+        return results.stream().map(r -> toJsonResult(r.href(), r.mimeType(), r.size()))
+                .collect(Collectors.toList());
+    }
+
+    public static JSONObject toJsonResult(String href, String mimeType, String size) {
+        JSONObject ro = new JSONObject();
+        applyIfNotEmpty(href, v -> ro.put("href", v));
+        applyIfNotEmpty(mimeType, v -> ro.put("mimeType", v));
+        applyIfNotEmpty(size, v -> ro.put("size", v));
+        return ro;
+    }
+
+    private static String getStr(JSONObject jo, String key) {
+        return jo.get(key) == null ? null : jo.get(key).toString();
+    }
+
+    public static Result toResult(JSONObject jo) {
+        return new Result(getStr(jo, "href"), getStr(jo, "hrefType"), getStr(jo, "mimeType"), getStr(jo, "size"));
+    }
+
+    /**
+     * @param infos
+     * @return an array of job IDs under the 'jobs' prop as a json string
+     */
+    public static String toJsonJobList(List<JobInfo> infos) {
+        JSONObject rval = new JSONObject();
+        if (infos != null && infos.size() > 0) {
+            // object with "jobs": array of JobInfo urls
+            List<String> urls = infos.stream().map(i -> i.getJobId()).collect(Collectors.toList());
+            rval.put("jobs", urls);
+        }
+        return rval.toJSONString();
+    }
+
+    /**
+     * @param info
+     * @return an array of result URLs for the given job
+     */
+    public static String toJsonResults(JobInfo info) {
+        JSONObject rval = new JSONObject();
+        if (info.getPhase() == COMPLETED) {
+            if (info.getResults().size() == 0) {
+                rval.put("results", Arrays.asList(Async.getAsyncUrl() + info.getJobId() + "/results/result"));
+            } else {
+                rval.put("results", info.getResults());
+            }
+        }
+        return rval.toJSONString();
+    }
+
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/ServCmdJob.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/ServCmdJob.java
@@ -9,6 +9,8 @@ import edu.caltech.ipac.firefly.server.ServCommand;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.SrvParam;
 
+import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
+
 /**
  * A base class which extends ServCommand function into a Job/Worker async processing
  *
@@ -46,7 +48,7 @@ public abstract class ServCmdJob extends ServCommand implements Job {
 
     public void setJobId(String jobId) {
         this.jobId = jobId;
-        getJobInfo().setParams(params.flatten());
+        updateJobInfo(jobId, ji -> ji.setParams(params.flatten()));
     }
 
     public Worker getWorker() {
@@ -61,9 +63,10 @@ public abstract class ServCmdJob extends ServCommand implements Job {
         if (jobId != null) {
             this.worker = worker;
             worker.setJob(this);
-            JobInfo info = getJobInfo();
-            info.setType(worker.getType());
-            info.setLabel(worker.getLabel());
+            updateJobInfo(getJobId(), ji -> {
+                ji.setType(worker.getType());
+                ji.setLabel(worker.getLabel());
+            });
         }
     }
 
@@ -71,7 +74,7 @@ public abstract class ServCmdJob extends ServCommand implements Job {
         try {
             this.reqOwner = (RequestOwner) reqOwner.clone();
         } catch (CloneNotSupportedException e) {
-            // ignore.. should not happen
+            // ignore. should not happen
         }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/messaging/JsonHelper.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/messaging/JsonHelper.java
@@ -21,7 +21,7 @@ import static edu.caltech.ipac.util.StringUtils.getInt;
  * This mimic the lodash's get/set behavior.  {@link JsonHelper#getValue(Object, String...)}} will
  * return the value at the given paths, or the given default is paths does not exist.
  * {@link JsonHelper#setValue(Object, String...)} will set the given value at the given paths.
- * Along the paths, if it does not exists, a Map or ArrayList will be created depending its path type.
+ * Along the paths, if it does not exist, a Map or ArrayList will be created depending on its path type.
  * When the path is an integer, it will assume it's an index to an ArrayList.  Otherwise, it's a key to a Map.
  *
  * Date: 2019-03-15
@@ -67,11 +67,11 @@ public class JsonHelper {
         Object current = root;
         for (String p : paths) {
             if (current == null) return def;
-            if (current instanceof List) {
+            if (current instanceof List clist) {
                 int idx = getInt(p, -1);
-                current = idx < 0 ? null : ((List) current).get(idx);
-            } else if(current instanceof Map) {
-                current = ((Map)current).get(p);
+                current = idx < 0 ? null : clist.get(idx);
+            } else if(current instanceof Map cmap) {
+                current = cmap.get(p);
             }
         }
         if (current==null) return def;
@@ -107,12 +107,10 @@ public class JsonHelper {
             cCont = getCont(cCont, ckey, nkey);
         }
 
-        if (cCont instanceof List) {
-            List alist = (List) cCont;
+        if (cCont instanceof List alist) {
             int idx = getInt(nkey, -1);
             return (v) -> alist.set(idx, v);
-        } else if (cCont instanceof Map) {
-            Map amap = (Map) cCont;
+        } else if (cCont instanceof Map amap) {
             String finalkey = nkey;
             return (v) -> amap.put(finalkey, v);
         }
@@ -122,16 +120,15 @@ public class JsonHelper {
     private Object ensureCont(Object cont, String key) {
         int idx = getInt(key, -1);
         if (cont == null) {
-            cont = idx == -1 ? new HashMap() :new ArrayList();
+            cont = idx == -1 ? new HashMap() : new ArrayList();
         }
-        if (idx >= 0 && cont instanceof List)  cont = ensureList((List) cont, idx);
+        if (idx >= 0 && cont instanceof List clist)  cont = ensureList(clist, idx);
         return cont;
     }
 
     private Object getCont(Object source, String key, String nkey) {
 
-        if (source instanceof List) {
-            List clist = (List) source;
+        if (source instanceof List clist) {
             int idx = getInt(key, -1);
             ensureList(clist, idx);
             Object cont = clist.get(idx);
@@ -142,8 +139,7 @@ public class JsonHelper {
                 cont = ensureCont(cont, nkey);
             }
             return cont;
-        } else if (source instanceof Map) {
-            Map cmap = (Map) source;
+        } else if (source instanceof Map cmap) {
             Object cont = cmap.get(key);
             if (cont == null) {
                 cont = ensureCont(cont, nkey);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -171,8 +171,8 @@ public class RequestOwner implements Cloneable {
             }
 
             if (userInfo == null) {
-                Cache cache = CacheManager.getLocal();
-                userInfo = (UserInfo) cache.get(new StringKey(getUserKey()));
+                Cache<UserInfo> cache = CacheManager.getLocal();
+                userInfo = cache.get(new StringKey(getUserKey()));
                 if (userInfo == null) {
                     userInfo = UserInfo.newGuestUser();
                     cache.put(new StringKey(getUserKey()), userInfo);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -16,6 +16,7 @@ import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.cache.StringKey;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.Cookie;
 import java.io.File;
 import java.util.Date;
@@ -161,6 +162,7 @@ public class RequestOwner implements Cloneable {
         return getSsoAdapter() != null && getSsoAdapter().getAuthToken() != null;
     }
 
+    @Nonnull
     public UserInfo getUserInfo() {
         if (userInfo == null) {
             if (isAuthUser() && !ignoreAuth) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistribMapCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistribMapCache.java
@@ -15,7 +15,7 @@ import java.util.List;
  * @author loi
  * @version $Id: EhcacheImpl.java,v 1.8 2009/12/16 21:43:25 loi Exp $
  */
-public class DistribMapCache extends DistributedCache {
+public class DistribMapCache<T> extends DistributedCache<T> {
     String mapKey;
     long lifespanInSecs;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheImpl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheImpl.java
@@ -6,10 +6,10 @@ package edu.caltech.ipac.firefly.server.cache;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheKey;
+import edu.caltech.ipac.util.cache.StringKey;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -56,6 +56,10 @@ public class EhcacheImpl<T> implements Cache<T> {
         }
     }
 
+    public void remove(CacheKey key) {
+        cache.remove(key.getUniqueString());
+    }
+
     public T get(CacheKey key) {
         Element el = cache.get(key.getUniqueString());
         T v = el == null ? null : (T) el.getValue();
@@ -71,10 +75,8 @@ public class EhcacheImpl<T> implements Cache<T> {
         return cache.isKeyInCache(key.getUniqueString());
     }
 
-    public List<String> getKeys() {
-        List<String> keys = new ArrayList<>();
-        cache.getKeys().forEach(k -> keys.add(k.toString()));
-        return keys;
+    public List<StringKey> getKeys() {
+        return cache.getKeys().stream().map(k -> new StringKey(k.toString())).toList();
     }
 
     public int getSize() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheImpl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheImpl.java
@@ -9,7 +9,9 @@ import edu.caltech.ipac.util.cache.CacheKey;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * This is an implementation of Cache using Ehcache.
@@ -19,16 +21,22 @@ import java.util.List;
  * @author loi
  * @version $Id: EhcacheImpl.java,v 1.8 2009/12/16 21:43:25 loi Exp $
  */
-public class EhcacheImpl implements Cache {
+public class EhcacheImpl<T> implements Cache<T> {
     private static final Logger.LoggerImpl logger = Logger.getLogger();
 
     Ehcache cache;
+    private transient Predicate<T> getValidator;
+
+    public Cache<T> validateOnGet(Predicate<T> validator) {
+        getValidator = validator;
+        return this;
+    }
 
     public EhcacheImpl(Ehcache cache) {
         this.cache = cache;
     }
 
-    public void put(CacheKey key, Object value) {
+    public void put(CacheKey key, T value) {
         String keystr = key.getUniqueString();
         if (value == null) {
             cache.remove(keystr);
@@ -37,7 +45,7 @@ public class EhcacheImpl implements Cache {
         }
     }
 
-    public void put(CacheKey key, Object value, int lifespanInSecs) {
+    public void put(CacheKey key, T value, int lifespanInSecs) {
         String keystr = key.getUniqueString();
         if (value == null) {
             cache.remove(keystr);
@@ -48,9 +56,15 @@ public class EhcacheImpl implements Cache {
         }
     }
 
-    public Object get(CacheKey key) {
+    public T get(CacheKey key) {
         Element el = cache.get(key.getUniqueString());
-        return el == null ? null : el.getValue();
+        T v = el == null ? null : (T) el.getValue();
+        if (v != null && getValidator != null && !getValidator.test(v)) {
+            cache.remove(key.getUniqueString());
+            return null;
+        } else {
+            return v;
+        }
     }
 
     public boolean isCached(CacheKey key) {
@@ -58,7 +72,9 @@ public class EhcacheImpl implements Cache {
     }
 
     public List<String> getKeys() {
-        return cache.getKeys();
+        List<String> keys = new ArrayList<>();
+        cache.getKeys().forEach(k -> keys.add(k.toString()));
+        return keys;
     }
 
     public int getSize() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/LocalMapCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/LocalMapCache.java
@@ -20,9 +20,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author loi
  * @version $Id: UserCache.java,v 1.5 2009/03/23 23:55:16 loi Exp $
  */
-public class LocalMapCache implements Cache {
+public class LocalMapCache<T> implements Cache<T> {
 
-    private Cache cache;
+    private Cache<Map<CacheKey, T>> cache;
     private StringKey uniqueKey;
 
     public LocalMapCache(String key) {
@@ -34,11 +34,11 @@ public class LocalMapCache implements Cache {
         return uniqueKey;
     }
 
-    public void put(CacheKey key, Object value) {
+    public void put(CacheKey key, T value) {
         if (key == null) {
             throw  new NullPointerException("key must not be null.");
         }
-        Map<CacheKey, Object> map = getSessionMap();
+        Map<CacheKey, T> map = getSessionMap();
         if (value == null) {
             map.remove(key);
         } else {
@@ -47,12 +47,12 @@ public class LocalMapCache implements Cache {
         cache.put(uniqueKey, map);
     }
 
-    public void put(CacheKey key, Object value, int lifespanInSecs) {
+    public void put(CacheKey key, T value, int lifespanInSecs) {
         throw new UnsupportedOperationException(
                 "This cache is used to store session related information.  This operation is not supported.");
     }
 
-    public Object get(CacheKey key) {
+    public T get(CacheKey key) {
         return key == null ? null : getSessionMap().get(key);
     }
 
@@ -77,10 +77,10 @@ public class LocalMapCache implements Cache {
 //
 //====================================================================
 
-    private Map<CacheKey, Object> getSessionMap() {
-        Map<CacheKey, Object> map = (Map<CacheKey, Object>) cache.get(uniqueKey);
+    private Map<CacheKey, T> getSessionMap() {
+        Map<CacheKey, T> map = cache.get(uniqueKey);
         if (map == null) {
-            map = new ConcurrentHashMap<CacheKey, Object>(100);
+            map = new ConcurrentHashMap(100);
         }
         return map;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/UserCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/UserCache.java
@@ -17,10 +17,10 @@ import static edu.caltech.ipac.firefly.server.RequestOwner.USER_KEY_EXPIRY;
  * @author loi
  * @version $Id: UserCache.java,v 1.5 2009/03/23 23:55:16 loi Exp $
  */
-public class UserCache extends DistribMapCache {
+public class UserCache<T> extends DistribMapCache<T> {
 
-    public static Cache getInstance(){
-        return new UserCache();
+    public static <T> Cache<T> getInstance(){
+        return new UserCache<>();
     }
 
     private UserCache() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/BaseGator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/BaseGator.java
@@ -33,10 +33,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Arrays;
 import java.util.List;
 
-import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 
 
 /**
@@ -111,7 +111,7 @@ public abstract class BaseGator extends EmbeddedDbProcessor {
             boolean isPost = isPost(req);
             URL url = createURL(req, isPost);
 
-            applyIfNotEmpty(getJob(), v -> v.getJobInfo().setDataOrigin(url.toString()));
+            ifNotNull(getJob()).then( j -> updateJobInfo(j.getJobId(), ji -> ji.setDataOrigin(url.toString())));
 
             if (isPost) {
                 _postBuilder = new MultiPartPostBuilder(url.toString());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -992,7 +992,9 @@ abstract public class BaseDbAdapter implements DbAdapter {
         while (cause != null && cause.getCause() != null) {
             cause = cause.getCause();
         }
-        if (cause instanceof DataAccessException dax) {
+        if (cause instanceof DataAccessException.Aborted aborted) {
+            return aborted;
+        } else if (cause instanceof DataAccessException dax) {
             return new DataAccessException(msg, dax);   // if DataAccessException, then no need to interpret the error message
         }
         return new DataAccessException(msg, new SQLDataException(interpretError(cause)));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -296,9 +296,6 @@ public class EmbeddedDbUtil {
     }
 
     public static void enumeratedValuesCheckBG(DbAdapter dbAdapter, DataGroupPart results, TableServerRequest treq) {
-        RequestOwner owner = ServerContext.getRequestOwner();
-        ServerEvent.EventTarget target = new ServerEvent.EventTarget(ServerEvent.Scope.SELF, owner.getEventConnID(),
-                owner.getEventChannel(), owner.getUserKey());
         SHORT_TASK_EXEC.submit(() -> {
             enumeratedValuesCheck(dbAdapter, results, treq);
             DataGroup updates = new DataGroup(null, results.getData().getDataDefinitions());
@@ -307,7 +304,7 @@ public class EmbeddedDbUtil {
             changes.remove("totalRows");        //changes contains only the columns with 0 rows.. we don't want to update totalRows
 
             FluxAction action = new FluxAction(FluxAction.TBL_UPDATE, changes);
-            ServerEventManager.fireAction(action, target);
+            ServerEventManager.fireAction(action, ServerEvent.Scope.SELF);
         });
     }
     public static void enumeratedValuesCheck(DbAdapter dbAdapter, DataGroupPart results, TableServerRequest treq) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ReplicatedQueueList.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ReplicatedQueueList.java
@@ -10,10 +10,7 @@ import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.cache.StringKey;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author Trey Roby
@@ -22,18 +19,19 @@ class ReplicatedQueueList {
 
    private static final StringKey HOST_NAME= new StringKey(FileUtil.getHostname());
    private static final String REP_QUEUE_MAP = "ReplicatedEventQueueMap";
-   private static Cache getCache() { return CacheManager.getDistributedMap(REP_QUEUE_MAP); }
+   private static Cache<List<ServerEventQueue>> getCache() {
+       return CacheManager.getDistributedMap(REP_QUEUE_MAP);
+   }
 
    synchronized void setQueueListForNode(List<ServerEventQueue> list)  {
-      Cache cache= getCache();
-      cache.put(HOST_NAME, list);
+      getCache().put(HOST_NAME, list);
    }
 
    synchronized List<ServerEventQueue> getCombinedNodeList()  {
        List<ServerEventQueue> retList= new ArrayList<>();
-       Cache cache= getCache();
+       Cache<List<ServerEventQueue>> cache= getCache();
        for(String k : cache.getKeys()) {
-           retList.addAll((List)cache.get(new StringKey(k)));
+           retList.addAll(cache.get(new StringKey(k)));
        }
        return retList;
    }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ReplicatedQueueList.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ReplicatedQueueList.java
@@ -6,6 +6,7 @@
 package edu.caltech.ipac.firefly.server.events;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.cache.Cache;
+import edu.caltech.ipac.util.cache.CacheKey;
 import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.cache.StringKey;
 
@@ -30,8 +31,8 @@ class ReplicatedQueueList {
    synchronized List<ServerEventQueue> getCombinedNodeList()  {
        List<ServerEventQueue> retList= new ArrayList<>();
        Cache<List<ServerEventQueue>> cache= getCache();
-       for(String k : cache.getKeys()) {
-           retList.addAll(cache.get(new StringKey(k)));
+       for(CacheKey k : cache.getKeys()) {
+           retList.addAll(cache.get(k));
        }
        return retList;
    }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/WebsocketConnector.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/WebsocketConnector.java
@@ -182,7 +182,7 @@ public class WebsocketConnector implements ServerEventQueue.EventConnector {
                             if (!l.contains(q.getConnID())) l.add(q.getConnID());
                         });
                 FluxAction action = new FluxAction(type, connInfo);
-                ServerEventManager.fireAction(action, new ServerEvent.EventTarget(ServerEvent.Scope.SELF, seq.getConnID(), null, null));
+                ServerEventManager.fireAction(action, ServerEvent.Scope.SELF);
             }
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
@@ -165,7 +165,7 @@ public final class DownloadScriptWorker implements Job.Worker {
     private void updateJobProgress() throws DataAccessException.Aborted {
         Job job = getJob();
         if (job != null) {
-            JobInfo.Phase phase = ifNotNull(getJobInfo(getJob().getJobId())).eval(JobInfo::getPhase);
+            JobInfo.Phase phase = ifNotNull(getJobInfo(getJob().getJobId())).get(JobInfo::getPhase);
             if (phase == JobInfo.Phase.ABORTED) throw new DataAccessException.Aborted();
             if (System.currentTimeMillis() - lastUpdatedTime > 2000) {
                 lastUpdatedTime = System.currentTimeMillis();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.core.background.JobManager.getJobInfo;
+import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.core.background.ScriptAttributes.*;
 import static edu.caltech.ipac.firefly.server.packagedata.PackagingWorker.makeDownloadUrl;
 import static edu.caltech.ipac.firefly.server.ws.WsServerParams.WS_SERVER_PARAMS.CURRENTRELPATH;
@@ -144,16 +147,17 @@ public final class DownloadScriptWorker implements Job.Worker {
             throw new DataAccessException("Operation aborted:" + dlreq.getRequestId(), new IllegalArgumentException("Unable to resolve a search processor for this request"));
         }
 
-        // JobInfo completion update
-        String summary = String.format("%,d files were processed.", totalFiles);
-        if (hasErrors) summary += "\nPlease, note:  There were error(s) while processing your request.";
-        JobInfo jobInfo = getJob().getJobInfo();
-        jobInfo.setProgress(100);
-        jobInfo.setProgressDesc(summary);
-        jobInfo.setSummary(summary);
+        updateJobInfo(getJob().getJobId(), ji -> {
+            // JobInfo completion update
+            String summary = String.format("%,d files were processed.", totalFiles);
+            if (hasErrors) summary += "\nPlease, note:  There were error(s) while processing your request.";
+            ji.setProgress(100);
+            ji.setProgressDesc(summary);
+            ji.setSummary(summary);
+        });
         getJob().setPhase(JobInfo.Phase.COMPLETED);
 
-        PackagedEmail.send(getJob().getJobInfo());
+        PackagedEmail.send(getJob().getJobId());
 
         return "";
     }
@@ -161,7 +165,7 @@ public final class DownloadScriptWorker implements Job.Worker {
     private void updateJobProgress() throws DataAccessException.Aborted {
         Job job = getJob();
         if (job != null) {
-            JobInfo.Phase phase = job.getJobInfo().getPhase();
+            JobInfo.Phase phase = ifNotNull(getJobInfo(getJob().getJobId())).eval(JobInfo::getPhase);
             if (phase == JobInfo.Phase.ABORTED) throw new DataAccessException.Aborted();
             if (System.currentTimeMillis() - lastUpdatedTime > 2000) {
                 lastUpdatedTime = System.currentTimeMillis();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagedEmail.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagedEmail.java
@@ -9,6 +9,7 @@ package edu.caltech.ipac.firefly.server.packagedata;
  */
 
 
+import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.core.background.ScriptAttributes;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
@@ -59,10 +60,11 @@ public class PackagedEmail {
 
 
     /**
-     * Send an email to the user that his files are ready
-     * @param jobInfo JobInfo
+     * Email the user that his files are ready
+     * @param jobId job id
      */
-    public static void send(JobInfo jobInfo) {
+    public static void send(String jobId) {
+        JobInfo jobInfo = JobManager.getJobInfo(jobId);
         DownloadRequest dlreq = jobInfo.getSrvParams().getDownloadRequest();
         String email = dlreq.getEmail();
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
@@ -146,7 +146,7 @@ public final class PackagingWorker implements Job.Worker {
     private void updateJobProgress() throws DataAccessException.Aborted {
         Job job = getJob();
         if (job != null) {
-            JobInfo.Phase phase = ifNotNull(getJobInfo(job.getJobId())).eval(JobInfo::getPhase);
+            JobInfo.Phase phase = ifNotNull(getJobInfo(job.getJobId())).get(JobInfo::getPhase);
             if (phase == JobInfo.Phase.ABORTED) throw new DataAccessException.Aborted();
 
             if (System.currentTimeMillis() - lastUpdatedTime > 2000) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/GuestHistoryCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/GuestHistoryCache.java
@@ -45,7 +45,7 @@ public class GuestHistoryCache {
     public static void removeSearch(final String userKey, final int... searchIds) {
         boolean needUpdate = false;
         List<SearchInfo> sh = getSearchHistory(userKey);
-        ArrayList<SearchInfo> newSh = new ArrayList<SearchInfo>(sh);
+        ArrayList<SearchInfo> newSh = new ArrayList<>(sh);
         for(int id : searchIds) {
             for (int i=0; i< newSh.size(); i++) {
                 if (newSh.get(i).getQueryID() == id) {
@@ -85,9 +85,9 @@ public class GuestHistoryCache {
     }
 
     public static List<SearchInfo> getSearchHistory(String userKey) {
-        Cache cache = CacheManager.getLocal();
-        List<SearchInfo> searchHistory = (List<SearchInfo>) cache.get(new StringKey("GuestHistoryCache", userKey));
-        return searchHistory == null ? new ArrayList<SearchInfo>() : searchHistory;
+        Cache<List<SearchInfo>> cache = CacheManager.getLocal();
+        List<SearchInfo> searchHistory = cache.get(new StringKey("GuestHistoryCache", userKey));
+        return searchHistory == null ? new ArrayList<>() : searchHistory;
     }
 
     public static List<SearchInfo> getSearchHistory() {
@@ -96,7 +96,7 @@ public class GuestHistoryCache {
     }
 
     static void updateSearchHistory(String userKey, List<SearchInfo> searchHistory) {
-        Cache cache = CacheManager.getLocal();
+        Cache<List<SearchInfo>> cache = CacheManager.getLocal();
         cache.put(new StringKey("GuestHistoryCache", userKey), searchHistory, LIFE_TO_LIVE);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryIBE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryIBE.java
@@ -101,8 +101,8 @@ public class QueryIBE extends EmbeddedDbProcessor {
             IBE ibe = IBEUtils.getIBE(mission, paramMap);
             IbeDataSource source = ibe.getIbeDataSource();
             CacheKey cacheKey = new StringKey("ibemeta", source.getIbeHost(), source.getMission(), source.getDataset(), source.getTableName());
-            Cache cache = CacheManager.getLocal();
-            DataGroup coldefs = (DataGroup) cache.get(cacheKey);
+            Cache<DataGroup> cache = CacheManager.getLocal();
+            DataGroup coldefs = cache.get(cacheKey);
             if (coldefs == null) {
                 File ofile = File.createTempFile(mission+"-dd", ".tbl", QueryUtil.getTempDir(request));
                 ibe.getMetaData(ofile);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
 import static edu.caltech.ipac.table.TableMeta.DESC_TAG;
 import static edu.caltech.ipac.table.TableMeta.makeAttribKey;
@@ -88,7 +89,7 @@ public abstract class QueryVOTABLE extends EmbeddedDbProcessor {
     private File getSearchResult(TableServerRequest req) throws IOException, DataAccessException, EndUserException {
         String urlQuery = getQueryString(req);
 
-        jobExecIf(v -> v.getJobInfo().setDataOrigin(urlQuery));
+        jobExecIf(v -> updateJobInfo(v.getJobId(), ji -> ji.setDataOrigin(urlQuery)));
 
         URL url;
         try {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/BaseFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/BaseFileInfoProcessor.java
@@ -18,6 +18,8 @@ import edu.caltech.ipac.util.cache.StringKey;
 import java.io.IOException;
 import java.util.List;
 
+import static edu.caltech.ipac.util.cache.Cache.fileInfoCheck;
+
 
 /**
  * Date: Mar 8, 2010
@@ -32,10 +34,10 @@ public abstract class BaseFileInfoProcessor implements SearchProcessor<FileInfo>
     public FileInfo getData(ServerRequest request) throws DataAccessException {
         try {
             FileInfo fi = null;
-            Cache cache = getCache(request);
+            Cache<FileInfo> cache = getCache(request);
             StringKey key = new StringKey(getClass().getName(), getUniqueID(request));
             if (doCache()) {
-                fi = cache != null ? (FileInfo) cache.get(key) : null;
+                fi = cache != null ? cache.get(key) : null;
             }
             if (fi == null) {
                 fi = loadData(request);
@@ -52,8 +54,8 @@ public abstract class BaseFileInfoProcessor implements SearchProcessor<FileInfo>
         }
     }
 
-    public Cache getCache(ServerRequest request) {
-        return CacheManager.getLocal();
+    public Cache<FileInfo> getCache(ServerRequest request) {
+        return CacheManager.<FileInfo>getLocal().validateOnGet(fileInfoCheck);
     }
 
     public QueryDescResolver getDescResolver() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -570,7 +570,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     protected void jobExecIf(Consumer<Job> f) throws DataAccessException {
         Job job = getJob();
         if (job != null) {
-            JobInfo.Phase phase = ifNotNull(getJobInfo(job.getJobId())).eval(JobInfo::getPhase);
+            JobInfo.Phase phase = ifNotNull(getJobInfo(job.getJobId())).get(JobInfo::getPhase);
             if (phase == JobInfo.Phase.EXECUTING) f.accept(job);
             if (phase == JobInfo.Phase.ABORTED) throw new DataAccessException.Aborted();
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -47,6 +47,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.core.background.JobManager.getJobInfo;
+import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.data.table.MetaConst.HIGHLIGHTED_ROW;
 import static edu.caltech.ipac.firefly.data.table.MetaConst.HIGHLIGHTED_ROW_BY_ROWIDX;
 import static edu.caltech.ipac.firefly.server.db.DbAdapter.*;
@@ -164,7 +167,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
 
             results.getData().getTableMeta().setAttribute(DataGroupPart.LOADING_STATUS, DataGroupPart.State.COMPLETED.name());
 
-            jobExecIf(v -> v.getJobInfo().setSummary(String.format("%,d rows found", totalRows)));
+            jobExecIf(j -> updateJobInfo(j.getJobId(), ji -> ji.setSummary(String.format("%,d rows found", totalRows))));
 
             return results;
         }catch (Exception e) {
@@ -567,7 +570,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     protected void jobExecIf(Consumer<Job> f) throws DataAccessException {
         Job job = getJob();
         if (job != null) {
-            JobInfo.Phase phase = job.getJobInfo().getPhase();
+            JobInfo.Phase phase = ifNotNull(getJobInfo(job.getJobId())).eval(JobInfo::getPhase);
             if (phase == JobInfo.Phase.EXECUTING) f.accept(job);
             if (phase == JobInfo.Phase.ABORTED) throw new DataAccessException.Aborted();
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/FileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/FileGroupsProcessor.java
@@ -41,8 +41,8 @@ abstract public class FileGroupsProcessor implements SearchProcessor<List<FileGr
             DownloadRequest request= (DownloadRequest)sr;
             List<FileGroup> fileGroups = null;
             StringKey key = new StringKey(FileGroupsProcessor.class.getName(), getUniqueID(request));
-            Cache cache = CacheManager.getLocalFile();
-            fileGroups = (List<FileGroup>) cache.get(key);
+            Cache<List<FileGroup>> cache = CacheManager.getLocal();
+            fileGroups = cache.get(key);
 
             if (fileGroups == null || isStaled(fileGroups)) {
                 fileGroups = loadData(request);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/JsonStringProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/JsonStringProcessor.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.FF_SESSION_ID;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
+import static edu.caltech.ipac.util.cache.Cache.fileCheck;
 
 
 /**
@@ -108,7 +109,7 @@ abstract public class JsonStringProcessor implements SearchProcessor<String> {
             try {
                 jsonFile = File.createTempFile("tmp-", ".json", QueryUtil.getTempDir());
                 FileUtil.writeStringToFile(jsonFile, results);
-                CacheManager.getLocalFile()
+                CacheManager.getLocal()
                         .put(new StringKey(getUniqueID(request)), jsonFile);
             } catch (IOException e) {
                 LOGGER.error("Cannot create temp file: " + e.getMessage());
@@ -117,8 +118,8 @@ abstract public class JsonStringProcessor implements SearchProcessor<String> {
     }
 
     protected String getCachedData(ServerRequest request) {
-        Cache cache = CacheManager.getLocalFile();
-        File jsonFile = (File)cache.get(new StringKey(getUniqueID(request)));
+        Cache<File> cache = CacheManager.<File>getLocal().validateOnGet(fileCheck);
+        File jsonFile = cache.get(new StringKey(getUniqueID(request)));
         if (jsonFile != null) {
             try {
                 return FileUtil.readFile(jsonFile);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
@@ -12,6 +12,7 @@ package edu.caltech.ipac.firefly.server.query;
 import edu.caltech.ipac.firefly.core.background.Job;
 import edu.caltech.ipac.firefly.core.background.JobInfo;
 import edu.caltech.ipac.firefly.core.background.JobManager;
+import edu.caltech.ipac.firefly.core.background.JobUtil;
 import edu.caltech.ipac.firefly.core.background.ScriptAttributes;
 import edu.caltech.ipac.firefly.core.background.ServCmdJob;
 import edu.caltech.ipac.firefly.data.ServerEvent;
@@ -66,7 +67,7 @@ public class SearchServerCommands {
 
     public static class TableSearch extends ServCmdJob {
         public Job.Type getType() {
-            JobInfo jInfo = getJobInfo();
+            JobInfo jInfo = JobManager.getJobInfo(getJobId());
             Type type = jInfo == null || jInfo.getType() == null ? Type.SEARCH : jInfo.getType();
             return type;
         }
@@ -298,7 +299,7 @@ public class SearchServerCommands {
         public String doCommand(SrvParam params) throws Exception {
             String jobId = params.getRequired(JOB_ID);
             JobInfo info = JobManager.setMonitored(jobId, true);
-            return JobManager.toJson(info);
+            return JobUtil.toJson(info);
         }
     }
 
@@ -307,7 +308,7 @@ public class SearchServerCommands {
         public String doCommand(SrvParam params) throws Exception {
             String jobId = params.getRequired(JOB_ID);
             JobInfo info = JobManager.setMonitored(jobId, false);
-            return JobManager.toJson(info);
+            return JobUtil.toJson(info);
         }
     }
 
@@ -316,7 +317,7 @@ public class SearchServerCommands {
         public String doCommand(SrvParam params) throws Exception {
             String jobId = params.getRequired(JOB_ID);
             JobInfo info = JobManager.abort(jobId, "Aborted by user");
-            return JobManager.toJson(info);
+            return JobUtil.toJson(info);
         }
     }
 
@@ -348,8 +349,8 @@ public class SearchServerCommands {
                 applyIfNotEmpty(local.getLocalRunId(), uws::setLocalRunId);
             }
 
-            if (uws != null) return JobManager.toJson(uws);
-            return local != null ? JobManager.toJson(local) : null;
+            if (uws != null) return JobUtil.toJson(uws);
+            return local != null ? JobUtil.toJson(local) : null;
         }
     }
 
@@ -359,7 +360,7 @@ public class SearchServerCommands {
             String id = params.getRequired(JOB_ID);
             String email = params.getOptional(EMAIL);
             JobInfo info = JobManager.sendEmail(id, email);
-            return JobManager.toJson(info);
+            return JobUtil.toJson(info);
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/security/OidcAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/security/OidcAdapter.java
@@ -131,8 +131,8 @@ public class OidcAdapter implements SsoAdapter {
     }
 
     public void clearAuthInfo() {
-        CacheManager.getSessionCache().put(new StringKey(AUTH_TOKEN_KEY), null);
-        CacheManager.getSessionCache().put(new StringKey(USER_INFO_KEY), null);
+        CacheManager.getSessionCache().remove(new StringKey(AUTH_TOKEN_KEY));
+        CacheManager.getSessionCache().remove(new StringKey(USER_INFO_KEY));
     }
 
     public Map<String, String> getIdentities() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/MultipartDataUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/MultipartDataUtil.java
@@ -11,7 +11,6 @@ package edu.caltech.ipac.firefly.server.servlets;
 
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.multipart.MultiPartData;
-import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.cache.StringKey;
 import org.apache.commons.fileupload.FileItem;
@@ -63,7 +62,7 @@ public class MultipartDataUtil {
                 item.write(uf);
                 data.addFile(fieldName, uf, fileName, contentType);
                 StringKey fileKey= new StringKey(fileName, System.currentTimeMillis());
-                CacheManager.getLocalFile().put(fileKey, uf);
+                CacheManager.getLocal().put(fileKey, uf);
             }
         }
         return data;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static edu.caltech.ipac.firefly.core.background.JobUtil.jobIdToDir;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.FF_SESSION_ID;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_ID;
 import static edu.caltech.ipac.firefly.visualize.WebPlotRequest.URL_CHECK_FOR_NEWER;
@@ -101,8 +102,14 @@ public class QueryUtil {
      * @return
      */
     public static File getTempDir(TableServerRequest tsr) {
-        File rootDir = tsr == null || tsr.getJobId() == null ? ServerContext.getTempWorkDir() : ServerContext.getPermWorkDir();
-        File tempDir = new File(rootDir, getSessPrefix(tsr));
+        if (tsr == null) { return new File(ServerContext.getTempWorkDir(), "bad-requests");}
+        File tempDir;
+        if (tsr.getJobId() != null) {
+            var baseDir = new File(ServerContext.getStageWorkDir(), "jobs");
+            tempDir = new File(baseDir, jobIdToDir(tsr.getJobId()));
+        } else {
+            tempDir = new File(ServerContext.getTempWorkDir(), getSessPrefix(tsr));
+        }
         if (!tempDir.exists()) tempDir.mkdirs();
         return tempDir;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/FitsCacher.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/FitsCacher.java
@@ -120,7 +120,7 @@ public class FitsCacher {
 
     private static void prepareCacheSpace(FileInfo fitsFileInfo) {
         memCache.put(fitsFileInfo, (HasSizeOf) () -> fitsFileInfo.getFile().length()); //force the cache to make space
-        memCache.put(fitsFileInfo, null);
+        memCache.remove(fitsFileInfo);
     }
 
     private static void logTime(FileInfo fitsFileInfo, long time) {
@@ -151,7 +151,7 @@ public class FitsCacher {
             return fitsDataInfo;
         }
         else {
-            memCache.put(key,null);
+            memCache.remove(key);
             return null;
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -199,7 +199,7 @@ public class VisServerOps {
             data= (StretchDataInfo)memCache.get(stretchDataKey);
             String fromCache= "";
             if (data!=null && data.isRangeValuesMatching(state) && data.findMostCompressAry(ct)!=null) {
-                if (ct==CompressType.FULL || ct==CompressType.HALF) memCache.put(stretchDataKey, null); // this the two types then this is the last time we need this data
+                if (ct==CompressType.FULL || ct==CompressType.HALF) memCache.remove(stretchDataKey); // this the two types then this is the last time we need this data
                 fromCache= " (from Cache)";
             }
             else {

--- a/src/firefly/java/edu/caltech/ipac/util/cache/Cache.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/Cache.java
@@ -3,7 +3,11 @@
  */
 package edu.caltech.ipac.util.cache;
 
+import edu.caltech.ipac.firefly.data.FileInfo;
+
+import java.io.File;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Date: Jul 7, 2008
@@ -11,11 +15,11 @@ import java.util.List;
  * @author loi
  * @version $Id: Cache.java,v 1.4 2009/06/23 18:57:17 loi Exp $
  */
-public interface Cache {
+public interface Cache<T> {
 
-    void put(CacheKey key, Object value);
-    void put(CacheKey key, Object value, int lifespanInSecs);
-    Object get(CacheKey key);
+    void put(CacheKey key, T value);
+    void put(CacheKey key, T value, int lifespanInSecs);
+    T get(CacheKey key);
     boolean isCached(CacheKey key);
     int getSize();
 
@@ -25,8 +29,21 @@ public interface Cache {
      */
     List<String> getKeys();
 
+    /**
+     * Set a get validator for this cache.  The validator will be called before returning the value from the cache.
+     * If the value failed the validation, it will be removed from the cache and null will be returned.
+     * @return this cache
+     */
+    default Cache<T> validateOnGet(Predicate<T> validator) {return this;}
 
     interface Provider {
-        Cache getCache(String type);
+        <T> Cache<T> getCache(String type);
     }
+
+//====================================================================
+//  Predefined validators
+//====================================================================
+    Predicate<File> fileCheck = (f) -> f.canRead();
+    Predicate<FileInfo> fileInfoCheck = (fi) -> fi.getFile() != null && fi.getFile().canRead();
+
 }

--- a/src/firefly/java/edu/caltech/ipac/util/cache/Cache.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/Cache.java
@@ -20,6 +20,7 @@ public interface Cache<T> {
     void put(CacheKey key, T value);
     void put(CacheKey key, T value, int lifespanInSecs);
     T get(CacheKey key);
+    void remove(CacheKey key);
     boolean isCached(CacheKey key);
     int getSize();
 
@@ -27,7 +28,7 @@ public interface Cache<T> {
      * returns a list of keys in this cache as string.
      * @return
      */
-    List<String> getKeys();
+    List<? extends CacheKey> getKeys();
 
     /**
      * Set a get validator for this cache.  The validator will be called before returning the value from the cache.
@@ -43,7 +44,7 @@ public interface Cache<T> {
 //====================================================================
 //  Predefined validators
 //====================================================================
-    Predicate<File> fileCheck = (f) -> f.canRead();
+    Predicate<File> fileCheck = File::canRead;
     Predicate<FileInfo> fileInfoCheck = (fi) -> fi.getFile() != null && fi.getFile().canRead();
 
 }

--- a/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
@@ -32,7 +32,7 @@ public class CacheManager {
      * Same as {@code getLocal}.
      * @return A Cache that represents the local cache, backed by both memory and disk overflow.
      */
-    public static Cache getCache() {
+    public static <T> Cache<T> getCache() {
         return getLocal();
     }
 
@@ -40,24 +40,15 @@ public class CacheManager {
      * Returns a local cache backed by Ehcache. The cache uses both in-memory storage and overflow to disk.
      * @return A Cache that represents the local cache, backed by both memory and disk overflow.
      */
-    public static Cache getLocal() {
+    public static <T> Cache<T> getLocal() {
         return getCacheProvider().getCache(PERM_SMALL);
-    }
-
-    /**
-     * A variant of {@code getLocal}, specifically designed with convenience features for handling
-     * File and FileInfo objects.
-     * @return A Cache tailored for File and FileInfo objects
-     */
-    public static Cache getLocalFile() {
-        return new FileCache(getCacheProvider().getCache(PERM_SMALL));
     }
 
     /**
      * A cache specifically designed for image visualization purposes.
      * @return A Cache optimized for storing and accessing image data.
      */
-    public static Cache getVisMemCache() {
+    public static <T> Cache<T> getVisMemCache() {
         return getCacheProvider().getCache(VIS_SHARED_MEM);
     }
 
@@ -66,17 +57,8 @@ public class CacheManager {
      * different instances in a distributed environment.
      * @return A Cache instance for distributed environments.
      */
-    public static Cache getDistributed() {
-        return new DistributedCache();
-    }
-
-    /**
-     * A variant of {@code getDistributed}, specifically designed with convenience features for handling
-     * File and FileInfo objects.
-     * @return A Cache tailored for File and FileInfo objects in a distributed environment
-     */
-    public static Cache getDistributedFile() {
-        return new FileCache(new DistributedCache());
+    public static <T> Cache<T> getDistributed() {
+        return new DistributedCache<T>();
     }
 
     /**
@@ -85,7 +67,7 @@ public class CacheManager {
      * of data that is specific to a user's session.
      * @return A Cache instance for session-specific data storage.
      */
-    public static Cache getSessionCache() {
+    public static <T> Cache<T> getSessionCache() {
         return getLocalMap(ServerContext.getRequestOwner().getRequestAgent().getSessId());
     }
 
@@ -95,7 +77,7 @@ public class CacheManager {
      * stored in a cookie, which allows user data to persist across multiple sessions.
      * @return A distributed Cache instance for storing user-related information with persistence across sessions.
      */
-    public static Cache getUserCache() {
+    public static <T> Cache<T> getUserCache() {
         return UserCache.getInstance();
     }
 
@@ -104,8 +86,8 @@ public class CacheManager {
      * @param mapKey The unique key associated with the cache.
      * @return A Cache instance specifically for the data associated with the provided map key.
      */
-    public static Cache getLocalMap(String mapKey) {
-        return new LocalMapCache(mapKey);
+    public static <T> Cache<T> getLocalMap(String mapKey) {
+        return new LocalMapCache<>(mapKey);
     }
 
     /**
@@ -113,8 +95,8 @@ public class CacheManager {
      * @param mapKey The unique key used to identify and access the data in the distributed cache.
      * @return A Cache instance specifically for the data associated with the provided map key in the distributed environment.
      */
-    public static Cache getDistributedMap(String mapKey) {
-        return new DistribMapCache(mapKey);
+    public static <T> Cache<T> getDistributedMap(String mapKey) {
+        return new DistribMapCache<>(mapKey);
     }
 
 //====================================================================

--- a/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
@@ -153,6 +153,8 @@ public class CacheManager {
             return null;
         }
 
+        public void remove(CacheKey key) {}
+
         public boolean isCached(CacheKey key) {
             return false;
         }

--- a/src/firefly/java/edu/caltech/ipac/util/cache/StringKey.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/StringKey.java
@@ -23,7 +23,7 @@ public class StringKey implements CacheKey, Comparable, Serializable {
     }
 
     public String getUniqueString() {
-        return key.toString();
+        return key;
     }
 
     public StringKey appendToKey(Object... ids) {

--- a/src/firefly/java/edu/caltech/ipac/util/download/CacheHelper.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/CacheHelper.java
@@ -10,6 +10,8 @@ import edu.caltech.ipac.util.cache.CacheManager;
 
 import java.io.File;
 
+import static edu.caltech.ipac.util.cache.Cache.fileInfoCheck;
+
 /**
  * This class is provides an interface for classes that use both server and client cache.  One will use one when running
  * on the server and the other when running as a client.
@@ -18,7 +20,7 @@ import java.io.File;
 public class CacheHelper {
 
     private static File    _cacheDir= null;
-    private final static Cache fileCache= CacheManager.getDistributedFile();
+    private final static Cache<FileInfo> fileCache = CacheManager.<FileInfo>getDistributed().validateOnGet(fileInfoCheck);
     public static void setCacheDir(File dir) { _cacheDir= dir; }
 
     public static File makeFitsFile(BaseNetParams params) { return makeFile(params.getUniqueString()+ ".fits"); }
@@ -34,8 +36,7 @@ public class CacheHelper {
 
     public static FileInfo getFileInfo(CacheKey key)   {
         try {
-            Object cacheObj= fileCache.get(key);
-            return (cacheObj instanceof FileInfo) ? (FileInfo)cacheObj : null;
+            return fileCache.get(key);
         } catch (Exception e) {
             try {
                 fileCache.put(key,null); // clean out the bad entry

--- a/src/firefly/java/edu/caltech/ipac/util/download/CacheHelper.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/CacheHelper.java
@@ -39,7 +39,7 @@ public class CacheHelper {
             return fileCache.get(key);
         } catch (Exception e) {
             try {
-                fileCache.put(key,null); // clean out the bad entry
+                fileCache.remove(key); // clean out the bad entry
             } catch (Exception ignore) {}
             return null;
         }

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
@@ -5,11 +5,10 @@ package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.core.background.JobInfo;
-import edu.caltech.ipac.firefly.core.background.JobManager;
+import edu.caltech.ipac.firefly.core.background.JobUtil;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.messaging.JsonHelper;
 import edu.caltech.ipac.table.DataGroup;
-import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -78,7 +77,7 @@ public class AsyncTapQueryTest extends ConfigTest {
 			Assert.assertNotNull(jobUrl);
 
 			JobInfo jobInfo = AsyncTapQuery.getUwsJobInfo(jobUrl);
-			JsonHelper json = JsonHelper.parse(JobManager.toJsonObject(jobInfo).toJSONString());
+			JsonHelper json = JsonHelper.parse(JobUtil.toJsonObject(jobInfo).toJSONString());
 
 			Assert.assertNotNull("has jobInfo", jobInfo);
 			Assert.assertNotNull("has jobId", json.getValue(null, "jobId"));


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1610

Additional changes here: https://github.com/IPAC-SW/irsa-ife/pull/378

Summary of Changes:
- Moved JobInfo ito Redis
- Refactored JobManager
- Replaced cache messaging with Redis Pub/Sub
- Fixed code so that it functions correctly in a clustered, distributed environment 
- Also, replaced FileCache with a more generic validator approach to support a wider range of use cases.

Test: https://fireflydev.ipac.caltech.edu/firefly-1610-job-storage-redis/firefly/
This is deployed with 3 relicas.  Test using multiple windows including private ones to ensure they worked properly in both cases.

Also built https://firefly-1610-job-storage-redis.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA with one replica for regression tests.