### PR TITLE
IRSA-7344: Download Dialog Improvements and Bug fixes

### DIFF
--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -22,6 +22,8 @@ import {CheckboxGroupInputField, SelectAllCheckbox} from 'firefly/ui/CheckboxGro
 import {FormControl, FormLabel, Stack, Typography} from '@mui/joy';
 import {ToolbarButton} from 'firefly/ui/ToolbarButton';
 import {FieldGroup} from 'firefly/ui/FieldGroup';
+import {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils';
+import {makeFoVString} from 'firefly/visualize/ZoomUtil';
 
 export const getAllStartIds= ()=> [
     getMocWatcherDef().id,
@@ -112,6 +114,8 @@ function ProductTypesBlock({tbl_id, dynamicOptions, cutoutValue}) {
 
     const isCutoutSelected = productTypes?.split(',').map((val) => val.trim()).includes('#cutout') ?? false;
 
+    const defaultValue = dynamicOptions.find((o) => o.value === '#this')?.value ?? '';
+
     return (<Stack spacing={2}>
             <FormControl>
                 <Stack direction='row' alignItems='center' spacing={1}>
@@ -129,18 +133,29 @@ function ProductTypesBlock({tbl_id, dynamicOptions, cutoutValue}) {
                         groupKey={tbl_id}
                         options={dynamicOptions}
                         //initialState={{ value: dynamicOptions.map((o) => o.value).toString() }} //this is if we want to keep default all  vals selected
-                        initialState={{ value: '' }}
+                        initialState={{value: defaultValue}}
                         alignment='horizontal'
                     />
                     {isCutoutSelected && (
                         <Typography level='body-sm' sx={{ ml: 1 }}>
-                            Note: the current cutout size is {cutoutValue} deg
+                            Note: the current cutout size is {makeFoVString(Number(cutoutValue))}
                             (you may change this via the cutout dialog).
                         </Typography>
                     )}
                 </Stack>
             </FormControl>
         </Stack>);
+}
+
+function validateProductSelection(formInputs, groupKey) {
+    const productTypes = getFieldVal(groupKey, 'productTypes');
+    const hasProductBlock = !!productTypes || formInputs?.productTypes !== undefined;
+
+    //if product types (checkboxes) exist but no selection was made
+    if (hasProductBlock && (!productTypes?.trim())) {
+        return {valid: false, message: 'Please select at least one product type to download.'};
+    }
+    return {valid: true};
 }
 
 
@@ -235,6 +250,7 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
                                 groupKey: tbl_id,
                                 tbl_id,
                                 downloadType,
+                                validateOnSubmit: validateProductSelection,
                                 dlParams: {
                                     FileGroupProcessor:'ObsCorePackager',
                                     worker: downloadType === 'script' ? 'DownloadScriptWorker' : 'PackagingWorker',

--- a/src/firefly/js/ui/DefaultSearchActions.js
+++ b/src/firefly/js/ui/DefaultSearchActions.js
@@ -273,8 +273,12 @@ async function showDatalinkTable() {
     const {tbl_id, serviceId} = result;
 
     const {tbl_ui_id, leftButtons = []} = getTableUiByTblId(tbl_id) ?? {};
-    leftButtons.unshift(() => <PrepareDownload tbl_id={tbl_id} viewerId={serviceId} downloadType={'script'} dataSource={serviceId}/>);
-    dispatchTableUiUpdate({ tbl_ui_id, leftButtons });
+
+    if (leftButtons.some((lb) => lb.prepareDownloadBtn)) return;
+
+    leftButtons.unshift(() => <PrepareDownload tbl_id={tbl_id} viewerId={serviceId} downloadType={'script'}
+                                               dataSource={serviceId}/>);
+    dispatchTableUiUpdate({tbl_ui_id, leftButtons});
     showPinMessage('Pinning to Table Area');
 }
 

--- a/src/firefly/js/ui/DownloadDialog.jsx
+++ b/src/firefly/js/ui/DownloadDialog.jsx
@@ -150,7 +150,7 @@ export function DownloadOptionPanel ({groupKey='DownloadDialog', cutoutSize, hel
             return showInfoPopup('You have not chosen any data to download', 'No Data Selected');
         }
 
-        const {valid, message} = validateOnSubmit?.(formInputs) ?? {valid : true};
+        const {valid, message} = validateOnSubmit?.(formInputs, groupKey) ?? {valid : true};
         if (!valid) {
             showInfoPopup(message ?? 'Invalid form input(s)', 'Error in form inputs');
             return false; // to prevent FormPanel to submit


### PR DESCRIPTION
**[Ticket](https://jira.ipac.caltech.edu/browse/IRSA-7344)**: 
- See [IFE PR](https://github.com/IPAC-SW/irsa-ife/pull/444)
- The code changes are small, but aim to fix all existing bugs and make important improvements to the download dialog
- Bug fixes: 
   - The datalink table (that you get to on Euclid, for instance, by clicking on `Show table of all Euclid products`) was displaying two download buttons
   - I think this happened because our code to detect `ObsCore` like tables recently got better, and recognized datalink tables as obscore-ish tables and added a download button to them. Now, adding a check in the `DefaultSearchActions`' `showDatalinkTable` to ensure it doesn't already have a download button fixes this. 
 - If no checkboxes are selected in the download dialog, and user attempts to click on the download button, they will now be prompted with an error message asking them to make at least one selection. 
 - The cutout size changes were not being respected in some instances in Spherex and Euclid (for example, if you did a TAP search or a Euclid catalogs search, the cutout size updates would not be reflected in the download dialog). 
- Euclid & Spherex now use Generate Download Script throughout (even for TAP / Catalog searches), except for Spherex's Spectrophotometry tool. 

**_Note_**: The default mode for checkboxes in our download dialogs is that all products will be unselected. If you'd like me to change it to rather make everything selected by default, let me know. 

**Testing**: 
- [Firefly](https://fireflydev.ipac.caltech.edu/irsa-7344-euclid-downloads-fixes/firefly/), [DCE](https://irsa-7344-euclid-downloads-fixes.irsakubedev.ipac.caltech.edu/irsaviewer/dce), [Euclid](https://irsa-7344-euclid-downloads-fixes.irsakubedev.ipac.caltech.edu/applications/euclid) and [Spherex](https://irsa-7344-euclid-downloads-fixes.irsakubedev.ipac.caltech.edu/applications/spherex/) 
- The main purpose of testing below is to try and see if you can find any bugs. Hence the instructions to make sure we cover all our bases. 
- **Firefly**: Use CADC IVOA search to find tables where the `Prepare Download` button shows up. If cutouts exist, attempt to change the cutout size and ensure that you see the updated cutout size in the download dialogs when you select the cutout checkbox. 
- **DCE**: Regression testing to ensure `Prepare Download` works as expected. 
- **Euclid & Spherex**: 
   - Do an Image, Inspect Objects and TAP (CADC ivoa) and Euclid Catalogs searches on Euclid. 
      - For all of these, try changing the cutout size and ensure it's reflected in the download dialog when cutout is selected. 
      - Ensure you only see the `Generate Download Button` everywhere, including on TAP and Euclid Catalog results. 
  - Do a Spectral Image, Spectrophotometry, and TAP (CADC ivoa) searches on Spherex   
    - Repeat the steps above. 
    - The only difference is that for the Spectrophotometry search, you should see a `Prepare Download` button
- For any of the search results above, click on the `Show table of all Euclid products` (or spherex) to see the products table. Ensure you only see one download (`Generate Download Script`) button. 
- And for some of the searches above, attempt to actually to do package or script download to ensure it works as expected. 