### PR TITLE
Firefly-1482: implement bandwidth in readout

### DIFF
--- a/src/firefly/js/visualize/MouseReadoutCntlr.js
+++ b/src/firefly/js/visualize/MouseReadoutCntlr.js
@@ -49,6 +49,7 @@ export const MR_ZERO_IP= 'zeroIP';
 export const MR_HEALPIX_PIXEL= 'healpixPixel';
 export const MR_HEALPIX_NORDER='healpixNorder';
 export const MR_WL= 'wl';
+export const MR_BAND_WIDTH= 'bandWidth';
 
 export const MR_FIELD_IMAGE_MOUSE_READOUT1= 'imageMouseReadout1';
 export const MR_FIELD_IMAGE_MOUSE_READOUT2= 'imageMouseReadout2';
@@ -159,5 +160,6 @@ const initState= () =>
             intFluxValueRadix: '10',
             floatFluxValueRadix: '10',
             wl: MR_WL,
+            bandWidth: MR_BAND_WIDTH,
         }
     });

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -940,6 +940,10 @@ export function getWaveLengthUnits(plot) {
     return plot.wlData?.spectralCoords?.[0].units ?? '';
 }
 
+export function getBandWidthUnits(plot) {
+    if (!plot || !hasWLInfo(plot)) return '';
+    return plot.wlData?.spectralCoords?.[1].units ?? '';
+}
 
 
 /**
@@ -971,6 +975,8 @@ export function getFormattedWaveLengthUnits(plotOrStr, anyPartOfStr=false) {
 export const getPtWavelength= (plot, pt, cubeIdx) =>
     (plot && hasWLInfo(plot) && getWavelength(CCUtil.getImageCoords(plot,pt),cubeIdx,plot.wlData))?.[0] ?? 0;
 
+export const getPtSpectralCoords= (plot, pt, cubeIdx) =>
+    (plot && hasWLInfo(plot) && getWavelength(CCUtil.getImageCoords(plot,pt),cubeIdx,plot.wlData)) ?? [0,0];
 
 //=============================================================
 //=============================================================

--- a/src/firefly/js/visualize/saga/MouseReadoutWatch.js
+++ b/src/firefly/js/visualize/saga/MouseReadoutWatch.js
@@ -20,7 +20,8 @@ import {mouseUpdatePromise, fireMouseReadoutChange} from '../VisMouseSync';
 import {
     primePlot, getPlotStateAry, getPlotViewById, getImageCubeIdx, getPtWavelength,
     getWavelengthParseFailReason, getWaveLengthUnits, hasPixelLevelWLInfo, hasPlaneOnlyWLInfo,
-    isImageCube, wavelengthInfoParsedSuccessfully, } from '../PlotViewUtil';
+    isImageCube, wavelengthInfoParsedSuccessfully, getPtSpectralCoords, getBandWidthUnits,
+} from '../PlotViewUtil';
 import {getFluxRadix} from 'firefly/visualize/ui/MouseReadoutUIUtil';
 
 
@@ -394,17 +395,22 @@ function makeWLResult(plot,imagePt= undefined) {
         if (wavelengthInfoParsedSuccessfully(plot)) {
             if (!imagePt) return;
             const cubeIdx= (isImageCube(plot) && getImageCubeIdx(plot)) || 0;
-            const wlValue= getPtWavelength(plot, imagePt, cubeIdx);
-            return makeValueReadoutItem('Wavelength', wlValue, getWaveLengthUnits(plot), 4);
+            // const wlValue= getPtWavelength(plot, imagePt, cubeIdx);
+            const specCoords= getPtSpectralCoords(plot, imagePt, cubeIdx);
+            return {
+                wl: makeValueReadoutItem('Wavelength', specCoords[0] ?? 0, getWaveLengthUnits(plot), 4),
+                bandWidth: makeValueReadoutItem('Wavelength', specCoords[1] ?? 0, getBandWidthUnits(plot), 4),
+
+            };
         }
         else {
             const item=  makeValueReadoutItem('Wavelength', 'Failed', '', 4);
             item.failReason= getWavelengthParseFailReason(plot);
-            return item;
+            return {wl:item, bandWidth:item};
         }
     }
     else {
-        return undefined;
+        return {};
     }
 }
 
@@ -433,12 +439,12 @@ function makeReadout(plot, worldPt, screenPt, imagePt) {
             title: makeDescriptionItem(plot.title),
             pixel: makeValueReadoutItem('Pixel Size', pixScale.value, pixScale.unit, 3),
             screenPixel:makeValueReadoutItem('Screen Pixel Size', screenPixScale.value, screenPixScale.unit, 3),
-            wl: makeWLResult(plot,imagePt)
+            ...makeWLResult(plot,imagePt)
         };
     }
     else {
         return {
-            wl: makeWLResult(plot)
+            ...makeWLResult(plot)
         };
     }
 

--- a/src/firefly/js/visualize/ui/MouseReadPopoutAll.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadPopoutAll.jsx
@@ -85,7 +85,7 @@ function Readout({readout, readoutData, showHealpixPixel=false, radix}){
     const fluxArray = getFluxInfo(readoutData, radix);
     const hipsPixel= showHealpixPixel && isHiPS;
     const showCopy= readout.lockByClick;
-    const {readout1, readout2, showReadout1PrefChange, showReadout2PrefChange, showWavelengthFailed, waveLength}= displayEle;
+    const {readout1, readout2, showReadout1PrefChange, showReadout2PrefChange, showWavelengthFailed, waveLength, bandWidth}= displayEle;
 
     return (
         <Box sx={{
@@ -127,6 +127,9 @@ function Readout({readout, readoutData, showHealpixPixel=false, radix}){
             {!threeColor && waveLength && image &&
                 <DataReadoutItem lArea='greenLabel' vArea='greenValue' label={waveLength.label} value={waveLength.value}
                                                      prefChangeFunc={showWavelengthFailed} /> }
+            {!threeColor && bandWidth && image &&
+                <DataReadoutItem lArea='blueLabel' vArea='blueValue' label={bandWidth.label} value={bandWidth.value}
+                                 prefChangeFunc={showWavelengthFailed} /> }
             {threeColor && <DataReadoutItem lArea='greenLabel' vArea='greenValue'
                                             monoFont={radix===16}
                                             prefChangeFunc={() =>showMouseReadoutFluxRadixDialog(readout.readoutPref)}

--- a/src/firefly/js/visualize/ui/MouseReadoutBottomLine.jsx
+++ b/src/firefly/js/visualize/ui/MouseReadoutBottomLine.jsx
@@ -33,9 +33,10 @@ export function MouseReadoutBottomLine({readout, readoutData, readoutShowing, st
 
     const isHiPS= readoutType===HIPS_STANDARD_READOUT;
     const displayEle= getNonFluxDisplayElements(readoutData,  readout.readoutPref, isHiPS);
-    const {readout1, showReadout1PrefChange, waveLength}= displayEle;
+    const {readout1, showReadout1PrefChange, waveLength, bandWidth}= displayEle;
     const r1Value= readout1?.value ??'';
     const wlValue= waveLength?.value ??'';
+    const bwValue= bandWidth?.value ??'';
     const {lockByClick=false}= readout??{};
     const showCopy= lockByClick;
 
@@ -59,7 +60,7 @@ export function MouseReadoutBottomLine({readout, readoutData, readoutShowing, st
         return <div/>;
     }
 
-    const fullSize= width>500;
+    const fullSize= width>520;
     const {threeColor= false}= readoutData;
     const monoFont= radix===16;
 
@@ -76,11 +77,13 @@ export function MouseReadoutBottomLine({readout, readoutData, readoutShowing, st
 
     const fluxLabel= threeColor ? label3C : labelStand;
     const fluxValue= threeColor ? value3C : valueStand;
-    const fluxWidth= threeColor ? '9rem' : '7rem';
+    const fluxWidth= threeColor ? '9.5rem' : '8rem';
+
+    let wlStr= doWL ? `${wlValue}${bwValue?' / ':''}${bwValue||''}` : '';
 
     return (
         <Stack {...{direction:'row', sx, ref: (c) => divref.element=c}}>
-            <Stack {...{direction:'row', alignItems:'center', sx:{'& .ff-readout-value':{pl:.5}} }}>
+            <Stack {...{direction:'row', alignItems:'center', sx:{'& .ff-readout-value':{pl:.25}} }}>
 
                 <ToolbarButton icon={<LaunchOutlinedIcon/>}
                                tip='Show expanded readout, thumbnail and magnifier'
@@ -88,16 +91,19 @@ export function MouseReadoutBottomLine({readout, readoutData, readoutShowing, st
 
                 <LabelItem {...{showCopy, label:readout1.label, value:r1Value, copyValue:readout1.copyValue,
                     sx:{pl:1}, prefChangeFunc:showReadout1PrefChange}}/>
-                <DataItem {...{value:r1Value, sx:{minWidth:!r1Value.length<3&&wlValue ? '2rem' : '13rem', pl:.5} }}/>
+                <DataItem {...{value:r1Value,
+                    sx:{
+                        minWidth: r1Value.length<3&&wlValue ? '2.5rem' : '13rem',
+                        } }}/>
 
                 {doFlux && <LabelItem {...{label:fluxLabel, value:fluxValue, sx:{pl:1},
                            prefChangeFunc:() => showMouseReadoutFluxRadixDialog(readout.readoutPref)}}/> }
                 {doFlux && <DataItem {...{value:fluxValue, unit: threeColor? '' :fluxArray[0].unit,
-                    sx:{minWidth:fluxWidth, pl:.5}, monoFont}}/> }
+                    sx:{minWidth:fluxWidth}, monoFont}}/> }
 
 
                 {doWL && <LabelItem {...{label:waveLength.label, value:wlValue, sx:{pl:1}}}/> }
-                {doWL && <DataItem {...{value:wlValue}}/> }
+                {doWL && <DataItem {...{value:wlStr}}/> }
 
             </Stack>
 
@@ -152,7 +158,7 @@ const DataItem= memo(({ value='', unit='', monoFont=false, sx}) => {
         <Stack {...{direction:'row', className:'ff-readout-value', alignItems:'center', sx }}>
             <Typography level='body-sm' color='warning'  title={vStr} sx={mStyle}>{value}</Typography>
             {unit && <Typography level='body-sm' color={!isEmptyUnit ? 'warning' : undefined}  title={vStr}
-                                 sx={{pl:.25, opacity:isEmptyUnit?.35:1}}>{unit}</Typography>}
+                                 sx={{pl:.25, whiteSpace: 'nowrap', opacity:isEmptyUnit?.35:1}}>{unit}</Typography>}
         </Stack>
     );
 });

--- a/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
+++ b/src/firefly/js/visualize/ui/MouseReadoutUIUtil.js
@@ -9,7 +9,8 @@ import {
     MR_EQJ2000_HMS, MR_FIELD_HIPS_MOUSE_READOUT1, MR_FIELD_HIPS_MOUSE_READOUT2, MR_FIELD_IMAGE_MOUSE_READOUT1,
     MR_FIELD_IMAGE_MOUSE_READOUT2, MR_FITS_IP, MR_WL, MR_ZERO_IP,
     MR_GALACTIC, MR_HEALPIX_NORDER, MR_HEALPIX_PIXEL, MR_PIXEL_SIZE, MR_SPIXEL_SIZE, MR_SUPER_GALACTIC, MR_WCS_COORDS,
-    STATUS_NAN, STATUS_UNAVAILABLE, STATUS_UNDEFINED, STATUS_VALUE, TYPE_DECIMAL_INT, TYPE_EMPTY, TYPE_FLOAT
+    STATUS_NAN, STATUS_UNAVAILABLE, STATUS_UNDEFINED, STATUS_VALUE, TYPE_DECIMAL_INT, TYPE_EMPTY, TYPE_FLOAT,
+    MR_BAND_WIDTH
 } from '../MouseReadoutCntlr.js';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {convertCelestial} from '../VisUtil';
@@ -42,6 +43,7 @@ const labelMap = {
     [MR_HEALPIX_PIXEL]: 'Pixel: ',
     [MR_HEALPIX_NORDER]: 'Norder: ',
     [MR_WL]: 'Wavelength: ',
+    [MR_BAND_WIDTH]: 'Band Width: ',
 };
 
 const coordOpTitle= 'Choose readout coordinates';
@@ -61,10 +63,10 @@ export function getNonFluxDisplayElements(readoutData, readoutPref, isHiPS= fals
     const objList= getNonFluxReadoutElements(readoutData,  readoutPref, isHiPS);
 
     const {imageMouseReadout1, imageMouseReadout2, imageMouseNoncelestialReadout1, imageMouseNoncelestialReadout2,
-        hipsMouseReadout1, hipsMouseReadout2, pixelSize, healpixPixel, healpixNorder, wl} = objList;
+        hipsMouseReadout1, hipsMouseReadout2, pixelSize, healpixPixel, healpixNorder, wl, bandWidth} = objList;
 
 
-    let readout1, readout2, healpixPixelReadout, healpixNorderReadout, waveLength;
+    let readout1, readout2, healpixPixelReadout, healpixNorderReadout, waveLength, bandWidthField= undefined;
     let showReadout1PrefChange, showReadout2PrefChange, showWavelengthFailed;
 
     if (isHiPS) {
@@ -108,13 +110,16 @@ export function getNonFluxDisplayElements(readoutData, readoutPref, isHiPS= fals
 
 
         if (wl?.value) {
-            waveLength= {...wl, label:labelMap.wl};
+            waveLength= {...wl, label:labelMap[MR_WL]};
             showWavelengthFailed= readoutItems.wl.failReason ? () => showInfoPopup(readoutItems.wl.failReason) : undefined;
+        }
+        if (bandWidth?.value) {
+            bandWidthField= {...bandWidth, label:labelMap[MR_BAND_WIDTH]};
         }
     }
 
     return {
-        readout1, readout2, waveLength, showWavelengthFailed,
+        readout1, readout2, waveLength, bandWidth:bandWidthField, showWavelengthFailed,
         showReadout1PrefChange, showReadout2PrefChange, healpixPixelReadout, healpixNorderReadout,
         pixelSize: {...pixelSize, label: labelMap[readoutPref.pixelSize]},
         showPixelPrefChange:() => showMouseReadoutOptionDialog('pixelSize', readoutPref.pixelSize, undefined, 'Choose pixel size'),
@@ -194,6 +199,10 @@ export function getReadoutElement(readoutItems, readoutKey, plotId, copyPref) {
             const {wl}= readoutItems;
             if (!wl) return {value:undefined};
             return {value:makeWLReturn(wl.value, getFormattedWaveLengthUnits(wl.unit))};
+        case MR_BAND_WIDTH:
+            const {bandWidth}= readoutItems;
+            if (!bandWidth) return {value:undefined};
+            return {value:makeWLReturn(bandWidth.value, getFormattedWaveLengthUnits(bandWidth.unit))};
     }
 
     return {value:''};


### PR DESCRIPTION
#### [Firefly-1482](https://jira.ipac.caltech.edu/browse/FIREFLY-1482): implement bandwidth in readout

#### Testing
- https://firefly-1482-bandwidth.irsakudev.ipac.caltech.edu/applications/spherex
- Band width will should up in the bottom mouse readout and the popout mouse readout
- I need feedback as to the most concise, reasonable way to display wavelength and bandwidth. Notice the difference between the popout and the bottom line readout.