### PR TITLE
FIREFLY-1811: ZipHandler fix to better handle GZIP 

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/ZipHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/ZipHandler.java
@@ -4,18 +4,13 @@
 package edu.caltech.ipac.firefly.server.packagedata;
 
 import edu.caltech.ipac.firefly.data.FileInfo;
-import edu.caltech.ipac.util.StringUtils;
-import edu.caltech.ipac.util.download.URLDownload;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.FileUtil;
+import edu.caltech.ipac.util.StringUtils;
+import edu.caltech.ipac.util.download.URLDownload;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -79,22 +74,24 @@ public class ZipHandler {
             filename = FileUtil.getUniqueFileNameForGroup(fi.getExternalName(), dupMap);
 
             int inBufSize = 4096;
-            if (filename != null && FileUtil.isExtension(filename, FileUtil.GZ)) {
-                InputStream decompressedIs = null;
-                try {// try to uncompress the data
-                    decompressedIs = new GZIPInputStream(is);  // for uncompressed data, throw an exception
-                    bis = new BufferedInputStream(decompressedIs);
-                } catch (Exception e) {
-                    FileUtil.silentClose(decompressedIs);
-                    bis = new BufferedInputStream(is, inBufSize);
+
+            BufferedInputStream peek = new BufferedInputStream(is, inBufSize);
+
+            boolean looksGzip = FileUtil.isGZipFile(peek) || FileUtil.isExtension(filename, FileUtil.GZ);
+
+            InputStream processedIS = peek;
+            if (looksGzip) {
+                try {
+                    processedIS = new GZIPInputStream(peek);
+                    if (FileUtil.isExtension(filename, FileUtil.GZ)) {
+                        filename = filename.substring(0, filename.length() - 3);
+                    }
+                } catch (IOException e) {
+                    processedIS = peek;
                 }
-            } else {
-                bis = new BufferedInputStream(is, inBufSize);
             }
-            // remove .gz, if exists - filename or url stream are all going to be uncompressed at this point
-            if (FileUtil.isExtension(filename, FileUtil.GZ)) {
-                filename = filename.substring(0, filename.length() - 3);
-            }
+
+            bis = new BufferedInputStream(processedIS, inBufSize);
 
             zipEntry = new ZipEntry(filename);
             zipEntry.setComment(zipEntryComment);

--- a/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
@@ -461,24 +461,35 @@ public class FileUtil
     }
 
 
+    public static boolean isGZipFile(InputStream is) {
+        if (!is.markSupported()) {
+            //to ensure mark and reset works
+            is = new BufferedInputStream(is);
+        }
+        try {
+            is.mark(2);
+            int b0 = is.read();
+            int b1 = is.read();
+            is.reset();
+
+            if (b0 == -1 || b1 == -1) {
+                return false; // too short
+            }
+            int value = (b1 << 8) | b0;
+            return (value == GZIPInputStream.GZIP_MAGIC); //0x8b1f
+        } catch (IOException e) {
+            return false;
+        }
+    }
 
     public static boolean isGZipFile(File f) {
-        boolean retval;
-        DataInputStream in=null;
-        try {
-            in=new DataInputStream( new FileInputStream(f));
-            int b0 = in.read();
-            int b1 = in.read();
-            if (b0 == -1 || b1==-1) throw new EOFException();
-            int value=  (b1 << 8) | b0;
-            retval= (value == GZIPInputStream.GZIP_MAGIC);
+        try (InputStream in = new BufferedInputStream(new FileInputStream(f))) {
+            return isGZipFile(in);
         } catch (IOException e) {
-            retval= false;
-        } finally {
-            FileUtil.silentClose(in);
+            return false;
         }
-        return retval;
     }
+
 
     /**
      * Write a file to an output stream


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1811
- Added some more logic to directly check the bytes for indicating gzip (works even if we have URL instead of a file directly) as `FileUtil.isGZipFile()` didn't work even after creating a tmp file from the URL. 
  - I can try `FileUtil.isGZipFile()` if you have some suggestions. But I still think this might be a little better as it'll work for both URLs and files, and directly tests the bytes for gzip. 

**Testing**: 
**Spherex**: https://firefly-1811-packager-gzip-fix.irsakudev.ipac.caltech.edu/applications/spherex
- Do a Spectophotometry Search: `21h24m24.39s +33d39m07.6s Equ J2000` should only take 3-5 minutes. 
  - download the 1 row generated. Unzip the packaged download. Inside, you should get a good filename and extension (.xml) and the file should just open up (won't be zipped). 
- Test [Firefly](https://fireflydev.ipac.caltech.edu/firefly-1811-packager-gzip-fix/firefly) (CADC) and [Euclid](https://firefly-1811-packager-gzip-fix.irsakudev.ipac.caltech.edu/applications/euclid) (Catalogs with `Prepare Download`) to ensure the changes in ZipHandler didn't break any existing behavior 