### PR TITLE
`user-name` switching unexpectedly for same user

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -15,7 +15,6 @@ import edu.caltech.ipac.util.cache.StringKey;
 
 import javax.annotation.Nonnull;
 import javax.servlet.http.Cookie;
-import java.io.File;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,14 +39,12 @@ public class RequestOwner implements Cloneable {
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     public static String USER_KEY = "usrkey";
-    public static StringKey USER_INFO_KEY = new StringKey("UserInfo");
     public static int USER_KEY_EXPIRY = AppProperties.getIntProperty("userkey.expiry", 3600 * 24 * 7 * 2);         // 2 weeks
     public static final String SET_USERINFO_ACTION = "app_data.setUserInfo";
     private static boolean ignoreAuth = AppProperties.getBooleanProperty("ignore.auth", false);
     private RequestAgent requestAgent;
     private Date startTime;
-    private File workingDir;
-    private HashMap<String, Object> attributes = new HashMap<String, Object>();
+    private HashMap<String, Object> attributes = new HashMap<String, Object>();         // TODO: seem like it's not used.  cleanup on next dev cycle
     private String eventChannel;
     private String eventConnID;
     // ------ these are lazy-load variables.. make sure you access it via getter. --------
@@ -59,8 +56,18 @@ public class RequestOwner implements Cloneable {
 
 
 
-    public RequestOwner(Date startTime) {
-        this.startTime = startTime;
+    public RequestOwner(){}
+
+    public void init(RequestAgent requestAgent) {
+        this.requestAgent = requestAgent;
+        startTime = new Date();
+        attributes = new HashMap<>();
+        userInfo = null;
+        ssoAdapter = null;
+        wsManager = null;
+        if (requestAgent != null) {
+            setWsConnInfo(requestAgent.getHeader("FF-connID"), requestAgent.getHeader("FF-channel"));
+        }
     }
 
     public RequestAgent getRequestAgent() {
@@ -72,13 +79,6 @@ public class RequestOwner implements Cloneable {
             ssoAdapter = SsoAdapter.getAdapter();
         }
         return ssoAdapter;
-    }
-
-    public void setRequestAgent(RequestAgent requestAgent) {
-        this.requestAgent = requestAgent;
-        if (requestAgent != null) {
-            setWsConnInfo(requestAgent.getHeader("FF-connID"), requestAgent.getHeader("FF-channel"));
-        }
     }
 
     public void setWsConnInfo(String connID, String channel) {
@@ -164,44 +164,44 @@ public class RequestOwner implements Cloneable {
         if (userInfo == null) {
             userInfo = ifNotNull(this::getAuthUser).get();
             if (userInfo == null) {
-                String userKey = ifNotNull(getUserKeyFromClient()).getOrElse(newUserKey());
-                UserCache<UserInfo> userInfoCache = UserCache.getInstance(userKey);
-                userInfo = userInfoCache.get(USER_INFO_KEY);
-                if (userInfo == null) {
-                    userInfo = UserInfo.newGuestUser();
-                    userInfo.setUserKey(userKey);
-                    userInfoCache.put(USER_INFO_KEY, userInfo);
+                userInfo = UserInfo.newGuestUser();
+                String userKey = getUserKeyFromClient();
+                if (isEmpty(userKey)) {
+                    userKey = newUserKey();
+                    updateClientUserKey(userKey);
                 }
-                syncUserKey(userInfo);
+                userInfo.setUserKey(userKey);
             }
             notifyClient(userInfo);
         }
         return userInfo;
     }
 
+    /**
+     * Copy the source RequestOwner to the target RequestOwner.
+     * @param source the source RequestOwner
+     * @param target the target RequestOwner
+     * @return the target RequestOwner
+     */
+    private RequestOwner copy(RequestOwner source, RequestOwner target) {
+        target.requestAgent = source.requestAgent;
+        target.startTime = source.startTime;
+        target.attributes = source.attributes;
+        target.userInfo = source.userInfo;
+        target.ssoAdapter = source.ssoAdapter;
+        target.eventChannel = source.eventChannel;
+        target.eventConnID = source.eventConnID;
+        target.wsManager = source.wsManager;
+        return target;
+    }
+
     @Override
     public Object clone() throws CloneNotSupportedException {
-        RequestOwner ro = new RequestOwner(startTime);
-        ro.setRequestAgent(requestAgent);
-        ro.workingDir = workingDir;
-        ro.attributes = (HashMap<String, Object>) attributes.clone();
-        ro.userInfo = userInfo;
-        ro.wsManager = wsManager;
-        ro.eventChannel = eventChannel;
-        ro.eventConnID = eventConnID;
-
-        return ro;
+        return copy(this, new RequestOwner());
     }
 
     public void setTo(RequestOwner ro) {
-        requestAgent = ro.requestAgent;
-        startTime = ro.startTime;
-        workingDir = ro.workingDir;
-        attributes = ro.attributes;
-        userInfo = ro.userInfo;
-        eventChannel = ro.eventChannel;
-        eventConnID = ro.eventConnID;
-        wsManager = ro.wsManager;
+        copy(ro, this);
     }
 
     public String getBaseUrl() {
@@ -269,10 +269,9 @@ public class RequestOwner implements Cloneable {
         ServerEventManager.fireAction(action);
     }
 
-    private void syncUserKey(UserInfo userInfo) {
-        if (requestAgent == null) return;
-        if (!userInfo.getUserKey().equals(String.valueOf(getUserKeyFromClient()))) {
-            Cookie cookie = new Cookie(USER_KEY, userInfo.getUserKey());
+    private void updateClientUserKey(String userKey) {
+        if (requestAgent != null) {
+            Cookie cookie = new Cookie(USER_KEY, userKey);
             cookie.setMaxAge(USER_KEY_EXPIRY);      // to live for two weeks
             cookie.setPath(requestAgent.getContextPath());
             requestAgent.sendCookie(cookie);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -830,7 +830,7 @@ public class ServerContext {
     static class RequestOwnerThreadLocal extends InheritableThreadLocal<RequestOwner> {
         @Override
         protected RequestOwner initialValue() {
-            return new RequestOwner(new Date());
+            return new RequestOwner();
         }
 
         @Override

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CommonFilter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CommonFilter.java
@@ -41,11 +41,8 @@ public class CommonFilter implements Filter {
     public void destroy() {}
 
     public static void setupRequestOwner(HttpServletRequest request, HttpServletResponse response) {
-
-        RequestOwner owner = ServerContext.getRequestOwner();   // establish a new one.
-        owner.setRequestAgent(ServerContext.getHttpRequestAgent(request, response));
-        owner.getUserKey();
-
+        // Initialize the RequestOwner for the current request.
+        ServerContext.getRequestOwner().init(ServerContext.getHttpRequestAgent(request, response));
     }
 
 }

--- a/src/firefly/js/ui/Menu.jsx
+++ b/src/firefly/js/ui/Menu.jsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/joy';
 import {tabClasses} from '@mui/joy/Tab';
 import {debounce, isFunction} from 'lodash';
-import React, {forwardRef, memo, useCallback, useContext, useEffect, useRef, useState} from 'react';
+import React, {forwardRef, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import shallowequal from 'shallowequal';
 import {
     COMMAND, dispatchAddPreference, dispatchSetMenu, getAppOptions,
@@ -351,7 +351,7 @@ function AppHelpButton({menuItem,sx,size='lg'}) {
 }
 
 
-const UserInfo= memo(() => {
+const UserInfo= () => {
     const userInfo = useStoreConnector(() => getUserInfo() ?? {});
 
     const {loginName='Guest', firstName='', lastName='', login_url, logout_url} = userInfo;
@@ -376,7 +376,7 @@ const UserInfo= memo(() => {
             {isGuest && <Chip onClick={onLogin}>Login</Chip>}
         </Stack>
     );
-});
+};
 
 
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
@@ -130,7 +130,7 @@ public class ConfigTest {
 
         requestAgent = requestAgent == null ? new RequestAgent(null, "localhost", "/test", "localhost:8080/", "127.0. 0.1", UUID.randomUUID().toString(), contextPath): requestAgent;
 
-        ServerContext.getRequestOwner().setRequestAgent(requestAgent);
+        ServerContext.getRequestOwner().init(requestAgent);
         ServerContext.init(contextPath, contextName, webappConfigPath);
     }
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1799

This PR is not easily testable in our current environment, so please verify that the updated code is correct. 
Previously, we rely on `owner.getUserKey()` to re-initialize the user key, but this was replaced with the full userInfo object during the job history and Redis migration work. That change is likely the root cause of the reported regression.

Please also perform regression testing to ensure the application still behaves as expected and nothing else is unintentionally broken.

Test: https://firefly-1799-user-name-switching.irsakudev.ipac.caltech.edu/irsaviewer/
