### PR TITLE
IRSA-6574: Misleading crosshairs and positions on images

### DIFF
--- a/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
@@ -1,5 +1,5 @@
 import {getPreferCutout} from '../../ui/tap/Cutout';
-import { getSearchTarget, makeWorldPtUsingCenterColumns } from '../../voAnalyzer/TableAnalysis.js';
+import { getSearchTarget } from '../../voAnalyzer/TableAnalysis.js';
 import {
     getDataLinkData, isDownloadType, isGzipType, isSimpleImageType, isTarType, isVoTable
 } from '../../voAnalyzer/VoDataLinkServDef.js';
@@ -124,9 +124,9 @@ function convertAllToDownload(menu) {
     }).filter( (d) => d.displayType);
 }
 
-function getDLMenuEntryData({dlTableUrl, dlData={}, idx, sourceTable, sourceRow}) {
+function getDLMenuEntryData({dlTableUrl, dlData={}, idx, sourceTable}) {
     return {
-        positionWP: getSearchTarget(sourceTable?.request,sourceTable) ?? makeWorldPtUsingCenterColumns(sourceTable,sourceRow),
+        positionWP: getSearchTarget(sourceTable?.request,sourceTable),
         contentType: dlData.contentType?.toLowerCase(),
         sRegion: dlData.sourceObsCoreData?.s_region,
         prodType: dlData.sourceObsCoreData?.dataproduct_type,


### PR DESCRIPTION
Fixes [IRSA-6574](https://jira.ipac.caltech.edu/browse/IRSA-6574)

- search target was not getting extracted from ADQL QUERY string in request for `POINT()` case. Changed regex to capture both `CIRCLE()` and `POINT()`


## Testing
https://irsa-6574-crosshair-bug.irsakudev.ipac.caltech.edu/applications/spherex

Go to LVF image search, enter coords in ticket: `10:22:19 +41:29:58` and "observation boundary contains point" -> search. In "Data" tab, change view to multi image view and align and lock by WCS. The crosshairs should land on searched coordinates.

Go back to LVF search tab, change to "observation bounary interesects shape", cone shape: 1 degree radius -> search. Again the crosshairs should be on the searched target. 

NOTE: If you go back to LVF search tab, and change to polygon shape and search. ~The resulting images will have crosshairs at image centre. It's because `getSearchTarget` returns `undefined` so it picks centre columns from table: https://github.com/Caltech-IPAC/firefly/blob/d4c9e0a9094234835ec673fcd016ffcbb3468948/src/firefly/js/metaConvert/vo/DataLinkProcessor.js#L129~

~@robyww Do we want to change the logic to either not show any crosshairs for polygon or make the layers tab say something other than "Image Search"?~ The resulting images will no longer have crosshairs because polygon search request doesn't resolve to a search target.