### PR TITLE
FIREFLY-1638: Fix TAP selected cols number missing upon filtering

### DIFF
--- a/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
+++ b/src/firefly/js/ui/tap/TableColumnsConstraints.jsx
@@ -85,7 +85,7 @@ function tableEffect(columnsModel, setTableModel, tbl_id, setFilterCount, setSel
         if (setFilterCount || setSelectedCount) {
             if (setSelectedCount) {
                 // principal columns are preselected
-                const si = get(tbl, 'origTableModel.selectInfo') || get(tbl, 'selectInfo');
+                const si = tbl?.selectInfo ?? tbl?.origTableModel?.selectInfo;
                 const selectInfoCls = si? new SelectInfo(si) : SelectInfo.newInstance(si);
                 setSelectedCount(selectInfoCls.getSelectedCount());
             }
@@ -100,10 +100,11 @@ function tableEffect(columnsModel, setTableModel, tbl_id, setFilterCount, setSel
                             const filterInfo = get(tableModel, 'request.filters', '');
                             setFilterCount && setFilterCount(filterInfo ? filterInfo.split(';').length : 0);
                         }
-                        selectInfo = get(tableModel, 'origTableModel.selectInfo');
+                        selectInfo = tableModel?.selectInfo ?? tableModel?.origTableModel?.selectInfo;
                     } else {
                         if (action.payload.tbl_id === tbl_id) {
-                            selectInfo = get(getTblById(tbl_id), 'origTableModel.selectInfo');
+                            const tableModel = getTblById(tbl_id);
+                            selectInfo = tableModel?.selectInfo ?? tableModel?.origTableModel?.selectInfo;
                         }
                     }
                     const selectInfoCls = selectInfo ? new SelectInfo(selectInfo) : SelectInfo.newInstance(selectInfo);


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1638
- See the movie/text in the ticket for the bug description
- From what I could tell, the bug (missing text for count of selected columns) only happens when you filter some selected rows
  -  This is now fixed. 

**Testing**: 
Firefly: https://fireflydev.ipac.caltech.edu/firefly-1638-fix-tap-col-bug/firefly
- On TAP, for the table on the right, select a bunch of rows and the filter to selected rows 
- you should see the `Remove 1 filter` button next to (before) the selected columns text 
- remove the filter, ensure you still see the selected columns text 
- try selecting/unselecting more rows while the filter is applied and also when it's removed
  - essentially test to try and re-create the bug in any way possible, to ensure that it's now fixed 