### PR TITLE
FIREFLY-1839: Fix UWS job error message

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/WebsocketConnector.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/WebsocketConnector.java
@@ -8,7 +8,6 @@ import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.util.event.Name;
-import edu.caltech.ipac.util.StringUtils;
 
 import javax.websocket.CloseReason;
 import javax.websocket.OnClose;
@@ -24,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
+
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 @ServerEndpoint(value = "/sticky/firefly/events")
 public class WebsocketConnector implements ServerEventQueue.EventConnector {
@@ -49,7 +50,7 @@ public class WebsocketConnector implements ServerEventQueue.EventConnector {
             Map<String, List<String>> params = session.getRequestParameterMap();
             userKey = ServerContext.getRequestOwner().getUserKey();
             channelID = params.containsKey(CHANNEL_ID) ? String.valueOf(params.get(CHANNEL_ID).get(0)) : null;
-            channelID = StringUtils.isEmpty(channelID) ? userKey : channelID;
+            channelID = isEmpty(channelID) ? userKey : channelID;
             eventQueue = new ServerEventQueue(session.getId(), channelID, userKey, this);
             ServerEvent connected = new ServerEvent(Name.EVT_CONN_EST, ServerEvent.Scope.SELF, "{\"connID\": \"" + session.getId() + "\", \"channel\": \"" + channelID + "\"}");
             send(ServerEventQueue.convertToJson(connected));
@@ -65,7 +66,7 @@ public class WebsocketConnector implements ServerEventQueue.EventConnector {
     public void onMessage(String message) {
         try {
 
-            if (StringUtils.isEmpty(message)) {
+            if (isEmpty(message)) {
                 LOG.trace(PREFIX+" PING from "+makeChannelStr(session));
                 return;  // ignore empty messages
             }
@@ -167,18 +168,16 @@ public class WebsocketConnector implements ServerEventQueue.EventConnector {
         List<ServerEventQueue> conns = ServerEventManager.getAllEventQueue();
         for (ServerEventQueue seq : conns) {
             // need to notify clients that are affected by update
-            if (seq.getChannel().equals(channelID) || seq.getUserKey().equals(userKey)) {
+            String cChannel = isEmpty(seq.getChannel()) ? "__NULL__" : seq.getChannel();
+            String cUserKey = isEmpty(seq.getUserKey()) ? "__NULL__" : seq.getUserKey();
+            if (cChannel.equals(channelID) || cUserKey.equals(userKey)) {
                 // Creates a map of all the channels and its connections that is visible to this user.
                 // This user has knowledge of all connections started by this user, as well as connections associated with this user's channel.
                 Map<String, List<String>> connInfo = new HashMap<>();
                 conns.stream()
                         .filter(q -> q.getChannel().equals(channelID) || q.getUserKey().equals(userKey))
                         .forEach(q -> {
-                            List<String> l = connInfo.get(q.getChannel());
-                            if (l == null) {
-                                l = new ArrayList<>();
-                                connInfo.put(q.getChannel(), l);
-                            }
+                            List<String> l = connInfo.computeIfAbsent(q.getChannel(), k -> new ArrayList<>());
                             if (!l.contains(q.getConnID())) l.add(q.getConnID());
                         });
                 FluxAction action = new FluxAction(type, connInfo);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServiceInput.java
@@ -4,8 +4,10 @@
 
 package edu.caltech.ipac.firefly.server.network;
 
+import com.google.common.net.HttpHeaders;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.security.SsoAdapter;
+import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.util.KeyVal;
 
 import java.io.File;
@@ -44,9 +46,13 @@ public class HttpServiceInput implements Cloneable, Serializable {
      * Constructs an instance with the given request URL.
      * The request will be created with credentials validated
      * through the configured {@link SsoAdapter}.
+     * It will also set the default headers.  Remove or modify as needed.
      * @param requestUrl  the target URL to access
      */
     public HttpServiceInput(String requestUrl) {
+        // set default headers
+        setHeader(HttpHeaders.USER_AGENT, VersionUtil.getUserAgentString());
+        setHeader(HttpHeaders.ACCEPT_ENCODING, "gzip");
         setRequestUrl(requestUrl);
     }
 
@@ -56,6 +62,14 @@ public class HttpServiceInput implements Cloneable, Serializable {
     public HttpServiceInput setRequestUrl(String requestUrl) {
         return setRequestUrl(requestUrl, true);
     }
+    /**
+     * Sets the request URL.  If {@code applyCredential} is {@code true},
+     * the configured {@link SsoAdapter} will be used to set authentication
+     * credentials on this input based on the request URL.
+     * @param requestUrl       the target URL to access
+     * @param applyCredential  if {@code true}, apply credentials from the configured {@code SsoAdapter}
+     * @return this {@code HttpServiceInput} instance for method chaining
+     */
     public HttpServiceInput setRequestUrl(String requestUrl, boolean applyCredential) {
         this.requestUrl = requestUrl;
         if (applyCredential) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/network/HttpServices.java
@@ -3,8 +3,6 @@
  */
 package edu.caltech.ipac.firefly.server.network;
 
-import com.google.common.net.HttpHeaders;
-import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.KeyVal;
 import edu.caltech.ipac.util.download.URLDownload;
@@ -12,6 +10,7 @@ import edu.caltech.ipac.firefly.server.util.Logger;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
@@ -214,8 +213,6 @@ public class HttpServices {
             input = input == null ? new HttpServiceInput() : input;
 
             method.setRequestHeader("Connection", "close");            // request server to NOT keep-alive. we don't plan to reuse this connection.
-            method.setRequestHeader("User-Agent", VersionUtil.getUserAgentString());
-            method.setRequestHeader(HttpHeaders.ACCEPT_ENCODING, "gzip");
             if (method instanceof GetMethod) {
                 method.setFollowRedirects(input.isFollowRedirect());    // httpclient 3.x, post are not allowed to follow redirect
             }
@@ -378,7 +375,21 @@ public class HttpServices {
                     String location = HttpServices.getResHeader(method, "Location", null);
                     if (location != null) {
                         if (maxFollow > 0) {
-                            return getData(new HttpServiceInput(location), maxFollow-1, handler);       // follow redirect is default to true.
+                            HttpServiceInput redirect = new HttpServiceInput(location);
+                            // carry over cookies
+                            Header[] setCookies = method.getResponseHeaders("Set-Cookie");
+                            if (setCookies != null && setCookies.length > 0) {
+                                String cookieHeader = Arrays.stream(setCookies)
+                                        .map(h -> h.getValue().split(";", 2)[0])
+                                        .collect(Collectors.joining("; "));
+                                redirect.setHeader("Cookie", cookieHeader);
+                            }
+                            // carry over previous headers
+                            input.getHeaders().entrySet().stream()
+                                    .filter(h -> isForwardHeader(h.getKey()))
+                                    .forEach(h -> redirect.setHeader(h.getKey(), h.getValue()));
+
+                            return getData(redirect, maxFollow-1, handler);
                         } else {
                             return new Status(421, "ERR_TOO_MANY_REDIRECTS");
                         }
@@ -393,14 +404,28 @@ public class HttpServices {
         }
     }
 
+    private static boolean isForwardHeader(String headerName) {
+        String lower = headerName.toLowerCase();
+        return switch (lower) {
+            case "user-agent", "accept", "accept-language" -> true;
+            default -> false;
+        };
+    }
+
     public static boolean isOk(HttpMethod method) {
         int status = method.getStatusCode();
         return status >= 200 && status < 300;
     }
 
     public static boolean isRedirected(HttpMethod method) {
-        int status = method.getStatusCode();
-        return status >= 300 && status < 400;
+        return  switch (method.getStatusCode()) {
+            case HttpStatus.SC_MOVED_PERMANENTLY,   // 301
+                HttpStatus.SC_MOVED_TEMPORARILY,    // 302
+                HttpStatus.SC_SEE_OTHER,            // 303
+                HttpStatus.SC_TEMPORARY_REDIRECT,   // 307
+                308    -> true;                     // 308 SC_PERMANENT_REDIRECT not defined in v3
+            default -> false;
+        };
     }
 
     public static String getReqHeader(HttpMethod method, String key, String def) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DaliUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DaliUtil.java
@@ -12,13 +12,12 @@ import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.table.io.VoTableReader;
 import edu.caltech.ipac.table.io.VoTableWriter;
 import edu.caltech.ipac.util.AppProperties;
-import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import org.apache.commons.httpclient.HttpMethod;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -122,7 +121,7 @@ public class DaliUtil {
     }
 
     /**
-     * Parse the error message from the given HttpMethod. Also takes into account whether the URL is an
+     * Reads the response body and extracts the error message from the given HttpMethod. Also takes into account whether the URL is an
      * error document or not.
      *
      * @param method the HttpMethod that contains the error response
@@ -130,38 +129,35 @@ public class DaliUtil {
      * @return a string containing the parsed error message
      */
     public static String parseError(HttpMethod method, String url) {
-        boolean isErrorDoc = HttpServices.isOk(method); // url is an error document (at /error) if isOK() is true
-        String httpErrMsg = isErrorDoc ? "" : String.format("Request to %s failed: %s", url, method.getStatusText());
-
-        String errMsg;
-        String contentType = HttpServices.getResHeader(method, "Content-Type", "");
-        boolean parseAsText = contentType.startsWith("text/plain") || contentType.startsWith("application/json");
         try {
-            if (parseAsText) {
-                // error can be parsed as text
-                errMsg = HttpServices.getResponseBodyAsString(method);
-                if (errMsg.length() > 1000) {
-                    errMsg = errMsg.substring(0, 1000) + "...";
-                }
-            } else {
-                // error is VOTable doc
-                try (InputStream is = HttpServices.getResponseBodyAsStream(method)) {
-                    String voError = VoTableReader.getError(is, url);
-                    if (voError == null) {
-                        voError = isErrorDoc
-                                ? "Non-compliant VOTable in error document at " + url
-                                : httpErrMsg; // give generic HTTP error message over the VOTable error
-                    }
-                    errMsg = voError;
-                }
-            }
-        } catch (Exception e) {
-            errMsg = isErrorDoc
-                    ? String.format("Error retrieving error document from %s: %s", url, e.getMessage())
-                    : httpErrMsg; // give generic HTTP error message over the exception in parsing
+            return parseError(method.getResponseBody(), HttpServices.getResHeader(method, "Content-Type", ""));
+        } catch (IOException e) {
+            return "Error retrieving error from %s: %s".formatted(url, e.getMessage());
         }
-        return errMsg;
     }
+
+    /**
+     * Parse the error message from the given response.  This may be plain text or a VOTable error document.
+     * @param response  the response that contains the error message
+     * @return a string containing the parsed error message
+     */
+    public static String parseError(byte[] response, String contentType) {
+        if (isEmpty(response)) return "Not found. The data may no longer be accessible.";
+        boolean parseAsText = contentType.startsWith("text/plain") || contentType.startsWith("application/json");
+        if (parseAsText) {
+            String msg = new String(response);
+            return msg.length() > 1000 ? msg.substring(0, 1000) + "..." : msg;
+        }
+        try {
+            // check for VOTable error doc
+            String voError = VoTableReader.getError(new ByteArrayInputStream(response), null);
+            if (voError == null) voError = "Non-compliant VOTable in error document";
+            return voError;
+        } catch (Exception e) {
+            return "Unrecognized error message format";
+        }
+    }
+
 
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -26,6 +26,7 @@ import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
@@ -307,16 +308,25 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
     }
 
     public static JobInfo getUwsJobInfo(String jobUrl) throws DataAccessException {
-        if (isEmpty(jobUrl)) return null;
+        if (isEmpty(jobUrl)) throw new DataAccessException("Job URL is missing");
 
         Ref<JobInfo> jInfo = new Ref<>();
         HttpServices.Status status = HttpServices.getData(jobUrl, method -> {
+            if (!isOk(method)) {
+                String error = parseError(method, jobUrl);
+                return new HttpServices.Status(404, error);
+            }
+            // Some services (e.g., IRSA TAP) may return errors without proper status codes.
+            // Preserve the response body, so it can be parsed for error if needed.
+            byte[] response = null;
             try {
-                Document doc = parse(getResponseBodyAsStream(method));
+                response = method.getResponseBody();
+                Document doc = parse(new ByteArrayInputStream(response));
                 jInfo.set(convertToJobInfo(doc));
                 return HttpServices.Status.ok();
             } catch (Exception e) {
-                return new HttpServices.Status(400, e.getMessage());
+                String error = parseError(response, getResHeader(method, "Content-Type", ""));
+                return new HttpServices.Status(404, error);
             }
         });
         if (status.isError()) throw createDax("Fail to fetch UWS job info", jobUrl, status.getException());

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/network/HttpServicesTest.java
@@ -3,8 +3,6 @@ package edu.caltech.ipac.firefly.server.network;
 import edu.caltech.ipac.TestCategory;
 import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.core.Util;
-import edu.caltech.ipac.firefly.server.RequestAgent;
-import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
@@ -36,6 +34,7 @@ import static edu.caltech.ipac.firefly.server.security.SsoAdapter.SSO_FRAMEWORK_
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.*;
 
+@Ignore("Temporarily disabled.  https://httpbin.org/ is not reliable")
 public class HttpServicesTest extends ConfigTest {
 
     private static String TEST_HOST_URL = "https://httpbin.org/";


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1839
- Improve user messaging when UWS jobs no longer exists
- Improve HttpServices follow redirect
- Fix NullPointerException in WebsocketConnector

Test: https://fireflydev.ipac.caltech.edu/firefly-1839-uws-job-error-msg/firefly/
This is hard to test because you need to load the result of a job that no longer exists.
For IRSA TAP, it's 72 hours.

I test it locally and got this error:
<img width="332" height="184" alt="image" src="https://github.com/user-attachments/assets/268de5c9-bb0b-4a85-8671-5167976b098b" />
