### PR TITLE
FIREFLY-1765: Allow non-array type columns

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/ResourceInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/table/ResourceInfo.java
@@ -53,6 +53,19 @@ public class ResourceInfo implements Serializable, Cloneable {
 
     public Map<String, String> getInfos() { return infos; }
     public void setInfos(Map<String, String> infos) { this.infos = infos; }
+
+    public ResourceInfo copyOf() {
+        ResourceInfo copy = new ResourceInfo();
+        copy.setID(this.ID);
+        copy.setName(this.name);
+        copy.setType(this.type);
+        copy.setUtype(this.utype);
+        copy.setDesc(this.desc);
+        copy.setGroups(new ArrayList<>(this.groups));
+        copy.setParams(new ArrayList<>(this.params));
+        copy.setInfos(new HashMap<>(this.infos));
+        return copy;
+    }
 }
 
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessorTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessorTest.java
@@ -1,0 +1,63 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.firefly.server.persistence;
+
+import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.firefly.util.FileLoader;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.VotableTest;
+import org.apache.logging.log4j.Level;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+
+import static edu.caltech.ipac.firefly.data.sofia.VOSpectraModel.SPECTRADM_UTYPE;
+import static edu.caltech.ipac.firefly.server.persistence.MultiSpectrumProcessor.*;
+import static edu.caltech.ipac.table.TableMeta.UTYPE;
+import static org.junit.Assert.*;
+
+/**
+ * Date: 6/3/25
+ *
+ * @author loi
+ * @version : $
+ */
+public class MultiSpectrumProcessorTest extends ConfigTest {
+
+    private static File testFile
+            ;
+
+    @BeforeClass
+    public static void setUp() {
+        setupServerContext(null);
+        testFile = FileLoader.resolveFile(VotableTest.class, "/multispectrum-array.vot");       // uses same ./table test data directory
+        if (false) Logger.setLogLevel(Level.DEBUG);
+    }
+
+    @Test
+    public void testExtract() {
+        MultiSpectrumProcessor processor = new MultiSpectrumProcessor();
+        TableServerRequest treq = new TableServerRequest(MultiSpectrumProcessor.PROC_ID);
+        treq.setParam(SOURCE, testFile.getAbsolutePath());
+        treq.setParam(MODE, Mode.extract.name());
+        treq.setParam(SEL_ROW_IDX, "0");
+        try {
+            DataGroup table = processor.getData(treq).getData();
+            assertNotNull("Should not be null", table);
+            assertEquals("Should have 694 row", 694, table.size());
+            assertEquals("Should have 18 columns", 18, table.getDataDefinitions().length);
+            assertEquals("Is a Spectrum", SPECTRADM_UTYPE, table.getAttribute(UTYPE));
+            assertEquals("Has defined spectrum data", SPECTRUM_DATA_UTYPE, table.getGroupInfos().getFirst().getUtype());
+            assertEquals("Is photometry spectrum", "photometry", table.getGroupInfos().getFirst().getID());
+            assertTrue("Has Service Descriptor", table.getResourceInfos().getFirst().getUtype().equalsIgnoreCase("adhoc:service"));
+        } catch (Exception e) {
+            Logger.getLogger().error(e);
+            throw new RuntimeException("Failed to process multi-spectrum data", e);
+        }
+    }
+}


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1765

Support Non-Array columns and service descriptor conversion in MultiSpectrum array-data files.

Test:  https://fireflydev.ipac.caltech.edu/firefly-1765-multispectrum-extract/firefly/
- Upload the test table attached in the ticket.  It has the added `ra/dec` columns.
- Verify that columns ra and dec appear in the extracted table under the Data Product tab.
- Note: The service descriptor is not visible in the UI. This is a known issue (see FIREFLY-1563).

However, the code to copy over the service descriptor is added and working.
You can verify this by running the MultiSpectrumProcessorTest, which checks that the RESOURCE is properly copied over.

