### PR TITLE
IRSA-7404: Fix for grid options not showing in MultiProductViewer

### DIFF
--- a/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
+++ b/src/firefly/js/metaConvert/vo/ObsCoreConverter.js
@@ -53,7 +53,7 @@ export function makeObsCoreConverter(table,converterTemplate,options={}) {
 
 function ensureOnlyImageInTable(table, options) {
     const {guaranteeOnlyImages=false, limitViewerDisplay}= options;
-    return guaranteeOnlyImages || obsCoreTableHasOnlyImages(table) || limitViewerDisplay!==IMAGE_ONLY;
+    return guaranteeOnlyImages || obsCoreTableHasOnlyImages(table) || limitViewerDisplay===IMAGE_ONLY;
 }
 
 function confirmHasRelatedBands(table,onlyImagesInTable, options) {


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/IRSA-7404
- This affects Euclid right now, but is a generic bug 
- In some cases, the grid doesn't show up for images even when `canGrid` was set to `true` via `dataProductsFactoryOptions`
  - For Euclid specifically, you can see in `ResultsViewer` that we set `canGrid: true` when calling `MultiProductViewerContainer`
    - and this is respected in Image, Inspect Objects and Search by ID Objects searches 
    - it only doesn't work for Search by ID Image search, so I tracked it down as follows: 
       - following the `watcher` in `MetaDataMultiProductViewer`, we get to `makeDataProductsConverter` in `DataProductsFactory`
         - in here is where I noticed the `retObj` has `canGrid: false` for the Search by ID image search case 
         - following the converter's factory function, in the case of Image search (`mer-tiles`, so both `Image` search and `Search by ID` Image search) , it happens to be `makeObsCoreConverter`
           - this is where `canGrid` is set to `false`, when `ensureOnlyImageInTable` is called
             - but since we set `limitViewerDisplay` to `IMAGE_ONLY`, it's my understanding that the fix should take care of this bug
- The 2nd bug reported in the ticket:
   - if you do a Search by ID Image search (try `102018211`), go to the spectra tab in the results 
   - a lot of the rows show the `Table | Chart ` option instead of the standard `No data available for this row` as is expected for an Image search
   - Upon inspecting the table, it appears that a lot of the entries in the `dataproduct_type` column are, in fact, `spectrum`
     - so could this be a backend bug? 

**Testing**: 
 - **Euclid**: https://irsa-7404-euclid-grid-not-showing.irsakubedev.ipac.caltech.edu/applications/euclid
 - Do a Search by ID Image search: you should see the grid options over the cutouts now 
 - Regression testing: Do an Image, Inspect Objects and Search by ID Objects search. You should see grid options in the toolbar for all of these. 