### PR TITLE
Firefly-1702: Experimental LSDB panel is enabled behind url api option

### DIFF
--- a/src/firefly/html/firefly-dev.html
+++ b/src/firefly/html/firefly-dev.html
@@ -111,7 +111,7 @@
                     }
                 },
                 gatorProtocol: {
-                    title: 'LSDB Searches',
+                    title: 'My LSDB Searches',
                     searchOptionsMask: 'Cone,Elliptical,Box,Polygon',
                     services: [
                         {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -299,21 +299,27 @@ function fireflyInit(props, appSpecificOptions={}, webApiCommands) {
 }
 
 function setupGatorProtocolPanel(installedOptions, appProps) {
-    if (!installedOptions.gatorProtocol?.services?.length) return appProps;
-    if (!isArray(appProps.menu)) return appProps;
-    const title=installedOptions.gatorProtocol.title ?? 'Gator Proto';
+    const title=installedOptions?.gatorProtocol?.title ?? 'LSDB Searches';
+    const ddPanels= appProps.dropdownPanels ?? [];
     const gatorProtoMenuItem= {
         label: title,
-        action: 'GatorProtocol',
-        primary: installedOptions.gatorProtocol.primary ?? true,
+        action: 'GatorProtocolRootPanel',
+        primary: installedOptions?.gatorProtocol?.primary ?? true,
         category:ARCHIVE
     };
-
-    const ddPanels= appProps.dropdownPanels ?? [];
-    const gpPanel= <GatorProtocolRootPanel name='GatorProtocol' title={title}/>;
-    const menu= [...appProps.menu, gatorProtoMenuItem];
-    const dropdownPanels= [...ddPanels, gpPanel];
-    return {...appProps, menu, dropdownPanels};
+    if (window.location.search.substring(1).split('view=').pop().split('&')[0]==='GatorProtocolRootPanel') {
+        if (!isArray(appProps.menu)) return appProps;
+        const menu= [...appProps.menu, gatorProtoMenuItem];
+        return {...appProps, menu, dropdownPanels:ddPanels};
+    }
+    else {
+        if (!installedOptions.gatorProtocol?.services?.length) return appProps;
+        if (!isArray(appProps.menu)) return appProps;
+        const gpPanel= <GatorProtocolRootPanel name='GatorProtocol' title={title}/>;
+        const menu= [...appProps.menu, gatorProtoMenuItem];
+        const dropdownPanels= [...ddPanels, gpPanel];
+        return {...appProps, menu, dropdownPanels};
+    }
 }
 
 

--- a/src/firefly/js/api/WebApi.js
+++ b/src/firefly/js/api/WebApi.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {WSCH} from '../core/History';
 import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
 import {Logger} from '../util/Logger.js';
+import {isDefined} from '../util/WebUtil';
 import {makeWorldPt, parseWorldPt} from '../visualize/Point';
 
 
@@ -386,7 +387,7 @@ export function makeExample(desc,cmd=undefined, params=undefined) {
     const sp= params ? Object.entries(params)
         .reduce( (str,[k,v]) => {
             const ary= isArray(v) ? v : [v];
-            const result= ary.reduce( (pStr,e) => (pStr +`&${k}=${e}`),'');
+            const result= ary.reduce( (pStr,e) => (pStr + (isDefined(e) ? `&${k}=${e}` : `&${k}`)),'');
             return str+ result;
         } ,'') : '';
     const cmdStr= cmd ? `${API_STR}=${cmd}${sp}` : API_STR;

--- a/src/firefly/js/api/webApiCommands/LsdbCommands.js
+++ b/src/firefly/js/api/webApiCommands/LsdbCommands.js
@@ -1,0 +1,58 @@
+import {makeExamples} from 'firefly/api/WebApi';
+import {dispatchShowDropDown, dispatchUpdateMenu} from 'firefly/core/LayoutCntlr';
+import {isUndefined} from 'lodash';
+import {getMenu} from '../../core/AppDataCntlr';
+
+
+const lsdbOverview= {
+    overview: [
+        'Enable Experimental LSDB Search Panel'
+    ],
+    allowAdditionalParameters: false,
+    parameters: {
+        enable: 'if defined panel is enabled'
+    }
+};
+
+const lsdbExample= [
+    {
+        desc:'Enable the LSDB panel',
+        params:{ enable: undefined, }
+    },
+];
+
+function enablePanel(cmd,inParams) {
+
+    const params= {...inParams};
+    if (isUndefined(params.enable)) return;
+    setTimeout(() => {
+
+        const lsdbMenuItem= {
+            label: 'LSDB Searches',
+            action: 'GatorProtocolRootPanel',
+            primary: true,
+            category:'Archive Searches'
+        };
+
+        const {menuItems,selected,showBgMonitor}= getMenu();
+        if (!menuItems?.find(({action}) => action===lsdbMenuItem.action)) { // add the toolbar option
+            const newMenuItems= [...menuItems];
+            const dlDrop= lsdbMenuItem;
+            newMenuItems.splice(1,0,dlDrop);
+            dispatchUpdateMenu({selected,showBgMonitor,menuItems:newMenuItems});
+        }
+        dispatchShowDropDown({view:'GatorProtocolRootPanel'});
+    },10);
+}
+
+export function getLsdbCommands() {
+    return [
+        {
+            cmd: 'lsdb',
+            validate: () => ({valid:true}),
+            execute: enablePanel,
+            ...lsdbOverview,
+            examples: makeExamples('lsdb', lsdbExample),
+        },
+    ];
+}

--- a/src/firefly/js/api/webApiCommands/ViewerWebApiCommands.js
+++ b/src/firefly/js/api/webApiCommands/ViewerWebApiCommands.js
@@ -1,5 +1,6 @@
 import {isEmpty} from 'lodash';
 import {getImageCommands} from './ImageCommands';
+import {getLsdbCommands} from './LsdbCommands';
 import {getTableCommands} from './TableCommands';
 import {getTapCommands} from './TapCommands';
 
@@ -13,6 +14,7 @@ export function getFireflyViewerWebApiCommands(cmdNameList, tapPanelList=[]) {
         ...getImageCommands(),
         ...getTableCommands(),
         ...getTapCommands(tapPanelList),
+        ...getLsdbCommands()
     ];
 
     if (isEmpty(cmdNameList)) return allCommands;

--- a/src/firefly/js/ui/DropDownContainer.jsx
+++ b/src/firefly/js/ui/DropDownContainer.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import {Alert, Stack} from '@mui/joy';
 
 import {getDropDownInfo} from '../core/LayoutCntlr.js';
+import {GatorProtocolRootPanel} from '../visualize/ui/GatorProtocolRootPanel';
 import {SearchPanel} from './SearchPanel';
 import {HiPSSearchPanel} from '../visualize/ui/HiPSSearchPanel.jsx';
 import {IrsaCatalogSearchDefault} from '../visualize/ui/IrsaCatalogSearch.jsx';
@@ -47,6 +48,7 @@ export const dropDownMap = {
     WorkspaceDropDownCmd: {view: <WorkspaceDropdown />},
     DLGeneratedDropDownCmd: {view: <DLGeneratedDropDown name='DLGeneratedDropDownCmd' loadRegistry={false}/>, layout: {width: '100%'}},
     IrsaCatalog: {view: <IrsaCatalogSearchDefault/>, layout: {width: '100%'}},
+    GatorProtocolRootPanel: {view:<GatorProtocolRootPanel name='GatorProtocol' title={'LSDB'}/>, layout: {width: '100%'}},
     ClassicVOCatalogPanelCmd : {view: <ClassicVOCatalogPanel/>, layout: {width: '100%'}},
     ClassicNedSearchCmd : {view: <ClassicNedSearchPanel/>, layout: {width: '100%'}},
     // --- testing

--- a/src/firefly/js/visualize/ui/GatorProtocolRootPanel.jsx
+++ b/src/firefly/js/visualize/ui/GatorProtocolRootPanel.jsx
@@ -35,10 +35,13 @@ function GatorProtocolPanelImpl({initArgs, lockedServiceUrl, lockedServiceName, 
     const gpOps= getGatorProtoServiceOptions();
     const servicesShowing= true;
     const showWarning= !serviceUrl;
+    const [enterUrl,setEnterUrl]=  useFieldGroupValue('enterUrl');
 
     useEffect( () => {
         if (!serviceUrl) {
-            setServiceUrl(getInitServiceUrl(initArgs,gpOps, lockedServiceUrl,lockedServiceName));
+            const initUrl= getInitServiceUrl(initArgs,gpOps, lockedServiceUrl,lockedServiceName);
+            setServiceUrl(initUrl);
+            if (!initUrl) setEnterUrl(true);
         }
     },[]);
 
@@ -49,7 +52,7 @@ function GatorProtocolPanelImpl({initArgs, lockedServiceUrl, lockedServiceName, 
         setServiceUrl(serviceUrl);
     };
     const searchOptionsMask= serviceUrl ?
-        (getGatorProtoService(serviceUrl)?.searchOptionsMask ?? getAppOptions().gatorProtocol.searchOptionsMask) : undefined;
+        (getGatorProtoService(serviceUrl)?.searchOptionsMask ?? getAppOptions()?.gatorProtocol?.searchOptionsMask) : undefined;
     const showSqlSection= serviceUrl ? getGatorProtoService(serviceUrl)?.showSqlSection : true;
 
     return (
@@ -115,14 +118,14 @@ function Services({serviceUrl, servicesShowing, gpOps, onGatorProtoServiceOption
                     <Typography {...{level:'title-lg', color:'primary', sx:{width:'17rem', mr:1} }}>
                         Select Source
                     </Typography>
-                    <SwitchInputField {...{ size:'sm', endDecorator:'Enter my URL', fieldKey:'enterUrl',
+                    { Boolean(gpOps?.length) &&  <SwitchInputField {...{ size:'sm', endDecorator:'Enter my URL', fieldKey:'enterUrl',
                         initState:{value:false},
                         sx: {
                             alignSelf: 'flex-start',
                             '--Switch-trackWidth': '20px',
                             '--Switch-trackHeight': '12px',
                         },
-                    }} />
+                    }} /> }
                 </Stack>
                 <Stack>
                     {enterUrl ? (
@@ -142,7 +145,7 @@ function Services({serviceUrl, servicesShowing, gpOps, onGatorProtoServiceOption
                         <ListBoxInputFieldView {...{
                             sx:{'& .MuiSelect-root':{width:'46.5rem'}},
                             options:gpOps, value:serviceUrl,
-                            placeholder:'Choose SIAv2 Service...',
+                            placeholder:'Choose LSDB Service...',
                             startDecorator:!gpOps.length ? <Button loading={true}/> : undefined,
                             onChange:(ev, value) => {
                                 onGatorProtoServiceOptionSelect({value});
@@ -200,6 +203,6 @@ function getInitServiceUrl(initArgs,gpOps, lockedServiceUrl,lockedServiceName) {
         const url= gpOps.find( ({labelOnly}) => labelOnly===lockedServiceName)?.value;
         if (url) return url;
     }
-    const {serviceUrl=gpOps[0].value} = gpOps;
+    const {serviceUrl=gpOps?.[0]?.value} = gpOps;
     return serviceUrl;
 }

--- a/src/firefly/js/visualize/ui/GatorProtocolUtil.jsx
+++ b/src/firefly/js/visualize/ui/GatorProtocolUtil.jsx
@@ -53,7 +53,7 @@ export function addGatorProtoUserService(serviceUrl) {
         value: serviceUrl,
         userAdded: true,
         showSqlSection:false,
-        searchOptionsMask: getAppOptions().gatorProtocol.searchOptionsMask
+        searchOptionsMask: getAppOptions()?.gatorProtocol?.searchOptionsMask
     });
     dispatchAddPreference(USER_SERVICE_PREFS, userServices);
 }


### PR DESCRIPTION
#### [Firefly-1702](https://jira.ipac.caltech.edu/browse/FIREFLY-1664): Experimental LSDB panel is enabled behind url api option


#### Testing

- enter url: https://fireflydev.ipac.caltech.edu/firefly-1702-lsdb/firefly/?api
     - You should see the lsdb option towards the bottom.
- enter url: https://fireflydev.ipac.caltech.edu/firefly-1702-lsdb/firefly/?api=lsdb&enable
     - the lsdb panel should be enabled
     - on the lsdb panel enter the url: https://troyraen.irsakudev.ipac.caltech.edu
     - It should populate
     - a search should work as well
- enter url: https://fireflydev.ipac.caltech.edu/firefly-1702-lsdb/firefly/
      - panel should not be there
