### PR TITLE
FIREFLY-1652: Heatmap fails to display data after filtering

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
@@ -75,13 +75,13 @@ public class DecimationProcessor extends TableFunctionProcessor {
         deciFunc.setCols(deciInfo.getxExp(), deciInfo.getyExp());
 
         int dataPoints = Math.min(deciKey.getxCount(), deciKey.getyCount());
-        int deciEnableSize = deciInfo.getDeciEnableSize() > 0 ? deciInfo.getDeciEnableSize() : DECI_ENABLE_SIZE;
+        int deciEnableSize = deciInfo.getDeciEnableSize() > -1 ? deciInfo.getDeciEnableSize() : DECI_ENABLE_SIZE;
         String tblName = getResultSetTable(treq);
         if (dataPoints < deciEnableSize) {
             String sql = """
                 CREATE TABLE %s as (
                 SELECT %s as "%s", %s as "%s", ROW_NUM as "rowidx", ROW_NUMBER() OVER () AS %s, ROW_NUMBER() OVER () AS %s,
-                FROM %s
+                FROM %s)
                 """.formatted(tblName, deciInfo.getxExp(), deciKey.getXCol(), deciInfo.getyExp(), deciKey.getYCol(), ROW_NUM, ROW_IDX, dataTbl);
             dbAdapter.execUpdate(sql);
         } else {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1652

Reported by NEXSci.


Test: https://fireflydev.ipac.caltech.edu/firefly-1652-heatmap-filtering/firefly/
-> IRSA Catalogs Search -> m31 -> 2000 asec
-> Add a chart(+ icon) -> heatmap -> x=ra y=dec -> Ok
Filter a small section of the heatmap to return fewer than 5000 points. This works correctly in the PR build but fails on irsatest/irsaviewer.