### PR TITLE
Enable pinning charts/table for Spectra

### DIFF
--- a/src/firefly/js/charts/ui/PinnedChartContainer.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartContainer.jsx
@@ -139,11 +139,11 @@ export const PinChart = ({viewerId, tbl_group}) => {
     return <PinButton onClick={doPinChart} tip='Pin this chart'/>;
 };
 
-export function pinChart({chartId, autoLayout=false }) {
+export function pinChart({chartId, autoLayout=false, displayPinMessage=true }) {
 
 
     if (!isChartLoading(chartId)) {
-        doPinChart({chartId,autoLayout});
+        doPinChart({chartId,autoLayout, displayPinMessage});
         return;
     }
     // there are cases when chart is not fully loaded.  if so, wait before pinning the chart
@@ -155,7 +155,7 @@ export function pinChart({chartId, autoLayout=false }) {
             }
             if (!isChartLoading(chartId)) { //chart is fully loaded now
                 cancelSelf?.();
-                doPinChart({chartId, autoLayout});
+                doPinChart({chartId, autoLayout, displayPinMessage});
             }
         }
     });
@@ -174,7 +174,7 @@ export function BadgeLabel({labelStr}) {
         );
 }
 
-function doPinChart({chartId, autoLayout=true }) {
+function doPinChart({chartId, autoLayout=true, displayPinMessage=true }) {
 
     const chartData = cloneDeep(omit(getChartData(chartId), ['_original', 'mounted']));
     chartData?.tablesources?.forEach((ts) => Reflect.deleteProperty(ts, '_cancel'));
@@ -199,7 +199,9 @@ function doPinChart({chartId, autoLayout=true }) {
             setLayout(true);
         }
         const {sideBySide} = getComponentState(PINNED_CHART_VIEWER_ID);
-        if (!sideBySide) showPinMessage('Pinning chart');
+        if (!sideBySide) {
+            if (displayPinMessage) showPinMessage('Pinning chart');
+        }
     };
 
     if (!chartData?.layout?.title?.text) {

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -9,11 +9,9 @@ import {dpdtChartTable, dpdtImage, dpdtTable, DPtypes, SHOW_CHART, SHOW_TABLE} f
 import {FileAnalysisType, Format, TableDataType, UIEntry, UIRender} from '../data/FileAnalysis';
 import {RequestType} from '../visualize/RequestType.js';
 import {TitleOptions} from '../visualize/WebPlotRequest';
-import {createChartTableActivate, createChartSingleRowArrayActivate, createTableExtraction} from './TableDataProductUtils.js';
+import {createChartTableActivate, createChartSingleRowArrayActivate, createTableExtraction, getExtractionText
+} from './TableDataProductUtils.js';
 import {createSingleImageActivate, createSingleImageExtraction} from './ImageDataProductsUtil';
-
-
-const extractionText= 'Pin Table';
 
 /**
  *
@@ -311,6 +309,7 @@ function makeSingleRowChartTableResult({ddTitleStr,source,activateParams,chartIn
     const activate= createChartSingleRowArrayActivate(source,titleStr,activateParams,chartInfo,0,paIdx);
     const extraction= createTableExtraction(source,titleStr,paIdx, imageAsTableInfo,
         0, chartInfo.tableDataType);
+    const extractionText = getExtractionText(chartInfo.tableDataType);
     return dpdtChartTable(ddTitleStr, activate,extraction, undefined,
         {extractionText, paIdx, chartTableDefOption, interpretedData, dropDownText});
 }
@@ -319,6 +318,7 @@ function makeChartTableResult({part, source, chartTableDefOption, ddTitleStr, ti
                                   chartId, activateParams, dropDownText, chartInfo,imageAsTableInfo}) {
     const {interpretedData=false}= part;
     const {tableDataType} = chartInfo;
+    const extractionText = getExtractionText(tableDataType);
     if (!imageAsTableInfo?.cubePlanes) {
         const extraction = createTableExtraction(source, titleInfo, tbl_index, imageAsTableInfo, 0, tableDataType);
         const activate = createChartTableActivate({
@@ -349,6 +349,7 @@ function makeChartTableResult({part, source, chartTableDefOption, ddTitleStr, ti
 function makeTableOnlyResult({ddTitleStr,tbl_id,source,titleInfo,tbl_index,imageAsTableInfo,
                                  activateParams, dropDownText}) {
     const {cubePlanes=0}= imageAsTableInfo;
+    const extractionText = 'Pin Table';
     if (cubePlanes===0) {
         const extraction= createTableExtraction(source,titleInfo,tbl_index, imageAsTableInfo, 0, '');
         const activate= createChartTableActivate({source,titleInfo,activateParams, tbl_index, imageAsTableInfo, tbl_id});


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1755
- **IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/414
- Enable pinning of `Table/Spectrum` (or `Table/Chart`) in the multi product viewer
- Logic is slightly different from just pinning an active chart, so per @loitly 's suggestion, I added a `Pin Chart/Table` (or `Pin Spectrum/Table`) button to enable pinning
    - cloning the table and fetch/search the new table with a new table ID is necessary because once you leave the Spectra tab, the `MultiChartViewer` component logic removes the table/chart upon unmounting (and hence you won't see the spectra in the `Pinned Chart` tab)
- passing in a prop `enablePinning` (defaults to false) determines if we show this button 
   - passing this in to `MultiProductViewerContainer` and `MetaDataMultiProductViewer` as these two components are independent and not necessarily called in this order (and then through to `MultiProductViewer` and `MultiProductChoice`)
- I'm pinning both the `Table` and the `Spectrum` (by adding table to UI using `dispatchTableSearch`)
   - if we don't wish to pin the Table, I can use `dispatchTableFetch` instead, only pinning the spectra in that case 

**Testing**: 
**Euclid**: https://firefly-1755-euclid-pin-spectra.irsakudev.ipac.caltech.edu/applications/euclid
- Do  a `Search by ID` search using any of these IDs: 
```
objectid    | tileid
---------------------+-----------
 2744680221654042404 | 102158895
 2742712297656044185 | 102158895
 2725778563673942907 | 102160061
 2721023473674756138 | 102160061
 2675273767649224116 | 102158583
 2716724967686301900 | 102160610
 2717129956683555247 | 102160610
 2717169855685117224 | 102160610
 2717237123686249836 | 102160610
 2717332793686082333 | 102160610
 2717339959683740929 | 102160610
 2717452413684054616 | 102160610
 2717543671686043340 | 102160610
 2717714979684089988 | 102160610
 2717844939685270525 | 102160610
 2717910101685433290 | 102160610
 2718025525685672387 | 102160610
 2718406919683764798 | 102160610
 2718418011682818394 | 102160610
```

Or do an `Inspect Objects` search on any of these locations:  (corresponding object and tile id contain spectra in the results table): 
```
|      object_id|        tileid|        ra|       dec|
  2675273767649224116       102158583   267.52737674    64.9224117
  2716724967686301900       102160610   271.67249671   68.630190029
  2717129956683555247       102160610   271.71299569   68.355524741
  2717169855685117224       102160610   271.71698559   68.511722421
  2717237123686249836       102160610   271.72371231   68.624983617
  2717332793686082333       102160610    [271.7332794](tel:2717332794)   68.608233363
  2721023473674756138       102160061   272.10234732   67.475613865
  2725778563673942907       102160061   272.57785634   67.394290721
  2742712297656044185       102158895   274.27122978   65.604418567
  2744680221654042404       102158895   274.46802211   65.404240434
```

- These should return valid spectra. Try a few different (2-3) searches. 
- Go to the spectra tab. 
- Attempt to `Pin Spectrum/Table` here. 
- Go to the Pinned Chart tab and ensure you can see the 2-3 pinned spectra there. 
- Also pin the active chart, ensure you see all pinned charts/spectra in the `Pinned Chart` tab.
- try and combine spectra in the `Pinned Charts` tab (you may even pin the same spectrum twice for this if you only did 1 search)