### PR TITLE
IRSA-7251 SPHEREx bug fixes

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/EmailNotification.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/EmailNotification.java
@@ -109,7 +109,7 @@ public class EmailNotification implements JobCompletedHandler {
                 String sugName = ifNotNull(jobInfo.getAux().getTitle()).getOrElse("Download");
                 String curlScript = getDownloadURL(makeScript(jobInfo, Curl), makeScriptFilename(Curl, sugName), jobInfo.getMeta().getAppUrl());
                 String wgetScript = getDownloadURL(makeScript(jobInfo, Wget), makeScriptFilename(Wget, sugName), jobInfo.getMeta().getAppUrl());
-                String directUrls = getDownloadURL(makeScript(jobInfo, ScriptAttributes.URLsOnly), makeScriptFilename(URLsOnly, sugName), jobInfo.getMeta().getAppUrl());
+                String directUrls = getDownloadURL(makeScript(jobInfo, ScriptAttributes.URLList), makeScriptFilename(URLList, sugName), jobInfo.getMeta().getAppUrl());
                 String msg = zipSuccess.formatted(name, curlScript, wgetScript, directUrls, contact);
                 EMailUtil.sendMessage(new String[]{email}, null, null, subject, msg);
             } catch (Exception e) {
@@ -118,7 +118,7 @@ public class EmailNotification implements JobCompletedHandler {
 
         } else if (type == Job.Type.SCRIPT) {
 
-            String msg = success.formatted(name, getUrl(jobInfo, Curl), getUrl(jobInfo, Wget), getUrl(jobInfo, URLsOnly), contact);
+            String msg = success.formatted(name, getUrl(jobInfo, Curl), getUrl(jobInfo, Wget), getUrl(jobInfo, URLList), contact);
             Try.it(() -> EMailUtil.sendMessage(new String[]{email}, null, null, subject, msg))
                     .getOrElse(e -> Logger.getLogger().error(e));
         } else {
@@ -130,7 +130,7 @@ public class EmailNotification implements JobCompletedHandler {
     }
 
     public static String getUrl(JobInfo jobInfo, ScriptAttributes type) {
-        String matcher = type == URLsOnly ? "list" : type.name().toLowerCase();
+        String matcher = type == URLList ? "list" : type.name().toLowerCase();
         return jobInfo.getResults().stream()
                 .filter(r -> r.id().contains(matcher))
                 .map(r -> r.href()).findFirst().orElse(null);

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/ScriptAttributes.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/ScriptAttributes.java
@@ -12,5 +12,5 @@ package edu.caltech.ipac.firefly.core.background;
 /**
 * @author Trey Roby
 */
-public enum ScriptAttributes {URLsOnly, Unzip, Curl, Wget}
+public enum ScriptAttributes {URLList, Unzip, Curl, Wget}
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
@@ -4,10 +4,8 @@
 
 package edu.caltech.ipac.firefly.server.packagedata;
 
-import java.io.File;
-import java.util.*;
-import java.util.function.Function;
-
+import edu.caltech.ipac.firefly.core.background.Job;
+import edu.caltech.ipac.firefly.core.background.JobInfo;
 import edu.caltech.ipac.firefly.core.background.JobUtil;
 import edu.caltech.ipac.firefly.core.background.ScriptAttributes;
 import edu.caltech.ipac.firefly.data.DownloadRequest;
@@ -20,17 +18,17 @@ import edu.caltech.ipac.firefly.server.util.DownloadScript;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.ws.WsServerParams;
 import edu.caltech.ipac.firefly.server.ws.WsServerUtils;
-import edu.caltech.ipac.firefly.core.background.Job;
-import edu.caltech.ipac.firefly.core.background.JobInfo;
+
+import java.io.File;
+import java.util.List;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
-import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
+import static edu.caltech.ipac.firefly.core.Util.Try;
 import static edu.caltech.ipac.firefly.core.background.ScriptAttributes.*;
 import static edu.caltech.ipac.firefly.server.servlets.AnyFileDownload.getDownloadURL;
 import static edu.caltech.ipac.firefly.server.util.DownloadScript.makeScriptFilename;
 import static edu.caltech.ipac.firefly.server.ws.WsServerParams.WS_SERVER_PARAMS.CURRENTRELPATH;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
-import static edu.caltech.ipac.firefly.core.Util.Try;
 
 /**
  * Downloads a script with products from the List<FileInfo>
@@ -83,18 +81,18 @@ public final class DownloadScriptWorker implements Job.Worker {
 
         File curlScript = makeScript(result, Curl, dataDesc);
         File wgetScript = makeScript(result, Wget, dataDesc);
-        File urlsFile = makeScript(result, URLsOnly, dataDesc);
+        File urlsFile = makeScript(result, URLList, dataDesc);
 
         // handle 'save to Workspace' option:  pushes downloaded script (.sh or .txt) to workspace  (LLY: should probably ignore.  what is the use case?)
         if (!isEmpty(wsDestPath)) {
             Try.it(() -> new WsServerUtils().putFile(new WsServerParams().set(CURRENTRELPATH, wsDestPath + makeScriptFilename(Curl, suggestedName)), curlScript));
             Try.it(() -> new WsServerUtils().putFile(new WsServerParams().set(CURRENTRELPATH, wsDestPath + makeScriptFilename(Wget, suggestedName)), wgetScript));
-            Try.it(() -> new WsServerUtils().putFile(new WsServerParams().set(CURRENTRELPATH, wsDestPath + makeScriptFilename(URLsOnly, suggestedName)), urlsFile));
+            Try.it(() -> new WsServerUtils().putFile(new WsServerParams().set(CURRENTRELPATH, wsDestPath + makeScriptFilename(URLList, suggestedName)), urlsFile));
         }
 
         String curlScriptUrl = getDownloadURL(curlScript, makeScriptFilename(Curl, suggestedName));
         String wgetScriptUrl = getDownloadURL(wgetScript, makeScriptFilename(Wget, suggestedName));
-        String urlsFileUrl = getDownloadURL(urlsFile, makeScriptFilename(URLsOnly, suggestedName));
+        String urlsFileUrl = getDownloadURL(urlsFile, makeScriptFilename(URLList, suggestedName));
 
         sendJobUpdate(ji -> {
             String summary = String.format("%,d files were processed.", totalFiles);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ObsCorePackager.java
@@ -173,28 +173,6 @@ public class ObsCorePackager extends FileGroupsProcessor {
             Map<String, ServDescUrl> serDefUrls = new HashMap<>();
 
             for (DataGroup dg : groups) {
-                boolean makeDataLinkFolder = false;
-                int countValidDLFiles = 0;
-                //do one initial pass through semantics column to determine if we need to create a folder for datalink files
-                for (int i=0; i < dg.size(); i++) {
-                    String sem = Objects.toString(dg.getData(SEMANTICS, i), null);
-                    if (sem == null) {
-                        continue;
-                    }
-
-                    if (products != null) { // Check if products exist and contains sem
-                        if (Arrays.asList(products).contains(sem) || Arrays.asList(products).contains("*")) { //* refers to all data products
-                            countValidDLFiles++;
-                        }
-                    }
-                    else countValidDLFiles++;
-
-                    if (countValidDLFiles > 1) {
-                        makeDataLinkFolder = true;
-                        break;
-                    }
-                }
-
                 for (int i=0; i < dg.size(); i++) {
                     //if (indices != null && !indices.contains(i)) continue;
                     String accessUrl = Objects.toString(dg.getData(ACCESS_URL, i), null);
@@ -228,10 +206,10 @@ public class ObsCorePackager extends FileGroupsProcessor {
                         String extension = "unknown";
                         extension = content_type != null ? getExtFromURL(content_type) : getExtFromURL(productUrl);
                         ext_file_name += "." + extension;
-                        ext_file_name = (isFlattenedStructure || (!makeDataLinkFolder)) ?
+                        ext_file_name = (isFlattenedStructure)  ?
                                 ext_file_name : prepend_file_name + "/" + ext_file_name;
                     } else {
-                        ext_file_name = (isFlattenedStructure || (!makeDataLinkFolder)) ?
+                        ext_file_name = (isFlattenedStructure) ?
                                 ext_file_name : (prepend_file_name + "/" + (fileName != null ? fileName : ""));
                     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/DownloadScript.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/DownloadScript.java
@@ -9,20 +9,12 @@ import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.packagedata.FileGroup;
 import edu.caltech.ipac.table.IpacTableUtil;
 import edu.caltech.ipac.util.AppProperties;
-import edu.caltech.ipac.util.StringUtils;
-import edu.caltech.ipac.util.download.URLDownload;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.Serializable;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Function;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.background.ScriptAttributes.*;
@@ -41,7 +33,9 @@ public class DownloadScript {
         *
         *    Date: %s
         *
-        *    Download %s from %s
+        *    Script to download %s data from %s
+        *
+        *    The script below defines a subroutine to download the files
         *
         ************************************************
         
@@ -222,8 +216,8 @@ static final String funcTmpl = """
 
         try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(outFile), IpacTableUtil.FILE_IO_BUFFER_SIZE))) {
 
-            if (is(URLsOnly, attribs)) {      // most tools do not natively support comments; maybe we should exclude them.
-                writer.printf("# Date: %s --- Download %s from %s \n", new Date(), dataDesc, FROM_ORG);
+            if (is(URLList, attribs)) {      // most tools do not natively support comments; maybe we should exclude them.
+                writer.printf("# Date: %s --- Download %s data from %s \n", new Date(), dataDesc, FROM_ORG);
                 urlInfos.forEach(pi -> writer.println(pi.getHref()));
                 return;
             }
@@ -248,7 +242,7 @@ static final String funcTmpl = """
     }
 
     public static String makeScriptFilename(ScriptAttributes type, String suggName) {
-        String ext = type.equals(URLsOnly) ? "txt" : "sh";
+        String ext = type.equals(URLList) ? "txt" : "sh";
         return "%s-%s.%s".formatted(suggName, type.name().toLowerCase(), ext);
     };
 

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -171,7 +171,7 @@ export function getErrMsg(jobInfo) {
     return jobInfo?.errorSummary?.message;
 }
 
-export const SCRIPT_ATTRIB = new Enum(['URLsOnly', 'Unzip', 'Ditto', 'Curl', 'Wget', 'RemoveZip']);
+export const SCRIPT_ATTRIB = new Enum(['URLList', 'Unzip', 'Ditto', 'Curl', 'Wget', 'RemoveZip']);
 
 export function doPackageRequest({dlRequest, searchRequest, selectInfo, bgKey, downloadType, onComplete}) {
 

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -131,6 +131,7 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
         '#auxiliary': 'Auxiliary',
         '#progenitor': 'Progenitor',
         '#thumbnail': 'Thumbnail',
+        '#calibration': 'Calibration',
         '#preview': 'Preview',
         '#package': 'Package',
         '#weight': 'Weight'
@@ -150,7 +151,7 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
             options = []; //fallback only to "All data" only below
         }
         //ensure '*' ("All data") is always included, even as a fallback when semList is empty
-        options.push({ label: 'All data', value: '*' });
+        options.push({ label: 'All Data', value: '*' });
         return options;
     }, [semList, labelMap]);
 

--- a/src/firefly/js/ui/ScriptDownloadDialog.jsx
+++ b/src/firefly/js/ui/ScriptDownloadDialog.jsx
@@ -39,7 +39,7 @@ class ScripDownloadPanel extends PureComponent {
 
     constructor(props) {
         super(props);
-        this.state = {urlsOnly: false};
+        this.state = {urlList: false};
         this.onSubmit = this.onSubmit.bind(this);
     }
 
@@ -56,8 +56,8 @@ class ScripDownloadPanel extends PureComponent {
     storeUpdate() {
         if (!this.isUnmounted) {
             const fields = FieldGroupUtils.getGroupFields('ScriptDownloadDialog');
-            const urlsOnly = FieldGroupUtils.getFldValue(fields, 'URLsOnly');
-            this.setState({urlsOnly});
+            const urlList = FieldGroupUtils.getFldValue(fields, 'URLList');
+            this.setState({urlList});
         }
     }
 
@@ -73,7 +73,7 @@ class ScripDownloadPanel extends PureComponent {
 
     render() {
         const {help_id, jobId} = this.props;
-        const {urlsOnly} = this.state;
+        const {urlList} = this.state;
         return (
             <div style = {{margin: '4px'}}>
                 <FormPanel
@@ -84,7 +84,7 @@ class ScripDownloadPanel extends PureComponent {
                     help_id={help_id}>
 
                     <FieldGroup groupKey={'ScriptDownloadDialog'}>
-                        <div style={{visibility: (urlsOnly ? 'hidden' : 'visible')}}>
+                        <div style={{visibility: (urlList ? 'hidden' : 'visible')}}>
                             <ListBoxInputField
                                 fieldKey ='downloader'
                                 initialState = {{
@@ -112,10 +112,10 @@ class ScripDownloadPanel extends PureComponent {
                         </div>
 
                         <CheckboxGroupInputField
-                            fieldKey='URLsOnly'
+                            fieldKey='URLList'
                             initialState= {{label : ' '}}
                             options={[
-                                        {label: 'Download just a list of URLs', value: 'URLsOnly'}
+                                        {label: 'Download just a list of URLs', value: 'URLList'}
                                     ]}
                         />
                     </FieldGroup>

--- a/src/firefly/test/edu/caltech/ipac/firefly/util/DownloadScriptTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/util/DownloadScriptTest.java
@@ -29,19 +29,19 @@ public class DownloadScriptTest {
     }
 
     @Test
-    public void urlsOnly() throws Exception {
+    public void urlList() throws Exception {
         List<FileGroup> fileInfoList = List.of(new FileGroup(List.of(
                 new FileInfo("https://example.com/file1.txt", "mydata/file1.txt", 0),
                 new FileInfo("https://example.com/file2.txt", "mydata/file1.txt", 0)
         )));
 
-        DownloadScript.createScript(tempScript, "Test Data", fileInfoList, URLsOnly);
+        DownloadScript.createScript(tempScript, "Test Data", fileInfoList, URLList);
 
         List<String> lines = Files.readAllLines(tempScript.toPath());
 
         assertTrue("File1 URL should be present", lines.contains("https://example.com/file1.txt"));
         assertTrue("File2 URL should be present", lines.contains("https://example.com/file2.txt"));
-        assertFalse("Script header should not exist in URLsOnly mode", lines.stream().anyMatch(line -> line.startsWith("#!")));
+        assertFalse("Script header should not exist in URLList mode", lines.stream().anyMatch(line -> line.startsWith("#!")));
     }
 
     @Test


### PR DESCRIPTION
**Tickets**: 
- [IRSA-7251](https://jira.ipac.caltech.edu/browse/IRSA-7251)  
  - fixes the unflattening/flattening downloads issue
    -  If `flattened` is turned off, the download script will always create folders (even if there's only 1 file per row/datalink entry)  
- [IRSA-7250](https://jira.ipac.caltech.edu/browse/IRSA-7250)
  - Change "All data" → "All Data" in the download dialog (and capitalized `Calibration` for when that's available as an option) 
  - when downloading `url-list`, the filename will now have `urllist` (instead of `urlsonly`)
  - In the script header (so for `wget` and `curl`): 
    - Changed: `Download SPHEREx from IRSA` → `Script to download SPHEREx data from IRSA`
    - and added this line `The script below defines a subroutine to download the files`
 - (please see my comments in ticket for items not addressed in this PR)  
- [IRSA-7249](https://jira.ipac.caltech.edu/browse/IRSA-7249)
  - Remove table navigation for the main table on the left for Spherex Spectrophotometry search results 
  - Code change for this change is in this IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/439 

**Testing**
- DCE: https://irsa-7251-spherex-bugs.irsakudev.ipac.caltech.edu/irsaviewer/dce
- Euclid: https://irsa-7251-spherex-bugs.irsakudev.ipac.caltech.edu/applications/euclid
- SPHEREx: https://irsa-7251-spherex-bugs.irsakudev.ipac.caltech.edu/applications/spherex
- Firefly: https://fireflydev.ipac.caltech.edu/irsa-7251-spherex-bugs/firefly
- Since changes have been made to the download script logic, I would test all apps where we have downloads 
  - CADC on Euclid, DCE on IRSAviewer, and Euclid & SPHEREx downloads 
- Notice folder (directory) creation for Spherex now when `flattened` option is turned off 
- @lrebull you may even test changing cutout sizes and noticing that being respected in the URLs generated in the download script (this was fixed in my last PR) 