### PR TITLE
FIREFLY-1327: Update job info dialog

### DIFF
--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -101,6 +101,10 @@ export function isSearchJob(job) {
     return ['SEARCH', 'UWS', 'TAP'].includes(job?.meta?.type);
 }
 
+export function isUWS(job) {
+    return ['UWS', 'TAP'].includes(job?.meta?.type);
+}
+
 export function isTapJob(job) {
     return job?.meta?.type === 'TAP';
 }

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -7,7 +7,7 @@ import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog, isDialogVisible} from '../ComponentCntlr.js';
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
-import {CollapsibleItem, CollapsibleGroup} from 'firefly/ui/panel/CollapsiblePanel.jsx';
+import {CollapsibleItem, CollapsibleGroup} from '../../ui/panel/CollapsiblePanel.jsx';
 import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson.js';
 import {Box, Skeleton, Stack} from '@mui/joy';
 import {TableErrorMsg} from 'firefly/tables/ui/TablePanel.jsx';
@@ -84,19 +84,48 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
     const hasMoreSection = hrefs || parameters || errorSummary || aux;
     return (
         <Stack spacing={.5} p={1} sx={sx}>
-            {Object.entries(rest)
-                    .filter(([k, v]) => k && v)
-                    .map(([k,v]) => <KeywordBlock key={k} label={k} value={v}/>)
-            }
+            <JobInfoDetails {...rest}/>
             {/*{ meta?.runId && <KeywordBlock key='localRunId' label='local runId' value={meta.runId}/>}*/}
             { hasMoreSection && (
                 <CollapsibleGroup>
-                    <OptionalBlock label='parameters' value={parameters} isOpen={isOpen}/>
-                    <OptionalBlock label='results' value={hrefs} asLink={true} isOpen={isOpen}/>
-                    <OptionalBlock label='errorSummary' value={errorSummary} isOpen={isOpen}/>
-                    <OptionalBlock label='jobInfo' value={aux} isOpen={isOpen}/>
+                    <OptionalBlock label='Parameters' title='Referred to as "parameters" in UWS' value={parameters} isOpen={isOpen}/>
+                    <OptionalBlock label='Results' title='Referred to as "results" in UWS' value={hrefs} asLink={true} isOpen={isOpen}/>
+                    <OptionalBlock label='Error Summary' title='Referred to as "errorSummary" in UWS' value={errorSummary} isOpen={isOpen}/>
+                    <OptionalBlock label='Extra Information' title='Referred to as "jobInfo" in UWS' value={aux} isOpen={isOpen}/>
                 </CollapsibleGroup>
             )}
+        </Stack>
+    );
+}
+
+function JobInfoDetails({jobId, ownerId, phase, creationTime, startTime, endTime, quote, executionDuration, destruction}) {
+    let actualRt = '';
+    startTime = startTime && new Date(startTime);
+    endTime = endTime && new Date(endTime);
+    creationTime = creationTime && new Date(creationTime);
+    quote = quote && new Date(quote);
+    destruction = destruction && new Date(destruction);
+    if (endTime && startTime) {
+        actualRt = Math.round((endTime - startTime) / 1000) + 's';
+    }
+    const duration =  executionDuration ? executionDuration + 's' : '';
+    const dateProps = {width: '18em', justifyContent:'space-between'};
+    return (
+        <Stack direction='row' spacing={2}>
+            <Stack>
+                <KeywordBlock label='Phase' title='Referred to as "phase" in UWS' value={phase} mb={1}/>
+                <KeywordBlock label='Created' title='Referred to as "creationTime" in UWS' value={creationTime?.toISOString()}  {...dateProps}/>
+                <KeywordBlock label='Start Time' title='Referred to as "startTime" in UWS' value={startTime?.toISOString()} {...dateProps}/>
+                <KeywordBlock label='End Time' title='Referred to as "endTime" in UWS' value={endTime?.toISOString()} {...dateProps}/>
+                <KeywordBlock label='Planned end' title='Referred to as "quote" in UWS' value={quote?.toISOString()} {...dateProps}/>
+                <KeywordBlock label='Destruction' title='Referred to as "destruction" in UWS' value={destruction?.toISOString()} {...dateProps}/>
+            </Stack>
+            <Stack>
+                <KeywordBlock label='Job ID' title='Referred to as "jobId" in UWS' value={jobId} mb={1}/>
+                <KeywordBlock label='Owner' title='Referred to as "ownerId" in UWS' value={ownerId}/>
+                <KeywordBlock label='Run time limit' title='Referred to as "executionDuration" in UWS' value={duration}/>
+                <KeywordBlock label='Actual run time' title='The difference of the "End" and "Start" times.' value={actualRt}/>
+            </Stack>
         </Stack>
     );
 }

--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -133,6 +133,7 @@
  * @prop {string} jobId         jobId for display only
  * @prop {string} ownerId       ID of the job creator
  * @prop {string} phase         execution phase.  One of PENDING, QUEUED, EXECUTING, COMPLETED, ERROR, ABORTED
+ * @prop {string} creationTime  creation time in UTC
  * @prop {string} startTime     start time in UTC
  * @prop {string} endTime       end time in UTC
  * @prop {number} executionDuration duration (in seconds) the job is allowed to run. 0 means unlimited

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -13,6 +13,7 @@ import {JobInfo} from '../../core/background/JobInfo.jsx';
 import {getJobIdFromTblId} from '../TableRequestUtil.js';
 import {CopyToClipboard} from '../../visualize/ui/MouseReadout.jsx';
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
+import {Slot} from '../../ui/SimpleComponent';
 
 
 export function TableInfo({tbl_id, tabsProps, ...props}) {
@@ -157,18 +158,18 @@ const ShowObjectTreeBtn = ({data, title}) => {
     );
 };
 
-export function KeywordBlock({sx={}, label, value, title, asLink}) {
+export function KeywordBlock({label, value, title, asLink, ...props}) {
     return (
-        <Stack direction='row' whiteSpace='nowrap' alignItems='baseline' sx={sx}>
+        <Slot component={Stack} direction='row' whiteSpace='nowrap' alignItems='baseline' slotProps={props}>
             <Keyword {...{label, value, title, asLink}}/>
-        </Stack>
+        </Slot>
     );
 }
 
-export function Keyword({label, value, title, asLink}) {
-    label = label && label + ':';
-    if (label || value) {
-        value = String(value);
+export function Keyword({label=null, value, title, asLink}) {
+    if ((label !== null) || value) {
+        label = label ? label + ':' : '\u00A0';
+        value = value ? String(value) : '\u00A0';
         return (
             <>
                 {label && <Typography level='title-sm' title={title} mr={1/2}>{label}</Typography>}

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -158,22 +158,23 @@ const ShowObjectTreeBtn = ({data, title}) => {
     );
 };
 
-export function KeywordBlock({label, value, title, asLink, ...props}) {
+export function KeywordBlock({label, value, title, asLink, href, ...props}) {
     return (
         <Slot component={Stack} direction='row' whiteSpace='nowrap' alignItems='baseline' slotProps={props}>
-            <Keyword {...{label, value, title, asLink}}/>
+            <Keyword {...{label, value, title, href, asLink}}/>
         </Slot>
     );
 }
 
-export function Keyword({label=null, value, title, asLink}) {
+export function Keyword({label=null, value, title, asLink, href}) {
     if ((label !== null) || value) {
         label = label ? label + ':' : '\u00A0';
         value = value ? String(value) : '\u00A0';
+        href ??= value;
         return (
             <>
                 {label && <Typography level='title-sm' title={title} mr={1/2}>{label}</Typography>}
-                { asLink ? <LinkTag title={value} href={value} /> :
+                { asLink ? <LinkTag title={value} href={href} /> :
                     <ContentEllipsis text={value} sx={{p: '1px', margin: 'unset'}}><Typography level='body-sm' title={value} noWrap mr={1/2}>{value}</Typography></ContentEllipsis>
                 }
             </>

--- a/src/firefly/js/ui/CssStrThemeWrapper.jsx
+++ b/src/firefly/js/ui/CssStrThemeWrapper.jsx
@@ -12,7 +12,7 @@ import {oneOfType, shape, string} from 'prop-types';
  * @param p.cssStr {string|Object} css string. If theme needs to be handled, pass `{light: cssString, dark: cssString}`.
  * @param p.children {React.ReactNode}
  */
-export default function CssStrThemeWrapper({cssStr, children}) {
+export default function CssStrThemeWrapper({cssStr, children, ...props}) {
     const {isDarkMode} = useColorMode();
     const themeCssStr = (isDarkMode ? cssStr?.dark : cssStr?.light) ?? cssStr ?? '';
 
@@ -21,7 +21,7 @@ export default function CssStrThemeWrapper({cssStr, children}) {
 
     return (
         // JoyUI Box accepts emotion "css" prop natively: https://mui.com/material-ui/integrations/interoperability/#the-css-prop
-        <Box css={themeCssStyles}>
+        <Box css={themeCssStyles} {...props}>
             {children}
         </Box>
     );


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1327

Implemented as described in the ticket, with two exceptions:
- Owner has been moved to the bottom section to provide a clearer separation between the top and bottom.
- The default proportional font is used, so the dates are not perfectly aligned as shown in the ticket. Would you like me to switch all values to a monospaced font for better alignment?  But, this will cause the dialog's font to deviate from the rest of the application.

Test: https://fireflydev.ipac.caltech.edu/firefly-1327-jobinfo-dialog/firefly/
Submit a few TAP or IRSA Catalog searches, then go to `Job Monitor` and click the Job Info (i-icon) to view details.

