### PR TITLE
Firefly-1801: line and point extractions supports multiple images

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ExtractFromImage.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ExtractFromImage.java
@@ -11,8 +11,14 @@ import edu.caltech.ipac.visualize.plot.plotdata.FitsExtract;
 import nom.tam.fits.FitsException;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static edu.caltech.ipac.firefly.core.Util.Try;
+
+;
 
 /**
  * Extract data from an image and make a table
@@ -22,16 +28,15 @@ import java.util.Map;
                 @ParamDoc(name="extractionType", desc="should be one of z-axis, line, or points"),
                 @ParamDoc(name="pt", desc="image point"),
                 @ParamDoc(name="wpt", desc="world point"),
-                @ParamDoc(name="pt2", desc="second image point, if line"),
-                @ParamDoc(name="ptAry", desc="for point selection"),
+                @ParamDoc(name="ptAry[i]", desc="for point selection"),
                 @ParamDoc(name="wptAry", desc="for point selection, added to the created table"),
-                @ParamDoc(name="wlAry", desc="an array of wavelength to add to the table, added to the created table"),
-                @ParamDoc(name="wlUnit", desc="wavelength units. if defined"),
-                @ParamDoc(name="fluxUnit", desc="flux units. if defined"),
-                @ParamDoc(name="filename", desc="filename on the server"),
-                @ParamDoc(name="refHDUNum", desc="hdu number to extract"),
-                @ParamDoc(name="extractionSizeX", desc="number of the square size of the extract, i.e. 4 would be 4x4"),
-                @ParamDoc(name="extractionSizeY", desc="number of the square size of the extract, i.e. 4 would be 4x4"),
+                @ParamDoc(name="wlAry[i]", desc="an array of wavelength to add to the table, added to the created table"),
+                @ParamDoc(name="wlUnit[i]", desc="wavelength units. if defined"),
+                @ParamDoc(name="fluxUnit[i]", desc="flux units. if defined"),
+                @ParamDoc(name="filename[i]", desc="filename on the server"),
+                @ParamDoc(name="refHDUNum[i]", desc="hdu number to extract"),
+                @ParamDoc(name="extractionSizeX", desc="number of the x size of the extract"),
+                @ParamDoc(name="extractionSizeY", desc="number of the y size of the extract"),
                 @ParamDoc(name="allMatchingHDUs", desc="extract every HDU that matches the refHDU")
         })
 public class ExtractFromImage extends EmbeddedDbProcessor {
@@ -46,42 +51,52 @@ public class ExtractFromImage extends EmbeddedDbProcessor {
 
     @Override
     public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
+
         String extType = req.getParam(EXTRACTION_TYPE);
-        String filename = req.getParam(FILENAME);
         int ptSizeX = req.getIntParam(EXTRACTION_SIZE_X, 1);
         int ptSizeY = req.getIntParam(EXTRACTION_SIZE_Y, 1);
-        int refHduNum = req.getIntParam(REF_HDU_NUM, -1);
-        int plane = req.getIntParam(ServerParams.PLANE, -1);
         FitsExtract.CombineType ct= Enum.valueOf(FitsExtract.CombineType.class,req.getParam(ServerParams.COMBINE_OP,"AVG"));
-        double[] wlAry= SrvParam.getDoubleAryFromJson(req.getParam(ServerParams.WL_ARY));
-        String wlUnit= req.getParam(ServerParams.WL_UNIT);
         boolean allMatchingHDUs = req.getBooleanParam(ALL_MATCHING_HDUS, true);
         try {
             if (extType == null || extType.equals("z-axis")) {
+                String filename = req.getParam(FILENAME);
+                int refHduNum = req.getIntParam(REF_HDU_NUM, -1);
                 ImagePt pt = ImagePt.parse(req.getParam(ServerParams.PT));
                 WorldPt wpt = WorldPt.parse(req.getParam(ServerParams.WPT));
+                String wlUnit= req.getParam(ServerParams.WL_UNIT);
+                double[] wlAry= SrvParam.getDoubleAryFromJson(req.getParam(ServerParams.WL_ARY));
                 checkZAxisParams(pt, filename, refHduNum);
                 Map<Integer,String> fluxUnit= makeMapOfUnitsFromParam(req);
                 return FITSExtractToTable.getCubeZaxisAsTable(pt, wpt, filename, refHduNum, allMatchingHDUs,
                         ptSizeX, ct, wlAry,wlUnit,fluxUnit);
             }
-            else if (extType.equals("line")) {
-                ImagePt[] ptAry= SrvParam.getImagePtAryFromJson(req.getParam(ServerParams.PTARY));
-                WorldPt[] wptAry= SrvParam.getWorldPtAryFromJson(req.getParam(ServerParams.WPT_ARY));
-                checkPointParams(ptAry, plane, filename, refHduNum);
-                return FITSExtractToTable.getLineSelectAsTable(ptAry, wptAry, filename, refHduNum, plane, allMatchingHDUs,
-                        ptSizeX, ptSizeY, ct, wlAry, wlUnit);
-            } else if (extType.equals("points")) {
-                ImagePt[] ptAry= SrvParam.getImagePtAryFromJson(req.getParam(ServerParams.PTARY));
-                WorldPt[] wptAry= SrvParam.getWorldPtAryFromJson(req.getParam(ServerParams.WPT_ARY));
-                checkPointParams(ptAry, plane, filename, refHduNum);
-                return FITSExtractToTable.getPointsAsTable(ptAry, wptAry, filename, refHduNum, plane,
-                        allMatchingHDUs, ptSizeX, ptSizeY, ct, wlAry, wlUnit);
+            else if (extType.equals("line") || extType.equals("points")) {
+                var extractParamsList = getDataExtractParams(req);
+                WorldPt[] wptAry = SrvParam.getWorldPtAryFromJson(req.getParam(ServerParams.WPT_ARY));
+                return FITSExtractToTable.getDataSelectAsTable(extractParamsList, wptAry, allMatchingHDUs,
+                        ptSizeX, ptSizeY, ct, extType.equals("line"));
             }
         } catch (IOException | FitsException e) {
             throw new IllegalArgumentException("Could not make a table from extracted data");
         }
         throw new IllegalArgumentException("extractionType must be z-axis, line, or points");
+    }
+
+    private static List<FITSExtractToTable.DataExtractParams> getDataExtractParams(TableServerRequest req) {
+        var eList = new ArrayList<FITSExtractToTable.DataExtractParams>();
+        String[] titles= SrvParam.getStringAryFromJson( req.getParam("titleAry"));
+        if (titles==null) titles= new String[] {""};
+        for (int i=0; i<titles.length; i++) {
+            String filename = req.getParam(FILENAME+i);
+            int refHduNum = req.getIntParam(REF_HDU_NUM+i, -1);
+            int plane = req.getIntParam(ServerParams.PLANE+i, -1);
+            double[] wlAry= SrvParam.getDoubleAryFromJson(req.getParam(ServerParams.WL_ARY+i));
+            String wlUnit= req.getParam(ServerParams.WL_UNIT+i);
+            ImagePt[] ptAry= SrvParam.getImagePtAryFromJson(req.getParam(ServerParams.PTARY+i));
+            checkPointParams(ptAry, plane, filename, refHduNum);
+            eList.add(new FITSExtractToTable.DataExtractParams(titles[i],ptAry,filename,plane,refHduNum,wlAry,wlUnit));
+        }
+        return eList;
     }
 
     private static Map<Integer,String> makeMapOfUnitsFromParam(TableServerRequest req) {
@@ -91,9 +106,7 @@ public class ExtractFromImage extends EmbeddedDbProcessor {
         for(String entry : sAry) {
             String[] s= entry.split("=");
             if (s.length==2) {
-                try {
-                    fluxUnit.put(Integer.parseInt(s[0]),s[1]);
-                } catch (NumberFormatException ignore) { }
+                Try.it(() -> fluxUnit.put(Integer.parseInt(s[0]),s[1]));
             }
         }
         return fluxUnit;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -237,6 +237,7 @@ public class VisJsonSerializer {
         putStr(map,"dataDesc", wpHeader.dataDesc());
         putJsonAry(map,"zeroHeaderAry", serializeHeaderAry(wpHeader.zeroHeaderAry()));
         putBoolIfTrue(map,"multiImageFile", wpHeader.multiImageFile());
+        putNumOver0(map, "totalImageHdusInFile", wpHeader.totalImageHdusInFile() );
         if (wpHeader.attributes()!=null) putJsonObj(map,"attributes", new JSONObject(wpHeader.attributes()));
         return map;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
@@ -156,7 +156,7 @@ public class WebPlotFactory {
         return new WebPlotHeaderInitializer(s.getOriginalFitsFileStr(NO_BAND),
                 s.getWorkingFitsFileStr(NO_BAND), s.getUploadFileName(NO_BAND),
                 s.getRangeValues(), pInfo.dataDesc(), s.isMultiImageFile(),
-                false, s.getPrimaryRequest(),zeroHeaderAry, attributes);
+                false, s.getPrimaryRequest(),zeroHeaderAry, attributes, frAry[0].getTotalImageHdusInFile());
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/visualize/WebPlotHeaderInitializer.java
@@ -13,5 +13,5 @@ public record WebPlotHeaderInitializer(String originalFitsFileStr, String workin
                                        String uploadFileNameStr, RangeValues rv,
                                        String dataDesc, boolean multiImageFile,
                                        boolean threeColor, WebPlotRequest request, Header[] zeroHeaderAry,
-                                       Map<String,String> attributes) {}
+                                       Map<String,String> attributes, int totalImageHdusInFile) {}
 

--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSExtractToTable.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSExtractToTable.java
@@ -24,22 +24,28 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 /**
  * @author Trey Roby
  */
 public class FITSExtractToTable {
 
-
-    private static String makeKeyforHDUTab(FitsExtract.ExtractionResults result) {
-        return result.extName()!=null ? result.extName() : "HDU#"+result.hduNum();
+    private static String makeKeyByHDU(FitsExtract.ExtractionResults result, String prefix, int plane) {
+        var planeStr= plane==0 ? "" : "/"+plane;
+        return result.extName()!=null ?
+                makeKey(prefix,result.extName()+planeStr) : makeKey(prefix,"HDU#"+result.hduNum()+planeStr);
     }
+
+    private static String makeKeyByHDU(FitsExtract.ExtractionResults result) { return makeKeyByHDU(result,null,0); }
 
     private static String makeMetaEntryForHDUs(List<FitsExtract.ExtractionResults> results) {
         StringBuilder str= new StringBuilder();
         for(FitsExtract.ExtractionResults r : results) {
-           if (str.length()>0) str.append(";");
-           str.append(makeKeyforHDUTab(r)).append("=").append(r.hduNum());
+           if (!str.isEmpty()) str.append(";");
+           str.append(makeKeyByHDU(r)).append("=").append(r.hduNum());
         }
         return str.toString();
     }
@@ -48,7 +54,7 @@ public class FITSExtractToTable {
         for(Number v: valueList) { // find first  non nan entry
             if (!Double.isNaN(v.doubleValue())) return v;
         }
-        return valueList.get(0);
+        return valueList.getFirst();
     }
 
     private static Class<?> getDataType(List<Number> valueList) {
@@ -65,17 +71,24 @@ public class FITSExtractToTable {
         return Math.round(d*factor)/factor;
     }
 
+    private static String makePrefix(int extractTotal, String title) {
+        return extractTotal==1 ? "" : title;
+    }
+
+    private static String makeKey(String prefix, String keyName) {
+        return isEmpty(prefix) ? keyName : keyName+"("+prefix+")";
+    }
+
     private static void insertZaxisSpectrumMeta(DataGroup dataGroup,
                                                 List<FitsExtract.ExtractionResults> results,
                                                 String wavelengthColName,
                                                 String fluxColName ) {
-
         // guess an error
         String errCol= null;
         for(FitsExtract.ExtractionResults result: results) {
             String extName= result.extName();
             if (extName!=null && extName.toLowerCase().startsWith("err")) {
-                errCol= makeKeyforHDUTab(result);
+                errCol= makeKeyByHDU(result);
                 break;
             }
         }
@@ -87,7 +100,7 @@ public class FITSExtractToTable {
                                                     String xColName ) {
         String defYCol= "";
         for(FitsExtract.ExtractionResults result : results) {
-            if (result.refHDU()) defYCol= makeKeyforHDUTab(result);
+            if (result.refHDU()) defYCol= makeKeyByHDU(result);
         }
         TableMeta meta= dataGroup.getTableMeta();
         meta.addKeyword(MetaConst.DEFAULT_CHART_X_COL, xColName);
@@ -102,7 +115,7 @@ public class FITSExtractToTable {
         List<FitsExtract.ExtractionResults> results= FitsExtract.getAllZAxisAryFromRelatedCubes(
                 pt, f, refHduNum, allMatchingHDUs, ptSize, ct);
         ArrayList<DataType> dataTypes = new ArrayList<>();
-        int len= results.get(0).aryData().size();
+        int len= results.getFirst().aryData().size();
         dataTypes.add(new DataType("plane","Plane", Integer.class));
         if (wlAry!=null) {
             DataType wlDt= new DataType("wavelength",Double.class, "Wavelength", wlUnit, null, null);
@@ -112,7 +125,7 @@ public class FITSExtractToTable {
         for(FitsExtract.ExtractionResults result : results) {
             String desc= result.extName()!=null ? result.extName() : "HDU# "+result.hduNum();
             desc= addSize(desc,ptSize,ptSize,ct);
-            String key= makeKeyforHDUTab(result);
+            String key= makeKeyByHDU(result);
             String u= fluxUnit.get(result.hduNum());
             Class<?> dataType= getDataType(result.aryData());
             DataType dt = new DataType(key,dataType, desc, u, null, null);
@@ -126,7 +139,7 @@ public class FITSExtractToTable {
             aRow.setDataElement("plane",i+1);
             if (wlAry!=null) aRow.setDataElement("wavelength",rnd(wlAry[i],7));
             for(FitsExtract.ExtractionResults result : results) {
-                aRow.setDataElement(makeKeyforHDUTab(result),result.aryData().get(i));
+                aRow.setDataElement(makeKeyByHDU(result),result.aryData().get(i));
             }
             dataGroup.add(aRow);
         }
@@ -145,136 +158,153 @@ public class FITSExtractToTable {
         return dataGroup;
     }
 
-    public static DataGroup getPointsAsTable(ImagePt[] ptAry, WorldPt[] wptAry, String filename, int refHduNum, int plane,
-                                             boolean allMatchingHDUs, int ptSizeX, int ptSizeY, FitsExtract.CombineType ct,
-                                             double[] wlAry, String wlUnit)
+    private static Object getWithEnsuredType(Object obj, Class<?> type) {
+        if (obj instanceof Number n) {
+            if (type==Float.class) return n.floatValue();
+            if (type==Double.class) return n.doubleValue();
+            if (type==int.class) return n.intValue();
+            if (type==long.class) return n.longValue();
+        }
+        return obj;
+    }
+
+    public record DataExtractParams(String title, ImagePt[] ptAry,
+                                    String filename,
+                                    int plane, int refHduNum, double[] wlAry, String wlUnit) {}
+
+    public record TitledExtractionResult(String title, ImagePt[] ptAry, double[] wlAry, String wlUnit,
+                                         List<FitsExtract.ExtractionResults> extractionResults,
+                                         File file, int refHduNum, int plane) {}
+
+    public static DataGroup getDataSelectAsTable(List<DataExtractParams> extractParamsList, WorldPt[] wptAry,
+                                                 boolean allMatchingHDUs, int ptSizeX, int ptSizeY,
+                                                 FitsExtract.CombineType ct, boolean isLine)
             throws IOException, FitsException {
-        File f= ServerContext.convertToFile(filename);
-        List<FitsExtract.ExtractionResults> results= FitsExtract.getAllPointsFromRelatedHDUs(
-                ptAry, f, refHduNum, plane, allMatchingHDUs, ptSizeX, ptSizeY, ct );
-        ArrayList<DataType> dataTypes = new ArrayList<>();
-        int len= results.get(0).aryData().size();
-        dataTypes.add(new DataType("x", Integer.class, "x", "pixel", null, null));
-        dataTypes.add(new DataType("y", Integer.class, "y", "pixel", null, null));
-        boolean hasWpt= wptAry!=null && wptAry.length==ptAry.length;
-        if (hasWpt) {
-            dataTypes.add(new DataType("ra",Double.class, "ra", "deg", null, null));
-            dataTypes.add(new DataType("dec",Double.class, "dec","deg", null, null ));
-        }
-        if (wlAry!=null) {
-            dataTypes.add(new DataType("wavelength", Double.class, "wavelength", wlUnit, null, null));
-        }
-        String defYCol= "";
-        for(FitsExtract.ExtractionResults result : results) {
-            String desc= result.extName()!=null ? result.extName() : "HDU# "+result.hduNum();
-            desc= addSize(desc,ptSizeX,ptSizeY,ct);
-            String key= makeKeyforHDUTab(result);
-            String bunit= FitsReadUtil.getBUnit(result.header());
-            Class<?> dataType= getDataType(result.aryData());
-            DataType dt = new DataType(key,dataType, desc, bunit, null,null);
-            if (result.refHDU()) defYCol= key;
-            dataTypes.add(dt);
-        }
-        DataGroup dataGroup = new DataGroup("Cube Z-Axis", dataTypes);
-        for (int i = 0; (i < len); i++) {
+
+        List<TitledExtractionResult> allExtractions=extractParamsList.stream().map( p -> {
+                    try {
+                        File f= ServerContext.convertToFile(p.filename);
+                        List<FitsExtract.ExtractionResults> extractionResults= FitsExtract.getAllPointsFromRelatedHDUs(
+                                p.ptAry, f, p.refHduNum, p.plane, allMatchingHDUs, ptSizeX, ptSizeY, ct);
+                        return new TitledExtractionResult(p.title, p.ptAry, p.wlAry, p.wlUnit,
+                                extractionResults, f, p.refHduNum, p.plane);
+                    } catch (IOException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        boolean hasWpt= wptAry!=null && wptAry.length==extractParamsList.getFirst().ptAry.length;
+        int totalRows= allExtractions.getFirst().extractionResults.getFirst().aryData().size();
+
+        List<DataType> dataTypes = initDataColumns(allExtractions,hasWpt,ptSizeX,ptSizeY,ct,isLine);
+        DataGroup dataGroup = new DataGroup("line extract", dataTypes);
+        for (int i = 0; (i < totalRows); i++) {
             DataObject aRow = new DataObject(dataGroup);
-            aRow.setDataElement("x",(int)Math.rint(ptAry[i].getX()));
-            aRow.setDataElement("y",(int)Math.rint(ptAry[i].getY()));
             if (hasWpt) {
+                if (isLine) aRow.setDataElement("offset",rnd(VisUtil.computeDistance(wptAry[0],wptAry[i])*3600,3));
                 aRow.setDataElement("ra",rnd(wptAry[i].getX(),7));
                 aRow.setDataElement("dec",rnd(wptAry[i].getY(),7));
             }
-            if (wlAry!=null) {
-                aRow.setDataElement("wavelength",rnd(wlAry[i],6));
-            }
-            for(FitsExtract.ExtractionResults result : results) {
-                aRow.setDataElement(makeKeyforHDUTab(result),result.aryData().get(i));
+            for(var titleResult : allExtractions) {
+                String title= makePrefix(allExtractions.size(),titleResult.title);
+                var ptAry= titleResult.ptAry;
+                int x= (int)Math.rint(ptAry[i].getX());
+                int y= (int)Math.rint(ptAry[i].getY());
+                if (isLine) aRow.setDataElement(makeKey(title,"pixOffset"),rnd(VisUtil.computeDistance(ptAry[0],ptAry[i]), 1));
+                aRow.setDataElement(makeKey(title,"x"),x);
+                aRow.setDataElement(makeKey(title,"y"),y);
+                if (titleResult.wlAry!=null) aRow.setDataElement(makeKey(title,"wavelength"),rnd(titleResult.wlAry[i],6));
+                for(FitsExtract.ExtractionResults result : titleResult.extractionResults) {
+                    String key= makeKeyByHDU(result,title,titleResult.plane);
+                    aRow.setDataElement(
+                            key,
+                            getWithEnsuredType(
+                                    result.aryData().get(i),
+                                    dataGroup.getDataDefintion(key).getDataType()
+                            )
+                    );
+                }
             }
             dataGroup.add(aRow);
         }
+
         TableMeta meta= dataGroup.getTableMeta();
-        meta.addKeyword(MetaConst.FITS_IMAGE_HDU, makeMetaEntryForHDUs(results));
+        var baseEx= allExtractions.getFirst();
+        var ptAry= baseEx.ptAry;
+        var baseTitle= makePrefix(allExtractions.size(),allExtractions.getFirst().title);
+
+        String defYCol= "";
+        var baseX= makeKey(baseTitle,"x");
+        var baseY= makeKey(baseTitle,"y");
+        var defXCol= !isLine ? baseX : wptAry!=null ? "offset" : "pixOffset"; //todo fix
+        if (allExtractions.getFirst().extractionResults.getFirst().refHDU()) {
+            var firstResult= allExtractions.getFirst();
+            defYCol= makeKeyByHDU(firstResult.extractionResults.getFirst(), baseTitle, firstResult.plane);
+        };
+
+
+        var plane= extractParamsList.getFirst().plane;
+        meta.addKeyword(MetaConst.FITS_IMAGE_HDU, makeMetaEntryForHDUs(baseEx.extractionResults));
         if (plane>0) meta.addKeyword(MetaConst.FITS_IMAGE_HDU_CUBE_PLANE, plane+"");
         if (hasWpt) meta.addKeyword(MetaConst.CENTER_COLUMN, "ra;dec;J2000");
-        meta.addKeyword(MetaConst.IMAGE_COLUMN, "x;y");
-        meta.addKeyword(MetaConst.CATALOG_OVERLAY_TYPE, hasWpt ? "TRUE" : "IMAGE_PTS");
-        meta.addKeyword(MetaConst.FITS_FILE_PATH, ServerContext.replaceWithPrefix(f));
-        meta.addKeyword(MetaConst.FITS_EXTRACTION_TYPE, "points");
-        meta.addKeyword(MetaConst.DEFAULT_CHART_X_COL, "x");
+        meta.addKeyword(MetaConst.FITS_FILE_PATH, ServerContext.replaceWithPrefix(baseEx.file));
+        meta.addKeyword(MetaConst.FITS_EXTRACTION_TYPE, isLine ? "line" : "points");
+        meta.addKeyword(MetaConst.DEFAULT_CHART_X_COL, defXCol);
         meta.addKeyword(MetaConst.DEFAULT_CHART_Y_COL, defYCol);
+        meta.addKeyword(MetaConst.IMAGE_COLUMN, baseX+";"+baseY);
+        meta.addKeyword(MetaConst.CATALOG_OVERLAY_TYPE, hasWpt ? "TRUE" : "IMAGE_PTS");
+        if (isLine) {
+            meta.addKeyword(MetaConst.FITS_IM_PT, ptAry[0].toString());
+            meta.addKeyword(MetaConst.FITS_IM_PT2, ptAry[ptAry.length-1].toString());
+        }
+
         dataGroup.trimToSize();
         return dataGroup;
     }
 
 
-    public static DataGroup getLineSelectAsTable(ImagePt[] ptAry, WorldPt[] wptAry, String filename, int refHduNum, int plane,
-                                                 boolean allMatchingHDUs, int ptSizeX, int ptSizeY, FitsExtract.CombineType ct,
-                                                 double[] wlAry, String wlUnit )
-            throws IOException, FitsException {
-        File f= ServerContext.convertToFile(filename);
-        List<FitsExtract.ExtractionResults> results= FitsExtract.getAllPointsFromRelatedHDUs(
-                ptAry, f, refHduNum, plane, allMatchingHDUs, ptSizeX, ptSizeY, ct);
+    public static List<DataType> initDataColumns(List<TitledExtractionResult> allExtractions,
+                                                 boolean hasWpt,
+                                                 int ptSizeX,
+                                                 int ptSizeY,
+                                                 FitsExtract.CombineType ct,
+                                                 boolean isLine) {
+
         ArrayList<DataType> dataTypes = new ArrayList<>();
-        int len= results.get(0).aryData().size();
-        boolean hasWpt= wptAry!=null && wptAry.length==ptAry.length;
         if (hasWpt) {
-            dataTypes.add(new DataType("offset", Double.class, "offset", "arcsec", null, null));
+            if (isLine) dataTypes.add(new DataType("offset", Double.class, "offset", "arcsec", null, null));
             dataTypes.add(new DataType("ra",Double.class, "ra", "deg", null, null));
             dataTypes.add(new DataType("dec",Double.class, "dec","deg", null, null ));
         }
-        dataTypes.add(new DataType("pixOffset",Double.class, "pixOffset", "pixel",null, null ));
-        dataTypes.add(new DataType("x", Integer.class, "x", "pixel", null, null));
-        dataTypes.add(new DataType("y", Integer.class, "y", "pixel", null, null));
-        if (wlAry!=null) {
-            dataTypes.add(new DataType("wavelength", Double.class, "wavelength", wlUnit, null, null));
+        for(var titleResult : allExtractions) {
+            String title= makePrefix(allExtractions.size(),titleResult.title);
+            if (isLine) dataTypes.add(new DataType(makeKey(title,"pixOffset"),Double.class, makeKey(title,"pixOffset"), "pixel",null, null ));
+            dataTypes.add(new DataType(makeKey(title,"x"), Integer.class, makeKey(title,"x"), "pixel", null, null));
+            dataTypes.add(new DataType(makeKey(title,"y"), Integer.class, makeKey(title,"y"), "pixel", null, null));
+            if (titleResult.wlAry!=null) {
+                dataTypes.add(new DataType(makeKey(title,"wavelength"), Double.class, makeKey(title,"wavelength"), titleResult.wlUnit, null, null));
+            }
+            for(FitsExtract.ExtractionResults result : titleResult.extractionResults) {
+                var plane= titleResult.plane+1;
+                var planeStr= plane==1 ? "" : "/"+plane;
+                String desc= result.extName()!=null
+                        ? makeKey(title,result.extName()+planeStr)
+                        : makeKey(title,"HDU# "+result.hduNum()+planeStr);
+                String key= makeKeyByHDU(result,title,titleResult.plane);
+                String bunit= FitsReadUtil.getBUnit(result.header());
+                Class<?> dataType= getDataType(result.aryData());
+                FitsExtract.CombineType activeCt= ct;
+                if (titleResult.refHduNum!=result.hduNum() && (dataType==Long.class || dataType==Integer.class)) {
+                    activeCt= FitsExtract.CombineType.OR;
+                }
+                desc= addSize(desc,ptSizeX,ptSizeY,activeCt);
+                DataType dt = new DataType(key,dataType, desc, bunit, null,null);
+                dataTypes.add(dt);
+            }
         }
-        String defYCol= "";
-        for(FitsExtract.ExtractionResults result : results) {
-            String desc= result.extName()!=null ? result.extName() : "HDU# "+result.hduNum();
-            String key= makeKeyforHDUTab(result);
-            String bunit= FitsReadUtil.getBUnit(result.header());
-            Class<?> dataType= getDataType(result.aryData());
-            FitsExtract.CombineType activeCt= ct;
-            if (refHduNum!=result.hduNum() && (dataType==Long.class || dataType==Integer.class)) {
-                activeCt= FitsExtract.CombineType.OR;
-            }
-            desc= addSize(desc,ptSizeX,ptSizeY,activeCt);
-            DataType dt = new DataType(key,dataType, desc, bunit, null,null);
-            if (result.refHDU()) defYCol= key;
-            dataTypes.add(dt);
-        }
-        DataGroup dataGroup = new DataGroup("Cube Z-Axis", dataTypes);
-        for (int i = 0; (i < len); i++) {
-            DataObject aRow = new DataObject(dataGroup);
-            aRow.setDataElement("pixOffset",rnd(VisUtil.computeDistance(ptAry[0],ptAry[i]), 1));
-            aRow.setDataElement("x",(int)Math.rint(ptAry[i].getX()));
-            aRow.setDataElement("y",(int)Math.rint(ptAry[i].getY()));
-            if (hasWpt) {
-                aRow.setDataElement("offset",rnd(VisUtil.computeDistance(wptAry[0],wptAry[i])*3600,3));
-                aRow.setDataElement("ra",rnd(wptAry[i].getX(),7));
-                aRow.setDataElement("dec",rnd(wptAry[i].getY(),7));
-            }
-            if (wlAry!=null) {
-                aRow.setDataElement("wavelength",rnd(wlAry[i],6));
-            }
-            for(FitsExtract.ExtractionResults result : results) {
-                aRow.setDataElement(makeKeyforHDUTab(result),result.aryData().get(i));
-            }
-            dataGroup.add(aRow);
-        }
-        TableMeta meta= dataGroup.getTableMeta();
-        meta.addKeyword(MetaConst.FITS_IM_PT, ptAry[0].toString());
-        meta.addKeyword(MetaConst.FITS_IM_PT2, ptAry[ptAry.length-1].toString());
-        meta.addKeyword(MetaConst.FITS_IMAGE_HDU, makeMetaEntryForHDUs(results));
-        if (plane>0) meta.addKeyword(MetaConst.FITS_IMAGE_HDU_CUBE_PLANE, plane+"");
-        meta.addKeyword(MetaConst.FITS_FILE_PATH, ServerContext.replaceWithPrefix(f));
-        meta.addKeyword(MetaConst.FITS_EXTRACTION_TYPE, "line");
-        meta.addKeyword(MetaConst.DEFAULT_CHART_X_COL, wptAry!=null ? "offset" : "pixOffset");
-        meta.addKeyword(MetaConst.DEFAULT_CHART_Y_COL, defYCol);
-        meta.addKeyword(MetaConst.IMAGE_COLUMN, "x;y");
-        meta.addKeyword(MetaConst.CATALOG_OVERLAY_TYPE, hasWpt ? "TRUE" : "IMAGE_PTS");
-
-        dataGroup.trimToSize();
-        return dataGroup;
+        return dataTypes;
     }
+
 }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsExtract.java
@@ -20,7 +20,7 @@ public class FitsExtract {
 
     public enum CombineType {AVG, SUM, OR}
 
-    private static  Number combineArray(List<Number> aryList, CombineType ct, Class<?> type) {
+    private static Number combineArray(List<Number> aryList, CombineType ct, Class<?> type) {
         if (aryList.isEmpty()) return Double.NaN;
         if (aryList.size() == 1) return aryList.get(0);
         double cnt = 0;
@@ -107,13 +107,7 @@ public class FitsExtract {
         int adjustY= (int)Math.floor((ptSizeY-1) / 2.0);
         x= x - adjustX;
         y= y - adjustY;
-        if (x<0) x= 0;
-        if (y<0) y= 0;
-
-        if (x+ptSizeX>=naxis1) x-= (x+ptSizeX-naxis1+1);
-        if (y+ptSizeY>=naxis2) y-= (y+ptSizeY-naxis2+1);
-        if (x<0) x= 0;
-        if (y<0) y= 0;
+        boolean outOfImage= x < 0 || y < 0 || x+ptSizeX>=naxis1+1 ||  y+ptSizeY>=naxis2+1;
 
         Class<?> arrayType= switch (bitpix) {
             case -32 -> Float.TYPE;
@@ -121,6 +115,17 @@ public class FitsExtract {
             case 64 -> Long.TYPE;
             default -> Double.TYPE;
         };
+        var blankValue= FitsReadUtil.getBlankValue(header);
+
+        if (outOfImage) {
+            return switch (arrayType.toString()) {
+                case "float" -> Float.NaN;
+                case "int" -> (int)blankValue;
+                case "long" -> (long)blankValue;
+                default -> Double.NaN;
+            };
+        }
+
 
         if (!primaryHdu && (arrayType==Integer.TYPE || arrayType==Long.TYPE)) {
            ct= CombineType.OR;
@@ -130,7 +135,6 @@ public class FitsExtract {
 
         var bscale= FitsReadUtil.getBscale(header);
         var bzero= FitsReadUtil.getBzero(header);
-        var blankValue= FitsReadUtil.getBlankValue(header);
 
         if (bscale==1.0D && bzero==0D && !isNaN(aveValue) && aveValue.doubleValue()!=blankValue) return aveValue;
         if (arrayType==Float.TYPE && Float.isNaN(aveValue.floatValue())) return Float.NaN;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -37,6 +37,7 @@ public class FitsRead implements Serializable, HasSizeOf {
     private final boolean cube;
     private final int hduNumber;
     private final Header zeroHeader;
+    private final int totalImageHdusInFile;
     private ImageHDU hdu;
     private float[] float1d;
     private final Header header;
@@ -58,7 +59,8 @@ public class FitsRead implements Serializable, HasSizeOf {
      * @param imageHdu this hdu to build this FitsRead around
      * @throws FitsException if we can process the data
      */
-    FitsRead(BasicHDU<?> imageHdu, Header zeroHeader, File file, boolean clearHdu, boolean cube, int planeNumber) throws FitsException {
+    FitsRead(BasicHDU<?> imageHdu, Header zeroHeader, File file, boolean clearHdu,
+             boolean cube, int planeNumber, int totalImageHdusInFile) throws FitsException {
 
         this.file= file;
         this.tileCompress= (imageHdu instanceof CompressedImageHDU);
@@ -68,6 +70,7 @@ public class FitsRead implements Serializable, HasSizeOf {
         this.planeNumber = cube ? planeNumber : 0;
         this.cube = cube;
         this.hduNumber = header.getIntValue(SPOT_EXT, 0);
+        this.totalImageHdusInFile = totalImageHdusInFile;
         this.bunit= hdu.getBUnit()!=null ? hdu.getBUnit() : "---";
 
         ImageHeader imageHeader = new ImageHeader(header, header.getLongValue(SPOT_OFF, 0), planeNumber);
@@ -89,6 +92,7 @@ public class FitsRead implements Serializable, HasSizeOf {
 
     public int getImageDataWidth() { return getNaxis1(); }
     public int getImageDataHeight() { return getNaxis2(); }
+    public int getTotalImageHdusInFile() { return totalImageHdusInFile; }
 
     public boolean isTileCompress() { return tileCompress; }
     public int getNaxis() { return FitsReadUtil.getNaxis(header); }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadFactory.java
@@ -42,7 +42,8 @@ public class FitsReadFactory {
         var headersSizesList= Arrays.stream(HDUs).map(hdu -> hdu.getHeader().getSize()).toList();
         var headersOffsetsList= Arrays.stream(HDUs).map(hdu -> hdu.getHeader().getFileOffset()).toList();
 
-        BasicHDU<?> [] imageHDUs= FitsReadUtil.getImageHDUArray(HDUs, true, headersSizesList, headersOffsetsList);
+        var totalImageHdusInFile= FitsReadUtil.getImageHDUArray(HDUs).length;
+        BasicHDU<?> [] imageHDUs= FitsReadUtil.getCubeExpandedImageHDUArray(HDUs, true, headersSizesList, headersOffsetsList);
         BasicHDU<?> hdu;
         Header zeroHeader= getZeroHeader(HDUs) ;
         confirmHasImageData(imageHDUs,HDUs);
@@ -61,7 +62,7 @@ public class FitsReadFactory {
             else {
                 planeNumber++;
             }
-            fitsReadAry[i]= new FitsRead(lastHdu, zeroHeader, f, clearHdu, cube, cube?planeNumber:0);
+            fitsReadAry[i]= new FitsRead(lastHdu, zeroHeader, f, clearHdu, cube, cube?planeNumber:0, totalImageHdusInFile);
         }
         return fitsReadAry;
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -74,6 +74,11 @@ public class FitsReadUtil {
         return clonedHeader;
     }
 
+    public static BasicHDU<?>[] getImageHDUArray(BasicHDU<?>[] HDUs) {
+        return Arrays.stream(HDUs)
+                .filter(hdu -> hdu instanceof ImageHDU || hdu instanceof CompressedImageHDU)
+                .toArray(BasicHDU[]::new);
+    }
 
     public static boolean hasCompressedImageHDUS(BasicHDU<?>[] HDUs)  {
         return Arrays.stream(HDUs).anyMatch(h -> h instanceof CompressedImageHDU);
@@ -107,7 +112,7 @@ public class FitsReadUtil {
         return new UncompressFitsInfo(retFile,inHDUs, retReadFits);
     }
 
-    public static BasicHDU<?>[] getImageHDUArray(BasicHDU<?>[] HDUs, boolean onlyFireCubeHdu, List<Long> headersSizesList, List<Long> headersOffsetsList) {
+    public static BasicHDU<?>[] getCubeExpandedImageHDUArray(BasicHDU<?>[] HDUs, boolean onlyFireCubeHdu, List<Long> headersSizesList, List<Long> headersOffsetsList) {
         ArrayList<BasicHDU<?>> HDUList = new ArrayList<>();
 
         String delayedExceptionMsg = null; // the exception can be ignored if HDUList size is greater than 0

--- a/src/firefly/js/data/MetaConst.js
+++ b/src/firefly/js/data/MetaConst.js
@@ -185,9 +185,9 @@ export const MetaConst = {
     SIMULATED_TABLE: 'SIMULATED_TABLE',
 
     /**
-     * if true, Show the coverage display even it this table does not have coverage information
-     * if false, treat this table as it has no coverage
-     * value must be true or false, it not defined or has some other value then evaluate the table for coverage as normal.
+     * If true, Show the coverage display even it this table does not have coverage information.
+     * If false, treat this table as it has no coverage.
+     * Value must be true or false, if not defined or has some other value then evaluate the table for coverage as normal.
      */
     COVERAGE_SHOWING : 'CoverageShowing',
 
@@ -253,6 +253,9 @@ export const MetaConst = {
      * If defined and true, dispatchTableSearch will be called but prevent going to results view directly
      */
     UPLOAD_TABLE: 'UploadTable',
+
+    /** boolean - if true then use with FITS_FILE_PATH to determine if a PlotView exist that is exclusive*/
+    EXCLUSIVE_TO_PLOT: 'ExclusiveToPlot',
 
     /**
      * if defined and an object, Then this will be table specific DataProductsFactory options

--- a/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
+++ b/src/firefly/js/templates/lightcurve/wise/WisePlotRequests.js
@@ -57,21 +57,6 @@ export function getWebPlotRequestViaWISEIbe(tableModel, hlrow, cutoutSize, param
     fluxCol: 'w1mpro_ep',
     dataSource: 'frame_id'
 }) {
-/*
-    const {CENTER_COLUMN} = get(tableModel, ['tableMeta']);
-    const ra_dec = ['ra', 'dec'];
-    const centerColumns = getCenterColumns(tableModel);
-
-
-    if (CENTER_COLUMN) {
-        const s = CENTER_COLUMN.split(';');
-
-        if (s && s.length === 3) {
-            ra_dec[0] = s[0];
-            ra_dec[1] = s[1];
-        }
-    }
- */
     const centerColumns = findTableCenterColumns(tableModel);
     const ra_dec = [get(centerColumns, 'lonCol', 'ra'), get(centerColumns, 'latCol', 'dec')];
 

--- a/src/firefly/js/ui/PopupUtil.jsx
+++ b/src/firefly/js/ui/PopupUtil.jsx
@@ -6,6 +6,7 @@ import {Sheet, Stack, Typography} from '@mui/joy';
 import React from 'react';
 import {isString} from 'lodash';
 import CompleteButton from './CompleteButton.jsx';
+import {FieldGroup} from './FieldGroup';
 import {PopupPanel} from './PopupPanel.jsx';
 import {ModalDialog} from './ModalDialog.jsx';
 import {dispatchShowDialog, dispatchHideDialog} from '../core/ComponentCntlr.js';
@@ -76,6 +77,21 @@ export function showPopup({ID, content, title='Options', modal = false}) {
     DialogRootContainer.defineDialog(ID, dialogContent);
     dispatchShowDialog(ID);
     return () => dispatchHideDialog(ID);
+}
+
+export function showFieldGroupPopup({groupKey, content, onSuccess, keepState=false,
+                                        successText='OK', title='Options', modal = false}) {
+    const dialogContent= (
+        <FieldGroup {...{groupKey,keepState}}>
+            <Stack spacing={4} sx={{p:2}}>
+                {content}
+                <Stack {...{direction:'row'}}>
+                    <CompleteButton onSuccess={onSuccess} text= {successText} dialogId={groupKey}/>
+                </Stack>
+            </Stack>
+        </FieldGroup>
+    );
+    return showPopup({ID:groupKey,content:dialogContent,title,modal} );
 }
 
 

--- a/src/firefly/js/ui/PopupUtil.jsx
+++ b/src/firefly/js/ui/PopupUtil.jsx
@@ -111,25 +111,46 @@ function makeContent(content) {
     );
 }
 
+/**
+ * show a popup with yes and no buttons
+ * @param content - text or react
+ * @param {Function} clickSelection - callback returns (popupId:string, yes:boolean)
+ * @param {String} title - title on popup
+ * @param {Object} sx - sx style
+ */
 export function showYesNoPopup(content, clickSelection,  title='Information', sx) {
+    showMultiAnswerPopup(content,(id,v) => clickSelection(id,v==='yes'), {yes:'Yes', 'no': 'No'}, title, sx);
+}
+
+/**
+ * show a popup with a set of buttons defined by the answers parameter
+ * @param content - text or react
+ * @param {Function} clickSelection - callback returns (popupId:string, answerId:string)
+ * @param {Object.<answerId:string, buttonText:String>} answers - e.g {hello:'Hello', goodbye:'Goodbye'}
+ * @param {String} title - title on popup
+ * @param {Object} sx - sx style
+ */
+export function showMultiAnswerPopup(content, clickSelection,  answers, title='Information', sx) {
     const results= (
         <PopupPanel title={title} >
-            {makeYesNoContent(content, clickSelection, sx)}
+            { makeMultiAnswerContent(content, clickSelection, answers, sx) }
         </PopupPanel>
     );
     DialogRootContainer.defineDialog(INFO_POPUP, results);
     dispatchShowDialog(INFO_POPUP);
 }
 
-function makeYesNoContent(content, clickSelection, sx) {
+function makeMultiAnswerContent(content, clickSelection, answers, sx) {
     return (
         <Stack direction='column' p={1} spacing={2}>
             <Sheet style={{minWidth:190, maxWidth: 400, p:1, ...sx}}>
                 {content}
             </Sheet>
             <Stack direction='row' spacing={1}>
-                <CompleteButton onSuccess={() => clickSelection(INFO_POPUP, true)} text= 'Yes'/>
-                <CompleteButton onSuccess={() => clickSelection(INFO_POPUP, false)} text= 'No'/>
+                {
+                    Object.entries(answers).map( ([k,v],idx) =>
+                        <CompleteButton key={k} primary={idx===0} onSuccess={() => clickSelection(INFO_POPUP, k)} text= {v}/>)
+                }
             </Stack>
         </Stack>
     );

--- a/src/firefly/js/ui/dynamic/ServiceDefTools.js
+++ b/src/firefly/js/ui/dynamic/ServiceDefTools.js
@@ -4,7 +4,7 @@ import {sprintf} from '../../externalSource/sprintf.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {makeFileRequest, makeTblRequest, setNoCache} from '../../tables/TableRequestUtil.js';
 import {cisxAdhocServiceUtype, standardIDs} from '../../voAnalyzer/VoConst.js';
-import {splitByWhiteSpace, tokenSub} from '../../util/WebUtil.js';
+import {isValidFullUrl, splitByWhiteSpace, tokenSub} from '../../util/WebUtil.js';
 import CoordinateSys from '../../visualize/CoordSys.js';
 import {makeWorldPt, parseWorldPt} from '../../visualize/Point.js';
 import {
@@ -293,7 +293,8 @@ function getMOCList(searchAreaInfo) {
                 mocColor: searchAreaInfo['mocColor'+cnt],
                 maxFetchDepth: searchAreaInfo['maxFetchDepth'+cnt]
             };
-        });
+        })
+        .filter((entry) => isValidFullUrl(entry.mocUrl) );
     return mocAry.length ? mocAry : undefined;
 }
 

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -826,6 +826,61 @@ export function matches(s, regExp, ignoreCase) {
     return false;
 }
 
+/**
+ * trim a string on one of several ways.
+ * <ul>
+ *  <li>middle - both end are preserver middle has an ellipsis</li>
+ *  <li>bothEnds - middle is preserved both ends have an ellipsis</li>
+ *  <li>complex - middle and ends are preserved with ellipsis between the parts </li>
+ *  <li>startMiddle - start and middle are preserved with ellipsis between the parts </li>
+ *  <li>start - start is preserved ellipsis at end</li>
+ *  <li>end - end is preserved ellipsis at start</li>
+ * </ul>
+ * @param s - the string to trim
+ * @param maxLength - max length of the string
+ * @param trimType - either- 'middle', 'bothEnds', 'complex', 'start', 'end', 'startMiddle', default to 'middle'
+ * @return {string}
+ */
+export function advancedTrim(s='', maxLength=15, trimType='middle') {
+    const len= s?.length ?? 0;
+    const e= '…';
+    if (!s || maxLength < 1 || len<maxLength) return s;
+    if (maxLength===1) return s[0] + '…';
+    const types= ['start', 'end', 'middle','bothends', 'startmiddle', 'complex'];
+    const useTrimType= types.find( (t) => t===trimType.toLowerCase()) ?? 'middle';
+
+    const midpoint = Math.ceil(len / 2);
+    const middleLen = len - maxLength;
+    const startLen = Math.ceil(middleLen / 2);
+    const endLen = middleLen - startLen;
+    const maxLenThird= Math.ceil(maxLength / 3);
+    const maxLenHalf= Math.ceil(maxLength / 2);
+    switch (useTrimType) {
+        case 'start':
+            return s.substring(0,maxLength) + e;
+        case 'end':
+            return e + s.substring(s.length-maxLength,s.length);
+        case 'startmiddle':
+            const start2= s.substring(0,maxLenHalf);
+            const halfHalf= Math.ceil(maxLenHalf/2);
+            const mid2= s.substring(midpoint-halfHalf, midpoint+halfHalf);
+            return `${start2}${e}${mid2}${e}`;
+            return '';
+        case 'bothends':
+            return e + s.substring(midpoint-maxLenHalf, midpoint+maxLenHalf)+ e;
+        case 'complex':
+            const start3= s.substring(0,maxLenThird);
+            const end3= s.substring(s.length-maxLenThird);
+            const halfThird= Math.ceil(maxLenThird/2);
+            const mid3= s.substring(midpoint-halfThird, midpoint+halfThird);
+            return `${start3}${e}${mid3}${e}${end3}`;
+        case 'middle':
+        default:
+            return s.substring(0, midpoint - startLen) + e + s.substring(midpoint + endLen);
+
+    }
+}
+
 export const matchesIgCase= (s, regExp) => matches(s, regExp, true);
 
 export function uuid() {

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -117,10 +117,26 @@ export function modifyURLToFull(url, rootPath) {
 }
 
 export function isFullURL(url) {
-    if (!url) return false;
+    if (url instanceof URL) return true;
+    if (!url || !isString(url)) return false;
     const hPref = ['http', 'https', '/', 'file'];
     url = url.toLowerCase();
     return hPref.some((s) => url.startsWith(s));
+}
+
+/**
+ * return true if the string is a valid full url
+ * @param url
+ * @return {boolean}
+ */
+export function isValidFullUrl(url) {
+    if (url instanceof URL) return true;
+    if (!url || !isString(url)) return false;
+    try {
+        return Boolean(new URL(url));
+    } catch {
+        return false;
+    }
 }
 
 

--- a/src/firefly/js/visualize/FitsHeaderUtil.js
+++ b/src/firefly/js/visualize/FitsHeaderUtil.js
@@ -37,6 +37,7 @@ export const HdrConst= {
     DATAMIN  : 'DATAMIN',
     EXTNAME  : 'EXTNAME',
     EXTTYPE  : 'EXTTYPE',
+    NAXIS    : 'NAXIS',
     NAXIS1   : 'NAXIS1',
     NAXIS2   : 'NAXIS2',
     NAXIS3   : 'NAXIS3',

--- a/src/firefly/js/visualize/FitsHeaderUtil.js
+++ b/src/firefly/js/visualize/FitsHeaderUtil.js
@@ -290,5 +290,24 @@ export function isFitsTableDataTypeNumeric(fdt) {
 }
 
 
+/**
+ * return true if the two plot HDU has the same number and matching dimensions
+ * @param refPlot
+ * @param plot
+ * @return {boolean}
+ */
+export function hduDimMatches(refPlot,plot) {
+    const dims= getHeader(refPlot,HdrConst.NAXIS,'0');
+    const xLen= getHeader(refPlot,HdrConst.NAXIS1,'1');
+    const yLen= getHeader(refPlot,HdrConst.NAXIS2,'1');
+    const zLen= getHeader(refPlot,HdrConst.NAXIS3,'1');
+
+    return (
+        dims=== getHeader(plot,HdrConst.NAXIS,'0') &&
+        xLen===getHeader(plot,HdrConst.NAXIS1,'1') &&
+        yLen===getHeader(plot,HdrConst.NAXIS2,'1') &&
+        zLen===getHeader(plot,HdrConst.NAXIS3,'1')
+    );
+}
 
 

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -932,7 +932,7 @@ export function getCubePlaneFromWavelength(pv,wl,imPt) {
 
 /**
  * Return the units string
- * @param {WebPlot} plot
+ * @param {WebPlot|undefined} plot
  * @param {Band} [band]
  * @return {string}
  */

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -62,6 +62,7 @@ export const RDConst= {
  * @prop {String} title - the title
  * @prop {number} colorTableId
  * @prop {Object} header
+ * @prop {number} totalImageHdusInFile
  * @prop {{cubePlane,cubeHeaderAry}} cubeCtx
  * @prop {number} cubeIdx
  * @prop {PlotState} plotState - the plot state, immutable
@@ -433,17 +434,18 @@ export const WebPlot= {
 
     /**
      *
-     * @param {string} plotId
-     * @param {Dimension} viewDim
-     * @param {WebPlotInitializer} wpInit init data returned from server
-     * @param {object} attributes any attributes to initialize
-     * @param {boolean} asOverlay
-     * @param {CubeCtx} [cubeCtx]
-     * @param {WebPlotRequest} [request0] - only used when this is part of a cube
-     * @param {RangeValues} [rv0] - only used when this is part of a cube
+     * @param {Object} obj
+     * @param {string} obj.plotId
+     * @param {Dimension} [obj.viewDim]
+     * @param {WebPlotInitializer} obj.wpInit init data returned from server
+     * @param {object} [obj.attributes] any attributes to initialize
+     * @param {boolean} [obj.asOverlay]
+     * @param {CubeCtx} [obj.cubeCtx]
+     * @param {WebPlotRequest} [obj.request0] - only used when this is part of a cube
+     * @param {RangeValues} [obj.rv0] - only used when this is part of a cube
      * @return {WebPlot} the plot
      */
-    makeWebPlotData(plotId, viewDim, wpInit, attributes= {}, asOverlay= false, cubeCtx, request0, rv0) {
+    makeWebPlotData({plotId, viewDim={}, wpInit, attributes= {}, asOverlay= false, cubeCtx, request0, rv0}) {
 
         const relatedData = cubeCtx ? cubeCtx.relatedData : wpInit.relatedData;
         const plotState= PlotState.makePlotStateWithJson(wpInit.plotState,request0, rv0);
@@ -497,6 +499,7 @@ export const WebPlot= {
             tileData    : undefined,
             relatedData     : null,
             colorTableId: request0?.getInitialColorTable() ?? 0,
+            totalImageHdusInFile: wpInit.totalImageHdusInFile ?? 1,
             header,
             headerAry,
             zeroHeader,

--- a/src/firefly/js/visualize/WebPlotRequest.js
+++ b/src/firefly/js/visualize/WebPlotRequest.js
@@ -759,6 +759,10 @@ export class WebPlotRequest extends ServerRequest {
     getDownloadFileNameRoot() { return this.getParam(WPConst.DOWNLOAD_FILENAME_ROOT); }
 
     setPlotId(id) { this.setParam(WPConst.PLOT_ID,id); }
+
+    /**
+     * @return {String}
+     */
     getPlotId() { return this.getParam(WPConst.PLOT_ID); }
 
     setPlotGroupId(id) { this.setParam(WPConst.PLOT_GROUP_ID,id); }

--- a/src/firefly/js/visualize/saga/CatalogWatcher.js
+++ b/src/firefly/js/visualize/saga/CatalogWatcher.js
@@ -14,7 +14,7 @@ import {cloneRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
 import {
     TABLE_HIGHLIGHT, TABLE_LOADED, TABLE_REMOVE, TABLE_SELECT, TBL_RESULTS_ACTIVE
 } from '../../tables/TablesCntlr.js';
-import {doFetchTable, getMetaEntry} from '../../tables/TableUtil';
+import {doFetchTable, getBooleanMetaEntry, getMetaEntry} from '../../tables/TableUtil';
 import {getTblById} from '../../tables/TableUtil.js';
 import {darker} from '../../util/Color.js';
 import {logger} from '../../util/Logger';
@@ -205,9 +205,12 @@ function updateHpxCatalogDrawingLayer(tbl_id, tableRequest, highlightedRow) {
     const color= coverageDrawLayer?.drawingDef.color;
     const catDL= dispatchCreateDrawLayer(HpxCatalog.TYPE_ID,
         {catalogId, tbl_id, title, highlightedRow, color, layersPanelLayoutId: catalogId});
-    const plotIdAry= visRoot().plotViewAry
-        .filter( (pv) => pv.plotViewCtx.useForSearchResults)
-        .map( (pv) => pv.plotId);
+
+    const plotIdAry=  isTableExclusiveToPlot(table)
+        ? [findPlotViewUsingFitsPathMeta(table)?.plotId]
+        : visRoot().plotViewAry
+            .filter( (pv) => pv.plotViewCtx.useForSearchResults)
+            .map( (pv) => pv.plotId);
     attachToPlot(catalogId,plotIdAry);
 
     const {showCatalogSearchTarget}= getAppOptions();
@@ -288,4 +291,11 @@ export function findPlotViewUsingFitsPathMeta(table) {
     if (!filePath) return;
     const pvAry= getPlotViewAry(visRoot());
     return pvAry.find( (pv) => primePlot(pv)?.plotState.getWorkingFitsFileStr()===filePath);
+}
+export function isTableExclusiveToPlot(table) {
+    const pv= findPlotViewUsingFitsPathMeta(table);
+    if (!pv) return false;
+    return getBooleanMetaEntry(table, MetaConst.EXCLUSIVE_TO_PLOT);
+
+
 }

--- a/src/firefly/js/visualize/task/CreateTaskUtil.js
+++ b/src/firefly/js/visualize/task/CreateTaskUtil.js
@@ -208,7 +208,7 @@ function findCubePlane(plotCreate) {
 
 /**
  * @param {Array.<WebPlotInitializer>} plotCreate
- * @return {Array.<Object>}
+ * @return {Array.<CubeCtx>}
  */
 export function makeCubeCtxAry(plotCreate) {
     let cubeStartIdx = -1;
@@ -280,6 +280,7 @@ export function populateFromHeader(plotCreateHeader, plotCreate) {
         }
         plotCreate[i].dataDesc = plotCreateHeader.dataDesc;
         plotCreate[i].zeroHeaderAry = plotCreateHeader.zeroHeaderAry;
+        plotCreate[i].totalImageHdusInFile= plotCreateHeader.totalImageHdusInFile ?? 1;
         if (plotCreateHeader.multiImage) plotCreate[i].plotState.multiImage = plotCreateHeader.multiImage;
     }
 }

--- a/src/firefly/js/visualize/task/ImageOverlayTask.js
+++ b/src/firefly/js/visualize/task/ImageOverlayTask.js
@@ -212,7 +212,7 @@ function processMaskSuccessResponse(dispatcher, payload, result) {
         const plotState= PlotState.makePlotStateWithJson(PlotCreate[0].plotState);
         const imageOverlayId= plotState.getWebPlotRequest().getPlotId();
 
-        const plot= WebPlot.makeWebPlotData(imageOverlayId, undefined, PlotCreate[0], {}, true, undefined, plotState.getWebPlotRequest());
+        const plot= WebPlot.makeWebPlotData({plotId:imageOverlayId, wpInit:PlotCreate[0], asOverlay:true, request0:plotState.getWebPlotRequest()});
         plot.tileData = undefined;
         const resultPayload= clone(payload, {plot});
         dispatcher({type: ImagePlotCntlr.PLOT_MASK, payload: resultPayload});

--- a/src/firefly/js/visualize/task/PlotChangeTask.js
+++ b/src/firefly/js/visualize/task/PlotChangeTask.js
@@ -326,7 +326,8 @@ function processPlotReplace(dispatcher, result, pv, makeSuccessAction, makeFailA
             resultAry.forEach((r, i) => {
                 if (i === 0) return;
                 const {imageOverlayId}= existingOverlayPlotViews[i-1];
-                const plot = WebPlot.makeWebPlotData(imageOverlayId, pv.viewDim, r.data[WebPlotResult.PLOT_CREATE][0], {}, true);
+                const plot = WebPlot.makeWebPlotData({plotId:imageOverlayId, viewDim:pv.viewDim,
+                    wpInit:r.data[WebPlotResult.PLOT_CREATE][0],  asOverlay:true});
                 overlayPlotViews[i - 1] = {plot};
             });
 
@@ -354,13 +355,14 @@ function getResultAry(result) {
 
 function makeCroppedPlot(pc,plotCreateHeader, pv, cubeCtx) {
     const oldPlot= primePlot(pv);
-    const plot= WebPlot.makeWebPlotData(pv.plotId, pv.viewDim,pc,
-        {...oldPlot.attributes,
+    const {plotId,viewDim}= pv;
+    const plot= WebPlot.makeWebPlotData({plotId, viewDim,wpInit:pc,cubeCtx,
+        attributes:{...oldPlot.attributes,
             [PlotAttribute.IMAGE_BOUNDS_SELECTION]:undefined,
             [PlotAttribute.SELECTION]: undefined,
             [PlotAttribute.SELECTION_SOURCE]: undefined
         },
-    false, cubeCtx);
+    });
     plot.title= oldPlot.title;
     plot.colorTableId= oldPlot.colorTableId;
     return plot;

--- a/src/firefly/js/visualize/task/PlotImageTask.js
+++ b/src/firefly/js/visualize/task/PlotImageTask.js
@@ -194,12 +194,7 @@ async function processPlotImageSuccessResponse(dispatcher, payload, result) {
         dispatchPlotProgressUpdate(wpRequest.getPlotId(), 'Loading Images', false,wpRequest.getRequestKey());
     });
 
-    // try {
-        await getRelatedData(successAry);
-    // }
-    // catch (e) {
-    //    console.log('related data failed'+ e) ;
-    // }
+    await getRelatedData(successAry);
     successAry.forEach( (r) => {
         onViewDimDefined(getRequestFromResult(r)?.getPlotId())
             .then(() => processSuccessResult(dispatcher, payload, [r]));
@@ -295,7 +290,7 @@ function createPlots(plotCreate, plotCreateHeader, payload, requestKey) {
     const attributes= {...initAttributes,  ...request0.getAttributes()};
     let title;
     const plotAry= plotCreate.map((wpInit,idx) => {
-        const plot= WebPlot.makeWebPlotData(plotId, viewDim, wpInit, attributes,false, cubeCtxAry[idx],request0,rv0);
+        const plot= WebPlot.makeWebPlotData({plotId, viewDim, wpInit, attributes,cubeCtx:cubeCtxAry[idx],request0,rv0});
         const extStr= plotCreate.length===1 ? getExtName(plot) || getExtType(plot) : undefined;
         if (!title) title= makePostPlotTitle(plot,request0, extStr);
         plot.title= title;

--- a/src/firefly/js/visualize/ui/extraction/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionDialog.jsx
@@ -253,13 +253,6 @@ function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     const plane= getImageCubeIdx(plot)>-1 ? getImageCubeIdx(plot) : 0;
     const {x:chartX,y:chartY,chartXAxis:lastChartChartXAxis=chartXAxis}=plot?.attributes?.[PlotAttribute.SELECT_ACTIVE_CHART_PT] ?? {};
 
-
-    // const bottomUI = plotlyData ?
-    //         (<RadioGroupInputFieldView value={chartXAxis} buttonGroup={true}
-    //                                    options={ [ {label: 'Image X', value: 'imageX'}, {label: 'Image Y', value: 'imageY'} ]}
-    //                                    onChange={(ev) => setChartXAxis(ev.target.value)} />) :
-    //         undefined;
-
     useEffect(() => {
         const getData= async () => {
             if (imPtAry && imPtAry.length && plot) {

--- a/src/firefly/js/visualize/ui/extraction/ExtractionDialog.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionDialog.jsx
@@ -4,11 +4,10 @@
 
 
 import {Box, Button, Divider, Stack, Tooltip, Typography} from '@mui/joy';
-import {isUndefined} from 'lodash';
+import {isUndefined,isArray} from 'lodash';
 import React, {useEffect, useState} from 'react';
 import sizeMe from 'react-sizeme';
 import {getAppOptions} from '../../../api/ApiUtil.js';
-import {isDefined} from '../../../util/WebUtil';
 import {makeImagePt} from '../../Point';
 import {allowPinnedCharts} from '../../../charts/ChartUtil';
 import {ensureDefaultChart} from '../../../charts/ui/ChartsContainer.jsx';
@@ -28,7 +27,6 @@ import {FieldGroup} from '../../../ui/FieldGroup';
 import HelpIcon from '../../../ui/HelpIcon.jsx';
 import {ListBoxInputField, ListBoxInputFieldView} from '../../../ui/ListBoxInputField.jsx';
 import {PopupPanel} from '../../../ui/PopupPanel.jsx';
-import {RadioGroupInputFieldView} from '../../../ui/RadioGroupInputFieldView.jsx';
 import {useFieldGroupValue, useStoreConnector} from '../../../ui/SimpleComponent.jsx';
 import {ValidationField} from '../../../ui/ValidationField';
 import {intValidator} from '../../../util/Validate';
@@ -48,8 +46,8 @@ import {
     isMultiHDUFits, primePlot
 } from '../../PlotViewUtil.js';
 import {computeDistance, computeScreenDistance, getLinePointAry} from '../../VisUtil.js';
-import {genPointChartData, genSliceChartData, genZAxisChartData} from './ExtractionChart';
-import {keepLineExtraction, keepPointsExtraction, keepZAxisExtraction} from './ExtractionTable';
+import {genPointChartData, genSliceChartData, genZAxisChartData} from './ExtractionChart.jsx';
+import {keepDataExtraction, keepZAxisExtraction} from './ExtractionTable.jsx';
 
 
 const DIALOG_ID= 'extractionDialog';
@@ -241,7 +239,7 @@ function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     const [pointSize,setPointSize]= useState(1);
     const [combineOp,setCombineOp]= useState(AVG);
     const [allRelatedHDUS,setAllRelatedHDUS]= useState(true);
-    const [chartXAxis,setChartXAxis]= useState('imageX');
+    const [chartXAxis]= useState('imageX');
     const plot= primePlot(pv);
     const ptAry=plot?.attributes?.[PlotAttribute.PT_ARY] ??[];
     const cc= CysConverter.make(plot);
@@ -256,11 +254,11 @@ function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
     const {x:chartX,y:chartY,chartXAxis:lastChartChartXAxis=chartXAxis}=plot?.attributes?.[PlotAttribute.SELECT_ACTIVE_CHART_PT] ?? {};
 
 
-    const bottomUI = plotlyData ?
-            (<RadioGroupInputFieldView value={chartXAxis} buttonGroup={true}
-                                       options={ [ {label: 'Image X', value: 'imageX'}, {label: 'Image Y', value: 'imageY'} ]}
-                                       onChange={(ev) => setChartXAxis(ev.target.value)} />) :
-            undefined;
+    // const bottomUI = plotlyData ?
+    //         (<RadioGroupInputFieldView value={chartXAxis} buttonGroup={true}
+    //                                    options={ [ {label: 'Image X', value: 'imageX'}, {label: 'Image Y', value: 'imageY'} ]}
+    //                                    onChange={(ev) => setChartXAxis(ev.target.value)} />) :
+    //         undefined;
 
     useEffect(() => {
         const getData= async () => {
@@ -295,10 +293,8 @@ function PointExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
                 </div>
             ),
             afterRedraw: (chart,pl) => afterPointsChartRedraw(pv,chart,pl,chartXAxis, imPtAry),
-            callKeepExtraction: (download, doOverlay) =>
-                keepPointsExtraction(imPtAry, pv, plot,
-                    plot.plotState.getWorkingFitsFileStr(), hduNum, plane,
-                    pointSize,combineOp, download, doOverlay),
+            callKeepExtraction: (save, doOverlay) =>
+                keepDataExtraction({pv,baseImPtAry:imPtAry,save,doOverlay,pointSize,combineOp})
         }} /> );
 }
 
@@ -371,17 +367,16 @@ function LineExtractionPanel({canCreateExtractionTable, pv, pvCnt}) {
             sizeType: axis==='y'?SIZE_HORIZONTAL:SIZE_VERTICAL,
             startUpHelp: <LineStartUpHelp {...{helpWarning,plot,pvCnt}}/>,
             afterRedraw: (chart,pl) => afterLineChartRedraw(pv,chart,pl,imPtAry,makeImagePt(x1,y1), makeImagePt(x2,y2)),
-            callKeepExtraction: (download, doOverlay) =>
-                keepLineExtraction(ipt1,ipt2, pv, plot, plot.plotState.getWorkingFitsFileStr(),
-                    hduNum, plane,
-                    axis==='x' ? 1 : pointSize,
-                    axis==='y' ? 1: pointSize,
-                    combineOp, download, doOverlay),
+            callKeepExtraction: (save, doOverlay) =>
+                keepDataExtraction({pv,baseImPtAry:getLinePointAry(ipt1, ipt2),save,
+                    doOverlay,axis,pointSize,combineOp, isLine:true})
         }}>
             <LineExtractionType {...{plotlyData:plotlyDataToUse, plotId, selectionType}}/>
         </ExtractionPanelView>
     );
 }
+
+
 
 const LineStartUpHelp= ({helpWarning,plot,pvCnt}) => (
     <Stack alignItems='center'>
@@ -631,6 +626,7 @@ function ExtractionPanelView({pointSize, setPointSize, afterRedraw, plotlyDivSty
         for(let i= 1; i<=7;i+=2) sizeOp.push({label:`${i}x${i}`, value:i});
     }
 
+    const canExtract = plotlyData && canCreateExtractionTable;
 
     return (
         <Stack {...{p:.5, alignItems:'stretch', overflow: 'hidden', zIndex:1, direction:'column',
@@ -661,21 +657,16 @@ function ExtractionPanelView({pointSize, setPointSize, afterRedraw, plotlyDivSty
             <Stack {...{
                 textAlign:'center', alignSelf: 'stretch', direction:'row',
                 justifyContent:'space-between', pt:2, pl:2, pb:1, pr: 1}}>
-                <Stack {...{direction:'row', justifyContent:'space-between'}}>
-                    {plotlyData && canCreateExtractionTable && !allowPinnedCharts() &&
-                    <CompleteButton style={{paddingLeft: 15}} text='Pin Table' onSuccess={()=> callKeepExtraction(false,true)} />}
-                    {plotlyData && canCreateExtractionTable && allowPinnedCharts() &&
-                        <CompleteButton style={{paddingLeft: 15}} text='Pin Chart/Table' onSuccess={() => {
-                            const tbl_id = callKeepExtraction(false,true);
-                            onTableLoaded(tbl_id).then(() => {
-                                const chartId = ensureDefaultChart(tbl_id);
-                                if (chartId) pinChart({chartId});
-                            });
-                        }} />}
+                <Stack {...{direction:'row', justifyContent:'space-between', spacing:2}}>
+                    {canExtract &&
+                        <CompleteButton text= {allowPinnedCharts() ? 'Pin Chart/Table' : 'Pin Table'}
+                                        onSuccess={ () => void keepExtractionAndPin(callKeepExtraction, allowPinnedCharts()) } />}
                     {plotlyData &&
-                    <CompleteButton sx={{pl: 2}} primary={false} text='Download as Table' onSuccess={()=> callKeepExtraction(true,false)}/>}
+                        <CompleteButton primary={false} text='Download as Table'
+                                        onSuccess={()=> void callKeepExtraction(true,false)}/>}
                     {plotlyData &&
-                    <CompleteButton sx={{pl: 2}} primary={false} text='Download Chart' onSuccess={()=> downloadChart(CHART_ID)}/>}
+                        <CompleteButton primary={false} text='Download Chart'
+                                        onSuccess={()=> void downloadChart(CHART_ID)}/>}
                 </Stack>
                 <HelpIcon helpId={'visualization.extraction'}/>
             </Stack>
@@ -684,6 +675,15 @@ function ExtractionPanelView({pointSize, setPointSize, afterRedraw, plotlyDivSty
 }
 
 
+async function keepExtractionAndPin(callKeepExtraction,allowpinChart=false) {
+    const tblIdAry = await callKeepExtraction(false,true);
+    if (!allowpinChart) return;
+    for (const tbl_id of tblIdAry) {
+        await onTableLoaded(tbl_id);
+        const chartId = ensureDefaultChart(tbl_id);
+        if (chartId) pinChart({chartId});
+    }
+}
 
 function cancelZaxisExtraction() {
     dispatchChangePointSelection(ZAXIS_POINT_SELECTION_ID, false);
@@ -709,6 +709,3 @@ function cancelPointExtraction() {
     }
     dispatchHideDialog(DIALOG_ID);
 }
-
-
-

--- a/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
@@ -1,22 +1,28 @@
+import {Stack, Typography} from '@mui/joy';
+import React from 'react';
+import {dispatchHideDialog} from '../../../core/ComponentCntlr';
 import {MetaConst} from '../../../data/MetaConst';
 import {ServerParams} from '../../../data/ServerParams';
 import {makeTblRequest} from '../../../tables/TableRequestUtil';
 import {dispatchTableFetch, dispatchTableSearch} from '../../../tables/TablesCntlr';
 import {onTableLoaded} from '../../../tables/TableUtil';
 import {showTableDownloadDialog} from '../../../tables/ui/TableSave';
-import {showInfoPopup, showPinMessage} from '../../../ui/PopupUtil';
-import {Band} from '../../Band';
+import {showInfoPopup, showMultiAnswerPopup, showPinMessage} from '../../../ui/PopupUtil';
+import {advancedTrim} from '../../../util/WebUtil';
 import {CCUtil, CysConverter} from '../../CsysConverter';
-import {getExtName} from '../../FitsHeaderUtil';
+import {getExtName, getHeader, HdrConst} from '../../FitsHeaderUtil';
+import {visRoot} from '../../ImagePlotCntlr';
 import {
-    getAllWaveLengthsForCube, getHDU, getHduPlotStartIndexes, getImageCubeIdx, getPtWavelength, getWaveLengthUnits,
-    hasPixelLevelWLInfo, hasWCSProjection, hasWLInfo, isImageCube, isMultiHDUFits
+    getAllWaveLengthsForCube, getHDU, getHduPlotStartIndexes, getImageCubeIdx, getPlotViewAry,
+    getPtWavelength, getWaveLengthUnits,
+    hasPixelLevelWLInfo, hasWCSProjection, hasWLInfo, isImageCube, isMultiHDUFits, primePlot,
 } from '../../PlotViewUtil';
-import {getLinePointAry} from '../../VisUtil';
-import {getFluxUnits} from '../../WebPlot';
+import {makeImagePt} from '../../Point';
+import {getFluxUnits, isImage} from '../../WebPlot';
 import {addZAxisExtractionWatcher} from '../ExtractionWatchers';
 
 let idCnt = 0;
+const MAX_HDU= 20;
 const getNextTblId = () => 'extraction-table-' + (idCnt++);
 
 async function doDispatchTableSaving(req, doOverlay) {
@@ -84,45 +90,168 @@ export function keepZAxisExtraction(pt, pv, plot, filename, refHDUNum, extractio
     save ? doDispatchTableSaving(dataTableReq, doOverlay) : doDispatchTable(dataTableReq, doOverlay);
     idCnt++;
     titleCnt++;
-    return tbl_id;
+    return Promise.resolve([tbl_id]);
 }
 
-export function keepLineExtraction(pt, pt2, pv, plot, filename, refHDUNum, plane, extractionSizeX, extractionSizeY, combineOp, save = false, doOverlay = true) {
+export function keepDataExtraction({pv, baseImPtAry, save, doOverlay, axis='both', pointSize, combineOp, isLine=false}) {
+    const plot= primePlot(pv);
+    const filename= plot?.plotState?.getWorkingFitsFileStr();
     if (!pv || !plot || !filename) {
         showInfoPopup('Plot no longer exist. Cannot extract.');
         return;
     }
+    const {pvAry,filteredPvAry,canDoMultiImage}= getExtractableImageList(pv);
+    const extractionSizeX= axis==='x' ? 1 : pointSize;
+    const extractionSizeY= axis==='y' ? 1: pointSize;
+    if (!canDoMultiImage) {
+        const tbl_id= makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extractionSizeY,
+            combineOp, save, doOverlay, isLine});
+        return Promise.resolve([tbl_id]);
+    }
+
+    if (filteredPvAry.length < pvAry.length) {
+        let msg= 'Cannot extract from all images';
+        if (pvAry.some( (testPv) => !hasWCSProjection(testPv))) {
+            msg+= ' Some image do not have a WCS Projection.';
+        }
+        if (pvAry.some( (testPv) => getMatchingHDUCount(testPv)>MAX_HDU)) {
+            msg+= ` Some images have more than ${MAX_HDU} HDUs.`;
+        }
+        msg+= ' These image can be extracted in single image mode';
+        setTimeout( () => showInfoPopup(msg), 1000);
+    }
+
+
+    const AllImagesQuestion= () => (
+        <Stack spacing={2} sx={{width:'30rem'}}>
+            <Typography>
+                You can either extract from a single image or all images that have a WCS and a limited amount of HDUs.
+            </Typography>
+            <Typography color='warning'>
+                Do you want to extract from all images?
+            </Typography>
+        </Stack>
+    );
+    const answers= {allSame: 'Yes / one table', allDiff: 'Yes / multiple tables', single: 'No'};
+
+    let tblId, tblIdAry;
+    return new Promise((resolve) => {
+        const handleAnswer= (id,answer) => {
+            dispatchHideDialog(id);
+            if (answer==='allDiff') {
+                tblIdAry= getExtractableImageList(pv,false).filteredPvAry.map( (pv) => {
+                    const ccBase = CysConverter.make(primePlot(filteredPvAry[0]));
+                    const cc= CysConverter.make(primePlot(pv));
+                    const newBaseImPtAry= baseImPtAry.map((pt) => cc.getImageCoords(ccBase.getWorldCoords(pt)));
+                    return makeDataExtractionTable({baseImPtAry:newBaseImPtAry, pv, extractionSizeX, extractionSizeY,
+                        combineOp, save, doOverlay, isLine, exclusiveToPlot:true});
+                } );
+                resolve(tblIdAry);
+            }
+            else {
+                tblId= makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extractionSizeY, combineOp, save,
+                    doOverlay, isLine, allImages: answer==='allSame'});
+                resolve([tblId]);
+            }
+        };
+        showMultiAnswerPopup(<AllImagesQuestion/>, handleAnswer, answers, 'Extract Image Type', {maxWidth:'30rem'});
+    });
+}
+
+
+
+
+export function makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extractionSizeY,
+                                       combineOp, save = false, doOverlay = true,
+                                            allImages=false, exclusiveToPlot=false, isLine}) {
+    const plot= primePlot(pv);
     const tbl_id = getNextTblId();
-    const imPtAry = getLinePointAry(pt, pt2);
     const cc = CysConverter.make(plot);
 
-    const wlAry = hasPixelLevelWLInfo(plot) ?
-        imPtAry.map((pt) => getPtWavelength(plot, pt, 0))
-        : undefined;
+    const baseWpAry= hasWCSProjection(plot) ? baseImPtAry.map((pt) => cc.getWorldCoords(pt)) : undefined;
+    const {filteredPvAry}= allImages ? getExtractableImageList(pv) : {filteredPvAry: [pv]};
 
-    const wptStrAry = hasWCSProjection(plot) ?
-        imPtAry.map((pt) => cc.getWorldCoords(pt)).map((wpt) => wpt.toString()) : undefined;
-    const dataTableReq = makeTblRequest('ExtractFromImage', makePlaneTitle('Extract Line', pv, plot, titleCnt), {
-            startIdx: 0,
-            extractionType: 'line',
-            ptAry: JSON.stringify(imPtAry.map((pt) => pt.toString())),
-            wptAry: JSON.stringify(wptStrAry),
-            wlAry,
-            wlUnit: getWaveLengthUnits(plot),
-            filename,
-            refHDUNum,
-            plane,
-            extractionSizeX,
-            extractionSizeY,
-            [ServerParams.COMBINE_OP]: combineOp,
-            allMatchingHDUs: true,
-        },
-        {tbl_id});
+    const epBase= {
+        wptAry: baseWpAry ? JSON.stringify(baseWpAry.map((wpt) => wpt.toString())) :  undefined,
+        startIdx: 0,
+        extractionType: isLine ? 'line' : 'points',
+        extractionSizeX,
+        extractionSizeY,
+        [ServerParams.COMBINE_OP]: combineOp,
+        allMatchingHDUs: true,
+        titleAry: JSON.stringify(getTitles(filteredPvAry)),
+    };
+
+    const extractParams= filteredPvAry.reduce( (obj,workingPv,idx) => {
+            const workingPlot= primePlot(workingPv);
+            const cc = CysConverter.make(workingPlot);
+            const ptAry= idx===0 ? baseImPtAry :
+                baseWpAry?.map( (wpt) => {
+                    const ipt= cc.getImageCoords(wpt);
+                    return ipt ? makeImagePt(Math.round(ipt.x), Math.round(ipt.y)) : undefined;
+                });
+            const wlAry = hasPixelLevelWLInfo(workingPlot) ?
+                ptAry.map((pt) => getPtWavelength(workingPlot, pt, 0))
+                : undefined;
+            obj['ptAry'+idx]= JSON.stringify(ptAry.map((pt) => pt.toString()));
+            obj['wlAry'+idx]= wlAry;
+            obj['wlUnit'+idx]= getWaveLengthUnits(workingPlot);
+            obj['filename'+idx]= workingPlot.plotState.getWorkingFitsFileStr();
+            obj['refHDUNum'+idx]= getHDU(workingPlot);
+            obj['plane'+idx]= getImageCubeIdx(workingPlot)>-1 ? getImageCubeIdx(workingPlot) : 0;
+            return obj;
+        },epBase);
+    if (exclusiveToPlot) {
+        extractParams.META_INFO= {[MetaConst.EXCLUSIVE_TO_PLOT]: 'true'};
+    }
+    const dataTableReq = makeTblRequest('ExtractFromImage',
+        makePlaneTitle(`Extract ${isLine?'Line':'Points'}`, pv, plot, titleCnt), extractParams, {tbl_id});
     save ? doDispatchTableSaving(dataTableReq, doOverlay) : doDispatchTable(dataTableReq, doOverlay);
     idCnt++;
     titleCnt++;
     return tbl_id;
 }
+
+
+function getTitles(pvAry) {
+    const titleAry= pvAry.map( (pv) => primePlot(pv)?.title ?? '');
+    const lenTest= [15,18,21,24];
+    for(let i=0;i<lenTest.length;i++) {
+        const tryArray= getTestTitles(titleAry,lenTest[i]);
+        if (new Set(tryArray).size === tryArray.length) return tryArray;
+    }
+    return titleAry;
+}
+
+function getTestTitles(titleAry,size) {
+    const sizeHalf= Math.floor(size/2);
+    const sizeThird= Math.floor(size/3);
+    const firstTitle= titleAry[0];
+    const firstTitleStart= firstTitle.substring(0,sizeThird);
+    const firstTitleEnd= titleAry[0].substring(firstTitle.length-sizeThird,firstTitle.length);
+    const firstMidPoint = Math.ceil(firstTitle.length / 2);
+    const firstTitleMiddle= titleAry[0].substring(firstMidPoint-sizeHalf,firstMidPoint+sizeHalf);
+    const discardStart= titleAry.every( (t) => firstTitleStart===t.substring(0,sizeThird));
+    const discardEnd= titleAry.every( (t) => firstTitleEnd===t.substring(t.length-sizeThird,t.length));
+    const discardMiddle= titleAry.every( (t) => {
+        const midPoint = Math.ceil(t.length / 2);
+        return firstTitleMiddle===t.substring(midPoint-sizeHalf,midPoint+sizeHalf);
+    });
+
+    let trimType;
+    if (discardStart && discardEnd && !discardMiddle) trimType= 'bothEnds';
+    else if (!discardStart && !discardEnd && !discardMiddle) trimType= 'complex';
+    else if (!discardStart && !discardMiddle) trimType= 'startMiddle';
+    else if (!discardStart) trimType= 'start';
+    else if (!discardEnd) trimType= 'end';
+    else trimType= 'middle';
+
+
+    return titleAry.map( (t) => advancedTrim(t,size,trimType) );
+}
+
+
+
 
 function makePlaneTitle(rootStr, pv, plot, cnt) {
     let hduStr = '';
@@ -170,4 +299,39 @@ export function keepPointsExtraction(ptAry, pv, plot, filename, refHDUNum, plane
     idCnt++;
     titleCnt++;
     return tbl_id;
+}
+
+function getMatchingHDUCount(pv) {
+    const plot= primePlot(pv);
+    if (!plot) return 0;
+    return pv.plots.filter( (p) => hduMatches(plot,p)).length;
+}
+
+
+function hduMatches(refPlot,plot) {
+
+    const dims= getHeader(refPlot,HdrConst.NAXIS,'0');
+    const xLen= getHeader(refPlot,HdrConst.NAXIS1,'1');
+    const yLen= getHeader(refPlot,HdrConst.NAXIS2,'1');
+    const zLen= getHeader(refPlot,HdrConst.NAXIS3,'1');
+
+    return (
+        dims=== getHeader(plot,HdrConst.NAXIS,'0') &&
+        xLen===getHeader(plot,HdrConst.NAXIS1,'1') &&
+        yLen===getHeader(plot,HdrConst.NAXIS2,'1') &&
+        zLen===getHeader(plot,HdrConst.NAXIS3,'1')
+    );
+
+
+}
+
+function getExtractableImageList(pv,limitHDUs=true) {
+    const singleRet= {filteredPvAry:[pv], pvAry:[pv], canDoMultiImage:false};
+    if (!hasWCSProjection(primePlot(pv))) return singleRet;
+    if (limitHDUs && getMatchingHDUCount(pv)>MAX_HDU) return singleRet;
+    const pvAry= [pv,
+        ...getPlotViewAry(visRoot(), pv.plotGroupId).filter( (testPv) => isImage(primePlot(testPv)) && testPv!==pv) ];
+    if (pvAry.length===1) return singleRet;
+    const filteredPvAry= pvAry.filter( (testPv) => hasWCSProjection(testPv) && (!limitHDUs || getMatchingHDUCount(testPv)<=MAX_HDU) );
+    return {filteredPvAry,pvAry,canDoMultiImage:true};
 }

--- a/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
+++ b/src/firefly/js/visualize/ui/extraction/ExtractionTable.jsx
@@ -1,16 +1,18 @@
 import {Stack, Typography} from '@mui/joy';
-import React from 'react';
-import {dispatchHideDialog} from '../../../core/ComponentCntlr';
+import React, {useEffect} from 'react';
 import {MetaConst} from '../../../data/MetaConst';
 import {ServerParams} from '../../../data/ServerParams';
 import {makeTblRequest} from '../../../tables/TableRequestUtil';
 import {dispatchTableFetch, dispatchTableSearch} from '../../../tables/TablesCntlr';
 import {onTableLoaded} from '../../../tables/TableUtil';
 import {showTableDownloadDialog} from '../../../tables/ui/TableSave';
-import {showInfoPopup, showMultiAnswerPopup, showPinMessage} from '../../../ui/PopupUtil';
+import {CheckboxGroupInputField} from '../../../ui/CheckboxGroupInputField';
+import { showFieldGroupPopup, showInfoPopup, showPinMessage, } from '../../../ui/PopupUtil';
+import {RadioGroupInputField} from '../../../ui/RadioGroupInputField';
+import {useFieldGroupValue} from '../../../ui/SimpleComponent';
 import {advancedTrim} from '../../../util/WebUtil';
 import {CCUtil, CysConverter} from '../../CsysConverter';
-import {getExtName, getHeader, HdrConst} from '../../FitsHeaderUtil';
+import {getExtName} from '../../FitsHeaderUtil';
 import {visRoot} from '../../ImagePlotCntlr';
 import {
     getAllWaveLengthsForCube, getHDU, getHduPlotStartIndexes, getImageCubeIdx, getPlotViewAry,
@@ -23,6 +25,7 @@ import {addZAxisExtractionWatcher} from '../ExtractionWatchers';
 
 let idCnt = 0;
 const MAX_HDU= 20;
+const MIN_FULL_TITLE_LEN= 15;
 const getNextTblId = () => 'extraction-table-' + (idCnt++);
 
 async function doDispatchTableSaving(req, doOverlay) {
@@ -100,76 +103,150 @@ export function keepDataExtraction({pv, baseImPtAry, save, doOverlay, axis='both
         showInfoPopup('Plot no longer exist. Cannot extract.');
         return;
     }
-    const {pvAry,filteredPvAry,canDoMultiImage}= getExtractableImageList(pv);
     const extractionSizeX= axis==='x' ? 1 : pointSize;
     const extractionSizeY= axis==='y' ? 1: pointSize;
+    const params= {baseImPtAry, pv, extractionSizeX, extractionSizeY, combineOp, save,
+        doOverlay, isLine, allMatchingHDUs: true};
+    const {canDoMultiImage}= getExtractableImageList(pv,true);
     if (!canDoMultiImage) {
-        const tbl_id= makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extractionSizeY,
-            combineOp, save, doOverlay, isLine});
-        return Promise.resolve([tbl_id]);
+        return Promise.resolve([makeDataExtractionTable(params)]);
     }
-
-    if (filteredPvAry.length < pvAry.length) {
-        let msg= 'Cannot extract from all images';
-        if (pvAry.some( (testPv) => !hasWCSProjection(testPv))) {
-            msg+= ' Some image do not have a WCS Projection.';
-        }
-        if (pvAry.some( (testPv) => getMatchingHDUCount(testPv)>MAX_HDU)) {
-            msg+= ` Some images have more than ${MAX_HDU} HDUs.`;
-        }
-        msg+= ' These image can be extracted in single image mode';
-        setTimeout( () => showInfoPopup(msg), 1000);
-    }
+    const {pvAry}= getExtractableImageList(pv,false);
 
 
-    const AllImagesQuestion= () => (
-        <Stack spacing={2} sx={{width:'30rem'}}>
-            <Typography>
-                You can either extract from a single image or all images that have a WCS and a limited amount of HDUs.
-            </Typography>
-            <Typography color='warning'>
-                Do you want to extract from all images?
-            </Typography>
-        </Stack>
-    );
-    const answers= {allSame: 'Yes / one table', allDiff: 'Yes / multiple tables', single: 'No'};
-
-    let tblId, tblIdAry;
     return new Promise((resolve) => {
-        const handleAnswer= (id,answer) => {
-            dispatchHideDialog(id);
-            if (answer==='allDiff') {
-                tblIdAry= getExtractableImageList(pv,false).filteredPvAry.map( (pv) => {
-                    const ccBase = CysConverter.make(primePlot(filteredPvAry[0]));
+        const handleAnswer= ({hdus= 'all', titleType='full', whatToExtract, pvAry:extractPvAry}) => {
+            const allMatchingHDUs= hdus==='all';
+            if (whatToExtract==='allDiff') {
+                const tblIdAry= extractPvAry.map( (pv) => {
+                    const ccBase = CysConverter.make(primePlot(extractPvAry[0]));
                     const cc= CysConverter.make(primePlot(pv));
                     const newBaseImPtAry= baseImPtAry.map((pt) => cc.getImageCoords(ccBase.getWorldCoords(pt)));
                     return makeDataExtractionTable({baseImPtAry:newBaseImPtAry, pv, extractionSizeX, extractionSizeY,
-                        combineOp, save, doOverlay, isLine, exclusiveToPlot:true});
+                        combineOp, save, doOverlay, isLine, exclusiveToPlot:true, allMatchingHDUs});
                 } );
                 resolve(tblIdAry);
             }
             else {
-                tblId= makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extractionSizeY, combineOp, save,
-                    doOverlay, isLine, allImages: answer==='allSame'});
-                resolve([tblId]);
+                const tbl_id= (whatToExtract==='allSame')
+                    ? makeDataExtractionTable({...params, allMatchingHDUs, pvAry: extractPvAry, truncatedHeaders:titleType!=='full'})
+                    : makeDataExtractionTable({...params, allMatchingHDUs});
+                resolve([tbl_id]);
             }
         };
-        showMultiAnswerPopup(<AllImagesQuestion/>, handleAnswer, answers, 'Extract Image Type', {maxWidth:'30rem'});
+        showFieldGroupPopup({groupKey:'ExtractOptions', keepState:true, successText:'Pin Chart/Table',
+            content:<ExtractTableOptions pvAry={pvAry} />,
+            onSuccess:handleAnswer,  title:'Extract Image Type'});
     });
 }
 
 
+const ExtractTableOptions= ({pvAry:initPvAry}) => {
+    const whatToExtract= useFieldGroupValue('whatToExtract')[0]();
+    const allHdus= useFieldGroupValue('hdus')[0]()==='all';
+    const [getPvAry,setPvAry]= useFieldGroupValue('pvAry');
+    const someHduOverMax=  initPvAry.some( (testPv) => primePlot(testPv).totalImageHdusInFile>MAX_HDU);
+
+    const pvAry= getPvAry() ?? initPvAry;
+    const allToSameFile= whatToExtract==='allSame';
+
+    useEffect(() => {
+        const newPvAry= (allHdus && allToSameFile)
+            ? initPvAry.filter( (pv) => primePlot(pv).totalImageHdusInFile<=MAX_HDU && hasWCSProjection(pv))
+            : initPvAry.filter( (pv) => hasWCSProjection(pv));
+        setPvAry(newPvAry);
+    }, [allHdus, allToSameFile, initPvAry, someHduOverMax]);
+
+    const wcsPvAry= initPvAry.filter( (testPv) => hasWCSProjection(testPv));
+    const wcsWarning= wcsPvAry.length < initPvAry.length;
+    const hasLongTitles= pvAry.some( (pv) =>  primePlot(pv)?.title?.length>MIN_FULL_TITLE_LEN);
+    const someMultiHDUs=  initPvAry.some( (testPv) => primePlot(testPv).totalImageHdusInFile>1);
+    const maxHduWarning= (allToSameFile && allHdus)
+        ? initPvAry.some( (testPv) => primePlot(testPv).totalImageHdusInFile>MAX_HDU)
+        : false ;
+
+    return (
+        <Stack spacing={3} m={2}>
+            <Stack spacing={1}>
+                <Stack spacing={2} sx={{width:'30rem'}}>
+                    <Typography>
+                        You can either extract from the currently selected single image, or all loaded images that have a WCS
+                        and a limited amount of HDUs (with WCS information).
+                    </Typography>
+                    <Typography color='warning'>
+                        What do you want to extract?
+                    </Typography>
+                </Stack>
+                <Stack pl={6}>
+                    <RadioGroupInputField
+                        fieldKey='whatToExtract'
+                        options={[
+                            {label: 'Selected image only', value: 'single'},
+                            {label: 'All images (into one table)', value: 'allSame'},
+                            {label: 'All images (into multiple table)', value: 'allDiff'}
+                        ]}
+                        initialState= {{value: 'allSame' }} />
+                </Stack>
+            </Stack>
+            <Stack spacing={1} pl={6}>
+                {someMultiHDUs &&
+                    <CheckboxGroupInputField
+                        fieldKey='hdus' options={[{
+                            label:'Include all matching HDUs', value: 'all'}]}
+                        initialState= {{value: 'all' }} />
+                }
+                {hasLongTitles &&
+                    <CheckboxGroupInputField
+                        fieldKey='titleType'
+                        sx={{visibility: (allToSameFile) ? 'visible' : 'hidden'}}
+                        options={[{label:'Use full image titles in column headers', value: 'full'}]}
+                        initialState= {{value: '' }} />
+                }
+            </Stack>
+            <Stack>
+                {(wcsWarning || maxHduWarning) &&
+                    <Typography color='warning' level='body-sm'> Cannot extract from all images.
+                    </Typography>}
+                <Stack sx={{pl:2}}>
+                    {wcsWarning &&
+                        <Typography level='body-sm'> Some images do not have a WCS Projection.
+                        </Typography>}
+                    {maxHduWarning &&
+                        <Typography level='body-sm'>
+                            <div>
+                                {` Some images have more than ${MAX_HDU} HDUs.`}
+                            </div>
+                            <div>
+                                Hint: turn off 'include all match HDUs' or don't use 'All image (into one table)'
+                            </div>
+                        </Typography>}
+                    {(wcsWarning || maxHduWarning) &&
+                        <Typography level='body-sm'>
+                            These images can also be extracted in single image mode
+                        </Typography>
+                    }
+                </Stack>
+            </Stack>
+        </Stack>
+    );
+};
 
 
-export function makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extractionSizeY,
+export function makeDataExtractionTable({baseImPtAry, pv, pvAry, extractionSizeX, extractionSizeY,
                                        combineOp, save = false, doOverlay = true,
-                                            allImages=false, exclusiveToPlot=false, isLine}) {
+                                            truncatedHeaders=false,
+                                            allMatchingHDUs= true,
+                                            exclusiveToPlot=false, isLine}) {
     const plot= primePlot(pv);
     const tbl_id = getNextTblId();
     const cc = CysConverter.make(plot);
 
     const baseWpAry= hasWCSProjection(plot) ? baseImPtAry.map((pt) => cc.getWorldCoords(pt)) : undefined;
-    const {filteredPvAry}= allImages ? getExtractableImageList(pv) : {filteredPvAry: [pv]};
+    const filteredPvAry= pvAry ?? [pv];
+
+
+
+    const headers= truncatedHeaders ? getTitles(filteredPvAry) : filteredPvAry.map( (pv) => primePlot(pv)?.title ?? '');
 
     const epBase= {
         wptAry: baseWpAry ? JSON.stringify(baseWpAry.map((wpt) => wpt.toString())) :  undefined,
@@ -178,8 +255,8 @@ export function makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extra
         extractionSizeX,
         extractionSizeY,
         [ServerParams.COMBINE_OP]: combineOp,
-        allMatchingHDUs: true,
-        titleAry: JSON.stringify(getTitles(filteredPvAry)),
+        allMatchingHDUs,
+        titleAry: JSON.stringify(headers),
     };
 
     const extractParams= filteredPvAry.reduce( (obj,workingPv,idx) => {
@@ -215,7 +292,7 @@ export function makeDataExtractionTable({baseImPtAry, pv, extractionSizeX, extra
 
 function getTitles(pvAry) {
     const titleAry= pvAry.map( (pv) => primePlot(pv)?.title ?? '');
-    const lenTest= [15,18,21,24];
+    const lenTest= [MIN_FULL_TITLE_LEN,MIN_FULL_TITLE_LEN+3,MIN_FULL_TITLE_LEN+6,MIN_FULL_TITLE_LEN+9];
     for(let i=0;i<lenTest.length;i++) {
         const tryArray= getTestTitles(titleAry,lenTest[i]);
         if (new Set(tryArray).size === tryArray.length) return tryArray;
@@ -250,9 +327,6 @@ function getTestTitles(titleAry,size) {
     return titleAry.map( (t) => advancedTrim(t,size,trimType) );
 }
 
-
-
-
 function makePlaneTitle(rootStr, pv, plot, cnt) {
     let hduStr = '';
     let cubeStr = '';
@@ -264,74 +338,14 @@ function makePlaneTitle(rootStr, pv, plot, cnt) {
     return `${rootStr} ${cnt}${hduStr}${cubeStr}`;
 }
 
-export function keepPointsExtraction(ptAry, pv, plot, filename, refHDUNum, plane, extractionSize, combineOp, save = false, doOverlay = true) {
-    if (!pv || !plot || !filename) {
-        showInfoPopup('Plot no longer exist. Cannot extract.');
-        return;
-    }
-    const tbl_id = getNextTblId();
-    const cc = CysConverter.make(plot);
-    const wlAry = hasPixelLevelWLInfo(plot) ?
-        ptAry.map((pt) => getPtWavelength(plot, pt, 0))
-        : undefined;
-    const wptStrAry =
-        hasWCSProjection(plot) ?
-            ptAry.map((pt) => cc.getWorldCoords(pt)).map((pt) => pt.toString()) :
-            undefined;
-    const dataTableReq = makeTblRequest('ExtractFromImage', makePlaneTitle('Points', pv, plot, titleCnt),
-        {
-            startIdx: 0,
-            extractionType: 'points',
-            ptAry: JSON.stringify(ptAry.map((pt) => pt.toString())),
-            wptAry: JSON.stringify(wptStrAry),
-            wlAry,
-            wlUnit: getWaveLengthUnits(plot),
-            filename,
-            refHDUNum,
-            plane,
-            extractionSizeX: extractionSize,
-            extractionSizeY: extractionSize,
-            [ServerParams.COMBINE_OP]: combineOp,
-            allMatchingHDUs: true,
-        },
-        {tbl_id});
-    save ? doDispatchTableSaving(dataTableReq, doOverlay) : doDispatchTable(dataTableReq, doOverlay);
-    idCnt++;
-    titleCnt++;
-    return tbl_id;
-}
-
-function getMatchingHDUCount(pv) {
-    const plot= primePlot(pv);
-    if (!plot) return 0;
-    return pv.plots.filter( (p) => hduMatches(plot,p)).length;
-}
-
-
-function hduMatches(refPlot,plot) {
-
-    const dims= getHeader(refPlot,HdrConst.NAXIS,'0');
-    const xLen= getHeader(refPlot,HdrConst.NAXIS1,'1');
-    const yLen= getHeader(refPlot,HdrConst.NAXIS2,'1');
-    const zLen= getHeader(refPlot,HdrConst.NAXIS3,'1');
-
-    return (
-        dims=== getHeader(plot,HdrConst.NAXIS,'0') &&
-        xLen===getHeader(plot,HdrConst.NAXIS1,'1') &&
-        yLen===getHeader(plot,HdrConst.NAXIS2,'1') &&
-        zLen===getHeader(plot,HdrConst.NAXIS3,'1')
-    );
-
-
-}
-
 function getExtractableImageList(pv,limitHDUs=true) {
     const singleRet= {filteredPvAry:[pv], pvAry:[pv], canDoMultiImage:false};
-    if (!hasWCSProjection(primePlot(pv))) return singleRet;
-    if (limitHDUs && getMatchingHDUCount(pv)>MAX_HDU) return singleRet;
+    const plot= primePlot(pv);
+    if (!hasWCSProjection(plot)) return singleRet;
+    if (limitHDUs && plot.totalImageHdusInFile>MAX_HDU) return singleRet;
     const pvAry= [pv,
         ...getPlotViewAry(visRoot(), pv.plotGroupId).filter( (testPv) => isImage(primePlot(testPv)) && testPv!==pv) ];
     if (pvAry.length===1) return singleRet;
-    const filteredPvAry= pvAry.filter( (testPv) => hasWCSProjection(testPv) && (!limitHDUs || getMatchingHDUCount(testPv)<=MAX_HDU) );
+    const filteredPvAry= pvAry.filter( (testPv) => hasWCSProjection(testPv) && (!limitHDUs || primePlot(testPv).totalImageHdusInFile<=MAX_HDU) );
     return {filteredPvAry,pvAry,canDoMultiImage:true};
 }

--- a/src/firefly/js/voAnalyzer/TableAnalysis.js
+++ b/src/firefly/js/voAnalyzer/TableAnalysis.js
@@ -11,6 +11,7 @@ import {
 import {isDefined} from '../util/WebUtil.js';
 import CoordinateSys from '../visualize/CoordSys.js';
 import {makeAnyPt, makeWorldPt, parseWorldPt} from '../visualize/Point.js';
+import {isTableExclusiveToPlot} from '../visualize/saga/CatalogWatcher';
 import {
     ACCESS_FORMAT, ACCESS_URL, DEFAULT_TNAME_OPTIONS, obsPrefix, OBSTAP_CNAMES, S_REGION, SERVICE_DESC_COL_NAMES,
     SSA_COV_UTYPE, SSA_TITLE_UTYPE
@@ -83,6 +84,7 @@ export function hasCoverageData(tableOrId) {
     if (!getBooleanMetaEntry(table, MetaConst.COVERAGE_SHOWING, true)) return false;
     if (!table) return false;
     if (!table.totalRows) return false;
+    if (isTableExclusiveToPlot(table)) return false;
     return !isEmpty(findTableRegionColumn(table)) || !isEmpty(findTableCenterColumns(table, true)) || !isEmpty(getCornersColumns(table));
 }
 


### PR DESCRIPTION
note this PR was closed accidentally. Github seems to have trouble reopening closed PRs. So i create and new PR and merged. https://github.com/Caltech-IPAC/firefly/pull/1814

#### Firefly-1801](https://jira.ipac.caltech.edu/browse/FIREFLY-1801): line and point extractions supports multiple images
 
 - create one wide table
 - create multiple tables

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1801-extraction/firefly
- Load more than one images
- do a line or point extract then click on `Pin Chart/Table`.
- this will give you three options. Try with all three
- Mullti HDU images work as well. In these cases the table can get pretty wide.