### PR TITLE
FIREFLY-1796: Optimize Redis usage when querying jobs by user

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/api/Async.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/api/Async.java
@@ -18,8 +18,11 @@ import edu.caltech.ipac.firefly.core.background.JobManager;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.time.Instant;
+import java.util.Comparator;
 import java.util.List;
 
+import static edu.caltech.ipac.firefly.core.background.JobManager.JOB_LIST_DEFAULT_LIMIT;
 import static edu.caltech.ipac.firefly.data.ServerParams.JOB_ID;
 import static edu.caltech.ipac.util.StringUtils.*;
 
@@ -54,7 +57,7 @@ public class Async extends BaseHttpServlet {
             if (jobId == null) {
                 if (params.size() == 0) {
                     // list all jobs for current user;          /CmdSrv/async
-                    listUserJob(res);
+                    listUserJob(res, params);
                 } else {
                     // submit job with given cmd parameters;    /CmdSrv/async?cmd=xxx
                     submitJob(res, params);
@@ -93,10 +96,35 @@ public class Async extends BaseHttpServlet {
 //
 //====================================================================
 
-    private static void listUserJob(HttpServletResponse res) throws Exception {
-        // list all jobs for current user; /CmdSrv/async
+    /**
+     * List all jobs for current user sorted by creation time. Returns a JSON array of job info.
+     * @param res
+     * @param params
+     * @throws Exception
+     */
+    private static void listUserJob(HttpServletResponse res, SrvParam params) throws Exception {
+        int last = params.getOptionalInt("LAST", JOB_LIST_DEFAULT_LIMIT);
+        List<String > phase = params.getOptionalList("PHASE");
+        String after = params.getOptional("AFTER");
         List<JobInfo> list = JobManager.list();
-        sendResponse(JobUtil.toJsonJobList(list), res);
+        list.sort(
+                Comparator.comparing(
+                        JobInfo::getCreationTime,
+                        Comparator.nullsFirst(Comparator.naturalOrder())
+                ).reversed()
+        );
+        if (phase != null && !phase.isEmpty()) {
+            list.removeIf(info -> !phase.contains(info.getPhase().name()));
+        }
+        if (after != null) {
+            list.removeIf(info -> info.getCreationTime().compareTo(Instant.parse(after)) < 0);
+        }
+        boolean overflow = false;
+        if (list.size() > last) {
+            overflow = true;
+            list = list.subList(0, last);
+        }
+        sendResponse(JobUtil.toJsonJobList(list, overflow), res);
     }
 
     private static void submitJob(HttpServletResponse res, SrvParam params) throws Exception {

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
@@ -64,7 +64,10 @@ public interface Job extends Callable<String> {
         });
         try {
             String results = run();
-            updateJobStatus(ji -> ji.setPhase(JobInfo.Phase.COMPLETED));
+            updateJobStatus(ji -> {
+                ji.setPhase(JobInfo.Phase.COMPLETED);
+                ji.getMeta().setProgress(100, "");
+            });
             return results;
         } catch (InterruptedException | DataAccessException.Aborted e) {
             updateJobStatus(ji -> ji.setPhase(JobInfo.Phase.ABORTED));

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -19,22 +19,21 @@ import edu.caltech.ipac.firefly.server.events.ServerEventManager;
 import edu.caltech.ipac.firefly.server.events.WebsocketConnector;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
-import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheKey;
 import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.cache.StringKey;
 import org.apache.commons.lang.text.StrBuilder;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import redis.clients.jedis.params.ScanParams;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
@@ -51,7 +50,6 @@ import static edu.caltech.ipac.firefly.data.ServerParams.EMAIL;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static edu.caltech.ipac.firefly.core.background.Job.Type.PACKAGE;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase.*;
-import static java.util.Optional.ofNullable;
 
 
 /**
@@ -64,19 +62,22 @@ public class JobManager {
 
     public static final String BG_INFO = "background.info";
     public static final String ALL_JOB_CACHE_KEY = "ALL_JOB_INFOS"; // cache key for all job infos
-    public static final long CLEANUP_INTVL_MINS = AppProperties.getIntProperty("job.cleanup.interval", 60);     // run cleanup once every 60 minutes
+    public static final long CLEANUP_INTVL_MINS = AppProperties.getIntProperty("job.cleanup.interval", 12*60);          // run cleanup once every 12 hours
+    public static final int JOB_LIST_DEFAULT_LIMIT = AppProperties.getIntProperty("job.list.default.limit", 100_000);    // the default limit for job list queries
     private static final int KEEP_ALIVE_INTERVAL = AppProperties.getIntProperty("job.keepalive.interval", 60);  // default keepalive interval in seconds
     private static final int WAIT_COMPLETE = AppProperties.getIntProperty("job.wait.complete", 1);              // wait for complete after submit in seconds
     private static final int MAX_PACKAGERS = AppProperties.getIntProperty("job.max.packagers", 10);             // maximum number of simultaneous packaging threads
     private static final int JOB_EXPIRY_HOURS = AppProperties.getIntProperty("job.expiry.hours", 24*14);        // Time in hours to keep a job after it has ended.  Default to 14 days.
+    public static final int JOB_SCAN_BATCH_SIZE = AppProperties.getIntProperty("job.scan.batch_size", 10_000);   // batch size for scanning job keys in Redis.  Default to 10,000.  Larger value return more keys per call but use more CPU and memory per iteration.  this is a good size for larger redis store.
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     private static final ExecutorService packagers = Executors.newFixedThreadPool(MAX_PACKAGERS);
     private static final ExecutorService searches = Executors.newCachedThreadPool();
     private static final HashMap<String, JobEntry> runningJobs = new HashMap<>();
-    private static final Cache<JobInfo> allJobInfos = new DistribMapCache<>(ALL_JOB_CACHE_KEY, 0, new JobInfoSerializer()); // the all job hash should never expire
+    private static final DistribMapCache<JobInfo> allJobInfos = new DistribMapCache<>(ALL_JOB_CACHE_KEY, 0, new JobInfoSerializer()); // the all job hash should never expire
     private static final String COMPLETED_HANDLER = AppProperties.getProperty("job.completed.handler");
-
+    private static final CacheKey JOB_CACHE_VERSION_KEY = new StringKey("job.all.cache.version");
+    private static final String JOB_CACHE_VERSION = "1.0";
 
     static {
         if (!isEmpty(COMPLETED_HANDLER)) {
@@ -92,16 +93,26 @@ public class JobManager {
         Messenger.subscribe(JobEvent.TOPIC, new JobEventHandler());
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
                     JobManager::checkJobs, KEEP_ALIVE_INTERVAL, KEEP_ALIVE_INTERVAL, TimeUnit.SECONDS);   // check every 30 seconds
+
+
+        String jobCacheVersion = (String) CacheManager.getDistributed().get(JOB_CACHE_VERSION_KEY);
+        if (isEmpty(jobCacheVersion) || !jobCacheVersion.equals(JOB_CACHE_VERSION)) {
+            LOG.info("Migrating job cache keys to new format");
+            int count = migrateRedisKeys();
+            LOG.info("Migrated " + count + " job cache keys to new format");
+            CacheManager.getDistributed().put(JOB_CACHE_VERSION_KEY, JOB_CACHE_VERSION); // set the version
+        }
     }
 
     /**
      * @return a list of JobInfo belonging to the current request owner
      */
     public static List<JobInfo> list() {
+        List<JobInfo> userJobs = JobManager.getUserJobs();      // Ensure getUserJobs() is called only once, since it may be expensive. List is updated and returned at the end.
         UWS_HISTORY_SVCS.forEach(svc -> {
-            Try.it(() -> importJobHistories(svc)).getOrElse(LOG::error);
+            Try.it(() -> importJobHistories(svc, userJobs)).getOrElse(LOG::error);
         });
-        return getAllUserJobs();
+        return userJobs;
     }
 
     public static JobInfo submit(Job job) {
@@ -196,16 +207,27 @@ public class JobManager {
 //  Getter/Setter
 //====================================================================
 
+    public static JobInfo getJobInfo(String jobId) {
+        String userKey = ServerContext.getRequestOwner().getUserKey();
+        return getJobInfo(jobId, userKey);
+    }
+
     /**
-     * Retrieves the stored JobInfo with the given jobId.
+     * Retrieves the stored JobInfo with the given jobId and userKey.
      * Returned value is read-only.  Use updateJobInfo to update the JobInfo.
      * @param jobId the ID of the job
      * @return the JobInfo with the jobId, or null not found
      */
-    public static JobInfo getJobInfo(String jobId) {
+    public static JobInfo getJobInfo(String jobId, String userKey) {
         if (isEmpty(jobId)) return null;
-        return allJobInfos.get(cacheKey(jobId));
+        return allJobInfos.get(cacheKey(jobId, userKey));
     }
+
+    public static JobInfo getJobInfo(CacheKey ckey) {
+        if (isEmpty(ckey)) return null;
+        return allJobInfos.get(ckey);
+    }
+
 
     /**
      *  see {@link #updateJobInfo(String, boolean, Consumer)}
@@ -291,30 +313,40 @@ public class JobManager {
     public static String getStatistics(boolean details) {
         StrBuilder sb = new StrBuilder();
 
-
         sb.append        ("          |   Job Count Active Count  Error Count\n");
         sb.append        ("          |------------ ------------ ------------\n");
+        List<JobInfo> allJobs = getAllJobs();
 
         Arrays.stream(Job.Type.values()).forEach(type -> {
-            long total = getAllJobs().stream().filter(v -> v.getMeta().getType() == type).count();
-            long active = getAllJobs().stream().filter(v -> v.getPhase() == EXECUTING && v.getMeta().getType() == type).count();
-            long error = getAllJobs().stream().filter(v -> v.getPhase() == ERROR && v.getMeta().getType() == type).count();
+            long total = allJobs.stream().filter(v -> v.getMeta().getType() == type).count();
+            long active = allJobs.stream().filter(v -> v.getPhase() == EXECUTING && v.getMeta().getType() == type).count();
+            long error = allJobs.stream().filter(v -> v.getPhase() == ERROR && v.getMeta().getType() == type).count();
 
             sb.append(String.format("%9s |%,12d %,12d %,12d\n", type, total, active, error));
         });
 
         if (details) {
-            sb.append("\n");
-            sb.append("JOB ID               LOCAL JOB ID         PHASE       startTime              elapsedTime(s) progress monitored userKy                               \n");
+            allJobs.sort(
+                    Comparator.comparing(
+                            JobInfo::getCreationTime,
+                            Comparator.nullsFirst(Comparator.naturalOrder())
+                    ).reversed()
+            );
+
+
+            List<JobInfo> subList = allJobs.subList(0, 100);
+            sb.append("\n (ONLY THE LATEST 100 JOBS ARE SHOWN BELOW) \n");
+            sb.append("JOB ID               LOCAL JOB ID         PHASE       creationTime           elapsedTime(s) progress monitored userKy                               \n");
             sb.append("-------------------- -------------------- ----------- ---------------------- -------------- -------- --------- -------------------------------------\n");
-            getAllJobs().forEach((ji) -> {
-                Instant endT = ji.getEndTime() != null ? ji.getEndTime() : Instant.now();
+            subList.forEach((ji) -> {
+                Instant endT = ji.getEndTime();
+                Instant startT = ji.getStartTime();
                 sb.append(String.format("%-20s %-20s %-11s %-22s %,14d %8d %9s %-37s\n",
                         ji.getJobId(),
                         ji.getMeta().getJobId(),
                         ji.getPhase(),
-                        ji.getStartTime().truncatedTo(ChronoUnit.SECONDS),
-                        Duration.between(ji.getStartTime(), endT).toSeconds(),
+                        ji.getCreationTime() == null ? "" : ji.getCreationTime().truncatedTo(ChronoUnit.SECONDS),
+                        startT == null || endT == null ? -1 : Duration.between(startT, endT).toSeconds(),
                         ji.getMeta().getProgress(),
                         ji.getMeta().isMonitored(),
                         ji.getMeta().getUserKey()));
@@ -328,32 +360,31 @@ public class JobManager {
                 .map(je -> getJobInfo(je.job.getJobId()))               // convert JobEntry to JobInfo
                 .filter(Objects::nonNull).toList();                     // return only non-null JobInfo
     }
+    /**
+     * Get all job keys in the datastore.
+     * @return a list of all job keys in the datastore
+     */
+    static List<String> getAllJobKeys() {
+        return allJobInfos.getKeys().stream().map(CacheKey::getUniqueString).toList();
+    }
 
+    /**
+     * Get jobs history.  This may be expensive when there are huge number of jobs, so use with caution.
+     * @return a list of all JobInfo in the datastore
+     */
     static List<JobInfo> getAllJobs() {
-        List<? extends CacheKey> keys = allJobInfos.getKeys();
-        if (keys == null || keys.isEmpty()) return Collections.emptyList();
-        ArrayList<JobInfo> rval = new ArrayList<JobInfo>(keys.size());
-        for (CacheKey key : keys) {
-            JobInfo jobInfo = ifNotNull(() -> allJobInfos.get(key)).get();  // ignore error
-            if (jobInfo != null) {
-                rval.add(jobInfo);
-            }
-        }
-        return rval;
+        ScanParams scanParams = new ScanParams().match("*").count(JOB_SCAN_BATCH_SIZE); // adjust count as needed
+        return allJobInfos.getValuesFor(scanParams);
     }
 
     /**
      * Get all jobs that belong to the current user
      * @return a list of JobInfo that belong to the current user
      */
-    static List<JobInfo> getAllUserJobs() {
+    static List<JobInfo> getUserJobs() {
         String userKey = ServerContext.getRequestOwner().getUserKey();
-        return ofNullable(getAllJobs())
-                .orElse(Collections.emptyList())
-                .stream()
-                .filter(info -> userKey.equals(info.getMeta().getUserKey()) && info.getMeta().isMonitored())  // only return monitored jobs belonging to the current user
-                .toList();
-
+        ScanParams scanParams = new ScanParams().match("*:%s".formatted(userKey)).count(JOB_SCAN_BATCH_SIZE); // adjust count as needed
+        return allJobInfos.getValuesFor(scanParams);
     }
 
 //====================================================================
@@ -386,20 +417,27 @@ public class JobManager {
     }
 
     private static CacheKey cacheKey(JobInfo jobInfo) {
-        return cacheKey(jobInfo.getMeta().getJobId());
+        return cacheKey(jobInfo.getMeta().getJobId(), jobInfo.getMeta().getUserKey());
     }
 
-    private static CacheKey cacheKey(String jobId) {
-        return isEmpty(jobId) ? null : new StringKey(jobId);
+    /**
+     * Redis key is compose of jobId and userKey.  This is so that we can filter the keys for a specific user.
+     * jobId should still be unique.  If jobId is empty, it will return null.
+     * @param jobId
+     * @param userKey
+     * @return a CacheKey for the jobId and userKey, or null if jobId is empty
+     */
+    private static CacheKey cacheKey(String jobId, String userKey) {
+        return isEmpty(jobId) ? null : new StringKey(jobId + ":" + userKey);
     }
 
     private static void checkJobs() {
 
-        // ping clients with active(EXECUTING) job
-        getAllJobs().stream().filter(fi -> fi != null && fi.getPhase() == EXECUTING)     // all running jobs
-                .map(fi -> fi.getMeta().getUserKey() + "::" + fi.getMeta().getEventConnId()).distinct()       // get distinct list of userKey and connId
+        // ping clients with active(EXECUTING) job to keep the connection alive
+        getRunningJobs().stream().filter(fi -> fi != null && fi.getPhase() == EXECUTING)     // all running jobs
+                .map(fi -> fi.getMeta().getUserKey() + ":" + fi.getMeta().getEventConnId()).distinct()       // get distinct list of userKey and connId
                 .forEach(client -> {                                                    // ensure it gets pinged only once, regardless of the number of jobs it has.
-                    String[] ownerConnId = client.split("::");
+                    String[] ownerConnId = client.split(":");
                     WebsocketConnector.pingClient(ownerConnId[0], ownerConnId[1]);      // this will only ping client with the given owner/connId
                 });
 
@@ -499,8 +537,9 @@ public class JobManager {
     }
 
     public static void cleanup() {
-        allJobInfos.getKeys().forEach( k -> {
-            JobInfo job = allJobInfos.get(k);
+        List<JobInfo> jobs = getAllJobs();
+        jobs.forEach(job -> {
+            CacheKey k = cacheKey(job);
             if (!job.getMeta().isMonitored() && job.getEndTime().plus(1, ChronoUnit.HOURS).isBefore(Instant.now())) {
                 LOG.info("Removing non-monitored job: " + k);
                 allJobInfos.remove(k);      // remove non-monitored job after 1 hour
@@ -515,7 +554,7 @@ public class JobManager {
      * This serializer is used to serialize JobInfo objects for storage in the cache.
      * Instead of using the default Java serialization, it uses a JSON string.
      */
-    private static class JobInfoSerializer implements DistribMapCache.Serializer {
+    private static class JobInfoSerializer implements DistribMapCache.Serializer<JobInfo> {
 
         public String serialize(Object obj) {
             if (obj instanceof JobInfo jobInfo) {
@@ -524,11 +563,36 @@ public class JobManager {
             return null;
         }
 
-        public Object deserialize(String str) throws Exception{
+        public JobInfo deserialize(String str) throws Exception{
             if (str != null) {
                 return toJobInfo((JSONObject) new JSONParser().parse(str));
             }
             return null;
         }
+    }
+
+
+//====================================================================
+//  Utilities: adhoc use cases
+//====================================================================
+
+    /**
+     * Migrate all Redis keys that do not have userKey in the key to the new format.
+     * @return the number of keys migrated
+     */
+    public static int migrateRedisKeys() {
+        // For keys without userKey, we need to migrate them to the new format where userKey is appended to the jobId.
+        int count = 0;
+        for(CacheKey key : allJobInfos.getKeys()) {
+            if (key instanceof StringKey sk && !sk.getUniqueString().contains(":")) { // has userKey in the key
+                JobInfo jobInfo = allJobInfos.get(key);
+                if (jobInfo != null) {
+                    allJobInfos.put(cacheKey(jobInfo), jobInfo);
+                    allJobInfos.remove(key); // remove old key
+                    count++;
+                }
+            }
+        }
+        return count;
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -26,8 +26,7 @@ import java.util.stream.Collectors;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.Util.Try;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
-import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase.COMPLETED;
-import static edu.caltech.ipac.firefly.core.background.JobManager.getAllUserJobs;
+import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase.*;
 import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.convertToJobList;
 import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.getUwsJobInfo;
@@ -92,10 +91,11 @@ public class JobUtil {
 
     /**
      * Import job histories from the given service URL.
-     * @param svcDef the service to import job histories from
+     * @param svcDef   the service to import job histories from
+     * @param userJobs
      * @return the number of job histories imported
      */
-    public static int importJobHistories(String svcDef) {
+    public static int importJobHistories(String svcDef, List<JobInfo> userJobs) {
         int count = 0;
 
         String[] svcParts = ifNotNull(svcDef).getOrElse("").split("\\|", 3);
@@ -107,8 +107,6 @@ public class JobUtil {
         URL urlObs= Try.it(() -> new URI(url).toURL()).getOrElse((URL)null);
         String paramStr= urlObs == null ? "" : urlObs.getQuery();
         String urlBase= (!isEmpty(paramStr) && url.contains("?"))  ? url.split("\\?")[0] : url;
-
-        List<JobInfo> history = getAllUserJobs();
 
         HttpServiceInput input = HttpServiceInput.createWithCredential(urlBase);
         if (!isEmpty(paramStr)) input.setRequestUrl(input.getRequestUrl()+"?"+paramStr);
@@ -130,17 +128,20 @@ public class JobUtil {
         if (hasBadJobs) LOG.debug("Some jobs with no URL or ignored runId were removed from list");
 
         for (JobInfo job : jobList.get()) {
-            JobInfo uws = Try.it(() -> getUwsJobInfo(job.getAux().getJobUrl())).get();
-            if (uws == null) {
-                LOG.debug("Failed to get job info for " + job.getAux().getJobUrl());
-            } else if (runIdIgnoreList.contains(String.valueOf(uws.getRunId()))) {
-                LOG.debug("Ignoring job at %s with RUNID=%s".formatted(job.getAux().getJobUrl(), uws.getRunId()));
+            JobInfo jobInfo = findJobInfo(job.getJobId(), userJobs);
+            if (jobInfo == null || isActive(jobInfo)) {
+                // for performance, we only get updated job info if the job is not in history, or it's still active
+                JobInfo uws = Try.it(() -> getUwsJobInfo(job.getAux().getJobUrl())).get();
+                if (uws == null) {
+                    LOG.debug("Failed to get job info for " + job.getAux().getJobUrl());
+                } else {
+                    count++;
+                    mergeJobInfo(jobInfo, uws, svcId, svcType);
+                    if (jobInfo == null )  userJobs.add(uws);           // update passed in userJobs; to avoid having to call getUserJobs, which can be expensive
+                    LOG.trace("Job added jobUrl=%s jobId=%s".formatted(job.getAux().getJobUrl(),uws.getJobId()));
+                }
             } else {
-                count++;
-                String jobId = uws.getJobId();
-                JobInfo jobInfo = findJobInfo(jobId, history);
-                mergeJobInfo(jobInfo, uws, svcId, svcType);
-                LOG.trace("Job added jobUrl=%s jobId=%s".formatted(job.getAux().getJobUrl(),uws.getJobId()));
+                LOG.debug("Job %s is already completed, skipping".formatted(job.getJobId()));
             }
         }
         LOG.debug("%d job histories imported".formatted(count));
@@ -166,8 +167,12 @@ public class JobUtil {
         return null;
     }
 
-    ;
-
+    public static boolean isActive(JobInfo jobInfo) {
+        Phase phase = jobInfo.getPhase();
+        return phase == PENDING
+            || phase == QUEUED
+            || phase == EXECUTING;
+    }
 //====================================================================
 //  JSON serialization
 //====================================================================
@@ -327,12 +332,13 @@ public class JobUtil {
      * @param infos
      * @return an array of job IDs under the 'jobs' prop as a json string
      */
-    public static String toJsonJobList(List<JobInfo> infos) {
+    public static String toJsonJobList(List<JobInfo> infos, boolean overflow) {
         JSONObject rval = new JSONObject();
-        if (infos != null && infos.size() > 0) {
-            // object with "jobs": array of JobInfo urls
-            List<String> urls = infos.stream().map(i -> i.getMeta().getJobId()).collect(Collectors.toList());
-            rval.put("jobs", urls);
+        if (infos != null && !infos.isEmpty()) {
+            // object with "jobs": array of JobInfo and "overflow: true" if the list exceed 'LAST' or default limit
+            List<JSONObject> jobs = infos.stream().map(JobUtil::toJsonObject).collect(Collectors.toList());
+            rval.put("jobs", jobs);
+            if (overflow) rval.put("overflow", true);
         }
         return rval.toJSONString();
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistribMapCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistribMapCache.java
@@ -3,9 +3,14 @@
  */
 package edu.caltech.ipac.firefly.server.cache;
 
+import edu.caltech.ipac.firefly.core.RedisService;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Like {@link DistributedCache} but specifically designed for managing Redis Maps.
@@ -24,13 +29,30 @@ public class DistribMapCache<T> extends DistributedCache<T> {
     }
 
     public DistribMapCache(String mapKey, long ttl) {
-        this(mapKey, ttl, new JavaSerializer());
+        this(mapKey, ttl, new DefaultImpl<>());
     }
 
-    public DistribMapCache(String mapKey, long ttl, Serializer serializer) {
+    public DistribMapCache(String mapKey, long ttl, Serializer<T> serializer) {
         super(serializer);
         this.mapKey = mapKey;
         this.ttl = ttl;
+    }
+
+    public List<T> getValuesFor(ScanParams scanParams) {
+        List<T> result = new ArrayList<>();
+        try (Jedis jedis = RedisService.getConnection()) {
+            String cursor = ScanParams.SCAN_POINTER_START;
+            do {
+                ScanResult<Map.Entry<String, String>> scanResult = jedis.hscan(mapKey, cursor, scanParams);
+                for (Map.Entry<String, String> entry : scanResult.getResult()) {
+                    result.add(deserialize(entry.getValue()));
+                }
+                cursor = scanResult.getCursor();
+            } while (!cursor.equals(ScanParams.SCAN_POINTER_START));
+        } catch (Exception e) {
+            LOG.error(e.getMessage());
+        }
+        return result;
     }
 
 //====================================================================
@@ -69,5 +91,6 @@ public class DistribMapCache<T> extends DistributedCache<T> {
     int size(Jedis redis) {
         return (int) redis.hlen(mapKey);
     }
+
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
@@ -40,13 +40,22 @@ public class DistributedCache<T> implements Cache<T> {
     private static final String BASE64 = "BASE64::";
     private transient Predicate<T> getValidator;
 
-    private Serializer serializer;
+    private final Serializer<T> serializer;      // required; default is DefaultImpl
 
     public DistributedCache() {
-        this(new JavaSerializer());
+        this(new DefaultImpl<>());
     }
-    public DistributedCache(Serializer serializer) {
+    public DistributedCache(Serializer<T> serializer) {
         this.serializer = serializer;
+    }
+
+
+    String serialize(Object value) {
+        return serializer.serialize(value);
+    }
+
+    T deserialize(String value) throws Exception {
+        return serializer.deserialize(value);
     }
 
     public Cache<T> validateOnGet(Predicate<T> validator) {
@@ -66,9 +75,9 @@ public class DistributedCache<T> implements Cache<T> {
                         del(redis, keystr);
                     } else {
                         if (lifespanInSecs > 0) {
-                            setex(redis, keystr, serializer.serialize(value), lifespanInSecs);
+                            setex(redis, keystr, serialize(value), lifespanInSecs);
                         } else {
-                            set(redis, keystr, serializer.serialize(value));
+                            set(redis, keystr, serialize(value));
                         }
                     }
                 }
@@ -83,7 +92,7 @@ public class DistributedCache<T> implements Cache<T> {
 
     public T get(CacheKey key) {
         try(Jedis redis = RedisService.getConnection()) {
-            T v = (T) serializer.deserialize( get(redis, key.getUniqueString()) );
+            T v = deserialize( get(redis, key.getUniqueString()) );
             if (v != null && getValidator != null && !getValidator.test(v)) {
                 del(redis, key.getUniqueString());
                 return null;
@@ -156,12 +165,16 @@ public class DistributedCache<T> implements Cache<T> {
 //  Utility functions
 //====================================================================
 
-    public interface Serializer {
+    public interface Serializer<T> {
         String serialize(Object object);
-        Object deserialize(String s) throws Exception;
+        T deserialize(String s) throws Exception;
     }
 
-    public static class JavaSerializer implements Serializer {
+    /**
+     * Default implementation of the Serializer.  It serializes objects to Base64 strings
+     * using java serialization.  When the object is a String, it returns the string directly.
+     */
+    public static class DefaultImpl<T> implements Serializer<T> {
 
         public String serialize(Object object) {
             if (object == null) return null;
@@ -172,9 +185,9 @@ public class DistributedCache<T> implements Cache<T> {
             }
         }
 
-        public Object deserialize(String s) throws Exception {
+        public T deserialize(String s) throws Exception {
             if (s == null) return null;
-            return !s.startsWith(BASE64) ? s : Util.deserialize(s.substring(BASE64.length()));
+            return !s.startsWith(BASE64) ? (T) s : (T) Util.deserialize(s.substring(BASE64.length()));
         }
     }
 

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -4,7 +4,7 @@
 
 import {flux} from '../ReduxFlux';
 
-import {updateSet} from '../../util/WebUtil.js';
+import {updateObject, updateSet} from '../../util/WebUtil.js';
 import {showJobMonitor, showMultiResults} from './JobMonitor.jsx';
 import {isSuccess} from './BackgroundUtil.js';
 import * as SearchServices from '../../rpc/SearchServicesJson.js';
@@ -20,6 +20,7 @@ export const BACKGROUND_PATH = 'background';
 
 /*---------------------------- ACTIONS -----------------------------*/
 export const BG_JOB_INFO        = `${BACKGROUND_PATH}.jobInfo`;
+export const BG_LOAD_JOBS       = `${BACKGROUND_PATH}.loadJobs`;
 export const BG_MONITOR_SHOW    = `${BACKGROUND_PATH}.bgMonitorShow`;
 
 export const BG_JOB_ADD         = `${BACKGROUND_PATH}.bgJobAdd`;
@@ -62,6 +63,13 @@ function reducers() {
  */
 export function dispatchBgJobInfo(jobInfo) {
     flux.process({ type : BG_JOB_INFO, payload: jobInfo });
+}
+
+/*
+ * Load the full list of background jobs.
+ */
+export function dispatchBgLoadJobs(jobListInfo) {
+    flux.process({ type : BG_LOAD_JOBS, payload: jobListInfo });
 }
 
 /**
@@ -240,6 +248,16 @@ function reducer(state={}, action={}) {
             }
             return nstate;
             break;
+        case BG_LOAD_JOBS: {
+            const {jobs, overflow} = action.payload;
+            let nstate = state;
+            if (jobs) {
+                const updates = {jobs, overflow};
+                nstate = updateObject(nstate, updates);
+            }
+            return nstate;
+            break;
+        }
         case BG_SET_INFO : {
             const {email, notifEnabled} = action.payload;
             let nstate = updateSet(state, 'email', email);

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -6,7 +6,7 @@ import {get, isNil} from 'lodash';
 import Enum from 'enum';
 
 import {flux} from '../ReduxFlux';
-import {BACKGROUND_PATH, BG_JOB_INFO, dispatchBgJobInfo, dispatchJobAdd} from './BackgroundCntlr.js';
+import {BACKGROUND_PATH, BG_JOB_INFO, dispatchBgJobInfo, dispatchBgLoadJobs, dispatchJobAdd} from './BackgroundCntlr.js';
 import {getCmdSrvAsyncURL} from '../../util/WebUtil.js';
 import {COMPONENT_STATE_CHANGE, dispatchComponentStateChange, getComponentState} from '../ComponentCntlr.js';
 import {dispatchAddActionWatcher} from '../MasterSaga.js';
@@ -56,21 +56,14 @@ export const fetchJobInfo = (jobId) => {
 
 export const loadAllJobs = () => {
     const url = getCmdSrvAsyncURL();
-    jsonFetch(url).then( ({jobs}) => {
-        jobs?.forEach( (jobId) => {
-            fetchJobInfo(jobId).then( (jobInfo) => {
-                if (jobInfo) {
-                    dispatchBgJobInfo(jobInfo);
-                }
-            });
-        });
+    jsonFetch(url).then( ({jobs, overflow}) => {
+        if (jobs) {
+            // convert List<JobInfo> to Object<JobId, JobInfo>
+            const jobsMap = Object.fromEntries(jobs.map((j) => [j?.meta?.jobId, j]));
+            dispatchBgLoadJobs({jobs:jobsMap, overflow});
+        }
     });
 };
-
-
-
-
-
 
 /**
  * returns the whole background info object

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import {isEmpty} from 'lodash';
 
 import {Slot, useStoreConnector} from '../../ui/SimpleComponent';
-import {getBackgroundInfo, getJobInfo, getJobTitle, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, Phase} from './BackgroundUtil';
+import {getBackgroundInfo, getJobInfo, getJobTitle, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, Phase} from './BackgroundUtil';
 import {TablePanel} from '../../tables/ui/TablePanel';
 import {dispatchFormSubmit, getAppOptions} from '../AppDataCntlr';
 import {dispatchBgJobInfo, dispatchBgSetInfo, dispatchJobCancel, dispatchJobRemove, dispatchSetJobNotif} from './BackgroundCntlr';
@@ -32,10 +32,24 @@ import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined
 import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import {FormWatcher} from '../../templates/router/RouteHelper';
+import {logger} from '../../util/Logger';
 
 export const jobMonitorPath = '/jobMonitor';
 
 export function JobMonitor({initArgs, help_id, slotProps, ...props}) {
+    const pollInterval = getAppOptions()?.background?.historyPollInterval || 30000;       // every 30 seconds
+    useEffect(() => {
+        logger.info(`Poll Job History every ${pollInterval/1000}s`);
+        const intervalId = setInterval(() => {
+            loadAllJobs();
+        }, pollInterval);
+
+        // 🔁 Cleanup: clear the interval when the component unmounts
+        return () => {
+            clearInterval(intervalId);
+        };
+    },[]);
+
     const {title, table, note, ...rest} = getAppOptions()?.background?.history || {};
     const titleProps = {...slotProps?.title, ...title};
     const tableProps = {...slotProps?.table, ...table};
@@ -109,18 +123,18 @@ export function showMultiResults(job) {
 // ----------------------------------Start of private functions ------------------------------------------//
 
 function TitleSection({summary, notification, ...props}) {
-    const {jobs:jobMap={}, email, notifEnabled} = useStoreConnector(() => getBackgroundInfo());
+    const {jobs:jobMap={}, email, notifEnabled, overflow} = useStoreConnector(() => getBackgroundInfo());
     const jobs = getMonitoredJob(jobMap);
 
     return (
         <Stack component={Sheet} variant='soft' borderRadius={4} padding={1} spacing={1} {...props}>
-            <Slot component={JobSummary} jobs={jobs} slotProps={summary}/>
+            <Slot component={JobSummary} jobs={jobs} overflow={overflow} slotProps={summary}/>
             <Slot component={Notification} {...{email, notifEnabled}} slotProps={notification}/>
         </Stack>
     );
 }
 
-function JobSummary({jobs, ...props}) {
+function JobSummary({jobs, overflow, ...props}) {
     const total = jobs?.length || 0;
     const active = jobs?.filter((j) => isActive(j)).length || 0;
     const failed = jobs?.filter((j) => isFail(j)).length || 0;
@@ -135,7 +149,7 @@ function JobSummary({jobs, ...props}) {
         <Stack direction='row' gap={5} {...props}>
             <Typography level='title-md' color='primary'>Job Summary</Typography>
             <Stack direction='row' gap={10}>
-                <Entry label='Total' value={total}/>
+                <Entry label='Total' value={total + (overflow ? '(+)' : '')}/>
                 <Entry label='Active' value={active}/>
                 <Entry label='Failed' value={failed}/>
                 {(archived>0) && <Entry label='Archived' value={archived} title={getPhaseTips(Phase.ARCHIVED)}/>}

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/background/JobManagerTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/background/JobManagerTest.java
@@ -14,8 +14,11 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * @author loi
@@ -54,6 +57,103 @@ public class JobManagerTest extends ConfigTest {
         }
         logger.debug("All jobs submitted.");
         Thread.currentThread().join(5000);      // wait long enough to see all the jobs processed before terminating.
+    }
+
+
+    @Category({TestCategory.Perf.class})
+    @Test
+    public void loadRedisDB() throws Exception {
+        /*
+          Redis benchmark results:
+          Redis is configured to use both AOF and RDB persistence.
+          Therefore, it will use rough 3 times the memory in disk space.  2 for the AOF and 1 for the RDB.
+          1m jobs requires 600M RAM
+            - 11s to get all jobs
+            - 1.9s to get user with 100k jobs
+            - 1s to get user with 1k or fewer jobs
+          500k jobs requires 270M RAM
+            - 4.7s to get all jobs
+            - 1.1s to get user with 100k jobs
+            - 450ms to get user with 1k or fewer jobs
+          100k jobs requires 64M
+            - 1s to get all jobs
+            - 100ms to get user with 1k or fewer jobs
+         */
+
+
+        // set so JobManager does not wait for results
+        AppProperties.setProperty("job.wait.complete", "0");
+        Logger.setLogLevel(Level.INFO);
+
+        ServerContext.getRequestOwner().setWsConnInfo("test", "test");
+        for(int i =0; i < 100_000; i++) {
+            JobManager.submit(new SleepJob(Job.Type.PACKAGE, ServerContext.getRequestOwner().getEventConnID()));
+        }
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414629999");      // load 9999 with 100k; extreme
+        for(int i =0; i < 100_000; i++) {
+            JobManager.submit(new SleepJob(Job.Type.PACKAGE, ServerContext.getRequestOwner().getEventConnID()));
+        }
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414621000");      // load 1000 with 1k; rare
+        for(int i =0; i < 1000; i++) {
+            JobManager.submit(new SleepJob(Job.Type.PACKAGE, ServerContext.getRequestOwner().getEventConnID()));
+        }
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414620100");      // load 0100 with 100; normal
+        for(int i =0; i < 100; i++) {
+            JobManager.submit(new SleepJob(Job.Type.PACKAGE, ServerContext.getRequestOwner().getEventConnID()));
+        }
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414620010");      // load 0010 with 10; less common
+        for(int i =0; i < 10; i++) {
+            JobManager.submit(new SleepJob(Job.Type.PACKAGE, ServerContext.getRequestOwner().getEventConnID()));
+        }
+    }
+
+    @Category({TestCategory.Perf.class})
+    @Test
+    public void loadTest() throws Exception {
+        /*
+          Performance results
+            Cache keys count: 101,104
+            All Jobs: 1,165ms with 101,104 jobs
+            User Jobs: 936ms with 99,994 jobs       # confirmed only 99,994 jobs for 9999; not sure why 6 missing
+            User Jobs: 94ms with 1,000 jobs
+            User Jobs: 84ms with 100 jobs
+            User Jobs: 92ms with 10 jobs
+         */
+
+        // set so JobManager does not wait for results
+        AppProperties.setProperty("job.wait.complete", "0");
+        Logger.setLogLevel(Level.INFO);
+        List<String> keys = JobManager.getAllJobKeys();
+        System.out.printf("Cache keys count: %,d %n", keys.size());
+
+        Instant start = Instant.now();
+        int aCount = JobManager.getAllJobs().size();
+        System.out.printf("All Jobs: %,dms with %,d jobs %n", Duration.between(start, Instant.now()).toMillis(), aCount);
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414629999");      // get jobs for 9999 with 100k jobs
+        start = Instant.now();
+        int count = JobManager.getUserJobs().size();
+        System.out.printf("User Jobs: %,dms with %,d jobs %n", Duration.between(start, Instant.now()).toMillis(), count);
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414621000");      // get jobs for 1000 with 1k jobs
+        start = Instant.now();
+        count = JobManager.getUserJobs().size();
+        System.out.printf("User Jobs: %,dms with %,d jobs %n", Duration.between(start, Instant.now()).toMillis(), count);
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414620100");      // get jobs for 0100 with 100 jobs
+        start = Instant.now();
+        count = JobManager.getUserJobs().size();
+        System.out.printf("User Jobs: %,dms with %,d jobs %n", Duration.between(start, Instant.now()).toMillis(), count);
+
+        ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414620010");      // get jobs for 0010 with 10 jobs
+        start = Instant.now();
+        count = JobManager.getUserJobs().size();
+        System.out.printf("User Jobs: %,dms with %,d jobs %n", Duration.between(start, Instant.now()).toMillis(), count);
+
     }
 
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1796

### Optimizations Implemented

* **Improved `getUserJobs`**: now uses a compound key to filter Redis keys by user before fetching `JobInfo`, significantly reducing lookup overhead.
* **Added `job_cache` versioning**: helps identify when a migration is required.
* **Migration support**: added logic to convert existing keys to compound-key format.
* **Minimized `getAllJobs` usage**:

  * This expensive call is now only used in `admin/status`.
  * Removed from other parts of the code, especially pinging logic.
* **Optimized `listUserJob`**:

  * Calls `getUserJobs()` once, updates results as needed, and returns the final list.
  * Returns full `JobInfo`, avoiding additional server calls for job details.
  * Supports `LAST` parameter to limit the number of jobs returned (default: 500 via config).
  * Also implemented `PHASE` and `AFTER` filters for future use.
* **Improved `importJobHistory`**:

  * Now receives `getUserJobs()` result as input.
  * Only fetches full `JobInfo` from UWS services for **active jobs** or if the job is not found in Firefly's history.

---

Test URL: https://fireflydev.ipac.caltech.edu/firefly-1796-optimize-redis-bgjobs/firefly

### Testing Notes from local testing

* **Job Cache loaded with 101,104 jobs** (mocked).

* **Performance Benchmarks**:

```
Redis is configured to use both AOF and RDB persistence.
Therefore, it will use at least 2-3 times the memory in disk space. 
1m jobs requires 600M RAM
  - 11s to get all jobs
  - 1.9s to get user with 100k jobs
  - 1s to get user with 1k or fewer jobs
500k jobs requires 270M RAM
  - 4.7s to get all jobs
  - 1.1s to get user with 100k jobs
  - 450ms to get user with 1k or fewer jobs
100k jobs requires 64M
  - 1s to get all jobs
  - 100ms to get user with 1k or fewer jobs
```
---

### Manual Test

* Start Firefly.
* Inject the 1,000 job userKey into the browser cookie.
* Open **Job Monitor** → loaded quickly with **no additional network call**.

