### PR TITLE
Firefly 1354 timeseries save table filename

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -281,7 +281,7 @@ export function* lcManager(params={}) {
 function updateRawTableChart(timeCName, fluxCName, converterId) {
 
     if (timeCName && fluxCName) {
-
+        const missionName = getConverter(converterId).missionName;
         const title =getConverter(converterId).showPlotTitle?getConverter(converterId).showPlotTitle(LC.RAW_TABLE):'';
 
         const chartX = get(getChartData(LC.RAW_TABLE), ['tablesources', 0, 'mappings', 'x']);
@@ -307,7 +307,7 @@ function updateRawTableChart(timeCName, fluxCName, converterId) {
                 mode: 'markers'
             }],
             layout: {
-                title,
+                title: `${missionName}` + ' ' + `${title}`,
                 yaxis: {autorange: 'reversed', showgrid: true, title: {text: fluxCName}}
             }
         };

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -130,7 +130,7 @@ export function ptfRawTableRequest(converter, source, uploadFileName='') {
         uploadFileName
 
     };
-    return makeFileRequest(`${mission}`+'-Input Data', source, null, options);
+    return makeFileRequest(`${mission}`+' Input Data', source, null, options);
 
 }
 

--- a/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ptf/PTFMissionOptions.js
@@ -130,7 +130,7 @@ export function ptfRawTableRequest(converter, source, uploadFileName='') {
         uploadFileName
 
     };
-    return makeFileRequest('Input Data', source, null, options);
+    return makeFileRequest(`${mission}`+'-Input Data', source, null, options);
 
 }
 

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -147,7 +147,7 @@ export function wiseRawTableRequest(converter, source, uploadFileName='') {
 
     };
 
-    return makeFileRequest('Input Data', source, null, options);
+    return makeFileRequest(`${mission}`+'-Input Data', source, null, options);
 
 }
 

--- a/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/wise/WiseMissionOptions.js
@@ -147,7 +147,7 @@ export function wiseRawTableRequest(converter, source, uploadFileName='') {
 
     };
 
-    return makeFileRequest(`${mission}`+'-Input Data', source, null, options);
+    return makeFileRequest(`${mission}`+' Input Data', source, null, options);
 
 }
 

--- a/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
@@ -127,7 +127,7 @@ export function ztfRawTableRequest(converter, source, uploadFileName='') {
         uploadFileName
 
     };
-    return makeFileRequest(`${mission}`+'-Input Data', source, null, options);
+    return makeFileRequest(`${mission}`+' Input Data', source, null, options);
 
 }
 

--- a/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
+++ b/src/firefly/js/templates/lightcurve/ztf/ZTFMissionOptions.js
@@ -127,7 +127,7 @@ export function ztfRawTableRequest(converter, source, uploadFileName='') {
         uploadFileName
 
     };
-    return makeFileRequest('Input Data', source, null, options);
+    return makeFileRequest(`${mission}`+'-Input Data', source, null, options);
 
 }
 


### PR DESCRIPTION
View [ticket](https://jira.ipac.caltech.edu/browse/FIREFLY-1354) for details. I added two test files in the ticket for testing purpose.

To test:
https://firefly-1354-ts.irsakudev.ipac.caltech.edu/irsaviewer/ts.html

1. upload ztt-ts.tbl or wise-ts.tbl 
2. follow the steps in Luisa's video, by applying filter on the chart, then save the filtered table
3. in the ztf case the table will be saved as table_ztf-Input-Data.tbl, for wise upload table name is table_wise-Input-Data.
4. if an  unspecified mission data is uploaded, there will be no mission name in the table name: table_Input-Data. I am open to suggestions.


