### PR TITLE
IRSA-7299: Update upload id for online help

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/table/io/IpacTableWriter.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/IpacTableWriter.java
@@ -62,9 +62,6 @@ public class IpacTableWriter {
     }
 
     private static void save(PrintWriter out, DataGroup dataGroup) throws IOException {
-
-
-        shrinkToFitData(dataGroup);
         List<DataType> headers = Arrays.asList(dataGroup.getDataDefinitions());
         int totalRow = dataGroup.size();
 
@@ -126,11 +123,14 @@ public class IpacTableWriter {
                     dt.setTypeDesc(typeToDesc(dt.getDataType()));
                 });
 
+        //shrink data *after* headers have been modified, to get the correct width for each column
+        shrinkToFitData(dataGroup, modHeaders);
+
         // print column headers
         IpacTableUtil.writeHeader(out, modHeaders);
 
         for (int i = 0; i < totalRow; i++) {
-            IpacTableUtil.writeRow(out, headers, dataGroup.get(i));
+            IpacTableUtil.writeRow(out, modHeaders, dataGroup.get(i));
         }
         out.flush();
     }
@@ -138,8 +138,8 @@ public class IpacTableWriter {
     /**
      * this method will shrink the Column's width to fit the maximum's width of the data
      */
-    private static void shrinkToFitData(DataGroup dataGroup) {
-        for (DataType dt : dataGroup.getDataDefinitions()) {
+    private static void shrinkToFitData(DataGroup dataGroup, List<DataType> modHeaders) {
+        for (DataType dt : modHeaders) {
             String[] headers = {dt.getKeyName(), dt.getTypeDesc(), dt.getUnits(), dt.getNullString()};
             int maxWidth = Arrays.stream(headers).mapToInt(s -> s == null ? 0 : s.length()).max().getAsInt();
             for (int i=0; i<dataGroup.size(); i++) {

--- a/src/firefly/js/ui/FileUploadDropdown.jsx
+++ b/src/firefly/js/ui/FileUploadDropdown.jsx
@@ -27,7 +27,7 @@ export const FileUploadDropdown= ({sx, onCancel, onSubmit=resultSuccess, keepSta
                                       }) =>{
     const [submitText,setSubmitText]= useState('Load');
     const [doMask, changeMasking]= useState(() => false);
-    const helpId = getAppOptions()?.uploadPanelHelpId ?? 'basics.searching';
+    const helpId = getAppOptions()?.uploadPanelHelpId ?? 'upload.intro';
     return (
         <Box position='relative' sx={{width: 1, height:1, ...sx}}>
             <FieldGroup groupKey={groupKey} keepState={keepState} sx={{height:1, width:1,

--- a/src/firefly/js/visualize/ui/ExtraIpacSearches.jsx
+++ b/src/firefly/js/visualize/ui/ExtraIpacSearches.jsx
@@ -36,7 +36,7 @@ const FormTemplate= ({children, onSuccess,groupKey, help_id}) => (
 
 
 export const ClassicCatalogUploadPanel= () => (
-    <FormTemplate groupKey='CLASSIC_UPLOAD' onSuccess={(request) => doLoadTable(request)} help_id= 'catalogs.owncatalogs'>
+    <FormTemplate groupKey='CLASSIC_UPLOAD' onSuccess={(request) => doLoadTable(request)} help_id= 'upload.intro'>
         <div style={{width:'100%'}}>
             <div style={{width:750, height:'calc(100% - 40px)', padding: 20, display: 'flex', flexDirection:'column', justifyContent: 'space-between'}}>
                 <div style={{width: '70%'}}>


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/IRSA-7299
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/445
- Updated the upload id from `catalogs.owncatalogs` to `upload.intro`
- This applies to the upload tab as well, and not just the upload dialogs 
  - @lrebull if there's a place where the help link should instead go to `catalogs.owncatalogs` when you test the apps below, please let me know
- **_Note_**: I suppose for [Firefly](https://fireflydev.ipac.caltech.edu/irsa-7299-help-fix-upload-dialog/firefly) we don't have an `upload.intro` for the online help, so maybe I should switch back to the default `basics.searching` for that? 

- Fixes [FIREFLY-1826](https://jira.ipac.caltech.edu/browse/FIREFLY-1826)
  - @loitly the bug fix for this is in DataType's `formatHeader` 
     - Bug summary: Essentially, if you have a spectrum table like this (from the ticket)
        - <img width="722" height="573" alt="photometry_tbl" src="https://github.com/user-attachments/assets/c676f43d-c3aa-4ba0-bd0b-b481fbab540b" />
     -  notice the `det_id` column. When saving this table as an IPAC table, we convert `short` to `integer`, that part works as expected. But when we call `fitValueInto` inside `formatHeader`, the width for this column is returned as 6 (because of the `det_id` string length), and `integer` is truncated into `intege`, hence the bug.
     - This fix takes care of that, while still being generic. 
        - When the `width` is longer than than the `val length` (as is the usual case), for example, for the `ra` column (not in the screenshot), the width is 11 due to the entries in the column, so we still get a nicely formated `"ra         "` as expected in that case. 
       - But in a case like this specific column, it will make sure the data type value is not truncated. 

**Testing**: 
- [Firefly](https://fireflydev.ipac.caltech.edu/irsa-7299-help-fix-upload-dialog/firefly), [Irsaviewer](https://irsa-7299-help-fix-upload-dialog.irsakubedev.ipac.caltech.edu/irsaviewer), [DCE](https://irsa-7299-help-fix-upload-dialog.irsakubedev.ipac.caltech.edu/irsaviewer/dce), [Euclid](https://irsa-7299-help-fix-upload-dialog.irsakubedev.ipac.caltech.edu/applications/euclid), [Spherex](https://irsa-7299-help-fix-upload-dialog.irsakubedev.ipac.caltech.edu/applications/spherex)
- Just test the help link anywhere upload is used takes you to `/onlinehelp/#id=upload.intro`
  - includes both upload tabs and dialogs   
- For [FIREFLY-1826](https://jira.ipac.caltech.edu/browse/FIREFLY-1826), test according to ticket. Saving the table as an IPAC table should fix the bug in the `det_id` column. And if you try to re-upload this column to firefly, that should work as well. 
  - if Spherex searches take too long, I attached a euclid spectrum table to the ticket. I changed the `NDITH` column to be datatype `short` (instead of `integer`). So if you upload this file to firefly, and try to save the table as an IPAC table, you can test this bug fix that way (and to cross verify, if you upload it on the nightly firefly build: https://fireflydev.ipac.caltech.edu/firefly you'll  encounter the bug again)
 