### PR TITLE
IRSA-6701: LVF image search minimized dialog incorrectly shows polygon search

### DIFF
--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -45,7 +45,7 @@ export const RadiusSize = 'coneSize';
 export const SpatialMethod = 'spatialMethod';
 export const PolygonCorners = 'polygoncoords';
 const cornerCalcType= 'imageCornerCalc';
-const SpatialRegOp= 'spatialRegionOperation';
+export const SpatialRegOp= 'spatialRegionOperation';
 export const SINGLE= 'single';
 export const MULTI= 'multi';
 


### PR DESCRIPTION
Fixes [IRSA-6701](https://jira.ipac.caltech.edu/browse/IRSA-6701)

See ife PR: https://github.com/IPAC-SW/irsa-ife/pull/385

Refactored `SearchSummary` to:
- replace hardcoded strings `{'Cone', 'Polygon', 'Multi-Object'}` with `*_CHOICE_KEY`
- get search type label to display from toggleOptions (in default case)
- accept `getSearchType` in place of `getSummaryInfo` because `searchType.value` and `searchType.label` are the only things that need to be customized (in LVF case), rest all follows default logic to generate key value pairs from these two variables 
- simplify redundant logic and overall cleanup

## Testing 
https://irsa-6701-spherex-search-summary.irsakudev.ipac.caltech.edu/applications/euclid/

Do regression testing in Euclid searches to see if search summary is working as before