### PR TITLE
FIREFLY-1683: prevent excessive thread use

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -855,11 +855,12 @@ public class ServerContext {
                 ServletContext cntx = servletContextEvent.getServletContext();
                 ServerContext.init(cntx.getContextPath(), cntx.getServletContextName(), cntx.getRealPath(WEBAPP_CONFIG_LOC));
                 VersionUtil.initVersion(cntx);  // can be called multiple times, only inits on the first call
-                SCHEDULE_TASK_EXEC.scheduleAtFixedRate(
-                        () -> DbMonitor.cleanup(false),
-                        DbMonitor.CLEANUP_INTVL,
-                        DbMonitor.CLEANUP_INTVL,
-                        TimeUnit.MILLISECONDS);
+                // we're using DuckDB exclusively for embedded database.  No need for cleanup.
+//                SCHEDULE_TASK_EXEC.scheduleAtFixedRate(
+//                        () -> DbMonitor.cleanup(false),
+//                        DbMonitor.CLEANUP_INTVL,
+//                        DbMonitor.CLEANUP_INTVL,
+//                        TimeUnit.SECONDS);
             } catch (Throwable e) {
                 e.printStackTrace();
             }
@@ -868,7 +869,7 @@ public class ServerContext {
         public void contextDestroyed(ServletContextEvent servletContextEvent) {
             try {
                 System.out.println("contextDestroyed...");
-                DbMonitor.cleanup(true, false);
+//                DbMonitor.cleanup(true, false);
                 ((EhcacheProvider)CacheManager.getCacheProvider()).shutdown();
                 try {
                     SHORT_TASK_EXEC.shutdownNow();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
@@ -274,12 +274,14 @@ public interface DbAdapter {
         int rowCnt = -1;
         int totalRows = -1;
         long memory = -1;
+        final long created = System.currentTimeMillis();
 
         public int tblCnt() { return tblCnt; }
         public int colCnt() { return colCnt;}
         public int rowCnt() { return rowCnt; }
         public int totalRows() { return totalRows;}
         public long memory() { return memory;}
+        public long created() { return created;}
     }
 
     /**
@@ -348,8 +350,13 @@ public interface DbAdapter {
         public void setCompact(boolean compact) { isCompact = compact;}
         public boolean isCompact() { return isCompact; }
 
-        public void updateStats() { this.dbStats = dbAdapter.getDbStats(); }
         public DbStats getDbStats() { return dbStats == null ? new DbStats() : dbStats; }
+
+        public void updateStats() {
+            if (dbStats == null || dbStats.created < lastAccessed) {
+                this.dbStats = dbAdapter.getDbStats();
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1683

It turned out this was part of an interval-based cleanup process. As part of that process, we collected statistics from all active databases to determine if cleanup was needed. Although each call was fast, running them sequentially became time-consuming because of the large number of databases. When we switched to parallel processing, an unbounded thread pool was used, which resulted in spawning too many threads.

Solution:
Since cleanup is no longer required with our current database system, I removed that process. However, our admin status page still needs database statistics. I've updated the code so that it only performs the check when needed and limits the process to at most 5 parallel threads.

Test:
- Checkout this PR branch, perform a clean build, and deploy the updated version.
- Run the load_test.sh script referenced in the ticket.
- Open JConsole to monitor the JVM's health. You'll notice that the thread count remains steady throughout the test.
