### PR TITLE
FIREFLY-1865: Incorrect pixel readout in 3-color with reprojection

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ModFileWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/ModFileWriter.java
@@ -8,7 +8,10 @@ import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.visualize.Band;
 import edu.caltech.ipac.firefly.visualize.PlotState;
 import edu.caltech.ipac.util.FileUtil;
+import edu.caltech.ipac.visualize.plot.ActiveFitsReadGroup;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsReadFactory;
+import nom.tam.fits.Fits;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,12 +37,23 @@ public class ModFileWriter {
      * Write the fits file and update data structures
      * @param state the PlotState to update
      */
-    public void writeFile(PlotState state) {
+    public void writeFile(PlotState state, ActiveFitsReadGroup frGroup) {
         PlotStateUtil.setWorkingFitsFile(state, targetFile, band);
         try {
             fr.writeSimpleFitsFile(targetFile);
         } catch (IOException e) {
-            Logger.getLogger().warn(e,"geom write failed", "geom file: "+targetFile.getPath());
+            Logger.getLogger().warn(e, "Failed to write geom for band "+band, "geom file: "+targetFile.getPath());
+        }
+
+        // re-create FitsRead arrays after files are written to disk to ensure correct SPOT_HS headers
+        try {
+            if (targetFile.exists()) {
+                Fits fits = new Fits(targetFile);
+                FitsRead[] fitsReadArray = FitsReadFactory.createFitsReadArray(fits);
+                frGroup.setFitsRead(band, fitsReadArray[0]);
+            }
+        } catch (Exception e) {
+            Logger.getLogger().warn(e, "Failed to refresh FitsRead for band "+band, "geom file: "+targetFile.getPath());
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/WebPlotFactory.java
@@ -123,7 +123,7 @@ public class WebPlotFactory {
                 ModFileWriter mfw = entry.getValue();
                 if (mfw != null) {
                     pi.state().setImageIdx(0, entry.getKey());
-                    mfw.writeFile(state);
+                    mfw.writeFile(state, pi.fitsReadGroup());
                 }
             }
         }

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -358,7 +358,9 @@ public class FitsRead implements Serializable, HasSizeOf {
     }
 
     public void writeSimpleFitsFile(File f) throws IOException{
-        createNewFits().write(f);
+        Fits fits = createNewFits();
+        fits.write(f);
+        fits.close();
     }
 
     public void clearHDU() { this.hdu= null; }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1865 (test images attached)
Test Build: https://fireflydev.ipac.caltech.edu/firefly-1865-readout/firefly

Fixed flux readout bug in 3-color image with re-projection.

To test:
- Images -> Create 3-color composite -> use images with different projections for different bands.
- Test images that should produce identical readout are attached to the ticket.
- Check flux readout from different bands.