### PR TITLE
FIREFLY-1803: Fix cutout size, ra, dec not updating in download script

### DIFF
--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -1,5 +1,5 @@
 import React, {useEffect, useMemo, useState} from 'react';
-import {cloneDeep, isEmpty, once} from 'lodash';
+import {cloneDeep, once} from 'lodash';
 import {dispatchAddTableTypeWatcherDef} from '../../core/MasterSaga.js';
 import {MetaConst} from '../../data/MetaConst';
 import {dispatchTableUiUpdate, TABLE_LOADED} from '../../tables/TablesCntlr.js';
@@ -11,11 +11,10 @@ import {findTableCenterColumns, hasDataLinkSvcDesc, hasObsCoreLikeDataProducts, 
 } from '../../voAnalyzer/TableAnalysis.js';
 import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
-import {getActiveRowToImageDef } from '../../visualize/saga/ActiveRowToImageWatcher.js';
+import {getActiveRowToImageDef} from '../../visualize/saga/ActiveRowToImageWatcher.js';
 import {getMocWatcherDef} from '../../visualize/saga/MOCWatcher.js';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent';
-import {findCutoutTarget, getCutoutSize, ROW_POSITION, tblIdToKey,
-} from 'firefly/ui/tap/Cutout';
+import {findCutoutTarget, getCutoutSize, ROW_POSITION, tblIdToKey,} from 'firefly/ui/tap/Cutout';
 import {getTableModel} from 'firefly/voAnalyzer/VoCoreUtils';
 import {fetchSemanticList} from 'firefly/metaConvert/vo/DatalinkFetch';
 import {checkForDatalinkServDesc} from 'firefly/ui/dynamic/ServiceDefTools';
@@ -183,12 +182,14 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
         centerColValues: { ra, dec }
     };
 
+    const keysToWatch = cutoutValue + '|' + position.centerColValues.ra + '|' + position.centerColValues.dec;
+
     return (
         <>
             {loading && <ToolbarButton enabled={false} variant={'soft'} color='warning' text={downloadType === 'script' ? 'Generate Download Script' : 'Prepare Download'}/>}
             {!loading &&
                 <Stack>
-                    <DownloadButton
+                    <DownloadButton key={keysToWatch}
                         buttonText = {downloadType === 'script' ? 'Generate Download Script' : 'Prepare Download'}>
                         <DownloadOptionPanel {...{
                             updateSearchRequest,

--- a/src/firefly/js/ui/CutoutSizeDialog.jsx
+++ b/src/firefly/js/ui/CutoutSizeDialog.jsx
@@ -315,12 +315,7 @@ function OptionalTarget({cutoutCenterWP,sx}) {
     useEffect(() => {
         const newWp= getEnteredTarget();
         if (newWp?.then) return; // ignore promises
-        if (!newWp || newWp?.toString()===cutoutCenterWP?.toString()) {
-            setOverrideTarget(undefined);
-        }
-        else {
-            setOverrideTarget(newWp);
-        }
+        setOverrideTarget(newWp);
     }, [getEnteredTarget]);
 
     const header= (


### PR DESCRIPTION
**Ticket**: [Firefly-1803](https://jira.ipac.caltech.edu/browse/FIREFLY-1803)
- While on the same row (or rows), after you update cutout size or cutout center and attempt to `Generate Download Script`, you would see stale cutout size / cutout center (ra,dec) values in the download script
   -  this is now fixed
- A related bug: 
  - if you select `Entered Position`, manually enter a position and run the download script, you'll see the `Entered Position` in the download script. But if you open the cutout dialog again (even without changing any values, or just update the cutout size, leaving the search target in the `Entered Position`, and run the download script, the center values will flip back to `Table Row Position`. And if you open the cutout dialog again, the values will flip back to the `Entered Position` and so on. This is due to a condition in the `useEffect` in `OptionalTarget` that would set `setOverrideTarget` to `undefined` when `newWp = cutoutCenterWP`, removing this check fixes the bug, without affecting anything else (far as I could tell) 

**Testing**: 
**Euclid**: https://firefly-1803-cutout-update-bug.irsakudev.ipac.caltech.edu/applications/euclid
- do an image/object search
- select 1 or more rows, and click the `Generate Download Script` with only cutouts. Notice the ra/dec/cutout size in the downloaded URLs
- now with the same row(s) selected, change the cutout size or cutout center (or both) via the cutout dialog. Download the script again via `Generate Download Script` for cutouts. You should see the updated cutout size / center values in the downloaded script now. 
- Try changing the cutout size and the center value (select all 3 options at least once) while on the same row(s) selection and download cutouts to ensure you see your selected values in the script. 