### PR TITLE
FIREFLY-1771: Fix Existing Table Load missing rows

### DIFF
--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -244,7 +244,7 @@ export function FileDropZone({dropEvent, setDropEvent, setLoadingOp, sx, childre
     );
 }
 
-const LoadingMessage= ({message}) => (
+export const LoadingMessage= ({message}) => (
     <div style={{
         position: 'absolute',
         zIndex:20,


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1771
- fixes the above ticket
- add a loading animation for bigger tables (similar to the one on the upload tab) 

**Testing**: 
**Euclid**: https://firefly-1771-row-mismatch.irsakudev.ipac.caltech.edu/applications/euclid
- test Euclid Catalogs according to ticket
   - here's what I did: 
     - Select the following catalog & search: `euclid_q1_spectro_zcatalog_spe_galaxy_candidates`
     - Back on Euclid Catalogs, now select: `euclid_q1_phz_photo_z`, but don't click on Search
     - Now under `Object ID search`, select `Load object IDs from a table` and select the first table you searched for from the `Loaded Tables` tab
- For both the ID columns, select `object_id`
- Do a search. You should get back several thousand rows (50,000  if you never changed row limit)
   -previously, you would only get back 100 (default page size) 