### PR TITLE
FIREFLY-1662: Support for Cutout Service Descriptor URL generation

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
@@ -2,29 +2,22 @@ package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.FileInfo;
-import edu.caltech.ipac.firefly.data.HttpResultInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
-import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import edu.caltech.ipac.table.DataGroup;
-import edu.caltech.ipac.table.MappedData;
+import edu.caltech.ipac.table.*;
 import edu.caltech.ipac.table.io.VoTableReader;
 import edu.caltech.ipac.util.FileUtil;
-import edu.caltech.ipac.util.download.URLDownload;
-import org.apache.commons.lang.ArrayUtils;
+import edu.caltech.ipac.util.StringUtils;
+import org.json.JSONObject;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
+import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.getSelectedData;
 import static edu.caltech.ipac.util.FileUtil.getUniqueFileNameForGroup;
 import static org.apache.commons.lang.StringUtils.substringAfterLast;
 
@@ -36,10 +29,28 @@ public class ObsCorePackager extends FileGroupsProcessor {
             "csv", "tbl", "fits", "json", "pdf", "tar", "html", "xml", "vot", "vot", "vot", "vot", "reg", "png", "xml");
 
     public static final String PRODUCTS = "productTypes";
-    public static final String SCRIPT = "scriptType";
     public static final String ACCESS_URL = "access_url";
+    public static final String SERVICE_DEF = "service_def";
     public static final String ACCESS_FORMAT = "access_format";
     public static final String SEMANTICS = "semantics";
+    public static final String CONTENT_TYPE = "content_type";
+
+    public static final String DATALINK_SER_DEF = "datalinkServiceDescriptor";
+    public static final String ADHOC_SERVICE = "adhoc:service";
+    public static final String DATALINK = "datalink";
+    public static final String CENTER_COLS = "centerCols";
+    public static final String CUTOUT_VALUE = "cutoutValue";
+    public static final String SER_DEF_ACCESS_URL = "accessURL";
+    public static final String SER_DEF_INPUT_PARAMS = "inputParams";
+    public static final String CIRCLE = "circle";
+    public static final String REF = "ref";
+    public static final String VALUE = "value";
+    public static final String TEMPLATE_COL_NAMES = "templateColNames";
+    public static final String USE_SOURCE_FILE_NAME = "useSourceUrlFileName";
+
+    private static final List<String> CUTOUT_UCDs= Arrays.asList("phys.size","phys.size.radius","phys.angSize", "pos.spherical.r");
+    private static final List<String>  RA_UCDs= List.of("pos.eq.ra");
+    private static final List<String>  DEC_UCDs= List.of("pos.eq.dec");
 
     public List<FileGroup> loadData(ServerRequest request) throws IOException, DataAccessException {
         try {
@@ -53,50 +64,86 @@ public class ObsCorePackager extends FileGroupsProcessor {
     private List<FileGroup> computeFileGroup(DownloadRequest request) throws DataAccessException{
         var selectedRows = new ArrayList<>(request.getSelectedRows());
 
-        String productTypes = request.getParam(PRODUCTS); //products to download in datalink file
-        String[] products = (productTypes != null && !productTypes.trim().isEmpty()) ? productTypes.split(",") : null;
-
         List<FileInfo> fileInfos = new ArrayList<>();
         MappedData dgDataUrl = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(), selectedRows); //returns all columns
+
+        DataGroup dg = getSelectedData(request.getSearchRequest(), selectedRows);
+        String datalinkServDesc = request.getParam(DATALINK_SER_DEF); //check for a non obscore file containing a datalink service descriptor
 
         try {
             Map<String,Integer> dataLinkFolders = new HashMap<>();
             for (int idx : selectedRows) {
-                String access_url = (String) dgDataUrl.get(idx, "access_url");
+
+                String access_url = (String) dgDataUrl.get(idx, ACCESS_URL);
+
                 if (access_url == null) {
-                    continue; //no file available to process
+                    //check if this could be a non-obscore table containing a datalink url
+                    if (datalinkServDesc != null) {
+                        //construct product url / access url here
+                        ServDescUrl serDescUrl = createUrlFromServDesc(datalinkServDesc);
+
+                        if (serDescUrl.isValid()) {
+                            StringBuilder finalUrl = new StringBuilder(serDescUrl.partialUrl);
+
+                            if (serDescUrl.missingParams.isEmpty()) {
+                                access_url = serDescUrl.partialUrl;
+                            }
+                            else {
+                                for (MissingParam missing : serDescUrl.missingParams) {
+                                    String refId = missing.refId;
+                                    String key = "";
+                                    for (DataType data : dg.getDataDefinitions()) {
+                                        if (data.getID().equalsIgnoreCase(refId)) {
+                                            key = data.getKeyName();
+                                            break;
+                                        }
+                                    }
+                                    String resolvedValue = (String) dgDataUrl.get(idx, key);
+                                    if (resolvedValue != null && !resolvedValue.isEmpty()) {
+                                        if (serDescUrl.partialUrl.endsWith("?"))
+                                            finalUrl.append(missing.paramName).append("=").append(resolvedValue);
+                                        else
+                                            finalUrl.append("&").append(missing.paramName).append("=").append(resolvedValue);
+                                    }
+                                }
+                                access_url = finalUrl.toString(); //datalink url from service descriptor
+                            }
+                        }
+                    }
+                    else continue; //no file available to process
                 }
-                String access_format = (String) dgDataUrl.get(idx, "access_format");
+                String access_format = (String) dgDataUrl.get(idx, ACCESS_FORMAT);
                 URL url = new URL(access_url);
 
-                FileInfo fileInf1o1 = new FileInfo(access_url, null, 0);
-                FileInfo fileInf1o2 = new FileInfo(access_url, ".txt", 0);
-
-                String colNames = request.getSearchRequest().getParam("templateColNames");
-                boolean useSourceUrlFileName= request.getSearchRequest().getBooleanParam("useSourceUrlFileName",false);
+                String colNames = request.getSearchRequest().getParam(TEMPLATE_COL_NAMES);
+                boolean useSourceUrlFileName= request.getSearchRequest().getBooleanParam(USE_SOURCE_FILE_NAME,false);
                 String[] cols = colNames != null ? colNames.split(",") : null;
-
                 String ext_file_name = getFileName(idx,cols,useSourceUrlFileName,dgDataUrl,url);
-                String extension;
 
                 if (access_format != null) {
-                    if (access_format.contains("datalink")) {
+                    if (access_format.contains(DATALINK)) {
                         ext_file_name = getUniqueFileNameForGroup(ext_file_name, dataLinkFolders);
-                        List<FileInfo> tmpFileInfos = parseDatalink(url, ext_file_name, products, useSourceUrlFileName);
+                        List<FileInfo> tmpFileInfos = parseDatalink(url, request, dgDataUrl, idx, ext_file_name);
                         fileInfos.addAll(tmpFileInfos);
                     }
                     else { //non datalink entry -  such as fits,jpg etc.
                         if (!useSourceUrlFileName || FileUtil.getExtension(ext_file_name).isEmpty()) {
-                            extension = access_format.replaceAll(".*/", "");
+                            String extension = access_format.replaceAll(".*/", "");
                             ext_file_name += "." + extension;
                         }
                         FileInfo fileInfo = new FileInfo(access_url, ext_file_name, 0);
                         fileInfos.add(fileInfo);
                     }
                 }
-                else { //access_format is null, so try and get it from the url's Content_Type
-                    FileInfo fileInfo = new FileInfo(access_url, ext_file_name, 0);
-                    fileInfos.add(fileInfo);
+                else {
+                    if (datalinkServDesc != null) { //parse the datalink url found in the non-obscore table
+                        List<FileInfo> tmpFileInfos = parseDatalink(url, request, dgDataUrl, idx, ext_file_name);
+                        fileInfos.addAll(tmpFileInfos);
+                    }
+                    else { //access_format & access_url are both null, so try and get it from the url's Content_Type
+                        FileInfo fileInfo = new FileInfo(access_url, ext_file_name, 0);
+                        fileInfos.add(fileInfo);
+                    }
                 }
 
             }
@@ -108,19 +155,39 @@ public class ObsCorePackager extends FileGroupsProcessor {
         return Arrays.asList(new FileGroup(fileInfos, null, 0, "ObsCore Download Files"));
     }
 
-    public static List<FileInfo> parseDatalink(URL url, String prepend_file_name, String[] products, boolean useSourceUrlFileName) {
-        List<FileInfo> fileInfos = new ArrayList<>();;
+    public static List<FileInfo> parseDatalink(URL url, DownloadRequest request, MappedData dgDataUrl, int idx, String prepend_file_name) {
+        List<FileInfo> fileInfos = new ArrayList<>();
+
+        //products to download in datalink file
+        String productTypes = request.getParam(PRODUCTS);
+        String[] products = (productTypes != null && !productTypes.trim().isEmpty()) ? productTypes.split(",") : null;
+
+        //to be used for cutouts (in the Service descriptor url query string)
+        String centerColParam = request.getParam(CENTER_COLS);
+        String[] centerCols = (centerColParam != null && !centerColParam.trim().isEmpty()) ? centerColParam.split(",") : null;
+        String cutoutValue = request.getParam(CUTOUT_VALUE);
+        String ra = centerCols[0];
+        String dec = centerCols[1];
+
+        boolean useSourceUrlFileName= request.getSearchRequest().getBooleanParam(USE_SOURCE_FILE_NAME,false);
+
         try {
             DataGroup[] groups = VoTableReader.voToDataGroups(url.toString(), false);
+
+            //to be used for cutout service descriptor url
+            String serDefUrl = "";
+            Map<String, ServDescUrl> serDefUrls = new HashMap<>();
+
             for (DataGroup dg : groups) {
                 boolean makeDataLinkFolder = false;
                 int countValidDLFiles = 0;
                 //do one initial pass through semantics column to determine if we need to create a folder for datalink files
                 for (int i=0; i < dg.size(); i++) {
-                    String sem = String.valueOf(dg.getData(SEMANTICS, i));
-                    if (sem.equals("null")) {
+                    String sem = Objects.toString(dg.getData(SEMANTICS, i), null);
+                    if (sem == null) {
                         continue;
                     }
+
                     if (testSem(sem,"#this") || testSem(sem,"#thumbnail") ||testSem(sem,"#preview") ||
                             testSem(sem,"#preview-plot")) {
                         countValidDLFiles++;
@@ -131,18 +198,58 @@ public class ObsCorePackager extends FileGroupsProcessor {
                 }
 
                 for (int i=0; i < dg.size(); i++) {
-                    String accessUrl = String.valueOf(dg.getData(ACCESS_URL, i));
-                    String sem = String.valueOf(dg.getData(SEMANTICS, i));
-                    String content_type = String.valueOf(dg.getData("content_type", i));
+                    String accessUrl = Objects.toString(dg.getData(ACCESS_URL, i), null);
+                    String sem = Objects.toString(dg.getData(SEMANTICS, i), null);
+                    String content_type = Objects.toString(dg.getData(CONTENT_TYPE, i), null);
 
-                    if (accessUrl.equals("null") || sem.equals("null")) { //todo, accessUrl will be null for #cutout, use serviceDescriptor url
+                    String productUrl = accessUrl;
+
+                    if (accessUrl == null || sem == null) {
                         //if only semantic (sem) is null, accessUrl may still be available, but we won't know which accessUrls ones to pick
-                        continue;
+                        String serviceDef = String.valueOf(dg.getData(SERVICE_DEF, i));
+
+                        if (testSem(sem, "#cutout") && serviceDef != null && !serviceDef.isEmpty()) {
+                            ServDescUrl result;
+
+                            if (serDefUrls.containsKey(serviceDef)) { //if we have already found this service descriptor url
+                                result = serDefUrls.get(serviceDef);
+                            } else { //else, parse this service descriptor to create a product url using access_url and the inputParams
+                                result = createCutoutSerDefUrl(groups, serviceDef, ra, dec, cutoutValue);
+                                serDefUrls.put(serviceDef, result);
+                            }
+
+                            if (result != null && result.isValid()) {
+                                if (result.missingParams.isEmpty()) {
+                                    serDefUrl = result.partialUrl;
+                                } else {
+                                    //Resolve missing params from currentRow (these are inputParams with no value but a "ref" instead)
+                                    StringBuilder finalUrl = new StringBuilder(result.partialUrl);
+                                    for (MissingParam missing : result.missingParams) {
+                                        String refId = missing.refId;
+                                        String key = "";
+                                        for (DataType data : dg.getDataDefinitions()) {
+                                            if (data.getID().equalsIgnoreCase(refId)) {
+                                                key = data.getKeyName();
+                                                break;
+                                            }
+                                        }
+                                        String resolvedValue = String.valueOf(dg.getData(key, i));
+                                        if (!StringUtils.isEmpty(resolvedValue)) {
+                                            finalUrl.append("&").append(missing.paramName).append("=").append(resolvedValue);
+                                        }
+                                    }
+                                    serDefUrl = finalUrl.toString();
+                                }
+                                productUrl = serDefUrl;
+                            }
+                            else continue; //couldn't create a valid service descriptor product url for this cutout
+                        }
+                        else continue;
                     }
 
                     String ext_file_name= null;
                     if (useSourceUrlFileName) {
-                        String fileName= new URL(accessUrl).getFile();
+                        String fileName= new URL(productUrl).getFile();
                         String ext= FileUtil.getExtension(fileName);
                         if (!ext.isEmpty()) ext_file_name= fileName;
                     }
@@ -150,7 +257,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
                         ext_file_name = prepend_file_name;
                         ext_file_name = testSem(sem, "#this") ? ext_file_name : ext_file_name + "-" + substringAfterLast(sem, "#");
                         String extension = "unknown";
-                        extension = content_type != null ? getExtFromURL(content_type) : getExtFromURL(accessUrl);
+                        extension = content_type != null ? getExtFromURL(content_type) : getExtFromURL(productUrl);
                         ext_file_name += "." + extension;
                         //create a folder only if makeDataLinkFolder is true
                         ext_file_name = makeDataLinkFolder ? prepend_file_name + "/" + ext_file_name : ext_file_name;
@@ -158,11 +265,11 @@ public class ObsCorePackager extends FileGroupsProcessor {
 
                     if (products != null) { // Check if products exist and contains sem
                         if (Arrays.asList(products).contains(sem) || Arrays.asList(products).contains("*")) { //* refers to all data products
-                            FileInfo fileInfo = new FileInfo(accessUrl, ext_file_name, 0);
+                            FileInfo fileInfo = new FileInfo(productUrl, ext_file_name, 0);
                             fileInfos.add(fileInfo);
                         }
-                    } else { //add all valid accessUrls
-                        FileInfo fileInfo = new FileInfo(accessUrl, ext_file_name, 0);
+                    } else { //add all valid productUrls (accessUrls or cutout service descriptor urls)
+                        FileInfo fileInfo = new FileInfo(productUrl, ext_file_name, 0);
                         fileInfos.add(fileInfo);
                     }
                 }
@@ -173,6 +280,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
         }
         return fileInfos;
     }
+
 
     private static boolean testSem(String sem, String val) {
         return (sem!=null && sem.toLowerCase().endsWith(val));
@@ -239,5 +347,165 @@ public class ObsCorePackager extends FileGroupsProcessor {
 
         if (file_name.length() == 0) file_name = "file"; //fallback option
         return file_name;
+    }
+
+
+    //the code below parses the service descriptors for cutouts to create a cutout product URL (and to check for a ServDesc containing datalink in non-obscore fileseu)
+
+    private static ServDescUrl createCutoutSerDefUrl(DataGroup[] groups, String serviceDefId, String ra, String dec, String cutoutValue) {
+        for (DataGroup dg : groups) {
+            for (ResourceInfo ri : dg.getResourceInfos()) {
+                if (ADHOC_SERVICE.equalsIgnoreCase(ri.getUtype()) && serviceDefId.equalsIgnoreCase(ri.getID())) {
+                    ServDescUrl result = parseCutoutServiceDescriptor(ri, ra, dec, cutoutValue);
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+
+    private static ServDescUrl parseCutoutServiceDescriptor(ResourceInfo serviceDescriptor, String ra, String dec, String cutoutValue) {
+        String accessUrl = null;
+        String primaryParamName = null;
+        StringBuilder queryString = new StringBuilder();
+        List<MissingParam> missingParams = new ArrayList<>(); //these are inputParams with no value but a "ref" instead
+
+        List<GroupInfo> groups = serviceDescriptor.getGroups();
+        List<ParamInfo> params = serviceDescriptor.getParams();
+
+        //Extract accessURL
+        for (ParamInfo param : params) {
+            if (SER_DEF_ACCESS_URL.equalsIgnoreCase(param.getKeyName())) {
+                accessUrl = param.getStringValue();
+                break;
+            }
+        }
+        if (accessUrl == null || accessUrl.isEmpty()) {
+            return new ServDescUrl("", Collections.emptyList()); // Invalid service descriptor
+        }
+
+        //Locate the "inputParams" group
+        for (GroupInfo group : groups) {
+            if (!SER_DEF_INPUT_PARAMS.equalsIgnoreCase(group.getName())) continue;
+
+            List<ParamInfo> inputParams = group.getParamInfos();
+
+            //Check for xtype = "CIRCLE"
+            for (ParamInfo param : inputParams) {
+                if (CIRCLE.equalsIgnoreCase(param.getXType())) {
+                    primaryParamName = param.getKeyName();
+                    String formattedString = String.format("%s=%s+%s+%s", primaryParamName, ra, dec, cutoutValue);
+                    queryString.append(formattedString);
+                    break;
+                }
+            }
+
+            //If no CIRCLE, check for separate RA, DEC, CUTOUT via UCDs
+            if (primaryParamName == null) {
+                String raName = null, decName = null, cutoutName = null;
+
+                for (ParamInfo param : inputParams) {
+                    String ucd = param.getUCD();
+                    if (ucd == null) continue;
+
+                    if (isMatch(ucd, CUTOUT_UCDs)) cutoutName = param.getKeyName();
+                    else if (isMatch(ucd, RA_UCDs)) raName = param.getKeyName();
+                    else if (isMatch(ucd, DEC_UCDs)) decName = param.getKeyName();
+                }
+
+                if (raName != null && decName != null && cutoutName != null) {
+                    String formattedString = String.format("%s=%s&%s=%s&%s=%s", raName, ra, decName, dec, cutoutName, cutoutValue);
+                    queryString.append(formattedString);
+                } else {
+                    return new ServDescUrl("", Collections.emptyList()); // Invalid service descriptor
+                }
+            }
+
+            //Append other valid params (where value is not null or empty) (excluding RA, DEC, CUTOUT)
+            for (ParamInfo param : inputParams) {
+                String ucd = param.getUCD();
+                if (isMatch(ucd, CUTOUT_UCDs) || isMatch(ucd, RA_UCDs) || isMatch(ucd, DEC_UCDs)) continue;
+
+                String key = param.getKeyName();
+                String value = param.getStringValue();
+
+                if (StringUtils.isEmpty(key)) continue;
+
+                if (param.getRef() != null && StringUtils.isEmpty(value)) {
+                    missingParams.add(new MissingParam(key, param.getRef()));
+                } else if (value != null && !value.isEmpty()) {
+                    queryString.append("&").append(key).append("=").append(value);
+                }
+            }
+        }
+
+        return new ServDescUrl(accessUrl + "?" + queryString.toString(), missingParams);
+    }
+
+    //Utility function to check if UCD matches a known UCD category
+    private static boolean isMatch(String ucd, List<String> ucdArray) {
+        if (ucd == null || ucdArray == null || ucdArray.isEmpty()) {
+            return false;
+        }
+
+        String[] ucdParts = ucd.split(";");
+
+        //check if any ucsd exists in ucdArray
+        for (String part : ucdParts) {
+            if (ucdArray.contains(part.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    record ServDescUrl(String partialUrl, List<MissingParam> missingParams) {
+        public boolean isValid() {
+            return !StringUtils.isEmpty(partialUrl);
+        }
+    }
+
+    record MissingParam(String paramName, String refId) {}
+
+    private static ServDescUrl createUrlFromServDesc(String datalinkServDesc) {
+        String accessUrl = null;
+        StringBuilder queryString = new StringBuilder();
+        List<MissingParam> missingParams = new ArrayList<>();
+        try {
+            JSONObject jsonObject = new JSONObject(datalinkServDesc);
+
+            //extract accessUrl
+            accessUrl = jsonObject.getString(SER_DEF_ACCESS_URL);
+
+            if (StringUtils.isEmpty(accessUrl)) {
+                return new ServDescUrl("", Collections.emptyList());
+            }
+
+            //extract inputParams
+            JSONObject inputParams = jsonObject.getJSONObject(SER_DEF_INPUT_PARAMS);
+
+            for (String key : inputParams.keySet()) {
+                JSONObject paramObject = inputParams.getJSONObject(key);
+
+                //extract either "ref" or "value" (checking which exists)
+                String ref = paramObject.optString(REF, null);
+                String value = paramObject.optString(VALUE, null);
+
+                if (ref != null) {
+                    missingParams.add(new MissingParam(key, ref));
+                }
+                if (value != null) {
+                    if (!queryString.isEmpty()) queryString.append("&");
+                    queryString.append(key).append("=").append(value);
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return new ServDescUrl(accessUrl + "?" + queryString.toString(), missingParams);
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileDownload.java
@@ -214,7 +214,7 @@ public class AnyFileDownload extends BaseHttpServlet {
         String retFileStr= (local!=null) ? local : f.getName();
         if (retFileStr.equals(USE_SERVER_NAME)) retFileStr= f.getName();
         if (!isEmpty(retFileStr)) {
-            res.addHeader("Content-Disposition", "attachment; filename=\"%s\"".formatted(retFileStr));
+            res.addHeader("Content-Disposition", "attachment; filename=" + retFileStr);
         }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/DownloadScript.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/DownloadScript.java
@@ -207,15 +207,30 @@ public class DownloadScript {
 
         // if no valid extension in the path, look for "return" parameter in the query string
         if (query != null && !query.isEmpty()) {
+            String fallbackPath = null;
             for (String param : query.split("&")) {
                 String[] keyValue = param.split("=");
-                if (keyValue.length > 1 && keyValue[0].trim().equals("return")) {
-                    return sanitizeFileName(keyValue[1].trim());
+                if (keyValue.length > 1) {
+                    String key = keyValue[0].trim();
+                    String value = keyValue[1].trim();
+
+                    if (key.equals("return")) {
+                        return sanitizeFileName(value);
+                    } else if (key.equals("path") || key.equals("file")) {
+                        fallbackPath = value;
+                    }
+                }
+            }
+            //if a "return" parameter was not found, but "path" or "file" exist, extract the filename from "path" / "file"
+            if (fallbackPath != null && fallbackPath.contains("/")) {
+                String fallbackName = fallbackPath.substring(fallbackPath.lastIndexOf('/') + 1);
+                if (fallbackName.contains(".") && !fallbackName.startsWith(".")) {
+                    return sanitizeFileName(fallbackName);
                 }
             }
         }
 
-        return "download_file_" + count++;
+        return "download_file_" + count++; //final fallback if mo filename was retrieved from the URL
     }
 
     private static String sanitizeFileName(String name) {

--- a/src/firefly/js/metaConvert/vo/DatalinkFetch.js
+++ b/src/firefly/js/metaConvert/vo/DatalinkFetch.js
@@ -5,6 +5,7 @@ import {synchronizeAsyncFunctionById} from '../../util/SynchronizeAsync';
 import { getObsCoreAccessURL, isFormatDataLink, isObsCoreLike } from '../../voAnalyzer/TableAnalysis';
 import {getTableModel} from '../../voAnalyzer/VoCoreUtils';
 import {getDataLinkData, getServiceDescriptors, isDataLinkServiceDesc} from '../../voAnalyzer/VoDataLinkServDef';
+import {makeDlUrl} from './DatalinkProducts';
 
 let dlTableCache = new Map();
 const maxEntries = 30;
@@ -51,6 +52,7 @@ export async function fetchSemanticList(tableOrId,row=0) {
     else {
         const dlDescriptor= getServiceDescriptors(table)?.filter( (dDesc) => isDataLinkServiceDesc(dDesc))[0];
         url= dlDescriptor?.accessURL;
+        url= makeDlUrl(dlDescriptor,table, row);
     }
     if (!url) return [];
     return await fetchDatalinkTableSemanticList(url);

--- a/src/firefly/js/metaConvert/vo/ServDescProducts.js
+++ b/src/firefly/js/metaConvert/vo/ServDescProducts.js
@@ -271,7 +271,7 @@ export function makeUrlFromParams(url, serDef, rowIdx, userInputParams = {}) {
     return newUrl.toString();
 }
 function logServiceDescriptor(baseUrl, sendParams, newUrl) {
-    // console.log(`service descriptor base URL: ${baseUrl}`);
-    // Object.entries(sendParams).forEach(([k,v]) => console.log(`param: ${k}, value: ${v}`));
-    // console.log(`service descriptor new URL: ${newUrl}`);
+     //console.log(`service descriptor base URL: ${baseUrl}`);
+     //Object.entries(sendParams).forEach(([k,v]) => console.log(`param: ${k}, value: ${v}`));
+     //console.log(`service descriptor new URL: ${newUrl}`);
 }

--- a/src/firefly/js/metaConvert/vo/ServDescProducts.js
+++ b/src/firefly/js/metaConvert/vo/ServDescProducts.js
@@ -143,7 +143,7 @@ function makeCutoutProduct({ name, serDef, sourceTable, sourceRow, idx, activate
             // note: the size is set as a number, if is a string it is coming from the dialog
             if (isNumber(cutoutSize) && cutoutSize===SD_DEFAULT_SPACIAL_CUTOUT_SIZE && sdSizeValue!==cutoutSize) {
                 params= {[obsfieldUcd] : sdSizeValue};
-                setCutoutSize(key,sdSizeValue);
+                setCutoutSize(key,sdSizeValue, sourceTable?.tbl_id);
             }
             else {
                 params= {[obsfieldUcd] : cutoutSize};
@@ -168,7 +168,7 @@ function makeCutoutProduct({ name, serDef, sourceTable, sourceRow, idx, activate
             else {
                 const valNum= parseInt(nameGuess.value) || SD_DEFAULT_PIXEL_CUTOUT_SIZE;
                 params= {[nameGuess.name] : valNum};
-                setCutoutSize(key,valNum+'px');
+                setCutoutSize(key,valNum+'px', sourceTable?.tbl_id);
             }
             pixelBasedCutout= true;
         }

--- a/src/firefly/js/ui/dynamic/ServiceDefTools.js
+++ b/src/firefly/js/ui/dynamic/ServiceDefTools.js
@@ -12,6 +12,7 @@ import {
     makePointDef,
     makePolygonDef, makeRangeDef, makeTargetDef, makeUnknownDef, POINT, POLYGON, POSITION, RANGE, UNKNOWN
 } from './DynamicDef.js';
+import {getServiceDescriptors, isDataLinkServiceDesc} from 'firefly/voAnalyzer/VoDataLinkServDef';
 
 /**
  * @param {Array.<FieldDef>} fieldDefAry
@@ -525,4 +526,38 @@ export function ingestInitArgs(fdAry, args) {
         }
     });
 }
+
+//check for and return a datalink service descriptor url and input params, if one is found
+export function checkForDatalinkServDesc(tblModel) {
+    const serviceDescriptors = getServiceDescriptors(tblModel);
+
+    if (!serviceDescriptors) return null;
+
+    if (serviceDescriptors) {
+        for (const sd of serviceDescriptors) {
+            //serviceDescriptors.forEach((sd) => {
+            const isDatalinkSerDesc = isDataLinkServiceDesc(sd);
+            if (isDatalinkSerDesc) {
+                const productUrl = {
+                    accessURL: sd?.accessURL || '',
+                    inputParams: {}
+                };
+
+                if (sd?.serDefParams) {
+                    for (const param of sd.serDefParams) {
+                        productUrl.inputParams[param?.name] = {value: param.value, ref: param.ref};
+                    }
+                }
+
+                //return only when valid datalink access url is found
+                if (productUrl.accessURL || Object.keys(productUrl.inputParams).length > 0) {
+                    return productUrl;
+                }
+
+            }
+        }
+    }
+    return null; //no valid datalink service descriptor found
+}
+
 


### PR DESCRIPTION
**Ticket**: [FIREFLY-1662](https://jira.ipac.caltech.edu/browse/FIREFLY-1662)
[IFE PR](https://github.com/IPAC-SW/irsa-ife/pull/383)
- I am mostly looking for feedback in `ObsCorePackager.java`, where support for Cutout Service Descriptors has been added 
- `CutoutServiceDescriptor` logic supports both kinds of service descriptors for cutouts we have come to expect
  - 1. Service Descriptors containing an `x-type=circle` entry
  - 2. Service Descriptors containing separate input params (ra, dec, size) like the current Euclid ones
  - The logic for finding the correct service descriptor (corresponding to the current cutout) among several service descriptors flows largely from our conversations @loitly & @robyww 
    - But I have been able to simplify the logic a bit: 
      - I am **_not_** explicitly doing a sync/async service descriptor check, and I am **_not_** checking the standardID 
        - Reason: Since I am able to identify service descriptors with `utype=adhoc:service`, I can then match this service descriptor's ID with the `service-def` of the cutout entry we're on, to ensure we process the correct service descriptor. 

**Updates 3/4**: 
- Addressed all feedback
- Download Script now works with non-obscore files containing datalink (so Objects Search in euclid works)

**Updates 3/5**
- CADC bug is now fixed, please test it out in the firefly build below 
  - you should now also see a list of products in the download dialog. Try selecting only a few (and unselected 'All data')
  - it should still give you a zipped file with your selection (if those products exist for the row you selected)
- Small changes to `DownloadScript.java` so that when the URL contains a query string, we look at `path` and `file` params in addition to the `return` param to try and construct a file name 
  - this currently helps cutouts in euclid, but we need to consider a more generalized solution in the future  


**Testing**: 
Euclid: https://firefly-1662-service-descriptor-url.irsakudev.ipac.caltech.edu/applications/euclid
Firefly: https://fireflydev.ipac.caltech.edu/firefly-1662-service-descriptor-url/firefly/
- do an Image search (like `57.717836123 -51.248639177`) and an Objects search
- you should be able to download cutouts now (and download any products for Objects search)
  - the semantics list you see in the download dialog now makes use of `fetchSemanticList`
  - try and run the download script to ensure the cutout URLs actually yield valid cutouts. You can even upload them back to firefly to ensure they look correct. 