### PR TITLE
FIREFLY-1752: Send to background requires 2 clicks

### DIFF
--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -55,9 +55,9 @@ export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, mask, show
         return (
             <MaskP msg={msg} jobInfo={jobInfo} mask={mask} {...props}>
                 <Stack direction='row' spacing={1}>
-                    <Button variant='solid' color='primary' onClick={doHide}>Send to background</Button>
-                    <Button variant='solid' color='primary' onClick={doShowMonitor}>Job Monitor</Button>
-                    <Button variant='soft' onClick={doCancel}>Cancel</Button>
+                    <Button variant='solid' disabled={!jobInfo} color='primary' onClick={doHide}>Send to background</Button>
+                    <Button variant='solid' disabled={!jobInfo} color='primary' onClick={doShowMonitor}>Job Monitor</Button>
+                    <Button variant='soft' disabled={!jobInfo} onClick={doCancel}>Cancel</Button>
                 </Stack>
             </MaskP>
         );


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1752

To reproduce: see ticket
Solution: disable button until JobInfo is available to avoid race condition

To test: 
https://firefly-1752-sendto-background-click-twice.irsakudev.ipac.caltech.edu/irsaviewer/
- Catalogs Search -> Send to background 

https://firefly-1752-sendto-background-click-twice.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA/
- Search by Position -> select first AOR -> Prepare Download 
- Select Level 2 -> click Prepare Download -> Send to background

In both cases, it should work as expected.
