### PR TITLE
Firefly-1740,48: clean up the color,strech,and otherlay sync button and add to other places

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/DirectStretchUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/DirectStretchUtils.java
@@ -81,7 +81,7 @@ public class DirectStretchUtils {
         int bPosQuarter=0;
         Band[] bands= state.getBands();
         ThreeCComponents tComp= get3CComponents(frGroup,sv.totWidth,sv.totHeight,state);
-        RGBIntensity rgbI= get3CRGBIntensity(state.getRangeValues(),frGroup,bands);
+        RGBIntensity rgbI= get3CRGBIntensity(state,frGroup,bands);
          new ArrayList<Stretch3CTile>(sv.tileLen);
 
         var sTileList =doTileStretch(sv,tileSize, Stretch3CTile::new,
@@ -212,13 +212,15 @@ public class DirectStretchUtils {
         return new ThreeCComponents(float1dAry,imHeadAry,histAry);
     }
 
-    private static RGBIntensity get3CRGBIntensity(RangeValues rv, ActiveFitsReadGroup frGroup, Band[] bands) {
+    private static RGBIntensity get3CRGBIntensity(PlotState state,ActiveFitsReadGroup frGroup, Band[] bands) {
         RGBIntensity rgbIntensity = new RGBIntensity();
         boolean useIntensity= false;
-        if (rv.rgbPreserveHue() && bands.length==3) {
+        if (state.getRangeValues().rgbPreserveHue() && bands.length==3) {
             FitsRead [] fitsReadAry= new FitsRead[] {
                     frGroup.getFitsRead(RED), frGroup.getFitsRead(GREEN), frGroup.getFitsRead(BLUE), };
-            for(int i=0; (i<3); i++) rgbIntensity.addRangeValues(fitsReadAry, i, rv);
+            rgbIntensity.addRangeValues(fitsReadAry, 0, state.getRangeValues(RED));
+            rgbIntensity.addRangeValues(fitsReadAry, 1, state.getRangeValues(GREEN));
+            rgbIntensity.addRangeValues(fitsReadAry, 2, state.getRangeValues(BLUE));
             useIntensity= true;
         }
         return useIntensity ? rgbIntensity : null;

--- a/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
+++ b/src/firefly/js/metaConvert/vo/DataLinkProcessor.js
@@ -1,4 +1,3 @@
-import {TableDataType} from '../../data/FileAnalysis';
 import {getPreferCutout} from '../../ui/tap/Cutout';
 import {getSearchTarget, obsCoreTableHasOnlyImages} from '../../voAnalyzer/TableAnalysis.js';
 import { getDataLinkData, isSimpleImageType, isVoTable } from '../../voAnalyzer/VoDataLinkServDef.js';
@@ -339,7 +338,7 @@ function createDataLinkMenuRet({dlTableUrl, dataLinkData, sourceTable, sourceRow
         })
         .filter(Boolean);
 
-    if (parsingAlgorithm===SPECTRUM && menu.length>1) {
+    if (parsingAlgorithm===SPECTRUM && menu.length>1) { // if I am only doing spectrum then gather them up into one display
         const singleItemMenu= menu.filter( (m) => m.displayType===DPtypes.CHOICE_CTI && m.tbl_id);
         const activateObj= Object.fromEntries(singleItemMenu.map( ({tbl_id,activate,chartId}) => [tbl_id,{activate,chartId}]));
         const extractionObj= Object.fromEntries(singleItemMenu.map( (m) => [m.tbl_id,m.extraction]));

--- a/src/firefly/js/metaConvert/vo/DatalinkProducts.js
+++ b/src/firefly/js/metaConvert/vo/DatalinkProducts.js
@@ -38,6 +38,9 @@ import {
  */
 export async function getDatalinkRelatedGridProduct({dlTableUrl, activateParams, table, row, threeColorOps, titleStr, options}) {
     try {
+
+        if (options.limitViewerDisplay===TABLE_ONLY) return dpdtSimpleMsg('Configuration Error: No support for related spectrum');
+
         dispatchUpdateDataProducts(activateParams.dpId, dpdtWorkingMessage('Loading data products...', 'working'));
         const datalinkTable = await fetchDatalinkTable(dlTableUrl, options.datalinkTblRequestOptions);
         const preferCutout= getPreferCutout(options.dataProductsComponentKey,table?.tbl_id);

--- a/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
@@ -1,6 +1,6 @@
 import {isEmpty, isUndefined} from 'lodash';
 import {getCellValue, getColumns, hasRowAccess} from '../../tables/TableUtil.js';
-import {getDataServiceOption, getDataServiceOptionByTable} from '../../ui/tap/DataServicesOptions';
+import {getDataServiceOptionByTable} from '../../ui/tap/DataServicesOptions';
 import {tokenSub} from '../../util/WebUtil.js';
 import {
     getObsCoreAccessURL, getObsReleaseDate, getObsTitle, getProdTypeGuess, getSearchTarget, isFormatDataLink,

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -369,8 +369,7 @@ export function getPlotStateAry(pv) {
  * @return {boolean}
  */
 export function hasOverlayColorLock(pv,plotGroup) {
-    return Boolean(plotGroup && plotGroup.plotGroupId && plotGroup.overlayColorLock &&
-        pv && pv.plotGroupId===plotGroup.plotGroupId);
+    return Boolean(plotGroup?.overlayColorLock && pv?.plotGroupId===plotGroup?.plotGroupId);
 }
 
 /**

--- a/src/firefly/js/visualize/ui/ColorBandPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorBandPanel.jsx
@@ -27,7 +27,7 @@ import {dispatchForceFieldGroupReducer} from 'firefly/fieldGroup/FieldGroupCntlr
 
 
 const LABEL_WIDTH= 105;
-const HIST_WIDTH= 340;
+const HIST_WIDTH= 360;
 const HIST_HEIGHT= 55;
 const maskWrapper= {position:'absolute', left:0, top:0, width:'100%', height:'100%' };
 const textPadding= {paddingBottom:3};
@@ -45,7 +45,7 @@ const histImStyle= {
 
 export const ColorBandPanel= memo(({fields,plot,band, groupKey}) => {
     const [exit, setExit]= useState(true);
-    const [{dataHistogram, dataBinMeanArray, dataBinColorIdx, dataMin, dataMax, largeBinPercent}, setDisplayState]= useState({});
+    const [{dataHistogram, dataBinMeanArray, dataBinColorIdx, dataMin, dataMax}, setDisplayState]= useState({});
     const [histReadout, setHistReadout]= useState({histValue:0,histMean:0,histIdx:0});
     const {plotId, plotState}= plot ?? {};
     const doMask= false;
@@ -295,7 +295,7 @@ const asinhSliderMarks = [
 ];
 const ASINH_Q_MAX_SLIDE_VAL = 20;
 
-export function renderAsinH(fields, renderRange, replot, qOnTop=false) {
+export function renderAsinH(fields, renderRange, qOnTop=false) {
     const qvalue = fields?.asinhQ?.value || 0;
     const label = `Q: ${Number.parseFloat(qvalue).toFixed(1)} `;
 
@@ -316,7 +316,6 @@ export function renderAsinH(fields, renderRange, replot, qOnTop=false) {
                          label={label}
                          sx={{mt: 1, mb: 2, mr: 2}}
                          decimalDig={1}
-                         onValueChange={replot}
             />
             {qOnTop && renderRange}
         </Stack>

--- a/src/firefly/js/visualize/ui/ColorDialog.jsx
+++ b/src/firefly/js/visualize/ui/ColorDialog.jsx
@@ -15,13 +15,14 @@ import {FieldGroup} from '../../ui/FieldGroup.jsx';
 import {ColorBandPanel} from './ColorBandPanel.jsx';
 import {ColorRGBHuePreservingPanel} from './ColorRGBHuePreservingPanel.jsx';
 import {dispatchStretchChange, visRoot} from '../ImagePlotCntlr.js';
-import {primePlot, getActivePlotView, isThreeColor} from '../PlotViewUtil.js';
+import {primePlot, getActivePlotView, isThreeColor, getPlotViewAry} from '../PlotViewUtil.js';
 import { RangeValues, ZSCALE, STRETCH_ASINH}from '../RangeValues.js';
 import HelpIcon from '../../ui/HelpIcon.jsx';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 import {isHiPS, isImage} from '../WebPlot';
 import {useStoreConnector} from '../../ui/SimpleComponent';
 import {FieldGroupTabs, Tab} from '../../ui/panel/TabPanel.jsx';
+import {ColorStretchLockButton} from './ColorTableDropDownView';
 
 import {RED_PANEL,
     GREEN_PANEL,
@@ -86,6 +87,7 @@ function renderThreeColorView(plot, rFields, gFields, bFields, rgbFields, isHueP
     const canBeHuePreserving = plotState.isBandUsed(Band.RED) && plotState.isBandUsed(Band.GREEN) && plotState.isBandUsed(Band.BLUE);
     const threeColorStretchMode = canBeHuePreserving &&
         <RadioGroupInputFieldView
+            buttonGroup={true}
             options={[
                 {label: 'Per-band stretch', value: 'perBand'},
                 {label: 'Hue preserving stretch', value: 'huePreserving'}
@@ -96,11 +98,15 @@ function renderThreeColorView(plot, rFields, gFields, bFields, rgbFields, isHueP
         />;
 
     return (
-        <Box sx={{m:1}}>
-            {threeColorStretchMode}
-            {Boolean(isHuePreservingSelected) && renderHuePreservingThreeColorView(plot, rgbFields)}
-            {!isHuePreservingSelected && renderStandardThreeColorView(plot, rFields, gFields, bFields)}
-        </Box>
+        <Stack sx={{m:1}}>
+            <Stack spacing={2}>
+                {getPlotViewAry(visRoot()).filter( (pv) => isImage(primePlot(pv))).length>1 &&
+                    <ColorStretchLockButton/>}
+                {threeColorStretchMode}
+                {Boolean(isHuePreservingSelected) && renderHuePreservingThreeColorView(plot, rgbFields)}
+                {!isHuePreservingSelected && renderStandardThreeColorView(plot, rFields, gFields, bFields)}
+            </Stack>
+        </Stack>
     );
 }
 
@@ -181,14 +187,18 @@ function renderStandardView(plot,fields) {
 
     return (
         <FieldGroup groupKey={NO_BAND_PANEL} keepState={true}  reducerFunc={colorPanelReducer} >
-            <ColorBandPanel groupKey={NO_BAND_PANEL} band={Band.NO_BAND} fields={fields} plot={plot}/>
-            <Stack direction='row' justifyContent='space-between' alignItems='center'>
-                <CompleteButton
-                    text='Refresh' dialogId='ColorStretchDialog'
-                    closeOnValid={false} sx={{pt:.25, pb:1, pl:1}}
-                    onSuccess={replot()} onFail={invalidMessage}
-                />
-                <HelpIcon helpId='visualization.modifyColorStretchSingleBand'/>
+            <Stack spacing={2}>
+                {getPlotViewAry(visRoot()).filter( (pv) => isImage(primePlot(pv))).length>1 &&
+                    <ColorStretchLockButton/>}
+                <ColorBandPanel groupKey={NO_BAND_PANEL} band={Band.NO_BAND} fields={fields} plot={plot}/>
+                <Stack direction='row' justifyContent='space-between' alignItems='center'>
+                    <CompleteButton
+                        text='Refresh' dialogId='ColorStretchDialog'
+                        closeOnValid={false} sx={{pt:.25, pb:1, pl:1}}
+                        onSuccess={replot()} onFail={invalidMessage}
+                    />
+                    <HelpIcon helpId='visualization.modifyColorStretchSingleBand'/>
+                </Stack>
             </Stack>
         </FieldGroup>
        );

--- a/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorRGBHuePreservingPanel.jsx
@@ -1,9 +1,7 @@
 import {Stack, Typography} from '@mui/joy';
 import React, {useEffect} from 'react';
 import {debounce} from 'lodash';
-import {replot3ColorHuePreserving} from './ColorDialog.jsx';
 import {getTypeMinField, renderAsinH, ZscaleCheckbox} from './ColorBandPanel.jsx';
-import {getFieldGroupResults, validateFieldGroup} from '../../fieldGroup/FieldGroupUtils';
 import {ValidationField} from '../../ui/ValidationField.jsx';
 import {RangeSlider} from '../../ui/RangeSlider.jsx';
 import {FieldGroupCollapsible} from '../../ui/panel/CollapsiblePanel.jsx';
@@ -14,8 +12,6 @@ import {dispatchForceFieldGroupReducer} from 'firefly/fieldGroup/FieldGroupCntlr
 const isDebug = () => window.firefly?.debugStretch ?? false;
 
 export const ColorRGBHuePreservingPanel= ({rgbFields,groupKey}) => {
-
-    const doReplot= debounce(getReplotFunc(groupKey), 600);
 
     useEffect(() => {
         dispatchForceFieldGroupReducer(groupKey);
@@ -60,8 +56,8 @@ export const ColorRGBHuePreservingPanel= ({rgbFields,groupKey}) => {
         }
     };
 
-    const asinH = renderAsinH(rgbFields, renderRange(zscaleValue), doReplot, true);
-    const scale = renderScalingCoefficients(rgbFields, doReplot);
+    const asinH = renderAsinH(rgbFields, renderRange(zscaleValue), true);
+    const scale = renderScalingCoefficients(rgbFields);
     return (
         <Stack spacing={2} sx={{mt:1, minWidth:360}}>
             <Typography level='body-sm'>
@@ -85,7 +81,7 @@ const scaleMarks = [
     {label:'1', value: 10}
 ];
 
-function renderScalingCoefficients(fields, replot) {
+function renderScalingCoefficients(fields) {
 
     return (
         <FieldGroupCollapsible  header='Scaling coefficients'
@@ -108,20 +104,8 @@ function renderScalingCoefficients(fields, replot) {
                     label={label}
                     style={{marginTop: 10, marginBottom: 20, marginRight: 15}}
                     decimalDig={2}
-                    onValueChange={replot}
                 />);
             })}
         </FieldGroupCollapsible>
     );
-}
-
-function getReplotFunc(groupKey) {
-    return () => {
-        validateFieldGroup(groupKey).then((valid) => {
-            if (valid) {
-                const request = getFieldGroupResults(groupKey);
-                replot3ColorHuePreserving(request);
-            }
-        });
-    };
 }

--- a/src/firefly/js/visualize/ui/StretchDropDownView.jsx
+++ b/src/firefly/js/visualize/ui/StretchDropDownView.jsx
@@ -13,6 +13,7 @@ import { PERCENTAGE, ZSCALE, SIGMA, STRETCH_LINEAR, STRETCH_LOG, STRETCH_LOGLOG,
     STRETCH_SQUARED, STRETCH_SQRT, STRETCH_ASINH, STRETCH_POWERLAW_GAMMA, } from '../RangeValues.js';
 import {showColorDialog} from './ColorDialog.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {ColorStretchLockButton} from './ColorTableDropDownView';
 
 
 function getLabel(rv,baseLabel) {
@@ -83,7 +84,9 @@ export function StretchDropDownView({toolbarElement}) {
 
     return (
         <SingleColumnMenu>
+            <ColorStretchLockButton/>
             <ToolbarButton text='Color stretch...'
+                           hasCheckBox={true}
                            tip='Change the background image stretch'
                            onClick={() => showColorDialog(toolbarElement)}/>
             <DropDownVerticalSeparator/>

--- a/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
+++ b/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
@@ -216,6 +216,12 @@ function setupRelatedCutout(prim,cutout) {
     cutout.relatedDLEntries.fullImage= prim;
     prim.dlAnalysis.cutoutFullPair= true;
     cutout.dlAnalysis.cutoutFullPair= true;
+    const rBand= prim.dlAnalysis.rBand || cutout.dlAnalysis.rBand;
+    const gBand= prim.dlAnalysis.gBand || cutout.dlAnalysis.gBand;
+    const bBand= prim.dlAnalysis.bBand || cutout.dlAnalysis.bBand;
+    prim.dlAnalysis.rBand= cutout.dlAnalysis.rBand= rBand;
+    prim.dlAnalysis.gBand= cutout.dlAnalysis.gBand= gBand;
+    prim.dlAnalysis.bBand= cutout.dlAnalysis.bBand= bBand;
 
     //?? todo determine if this is right
     if (prim.dlAnalysis.isThis) cutout.dlAnalysis.isThis= true;


### PR DESCRIPTION
#### [Firefly-1740](https://jira.ipac.caltech.edu/browse/FIREFLY-1740), [Firefly-48](https://jira.ipac.caltech.edu/browse/FIREFLY-48): Add `color,strech,and otherlay` lock button to stretch panels

  - [Firefly-1740](https://jira.ipac.caltech.edu/browse/FIREFLY-1740): done
  - [Firefly-48](https://jira.ipac.caltech.edu/browse/FIREFLY-48): done
  - Fixes bug: an issue `Hue preserving stretch`. Scaling coefficients not working
  - Changes `Hue preserving stretch` change  to only work with refresh button like the rest of the panel
  - A little clean on datalink related processing

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1740-color/firefly
- [Firefly-1740](https://jira.ipac.caltech.edu/browse/FIREFLY-1740): `color,strech,and otherlay` lock button is in both color and stretch dropdown. And it color and stretch dialog
- [Firefly-48](https://jira.ipac.caltech.edu/browse/FIREFLY-48): no bounds checking on lower/upper range in data mode
- `Hue preserving stretch` Scaling coefficients now work: you will see the data change when the are changed
-  `Hue preserving stretch` only refreshed when button is pushed.