### PR TITLE
FIREFLY-1711: Table ingestion bug

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/io/TableParseHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/TableParseHandler.java
@@ -131,7 +131,7 @@ public interface TableParseHandler {
         public void data(Object[] row) throws IOException {
             try {
                 aryIdx.forEach(idx -> row[idx] = serialize(row[idx]));      // serialize array data if necessary
-                addRow(appender, row, ++rowCnt);
+                addRow(appender, row, rowCnt++);
             } catch (SQLException e) {
                 throw new IOException(e);
             }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1711
- Table ingestion create indexes starting from 1 when it should have been from 0

Test: https://firefly-1711-table-ingestion-index-bug.irsakudev.ipac.caltech.edu/irsaviewer

Steps to recreate: 

- goto DCE and choose DIGIT
  - 20h23m46.89s +42d12m43.0s Equ J2000
  - 200 arcsec
- select first 3 rows and download - 2 results in zip
- select second and third row and download - 2 results in zip (same as above)
- select only first row and download - no results