### PR TITLE
FIREFLY-1880: Enable uploads and pinning spectra in spherex

### DIFF
--- a/src/firefly/js/charts/ui/PinnedChartContainer.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartContainer.jsx
@@ -86,7 +86,7 @@ export const PinnedChartContainer = (props) => {
                         <ActiveChartsPanel {...props}/>
                     </Tab>
                     {showPinnedTab &&
-                        <Tab name='Pinned Charts' label={<BadgeLabel labelStr='Pinned Charts'/>}>
+                        <Tab name='Pinned Charts' label={<ChartBadgeLabel labelStr='Pinned Charts'/>}>
                             <PinnedChartPanel {...props}/>
                         </Tab>
                     }
@@ -161,7 +161,7 @@ export function pinChart({chartId, autoLayout=false, displayPinMessage=true }) {
     });
 }
 
-export function BadgeLabel({labelStr}) {
+export function ChartBadgeLabel({labelStr}) {
     const badgeCnt= useStoreConnector(() => getViewerItemIds(getMultiViewRoot(),PINNED_CHART_VIEWER_ID)?.length??0);
     return badgeCnt===0 ?  labelStr:
         (

--- a/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/TriViewPanel.jsx
@@ -3,8 +3,7 @@
  */
 
 import {Box, Stack} from '@mui/joy';
-import {
-    BadgeLabel, PinnedChartPanel, usePinnedChartInfo
+import {ChartBadgeLabel, PinnedChartPanel, usePinnedChartInfo
 } from 'firefly/charts/ui/PinnedChartContainer.jsx';
 import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
 import {pick} from 'lodash';
@@ -187,7 +186,7 @@ function makePinnedChartTab({pinnedLabel, chartExpandedMode, closeable, asTab,id
                              useOnlyChartsInViewer={false}
                              tbl_group='main' addDefaultChart={true}/>);
 
-    return asTab ? <Tab name={pinnedLabel} removable={false} id={id} label={<BadgeLabel labelStr={pinnedLabel}/>}>{chartpanel}</Tab> : chartpanel;
+    return asTab ? <Tab name={pinnedLabel} removable={false} id={id} label={<ChartBadgeLabel labelStr={pinnedLabel}/>}>{chartpanel}</Tab> : chartpanel;
     }
 
 function searchDesc({showViewsSwitch, leftButtons, centerButtons, rightButtons}) {

--- a/src/firefly/js/visualize/ui/ImageTableRowViewer.jsx
+++ b/src/firefly/js/visualize/ui/ImageTableRowViewer.jsx
@@ -408,6 +408,7 @@ async function doLayoutImages({viewerId, imageCnt, table, makeRequestFromRow,
             wpRequest.setRotateNorth(true);
             dispatchPlotImage({
                 plotId, wpRequest,
+                viewerId,
                 setNewPlotAsActive: false,
                 holdWcsMatch: true,
                 pvOptions: {userCanDeletePlots: false}

--- a/src/firefly/js/visualize/ui/TriViewImageSection.jsx
+++ b/src/firefly/js/visualize/ui/TriViewImageSection.jsx
@@ -88,7 +88,7 @@ export const makeMultiProductViewerTab= ({id,dataProductTableId}) => {
 };
 
 
-function BadgeLabel({labelStr}) {
+export function ImageBadgeLabel({labelStr}) {
     const badgeCnt= useStoreConnector(() => getViewerItemIds(getMultiViewRoot(),DEFAULT_FITS_VIEWER_ID)?.length??0);
     return badgeCnt===0 ?  labelStr:
         (
@@ -109,12 +109,12 @@ export function makeFitsPinnedTab({id,asTab})  {
     return (
         asTab ?
             (<Tab key='fits' name='Pinned Images'  removable={false} id={id}
-                  label={<BadgeLabel labelStr={'Pinned Images'}/>}>
+                  label={<ImageBadgeLabel labelStr={'Pinned Images'}/>}>
                 {viewer}
             </Tab>) :
             viewer
     );
-};
+}
 
 
 TriViewImageSection.propTypes= {


### PR DESCRIPTION
**Tickets**: [FIREFLY-1880](https://jira.ipac.caltech.edu/browse/FIREFLY-1880) , [FIREFLY-1878](https://jira.ipac.caltech.edu/browse/FIREFLY-1878)

**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/447

- Passing in viewerId to `dispatchPlotImage` is the crucial fix here to ensure the spectrum cutouts don't show up in the `Pinned Images` tab as well when you upload new images. 
  - Because uploads uses our default viewerId  (`DEFAULT_FITS_VIEWER_ID`), and if we don't pass in the custom `viewerId` to `dispatchPlotImage` for `ImageTableRowViewer`, it'll also default to the default viewerId. 