### PR TITLE
FIREFLY-1884: Fix Plot Parameter dialog reflecting incorrect state of plotted column

### DIFF
--- a/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
+++ b/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
@@ -76,6 +76,16 @@ export function getUnitOptions(unit) {
 }
 
 /**
+ * returns the representation of a given unit in the conversion options. `value` of unit in `{label, value}[]` options.
+ * @param unit
+ * @returns {string|UnitKey|null}
+ */
+export function getUnitOptionValue(unit) {
+    const {unit: unitKey, factor} = normalizeUnit(unit);
+    return factor ? `${factor}${unitKey}` : unitKey;
+}
+
+/**
  * returns the axis label for a unit and column name and whether the label is a Latex fragment.
  * @param {string} unit         the unit to get the info for
  * @param {string} cname        the name (or expression) of the column being evaluated

--- a/src/firefly/js/charts/ui/options/SpectrumOptions.jsx
+++ b/src/firefly/js/charts/ui/options/SpectrumOptions.jsx
@@ -5,7 +5,13 @@ import {getSpectrumDM, REF_POS} from '../../../voAnalyzer/SpectrumDM.js';
 import {getChartData} from '../../ChartsCntlr.js';
 import {getTblById} from '../../../tables/TableUtil.js';
 import {
-    canUnitConv, getUnitConvExpr, getMeasurementLabel, getUnitOptions, getXLabel, getYLabel
+    canUnitConv,
+    getUnitConvExpr,
+    getMeasurementLabel,
+    getUnitOptions,
+    getXLabel,
+    getYLabel,
+    getUnitOptionValue
 } from '../../dataTypes/SpectrumUnitConversion.js';
 
 import {useStoreConnector} from '../../../ui/SimpleComponent.jsx';
@@ -307,9 +313,11 @@ function Units({activeTrace, value, axis, ...rest}) {
     const unitProp = axis === 'x' ? 'xUnit' : 'yUnit';
     const label = axis === 'x' ? 'Spectral axis units:' : 'Flux axis units:';
     const options = getUnitOptions(value);
+    const initValue = getUnitOptionValue(value);
 
     return options?.length > 1
-        ? <ListBoxInputField fieldKey={`fireflyData.${activeTrace}.${unitProp}`} initialState={{value}}
+        ? <ListBoxInputField fieldKey={`fireflyData.${activeTrace}.${unitProp}`}
+                             initialState={{value: initValue}}
                              options={options.map(({label, ...opt}) =>
                                  ({...opt, label: <MathJax>{label}</MathJax>}))}
                              {...{label, ...rest}}/>


### PR DESCRIPTION
Fixes [FIREFLY-1884](https://jira.ipac.caltech.edu/browse/FIREFLY-1884)

Bug was happening because when alias is provided, it couldn't find that string in options list. Updated it to use the corresponding option value instead of original string.

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1884-charts-dialog-state-bug/firefly

Check that the issue described in ticket should no longer be reproducible. 