### PR TITLE
Trying out redis improvements

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
@@ -1,5 +1,6 @@
 package edu.caltech.ipac.firefly.core.background;
 
+import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.server.RequestOwner;
 import edu.caltech.ipac.firefly.server.SrvParam;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
@@ -13,6 +14,9 @@ import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.server.util.QueryUtil.combineErrorMsg;
 import static java.util.Optional.ofNullable;
+
+import redis.clients.jedis.Jedis;
+
 
 /**
  * Date: 9/29/21
@@ -57,11 +61,20 @@ public interface Job extends Callable<String> {
 
     default String call() {
 
+        String jobId = getJobId();
+
         sendJobStatus(ji -> {
             ji.setPhase(JobInfo.Phase.EXECUTING);
             ji.getMeta().setProgress(10);
             ji.setStartTime(Instant.now());
         });
+
+        try (Jedis redis = RedisService.getConnection()) {
+            redis.sadd("runningJobs", jobId); //add job a new runningJobs redis set
+        } catch (Exception e) {
+            Logger.getLogger().error(e);
+        }
+
         try {
             String results = run();
             updateJobStatus(ji -> ji.setPhase(JobInfo.Phase.COMPLETED));
@@ -79,6 +92,12 @@ public interface Job extends Callable<String> {
                 ji.getMeta().setProgress(100);
             });
             getWorker().onComplete();
+            //cleanup jobs from runningJobs set
+            try (Jedis redis = RedisService.getConnection()) {
+                redis.srem("runningJobs", jobId);
+            } catch (Exception e) {
+                Logger.getLogger().error(e);
+            }
         }
         return null;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -5,6 +5,7 @@
 package edu.caltech.ipac.firefly.core.background;
 
 import edu.caltech.ipac.firefly.api.Async;
+import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.Util.Try;
 import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
@@ -26,18 +27,14 @@ import edu.caltech.ipac.util.cache.StringKey;
 import org.apache.commons.lang.text.StrBuilder;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import redis.clients.jedis.Jedis;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -395,7 +392,46 @@ public class JobManager {
 
     private static void checkJobs() {
 
-        // ping clients with active(EXECUTING) job
+        try (Jedis redis = RedisService.getConnection()) {
+            Set<String> jobIds = redis.smembers("runningJobs"); //this allows us to only go through running jobs - and not ALL jobs
+
+            jobIds.forEach(id -> {
+                JobInfo ji = JobManager.getJobInfo(id);
+                if (ji == null || ji.getPhase() != EXECUTING) {
+                        redis.srem("runningJobs", id); // clean up stale ID
+                }
+            });
+
+
+            //ping clients with EXECUTING/Running jobs
+            jobIds.stream()
+                    .map(JobManager::getJobInfo)
+                    .filter(Objects::nonNull)
+                    .filter(ji -> ji.getPhase() == EXECUTING)
+                    .map(ji -> ji.getMeta().getUserKey() + "::" + ji.getMeta().getEventConnId())
+                    .distinct()
+                    .forEach(client -> {
+                        String[] ownerConnId = client.split("::");
+                        WebsocketConnector.pingClient(ownerConnId[0], ownerConnId[1]);
+                    });
+
+
+
+            //kill expired jobs
+            jobIds.stream()
+                    .map(JobManager::getJobInfo)
+                    .filter(Objects::nonNull)
+                    .forEach(ji -> {
+                        long duration = ji.executionDuration();
+                        if (duration != 0 && ji.getStartTime().plus(duration, ChronoUnit.SECONDS).isBefore(Instant.now())) {
+                            abort(ji.getMeta().getJobId(), "Exceeded execution duration");
+                        }
+                    });
+
+        } catch (Exception e) {
+            Logger.getLogger().error(e);
+        }
+        /*// ping clients with active(EXECUTING) job
         getAllJobs().stream().filter(fi -> fi != null && fi.getPhase() == EXECUTING)     // all running jobs
                 .map(fi -> fi.getMeta().getUserKey() + "::" + fi.getMeta().getEventConnId()).distinct()       // get distinct list of userKey and connId
                 .forEach(client -> {                                                    // ensure it gets pinged only once, regardless of the number of jobs it has.
@@ -409,7 +445,7 @@ public class JobManager {
                     if (duration != 0 && fi.getStartTime().plus(duration, ChronoUnit.SECONDS).isBefore(Instant.now())) {
                         abort(fi.getMeta().getJobId(), "Exceeded execution duration");
                     }
-                });
+                });*/
     }
 
     private static class JobEntry {


### PR DESCRIPTION
- This is only a prototype. We can discuss this further at Thursday's meeting. I haven't been able to pin down yet whether we can safely get rid of `checkJobs` polling every 30 seconds. 
- This PR allows us to still do `checkJobs`, but instead of calling `getAllJobs` every 30 seconds, it maintains a running jobs set in redis, and uses that instead. So that check should be a lot less expensive than calling `getAllJobs` every 30 seconds. 
- I'm trying to verify if this works as expected, or if it breaks anything that `getAllJobs` achieves instead. You can test below to verify the same. 


**Testing** 
- **Euclid**: https://redis-improvements.irsakudev.ipac.caltech.edu/applications/euclid
- **Spherex**: https://redis-improvements.irsakudev.ipac.caltech.edu/applications/spherex
- **Firefly**: https://fireflydev.ipac.caltech.edu/redis-improvements/firefly
- Submit a bunch of jobs on `firefly`, `euclid` & `spherex` (some big ones, that'll take some time to process so that they're in `EXECUTING` phase).
- Then go to Job Monitor and ensure everything works as expected and that you see your `EXECUTING` jobs there.
- You can also keep the admin status page on a different tab, and look at `Redis Details` there to monitor memory usage and other stats: 
   - https://fireflydev.ipac.caltech.edu/redis-improvements/firefly/admin/status