### PR TITLE
FIREFLY-1715: Failed to recognize single column CSV file

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -354,9 +355,16 @@ public class JobManager {
     }
 
     static List<JobInfo> getAllJobs() {
-        return allJobInfos.getKeys().stream()
-                .map(allJobInfos::get)
-                .filter(Objects::nonNull).toList();
+        List<? extends CacheKey> keys = allJobInfos.getKeys();
+        if (keys == null || keys.isEmpty()) return Collections.emptyList();
+        ArrayList<JobInfo> rval = new ArrayList<JobInfo>(keys.size());
+        for (CacheKey key : keys) {
+            JobInfo jobInfo = ifNotNull(() -> allJobInfos.get(key)).get();  // ignore error
+            if (jobInfo != null) {
+                rval.add(jobInfo);
+            }
+        }
+        return rval;
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.INCL_COLUMNS;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.parseSqlFilter;
 import static edu.caltech.ipac.firefly.server.db.DbMonitor.getDbInstances;
@@ -293,7 +294,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
             LOGGER.warn("execQuery failed with error: " + e.getMessage(),
                     "sql: " + sql,
                     "refTable: " + refTable,
-                    "dbFile: " + getDbFile().getAbsolutePath());
+                    "dbFile: " + ifNotNull(getDbFile()).get(File::getAbsolutePath));
             throw handleSqlExp("Query failed", e);
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -5,7 +5,6 @@ package edu.caltech.ipac.firefly.server.servlets;
 
 import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.background.JobManager;
-import edu.caltech.ipac.firefly.messaging.Messenger;
 import edu.caltech.ipac.firefly.server.Counters;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
@@ -39,6 +38,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.server.ServerContext.ACCESS_TEST_EXT;
+import static edu.caltech.ipac.firefly.core.Util.Try;
 
 
 /**
@@ -77,33 +77,34 @@ public class ServerStatus extends BaseHttpServlet {
             writer.println("<li><a href=./status?execGC=true>Trigger GC</a>:     Invoke JVM garbage collection");
             skip(writer);
 
-            showCountStatus(writer);
+            Try.it(() -> showCountStatus(writer)).getOrElse(e -> writer.println("Failed to load Count Status: " + e.getMessage()));
             skip(writer);
 
-            showPackagingStatus(writer, showJobDetails);
+            Try.it(() -> showPackagingStatus(writer, showJobDetails)).getOrElse(e -> writer.println("Failed to Packaging Status: " + e.getMessage()));
             skip(writer);
 
-            showMessagingStatus(writer);
+            Try.it(() -> showMessagingStatus(writer)).getOrElse(e -> writer.println("Failed to load Messaging Status: " + e.getMessage()));
             skip(writer);
 
-            showEventsStatus(writer);
+            Try.it(() -> showEventsStatus(writer)).getOrElse(e -> writer.println("Failed to load Event Status: " + e.getMessage()));
             skip(writer);
 
-            showDatabaseStatus(writer);
+            Try.it(() -> showDatabaseStatus(writer)).getOrElse(e -> writer.println("Failed to load Database Status: " + e.getMessage()));
             skip(writer);
 
-            showWorkAreaStatus(writer);
+            Try.it(() -> showWorkAreaStatus(writer)).getOrElse(e -> writer.println("Failed to load Work Area Status: " + e.getMessage()));
             skip(writer);
 
             EhcacheProvider prov = (EhcacheProvider) edu.caltech.ipac.util.cache.CacheManager.getCacheProvider();
 
-            displayCacheInfo(writer, prov.getEhcacheManager(), sInfo);
+            Try.it(() -> displayCacheInfo(writer, prov.getEhcacheManager(), sInfo)).getOrElse(e -> writer.println("Failed to load Cache Info: " + e.getMessage()));
 
             if (showDebug) {
                 skip(writer);
-                showHeaders(writer, req);
+                Try.it(() -> showHeaders(writer, req)).getOrElse(e -> writer.println("Failed to load Request Headers: " + e.getMessage()));
+
                 skip(writer);
-                showSystemProperties(writer);
+                Try.it(() -> showSystemProperties(writer)).getOrElse(e -> writer.println("Failed to load System Properties: " + e.getMessage()));
             }
 
             writer.println("</pre>");

--- a/src/firefly/java/edu/caltech/ipac/util/FormatUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FormatUtil.java
@@ -108,20 +108,16 @@ public class FormatUtil {
         }
 
         // all failed; fallback to trial and error
-        if ( mime.startsWith("text/") ) {     // including "text/xml"
+        if ( mime.startsWith("text/") && !FileUtil.getExtension(inFile).equalsIgnoreCase("html")) {     // including "text/xml"
             // if text file, we'll test it against ipactable, region, csv, and tsv
             if (isIpacTable(inFile)) {
                 format = IPACTABLE;
             } else if (isRegionFile(inFile)) {
                 format = REGION;
             } else {
-                DataGroup csv = DuckDbReadable.getInfoOrNull(CSV, inFile.getAbsolutePath());
-                DataGroup tsv = DuckDbReadable.getInfoOrNull(TSV, inFile.getAbsolutePath());
-                int csvCols = csv == null ? 0 : csv.getDataDefinitions().length - 1;
-                int tsvCols = tsv == null ? 0 : tsv.getDataDefinitions().length - 1;
-                if (csvCols + tsvCols > 0) {
-                    format =  tsvCols > csvCols ? TSV : CSV;
-                }
+                // check for csv or tsv
+                Format dformat = DuckDbReadable.Csv.detect(inFile.getAbsolutePath());
+                if (dformat != null) format = dformat;
             }
         }
 
@@ -162,7 +158,7 @@ public class FormatUtil {
             case "application/gzip", "application/x-gzip" -> GZIP;
             case "application/java-archive" -> JAR;
             case "application/x-tar", "application/tar" -> TAR;
-            case "application/html" -> HTML;            // some text file with HTML comments will appear as test/xml.  to avoid false positive, we will not accept text/html.
+            case "application/html" -> HTML;            // some text file with HTML comments will appear as text/html.  to avoid false positive, we will not accept text/html.
             case "application/json", "text/json" -> JSON;
             default -> null;
         };


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1715
- Add better error handling to the status page to ensure it continues rendering even if an error occurs.
- Added unit tests to show what it can detect.

**Note:** Unfortunately, this might produce false positives, since single-column CSV files are easy to match.
We should talk about this to narrow down the number of false positives.


Test:  https://fireflydev.ipac.caltech.edu/firefly-1715-single-col-table/firefly
Try uploading various file types to confirm the issue is resolved and everything still works as expected.

