### PR TITLE
Firefly-1164,1734: multiple tickets

### DIFF
--- a/src/firefly/js/drawingLayers/SelectArea.js
+++ b/src/firefly/js/drawingLayers/SelectArea.js
@@ -4,9 +4,10 @@
 import {get, isEmpty} from 'lodash';
 import Enum from 'enum';
 import DrawLayerCntlr, {DRAWING_LAYER_KEY} from '../visualize/DrawLayerCntlr.js';
-import {dispatchAttributeChange, visRoot} from '../visualize/ImagePlotCntlr.js';
+import ImagePlotCntlr, {dispatchAttributeChange, visRoot} from '../visualize/ImagePlotCntlr.js';
 import {makeDrawingDef, Style} from '../visualize/draw/DrawingDef.js';
 import DrawLayer, {ColorChangeType} from '../visualize/draw/DrawLayer.js';
+import {closeToolbarModalLayers} from '../visualize/ui/ToolbarToolModalEnd';
 import {MouseState} from '../visualize/VisMouseSync.js';
 import {PlotAttribute} from '../visualize/PlotAttribute.js';
 import CsysConverter from '../visualize/CsysConverter.js';
@@ -157,6 +158,11 @@ function getLayerChanges(drawLayer, action) {
             break;
         case DrawLayerCntlr.SELECT_MOUSE_LOC:
             return moveMouse(drawLayer,action);
+        case ImagePlotCntlr.CHANGE_HIPS:
+            if (action.payload.coordSys) {
+                setTimeout(() => closeToolbarModalLayers(),4);
+            }
+            return;
     }
     return null;
 }

--- a/src/firefly/js/drawingLayers/hpx/HpxCatalog.js
+++ b/src/firefly/js/drawingLayers/hpx/HpxCatalog.js
@@ -374,10 +374,10 @@ function handlePlotActions(action, cancelSelf, params) {
             break;
 
         case ImagePlotCntlr.UPDATE_VIEW_SIZE:
+        case ImagePlotCntlr.RECENTER:
             if (!connectedIds.includes(plotId)) return;
             void makeTileDataAndUpdate(dl,plotId,tbl_id, action.type!==ImagePlotCntlr.CHANGE_CENTER_OF_PROJECTION);
             break;
-        case ImagePlotCntlr.RECENTER:
         case ImagePlotCntlr.ANY_REPLOT:
         case ImagePlotCntlr.CHANGE_HIPS:
         case ImagePlotCntlr.CHANGE_CENTER_OF_PROJECTION:

--- a/src/firefly/js/drawingLayers/hpx/HpxCatalogUtil.js
+++ b/src/firefly/js/drawingLayers/hpx/HpxCatalogUtil.js
@@ -1,3 +1,4 @@
+import pointInPolygon from 'point-in-polygon';
 import {dispatchAddTaskCount, dispatchRemoveTaskCount} from '../../core/AppDataCntlr';
 import {FilterInfo} from '../../tables/FilterInfo';
 import {
@@ -194,7 +195,11 @@ async function getSelectedHealPix(tbl_id, cc, pt0, pt1, tileList, norder, contai
         const pix = getCornersForCell(norder, tile.pixel, CoordSys.EQ_J2000);
         const devC = pix.wpCorners.map((wp) => cc.getDeviceCoords(wp)).filter(Boolean);
         if (devC.length < 2) return;
-        if (devC.some((pt) => containsTest(pt))) selectedTiles.push(tile);
+        const polygon= devC.map( ({x,y}) => [x,y]);
+        const match= pointInPolygon([pt0.x,pt0.y], polygon)
+            || pointInPolygon([pt1.x,pt1.y], polygon)
+            || devC.some((pt) => containsTest(pt));
+        if (match) selectedTiles.push(tile);
     });
 
     dispatchAddTaskCount(DEFAULT_COVERAGE_PLOT_ID,HPX_WORKING_KEY);


### PR DESCRIPTION
#### Firefly-1164,1734: multiple tickets

- [Firefly-1734](https://jira.ipac.caltech.edu/browse/FIREFLY-1734): fixed: filtering not working for some very small selections
- [Firefly-1164](https://jira.ipac.caltech.edu/browse/FIREFLY-1164): turn off selection when projection changes
- [IRSA-6890](https://jira.ipac.caltech.edu/browse/IRSA-6890): catalog scrolling on center change


#### Testing
 - https://fireflydev.ipac.caltech.edu/firefly-1734-filtering/firefly
 - Test [Firefly-1734](https://jira.ipac.caltech.edu/browse/FIREFLY-1734) according to the ticket.
 - Test [Firefly-1164](https://jira.ipac.caltech.edu/browse/FIREFLY-1164): selection will turn off when HiPS is flipped between galactic and eq 
 - Test [IRSA-6890](https://jira.ipac.caltech.edu/browse/IRSA-6890) according to the ticket.