### PR TITLE
FIREFLY-1847: Render Euclid spectral units in charts

### DIFF
--- a/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
+++ b/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
@@ -338,6 +338,7 @@ const UnitMetadata = {
     'erg/s/cm^2/A' : {
         type: Measurement.F_LAMBDA.key,
         label: `erg/s/cm²/${WAVELENGTH_UNITS.angstrom.symbol}`,
+        aliases: ['erg.Angstrom**-1.s**-1.cm**-2'], // non-standard order of subunits for Euclid SpectrumDM until astropy bug is fixed
     },
     'W/m^2/um' : {
         type: Measurement.F_LAMBDA.key,


### PR DESCRIPTION
Fixes [FIREFLY-1847](https://jira.ipac.caltech.edu/browse/FIREFLY-1847)


## Testing

https://firefly-1847-euclid-spec-units.irsakudev.ipac.caltech.edu/applications/euclid/

Do an Inspect Object search, sort by flux_vis_psf descending order. Check the spectrum of first 5-6 rows, firefly should be able to recognize the flux axis units (in chart axis and options dialog)

