### PR TITLE
FIREFLY-1693: ObsCore improvements 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -8,7 +8,6 @@ import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.data.table.SelectionInfo;
-import edu.caltech.ipac.firefly.server.RequestOwner;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.db.spring.JdbcFactory;
 import edu.caltech.ipac.firefly.server.events.FluxAction;
@@ -246,13 +245,14 @@ public class EmbeddedDbUtil {
         if (cols != null && cols.length > 0) {
             ArrayList<String> colsAry = new ArrayList<>(Arrays.asList(cols));
             if (!colsAry.contains(DataGroup.ROW_NUM)) {
-                // add ROW_NUM into the returned results if not asked
+                //add ROW_NUM into the returned results if not asked
                 colsAry.add(DataGroup.ROW_NUM);
                 cols = colsAry.toArray(new String[colsAry.size()]);
             }
         }
         MappedData results = new MappedData();
         DataGroup data = getSelectedData(searchRequest, selRows, cols);
+
         for (DataObject row : data) {
             int idx = row.getIntData(DataGroup.ROW_NUM);
             for (DataType dt : data.getDataDefinitions()) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
@@ -110,7 +110,7 @@ public final class PackagingWorker implements Job.Worker {
 
                     curFileInfoIdx++;
                     try {
-                        zippedBytes += zipHandler.addZipEntry(zout, fi);
+                        zippedBytes += (int) zipHandler.addZipEntry(zout, fi);
                         totalBytes += zippedBytes;
                     } catch (AccessDeniedException e) {
                         denied.add(e.getMessage());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
@@ -9,7 +9,6 @@ import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.table.*;
 import edu.caltech.ipac.table.io.VoTableReader;
-import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import org.json.JSONObject;
 
@@ -18,9 +17,9 @@ import java.net.URL;
 import java.util.*;
 
 import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.getSelectedData;
-import static edu.caltech.ipac.util.FileUtil.getUniqueFileNameForGroup;
-import static org.apache.commons.lang.StringUtils.substringAfterLast;
+import static org.apache.commons.lang.StringUtils.isEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static org.apache.commons.lang.StringUtils.substringAfterLast;
 
 @SearchProcessorImpl(id = "ObsCorePackager")
 public class ObsCorePackager extends FileGroupsProcessor {
@@ -35,6 +34,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
     public static final String ACCESS_FORMAT = "access_format";
     public static final String SEMANTICS = "semantics";
     public static final String CONTENT_TYPE = "content_type";
+    public static final String FILE = "file";
 
     public static final String DATALINK_SER_DEF = "datalinkServiceDescriptor";
     public static final String ADHOC_SERVICE = "adhoc:service";
@@ -46,6 +46,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
     public static final String RA = "ra";
     public static final String DEC = "dec";
     public static final String CUTOUT_VALUE = "cutoutValue";
+    public static final String ZIP_TYPE = "zipType";
     public static final String SER_DEF_ACCESS_URL = "accessURL";
     public static final String SER_DEF_INPUT_PARAMS = "inputParams";
     public static final String CIRCLE = "circle";
@@ -54,6 +55,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
     public static final String TEMPLATE_COL_NAMES = "templateColNames";
     public static final String USE_SOURCE_FILE_NAME = "useSourceUrlFileName";
     public static final String POSITION = "position";
+    public static final String GENERATE_DOWNLOAD_FILE_NAME = "generateDownloadFileName";
 
     private static final List<String> CUTOUT_UCDs= Arrays.asList("phys.size","phys.size.radius","phys.angSize", "pos.spherical.r");
     private static final List<String>  RA_UCDs= List.of("pos.eq.ra");
@@ -83,18 +85,16 @@ public class ObsCorePackager extends FileGroupsProcessor {
     }
 
     private List<FileGroup> computeFileGroup(DownloadRequest request) throws DataAccessException{
-        var selectedRows = new ArrayList<>(request.getSelectedRows());
-
         List<FileInfo> fileInfos = new ArrayList<>();
-        MappedData dgDataUrl = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(), selectedRows); //returns all columns
-
-        DataGroup dg = getSelectedData(request.getSearchRequest(), selectedRows);
-        String datalinkServDesc = request.getParam(DATALINK_SER_DEF); //check for a non obscore file containing a datalink service descriptor
-
         try {
-            Map<String,Integer> dataLinkFolders = new HashMap<>();
-            for (int idx : selectedRows) {
+            var selectedRows = new ArrayList<>(request.getSelectedRows());
+            MappedData dgDataUrl = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(), selectedRows); //returns all columns
+            DataGroup dg = getSelectedData(request.getSearchRequest(), selectedRows);
 
+            String datalinkServDesc = request.getParam(DATALINK_SER_DEF); //check for a non-obscore table containing a Datalink Service Descriptor
+            String pos = request.getParam(POSITION);
+
+            for (int idx : selectedRows) {
                 String access_url = (String) dgDataUrl.get(idx, ACCESS_URL);
 
                 if (access_url == null) {
@@ -102,71 +102,31 @@ public class ObsCorePackager extends FileGroupsProcessor {
                     if (datalinkServDesc != null) {
                         //construct product url / access url here
                         ServDescUrl serDescUrl = createUrlFromServDesc(datalinkServDesc);
-
-                        if (serDescUrl.isValid()) {
-                            StringBuilder finalUrl = new StringBuilder(serDescUrl.partialUrl);
-
-                            if (serDescUrl.missingParams.isEmpty()) {
-                                access_url = serDescUrl.partialUrl;
-                            }
-                            else {
-                                for (MissingParam missing : serDescUrl.missingParams) {
-                                    String refId = missing.refId;
-                                    String key = "";
-                                    for (DataType data : dg.getDataDefinitions()) {
-                                        if (data.getID().equalsIgnoreCase(refId)) {
-                                            key = data.getKeyName();
-                                            break;
-                                        }
-                                    }
-                                    String resolvedValue = (String) dgDataUrl.get(idx, key);
-                                    if (resolvedValue != null && !resolvedValue.isEmpty()) {
-                                        if (serDescUrl.partialUrl.endsWith("?"))
-                                            finalUrl.append(missing.paramName).append("=").append(resolvedValue);
-                                        else
-                                            finalUrl.append("&").append(missing.paramName).append("=").append(resolvedValue);
-                                    }
-                                }
-                                access_url = finalUrl.toString(); //datalink url from service descriptor
-                            }
-                        }
+                        access_url = getAccessUrlFromNonObsCore(serDescUrl, dg, dgDataUrl, idx);
                     }
                     else continue; //no file available to process
                 }
+
                 String access_format = (String) dgDataUrl.get(idx, ACCESS_FORMAT);
                 URL url = new URL(access_url);
 
+                List<String> positionColVals = getPositionColVals(pos, idx, dgDataUrl);
                 String colNames = request.getSearchRequest().getParam(TEMPLATE_COL_NAMES);
-                boolean useSourceUrlFileName= request.getSearchRequest().getBooleanParam(USE_SOURCE_FILE_NAME,false);
                 String[] cols = colNames != null ? colNames.split(",") : null;
-                String ext_file_name = getFileName(idx,cols,useSourceUrlFileName,dgDataUrl,url);
+                String fileNamePrefix = getFileNamePrefix(idx, cols, dgDataUrl, url, positionColVals); //this will be used as folder name, and as prefix for individual file names
 
-                if (access_format != null) {
-                    if (access_format.contains(DATALINK)) {
-                        ext_file_name = getUniqueFileNameForGroup(ext_file_name, dataLinkFolders);
-                        List<FileInfo> tmpFileInfos = parseDatalink(url, request, dgDataUrl, idx, ext_file_name);
-                        fileInfos.addAll(tmpFileInfos);
-                    }
-                    else { //non datalink entry -  such as fits,jpg etc.
-                        if (!useSourceUrlFileName || FileUtil.getExtension(ext_file_name).isEmpty()) {
-                            String extension = access_format.replaceAll(".*/", "");
-                            ext_file_name += "." + extension;
-                        }
-                        FileInfo fileInfo = new FileInfo(access_url, ext_file_name, 0);
-                        fileInfos.add(fileInfo);
-                    }
-                }
-                else {
-                    if (datalinkServDesc != null) { //parse the datalink url found in the non-obscore table
-                        List<FileInfo> tmpFileInfos = parseDatalink(url, request, dgDataUrl, idx, ext_file_name);
-                        fileInfos.addAll(tmpFileInfos);
-                    }
-                    else { //access_format & access_url are both null, so try and get it from the url's Content_Type
-                        FileInfo fileInfo = new FileInfo(access_url, ext_file_name, 0);
-                        fileInfos.add(fileInfo);
-                    }
-                }
+                String zipType = request.getParam(ZIP_TYPE); //flat or folder
+                
+                boolean isDatalink = (datalinkServDesc != null) || (access_format != null && access_format.contains(DATALINK));
 
+                if (isDatalink) {
+                    List<FileInfo> tmpFileInfos = parseDatalink(url, request, dgDataUrl, idx, fileNamePrefix, positionColVals);
+                    fileInfos.addAll(tmpFileInfos);
+                } else {
+                    String extName = "folder".equalsIgnoreCase(zipType) ? fileNamePrefix + "/" : null; //if flattened, no external name, just set null
+                    FileInfo fileInfo = new FileInfo(access_url, extName, 0);
+                    fileInfos.add(fileInfo);
+                }
             }
             fileInfos.forEach(fileInfo -> fileInfo.setRequestInfo(HttpServiceInput.createWithCredential(fileInfo.getInternalFilename())));
         }
@@ -176,38 +136,19 @@ public class ObsCorePackager extends FileGroupsProcessor {
         return Arrays.asList(new FileGroup(fileInfos, null, 0, "ObsCore Download Files"));
     }
 
-    public static List<FileInfo> parseDatalink(URL url, DownloadRequest request, MappedData dgDataUrl, int idx, String prepend_file_name) {
+    public static List<FileInfo> parseDatalink(URL url, DownloadRequest request, MappedData dgDataUrl, int idx, String prepend_file_name, List<String> positionColVals) {
         List<FileInfo> fileInfos = new ArrayList<>();
+        String zipType = request.getParam(ZIP_TYPE); //flattened downloads or folders
+        boolean generateDownloadFileName = Boolean.parseBoolean(Objects.toString(request.getParam(GENERATE_DOWNLOAD_FILE_NAME), "false"));
 
-        //products to download in datalink file
-        String productTypes = request.getParam(PRODUCTS);
+        String productTypes = request.getParam(PRODUCTS); //products to download in datalink file
         String[] products = (productTypes != null && !productTypes.trim().isEmpty()) ? productTypes.split(",") : null;
-
         String cutoutValue = request.getParam(CUTOUT_VALUE);
-        boolean useSourceUrlFileName= request.getSearchRequest().getBooleanParam(USE_SOURCE_FILE_NAME,false);
 
         try {
             DataGroup[] groups = VoTableReader.voToDataGroups(url.toString(), false);
 
-            String pos = request.getParam(POSITION);
-            Position position = getPosition(pos);
-            String ra, dec;
-
-            ra = ifNotNull(position.centerColValues().ra())
-                    .get(v -> v.equals("null") ? null : v);  // Ensure "null" is treated as null
-
-            dec = ifNotNull(position.centerColValues().dec())
-                    .get(v -> v.equals("null") ? null : v);
-
-            if (ra == null || dec == null) { //if ra dec are null, use center columns to get the lon & lat values from the file
-                String lonCol = position.centerColNames.lonCol(); //for ra/lon
-                String latCol = position.centerColNames.latCol(); //for dec/lat
-                ra = Objects.toString(dgDataUrl.get(idx, lonCol), null);
-                dec = Objects.toString(dgDataUrl.get(idx, latCol), null);
-            }
-
             //to be used for cutout service descriptor url
-            String serDefUrl = "";
             Map<String, ServDescUrl> serDefUrls = new HashMap<>();
 
             for (DataGroup dg : groups) {
@@ -228,72 +169,43 @@ public class ObsCorePackager extends FileGroupsProcessor {
                 if (countValidDLFiles > 1) {
                     makeDataLinkFolder = true;
                 }
-
                 for (int i=0; i < dg.size(); i++) {
                     String accessUrl = Objects.toString(dg.getData(ACCESS_URL, i), null);
                     String sem = Objects.toString(dg.getData(SEMANTICS, i), null);
+                    String file = Objects.toString(dg.getData(FILE, i), null);
                     String content_type = Objects.toString(dg.getData(CONTENT_TYPE, i), null);
 
                     String productUrl = accessUrl;
+
+                    String fileName = null;
 
                     if (accessUrl == null || sem == null) {
                         //if only semantic (sem) is null, accessUrl may still be available, but we won't know which accessUrls ones to pick
                         String serviceDef = String.valueOf(dg.getData(SERVICE_DEF, i));
 
                         if (testSem(sem, "#cutout") && serviceDef != null && !serviceDef.isEmpty()) {
-                            ServDescUrl result;
-
-                            if (serDefUrls.containsKey(serviceDef)) { //if we have already found this service descriptor url
-                                result = serDefUrls.get(serviceDef);
-                            } else { //else, parse this service descriptor to create a product url using access_url and the inputParams
-                                if (ra == null || dec == null || cutoutValue == null) continue; //cannot create service descriptor url
-                                result = createCutoutSerDefUrl(groups, serviceDef, ra, dec, cutoutValue);
-                                serDefUrls.put(serviceDef, result);
-                            }
-
-                            if (result != null && result.isValid()) {
-                                if (result.missingParams.isEmpty()) {
-                                    serDefUrl = result.partialUrl;
-                                } else {
-                                    //Resolve missing params from currentRow (these are inputParams with no value but a "ref" instead)
-                                    StringBuilder finalUrl = new StringBuilder(result.partialUrl);
-                                    for (MissingParam missing : result.missingParams) {
-                                        String refId = missing.refId;
-                                        String key = "";
-                                        for (DataType data : dg.getDataDefinitions()) {
-                                            if (data.getID().equalsIgnoreCase(refId)) {
-                                                key = data.getKeyName();
-                                                break;
-                                            }
-                                        }
-                                        String resolvedValue = String.valueOf(dg.getData(key, i));
-                                        if (!StringUtils.isEmpty(resolvedValue)) {
-                                            finalUrl.append("&").append(missing.paramName).append("=").append(resolvedValue);
-                                        }
-                                    }
-                                    serDefUrl = finalUrl.toString();
-                                }
-                                productUrl = serDefUrl;
-                            }
-                            else continue; //couldn't create a valid service descriptor product url for this cutout
+                                productUrl = getCutoutSerDefUrl(serDefUrls, serviceDef, positionColVals, cutoutValue, groups, dg, i);//serDefUrl;
+                                if (isEmpty(productUrl)) continue;
+                                if (!isEmpty(file)) fileName = file.substring(file.lastIndexOf('/') + 1);
                         }
                         else continue;
                     }
 
                     String ext_file_name= null;
-                    if (useSourceUrlFileName) {
-                        String fileName= new URL(productUrl).getFile();
-                        String ext= FileUtil.getExtension(fileName);
-                        if (!ext.isEmpty()) ext_file_name= fileName;
-                    }
-                    if (ext_file_name==null){
+
+                    if (generateDownloadFileName) {
                         ext_file_name = prepend_file_name;
                         ext_file_name = testSem(sem, "#this") ? ext_file_name : ext_file_name + "-" + substringAfterLast(sem, "#");
                         String extension = "unknown";
                         extension = content_type != null ? getExtFromURL(content_type) : getExtFromURL(productUrl);
                         ext_file_name += "." + extension;
-                        //create a folder only if makeDataLinkFolder is true
-                        ext_file_name = makeDataLinkFolder ? prepend_file_name + "/" + ext_file_name : ext_file_name;
+                        ext_file_name = ("folder".equalsIgnoreCase(zipType) || (zipType == null && makeDataLinkFolder))
+                                ? prepend_file_name + "/" + ext_file_name
+                                : ext_file_name;
+                    } else {
+                        ext_file_name = ("folder".equalsIgnoreCase(zipType) || (zipType == null && makeDataLinkFolder))
+                                ? (prepend_file_name + "/" + (fileName != null ? fileName : ""))
+                                : fileName;
                     }
 
                     if (products != null) { // Check if products exist and contains sem
@@ -312,6 +224,100 @@ public class ObsCorePackager extends FileGroupsProcessor {
             e.printStackTrace();
         }
         return fileInfos;
+    }
+
+    public static String getCutoutSerDefUrl(Map<String, ServDescUrl> serDefUrls, String serviceDef, List<String> positionColVals, String cutoutValue, DataGroup[] groups, DataGroup dg, int idx) {
+        String serDefUrl = "";
+        ServDescUrl result;
+        String ra = positionColVals.get(0);
+        String dec = positionColVals.get(1);
+
+        if (serDefUrls.containsKey(serviceDef)) { //if we have already found this service descriptor url
+            result = serDefUrls.get(serviceDef);
+        } else { //else, parse this service descriptor to create a product url using access_url and the inputParams
+            if (ra == null || dec == null || cutoutValue == null) return null; //continue; //cannot create service descriptor url
+            result = createCutoutSerDefUrl(groups, serviceDef, ra, dec, cutoutValue);
+            serDefUrls.put(serviceDef, result);
+        }
+
+        if (result != null && result.isValid()) {
+            if (result.missingParams.isEmpty()) {
+                serDefUrl = result.partialUrl;
+            } else {
+                //Resolve missing params from currentRow (these are inputParams with no value but a "ref" instead)
+                StringBuilder finalUrl = new StringBuilder(result.partialUrl);
+                for (MissingParam missing : result.missingParams) {
+                    String refId = missing.refId;
+                    if (StringUtils.isEmpty(refId)) continue;
+                    String key = "";
+                    for (DataType data : dg.getDataDefinitions()) {
+                        String dataId = data.getID();
+                        if (dataId != null && data.getID().equalsIgnoreCase(refId)) {
+                            key = data.getKeyName();
+                            break;
+                        }
+                    }
+                    String resolvedValue = String.valueOf(dg.getData(key, idx));
+                    if (!StringUtils.isEmpty(resolvedValue)) {
+                        finalUrl.append("&").append(missing.paramName).append("=").append(resolvedValue);
+                    }
+                }
+                serDefUrl = finalUrl.toString();
+            }
+        }
+        return serDefUrl;
+    }
+
+
+    public static List<String> getPositionColVals(String pos, int idx, MappedData dgDataUrl) {
+        Position position = getPosition(pos);
+        String ra, dec;
+
+        ra = ifNotNull(position.centerColValues().ra())
+                .get(v -> v.equals("null") ? null : v);  // Ensure "null" is treated as null
+
+        dec = ifNotNull(position.centerColValues().dec())
+                .get(v -> v.equals("null") ? null : v);
+
+        if (ra == null || dec == null) { //if ra dec are null, use center columns to get the lon & lat values from the file
+            String lonCol = position.centerColNames.lonCol(); //for ra/lon
+            String latCol = position.centerColNames.latCol(); //for dec/lat
+            ra = Objects.toString(dgDataUrl.get(idx, lonCol), null);
+            dec = Objects.toString(dgDataUrl.get(idx, latCol), null);
+        }
+        return List.of(ra, dec);
+    }
+
+    public static String getAccessUrlFromNonObsCore(ServDescUrl serDescUrl, DataGroup dg, MappedData dgDataUrl, int idx) {
+        String access_url = null;
+        if (serDescUrl.isValid()) {
+            StringBuilder finalUrl = new StringBuilder(serDescUrl.partialUrl);
+
+            if (serDescUrl.missingParams.isEmpty()) {
+                access_url = serDescUrl.partialUrl;
+            }
+            else {
+                for (MissingParam missing : serDescUrl.missingParams) {
+                    String refId = missing.refId;
+                    String key = "";
+                    for (DataType data : dg.getDataDefinitions()) {
+                        if (data.getID().equalsIgnoreCase(refId)) {
+                            key = data.getKeyName();
+                            break;
+                        }
+                    }
+                    String resolvedValue = (String) dgDataUrl.get(idx, key);
+                    if (resolvedValue != null && !resolvedValue.isEmpty()) {
+                        if (serDescUrl.partialUrl.endsWith("?"))
+                            finalUrl.append(missing.paramName).append("=").append(resolvedValue);
+                        else
+                            finalUrl.append("&").append(missing.paramName).append("=").append(resolvedValue);
+                    }
+                }
+                access_url = finalUrl.toString(); //datalink url from service descriptor
+            }
+        }
+        return access_url;
     }
 
     private static boolean testSem(String sem, String val) {
@@ -340,19 +346,15 @@ public class ObsCorePackager extends FileGroupsProcessor {
         //remove spaces and replace all non-(alphanumeric,period,underscore,hyphen) chars with underscore
         return val.replaceAll("\\s", "").replaceAll("[^a-zA-Z0-9._-]", "_");
     }
-    public static String getFileName(int idx, String[] colNames, boolean useSourceUrlFileName, MappedData dgDataUrl, URL url) {
+    public static String getFileNamePrefix(int idx, String[] colNames, MappedData dgDataUrl, URL url, List<String> positionColVals) {
         String obs_collection = (String) dgDataUrl.get(idx, "obs_collection");
         String instrument_name = (String) dgDataUrl.get(idx, "instrument_name");
         String obs_id = (String) dgDataUrl.get(idx, "obs_id");
         String obs_title = (String) dgDataUrl.get(idx, "obs_title");
-        String file_name = "";
+        String ra = positionColVals.get(0);
+        String dec = positionColVals.get(1);
 
-        //option 0: if useSourceUrlFileName is true the try to get it from the URL
-        if (useSourceUrlFileName) {
-            String fileName= url.getFile();
-            String ext= FileUtil.getExtension(fileName);
-            if (!ext.isEmpty()) return fileName;
-        }
+        String file_name = "";
 
         //option 1: use productTitleTemplate (colNames) if available to construct file name
         if (colNames != null) {
@@ -377,7 +379,12 @@ public class ObsCorePackager extends FileGroupsProcessor {
                     (obs_id != null? makeValidString(obs_id) : "") ;
         }
 
-        if (file_name.length() == 0) file_name = "file"; //fallback option
+        if (file_name.length() == 0) {
+            if (!isEmpty(ra) && !isEmpty(dec)) {
+                file_name = ra + "_" + dec; //fallback
+            }
+            else file_name = "file_" + idx; //final fallback
+        }
         return file_name;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -109,8 +109,28 @@ public class URLDownload {
         String[] strs = disposition.split(";");
         if (strs.length != 2) return null;
         String[] fname = strs[1].split("=");
-        if (fname[0].toLowerCase().contains("filename")) return fname[1];
+        if (fname[0].toLowerCase().contains("filename")) {
+            return sanitizeFilename(fname[1]);
+        }
         return null;
+    }
+
+    public static String getFileNameFromUrl(URL url) {
+        if (url == null) return null;
+        String urlPath = url.getPath();
+        String suggestedFileName = urlPath.substring(urlPath.lastIndexOf('/') + 1);
+        return sanitizeFilename(suggestedFileName);
+    }
+
+    public static String sanitizeFilename(String fName) {
+        if (StringUtils.isEmpty(fName)) return "";
+        //trim leading/trailing whitespace and quotes
+        fName = fName.trim().replaceAll("^[\"']+|[\"']+$", "");
+        //replace unwanted characters
+        fName = fName.replaceAll("[^a-zA-Z0-9._-]", "_");
+        //remove leading/trailing underscores
+        fName = fName.replaceAll("^_+", "").replaceAll("_+$", "");
+        return fName;
     }
 
     private static int getResponseCode(URLConnection conn) {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -199,6 +199,7 @@ const defFireflyOptions = {
     },
     dataServiceOptions: {
         enableObsCoreDownload: true,
+        generateDownloadFileName: true //todo: remove this before merging this PR FIREFLY-1693
         // debug: true,
     },
     coverage : {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -199,7 +199,7 @@ const defFireflyOptions = {
     },
     dataServiceOptions: {
         enableObsCoreDownload: true,
-        generateDownloadFileName: true //todo: remove this before merging this PR FIREFLY-1693
+        generateDownloadFileName: false
         // debug: true,
     },
     coverage : {

--- a/src/firefly/js/metaConvert/vo/DatalinkFetch.js
+++ b/src/firefly/js/metaConvert/vo/DatalinkFetch.js
@@ -43,19 +43,24 @@ async function doMultRequestTableFetch(fetchKey, url, requestOptions) {
 }
 
 export async function fetchSemanticList(tableOrId,row=0) {
-    const table= getTableModel(tableOrId);
-    if (!table) return [];
-    let url;
-    if (isObsCoreLike(table) || isFormatDataLink(table,row)) {
-        url= getObsCoreAccessURL(table,row);
+    try {
+        const table = getTableModel(tableOrId);
+        if (!table) return [];
+        let url;
+        if (isObsCoreLike(table) || isFormatDataLink(table, row)) {
+            url = getObsCoreAccessURL(table, row);
+        } else {
+            const dlDescriptor = getServiceDescriptors(table)?.filter((dDesc) => isDataLinkServiceDesc(dDesc))[0];
+            url = dlDescriptor?.accessURL;
+            url = makeDlUrl(dlDescriptor, table, row);
+        }
+        if (!url) return [];
+        return await fetchDatalinkTableSemanticList(url);
     }
-    else {
-        const dlDescriptor= getServiceDescriptors(table)?.filter( (dDesc) => isDataLinkServiceDesc(dDesc))[0];
-        url= dlDescriptor?.accessURL;
-        url= makeDlUrl(dlDescriptor,table, row);
+    catch (err) {
+        console.error('fetchSemanticList call failed');
+        return [];
     }
-    if (!url) return [];
-    return await fetchDatalinkTableSemanticList(url);
 }
 
 export async function fetchDatalinkTableSemanticList(url, requestOptions={}) {

--- a/src/firefly/js/metaConvert/vo/DatalinkFetch.js
+++ b/src/firefly/js/metaConvert/vo/DatalinkFetch.js
@@ -47,18 +47,21 @@ export async function fetchSemanticList(tableOrId,row=0) {
         const table = getTableModel(tableOrId);
         if (!table) return [];
         let url;
-        if (isObsCoreLike(table) || isFormatDataLink(table, row)) {
+        if (isObsCoreLike(table) && isFormatDataLink(table, row)) {
             url = getObsCoreAccessURL(table, row);
-        } else {
-            const dlDescriptor = getServiceDescriptors(table)?.filter((dDesc) => isDataLinkServiceDesc(dDesc))[0];
-            url = dlDescriptor?.accessURL;
-            url = makeDlUrl(dlDescriptor, table, row);
+        }
+        if (!url) {
+            const serDefAry = getServiceDescriptors(table);
+            if (serDefAry) {
+                const dlDescriptor = serDefAry && serDefAry.filter((dDesc) => isDataLinkServiceDesc(dDesc))[0];
+                if (dlDescriptor?.accessURL) url = makeDlUrl(dlDescriptor, table, row);
+            }
         }
         if (!url) return [];
         return await fetchDatalinkTableSemanticList(url);
     }
     catch (err) {
-        console.error('fetchSemanticList call failed');
+        console.error('fetchSemanticList call failed',err);
         return [];
     }
 }

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -274,8 +274,8 @@ export function ZipStructure({fieldKey='zipType'}) {
         <ListBoxInputField
             fieldKey = {fieldKey}
             initialState = {{
-                tooltip: 'Zip File Structure',
-                label : 'Zip File Structure:'
+                tooltip: 'File Structure',
+                label : 'File Structure:'
             }}
             options = {[
                 {label: 'Structured (with folders)', value: 'folder'},


### PR DESCRIPTION
**Tickets**: [Firefly-1693](https://jira.ipac.caltech.edu/browse/FIREFLY-1693) and [Firefly-1692](https://jira.ipac.caltech.edu/browse/FIREFLY-1692)
IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/400
- Cleaning up the logic in ObsCorePackager to **_remove_** all custom file naming logic, as this will be handled by both the Download Script and the Zipped Packager, by first looking at Content-Disposition header, and then at the URL path as a fallback
   - this keeps our code generic, and lets the service set the name. 
   - @robyww suggested maybe keeping some of the file naming convention, @loitly is making a strong case for not doing that with which I agree. We can discuss this further if needed. For now, I am only setting file name (from the `file` column, if available) for cutouts. But we can move away from doing this as well.   
- merged the `PrepareDownload` from `EuclidUtils` into `ttFeatureWatchers` 
- apps have the option of choosing via props to `PrepareDownload` whether they want to display File Structure (flattened vs folder)
  - I have kept the default as `flattened`. Currently Euclid is the only one giving users this option. 
- When users select `folder`, I have used `"row_" + row_index` as the folder name. Open to other suggestions instead of this, but not sure if looking at any of the columns again for this makes sense, in the spirit of keeping it generic? 


**Testing**: 
   - **DCE**: https://firefly-1693-obscore-improvements.irsakudev.ipac.caltech.edu/irsaviewer/dce
   - **Euclid**: https://firefly-1693-obscore-improvements.irsakudev.ipac.caltech.edu/applications/euclid 
   - **Firefly**: https://fireflydev.ipac.caltech.edu/firefly-1693-obscore-improvements/firefly
   - **SPHEREx**: https://firefly-1693-obscore-improvements.irsakudev.ipac.caltech.edu/applications/spherex
   - **SUIT Portal**: (creating the test build shortly)
   - Do a search on all apps (CADC ivoa ObsCore for Firefly and in SPHEREx, search LVF images)
      - Select a few rows from the results and run `Prepare Download` for DCE, CADC and SUIT, and `Generate Download Script` for Euclid & SPHEREx 
      - For Euclid and SPHEREx, select both `flattened` and then `folder` as the File Structure. 
      
