### PR TITLE
FIREFLY-1807: Firefly fails to detect broken Redis connection; misleading server-status and client UI

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
@@ -141,13 +141,14 @@ public class RedisService {
             return; // state unchanged
         }
         failSince = ok ? null : Instant.now();
-        sendConnectionStatus(true);     // notify clients of the update
+        sendConnectionStatus();     // notify clients of the update
     }
 
-    public static void sendConnectionStatus(boolean always) {
-        if (!always && failSince == null) {
-            return; // no need to send status if not lost
-        }
+    public static void sendConnectionStatusIfFailed () {
+        if (failSince != null) sendConnectionStatus();
+    }
+
+    public static void sendConnectionStatus() {
         boolean lost = failSince != null;
         String reason = lost ? "A critical system component is currently unavailable" : "";
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
@@ -82,7 +82,7 @@ public class RedisService {
             pconfig.setBlockWhenExhausted(true);                // wait; if needed
             pconfig.setMaxWait(Duration.of(5, ChronoUnit.SECONDS));
             JedisPool pool = new JedisPool(pconfig, redisHost, REDIS_PORT, Protocol.DEFAULT_TIMEOUT, REDIS_PASSWORD);
-            pool.getResource().close();     // test connection
+            pool.getResource().ping();     // test connection
             return pool;
         } catch(Exception ignored) {}
         return null;
@@ -107,31 +107,28 @@ public class RedisService {
         } catch (IOException ignored) {}
     }
 
-    public static Instant getFailSince() { return failSince; }
-
     public static Jedis getConnection() throws Exception {
         try {
-            if (jedisPool == null || jedisPool.isClosed()) {
+            if (jedisPool == null) {
                 jedisPool = createJedisPool();
-                if (jedisPool == null && redisHost.equals("localhost")) {
-                    // can't connect; will start up embedded version if localhost
-                    startLocal();
-                    jedisPool = createJedisPool();
-                }
-                if (jedisPool == null || jedisPool.isClosed()) {
-                    if (jedisPool != null) {
-                        Try.it(jedisPool::close);
-                        jedisPool = null;
-                    }
-                    throw new RuntimeException("Unable to connect to Redis at " + redisHost + ":" + REDIS_PORT);
-                }
+            }
+            if (jedisPool == null && redisHost.equals("localhost")) {
+                // when running on localhost, startup Redis if it’s not already running.
+                startLocal();
+                jedisPool = createJedisPool();
+            }
+            if (jedisPool == null) {
+                throw new Exception("Failed to connect to Redis at %s:%d".formatted(redisHost, REDIS_PORT));
             }
             Jedis jedis = jedisPool.getResource();
-            if (failSince != null) updateConnectionStatus(false);
+            jedis.ping(); // test connection before returning
+            setConnectionOk(true);
             return jedis;
         } catch (Exception e) {
-            if (failSince == null) {
-                updateConnectionStatus(true);
+            setConnectionOk(false);
+            if (jedisPool != null) {
+                Try.it(jedisPool::close);
+                jedisPool = null;
             }
             throw e;
         }
@@ -139,8 +136,19 @@ public class RedisService {
 
     // because Redis may be down, we need to use processEvent to directly send it to clients currently connected
     // to this server and not rely on distributed event messaging.
-    public static void updateConnectionStatus(boolean lost) {
-        failSince = lost ? Instant.now() : null;
+    public static void setConnectionOk(boolean ok) {
+        if (ok == (failSince == null)) {
+            return; // state unchanged
+        }
+        failSince = ok ? null : Instant.now();
+        sendConnectionStatus(true);     // notify clients of the update
+    }
+
+    public static void sendConnectionStatus(boolean always) {
+        if (!always && failSince == null) {
+            return; // no need to send status if not lost
+        }
+        boolean lost = failSince != null;
         String reason = lost ? "A critical system component is currently unavailable" : "";
 
         FluxAction action = new FluxAction("app_data.appUpdate");

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -5,6 +5,7 @@
 package edu.caltech.ipac.firefly.core.background;
 
 import edu.caltech.ipac.firefly.api.Async;
+import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.Util.Try;
 import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
@@ -25,6 +26,7 @@ import edu.caltech.ipac.util.cache.StringKey;
 import org.apache.commons.lang.text.StrBuilder;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.params.ScanParams;
 
 import javax.annotation.Nonnull;
@@ -79,7 +81,7 @@ public class JobManager {
     private static final CacheKey JOB_CACHE_VERSION_KEY = new StringKey("job.all.cache.version");
     private static final String JOB_CACHE_VERSION = "1.0";
 
-    static {
+    public static void init() {
         if (!isEmpty(COMPLETED_HANDLER)) {
             Class<?> clz = Try.it(() -> Class.forName(COMPLETED_HANDLER)).get();
             if (clz != null && JobCompletedHandler.class.isAssignableFrom(clz)) {
@@ -92,16 +94,25 @@ public class JobManager {
 
         Messenger.subscribe(JobEvent.TOPIC, new JobEventHandler());
         Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                    JobManager::checkJobs, KEEP_ALIVE_INTERVAL, KEEP_ALIVE_INTERVAL, TimeUnit.SECONDS);   // check every 30 seconds
+                JobManager::checkJobs, KEEP_ALIVE_INTERVAL, KEEP_ALIVE_INTERVAL, TimeUnit.SECONDS);   // check every 30 seconds
 
-
-        String jobCacheVersion = (String) CacheManager.getDistributed().get(JOB_CACHE_VERSION_KEY);
-        if (isEmpty(jobCacheVersion) || !jobCacheVersion.equals(JOB_CACHE_VERSION)) {
-            LOG.info("Migrating job cache keys to new format");
-            int count = migrateRedisKeys();
-            LOG.info("Migrated " + count + " job cache keys to new format");
-            CacheManager.getDistributed().put(JOB_CACHE_VERSION_KEY, JOB_CACHE_VERSION); // set the version
-        }
+        ScheduledExecutorService migrator = Executors.newSingleThreadScheduledExecutor();
+        migrator.scheduleWithFixedDelay(() -> {
+            try (Jedis jedis = RedisService.getConnection()) {
+                // run migration only when there's connection to Redis
+                LOG.info("Ensure job history is up to date");
+                String jobCacheVersion = (String) CacheManager.getDistributed().get(JOB_CACHE_VERSION_KEY);
+                if (isEmpty(jobCacheVersion) || !jobCacheVersion.equals(JOB_CACHE_VERSION)) {
+                    LOG.info("Migrating job history keys to new format");
+                    int count = migrateRedisKeys();
+                    LOG.info("Migrated "+ count + " job keys to new format");
+                    CacheManager.getDistributed().put(JOB_CACHE_VERSION_KEY, JOB_CACHE_VERSION);
+                }
+                migrator.shutdown(); // stop once successful
+            } catch (Exception e) {
+                LOG.debug("Job history check failed, retrying in 5s");
+            }
+        }, 0, 5, TimeUnit.SECONDS);
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -57,8 +57,8 @@ public class AppServerCommands {
             action.setValue(bgInfo.notifEnabled(), "notifEnabled");
             ServerEventManager.fireAction(action, ServerEvent.Scope.SELF);
 
-            // check for redis connection
-            if (RedisService.getFailSince() != null)  RedisService.updateConnectionStatus(true);
+            // send redis connection status
+            RedisService.sendConnectionStatus(true);
 
             return "true";
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -58,7 +58,7 @@ public class AppServerCommands {
             ServerEventManager.fireAction(action, ServerEvent.Scope.SELF);
 
             // send redis connection status
-            RedisService.sendConnectionStatus(true);
+            RedisService.sendConnectionStatus();
 
             return "true";
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServCommand.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServCommand.java
@@ -1,6 +1,7 @@
 package edu.caltech.ipac.firefly.server;
 
 import edu.caltech.ipac.firefly.core.EndUserException;
+import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -22,6 +23,7 @@ public abstract class ServCommand extends ServerCommandAccess.HttpCommand {
     public void processRequest(HttpServletRequest req, HttpServletResponse res, SrvParam sp) throws Exception {
         JSONObject json=new JSONObject();
         String jsonData;
+        RedisService.sendConnectionStatus(false);      // notify the client if redis is down
         try {
             String result = doCommand(new SrvParam(sp.getParamMap()));
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServCommand.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServCommand.java
@@ -23,7 +23,7 @@ public abstract class ServCommand extends ServerCommandAccess.HttpCommand {
     public void processRequest(HttpServletRequest req, HttpServletResponse res, SrvParam sp) throws Exception {
         JSONObject json=new JSONObject();
         String jsonData;
-        RedisService.sendConnectionStatus(false);      // notify the client if redis is down
+        RedisService.sendConnectionStatusIfFailed();
         try {
             String result = doCommand(new SrvParam(sp.getParamMap()));
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -859,6 +859,8 @@ public class ServerContext {
                         JobManager.CLEANUP_INTVL_MINS,
                         JobManager.CLEANUP_INTVL_MINS,
                         TimeUnit.MINUTES);
+
+                JobManager.init();  // initialize JobManager on startup
             } catch (Throwable e) {
                 e.printStackTrace();
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
@@ -113,11 +113,12 @@ public class DistributedCache<T> implements Cache<T> {
         return false;
     }
 
+    @Nonnull
     public List<StringKey> getKeys() {
         try(Jedis redis = RedisService.getConnection()) {
             return keys(redis).stream().map(StringKey::new).toList();
         } catch (Exception ex) { LOG.error(ex); }
-        return null;
+        return List.of();
     }
 
     public int getSize() {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1807
Changes:
- use ping for a more direct test
- update client more aggressively
- prevent exception during JobManager init.

Test: https://fireflydev.ipac.caltech.edu/firefly-1807-detect-redis-outage/firefly/
The recommend approach to testing is to run Redis locally and start Tomcat with -Dredis.host=127.0.0.1. 
This allows you to manually stop and restart Redis to observe how Firefly reacts to connection loss and recovery.