### PR TITLE
Firefly 1654 euclid download failed

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -239,6 +239,6 @@ public class JobInfo implements Serializable {
 //====================================================================
 
     public static record Error ( int code, String msg) implements Serializable {}
-    public static record Result(String href, String hrefType, String mimeType, String size){};
+    public static record Result(String href, String hrefType, String mimeType, String size) implements Serializable {};
 
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
@@ -24,15 +24,12 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -119,7 +119,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     public DbAdapter getDbAdapter(TableServerRequest treq) {
         String reqId = treq.getRequestId();
         String hash = DigestUtils.md5Hex(getUniqueID(treq));
-        DbFileCreator dbFileCreator = (ext) -> new File(QueryUtil.getTempDir(treq), "%s_%s.%s".formatted(reqId, hash, ext));
+        DbFileCreator dbFileCreator = (ext) -> new File(QueryUtil.getSessDir(treq), "%s_%s.%s".formatted(reqId, hash, ext));
         return DbAdapter.getAdapter(treq, dbFileCreator);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -115,10 +115,10 @@ public class QueryUtil {
     }
 
     /**
-     * returns a hierarchical temporary directory.
+     * returns a temporary directory based on a user's session ID.
      * @return
      */
-    public static File getTempDir(ServerRequest req) {
+    public static File getSessDir(TableServerRequest req) {
         File tempDir = new File(ServerContext.getTempWorkDir(), getSessPrefix(req));
         if (!tempDir.exists()) tempDir.mkdirs();
         return tempDir;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -102,15 +102,14 @@ public class QueryUtil {
      * @return
      */
     public static File getTempDir(TableServerRequest tsr) {
-        if (tsr == null) { return new File(ServerContext.getTempWorkDir(), "bad-requests");}
         File tempDir;
-        if (tsr.getJobId() != null) {
+        if (tsr != null && !isEmpty(tsr.getJobId())) {
             var baseDir = new File(ServerContext.getStageWorkDir(), "jobs");
             tempDir = new File(baseDir, jobIdToDir(tsr.getJobId()));
         } else {
             tempDir = new File(ServerContext.getTempWorkDir(), getSessPrefix(tsr));
         }
-        if (!tempDir.exists()) tempDir.mkdirs();
+        tempDir.mkdirs();
         return tempDir;
     }
 

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -14,13 +14,14 @@ import {BG_JOB_ADD} from './BackgroundCntlr.js';
 import {jsonFetch} from '../JsonUtils.js';
 import {ServerParams} from '../../data/ServerParams.js';
 import * as SearchServices from '../../rpc/SearchServicesJson.js';
+import {logger} from '../../util/Logger';
 
 
 
 export const submitJob = (cmd, params) => {
     // submit this job.  No need to add it into flux.  Server will push update to it.
     params[ServerParams.COMMAND] = cmd;
-    return jsonFetch(getCmdSrvAsyncURL(), params, true);
+    return jsonFetch(getCmdSrvAsyncURL(), params, true).catch( (e) => { logger.error(e); });
 };
 
 export const modifyJob = (jobId, cmd, params) => {

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -172,11 +172,8 @@ export function packageRequest(dlRequest, searchRequest, selectionInfo, download
         [ServerParams.REQUEST]: JSON.stringify(searchRequest),
         [SELECTION_INFO]: selectionInfo
     };
-
-    if (downloadType === 'script') {
-        return submitJob(ServerParams.DOWNLOAD_SCRIPT_REQUEST, params); //DownloadScriptWorker will download a script with urls, per the clients scriptType
-    }
-    return submitJob(ServerParams.PACKAGE_REQUEST, params);
+    const cmd = downloadType === 'script' ? ServerParams.DOWNLOAD_SCRIPT_REQUEST : ServerParams.PACKAGE_REQUEST;
+    return submitJob(cmd, params);
 }
 
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/RedisServiceTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/RedisServiceTest.java
@@ -32,8 +32,7 @@ public class RedisServiceTest extends ConfigTest {
 
     @Before
     public void setup() {
-        RedisService.connect();
-        if (RedisService.isOffline()) {
+        if (!RedisService.connect()) {
             System.out.println("Messenger is offline; skipping test.");
         }
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
@@ -73,7 +72,7 @@ public class RedisServiceTest extends ConfigTest {
 
     private void testRedis() {
 
-        if (RedisService.isOffline()) return;
+        if (!RedisService.connect()) return;
 
         assertEquals(RedisService.Status.ONLINE, RedisService.getStatus());
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/messaging/MessengerTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/messaging/MessengerTest.java
@@ -39,8 +39,7 @@ public class MessengerTest extends ConfigTest {
 
     @Before
     public void setup() {
-        RedisService.connect();
-        if (RedisService.isOffline()) {
+        if (!RedisService.connect()) {
             System.out.println("Messenger is offline; skipping test.");
             isOffline = true;
         }

--- a/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
@@ -83,7 +83,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
     @BeforeClass
     public static void setUp() throws InterruptedException {
 
-        if (RedisService.isOffline()) {
+        if (!RedisService.connect()) {
             System.out.println("Messenger is offline; skipping all tests in CachePeerProviderFactoryTest.");
             return;
         }
@@ -106,7 +106,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void pubSub_InitialSetup() throws InterruptedException, RemoteException {
-        if (RedisService.isOffline()) return;
+        if (!RedisService.connect()) return;
 
         assertEquals("Number of caches", 2, peer1.getCacheNames().length);
 
@@ -123,7 +123,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void pubSub_CacheReplication() throws InterruptedException, RemoteException {
-        if (RedisService.isOffline()) return;
+        if (!RedisService.connect()) return;
 
         LOG.debug("put a few entries into peer1... it should be replicated to the rest of the peers");
         peer1.getCache("cache_1").put(new Element("key1", "value1"));
@@ -146,7 +146,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void pubSub_PeerAddDrop() throws InterruptedException, RemoteException {
-        if (RedisService.isOffline()) return;
+        if (!RedisService.connect()) return;
 
         LOG.debug("testing drop-off.... shutdown peer1");
         peer1.shutdown();
@@ -178,7 +178,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void multicast_InitialSetup() throws InterruptedException, RemoteException {
-        if (RedisService.isOffline()) return;
+        if (!RedisService.connect()) return;
 
         assertEquals("Number of caches", 2, mcPeer1.getCacheNames().length);
 
@@ -195,7 +195,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void multicast_CacheReplication() throws InterruptedException, RemoteException {
-        if (RedisService.isOffline()) return;
+        if (!RedisService.connect()) return;
 
         LOG.debug("put a few entries into mcPeer1... it should be replicated to the rest of the peers");
         mcPeer1.getCache("cache_1").put(new Element("key1", "value1"));
@@ -218,7 +218,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void multicast_PeerAddDrop() throws InterruptedException, RemoteException {
-        if (RedisService.isOffline()) return;
+        if (!RedisService.connect()) return;
 
         LOG.debug("testing drop-off.... shutdown mcPeer1");
         mcPeer1.shutdown();


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1654

- Ensure the temp directory exists before returning it.  This was causing download to fail.
- Update Redis to reconnect if not already connected on every use, since it is now a mandatory runtime dependency.

Test: https://firefly-1654-euclid-download-failed.irsakudev.ipac.caltech.edu/applications/euclid/

-> Images Tab -> 1st example coordinate -> Submit
-> Select all rows, then click "Generate Download Script" -> click "Download Script"

The script should successfully download.