### PR TITLE
Firefly-1680: FITS image optimizations

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -15,7 +15,7 @@ alerts.dir = ""
 ignore.auth=true
 
 /*  keep vis.shared.mem.size small if pct is used */
-pct.vis.shared.mem.size = 0.4
+pct.vis.shared.mem.size = 0.25
 vis.shared.mem.size = "100M"
 ehcache.peerDiscovery="MultiCast"
 ehcache.multicast.ttl = 1

--- a/src/firefly/java/edu/caltech/ipac/astro/net/HorizonsEphPairs.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/net/HorizonsEphPairs.java
@@ -58,9 +58,12 @@ public class HorizonsEphPairs {
 
         try {
             String urlStr = horizonsServer + path + "?sstr="+ URLEncoder.encode(idOrName, "UTF-8");
-            URL url = new URL(urlStr);
-            String jsonStrResult = URLDownload.getDataFromURL(url, null,null,null).getResultAsString();
-            JsonHelper json= JsonHelper.parse(jsonStrResult);
+            var result = URLDownload.getDataFromURL(new URL(urlStr), null,null,null);
+            if (result.getResponseCode() != 200) {
+                throw new FailedRequestException("failed to retrieve ephemeris pairs, response code: " + result.getResponseCode());
+            }
+            var json= JsonHelper.parse(result.getResultAsString());
+
 
             JSONArray rList= json.getValue(new JSONArray(), "result");
             List<HorizonsResults> horizonsResults= new ArrayList<>();

--- a/src/firefly/java/edu/caltech/ipac/astro/net/TargetNetwork.java
+++ b/src/firefly/java/edu/caltech/ipac/astro/net/TargetNetwork.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.astro.net;
 
+import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.download.FailedRequestException;
@@ -18,7 +19,7 @@ import static edu.caltech.ipac.astro.net.Resolver.UNKNOWN;
 public class TargetNetwork {
 
     public final static int TWO_MONTHS= 60 * 86400;
-    private final static Cache objCache= CacheManager.getLocal();
+    private final static Cache objCache= getLocalCache();
 
     public static ResolvedWorldPt resolveToWorldPt(String objName, Resolver resolver) {
         if (resolver==null || resolver==UNKNOWN || resolver==NONE) {
@@ -61,6 +62,15 @@ public class TargetNetwork {
             return (a!=null) ? a.getWorldPt() : null;
         } catch (FailedRequestException e) {
             return null;
+        }
+    }
+
+    private static Cache<?> getLocalCache() {
+        try {
+            return CacheManager.getLocal();
+        } catch (Throwable e) {
+            Logger.warn("Could not get cache, this is normal when running test");
+            return new CacheManager.EmptyCache();
         }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/ResolveServerCommands.java
@@ -102,7 +102,7 @@ public class ResolveServerCommands {
                 wrapperAry.add(result);
 
             }catch (Exception e){
-                logger.error("Could not resolve object name: "+ sp.getRequired(ServerParams.OBJ_NAME));
+                logger.error("Could not resolve object name: "+ " "+ e +" " + sp.getRequired(ServerParams.OBJ_NAME));
 
                 result.put("success", "false");
                 result.put("error", e.getMessage());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/rpc/VisServerCommands.java
@@ -113,7 +113,7 @@ public class VisServerCommands {
                 ct= CompressType.FULL;
             }
 
-            byte[] data = VisServerOps.getByteStretchArray(state,tileSize,mask,maskBits,ct);
+            byte[] data = VisServerOps.getByteStretchArrayWithUserLocking(state,tileSize,mask,maskBits,ct);
 
             res.setContentType("application/octet-stream");
             ByteBuffer byteBuf = ByteBuffer.wrap(data);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ImagePlotCreator.java
@@ -12,7 +12,6 @@ import edu.caltech.ipac.firefly.visualize.WebFitsData;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.util.download.FailedRequestException;
 import edu.caltech.ipac.visualize.plot.ActiveFitsReadGroup;
-import edu.caltech.ipac.visualize.plot.Histogram;
 import edu.caltech.ipac.visualize.plot.RangeValues;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
 import edu.caltech.ipac.visualize.plot.plotdata.GeomException;
@@ -168,16 +167,7 @@ public class ImagePlotCreator {
         long fileLength= (f!=null && f.canRead()) ? f.length() : 0;
         FitsRead fr=  frGroup.getFitsReadAry()[band.getIdx()];
         if (fr==null) return null;
-        double dataMin= Double.NaN;
-        double dataMax= Double.NaN;
-        double largeBinPercent= 0;
-        if (!fr.isDeferredRead()) {
-            Histogram hist= fr.getHistogram();
-            dataMin= hist.getDNMin() * fr.getBscale() + fr.getBzero();
-            dataMax= hist.getDNMax() * fr.getBscale() + fr.getBzero();
-            largeBinPercent= hist.getLargeBinPercent();
-        }
-        return new WebFitsData( dataMin, dataMax, largeBinPercent, fileLength, fr.getFluxUnits());
+        return new WebFitsData( fileLength);
     }
 
     private static Map<Band,WebFitsData> noBandMap(WebFitsData wfd) { return Collections.singletonMap(NO_BAND,wfd);}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -136,6 +136,15 @@ public class VisJsonSerializer {
                 for(double v : dAry) ary.add(v);
                 putJsonAry(map, WebPlotResult.DATA_BIN_MEAN_ARRAY, ary);
             }
+            if (res.containsKey(WebPlotResult.DATA_MIN)) {
+                putDouble(map, WebPlotResult.DATA_MIN, (double)res.getResult(WebPlotResult.DATA_MIN));
+            }
+            if (res.containsKey(WebPlotResult.DATA_MAX)) {
+                putDouble(map, WebPlotResult.DATA_MAX, (double)res.getResult(WebPlotResult.DATA_MAX));
+            }
+            if (res.containsKey(WebPlotResult.LARGE_BIN_PERCENT)) {
+                putDouble(map, WebPlotResult.LARGE_BIN_PERCENT, (double)res.getResult(WebPlotResult.LARGE_BIN_PERCENT));
+            }
             if (res.containsKey(WebPlotResult.DATA_BIN_COLOR_IDX)) {
                 byte[] bAry = (byte[]) res.getResult(WebPlotResult.DATA_BIN_COLOR_IDX);
                 JSONArray ary = new JSONArray();
@@ -332,10 +341,6 @@ public class VisJsonSerializer {
     private static JSONObject serializeWebFitsData(WebFitsData wfData) {
         if (wfData==null) return null;
         JSONObject map = new JSONObject();
-        putDoubleNot0(map, "dataMin", wfData.dataMin());
-        putDoubleNot0(map,"dataMax", wfData.dataMax());
-        putDoubleNot0(map,"largeBinPercent", wfData.largeBinPercent());
-        putStr(map, "fluxUnits", wfData.fluxUnits());
         putNum(map, "getFitsFileSize", wfData.fitsFileSize());
         return map;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebFitsData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebFitsData.java
@@ -6,5 +6,5 @@ package edu.caltech.ipac.firefly.visualize;
 /**
  * @author Trey Roby
  */
-public record WebFitsData(double dataMin, double dataMax, double largeBinPercent, long fitsFileSize, String fluxUnits) { }
+public record WebFitsData(long fitsFileSize) { }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResult.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotResult.java
@@ -25,6 +25,9 @@ public record WebPlotResult(boolean success,
     public static final String DATA_HISTOGRAM= "DataHistogram";
     public static final String DATA_BIN_MEAN_ARRAY= "DataBinMeanArray";
     public static final String DATA_BIN_COLOR_IDX= "DataBinColorIdx";
+    public static final String DATA_MIN= "DataMin";
+    public static final String DATA_MAX= "DataMax";
+    public static final String LARGE_BIN_PERCENT= "LargeBinPercent";
     public static final String REGION_FILE_NAME = "RegionFileName";
     public static final String BAND_INFO= "Band_Info";
     public static final String REGION_ERRORS= "RegionErrors";
@@ -35,6 +38,7 @@ public record WebPlotResult(boolean success,
     public static final List<String> keyList= Arrays.asList(
             PLOT_CREATE, PLOT_CREATE_HEADER, STRING, DATA_HISTOGRAM,
             DATA_BIN_MEAN_ARRAY, DATA_BIN_COLOR_IDX, REGION_FILE_NAME, BAND_INFO, REGION_ERRORS,
+            DATA_MIN, DATA_MAX, LARGE_BIN_PERCENT,
             REGION_DATA, TITLE, RESULT_ARY);
 
 //======================================================================

--- a/src/firefly/java/edu/caltech/ipac/util/CollectionUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/CollectionUtil.java
@@ -7,6 +7,7 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -250,20 +251,17 @@ public class CollectionUtil {
 
     }
 
+    @SafeVarargs
     public static <T> List<T> asList(T... items) {
 
         ArrayList<T> list = new ArrayList<T>(items.length);
-        if (items != null) {
-            for (T item : items) {
-                list.add(item);
-            }
-        }
+        Collections.addAll(list, items);
         return list;
     }
 
     public static <T> boolean matches(int cursorIdx, T src, List<Filter<T>> filters) {
         if ( filters !=  null ) {
-            cursorIdx = cursorIdx < 0 ? 0 : cursorIdx;
+            cursorIdx = Math.max(cursorIdx, 0);
             for(Filter<T> f : filters) {
                 boolean accept = f.isRowIndexBased() ? f.accept(cursorIdx) : f.accept(src);
                 if (!accept) {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
@@ -216,7 +216,7 @@ public class ImageData implements Serializable {
                     imHeadAry[i]=null;
                     histAry[i]=null;
                 } else {
-                    float1dAry[i] = fitsReadAry[i].getRawFloatAry();
+                    float1dAry[i] = fitsReadAry[i].getRawFloatAryStandard();
                     imHeadAry[i]= new ImageHeader(fitsReadAry[i].getHeader());
                     histAry[i]= fitsReadAry[i].getHistogram();
                 }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImagePlot.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImagePlot.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This is the major subclass implementation of Plot.  This class plots fits data.
+ * This class is now only used for creating PNG file, not for interactive visualization
  * @author Trey Roby
  */
 public class ImagePlot implements Serializable {

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadFactory.java
@@ -58,8 +58,7 @@ public class FitsReadFactory {
             else {
                 planeNumber++;
             }
-            File file= cube ? f : null;
-            fitsReadAry[i]= new FitsRead(lastHdu, zeroHeader, file, clearHdu, cube, cube?planeNumber:0);
+            fitsReadAry[i]= new FitsRead(lastHdu, zeroHeader, f, clearHdu, cube, cube?planeNumber:0);
         }
         return fitsReadAry;
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -4,6 +4,7 @@
 
 package edu.caltech.ipac.visualize.plot.plotdata;
 
+import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.visualize.VisUtil;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.visualize.plot.CoordinateSys;
@@ -288,6 +289,19 @@ public class FitsReadUtil {
 
     }
 
+    public static float[] dataArrayFromHDUAndPlane(File file, int hduNumber, int planeNumber) {
+        try (Fits fits = new Fits(file)) {
+            BasicHDU<?> hdu= fits.read()[hduNumber];
+            if (!(hdu instanceof ImageHDU)) return null;
+            var h= hdu.getHeader();
+            return (float [])dataArrayFromFitsFile((ImageHDU)hdu, 0,0,getNaxis1(h),getNaxis2(h), planeNumber,Float.TYPE);
+        }
+        catch (Exception e) {
+            Logger.getLogger("FitsRead").error(e,"Could not read FITS data");
+            return null;
+        }
+    }
+
     /**
      * This returns a 1d array of double.  This is not interchangable with getImageHDUDataInFloatArray. It is used
      * mostly for tables and if not as efficent.
@@ -414,6 +428,10 @@ public class FitsReadUtil {
         } catch (IOException ignore) {
         }
     }
+
+
+
+
 
     /**
      *

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -9,7 +9,7 @@ import {getActiveTableId, getCellValue, getTblById} from '../tables/TableUtil.js
 import {uniqueID} from '../util/WebUtil';
 import {allBandAry} from '../visualize/Band.js';
 import ImagePlotCntlr, {
-    dispatchChangeActivePlotView, dispatchDeletePlotView, dispatchPlotGroup, dispatchPlotImage, dispatchZoom, visRoot
+    dispatchChangeActivePlotView, dispatchDeletePlotView, dispatchPlotImage, dispatchZoom, visRoot
 } from '../visualize/ImagePlotCntlr.js';
 import {
     DEFAULT_FITS_VIEWER_ID, dispatchReplaceViewerItems, getLayoutType, getMultiViewRoot, getViewerItemIds, GRID, IMAGE
@@ -213,8 +213,6 @@ function onImagePlotComplete(plotId,onComplete) {
 
 }
 
-///=========================
-
 export function resetImageFullGridActivePlot(tbl_id, plotIdAry) {
     if (!tbl_id || isEmpty(plotIdAry)) return;
 
@@ -315,12 +313,15 @@ function replotImageDataProducts(activePlotId, makeActive, imageViewerId, tbl_id
 
     // prepare standard plot
     const wpRequestAry= makePlottingList(reqAry);
-    if (!isEmpty(wpRequestAry)) {
-        dispatchPlotGroup({wpRequestAry, viewerId:imageViewerId, holdWcsMatch:true,
-            // setNewPlotAsActive: makeActive && workingActivePlotId,
-            pvOptions: { userCanDeletePlots: false, menuItemKeys:{imageSelect : false}, useSticky:true },
-            attributes: { tbl_id }
-        });
+    if (wpRequestAry?.length) {
+        wpRequestAry.forEach( (wpRequest) =>
+            dispatchPlotImage({
+                wpRequest, plotId:wpRequest.getPlotId(),holdWcsMatch:true,
+                viewerId:imageViewerId,
+                pvOptions: { userCanDeletePlots: false, menuItemKeys:{imageSelect : false}, useSticky:true },
+                attributes: { tbl_id }
+
+            }) );
     }
     if (makeActive && workingActivePlotId) {
         onImagePlotComplete(workingActivePlotId,

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -4,6 +4,7 @@
 import {ZoomType} from 'firefly/visualize/ZoomType.js';
 import {isArray, isBoolean, isEmpty, isNumber, isUndefined} from 'lodash';
 import {memorizeLastCall} from '../util/WebUtil';
+import {Band} from './Band';
 import CoordinateSys from './CoordSys.js';
 import {CysConverter} from './CsysConverter.js';
 import PlotState, {makePlotStateShimForHiPS} from './PlotState';
@@ -69,7 +70,7 @@ export const RDConst= {
  * @prop {number} zoomFactor - the zoom factor
  * @prop {boolean} blank - true if the is a blank plot, default to false
  * @prop {string} title - title of the plot
- * @prop {WebFitsData} webFitsData -  needs documentation
+ * @prop {WebFitsData} webFitsData
  * @prop {ImageTileData} tileData -  object contains the image tile information
  * @prop {CoordinateSys} imageCoordSys - the image coordinate system
  * @prop {Dimension} screenSize - width/height in screen pixels
@@ -93,11 +94,7 @@ export const RDConst= {
  * @public
  * @typedef {Object} WebFitsData
  *
- * @prop {number} dataMin
- * @prop {number} dataMax
- * @prop {number} largeBinPercent,
  * @prop {number} fitsFileSize
- * @prop {number} fluxUnits
  */
 
 
@@ -238,7 +235,6 @@ export const RDConst= {
  * @prop wlTableRelatedAry
  * @prop wlData
  * @prop getFitsFileSize
- * @prop fluxUnits
  */
 
 
@@ -384,7 +380,7 @@ export const WebPlot= {
         const fluxUnitAry= processHeaderAry.map( (p) => p.fluxUnits);
         const rawData= {
             useRed: true, useGreen: true, useBlue:true,
-            bandData:processHeaderAry.map( (pH) => ({processHeader:pH, datamin: pH.datamin, datamax:pH.datamax, bias:.5,contrast:1}))
+            bandData:processHeaderAry.map( (pH) => ({processHeader:pH, bias:.5,contrast:1}))
         };
 
 
@@ -461,7 +457,7 @@ export const WebPlot= {
             imagePlot.webFitsData=
                 imagePlot.webFitsData.map( (wfd) => {
                     let newWfd=  { ...wfd, dataMin: wfd?.dataMin ?? 0, dataMax: wfd?.dataMax ?? 0 };
-                    if (cubeCtx) newWfd= {...newWfd, fluxUnits:cubeCtx.fluxUnits, getFitsFileSize:cubeCtx.getFitsFileSize};
+                    if (cubeCtx) newWfd= {...newWfd, getFitsFileSize:cubeCtx.getFitsFileSize};
                     return newWfd;
                 });
         }
@@ -728,7 +724,9 @@ export const getScreenPixScaleArcSec= memorizeLastCall((plot) => {
 },8);
 
 
-export const getFluxUnits= (plot,band) => (!plot || !band || !isImage(plot)) ? '' : plot.fluxUnitAry[band.value];
+export const getFluxUnits= (plot,band=Band.NO_BAND) => {
+   return  (!plot || !band || !isImage(plot)) ? '' : plot.fluxUnitAry[band.value];
+};
 
 
 /**

--- a/src/firefly/js/visualize/saga/MouseReadoutWatch.js
+++ b/src/firefly/js/visualize/saga/MouseReadoutWatch.js
@@ -314,7 +314,7 @@ function doFluxCall(plotView,iPt) {
 function getFlux(result, plot) {
     const fluxArray = [];
     if (result.NO_BAND) {
-        fluxArray[0]= {...result.NO_BAND, unit: getFluxUnits(plot,Band.NO_BAND)};
+        fluxArray[0]= {...result.NO_BAND, unit: getFluxUnits(plot)};
     }
     else {
         const bands = plot.plotState.getBands();

--- a/src/firefly/js/visualize/task/CreateTaskUtil.js
+++ b/src/firefly/js/visualize/task/CreateTaskUtil.js
@@ -239,7 +239,6 @@ export function makeCubeCtxAry(plotCreate) {
                 dataWidth: cubeStartPC.dataWidth,
                 dataHeight: cubeStartPC.dataHeight,
                 imageCoordSys: cubeStartPC.imageCoordSys,
-                fluxUnits: cubeStartPC.fitsData.fluxUnits,
                 getFitsFileSize: cubeStartPC.fitsData.getFitsFileSize,
                 desc: cubeStartPC.desc
             };

--- a/src/firefly/js/visualize/ui/extraction/ExtractionChart.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionChart.jsx
@@ -62,7 +62,7 @@ function makePlotlyDataObj(xDataAry, yDataAry, x, y, ttXStr, ttYStr, makeXDesc =
 
 export function genSliceChartData(plot, ipt1, ipt2, xDataAry, yDataAry, x, y, pointSize, combineOp, title, reversed) {
     const unitStr = hasWCSProjection(plot) ? ' (arcsec)' : '';
-    const yUnits = getFluxUnits(plot, Band.NO_BAND);
+    const yUnits = getFluxUnits(plot);
     const yAxisLabel = getExtName(plot) || 'HDU# ' + getHDU(plot);
     return {
         plotlyDivStyle,
@@ -77,7 +77,7 @@ export function genPointChartData(plot, dataAry, imPtAry, x, y, pointSize, combi
     const xAxis = chartXAxis === 'imageX' ? imPtAry.map((pt) => pt.x) : imPtAry.map((pt) => pt.y);
     const xAxisTitle = chartXAxis === 'imageX' ? 'Image X' : 'Image Y';
     const xLabel = (i) => `(${imPtAry[i].x},${imPtAry[i].y})`;
-    const yUnits = getFluxUnits(plot, Band.NO_BAND);
+    const yUnits = getFluxUnits(plot);
     const yAxisLabel = getExtName(plot) || 'HDU# ' + getHDU(plot);
 
     return {

--- a/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
@@ -58,7 +58,7 @@ export function keepZAxisExtraction(pt, pv, plot, filename, refHDUNum, extractio
     const wlUnit = getWaveLengthUnits(plot);
     const wpt = CCUtil.getWorldCoords(plot, pt);
     const fluxUnit = getHduPlotStartIndexes(pv)
-        .map((idx) => ({hdu: getHDU(pv.plots[idx]), unit: getFluxUnits(pv.plots[idx], Band.NO_BAND)}))
+        .map((idx) => ({hdu: getHDU(pv.plots[idx]), unit: getFluxUnits(pv.plots[idx])}))
         .map(({hdu, unit}) => `${hdu}=${unit}`);
 
     const tbl_id = getNextTblId();

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/rpc/ResolveNaifidNameTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/rpc/ResolveNaifidNameTest.java
@@ -2,7 +2,6 @@ package edu.caltech.ipac.firefly.server.rpc;
 
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.server.SrvParam;
-import org.json.simple.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import java.util.HashMap;


### PR DESCRIPTION
#### [Firefly-1680](https://jira.ipac.caltech.edu/browse/FIREFLY-1680): FITS image optimizations

 - Flip the image in place without memory allocation, this also means the interation is cut in half
 - Read fits data during render process, this way the data does not have to be cached. Makes for better GC.
 - build large data histogram with threads
 - getByteStretchArray now only allows one call at a time per session using semaphores
      - radically improving memory managment and not really affecting performance
 - Only cache image on second image read.
     - This indicates the user is changing stretch or the user has gone back to this image.
     - Stretch changes often happen in groups.
     - If the user is not changing stretch more moving back and forth then there is not reason to cache the data

#### Testing
- https://firefly-1680-optimize-fits.irsakudev.ipac.caltech.edu/applications/euclid/
- Everything should work as before
- Try loading full images in a grid
