### PR TITLE
FIREFLY-1648: fix Dockerfile parsing envVars bugs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN yarn install --ignore-platform --frozen-lockfile
 FROM node_module AS dev_env
 
 RUN apt-get update \
-    && apt-get install -y vim procps \
+    && apt-get install -y vim procps python3 \
 # cleanup
     && rm -rf /var/lib/apt/lists/*;
 
@@ -52,7 +52,7 @@ ENV env=local
 WORKDIR ${CATALINA_HOME}
 
 # Tomcat scripts, config files, etc
-COPY firefly/docker/*.sh ./
+COPY firefly/docker/*.sh firefly/docker/*.py ./
 COPY firefly/docker/tomcat-users.xml conf/
 
 # set up directory protections, copy stuff around, add tomcat user and group
@@ -120,7 +120,7 @@ ARG gid=91
 # - this is a big part of the layer so do it early
 # - emacs removed because it is so big: to readd emacs: emacs-nox
 RUN apt-get update && apt-get install -y \
-        vim procps wget unzip \
+        vim procps wget unzip python3 \
         && rm -rf /var/lib/apt/lists/*;
 
 # These are the users replaceable environment variables, basically runtime arguments
@@ -132,7 +132,8 @@ RUN apt-get update && apt-get install -y \
 ENV JVM_CORES=0\
     DEBUG=false \
     CLEANUP_INTERVAL=12h \
-    PROPS=''
+    PROPS='' \
+    PYTHONUNBUFFERED=1
 
 # ----------------------------------------------------------
 # ----------------------------------------------------------
@@ -153,7 +154,7 @@ RUN mkdir -p conf/Catalina/localhost /local/www /firefly/config /firefly/workare
   && rm -r logs && ln -s /firefly/logs logs
 
 # These are the file that are executed at startup: start tomcat, logging, help, etc
-COPY firefly/docker/*.sh firefly/docker/*.txt ${CATALINA_HOME}/
+COPY firefly/docker/*.sh firefly/docker/*.txt firefly/docker/*.py ${CATALINA_HOME}/
 
 # Tomcat config files, tomcat-users is for the admin username and password
 # context.xml set delegate to true for we can use the classpath of tomcat
@@ -182,4 +183,5 @@ EXPOSE 8080 5050
 USER tomcat
 
 #CMD ["/bin/bash", "./launchTomcat.sh"]
-ENTRYPOINT ["/bin/bash", "-c", "./launchTomcat.sh ${*}", "--"]
+#ENTRYPOINT ["/bin/bash", "-c", "./launchTomcat.sh ${*}", "--"]
+ENTRYPOINT ["python3", "./entrypoint.py"]

--- a/docker/devMode.sh
+++ b/docker/devMode.sh
@@ -14,4 +14,5 @@ for n in *.war; do \
 done
 
 cd ${CATALINA_HOME}
-${CATALINA_HOME}/launchTomcat.sh
+#${CATALINA_HOME}/launchTomcat.sh
+python3 ${CATALINA_HOME}/entrypoint.py

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -7,26 +7,28 @@ import base64
 import subprocess
 import shlex
 
-def extract_war_files(webapps_dir, webapps_ref, PATH_PREFIX):
+
+def extract_war_files(webapps_dir, webapps_ref, path_prefix):
     """
     Prepare webapps on first-time startup:
     - Extract WAR files from webapps-ref to webapps.
     - Modify log4j to send logs to stdout.
     - Modify context path (pathPrefix) if given.
 
-    :param webapps_dir: Path to the webapps directory
+    :param webapps_dir: Path to the webapps directory.
     :param webapps_ref: Path to the webapps reference directory.
+    :param path_prefix: Prefix for the context path.
     """
-
     if not os.listdir(webapps_dir):
         for war in os.listdir(webapps_ref):
             if war.endswith(".war"):
                 fn = os.path.splitext(war)[0]
-                prefix = PATH_PREFIX.replace("/", "#").strip("#")
+                prefix = path_prefix.replace("/", "#").strip("#")
                 war_dir = os.path.join(webapps_dir, f"{prefix}#{fn}" if prefix else fn)
                 os.makedirs(war_dir, exist_ok=True)
                 subprocess.call(["unzip", "-oqd", war_dir, os.path.join(webapps_ref, war)])
                 subprocess.call(["sed", "-E", "-i.bak", "s/##out--//", os.path.join(war_dir, "WEB-INF/classes/log4j2.properties")])
+
 
 def add_multi_props_env_var():
     """
@@ -38,22 +40,22 @@ def add_multi_props_env_var():
         str: JVM `-Dkey=value` options.
     """
     props_opts = ""
-    PROPS = os.getenv("PROPS", "")
+    props_env = os.getenv("PROPS", "")
 
-    if PROPS:
+    if props_env:
         placeholder = "__SEMICOLON__"
-        PROPS = PROPS.replace(";;", placeholder)  # Handle escaped semicolons
+        props_env = props_env.replace(";;", placeholder)
 
-        for prop in PROPS.split(";"):
-            prop = prop.replace(placeholder, ";")  # Restore escaped semicolons
-
+        for prop in props_env.split(";"):
+            prop = prop.replace(placeholder, ";")
             if "=" in prop:
                 key, value = prop.split("=", 1)
                 key = key.strip()
-                value = shlex.quote(value.strip())  # Safely quote values
+                value = shlex.quote(value.strip())
                 props_opts += f" -D{key}={value}"
 
     return props_opts
+
 
 def add_single_prop_env_vars():
     """
@@ -69,66 +71,74 @@ def add_single_prop_env_vars():
     for key, value in os.environ.items():
         if key.startswith("PROPS_"):
             prop_key = key.replace("PROPS_", "").replace("__", ".").strip()
-            value = shlex.quote(value.strip())  # Ensure safe values
+            value = shlex.quote(value.strip())
             props_opts += f" -D{prop_key}={value}"
 
     return props_opts
 
-def log_env_info(PATH_PREFIX, VISUALIZE_FITS_SEARCH_PATH):
-    print("========== Information:  you can set environment variable using -e on docker run line =====  \n")
-    print("Environment Variables:")
-    print("        Description                      Name                          Value")
-    print("        -----------                      --------                      -----")
-    print(f"        Admin username                   ADMIN_USER                    {os.getenv('ADMIN_USER')}")
-    print(f"        Admin password                   ADMIN_PASSWORD                {os.getenv('ADMIN_PASSWORD')}")
-    print(f"        Additional data path             VISUALIZE_FITS_SEARCH_PATH    {VISUALIZE_FITS_SEARCH_PATH}")
-    print(f"        Clean internal(eg- 720m, 5h, 3d) CLEANUP_INTERVAL              {os.getenv('CLEANUP_INTERVAL', '')}")
-    print(f"        Context path prefix              pathPrefix                    {PATH_PREFIX}")
-    print()
-    print("Advanced environment variables:")
-    print(f"        Run tomcat with debug            DEBUG                         {os.getenv('DEBUG', '')}")
-    print(f"        Extra firefly properties(*)      PROPS                         {os.getenv('PROPS', '')}")
-    print(f"        Redis host                       PROPS_redis__host             {os.getenv('PROPS_redis__host', '')}")
-    print(f"        SSO host                         PROPS_sso__req__auth__hosts   {os.getenv('PROPS_sso__req__auth__hosts', '')}")
-    print(f"        firefly.options (JSON string)    PROPS_FIREFLY_OPTIONS         {os.getenv('PROPS_FIREFLY_OPTIONS', '')}")
-    print(" (*) key=value pairs separated by semicolon, use double semicolons to escape semicolon")
-    print()
-    print("Ports: ")
-    print("        8080 - http")
-    print("        5050 - debug")
-    print()
-    print("Volume Mount Points: ")
-    print("    /firefly/logs             : logs directory")
-    print("    /firefly/workarea         : work area for temporary files")
-    print("    /firefly/shared-workarea  : work area for files that are shared between multiple instances of the application")
-    print("    /external                 : default external data directory visible to Firefly")
-    print()
-    print("  Less used:")
-    print("    /firefly/config           : used to override application properties")
-    print("    /firefly/logs/statistics  : directory for statistics logs")
-    print("    /firefly/alerts           : alerts monitor will watch this directory for application alerts")
-    print()
-    print("Command line options: ")
-    print("        --help  : show help message, examples, stop")
-    print("        --debug : start in debug mode")
-    print("\n")
 
-def show_help(NAME):
+def log_env_info(path_prefix, visualize_fits_search_path):
+    """Log environment variables and configuration information."""
+    print(f"""
+    ========== Information: You can set environment variables using -e on the docker run line =====
+
+    Environment Variables:
+            Description                      Name                          Value
+            -----------                      --------                      -----
+            Admin username                   ADMIN_USER                    {os.getenv('ADMIN_USER')}
+            Admin password                   ADMIN_PASSWORD                {os.getenv('ADMIN_PASSWORD')}
+            Additional data path             VISUALIZE_FITS_SEARCH_PATH    {visualize_fits_search_path}
+            Clean internal (e.g., 720m, 5h)  CLEANUP_INTERVAL              {os.getenv('CLEANUP_INTERVAL', '')}
+            Context path prefix              PATH_PREFIX                   {path_prefix}
+
+    Advanced environment variables:
+            Run tomcat with debug            DEBUG                         {os.getenv('DEBUG', '')}
+            Extra firefly properties (*)     PROPS                         {os.getenv('PROPS', '')}
+            Redis host                       PROPS_redis__host             {os.getenv('PROPS_redis__host', '')}
+            SSO host                         PROPS_sso__req__auth__hosts   {os.getenv('PROPS_sso__req__auth__hosts', '')}
+            firefly.options (JSON string)    PROPS_FIREFLY_OPTIONS         {os.getenv('PROPS_FIREFLY_OPTIONS', '')}
+     (*) key=value pairs separated by semicolon; use double semicolons to escape semicolon
+
+    Ports:
+            8080 - http
+            5050 - debug
+
+    Volume Mount Points:
+        /firefly/logs             : logs directory
+        /firefly/workarea         : work area for temporary files
+        /firefly/shared-workarea  : work area for files shared between multiple instances of the application
+        /external                 : default external data directory visible to Firefly
+
+      Less used:
+        /firefly/config           : used to override application properties
+        /firefly/logs/statistics  : directory for statistics logs
+        /firefly/alerts           : alerts monitor will watch this directory for application alerts
+
+    Command line options:
+            --help  : show help message, examples, stop
+            --debug : start in debug mode
+    """)
+
+
+def show_help(name):
     """Show help message and exit."""
     with open("./start-examples.txt") as f:
-        print(f.read().replace("ipac/firefly", NAME))
+        print(f.read().replace("ipac/firefly", name))
+
     war_files = [f for f in os.listdir(webapps_ref) if f.endswith(".war")]
     if war_files and war_files[0] == "firefly.war":
         with open("./customize-firefly.txt") as f:
             print(f.read())
     sys.exit(0)
 
-def dry_run(cmd, webapps_dir):
-    print("\n\n----------------------")
-    print(f"Command: {' '.join(cmd)}")  # Fixed by using single quotes inside the f-string
-    print(f"CATALINA_OPTS: {os.getenv('CATALINA_OPTS')}")
 
-    print(f"\nContents of '{webapps_dir}':")
+def dry_run(cmd, webapps_dir):
+    """Display a dry run of the command and environment setup."""
+    print("\n\n----------------------")
+    print(f"Command: {' '.join(cmd)}")
+    print(f"CATALINA_OPTS: {os.getenv('CATALINA_OPTS')}\n")
+
+    print(f"Contents of '{webapps_dir}':")
     for item in os.listdir(webapps_dir):
         item_path = os.path.join(webapps_dir, item)
         if os.path.isdir(item_path):
@@ -138,31 +148,30 @@ def dry_run(cmd, webapps_dir):
     print()
     sys.exit(0)
 
+
 # ================================ Main Execution =============================
 def main():
     """Main execution function for the entrypoint script."""
 
-    # Load environment variables with fallback defaults
     os.environ["JPDA_ADDRESS"] = "*:5050"
-    CATALINA_HOME = os.getenv("CATALINA_HOME", "/usr/local/tomcat")
-    VISUALIZE_FITS_SEARCH_PATH = os.getenv("VISUALIZE_FITS_SEARCH_PATH", "")
-    START_MODE = os.getenv("START_MODE", "run")
-    NAME = os.getenv("BUILD_TIME_NAME", "ipac/firefly")
-    ADMIN_USER = os.getenv("ADMIN_USER", "admin")
-    ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", base64.b64encode(str(random.randint(100000, 999999)).encode()).decode()[:8])
-    USE_ADMIN_AUTH = os.getenv("USE_ADMIN_AUTH", "true").lower()
-    PATH_PREFIX = os.getenv("pathPrefix") or os.getenv("baseURL") or ""      # use pathPrefix; baseURL is for backward compatibility
+    catalina_home = os.getenv("CATALINA_HOME", "/usr/local/tomcat")
+    visualize_fits_search_path = os.getenv("VISUALIZE_FITS_SEARCH_PATH", "")
+    start_mode = os.getenv("START_MODE", "run")
+    name = os.getenv("BUILD_TIME_NAME", "ipac/firefly")
+    admin_user = os.getenv("ADMIN_USER", "admin")
+    admin_password = os.getenv("ADMIN_PASSWORD", base64.b64encode(str(random.randint(100000, 999999)).encode()).decode()[:8])
+    use_admin_auth = os.getenv("USE_ADMIN_AUTH", "true").lower()
+    path_prefix = os.getenv("PATH_PREFIX") or os.getenv("baseURL") or ""      # use PATH_PREFIX; baseURL is for backward compatibility
 
-    # Set visualize path
-    VIS_PATH = "/external" if not VISUALIZE_FITS_SEARCH_PATH else f"/external:{VISUALIZE_FITS_SEARCH_PATH}"
+    vis_path = "/external" if not visualize_fits_search_path \
+        else f"/external:{visualize_fits_search_path}"
 
-    # Set Catalina options
-    CATALINA_OPTS = " ".join([
+    catalina_opts = " ".join([
         f"-XX:InitialRAMPercentage={os.getenv('INIT_RAM_PERCENT', '10')}",
         f"-XX:MaxRAMPercentage={os.getenv('MAX_RAM_PERCENT', '80')}",
         "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=30000",
-        f"-DADMIN_USER={ADMIN_USER}",
-        f"-DADMIN_PASSWORD={ADMIN_PASSWORD}",
+        f"-DADMIN_USER={admin_user}",
+        f"-DADMIN_PASSWORD={admin_password}",
         f"-Dhost.name={os.getenv('HOSTNAME', '')}",
         f"-Dserver.cores={os.getenv('JVM_CORES', '')}",
         "-Djava.net.preferIPv4Stack=true",
@@ -171,53 +180,54 @@ def main():
         "-Dserver_config_dir=/firefly/config",
         "-Dstats.log.dir=/firefly/logs/statistics",
         "-Dalerts.dir=/firefly/alerts",
-        f"-Dvisualize.fits.search.path={VIS_PATH}"
+        f"-Dvisualize.fits.search.path={vis_path}"
     ])
 
     # Remove admin protection if disabled
-    if USE_ADMIN_AUTH == "false":
-        CATALINA_OPTS += " -DADMIN_PROTECTED="
+    if use_admin_auth == "false":
+        catalina_opts += " -DADMIN_PROTECTED="
 
     # extract and add properties defined as environment variables
-    CATALINA_OPTS += add_multi_props_env_var()
-    CATALINA_OPTS += add_single_prop_env_vars()
+    catalina_opts += add_multi_props_env_var()
+    catalina_opts += add_single_prop_env_vars()
 
     # Set environment variables so they persist in Tomcat
-    os.environ["CATALINA_PID"] = os.path.join(CATALINA_HOME, "bin", "catalina.pid")
-    os.environ["CATALINA_OPTS"] = CATALINA_OPTS
-    os.environ["ADMIN_USER"] = ADMIN_USER
-    os.environ["ADMIN_PASSWORD"] = ADMIN_PASSWORD
+    os.environ["CATALINA_PID"] = os.path.join(catalina_home, "bin", "catalina.pid")
+    os.environ["CATALINA_OPTS"] = catalina_opts
+    os.environ["ADMIN_USER"] = admin_user
+    os.environ["ADMIN_PASSWORD"] = admin_password
     debug_mode = os.getenv("DEBUG", "false").lower() == "true" or (len(sys.argv) > 1 and sys.argv[1] == "--debug")
-    cmd = [f"{CATALINA_HOME}/bin/catalina.sh"]
+    cmd = [f"{catalina_home}/bin/catalina.sh"]
     if debug_mode:
         cmd.append("jpda")
-    cmd.append(START_MODE)
+    cmd.append(start_mode)
 
     # log environment information
-    log_env_info(PATH_PREFIX, VISUALIZE_FITS_SEARCH_PATH)
+    log_env_info(path_prefix, visualize_fits_search_path)
 
     # Setup examples
     subprocess.call("./setupFireflyExample.sh", shell=True)
 
     # Prepare webapps on first-time startup
-    webapps_dir = os.path.join(CATALINA_HOME, "webapps")
-    webapps_ref = os.path.join(CATALINA_HOME, "webapps-ref")
-    extract_war_files(webapps_dir, webapps_ref, PATH_PREFIX)
+    webapps_dir = os.path.join(catalina_home, "webapps")
+    webapps_ref = os.path.join(catalina_home, "webapps-ref")
+    extract_war_files(webapps_dir, webapps_ref, path_prefix)
 
     # check for no-ops flags
     if len(sys.argv) > 1:
         arg = sys.argv[1]
         if arg in ["--help", "-help", "-h"]:
-            show_help(NAME)
+            show_help(name)
         elif arg == "--dry-run":
             dry_run(cmd, webapps_dir)
 
     # Start background cleanup
-    subprocess.Popen([f"{CATALINA_HOME}/cleanup.sh", "/firefly/workarea", "/firefly/shared-workarea"])
+    subprocess.Popen([f"{catalina_home}/cleanup.sh", "/firefly/workarea", "/firefly/shared-workarea"])
 
     # Start Tomcat; Replace the current process with Tomcat
     print("Starting Tomcat...")
     os.execvp(cmd[0], cmd)
+
 
 if __name__ == "__main__":
     main()

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import random
+import base64
+import subprocess
+import shlex
+
+def extract_war_files(webapps_dir, webapps_ref, PATH_PREFIX):
+    """
+    Prepare webapps on first-time startup:
+    - Extract WAR files from webapps-ref to webapps.
+    - Modify log4j to send logs to stdout.
+    - Modify context path (pathPrefix) if given.
+
+    :param webapps_dir: Path to the webapps directory
+    :param webapps_ref: Path to the webapps reference directory.
+    """
+
+    if not os.listdir(webapps_dir):
+        for war in os.listdir(webapps_ref):
+            if war.endswith(".war"):
+                fn = os.path.splitext(war)[0]
+                prefix = PATH_PREFIX.replace("/", "#").strip("#")
+                war_dir = os.path.join(webapps_dir, f"{prefix}#{fn}" if prefix else fn)
+                os.makedirs(war_dir, exist_ok=True)
+                subprocess.call(["unzip", "-oqd", war_dir, os.path.join(webapps_ref, war)])
+                subprocess.call(["sed", "-E", "-i.bak", "s/##out--//", os.path.join(war_dir, "WEB-INF/classes/log4j2.properties")])
+
+def add_multi_props_env_var():
+    """
+    Process environment variable `PROPS`, where:
+    - Key-value pairs are separated by `;`
+    - Use double semicolons (`;;`) to escape semicolon `;`
+
+    Returns:
+        str: JVM `-Dkey=value` options.
+    """
+    props_opts = ""
+    PROPS = os.getenv("PROPS", "")
+
+    if PROPS:
+        placeholder = "__SEMICOLON__"
+        PROPS = PROPS.replace(";;", placeholder)  # Handle escaped semicolons
+
+        for prop in PROPS.split(";"):
+            prop = prop.replace(placeholder, ";")  # Restore escaped semicolons
+
+            if "=" in prop:
+                key, value = prop.split("=", 1)
+                key = key.strip()
+                value = shlex.quote(value.strip())  # Safely quote values
+                props_opts += f" -D{key}={value}"
+
+    return props_opts
+
+def add_single_prop_env_vars():
+    """
+    Process environment variables that match `PROPS_*`, replacing:
+    - `__` in variable names with `.`
+    - Supports secrets and hard-to-escape characters.
+
+    Returns:
+        str: JVM `-Dkey=value` options.
+    """
+    props_opts = ""
+
+    for key, value in os.environ.items():
+        if key.startswith("PROPS_"):
+            prop_key = key.replace("PROPS_", "").replace("__", ".").strip()
+            value = shlex.quote(value.strip())  # Ensure safe values
+            props_opts += f" -D{prop_key}={value}"
+
+    return props_opts
+
+def log_env_info(PATH_PREFIX, VISUALIZE_FITS_SEARCH_PATH):
+    print("========== Information:  you can set environment variable using -e on docker run line =====  \n")
+    print("Environment Variables:")
+    print("        Description                      Name                          Value")
+    print("        -----------                      --------                      -----")
+    print(f"        Admin username                   ADMIN_USER                    {os.getenv('ADMIN_USER')}")
+    print(f"        Admin password                   ADMIN_PASSWORD                {os.getenv('ADMIN_PASSWORD')}")
+    print(f"        Additional data path             VISUALIZE_FITS_SEARCH_PATH    {VISUALIZE_FITS_SEARCH_PATH}")
+    print(f"        Clean internal(eg- 720m, 5h, 3d) CLEANUP_INTERVAL              {os.getenv('CLEANUP_INTERVAL', '')}")
+    print(f"        Context path prefix              pathPrefix                    {PATH_PREFIX}")
+    print()
+    print("Advanced environment variables:")
+    print(f"        Run tomcat with debug            DEBUG                         {os.getenv('DEBUG', '')}")
+    print(f"        Extra firefly properties(*)      PROPS                         {os.getenv('PROPS', '')}")
+    print(f"        Redis host                       PROPS_redis__host             {os.getenv('PROPS_redis__host', '')}")
+    print(f"        SSO host                         PROPS_sso__req__auth__hosts   {os.getenv('PROPS_sso__req__auth__hosts', '')}")
+    print(f"        firefly.options (JSON string)    PROPS_FIREFLY_OPTIONS         {os.getenv('PROPS_FIREFLY_OPTIONS', '')}")
+    print(" (*) key=value pairs separated by semicolon, use double semicolons to escape semicolon")
+    print()
+    print("Ports: ")
+    print("        8080 - http")
+    print("        5050 - debug")
+    print()
+    print("Volume Mount Points: ")
+    print("    /firefly/logs             : logs directory")
+    print("    /firefly/workarea         : work area for temporary files")
+    print("    /firefly/shared-workarea  : work area for files that are shared between multiple instances of the application")
+    print("    /external                 : default external data directory visible to Firefly")
+    print()
+    print("  Less used:")
+    print("    /firefly/config           : used to override application properties")
+    print("    /firefly/logs/statistics  : directory for statistics logs")
+    print("    /firefly/alerts           : alerts monitor will watch this directory for application alerts")
+    print()
+    print("Command line options: ")
+    print("        --help  : show help message, examples, stop")
+    print("        --debug : start in debug mode")
+    print("\n")
+
+def show_help(NAME):
+    """Show help message and exit."""
+    with open("./start-examples.txt") as f:
+        print(f.read().replace("ipac/firefly", NAME))
+    war_files = [f for f in os.listdir(webapps_ref) if f.endswith(".war")]
+    if war_files and war_files[0] == "firefly.war":
+        with open("./customize-firefly.txt") as f:
+            print(f.read())
+    sys.exit(0)
+
+def dry_run(cmd, webapps_dir):
+    print("\n\n----------------------")
+    print(f"Command: {' '.join(cmd)}")  # Fixed by using single quotes inside the f-string
+    print(f"CATALINA_OPTS: {os.getenv('CATALINA_OPTS')}")
+
+    print(f"\nContents of '{webapps_dir}':")
+    for item in os.listdir(webapps_dir):
+        item_path = os.path.join(webapps_dir, item)
+        if os.path.isdir(item_path):
+            print(f" [DIR]  {item}")
+        else:
+            print(f" [FILE] {item}")
+    print()
+    sys.exit(0)
+
+# ================================ Main Execution =============================
+def main():
+    """Main execution function for the entrypoint script."""
+
+    # Load environment variables with fallback defaults
+    os.environ["JPDA_ADDRESS"] = "*:5050"
+    CATALINA_HOME = os.getenv("CATALINA_HOME", "/usr/local/tomcat")
+    VISUALIZE_FITS_SEARCH_PATH = os.getenv("VISUALIZE_FITS_SEARCH_PATH", "")
+    START_MODE = os.getenv("START_MODE", "run")
+    NAME = os.getenv("BUILD_TIME_NAME", "ipac/firefly")
+    ADMIN_USER = os.getenv("ADMIN_USER", "admin")
+    ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", base64.b64encode(str(random.randint(100000, 999999)).encode()).decode()[:8])
+    USE_ADMIN_AUTH = os.getenv("USE_ADMIN_AUTH", "true").lower()
+    PATH_PREFIX = os.getenv("pathPrefix") or os.getenv("baseURL") or ""      # use pathPrefix; baseURL is for backward compatibility
+
+    # Set visualize path
+    VIS_PATH = "/external" if not VISUALIZE_FITS_SEARCH_PATH else f"/external:{VISUALIZE_FITS_SEARCH_PATH}"
+
+    # Set Catalina options
+    CATALINA_OPTS = " ".join([
+        f"-XX:InitialRAMPercentage={os.getenv('INIT_RAM_PERCENT', '10')}",
+        f"-XX:MaxRAMPercentage={os.getenv('MAX_RAM_PERCENT', '80')}",
+        "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=30000",
+        f"-DADMIN_USER={ADMIN_USER}",
+        f"-DADMIN_PASSWORD={ADMIN_PASSWORD}",
+        f"-Dhost.name={os.getenv('HOSTNAME', '')}",
+        f"-Dserver.cores={os.getenv('JVM_CORES', '')}",
+        "-Djava.net.preferIPv4Stack=true",
+        "-Dwork.directory=/firefly/workarea",
+        "-Dshared.work.directory=/firefly/shared-workarea",
+        "-Dserver_config_dir=/firefly/config",
+        "-Dstats.log.dir=/firefly/logs/statistics",
+        "-Dalerts.dir=/firefly/alerts",
+        f"-Dvisualize.fits.search.path={VIS_PATH}"
+    ])
+
+    # Remove admin protection if disabled
+    if USE_ADMIN_AUTH == "false":
+        CATALINA_OPTS += " -DADMIN_PROTECTED="
+
+    # extract and add properties defined as environment variables
+    CATALINA_OPTS += add_multi_props_env_var()
+    CATALINA_OPTS += add_single_prop_env_vars()
+
+    # Set environment variables so they persist in Tomcat
+    os.environ["CATALINA_PID"] = os.path.join(CATALINA_HOME, "bin", "catalina.pid")
+    os.environ["CATALINA_OPTS"] = CATALINA_OPTS
+    os.environ["ADMIN_USER"] = ADMIN_USER
+    os.environ["ADMIN_PASSWORD"] = ADMIN_PASSWORD
+    debug_mode = os.getenv("DEBUG", "false").lower() == "true" or (len(sys.argv) > 1 and sys.argv[1] == "--debug")
+    cmd = [f"{CATALINA_HOME}/bin/catalina.sh"]
+    if debug_mode:
+        cmd.append("jpda")
+    cmd.append(START_MODE)
+
+    # log environment information
+    log_env_info(PATH_PREFIX, VISUALIZE_FITS_SEARCH_PATH)
+
+    # Setup examples
+    subprocess.call("./setupFireflyExample.sh", shell=True)
+
+    # Prepare webapps on first-time startup
+    webapps_dir = os.path.join(CATALINA_HOME, "webapps")
+    webapps_ref = os.path.join(CATALINA_HOME, "webapps-ref")
+    extract_war_files(webapps_dir, webapps_ref, PATH_PREFIX)
+
+    # check for no-ops flags
+    if len(sys.argv) > 1:
+        arg = sys.argv[1]
+        if arg in ["--help", "-help", "-h"]:
+            show_help(NAME)
+        elif arg == "--dry-run":
+            dry_run(cmd, webapps_dir)
+
+    # Start background cleanup
+    subprocess.Popen([f"{CATALINA_HOME}/cleanup.sh", "/firefly/workarea", "/firefly/shared-workarea"])
+
+    # Start Tomcat; Replace the current process with Tomcat
+    print("Starting Tomcat...")
+    os.execvp(cmd[0], cmd)
+
+if __name__ == "__main__":
+    main()

--- a/docker/entrypoint_test.py
+++ b/docker/entrypoint_test.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+import os
+import entrypoint  # Import your script
+
+class TestEntrypoint(unittest.TestCase):
+
+
+    @patch.dict(os.environ, {
+        "PROPS": (
+            "logging.level=DEBUG;"
+            "app.mode=production;"
+            "key=value;;with semicolon;"
+            "key2=value with \"quotes\";"
+            "key3=value with 'single-quotes'"
+        )
+    })
+    def test_addMultiPropsEnvVar(self):
+        """Test addMultiPropsEnvVar() processes PROPS correctly."""
+        result = entrypoint.add_multi_props_env_var()
+        print("Test: addMultiPropsEnvVar()")
+        print("Actual Output  :", result)
+
+        # Expected formatted JVM options
+        expected_options = [
+            "-Dlogging.level=DEBUG",
+            "-Dapp.mode=production",
+            "-Dkey='value;with semicolon'",
+            "-Dkey2='value with \"quotes\"'",
+            """-Dkey3='value with '"'"'single-quotes'"'"''"""
+        ]
+
+        for option in expected_options:
+            self.assertIn(option, result)
+
+    @patch.dict(os.environ, {
+        "PROPS_logging__level": "DEBUG",
+        "PROPS_app__mode": "production",
+        "PROPS_special__key": "value with spaces",
+        "PROPS_with__semicolon": "value; with semicolon",
+        "PROPS_json": '{"abc": 123, "def": "value"}'
+    })
+    def test_addSinglePropEnvVars(self):
+        """Test addSinglePropEnvVars() processes PROPS_* environment variables correctly."""
+        result = entrypoint.add_single_prop_env_vars()
+        print("Test: test_addSinglePropEnvVars()")
+        print("Actual Output  :", result)
+
+        # Expected formatted JVM options
+        expected_options = [
+            "-Dlogging.level=DEBUG",
+            "-Dapp.mode=production",
+            "-Dspecial.key='value with spaces'",
+            "-Dwith.semicolon='value; with semicolon'",
+            "-Djson='{\"abc\": 123, \"def\": \"value\"}'"
+        ]
+
+        for option in expected_options:
+            self.assertIn(option, result)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -52,9 +52,3 @@ ADMIN_PASSWORD
 env
 
 
-## FIREFLY-1648 tests  -- will remove before merging.
-pathPrefix=local       # path to firefly is now /local/firefly/ instead of /firefly/
-PROPS="abc=123;semicolon=abc;;xyz;space=abc xyz;quote=abc\"xyz\""
-PROPS_OP_tap_additional_services_0_centerWP=5;5;EQ_J2000
-
-

--- a/firefly-docker.env
+++ b/firefly-docker.env
@@ -51,3 +51,10 @@
 ADMIN_PASSWORD
 env
 
+
+## FIREFLY-1648 tests  -- will remove before merging.
+pathPrefix=local       # path to firefly is now /local/firefly/ instead of /firefly/
+PROPS="abc=123;semicolon=abc;;xyz;space=abc xyz;quote=abc\"xyz\""
+PROPS_OP_tap_additional_services_0_centerWP=5;5;EQ_J2000
+
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -56,7 +56,7 @@ public class ServerStatus extends BaseHttpServlet {
 
     protected void processRequest(HttpServletRequest req, HttpServletResponse res) throws Exception {
 
-        boolean showHeaders = Boolean.parseBoolean(req.getParameter("headers"));
+        boolean showDebug = Boolean.parseBoolean(req.getParameter("debug"));
         boolean execGC = Boolean.parseBoolean(req.getParameter("execGC"));
         boolean showJobDetails = Boolean.parseBoolean(req.getParameter("job.details"));
 
@@ -72,7 +72,7 @@ public class ServerStatus extends BaseHttpServlet {
             writer.println("Available Actions");
             writer.println("--------------------");
             writer.println("<li><a href=./status>Default View</a>:   Default set of information");
-            writer.println("<li><a href=./status?headers=true>Full Headers</a>:   Display all request's headers");
+            writer.println("<li><a href=./status?debug=true>Debug Info</a>:     Display information for debugging; request headers, system properties, etc.");
             writer.println("<li><a href=./status?job.details=true>Job Details</a>:    View detailed Async Job Information");
             writer.println("<li><a href=./status?execGC=true>Trigger GC</a>:     Invoke JVM garbage collection");
             skip(writer);
@@ -99,9 +99,11 @@ public class ServerStatus extends BaseHttpServlet {
 
             displayCacheInfo(writer, prov.getEhcacheManager(), sInfo);
 
-            if (showHeaders) {
+            if (showDebug) {
                 skip(writer);
                 showHeaders(writer, req);
+                skip(writer);
+                showSystemProperties(writer);
             }
 
             writer.println("</pre>");
@@ -317,6 +319,21 @@ public class ServerStatus extends BaseHttpServlet {
         w.println("Async Job Information");
         w.println();
         w.println(JobManager.getStatistics(details));
+    }
+
+    private static void showSystemProperties(PrintWriter w) {
+
+        w.println("System Properties");
+        w.println("-----------------");
+
+        // Get system properties
+        var props = System.getProperties();
+
+        // Iterate through properties and print them
+        for (String key : props.stringPropertyNames()) {
+            String value = props.getProperty(key);
+            w.println(String.format("    %s: %s", key, value));
+        }
     }
 
     private static void showHeaders(PrintWriter w, HttpServletRequest req) {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1648

This PR addresses several issues and improvements related to environment variable parsing.

The key changes are:

- Resolved issues with escaping special characters during Dockerfile parsing of environment variables.
- Rewritten the old launchTomcat.sh launch script into entrypoint.py, which is now the primary entrypoint for launching Tomcat.
- Add unit test entrypoint_test.py to make testing easier when modifying entrypoint.py
- Expose System Properties in ServerStatus
- Updated Jenkinsscripts to ensure that special characters in env variables are properly escaped

Test via Jenkins + Helm:  https://firefly-1648-envvars-parsing.irsakudev.ipac.caltech.edu/irsaviewer/
This is built with FIREFLY_PROPS=
```
OP_tap_additional_services_0_label=IRSA
OP_tap_additional_services_0_value=https://irsadev.ipac.caltech.edu/TAP
OP_tap_additional_services_0_hipsUrl=ivo://CDS/P/SDSS9/color
OP_tap_additional_services_0_fovDeg=2
OP_tap_additional_services_0_centerWP=5;5;EQ_J2000

```
I'm not entirely sure what all of this means, but I can confirm that it's hitting irsadev instead of irsa and that HiPS coverage is using SDSS9 color.

Test via Docker Compose:

Added to firefly-docker.env
```
## FIREFLY-1648 tests  -- will remove before merging.
pathPrefix=local       # path to firefly is now /local/firefly/ instead of /firefly/
PROPS="abc=123;semicolon=abc;;xyz;space=abc xyz;quote=abc\"xyz\""
PROPS_OP_tap_additional_services_0_centerWP=5;5;EQ_J2000
```
Start Firefly using Docker Comopse
```bash
cd firefly
docker compose up firefly --build
```
Verify that Firefly is now running at http://localhost:8080/local/firefly/ instead of /firefly/
Go to /admin/status -> click 'Debug Info'
to see that PROPS (multi-props) and PROPS_OP_tap_additional.. (single prop) are set.

You can also run `docker compose run firefly --dry-run` to see what envVars were used and how it will appears in the `CATALINA_OPTS` envVar.

If you have python3 installed, you can run unit tests:
```bash
cd firefly/docker
python3 entrypoint_test.py
```

These are fixes to Jenkins script if interested.  [commit](https://github.com/IPAC-SW/irsa-jenkins/commit/165905782e2edee82c52cb657314b17ee5a1db68) and [commit](https://github.com/IPAC-SW/irsa-jenkins/commit/169a29dc4cf9d2c32b2a1373649909194acfa479)
