### PR TITLE
FIREFLY-1721: fixed added columns go away

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -711,6 +711,11 @@ abstract public class BaseDbAdapter implements DbAdapter {
     }
 
     protected Object[] getDdFrom(DataType dt, int colIdx) {
+        colIdx = switch (dt.getKeyName()) {     // place these at the end, so it will always appear there.
+            case ROW_IDX -> 1_000_000;
+            case ROW_NUM -> 1_000_001;
+            default -> colIdx;
+        };
         return new Object[] {
                 dt.getKeyName(),
                 dt.getLabel(),


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1721
- remove use of backgrounding enumeratedValuesCheck to avoid race condition

Test:  https://fireflydev.ipac.caltech.edu/firefly-1721-added-col-go-away/firefly/
- load any table
- add a column (a -> 1)
- impose a filter to any column, e.g. "> 0"
- add another column (b -> 2)
- cancel the filters
2nd column **SHOULD NOT** goes away.

Also fixed drop-down column filter not appearing for large tables.
- TAP => CACD => choose Use Image Search (ObsTAP) => m81 -> Search
Drop-down filter option should appear for `dataproduct_type` column
