### PR TITLE
FIREFLY-1757: Load Euclid and SPHEREx results from Job Monitor

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -150,7 +150,14 @@ public class JobManager {
         return info;
     }
 
-    static void handleAborted(JobInfo jobInfo) {
+    public static void removeJob(String jobId) {
+        ifNotNull(getJobInfo(jobId)).apply(ji -> {
+            allJobInfos.remove(cacheKey(ji));
+            removeLocalJob(ji);
+        });
+    }
+
+    static void removeLocalJob(JobInfo jobInfo) {
         if (jobInfo == null) return;
         JobEntry jobEntry = runningJobs.get(jobInfo.getMeta().getJobId());
         if (jobEntry != null) {
@@ -419,7 +426,7 @@ public class JobManager {
             ifNotNull(JobEvent.getJobInfo(msg)).apply(jobInfo -> {
                 JobEvent.EventType type = Try.it(() -> JobEvent.EventType.valueOf(msg.getValue(null, JobEvent.TYPE))).get();
                 if (type == JobEvent.EventType.ABORTED) {
-                    handleAborted(jobInfo);
+                    removeLocalJob(jobInfo);
                 } else {
                     updateClient(jobInfo);        // update jobInfo to client
                 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -110,7 +110,7 @@ public class JobUtil {
                 Document doc = parse(r.getResponseBodyAsStream());
                 jobList.set(convertToJobList(doc, url));
             }).getOrElse(e -> {
-                throw new UnsupportedOperationException(e.getMessage());
+                LOG.error("Failed to import job histories from %s: %s".formatted(url, e.getMessage()));
             });
            return HttpServices.Status.ok();
         });

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
@@ -304,7 +304,8 @@ public class SearchServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             String jobId = params.getRequired(JOB_ID);
-            JobInfo info = JobManager.setMonitored(jobId, false);
+            JobInfo info = JobManager.setMonitored(jobId, false);       // this removes if from the client job list
+            JobManager.removeJob(jobId);        // stop(if needed) and remove from the server
             return JobUtil.toJson(info);
         }
     }

--- a/src/firefly/js/rpc/SearchServicesJson.js
+++ b/src/firefly/js/rpc/SearchServicesJson.js
@@ -10,9 +10,8 @@
 import {get, pickBy, cloneDeep, has, isUndefined} from 'lodash';
 import {ServerParams} from '../data/ServerParams.js';
 import {doJsonRequest} from '../core/JsonUtils.js';
-import {submitJob, getJobInfo, Phase} from '../core/background/BackgroundUtil.js';
-import {dispatchBgJobInfo} from '../core/background/BackgroundCntlr.js';
-import {encodeUrl, updateSet, getCmdSrvSyncURL} from '../util/WebUtil.js';
+import {submitJob} from '../core/background/BackgroundUtil.js';
+import {encodeUrl, getCmdSrvSyncURL} from '../util/WebUtil.js';
 
 import {getTblById, getResultSetID, getResultSetRequest} from '../tables/TableUtil.js';
 import {MAX_ROW, getTblId, setResultSetID, setResultSetRequest, setSelectInfo} from '../tables/TableRequestUtil.js';
@@ -207,11 +206,7 @@ export function addBgJob(jobId) {
  */
 export function removeBgJob(jobId) {
     const params = {[ServerParams.JOB_ID]: jobId};
-    return doJsonRequest(ServerParams.REMOVE_JOB, params).then( (jobInfo) => {
-        if (!jobInfo) {     // job is not on the server.. remove it locally
-            dispatchBgJobInfo(updateSet(getJobInfo(jobId), 'phase', Phase.ARCHIVED));
-        }
-    });
+    return doJsonRequest(ServerParams.REMOVE_JOB, params);
 }
 
 /**

--- a/src/firefly/js/tables/TableRequestUtil.js
+++ b/src/firefly/js/tables/TableRequestUtil.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, set, unset, cloneDeep, omit, omitBy, isNil, pickBy, uniqueId} from 'lodash';
+import {get, set, unset, cloneDeep, omit, omitBy, isNil, pickBy, uniqueId, merge} from 'lodash';
 
 import {getTblById, uniqueTblId} from './TableUtil.js';
 import {SelectInfo} from './SelectInfo.js';
@@ -40,6 +40,9 @@ export function makeTblRequest(id, title, params={}, options={}) {
     const tbl_id = options.tbl_id || uniqueTblId();
     var META_INFO = pickBy(Object.assign(options.META_INFO || {}, {title, tbl_id}));
     options = omit(options, 'tbl_id');
+    if (params.META_INFO) {     // if META_INFO is provided as params, merge it with the options.META_INFO
+        merge(META_INFO, params.META_INFO);
+    }
     return omitBy(Object.assign({startIdx: 0}, options, params, {META_INFO, tbl_id, id}), isNil);
 }
 
@@ -139,6 +142,9 @@ export function makeIrsaCatalogRequest(title, project, catalog, params={}, optio
     options = omit(options, 'tbl_id');
     params = omit(params, 'position');
 
+    if (params.META_INFO) {     // if META_INFO is provided as params, merge it with the options.META_INFO
+        merge(META_INFO, params.META_INFO);
+    }
     return omitBy(Object.assign({startIdx: 0}, options, params, {id, tbl_id, META_INFO, UserTargetWorldPt, catalogProject, catalog}), isNil);
 }
 
@@ -161,6 +167,9 @@ export function makeVOCatalogRequest(title, params={}, options={}) {
     options = omit(options, 'tbl_id');
     params = omit(params, 'position');
 
+    if (params.META_INFO) {     // if META_INFO is provided as params, merge it with the options.META_INFO
+        merge(META_INFO, params.META_INFO);
+    }
     return omitBy({startIdx: 0, ...options, ...params, id, tbl_id, META_INFO, UserTargetWorldPt}, isNil);
 }
 

--- a/src/firefly/js/tables/TableRequestUtil.js
+++ b/src/firefly/js/tables/TableRequestUtil.js
@@ -38,7 +38,7 @@ export const META = {
 export function makeTblRequest(id, title, params={}, options={}) {
     title = title ?? id;
     const tbl_id = options.tbl_id || uniqueTblId();
-    var META_INFO = pickBy(Object.assign(options.META_INFO || {}, {title, tbl_id}));
+    const META_INFO = cloneDeep({...options.META_INFO, title, tbl_id});
     options = omit(options, 'tbl_id');
     if (params.META_INFO) {     // if META_INFO is provided as params, merge it with the options.META_INFO
         merge(META_INFO, params.META_INFO);
@@ -137,7 +137,7 @@ export function makeIrsaCatalogRequest(title, project, catalog, params={}, optio
     const id = 'GatorQuery';
     const UserTargetWorldPt = params.UserTargetWorldPt || params.position;  // may need to convert to worldpt.
     const catalogProject = project;
-    var META_INFO = pickBy(Object.assign(options.META_INFO || {}, {title, tbl_id}));
+    const META_INFO = cloneDeep({...options.META_INFO, title, tbl_id});
 
     options = omit(options, 'tbl_id');
     params = omit(params, 'position');
@@ -162,7 +162,7 @@ export function makeVOCatalogRequest(title, params={}, options={}) {
     const tbl_id = options.tbl_id || uniqueTblId();
     const id = voProviders[params.providerName] || 'ConeSearchByURL';
     const UserTargetWorldPt = params.UserTargetWorldPt || params.position;  // may need to convert to worldpt.
-    const META_INFO = {...options.META_INFO, title, tbl_id};
+    const META_INFO = cloneDeep({...options.META_INFO, title, tbl_id});
 
     options = omit(options, 'tbl_id');
     params = omit(params, 'position');

--- a/src/firefly/js/templates/router/RouteHelper.jsx
+++ b/src/firefly/js/templates/router/RouteHelper.jsx
@@ -1,15 +1,14 @@
 
-import React, {useEffect} from 'react';
+import React, {createContext, useEffect} from 'react';
 import {oneOfType, string, func} from 'prop-types';
 import {RouterProvider, useNavigate, redirect, useLocation} from 'react-router-dom';
 import {isFunction} from 'lodash';
 import {
-    dispatchOnAppReady, dispatchSetMenu, FORM_CANCEL, FORM_SUBMIT, getMenu
+    dispatchOnAppReady, FORM_CANCEL, FORM_SUBMIT, getMenu
 } from '../../core/AppDataCntlr.js';
 import {
     dispatchHideDropDown,
     dispatchSetLayoutInfo,
-    dispatchShowDropDown,
     getDropDownInfo
 } from '../../core/LayoutCntlr.js';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from '../../core/MasterSaga.js';
@@ -18,6 +17,14 @@ import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {dispatchComponentStateChange, getComponentState} from 'firefly/core/ComponentCntlr.js';
 
 export const ROUTER = 'router';
+
+/**
+ * Context for managing routing-related form data.
+ *
+ * Currently, this context only provides the `submitTo` property,
+ * which specifies the path or route where the form should submit its data.
+ */
+export const RoutedFormContext = createContext({});
 
 const getMenuItems= () => getMenu()?.menuItems;
 
@@ -71,7 +78,11 @@ export function redirectOnMatch(pattern, url, {redirectTo}) {
  */
 export function FormWatcher({submitTo, onCancel, children}) {
     useFormWatcher(submitTo, onCancel);
-    return children;
+    return (
+        <RoutedFormContext.Provider value={{submitTo}}>
+            {children}
+        </RoutedFormContext.Provider>
+    );
 }
 FormWatcher.propTypes = {
     submitTo: oneOfType([string, func]),

--- a/src/firefly/js/templates/router/RoutedApp.jsx
+++ b/src/firefly/js/templates/router/RoutedApp.jsx
@@ -1,14 +1,15 @@
 import React, {useEffect} from 'react';
-import {useOutlet} from 'react-router-dom';
+import {createBrowserRouter, useOutlet} from 'react-router-dom';
 
-import {FireflyLayout} from 'firefly/templates/common/FireflyLayout.jsx';
-import {IrsaFooterSmall} from 'firefly/ui/IrsaFooter.jsx';
+import {FireflyLayout} from '../common/FireflyLayout.jsx';
+import {IrsaFooterSmall} from '../../ui/IrsaFooter.jsx';
 import {useDropdownRoute} from './RouteHelper.jsx';
-import {DropDownContainer} from 'firefly/ui/DropDownContainer.jsx';
-import {startTTFeatureWatchers} from 'firefly/templates/common/ttFeatureWatchers.js';
-import {dispatchNotifyRemoteAppReady, dispatchOnAppReady, dispatchSetMenu} from 'firefly/core/AppDataCntlr.js';
-import {applyLayoutFix, HydraLanding} from 'firefly/templates/hydra/HydraViewer.jsx';
-import {Slot} from 'firefly/ui/SimpleComponent.jsx';
+import {DropDownContainer} from '../../ui/DropDownContainer.jsx';
+import {startTTFeatureWatchers} from '../common/ttFeatureWatchers.js';
+import {dispatchNotifyRemoteAppReady, dispatchOnAppReady, dispatchSetMenu} from '../../core/AppDataCntlr.js';
+import {applyLayoutFix, HydraLanding} from '../hydra/HydraViewer.jsx';
+import {Slot} from '../../ui/SimpleComponent.jsx';
+import {JobMonitor, jobMonitorPath} from '../../core/background/JobMonitor';
 
 
 /*
@@ -96,3 +97,21 @@ export  default function RoutedApp({slotProps, menu, mainPanel, children, dropdo
 }
 
 RoutedApp.propTypes = FireflyLayout.propTypes;
+
+export function createRouter(basename, routes=[]) {
+    return (props) => {
+        const allRoutes = [
+            {
+                path: '/',
+                element: <RoutedApp {...props}/>,
+                children: [
+                    {   path: jobMonitorPath,
+                        element: <JobMonitor/>,
+                    },
+                    ...routes,
+                ]
+            }
+        ];
+        return createBrowserRouter(allRoutes, {basename});
+    };
+}

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -3,14 +3,17 @@
  */
 
 import {Button, Sheet, Stack} from '@mui/joy';
-import React, {useCallback} from 'react';
+import React, {useCallback, useContext} from 'react';
+import {set} from 'lodash';
+
 import {elementType, shape, node, string, func, oneOfType, element, bool, arrayOf} from 'prop-types';
 import CompleteButton from './CompleteButton.jsx';
 import {HelpIcon} from './HelpIcon.jsx';
 import {dispatchHideDropDown} from '../core/LayoutCntlr.js';
-import {dispatchFormCancel, dispatchFormSubmit} from 'firefly/core/AppDataCntlr.js';
-import {Stacker} from 'firefly/ui/Stacker.jsx';
-import {Slot} from 'firefly/ui/SimpleComponent.jsx';
+import {dispatchFormCancel, dispatchFormSubmit} from '../core/AppDataCntlr.js';
+import {Stacker} from './Stacker.jsx';
+import {Slot} from './SimpleComponent.jsx';
+import {RoutedFormContext} from '../templates/router/RouteHelper';
 
 /*
 onSuccess: This function is invoked when the submit button is pressed and all input fields pass validation.
@@ -26,13 +29,17 @@ onCancel: This function is invoked when the cancel button is pressed.
  */
 export const FormPanel = function ({groupKey, onSuccess, onError, onCancel, cancelText='Cancel', completeText='Search', help_id, disabledDropdownHide, slotProps, children, ...rootProps}) {
 
+    const {submitTo} = useContext(RoutedFormContext);
+
     const doSubmit = ((p, valid) => {
 
         const funcToCall = valid ? onSuccess : onError;
-
+        if (submitTo && !p?.META_INFO?.form_submitTo) {
+            set(p, 'META_INFO.form_submitTo', submitTo);
+        }
         const submitted = funcToCall?.(p) ?? valid;
         if (submitted) {
-            dispatchFormSubmit(p);
+            dispatchFormSubmit({submitTo});
             !disabledDropdownHide && dispatchHideDropDown();
         }
         return submitted;

--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -61,6 +61,8 @@ export function onTapSearchSubmit({request, serviceUrl, tapBrowserState, additio
         const hips= getServiceHiPS(serviceUrl);
         const adqlClean = adql.replace(/\s/g, ' ');    // replace all whitespaces with spaces
         const params = {serviceUrl, QUERY: adqlClean};
+        if (request.META_INFO)  params.META_INFO = request.META_INFO;       // pass along META_INFO if it exists
+
         if (isUpload) {
             params.UPLOAD= serverFile;
             params.adqlUploadSelectTable= uploadTableName;


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1757

**Additional changes here**:  https://github.com/IPAC-SW/irsa-ife/pull/419

### Summary:
- Fixed: Load Euclid and SPHEREx results from Job Monitor
- Fixed: Job Monitor tab not always working correctly
- Minor: Refactored RoutedApp
- Fixed: Job deletion not persisting as expected

###  Test 
**Euclid:** https://firefly-1757-routed-load-results.irsakudev.ipac.caltech.edu/applications/euclid/
_** Note: Only background-able searches are saved as jobs; for Euclid, this means "Euclid Catalogs" only._
@robyww @kpuriIpac Should we make Euclid primary searches 'background-able' so that it becomes `jobs`?

- Go to `Euclid Catalogs` -> 267 65 -> click `Search`
- Open the `Job Monitor` tab; confirm your job appears and is marked `COMPLETED`.
- Reload the browser — you should remain on the `Job Monitor` tab.
- Click the ![image](https://github.com/user-attachments/assets/1c514f55-1bcf-4a33-82f6-faff636319cb) icon to load the results into the UI.


**SPHEREx:** https://firefly-1757-routed-load-results.irsakudev.ipac.caltech.edu/applications/spherex/
`Search for LVF images` and `Spectrophotometry` will work.
- Go to one -> m19 -> click Search
- Open the `Job Monitor` tab; confirm your job appears and is marked `COMPLETED`.
- Reload the browser — you should remain on the `Job Monitor` tab.
- Click the ![image](https://github.com/user-attachments/assets/1c514f55-1bcf-4a33-82f6-faff636319cb) icon to load the results into the UI.

