### PR TITLE
FIREFLY-1644: Fix Readout values in Flags-extension of the LVF Images

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/DirectFitsAccessData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/DirectFitsAccessData.java
@@ -34,7 +34,7 @@ public class DirectFitsAccessData implements Serializable {
     public int naxis1() { return getIntHeader(NAXIS1,0); }
     public int naxis2() { return getIntHeader(NAXIS2,0); }
     public double cDelt2() { return getDoubleHeader(CDELT2,0.0); }
-    public double bScale() { return getDoubleHeader(BSCALE,0.0); }
+    public double bScale() { return getDoubleHeader(BSCALE,1.0); }
     public double bZero() { return getDoubleHeader(BZERO,0.0); }
     public String blankValue() { return getStringHeader(BLANK_VALUE,""); }
     public long dataOffset() { return getLongHeader(DATA_OFFSET,0L); }

--- a/src/firefly/js/visualize/saga/MouseReadoutWatch.js
+++ b/src/firefly/js/visualize/saga/MouseReadoutWatch.js
@@ -21,7 +21,7 @@ import {
     primePlot, getPlotStateAry, getPlotViewById, getImageCubeIdx, getPtWavelength,
     getWavelengthParseFailReason, getWaveLengthUnits, hasPixelLevelWLInfo, hasPlaneOnlyWLInfo,
     isImageCube, wavelengthInfoParsedSuccessfully, } from '../PlotViewUtil';
-import {getBixPix} from '../FitsHeaderUtil.js';
+import {getFluxRadix} from 'firefly/visualize/ui/MouseReadoutUIUtil';
 
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -251,7 +251,7 @@ function makeImagePlotAsyncReadout(plotView, worldPt, screenPt, imagePt, threeCo
     const plot= primePlot(plotView);
     const readoutItems= makeImmediateReadout(plot, worldPt, screenPt, imagePt, threeColor, healpixPixel, norder);
     const {readoutPref}= readoutRoot();
-    const radix= Number(getBixPix(plot)>0 ? readoutPref.intFluxValueRadix : readoutPref.floatFluxValueRadix);
+    const radix= getFluxRadix(readoutPref, plot);
     return doFluxCall(plotView,imagePt).then( (fluxResult) => {
         return makeReadoutWithFlux(readoutItems,primePlot(plotView), fluxResult, radix, threeColor);
     });

--- a/src/firefly/js/visualize/ui/MouseReadPopoutAll.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadPopoutAll.jsx
@@ -13,10 +13,9 @@ import {getAppOptions} from 'firefly/core/AppDataCntlr.js';
 import {ThumbnailView} from 'firefly/visualize/ui/ThumbnailView.jsx';
 import {MagnifiedView} from 'firefly/visualize/ui/MagnifiedView.jsx';
 import {getActivePlotView, getPlotViewById, primePlot} from 'firefly/visualize/PlotViewUtil.js';
-import {getFluxInfo, getNonFluxDisplayElements} from 'firefly/visualize/ui/MouseReadoutUIUtil.js';
+import {getFluxInfo, getFluxRadix, getNonFluxDisplayElements} from 'firefly/visualize/ui/MouseReadoutUIUtil.js';
 import {DataReadoutItem, MouseReadoutLock} from 'firefly/visualize/ui/MouseReadout.jsx';
 import {isImage} from 'firefly/visualize/WebPlot.js';
-import {getBixPix} from '../FitsHeaderUtil.js';
 import {showMouseReadoutFluxRadixDialog} from './MouseReadoutOptionPopups.jsx';
 
 export const MOUSE_READOUT_DIALOG_ID= 'MouseReadoutPopoutAll';
@@ -55,7 +54,7 @@ function PopoutMouseReadoutContents({vr,currMouseState, readout, readoutData}) {
     const lockByClick= isLockByClick(readoutRoot());
     const pvToUse= lockByClick ? pv : mousePv;
     const {readoutPref}= readoutRoot();
-    const radix= Number(getBixPix(primePlot(pvToUse))>0 ? readoutPref.intFluxValueRadix : readoutPref.floatFluxValueRadix);
+    const radix= getFluxRadix(readoutPref, primePlot(pvToUse));
 
     return (
         <div>

--- a/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
+++ b/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
@@ -15,6 +15,7 @@ import CoordinateSys from '../CoordSys.js';
 import {showMouseReadoutOptionDialog} from './MouseReadoutOptionPopups.jsx';
 import {getFormattedWaveLengthUnits, primePlot} from '../PlotViewUtil';
 import {showInfoPopup} from '../../ui/PopupUtil';
+import {getBixPix, getBScale, getBZero} from 'firefly/visualize/FitsHeaderUtil';
 
 
 const myFormat= (v,precision) => !isNaN(v) ? sprintf(`%.${precision}f`,v) : '';
@@ -40,6 +41,17 @@ const labelMap = {
 };
 
 const coordOpTitle= 'Choose readout coordinates';
+
+export const getFluxRadix = (readoutPref, primePlot) => {
+    // From FITS 4.00 (https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf), p. 14-15, Table 11 and section 4.4.2.5
+    const isFluxInt = getBixPix(primePlot)>0 && getBScale(primePlot)===1 && (getBZero(primePlot)===0
+            // OR if bZero was used as follows for representation of unsigned-integer data
+            || (getBixPix(primePlot)===8 && getBZero(primePlot)===-128)
+            || (getBixPix(primePlot)===16 && getBZero(primePlot)===32768)
+            || (getBixPix(primePlot)===32 && getBZero(primePlot)===2147483648)
+        );
+    return Number(isFluxInt ? readoutPref.intFluxValueRadix : readoutPref.floatFluxValueRadix);
+};
 
 export function getNonFluxDisplayElements(readoutData, readoutPref, isHiPS= false) {
     const objList= getNonFluxReadoutElements(readoutData,  readoutPref, isHiPS);

--- a/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
@@ -6,9 +6,8 @@
 import React, {forwardRef} from 'react';
 import PropTypes from 'prop-types';
 import {omit} from 'lodash';
-import {getBixPix} from '../FitsHeaderUtil.js';
 import {SINGLE, GRID} from '../MultiViewCntlr.js';
-import {getPlotViewById, primePlot} from '../PlotViewUtil.js';
+import {primePlot} from '../PlotViewUtil.js';
 import {MultiItemViewerView} from './MultiItemViewerView.jsx';
 import {ImageViewer} from '../iv/ImageViewer';
 import {useMouseStoreConnector} from 'firefly/visualize/ui/MouseStoreConnector.jsx';
@@ -17,6 +16,7 @@ import {isLockByClick, readoutRoot} from 'firefly/visualize/MouseReadoutCntlr.js
 import {MouseReadoutBottomLine} from 'firefly/visualize/ui/MouseReadoutBottomLine.jsx';
 import {isDialogVisible} from 'firefly/core/ComponentCntlr.js';
 import {MOUSE_READOUT_DIALOG_ID} from 'firefly/visualize/ui/MouseReadPopoutAll.jsx';
+import {getFluxRadix} from 'firefly/visualize/ui/MouseReadoutUIUtil';
 
 
 function makeState() {
@@ -60,8 +60,8 @@ export const MultiImageViewerView = forwardRef( (props, ref) => {
     }
     
     const {readoutPref}= readoutRoot();
-    const pvToUse= isLockByClick(readoutRoot()) ? primePlot(visRoot) : getPlotViewById(visRoot,lastMouseCtx().plotId);
-    const radix= Number(getBixPix(primePlot(pvToUse))>0 ? readoutPref.intFluxValueRadix : readoutPref.floatFluxValueRadix);
+    const pvToUse= isLockByClick(readoutRoot()) ? primePlot(visRoot) : primePlot(visRoot,lastMouseCtx().plotId);
+    const radix= getFluxRadix(readoutPref, pvToUse);
 
     if (layoutType===SINGLE || viewerPlotIds?.length===1) {
         return (


### PR DESCRIPTION
Fixes [FIREFLY-1644](https://jira.ipac.caltech.edu/browse/FIREFLY-1644)

- Made server side code treat integer values different than double when formatting base 10 string
- Created getFluxRadix() and fixed MultiImageViewerView.jsx calling primePlot twice

## Testing
https://firefly-1644-flag-readout-bug.irsakudev.ipac.caltech.edu/applications/spherex

Make a LVF search (without any constraints) -> LVF image result, make sure it's full image -> change HDU to #2(FLAGS):
1. hovering over image should show values in integer (without `.0`)
2. turn on click lock -> click on "Value" -> Radix dialog -> change floating point radix to hexadecimal that shouldn't change value being displayed, but changing integer radix should change it
    - also make sure same applies to with click-lock off, and mouse readout popout modes.