### PR TITLE
Firefly-1667: when HiPS is changed, the associated MOC is added

### DIFF
--- a/src/firefly/js/visualize/task/PlotHipsTask.js
+++ b/src/firefly/js/visualize/task/PlotHipsTask.js
@@ -382,6 +382,17 @@ async function doHiPSChange(rawAction, dispatcher, getState) {
         }
         const s = await result.text();
         const hipsProperties = parseProperties(s);
+
+        const someMocs= getDrawLayersByType(dlRoot(),HiPSMOC.TYPE_ID);
+        if (!blank && someMocs?.length) { //start moc retrieval but don't wait
+            void createHiPSMocLayer({
+                ivoid: getPropertyItem(hipsProperties, 'ivoid'),
+                title: getPropertyItem(hipsProperties, 'obs_title'),
+                hipsUrl: resolvedHipsRootUrl,
+                plot
+            });
+        }
+
         dispatcher(
             {
                 type: ImagePlotCntlr.CHANGE_HIPS,


### PR DESCRIPTION
####[ Firefly-1667](https://jira.ipac.caltech.edu/browse/FIREFLY-1667): when HiPS is changed, the associated MOC is added to the drawing layers

- _Note:_ MOCs are always added not replaced

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1667-moc-adding/firefly
- Test according to the ticket
- Be aware the the MOCs are only added not replaced.  The user can always delete a MOC

