### PR TITLE
FIREFLY-1759: Enable downloads for Datalink tables

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.net.URL;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.getSelectedData;
 import static org.apache.commons.lang.StringUtils.isEmpty;
@@ -35,6 +36,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
     public static final String SEMANTICS = "semantics";
     public static final String CONTENT_TYPE = "content_type";
     public static final String FILE = "file";
+    public static final String SOURCE = "source";
 
     public static final String DATALINK_SER_DEF = "datalinkServiceDescriptor";
     public static final String ADHOC_SERVICE = "adhoc:service";
@@ -59,6 +61,11 @@ public class ObsCorePackager extends FileGroupsProcessor {
     private static final List<String> CUTOUT_UCDs= Arrays.asList("phys.size","phys.size.radius","phys.angSize", "pos.spherical.r");
     private static final List<String>  RA_UCDs= List.of("pos.eq.ra");
     private static final List<String>  DEC_UCDs= List.of("pos.eq.dec");
+
+    private static final List<String> SERVICE_DESC_COL_NAMES = List.of(
+            "id", "access_url", "service_def", "error_message", "semantics",
+            "description", "content_type", "content_length"
+    );
 
     record CenterCols(String lonCol, String latCol) {}
 
@@ -89,42 +96,51 @@ public class ObsCorePackager extends FileGroupsProcessor {
             var selectedRows = new ArrayList<>(request.getSelectedRows());
             MappedData dgDataUrl = EmbeddedDbUtil.getSelectedMappedData(request.getSearchRequest(), selectedRows); //returns all columns
             DataGroup dg = getSelectedData(request.getSearchRequest(), selectedRows);
-            Map<String, Integer> prefixCounter = new HashMap<>();
 
-            String datalinkServDesc = request.getParam(DATALINK_SER_DEF); //check for a non-obscore table containing a Datalink Service Descriptor
             String pos = request.getParam(POSITION);
+            Map<String, Integer> prefixCounter = new HashMap<>();
+            String datalinkServDesc = request.getParam(DATALINK_SER_DEF); //check for a non-obscore table containing a Datalink Service Descriptor
 
-            for (int idx : selectedRows) {
-                String access_url = (String) dgDataUrl.get(idx, ACCESS_URL);
+            DataType[] dataDefs = dg.getDataDefinitions();
+            boolean isRequestDatalink = checkIfRequestIsDatalink(dataDefs);
 
-                if (access_url == null) {
-                    //check if this could be a non-obscore table containing a datalink url
-                    if (datalinkServDesc != null) {
-                        //construct product url / access url here
-                        ServDescUrl serDescUrl = createUrlFromServDesc(datalinkServDesc);
-                        access_url = getAccessUrlFromNonObsCore(serDescUrl, dg, dgDataUrl, idx);
+            if (isRequestDatalink) { //to check if the incoming request is directly from a datalink table (in cases where user may extract a table from an existing obscore type table)
+                List<String> positionColVals = getPositionColVals(pos, -1, null); //don't need index or dgDataUrl, pos should have ra/dec vals
+                List<FileInfo> tmpFileInfos = parseDatalink(null, request, "", positionColVals, dg);
+                fileInfos.addAll(tmpFileInfos);
+            }
+            else {
+                for (int idx : selectedRows) {
+                    String access_url = (String) dgDataUrl.get(idx, ACCESS_URL);
+
+                    if (access_url == null) {
+                        //check if this could be a non-obscore table containing a datalink url
+                        if (datalinkServDesc != null) {
+                            //construct product url / access url here
+                            ServDescUrl serDescUrl = createUrlFromServDesc(datalinkServDesc);
+                            access_url = getAccessUrlFromNonObsCore(serDescUrl, dg, dgDataUrl, idx);
+                        } else continue; //no file available to process
                     }
-                    else continue; //no file available to process
-                }
 
-                String access_format = (String) dgDataUrl.get(idx, ACCESS_FORMAT);
-                URL url = new URL(access_url);
+                    String access_format = (String) dgDataUrl.get(idx, ACCESS_FORMAT);
+                    URL url = new URL(access_url);
 
-                List<String> positionColVals = getPositionColVals(pos, idx, dgDataUrl);
-                String colNames = request.getSearchRequest().getParam(TEMPLATE_COL_NAMES);
-                String[] cols = colNames != null ? colNames.split(",") : null;
-                String fileNamePrefix = getFileNamePrefix(idx, cols, dgDataUrl, url, positionColVals); //this will be used as folder name, and as prefix for individual file names
-                fileNamePrefix = makeUniquePrefix(fileNamePrefix, prefixCounter);
+                    List<String> positionColVals = getPositionColVals(pos, idx, dgDataUrl);
+                    String colNames = request.getSearchRequest().getParam(TEMPLATE_COL_NAMES);
+                    String[] cols = colNames != null ? colNames.split(",") : null;
+                    String fileNamePrefix = getFileNamePrefix(idx, cols, dgDataUrl, url, positionColVals); //this will be used as folder name, and as prefix for individual file names
+                    fileNamePrefix = makeUniquePrefix(fileNamePrefix, prefixCounter);
 
-                boolean isDatalink = (datalinkServDesc != null) || (access_format != null && access_format.contains(DATALINK));
+                    boolean isTblContainsDatalink = (datalinkServDesc != null) || (access_format != null && access_format.contains(DATALINK));
 
-                if (isDatalink) {
-                    List<FileInfo> tmpFileInfos = parseDatalink(url, request, dgDataUrl, idx, fileNamePrefix, positionColVals);
-                    fileInfos.addAll(tmpFileInfos);
-                } else {
-                    String extName = null;
-                    FileInfo fileInfo = new FileInfo(access_url, extName, 0);
-                    fileInfos.add(fileInfo);
+                    if (isTblContainsDatalink) {
+                        List<FileInfo> tmpFileInfos = parseDatalink(url, request, fileNamePrefix, positionColVals, null);
+                        fileInfos.addAll(tmpFileInfos);
+                    } else {
+                        String extName = null;
+                        FileInfo fileInfo = new FileInfo(access_url, extName, 0);
+                        fileInfos.add(fileInfo);
+                    }
                 }
             }
             fileInfos.forEach(fileInfo -> fileInfo.setRequestInfo(HttpServiceInput.createWithCredential(fileInfo.getInternalFilename())));
@@ -135,7 +151,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
         return Arrays.asList(new FileGroup(fileInfos, null, 0, "ObsCore Download Files"));
     }
 
-    public static List<FileInfo> parseDatalink(URL url, DownloadRequest request, MappedData dgDataUrl, int idx, String prepend_file_name, List<String> positionColVals) {
+    public static List<FileInfo> parseDatalink(URL url, DownloadRequest request, String prepend_file_name, List<String> positionColVals, DataGroup data) throws IOException {
         List<FileInfo> fileInfos = new ArrayList<>();
         boolean isFlattenedStructure = request.getBooleanParam("isFlattenedStructure"); //true if flattened, else false for structured logic
         boolean generateDownloadFileName = Boolean.parseBoolean(Objects.toString(request.getParam(GENERATE_DOWNLOAD_FILE_NAME), "false"));
@@ -145,7 +161,13 @@ public class ObsCorePackager extends FileGroupsProcessor {
         String cutoutValue = request.getParam(CUTOUT_VALUE);
 
         try {
-            DataGroup[] groups = VoTableReader.voToDataGroups(url.toString(), false);
+            DataGroup[] groups;
+            if (data != null) { //if the request is from a datalink table, we will get the DataGroup object created directly from the table's selected rows
+                groups = new DataGroup[]{data};
+            }
+            else {
+                groups = VoTableReader.voToDataGroups(url.toString(), false); //for obscore/non obscore tables containing datalink, we use the acesss_url of the datalink
+            }
 
             //to be used for cutout service descriptor url
             Map<String, ServDescUrl> serDefUrls = new HashMap<>();
@@ -174,6 +196,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
                 }
 
                 for (int i=0; i < dg.size(); i++) {
+                    //if (indices != null && !indices.contains(i)) continue;
                     String accessUrl = Objects.toString(dg.getData(ACCESS_URL, i), null);
                     String sem = Objects.toString(dg.getData(SEMANTICS, i), null);
                     String file = Objects.toString(dg.getData(FILE, i), null);
@@ -230,6 +253,19 @@ public class ObsCorePackager extends FileGroupsProcessor {
             e.printStackTrace();
         }
         return fileInfos;
+    }
+
+    //this function checks if the incoming request is directly from a datalink table (in cases where user may extract a table from an existing obscore type table)
+    public static boolean checkIfRequestIsDatalink(DataType[] dataDefs) {
+        if (dataDefs == null || dataDefs.length == 0) return false;
+
+        Set<String> columnNames = Arrays.stream(dataDefs)
+                .map(attr -> attr.getKeyName().toLowerCase())
+                .collect(Collectors.toSet());
+
+        //check if all service desc column names are present - confirming whether this is a datalink table
+        return SERVICE_DESC_COL_NAMES.stream()
+                .allMatch(columnNames::contains);
     }
 
     private static String makeUniquePrefix(String basePrefix, Map<String, Integer> prefixCounter) {
@@ -418,16 +454,30 @@ public class ObsCorePackager extends FileGroupsProcessor {
 
     private static Position getPosition(String pos) {
         JSONObject jsonObject = new JSONObject(pos);
-        JSONObject centerColsJson = jsonObject.getJSONObject(CENTER_COL_NAMES);
-        CenterCols centerColNames = new CenterCols(
-                String.valueOf(centerColsJson.get(LON_COL)),
-                String.valueOf(centerColsJson.get(LAT_COL))
-        );
+
+        //handle centerColNames with fallback
+        String lonCol = RA;
+        String latCol = DEC;
+
+        if (jsonObject.has(CENTER_COL_NAMES)) {
+            JSONObject centerColsJson = jsonObject.getJSONObject(CENTER_COL_NAMES);
+            if (centerColsJson.has(LON_COL)) {
+                lonCol = String.valueOf(centerColsJson.get(LON_COL));
+            }
+            if (centerColsJson.has(LAT_COL)) {
+                latCol = String.valueOf(centerColsJson.get(LAT_COL));
+            }
+        }
+
+        CenterCols centerColNames = new CenterCols(lonCol, latCol);
+
+        //parse centerColValues
         JSONObject centerColValuesJson = jsonObject.getJSONObject(CENTER_COL_VALS);
-        CenterColValues centerColValues = new CenterColValues(
-                String.valueOf(centerColValuesJson.get(RA)),
-                String.valueOf(centerColValuesJson.get(DEC))
-        );
+        String raVal = String.valueOf(centerColValuesJson.opt(RA));//could be "null"
+        String decVal = String.valueOf(centerColValuesJson.opt(DEC));//could be "null"
+
+        CenterColValues centerColValues = new CenterColValues(raVal, decVal);
+
         return new Position(centerColNames, centerColValues);
     }
 

--- a/src/firefly/js/metaConvert/TableDataProductUtils.js
+++ b/src/firefly/js/metaConvert/TableDataProductUtils.js
@@ -13,9 +13,13 @@ import {ChartType, TableDataType} from '../data/FileAnalysis';
 import {MetaConst} from '../data/MetaConst';
 import {makeFileRequest} from '../tables/TableRequestUtil';
 import {
-    dispatchActiveTableChanged, dispatchTableRemove, dispatchTableSearch, TBL_RESULTS_ACTIVE, TBL_UI_EXPANDED
+    dispatchActiveTableChanged,
+    dispatchTableRemove,
+    dispatchTableSearch,
+    TBL_RESULTS_ACTIVE,
+    TBL_UI_EXPANDED
 } from '../tables/TablesCntlr';
-import {getActiveTableId, getTblById, onTableLoaded} from '../tables/TableUtil';
+import {getActiveTableId, getMetaEntry, getTblById, onTableLoaded} from '../tables/TableUtil';
 import {getCellValue, getTblInfo} from '../tables/TableUtil.js';
 import MultiViewCntlr, {dispatchUpdateCustom, getMultiViewRoot, getViewer} from '../visualize/MultiViewCntlr.js';
 import {
@@ -181,14 +185,18 @@ export function extractDatalinkTable(table,row,title,setAsActive=true) {
     const sRegion= getObsCoreSRegion(table,row);
     const rowWP=  makeWorldPtUsingCenterColumns(table, row);
 
-
     const dataTableReq= makeTableRequest(url,{titleStr:title},undefined,0,undefined,undefined,undefined,true);
     if (positionWP) dataTableReq.META_INFO[MetaConst.SEARCH_TARGET]= positionWP.toString();
     if (sRegion) dataTableReq.META_INFO[MetaConst.S_REGION]= sRegion;
     if (rowWP) dataTableReq.META_INFO[MetaConst.ROW_TARGET]= rowWP.toString();
 
     dispatchTableSearch(dataTableReq, {setAsActive, logHistory: false, showFilters: true, showInfoButton: true});
-    showPinMessage('Pinning to Table Area');
+
+    //return promise to let caller handle UI updates
+    return onTableLoaded(dataTableReq.tbl_id).then(() => ({
+        tbl_id: dataTableReq.tbl_id,
+        serviceId: getMetaEntry(table.tbl_id, MetaConst.DATA_SERVICE_ID) //use service id as the viewer id for MultiProductViewer
+    }));
 }
 
 

--- a/src/firefly/js/ui/DefaultSearchActions.js
+++ b/src/firefly/js/ui/DefaultSearchActions.js
@@ -3,13 +3,11 @@ import {makeSearchActionObj, SearchTypes} from '../core/ClickToAction.js';
 import {flux} from '../core/ReduxFlux.js';
 import {ServerParams} from '../data/ServerParams.js';
 import {sprintf} from '../externalSource/sprintf.js';
-import {
-    getActiveTableId, getAllColumns, getMetaEntry, getTableUiByTblId, getTblById, getTblRowAsObj, makeFileRequest,
-    onTableLoaded
+import {getActiveTableId, getTableUiByTblId, getTblById, getTblRowAsObj, makeFileRequest, onTableLoaded
 } from '../api/ApiUtilTable.jsx';
 import {extractDatalinkTable} from '../metaConvert/TableDataProductUtils';
 import {makeVOCatalogRequest} from '../tables/TableRequestUtil.js';
-import {dispatchTableSearch, dispatchTableUpdate} from '../tables/TablesCntlr.js';
+import {dispatchTableSearch, dispatchTableUiUpdate, dispatchTableUpdate} from '../tables/TablesCntlr.js';
 import {tokenSub} from '../util/WebUtil';
 import { findTableCenterColumns, isFormatDataLink, isObsCoreLike } from '../voAnalyzer/TableAnalysis.js';
 import {DEFAULT_FITS_VIEWER_ID} from '../visualize/MultiViewCntlr.js';
@@ -18,8 +16,10 @@ import {getServiceDescriptors, isDataLinkServiceDesc} from '../voAnalyzer/VoData
 import {setMultiSearchPanelTab} from './MultiSearchPanel.jsx';
 import {Format} from 'firefly/data/FileAnalysis';
 import {doJsonRequest} from 'firefly/core/JsonUtils';
-import {showInfoPopup} from 'firefly/ui/PopupUtil';
+import {showInfoPopup, showPinMessage} from 'firefly/ui/PopupUtil';
 import {getDataServiceOptionByTable} from './tap/DataServicesOptions';
+import {PrepareDownload} from 'firefly/templates/common/ttFeatureWatchers';
+import React from 'react';
 
 //note - these two redundant function are here because of circular dependencies.
 // this file is imported very early and webpack is creating errors
@@ -261,12 +261,23 @@ function searchNed(cenWpt,radius) {
     dispatchTableSearch(request);
 }
 
-function showDatalinkTable() {
-    const table= getTblById(getActiveTableId());
+
+async function showDatalinkTable() {
+    const table = getTblById(getActiveTableId());
     if (!table) return;
-    const row= table.highlightedRow;
-    extractDatalinkTable(table,row,table.title + `: Products row ${row+1}`); //row+1 for better UX for user (since row is 0 based)
+    const row = table.highlightedRow;
+
+    const result = await extractDatalinkTable(table, row, `${table.title}: Products row ${row + 1}`); //row+1 for better UX for user (since row is 0 based)
+
+    if (!result) return;
+    const {tbl_id, serviceId} = result;
+
+    const {tbl_ui_id, leftButtons = []} = getTableUiByTblId(tbl_id) ?? {};
+    leftButtons.unshift(() => <PrepareDownload tbl_id={tbl_id} viewerId={serviceId} downloadType={'script'} dataSource={serviceId}/>);
+    dispatchTableUiUpdate({ tbl_ui_id, leftButtons });
+    showPinMessage('Pinning to Table Area');
 }
+
 
 function canShowDatalinkTable(table) {
     const isObsCore= isObsCoreLike(table) && isFormatDataLink(table,table.highlightedRow);

--- a/src/firefly/js/ui/tap/Cutout.js
+++ b/src/firefly/js/ui/tap/Cutout.js
@@ -4,10 +4,9 @@ import {MetaConst} from '../../data/MetaConst';
 import {DEFAULT_DATA_PRODUCTS_COMPONENT_KEY} from '../../metaConvert/DataProductConst';
 import {getMetaEntry} from '../../tables/TableUtil';
 import {parseObsCoreRegion} from '../../util/ObsCoreSRegionParser';
-import {isValidPoint, parseWorldPt} from '../../visualize/Point';
+import {parseWorldPt} from '../../visualize/Point';
 import {pointIn} from '../../visualize/projection/Projection';
-import {
-    getObsCoreSRegion, getSearchTargetFromTable, isRowTargetCapable, makeWorldPtUsingCenterColumns
+import {getObsCoreSRegion, getSearchTargetFromTable, isDatalinkTable, isRowTargetCapable, makeWorldPtUsingCenterColumns
 } from '../../voAnalyzer/TableAnalysis';
 import {findWorldPtInServiceDef} from '../../voAnalyzer/VoDataLinkServDef';
 import {getDataServiceOptionByTable} from './DataServicesOptions';
@@ -119,7 +118,7 @@ function getIdForCutoutType(tbl_id, serDef) {
     let canDoRow = false;
     if (tbl_id) canDoRow = isRowTargetCapable(tbl_id);
 
-    if (!canDoRow && serDef) {
+    if (!canDoRow && serDef && !isDatalinkTable(tbl_id)) { //if this is a datalink table (extracted from obs core type tbl, we don't want to change the lookupTblId)
         canDoRow = Boolean(serDef?.rowWP);
         lookupTblId = canDoRow ? ROW_CAPABLE : NOT_ROW_CAPABLE;
     }
@@ -168,14 +167,20 @@ export function findPreferredCutoutTarget(dataProductsComponentKey=DEFAULT_DATA_
         if (positionWP) {
             foundType = SEARCH_POSITION;
         } else {
-            positionWP = makeWorldPtUsingCenterColumns(table, row);
+            if (isDatalinkTable(table)) positionWP = parseWorldPt(getMetaEntry(table, MetaConst.ROW_TARGET, undefined));
+            else positionWP = makeWorldPtUsingCenterColumns(table, row);
             foundType = ROW_POSITION;
         }
     } else if (cutoutType === ROW_POSITION) {
-        positionWP = makeWorldPtUsingCenterColumns(table, row);
+        if (isDatalinkTable(table)) {
+            //positionWP to come from metadata
+            positionWP = parseWorldPt(getMetaEntry(table, MetaConst.ROW_TARGET, undefined));
+        }
+        else {
+            positionWP = makeWorldPtUsingCenterColumns(table, row);
+        }
         if (!positionWP) positionWP = serDef?.rowWP;
         if (positionWP) foundType = ROW_POSITION;
-
     } else if (getCutoutTargetOverride(dataProductsComponentKey)) {
         positionWP = getCutoutTargetOverride(dataProductsComponentKey);
         if (positionWP) foundType = USER_ENTERED_POSITION;

--- a/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
+++ b/src/firefly/js/voAnalyzer/VoDataLinkServDef.js
@@ -6,7 +6,7 @@ import {MetaConst} from '../data/MetaConst';
 import {isDefined} from '../util/WebUtil';
 import {makeWorldPt, parseWorldPt} from '../visualize/Point';
 import {
-    getObsCoreAccessFormat, getObsCoreAccessURL, getObsCoreProdType, getObsCoreSRegion, getSearchTarget,
+    getObsCoreAccessFormat, getObsCoreAccessURL, getObsCoreProdType, getObsCoreSRegion,
     isDatalinkTable, isObsCoreLike,
 } from './TableAnalysis';
 import {
@@ -97,7 +97,7 @@ function getSDDescription(table, ID) {
     const descriptionCol = getColumnIdx(table, 'description');
     if (descriptionCol === -1 || serviceDefCol === -1) return;
     if (table.totalRows > 50) return;
-    const sdRow = table.tableData.data.find((dAry) => dAry[serviceDefCol] === ID);
+    const sdRow = table?.tableData?.data?.find((dAry) => dAry[serviceDefCol] === ID);
     if (!sdRow) return;
     return sdRow[descriptionCol];
 }


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1719
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/423

- Code should be fairly straightforward, just needed a bit of work to get it going and to make existing code adapt to work directly with datalink table (as opposed to obscore/non-obscore tables **_containing_** datalink, which is what our primary use case was)

**Testing**: 
- Euclid: https://firefly-1759-datalink-downloads.irsakudev.ipac.caltech.edu/applications/euclid
- do an image or object search, then extract one or more rows
- select one or more rows in the extracted Products table and the download script 
   -  you may even filter the table and then try this. For example, try searching for cutouts and download all cutouts. Ensure you see cutouts in the download script in this case. 
- try changing the cutout selection (cutout size and/or search target) directly from the products table. Any of the search targets should work as expected same as they do for the image/objects table. 
- Regression testing: select a few rows and download products on the images/objects results table as well, to ensure there are no new issues introduced there. 