### PR TITLE
FIREFLY-1779: Improve Redis configuration and administration features

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
@@ -26,6 +26,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static edu.caltech.ipac.firefly.core.Util.Try;
@@ -64,6 +65,8 @@ public class RedisService {
     public static final int maxPoolSize = AppProperties.getIntProperty(MAX_POOL_SIZE, 100);
     private static JedisPool jedisPool;
     private static Instant failSince;
+
+    private static List<String> RESERVED_KEYS = List.of(ALL_JOB_CACHE_KEY);
 
     private static String getRedisPassword() {
         String passwd = System.getenv("REDIS_PASSWORD");
@@ -166,6 +169,7 @@ public class RedisService {
             do {
                 var scanResult = redis.scan(cursor);
                 for (String key : scanResult.getResult()) {
+                    if (RESERVED_KEYS.contains(key)) continue; // skip reserved keys
                     long ttl = redis.ttl(key);
                     if (ttl == -1) {        // no expiry time
                         Long idletime = redis.objectIdletime(key);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.server.cache;
 import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.Util;
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheKey;
 import edu.caltech.ipac.util.cache.StringKey;
@@ -34,6 +35,7 @@ import java.util.function.Predicate;
  * @version $Id: EhcacheImpl.java,v 1.8 2009/12/16 21:43:25 loi Exp $
  */
 public class DistributedCache<T> implements Cache<T> {
+    public static final int DEF_TTL = AppProperties.getIntProperty("dist.cache.ttl.hours", 14*24) * 60 * 60;   // default to 14 days in seconds
     static final Logger.LoggerImpl LOG = Logger.getLogger();
     private static final String BASE64 = "BASE64::";
     private transient Predicate<T> getValidator;
@@ -53,7 +55,7 @@ public class DistributedCache<T> implements Cache<T> {
     }
 
     public void put(CacheKey key, Object value) {
-        put(key, value, 0);
+        put(key, value, DEF_TTL);
     }
 
     public void put(CacheKey key, Object value, int lifespanInSecs) {

--- a/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/VoTableReader.java
@@ -57,8 +57,8 @@ import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.core.FileAnalysisReport.TableDataType.NotSpecified;
 import static edu.caltech.ipac.firefly.core.FileAnalysisReport.TableDataType.Spectrum;
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.table.TableUtil.getAliasName;
-import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static uk.ac.starlink.table.StoragePolicy.*;
 
@@ -303,11 +303,11 @@ public class VoTableReader {
 
         if (docRoot == null) return null;
         List<ResourceInfo> resources = new ArrayList<>();
-        applyIfNotEmpty(makeResourceInfo(table.getParent()), resources::add);      // ensure the first resource is for the given table.
+        ifNotEmpty(makeResourceInfo(table.getParent())).apply(resources::add);      // ensure the first resource is for the given table.
 
         Arrays.stream(docRoot.getChildrenByName("RESOURCE"))
                 .filter(res -> res.getChildrenByName("TABLE").length == 0)      // only the ones without TABLE
-                .forEach( res -> applyIfNotEmpty(makeResourceInfo(res), resources::add));
+                .forEach( res -> ifNotEmpty(makeResourceInfo(res)).apply(resources::add));
         return resources;
     }
 
@@ -400,12 +400,12 @@ public class VoTableReader {
         DataGroup dg = new DataGroup(name, cols);
 
         // attribute ID, ref, ucd, utype from TABLE
-        applyIfNotEmpty(name, v -> dg.getTableMeta().addKeyword(TableMeta.NAME, v));
-        applyIfNotEmpty(table.getAttribute(ID), v -> dg.getTableMeta().addKeyword(TableMeta.ID, v));
-        applyIfNotEmpty(table.getAttribute(REF), v -> dg.getTableMeta().addKeyword(TableMeta.REF, v));
-        applyIfNotEmpty(table.getAttribute(UCD), v -> dg.getTableMeta().addKeyword(TableMeta.UCD, v));
-        applyIfNotEmpty(table.getAttribute(UTYPE), v -> dg.getTableMeta().addKeyword(TableMeta.UTYPE, v));
-        applyIfNotEmpty(table.getDescription(), v -> dg.getTableMeta().addKeyword(TableMeta.DESC, v));
+        ifNotEmpty(name).apply( v -> dg.getTableMeta().addKeyword(TableMeta.NAME, v.trim()));
+        ifNotEmpty(table.getAttribute(ID)).apply(v -> dg.getTableMeta().addKeyword(TableMeta.ID, v.trim()));
+        ifNotEmpty(table.getAttribute(REF)).apply(v -> dg.getTableMeta().addKeyword(TableMeta.REF, v.trim()));
+        ifNotEmpty(table.getAttribute(UCD)).apply(v -> dg.getTableMeta().addKeyword(TableMeta.UCD, v.trim()));
+        ifNotEmpty(table.getAttribute(UTYPE)).apply(v -> dg.getTableMeta().addKeyword(TableMeta.UTYPE, v.trim()));
+        ifNotEmpty(table.getDescription()).apply(v -> dg.getTableMeta().addKeyword(TableMeta.DESC, v.trim()));
 
         // PARAMs info
         Arrays.stream(table.getChildrenByName("PARAM"))
@@ -471,9 +471,9 @@ public class VoTableReader {
         String desc = group.getDescription();
 
         GroupInfo gObj = new GroupInfo(name, desc);
-        applyIfNotEmpty(group.getAttribute(ID), gObj::setID);
-        applyIfNotEmpty(group.getAttribute(UCD), gObj::setUCD);
-        applyIfNotEmpty(group.getAttribute(UTYPE), gObj::setUtype);
+        ifNotEmpty(group.getAttribute(ID)).apply(v -> gObj.setID(v.trim()));
+        ifNotEmpty(group.getAttribute(UCD)).apply(v -> gObj.setUCD(v.trim()));
+        ifNotEmpty(group.getAttribute(UTYPE)).apply(v -> gObj.setUtype(v.trim()));
 
         // add FIELDref
         Arrays.stream(group.getChildrenByName("FIELDref"))
@@ -498,19 +498,19 @@ public class VoTableReader {
     private static LinkInfo linkElToLinkInfo(VOElement el) {
         if (el == null) return null;
         LinkInfo li = new LinkInfo();
-        applyIfNotEmpty(el.getAttribute(ID), li::setID);
-        applyIfNotEmpty(el.getAttribute("content-role"), li::setRole);
-        applyIfNotEmpty(el.getAttribute("content-type"), li::setType);
-        applyIfNotEmpty(el.getAttribute("title"), li::setTitle);
-        applyIfNotEmpty(el.getAttribute("href"), li::setHref);
-        applyIfNotEmpty(el.getAttribute("value"), li::setValue);
-        applyIfNotEmpty(el.getAttribute("action"), li::setAction);
+        ifNotEmpty(el.getAttribute(ID)).apply(v -> li.setID(v.trim()));
+        ifNotEmpty(el.getAttribute("content-role")).apply(v -> li.setRole(v.trim()));
+        ifNotEmpty(el.getAttribute("content-type")).apply(v -> li.setType(v.trim()));
+        ifNotEmpty(el.getAttribute("title")).apply(v -> li.setTitle(v.trim()));
+        ifNotEmpty(el.getAttribute("href")).apply(v -> li.setHref(v.trim()));
+        ifNotEmpty(el.getAttribute("value")).apply(v -> li.setValue(v.trim()));
+        ifNotEmpty(el.getAttribute("action")).apply(v -> li.setAction(v.trim()));
         return li;
     }
 
     private static ParamInfo paramElToParamInfo(VOElement el) {
         ParamInfo dt = (ParamInfo) fieldElToDataType(new ParamInfo(), el,0, null);
-        applyIfNotEmpty(dt.convertStringToData(el.getAttribute("value")), dt::setValue);
+        ifNotEmpty(dt.convertStringToData(el.getAttribute("value"))).apply( dt::setValue);
         return dt;
     }
 
@@ -528,19 +528,19 @@ public class VoTableReader {
         String name = getCName(el, idx, cols);
         dt.setKeyName(name);
 
-        applyIfNotEmpty(el.getAttribute(ID), dt::setID);
-        applyIfNotEmpty(el.getAttribute("unit"), dt::setUnits);
-        applyIfNotEmpty(el.getAttribute("precision"), v -> dt.setPrecision(makePrecisionStr(v)));
-        applyIfNotEmpty(el.getAttribute("width"), v -> dt.setWidth(Integer.parseInt(v)));
-        applyIfNotEmpty(el.getAttribute("ref"), dt::setRef);
-        applyIfNotEmpty(el.getAttribute("ucd"), dt::setUCD);
-        applyIfNotEmpty(el.getAttribute("utype"), dt::setUType);
-        applyIfNotEmpty(el.getAttribute("xtype"), dt::setXType);
-        applyIfNotEmpty(el.getDescription(), dt::setDesc);
-        applyIfNotEmpty(el.getAttribute("datatype"), v -> {
-            dt.setDataType(DataType.descToType(v));
+        ifNotEmpty(el.getAttribute(ID)).apply(v -> dt.setID(v.trim()));
+        ifNotEmpty(el.getAttribute("unit")).apply(v -> dt.setUnits(v.trim()));
+        ifNotEmpty(el.getAttribute("precision")).apply(v -> dt.setPrecision(makePrecisionStr(v.trim())));
+        ifNotEmpty(el.getAttribute("width")).apply(v -> dt.setWidth(Integer.parseInt(v.trim())));
+        ifNotEmpty(el.getAttribute("ref")).apply(v -> dt.setRef(v.trim()));
+        ifNotEmpty(el.getAttribute("ucd")).apply(v -> dt.setUCD(v.trim()));
+        ifNotEmpty(el.getAttribute("utype")).apply(v -> dt.setUType(v.trim()));
+        ifNotEmpty(el.getAttribute("xtype")).apply(v -> dt.setXType(v.trim()));
+        ifNotEmpty(el.getDescription()).apply(v -> dt.setDesc(v.trim()));
+        ifNotEmpty(el.getAttribute("datatype")).apply(v -> {
+            dt.setDataType(DataType.descToType(v.trim()));
         });
-        applyIfNotEmpty(el.getAttribute("type"), v -> {
+        ifNotEmpty(el.getAttribute("type")).then(String::trim).apply(v -> {
             if (v.equals("hidden")) {       // mentioned in appendix A.1(LINK substitutions)
                 dt.setVisibility(DataType.Visibility.hidden);
             }else if (v.equals("location")) {       // mentioned in appendix A.4(FIELDs as Data Pointers)
@@ -548,12 +548,12 @@ public class VoTableReader {
             }
         });
 
-        applyIfNotEmpty(el.getAttribute("arraysize"), dt::setArraySize);
+        ifNotEmpty(el.getAttribute("arraysize")).apply(v ->  dt.setArraySize(v.trim()));
 
         // handle VALUES and OPTIONS
         VOElement values = el.getChildByName("VALUES");
             if (values != null) {
-                applyIfNotEmpty(el.getAttribute("null"), dt::setNullString);
+                ifNotEmpty(el.getAttribute("null")).apply(v -> dt.setNullString(v.trim()));
                 dt.setMaxValue(getChildValue(values, "MAX", "value"));
                 dt.setMinValue(getChildValue(values, "MIN", "value"));
                 String options = Arrays.stream(values.getChildrenByName("OPTION"))
@@ -592,10 +592,10 @@ public class VoTableReader {
                 meta.setCols(Arrays.asList(dg.getDataDefinitions()));
                 parts.get(i).getDetails().getAttributeList().forEach(attr -> meta.setAttribute(attr.getKey(), attr.getValue()));
                 DataGroup details = TableUtil.getDetails(i, meta);
-                applyIfNotEmpty(dg.getGroupInfos(), details::setGroupInfos);
-                applyIfNotEmpty(dg.getLinkInfos(), details::setLinkInfos);
-                applyIfNotEmpty(dg.getParamInfos(), details::setParamInfos);
-                applyIfNotEmpty(dg.getResourceInfos(), details::setResourceInfos);
+                ifNotEmpty(dg.getGroupInfos()).apply(details::setGroupInfos);
+                ifNotEmpty(dg.getLinkInfos()).apply(details::setLinkInfos);
+                ifNotEmpty(dg.getParamInfos()).apply(details::setParamInfos);
+                ifNotEmpty(dg.getResourceInfos()).apply(details::setResourceInfos);
 
                 var part= parts.get(i);
                 part.setTableDataType(SpectrumMetaInspector.isPossiblySpectrum(dg) ? Spectrum : NotSpecified);

--- a/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/util/StringUtils.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.util;
 
+import edu.caltech.ipac.firefly.core.Util;
 import edu.caltech.ipac.firefly.server.util.Logger;
 
 import javax.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -135,6 +137,10 @@ public class StringUtils {
         result.append(input.substring(lastIndex).replaceAll("(?i)\\s%s\\s".formatted(oldVal), newVal));
 
         return result.toString();
+    }
+
+    public static boolean isUUID(String key) {
+        return Util.Try.it(() -> UUID.fromString(key)).get() != null;
     }
 
     /**
@@ -351,15 +357,20 @@ public class StringUtils {
 
 
     /**
-     * Returns true is the given string is either null, or an empty string.
-     * A string of white spaces is also considered empty.
+     * Returns true is the object is either null, or empty collections, maps, and strings.
+     * A string of white spaces is considered empty.
      * @param o a Object
-     * @return Returns true is the given toString() is either null, or an empty string.
+     * @return Returns true is the given object is empty.
      */
     public static boolean isEmpty(Object o) {
-        return o == null || isEmpty(o.toString());
+        return switch (o) {
+            case null -> true;
+            case String s -> s.trim().isEmpty();
+            case Collection<?> c -> c.isEmpty();
+            case Map<?,?> m -> m.isEmpty();
+            default -> o.toString().isEmpty();
+        };
     }
-
     /**
      * Returns true if two strings have the same value (null is considered to be equal to "") 
      * @param s1 first string


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1779
- add configurable default TTL to distributed cache
- remove TTL from job history cache
- add new redis admin detail view
- add manual purge feature to admin/status

Test: https://fireflydev.ipac.caltech.edu/firefly-1779-redis-config-admin/firefly/admin/status

Added Actions:
- Redis Details:     View detailed Redis information
- Redis Cleanup:  Manually trigger Redis cleanup of stale keys

Click on `Redis Details` to see the Redis-only view
Additional info is now available: 
- `CACHE USAGE SUMMARY` 
- `FULL RAW REDIS MEMORY STATS`

**Note:**
- The `CACHE USAGE SUMMARY` requires scanning the entire Redis database to gather information.
- This summary provides useful information, including the number of stale keys.
- If you see many entries under `Stale keys`, you can click on `Redis Cleanup` to manually trigger a cleanup and remove them.

Also fixed VoTableReader not trimming Description when read in.  (Reported by Eric Bratton)
