### PR TITLE
Firefly-1739: better handle table filtering when nothing is selected

### DIFF
--- a/src/firefly/js/drawingLayers/hpx/HpxCatalogUtil.js
+++ b/src/firefly/js/drawingLayers/hpx/HpxCatalogUtil.js
@@ -108,9 +108,9 @@ async function executeFiltering(promiseAry) {
     if (foundCnt<resultAry.length) {
         const notCovCnt= resultAry.length - foundCnt;
         const desc= notCovCnt===1
-            ? 'One table is not covered in this selection, it will be filtered to zero rows'
-            : `${notCovCnt} tables are not covered in this selection, they will be filtered to zero rows`;
-        showInfoPopup(desc, `${notCovCnt} ${notCovCnt===1 ? 'table' : 'tables'} not covered`);
+            ? 'This selection omits a table. It will be filtered down to have zero rows.'
+            : `This selection omits ${notCovCnt} tables. They will be filtered down to have zero rows.`;
+        showInfoPopup(desc, `${notCovCnt} ${notCovCnt===1 ? 'table' : 'tables'} omitted`);
     }
 }
 


### PR DESCRIPTION
#### [Firefly-1739](https://jira.ipac.caltech.edu/browse/FIREFLY-1739): better handle table filtering when nothing is selected


#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1739-filtering/firefly
- search two or three catalogs
- do a selection that does not include any - you should get a warning
- do a selection that just covers some
   - you should get a warning
   - the covered tables will be filtered
   - the non-covered tables will be filtered to zero rows