### PR TITLE
Firefly-1676: improve the titling and position for the 'Show table with all data products' option

### DIFF
--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -203,6 +203,11 @@ export const MetaConst = {
     DATA_SERVICE_ID: 'DATA_SERVICE_ID',
 
     /**
+     * object that can override config
+     */
+    DATA_SERVICE_OPTIONS: 'dataServiceOptions',
+
+    /**
      * If we are doing cutout, this is the default type, either: ROW_POSITION or SEARCH_POSITION
      */
     OBSCORE_CUTOUT_TYPE: 'OBSCORE_CUTOUT_TYPE',

--- a/src/firefly/js/drawingLayers/CatalogUI.jsx
+++ b/src/firefly/js/drawingLayers/CatalogUI.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {Box, Button, Chip, IconButton, Stack, Switch, Typography} from '@mui/joy';
+import {Chip, IconButton, Stack, Switch, Typography} from '@mui/joy';
 import React, {useEffect, useState} from 'react';
 import {object,number} from 'prop-types';
 import Enum from 'enum';
@@ -18,10 +18,9 @@ import {ListBoxInputFieldView} from '../ui/ListBoxInputField';
 import {INFO_POPUP, showInfoPopup} from '../ui/PopupUtil.jsx';
 import {RadioGroupInputFieldView} from '../ui/RadioGroupInputFieldView.jsx';
 import {useStoreConnector} from '../ui/SimpleComponent';
-import BrowserInfo from '../util/BrowserInfo';
 import {DataTypes} from '../visualize/draw/DrawLayer.js';
 import {dispatchChangeVisibility, dispatchModifyCustomField, GroupingScope} from '../visualize/DrawLayerCntlr.js';
-import {dispatchBottomUIComponent, dispatchViewerScroll} from '../visualize/MultiViewCntlr';
+import {dispatchBottomUIComponent} from '../visualize/MultiViewCntlr';
 import {isDrawLayerVisible} from '../visualize/PlotViewUtil.js';
 import {InfoButton} from '../visualize/ui/Buttons.jsx';
 

--- a/src/firefly/js/ui/CutoutSizeDialog.jsx
+++ b/src/firefly/js/ui/CutoutSizeDialog.jsx
@@ -11,6 +11,7 @@ import {dispatchChangePointSelection, visRoot} from '../visualize/ImagePlotCntlr
 import {PlotAttribute} from '../visualize/PlotAttribute';
 import {primePlot} from '../visualize/PlotViewUtil';
 import {parseWorldPt} from '../visualize/Point';
+import {makeFoVString} from '../visualize/ZoomUtil';
 import {getSearchTargetFromTable, isRowTargetCapable} from '../voAnalyzer/TableAnalysis';
 import {FieldGroupCollapsible} from './panel/CollapsiblePanel';
 import {RadioGroupInputField} from './RadioGroupInputField';
@@ -141,9 +142,14 @@ function CutoutSizePanel({showingCutout,cutoutDefSizeDeg,pixelBasedCutout,dataPr
                 value:SEARCH_POSITION,
             });
     }
+    const cutoutInfoStr= showingCutout
+            ? `Current cutout size: ${makeFoVString(Number(cutoutValue))}`
+            : 'Now displaying full image. Cutouts are turned off.';
+
     return (
         <Stack justifyContent='space-between' alignItems='center' spacing={1} minWidth='25rem' ml={1}>
             <Stack spacing={4} minWidth={'40rem'}>
+                <Typography level='title-md'>{cutoutInfoStr}</Typography>
                 { pixelBasedCutout ?
                     <ValidationField {...{
                         nullAllowed: false,

--- a/src/firefly/js/ui/DefaultSearchActions.js
+++ b/src/firefly/js/ui/DefaultSearchActions.js
@@ -4,13 +4,16 @@ import {flux} from '../core/ReduxFlux.js';
 import {ServerParams} from '../data/ServerParams.js';
 import {sprintf} from '../externalSource/sprintf.js';
 import {
-    getActiveTableId, getMetaEntry, getTableUiByTblId, getTblById, makeFileRequest, onTableLoaded
+    getActiveTableId, getAllColumns, getMetaEntry, getTableUiByTblId, getTblById, getTblRowAsObj, makeFileRequest,
+    onTableLoaded
 } from '../api/ApiUtilTable.jsx';
 import {extractDatalinkTable} from '../metaConvert/TableDataProductUtils';
 import {makeVOCatalogRequest} from '../tables/TableRequestUtil.js';
 import {dispatchTableSearch, dispatchTableUpdate} from '../tables/TablesCntlr.js';
+import {tokenSub} from '../util/WebUtil';
 import { findTableCenterColumns, isFormatDataLink, isObsCoreLike } from '../voAnalyzer/TableAnalysis.js';
 import {DEFAULT_FITS_VIEWER_ID} from '../visualize/MultiViewCntlr.js';
+import {getTableModel} from '../voAnalyzer/VoCoreUtils';
 import {getServiceDescriptors, isDataLinkServiceDesc} from '../voAnalyzer/VoDataLinkServDef';
 import {setMultiSearchPanelTab} from './MultiSearchPanel.jsx';
 import {Format} from 'firefly/data/FileAnalysis';
@@ -105,6 +108,24 @@ export const makeDefImageSearchActions = () => {
 
 export const makeDefTableSearchActions= () => {
     return [
+        makeSearchActionObj({cmd:'showDatalinkTable',
+            groupId:'resolver',
+            label:'all data productions',
+            tip:'',
+            searchType: SearchTypes.point_table_only,
+            execute: () => showDatalinkTable(),
+            supported: (table) => canShowDatalinkTable(table),
+            searchDesc: ({tbl_id}) => {
+                const table= getTableModel(tbl_id);
+                const defStr= getDataServiceOptionByTable( 'datalinkExtractTableDesc', table,
+                    'Show table with all data products for this row (Datalink)');
+
+                const colObj= getTblRowAsObj(table, table.highlightedRow);
+                // const cNames= getAllColumns(getTableModel(tbl_id)).map( (c) => c.name);
+                const retStr= tokenSub(colObj,defStr);
+                return retStr;
+            }
+        } ),
         makeSearchActionObj({cmd:'tableNed',
             groupId:'resolver',
             label:'NED',
@@ -157,18 +178,6 @@ export const makeDefTableSearchActions= () => {
             execute: (sa,table) => searchWholeTable(table),
             searchDesc: 'Use table as an upload to TAP search'
         }),
-        makeSearchActionObj({cmd:'showDatalinkTable',
-            groupId:'resolver',
-            label:'all data productions',
-            tip:'',
-            searchType: SearchTypes.point_table_only,
-            execute: () => showDatalinkTable(),
-            supported: (table) => canShowDatalinkTable(table),
-            searchDesc: ({tbl_id}) => {
-                return getDataServiceOptionByTable( 'datalinkExtractTableDesc', tbl_id,
-                    'Show table with all data products for this row (Datalink)');
-            }
-        } ),
     ];
 };
 

--- a/src/firefly/js/ui/tap/DataServicesOptions.js
+++ b/src/firefly/js/ui/tap/DataServicesOptions.js
@@ -1,7 +1,8 @@
 import {isObject} from 'lodash';
 import {getAppOptions} from '../../core/AppDataCntlr';
 import {MetaConst} from '../../data/MetaConst';
-import {getMetaEntry} from '../../tables/TableUtil';
+import {getMetaEntry, getObjectMetaEntry} from '../../tables/TableUtil';
+import {getServiceMetaOptions} from './SiaUtil';
 
 const dsOps= () => getAppOptions().dataServiceOptions ?? {};
 
@@ -31,6 +32,8 @@ export function getDataServiceOption(key, dataServiceId = undefined, defVal=unde
  * @return {*}
  */
 export function getDataServiceOptionByTable(key, tableOrId, defVal=undefined) {
+    const entry= getObjectMetaEntry(tableOrId, MetaConst.DATA_SERVICE_OPTIONS)?.[key];
+    if (entry) return entry;
     return getDataServiceOption(key, getMetaEntry(tableOrId,MetaConst.DATA_SERVICE_ID), defVal);
 }
 


### PR DESCRIPTION
#### [Firefly-1676](https://jira.ipac.caltech.edu/browse/FIREFLY-1676): improve the titling and position for the 'Show table with all data products' option

- [Firefly-1722](https://jira.ipac.caltech.edu/browse/FIREFLY-1722): cutout feedback message in dialog 

#### ife PR: https://github.com/IPAC-SW/irsa-ife/pull/405

#### Testing
- https://firefly-1676-dl-seach-action.irsakudev.ipac.caltech.edu/applications/euclid
- do a search the from the table click on the ![Screenshot 2025-04-25 at 1 15 51 PM](https://github.com/user-attachments/assets/bb905ccd-8e24-40a9-87a8-9bdae58c2b0b)
- The option will be at the top
   - for images is should say `'Show table of all Euclid products for Tile ID: <id>`
   - for objects it should say `'Show table of all Euclid products for ID: <id>`


