### PR TITLE
Firefly-1815: upload a file via an action, usually firefly_client

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
@@ -63,12 +63,14 @@ public class AnyFileUpload extends BaseHttpServlet {
     private static final String WORKSPACE_PUT = "workspacePut";
     private static final String WS_CMD = "wsCmd";
     public  static final String ANALYZER_ID = "analyzerId";
+    public  static final String NAME = "name";
     /** use the hips cache hierarchy */
     public  static final String HIPS_CACHE = "hipsCache";
     /** load from a URL */
     private static final String URL = "URL";
     /** load from a WebPlotRequest */
     private static final String WEB_PLOT_REQUEST = "webPlotRequest";
+    private static final String FILE_ON_SERVER = "fileOnServer";
     /** run file analysis and return an analysis json object */
     private static final String FILE_ANALYSIS= "fileAnalysis";
 
@@ -116,7 +118,7 @@ public class AnyFileUpload extends BaseHttpServlet {
             int responseCode= statusFileInfo.getResponseCode();
 
             if (responseCode>=400) {
-                res.sendError(statusFileInfo.getResponseCode(), statusFileInfo.getResponseCodeMsg());
+                res.sendError(responseCode, statusFileInfo.getResponseCodeMsg());
                 return;
             }
 
@@ -144,7 +146,6 @@ public class AnyFileUpload extends BaseHttpServlet {
 
             // returns the fileCacheKey or full analysis json
             String returnVal= analyzeFile ? callAnalysis(sp,statusFileInfo,uploadFileInfo,fileCacheKey) : fileCacheKey;
-            if (responseCode>=400) throw new Exception(codeFailMsg(responseCode));
 
             sendReturnMsg(res, 200, null, returnVal);
             Counters.getInstance().increment(Counters.Category.Upload, uploadFileInfo.getContentType());
@@ -175,7 +176,7 @@ public class AnyFileUpload extends BaseHttpServlet {
     private static UploadFileInfo makeUploadFileInfo(FileInfo statusFileInfo, String fname) {
         File file= statusFileInfo.getFile();
         return new UploadFileInfo(ServerContext.replaceWithPrefix(file), file, fname!=null ? fname : file.getName(),
-                statusFileInfo.getContentType());
+                statusFileInfo.getContentType(), statusFileInfo.getResponseCode());
     }
 
     private static void updateFeedback(String statusKey, long totalRead) {
@@ -225,6 +226,7 @@ public class AnyFileUpload extends BaseHttpServlet {
         String wsCmd = sp.getOptional(WS_CMD);
         String fromUrl = sp.getOptional(URL);
         WebPlotRequest fromWPR= sp.getOptionalWebPlotRequest(WEB_PLOT_REQUEST);
+        String fileOnServer= sp.getOptional(FILE_ON_SERVER);
         boolean hipsCache = sp.getOptionalBoolean(HIPS_CACHE,false);
 
         UploadFileInfo uploadFileInfo;
@@ -254,6 +256,14 @@ public class AnyFileUpload extends BaseHttpServlet {
             if (retrieve==null) throw new Exception("Could not determine how to retrieve file");
             statusFileInfo = retrieve.getFile(fromWPR,false);
             uploadFileInfo= makeUploadFileInfo(statusFileInfo,null);
+        } else if (fileOnServer != null) {
+            File f= ServerContext.convertToFile(fileOnServer);
+            if (!f.canRead()) {
+                return new Result(new FileInfo(404),null);
+            }
+            String name= sp.getOptional(NAME,f.getName());
+            uploadFileInfo= new UploadFileInfo(fileOnServer, f,name,null);
+            statusFileInfo= new FileInfo(uploadFileInfo.getFile());
         } else if (uploadedItem != null) {
             // it's a stream from multipart.. write it to disk
             String name = uploadedItem.getName();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/multipart/UploadFileInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/multipart/UploadFileInfo.java
@@ -3,6 +3,8 @@
  */
 package edu.caltech.ipac.firefly.server.util.multipart;
 
+import edu.caltech.ipac.firefly.data.FileInfo;
+
 import java.io.File;
 import java.io.Serializable;
 
@@ -17,13 +19,27 @@ public class UploadFileInfo implements Serializable {
     private File file;
     private String fileName;
     private String contentType;
+    private int responseCode;
     private long size;
+    private transient FileInfo fileInfo;
+
+    public UploadFileInfo(String pname, File file, String fileName, String contentType, int responseCode) {
+        this.pname = pname;
+        this.file = file;
+        this.fileName = fileName;
+        this.contentType = contentType;
+        this.responseCode = responseCode;
+        if (file != null && file.exists()) {
+            size = file.length();
+        }
+    }
 
     public UploadFileInfo(String pname, File file, String fileName, String contentType) {
         this.pname = pname;
         this.file = file;
         this.fileName = fileName;
         this.contentType = contentType;
+        this.responseCode = 200;
         if (file != null && file.exists()) {
             size = file.length();
         }
@@ -52,6 +68,8 @@ public class UploadFileInfo implements Serializable {
     public void setFileName(String fileName) {
         this.fileName = fileName;
     }
+
+    public int getResponseCode() {return responseCode;}
 
     @Override
     public String toString() {

--- a/src/firefly/js/api/webApiCommands/AnyFileLoadCommands.js
+++ b/src/firefly/js/api/webApiCommands/AnyFileLoadCommands.js
@@ -1,0 +1,56 @@
+import {makeExamples} from 'firefly/api/WebApi';
+import {EXTERNAL_UPLOAD} from '../../core/AppDataCntlr';
+import {flux} from '../../core/ReduxFlux';
+
+
+const anyFileOverview= {
+    overview: [
+        'Load any file the Firefly can recognize'
+    ],
+    allowAdditionalParameters: false,
+    parameters: {
+        execute: 'true or false - if true, fully load the file',
+        url : 'URL to the file',
+        displayName : 'name to show as this file',
+    }
+};
+
+const anyFileExample= [
+    {
+        desc:'Load a image file',
+        params:{ url : 'http://web.ipac.caltech.edu/staff/roby/data-products-test/1904-66_SFL.fits' }
+    },
+    {
+        desc:'Load a table file',
+        params:{ url : 'https://web.ipac.caltech.edu/staff/roby/demo/WiseDemoTable.tbl' }
+    },
+    {
+        desc:'Load a table file',
+        params:{ url : 'https://web.ipac.caltech.edu/staff/roby/demo/fp_2mass.fp_psc29179.tbl' }
+    },
+    {
+        desc:'Same as a above, specify and load immediately',
+        params:{ url : 'https://web.ipac.caltech.edu/staff/roby/demo/fp_2mass.fp_psc29179.tbl', execute:true }
+    },
+];
+
+function enableFileLoad(cmd,inParams) {
+
+    const params= {...inParams};
+    setTimeout(() => {
+        const {url, execute=false}= params;
+        flux.process({type:EXTERNAL_UPLOAD, payload:{url, displayName:'some name', immediate:execute}});
+    },10);
+}
+
+export function getAnyFileLoadCommands() {
+    return [
+        {
+            cmd: 'load',
+            validate: () => ({valid:true}),
+            execute: enableFileLoad,
+            ...anyFileOverview,
+            examples: makeExamples('load', anyFileExample),
+        },
+    ];
+}

--- a/src/firefly/js/api/webApiCommands/ImageCommands.js
+++ b/src/firefly/js/api/webApiCommands/ImageCommands.js
@@ -21,7 +21,7 @@ const imageOverview= {
     ],
     allowAdditionalParameters: true,
     parameters: {
-        url : 'URL of the FITS image',
+        url : 'URL to the FITS image',
         title : 'title to show',
         service : 'one of IRIS, ISSA, DSS, SDSS, TWOMASS, MSX-ATLAS, WISE, ATLAS,ZTF, PTF',
         SurveyKey : [

--- a/src/firefly/js/api/webApiCommands/ViewerWebApiCommands.js
+++ b/src/firefly/js/api/webApiCommands/ViewerWebApiCommands.js
@@ -1,4 +1,5 @@
 import {isEmpty} from 'lodash';
+import {getAnyFileLoadCommands} from './AnyFileLoadCommands';
 import {getImageCommands} from './ImageCommands';
 import {getLsdbCommands} from './LsdbCommands';
 import {getTabCommands} from './TabCommands';
@@ -16,7 +17,8 @@ export function getFireflyViewerWebApiCommands(cmdNameList, tapPanelList=[]) {
         ...getImageCommands(),
         ...getTableCommands(),
         ...getTapCommands(tapPanelList),
-        ...getLsdbCommands()
+        ...getLsdbCommands(),
+        ...getAnyFileLoadCommands()
     ];
 
     if (isEmpty(cmdNameList)) return allCommands;

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -37,6 +37,7 @@ export const LOAD_SEARCHES = `${APP_DATA_PATH}.loadSearches`;
 export const NOTIFY_REMOTE_APP_READY = `${APP_DATA_PATH}.notifyRemoteAppReady`;
 export const FORM_SUBMIT = `${APP_DATA_PATH}.formSubmit`;
 export const FORM_CANCEL = `${APP_DATA_PATH}.formCancel`;
+export const EXTERNAL_UPLOAD = `${APP_DATA_PATH}.externalUpload`;
 
 /** fired when there's a connection is added/removed from this channel.  useful for tracking connections in channel, etc   */
 export const WS_CONN_UPDATED = `${APP_DATA_PATH}.wsConnUpdated`;
@@ -46,7 +47,7 @@ export const GRAB_WINDOW_FOCUS = `${APP_DATA_PATH}.grabFocus`;
 
 /** the extension to add to a channel string to make a viewer channel */
 const CHANNEL_VIEWER_EXTENSION = '__viewer';
-const channel_matcher = new RegExp(`(.+)${CHANNEL_VIEWER_EXTENSION}(?:-(.+))?`)
+const channel_matcher = new RegExp(`(.+)${CHANNEL_VIEWER_EXTENSION}(?:-(.+))?`);
 
 /** @type {SearchInfo} */
 const searchInfo = {};
@@ -209,6 +210,7 @@ export function dispatchFormCancel(payload) {
 /**
  * Given a channel string return a version of the will be the channel for a viewer
  * @param {String} channel
+ * @param {String} file
  * @return {string}
  */
 export function makeViewerChannel(channel, file) {

--- a/src/firefly/js/core/BootstrapRegistry.js
+++ b/src/firefly/js/core/BootstrapRegistry.js
@@ -55,6 +55,7 @@ import ImageLineBasedFootprint from '../drawingLayers/ImageLineBasedFootprint.js
 import {dispatchAddSaga, masterSaga} from './MasterSaga.js';
 import {watchReadout} from '../visualize/saga/MouseReadoutWatch.js';
 import {addExtensionWatcher} from './messaging/ExternalAccessWatcher.js';
+import {initHandleExternalUpload} from '../ui/FileUploadProcessor';
 
 
 const USE_LOGGING_MIDDLEWARE= false; // logging middleware is useful for debugging but we don't use if much
@@ -132,6 +133,7 @@ export const getBootstrapRegistry= once(() => {
         sagaMiddleware.run(masterSaga);
         dispatchAddSaga( watchReadout);
         addExtensionWatcher();
+        initHandleExternalUpload();
     };
 
     const registerCntlr= (cntlr = {}) => {

--- a/src/firefly/js/rpc/CoreServices.js
+++ b/src/firefly/js/rpc/CoreServices.js
@@ -3,7 +3,7 @@
  */
 
 
-import {isString} from 'lodash';
+import {isEmpty, isString} from 'lodash';
 import {ServerParams} from '../data/ServerParams.js';
 import {doJsonRequest} from '../core/JsonUtils.js';
 import {WebPlotRequest} from '../visualize/WebPlotRequest';
@@ -52,7 +52,7 @@ export function getTextFile(url,maxSize) {
  * @return {Promise}
  */
 export async function upload(item, fileAnalysis= false, params={}) {
-    const fetchParam= item && buildUploadParam(item);
+    const fetchParam= (item || !isEmpty(params)) && buildUploadParam(item, params);
     if (!fetchParam) {
         const msg= item ? 'Did not recognize item to upload: must be URL (String), File, Blob, or WebPlotRequest' :
                           'item parameter not given';
@@ -66,11 +66,17 @@ export async function upload(item, fileAnalysis= false, params={}) {
 /**
  * return the correct upload parameter based on the type that is passed
  * @param {WebPlotRequest|Blob|File|String} item - the parameter to evaluate
+ * @param {Object} [params] - this will override the analysis of item
  * @return {Object|undefined} an object with the correct parameter to pass to the upload,
  * or undefined if it is not the correct parameter type
  */
-function buildUploadParam(item) {
-    if (isString(item)) return {URL: item};
+function buildUploadParam(item, params={}) {
+    const overrideKeys= ['URL', 'fileOnServer', 'file', 'webPlotRequest'];
+    const overrideUploadParamKey= Object.keys(params).find( (k) => overrideKeys.includes(k));
+    if (overrideUploadParamKey) return {[overrideUploadParamKey]:params[overrideUploadParamKey]};
+    if (isString(item)) {
+       return (item.startsWith('${') || item.startsWith('/')) ? {fileOnServer:item} : {URL: item};
+    }
     else if (WebPlotRequest.isWPR(item)) return {webPlotRequest: item.toString()};
     else if (item instanceof Blob)  return {file:item}; // handles blob or file
 }

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -158,10 +158,13 @@ function doUrlAnalysis(value, fireValueChange, type, fileAnalysis) {
 
 function handleChange(ev, fireValueChange, type, fileAnalysis) {
     let file = ev?.target?.files?.[0];
-    let displayValue = ev?.target?.value;
-    if (ev.type === 'drop') { //drag drop files - instead of picking file from 'Choose File'
-        file = Array.from(ev.dataTransfer.files)[0];
-        displayValue = file?.name;
+    let displayValue;
+    if (ev) {
+        displayValue = ev.target?.value;
+        if (ev.type === 'drop') { //drag drop files - instead of picking file from 'Choose File'
+            file = Array.from(ev.dataTransfer.files)[0];
+            displayValue = ev.transferIsUrl ?  ev?.dataTransfer?.files?.[0] : file?.name;
+        }
     }
     fireValueChange({
         displayValue,

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -2,38 +2,29 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {Box, Skeleton} from '@mui/joy';
 import React, {useState} from 'react';
-import {FormPanel} from './FormPanel.jsx';
-import {FileUploadViewPanel, resultFail} from '../visualize/ui/FileUploadViewPanel.jsx';
+import {Box, Skeleton} from '@mui/joy';
 import {getAppOptions} from 'firefly/api/ApiUtil.js';
-import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr.js';
-import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
-import {resultSuccess} from 'firefly/ui/FileUploadProcessor';
+import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
 import {FieldGroup} from 'firefly/ui/FieldGroup';
-import {DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES, TABLES, UWS} from 'firefly/ui/FileUploadUtil';
+import {defaultAcceptList, resultSuccess} from 'firefly/ui/FileUploadProcessor';
+import {TABLES} from 'firefly/ui/FileUploadUtil';
+import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
+import {FileUploadViewPanel, resultFail} from '../visualize/ui/FileUploadViewPanel.jsx';
+import {FormPanel} from './FormPanel.jsx';
 
 const panelKey = 'FileUploadAnalysis';
-
-const defaultAcceptList = [
-    TABLES,
-    REGIONS,
-    DATA_LINK_TABLES,
-    SPECTRUM_TABLES,
-    MOC_TABLES,
-    IMAGES,
-    UWS
-];
-
-const tableOnlyDefaultAcceptList = [
-    TABLES
-];
+const tableOnlyDefaultAcceptList = [ TABLES ];
 
 export const FileUploadDropdown= ({sx, onCancel, onSubmit=resultSuccess, keepState=true,
                                       initArgs,
-                                      groupKey=panelKey, acceptList= getAppOptions()?.uploadPanelLimit==='tablesOnly'?
-        tableOnlyDefaultAcceptList: defaultAcceptList, acceptOneItem=false}) =>{
+                                      groupKey=panelKey,
+                                      acceptOneItem=false,
+                                      acceptList= getAppOptions()?.uploadPanelLimit==='tablesOnly'
+                                          ? tableOnlyDefaultAcceptList
+                                          : defaultAcceptList,
+                                      }) =>{
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
     const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
@@ -56,7 +47,7 @@ export const FileUploadDropdown= ({sx, onCancel, onSubmit=resultSuccess, keepSta
                     }}>
 
                     <FileUploadViewPanel {...{setSubmitText, acceptList, acceptOneItem,
-                        externalDropEvent:initArgs?.searchParams?.dropEvent}}/>
+                        externalDropEvent:initArgs?.searchParams?.dropEvent, initArgs}}/>
                 </FormPanel>
             </FieldGroup>
             { doMask && <Skeleton sx={{inset:0, zIndex:10}}/> }

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -1,31 +1,41 @@
+import {Stack, Typography} from '@mui/joy';
+import {dispatchHideDialog} from 'firefly/core/ComponentCntlr';
 import {FileAnalysisType, Format, TableDataType} from 'firefly/data/FileAnalysis';
-import {showInfoPopup, showYesNoPopup} from 'firefly/ui/PopupUtil';
-import {getAppHiPSForMoc, isMOCFitsFromUploadAnalsysis} from 'firefly/visualize/HiPSMocUtil';
 import {MetaConst} from 'firefly/data/MetaConst';
-import {isLsstFootprintTable} from 'firefly/visualize/task/LSSTFootprintTask';
-import {makeFileRequest, makeTblRequest} from 'firefly/tables/TableRequestUtil';
-import {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils';
+import LSSTFootprint from 'firefly/drawingLayers/ImageLineBasedFootprint';
 import {createNewRegionLayerId} from 'firefly/drawingLayers/RegionPlot';
-import {dispatchCreateImageLineBasedFootprintLayer, dispatchCreateRegionLayer, getDlAry} from 'firefly/visualize/DrawLayerCntlr';
-import {getDrawLayersByType, getPlotViewAry, primePlot} from 'firefly/visualize/PlotViewUtil';
-import {dispatchPlotImage, visRoot} from 'firefly/visualize/ImagePlotCntlr';
+import {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils';
+import {makeFileRequest, makeTblRequest} from 'firefly/tables/TableRequestUtil';
 import {dispatchTableFetch, dispatchTableSearch} from 'firefly/tables/TablesCntlr';
 import {getSelectedDataSync, uniqueTblId} from 'firefly/tables/TableUtil';
-import LSSTFootprint from 'firefly/drawingLayers/ImageLineBasedFootprint';
-import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
-import RangeValues from 'firefly/visualize/RangeValues';
+import {
+    acceptAnyTables, acceptDataLinkTables, acceptImages, acceptMocTables, acceptNonDataLinkTables, acceptNonMocTables,
+    acceptRegions, acceptTableOrSpectrum, acceptUWS, DATA_LINK_TABLES, IMAGES, MOC_TABLES, REGIONS, SPECTRUM_TABLES,
+    TABLES, UWS
+} from 'firefly/ui/FileUploadUtil';
+import {showInfoPopup, showYesNoPopup} from 'firefly/ui/PopupUtil';
+import {
+    dispatchCreateImageLineBasedFootprintLayer, dispatchCreateRegionLayer, getDlAry
+} from 'firefly/visualize/DrawLayerCntlr';
+import {getAppHiPSForMoc, isMOCFitsFromUploadAnalsysis} from 'firefly/visualize/HiPSMocUtil';
+import {dispatchPlotImage, visRoot} from 'firefly/visualize/ImagePlotCntlr';
 import {getAViewFromMultiView, getMultiViewRoot, IMAGE} from 'firefly/visualize/MultiViewCntlr';
 import {PlotAttribute} from 'firefly/visualize/PlotAttribute';
-import {getTableHeaderFromAnalysis} from '../metaConvert/PartAnalyzer.js';
+import {getDrawLayersByType, getPlotViewAry, primePlot} from 'firefly/visualize/PlotViewUtil';
+import RangeValues from 'firefly/visualize/RangeValues';
+import {isLsstFootprintTable} from 'firefly/visualize/task/LSSTFootprintTask';
+import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
+import React from 'react';
+import {EXTERNAL_UPLOAD} from '../core/AppDataCntlr';
+import {dispatchHideDropDown, dispatchShowDropDown} from '../core/LayoutCntlr';
+import {dispatchAddActionWatcher} from '../core/MasterSaga';
+import {getIntHeaderFromAnalysis, getTableHeaderFromAnalysis} from '../metaConvert/PartAnalyzer.js';
+import {upload} from '../rpc/CoreServices';
+import {getHttpErrorMessage} from '../util/HttpErrorMessage';
+import {getStatusFromFetchError} from '../util/WebUtil';
 
 import {isAnalysisTableDatalink} from '../voAnalyzer/VoDataLinkServDef.js';
 import {fetchDatalinkUITable} from './dynamic/FetchDatalinkTable.js';
-import {dispatchHideDialog} from 'firefly/core/ComponentCntlr';
-import React from 'react';
-import {
-    acceptAnyTables, acceptDataLinkTables, acceptImages, acceptMocTables, acceptNonDataLinkTables,
-    acceptNonMocTables, acceptRegions, acceptTableOrSpectrum, acceptUWS, IMAGES, REGIONS, TABLES, UWS
-} from 'firefly/ui/FileUploadUtil';
 
 const FILE_ID = 'fileUpload';
 const uploadOptions = 'uploadOptions';
@@ -36,6 +46,16 @@ const SUPPORTED_TYPES=[
     FileAnalysisType.Table,
     FileAnalysisType.Spectrum,
     FileAnalysisType.UWS
+];
+
+export const defaultAcceptList = [
+    TABLES,
+    REGIONS,
+    DATA_LINK_TABLES,
+    SPECTRUM_TABLES,
+    MOC_TABLES,
+    IMAGES,
+    UWS
 ];
 
 const LOAD_REGION=0;
@@ -51,13 +71,12 @@ const imageWarning = 'Only loading the table(s), ignoring any selected image(s).
 const tableWarning = 'Only loading the image(s), ignoring any selected table(s).';
 export const fileAnalysisErr = {valid: false, errorMsg: 'Could not analyze the file.', title: 'File Analysis Error'};
 
-
-export function resultSuccess(request) {
+export function resultSuccess(request,cacheKey) {
 
     const {message, report, detailsModel, summaryModel, groupKey, acceptList,
         uniqueTypes, acceptOneItem} = request.additionalParams ?? {};
     const summaryTblId = groupKey; //FileUploadAnalysis
-    const fileCacheKey = getFileCacheKey(groupKey);
+    const fileCacheKey = cacheKey ?? getFileCacheKey(groupKey);
 
     //determine if the file type or selections are valid to be loaded
     const {valid, errorMsg, title} = determineValidity(acceptList, uniqueTypes, summaryModel,
@@ -473,7 +492,9 @@ export function getSelectedRows(type, summaryTblId, report, currentSummaryModel,
         if (type===getFirstPartType(currentSummaryModel)) retRows= [0];
     }
     else {
-        const {totalRows=0, tableData} = getSelectedDataSync(summaryTblId, ['Index', 'Type']);
+        const {totalRows=0, tableData} = summaryTblId
+            ? getSelectedDataSync(summaryTblId, ['Index', 'Type'])
+            : {totalRows:currentSummaryModel.totalRows, tableData:currentSummaryModel.tableData};
         if (totalRows>0) {
             retRows= tableData.data.filter((row) => row[1] === type)            // take only rows with the right type
                 .map((row) => row[0]);                       // returns only the index
@@ -488,4 +509,115 @@ export function getSelectedRows(type, summaryTblId, report, currentSummaryModel,
         retRows= retRows.filter( (idx) => !singleAxisIdxs.includes(idx));
     }
     return retRows;
+}
+
+export function makeSummaryModel(report, summaryTblId, acceptList) {
+    const isFits = report?.fileFormat === Format.FITS;
+    const columns = [
+        {name: 'Index', label: isFits ? 'HDU' : 'Index', type: 'int', desc: 'Extension Index', width: isFits ? 3 : 5},
+        {name: 'Type', type: 'char', desc: 'Data Type'},
+        {name: 'Description', type: 'char', desc: 'Extension Description', width: 40},
+        {name: 'AllowedType', type: 'boolean', desc: 'Type in AcceptList', visibility: 'hidden'}
+    ];
+    const {parts = []} = report;
+    const data = parts.map((p) => {
+        const naxis = getIntHeaderFromAnalysis('NAXIS', p, 0);
+        const entryType = (naxis === 1 && p.type === FileAnalysisType.Image) ? FileAnalysisType.Table : p.type;
+        const descPrefix = (naxis === 1 && p.type === FileAnalysisType.Image) ? '1D image, load as table, ' : '';
+        const isMoc = isMOCFitsFromUploadAnalsysis(report)?.valid;
+        const isDatalink = isAnalysisTableDatalink(report);
+        let isImageAllowed = true;
+        let isTableAllowed = true;
+        if (!acceptImages(acceptList)) {
+            isImageAllowed = false;
+        }
+        if (!acceptTableOrSpectrum(acceptList)) {
+            //edge case: could still be a MOC/DL table file - which only has table entries - don't pink those out
+            isMoc || isDatalink ? isTableAllowed = true : isTableAllowed = false;
+        }
+        let allowedType = true;
+        if (entryType === FileAnalysisType.Table || entryType === FileAnalysisType.Image) {
+            allowedType = entryType === FileAnalysisType.Table ? isTableAllowed : isImageAllowed;
+        }
+        const desc = p.desc ? descPrefix + p.desc : '';
+        return [p.index, entryType, desc, allowedType];
+    });
+
+    const summaryModel = {
+        tbl_id: summaryTblId,
+        tableMeta: {
+            DATARIGHTS_COL: 'AllowedType'
+        },
+        title: 'File Summary',
+        totalRows: data.length,
+        tableData: {columns, data}
+    };
+    return summaryModel;
+}
+
+
+async function loadFile(loadParam,displayName) {
+    try {
+        const {status, analysisResult}= await upload(undefined, 'details', {name:displayName, ...loadParam});
+        if (Number(status)!==200) {
+            showUploadErrorMsg(status, displayName);
+            return;
+        }
+
+        const report= JSON.parse(analysisResult);
+        const summaryModel= makeSummaryModel(report, '', defaultAcceptList);
+        const types= summaryModel?.tableData?.data.map( (d) => d[1]) ?? [];
+        const request= {
+            additionalParams: {
+                acceptOneItem: false,
+                acceptList: defaultAcceptList,
+                groupKey : '',
+                summaryModel,
+                report,
+                uniqueTypes: [...new Set(types)],
+
+            }
+        };
+        resultSuccess(request, report.filePath);
+        dispatchHideDropDown();
+    }
+    catch(error) {
+        const status= getStatusFromFetchError(error?.message);
+        showUploadErrorMsg(status, displayName);
+    }
+}
+
+function showUploadErrorMsg(status, displayName) {
+    const msg= (
+        <Stack>
+            <Typography>{`File upload of ${displayName} failed`}</Typography>
+            <Typography>{`status: ${status}`}</Typography>
+            <Typography>{`message: ${getHttpErrorMessage(status)}`}</Typography>
+        </Stack>
+    );
+    showInfoPopup(msg,'Error');
+}
+
+
+export function initHandleExternalUpload() {
+    const handleExternalUpload= (action) => {
+        const {type,payload}= action ?? {};
+        if (type!==EXTERNAL_UPLOAD) return;
+        const {fileOnServer,displayName= 'Loaded File', immediate= false, url}= payload;
+        if (immediate) {
+            const loadParam= fileOnServer ? {fileOnServer} : url ? {URL:url} : undefined;
+            void loadFile(loadParam,displayName);
+        }
+        else {
+            if (!fileOnServer && !url) {
+                showInfoPopup('external upload parameters incorrect','Error');
+                return;
+            }
+            const searchParams= fileOnServer
+                ? { fileOnServer, displayName, uploadOptions: 'onServer' }
+                : { dropEvent: {type: 'drop', dataTransfer: {files: [url]}, transferIsUrl: true}};
+            dispatchShowDropDown({view:'FileUploadDropDownCmd', initArgs:{searchParams}});
+        }
+    };
+    dispatchAddActionWatcher({ actions:[EXTERNAL_UPLOAD], callback: handleExternalUpload, });
 }

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -1,15 +1,20 @@
-import React from 'react';
-import {isEmpty, uniqueId} from 'lodash';
-import {useCallback, useContext, useEffect, useState, useTransition} from 'react';
+import React, {useCallback, useContext, useEffect, useState, useTransition} from 'react';
+import {isEmpty, isUndefined, uniqueId} from 'lodash';
 import shallowequal from 'shallowequal';
 import {flux} from '../core/ReduxFlux.js';
 import FieldGroupUtils, {
-    getField, getFieldsForKeys, getFieldVal, getGroupFields, getMetaState, makeFieldsObject, setFieldValue
+    getField, getFieldsForKeys, getFieldVal, getGroupFields, getMetaState, makeFieldsObject, setField, setFieldValue
 } from '../fieldGroup/FieldGroupUtils.js';
 import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from 'firefly/core/MasterSaga.js';
 import {dispatchMetaStateChange} from 'firefly/fieldGroup/FieldGroupCntlr.js';
 import {FieldGroupCtx} from './FieldGroup.jsx';
 import {smartMerge} from 'firefly/tables/TableUtil.js';
+
+/**
+ * @typedef InitArgs
+ * @prop {Object} searchParams = any value that the panel should change the default to
+ * @prop {Object} urlApi - parameters coming from the URL api. Should only be used once
+ */
 
 
 /**
@@ -61,6 +66,25 @@ export function useStoreConnector(stateGetter, deps=[], markAsTransition=false) 
     return val;
 }
 
+/**
+ * Set a field group field from the initArea.searchParams object.
+ * @param {InitArgs} initArgs
+ * @param {String} paramKey - the key in the initArea.searchParams object
+ * @param {String} additionalUpdatesFunc - calls a function (setFld,value,fieldObj
+ * @param [fieldKey] - the field key, defaults to paramKey
+ * @param [groupKey] - groupKey - the should not be used except for a good reason
+ */
+export function useInitArgSearchParam(initArgs, paramKey, additionalUpdatesFunc, fieldKey= undefined, groupKey=undefined) {
+    const context= useContext(FieldGroupCtx);
+    return useEffect(() => {
+        const v= initArgs?.searchParams?.[paramKey];
+        if (isUndefined(v) || (!context && !groupKey)) return;
+        const fk= fieldKey ?? paramKey;
+        (context && !groupKey) ? context.setVal(fk,v) : setFieldValue(groupKey,fk,v);
+        const gk= groupKey||context.groupKey;
+        additionalUpdatesFunc?.(getField(gk,fk), (obj) => setField( gk, fk, obj), );
+    }, [initArgs?.searchParams?.[paramKey]]);
+}
 
 /**
  * @deprecated

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -881,7 +881,6 @@ export function advancedTrim(s='', maxLength=15, trimType='middle') {
             const halfHalf= Math.ceil(maxLenHalf/2);
             const mid2= s.substring(midpoint-halfHalf, midpoint+halfHalf);
             return `${start2}${e}${mid2}${e}`;
-            return '';
         case 'bothends':
             return e + s.substring(midpoint-maxLenHalf, midpoint+maxLenHalf)+ e;
         case 'complex':

--- a/src/firefly/js/visualize/task/LSSTFootprintTask.js
+++ b/src/firefly/js/visualize/task/LSSTFootprintTask.js
@@ -23,6 +23,7 @@ import {logger} from '../../util/Logger.js';
 
 
 export const isLsstFootprintTable = (tableModel) => {
+    if (!tableModel) return false;
     const lsstKeys = ['contains_lsst_footprints', 'contains_lsst_measurements'];
     const {tableMeta} = tableModel || {};
 

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -3,50 +3,52 @@
  */
 
 import {Box, Chip, Stack, Typography} from '@mui/joy';
+import {UwsJobInfo} from 'firefly/core/background/JobInfo';
+import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from 'firefly/core/MasterSaga.js';
+import {dispatchValueChange} from 'firefly/fieldGroup/FieldGroupCntlr.js';
+import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson';
+import {CheckboxGroupInputField} from 'firefly/ui/CheckboxGroupInputField.jsx';
+import {
+    findSingleAxisImages, getFileFormat, getFirstPartType, getSelectedRows, isRegion, isUWS, makeSummaryModel
+} from 'firefly/ui/FileUploadProcessor';
+import {
+    acceptAnyTables, acceptDataLinkTables, acceptImages, acceptMocTables, acceptNonDataLinkTables, acceptNonMocTables,
+    acceptOnlyTables, acceptRegions, acceptTableOrSpectrum, acceptUWS, DATA_LINK_TABLES, IMAGES, REGIONS,
+    SPECTRUM_TABLES, TABLES, UWS
+} from 'firefly/ui/FileUploadUtil';
 import React, {useContext, useEffect, useState} from 'react';
-import shallowequal from 'shallowequal';
 import SplitPane from 'react-split-pane';
+import shallowequal from 'shallowequal';
+import {FileAnalysisType, Format, TableDataType} from '../../data/FileAnalysis';
+import {getField} from '../../fieldGroup/FieldGroupUtils';
+import {upload} from '../../rpc/CoreServices';
+
+import {SelectInfo} from '../../tables/SelectInfo.js';
+import {dispatchTableAddLocal, dispatchTableRemove} from '../../tables/TablesCntlr.js';
+import {getCellValue, getTblById} from '../../tables/TableUtil.js';
+import {TablePanel} from '../../tables/ui/TablePanel.jsx';
 
 import {FieldGroupCtx} from '../../ui/FieldGroup.jsx';
 import {FileUpload} from '../../ui/FileUpload.jsx';
-import {getField} from '../../fieldGroup/FieldGroupUtils';
-import {TablePanel} from '../../tables/ui/TablePanel.jsx';
-import {getCellValue, getTblById} from '../../tables/TableUtil.js';
-import {dispatchTableAddLocal, dispatchTableRemove} from '../../tables/TablesCntlr.js';
+import {showInfoPopup} from '../../ui/PopupUtil.jsx';
+import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
 
-import {isAnalysisTableDatalink} from '../../voAnalyzer/VoDataLinkServDef.js';
+import {
+    useFieldGroupMetaState, useFieldGroupValue, useInitArgSearchParam, useStoreConnector
+} from '../../ui/SimpleComponent.jsx';
+import {WorkspaceUpload} from '../../ui/WorkspaceViewer.jsx';
 import {getSizeAsString} from '../../util/WebUtil.js';
 
-import {SelectInfo} from '../../tables/SelectInfo.js';
-import ImagePlotCntlr from '../ImagePlotCntlr.js';
-import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
-import {showInfoPopup} from '../../ui/PopupUtil.jsx';
-import {WorkspaceUpload} from '../../ui/WorkspaceViewer.jsx';
-import {isAccessWorkspace, getWorkspaceConfig} from '../WorkspaceCntlr.js';
+import {isAnalysisTableDatalink} from '../../voAnalyzer/VoDataLinkServDef.js';
 import {isMOCFitsFromUploadAnalsysis} from '../HiPSMocUtil.js';
+import ImagePlotCntlr from '../ImagePlotCntlr.js';
 import {isLsstFootprintTable} from '../task/LSSTFootprintTask.js';
+import {getWorkspaceConfig, isAccessWorkspace} from '../WorkspaceCntlr.js';
 
-import {useFieldGroupMetaState, useFieldGroupValue, useStoreConnector} from '../../ui/SimpleComponent.jsx';
-
-import {getIntHeaderFromAnalysis} from '../../metaConvert/PartAnalyzer';
-import {FileAnalysisType, TableDataType} from '../../data/FileAnalysis';
-import {Format} from '../../data/FileAnalysis';
-import {dispatchValueChange} from 'firefly/fieldGroup/FieldGroupCntlr.js';
-import {dispatchAddActionWatcher, dispatchCancelActionWatcher} from 'firefly/core/MasterSaga.js';
-import {CheckboxGroupInputField} from 'firefly/ui/CheckboxGroupInputField.jsx';
-import {
-    findSingleAxisImages, getFileFormat, getFirstPartType, getSelectedRows, isRegion, isUWS
-} from 'firefly/ui/FileUploadProcessor';
-import {
-    acceptAnyTables, acceptDataLinkTables, acceptImages, acceptMocTables, acceptNonDataLinkTables,
-    acceptNonMocTables, acceptOnlyTables, acceptRegions, acceptTableOrSpectrum, acceptUWS, DATA_LINK_TABLES,
-    IMAGES, REGIONS, SPECTRUM_TABLES, TABLES, UWS
-} from 'firefly/ui/FileUploadUtil';
-import {UwsJobInfo} from 'firefly/core/background/JobInfo';
-import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson';
 export const  FILE_ID = 'fileUpload';
 export const  URL_ID = 'urlUpload';
 const  WS_ID = 'wsUpload';
+const  ON_SERVIER_ID = 'onServer';
 const SINGLE_ROW_AS_TABLE= 'singleRowImageAsTable';
 
 const TABLE_MSG = 'Custom catalog or table in IPAC, CSV, TSV, VOTABLE, Parquet, or FITS table format';
@@ -69,19 +71,19 @@ const TABLES_ONLY_SUPPORTED_TYPES=[
     FileAnalysisType.Table,
 ];
 
-const uploadOptions = 'uploadOptions';
+const UPLOAD_OPTIONS_KEY = 'uploadOptions';
 
 const FILE_UPLOAD_KEY= 'file-upload-key-';
 let keyCnt=0;
+let cachedFileOnServerOptions= {};
 
-export function FileUploadViewPanel({setSubmitText, acceptList, acceptOneItem, externalDropEvent}) {
+export function FileUploadViewPanel({setSubmitText, acceptList, acceptOneItem, externalDropEvent, initArgs}) {
 
     const {groupKey, keepState}= useContext(FieldGroupCtx);
 
     const isWsUpdating          = useStoreConnector(() => isAccessWorkspace());
-    const [getLoadingOp, setLoadingOp]= useFieldGroupValue(uploadOptions);
+    const [getLoadingOp, setLoadingOp]= useFieldGroupValue(UPLOAD_OPTIONS_KEY);
     const singleAxisImageAsTable= useFieldGroupValue(SINGLE_ROW_AS_TABLE)[0]()==='singleAxisImage';
-
     //dropEvent is used for files being dragged and drooped for uploads
     const [dropEvent, setDropEvent] = useState(() => externalDropEvent);
 
@@ -154,10 +156,26 @@ export function FileUploadViewPanel({setSubmitText, acceptList, acceptOneItem, e
         });
     }, [isLoading, statusKey] );
 
+    useInitArgSearchParam(initArgs,UPLOAD_OPTIONS_KEY);
+
+    let fileOnServerOptions= {
+        fileOnServer:initArgs?.searchParams?.fileOnServer,
+        displayName:initArgs?.searchParams?.displayName ?? 'Loaded File',
+    };
+    let useFileOnServer= false;
+    if (fileOnServerOptions.fileOnServer || cachedFileOnServerOptions.fileOnServer) {
+        useFileOnServer= true;
+        if (fileOnServerOptions.fileOnServer) cachedFileOnServerOptions= fileOnServerOptions;
+        else fileOnServerOptions= cachedFileOnServerOptions;
+    }
+
+
+
     const workspace = getWorkspaceConfig();
-    const uploadMethod = [{value: FILE_ID, label: 'Upload file'},
-        {value: URL_ID, label: 'Upload from URL'}
-    ].concat(workspace ? [{value: WS_ID, label: 'Upload from workspace'}] : []);
+    const uploadMethod = [{value: FILE_ID, label: 'Upload file'}, {value: URL_ID, label: 'Upload from URL'}];
+    if (workspace) uploadMethod.push({value: WS_ID, label: 'Upload from workspace'});
+    if (useFileOnServer) uploadMethod.push({value: ON_SERVIER_ID, label: 'Preloaded file'});
+
 
     const clearReport= () => {
         dispatchValueChange({fieldKey:getLoadingOp(), groupKey, value:'', displayValue:'', analysisResult:undefined});
@@ -166,6 +184,7 @@ export function FileUploadViewPanel({setSubmitText, acceptList, acceptOneItem, e
     const isMoc=  isMOCFitsFromUploadAnalsysis(report)?.valid;
     const isDatalink=  isAnalysisTableDatalink(report);
 
+    const loadingOp= dropEvent ? dropEvent.transferIsUrl ? URL_ID : FILE_ID : getLoadingOp();
     return (
         <Stack {...{flexGrow:1, position: 'relative', height:1, alignItems: 'stretch'}}>
             <FileDropZone {...{dropEvent, setDropEvent, setLoadingOp}}>
@@ -174,11 +193,11 @@ export function FileUploadViewPanel({setSubmitText, acceptList, acceptOneItem, e
                         <RadioGroupInputField
                             initialState={{value: uploadMethod[0].value}}
                             slotProps={{radio:{size:'md'}}}
-                            fieldKey={uploadOptions}
+                            fieldKey={UPLOAD_OPTIONS_KEY}
                             orientation='horizontal'
                             options={uploadMethod} />
                         <Stack {...{pt: 1, direction:'row', justifyContent:'space-between'}}>
-                            <UploadOptions {...{uploadSrc: dropEvent ? FILE_ID : getLoadingOp(), isLoading, isWsUpdating,  uploadKey, dropEvent, setDropEvent}}/>
+                            <UploadOptions {...{uploadSrc: loadingOp, isLoading, isWsUpdating,  uploadKey, dropEvent, setDropEvent, fileOnServerOptions}}/>
                             <Stack>
                                 {report && <Chip sx={{whiteSpace:'nowrap', ml:1}}
                                                  onClick={() =>{
@@ -210,7 +229,7 @@ export function FileDropZone({dropEvent, setDropEvent, setLoadingOp, sx, childre
 
     useEffect(() => {
         if (dropEvent) {
-             setLoadingOp('fileUpload');
+            setLoadingOp(dropEvent.transferIsUrl ? URL_ID : FILE_ID);
         }
     }, [dropEvent]);
 
@@ -402,50 +421,6 @@ function summaryModelEqual(sm1,sm2) {
         sm1?.selectInfo !== sm2?.selectInfo);
 }
 
-function makeSummaryModel(report, summaryTblId, acceptList) {
-    const isFits= report?.fileFormat===Format.FITS;
-    const columns = [
-        {name: 'Index', label:isFits? 'HDU' : 'Index', type: 'int', desc: 'Extension Index', width:isFits?3:5},
-        {name: 'Type', type: 'char', desc: 'Data Type'},
-        {name: 'Description', type: 'char', desc: 'Extension Description', width: 40},
-        {name: 'AllowedType', type: 'boolean', desc: 'Type in AcceptList', visibility: 'hidden'}
-    ];
-    const {parts=[]} = report;
-    const data = parts.map( (p) => {
-        const naxis= getIntHeaderFromAnalysis('NAXIS',p,0);
-        const entryType = (naxis===1 && p.type===FileAnalysisType.Image)?FileAnalysisType.Table :p.type;
-        const descPrefix= (naxis===1 && p.type===FileAnalysisType.Image)? '1D image, load as table, ' : '';
-        const isMoc=  isMOCFitsFromUploadAnalsysis(report)?.valid;
-        const isDatalink=  isAnalysisTableDatalink(report);
-        let isImageAllowed = true;
-        let isTableAllowed = true;
-        if (!acceptImages(acceptList)) {
-            isImageAllowed = false;
-        }
-        if (!acceptTableOrSpectrum(acceptList)) {
-            //edge case: could still be a MOC/DL table file - which only has table entries - don't pink those out
-            isMoc || isDatalink? isTableAllowed= true: isTableAllowed= false;
-        }
-        let allowedType = true;
-        if (entryType === FileAnalysisType.Table || entryType === FileAnalysisType.Image) {
-            allowedType = entryType === FileAnalysisType.Table? isTableAllowed: isImageAllowed;
-        }
-        const desc= p.desc ? descPrefix+p.desc : '';
-        return [p.index, entryType , desc, allowedType];
-    });
-
-    const summaryModel = {
-        tbl_id: summaryTblId,
-        tableMeta: {
-            DATARIGHTS_COL: 'AllowedType'
-        },
-        title: 'File Summary',
-        totalRows: data.length,
-        tableData: {columns, data}
-    };
-    return summaryModel;
-}
-
 function getDetailsModel(tableModel, report, detailsTblId, UNKNOWN_FORMAT) {
     if (!tableModel) return;
     const {highlightedRow=0} = tableModel;
@@ -556,7 +531,23 @@ function ImageDisplayOption({summaryTblId, currentReport, currentSummaryModel, a
     }
 }
 
-function UploadOptions({uploadSrc, isLoading, isWsUpdating, uploadKey, dropEvent, setDropEvent}) {
+function UploadOptions({uploadSrc, isLoading, isWsUpdating, uploadKey, dropEvent, setDropEvent, fileOnServerOptions}) {
+
+    const {setFld,getVal}= useContext(FieldGroupCtx);
+    const {fileOnServer, displayName}= fileOnServerOptions;
+
+    useEffect(() => {
+        const up= async () => {
+            if (uploadSrc!==ON_SERVIER_ID || !fileOnServer || getVal(ON_SERVIER_ID)===fileOnServer) return;
+            const {status, analysisResult}= await upload(fileOnServer, 'details', {name:displayName});
+            const value= fileOnServer;
+            const fld= Number(status)===200
+                ? {analysisResult, message:undefined, value}
+                : {analysisResult:undefined, message:'External Upload failed', value};
+            setFld(ON_SERVIER_ID,fld);
+        };
+        void up();
+    }, [uploadSrc,fileOnServer,displayName]);
 
     const [getUploadMetaInfo, setUploadMetaInfo]= useFieldGroupMetaState({isLoading:undefined, statusKey: undefined });
     const onLoading = (loading, statusKey) => {
@@ -599,6 +590,18 @@ function UploadOptions({uploadSrc, isLoading, isWsUpdating, uploadKey, dropEvent
                 fileAnalysis={onLoading}
                 tooltip='Select a file in FITS, VOTABLE, CSV, TSV, or IPAC format from workspace'
             />
+        );
+    } else if (uploadSrc === ON_SERVIER_ID) {
+        return (
+            <Stack direction='row' spacing={1} pt={1} pb={2}>
+                <Typography>
+                    Preloaded file:
+                </Typography>
+                <Typography level='title-lg'>
+                    {`${displayName}`}
+                </Typography>
+            </Stack>
+
         );
     }
     return null;


### PR DESCRIPTION
### [Firefly-1815](https://jira.ipac.caltech.edu/browse/FIREFLY-1815): Upload via a action, usually from firefly_client

- Also added URL API support

### Testing From Python firefly_client

- use https://fireflydev.ipac.caltech.edu/firefly-1815-upload/firefly/
- Test from python using `firefly_client`
#### Test loading to the upload panel
```python
import os
from firefly_client import FireflyClient
ffurl= 'https://fireflydev.ipac.caltech.edu/firefly-1815-upload/firefly/'
fc = FireflyClient.make_client(ffurl, channel_override='up')
file= 'path to a fits and/or table file'
key= fc.upload_file(file)
fc.dispatch('app_data.externalUpload', {'fileOnServer':key, 'displayName':os.path.basename(file)})
```
#### Test immediate loading, change last line to add `'immediate':True`
```python
fc.dispatch('app_data.externalUpload', {'immediate':True, 'fileOnServer':key, 'displayName':os.path.basename(file)})
```
#### Test a url
```python
fc.dispatch('app_data.externalUpload', {'url':'http://web.ipac.caltech.edu/staff/roby/data-products-test/1904-66_SFL.fits' })
```

### Testing URL API
- https://fireflydev.ipac.caltech.edu/firefly-1815-upload/firefly/?api=load
- Try the examples or make your own