### PR TITLE
Firelfly-1730: MultiProductViewer: more aggressively call Service Descriptors

### DIFF
--- a/src/firefly/js/metaConvert/AnalysisUtils.js
+++ b/src/firefly/js/metaConvert/AnalysisUtils.js
@@ -37,12 +37,13 @@ export function makeAnalysisGetSingleDataProduct(makeReq) {
 }
 
 
-export async function uploadAndAnalyze({request, table, row, activateParams, dataTypeHint = '', options, serviceDescMenuList}) {
+export async function uploadAndAnalyze({request, table, row, activateParams, dataTypeHint = '', options, serviceDescMenuList, originalTitle}) {
     const ct= getObsCoreAccessFormat(table,row);
     const obsTitle= getObsTitle(table,row);
     if (!hasRowAccess(table, row)) dpdtSimpleMsg('You do not have access to this data.');
     if (isNonServerAnalysisType(request?.getURL(), ct)) return doFileNameAndTypeAnalysis({url:request?.getURL(),ct, obsTitle});
-    const analysisPromise = doUploadAndAnalysis({table, row, request, activateParams, dataTypeHint, options, serviceDescMenuList});
+    const analysisPromise = doUploadAndAnalysis({table, row, request, activateParams, dataTypeHint,
+        options, originalTitle, serviceDescMenuList});
     return dpdtWorkingPromise(LOADING_MSG, analysisPromise, request);
 }
 

--- a/src/firefly/js/metaConvert/DataProductsFactory.js
+++ b/src/firefly/js/metaConvert/DataProductsFactory.js
@@ -303,7 +303,7 @@ function initConverterTemplates() {
 export const getDefaultFactoryOptions= once(() => ({
     dataProductsComponentKey: DEFAULT_DATA_PRODUCTS_COMPONENT_KEY,
     limitViewerDisplay: NO_LIMIT,
-    activateServiceDef: false,
+    activateServiceDef: undefined,
     threeColor: undefined,
     maxPlots: undefined,
     canGrid: undefined, // some specific factories might have parameters that override this parameter

--- a/src/firefly/js/metaConvert/DataProductsType.js
+++ b/src/firefly/js/metaConvert/DataProductsType.js
@@ -226,6 +226,7 @@ export function dpdtChartTable(name, activate, extraction, menuKey='chart-table-
  *
  * @param {object} p
  * @param {String} p.name
+ * @param {String} p.dropDownText
  * @param {function} p.activate
  * @param {String} p.url
  * @param {ServiceDescriptorDef} p.serDef
@@ -246,6 +247,7 @@ export function dpdtChartTable(name, activate, extraction, menuKey='chart-table-
  */
 export function dpdtAnalyze({
                              name,
+                             dropDownText,
                              activate,
                              url,
                              serDef= undefined,
@@ -263,7 +265,7 @@ export function dpdtAnalyze({
                              cutoutToFullWarning,
                              dlData}) {
     return { displayType:DPtypes.ANALYZE,
-        name, url, activate, serDef, menuKey, semantics,
+        name, dropDownText, url, activate, serDef, menuKey, semantics,
         size, activeMenuLookupKey, request, sRegion, prodTypeHint,
         cutoutToFullWarning, serviceDefRef, allowsInput, standardID, ID, dlData
     };

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -25,12 +25,14 @@ import {createSingleImageActivate, createSingleImageExtraction} from './ImageDat
  * @param {String} p.serverCacheFileKey
  * @param {ActivateParams} p.activateParams
  * @param {DataProductsFactoryOptions} p.options
+ * @param {String} title
  * @return {{tableResult: DataProductsDisplayType|Array.<DataProductsDisplayType>|undefined, imageResult: DataProductsDisplayType|undefined}}
  */
 export function analyzePart({part, request, table, row, fileFormat, dataTypeHint, dlData,
-                                serverCacheFileKey, activateParams, options}) {
+                                serverCacheFileKey, activateParams, options={}, title}) {
 
     const {type,desc, fileLocationIndex}= part;
+    const titleToUse= title ?? desc;
     const aTypes= findAvailableTypesForAnalysisPart(part, fileFormat);
     if (isEmpty(aTypes)) return {imageResult:false, tableResult:false};
 
@@ -41,7 +43,7 @@ export function analyzePart({part, request, table, row, fileFormat, dataTypeHint
             title:desc,activateParams,hduIdx:fileLocationIndex});
 
     const tableResult= aTypes.includes(DPtypes.TABLE) &&
-        analyzeChartTableResult(false, table, row, part, fileFormat, fileOnServer,desc,dataTypeHint,activateParams,fileLocationIndex, options);
+        analyzeChartTableResult(false, table, row, part, fileFormat, fileOnServer,titleToUse??desc,dataTypeHint,activateParams,fileLocationIndex, options);
 
     return {imageResult, tableResult};
 }
@@ -206,7 +208,7 @@ function getTableDropTitleStr(title,part,fileFormat,tableOnly) {
  * @param {DataProductsFactoryOptions} options
  * @return {DataProductsDisplayType|undefined}
  */
-function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOnServer, title, dataTypeHint='', activateParams, tbl_index=0, options) {
+function analyzeChartTableResult(tableOnly, table, row, part, fileFormat, fileOnServer, title, dataTypeHint='', activateParams, tbl_index=0, options={}) {
     const {uiEntry,uiRender,chartParamsAry, interpretedData=false, defaultPart:requestDefault= false}= part;
     const partFormat= part.convertedFileFormat||fileFormat;
     if (uiEntry===UIEntry.UseSpecified) {

--- a/src/firefly/js/metaConvert/UploadAndAnalysis.js
+++ b/src/firefly/js/metaConvert/UploadAndAnalysis.js
@@ -54,7 +54,8 @@ const parseAnalysis= (serverCacheFileKey, analysisResult) =>
  * @return {Promise.<DataProductsDisplayType>}
  */
 export async function doUploadAndAnalysis({ table, row, request, activateParams={}, dataTypeHint='', options, menuKey,
-                                 menu, serDef, dlData, userInputParams, analysisActivateFunc, originalTitle,serviceDescMenuList}) {
+                                              menu, serDef, dlData, userInputParams, analysisActivateFunc,
+                                              originalTitle,serviceDescMenuList}) {
 
     const {dpId}= activateParams;
 
@@ -245,10 +246,11 @@ function deeperInspection({ table, row, request, activateParams,
     const rStr= request.toString();
     const activeItemLookupKey= hashCode(rStr);
     const fileMenu= {fileAnalysis, menu:[],activeItemLookupKey, activeItemLookupKeyOrigin:rStr};
+    const title= parts.length===1 ? originalTitle : undefined;
 
     const partAnalysis= parts.map( (part) =>
         analyzePart({part,request, table, row, fileFormat, dataTypeHint,
-            dlData, serverCacheFileKey,activateParams, options}));
+            dlData, serverCacheFileKey,activateParams, options, title}));
     const imageParts= partAnalysis.filter( (pa) => pa.imageResult);
     let makeAllImageOption= !disableAllImageOption;
     if (makeAllImageOption) makeAllImageOption= imageParts.length>1 || (imageParts.length===1 && parts.length===1);

--- a/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
@@ -194,7 +194,7 @@ async function getObsCoreSingleDataProduct({table, row, activateParams, serviceD
         const positionWP= getSearchTarget(table.request,table) ?? makeWorldPtUsingCenterColumns(table,row);
         const request= makeObsCoreRequest(dataSource, positionWP, titleStr,table,row);
         const primDPType= doFileAnalysis ?
-            await uploadAndAnalyze({request,table,row,activateParams,serviceDescMenuList}) :
+            await uploadAndAnalyze({request,table,row,activateParams,serviceDescMenuList,originalTitle:request.getTitle()}) :
             createGuessDataType(titleStr,'guess-0',dataSource,prodType,undefined,activateParams, positionWP,table,row,size);
         return makeSingleDataProductWithMenu(activateParams.dpId, primDPType,size, serviceDescMenuList);
     }

--- a/src/firefly/js/metaConvert/vo/ServDescConverter.js
+++ b/src/firefly/js/metaConvert/vo/ServDescConverter.js
@@ -82,7 +82,9 @@ export async function getServiceDescSingleDataProduct(table, row, activateParams
             additionalServiceDescMenuList:!isEmpty(menu)?menu:undefined});
     }
     else {
-        return dpdtFromMenu(menu,index,activeMenuLookupKey,true);
+        // there will be no menu if the there is only one service descriptor, and it is not datalink
+        // no menu is a common case.
+        return menu.length===1 ? menu[0] : dpdtFromMenu(menu,index,activeMenuLookupKey,true);
     }
 }
 

--- a/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
+++ b/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {Stack, Typography} from '@mui/joy';
+import {Card, Stack, Typography} from '@mui/joy';
 import {func, object, string} from 'prop-types';
 import React, {memo, useContext, useEffect, useState} from 'react';
 import {getAppOptions} from '../../core/AppDataCntlr.js';
@@ -49,12 +49,17 @@ export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDef, setSe
     const fieldDefAry= sdToFieldDefAry({
         serviceDef:serDef, sRegion, hipsUrl:getAppOptions()?.coverage?.hipsSourceURL, fovSize });
 
+    const hasSpacial= hasAnySpacial(fieldDefAry);
+    const formSx= hasSpacial ? {} : { ml: 1/2, mr: 2, mt: 2 };
+
     return (
-        <Stack {...{direction:'row', key:serviceDefRef, width:1, height:1}}>
-            <Stack {...{direction:'column', p:.25, width:1}}>
+        <Stack {...{direction:'row', key:serviceDefRef, width:1, height:hasSpacial ? 1 : undefined}}>
+            <Stack {...{component:hasSpacial?undefined:Card,
+                direction:'column', p:hasSpacial?.25: undefined, width:1, ...formSx,
+                variant: hasSpacial ? undefined : 'outlined', }}>
                 <Stack {...{direction:'row', alignItems:'center'}}>
                     {makeDropDown?.()}
-                    <Typography level= {title?.length>30 ? 'body-xs' : 'body-sm'}>{title}</Typography>
+                    <Typography level= {title?.length>80 ? 'title-sm' : 'title-lg'}>{title}</Typography>
                 </Stack>
 
                 <FieldGroup groupKey={GROUP_KEY} keepState={false} style={{display:'flex', flexGrow:1}}>
@@ -108,6 +113,8 @@ function SDPanelContent({fieldDefAry, plotId, serDef={}, setSearchParams, dataSe
         setSearchParams(convertedR);
     };
 
+    const hasSpacial= hasAnySpacial(fieldDefAry);
+
     return (
         <ConstraintContext.Provider value={constraintCtx}>
             <DynLayoutPanelTypes.Inset fieldDefAry={fieldDefAry} style={{width: '100%'}}
@@ -122,7 +129,7 @@ function SDPanelContent({fieldDefAry, plotId, serDef={}, setSearchParams, dataSe
                 <Stack direction='column' alignItems='flex-start' p={.25}>
                     <Stack {...{direction:'row', justifyContent:'space-between', alignItems:'flex-start',
                         pt:.5, pr:.5, width:'100%', alignSelf:'flex-start' }}>
-                        {hasAnySpacial(fieldDefAry) &&
+                        {hasSpacial &&
                             <Typography level='body-xs'>Enter search position or click on background HiPS</Typography>}
                     </Stack>
                 </Stack>

--- a/src/firefly/js/visualize/ui/Buttons.jsx
+++ b/src/firefly/js/visualize/ui/Buttons.jsx
@@ -64,6 +64,8 @@ import FitIcon from '@mui/icons-material/ZoomInMapOutlined';
 import FillIcon from '@mui/icons-material/OpenInFullOutlined';
 import OneXIcon from '@mui/icons-material/TimesOneMobiledataOutlined';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
+import ChangeCircleIcon from '@mui/icons-material/ChangeCircle';
+
 
 import FiberManualRecordRoundedIcon from '@mui/icons-material/FiberManualRecordRounded';
 
@@ -252,6 +254,7 @@ export const CropButton= (props) => ( <TB {...{ icon: <CropRoundedIcon/>, ...pro
 export const StatsButton= (props) => ( <TB {...{ icon: <FunctionsOutlinedIcon/>, ...props}}/>);
 export const ExpandAll= (props) => ( <TB {...{icon: <UnfoldMoreOutlinedIcon/>, ...props}}/>);
 export const CollapseAll= (props) => ( <TB {...{icon: <UnfoldLessOutlinedIcon/>, ...props}}/>);
+export const ChangeSearch= (props) => ( <TB {...{icon: <ChangeCircleIcon/>, ...props}}/>);
 
 export const FiltersOffButton= (props) => ( <TB {...{ icon: <ClearFilterIco/>, ...props}}/>);
 

--- a/src/firefly/js/visualize/ui/multiProduct/DPDropdown.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/DPDropdown.jsx
@@ -9,7 +9,7 @@ import {DPtypes} from '../../../metaConvert/DataProductsType.js';
 import {SingleColumnMenu} from '../../../ui/DropDownMenu.jsx';
 import {DropDownToolbarButton} from '../../../ui/DropDownToolbarButton.jsx';
 import {ToolbarButton, ToolbarHorizontalSeparator} from '../../../ui/ToolbarButton.jsx';
-import {PinButton} from '../Buttons.jsx';
+import {ChangeSearch, PinButton} from '../Buttons.jsx';
 
 /**
  *
@@ -63,15 +63,16 @@ function DropDown({dataProductsState, menuKey, originalTitle, hasMenu, menu, dpI
                 }
             {showRedoSearchButton && analysisActivateFunc &&
                 <Stack direction='row'>
-                    <ToolbarButton
-                        text='Redo Search' tip='Redo Search'
-                        onClick={() => {
+                    <ChangeSearch {...{
+                        tip:`Enter new search parameters: ${originalTitle}`,
+                        onClick:() => {
                             dispatchSetSearchParams({dpId, activeMenuLookupKey, menuKey, params: undefined});
                             dispatchUpdateDataProducts(dpId, {
                                 ...dataProductsState, allowsInput: true, name: originalTitle,
                                 displayType: DPtypes.ANALYZE, activate: analysisActivateFunc
                             });
-                        }}/>
+                        },
+                    }} />
                 </Stack>
             }
         </Stack>

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
@@ -7,6 +7,7 @@ import {getMetaEntry, getTableGroup, getTblById, onTableLoaded} from '../../../t
 import {TablesContainer} from '../../../tables/ui/TablesContainer.jsx';
 import {RadioGroupInputFieldView} from '../../../ui/RadioGroupInputFieldView.jsx';
 import {useStoreConnector} from '../../../ui/SimpleComponent';
+import {ToolbarHorizontalSeparator} from '../../../ui/ToolbarButton';
 import {dispatchChangePrimePlot, visRoot} from '../../ImagePlotCntlr';
 import {NewPlotMode} from '../../MultiViewCntlr.js';
 import { convertHDUIdxToImageIdx, getActivePlotView, getHDUIndex, hasImageCubes} from '../../PlotViewUtil';
@@ -66,7 +67,7 @@ export function MultiProductChoice({ dataProductsState, dpId,
 
 
     const toolbar = (
-        <Stack {...{direction:'row', alignItems:'center', height:30}}>
+        <Stack {...{direction:'row', alignItems:'center', height:30, divider:<ToolbarHorizontalSeparator/>}}>
             {makeDropDown && <Box sx={{height: 30}}> {makeDropDown()} </Box>}
             {mayToggle && <RadioGroupInputFieldView {...{options, value: whatToShow, buttonGroup: true, onChange}} />}
         </Stack>);


### PR DESCRIPTION
#### [Firelfly-1730](https://jira.ipac.caltech.edu/browse/FIREFLY-1730): MultiProductViewer: more aggressively call Service Descriptors

- Make the MultiProductViewer more aggressively call service descriptors if
  - is it a non-obscore / catalog table
  - call the first one by default
- Clean up the service descriptor panel
- Clean up the service descriptor  toolbar

#### Testing
- Firefly: https://fireflydev.ipac.caltech.edu/firefly-1730-sd-calling/firefly
   - goto tap
   - choose project `ztf` with the first (default) table
   -  results should include a table in the Data Products area
- Rubin portal: https://tag-rc-2025-3.irsakudev.ipac.caltech.edu/suit
   - search DP0.2 or DP0.3 catalogs
   - results should include a table in the Data Products area
   - click ![Screenshot 2025-04-29 at 5 09 31 PM](https://github.com/user-attachments/assets/6d0232b0-b4ab-49c9-8d4b-593c0c3e2d3c) to redo the search, change the band
