### PR TITLE
FIREFLY-1829: Fully support Job ABORT

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/api/Async.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/api/Async.java
@@ -156,7 +156,7 @@ public class Async extends BaseHttpServlet {
     private static void updateJobPhase(HttpServletRequest req, HttpServletResponse res, String jobId) throws Exception {
         String phase = req.getParameter("PHASE");
         if (String.valueOf(phase).equals("ABORT")) {
-            JobInfo fi = JobManager.abort(jobId, "Abort by user");
+            JobInfo fi = JobManager.abort(jobId, null);
             sendResponse(JobUtil.toJson(fi), res);
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
@@ -10,6 +10,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.core.background.JobManager.sendUpdate;
 import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.server.util.QueryUtil.combineErrorMsg;
 import static java.util.Optional.ofNullable;
@@ -30,7 +31,7 @@ public interface Job extends Callable<String> {
 
     Worker getWorker();
 
-    void setWorker(Worker worker);
+    void onStart(Worker worker);
 
     void setParams(SrvParam params);
 
@@ -42,46 +43,44 @@ public interface Job extends Callable<String> {
 
     String run() throws Exception;
 
-    default boolean shouldUpdate() {
-        boolean isSelfManaged = ofNullable(getWorker()).map(Worker::isSelfManaged).orElse(false);
-        return !isSelfManaged;
-    }
-
-    default void updateJobStatus(Consumer<JobInfo> apply) {
-        if (shouldUpdate()) updateJobInfo(getJobId(), apply);
-    }
-
-    default void sendJobStatus(Consumer<JobInfo> apply) {
-        if (shouldUpdate()) JobManager.sendUpdate(getJobId(), apply);
+    default void updateManagedStatus(Consumer<JobInfo> func) {
+        if (getWorker() != null && !getWorker().isSelfManaged()) {
+            updateJobInfo(getJobId(), func);
+        }
     }
 
     default String call() {
-
-        sendJobStatus(ji -> {
-            ji.setPhase(JobInfo.Phase.EXECUTING);
-            ji.getMeta().setProgress(10);
-            ji.setStartTime(Instant.now());
-        });
         try {
+            updateJobInfo(getJobId(), ji -> {
+                ji.setStartTime(Instant.now());
+                ji.getMeta().setProgress(0);
+            });
             String results = run();
-            updateJobStatus(ji -> {
+            // the worker is set in onStart().
+            getWorker().onComplete();
+            if (Thread.currentThread().isInterrupted()) throw new InterruptedException("Job was aborted");
+            updateManagedStatus(ji -> {
                 ji.setPhase(JobInfo.Phase.COMPLETED);
                 ji.getMeta().setProgress(100, "");
             });
             return results;
         } catch (InterruptedException | DataAccessException.Aborted e) {
-            updateJobStatus(ji -> ji.setPhase(JobInfo.Phase.ABORTED));
+            updateJobInfo(getJobId(), ji -> {
+                ji.setPhase(JobInfo.Phase.ABORTED);
+                ji.getMeta().setProgress(100, "Job was aborted");
+            });
             getWorker().onAbort();
         } catch (Exception e) {
-            String msg = combineErrorMsg(e.getMessage(), e.getCause() == null ? null : e.getCause().getMessage());
-            updateJobStatus(ji -> ji.setError(new JobInfo.Error(500, msg)));
+            updateManagedStatus(ji -> {
+                String msg = combineErrorMsg(e.getMessage(), e.getCause() == null ? null : e.getCause().getMessage());
+                ji.setError(new JobInfo.Error(500, msg));
+            });
             Logger.getLogger().error(e);
         } finally {
-            sendJobStatus(ji -> {
+            sendUpdate(getJobId(), ji -> {
                 ji.setEndTime(Instant.now());
                 ji.getMeta().setProgress(100);
             });
-            getWorker().onComplete();
         }
         return null;
     }
@@ -118,7 +117,7 @@ public interface Job extends Callable<String> {
          */
         default void sendJobUpdate(Consumer<JobInfo> func) {
             ifNotNull(getJob()).apply(j -> {
-                JobManager.sendUpdate(j.getJobId(), func);
+                sendUpdate(j.getJobId(), func);
             });
         }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -21,8 +21,9 @@ import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 
 
 /**
- * Value object containing information of a Job
- *
+ * Represents a Job value object persisted in Redis as JSON string.
+ * Modifying this data structure may require additional logic in the JobManager
+ * to migrate previously persisted data.
  * Date: 9/29/21
  *
  * @author loi

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -35,8 +35,10 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -44,9 +46,11 @@ import java.util.stream.Stream;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.core.background.Job.Type.UWS;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
 import static edu.caltech.ipac.firefly.core.background.JobUtil.*;
 import static edu.caltech.ipac.firefly.data.ServerParams.EMAIL;
+import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.getUwsJobInfo;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static edu.caltech.ipac.firefly.core.background.Job.Type.PACKAGE;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase.*;
@@ -109,9 +113,26 @@ public class JobManager {
      */
     public static List<JobInfo> list() {
         List<JobInfo> userJobs = JobManager.getUserJobs();      // Ensure getUserJobs() is called only once, since it may be expensive. List is updated and returned at the end.
+        Set<String> importedJobIds = new HashSet<>();
         UWS_HISTORY_SVCS.forEach(svc -> {
-            Try.it(() -> importJobHistories(svc, userJobs)).getOrElse(LOG::error);
+            Set<String> ids = Try.it(() -> importJobHistories(svc, userJobs)).getOrElse(LOG::error);
+            if (ids != null) importedJobIds.addAll(ids);
         });
+        // update all userJobs with active status
+        userJobs.forEach(ji -> {
+            if (ji.getMeta().getType() == UWS &&
+                    isActive(ji) &&
+                    !importedJobIds.contains(ji.getMeta().getJobId())) {
+                JobInfo uws = Try.it(() -> getUwsJobInfo(ji.getAux().getJobUrl())).get();
+                if (uws == null) {
+                    LOG.debug("Job no longer exists:" + ji.getAux().getJobUrl());
+                    ji.setError(new JobInfo.Error(404, "Job no longer exists"));
+                } else {
+                    mergeJobInfo(ji, uws, null, null);
+                }
+            }
+        });
+
         return userJobs;
     }
 
@@ -153,7 +174,7 @@ public class JobManager {
 
     public static JobInfo abort(String jobId, String reason) {
         JobInfo info = updateJobInfo(jobId, (ji) -> {
-            ji.setError(new JobInfo.Error(410, reason));
+            if (reason != null) ji.setError(new JobInfo.Error(500, reason));
             ji.setPhase(ABORTED);
         });
         if (info != null) {
@@ -465,9 +486,8 @@ public class JobManager {
                 JobEvent.EventType type = Try.it(() -> JobEvent.EventType.valueOf(msg.getValue(null, JobEvent.TYPE))).get();
                 if (type == JobEvent.EventType.ABORTED) {
                     removeLocalJob(jobInfo);
-                } else {
-                    updateClient(jobInfo);        // update jobInfo to client
                 }
+                updateClient(jobInfo);        // update jobInfo to client
             });
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -19,8 +19,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
@@ -93,16 +95,16 @@ public class JobUtil {
      * Import job histories from the given service URL.
      * @param svcDef   the service to import job histories from
      * @param userJobs
-     * @return the number of job histories imported
+     * @return the set of job IDs that were imported
      */
-    public static int importJobHistories(String svcDef, List<JobInfo> userJobs) {
+    public static Set<String> importJobHistories(String svcDef, List<JobInfo> userJobs) {
         int count = 0;
 
         String[] svcParts = ifNotNull(svcDef).getOrElse("").split("\\|", 3);
         String url = svcParts[0].trim();
         String svcId = svcParts.length > 1 ? svcParts[1].trim() : null;
         String svcType = svcParts.length > 2 ? svcParts[2].trim() : null;
-        if (url.isEmpty()) return count;
+        if (url.isEmpty()) return Set.of();
 
         URL urlObs= Try.it(() -> new URI(url).toURL()).getOrElse((URL)null);
         String paramStr= urlObs == null ? "" : urlObs.getQuery();
@@ -121,12 +123,12 @@ public class JobUtil {
             });
            return HttpServices.Status.ok();
         });
-        if (jobList.get() == null || jobList.get().isEmpty()) return count;
+        if (jobList.get() == null || jobList.get().isEmpty()) return Set.of();
 
         // remove jobs with no URL or runId in the ignore list
         boolean hasBadJobs = jobList.get().removeIf(j -> j.getAux().getJobUrl() == null || runIdIgnoreList.contains(String.valueOf(j.getRunId())));
         if (hasBadJobs) LOG.debug("Some jobs with no URL or ignored runId were removed from list");
-
+        HashSet<String> importedIds = new HashSet<>();
         for (JobInfo job : jobList.get()) {
             JobInfo jobInfo = findJobInfo(job.getJobId(), userJobs);
             if (jobInfo == null || isActive(jobInfo)) {
@@ -138,6 +140,7 @@ public class JobUtil {
                     count++;
                     mergeJobInfo(jobInfo, uws, svcId, svcType);
                     if (jobInfo == null )  userJobs.add(uws);           // update passed in userJobs; to avoid having to call getUserJobs, which can be expensive
+                    importedIds.add(uws.getJobId());
                     LOG.trace("Job added jobUrl=%s jobId=%s".formatted(job.getAux().getJobUrl(),uws.getJobId()));
                 }
             } else {
@@ -145,7 +148,7 @@ public class JobUtil {
             }
         }
         LOG.debug("%d job histories imported".formatted(count));
-        return count;
+        return importedIds;     // return imported job IDs to the caller to avoid having to call the uws service again
     }
 
     public static JobInfo mergeJobInfo(JobInfo local, JobInfo uws, String svcId, String svcType) {
@@ -154,7 +157,7 @@ public class JobUtil {
             ji.copyFrom(uws);
             Job.Type type = Try.it(() -> Job.Type.valueOf(svcType)).getOrElse(Job.Type.UWS);
             ji.getMeta().setType(type);
-            ji.getMeta().setSvcId(svcId);
+            if (svcId != null )  ji.getMeta().setSvcId(svcId);
         });
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/ServCmdJob.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/ServCmdJob.java
@@ -9,6 +9,7 @@ import edu.caltech.ipac.firefly.server.ServCommand;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.SrvParam;
 
+import java.time.Instant;
 import java.util.Map;
 
 import static edu.caltech.ipac.firefly.core.background.JobManager.*;
@@ -65,11 +66,15 @@ public abstract class ServCmdJob extends ServCommand implements Job {
         return params;
     }
 
-    public void setWorker(Worker worker) {
-        if (jobId != null) {
+    public void onStart(Worker worker) {
+        if (jobId != null || worker == null) {  // a job must have a jobId and worker
             this.worker = worker;
             worker.setJob(this);
-            sendUpdate(getJobId(), ji -> {      // needs to update clients, because these values may change after the job has submitted
+            updateManagedStatus(ji -> {     // set these only if it's not a self-managed job
+                ji.setPhase(JobInfo.Phase.EXECUTING);
+                ji.getMeta().setProgress(10);
+            });
+            sendUpdate(jobId, ji -> {      // needs to update clients, because these values may change after the job has submitted
                 ji.getMeta().setType(worker.getType());
                 ji.getAux().setTitle(worker.getLabel());
                 ji.getMeta().setSvcId(worker.getSvcId());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -41,6 +41,7 @@ public class AppServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             String spaName = params.getRequired(SPA_NAME);
+            ServerContext.getRequestOwner().extendUserKeyExpiry();
 
             // check for alerts
             AlertsMonitor.checkAlerts(true);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -38,7 +39,7 @@ public class RequestOwner implements Cloneable {
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     public static String USER_KEY = "usrkey";
-    public static int USER_KEY_EXPIRY = AppProperties.getIntProperty("userkey.expiry", 3600 * 24 * 7 * 2);         // 2 weeks
+    public static int USER_KEY_EXPIRY = AppProperties.getIntProperty("userkey.expiry", 3600 * 24 * 365);         // 1 year
     public static final String SET_USERINFO_ACTION = "app_data.setUserInfo";
     private static boolean ignoreAuth = AppProperties.getBooleanProperty("ignore.auth", false);
     private RequestAgent requestAgent;
@@ -98,6 +99,10 @@ public class RequestOwner implements Cloneable {
             usrKey = newUserKey();
             updateClientUserKey(usrKey);
         }
+    }
+
+    public void extendUserKeyExpiry() {
+        ifNotEmpty(getUserKeyFromClient()).apply(this::updateClientUserKey);
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
@@ -193,7 +193,7 @@ public class HttpServices {
         try {
             String url = input.getRequestUrl();
             if (isEmpty(url))  throw new FileNotFoundException("Missing URL parameter");
-            input.setFollowRedirect(false);                                                 // post are not allowed to follow redirect
+            input.setFollowRedirect(false);                                                 // httpclient 3.x, post are not allowed to follow redirect
             return executeMethod(new PostMethod(url), input, handler);
         } catch (Exception e) {
             return new Status(400, e.getMessage());
@@ -232,11 +232,11 @@ public class HttpServices {
         try {
             input = input == null ? new HttpServiceInput() : input;
 
-            method.setRequestHeader("Connection", "close");            // request server to NOT keep-alive.. we don't plan to reuse this connection.
+            method.setRequestHeader("Connection", "close");            // request server to NOT keep-alive. we don't plan to reuse this connection.
             method.setRequestHeader("User-Agent", VersionUtil.getUserAgentString());
             method.setRequestHeader(HttpHeaders.ACCEPT_ENCODING, "gzip");
             if (method instanceof GetMethod) {
-                method.setFollowRedirects(input.isFollowRedirect());    // post are not allowed to follow redirect
+                method.setFollowRedirects(input.isFollowRedirect());    // httpclient 3.x, post are not allowed to follow redirect
             }
 
             HttpClient httpClient = newHttpClient();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchServerCommands.java
@@ -83,7 +83,7 @@ public class SearchServerCommands {
             String format = params.getOptional(FORMAT, "json");
 
             SearchProcessor<?> processor = SearchManager.getProcessor(tsr.getRequestId());
-            if (processor instanceof Job.Worker) setWorker((Job.Worker)processor);
+            onStart(processor instanceof Job.Worker ? (Worker) processor : null);
 
             if (format.toLowerCase().contains("votable")) {
                 ByteArrayOutputStream rval = new ByteArrayOutputStream();
@@ -275,7 +275,7 @@ public class SearchServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             PackagingWorker worker = new PackagingWorker();
-            setWorker(worker);
+            onStart(worker);
             return worker.doCommand(params);
         }
     }
@@ -286,7 +286,7 @@ public class SearchServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             DownloadScriptWorker worker = new DownloadScriptWorker();
-            setWorker(worker);
+            onStart(worker);
             return worker.doCommand(params);
         }
     }
@@ -314,7 +314,7 @@ public class SearchServerCommands {
 
         public String doCommand(SrvParam params) throws Exception {
             String jobId = params.getRequired(JOB_ID);
-            JobInfo info = JobManager.abort(jobId, "Aborted by user");
+            JobInfo info = JobManager.abort(jobId, null);
             return JobUtil.toJson(info);
         }
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -5,6 +5,7 @@ package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.core.background.Job;
 import edu.caltech.ipac.firefly.core.background.JobManager;
+import edu.caltech.ipac.firefly.core.background.JobUtil;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.network.HttpServices;
@@ -33,12 +34,14 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
 import static edu.caltech.ipac.firefly.core.background.JobManager.getJobInfo;
 import static edu.caltech.ipac.firefly.server.network.HttpServices.*;
 import static edu.caltech.ipac.firefly.server.query.DaliUtil.*;
 import static edu.caltech.ipac.util.StringUtils.*;
+import edu.caltech.ipac.firefly.core.Util.Try;
 
 /**
  * Date: Sept 19, 2018
@@ -79,11 +82,31 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
         // send abort request.  ignore if there's error
         if (isEmpty(jobUrl)) return;
         String phaseUrl = jobUrl.trim().replaceAll("/$", "") + "/phase" ;        // remove trailing slash
-        HttpServices.postData(
-                HttpServiceInput.createWithCredential(phaseUrl)
-                        .setParam("PHASE", "ABORT")
+        Status status = HttpServices.postData(HttpServiceInput.createWithCredential(phaseUrl).setParam("PHASE", "ABORT"),
+                res -> {
+                    String location = getResHeader(res, "Location", null);      // expecting a 303 redirect to the job URL
+                    if (location == null) {
+                        String error = ifNotEmpty(parseError(res, phaseUrl)).getOrElse("Unknown error");
+                        int errorCode = isOk(res) ? 400 : res.getStatusCode();
+                        return new Status(errorCode, "Failed to abort: " + error);
+                    } else {
+                        JobInfo jobInfo = Try.it(() -> getUwsJobInfo(jobUrl)).get();
+                        if (jobInfo == null || JobUtil.isActive(jobInfo)) {
+                            String msg = ifNotNull(jobInfo.getError().msg()).getOrElse("Job cannot be aborted");
+                            return new Status(400, "Failed to abort: %s".formatted(msg) );
+                        }
+                        return Status.ok();         // aborted or no longer active
+                    }
+                }
         );
-        Logger.getLogger().debug("UWS job aborted: " + jobUrl);
+        if (status.isError()) {
+            logger.warn(status.getErrMsg());
+            sendJobUpdate(ji -> {
+                ji.setError(new JobInfo.Error(status.getStatusCode(), status.getErrMsg()));
+            });
+        } else {
+            logger.info("UWS job aborted: " + jobUrl);
+        }
     }
 
 //====================================================================
@@ -104,8 +127,8 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                 jobUrl = submitJob(req);
                 if (jobUrl != null) runJob(jobUrl);
                 updateJob(ji -> {
-                    ji.setPhase(Phase.PENDING);
-                    ji.getMeta().setProgress(10, "UWS job submitted");
+                    ji.setPhase(Phase.QUEUED);
+                    ji.getMeta().setProgress(0, "UWS job submitted");
                 });
             }
         } catch (Exception e) {
@@ -141,9 +164,9 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                 } else if (phase == Phase.HELD) {
                     updateJob(ji -> ji.setPhase(Phase.HELD));
                     throw new DataAccessException("The job is HELD pending execution and will not automatically be executed");
-                } else if (phase == Phase.SUSPENDED) {
-                    updateJob(ji -> ji.setPhase(Phase.SUSPENDED));
-                    throw new DataAccessException("Job temporarily paused by the system");
+                } else if (phase == Phase.PENDING) {
+                    updateJob(ji -> ji.setPhase(Phase.PENDING));
+                    throw new DataAccessException("The job was submitted, but no execution request has been made.");
                 } else if (phase == Phase.ERROR) {
                     JobInfo.Error error = getError(uwsJob, jobUrl);
                     updateJob(ji -> ji.setError(error));

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -160,7 +160,7 @@ function bgJobRemove(action) {
     return (dispatch) => {
         const {jobId} = action.payload;
         if (jobId) {
-            SearchServices.cancel(jobId);
+            // SearchServices.cancel(jobId);
             SearchServices.removeBgJob(jobId);
             dispatch(action);
         }

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -248,7 +248,8 @@ function PhaseRenderer({cellInfo}) {
 
 function ControlRenderer({cellInfo}) {
     const {value:jobId} = cellInfo;
-    const job = useStoreConnector(() => getJobInfo(jobId), [jobId]);
+    const job = getJobInfo(jobId);
+    // const job = useStoreConnector(() => getJobInfo(jobId), [jobId]);
     if (!job?.meta?.jobId) return null;
 
     return  (
@@ -271,7 +272,7 @@ function Delete({job}) {
     const title = job?.jobInfo?.title || job.jobId;
     if (isDone(job)) {
         return <IconButton  title={`Delete job ${job?.meta?.jobId}`} color='danger' onClick={doDelete}><DeleteOutlineOutlinedIcon/></IconButton>;
-    } else if (isExecuting(job)) {
+    } else if (isActive(job)) {
         return <IconButton  title={`Abort job ${title}`} color='danger' onClick={() => dispatchJobCancel(job?.meta?.jobId)}><StopCircleOutlinedIcon/></IconButton>;
     }
 }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1829
- Confirmed that `/phase?PHASE=ABORT` was already being sent to the backend UWS service.
- Added error handling to report cases where a job fails to abort.
- Fixed an issue where multiple clicks were required for the abort action to take effect.
- Extended UserKey expiration time to 1 year.

Test: https://firefly-1829-job-cancel.irsakudev.ipac.caltech.edu/applications/spherex/
Test `Abort` functionality:
- SPHEREx Spectrometry Tool (UWS-based)
  - Submit a job and verify that the Abort action correctly cancels the job.
  - Ensure the UI reflects the aborted state without requiring multiple clicks.
- IRSA TAP Service
  - Submit a TAP job and then attempt to abort.
  - Expected Result: Abort will fail, since IRSA TAP does not support abort. Confirm that an error is reported.
- Other TAP Providers (e.g., CADC)
  - Submit a job to another TAP service such as CADC.
  - Test abort functionality.
- IRSA Catalog Service
  - Submit a job and then abort the job.
  - Expected Result: Even though it is not UWS-based, abort should succeed without issue.