### PR TITLE
 FIREFLY-1677: Better messaging for Position Cols in TAP Spatial Search

### DIFF
--- a/src/firefly/js/ui/UploadTableSelector.jsx
+++ b/src/firefly/js/ui/UploadTableSelector.jsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
 import {Box, Chip, Stack, Tooltip, Typography} from '@mui/joy';
 import PropTypes from 'prop-types';
 import {defaultsDeep, omit} from 'lodash';
@@ -16,6 +16,10 @@ import {FilterInfo} from 'firefly/tables/FilterInfo';
 import {dispatchTableFilter} from 'firefly/tables/TablesCntlr';
 import {onTableLoaded} from 'firefly/tables/TableUtil';
 
+const TAB_COLUMNS_DEFAULT_MSG='These are the recommended columns to use for a spatial search on this table; changing them could cause the query to fail.';
+const TAB_COLUMNS_USER_MSG = 'User-specified coordinate columns may or may not work depending on the configuration of the database being queried.';
+const TAB_COLUMNS_EMPTY_MSG = 'Unable to identify coordinate columns for spatial searches; spatial searches are disabled. It is possible to designate coordinate ' +
+    'columns by hand if the automatic recognition has failed; depending on the database being queried, this may or may not work.';
 
 //--------------------------------------------------------------------------------------------------------------------
 // GENERIC components and helpers
@@ -367,17 +371,32 @@ export function UploadTableSelectorPosCol(props) {
 
 export function CenterColumns({lonCol,latCol, sx, cols, lonKey, latKey, openKey,
                                   doQuoteNonAlphanumeric, headerTitle='Position Columns:',
-                                  headerPostTitle = '', openPreMessage='', slotProps}) {
+                                  headerPostTitle = '', posDefaultOpenMsg='', setPosDefaultOpenMsg, slotProps}) {
     const columnFields = positionColumnFields(
         {fieldKey: lonKey, doQuoteNonAlphanumeric},
         {fieldKey: latKey, doQuoteNonAlphanumeric}
     );
-    const customSlotProps = defaultsDeep({...slotProps}, selectorPosColSlotProps.columnMappingPanel.slotProps);
+
+    const customSlotProps = defaultsDeep({openPreMessage: {level: 'body-sm'}}, slotProps, selectorPosColSlotProps.columnMappingPanel.slotProps);
+
+    const [openPreMsg, setOpenPreMsg] = useState(TAB_COLUMNS_DEFAULT_MSG);
+
+    useEffect(() => {
+        if (!lonCol || !latCol) setOpenPreMsg(TAB_COLUMNS_EMPTY_MSG);
+        else {
+            if (posDefaultOpenMsg) {
+                setOpenPreMsg(TAB_COLUMNS_DEFAULT_MSG);
+                setPosDefaultOpenMsg(false);
+            }
+            else setOpenPreMsg(TAB_COLUMNS_USER_MSG);
+        }
+    }, [lonCol, latCol]);
+
 
     return (
         <ColumnMappingPanel cols={cols} columnFieldValues={[lonCol, latCol]} columnFields={columnFields}
                             panelKey={openKey} headerTitle={headerTitle} headerPostTitle={headerPostTitle}
-                            openPreMessage={openPreMessage} sx={sx} slotProps={customSlotProps}/>
+                            openPreMessage={openPreMsg} sx={sx} slotProps={customSlotProps}/>
     );
 }
 
@@ -392,7 +411,8 @@ CenterColumns.propTypes = {
     doQuoteNonAlphanumeric: PropTypes.bool,
     headerTitle: PropTypes.node,
     headerPostTitle: PropTypes.string,
-    openPreMessage: PropTypes.string,
+    posDefaultOpenMsg: PropTypes.bool,
+    setPosDefaultOpenMsg: PropTypes.func,
     slotProps: ColumnMappingPanel.propTypes.slotProps,
     children: PropTypes.node
 };

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -69,8 +69,6 @@ export const MULTI= 'multi';
 const SpatialLabelSpatial = '6em';
 const ICRS = 'ICRS';
 
-const TAB_COLUMNS_MSG='These are the recommended columns to use for a spatial search on this table; changing them could cause the query to fail';
-
 const spacialTypeOps = [{label: 'Single Object', value: SINGLE}, {label: 'Multi-object', value: MULTI, tooltip:'for uploaded table'}];
 
 const emptyCenterCols= {lon: '', lat: ''};
@@ -133,13 +131,11 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, serviceId, co
     const {setVal,getVal,makeFldObj}= useContext(FieldGroupCtx);
     const [constraintResult, setConstraintResult] = useState({});
     const [getUploadInfo, setUploadInfo]= useFieldGroupValue('uploadInfo');
-    const [posOpenMsg, setPosOpenMsg]= useState(TAB_COLUMNS_MSG);
+    const [posDefaultOpenMsg, setPosDefaultOpenMsg]= useState(true);
 
     useFieldGroupRerender([...fldListAry, ...collapsibleCheckHeaderKeys]); // force rerender on any change
 
     const uploadInfo= getUploadInfo() || undefined;
-
-
 
     const updatePanelStatus= makePanelStatusUpdater(checkHeaderCtl.isPanelActive(), Spatial);
 
@@ -196,6 +192,7 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, serviceId, co
             cols && setVal(CenterLonColumns, lon, {validator: getColValidator(cols, true, false, errMsg), valid: true});
             cols && setVal(CenterLatColumns, lat, {validator: getColValidator(cols, true, false, errMsg), valid: true});
             const noDefaults= !lon || !lat;
+            if (lon && lat) setPosDefaultOpenMsg(true);
             setVal(posOpenKey, (noDefaults) ? 'open' : 'closed');
             if (noDefaults || disablePanel) checkHeaderCtl.setPanelActive(false);
             checkHeaderCtl.setPanelActive(!noDefaults);
@@ -294,8 +291,7 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, serviceId, co
                             headerTitle:posHeaderTitle, openKey:posOpenKey,
                             doQuoteNonAlphanumeric:false,
                             headerPostTitle:'(from the selected table on the right)',
-                            openPreMessage:posOpenMsg,
-                            cols, lonKey:CenterLonColumns, latKey:CenterLatColumns}} />}
+                            posDefaultOpenMsg, cols, lonKey:CenterLonColumns, latKey:CenterLatColumns, setPosDefaultOpenMsg}} />}
                 </ForceFieldGroupValid>
             </Stack>
             <DebugObsCore {...{constraintResult}}/>


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1677
- See ticket for changes requested
- Also made the text a bit smaller
- The text for empty columns might be a bit too long. Should we consider a shorter version or does it look ok @gpdf?

**Testing**: https://fireflydev.ipac.caltech.edu/firefly-1677-better-tap-msg/firefly
- Test according to ticket
- if you select a table with pre-filled columns, you should see the default message (`These are the recommended columns...`)
- If you now manually select any columns, you should see the user selected message (`User-specified coordinate columns...`)
- if you remove a column selection or get a table with no pre filled columns (try `TAP_SCHEMA` under `IRSA`), you should get an empty columns message (`Unable to identify coordinate columns...`)