### PR TITLE
FIREFLY-1781: Fix spherex list of target search never returns

### DIFF
--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -132,14 +132,15 @@ export function getAdqlQuery(tapBrowserState, additionalClauses, allowColumnCons
     }
 
     const helperFragment = getHelperConstraints(tapBrowserState);
+    const tableAsName = getAsEntryForTableName(tableName); // alias is used when upload table is present
     const tableCol = tableColumnsConstraints(tapBrowserState.columnsModel,
-        isUpload?getAsEntryForTableName(tableName):undefined);
+        isUpload ? tableAsName : undefined);
 
-    const { table:uploadTable, asTable:uploadAsTable, columns:uploadColumns}= isUpload ?
+    const { table:uploadTable, asTable:uploadAsTable, columns:uploadColumns} = isUpload ?
         getTapUploadSchemaEntry(tapBrowserState) : {};
 
     const fromTables= isUpload ?
-        `${tableName} AS ${getAsEntryForTableName(tableName)}, ${TAP_UPLOAD_SCHEMA}.${uploadTable} ${uploadAsTable ? 'AS '+uploadAsTable : ''}` :
+        `${tableName} AS ${tableAsName}, ${TAP_UPLOAD_SCHEMA}.${uploadTable} ${uploadAsTable ? 'AS '+uploadAsTable : ''}` :
         tableName;
 
     // check for errors
@@ -153,7 +154,7 @@ export function getAdqlQuery(tapBrowserState, additionalClauses, allowColumnCons
     }
 
     // build columns
-    let selcols = tableCol.selcols || (isUpload ? `${tableName}.*` : '*');
+    let selcols = tableCol.selcols || (isUpload ? `${tableAsName}.*` : '*');
     if (isUpload) {
         const ut= uploadAsTable ?? uploadTable ?? '';
         const tCol= uploadColumns.filter(({use}) => use).map( ({name}) => ut+'.'+name);


### PR DESCRIPTION
Fixes [FIREFLY-1781](https://jira.ipac.caltech.edu/browse/FIREFLY-1781)

At L156, ADQL query creation was using original table name instead of alias when there are no selected columns (which is the case with spherex that has column constraints turned off). Now alias `tableAsName` is used whenever `isUpload` is true.

## Testing
https://firefly-1781-lvf-multiobject.irsakudev.ipac.caltech.edu/applications/spherex

In spectral image search, select "Multi-object" -> upload the tables in the ticket -> the query should complete instead of getting stuck or failing:
- `example2input-short.tbl`: Luisa's original table doesn't have any covered targets so it should come back with no data found
- `modded-example2input-short.tbl`: I created this table with 3 targets covered by spherex, so it should come back with data.