### PR TITLE
FIREFLY-1343: Enable tooltip text for ADQL JOINs

### DIFF
--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -530,18 +530,21 @@ async function addAvailKeyNodes({serviceUrl, title, cols, treeData, setTreeData}
     });
 }
 
-function JoinNode({targetTable, keyId, desc, treeData, setTreeData}) {
+function JoinNode({ targetTable, keyId, desc, treeData, setTreeData }) {
+    const text = `${targetTable} [${keyId}]${desc ?? ''}`;
 
     const jumpTo = useCallback(() => {
         const nodeKey = searchNodeBy(treeData, (n) => n.title === targetTable);
-        if (nodeKey) {
-            const nTree = updateSet(treeData, 'expandedKeys', treeData.expandedKeys.push(nodeKey));
-            setTreeData(nTree);
-        }
-    });
-    // <img src={INFO_ICO} onClick={jumpTo} style={{height:16, verticalAlign:'middle'}}/>  // can't get it to work.
-    return <div>{targetTable} [{keyId}]{desc}</div>;
+        if (!nodeKey) return;
+        const nTree = updateSet(treeData, 'expandedKeys', treeData.expandedKeys.push(nodeKey));
+        setTreeData(nTree);
+    }, [treeData, setTreeData, targetTable]);
+
+    return (
+        <span title={text}>{text}</span>
+    );
 }
+
 
 function addChildNodes(data, key, children) {
     for (let idx = 0; idx < data.length; idx++) {


### PR DESCRIPTION
**Ticket**: [Firefly-1343](https://jira.ipac.caltech.edu/browse/FIREFLY-1343)
- enable the tooltip (mouse over) text for ADQL joins 
- the tooltip will match the exact text (not the ADQL query text) 

**Testing:**
Firefly: https://fireflydev.ipac.caltech.edu/firefly-1343-adql-mouseover/firefly
- Go to TAP -> Edit ADQL -> Under `Schema Browser`, expand `TAP_SCEMA` (or anywhere else you'd expect to see `JOINs Available`)
- Here, under `JOINs Available`, the tooltip should now work for the available joins