### PR TITLE
FIREFLY-1802: Fixed deleted jobs return after importing history

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -74,6 +74,7 @@ public class JobManager {
     private static final int WAIT_COMPLETE = AppProperties.getIntProperty("job.wait.complete", 1);              // wait for complete after submit in seconds
     private static final int MAX_PACKAGERS = AppProperties.getIntProperty("job.max.packagers", 10);             // maximum number of simultaneous packaging threads
     private static final int JOB_EXPIRY_HOURS = AppProperties.getIntProperty("job.expiry.hours", 24*14);        // Time in hours to keep a job after it has ended.  Default to 14 days.
+    private static final int JOB_ARCHIVED_EXPIRY_HOURS = AppProperties.getIntProperty("job.archived.expiry.hours", 24*14);   // Time in hours to keep an archived job after it has ended.  Default to 14 days.
     public static final int JOB_SCAN_BATCH_SIZE = AppProperties.getIntProperty("job.scan.batch_size", 10_000);   // batch size for scanning job keys in Redis.  Default to 10,000.  Larger value return more keys per call but use more CPU and memory per iteration.  this is a good size for larger redis store.
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
@@ -196,7 +197,7 @@ public class JobManager {
 
     public static void removeJob(String jobId) {
         ifNotNull(getJobInfo(jobId)).apply(ji -> {
-            allJobInfos.remove(cacheKey(ji));
+            ji.setPhase(ARCHIVED);
             removeLocalJob(ji);
         });
     }
@@ -573,6 +574,11 @@ public class JobManager {
             if (!job.getMeta().isMonitored() && job.getEndTime().plus(1, ChronoUnit.HOURS).isBefore(Instant.now())) {
                 LOG.info("Removing non-monitored job: " + k);
                 allJobInfos.remove(k);      // remove non-monitored job after 1 hour
+            } else if (job.getPhase() == ARCHIVED) {
+                if (job.getEndTime().plus(JOB_ARCHIVED_EXPIRY_HOURS, ChronoUnit.HOURS).isBefore(Instant.now())) {
+                    LOG.info("Removing expired archived job: " + k);
+                    allJobInfos.remove(k);
+                }
             } else if (!CLEANUP_PHASES_EXCLUDES.contains(job.getPhase()) && job.getEndTime().plus(JOB_EXPIRY_HOURS, ChronoUnit.HOURS).isBefore(Instant.now())) {
                 LOG.info("Removing expired job: " + k);
                 allJobInfos.remove(k);

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -48,7 +48,6 @@ public class JobUtil {
     public static final List<String> RUNID_IGNORE = Arrays.stream(AppProperties.getProperty("uws.runid.ignore", "")
                                                             .split(",")).map(String::trim).toList();        // strings separated by comma
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
-    private static final long yearMs = 365*24*60*60*1000L;  // one year in milliseconds; 31_536_000_000
     public static final List<String> runIdIgnoreList = new ArrayList<>();
     private static final char[] ALPHABET =
             "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".toCharArray();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -84,21 +84,16 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
         // send abort request.  ignore if there's error
         if (isEmpty(jobUrl)) return;
         String phaseUrl = jobUrl.trim().replaceAll("/$", "") + "/phase" ;        // remove trailing slash
-        Status status = HttpServices.postData(new HttpServiceInput(phaseUrl).setParam("PHASE", "ABORT"),
+        Status status = HttpServices.postData(new HttpServiceInput(phaseUrl).setParam("PHASE", "ABORT").setFollowRedirect(false),
                 res -> {
-                    String location = getResHeader(res, "Location", null);      // expecting a 303 redirect to the job URL
-                    if (location == null) {
-                        String error = ifNotEmpty(parseError(res, phaseUrl)).getOrElse("Unknown error");
-                        int errorCode = isOk(res) ? 400 : res.getStatusCode();
-                        return new Status(errorCode, "Failed to abort: " + error);
-                    } else {
-                        JobInfo jobInfo = Try.it(() -> getUwsJobInfo(jobUrl)).get();
-                        if (jobInfo == null || JobUtil.isActive(jobInfo)) {
-                            String msg = ifNotNull(jobInfo.getError().msg()).getOrElse("Job cannot be aborted");
-                            return new Status(400, "Failed to abort: %s".formatted(msg) );
-                        }
-                        return Status.ok();         // aborted or no longer active
+                    // expecting a 303 redirect to the job URL
+                    // instead, we will query the jobUrl directly to see if it's aborted
+                    JobInfo jobInfo = Try.it(() -> getUwsJobInfo(jobUrl)).get();
+                    if (jobInfo == null || jobInfo.getPhase() != Phase.ABORTED) {
+                        String msg = ifNotNull(jobInfo.getError().msg()).getOrElse("Job cannot be aborted");
+                        return new Status(400, "Failed to abort: %s".formatted(msg) );
                     }
+                    return Status.ok();         // aborted or no longer active
                 }
         );
         if (status.isError()) {

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -36,6 +36,7 @@ import {FormWatcher} from '../../templates/router/RouteHelper';
 import {logger} from '../../util/Logger';
 
 export const jobMonitorPath = '/jobMonitor';
+const jobIdColIdx = 7;  // the index of the jobId column in the table
 
 export function JobMonitor({initArgs, help_id, slotProps, ...props}) {
     const pollInterval = getAppOptions()?.background?.historyPollInterval || 30000;       // every 30 seconds
@@ -203,7 +204,7 @@ function JobMonitorTable({help_id, ...props}) {
     useEffect(() => {
         const table = convertToTableModel(getMonitoredJob(jobMap), tbl_id);
         if (hlJobId) {
-            const highlightedRow = table.tableData.data.findIndex((row) => row[6] === hlJobId);
+            const highlightedRow = table.tableData.data.findIndex((row) => row[jobIdColIdx] === hlJobId);
             if (highlightedRow >= 0) table.highlightedRow = highlightedRow; // set the highlighted row if the job is found
         }
         dispatchTableAddLocal(table, undefined, false);
@@ -253,7 +254,7 @@ function ControlRenderer({cellInfo}) {
     if (!job?.meta?.jobId) return null;
 
     return  (
-        <Stack mx={2} direction='row' justifyContent='right'>
+        <Stack mx={1} direction='row' justifyContent='right'>
             <Progress job={job}/>
             <Results job={job}/>
             <InfoPopup job={job}/>
@@ -374,7 +375,7 @@ function convertToTableModel(jobs, tbl_id) {
             job.startTime && moment.utc(job.startTime).format('YYYY-MM-DD HH:mm:ss'),
             job.endTime && moment.utc(job.endTime).format('YYYY-MM-DD HH:mm:ss'),
             job.phase,
-            job.meta?.jobId
+            job.meta?.jobId         // remember to adjust jobIdColIdx if columns changed
         ]);
 
     const phaseIdx = columns.findIndex((c) => c.name === 'Phase');


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1802

This PR ensures that deleted jobs do not reappear after importing job history from preconfigured UWS services.

**Changes**
- When a user deletes a job from the UI, the job phase is now transitioned to ARCHIVED instead of being immediately expired.
- Archived jobs are not displayed in the UI.
- Have a dedicated archive job cleanup expiry time that is longer than the general job expiry.
- This guarantees that deleted jobs remain hidden long enough to prevent them from reappearing after an import when the general expiry time is set too short.

Test: https://firefly-1802-deleted-jobs-come-back.irsakudev.ipac.caltech.edu/applications/spherex/
- Run one or more Spectrometry Tool queries to generate job history.
- Delete a job from the UI and confirm that it disappeared.
- Verify that deleted jobs are not shown in job listings after reloading the page.

**Note:** This instance was deployed with the Spectrometry Tool service configured as one of the UWS services to import job history from.