### PR TITLE
IRSA-7231: Fix extra Prepare Download button in Spherex Spectrophotometry results

### DIFF
--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -7,7 +7,7 @@ import {getActiveTableId, getMetaEntry, getTableUiByTblId, getTblById} from '../
 import {DownloadButton, DownloadOptionPanel} from '../../ui/DownloadDialog.jsx';
 import {getDataServiceOption, getDataServiceOptionByTable, getDataServiceOptionsFallback,
 } from '../../ui/tap/DataServicesOptions';
-import {findTableCenterColumns, hasDataLinkSvcDesc, hasObsCoreLikeDataProducts, isDatalinkTable
+import {findTableCenterColumns, hasDataLinkSvcDesc, hasObsCoreLikeDataProducts, isDatalinkTable, isDataProductsTable
 } from '../../voAnalyzer/TableAnalysis.js';
 import {getCatalogWatcherDef} from '../../visualize/saga/CatalogWatcher.js';
 import {getUrlLinkWatcherDef} from '../../visualize/saga/UrlLinkWatcher.js';
@@ -73,6 +73,8 @@ function setupObsCorePackaging(tbl_id) {
         enabled= getDataServiceOption('enableObsCoreDownload');
     }
     if (!enabled) return;
+
+    if (!isDataProductsTable(tbl_id)) return;
 
     const dlProps = getDataServiceOptionByTable('obsCoreDownloadProps', table, {}) || {};
 


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/IRSA-7231
- The current change assumes that spectrum tables (even if `obscore` type) will always be tables on the right, and therefore will not need a `Prepare Download` button (correct me if I am wrong)
  - If my assumption is correct, then this change will be safe elsewhere on firefly apps too, for any spectrum tables that happen to be ObsCore 
- (What I can't figure out, though, is why there's no `Prepare Download` button for this same spectrum table on current Spherex ops - my code to recognize `ObsCore` tables and add a `Prepare Download` button in `ttFeatureWatchers` went out before our ops release) 
  - I am sure it's a regression bug but I couldn't figure out the source, either way, this should now be handled.

**Testing**
- SPHEREx: https://irsa-7231-download-button-bug.irsakudev.ipac.caltech.edu/applications/spherex
  - Do a Spectrophotometry Search (can try `21h24m24.39s +33d39m07.6s Equ J2000`)
  - In the results table, go to the spectrum table on the right (there should be no `Prepare Download` button here)
  - To cross-verify, repeat the same on nightly/irsadev: https://irsadev.ipac.caltech.edu/applications/spherex/
     - you'll notice there's a `Prepare Download` button here for the spectrum table 
- Only test for the above, if you spot any other issues (check if they're being addressed in this parallel open PR: https://github.com/Caltech-IPAC/firefly/pull/1843)