### PR TITLE
FIREFLY-1695: Display error message when upload table can't be read

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -228,8 +228,8 @@ public class VoTableReader {
                 voTablePath = tmpFile.getPath();
             } catch (Exception e) {
                 tmpFile.delete();
-                LOG.error(e);
-                throw new IOException("Unable to fetch URL: "+ location + "\n" + e.getMessage(), e);
+                LOG.error(e, "Unable to fetch URL: " + location);
+                throw new IOException(e.getMessage(), e);
             }
         } catch (MalformedURLException ex) { /* ok to ignore.  location may not be a URL */ }
 
@@ -238,8 +238,8 @@ public class VoTableReader {
             // at this point, voTablePath is a file path.
             return getVoTableRoot(new FileInputStream(voTablePath), policy);
         }  catch (Exception e) {
-            throw new IOException("Unable to parse VOTABLE from "+ location + "\n" +
-                    e.getMessage(), e);
+            LOG.error(e, "Unable to parse VOTABLE from "+ location);
+            throw new IOException(e.getMessage(), e);
         }
     }
 
@@ -250,7 +250,8 @@ public class VoTableReader {
             voFactory.setStoragePolicy(policy);
             return voFactory.makeVOElement(new BufferedInputStream(source), null);
         } catch (Exception e) {
-            throw new IOException("Unable to parse VOTable from stream: \n" + e.getMessage(), e);
+            LOG.error(e, "Unable to parse VOTable from stream");
+            throw new IOException(e.getMessage(), e);
         }
     }
 

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -49,18 +49,19 @@ const LOAD_UWS=7;
 
 const imageWarning = 'Only loading the table(s), ignoring any selected image(s).';
 const tableWarning = 'Only loading the image(s), ignoring any selected table(s).';
+export const fileAnalysisErr = {valid: false, errorMsg: 'Could not analyze the file.', title: 'File Analysis Error'};
 
 
 export function resultSuccess(request) {
 
-    const {report, detailsModel, summaryModel, groupKey, acceptList, uniqueTypes,
-        acceptOneItem}= request.additionalParams ?? {};
+    const {message, report, detailsModel, summaryModel, groupKey, acceptList,
+        uniqueTypes, acceptOneItem} = request.additionalParams ?? {};
     const summaryTblId = groupKey; //FileUploadAnalysis
     const fileCacheKey = getFileCacheKey(groupKey);
 
     //determine if the file type or selections are valid to be loaded
     const {valid, errorMsg, title} = determineValidity(acceptList, uniqueTypes, summaryModel,
-        summaryTblId, report, acceptOneItem);
+        summaryTblId, report, acceptOneItem, message);
 
     if (!valid) {
         showInfoPopup(errorMsg, title);
@@ -229,8 +230,8 @@ const errorObj = {
     tblNotAcceptedErr: {valid: false, errorMsg: 'You may not load tables from here.', title: 'File Type Mismatch'},
 };
 
-function determineValidity(acceptList, uniqueTypes, summaryModel, summaryTblId,
-                           report, acceptOneItem) {
+export function determineValidity(acceptList, uniqueTypes, summaryModel, summaryTblId,
+                           report, acceptOneItem, message) {
     let {errorMsg, title} = '';
     let valid = true;
 
@@ -247,6 +248,10 @@ function determineValidity(acceptList, uniqueTypes, summaryModel, summaryTblId,
     const isMocFits =  isMOCFitsFromUploadAnalsysis(report);
     const isDL=  isAnalysisTableDatalink(report);
 
+    if (!report) {// report is the basis for all the checks below, handle it early on if undefined
+        errorMsg = message || fileAnalysisErr.errorMsg;
+        return {...fileAnalysisErr, errorMsg};
+    }
 
     if (uniqueTypes.includes(REGIONS) && !acceptRegions(acceptList)) {
         return errorObj.regionMismatchErr;


### PR DESCRIPTION
Fixes [FIREFLY-1695](https://jira.ipac.caltech.edu/browse/FIREFLY-1695)

- onSubmit of UploadTableChooser (used in Multi-object fields) now uses `determineValidity` like FileUploadPanel's onSubmit, that shows an error popup if invalid
- FileUploadPanel was maintaining a `message` state besides `report` but wasn't using it in generating invalidation popup, now made it do so by registering in `request.additionalParams` and passing it to `determineValidity`.
- Made `message` state to read `FileAnalysis.ErrorResponse` description from server-side for showing more specific error messages.


## Testing
https://fireflydev.ipac.caltech.edu/firefly-1695-upload-error-msg/firefly/

Go to "Upload" tab -> Upload the bad table file in ticket -> click "load" button, the error popup should show VOTable parsing error instead of "Could not recognize the file type" error which is misleading.

Go to TAP -> Spatial -> Multi-object -> Upload the bad table file in ticket -> click "load" button, it should show an error popup with same error message as Upload tab.