### PR TITLE
FIREFLY-1754: Fix poor positioning of App Hints

### DIFF
--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -558,4 +558,7 @@ function getColFitIdx(gridView, row, testIdx, gridColumns, testWidth) {
 
 }
 
-
+// getter/setters for the DOM nodes of Menu Tabs, stored in the layout info
+export const MENU_TAB_NODES = 'menuTabNodes';
+export const getMenuTabNodes = () => getLayouInfo()?.[MENU_TAB_NODES] ?? {};
+export const dispatchUpdateMenuTabNodes = (menuTabNodes) => dispatchUpdateLayoutInfo({[MENU_TAB_NODES]: menuTabNodes});

--- a/src/firefly/js/templates/common/FireflyLayout.jsx
+++ b/src/firefly/js/templates/common/FireflyLayout.jsx
@@ -15,7 +15,7 @@ import {AppConfigDrawer} from '../../ui/AppConfigDrawer.jsx';
 import {getActionFromUrl} from 'firefly/core/History';
 import {getDropDownInfo, SHOW_DROPDOWN} from 'firefly/core/LayoutCntlr';
 import {flux} from 'firefly/core/ReduxFlux';
-import {APP_HINT_IDS, appHintPrefName} from 'firefly/templates/fireflyviewer/LandingPage';
+import {APP_HINT_IDS, appHintPrefName} from 'firefly/ui/AppHint';
 import {InitArgsCtx} from './InitArgsCtx';
 
 /*

--- a/src/firefly/js/templates/hydra/HydraViewer.jsx
+++ b/src/firefly/js/templates/hydra/HydraViewer.jsx
@@ -161,7 +161,6 @@ const HydraAppBranding = ({title, desc}) => (
 );
 
 const defaultCommonProps = ({title, desc}) => ({
-    bgMonitorHint: { sx: { right: 50 } },
     topSection: { title, desc }
 });
 

--- a/src/firefly/js/ui/AppHint.jsx
+++ b/src/firefly/js/ui/AppHint.jsx
@@ -1,0 +1,109 @@
+import {useStoreConnector} from 'firefly/ui/SimpleComponent';
+import {dispatchAddPreference, getPreference} from 'firefly/core/AppDataCntlr';
+import React, {useLayoutEffect, useRef, useState} from 'react';
+import {Button, Snackbar} from '@mui/joy';
+import TipsAndUpdates from '@mui/icons-material/TipsAndUpdates';
+import {object, oneOf, string} from 'prop-types';
+
+
+export const APP_HINT_IDS = {
+    TABS_MENU: 'tabsMenu',
+    BG_MONITOR: 'bgMonitor'
+};
+
+export const HINT_TIP_PLACEMENTS = {
+    START: 'start',
+    MIDDLE: 'middle',
+    END: 'end'
+};
+
+/**An app hint needs to be shown only the first time user loads an app. So this is controlled by a flag saved as app preference**/
+export const appHintPrefName = (appTitle, hintId) => `showAppHint__${appTitle}--${hintId}`;
+
+export function AppHint({appTitle, id, anchorNode, hintText, tipPlacement=HINT_TIP_PLACEMENTS.MIDDLE, sx={}}) {
+    const showAppHint = useStoreConnector(() => getPreference(appHintPrefName(appTitle, id), true));
+    const appHintRef = useRef();
+
+    // AppHint is rendered inside LandingPage, so we cannot yet compute top/bottom from the anchor node but only left/right
+    const [anchorRelativePosSx, setAnchorRelativePosSx] = useState({});
+    useLayoutEffect(() => {
+        if (anchorNode) {
+            const anchorRect = anchorNode.getBoundingClientRect();
+            const appHintRect = appHintRef.current?.getBoundingClientRect() ?? {width: 0};
+            const posSx = {left: 'auto', right: 'auto'};
+            switch (tipPlacement) {
+                case HINT_TIP_PLACEMENTS.START:
+                    posSx.left = anchorRect.left;
+                    break;
+                case HINT_TIP_PLACEMENTS.END:
+                    posSx.right = `calc(100vw - ${anchorRect.right}px)`;
+                    break;
+                case HINT_TIP_PLACEMENTS.MIDDLE:
+                default:
+                    posSx.left = anchorRect.left + (anchorRect.width/2) - (appHintRect.width/2); // to center the hint
+                    break;
+            }
+            setAnchorRelativePosSx(posSx);
+        }
+    }, [anchorNode]);
+
+    const arrowTip = {
+        '&::before': {
+            content: '""',
+            width: '1rem',
+            height: '1rem',
+            backgroundColor: 'inherit',
+            transform: 'rotate(-45deg)',
+            position: 'absolute',
+            top: '-0.5rem',
+            left: 'calc(50% - 0.5rem)', //tipPlacement===HINT_TIP_PLACEMENTS.MIDDLE
+            ...tipPlacement===HINT_TIP_PLACEMENTS.START && {left: 'var(--Snackbar-padding)'},
+            ...tipPlacement===HINT_TIP_PLACEMENTS.END && {left: 'auto', right: 'var(--Snackbar-padding)'}
+        }
+    };
+
+    // to undo positioning controlled by anchorOrigin prop of Snackbar, and to place it directly below MenuTabBar
+    const defaultPositionSx = {
+        position: 'absolute',
+        top: '0.75rem', // to create space for the arrow tip (with height: sqrt(2) * 1 rem / 2)
+        bottom: 'auto',
+        left: 'auto',
+        right: 'auto',
+    };
+
+    return (
+        <Snackbar open={Boolean(showAppHint)}
+                  ref={appHintRef}
+                  size='lg'
+                  variant='solid' //to make it look different from alerts
+                  color='primary'
+                  invertedColors={true}
+                  onClose={(e, reason)=> {
+                      //don't close a hint if the click made outside it (clickaway) originated from another hint
+                      if (reason==='clickaway' && e?.target?.closest('.MuiSnackbar-root')) return;
+                      dispatchAddPreference(appHintPrefName(appTitle, id), false);
+                  }}
+                  sx={{...defaultPositionSx, ...anchorRelativePosSx, ...sx, ...arrowTip}}
+                  startDecorator={<TipsAndUpdates/>}
+                  endDecorator={
+                      <Button
+                          onClick={() => dispatchAddPreference(appHintPrefName(appTitle, id), false)}
+                          variant='outlined'
+                          color='primary'>
+                          Got it
+                      </Button>
+                  }>
+            {hintText}
+        </Snackbar>
+    );
+}
+
+AppHint.propTypes = {
+    appTitle: string.isRequired,
+    id: string.isRequired,
+    anchorNode: object, // generally a Menu Tab DOM node
+    hintText: string.isRequired,
+    tipPlacement: oneOf(['start', 'middle', 'end']),
+    sx: object,
+};
+


### PR DESCRIPTION
Fixes [FIREFLY-1754](https://jira.ipac.caltech.edu/browse/FIREFLY-1754)

- Moved AppHint code from Landing page to its own file
- Made AppHint accept an `anchorNode` prop that is used to calculate its position relative to that anchor
- Stored tabs' DOM refs at `MenuTabBar` in the layout info store and then reading them in `LandingPage` as AppHint anchor nodes.
- Removed hardcoded position settings (that broke with job monitor refactoring) in different apps. See:
  - IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/421
  - SUIT PR: https://github.com/lsst/suit/pull/62

## Testing
Go to each app and see if app hints are positioned correctly (if they are not present, go to dev tools -> "Application" tab -> clear all preferences by pressing none icon, reload the page):

Note: For job monitor hint to appear, you need to perform some catalog search and once results are avaialabe reload the page while staying at results/landing-page

1. Firefly: https://fireflydev.ipac.caltech.edu/firefly-1754-bgmon-hint/firefly
2. Firefly template in IV: https://firefly-1754-bgmon-hint.irsakudev.ipac.caltech.edu/irsaviewer
3. Routed template in spherex: https://firefly-1754-bgmon-hint.irsakudev.ipac.caltech.edu/applications/spherex
4. Hydra template in wise: https://firefly-1754-bgmon-hint.irsakudev.ipac.caltech.edu/applications/wise