### PR TITLE
FIREFLY-1653: Create a WavelengthInputField component to handle trailing units

### DIFF
--- a/src/firefly/js/ui/WavelengthInputField.jsx
+++ b/src/firefly/js/ui/WavelengthInputField.jsx
@@ -1,23 +1,19 @@
 import React, {memo} from 'react';
 import PropTypes from 'prop-types';
-import {Divider, FormHelperText, Stack} from '@mui/joy';
+import {Divider, FormHelperText, Stack, Typography} from '@mui/joy';
+import {isNaN, memoize} from 'lodash';
 import {ListBoxInputFieldView} from 'firefly/ui/ListBoxInputField';
 import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
 import {InputFieldView} from 'firefly/ui/InputFieldView';
 import Validate from 'firefly/util/Validate';
-import {memoize} from 'lodash';
+import {useFieldGroupValue} from 'firefly/ui/SimpleComponent';
+import {WAVELENGTH_UNITS} from 'firefly/visualize/VisUtil';
 
+// following strings are the keys in WAVELENGTH_UNITS object
 export const BASE_UNIT = 'um';
-const WAVELENGTH_UNITS = {
-    // key: { m: meters equivalent, label: full string that appears in dropdown, symbol: shorter string that appears elsewhere }
-    m: { m: 1, label: 'meters', symbol: 'm' },
-    [BASE_UNIT]: { m: 1e-6, label: 'microns', symbol: 'µm' },
-    nm: { m: 1e-9, label: 'nanometers', symbol: 'nm' },
-    angstrom: { m: 1e-10, label: 'angstroms', symbol: 'Å' },
-};
 const WVL_UNITS_OPTIONS = [BASE_UNIT, 'nm', 'angstrom']; // options that appear in the units dropdown
 
-// Following are in BASE_UNIT (microns). These bounds work well for most of the EM spectrum we will ever deal with: X-rays to Microwaves
+// following are in BASE_UNIT (microns). These bounds work well for most of the EM spectrum we will ever deal with: X-rays to Microwaves
 const MIN_WVL = 1e-5; // = 0.1 Å (gamma rays < 0.1 Å)
 const MAX_WVL = 1e5; // = 0.1 m (radio waves > 0.1 m)
 
@@ -45,11 +41,6 @@ export const convertWavelengthStr = (valueStr, fromUnit, toUnit) => {
 
 const wvlWithUnitsStr = (value, unit) => `${convertWavelengthStr(value, BASE_UNIT, unit)} ${WAVELENGTH_UNITS[unit].symbol}`;
 
-const isValidWavelength = (valueInMicrons, unit, nullAllowed, minInMicrons, maxInMicrons) => {
-    const makeMinMaxStr = (value) => wvlWithUnitsStr(value, unit);
-    return Validate.floatRange(minInMicrons, maxInMicrons, null, 'Wavelength', valueInMicrons, nullAllowed, makeMinMaxStr);
-};
-
 
 export const WavelengthUnitsView = ({ unit, onChange, ...props }) => (
     <Stack direction='row' alignItems='center'>
@@ -58,7 +49,7 @@ export const WavelengthUnitsView = ({ unit, onChange, ...props }) => (
             value={unit}
             onChange={onChange}
             options={WVL_UNITS_OPTIONS.map((unitKey) => ({
-                label: WAVELENGTH_UNITS[unitKey].label,
+                label: WAVELENGTH_UNITS[unitKey].symbol,
                 value: unitKey
             }))}
             tooltip='Unit of the wavelength'
@@ -74,11 +65,24 @@ export const WavelengthUnitsView = ({ unit, onChange, ...props }) => (
     </Stack>
 );
 
-
-// TODO for future: Make a HOC called QuantityInputField for abstraction of the redundant code in this and SizeInputField
+/**Controlled component for Wavelength Input.
+ *
+ * The state is controlled by `{value, displayValue, unit, valid, message}` props and the effect of state change is
+ * controlled by `onChange`.
+ *
+ * @param props
+ * @param props.value {string} wavelength value in BASE_UNIT
+ * @param props.displayValue {string} wavelength value that is input by user
+ * @param props.unit {string} wavelength unit input by user
+ * @param props.valid {boolean} whether `value` is valid (i.e. satisfies min/max bounds, nullAllowed, etc.)
+ * @param props.message {string} message to display if invalid
+ * @param props.onChange {function(object, {value: string, displayValue: string, unit: string}): void} lifts the updated
+ * value, displayValue, unit to the parent that controls the state.
+ */
 function WavelengthInputFieldView({min=MIN_WVL, max=MAX_WVL, sx, slotProps, inputStyle={},
                                       orientation='vertical', label='Wavelength: ', showFeedback=false,
-                                      onChange, valid, message, unit=BASE_UNIT, value, displayValue}) {
+                                      placeholder='Enter wavelength', tooltip='Enter wavelength within the valid range',
+                                      onChange, valid, message, unit, value, displayValue}) {
 
     const handleWvlChange = (ev) => {
         const newDisplayValue = ev?.target?.value?.trim();
@@ -123,8 +127,8 @@ function WavelengthInputFieldView({min=MIN_WVL, max=MAX_WVL, sx, slotProps, inpu
                 onBlur={handleWvlChange}
                 value={displayValue}
                 inputStyle={inputStyle}
-                placeholder='Enter wavelength'
-                tooltip='Enter wavelength within the valid range'
+                placeholder={placeholder}
+                tooltip={tooltip}
                 label={label}
                 orientation={orientation}
                 sx={{ '& .MuiInput-root': { paddingInlineEnd: 0 } }}
@@ -135,26 +139,50 @@ function WavelengthInputFieldView({min=MIN_WVL, max=MAX_WVL, sx, slotProps, inpu
             </FormHelperText>
         </Stack>
     );
+}
+
+const isValidWavelength = (value, unit, nullAllowed, min, max, description) => {
+    const makeMinMaxStr = (value) => wvlWithUnitsStr(value, unit);
+    return Validate.floatRange(min, max, null, description, value, nullAllowed, makeMinMaxStr);
 };
 
-
 const handleOnChange = (ev, wvlInfoUpdate, viewProps, fireValueChange) => {
-    const { value, displayValue, unit=BASE_UNIT, nullAllowed=false,
-        min=MIN_WVL, max=MAX_WVL } = { ...viewProps, ...wvlInfoUpdate }; //even validator can come from viewProps
+    const { value, displayValue, unit=BASE_UNIT, validator, nullAllowed=false,
+        min=MIN_WVL, max=MAX_WVL, description='Wavelength' } = { ...viewProps, ...wvlInfoUpdate };
 
-    const { valid, message } = isValidWavelength(value, unit, nullAllowed, min, max);
+    // run custom validator (`validator()`) before the default validator (`isValidWavelength()`) that checks wavelength bounds
+    let validationResult = validator?.(value) ?? {valid: true, message: ''};
+    if (validationResult?.valid) validationResult = isValidWavelength(value, unit, nullAllowed, min, max, description);
+    const { valid, message } = validationResult;
+
     fireValueChange({ value, displayValue, unit, valid, message });
 };
 
+const updateInitState = ({value='', displayValue='', unit=BASE_UNIT}) => {
+    const initialState = {value, displayValue, unit};
+    if (value && !displayValue) initialState.displayValue = convertWavelengthStr(value, BASE_UNIT, unit);
+    else if (!value && displayValue) initialState.value = convertWavelengthStr(displayValue, unit, BASE_UNIT);
+    return initialState;
+};
 
+
+// TODO for future: Make a HOC called QuantityInputField for
+//  - abstraction of the redundant code/logic in WavelengthInputField(View) and SizeInputField(View)
+//  - cleanup state logic of SizeInputField (it's unnecessarily convoluted)
+
+/**Uncontrolled component for Wavelength Input that manages the state with respect to the FieldGroup.
+ */
 export const WavelengthInputField = memo((props) => {
-    const { viewProps, fireValueChange } = useFieldGroupConnector(props);
-    return (
-        <WavelengthInputFieldView
-            {...viewProps}
-            onChange={(ev, wvlInfoUpdate) => handleOnChange(ev, wvlInfoUpdate, viewProps, fireValueChange)}
-        />
-    );
+    const { viewProps, fireValueChange } = useFieldGroupConnector({
+        ...props,
+        initialState: updateInitState(props?.initialState),
+    });
+
+    const newProps = {
+        ...viewProps,
+        onChange: (ev, wvlInfoUpdate) => handleOnChange(ev, wvlInfoUpdate, viewProps, fireValueChange)
+    };
+    return (<WavelengthInputFieldView {...newProps}/>);
 });
 
 const commonPropTypes = {
@@ -164,6 +192,7 @@ const commonPropTypes = {
     showFeedback: PropTypes.bool,
     label: PropTypes.string,
     tooltip: PropTypes.string,
+    placeholder: PropTypes.string,
     orientation: PropTypes.string,
     inputStyle: PropTypes.object,
     sx: PropTypes.object,
@@ -185,11 +214,60 @@ WavelengthInputFieldView.propTypes = {
 
 WavelengthInputField.propTypes = {
     ...commonPropTypes,
-    fieldKey: PropTypes.string.isRequired,
+    fieldKey: PropTypes.string,
     groupKey: PropTypes.string,
     initialState: PropTypes.shape({
         value: PropTypes.any,
         displayValue: PropTypes.string,
         unit: PropTypes.string,
     }),
+    validator: PropTypes.func,
+    description: PropTypes.string,
+};
+
+const MIN_MAX_WVL_RANGE_ERR = 'Max wavelength must not be smaller than Min wavelength';
+
+export function WavelengthRangeInput({minFieldKey, maxFieldKey, slotProps}) {
+    const [getMinVal] = useFieldGroupValue(minFieldKey);
+    const [getMaxVal] = useFieldGroupValue(maxFieldKey);
+
+    const minMaxWvlRangeValidator = (currentValueStr, pairedValueStr, isMaxField) => {
+        const [currentValue, pairedValue] = [currentValueStr, pairedValueStr].map((str) => Number.parseFloat(str));
+        if (!isNaN(currentValue) && !isNaN(pairedValue)) {
+            return ((isMaxField && currentValue < pairedValue) // maxValue < minValue (validation happened on the Max Wvl field)
+                || (!isMaxField && currentValue > pairedValue)) // minValue > maxValue (validation happened on the Min Wvl field)
+                ? {valid: false, message: MIN_MAX_WVL_RANGE_ERR}
+                : {valid: true, message: ''};
+        }
+    };
+
+    return (
+        <Stack direction='row' spacing={1} alignItems='center'
+               sx={{ '& .MuiInput-root': { 'width': '14rem' } }}
+               {...slotProps?.root}>
+            <WavelengthInputField fieldKey={minFieldKey}
+                                  label=''
+                                  placeholder='Min wavelength'
+                                  description='Min wavelength'
+                                  validator={(value)=>minMaxWvlRangeValidator(value, getMaxVal(), false)}
+                                  {...slotProps?.wvlMin} />
+            <Typography level='body-md'>to</Typography>
+            <WavelengthInputField fieldKey={maxFieldKey}
+                                  label=''
+                                  placeholder='Max wavelength'
+                                  description='Max wavelength'
+                                  validator={(value)=>minMaxWvlRangeValidator(value, getMinVal(), true)}
+                                  {...slotProps?.wvlMax} />
+        </Stack>
+    );
+}
+
+WavelengthRangeInput.propTypes = {
+    minFieldKey: PropTypes.string.isRequired,
+    maxFieldKey: PropTypes.string.isRequired,
+    slotProps: PropTypes.shape({
+        root: PropTypes.object,
+        wvlMin: PropTypes.shape({...WavelengthInputField.propTypes}),
+        wvlMax: PropTypes.shape({...WavelengthInputField.propTypes})
+    })
 };

--- a/src/firefly/js/ui/WavelengthInputField.jsx
+++ b/src/firefly/js/ui/WavelengthInputField.jsx
@@ -1,0 +1,195 @@
+import React, {memo} from 'react';
+import PropTypes from 'prop-types';
+import {Divider, FormHelperText, Stack} from '@mui/joy';
+import {ListBoxInputFieldView} from 'firefly/ui/ListBoxInputField';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
+import {InputFieldView} from 'firefly/ui/InputFieldView';
+import Validate from 'firefly/util/Validate';
+import {memoize} from 'lodash';
+
+export const BASE_UNIT = 'um';
+const WAVELENGTH_UNITS = {
+    // key: { m: meters equivalent, label: full string that appears in dropdown, symbol: shorter string that appears elsewhere }
+    m: { m: 1, label: 'meters', symbol: 'm' },
+    [BASE_UNIT]: { m: 1e-6, label: 'microns', symbol: 'µm' },
+    nm: { m: 1e-9, label: 'nanometers', symbol: 'nm' },
+    angstrom: { m: 1e-10, label: 'angstroms', symbol: 'Å' },
+};
+const WVL_UNITS_OPTIONS = [BASE_UNIT, 'nm', 'angstrom']; // options that appear in the units dropdown
+
+// Following are in BASE_UNIT (microns). These bounds work well for most of the EM spectrum we will ever deal with: X-rays to Microwaves
+const MIN_WVL = 1e-5; // = 0.1 Å (gamma rays < 0.1 Å)
+const MAX_WVL = 1e5; // = 0.1 m (radio waves > 0.1 m)
+
+const convertWavelength = (value, fromUnit, toUnit) => {
+    const fromUnitInMeters = WAVELENGTH_UNITS[fromUnit].m;
+    const toUnitInMeters = WAVELENGTH_UNITS[toUnit].m;
+    return value * fromUnitInMeters / toUnitInMeters;
+};
+
+// get the number of digits after decimal point that we will ever need to represent the lowest wavelength (MIN_WVL)
+const getFracDigits = memoize((unit) =>
+    Math.log10(convertWavelength(MIN_WVL, BASE_UNIT, unit)) * -1);
+
+export const convertWavelengthStr = (valueStr, fromUnit, toUnit) => {
+    const value = parseFloat(valueStr);
+    if (isNaN(value)) return valueStr;
+    const newValue = convertWavelength(value, fromUnit, toUnit);
+
+    // to avoid floating-point rounding errors
+    let newValueStr = newValue.toFixed(getFracDigits(toUnit));
+    // remove leading 0s (if any)
+    newValueStr = parseFloat(newValueStr).toString();
+    return newValueStr;
+};
+
+const wvlWithUnitsStr = (value, unit) => `${convertWavelengthStr(value, BASE_UNIT, unit)} ${WAVELENGTH_UNITS[unit].symbol}`;
+
+const isValidWavelength = (valueInMicrons, unit, nullAllowed, minInMicrons, maxInMicrons) => {
+    const makeMinMaxStr = (value) => wvlWithUnitsStr(value, unit);
+    return Validate.floatRange(minInMicrons, maxInMicrons, null, 'Wavelength', valueInMicrons, nullAllowed, makeMinMaxStr);
+};
+
+
+export const WavelengthUnitsView = ({ unit, onChange, ...props }) => (
+    <Stack direction='row' alignItems='center'>
+        <Divider orientation='vertical' />
+        <ListBoxInputFieldView
+            value={unit}
+            onChange={onChange}
+            options={WVL_UNITS_OPTIONS.map((unitKey) => ({
+                label: WAVELENGTH_UNITS[unitKey].label,
+                value: unitKey
+            }))}
+            tooltip='Unit of the wavelength'
+            multiple={false}
+            slotProps={{
+                input: {
+                    variant: 'plain',
+                    sx: { minHeight: 'unset' },
+                },
+            }}
+            {...props}
+        />
+    </Stack>
+);
+
+
+// TODO for future: Make a HOC called QuantityInputField for abstraction of the redundant code in this and SizeInputField
+function WavelengthInputFieldView({min=MIN_WVL, max=MAX_WVL, sx, slotProps, inputStyle={},
+                                      orientation='vertical', label='Wavelength: ', showFeedback=false,
+                                      onChange, valid, message, unit=BASE_UNIT, value, displayValue}) {
+
+    const handleWvlChange = (ev) => {
+        const newDisplayValue = ev?.target?.value?.trim();
+        const newValue = convertWavelengthStr(newDisplayValue, unit, BASE_UNIT);
+        const wvlInfoUpdate = {
+            value: newValue,
+            displayValue: newDisplayValue,
+            unit,
+        };
+        onChange?.(ev, wvlInfoUpdate); // lift the state
+    };
+
+    const handleUnitChange = (ev, newUnit) => {
+        if (unit === newUnit) return;
+        let newValue = value;
+        let newDisplayValue = displayValue;
+
+        if (valid) {
+            newDisplayValue = convertWavelengthStr(value, BASE_UNIT, newUnit);
+        } else {
+            // maybe the displayValue (user-input number) is valid for new unit
+            // so keep displayValue unchanged but update value (which will be checked for validity by parent component)
+            newValue = convertWavelengthStr(displayValue, newUnit, BASE_UNIT);
+        }
+
+        const wvlInfoUpdate = {
+            value: newValue,
+            displayValue: newDisplayValue,
+            unit: newUnit,
+        };
+        onChange?.(ev, wvlInfoUpdate);
+    };
+
+    const feedback = showFeedback ? `Valid range: ${wvlWithUnitsStr(min, unit)} - ${wvlWithUnitsStr(max, unit)}` : '';
+
+    return (
+        <Stack sx={sx}>
+            <InputFieldView
+                valid={valid}
+                message={message}
+                onChange={handleWvlChange}
+                onBlur={handleWvlChange}
+                value={displayValue}
+                inputStyle={inputStyle}
+                placeholder='Enter wavelength'
+                tooltip='Enter wavelength within the valid range'
+                label={label}
+                orientation={orientation}
+                sx={{ '& .MuiInput-root': { paddingInlineEnd: 0 } }}
+                endDecorator={<WavelengthUnitsView unit={unit} onChange={handleUnitChange} {...slotProps?.units}/>}
+            />
+            <FormHelperText {...{...slotProps?.feedback}}>
+                {feedback}
+            </FormHelperText>
+        </Stack>
+    );
+};
+
+
+const handleOnChange = (ev, wvlInfoUpdate, viewProps, fireValueChange) => {
+    const { value, displayValue, unit=BASE_UNIT, nullAllowed=false,
+        min=MIN_WVL, max=MAX_WVL } = { ...viewProps, ...wvlInfoUpdate }; //even validator can come from viewProps
+
+    const { valid, message } = isValidWavelength(value, unit, nullAllowed, min, max);
+    fireValueChange({ value, displayValue, unit, valid, message });
+};
+
+
+export const WavelengthInputField = memo((props) => {
+    const { viewProps, fireValueChange } = useFieldGroupConnector(props);
+    return (
+        <WavelengthInputFieldView
+            {...viewProps}
+            onChange={(ev, wvlInfoUpdate) => handleOnChange(ev, wvlInfoUpdate, viewProps, fireValueChange)}
+        />
+    );
+});
+
+const commonPropTypes = {
+    min: PropTypes.number,
+    max: PropTypes.number,
+    nullAllowed: PropTypes.bool,
+    showFeedback: PropTypes.bool,
+    label: PropTypes.string,
+    tooltip: PropTypes.string,
+    orientation: PropTypes.string,
+    inputStyle: PropTypes.object,
+    sx: PropTypes.object,
+    slotProps: PropTypes.shape({
+        units: PropTypes.object,
+        feedback: PropTypes.object,
+    }),
+};
+
+WavelengthInputFieldView.propTypes = {
+    ...commonPropTypes,
+    value: PropTypes.string, // used by field group state, always in BASE_UNIT
+    displayValue: PropTypes.string, // what's displayed in the input field UI
+    unit: PropTypes.string,
+    valid: PropTypes.bool,
+    message: PropTypes.string,
+    onChange: PropTypes.func,
+};
+
+WavelengthInputField.propTypes = {
+    ...commonPropTypes,
+    fieldKey: PropTypes.string.isRequired,
+    groupKey: PropTypes.string,
+    initialState: PropTypes.shape({
+        value: PropTypes.any,
+        displayValue: PropTypes.string,
+        unit: PropTypes.string,
+    }),
+};

--- a/src/firefly/js/util/Validate.js
+++ b/src/firefly/js/util/Validate.js
@@ -31,12 +31,12 @@ const makePrecisionStr= function(value,precision) {
     else return '';
 };
 
-const makeErrorMessage= function(description,min,max,precision) {
+const makeErrorMessage= function(description,min,max,makeMinMaxStr) {
     let retval= '';
     const hasMin= (min !== undefined && min!==null);
     const hasMax= (min !== undefined && min!==null);
-    const minStr= makePrecisionStr(min,precision);
-    const maxStr= makePrecisionStr(max,precision);
+    const minStr= makeMinMaxStr(min);
+    const maxStr= makeMinMaxStr(max);
     description= description || '';
     if (hasMin && hasMax) {
         retval= description + ': must be between ' + minStr + ' and ' + maxStr;
@@ -50,7 +50,8 @@ const makeErrorMessage= function(description,min,max,precision) {
     return retval;
 };
 
-const validateRange = function(min,max,precision,description,dType, valStr, nullAllowed) {
+const validateRange = function(min,max,precision,description,dType, valStr, nullAllowed, makeMinMaxStr) {
+    if (!makeMinMaxStr) makeMinMaxStr = (value) => makePrecisionStr(value, precision);
     const retval= {
         valid : true,
         message : ''
@@ -61,17 +62,17 @@ const validateRange = function(min,max,precision,description,dType, valStr, null
             const v = dType.convertFunc(valStr);
             if (!isInRange(v, min, max) || isNaN(v)) {
                 retval.valid = false;
-                retval.message = makeErrorMessage(description, min, max, precision);
+                retval.message = makeErrorMessage(description, min, max, makeMinMaxStr);
             }
         }
         else {
             retval.valid = false;
-            retval.message = description + ': must be a '+ dType.dataTypeDesc + makeErrorMessage(null, min, max, precision);
+            retval.message = description + ': must be a '+ dType.dataTypeDesc + makeErrorMessage(null, min, max, makeMinMaxStr);
         }
     }
     else if (!nullAllowed) {
         retval.valid = false;
-        retval.message = description + ': must be a '+ dType.dataTypeDesc + makeErrorMessage(null, min, max, precision);
+        retval.message = description + ': must be a '+ dType.dataTypeDesc + makeErrorMessage(null, min, max, makeMinMaxStr);
     }
     return retval;
 };
@@ -150,8 +151,8 @@ export const intRange = function(min,max,description, valStr, nullAllowed=true) 
    return validateRange(min,max,null,description,typeInject.asInt,valStr, nullAllowed);
 };
 
-export const floatRange = function(min,max,precision, description, valStr, nullAllowed=true) {
-    return validateRange(min,max,precision,description,typeInject.asFloat,valStr, nullAllowed);
+export const floatRange = function(min,max,precision, description, valStr, nullAllowed=true, makeMinMaxStr) {
+    return validateRange(min,max,precision,description,typeInject.asFloat,valStr, nullAllowed, makeMinMaxStr);
 };
 
 export const isFloat = function(description, valStr) {

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -15,7 +15,7 @@ import {makeDevicePt, makeImagePt, makeWorldPt, pointEquals} from './Point.js';
 import {getWavelength} from './projection/Wavelength.js';
 import {removeRawData} from './rawData/RawDataCache.js';
 import {hasClearedDataInStore, hasLocalStretchByteDataInStore} from './rawData/RawDataOps.js';
-import {computeDistance} from './VisUtil';
+import {computeDistance, WAVELENGTH_UNITS} from './VisUtil';
 import {isHiPS, isHiPSAitoff, isImage} from './WebPlot.js';
 
 
@@ -949,7 +949,7 @@ export function getWaveLengthUnits(plot) {
  * @return {string}
  */
 export function getFormattedWaveLengthUnits(plotOrStr, anyPartOfStr=false) {
-    const MICRON_SYMBOL= String.fromCharCode(0x03BC)+'m';
+    const MICRON_SYMBOL= WAVELENGTH_UNITS.um.symbol;
     const uStr= isString(plotOrStr) ? plotOrStr : getWaveLengthUnits(plotOrStr);
     if (anyPartOfStr) {
         return uStr.replace(new RegExp('microns|micron|um|micrometers','gi'),MICRON_SYMBOL);

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -20,6 +20,24 @@ export const RtoD = 180.0 / Math.PI;
 export const toDegrees = (angle) => angle * (180 / Math.PI);
 export const toRadians = (angle) => (angle * Math.PI) / 180;
 
+/**
+ * @typedef {Object} WavelengthUnitDefinition
+ * @property {number} m - The equivalent value in meters.
+ * @property {string} name - The full unit name in ASCII characters.
+ * @property {string} symbol - The shorter unit symbol using Unicode characters.
+ */
+
+/**
+ * Mapping of wavelength unit keys to their definitions.
+ * @type {Object.<string, WavelengthUnitDefinition>}
+ */
+export const WAVELENGTH_UNITS = {
+    // key: { m: meters equivalent, name: full string in ASCII, symbol: shorter string with Unicode characters }
+    m: { m: 1, name: 'meters', symbol: 'm' },
+    um: { m: 1e-6, name: 'microns', symbol: 'μm' },
+    nm: { m: 1e-9, name: 'nanometers', symbol: 'nm' },
+    angstrom: { m: 1e-10, name: 'angstroms', symbol: 'Å' },
+};
 
 //======================================================================
 //----------------------- Public Methods -------------------------------


### PR DESCRIPTION
Fixes [FIREFLY-1653](https://jira.ipac.caltech.edu/browse/FIREFLY-1653)

- Added `WavelengthInputField` and `WavelengthRangeInput` components that can handle units changes and validation
- Updated ObsTAP `WavelengthPanel` to use these components (cleaned up TAP/SIA constraints generation logic because these component handle that already)
- Made floatRange validator accept custom error message
- Now SPHEREx instances can define min max bounds on wavelength as well as initial value and initial unit and the component will handle input validation

See IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/396

# Testing
https://firefly-1653-wvl-input-component.irsakudev.ipac.caltech.edu/applications/spherex/

Go to LVF search -> **_Uncheck "Location"_** -> "Spectral Coverage" -> select:
- "By Wavelength" and "contains": 
  - enter `8` -> should show error message because out of bounds
  - enter `4.72` -> change units -> it should update field as per conversion logic (similar to SizeInputField does)
  - "search" -> `2043` rows should appear. Cross check if ObsTAP constraint on `em_min` and `em_max` column was right by switching to "By Filter Bands" -> check "Band 6" checkbox -> search -> `2043` rows should appear
- "By Wavelength" and "overlaps":
  - enter `.5` in max wavelength input -> should show error message
  - enter `5.8` in max wavelength input -> should show error message
  - enter `5` in max wavelength input and `4.45` in min wavelength input -> search -> `2043` rows should appear (since we constrained to only Band 6 by wavelength range)


## Regression Testing 
https://fireflydev.ipac.caltech.edu/firefly-1653-wvl-input-component/firefly

Perform SIA or ObsTAP searches, and see if wavelength constraints are generated correctly when using wavelength range or wavelength input fields. E.g.:
- SIA: CADC m81, 200 nm -> all rows have em_min <= 2e-7 <= em_max
- ObsTAP: just use ADQL edit screen to see constraints

> Note: now that we have bounds validation on wavelength input, we can't work with -Inf and Inf (those are not physically possible for wavelength anyways). I have chosen 0.1 meter to 0.1 Angstrom as default min, max based on EM spectrum classification. We can change it later if scientists disagree. There are also floating point precision issues that need to be taken care of. 