### PR TITLE
IRSA-6706, IRSA-6571: Add Image on background of Results tab

### DIFF
--- a/buildScript/webpack.config.js
+++ b/buildScript/webpack.config.js
@@ -173,8 +173,9 @@ export default function makeWebpackConfig(config) {
             use: ['@svgr/webpack'],
         },
         {
-            test: /\.(png|jpg|gif)$/,
-            type: 'asset/inline'
+            test: /\.(png|jpg|gif|webp)$/,
+            // webpack will automatically choose 'asset/inline' (data URI) for <8KB and 'asset/resource' (file path) otherwise
+            type: 'asset', // see https://webpack.js.org/guides/asset-modules/#general-asset-type
         }
     ];
 

--- a/src/firefly/js/templates/fireflyviewer/LandingPage.jsx
+++ b/src/firefly/js/templates/fireflyviewer/LandingPage.jsx
@@ -24,7 +24,7 @@ export function LandingPage({slotProps={}, sx, ...props}) {
     const defSlotProps = {
         tabsMenuHint: {appTitle, id: APP_HINT_IDS.TABS_MENU, hintText: 'Choose a tab to search for or upload data.', sx: { left: '16rem' }},
         bgMonitorHint: {appTitle, id: APP_HINT_IDS.BG_MONITOR, hintText: 'Load job results from background monitor', tipPlacement: 'end', sx: { right: 8 }},
-        topSection: { appTitle },
+        topSection: { title: `Welcome to ${appTitle}` },
         bottomSection: {
                 icon: <QueryStats sx={{ width: '6rem', height: '6rem' }} />,
                 text: 'Getting Started',
@@ -57,7 +57,7 @@ export function LandingPage({slotProps={}, sx, ...props}) {
                 },
             }}>
                 <Stack justifyContent='space-between' width={1} spacing={1}>
-                    <Box display={'flex'} flexGrow={1} {...slotProps?.bgContainer}>
+                    <Box {...slotProps?.bgContainer}>
                         <Stack spacing={2} width={1} px={4} py={3} {...slotProps?.contentSection}>
                             <Slot component={DefaultAppBranding} {...defSlotProps.topSection} slotProps={slotProps?.topSection}/>
                             <Slot component={EmptyResults} {...defSlotProps.bottomSection} slotProps={slotProps?.bottomSection}/>
@@ -71,11 +71,11 @@ export function LandingPage({slotProps={}, sx, ...props}) {
 }
 
 
-function DefaultAppBranding({appTitle, appDescription}) {
+function DefaultAppBranding({title, desc}) {
     return (
         <Stack spacing={.25} alignItems='center'>
-            <Typography fontSize='xl3' color='neutral'>{`Welcome to ${appTitle}`}</Typography>
-            {appDescription && <Typography level={'body-md'}>{appDescription}</Typography>}
+            <Typography fontSize='xl3' color='neutral'>{title}</Typography>
+            {desc && <Typography level='body-md' textAlign='center'>{desc}</Typography>}
         </Stack>
     );
 }
@@ -201,8 +201,8 @@ LandingPage.propTypes = {
 
 
 DefaultAppBranding.propTypes = {
-    appTitle: string,
-    appDescription: string,
+    title: string,
+    desc: string,
 };
 
 

--- a/src/firefly/js/templates/fireflyviewer/LandingPage.jsx
+++ b/src/firefly/js/templates/fireflyviewer/LandingPage.jsx
@@ -1,6 +1,6 @@
-import {Button, Divider, Sheet, Snackbar, Stack, Typography} from '@mui/joy';
+import {Box, Button, Divider, Sheet, Snackbar, Stack, Typography} from '@mui/joy';
 import React, {useContext, useState} from 'react';
-import {elementType, shape, object, string, arrayOf, element, oneOf} from 'prop-types';
+import {elementType, shape, object, string, arrayOf, oneOf, node} from 'prop-types';
 import QueryStats from '@mui/icons-material/QueryStats';
 import TipsAndUpdates from '@mui/icons-material/TipsAndUpdates';
 
@@ -29,7 +29,6 @@ export function LandingPage({slotProps={}, sx, ...props}) {
                 icon: <QueryStats sx={{ width: '6rem', height: '6rem' }} />,
                 text: 'Getting Started',
                 subtext: undefined,
-                // subtext: undefined,
                 summaryText: 'Visualizations of the results will appear in this tab',
                 actionItems: [
                     { text: 'Search for data', subtext: 'using the tabs above' },
@@ -57,11 +56,13 @@ export function LandingPage({slotProps={}, sx, ...props}) {
                     dispatchShowDropDown({view:fileDropEventAction, initArgs: {searchParams: {dropEvent: newEv}}});
                 },
             }}>
-                <Stack justifyContent='space-between' width={1}>
-                    <Stack spacing={2} width={1} px={4} py={3} {...slotProps?.contentSection}>
-                        <Slot component={DefaultAppBranding} {...defSlotProps.topSection} slotProps={slotProps?.topSection}/>
-                        <Slot component={EmptyResults} {...defSlotProps.bottomSection} slotProps={slotProps?.bottomSection}/>
-                    </Stack>
+                <Stack justifyContent='space-between' width={1} spacing={1}>
+                    <Box display={'flex'} flexGrow={1} {...slotProps?.bgContainer}>
+                        <Stack spacing={2} width={1} px={4} py={3} {...slotProps?.contentSection}>
+                            <Slot component={DefaultAppBranding} {...defSlotProps.topSection} slotProps={slotProps?.topSection}/>
+                            <Slot component={EmptyResults} {...defSlotProps.bottomSection} slotProps={slotProps?.bottomSection}/>
+                        </Stack>
+                    </Box>
                     {footer ? footer : undefined}
                 </Stack>
             </FileDropZone>
@@ -80,7 +81,7 @@ function DefaultAppBranding({appTitle, appDescription}) {
 }
 
 
-function EmptyResults({icon, text, subtext, summaryText, actionItems}) {
+function EmptyResults({icon, text, subtext, summaryText, actionItems, slotProps}) {
     const renderActionItem = ({text, subtext}) => (
         <Stack spacing={.5} alignItems='center'>
             <Typography level={'title-lg'} color={'primary'}>{text}</Typography>
@@ -89,7 +90,7 @@ function EmptyResults({icon, text, subtext, summaryText, actionItems}) {
     );
 
     return (
-        <Sheet variant='soft' sx={{pt: 8, pb: 4, px: 2}}>
+        <Sheet variant='soft' sx={{pt: 8, pb: 4, px: 2}} {...slotProps?.root}>
             <Stack spacing={10} alignItems='center'>
                 <Stack spacing={Boolean(subtext) ? 6 : 3}>
                     <Stack spacing={2} alignItems='center'>
@@ -194,6 +195,7 @@ LandingPage.propTypes = {
             ...EmptyResults.propTypes,      // defaults to EmptyResults.propTypes
         }),
         contentSection: object,
+        bgContainer: object,
     })
 };
 
@@ -205,13 +207,14 @@ DefaultAppBranding.propTypes = {
 
 
 EmptyResults.propTypes = {
-    icon: element,
+    icon: node,
     text: string,
     subtext: string,
     actionItems: arrayOf(shape({
         text: string,
         subtext: string
-    }))
+    })),
+    slotProps: object,
 };
 
 

--- a/src/firefly/js/util/Color.js
+++ b/src/firefly/js/util/Color.js
@@ -13,6 +13,8 @@ export const toRGB= (color) => chroma.valid(color) ? chroma(color).rgb() : [0,0,
  */
 export const getRGBA= (color)  => chroma.valid(color) ? chroma(color).rgba() : [0,0,0,1];
 
+export const hexColorWithAlpha = (color, alpha) => chroma.valid(color) ? chroma(color).alpha(alpha).hex() : color;
+
 
 export const brighter = (colorStr,level=1) =>
     chroma.valid(colorStr) ? chroma(colorStr).brighten(level).toString() : undefined;


### PR DESCRIPTION
Fixes [IRSA-6706](https://jira.ipac.caltech.edu/browse/IRSA-6706), [IRSA-6571](https://jira.ipac.caltech.edu/browse/IRSA-6571)

See ife PR: https://github.com/IPAC-SW/irsa-ife/pull/388

- HydraLanding styles change if `bgImage` is supplied by consumers (ife apps) and changes in LandingPage to support that
- Edit webpack config to support `.webp` files (SPHEREx image is available as webp) and to switch to `asset/resource` for large files (background images are large, we don't want them inline)
- Several cleanups:
  - `topSection` now accepts `title` (to distinguish from `appTitle`), and `desc` that are used by Hydra apps
  - `icon` prop of HydraLanding is never used by `topSection` in any apps but `bottomSection` uses it, so moved it there to avoid confusion and make it easier for consumers to define it (without going through slotProps route)
  - Replaced `setIfUndefined` with `defaultsDeep` since there are lot of slotProps modification, and having single nested object is more readable when overriding


## Testing
Check background image in landing page of:
- https://irsa-6571-bg-img.irsakudev.ipac.caltech.edu/applications/euclid
- https://irsa-6571-bg-img.irsakudev.ipac.caltech.edu/applications/spherex

Regression Testing in landing page of:
- https://irsa-6571-bg-img.irsakudev.ipac.caltech.edu/irsaviewer
- https://irsa-6571-bg-img.irsakudev.ipac.caltech.edu/applications/wise
