### PR TITLE
FIREFLY-1278: Popup Column Filters

### DIFF
--- a/src/firefly/js/charts/ui/ColSelectView.jsx
+++ b/src/firefly/js/charts/ui/ColSelectView.jsx
@@ -33,9 +33,9 @@ export function showColSelectPopup(colValStats,onColSelected,popupTitle,buttonTe
 
     // make a local table for plot column selection panel
     const columns = [
-        {name: 'Name'},
-        {name: 'Unit'},
-        {name: 'Type'},
+        {name: 'Name', type: 'char'},
+        {name: 'Unit', type: 'char'},
+        {name: 'Type', type: 'char'},
         {name: '', visibility: 'hidden'},
         {name: '', visibility: 'hidden'}
     ];

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -377,13 +377,14 @@ function fixClientTable(tableModel) {
 
     tableModel.totalRows = tableModel?.tableData?.data?.length ?? 0;
 
+    ensureEnumVals(tableModel);         // apply enum values to the client tableModel using server-side logic
+
     if (!tableModel.origTableModel) {
         tableModel = TblUtil.cloneClientTable(tableModel);
     }
 
     set(tableModel, 'request.pageSize', fixPageSize(tableModel.request?.pageSize));
-    ensureEnumVals(tableModel);         // apply enum values to the client tableModel using server-side logic
-
+    
     return tableModel;
 }
 


### PR DESCRIPTION
**Ticket**: [FIREFLY-1278](https://jira.ipac.caltech.edu/browse/FIREFLY-1278) 
- This fix was eventually way simpler than I thought, just took me some time to understand the code. We were already calling `ensureEnumVals` for the column picker tables (through `tableAddLocal`), but `ensureEnumVals` relies on a `type` entry which was missing in the columns for the column picker popup. 
- There was a second bug, where for some client tables you would lose the dropdown filter button after filtering any column once. This is related to the `origTableModel` not having `enumVals`. Moving `ensureEnumVals` up before calling `cloneClientTable` on the `tableModel` fixes this. 

**Testing:**
**Firefly**: https://fireflydev.ipac.caltech.edu/firefly-1278-col-filters/firefly
- click on any column selector popup, either from an uploaded table or from the position columns for the selected table on the right (on TAP), or even from a chart's column picker
- for columns that allow it, you should be able to filter the columns in the popup through a dropdown that displays the unique values in the column 
  - (our existing behavior is that this is limited to: `ENUM_TYPES`, which includes: `['long', 'int', 'short', 'integer', 'char', 'boolean','bool']`)