### PR TITLE
FIREFLY-1766: TAP jobs remain stuck in PENDING status.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -236,7 +236,7 @@ public class JobUtil {
         ifNotNull(toParameters(json.get(PARAMETERS))).apply(p -> rval.setParams(p));
         ifNotNull(toResults(json.get(RESULTS))).apply(r -> rval.setResults(r));
 
-        ifNotNull(json.get(ERROR)).apply(v -> {
+        ifNotNull(json.get(ERROR_SUMMARY)).apply(v -> {
             if (v instanceof JSONObject jo) {
                 int code = getInt(jo.get(ERROR_TYPE), 500);
                 String msg = String.valueOf(jo.get(ERROR_MSG));

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -91,9 +91,9 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
             {/*{ meta?.runId && <KeywordBlock key='localRunId' label='local runId' value={meta.runId}/>}*/}
             { hasMoreSection && (
                 <CollapsibleGroup>
+                    <OptionalBlock label='Error Summary' title='Referred to as "errorSummary" in UWS' value={errorSummary} isOpen={isOpen}/>
                     <OptionalBlock label='Parameters' title='Referred to as "parameters" in UWS' value={parameters} isOpen={isOpen}/>
                     <OptionalBlock label='Results' title='Referred to as "results" in UWS' value={hrefs} asLink={true} isOpen={isOpen}/>
-                    <OptionalBlock label='Error Summary' title='Referred to as "errorSummary" in UWS' value={errorSummary} isOpen={isOpen}/>
                     <OptionalBlock label='Extra Information' title='Referred to as "jobInfo" in UWS' value={aux} isOpen={isOpen}/>
                 </CollapsibleGroup>
             )}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1766
From ticket:
```
When manually running an ADQL query that references a non-existent database (e.g., SELECT blah FROM asdf.Whatever), the Job Monitor displays the query as “PENDING” indefinitely. After investigating, it appears the TAP processor fails to detect and handle the ERROR status after the query is submitted.
```

Test: https://fireflydev.ipac.caltech.edu/firefly-1766-tap-job-pending/firefly/
- Go to TAP -> Edit ADQL
- ADQL Query: enter 'select abc from xzy'
- Click Search
You should get an error message.  Go to Job Monitor to see that the phase is ERROR.

Try a different service, e.g. CADC
Repeat the above steps and the results should be the same.
 