### PR TITLE
FIREFLY-1753: Fix Charts X/Y Ratio ui cutting off problem

### DIFF
--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -251,7 +251,7 @@ function XyRatio({groupKey, Xyratio, Stretch, xNoLog}) {
                 Enter display aspect ratio below.<br/>
                 Leave it blank to use all available space.
             </Typography>
-            <Stack spacing={2} direction={'row'}>
+            <Stack>
                 <Xyratio/>
                 {showStretch && <Stretch/>}
             </Stack>

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -246,12 +246,12 @@ function XyRatio({groupKey, Xyratio, Stretch, xNoLog}) {
 
     if (xNoLog) return null;
     return (
-        <Stack spacing={.5}>
+        <Stack spacing={0.5}>
             <Typography level='body-sm'>
                 Enter display aspect ratio below.<br/>
                 Leave it blank to use all available space.
             </Typography>
-            <Stack>
+            <Stack spacing={1}>
                 <Xyratio/>
                 {showStretch && <Stretch/>}
             </Stack>


### PR DESCRIPTION
View [ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-1753) for details.

To test:
Euclid: https://firefly-1753-euclid-xyratio.irsakudev.ipac.caltech.edu/applications/euclid

- do Search by ID = -606624697489151697
- in spectrum view, click on option gear and expand Chart Options, enter an X/Y ratio, the Stretch to: height and width selection will appear below the X/Y ration input

SHA: https://firefly-1753-sha-xyration.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA

- do position search for PBCD, m51
- in the result table apply filter with `File Type` as "Table", in spectrum view, try enter X/Y ratio.