### PR TITLE
FIREFLY-1834: Stereographic  projection implementation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default [
             globals: {
                 ...globals.browser,
                 ...globals.jest,
+                ...globals.node
             },
             parser: babelParser,
             ecmaVersion: 2020,

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageHeader.java
@@ -172,6 +172,8 @@ public class ImageHeader implements Serializable
 			maptype = Projection.SFL;
 		else if (ctype1_trim.endsWith("-GLS"))
 			maptype = Projection.SFL;
+		else if (ctype1_trim.endsWith("-STG"))
+			maptype = Projection.STG;
 		else if (ctype1_trim.endsWith("----"))
 			maptype = Projection.LINEAR;
 		else if (ctype1_tail.equals("    "))

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/Projection.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/Projection.java
@@ -17,37 +17,37 @@ import java.io.Serializable;
 public class Projection implements Serializable {
 
 
-    public static final double dtr = Math.PI/180.;
-    public static final double rtd = 180./Math.PI;
-    final static double DtoR = Math.PI/180.0;
-    final static double RtoD = 180.0/Math.PI;
-    static public final int GNOMONIC     = 1001;
+    public static final double dtr = Math.PI / 180.;
+    public static final double rtd = 180. / Math.PI;
+    final static double DtoR = Math.PI / 180.0;
+    final static double RtoD = 180.0 / Math.PI;
+    static public final int GNOMONIC = 1001;
     static public final int ORTHOGRAPHIC = 1002;
-    static public final int NCP          = 1003;
-    static public final int AITOFF       = 1004;
-    static public final int CAR          = 1005;
-    static public final int LINEAR       = 1006;
-    static public final int PLATE        = 1007;
-    static public final int ARC          = 1008;
-    static public final int SFL          = 1009;
-    static public final int CEA          = 1010;
-    static public final int TPV          = 1011;
-    static public final int UNSPECIFIED  = 1998;
+    static public final int NCP = 1003;
+    static public final int AITOFF = 1004;
+    static public final int CAR = 1005;
+    static public final int LINEAR = 1006;
+    static public final int PLATE = 1007;
+    static public final int ARC = 1008;
+    static public final int SFL = 1009;
+    static public final int CEA = 1010;
+    static public final int TPV = 1011;
+    static public final int STG = 1012;
+    static public final int UNSPECIFIED = 1998;
     static public final int UNRECOGNIZED = 1999;
 
-    private double      _scale1;
-    private double      _scale2;
-    private double      _pixelScaleArcSec;
+    private double _scale1;
+    private double _scale2;
+    private double _pixelScaleArcSec;
     private CoordinateSys _coordSys;
     private ProjectionParams _params;
 
-    public Projection(ProjectionParams params, CoordinateSys coordSys)
-    {
-        _params= params;
-        _scale1= 1/_params.cdelt1;
-        _scale2= 1/_params.cdelt2;
-        _pixelScaleArcSec= Math.abs(_params.cdelt1) * 3600.0;
-        _coordSys= coordSys;
+    public Projection(ProjectionParams params, CoordinateSys coordSys) {
+        _params = params;
+        _scale1 = 1 / _params.cdelt1;
+        _scale2 = 1 / _params.cdelt2;
+        _pixelScaleArcSec = Math.abs(_params.cdelt1) * 3600.0;
+        _coordSys = coordSys;
     }
 
     public CoordinateSys getCoordinateSys() { return _coordSys; }
@@ -55,6 +55,7 @@ public class Projection implements Serializable {
 
     /**
      * Get the pixel scale in degrees
+     *
      * @return double Pixel scale in ArcSec
      */
     public double getPixelScaleArcSec() { return _pixelScaleArcSec; }
@@ -63,22 +64,22 @@ public class Projection implements Serializable {
     public double getPixelHeightDegree() { return Math.abs(_params.cdelt2); }
 
     public ImagePt getDistanceCoords(ImagePt pt, double x, double y) {
-          ImagePt outpt= new ImagePt (
-               pt.getX()+(x * _scale1), pt.getY()+(y * _scale2) );
-          return outpt;
+        ImagePt outpt = new ImagePt(
+                pt.getX() + (x * _scale1), pt.getY() + (y * _scale2));
+        return outpt;
     }
 
     public ImageWorkSpacePt getDistanceCoords(ImageWorkSpacePt pt, double x, double y) {
-          ImageWorkSpacePt outpt= new ImageWorkSpacePt (
-               pt.getX()+(x * _scale1), pt.getY()+(y * _scale2) );
-          return outpt;
+        ImageWorkSpacePt outpt = new ImageWorkSpacePt(
+                pt.getX() + (x * _scale1), pt.getY() + (y * _scale2));
+        return outpt;
     }
 
-    public ProjectionPt getImageCoords( double ra, double dec) throws ProjectionException {
+    public ProjectionPt getImageCoords(double ra, double dec) throws ProjectionException {
         return getImageCoordsInternal(ra, dec, true);
     }
 
-    public ProjectionPt getImageCoordsSilent( double ra, double dec) {
+    public ProjectionPt getImageCoordsSilent(double ra, double dec) {
         try {
             return getImageCoordsInternal(ra, dec, false);
         } catch (ProjectionException e) { // exception will not happen since parameter turns if off
@@ -87,60 +88,61 @@ public class Projection implements Serializable {
     }
 
 
+    /**
+     * Convert World coordinates to "Skyview Screen" coordinates
+     * "Skyview Screen" coordinates have 0,0 in center of lower left pixel
+     *
+     * @param ra  double precision
+     * @param dec double precision
+     * @return ImagePt with X,Y in "Skyview Screen" coordinates
+     */
+    private ProjectionPt getImageCoordsInternal(double ra, double dec, boolean useProjException) throws ProjectionException {
+        ProjectionPt image_pt = null;
 
-    /** Convert World coordinates to "Skyview Screen" coordinates
-    *    "Skyview Screen" coordinates have 0,0 in center of lower left pixel
-    * @param ra double precision 
-    * @param dec double precision 
-    * @return ImagePt with X,Y in "Skyview Screen" coordinates
-    */
+        switch (_params.maptype) {
+            case (GNOMONIC):
+                image_pt = GnomonicProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (TPV):
+                image_pt = TpvProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (STG):
+                image_pt = StereographicProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (PLATE):
+                image_pt = PlateProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (ORTHOGRAPHIC):
+                image_pt = OrthographicProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (NCP):
+                image_pt = NCPProjection.RevProject(ra, dec, _params);
+                break;
+            case (ARC):
+                image_pt = ARCProjection.RevProject(ra, dec, _params);
+                break;
+            case (AITOFF):
+                image_pt = AitoffProjection.RevProject(ra, dec, _params);
+                break;
+            case (LINEAR):
+                image_pt = LinearProjection.RevProject(ra, dec, _params);
+                break;
+            case (CAR):
+                image_pt = CartesianProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (CEA):
+                image_pt = CylindricalProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (SFL):
+                image_pt = SansonFlamsteedProjection.RevProject(ra, dec, _params, useProjException);
+                break;
+            case (UNSPECIFIED):
+                if (useProjException) throw new ProjectionException("image contains no projection information");
+            default:
+                if (useProjException) throw new ProjectionException("projection is not implemented");
+        }
 
-    private ProjectionPt getImageCoordsInternal(double ra, double dec, boolean useProjException) throws ProjectionException
-    {
-	ProjectionPt image_pt = null;
-
-	switch (_params.maptype)
-	{
-	case (GNOMONIC):
-	    image_pt = GnomonicProjection.RevProject( ra, dec, _params, useProjException);
-	    break;
-	case (TPV):
-        image_pt = TpvProjection.RevProject( ra, dec, _params, useProjException);
-        break;
-	case (PLATE):
-	    image_pt = PlateProjection.RevProject( ra, dec, _params, useProjException);
-	    break;
-	case (ORTHOGRAPHIC):
-	    image_pt = OrthographicProjection.RevProject( ra, dec, _params, useProjException);
-	    break;
-	case (NCP):
-	    image_pt = NCPProjection.RevProject( ra, dec, _params);
-	    break;
-	case (ARC):
-	    image_pt = ARCProjection.RevProject( ra, dec, _params);
-	    break;
-	case (AITOFF):
-	    image_pt = AitoffProjection.RevProject( ra, dec, _params);
-	    break;
-	case (LINEAR):
-	    image_pt = LinearProjection.RevProject( ra, dec, _params);
-	    break;
-	case (CAR):
-	    image_pt = CartesianProjection.RevProject( ra, dec, _params, useProjException);
-	    break;
-	case (CEA):
-	    image_pt = CylindricalProjection.RevProject( ra, dec, _params, useProjException);
-	    break;
-	case (SFL):
-	    image_pt = SansonFlamsteedProjection.RevProject( ra, dec, _params, useProjException);
-	    break;
-	case (UNSPECIFIED):
-        if (useProjException) throw new ProjectionException("image contains no projection information");
-	default:
-        if (useProjException) throw new ProjectionException("projection is not implemented");
-	}
-	    
-	return (image_pt);
+        return (image_pt);
     }
 
 //    public ProjectionPt getImageCoords(WorldPt worldPt)
@@ -150,12 +152,12 @@ public class Projection implements Serializable {
 //	return (image_pt);
 //    }
 
-    public WorldPt getWorldCoords( double x, double y) throws ProjectionException {
+    public WorldPt getWorldCoords(double x, double y) throws ProjectionException {
         return getWorldCoordsInternal(x, y, true);
     }
 
 
-    public WorldPt getWorldCoordsSilent( double x, double y) {
+    public WorldPt getWorldCoordsSilent(double x, double y) {
         try {
             return getWorldCoordsInternal(x, y, false);
         } catch (ProjectionException e) { // exception will not happen since parameter turns if off
@@ -164,62 +166,63 @@ public class Projection implements Serializable {
     }
 
 
+    /**
+     * Convert "ProjectionPt" coordinates to World coordinates
+     * "ProjectionPt" coordinates have 0,0 in center of lower left pixel
+     * (same as "Skyview Screen" coordinates)
+     *
+     * @param x double precision in "ProjectionPt" coordinates
+     * @param y double precision in "ProjectionPt" coordinates
+     */
+    private WorldPt getWorldCoordsInternal(double x, double y, boolean useProjException) throws ProjectionException {
+        Pt pt = null;
 
-    /** Convert "ProjectionPt" coordinates to World coordinates
-    *    "ProjectionPt" coordinates have 0,0 in center of lower left pixel
-    *    (same as "Skyview Screen" coordinates)
-    * @param x double precision in "ProjectionPt" coordinates
-    * @param y double precision in "ProjectionPt" coordinates
-    */
+        switch (_params.maptype) {
+            case (GNOMONIC):
+                pt = GnomonicProjection.FwdProject(x, y, _params);
+                break;
+            case (TPV):
+                pt = TpvProjection.FwdProject(x, y, _params);
+                break;
+            case (STG):
+                pt = StereographicProjection.FwdProject(x, y, _params);
+                break;
+            case (PLATE):
+                pt = PlateProjection.FwdProject(x, y, _params);
+                break;
+            case (ORTHOGRAPHIC):
+                pt = OrthographicProjection.FwdProject(x, y, _params, useProjException);
+                break;
+            case (NCP):
+                pt = NCPProjection.FwdProject(x, y, _params);
+                break;
+            case (ARC):
+                pt = ARCProjection.FwdProject(x, y, _params);
+                break;
+            case (AITOFF):
+                pt = AitoffProjection.FwdProject(x, y, _params, useProjException);
+                break;
+            case (LINEAR):
+                pt = LinearProjection.FwdProject(x, y, _params);
+                break;
+            case (CAR):
+                pt = CartesianProjection.FwdProject(x, y, _params, useProjException);
+                break;
+            case (CEA):
+                pt = CylindricalProjection.FwdProject(x, y, _params, useProjException);
+                break;
+            case (SFL):
+                pt = SansonFlamsteedProjection.FwdProject(x, y, _params, useProjException);
+                break;
+            case (UNSPECIFIED):
+                if (useProjException) throw new ProjectionException("image contains no projection information");
+            default:
+                if (useProjException) throw new ProjectionException("projection is not implemented");
+        }
 
-    private WorldPt getWorldCoordsInternal(double x, double y, boolean useProjException)  throws ProjectionException {
-	Pt pt = null;
-
-	switch (_params.maptype)
-	{
-	case (GNOMONIC):
-	    pt = GnomonicProjection.FwdProject( x, y, _params);
-	    break;
-    case (TPV):
-        pt = TpvProjection.FwdProject( x, y, _params);
-        break;
-	case (PLATE):
-	    pt = PlateProjection.FwdProject( x, y, _params);
-	    break;
-	case (ORTHOGRAPHIC):
-	    pt = OrthographicProjection.FwdProject( x, y, _params, useProjException);
-	    break;
-	case (NCP):
-	    pt = NCPProjection.FwdProject( x, y, _params);
-	    break;
-	case (ARC):
-	    pt = ARCProjection.FwdProject( x, y, _params);
-	    break;
-	case (AITOFF):
-	    pt = AitoffProjection.FwdProject( x, y, _params, useProjException);
-	    break;
-	case (LINEAR):
-	    pt = LinearProjection.FwdProject( x, y, _params);
-	    break;
-	case (CAR):
-	    pt = CartesianProjection.FwdProject( x, y, _params, useProjException);
-	    break;
-	case (CEA):
-	    pt = CylindricalProjection.FwdProject( x, y, _params, useProjException);
-	    break;
-	case (SFL):
-	    pt = SansonFlamsteedProjection.FwdProject( x, y, _params, useProjException);
-	    break;
-	case (UNSPECIFIED):
-	    if (useProjException) throw new ProjectionException("image contains no projection information");
-	default:
-	    if (useProjException) throw new ProjectionException("projection is not implemented");
-	}
-
-	WorldPt world_pt = (pt!=null) ? new WorldPt(pt.getX(), pt.getY(), _coordSys) : null;
-	return (world_pt);
+        WorldPt world_pt = (pt != null) ? new WorldPt(pt.getX(), pt.getY(), _coordSys) : null;
+        return (world_pt);
     }
-
 
 //    public WorldPt getWorldCoords( ProjectionPt imagePt)
 //	throws ProjectionException
@@ -228,62 +231,62 @@ public class Projection implements Serializable {
 //	return (world_pt);
 //    }
 
-    public boolean isImplemented()
-    {
-	boolean retval;
+    public boolean isImplemented() {
+        boolean retval;
 
-	switch (_params.maptype)
-	{
-	    case (GNOMONIC):
-        case (TPV):
-	    case (PLATE):
-	    case (ORTHOGRAPHIC):
-	    case (NCP):
-	    case (ARC):
-	    case (AITOFF):
-	    case (LINEAR):
-	    case (CAR):
-	    case (CEA):
-	    case (SFL):
-		retval = true;
-		break;
-	    default:
-		retval = false;
-	}
-	return (retval);
+        switch (_params.maptype) {
+            case (GNOMONIC):
+            case (TPV):
+            case (STG):
+            case (PLATE):
+            case (ORTHOGRAPHIC):
+            case (NCP):
+            case (ARC):
+            case (AITOFF):
+            case (LINEAR):
+            case (CAR):
+            case (CEA):
+            case (SFL):
+                retval = true;
+                break;
+            default:
+                retval = false;
+        }
+        return (retval);
     }
 
     public boolean isSpecified()
     {
-	if (_params.maptype == UNSPECIFIED)
-	    return false;
-	else
-	    return true;
+        if (_params.maptype == UNSPECIFIED)
+            return false;
+        else
+            return true;
     }
 
     public boolean isWrappingProjection()
     {
-	boolean retval;
+        boolean retval;
 
-	switch (_params.maptype)
-	{
-	    case (GNOMONIC):
-        case (TPV):
-	    case (CAR):
-	    case (CEA):
-	    case (SFL):
-	    case (NCP):
-	    case (PLATE):
-	    case (ORTHOGRAPHIC):
-	    case (ARC):
-	    case (LINEAR):
-		retval = false;
-		break;
-	    case (AITOFF):
-	    default:
-		retval = true;
-	}
-	return (retval);
+        switch (_params.maptype)
+        {
+            case (GNOMONIC):
+            case (TPV):
+            case (STG):
+            case (CAR):
+            case (CEA):
+            case (SFL):
+            case (NCP):
+            case (PLATE):
+            case (ORTHOGRAPHIC):
+            case (ARC):
+            case (LINEAR):
+                retval = false;
+                break;
+            case (AITOFF):
+            default:
+                retval = true;
+        }
+        return (retval);
     }
 
 //    public static void main(String args[])
@@ -427,6 +430,9 @@ public class Projection implements Serializable {
             case (Projection.TPV):
                 retval = "TPV";
                 break;
+            case (Projection.STG):
+                retval = "STG";
+                break;
             case (Projection.ORTHOGRAPHIC):
                 retval = "ORTHOGRAPHIC";
                 break;
@@ -464,7 +470,4 @@ public class Projection implements Serializable {
         }
         return (retval);
     }
-
-
-
 }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/StereographicProjection.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/projection/StereographicProjection.java
@@ -1,0 +1,200 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.visualize.plot.projection;
+
+import edu.caltech.ipac.visualize.plot.ImageHeader;
+import edu.caltech.ipac.visualize.plot.ProjectionException;
+import edu.caltech.ipac.visualize.plot.ProjectionPt;
+import edu.caltech.ipac.visualize.plot.Pt;
+
+public class StereographicProjection {
+
+    static private final double DtoR = Math.PI/180.0;
+    static private final double RtoD = 180.0/Math.PI;
+
+    static public ProjectionPt RevProject(double ra, double dec, ProjectionParams hdr, boolean useProjException)
+            throws ProjectionException {
+        // variables for linear transformation from pixels coordinates to
+        // intermediate world (projection plane) coordinates
+        double rpp1, rpp2;
+        double rtwist, temp;
+
+        double lon = ra * DtoR;
+        double lat = dec * DtoR;
+        double alpha0 = hdr.crval1 * DtoR;  // reference longitude
+        double delta0 = hdr.crval2 * DtoR;  // reference latitude
+
+        double cos_lat = Math.cos(lat);
+        double sin_lat = Math.sin(lat);
+        double cos_delta0 = Math.cos(delta0);
+        double sin_delta0 = Math.sin(delta0);
+        double cos_dlon = Math.cos(lon - alpha0);
+        double sin_dlon = Math.sin(lon - alpha0);
+
+        // Calculate angular distance from reference point
+        double cos_c = sin_delta0 * sin_lat + cos_delta0 * cos_lat * cos_dlon;
+
+        // Check for points on opposite hemisphere (not visible in stereographic)
+        if (cos_c <= 0) {
+            if (useProjException) {
+                throw new ProjectionException("Point not visible in stereographic projection");
+            }
+            return null;
+        }
+
+        double k = 2.0 / (1.0 + cos_c);
+
+        // Calculate intermediate / projection plane coordinates
+        double fsamp = k * cos_lat * sin_dlon;
+        double fline = k * (cos_delta0 * sin_lat - sin_delta0 * cos_lat * cos_dlon);
+
+        // Linear transformation from projection plane coordinates to pixel coordinates
+        if (hdr.using_cd)
+        {
+            temp = (hdr.dc1_1 * fsamp + hdr.dc1_2 * fline) * RtoD;
+            fline = (hdr.dc2_1 * fsamp + hdr.dc2_2 * fline) * RtoD;
+            fsamp = temp;
+        }
+        else
+        {
+            rpp1 = hdr.cdelt1 * DtoR;
+            rpp2 = hdr.cdelt2 * DtoR;
+            /* do the twist */
+            rtwist = hdr.crota2 * DtoR;       /* convert to radians */
+            temp = fsamp * Math.cos(rtwist) + fline * Math.sin(rtwist);
+            fline = -fsamp * Math.sin(rtwist) + fline * Math.cos(rtwist);
+            fsamp = temp;
+
+            fsamp = (fsamp / rpp1);     /* now apply cdelt */
+            fline = (fline / rpp2);
+        }
+
+        // Apply inverse SIP distortion corrections if present
+        // Inverse SIP must be applied after the projection math but before converting to final pixel coords
+        if (hdr.map_distortion) {
+            double fsamp_correction = 0.0;
+            int len = (int)Math.min(hdr.ap_order + 1, ImageHeader.MAX_SIP_LENGTH);
+            for (int i = 0; i < len; i++) {
+                for (int j = 0; j < len; j++) {
+                    if (i + j <= hdr.ap_order) {
+                        fsamp_correction += hdr.ap[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+
+            double fline_correction = 0.0;
+            len = (int)Math.min(hdr.bp_order + 1, ImageHeader.MAX_SIP_LENGTH);
+            for (int i = 0; i < len; i++) {
+                for (int j = 0; j < len; j++) {
+                    if (i + j <= hdr.bp_order) {
+                        fline_correction += hdr.bp[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+            fsamp += fsamp_correction;
+            fline += fline_correction;
+        }
+
+        double x = fsamp + hdr.crpix1 - 1;
+        double y = fline + hdr.crpix2 - 1;
+
+        return new ProjectionPt(x, y);
+    }
+
+    static public Pt FwdProject(double x, double y, ProjectionParams hdr)
+            throws ProjectionException {
+        // variables for linear transformation from pixels coordinates to
+        // intermediate world (projection plane) coordinates
+        double rpp1, rpp2;
+        double rtwist, temp;
+        double xx, yy;
+
+        // Convert from pixel coordinates to intermediate pixel coordinates
+
+        // historical variable names:
+        // fsamp = intermediate x-coordinate (sample direction)
+        // fline = intermediate y-coordinate (line direction)
+        double fsamp = x - hdr.crpix1 + 1;
+        double fline = y - hdr.crpix2 + 1;
+
+        // Apply SIP distortion corrections if present
+        // SIP must be applied in pixel space, before the linear CD/PC transform and the projection
+        if (hdr.map_distortion) {
+            double fsamp_correction = 0.0;
+            int len = (int)Math.min(hdr.a_order + 1, ImageHeader.MAX_SIP_LENGTH);
+            for (int i = 0; i < len; i++) {
+                for (int j = 0; j < len; j++) {
+                    if (i + j <= hdr.a_order) {
+                        fsamp_correction += hdr.a[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+
+            double fline_correction = 0.0;
+            len = (int)Math.min(hdr.b_order + 1, ImageHeader.MAX_SIP_LENGTH);
+            for (int i = 0; i < len; i++) {
+                for (int j = 0; j < len; j++) {
+                    if (i + j <= hdr.b_order) {
+                        fline_correction += hdr.b[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+            fsamp += fsamp_correction;
+            fline += fline_correction;
+        }
+
+        // Linear transformation to intermediate world (projection plane) coordinates
+        if (hdr.using_cd)
+        {
+            // cdelt scaling factors are included int CD matrix coefficients
+            // both are in units of degrees
+            xx = (hdr.cd1_1 * fsamp + hdr.cd1_2 * fline) * DtoR;
+            yy = (hdr.cd2_1 * fsamp + hdr.cd2_2 * fline) * DtoR;
+        }
+        else
+        {
+            rpp1 = hdr.cdelt1 * DtoR;        /* radians per pixel */
+            rpp2 = hdr.cdelt2 * DtoR;        /* radians per pixel */
+            xx = fsamp * rpp1;
+            yy = fline * rpp2;
+
+            rtwist = hdr.crota2 * DtoR;       /* convert to radians */
+            temp = xx * Math.cos(rtwist) - yy * Math.sin(rtwist); /* do twist */
+            yy = xx * Math.sin(rtwist) + yy * Math.cos(rtwist);
+            xx = temp;
+        }
+
+        // Convert to radians
+        double xi_rad = xx;  // intermediate x-coordinate already in radians
+        double eta_rad = yy;  // intermediate y-coordinate already in radians
+        double alpha0 = hdr.crval1 * DtoR;  // reference longitude
+        double delta0 = hdr.crval2 * DtoR;  // reference latitude
+
+        // Stereographic projection formulas
+        double rho = Math.sqrt(xi_rad * xi_rad + eta_rad * eta_rad);
+        double c = 2.0 * Math.atan(rho / 2.0);
+
+        if (rho == 0.0) {
+            // At the reference point
+            return new Pt(hdr.crval1, hdr.crval2);
+        }
+
+        double cos_c = Math.cos(c);
+        double sin_c = Math.sin(c);
+        double cos_delta0 = Math.cos(delta0);
+        double sin_delta0 = Math.sin(delta0);
+
+        // Calculate latitude
+        double lat = Math.asin(cos_c * sin_delta0 + (eta_rad * sin_c * cos_delta0) / rho);
+
+        // Calculate longitude
+        double lon = alpha0 + Math.atan2(xi_rad * sin_c,
+                rho * cos_delta0 * cos_c - eta_rad * sin_delta0 * sin_c);
+
+        lat = lat * RtoD;
+        lon = (360. + lon * RtoD) % 360.; // handle negative value and greater than 360 value
+
+        return new Pt(lon, lat);
+    }
+}

--- a/src/firefly/js/visualize/projection/Projection.js
+++ b/src/firefly/js/visualize/projection/Projection.js
@@ -16,6 +16,7 @@ import {NCPProjection} from './NCPProjection.js';
 import {OrthographicProjection} from './OrthographicProjection.js';
 import {PlateProjection} from './PlateProjection.js';
 import {SansonFlamsteedProjection} from './SansonFlamsteedProjection.js';
+import {StereographicProjection} from './StereographicProjection.js';
 import {TpvProjection} from './TpvProjection.js';
 
 
@@ -33,6 +34,7 @@ export const ARC          = 1008;
 export const SFL          = 1009; // TESTED
 export const CEA          = 1010;
 export const TPV          = 1011;
+export const STG          = 1012;
 export const UNSPECIFIED  = 1998; // TESTED
 export const UNRECOGNIZED = 1999; // TESTED
 
@@ -109,6 +111,13 @@ const projTypes= {
 		revProject: SansonFlamsteedProjection.revProject,
         implemented : true,
         wrapping : true
+	},
+	[STG] : {
+		name: 'STG',
+		fwdProject: StereographicProjection.fwdProject,
+		revProject: StereographicProjection.revProject,
+		implemented : true,
+		wrapping : false
 	},
 	[LINEAR] : {
 		name: 'LINEAR',

--- a/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
+++ b/src/firefly/js/visualize/projection/ProjectionHeaderParser.js
@@ -5,7 +5,7 @@
 import {isUndefined} from 'lodash';
 import {DtoR, RtoD, computeDistance} from '../VisUtil.js';
 import { GNOMONIC, ORTHOGRAPHIC, NCP, AITOFF, CAR, LINEAR, PLATE,
-    ARC, SFL, CEA, TPV, UNSPECIFIED, UNRECOGNIZED } from './Projection.js';
+    ARC, SFL, CEA, TPV, STG, UNSPECIFIED, UNRECOGNIZED } from './Projection.js';
 import {findCoordSys, EQUATORIAL_J, EQUATORIAL_B, GALACTIC_JSYS,
     ECLIPTIC_B, SUPERGALACTIC_JSYS, ECLIPTIC_J, NONCELESTIAL} from '../CoordSys.js';
 import {MAX_SIP_LENGTH} from './ProjectionUtil.js';
@@ -122,11 +122,11 @@ export function parseSpacialHeaderInfo(header, altWcs='', zeroHeader) {
     /**
      * CTYPEi indicates the coordinate type and projection. According to the standard specified by the paper: Representations of world coordinates in FITS
      * E. W. Greisen1 and M. R. Calabretta2 (paper I). The CTYPEn has linear and non-linear.  Non-linear coordinate systems will be signaled by CTYPEi
-     * in “4–3” form: the first four characters specify the coordinate type, the fifth character is a ’-’, and the remaining three characters
-     * specify an algorithm code for computing the world coordinate value, for example ’ABCD-XYZ’. We explicitly allow the
-     * possibility that the coordinate type may augment the algorithm code, for example ’FREQ-F2W’ and ’VRAD-F2W’ may denote
+     * in “4–3” form: the first four characters specify the coordinate type, the fifth character is a '-', and the remaining three characters
+     * specify an algorithm code for computing the world coordinate value, for example 'ABCD-XYZ'. We explicitly allow the
+     * possibility that the coordinate type may augment the algorithm code, for example 'FREQ-F2W' and 'VRAD-F2W' may denote
      * somewhat different algorithms (see Paper III). Coordinate types with names of less than four characters are padded on the right
-     * with ’-’, and algorithm codes with less than three characters are padded on the right with blanks, for example ’RA---UV ’.
+     * with '-', and algorithm codes with less than three characters are padded on the right with blanks, for example 'RA---UV '.
      * However, we encourage the use of three-letter algorithm codes. Particular coordinate types and algorithm codes must be established by convention.
      * CTYPEi values that are not in “4–3” form should be interpreted as linear axes. It is possible that there may be old FITS files with a linear axis for
      * which CTYPEi is, by chance, in 4–3 form. However, it is very unlikely that it will match a recognized algorithm code (use of
@@ -152,6 +152,7 @@ export function parseSpacialHeaderInfo(header, altWcs='', zeroHeader) {
             case '-CEA': p.maptype = CEA; break;
             case '-SFL': p.maptype = SFL; break;
             case '-GLS': p.maptype = SFL; break;
+            case '-STG': p.maptype = STG; break;
             case '----':
             case '':     p.maptype = LINEAR; break;
             default :    p.maptype = UNRECOGNIZED;

--- a/src/firefly/js/visualize/projection/StereographicProjection.js
+++ b/src/firefly/js/visualize/projection/StereographicProjection.js
@@ -1,0 +1,188 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+import {DtoR, RtoD, MAX_SIP_LENGTH} from './ProjectionUtil.js';
+import {makeProjectionPt, makeImagePt} from '../Point.js';
+
+const StereographicProjection = {
+    
+    revProject(ra, dec, header) {
+        const {crval1, crval2, crpix1, crpix2, cdelt1, cdelt2, map_distortion} = header;
+        const {dc1_1, dc1_2, dc2_1, dc2_2, using_cd, crota2: twist} = header;
+
+        // Convert to radians
+        const lon = ra * DtoR;
+        const lat = dec * DtoR;
+        const alpha0 = crval1 * DtoR;  // reference longitude
+        const delta0 = crval2 * DtoR;  // reference latitude
+
+        const cos_lat = Math.cos(lat);
+        const sin_lat = Math.sin(lat);
+        const cos_delta0 = Math.cos(delta0);
+        const sin_delta0 = Math.sin(delta0);
+        const cos_dlon = Math.cos(lon - alpha0);
+        const sin_dlon = Math.sin(lon - alpha0);
+
+        // Calculate angular distance from reference point
+        const cos_c = sin_delta0 * sin_lat + cos_delta0 * cos_lat * cos_dlon;
+
+        // Check for points on opposite hemisphere (not visible in stereographic)
+        if (cos_c <= 0) {
+            return null; // Point not visible
+        }
+
+        const k = 2 / (1 + cos_c);
+
+        // Calculate intermediate / projection plane coordinates
+        let fsamp = k * cos_lat * sin_dlon;  // xi
+        let fline = k * (cos_delta0 * sin_lat - sin_delta0 * cos_lat * cos_dlon);  // eta
+
+        // Linear transformation from projection plane coordinates to pixel coordinates
+        if (using_cd) {
+            const temp = (dc1_1 * fsamp + dc1_2 * fline) * RtoD;
+            fline = (dc2_1 * fsamp + dc2_2 * fline) * RtoD;
+            fsamp = temp;
+        }
+        else {
+            // do the twist
+            const rtwist = twist * DtoR;       // convert to radians
+            const temp = fsamp * Math.cos(rtwist) + fline * Math.sin(rtwist);
+            fline = -fsamp * Math.sin(rtwist) + fline * Math.cos(rtwist);
+            fsamp = temp;
+
+            const rpp1 = cdelt1 * DtoR;
+            const rpp2 = cdelt2 * DtoR;
+            fsamp = (fsamp / rpp1);     // now apply cdelt
+            fline = (fline / rpp2);
+        }
+
+        // Apply inverse SIP distortion corrections if present
+        // Inverse SIP must be applied after the projection math but before converting to final pixel coords
+        if (map_distortion) {
+            let fsamp_correction = 0.0;
+            let len = Math.floor(Math.min(header.ap_order + 1, MAX_SIP_LENGTH));
+            for (let i = 0; i < len; i++) {
+                for (let j = 0; j < len; j++) {
+                    if (i + j <= header.ap_order) {
+                        fsamp_correction += header.ap[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+
+            let fline_correction = 0.0;
+            len = Math.floor(Math.min(header.bp_order + 1, MAX_SIP_LENGTH));
+            for (let i = 0; i < len; i++) {
+                for (let j = 0; j < len; j++) {
+                    if (i + j <= header.bp_order) {
+                        fline_correction += header.bp[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+            fsamp += fsamp_correction;
+            fline += fline_correction;
+        }
+
+        const x = fsamp + crpix1 - 1;
+        const y = fline + crpix2 - 1;
+
+        return makeImagePt(x, y);
+    },
+
+    fwdProject(x, y, header) {
+        const {crval1, crval2, crpix1, crpix2, cdelt1, cdelt2, map_distortion} = header;
+        const {cd1_1, cd1_2, cd2_1, cd2_2, using_cd, crota2: twist} = header;
+        // variables for linear transformation from pixels coordinates to
+        // intermediate world (projection plane) coordinates
+        let rpp1, rpp2;
+        let rtwist, temp;
+        let xx, yy;
+
+        // Convert from pixel coordinates to intermediate pixel coordinates
+
+        // historical variable names:
+        // fsamp = intermediate x-coordinate (sample direction) 
+        // fline = intermediate y-coordinate (line direction)
+        let fsamp = x - crpix1 + 1;
+        let fline = y - crpix2 + 1;
+
+        // Apply SIP distortion corrections if present
+        // SIP must be applied in pixel space, before the linear CD/PC transform and the projection
+        if (map_distortion) {
+            let fsamp_correction = 0.0;
+            let len = Math.floor(Math.min(header.a_order + 1, MAX_SIP_LENGTH));
+            for (let i = 0; i < len; i++) {
+                for (let j = 0; j < len; j++) {
+                    if (i + j <= header.a_order) {
+                        fsamp_correction += header.a[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+
+            let fline_correction = 0.0;
+            len = Math.floor(Math.min(header.b_order + 1, MAX_SIP_LENGTH));
+            for (let i = 0; i < len; i++) {
+                for (let j = 0; j < len; j++) {
+                    if (i + j <= header.b_order) {
+                        fline_correction += header.b[i][j] * Math.pow(fsamp, i) * Math.pow(fline, j);
+                    }
+                }
+            }
+            fsamp += fsamp_correction;
+            fline += fline_correction;
+        }
+
+        // Linear transformation to intermediate world (projection plane) coordinates
+        if (using_cd) {
+            // cdelt scaling factors are included int CD matrix coefficients
+            // both are in units of degrees
+            xx = (cd1_1 * fsamp + cd1_2 * fline) * DtoR;
+            yy = (cd2_1 * fsamp + cd2_2 * fline) * DtoR;
+        }
+        else {
+            rpp1 = cdelt1 * DtoR;        /* radians per pixel */
+            rpp2 = cdelt2 * DtoR;        /* radians per pixel */
+            xx = fsamp * rpp1;
+            yy = fline * rpp2;
+
+            rtwist = twist * DtoR;       /* convert to radians */
+            temp = xx * Math.cos(rtwist) - yy * Math.sin(rtwist); /* do twist */
+            yy = xx * Math.sin(rtwist) + yy * Math.cos(rtwist);
+            xx = temp;
+        }
+
+        // Convert to radians
+        const xi_rad = xx;  // intermediate x-coordinate already in radians
+        const eta_rad = yy;  // intermediate y-coordinate already in radians
+        const alpha0 = crval1 * DtoR;  // reference longitude
+        const delta0 = crval2 * DtoR;  // reference latitude
+
+        // Stereographic projection formulas
+        const rho = Math.sqrt(xi_rad * xi_rad + eta_rad * eta_rad);
+        const c = 2 * Math.atan(rho / 2);
+
+        if (rho === 0) {
+            // At the reference point
+            return makeProjectionPt(crval1, crval2);
+        }
+
+        const cos_c = Math.cos(c);
+        const sin_c = Math.sin(c);
+        const cos_delta0 = Math.cos(delta0);
+        const sin_delta0 = Math.sin(delta0);
+
+        // Calculate latitude
+        let lat = Math.asin(cos_c * sin_delta0 + (eta_rad * sin_c * cos_delta0) / rho);
+
+        // Calculate longitude
+        let lon = alpha0 + Math.atan2(xi_rad * sin_c,
+            rho * cos_delta0 * cos_c - eta_rad * sin_delta0 * sin_c);
+
+        lat = lat * RtoD;
+        lon = (360.0 + lon * RtoD) % 360.0; // handle negative value and greater than 360 value
+
+        return makeProjectionPt(lon, lat);
+    },
+
+};
+
+export {StereographicProjection};

--- a/src/firefly/js/visualize/projection/__tests__/StereographicProjection-test.js
+++ b/src/firefly/js/visualize/projection/__tests__/StereographicProjection-test.js
@@ -1,0 +1,206 @@
+import {StereographicProjection} from '../StereographicProjection.js';
+
+describe('StereographicProjection', () => {
+    const cmpNumDigits = 8;
+
+    // Base header for CDELT/CROTA2 tests
+    const cdeltHeader = {
+        crval1: 180.0,  // reference RA
+        crval2: 0.0,    // reference Dec
+        crpix1: 512.5,  // reference pixel X
+        crpix2: 512.5,  // reference pixel Y
+        cdelt1: 0.1,   // pixel scale X (degrees)
+        cdelt2: 0.1,    // pixel scale Y (degrees)
+        crota2: 0.0,    // rotation angle
+        using_cd: false
+    };
+
+    // Header with CROTA2 rotation
+    const rotatedHeader = {
+        ...cdeltHeader,
+        crota2: 30.0    // 30 degree rotation
+    };
+
+    // Header using CD matrix (equivalent to rotatedHeader)
+    const cdMatrixHeader = (() => {
+        const cos30 = Math.cos(30 * Math.PI / 180);
+        const sin30 = Math.sin(30 * Math.PI / 180);
+
+        // CD matrix for 30 degree rotation with scale [0.1, 0.1]
+        // CD = [cdelt1*cos(θ)  -cdelt2*sin(θ)]
+        //      [cdelt1*sin(θ)   cdelt2*cos(θ)]
+        const cd1_1 = 0.1 * cos30;  // cdelt1 * cos(θ)
+        const cd1_2 = -0.1 * sin30;  // -cdelt2 * sin(θ)
+        const cd2_1 = 0.1 * sin30;  // cdelt1 * sin(θ)
+        const cd2_2 = 0.1 * cos30;   // cdelt2 * cos(θ)
+
+        // Calculate inverse DC matrix
+        const det = cd1_1 * cd2_2 - cd1_2 * cd2_1;
+        const dc1_1 = cd2_2 / det;
+        const dc1_2 = -cd1_2 / det;
+        const dc2_1 = -cd2_1 / det;
+        const dc2_2 = cd1_1 / det;
+
+        return {
+            crval1: 180.0,
+            crval2: 0.0,
+            crpix1: 512.5,
+            crpix2: 512.5,
+            using_cd: true,
+            cd1_1, cd1_2, cd2_1, cd2_2,
+            dc1_1, dc1_2, dc2_1, dc2_2
+        };
+    })();
+
+    // Header with SIP distortion
+    const sipHeader = {
+        ...cdeltHeader,
+        map_distortion: true,
+        a_order: 2,
+        b_order: 2,
+        ap_order: 2,
+        bp_order: 2,
+        a: [[0, 0, 1e-6], [0, 0, 0], [1e-6, 0, 0]],
+        b: [[0, 0, 1e-6], [0, 0, 0], [1e-6, 0, 0]],
+        ap: [[0, 0, -1e-6], [0, 0, 0], [-1e-6, 0, 0]],
+        bp: [[0, 0, -1e-6], [0, 0, 0], [-1e-6, 0, 0]]
+    };
+
+    describe('CDELT/CROTA2 transformation', () => {
+        test('reference point handling', () => {
+            const result = StereographicProjection.fwdProject(512.5-1, 512.5-1, cdeltHeader);
+            expect(result.x).toBeCloseTo(180.0, cmpNumDigits);
+            expect(result.y).toBeCloseTo(0.0, cmpNumDigits);
+        });
+
+        test('round-trip conversion without rotation', () => {
+            const originalRA = 179.0;
+            const originalDec = 1.0;
+
+            const imageCoords = StereographicProjection.revProject(originalRA, originalDec, cdeltHeader);
+            expect(imageCoords).toBeTruthy();
+
+            const worldCoords = StereographicProjection.fwdProject(imageCoords.x, imageCoords.y, cdeltHeader);
+            expect(worldCoords.x).toBeCloseTo(originalRA, cmpNumDigits);
+            expect(worldCoords.y).toBeCloseTo(originalDec, cmpNumDigits);
+        });
+
+        test('round-trip conversion with CROTA2 rotation', () => {
+            const originalRA = 179.0;
+            const originalDec = 1.0;
+
+            const imageCoords = StereographicProjection.revProject(originalRA, originalDec, rotatedHeader);
+            expect(imageCoords).toBeTruthy();
+
+            const worldCoords = StereographicProjection.fwdProject(imageCoords.x, imageCoords.y, rotatedHeader);
+            expect(worldCoords.x).toBeCloseTo(originalRA, cmpNumDigits);
+            expect(worldCoords.y).toBeCloseTo(originalDec, cmpNumDigits);
+        });
+
+        test('rotation effect on pixel coordinates', () => {
+            const ra = 179.0;
+            const dec = 1.0;
+
+            const unrotated = StereographicProjection.revProject(ra, dec, cdeltHeader);
+            const rotated = StereographicProjection.revProject(ra, dec, rotatedHeader);
+
+            expect(unrotated).toBeTruthy();
+            expect(rotated).toBeTruthy();
+
+            // Coordinates should be different due to rotation
+            expect(Math.abs(unrotated.x - rotated.x)).toBeGreaterThan(0.1);
+            expect(Math.abs(unrotated.y - rotated.y)).toBeGreaterThan(0.1);
+        });
+    });
+
+    describe('CD matrix transformation', () => {
+        test('reference point handling with CD matrix', () => {
+            const result = StereographicProjection.fwdProject(512.5-1, 512.5-1, cdMatrixHeader);
+            expect(result.x).toBeCloseTo(180.0, cmpNumDigits);
+            expect(result.y).toBeCloseTo(0.0, cmpNumDigits);
+        });
+
+        test('round-trip conversion with CD matrix', () => {
+            const originalRA = 179.0;
+            const originalDec = 1.0;
+
+            const imageCoords = StereographicProjection.revProject(originalRA, originalDec, cdMatrixHeader);
+            expect(imageCoords).toBeTruthy();
+
+            const worldCoords = StereographicProjection.fwdProject(imageCoords.x, imageCoords.y, cdMatrixHeader);
+            expect(worldCoords.x).toBeCloseTo(originalRA, cmpNumDigits);
+            expect(worldCoords.y).toBeCloseTo(originalDec, cmpNumDigits);
+        });
+
+        test('CD matrix equivalent to CROTA2 transformation', () => {
+            const ra = 179.5;
+            const dec = 0.5;
+
+            const rotatedCoords = StereographicProjection.revProject(ra, dec, rotatedHeader);
+            const cdCoords = StereographicProjection.revProject(ra, dec, cdMatrixHeader);
+
+            expect(rotatedCoords).toBeTruthy();
+            expect(cdCoords).toBeTruthy();
+
+            // Results should be very close (within numerical precision)
+            expect(rotatedCoords.x).toBeCloseTo(cdCoords.x, cmpNumDigits);
+            expect(rotatedCoords.y).toBeCloseTo(cdCoords.y, cmpNumDigits);
+        });
+    });
+
+    describe('SIP distortion correction', () => {
+        test('round-trip conversion with SIP distortion', () => {
+            const originalRA = 179.0;
+            const originalDec = 1.0;
+
+            const imageCoords = StereographicProjection.revProject(originalRA, originalDec, sipHeader);
+            expect(imageCoords).toBeTruthy();
+
+            const worldCoords = StereographicProjection.fwdProject(imageCoords.x, imageCoords.y, sipHeader);
+            expect(worldCoords.x).toBeCloseTo(originalRA, cmpNumDigits);
+            expect(worldCoords.y).toBeCloseTo(originalDec, cmpNumDigits);
+        });
+
+        test('SIP distortion effect on coordinates', () => {
+            const ra = 178.0;
+            const dec = 2.0;
+
+            const undistorted = StereographicProjection.revProject(ra, dec, cdeltHeader);
+            const distorted = StereographicProjection.revProject(ra, dec, sipHeader);
+
+            expect(undistorted).toBeTruthy();
+            expect(distorted).toBeTruthy();
+
+            // Coordinates should be slightly different due to distortion
+            expect(Math.abs(undistorted.x - distorted.x)).toBeGreaterThan(0);
+            expect(Math.abs(undistorted.y - distorted.y)).toBeGreaterThan(0);
+        });
+    });
+
+    describe('edge cases and error handling', () => {
+        test('points on opposite hemisphere', () => {
+            // Point on opposite hemisphere should not be visible
+            const result = StereographicProjection.revProject(0.0, 0.0, cdeltHeader);
+            expect(result).toBeNull();
+        });
+
+        test('near-edge points', () => {
+            // Point near the edge of visibility (89 degrees from center)
+            const result = StereographicProjection.revProject(180.0, 89.0, cdeltHeader);
+            expect(result).toBeTruthy();
+        });
+
+        test('large coordinate values', () => {
+            // Test with coordinates far from reference point
+            const originalRA = 170.0;
+            const originalDec = 30.0;
+
+            const imageCoords = StereographicProjection.revProject(originalRA, originalDec, cdeltHeader);
+            expect(imageCoords).toBeTruthy();
+
+            const worldCoords = StereographicProjection.fwdProject(imageCoords.x, imageCoords.y, cdeltHeader);
+            expect(worldCoords.x).toBeCloseTo(originalRA, cmpNumDigits);
+            expect(worldCoords.y).toBeCloseTo(originalDec, cmpNumDigits);
+        });
+    });
+});

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/plotdata/GeomTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/plotdata/GeomTest.java
@@ -6,14 +6,14 @@ package edu.caltech.ipac.visualize.plot.plotdata;
 
 import edu.caltech.ipac.firefly.util.FileLoader;
 import edu.caltech.ipac.firefly.util.FitsValidation;
-import edu.caltech.ipac.visualize.plot.ImageHeader;
+// import edu.caltech.ipac.visualize.plot.ImageHeader;
 import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.Header;
 import nom.tam.fits.ImageHDU;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -24,20 +24,17 @@ import java.io.IOException;
  */
 public class GeomTest extends FitsValidation {
 
+    private static Fits  inFits=null;
+    // private static ImageHeader expectedImageHeader=null;
 
 
-    private static String fileName = "f3.fits";
-    private  Fits  inFits=null;
-    private ImageHeader expectedImageHeader=null;
-    private Geom geom=null;
-
-
-    @Before
     /**
-     * An one dimensional array is created and it is used to run the unit test
+     * A one dimensional array is created and  used to run the unit test
      */
-    public void setUp() throws FitsException, ClassNotFoundException, IOException {
+    @BeforeClass
+    public static void setUp() throws FitsException, ClassNotFoundException, IOException {
 
+        String fileName = "f3.fits";
         inFits = FileLoader.loadFits(GeomTest.class, fileName);
 
         //get the expected ImageHeader from calling it directly
@@ -53,19 +50,16 @@ public class GeomTest extends FitsValidation {
         }
 
         if (HDU_offset < 0) HDU_offset = 0;
-        expectedImageHeader = new ImageHeader(header, HDU_offset,planeNumber);
-
-        geom = new Geom();
+        // expectedImageHeader = new ImageHeader(header, HDU_offset,planeNumber);
     }
-    @After
+
     /**
      * Release the memories
      */
-    public void tearDown() {
+    @AfterClass
+    public static void tearDown() {
         inFits=null;
-        expectedImageHeader=null;
-        geom=null;
-
+        // expectedImageHeader=null;
     }
 
 //    @Test
@@ -100,38 +94,37 @@ public class GeomTest extends FitsValidation {
 //
 //    }
 
-    @Test
-    public void endToEndTest() throws FitsException, IOException, GeomException {
-
-
-        testGeomDefault();
-        testComputeTiePoints();
-        //testUsingBiLinear();  //TODO disable it due to the change in the FITs header
-        testUsingNearestNeighbor();
-        testDeriveOutput();
-        testOverrideNaxis();
-        testPixelFraction();
-        testOverridCdelt11();
-        testOverridCdelt12();
-        testOverridCrval1();
-        testOverridCrval2();
-        testOverridCtype1();
-        testOverridCrot2();
-
-
-        testGeomException();
-        testGeomWithRefFits();
-
-    }
+//    @Test
+//    public void endToEndTest() throws FitsException, IOException, GeomException {
+//        testGeomDefault();
+//        testComputeTiePoints();
+//        //testUsingBiLinear();  //TODO disable it due to the change in the FITs header
+//        testUsingNearestNeighbor();
+//        testDeriveOutput();
+//        testOverrideNaxis();
+//        testPixelFraction();
+//        testOverridCdelt11();
+//        testOverridCdelt12();
+//        testOverridCrval1();
+//        testOverridCrval2();
+//        testOverridCtype1();
+//        testOverridCrot2();
+//
+//        testGeomException();
+//        testGeomWithRefFits();
+//        testStgToSinReprojection();
+//    }
 
     /**test default Geom case
      Input f3.fits
      Expected result Fits f3_Geom_default.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testGeomDefault() throws FitsException, IOException, GeomException {
         String fileName = "f3_Geom_default.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
+        Geom geom = new Geom();
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
     }
@@ -141,67 +134,68 @@ public class GeomTest extends FitsValidation {
      *  Input f3.fits
      *  Expected result file f3_Geom_skip15.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testComputeTiePoints()throws FitsException, IOException, GeomException {
 
         String fileName = "f3_Geom_skip15.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.tie_skip = 15;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
-
     }
     /**
      * Test setting interpolation to bi-linear
      *  Input f3.fits
      *  Expected result file f3_Geom_ib.fits which was created by GeomTestMain.java what Booth wrote.
+     *  TODO: this test is failing - needs update (tests non-default interp_flag value)
      */
-    public void testUsingBiLinear()throws FitsException, IOException, GeomException {
+    public void testUsingBiLinear() throws FitsException, IOException, GeomException {
         String fileName = "f3_Geom_ib.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.interp_flag= true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
+
     /**
      * Test setting interpolation to nearest neighbor
      *  Input f3.fits
      *  Expected result file f3_Geom_in.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testUsingNearestNeighbor() throws FitsException, IOException, GeomException {
         String fileName = "f3_Geom_in.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.interp_flag= false;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
     }
+
     /**
-     * Test to derive output naxis and crpix values from input
-     *
+     * Test to derive output naxis and crpix values from the input.
      *  Input f3.fits
      *  Expected result file f3_Gemo_derived.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testDeriveOutput() throws FitsException, IOException, GeomException{
         String fileName = "f3_Gemo_derived.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_naxis1 = 0;
         geom.n_override_naxis1 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
 
     /**
@@ -210,16 +204,16 @@ public class GeomTest extends FitsValidation {
      *  Input f3.fits
      *  Expected result file f3_Geom_pixelValue_0.7.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testPixelFraction() throws FitsException, IOException, GeomException{
         String fileName = "f3_Geom_pixelValue_0.7.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.min_wgt=0.7;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
 
     /**
@@ -228,21 +222,20 @@ public class GeomTest extends FitsValidation {
      *  Input f3.fits
      *  Expected result file f3_Geom_overrideNaxis_100.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testOverrideNaxis() throws FitsException, IOException, GeomException{
         String fileName = "f3_Geom_overrideNaxis_100.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_naxis1=100;
         geom.override_naxis2=100;
         geom.n_override_naxis1 = true;
         geom.n_override_naxis2 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
-
 
     /**
      * Test setting overriding cdelt1 value
@@ -250,35 +243,36 @@ public class GeomTest extends FitsValidation {
      *  Input f3.fits
      *  Expected result file f3_Geom_overrideCdelt1_0.03333.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testOverridCdelt11() throws FitsException, IOException, GeomException {
         String fileName = "f3_Geom_overrideCdelt1_0.03333.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_cdelt1 = 0.03333;
         geom.n_override_cdelt1 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
+
     /**
      * Test setting overriding cdelt2 value
      *  cdelt2=0.03333;
      *  Input f3.fits
      *  Expected result file f3_Geom_overrideCdelt2_0.03333.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testOverridCdelt12() throws FitsException, IOException, GeomException{
         String fileName = "f3_Geom_overrideCdelt2_0.03333.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_cdelt2 = 0.03333;
         geom.n_override_cdelt2 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
 
     /**
@@ -287,30 +281,32 @@ public class GeomTest extends FitsValidation {
      *  Input f3.fits
      *  Expected result file f3_Geom_overrideCrval1_200.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testOverridCrval1() throws FitsException, IOException, GeomException{
         String fileName = "f3_Geom_overrideCrval1_200.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_crval1 = 200.0;
         geom.n_override_crval1 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
+
     /**
      * Test setting overriding crval2 value
      *  crval2=200;
      *  Input f3.fits
      *  Expected result file f3_Geom_overrideCrval2_200.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testOverridCrval2() throws FitsException, IOException, GeomException {
         String fileName = "f3_Geom_overrideCrval2_70.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_crval2 = 70;
         geom.n_override_crval2 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
@@ -318,15 +314,12 @@ public class GeomTest extends FitsValidation {
     }
 
     /**
-     * This method test if the the Geom catch the exception when the parameter is wrong
-     * @throws FitsException
-     * @throws IOException
+     * Test that Geom catches the exception when the parameter is wrong
      */
+    @Test
     public void testGeomException() throws FitsException, IOException{
-
-
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_naxis1=2;
         geom.override_naxis2=2;
         geom.n_override_naxis1 = true;
@@ -343,22 +336,21 @@ public class GeomTest extends FitsValidation {
 
     /**
      * Test setting overriding ctype1=GLON
-     *  ctype1 = "GLON
+     *  ctype1=GLON
      *  Input f3.fits
      *  Expected result file f3_Geom_overrideCtype1GLON.fits which was created by GeomTestMain.java what Booth wrote.
      */
-
+    @Test
     public void testOverridCtype1() throws FitsException, IOException, GeomException {
         String fileName = "f3_Geom_overrideCtype1GLON.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_ctype1 = "GLON";
         geom.n_override_ctype1 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
     }
 
     /**
@@ -367,19 +359,17 @@ public class GeomTest extends FitsValidation {
      *  Input f3.fits
      *  Expected result file f3_Geom_Crota2_0.5.fits which was created by GeomTestMain.java what Booth wrote.
      */
-
+    @Test
     public void testOverridCrot2() throws FitsException, IOException, GeomException{
         String fileName = "f3_Geom_Crota2_0.5.fits";
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, fileName);
 
         Geom geom = new Geom();
-        setCommomParametrs(geom);
+        setCommonParameters(geom);
         geom.override_crota2 = 0.5;
         geom.n_override_crota2 = true;
         Fits acutualFits = geom.do_geom(inFits, null);
         validateFits(expectedFits,acutualFits);
-
-
     }
 
     /**test Geom case
@@ -387,9 +377,11 @@ public class GeomTest extends FitsValidation {
      reference f3Ref.fits (this is created by rotation f3.fits by 10 degree)
      Expected result Fits f3_withRef.fits which was created by GeomTestMain.java what Booth wrote.
      */
+    @Test
     public void testGeomWithRefFits() throws FitsException, IOException, GeomException {
         String fileName = "f3Ref.fits";
         Fits refFits =  FileLoader.loadFits(GeomTest.class, fileName);
+        Geom geom = new Geom();
         Fits acutualFits = geom.do_geom(inFits, refFits);
         Assert.assertNotNull(acutualFits);
 
@@ -397,13 +389,90 @@ public class GeomTest extends FitsValidation {
         Fits expectedFits =  FileLoader.loadFits(GeomTest.class, expcFileName);
         validateFits(expectedFits,acutualFits);
         validateFits(expectedFits,acutualFits);
-
     }
 
+    /**
+     * Test reprojecting wise-w1-SIN.fits to STG projection using wise-w1-STG.fits as reference
+     * and validating that the reprojected data remains close
+     */
+    @Test
+    public void testStgToSinReprojection() throws FitsException, IOException, GeomException {
+        String sinFileName = "wise-w1-SIN.fits";
+        String stgFileName = "wise-w1-STG.fits";
 
+        // Load input SIN projection FITS
+        Fits sinFits = FileLoader.loadFits(GeomTest.class, sinFileName);
 
-    private void setCommomParametrs(Geom geom){
+        // Load STG projection FITS as reference
+        Fits stgRefFits = FileLoader.loadFits(GeomTest.class, stgFileName);
 
+        for (boolean interpFlag : new boolean[]{false, true}) {
+            String interpMode = interpFlag ? "bilinear" : "nearest neighbor";
+
+            Geom geom = new Geom();
+            geom.interp_flag = interpFlag;
+
+            // perform reprojection using STG as reference
+            Fits reprojectedFits = geom.do_geom(sinFits, stgRefFits);
+
+            Assert.assertNotNull("Reprojected FITS should not be null (" + interpMode + ")", reprojectedFits);
+
+            // Get the image data from both reprojected result and reference
+            ImageHDU reprojectedHDU = (ImageHDU) reprojectedFits.getHDU(0);
+            ImageHDU referenceHDU = (ImageHDU) stgRefFits.getHDU(0);
+
+            float[][] reprojectedData = (float[][]) reprojectedHDU.getKernel();
+            float[][] referenceData = (float[][]) referenceHDU.getKernel();
+
+            // Validate dimensions match
+            Assert.assertEquals("Height should match (" + interpMode + ")",
+                    referenceData.length, reprojectedData.length);
+            Assert.assertEquals("Width should match (" + interpMode + ")",
+                    referenceData[0].length, reprojectedData[0].length);
+
+            // Check that pixel values are reasonably close
+            int validPixelCount = 0;
+            int closePixelCount = 0;
+            // we don't expect exact matches if interpolation is used
+            double tolerance = 0.01; // 1% tolerance for pixel value differences
+
+            for (int y = 0; y < referenceData.length; y++) {
+                for (int x = 0; x < referenceData[y].length; x++) {
+                    float refValue = referenceData[y][x];
+                    float reprojValue = reprojectedData[y][x];
+
+                    // Skip NaN values
+                    if (!Float.isNaN(refValue) && !Float.isNaN(reprojValue)) {
+                        validPixelCount++;
+
+                        // Check if values are close (within tolerance)
+                        if (Math.abs(refValue) < 1e-6) {
+                            // For very small values, use absolute difference
+                            if (Math.abs(reprojValue - refValue) < 1e-6) {
+                                closePixelCount++;
+                            }
+                        } else {
+                            // For larger values, use relative difference
+                            double relativeDiff = Math.abs((reprojValue - refValue) / refValue);
+                            if (relativeDiff < tolerance) {
+                                closePixelCount++;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // require that valid pixels are close to reference values
+            double closePixelRatio = (double) closePixelCount / validPixelCount;
+            Assert.assertTrue(
+                    String.format("Expected at least 99.9%% of pixels to be close to reference values (%s), but got %.2f%% (%d/%d)",
+                            interpMode, closePixelRatio * 100, closePixelCount, validPixelCount),
+                    closePixelRatio >= .999
+            );
+        }
+    }
+
+    private void setCommonParameters(Geom geom) {
         geom.crpix1_base = 162.5;
         geom.crpix2_base = 485.5;
         geom.imageScaleFactor = 89;
@@ -421,5 +490,4 @@ public class GeomTest extends FitsValidation {
         geom.n_override_crval2 = false;
         geom.n_override_crota2 = false;
     }
-
 }

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/projection/ProjectionTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/projection/ProjectionTest.java
@@ -211,6 +211,53 @@ public class ProjectionTest {
 
     }
 
+
+    @Test
+    public void testStgProjection() throws ProjectionException, Exception {
+//        // Uncomment to regenerate sample for js test.
+//        String path = FileLoader.getDataPath(ProjectionTest.class);
+//        String[] fNames = {"roman-SGT_200x240.fits"};
+//        FitsHeaderToJson.writeImageHeaderProjectionToJson(path + fNames[0]);
+
+        Fits fits = new Fits(new File(FileLoader.getDataPath(ProjectionTest.class) + "roman-SGT_200x240.fits"));
+        FitsRead[] fitsReadArray = FitsReadFactory.createFitsReadArray(fits);
+
+        FitsRead reader = fitsReadArray[0];
+        CoordinateSys cs = CoordinateSys.EQ_J2000;
+        ImageHeader imageHeader = new ImageHeader(reader.getHeader());
+        Projection proj = imageHeader.createProjection(cs);
+
+        // WorldPt worldCoords = proj.getWorldCoords(10.7759522, 41.19942861);
+        // System.out.println(proj.getProjectionName()+": "+worldCoords.getLon()+", "+worldCoords.getLat());
+
+        // x, y are zero-based, hence not quite corners
+        // should match astropy's wcs.pixel_to_world([1, 1, 200, 200], [1, 240, 240, 1])
+        // <SkyCoord (ICRS): (ra, dec) in deg
+        //    [(9.78256769, -44.25126713), (9.78255745, -44.24867384),
+        //     (9.77954305, -44.2486799 ), (9.77955316, -44.2512732 )]>
+        double[] x_vals = {1.0, 1.0, 200.0, 200.0};
+        double[] y_vals = {1.0, 240.0, 240.0, 1.0};
+        double[] ra_vals = {9.78256769, 9.78255745, 9.77954305, 9.77955316};
+        double[] dec_vals = {-44.25126713, -44.24867384, -44.2486799, -44.2512732};
+
+        for (int i = 0; i < x_vals.length; i++){
+            double ra = ra_vals[i];
+            double dec = dec_vals[i];
+            double x =  x_vals[i];
+            double y = y_vals[i];
+
+            ProjectionPt pix = proj.getImageCoords(ra, dec);
+
+            Assert.assertEquals(pix.getX(),  x, 1E-01);
+            Assert.assertEquals(pix.getY(), y,1E-01);
+
+            WorldPt pix2 = proj.getWorldCoords(x, y);
+
+            Assert.assertEquals(pix2.getLon(), ra, 1E-06);
+            Assert.assertEquals(pix2.getLat(), dec, 1E-06);
+        }
+    }
+
     /**
      * This main method is used to create unit test reference files.
      *


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1834

- Implemented Stereographic projection and added unit tests
- Added a test for Geom.java to cover a case when reference file has different sky projection (to eliminate a possible cause of the readout bug in 3-color, see [FIREFLY-1865](https://jira.ipac.caltech.edu/browse/FIREFLY-1865).
- The test data for unit tests are in `SP-1834_stg_projection` branch in `firefly_test_data` repo.

Test images with STG projection:
- Roman coadd images (simulated images from OpenUniverse 2024 set) 500MB
  - https://irsa.ipac.caltech.edu/data/theory/openuniverse2024/roman/preview/RomanWAS/images/coadds/F184/Row12/
  - https://irsa.ipac.caltech.edu/data/theory/openuniverse2024/roman/preview/RomanWAS/images/coadds/H158/Row12/
- Attched to the ticket:
  - 200KB cutouts (2 bands) from 2 science images above (first image in each directory)
  - WISE Allsky cutout (SIN), reprojected to TAN and STG

Known issue with 3-color using different projections: [FIREFLY-1865](https://jira.ipac.caltech.edu/browse/FIREFLY-1865)

Also added a small fix to `eslint.config.mjs`, to prevent eslint reporting Node globals like `require` as unknown functions in the tests.