### PR TITLE
Firefly-1848: support FITS bz2 & SDSS dr 17

### DIFF
--- a/buildScript/dependencies.gradle
+++ b/buildScript/dependencies.gradle
@@ -35,7 +35,7 @@ dependencies {
     // ============== from maven central ===============
 
     // apache commons
-    implementation 'commons-fileupload:commons-fileupload:1.2.2', 'commons-io:commons-io:2.4', 'commons-lang:commons-lang:2.2', 'org.apache.commons:commons-csv:1.0'
+    implementation 'commons-fileupload:commons-fileupload:1.2.2', 'commons-io:commons-io:2.4', 'commons-lang:commons-lang:2.2', 'org.apache.commons:commons-csv:1.0', 'org.apache.commons:commons-compress:1.28.0'
 
     // axis  Web Services SOAP
     implementation 'axis:axis:1.4'

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsEvaluation.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/FitsEvaluation.java
@@ -37,7 +37,7 @@ public class FitsEvaluation {
         FitsReadUtil.UncompressFitsInfo uFitsInfo= null;
         try  {
             BasicHDU<?>[] HDUs= fits.read();
-            if (FileUtil.isGZipFile(f) || FitsReadUtil.hasCompressedImageHDUS(HDUs)) {
+            if (FileUtil.isBz2OrGzipFile(f) || FitsReadUtil.hasCompressedImageHDUS(HDUs)) {
                 uFitsInfo = FitsReadUtil.createdUncompressVersionOfFile(HDUs,f);
             }
 

--- a/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
+++ b/src/firefly/java/edu/caltech/ipac/table/DataGroup.java
@@ -256,6 +256,8 @@ public class DataGroup implements Serializable, Cloneable, Iterable<DataObject> 
         return size;
     }
 
+    public boolean isEmpty() {return size()==0;}
+
     public void setSize(int size) {
         this.size = size;
     }

--- a/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FileUtil.java
@@ -19,6 +19,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
@@ -48,6 +49,7 @@ public class FileUtil
     public final static String FIT  = "fit";
     public final static String FITS = "fits";
     public final static String GZ   = "gz";
+    public final static String BZ2   = "bz2";
     public final static String PS   = "ps";
     public final static String PDF  = "pdf";
     public final static String HTML = "html";
@@ -84,19 +86,37 @@ public class FileUtil
 
   private final static String  ADD_START= "---";
 
+
+    /**
+     * Get the extension of a filename.
+     * @param  s a file name such as <code>a.dat</code> or <code>a.dat.gz</code>
+     * @param useCompressFullExt - if true and the file is compress with a gz, bz2 or zip extension
+     *                           then return the two part extension such as <code>dat.gz</code>. A false would return
+     *                           <code>gz</code>
+     * @return String the extension of the file. An empty string is returned if there is no extension;
+     */
+    public static String getExtension(String s, boolean useCompressFullExt) {
+        if (!useCompressFullExt) return getExtension(s);;
+        var lastExtension= getExtension(s);
+        if (lastExtension.isEmpty()) return "";
+        if (Arrays.asList(BZ2, GZ, ZIP).contains(lastExtension)) {
+            var firstExt= getExtension(getBase(s));
+            if (!firstExt.isEmpty()) return firstExt+"."+lastExtension;
+        }
+        return lastExtension;
+    }
+
     /**
      * Get the extension of a filename.
      * @param  s a file name such as <code>a.dat</code>
-     * @return String the extension of the file.
-     *                A null is returned if there is no extension;
+     * @return String the extension of the file. An empty string is returned if there is no extension;
      *
      */
   public static String getExtension(String s)
   {
     String ext = "";
     int i = s.lastIndexOf('.');
-    if (i > 0 &&  i < s.length() - 1)
-    {
+    if (i > 0 &&  i < s.length() - 1) {
       ext = s.substring(i+1).toLowerCase();
     }
     return ext;
@@ -105,14 +125,23 @@ public class FileUtil
     /**
      * Get the extension of a file.
      * @param  f a file such as <code>a.dat</code>
-     * @return String the extension of the file.
-     *                A null is returned if there is no extension
-     *
+     * @return String the extension of the file. An empty string is returned if there is no extension;
      */
-  public static String getExtension(File f)
-  {
-    return getExtension(f.getName());
-  }
+    public static String getExtension(File f) { return getExtension(f,false); }
+
+
+    /**
+     * Get the extension of a filename.
+     * @param  f a file name such as <code>a.dat</code> or <code>a.dat.gz</code>
+     * @param useCompressFullExt - if true and the file is compress with a gz, bz2 or zip extension
+     *                           then return the two part extension such as <code>dat.gz</code>. A false would return
+     *                           <code>gz</code>
+     * @return String the extension of the file. An empty string is returned if there is no extension;
+     */
+    public static String getExtension(File f, boolean useCompressFullExt) {
+        return f==null ? "" : getExtension(f.getName(), useCompressFullExt);
+    }
+
 
     public static boolean isExtension(File f, String ext) {
         return isExtension(f.getName(),ext);
@@ -472,9 +501,8 @@ public class FileUtil
             int b1 = is.read();
             is.reset();
 
-            if (b0 == -1 || b1 == -1) {
-                return false; // too short
-            }
+            if (b0 == -1 || b1 == -1) return false; // too short
+
             int value = (b1 << 8) | b0;
             return (value == GZIPInputStream.GZIP_MAGIC); //0x8b1f
         } catch (IOException e) {
@@ -488,6 +516,42 @@ public class FileUtil
         } catch (IOException e) {
             return false;
         }
+    }
+
+    public static boolean isBz2File(InputStream is) {
+        if (!is.markSupported()) {
+            //to ensure mark and reset works
+            is = new BufferedInputStream(is);
+        }
+        try {
+            is.mark(3);
+            byte[] bAry= {(byte)is.read(), (byte)is.read(), (byte)is.read()} ;
+            is.reset();
+
+            if (bAry[0] == -1 || bAry[1] == -1 || bAry[2] == -1) return false; // too short
+
+            String magicStr= new String(bAry,0,3);
+            return "BZh".equals(magicStr);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    public static boolean isBz2File(File f) {
+        try (InputStream in = new BufferedInputStream(new FileInputStream(f))) {
+            return isBz2File(in);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    public static boolean isBz2OrGzipFile(File f) {
+        try (InputStream in = new BufferedInputStream(new FileInputStream(f))) {
+            return isBz2File(in) || isGZipFile(in);
+        } catch (IOException e) {
+            return false;
+        }
+
     }
 
 

--- a/src/firefly/java/edu/caltech/ipac/util/FormatUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FormatUtil.java
@@ -10,7 +10,8 @@ package edu.caltech.ipac.util;
 import edu.caltech.ipac.firefly.server.db.DuckDbAdapter;
 import edu.caltech.ipac.firefly.server.db.DuckDbReadable;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import edu.caltech.ipac.table.DataGroup;
+import nom.tam.fits.Fits;
+import nom.tam.fits.FitsException;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
@@ -99,6 +100,17 @@ public class FormatUtil {
         if (format != null) {
             LOGGER.debug("Format: %s resolved via mime-type/magic number".formatted(format));
             return format;
+        }
+
+
+        if (("application/x-bzip2".equals(mime) || "application/x-gzip".equals(mime)) &&
+                inFile.getName().toLowerCase().contains("fit")) {
+            // special case and a very heavy operation: we can handle fits bz2 or gzip files but don't try unless we are pretty sure
+            // in archives: legacy files are often named a.fits.gz or a.fits.bz2
+            try (var ignored = new Fits(inFile)) {
+                return FITS;
+            }
+            catch (FitsException ignore) {}
         }
 
         format = guessBySamplingContent(inFile);

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/AnyUrlParams.java
@@ -19,7 +19,8 @@ public class AnyUrlParams extends BaseNetParams {
             Arrays.asList(
                     "ul", FileUtil.FITS, FileUtil.GZ, FileUtil.TAR, FileUtil.PDF, FileUtil.GZ, FileUtil.REG,
                     "votable", FileUtil.VOT, FileUtil.XML, FileUtil.TBL, FileUtil.CSV, FileUtil.TSV, FileUtil.TXT,
-                    FileUtil.jpeg, FileUtil.jpg, FileUtil.png, FileUtil.bmp, FileUtil.gif, FileUtil.tiff, FileUtil.tif);
+                    FileUtil.jpeg, FileUtil.jpg, FileUtil.png, FileUtil.bmp, FileUtil.gif, FileUtil.tiff, FileUtil.tif,
+                    FileUtil.FITS+"."+FileUtil.GZ, FileUtil.FITS+"."+FileUtil.BZ2);
 
     private final static int MAX_LENGTH = 30;
     private final URL _url;
@@ -84,7 +85,7 @@ public class AnyUrlParams extends BaseNetParams {
         }
         //note: "=","," signs causes problem in download servlet.
         retval = retval.replaceAll("[ :\\[\\]\\/\\\\|\\*\\?<>\\=\\,]","\\-");
-        String ext= FileUtil.getExtension(fileStr);
+        String ext= FileUtil.getExtension(fileStr,true);
         var fileExt= _localFileExtensions.contains(ext) ? ext : _localFileExtensions.getFirst();
         return retval + "." + fileExt;
     }

--- a/src/firefly/java/edu/caltech/ipac/visualize/net/SloanDssImageGetter.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/net/SloanDssImageGetter.java
@@ -3,7 +3,6 @@
  */
 package edu.caltech.ipac.visualize.net;
 
-
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.io.VoTableReader;
@@ -16,58 +15,54 @@ import edu.caltech.ipac.visualize.plot.WorldPt;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
-/**
- * @author Trey Roby
- * @version $Id: SloanDssImageGetter.java,v 1.4 2012/08/21 21:30:41 roby Exp $
- */
 public class SloanDssImageGetter {
 
     private static final String server = AppProperties.getProperty("sdss.host", "https://skyserver.sdss.org");
-    private static final String cgiapp = "/vo/dr7siap/siap.asmx/getSiapInfo";
+    private static final String RELEASE= "17";
+    private static final String path = "/vo/dr"+RELEASE+"siap/siap.asmx/getSiapInfo";
+    private static final String NOT_COVERED=  String.format("SDSS (dr%s): Area not covered", RELEASE);
+    private static final String NOT_COVERED_DETAIL =  "votable returned not results, probably area is not covered: ";
+    private static final String SDSS_SRV_ERR= "The SDSS server is reporting a severe error: %s (%d)";
 
     public static FileInfo get(SloanDssImageParams params, File outFile) throws FailedRequestException, IOException {
         try {
-            String req = makeSDssRequest(params);
+            URL url= new URI(makeSDssRequest(params)).toURL();
             SloanDssImageParams qParam= params.makeQueryKey();
-            File  f= CacheHelper.makeFile(qParam.getUniqueString() + ".xml");
-            FileInfo fi= URLDownload.getDataToFile(new URL(req), f);
+            FileInfo fi= URLDownload.getDataToFile(url, CacheHelper.makeFile(qParam.getUniqueString() + ".xml"));
             if (fi.getResponseCode()!=200) {
-                String htmlErr= f.canRead() ? FileUtil.readFile(f) : "Sloan DSS Image Error";
-                throw new FailedRequestException( htmlErr, "The SDss server is reporting an error", null);
+                var detail= String.format(SDSS_SRV_ERR, fi.getResponseCodeMsg(), fi.getResponseCode());
+                throw new FailedRequestException( getHtmlErr(fi.getFile(), detail), detail);
             }
-            DataGroup[] dgAry= VoTableReader.voToDataGroups(f.getAbsolutePath());
-            DataGroup dataGroup= dgAry[0];
-            if (dataGroup.size() >0) {
-                URLDownload.getDataToFile(new URL((String)dataGroup.get(0).getDataElement("url")), outFile);
-                return new FileInfo(outFile);
-            }
-            else {
-                throw new FailedRequestException("SDSS: Area not covered",
-                        "votable returned not results, probably area is not covered: ");
-            }
+            DataGroup dataGroup= VoTableReader.voToDataGroups(fi.getFile().getPath())[0]; // should only be one but get first
+            if (dataGroup.isEmpty()) throw new FailedRequestException(NOT_COVERED, NOT_COVERED_DETAIL);
+            URL imageUrl= new URI(dataGroup.get(0).getStringData("url")).toURL();
+            return URLDownload.getDataToFile(imageUrl, outFile);
         } catch (SocketTimeoutException timeOutE) {
-            if (outFile.exists() && outFile.canWrite()) outFile.delete();
+            if (outFile.canWrite()) outFile.delete();
             throw timeOutE;
-        } catch (MalformedURLException me) {
+        } catch (URISyntaxException me) {
             throw new FailedRequestException( "Invalid URL", "Details in exception", me );
         }
-
     }
 
     private static String makeSDssRequest(SloanDssImageParams params) {
-        return server + cgiapp +
+        return server + path +
                 "?POS=" + params.getRaJ2000String() + "," + params.getDecJ2000String() +
                 "&size=" + params.getSizeInDeg() +
                 "&bandpass=" + params.getBand().toString().toLowerCase() +
                 "&format=image/fits";
     }
 
+    private static String getHtmlErr(File f, String detail) throws IOException {
+        return f.canRead() ? FileUtil.readFile(f) : detail;
+    }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         SloanDssImageParams params = new SloanDssImageParams("test", "test");
         params.setSizeInDeg(0.1F);
         params.setBand(SloanDssImageParams.SDSSBand.r);

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -98,9 +98,13 @@ public class FitsReadUtil {
             throws IOException {
         String fBase= FileUtil.getBase(originalFile);
         String dir= originalFile.getParent();
-        var gzType= FileUtil.isGZipFile(originalFile) ? "---gzip" : "";
+        var compressType= FileUtil.isGZipFile(originalFile)
+                ? "---gzip"
+                : FileUtil.isBz2OrGzipFile(originalFile)
+                ? "---bz2"
+                : "";
         var hduType=  FitsReadUtil.hasCompressedImageHDUS(HDUs) ? "---hdu" : "";
-        File retFile= new File(dir+"/"+ fBase+gzType+hduType+"-uncompressed"+".fits");
+        File retFile= new File(dir+"/"+ fBase+compressType+hduType+"-uncompressed"+".fits");
         Fits fits= new Fits();
         for (BasicHDU<?> hdu : HDUs) {
             fits.addHDU( hdu instanceof CompressedImageHDU ?  ((CompressedImageHDU) hdu).asImageHDU() : hdu );


### PR DESCRIPTION
#### [ Firefly-1848](https://jira.ipac.caltech.edu/browse/FIREFLY-1848): Support FITS bz2 & SDSS dr 17

 -  [ Firefly-1848](https://jira.ipac.caltech.edu/browse/FIREFLY-1848): bz2
 -  [ Firefly-593](https://jira.ipac.caltech.edu/browse/FIREFLY-593): SDSS
 - jars changes
   - upgrade commons-io to 2.4 -0
   - add 'org.apache.commons:commons-compress:1.28.0'
 - recognize bz2 file and load
 - support in upload panel via FileAnalysis (FormatUtil.java)


#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1848-bz2/firefly
- Test 1: from upload panel: https://dr9.sdss.org/sas/dr9/boss/photoObj/frames/301/3367/4/frame-r-003367-4-0077.fits.bz2
- Test 2: do SDSS search in image panel