### PR TITLE
FIREFLY-1812 & FIREFLY-1813: Improve Result File Retention and UWS Job Recovery

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -334,11 +334,10 @@ public class JobManager {
             );
 
 
-            List<JobInfo> subList = allJobs.subList(0, 100);
             sb.append("\n (ONLY THE LATEST 100 JOBS ARE SHOWN BELOW) \n");
             sb.append("JOB ID               LOCAL JOB ID         PHASE       creationTime           elapsedTime(s) progress monitored userKy                               \n");
             sb.append("-------------------- -------------------- ----------- ---------------------- -------------- -------- --------- -------------------------------------\n");
-            subList.forEach((ji) -> {
+            allJobs.stream().limit(100).forEach((ji) -> {
                 Instant endT = ji.getEndTime();
                 Instant startT = ji.getStartTime();
                 sb.append(String.format("%-20s %-20s %-11s %-22s %,14d %8d %9s %-37s\n",

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/BaseGator.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/catquery/BaseGator.java
@@ -35,9 +35,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.List;
 
-import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
-import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
-
 
 /**
  * Date: Jun 5, 2009
@@ -111,7 +108,7 @@ public abstract class BaseGator extends EmbeddedDbProcessor {
             boolean isPost = isPost(req);
             URL url = createURL(req, isPost);
 
-            ifNotNull(getJob()).then( j -> updateJobInfo(j.getJobId(), ji -> ji.getAux().setJobUrl(url.toString())));
+            updateJob(ji -> ji.getAux().setJobUrl(url.toString()));
 
             if (isPost) {
                 _postBuilder = new MultiPartPostBuilder(url.toString());
@@ -140,6 +137,9 @@ public abstract class BaseGator extends EmbeddedDbProcessor {
             _log.error(e, e.toString());
             throw new DataAccessException("Catalog Query Failed", e);
         }
+
+        setJobResults(outFile);
+
         return outFile;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessor.java
@@ -63,8 +63,12 @@ public class MultiSpectrumProcessor extends EmbeddedDbProcessor {
     public DataGroup fetchDataGroup(TableServerRequest treq) throws DataAccessException {
         try {
             String source = treq.getParam(SOURCE);
+            updateJob(ji -> ji.getAux().setJobUrl(source));
+
             File inFile = QueryUtil.resolveFileFromSource(source, treq);
             DataGroup table = TableUtil.readAnyFormat(inFile);
+
+            setJobResults(inFile);
 
             return table;
         } catch (Exception e) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/QueryVOTABLE.java
@@ -23,7 +23,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
-import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
 import static edu.caltech.ipac.table.TableMeta.DESC_TAG;
 import static edu.caltech.ipac.table.TableMeta.makeAttribKey;
@@ -89,7 +88,7 @@ public abstract class QueryVOTABLE extends EmbeddedDbProcessor {
     private File getSearchResult(TableServerRequest req) throws IOException, DataAccessException, EndUserException {
         String urlQuery = getQueryString(req);
 
-        sendJobUpdate(ji -> ji.getAux().setJobUrl(urlQuery));
+        updateJob(ji -> ji.getAux().setJobUrl(urlQuery));
 
         URL url;
         try {
@@ -111,6 +110,9 @@ public abstract class QueryVOTABLE extends EmbeddedDbProcessor {
         } catch (Exception e) {
             throw new DataAccessException("query failed", e);
         }
+
+        setJobResults(outFile);
+
         return outFile;
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DaliQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DaliQuery.java
@@ -4,7 +4,6 @@
 package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.data.TableServerRequest;
-import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.network.HttpServices;
 import edu.caltech.ipac.table.DataGroup;
@@ -31,13 +30,18 @@ public class DaliQuery extends EmbeddedDbProcessor {
 
     public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
         var inputs = createInput(req);
+        updateJob(ji -> ji.getAux().setJobUrl(inputs.getRequestUrl()));
+
         try {
-            File outFile = File.createTempFile(req.getRequestId()+"-", ".vot", ServerContext.getTempWorkDir());
+            File outFile = createTempFile(req, ".vot");
             HttpServices.Status status = HttpServices.getWithAuth(inputs, HttpServices.defaultHandler(outFile));
             if (status.isError()) {
                 throw DaliUtil.createDax("Failed to retrieve the result from", inputs.getRequestUrl(), status.getException());
             }
             DataGroup[] results = VoTableReader.voToDataGroups(outFile.getAbsolutePath());
+
+            setJobResults(outFile);
+
             return results.length > 0 ? results[0] : null;
 
         } catch (Exception e) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -4,7 +4,9 @@
 package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.core.Util;
+import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.server.ServCommand;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.db.DuckDbReadable;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.table.TableUtil;
@@ -47,12 +49,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
 import static edu.caltech.ipac.firefly.data.table.MetaConst.HIGHLIGHTED_ROW;
 import static edu.caltech.ipac.firefly.data.table.MetaConst.HIGHLIGHTED_ROW_BY_ROWIDX;
+import static edu.caltech.ipac.firefly.server.ServerContext.convertToFile;
 import static edu.caltech.ipac.firefly.server.db.DbAdapter.*;
 import static edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil.*;
 import static edu.caltech.ipac.table.DataGroup.*;
 import static edu.caltech.ipac.util.StringUtils.*;
+import static edu.caltech.ipac.firefly.core.Util.Try;
 
 /**
  * NOTE: We're using spring jdbc v2.x.  API changes dramatically in later versions.
@@ -216,7 +222,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             StopWatch.getInstance().start("ingestDataIntoDb: " + req.getRequestId());
 
             // dataSupplier is passed in.  the adapter decides if fetch is needed.
-            FileInfo finfo = dbAdapter.ingestData(makeDgSupplier(req, () -> fetchDataGroup(req)), dbAdapter.getDataTable());
+            FileInfo finfo = dbAdapter.ingestData(makeDgSupplier(req, () -> getOrFetchDataGroup(req)), dbAdapter.getDataTable());
 
             StopWatch.getInstance().stop("ingestDataIntoDb: " + req.getRequestId()).printLog("ingestDataIntoDb: " + req.getRequestId());
             return finfo;
@@ -224,6 +230,34 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             logger.error(ex,"Failed to ingest data into the database:" + req.getRequestId());
             throw new DataAccessException(ex);
         }
+    }
+
+    /**
+     * This allows the processor to fetch data from a previously submitted job.
+     * @param req  the request to fetch data from
+     * @return the DataGroup containing the data
+     */
+    protected DataGroup getOrFetchDataGroup(TableServerRequest req) throws DataAccessException {
+        DataGroup retval = null;
+        if (!isEmpty(req.getJobId())) {
+            // a previously submitted job; try to get from cache
+            List<JobInfo.Result> results = ifNotNull(JobManager.getJobInfo(req.getJobId()))
+                                           .get(JobInfo::getResults);
+            if (results != null && !results.isEmpty()) {
+                String href = results.getFirst().href();
+                if (!isEmpty(href)) {
+                    File file = convertToFile(href);
+                    if (file.exists()) {        // if the result is a file cached on the server, use it.
+                        int tblIdx = req.getIntParam(TBL_INDEX, 0);
+                        retval = Try.it(() -> TableUtil.readAnyFormat(file, tblIdx, req)).get();  // ignore exception
+                    }
+                }
+            }
+        }
+        if (retval == null) {       // if not found in cache, fetch from source
+            retval = fetchDataGroup(req);
+        }
+        return retval;
     }
 
     protected DataGroupSupplier makeDgSupplier(TableServerRequest req, DataGroupSupplier getter) throws DataAccessException {
@@ -235,16 +269,14 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
 
             sendJobUpdate(v -> v.getMeta().setProgress(70, dg.size() + " rows of data found"));
 
-            makeExtraMetaSetter(req).accept(dg);
+            applyExtraMeta(dg, req);
             return dg;
         };
     }
 
-    protected Consumer<DataGroup> makeExtraMetaSetter(TableServerRequest req) {
-        return dg -> {
-            prepareTableMeta(dg.getTableMeta(), Arrays.asList(dg.getDataDefinitions()), req);
-            TableUtil.consumeColumnMeta(dg, null);      // META-INFO in the request should only be pass-along and not persist.
-        };
+    protected void applyExtraMeta(DataGroup dg, TableServerRequest req) {
+        prepareTableMeta(dg.getTableMeta(), Arrays.asList(dg.getDataDefinitions()), req);
+        TableUtil.consumeColumnMeta(dg, null);      // META-INFO in the request should only be pass-along and not persist.
     }
 
     public File getDataFile(TableServerRequest request) throws IpacTableException, IOException, DataAccessException {
@@ -502,6 +534,15 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         }
         selectInfo.setRowCount(rowCnt);
         return selectInfo;
+    }
+
+    protected void setJobResults(File... files) {
+        if (files == null || files.length == 0) return;
+        updateJob(ji -> {
+            Arrays.stream(files)
+                    .filter(f -> f != null && f.isFile() && f.canRead())
+                    .forEach(file -> ji.addResult(new JobInfo.Result("result", ServerContext.replaceWithPrefix(file), null, String.valueOf(file.length()))));
+        });
     }
 
     private static String retrieveMsgFromError(Exception e, TableServerRequest treq, DbAdapter dbAdapter) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -4,6 +4,7 @@
 package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.core.background.Job;
+import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.network.HttpServices;
@@ -92,7 +93,13 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
     public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
         // this worker is self-managed, so it needs to update job status
         try {
-            jobUrl = req.getParam(JOB_URL);
+            if (!isEmpty(req.getJobId())) {
+                // a previously submitted job
+                jobUrl = ifNotNull(JobManager.getJobInfo(req.getJobId()))
+                        .get(j -> j.getAux().getJobUrl());
+            } else {
+                jobUrl = req.getParam(JOB_URL);
+            }
             if (jobUrl == null) {
                 jobUrl = submitJob(req);
                 if (jobUrl != null) runJob(jobUrl);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/mos/QueryMOS.java
@@ -126,6 +126,7 @@ public class QueryMOS extends EmbeddedDbProcessor {
         URLConnection conn = null;
         try {
             _log.info("querying MOS:" + url);
+            updateJob(ji -> ji.getAux().setJobUrl(url.toString()));
 
             final Ref<File> catOverlayFile = new Ref<File>(null);
 
@@ -140,6 +141,9 @@ public class QueryMOS extends EmbeddedDbProcessor {
 
             DataGroup[] groups = VoTableReader.voToDataGroups(votable.getAbsolutePath(), headerOnly);
             if (groups != null) {
+
+//                setJobResults(votable);       // TODO: cannot save result because it needs custom logic to load DataGroup from saved file.
+
                 for (DataGroup dg : groups) {
                     if (dg.getTitle().equalsIgnoreCase(RESULT_TABLE_NAME) && catOverlayFile.get() != null) {
                             // save the generated file as ipac table headers

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -3,6 +3,8 @@
  */
 package edu.caltech.ipac.firefly.server.query.tables;
 
+import edu.caltech.ipac.firefly.core.background.JobInfo;
+import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.data.ServerRequest;
@@ -27,11 +29,13 @@ import edu.caltech.ipac.util.FormatUtil;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
 import static edu.caltech.ipac.firefly.data.table.MetaConst.CATALOG_OVERLAY_TYPE;
+import static edu.caltech.ipac.firefly.server.ServerContext.convertToFile;
 import static edu.caltech.ipac.firefly.server.query.tables.IpacTableFromSource.PROC_ID;
 import static edu.caltech.ipac.firefly.server.util.QueryUtil.SEARCH_REQUEST;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
@@ -77,18 +81,15 @@ public class IpacTableFromSource extends EmbeddedDbProcessor {
     }
 
     @Override
-    protected Consumer<DataGroup> makeExtraMetaSetter(TableServerRequest req) {
-        var sup = super.makeExtraMetaSetter(req);
-        return dg -> {
-            if (sup != null) sup.accept(dg);
-            if (!dg.getTableMeta().contains(CATALOG_OVERLAY_TYPE)) {                    // when CATALOG_OVERLAY_TYPE is not set, apply defaults
-                if (req.getParam(TBL_TYPE, TYPE_CATALOG).equals(TYPE_CATALOG)) {        // if catalog and overlay is not set, set it to "TRUE"
-                    if (isEmpty(req.getMeta(CATALOG_OVERLAY_TYPE))) {
-                        dg.getTableMeta().setAttribute(CATALOG_OVERLAY_TYPE, "TRUE");
-                    }
+    protected void applyExtraMeta(DataGroup dg, TableServerRequest req) {
+        super.applyExtraMeta(dg, req);
+        if (!dg.getTableMeta().contains(CATALOG_OVERLAY_TYPE)) {                    // when CATALOG_OVERLAY_TYPE is not set, apply defaults
+            if (req.getParam(TBL_TYPE, TYPE_CATALOG).equals(TYPE_CATALOG)) {        // if catalog and overlay is not set, set it to "TRUE"
+                if (isEmpty(req.getMeta(CATALOG_OVERLAY_TYPE))) {
+                    dg.getTableMeta().setAttribute(CATALOG_OVERLAY_TYPE, "TRUE");
                 }
             }
-        };
+        }
     }
 
     @Override
@@ -109,22 +110,48 @@ public class IpacTableFromSource extends EmbeddedDbProcessor {
             } else if (!isEmpty(jsonSearchRequest)) {
                 fetchDataGroup = () -> getByTableRequest(jsonSearchRequest);
             } else {
-                srcFile = fetchSourceFile(req);
+                srcFile = getOrFetchSourceFile(req);
             }
             if (srcFile == null) {
                 return DbDataIngestor.ingestData(req, dbAdapter, makeDgSupplier(req, fetchDataGroup));
             } else {
-                return DbDataIngestor.ingestData(req, dbAdapter, makeExtraMetaSetter(req), srcFile, tblIdx, format);
+                return DbDataIngestor.ingestData(req, dbAdapter, (dg) -> applyExtraMeta(dg, req), srcFile, tblIdx, format);
             }
         } catch (IOException e) {
             Logger.getLogger().error(e,"Failed to ingest data into the database:" + req.getRequestId());
             throw new DataAccessException(e);
         }
     }
+
+    /**
+     * This allows the processor to fetch data from a previously submitted job.
+     * @param req  the request to fetch data from
+     * @return the DataGroup containing the data
+     */
+    private File getOrFetchSourceFile(TableServerRequest req) throws DataAccessException {
+        File retval = null;
+        if (!isEmpty(req.getJobId())) {
+            // a previously submitted job; try to get from cache
+            List<JobInfo.Result> results = ifNotNull(JobManager.getJobInfo(req.getJobId()))
+                    .get(JobInfo::getResults);
+            if (results != null && !results.isEmpty()) {
+                String href = results.getFirst().href();
+                if (!isEmpty(href)) {
+                    retval = convertToFile(href);
+                }
+            }
+        }
+        if (retval == null || ! retval.canRead()) {       // if not found in cache, fetch from source
+            retval = fetchSourceFile(req);
+        }
+        return retval;
+    }
+
     private File fetchSourceFile (TableServerRequest req) throws DataAccessException {
 
         String source = req.getParam(ServerParams.SOURCE);
         String altSource = req.getParam(ServerParams.ALT_SOURCE);
+        updateJob(ji -> ji.getAux().setJobUrl(source));
 
         File inf = null;
         if (isWorkspace(req)) {
@@ -142,6 +169,9 @@ public class IpacTableFromSource extends EmbeddedDbProcessor {
         if (inf == null) {
             throw new DataAccessException(String.format("Unable to fetch file from path[alt_path]: %s[%s]", source, altSource));
         }
+
+        setJobResults(inf);
+
         return inf;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -264,10 +264,11 @@ public class ServerStatus extends BaseHttpServlet {
             </div>
             """, ServerContext.getRequestOwner().getBaseUrl(), driver);
 
-        writer.println("Idled   Age     Rows        Columns  Tables  Total Rows       Memory  JDBC URL     (elapsed time are in min:sec; memory is in MB)");
+        writer.println("Idled   Age     Rows        Columns  Tables  Total Rows       Memory  JDBC URL     (elapsed time are in min:sec; memory is in MB) (ONLY THE LATEST 100 JOBS ARE SHOWN BELOW)");
         writer.println("------  ------  ----------  -------  ------  ----------       ------  ---------");
         DbMonitor.getDbInstances().values().stream()
             .sorted((db1, db2) -> Long.compare(db2.getLastAccessed(), db1.getLastAccessed()))
+            .limit(100) // only show the latest 100
             .forEach((db) -> writer.printf("%7$tM:%7$tS   %8$tM:%8$tS   %,10d  %7d  %6d  %,10d  %11.1f  %s\n",
                 db.getDbStats().rowCnt(),
                 db.getDbStats().colCnt(),


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1812
https://jira.ipac.caltech.edu/browse/FIREFLY-1813

See also: https://github.com/IPAC-SW/irsa-ife/pull/432

This PR addresses two related issues with result file handling and UWS job recovery after DB file cleanup.
FIREFLY-1812: Result file removed prematurely
- Save result files to the staging directory to ensure a longer expiration time.
- Add the file location to the Job’s results so it is stored in JobInfo.
- When the DB file is purged, recreate it from the saved result file.

FIREFLY-1813: UWS job should reload results from its source when the DB file is purged
- Update UWS job logic to reload results from the original data source if the DB file has been deleted.

Tests:
https://firefly-1812-1813-load-job-results.irsakudev.ipac.caltech.edu/irsaviewer/
https://firefly-1812-1813-load-job-results.irsakudev.ipac.caltech.edu/applications/sofia/
https://firefly-1812-1813-load-job-results.irsakudev.ipac.caltech.edu/applications/euclid/
https://firefly-1812-1813-load-job-results.irsakudev.ipac.caltech.edu/applications/spherex/

- Use provided test links to ensure all functionality still works as expected.
- For deeper testing of the cleanup/recovery logic:
  - Build and run the app locally.
  - Perform a search to generate result files.
  - Remove files from the temp directory 
    - The job should reload from either the stage directory or the UWS service. This should be relatively fast.
  - Remove files from both the temp and stage directories
    - UWS jobs should still reload results quickly, while non-UWS jobs will need to re-run the search.
