### PR TITLE
FIREFLY-1727: Handle Redis failure

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server;
 
+import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.data.Alert;
 import edu.caltech.ipac.firefly.data.ServerEvent;
@@ -20,6 +21,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import redis.clients.jedis.Jedis;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,6 +56,9 @@ public class AppServerCommands {
             action.setValue(email, "email");
             action.setValue(bgInfo.notifEnabled(), "notifEnabled");
             ServerEventManager.fireAction(action, ServerEvent.Scope.SELF);
+
+            // check for redis connection
+            if (RedisService.getFailSince() != null)  RedisService.updateConnectionStatus(true);
 
             return "true";
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -146,7 +146,7 @@ public class ServerContext {
         configDirname = configDirname == null ? null : configDirname + "/" + contextName;
 
         if (StringUtils.isEmpty(contextName)) {
-            String errmsg = " is not setup correctly.  System will not function properly";
+            String errmsg = "Failed to init.  System will not function properly";
             throw new RuntimeException(errmsg);
         };
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
@@ -68,7 +68,9 @@ public class ServerEventManager {
         ServerEventManager.fireEvent(sev);
     }
 
-
+    public static ServerEvent convertTo(FluxAction action, ServerEvent.Scope scope) {
+        return new ServerEvent(Name.ACTION, makeTarget(scope), action.toString());
+    }
 
     public static void fireEvent(ServerEvent sev) {
         if (sev == null || sev.getTarget() == null || !sev.getTarget().hasDestination()) {
@@ -120,7 +122,8 @@ public class ServerEventManager {
         return  allEventQueues.getCombinedNodeList();
     }
 
-    static void processEvent(ServerEvent ev) {
+    // bypass distributed event messaging.  should not be call directly unless you know exactly why it's needed.
+    public static void processEvent(ServerEvent ev) {
         totalEventCnt++;
         boolean delivered = false;
         for(ServerEventQueue queue : localEventQueues) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -5,6 +5,7 @@ package edu.caltech.ipac.firefly.server.servlets;
 
 import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.background.JobManager;
+import edu.caltech.ipac.firefly.messaging.Messenger;
 import edu.caltech.ipac.firefly.server.Counters;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
@@ -28,6 +29,8 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.rmi.RemoteException;
 import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -314,6 +317,16 @@ public class ServerStatus extends BaseHttpServlet {
         w.println("-----------------  ");
         Map<String, Object> stats = RedisService.getStats();
         stats.forEach((k,v)-> w.println("  - " + k + ": " + v));
+
+        w.println("\nMessenger info: ");
+        w.println("-----------------  ");
+        w.println("  Subscribed Topics: " + Messenger.getSubscribedTopics());
+        for (Map.Entry<String, Messenger.SubscriberHandler> entry : Messenger.getSubscribers().entrySet()) {
+            String topic = entry.getKey();
+            Messenger.SubscriberHandler handler = entry.getValue();
+            w.println("  - Topic: " + "%-20s".formatted(topic) + " Status: " + (String.format(handler.getFailSince() == null ? "OK" :
+                    "Failed since " + DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault()).format(handler.getFailSince()))));
+        }
     }
 
     private static void showPackagingStatus(PrintWriter w, boolean details) {

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -10,7 +10,7 @@ import {createRoot} from 'react-dom/client';
 import {set, defer, once, isArray} from 'lodash';
 import 'styles/global.css';
 
-import {APP_LOAD, dispatchAppOptions, dispatchUpdateAppData} from './core/AppDataCntlr.js';
+import {APP_LOAD, dispatchAppOptions, dispatchConnectionStatus, dispatchUpdateAppData} from './core/AppDataCntlr.js';
 import {FireflyViewer} from './templates/fireflyviewer/FireflyViewer.js';
 import {FireflySlate} from './templates/fireflyslate/FireflySlate.jsx';
 import {LandingPage} from './templates/fireflyviewer/LandingPage.jsx';
@@ -36,7 +36,6 @@ import {evaluateWebApi, initWebApi, isUsingWebApi, WebApiStat} from './api/WebAp
 import {WebApiHelpInfoPage} from './ui/WebApiHelpInfoPage.jsx';
 import {dispatchOnAppReady} from './core/AppDataCntlr.js';
 import {getBootstrapRegistry} from './core/BootstrapRegistry.js';
-import {showLostConnection} from './ui/LostConnection.jsx';
 import {recordHistory} from './core/History.js';
 import {GatorProtocolRootPanel} from './visualize/ui/GatorProtocolRootPanel';
 import {setDefaultImageColorTable} from './visualize/WebPlotRequest.js';
@@ -465,7 +464,7 @@ function bootstrap(props, clientAppSpecificOptions, webApiCommands) {
     return new Promise(async (resolve) => {
 
         const processDecor= (process) => (rawAction) => {
-            getOrCreateWsConn().catch(() => showLostConnection());
+            getOrCreateWsConn().catch(() => dispatchConnectionStatus({lost: true, reason: 'You are no longer connected to the server'}));
             process(rawAction);
             recordHistory(rawAction);
         };

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -153,6 +153,17 @@ export function dispatchUpdateAppData(appData) {
 }
 
 /**
+ * updates connection status.
+ * @param p
+ * @param p.lost    true if connection is lost
+ * @param p.reason  reason for the lost connection
+ * @returns {{type: string, payload: *}}
+ */
+export function dispatchConnectionStatus({lost, reason}) {
+    flux.process({ type : APP_UPDATE, payload: {connectionStatus: {lost, reason} }});
+}
+
+/**
  * Notify other apps this app is ready
  */
 export function dispatchNotifyRemoteAppReady() {
@@ -208,6 +219,10 @@ export function makeViewerChannel(channel, file) {
 
 export function isAppReady() {
     return get(flux.getState(), [APP_DATA_PATH, 'isReady']);
+}
+
+export function getConnectionStatus() {
+    return get(flux.getState(), [APP_DATA_PATH, 'connectionStatus']);
 }
 
 export function getSearchInfo() {

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -218,11 +218,11 @@ export function makeViewerChannel(channel, file) {
 }
 
 export function isAppReady() {
-    return get(flux.getState(), [APP_DATA_PATH, 'isReady']);
+    return flux.getState()?.[APP_DATA_PATH]?.isReady;
 }
 
 export function getConnectionStatus() {
-    return get(flux.getState(), [APP_DATA_PATH, 'connectionStatus']);
+    return flux.getState()?.[APP_DATA_PATH]?.connectionStatus;
 }
 
 export function getSearchInfo() {
@@ -236,11 +236,11 @@ export function getSearchByName(name) {
 }
 
 export function getMenu() {
-    return get(flux.getState(), [APP_DATA_PATH, 'menu']);
+    return flux.getState()?.[APP_DATA_PATH]?.menu;
 }
 
 export function getAlerts() {
-    return get(flux.getState(), [APP_DATA_PATH, 'alerts'], {});
+    return flux.getState()?.[APP_DATA_PATH]?.alerts || {};
 }
 
 export const getActiveTarget= function() { return flux.getState()[APP_DATA_PATH].activeTarget; };

--- a/src/firefly/js/core/AppDataReducers.js
+++ b/src/firefly/js/core/AppDataReducers.js
@@ -144,6 +144,7 @@ function getInitState() {
      * @summary Information about the core of the application
      *
      * @prop {boolean} isReady : false,
+     * @prop {Object} connectionStatus :  {lost, reason}, Status of the client connection to the server. e.g. WebSocket, Redis.
      * @prop {Object.<String,Array>} connections  channel:[] ... keyed by channel, contains an array of connId(s).
      * @prop {WorldPt} activeTarget
      * @prop {string} rootUrlPath

--- a/src/firefly/js/core/messaging/WebSocketClient.js
+++ b/src/firefly/js/core/messaging/WebSocketClient.js
@@ -6,8 +6,7 @@ import {pickBy} from 'lodash';
 import {parseUrl, getRootURL} from '../../util/WebUtil.js';
 import {Logger} from '../../util/Logger.js';
 import {WSCH} from '../History.js';
-import {getAppOptions} from '../AppDataCntlr.js';
-import {showLostConnection, hideLostConnection} from '../../ui/LostConnection.jsx';
+import {dispatchConnectionStatus, getAppOptions} from '../AppDataCntlr.js';
 
 export const CH_ID = 'channelID';
 
@@ -55,7 +54,7 @@ export function getOrCreateWsConn(baseUrl=getRootURL()) {
     const p = new Promise( (resolve, reject) => {
         const mResolve = (proxy) => {
             conns[baseUrl] = proxy;
-            hideLostConnection();
+            dispatchConnectionStatus({lost: false, reason: null});
             resolve?.(proxy);
         };
         const mReject = (e) => {
@@ -126,7 +125,7 @@ function makeWsConn(baseUrl, resolve, reject) {
             window.addEventListener('online', () => {
                 window.removeEventListener('online', connectWhenOnline);
                 logger.debug('online detected -> attempting to re-connect');
-                getOrCreateWsConn().catch(() => showLostConnection());
+                getOrCreateWsConn().catch(() => dispatchConnectionStatus({lost: true, reason: 'You are no longer connected to the server'}));
             });
         };
         window.addEventListener('offline', connectWhenOnline);
@@ -170,7 +169,7 @@ function makeWsConn(baseUrl, resolve, reject) {
         };
         window.addEventListener('focus', _handler);
         if (requireWs && window.navigator.onLine) {
-            showLostConnection();
+            dispatchConnectionStatus({lost: true, reason: 'You are no longer connected to the server'});
         }
     };
 

--- a/src/firefly/js/templates/common/FireflyLayout.jsx
+++ b/src/firefly/js/templates/common/FireflyLayout.jsx
@@ -4,7 +4,7 @@ import {object, bool, element, shape, elementType} from 'prop-types';
 import {Stack, Sheet, LinearProgress} from '@mui/joy';
 import {pick} from 'lodash/object.js';
 
-import {warningDivId} from 'firefly/ui/LostConnection.jsx';
+import {LostConnection} from '../../ui/LostConnection.jsx';
 import {Alerts} from 'firefly/ui/DropDownContainer.jsx';
 import {Banner} from 'firefly/ui/Banner.jsx';
 import {Menu} from 'firefly/ui/Menu.jsx';
@@ -82,7 +82,7 @@ export function FireflyLayout({footer, useDefaultExpandedView,
         <Sheet id='app-root' component={Stack} spacing={1} sx={{position:'absolute', inset:'0', ...sx}}>
             <Stack>
                 <BannerSection {...bannerProps} menu={menu} {...slotProps?.banner}/>
-                <div id={warningDivId} data-decor='full' className='warning-div center'/>
+                <LostConnection/>
                 <Alerts />
                 <Slot component={AppConfigDrawer} slotProps={slotProps?.drawer}/>
             </Stack>

--- a/src/firefly/js/ui/LostConnection.jsx
+++ b/src/firefly/js/ui/LostConnection.jsx
@@ -3,82 +3,23 @@
  */
 
 import React from 'react';
-import {get} from 'lodash';
-import {createRoot} from 'react-dom/client';
-import {dispatchAddActionWatcher} from '../core/MasterSaga';
-import {APP_UPDATE} from '../core/AppDataCntlr';
-
-export const warningDivId = 'fireflyLostConnWarn';
+import {getConnectionStatus} from '../core/AppDataCntlr';
+import {useStoreConnector} from './SimpleComponent';
+import {Alert, Stack, Typography} from '@mui/joy';
 
 /**
- * When connection is lost, a warning indicator will attach itself to a div with an id that starts with 'fireflyLostConnWarn'.
- * This means there can be more than one.  However, if one is not detected, it will do nothing.
- * When constructing the div, a 'data-decor' attribute can be set to affect how the warning look.
- *      <div id="fireflyLostConnWarn" data-decor="small" class="warning-div center"></div>
- *
- * Currently, we support 'data-decor' of 'small', 'medium', and 'full' with 'medium' as the default.
- *  small   : 24x24 transparent icon with tooltips
- *  medium  : 48x48 transparent icon with tooltips
- *  full    : 48x48 transparent icon with the message visible
- *
- * For conveniences, there are 3 defined styles to layout the fireflyLostConnWarn div:
- *   warning-div right:    horizontally right-align with a z-index of 300
- *   warning-div left:     horizontally left-align with a z-index of 300
- *   warning-div center:   horizontally center-align with a z-index of 300
- *
- * See src/firefly/html/demo/ffapi-table-test.html for an example of multiple warning is different styles.
- * There is one on top center and 3 on the bottom.  Search for div with id starting with 'fireflyLostConnWarn'.
- *
+ * When connection is lost, a warning indicator will appear.
  */
-export function initLostConnectionWarning() {
 
+export function LostConnection () {
 
-    const onConnectionUpdate = (action) => {
-        const {payload} = action || {};
-        if (! get(payload, 'websocket.isConnected', true)) {
-            showLostConnection();
-        }
-    };
-
-    dispatchAddActionWatcher({ actions:[APP_UPDATE], callback: onConnectionUpdate});
-
-}
-
-
-
-const reactRoots= new Map();
-
-export function showLostConnection() {
-    const divElements = document.querySelectorAll('[id^="fireflyLostConnWarn"]');
-    if (divElements) {
-        divElements.forEach( (div) => {
-            reactRoots.get(div)?.unmount();
-            const decor = div.getAttribute('data-decor') || 'medium';
-            const root= reactRoots.get(div) ?? createRoot(div);
-            reactRoots.set(div,root);
-            root.render(<LostConnection {...{decor}}/>);
-        });
-    }
-}
-
-export function hideLostConnection() {
-    const divElements = document.querySelectorAll('[id^="fireflyLostConnWarn"]');
-    if (divElements) {
-        divElements.forEach( (div) => {
-            reactRoots.get(div)?.unmount();
-        });
-    }
-}
-
-function LostConnection ({decor}) {
-    const clzName = decor === 'small' ? 'lost-connection--small' : 'lost-connection';
-    const msg = 'You are no longer connected to the server. Try reloading the page to reconnect.';
-    if (decor !== 'full') return <div className = {clzName} title = {msg} />;
-
+    const {lost, reason} = useStoreConnector(() => getConnectionStatus());
+    if (!lost) return null;
     return (
-        <div style={{display: 'inline-flex', alignItems: 'center', color: 'maroon', width: 300}}>
-            <div className={clzName} style={{margin: '1px 5px'}}/>
-            <div> {msg}</div>
-        </div>
-    );
-}
+        <Alert variant='soft' color='danger' size='sm' sx={{justifyContent:'center', borderRadius: 'unset'}}>
+            <Stack>
+                <Typography color='danger' level='h4'>{reason}</Typography>
+                <Typography color='danger' level='data-sm'>Try reloading the page to reconnect. If the problem persists, please contact support.</Typography>
+            </Stack>
+        </Alert>
+    );}

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/RedisServiceTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/RedisServiceTest.java
@@ -32,9 +32,6 @@ public class RedisServiceTest extends ConfigTest {
 
     @Before
     public void setup() {
-        if (!RedisService.connect()) {
-            System.out.println("Messenger is offline; skipping test.");
-        }
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
     }
 
@@ -71,10 +68,6 @@ public class RedisServiceTest extends ConfigTest {
     }
 
     private void testRedis() {
-
-        if (!RedisService.connect()) return;
-
-        assertEquals(RedisService.Status.ONLINE, RedisService.getStatus());
 
         // ping test
         try (Jedis conn = RedisService.getConnection()) {

--- a/src/firefly/test/edu/caltech/ipac/firefly/messaging/MessengerTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/messaging/MessengerTest.java
@@ -36,14 +36,9 @@ import static org.junit.Assert.*;
  * @version $Id: $
  */
 public class MessengerTest extends ConfigTest {
-    private static boolean isOffline;
 
     @Before
     public void setup() {
-        if (!RedisService.connect()) {
-            System.out.println("Messenger is offline; skipping test.");
-            isOffline = true;
-        }
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
     }
 
@@ -56,7 +51,6 @@ public class MessengerTest extends ConfigTest {
     @Test
     public void testMsgContent() throws InterruptedException {
 
-        if (isOffline) return;
         LOG.debug("testMsgContent");
 
         String topic = "testPublish";
@@ -89,7 +83,6 @@ public class MessengerTest extends ConfigTest {
     @Ignore
     public void testMsgCount() throws InterruptedException {
 
-        if (isOffline) return;
         LOG.debug("testMsgCount");
 
         Message testMsg = new Message().setValue("abc", "a");
@@ -140,7 +133,6 @@ public class MessengerTest extends ConfigTest {
     @Ignore
     public void testSubscribe() throws InterruptedException {
 
-        if (isOffline) return;
         LOG.debug("testSubscribe");
 
         String topic1 = "test1";
@@ -186,8 +178,6 @@ public class MessengerTest extends ConfigTest {
     @Category({TestCategory.Perf.class})
     @Test
     public void perfTest() throws InterruptedException {
-
-        if (isOffline) return;
 
         int numSent = 100_000;
         long startTime = System.currentTimeMillis();

--- a/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
@@ -83,10 +83,6 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
     @BeforeClass
     public static void setUp() throws InterruptedException {
 
-        if (!RedisService.connect()) {
-            System.out.println("Messenger is offline; skipping all tests in CachePeerProviderFactoryTest.");
-            return;
-        }
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
 
         LOG.debug("Initial setup for PubSub, creating 3 peers");
@@ -106,7 +102,6 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void pubSub_InitialSetup() throws InterruptedException, RemoteException {
-        if (!RedisService.connect()) return;
 
         assertEquals("Number of caches", 2, peer1.getCacheNames().length);
 
@@ -123,7 +118,6 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void pubSub_CacheReplication() throws InterruptedException, RemoteException {
-        if (!RedisService.connect()) return;
 
         LOG.debug("put a few entries into peer1... it should be replicated to the rest of the peers");
         peer1.getCache("cache_1").put(new Element("key1", "value1"));
@@ -146,7 +140,6 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void pubSub_PeerAddDrop() throws InterruptedException, RemoteException {
-        if (!RedisService.connect()) return;
 
         LOG.debug("testing drop-off.... shutdown peer1");
         peer1.shutdown();
@@ -178,7 +171,6 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void multicast_InitialSetup() throws InterruptedException, RemoteException {
-        if (!RedisService.connect()) return;
 
         assertEquals("Number of caches", 2, mcPeer1.getCacheNames().length);
 
@@ -195,7 +187,6 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void multicast_CacheReplication() throws InterruptedException, RemoteException {
-        if (!RedisService.connect()) return;
 
         LOG.debug("put a few entries into mcPeer1... it should be replicated to the rest of the peers");
         mcPeer1.getCache("cache_1").put(new Element("key1", "value1"));
@@ -218,7 +209,6 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @Test
     public void multicast_PeerAddDrop() throws InterruptedException, RemoteException {
-        if (!RedisService.connect()) return;
 
         LOG.debug("testing drop-off.... shutdown mcPeer1");
         mcPeer1.shutdown();

--- a/src/firefly/test/edu/caltech/ipac/util/cache/CacheTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/cache/CacheTest.java
@@ -37,11 +37,6 @@ public class CacheTest extends ConfigTest {
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
     }
 
-    @Before
-    public void setup() {
-        RedisService.connect();
-    }
-
     @After
     public void tearDown() {
         RedisService.teardown();


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1727

- Try to reconnect until Redis is back online
- Show error status to client
- Show status in ServerStatus page
- Refactor LostConnection.jsx component to use JoyUI

Test:  https://fireflydev.ipac.caltech.edu/firefly-1727-handle-redis-failure/firefly/
It's a bit harder to test.  To simulate Redis down, I've deployed this instance with 2 replicas.  
- You can find and delete the Redis pod to see that Firefly can recover from a redis restart.
- You can find and edit the Redis deployment so that i cannot start back up to see what happen when it's down for a long time.
- Both requires kubectl access.

Locally: 
- You can see the LostConnection.jsx when you shutdown tomcat
- Find redis process, then kill it and you will see it's got restarted
- If you install Redis locally, then you can add `-Dredis.host=127.0.0.1` to Tomcat's `bin/setenv.sh` to see how it behaves when Redis is down.
  - brew install redis
  - brew services stop redis
  - brew services start redis

