### PR TITLE
FIREFLY-1563: VoTableWriter missing RESOURCES in output file

### DIFF
--- a/buildScript/dependencies.gradle
+++ b/buildScript/dependencies.gradle
@@ -85,7 +85,7 @@ dependencies {
 
     // starlink
     implementation ':starlink-registry-1.2+2016.05.03'
-    implementation ('uk.ac.starlink:stil:4.1.4')
+    implementation ('uk.ac.starlink:stil:4.3.2')
 
     // validation
     implementation 'javax.validation:validation-api:1.1.0.Final'

--- a/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableMeta.java
@@ -70,6 +70,8 @@ public class TableMeta implements Serializable {
     public static final String XTYPE = "xtype";
     public static final String DESC = "description";
     public static final String NAME = "name";
+    public static final String TYPE = "type";
+    public static final String VALUE = "value";
     public static final String DERIVED_FROM = "DERIVED_FROM";
 
     public static final String DOCLINK = "doclink.url";

--- a/src/firefly/java/edu/caltech/ipac/table/io/DataGroupStarTable.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/DataGroupStarTable.java
@@ -75,12 +75,12 @@ public class DataGroupStarTable extends RandomStarTable {
 //====================================================================
 
     private static ColumnInfo convertToColumnInfo(DataType dt, Object data) {
-        Class dType = data != null ? data.getClass() : dt.getDataType();
+        Class dClz = data != null ? data.getClass() : dt.getDataType();
 
         // name, datatype, <DESCRIPTION>
         String desc = dt.getDesc();
         String cname = getAliasName(dt);
-        ColumnInfo col = new ColumnInfo(cname, dType, desc);
+        ColumnInfo col = new ColumnInfo(cname, dClz, desc);
         // LINK child
         List<LinkInfo> links = dt.getLinkInfos();
         if (links.size() > 0 && !isEmpty(links.get(0).getHref())) {
@@ -110,7 +110,7 @@ public class DataGroupStarTable extends RandomStarTable {
         // utype
         applyIfNotEmpty(dt.getUType(), col::setUtype);
 
-        if (dType == Integer.class) {
+        if (dt.isWholeNumber()) {       // Firefly allows all value types to be nullable; to avoid have null=val in the field, we set nullable to false
             col.setNullable(false);
         }
 

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -229,7 +229,6 @@ public class VoTableReader {
                 HttpServices.getData( HttpServiceInput.createWithCredential(url), tmpFile);
                 voTablePath = tmpFile.getPath();
             } catch (Exception e) {
-                tmpFile.delete();
                 LOG.error(e, "Unable to fetch URL: " + location);
                 throw new IOException(e.getMessage(), e);
             }
@@ -299,6 +298,7 @@ public class VoTableReader {
     }
 
     // return this table's resource as well as all non-table <RESOURCE> from the given votable
+    // The first RESOURCE is the one for the given table.
     private static List<ResourceInfo> getResourcesForTable(VOElement docRoot, TableElement table) {
 
         if (docRoot == null) return null;

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableUtil.java
@@ -1,0 +1,263 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.table.io;
+
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.GroupInfo;
+import edu.caltech.ipac.table.LinkInfo;
+import edu.caltech.ipac.table.ParamInfo;
+import edu.caltech.ipac.table.ResourceInfo;
+import edu.caltech.ipac.table.TableMeta;
+import uk.ac.starlink.votable.VOTableWriter;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.StringWriter;
+import java.util.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.table.DataType.*;
+import static edu.caltech.ipac.table.TableMeta.*;
+import static edu.caltech.ipac.table.TableMeta.REF;
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
+
+/**
+ * Date: 6/2/25
+ *
+ * @author loi
+ * @version : $
+ */
+public class VoTableUtil extends VOTableWriter {
+
+    public static Element xmlResource(ResourceInfo ri) {
+        Element el = new Element("RESOURCE")
+                .attr(UTYPE, ri.getUtype())
+                .attr(ID, ri.getID())
+                .attr(NAME, ri.getName())
+                .attr(TYPE, ri.getType())
+                .add(xmlDesc(ri.getDesc()));
+
+        ri.getInfos().forEach((k, v) -> el.add(xmlInfo(k, v)));
+        ri.getGroups().forEach(g -> el.add(xmlGroup(g)));
+        ri.getParams().forEach(p -> el.add(xmlParam(p)));
+        return el;
+    }
+
+    public static Element xmlTable(DataGroup table)  {
+        TableMeta meta = table.getTableMeta();
+        Element el = new Element("TABLE")
+                .attr(ID, meta.getAttribute(ID))
+                .attr(NAME, meta.getAttribute(NAME))
+                .attr(UTYPE, meta.getAttribute(UTYPE))
+                .attr(UCD, meta.getAttribute(UCD))
+                .add(xmlDesc(meta.getAttribute(DESC)));
+
+        if (table.size() > 0) {
+            el.attr("nrows", String.valueOf(table.size()));
+        }
+        return el;
+    }
+
+    public static Element xmlField(DataType dt) {
+        return xmlColumn(dt, "FIELD");
+    }
+
+    public static Element xmlParam(ParamInfo pInfo) {
+        Element el = xmlColumn(pInfo, "PARAM");
+        el.attr("value", pInfo.getStringValue());
+        return el;
+    }
+
+    static Element xmlColumn(DataType dt, String tagName) {
+        String prec = ifNotNull(dt.getPrecision()).getOrElse("");
+        prec = prec.startsWith("G") ? prec.substring(1) : prec; // remove 'G' prefix if exists
+        String width = dt.getWidth() == 0 ? "" : "" + dt.getWidth();
+        String arysize = ifNotEmpty(dt.getArraySize()).getOrElse(dt.getDataType() == String.class ? "*" : "");
+
+        Element el = new Element(tagName)
+                .attr(ID, dt.getID())
+                .attr(NAME, dt.getKeyName())
+                .attr(UCD, dt.getUCD())
+                .attr("datatype", mapToVoType(dt.getTypeDesc()))
+                .attr("width", width)
+                .attr("precision", prec)
+                .attr("unit", dt.getUnits())
+                .attr(UTYPE, dt.getUType())
+                .attr(REF, dt.getRef())
+                .attr("arraysize", arysize)
+                .add(xmlDesc(dt.getDesc()));
+        dt.getLinkInfos().forEach(l -> el.add(xmlLink(l)));
+        return el;
+    }
+
+    public static Element xmlGroup(GroupInfo gInfo) {
+        Element el = new Element("GROUP")
+                .attr(ID, gInfo.getID())
+                .attr(NAME, gInfo.getName())
+                .attr(UTYPE, gInfo.getUtype())
+                .attr(UCD, gInfo.getUCD())
+                .add(xmlDesc(gInfo.getDescription()));
+        gInfo.getGroupInfos().forEach(g -> el.add(xmlGroup(g)));
+        gInfo.getParamInfos().forEach(p -> el.add(xmlParam(p)));
+        gInfo.getParamRefs().forEach(r -> el.add(xmlParamRef(r)));
+        gInfo.getColumnRefs().forEach(r -> el.add(xmlFieldRef(r)));
+        return el;
+    }
+
+    public static Element xmlLink(LinkInfo linkInfo)   {
+        Element el = new Element("LINK")
+                .attr(ID, linkInfo.getID())
+                .attr("content-role", linkInfo.getRole())
+                .attr("content-type", linkInfo.getType())
+                .attr("title", linkInfo.getTitle())
+                .attr("value", linkInfo.getValue())
+                .attr("href", linkInfo.getHref())
+                .attr("action", linkInfo.getAction());
+        return el;
+    }
+
+    public static Element xmlParamRef(GroupInfo.RefInfo ref) {
+        return xmlRefInfo(ref, "PARAMref");
+    }
+
+    public static Element xmlFieldRef(GroupInfo.RefInfo ref) {
+        return xmlRefInfo(ref, "FIELDref");
+    }
+
+    public static Element xmlRefInfo(GroupInfo.RefInfo ref, String tagName) {
+        return new Element(tagName)
+                .attr(REF, ref.getRef())
+                .attr(TableMeta.UCD, ref.getUcd())
+                .attr(TableMeta.UTYPE, ref.getUtype());
+    }
+
+    public static Element xmlInfo(String name, String value) {
+        return new Element("INFO")
+                .attr(TableMeta.NAME, name)
+                .attr("value", value);
+    }
+
+    public static Element xmlDesc(String desc) {
+        if (isEmpty(desc)) return null;
+        return new Element("DESCRIPTION").text(desc);
+    }
+
+    /**
+     * @param typeDesc  String description of column's data type
+     * @return VoTable type for the given Firefly's Type
+     */
+    private static String mapToVoType(String typeDesc) {
+        if (typeDesc.equals(DATE))      return "char";
+        if (typeDesc.equals(LOCATION))  return "char";
+        if (typeDesc.equals(REAL))      return "double";
+
+        return typeDesc;
+    }
+
+    //====================================================================
+    //
+    //====================================================================
+
+    /**
+     * This class provides helper methods to simplify the creation of XML elements
+     * by using the {@link javax.xml.stream.XMLStreamWriter} API. All output
+     * generated is compliant with XML standards, including correct escaping of special
+     * characters and proper element nesting.
+     */
+    public static class Element {
+        private final String name;
+        private final Map<String, String> attrs = new LinkedHashMap<>();
+        private final List<Object> children = new ArrayList<>(); // Element or String
+        private static final XMLOutputFactory factory = XMLOutputFactory.newInstance();
+
+        public Element(String name) {
+            this.name = name;
+        }
+
+        public Element attr(String k, String v) {
+            if (!isEmpty(k) && !isEmpty(v)) {
+                attrs.put(k, v);
+            }
+            return this;
+        }
+
+        public Element add(Element child) {
+            if (child != null) {
+                children.add(child);
+            }
+            return this;
+        }
+
+        public Element text(String text) {
+            if(!isEmpty(text)) {
+                children.add(text);
+            }
+            return this;
+        }
+
+        public String toXml() {
+            return toXml(false);
+        }
+
+        public String toXmlNoFooter() {
+            return toXml(true);
+        }
+
+        // Serialize to XML string using StAX
+        public String toXml(boolean noFooter) {
+            try {
+                StringWriter sw = new StringWriter();
+                XMLStreamWriter writer = factory.createXMLStreamWriter(sw);
+
+                writeElement(writer,noFooter, 0);
+                writer.flush();
+                writer.close();
+                return sw.toString();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // Recursive method to write self (and children) to the XMLStreamWriter
+        private void writeElement(XMLStreamWriter writer, boolean noFooter, int depth) throws Exception {
+
+            doIndent(writer, depth);
+            writer.writeStartElement(name);
+
+            for (Map.Entry<String, String> entry : attrs.entrySet()) {
+                writer.writeAttribute(entry.getKey(), entry.getValue());
+            }
+
+            boolean hasChildEl = false;
+            for (Object child : children) {
+                if (child instanceof Element) {
+                    hasChildEl = true;
+                    ((Element) child).writeElement(writer, false, depth + 1);
+                } else if (child instanceof String) {
+                    writer.writeCharacters((String) child);
+                }
+            }
+
+            if (noFooter) {
+                writer.writeCharacters("");     // close previous element if needed
+            } else {
+                if (hasChildEl) doIndent(writer, depth);
+                writer.writeEndElement();
+            }
+        }
+
+    }
+
+    private static void doIndent(XMLStreamWriter writer, int depth) throws Exception {
+        writer.writeCharacters("\n");
+        writer.writeCharacters("  ".repeat(depth));
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableWriter.java
@@ -4,21 +4,23 @@
 package edu.caltech.ipac.table.io;
 import edu.caltech.ipac.table.*;
 
-import static edu.caltech.ipac.table.DataType.*;
-import static edu.caltech.ipac.util.StringUtils.isEmpty;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import edu.caltech.ipac.util.FormatUtil;
-import edu.caltech.ipac.util.StringUtils;
-import uk.ac.starlink.table.*;
+import uk.ac.starlink.table.StarTable;
+import uk.ac.starlink.table.TableSequence;
 import uk.ac.starlink.votable.*;
 import nom.tam.fits.FitsFactory;
+
+import static edu.caltech.ipac.table.TableMeta.*;
+import static edu.caltech.ipac.table.TableMeta.DESC;
+import static edu.caltech.ipac.table.io.VoTableUtil.*;
+import static edu.caltech.ipac.firefly.core.Util.Try;
 
 /**
  * This class handles an action to save a catalog in VOTable (metadata, binary, binary2, fits) format to local file.
@@ -37,9 +39,7 @@ public class VoTableWriter {
      * @param outputFormat votable output format
      * @throws IOException on error
      */
-    public static void save(File file, DataGroup dataGroup, FormatUtil.Format outputFormat)
-            throws IOException {
-
+    public static void save(File file, DataGroup dataGroup, FormatUtil.Format outputFormat) throws IOException {
 
         OutputStream ostream = new BufferedOutputStream( new FileOutputStream(file) );
         save(ostream, dataGroup, outputFormat);
@@ -54,341 +54,115 @@ public class VoTableWriter {
      * @param outputFormat votable output format
      * @throws IOException on error
      */
-    public static void save(OutputStream stream, DataGroup dataGroup, FormatUtil.Format outputFormat)
-            throws IOException {
+    public static void save(OutputStream stream, DataGroup dataGroup, FormatUtil.Format outputFormat) throws IOException {
 
         FitsFactory.useThreadLocalSettings(true);  // consistent with FitsTableReader
         FitsFactory.setLongStringsEnabled(false);
 
-        VOTableWriterImpl voWriter = new VOTableWriterImpl(outputFormat, dataGroup);
+        VoTableWriterImpl voWriter = new VoTableWriterImpl(outputFormat, dataGroup);
         voWriter.write(stream);
 
         FitsFactory.useThreadLocalSettings(false);
     }
 
     /**
-     * @param typeDesc  String description of column's data type
-     * @return VoTable type for the given Firefly's Type
+     * A {@link VOTableWriter} implementation that outputs extra metadata from a {@link DataGroup} in VOTable format.
+     * This writer is designed for a single DataGroup and does not support multiple tables.
+     * It can, however, write multiple RESOURCE tags with empty TABLE elements as metadata.
      */
-    private static String mapToVoType(String typeDesc) {
-        if (typeDesc.equals(DATE))      return "char";
-        if (typeDesc.equals(LOCATION))  return "char";
-        if (typeDesc.equals(REAL))      return "double";
+    public static class VoTableWriterImpl extends VOTableWriter {
+        private final DataGroup dataGroup;
 
-        return typeDesc;
-    }
-
-    private static class DataGroupXML {
-        private List<DataGroup.Attribute> tableMeta;
-        private DataGroup dataGroup;
-        private String tagDesc = "DESCRIPTION";
-
-        DataGroupXML(DataGroup dg) {
-            this.dataGroup = dg;
-            tableMeta = dg.getTableMeta().getKeywords();
-        }
-
-        public String xmlINFOs() {
-            List<DataGroup.Attribute> metaList = infosInTable(tableMeta);
-
-            return metaList.isEmpty() ? ""
-                    : metaList.stream()
-                        .map( oneAtt -> "<INFO" +
-                                VOSerializer.formatAttribute(TableMeta.NAME, oneAtt.getKey()) +
-                                VOSerializer.formatAttribute("value", oneAtt.getValue()) + "/>" )
-                        .collect(Collectors.joining("\n"));
-        }
-
-        private String xmlDESCRIPTION() {
-            String descVal = dataGroup.getAttribute(TableMeta.DESC);
-
-            return isEmpty(descVal) ? "" : "<"+tagDesc+">" + descVal + "</"+tagDesc+">";
-        }
-
-        private String xmlTABLE() {
-            long nrow = dataGroup.size();
-            String tname = dataGroup.getTableMeta().getAttribute(TableMeta.NAME);
-            String res = "<TABLE";
-            String ucd = dataGroup.getTableMeta().getAttribute(TableMeta.UCD);
-            String utype = dataGroup.getTableMeta().getAttribute(TableMeta.UTYPE);
-
-            if (!StringUtils.isEmpty(tname)) {
-                res += VOSerializer.formatAttribute(TableMeta.NAME, tname.trim());
-            }
-            if (nrow > 0) {
-                res += VOSerializer.formatAttribute("nrows", Long.toString(nrow));
-            }
-            if (ucd != null) {
-                res += VOSerializer.formatAttribute(TableMeta.UCD, ucd);
-            }
-            if (utype != null) {
-                res += VOSerializer.formatAttribute(TableMeta.UTYPE, utype);
-            }
-            res += ">";
-            return res;
-        }
-
-        private String xmlLINK(LinkInfo link) {
-            List<String> atts = new ArrayList<>();
-
-            atts.add(elementAtt(TableMeta.ID, link.getID()));
-            atts.add(elementAtt("content-role", link.getRole()));
-            atts.add(elementAtt("content-type", link.getType()));
-            atts.add(elementAtt("title" , link.getTitle()));
-            atts.add(elementAtt("value", link.getValue()));
-            atts.add(elementAtt("href", link.getHref()));
-            atts.add(elementAtt("action", link.getAction()));
-
-            String attsInElement =  atts.stream()
-                                    .filter( v -> !isEmpty(v))
-                                    .collect(Collectors.joining());
-
-            return "<LINK"+attsInElement + "/>";
-        }
-
-        private String xmlVALUES(String nullStr, String minStr, String maxStr, String options) {
-            String[] opts = isEmpty(options) ? new String[0] : options.split(",");
-
-            if (isEmpty(nullStr) && isEmpty(minStr) && isEmpty(maxStr) && (opts.length == 0)) {
-                return "";
-            }
-
-            //  null="null", null='""' or null="xxxx"
-            String valuesAtts = elementAtt("null", nullStr);
-            String valuesElement = "";
-            if (!isEmpty(minStr)) {
-                valuesElement += "<MIN" + elementAtt("value", minStr) + "/>\n";
-            }
-            if (!isEmpty(maxStr)) {
-                valuesElement += "<MAX" + elementAtt("value", maxStr) + "/>\n";
-            }
-            if (opts.length > 0) {
-                for (String op : opts) {
-                    valuesElement += "<OPTION" + elementAtt("value", op) + "/>\n";
-                }
-            }
-
-            return completeTag(valuesAtts, valuesElement, "VALUES");
-        }
-
-        private String xmlColumnAtt(DataType dt) {
-            String prec = dt.getPrecision();
-            String width = dt.getWidth() == 0 ? "" : ""+dt.getWidth();
-            String atts = elementAtt(TableMeta.ID, dt.getID()) +
-                          elementAtt(TableMeta.NAME, dt.getKeyName()) +
-                          elementAtt(TableMeta.UCD, dt.getUCD()) +
-                          elementAtt("datatype", mapToVoType(dt.getTypeDesc())) +
-                          elementAtt("width", width) +
-                          elementAtt("precision",
-                                     (!isEmpty(prec) && prec.startsWith("G")) ? prec.substring(1) : prec) +
-                          elementAtt("unit", dt.getUnits()) +
-                          elementAtt(TableMeta.UTYPE, dt.getUType()) +
-                          getArraySize(dt);
-
-
-            return atts;
-
-        }
-
-        public String xmlLINKs(List<LinkInfo> links) {
-            return links.stream()
-                        .map(oneLink -> xmlLINK(oneLink))
-                        .collect(Collectors.joining("\n"));
-        }
-
-        private String xmlFIELD(DataType dt) {
-            String descriptionTag = tagElement(tagDesc, dt.getDesc());
-            String linkTag = xmlLINKs(dt.getLinkInfos());
-            String values = xmlVALUES(dt.getNullString(), dt.getMinValue(), dt.getMaxValue(),
-                                      dt.getDataOptions());
-            String childElements = (isEmpty(descriptionTag) ? "" : descriptionTag + "\n") +
-                                   (isEmpty(values) ? "" : values + "\n") +
-                                   (isEmpty(linkTag) ? "" : linkTag + "\n");
-
-            String atts = xmlColumnAtt(dt);
-
-            return completeTag(atts, childElements, "FIELD");
-        }
-
-        private String xmlPARAM(ParamInfo pInfo) {
-            String paramAtts = xmlColumnAtt(pInfo) + elementAtt("value", pInfo.getStringValue());
-            String descriptionTag = tagElement(tagDesc, pInfo.getDesc());
-            String linkTag = xmlLINKs(pInfo.getLinkInfos());
-            String childElements = (isEmpty(descriptionTag) ? "" : descriptionTag + "\n") +
-                                   (isEmpty(linkTag) ? "" : linkTag + "\n");
-
-            return completeTag(paramAtts, childElements, "PARAM" );
-        }
-
-        public String xmlPARAMs(List<ParamInfo> paramInfos) {
-            return paramInfos.stream()
-                             .map( (oneParam) -> xmlPARAM(oneParam))
-                             .collect(Collectors.joining("\n"));
-        }
-
-        private String xmlRefAtt(GroupInfo.RefInfo ref) {
-            return  elementAtt(TableMeta.REF, ref.getRef()) +
-                    elementAtt(TableMeta.UCD, ref.getUcd()) +
-                    elementAtt(TableMeta.UTYPE, ref.getUtype());
-        }
-
-
-        private String xmlPARAMrefs(List<GroupInfo.RefInfo> refs) {
-            return refs.stream()
-                    .map( (oneRef) -> "<PARAMref" + xmlRefAtt(oneRef) + "/>")
-                    .collect(Collectors.joining("\n"));
-
-        }
-
-        private String xmlFIELDrefs(List<GroupInfo.RefInfo> refs) {
-            return refs.stream()
-                    .map( (oneRef) -> "<FIELDref" + xmlRefAtt(oneRef) + "/>")
-                    .collect(Collectors.joining("\n"));
-        }
-
-
-        private String xmlGROUP(GroupInfo gInfo) {
-            String params = xmlPARAMs(gInfo.getParamInfos());
-            String groups = xmlGROUPs(gInfo.getGroupInfos());
-            String paramRefs = xmlPARAMrefs(gInfo.getParamRefs());
-            String fieldRefs = xmlFIELDrefs(gInfo.getColumnRefs());
-            String descriptionTag = tagElement(tagDesc, gInfo.getDescription());
-            String groupElement = "<GROUP" + elementAtt(TableMeta.ID, gInfo.getID()) +
-                                             elementAtt(TableMeta.NAME, gInfo.getName()) +
-                                             elementAtt(TableMeta.UTYPE, gInfo.getUtype()) +
-                                             elementAtt(TableMeta.UCD, gInfo.getUCD()) + ">\n" +
-                                  (isEmpty(descriptionTag) ? "" : descriptionTag+"\n") +
-                                  (isEmpty(fieldRefs) ? "" : fieldRefs+"\n") +
-                                  (isEmpty(params) ? "" : params+"\n") +
-                                  (isEmpty(groups) ? "" : groups+"\n") +
-                                  (isEmpty(paramRefs) ? "" : paramRefs + "\n") +
-                                  "</GROUP>";
-
-            return groupElement;
-        }
-
-        public String xmlGROUPs(List<GroupInfo> groups) {
-
-            return groups.stream()
-                         .map( (oneGroup -> xmlGROUP(oneGroup)))
-                         .collect(Collectors.joining("\n"));
-        }
-
-        public static List<DataGroup.Attribute> getInfosFromMeta(List<DataGroup.Attribute> meta) {
-            String[] tableMetaNotInfo = { TableMeta.ID, TableMeta.REF,
-                                          TableMeta.UCD, TableMeta.UTYPE,
-                                          TableMeta.NAME, TableMeta.DESC};
-
-            List<String> attList = Arrays.asList(tableMetaNotInfo);
-            List<DataGroup.Attribute> infoList = meta.stream()
-                    .filter(oneAtt -> (!oneAtt.isComment()) && !attList.contains(oneAtt.getKey()))
-                    .collect(Collectors.toList());
-            return infoList;
-        }
-
-
-        private List<DataGroup.Attribute> infosInTable(List<DataGroup.Attribute> meta) {
-            return getInfosFromMeta(meta);
-        }
-
-        private String tagElement(String tag, String val) {
-            return !isEmpty(val) ? "<"+tag+">" + val + "</"+tag+">" : "";
-        }
-
-        private String elementAtt(String key, String val) {
-             return (val != null && !isEmpty(val))  ? VOSerializer.formatAttribute(key, val) : "";
-        }
-
-        private String getArraySize(DataType type) {
-            if (type.getDataType() == String.class && StringUtils.isEmpty(type.getArraySize())) {
-                return VOSerializer.formatAttribute("arraysize", "*");
-            }
-            return elementAtt("arraysize", type.getArraySize());
-        }
-
-        private String completeTag(String elementAtts, String childElements, String tagName) {
-            String startTag = "<"+tagName+elementAtts;
-            return isEmpty(childElements) ? startTag+"/>" : startTag+">\n"+childElements+"</"+tagName+">";
-        }
-    }
-
-
-
-
-
-    private static class VOTableWriterImpl extends VOTableWriter {
-        private DataGroup dataGroup;
-
-        private VOTableWriterImpl(FormatUtil.Format outputFormat, DataGroup dataGroup) {
+        public VoTableWriterImpl(FormatUtil.Format outputFormat, DataGroup dataGroup) {
             super(getDataFormat(outputFormat), true, getVotVersion(outputFormat));
             this.dataGroup = dataGroup;
         }
 
-        public void write(OutputStream stream)  throws IOException {
-
+        public void write(OutputStream stream) throws IOException {
             // this should return only visible columns
-            List<String> columns = Arrays.asList(dataGroup.getDataDefinitions()).stream()
+            List<String> columns = Arrays.stream(dataGroup.getDataDefinitions())
                     .filter(dt -> IpacTableUtil.isVisible(dataGroup, dt))
-                    .map((dt) -> dt.getKeyName())
+                    .map(DataType::getKeyName)
                     .collect(Collectors.toList());
 
             StarTable st = new DataGroupStarTable(dataGroup, columns);
-
-
-
             writeStarTable(st, stream);
         }
 
         /**
-         *  Override to inject additional info into the table.
-         *  This also forces inline writing only.. and ignore optimization and File writing.
+         * Override to include all RESOURCE tags, placing the RESOURCE tag containing the TABLE last.
          */
         @Override
-        public void writeStarTables( TableSequence tableSeq, OutputStream out, File file ) throws IOException {
+        protected String createResourceStartTag() {
+            List<ResourceInfo> resources = new ArrayList<>(dataGroup.getResourceInfos());
+
+            // When there are no resources or a single META resource,
+            // create a "results" resource to represent the main table.
+            if (resources.isEmpty() ||
+                    (resources.size() == 1 && "META".equalsIgnoreCase(String.valueOf(resources.getFirst().getType())))) {
+                resources.addFirst(new ResourceInfo(null, null, "results", dataGroup.getAttribute(UTYPE), null));
+            }
+            // output other resources first
+            StringBuilder rval = new StringBuilder();
+            for (int i = 1; i < resources.size(); i++) {
+                rval.append(xmlResource(resources.get(i)).toXml());
+            }
+            // output the main table resource without ending tag
+            rval.append(xmlResource(resources.getFirst()).toXmlNoFooter());
+            return rval.toString();
+        }
+
+        /**
+         * Override to inject additional info into the table.
+         * This also forces inline writing only. and ignore optimization and File writing.
+         */
+        @Override
+        public void writeStarTables(TableSequence tableSeq, OutputStream out, File file) throws IOException {
 
             OutputStreamWriter osw;
-            osw = new OutputStreamWriter( out, StandardCharsets.UTF_8);
-            BufferedWriter writer = new BufferedWriter( osw );
+            osw = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+            BufferedWriter writer = new BufferedWriter(osw);
 
             /* Output preamble. */
-            writePreTableXML( writer );
+            writePreTableXML(writer);
 
-            /* Loop over all tables for output. */
-            int itable = 0;
-            for ( StarTable startab; ( startab = tableSeq.nextTable() ) != null;
-                  itable++ ) {
+            /* There should be only 1 table in tableSep */
+            StarTable starTbl = tableSeq.nextTable();
+            if (starTbl != null) {
+                VOSerializer serializer = VOSerializer.makeSerializer(getDataFormat(), getVotableVersion(), starTbl);
 
-                VOSerializer serializer = VOSerializer.makeSerializer( getDataFormat(), getVotableVersion(), startab );
-
-                /* Now add our additional info */
-                DataGroupXML dgXML = new DataGroupXML(dataGroup);
                 //note: in accordance with the IVOA standard for VOTable, the order of the tags below needs to be maintained
-                outputElement(writer, dgXML.xmlTABLE());     // TABLE tag
-                outputElement(writer, dgXML.xmlDESCRIPTION());     // DESCRIPTION tag
-                serializer.writeFields(writer);     // FIELDS tags
-                outputElement(writer, dgXML.xmlGROUPs(dataGroup.getGroupInfos()));          // GROUP
-                outputElement(writer, dgXML.xmlPARAMs(dataGroup.getParamInfos())); // PARAM
-                outputElement(writer, dgXML.xmlLINKs(dataGroup.getLinkInfos()));
+                writer.write(xmlTable(dataGroup).toXmlNoFooter() + "\n");      // TABLE tag; without closing tag
+                serializer.writeFields(writer);                         // FIELDS tags
+                dataGroup.getParamInfos().forEach(p -> {
+                    Try.it(() -> writer.write(xmlParam(p).toXml()));    // PARAM tags
+                });
+                dataGroup.getGroupInfos().forEach(g -> {
+                    Try.it(() -> writer.write(xmlGroup(g).toXml()));    // GROUP tags
+                });
+                dataGroup.getLinkInfos().forEach(l -> {
+                    Try.it(() -> writer.write(xmlLink(l).toXml()));     // LINK tags
+                });
 
-                /* Now write the DATA element. */
-                /* ALWAYS write inline. */
-                serializer.writeInlineDataElement( writer );
+                /* Now write the DATA element. ALWAYS write inline. */
+                serializer.writeInlineDataElement(writer);                  // DATA tag
 
-                /* Now add our additional info */
-                outputElement(writer, dgXML.xmlINFOs());
+                getInfosFromMeta(dataGroup.getAttributeList()).stream()     // INFO tags
+                        .map( a -> xmlInfo(a.getKey(), a.getValue()))
+                        .forEach(info -> Try.it(() -> writer.write(info.toXml())));
 
-                /* Write postamble. */
-                serializer.writePostDataXML( writer );
+                serializer.writePostDataXML(writer);                        // close TABLE tag
             }
-            writePostTableXML( writer );
+            writePostTableXML(writer);
 
-            /* Tidy up. */
             writer.flush();
         }
 
+        private static VOTableVersion getVotVersion(FormatUtil.Format outputFormat) {
+            return outputFormat.equals(FormatUtil.Format.VO_TABLE_BINARY2) ? VOTableVersion.V13 : VOTableVersion.V12;
+        }
+
         private static DataFormat getDataFormat(FormatUtil.Format outputFormat) {
-
-
             if (outputFormat.equals(FormatUtil.Format.VO_TABLE_BINARY2)) {
                 return DataFormat.BINARY2;
             } else if (outputFormat.equals(FormatUtil.Format.VO_TABLE_BINARY)) {
@@ -399,17 +173,15 @@ public class VoTableWriter {
                 return DataFormat.TABLEDATA;
             }
         }
-
-        private static VOTableVersion getVotVersion(FormatUtil.Format outputFormat) {
-            return outputFormat.equals(FormatUtil.Format.VO_TABLE_BINARY2) ? VOTableVersion.V13 : VOTableVersion.V12;
-        }
-
-        private static void outputElement(BufferedWriter out, String s) throws IOException {
-            if (!isEmpty(s)) {
-                out.write(s + "\n");
-            }
-        }
-
     }
+
+    private static List<DataGroup.Attribute> getInfosFromMeta(List<DataGroup.Attribute> meta) {
+        List<String> ignore = Arrays.asList(ID, REF,UCD, UTYPE,NAME, DESC);     // these are table attributes, not infos
+        return meta.stream()
+                .filter(a -> (!a.isComment()) && !ignore.contains(a.getKey()))
+                .collect(Collectors.toList());
+    }
+
+
 }
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1563
- Significant refactoring of VoTableWriter
- Upgraded starlink STIL to 4.3.2


Test: https://fireflydev.ipac.caltech.edu/firefly-1563-votable-writer-missing-resources/firefly/
- Upload the latest multispectrum sample file attached in the ticket.
- Expand the Resources tab—you should see two resources.
![image](https://github.com/user-attachments/assets/c26ded5f-fecf-4052-a253-6015b520a0db)
- Click Load Table
  - The table is now displayed as a DataProduct table. If you save it, you’ll notice three hidden columns that identify it as a DataProduct.

  -  In the Data Product tab, switch to table view, then click the Table Info (i) icon.
  - The selected row is now extracted as a spectrum table, and the MultiSpectrum-service has been converted to 'adhoc:service'.
![image](https://github.com/user-attachments/assets/5107a247-4868-4884-9aaa-f0f6a64a5301)

