### PR TITLE
FIREFLY-1851: Fix axes labels not getting updated when columns to plot change

### DIFF
--- a/src/firefly/js/charts/ui/options/BasicOptions.jsx
+++ b/src/firefly/js/charts/ui/options/BasicOptions.jsx
@@ -21,7 +21,7 @@ import {useStoreConnector} from '../../../ui/SimpleComponent.jsx';
 import {updateSet} from '../../../util/WebUtil.js';
 import {hideColSelectPopup} from '../ColSelectView.jsx';
 import {addColorbarChanges} from '../../dataTypes/FireflyHeatmap.js';
-import {colorsOnTypes, getChartProps, toRGBA, TRACE_COLORS, uniqueChartId} from '../../ChartUtil.js';
+import {colorsOnTypes, getChartProps, toRGBA, TRACE_COLORS, uniqueChartId, isSpectrum} from '../../ChartUtil.js';
 import {colorscaleNameToVal} from '../../Colorscale.js';
 import {DEFAULT_PLOT2D_VIEWER_ID} from '../../../visualize/MultiViewCntlr.js';
 
@@ -117,10 +117,10 @@ export function basicFieldReducer({chartId, activeTrace}) {
             if (action.type === VALUE_CHANGE) {
                 fieldKey = get(action.payload, 'fieldKey');
                 ['x','y'].forEach((a) => {
-                    if (fieldKey === `_tables.data.${activeTrace}.${a}`) {
-                        // if needed in other chart types, uncomment the following line and only disable it for spectrum
-                        // (because spectrumReducer changes axes labels as _tables.data changes, and they need to be persisted)
-                        // inFields = updateSet(inFields, [`layout.${a}axis.title.text`, 'value'], undefined);
+                    if (fieldKey === `_tables.data.${activeTrace}.${a}`) { // column name or expression changed
+                        // unset the axis title so that the chart generates a title based on the changed column name
+                        // but not in spectrum because spectrumReducer changes axes labels itself which need to be persisted
+                        if (!isSpectrum(chartId)) inFields = updateSet(inFields, [`layout.${a}axis.title.text`, 'value'], undefined);
 
                         inFields = updateSet(inFields, [`fireflyLayout.${a}axis.min`, 'value'], undefined);
                         inFields = updateSet(inFields, [`fireflyLayout.${a}axis.max`, 'value'], undefined);


### PR DESCRIPTION
Fixes [FIREFLY-1851](https://jira.ipac.caltech.edu/browse/FIREFLY-1851)

> This was a regression issue that I introduced in https://github.com/Caltech-IPAC/firefly/pull/1798 but fortunately left a comment for my future self then (present self now) :)

Reverted to unset axis label fields in "chart options" so that when chart is updated the title gets generated (via existing code):
https://github.com/Caltech-IPAC/firefly/blob/441fb8995257795a82c2ce7b8e8af52fe9dd92ca/src/firefly/js/charts/dataTypes/FireflyGenericData.js#L174-L182

(Also true for [histogram](https://github.com/Caltech-IPAC/firefly/blob/5325b17db8edaf10a30d31dc8713644b21e0a579/src/firefly/js/charts/dataTypes/FireflyHistogram.js#L123-L132), [heatmap](https://github.com/Caltech-IPAC/firefly/blob/5325b17db8edaf10a30d31dc8713644b21e0a579/src/firefly/js/charts/dataTypes/FireflyHeatmap.js#L223-L230))

## Testing
https://fireflydev.ipac.caltech.edu/firefly-1851-chart-axes-labels-bug/firefly

- Check the examples mentioned in ticket (scatter type), should be fixed
- Increase radius and check the heatmap instance for above too
- Click "Add chart" and make a histogram, check that changing column and applying causes chart to update
- Upload a spectrum and check it is working as before

 