### PR TITLE
Firefly-281 set mission slide range value.

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcConverterFactory.js
+++ b/src/firefly/js/templates/lightcurve/LcConverterFactory.js
@@ -91,6 +91,8 @@ const converters = {
         onNewRawTable: wiseOnNewRawTable,
         onFieldUpdate: wiseOnFieldUpdate,
         rawTableRequest: wiseRawTableRequest,
+        sliderRangeMin: 0.1,
+        sliderRangeMax: 2,
         /*timeNames: ['mjd'],*/
         /*yNames: ['w1mpro_ep', 'w2mpro_ep', 'w3mpro_ep', 'w4mpro_ep'],*/
         yErrNames: '',
@@ -135,6 +137,8 @@ const converters = {
         onNewRawTable: ptfOnNewRawTable,
         onFieldUpdate: ptfOnFieldUpdate,
         rawTableRequest: ptfRawTableRequest,
+        sliderRangeMin: 0.001,
+        sliderRangeMax: 100,
         yErrNames: '',
         dataSource: 'pid',
         webplotRequestCreator: getWebPlotRequestViaPTFIbe,
@@ -155,6 +159,8 @@ const converters = {
         onNewRawTable: ztfOnNewRawTable,
         onFieldUpdate: ztfOnFieldUpdate,
         rawTableRequest: ztfRawTableRequest,
+        sliderRangeMin: 0.001,
+        sliderRangeMax: 100,
         yErrNames: '',
         dataSource: 'field',
         webplotRequestCreator: getWebPlotRequestViaZTFIbe,

--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -73,6 +73,8 @@ export const LC = {
     UPLOAD_FILENAME: 'uploadFileName',
     MISSION_DATA: 'missionEntries',
     GENERAL_DATA:'generalEntries',
+    SLIDER_RANGE_MIN: 'sliderRangeMin',
+    SLIDER_RANGE_MAX: 'sliderRangeMax',
 
     TABLE_PAGESIZE: MAX_ROW
 };

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -312,9 +312,10 @@ function updateFullRawTable(callback) {
         }, []);
 
         var [tzero, tzeroMax] = arr.length > 0 ? [Math.min(...arr), Math.max(...arr)] : [0.0, 0.0];
-        var max = 365;
-        var min = Math.pow(10, -3);   // 0.001
-
+        // if no mission defined max value, set default 365
+        var max = get(layoutInfo, [LC.MISSION_DATA, LC.SLIDER_RANGE_MAX]) ?? 365;
+        // if no mission defined min value, set default 0.001
+        var min = get(layoutInfo, [LC.MISSION_DATA, LC.SLIDER_RANGE_MIN]) ?? Math.pow(10, -3);
         // var period = get( FieldGroupUtils.getGroupFields(LC.FG_PERIOD_FINDER), ['period', 'value'], '');
 
         const period = '';

--- a/src/firefly/js/templates/lightcurve/LcUtil.jsx
+++ b/src/firefly/js/templates/lightcurve/LcUtil.jsx
@@ -59,6 +59,8 @@ export function makeMissionEntries(tableMeta, layoutInfo={}, uploadFileName) {
         [LC.META_ERR_NAMES]: get(tableMeta, LC.META_ERR_NAMES, converterData.yErrNames),
         [LC.META_FLUX_BAND]: get(tableMeta, LC.META_FLUX_BAND, converterData.bandName),
         [LC.UPLOAD_FILENAME]: uploadFileName,
+        [LC.SLIDER_RANGE_MIN]: converterData.sliderRangeMin,
+        [LC.SLIDER_RANGE_MAX]: converterData.sliderRangeMax
     });
     return {converterData, missionEntries};
 }
@@ -123,8 +125,10 @@ export function getInitialDefaultValues(labelWidth, missionName) {
         [LC.META_URL_CNAME]: Object.assign(getTypeData(LC.META_URL_CNAME, '',
             'Image url column name',
             'Source Column', labelWidth)),
-        [LC.UPLOAD_FILENAME]: Object.assign(getTypeData(LC.UPLOAD_FILENAME, ''))
-
+        [LC.UPLOAD_FILENAME]: Object.assign(getTypeData(LC.UPLOAD_FILENAME, '')),
+        [LC.SLIDER_RANGE_MIN]: Object.assign(getTypeData(LC.SLIDER_RANGE_MIN, '')),
+        [LC.SLIDER_RANGE_MAX]: Object.assign(getTypeData(LC.SLIDER_RANGE_MAX, ''))
+        
     };
 
     switch (missionName){
@@ -152,7 +156,7 @@ export function getInitialDefaultValues(labelWidth, missionName) {
                 [LC.META_FLUX_BAND]: Object.assign(getTypeData(LC.META_FLUX_BAND, '',        '' +
                     'Select WISE band for images to be displayed',        'Image display:', 70)),
                 [LC.META_ERR_CNAME]: Object.assign(getTypeData(LC.META_ERR_CNAME, '',
-                    'value error column name',       'Error Column:', labelWidth))
+                    'value error column name',       'Error Column:', labelWidth)),
             };
             return Object.assign ({},commonDefault, wiseDefault );
         case 'ptf':


### PR DESCRIPTION
View [ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-281) for details. The default time series slider range is set per mission request. 
WISE/NEOWISE: 0.1 - 2
PTF/ZTF:   0.001 - 100 
Other:       0.001 - 365

To test:
https://firefly-281-ts.irsakudev.ipac.caltech.edu/irsaviewer/ts.html

upload attached time series files for WISE, ZTF and Other (attached in [ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-281) ),  do `Period Finder`, inspect slider range setting.
