### PR TITLE
FIREFLY-1824: Allow option for Job's date/time to be displayed in local timezone.

### DIFF
--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -13,6 +13,8 @@ import {Box, Card, Skeleton, Stack, Typography} from '@mui/joy';
 import {TableErrorMsg} from 'firefly/tables/ui/TablePanel.jsx';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {PrismADQLAware} from '../../ui/tap/AdvancedADQL';
+import {getFieldVal} from '../../fieldGroup/FieldGroupUtils';
+import {jobMonitorGroupKey, toDateString, useLocalTimeKey} from '../../core/background/JobMonitor';
 
 const dialogID = 'show-job-info';
 
@@ -104,6 +106,8 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
 const toDate = (d) => d && new Date(d);
 
 function JobInfoDetails({jobInfo={}}) {
+    const useLocalTime = useStoreConnector(() => getFieldVal(jobMonitorGroupKey, useLocalTimeKey));
+
     const {ownerId, phase, executionDuration} = jobInfo;
     const startTime = toDate(jobInfo.startTime);
     const endTime = toDate(jobInfo.endTime);
@@ -117,11 +121,11 @@ function JobInfoDetails({jobInfo={}}) {
         <Stack direction='row' spacing={4}>
             <Stack>
                 <KeywordBlock label='Phase' title='Referred to as "phase" in UWS' value={phase} mb={1}/>
-                <KeywordBlock label='Created' title='Referred to as "creationTime" in UWS' value={creationTime?.toISOString()}  {...dateProps}/>
-                <KeywordBlock label='Start Time' title='Referred to as "startTime" in UWS' value={startTime?.toISOString()} {...dateProps}/>
-                <KeywordBlock label='End Time' title='Referred to as "endTime" in UWS' value={endTime?.toISOString()} {...dateProps}/>
-                <KeywordBlock label='Planned end' title='Referred to as "quote" in UWS' value={quote?.toISOString()} {...dateProps}/>
-                <KeywordBlock label='Destruction' title='Referred to as "destruction" in UWS' value={destruction?.toISOString()} {...dateProps}/>
+                <KeywordBlock label='Created' title='Referred to as "creationTime" in UWS' value={toDateString(creationTime, useLocalTime)}  {...dateProps}/>
+                <KeywordBlock label='Start Time' title='Referred to as "startTime" in UWS' value={toDateString(startTime, useLocalTime)} {...dateProps}/>
+                <KeywordBlock label='End Time' title='Referred to as "endTime" in UWS' value={toDateString(endTime, useLocalTime)} {...dateProps}/>
+                <KeywordBlock label='Planned end' title='Referred to as "quote" in UWS' value={toDateString(quote, useLocalTime)} {...dateProps}/>
+                <KeywordBlock label='Destruction' title='Referred to as "destruction" in UWS' value={toDateString(destruction, useLocalTime)} {...dateProps}/>
             </Stack>
             <Stack>
                 <JobIdWrapper jobInfo={jobInfo}/>

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -34,8 +34,13 @@ import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import {FormWatcher} from '../../templates/router/RouteHelper';
 import {logger} from '../../util/Logger';
+import {SwitchInputField} from 'firefly/ui/SwitchInputField';
+import {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils';
 
 export const jobMonitorPath = '/jobMonitor';
+export const jobMonitorGroupKey = 'jobMonitor';
+export const useLocalTimeKey = 'useLocalTime';
+
 const jobIdColIdx = 7;  // the index of the jobId column in the table
 
 export function JobMonitor({initArgs, help_id, slotProps, ...props}) {
@@ -148,7 +153,7 @@ function JobSummary({jobs, overflow, ...props}) {
         </Stack>
     );
     return (
-        <Stack direction='row' gap={5} {...props}>
+        <Stack direction='row' gap={5} justifyContent='space-between' {...props}>
             <Typography level='title-md' color='primary'>Job Summary</Typography>
             <Stack direction='row' gap={10}>
                 <Entry label='Total' value={total + (overflow ? '(+)' : '')}/>
@@ -156,7 +161,25 @@ function JobSummary({jobs, overflow, ...props}) {
                 <Entry label='Failed' value={failed}/>
                 {(archived>0) && <Entry label='Archived' value={archived} title={getPhaseTips(Phase.ARCHIVED)}/>}
             </Stack>
+            <LocalOrUTC/>
         </Stack>
+    );
+}
+
+export function LocalOrUTC() {
+    const parts = Intl.DateTimeFormat('en', { timeZoneName: 'short' }).formatToParts(new Date());
+    const tzAbbr = parts.find((p) => p.type === 'timeZoneName').value;
+    return (
+        <SwitchInputField fieldKey={useLocalTimeKey}
+                          groupKey={jobMonitorGroupKey}
+                          label='Time Zone:'
+                          startDecorator='UTC'
+                          endDecorator={tzAbbr}
+                          size='sm'
+                          slotProps={{
+                              input: {color: 'primary', sx: {alignItems:'flex-start'}}
+                          }}
+        />
     );
 }
 
@@ -198,17 +221,18 @@ function Notification({email='', notifEnabled, ...props}) {
 
 function JobMonitorTable({help_id, ...props}) {
     const jobMap = useStoreConnector(() => getBackgroundInfo()?.jobs || {});
+    const useLocalTime = useStoreConnector(() => getFieldVal(jobMonitorGroupKey, useLocalTimeKey));
     const [hlJobId, setHlJobId] = useState();
 
     const tbl_id = 'JobHistoryTable';
     useEffect(() => {
-        const table = convertToTableModel(getMonitoredJob(jobMap), tbl_id);
+        const table = convertToTableModel(getMonitoredJob(jobMap), tbl_id, useLocalTime);
         if (hlJobId) {
             const highlightedRow = table.tableData.data.findIndex((row) => row[jobIdColIdx] === hlJobId);
             if (highlightedRow >= 0) table.highlightedRow = highlightedRow; // set the highlighted row if the job is found
         }
         dispatchTableAddLocal(table, undefined, false);
-    }, [jobMap]); // refreshed only when jobMap changes
+    }, [jobMap, useLocalTime]); // refreshed only when jobMap changes
 
     useEffect(() => {
         return watchTableChanges(tbl_id,
@@ -353,7 +377,14 @@ function DownloadBtn({job, index=0}) {
     );
 }
 
-function convertToTableModel(jobs, tbl_id) {
+export function toDateString(date, useLocalTime) {
+    if (!date) return '';
+    let d = moment.utc(date);
+    if (useLocalTime) d = d.local();
+    return d.format('YYYY-MM-DD HH:mm:ss');
+}
+
+function convertToTableModel(jobs, tbl_id, useLocalTime) {
     const cProps = {align: 'center'};
     const columns = [
         {name: 'Title', width: 22},
@@ -371,9 +402,9 @@ function convertToTableModel(jobs, tbl_id) {
             getJobTitle(job),
             job.meta?.svcId,
             job.meta?.type,
-            job.creationTime && moment.utc(job.creationTime).format('YYYY-MM-DD HH:mm:ss'),
-            job.startTime && moment.utc(job.startTime).format('YYYY-MM-DD HH:mm:ss'),
-            job.endTime && moment.utc(job.endTime).format('YYYY-MM-DD HH:mm:ss'),
+            toDateString(job.creationTime, useLocalTime),
+            toDateString(job.startTime, useLocalTime),
+            toDateString(job.endTime, useLocalTime),
             job.phase,
             job.meta?.jobId         // remember to adjust jobIdColIdx if columns changed
         ]);


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1824

Add a toggle to switch between **UTC** and **local timezone**.
Update all job date/time fields to display according to the selected timezone.

Test: https://firefly-1824-bgmonitor-timezone.irsakubedev.ipac.caltech.edu/applications/spherex/

- Go to Job Monitor.
- If no job history exists, create a new job.
- Toggle between UTC and Local Time. Verify that all date/time values in the Job History table update accordingly.
- Open Job Details.  Confirm that date/time fields there also reflect the selected timezone.