### PR TITLE
Fix Cutout Dialog Help ID

### DIFF
--- a/src/firefly/js/ui/CutoutSizeDialog.jsx
+++ b/src/firefly/js/ui/CutoutSizeDialog.jsx
@@ -193,7 +193,7 @@ function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataPr
                                                 cutoutToFullWarning,tbl_id)}/>
                     }
                 </Stack>
-                <HelpIcon helpId={'visualization.rotate'} />
+                <HelpIcon helpId={'visualization.cutout'} />
             </Stack>
         </Stack>
     );


### PR DESCRIPTION
**Euclid test build**: https://euclid-bugfixes.irsakudev.ipac.caltech.edu/applications/euclid
- do any search, then from cutout dialog click on the help icon -> the online help may not be fully updated yet, but the link you go to should end with: `onlinehelp/euclid/#id=visualization.cutout`