### PR TITLE
FIREFLY-1835: hotfix for Jest

### DIFF
--- a/__jest__/jest.base.config.js
+++ b/__jest__/jest.base.config.js
@@ -9,26 +9,29 @@ module.exports = {
     'coverageDirectory': '../../build/dist/reports/firefly',
     'coverageReporters': ['lcov'],
     'moduleFileExtensions': [
-    'js',
-    'jsx'
-],
+        'js',
+        'jsx'
+    ],
     'moduleDirectories': [
-    'node_modules',
-    'js'
-],
+        'node_modules',
+        'js'
+    ],
     'setupFiles': [
-    '<rootDir>/../../__jest__/InitTest.js'
-],
+        '<rootDir>/../../__jest__/InitTest.js'
+    ],
     'moduleNameMapper': {
         '^.+\\?(raw|url)$': '<rootDir>/../../__jest__/fileMock.js',
         '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/../../__jest__/fileMock.js',
         '\\.(css|less)$': '<rootDir>/../../__jest__/styleMock.js',
         '^firefly/(.*)$': '<rootDir>/js/$1'
-},
+    },
     'transform': {
-    '^.+\\.jsx?$': '<rootDir>/../../__jest__/jest.transform.js'
-},
+        '^.+\\.jsx?$': '<rootDir>/../../__jest__/jest.transform.js'
+    },
+    'transformIgnorePatterns': [
+        'node_modules/(?!(slug|lodash-es|chroma-js)/)'
+    ],
     'globals': {
-    '__PROPS__': {}
-}
+        '__PROPS__': {}
+    }
 };


### PR DESCRIPTION
Hotfix for React 19 PR that fixes JS unit tests (`gradle :firefly:jsTest`).

Jest now requires `transformIgnorePatterns` for packages like slug, chroma-js, and lodash-es because the newer versions of these packages now have "type": "module" in their package.json and use ES module syntax (import/export). 

By default, Jest ignores all files in node_modules and doesn't transform them, but Jest cannot run ES module code without transformation.