### PR TITLE
FIREFLY-1686: Invalid SQL statement generated when expressions are used in charts requiring decimation.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
@@ -87,10 +87,18 @@ public class DecimationProcessor extends TableFunctionProcessor {
         } else {
             String sql = """
                 CREATE TABLE %s as (
-                SELECT FIRST(%s) as "%s", FIRST(%s) as "%s", FIRST(ROW_NUM) as "rowidx", count(*) as "weight", %s as "dkey", ROW_NUMBER() OVER () AS %s, ROW_NUMBER() OVER () AS %s,
-                FROM %s WHERE "%s" IS NOT NULL AND "%s" IS NOT NULL
-                GROUP BY "dkey" )
-                """.formatted(tblName, deciInfo.getxExp(), deciKey.getXCol(), deciInfo.getyExp(), deciKey.getYCol(), deciFunc, ROW_NUM, ROW_IDX, dataTbl, deciKey.getXCol(), deciKey.getYCol());
+                SELECT *, ROW_NUMBER() OVER () AS %s, ROW_NUMBER() OVER () AS %s
+                FROM (
+                    SELECT
+                       FIRST(%s) as "%s",
+                       FIRST(%s) as "%s",
+                       FIRST(ROW_NUM) as "rowidx",
+                       count(*) as "weight",
+                       %s as "dkey"
+                    FROM %s GROUP BY "dkey"
+                ) WHERE "%s" IS NOT NULL AND "%s" IS NOT NULL
+                )
+                """.formatted(tblName, ROW_NUM, ROW_IDX, deciInfo.getxExp(), deciKey.getXCol(), deciInfo.getyExp(), deciKey.getYCol(), deciFunc, dataTbl, deciKey.getXCol(), deciKey.getYCol());
             dbAdapter.execUpdate(sql);
 
             // add decimation info to the returned table


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1686

A regression bug has been identified where Firefly generates an invalid SQL statement when expressions are used in charts that require decimation. This bug was introduced in ticket [FIREFLY-1649](https://jira.ipac.caltech.edu/browse/FIREFLY-1649).

Test: https://fireflydev.ipac.caltech.edu/firefly-1686-invalid-sql-chart/firefly/
Steps to reproduce in Firefly:

Load a table with more than 10,000 rows.
Open the heatmap setting, change X and Y axes to use an expression, such as `log(x)` and `log(y)`
Click Apply

@lrebull At your convenience, please verify that the fix is working.