### PR TITLE
FIREFLY-1804: Fix job monitor to search results bug

### DIFF
--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -52,16 +52,13 @@ function isObsCoreish(tableOrId) {
     return hasObsCoreLikeDataProducts(tableOrId) || hasDataLinkSvcDesc(tableOrId);
 }
 
-const addedTblIds=[];
-
 function watchForObsCoreTable(tbl_id, action, cancelSelf) {
     if (action) return;
-    if (addedTblIds.includes(tbl_id)) return;
+    const {leftButtons=[]} = getTableUiByTblId(tbl_id);
+    if (leftButtons.some((lb) => lb.prepareDownloadBtn)) return;
     setupObsCorePackaging(tbl_id);
-    addedTblIds.push(tbl_id);
     cancelSelf();
 }
-
 
 function setupObsCorePackaging(tbl_id) {
     const table= getTblById(tbl_id);
@@ -80,7 +77,9 @@ function setupObsCorePackaging(tbl_id) {
     const dlProps = getDataServiceOptionByTable('obsCoreDownloadProps', table, {}) || {};
 
     const {tbl_ui_id, leftButtons=[]}= getTableUiByTblId(tbl_id) ?? {} ;
-    leftButtons.unshift(() => <PrepareDownload {...dlProps} />);
+    const prepareDownloadFunc = () => <PrepareDownload {...dlProps} />;
+    prepareDownloadFunc.prepareDownloadBtn = true;
+    leftButtons.unshift(prepareDownloadFunc);
     dispatchTableUiUpdate({ tbl_ui_id, leftButtons});
 }
 


### PR DESCRIPTION
**Ticket**: [FIREFLY-1804](https://jira.ipac.caltech.edu/browse/FIREFLY-1804)
- There's a serious bug where if a table (obs core or obs core like) contains a `Prepare Download` or `Generate Download Script` button, and you re-add this table (either after removing it or even if it's still in the results view) from the job monitor, the download button is not present anymore
  - the reason is that the global variable we use `const addedTblIds=[];` to keep track of added tables never gets rid of the table ids when you remove/re-add the tables, so `setupObsCorePackaging` is not called again for these tables
  - I switched to using `WeakSet`, which apparently does automatic garbage collection as well so we don't have to worry about cleaning up tbl ids 
  - `WeakSet` only stores objects. Technically, we can run into the same problem since we check for tableModel already exists in the WeakSet, but we always get back different objects in memory (even if they're deeply the same objects) when we call `getTableModel(tbl_id)`, so this should work. 
    - but I do worry that `initializedTbls.has(tableModel)` will always be false in this case? So maybe that check and WeakSet is unnecessary, and as long as a tblModel exists, we can just call `setupObsCorePackaging` for this tbl. 


**Testing**: 
- [Firefly](https://fireflydev.ipac.caltech.edu/firefly-1804-download-button-missing/firefly), [DCE](https://firefly-1804-download-button-missing.irsakudev.ipac.caltech.edu/irsaviewer/dce), [Euclid](https://firefly-1804-download-button-missing.irsakudev.ipac.caltech.edu/applications/euclid), [Spherex](https://firefly-1804-download-button-missing.irsakudev.ipac.caltech.edu/applications/spherex) 
- Do at least one search resulting in Prepare Download or Generate Download Script button in the results (CADC and IVOA ObsCore on firefly, I think any searches on DCE and Euclid, and image search on Spherex) 
   - you don't need to send the search to job monitor 
- Either remove some of the tables or leave them as is, but now go to Job Monitor and re-add all tables. Ensure you see the `Prepare Download` or `Generate Download Script` button.  
