### PR TITLE
FIREFLY-1729: Client tables reset scroll on column width change

### DIFF
--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -510,8 +510,9 @@ function tableSort(action) {
             const [nreq, tableStub, tableModel] = setupTableOps(tbl_id, request);
             if (!tableStub) return;
 
-            // rollback changes to keep current highlighted row.  instead set highlighted to 0.
+            // rollback changes from IRSA-2421(keep current highlighted row on sort).
             // TblUtil.setHlRowByRowIdx(nreq, tableModel);
+            // set highlighted to 0 on sort. (FIREFLY-360 based on CCB FIREFLY-267)
             nreq.startIdx = 0;
 
             dispatch({type:TABLE_FETCH, payload: tableStub});

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -11,6 +11,9 @@ import {getNumFilters} from '../FilterInfo.js';
 import {makeDefaultRenderer} from '../ui/TableRenderer.js';
 import {applyTblPref} from '../TablePref.js';
 
+export const BY_SCROLL = 'byScroll';
+export const BY_TABLE = 'byTable';
+
 
 /*
 `table_space`(table store) is separated into 3 parts; data, ui, and results
@@ -61,7 +64,7 @@ function handleTableUpdates(root, action, state) {
 
         case (Cntlr.TBL_RESULTS_ADDED) :
             const options = onUiUpdate(get(action, 'payload.options', {}));
-            return updateMerge(root, [tbl_ui_id], {tbl_ui_id, tbl_id, triggeredBy: 'byTable', ...options});
+            return updateMerge(root, [tbl_ui_id], {tbl_ui_id, tbl_id, triggeredBy: BY_TABLE, ...options});
 
         case (Cntlr.TABLE_FETCH)      :
         case (Cntlr.TABLE_FILTER)      :

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -26,13 +26,11 @@ import 'fixed-data-table-2/dist/fixed-data-table.css';
 import {updateSet} from 'firefly/util/WebUtil.js';
 import {TableMask} from 'firefly/ui/panel/MaskPanel.jsx';
 import {TableErrorMsg} from 'firefly/tables/ui/TablePanel.jsx';
+import {BY_SCROLL, BY_TABLE} from '../reducer/TableUiReducer';
 
 const logger = Logger('Tables').tag('BasicTable');
 const noDataMsg = 'No Data Found';
 const noDataFromFilter = 'No data match these criteria';
-
-export const BY_SCROLL = 'byScroll';
-
 
 // Override default fixed-data-table-2 css with joy-ui colors and styles
 const tableStyleOverrides = {
@@ -375,7 +373,7 @@ const TextView = ({columns, data, width, height}) => {
 
 function correctScrollTopIfNeeded(maxScrollWidth, scrollTop, width, height, rowHeight, hlRowIdx, triggeredBy) {
     const rowHpos = hlRowIdx * rowHeight;
-    if (triggeredBy !== BY_SCROLL) {
+    if (triggeredBy === BY_TABLE) {     // FIREFLY-1729: don't correct scroll on column resize.
         // delta is a workaround for the horizontal scrollbar hiding part of the last row when visible
         const delta = maxScrollWidth > width ? (.5*rowHeight) : 0;
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1729
- should behave the same for both client and server backed table.

Test: https://fireflydev.ipac.caltech.edu/firefly-1729-table-reload-column-resize/firefly/
- Images -> M81; WISE -> Search
- Image Toolbar -> Show FITS header 'i' icon
- Scroll to the bottom of the table, then resize a column.  Scroll position should remain the same.