### PR TITLE
IRSA-7248: Fix combined Euclid spectra (and multi-trace chart) bugs 

### DIFF
--- a/src/firefly/js/charts/dataTypes/FireflyGenericData.js
+++ b/src/firefly/js/charts/dataTypes/FireflyGenericData.js
@@ -354,9 +354,9 @@ export function addScatterChanges({changes, chartId, traceNum, tablesource, tabl
     // hoverinfo 'skip' disables hover layer - hence we can not highlight clicking on a point or select points in the chart
     // if we support it, we need to exclude select button from the tools appearing on select
     // also, we might want to disable showing highlighted and selected points in the chart
-    if (get(data, `${traceNum}.hoverinfo`, 'text') === 'text') {
+    const y = get(changes, [`data.${traceNum}.y`]);
+    if (y && get(data, `${traceNum}.hoverinfo`, 'text') === 'text') {
         const text = x.map((xval, idx) => {
-            const y = get(changes, [`data.${traceNum}.y`]);
             const yval = y[idx];
             const xerr = hasXErrors ? formatError(xval, xErr[idx], xErrLow[idx], xErrHigh[idx]) : '';
             const yerr = hasYErrors ? formatError(yval, yErr[idx], yErrLow[idx], yErrHigh[idx]) : '';

--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -469,10 +469,11 @@ function filterOptions(options, opts) {
 
 /*
  * This function returns a collection of components using `useCallback`, ensuring they are not recreated between re-renders.
- * To modify this behavior, you can set the `deps` parameter accordingly.
+ * To modify this behavior, you can set the `deps` parameter accordingly. By default, `deps` is set to activeTrace so that
+ * components re-render when the active trace changes.
  */
 export const useBasicOptions = ({activeTrace:pActiveTrace, chartId, tbl_id, groupKey, isXNotNumeric,
-                                  isYNotNumeric, xNoLog, yNoLog, orientation='horizontal'}, deps=[]) => {
+                                  isYNotNumeric, xNoLog, yNoLog, orientation='horizontal'}, deps=[pActiveTrace]) => {
     const {activeTrace, data, layout, fireflyLayout, color, ...rest} = getChartProps(chartId, tbl_id, pActiveTrace);
     xNoLog = xNoLog ?? rest.xNoLog;
     yNoLog = yNoLog ?? rest.yNoLog;


### PR DESCRIPTION
Fixes [IRSA-7248](https://jira.ipac.caltech.edu/browse/IRSA-7248): **refer to my comment on this ticket** since it has evolved since it was created

- Allow re-render of `useBasicOptions` components when trace changes - this was a regression issue, likely introduced [in this PR](https://github.com/Caltech-IPAC/firefly/pull/1614/files#diff-48ae7375b9d501164e453813c277305cf7f0af205cd619092f5407d87c01d4b7R472)
- The chart modifications trigger `addScatterChanges` (to handle table source connections for other traces), which doesn't always have `y` defined causing chart to throw runtime error and get stuck loading


## Testing
Firefly: https://fireflydev.ipac.caltech.edu/irsa-7248-combine-charts-bugs/firefly

- Upload a spectra file with more than one traces (use the Spitzer spectra linked in ticket)
- Open chart options (gears dialog), check you can change trace from "choose trace" listbox and it reflects changes in the listbox and trace options fields
- Do any modification. change chart title, apply -> change trace -> apply -> no errors in console/ chart shouldn't get stuck

Euclid: https://irsa-7248-combine-charts-bugs.irsakubedev.ipac.caltech.edu/applications/euclid

Combine a few spectra rows, and open chart options for the combined spectra chart. Then do same as above or items 3, 7, 8 from @lrebull's Euclid testing list. They shouldn't make chart freeze.

> NOTE: multi-trace chart still has some problems when applying chart modifications from the dialog because some of them propogate to other traces and some don't and then changing trace causes things like error bars, redshift spectral frame to disapper, etc. But we should track them in separate ticket (since they may require some redesign of dialog itself).