### PR TITLE
FIREFLY-1748: Cleanup and fix failing tests

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/DownloadRequest.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/DownloadRequest.java
@@ -70,11 +70,11 @@ public class DownloadRequest extends ServerRequest implements Serializable {
 
     public boolean isSelectAll () { return _selectInfo.isSelectAll(); }
 
-    public String getBaseFileName() { return getParam(BASE_FILE_NAME); }
+    public String getBaseFileName() { return getParam(TITLE); } //use Title as the file name also
 
     public String getDataSource() { return getParam(DATA_SOURCE); }
 
-    public String getTitle() { return getParam(BASE_FILE_NAME); }
+    public String getTitle() { return getParam(TITLE); }
 
     public String getEmail() { return getParam(EMAIL); }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/DownloadScript.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/DownloadScript.java
@@ -176,6 +176,8 @@ static final String funcTmpl = """
       # move file to main directory and cleanup
       mv "$downloadedFile" "$destPath"
       echo ">> Saved as $destPath"
+      
+      [zip-logic-added-here]
 
       cd "$startDir"
       rm -rf "$tmpDir"

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -198,11 +198,11 @@ function bgSetInfo(action) {
 function bgPackage(action) {
     return (dispatch) => {
         const {dlRequest={}, searchRequest, selectionInfo, bgKey='', downloadType} = action.payload;
-        let {fileLocation, wsSelect, BaseFileName} = dlRequest;
+        let {fileLocation, wsSelect, Title} = dlRequest; //use Title as the file name
 
-        BaseFileName = BaseFileName.endsWith('.zip') ? BaseFileName : BaseFileName.trim() + '.zip';
+        Title = Title.endsWith('.zip') ? Title : Title.trim() + '.zip';
         if (fileLocation === WORKSPACE) {
-            if (!validateFileName(wsSelect, BaseFileName)) return false;
+            if (!validateFileName(wsSelect, Title)) return false;
         }
 
         const onComplete = (jobInfo) => {

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -200,7 +200,7 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
                                 viewerId,
                                 DataSource: dataSource,
                                 help_id:'table.obsCorePackage',
-                                BaseFileName: fileName ? fileName+ `_${baseFileName}` : `${baseFileName}`
+                                Title: fileName ? fileName+ `_${baseFileName}` : `${baseFileName}`
                             }}}>
                             {!isDatalink && <Stack spacing={1}>
                                 <CheckboxGroupInputField

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -140,7 +140,7 @@ export function defaultDownloadPanel(mission='', cutoutSize, addtlParams={}) {
                 title={'Image Download Options'}
                 dlParams={{
                     MaxBundleSize: 200 * 1024 * 1024,    // set it to 200mb to make it easier to test multi-parts download.  each wise image is ~64mb
-                    BaseFileName: `${mission}_Files`,
+                    Title: `${mission}_Files`,
                     DataSource: `${mission} images`,
                     FileGroupProcessor: 'LightCurveFileGroupsProcessor',
                     ...addtlParams

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -190,7 +190,7 @@ export function DownloadOptionPanel ({groupKey='DownloadDialog', cutoutSize, hel
     const maskPanel = (<BgMaskPanel key={bgKey} componentKey={bgKey}
                                    onMaskComplete={() =>hideDownloadDialog()}/>);
 
-    const dlTitle = get(dlParams, 'BaseFileName', 'Download' + '-' + dlTitleIdx); //use BaseFileName as title as well
+    const dlTitle = get(dlParams, 'Title', 'Download' + '-' + dlTitleIdx); //title will also be filename of the downloaded file
     const preTitleMessage = dlParams?.PreTitleMessage ?? '';
     return (
         <Stack sx ={{m:1/2, position: 'relative', minWidth:400, height:'auto', ...style}}>
@@ -241,9 +241,8 @@ DownloadOptionPanel.propTypes = {
 
     validateOnSubmit: PropTypes.func,      // to validate form inputs on submit
     dlParams:   PropTypes.shape({               // these params should be used as defaults value if they appears as input fields
-        TitlePrefix:    PropTypes.string,           // default title of the download..  an index number will be appended to this.
         FilePrefix:     PropTypes.string,           // packaged file prefix
-        BaseFileName:   PropTypes.string,           // zip file name
+        Title:   PropTypes.string,           // title in the UI, also the file name of the downloaded file
         DataSource:     PropTypes.string,
         MaxBundleSize:  PropTypes.number,
         FileGroupProcessor: PropTypes.string.isRequired,
@@ -255,7 +254,7 @@ export function TitleField({style={}, value, label='Title:', size=30}) {
     return (
         <ValidationField
             forceReinit={true}
-            fieldKey='BaseFileName' //title on the UI will also be used as file name on the backend
+            fieldKey='Title' //title will also be used as the filename on the server
             tooltip='Enter a description to identify this download.'
             {...{validator:NotBlank, initialState:{value}, label, size, style}}
         />

--- a/src/firefly/test/edu/caltech/ipac/firefly/util/DownloadScriptTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/util/DownloadScriptTest.java
@@ -82,8 +82,7 @@ public class DownloadScriptTest {
         assertTrue("Mkdir should be present", lines.stream().anyMatch(line -> line.contains("mkdir ")));
         assertTrue("Unzip command should be present", lines.stream().anyMatch(line -> line.contains("unzip -qq")));
     }
-
-    @Ignore("Need to update test to match new script format")
+    
     @Test
     public void wgetUnzip() throws Exception {
         List<FileGroup> fileInfoList = List.of(new FileGroup(List.of(


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1748
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/426
- fix failing unzip test in download script, re-enabled the test
- Per an older PR suggestion (https://github.com/Caltech-IPAC/firefly/pull/1745), change usage of `BaseFileName` to `Title` (since we merged these fields in the UI), and use `Title` as the file name 
  - this change has been made for the IFE apps as well, refer to the IFE PR above for the same


**Testing**
- [Spherex](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/applications/spherex), [Euclid](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/applications/euclid), [Wise](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/applications/wise), [SHA](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/applications/Spitzer/SHA), [ZTF](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/applications/ztf), [Sofia](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/applications/sofia), [Finderchart](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/applications/finderchart), [DCE](https://firefly-1748-cleanup-fixes.irsakudev.ipac.caltech.edu/irsaviewer/dce)
- For all apps, just do any (only one) search, try and select a few resulting rows and download, ensure the downloaded file name matches the name in the `Title` field of the download dialog