### PR TITLE
Add a listbox slotProp in ListBoxInputFieldView to fix dropdown alignment

### DIFF
--- a/src/firefly/js/ui/ListBoxInputField.jsx
+++ b/src/firefly/js/ui/ListBoxInputField.jsx
@@ -32,7 +32,9 @@ export function ListBoxInputFieldView({value:fieldValue='', onChange, fieldKey, 
                 <Tooltip {...{title:tooltip, placement:'top', ...slotProps?.tooltip}}>
                     <Select {...{name: fieldKey, multiple, onChange, placeholder, renderValue, startDecorator,
                         disabled: readonly, size, value: multiple ? vAry : fieldValue,
-                        ...slotProps?.input}}>
+                        slotProps: {...slotProps?.input,
+                                listbox: {...(slotProps?.listbox ?? {}),}}
+                    }}>
                         {options?.map((({value,label,disabled=false},idx) => {
                             return (
                                 <Option {...{value, key:`k${idx}`, label:forceLabelToValue?value:label, disabled}}>


### PR DESCRIPTION
**Ticket**: [IRSA-6934](https://jira.ipac.caltech.edu/browse/IRSA-6934)
- [IFE PR](https://github.com/IPAC-SW/irsa-ife/pull/430)
- Allow `ListBoxInputFieldView` to set a `listbox` property 
- Previously, for longer text entries in `ListBoxInputFieldView` (like when called via `IbeSearchType` for Euclid/Wise), the drop downdown would open to the left like this:  
<img width="540" height="268" alt="Screenshot 2025-08-05 at 4 39 49 PM" src="https://github.com/user-attachments/assets/787bf321-0fe2-4a27-a026-ddb5da1ff3ac" />

- Setting the `placement` of `listbox` to `bottom-start` fixes this (per JoyUI docs) 
- I skipped implementing the 2nd part of the ticket, as I think to achieve same height for the EmbeddedPositionSearchPanel (by setting a min height), stretches out the  panel for the `Images` tab in Euclid with the default `Image contains target `(which has fewer elements than when you select any of the other `Region Intersection` options, making it look awkward)  
  - But I'm open to suggestions here. 


**Testing** 
- [Euclid](https://irsa-6934-euclid-cleanup.irsakudev.ipac.caltech.edu/applications/euclid) & [Wise](https://irsa-6934-euclid-cleanup.irsakudev.ipac.caltech.edu/applications/wise) 
- For Euclid, open the dropdown for `Search Type (Region Intersection)` in the **Images** tab, it should be aligned with the input now (same line as opposed to a little to the left) 
- For Wise, also open the dropdown for `Search Type (Region Intersection)` and notice the corrected alignment 