### PR TITLE
FIREFLY-1731: Download Dialog UI Improvement

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/PtfFileGroupsProcessor.java
@@ -58,9 +58,9 @@ public class PtfFileGroupsProcessor extends FileGroupsProcessor {
         String dlCutouts = request.getParam("dlCutouts");
         boolean doCutout = dlCutouts != null && dlCutouts.equalsIgnoreCase("cut");
 
-        // values = folder or flat
-        String zipType = request.getParam("zipType");
-        boolean doFolders = zipType != null && zipType.equalsIgnoreCase("folder");
+        // values = true for flattened, false for folder/structured
+        boolean isFlattenedStructure = request.getBooleanParam("isFlattenedStructure");
+        boolean doFolders = !isFlattenedStructure;
 
         List<String> types = new ArrayList<String>();
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/WiseLightCurveFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/WiseLightCurveFileGroupsProcessor.java
@@ -79,12 +79,9 @@ public class WiseLightCurveFileGroupsProcessor extends FileGroupsProcessor {
             cutFlag = true;
         }
 
-        // values = folder or flat
-        String zipType = request.getParam("zipType");
-        boolean zipFolders = true;
-        if (zipType != null && zipType.equalsIgnoreCase("flat")) {
-            zipFolders = false;
-        }
+        // values = true for flattened, false for folder/structured
+        boolean isFlattenedStructure = request.getBooleanParam("isFlattenedStructure");
+        boolean zipFolders = !isFlattenedStructure; //is isFlattenedStructure is null, getBooleanParam will return false and the default will always be true for zipFolders
 
         // build file types list
         ArrayList<WiseFileRetrieve.IMG_TYPE> types = new ArrayList<WiseFileRetrieve.IMG_TYPE>();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/ZtfLCFileGroupsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/lc/ZtfLCFileGroupsProcessor.java
@@ -64,9 +64,9 @@ public class ZtfLCFileGroupsProcessor extends FileGroupsProcessor {
         String dlCutouts = request.getParam("dlCutouts");
         boolean doCutout = dlCutouts != null && dlCutouts.equalsIgnoreCase("cut");
 
-        // values = folder or flat
-        String zipType = request.getParam("zipType");
-        boolean doFolders = zipType != null && zipType.equalsIgnoreCase("folder");
+        // values = true for flattened, false for folder/structured
+        boolean isFlattenedStructure = request.getBooleanParam("isFlattenedStructure");
+        boolean doFolders = !isFlattenedStructure;
 
         MappedData dgData = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(), selectedRows);
 

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -186,7 +186,6 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
                             updateSearchRequest,
                             groupKey: tbl_id,
                             tbl_id,
-                            showZipStructure: showFileStructure, //default to false (flattened)
                             downloadType,
                             dlParams: {
                                 FileGroupProcessor:'ObsCorePackager',

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -27,6 +27,7 @@ import {CheckboxGroupInputField} from './CheckboxGroupInputField.jsx';
 import {getFieldVal} from '../fieldGroup/FieldGroupUtils.js';
 import {Stack, Typography, Box} from '@mui/joy';
 import {ToolbarButton} from 'firefly/ui/ToolbarButton';
+import {SwitchInputField} from 'firefly/ui/SwitchInputField';
 
 const DOWNLOAD_DIALOG_ID = 'Download Options';
 const OptionsContext = React.createContext();
@@ -212,7 +213,7 @@ export function DownloadOptionPanel ({groupKey='DownloadDialog', cutoutSize, hel
                         {children}
 
                         {cutoutSize         && <DownloadCutout />}
-                        {showZipStructure   && <ZipStructure />}
+                        {showZipStructure && <FileStructure/>}
                         {showFileLocation   && <WsSaveOptions {...{groupKey, labelWidth:110}}/>}
                         {showEmailNotify    && <EmailNotification {...{groupKey}}/>}
                     </Stack>
@@ -233,7 +234,6 @@ DownloadOptionPanel.propTypes = {
     style:      PropTypes.object,
 
     showTitle:        PropTypes.bool,           // layout Title field.  This is the title of the package request.  It will be displayed in Job History.
-    showZipStructure: PropTypes.bool,           // layout ZipStructure field
     showEmailNotify:  PropTypes.bool,           // layout EmailNotification field
     showFileLocation: PropTypes.bool,           // layout FileLocation field
     updateSearchRequest: PropTypes.func,   // customized parameters to be added or updated in request
@@ -262,21 +262,10 @@ export function TitleField({style={}, value, label='Title:', size=30}) {
     );
 }
 
-export function ZipStructure({fieldKey='zipType'}) {
-    return (
-        <ListBoxInputField
-            fieldKey = {fieldKey}
-            initialState = {{
-                tooltip: 'File Structure',
-                label : 'File Structure:'
-            }}
-            options = {[
-                {label: 'Structured (with folders)', value: 'folder'},
-                {label: 'Flattened (no folders)', value: 'flat'}
-            ]}
-        />
-
-    );
+export function FileStructure({fieldKey='isFlattenedStructure'}) {
+    return (<SwitchInputField fieldKey={fieldKey}
+                              label={'Flattened File Structure'}
+                              initialState={{value: false}}/>);
 }
 
 export function DownloadCutout({fieldKey='dlCutouts'}) {


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1731
**IFE PR**:  https://github.com/IPAC-SW/irsa-ife/pull/407 

- The download dialog now only has one checkbox option: `Flattened File Structure`, 
  - When selected, we flatten downloaded files , else we default to 'structured' (`folder`) 
  - for IFE apps not using ObsCorePackager, their downloads should look the same as before when flattened is selected and when it's turned off (defaulting to structured)
  - the logical changes in this PR only affect Obs Core files, for these:
    -  flattened will flatten the files, even if you have multiple rows selected
    - for 'structured' (folder), which is the default, we only create folders when there's more than one entry in the datalink, if there's only 1 entry per row, we still flatten files 
- I made some changes in `SwitchInputField` to be able to pass non-boolean values (like `folder` and `flat` in this case). It should still work as expected in other places it's used. 
  - @jaladh-singhal you may want to take a look at this. 
- There was an issue with folder names when **_we_** assign them in `ObsCorePacakger`. 
  - to test this, select 2 or more rows to download in SPHEREx. Earlier (you can test on nightly) you would see in the downloaded script that even though each row has more than 1 product, we still use the same folder name (because it comes from `obs_title`) 
    - so when we assign folder names ourselves in `ObsCorePackager`, we need to check for duplicate folder names there and assign `-1`, -`2`, and so on at the end of the folder name if it already exists. 
    - This is now fixed. 


**Testing**: 
- On firefly (TAP panel), test the `SwitchInputField` toggle (`Enter my URL` right under `Select TAP Service`) to ensure it works as expected. 
- For IFE apps like WISE, SHA, etc. ensure that downloads work as before (you can compare the downloads on ops or nightly) 
- Test the **_logic_** changes with CADC, DCE, Euclid & SPHEREx 
  - For packagers (like with CADC and DCE), if you select flattened checkbox you shouldn't see any folders, otherwise you should see folders created, if there's more than one file per row. This is usually the case for CADC. 
    - For DCE, you may see the same results when flattened is turned on or off, this is because lots of tables have only one fits file per row, so this is expected behavior. 
  - For the download script (euclid, spherex), when flattened is selected you'll see no folder name being passed as an argument (2nd argument) to the `download_file` function, otherwise you should see a folder name here. 
-  CADC on firefly: https://fireflydev.ipac.caltech.edu/firefly-1731-download-dialog/firefly
- Euclid: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/applications/euclid
- SPHEREx: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/applications/spherex
- DCE: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/irsaviewer/dce
- Wise: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/applications/wise
- SHA: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA
- ZTF: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/applications/ztf
- Sofia: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/applications/sofia
- Finderchart: https://firefly-1731-download-dialog.irsakudev.ipac.caltech.edu/applications/finderchart