### PR TITLE
FIREFLY-1827: Improve messaging about missing column specifications

### DIFF
--- a/src/firefly/js/ui/UploadTableSelector.jsx
+++ b/src/firefly/js/ui/UploadTableSelector.jsx
@@ -16,6 +16,7 @@ import {FilterInfo} from 'firefly/tables/FilterInfo';
 import {dispatchTableFilter} from 'firefly/tables/TablesCntlr';
 import {onTableLoaded} from 'firefly/tables/TableUtil';
 
+export const MISSING_COLS_HEADER_MSG = 'Unspecified Column(s)';
 const TAB_COLUMNS_DEFAULT_MSG='These are the recommended columns to use for a spatial search on this table; changing them could cause the query to fail.';
 const TAB_COLUMNS_USER_MSG = 'User-specified coordinate columns may or may not work depending on the configuration of the database being queried.';
 const TAB_COLUMNS_EMPTY_MSG = 'Unable to identify coordinate columns for spatial searches; spatial searches are disabled. It is possible to designate coordinate ' +
@@ -222,11 +223,11 @@ UploadTableSelector.propTypes = {
 export function ColumnMappingPanel({cols, columnFieldValues, columnFields, panelKey,
                                        headerTitle='Mapped Columns:', getHeaderColumnMapping, headerPostTitle = '',
                                        openPreMessage='', sx, slotProps, children}) {
-    const defaultColumnMapping = (colValues) => colValues?.every((val) => !val)
-        ? 'unset'
+    const defaultColumnMapping = (colValues) => colValues?.some((val) => !val)
+        ? <Typography color='warning'>{MISSING_COLS_HEADER_MSG}</Typography>
         : colValues.length===2 && colValues[0]===colValues[1]
             ? colValues[0]
-            : colValues?.map((val) => val || 'unset').join(', ');
+            : colValues.join(', ');
 
     const panelHeader= (
         <Stack {...{direction:'row', alignItems:'baseline', spacing:1}}>
@@ -296,7 +297,6 @@ export const MappedColumnFld = ({cols, fieldKey, name, ...props}) => (
                // use following defaults if not present in props
                label={name}
                orientation={'vertical'}
-               validator={getColValidator(cols, true, false)}
                {...props}/>
 );
 


### PR DESCRIPTION
Fixes [FIREFLY-1827](https://jira.ipac.caltech.edu/browse/FIREFLY-1827)

- UI will now show warning text "Unspecified column(s)" instead of "unset" if a column wasn't specified in the column mapping panel
- Also see IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/435

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1827-missing-col-warning/firefly
https://firefly-1827-missing-col-warning.irsakudev.ipac.caltech.edu/applications/euclid
https://firefly-1827-missing-col-warning.irsakudev.ipac.caltech.edu/applications/spherex

Check all instances where column mapping panel appears in the firefly/ife apps - these were listed out in the "Testing" section of https://github.com/Caltech-IPAC/firefly/pull/1751 (they are too many cases but testing TAP spatial, euclid images, etc. should give enough idea)