### PR TITLE
Firefly-1725: improve center on selected table row so the data products images are never scrolled off screen

### DIFF
--- a/src/firefly/js/drawingLayers/hpx/HpxCatalog.js
+++ b/src/firefly/js/drawingLayers/hpx/HpxCatalog.js
@@ -194,7 +194,6 @@ function makeHighlightDeferred(drawLayer,plotId,screenPt,worldPt) {
                     const table= getTblById(tbl_id);
                     if (drawLayer.tbl_id===plot.attributes[PlotAttribute.RELATED_TABLE_ID] &&
                         isDefined(plot.attributes[PlotAttribute.RELATED_TABLE_ROW])) {
-                        console.log('found');
                         const viewerId= findViewerWithItemId(getMultiViewRoot(),plotId,IMAGE);
                         if (!viewerId || data[closestIdx].fromRow===table.highlightedRow) {
                             viewerId && dispatchBottomUIComponent({viewerId});

--- a/src/firefly/js/metaConvert/ImageDataProductsUtil.js
+++ b/src/firefly/js/metaConvert/ImageDataProductsUtil.js
@@ -14,7 +14,7 @@ import ImagePlotCntlr, {
 import {
     DEFAULT_FITS_VIEWER_ID, dispatchReplaceViewerItems, getLayoutType, getMultiViewRoot, getViewerItemIds, GRID, IMAGE
 } from '../visualize/MultiViewCntlr.js';
-import {PlotAttribute} from '../visualize/PlotAttribute.js';
+import {PlotAttribute as PlotAttribues, PlotAttribute} from '../visualize/PlotAttribute.js';
 import {getPlotGroupById} from '../visualize/PlotGroup.js';
 import {
     getActivePlotView, getPlotViewAry, getPlotViewById, isDefaultCoverageActive, isImageExpanded, primePlot
@@ -114,7 +114,7 @@ export function createSingleImageExtraction(request, sourceObsCoreData, dlData) 
     if (!request) return undefined;
     const wpRequest= isArray(request) ? request.map( (r) => copyRequest(r)) : copyRequest(request);
     const plotIds= isArray(request) ? request.map( (r) => r.getPlotId()) : copyRequest(request);
-    const attributes= {};
+    const attributes= {[PlotAttribues.USER_PINNED_IMAGE]:true};
     if (sourceObsCoreData) attributes.sourceObsCoreData= sourceObsCoreData;
     if (dlData) attributes.dlData= dlData;
     return () => {

--- a/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
@@ -1,6 +1,6 @@
 import {isEmpty, isUndefined} from 'lodash';
 import {getCellValue, getColumns, hasRowAccess} from '../../tables/TableUtil.js';
-import {getDataServiceOption} from '../../ui/tap/DataServicesOptions';
+import {getDataServiceOption, getDataServiceOptionByTable} from '../../ui/tap/DataServicesOptions';
 import {tokenSub} from '../../util/WebUtil.js';
 import {
     getObsCoreAccessURL, getObsReleaseDate, getObsTitle, getProdTypeGuess, getSearchTarget, isFormatDataLink,
@@ -230,9 +230,9 @@ export function getObsCoreRowMetaInfo(table,row) {
 
 function createObsCoreTitle(table,row) {
  // 1. try a template
-    const template= getDataServiceOption('productTitleTemplate');
+    const template= getDataServiceOptionByTable('productTitleTemplate',table);
     if (template?.trim()==='') return ''; // setting template to empty string disables all title guessing
-    if (!template) {
+    if (template) {
         const templateColNames= template && getColNameFromTemplate(template);
         const columns= getColumns(table);
         if (templateColNames?.length && columns?.length) {

--- a/src/firefly/js/visualize/PlotAttribute.js
+++ b/src/firefly/js/visualize/PlotAttribute.js
@@ -157,5 +157,7 @@ export const PlotAttribute= {
     USER_SEARCH_RADIUS_DEG: 'USER_SEARCH_RADIUS_DEG',
 
     /** an object warnings: {key: string, warning:string} */
-    USER_WARNINGS: 'USER_WARNINGS'
+    USER_WARNINGS: 'USER_WARNINGS',
+
+    USER_PINNED_IMAGE: 'USER_PINNED_IMAGE',
 };

--- a/src/firefly/js/visualize/ui/ImageCenterDropDown.jsx
+++ b/src/firefly/js/visualize/ui/ImageCenterDropDown.jsx
@@ -101,7 +101,7 @@ export function ImageCenterDropDown({visRoot:vr, visible, mi}) {
     const dropDown= (
         <SingleColumnMenu>
 
-            <ToolbarButton text='Pan by table row' tip='Center selected images position of the highlighted row'
+            <ToolbarButton text='Pan by table row' tip='Center coverage or pinned images position of the highlighted row'
                            enabled={coordTables}
                            horizontal={false} key={'pan-table'}
                            hasCheckBox={true} checkBoxOn={vr.autoScrollToHighlightedTableRow}


### PR DESCRIPTION
#### [Firefly-1725](https://jira.ipac.caltech.edu/browse/FIREFLY-1725): improve center on selected table row so the data products images are never scrolled off screen

#### Testing
- https://firefly-1725-recenter.irsakudev.ipac.caltech.edu/applications/euclid
- https://firefly-1725-recenter.irsakudev.ipac.caltech.edu/applications/spherex
- do a cutout grid with either application, cutout should not longer scroll off the screen