### PR TITLE
FIREFLY-1749: HTML sanitizer removes supported features

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
@@ -60,6 +60,7 @@ public class TableMeta implements Serializable {
 
     public static final String RESULTSET_ID = "resultSetID";            // this meta if exists contains the ID of the resultset returned.
     public static final String RESULTSET_REQ = "resultSetRequest";      // this meta if exists contains the Request used to create this resultset.
+    public static final String DATA_ORIGIN = "data_origin";             // with values like, "internal", "external", or others future values
 
 
     public static final String ID = "ID";

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1591,6 +1591,10 @@ export function isHtml(text) {
     return HtmlRegex.test(text);
 }
 
+export function isExternalSource(tableOrId) {
+    return getMetaEntry(tableOrId, 'data_origin', '') === 'external';
+}
+
 export function cleanHtml(text) {
     const clean = DOMPurify.sanitize(text);
     if (DOMPurify.removed) logger.debug(`cleanHtml removed: ${DOMPurify.removed}`);


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1749
The recently added HTML sanitizer is removing features that are currently supported

**Solution**
Introduce a `data_origin` in the table metadata to indicate whether a table is externally sourced.
Apply HTML sanitization only to externally sourced table data.
Internally generated tables will bypass the sanitizer, retaining all supported features.

Test: https://firefly-1749-sanitize-external-table.irsakudev.ipac.caltech.edu/
- Search for Source: enter 'm31' -> click Search
Click on both `To IRSAViewer` and `To WISE Image Service` should open a new browser tab/window.