### PR TITLE
IRSA-6572: Add "Prepare Download" to download LVF images

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
@@ -118,7 +118,7 @@ public final class DownloadScriptWorker implements Job.Worker {
 
                     //retrieve attributes based on scriptType
                     List<ScriptAttributes> attribute = scriptTypeMap.getOrDefault(scriptType.toLowerCase(), text);
-                    DownloadScript.composeDownloadScript(outFile, "Euclid", urlList, attribute);
+                    DownloadScript.composeDownloadScript(outFile, dlreq.getDataSource(), urlList, attribute);
 
                     if (outFile.exists()) {
                         String fileExtension = scriptTypeToExtension.getOrDefault(scriptType.toLowerCase(), ".txt");

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -27,6 +27,7 @@ import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
 import {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
 import {Stack, Typography, Box} from '@mui/joy';
 import {ToolbarButton} from 'firefly/ui/ToolbarButton';
+import {RadioGroupInputField} from 'firefly/ui/RadioGroupInputField';
 
 const DOWNLOAD_DIALOG_ID = 'Download Options';
 const OptionsContext = React.createContext();
@@ -299,6 +300,21 @@ export function DownloadCutout({fieldKey='dlCutouts'}) {
         />
     );
 }
+
+export function ScriptTypeOptions({fieldKey='scriptType', ...props}) {
+    return (
+        <RadioGroupInputField
+            fieldKey={fieldKey}
+            orientation={'horizontal'}
+            initialState={{value: 'curl'}}
+            options={[{label: 'Curl', value: 'curl'}, {label: 'Wget', value: 'wget'}, {label: 'Plain Text (URLs)', value: 'urls'}]}
+            label='Download Script:'
+            tooltip='Choose the download script type'
+            {...props}
+        />
+    );
+}
+
 export function EmailNotification({style, groupKey}) {
     const enableEmail = useStoreConnector(() => getFieldVal(groupKey, emailNotif));
 

--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -23,7 +23,7 @@ import {dispatchHideDialog} from 'firefly/core/ComponentCntlr';
 import {makeColsLines, tableColumnsConstraints} from 'firefly/ui/tap/TableColumnsConstraints';
 
 
-export function onTapSearchSubmit(request, serviceUrl, tapBrowserState, additionalClauses='', metaInfo={}) {
+export function onTapSearchSubmit(request, serviceUrl, tapBrowserState, additionalClauses='', metaInfo={}, tblOptions={}) {
     const isUserEnteredADQL = (request.selectBy === 'adql');
     let adql;
     let isUpload;
@@ -82,7 +82,7 @@ export function onTapSearchSubmit(request, serviceUrl, tapBrowserState, addition
             ...metaInfo,
             [MetaConst.DATA_SERVICE_ID] : getServiceId(serviceUrl),
         };
-        dispatchTableSearch(treq, {backgroundable: true, showFilters: true, showInfoButton: true});
+        dispatchTableSearch(treq, {backgroundable: true, showFilters: true, showInfoButton: true, ...tblOptions});
     };
 
     if (!hasMaxrec && !adql.toUpperCase().match(/ TOP | WHERE /)) {


### PR DESCRIPTION
Fixes [IRSA-6572](https://jira.ipac.caltech.edu/browse/IRSA-6572)

See ife PR: https://github.com/IPAC-SW/irsa-ife/pull/382

- Generalized common code as ScriptTypeOptions component
- Made DataSource in DownloadScriptWorker to be accepted as a param
- Exposed table options in onTapSearchSubmit needed for adding download button in LVF results

## Testing
https://irsa-6572-download-lvf.irsakudev.ipac.caltech.edu/applications/euclid

Just do regression testing on Euclid downloads

