### PR TITLE
FIREFLY-1866: Parenthesize composite-key JOINs in ADQL-generation

### DIFF
--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -213,12 +213,16 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
             const keys = keysInfo?.tableData?.data?.filter((row) => row[0] === keyId);
 
             targetTable  = maybeQuote(targetTable, true);
-            let val = ` INNER JOIN ${targetTable} ON `;
+            let val = '';
             keys.forEach((row, idx) => {
                 const fromColumn   = maybeQuote(fixCname(row[4], row[1]));
                 const targetColumn = maybeQuote(fixCname(row[5], row[2]));
                 val += `${idx>0 ? ' AND' : ''} ${fromColumn} = ${targetColumn}`;
             });
+            if ( keys.length > 1 ) {
+                val = '( ' + val + ' )';
+            }
+            val = ` INNER JOIN ${targetTable} ON ` + val;
             insertAtCursor(textArea, val, adqlKey, groupKey, prismLiveRef.current);
         }
     };


### PR DESCRIPTION
[FIREFLY-1866](https://jira.ipac.caltech.edu/browse/FIREFLY-1866)

This is:
* a pedagogical improvement because it keeps composite keys clearly identified in the output
* a workaround for a problem in Rubin Qserv which doesn't correctly handle `AND`s in `JOIN ON` clauses