### PR TITLE
FIREFLY-1798: Fix downloads for routed apps and improve obs core tbl recognition 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
@@ -367,7 +367,7 @@ public class ObsCorePackager extends FileGroupsProcessor {
                             break;
                         }
                     }
-                    String resolvedValue = (String) dgDataUrl.get(idx, key);
+                    String resolvedValue = Objects.toString(dgDataUrl.get(idx, key), null);
                     if (resolvedValue != null && !resolvedValue.isEmpty()) {
                         if (serDescUrl.partialUrl.endsWith("?"))
                             finalUrl.append(missing.paramName).append("=").append(resolvedValue);
@@ -644,6 +644,9 @@ public class ObsCorePackager extends FileGroupsProcessor {
             e.printStackTrace();
         }
 
-        return new ServDescUrl(accessUrl + "?" + queryString.toString(), missingParams);
+        String separator = Objects.requireNonNull(accessUrl, "accessUrl cannot be null")
+                .endsWith("?") ? "" : "?";
+        return new ServDescUrl(accessUrl + separator + queryString.toString(), missingParams);
+
     }
 }

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo, useState} from 'react';
-import {cloneDeep, once} from 'lodash';
+import {cloneDeep, isEmpty, once} from 'lodash';
 import {dispatchAddTableTypeWatcherDef} from '../../core/MasterSaga.js';
 import {MetaConst} from '../../data/MetaConst';
 import {dispatchTableUiUpdate, TABLE_LOADED} from '../../tables/TablesCntlr.js';
@@ -7,7 +7,8 @@ import {getActiveTableId, getMetaEntry, getTableUiByTblId, getTblById} from '../
 import {DownloadButton, DownloadOptionPanel} from '../../ui/DownloadDialog.jsx';
 import {getDataServiceOption, getDataServiceOptionByTable, getDataServiceOptionsFallback,
 } from '../../ui/tap/DataServicesOptions';
-import {findTableCenterColumns, hasObsCoreLikeDataProducts, isDatalinkTable} from '../../voAnalyzer/TableAnalysis.js';
+import {findTableCenterColumns, hasDataLinkSvcDesc, hasObsCoreLikeDataProducts, isDatalinkTable
+} from '../../voAnalyzer/TableAnalysis.js';
 import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
 import {getActiveRowToImageDef } from '../../visualize/saga/ActiveRowToImageWatcher.js';
@@ -44,10 +45,13 @@ export function startTTFeatureWatchers(startIds=[
 export const getObsCoreWatcherDef= once(() => ({
     id : 'ObsCorePackage',
     watcher : watchForObsCoreTable,
-    testTable : hasObsCoreLikeDataProducts,
+    testTable : isObsCoreish,
     actions: [TABLE_LOADED]
 }));
 
+function isObsCoreish(tableOrId) {
+    return hasObsCoreLikeDataProducts(tableOrId) || hasDataLinkSvcDesc(tableOrId);
+}
 
 const addedTblIds=[];
 
@@ -74,8 +78,10 @@ function setupObsCorePackaging(tbl_id) {
     }
     if (!enabled) return;
 
+    const dlProps = getDataServiceOptionByTable('obsCoreDownloadProps', table, {}) || {};
+
     const {tbl_ui_id, leftButtons=[]}= getTableUiByTblId(tbl_id) ?? {} ;
-    leftButtons.unshift(() => <PrepareDownload/>);
+    leftButtons.unshift(() => <PrepareDownload {...dlProps} />);
     dispatchTableUiUpdate({ tbl_ui_id, leftButtons});
 }
 

--- a/src/firefly/js/templates/router/RoutedApp.jsx
+++ b/src/firefly/js/templates/router/RoutedApp.jsx
@@ -5,7 +5,7 @@ import {FireflyLayout} from '../common/FireflyLayout.jsx';
 import {IrsaFooterSmall} from '../../ui/IrsaFooter.jsx';
 import {useDropdownRoute} from './RouteHelper.jsx';
 import {DropDownContainer} from '../../ui/DropDownContainer.jsx';
-import {startTTFeatureWatchers} from '../common/ttFeatureWatchers.js';
+import {getAllStartIds, startTTFeatureWatchers} from '../common/ttFeatureWatchers.js';
 import {dispatchNotifyRemoteAppReady, dispatchOnAppReady, dispatchSetMenu} from '../../core/AppDataCntlr.js';
 import {applyLayoutFix, HydraLanding} from '../hydra/HydraViewer.jsx';
 import {Slot} from '../../ui/SimpleComponent.jsx';
@@ -61,7 +61,7 @@ useDropdownRoute:  The hook marrying route behavior on top of Firefly's layout c
 export  default function RoutedApp({slotProps, menu, mainPanel, children, dropdownPanels, ...props}) {
 
     useEffect(() => {
-        startTTFeatureWatchers();
+        startTTFeatureWatchers(getAllStartIds());
         dispatchSetMenu({menuItems: menu});
         dispatchOnAppReady(() => {
             dispatchNotifyRemoteAppReady();

--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -82,7 +82,7 @@ export function onTapSearchSubmit({request, serviceUrl, tapBrowserState, additio
             ...treq.META_INFO,
             ...additionalTapMeta,
             ...metaInfo,
-            [MetaConst.DATA_SERVICE_ID] : getServiceId(serviceUrl),
+            [MetaConst.DATA_SERVICE_ID] : metaInfo?.[MetaConst.DATA_SERVICE_ID] ?? getServiceId(serviceUrl)
         };
         dispatchTableSearch(treq, {backgroundable: true, showFilters: true, showInfoButton: true, ...tblOptions});
     };

--- a/src/firefly/js/voAnalyzer/TableAnalysis.js
+++ b/src/firefly/js/voAnalyzer/TableAnalysis.js
@@ -17,7 +17,7 @@ import {
     SSA_COV_UTYPE, SSA_TITLE_UTYPE
 } from './VoConst.js';
 import {getObsTabColEntry, getTableModel} from './VoCoreUtils.js';
-import {hasServiceDescriptors} from './VoDataLinkServDef.js';
+import {getServiceDescriptors, hasServiceDescriptors, isDataLinkServiceDesc} from './VoDataLinkServDef.js';
 import {VoTableRecognizer} from './VoTableRecognizer.js';
 
 
@@ -176,6 +176,17 @@ export function hasObsCoreLikeDataProducts(tableOrId) {
     const hasFormat = getObsCoreTableColumn(table, ACCESS_FORMAT);
     const hasProdType = getObsCoreProdTypeCol(table);
     return Boolean(hasUrl && hasFormat && hasProdType);
+}
+
+/**
+ * Return true if this table has a datalink service descriptor (treat it like obscore-type table in this case)
+ * @param {TableModel|String} tableOrId
+ * @return {boolean}
+ */
+export function hasDataLinkSvcDesc(tableOrId) {
+    const table = getTableModel(tableOrId);
+    const serDefs  = getServiceDescriptors?.(table) ?? [];
+    return serDefs.some(isDataLinkServiceDesc);
 }
 
 


### PR DESCRIPTION
**Ticket**: [FIREFLY-1798](https://jira.ipac.caltech.edu/browse/FIREFLY-1798) 
- **[IFE PR](https://github.com/IPAC-SW/irsa-ife/pull/428)**
- The `Prepare Download` button wouldn't show up in our routed apps in some places (like TAP search, Catalogs, etc.) 
- So the first step was for routed apps to trigger the `ObsCore` watcher (which takes care of generating the download buttons) 
- Some improvements to our ObsCore Watcher logic 
   - Now recognize ObsCore like tables (tbls containing a datalink service descriptor), so that the download script/packager works button shows up for these tables as well
  - Let apps pass in `obsCoreDownloadProps` (such as `script` or `packager`), and pass those on to `PrepareDownload` now to generalize logic (this helps get rid of  `PrepareDownload` calls in `Euclid` and `Spherex`)

**Testing**: 
- [Euclid](https://firefly-1798-euc-cats-download-bug.irsakudev.ipac.caltech.edu/applications/euclid): 
  - Do an `Image` and `Inspect Objects` search, the results should have the `Generate Download Script` button. Try downloading some data. 
  - Do a Euclid Catalogs search, if it has cutouts, you should see a `Prepare Download` button
  - Do a TAP search (try CADC -> ivoa obscore table -> m81), you should see a `Prepare Download` button
- [Spherex](https://firefly-1798-euc-cats-download-bug.irsakudev.ipac.caltech.edu/applications/spherex)
  - Repeat the TAP search here as well
  - Do an LVF search to ensure you see the download script button and it works like before 
- [Firefly](https://fireflydev.ipac.caltech.edu/firefly-1798-euc-cats-download-bug/firefly) and [DCE](https://firefly-1798-euc-cats-download-bug.irsakudev.ipac.caltech.edu/irsaviewer/dce): Do a CADC search on firefly, and do any search on DCE. Ensure you see the `Prepare Download` button like before (just regression testing) 