### PR TITLE
FIREFLY-1704: Download Script Enhancement

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/EmailNotification.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/EmailNotification.java
@@ -138,7 +138,7 @@ public class EmailNotification implements JobCompletedHandler {
 
     public static File makeScript(JobInfo jobInfo, ScriptAttributes type) {
         List<DownloadScript.UrlInfo> urlInfos = ifNotNull(jobInfo.getResults())
-                .get(list -> list.stream().map(r -> new DownloadScript.UrlInfo(r.href(), null)).toList());
+                .get(list -> list.stream().map(r -> new DownloadScript.UrlInfo(r.href(), null, null)).toList());
         String id = jobInfo.getJobId();
         String fname = type == Curl ? "curl_script_%s.sh" : type   == Wget ? "wget_script_%s.sh" : "urls_%s.txt";
         fname = fname.formatted(id.substring(id.length()-4));      // safe; id is always greater than 4 chars

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/DownloadRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/DownloadRequest.java
@@ -74,7 +74,7 @@ public class DownloadRequest extends ServerRequest implements Serializable {
 
     public String getDataSource() { return getParam(DATA_SOURCE); }
 
-    public String getTitle() { return getParam(TITLE); }
+    public String getTitle() { return getParam(BASE_FILE_NAME); }
 
     public String getEmail() { return getParam(EMAIL); }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/FileInfo.java
@@ -15,11 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static edu.caltech.ipac.firefly.data.HttpResultInfo.CONTENT_TYPE;
-import static edu.caltech.ipac.firefly.data.HttpResultInfo.EXTERNAL_NAME;
-import static edu.caltech.ipac.firefly.data.HttpResultInfo.RESPONSE_CODE;
-import static edu.caltech.ipac.firefly.data.HttpResultInfo.RESPONSE_CODE_MSG;
-import static edu.caltech.ipac.firefly.data.HttpResultInfo.SIZE_IN_BYTES;
+import static edu.caltech.ipac.firefly.data.HttpResultInfo.*;
 
 
 public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
@@ -90,6 +86,7 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
     }
 
 
+
     public static FileInfo blankFilePlaceholder() {
         FileInfo fi= new FileInfo();
         fi.putAttribute(BLANK,true+"");
@@ -143,12 +140,22 @@ public class FileInfo implements HasAccessInfo, Serializable, CacheKey {
 
     public String getExternalName() { return getAttribute(EXTERNAL_NAME); }
 
+    public String getSuffix() { return getAttribute(SUFFIX); }
+
     public String getContentType() { return getAttribute(CONTENT_TYPE); }
 
     public void setInternalName(String filename) {
         if (filename!=null) putAttribute(INTERNAL_NAME,filename);
     }
     public void setExternalName(String filename) { putAttribute(EXTERNAL_NAME,filename); }
+
+    public void setSuffix(String filename) {
+        if (StringUtils.isEmpty(filename)) {
+            attributes.remove(SUFFIX);
+        } else {
+            putAttribute(SUFFIX,filename);
+        }
+    }
 
     public long getSizeInBytes() { return StringUtils.getInt(getAttribute(SIZE_IN_BYTES),0); }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/data/HttpResultInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/HttpResultInfo.java
@@ -21,6 +21,7 @@ public class HttpResultInfo {
     public static final String CONTENT_TYPE= "contentType";
     public static final String SIZE_IN_BYTES= "sizeInBytes";
     public static final String EXTERNAL_NAME= "externalName";
+    public static final String SUFFIX= "suffix";
 
     private final byte[] result;
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/ZipHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/ZipHandler.java
@@ -4,6 +4,7 @@
 package edu.caltech.ipac.firefly.server.packagedata;
 
 import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.util.StringUtils;
 import edu.caltech.ipac.util.download.URLDownload;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
@@ -180,10 +181,16 @@ public class ZipHandler {
                 uc.setRequestProperty("Accept", "text/plain");
 
                 String extName = ofNullable(fi.getExternalName()).orElse("").trim();
+                String suffix = fi.getSuffix();
                 if (extName.isEmpty() || extName.endsWith("/")) {
                     String suggestedFilename = URLDownload.getSugestedFileName(uc);
                     suggestedFilename = isEmpty(suggestedFilename) ? getFileNameFromUrl(url) : suggestedFilename;
-                    fi.setExternalName(extName + suggestedFilename);
+                    extName = extName + suggestedFilename;
+                    fi.setExternalName(extName);
+                }
+
+                if (!StringUtils.isEmpty(suffix)) {
+                    fi.setExternalName(FileUtil.appendSuffixBeforeExtension(extName, suffix));
                 }
 
                 is = uc.getInputStream();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
@@ -178,6 +178,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
                     String productUrl = accessUrl;
 
                     String fileName = null;
+                    String suffix = null;
 
                     if (accessUrl == null || sem == null) {
                         //if only semantic (sem) is null, accessUrl may still be available, but we won't know which accessUrls ones to pick
@@ -187,6 +188,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
                                 productUrl = getCutoutSerDefUrl(serDefUrls, serviceDef, positionColVals, cutoutValue, groups, dg, i);//serDefUrl;
                                 if (isEmpty(productUrl)) continue;
                                 if (!isEmpty(file)) fileName = file.substring(file.lastIndexOf('/') + 1);
+                                suffix = "cutout";
                         }
                         else continue;
                     }
@@ -211,10 +213,12 @@ public class ObsCorePackager extends FileGroupsProcessor {
                     if (products != null) { // Check if products exist and contains sem
                         if (Arrays.asList(products).contains(sem) || Arrays.asList(products).contains("*")) { //* refers to all data products
                             FileInfo fileInfo = new FileInfo(productUrl, ext_file_name, 0);
+                            fileInfo.setSuffix(suffix);
                             fileInfos.add(fileInfo);
                         }
                     } else { //add all valid productUrls (accessUrls or cutout service descriptor urls)
                         FileInfo fileInfo = new FileInfo(productUrl, ext_file_name, 0);
+                        fileInfo.setSuffix(suffix);
                         fileInfos.add(fileInfo);
                     }
                 }

--- a/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
@@ -851,6 +851,20 @@ public class FileUtil
         return retHost;
     }
 
+    public static String appendSuffixBeforeExtension(String fName, String suffix) {
+        if (fName == null || suffix == null) return fName;
+
+        int lastDotIndex = fName.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return fName + suffix; //no extension found, just append suffix
+        }
+
+        String name = FileUtil.getBase(fName);
+        String extension = FileUtil.getExtension(fName);
+
+        return name + "-" + suffix + "." + extension;
+    }
+
     //============================================================================
     //                       File Directory Utilities
     //============================================================================

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -133,6 +133,7 @@ public class URLDownload {
         return fName;
     }
 
+
     private static int getResponseCode(URLConnection conn) {
         if (conn==null) return -1;
         try {

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -188,7 +188,6 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
                             tbl_id,
                             showZipStructure: showFileStructure, //default to false (flattened)
                             downloadType,
-                            saveAsProps: {label: 'File name:'},
                             dlParams: {
                                 FileGroupProcessor:'ObsCorePackager',
                                 worker: downloadType === 'script' ? 'DownloadScriptWorker' : 'PackagingWorker',
@@ -199,9 +198,8 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
                                 datalinkServiceDescriptor: isDatalinkSerDesc,
                                 viewerId,
                                 DataSource: dataSource,
-                                TitlePrefix: tblTitle,
                                 help_id:'table.obsCorePackage',
-                                BaseFileName: fileName ?? `${baseFileName}`
+                                BaseFileName: fileName ? fileName+ `_${baseFileName}` : `${baseFileName}`
                             }}}>
                             <Stack spacing={1}>
                                 <CheckboxGroupInputField

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -140,7 +140,6 @@ export function defaultDownloadPanel(mission='', cutoutSize, addtlParams={}) {
                 title={'Image Download Options'}
                 dlParams={{
                     MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
-                    TitlePrefix: mission,
                     BaseFileName: `${mission}_Files`,
                     DataSource: `${mission} images`,
                     FileGroupProcessor: 'LightCurveFileGroupsProcessor',

--- a/src/firefly/js/templates/router/RouteHelper.jsx
+++ b/src/firefly/js/templates/router/RouteHelper.jsx
@@ -6,7 +6,12 @@ import {isFunction} from 'lodash';
 import {
     dispatchOnAppReady, dispatchSetMenu, FORM_CANCEL, FORM_SUBMIT, getMenu
 } from '../../core/AppDataCntlr.js';
-import {dispatchHideDropDown, dispatchSetLayoutInfo, getDropDownInfo} from '../../core/LayoutCntlr.js';
+import {
+    dispatchHideDropDown,
+    dispatchSetLayoutInfo,
+    dispatchShowDropDown,
+    getDropDownInfo
+} from '../../core/LayoutCntlr.js';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../../core/MasterSaga.js';
 import {FireflyRoot} from '../../ui/FireflyRoot.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
@@ -114,7 +119,6 @@ export function useDropdownRoute() {
             const menuItem = getMenuItem(pathname);
             if (menuItem) {     // the requested pathname is in the menu
                 dispatchSetLayoutInfo({dropDown:{view: menuItem.action, menuItem, visible: true}});
-                dispatchSetMenu({selected: menuItem.action});
             } else if (visible) {
                 dispatchHideDropDown();     // it's not a menu path, hide dropdown
             }

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -27,7 +27,6 @@ import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
 import {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
 import {Stack, Typography, Box} from '@mui/joy';
 import {ToolbarButton} from 'firefly/ui/ToolbarButton';
-import {RadioGroupInputField} from 'firefly/ui/RadioGroupInputField';
 
 const DOWNLOAD_DIALOG_ID = 'Download Options';
 const OptionsContext = React.createContext();
@@ -132,7 +131,7 @@ const newBgKey = () => 'DownloadOptionPanel-' + Date.now();
 export function DownloadOptionPanel ({groupKey='DownloadDialog', cutoutSize, help_id, children, style, title, dlParams,
                                          updateSearchRequest, updateDownloadRequest, validateOnSubmit,
                                          cancelText='Cancel', showZipStructure=true, showEmailNotify=false,
-                                         showFileLocation=true, showTitle=true, downloadType='package', saveAsProps={}, ...props}) {
+                                         showFileLocation=true, showTitle=true, downloadType='package', ...props}) {
     const {tbl_id:p_tbl_id, checkSelectedRow} = React.useContext(OptionsContext);
     const tbl_id = props.tbl_id || p_tbl_id;
 
@@ -190,13 +189,7 @@ export function DownloadOptionPanel ({groupKey='DownloadDialog', cutoutSize, hel
     const maskPanel = (<BgMaskPanel key={bgKey} componentKey={bgKey}
                                    onMaskComplete={() =>hideDownloadDialog()}/>);
 
-    saveAsProps = {
-        initialState: {
-            value: get(dlParams, 'BaseFileName')
-        },
-        ...saveAsProps
-    };
-    const dlTitle = get(dlParams, 'TitlePrefix', 'Download') + '-' + dlTitleIdx;
+    const dlTitle = get(dlParams, 'BaseFileName', 'Download' + '-' + dlTitleIdx); //use BaseFileName as title as well
     const preTitleMessage = dlParams?.PreTitleMessage ?? '';
     return (
         <Stack sx ={{m:1/2, position: 'relative', minWidth:400, height:'auto', ...style}}>
@@ -213,14 +206,14 @@ export function DownloadOptionPanel ({groupKey='DownloadDialog', cutoutSize, hel
                             {preTitleMessage}
                         </Typography>
                     )}
-                    <Stack spacing={1}>
+                    <Stack spacing={2}>
                         {showTitle && <TitleField {...{value:dlTitle}}/>}
 
                         {children}
 
                         {cutoutSize         && <DownloadCutout />}
                         {showZipStructure   && <ZipStructure />}
-                        {showFileLocation   && <WsSaveOptions {...{groupKey, labelWidth:110, saveAsProps}}/>}
+                        {showFileLocation   && <WsSaveOptions {...{groupKey, labelWidth:110}}/>}
                         {showEmailNotify    && <EmailNotification {...{groupKey}}/>}
                     </Stack>
                 </FieldGroup>
@@ -262,7 +255,7 @@ export function TitleField({style={}, value, label='Title:', size=30}) {
     return (
         <ValidationField
             forceReinit={true}
-            fieldKey='Title'
+            fieldKey='BaseFileName' //title on the UI will also be used as file name on the backend
             tooltip='Enter a description to identify this download.'
             {...{validator:NotBlank, initialState:{value}, label, size, style}}
         />
@@ -298,20 +291,6 @@ export function DownloadCutout({fieldKey='dlCutouts'}) {
                 {label: 'Specified Cutouts', value: 'cut'},
                 {label: 'Original Images', value: 'orig'}
             ]}
-        />
-    );
-}
-
-export function ScriptTypeOptions({fieldKey='scriptType', ...props}) {
-    return (
-        <RadioGroupInputField
-            fieldKey={fieldKey}
-            orientation={'horizontal'}
-            initialState={{value: 'curl'}}
-            options={[{label: 'Curl', value: 'curl'}, {label: 'Wget', value: 'wget'}, {label: 'Plain Text (URLs)', value: 'urls'}]}
-            label='Download Script:'
-            tooltip='Choose the download script type'
-            {...props}
         />
     );
 }

--- a/src/firefly/js/ui/WorkspaceSelectPane.jsx
+++ b/src/firefly/js/ui/WorkspaceSelectPane.jsx
@@ -38,9 +38,8 @@ export const WORKSPACE = 'isWs';
  */
 export function WsSaveOptions (props) {
     const {groupKey, style, labelWidth} = props;
-    let {fileLocProps={}, saveAsProps={}} = props;
+    let {fileLocProps={}} = props;
 
-    saveAsProps = {label:'Save as:', labelWidth, wrapperStyle:{margin: '3px 0'}, size:30, ...saveAsProps};
     fileLocProps = {label:'File Location:', labelWidth, ...fileLocProps};
 
     const loc      = useStoreConnector(() => getFieldVal(groupKey, 'fileLocation'));
@@ -54,7 +53,6 @@ export function WsSaveOptions (props) {
 
     return (
         <Stack style={style} spacing={1}>
-            <ValidationField fieldKey='BaseFileName' forceReinit={true} {...saveAsProps}/>
             { useWs &&
                 <RadioGroupInputField
                     fieldKey='fileLocation'
@@ -77,7 +75,6 @@ WsSaveOptions.propTypes = {
     style:          PropTypes.string,
     labelWidth:     PropTypes.number,
     fileLocProps:   PropTypes.object,       // properties to send into the File Location radio button..  see render function for defaults
-    saveAsProps:    PropTypes.object        // properties to send into the Save As input box..  see render function for defaults
 };
 
 


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1704
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/403

- Changes to download dialog (merging `Title` and `File Name` fields into one in the UI, and using this value as `BaseFileName` on the backend)
- Added getter/setter for suffix in `FileInfo` (currently used only for cutouts as `-cutout` at the end of a filename before the extension, but could be anything)
- Modified Download Script to handle duplicate file names (especially for curl, as wget does it internally) by roughly using the logic/algorithm described in the ticket

**Testing**: 
-  **CADC** on **Firefly**: https://fireflydev.ipac.caltech.edu/firefly-1704-download-script/firefly
- **Euclid**: https://firefly-1704-download-script.irsakudev.ipac.caltech.edu/applications/euclid
- **CADC**:  This is to test our original packager, ensure it works as expected. If there is a cutout, you should see `-cutout` at the end of the file name.  
   - since the packager downloads files, duplicate file names will be handled by the OS, I didn't add any explicit logic to check for that here. 
- **Euclid**: This is super important to test, as it'll test the download script changes. Do any image/object search. Select 1 or more rows and download. 
  - download all 3 (URLs, curl and wget). 
  - Run the curl script at the very least. You don't need to run it all the way, just ensure that folders are created and you see some files downloaded. You may even choose to only download cutouts - notice that a 4th argument of "cutout" (as the suffix) will be passed to the `download_file` function in the script. 
    - the downloaded cutout files should also have a `-cutout` suffix at the end of the file name. 
- On **Euclid (& Spherex)**, when you're on any tab other than the `Results`,  refresh the page. Previously, this would lead to all tabs except for `Results` and `Job Monitor` getting removed. This is now fixed. 