### PR TITLE
Firefly-441: provide target panel example config and make example clickable

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/ibe/IBE.java
@@ -153,7 +153,7 @@ public class IBE {
 
             HttpServiceInput addtlInfo = HttpServiceInput.createWithCredential(url.toString());
 
-            return URLFileInfoProcessor.retrieveViaURL(url, dir, progressKey, plotId, null, addtlInfo);
+            return URLFileInfoProcessor.retrieveViaURL(url, dir, progressKey, plotId, addtlInfo);
         } catch (DataAccessException e) {
             throw new IOException(e.getMessage(), e);
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -139,8 +139,8 @@ public class AppServerCommands {
     }
 
 
-    private static final String STRING_START="::STRING::";
-    private static final int SS_OFFSET= STRING_START.length();
+//    private static final String STRING_START="::STRING::";
+//    private static final int SS_OFFSET= STRING_START.length();
     private static final String HELP_BASE_URL = "help.base.url";
     private static final String OP_ROOT = "OP_";
     private static final String EMPTY_APP_PROP = "{}";
@@ -174,13 +174,13 @@ public class AppServerCommands {
     private static void setToJson(JsonHelper jhelp, String key, String valStr) {
         if (key.length()<=OP_ROOT_LENGTH) return;
         Object val;
-        if (valStr.startsWith(STRING_START)) {
-            val= valStr.substring(SS_OFFSET).replaceAll("_", " ");
-        }
-        else {
+//        if (valStr.startsWith(STRING_START)) {
+//            val= valStr.substring(SS_OFFSET).replaceAll("_", " ");
+//        }
+//        else {
             double num= getDouble(valStr);
             val= Double.isNaN(num) ? valStr : num;
-        }
+//        }
         jhelp.setValueFromPath(val,key.substring(OP_ROOT_LENGTH),"_");
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/URLFileInfoProcessor.java
@@ -3,14 +3,13 @@
  */
 package edu.caltech.ipac.firefly.server.query;
 
+import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
-import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.visualize.LockingVisNetwork;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.util.FileUtil;
-import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.visualize.net.AnyUrlParams;
 
@@ -18,8 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Map;
 
 
 /**
@@ -42,7 +39,7 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
         }
 
 
-        return retrieveViaURL(url,null,progressKey,plotId,getFileExtension(),addtlInfo );
+        return retrieveViaURL(url,null,progressKey,plotId,addtlInfo );
 
     }
 
@@ -50,15 +47,12 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
         return true;
     }
 
-    public String getFileExtension()  { return ""; }
-
     public abstract URL getURL(ServerRequest sr) throws MalformedURLException;
 
     public static FileInfo retrieveViaURL(URL url,
                                           File dir,
                                           String progressKey,
                                           String plotId,
-                                          String fileExtension,
                                           HttpServiceInput addtlInfo)
                                                  throws IOException, DataAccessException {
         FileInfo retval= null;
@@ -67,9 +61,6 @@ abstract public class URLFileInfoProcessor extends BaseFileInfoProcessor {
 
             AnyUrlParams params = new AnyUrlParams(url,progressKey,plotId);
             if (dir!=null) params.setFileDir(dir);
-            if (!StringUtils.isEmpty(fileExtension)) {
-                params.setLocalFileExtensions(Arrays.asList(fileExtension));
-            }
 
             if (addtlInfo != null) {
                 params.setAddtlInfo(addtlInfo);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/LockingVisNetwork.java
@@ -48,7 +48,6 @@ public class LockingVisNetwork {
 
     public static FileInfo retrieveURL(URL url) throws FailedRequestException {
         AnyUrlParams p= new AnyUrlParams(url, url.toString(),null);
-        p.setLocalFileExtensions(Collections.singletonList(FileUtil.FITS));
         return retrieveURL(p);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/AllSkyRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/AllSkyRetriever.java
@@ -10,13 +10,11 @@ package edu.caltech.ipac.firefly.server.visualize.imageretrieve;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.server.visualize.LockingVisNetwork;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
-import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.visualize.net.AnyUrlParams;
 import edu.caltech.ipac.visualize.plot.plotdata.GeomException;
 
 import java.net.URL;
-import java.util.Collections;
 /**
  * User: roby
  * Date: Feb 26, 2010
@@ -52,7 +50,6 @@ public class AllSkyRetriever implements FileRetriever {
         try {
             URL url= this.getClass().getClassLoader().getResource(urlStr);
             AnyUrlParams p= new AnyUrlParams(url);
-            p.setLocalFileExtensions(Collections.singletonList(FileUtil.FITS));
             fitsFileInfo= LockingVisNetwork.retrieveURL(p);
         }  catch (FailedRequestException e) {
             throw e;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URLFileRetriever.java
@@ -15,7 +15,6 @@ import edu.caltech.ipac.firefly.server.visualize.PlotServUtils;
 import edu.caltech.ipac.firefly.server.visualize.ProgressStat;
 import edu.caltech.ipac.firefly.server.visualize.VisContext;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
-import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.util.download.ResponseMessage;
 import edu.caltech.ipac.visualize.net.AnyUrlParams;
@@ -24,8 +23,6 @@ import edu.caltech.ipac.visualize.plot.plotdata.GeomException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
@@ -44,8 +41,6 @@ public class URLFileRetriever implements FileRetriever {
 
     public static final long EXPIRE_IN_SEC = 60 * 60 * 4; // 4 hours
     public static final String FITS = "fits";
-    private static List<String> extsList=
-            Arrays.asList(FileUtil.FITS, FileUtil.GZ, "tar", FileUtil.PDF, "votable", "tbl", "csv", "tsv");
 
     public FileInfo getFile(WebPlotRequest request) throws FailedRequestException, GeomException, SecurityException {
        return getFile(request,true);
@@ -81,7 +76,6 @@ public class URLFileRetriever implements FileRetriever {
                 }
             }
             params.setCheckForNewer(request.getUrlCheckForNewer());
-            params.setLocalFileExtensions(extsList);
             params.setMaxSizeToDownload(VisContext.FITS_MAX_SIZE);
             if (request.getUserDesc() != null) params.setDesc(request.getUserDesc()); // set file description
 

--- a/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
@@ -51,6 +51,7 @@ public class FileUtil
     public final static String PS   = "ps";
     public final static String PDF  = "pdf";
     public final static String HTML = "html";
+    public final static String XML = "xml";
     public final static String AOR  = "aor";
     public final static String TXT  = "txt";
     public final static String TGT  = "tgt";
@@ -58,11 +59,15 @@ public class FileUtil
     public final static String TBL  = "tbl";
     public final static String NL   = "nl";
     public final static String JAR   = "jar";
+    public final static String TAR   = "tar";
     public final static String CSH   = "csh";
     public final static String SH   = "sh";
     public final static String PL   = "pl";
     public final static String SO   = "so";
     public final static String REG  = "reg";
+    public final static String CSV  = "csv";
+    public final static String TSV  = "tsv";
+    public final static String VOT  = "vot";
 
     public static final long MEG          = 1048576;
     public static final long GIG          = 1048576 * 1024;

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
@@ -9,18 +9,25 @@ import edu.caltech.ipac.util.download.BaseNetParams;
 
 import java.io.File;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class AnyUrlParams extends BaseNetParams {
+    public static List<String> DEF_EXT_LIST=
+            Arrays.asList(
+                    "ul", FileUtil.FITS, FileUtil.GZ, FileUtil.TAR, FileUtil.PDF, FileUtil.GZ, FileUtil.REG,
+                    "votable", FileUtil.VOT, FileUtil.XML, FileUtil.TBL, FileUtil.CSV, FileUtil.TSV,
+                    FileUtil.jpeg, FileUtil.jpg, FileUtil.png, FileUtil.bmp, FileUtil.gif, FileUtil.tiff, FileUtil.tif);
+
     private final static int MAX_LENGTH = 30;
     private final URL _url;
     private final Map<String,String> cookies= new HashMap<>();
     private String _loginName= null;
     private String _securityCookie= null;
     private boolean _checkForNewer= false;
-    private List<String> _localFileExtensions = null;
+    private final List<String> _localFileExtensions = DEF_EXT_LIST;
     private String _desc = null;
     private File _dir = null; // if null, the use the default dir
     private long _maxSizeToDownload= 0L;
@@ -77,16 +84,9 @@ public class AnyUrlParams extends BaseNetParams {
         }
         //note: "=","," signs causes problem in download servlet.
         retval = retval.replaceAll("[ :\\[\\]\\/\\\\|\\*\\?<>\\=\\,]","\\-");
-        if (_localFileExtensions!=null) {
-            String ext= FileUtil.getExtension(fileStr);
-            if (_localFileExtensions.contains(ext)) {
-                retval = retval + "." + ext;
-            }
-            else {
-                retval = retval + "." + _localFileExtensions.get(0);
-            }
-        }
-        return retval;
+        String ext= FileUtil.getExtension(fileStr);
+        var fileExt= _localFileExtensions.contains(ext) ? ext : _localFileExtensions.getFirst();
+        return retval + "." + fileExt;
     }
 
     public void setLoginName(String name) { _loginName= name; }
@@ -111,20 +111,6 @@ public class AnyUrlParams extends BaseNetParams {
         if (addtlInfo != null && addtlInfo.getCookies() != null) retval.putAll(addtlInfo.getCookies());
         return retval;
     }
-
-    public String getAllCookiesAsString() {
-        if (cookies.size()==0) return null;
-        StringBuilder sb= new StringBuilder(200);
-        for(Map.Entry<String,String> entry : cookies.entrySet()) {
-            if (sb.length()>0) sb.append("; ");
-            sb.append(entry.getKey());
-            sb.append("=");
-            sb.append(entry.getValue());
-        }
-        return sb.toString();
-    }
-
-    public void setLocalFileExtensions(List<String> extList) { _localFileExtensions = extList; }
 
     public void setDesc(String desc) { _desc = desc; }
     public String getDesc() { return _desc; }

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -199,6 +199,14 @@ const defFireflyOptions = {
     tapObsCore: {
         enableObsCoreDownload: true,
         // debug: true,
+        // todo BEGIN- remove these lines after testing
+        targetPanelExampleRow1: ['11, 11', '22.2 -33.3', '4h11m59s -32d51m59s equ j2000', '0 0 gal'],
+        targetPanelExampleRow2: ['5h55m55s -55d55m55s equ j2000'],
+        IRSA: {
+            targetPanelExampleRow1: ['55, 66', '5 -6', '4h11m59s -32d51m59s equ j2000', '5 6 gal'],
+            targetPanelExampleRow2: ['1h11m11s -22d22m22s equ j2000'],
+        }
+        // todo END- remove these lines after testing
     },
     coverage : {
         // TODO: need to define all options with defaults here.  used in FFEntryPoint.js
@@ -225,7 +233,7 @@ const defFireflyOptions = {
     SIAv2 : {
         services: getSIAv2Services( ['IRSA', 'CADC', ]),
         defaultMaxrec: 50000
-    }
+    },
 };
 
 

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -199,14 +199,6 @@ const defFireflyOptions = {
     tapObsCore: {
         enableObsCoreDownload: true,
         // debug: true,
-        // todo BEGIN- remove these lines after testing
-        targetPanelExampleRow1: ['11, 11', '22.2 -33.3', '4h11m59s -32d51m59s equ j2000', '0 0 gal'],
-        targetPanelExampleRow2: ['5h55m55s -55d55m55s equ j2000'],
-        IRSA: {
-            targetPanelExampleRow1: ['55, 66', '5 -6', '4h11m59s -32d51m59s equ j2000', '5 6 gal'],
-            targetPanelExampleRow2: ['1h11m11s -22d22m22s equ j2000'],
-        }
-        // todo END- remove these lines after testing
     },
     coverage : {
         // TODO: need to define all options with defaults here.  used in FFEntryPoint.js

--- a/src/firefly/js/api/webApiCommands/TableCommands.js
+++ b/src/firefly/js/api/webApiCommands/TableCommands.js
@@ -48,9 +48,6 @@ const boolKeys=[ 'selectable' , 'showTitle', 'removable', 'showUnits', 'showFilt
 
 
 function validateTable(params) {
-    // if (isEmpty(params)) {
-    //     return {valid:false,msg:`url contains unsupported params: ${badParams?badParams.join():''}`,badParams};
-    // }
     if (!params.source) {
         return {valid:false,msg:'the source parameter is required'};
     }

--- a/src/firefly/js/api/webApiCommands/TableCommands.js
+++ b/src/firefly/js/api/webApiCommands/TableCommands.js
@@ -1,3 +1,5 @@
+import {dispatchHideDropDown} from '../../core/LayoutCntlr';
+import {toBoolean} from '../ApiUtil';
 import {findExtraParams, makeExamples} from '../WebApi';
 import {isEmpty} from 'lodash';
 import {makeFileRequest} from '../../tables/TableRequestUtil';
@@ -8,10 +10,11 @@ import {dispatchTableSearch} from '../../tables/TablesCntlr';
 
 const tableOverview= {
     overview: [
-        'Load table to firefly'
+        'Load table to firefly, any parameters not listed below will be used as table metadata'
     ],
     parameters: {
         source: 'URL of the table - true/false',
+        title: 'title of the table',
         showTitle : 'show the title - true/false',
         selectable : 'table is selectable - true/false',
         removable: 'table is removable - true/false',
@@ -23,18 +26,31 @@ const tableOverview= {
     },
 };
 const tableExamples= [
-    {desc:'Load A Table', params:{source: 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl'}}
+    {desc:'Load A Table, set title to "a table"',
+        params: {
+            source: 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',
+            title: 'a table'
+        }
+    },
+    {desc:'Load A Table.  Use meta data to set subHighlight on column "scangrp" and rename band column to "My Band". Set ShowFilter to false',
+        params: {
+            source: 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl',
+            showFilters: false,
+            'tbl.relatedCols': 'scangrp',
+            'col.band.label': 'My Band',
+        }
+    }
 ];
 
 
+const boolKeys=[ 'selectable' , 'showTitle', 'removable', 'showUnits', 'showFilters', 'showToolbar', 'showPaging'];
 
 
 
 function validateTable(params) {
-    const badParams= findExtraParams(Object.keys(tableOverview.parameters),params);
-    if (!isEmpty(badParams) || isEmpty(params)) {
-        return {valid:false,msg:`url contains unsupported params: ${badParams?badParams.join():''}`,badParams};
-    }
+    // if (isEmpty(params)) {
+    //     return {valid:false,msg:`url contains unsupported params: ${badParams?badParams.join():''}`,badParams};
+    // }
     if (!params.source) {
         return {valid:false,msg:'the source parameter is required'};
     }
@@ -45,11 +61,26 @@ const tableRootStr= 'API_tableId';
 let nextId= 1;
 
 function showTable(cmd,params) {
-    const {title='', source, ...rest}= params;
-    const options= {tbl_id: `${tableRootStr}${nextId++}`, startIdx:0, ...rest};
+    setTimeout(() => {
+        // const extraParams= findExtraParams(Object.keys(tableOverview.parameters),params);
+        const metaKeys= findExtraParams(Object.keys(tableOverview.parameters),params);
+        const primeAry= Object
+            .entries(params)
+            .filter( ([k,v]) => !metaKeys.includes(k))
+            .map( ([k,v]) =>
+                boolKeys.includes(k) ? [k,v?toBoolean(v,false,['true','t']):true] : [k,v] );
 
-    const dataTableReq= makeFileRequest(title, source, undefined,options);
-    dispatchTableSearch(dataTableReq,options);
+        const primeParams= Object.fromEntries(primeAry);
+
+        const metaParams= Object.fromEntries(Object.entries(params).filter( ([k,v]) => metaKeys.includes(k) ));
+
+
+        const {title='', source, ...rest}= primeParams;
+        const options= {tbl_id: `${tableRootStr}${nextId++}`, startIdx:0, ...rest};
+        if (metaKeys.length) options.META_INFO= metaParams;
+        const dataTableReq= makeFileRequest(title, source, undefined,options);
+        dispatchTableSearch(dataTableReq,options);
+    },10);
 }
 
 /**
@@ -61,6 +92,7 @@ export function getTableCommands() {
             cmd : 'table',
             validate : validateTable,
             execute:  showTable,
+            allowAdditionalParameters:true,
             ...tableOverview,
             examples: makeExamples('table', tableExamples),
         },

--- a/src/firefly/js/ui/PositionFieldDef.js
+++ b/src/firefly/js/ui/PositionFieldDef.js
@@ -24,6 +24,7 @@ function positionValidateInternal(s, hard, nullAllowed= true) {
     // validate ObjName
     if (inputType===PositionParsedInputType.Name) {
         if (hard) throw 'Object names must be more than one character';
+        return {valid,inputType};
     }
     else {
         // check coordinate system

--- a/src/firefly/js/ui/TargetFeedback.jsx
+++ b/src/firefly/js/ui/TargetFeedback.jsx
@@ -1,30 +1,55 @@
-import {FormHelperText, Typography} from '@mui/joy';
+import {FormHelperText, Link, Stack, Typography} from '@mui/joy';
 import {isArray} from 'lodash';
-import React from 'react';
+import React, {useContext} from 'react';
 import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
+import {FieldGroupCtx} from './FieldGroup';
+import {positionValidateSoft} from './PositionFieldDef';
+import {ingestNewTargetValue} from './TargetPanel';
 
 const defExampleEntries= {
-    /* eslint-disable-next-line quotes */
-    row1: [`'m81'`, `'ngc 18'`, `'12.34 34.89'`, `'46.53 -0.251 gal'`],
-    /* eslint-disable-next-line quotes */
-    row2: [ `'19h17m32s 11d58m02s equ j2000'`,`'12.3 8.5 b1950'`,`'J140258.51+542318.3'`]
+    row1: ['m81', 'ngc 18', '12.34 34.89', '46.53 -0.251 gal'],
+    row2: [ '19h17m32s 11d58m02s equ j2000','12.3 8.5 b1950','J140258.51+542318.3']
     };
 
-const defaultExamples= (targetPanelExampleRow1, targetPanelExampleRow2) => {
+
+function formatExample(row, fieldKey, setFld) {
+    return (
+        <Stack {...{direction:'row', spacing:1.5}}>
+            {row?.map( (s) => {
+                const {valid}= positionValidateSoft(s);
+                if (s && valid && fieldKey) {
+                    return (
+                        <Link key={s}
+                              onClick={(ev) => ingestNewTargetValue(s,(params) => setFld(fieldKey,params))}>
+                            {s}
+                        </Link>
+                    );
+                }
+                else {
+                    return <span key={s} >{s}</span>;
+                }
+            })}
+        </Stack>
+    )
+}
+
+
+const ConfigExamples = ({targetPanelExampleRow1, targetPanelExampleRow2, fieldKey}) => {
+    const {setFld}= useContext(FieldGroupCtx);
     const tpR1= !targetPanelExampleRow1 || isArray(targetPanelExampleRow1) ? targetPanelExampleRow1 : [targetPanelExampleRow1];
     const tpR2= !targetPanelExampleRow2 || isArray(targetPanelExampleRow2) ? targetPanelExampleRow2 : [targetPanelExampleRow2];
     const row1Op= tpR1 ?? getAppOptions()?.targetPanelExampleRow1 ?? defExampleEntries.row1;
     const row2Op= tpR2 ?? getAppOptions()?.targetPanelExampleRow2 ?? defExampleEntries.row2;
     return (
-        <div style={{ display : 'inline-block', lineHeight : '1.2em', fontSize:'smaller'}}>
-            {row1Op?.map( (s,idx) => <span key={s} style={{paddingLeft: (idx===0) ? 5 : 15}}>{s}</span> )}
-            <br/>
-            {row2Op?.map( (s,idx) => <span key={s} style={{paddingLeft: (idx===0) ? 5 : 15}}>{s}</span> )}
-        </div>
+        <Stack {...{lineHeight : '1.2em', fontSize:'smaller', direction:'column', spacing:1/2, alignItems:'center'}}>
+            {formatExample(row1Op, fieldKey, setFld)}
+            {formatExample(row2Op, fieldKey, setFld)}
+        </Stack>
         );
 };
 
-export function TargetFeedback ({showHelp, feedback, sx, targetPanelExampleRow1, targetPanelExampleRow2, examples}) {
+export function TargetFeedback ({showHelp, feedback, sx, targetPanelExampleRow1, targetPanelExampleRow2,
+                                    examples,fieldKey}) {
     const minHeight= '3rem';
     if (!showHelp) {
         return (
@@ -37,11 +62,9 @@ export function TargetFeedback ({showHelp, feedback, sx, targetPanelExampleRow1,
     }
     return (
             <FormHelperText sx={{textAlign:'center', minHeight, ...sx}}>
-                <Typography level='body-sm'>
-                    <i>Examples: </i>
-                </Typography>
+                <Typography level='body-sm' sx={{pr:1}}> Examples: </Typography>
                 <Typography level='body-sm' component='div'>
-                    {examples ?? defaultExamples(targetPanelExampleRow1, targetPanelExampleRow2)}
+                    {examples ?? <ConfigExamples {...{targetPanelExampleRow1, targetPanelExampleRow2, fieldKey}}/>}
                 </Typography>
             </FormHelperText>
     );

--- a/src/firefly/js/ui/TargetPanel.jsx
+++ b/src/firefly/js/ui/TargetPanel.jsx
@@ -25,7 +25,7 @@ const nedThenSimbad= 'nedthensimbad';
 const simbadThenNed= 'simbadthenned';
 
 const TargetPanelView = (props) =>{
-    const {showHelp, feedback, valid, message, onChange, value, button, slotProps,
+    const {showHelp, feedback, valid, message, onChange, value, button, slotProps, fieldKey,
         children, resolver, showResolveSourceOp= true, showExample= true,
         label= LABEL_DEFAULT,
         targetPanelExampleRow1, targetPanelExampleRow2,
@@ -63,7 +63,7 @@ const TargetPanelView = (props) =>{
     return (
         <Stack direction='column'>
             {positionInput}
-            {(showExample || !showHelp) && <TargetFeedback {...{showHelp, feedback,
+            {(showExample || !showHelp) && <TargetFeedback {...{showHelp, feedback, fieldKey,
                 targetPanelExampleRow1, targetPanelExampleRow2, examples, ...slotProps?.feedback}}/> }
         </Stack>
     );
@@ -181,6 +181,31 @@ function handleOnChange(value, source, params, fireValueChange) {
 
 }
 
+
+
+export function ingestNewTargetValue(value, setter, params, ) {
+    const {resolver= nedThenSimbad}= params ?? {};
+
+    const displayValue= value;
+
+    const parseResults= parseTarget(displayValue, undefined, resolver);
+    let {resolvePromise}= parseResults;
+
+    const targetResolve= (asyncParseResults) => {
+        return asyncParseResults ? setter(makePayloadAndUpdateActive(displayValue, asyncParseResults, null, resolver)) : null;
+    };
+
+    resolvePromise= resolvePromise ? resolvePromise.then(targetResolve) : null;
+
+
+    setter(makePayloadAndUpdateActive(displayValue,parseResults, resolvePromise, resolver));
+
+}
+
+
+
+
+
 /**
  * Make a payload and update the active target, Note: this function has as side effect to fires an action to update the active target
  * @param displayValue
@@ -224,7 +249,7 @@ export const TargetPanel = memo( ({fieldKey= DEF_TARGET_PANEL_KEY,initialState= 
                                 fieldKey, initialState,
                                 confirmValueOnInit: (v, props,initialState,computedState) => replaceValue(v,defaultToActiveTarget,computedState)});
     const newProps= computeProps(viewProps, restOfProps, fieldKey, groupKey);
-    return ( <TargetPanelView {...newProps}
+    return ( <TargetPanelView {...{...newProps,fieldKey}}
                               onChange={(value,source) => handleOnChange(value,source,newProps, fireValueChange)}/>);
 });
 

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -22,7 +22,7 @@ import {useFieldGroupRerender, useFieldGroupValue, useFieldGroupWatch} from '../
 import {SizeInputFields} from '../SizeInputField.jsx';
 import {DEF_TARGET_PANEL_KEY} from '../TargetPanel.jsx';
 import {ConstraintContext} from './Constraints.js';
-import {ROW_POSITION, SEARCH_POSITION} from './ObsCoreOptions';
+import {getObsCoreOption, ROW_POSITION, SEARCH_POSITION} from './ObsCoreOptions';
 import {
     DebugObsCore, getPanelPrefix, makeCollapsibleCheckHeader, makeFieldErrorList, makePanelStatusUpdater,
     } from './TableSearchHelpers.jsx';
@@ -232,7 +232,7 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, columnsModel,
                             sx:{'label' : {width: SpatialLabelSpatial}},
                         }}
                         /> }
-                    <SpatialSearchLayout {...{obsCoreEnabled, initArgs, uploadInfo, setUploadInfo,
+                    <SpatialSearchLayout {...{obsCoreEnabled, initArgs, uploadInfo, setUploadInfo, serviceLabel,
                         hipsUrl, centerWP, fovDeg, capabilities, slotProps: layoutSlotProps}} />
                     {!obsCoreEnabled && cols &&
                         <CenterColumns {...{lonCol: getVal(CenterLonColumns), latCol: getVal(CenterLatColumns),
@@ -262,7 +262,7 @@ function getSpacialLayoutMode(spacialType, obsCoreEnabled, canUpload) {
 }
 
 
-const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInfo,
+const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInfo, serviceLabel,
                                  hipsUrl, centerWP, fovDeg, capabilities, slotProps}) => {
 
     const {getVal}= useContext(FieldGroupCtx);
@@ -287,7 +287,7 @@ const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInf
                 <Stack spacing={1} direction='column'>
                     <RegionOpField {...{initArgs, capabilities, ...slotProps?.regionOpField}}/>
                     {!containsPoint && <ConeOrAreaField {...slotProps?.coneOrAreaField}/>}
-                    { (isCone || containsPoint) && <TargetPanelForSpacial {...{hipsUrl, centerWP, fovDeg, ...slotProps?.targetPanel}}/>}
+                    { (isCone || containsPoint) && <TargetPanelForSpacial {...{serviceLabel, hipsUrl, centerWP, fovDeg, ...slotProps?.targetPanel}}/>}
                     {!containsPoint && radiusOrPolygon}
                 </Stack>
             );
@@ -303,7 +303,7 @@ const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInf
             return (
                 <Stack spacing={1} direction='column'>
                     <ConeOrAreaField {...slotProps?.coneOrAreaField}/>
-                    {isCone && <TargetPanelForSpacial {...{hipsUrl, centerWP, fovDeg, ...slotProps?.targetPanel}}/>}
+                    {isCone && <TargetPanelForSpacial {...{serviceLabel, hipsUrl, centerWP, fovDeg, ...slotProps?.targetPanel}}/>}
                     {radiusOrPolygon}
                 </Stack>
             );
@@ -427,13 +427,17 @@ const RegionOpField= ({initArgs, capabilities, ...props}) => {
     );
 };
 
-function TargetPanelForSpacial({hasRadius=true,
+function TargetPanelForSpacial({hasRadius=true, serviceLabel,
                                    hipsUrl= getAppOptions().coverage?.hipsSourceURL  ??  'ivo://CDS/P/2MASS/color',
                                    centerWP, fovDeg=240, ...props}) {
+
+    const targetPanelExampleRow1= getObsCoreOption('targetPanelExampleRow1', serviceLabel);
+    const targetPanelExampleRow2= getObsCoreOption('targetPanelExampleRow2', serviceLabel);
     return (
-        <VisualTargetPanel sizeKey={hasRadius? RadiusSize : undefined}
-                           hipsDisplayKey={fovDeg} hipsUrl={hipsUrl} hipsFOVInDeg={fovDeg}
-                           centerPt={parseWorldPt(centerWP)} {...props} />
+        <VisualTargetPanel {...{sizeKey:hasRadius? RadiusSize : undefined,
+                           targetPanelExampleRow1, targetPanelExampleRow2,
+                           hipsDisplayKey:fovDeg, hipsUrl, hipsFOVInDeg:fovDeg,
+                           centerPt:parseWorldPt(centerWP), ...props }}/>
     );
 }
 

--- a/src/firefly/js/util/PositionParser.js
+++ b/src/firefly/js/util/PositionParser.js
@@ -35,7 +35,7 @@ export function parsePosition(s) {
     inputType= determineType(s);
     if (inputType ===PositionParsedInputType.Name) {
         objName= s;
-        valid = s.length>1;
+        valid = s.length>1 && s.split(' ')?.length<6;
     }
     else if (inputType ===PositionParsedInputType.DB_ID) {
         const r= parseDBIdToCoord(s);


### PR DESCRIPTION
#### [Firefly-441](https://jira.ipac.caltech.edu/browse/FIREFLY-441):  target panel example config and make example clickable

- `TargetPanel` example settable from appOptions, tapObsCore and tapObsCore[source]
   - use  `targetPanelExampleRow1`, `targetPanelExampleRow2`
 - `TargetPanel` examples now clickable

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-441-examples/firefly/
- Demonstrates the clickable examples
- Examples are configured in options as described below
- To test
   - go to images target panel, it should have the default examples, click on any example
   - go to the IRSA tap target panel, it will show examples as described below  
   -  go to the NED tap target panel, it will show examples as described below  
   - go to a  non-IRSA, non-NED tap target panel, it will show examples as described below




#### Options setting for test
The following options will
 - use the default for the images panel (or any non-tap panel)
 - set tap panel (except for IRSA and NED) option to the first set below
 - set the IRSA TAP panel to the second set
 - set the NED TAP panel to the thired set

```js
tapObsCore: { 
    targetPanelExampleRow1: ['11, 11', '22.2 -33.3', '4h11m59s -32d51m59s equ j2000', '0 0 gal'],
    targetPanelExampleRow2: ['5h55m55s -55d55m55s equ j2000'],
    IRSA: {
        targetPanelExampleRow1: ['55, 66', '5 -6', '4h11m59s -32d51m59s equ j2000', '5 6 gal'],
        targetPanelExampleRow2: ['1h11m11s -22d22m22s equ j2000'],
}
```

Built with
```
OP_tapObsCore_NED_targetPanelExampleRow1_0='::STRING::55\,_66'
OP_tapObsCore_NED_targetPanelExampleRow1_1='::STRING::33.3_-44.4'
OP_tapObsCore_NED_targetPanelExampleRow1_3='::STRING::1h22m33s_-12d33m11s_equ_j2000'
OP_tapObsCore_NED_targetPanelExampleRow1_4='::STRING::0_0_gal'
OP_tapObsCore_NED_targetPanelExampleRow2_0=m1
OP_tapObsCore_NED_targetPanelExampleRow2_1=m2
OP_tapObsCore_NED_targetPanelExampleRow2_2=m4
```