### PR TITLE
FIREFLY-1841: MultiSpectrum file intermittently fails to load in multi-instance deployments

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/SrvParam.java
@@ -9,6 +9,7 @@ package edu.caltech.ipac.firefly.server;
 
 import edu.caltech.ipac.firefly.data.DownloadRequest;
 import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.messaging.JsonHelper;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
@@ -380,6 +381,18 @@ public class SrvParam {
 //====================================================================
 //  Table related convenience methods
 //====================================================================
+
+    /**
+     * @return a ServerRequest object built from the parameters in this SrvParam object
+     */
+    public ServerRequest convertToServerRequest() {
+        ServerRequest sr = new ServerRequest();
+        for(Map.Entry<String,String[]> entry : paramMap.entrySet()) {
+            sr.setParam(entry.getKey(), entry.getValue());
+        }
+        return sr;
+    }
+
     public TableServerRequest getTableServerRequest() {
         String reqString = getRequired(ServerParams.REQUEST);
         return QueryUtil.convertToServerRequest(reqString);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessor.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.data.sofia.VOSpectraModel.SPECTRADM_UTYPE;
+import static edu.caltech.ipac.firefly.server.util.QueryUtil.*;
 import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
@@ -68,7 +69,7 @@ public class MultiSpectrumProcessor extends EmbeddedDbProcessor {
             ifNotEmpty(treq.getParam(RequestOwner.USER_KEY)).apply((uk) -> ServerContext.getRequestOwner().setUserKey(uk));
             updateJob(ji -> ji.getAux().setJobUrl(source));
 
-            File inFile = QueryUtil.resolveFileFromSource(source, treq);
+            File inFile = QueryUtil.resolveFileFromSource(source, true, tmpFileForUrl(source, treq.getRequestId() + "_", getSessUploadDir(treq)));
             DataGroup table = TableUtil.readAnyFormat(inFile);
 
             setJobResults(inFile);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AnyFileUpload.java
@@ -12,7 +12,6 @@ import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.SrvParam;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.firefly.server.util.multipart.UploadFileInfo;
-import edu.caltech.ipac.firefly.server.visualize.LockingVisNetwork;
 import edu.caltech.ipac.firefly.server.visualize.PlotServUtils;
 import edu.caltech.ipac.firefly.server.visualize.ProgressStat;
 import edu.caltech.ipac.firefly.server.visualize.imageretrieve.FileRetriever;
@@ -34,9 +33,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+
+import static edu.caltech.ipac.firefly.server.util.QueryUtil.*;
 
 /**
  * Date: Feb 16, 2011
@@ -94,7 +94,7 @@ public class AnyFileUpload extends BaseHttpServlet {
         SrvParam sp = new SrvParam(req.getParameterMap());
 
         if (ServletFileUpload.isMultipartContent(req)) {        // this is a multipart request.. extract params from parts
-            ServletFileUpload upload = new ServletFileUpload( new DiskFileItemFactory(64 * 1024, ServerContext.getUploadDir()));        // set factory to raise in-memory usage
+            ServletFileUpload upload = new ServletFileUpload( new DiskFileItemFactory(64 * 1024, getUploadDir("tmpDiskStore")));        // set factory to raise in-memory usage
             for (FileItemIterator iter = upload.getItemIterator(req); iter.hasNext(); ) {
                 FileItemStream item = iter.next();
                 if (item.isFormField()) {
@@ -243,10 +243,8 @@ public class AnyFileUpload extends BaseHttpServlet {
                 fname= (statusFileInfo.getFile()!=null) ? statusFileInfo.getFile().getName() : null;
             }
             else {
-                int idx = fromUrl.lastIndexOf('/');
-                fname = (idx >= 0) ? fromUrl.substring(idx + 1) : fromUrl;
-                fname = fname.contains("?") ? "Upload-"+System.currentTimeMillis() : fname;       // don't save queryString as file name.  this will confuse reader expecting a url, like VoTableReader
-                statusFileInfo = LockingVisNetwork.retrieveURL(new URL(fromUrl));
+                statusFileInfo = fetchFile(fromUrl, sp);
+                fname = statusFileInfo.getExternalName();
             }
             if (isUrlFail(statusFileInfo)) throw new Exception(codeFailMsg(statusFileInfo.getResponseCode()));
             uploadFileInfo= makeUploadFileInfo(statusFileInfo,fname);
@@ -267,7 +265,7 @@ public class AnyFileUpload extends BaseHttpServlet {
         } else if (uploadedItem != null) {
             // it's a stream from multipart.. write it to disk
             String name = uploadedItem.getName();
-            File tmpFile = File.createTempFile("upload_", "_" + name, ServerContext.getUploadDir());
+            File tmpFile = File.createTempFile("upload_", "_" + name, getSessUploadDir(sp.convertToServerRequest()));
             FileUtil.writeToFile(uploadedItem.openStream(), tmpFile, (current) -> updateFeedback(name, current));
             uploadFileInfo = new UploadFileInfo(ServerContext.replaceWithPrefix(tmpFile), tmpFile, name, uploadedItem.getContentType());
             statusFileInfo= new FileInfo(uploadFileInfo.getFile());
@@ -278,6 +276,17 @@ public class AnyFileUpload extends BaseHttpServlet {
         return new Result(statusFileInfo,uploadFileInfo);
     }
 
+    private static FileInfo fetchFile(String fromUrl, SrvParam sp) {
+        try {
+            return new FileInfo(resolveFileFromSource(
+                    fromUrl,
+                    true,
+                    tmpFileForUrl(fromUrl, "fromUrl_", getSessUploadDir(sp.convertToServerRequest()))
+            ));
+        } catch (Exception e) {
+            return new FileInfo(null, "", 400, e.getMessage());
+        }
+    }
 
     private static class Result {
         final FileInfo statusFileInfo;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -8,6 +8,7 @@ import edu.caltech.ipac.astro.net.TargetNetwork;
 import edu.caltech.ipac.astro.target.IpacTableTargetsParser;
 import edu.caltech.ipac.astro.target.TargetFixedSingle;
 import edu.caltech.ipac.firefly.core.EndUserException;
+import edu.caltech.ipac.firefly.core.Util;
 import edu.caltech.ipac.firefly.core.background.JobUtil;
 import edu.caltech.ipac.firefly.data.CatalogRequest;
 import edu.caltech.ipac.firefly.data.DecimateInfo;
@@ -98,7 +99,23 @@ public class QueryUtil {
     }
 
     /**
-     * returns a hierarchical temporary directory.
+     * @return a hierarchical upload directory based on the user's session ID.
+     */
+    public static File getSessUploadDir(ServerRequest tsr) {
+        return getUploadDir(getSessPrefix(tsr));
+    }
+
+    /**
+     * @return returns a subdirectory under the main upload directory.  The directory is created if it does not exist.
+     */
+    public static File getUploadDir(String subDir) {
+        File dir = new File(ServerContext.getUploadDir(), subDir);
+        dir.mkdirs();
+        return dir;
+    }
+
+    /**
+     * returns a hierarchical temporary directory. If the request is part of a job, then the job work dir is returned.
      * @return
      */
     public static File getTempDir(TableServerRequest tsr) {
@@ -130,15 +147,22 @@ public class QueryUtil {
         return sessId.substring(0, 3);
     }
 
+    public static File resolveFileFromSource(String source,TableServerRequest request) throws DataAccessException {
+        return resolveFileFromSource(source,
+                request.getBooleanParam(URL_CHECK_FOR_NEWER, true),
+                tmpFileForUrl(source, request.getRequestId() + "_", QueryUtil.getTempDir(request))
+        );
+    }
 
     /**
-     * resolve the file given a 'source' string.  it could be a local path, or a url.
-     * if it's a url, download it into the application's workarea
+     * resolve the file given a 'source' string.  it could be a local path, or a URL.
+     * if it's a URL, download it into the application's workarea
      * @param source source file
-     * @param request table request
+     * @param checkForUpdates check for updates if the source is a URL and the file has been cached.
+     * @param outFile a file to save the downloaded file.  it will be called only if the source is a URL.
      * @return file
      */
-    public static File resolveFileFromSource(String source,TableServerRequest request) throws DataAccessException {
+    public static File resolveFileFromSource(String source, boolean checkForUpdates, File outFile) throws DataAccessException {
         if (source == null) return null;
         try {
             URL url = makeUrl(source);
@@ -150,28 +174,27 @@ public class QueryUtil {
 
                 return f;
             } else {
-                boolean checkForUpdates = request.getBooleanParam(URL_CHECK_FOR_NEWER, true);
                 HttpServiceInput inputs = new HttpServiceInput(url.toString());
                 StringKey key = new StringKey(inputs.getUniqueKey());
                 File res  = (File) CacheManager.getCache().get(key);
-                String ext = FileUtil.getExtension(url.getPath().replaceFirst("^.*/", ""));
-                ext = isEmpty(ext) ? ".ul" : "." + ext;
-                File nFile = File.createTempFile(request.getRequestId(), ext, QueryUtil.getTempDir(request));
+                if (outFile == null) {
+                    throw new DataAccessException("Disk Error: Failed to create temporary file");       // should not happen
+                }
 
                 if (res == null) {
-                    FileInfo finfo = URLDownload.getDataToFile(url, nFile, inputs.getCookies(), inputs.getHeaders(),
+                    FileInfo finfo = URLDownload.getDataToFile(url, outFile, inputs.getCookies(), inputs.getHeaders(),
                             URLDownload.Options.defWithRedirect());
                     checkForFailures(finfo);
-                    res = nFile;
+                    res = outFile;
                     CacheManager.getCache().put(key, res);
                 } else if (checkForUpdates) {
-                    FileUtil.writeStringToFile(nFile, "workaround");
-                    nFile.setLastModified(res.lastModified());
+                    FileUtil.writeStringToFile(outFile, "workaround");
+                    outFile.setLastModified(res.lastModified());
                     URLDownload.Options ops= URLDownload.Options.modifiedOp(false);
-                    FileInfo finfo = URLDownload.getDataToFile(url, nFile, inputs.getCookies(), inputs.getHeaders(), ops);
+                    FileInfo finfo = URLDownload.getDataToFile(url, outFile, inputs.getCookies(), inputs.getHeaders(), ops);
                     if (finfo.getResponseCode() != HttpURLConnection.HTTP_NOT_MODIFIED) {
                         checkForFailures(finfo);
-                        res = nFile;
+                        res = outFile;
                         CacheManager.getCache().put(key, res);
                     }
                 }
@@ -182,6 +205,19 @@ public class QueryUtil {
         } catch (Exception ex) {
             throw new DataAccessException(ex.getMessage());
         }
+    }
+
+    /**
+     * @param urlStr  the URL string
+     * @param prefix  the prefix of the temporary file
+     * @param dir  the directory to create the temporary file
+     * @return a temporary file used to download a URL.  The file extension is based on the URL's file extension, or .ul if none
+     */
+    public static File tmpFileForUrl(String urlStr, String prefix, File dir) {
+        URL url = makeUrl(urlStr);
+        String pExt = url == null ? null : FileUtil.getExtension(url.getPath().replaceFirst("^.*/", ""), true);
+        String ext = isEmpty(pExt) ? ".ul" : "." + pExt;
+        return Util.Try.it(() -> File.createTempFile(prefix, ext, dir)).get();
     }
 
     public static String combineErrorMsg(String main, String cause) {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1841

**Changes**
- Fixed `AnyFileUpload` so uploaded files are saved correctly in the shared upload directory.
- The upload directory is now shared across all deployment instances, ensuring consistent access.

**Test**
https://firefly-1841-multispectrum-multiple-instances.irsakudev.ipac.caltech.edu/irsaviewer/
(This deployment is running with 3 instances)

Steps to reproduce:
1. Go to **Upload → Upload From URL**.
2. Enter: https://irsa.ipac.caltech.edu/api/spherex/spectrophotometry/async/25a18090-ec2c-42ce-9394-aaf9ed463729/results/phot-tool-result.vot
3. Click **Load**.

Expected:
- The file loads successfully every time.
- In IRSA OPS (multi-instance), the same action may fail intermittently without this fix.
