### PR TITLE
FIREFLY-1703: SPHEREx: support URL API

### DIFF
--- a/src/firefly/js/api/WebApi.js
+++ b/src/firefly/js/api/WebApi.js
@@ -1,10 +1,10 @@
 import {isEmpty, isArray, isObject} from 'lodash';
-import React from 'react';
 import {WSCH} from '../core/History';
 import {dispatchAddActionWatcher} from '../core/MasterSaga.js';
 import {Logger} from '../util/Logger.js';
 import {isDefined} from '../util/WebUtil';
 import {makeWorldPt, parseWorldPt} from '../visualize/Point';
+import {dispatchActiveTarget} from 'firefly/core/AppDataCntlr';
 
 
 const API_STR= 'api';
@@ -429,3 +429,14 @@ export function getReservedParamKeyDesc(paramKey) {
     }
 
 }
+
+
+export const processSpatialReservedParams= (inParams) => {
+    const params= {...inParams};
+    if (params[ReservedParams.POSITION.name]) dispatchActiveTarget(params[ReservedParams.POSITION.name]);
+    if (params[ReservedParams.SR.name]) {
+        params.radiusInArcSec= params[ReservedParams.SR.name] * 3600;
+        Reflect.deleteProperty(params, ReservedParams.SR.name);
+    }
+    return params;
+};

--- a/src/firefly/js/ui/CatalogSearchMethodType.jsx
+++ b/src/firefly/js/ui/CatalogSearchMethodType.jsx
@@ -308,7 +308,7 @@ function SizeArea({groupKey, searchType, imageCornerCalc}) {
     }
 }
 
-export function PolygonDataArea({imageCornerCalc,
+export function PolygonDataArea({imageCornerCalc, initValue='',
                                           hipsUrl= getAppOptions().coverage?.hipsSourceURL  ??  'ivo://CDS/P/2MASS/color',
                                           centerWP, fovDeg=240, showCornerTypeField=true, slotProps }) {
     let cornerTypeOps=
@@ -354,6 +354,7 @@ export function PolygonDataArea({imageCornerCalc,
                 centerPt:wp,
                 label:'Coordinates:',
                 tooltip:'Enter polygon coordinates search',
+                initValue,
                 ...slotProps?.polygonPanel
             }} />
             <Typography level='body-sm' component='ul' sx={{pl:1, li: {listStyleType: 'none'}}} {...slotProps?.polygonHelp}>
@@ -368,6 +369,7 @@ export function PolygonDataArea({imageCornerCalc,
 
 PolygonDataArea.propTypes = {
     imageCornerCalc: string,
+    initValue: string,
     hipsUrl: string,
     centerWP: string,
     fovDeg: number,

--- a/src/firefly/js/ui/CompleteButton.jsx
+++ b/src/firefly/js/ui/CompleteButton.jsx
@@ -67,7 +67,29 @@ async function onClick(onSuccess, onFail, registeredComponents, closeOnValid, gr
     if (continueValid && dialogId && closeOnValid) dispatchHideDialog(dialogId);
 }
 
-
+/**
+ * Button that collects inputs from the field group and handles validation, etc. before submitting.
+ *
+ * @param p
+ * @param p.onFail
+ * @param p.onSuccess
+ * @param p.groupKey
+ * @param p.text
+ * @param p.color
+ * @param p.variant
+ * @param p.requireAllValid
+ * @param p.closeOnValid
+ * @param p.dialogId
+ * @param p.includeUnmounted
+ * @param p.primary
+ * @param p.style
+ * @param p.sx
+ * @param p.changeMasking
+ * @param p.fireOnEnter
+ * @param p.getDoOnClickFunc - callback function that allows the parent component to retrieve the `onComplete` function,
+ * usually for programmatically triggering the button's click behavior.
+ * @returns {Element}
+ */
 export function CompleteButton ({onFail, onSuccess, groupKey=null, text='OK',
                           color=undefined, variant=undefined, requireAllValid=true,
                           closeOnValid=true, dialogId,includeUnmounted= false, primary=true,

--- a/src/firefly/js/ui/SearchPanel.jsx
+++ b/src/firefly/js/ui/SearchPanel.jsx
@@ -129,6 +129,15 @@ function searchesAsTabs(allSearchItems, initArgs) {
 
 const searchOnce= makeSearchOnce(); // setup options to immediately execute the search the first time
 
+/**
+ * Execute the `clickFunc` the first time if `initArgs.urlApi.execute` is true and
+ * if `initArgs.urlApi.searchoption` matches `searchItem`.
+ *
+ * @param clickFunc - generally, a function that gets called when FormPanel's complete button is clicked.
+ * @param initArgs - initial arguments containing `urlApi` parameters.
+ * @param searchItem - only relevant to HydraViewer based apps that use `SearchPanel`. Ignored if there is no
+ * `initArgs.urlApi.searchoption` defined.
+ */
 export function executeOK(clickFunc,initArgs,searchItem) {
     searchOnce(
         () => {

--- a/src/firefly/js/ui/tap/ObsCoreExposureDuration.jsx
+++ b/src/firefly/js/ui/tap/ObsCoreExposureDuration.jsx
@@ -22,6 +22,7 @@ const ONE_POPULATED= 'at least one field must be populated';
 const panelTitle = 'Timing';
 const panelValue = 'Exposure';
 const panelPrefix = getPanelPrefix(panelValue);
+export const exposurePanelId = panelPrefix;
 const exposureRangeOptions = [
     {label: 'Completed in the Last...', value: 'since' },
     {label: 'Overlapping specified range', value: 'range'}
@@ -110,7 +111,7 @@ function makeExposureConstraints(rangeType, fldObj) {
 }
 
 
-const checkHeaderCtl= makeCollapsibleCheckHeader(getPanelPrefix(panelValue));
+const checkHeaderCtl= makeCollapsibleCheckHeader(exposurePanelId);
 const {CollapsibleCheckHeader, collapsibleCheckHeaderKeys}= checkHeaderCtl;
 
 const fldListAry= ['exposureSinceValue', 'exposureLengthMin', 'exposureLengthMax',

--- a/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/TapSearchRootPanel.jsx
@@ -70,10 +70,11 @@ const initApiAddedServiceOnce= once((initArgs) => {
  * @param {TapBrowserState} tapBrowserState
  * @return {boolean} true if the field are valid to doa search
  */
-function validateAutoSearch(fields, initArgs, tapBrowserState) {
+export function validateAutoSearch(fields, initArgs, tapBrowserState) {
     const {urlApi = {}} = initArgs;
     if (urlApi.adql) return true;
-    if (!getAdqlQuery(tapBrowserState, false)) return false; // if we can't build a query then we are not initialized yet
+    // disable column constraints otherwise we will get recursion error because they aren't ready by the time we execute a urlApi search
+    if (!getAdqlQuery(tapBrowserState, '', false)) return false; // if we can't build a query then we are not initialized yet
     const {valid, where} = getHelperConstraints(tapBrowserState);
     if (!valid) return false;
     const notWhereArgs = ['MAXREC', 'execute', 'schema', 'service', 'table'];
@@ -193,7 +194,7 @@ function TapSearchPanelImpl({initArgs= {}, titleOn=true, lockService=false, lock
     return (
         <Box width={1} height={1}>
             <ConstraintContext.Provider value={ctx}>
-                <FormPanel  onSuccess={(request) => onTapSearchSubmit(request, serviceUrl, tapState)}
+                <FormPanel  onSuccess={(request) => onTapSearchSubmit({request, serviceUrl, tapBrowserState: tapState})}
                             cancelText=''
                             help_id = {tapHelpId('form')}
                             slotProps={{

--- a/src/firefly/js/ui/tap/WavelengthPanel.jsx
+++ b/src/firefly/js/ui/tap/WavelengthPanel.jsx
@@ -25,6 +25,7 @@ import {omit} from 'lodash';
 const panelTitle = 'Spectral Coverage';
 const panelValue = 'Wavelength';
 const panelPrefix = getPanelPrefix(panelValue);
+export const wavelengthPanelId = panelPrefix;
 
 const obsCoreWvlFieldKeys = {
     selectionType: 'obsCoreWavelengthSelectionType',
@@ -107,13 +108,19 @@ function makeWavelengthConstraints(filterDefinitions, fldObj) {
 
 }
 
-const checkHeaderCtl= makeCollapsibleCheckHeader(getPanelPrefix(panelValue));
+const checkHeaderCtl= makeCollapsibleCheckHeader(wavelengthPanelId);
 const {CollapsibleCheckHeader, collapsibleCheckHeaderKeys}= checkHeaderCtl;
 
 export function WavelengthOptions({initArgs, fieldKeys, filterDefinitionsLabel, filterDefinitions, fixedSelectionType,
                                       fixedRangeType, slotProps }) {
-    const [getSelectionType,] = useFieldGroupValue(fieldKeys.selectionType);
+    const [getSelectionType, setSelectionType] = useFieldGroupValue(fieldKeys.selectionType);
     const [getRangeType,] = useFieldGroupValue(fieldKeys.rangeType);
+
+    useEffect(() => {
+        if (Object.keys(initArgs?.urlApi ?? {})?.some((k) => k.startsWith('obsCoreWavelength'))) {
+            setSelectionType('numerical'); //url api doesn't allow selecting filter bands, so we default to numerical
+        }
+    }, [initArgs?.urlApi]);
 
     const hasFilters = filterDefinitions?.length > 0;
     const useFilters = hasFilters && (fixedSelectionType
@@ -165,7 +172,7 @@ export function WavelengthOptions({initArgs, fieldKeys, filterDefinitionsLabel, 
                                     {label: 'contains', value: 'contains'},
                                     {label: 'overlaps', value: 'overlaps'},
                                 ]}
-                                initialState={{value: initArgs?.urlApi?.rangeType || 'contains'}}
+                                initialState={{value: initArgs?.urlApi?.[fieldKeys.rangeType] || 'contains'}}
                                 label='Select observations whose wavelength coverage'
                                 orientation='vertical'
                                 multiple={false}
@@ -178,11 +185,14 @@ export function WavelengthOptions({initArgs, fieldKeys, filterDefinitionsLabel, 
                             <WavelengthInputField fieldKey={fieldKeys.wvlContains}
                                                   inputStyle={{ overflow: 'auto', height: 16 }}
                                                   placeholder='enter wavelength'
+                                                  {...slotProps?.wvlContains}
                                                   initialState={{
-                                                      value: initArgs?.urlApi?.wvlContains || '',
-                                                      unit: initArgs?.urlApi?.wvlUnits || 'nm'
-                                                  }}
-                                                  {...slotProps?.wvlContains} />
+                                                      unit: 'nm', //unit that shows up in the units dropdown
+                                                      ...slotProps?.wvlContains?.initialState,
+                                                      value: initArgs?.urlApi?.[fieldKeys.wvlContains], //always in BASE_UNIT
+                                                      //we don't need `unit` from initArgs since its purpose is only for display:
+                                                      //displayValue that shows in input field is computed with value and unit
+                                                  }}/>
                         </div>
                     )}
                     {useRangeOverlaps && (
@@ -190,18 +200,20 @@ export function WavelengthOptions({initArgs, fieldKeys, filterDefinitionsLabel, 
                                               {...slotProps?.wvlRange}
                                               slotProps={{
                                                   wvlMin: {
+                                                      ...slotProps?.wvlMin,
                                                       initialState: {
-                                                          value: initArgs?.urlApi?.wvlMin || '',
-                                                          unit: initArgs?.urlApi?.wvlUnits || 'nm'
+                                                          unit: 'nm',
+                                                          ...slotProps?.wvlMin?.initialState,
+                                                          value: initArgs?.urlApi?.[fieldKeys.wvlMin],
                                                       },
-                                                      ...slotProps?.wvlMin
                                                   },
                                                   wvlMax: {
+                                                      ...slotProps?.wvlMax,
                                                       initialState: {
-                                                          value: initArgs?.urlApi?.wvlMax || '',
-                                                          unit: initArgs?.urlApi?.wvlUnits || 'nm'
+                                                          unit: 'nm',
+                                                          ...slotProps?.wvlMax?.initialState,
+                                                          value: initArgs?.urlApi?.[fieldKeys.wvlMax],
                                                       },
-                                                      ...slotProps?.wvlMax
                                                   }
                                               }}/>
                     )}


### PR DESCRIPTION
Fixes [FIREFLY-1703](https://jira.ipac.caltech.edu/browse/FIREFLY-1703)

### Changes in TAP url api so that LVF url api can build upon it
* Exposed polygon input as `polygon` parameter and updated `PolygonDataArea` component to accept an `initValue`
* Exposed spatial region operations in ObsTAP (`contains_point`, `intersects`, etc.) as `spatialRegionOperation` parameter 
* Made it possible for url api to control panel active states - needed when executing the search but the constraint panel doesn't expand and get checked
* Deprecated the `obsCoreWavelengthUnits` parameter, defaulting it to a base unit because `WavelengthInputField` has evolved since its URL api was written

### Changes in SPHEREx:
See ife PR: https://github.com/IPAC-SW/irsa-ife/pull/415

* Added url API for SPHEREx LVF, **reusing** TAP's API wherever possible
* Added a one-time auto-search logic to automatically execute a search if `initArgs.urlApi.execute` is set

### Bonus:
* Moved the redundant code for handling spatial reserved parameters (`POSITION`, `SR`) into a new `processSpatialReservedParams` function. Using this now in Euclid, TAP, LVF.
* Allowed disabling of column constraints in TAP search. Needed for TAP urlAPI because it leads to recursion error otherwise when execute was being performed and for LVF search because it doesn't use TableColumnsConstraints
* Added JSDoc comments to `CompleteButton` and `executeOK` functions while I was studying how specific parameters in them work

## Testing
Try different examples, build your own:
- SPHEREx URL API: https://firefly-1703-spherex-url-api.irsakudev.ipac.caltech.edu/applications/spherex/?api

> ~Note: the last example (that combines Location and Wavelength constraints) is kinda finicky and may need more debugging~ **works now!**

### Regression test
- Firefly TAP URL API (scroll down to tap command): https://fireflydev.ipac.caltech.edu/firefly-1703-spherex-url-api/firefly/?api - test the changed/added examples, make sure TAP searches can be executed which are failing on nightly
- Firefly TAP Panel: test an obscore search to see if it's working as before (esp Spatial, Wavelength): https://fireflydev.ipac.caltech.edu/firefly-1703-spherex-url-api/firefly/?__action=layout.showDropDown&view=TAPSearch
